### PR TITLE
refactor: separate git/gh API endpoints for fast boot

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2,7 +2,7 @@
   import { onMount, onDestroy } from 'svelte';
   import { getAuth, checkExistingAuth } from './lib/state/auth.svelte.js';
   import { getUi, openSidebar, closeSidebar, toggleSidebarCollapsed } from './lib/state/ui.svelte.js';
-  import { getSessionState, refreshAll, refreshWorktreesEnriched, handleBackendStateChanged, handleActivityChanged, handleUserViewed, renameSession, handleBranchChanged, initSessionNotification, getNotificationSessionIds, getSessionsForRepo, setLoading, clearLoading, isItemLoading, rememberSessionForWorkspace, recallSessionForWorkspace } from './lib/state/sessions.svelte.js';
+  import { getSessionState, refreshAll, enrichSidebarBranches, handleBackendStateChanged, handleActivityChanged, handleUserViewed, renameSession, handleBranchChanged, initSessionNotification, getNotificationSessionIds, getSessionsForRepo, setLoading, clearLoading, isItemLoading, rememberSessionForWorkspace, recallSessionForWorkspace } from './lib/state/sessions.svelte.js';
   import { connectEventSocket, sendPtyData } from './lib/ws.js';
   import { initNotifications, initPushNotifications, resubscribeIfNeeded } from './lib/notifications.js';
   import { getConfigState } from './lib/state/config.svelte.js';
@@ -479,13 +479,13 @@
         bootRefreshDone = true;
         reportFetch('auth', 'ok');
       }
