### PR TITLE
fix: preserve sessions across server updates/restarts

### DIFF
--- a/docs/PLANS.md
+++ b/docs/PLANS.md
@@ -6,6 +6,7 @@ Execution plans for active and completed work.
 
 | Plan | Created | Topic |
 |------|---------|-------|
+| `session-persistence-fix` | 2026-03-17 | Fix sessions lost after auto-update restart |
 | `mobile-input-redesign` | 2026-02-25 | Event-intent architecture replacing value-diffing for mobile input |
 
 ## Tech Debt

--- a/docs/bug-analyses/2026-03-17-session-persistence-across-updates-bug-analysis.md
+++ b/docs/bug-analyses/2026-03-17-session-persistence-across-updates-bug-analysis.md
@@ -1,0 +1,96 @@
+# Bug Analysis: Sessions Lost After Auto-Update Restart
+
+> **Status**: Confirmed | **Date**: 2026-03-17
+> **Severity**: High
+> **Affected Area**: `server/sessions.ts`, `server/index.ts` (session lifecycle + update flow)
+
+## Symptoms
+
+- After clicking "Update Now" in the frontend, the server updates and restarts
+- All sessions (repos, worktrees, terminals) disappear from the UI
+- Sessions are not preserved across the restart despite `serializeAll`/`restoreFromDisk` implementation
+
+## Reproduction Steps
+
+1. Start the server as a background service (`claude-remote-cli --bg`)
+2. Open several sessions (repo, worktree, and/or terminal)
+3. When an update is available, click "Update Now" in the frontend toast
+4. Wait for the server to restart and the page to reload (5 seconds)
+5. Observe: all sessions are gone
+
+## Root Cause
+
+Three compounding failures in the session persistence mechanism:
+
+### Failure 1: Tmux orphan cleanup kills restored sessions (critical)
+
+In `restoreFromDisk` (sessions.ts:470), restored sessions are created with `useTmux: false`:
+
+```ts
+const createParams: CreateParams = {
+  // ...
+  useTmux: false, // Don't re-wrap in tmux — either attaching to existing or using plain agent
+};
+```
+
+This means restored sessions have `tmuxSessionName = ''` (sessions.ts:126), so they aren't included in `activeTmuxSessionNames()`.
+
+Immediately after restore, the orphan cleanup (index.ts:1060-1073) runs:
+
+```ts
+const adoptedNames = activeTmuxSessionNames(); // empty — restored sessions have no tmuxSessionName!
+const orphanedSessions = stdout.split('\n').filter(name => name.startsWith('crc-') && !adoptedNames.has(name));
+for (const name of orphanedSessions) {
+  execFileAsync('tmux', ['kill-session', '-t', name]).catch(() => {});
+}
+```
+
+This kills the tmux sessions that `restoreFromDisk` just attached PTYs to, causing those PTYs to exit, triggering `sessions.delete(id)` in the exit handler.
+
+### Failure 2: Restored PTY processes may exit immediately
+
+For non-tmux sessions, `restoreFromDisk` spawns `claude --continue` or `codex resume --last`. These commands may fail or exit quickly if:
+- The old agent process is still running (orphaned from `process.exit(0)` which doesn't call `gracefulShutdown`)
+- The agent can't find a session to continue
+- The working directory no longer exists
+
+When the PTY exits, the exit handler at sessions.ts:268 fires `sessions.delete(id)`, removing the session before the frontend reloads.
+
+### Failure 3: `gracefulShutdown` doesn't serialize (secondary)
+
+The `gracefulShutdown` handler (index.ts:1075-1083) kills all sessions without calling `serializeAll`. This means:
+- CLI `update` command (bin/claude-remote-cli.ts:76-102) — does `service.uninstall()` + `service.install()` which sends SIGTERM, triggering `gracefulShutdown` without serialization
+- Any service manager restart outside the HTTP update flow loses all sessions
+
+### Failure 4: No decoupling of session metadata from PTY lifecycle
+
+Sessions only exist in the `Map` while their PTY is alive. The moment a PTY exits (for any reason), the session is deleted. There's no concept of a "disconnected" or "pending reconnect" session that persists in the UI while waiting for its PTY to be re-established.
+
+## Evidence
+
+- **sessions.ts:126**: `tmuxSessionName` is `''` when `useTmux` is false
+- **sessions.ts:470**: `useTmux: false` hardcoded in restore
+- **sessions.ts:492-498**: `activeTmuxSessionNames()` only returns names from sessions with non-empty `tmuxSessionName`
+- **index.ts:1060-1073**: Orphan cleanup runs after restore, kills untracked tmux sessions
+- **sessions.ts:268**: PTY exit handler unconditionally deletes session from map
+- **index.ts:1075-1083**: `gracefulShutdown` kills sessions without serialization
+- **bin/claude-remote-cli.ts:87-96**: CLI update path reinstalls service (SIGTERM) without serializing
+
+## Impact Assessment
+
+- **All sessions lost on every update** — the primary feature of session persistence is completely broken
+- **Affects all session types**: repo, worktree, and terminal sessions
+- **Both update paths broken**: HTTP `/update` (tmux cleanup race) and CLI `update` (no serialization)
+- **User must manually recreate all sessions after every update**
+
+## Recommended Fix Direction
+
+A two-pronged approach:
+
+1. **Decouple session metadata from PTY lifecycle** — Persist session metadata (id, type, agent, paths, display name, scrollback) to disk independently. Sessions should appear in the UI as "reconnecting" even if their PTY hasn't spawned yet. The session list should be driven by persisted state, not just the in-memory Map of live PTYs.
+
+2. **Fix the restore mechanism**:
+   - Pass `tmuxSessionName` through to restored sessions so orphan cleanup doesn't kill them
+   - Add `serializeAll` to `gracefulShutdown` (before killing PTYs)
+   - Add serialization to the CLI update path
+   - Handle the case where restored PTYs exit immediately (keep session metadata, show as "disconnected")

--- a/docs/bug-analyses/index.md
+++ b/docs/bug-analyses/index.md
@@ -11,3 +11,4 @@
 | [osc52-clipboard-utf8-bug-analysis.md](2026-03-13-osc52-clipboard-utf8-bug-analysis.md) | OSC 52 clipboard handler uses atob() which mangles UTF-8 multi-byte characters to Latin-1 | 2026-03-13 |
 | [continue-retry-tmux-exit-code-bug-analysis.md](2026-03-14-continue-retry-tmux-exit-code-bug-analysis.md) | --continue retry never fires because tmux masks inner exit code to 0 | 2026-03-14 |
 | [mobile-scroll-escape-sequences-bug-analysis.md](2026-03-16-mobile-scroll-escape-sequences-bug-analysis.md) | Mobile scroll sends SGR escape sequences to shell when mouse tracking not enabled | 2026-03-16 |
+| [session-persistence-across-updates-bug-analysis.md](2026-03-17-session-persistence-across-updates-bug-analysis.md) | Sessions lost after auto-update: tmux orphan cleanup race, no graceful shutdown serialization, PTY-coupled lifecycle | 2026-03-17 |

--- a/docs/exec-plans/active/2026-03-17-session-persistence-fix.md
+++ b/docs/exec-plans/active/2026-03-17-session-persistence-fix.md
@@ -1,0 +1,484 @@
+# Session Persistence Fix Implementation Plan
+
+> **Status**: Active | **Created**: 2026-03-17 | **Last Updated**: 2026-03-17
+> **Bug Analysis**: `docs/bug-analyses/2026-03-17-session-persistence-across-updates-bug-analysis.md`
+> **For Claude:** Use /harness:orchestrate to execute this plan.
+
+## Decision Log
+
+| Date | Phase | Decision | Rationale |
+|------|-------|----------|-----------|
+| 2026-03-17 | Design | Fix existing serialize/restore instead of full session-metadata decoupling | The serialize/restore mechanism is 90% correct; fixing the 3 specific bugs is simpler and lower-risk than redesigning the session lifecycle |
+| 2026-03-17 | Design | Add `tmuxSessionName` pass-through on restore | Without it, orphan cleanup kills restored tmux sessions |
+| 2026-03-17 | Design | Add `serializeAll` to `gracefulShutdown` | Both update paths (HTTP and CLI) need serialization before shutdown |
+| 2026-03-17 | Design | Add a `restoring` flag to prevent PTY exit from deleting restored sessions immediately | Restored sessions whose PTYs exit quickly should remain in the session list as "disconnected" rather than vanishing |
+
+## Progress
+
+- [x] Task 1: Fix tmux session name propagation during restore
+- [x] Task 2: Add `serializeAll` to graceful shutdown
+- [x] Task 3: Protect restored sessions from immediate deletion on PTY exit
+- [x] Task 4: Integration: wire everything together and verify
+
+## Surprises & Discoveries
+
+_None yet — updated during execution by /harness:orchestrate._
+
+## Plan Drift
+
+_None yet — updated when tasks deviate from plan during execution._
+
+---
+
+### Task 1: Fix tmux session name propagation during restore
+
+**Goal:** Restored tmux sessions must have their `tmuxSessionName` set so orphan cleanup doesn't kill them.
+
+**Files:**
+- Modify: `server/sessions.ts` (restoreFromDisk and create functions)
+- Modify: `test/sessions.test.ts`
+
+- [ ] **Step 1: Write failing test — restored tmux sessions preserve tmuxSessionName**
+
+Add to the `session persistence` describe block in `test/sessions.test.ts`:
+
+```ts
+it('restoreFromDisk preserves tmuxSessionName for tmux sessions', async () => {
+  const configDir = createTmpDir();
+
+  // Write a pending file with a tmux session
+  const pending = {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    sessions: [{
+      id: 'tmux-test-id',
+      type: 'worktree' as const,
+      agent: 'claude' as const,
+      root: '',
+      repoName: 'test-repo',
+      repoPath: '/tmp',
+      worktreeName: 'my-wt',
+      branchName: 'my-branch',
+      displayName: 'my-session',
+      createdAt: new Date().toISOString(),
+      lastActivity: new Date().toISOString(),
+      useTmux: true,
+      tmuxSessionName: 'crc-my-session-tmux-tes',
+      customCommand: null,
+      cwd: '/tmp',
+    }],
+  };
+  fs.writeFileSync(path.join(configDir, 'pending-sessions.json'), JSON.stringify(pending));
+
+  const restored = await restoreFromDisk(configDir);
+  assert.strictEqual(restored, 1);
+
+  const session = sessions.get('tmux-test-id');
+  assert.ok(session, 'restored session should exist');
+  assert.strictEqual(session.tmuxSessionName, 'crc-my-session-tmux-tes', 'tmuxSessionName should be preserved from serialized data');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test dist/test/sessions.test.js`
+Expected: FAIL — restored session has `tmuxSessionName === ''` because `useTmux: false` in restore.
+
+- [ ] **Step 3: Implement fix — pass tmuxSessionName through CreateParams during restore**
+
+In `server/sessions.ts`, modify `CreateParams` to accept an optional `tmuxSessionName`:
+
+```ts
+type CreateParams = {
+  // ... existing fields ...
+  tmuxSessionName?: string;
+};
+```
+
+In the `create` function (line ~126), change tmuxSessionName assignment to prefer the provided value:
+
+```ts
+const tmuxSessionName = paramTmuxSessionName || (useTmux ? generateTmuxSessionName(displayName || repoName || 'session', id) : '');
+```
+
+Where `paramTmuxSessionName` is destructured from the params (rename the param to avoid conflict with the local variable).
+
+In `restoreFromDisk`, pass the serialized `tmuxSessionName` through:
+
+```ts
+const createParams: CreateParams = {
+  id: s.id,
+  type: s.type,
+  agent: s.agent,
+  repoName: s.repoName,
+  repoPath: s.repoPath,
+  cwd: s.cwd,
+  root: s.root,
+  worktreeName: s.worktreeName,
+  branchName: s.branchName,
+  displayName: s.displayName,
+  args,
+  useTmux: false,
+  tmuxSessionName: s.tmuxSessionName, // preserve the original tmux name
+};
+```
+
+- [ ] **Step 4: Run tests to verify it passes**
+
+Run: `npm run build && node --test dist/test/sessions.test.js`
+Expected: All tests PASS, including the new one.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/sessions.ts test/sessions.test.ts
+git commit -m "fix: preserve tmuxSessionName during session restore"
+```
+
+---
+
+### Task 2: Add `serializeAll` to graceful shutdown
+
+**Goal:** Sessions are serialized to disk before the process exits, regardless of how the exit is triggered (SIGTERM, SIGINT, or update handler). This also fixes the CLI `update` command path (`bin/claude-remote-cli.ts:87-96`) which does `service.uninstall()` + `service.install()`, sending SIGTERM to the running process — once `gracefulShutdown` calls `serializeAll`, the CLI path is covered automatically.
+
+**Files:**
+- Modify: `server/index.ts` (gracefulShutdown function)
+- Note: `bin/claude-remote-cli.ts` — CLI update triggers SIGTERM → fixed indirectly via this task
+- Modify: `test/sessions.test.ts`
+
+- [ ] **Step 1: Write component test — serializeAll captures state before kill**
+
+This test validates the component behavior needed by the gracefulShutdown integration (serialize → kill sequence). The integration itself is in index.ts and verified via Task 4.
+
+```ts
+it('serializeAll captures session state before kill', () => {
+  const configDir = createTmpDir();
+
+  const s = sessions.create({
+    repoName: 'test-repo',
+    repoPath: '/tmp',
+    command: '/bin/cat',
+    args: [],
+    displayName: 'before-kill',
+  });
+
+  const session = sessions.get(s.id);
+  assert.ok(session);
+  session.scrollback.push('important output');
+
+  serializeAll(configDir);
+
+  // Kill after serialize (mimics gracefulShutdown sequence)
+  sessions.kill(s.id);
+
+  // Verify data is on disk
+  const pendingPath = path.join(configDir, 'pending-sessions.json');
+  assert.ok(fs.existsSync(pendingPath));
+  const pending = JSON.parse(fs.readFileSync(pendingPath, 'utf-8'));
+  assert.strictEqual(pending.sessions.length, 1);
+  assert.strictEqual(pending.sessions[0].displayName, 'before-kill');
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npm run build && node --test dist/test/sessions.test.js`
+Expected: PASS — serializeAll is synchronous and captures state before kill.
+
+- [ ] **Step 3: Implement — add serializeAll to gracefulShutdown**
+
+In `server/index.ts`, modify the `gracefulShutdown` function:
+
+```ts
+function gracefulShutdown() {
+  server.close();
+  // Serialize sessions to disk BEFORE killing them
+  const configDir = path.dirname(CONFIG_PATH);
+  serializeAll(configDir);
+  // Kill all active sessions (PTY + tmux)
+  for (const s of sessions.list()) {
+    try { sessions.kill(s.id); } catch { /* already exiting */ }
+  }
+  // Brief delay to let async tmux kill-session calls fire
+  setTimeout(() => process.exit(0), 200);
+}
+```
+
+- [ ] **Step 4: Build to verify no type errors**
+
+Run: `npm run build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/index.ts test/sessions.test.ts
+git commit -m "fix: serialize sessions before graceful shutdown"
+```
+
+---
+
+### Task 3: Protect restored sessions from immediate deletion on PTY exit
+
+**Goal:** When a restored session's PTY exits quickly (e.g., `claude --continue` fails), the session should remain in the registry with a "disconnected" state rather than being deleted. The frontend already shows sessions from the list; keeping them there ensures they remain visible.
+
+**Files:**
+- Modify: `server/types.ts` (add `status` field to Session)
+- Modify: `server/sessions.ts` (exit handler, list, create)
+- Modify: `test/sessions.test.ts`
+- Modify: `frontend/src/lib/types.ts` (add `status` field to SessionSummary)
+
+- [ ] **Step 1: Write failing test — restored session stays in list after PTY exit**
+
+```ts
+it('restored session remains in list after PTY exits (disconnected state)', async () => {
+  const configDir = createTmpDir();
+
+  // Serialize a session with /bin/false as the command (exits immediately)
+  const pending = {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    sessions: [{
+      id: 'restore-exit-test',
+      type: 'worktree' as const,
+      agent: 'claude' as const,
+      root: '',
+      repoName: 'test-repo',
+      repoPath: '/tmp',
+      worktreeName: 'my-wt',
+      branchName: 'my-branch',
+      displayName: 'restored-session',
+      createdAt: new Date().toISOString(),
+      lastActivity: new Date().toISOString(),
+      useTmux: false,
+      tmuxSessionName: '',
+      customCommand: '/bin/false',
+      cwd: '/tmp',
+    }],
+  };
+  fs.writeFileSync(path.join(configDir, 'pending-sessions.json'), JSON.stringify(pending));
+
+  await restoreFromDisk(configDir);
+
+  // Wait for PTY to exit
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  // Session should still be in the list
+  const list = sessions.list();
+  const found = list.find(s => s.id === 'restore-exit-test');
+  assert.ok(found, 'restored session should remain in list after PTY exit');
+  assert.strictEqual(found.status, 'disconnected');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run build && node --test dist/test/sessions.test.js`
+Expected: FAIL — session is deleted from map when PTY exits.
+
+- [ ] **Step 3: Add `status` field to Session type**
+
+In `server/types.ts`, add to Session interface:
+
+```ts
+export type SessionStatus = 'active' | 'disconnected';
+
+export interface Session {
+  // ... existing fields ...
+  status: SessionStatus;
+}
+```
+
+- [ ] **Step 4: Add `status` field to session creation and list output**
+
+In `server/sessions.ts`:
+
+1. In `create()`, add `status: 'active'` to the session object (line ~148).
+2. In `list()`, include `status` in the mapped output.
+3. In `CreateResult` type, add `status` field.
+4. In `SessionSummary` type (line ~13), add `status`.
+
+- [ ] **Step 5: Mark restored sessions and protect them in exit handler**
+
+In `server/sessions.ts`:
+
+1. Add a `restored` field to Session (internal only, not serialized). Also add `restored` to the `Omit<>` exclusion in `SessionSummary` so it doesn't leak into the API:
+   ```ts
+   type SessionSummary = Omit<Session, 'pty' | 'scrollback' | 'onPtyReplacedCallbacks' | 'restored'>;
+   ```
+
+2. In `create()`, set `restored: false` by default. Add `restored` to `CreateParams`.
+
+3. In `restoreFromDisk`, pass `restored: true` when calling create.
+
+4. In the PTY exit handler (the `proc.onExit` callback), check if the session is restored:
+   ```ts
+   proc.onExit(() => {
+     // ... existing retry logic ...
+
+     if (session.restored) {
+       // Don't delete — mark as disconnected
+       session.status = 'disconnected';
+       session.restored = false; // clear so user-initiated kills can delete normally
+       if (idleTimer) clearTimeout(idleTimer);
+       if (metaFlushTimer) clearTimeout(metaFlushTimer);
+       return;
+     }
+
+     // ... existing delete logic ...
+   });
+   ```
+
+5. Clear `restored` after PTY has been running for >3 seconds (same heuristic as continue-retry). In `attachHandlers`, after the `spawnTime` declaration:
+   ```ts
+   const restoredClearTimer = session.restored ? setTimeout(() => { session.restored = false; }, 3000) : null;
+   ```
+   Clear this timer in the exit handler if it fires before 3s.
+
+**Known limitation:** Disconnected sessions cannot currently be removed from the UI until the server restarts. This is acceptable for the initial fix; a follow-up can add a DELETE endpoint for disconnected sessions.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm run build && node --test dist/test/sessions.test.js`
+Expected: All tests PASS.
+
+- [ ] **Step 7: Update frontend SessionSummary type**
+
+In `frontend/src/lib/types.ts`, add:
+
+```ts
+export interface SessionSummary {
+  // ... existing fields ...
+  status?: 'active' | 'disconnected';
+}
+```
+
+- [ ] **Step 8: Build to verify no type errors (server + frontend)**
+
+Run: `npm run build`
+Expected: PASS — both tsc and svelte-check pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add server/types.ts server/sessions.ts test/sessions.test.ts frontend/src/lib/types.ts
+git commit -m "fix: keep restored sessions in list as 'disconnected' after PTY exit"
+```
+
+---
+
+### Task 4: Integration — wire everything together and verify
+
+**Goal:** Validate the full serialize → shutdown → restart → restore flow works correctly end-to-end.
+
+**Files:**
+- Modify: `test/sessions.test.ts`
+
+- [ ] **Step 1: Write integration test — full serialize-restore round trip preserves tmux names and session status**
+
+```ts
+it('full serialize-restore round trip preserves all session fields including tmuxSessionName', async () => {
+  const configDir = createTmpDir();
+
+  // Create sessions of different types
+  const repo = sessions.create({
+    type: 'repo',
+    repoName: 'my-repo',
+    repoPath: '/tmp/repo',
+    command: '/bin/cat',
+    args: [],
+    displayName: 'My Repo',
+  });
+
+  const terminal = sessions.create({
+    type: 'terminal',
+    repoPath: '/tmp',
+    command: '/bin/sh',
+    args: [],
+    displayName: 'Terminal 1',
+  });
+
+  // Serialize all
+  serializeAll(configDir);
+
+  // Kill originals
+  sessions.kill(repo.id);
+  sessions.kill(terminal.id);
+  assert.strictEqual(sessions.list().length, 0);
+
+  // Also inject a tmux-style session into the pending file to test tmuxSessionName round-trip
+  const pendingPath = path.join(configDir, 'pending-sessions.json');
+  const pending = JSON.parse(fs.readFileSync(pendingPath, 'utf-8'));
+  pending.sessions.push({
+    id: 'tmux-roundtrip-id',
+    type: 'worktree',
+    agent: 'claude',
+    root: '',
+    repoName: 'tmux-repo',
+    repoPath: '/tmp/tmux',
+    worktreeName: 'tmux-wt',
+    branchName: 'feat/tmux',
+    displayName: 'Tmux Session',
+    createdAt: new Date().toISOString(),
+    lastActivity: new Date().toISOString(),
+    useTmux: true,
+    tmuxSessionName: 'crc-tmux-session-tmux-rou',
+    customCommand: null,
+    cwd: '/tmp/tmux',
+  });
+  fs.writeFileSync(pendingPath, JSON.stringify(pending));
+
+  // Restore
+  const restored = await restoreFromDisk(configDir);
+  assert.strictEqual(restored, 3);
+
+  // Verify all sessions exist
+  const list = sessions.list();
+  assert.strictEqual(list.length, 3);
+
+  const restoredRepo = list.find(s => s.id === repo.id);
+  assert.ok(restoredRepo);
+  assert.strictEqual(restoredRepo.type, 'repo');
+  assert.strictEqual(restoredRepo.displayName, 'My Repo');
+
+  const restoredTerminal = list.find(s => s.id === terminal.id);
+  assert.ok(restoredTerminal);
+  assert.strictEqual(restoredTerminal.type, 'terminal');
+  assert.strictEqual(restoredTerminal.displayName, 'Terminal 1');
+
+  // Verify tmux session name survived the round trip
+  const restoredTmux = sessions.get('tmux-roundtrip-id');
+  assert.ok(restoredTmux);
+  assert.strictEqual(restoredTmux.tmuxSessionName, 'crc-tmux-session-tmux-rou');
+  assert.strictEqual(restoredTmux.displayName, 'Tmux Session');
+});
+```
+
+- [ ] **Step 2: Run all tests**
+
+Run: `npm test`
+Expected: All tests PASS (including svelte-check).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/sessions.test.ts
+git commit -m "test: add integration test for full session persistence round trip"
+```
+
+---
+
+## Outcomes & Retrospective
+
+**What worked:**
+- Targeted fixes to 3 specific bugs rather than redesigning session lifecycle
+- TDD approach — each fix verified with focused tests
+- Parallel execution of Tasks 1 and 2 (independent changes)
+
+**What didn't:**
+- Task 3 agent left type errors that needed manual cleanup
+- Integration test initially failed because it created a tmux session without a surviving tmux process, causing the restored PTY to exit immediately → disconnected state
+
+**Learnings to codify:**
+- Restored sessions need `restored` flag cleared after healthy PTY runs for >3s (same heuristic as continue-retry)
+- Disconnected sessions can pile up — future work needed for cleanup UI

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -14,6 +14,7 @@ export interface SessionSummary {
   lastActivity: string;
   idle: boolean;
   useTmux?: boolean;
+  status?: 'active' | 'disconnected';
 }
 
 export interface WorktreeInfo {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1074,6 +1074,9 @@ async function main(): Promise<void> {
 
   function gracefulShutdown() {
     server.close();
+    // Serialize sessions to disk BEFORE killing them
+    const configDir = path.dirname(CONFIG_PATH);
+    serializeAll(configDir);
     // Kill all active sessions (PTY + tmux)
     for (const s of sessions.list()) {
       try { sessions.kill(s.id); } catch { /* already exiting */ }

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -5,12 +5,12 @@ import os from 'node:os';
 import path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import type { AgentType, Session, SessionType } from './types.js';
+import type { AgentType, Session, SessionStatus, SessionType } from './types.js';
 import { readMeta, writeMeta } from './config.js';
 
 const execFileAsync = promisify(execFile);
 
-type SessionSummary = Omit<Session, 'pty' | 'scrollback' | 'onPtyReplacedCallbacks'>;
+type SessionSummary = Omit<Session, 'pty' | 'scrollback' | 'onPtyReplacedCallbacks' | 'restored'>;
 
 const AGENT_COMMANDS: Record<AgentType, string> = {
   claude: 'claude',
@@ -74,6 +74,8 @@ type CreateParams = {
   tmuxSessionName?: string;
   /** Pre-loaded scrollback for restored sessions */
   initialScrollback?: string[];
+  /** Mark this session as a restored session (PTY exit won't delete it) */
+  restored?: boolean;
 };
 
 type CreateResult = SessionSummary & { pid: number | undefined };
@@ -113,7 +115,7 @@ function onIdleChange(cb: IdleChangeCallback): void {
   idleChangeCallbacks.push(cb);
 }
 
-function create({ id: providedId, type, agent = 'claude', repoName, repoPath, cwd, root, worktreeName, branchName, displayName, command, args = [], cols = 80, rows = 24, configPath, useTmux: paramUseTmux, tmuxSessionName: paramTmuxSessionName, initialScrollback }: CreateParams): CreateResult {
+function create({ id: providedId, type, agent = 'claude', repoName, repoPath, cwd, root, worktreeName, branchName, displayName, command, args = [], cols = 80, rows = 24, configPath, useTmux: paramUseTmux, tmuxSessionName: paramTmuxSessionName, initialScrollback, restored: paramRestored }: CreateParams): CreateResult {
   const id = providedId || crypto.randomBytes(8).toString('hex');
   const createdAt = new Date().toISOString();
   const resolvedCommand = command || AGENT_COMMANDS[agent];
@@ -167,6 +169,8 @@ function create({ id: providedId, type, agent = 'claude', repoName, repoPath, cw
     useTmux,
     tmuxSessionName,
     onPtyReplacedCallbacks: [],
+    status: 'active' as SessionStatus,
+    restored: paramRestored || false,
   };
   sessions.set(id, session);
 
@@ -200,6 +204,8 @@ function create({ id: providedId, type, agent = 'claude', repoName, repoPath, cw
 
   function attachHandlers(proc: pty.IPty, canRetry: boolean): void {
     const spawnTime = Date.now();
+    // Clear restored flag after 3s of running — means the PTY is healthy
+    const restoredClearTimer = session.restored ? setTimeout(() => { session.restored = false; }, 3000) : null;
 
     proc.onData((data) => {
       session.lastActivity = new Date().toISOString();
@@ -251,6 +257,7 @@ function create({ id: providedId, type, agent = 'claude', repoName, repoPath, cw
           });
         } catch {
           // Retry spawn failed — fall through to normal exit cleanup
+          if (restoredClearTimer) clearTimeout(restoredClearTimer);
           if (idleTimer) clearTimeout(idleTimer);
           if (metaFlushTimer) clearTimeout(metaFlushTimer);
           sessions.delete(id);
@@ -259,6 +266,17 @@ function create({ id: providedId, type, agent = 'claude', repoName, repoPath, cw
         session.pty = retryPty;
         for (const cb of session.onPtyReplacedCallbacks) cb(retryPty);
         attachHandlers(retryPty, false);
+        return;
+      }
+
+      if (restoredClearTimer) clearTimeout(restoredClearTimer);
+
+      // If PTY exited and this is a restored session, mark disconnected rather than delete
+      if (session.restored) {
+        session.status = 'disconnected';
+        session.restored = false; // clear so user-initiated kills can delete normally
+        if (idleTimer) clearTimeout(idleTimer);
+        if (metaFlushTimer) clearTimeout(metaFlushTimer);
         return;
       }
 
@@ -275,7 +293,7 @@ function create({ id: providedId, type, agent = 'claude', repoName, repoPath, cw
 
   attachHandlers(ptyProcess, continueArgs.some(a => args.includes(a)));
 
-  return { id, type: session.type, agent: session.agent, root: session.root, repoName: session.repoName, repoPath, worktreeName: session.worktreeName, branchName: session.branchName, displayName: session.displayName, pid: ptyProcess.pid, createdAt, lastActivity: createdAt, idle: false, cwd: resolvedCwd, customCommand: command || null, useTmux, tmuxSessionName };
+  return { id, type: session.type, agent: session.agent, root: session.root, repoName: session.repoName, repoPath, worktreeName: session.worktreeName, branchName: session.branchName, displayName: session.displayName, pid: ptyProcess.pid, createdAt, lastActivity: createdAt, idle: false, cwd: resolvedCwd, customCommand: command || null, useTmux, tmuxSessionName, status: 'active' as SessionStatus };
 }
 
 function get(id: string): Session | undefined {
@@ -284,7 +302,7 @@ function get(id: string): Session | undefined {
 
 function list(): SessionSummary[] {
   return Array.from(sessions.values())
-    .map(({ id, type, agent, root, repoName, repoPath, worktreeName, branchName, displayName, createdAt, lastActivity, idle, cwd, customCommand, useTmux, tmuxSessionName }) => ({
+    .map(({ id, type, agent, root, repoName, repoPath, worktreeName, branchName, displayName, createdAt, lastActivity, idle, cwd, customCommand, useTmux, tmuxSessionName, status }) => ({
       id,
       type,
       agent,
@@ -301,6 +319,7 @@ function list(): SessionSummary[] {
       customCommand,
       useTmux,
       tmuxSessionName,
+      status,
     }))
     .sort((a, b) => b.lastActivity.localeCompare(a.lastActivity));
 }
@@ -317,7 +336,11 @@ function kill(id: string): void {
   if (!session) {
     throw new Error(`Session not found: ${id}`);
   }
-  session.pty.kill('SIGTERM');
+  try {
+    session.pty.kill('SIGTERM');
+  } catch {
+    // PTY may already be dead (e.g. disconnected sessions) — still delete from registry
+  }
   if (session.tmuxSessionName) {
     execFile('tmux', ['kill-session', '-t', session.tmuxSessionName], () => {});
   }
@@ -471,6 +494,7 @@ async function restoreFromDisk(configDir: string): Promise<number> {
         args,
         useTmux: false, // Don't re-wrap in tmux — either attaching to existing or using plain agent
         tmuxSessionName: s.tmuxSessionName,
+        restored: true,
       };
       if (command) createParams.command = command;
       if (initialScrollback) createParams.initialScrollback = initialScrollback;

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -70,6 +70,8 @@ type CreateParams = {
   rows?: number;
   configPath?: string;
   useTmux?: boolean;
+  /** Override for the tmux session name (used when restoring serialized sessions) */
+  tmuxSessionName?: string;
   /** Pre-loaded scrollback for restored sessions */
   initialScrollback?: string[];
 };
@@ -111,7 +113,7 @@ function onIdleChange(cb: IdleChangeCallback): void {
   idleChangeCallbacks.push(cb);
 }
 
-function create({ id: providedId, type, agent = 'claude', repoName, repoPath, cwd, root, worktreeName, branchName, displayName, command, args = [], cols = 80, rows = 24, configPath, useTmux: paramUseTmux, initialScrollback }: CreateParams): CreateResult {
+function create({ id: providedId, type, agent = 'claude', repoName, repoPath, cwd, root, worktreeName, branchName, displayName, command, args = [], cols = 80, rows = 24, configPath, useTmux: paramUseTmux, tmuxSessionName: paramTmuxSessionName, initialScrollback }: CreateParams): CreateResult {
   const id = providedId || crypto.randomBytes(8).toString('hex');
   const createdAt = new Date().toISOString();
   const resolvedCommand = command || AGENT_COMMANDS[agent];
@@ -123,7 +125,7 @@ function create({ id: providedId, type, agent = 'claude', repoName, repoPath, cw
   const useTmux = !command && !!paramUseTmux;
   let spawnCommand = resolvedCommand;
   let spawnArgs = args;
-  const tmuxSessionName = useTmux ? generateTmuxSessionName(displayName || repoName || 'session', id) : '';
+  const tmuxSessionName = paramTmuxSessionName || (useTmux ? generateTmuxSessionName(displayName || repoName || 'session', id) : '');
 
   if (useTmux) {
     const tmux = resolveTmuxSpawn(resolvedCommand, args, tmuxSessionName);
@@ -468,6 +470,7 @@ async function restoreFromDisk(configDir: string): Promise<number> {
         displayName: s.displayName,
         args,
         useTmux: false, // Don't re-wrap in tmux — either attaching to existing or using plain agent
+        tmuxSessionName: s.tmuxSessionName,
       };
       if (command) createParams.command = command;
       if (initialScrollback) createParams.initialScrollback = initialScrollback;

--- a/server/types.ts
+++ b/server/types.ts
@@ -2,6 +2,7 @@ import type { IPty } from 'node-pty';
 
 export type SessionType = 'repo' | 'worktree' | 'terminal';
 export type AgentType = 'claude' | 'codex';
+export type SessionStatus = 'active' | 'disconnected';
 
 export interface Session {
   id: string;
@@ -23,6 +24,8 @@ export interface Session {
   customCommand: string | null;
   tmuxSessionName: string;
   onPtyReplacedCallbacks: Array<(newPty: IPty) => void>;
+  status: SessionStatus;
+  restored: boolean;
 }
 
 export interface WorktreeMetadata {

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -741,6 +741,84 @@ describe('session persistence', () => {
     assert.strictEqual(found.status, 'disconnected');
   });
 
+  it('full serialize-restore round trip preserves all session fields including tmuxSessionName', async () => {
+    const configDir = createTmpDir();
+
+    // Create sessions of different types
+    const repo = sessions.create({
+      type: 'repo',
+      repoName: 'my-repo',
+      repoPath: '/tmp/repo',
+      command: '/bin/cat',
+      args: [],
+      displayName: 'My Repo',
+    });
+
+    const terminal = sessions.create({
+      type: 'terminal',
+      repoPath: '/tmp',
+      command: '/bin/sh',
+      args: [],
+      displayName: 'Terminal 1',
+    });
+
+    // Serialize all
+    serializeAll(configDir);
+
+    // Kill originals
+    sessions.kill(repo.id);
+    sessions.kill(terminal.id);
+    assert.strictEqual(sessions.list().length, 0);
+
+    // Also inject a tmux-style session into the pending file to test tmuxSessionName round-trip.
+    // Use customCommand so restore spawns that instead of claude --continue (which would exit instantly).
+    const pendingPath = path.join(configDir, 'pending-sessions.json');
+    const pending = JSON.parse(fs.readFileSync(pendingPath, 'utf-8'));
+    pending.sessions.push({
+      id: 'tmux-roundtrip-id',
+      type: 'worktree',
+      agent: 'claude',
+      root: '',
+      repoName: 'tmux-repo',
+      repoPath: '/tmp',
+      worktreeName: 'tmux-wt',
+      branchName: 'feat/tmux',
+      displayName: 'Tmux Session',
+      createdAt: new Date().toISOString(),
+      lastActivity: new Date().toISOString(),
+      useTmux: true,
+      tmuxSessionName: 'crc-tmux-session-tmux-rou',
+      customCommand: '/bin/cat',
+      cwd: '/tmp',
+    });
+    fs.writeFileSync(pendingPath, JSON.stringify(pending));
+
+    // Restore
+    const restored = await restoreFromDisk(configDir);
+    assert.strictEqual(restored, 3);
+
+    // Verify all sessions exist
+    const list = sessions.list();
+    assert.strictEqual(list.length, 3);
+
+    const restoredRepo = list.find(s => s.id === repo.id);
+    assert.ok(restoredRepo);
+    assert.strictEqual(restoredRepo.type, 'repo');
+    assert.strictEqual(restoredRepo.displayName, 'My Repo');
+    assert.strictEqual(restoredRepo.status, 'active');
+
+    const restoredTerminal = list.find(s => s.id === terminal.id);
+    assert.ok(restoredTerminal);
+    assert.strictEqual(restoredTerminal.type, 'terminal');
+    assert.strictEqual(restoredTerminal.displayName, 'Terminal 1');
+
+    // Verify tmux session name survived the round trip
+    const restoredTmux = sessions.get('tmux-roundtrip-id');
+    assert.ok(restoredTmux);
+    assert.strictEqual(restoredTmux.tmuxSessionName, 'crc-tmux-session-tmux-rou');
+    assert.strictEqual(restoredTmux.displayName, 'Tmux Session');
+  });
+
   it('serializeAll captures session state before kill', () => {
     const configDir = createTmpDir();
 

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -667,4 +667,67 @@ describe('session persistence', () => {
     const restored = await restoreFromDisk(configDir);
     assert.strictEqual(restored, 0);
   });
+
+  it('restoreFromDisk preserves tmuxSessionName for tmux sessions', async () => {
+    const configDir = createTmpDir();
+
+    // Write a pending file with a tmux session
+    const pending = {
+      version: 1,
+      timestamp: new Date().toISOString(),
+      sessions: [{
+        id: 'tmux-test-id',
+        type: 'worktree' as const,
+        agent: 'claude' as const,
+        root: '',
+        repoName: 'test-repo',
+        repoPath: '/tmp',
+        worktreeName: 'my-wt',
+        branchName: 'my-branch',
+        displayName: 'my-session',
+        createdAt: new Date().toISOString(),
+        lastActivity: new Date().toISOString(),
+        useTmux: true,
+        tmuxSessionName: 'crc-my-session-tmux-tes',
+        customCommand: null,
+        cwd: '/tmp',
+      }],
+    };
+    fs.writeFileSync(path.join(configDir, 'pending-sessions.json'), JSON.stringify(pending));
+
+    const restored = await restoreFromDisk(configDir);
+    assert.strictEqual(restored, 1);
+
+    const session = sessions.get('tmux-test-id');
+    assert.ok(session, 'restored session should exist');
+    assert.strictEqual(session.tmuxSessionName, 'crc-my-session-tmux-tes', 'tmuxSessionName should be preserved from serialized data');
+  });
+
+  it('serializeAll captures session state before kill', () => {
+    const configDir = createTmpDir();
+
+    const s = sessions.create({
+      repoName: 'test-repo',
+      repoPath: '/tmp',
+      command: '/bin/cat',
+      args: [],
+      displayName: 'before-kill',
+    });
+
+    const session = sessions.get(s.id);
+    assert.ok(session);
+    session.scrollback.push('important output');
+
+    serializeAll(configDir);
+
+    // Kill after serialize (mimics gracefulShutdown sequence)
+    sessions.kill(s.id);
+
+    // Verify data is on disk
+    const pendingPath = path.join(configDir, 'pending-sessions.json');
+    assert.ok(fs.existsSync(pendingPath));
+    const pending = JSON.parse(fs.readFileSync(pendingPath, 'utf-8'));
+    assert.strictEqual(pending.sessions.length, 1);
+    assert.strictEqual(pending.sessions[0].displayName, 'before-kill');
+  });
 });

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -703,6 +703,44 @@ describe('session persistence', () => {
     assert.strictEqual(session.tmuxSessionName, 'crc-my-session-tmux-tes', 'tmuxSessionName should be preserved from serialized data');
   });
 
+  it('restored session remains in list after PTY exits (disconnected status)', async () => {
+    const configDir = createTmpDir();
+
+    const pending = {
+      version: 1,
+      timestamp: new Date().toISOString(),
+      sessions: [{
+        id: 'restore-exit-test',
+        type: 'worktree' as const,
+        agent: 'claude' as const,
+        root: '',
+        repoName: 'test-repo',
+        repoPath: '/tmp',
+        worktreeName: 'my-wt',
+        branchName: 'my-branch',
+        displayName: 'restored-session',
+        createdAt: new Date().toISOString(),
+        lastActivity: new Date().toISOString(),
+        useTmux: false,
+        tmuxSessionName: '',
+        customCommand: '/bin/false',
+        cwd: '/tmp',
+      }],
+    };
+    fs.writeFileSync(path.join(configDir, 'pending-sessions.json'), JSON.stringify(pending));
+
+    await restoreFromDisk(configDir);
+
+    // Wait for PTY to exit
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    // Session should still be in the list with disconnected status
+    const list = sessions.list();
+    const found = list.find(s => s.id === 'restore-exit-test');
+    assert.ok(found, 'restored session should remain in list after PTY exit');
+    assert.strictEqual(found.status, 'disconnected');
+  });
+
   it('serializeAll captures session state before kill', () => {
     const configDir = createTmpDir();
 


### PR DESCRIPTION
## Summary

- Fix tmux orphan cleanup killing restored sessions by preserving `tmuxSessionName` through the serialize/restore cycle
- Add `serializeAll` to `gracefulShutdown` so sessions are persisted before SIGTERM/SIGINT shutdown (covers both HTTP update and CLI update paths)
- Keep restored sessions in the session list as "disconnected" when their PTY exits quickly, instead of silently deleting them

## Bug Analysis

Sessions were lost after every auto-update due to 3 compounding failures:
1. **Tmux orphan cleanup race** — restored sessions had `tmuxSessionName: ''`, so orphan cleanup killed the tmux sessions restore just attached to
2. **No graceful shutdown serialization** — `gracefulShutdown` killed sessions without saving them to disk first
3. **PTY-coupled lifecycle** — restored PTYs that exited quickly (e.g., `claude --continue` fails) caused immediate session deletion

See `docs/bug-analyses/2026-03-17-session-persistence-across-updates-bug-analysis.md` for full analysis.

## Test plan

- [x] New test: restored tmux sessions preserve `tmuxSessionName`
- [x] New test: `serializeAll` captures state before kill (graceful shutdown sequence)
- [x] New test: restored sessions remain in list as "disconnected" after PTY exit
- [x] New test: full serialize-restore round trip preserves all fields including tmux names
- [x] All existing session tests pass
- [x] Build passes (tsc + svelte-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)