### PR TITLE
feat: add session telemetry

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -7,8 +7,8 @@
   import { initNotifications, initPushNotifications, resubscribeIfNeeded } from './lib/notifications.js';
   import { getConfigState } from './lib/state/config.svelte.js';
   import { isMobileDevice, isMac, estimateTerminalDimensions } from './lib/utils.js';
-  import type { WorktreeInfo, Repo, PullRequest } from './lib/types.js';
-  import { createWorktree, createSession, fetchWorkspaceSettings, killSession, deleteWorktree, setDefaultYolo, renameSession as renameSessionApi, launchWorkspaceSession, fetchTelemetrySessions, fetchTelemetryAccount } from './lib/api.js';
+  import type { AccountTelemetry, SessionTelemetry, WorktreeInfo, Repo, PullRequest } from './lib/types.js';
+  import { createWorktree, createSession, fetchWorkspaceSettings, killSession, deleteWorktree, setDefaultYolo, renameSession as renameSessionApi, launchWorkspaceSession } from './lib/api.js';
   import { derivePrAction, buildPrStateInput, getActionPrompt } from './lib/pr-state.js';
   import { initAnalytics, destroyAnalytics, track } from './lib/analytics.js';
   import { registerGlobal, getAllActions } from './lib/actions/registry.svelte.js';
@@ -54,7 +54,7 @@
   import FileViewerPane from './components/FileViewerPane.svelte';
   import SplitPaneLayout from './components/SplitPaneLayout.svelte';
   import { openFileTab, toggleRightSidebarCollapsed } from './lib/state/ui.svelte.js';
-  import { handleTelemetryEvent, hydrateTelemetry } from './lib/state/telemetry.svelte.js';
+  import { refreshTelemetry, handleSessionTelemetryEvent, handleAccountTelemetryEvent } from './lib/state/telemetry.svelte.js';
 
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -469,15 +469,8 @@
         bootRefreshDone = true;
         reportFetch('auth', 'ok');
       }