-      refreshAll(isInitialBoot ? reportFetch : undefined, isInitialBoot ? { enrich: false } : undefined).then(async () => {
+      refreshAll(isInitialBoot ? reportFetch : undefined).then(async () => {
         await refreshTelemetry();
 
         if (isInitialBoot) {
           finishBoot();
-          // Backfill PR info and staleness without racing a full refreshAll
-          refreshWorktreesEnriched();
+          // Backfill PR info and staleness via batch enrichment
+          enrichSidebarBranches();
         }
         const params = new URLSearchParams(window.location.search);
         const sessionParam = params.get('session');
@@ -518,9 +518,12 @@
     const refChangedTimers = new Map<string, ReturnType<typeof setTimeout>>();
     let pollInvalidateTimer: ReturnType<typeof setTimeout> | null = null;
 
-    function invalidatePrQueries(): void {
+    function invalidatePrData(): void {
+      // Invalidate TanStack Query caches for PrTopBar individual queries
       queryClient.invalidateQueries({ queryKey: ['pr'] });
       queryClient.invalidateQueries({ queryKey: ['ci-status'] });
+      // Re-enrich sidebar batch data
+      enrichSidebarBranches();
     }
 
     /** Throttled invalidation for poll-based events (pr-updated/ci-updated).
@@ -530,7 +533,7 @@
       if (pollInvalidateTimer) return;
       pollInvalidateTimer = setTimeout(() => {
         pollInvalidateTimer = null;
-        invalidatePrQueries();
+        invalidatePrData();
         queryClient.invalidateQueries({ queryKey: ['org-prs'] });
       }, 500);
     }
@@ -543,11 +546,11 @@
           handleBackendStateChanged(msg.sessionId, msg.state, msg.permissionType);
         } else if (msg.type === 'session-renamed') {
           renameSession(msg.sessionId, msg.branchName, msg.displayName);
-          invalidatePrQueries();
+          invalidatePrData();
         } else if (msg.type === 'session-branch-changed') {
           handleBranchChanged(msg.sessionId, msg.branch);
         } else if (msg.type === 'session-ended') {
-          invalidatePrQueries();
+          invalidatePrData();
           refreshAll();
         } else if (msg.type === 'ref-changed') {
           const key = msg.cwdPath;
@@ -555,7 +558,7 @@
           if (existing) clearTimeout(existing);
           refChangedTimers.set(key, setTimeout(() => {
             refChangedTimers.delete(key);
-            invalidatePrQueries();
+            invalidatePrData();
           }, 5000));
         } else if (msg.type === 'pr-updated' || msg.type === 'ci-updated') {
           throttledPollInvalidate();

--- a/frontend/src/components/BootScreen.svelte
+++ b/frontend/src/components/BootScreen.svelte
@@ -2,7 +2,7 @@
   import CipherText from './CipherText.svelte';
   import TuiProgress from './TuiProgress.svelte';
   import { getBootState, resetBoot, reportFetch, finishBoot } from '../lib/state/boot-state.svelte.js';
-  import { refreshAll, refreshWorktreesEnriched } from '../lib/state/sessions.svelte.js';
+  import { refreshAll, enrichSidebarBranches } from '../lib/state/sessions.svelte.js';
   import type { BootLine } from '../lib/state/boot-state.svelte.js';
 
   const boot = getBootState();
@@ -26,9 +26,9 @@
     if (retrying) return;
     retrying = true;
     resetBoot();
-    await refreshAll(reportFetch, { enrich: false });
+    await refreshAll(reportFetch);
     finishBoot();
-    refreshWorktreesEnriched();
+    enrichSidebarBranches();
     retrying = false;
   }
 

--- a/frontend/src/components/TargetBranchSwitcher.svelte
+++ b/frontend/src/components/TargetBranchSwitcher.svelte
@@ -74,7 +74,7 @@
     switching = branchName;
     switchError = null;
     try {
-      const res = await fetch('/workspaces/pr-base?path=' + encodeURIComponent(repoPath), {
+      const res = await fetch('/gh/pr-base?path=' + encodeURIComponent(repoPath), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ prNumber, baseBranch: branchName }),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -143,9 +143,8 @@ export async function fetchTelemetrySetupStatus(): Promise<{ installed: boolean 
   return { installed: value.installed === true };
 }
 
-export async function fetchWorktrees(enrich = true): Promise<WorktreeInfo[]> {
-  const url = enrich ? '/worktrees' : '/worktrees?enrich=false';
-  return json<WorktreeInfo[]>(await fetch(url));
+export async function fetchWorktrees(): Promise<WorktreeInfo[]> {
+  return json<WorktreeInfo[]>(await fetch('/git/worktrees'));
 }
 
 export async function fetchWorkspaces(): Promise<Repo[]> {
@@ -218,13 +217,13 @@ export async function fetchDashboard(repoPath: string): Promise<DashboardData> {
 }
 
 export async function fetchCiStatusOrNull(repoPath: string, branch: string): Promise<CiStatus | null> {
-  const res = await fetch('/workspaces/ci-status?path=' + encodeURIComponent(repoPath) + '&branch=' + encodeURIComponent(branch));
+  const res = await fetch('/gh/ci-status?path=' + encodeURIComponent(repoPath) + '&branch=' + encodeURIComponent(branch));
   if (!res.ok) return null;
   return res.json() as Promise<CiStatus>;
 }
 
 export async function fetchPrForBranchOrNull(repoPath: string, branch: string): Promise<PrInfo | null> {
-  const res = await fetch('/workspaces/pr?path=' + encodeURIComponent(repoPath) + '&branch=' + encodeURIComponent(branch));
+  const res = await fetch('/gh/pr?path=' + encodeURIComponent(repoPath) + '&branch=' + encodeURIComponent(branch));
   if (!res.ok) return null;
   const data = await res.json() as { pr: PrInfo | null };
   return data.pr;
@@ -262,7 +261,21 @@ export async function switchBranch(repoPath: string, branch: string): Promise<{ 
 export async function fetchBranches(repoPath: string, options: { refresh?: boolean } = {}): Promise<BranchInfo[]> {
   const params = new URLSearchParams({ repo: repoPath });
   if (options.refresh) params.set('refresh', '1');
-  return json<BranchInfo[]>(await fetch('/branches?' + params.toString()));
+  return json<BranchInfo[]>(await fetch('/git/branches?' + params.toString()));
+}
+
+export interface EnrichBranchesResult {
+  results: Record<string, { pr: PrInfo | null; stale: boolean }>;
+}
+
+export async function enrichBranches(branches: Array<{ repoPath: string; branchName: string }>): Promise<EnrichBranchesResult> {
+  const res = await fetch('/gh/enrich-branches', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ branches }),
+  });
+  if (!res.ok) return { results: {} };
+  return res.json() as Promise<EnrichBranchesResult>;
 }
 
 export async function createSession(body: {

--- a/frontend/src/lib/state/sessions.svelte.ts
+++ b/frontend/src/lib/state/sessions.svelte.ts
@@ -46,6 +46,7 @@ let workspaceLastSession: Record<string, string> = loadWorkspaceSessions();
 let loadingItems = $state<Record<string, boolean>>({});
 let notificationSessions = $state<Record<string, boolean>>({});
 let sidebarItems = $state<SidebarItem[]>([]);
+let enrichmentResults = $state<Record<string, { pr: import('../types.js').PrInfo | null; stale: boolean }>>({});
 
 function loadNotificationPrefs(): void {
   try {
@@ -134,20 +135,26 @@ async function timed<T>(
   }
 }
 
-/** Refresh only worktrees state (with enrichment). Used after boot to backfill PR/staleness data without racing a full refreshAll. */
-export async function refreshWorktreesEnriched(): Promise<void> {
+/** Batch-enrich all sidebar worktree branches with PR + staleness data from /gh/enrich-branches. */
+export async function enrichSidebarBranches(): Promise<void> {
+  const branches = worktrees.map(wt => ({ repoPath: wt.repoPath, branchName: wt.branchName }));
+  if (branches.length === 0) return;
   try {
-    worktrees = await api.fetchWorktrees(true);
+    const data = await api.enrichBranches(branches);
+    enrichmentResults = data.results;
   } catch (err) {
-    console.warn('[refreshWorktreesEnriched] failed:', err);
+    console.warn('[enrichSidebarBranches] failed:', err);
   }
 }
 
-export async function refreshAll(report?: FetchReporter, opts?: { enrich?: boolean }): Promise<void> {
-  const enrich = opts?.enrich ?? true;
+export function getEnrichment(repoPath: string, branchName: string): { pr: import('../types.js').PrInfo | null; stale: boolean } | undefined {
+  return enrichmentResults[`${repoPath}::${branchName}`];
+}
+
+export async function refreshAll(report?: FetchReporter): Promise<void> {
   const [sResult, wResult, wsResult, wgResult] = await Promise.all([
     timed('sessions', api.fetchSessions, v => `${v.length} active`, report),
-    timed('worktrees', () => api.fetchWorktrees(enrich), v => `${v.length} ${v.length === 1 ? 'tree' : 'trees'}`, report),
+    timed('worktrees', () => api.fetchWorktrees(), v => `${v.length} ${v.length === 1 ? 'tree' : 'trees'}`, report),
     timed('workspaces', api.fetchWorkspaces, v => `${v.length} ${v.length === 1 ? 'repo' : 'repos'}`, report),
     timed('groups', api.fetchWorkspaceGroups, v => `${v.length} ${v.length === 1 ? 'group' : 'groups'}`, report),
   ]);

--- a/server/gh-routes.ts
+++ b/server/gh-routes.ts
@@ -1,0 +1,165 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+
+import { isBranchStale } from './git.js';
+import { batchGetPrsForRepo, getCiStatus, getPrForBranch, isStalePr, getUnresolvedCommentCount, changePrBase, getPrCached, setPrCached } from './gh.js';
+import type { PrInfo } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+type ExecFileAsyncLike = (
+  file: string,
+  args: string[],
+  options: { cwd: string; timeout?: number },
+) => Promise<{ stdout: string; stderr: string }>;
+
+export interface GhRouterDeps {
+  execFileAsync: ExecFileAsyncLike;
+}
+
+interface BranchInput {
+  repoPath: string;
+  branchName: string;
+}
+
+interface EnrichResult {
+  pr: PrInfo | null;
+  stale: boolean;
+  ci?: { total: number; passing: number; failing: number; pending: number } | null;
+}
+
+export async function enrichBranches(
+  branches: BranchInput[],
+  exec: ExecFileAsyncLike,
+): Promise<Record<string, EnrichResult>> {
+  if (branches.length === 0) return {};
+
+  // Group by unique repo
+  const repoGroups = new Map<string, BranchInput[]>();
+  for (const b of branches) {
+    const group = repoGroups.get(b.repoPath) || [];
+    group.push(b);
+    repoGroups.set(b.repoPath, group);
+  }
+
+  // Batch PR lookups: 1 gh pr list per repo
+  const prMaps = new Map<string, Map<string, PrInfo>>();
+  await Promise.all(
+    [...repoGroups.keys()].map(async (repoPath) => {
+      try {
+        prMaps.set(repoPath, await batchGetPrsForRepo(repoPath, { exec }));
+      } catch {
+        prMaps.set(repoPath, new Map());
+      }
+    }),
+  );
+
+  // Enrich each branch in parallel
+  const results: Record<string, EnrichResult> = {};
+  await Promise.all(
+    branches.map(async ({ repoPath, branchName }) => {
+      const key = `${repoPath}::${branchName}`;
+      const pr = prMaps.get(repoPath)?.get(branchName) ?? null;
+
+      let stale = false;
+      try {
+        stale = await isBranchStale(repoPath, branchName, { exec });
+      } catch {
+        // default to not stale
+      }
+
+      results[key] = { pr, stale };
+    }),
+  );
+
+  return results;
+}
+
+export function createGhRouter(deps?: GhRouterDeps): Router {
+  const exec: ExecFileAsyncLike = deps?.execFileAsync ?? (execFileAsync as ExecFileAsyncLike);
+  const router = Router();
+
+  // POST /gh/enrich-branches — batch enrichment for sidebar
+  router.post('/enrich-branches', async (req: Request, res: Response) => {
+    const body = req.body as { branches?: BranchInput[] };
+    const branches = body.branches ?? [];
+    const results = await enrichBranches(branches, exec);
+    res.json({ results });
+  });
+
+  // GET /gh/pr — single-branch PR detail (for PrTopBar)
+  router.get('/pr', async (req: Request, res: Response) => {
+    const repoPath = typeof req.query.path === 'string' ? req.query.path : undefined;
+    const branch = typeof req.query.branch === 'string' ? req.query.branch : undefined;
+
+    if (!repoPath || !branch) {
+      res.status(400).json({ error: 'path and branch query parameters are required' });
+      return;
+    }
+
+    const cached = getPrCached(repoPath, branch);
+    if (cached) {
+      res.json({ pr: cached.result });
+      return;
+    }
+
+    try {
+      const pr = await getPrForBranch(repoPath, branch, { exec });
+      if (pr && !isStalePr(pr)) {
+        let unresolvedCommentCount = 0;
+        if (pr.state === 'OPEN') {
+          try {
+            unresolvedCommentCount = await getUnresolvedCommentCount(repoPath, pr.number, { exec });
+          } catch { /* degrade gracefully */ }
+        }
+        const enriched = { ...pr, unresolvedCommentCount };
+        setPrCached(repoPath, branch, enriched);
+        res.json({ pr: enriched });
+      } else {
+        setPrCached(repoPath, branch, null);
+        res.json({ pr: null });
+      }
+    } catch {
+      res.json({ pr: null });
+    }
+  });
+
+  // GET /gh/ci-status — CI check results
+  router.get('/ci-status', async (req: Request, res: Response) => {
+    const repoPath = typeof req.query.path === 'string' ? req.query.path : undefined;
+    const branch = typeof req.query.branch === 'string' ? req.query.branch : undefined;
+
+    if (!repoPath) {
+      res.status(400).json({ error: 'path query parameter is required' });
+      return;
+    }
+
+    try {
+      const status = await getCiStatus(repoPath, branch ?? 'HEAD', { exec });
+      res.json(status);
+    } catch {
+      res.json({ total: 0, passing: 0, failing: 0, pending: 0 });
+    }
+  });
+
+  // POST /gh/pr-base — change PR base branch
+  router.post('/pr-base', async (req: Request, res: Response) => {
+    const repoPath = typeof req.query.path === 'string' ? req.query.path : undefined;
+    const { prNumber, baseBranch } = req.body as { prNumber?: number; baseBranch?: string };
+    if (!repoPath) { res.status(400).json({ error: 'path query parameter required' }); return; }
+    if (!prNumber || typeof prNumber !== 'number') { res.status(400).json({ error: 'prNumber is required' }); return; }
+    if (!baseBranch || typeof baseBranch !== 'string') { res.status(400).json({ error: 'baseBranch is required' }); return; }
+
+    const result = await changePrBase(repoPath, prNumber, baseBranch, { exec });
+    if (result.success) {
+      res.json(result);
+    } else {
+      res.status(400).json({ error: result.error });
+    }
+  });
+
+  return router;
+}

--- a/server/gh-routes.ts
+++ b/server/gh-routes.ts
@@ -5,7 +5,7 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 
 import { isBranchStale } from './git.js';
-import { batchGetPrsForRepo, getCiStatus, getPrForBranch, isStalePr, getUnresolvedCommentCount, changePrBase, getPrCached, setPrCached } from './gh.js';
+import { batchGetPrsForRepo, getCiStatus, getPrForBranch, isStalePr, getUnresolvedCommentCount, changePrBase, getPrCached, setPrCached, clearPrCache } from './gh.js';
 import type { PrInfo } from './types.js';
 
 const execFileAsync = promisify(execFile);
@@ -62,7 +62,15 @@ export async function enrichBranches(
   await Promise.all(
     branches.map(async ({ repoPath, branchName }) => {
       const key = `${repoPath}::${branchName}`;
-      const pr = prMaps.get(repoPath)?.get(branchName) ?? null;
+      // Batch lookup first; fall back to per-branch call if batch was truncated (--limit 100)
+      let pr = prMaps.get(repoPath)?.get(branchName) ?? null;
+      if (!pr) {
+        try {
+          pr = await getPrForBranch(repoPath, branchName, { exec });
+        } catch {
+          // degrade gracefully
+        }
+      }
 
       let stale = false;
       try {
@@ -84,8 +92,21 @@ export function createGhRouter(deps?: GhRouterDeps): Router {
 
   // POST /gh/enrich-branches — batch enrichment for sidebar
   router.post('/enrich-branches', async (req: Request, res: Response) => {
-    const body = req.body as { branches?: BranchInput[] };
-    const branches = body.branches ?? [];
+    const raw = (req.body as Record<string, unknown>)?.branches;
+    if (raw !== undefined && !Array.isArray(raw)) {
+      res.status(400).json({ error: 'branches must be an array' });
+      return;
+    }
+    const branches: BranchInput[] = [];
+    for (const item of (raw ?? []) as unknown[]) {
+      if (!item || typeof item !== 'object'
+        || typeof (item as Record<string, unknown>).repoPath !== 'string'
+        || typeof (item as Record<string, unknown>).branchName !== 'string') {
+        res.status(400).json({ error: 'each branch must have string repoPath and branchName' });
+        return;
+      }
+      branches.push({ repoPath: (item as BranchInput).repoPath, branchName: (item as BranchInput).branchName });
+    }
     const results = await enrichBranches(branches, exec);
     res.json({ results });
   });
@@ -155,6 +176,7 @@ export function createGhRouter(deps?: GhRouterDeps): Router {
 
     const result = await changePrBase(repoPath, prNumber, baseBranch, { exec });
     if (result.success) {
+      clearPrCache(repoPath);
       res.json(result);
     } else {
       res.status(400).json({ error: result.error });

--- a/server/gh.ts
+++ b/server/gh.ts
@@ -1,0 +1,379 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import type { CiStatus, PrInfo } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+type ExecFileAsyncResult = {
+  stdout: string;
+  stderr: string;
+};
+
+type ExecFileAsyncLike = (
+  file: string,
+  args: string[],
+  options: { cwd: string; timeout?: number },
+) => Promise<ExecFileAsyncResult>;
+
+// ── PR lookup cache ─────────────────────────────────────────────────────────
+// Caches `getPrForBranch` results to avoid spawning a `gh` subprocess on every
+// request. Negative results (no PR) use a longer TTL since they only change on
+// user action (push, PR creation).
+
+const PR_CACHE_POSITIVE_TTL_MS = 60_000;   // 60s — same as org-dashboard
+const PR_CACHE_NEGATIVE_TTL_MS = 300_000;  // 5 min — "no PR" rarely changes without user action
+
+interface PrCacheEntry {
+  result: PrInfo | null;
+  fetchedAt: number;
+}
+
+const prCache = new Map<string, PrCacheEntry>();
+
+function prCacheKey(repoPath: string, branch: string): string {
+  return `${repoPath}:${branch}`;
+}
+
+function getPrCached(repoPath: string, branch: string): PrCacheEntry | undefined {
+  const key = prCacheKey(repoPath, branch);
+  const entry = prCache.get(key);
+  if (!entry) return undefined;
+  const ttl = entry.result ? PR_CACHE_POSITIVE_TTL_MS : PR_CACHE_NEGATIVE_TTL_MS;
+  if (Date.now() - entry.fetchedAt > ttl) {
+    prCache.delete(key);
+    return undefined;
+  }
+  return entry;
+}
+
+function setPrCached(repoPath: string, branch: string, result: PrInfo | null): void {
+  prCache.set(prCacheKey(repoPath, branch), { result, fetchedAt: Date.now() });
+}
+
+/** Clear PR cache entries. If repoPath is given, only clears entries for that repo. */
+function clearPrCache(repoPath?: string): void {
+  if (!repoPath) {
+    prCache.clear();
+    return;
+  }
+  const prefix = `${repoPath}:`;
+  for (const key of prCache.keys()) {
+    if (key.startsWith(prefix)) prCache.delete(key);
+  }
+}
+
+async function getCiStatus(
+  repoPath: string,
+  branch: string,
+  options: {
+    exec?: ExecFileAsyncLike;
+  } = {},
+): Promise<(CiStatus & { authError?: boolean }) | null> {
+  const run: ExecFileAsyncLike = options.exec || execFileAsync as ExecFileAsyncLike;
+
+  let stdout: string;
+  let stderr: string;
+
+  try {
+    ({ stdout, stderr } = await run(
+      'gh',
+      ['pr', 'checks', branch, '--json', 'name,state,conclusion'],
+      { cwd: repoPath, timeout: 5000 },
+    ));
+  } catch (err: unknown) {
+    if (err && typeof err === 'object') {
+      const errObj = err as { code?: string; message?: string; stderr?: string };
+      const errorText = errObj.stderr ?? errObj.message ?? '';
+
+      // gh not installed
+      if (errObj.code === 'ENOENT') return null;
+
+      // Not authenticated
+      if (
+        typeof errorText === 'string' &&
+        (errorText.includes('not logged into') || errorText.includes('authentication'))
+      ) {
+        return { total: 0, passing: 0, failing: 0, pending: 0, authError: true };
+      }
+
+      // No PR for branch
+      if (
+        typeof errorText === 'string' &&
+        (errorText.includes('no pull requests found') || errorText.includes('Could not find'))
+      ) {
+        return null;
+      }
+    }
+
+    return null;
+  }
+
+  // gh may exit 0 but write errors or auth prompts to stderr
+  if (stderr && (stderr.includes('not logged into') || stderr.includes('authentication'))) {
+    return { total: 0, passing: 0, failing: 0, pending: 0, authError: true };
+  }
+
+  if (!stdout.trim()) return null;
+
+  try {
+    const checks: Array<{ name: string; state: string; conclusion: string }> = JSON.parse(stdout);
+
+    let passing = 0;
+    let failing = 0;
+    let pending = 0;
+
+    for (const check of checks) {
+      const conclusion = (check.conclusion ?? '').toUpperCase();
+      const state = (check.state ?? '').toUpperCase();
+
+      if (conclusion === 'SUCCESS' || conclusion === 'SKIPPED' || conclusion === 'NEUTRAL') {
+        passing++;
+      } else if (conclusion === 'FAILURE' || conclusion === 'CANCELLED' || conclusion === 'TIMED_OUT') {
+        failing++;
+      } else if (state === 'IN_PROGRESS' || state === 'QUEUED' || state === 'PENDING' || conclusion === '') {
+        pending++;
+      } else {
+        // Unknown conclusion — treat as pending rather than silently ignoring
+        pending++;
+      }
+    }
+
+    return { total: checks.length, passing, failing, pending };
+  } catch {
+    return null;
+  }
+}
+
+async function getPrForBranch(
+  repoPath: string,
+  branch: string,
+  options: {
+    exec?: ExecFileAsyncLike;
+  } = {},
+): Promise<PrInfo | null> {
+  const run: ExecFileAsyncLike = options.exec || execFileAsync as ExecFileAsyncLike;
+
+  let stdout: string;
+
+  try {
+    ({ stdout } = await run(
+      'gh',
+      [
+        'pr',
+        'view',
+        branch,
+        '--json',
+        'number,title,url,state,headRefName,baseRefName,reviewDecision,isDraft,additions,deletions,mergeable,updatedAt',
+      ],
+      { cwd: repoPath, timeout: 5000 },
+    ));
+  } catch {
+    return null;
+  }
+
+  if (!stdout.trim()) return null;
+
+  try {
+    const data = JSON.parse(stdout) as {
+      number: number;
+      title: string;
+      url: string;
+      state: string;
+      headRefName: string;
+      baseRefName: string;
+      isDraft: boolean;
+      reviewDecision: string | null;
+      additions: number;
+      deletions: number;
+      mergeable: string;
+      updatedAt: string;
+    };
+
+    return {
+      number: data.number,
+      title: data.title,
+      url: data.url,
+      state: data.state as PrInfo['state'],
+      headRefName: data.headRefName,
+      baseRefName: data.baseRefName,
+      isDraft: data.isDraft,
+      reviewDecision: data.reviewDecision ?? null,
+      additions: data.additions ?? 0,
+      deletions: data.deletions ?? 0,
+      mergeable: (data.mergeable as PrInfo['mergeable']) ?? 'UNKNOWN',
+      unresolvedCommentCount: 0,
+      updatedAt: data.updatedAt ?? '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Batch-fetch all PRs for a repo in a single `gh pr list` call.
+ * Returns a Map of headRefName → PrInfo for quick branch lookup.
+ * Includes both open and closed/merged PRs (up to 100 most recent).
+ */
+async function batchGetPrsForRepo(
+  repoPath: string,
+  options: { exec?: ExecFileAsyncLike } = {},
+): Promise<Map<string, PrInfo>> {
+  const run: ExecFileAsyncLike = options.exec || execFileAsync as ExecFileAsyncLike;
+  const prMap = new Map<string, PrInfo>();
+
+  try {
+    const { stdout } = await run(
+      'gh',
+      [
+        'pr', 'list',
+        '--state', 'all',
+        '--limit', '100',
+        '--json',
+        'number,title,url,state,headRefName,baseRefName,reviewDecision,isDraft,additions,deletions,mergeable,updatedAt',
+      ],
+      { cwd: repoPath, timeout: 10000 },
+    );
+
+    if (!stdout.trim()) return prMap;
+
+    const prs = JSON.parse(stdout) as Array<{
+      number: number;
+      title: string;
+      url: string;
+      state: string;
+      headRefName: string;
+      baseRefName: string;
+      isDraft: boolean;
+      reviewDecision: string | null;
+      additions: number;
+      deletions: number;
+      mergeable: string;
+      updatedAt: string;
+    }>;
+
+    for (const data of prs) {
+      prMap.set(data.headRefName, {
+        number: data.number,
+        title: data.title,
+        url: data.url,
+        state: data.state as PrInfo['state'],
+        headRefName: data.headRefName,
+        baseRefName: data.baseRefName,
+        isDraft: data.isDraft,
+        reviewDecision: data.reviewDecision ?? null,
+        additions: data.additions ?? 0,
+        deletions: data.deletions ?? 0,
+        mergeable: (data.mergeable as PrInfo['mergeable']) ?? 'UNKNOWN',
+        unresolvedCommentCount: 0,
+        updatedAt: data.updatedAt ?? '',
+      });
+    }
+  } catch (err) {
+    console.warn('[gh] batchGetPrsForRepo failed for', repoPath, err instanceof Error ? err.message : err);
+  }
+
+  return prMap;
+}
+
+async function getUnresolvedCommentCount(
+  repoPath: string,
+  prNumber: number,
+  options: {
+    exec?: ExecFileAsyncLike;
+  } = {},
+): Promise<number> {
+  const run: ExecFileAsyncLike = options.exec || execFileAsync as ExecFileAsyncLike;
+
+  try {
+    const { stdout: repoStdout } = await run(
+      'gh',
+      ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
+      { cwd: repoPath, timeout: 5000 },
+    );
+    const nameWithOwner = repoStdout.trim();
+    if (!nameWithOwner) return 0;
+
+    const [owner, repo] = nameWithOwner.split('/');
+    if (!owner || !repo) return 0;
+
+    const query = `query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes { isResolved }
+      }
+    }
+  }
+}`;
+
+    const { stdout } = await run(
+      'gh',
+      [
+        'api', 'graphql',
+        '-f', `query=${query}`,
+        '-f', `owner=${owner}`,
+        '-f', `repo=${repo}`,
+        '-F', `number=${prNumber}`,
+      ],
+      { cwd: repoPath, timeout: 10000 },
+    );
+
+    const result = JSON.parse(stdout) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            reviewThreads?: {
+              nodes?: Array<{ isResolved: boolean }>;
+            };
+          };
+        };
+      };
+    };
+
+    const nodes = result?.data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
+    return nodes.filter((n) => !n.isResolved).length;
+  } catch {
+    return 0;
+  }
+}
+
+async function changePrBase(
+  repoPath: string,
+  prNumber: number,
+  baseBranch: string,
+  options: { exec?: ExecFileAsyncLike } = {},
+): Promise<{ success: true } | { success: false; error: string }> {
+  const run = options.exec || execFileAsync as ExecFileAsyncLike;
+  try {
+    await run('gh', ['pr', 'edit', String(prNumber), '--base', baseBranch], { cwd: repoPath, timeout: 10000 });
+    return { success: true };
+  } catch (err: unknown) {
+    const errObj = err as { stderr?: string; message?: string; code?: string };
+    if (errObj.code === 'ENOENT') return { success: false, error: 'gh CLI not installed' };
+    return { success: false, error: (errObj.stderr ?? errObj.message ?? 'Unknown error').trim() };
+  }
+}
+
+const ONE_DAY_MS = 86_400_000;
+
+/** A PR is stale if it's MERGED or CLOSED and was last updated more than 1 day ago (or has no valid timestamp). */
+function isStalePr(pr: PrInfo): boolean {
+  if (pr.state === 'OPEN') return false;
+  if (!pr.updatedAt) return true; // no timestamp → treat as stale
+  const elapsed = Date.now() - new Date(pr.updatedAt).getTime();
+  if (Number.isNaN(elapsed)) return true; // unparseable date → treat as stale
+  return elapsed > ONE_DAY_MS;
+}
+
+export {
+  getCiStatus,
+  getPrForBranch,
+  batchGetPrsForRepo,
+  getUnresolvedCommentCount,
+  changePrBase,
+  isStalePr,
+  getPrCached,
+  setPrCached,
+  clearPrCache,
+};

--- a/server/git-routes.ts
+++ b/server/git-routes.ts
@@ -1,0 +1,188 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+
+import { listBranchesEnriched } from './git.js';
+import { readMeta } from './config.js';
+import { WORKTREE_DIRS, parseWorktreeListPorcelain } from './watcher.js';
+import type { WorktreeMetadata } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+type ExecFileAsyncLike = (
+  file: string,
+  args: string[],
+  options: { cwd: string; timeout?: number },
+) => Promise<{ stdout: string; stderr: string }>;
+
+export interface GitRouterDeps {
+  getConfig: () => { rootDirs?: string[] | undefined; repos?: string[] | undefined };
+  configPath: string;
+  execFileAsync: ExecFileAsyncLike;
+  readdirSync: (dir: string) => Array<{ name: string; isDirectory: () => boolean }>;
+  statSync: (path: string) => { isDirectory: () => boolean };
+  readMeta: (configPath: string, worktreePath: string) => WorktreeMetadata | null;
+}
+
+interface RepoEntry {
+  name: string;
+  path: string;
+  root: string;
+}
+
+interface WorktreeResult {
+  name: string;
+  path: string;
+  repoName: string;
+  repoPath: string;
+  root: string;
+  displayName: string;
+  lastActivity: string;
+  branchName: string;
+}
+
+export async function scanWorktrees(
+  deps: GitRouterDeps,
+  repoParam?: string,
+): Promise<WorktreeResult[]> {
+  const config = deps.getConfig();
+  const roots = config.rootDirs || [];
+  const worktrees: WorktreeResult[] = [];
+
+  let reposToScan: RepoEntry[];
+  if (repoParam) {
+    const root = roots.find(r => repoParam.startsWith(r)) || '';
+    reposToScan = [{ path: repoParam, name: repoParam.split('/').filter(Boolean).pop() || '', root }];
+  } else {
+    reposToScan = [];
+    for (const rootDir of roots) {
+      let entries: Array<{ name: string; isDirectory: () => boolean }>;
+      try {
+        entries = deps.readdirSync(rootDir);
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
+        const fullPath = path.join(rootDir, entry.name);
+        const dotGit = path.join(fullPath, '.git');
+        try {
+          if (deps.statSync(dotGit).isDirectory()) {
+            reposToScan.push({ name: entry.name, path: fullPath, root: rootDir });
+          }
+        } catch {
+          // .git doesn't exist — not a repo
+        }
+      }
+    }
+
+    // Also include directly-configured repos (may not be under any rootDir)
+    const configRepos = config.repos ?? [];
+    const scannedPaths = new Set(reposToScan.map(r => r.path));
+    for (const wp of configRepos) {
+      if (scannedPaths.has(wp)) continue;
+      const root = roots.find(r => wp.startsWith(r)) || '';
+      reposToScan.push({ path: wp, name: wp.split('/').filter(Boolean).pop() || '', root });
+    }
+  }
+
+  for (const repo of reposToScan) {
+    try {
+      const { stdout } = await deps.execFileAsync('git', ['worktree', 'list', '--porcelain'], { cwd: repo.path });
+      const parsed = parseWorktreeListPorcelain(stdout, repo.path);
+      for (const wt of parsed) {
+        const dirName = wt.path.split('/').pop() || '';
+        const meta = deps.readMeta(deps.configPath, wt.path);
+        worktrees.push({
+          name: dirName,
+          path: wt.path,
+          repoName: repo.name,
+          repoPath: repo.path,
+          root: repo.root,
+          displayName: meta?.displayName || wt.branch || dirName,
+          lastActivity: meta?.lastActivity || '',
+          branchName: wt.branch || meta?.branchName || dirName,
+        });
+      }
+    } catch {
+      // git worktree list failed — fall back to directory scanning
+      for (const dir of WORKTREE_DIRS) {
+        const worktreeDir = path.join(repo.path, dir);
+        let entries: Array<{ name: string; isDirectory: () => boolean }>;
+        try {
+          entries = deps.readdirSync(worktreeDir);
+        } catch {
+          continue;
+        }
+        for (const entry of entries) {
+          if (!entry.isDirectory()) continue;
+          const wtPath = path.join(worktreeDir, entry.name);
+          const meta = deps.readMeta(deps.configPath, wtPath);
+          worktrees.push({
+            name: entry.name,
+            path: wtPath,
+            repoName: repo.name,
+            repoPath: repo.path,
+            root: repo.root,
+            displayName: meta?.displayName || '',
+            lastActivity: meta?.lastActivity || '',
+            branchName: meta?.branchName || entry.name,
+          });
+        }
+      }
+    }
+  }
+
+  // Deduplicate by path
+  const seen = new Set<string>();
+  return worktrees.filter(wt => {
+    if (seen.has(wt.path)) return false;
+    seen.add(wt.path);
+    return true;
+  });
+}
+
+export interface CreateGitRouterDeps {
+  configPath: string;
+  getConfig: () => { rootDirs?: string[] | undefined; repos?: string[] | undefined };
+  getSessions: () => Array<{ id: string; worktreePath: string | null }>;
+}
+
+export function createGitRouter(deps: CreateGitRouterDeps): Router {
+  const router = Router();
+
+  const routerDeps: GitRouterDeps = {
+    getConfig: deps.getConfig,
+    configPath: deps.configPath,
+    execFileAsync: execFileAsync as ExecFileAsyncLike,
+    readdirSync: (dir: string) => fs.readdirSync(dir, { withFileTypes: true }),
+    statSync: (p: string) => fs.statSync(p),
+    readMeta: (configPath: string, worktreePath: string) => readMeta(configPath, worktreePath),
+  };
+
+  // GET /git/worktrees — pure git worktree list, no enrichment
+  router.get('/worktrees', async (req: Request, res: Response) => {
+    const repoParam = typeof req.query.repo === 'string' ? req.query.repo : undefined;
+    const items = await scanWorktrees(routerDeps, repoParam);
+    res.json(items);
+  });
+
+  // GET /git/branches — branch list with local-only data
+  router.get('/branches', async (req: Request, res: Response) => {
+    const repoPath = typeof req.query.repo === 'string' ? req.query.repo : undefined;
+    const refresh = req.query.refresh === '1';
+    if (!repoPath) {
+      res.status(400).json({ error: 'repo query parameter is required' });
+      return;
+    }
+
+    const sessionList = deps.getSessions();
+    res.json(await listBranchesEnriched(repoPath, { refresh, sessions: sessionList }));
+  });
+
+  return router;
+}

--- a/server/git.ts
+++ b/server/git.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
-import type { ActivityEntry, BranchInfo, BranchLifecycleState, ChangedFile, CiStatus, FileChangeStatus, PrInfo } from './types.js';
+import type { ActivityEntry, BranchInfo, BranchLifecycleState, ChangedFile, FileChangeStatus, PrInfo } from './types.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -139,218 +139,6 @@ async function getActivityFeed(
   }
 }
 
-async function getCiStatus(
-  repoPath: string,
-  branch: string,
-  options: {
-    exec?: ExecFileAsyncLike;
-  } = {},
-): Promise<(CiStatus & { authError?: boolean }) | null> {
-  const run: ExecFileAsyncLike = options.exec || execFileAsync as ExecFileAsyncLike;
-
-  let stdout: string;
-  let stderr: string;
-
-  try {
-    ({ stdout, stderr } = await run(
-      'gh',
-      ['pr', 'checks', branch, '--json', 'name,state,conclusion'],
-      { cwd: repoPath, timeout: 5000 },
-    ));
-  } catch (err: unknown) {
-    if (err && typeof err === 'object') {
-      const errObj = err as { code?: string; message?: string; stderr?: string };
-      const errorText = errObj.stderr ?? errObj.message ?? '';
-
-      // gh not installed
-      if (errObj.code === 'ENOENT') return null;
-
-      // Not authenticated
-      if (
-        typeof errorText === 'string' &&
-        (errorText.includes('not logged into') || errorText.includes('authentication'))
-      ) {
-        return { total: 0, passing: 0, failing: 0, pending: 0, authError: true };
-      }
-
-      // No PR for branch
-      if (
-        typeof errorText === 'string' &&
-        (errorText.includes('no pull requests found') || errorText.includes('Could not find'))
-      ) {
-        return null;
-      }
-    }
-
-    return null;
-  }
-
-  // gh may exit 0 but write errors or auth prompts to stderr
-  if (stderr && (stderr.includes('not logged into') || stderr.includes('authentication'))) {
-    return { total: 0, passing: 0, failing: 0, pending: 0, authError: true };
-  }
-
-  if (!stdout.trim()) return null;
-
-  try {
-    const checks: Array<{ name: string; state: string; conclusion: string }> = JSON.parse(stdout);
-
-    let passing = 0;
-    let failing = 0;
-    let pending = 0;
-
-    for (const check of checks) {
-      const conclusion = (check.conclusion ?? '').toUpperCase();
-      const state = (check.state ?? '').toUpperCase();
-
-      if (conclusion === 'SUCCESS' || conclusion === 'SKIPPED' || conclusion === 'NEUTRAL') {
-        passing++;
-      } else if (conclusion === 'FAILURE' || conclusion === 'CANCELLED' || conclusion === 'TIMED_OUT') {
-        failing++;
-      } else if (state === 'IN_PROGRESS' || state === 'QUEUED' || state === 'PENDING' || conclusion === '') {
-        pending++;
-      } else {
-        // Unknown conclusion — treat as pending rather than silently ignoring
-        pending++;
-      }
-    }
-
-    return { total: checks.length, passing, failing, pending };
-  } catch {
-    return null;
-  }
-}
-
-async function getPrForBranch(
-  repoPath: string,
-  branch: string,
-  options: {
-    exec?: ExecFileAsyncLike;
-  } = {},
-): Promise<PrInfo | null> {
-  const run: ExecFileAsyncLike = options.exec || execFileAsync as ExecFileAsyncLike;
-
-  let stdout: string;
-
-  try {
-    ({ stdout } = await run(
-      'gh',
-      [
-        'pr',
-        'view',
-        branch,
-        '--json',
-        'number,title,url,state,headRefName,baseRefName,reviewDecision,isDraft,additions,deletions,mergeable,updatedAt',
-      ],
-      { cwd: repoPath, timeout: 5000 },
-    ));
-  } catch {
-    return null;
-  }
-
-  if (!stdout.trim()) return null;
-
-  try {
-    const data = JSON.parse(stdout) as {
-      number: number;
-      title: string;
-      url: string;
-      state: string;
-      headRefName: string;
-      baseRefName: string;
-      isDraft: boolean;
-      reviewDecision: string | null;
-      additions: number;
-      deletions: number;
-      mergeable: string;
-      updatedAt: string;
-    };
-
-    return {
-      number: data.number,
-      title: data.title,
-      url: data.url,
-      state: data.state as PrInfo['state'],
-      headRefName: data.headRefName,
-      baseRefName: data.baseRefName,
-      isDraft: data.isDraft,
-      reviewDecision: data.reviewDecision ?? null,
-      additions: data.additions ?? 0,
-      deletions: data.deletions ?? 0,
-      mergeable: (data.mergeable as PrInfo['mergeable']) ?? 'UNKNOWN',
-      unresolvedCommentCount: 0,
-      updatedAt: data.updatedAt ?? '',
-    };
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Batch-fetch all PRs for a repo in a single `gh pr list` call.
- * Returns a Map of headRefName → PrInfo for quick branch lookup.
- * Includes both open and closed/merged PRs (up to 100 most recent).
- */
-async function batchGetPrsForRepo(
-  repoPath: string,
-  options: { exec?: ExecFileAsyncLike } = {},
-): Promise<Map<string, PrInfo>> {
-  const run: ExecFileAsyncLike = options.exec || execFileAsync as ExecFileAsyncLike;
-  const prMap = new Map<string, PrInfo>();
-
-  try {
-    const { stdout } = await run(
-      'gh',
-      [
-        'pr', 'list',
-        '--state', 'all',
-        '--limit', '100',
-        '--json',
-        'number,title,url,state,headRefName,baseRefName,reviewDecision,isDraft,additions,deletions,mergeable,updatedAt',
-      ],
-      { cwd: repoPath, timeout: 10000 },
-    );
-
-    if (!stdout.trim()) return prMap;
-
-    const prs = JSON.parse(stdout) as Array<{
-      number: number;
-      title: string;
-      url: string;
-      state: string;
-      headRefName: string;
-      baseRefName: string;
-      isDraft: boolean;
-      reviewDecision: string | null;
-      additions: number;
-      deletions: number;
-      mergeable: string;
-      updatedAt: string;
-    }>;
-
-    for (const data of prs) {
-      prMap.set(data.headRefName, {
-        number: data.number,
-        title: data.title,
-        url: data.url,
-        state: data.state as PrInfo['state'],
-        headRefName: data.headRefName,
-        baseRefName: data.baseRefName,
-        isDraft: data.isDraft,
-        reviewDecision: data.reviewDecision ?? null,
-        additions: data.additions ?? 0,
-        deletions: data.deletions ?? 0,
-        mergeable: (data.mergeable as PrInfo['mergeable']) ?? 'UNKNOWN',
-        unresolvedCommentCount: 0,
-        updatedAt: data.updatedAt ?? '',
-      });
-    }
-  } catch (err) {
-    console.warn('[git] batchGetPrsForRepo failed for', repoPath, err instanceof Error ? err.message : err);
-  }
-
-  return prMap;
-}
 
 async function switchBranch(
   repoPath: string,
@@ -392,68 +180,6 @@ async function getCommitsAhead(
     );
     const count = parseInt(stdout.trim(), 10);
     return Number.isFinite(count) ? count : 0;
-  } catch {
-    return 0;
-  }
-}
-
-async function getUnresolvedCommentCount(
-  repoPath: string,
-  prNumber: number,
-  options: {
-    exec?: ExecFileAsyncLike;
-  } = {},
-): Promise<number> {
-  const run: ExecFileAsyncLike = options.exec || execFileAsync as ExecFileAsyncLike;
-
-  try {
-    const { stdout: repoStdout } = await run(
-      'gh',
-      ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
-      { cwd: repoPath, timeout: 5000 },
-    );
-    const nameWithOwner = repoStdout.trim();
-    if (!nameWithOwner) return 0;
-
-    const [owner, repo] = nameWithOwner.split('/');
-    if (!owner || !repo) return 0;
-
-    const query = `query($owner: String!, $repo: String!, $number: Int!) {
-  repository(owner: $owner, name: $repo) {
-    pullRequest(number: $number) {
-      reviewThreads(first: 100) {
-        nodes { isResolved }
-      }
-    }
-  }
-}`;
-
-    const { stdout } = await run(
-      'gh',
-      [
-        'api', 'graphql',
-        '-f', `query=${query}`,
-        '-f', `owner=${owner}`,
-        '-f', `repo=${repo}`,
-        '-F', `number=${prNumber}`,
-      ],
-      { cwd: repoPath, timeout: 10000 },
-    );
-
-    const result = JSON.parse(stdout) as {
-      data?: {
-        repository?: {
-          pullRequest?: {
-            reviewThreads?: {
-              nodes?: Array<{ isResolved: boolean }>;
-            };
-          };
-        };
-      };
-    };
-
-    const nodes = result?.data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
-    return nodes.filter((n) => !n.isResolved).length;
   } catch {
     return 0;
   }
@@ -699,23 +425,6 @@ async function createBranch(
   }
 }
 
-async function changePrBase(
-  repoPath: string,
-  prNumber: number,
-  baseBranch: string,
-  options: { exec?: ExecFileAsyncLike } = {},
-): Promise<{ success: true } | { success: false; error: string }> {
-  const run = options.exec || execFileAsync as ExecFileAsyncLike;
-  try {
-    await run('gh', ['pr', 'edit', String(prNumber), '--base', baseBranch], { cwd: repoPath, timeout: 10000 });
-    return { success: true };
-  } catch (err: unknown) {
-    const errObj = err as { stderr?: string; message?: string; code?: string };
-    if (errObj.code === 'ENOENT') return { success: false, error: 'gh CLI not installed' };
-    return { success: false, error: (errObj.stderr ?? errObj.message ?? 'Unknown error').trim() };
-  }
-}
-
 async function pushBranch(
   repoPath: string,
   branch: string,
@@ -939,17 +648,6 @@ async function getDefaultBranch(
   return 'main'; // ultimate fallback
 }
 
-const ONE_DAY_MS = 86_400_000;
-
-/** A PR is stale if it's MERGED or CLOSED and was last updated more than 1 day ago (or has no valid timestamp). */
-function isStalePr(pr: PrInfo): boolean {
-  if (pr.state === 'OPEN') return false;
-  if (!pr.updatedAt) return true; // no timestamp → treat as stale
-  const elapsed = Date.now() - new Date(pr.updatedAt).getTime();
-  if (Number.isNaN(elapsed)) return true; // unparseable date → treat as stale
-  return elapsed > ONE_DAY_MS;
-}
-
 interface EnsureBranchResult {
   found: boolean;
   reason?: 'not_found' | 'fetch_failed';
@@ -1054,21 +752,16 @@ export {
   listBranchesEnriched,
   normalizeBranchNames,
   getActivityFeed,
-  getCiStatus,
-  getPrForBranch,
-  getUnresolvedCommentCount,
   switchBranch,
   getCommitsAhead,
   getCurrentBranch,
   getWorkingTreeDiff,
   branchToDisplayName,
   isBranchStale,
-  isStalePr,
   extractOwnerRepo,
   buildRepoMap,
   renameBranch,
   createBranch,
-  changePrBase,
   pushBranch,
   getChangedFiles,
   getFileDiff,
@@ -1076,6 +769,5 @@ export {
   ensureBranchLocal,
   isPrMerged,
   computeBranchLifecycleState,
-  batchGetPrsForRepo,
 };
 export type { EnsureBranchResult };

--- a/server/index.ts
+++ b/server/index.ts
@@ -403,7 +403,7 @@ async function main(): Promise<void> {
   // Mount git (local/fast) and gh (network/slow) routers
   app.use('/git', requireAuth, createGitRouter({
     configPath: CONFIG_PATH,
-    getConfig: () => loadConfig(CONFIG_PATH),
+    getConfig,
     getSessions: () => sessions.list().map(s => ({ id: s.id, worktreePath: s.worktreePath ?? s.repoPath })),
   }));
   app.use('/gh', requireAuth, createGhRouter());

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,10 +16,11 @@ import * as sessions from './sessions.js';
 import { AGENT_CONTINUE_ARGS, AGENT_YOLO_ARGS, serializeAll, restoreFromDisk, activeTmuxSessionNames, populateMetaCache } from './sessions.js';
 import { getTmuxPrefix } from './pty-handler.js';
 import { setupWebSocket } from './ws.js';
-import { WorktreeWatcher, BranchWatcher, RefWatcher, GitWatcher, WORKTREE_DIRS, parseWorktreeListPorcelain, parseAllWorktrees } from './watcher.js';
+import { WorktreeWatcher, BranchWatcher, RefWatcher, GitWatcher, parseAllWorktrees } from './watcher.js';
 import { isInstalled as serviceIsInstalled } from './service.js';
 import { extensionForMime, setClipboardImage } from './clipboard.js';
-import { listBranches, listBranchesEnriched, isBranchStale, getPrForBranch, computeBranchLifecycleState, batchGetPrsForRepo } from './git.js';
+import { createGitRouter } from './git-routes.js';
+import { createGhRouter } from './gh-routes.js';
 import * as push from './push.js';
 import { initAnalytics, closeAnalytics, createAnalyticsRouter } from './analytics.js';
 import { createWorkspaceRouter, clearPrCache, clearFilesListCache } from './workspaces.js';
@@ -399,6 +400,14 @@ async function main(): Promise<void> {
   });
   app.use('/workspaces', requireAuth, workspaceRouter);
 
+  // Mount git (local/fast) and gh (network/slow) routers
+  app.use('/git', requireAuth, createGitRouter({
+    configPath: CONFIG_PATH,
+    getConfig: () => loadConfig(CONFIG_PATH),
+    getSessions: () => sessions.list().map(s => ({ id: s.id, worktreePath: s.worktreePath ?? s.repoPath })),
+  }));
+  app.use('/gh', requireAuth, createGhRouter());
+
   // Mount workspace-groups CRUD router
   app.use('/workspace-groups', createWorkspaceGroupsRouter(CONFIG_PATH, requireAuth, {
     sessions,
@@ -706,192 +715,6 @@ async function main(): Promise<void> {
       }
     }));
     res.json(enriched);
-  });
-
-  // GET /branches?repo=<path> — list local and remote branches for a repo
-  app.get('/branches', requireAuth, async (req, res) => {
-    const repoPath = typeof req.query.repo === 'string' ? req.query.repo : undefined;
-    const refresh = req.query.refresh === '1';
-    if (!repoPath) {
-      res.status(400).json({ error: 'repo query parameter is required' });
-      return;
-    }
-
-    const sessionList = sessions.list().map((s) => ({ id: s.id, worktreePath: s.worktreePath ?? s.repoPath }));
-    res.json(await listBranchesEnriched(repoPath, { refresh, sessions: sessionList }));
-  });
-
-  // GET /worktrees?repo=<path>&enrich=true|false — list worktrees
-  // enrich=false (default during boot) returns basic git worktree data fast.
-  // enrich=true adds PR info and staleness checks (slower, hits GitHub API).
-  // Omit repo to scan all repos in all rootDirs.
-  app.get('/worktrees', requireAuth, async (req, res) => {
-    const repoParam = typeof req.query.repo === 'string' ? req.query.repo : undefined;
-    const enrich = req.query.enrich !== 'false';
-    const roots = getConfig().rootDirs || [];
-    const worktrees: Array<{
-      name: string; path: string; repoName: string; repoPath: string;
-      root: string; displayName: string; lastActivity: string; branchName: string;
-      branchState?: 'active' | 'stale' | 'merged';
-      prNumber?: number;
-      prTitle?: string;
-    }> = [];
-
-    let reposToScan: RepoEntry[];
-    if (repoParam) {
-      const root = roots.find(function (r) { return repoParam.startsWith(r); }) || '';
-      reposToScan = [{ path: repoParam, name: repoParam.split('/').filter(Boolean).pop() || '', root }];
-    } else {
-      reposToScan = [];
-      for (const rootDir of roots) {
-        let entries: fs.Dirent[];
-        try {
-          entries = fs.readdirSync(rootDir, { withFileTypes: true });
-        } catch (_) {
-          continue;
-        }
-        for (const entry of entries) {
-          if (!entry.isDirectory() || entry.name.startsWith('.')) continue;
-          const fullPath = path.join(rootDir, entry.name);
-          const dotGit = path.join(fullPath, '.git');
-          try {
-            if (fs.statSync(dotGit).isDirectory()) {
-              reposToScan.push({ name: entry.name, path: fullPath, root: rootDir });
-            }
-          } catch (_) {
-            // .git doesn't exist — not a repo
-          }
-        }
-      }
-
-      // Also include directly-configured repos (may not be under any rootDir)
-      const configRepos = getConfig().repos ?? [];
-      const scannedPaths = new Set(reposToScan.map(r => r.path));
-      for (const wp of configRepos) {
-        if (scannedPaths.has(wp)) continue;
-        const root = roots.find(r => wp.startsWith(r)) || '';
-        reposToScan.push({ path: wp, name: wp.split('/').filter(Boolean).pop() || '', root });
-      }
-    }
-
-    for (const repo of reposToScan) {
-      // Use git worktree list to discover all worktrees (including those at arbitrary paths)
-      try {
-        const { stdout } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], { cwd: repo.path });
-        const parsed = parseWorktreeListPorcelain(stdout, repo.path);
-        for (const wt of parsed) {
-          const dirName = wt.path.split('/').pop() || '';
-          const meta = readMeta(CONFIG_PATH, wt.path);
-          worktrees.push({
-            name: dirName,
-            path: wt.path,
-            repoName: repo.name,
-            repoPath: repo.path,
-            root: repo.root,
-            displayName: meta?.displayName || wt.branch || dirName,
-            lastActivity: meta?.lastActivity || '',
-            branchName: wt.branch || meta?.branchName || dirName,
-          });
-        }
-      } catch {
-        // git worktree list failed — fall back to directory scanning
-        for (const dir of WORKTREE_DIRS) {
-          const worktreeDir = path.join(repo.path, dir);
-          let entries: fs.Dirent[];
-          try {
-            entries = fs.readdirSync(worktreeDir, { withFileTypes: true });
-          } catch (_) {
-            continue;
-          }
-          for (const entry of entries) {
-            if (!entry.isDirectory()) continue;
-            const wtPath = path.join(worktreeDir, entry.name);
-            const meta = readMeta(CONFIG_PATH, wtPath);
-            worktrees.push({
-              name: entry.name,
-              path: wtPath,
-              repoName: repo.name,
-              repoPath: repo.path,
-              root: repo.root,
-              displayName: meta?.displayName || '',
-              lastActivity: meta?.lastActivity || '',
-              branchName: meta?.branchName || entry.name,
-            });
-          }
-        }
-      }
-    }
-
-    // Deduplicate by path (a worktree can appear via multiple repo scans)
-    const seen = new Set<string>();
-    const unique = worktrees.filter(wt => {
-      if (seen.has(wt.path)) return false;
-      seen.add(wt.path);
-      return true;
-    });
-
-    // Skip expensive PR/staleness enrichment when enrich=false (boot fast path)
-    if (!enrich) {
-      for (const wt of unique) {
-        wt.branchState = 'active';
-      }
-      res.json(unique);
-      return;
-    }
-
-    // Compute branch lifecycle state for each worktree
-    // Batch PR lookups per repo to avoid N subprocess spawns
-    const activeSessions = sessions.list();
-    const uniqueRepos = [...new Set(unique.map(wt => wt.repoPath))];
-    const prMaps = new Map<string, Map<string, import('./types.js').PrInfo>>();
-    await Promise.all(uniqueRepos.map(async (repoPath) => {
-      try {
-        prMaps.set(repoPath, await batchGetPrsForRepo(repoPath));
-      } catch (err) {
-        console.warn('[worktrees] batchGetPrsForRepo failed for', repoPath, err instanceof Error ? err.message : err);
-        prMaps.set(repoPath, new Map());
-      }
-    }));
-
-    await Promise.all(unique.map(async (wt) => {
-      try {
-        const hasActiveSessions = activeSessions.some(s => s.worktreePath === wt.path || s.cwd === wt.path);
-        const isMainBranch = wt.path === wt.repoPath;
-
-        let stale = false;
-        try {
-          stale = await isBranchStale(wt.repoPath, wt.branchName);
-        } catch (err) {
-          console.warn('[worktrees] isBranchStale failed for', wt.branchName, err instanceof Error ? err.message : err);
-        }
-
-        // Look up PR from batched result; fall back to per-branch call on cache miss
-        let pr = prMaps.get(wt.repoPath)?.get(wt.branchName) ?? null;
-        if (!pr) {
-          try {
-            pr = await getPrForBranch(wt.repoPath, wt.branchName);
-          } catch (err) {
-            console.warn('[worktrees] getPrForBranch failed for', wt.branchName, err instanceof Error ? err.message : err);
-          }
-        }
-
-        const lifecycle = computeBranchLifecycleState({
-          pr,
-          isBranchStale: stale,
-          hasActiveSessions,
-          isMainBranch,
-        });
-
-        wt.branchState = lifecycle.state;
-        if (lifecycle.prNumber != null) wt.prNumber = lifecycle.prNumber;
-        if (lifecycle.prTitle != null) wt.prTitle = lifecycle.prTitle;
-      } catch (err) {
-        console.error('[worktrees] lifecycle computation failed for', wt.path, err);
-        wt.branchState = 'active';
-      }
-    }));
-
-    res.json(unique);
   });
 
   // GET /worktrees/status — pre-cleanup checks for a worktree

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -8,7 +8,8 @@ export type { BackendDisplayState };
 import { AGENT_COMMANDS, AGENT_CONTINUE_ARGS, AGENT_YOLO_ARGS } from './types.js';
 import { createPtySession } from './pty-handler.js';
 import type { CreatePtyParams } from './pty-handler.js';
-import { getPrForBranch, isStalePr, getWorkingTreeDiff } from './git.js';
+import { getWorkingTreeDiff } from './git.js';
+import { getPrForBranch, isStalePr } from './gh.js';
 import { trackEvent } from './analytics.js';
 
 const execFileAsync = promisify(execFile);

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -11,8 +11,9 @@ import type { Request, Response } from 'express';
 import { loadConfig, saveConfig, getRepoSettings, setRepoSettings, deleteRepoSettingKeys, writeMeta, readMeta } from './config.js';
 import { findOrCreateWorktreeForBranch } from './watcher.js';
 import { trackEvent } from './analytics.js';
-import { listBranches, getActivityFeed, getCiStatus, getPrForBranch, isStalePr, getUnresolvedCommentCount, switchBranch, getCurrentBranch, extractOwnerRepo, renameBranch, createBranch, changePrBase, pushBranch, getChangedFiles, getFileDiff, getDefaultBranch, ensureBranchLocal } from './git.js';
-import type { Config, PrInfo, PullRequest, PullRequestsResponse, Repo } from './types.js';
+import { listBranches, getActivityFeed, switchBranch, getCurrentBranch, extractOwnerRepo, renameBranch, createBranch, pushBranch, getChangedFiles, getFileDiff, getDefaultBranch, ensureBranchLocal } from './git.js';
+import { clearPrCache as clearPrCacheImpl } from './gh.js';
+import type { Config, PullRequest, PullRequestsResponse, Repo } from './types.js';
 import { MOUNTAIN_NAMES } from './types.js';
 
 const execFileAsync = promisify(execFile);
@@ -47,52 +48,7 @@ export function clearFilesListCache(workspacePath?: string): void {
 const BROWSE_MAX_ENTRIES = 100;
 const BULK_MAX_PATHS = 50;
 
-// ── PR lookup cache ─────────────────────────────────────────────────────────
-// Caches `getPrForBranch` results to avoid spawning a `gh` subprocess on every
-// request. Negative results (no PR) use a longer TTL since they only change on
-// user action (push, PR creation).
-
-const PR_CACHE_POSITIVE_TTL_MS = 60_000;   // 60s — same as org-dashboard
-const PR_CACHE_NEGATIVE_TTL_MS = 300_000;  // 5 min — "no PR" rarely changes without user action
-
-interface PrCacheEntry {
-  result: PrInfo | null;
-  fetchedAt: number;
-}
-
-const prCache = new Map<string, PrCacheEntry>();
-
-function prCacheKey(repoPath: string, branch: string): string {
-  return `${repoPath}:${branch}`;
-}
-
-function getPrCached(repoPath: string, branch: string): PrCacheEntry | undefined {
-  const key = prCacheKey(repoPath, branch);
-  const entry = prCache.get(key);
-  if (!entry) return undefined;
-  const ttl = entry.result ? PR_CACHE_POSITIVE_TTL_MS : PR_CACHE_NEGATIVE_TTL_MS;
-  if (Date.now() - entry.fetchedAt > ttl) {
-    prCache.delete(key);
-    return undefined;
-  }
-  return entry;
-}
-
-function setPrCached(repoPath: string, branch: string, result: PrInfo | null): void {
-  prCache.set(prCacheKey(repoPath, branch), { result, fetchedAt: Date.now() });
-}
-
-/** Clear PR cache entries. If repoPath is given, only clears entries for that repo. */
-export function clearPrCache(repoPath?: string): void {
-  if (!repoPath) {
-    prCache.clear();
-    return;
-  }
-  const prefix = `${repoPath}:`;
-  for (const key of prCache.keys()) {
-    if (key.startsWith(prefix)) prCache.delete(key);
-  }
-}
+export { clearPrCacheImpl as clearPrCache };
 
 // Deps type
 
@@ -635,62 +591,6 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
     res.json(final);
   });
 
-  // GET /workspaces/pr — PR info for a specific branch
-  router.get('/pr', async (req: Request, res: Response) => {
-    const repoPath = typeof req.query.path === 'string' ? req.query.path : undefined;
-    const branch = typeof req.query.branch === 'string' ? req.query.branch : undefined;
-
-    if (!repoPath || !branch) {
-      res.status(400).json({ error: 'path and branch query parameters are required' });
-      return;
-    }
-
-    const cached = getPrCached(repoPath, branch);
-    if (cached) {
-      res.json({ pr: cached.result });
-      return;
-    }
-
-    try {
-      const pr = await getPrForBranch(repoPath, branch);
-      if (pr && !isStalePr(pr)) {
-        let unresolvedCommentCount = 0;
-        if (pr.state === 'OPEN') {
-          try {
-            unresolvedCommentCount = await getUnresolvedCommentCount(repoPath, pr.number);
-          } catch { /* degrade gracefully — show PR without comment count */ }
-        }
-        const enriched = { ...pr, unresolvedCommentCount };
-        setPrCached(repoPath, branch, enriched);
-        res.json({ pr: enriched });
-      } else {
-        setPrCached(repoPath, branch, null);
-        res.json({ pr: null });
-      }
-    } catch {
-      // Do NOT cache transient errors — only cache clean null from getPrForBranch
-      res.json({ pr: null });
-    }
-  });
-
-  // GET /workspaces/ci-status — CI check results for a repo + branch
-  router.get('/ci-status', async (req: Request, res: Response) => {
-    const repoPath = typeof req.query.path === 'string' ? req.query.path : undefined;
-    const branch = typeof req.query.branch === 'string' ? req.query.branch : undefined;
-
-    if (!repoPath) {
-      res.status(400).json({ error: 'path query parameter is required' });
-      return;
-    }
-
-    try {
-      const status = await getCiStatus(repoPath, branch ?? 'HEAD');
-      res.json(status);
-    } catch {
-      res.json({ total: 0, passing: 0, failing: 0, pending: 0 });
-    }
-  });
-
   // POST /workspaces/branch — switch branch for a workspace
   router.post('/branch', async (req: Request, res: Response) => {
     const repoPath = typeof req.query.path === 'string' ? req.query.path : undefined;
@@ -1061,22 +961,6 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
     if (!branchName || typeof branchName !== 'string') { res.status(400).json({ error: 'branchName is required' }); return; }
 
     const result = await createBranch(repoPath, branchName);
-    if (result.success) {
-      res.json(result);
-    } else {
-      res.status(400).json({ error: result.error });
-    }
-  });
-
-  // POST /workspaces/pr-base — change the base branch of a PR for a workspace
-  router.post('/pr-base', async (req: Request, res: Response) => {
-    const repoPath = typeof req.query.path === 'string' ? req.query.path : undefined;
-    const { prNumber, baseBranch } = req.body as { prNumber?: number; baseBranch?: string };
-    if (!repoPath) { res.status(400).json({ error: 'path query parameter required' }); return; }
-    if (!prNumber || typeof prNumber !== 'number') { res.status(400).json({ error: 'prNumber is required' }); return; }
-    if (!baseBranch || typeof baseBranch !== 'string') { res.status(400).json({ error: 'baseBranch is required' }); return; }
-
-    const result = await changePrBase(repoPath, prNumber, baseBranch);
     if (result.success) {
       res.json(result);
     } else {

--- a/test/gh-routes.test.ts
+++ b/test/gh-routes.test.ts
@@ -1,0 +1,155 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { enrichBranches, type GhRouterDeps } from '../server/gh-routes.js';
+
+type ExecFn = GhRouterDeps['execFileAsync'];
+
+function makeExec(responses: Record<string, { stdout: string; stderr?: string }>): ExecFn {
+  return async (file: string, args: string[], _opts: { cwd: string }) => {
+    const key = `${file} ${args.slice(0, 3).join(' ')}`;
+    for (const [pattern, response] of Object.entries(responses)) {
+      if (key.startsWith(pattern)) {
+        return { stdout: response.stdout, stderr: response.stderr ?? '' };
+      }
+    }
+    throw new Error(`unexpected exec: ${file} ${args.join(' ')}`);
+  };
+}
+
+describe('enrichBranches', () => {
+  it('returns PR + staleness per branch keyed by repoPath::branchName', async () => {
+    const prList = JSON.stringify([
+      {
+        number: 42, title: 'Add login', url: 'https://github.com/o/r/pull/42',
+        state: 'OPEN', headRefName: 'feat/login', baseRefName: 'main',
+        isDraft: false, reviewDecision: 'APPROVED', additions: 10, deletions: 2,
+        mergeable: 'MERGEABLE', updatedAt: new Date().toISOString(),
+      },
+    ]);
+
+    const results = await enrichBranches(
+      [{ repoPath: '/repos/my-repo', branchName: 'feat/login' }],
+      makeExec({
+        'gh pr list': { stdout: prList },
+        'git rev-list': { stdout: '3\n' },
+      }),
+    );
+
+    const key = '/repos/my-repo::feat/login';
+    assert.ok(results[key], `expected key ${key} in results`);
+    assert.equal(results[key]!.pr!.number, 42);
+    assert.equal(results[key]!.stale, false);
+  });
+
+  it('handles partial failure (one repo fails, others succeed)', async () => {
+    const prList = JSON.stringify([
+      {
+        number: 1, title: 'Fix', url: 'https://github.com/o/r/pull/1',
+        state: 'OPEN', headRefName: 'fix/bug', baseRefName: 'main',
+        isDraft: false, reviewDecision: null, additions: 1, deletions: 1,
+        mergeable: 'MERGEABLE', updatedAt: new Date().toISOString(),
+      },
+    ]);
+
+    const exec: ExecFn = async (file: string, args: string[], opts: { cwd: string }) => {
+      if (opts.cwd === '/repos/bad-repo' && file === 'gh') {
+        throw new Error('gh: not logged in');
+      }
+      if (file === 'gh' && args[0] === 'pr' && args[1] === 'list') {
+        return { stdout: prList, stderr: '' };
+      }
+      if (file === 'git' && args[0] === 'rev-list') {
+        return { stdout: '1\n', stderr: '' };
+      }
+      throw new Error(`unexpected: ${file} ${args.join(' ')}`);
+    };
+
+    const results = await enrichBranches(
+      [
+        { repoPath: '/repos/good-repo', branchName: 'fix/bug' },
+        { repoPath: '/repos/bad-repo', branchName: 'feat/x' },
+      ],
+      exec,
+    );
+
+    // Good repo should have data
+    assert.ok(results['/repos/good-repo::fix/bug']);
+    assert.equal(results['/repos/good-repo::fix/bug']!.pr!.number, 1);
+
+    // Bad repo should have null pr and default stale=false
+    assert.equal(results['/repos/bad-repo::feat/x']!.pr, null);
+    assert.equal(results['/repos/bad-repo::feat/x']!.stale, false);
+  });
+
+  it('returns empty results for empty input', async () => {
+    const results = await enrichBranches(
+      [],
+      async () => ({ stdout: '', stderr: '' }),
+    );
+    assert.deepEqual(results, {});
+  });
+
+  it('degrades when gh CLI is missing (ENOENT)', async () => {
+    const exec: ExecFn = async (file: string, args: string[]) => {
+      if (file === 'gh') {
+        const err = new Error('spawn gh ENOENT') as Error & { code: string };
+        err.code = 'ENOENT';
+        throw err;
+      }
+      if (file === 'git' && args[0] === 'rev-list') {
+        return { stdout: '0\n', stderr: '' };
+      }
+      throw new Error(`unexpected: ${file} ${args.join(' ')}`);
+    };
+
+    const results = await enrichBranches(
+      [{ repoPath: '/repos/my-repo', branchName: 'feat/x' }],
+      exec,
+    );
+
+    const entry = results['/repos/my-repo::feat/x']!;
+    assert.equal(entry.pr, null);
+    assert.equal(entry.stale, true); // 0 commits ahead = stale
+  });
+
+  it('batches PR lookups per unique repo (one gh call per repo)', async () => {
+    const callLog: string[] = [];
+
+    const prList = JSON.stringify([
+      {
+        number: 1, title: 'A', url: 'u', state: 'OPEN', headRefName: 'a',
+        baseRefName: 'main', isDraft: false, reviewDecision: null,
+        additions: 0, deletions: 0, mergeable: 'MERGEABLE', updatedAt: new Date().toISOString(),
+      },
+      {
+        number: 2, title: 'B', url: 'u', state: 'OPEN', headRefName: 'b',
+        baseRefName: 'main', isDraft: false, reviewDecision: null,
+        additions: 0, deletions: 0, mergeable: 'MERGEABLE', updatedAt: new Date().toISOString(),
+      },
+    ]);
+
+    const exec: ExecFn = async (file: string, args: string[], opts: { cwd: string }) => {
+      callLog.push(`${file} ${args[0]} ${args[1] ?? ''} [${opts.cwd}]`);
+      if (file === 'gh' && args[0] === 'pr' && args[1] === 'list') {
+        return { stdout: prList, stderr: '' };
+      }
+      if (file === 'git' && args[0] === 'rev-list') {
+        return { stdout: '1\n', stderr: '' };
+      }
+      throw new Error(`unexpected`);
+    };
+
+    await enrichBranches(
+      [
+        { repoPath: '/repos/repo1', branchName: 'a' },
+        { repoPath: '/repos/repo1', branchName: 'b' },
+      ],
+      exec,
+    );
+
+    // Should have exactly 1 gh pr list call for repo1 (not 2)
+    const ghCalls = callLog.filter(c => c.startsWith('gh pr list'));
+    assert.equal(ghCalls.length, 1, `expected 1 gh pr list call, got ${ghCalls.length}`);
+  });
+});

--- a/test/git-routes.test.ts
+++ b/test/git-routes.test.ts
@@ -1,0 +1,153 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { scanWorktrees, type GitRouterDeps } from '../server/git-routes.js';
+
+function makeDeps(overrides: Partial<GitRouterDeps> = {}): GitRouterDeps {
+  return {
+    getConfig: () => ({ rootDirs: ['/repos'], repos: [] }),
+    configPath: '/tmp/test-config.json',
+    execFileAsync: async () => ({ stdout: '', stderr: '' }),
+    readdirSync: () => [],
+    statSync: () => ({ isDirectory: () => true }),
+    readMeta: () => null,
+    ...overrides,
+  };
+}
+
+describe('scanWorktrees', () => {
+  it('returns worktrees without PR data (no branchState, prNumber, prTitle)', async () => {
+    const deps = makeDeps({
+      getConfig: () => ({ rootDirs: ['/repos'], repos: [] }),
+      execFileAsync: async (file: string, args: string[], opts: { cwd: string }) => {
+        if (file === 'git' && args[0] === 'worktree') {
+          return {
+            stdout: [
+              `worktree ${opts.cwd}`,
+              'HEAD abc123',
+              'branch refs/heads/main',
+              '',
+              `worktree ${opts.cwd}/.worktrees/feat`,
+              'HEAD def456',
+              'branch refs/heads/feat/login',
+              '',
+            ].join('\n'),
+            stderr: '',
+          };
+        }
+        throw new Error(`unexpected: ${file} ${args.join(' ')}`);
+      },
+      readdirSync: (_dir: string) => [
+        { name: 'my-repo', isDirectory: () => true },
+      ],
+      statSync: () => ({ isDirectory: () => true }),
+    });
+
+    const items = await scanWorktrees(deps);
+    assert.ok(Array.isArray(items));
+    // parseWorktreeListPorcelain excludes the main worktree, so only child worktrees are returned
+    assert.equal(items.length, 1);
+    assert.equal(items[0]!.branchName, 'feat/login');
+    for (const wt of items) {
+      assert.equal((wt as unknown as Record<string, unknown>).branchState, undefined);
+      assert.equal((wt as unknown as Record<string, unknown>).prNumber, undefined);
+      assert.equal((wt as unknown as Record<string, unknown>).prTitle, undefined);
+      assert.ok(typeof wt.path === 'string');
+      assert.ok(typeof wt.branchName === 'string');
+    }
+  });
+
+  it('handles empty rootDirs gracefully', async () => {
+    const deps = makeDeps({
+      getConfig: () => ({ rootDirs: [], repos: [] }),
+    });
+
+    const items = await scanWorktrees(deps);
+    assert.deepEqual(items, []);
+  });
+
+  it('filters by repo param', async () => {
+    const deps = makeDeps({
+      execFileAsync: async (file: string, args: string[], opts: { cwd: string }) => {
+        if (file === 'git' && args[0] === 'worktree') {
+          return {
+            stdout: [
+              `worktree ${opts.cwd}`,
+              'HEAD abc123',
+              'branch refs/heads/main',
+              '',
+              `worktree ${opts.cwd}/.worktrees/feat`,
+              'HEAD def456',
+              'branch refs/heads/feat/x',
+              '',
+            ].join('\n'),
+            stderr: '',
+          };
+        }
+        throw new Error(`unexpected: ${file} ${args.join(' ')}`);
+      },
+    });
+
+    // parseWorktreeListPorcelain excludes the main worktree, so only the child is returned
+    const items = await scanWorktrees(deps, '/repos/my-repo');
+    assert.ok(Array.isArray(items));
+    assert.equal(items.length, 1);
+    assert.equal(items[0]!.branchName, 'feat/x');
+  });
+
+  it('deduplicates worktrees appearing via multiple repos', async () => {
+    const sharedWorktreePath = '/repos/my-repo/.worktrees/feat';
+    const deps = makeDeps({
+      getConfig: () => ({
+        rootDirs: ['/repos'],
+        repos: ['/repos/my-repo'],
+      }),
+      execFileAsync: async (file: string, args: string[], opts: { cwd: string }) => {
+        if (file === 'git' && args[0] === 'worktree') {
+          return {
+            stdout: [
+              `worktree ${opts.cwd}`,
+              'HEAD abc123',
+              'branch refs/heads/main',
+              '',
+              `worktree ${sharedWorktreePath}`,
+              'HEAD def456',
+              'branch refs/heads/feat/x',
+              '',
+            ].join('\n'),
+            stderr: '',
+          };
+        }
+        throw new Error(`unexpected: ${file} ${args.join(' ')}`);
+      },
+      readdirSync: () => [
+        { name: 'my-repo', isDirectory: () => true },
+      ],
+      statSync: () => ({ isDirectory: () => true }),
+    });
+
+    const items = await scanWorktrees(deps);
+    const paths = items.map(wt => wt.path);
+    const uniquePaths = [...new Set(paths)];
+    assert.equal(paths.length, uniquePaths.length, 'should have no duplicate paths');
+  });
+
+  it('falls back to directory scanning when git worktree list fails', async () => {
+    const deps = makeDeps({
+      getConfig: () => ({ rootDirs: ['/repos'], repos: [] }),
+      execFileAsync: async () => {
+        throw new Error('git worktree list failed');
+      },
+      readdirSync: (dir: string) => {
+        if (dir === '/repos') return [{ name: 'my-repo', isDirectory: () => true }];
+        if (dir.includes('.worktrees')) return [{ name: 'feat-branch', isDirectory: () => true }];
+        return [];
+      },
+      statSync: () => ({ isDirectory: () => true }),
+      readMeta: () => ({ worktreePath: '/repos/my-repo/.worktrees/feat-branch', displayName: 'Feature', lastActivity: '', branchName: 'feat-branch' }),
+    });
+
+    const items = await scanWorktrees(deps);
+    assert.ok(items.length > 0, 'should fall back to directory scanning');
+  });
+});

--- a/test/git-utils.test.ts
+++ b/test/git-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { extractOwnerRepo, isStalePr } from '../server/git.js';
+import { extractOwnerRepo } from '../server/git.js';
+import { isStalePr } from '../server/gh.js';
 import type { PrInfo } from '../server/types.js';
 
 describe('extractOwnerRepo', () => {

--- a/test/sidebar-items.test.ts
+++ b/test/sidebar-items.test.ts
@@ -103,7 +103,7 @@ describe('buildSidebarItems', () => {
   });
 
   it('workspace defaultBranch is used as branchName for inactive repo root', () => {
-    const workspace = makeWorkspace({ path: '/repo', defaultBranch: 'feature-x' });
+    const workspace = makeWorkspace({ path: '/repo', defaultBranch: 'feature-x', currentBranch: null });
     const items = buildSidebarItems([], [], [workspace], []);
 
     assert.equal(items.length, 1);


### PR DESCRIPTION
## Summary

Boot performance was blocked 10+ seconds because `GET /worktrees` mixed fast git operations with slow `gh` CLI calls. This creates a clean `git/gh` module boundary: `/git/*` endpoints return in <200ms (no gh subprocesses), and a new batch `POST /gh/enrich-branches` replaces N+1 per-item PR queries with 1 `gh pr list` call per repo.

## Changes

- **New modules**: `server/gh.ts` (gh CLI functions + prCache), `server/git-routes.ts` (`/git/*` router), `server/gh-routes.ts` (`/gh/*` router)
- **Deleted dead enrichment**: `branchState`/`prNumber`/`prTitle` fields in worktrees response were never consumed by the frontend `WorktreeInfo` type
- **Batch replaces N+1**: `POST /gh/enrich-branches` groups by repo, calls `batchGetPrsForRepo()` once per unique repo instead of N individual `gh pr view` calls
- **Relocated endpoints**: `/workspaces/pr` → `/gh/pr`, `/workspaces/ci-status` → `/gh/ci-status`, `/workspaces/pr-base` → `/gh/pr-base`
- **Frontend**: `enrichSidebarBranches()` replaces `refreshWorktreesEnriched()`, `refreshAll()` no longer accepts `enrich` option

## Testing

- 10 new tests across `test/git-routes.test.ts` and `test/gh-routes.test.ts`
- All 706 tests pass, build clean
- Tests cover: batch enrichment, partial failure, empty input, missing gh CLI, deduplication, directory fallback

---
*Created with `/pr:author`*