### PR TITLE
Fix tmux Unicode rendering (underscores)

### DIFF
--- a/frontend/src/components/Terminal.svelte
+++ b/frontend/src/components/Terminal.svelte
@@ -217,7 +217,8 @@
   // React to sessionId changes
   $effect(() => {
     if (sessionId && term && !companionMode) {
-      term.reset();
+      term.write('\x1b[?1049l'); // Exit alternate screen buffer if active
+      term.clear();
       connectPtySocket(
         sessionId,
         term,


### PR DESCRIPTION
## Summary

- Revert `term.reset()` to `term.clear()` in `Terminal.svelte:220` to preserve terminal character set state across session switches
- Add explicit alternate screen buffer exit (`\x1b[?1049l`) before clearing to handle the state leak that `reset()` was originally meant to fix
- Fixes tmux Unicode status indicators (⏵, ✗, ●) rendering as `_` underscores

**Root cause:** `term.reset()` (introduced in `b47fd32`) wipes all terminal state including character set configuration. When tmux's initial setup sequences get evicted from the 256KB scrollback FIFO, re-entering a session loses the UTF-8 state, causing tmux to fall back to `_` for characters with unknown display width.

## Test plan

- [x] `npm run build` — clean (0 errors)
- [x] `npm test` — 183 tests pass
- [ ] Manual: open a tmux session, trigger Claude tool use, verify Unicode indicators render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)