### PR TITLE
fix: DYS-8 — prevent Add Repo modal content shift on checkbox focus

### DIFF
--- a/docs/bug-analyses/2026-04-03-add-repo-modal-focus-shift-bug-analysis.md
+++ b/docs/bug-analyses/2026-04-03-add-repo-modal-focus-shift-bug-analysis.md
@@ -1,0 +1,90 @@
+# Bug Analysis: Add Repo modal content shifts and disappears on checkbox focus
+
+- **Date:** 2026-04-03
+- **Ticket:** DYS-8
+- **Severity:** High
+- **Branch:** nightly
+
+## Symptoms
+
+When using the "Add Repo" dialog, focusing UI elements (particularly checkboxes in the file browser tree) causes the modal content to shift entirely out of the visible area. The effect worsens for items further down the scrollable list. Pressing Tab sometimes snaps content back into view, but the behavior is inconsistent and jarring. This completely breaks keyboard accessibility.
+
+## Reproduction Steps
+
+1. Open the "add repo" dialog from the sidebar.
+2. Wait for the file browser tree to load.
+3. Click on a checkbox in the tree, or Tab into the tree and navigate with arrow keys.
+4. Observe that the dialog body content shifts upward, making the file browser invisible.
+5. Tab again -- content may snap back partially, then shift again on the next focus.
+
+## Root Cause
+
+**Nested scrollable containers + browser auto-scroll-on-focus behavior.**
+
+The dialog layout creates two nested scrollable containers:
+
+1. `.dialog-shell__body` (DialogShell.css:130-134) -- `overflow-y: auto`, flex child of the dialog
+2. `.tree-container` (FileBrowser.css:33-38) -- `max-height: 50vh`, `overflow-y: auto`, inside the dialog body
+
+When any focusable element inside `.tree-container` receives focus (via Tab, click, or programmatic `.focus()`), the browser walks up the entire ancestor chain and scrolls **every** scrollable ancestor to ensure the focused element is in the viewport. The `.tree-container` scrolls correctly (it is the intended scroll container), but `.dialog-shell__body` also scrolls, pushing the entire file browser component out of view.
+
+**Contributing factor:** The `TuiCheckbox` component uses a visually-hidden `<input>` element (`position: absolute; clip: rect(0,0,0,0); width: 1px; height: 1px`). The computed layout position of this hidden input can confuse the browser's scroll-into-view algorithm, causing larger-than-expected scroll offsets on ancestor containers.
+
+**Secondary issue:** The `DialogShell.open()` method calls `.focus()` on the first focusable element without `{ preventScroll: true }`, which can trigger the same ancestor-scroll behavior on dialog open.
+
+## Evidence
+
+| File                                              | Line    | Issue                                                                         |
+| ------------------------------------------------- | ------- | ----------------------------------------------------------------------------- |
+| `frontend/src/components/dialogs/DialogShell.css` | 130-134 | `.dialog-shell__body` has `overflow-y: auto` (scrollable ancestor)            |
+| `frontend/src/components/FileBrowser.css`         | 33-38   | `.tree-container` has `overflow-y: auto` + `max-height: 50vh` (nested scroll) |
+| `frontend/src/components/TuiCheckbox.css`         | 17-24   | Hidden `<input>` with `position: absolute; clip: rect(0,0,0,0)`               |
+| `frontend/src/components/dialogs/DialogShell.tsx` | 44      | `.focus()` called without `preventScroll: true`                               |
+
+## Impact
+
+- Keyboard accessibility is completely broken -- Tab navigation makes content disappear.
+- Click-based interaction is impaired -- clicking a checkbox can make the tree invisible.
+- Affects all users of the "add repo" flow.
+- Any dialog using DialogShell that contains a nested scrollable container with focusable elements is susceptible.
+
+## Fix
+
+Three-part fix:
+
+### 1. `preventScroll` on initial dialog focus (DialogShell.tsx)
+
+Added `{ preventScroll: true }` to the `.focus()` call in `useDialogControls.open()`. This prevents the browser from scrolling the dialog body when focus is programmatically moved to the first focusable element on dialog open.
+
+### 2. Focus-in scroll guard on tree container (FileBrowser.tsx)
+
+Added an `onFocus` handler on `.tree-container` that captures the dialog body's `scrollTop` before focus and restores it on the next animation frame if the browser changed it. This prevents the browser's auto-scroll-on-focus from disturbing the outer dialog body scroll position.
+
+### 3. `overscroll-behavior: contain` on tree container (FileBrowser.css)
+
+Added `overscroll-behavior: contain` to `.tree-container` to prevent scroll chaining from the tree to the dialog body during normal scroll interactions (mouse wheel, touch scroll).
+
+## Architecture Review
+
+### Systemic spread
+
+This bug pattern can affect **any** DialogShell consumer that places a scrollable container with focusable elements inside the dialog body. Current consumers to audit:
+
+- `SettingsDialog` -- uses fullscreen variant with its own scroll sections
+- `WorkspaceSettingsDialog` -- may contain scrollable lists
+- `CustomizeSessionDialog` -- contains form inputs
+
+### Design gap
+
+The DialogShell component assumes its body will be the sole scroll container for its children. When children introduce their own scroll containers (as FileBrowser does), the nested overflow creates this focus-scroll conflict. A stronger design would either:
+
+- Make `.dialog-shell__body` non-scrollable (`overflow: hidden`) and require children to manage their own scroll, OR
+- Provide a mechanism for children to signal "I handle my own scroll"
+
+### Testing gaps
+
+No automated tests cover focus behavior within nested scroll containers in dialogs. A test that opens AddWorkspaceDialog, focuses a checkbox, and asserts that the dialog body scroll position remains unchanged would catch regressions.
+
+### Prior art
+
+Related to learning L-20260324-fixed-in-dialog: `position: fixed` inside dialogs uses the dialog as containing block. Similarly, browser focus-scroll behavior inside dialog top-layer elements interacts unexpectedly with nested scroll containers.

