### PR TITLE
fix: clicking inactive repo root creates session instead of navigating to dashboard

### DIFF
--- a/docs/bug-analyses/2026-03-19-repo-root-click-dashboard-bug-analysis.md
+++ b/docs/bug-analyses/2026-03-19-repo-root-click-dashboard-bug-analysis.md
@@ -1,0 +1,84 @@
+# Bug Analysis: Clicking Inactive Repo Root Goes to Dashboard Instead of Opening Session
+
+> **Status**: Confirmed | **Date**: 2026-03-19
+> **Severity**: High
+> **Affected Area**: `frontend/src/components/WorkspaceItem.svelte` — persistent repo root click handler
+
+## Symptoms
+- Clicking on the default repo branch (repo root entry) in the sidebar navigates to the dashboard instead of opening a new Claude session at that repo's folder level
+- The entry appears as an inactive row when no sessions exist for the repo root
+- Inactive worktrees correctly create sessions on click; only the repo root is broken
+
+## Reproduction Steps
+1. Add a workspace (e.g. `claude-remote-cli`)
+2. If a session exists at the repo root, kill it — the repo root entry now shows as inactive (gray dot)
+3. Click the inactive repo root entry
+4. **Expected**: A new session is created at the repo folder, and the terminal opens
+5. **Actual**: The view switches to the dashboard (workspace overview), no session is created
+
+## Root Cause
+
+Introduced in commit `2a99318 fix: sidebar shows one row per folder instead of per session`.
+
+The fix added a persistent repo root entry in the `{:else if isRepoRoot}` branch at **WorkspaceItem.svelte:248-261**. When the repo root has zero active sessions, this branch renders an inactive row with the click handler:
+
+```svelte
+onclick={() => onSelectWorkspace(workspace.path)}
+```
+
+`onSelectWorkspace` maps to `handleSelectWorkspace` in **Sidebar.svelte:44-48**:
+
+```typescript
+function handleSelectWorkspace(path: string) {
+    ui.activeWorkspacePath = path;
+    sessionState.activeSessionId = null; // clears session → shows dashboard
+}
+```
+
+This **clears the active session** and shows the dashboard. It's the correct behavior for clicking a workspace header, but wrong for clicking an inactive session row that should launch a new session.
+
+Compare with inactive worktree rows (**WorkspaceItem.svelte:270-280**), which correctly create a session:
+
+```svelte
+onclick={async () => {
+    const session = await createSession({ repoPath: workspace.path, ... });
+    await refreshAll();
+    onSelectSession(session.id);
+}}
+```
+
+The repo root entry should use the same pattern.
+
+## Evidence
+- **WorkspaceItem.svelte:254**: `onclick={() => onSelectWorkspace(workspace.path)}` — calls dashboard navigation
+- **WorkspaceItem.svelte:270-280**: Inactive worktree handler correctly calls `createSession()` + `onSelectSession()` — this is the correct pattern
+- **Sidebar.svelte:44-48**: `handleSelectWorkspace` explicitly sets `activeSessionId = null` (dashboard view)
+- `createSession` is already imported in WorkspaceItem.svelte (line 6)
+
+## Impact Assessment
+- **High severity**: The repo root is the most common entry point — users expect clicking it to start working in that repo
+- **UX confusion**: Clicking what looks like a session row navigates away from sessions entirely
+- **Regression**: Introduced by the sidebar fix in `2a99318`
+
+## Recommended Fix Direction
+
+Replace the `onSelectWorkspace` call in the inactive repo root handler with a `createSession` + `onSelectSession` call, mirroring the inactive worktree pattern:
+
+```svelte
+{:else if isRepoRoot}
+  <li
+    class="session-row inactive"
+    onclick={async () => {
+      try {
+        const session = await createSession({
+          repoPath: workspace.path,
+          repoName: workspace.name,
+        });
+        await refreshAll();
+        onSelectSession(session.id);
+      } catch { /* silent */ }
+    }}
+  >
+```
+
+This is a ~5-line change in a single file. No architectural changes needed.

