### PR TITLE
feat: remote browser — HTML viewer in FileViewerPane

### DIFF
--- a/bin/claude-remote-cli.ts
+++ b/bin/claude-remote-cli.ts
@@ -32,6 +32,8 @@ Commands:
     add [path] [-b branch] [--yolo]   Create worktree and launch Claude
     remove <path>                      Forward to git worktree remove
     list                               Forward to git worktree list
+  browser            Open an HTML file in the remote viewer
+    <path>             Path to HTML file
   pin                Manage authentication PIN
     reset              Reset the PIN (interactive, requires TTY)
 
@@ -292,6 +294,68 @@ if (command === 'install' || command === 'uninstall' || command === 'status' || 
         host: getArg('--host') ?? DEFAULTS.host,
       });
     });
+  }
+}
+
+if (command === 'browser') {
+  const browserArgs = args.slice(1);
+
+  if (browserArgs.includes('--help') || browserArgs.includes('-h') || browserArgs.length === 0) {
+    console.error(`Usage: claude-remote-cli browser <path>
+
+Opens an HTML file in the remote browser viewer tab.
+
+Arguments:
+  <path>    Path to HTML file (absolute or relative)
+
+Environment:
+  CLAUDE_REMOTE_PORT            Server port (default: 3456)
+  CLAUDE_REMOTE_BROWSER_TOKEN   Auth token for browser tab API`);
+    process.exit(browserArgs.includes('--help') || browserArgs.includes('-h') ? 0 : 1);
+  }
+
+  const filePath = path.resolve(browserArgs[0]!);
+
+  if (!fs.existsSync(filePath)) {
+    console.error(`Error: file not found: ${filePath}`);
+    process.exit(1);
+  }
+
+  const port = process.env['CLAUDE_REMOTE_PORT'] ?? String(DEFAULTS.port);
+  const token = process.env['CLAUDE_REMOTE_BROWSER_TOKEN'] ?? '';
+
+  if (!token) {
+    console.error('Error: CLAUDE_REMOTE_BROWSER_TOKEN not set. Are you running inside a claude-remote-cli session?');
+    process.exit(1);
+  }
+
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/browser-tabs`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({ path: filePath }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      console.error(`Error: server returned ${res.status}: ${body}`);
+      process.exit(1);
+    }
+
+    const data = await res.json() as { token: string; refreshed: boolean };
+    if (data.refreshed) {
+      console.log(`Refreshed: ${filePath}`);
+    } else {
+      console.log(`Opened: ${filePath}`);
+    }
+    process.exit(0);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Error: could not connect to server on port ${port}: ${msg}`);
+    process.exit(1);
   }
 }
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -50,7 +50,7 @@
   import FileTreeSidebar from './components/FileTreeSidebar.svelte';
   import FileViewerPane from './components/FileViewerPane.svelte';
   import SplitPaneLayout from './components/SplitPaneLayout.svelte';
