### PR TITLE
feat: auto-restart on npm update and update channel preference

### DIFF
--- a/bin/claude-remote-cli.ts
+++ b/bin/claude-remote-cli.ts
@@ -82,8 +82,17 @@ if (command === 'update') {
   try {
     const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf-8')) as { version: string };
     console.log(`Current version: ${pkg.version}`);
-    console.log('Updating claude-remote-cli...');
-    await execFileAsync('npm', ['install', '-g', 'claude-remote-cli@latest']);
+    const configPath = resolveConfigPath();
+    let channel = 'stable';
+    if (fs.existsSync(configPath)) {
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as { updateChannel?: string };
+      if (config.updateChannel === 'nightly' || config.updateChannel === 'stable') {
+        channel = config.updateChannel;
+      }
+    }
+    const tag = channel === 'nightly' ? 'nightly' : 'latest';
+    console.log(`Updating claude-remote-cli from ${channel} channel...`);
+    await execFileAsync('npm', ['install', '-g', `claude-remote-cli@${tag}`]);
     const updatedPkg = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf-8')) as { version: string };
     if (updatedPkg.version === pkg.version) {
       console.log(`Already on the latest version (${pkg.version}).`);

--- a/frontend/src/components/dialogs/SettingsDialog.svelte
+++ b/frontend/src/components/dialogs/SettingsDialog.svelte
@@ -18,6 +18,8 @@
     setDefaultNotifications,
     checkVersion,
     triggerUpdate,
+    fetchUpdateChannel,
+    setUpdateChannel,
     fetchAnalyticsSize,
     clearAnalytics,
     fetchGitHubStatus,
@@ -44,6 +46,8 @@
   let versionChecked = $state(false);
   let updating = $state(false);
   let updateStatus = $state('');
+  let updateChannelValue = $state<'stable' | 'nightly'>('stable');
+  let savingChannel = $state(false);
 
   // Analytics state
   let analyticsSize = $state<number | null>(null);
@@ -96,6 +100,29 @@
     }
   }
 
+  async function loadUpdateChannel() {
+    try {
+      updateChannelValue = await fetchUpdateChannel();
+    } catch {
+      updateChannelValue = 'stable';
+    }
+  }
+
+  async function handleChannelChange(channel: 'stable' | 'nightly') {
+    if (savingChannel || channel === updateChannelValue) return;
+    savingChannel = true;
+    try {
+      await setUpdateChannel(channel);
+      updateChannelValue = channel;
+      versionChecked = false;
+      await checkVersionAsync();
+    } catch {
+      error = 'Failed to update channel.';
+    } finally {
+      savingChannel = false;
+    }
+  }
+
   async function fetchAnalyticsSizeAsync() {
     try {
       const d = await fetchAnalyticsSize();
@@ -129,6 +156,7 @@
     devtoolsEnabled = localStorage.getItem('devtools-enabled') === 'true';
     notificationPermission = getPermissionState();
     refreshConfig();
+    loadUpdateChannel();
     checkVersionAsync();
     fetchAnalyticsSizeAsync();
     fetchGitHubStatusAsync();
@@ -428,6 +456,23 @@
         {/if}
       </SettingRow>
 
+      <SettingRow name="Update Channel" description={updateChannelValue === 'nightly' ? 'Nightly builds' : 'Stable releases'}>
+        <div class="channel-selector">
+          <button
+            class="channel-btn"
+            class:active={updateChannelValue === 'stable'}
+            disabled={savingChannel}
+            onclick={() => handleChannelChange('stable')}
+          >Stable</button>
+          <button
+            class="channel-btn"
+            class:active={updateChannelValue === 'nightly'}
+            disabled={savingChannel}
+            onclick={() => handleChannelChange('nightly')}
+          >Nightly</button>
+        </div>
+      </SettingRow>
+
       {#if updateStatus}
         <p class="update-status">{updateStatus}</p>
       {/if}
@@ -597,5 +642,41 @@
   .ghost-btn:hover {
     border-color: var(--accent);
     color: var(--accent);
+  }
+
+  .channel-selector {
+    display: flex;
+    gap: 0;
+    border: 1px solid var(--border);
+  }
+
+  .channel-btn {
+    background: var(--bg);
+    border: none;
+    border-right: 1px solid var(--border);
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: var(--font-size-xs);
+    padding: 6px 12px;
+    cursor: pointer;
+  }
+
+  .channel-btn:last-child {
+    border-right: none;
+  }
+
+  .channel-btn:hover:not(:disabled) {
+    background: var(--surface-hover);
+    color: var(--text);
+  }
+
+  .channel-btn.active {
+    background: var(--accent);
+    color: var(--bg);
+  }
+
+  .channel-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 </style>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -356,12 +356,26 @@ export async function uploadImage(
   );
 }
 
-export async function checkVersion(): Promise<{ current: string; latest: string | null; updateAvailable: boolean }> {
-  return json<{ current: string; latest: string | null; updateAvailable: boolean }>(await fetch('/version'));
+export async function checkVersion(): Promise<{ current: string; latest: string | null; updateAvailable: boolean; channel: string }> {
+  return json<{ current: string; latest: string | null; updateAvailable: boolean; channel: string }>(await fetch('/version'));
 }
 
 export async function triggerUpdate(): Promise<{ ok: boolean; restarting?: boolean; error?: string }> {
   return json<{ ok: boolean; restarting?: boolean; error?: string }>(await fetch('/update', { method: 'POST' }));
+}
+
+export async function fetchUpdateChannel(): Promise<'stable' | 'nightly'> {
+  const data = await json<{ channel: 'stable' | 'nightly' }>(await fetch('/update-channel'));
+  return data.channel;
+}
+
+export async function setUpdateChannel(channel: 'stable' | 'nightly'): Promise<void> {
+  const res = await fetch('/update-channel', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ channel }),
+  });
+  if (!res.ok) throw new Error('Failed to update channel');
 }
 
 export async function fetchDefaultAgent(): Promise<string> {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start": "tsc && svelte-check --workspace frontend && vite build --config frontend/vite.config.ts && node dist/server/index.js",
     "test": "svelte-check --workspace frontend && tsc -p tsconfig.test.json && node --test --test-force-exit dist/test/*.test.js dist/test/**/*.test.js",
     "prepublishOnly": "npm run build",
-    "postinstall": "chmod +x node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper 2>/dev/null || true"
+    "postinstall": "node scripts/postinstall.js"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Post-install script for claude-remote-cli
+ * 
+ * 1. Fixes node-pty permissions (macOS ARM64)
+ * 2. Auto-restarts background service if running (picks up new code after npm update)
+ */
+
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ── Step 1: Fix node-pty permissions (existing behavior) ──
+
+try {
+  execSync('chmod +x node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper 2>/dev/null || true', {
+    cwd: path.join(__dirname, '..'),
+    stdio: 'ignore'
+  });
+} catch {
+  // Ignore errors - this is best-effort
+}
+
+// ── Step 2: Auto-restart background service if running ──
+
+async function restartServiceIfRunning() {
+  try {
+    // Import service module from compiled dist
+    // Note: This runs after npm install, so dist/ should be available
+    const servicePath = path.join(__dirname, '../dist/server/service.js');
+    
+    if (!fs.existsSync(servicePath)) {
+      // Dist not built yet (e.g., during development), skip restart
+      return;
+    }
+
+    const service = await import(servicePath);
+    
+    // Check if service is installed
+    if (!service.isInstalled()) {
+      // Service not installed, nothing to restart
+      return;
+    }
+
+    // Check if service is running
+    const status = service.status();
+    if (!status.running) {
+      // Service installed but not running, nothing to restart
+      return;
+    }
+
+    // Service is installed and running - restart it to pick up new code
+    console.log('[postinstall] Background service detected - restarting to apply update...');
+    
+    try {
+      // Get config path
+      const home = process.env.HOME || process.env.USERPROFILE || '~';
+      const configDir = path.join(home, '.config', 'claude-remote-cli');
+      const configPath = path.join(configDir, 'config.json');
+      
+      // Load config to get port/host
+      let port = '3456';
+      let host = '0.0.0.0';
+      if (fs.existsSync(configPath)) {
+        const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+        port = String(config.port || 3456);
+        host = config.host || '0.0.0.0';
+      }
+
+      // Uninstall the service (stops it)
+      service.uninstall();
+      
+      // Re-install the service (starts it with new code)
+      service.install({ configPath, port, host });
+      
+      console.log('[postinstall] Service restarted successfully.');
+    } catch (err) {
+      console.warn('[postinstall] Failed to restart service:', err.message);
+      console.warn('[postinstall] You may need to restart manually: claude-remote-cli install');
+    }
+  } catch (err) {
+    // Don't fail the install if restart fails
+    console.warn('[postinstall] Could not check service status:', err.message);
+  }
+}
+
+// Run restart check
+restartServiceIfRunning();

--- a/server/config.ts
+++ b/server/config.ts
@@ -16,11 +16,12 @@ export const DEFAULTS: Omit<Config, 'pinHash' | 'rootDirs' | 'workspaceSettings'
   claudeCommand: 'claude',
   claudeArgs: [],
   defaultAgent: 'claude',
-  defaultFramework: 'claude',  // set from defaultAgent in loadConfig; default is 'claude'
+  defaultFramework: 'claude',
   defaultContinue: true,
   defaultYolo: false,
   launchInTmux: false,
   defaultNotifications: true,
+  updateChannel: 'stable',
 };
 
 function migrateToV4(config: Config, configPath: string): void {
@@ -127,6 +128,17 @@ function migrateToV5(config: Config, configPath: string): void {
   saveConfig(configPath, config);
 }
 
+function migrateToV6(config: Config, configPath: string): void {
+  if (config.configVersion != null && config.configVersion >= 6) return;
+
+  if (!config.updateChannel) {
+    config.updateChannel = 'stable';
+  }
+
+  config.configVersion = 6;
+  saveConfig(configPath, config);
+}
+
 export function loadConfig(configPath: string): Config {
   if (!fs.existsSync(configPath)) {
     throw new Error(`Config file not found: ${configPath}`);
@@ -179,6 +191,7 @@ export function loadConfig(configPath: string): Config {
 
   migrateToV4(config, configPath);
   migrateToV5(config, configPath);
+  migrateToV6(config, configPath);
 
   return config;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -62,13 +62,14 @@ function getCurrentVersion(): string {
 }
 
 
-async function getLatestVersion(): Promise<string | null> {
+async function getLatestVersion(channel: 'stable' | 'nightly' = 'stable'): Promise<string | null> {
   const now = Date.now();
   if (versionCache && now - versionCache.fetchedAt < VERSION_CACHE_TTL) {
     return versionCache.latest;
   }
   try {
-    const res = await fetch('https://registry.npmjs.org/claude-remote-cli/latest');
+    const tag = channel === 'nightly' ? 'nightly' : 'latest';
+    const res = await fetch(`https://registry.npmjs.org/claude-remote-cli/${tag}`);
     if (!res.ok) return null;
     const data = await res.json() as { version?: string };
     if (!data.version) return null;
@@ -1408,18 +1409,20 @@ async function main(): Promise<void> {
   // GET /version — check current vs latest
   app.get('/version', requireAuth, async (_req, res) => {
     const current = getCurrentVersion();
-    const latest = await getLatestVersion();
+    const channel = startupConfig.updateChannel ?? 'stable';
+    const latest = await getLatestVersion(channel);
     const updateAvailable = latest !== null && semverLessThan(current, latest);
-    res.json({ current, latest, updateAvailable });
+    res.json({ current, latest, updateAvailable, channel });
   });
 
   // POST /update — install latest version from npm
   app.post('/update', requireAuth, async (_req, res) => {
     try {
-      await execFileAsync('npm', ['install', '-g', 'claude-remote-cli@latest']);
+      const channel = startupConfig.updateChannel ?? 'stable';
+      const tag = channel === 'nightly' ? 'nightly' : 'latest';
+      await execFileAsync('npm', ['install', '-g', `claude-remote-cli@${tag}`]);
       const restarting = serviceIsInstalled();
       if (restarting) {
-        // Persist sessions so they can be restored after restart
         stopEventBatching();
         stopTelemetry();
         serializeAll(configDir);
@@ -1432,6 +1435,21 @@ async function main(): Promise<void> {
       const message = err instanceof Error ? err.message : 'Update failed';
       res.status(500).json({ ok: false, error: message });
     }
+  });
+
+  app.get('/update-channel', requireAuth, (_req, res) => {
+    res.json({ channel: startupConfig.updateChannel ?? 'stable' });
+  });
+
+  app.put('/update-channel', requireAuth, (req, res) => {
+    const { channel } = req.body as { channel?: string };
+    if (channel !== 'stable' && channel !== 'nightly') {
+      res.status(400).json({ error: 'Invalid channel. Must be "stable" or "nightly".' });
+      return;
+    }
+    startupConfig.updateChannel = channel;
+    saveConfig(CONFIG_PATH, startupConfig);
+    res.json({ channel });
   });
 
   // Browser content viewer (token-based auth, not cookie auth)

--- a/server/index.ts
+++ b/server/index.ts
@@ -53,7 +53,7 @@ const CONFIG_PATH = process.env.CLAUDE_REMOTE_CONFIG || path.join(__dirname, '..
 const DEFAULT_GITHUB_CLIENT_ID = 'Ov23lilheF3LelYSo0bu';
 
 const VERSION_CACHE_TTL = 5 * 60 * 1000;
-let versionCache: { latest: string; fetchedAt: number } | null = null;
+const versionCache: Map<string, { latest: string; fetchedAt: number }> = new Map();
 
 function getCurrentVersion(): string {
   const pkgPath = path.join(__dirname, '..', '..', 'package.json');
@@ -64,8 +64,9 @@ function getCurrentVersion(): string {
 
 async function getLatestVersion(channel: 'stable' | 'nightly' = 'stable'): Promise<string | null> {
   const now = Date.now();
-  if (versionCache && now - versionCache.fetchedAt < VERSION_CACHE_TTL) {
-    return versionCache.latest;
+  const cached = versionCache.get(channel);
+  if (cached && now - cached.fetchedAt < VERSION_CACHE_TTL) {
+    return cached.latest;
   }
   try {
     const tag = channel === 'nightly' ? 'nightly' : 'latest';
@@ -73,7 +74,7 @@ async function getLatestVersion(channel: 'stable' | 'nightly' = 'stable'): Promi
     if (!res.ok) return null;
     const data = await res.json() as { version?: string };
     if (!data.version) return null;
-    versionCache = { latest: data.version, fetchedAt: now };
+    versionCache.set(channel, { latest: data.version, fetchedAt: now });
     return data.version;
   } catch (_) {
     return null;
@@ -1449,6 +1450,7 @@ async function main(): Promise<void> {
     }
     startupConfig.updateChannel = channel;
     saveConfig(CONFIG_PATH, startupConfig);
+    versionCache.clear();
     res.json({ channel });
   });
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -355,6 +355,7 @@ export interface Config {
     autoProvision?: boolean;    // defaults to false
     backfillOffered?: boolean;  // tracks if backfill prompt was shown
   } | undefined;
+  updateChannel?: 'stable' | 'nightly' | undefined;
 }
 
 export interface AutomationSettings {


### PR DESCRIPTION
## Summary

This PR adds two related features:

### 1. Auto-restart on npm update
When users run "npm i -g claude-remote-cli@nightly", the postinstall script now automatically restarts the background service if it's running. This ensures the new code is picked up immediately.

### 2. Update channel preference (nightly vs stable)
Users can now choose between 'stable' (@latest) and 'nightly' (@nightly) update channels via Settings > About. The preference is stored in config and affects:
- Version checking (GET /version endpoint)
- In-app updates (POST /update endpoint)  
- CLI update command (claude-remote-cli update)

## Changes

- **scripts/postinstall.js** (new): Auto-restart background service on npm update
- **server/types.ts**: Add updateChannel to Config type
- **server/config.ts**: Add updateChannel default ('stable') and migrateToV6
- **server/index.ts**: 
  - Update /version and /update endpoints to respect channel
  - Add GET/PUT /update-channel endpoints
- **frontend/src/lib/api.ts**: Add fetchUpdateChannel() and setUpdateChannel()
- **frontend/src/components/dialogs/SettingsDialog.svelte**: Add channel selector UI
- **bin/claude-remote-cli.ts**: Update command respects channel preference
- **package.json**: Use new postinstall script

## Testing

- [x] TypeScript compilation passes
- [x] Svelte check passes
- [x] Build succeeds
- [x] Existing tests pass