### PR TITLE
fix: add active session indicator in sidenav

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -223,6 +223,11 @@
           navigateToSession(sessionParam, 'repo');
         }
 
+        // Auto-select if exactly one session exists and none is selected
+        if (!sessionState.activeSessionId && !sessionParam && sessionState.sessions.length === 1) {
+          handleSelectSession(sessionState.sessions[0]!.id);
+        }
+
         for (const s of sessionState.sessions) {
           initSessionNotification(s.id, configState.defaultNotifications);
         }

--- a/frontend/src/components/WorkspaceItem.svelte
+++ b/frontend/src/components/WorkspaceItem.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import type { Workspace, SessionSummary, WorktreeInfo } from '../lib/types.js';
-  import { getSessionStatus, refreshAll } from '../lib/state/sessions.svelte.js';
+  import { getSessionState, getSessionStatus, refreshAll } from '../lib/state/sessions.svelte.js';
   import { createSession } from '../lib/api.js';
   import ContextMenu from './ContextMenu.svelte';
   import type { MenuItem } from './ContextMenu.svelte';
+
+  const sessionState = getSessionState();
 
   let {
     workspace,
@@ -180,6 +182,7 @@
         <li
           class="session-row"
           class:terminal={session.type === 'terminal'}
+          class:selected={sessionState.activeSessionId === session.id}
           class:attention={getSessionStatus(session) === 'attention'}
           onclick={() => onSelectSession(session.id)}
         >
@@ -337,7 +340,17 @@
     transition: background 0.1s;
   }
 
+  .session-row {
+    border-left: 3px solid transparent;
+  }
+
   .session-row:hover {
+    background: var(--surface-hover);
+    color: var(--text);
+  }
+
+  .session-row.selected {
+    border-left-color: var(--accent);
     background: var(--surface-hover);
     color: var(--text);
   }


### PR DESCRIPTION
## Summary

Users couldn't tell at a glance which session was currently selected in the sidenav. This adds a left accent border to the active session row and auto-selects when only one session exists on first load.

## Changes

- **WorkspaceItem.svelte**: Added `selected` class to session rows matching `activeSessionId`, with `border-left: 3px solid var(--accent)` + subtle background highlight
- **App.svelte**: Auto-select the single session on page load when no session is active and no URL param targets a specific session

## Testing

- All 158 tests pass (`npm test`)
- svelte-check: 0 errors
- Targets master's v3 workspace UI (WorkspaceItem, not old SessionItem)

---
*Created with `/pr:author`*