-  import { openFileTab, toggleRightSidebarCollapsed } from './lib/state/ui.svelte.js';
+  import { openFileTab, openHtmlTab, refreshHtmlTab, toggleRightSidebarCollapsed } from './lib/state/ui.svelte.js';
 
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -549,6 +549,10 @@
       } else if (msg.type === 'session-activity-changed') {
         // No changed-files refresh here — git watcher handles actual file changes.
         // Refreshing on every tool call (Read, Grep, etc.) caused request floods.
+      } else if (msg.type === 'browser-tab-opened') {
+        openHtmlTab(msg.filePath, msg.token);
+      } else if (msg.type === 'browser-tab-refreshed') {
+        refreshHtmlTab(msg.filePath);
       }
     });
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -519,16 +519,16 @@
     connectEventSocket((msg) => {
       if (msg.type === 'worktrees-changed') {
         refreshAll();
-      } else if (msg.type === 'session-backend-state-changed' && msg.sessionId && msg.state) {
+      } else if (msg.type === 'session-backend-state-changed') {
         handleBackendStateChanged(msg.sessionId, msg.state, msg.permissionType);
-      } else if (msg.type === 'session-renamed' && msg.sessionId) {
-        renameSession(msg.sessionId, msg.branchName ?? '', msg.displayName ?? '');
-      } else if (msg.type === 'session-branch-changed' && msg.sessionId) {
-        handleBranchChanged(msg.sessionId, msg.branch ?? '');
+      } else if (msg.type === 'session-renamed') {
+        renameSession(msg.sessionId, msg.branchName, msg.displayName);
+      } else if (msg.type === 'session-branch-changed') {
+        handleBranchChanged(msg.sessionId, msg.branch);
       } else if (msg.type === 'session-ended') {
         invalidatePrQueries();
         refreshAll();
-      } else if (msg.type === 'ref-changed' && msg.cwdPath) {
+      } else if (msg.type === 'ref-changed') {
         const key = msg.cwdPath;
         const existing = refChangedTimers.get(key);
         if (existing) clearTimeout(existing);
@@ -540,7 +540,7 @@
         throttledPollInvalidate();
       } else if (msg.type === 'files-changed') {
         const activeWs = activeSession?.cwd ?? activeSession?.repoPath;
-        if (!msg.workspacePath || activeWs === msg.workspacePath) {
+        if (activeWs === msg.workspacePath) {
           throttledChangedFilesRefresh();
           if (msg.changedFiles) {
             changedFilesData = msg.changedFiles;

--- a/frontend/src/components/FileViewerPane.svelte
+++ b/frontend/src/components/FileViewerPane.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getUi, closeFileTab, closeAllFileTabs, refreshHtmlTab, type OpenFileTab } from '../lib/state/ui.svelte.js';
+  import { getUi, closeFileTab, closeAllFileTabs, refreshHtmlTab, fileTabKey, type OpenFileTab } from '../lib/state/ui.svelte.js';
   import { getSessionState } from '../lib/state/sessions.svelte.js';
   import { fetchFileDiff } from '../lib/api.js';
   import { diffSourceToBase } from '../lib/diff-utils.js';
@@ -40,7 +40,7 @@
 
   let base = $derived(diffSourceToBase(diffSource, defaultBranch));
   let activeTab = $derived<OpenFileTab | undefined>(
-    ui.openFileTabs.find(t => t.filePath === ui.activeFileTabPath)
+    ui.openFileTabs.find(t => fileTabKey(t.filePath, t.tabType) === ui.activeFileTabKey)
   );
   let activeDiff = $derived(activeTab ? diffCache.get(cacheKey(activeTab.filePath)) ?? '' : '');
   let activeLoading = $derived(activeTab ? loadingPaths.has(cacheKey(activeTab.filePath)) : false);
@@ -110,7 +110,7 @@
   }
 
   function handleTabClick(tab: OpenFileTab): void {
-    ui.activeFileTabPath = tab.filePath;
+    ui.activeFileTabKey = fileTabKey(tab.filePath, tab.tabType);
   }
 
   function handleDiffLineClick(filePath: string, lineNumber: number): void {
@@ -175,13 +175,13 @@
   <!-- File tab bar -->
   <div class="file-tab-bar">
     <div class="tabs-scroll">
-      {#each ui.openFileTabs as tab (tab.filePath + '::' + (tab.tabType ?? 'code'))}
+      {#each ui.openFileTabs as tab (fileTabKey(tab.filePath, tab.tabType))}
         <div
           class="file-tab"
-          class:active={ui.activeFileTabPath === tab.filePath}
+          class:active={ui.activeFileTabKey === fileTabKey(tab.filePath, tab.tabType)}
           role="tab"
           tabindex="0"
-          aria-selected={ui.activeFileTabPath === tab.filePath}
+          aria-selected={ui.activeFileTabKey === fileTabKey(tab.filePath, tab.tabType)}
           onclick={() => handleTabClick(tab)}
           onkeydown={(e) => { if (e.key === 'Enter') handleTabClick(tab); }}
           title={tab.filePath}
@@ -239,7 +239,7 @@
         <div class="error-text">failed to load diff: {activeError}</div>
         <div class="error-actions">
           <button class="retry-btn" onclick={handleRetry}>retry</button>
-          <button class="close-btn" onclick={() => closeFileTab(activeTab!.filePath)}>close tab</button>
+          <button class="close-btn" onclick={() => closeFileTab(activeTab!.filePath, activeTab!.tabType)}>close tab</button>
         </div>
       </div>
     {:else if activeTab.tabType === 'html' && activeTab.token}

--- a/frontend/src/components/FileViewerPane.svelte
+++ b/frontend/src/components/FileViewerPane.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getUi, closeFileTab, closeAllFileTabs, type OpenFileTab } from '../lib/state/ui.svelte.js';
+  import { getUi, closeFileTab, closeAllFileTabs, refreshHtmlTab, type OpenFileTab } from '../lib/state/ui.svelte.js';
   import { getSessionState } from '../lib/state/sessions.svelte.js';
   import { fetchFileDiff } from '../lib/api.js';
   import { diffSourceToBase } from '../lib/diff-utils.js';
@@ -62,6 +62,7 @@
   $effect(() => {
     const tab = activeTab;
     if (!tab || !workspacePath) return;
+    if (tab.tabType === 'html') return;
     const key = cacheKey(tab.filePath);
     if (diffCache.has(key)) return;
     if (loadingPaths.has(key)) return;
@@ -135,13 +136,41 @@
     };
     return map[ext] ?? 'text';
   }
+
+  // ── HTML tab support ──
+  const globeIcon = `<svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square"><circle cx="7" cy="7" r="5.5"/><path d="M1.5 7h11M7 1.5c-1.5 2-2 3.5-2 5.5s.5 3.5 2 5.5M7 1.5c1.5 2 2 3.5 2 5.5s-.5 3.5-2 5.5"/></svg>`;
+
+  let sandboxDismissed = $state(false);
+  let lastHtmlTabPath = $state('');
+
+  // Auto-dismiss sandbox notice after 4 seconds
+  $effect(() => {
+    if (activeTab?.tabType === 'html' && !sandboxDismissed) {
+      const timer = setTimeout(() => { sandboxDismissed = true; }, 4000);
+      return () => clearTimeout(timer);
+    }
+  });
+
+  // Reset dismissal when switching to a different HTML tab
+  $effect(() => {
+    if (activeTab?.tabType === 'html' && activeTab.filePath !== lastHtmlTabPath) {
+      lastHtmlTabPath = activeTab.filePath;
+      sandboxDismissed = false;
+    }
+  });
+
+  function handleRefresh(): void {
+    if (activeTab?.tabType === 'html' && activeTab.filePath) {
+      refreshHtmlTab(activeTab.filePath);
+    }
+  }
 </script>
 
 <div class="file-viewer">
   <!-- File tab bar -->
   <div class="file-tab-bar">
     <div class="tabs-scroll">
-      {#each ui.openFileTabs as tab (tab.filePath)}
+      {#each ui.openFileTabs as tab (tab.filePath + '::' + (tab.tabType ?? 'code'))}
         <div
           class="file-tab"
           class:active={ui.activeFileTabPath === tab.filePath}
@@ -152,6 +181,9 @@
           onkeydown={(e) => { if (e.key === 'Enter') handleTabClick(tab); }}
           title={tab.filePath}
         >
+          {#if tab.tabType === 'html'}
+            <span class="tab-icon">{@html globeIcon}</span>
+          {/if}
           <span class="tab-name">{tab.fileName}</span>
           {#if tab.isChanged}
             <span class="tab-badge">M</span>
@@ -168,6 +200,11 @@
       {#if activeTab?.isChanged}
         <button class="diff-mode-btn" onclick={toggleDiffViewMode} title="Toggle split/unified diff">
           {diffViewMode === 'unified' ? '[split]' : '[unified]'}
+        </button>
+      {/if}
+      {#if activeTab?.tabType === 'html'}
+        <button class="refresh-btn" onclick={handleRefresh} title="Reload HTML content">
+          [refresh]
         </button>
       {/if}
       {#if ui.openFileTabs.length > 1}
@@ -196,6 +233,21 @@
           <button class="retry-btn" onclick={handleRetry}>retry</button>
           <button class="close-btn" onclick={() => closeFileTab(activeTab!.filePath)}>close tab</button>
         </div>
+      </div>
+    {:else if activeTab.tabType === 'html' && activeTab.token}
+      <div class="html-viewer">
+        {#if !sandboxDismissed}
+          <div class="sandbox-notice">
+            <span class="notice-text">rendered in sandbox · some web features may not work</span>
+            <button class="notice-dismiss" onclick={() => { sandboxDismissed = true; }} aria-label="dismiss notice">×</button>
+          </div>
+        {/if}
+        <iframe
+          src="/browser-content/{activeTab.token}/{activeTab.fileName}"
+          sandbox="allow-scripts"
+          title="HTML preview: {activeTab.fileName}"
+          class="html-iframe"
+        ></iframe>
       </div>
     {:else if activeTab.isChanged && activeDiff}
       <!-- Diff view with line-click handler -->
@@ -470,5 +522,82 @@
 
   @keyframes braille-spin {
     to { content: '⠏'; }
+  }
+
+  /* HTML tab support */
+  .tab-icon {
+    display: inline-flex;
+    align-items: center;
+    color: var(--text-muted, #888);
+    margin-right: 4px;
+  }
+
+  .file-tab.active .tab-icon {
+    color: var(--text, #e0e0e0);
+  }
+
+  .refresh-btn {
+    background: none;
+    border: 1px solid var(--border, #333);
+    color: var(--text-muted, #888);
+    font-family: var(--font-mono, monospace);
+    font-size: var(--font-size-xs, 0.75rem);
+    cursor: pointer;
+    white-space: nowrap;
+    padding: 1px 6px;
+  }
+
+  .refresh-btn:hover {
+    color: var(--text, #e0e0e0);
+    border-color: var(--text-muted, #888);
+  }
+
+  .html-viewer {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+  }
+
+  .sandbox-notice {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 12px;
+    border-bottom: 1px solid var(--border, #333);
+    font-family: var(--font-mono, monospace);
+    font-size: var(--font-size-xs, 0.75rem);
+    color: var(--text-muted, #888);
+    transition: opacity 0.3s ease-out;
+  }
+
+  .notice-text {
+    font-family: inherit;
+  }
+
+  .notice-dismiss {
+    background: none;
+    border: none;
+    color: var(--text-muted, #888);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: var(--font-size-sm, 0.8125rem);
+    padding: 0 4px;
+    min-width: 44px;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .notice-dismiss:hover {
+    color: var(--text, #e0e0e0);
+  }
+
+  .html-iframe {
+    flex: 1;
+    width: 100%;
+    border: none;
+    background: white;
   }
 </style>

--- a/frontend/src/components/FileViewerPane.svelte
+++ b/frontend/src/components/FileViewerPane.svelte
@@ -94,10 +94,10 @@
     });
   });
 
-  function handleCloseTab(filePath: string, e: MouseEvent): void {
+  function handleCloseTab(tab: OpenFileTab, e: MouseEvent): void {
     e.stopPropagation();
-    closeFileTab(filePath);
-    const key = cacheKey(filePath);
+    closeFileTab(tab.filePath, tab.tabType);
+    const key = cacheKey(tab.filePath);
     diffCache.delete(key);
     errorPaths.delete(key);
     diffCache = new Map(diffCache);
@@ -190,7 +190,7 @@
           {/if}
           <button
             class="tab-close"
-            onclick={(e) => handleCloseTab(tab.filePath, e)}
+            onclick={(e) => handleCloseTab(tab, e)}
             aria-label="close {tab.fileName}"
           >×</button>
         </div>
@@ -243,7 +243,7 @@
           </div>
         {/if}
         <iframe
-          src="/browser-content/{activeTab.token}/{activeTab.fileName}"
+          src="/browser-content/{activeTab.token}/{activeTab.fileName}{activeTab.refreshVersion ? `?v=${activeTab.refreshVersion}` : ''}"
           sandbox="allow-scripts"
           title="HTML preview: {activeTab.fileName}"
           class="html-iframe"

--- a/frontend/src/lib/state/ui.svelte.ts
+++ b/frontend/src/lib/state/ui.svelte.ts
@@ -70,10 +70,14 @@ let fullPageDiff = $state<{
 // ── Right sidebar & file viewer state ──
 export type RightSidebarTab = 'changes' | 'all-files' | 'checks';
 
+export type FileTabType = 'diff' | 'code' | 'html';
+
 export interface OpenFileTab {
   filePath: string;
   fileName: string;
   isChanged: boolean; // true = show diff, false = show raw content
+  tabType?: FileTabType;  // undefined = legacy diff/code (backward compat)
+  token?: string;         // content token for html tabs
 }
 
 let fileDiffSource = $state<'working' | 'staged' | 'branch'>('working');
@@ -203,14 +207,22 @@ export function saveFileViewerRatio(): void {
   catch { /* localStorage unavailable */ }
 }
 
-export function openFileTab(filePath: string, isChanged: boolean): void {
+export function openFileTab(filePath: string, isChanged: boolean, tabType?: FileTabType, token?: string): void {
   const fileName = filePath.split('/').pop() ?? filePath;
-  const existing = openFileTabs.find(t => t.filePath === filePath);
+  const matchType = tabType ?? (isChanged ? 'diff' : 'code');
+  const existing = openFileTabs.find(t => t.filePath === filePath && (t.tabType ?? (t.isChanged ? 'diff' : 'code')) === matchType);
   if (!existing) {
-    openFileTabs = [...openFileTabs, { filePath, fileName, isChanged }];
-  } else if (existing.isChanged !== isChanged) {
-    // Update existing tab's mode if reopened from a different context (all-files vs changes)
-    openFileTabs = openFileTabs.map(t => t.filePath === filePath ? { ...t, isChanged } : t);
+    const newTab: OpenFileTab = { filePath, fileName, isChanged };
+    if (tabType) newTab.tabType = tabType;
+    if (token) newTab.token = token;
+    openFileTabs = [...openFileTabs, newTab];
+  } else if (existing.isChanged !== isChanged || existing.token !== token) {
+    openFileTabs = openFileTabs.map(t => {
+      if (t.filePath !== filePath || (t.tabType ?? (t.isChanged ? 'diff' : 'code')) !== matchType) return t;
+      const updated: OpenFileTab = { ...t, isChanged };
+      if (token !== undefined) updated.token = token;
+      return updated;
+    });
   }
   activeFileTabPath = filePath;
 }
@@ -225,6 +237,23 @@ export function closeFileTab(filePath: string): void {
 export function closeAllFileTabs(): void {
   openFileTabs = [];
   activeFileTabPath = null;
+}
+
+export function openHtmlTab(filePath: string, token: string): void {
+  openFileTab(filePath, false, 'html', token);
+}
+
+export function refreshHtmlTab(filePath: string): void {
+  const tab = openFileTabs.find(t => t.filePath === filePath && t.tabType === 'html');
+  if (tab && tab.token) {
+    const baseToken = tab.token.split('?')[0];
+    openFileTabs = openFileTabs.map(t =>
+      t.filePath === filePath && t.tabType === 'html'
+        ? { ...t, token: `${baseToken}?t=${Date.now()}` }
+        : t
+    );
+    activeFileTabPath = filePath;
+  }
 }
 export function saveSidebarWidth(): void {
   try { localStorage.setItem(SIDEBAR_WIDTH_KEY, String(sidebarWidth)); }

--- a/frontend/src/lib/state/ui.svelte.ts
+++ b/frontend/src/lib/state/ui.svelte.ts
@@ -78,6 +78,7 @@ export interface OpenFileTab {
   isChanged: boolean; // true = show diff, false = show raw content
   tabType?: FileTabType;  // undefined = legacy diff/code (backward compat)
   token?: string;         // content token for html tabs
+  refreshVersion?: number; // cache-buster for iframe reload
 }
 
 let fileDiffSource = $state<'working' | 'staged' | 'branch'>('working');
@@ -227,9 +228,13 @@ export function openFileTab(filePath: string, isChanged: boolean, tabType?: File
   activeFileTabPath = filePath;
 }
 
-export function closeFileTab(filePath: string): void {
-  openFileTabs = openFileTabs.filter(t => t.filePath !== filePath);
-  if (activeFileTabPath === filePath) {
+export function closeFileTab(filePath: string, tabType?: FileTabType): void {
+  if (tabType) {
+    openFileTabs = openFileTabs.filter(t => !(t.filePath === filePath && t.tabType === tabType));
+  } else {
+    openFileTabs = openFileTabs.filter(t => t.filePath !== filePath);
+  }
+  if (activeFileTabPath === filePath && !openFileTabs.some(t => t.filePath === filePath)) {
     activeFileTabPath = openFileTabs.length > 0 ? openFileTabs[openFileTabs.length - 1]!.filePath : null;
   }
 }
@@ -245,11 +250,10 @@ export function openHtmlTab(filePath: string, token: string): void {
 
 export function refreshHtmlTab(filePath: string): void {
   const tab = openFileTabs.find(t => t.filePath === filePath && t.tabType === 'html');
-  if (tab && tab.token) {
-    const baseToken = tab.token.split('?')[0];
+  if (tab) {
     openFileTabs = openFileTabs.map(t =>
       t.filePath === filePath && t.tabType === 'html'
-        ? { ...t, token: `${baseToken}?t=${Date.now()}` }
+        ? { ...t, refreshVersion: (t.refreshVersion ?? 0) + 1 }
         : t
     );
     activeFileTabPath = filePath;

--- a/frontend/src/lib/state/ui.svelte.ts
+++ b/frontend/src/lib/state/ui.svelte.ts
@@ -73,6 +73,10 @@ export type RightSidebarTab = 'changes' | 'all-files' | 'checks';
 
 export type FileTabType = 'diff' | 'code' | 'html';
 
+export function fileTabKey(filePath: string, tabType?: FileTabType): string {
+  return `${tabType ?? 'code'}::${filePath}`;
+}
+
 export interface OpenFileTab {
   filePath: string;
   fileName: string;
@@ -117,7 +121,7 @@ let rightSidebarWidth = $state((() => {
 })());
 let rightSidebarTab = $state<RightSidebarTab>('changes');
 let openFileTabs = $state<OpenFileTab[]>([]);
-let activeFileTabPath = $state<string | null>(null);
+let activeFileTabKey = $state<string | null>(null);
 let fileViewerRatio = $state((() => {
   try {
     const stored = localStorage.getItem(FILE_VIEWER_WIDTH_KEY);
@@ -192,8 +196,8 @@ export function getUi() {
     set rightSidebarTab(v: RightSidebarTab) { rightSidebarTab = v; },
     get openFileTabs() { return openFileTabs; },
     set openFileTabs(v: OpenFileTab[]) { openFileTabs = v; },
-    get activeFileTabPath() { return activeFileTabPath; },
-    set activeFileTabPath(v: string | null) { activeFileTabPath = v; },
+    get activeFileTabKey() { return activeFileTabKey; },
+    set activeFileTabKey(v: string | null) { activeFileTabKey = v; },
     get fileViewerRatio() { return fileViewerRatio; },
     set fileViewerRatio(v: number) { fileViewerRatio = v; },
     get sendToTargetSessionId() { return sendToTargetSessionId; },
@@ -228,19 +232,18 @@ export function openFileTab(filePath: string, isChanged: boolean, tabType?: File
   const matchType = tabType ?? (isChanged ? 'diff' : 'code');
   const existing = openFileTabs.find(t => t.filePath === filePath && (t.tabType ?? (t.isChanged ? 'diff' : 'code')) === matchType);
   if (!existing) {
-    const newTab: OpenFileTab = { filePath, fileName, isChanged };
-    if (tabType) newTab.tabType = tabType;
+    const newTab: OpenFileTab = { filePath, fileName, isChanged, tabType: matchType };
     if (token) newTab.token = token;
     openFileTabs = [...openFileTabs, newTab];
   } else if (existing.isChanged !== isChanged || existing.token !== token) {
     openFileTabs = openFileTabs.map(t => {
       if (t.filePath !== filePath || (t.tabType ?? (t.isChanged ? 'diff' : 'code')) !== matchType) return t;
-      const updated: OpenFileTab = { ...t, isChanged };
+      const updated: OpenFileTab = { ...t, isChanged, tabType: matchType };
       if (token !== undefined) updated.token = token;
       return updated;
     });
   }
-  activeFileTabPath = filePath;
+  activeFileTabKey = fileTabKey(filePath, matchType);
 }
 
 export function closeFileTab(filePath: string, tabType?: FileTabType): void {
@@ -249,14 +252,17 @@ export function closeFileTab(filePath: string, tabType?: FileTabType): void {
   } else {
     openFileTabs = openFileTabs.filter(t => t.filePath !== filePath);
   }
-  if (activeFileTabPath === filePath && !openFileTabs.some(t => t.filePath === filePath)) {
-    activeFileTabPath = openFileTabs.length > 0 ? openFileTabs[openFileTabs.length - 1]!.filePath : null;
+  const key = tabType ? fileTabKey(filePath, tabType) : null;
+  if (key ? activeFileTabKey === key : activeFileTabKey?.endsWith('::' + filePath)) {
+    activeFileTabKey = openFileTabs.length > 0
+      ? fileTabKey(openFileTabs[openFileTabs.length - 1]!.filePath, openFileTabs[openFileTabs.length - 1]!.tabType)
+      : null;
   }
 }
 
 export function closeAllFileTabs(): void {
   openFileTabs = [];
-  activeFileTabPath = null;
+  activeFileTabKey = null;
 }
 
 export function openHtmlTab(filePath: string, token: string): void {
@@ -271,7 +277,7 @@ export function refreshHtmlTab(filePath: string): void {
         ? { ...t, refreshVersion: (t.refreshVersion ?? 0) + 1 }
         : t
     );
-    activeFileTabPath = filePath;
+    activeFileTabKey = fileTabKey(filePath, 'html');
   }
 }
 export function saveSidebarWidth(): void {

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -2,21 +2,21 @@ import type { Terminal } from '@xterm/xterm';
 import type { BackendDisplayState } from './state/display-state.js';
 const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
 
-interface EventMessage {
-  type: string;
-  sessionId?: string;
-  idle?: boolean;
-  state?: BackendDisplayState;
-  permissionType?: 'approval' | 'question';
-  branchName?: string;
-  displayName?: string;
-  cwd?: string;
-  cwdPath?: string;
-  branch?: string;
-  repo?: string;
-  workspacePath?: string;
-  changedFiles?: string[];
-}
+// Discriminated union for WebSocket event messages.
+// Each event type declares only its required fields.
+export type EventMessage =
+  | { type: 'worktrees-changed' }
+  | { type: 'session-backend-state-changed'; sessionId: string; state: BackendDisplayState; permissionType?: 'approval' | 'question' }
+  | { type: 'session-renamed'; sessionId: string; branchName: string; displayName: string }
+  | { type: 'session-branch-changed'; sessionId: string; branch: string; cwdPath?: string }
+  | { type: 'session-ended'; sessionId?: string; cwd?: string; branchName?: string }
+  | { type: 'ref-changed'; cwdPath: string; branch?: string; repo?: string }
+  | { type: 'pr-updated' }
+  | { type: 'ci-updated' }
+  | { type: 'files-changed'; workspacePath: string; changedFiles?: string[] }
+  | { type: 'session-activity-changed'; sessionId: string }
+  | { type: 'browser-tab-opened'; filePath: string; token: string }
+  | { type: 'browser-tab-refreshed'; filePath: string };
 
 type EventCallback = (msg: EventMessage) => void;
 

--- a/server/browser-content.ts
+++ b/server/browser-content.ts
@@ -95,10 +95,6 @@ export function createBrowserContentRouter(
     }
 
     const resolved = path.resolve(filePath);
-    if (!path.isAbsolute(resolved)) {
-      res.status(400).json({ error: 'path must be absolute' });
-      return;
-    }
 
     try {
       const stat = fs.statSync(resolved);

--- a/server/browser-content.ts
+++ b/server/browser-content.ts
@@ -1,0 +1,150 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import crypto from 'node:crypto';
+import { Router } from 'express';
+import type express from 'express';
+
+// ── Content token store ──
+interface TokenEntry {
+  baseDir: string;
+  filePath: string;
+  createdAt: number;
+}
+
+const tokenStore = new Map<string, TokenEntry>();
+const pathToToken = new Map<string, string>();
+
+// ── Scoped auth token ──
+let scopedToken = '';
+
+export function generateScopedToken(): string {
+  scopedToken = crypto.randomBytes(32).toString('hex');
+  return scopedToken;
+}
+
+export function validateScopedToken(token: string): boolean {
+  return token.length > 0 && token === scopedToken;
+}
+
+// ── Content tokens ──
+export function createBrowserToken(filePath: string): string {
+  const existing = pathToToken.get(filePath);
+  if (existing && tokenStore.has(existing)) return existing;
+
+  const token = crypto.randomBytes(16).toString('hex');
+  const baseDir = path.dirname(filePath);
+  tokenStore.set(token, { baseDir, filePath, createdAt: Date.now() });
+  pathToToken.set(filePath, token);
+  return token;
+}
+
+export function validateToken(token: string): { baseDir: string; filePath: string } | null {
+  const entry = tokenStore.get(token);
+  return entry ? { baseDir: entry.baseDir, filePath: entry.filePath } : null;
+}
+
+export function resolveTokenPath(token: string, relativePath: string): string | null {
+  const entry = tokenStore.get(token);
+  if (!entry) return null;
+  if (path.isAbsolute(relativePath)) return null;
+
+  const resolved = path.resolve(entry.baseDir, relativePath);
+  if (!resolved.startsWith(entry.baseDir + path.sep) && resolved !== entry.baseDir) return null;
+
+  return resolved;
+}
+
+export function getTokenForPath(filePath: string): string | null {
+  return pathToToken.get(filePath) ?? null;
+}
+
+export function cleanExpiredTokens(ttlMs: number): void {
+  const now = Date.now();
+  for (const [token, entry] of tokenStore) {
+    if (now - entry.createdAt >= ttlMs) {
+      tokenStore.delete(token);
+      pathToToken.delete(entry.filePath);
+    }
+  }
+}
+
+export function _resetForTesting(): void {
+  tokenStore.clear();
+  pathToToken.clear();
+  scopedToken = '';
+}
+
+// ── Express router ──
+export function createBrowserContentRouter(
+  broadcastEvent: (type: string, data?: Record<string, unknown>) => void,
+): Router {
+  const router = Router();
+
+  router.post('/browser-tabs', (req: express.Request, res: express.Response) => {
+    const authHeader = req.headers.authorization;
+    const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : '';
+    if (!validateScopedToken(bearerToken)) {
+      res.status(401).json({ error: 'Invalid browser token' });
+      return;
+    }
+
+    const { path: filePath } = req.body as { path?: string };
+    if (!filePath || typeof filePath !== 'string') {
+      res.status(400).json({ error: 'path is required' });
+      return;
+    }
+
+    const resolved = path.resolve(filePath);
+    if (!path.isAbsolute(resolved)) {
+      res.status(400).json({ error: 'path must be absolute' });
+      return;
+    }
+
+    try {
+      const stat = fs.statSync(resolved);
+      if (!stat.isFile()) {
+        res.status(400).json({ error: 'path must be a file, not a directory' });
+        return;
+      }
+    } catch {
+      res.status(404).json({ error: 'file not found' });
+      return;
+    }
+
+    const existingToken = getTokenForPath(resolved);
+    if (existingToken) {
+      broadcastEvent('browser-tab-refreshed', { filePath: resolved });
+      res.json({ token: existingToken, refreshed: true });
+      return;
+    }
+
+    const token = createBrowserToken(resolved);
+    broadcastEvent('browser-tab-opened', { filePath: resolved, token });
+    res.json({ token, refreshed: false });
+  });
+
+  router.get('/browser-content/:token/*', (req: express.Request, res: express.Response) => {
+    const { token } = req.params;
+    const relativePath = req.params[0] ?? '';
+
+    if (!relativePath) {
+      res.status(400).send('Missing file path');
+      return;
+    }
+
+    const resolved = resolveTokenPath(token!, relativePath);
+    if (!resolved) {
+      res.status(403).send('Forbidden');
+      return;
+    }
+
+    if (!fs.existsSync(resolved)) {
+      res.status(404).send('Not found');
+      return;
+    }
+
+    res.sendFile(resolved);
+  });
+
+  return router;
+}

--- a/server/browser-content.ts
+++ b/server/browser-content.ts
@@ -51,6 +51,14 @@ export function resolveTokenPath(token: string, relativePath: string): string | 
   const resolved = path.resolve(entry.baseDir, relativePath);
   if (!resolved.startsWith(entry.baseDir + path.sep) && resolved !== entry.baseDir) return null;
 
+  try {
+    const realBaseDir = fs.realpathSync(entry.baseDir);
+    const realResolved = fs.realpathSync(resolved);
+    if (realResolved !== realBaseDir && !realResolved.startsWith(realBaseDir + path.sep)) return null;
+  } catch {
+    return null;
+  }
+
   return resolved;
 }
 
@@ -134,8 +142,15 @@ export function createBrowserContentRouter(
       return;
     }
 
-    if (!fs.existsSync(resolved)) {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(resolved);
+    } catch {
       res.status(404).send('Not found');
+      return;
+    }
+    if (!stat.isFile()) {
+      res.status(400).send('Not a file');
       return;
     }
 

--- a/server/browser-content.ts
+++ b/server/browser-content.ts
@@ -117,6 +117,10 @@ export function createBrowserContentRouter(
 
     const existingToken = getTokenForPath(resolved);
     if (existingToken) {
+      // Always emit browser-tab-opened (not just refreshed) so reconnecting clients,
+      // second devices, or users who closed the tab get it re-opened with the token.
+      // openHtmlTab on the frontend is idempotent — it focuses existing tabs.
+      broadcastEvent('browser-tab-opened', { filePath: resolved, token: existingToken });
       broadcastEvent('browser-tab-refreshed', { filePath: resolved });
       res.json({ token: existingToken, refreshed: true });
       return;

--- a/server/index.ts
+++ b/server/index.ts
@@ -37,6 +37,7 @@ import { createWebhookManagerRouter, reloadSmee, startSmartPolling } from './web
 import { fetchPrsGraphQL } from './github-graphql.js';
 import type { AgentType, AutomationSettings, Config, ContinuePolicy } from './types.js';
 import { semverLessThan } from './utils.js';
+import { createBrowserContentRouter, generateScopedToken, cleanExpiredTokens } from './browser-content.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -286,6 +287,15 @@ async function main(): Promise<void> {
 
   const server = http.createServer(app);
   const { broadcastEvent, broadcastBranchChanged } = setupWebSocket(server, authenticatedTokens, watcher, CONFIG_PATH);
+
+  const browserScopedToken = generateScopedToken();
+  process.env['CLAUDE_REMOTE_BROWSER'] = '1';
+  process.env['CLAUDE_REMOTE_BROWSER_CMD'] = 'claude-remote-cli browser';
+  process.env['CLAUDE_REMOTE_BROWSER_TOKEN'] = browserScopedToken;
+  if (!process.env['CLAUDE_REMOTE_PORT']) {
+    process.env['CLAUDE_REMOTE_PORT'] = String(startupConfig.port);
+  }
+
   // Wire up the delegate used by the webhook router (mounted before broadcastEvent was available)
   // Also clear the PR cache on real webhook events — these indicate actual PR state changes
   broadcastEventDelegate = (type, data) => {
@@ -1463,6 +1473,14 @@ async function main(): Promise<void> {
       res.status(500).json({ ok: false, error: message });
     }
   });
+
+  // Browser content viewer (token-based auth, not cookie auth)
+  const browserContentRouter = createBrowserContentRouter(broadcastEvent);
+  app.use(browserContentRouter);
+
+  // Clean expired browser content tokens every hour
+  const BROWSER_TOKEN_TTL = 24 * 60 * 60 * 1000;
+  setInterval(() => cleanExpiredTokens(BROWSER_TOKEN_TTL), 60 * 60 * 1000);
 
   // Clean up orphaned tmux sessions from previous runs (skip any adopted by restore)
   // Skip in dev mode — another server instance owns these sessions

--- a/test/browser-cli.test.ts
+++ b/test/browser-cli.test.ts
@@ -1,0 +1,84 @@
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browser-cli-test-'));
+  fs.writeFileSync(path.join(tmpDir, 'test.html'), '<h1>Test</h1>');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+test('browser command with no args prints usage and exits 1', () => {
+  try {
+    execFileSync('node', ['dist/bin/claude-remote-cli.js', 'browser'], {
+      encoding: 'utf-8',
+      env: { ...process.env, PATH: process.env.PATH },
+    });
+    assert.fail('Should have exited with code 1');
+  } catch (err) {
+    const e = err as { status?: number; stderr?: string };
+    assert.strictEqual(e.status, 1);
+    assert.ok((e.stderr ?? '').includes('Usage'));
+  }
+});
+
+test('browser --help shows usage and exits 0', () => {
+  try {
+    const output = execFileSync('node', ['dist/bin/claude-remote-cli.js', 'browser', '--help'], {
+      encoding: 'utf-8',
+      env: { ...process.env, PATH: process.env.PATH },
+    });
+    assert.ok(output.includes('Usage') || output.includes('browser'));
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    // --help may print to stderr
+    const out = (e.stdout ?? '') + (e.stderr ?? '');
+    assert.ok(out.includes('Usage') || out.includes('browser'));
+  }
+});
+
+test('browser command fails gracefully when server is not running', () => {
+  try {
+    execFileSync('node', ['dist/bin/claude-remote-cli.js', 'browser', path.join(tmpDir, 'test.html')], {
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        CLAUDE_REMOTE_PORT: '19999',
+        CLAUDE_REMOTE_BROWSER_TOKEN: 'test-token',
+        PATH: process.env.PATH,
+      },
+    });
+    assert.fail('Should have exited with error');
+  } catch (err) {
+    const e = err as { status?: number; stderr?: string };
+    assert.ok(e.status !== 0);
+    assert.ok((e.stderr ?? '').includes('connect') || (e.stderr ?? '').includes('ECONNREFUSED') || (e.stderr ?? '').includes('Error'));
+  }
+});
+
+test('browser command fails when token not set', () => {
+  try {
+    execFileSync('node', ['dist/bin/claude-remote-cli.js', 'browser', path.join(tmpDir, 'test.html')], {
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        CLAUDE_REMOTE_PORT: '19999',
+        CLAUDE_REMOTE_BROWSER_TOKEN: '', // empty token
+        PATH: process.env.PATH,
+      },
+    });
+    assert.fail('Should have exited with error');
+  } catch (err) {
+    const e = err as { status?: number; stderr?: string };
+    assert.ok(e.status !== 0);
+    assert.ok((e.stderr ?? '').includes('CLAUDE_REMOTE_BROWSER_TOKEN'));
+  }
+});

--- a/test/browser-content.test.ts
+++ b/test/browser-content.test.ts
@@ -1,0 +1,120 @@
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  createBrowserToken,
+  validateToken,
+  resolveTokenPath,
+  generateScopedToken,
+  validateScopedToken,
+  cleanExpiredTokens,
+  getTokenForPath,
+  _resetForTesting,
+} from '../server/browser-content.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  _resetForTesting();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browser-content-test-'));
+  fs.writeFileSync(path.join(tmpDir, 'index.html'), '<h1>Hello</h1>');
+  fs.writeFileSync(path.join(tmpDir, 'styles.css'), 'body { color: red; }');
+  fs.mkdirSync(path.join(tmpDir, 'sub'));
+  fs.writeFileSync(path.join(tmpDir, 'sub', 'nested.js'), 'console.log("hi")');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// Content token tests
+test('createBrowserToken returns a token string', () => {
+  const token = createBrowserToken(path.join(tmpDir, 'index.html'));
+  assert.ok(typeof token === 'string');
+  assert.ok(token.length > 0);
+});
+
+test('validateToken returns baseDir for valid token', () => {
+  const filePath = path.join(tmpDir, 'index.html');
+  const token = createBrowserToken(filePath);
+  const result = validateToken(token);
+  assert.ok(result);
+  assert.strictEqual(result.baseDir, tmpDir);
+});
+
+test('validateToken returns null for invalid token', () => {
+  assert.strictEqual(validateToken('nonexistent-token'), null);
+});
+
+test('resolveTokenPath serves file within baseDir', () => {
+  const filePath = path.join(tmpDir, 'index.html');
+  const token = createBrowserToken(filePath);
+  assert.strictEqual(resolveTokenPath(token, 'index.html'), filePath);
+});
+
+test('resolveTokenPath serves nested file', () => {
+  const filePath = path.join(tmpDir, 'index.html');
+  const token = createBrowserToken(filePath);
+  assert.strictEqual(resolveTokenPath(token, 'sub/nested.js'), path.join(tmpDir, 'sub', 'nested.js'));
+});
+
+test('resolveTokenPath rejects path traversal', () => {
+  const token = createBrowserToken(path.join(tmpDir, 'index.html'));
+  assert.strictEqual(resolveTokenPath(token, '../../../etc/passwd'), null);
+});
+
+test('resolveTokenPath rejects absolute path in relative', () => {
+  const token = createBrowserToken(path.join(tmpDir, 'index.html'));
+  assert.strictEqual(resolveTokenPath(token, '/etc/passwd'), null);
+});
+
+// Scoped auth token tests
+test('generateScopedToken returns a hex string', () => {
+  const token = generateScopedToken();
+  assert.ok(/^[a-f0-9]+$/.test(token));
+});
+
+test('validateScopedToken returns true for correct token', () => {
+  const token = generateScopedToken();
+  assert.strictEqual(validateScopedToken(token), true);
+});
+
+test('validateScopedToken returns false for wrong token', () => {
+  generateScopedToken();
+  assert.strictEqual(validateScopedToken('wrong-token'), false);
+});
+
+// Token expiry tests
+test('cleanExpiredTokens removes old tokens', () => {
+  const token = createBrowserToken(path.join(tmpDir, 'index.html'));
+  assert.ok(validateToken(token));
+  cleanExpiredTokens(0); // TTL of 0ms = everything expired
+  assert.strictEqual(validateToken(token), null);
+});
+
+test('cleanExpiredTokens keeps fresh tokens', () => {
+  const token = createBrowserToken(path.join(tmpDir, 'index.html'));
+  cleanExpiredTokens(24 * 60 * 60 * 1000);
+  assert.ok(validateToken(token));
+});
+
+// Idempotent token creation
+test('createBrowserToken for same path returns existing token', () => {
+  const filePath = path.join(tmpDir, 'index.html');
+  const token1 = createBrowserToken(filePath);
+  const token2 = createBrowserToken(filePath);
+  assert.strictEqual(token1, token2);
+});
+
+// getTokenForPath
+test('getTokenForPath returns token for known path', () => {
+  const filePath = path.join(tmpDir, 'index.html');
+  const token = createBrowserToken(filePath);
+  assert.strictEqual(getTokenForPath(filePath), token);
+});
+
+test('getTokenForPath returns null for unknown path', () => {
+  assert.strictEqual(getTokenForPath('/no/such/file'), null);
+});

--- a/test/browser-tabs-ui.test.ts
+++ b/test/browser-tabs-ui.test.ts
@@ -36,9 +36,10 @@ test('openHtmlTab logic creates correct tab shape', () => {
   assert.strictEqual(tab.token, 'abc123');
 });
 
-test('refreshHtmlTab logic appends cache buster', () => {
+test('refreshHtmlTab logic uses version counter', () => {
   const baseUrl = '/browser-content/abc123/design-board.html';
-  const refreshed = `${baseUrl}?t=${Date.now()}`;
-  assert.ok(refreshed.includes('?t='));
+  const refreshVersion = 1;
+  const refreshed = `${baseUrl}?v=${refreshVersion}`;
+  assert.ok(refreshed.includes('?v='));
   assert.ok(refreshed.startsWith(baseUrl));
 });

--- a/test/browser-tabs-ui.test.ts
+++ b/test/browser-tabs-ui.test.ts
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+// Test the pure logic of tab identity and deduplication.
+// We can't import .svelte.ts files in node:test (they need the Svelte compiler),
+// so we test the logic by duplicating the key algorithm here.
+
+function tabKey(filePath: string, tabType: string): string {
+  return `${tabType}::${filePath}`;
+}
+
+test('tabKey differentiates same file with different types', () => {
+  const diffKey = tabKey('/tmp/index.html', 'diff');
+  const htmlKey = tabKey('/tmp/index.html', 'html');
+  assert.notStrictEqual(diffKey, htmlKey);
+});
+
+test('tabKey matches same file with same type', () => {
+  const key1 = tabKey('/tmp/index.html', 'html');
+  const key2 = tabKey('/tmp/index.html', 'html');
+  assert.strictEqual(key1, key2);
+});
+
+test('openHtmlTab logic creates correct tab shape', () => {
+  const filePath = '/tmp/gstack-sketch/design-board.html';
+  const tab = {
+    filePath,
+    fileName: filePath.split('/').pop() ?? filePath,
+    isChanged: false,
+    tabType: 'html' as const,
+    token: 'abc123',
+  };
+  assert.strictEqual(tab.fileName, 'design-board.html');
+  assert.strictEqual(tab.isChanged, false);
+  assert.strictEqual(tab.tabType, 'html');
+  assert.strictEqual(tab.token, 'abc123');
+});
+
+test('refreshHtmlTab logic appends cache buster', () => {
+  const baseUrl = '/browser-content/abc123/design-board.html';
+  const refreshed = `${baseUrl}?t=${Date.now()}`;
+  assert.ok(refreshed.includes('?t='));
+  assert.ok(refreshed.startsWith(baseUrl));
+});

--- a/test/event-message-types.test.ts
+++ b/test/event-message-types.test.ts
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { execFileSync } from 'node:child_process';
+
+test('EventMessage types compile without errors', () => {
+  try {
+    execFileSync('npx', ['tsc', '--noEmit', '--strict', '-p', 'tsconfig.json'], {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+    });
+    assert.ok(true, 'TypeScript compilation succeeded');
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string };
+    assert.fail(`TypeScript compilation failed:\n${e.stdout ?? ''}\n${e.stderr ?? ''}`);
+  }
+});

--- a/test/event-message-types.test.ts
+++ b/test/event-message-types.test.ts
@@ -1,10 +1,25 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import fs from 'node:fs';
+
+function findTsc(startDir: string): string {
+  let dir = startDir;
+  for (let i = 0; i < 5; i++) {
+    const candidate = path.join(dir, 'node_modules', '.bin', 'tsc');
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return 'tsc'; // fallback to PATH
+}
 
 test('EventMessage types compile without errors', () => {
+  const tscPath = findTsc(process.cwd());
   try {
-    execFileSync('npx', ['tsc', '--noEmit', '--strict', '-p', 'tsconfig.json'], {
+    execFileSync(tscPath, ['--noEmit', '--strict', '-p', 'tsconfig.json'], {
       cwd: process.cwd(),
       encoding: 'utf-8',
     });


### PR DESCRIPTION
## Summary

Adds a remote browser feature that lets AI agents surface HTML files (design mockups, comparison boards, wireframes) as viewable tabs in the remote web UI. When an agent generates an HTML file, it appears in a viewer pane next to the terminal instead of being invisible to remote users.

**Architecture:** Extends the existing FileViewerPane (diff/code tabs) with an `html` tab type rendered via sandboxed iframe. Token-based content serving ensures auth without cookies (iframe sandbox blocks cookie access). CLI sub-command bridges agents to the server.

**Key changes:**
- **EventMessage discriminated union** — refactored from bag-of-optionals to typed union (12+ event types with compile-time safety)
- **OpenFileTab.tabType** — new field supporting `diff | code | html` with (filePath, tabType) composite key
- **server/browser-content.ts** — new module: token store, scoped auth, POST /browser-tabs, GET /browser-content/:token/*
- **FileViewerPane.svelte** — iframe render, SVG globe icon, [refresh] button, 4-second auto-dismiss sandbox notice
- **CLI `browser` sub-command** — `claude-remote-cli browser <path>` discovers server via env vars, POSTs to open/refresh tabs
- **PTY env injection** — `CLAUDE_REMOTE_BROWSER`, `_CMD`, `_PORT`, `_BROWSER_TOKEN` for agent discovery

**Security model:**
- iframe sandbox: `allow-scripts` only (no `allow-same-origin` — prevents parent frame access)
- Content tokens: random 16-byte hex, 24h TTL with hourly sweep
- Scoped auth token: CLI uses a limited-scope Bearer token that only authorizes POST /browser-tabs
- Path traversal prevention: resolved paths validated against base directory

## Test Coverage
- 23 new tests across 3 test files
- `test/browser-content.test.ts` — 15 tests (token CRUD, path traversal, TTL expiry, scoped auth)
- `test/browser-tabs-ui.test.ts` — 4 tests (tab key logic, HTML tab shape)
- `test/browser-cli.test.ts` — 4 tests (no-args usage, --help, server down, missing token)

## Pre-Landing Review
3 issues found and fixed:
- [CRITICAL] Refresh URL corruption (cache-buster in token path) — fixed with version counter
- [MEDIUM] closeFileTab ignored tabType — fixed with composite key filter
- [INFO] Dead code (unreachable path.isAbsolute check) — removed

Adversarial review ran (Claude + Codex). Both independently caught the refresh URL bug.

## Test plan
- [x] All tests pass (720/720)
- [x] Build clean (0 errors)
- [x] TypeScript compilation clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)