### PR TITLE
fix: add loading feedback to session/worktree creation

### DIFF
--- a/docs/bug-analyses/2026-03-19-missing-loading-feedback-bug-analysis.md
+++ b/docs/bug-analyses/2026-03-19-missing-loading-feedback-bug-analysis.md
@@ -1,0 +1,52 @@
+# Bug Analysis: Missing Loading Feedback on Worktree/Session Creation
+
+> **Status**: Confirmed | **Date**: 2026-03-19
+> **Severity**: Medium
+> **Affected Area**: Frontend — WorkspaceItem, App, NewSessionDialog, api
+
+## Symptoms
+- Clicking "+ new worktree" in the sidebar produces no visual feedback while the git worktree and session are being created (several seconds)
+- The button remains clickable, allowing accidental duplicate creation via rapid clicks
+- Same issue affects: dashboard "+ New Worktree" button, "New Session" dialog create button, and worktree "Resume" context menu action
+- Delete worktree dialog is the only flow that correctly shows loading state ("Deleting...")
+
+## Reproduction Steps
+1. Open the app with a workspace visible in the sidebar
+2. Click "+ new worktree" on any workspace
+3. Observe: no spinner, no disabled state, no "Creating..." text — the UI appears frozen
+4. The worktree eventually appears after several seconds with no intermediate feedback
+
+## Root Cause
+
+`handleNewWorktree()` in `App.svelte` (lines 351-389) performs two sequential async API calls — `createWorktree()` then `createSession()` — without setting any loading state before or clearing it after. The button in `WorkspaceItem.svelte` (lines 305-310) has no `disabled` prop or loading indicator.
+
+**Loading infrastructure already exists but is unused for creation flows:**
+- `setLoading(key)` / `clearLoading(key)` / `isItemLoading(key)` are defined in `sessions.svelte.ts` (lines 178-188)
+- These are only used by `DeleteWorktreeDialog.svelte` — never for creation
+
+| Flow | Has Loading? | Spinner? | Button Disabled? | Loading Text? |
+|------|---|---|---|---|
+| + new worktree (sidebar) | No | No | No | No |
+| + New Worktree (dashboard) | No | No | No | No |
+| New Session dialog create | No | No | No | No |
+| Resume Worktree (context menu) | No | No | No | No |
+| Delete Worktree confirm | **Yes** | No | **Yes** | **"Deleting..."** |
+
+## Evidence
+- `WorkspaceItem.svelte:305-310` — no disabled/loading props on `add-worktree-btn`
+- `App.svelte:351-389` — `handleNewWorktree()` has no loading state management
+- `NewSessionDialog.svelte:392` — create button has no creating state (only branch refresh has spinner)
+- `sessions.svelte.ts:178-188` — `setLoading/clearLoading/isItemLoading` exist but unused for creation
+- `DeleteWorktreeDialog.svelte:10,27,36,76,80,82` — correctly implements loading pattern as reference
+
+## Impact Assessment
+- Users perceive the app as unresponsive during worktree creation
+- Rapid clicks can trigger multiple concurrent git worktree operations, creating duplicate worktrees
+- Inconsistent UX — delete shows feedback but create does not
+
+## Recommended Fix Direction
+
+1. Use the existing `setLoading()`/`clearLoading()` infrastructure for all creation flows
+2. Add a `creating` state to `handleNewWorktree()` that disables the button and shows feedback text
+3. Apply the same pattern to `NewSessionDialog` create button and worktree resume action
+4. Follow the `DeleteWorktreeDialog` as the reference implementation for consistent loading UX

