### PR TITLE
feat: real-time worktree watching via WebSocket

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+> Remote web interface for interacting with Claude Code CLI sessions from any device.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `npm start` | Start the server (`node server/index.js`) |
+| `npm test` | Run all tests (`node --test test/*.test.js`) |
+| `node --test test/auth.test.js` | Run a single test file |
+| `claude-remote-cli` | Run as global CLI (after `npm install -g`) |
+
+## Architecture
+
+Node.js backend (Express + node-pty + WebSocket) manages Claude Code CLI sessions as PTY processes. Vanilla JS frontend with xterm.js renders terminals in the browser. No build step.
+
+- `bin/` - CLI entry point, flag parsing, config directory setup
+- `server/` - Express REST API, WebSocket relay, PTY session manager, auth, config
+- `public/` - Single-page app (HTML/CSS/JS), bundled xterm.js vendor libs
+- `test/` - Unit tests using Node.js built-in `node:test`
+
+## Documentation Map
+
+| Topic | Location |
+|-------|----------|
+| Architecture & Data Flow | [docs/guides/architecture.md](docs/guides/architecture.md) |
+| Testing | [docs/guides/testing.md](docs/guides/testing.md) |
+| Patterns & Conventions | [docs/guides/patterns.md](docs/guides/patterns.md) |
+| Guide Index | [docs/guides/index.md](docs/guides/index.md) |
+| Risk Contract | [docs/risk-contract.json](docs/risk-contract.json) |
+| Review Agent Setup | [docs/guides/review-agent-setup.md](docs/guides/review-agent-setup.md) |
+| ADRs | [docs/adrs/](docs/adrs/) |
+| Active Plans | [docs/exec-plans/active/](docs/exec-plans/active/) |
+| Completed Plans | [docs/exec-plans/completed/](docs/exec-plans/completed/) |
+
+## Gotchas
+
+- `node-pty` requires native compilation; `postinstall` script fixes prebuilt binaries on macOS
+- `CLAUDECODE` env var must be stripped from PTY env to allow nesting Claude sessions
+- Scrollback buffer is capped at 256KB per session; oldest chunks are trimmed first
+- Config lives at `~/.config/claude-remote-cli/config.json` when installed globally, `./config.json` for local dev
+- PIN reset: delete `pinHash` from config file and restart server
+- Requires Node.js >= 20.0.0

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ On first launch you'll be prompted to set a PIN. Then open `http://localhost:345
 - **Node.js 20+**
 - **Claude Code CLI** installed and available in your PATH (or configure `claudeCommand` in config)
 