--- a/docs/bug-analyses/2026-04-03-add-repo-modal-focus-shift-bug-analysis.md
+++ b/docs/bug-analyses/2026-04-03-add-repo-modal-focus-shift-bug-analysis.md
@@ -34,12 +34,12 @@ When any focusable element inside `.tree-container` receives focus (via Tab, cli
 
 ## Evidence
 
-| File                                              | Line    | Issue                                                                         |
-| ------------------------------------------------- | ------- | ----------------------------------------------------------------------------- |
-| `frontend/src/components/dialogs/DialogShell.css` | 130-134 | `.dialog-shell__body` has `overflow-y: auto` (scrollable ancestor)            |
-| `frontend/src/components/FileBrowser.css`         | 33-38   | `.tree-container` has `overflow-y: auto` + `max-height: 50vh` (nested scroll) |
-| `frontend/src/components/TuiCheckbox.css`         | 17-24   | Hidden `<input>` with `position: absolute; clip: rect(0,0,0,0)`               |
-| `frontend/src/components/dialogs/DialogShell.tsx` | 44      | `.focus()` called without `preventScroll: true`                               |
+| File                                              | Location                                              | Issue                                                                         |
+| ------------------------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `frontend/src/components/dialogs/DialogShell.css` | `.dialog-shell__body` rule                            | `.dialog-shell__body` has `overflow-y: auto` (scrollable ancestor)            |
+| `frontend/src/components/FileBrowser.css`         | `.tree-container` rule                                | `.tree-container` has `overflow-y: auto` + `max-height: 50vh` (nested scroll) |
+| `frontend/src/components/TuiCheckbox.css`         | Hidden input rule inside `.tui-checkbox`              | Hidden `<input>` with `position: absolute; clip: rect(0,0,0,0)`               |
+| `frontend/src/components/dialogs/DialogShell.tsx` | `DialogShell.open()` focus logic in useDialogControls | `.focus()` called without `preventScroll: true`                               |
 
 ## Impact
 

--- a/docs/bug-analyses/index.md
+++ b/docs/bug-analyses/index.md
@@ -1,3 +1,4 @@
 # Bug Analyses
 
 - [2026-04-03-pr-table-ui-regressions-bug-analysis](2026-04-03-pr-table-ui-regressions-bug-analysis.md) — PR table button alignment, truncated age columns, missing semantic button colors, and phantom scroll fade (2026-04-03)
+- [2026-04-03-add-repo-modal-focus-shift-bug-analysis](2026-04-03-add-repo-modal-focus-shift-bug-analysis.md) — Add Repo modal content shifts on checkbox focus (DYS-8, 2026-04-03)

--- a/frontend/src/components/FileBrowser.css
+++ b/frontend/src/components/FileBrowser.css
@@ -36,6 +36,7 @@
   max-height: 50vh;
   overflow-y: auto;
   outline: none;
+  overscroll-behavior: contain;
 }
 
 .tree-container:focus-visible {

--- a/frontend/src/components/FileBrowser.tsx
+++ b/frontend/src/components/FileBrowser.tsx
@@ -169,14 +169,38 @@ function TreeView({
    * the browser walks up ALL scrollable ancestors and scrolls each one to
    * reveal the focused element. The tree-container handles its own scrolling,
    * but the dialog body (an ancestor with overflow-y: auto) also gets scrolled,
-   * pushing the entire file browser out of view. Fix: capture the dialog body's
-   * scroll position before focus and restore it on the next frame.
+   * pushing the entire file browser out of view.
+   *
+   * Fix: capture the dialog body's scroll position before focus, then restore
+   * it on the next frame — but ONLY when the focused element is already within
+   * the visible viewport of the dialog body. When the element is out of view,
+   * we allow the browser's normal scroll-into-view behavior so the user can
+   * reach offscreen content via keyboard navigation.
+   *
+   * Testing note: asserting that scrollTop stays stable when focusing a
+   * checkbox inside the file tree requires a real browser DOM (the behavior
+   * depends on native scroll-into-view and requestAnimationFrame timing).
+   * The project's component tests are logic-only (no jsdom/RTL). Playwright
+   * e2e tests exist under test/e2e/ but do not cover this interaction.
+   * A dedicated e2e spec for this behaviour is a known gap; tracked in the
+   * bug analysis at docs/bug-analyses/2026-04-03-add-repo-modal-focus-shift-bug-analysis.md.
    */
   const handleFocusIn = useCallback((e: React.FocusEvent) => {
-    const dialogBody = (e.currentTarget as HTMLElement).closest(
-      '.dialog-shell__body'
-    );
+    const treeContainer = e.currentTarget as HTMLElement;
+    const dialogBody = treeContainer.closest('.dialog-shell__body');
     if (!dialogBody) return;
+
+    // Only guard the scroll when the focused element is already visible inside
+    // the dialog body's viewport. If it's offscreen, let the browser scroll it
+    // into view normally so keyboard users can reach out-of-view items.
+    const focusedEl = e.target as HTMLElement;
+    const bodyRect = dialogBody.getBoundingClientRect();
+    const elRect = focusedEl.getBoundingClientRect();
+    const isInView =
+      elRect.top >= bodyRect.top && elRect.bottom <= bodyRect.bottom;
+
+    if (!isInView) return;
+
     const savedScrollTop = dialogBody.scrollTop;
     requestAnimationFrame(() => {
       if (dialogBody.scrollTop !== savedScrollTop) {

--- a/frontend/src/components/FileBrowser.tsx
+++ b/frontend/src/components/FileBrowser.tsx
@@ -163,12 +163,35 @@ function TreeView({
   filterText,
   initialLoading,
 }: TreeViewProps) {
+  /**
+   * Prevent browser auto-scroll-on-focus from scrolling ancestor containers.
+   * When a focusable element (checkbox input) inside the tree receives focus,
+   * the browser walks up ALL scrollable ancestors and scrolls each one to
+   * reveal the focused element. The tree-container handles its own scrolling,
+   * but the dialog body (an ancestor with overflow-y: auto) also gets scrolled,
+   * pushing the entire file browser out of view. Fix: capture the dialog body's
+   * scroll position before focus and restore it on the next frame.
+   */
+  const handleFocusIn = useCallback((e: React.FocusEvent) => {
+    const dialogBody = (e.currentTarget as HTMLElement).closest(
+      '.dialog-shell__body'
+    );
+    if (!dialogBody) return;
+    const savedScrollTop = dialogBody.scrollTop;
+    requestAnimationFrame(() => {
+      if (dialogBody.scrollTop !== savedScrollTop) {
+        dialogBody.scrollTop = savedScrollTop;
+      }
+    });
+  }, []);
+
   return (
     <div
       className="tree-container"
       role="tree"
       aria-label="File browser"
       onKeyDown={onKeyDown}
+      onFocus={handleFocusIn}
       tabIndex={0}
     >
       {initialLoading ? (

--- a/frontend/src/components/dialogs/DialogShell.tsx
+++ b/frontend/src/components/dialogs/DialogShell.tsx
@@ -21,11 +21,20 @@ interface DialogShellProps {
   footer?: React.ReactNode;
 }
 
-const FOCUSABLE_SELECTOR = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
 function CloseIcon() {
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" width="14" height="14">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="square"
+      width="14"
+      height="14"
+    >
       <line x1="18" y1="6" x2="6" y2="18" />
       <line x1="6" y1="6" x2="18" y2="18" />
     </svg>
@@ -41,7 +50,9 @@ function useDialogControls(
     dialogRef.current.showModal();
     requestAnimationFrame(() => {
       if (!dialogRef.current) return;
-      dialogRef.current.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
+      dialogRef.current
+        .querySelector<HTMLElement>(FOCUSABLE_SELECTOR)
+        ?.focus({ preventScroll: true });
       const body = dialogRef.current.querySelector('.dialog-shell__body');
       if (body) setScrolledBottom(body.scrollHeight <= body.clientHeight);
     });
@@ -55,7 +66,17 @@ function useDialogControls(
 }
 
 export const DialogShell = forwardRef<DialogShellHandle, DialogShellProps>(
-  function DialogShell({ variant = 'compact', width = '460px', title, children, headerExtra, footer }, ref) {
+  function DialogShell(
+    {
+      variant = 'compact',
+      width = '460px',
+      title,
+      children,
+      headerExtra,
+      footer,
+    },
+    ref
+  ) {
     const dialogRef = useRef<HTMLDialogElement>(null);
     const [scrolledBottom, setScrolledBottom] = useState(false);
     const { open, close } = useDialogControls(dialogRef, setScrolledBottom);
@@ -64,24 +85,55 @@ export const DialogShell = forwardRef<DialogShellHandle, DialogShellProps>(
 
     const handleBodyScroll = (e: React.UIEvent<HTMLDivElement>) => {
       const el = e.currentTarget;
-      setScrolledBottom(el.scrollHeight - el.scrollTop - el.clientHeight < 8 || el.scrollHeight <= el.clientHeight);
+      setScrolledBottom(
+        el.scrollHeight - el.scrollTop - el.clientHeight < 8 ||
+          el.scrollHeight <= el.clientHeight
+      );
     };
 
     const handleDialogClick = (e: React.MouseEvent<HTMLDialogElement>) => {
       if (e.target === dialogRef.current) dialogRef.current?.close();
     };
 
-    const dialogClass = ['dialog-shell', variant === 'fullscreen' && 'dialog-shell--fullscreen', variant === 'compact' && 'dialog-shell--compact'].filter(Boolean).join(' ');
-    const bodyClass = ['dialog-shell__body', scrolledBottom && 'scrolled-bottom'].filter(Boolean).join(' ');
-    const dialogStyle = variant === 'compact' ? ({ '--dialog-width': width } as React.CSSProperties) : undefined;
+    const dialogClass = [
+      'dialog-shell',
+      variant === 'fullscreen' && 'dialog-shell--fullscreen',
+      variant === 'compact' && 'dialog-shell--compact',
+    ]
+      .filter(Boolean)
+      .join(' ');
+    const bodyClass = [
+      'dialog-shell__body',
+      scrolledBottom && 'scrolled-bottom',
+    ]
+      .filter(Boolean)
+      .join(' ');
+    const dialogStyle =
+      variant === 'compact'
+        ? ({ '--dialog-width': width } as React.CSSProperties)
+        : undefined;
 
     return (
-      <dialog ref={dialogRef} className={dialogClass} style={dialogStyle} onClick={handleDialogClick} aria-modal="true" aria-label={title}>
+      <dialog
+        ref={dialogRef}
+        className={dialogClass}
+        style={dialogStyle}
+        onClick={handleDialogClick}
+        aria-modal="true"
+        aria-label={title}
+      >
         <div className="dialog-shell__content">
           <header className="dialog-shell__header">
             <h2 className="dialog-shell__title">{title}</h2>
-            {headerExtra && <div className="dialog-shell__header-extra">{headerExtra}</div>}
-            <button className="dialog-shell__close" onClick={close} aria-label="Close" type="button">
+            {headerExtra && (
+              <div className="dialog-shell__header-extra">{headerExtra}</div>
+            )}
+            <button
+              className="dialog-shell__close"
+              onClick={close}
+              aria-label="Close"
+              type="button"
+            >
               <CloseIcon />
             </button>
           </header>


### PR DESCRIPTION
## Summary

Fixes the "Add Repo" modal content shifting and disappearing when checkboxes receive focus. The browser's auto-scroll-on-focus behavior conflicted with nested scroll containers, pushing content out of the viewport.

## Changes

- **FileBrowser.tsx**: Added `onFocus` handler that preserves the dialog body's `scrollTop` before browser auto-scroll fires and restores it on the next animation frame
- **DialogShell.tsx**: Changed `.focus()` to `.focus({ preventScroll: true })` on dialog open
- **FileBrowser.css**: Added `overscroll-behavior: contain` to `.tree-container` to prevent scroll chaining
- **Bug analysis**: Root cause documented in `docs/bug-analyses/2026-04-03-add-repo-modal-focus-shift-bug-analysis.md`

## Testing

- Build passes (`npm run build`)
- All tests pass (`npm test` — 1074 passing)
- Fix targets the specific interaction between nested scroll containers and browser focus behavior

## Linear

Closes [DYS-8](https://linear.app/dystudios/issue/DYS-8)

---
*Created with `/pr:author`*