--- a/docs/bug-analyses/index.md
+++ b/docs/bug-analyses/index.md
@@ -20,3 +20,4 @@
 | [tmux-underscore-rendering-bug-analysis.md](2026-03-19-tmux-underscore-rendering-bug-analysis.md) | tmux Unicode status icons render as underscores — likely caused by term.reset() wiping terminal state | 2026-03-19 |
 | [sidebar-session-model-mismatch-bug-analysis.md](2026-03-19-sidebar-session-model-mismatch-bug-analysis.md) | Sidebar shows 1 row per session instead of 1 row per folder — duplicates, no persistent repo entry, architectural mismatch | 2026-03-19 |
 | [repo-root-click-dashboard-bug-analysis.md](2026-03-19-repo-root-click-dashboard-bug-analysis.md) | Clicking inactive repo root goes to dashboard instead of creating a session — wrong click handler in persistent entry | 2026-03-19 |
+| [missing-loading-feedback-bug-analysis.md](2026-03-19-missing-loading-feedback-bug-analysis.md) | No loading feedback on worktree/session creation — button stays clickable, no spinner or disabled state | 2026-03-19 |

--- a/docs/exec-plans/done/2026-03-19-missing-loading-feedback.md
+++ b/docs/exec-plans/done/2026-03-19-missing-loading-feedback.md
@@ -1,0 +1,48 @@
+# Plan: Missing Loading Feedback on Session/Worktree Creation
+
+> **Status**: Complete | **Created**: 2026-03-19
+> **Source**: docs/bug-analyses/2026-03-19-missing-loading-feedback-bug-analysis.md
+
+## Goal
+
+Add loading feedback (disabled state, text change) to all session/worktree creation flows, following the existing `DeleteWorktreeDialog` pattern.
+
+## Progress
+
+- [x] Task 1: Add loading state to `handleNewWorktree` in App.svelte
+- [x] Task 2: Show loading state on "+ new worktree" button in WorkspaceItem.svelte
+- [x] Task 3: Add loading state to inactive worktree resume click in WorkspaceItem.svelte
+- [x] Task 4: Add creating state to NewSessionDialog submit button
+- [x] Task 5: Add loading state to RepoDashboard CTA buttons
+- [x] Task 6: Build and verify
+
+---
+
+### Task 1: Add loading state to `handleNewWorktree` in App.svelte
+
+**File:** `frontend/src/App.svelte`
+**What:** Wrap `handleNewWorktree` with `setLoading`/`clearLoading` using key `new-worktree:{workspace.path}`. Guard against double-clicks by checking `isItemLoading` at entry.
+
+### Task 2: Show loading state on "+ new worktree" button in WorkspaceItem.svelte
+
+**File:** `frontend/src/components/WorkspaceItem.svelte`
+**What:** Import `isItemLoading` from sessions state. Derive loading state from `isItemLoading('new-worktree:' + workspace.path)`. When loading: show "creating..." text, reduce opacity, disable pointer events.
+
+### Task 3: Add loading state to inactive worktree resume click in WorkspaceItem.svelte
+
+**File:** `frontend/src/components/WorkspaceItem.svelte`
+**What:** Wrap the inline `createSession` calls (lines 270-280) with `setLoading(wt.path)`/`clearLoading(wt.path)`. Show a loading indicator on the row using `isItemLoading(wt.path)`. Same for context menu Resume actions (lines 115-143).
+
+### Task 4: Add creating state to NewSessionDialog submit button
+
+**File:** `frontend/src/components/dialogs/NewSessionDialog.svelte`
+**What:** Add `let creating = $state(false)`. Set `creating = true` before API call in `handleSubmit`, reset in finally. Button text changes to "Creating..." when creating. Button disabled when creating.
+
+### Task 5: Add loading state to RepoDashboard CTA buttons
+
+**File:** `frontend/src/components/RepoDashboard.svelte`
+**What:** Accept optional `creatingWorktree` prop. When true, the "+ New Worktree" button shows "Creating..." and is disabled. The prop comes from App.svelte checking `isItemLoading`.
+
+### Task 6: Build and verify
+
+Run `npm run build` to verify no TypeScript errors.

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { getAuth, checkExistingAuth } from './lib/state/auth.svelte.js';
   import { getUi, openSidebar, closeSidebar } from './lib/state/ui.svelte.js';
