### PR TITLE
fix: sidebar UX — marquee text, alignment, icons, stable ordering

### DIFF
--- a/frontend/src/components/Sidebar.svelte
+++ b/frontend/src/components/Sidebar.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import {
     getUi,
     closeSidebar,
@@ -10,7 +11,6 @@
     COLLAPSED_SIDEBAR_WIDTH,
   } from '../lib/state/ui.svelte.js';
   import { getSessionState, getSessionsForRepo, getSessionsForWorkspaceGroup, reorderWorkspaces } from '../lib/state/sessions.svelte.js';
-  import { workspaceAttentionScore } from '../lib/state/attention.js';
   import type { Repo, WorktreeInfo, OrgPrsResponse, Workspace } from '../lib/types.js';
   import WorkspaceGroup from './WorkspaceGroup.svelte';
   import { fetchOrgPrs } from '../lib/api.js';
@@ -97,34 +97,28 @@
   let mobileDragEnabled = $state(false);
   let dragDisabled = $derived(isTouchDevice && !mobileDragEnabled);
 
-  // Track whether user has manually reordered in this session
-  let userHasDragged = $state(false);
-
-  // Pre-compute sidebar items grouped by repo for O(1) lookup in sort
-  let itemsByRepo = $derived(new Map(
-    sessionState.repos.map(r => [
-      r.path,
-      sessionState.sidebarItems.filter(i => i.repoPath === r.path),
-    ])
-  ));
-
-  // Attention-sorted ungrouped workspace list
-  let attentionSortedUngrouped = $derived(
-    [...ungroupedRepos].sort((a, b) => {
-      return workspaceAttentionScore(itemsByRepo.get(b.path) ?? [])
-        - workspaceAttentionScore(itemsByRepo.get(a.path) ?? []);
-    })
-  );
-
   // svelte-dnd-action requires items with `id` property
   let dndItems = $derived(
-    (userHasDragged ? ungroupedRepos : attentionSortedUngrouped)
-      .map(w => ({ id: w.path, workspace: w }))
+    ungroupedRepos.map(w => ({ id: w.path, workspace: w }))
   );
 
-  // Local mutable copy for DnD updates
+  // Local mutable copy for DnD updates — only sync when workspace set actually changes
+  // (add/remove), not on every poll. This preserves user's drag-and-drop order.
   let localDndItems = $state<Array<{ id: string; workspace: Repo }>>([]);
-  $effect(() => { localDndItems = dndItems; });
+  $effect(() => {
+    const incoming = dndItems;
+    const current = untrack(() => localDndItems);
+    const localIds = new Set(current.map(i => i.id));
+    const incomingIds = new Set(incoming.map(i => i.id));
+    const added = incoming.some(i => !localIds.has(i.id));
+    const removed = current.some(i => !incomingIds.has(i.id));
+    if (added || removed || current.length === 0) {
+      localDndItems = incoming;
+    } else {
+      const incomingById = new Map(incoming.map(i => [i.id, i]));
+      localDndItems = current.map(item => incomingById.get(item.id) ?? item);
+    }
+  });
 
   function handleDndConsider(e: CustomEvent<{ items: typeof localDndItems }>) {
     localDndItems = e.detail.items;
@@ -132,7 +126,6 @@
 
   function handleDndFinalize(e: CustomEvent<{ items: typeof localDndItems }>) {
     localDndItems = e.detail.items;
-    userHasDragged = true;
     // Server requires the full set of repo paths (grouped + ungrouped).
     // Keep grouped repos in their current order, then append the new ungrouped order.
     const groupedPaths = sessionState.repos.filter(r => groupedRepoPaths.has(r.path)).map(r => r.path);
@@ -256,15 +249,23 @@
               !activeWorktreePaths.has(wt.path)
             )}
             {@const groupedByPath = (() => {
-              const groups = new Map<string, typeof activeSessions>();
-              groups.set(workspace.path, []);
+              const unsorted = new Map<string, typeof activeSessions>();
+              unsorted.set(workspace.path, []);
               for (const s of activeSessions) {
                 const groupKey = s.worktreePath ?? s.repoPath;
-                const existing = groups.get(groupKey);
+                const existing = unsorted.get(groupKey);
                 if (existing) existing.push(s);
-                else groups.set(groupKey, [s]);
+                else unsorted.set(groupKey, [s]);
               }
-              return groups;
+              // Stable sort: repo root first, then worktrees alphabetically
+              const sorted = new Map<string, typeof activeSessions>();
+              const rootSessions = unsorted.get(workspace.path);
+              if (rootSessions) sorted.set(workspace.path, rootSessions);
+              const worktreeKeys = [...unsorted.keys()]
+                .filter(k => k !== workspace.path)
+                .sort();
+              for (const k of worktreeKeys) sorted.set(k, unsorted.get(k)!);
+              return sorted;
             })()}
             <div>
               <WorkspaceItem

