### PR TITLE
fix: PR dashboard scroll, action buttons, search filter

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -9,6 +9,7 @@
   import { isMobileDevice } from './lib/utils.js';
   import type { WorktreeInfo, OpenSessionOptions, Workspace, PullRequest } from './lib/types.js';
   import { createWorktree, createSession, fetchWorkspaceSettings, killSession, deleteWorktree } from './lib/api.js';
+  import { derivePrAction, getActionPrompt } from './lib/pr-state.js';
   import PinGate from './components/PinGate.svelte';
   import Sidebar from './components/Sidebar.svelte';
   import Terminal from './components/Terminal.svelte';
@@ -449,6 +450,78 @@
     }
   }
 
+  async function handleOpenPrBranch(pr: PullRequest, prompt?: string) {
+    if (!activeWorkspace) return;
+    const workspacePath = activeWorkspace.path;
+
+    const existingSession = sessionState.sessions.find(s => s.branchName === pr.headRefName && s.repoPath.startsWith(workspacePath));
+    const existingWorktree = sessionState.worktrees.find(w => w.branchName === pr.headRefName && w.repoPath === workspacePath);
+
+    try {
+      let worktreePath: string;
+      let branchName: string;
+
+      if (existingSession) {
+        worktreePath = existingSession.repoPath;
+        branchName = existingSession.branchName;
+      } else if (existingWorktree) {
+        worktreePath = existingWorktree.path;
+        branchName = existingWorktree.branchName;
+      } else {
+        const wt = await createWorktree(workspacePath, pr.headRefName);
+        worktreePath = wt.worktreePath;
+        branchName = wt.branchName;
+      }
+
+      const session = await createSession({
+        repoPath: workspacePath,
+        repoName: activeWorkspace.name,
+        worktreePath,
+        branchName,
+        allowMultiple: true,
+      });
+      await refreshAll();
+      sessionState.activeSessionId = session.id;
+      ui.activeWorkspacePath = workspacePath;
+      initSessionNotification(session.id, configState.defaultNotifications);
+      closeSidebar();
+
+      if (prompt) {
+        setTimeout(() => {
+          sendPtyData(prompt + '\r');
+        }, 1500);
+      }
+    } catch (e) {
+      console.error('Failed to open PR branch session:', e);
+    }
+  }
+
+  function handlePrAction(pr: PullRequest) {
+    const prState = pr.state === 'OPEN' ? 'OPEN' : pr.state === 'MERGED' ? 'MERGED' : 'CLOSED';
+    const action = derivePrAction({
+      commitsAhead: 1,
+      prState,
+      ciPassing: 0,
+      ciFailing: 0,
+      ciPending: 0,
+      ciTotal: 0,
+      mergeable: (pr.mergeable as 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN' | null) ?? null,
+      unresolvedCommentCount: 0,
+    });
+    const prompt = getActionPrompt(action, {
+      branchName: pr.headRefName,
+      baseBranch: pr.baseRefName,
+      prNumber: pr.number,
+    });
+    if (prompt) {
+      handleOpenPrBranch(pr, prompt);
+    }
+  }
+
+  function handleOpenPrSession(pr: PullRequest) {
+    handleOpenPrBranch(pr);
+  }
+
   function handleDeleteWorktree(wt: WorktreeInfo) {
     deleteWorktreeDialogRef?.open(wt);
   }
@@ -586,6 +659,8 @@
           onNewSession={() => handleOpenNewSession()}
           onNewWorktree={() => { if (activeWorkspace) handleNewWorktree(activeWorkspace); }}
           onFixConflicts={handleFixConflicts}
+          onPrAction={handlePrAction}
+          onOpenPrSession={handleOpenPrSession}
         />
 
       {:else if viewMode === 'session'}

--- a/frontend/src/components/RepoDashboard.svelte
+++ b/frontend/src/components/RepoDashboard.svelte
@@ -11,12 +11,16 @@
     onNewSession,
     onNewWorktree,
     onFixConflicts,
+    onPrAction,
+    onOpenPrSession,
   }: {
     workspacePath: string;
     workspaceName: string;
     onNewSession: () => void;
     onNewWorktree: () => void;
     onFixConflicts: (pr: PullRequest) => void;
+    onPrAction: (pr: PullRequest) => void;
+    onOpenPrSession: (pr: PullRequest) => void;
   } = $props();
 
   const dashQuery = createQuery<DashboardData>(() => ({
@@ -62,6 +66,19 @@
     if (!entry.branches || entry.branches.length === 0) return '';
     return '(' + entry.branches.join(', ') + ')';
   }
+
+  let searchQuery = $state('');
+  let showSearch = $derived(data ? data.prs.length > 5 : false);
+  let filteredPrs = $derived(() => {
+    if (!data) return [];
+    const q = searchQuery.toLowerCase().trim();
+    if (!q) return data.prs;
+    return data.prs.filter(pr =>
+      pr.title.toLowerCase().includes(q) ||
+      String(pr.number).includes(q) ||
+      pr.headRefName.toLowerCase().includes(q)
+    );
+  });
 </script>
 
 <div class="repo-dashboard">
@@ -96,8 +113,16 @@
       {:else if data && data.prs.length === 0}
         <div class="section-message">No open pull requests</div>
       {:else if data}
+        {#if showSearch}
+          <input
+            class="pr-search"
+            type="text"
+            placeholder="Filter PRs by title, number, or branch..."
+            bind:value={searchQuery}
+          />
+        {/if}
         <div class="pr-list">
-          {#each data.prs as pr (pr.number)}
+          {#each filteredPrs() as pr (pr.number)}
             {@const action = prActionForRow(pr)}
             {@const actionColor = getStatusCssVar(action.color)}
             {@const darkText = shouldUseDarkText(action.color)}
@@ -118,6 +143,11 @@
                 </div>
               </div>
               <div class="pr-row-actions">
+                <button
+                  class="pr-session-btn"
+                  title="Open session on this branch"
+                  onclick={() => onOpenPrSession(pr)}
+                >+</button>
                 {#if pr.mergeable === 'CONFLICTING'}
                   <button
                     class="pr-action-pill pr-conflict-pill"
@@ -139,16 +169,15 @@
                   </a>
                 {/if}
                 {#if action.type !== 'none' && action.label}
-                  <a
+                  <button
                     class="pr-action-pill"
-                    href={pr.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
                     style:--pill-color={actionColor}
                     class:dark-text={darkText}
+                    title={action.label}
+                    onclick={() => onPrAction(pr)}
                   >
                     {action.label}
-                  </a>
+                  </button>
                 {/if}
               </div>
             </div>
@@ -206,6 +235,8 @@
     background: var(--bg);
     min-height: 0;
     max-width: none;
+    overflow-y: auto;
+    flex: 1;
   }
 
   /* ── Section ── */
@@ -239,6 +270,28 @@
 
   .section-message.info a:hover {
     text-decoration: underline;
+  }
+
+  /* ── PR search ── */
+  .pr-search {
+    padding: 8px 10px;
+    font-size: var(--font-size-sm);
+    font-family: var(--font-mono);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    color: var(--text);
+    outline: none;
+    transition: border-color 0.12s;
+  }
+
+  .pr-search::placeholder {
+    color: var(--text-muted);
+    opacity: 0.6;
+  }
+
+  .pr-search:focus {
+    border-color: var(--accent);
   }
 
   /* ── PR list ── */
@@ -303,6 +356,29 @@
     flex-shrink: 0;
   }
 
+  .pr-session-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text-muted);
+    font-size: var(--font-size-sm);
+    font-family: var(--font-mono);
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s, border-color 0.12s;
+    flex-shrink: 0;
+  }
+
+  .pr-session-btn:hover {
+    background: color-mix(in srgb, var(--accent) 12%, transparent);
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
   .pr-conflict-pill {
     --pill-color: var(--status-error);
     font-weight: 600;
@@ -357,6 +433,7 @@
     color: #fff;
     text-decoration: none;
     white-space: nowrap;
+    cursor: pointer;
     transition: opacity 0.12s;
   }
 


### PR DESCRIPTION
## Summary
- **Scroll fix**: Added `overflow-y: auto` to `.repo-dashboard` so PR list scrolls within the viewport instead of being clipped
- **Code Review → worktree session**: Changed action pill from `<a href>` (linking to GitHub) to `<button>` that creates a worktree session and injects the review prompt via PTY
- **Per-PR session button**: Added "+" button on each PR row to open a generic session on that PR's branch
- **Search/filter**: Added client-side search input (filters by title, number, or branch name) when >5 PRs are present

## Test plan
- [ ] Open dashboard for a repo with 10+ open PRs — verify scrolling works
- [ ] Click "Review PR" on any PR — verify it creates a worktree session with review prompt (not GitHub redirect)
- [ ] Click "+" on a PR row — verify it opens a session on that PR's branch
- [ ] Type in the search input — verify PRs filter by title, number, and branch name
- [ ] Verify build passes: `npm run build`
- [ ] Verify tests pass: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)