-  import { getSessionState, refreshAll, setAttention, clearAttention, initSessionNotification, getNotificationSessionIds, getSessionsForWorkspace, refreshSessionMeta } from './lib/state/sessions.svelte.js';
+  import { getSessionState, refreshAll, setAttention, clearAttention, initSessionNotification, getNotificationSessionIds, getSessionsForWorkspace, refreshSessionMeta, setLoading, clearLoading, isItemLoading } from './lib/state/sessions.svelte.js';
   import { connectEventSocket, sendPtyData } from './lib/ws.js';
   import { initNotifications, initPushNotifications, resubscribeIfNeeded } from './lib/notifications.js';
   import { getConfigState } from './lib/state/config.svelte.js';
@@ -353,6 +353,9 @@
     // 1. Create git worktree with next mountain name via POST /workspaces/worktree
     // 2. Start a session in the new worktree with workspace default settings
     // 3. Session is flagged needsBranchRename — first message triggers auto-rename
+    const loadingKey = `new-worktree:${workspace.path}`;
+    if (isItemLoading(loadingKey)) return;
+    setLoading(loadingKey);
     try {
       // Resolve session defaults: workspace settings override global config
       let yolo = configState.defaultYolo;
@@ -385,6 +388,8 @@
     } catch (e) {
       // Fall back to dialog on error
       newSessionDialogRef?.open({ name: workspace.name, path: workspace.path });
+    } finally {
+      clearLoading(loadingKey);
     }
   }
 
@@ -655,6 +660,7 @@
         <RepoDashboard
           workspacePath={ui.activeWorkspacePath ?? ''}
           workspaceName={activeWorkspace?.name ?? ''}
+          creatingWorktree={isItemLoading(`new-worktree:${ui.activeWorkspacePath ?? ''}`)}
           onNewSession={() => handleOpenNewSession()}
           onNewWorktree={() => { if (activeWorkspace) handleNewWorktree(activeWorkspace); }}
           onFixConflicts={handleFixConflicts}

--- a/frontend/src/components/RepoDashboard.svelte
+++ b/frontend/src/components/RepoDashboard.svelte
@@ -8,6 +8,7 @@
   let {
     workspacePath,
     workspaceName,
+    creatingWorktree = false,
     onNewSession,
     onNewWorktree,
     onFixConflicts,
@@ -16,6 +17,7 @@
   }: {
     workspacePath: string;
     workspaceName: string;
+    creatingWorktree?: boolean;
     onNewSession: () => void;
     onNewWorktree: () => void;
     onFixConflicts: (pr: PullRequest) => void;
@@ -229,7 +231,9 @@
   <div class="cta-row">
     <button class="cta-btn" onclick={onNewSession}>+ Start Session</button>
     {#if !data || data.isGitRepo}
-      <button class="cta-btn" onclick={onNewWorktree}>+ New Worktree</button>
+      <button class="cta-btn" onclick={onNewWorktree} disabled={creatingWorktree}>
+        {creatingWorktree ? 'Creating...' : '+ New Worktree'}
+      </button>
     {/if}
   </div>
 </div>
@@ -566,8 +570,13 @@
     white-space: nowrap;
   }
 
-  .cta-btn:hover {
+  .cta-btn:hover:not(:disabled) {
     background: color-mix(in srgb, var(--accent) 12%, transparent);
+  }
+
+  .cta-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
   /* ── Skeletons ── */

--- a/frontend/src/components/WorkspaceItem.svelte
+++ b/frontend/src/components/WorkspaceItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Workspace, SessionSummary, WorktreeInfo } from '../lib/types.js';
-  import { getSessionState, getSessionStatus, refreshAll, getSessionMetaById } from '../lib/state/sessions.svelte.js';
+  import { getSessionState, getSessionStatus, refreshAll, getSessionMetaById, setLoading, clearLoading, isItemLoading } from '../lib/state/sessions.svelte.js';
   import { toggleWorkspaceCollapse, isWorkspaceCollapsed, getTimeTick } from '../lib/state/ui.svelte.js';
   import { formatRelativeTimeCompact } from '../lib/utils.js';
   import { createSession } from '../lib/api.js';
@@ -75,6 +75,7 @@
   }
 
   let hasAttention = $derived(allSessions.some(s => getSessionStatus(s) === 'attention'));
