### PR TITLE
fix: DYS-9 — dialog not closing after submit due to CSS specificity conflict

### DIFF
--- a/docs/bug-analyses/2026-04-03-add-repo-modal-not-closing-bug-analysis.md
+++ b/docs/bug-analyses/2026-04-03-add-repo-modal-not-closing-bug-analysis.md
@@ -1,0 +1,74 @@
+# Bug Analysis: "Add Repo" modal does not close after clicking "add repo"
+
+**Ticket:** DYS-9
+**Date:** 2026-04-03
+**Status:** Fixed
+
+## Symptoms
+
+- User opens the "add repo" dialog from the sidebar
+- Selects one or more folders and clicks "add repo"
+- The API call succeeds (sidebar updates with the new repo)
+- The modal overlay does not dismiss; it stays visible on screen
+- User must manually close the dialog (click X, press Escape, or click the backdrop)
+
+## Reproduction Steps
+
+1. Launch the app and authenticate
+2. Click "+ add repo" in the sidebar footer
+3. Browse and select a folder
+4. Click "add repo" to confirm
+5. Observe: sidebar updates with the new workspace, but the dialog remains open
+
+## Root Cause
+
+**CSS specificity conflict with native `<dialog>` element behavior.**
+
+In commit `3e7e737`, `display: flex` and `flex-direction: column` were added directly to the `.dialog-shell` selector in `frontend/src/components/dialogs/DialogShell.css`:
+
+```css
+.dialog-shell {
+  /* ... */
+  display: flex; /* <-- introduced in 3e7e737 */
+  flex-direction: column; /* <-- introduced in 3e7e737 */
+}
+```
+
+The native HTML `<dialog>` element relies on a user-agent stylesheet rule to hide itself when closed:
+
+```css
+dialog:not([open]) {
+  display: none;
+}
+```
+
+The `.dialog-shell` class selector has higher specificity than the UA `dialog:not([open])` type+pseudo selector. When `dialog.close()` is called, the browser removes the `open` attribute and removes the dialog from the top layer (hiding the `::backdrop`), but the element remains visible because `display: flex` overrides the browser's `display: none`.
+
+**Evidence:**
+
+- `frontend/src/components/dialogs/DialogShell.css:14-15` -- the `display: flex` rule
+- `frontend/src/components/dialogs/DialogShell.tsx:50-52` -- the `close()` method calls `dialogRef.current?.close()`
+- The `<dialog>` element's `close()` method correctly removes `[open]`, but CSS prevents visual hiding
+
+## Impact
+
+- **All dialogs** using `DialogShell` are affected (AddWorkspaceDialog, SettingsDialog, DeleteWorktreeDialog, CustomizeSessionDialog, WorkspaceSettingsDialog)
+- Most visible with AddWorkspaceDialog since it's the primary onboarding action
+- Blocks user workflow -- requires manual dismissal after every dialog submission
+
+## Fix
+
+Move `display: flex` and `flex-direction: column` to a `.dialog-shell[open]` rule so the flex layout only applies when the dialog is open. When closed, the browser's native `display: none` takes effect:
+
+```css
+.dialog-shell[open] {
+  display: flex;
+  flex-direction: column;
+}
+```
+
+**File changed:** `frontend/src/components/dialogs/DialogShell.css`
+
+## Architecture Review
+
+The `DialogShell` component correctly delegates open/close to the native `<dialog>` API (`showModal()` / `close()`). The `AddWorkspaceDialog` submit handler correctly calls `shellRef.current?.close()` after a successful API response. No logic changes were needed -- the fix is purely CSS specificity.

--- a/docs/bug-analyses/2026-04-03-add-repo-modal-not-closing-bug-analysis.md
+++ b/docs/bug-analyses/2026-04-03-add-repo-modal-not-closing-bug-analysis.md
@@ -22,7 +22,7 @@
 
 ## Root Cause
 
-**CSS specificity conflict with native `<dialog>` element behavior.**
+**Author stylesheet overriding the browser's default `<dialog>` hiding behavior.**
 
 In commit `3e7e737`, `display: flex` and `flex-direction: column` were added directly to the `.dialog-shell` selector in `frontend/src/components/dialogs/DialogShell.css`:
 