+## Platform Support
+
+Tested on **macOS** and **Linux**. Windows is not currently tested — file watching and PTY spawning may behave differently.
+
 ## CLI Usage
 
 ```
@@ -75,6 +79,7 @@ The PIN hash is stored in config under `pinHash`. To reset:
 - **Scrollback buffer** — reconnect to a session and see prior output
 - **Touch toolbar** — mobile-friendly buttons for special keys (arrows, Enter, Escape, Ctrl+C, Tab, y/n)
 - **Responsive layout** — works on desktop and mobile with slide-out sidebar
+- **Real-time updates** — worktree changes on disk are pushed to the browser instantly via WebSocket
 
 ## Architecture
 
@@ -86,6 +91,7 @@ claude-remote-cli/
 │   ├── index.js       # Express server, REST API routes
 │   ├── sessions.js    # PTY session manager (node-pty)
 │   ├── ws.js          # WebSocket relay (PTY ↔ browser)
+│   ├── watcher.js     # File watcher for .claude/worktrees/ changes
 │   ├── auth.js        # PIN hashing, verification, rate limiting
 │   └── config.js      # Config loading/saving
 ├── public/

--- a/docs/adrs/000-template.md
+++ b/docs/adrs/000-template.md
@@ -1,0 +1,27 @@
+# ADR-{NUMBER}: {TITLE}
+
+## Status
+{Proposed | Accepted | Deprecated | Superseded}
+
+## Date
+{YYYY-MM-DD}
+
+## Decider(s)
+{Names}
+
+## Context
+{What is the issue that we're seeing that is motivating this decision or change?}
+
+## Decision
+{What is the change that we're proposing and/or doing?}
+
+## Consequences
+
+### Positive
+- {benefit}
+
+### Negative
+- {tradeoff}
+
+### Risks
+- {risk}

--- a/docs/adrs/001-modular-express-server-architecture.md
+++ b/docs/adrs/001-modular-express-server-architecture.md
@@ -1,0 +1,44 @@
+# ADR-001: Modular Express Server Architecture
+
+## Status
+Accepted
+
+## Date
+2026-02-21
+
+## Decider(s)
+Donovan Yohan
+
+## Context
+claude-remote-cli is a remote web interface for Claude Code CLI sessions. The server must handle several distinct concerns: HTTP routing, PTY process lifecycle, WebSocket relay, file system watching, authentication, and configuration I/O. A single monolithic file would become difficult to navigate and modify as features are added. However, the project is small enough that introducing a formal layered architecture (hexagonal, clean architecture, etc.) would add unnecessary abstraction without proportional benefit.
+
+## Decision
+The server MUST be organized into six modules under `server/`, each responsible for a single concern:
+
+| Module | Responsibility |
+|--------|---------------|
+| `index.js` | Express app setup, HTTP route handlers, server startup |
+| `sessions.js` | PTY process spawning, in-memory session registry, session lifecycle (create/list/get/kill/resize) |
+| `ws.js` | WebSocket upgrade handling, PTY-to-browser data relay, event channel broadcast |
+| `watcher.js` | File system watching for `.claude/worktrees/` directories, debounced event emission |
+| `auth.js` | PIN hashing (bcrypt), PIN verification, rate limiting, cookie token generation |
+| `config.js` | Config file I/O (load/save JSON), default values |
+
+Modules MUST communicate through direct `require()` imports. There is no dependency injection container, no service layer, and no abstract interfaces. `index.js` serves as the composition root, wiring modules together at startup.
+
+Modules SHOULD NOT import `index.js`. Cross-module dependencies flow downward: `index.js` imports all others; `ws.js` imports `sessions`; all other modules are self-contained.
+
+## Consequences
+
+### Positive
+- Each file stays under 120 lines, making it easy to read and modify in isolation
+- New contributors can understand the full server by reading six small files
+- No framework boilerplate or abstraction layers to learn
+- Module boundaries map directly to the npm dependency graph (e.g., only `auth.js` depends on bcrypt, only `sessions.js` depends on node-pty)
+
+### Negative
+- `index.js` accumulates route handlers and grows as new REST endpoints are added; it currently handles routes for sessions, repos, worktrees, roots, and auth
+- No formal interface contracts between modules means refactoring a module's API requires updating all callers manually
+
+### Risks
+- If the project grows significantly (e.g., adding user accounts, multi-tenant support), this flat module structure may need to evolve into a layered or domain-grouped architecture

--- a/docs/adrs/002-vanilla-js-frontend-no-build-step.md
+++ b/docs/adrs/002-vanilla-js-frontend-no-build-step.md
@@ -1,0 +1,41 @@
+# ADR-002: Vanilla JS Frontend with No Build Step
+
+## Status
+Accepted
+
+## Date
+2026-02-21
+
+## Decider(s)
+Donovan Yohan
+
+## Context
+The frontend needs to render terminal sessions in the browser, handle PIN authentication, manage a session sidebar with filtering, and relay keyboard input over WebSocket. These requirements are well within the capability of plain browser APIs. Introducing a framework (React, Vue, Svelte) or a bundler (Vite, webpack) would add tooling complexity, increase the contributor onboarding cost, and create a build step that must be maintained. The project targets a single-page interface with a small number of UI components.
+
+## Decision
+The frontend MUST be a single-page application using plain HTML, CSS, and JavaScript in the `public/` directory. There MUST NOT be a build step, transpiler, or bundler.
+
+- All application logic MUST reside in `public/app.js` as a single IIFE
+- Styles MUST be in `public/style.css`
+- The HTML entry point MUST be `public/index.html`
+- Vendor dependencies (xterm.js, xterm-addon-fit) MUST be self-hosted as pre-built files in `public/vendor/` and loaded via `<script>` tags
+- The frontend MUST use ES5-compatible syntax (var declarations, function expressions, `.then()` chains instead of async/await) to maximize browser compatibility without transpilation
+- DOM manipulation MUST use `document.getElementById`, `document.createElement`, and event listeners directly -- no virtual DOM or template engine
+
+## Consequences
+
+### Positive
+- Zero build tooling to install, configure, or maintain
+- `npm start` serves the frontend immediately via `express.static` with no pre-build step
+- The entire frontend can be understood by reading three files
+- No node_modules bloat for frontend dependencies; vendor files are checked into version control
+- Works in any browser that supports xterm.js (all modern browsers)
+
+### Negative
+- No component abstractions; UI patterns like the session list item are built imperatively with `createElement` calls, which is more verbose than JSX or templates
+- No TypeScript type checking on the frontend code
+- ES5 constraint means no destructuring, arrow functions, or template literals in `app.js`, making code slightly more verbose than modern JS
+- Adding significant new UI features (e.g., split panes, settings panels) will increase `app.js` size without module boundaries
+
+### Risks
+- If the frontend grows beyond approximately 1000 lines, the single-file approach may become difficult to maintain and a module system (ES modules or a bundler) should be reconsidered

--- a/docs/adrs/003-pty-session-management-in-memory-state.md
+++ b/docs/adrs/003-pty-session-management-in-memory-state.md
@@ -1,0 +1,52 @@
+# ADR-003: PTY-Based Session Management with In-Memory State
+
+## Status
+Accepted
+
+## Date
+2026-02-21
+
+## Decider(s)
+Donovan Yohan
+
+## Context
+The core purpose of claude-remote-cli is to let users interact with Claude Code CLI from a browser. This requires spawning a real terminal process that Claude Code can run inside, capturing its output (including ANSI escape sequences, color codes, and cursor movement), and relaying input from the browser. A simple `child_process.spawn` with piped stdio would not preserve terminal semantics. The application also needs to track active sessions so users can reconnect to them after navigating away or refreshing the page.
+
+## Decision
+Sessions MUST be managed using `node-pty` to spawn pseudo-terminal processes. Each session represents one Claude Code CLI process running in a PTY.
+
+### Session Registry
+- Active sessions MUST be stored in an in-memory `Map` keyed by session ID
+- Session IDs MUST be generated using `crypto.randomBytes(8).toString('hex')` (16-character hex strings)
+- There MUST NOT be a database or persistent storage for session state; sessions exist only while their PTY process is alive
+- When a PTY process exits, its session MUST be automatically removed from the registry
+
+### Scrollback Buffer
+- Each session MUST maintain a scrollback buffer that stores all PTY output chunks
+- The scrollback buffer MUST be capped at 256KB per session
+- When the buffer exceeds 256KB, the oldest chunks MUST be trimmed first (FIFO eviction)
+- On WebSocket connection, the full scrollback buffer MUST be replayed to the client so users see previous output
+
+### PTY Environment
+- The `CLAUDECODE` environment variable MUST be stripped from the PTY's environment to prevent conflicts when spawning Claude Code inside a Claude-managed server process
+- The PTY MUST be configured with `xterm-256color` as the terminal name
+
+### Session Lifecycle API
+The sessions module MUST export: `create`, `get`, `list`, `kill`, `resize`, `updateDisplayName`.
+
+## Consequences
+
+### Positive
+- Full terminal fidelity: ANSI colors, cursor positioning, interactive prompts, and TUI interfaces all work correctly
+- Scrollback replay enables seamless reconnection -- users see the full session history when they return
+- No database dependency keeps the deployment simple (single `npm install` and `npm start`)
+- In-memory state is fast with zero serialization overhead
+
+### Negative
+- All session state is lost on server restart; there is no way to resume a session after the server process exits
+- Memory usage grows linearly with active sessions (up to 256KB scrollback per session plus PTY process overhead)
+- No session persistence means sessions cannot be shared across multiple server instances
+
+### Risks
+- If many concurrent sessions are created (e.g., 50+), memory consumption from scrollback buffers alone could reach ~12.5MB, plus the memory used by each Claude Code process itself
+- The 256KB scrollback cap means very long sessions will lose early output; users cannot scroll back to the beginning of extended conversations

--- a/docs/adrs/004-pin-authentication-bcrypt-cookie-tokens.md
+++ b/docs/adrs/004-pin-authentication-bcrypt-cookie-tokens.md
@@ -1,0 +1,57 @@
+# ADR-004: PIN Authentication with Bcrypt and Cookie Tokens
+
+## Status
+Accepted
+
+## Date
+2026-02-21
+
+## Decider(s)
+Donovan Yohan
+
+## Context
+claude-remote-cli exposes Claude Code CLI sessions over HTTP/WebSocket, which means anyone who can reach the server's port could read terminal output or send input to active sessions. The application needs an authentication mechanism that is simple enough for a personal tool (no user accounts, no OAuth) but strong enough to prevent unauthorized access. Since the tool is designed for mobile access over a network, brute-force protection is also necessary.
+
+## Decision
+
+### PIN Setup
+- On first run, the server MUST prompt the user to set a PIN via the terminal (using readline)
+- The PIN MUST be hashed using bcrypt with 10 salt rounds before storage
+- The bcrypt hash MUST be stored in the config file under the `pinHash` key
+- To reset the PIN, the user MUST delete the `pinHash` field from the config file and restart the server
+
+### PIN Verification
+- The frontend MUST present a PIN gate that blocks access to the main application until a valid PIN is submitted
+- PIN verification MUST use `bcrypt.compare` against the stored hash
+- On successful verification, the server MUST generate a session token using `crypto.randomBytes(32).toString('hex')` (64-character hex string)
+- The token MUST be set as an `httpOnly`, `sameSite: strict` cookie with a configurable TTL (default: 24 hours)
+- Authenticated tokens MUST be stored in an in-memory `Set` on the server; token validity expires via `setTimeout` based on the configured `cookieTTL`
+
+### Rate Limiting
+- Failed PIN attempts MUST be tracked per IP address using an in-memory `Map`
+- After 5 failed attempts from a single IP, that IP MUST be locked out for 15 minutes
+- A successful authentication MUST clear the rate limit counter for that IP
+- Rate limit state is in-memory and resets on server restart
+
+### WebSocket Authentication
+- WebSocket upgrade requests MUST be authenticated by checking the `token` cookie from the HTTP upgrade headers
+- Unauthenticated WebSocket connections MUST be rejected with a 401 response before the upgrade completes
+
+## Consequences
+
+### Positive
+- Single shared PIN is simple to set up and appropriate for a personal/small-team tool
+- Bcrypt hashing protects the PIN even if the config file is compromised
+- Cookie-based tokens mean the browser automatically includes credentials on every request and WebSocket upgrade without custom client-side token management
+- Rate limiting prevents brute-force PIN guessing over the network
+
+### Negative
+- No multi-user support; everyone who accesses the server uses the same PIN
+- Token storage is in-memory, so all authenticated sessions are invalidated on server restart
+- No CSRF token (mitigated by `sameSite: strict` cookies and JSON-only endpoints)
+- No HTTPS enforcement at the application level; the PIN and cookie travel in plaintext unless a reverse proxy provides TLS
+
+### Risks
+- If the server is exposed to the public internet without TLS, the PIN can be intercepted in transit
+- The 15-minute lockout applies per IP, so an attacker behind a NAT or VPN could affect all users sharing that IP
+- In-memory rate limiting does not persist across restarts, allowing a fresh set of 5 attempts after each server restart

--- a/docs/adrs/005-nodejs-builtin-test-runner.md
+++ b/docs/adrs/005-nodejs-builtin-test-runner.md
@@ -1,0 +1,55 @@
+# ADR-005: Node.js Built-in Test Runner
+
+## Status
+Accepted
+
+## Date
+2026-02-21
+
+## Decider(s)
+Donovan Yohan
+
+## Context
+The project needs automated tests for its server modules (auth, config, sessions). Choosing a test framework involves tradeoffs between features, dependencies, and maintenance burden. Popular frameworks like Jest or Vitest add significant dependency trees and configuration. Since the project already requires Node.js >= 20.0.0, the built-in `node:test` module is available as a zero-dependency alternative that covers the project's current testing needs.
+
+## Decision
+All unit tests MUST use the `node:test` module and `node:assert` for assertions. No external test framework (Jest, Vitest, Mocha, etc.) SHOULD be installed for unit testing.
+
+### Test Structure
+- Test files MUST be located in the `test/` directory with the naming convention `*.test.js`
+- Tests MUST be runnable via `npm test`, which executes `node --test test/*.test.js`
+- Individual test files MUST be runnable in isolation via `node --test test/<file>.test.js`
+
+### Current Test Coverage
+Three test files MUST exist:
+
+| File | Coverage |
+|------|----------|
+| `test/auth.test.js` | PIN hashing, PIN verification, rate limiting (threshold and lockout), token generation |
+| `test/config.test.js` | Config loading, default merging, missing file error, save format, default values |
+| `test/sessions.test.js` | Session create/list/get/kill/resize lifecycle, PTY spawning with real processes |
+
+### Test Isolation
+- `auth.test.js` MUST clear the `require` cache before each test to get fresh module state (fresh rate-limit maps)
+- `sessions.test.js` MUST clean up spawned PTY processes in `afterEach` hooks to prevent resource leaks
+- `config.test.js` MUST use temporary directories and clean up files between tests
+
+### Future E2E Testing
+- Playwright is installed as a dev dependency for future browser-level end-to-end tests
+- E2E tests SHOULD be kept separate from unit tests and are not yet implemented
+
+## Consequences
+
+### Positive
+- Zero additional test dependencies for unit tests; `node:test` ships with Node.js
+- Test output integrates with Node.js TAP reporter and CI environments natively
+- Tests run fast with no framework startup overhead
+- Developers familiar with Node.js do not need to learn framework-specific APIs
+
+### Negative
+- `node:test` has fewer convenience features than Jest (no built-in mocking library, no snapshot testing, no parallel test file execution by default)
+- No watch mode out of the box (Jest provides `--watch` for iterative development)
+- Test isolation for `auth.test.js` requires manual `require` cache clearing, which is a workaround rather than a proper module reset
+
+### Risks
+- If test complexity grows (e.g., requiring extensive mocking of node-pty or Express middleware), the lack of a built-in mocking library may become a friction point that warrants reconsideration

--- a/docs/adrs/006-dual-distribution-npm-global-local-dev.md
+++ b/docs/adrs/006-dual-distribution-npm-global-local-dev.md
@@ -1,0 +1,54 @@
+# ADR-006: Dual Distribution via npm Global Install and Local Dev
+
+## Status
+Accepted
+
+## Date
+2026-02-21
+
+## Decider(s)
+Donovan Yohan
+
+## Context
+claude-remote-cli needs to be easy to install for end users while remaining convenient for local development. End users expect a single `npm install -g` command followed by a named CLI command. Developers cloning the repo expect `npm start` to work immediately. These two modes have different expectations for where configuration files live: global installs should follow XDG conventions and not pollute the project directory, while local dev should keep config adjacent to the source code.
+
+## Decision
+
+### CLI Entry Point
+- The package MUST declare a `bin` entry pointing to `bin/claude-remote-cli.js`
+- `bin/claude-remote-cli.js` MUST parse CLI flags (`--port`, `--host`, `--config`, `--version`, `--help`) before delegating to `server/index.js`
+- CLI flags MUST be passed to the server via environment variables (`CLAUDE_REMOTE_CONFIG`, `CLAUDE_REMOTE_PORT`, `CLAUDE_REMOTE_HOST`)
+
+### Configuration Resolution
+Configuration values MUST be resolved in the following precedence order (highest to lowest):
+
+1. CLI flags (`--port`, `--host`, `--config`)
+2. Environment variables (`CLAUDE_REMOTE_PORT`, `CLAUDE_REMOTE_HOST`, `CLAUDE_REMOTE_CONFIG`)
+3. Config file values
+4. Built-in defaults (`host: '0.0.0.0'`, `port: 3456`, `cookieTTL: '24h'`)
+
+### Config File Location
+- When run via the CLI bin (global install): `~/.config/claude-remote-cli/config.json`
+- When run directly via `npm start` or `node server/index.js` (local dev): `./config.json` in the project root
+- The config directory MUST be created automatically if it does not exist
+- The `CLAUDE_REMOTE_CONFIG` environment variable MAY override both defaults
+
+### Published Files
+The `files` field in `package.json` MUST limit the published package to: `bin/`, `server/`, `public/`, and `config.example.json`. Test files, documentation, and development configuration MUST NOT be included in the published package.
+
+## Consequences
+
+### Positive
+- End users get a clean install experience: `npm install -g claude-remote-cli && claude-remote-cli`
+- Global config in `~/.config/` follows platform conventions and survives package upgrades
+- Local dev config in `./config.json` is gitignored and does not interfere with the global install
+- CLI flag precedence allows one-off overrides without editing the config file
+
+### Negative
+- Two config file locations means developers must be aware of which mode they are running in to find the right config
+- CLI flag parsing in `bin/claude-remote-cli.js` is manual (no argument parsing library like yargs or commander), which means adding new flags requires updating the parser by hand
+- Environment variable bridging between the bin script and server is an implicit coupling
+
+### Risks
+- If a user runs `npm start` after a global install, they get the local dev config path, which may cause confusion if they have already configured the global path
+- The `postinstall` script for node-pty native binaries (`chmod +x` on macOS prebuilds) may fail silently on some platforms, leaving the package in a broken state

--- a/docs/adrs/007-websocket-dual-channel-realtime-sync.md
+++ b/docs/adrs/007-websocket-dual-channel-realtime-sync.md
@@ -1,0 +1,63 @@
+# ADR-007: WebSocket Dual-Channel Design for Real-Time Sync
+
+## Status
+Accepted
+
+## Date
+2026-02-21
+
+## Decider(s)
+Donovan Yohan
+
+## Context
+The application has two distinct real-time communication needs: (1) bidirectional terminal I/O between the browser and a specific PTY session, and (2) server-to-client broadcast notifications when the state of worktree directories changes. Mixing both types of traffic on a single WebSocket connection would complicate message routing, require every terminal data frame to be parsed for control messages, and couple session-specific connections to global broadcast events. A single shared connection would also mean losing global event updates whenever the user switches sessions or disconnects from a terminal.
+
+## Decision
+The server MUST expose two separate WebSocket channels, both handled by a single `WebSocketServer` instance using the `noServer` mode with manual upgrade routing.
+
+### PTY Channel (`/ws/:sessionId`)
+- Each PTY channel connection MUST be scoped to a single session identified by the hex session ID in the URL path
+- The URL pattern MUST match `/ws/[a-f0-9]+`
+- **Server-to-client**: Raw PTY output data MUST be sent as text frames, with no JSON wrapping or framing protocol
+- **Client-to-server**: Text frames MUST be forwarded directly to the PTY's stdin, except for JSON messages with `type: "resize"` which MUST trigger a PTY resize operation
+- On connection, the server MUST replay the session's full scrollback buffer before attaching the live data handler
+- When the PTY process exits, the server MUST close the WebSocket with code 1000
+
+### Event Channel (`/ws/events`)
+- The event channel MUST be accessible at the fixed path `/ws/events`
+- This channel is server-to-client only; client messages are ignored
+- Event messages MUST be JSON objects with a `type` field (e.g., `{"type": "worktrees-changed"}`)
+- All connected event channel clients MUST receive every broadcast event
+- Connected clients are tracked in an in-memory `Set` and removed on close
+
+### WorktreeWatcher Integration
+- `WorktreeWatcher` (in `server/watcher.js`) MUST monitor `.claude/worktrees/` directories across all configured root directories using `fs.watch`
+- File system change events MUST be debounced with a 500ms delay before emitting a `worktrees-changed` event
+- The `worktrees-changed` event MUST trigger a broadcast to all event channel clients via `broadcastEvent`
+- REST endpoints that modify roots (POST/DELETE `/roots`) MUST also trigger `worktrees-changed` broadcasts and rebuild the watcher
+
+### Frontend Reconnection
+- The frontend MUST auto-reconnect the event socket with a 3-second delay when the connection closes
+- The PTY channel does NOT auto-reconnect; the user explicitly reconnects by clicking a session in the sidebar
+
+### Authentication
+- Both WebSocket channels MUST require authentication via the `token` cookie, verified during the HTTP upgrade before the WebSocket handshake completes
+- Unauthenticated upgrade requests MUST receive a `401 Unauthorized` response and the socket MUST be destroyed
+
+## Consequences
+
+### Positive
+- Clean separation of concerns: terminal I/O is raw and fast with no parsing overhead; event messages are structured JSON
+- The event channel survives session switches; the frontend always stays informed about worktree changes regardless of which terminal session is active
+- Raw PTY data on the terminal channel means zero encoding overhead for high-throughput terminal output
+- Single `WebSocketServer` instance with `noServer` mode avoids port conflicts and shares the HTTP server
+
+### Negative
+- Two WebSocket connections per authenticated client increases the number of open file descriptors on the server
+- The event channel is broadcast-only with no per-client filtering; all clients receive all events even if they are only interested in a subset of repositories
+- No message acknowledgment or delivery guarantees on the event channel; if a client misses an event, it must wait for the next one or poll via REST
+
+### Risks
+- `fs.watch` behavior varies across operating systems (especially on Linux with inotify limits); the watcher may silently fail to detect changes on some platforms
+- The 500ms debounce window means rapid successive worktree changes are collapsed into a single event, which could theoretically cause the frontend to miss intermediate states (mitigated by the frontend re-fetching the full worktree list on each event)
+- If many clients connect to the event channel simultaneously, the broadcast loop iterates over all of them synchronously, which could introduce latency for large client counts

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -1,0 +1,171 @@
+# Architecture
+
+> Part of the [Harness documentation system](../../CLAUDE.md). Edit this file for detailed architecture guidance.
+
+## Overview
+
+Remote web interface for Claude Code CLI sessions. Node.js backend manages PTY processes and relays I/O over WebSockets to a vanilla JS + xterm.js frontend.
+
+## Server Modules
+
+| Module | Role |
+|--------|------|
+| `server/index.js` | Express app, REST API routes, auth middleware, config loading |
+| `server/sessions.js` | PTY spawning via `node-pty`, session lifecycle, scrollback buffering (256KB max) |
+| `server/ws.js` | WebSocket upgrade handler, bidirectional PTY relay, scrollback replay on connect |
+| `server/watcher.js` | File system watching for `.claude/worktrees/` directories, debounced event emission |
+| `server/auth.js` | PIN hashing (bcrypt), rate limiting (5 fails = 15-min lockout), cookie token generation |
+| `server/config.js` | Config loading/saving with defaults |
+
+## Frontend
+
+Single-page app in `public/`. No build step, no framework.
+
+| File | Role |
+|------|------|
+| `public/app.js` | All frontend logic: session management, WebSocket, terminal, filtering, sidebar |
+| `public/index.html` | HTML structure with PIN gate, sidebar, terminal container, dialogs |
+| `public/style.css` | Dark theme, responsive mobile-first layout |
+| `public/vendor/` | Bundled xterm.js and addon-fit.js |
+
+## Data Flow
+
+```
+Browser (xterm.js) <--WebSocket /ws/:id--> server/ws.js <--PTY I/O--> node-pty <--spawns--> claude CLI
+                                                |
+                                           scrollback buffer (in-memory, per session)
+
+Browser (app.js)   <--WebSocket /ws/events-- server/ws.js <-- watcher.js (fs.watch on .claude/worktrees/)
+                                                           <-- POST/DELETE /roots (manual broadcast)
+```
+
+1. User types in xterm.js terminal
+2. Keystrokes sent via WebSocket to server
+3. Server writes to PTY stdin
+4. PTY stdout/stderr relayed back over WebSocket
+5. xterm.js renders output in browser
+6. Resize events sent as JSON: `{type: 'resize', cols, rows}`
+
+## REST API Routes
+
+- `POST /auth` - Authenticate with PIN, returns session cookie
+- `GET /sessions` - List active sessions
+- `POST /sessions` - Create new session or resume worktree
+- `PATCH /sessions/:id` - Rename session (syncs `/rename` to PTY)
+- `DELETE /sessions/:id` - Terminate session
+- `GET /repos` - Scan root directories for git repos
+- `GET /worktrees` - List available inactive Claude Code worktrees
+- `GET /roots` / `POST /roots` / `DELETE /roots` - Manage root directories (POST/DELETE also rebuild watcher + broadcast)
+
+## WebSocket Channels
+
+- `/ws/:sessionId` - PTY relay (bidirectional: terminal I/O + resize)
+- `/ws/events` - Server-to-client broadcast (JSON `{type: "worktrees-changed"}`)
+
+## Session Object Structure
+
+```javascript
+{
+  id,            // random hex
+  root,          // configured root directory
+  repoName,      // repository name
+  repoPath,      // working directory
+  worktreeName,  // Claude Code worktree name
+  displayName,   // user-friendly name
+  pty,           // node-pty process
+  createdAt,     // ISO timestamp
+  lastActivity,  // ISO timestamp
+  scrollback,    // array of data chunks, max 256KB
+}
+```
+
+## CLI Entry Point
+
+`bin/claude-remote-cli.js` - Parses flags (`--port`, `--host`, `--config`), manages config directory at `~/.config/claude-remote-cli/`, prompts for PIN on first run.
+
+---
+
+## Architecture Rules (derived from ADRs)
+
+> Regenerate with `/adr:update`. See [docs/adrs/](../adrs/) for full decision records.
+
+### Server module structure
+
+- [ADR-001] The server MUST be organized into six modules under `server/`: `index.js`, `sessions.js`, `ws.js`, `watcher.js`, `auth.js`, `config.js`.
+- [ADR-001] Modules MUST communicate through direct `require()` imports with no DI container, service layer, or abstract interfaces.
+- [ADR-001] `index.js` MUST serve as the composition root, wiring all other modules at startup.
+- [ADR-001] Modules SHOULD NOT import `index.js`; cross-module dependencies flow downward only.
+
+### Frontend architecture
+
+- [ADR-002] The frontend MUST be a single-page application using plain HTML, CSS, and JavaScript in `public/`.
+- [ADR-002] There MUST NOT be a build step, transpiler, or bundler.
+- [ADR-002] All application logic MUST reside in `public/app.js` as a single IIFE.
+- [ADR-002] Styles MUST be in `public/style.css`; the HTML entry point MUST be `public/index.html`.
+- [ADR-002] Vendor dependencies MUST be self-hosted as pre-built files in `public/vendor/` and loaded via `<script>` tags.
+- [ADR-002] The frontend MUST use ES5-compatible syntax (`var`, `.then()`, no arrow functions, no template literals).
+- [ADR-002] DOM manipulation MUST use `document.getElementById`, `document.createElement`, and event listeners directly.
+
+### PTY session management
+
+- [ADR-003] Sessions MUST be managed using `node-pty` to spawn pseudo-terminal processes.
+- [ADR-003] Active sessions MUST be stored in an in-memory `Map` keyed by session ID.
+- [ADR-003] Session IDs MUST be generated using `crypto.randomBytes(8).toString('hex')`.
+- [ADR-003] There MUST NOT be a database or persistent storage for session state.
+- [ADR-003] When a PTY process exits, its session MUST be automatically removed from the registry.
+- [ADR-003] Each session MUST maintain a scrollback buffer capped at 256KB with FIFO eviction.
+- [ADR-003] On WebSocket connection, the full scrollback buffer MUST be replayed to the client.
+- [ADR-003] The `CLAUDECODE` environment variable MUST be stripped from the PTY's environment.
+- [ADR-003] The PTY MUST be configured with `xterm-256color` as the terminal name.
+- [ADR-003] The sessions module MUST export: `create`, `get`, `list`, `kill`, `resize`, `updateDisplayName`.
+
+### Authentication
+
+- [ADR-004] On first run, the server MUST prompt the user to set a PIN via the terminal.
+- [ADR-004] The PIN MUST be hashed using bcrypt with 10 salt rounds before storage.
+- [ADR-004] The bcrypt hash MUST be stored in the config file under the `pinHash` key.
+- [ADR-004] PIN verification MUST use `bcrypt.compare` against the stored hash.
+- [ADR-004] On successful verification, the server MUST generate a token using `crypto.randomBytes(32).toString('hex')`.
+- [ADR-004] The token MUST be set as an `httpOnly`, `sameSite: strict` cookie with configurable TTL (default: 24h).
+- [ADR-004] Authenticated tokens MUST be stored in an in-memory `Set` with `setTimeout`-based expiry.
+- [ADR-004] Failed PIN attempts MUST be tracked per IP; after 5 failures, the IP MUST be locked out for 15 minutes.
+- [ADR-004] A successful authentication MUST clear the rate limit counter for that IP.
+- [ADR-004] WebSocket upgrade requests MUST be authenticated by checking the `token` cookie.
+- [ADR-004] Unauthenticated WebSocket connections MUST be rejected with a 401 before the upgrade completes.
+
+### Testing
+
+- [ADR-005] All unit tests MUST use `node:test` and `node:assert`; no external test framework SHOULD be installed.
+- [ADR-005] Test files MUST be in `test/` with the naming convention `*.test.js`.
+- [ADR-005] Tests MUST be runnable via `npm test` (`node --test test/*.test.js`).
+- [ADR-005] Individual test files MUST be runnable in isolation via `node --test test/<file>.test.js`.
+- [ADR-005] `auth.test.js` MUST clear the `require` cache before each test for fresh module state.
+- [ADR-005] `sessions.test.js` MUST clean up spawned PTY processes in `afterEach` hooks.
+- [ADR-005] `config.test.js` MUST use temporary directories and clean up files between tests.
+- [ADR-005] E2E tests SHOULD be kept separate from unit tests.
+
+### Distribution and configuration
+
+- [ADR-006] The package MUST declare a `bin` entry pointing to `bin/claude-remote-cli.js`.
+- [ADR-006] The CLI MUST parse `--port`, `--host`, `--config`, `--version`, `--help` flags before delegating to `server/index.js`.
+- [ADR-006] CLI flags MUST be passed to the server via environment variables (`CLAUDE_REMOTE_CONFIG`, `CLAUDE_REMOTE_PORT`, `CLAUDE_REMOTE_HOST`).
+- [ADR-006] Configuration precedence MUST be: CLI flags > environment variables > config file > built-in defaults.
+- [ADR-006] Global install config MUST be at `~/.config/claude-remote-cli/config.json`; local dev config MUST be at `./config.json`.
+- [ADR-006] The config directory MUST be created automatically if it does not exist.
+- [ADR-006] The `CLAUDE_REMOTE_CONFIG` environment variable MAY override both default config paths.
+- [ADR-006] The `files` field in `package.json` MUST limit published content to `bin/`, `server/`, `public/`, and `config.example.json`.
+
+### WebSocket channels
+
+- [ADR-007] The server MUST expose two separate WebSocket channels via a single `WebSocketServer` in `noServer` mode.
+- [ADR-007] PTY channel (`/ws/:sessionId`) MUST be scoped to one session; the URL pattern MUST match `/ws/[a-f0-9]+`.
+- [ADR-007] PTY server-to-client data MUST be sent as raw text frames with no JSON wrapping.
+- [ADR-007] PTY client-to-server text frames MUST be forwarded to stdin, except JSON `type: "resize"` messages which MUST trigger a PTY resize.
+- [ADR-007] On PTY channel connection, the server MUST replay the scrollback buffer before attaching the live handler.
+- [ADR-007] When a PTY process exits, the server MUST close the WebSocket with code 1000.
+- [ADR-007] Event channel MUST be at the fixed path `/ws/events`; it is server-to-client only.
+- [ADR-007] Event messages MUST be JSON objects with a `type` field.
+- [ADR-007] `WorktreeWatcher` MUST monitor `.claude/worktrees/` directories using `fs.watch` with 500ms debounce.
+- [ADR-007] The frontend MUST auto-reconnect the event socket with a 3-second delay on close.
+- [ADR-007] Both WebSocket channels MUST require authentication via the `token` cookie during HTTP upgrade.
+- [ADR-007] Unauthenticated upgrade requests MUST receive a 401 response and the socket MUST be destroyed.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,8 @@
+# Documentation Guides
+
+| Guide | Description | Last Updated |
+|-------|-------------|--------------|
+| [architecture.md](architecture.md) | Server/client architecture, data flow, API routes | 2026-02-21 |
+| [testing.md](testing.md) | Test runner, test files, running single tests | 2026-02-21 |
+| [patterns.md](patterns.md) | Config precedence, auth flow, PTY management, conventions | 2026-02-21 |
+| [review-agent-setup.md](review-agent-setup.md) | Code review agent configuration for harness loop | 2026-02-21 |

--- a/docs/guides/patterns.md
+++ b/docs/guides/patterns.md
@@ -1,0 +1,48 @@
+# Patterns & Conventions
+
+> Part of the [Harness documentation system](../../CLAUDE.md). Edit this file for detailed patterns guidance.
+
+## Config Precedence
+
+1. CLI flags (`--port`, `--host`, `--config`)
+2. Environment variables (`CLAUDE_REMOTE_PORT`, `CLAUDE_REMOTE_HOST`, `CLAUDE_REMOTE_CONFIG`)
+3. Config file (`~/.config/claude-remote-cli/config.json` when global, `./config.json` for dev)
+4. Hardcoded defaults
+
+## Authentication Flow
+
+1. First run: CLI prompts for PIN, bcrypt-hashes it, saves to config
+2. Browser: user enters PIN at login screen
+3. Server verifies via bcrypt, issues `crypto.randomBytes(32)` cookie token
+4. Rate limiting: per-IP, 5 failures = 15-minute lockout
+5. To reset PIN: delete `pinHash` from config and restart
+
+## PTY Management
+
+- `CLAUDECODE` env var is stripped from PTY env to allow nesting
+- Worktree naming convention: `mobile-<name>-<timestamp>`
+- Scrollback buffer: max 256KB per session, auto-trims oldest entries
+- Session auto-deleted when PTY exits; WebSocket closed on exit
+
+## Cookie TTL Parsing
+
+Human-readable format: `s` (seconds), `m` (minutes), `h` (hours), `d` (days). Default: `24h`.
+
+## Root Directory Scanning
+
+Scans configured `rootDirs` one level deep for git repos. Hidden directories (starting with `.`) are excluded.
+
+## Real-Time Worktree Sync
+
+- `WorktreeWatcher` monitors `.claude/worktrees/` dirs using `fs.watch` (macOS/Linux only)
+- File system events are debounced (500ms) before broadcasting `worktrees-changed` via `/ws/events`
+- REST root changes (POST/DELETE `/roots`) also trigger watcher rebuild + broadcast
+- Frontend auto-reconnects the event socket with 3-second retry on close
+- Settings dialog close triggers `refreshAll()` for immediate sidebar update
+
+## Frontend Conventions
+
+- Vanilla JS, no build step, no framework
+- All frontend state lives in `public/app.js` module-level variables
+- Vendor libraries (xterm.js) bundled in `public/vendor/`
+- Mobile-first responsive design with touch toolbar

--- a/docs/guides/review-agent-setup.md
+++ b/docs/guides/review-agent-setup.md
@@ -1,0 +1,64 @@
+# Review Agent Setup
+
+> Part of the [Harness documentation system](../../CLAUDE.md). Edit this file to configure your code review agent.
+
+## Default (zero-config)
+
+With `"provider": "default"` in `docs/risk-contract.json`, the harness loop uses `pr:review` (code-quality:code-reviewer subagent). No external service needed.
+
+## Configuring an External Reviewer
+
+Edit the `reviewAgent` section in `docs/risk-contract.json`:
+
+### Greptile
+
+```json
+"reviewAgent": {
+  "provider": "greptile",
+  "config": {
+    "checkName": "Greptile Code Review",
+    "rerunComment": "@greptile please re-review",
+    "timeoutMinutes": 20
+  }
+}
+```
+
+### CodeRabbit
+
+```json
+"reviewAgent": {
+  "provider": "coderabbit",
+  "config": {
+    "checkName": "CodeRabbit Review",
+    "rerunComment": "@coderabbitai full review",
+    "timeoutMinutes": 15
+  }
+}
+```
+
+### Custom Provider
+
+```json
+"reviewAgent": {
+  "provider": "custom",
+  "config": {
+    "checkName": "Your Check Run Name",
+    "rerunComment": "Text that triggers re-review",
+    "timeoutMinutes": 20
+  }
+}
+```
+
+**Config fields:**
+- `checkName` — The GitHub check run name the gate waits for
+- `rerunComment` — Comment text posted to trigger re-review after remediation
+- `timeoutMinutes` — Max time to wait for review completion (default: 20)
+
+## How the Loop Uses the Review Agent
+
+1. After the risk gate passes, the loop checks `reviewAgent.provider`
+2. If `"default"`: spawns `pr:review` subagent directly
+3. If anything else: waits for the GitHub check run matching `checkName` on the current head SHA
+4. Review findings are parsed from check run output or PR review comments
+5. If findings exist, the remediation-coordinator agent fixes and pushes
+6. A SHA-deduped rerun comment using `rerunComment` text triggers re-review

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,0 +1,28 @@
+# Testing
+
+> Part of the [Harness documentation system](../../CLAUDE.md). Edit this file for detailed testing guidance.
+
+## Test Runner
+
+Uses Node.js built-in `node:test` module. No external test framework.
+
+```bash
+npm test                          # Run all tests
+node --test test/auth.test.js     # Run a single test file
+```
+
+## Test Files
+
+| File | Covers |
+|------|--------|
+| `test/auth.test.js` | PIN hashing, verification, rate limiting |
+| `test/config.test.js` | Config loading/saving |
+| `test/sessions.test.js` | PTY spawning, session lifecycle |
+
+## E2E Testing
+
+Playwright is installed as a dev dependency but no E2E test files exist yet.
+
+```bash
+npx playwright test               # Would run E2E tests
+```

--- a/docs/risk-contract.json
+++ b/docs/risk-contract.json
@@ -1,0 +1,38 @@
+{
+  "version": "1",
+  "riskTierRules": {
+    "critical": ["server/auth.js", "server/ws.js"],
+    "high": ["server/index.js", "server/sessions.js", "server/config.js", "bin/**"],
+    "medium": ["public/**"],
+    "low": ["**"]
+  },
+  "mergePolicy": {
+    "critical": {
+      "requiredChecks": ["risk-policy-gate", "code-review-agent"],
+      "requireHumanApproval": true,
+      "maxRemediationAttempts": 1
+    },
+    "high": {
+      "requiredChecks": ["risk-policy-gate", "code-review-agent"],
+      "requireHumanApproval": true,
+      "maxRemediationAttempts": 2
+    },
+    "medium": {
+      "requiredChecks": ["risk-policy-gate", "code-review-agent"],
+      "requireHumanApproval": false,
+      "maxRemediationAttempts": 3
+    },
+    "low": {
+      "requiredChecks": ["risk-policy-gate"],
+      "requireHumanApproval": false,
+      "maxRemediationAttempts": 3
+    }
+  },
+  "reviewAgent": {
+    "provider": "default",
+    "config": {}
+  },
+  "docsDriftRules": {
+    "requireUpdateWith": {}
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-remote-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-remote-cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "dependencies": {
         "bcrypt": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-remote-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Remote web interface for Claude Code CLI sessions",
   "main": "server/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/donovan-yohan/claude-remote-cli.git"
+    "url": "git+https://github.com/donovan-yohan/claude-remote-cli.git"
   },
   "license": "MIT",
   "author": "Donovan Yohan",

--- a/server/watcher.js
+++ b/server/watcher.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const EventEmitter = require('events');
+
+class WorktreeWatcher extends EventEmitter {
+  constructor() {
+    super();
+    this._watchers = [];
+    this._debounceTimer = null;
+  }
+
+  rebuild(rootDirs) {
+    this._closeAll();
+
+    for (const rootDir of rootDirs) {
+      let entries;
+      try {
+        entries = fs.readdirSync(rootDir, { withFileTypes: true });
+      } catch (_) {
+        continue;
+      }
+      for (const entry of entries) {
+        if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+        const repoPath = path.join(rootDir, entry.name);
+        if (!fs.existsSync(path.join(repoPath, '.git'))) continue;
+        this._watchRepo(repoPath);
+      }
+    }
+  }
+
+  _watchRepo(repoPath) {
+    const worktreeDir = path.join(repoPath, '.claude', 'worktrees');
+    if (fs.existsSync(worktreeDir)) {
+      this._addWatch(worktreeDir);
+    } else {
+      const claudeDir = path.join(repoPath, '.claude');
+      if (fs.existsSync(claudeDir)) {
+        this._addWatch(claudeDir);
+      }
+    }
+  }
+
+  _addWatch(dirPath) {
+    try {
+      const watcher = fs.watch(dirPath, { persistent: false }, () => {
+        this._debouncedEmit();
+      });
+      watcher.on('error', () => {});
+      this._watchers.push(watcher);
+    } catch (_) {}
+  }
+
+  _debouncedEmit() {
+    if (this._debounceTimer) clearTimeout(this._debounceTimer);
+    this._debounceTimer = setTimeout(() => {
+      this.emit('worktrees-changed');
+    }, 500);
+  }
+
+  _closeAll() {
+    for (const w of this._watchers) {
+      try { w.close(); } catch (_) {}
+    }
+    this._watchers = [];
+    if (this._debounceTimer) {
+      clearTimeout(this._debounceTimer);
+      this._debounceTimer = null;
+    }
+  }
+
+  close() {
+    this._closeAll();
+  }
+}
+
+module.exports = { WorktreeWatcher };


### PR DESCRIPTION
## Summary

Worktree changes on disk are now pushed to all connected browser clients in real time, so the sidebar stays up to date without polling. Settings changes (adding/removing root directories) also trigger an immediate refresh.

## Changes

- **New module `server/watcher.js`**: Uses `fs.watch` to monitor `.claude/worktrees/` directories across all configured repos with 500ms debounce
- **WebSocket event channel `/ws/events`**: Server-to-client broadcast channel alongside existing PTY channel, shares the same `WebSocketServer` instance
- **Server integration**: Root dir add/remove endpoints rebuild watchers and broadcast changes; watcher initialized on startup
- **Client event socket**: Auto-reconnecting WebSocket listener calls `refreshAll()` + `loadRepos()` on worktree changes; settings close also refreshes sidebar
- **DRY cleanup**: Extracted shared repo-scanning logic into `scanReposInRoot`/`scanAllRepos` helpers, moved `fs` require to top-level
- **README**: Added platform support note (macOS/Linux tested), updated architecture diagram and features list
- **Docs**: Updated architecture guide data flow diagram and patterns guide with real-time sync section

## Testing

- All 18 existing tests pass (`npm test`)
- Syntax checks pass on all modified files
- Code simplifier ran and cleaned up DRY violations, dead code paths, and redundant guards
- Platform: macOS and Linux only (`fs.watch` behavior varies on Windows)

---
*Created with `/pr:author`*