+  let creatingWorktree = $derived(isItemLoading(`new-worktree:${workspace.path}`));
 
   // Force re-derive on time tick
   let _tick = $derived(getTimeTick());
@@ -113,6 +114,8 @@
       {
         label: 'Resume',
         action: async () => {
+          if (isItemLoading(wt.path)) return;
+          setLoading(wt.path);
           try {
             const session = await createSession({
               repoPath: workspace.path,
@@ -122,12 +125,16 @@
             });
             await refreshAll();
             onSelectSession(session.id);
-          } catch { /* silent */ }
+          } catch { /* silent */ } finally {
+            clearLoading(wt.path);
+          }
         },
       },
       {
         label: 'Resume (YOLO)',
         action: async () => {
+          if (isItemLoading(wt.path)) return;
+          setLoading(wt.path);
           try {
             const session = await createSession({
               repoPath: workspace.path,
@@ -138,7 +145,9 @@
             });
             await refreshAll();
             onSelectSession(session.id);
-          } catch { /* silent */ }
+          } catch { /* silent */ } finally {
+            clearLoading(wt.path);
+          }
         },
       },
       {
@@ -249,9 +258,13 @@
           <!-- Persistent repo root entry — always shown even with no active sessions -->
           <!-- svelte-ignore a11y_click_events_have_key_events -->
           <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+          {@const repoLoadingKey = `repo-session:${workspace.path}`}
           <li
             class="session-row inactive"
+            class:loading={isItemLoading(repoLoadingKey)}
             onclick={async () => {
+              if (isItemLoading(repoLoadingKey)) return;
+              setLoading(repoLoadingKey);
               try {
                 const session = await createSession({
                   repoPath: workspace.path,
@@ -259,12 +272,14 @@
                 });
                 await refreshAll();
                 onSelectSession(session.id);
-              } catch { /* silent */ }
+              } catch { /* silent */ } finally {
+                clearLoading(repoLoadingKey);
+              }
             }}
           >
             <div class="session-row-primary">
               <span class="dot dot-inactive"></span>
-              <span class="session-name">{workspace.name}</span>
+              <span class="session-name">{isItemLoading(repoLoadingKey) ? 'starting...' : workspace.name}</span>
             </div>
           </li>
         {/if}
@@ -276,7 +291,10 @@
         <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
         <li
           class="session-row inactive"
+          class:loading={isItemLoading(wt.path)}
           onclick={async () => {
+            if (isItemLoading(wt.path)) return;
+            setLoading(wt.path);
             try {
               const session = await createSession({
                 repoPath: workspace.path,
@@ -286,12 +304,14 @@
               });
               await refreshAll();
               onSelectSession(session.id);
-            } catch { /* silent */ }
+            } catch { /* silent */ } finally {
+              clearLoading(wt.path);
+            }
           }}
         >
           <div class="session-row-primary">
             <span class="dot dot-inactive"></span>
