### PR TITLE
fix: gate sidebar DnD behind reorder mode to restore mobile scroll

### DIFF
--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -131,3 +131,13 @@ TanStack Query's `createQuery` returns a Svelte 5 reactive proxy. Accessing `.re
 `POST /sessions` and `POST /workspaces/worktree` both create git worktrees with mountain names, but use different counters (global `config.nextMountainIndex` vs per-workspace `settings.nextMountainIndex`). Worktrees created via one path don't increment the other's counter, causing name collisions that silently break worktree creation. Additionally, resource creation APIs that depend on sequential naming must include collision detection (check if name/branch/directory exists, skip to next) — never assume the counter is accurate. When adding any auto-naming feature, grep for all code paths that create the same resource type and ensure they share one source of truth.
 
 ---
+
+### L-014: Always gate drag-and-drop library activation behind an explicit mode toggle — never leave it always-on
+- status: active
+- category: patterns
+- source: /harness:bug 2026-03-24
+- branch: mobile-longpress-drag
+
+When using `svelte-dnd-action` (or any drag-and-drop library) on a scrollable container, pass `dragDisabled: true` by default and only enable it when the user explicitly enters reorder mode. Libraries like `svelte-dnd-action` attach touch event listeners to draggable children and `preventDefault()` on `touchmove`, which blocks native scroll. Having an application-level reorder mode toggle (e.g., `ui.reorderMode`) without wiring it to the library's `dragDisabled` option creates a disconnect — your mode gate is purely cosmetic while the library still steals events. Always check library docs for disable/enable APIs and wire them to your mode state.
+
+---

--- a/docs/bug-analyses/2026-03-24-sidebar-touch-scroll-blocked-by-dnd-bug-analysis.md
+++ b/docs/bug-analyses/2026-03-24-sidebar-touch-scroll-blocked-by-dnd-bug-analysis.md
@@ -1,0 +1,65 @@
+# Bug Analysis: Sidebar touch scroll blocked by drag-and-drop
+
+> **Status**: Confirmed | **Date**: 2026-03-24
+> **Severity**: High
+> **Affected Area**: `frontend/src/components/Sidebar.svelte` — `svelte-dnd-action` dndzone
+
+## Symptoms
+- On mobile, the sidebar workspace list cannot be scrolled because touch events are intercepted
+- Attempting to scroll initiates a drag-and-drop reorder instead
+- The drag-to-reorder interaction steals all touch events, making the sidebar unusable when the workspace list exceeds viewport height
+
+## Reproduction Steps
+1. Open the app on a mobile device (or use mobile emulation)
+2. Have enough workspaces in the sidebar that the list overflows
+3. Try to scroll the sidebar by swiping up/down
+4. Observe: the touch is intercepted by `svelte-dnd-action` for drag-and-drop instead of scrolling
+
+## Root Cause
+
+The `use:dndzone` directive (`Sidebar.svelte:209`) is applied to the `.workspace-list` container **unconditionally** — it is always active regardless of whether the user is in reorder mode:
+
+```svelte
+<div
+  class="workspace-list"
+  use:dndzone={{ items: localDndItems, flipDurationMs, type: 'workspaces', dropTargetStyle: {} }}
+  ...
+>
+```
+
+`svelte-dnd-action` attaches `touchstart` listeners to all draggable child elements. When a touch event fires, the library intercepts it to initiate a potential drag operation, which `preventDefault()`s the touch and blocks the browser's native scroll.
+
+The existing long-press mechanism (lines 148–170) only controls entering `ui.reorderMode` — it does **not** prevent `svelte-dnd-action` from intercepting touches. The library has a `dragDisabled` option specifically for this use case, but the current code does not use it.
+
+## Evidence
+
+1. **`Sidebar.svelte:209`** — `use:dndzone={{ items: localDndItems, flipDurationMs, type: 'workspaces', dropTargetStyle: {} }}` — no `dragDisabled` option passed
+2. **`svelte-dnd-action` README (line 113)** — documents `dragDisabled: Boolean` option: "Setting it to true will make it impossible to drag elements out of the dnd-zone. You can change it at any time, and the zone will adjust on the fly"
+3. **`svelte-dnd-action` README (line 125)** — also documents `delayTouchStart` option for touch scroll conflicts, but `dragDisabled` is the correct fix here since the app already has an explicit reorder mode gate
+4. **`pointerAction.js:647`** — library attaches `touchstart` listener to each draggable element unconditionally when `dragDisabled` is false (the default)
+5. **`ui.svelte.ts:35,62-63`** — `reorderMode` state exists and is toggled by `enterReorderMode()`/`exitReorderMode()` but is never wired to `dragDisabled`
+
+## Impact Assessment
+
+- **All mobile users** cannot scroll the sidebar when they have more workspaces than fit on screen
+- Desktop users are unaffected (mouse events use different handling path)
+- The reorder feature itself works — it's just always-on instead of gated behind reorder mode
+
+## Recommended Fix Direction
+
+Pass `dragDisabled: !ui.reorderMode` to the `dndzone` configuration on the `.workspace-list` div. This ensures:
+
+- **Normal state** (`reorderMode: false`): `dragDisabled: true` — touch events pass through to native scroll
+- **Reorder mode** (`reorderMode: true`, entered via long-press): `dragDisabled: false` — drag-and-drop works
+
+The change is a single property addition on line 209:
+
+```svelte
+use:dndzone={{ items: localDndItems, flipDurationMs, type: 'workspaces', dropTargetStyle: {}, dragDisabled: !ui.reorderMode }}
+```
+
+**Regression considerations:**
+- Desktop reorder mode: verify it still works (enter via button/long-press, drag items, click "Done reordering")
+- Mobile long-press: verify the 500ms long-press still enters reorder mode and enables dragging
+- Sidebar scroll: verify the `.workspace-list` scrolls normally on mobile when NOT in reorder mode
+- The `delayTouchStart` option is NOT needed here since the reorder mode gate is sufficient

