### PR TITLE
feat: handle existing worktrees on branch conflict

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -32,7 +32,8 @@ Backend patterns and conventions for claude-remote-cli. The server is a composit
 ## Session Types
 
 - **Repo sessions** (`POST /sessions/repo`) — Claude runs directly in repo root. One per repo path (409 on conflict). Supports `continue: true` for `--continue` mode.
-- **Worktree sessions** (`POST /sessions`) — Creates git worktree under `.worktrees/`. Multiple per repo allowed.
+- **Worktree sessions** (`POST /sessions`) — Creates git worktree under `.worktrees/`. Multiple per repo allowed. If branch is already checked out (main worktree or another worktree), auto-redirects to that location instead of failing.
+- **Worktree deletion** (`DELETE /worktrees`) — Validated via `git worktree list` (supports arbitrary paths, not just `.worktrees/`). Main worktree cannot be deleted.
 
 ## Idle Detection
 

--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -14,7 +14,7 @@ No tech debt tracked yet.
 
 ## Completed Plans
 
-See `docs/exec-plans/completed/` for historical plans (18 completed).
+See `docs/exec-plans/completed/` for historical plans (19 completed).
 
 ## See Also
 

--- a/docs/design-docs/2026-02-26-handle-existing-worktrees-design.md
+++ b/docs/design-docs/2026-02-26-handle-existing-worktrees-design.md
@@ -1,0 +1,107 @@
+# Handle Existing Worktrees Design
+
+**Date:** 2026-02-26
+**Status:** Proposed
+
+## Problem
+
+When creating a worktree for a branch that's already checked out (either in the main worktree or another worktree), `git worktree add` fails with:
+
+```
+fatal: '<branch>' is already used by worktree at '<path>'
+```
+
+The server surfaces this as a raw 500 error. Users expect the UI to detect this and redirect to the existing worktree.
+
+Additionally, worktrees at arbitrary paths (outside `.worktrees/` and `.claude/worktrees/`) cannot be deleted from the UI because `isValidWorktreePath` rejects them.
+
+## Design
+
+### Change 1: Auto-redirect to existing worktree on branch conflict
+
+**Where:** `POST /sessions` in `server/index.ts`
+
+After confirming the branch exists locally, check `git worktree list --porcelain` to see if it's already checked out somewhere. If so, skip `git worktree add` and open a session at the existing path.
+
+**Logic:**
+
+```
+if (branchName && branchExists) {
+  // NEW: Check if branch is already checked out in a worktree
+  const worktrees = parseWorktreeListPorcelain(gitWorktreeList, repoPath);
+  const existing = findWorktreeForBranch(allWorktrees, branchName);
+
+  if (existing is main worktree) {
+    → create repo session at repoPath (same as POST /sessions/repo)
+  } else if (existing is another worktree) {
+    → create worktree session at existing.path with --continue
+  } else {
+    → proceed with git worktree add as before
+  }
+}
+```
+
+**Key details:**
+- Must include the main worktree in the search (currently `parseWorktreeListPorcelain` skips it). Write a variant or separate search that includes all entries.
+- When redirecting to the main worktree, create a **repo session** (auto-detect).
+- When redirecting to another worktree, create a **worktree session** with `--continue`.
+- Return 201 with the session — the frontend doesn't need to know about the redirect.
+
+### Change 2: Git-based delete validation
+
+**Where:** `DELETE /worktrees` in `server/index.ts`, `isValidWorktreePath` in `server/watcher.ts`
+
+Replace directory-name validation with git-based validation: a path is valid for deletion if it appears in `git worktree list --porcelain` output for the given repo.
+
+**Logic:**
+
+```
+// Instead of: isValidWorktreePath(worktreePath) — checks directory name
+// Use: isGitWorktree(repoPath, worktreePath) — checks git worktree list
+
+async function isGitWorktree(repoPath, worktreePath): boolean {
+  const { stdout } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], { cwd: repoPath });
+  const allWorktrees = parseAllWorktrees(stdout);  // includes main
+  return allWorktrees.some(wt => wt.path === worktreePath && wt.path !== repoPath);
+}
+```
+
+**Safety:** Still prevent deleting the main worktree (that would be destructive). Only allow deleting non-main worktrees that git recognizes.
+
+### Change 3: Helper to find worktree by branch (including main)
+
+**Where:** `server/watcher.ts`
+
+Add a `parseAllWorktrees` function that works like `parseWorktreeListPorcelain` but includes the main worktree. This is used by both Change 1 (branch conflict detection) and Change 2 (delete validation).
+
+```typescript
+interface ParsedWorktreeEntry {
+  path: string;
+  branch: string;
+  isMain: boolean;
+}
+
+function parseAllWorktrees(stdout: string, repoPath: string): ParsedWorktreeEntry[]
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `server/watcher.ts` | Add `parseAllWorktrees` function, `ParsedWorktreeEntry` type |
+| `server/index.ts` | Update `POST /sessions` with branch-conflict detection; update `DELETE /worktrees` with git-based validation |
+
+## Non-Changes
+
+- `GET /worktrees` — already uses `git worktree list` for discovery; main worktree skip is correct for listing
+- `WorktreeWatcher` — no change; filesystem watching scope is unchanged
+- Frontend — no changes needed; the redirect is transparent (same 201 response shape)
+
+## Edge Cases
+
+1. **Branch checked out in main worktree** → auto-detect, create repo session
+2. **Branch checked out in worktree outside `.worktrees/`** → create worktree session there
+3. **Branch checked out in `.worktrees/` dir** → create worktree session (existing behavior, just detected earlier)
+4. **Orphaned worktree (directory exists but git doesn't track it)** → existing fallback handles this
+5. **Deleting worktree at arbitrary path** → git-validated, allowed if git recognizes it
+6. **Attempting to delete main worktree** → rejected (path === repoPath check)

--- a/docs/design-docs/index.md
+++ b/docs/design-docs/index.md
@@ -20,3 +20,4 @@
 | [2026-02-24-session-card-action-buttons-design.md](2026-02-24-session-card-action-buttons-design.md) | Inline pill buttons replacing context menu | 2026-02-24 |
 | [2026-02-25-mobile-input-redesign-design.md](2026-02-25-mobile-input-redesign-design.md) | Event-intent architecture replacing value-diffing for mobile input | 2026-02-25 |
 | [2026-02-25-mobile-scroll-ux-design.md](2026-02-25-mobile-scroll-ux-design.md) | Mobile scroll & touch UX improvements (6 patterns from claude-wormhole analysis) | 2026-02-25 |
+| [2026-02-26-handle-existing-worktrees-design.md](2026-02-26-handle-existing-worktrees-design.md) | Auto-redirect to existing worktrees on branch conflict + git-based delete validation | 2026-02-26 |

--- a/docs/exec-plans/completed/2026-02-26-handle-existing-worktrees.md
+++ b/docs/exec-plans/completed/2026-02-26-handle-existing-worktrees.md
@@ -1,0 +1,460 @@
+# Handle Existing Worktrees Implementation Plan
+
+> **Status**: Completed | **Created**: 2026-02-26 | **Completed**: 2026-02-26
+> **Design Doc**: `docs/design-docs/2026-02-26-handle-existing-worktrees-design.md`
+> **For Claude:** Use /harness:orchestrate to execute this plan.
+
+## Decision Log
+
+| Date | Phase | Decision | Rationale |
+|------|-------|----------|-----------|
+| 2026-02-26 | Design | Auto-redirect to existing worktree on branch conflict | Users expect seamless UX, not raw git errors |
+| 2026-02-26 | Design | Main worktree → repo session, other worktree → worktree session | Auto-detect session type based on worktree location |
+| 2026-02-26 | Design | Git-based delete validation (replace path-pattern check) | Allow managing worktrees at arbitrary paths |
+| 2026-02-26 | Design | Full management of arbitrary-path worktrees | Users want view + open + delete regardless of path |
+| 2026-02-26 | Plan | Auto-switch sidebar tab when redirect changes session type | User expects to see the created session regardless of tab |
+| 2026-02-26 | Retrospective | Plan completed — 5/5 tasks, 0 surprises, 0 drift | Clean execution, all tests pass |
+
+## Progress
+
+- [x] Task 1: Add `parseAllWorktrees` helper to `server/watcher.ts` _(completed 2026-02-26)_
+- [x] Task 2: Add branch conflict detection to `POST /sessions` _(completed 2026-02-26)_
+- [x] Task 3: Replace `isValidWorktreePath` with git-based validation in `DELETE /worktrees` _(completed 2026-02-26)_
+- [x] Task 4: Frontend tab auto-switch on redirect to repo session _(completed 2026-02-26)_
+- [x] Task 5: Build and verify all tests pass _(completed 2026-02-26)_
+
+## Surprises & Discoveries
+
+_None yet — updated during execution by /harness:orchestrate._
+
+## Plan Drift
+
+_None yet — updated when tasks deviate from plan during execution._
+
+---
+
+### Task 1: Add `parseAllWorktrees` helper to `server/watcher.ts`
+
+**Files:**
+- Modify: `server/watcher.ts:14-41`
+- Test: `test/worktrees.test.ts`
+
+**Step 1: Write the failing tests**
+
+In `test/worktrees.test.ts`, add a new `describe` block after the existing `parseWorktreeListPorcelain` tests (after line 171). Import `parseAllWorktrees` alongside existing imports.
+
+Update the import at line 3:
+
+```typescript
+import { WORKTREE_DIRS, isValidWorktreePath, parseWorktreeListPorcelain, parseAllWorktrees } from '../server/watcher.js';
+```
+
+Add tests:
+
+```typescript
+describe('parseAllWorktrees', () => {
+  const repoPath = '/Users/me/code/my-repo';
+
+  it('should include the main worktree with isMain=true', () => {
+    const stdout = [
+      `worktree ${repoPath}`,
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+    ].join('\n');
+
+    const result = parseAllWorktrees(stdout, repoPath);
+    assert.equal(result.length, 1);
+    assert.equal(result[0]!.path, repoPath);
+    assert.equal(result[0]!.branch, 'main');
+    assert.equal(result[0]!.isMain, true);
+  });
+
+  it('should mark non-main worktrees with isMain=false', () => {
+    const stdout = [
+      `worktree ${repoPath}`,
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /Users/me/code/my-repo/.worktrees/feat-branch',
+      'HEAD def456',
+      'branch refs/heads/feat/branch',
+      '',
+    ].join('\n');
+
+    const result = parseAllWorktrees(stdout, repoPath);
+    assert.equal(result.length, 2);
+    assert.equal(result[0]!.isMain, true);
+    assert.equal(result[1]!.isMain, false);
+    assert.equal(result[1]!.path, '/Users/me/code/my-repo/.worktrees/feat-branch');
+    assert.equal(result[1]!.branch, 'feat/branch');
+  });
+
+  it('should still skip bare entries', () => {
+    const stdout = [
+      `worktree ${repoPath}`,
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /some/bare/repo',
+      'HEAD def456',
+      'bare',
+      '',
+    ].join('\n');
+
+    const result = parseAllWorktrees(stdout, repoPath);
+    assert.equal(result.length, 1);
+    assert.equal(result[0]!.isMain, true);
+  });
+
+  it('should include detached HEAD entries with empty branch', () => {
+    const stdout = [
+      `worktree ${repoPath}`,
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /Users/me/code/my-repo/.worktrees/detached',
+      'HEAD def456',
+      'detached',
+      '',
+    ].join('\n');
+
+    const result = parseAllWorktrees(stdout, repoPath);
+    assert.equal(result.length, 2);
+    assert.equal(result[1]!.branch, '');
+  });
+
+  it('should handle empty output', () => {
+    const result = parseAllWorktrees('', repoPath);
+    assert.equal(result.length, 0);
+  });
+
+  it('should find worktree by branch name', () => {
+    const stdout = [
+      `worktree ${repoPath}`,
+      'HEAD abc123',
+      'branch refs/heads/dy/feat/worktree-isolation',
+      '',
+      'worktree /Users/me/code/my-repo/.worktrees/feat-a',
+      'HEAD def456',
+      'branch refs/heads/feat/a',
+      '',
+    ].join('\n');
+
+    const result = parseAllWorktrees(stdout, repoPath);
+    const match = result.find(wt => wt.branch === 'dy/feat/worktree-isolation');
+    assert.ok(match);
+    assert.equal(match!.path, repoPath);
+    assert.equal(match!.isMain, true);
+  });
+});
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `npm run build && node --test dist/test/worktrees.test.js`
+Expected: FAIL — `parseAllWorktrees` is not exported
+
+**Step 3: Write the implementation**
+
+In `server/watcher.ts`, add a new interface and function after `ParsedWorktree` (after line 17):
+
+```typescript
+export interface ParsedWorktreeEntry {
+  path: string;
+  branch: string;
+  isMain: boolean;
+}
+
+/**
+ * Parse `git worktree list --porcelain` output into ALL entries (including main worktree).
+ * Skips bare entries. Detached HEAD entries get empty branch string.
+ */
+export function parseAllWorktrees(stdout: string, repoPath: string): ParsedWorktreeEntry[] {
+  const results: ParsedWorktreeEntry[] = [];
+  const blocks = stdout.split('\n\n').filter(Boolean);
+  for (const block of blocks) {
+    const lines = block.split('\n');
+    let wtPath = '';
+    let branch = '';
+    let bare = false;
+    for (const line of lines) {
+      if (line.startsWith('worktree ')) wtPath = line.slice(9);
+      if (line.startsWith('branch refs/heads/')) branch = line.slice(18);
+      if (line === 'bare') bare = true;
+    }
+    if (!wtPath || bare) continue;
+    results.push({ path: wtPath, branch, isMain: wtPath === repoPath });
+  }
+  return results;
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `npm run build && node --test dist/test/worktrees.test.js`
+Expected: ALL PASS
+
+**Step 5: Commit**
+
+```bash
+git add server/watcher.ts test/worktrees.test.ts
+git commit -m "feat: add parseAllWorktrees helper that includes main worktree"
+```
+
+---
+
+### Task 2: Add branch conflict detection to `POST /sessions`
+
+**Files:**
+- Modify: `server/index.ts:591-679` (POST /sessions handler)
+
+**Step 1: Add the import**
+
+At the top of `server/index.ts`, update the import from `./watcher.js` to include `parseAllWorktrees`:
+
+```typescript
+import { WorktreeWatcher, WORKTREE_DIRS, isValidWorktreePath, parseWorktreeListPorcelain, parseAllWorktrees } from './watcher.js';
+```
+
+**Step 2: Add branch-conflict detection in the creation flow**
+
+In `POST /sessions`, after `branchExists` is determined (after line 661), add conflict detection before the `git worktree add` calls. Replace the block from line 663 to line 669:
+
+```typescript
+        if (branchName && branchExists) {
+          // Check if branch is already checked out in an existing worktree
+          const { stdout: wtListOut } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], { cwd: repoPath });
+          const allWorktrees = parseAllWorktrees(wtListOut, repoPath);
+          const existingWt = allWorktrees.find(wt => wt.branch === branchName);
+
+          if (existingWt) {
+            // Branch already checked out — redirect to the existing worktree
+            if (existingWt.isMain) {
+              // Main worktree → create a repo session
+              const existingRepoSession = sessions.findRepoSession(repoPath);
+              if (existingRepoSession) {
+                res.status(409).json({ error: 'A session already exists for this repo', sessionId: existingRepoSession.id });
+                return;
+              }
+
+              const repoSession = sessions.create({
+                type: 'repo',
+                repoName: name,
+                repoPath,
+                cwd: repoPath,
+                root,
+                displayName: name,
+                command: config.claudeCommand,
+                args: baseArgs,
+              });
+
+              res.status(201).json(repoSession);
+              return;
+            } else {
+              // Another worktree → create a worktree session with --continue
+              cwd = existingWt.path;
+              sessionRepoPath = existingWt.path;
+              worktreeName = existingWt.path.split('/').pop() || '';
+              args = ['--continue', ...baseArgs];
+
+              const displayNameVal = branchName || worktreeName;
+
+              const session = sessions.create({
+                type: 'worktree',
+                repoName: name,
+                repoPath: sessionRepoPath,
+                cwd,
+                root,
+                worktreeName,
+                branchName: branchName || worktreeName,
+                displayName: displayNameVal,
+                command: config.claudeCommand,
+                args,
+                configPath: CONFIG_PATH,
+              });
+
+              writeMeta(CONFIG_PATH, {
+                worktreePath: sessionRepoPath,
+                displayName: displayNameVal,
+                lastActivity: new Date().toISOString(),
+                branchName: branchName || worktreeName,
+              });
+
+              res.status(201).json(session);
+              return;
+            }
+          }
+
+          await execFileAsync('git', ['worktree', 'add', targetDir, resolvedBranch], { cwd: repoPath });
+        } else if (branchName) {
+```
+
+**Step 3: Run tests to verify nothing is broken**
+
+Run: `npm run build && node --test dist/test/worktrees.test.js`
+Expected: ALL PASS
+
+**Step 4: Commit**
+
+```bash
+git add server/index.ts
+git commit -m "feat: auto-redirect to existing worktree on branch conflict"
+```
+
+---
+
+### Task 3: Replace `isValidWorktreePath` with git-based validation in `DELETE /worktrees`
+
+**Files:**
+- Modify: `server/index.ts:527-589` (DELETE /worktrees handler)
+
+**Step 1: Replace the path validation**
+
+In `DELETE /worktrees`, replace the `isValidWorktreePath` check (lines 535-538) with a git-based validation:
+
+Replace:
+```typescript
+    if (!isValidWorktreePath(worktreePath)) {
+      res.status(400).json({ error: 'Path is not inside a worktree directory' });
+      return;
+    }
+```
+
+With:
+```typescript
+    // Validate the path is a real git worktree (not the main worktree)
+    try {
+      const { stdout: wtListOut } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], { cwd: repoPath });
+      const allWorktrees = parseAllWorktrees(wtListOut, repoPath);
+      const isKnownWorktree = allWorktrees.some(wt => wt.path === path.resolve(worktreePath) && !wt.isMain);
+      if (!isKnownWorktree) {
+        res.status(400).json({ error: 'Path is not a recognized git worktree' });
+        return;
+      }
+    } catch {
+      // If git worktree list fails, fall back to the directory-name check
+      if (!isValidWorktreePath(worktreePath)) {
+        res.status(400).json({ error: 'Path is not inside a worktree directory' });
+        return;
+      }
+    }
+```
+
+Note: The handler also needs to become `async` if it isn't already. Check the existing signature — it already is `async` (line 528).
+
+**Step 2: Run tests to verify nothing is broken**
+
+Run: `npm run build && node --test dist/test/worktrees.test.js`
+Expected: ALL PASS
+
+**Step 3: Commit**
+
+```bash
+git add server/index.ts
+git commit -m "feat: git-based worktree validation for delete (supports arbitrary paths)"
+```
+
+---
+
+### Task 4: Frontend tab auto-switch on redirect to repo session
+
+**Files:**
+- Modify: `frontend/src/components/dialogs/NewSessionDialog.svelte:151-196`
+
+When the user is on the "worktrees" tab and creates a session, but the backend returns a repo-type session (because the branch was already checked out in the main worktree), the frontend should switch to the "repos" tab so the new session is visible.
+
+**Step 1: Update handleSubmit to check session type and switch tab**
+
+In `NewSessionDialog.svelte`, the `handleSubmit()` function at line 180-184 currently does:
+
+```typescript
+      dialogEl.close();
+      await refreshAll();
+      if (session?.id) {
+        onSessionCreated?.(session.id);
+      }
+```
+
+Replace with:
+
+```typescript
+      dialogEl.close();
+      await refreshAll();
+      if (session?.id) {
+        // If backend redirected a worktree request to a repo session,
+        // switch to the repos tab so the user can see it
+        if (activeTab === 'worktrees' && session.type === 'repo') {
+          ui.activeTab = 'repos';
+        }
+        onSessionCreated?.(session.id);
+      }
+```
+
+This requires importing `ui` — check if it's already imported. Look at the script block imports.
+
+**Step 2: Verify the import**
+
+Check that `NewSessionDialog.svelte` already imports `ui` from the state module. If not, add:
+
+```typescript
+import { getUi } from '../lib/state/ui.svelte.js';
+const ui = getUi();
+```
+
+**Step 3: Build to verify**
+
+Run: `npm run build`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add frontend/src/components/dialogs/NewSessionDialog.svelte
+git commit -m "feat: auto-switch to repos tab when worktree redirects to repo session"
+```
+
+---
+
+### Task 5: Build and verify all tests pass
+
+**Files:**
+- None (verification only)
+
+**Step 1: Full build**
+
+Run: `npm run build`
+Expected: No errors
+
+**Step 2: Full test suite**
+
+Run: `npm test`
+Expected: ALL PASS (svelte-check + tsc + node --test)
+
+**Step 3: Verify no regressions**
+
+Check that the existing `isValidWorktreePath` tests still pass (they test internal function behavior, not the endpoint, so they remain valid).
+
+**Step 4: Final commit if needed**
+
+If any build/lint fixes were needed:
+```bash
+git add -A
+git commit -m "fix: address build issues from worktree handling changes"
+```
+
+---
+
+## Outcomes & Retrospective
+
+**What worked:**
+- Clean execution — 0 surprises, 0 drift across all 5 tasks
+- Parallel dispatch of independent tasks (Task 1 + Task 4) saved time
+- Sequential dispatch of Tasks 2 and 3 (both editing server/index.ts) avoided merge conflicts
+
+**What didn't:**
+- Nothing notable — straightforward implementation
+
+**Learnings to codify:**
+- `parseAllWorktrees` as a reusable helper pattern: include main worktree with `isMain` flag rather than duplicating parsing logic
+- Git-based validation (`git worktree list`) is more robust than path-pattern checks for worktree operations

