### PR TITLE
feat: clickable URLs and file paths in terminal

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -639,6 +639,10 @@
     } else if (clickedPath.startsWith('./')) {
       relative = clickedPath.slice(2);
     }
+    // Normalize: strip any remaining leading "./" (e.g. from ${cwd}/./src/foo.ts)
+    while (relative.startsWith('./')) {
+      relative = relative.slice(2);
+    }
     openFileTab(relative, false);
   }
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -625,6 +625,23 @@
     openFileTab(filePath, isChanged);
   }
 
+  // Handle file path clicks from terminal output
+  function handleTerminalFilePathClick(clickedPath: string) {
+    const cwd = activeWorkspaceCwd;
+    if (!cwd) return;
+    // Resolve to a path relative to the workspace root
+    let relative = clickedPath;
+    if (clickedPath.startsWith(cwd + '/')) {
+      relative = clickedPath.slice(cwd.length + 1);
+    } else if (clickedPath.startsWith('/')) {
+      // Absolute path outside workspace — ignore
+      return;
+    } else if (clickedPath.startsWith('./')) {
+      relative = clickedPath.slice(2);
+    }
+    openFileTab(relative, false);
+  }
+
   // Handlers
   function handleSelectWorkspace(path: string) {
     if (ui.activeRepoPath === path) {
@@ -1174,6 +1191,7 @@
               onImageUpload={handleImageUpload}
               useTmux={activeSessionUseTmux}
               onCopyModeChange={handleCopyModeChange}
+              onFilePathClick={handleTerminalFilePathClick}
             />
 
             <Toolbar

--- a/frontend/src/components/Terminal.svelte
+++ b/frontend/src/components/Terminal.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { Terminal } from '@xterm/xterm';
   import { FitAddon } from '@xterm/addon-fit';
+  import { WebLinksAddon } from '@xterm/addon-web-links';
   import '@xterm/xterm/css/xterm.css';
   import { connectPtySocket, sendPtyData, sendPtyResize } from '../lib/ws.js';
   import { isMobileDevice } from '../lib/utils.js';
@@ -14,12 +15,14 @@
     onImageUpload,
     useTmux = false,
     onCopyModeChange,
+    onFilePathClick,
     companionMode = false,
   }: {
     sessionId: string | null;
     onImageUpload?: ((text: string, showInsert: boolean, path?: string) => void) | undefined;
     useTmux?: boolean;
     onCopyModeChange?: ((active: boolean) => void) | undefined;
+    onFilePathClick?: ((path: string) => void) | undefined;
     companionMode?: boolean;
   } = $props();
 
@@ -88,6 +91,45 @@
 
     fitAddon = new FitAddon();
     t.loadAddon(fitAddon);
+    t.loadAddon(new WebLinksAddon());
+
+    // File path link provider — matches paths like src/foo.ts or /abs/path.html
+    // and opens them in the in-app file viewer on click
+    const fileExtPattern = /(?:^|(?<=[\s'"(`\[{]))(\/?(?:\.\/)?(?:[\w.@~-]+\/)*(?:[\w.@~-]+\.(?:ts|tsx|js|jsx|svelte|html|htm|css|scss|json|yaml|yml|toml|md|txt|py|rs|go|rb|java|c|cpp|h|sh|sql|graphql|xml|csv|env|log|cfg|conf|ini)|(?:Makefile|Dockerfile|Vagrantfile|Rakefile|Gemfile|Procfile|Brewfile|Justfile|Taskfile|Containerfile)(?:\.\w+)?))(?::(\d+)(?::(\d+))?)?/;
+    t.registerLinkProvider({
+      provideLinks(lineNumber, callback) {
+        const line = t.buffer.active.getLine(lineNumber - 1);
+        if (!line) { callback(undefined); return; }
+        const text = line.translateToString(true);
+        const links: import('@xterm/xterm').ILink[] = [];
+        // Scan for all file path matches in the line
+        let offset = 0;
+        let remaining = text;
+        while (remaining.length > 0) {
+          const m = remaining.match(fileExtPattern);
+          if (!m || m.index === undefined) break;
+          const matchStart = offset + m.index;
+          const fullMatch = m[0];
+          const matchEnd = matchStart + fullMatch.length;
+          links.push({
+            range: {
+              start: { x: matchStart + 1, y: lineNumber },
+              end: { x: matchEnd + 1, y: lineNumber },
+            },
+            text: fullMatch,
+            activate(_event, linkText) {
+              // Strip trailing :line:col suffix to get clean path
+              const cleanPath = linkText.replace(/:\d+(?::\d+)?$/, '');
+              onFilePathClick?.(cleanPath);
+            },
+          });
+          offset = matchEnd;
+          remaining = text.slice(offset);
+        }
+        callback(links.length > 0 ? links : undefined);
+      },
+    });
+
     t.open(containerEl);
     if (isMobileDevice) {
       // Disable xterm's internal touch scroll — it scrolls one line at a time.

--- a/frontend/src/components/Terminal.svelte
+++ b/frontend/src/components/Terminal.svelte
@@ -94,37 +94,37 @@
     t.loadAddon(new WebLinksAddon());
 
     // File path link provider — matches paths like src/foo.ts or /abs/path.html
-    // and opens them in the in-app file viewer on click
-    const fileExtPattern = /(?:^|(?<=[\s'"(`\[{]))(\/?(?:\.\/)?(?:[\w.@~-]+\/)*(?:[\w.@~-]+\.(?:ts|tsx|js|jsx|svelte|html|htm|css|scss|json|yaml|yml|toml|md|txt|py|rs|go|rb|java|c|cpp|h|sh|sql|graphql|xml|csv|env|log|cfg|conf|ini)|(?:Makefile|Dockerfile|Vagrantfile|Rakefile|Gemfile|Procfile|Brewfile|Justfile|Taskfile|Containerfile)(?:\.\w+)?))(?::(\d+)(?::(\d+))?)?/;
+    // and opens them in the in-app file viewer on click.
+    // Uses a capturing group for the optional leading delimiter so we can compute
+    // the real match start without lookbehind (which breaks older iOS Safari).
+    const fileExtPattern = /([\s'"(`\[{])?(\/?\/?(?:\.\/)?(?:[\w.@~-]+\/)*(?:[\w.@~-]+\.(?:ts|tsx|js|jsx|svelte|html|htm|css|scss|json|yaml|yml|toml|md|txt|py|rs|go|rb|java|c|cpp|h|sh|sql|graphql|xml|csv|env|log|cfg|conf|ini)|(?:Makefile|Dockerfile|Vagrantfile|Rakefile|Gemfile|Procfile|Brewfile|Justfile|Taskfile|Containerfile)(?:\.\w+)?))(?::(\d+)(?::(\d+))?)?/g;
     t.registerLinkProvider({
       provideLinks(lineNumber, callback) {
         const line = t.buffer.active.getLine(lineNumber - 1);
         if (!line) { callback(undefined); return; }
         const text = line.translateToString(true);
         const links: import('@xterm/xterm').ILink[] = [];
-        // Scan for all file path matches in the line
-        let offset = 0;
-        let remaining = text;
-        while (remaining.length > 0) {
-          const m = remaining.match(fileExtPattern);
-          if (!m || m.index === undefined) break;
-          const matchStart = offset + m.index;
-          const fullMatch = m[0];
-          const matchEnd = matchStart + fullMatch.length;
+        // Use matchAll with a global regex to iterate without slicing
+        for (const m of text.matchAll(fileExtPattern)) {
+          if (m.index === undefined) continue;
+          const delimiter = m[1] || '';
+          // Only allow match at start-of-line or after a boundary character
+          if (m.index > 0 && !delimiter) continue;
+          const pathStart = m.index + delimiter.length;
+          const pathText = m[0].slice(delimiter.length);
+          const pathEnd = pathStart + pathText.length;
           links.push({
             range: {
-              start: { x: matchStart + 1, y: lineNumber },
-              end: { x: matchEnd + 1, y: lineNumber },
+              start: { x: pathStart + 1, y: lineNumber },
+              end: { x: pathEnd + 1, y: lineNumber },
             },
-            text: fullMatch,
+            text: pathText,
             activate(_event, linkText) {
               // Strip trailing :line:col suffix to get clean path
               const cleanPath = linkText.replace(/:\d+(?::\d+)?$/, '');
               onFilePathClick?.(cleanPath);
             },
           });
-          offset = matchEnd;
-          remaining = text.slice(offset);
         }
         callback(links.length > 0 ? links : undefined);
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@tanstack/svelte-query": "^6.0.18",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "better-sqlite3": "^12.8.0",
         "cookie-parser": "^1.4.7",
@@ -1348,6 +1349,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+      "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
       "license": "MIT"
     },
     "node_modules/@xterm/xterm": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@tanstack/svelte-query": "^6.0.18",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
     "better-sqlite3": "^12.8.0",
     "cookie-parser": "^1.4.7",


### PR DESCRIPTION
## Summary
- Adds `@xterm/addon-web-links` for clickable http/https URLs in terminal output (opens in new tab)
- Adds a custom link provider that detects file paths in terminal output and opens them in the in-app file viewer tab
- Supports paths with common extensions (.ts, .js, .svelte, .html, .css, .json, .md, .py, etc.) and extensionless special files (Makefile, Dockerfile, Vagrantfile, etc.)
- Handles absolute paths (resolved to workspace-relative), relative paths, and `./` prefixed paths
- Strips `:line:col` suffixes before opening

## Test plan
- [ ] Verify http/https URLs in terminal output are clickable and open in new tab
- [ ] Verify file paths like `src/foo.ts` in terminal output are clickable and open in file viewer
- [ ] Verify `Makefile` and `Dockerfile` paths are detected
- [ ] Verify paths with line numbers like `src/foo.ts:42` work (strip suffix)
- [ ] Verify absolute paths within workspace resolve correctly
- [ ] Verify absolute paths outside workspace are ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)