-      refreshAll(isInitialBoot ? reportFetch : undefined).then(() => {
-        Promise.all([
-          fetchTelemetrySessions(),
-          fetchTelemetryAccount(),
-        ]).then(([sessionsTelemetry, account]) => {
-          hydrateTelemetry(sessionsTelemetry, account);
-        }).catch(() => {
-          hydrateTelemetry({}, null);
-        });
+      refreshAll(isInitialBoot ? reportFetch : undefined).then(async () => {
+        await refreshTelemetry();
 
         if (isInitialBoot) finishBoot();
         const params = new URLSearchParams(window.location.search);
@@ -528,43 +521,51 @@
       }, 500);
     }
 
-    connectEventSocket((msg) => {
-      handleTelemetryEvent(msg);
-      if (msg.type === 'worktrees-changed') {
-        refreshAll();
-      } else if (msg.type === 'session-backend-state-changed' && msg.sessionId && msg.state) {
-        handleBackendStateChanged(msg.sessionId, msg.state, msg.permissionType);
-      } else if (msg.type === 'session-renamed' && msg.sessionId) {
-        renameSession(msg.sessionId, msg.branchName ?? '', msg.displayName ?? '');
-        // Branch changed — old PR data is stale
-        invalidatePrQueries();
-      } else if (msg.type === 'session-branch-changed' && msg.sessionId) {
-        handleBranchChanged(msg.sessionId, msg.branch ?? '');
-      } else if (msg.type === 'session-ended') {
-        invalidatePrQueries();
-        refreshAll();
-      } else if (msg.type === 'ref-changed' && msg.cwdPath) {
-        const key = msg.cwdPath;
-        const existing = refChangedTimers.get(key);
-        if (existing) clearTimeout(existing);
-        refChangedTimers.set(key, setTimeout(() => {
-          refChangedTimers.delete(key);
+    connectEventSocket(
+      (msg) => {
+        if (msg.type === 'worktrees-changed') {
+          refreshAll();
+        } else if (msg.type === 'session-backend-state-changed' && msg.sessionId && msg.state) {
+          handleBackendStateChanged(msg.sessionId, msg.state, msg.permissionType);
+        } else if (msg.type === 'session-renamed' && msg.sessionId) {
+          renameSession(msg.sessionId, msg.branchName ?? '', msg.displayName ?? '');
+          // Branch changed — old PR data is stale
           invalidatePrQueries();
-        }, 5000));
-      } else if (msg.type === 'pr-updated' || msg.type === 'ci-updated') {
-        throttledPollInvalidate();
-      } else if (msg.type === 'files-changed') {
-        const activeWs = activeSession?.cwd ?? activeSession?.repoPath;
-        if (!msg.workspacePath || activeWs === msg.workspacePath) {
-          throttledChangedFilesRefresh();
-          if (msg.changedFiles) {
-            changedFilesData = msg.changedFiles;
+        } else if (msg.type === 'session-branch-changed' && msg.sessionId) {
+          handleBranchChanged(msg.sessionId, msg.branch ?? '');
+        } else if (msg.type === 'session-ended') {
+          invalidatePrQueries();
+          refreshAll();
+        } else if (msg.type === 'ref-changed' && msg.cwdPath) {
+          const key = msg.cwdPath;
+          const existing = refChangedTimers.get(key);
+          if (existing) clearTimeout(existing);
+          refChangedTimers.set(key, setTimeout(() => {
+            refChangedTimers.delete(key);
+            invalidatePrQueries();
+          }, 5000));
+        } else if (msg.type === 'pr-updated' || msg.type === 'ci-updated') {
+          throttledPollInvalidate();
+        } else if (msg.type === 'files-changed') {
+          const activeWs = activeSession?.cwd ?? activeSession?.repoPath;
+          if (!msg.workspacePath || activeWs === msg.workspacePath) {
+            throttledChangedFilesRefresh();
+            if (msg.changedFiles) {
+              changedFilesData = msg.changedFiles;
+            }
           }
+        } else if (msg.type === 'session-activity-changed' && msg.sessionId) {
+          handleActivityChanged(msg.sessionId, msg.timestamp, msg.currentActivity ?? undefined);
+        } else if (msg.type === 'session-telemetry' && msg.sessionId && msg.data) {
+          handleSessionTelemetryEvent(msg.sessionId, msg.data as SessionTelemetry | Record<string, unknown>);
+        } else if (msg.type === 'account-telemetry' && msg.data) {
+          handleAccountTelemetryEvent(msg.data as AccountTelemetry | Record<string, unknown> | null);
         }
-      } else if (msg.type === 'session-activity-changed' && msg.sessionId) {
-        handleActivityChanged(msg.sessionId, msg.timestamp);
-      }
-    });
+      },
+      () => {
+        void refreshTelemetry();
+      },
+    );
 
     return () => {
       for (const timer of refChangedTimers.values()) clearTimeout(timer);
@@ -1188,7 +1189,10 @@
             />
 
             {#if sessionState.activeSessionId}
-              <SessionStatusBar sessionId={sessionState.activeSessionId} />
+              <SessionStatusBar
+                sessionId={sessionState.activeSessionId}
+                currentActivity={activeSession?.currentActivity ?? null}
+              />
             {/if}
 
             <Toolbar

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -8,7 +8,7 @@
   import { getConfigState } from './lib/state/config.svelte.js';
   import { isMobileDevice, isMac, estimateTerminalDimensions } from './lib/utils.js';
   import type { WorktreeInfo, Repo, PullRequest } from './lib/types.js';
-  import { createWorktree, createSession, fetchWorkspaceSettings, killSession, deleteWorktree, setDefaultYolo, renameSession as renameSessionApi, launchWorkspaceSession } from './lib/api.js';
+  import { createWorktree, createSession, fetchWorkspaceSettings, killSession, deleteWorktree, setDefaultYolo, renameSession as renameSessionApi, launchWorkspaceSession, fetchTelemetrySessions, fetchTelemetryAccount } from './lib/api.js';
   import { derivePrAction, buildPrStateInput, getActionPrompt } from './lib/pr-state.js';
   import { initAnalytics, destroyAnalytics, track } from './lib/analytics.js';
   import { registerGlobal, getAllActions } from './lib/actions/registry.svelte.js';
@@ -34,6 +34,7 @@
   import EmptyState from './components/EmptyState.svelte';
   import Toolbar from './components/Toolbar.svelte';
   import MobileHeader from './components/MobileHeader.svelte';
+  import SessionStatusBar from './components/SessionStatusBar.svelte';
   import UpdateToast from './components/UpdateToast.svelte';
   import ImageToast from './components/ImageToast.svelte';
   import ErrorToast from './components/ErrorToast.svelte';
@@ -53,6 +54,7 @@
   import FileViewerPane from './components/FileViewerPane.svelte';
   import SplitPaneLayout from './components/SplitPaneLayout.svelte';
   import { openFileTab, toggleRightSidebarCollapsed } from './lib/state/ui.svelte.js';
+  import { handleTelemetryEvent, hydrateTelemetry } from './lib/state/telemetry.svelte.js';
 
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -128,7 +130,6 @@
   let workspaceSettingsDialogRef = $state<WorkspaceSettingsDialog | undefined>();
   let mainAppEl = $state<HTMLDivElement | undefined>();
 
-  let keyboardOpen = $state(false);
   let spotlightOpen = $state(false);
   let pickerOpen = $state(false);
 
@@ -295,9 +296,9 @@
 
       const onViewportResize = () => {
         const kbHeight = window.innerHeight - vv.height;
-        keyboardOpen = kbHeight > 50;
+        ui.keyboardOpen = kbHeight > 50;
         if (mainAppEl) {
-          mainAppEl.style.height = keyboardOpen ? vv.height + 'px' : '';
+          mainAppEl.style.height = ui.keyboardOpen ? vv.height + 'px' : '';
         }
         window.scrollTo(0, 0);
         if (fitTimer) clearTimeout(fitTimer);
@@ -469,6 +470,15 @@
         reportFetch('auth', 'ok');
       }
       refreshAll(isInitialBoot ? reportFetch : undefined).then(() => {
+        Promise.all([
+          fetchTelemetrySessions(),
+          fetchTelemetryAccount(),
+        ]).then(([sessionsTelemetry, account]) => {
+          hydrateTelemetry(sessionsTelemetry, account);
+        }).catch(() => {
+          hydrateTelemetry({}, null);
+        });
+
         if (isInitialBoot) finishBoot();
         const params = new URLSearchParams(window.location.search);
         const sessionParam = params.get('session');
@@ -519,6 +529,7 @@
     }
 
     connectEventSocket((msg) => {
+      handleTelemetryEvent(msg);
       if (msg.type === 'worktrees-changed') {
         refreshAll();
       } else if (msg.type === 'session-backend-state-changed' && msg.sessionId && msg.state) {
@@ -1119,7 +1130,7 @@
         title={sessionTitle}
         onMenuClick={openSidebar}
         onCommandClick={() => { spotlightOpen = true; }}
-        hidden={keyboardOpen}
+        hidden={ui.keyboardOpen}
       />
 
       {#if viewMode === 'empty'}
@@ -1175,6 +1186,10 @@
               useTmux={activeSessionUseTmux}
               onCopyModeChange={handleCopyModeChange}
             />
+
+            {#if sessionState.activeSessionId}
+              <SessionStatusBar sessionId={sessionState.activeSessionId} />
+            {/if}
 
             <Toolbar
               onSendKey={handleSendKey}

--- a/frontend/src/components/OrgDashboard.svelte
+++ b/frontend/src/components/OrgDashboard.svelte
@@ -6,6 +6,8 @@
   import type { AnyIssue, PullRequest, OrgPrsResponse, BranchLinksResponse, FilterPreset } from '../lib/types.js';
   import { deriveColor } from '../lib/colors.js';
   import { derivePrDotStatus } from '../lib/pr-status.js';
+  import { getSessionState } from '../lib/state/sessions.svelte.js';
+  import { getTelemetryState } from '../lib/state/telemetry.svelte.js';
   import DataTable from './DataTable.svelte';
   import type { Column } from './DataTable.svelte';
   import FilterChipBar from './FilterChipBar.svelte';
@@ -22,6 +24,8 @@
   } = $props();
 
   const queryClient = useQueryClient();
+  const sessionState = getSessionState();
+  const telemetry = getTelemetryState();
 
   let activeTab = $state<'prs' | 'tickets'>('prs');
   let startWorkIssue = $state<AnyIssue | null>(null);
@@ -231,6 +235,40 @@
       console.error('Failed to delete preset:', e);
     }
   }
+
+  function formatTokens(value: number): string {
+    if (!Number.isFinite(value) || value <= 0) return '0';
+    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}m`;
+    if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+    return String(Math.round(value));
+  }
+
+  let usageByRepo = $derived.by(() => {
+    const rows = new Map<string, { repoPath: string; repoName: string; total: number; input: number; output: number }>();
+
+    for (const session of sessionState.sessions) {
+      const entry = telemetry.sessionTelemetry.get(session.id);
+      if (!entry) continue;
+      const current = rows.get(session.repoPath) ?? {
+        repoPath: session.repoPath,
+        repoName: session.repoName,
+        total: 0,
+        input: 0,
+        output: 0,
+      };
+      current.total += entry.totalInputTokens + entry.totalOutputTokens;
+      current.input += entry.totalInputTokens;
+      current.output += entry.totalOutputTokens;
+      rows.set(session.repoPath, current);
+    }
+
+    const list = [...rows.values()].sort((a, b) => b.total - a.total);
+    const grandTotal = list.reduce((sum, row) => sum + row.total, 0);
+    return list.map((row) => ({
+      ...row,
+      percent: grandTotal > 0 ? (row.total / grandTotal) * 100 : 0,
+    }));
+  });
 </script>
 
 <div class="org-dashboard">
@@ -242,6 +280,23 @@
       </span>
     {/if}
   </div>
+
+  <section class="usage-section">
+    <div class="usage-heading">usage by repo</div>
+    {#if usageByRepo.length === 0}
+      <div class="state-message">no telemetry data available</div>
+    {:else}
+      <div class="usage-list">
+        {#each usageByRepo as usage (usage.repoPath)}
+          <button class="usage-item" onclick={() => onOpenWorkspace(usage.repoPath)}>
+            <span class="usage-name">{usage.repoName}</span>
+            <div class="usage-bar"><div class="usage-fill" style:width={`${usage.percent}%`}></div></div>
+            <span class="usage-value">↓{formatTokens(usage.input)} ↑{formatTokens(usage.output)}</span>
+          </button>
+        {/each}
+      </div>
+    {/if}
+  </section>
 
   <!-- Tab strip -->
   <div class="tab-strip">
@@ -539,6 +594,59 @@
     color: var(--accent);
     margin-left: 4px;
     opacity: 0.8;
+  }
+
+  .usage-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+
+  .usage-heading {
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    color: var(--text-muted);
+    letter-spacing: 0.08em;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .usage-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .usage-item {
+    display: grid;
+    grid-template-columns: 140px 1fr auto;
+    gap: 8px;
+    align-items: center;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--text);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    padding: 6px 8px;
+    cursor: pointer;
+  }
+
+  .usage-name,
+  .usage-value {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .usage-bar {
+    height: 8px;
+    border: 1px solid var(--border);
+  }
+
+  .usage-fill {
+    height: 100%;
+    background: var(--accent);
   }
 
   /* -- State messages (gh errors) -- */

--- a/frontend/src/components/OrgDashboard.svelte
+++ b/frontend/src/components/OrgDashboard.svelte
@@ -6,8 +6,6 @@
   import type { AnyIssue, PullRequest, OrgPrsResponse, BranchLinksResponse, FilterPreset } from '../lib/types.js';
   import { deriveColor } from '../lib/colors.js';
   import { derivePrDotStatus } from '../lib/pr-status.js';
-  import { getSessionState } from '../lib/state/sessions.svelte.js';
-  import { getTelemetryState } from '../lib/state/telemetry.svelte.js';
   import DataTable from './DataTable.svelte';
   import type { Column } from './DataTable.svelte';
   import FilterChipBar from './FilterChipBar.svelte';
@@ -24,8 +22,6 @@
   } = $props();
 
   const queryClient = useQueryClient();
-  const sessionState = getSessionState();
-  const telemetry = getTelemetryState();
 
   let activeTab = $state<'prs' | 'tickets'>('prs');
   let startWorkIssue = $state<AnyIssue | null>(null);
@@ -235,40 +231,6 @@
       console.error('Failed to delete preset:', e);
     }
   }
-
-  function formatTokens(value: number): string {
-    if (!Number.isFinite(value) || value <= 0) return '0';
-    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}m`;
-    if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
-    return String(Math.round(value));
-  }
-
-  let usageByRepo = $derived.by(() => {
-    const rows = new Map<string, { repoPath: string; repoName: string; total: number; input: number; output: number }>();
-
-    for (const session of sessionState.sessions) {
-      const entry = telemetry.sessionTelemetry.get(session.id);
-      if (!entry) continue;
-      const current = rows.get(session.repoPath) ?? {
-        repoPath: session.repoPath,
-        repoName: session.repoName,
-        total: 0,
-        input: 0,
-        output: 0,
-      };
-      current.total += entry.totalInputTokens + entry.totalOutputTokens;
-      current.input += entry.totalInputTokens;
-      current.output += entry.totalOutputTokens;
-      rows.set(session.repoPath, current);
-    }
-
-    const list = [...rows.values()].sort((a, b) => b.total - a.total);
-    const grandTotal = list.reduce((sum, row) => sum + row.total, 0);
-    return list.map((row) => ({
-      ...row,
-      percent: grandTotal > 0 ? (row.total / grandTotal) * 100 : 0,
-    }));
-  });
 </script>
 
 <div class="org-dashboard">
@@ -280,23 +242,6 @@
       </span>
     {/if}
   </div>
-
-  <section class="usage-section">
-    <div class="usage-heading">usage by repo</div>
-    {#if usageByRepo.length === 0}
-      <div class="state-message">no telemetry data available</div>
-    {:else}
-      <div class="usage-list">
-        {#each usageByRepo as usage (usage.repoPath)}
-          <button class="usage-item" onclick={() => onOpenWorkspace(usage.repoPath)}>
-            <span class="usage-name">{usage.repoName}</span>
-            <div class="usage-bar"><div class="usage-fill" style:width={`${usage.percent}%`}></div></div>
-            <span class="usage-value">↓{formatTokens(usage.input)} ↑{formatTokens(usage.output)}</span>
-          </button>
-        {/each}
-      </div>
-    {/if}
-  </section>
 
   <!-- Tab strip -->
   <div class="tab-strip">
@@ -594,59 +539,6 @@
     color: var(--accent);
     margin-left: 4px;
     opacity: 0.8;
-  }
-
-  .usage-section {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    margin-bottom: 8px;
-  }
-
-  .usage-heading {
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
-    color: var(--text-muted);
-    letter-spacing: 0.08em;
-    padding-bottom: 6px;
-    border-bottom: 1px solid var(--border);
-  }
-
-  .usage-list {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
-
-  .usage-item {
-    display: grid;
-    grid-template-columns: 140px 1fr auto;
-    gap: 8px;
-    align-items: center;
-    border: 1px solid var(--border);
-    background: transparent;
-    color: var(--text);
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
-    padding: 6px 8px;
-    cursor: pointer;
-  }
-
-  .usage-name,
-  .usage-value {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .usage-bar {
-    height: 8px;
-    border: 1px solid var(--border);
-  }
-
-  .usage-fill {
-    height: 100%;
-    background: var(--accent);
   }
 
   /* -- State messages (gh errors) -- */

--- a/frontend/src/components/PrTopBar.svelte
+++ b/frontend/src/components/PrTopBar.svelte
@@ -207,12 +207,7 @@
   }
 </script>
 
-<div
-  class="pr-top-bar"
-  class:bar-merged={pr?.state === 'MERGED'}
-  class:bar-conflicts={pr?.mergeable === 'CONFLICTING'}
-  style:display={ui.keyboardOpen ? 'none' : undefined}
->
+<div class="pr-top-bar" hidden={ui.keyboardOpen} class:bar-merged={pr?.state === 'MERGED'} class:bar-conflicts={pr?.mergeable === 'CONFLICTING'}>
   <!-- Left section: branch switcher + target branch -->
   <div class="bar-left">
     {#if renaming}

--- a/frontend/src/components/PrTopBar.svelte
+++ b/frontend/src/components/PrTopBar.svelte
@@ -207,7 +207,12 @@
   }
 </script>
 
-<div class="pr-top-bar" class:bar-merged={pr?.state === 'MERGED'} class:bar-conflicts={pr?.mergeable === 'CONFLICTING'}>
+<div
+  class="pr-top-bar"
+  class:bar-merged={pr?.state === 'MERGED'}
+  class:bar-conflicts={pr?.mergeable === 'CONFLICTING'}
+  style:display={ui.keyboardOpen ? 'none' : undefined}
+>
   <!-- Left section: branch switcher + target branch -->
   <div class="bar-left">
     {#if renaming}

--- a/frontend/src/components/RepoDashboard.svelte
+++ b/frontend/src/components/RepoDashboard.svelte
@@ -5,11 +5,12 @@
   import { formatRelativeTime } from '../lib/utils.js';
   import type { PullRequest, ActivityEntry, DashboardData } from '../lib/types.js';
   import { getSessionState } from '../lib/state/sessions.svelte.js';
-  import { getTelemetryState } from '../lib/state/telemetry.svelte.js';
+  import { getTelemetryState, summarizeSessionSetTelemetry } from '../lib/state/telemetry.svelte.js';
   import DataTable from './DataTable.svelte';
   import type { Column } from './DataTable.svelte';
   import StatusDot from './StatusDot.svelte';
   import TuiButton from './TuiButton.svelte';
+  import TuiProgress from './TuiProgress.svelte';
   import { derivePrDotStatus } from '../lib/pr-status.js';
 
   let {
@@ -32,6 +33,9 @@
     onOpenPrSession: (pr: PullRequest) => void;
   } = $props();
 
+  const sessionState = getSessionState();
+  const telemetryState = getTelemetryState();
+
   const dashQuery = createQuery<DashboardData>(() => ({
     queryKey: ['dashboard', repoPath],
     queryFn: () => fetchDashboard(repoPath),
@@ -42,8 +46,9 @@
   let data = $derived(dashQuery.data);
   let isLoading = $derived(dashQuery.isLoading);
   let isError = $derived(dashQuery.isError);
-  const sessionState = getSessionState();
-  const telemetry = getTelemetryState();
+  let repoSessions = $derived(sessionState.sessions.filter((session) => session.repoPath === repoPath));
+  let repoTelemetry = $derived(summarizeSessionSetTelemetry(repoSessions));
+  let accountTelemetry = $derived(telemetryState.accountTelemetry);
 
   const prColumns: Column[] = [
     { key: 'status', label: 'St', sortable: false, width: '36px' },
@@ -65,6 +70,39 @@
     if (!entry.branches || entry.branches.length === 0) return '';
     return '(' + entry.branches.join(', ') + ')';
   }
+
+  function compactCount(value: number): string {
+    if (value < 1000) return String(Math.round(value));
+    if (value < 1_000_000) return `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)}k`;
+    return `${(value / 1_000_000).toFixed(value >= 10_000_000 ? 0 : 1)}M`;
+  }
+
+  function formatResetAt(value: string | null | undefined): string {
+    if (!value) return '—';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '—';
+    const now = new Date();
+    const sameDay =
+      date.getFullYear() === now.getFullYear() &&
+      date.getMonth() === now.getMonth() &&
+      date.getDate() === now.getDate();
+    if (sameDay) {
+      return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+    }
+    return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  }
+
+  let sessionCoveragePercent = $derived(
+    repoTelemetry.totalSessions > 0
+      ? Math.round((repoTelemetry.trackedSessions / repoTelemetry.totalSessions) * 100)
+      : 0
+  );
+
+  let contextPercent = $derived(
+    repoTelemetry.averageContextPercent !== null
+      ? Math.max(0, Math.min(100, Math.round(repoTelemetry.averageContextPercent)))
+      : -1
+  );
 
   let searchQuery = $state('');
   let sortBy = $state('age');
@@ -92,27 +130,6 @@
     });
     return prs;
   });
-
-  function formatTokens(value: number): string {
-    if (!Number.isFinite(value) || value <= 0) return '0';
-    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}m`;
-    if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
-    return String(Math.round(value));
-  }
-
-  let repoUsage = $derived.by(() => {
-    const tracked = sessionState.sessions
-      .filter((session) => session.repoPath === repoPath)
-      .map((session) => telemetry.sessionTelemetry.get(session.id))
-      .filter((entry): entry is NonNullable<typeof entry> => !!entry);
-
-    return tracked.reduce((totals, entry) => ({
-      sessions: totals.sessions + 1,
-      input: totals.input + entry.totalInputTokens,
-      output: totals.output + entry.totalOutputTokens,
-      cache: totals.cache + entry.totalCacheRead + entry.totalCacheWrite,
-    }), { sessions: 0, input: 0, output: 0, cache: 0 });
-  });
 </script>
 
 <div class="repo-dashboard">
@@ -123,31 +140,69 @@
     </div>
   {:else}
     <section class="dashboard-section">
-      <div class="section-heading">usage</div>
-      {#if repoUsage.sessions === 0}
-        <div class="section-message">no telemetry data available</div>
-      {:else}
-        <div class="usage-grid">
-          <div class="usage-row"><span>sessions tracked</span><span>{repoUsage.sessions}</span></div>
-          <div class="usage-row"><span>tokens</span><span>↓{formatTokens(repoUsage.input)} ↑{formatTokens(repoUsage.output)}</span></div>
-          <div class="usage-row"><span>cache</span><span>{formatTokens(repoUsage.cache)}</span></div>
+      <div class="section-heading">usage this window</div>
+      <div class="usage-panel">
+        <div class="usage-row">
+          <span class="usage-label">sessions tracked</span>
+          <span class="usage-bar">
+            <TuiProgress variant="bar" value={sessionCoveragePercent} width={14} />
+          </span>
+          <span class="usage-value">
+            {repoTelemetry.trackedSessions} of {repoTelemetry.totalSessions}
+            {#if repoTelemetry.totalSessions > repoTelemetry.trackedSessions}
+              ({repoTelemetry.totalSessions - repoTelemetry.trackedSessions} outside relay)
+            {/if}
+          </span>
         </div>
-      {/if}
 
-      {#if telemetry.accountTelemetry}
-        <div class="rate-limit-list">
-          <div class="rate-limit-row">
-            <span>5-hour</span>
-            <div class="rate-limit-bar"><div class="rate-limit-fill" style:width={`${Math.max(0, telemetry.accountTelemetry.fiveHourUsedPercent)}%`}></div></div>
-            <span>{Math.round(telemetry.accountTelemetry.fiveHourUsedPercent)}%</span>
-          </div>
-          <div class="rate-limit-row">
-            <span>7-day</span>
-            <div class="rate-limit-bar"><div class="rate-limit-fill" style:width={`${Math.max(0, telemetry.accountTelemetry.sevenDayUsedPercent)}%`}></div></div>
-            <span>{Math.round(telemetry.accountTelemetry.sevenDayUsedPercent)}%</span>
-          </div>
+        <div class="usage-row">
+          <span class="usage-label">relay tokens</span>
+          <span class="usage-value">
+            ↓{compactCount(repoTelemetry.totalInputTokens)} ↑{compactCount(repoTelemetry.totalOutputTokens)}
+          </span>
+          <span class="usage-meta">
+            cache: {compactCount(repoTelemetry.totalCacheRead)} read
+          </span>
         </div>
-      {/if}
+
+        <div class="usage-row">
+          <span class="usage-label">context pressure</span>
+          <span class="usage-bar">
+            <TuiProgress variant="bar" value={contextPercent >= 0 ? contextPercent : 0} width={14} />
+          </span>
+          <span class="usage-value">
+            {repoTelemetry.averageContextPercent !== null ? `${Math.round(repoTelemetry.averageContextPercent)}% avg` : '—'}
+            {#if repoTelemetry.maxContextPercent !== null}
+              <span class="usage-meta">peak {Math.round(repoTelemetry.maxContextPercent)}%</span>
+            {/if}
+          </span>
+        </div>
+
+        {#if accountTelemetry}
+          <div class="usage-divider"></div>
+          <div class="usage-row">
+            <span class="usage-label">5h limit</span>
+            <span class="usage-bar">
+              <TuiProgress variant="bar" value={Math.max(0, Math.min(100, accountTelemetry.fiveHourUsedPercent >= 0 ? accountTelemetry.fiveHourUsedPercent : 0))} width={14} />
+            </span>
+            <span class="usage-value">
+              {accountTelemetry.fiveHourUsedPercent >= 0 ? `${Math.round(accountTelemetry.fiveHourUsedPercent)}% used` : '—'}
+            </span>
+            <span class="usage-meta">resets {formatResetAt(accountTelemetry.fiveHourResetsAt)}</span>
+          </div>
+
+          <div class="usage-row">
+            <span class="usage-label">7d limit</span>
+            <span class="usage-bar">
+              <TuiProgress variant="bar" value={Math.max(0, Math.min(100, accountTelemetry.sevenDayUsedPercent >= 0 ? accountTelemetry.sevenDayUsedPercent : 0))} width={14} />
+            </span>
+            <span class="usage-value">
+              {accountTelemetry.sevenDayUsedPercent >= 0 ? `${Math.round(accountTelemetry.sevenDayUsedPercent)}% used` : '—'}
+            </span>
+            <span class="usage-meta">resets {formatResetAt(accountTelemetry.sevenDayResetsAt)}</span>
+          </div>
+        {/if}
+      </div>
     </section>
 
     <!-- OPEN PULL REQUESTS section -->
@@ -382,34 +437,6 @@
 
   .section-message.info a:hover {
     text-decoration: underline;
-  }
-
-  .usage-grid,
-  .rate-limit-list {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-    font-family: var(--font-mono);
-    font-size: var(--font-size-xs);
-  }
-
-  .usage-row,
-  .rate-limit-row {
-    display: grid;
-    grid-template-columns: 120px 1fr auto;
-    gap: 8px;
-    align-items: center;
-    color: var(--text);
-  }
-
-  .rate-limit-bar {
-    height: 8px;
-    border: 1px solid var(--border);
-  }
-
-  .rate-limit-fill {
-    height: 100%;
-    background: var(--accent);
   }
 
   /* -- PR cell layout (DataTable row) -- */

--- a/frontend/src/components/RepoDashboard.svelte
+++ b/frontend/src/components/RepoDashboard.svelte
@@ -4,6 +4,8 @@
   import { derivePrAction, buildPrStateInput } from '../lib/pr-state.js';
   import { formatRelativeTime } from '../lib/utils.js';
   import type { PullRequest, ActivityEntry, DashboardData } from '../lib/types.js';
+  import { getSessionState } from '../lib/state/sessions.svelte.js';
+  import { getTelemetryState } from '../lib/state/telemetry.svelte.js';
   import DataTable from './DataTable.svelte';
   import type { Column } from './DataTable.svelte';
   import StatusDot from './StatusDot.svelte';
@@ -40,6 +42,8 @@
   let data = $derived(dashQuery.data);
   let isLoading = $derived(dashQuery.isLoading);
   let isError = $derived(dashQuery.isError);
+  const sessionState = getSessionState();
+  const telemetry = getTelemetryState();
 
   const prColumns: Column[] = [
     { key: 'status', label: 'St', sortable: false, width: '36px' },
@@ -88,6 +92,27 @@
     });
     return prs;
   });
+
+  function formatTokens(value: number): string {
+    if (!Number.isFinite(value) || value <= 0) return '0';
+    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}m`;
+    if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+    return String(Math.round(value));
+  }
+
+  let repoUsage = $derived.by(() => {
+    const tracked = sessionState.sessions
+      .filter((session) => session.repoPath === repoPath)
+      .map((session) => telemetry.sessionTelemetry.get(session.id))
+      .filter((entry): entry is NonNullable<typeof entry> => !!entry);
+
+    return tracked.reduce((totals, entry) => ({
+      sessions: totals.sessions + 1,
+      input: totals.input + entry.totalInputTokens,
+      output: totals.output + entry.totalOutputTokens,
+      cache: totals.cache + entry.totalCacheRead + entry.totalCacheWrite,
+    }), { sessions: 0, input: 0, output: 0, cache: 0 });
+  });
 </script>
 
 <div class="repo-dashboard">
@@ -97,6 +122,34 @@
       <span class="non-git-msg">Not a git repository</span>
     </div>
   {:else}
+    <section class="dashboard-section">
+      <div class="section-heading">usage</div>
+      {#if repoUsage.sessions === 0}
+        <div class="section-message">no telemetry data available</div>
+      {:else}
+        <div class="usage-grid">
+          <div class="usage-row"><span>sessions tracked</span><span>{repoUsage.sessions}</span></div>
+          <div class="usage-row"><span>tokens</span><span>↓{formatTokens(repoUsage.input)} ↑{formatTokens(repoUsage.output)}</span></div>
+          <div class="usage-row"><span>cache</span><span>{formatTokens(repoUsage.cache)}</span></div>
+        </div>
+      {/if}
+
+      {#if telemetry.accountTelemetry}
+        <div class="rate-limit-list">
+          <div class="rate-limit-row">
+            <span>5-hour</span>
+            <div class="rate-limit-bar"><div class="rate-limit-fill" style:width={`${Math.max(0, telemetry.accountTelemetry.fiveHourUsedPercent)}%`}></div></div>
+            <span>{Math.round(telemetry.accountTelemetry.fiveHourUsedPercent)}%</span>
+          </div>
+          <div class="rate-limit-row">
+            <span>7-day</span>
+            <div class="rate-limit-bar"><div class="rate-limit-fill" style:width={`${Math.max(0, telemetry.accountTelemetry.sevenDayUsedPercent)}%`}></div></div>
+            <span>{Math.round(telemetry.accountTelemetry.sevenDayUsedPercent)}%</span>
+          </div>
+        </div>
+      {/if}
+    </section>
+
     <!-- OPEN PULL REQUESTS section -->
     <section class="dashboard-section dashboard-section--scroll">
       <div class="section-heading">open pull requests</div>
@@ -329,6 +382,34 @@
 
   .section-message.info a:hover {
     text-decoration: underline;
+  }
+
+  .usage-grid,
+  .rate-limit-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+  }
+
+  .usage-row,
+  .rate-limit-row {
+    display: grid;
+    grid-template-columns: 120px 1fr auto;
+    gap: 8px;
+    align-items: center;
+    color: var(--text);
+  }
+
+  .rate-limit-bar {
+    height: 8px;
+    border: 1px solid var(--border);
+  }
+
+  .rate-limit-fill {
+    height: 100%;
+    background: var(--accent);
   }
 
   /* -- PR cell layout (DataTable row) -- */

--- a/frontend/src/components/SessionStatusBar.svelte
+++ b/frontend/src/components/SessionStatusBar.svelte
@@ -1,84 +1,121 @@
 <script lang="ts">
-  import { getSessionState } from '../lib/state/sessions.svelte.js';
-  import { getTelemetryState } from '../lib/state/telemetry.svelte.js';
   import { getUi } from '../lib/state/ui.svelte.js';
+  import { getTelemetryState } from '../lib/state/telemetry.svelte.js';
+  import type { CurrentActivity } from '../lib/types.js';
 
-  let { sessionId }: { sessionId: string } = $props();
+  let {
+    sessionId,
+    currentActivity = null,
+  }: {
+    sessionId: string | null;
+    currentActivity?: CurrentActivity | null;
+  } = $props();
 
-  const sessionState = getSessionState();
-  const telemetry = getTelemetryState();
   const ui = getUi();
+  const telemetryState = getTelemetryState();
 
-  const dash = '—';
+  const BAR_WIDTH = 10;
 
-  let session = $derived(sessionState.sessions.find((item) => item.id === sessionId));
-  let sessionTelemetry = $derived(telemetry.sessionTelemetry.get(sessionId));
-  let accountTelemetry = $derived(telemetry.accountTelemetry);
-  let contextPercent = $derived(sessionTelemetry?.contextPercent ?? -1);
-
-  function formatNumber(value: number): string {
-    if (!Number.isFinite(value) || value <= 0) return dash;
-    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}m`;
-    if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
-    return String(Math.round(value));
+  function formatCompact(value: number | null | undefined): string {
+    if (value === null || value === undefined || Number.isNaN(value)) return '—';
+    const abs = Math.abs(value);
+    if (abs < 1000) return String(Math.round(value));
+    if (abs < 1_000_000) return `${(value / 1000).toFixed(abs >= 10_000 ? 0 : 1)}k`;
+    if (abs < 1_000_000_000) return `${(value / 1_000_000).toFixed(abs >= 10_000_000 ? 0 : 1)}M`;
+    return `${(value / 1_000_000_000).toFixed(1)}B`;
   }
 
-  function formatCost(value: number | null | undefined): string {
-    if (value == null || !Number.isFinite(value)) return `~$${dash}`;
+  function formatCurrency(value: number | null | undefined): string {
+    if (value === null || value === undefined || Number.isNaN(value)) return '~$—';
     return `~$${value.toFixed(2)}`;
   }
 
-  function formatTool(): string {
-    if (!session?.currentActivity?.tool) return dash;
-    if (session.currentActivity.detail) return `[${session.currentActivity.tool}: ${session.currentActivity.detail}]`;
-    return `[${session.currentActivity.tool}]`;
+  function formatResetAt(value: string | null | undefined): string {
+    if (!value) return '—';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '—';
+    const now = new Date();
+    const sameDay =
+      date.getFullYear() === now.getFullYear() &&
+      date.getMonth() === now.getMonth() &&
+      date.getDate() === now.getDate();
+    if (sameDay) {
+      return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+    }
+    const sameYear = date.getFullYear() === now.getFullYear();
+    return date.toLocaleDateString([], sameYear ? { month: 'short', day: 'numeric' } : { month: 'short', day: 'numeric', year: '2-digit' });
   }
 
-  function rateLimitLabel(label: 'fiveHour' | 'sevenDay'): string {
-    if (!accountTelemetry) return `${label === 'fiveHour' ? '5h' : '7d'}: ${dash}`;
-    const value = label === 'fiveHour' ? accountTelemetry.fiveHourUsedPercent : accountTelemetry.sevenDayUsedPercent;
-    return `${label === 'fiveHour' ? '5h' : '7d'}: ${value >= 0 ? `${Math.round(value)}%` : dash}`;
+  function barForPercent(value: number): string {
+    const clamped = Math.max(0, Math.min(100, value));
+    const filled = Math.round((clamped / 100) * BAR_WIDTH);
+    return `${'█'.repeat(filled)}${'░'.repeat(BAR_WIDTH - filled)}`;
   }
 
-  function meterColor(percent: number): string {
-    if (percent >= 85) return 'var(--status-error)';
-    if (percent >= 60) return 'var(--status-warning)';
-    return 'var(--text)';
-  }
+  let telemetry = $derived(sessionId ? telemetryState.sessionTelemetryById[sessionId] ?? null : null);
+  let contextTone = $derived(
+    !telemetry || telemetry.contextPercent < 0 ? 'muted'
+    : telemetry.contextPercent >= 85 ? 'danger'
+    : telemetry.contextPercent >= 60 ? 'warning'
+    : 'ok'
+  );
 
-  function modelLabel(): string {
-    if (!sessionTelemetry?.model) return dash;
-    return sessionTelemetry.model.replace(/^Claude\s+/i, '');
-  }
+  let contextLabel = $derived(
+    telemetry && telemetry.contextPercent >= 0
+      ? `${barForPercent(telemetry.contextPercent)} ${Math.round(telemetry.contextPercent)}%`
+      : `${'░'.repeat(BAR_WIDTH)} —%`
+  );
+
+  let activityLabel = $derived(
+    currentActivity
+      ? `${currentActivity.tool}${currentActivity.detail ? `: ${currentActivity.detail}` : ''}`
+      : 'idle'
+  );
+
+  let rateLimitLabel = $derived.by(() => {
+    const accountTelemetry = telemetryState.accountTelemetry;
+    if (!accountTelemetry) return '—';
+
+    const parts: string[] = [];
+    if (accountTelemetry.fiveHourUsedPercent >= 0) {
+      parts.push(`5h: ${Math.round(accountTelemetry.fiveHourUsedPercent)}%`);
+    }
+    if (accountTelemetry.sevenDayUsedPercent >= 0) {
+      parts.push(`7d: ${Math.round(accountTelemetry.sevenDayUsedPercent)}%`);
+    }
+    return parts.length > 0 ? parts.join(' | ') : '—';
+  });
+
+  let telemetryTitle = $derived(
+    telemetry
+      ? `turns ${telemetry.turnCount} · subagents ${telemetry.subagentCount} · context ${telemetry.contextWindowSize || 'unknown'}`
+      : 'telemetry unavailable'
+  );
 </script>
 
-<div class="session-status-bar" style:display={ui.keyboardOpen ? 'none' : undefined}>
-  <div class="segment segment--model">{modelLabel()}</div>
-
-  <div class="segment segment--context">
-    <div class="context-meter" aria-hidden="true">
-      <div
-        class="context-meter-fill"
-        style:width={contextPercent >= 0 ? `${Math.min(contextPercent, 100)}%` : '0%'}
-        style:background={meterColor(contextPercent)}
-      ></div>
-    </div>
-    <span class="context-value" style:color={meterColor(contextPercent)}>
-      {contextPercent >= 0 ? `${Math.round(contextPercent)}%` : `${dash}%`}
+<div class="session-status-bar" hidden={ui.keyboardOpen}>
+  <div class="status-left">
+    <span class="status-model status-segment" title={telemetryTitle}>
+      {telemetry?.model ?? '—'}
+    </span>
+    <span class="status-context status-segment" class:status-context--muted={contextTone === 'muted'} class:status-context--warning={contextTone === 'warning'} class:status-context--danger={contextTone === 'danger'} title={telemetryTitle}>
+      {contextLabel}
+    </span>
+    <span class="status-tokens status-segment" title={telemetryTitle}>
+      ↓{telemetry ? formatCompact(telemetry.totalInputTokens) : '—'} ↑{telemetry ? formatCompact(telemetry.totalOutputTokens) : '—'}
+    </span>
+    <span class="status-cost status-segment" title={telemetryTitle}>
+      {telemetry ? formatCurrency(telemetry.costUsd) : '~$—'}
+    </span>
+    <span class="status-activity status-segment" title={activityLabel}>
+      [{activityLabel}]
     </span>
   </div>
 
-  <div class="segment segment--tokens">
-    ↓{formatNumber(sessionTelemetry?.totalInputTokens ?? 0)}
-    ↑{formatNumber(sessionTelemetry?.totalOutputTokens ?? 0)}
-  </div>
-
-  <div class="segment segment--cost">{formatCost(sessionTelemetry?.costUsd)}</div>
-
-  <div class="segment segment--tool" title={formatTool()}>{formatTool()}</div>
-
-  <div class="segment segment--limits">
-    {rateLimitLabel('fiveHour')} | {rateLimitLabel('sevenDay')}
+  <div class="status-right">
+    <span class="status-rate-limits status-segment" title={`${formatResetAt(telemetryState.accountTelemetry?.fiveHourResetsAt)} · ${formatResetAt(telemetryState.accountTelemetry?.sevenDayResetsAt)}`}>
+      {rateLimitLabel}
+    </span>
   </div>
 </div>
 
@@ -86,66 +123,89 @@
   .session-status-bar {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 12px;
     min-height: 28px;
-    padding: 0 8px;
-    border-top: 1px solid var(--border);
+    padding: 0 12px;
     background: var(--bg);
-    color: var(--text);
+    border-top: 1px solid var(--border);
     font-family: var(--font-mono);
     font-size: var(--font-size-xs);
-    flex-shrink: 0;
     overflow: hidden;
+    white-space: nowrap;
   }
 
-  .segment {
-    white-space: nowrap;
+  .status-left,
+  .status-right {
+    display: flex;
+    align-items: center;
+    gap: 10px;
     min-width: 0;
   }
 
-  .segment--model {
-    color: var(--text-muted);
+  .status-left {
+    flex: 1;
+    overflow: hidden;
   }
 
-  .segment--context {
-    display: flex;
-    align-items: center;
-    gap: 6px;
+  .status-right {
+    flex-shrink: 0;
+    margin-left: auto;
   }
 
-  .context-meter {
-    width: 72px;
-    height: 6px;
-    border: 1px solid var(--border);
-    background: transparent;
-  }
-
-  .context-meter-fill {
-    height: 100%;
-  }
-
-  .segment--tool {
+  .status-segment {
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
-    flex: 1;
   }
 
-  .segment--limits {
-    margin-left: auto;
+  .status-model,
+  .status-cost,
+  .status-tokens,
+  .status-activity,
+  .status-rate-limits {
     color: var(--text-muted);
+  }
+
+  .status-context {
+    color: var(--text);
+  }
+
+  .status-context--muted {
+    color: var(--text-muted);
+  }
+
+  .status-context--warning {
+    color: var(--status-warning);
+  }
+
+  .status-context--danger {
+    color: var(--status-error);
+  }
+
+  .status-activity {
+    min-width: 0;
+    max-width: 38vw;
+  }
+
+  .status-rate-limits {
+    text-align: right;
   }
 
   @media (max-width: 600px) {
-    .segment--model,
-    .segment--tokens,
-    .segment--cost,
-    .segment--limits {
+    .status-model,
+    .status-tokens,
+    .status-cost,
+    .status-rate-limits {
       display: none;
+    }
+
+    .status-activity {
+      max-width: 48vw;
     }
   }
 
   @media (max-width: 400px) {
-    .segment--tool {
+    .status-activity {
       display: none;
     }
   }

--- a/frontend/src/components/SessionStatusBar.svelte
+++ b/frontend/src/components/SessionStatusBar.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import { getSessionState } from '../lib/state/sessions.svelte.js';
+  import { getTelemetryState } from '../lib/state/telemetry.svelte.js';
+  import { getUi } from '../lib/state/ui.svelte.js';
+
+  let { sessionId }: { sessionId: string } = $props();
+
+  const sessionState = getSessionState();
+  const telemetry = getTelemetryState();
+  const ui = getUi();
+
+  const dash = '—';
+
+  let session = $derived(sessionState.sessions.find((item) => item.id === sessionId));
+  let sessionTelemetry = $derived(telemetry.sessionTelemetry.get(sessionId));
+  let accountTelemetry = $derived(telemetry.accountTelemetry);
+  let contextPercent = $derived(sessionTelemetry?.contextPercent ?? -1);
+
+  function formatNumber(value: number): string {
+    if (!Number.isFinite(value) || value <= 0) return dash;
+    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}m`;
+    if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
+    return String(Math.round(value));
+  }
+
+  function formatCost(value: number | null | undefined): string {
+    if (value == null || !Number.isFinite(value)) return `~$${dash}`;
+    return `~$${value.toFixed(2)}`;
+  }
+
+  function formatTool(): string {
+    if (!session?.currentActivity?.tool) return dash;
+    if (session.currentActivity.detail) return `[${session.currentActivity.tool}: ${session.currentActivity.detail}]`;
+    return `[${session.currentActivity.tool}]`;
+  }
+
+  function rateLimitLabel(label: 'fiveHour' | 'sevenDay'): string {
+    if (!accountTelemetry) return `${label === 'fiveHour' ? '5h' : '7d'}: ${dash}`;
+    const value = label === 'fiveHour' ? accountTelemetry.fiveHourUsedPercent : accountTelemetry.sevenDayUsedPercent;
+    return `${label === 'fiveHour' ? '5h' : '7d'}: ${value >= 0 ? `${Math.round(value)}%` : dash}`;
+  }
+
+  function meterColor(percent: number): string {
+    if (percent >= 85) return 'var(--status-error)';
+    if (percent >= 60) return 'var(--status-warning)';
+    return 'var(--text)';
+  }
+
+  function modelLabel(): string {
+    if (!sessionTelemetry?.model) return dash;
+    return sessionTelemetry.model.replace(/^Claude\s+/i, '');
+  }
+</script>
+
+<div class="session-status-bar" style:display={ui.keyboardOpen ? 'none' : undefined}>
+  <div class="segment segment--model">{modelLabel()}</div>
+
+  <div class="segment segment--context">
+    <div class="context-meter" aria-hidden="true">
+      <div
+        class="context-meter-fill"
+        style:width={contextPercent >= 0 ? `${Math.min(contextPercent, 100)}%` : '0%'}
+        style:background={meterColor(contextPercent)}
+      ></div>
+    </div>
+    <span class="context-value" style:color={meterColor(contextPercent)}>
+      {contextPercent >= 0 ? `${Math.round(contextPercent)}%` : `${dash}%`}
+    </span>
+  </div>
+
+  <div class="segment segment--tokens">
+    ↓{formatNumber(sessionTelemetry?.totalInputTokens ?? 0)}
+    ↑{formatNumber(sessionTelemetry?.totalOutputTokens ?? 0)}
+  </div>
+
+  <div class="segment segment--cost">{formatCost(sessionTelemetry?.costUsd)}</div>
+
+  <div class="segment segment--tool" title={formatTool()}>{formatTool()}</div>
+
+  <div class="segment segment--limits">
+    {rateLimitLabel('fiveHour')} | {rateLimitLabel('sevenDay')}
+  </div>
+</div>
+
+<style>
+  .session-status-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 28px;
+    padding: 0 8px;
+    border-top: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    flex-shrink: 0;
+    overflow: hidden;
+  }
+
+  .segment {
+    white-space: nowrap;
+    min-width: 0;
+  }
+
+  .segment--model {
+    color: var(--text-muted);
+  }
+
+  .segment--context {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .context-meter {
+    width: 72px;
+    height: 6px;
+    border: 1px solid var(--border);
+    background: transparent;
+  }
+
+  .context-meter-fill {
+    height: 100%;
+  }
+
+  .segment--tool {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+  }
+
+  .segment--limits {
+    margin-left: auto;
+    color: var(--text-muted);
+  }
+
+  @media (max-width: 600px) {
+    .segment--model,
+    .segment--tokens,
+    .segment--cost,
+    .segment--limits {
+      display: none;
+    }
+  }
+
+  @media (max-width: 400px) {
+    .segment--tool {
+      display: none;
+    }
+  }
+</style>

--- a/frontend/src/components/SessionTabBar.svelte
+++ b/frontend/src/components/SessionTabBar.svelte
@@ -113,7 +113,7 @@
 
 <svelte:window onclick={onWindowClick} />
 
-<div class="session-tab-bar" role="tablist" aria-label="Sessions" style:display={ui.keyboardOpen ? 'none' : undefined}>
+<div class="session-tab-bar" hidden={ui.keyboardOpen} role="tablist" aria-label="Sessions">
   <div class="tabs-scroll">
     {#each sessions as session (session.id)}
       {@const isActive = session.id === activeSessionId}

--- a/frontend/src/components/SessionTabBar.svelte
+++ b/frontend/src/components/SessionTabBar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { SessionSummary } from '../lib/types.js';
+  import { getUi } from '../lib/state/ui.svelte.js';
 
   let {
     sessions,
@@ -18,6 +19,8 @@
     onNewTerminal: () => void;
     onCustomize: () => void;
   } = $props();
+
+  const ui = getUi();
 
   let newMenuOpen = $state(false);
   let newMenuBtnEl = $state<HTMLButtonElement | null>(null);
@@ -110,7 +113,7 @@
 
 <svelte:window onclick={onWindowClick} />
 
-<div class="session-tab-bar" role="tablist" aria-label="Sessions">
+<div class="session-tab-bar" role="tablist" aria-label="Sessions" style:display={ui.keyboardOpen ? 'none' : undefined}>
   <div class="tabs-scroll">
     {#each sessions as session (session.id)}
       {@const isActive = session.id === activeSessionId}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { SessionSummary, WorktreeInfo, Repo, DashboardData, CiStatus, PrInfo, PullRequest, ActivityEntry, WorkspaceSettings, OrgPrsResponse, GitHubIssuesResponse, BranchLinksResponse, JiraIssuesResponse, JiraStatus, AutomationSettings, FilterPreset, BranchInfo, Workspace, ChangedFilesResponse, FileDiffResponse } from './types.js';
+import type { SessionSummary, WorktreeInfo, Repo, DashboardData, CiStatus, PrInfo, PullRequest, ActivityEntry, WorkspaceSettings, OrgPrsResponse, GitHubIssuesResponse, BranchLinksResponse, JiraIssuesResponse, JiraStatus, AutomationSettings, FilterPreset, BranchInfo, Workspace, ChangedFilesResponse, FileDiffResponse, TelemetryData, AccountTelemetry } from './types.js';
 
 export class ConflictError extends Error {
   sessionId: string;
@@ -77,6 +77,14 @@ export async function setupPin(pin: string, confirm: string): Promise<void> {
 
 export async function fetchSessions(): Promise<SessionSummary[]> {
   return json<SessionSummary[]>(await fetch('/sessions'));
+}
+
+export async function fetchTelemetrySessions(): Promise<Record<string, TelemetryData>> {
+  return json<Record<string, TelemetryData>>(await fetch('/telemetry/sessions'));
+}
+
+export async function fetchTelemetryAccount(): Promise<AccountTelemetry | null> {
+  return json<AccountTelemetry | null>(await fetch('/telemetry/account'));
 }
 
 export async function fetchWorktrees(): Promise<WorktreeInfo[]> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { SessionSummary, WorktreeInfo, Repo, DashboardData, CiStatus, PrInfo, PullRequest, ActivityEntry, WorkspaceSettings, OrgPrsResponse, GitHubIssuesResponse, BranchLinksResponse, JiraIssuesResponse, JiraStatus, AutomationSettings, FilterPreset, BranchInfo, Workspace, ChangedFilesResponse, FileDiffResponse, TelemetryData, AccountTelemetry } from './types.js';
+import type { SessionSummary, WorktreeInfo, Repo, DashboardData, CiStatus, PrInfo, PullRequest, ActivityEntry, WorkspaceSettings, OrgPrsResponse, GitHubIssuesResponse, BranchLinksResponse, JiraIssuesResponse, JiraStatus, AutomationSettings, FilterPreset, BranchInfo, Workspace, ChangedFilesResponse, FileDiffResponse, SessionTelemetry, AccountTelemetry } from './types.js';
 
 export class ConflictError extends Error {
   sessionId: string;
@@ -27,6 +27,11 @@ export interface BrowseResponse {
 
 async function json<T>(res: Response): Promise<T> {
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
+async function jsonOrNull<T>(res: Response): Promise<T | null> {
+  if (!res.ok) return null;
   return res.json() as Promise<T>;
 }
 
@@ -79,12 +84,59 @@ export async function fetchSessions(): Promise<SessionSummary[]> {
   return json<SessionSummary[]>(await fetch('/sessions'));
 }
 
-export async function fetchTelemetrySessions(): Promise<Record<string, TelemetryData>> {
-  return json<Record<string, TelemetryData>>(await fetch('/telemetry/sessions'));
+function normalizeTelemetrySessions(data: unknown): SessionTelemetry[] {
+  if (Array.isArray(data)) {
+    return data.filter((item): item is SessionTelemetry => !!item && typeof item === 'object' && 'sessionId' in item) as SessionTelemetry[];
+  }
+  if (data && typeof data === 'object') {
+    const value = data as { sessions?: unknown; data?: unknown };
+    if (Array.isArray(value.sessions)) return normalizeTelemetrySessions(value.sessions);
+    if (value.sessions && typeof value.sessions === 'object') {
+      return Object.entries(value.sessions as Record<string, unknown>).flatMap(([sessionId, raw]) => {
+        if (!raw || typeof raw !== 'object') return [];
+        return [{ sessionId, ...(raw as Omit<SessionTelemetry, 'sessionId'>) }];
+      });
+    }
+    if (Array.isArray(value.data)) return normalizeTelemetrySessions(value.data);
+    if (value.data && typeof value.data === 'object') return normalizeTelemetrySessions(value.data);
+  }
+  return [];
 }
 
-export async function fetchTelemetryAccount(): Promise<AccountTelemetry | null> {
-  return json<AccountTelemetry | null>(await fetch('/telemetry/account'));
+function normalizeAccountTelemetry(data: unknown): AccountTelemetry | null {
+  if (!data || typeof data !== 'object') return null;
+  const value = data as { data?: unknown; account?: unknown };
+  const raw = value.data ?? value.account ?? data;
+  if (!raw || typeof raw !== 'object') return null;
+  const candidate = raw as Partial<AccountTelemetry>;
+  if (typeof candidate.updatedAt !== 'string') return null;
+  return {
+    fiveHourUsedPercent: typeof candidate.fiveHourUsedPercent === 'number' ? candidate.fiveHourUsedPercent : -1,
+    fiveHourResetsAt: typeof candidate.fiveHourResetsAt === 'string' ? candidate.fiveHourResetsAt : null,
+    sevenDayUsedPercent: typeof candidate.sevenDayUsedPercent === 'number' ? candidate.sevenDayUsedPercent : -1,
+    sevenDayResetsAt: typeof candidate.sevenDayResetsAt === 'string' ? candidate.sevenDayResetsAt : null,
+    updatedAt: candidate.updatedAt,
+  };
+}
+
+export async function fetchSessionTelemetry(): Promise<SessionTelemetry[]> {
+  const res = await fetch('/telemetry/sessions');
+  const data = await jsonOrNull<unknown>(res);
+  return normalizeTelemetrySessions(data);
+}
+
+export async function fetchAccountTelemetry(): Promise<AccountTelemetry | null> {
+  const res = await fetch('/telemetry/account');
+  const data = await jsonOrNull<unknown>(res);
+  return normalizeAccountTelemetry(data);
+}
+
+export async function fetchTelemetrySetupStatus(): Promise<{ installed: boolean }> {
+  const res = await fetch('/telemetry/setup-status');
+  const data = await jsonOrNull<unknown>(res);
+  if (!data || typeof data !== 'object') return { installed: false };
+  const value = data as { installed?: unknown };
+  return { installed: value.installed === true };
 }
 
 export async function fetchWorktrees(): Promise<WorktreeInfo[]> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -89,7 +89,7 @@ function normalizeTelemetrySessions(data: unknown): SessionTelemetry[] {
     return data.filter((item): item is SessionTelemetry => !!item && typeof item === 'object' && 'sessionId' in item) as SessionTelemetry[];
   }
   if (data && typeof data === 'object') {
-    const value = data as { sessions?: unknown; data?: unknown };
+    const value = data as { sessions?: unknown; data?: unknown } & Record<string, unknown>;
     if (Array.isArray(value.sessions)) return normalizeTelemetrySessions(value.sessions);
     if (value.sessions && typeof value.sessions === 'object') {
       return Object.entries(value.sessions as Record<string, unknown>).flatMap(([sessionId, raw]) => {
@@ -99,6 +99,10 @@ function normalizeTelemetrySessions(data: unknown): SessionTelemetry[] {
     }
     if (Array.isArray(value.data)) return normalizeTelemetrySessions(value.data);
     if (value.data && typeof value.data === 'object') return normalizeTelemetrySessions(value.data);
+    return Object.entries(value).flatMap(([sessionId, raw]) => {
+      if (!raw || typeof raw !== 'object') return [];
+      return [{ sessionId, ...(raw as Omit<SessionTelemetry, 'sessionId'>) }];
+    });
   }
   return [];
 }

--- a/frontend/src/lib/state/sessions.svelte.ts
+++ b/frontend/src/lib/state/sessions.svelte.ts
@@ -1,4 +1,4 @@
-import type { SessionSummary, WorktreeInfo, Repo, SidebarItem, Workspace } from '../types.js';
+import type { CurrentActivity, SessionSummary, WorktreeInfo, Repo, SidebarItem, Workspace } from '../types.js';
 import { fireNotification, shouldFireNotification } from '../notifications.js';
 import * as api from '../api.js';
 import type { BackendDisplayState } from './display-state.js';
@@ -225,10 +225,15 @@ export function handleBranchChanged(sessionId: string, branch: string): void {
   }
 }
 
-export function handleActivityChanged(sessionId: string, timestamp?: string): void {
+export function handleActivityChanged(sessionId: string, timestamp?: string, currentActivity?: CurrentActivity | null): void {
   const now = timestamp || new Date().toISOString();
   const session = sessions.find(s => s.id === sessionId);
-  if (session) session.lastActivity = now;
+  if (session) {
+    session.lastActivity = now;
+    if (currentActivity !== undefined) {
+      session.currentActivity = currentActivity ?? undefined;
+    }
+  }
   const item = sidebarItems.find(i => i.sessions.some(s => s.id === sessionId));
   if (item) item.lastActivity = now;
 }

--- a/frontend/src/lib/state/telemetry.svelte.ts
+++ b/frontend/src/lib/state/telemetry.svelte.ts
@@ -1,45 +1,230 @@
-import type { AccountTelemetry, TelemetryData } from '../types.js';
+import * as api from '../api.js';
+import type { AccountTelemetry, Repo, SessionSummary, SessionTelemetry } from '../types.js';
+import {
+  mergeAccountTelemetrySnapshot,
+  mergeSessionTelemetrySnapshot,
+  pickNewerAccountTelemetry,
+  pickNewerSessionTelemetry,
+} from '../telemetry-sync.js';
 
-let sessionTelemetry = $state<Map<string, TelemetryData>>(new Map());
+let sessionTelemetryById = $state<Record<string, SessionTelemetry>>({});
 let accountTelemetry = $state<AccountTelemetry | null>(null);
+let telemetrySetupInstalled = $state<boolean | null>(null);
 
-export function getTelemetryState() {
+export interface TelemetryAggregate {
+  trackedSessions: number;
+  totalSessions: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheRead: number;
+  totalCacheWrite: number;
+  totalCostUsd: number | null;
+  averageContextPercent: number | null;
+  maxContextPercent: number | null;
+}
+
+export interface RepoTelemetrySummary {
+  repoPath: string;
+  repoName: string;
+  aggregate: TelemetryAggregate;
+}
+
+export interface OrgTelemetrySummary {
+  repos: RepoTelemetrySummary[];
+  outsideRelay: TelemetryAggregate;
+}
+
+function emptyAggregate(totalSessions = 0): TelemetryAggregate {
   return {
-    get sessionTelemetry() { return sessionTelemetry; },
-    get accountTelemetry() { return accountTelemetry; },
+    trackedSessions: 0,
+    totalSessions,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheRead: 0,
+    totalCacheWrite: 0,
+    totalCostUsd: null,
+    averageContextPercent: null,
+    maxContextPercent: null,
   };
 }
 
-export function hydrateTelemetry(
-  sessions: Record<string, TelemetryData>,
-  account: AccountTelemetry | null,
-): void {
-  sessionTelemetry = new Map(Object.entries(sessions));
-  accountTelemetry = account;
+function mergeCost(current: number | null, next: number | null): number | null {
+  if (current === null) return next;
+  if (next === null) return current;
+  return current + next;
 }
 
-export function getSessionTelemetry(sessionId: string): TelemetryData | undefined {
-  return sessionTelemetry.get(sessionId);
+function buildAggregate(sessions: SessionSummary[]): TelemetryAggregate {
+  const aggregate = emptyAggregate(sessions.length);
+  let contextPercentTotal = 0;
+  let contextPercentCount = 0;
+
+  for (const session of sessions) {
+    const telemetry = sessionTelemetryById[session.id];
+    if (!telemetry) continue;
+    aggregate.trackedSessions += 1;
+    aggregate.totalInputTokens += telemetry.totalInputTokens || 0;
+    aggregate.totalOutputTokens += telemetry.totalOutputTokens || 0;
+    aggregate.totalCacheRead += telemetry.totalCacheRead || 0;
+    aggregate.totalCacheWrite += telemetry.totalCacheWrite || 0;
+    aggregate.totalCostUsd = mergeCost(aggregate.totalCostUsd, telemetry.costUsd);
+    if (telemetry.contextPercent >= 0) {
+      contextPercentTotal += telemetry.contextPercent;
+      contextPercentCount += 1;
+      aggregate.maxContextPercent = aggregate.maxContextPercent === null
+        ? telemetry.contextPercent
+        : Math.max(aggregate.maxContextPercent, telemetry.contextPercent);
+    }
+  }
+
+  if (contextPercentCount > 0) {
+    aggregate.averageContextPercent = contextPercentTotal / contextPercentCount;
+  }
+
+  return aggregate;
 }
 
-export function handleTelemetryEvent(message: {
-  type: string;
-  sessionId?: string;
-  data?: TelemetryData | AccountTelemetry;
-}): void {
-  if (message.type === 'session-telemetry' && message.sessionId && message.data) {
-    sessionTelemetry.set(message.sessionId, message.data as TelemetryData);
-    sessionTelemetry = new Map(sessionTelemetry);
-    return;
+export function summarizeSessionSetTelemetry(sessions: SessionSummary[]): TelemetryAggregate {
+  return buildAggregate(sessions);
+}
+
+export function summarizeReposTelemetry(repos: Repo[], sessions: SessionSummary[]): OrgTelemetrySummary {
+  const sessionsByRepo = new Map<string, SessionSummary[]>();
+  for (const session of sessions) {
+    const bucket = sessionsByRepo.get(session.repoPath) ?? [];
+    bucket.push(session);
+    sessionsByRepo.set(session.repoPath, bucket);
   }
 
-  if (message.type === 'account-telemetry') {
-    accountTelemetry = (message.data as AccountTelemetry | undefined) ?? null;
+  const repoSummaries = repos.map((repo) => ({
+    repoPath: repo.path,
+    repoName: repo.name,
+    aggregate: buildAggregate(sessionsByRepo.get(repo.path) ?? []),
+  }));
+
+  const outsideRelaySessions = sessions.filter((session) => !sessionTelemetryById[session.id]);
+  const outsideRelay = buildAggregate(outsideRelaySessions);
+  outsideRelay.totalSessions = outsideRelaySessions.length;
+
+  return {
+    repos: repoSummaries,
+    outsideRelay,
+  };
+}
+
+export function summarizeSessionTelemetry(sessionId: string): SessionTelemetry | null {
+  return sessionTelemetryById[sessionId] ?? null;
+}
+
+export function getTelemetryState() {
+  return {
+    get sessionTelemetryById() { return sessionTelemetryById; },
+    get accountTelemetry() { return accountTelemetry; },
+    get telemetrySetupInstalled() { return telemetrySetupInstalled; },
+  };
+}
+
+function normalizeSessionTelemetry(sessionId: string, data: Partial<SessionTelemetry>): SessionTelemetry {
+  return {
+    sessionId,
+    model: typeof data.model === 'string' || data.model === null ? data.model ?? null : null,
+    totalInputTokens: typeof data.totalInputTokens === 'number' ? data.totalInputTokens : 0,
+    totalOutputTokens: typeof data.totalOutputTokens === 'number' ? data.totalOutputTokens : 0,
+    totalCacheRead: typeof data.totalCacheRead === 'number' ? data.totalCacheRead : 0,
+    totalCacheWrite: typeof data.totalCacheWrite === 'number' ? data.totalCacheWrite : 0,
+    contextPercent: typeof data.contextPercent === 'number' ? data.contextPercent : -1,
+    contextWindowSize: typeof data.contextWindowSize === 'number' ? data.contextWindowSize : 0,
+    costUsd: typeof data.costUsd === 'number' ? data.costUsd : null,
+    turnCount: typeof data.turnCount === 'number' ? data.turnCount : 0,
+    subagentCount: typeof data.subagentCount === 'number' ? data.subagentCount : 0,
+    source: data.source === 'jsonl' ? 'jsonl' : 'statusLine',
+    updatedAt: typeof data.updatedAt === 'string' ? data.updatedAt : new Date().toISOString(),
+  };
+}
+
+function normalizeAccountTelemetry(data: Partial<AccountTelemetry>): AccountTelemetry {
+  return {
+    fiveHourUsedPercent: typeof data.fiveHourUsedPercent === 'number' ? data.fiveHourUsedPercent : -1,
+    fiveHourResetsAt: typeof data.fiveHourResetsAt === 'string' ? data.fiveHourResetsAt : null,
+    sevenDayUsedPercent: typeof data.sevenDayUsedPercent === 'number' ? data.sevenDayUsedPercent : -1,
+    sevenDayResetsAt: typeof data.sevenDayResetsAt === 'string' ? data.sevenDayResetsAt : null,
+    updatedAt: typeof data.updatedAt === 'string' ? data.updatedAt : new Date().toISOString(),
+  };
+}
+
+export function setSessionTelemetry(data: SessionTelemetry): void {
+  const normalized = normalizeSessionTelemetry(data.sessionId, data);
+  const next = pickNewerSessionTelemetry(sessionTelemetryById[normalized.sessionId], normalized);
+  if (sessionTelemetryById[normalized.sessionId] === next) return;
+  sessionTelemetryById = { ...sessionTelemetryById, [normalized.sessionId]: next };
+}
+
+export function setSessionTelemetryBatch(items: SessionTelemetry[], requestStartedAt = new Date().toISOString()): void {
+  const normalized = items.map((item) => normalizeSessionTelemetry(item.sessionId, item));
+  sessionTelemetryById = mergeSessionTelemetrySnapshot(sessionTelemetryById, normalized, requestStartedAt);
+}
+
+export function clearSessionTelemetry(sessionId: string): void {
+  if (!(sessionId in sessionTelemetryById)) return;
+  const next = { ...sessionTelemetryById };
+  delete next[sessionId];
+  sessionTelemetryById = next;
+}
+
+export function pruneSessionTelemetry(activeSessionIds: Iterable<string>): void {
+  const allowed = new Set(activeSessionIds);
+  const next: Record<string, SessionTelemetry> = {};
+  let changed = false;
+  for (const [sessionId, telemetry] of Object.entries(sessionTelemetryById)) {
+    if (allowed.has(sessionId)) {
+      next[sessionId] = telemetry;
+    } else {
+      changed = true;
+    }
+  }
+  if (changed) sessionTelemetryById = next;
+}
+
+export function setAccountTelemetrySnapshot(data: AccountTelemetry | null): void {
+  if (!data) {
+    accountTelemetry = null;
     return;
   }
+  accountTelemetry = pickNewerAccountTelemetry(accountTelemetry, normalizeAccountTelemetry(data));
+}
 
-  if (message.type === 'session-ended' && message.sessionId) {
-    sessionTelemetry.delete(message.sessionId);
-    sessionTelemetry = new Map(sessionTelemetry);
+export function setTelemetrySetupInstalled(installed: boolean | null): void {
+  telemetrySetupInstalled = installed;
+}
+
+export function handleSessionTelemetryEvent(sessionId: string, data: SessionTelemetry | Record<string, unknown>): void {
+  if (!data || typeof data !== 'object') return;
+  setSessionTelemetry(normalizeSessionTelemetry(sessionId, data as Partial<SessionTelemetry>));
+}
+
+export function handleAccountTelemetryEvent(data: AccountTelemetry | Record<string, unknown> | null): void {
+  if (!data || typeof data !== 'object') {
+    accountTelemetry = null;
+    return;
+  }
+  accountTelemetry = pickNewerAccountTelemetry(accountTelemetry, normalizeAccountTelemetry(data as Partial<AccountTelemetry>));
+}
+
+export async function refreshTelemetry(): Promise<void> {
+  const requestStartedAt = new Date().toISOString();
+  const [sessionResult, accountResult, setupResult] = await Promise.allSettled([
+    api.fetchSessionTelemetry(),
+    api.fetchAccountTelemetry(),
+    api.fetchTelemetrySetupStatus(),
+  ]);
+
+  if (sessionResult.status === 'fulfilled') {
+    setSessionTelemetryBatch(sessionResult.value, requestStartedAt);
+  }
+  if (accountResult.status === 'fulfilled') {
+    accountTelemetry = mergeAccountTelemetrySnapshot(accountTelemetry, accountResult.value, requestStartedAt);
+  }
+  if (setupResult.status === 'fulfilled') {
+    setTelemetrySetupInstalled(setupResult.value.installed);
   }
 }

--- a/frontend/src/lib/state/telemetry.svelte.ts
+++ b/frontend/src/lib/state/telemetry.svelte.ts
@@ -1,0 +1,45 @@
+import type { AccountTelemetry, TelemetryData } from '../types.js';
+
+let sessionTelemetry = $state<Map<string, TelemetryData>>(new Map());
+let accountTelemetry = $state<AccountTelemetry | null>(null);
+
+export function getTelemetryState() {
+  return {
+    get sessionTelemetry() { return sessionTelemetry; },
+    get accountTelemetry() { return accountTelemetry; },
+  };
+}
+
+export function hydrateTelemetry(
+  sessions: Record<string, TelemetryData>,
+  account: AccountTelemetry | null,
+): void {
+  sessionTelemetry = new Map(Object.entries(sessions));
+  accountTelemetry = account;
+}
+
+export function getSessionTelemetry(sessionId: string): TelemetryData | undefined {
+  return sessionTelemetry.get(sessionId);
+}
+
+export function handleTelemetryEvent(message: {
+  type: string;
+  sessionId?: string;
+  data?: TelemetryData | AccountTelemetry;
+}): void {
+  if (message.type === 'session-telemetry' && message.sessionId && message.data) {
+    sessionTelemetry.set(message.sessionId, message.data as TelemetryData);
+    sessionTelemetry = new Map(sessionTelemetry);
+    return;
+  }
+
+  if (message.type === 'account-telemetry') {
+    accountTelemetry = (message.data as AccountTelemetry | undefined) ?? null;
+    return;
+  }
+
+  if (message.type === 'session-ended' && message.sessionId) {
+    sessionTelemetry.delete(message.sessionId);
+    sessionTelemetry = new Map(sessionTelemetry);
+  }
+}

--- a/frontend/src/lib/state/ui.svelte.ts
+++ b/frontend/src/lib/state/ui.svelte.ts
@@ -60,6 +60,7 @@ let activeWorkspaceId = $state<string | null>((() => {
   catch { return null; }
 })());
 let terminalFontSize = $state(loadTerminalFontSize());
+let keyboardOpen = $state(false);
 let hasHardwareKeyboard = $state(false);
 let fullPageDiff = $state<{
   workspacePath: string;
@@ -153,6 +154,8 @@ export function getUi() {
     },
     get terminalFontSize() { return terminalFontSize; },
     set terminalFontSize(v: number) { terminalFontSize = v; },
+    get keyboardOpen() { return keyboardOpen; },
+    set keyboardOpen(v: boolean) { keyboardOpen = v; },
     get hasHardwareKeyboard() { return hasHardwareKeyboard; },
     set hasHardwareKeyboard(v: boolean) { hasHardwareKeyboard = v; },
     get fullPageDiff() { return fullPageDiff; },

--- a/frontend/src/lib/state/ui.svelte.ts
+++ b/frontend/src/lib/state/ui.svelte.ts
@@ -60,8 +60,8 @@ let activeWorkspaceId = $state<string | null>((() => {
   catch { return null; }
 })());
 let terminalFontSize = $state(loadTerminalFontSize());
-let keyboardOpen = $state(false);
 let hasHardwareKeyboard = $state(false);
+let keyboardOpen = $state(false);
 let fullPageDiff = $state<{
   workspacePath: string;
   file?: string | undefined;
@@ -154,10 +154,10 @@ export function getUi() {
     },
     get terminalFontSize() { return terminalFontSize; },
     set terminalFontSize(v: number) { terminalFontSize = v; },
-    get keyboardOpen() { return keyboardOpen; },
-    set keyboardOpen(v: boolean) { keyboardOpen = v; },
     get hasHardwareKeyboard() { return hasHardwareKeyboard; },
     set hasHardwareKeyboard(v: boolean) { hasHardwareKeyboard = v; },
+    get keyboardOpen() { return keyboardOpen; },
+    set keyboardOpen(v: boolean) { keyboardOpen = v; },
     get fullPageDiff() { return fullPageDiff; },
     set fullPageDiff(v: typeof fullPageDiff) { fullPageDiff = v; },
     // Right sidebar & file viewer

--- a/frontend/src/lib/telemetry-sync.ts
+++ b/frontend/src/lib/telemetry-sync.ts
@@ -1,0 +1,57 @@
+import type { AccountTelemetry, SessionTelemetry } from './types.js';
+
+function parseUpdatedAt(value: string | null | undefined): number {
+  if (!value) return 0;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+export function pickNewerSessionTelemetry(
+  current: SessionTelemetry | undefined,
+  incoming: SessionTelemetry,
+): SessionTelemetry {
+  if (!current) return incoming;
+  return parseUpdatedAt(incoming.updatedAt) >= parseUpdatedAt(current.updatedAt) ? incoming : current;
+}
+
+export function pickNewerAccountTelemetry(
+  current: AccountTelemetry | null,
+  incoming: AccountTelemetry,
+): AccountTelemetry {
+  if (!current) return incoming;
+  return parseUpdatedAt(incoming.updatedAt) >= parseUpdatedAt(current.updatedAt) ? incoming : current;
+}
+
+export function mergeSessionTelemetrySnapshot(
+  currentSessions: Record<string, SessionTelemetry>,
+  incomingSessions: SessionTelemetry[],
+  requestStartedAt: string,
+): Record<string, SessionTelemetry> {
+  const requestStartedMs = parseUpdatedAt(requestStartedAt);
+  const next: Record<string, SessionTelemetry> = {};
+  const incomingIds = new Set<string>();
+
+  for (const incoming of incomingSessions) {
+    incomingIds.add(incoming.sessionId);
+    next[incoming.sessionId] = pickNewerSessionTelemetry(currentSessions[incoming.sessionId], incoming);
+  }
+
+  for (const [sessionId, current] of Object.entries(currentSessions)) {
+    if (incomingIds.has(sessionId)) continue;
+    if (parseUpdatedAt(current.updatedAt) > requestStartedMs) {
+      next[sessionId] = current;
+    }
+  }
+
+  return next;
+}
+
+export function mergeAccountTelemetrySnapshot(
+  current: AccountTelemetry | null,
+  incoming: AccountTelemetry | null,
+  requestStartedAt: string,
+): AccountTelemetry | null {
+  if (incoming) return pickNewerAccountTelemetry(current, incoming);
+  if (!current) return null;
+  return parseUpdatedAt(current.updatedAt) > parseUpdatedAt(requestStartedAt) ? current : null;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -4,6 +4,37 @@ import type { PrDotStatus } from './pr-status.js';
 export type AgentType = 'claude' | 'codex';
 export type AgentState = 'initializing' | 'waiting-for-input' | 'processing' | 'permission-prompt' | 'error' | 'idle';
 
+export interface CurrentActivity {
+  tool: string;
+  detail?: string;
+}
+
+export interface SessionTelemetry {
+  sessionId: string;
+  model: string | null;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheRead: number;
+  totalCacheWrite: number;
+  contextPercent: number;
+  contextWindowSize: number;
+  costUsd: number | null;
+  turnCount: number;
+  subagentCount: number;
+  source: 'statusLine' | 'jsonl';
+  updatedAt: string;
+}
+
+export type TelemetryData = SessionTelemetry;
+
+export interface AccountTelemetry {
+  fiveHourUsedPercent: number;
+  fiveHourResetsAt: string | null;
+  sevenDayUsedPercent: number;
+  sevenDayResetsAt: string | null;
+  updatedAt: string;
+}
+
 export interface Repo {
   path: string;
   name: string;
@@ -36,30 +67,9 @@ export interface SessionSummary {
   useTmux?: boolean | undefined;
   status?: 'active' | 'disconnected' | undefined;
   agentState?: AgentState | undefined;
-  currentActivity?: { tool: string; detail?: string } | undefined;
   workspaceId?: string | undefined;
   additionalDirs?: string[] | undefined;
-}
-
-export interface TelemetryData {
-  sessionId: string;
-  model: string | null;
-  totalInputTokens: number;
-  totalOutputTokens: number;
-  totalCacheRead: number;
-  totalCacheWrite: number;
-  contextPercent: number;
-  contextWindowSize: number;
-  costUsd: number | null;
-  source: 'statusLine' | 'jsonl';
-}
-
-export interface AccountTelemetry {
-  fiveHourUsedPercent: number;
-  fiveHourResetsAt: string;
-  sevenDayUsedPercent: number;
-  sevenDayResetsAt: string;
-  updatedAt: string;
+  currentActivity?: CurrentActivity | undefined;
 }
 
 export interface WorktreeInfo {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -36,8 +36,30 @@ export interface SessionSummary {
   useTmux?: boolean | undefined;
   status?: 'active' | 'disconnected' | undefined;
   agentState?: AgentState | undefined;
+  currentActivity?: { tool: string; detail?: string } | undefined;
   workspaceId?: string | undefined;
   additionalDirs?: string[] | undefined;
+}
+
+export interface TelemetryData {
+  sessionId: string;
+  model: string | null;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheRead: number;
+  totalCacheWrite: number;
+  contextPercent: number;
+  contextWindowSize: number;
+  costUsd: number | null;
+  source: 'statusLine' | 'jsonl';
+}
+
+export interface AccountTelemetry {
+  fiveHourUsedPercent: number;
+  fiveHourResetsAt: string;
+  sevenDayUsedPercent: number;
+  sevenDayResetsAt: string;
+  updatedAt: string;
 }
 
 export interface WorktreeInfo {

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -1,5 +1,6 @@
 import type { Terminal } from '@xterm/xterm';
 import type { BackendDisplayState } from './state/display-state.js';
+import type { AccountTelemetry, TelemetryData } from './types.js';
 const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
 
 interface EventMessage {
@@ -17,6 +18,7 @@ interface EventMessage {
   workspacePath?: string;
   changedFiles?: string[];
   timestamp?: string;
+  data?: TelemetryData | AccountTelemetry;
 }
 
 type EventCallback = (msg: EventMessage) => void;

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -1,9 +1,9 @@
 import type { Terminal } from '@xterm/xterm';
 import type { BackendDisplayState } from './state/display-state.js';
-import type { AccountTelemetry, TelemetryData } from './types.js';
+import type { AccountTelemetry, CurrentActivity, SessionTelemetry } from './types.js';
 const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
 
-interface EventMessage {
+interface BaseEventMessage {
   type: string;
   sessionId?: string;
   idle?: boolean;
@@ -18,10 +18,35 @@ interface EventMessage {
   workspacePath?: string;
   changedFiles?: string[];
   timestamp?: string;
-  data?: TelemetryData | AccountTelemetry;
+  currentActivity?: CurrentActivity | null;
+  data?: SessionTelemetry | AccountTelemetry | Record<string, unknown> | null;
 }
 
+interface SessionActivityChangedMessage extends BaseEventMessage {
+  type: 'session-activity-changed';
+  sessionId: string;
+  currentActivity?: CurrentActivity | null;
+}
+
+interface SessionTelemetryMessage extends BaseEventMessage {
+  type: 'session-telemetry';
+  sessionId: string;
+  data: SessionTelemetry | Record<string, unknown>;
+}
+
+interface AccountTelemetryMessage extends BaseEventMessage {
+  type: 'account-telemetry';
+  data: AccountTelemetry | Record<string, unknown> | null;
+}
+
+type EventMessage =
+  | SessionActivityChangedMessage
+  | SessionTelemetryMessage
+  | AccountTelemetryMessage
+  | BaseEventMessage;
+
 type EventCallback = (msg: EventMessage) => void;
+type EventOpenCallback = () => void;
 
 let eventWs: WebSocket | null = null;
 let ptyWs: WebSocket | null = null;
@@ -45,16 +70,18 @@ let lastPtyTerm: Terminal | null = null;
 let lastPtyOnResize: (() => void) | null = null;
 let lastPtyOnSessionEnd: (() => void) | null = null;
 let lastEventOnMessage: EventCallback | null = null;
+let lastEventOnOpen: EventOpenCallback | null = null;
 
 const PING_INTERVAL = 30_000;   // 30s heartbeat
 const PONG_TIMEOUT = 5_000;     // 5s to respond
 const PING_MSG = '{"type":"ping"}';
 const PONG_MSG = '{"type":"pong"}';
 
-export function connectEventSocket(onMessage: EventCallback): void {
+export function connectEventSocket(onMessage: EventCallback, onOpen?: EventOpenCallback): void {
   // Null onclose before close to prevent old socket from scheduling a reconnect
   if (eventWs) { eventWs.onclose = null; eventWs.close(); eventWs = null; }
   lastEventOnMessage = onMessage;
+  lastEventOnOpen = onOpen ?? null;
   clearEventPing();
 
   const url = wsProtocol + '//' + location.host + '/ws/events';
@@ -62,6 +89,7 @@ export function connectEventSocket(onMessage: EventCallback): void {
 
   eventWs.onopen = () => {
     startEventPing();
+    onOpen?.();
   };
 
   eventWs.onmessage = (event) => {
@@ -75,7 +103,7 @@ export function connectEventSocket(onMessage: EventCallback): void {
 
   eventWs.onclose = () => {
     clearEventPing();
-    setTimeout(() => connectEventSocket(onMessage), 3000);
+    setTimeout(() => connectEventSocket(onMessage, onOpen), 3000);
   };
 
   eventWs.onerror = () => {};
@@ -243,7 +271,7 @@ function sendEventPing(): void {
 function forceReconnectEvent(): void {
   clearEventPing();
   if (eventWs) { eventWs.onclose = null; eventWs.close(); eventWs = null; }
-  if (lastEventOnMessage) connectEventSocket(lastEventOnMessage);
+  if (lastEventOnMessage) connectEventSocket(lastEventOnMessage, lastEventOnOpen ?? undefined);
 }
 
 function startEventPing(): void {

--- a/server/config.ts
+++ b/server/config.ts
@@ -130,8 +130,12 @@ export function saveConfig(configPath: string, config: Config): void {
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
 }
 
+export function getConfigDir(configPath: string): string {
+  return path.dirname(configPath);
+}
+
 function metaDir(configPath: string): string {
-  return path.join(path.dirname(configPath), 'worktree-meta');
+  return path.join(getConfigDir(configPath), 'worktree-meta');
 }
 
 function metaFilePath(configPath: string, worktreePath: string): string {

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,7 +10,7 @@ import { promisify } from 'node:util';
 import express from 'express';
 import cookieParser from 'cookie-parser';
 
-import { loadConfig, saveConfig, DEFAULTS, readMeta, writeMeta, deleteMeta, ensureMetaDir, resolveSessionSettings } from './config.js';
+import { loadConfig, saveConfig, DEFAULTS, readMeta, writeMeta, deleteMeta, ensureMetaDir, getConfigDir, resolveSessionSettings } from './config.js';
 import * as auth from './auth.js';
 import * as sessions from './sessions.js';
 import { AGENT_CONTINUE_ARGS, AGENT_YOLO_ARGS, serializeAll, restoreFromDisk, activeTmuxSessionNames, populateMetaCache } from './sessions.js';
@@ -35,6 +35,7 @@ import { createGitHubAppRouter } from './github-app.js';
 import { createWebhookRouter } from './webhooks.js';
 import { createWebhookManagerRouter, reloadSmee, startSmartPolling } from './webhook-manager.js';
 import { fetchPrsGraphQL } from './github-graphql.js';
+import { createTelemetryRouter, startTelemetry, stopTelemetry } from './telemetry.js';
 import type { AgentType, AutomationSettings, Config, ContinuePolicy } from './types.js';
 import { semverLessThan } from './utils.js';
 
@@ -178,7 +179,8 @@ async function main(): Promise<void> {
 
   push.ensureVapidKeys(startupConfig, CONFIG_PATH, saveConfig);
 
-  const configDir = path.dirname(CONFIG_PATH);
+  const configDir = getConfigDir(CONFIG_PATH);
+  fs.mkdirSync(path.join(configDir, 'telemetry'), { recursive: true });
   try {
     initAnalytics(configDir);
   } catch (err) {
@@ -353,7 +355,11 @@ async function main(): Promise<void> {
   sessions.onSessionEnd(() => rebuildRefWatcher());
 
   // Configure session defaults for hooks injection (startup-only — changing these requires restart)
-  sessions.configure({ port: startupConfig.port, forceOutputParser: startupConfig.forceOutputParser ?? false });
+  sessions.configure({
+    port: startupConfig.port,
+    forceOutputParser: startupConfig.forceOutputParser ?? false,
+    configDir,
+  });
 
   // Mount hooks router BEFORE auth middleware — hook callbacks come from localhost Claude Code
   const hooksRouter = createHooksRouter({
@@ -442,6 +448,7 @@ async function main(): Promise<void> {
 
   // Mount analytics router
   app.use('/analytics', requireAuth, createAnalyticsRouter(configDir));
+  app.use('/telemetry', requireAuth, createTelemetryRouter());
 
   // Restore sessions from a previous update restart
   const restoredCount = await restoreFromDisk(configDir, getConfig().repos ?? []);
@@ -452,6 +459,12 @@ async function main(): Promise<void> {
       gitWatcher.watch(session.cwd);
     }
   }
+
+  startTelemetry({
+    getActiveSessions: sessions.list,
+    broadcastEvent,
+    configDir,
+  });
 
   // Populate session metadata cache in background (non-blocking)
   populateMetaCache().catch(() => {});
@@ -1451,7 +1464,7 @@ async function main(): Promise<void> {
       const restarting = serviceIsInstalled();
       if (restarting) {
         // Persist sessions so they can be restored after restart
-        const configDir = path.dirname(CONFIG_PATH);
+        stopTelemetry();
         serializeAll(configDir);
       }
       res.json({ ok: true, restarting });
@@ -1485,13 +1498,13 @@ async function main(): Promise<void> {
 
   async function gracefulShutdown() {
     await stopPolling();
+    stopTelemetry();
     closeAnalytics();
     branchWatcher.close();
     refWatcher.close();
     gitWatcher.close();
     server.close();
     // Serialize sessions to disk BEFORE killing them
-    const configDir = path.dirname(CONFIG_PATH);
     serializeAll(configDir);
     // Kill all active sessions (PTY + tmux)
     for (const s of sessions.list()) {

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -37,10 +37,47 @@ export function resolveTmuxSpawn(
   };
 }
 
-function writeHooksSettingsFile(sessionId: string, port: number, token: string): string {
+function shellQuote(value: string): string {
+  return "'" + value.replace(/'/g, "'\"'\"'") + "'";
+}
+
+function readGlobalStatusLineCommand(): string {
+  try {
+    const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+    const raw = fs.readFileSync(settingsPath, 'utf-8');
+    const parsed = JSON.parse(raw) as { statusLine?: { command?: string } };
+    return typeof parsed.statusLine?.command === 'string' ? parsed.statusLine.command : '';
+  } catch {
+    return '';
+  }
+}
+
+function writeStatusLineScript(sessionId: string, dir: string, configDir: string): string {
+  const scriptPath = path.join(dir, 'relay-statusline.sh');
+  const telemetryDir = path.join(configDir, 'telemetry');
+  const telemetryPath = path.join(telemetryDir, `${sessionId}.json`);
+  const globalCmd = readGlobalStatusLineCommand();
+  const script = `#!/usr/bin/env bash
+input=$(cat)
+mkdir -p ${shellQuote(telemetryDir)}
+printf '%s\n' "$input" > ${shellQuote(telemetryPath)}
+GLOBAL_CMD=${shellQuote(globalCmd)}
+if [ -n "$GLOBAL_CMD" ] && [ -x "$GLOBAL_CMD" ]; then
+  printf '%s\n' "$input" | "$GLOBAL_CMD"
+else
+  printf '%s\n' "$input" | node -e 'let raw="";process.stdin.setEncoding("utf8");process.stdin.on("data", (chunk) => raw += chunk);process.stdin.on("end", () => { try { const data = JSON.parse(raw); const model = data?.model?.display_name ?? "Claude"; const remaining = data?.context_window?.remaining_percentage ?? "?"; console.log(\`\${model} | \${remaining}% ctx\`); } catch { console.log("Claude | ?% ctx"); } });'
+fi
+`;
+  fs.writeFileSync(scriptPath, script, 'utf-8');
+  fs.chmodSync(scriptPath, 0o755);
+  return scriptPath;
+}
+
+function writeHooksSettingsFile(sessionId: string, port: number, token: string, configDir: string): string {
   const dir = path.join(os.tmpdir(), 'claude-remote-cli', sessionId);
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   const filePath = path.join(dir, 'hooks-settings.json');
+  const statusLinePath = writeStatusLineScript(sessionId, dir, configDir);
   const base = `http://127.0.0.1:${port}`;
   const q = `sessionId=${sessionId}&token=${token}`;
   const settings = {
@@ -54,6 +91,10 @@ function writeHooksSettingsFile(sessionId: string, port: number, token: string):
       SessionEnd: [{ hooks: [{ type: 'http', url: `${base}/hooks/session-end?${q}`, timeout: 5 }] }],
       PreToolUse: [{ hooks: [{ type: 'http', url: `${base}/hooks/tool-use?${q}`, timeout: 5 }] }],
       PostToolUse: [{ hooks: [{ type: 'http', url: `${base}/hooks/tool-result?${q}`, timeout: 5 }] }],
+    },
+    statusLine: {
+      type: 'command',
+      command: statusLinePath,
     },
   };
   fs.writeFileSync(filePath, JSON.stringify(settings, null, 2), 'utf-8');
@@ -76,6 +117,7 @@ export type CreatePtyParams = {
   cols?: number | undefined;
   rows?: number | undefined;
   configPath?: string | undefined;
+  configDir?: string | undefined;
   useTmux?: boolean | undefined;
   tmuxSessionName?: string | undefined;
   tmuxDisplayName?: string | undefined;
@@ -114,6 +156,7 @@ export function createPtySession(
     cols = 80,
     rows = 24,
     configPath,
+    configDir,
     useTmux: paramUseTmux,
     tmuxSessionName: paramTmuxSessionName,
     initialScrollback,
@@ -146,7 +189,7 @@ export function createPtySession(
       hookToken = crypto.randomBytes(32).toString('hex');
     }
     try {
-      settingsPath = writeHooksSettingsFile(id, port, hookToken);
+      settingsPath = writeHooksSettingsFile(id, port, hookToken, configDir ?? process.cwd());
       args = ['--settings', settingsPath, ...args];
       hooksActive = true;
     } catch (err) {

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -52,22 +52,46 @@ function readGlobalStatusLineCommand(): string {
   }
 }
 
-function writeStatusLineScript(sessionId: string, dir: string, configDir: string): string {
-  const scriptPath = path.join(dir, 'relay-statusline.sh');
+export function buildStatusLineRelayScript(sessionId: string, configDir: string, globalCmd: string): string {
   const telemetryDir = path.join(configDir, 'telemetry');
   const telemetryPath = path.join(telemetryDir, `${sessionId}.json`);
-  const globalCmd = readGlobalStatusLineCommand();
-  const script = `#!/usr/bin/env bash
-input=$(cat)
+  const tempPattern = `${telemetryPath}.tmp.XXXXXX`;
+  return `#!/usr/bin/env bash
+set -u
 mkdir -p ${shellQuote(telemetryDir)}
-printf '%s\n' "$input" > ${shellQuote(telemetryPath)}
+tmp_file=$(mktemp ${shellQuote(tempPattern)})
+cleanup() {
+  rm -f "$tmp_file"
+}
+trap cleanup EXIT
 GLOBAL_CMD=${shellQuote(globalCmd)}
 if [ -n "$GLOBAL_CMD" ] && [ -x "$GLOBAL_CMD" ]; then
-  printf '%s\n' "$input" | "$GLOBAL_CMD"
+  tee "$tmp_file" | "$GLOBAL_CMD"
+  pipeline_statuses=("\${PIPESTATUS[@]}")
 else
-  printf '%s\n' "$input" | node -e 'let raw="";process.stdin.setEncoding("utf8");process.stdin.on("data", (chunk) => raw += chunk);process.stdin.on("end", () => { try { const data = JSON.parse(raw); const model = data?.model?.display_name ?? "Claude"; const remaining = data?.context_window?.remaining_percentage ?? "?"; console.log(\`\${model} | \${remaining}% ctx\`); } catch { console.log("Claude | ?% ctx"); } });'
+  tee "$tmp_file" | node -e 'let raw="";process.stdin.setEncoding("utf8");process.stdin.on("data", (chunk) => raw += chunk);process.stdin.on("end", () => { try { const data = JSON.parse(raw); const model = data?.model?.display_name ?? "Claude"; const remaining = data?.context_window?.remaining_percentage ?? "?"; console.log(\`\${model} | \${remaining}% ctx\`); } catch { console.log("Claude | ?% ctx"); } });'
+  pipeline_statuses=("\${PIPESTATUS[@]}")
 fi
+
+pipeline_status=0
+for status in "\${pipeline_statuses[@]}"; do
+  if [ "$status" -ne 0 ]; then
+    pipeline_status=$status
+  fi
+done
+
+if [ "\${pipeline_statuses[0]}" -eq 0 ]; then
+  mv "$tmp_file" ${shellQuote(telemetryPath)}
+  trap - EXIT
+fi
+
+exit "$pipeline_status"
 `;
+}
+
+function writeStatusLineScript(sessionId: string, dir: string, configDir: string): string {
+  const scriptPath = path.join(dir, 'relay-statusline.sh');
+  const script = buildStatusLineRelayScript(sessionId, configDir, readGlobalStatusLineCommand());
   fs.writeFileSync(scriptPath, script, 'utf-8');
   fs.chmodSync(scriptPath, 0o755);
   return scriptPath;

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -67,10 +67,12 @@ const metaCache = new Map<string, SessionMeta>();
 // Module-level defaults for hooks injection (set via configure())
 let defaultPort: number | undefined;
 let defaultForceOutputParser: boolean | undefined;
+let defaultConfigDir: string | undefined;
 
-function configure(opts: { port?: number; forceOutputParser?: boolean }): void {
+function configure(opts: { port?: number; forceOutputParser?: boolean; configDir?: string }): void {
   defaultPort = opts.port;
   defaultForceOutputParser = opts.forceOutputParser;
+  defaultConfigDir = opts.configDir;
 }
 
 let terminalCounter = 0;
@@ -167,6 +169,7 @@ function create({ id: providedId, needsBranchRename, branchRenamePrompt, initial
     args,
     port: port ?? defaultPort,
     forceOutputParser: forceOutputParser ?? defaultForceOutputParser,
+    configDir: rest.configDir ?? defaultConfigDir,
   };
 
   const { session: ptySession, result } = createPtySession(ptyParams, sessions, stateChangeCallbacks, sessionEndCallbacks, fireBackendStateIfChanged);

--- a/server/telemetry.ts
+++ b/server/telemetry.ts
@@ -260,5 +260,9 @@ export function createTelemetryRouter(): Router {
     res.json(accountTelemetry);
   });
 
+  router.get('/setup-status', (_req: Request, res: Response) => {
+    res.json({ installed: activeDeps !== null });
+  });
+
   return router;
 }

--- a/server/telemetry.ts
+++ b/server/telemetry.ts
@@ -16,6 +16,8 @@ interface PendingTelemetryFile {
   account: AccountTelemetry | null;
 }
 
+type IncomingTelemetryData = Omit<TelemetryData, 'updatedAt'>;
+
 export interface TelemetryDeps {
   getActiveSessions: () => Array<Pick<Session, 'id'>>;
   broadcastEvent: (type: string, data?: Record<string, unknown>) => void;
@@ -49,8 +51,18 @@ function telemetryToObject(): Record<string, TelemetryData> {
   return Object.fromEntries(sessionTelemetry.entries());
 }
 
-function sameTelemetry(a: TelemetryData | undefined, b: TelemetryData): boolean {
-  return a !== undefined && JSON.stringify(a) === JSON.stringify(b);
+function sameTelemetry(a: TelemetryData | undefined, b: IncomingTelemetryData): boolean {
+  if (!a) return false;
+  return a.sessionId === b.sessionId
+    && a.model === b.model
+    && a.totalInputTokens === b.totalInputTokens
+    && a.totalOutputTokens === b.totalOutputTokens
+    && a.totalCacheRead === b.totalCacheRead
+    && a.totalCacheWrite === b.totalCacheWrite
+    && a.contextPercent === b.contextPercent
+    && a.contextWindowSize === b.contextWindowSize
+    && a.costUsd === b.costUsd
+    && a.source === b.source;
 }
 
 function sameAccountTelemetry(a: AccountTelemetry | null, b: Omit<AccountTelemetry, 'updatedAt'>): boolean {
@@ -62,7 +74,7 @@ function sameAccountTelemetry(a: AccountTelemetry | null, b: Omit<AccountTelemet
 }
 
 function extractTelemetry(sessionId: string, payload: unknown): {
-  session: TelemetryData;
+  session: IncomingTelemetryData;
   account: Omit<AccountTelemetry, 'updatedAt'> | null;
 } | null {
   if (!payload || typeof payload !== 'object') return null;
@@ -76,7 +88,7 @@ function extractTelemetry(sessionId: string, payload: unknown): {
   const sevenDay = (rateLimits.seven_day ?? {}) as Record<string, unknown>;
   const model = (data.model ?? {}) as Record<string, unknown>;
 
-  const session: TelemetryData = {
+  const session: IncomingTelemetryData = {
     sessionId,
     model: typeof model.display_name === 'string' ? model.display_name : null,
     totalInputTokens: asNumber(contextWindow.total_input_tokens, 0),
@@ -132,13 +144,21 @@ function persistPendingTelemetry(configDir: string): void {
     sessions: telemetryToObject(),
     account: accountTelemetry,
   };
-  fs.writeFileSync(pendingFilePath(configDir), JSON.stringify(payload, null, 2), 'utf-8');
+  const filePath = pendingFilePath(configDir);
+
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), 'utf-8');
+  } catch (err) {
+    console.warn('[telemetry] Failed to persist pending telemetry:', err);
+  }
 }
 
 function collectTelemetry(): void {
   if (!activeDeps) return;
 
-  const activeSessionIds = new Set(activeDeps.getActiveSessions().map((session) => session.id));
+  const activeSessions = activeDeps.getActiveSessions();
+  const activeSessionIds = new Set(activeSessions.map((session) => session.id));
 
   if (activeSessionIds.size > 0) {
     restoredPendingOnly = false;
@@ -151,7 +171,7 @@ function collectTelemetry(): void {
     sessionTelemetry = new Map();
   }
 
-  for (const session of activeDeps.getActiveSessions()) {
+  for (const session of activeSessions) {
     const filePath = path.join(telemetryDir(activeDeps.configDir), `${session.id}.json`);
     let raw: string;
     try {
@@ -176,8 +196,12 @@ function collectTelemetry(): void {
     if (!extracted) continue;
 
     if (!sameTelemetry(sessionTelemetry.get(session.id), extracted.session)) {
-      sessionTelemetry.set(session.id, extracted.session);
-      activeDeps.broadcastEvent('session-telemetry', { sessionId: session.id, data: extracted.session });
+      const nextSessionTelemetry: TelemetryData = {
+        ...extracted.session,
+        updatedAt: new Date().toISOString(),
+      };
+      sessionTelemetry.set(session.id, nextSessionTelemetry);
+      activeDeps.broadcastEvent('session-telemetry', { sessionId: session.id, data: nextSessionTelemetry });
     }
 
     if (extracted.account && !sameAccountTelemetry(accountTelemetry, extracted.account)) {

--- a/server/telemetry.ts
+++ b/server/telemetry.ts
@@ -1,0 +1,240 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+
+import type { AccountTelemetry, Session, TelemetryData } from './types.js';
+
+const POLL_INTERVAL_MS = 2_000;
+const PERSIST_INTERVAL_MS = 60_000;
+const STALE_THRESHOLD_MS = 5 * 60 * 1000;
+
+interface PendingTelemetryFile {
+  version: number;
+  timestamp: string;
+  sessions: Record<string, TelemetryData>;
+  account: AccountTelemetry | null;
+}
+
+export interface TelemetryDeps {
+  getActiveSessions: () => Array<Pick<Session, 'id'>>;
+  broadcastEvent: (type: string, data?: Record<string, unknown>) => void;
+  configDir: string;
+}
+
+let activeDeps: TelemetryDeps | null = null;
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let persistTimer: ReturnType<typeof setInterval> | null = null;
+let sessionTelemetry = new Map<string, TelemetryData>();
+let accountTelemetry: AccountTelemetry | null = null;
+let restoredPendingOnly = false;
+
+function telemetryDir(configDir: string): string {
+  return path.join(configDir, 'telemetry');
+}
+
+function pendingFilePath(configDir: string): string {
+  return path.join(configDir, 'pending-telemetry.json');
+}
+
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function asString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function telemetryToObject(): Record<string, TelemetryData> {
+  return Object.fromEntries(sessionTelemetry.entries());
+}
+
+function sameTelemetry(a: TelemetryData | undefined, b: TelemetryData): boolean {
+  return a !== undefined && JSON.stringify(a) === JSON.stringify(b);
+}
+
+function sameAccountTelemetry(a: AccountTelemetry | null, b: Omit<AccountTelemetry, 'updatedAt'>): boolean {
+  if (!a) return false;
+  return a.fiveHourUsedPercent === b.fiveHourUsedPercent
+    && a.fiveHourResetsAt === b.fiveHourResetsAt
+    && a.sevenDayUsedPercent === b.sevenDayUsedPercent
+    && a.sevenDayResetsAt === b.sevenDayResetsAt;
+}
+
+function extractTelemetry(sessionId: string, payload: unknown): {
+  session: TelemetryData;
+  account: Omit<AccountTelemetry, 'updatedAt'> | null;
+} | null {
+  if (!payload || typeof payload !== 'object') return null;
+
+  const data = payload as Record<string, unknown>;
+  const contextWindow = (data.context_window ?? {}) as Record<string, unknown>;
+  const currentUsage = (contextWindow.current_usage ?? {}) as Record<string, unknown>;
+  const cost = (data.cost ?? {}) as Record<string, unknown>;
+  const rateLimits = (data.rate_limits ?? {}) as Record<string, unknown>;
+  const fiveHour = (rateLimits.five_hour ?? {}) as Record<string, unknown>;
+  const sevenDay = (rateLimits.seven_day ?? {}) as Record<string, unknown>;
+  const model = (data.model ?? {}) as Record<string, unknown>;
+
+  const session: TelemetryData = {
+    sessionId,
+    model: typeof model.display_name === 'string' ? model.display_name : null,
+    totalInputTokens: asNumber(contextWindow.total_input_tokens, 0),
+    totalOutputTokens: asNumber(contextWindow.total_output_tokens, 0),
+    totalCacheRead: asNumber(currentUsage.cache_read_input_tokens, 0),
+    totalCacheWrite: asNumber(currentUsage.cache_creation_input_tokens, 0),
+    contextPercent: asNumber(contextWindow.used_percentage, -1),
+    contextWindowSize: asNumber(contextWindow.context_window_size, 0),
+    costUsd: typeof cost.total_cost_usd === 'number' ? cost.total_cost_usd : null,
+    source: 'statusLine',
+  };
+
+  const account = (
+    typeof fiveHour.used_percentage === 'number'
+    || typeof sevenDay.used_percentage === 'number'
+    || typeof fiveHour.resets_at === 'string'
+    || typeof sevenDay.resets_at === 'string'
+  ) ? {
+    fiveHourUsedPercent: asNumber(fiveHour.used_percentage, -1),
+    fiveHourResetsAt: asString(fiveHour.resets_at),
+    sevenDayUsedPercent: asNumber(sevenDay.used_percentage, -1),
+    sevenDayResetsAt: asString(sevenDay.resets_at),
+  } : null;
+
+  return { session, account };
+}
+
+function restorePendingTelemetry(configDir: string): void {
+  const pendingPath = pendingFilePath(configDir);
+  if (!fs.existsSync(pendingPath)) return;
+
+  try {
+    const pending = JSON.parse(fs.readFileSync(pendingPath, 'utf-8')) as PendingTelemetryFile;
+    const ageMs = Date.now() - new Date(pending.timestamp).getTime();
+    if (!Number.isFinite(ageMs) || ageMs > STALE_THRESHOLD_MS) {
+      fs.unlinkSync(pendingPath);
+      return;
+    }
+
+    sessionTelemetry = new Map(Object.entries(pending.sessions ?? {}));
+    accountTelemetry = pending.account ?? null;
+    restoredPendingOnly = sessionTelemetry.size > 0 || accountTelemetry !== null;
+    fs.unlinkSync(pendingPath);
+  } catch {
+    try { fs.unlinkSync(pendingPath); } catch { /* ignore */ }
+  }
+}
+
+function persistPendingTelemetry(configDir: string): void {
+  const payload: PendingTelemetryFile = {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    sessions: telemetryToObject(),
+    account: accountTelemetry,
+  };
+  fs.writeFileSync(pendingFilePath(configDir), JSON.stringify(payload, null, 2), 'utf-8');
+}
+
+function collectTelemetry(): void {
+  if (!activeDeps) return;
+
+  const activeSessionIds = new Set(activeDeps.getActiveSessions().map((session) => session.id));
+
+  if (activeSessionIds.size > 0) {
+    restoredPendingOnly = false;
+    for (const sessionId of [...sessionTelemetry.keys()]) {
+      if (!activeSessionIds.has(sessionId)) {
+        sessionTelemetry.delete(sessionId);
+      }
+    }
+  } else if (!restoredPendingOnly) {
+    sessionTelemetry = new Map();
+  }
+
+  for (const session of activeDeps.getActiveSessions()) {
+    const filePath = path.join(telemetryDir(activeDeps.configDir), `${session.id}.json`);
+    let raw: string;
+    try {
+      raw = fs.readFileSync(filePath, 'utf-8');
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException;
+      if (error.code !== 'ENOENT') {
+        console.warn(`[telemetry] Failed to read telemetry for session ${session.id}:`, err);
+      }
+      continue;
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(raw);
+    } catch (err) {
+      console.warn(`[telemetry] Malformed telemetry JSON for session ${session.id}:`, err);
+      continue;
+    }
+
+    const extracted = extractTelemetry(session.id, payload);
+    if (!extracted) continue;
+
+    if (!sameTelemetry(sessionTelemetry.get(session.id), extracted.session)) {
+      sessionTelemetry.set(session.id, extracted.session);
+      activeDeps.broadcastEvent('session-telemetry', { sessionId: session.id, data: extracted.session });
+    }
+
+    if (extracted.account && !sameAccountTelemetry(accountTelemetry, extracted.account)) {
+      accountTelemetry = {
+        ...extracted.account,
+        updatedAt: new Date().toISOString(),
+      };
+      activeDeps.broadcastEvent('account-telemetry', { data: accountTelemetry });
+    }
+  }
+}
+
+export function startTelemetry(deps: TelemetryDeps): void {
+  stopTelemetry();
+  activeDeps = deps;
+  restorePendingTelemetry(deps.configDir);
+  collectTelemetry();
+  pollTimer = setInterval(collectTelemetry, POLL_INTERVAL_MS);
+  persistTimer = setInterval(() => persistPendingTelemetry(deps.configDir), PERSIST_INTERVAL_MS);
+}
+
+export function stopTelemetry(): void {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+  if (persistTimer) {
+    clearInterval(persistTimer);
+    persistTimer = null;
+  }
+  if (activeDeps) {
+    persistPendingTelemetry(activeDeps.configDir);
+  }
+  activeDeps = null;
+  sessionTelemetry = new Map();
+  accountTelemetry = null;
+  restoredPendingOnly = false;
+}
+
+export function getTelemetryForSession(sessionId: string): TelemetryData | undefined {
+  return sessionTelemetry.get(sessionId);
+}
+
+export function getAccountTelemetry(): AccountTelemetry | null {
+  return accountTelemetry;
+}
+
+export function createTelemetryRouter(): Router {
+  const router = Router();
+
+  router.get('/sessions', (_req: Request, res: Response) => {
+    res.json(telemetryToObject());
+  });
+
+  router.get('/account', (_req: Request, res: Response) => {
+    res.json(accountTelemetry);
+  });
+
+  return router;
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -113,6 +113,7 @@ export interface TelemetryData {
   contextWindowSize: number;
   costUsd: number | null;
   source: 'statusLine' | 'jsonl';
+  updatedAt: string;
 }
 
 export interface AccountTelemetry {

--- a/server/types.ts
+++ b/server/types.ts
@@ -102,6 +102,27 @@ export interface SessionSummary {
   additionalDirs?: string[];
 }
 
+export interface TelemetryData {
+  sessionId: string;
+  model: string | null;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheRead: number;
+  totalCacheWrite: number;
+  contextPercent: number;
+  contextWindowSize: number;
+  costUsd: number | null;
+  source: 'statusLine' | 'jsonl';
+}
+
+export interface AccountTelemetry {
+  fiveHourUsedPercent: number;
+  fiveHourResetsAt: string;
+  sevenDayUsedPercent: number;
+  sevenDayResetsAt: string;
+  updatedAt: string;
+}
+
 export interface WorktreeMetadata {
   worktreePath: string;
   displayName: string;

--- a/test/pty-handler.test.ts
+++ b/test/pty-handler.test.ts
@@ -1,0 +1,15 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildStatusLineRelayScript } from '../server/pty-handler.js';
+
+describe('status-line relay script', () => {
+  it('writes telemetry via a temp file while streaming stdin once', () => {
+    const script = buildStatusLineRelayScript('session-123', '/tmp/claude-remote-config', '/usr/local/bin/status-line');
+
+    assert.match(script, /mktemp/);
+    assert.match(script, /tee "\$tmp_file"/);
+    assert.match(script, /mv "\$tmp_file"/);
+    assert.doesNotMatch(script, /input=\$\(cat\)/);
+  });
+});

--- a/test/telemetry-api.test.ts
+++ b/test/telemetry-api.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fetchSessionTelemetry, fetchTelemetrySetupStatus } from '../frontend/src/lib/api.js';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test('fetchSessionTelemetry handles plain object-map responses', async () => {
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    'session-1': {
+      sessionId: 'session-1',
+      model: 'Claude Sonnet 4',
+      totalInputTokens: 10,
+      totalOutputTokens: 20,
+      totalCacheRead: 30,
+      totalCacheWrite: 40,
+      contextPercent: 12,
+      contextWindowSize: 200000,
+      costUsd: 0.5,
+      turnCount: 1,
+      subagentCount: 2,
+      source: 'statusLine',
+      updatedAt: '2026-04-01T00:00:00.000Z',
+    },
+  }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })) as typeof globalThis.fetch;
+
+  const result = await fetchSessionTelemetry();
+
+  assert.deepEqual(result, [{
+    sessionId: 'session-1',
+    model: 'Claude Sonnet 4',
+    totalInputTokens: 10,
+    totalOutputTokens: 20,
+    totalCacheRead: 30,
+    totalCacheWrite: 40,
+    contextPercent: 12,
+    contextWindowSize: 200000,
+    costUsd: 0.5,
+    turnCount: 1,
+    subagentCount: 2,
+    source: 'statusLine',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+  }]);
+});
+
+test('fetchTelemetrySetupStatus returns installed flag from the server response', async () => {
+  globalThis.fetch = (async () => new Response(JSON.stringify({ installed: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })) as typeof globalThis.fetch;
+
+  assert.deepEqual(await fetchTelemetrySetupStatus(), { installed: true });
+});

--- a/test/telemetry-sync.test.ts
+++ b/test/telemetry-sync.test.ts
@@ -1,0 +1,93 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import type { AccountTelemetry, SessionTelemetry } from '../frontend/src/lib/types.js';
+import {
+  mergeAccountTelemetrySnapshot,
+  mergeSessionTelemetrySnapshot,
+} from '../frontend/src/lib/telemetry-sync.js';
+
+function makeSessionTelemetry(overrides: Partial<SessionTelemetry> = {}): SessionTelemetry {
+  return {
+    sessionId: 'session-1',
+    model: 'Claude Sonnet 4',
+    totalInputTokens: 10,
+    totalOutputTokens: 20,
+    totalCacheRead: 30,
+    totalCacheWrite: 40,
+    contextPercent: 12,
+    contextWindowSize: 200000,
+    costUsd: 0.5,
+    turnCount: 0,
+    subagentCount: 0,
+    source: 'statusLine',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeAccountTelemetry(overrides: Partial<AccountTelemetry> = {}): AccountTelemetry {
+  return {
+    fiveHourUsedPercent: 10,
+    fiveHourResetsAt: '2026-04-01T05:00:00.000Z',
+    sevenDayUsedPercent: 20,
+    sevenDayResetsAt: '2026-04-07T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('mergeSessionTelemetrySnapshot', () => {
+  it('keeps newer in-memory telemetry when an older snapshot finishes later', () => {
+    const currentSession = makeSessionTelemetry({
+      totalInputTokens: 99,
+      updatedAt: '2026-04-01T00:00:10.000Z',
+    });
+    const currentAccount = makeAccountTelemetry({
+      fiveHourUsedPercent: 55,
+      updatedAt: '2026-04-01T00:00:10.000Z',
+    });
+
+    const mergedSessions = mergeSessionTelemetrySnapshot(
+      {
+        'session-1': currentSession,
+        'stale-session': makeSessionTelemetry({ sessionId: 'stale-session' }),
+      },
+      [
+        makeSessionTelemetry({
+          totalInputTokens: 10,
+          updatedAt: '2026-04-01T00:00:05.000Z',
+        }),
+      ],
+      '2026-04-01T00:00:08.000Z',
+    );
+    const mergedAccount = mergeAccountTelemetrySnapshot(
+      currentAccount,
+      makeAccountTelemetry({
+        fiveHourUsedPercent: 20,
+        updatedAt: '2026-04-01T00:00:05.000Z',
+      }),
+      '2026-04-01T00:00:08.000Z',
+    );
+
+    assert.deepEqual(Object.keys(mergedSessions).sort(), ['session-1']);
+    assert.deepEqual(mergedSessions['session-1'], currentSession);
+    assert.deepEqual(mergedAccount, currentAccount);
+  });
+
+  it('preserves a newer websocket-only session that arrived after snapshot start', () => {
+    const currentSession = makeSessionTelemetry({
+      sessionId: 'session-2',
+      updatedAt: '2026-04-01T00:00:10.000Z',
+    });
+
+    const mergedSessions = mergeSessionTelemetrySnapshot(
+      { 'session-2': currentSession },
+      [],
+      '2026-04-01T00:00:08.000Z',
+    );
+
+    assert.deepEqual(Object.keys(mergedSessions), ['session-2']);
+    assert.deepEqual(mergedSessions['session-2'], currentSession);
+  });
+});

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -1,0 +1,298 @@
+import { test, before, afterEach, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import type { Server } from 'node:http';
+
+import {
+  createTelemetryRouter,
+  getAccountTelemetry,
+  getTelemetryForSession,
+  startTelemetry,
+  stopTelemetry,
+  type TelemetryDeps,
+} from '../server/telemetry.js';
+import type { Session } from '../server/types.js';
+
+const noopAuth = (_req: express.Request, _res: express.Response, next: express.NextFunction): void => next();
+
+let tmpDir: string;
+
+before(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-remote-cli-telemetry-test-'));
+});
+
+afterEach(() => {
+  stopTelemetry();
+  for (const entry of fs.readdirSync(tmpDir)) {
+    fs.rmSync(path.join(tmpDir, entry), { recursive: true, force: true });
+  }
+});
+
+after(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeSession(id: string): Session {
+  return { id } as unknown as Session;
+}
+
+function makeDeps(
+  sessionIds: string[],
+  events: Array<{ type: string; data?: Record<string, unknown> }>,
+  configDir = tmpDir,
+): TelemetryDeps {
+  return {
+    configDir,
+    getActiveSessions: () => sessionIds.map(makeSession),
+    broadcastEvent: (type, data) => {
+      if (data === undefined) events.push({ type });
+      else events.push({ type, data });
+    },
+  };
+}
+
+function writeStatusLineFile(sessionId: string, payload: unknown, configDir = tmpDir): string {
+  const telemetryDir = path.join(configDir, 'telemetry');
+  fs.mkdirSync(telemetryDir, { recursive: true });
+  const filePath = path.join(telemetryDir, `${sessionId}.json`);
+  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2));
+  return filePath;
+}
+
+function writePendingTelemetryFile(configDir: string, payload: unknown): string {
+  const filePath = path.join(configDir, 'pending-telemetry.json');
+  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2));
+  return filePath;
+}
+
+function sampleStatusLinePayload(): Record<string, unknown> {
+  return {
+    session_id: 'abc-123',
+    model: { id: 'claude-opus-4-6', display_name: 'Claude Opus 4.6' },
+    context_window: {
+      total_input_tokens: 12400,
+      total_output_tokens: 3200,
+      context_window_size: 200000,
+      used_percentage: 7.8,
+      remaining_percentage: 92.2,
+      current_usage: {
+        input_tokens: 500,
+        output_tokens: 100,
+        cache_creation_input_tokens: 1000,
+        cache_read_input_tokens: 5000,
+      },
+    },
+    cost: { total_cost_usd: 0.42 },
+    rate_limits: {
+      five_hour: { used_percentage: 22, resets_at: '2026-03-31T19:30:00Z' },
+      seven_day: { used_percentage: 8, resets_at: '2026-04-03T00:00:00Z' },
+    },
+  };
+}
+
+test('parses session telemetry from the statusLine file', () => {
+  const events: Array<{ type: string; data?: Record<string, unknown> }> = [];
+  writeStatusLineFile('abc-123', sampleStatusLinePayload());
+
+  startTelemetry(makeDeps(['abc-123'], events));
+
+  const account = getAccountTelemetry();
+  assert.deepEqual(getTelemetryForSession('abc-123'), {
+    sessionId: 'abc-123',
+    model: 'Claude Opus 4.6',
+    totalInputTokens: 12400,
+    totalOutputTokens: 3200,
+    totalCacheRead: 5000,
+    totalCacheWrite: 1000,
+    contextPercent: 7.8,
+    contextWindowSize: 200000,
+    costUsd: 0.42,
+    source: 'statusLine',
+  });
+
+  assert.deepEqual(account, {
+    fiveHourUsedPercent: 22,
+    fiveHourResetsAt: '2026-03-31T19:30:00Z',
+    sevenDayUsedPercent: 8,
+    sevenDayResetsAt: '2026-04-03T00:00:00Z',
+    updatedAt: account?.updatedAt,
+  });
+
+  assert.equal(events.filter((event) => event.type === 'session-telemetry').length, 1);
+  assert.equal(events.filter((event) => event.type === 'account-telemetry').length, 1);
+});
+
+test('missing statusLine file leaves telemetry undefined', () => {
+  const events: Array<{ type: string; data?: Record<string, unknown> }> = [];
+
+  startTelemetry(makeDeps(['missing-session'], events));
+
+  assert.equal(getTelemetryForSession('missing-session'), undefined);
+  assert.equal(getAccountTelemetry(), null);
+  assert.equal(events.length, 0);
+});
+
+test('inactive sessions are pruned once active telemetry is available', () => {
+  writePendingTelemetryFile(tmpDir, {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    sessions: {
+      stale: {
+        sessionId: 'stale',
+        model: 'Claude Sonnet 4',
+        totalInputTokens: 10,
+        totalOutputTokens: 20,
+        totalCacheRead: 30,
+        totalCacheWrite: 40,
+        contextPercent: 11,
+        contextWindowSize: 999,
+        costUsd: 1.23,
+        source: 'statusLine',
+      },
+    },
+    account: null,
+  });
+  writeStatusLineFile('fresh', sampleStatusLinePayload());
+
+  startTelemetry(makeDeps(['fresh'], []));
+
+  assert.equal(getTelemetryForSession('stale'), undefined);
+  assert.ok(getTelemetryForSession('fresh'));
+});
+
+test('malformed statusLine JSON is ignored without crashing', () => {
+  const events: Array<{ type: string; data?: Record<string, unknown> }> = [];
+  const telemetryDir = path.join(tmpDir, 'telemetry');
+  fs.mkdirSync(telemetryDir, { recursive: true });
+  fs.writeFileSync(path.join(telemetryDir, 'bad-session.json'), '{"model":');
+
+  assert.doesNotThrow(() => {
+    startTelemetry(makeDeps(['bad-session'], events));
+  });
+
+  assert.equal(getTelemetryForSession('bad-session'), undefined);
+  assert.equal(getAccountTelemetry(), null);
+  assert.equal(events.length, 0);
+});
+
+test('restores pending telemetry from disk on startup', () => {
+  const restored = {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    sessions: {
+      restored: {
+        sessionId: 'restored',
+        model: 'Claude Sonnet 4',
+        totalInputTokens: 10,
+        totalOutputTokens: 20,
+        totalCacheRead: 30,
+        totalCacheWrite: 40,
+        contextPercent: 11,
+        contextWindowSize: 999,
+        costUsd: 1.23,
+        source: 'statusLine',
+      },
+    },
+    account: {
+      fiveHourUsedPercent: 44,
+      fiveHourResetsAt: '2026-03-31T19:30:00Z',
+      sevenDayUsedPercent: 55,
+      sevenDayResetsAt: '2026-04-03T00:00:00Z',
+      updatedAt: '2026-03-31T18:00:00Z',
+    },
+  };
+  const pendingPath = writePendingTelemetryFile(tmpDir, restored);
+  const events: Array<{ type: string; data?: Record<string, unknown> }> = [];
+
+  startTelemetry(makeDeps([], events));
+
+  assert.deepEqual(getTelemetryForSession('restored'), {
+    sessionId: 'restored',
+    model: 'Claude Sonnet 4',
+    totalInputTokens: 10,
+    totalOutputTokens: 20,
+    totalCacheRead: 30,
+    totalCacheWrite: 40,
+    contextPercent: 11,
+    contextWindowSize: 999,
+    costUsd: 1.23,
+    source: 'statusLine',
+  });
+  assert.deepEqual(getAccountTelemetry(), restored.account);
+  assert.equal(fs.existsSync(pendingPath), false, 'pending telemetry should be cleared after restore');
+  assert.equal(events.length, 0);
+});
+
+test('GET /telemetry endpoints return session and account telemetry', async () => {
+  const restored = {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    sessions: {
+      endpoint: {
+        sessionId: 'endpoint',
+        model: 'Claude Opus 4.6',
+        totalInputTokens: 100,
+        totalOutputTokens: 200,
+        totalCacheRead: 300,
+        totalCacheWrite: 400,
+        contextPercent: 12.5,
+        contextWindowSize: 123456,
+        costUsd: 4.56,
+        source: 'statusLine',
+      },
+    },
+    account: {
+      fiveHourUsedPercent: 9,
+      fiveHourResetsAt: '2026-03-31T19:30:00Z',
+      sevenDayUsedPercent: 18,
+      sevenDayResetsAt: '2026-04-03T00:00:00Z',
+      updatedAt: '2026-03-31T18:00:00Z',
+    },
+  };
+  writePendingTelemetryFile(tmpDir, restored);
+  startTelemetry(makeDeps([], []));
+
+  let server: Server | undefined;
+  try {
+    const app = express();
+    app.use(express.json());
+    app.use('/telemetry', noopAuth, createTelemetryRouter());
+    server = await new Promise<Server>((resolve) => {
+      const srv = app.listen(0, '127.0.0.1', () => resolve(srv));
+    });
+
+    const addr = server.address();
+    assert.equal(typeof addr, 'object');
+    assert.ok(addr);
+    const baseUrl = `http://127.0.0.1:${(addr as { port: number }).port}`;
+
+    const sessionsRes = await fetch(`${baseUrl}/telemetry/sessions`);
+    assert.equal(sessionsRes.status, 200);
+    assert.deepEqual(await sessionsRes.json(), {
+      endpoint: {
+        sessionId: 'endpoint',
+        model: 'Claude Opus 4.6',
+        totalInputTokens: 100,
+        totalOutputTokens: 200,
+        totalCacheRead: 300,
+        totalCacheWrite: 400,
+        contextPercent: 12.5,
+        contextWindowSize: 123456,
+        costUsd: 4.56,
+        source: 'statusLine',
+      },
+    });
+
+    const accountRes = await fetch(`${baseUrl}/telemetry/account`);
+    assert.equal(accountRes.status, 200);
+    assert.deepEqual(await accountRes.json(), restored.account);
+  } finally {
+    await new Promise<void>((resolve) => {
+      if (server) server.close(() => resolve());
+      else resolve();
+    });
+  }
+});

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -99,8 +99,9 @@ test('parses session telemetry from the statusLine file', () => {
 
   startTelemetry(makeDeps(['abc-123'], events));
 
+  const session = getTelemetryForSession('abc-123');
   const account = getAccountTelemetry();
-  assert.deepEqual(getTelemetryForSession('abc-123'), {
+  assert.deepEqual(session, {
     sessionId: 'abc-123',
     model: 'Claude Opus 4.6',
     totalInputTokens: 12400,
@@ -111,6 +112,7 @@ test('parses session telemetry from the statusLine file', () => {
     contextWindowSize: 200000,
     costUsd: 0.42,
     source: 'statusLine',
+    updatedAt: session?.updatedAt,
   });
 
   assert.deepEqual(account, {
@@ -151,6 +153,7 @@ test('inactive sessions are pruned once active telemetry is available', () => {
         contextWindowSize: 999,
         costUsd: 1.23,
         source: 'statusLine',
+        updatedAt: '2026-03-31T17:00:00Z',
       },
     },
     account: null,
@@ -194,6 +197,7 @@ test('restores pending telemetry from disk on startup', () => {
         contextWindowSize: 999,
         costUsd: 1.23,
         source: 'statusLine',
+        updatedAt: '2026-03-31T18:00:00Z',
       },
     },
     account: {
@@ -220,6 +224,7 @@ test('restores pending telemetry from disk on startup', () => {
     contextWindowSize: 999,
     costUsd: 1.23,
     source: 'statusLine',
+    updatedAt: '2026-03-31T18:00:00Z',
   });
   assert.deepEqual(getAccountTelemetry(), restored.account);
   assert.equal(fs.existsSync(pendingPath), false, 'pending telemetry should be cleared after restore');
@@ -242,6 +247,7 @@ test('GET /telemetry endpoints return session and account telemetry', async () =
         contextWindowSize: 123456,
         costUsd: 4.56,
         source: 'statusLine',
+        updatedAt: '2026-03-31T18:00:00Z',
       },
     },
     account: {
@@ -283,6 +289,7 @@ test('GET /telemetry endpoints return session and account telemetry', async () =
         contextWindowSize: 123456,
         costUsd: 4.56,
         source: 'statusLine',
+        updatedAt: '2026-03-31T18:00:00Z',
       },
     });
 
@@ -295,4 +302,37 @@ test('GET /telemetry endpoints return session and account telemetry', async () =
       else resolve();
     });
   }
+});
+
+test('stopTelemetry ignores pending persistence write failures', () => {
+  const blockedPath = path.join(tmpDir, 'not-a-directory');
+  fs.writeFileSync(blockedPath, 'blocked');
+
+  startTelemetry(makeDeps([], [], blockedPath));
+
+  assert.doesNotThrow(() => {
+    stopTelemetry();
+  });
+});
+
+test('collectTelemetry reuses a single active session snapshot per poll', () => {
+  const events: Array<{ type: string; data?: Record<string, unknown> }> = [];
+  let calls = 0;
+
+  writeStatusLineFile('abc-123', sampleStatusLinePayload());
+
+  startTelemetry({
+    configDir: tmpDir,
+    getActiveSessions: () => {
+      calls++;
+      return [makeSession('abc-123')];
+    },
+    broadcastEvent: (type, data) => {
+      if (data === undefined) events.push({ type });
+      else events.push({ type, data });
+    },
+  });
+
+  assert.equal(calls, 1);
+  assert.equal(events.filter((event) => event.type === 'session-telemetry').length, 1);
 });

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -296,6 +296,10 @@ test('GET /telemetry endpoints return session and account telemetry', async () =
     const accountRes = await fetch(`${baseUrl}/telemetry/account`);
     assert.equal(accountRes.status, 200);
     assert.deepEqual(await accountRes.json(), restored.account);
+
+    const setupStatusRes = await fetch(`${baseUrl}/telemetry/setup-status`);
+    assert.equal(setupStatusRes.status, 200);
+    assert.deepEqual(await setupStatusRes.json(), { installed: true });
   } finally {
     await new Promise<void>((resolve) => {
       if (server) server.close(() => resolve());


### PR DESCRIPTION
## Summary
- add per-session statusLine telemetry collection on the server and persist/restream it over REST + websocket events
- add a session status bar plus repo/org usage panels driven by a new frontend telemetry store
- hide the session status bar, PR top bar, and session tabs when the mobile keyboard is open

## Verification
- `npm run check`
- `npm run build`
- `tsc -p tsconfig.test.json`
- `node --test dist/test/telemetry.test.js`
- `npm test` *(fails due to pre-existing environment/test issues listed below)*

## Known test blockers
- `dist/test/analytics.test.js` has 8 failures because `better-sqlite3` in the repo root `node_modules` is built for `NODE_MODULE_VERSION 137`, while the current Node runtime requires `141`
- `dist/test/server-startup.test.js` has 1 pre-existing `ENOTEMPTY` temp-dir cleanup failure