--- a/frontend/src/components/WorkspaceItem.svelte
+++ b/frontend/src/components/WorkspaceItem.svelte
@@ -333,7 +333,7 @@
                 <span class="session-count-badge">{sessionCount}</span>
               {/if}
               {#if matchedPr}
-                <span class="sidebar-pr-status" title="PR #{matchedPr.number}: {derivePrDotStatus(matchedPr)}">
+                <span class="sidebar-pr-status" title="PR #{matchedPr.number}: {matchedPr.title}">
                   <PrGlyph status={derivePrDotStatus(matchedPr)} />
                   {#if matchedPr.ciStatus === 'SUCCESS'}<span class="ci-pass">✓</span>
                   {:else if matchedPr.ciStatus === 'FAILURE' || matchedPr.ciStatus === 'ERROR'}<span class="ci-fail">✕</span>

--- a/frontend/src/components/WorkspaceItem.svelte
+++ b/frontend/src/components/WorkspaceItem.svelte
@@ -11,6 +11,7 @@
   import ContextMenu from './ContextMenu.svelte';
   import type { MenuItem } from './ContextMenu.svelte';
   import CipherText from './CipherText.svelte';
+  import MarqueeText from './MarqueeText.svelte';
   import SessionIndicator from './SessionIndicator.svelte';
 
   const sessionState = getSessionState();
@@ -191,7 +192,7 @@
   }
 
   function findPrForBranch(branchName: string): PullRequest | undefined {
-    return orgPrs?.find(pr => pr.headRefName === branchName && pr.state === 'OPEN' && pr.repoPath === workspace.path);
+    return orgPrs?.find(pr => pr.headRefName === branchName && pr.repoPath === workspace.path);
   }
 
   async function handleRename(session: SessionSummary) {
@@ -277,7 +278,7 @@
         onclick={(e) => { e.stopPropagation(); toggleWorkspaceCollapse(workspace.path); }}
       >{collapsed ? '›' : '⌄'}</span>
       <span class="initial-block" style:background={initialColor}>{initial}</span>
-      <span class="workspace-name">{workspace.name}</span>
+      <span class="workspace-name"><MarqueeText>{workspace.name}</MarqueeText></span>
       {#if collapsed}
         {@const pips = summaryPips}
         {#if pips.length > 0}
@@ -325,12 +326,14 @@
           >
             <div class="session-row-primary">
               <SessionIndicator state={sidebarItemById.get(groupPath)?.displayState ?? 'inactive'} />
-              <span class="session-name" class:bold={itemIsUnread || itemHasAttention(groupPath)}>{groupDisplayName(groupPath, groupSessions)}</span>
+              <span class="session-name" class:bold={itemIsUnread || itemHasAttention(groupPath)}>
+                <MarqueeText>{groupDisplayName(groupPath, groupSessions)}</MarqueeText>
+              </span>
               {#if sessionCount > 1}
                 <span class="session-count-badge">{sessionCount}</span>
               {/if}
               {#if matchedPr}
-                <span class="sidebar-pr-status">
+                <span class="sidebar-pr-status" title="PR #{matchedPr.number}: {derivePrDotStatus(matchedPr)}">
                   <PrGlyph status={derivePrDotStatus(matchedPr)} />
                   {#if matchedPr.ciStatus === 'SUCCESS'}<span class="ci-pass">✓</span>
                   {:else if matchedPr.ciStatus === 'FAILURE' || matchedPr.ciStatus === 'ERROR'}<span class="ci-fail">✕</span>
@@ -342,7 +345,9 @@
             <div class="session-row-secondary">
               <span class="secondary-time">{sessionTime(representative)}</span>
               {#if representative.branchName}
-                <span class="secondary-branch"><CipherText text={representative.branchName} /></span>
+                <span class="secondary-branch">
+                  <MarqueeText><CipherText text={representative.branchName} /></MarqueeText>
+                </span>
               {/if}
             </div>
             <div class="row-menu-overlay">
@@ -415,12 +420,16 @@
         >
           <div class="session-row-primary">
             <SessionIndicator state="inactive" />
-            <span class="session-name">{isItemLoading(wt.path) ? 'resuming...' : wt.branchName || wt.displayName || wt.name}</span>
+            <span class="session-name">
+              <MarqueeText>{isItemLoading(wt.path) ? 'resuming...' : wt.branchName || wt.displayName || wt.name}</MarqueeText>
+            </span>
           </div>
           <div class="session-row-secondary">
             <span class="secondary-time">{worktreeTime(wt)}</span>
             {#if wt.branchName}
-              <span class="secondary-branch"><CipherText text={wt.branchName} /></span>
+              <span class="secondary-branch">
+                <MarqueeText><CipherText text={wt.branchName} /></MarqueeText>
+              </span>
             {/if}
           </div>
           <div class="row-menu-overlay">
@@ -534,9 +543,7 @@
     font-weight: 700;
     color: var(--text);
     font-family: var(--font-mono);
-    white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis;
     min-width: 0;
   }
 
@@ -583,7 +590,7 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
-    padding: 8px 8px 8px 36px;
+    padding: 8px 8px 8px 14px;
     cursor: pointer;
     min-height: 44px;
     font-size: var(--font-size-xs);
@@ -622,16 +629,14 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    padding-left: 16px;
+    padding-left: 15px;
     font-size: var(--font-size-xs);
     color: var(--text-muted);
     min-width: 0;
   }
 
   .secondary-branch {
-    white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis;
     min-width: 0;
   }
 
@@ -716,7 +721,6 @@
     flex: 1;
     overflow: hidden;
     white-space: nowrap;
-    text-overflow: ellipsis;
     min-width: 0;
   }
 
@@ -726,7 +730,7 @@
 
   /* Add worktree row */
   .add-worktree-row {
-    padding: 4px 8px 8px 36px;
+    padding: 4px 8px 8px 14px;
   }
 
   .add-worktree-btn {


### PR DESCRIPTION
## Summary

Fixes 5 sidebar UX issues reported from visual inspection:

- **Indentation** — session row padding reduced from 36px to 14px so status dots align with workspace chevrons instead of being pushed far right
- **Text overflow** — replaced CSS `text-overflow: ellipsis` with `MarqueeText` component (Spotify-style scroll-on-hover with fade gradient) on session names, branch names, and workspace names per DESIGN.md spec
- **Timestamp alignment** — secondary row padding fixed from 16px to 15px to match primary row's dot(7px) + gap(8px) = 15px offset
- **PR icons** — removed `state === 'OPEN'` filter from `findPrForBranch` so merged/closed PRs can display; added title tooltip for context
- **Workspace reordering** — removed `workspaceAttentionScore` sorting that overrode user drag-and-drop order; workspaces now always respect config ordering. Fixed DnD sync `$effect` with `untrack()` to prevent Svelte reactive circular dependency
- **Session group ordering** — sorted worktree groups alphabetically within workspaces so session rows don't jump around on poll refreshes

## Pre-Landing Review

No issues found. (Ran `/review` in-session, caught and fixed `$effect` circular dependency with `untrack()` before commit.)

## Test plan
- [x] All tests pass (682 tests, 0 failures)
- [x] Build passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)