@@ -42,7 +42,7 @@ dialog:not([open]) {
 }
 ```
 
-The `.dialog-shell` class selector has higher specificity than the UA `dialog:not([open])` type+pseudo selector. When `dialog.close()` is called, the browser removes the `open` attribute and removes the dialog from the top layer (hiding the `::backdrop`), but the element remains visible because `display: flex` overrides the browser's `display: none`.
+In the CSS cascade, author stylesheets take precedence over user-agent stylesheets regardless of specificity. (In fact, `dialog:not([open])` has _higher_ specificity than `.dialog-shell`, but specificity only applies within the same cascade origin.) Because `.dialog-shell { display: flex }` is an author rule, it wins over the UA rule unconditionally. When `dialog.close()` is called, the browser removes the `open` attribute and removes the dialog from the top layer (hiding the `::backdrop`), but the element remains visible because the author `display: flex` rule overrides the UA `display: none`.
 
 **Evidence:**
 
@@ -71,4 +71,4 @@ Move `display: flex` and `flex-direction: column` to a `.dialog-shell[open]` rul
 
 ## Architecture Review
 
-The `DialogShell` component correctly delegates open/close to the native `<dialog>` API (`showModal()` / `close()`). The `AddWorkspaceDialog` submit handler correctly calls `shellRef.current?.close()` after a successful API response. No logic changes were needed -- the fix is purely CSS specificity.
+The `DialogShell` component correctly delegates open/close to the native `<dialog>` API (`showModal()` / `close()`). The `AddWorkspaceDialog` submit handler correctly calls `shellRef.current?.close()` after a successful API response. No logic changes were needed -- the fix is purely CSS: scoping `display: flex` to `.dialog-shell[open]` so the author rule no longer overrides the browser's UA `display: none` when the dialog is closed.

--- a/docs/bug-analyses/index.md
+++ b/docs/bug-analyses/index.md
@@ -2,3 +2,4 @@
 
 - [2026-04-03-pr-table-ui-regressions-bug-analysis](2026-04-03-pr-table-ui-regressions-bug-analysis.md) — PR table button alignment, truncated age columns, missing semantic button colors, and phantom scroll fade (2026-04-03)
 - [2026-04-03-add-repo-modal-focus-shift-bug-analysis](2026-04-03-add-repo-modal-focus-shift-bug-analysis.md) — Add Repo modal content shifts on checkbox focus (DYS-8, 2026-04-03)
+- [2026-04-03-add-repo-modal-not-closing-bug-analysis](2026-04-03-add-repo-modal-not-closing-bug-analysis.md) — Dialog not closing after submit due to CSS cascade conflict (DYS-9, 2026-04-03)

--- a/frontend/src/components/dialogs/DialogShell.css
+++ b/frontend/src/components/dialogs/DialogShell.css
@@ -14,9 +14,10 @@
 }
 
 /* Apply flex layout only when the dialog is open.
-   Without the [open] qualifier, display:flex overrides the browser's
-   built-in dialog:not([open]) { display:none } rule, preventing the
-   dialog from hiding when .close() is called. */
+   Without the [open] qualifier, this author rule would apply
+   display:flex even when the dialog is closed, overriding the
+   browser's default dialog:not([open]) { display:none } behavior
+   and preventing the dialog from hiding when .close() is called. */
 .dialog-shell[open] {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/dialogs/DialogShell.css
+++ b/frontend/src/components/dialogs/DialogShell.css
@@ -11,6 +11,13 @@
   border-radius: 0;
   padding: 0;
   overflow: hidden;
+}
+
+/* Apply flex layout only when the dialog is open.
+   Without the [open] qualifier, display:flex overrides the browser's
+   built-in dialog:not([open]) { display:none } rule, preventing the
+   dialog from hiding when .close() is called. */
+.dialog-shell[open] {
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
## Summary

Fixes ALL dialogs (not just Add Repo) staying visible after `.close()` is called. The `display: flex` on `.dialog-shell` overrode the browser's native `dialog:not([open]) { display: none }` rule because class selectors have higher specificity than the UA stylesheet's type selector.

## Changes

- **DialogShell.css**: Moved `display: flex` and `flex-direction: column` from `.dialog-shell` to `.dialog-shell[open]` so the browser's native dialog hiding works when the `open` attribute is removed
- **Bug analysis**: Root cause documented in `docs/bug-analyses/2026-04-03-add-repo-modal-not-closing-bug-analysis.md`

## Testing

- Build passes (`npm run build`)
- Fix is a CSS-only change scoped to the `[open]` attribute selector
- Affects all `DialogShell` consumers — verified no regressions in dialog open behavior

## Linear

Closes [DYS-9](https://linear.app/dystudios/issue/DYS-9)

---
*Created with `/pr:author`*