--- a/frontend/src/components/dialogs/NewSessionDialog.svelte
+++ b/frontend/src/components/dialogs/NewSessionDialog.svelte
@@ -180,6 +180,11 @@
       dialogEl.close();
       await refreshAll();
       if (session?.id) {
+        // If backend redirected a worktree request to a repo session,
+        // switch to the repos tab so the user can see it
+        if (activeTab === 'worktrees' && session.type === 'repo') {
+          ui.activeTab = 'repos';
+        }
         onSessionCreated?.(session.id);
       }
     } catch (err: unknown) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -68,13 +68,16 @@ export async function createSession(body: {
   branchName?: string | undefined;
   claudeArgs?: string[] | undefined;
 }): Promise<SessionSummary> {
-  return json<SessionSummary>(
-    await fetch('/sessions', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    }),
-  );
+  const res = await fetch('/sessions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (res.status === 409) {
+    const data = await res.json() as { sessionId?: string };
+    throw new ConflictError(data.sessionId ?? '');
+  }
+  return json<SessionSummary>(res);
 }
 
 export async function createRepoSession(body: {


### PR DESCRIPTION
## Summary

- **Auto-redirect on branch conflict**: When creating a worktree for a branch already checked out elsewhere, automatically open a session at the existing location instead of failing with a git error
  - Main worktree → creates a repo session
  - Other worktree → creates a worktree session with `--continue`
- **Git-based delete validation**: `DELETE /worktrees` now validates via `git worktree list` instead of directory-name pattern matching, enabling management of worktrees at arbitrary paths
- **Frontend tab auto-switch**: When a worktree creation redirects to a repo session, the sidebar switches to the repos tab so the session is visible
- **409 handling fix**: `createSession` API now handles 409 conflict responses (matching `createRepoSession` behavior)

## Test plan

- [x] 83 unit tests pass (including 6 new `parseAllWorktrees` tests)
- [x] `npm run build` clean (0 errors)
- [ ] Manual: create worktree for branch already checked out in main worktree → should open repo session + switch to repos tab
- [ ] Manual: create worktree for branch checked out in another worktree → should open session at that path
- [ ] Manual: delete a worktree at an arbitrary path (outside `.worktrees/`) → should succeed
- [ ] Manual: attempt to delete the main worktree → should be rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)