### PR TITLE
fix: resolve mobile text input garbling and PWA installability

### DIFF
--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="64" fill="#1a1a1a"/>
+  <text x="256" y="200" text-anchor="middle" font-family="monospace" font-size="72" font-weight="bold" fill="#d97757">&gt;_</text>
+  <text x="256" y="320" text-anchor="middle" font-family="-apple-system,sans-serif" font-size="56" font-weight="600" fill="#ececec">Claude</text>
+  <text x="256" y="390" text-anchor="middle" font-family="-apple-system,sans-serif" font-size="40" fill="#9b9b9b">Remote CLI</text>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
   <title>Claude Remote CLI</title>
   <link rel="manifest" href="/manifest.json" />
+  <link rel="icon" href="/icon.svg" type="image/svg+xml" />
+  <link rel="apple-touch-icon" href="/icon.svg" />
   <meta name="mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
@@ -64,7 +66,7 @@
         <button id="menu-btn" class="icon-btn" aria-label="Open sessions menu">&#9776;</button>
         <span id="session-title" class="mobile-title">No session</span>
       </div>
-      <input type="text" id="mobile-input" autocomplete="on" autocorrect="on" autocapitalize="sentences" spellcheck="true" aria-label="Terminal input" />
+      <input type="text" id="mobile-input" dir="ltr" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-label="Terminal input" />
       <div id="terminal-container"></div>
       <div id="terminal-scrollbar"><div id="terminal-scrollbar-thumb"></div></div>
       <div id="no-session-msg">No active session. Create or select a session to begin.</div>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,5 +4,13 @@
   "display": "standalone",
   "start_url": "/",
   "background_color": "#1a1a1a",
-  "theme_color": "#1a1a1a"
+  "theme_color": "#1a1a1a",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
 }

--- a/public/style.css
+++ b/public/style.css
@@ -470,13 +470,20 @@ html, body {
 
 #mobile-input {
   position: absolute;
-  top: -9999px;
-  left: -9999px;
+  left: 0;
+  top: 0;
   width: 1px;
   height: 1px;
   opacity: 0;
   font-size: 16px; /* prevents iOS zoom on focus */
   z-index: -1;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  outline: none;
+  color: transparent;
+  caret-color: transparent;
+  background: transparent;
 }
 
 /* ===== Terminal Scrollbar ===== */


### PR DESCRIPTION
## Summary

Fixes broken mobile text input where typed characters appeared reversed/garbled on Android, and makes the app installable as a PWA by adding required manifest icons.

## Changes

- **Mobile input (critical)**: Merged two `attachCustomKeyEventHandler` calls into one — the second was silently overwriting the mobile keyboard blocker on Android, causing xterm's internal textarea to compete with the mobile input proxy
- **IME composition**: Added `compositionstart`/`compositionend` tracking with `blur` and session-switch recovery to prevent stuck state or double-send on Android Gboard
- **Input positioning**: Moved hidden input from `top: -9999px` to within viewport (`left: 0; top: 0`) for Android IME compatibility; disabled autocorrect/autocapitalize (harmful for CLI input)
- **PWA manifest**: Added SVG icon and `icons` array so browsers show the install prompt

## Testing

- All 46 tests pass after rebase on master (1.9.0)
- Build compiles clean
- Verified `attachCustomKeyEventHandler` is called exactly once
- Composition handlers include blur recovery and session-switch reset to prevent stuck `isComposing` state

---
*Created with `/pr:author`*