--- a/docs/bug-analyses/index.md
+++ b/docs/bug-analyses/index.md
@@ -19,3 +19,4 @@
 | [pr-dashboard-usability-bug-analysis.md](2026-03-19-pr-dashboard-usability-bug-analysis.md) | PR dashboard: no scroll, Code Review links to GitHub, no per-PR session button, no search | 2026-03-19 |
 | [tmux-underscore-rendering-bug-analysis.md](2026-03-19-tmux-underscore-rendering-bug-analysis.md) | tmux Unicode status icons render as underscores — likely caused by term.reset() wiping terminal state | 2026-03-19 |
 | [sidebar-session-model-mismatch-bug-analysis.md](2026-03-19-sidebar-session-model-mismatch-bug-analysis.md) | Sidebar shows 1 row per session instead of 1 row per folder — duplicates, no persistent repo entry, architectural mismatch | 2026-03-19 |
+| [repo-root-click-dashboard-bug-analysis.md](2026-03-19-repo-root-click-dashboard-bug-analysis.md) | Clicking inactive repo root goes to dashboard instead of creating a session — wrong click handler in persistent entry | 2026-03-19 |

--- a/docs/exec-plans/active/2026-03-19-repo-root-click-dashboard.md
+++ b/docs/exec-plans/active/2026-03-19-repo-root-click-dashboard.md
@@ -1,0 +1,49 @@
+# Execution Plan: Fix Repo Root Click → Dashboard Bug
+
+> **Status**: Active | **Created**: 2026-03-19
+> **Source**: `docs/bug-analyses/2026-03-19-repo-root-click-dashboard-bug-analysis.md`
+> **Branch**: `kangchenjunga`
+
+## Goal
+
+When clicking the inactive repo root entry in the sidebar, create a new session at the repo folder level instead of navigating to the dashboard.
+
+## Progress
+
+- [ ] Task 1: Fix the click handler for the inactive repo root entry
+- [ ] Task 2: Build and verify
+
+---
+
+### Task 1: Fix click handler for inactive repo root entry
+
+**File:** `frontend/src/components/WorkspaceItem.svelte`
+**Lines:** 248-261
+
+**What:** Replace `onSelectWorkspace(workspace.path)` with `createSession()` + `onSelectSession()`, mirroring the inactive worktree pattern at lines 270-280.
+
+**Change:**
+```svelte
+<!-- Before -->
+<li class="session-row inactive"
+    onclick={() => onSelectWorkspace(workspace.path)}>
+
+<!-- After -->
+<li class="session-row inactive"
+    onclick={async () => {
+      try {
+        const session = await createSession({
+          repoPath: workspace.path,
+          repoName: workspace.name,
+        });
+        await refreshAll();
+        onSelectSession(session.id);
+      } catch { /* silent */ }
+    }}>
+```
+
+**Dependencies:** `createSession` and `refreshAll` are already imported (lines 3, 6).
+
+### Task 2: Build and verify
+
+Run `npm run build` to confirm no TypeScript or Svelte compilation errors.

--- a/frontend/src/components/WorkspaceItem.svelte
+++ b/frontend/src/components/WorkspaceItem.svelte
@@ -251,7 +251,16 @@
           <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
           <li
             class="session-row inactive"
-            onclick={() => onSelectWorkspace(workspace.path)}
+            onclick={async () => {
+              try {
+                const session = await createSession({
+                  repoPath: workspace.path,
+                  repoName: workspace.name,
+                });
+                await refreshAll();
+                onSelectSession(session.id);
+              } catch { /* silent */ }
+            }}
           >
             <div class="session-row-primary">
               <span class="dot dot-inactive"></span>


### PR DESCRIPTION
## Summary
- Fixed a regression from #20 where clicking the inactive repo root entry in the sidebar navigated to the dashboard instead of creating a new session
- The persistent repo root entry now calls `createSession()` + `onSelectSession()`, matching the inactive worktree pattern
- Single-file fix in `WorkspaceItem.svelte` (~5 lines changed)

## Root Cause
The `{:else if isRepoRoot}` branch added in `2a99318` used `onSelectWorkspace()` (which clears `activeSessionId` → dashboard) instead of `createSession()` (which creates a PTY session).

## Test plan
- [ ] Add a workspace, kill any repo-root session so it shows as inactive
- [ ] Click the inactive repo root entry → should create a new session and open the terminal
- [ ] Verify inactive worktrees still work the same way (click → creates session)
- [ ] Build passes (`npm run build`), 183/183 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)