--- a/docs/bug-analyses/index.md
+++ b/docs/bug-analyses/index.md
@@ -37,3 +37,4 @@
 | [session-flags-lost-on-restart-bug-analysis.md](2026-03-22-session-flags-lost-on-restart-bug-analysis.md) | Session flags (yolo, claudeArgs) lost on auto-update restart — args consumed at spawn, never stored or serialized | 2026-03-22 |
 | [pr-query-infinite-loop-bug-analysis.md](2026-03-23-pr-query-infinite-loop-bug-analysis.md) | Infinite PR/CI fetch loop — `$effect` tracks TanStack Query reactive proxy, refetch mutates tracked state | 2026-03-23 |
 | [new-worktree-button-regression-bug-analysis.md](2026-03-23-new-worktree-button-regression-bug-analysis.md) | New worktree button opens session dialog — mountain name collision + dual counter desync + silent error fallback | 2026-03-23 |
+| [sidebar-touch-scroll-blocked-by-dnd-bug-analysis.md](2026-03-24-sidebar-touch-scroll-blocked-by-dnd-bug-analysis.md) | Sidebar can't scroll on mobile — svelte-dnd-action intercepts touches because dragDisabled not set | 2026-03-24 |

--- a/docs/exec-plans/archive/2026-03-24-sidebar-touch-scroll-blocked-by-dnd.md
+++ b/docs/exec-plans/archive/2026-03-24-sidebar-touch-scroll-blocked-by-dnd.md
@@ -1,0 +1,42 @@
+# Fix: Sidebar touch scroll blocked by drag-and-drop
+
+> **Status**: Complete | **Created**: 2026-03-24
+> **Source**: `docs/bug-analyses/2026-03-24-sidebar-touch-scroll-blocked-by-dnd-bug-analysis.md`
+> **Branch**: `cook`
+
+## Goal
+
+Fix mobile sidebar scrolling by gating `svelte-dnd-action` drag behind `reorderMode`. No regressions to desktop or mobile reorder flow.
+
+## Progress
+
+- [x] Task 1: Add `dragDisabled: !ui.reorderMode` to dndzone config
+- [x] Task 2: Build and verify no compile errors (0 errors, 23 pre-existing warnings)
+- [x] Task 3: Run existing test suite (377 pass, 0 fail)
+
+---
+
+### Task 1: Add `dragDisabled` to dndzone config
+**File:** `frontend/src/components/Sidebar.svelte`
+**Line:** 209
+**Change:** Add `dragDisabled: !ui.reorderMode` to the `use:dndzone` options object
+
+Current:
+```svelte
+use:dndzone={{ items: localDndItems, flipDurationMs, type: 'workspaces', dropTargetStyle: {} }}
+```
+
+After:
+```svelte
+use:dndzone={{ items: localDndItems, flipDurationMs, type: 'workspaces', dropTargetStyle: {}, dragDisabled: !ui.reorderMode }}
+```
+
+**Why this works:** When `reorderMode` is `false` (default), `dragDisabled` is `true` — the library won't attach touch/pointer handlers to children, allowing native scroll. When the user long-presses (500ms) and enters reorder mode, `dragDisabled` becomes `false` and dragging works. The library docs confirm it adjusts "on the fly" when `dragDisabled` changes.
+
+### Task 2: Build verification
+**Command:** `npm run build`
+**Expected:** Clean compile, no TypeScript or Svelte errors
+
+### Task 3: Test suite
+**Command:** `npm test`
+**Expected:** All existing tests pass — no regressions

--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -206,7 +206,7 @@
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
       class="workspace-list"
-      use:dndzone={{ items: localDndItems, flipDurationMs, type: 'workspaces', dropTargetStyle: {} }}
+      use:dndzone={{ items: localDndItems, flipDurationMs, type: 'workspaces', dropTargetStyle: {}, dragDisabled: !ui.reorderMode }}
       onconsider={handleDndConsider}
       onfinalize={handleDndFinalize}
       ontouchstart={handleTouchStart}


### PR DESCRIPTION
## Summary
- Add `dragDisabled: !ui.reorderMode` to the `svelte-dnd-action` dndzone config on the sidebar workspace list
- Dragging is now disabled by default, restoring native touch scroll on mobile
- Long-press (500ms) still enters reorder mode, which enables drag-and-drop

## Root Cause
`svelte-dnd-action`'s `dndzone` directive intercepted all touch events on the `.workspace-list` container because no `dragDisabled` option was passed. The library's default (`dragDisabled: false`) attached touch handlers to every draggable child, `preventDefault()`ing `touchmove` and blocking native scroll.

## Test plan
- [x] Build passes (0 errors)
- [x] All 377 tests pass
- [ ] Manual: verify sidebar scrolls on mobile when workspace list overflows
- [ ] Manual: verify long-press enters reorder mode and drag works on mobile
- [ ] Manual: verify desktop drag-and-drop reorder still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)