### PR TITLE
fix: expand ~/paths in file-diff endpoint for files outside workspace

### DIFF
--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -125,6 +125,13 @@ export async function detectGitRepo(
   return { isGitRepo: true, defaultBranch };
 }
 
+function expandTilde(p: string): string {
+  if (p === '~' || p.startsWith('~/')) {
+    return path.join(os.homedir(), p.slice(1));
+  }
+  return p;
+}
+
 // Router factory
 
 /**
@@ -789,11 +796,7 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
     const prefix = typeof req.query.prefix === 'string' ? req.query.prefix : '';
     const showHidden = req.query.showHidden === 'true';
 
-    // Resolve ~ to home directory
-    const expanded = rawPath === '~' || rawPath.startsWith('~/')
-      ? path.join(os.homedir(), rawPath.slice(1))
-      : rawPath;
-    const resolved = path.resolve(expanded);
+    const resolved = path.resolve(expandTilde(rawPath));
 
     let stat: fs.Stats;
     try {
@@ -1068,8 +1071,34 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
       return;
     }
 
-    if (filePath.includes('..') || path.isAbsolute(filePath)) {
+    const expandedFile = expandTilde(filePath);
+
+    if (expandedFile.includes('..')) {
       res.status(400).json({ diff: '', error: 'invalid file path' });
+      return;
+    }
+
+    if (path.isAbsolute(expandedFile)) {
+      try {
+        const stat = await fs.promises.stat(expandedFile);
+        if (!stat.isFile()) {
+          res.status(400).json({ diff: '', error: 'not a regular file' });
+          return;
+        }
+        if (stat.size > 2 * 1024 * 1024) {
+          res.status(413).json({ diff: '', error: 'file too large' });
+          return;
+        }
+        const content = await fs.promises.readFile(expandedFile, 'utf-8');
+        res.json({ diff: content });
+      } catch (err: unknown) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'EACCES' || code === 'EPERM') {
+          res.status(403).json({ diff: '', error: 'permission denied' });
+        } else {
+          res.status(404).json({ diff: '', error: 'file not found' });
+        }
+      }
       return;
     }
 
@@ -1079,7 +1108,7 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
     }
 
     try {
-      const diff = await getFileDiff(resolvedRepo, filePath, base, exec);
+      const diff = await getFileDiff(resolvedRepo, expandedFile, base, exec);
       res.json({ diff });
     } catch (err: unknown) {
       console.warn('[workspaces] /file-diff failed for', resolvedRepo, filePath, err instanceof Error ? err.message : String(err));

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -127,7 +127,13 @@ export async function detectGitRepo(
 
 function expandTilde(p: string): string {
   if (p === '~' || p.startsWith('~/')) {
-    return path.join(os.homedir(), p.slice(1));
+    const homeDir = os.homedir();
+    const resolved = path.resolve(path.join(homeDir, p.slice(1)));
+    const relative = path.relative(homeDir, resolved);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      return p; // traversal attempt — return unexpanded
+    }
+    return resolved;
   }
   return p;
 }
@@ -1073,7 +1079,7 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
 
     const expandedFile = expandTilde(filePath);
 
-    if (expandedFile.includes('..')) {
+    if (expandedFile.includes('..') || (path.isAbsolute(filePath) && !filePath.startsWith('~'))) {
       res.status(400).json({ diff: '', error: 'invalid file path' });
       return;
     }

--- a/test/changed-files-api.test.ts
+++ b/test/changed-files-api.test.ts
@@ -90,6 +90,58 @@ describe('GET /workspaces/file-diff', () => {
     const res = await fetch(`${baseUrl}/workspaces/file-diff?path=${encodeURIComponent(repoDir)}`);
     assert.equal(res.status, 400);
   });
+
+  test('rejects absolute paths that did not start with ~', async () => {
+    const res = await fetch(`${baseUrl}/workspaces/file-diff?path=${encodeURIComponent(repoDir)}&file=/etc/passwd`);
+    assert.equal(res.status, 400);
+    const data = await res.json() as any;
+    assert.equal(data.error, 'invalid file path');
+  });
+
+  test('rejects .. traversal in relative paths', async () => {
+    const res = await fetch(`${baseUrl}/workspaces/file-diff?path=${encodeURIComponent(repoDir)}&file=../../etc/passwd`);
+    assert.equal(res.status, 400);
+    const data = await res.json() as any;
+    assert.equal(data.error, 'invalid file path');
+  });
+
+  test('reads ~/file paths directly via fs', async () => {
+    const testFile = path.join(os.homedir(), '.claude-remote-cli-test-tilde');
+    fs.writeFileSync(testFile, 'tilde-test-content', 'utf-8');
+    try {
+      const res = await fetch(`${baseUrl}/workspaces/file-diff?path=${encodeURIComponent(repoDir)}&file=~/.claude-remote-cli-test-tilde`);
+      assert.equal(res.status, 200);
+      const data = await res.json() as any;
+      assert.equal(data.diff, 'tilde-test-content');
+    } finally {
+      fs.unlinkSync(testFile);
+    }
+  });
+
+  test('rejects ~/../../ etc traversal attempts', async () => {
+    const res = await fetch(`${baseUrl}/workspaces/file-diff?path=${encodeURIComponent(repoDir)}&file=~/../../etc/passwd`);
+    assert.equal(res.status, 400);
+    const data = await res.json() as any;
+    assert.equal(data.error, 'invalid file path');
+  });
+
+  test('returns 404 for non-existent ~/file', async () => {
+    const res = await fetch(`${baseUrl}/workspaces/file-diff?path=${encodeURIComponent(repoDir)}&file=~/.claude-remote-cli-nonexistent-file`);
+    assert.equal(res.status, 404);
+  });
+
+  test('returns 400 for directory ~/path', async () => {
+    const testDir = path.join(os.homedir(), '.claude-remote-cli-test-dir');
+    fs.mkdirSync(testDir, { recursive: true });
+    try {
+      const res = await fetch(`${baseUrl}/workspaces/file-diff?path=${encodeURIComponent(repoDir)}&file=~/.claude-remote-cli-test-dir`);
+      assert.equal(res.status, 400);
+      const data = await res.json() as any;
+      assert.equal(data.error, 'not a regular file');
+    } finally {
+      fs.rmdirSync(testDir);
+    }
+  });
 });
 
 describe('GET /workspaces/default-branch', () => {


### PR DESCRIPTION
## Summary

Clicking a `~/path` in the terminal output (e.g. a gstack output file like `~/.gstack/projects/...`) showed `(empty file)` in the file viewer. The `/workspaces/file-diff` endpoint was passing tilde paths verbatim to `git diff`, which found nothing relative to the repo directory.

## Changes

- **Fix**: `~/` paths are now expanded to the home directory before processing; bare `~` is also handled
- **Refactor**: Extracted `expandTilde()` helper and applied it in both `/browse` and `/file-diff` (was duplicated inline)
- **Security**: `..` traversal check now runs against the expanded path (previously `~/../../etc/passwd` would have bypassed it)
- **Safety**: 2MB size cap on direct file reads to prevent unbounded memory use

## Testing

- Build passes, 741/742 tests pass (1 pre-existing environment-dependent failure in `sidebar-items.test.ts`)
- Manually verified: clicking a `~/` path in terminal now opens and renders the file contents correctly

---
*Created with `/pr:author`*