### PR TITLE
fix: break infinite PR/CI query loop with untrack() in PrTopBar $effect

### DIFF
--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -111,3 +111,13 @@ When a sidebar row represents a group of sessions (e.g., all tabs for a worktree
 When session creation accepts flags that affect runtime behavior (yolo mode, custom CLI args, continue mode), these must be stored on the Session object — not just consumed to build a spawn command and discarded. The serialization/restoration cycle can only preserve what's on the session object. In this project, `yolo`, `claudeArgs`, and `args` were converted to CLI arguments at route handler level and passed through to `createPtySession()` as a transient `args` parameter, making it impossible to serialize them for post-update restoration. When adding any creation-time parameter that should persist across restarts, add it to both the `PtySession` interface and `SerializedPtySession`.
 
 ---
+
+### L-012: Never call `.refetch()` on a TanStack Query store inside a Svelte 5 `$effect` without `untrack()`
+- status: active
+- category: debugging
+- source: /harness:bug 2026-03-23
+- branch: master
+
+TanStack Query's `createQuery` returns a Svelte 5 reactive proxy. Accessing `.refetch` inside a `$effect` tracks the query store as a dependency. When `refetch()` completes, it updates internal state (`isFetching`, `data`), which re-triggers the effect, creating an infinite loop. Always wrap `.refetch()` calls in `untrack()` when used inside `$effect`, or use `queryClient.invalidateQueries()` from outside reactive contexts instead.
+
+---

--- a/docs/bug-analyses/2026-03-23-pr-query-infinite-loop-bug-analysis.md
+++ b/docs/bug-analyses/2026-03-23-pr-query-infinite-loop-bug-analysis.md
@@ -1,0 +1,72 @@
+# Bug Analysis: PR/CI Query Infinite Loop
+
+> **Status**: Confirmed | **Date**: 2026-03-23
+> **Severity**: Critical
+> **Affected Area**: frontend/src/components/PrTopBar.svelte
+
+## Symptoms
+- Network tab shows 583+ requests growing rapidly to 1878+ within seconds
+- All requests to `/workspaces/pr?path=` and `/workspaces/ci-status?path=` endpoints
+- Requests initiated by `sw.js:4` (service worker pass-through) and `index-B` (main bundle)
+- All requests stuck in "pending" status, saturating the browser's connection pool
+- UI becomes unresponsive due to request flooding
+
+## Reproduction Steps
+1. Open claude-remote-cli web interface
+2. Navigate to any workspace with a session (so `sessionId` is non-null)
+3. Open browser DevTools → Network tab
+4. Observe continuous rapid-fire requests to `pr?path=` and `ci-status?path=`
+
+## Root Cause
+
+The `$effect` at `PrTopBar.svelte:59-64` creates an infinite reactive loop:
+
+```typescript
+$effect(() => {
+  if (sessionId) {
+    prQuery.refetch();
+    ciQuery.refetch();
+  }
+});
+```
+
+In Svelte 5, `$effect()` auto-tracks all reactive values read during synchronous execution. TanStack Query's `createQuery` returns a reactive proxy — accessing `.refetch` on the query object tracks the entire query store as a dependency.
+
+**The infinite cycle:**
+1. `$effect` runs → reads `sessionId` (tracked), accesses `prQuery.refetch` (tracked), accesses `ciQuery.refetch` (tracked)
+2. `prQuery.refetch()` starts a fetch → query transitions to `isFetching: true` → reactive state update
+3. Reactive change re-triggers the `$effect` → calls `refetch()` again
+4. Goto step 2
+
+Each refetch call mutates the query state that the effect is tracking, creating a synchronous feedback loop that fires as fast as the browser can process microtasks.
+
+## Evidence
+- `PrTopBar.svelte:59-64`: The `$effect` accesses reactive TanStack Query stores and calls `.refetch()` which mutates those stores
+- `PrTopBar.svelte:43-56`: Both `prQuery` and `ciQuery` are created via `createQuery` which returns Svelte 5 reactive proxies
+- Network tab screenshots show hundreds of pending `pr?path=` and `ci-status?path=` requests accumulating rapidly
+- The effect was introduced in commit `b159f1c0` (PR lifecycle top bar feature)
+- The `invalidatePrQueries()` added in `5155ac2` (auto-refresh feature) likely amplifies the loop by invalidating query caches via WebSocket events, further triggering the reactive cycle
+
+## Impact Assessment
+- **Browser**: Connection pool saturation, UI freeze, potential tab crash
+- **Server**: Hundreds of concurrent `gh pr checks` and `gh pr view` subprocess spawns per second, risking GitHub API rate limiting and server resource exhaustion
+- **User experience**: Application unusable when any session is active
+
+## Recommended Fix Direction
+
+Use Svelte 5's `untrack()` to prevent the effect from tracking the query stores:
+
+```typescript
+import { untrack } from 'svelte';
+
+$effect(() => {
+  if (sessionId) {
+    untrack(() => {
+      prQuery.refetch();
+      ciQuery.refetch();
+    });
+  }
+});
+```
+
+This ensures the effect only re-runs when `sessionId` changes (its intended behavior), not when the query state updates from the refetch it just triggered.

--- a/docs/bug-analyses/index.md
+++ b/docs/bug-analyses/index.md
@@ -35,3 +35,4 @@
 | [stale-session-branch-name-bug-analysis.md](2026-03-22-stale-session-branch-name-bug-analysis.md) | Session branch name frozen at creation time — no `.git/HEAD` watcher, no polling, no refresh mechanism | 2026-03-22 |
 | [sidenav-tab-leak-bug-analysis.md](2026-03-22-sidenav-tab-leak-bug-analysis.md) | Sidenav entry name/icon changes when adding new tab — representative session leaks tab identity into sidebar | 2026-03-22 |
 | [session-flags-lost-on-restart-bug-analysis.md](2026-03-22-session-flags-lost-on-restart-bug-analysis.md) | Session flags (yolo, claudeArgs) lost on auto-update restart — args consumed at spawn, never stored or serialized | 2026-03-22 |
+| [pr-query-infinite-loop-bug-analysis.md](2026-03-23-pr-query-infinite-loop-bug-analysis.md) | Infinite PR/CI fetch loop — `$effect` tracks TanStack Query reactive proxy, refetch mutates tracked state | 2026-03-23 |

--- a/docs/exec-plans/completed/2026-03-23-pr-query-infinite-loop-fix.md
+++ b/docs/exec-plans/completed/2026-03-23-pr-query-infinite-loop-fix.md
@@ -1,0 +1,35 @@
+# Plan: Fix PR/CI Query Infinite Loop
+
+> **Status**: Completed | **Created**: 2026-03-23
+> **Source**: `docs/bug-analyses/2026-03-23-pr-query-infinite-loop-bug-analysis.md`
+> **Branch**: `fix/pr-query-infinite-loop`
+
+## Progress
+
+- [x] Task 1: Wrap refetch calls in `untrack()` to break the reactive loop
+- [x] Task 2: Build and verify no regressions
+
+---
+
+### Task 1: Wrap refetch calls in `untrack()` to break the reactive loop
+**File:** `frontend/src/components/PrTopBar.svelte`
+**Change:**
+1. Add `import { untrack } from 'svelte';` to the script imports
+2. Wrap the `prQuery.refetch()` and `ciQuery.refetch()` calls at lines 59-64 in `untrack()` so the effect only tracks `sessionId`:
+
+```typescript
+$effect(() => {
+  if (sessionId) {
+    untrack(() => {
+      prQuery.refetch();
+      ciQuery.refetch();
+    });
+  }
+});
+```
+
+This ensures the effect re-runs only when `sessionId` changes, not when the query stores update from the refetch they triggered.
+
+### Task 2: Build and verify no regressions
+**Command:** `npm run build`
+**Verify:** Build succeeds with no TypeScript errors. The `untrack` import is valid Svelte 5 API.

--- a/frontend/src/components/PrTopBar.svelte
+++ b/frontend/src/components/PrTopBar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import { createQuery } from '@tanstack/svelte-query';
   import { fetchPrForBranchOrNull, fetchCiStatusOrNull, fetchCurrentBranch } from '../lib/api.js';
   import { sendPtyData } from '../lib/ws.js';
@@ -55,11 +56,15 @@
     enabled: prQuery.data?.state === 'OPEN',
   }));
 
-  // Refetch PR and CI data when session changes (e.g. workspace navigation)
+  // Refetch PR and CI data when session changes (e.g. workspace navigation).
+  // untrack() prevents tracking prQuery/ciQuery stores — without it, the effect
+  // re-triggers on every query state change (isFetching, data), creating an infinite loop.
   $effect(() => {
     if (sessionId) {
-      prQuery.refetch();
-      ciQuery.refetch();
+      untrack(() => {
+        prQuery.refetch();
+        ciQuery.refetch();
+      });
     }
   });
 


### PR DESCRIPTION
The $effect that refetches PR and CI data on session change was tracking the TanStack Query reactive proxies as dependencies. When refetch() updated query state (isFetching, data), the effect re- triggered, creating an infinite request loop (583+ requests/sec).

Wrap refetch calls in Svelte 5's untrack() so the effect only depends on sessionId.