-            <span class="session-name">{wt.branchName || wt.displayName || wt.name}</span>
+            <span class="session-name">{isItemLoading(wt.path) ? 'resuming...' : wt.branchName || wt.displayName || wt.name}</span>
             {#if hasDiff}
               <span class="diff-badge">
                 <span class="diff-add">+{meta.additions}</span>
@@ -314,8 +334,8 @@
   {#if !collapsed}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="add-worktree-row" onclick={() => onNewWorktree(workspace)}>
-      <span class="add-worktree-btn">+ new worktree</span>
+    <div class="add-worktree-row" class:disabled={creatingWorktree} onclick={() => { if (!creatingWorktree) onNewWorktree(workspace); }}>
+      <span class="add-worktree-btn">{creatingWorktree ? 'creating...' : '+ new worktree'}</span>
     </div>
   {/if}
 
@@ -560,6 +580,8 @@
   .dot-inactive        { width: 7px; height: 7px; border-radius: 50%; background: var(--border); flex-shrink: 0; }
   .session-row.inactive { opacity: 0.6; }
   .session-row.inactive:hover { opacity: 1; }
+  .session-row.loading { pointer-events: none; opacity: 0.7; }
+  .session-row.loading .session-name { color: var(--accent); }
   .status-dot--attention {
     background: var(--status-warning);
     box-shadow: 0 0 5px 1px rgba(251, 191, 36, 0.45);
@@ -610,6 +632,15 @@
   .add-worktree-btn:hover {
     opacity: 1;
     color: var(--text);
+  }
+
+  .add-worktree-row.disabled {
+    pointer-events: none;
+  }
+
+  .add-worktree-row.disabled .add-worktree-btn {
+    opacity: 0.7;
+    color: var(--accent);
   }
 
   /* Solid divider */

--- a/frontend/src/components/dialogs/NewSessionDialog.svelte
+++ b/frontend/src/components/dialogs/NewSessionDialog.svelte
@@ -36,6 +36,7 @@
   let branchDropdownVisible = $state(false);
   let branchesLoading = $state(false);
   let branchesRefreshing = $state(false);
+  let creating = $state(false);
   let branchRequestId = 0;
 
   // Derived
@@ -152,7 +153,8 @@
 
   async function handleSubmit() {
     const repoPath = selectedRepoPath;
-    if (!repoPath) return;
+    if (!repoPath || creating) return;
+    creating = true;
 
     const claudeArgs = claudeArgsInput.trim().split(/\s+/).filter(Boolean);
 
@@ -203,6 +205,8 @@
           onSessionCreated?.(conflictErr.sessionId);
         }
       }
+    } finally {
+      creating = false;
     }
   }
 
@@ -385,13 +389,13 @@
     </div>
 
     <div class="dialog-footer">
-      <button class="btn btn-ghost" onclick={() => dialogEl.close()}>Cancel</button>
+      <button class="btn btn-ghost" onclick={() => dialogEl.close()} disabled={creating}>Cancel</button>
       <button
         class="btn btn-primary"
         onclick={handleSubmit}
-        disabled={!selectedRepoPath}
+        disabled={!selectedRepoPath || creating}
       >
-        {activeTab === 'repos' ? 'Start Session' : 'Create Worktree'}
+        {creating ? 'Creating...' : activeTab === 'repos' ? 'Start Session' : 'Create Worktree'}
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Adds "creating..."/"resuming..." loading text and disabled states to all session/worktree creation flows
- Prevents double-click race conditions during async git worktree + session creation
- Uses existing `setLoading`/`clearLoading` infrastructure (previously only used by DeleteWorktreeDialog)

**Affected flows:**
| Flow | Before | After |
|------|--------|-------|
| Sidebar "+ new worktree" | No feedback | Shows "creating...", disables click |
| Dashboard "+ New Worktree" | No feedback | Shows "Creating...", button disabled |
| NewSessionDialog submit | No feedback | Shows "Creating...", buttons disabled |
| Inactive worktree click/resume | No feedback | Shows "resuming...", row disabled |

## Test plan
- [ ] Click "+ new worktree" in sidebar — verify "creating..." text appears and button is unclickable
- [ ] Click "+ New Worktree" on dashboard — verify "Creating..." text and disabled state
- [ ] Open New Session dialog and submit — verify "Creating..." and disabled buttons
- [ ] Click an inactive worktree row — verify "resuming..." text appears
- [ ] Right-click → Resume on inactive worktree — verify no double-trigger
- [ ] Verify loading states clear on both success and error paths
- [ ] Build passes: `npm run build` (0 errors)
- [ ] Tests pass: `npm test` (183/183)

🤖 Generated with [Claude Code](https://claude.com/claude-code)