### PR TITLE
fix: DYS-10 — PR table UI regressions (button colors, column widths, scroll fade)

### DIFF
--- a/docs/bug-analyses/2026-04-03-pr-table-ui-regressions-bug-analysis.md
+++ b/docs/bug-analyses/2026-04-03-pr-table-ui-regressions-bug-analysis.md
@@ -1,0 +1,76 @@
+# PR Table UI Regressions (DYS-10)
+
+**Date:** 2026-04-03
+**Severity:** Medium (visual regressions, no data loss)
+**Status:** Fixed
+
+## Symptoms
+
+Four UI regressions in the PR table across both RepoDashboard and OrgDashboard, introduced during the Svelte-to-React migration:
+
+1. **Button alignment** -- Action buttons (`+` and action labels like "review", "fix conflicts") not vertically aligned in the action column
+2. **Column width truncation** -- Age column (`width: 50`) too narrow, causing "1h ago" to render as "1h a..."
+3. **Missing button colors** -- All action buttons rendered as `ghost` variant (muted gray) regardless of semantic meaning (merge = green, fix conflicts = red, review = blue)
+4. **Phantom scroll fade** -- Fade-to-black gradient at bottom of scroll sections always visible, even when content fits without scrolling
+
+## Root Cause
+
+### 1. Button alignment
+- `RepoDashboard.css` `.pr-cell--action` lacked explicit `align-items: center` and `gap`
+- `OrgDashboard.css` `.cell--action` same issue
+
+### 2. Column width truncation
+- `RepoDashboard.tsx` PrRow: age column set to `width: 50` (too narrow for monospace relative times)
+- `OrgDashboard.tsx` OrgPrRow: same `width: 50`
+- `RepoDashboard.css` `.pr-age-text` had `overflow: hidden; text-overflow: ellipsis` which actively truncated text
+
+### 3. Missing button colors
+- `RepoDashboard.tsx` PrRow: `+` button used `variant="ghost"` instead of `variant="primary"`. Action button hardcoded to `variant="ghost"` instead of mapping `action.color` through a `colorToVariant()` helper (which PrTopBar.tsx already had)
+- `OrgDashboard.tsx` OrgPrRow: used a raw `<button>` element instead of `TuiButton` with semantic variant
+- Both components were missing the `colorToVariant` mapping function present in PrTopBar.tsx
+
+### 4. Phantom scroll fade
+- `RepoDashboard.css` `.dashboard-section--scroll::after` unconditionally rendered a 32px gradient overlay
+- No scroll detection mechanism -- the fade appeared even when content did not overflow
+
+## Evidence
+
+| File | Line | Issue |
+|------|------|-------|
+| `frontend/src/components/RepoDashboard.tsx` | 309 | `variant="ghost"` on `+` button |
+| `frontend/src/components/RepoDashboard.tsx` | 317 | `variant="ghost"` on action button |
+| `frontend/src/components/RepoDashboard.tsx` | 302 | `width: 50` age column |
+| `frontend/src/components/RepoDashboard.css` | 38-48 | Unconditional `::after` fade |
+| `frontend/src/components/RepoDashboard.css` | 203-207 | `overflow: hidden; text-overflow: ellipsis` on age text |
+| `frontend/src/components/OrgDashboard.tsx` | 141 | Raw `<button>` instead of TuiButton |
+| `frontend/src/components/OrgDashboard.tsx` | 140 | `width: 50` age column |
+
+## Fix
+
+### 1. Button alignment
+- Added `align-items: center; gap: 8px` to `.pr-cell--action` (RepoDashboard.css)
+- Added `align-items: center` to `.cell--action` (OrgDashboard.css)
+
+### 2. Column width
+- Widened age column from `width: 50` to `width: 72` in both RepoDashboard and OrgDashboard
+- Changed `.pr-age-text` from truncating (`overflow: hidden; text-overflow: ellipsis`) to `white-space: nowrap` only
+
+### 3. Button colors
+- Added `colorToVariant()` helper to both RepoDashboard.tsx and OrgDashboard.tsx (matching PrTopBar.tsx pattern)
+- Changed `+` button from `variant="ghost"` to `variant="primary"` (accent color per DESIGN.md)
+- Changed action button from `variant="ghost"` to `variant={colorToVariant(action.color)}`
+- Replaced raw `<button>` in OrgPrRow with `<TuiButton variant={colorToVariant(action.color)} size="sm">`
+
+### 4. Scroll fade
+- Made `::after` fade default to `opacity: 0` with a transition
+- Added `.has-overflow` modifier class that sets `opacity: 1`
+- Added `useScrollOverflow()` hook using `ResizeObserver` to detect when content overflows
+- Applied to both the PR list section and the activity section
+
+## Impact
+- Visual-only regression, no functional or data impact
+- Affected both per-repo dashboard (RepoDashboard) and org-wide dashboard (OrgDashboard)
+
+## Architecture Review
+- The `colorToVariant()` function is now duplicated in 3 files (PrTopBar, RepoDashboard, OrgDashboard). Consider extracting to a shared utility if more consumers appear.
+- The `useScrollOverflow` hook could be extracted to a shared hooks module for reuse.

--- a/docs/bug-analyses/index.md
+++ b/docs/bug-analyses/index.md
@@ -1,0 +1,3 @@
+# Bug Analyses
+
+- [2026-04-03-pr-table-ui-regressions-bug-analysis](2026-04-03-pr-table-ui-regressions-bug-analysis.md) — PR table button alignment, truncated age columns, missing semantic button colors, and phantom scroll fade (2026-04-03)

--- a/frontend/src/components/OrgDashboard.css
+++ b/frontend/src/components/OrgDashboard.css
@@ -141,6 +141,7 @@
 
 .cell--action {
   justify-content: flex-end;
+  align-items: center;
 }
 
 .cell--ci {

--- a/frontend/src/components/OrgDashboard.tsx
+++ b/frontend/src/components/OrgDashboard.tsx
@@ -8,6 +8,7 @@ import {
   deletePreset,
 } from '../lib/api.js';
 import { derivePrAction, buildPrStateInput } from '../lib/pr-state.js';
+import type { StatusColor } from '../lib/pr-state.js';
 import { prRoleLabel, sortPrs } from '../lib/pr-utils.js';
 import { formatRelativeTime } from '../lib/utils.js';
 import type {
@@ -20,6 +21,8 @@ import TicketsPanel from './TicketsPanel.js';
 import { deriveColor } from '../lib/colors.js';
 import { derivePrDotStatus } from '../lib/pr-status.js';
 import StatusDot from './StatusDot.js';
+import { TuiButton } from './TuiButton.js';
+import type { TuiButtonVariant } from './TuiButton.js';
 import './OrgDashboard.css';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -57,6 +60,14 @@ function getTicketIdForPr(
     }
   }
   return null;
+}
+
+function colorToVariant(color: StatusColor): TuiButtonVariant {
+  if (color === 'success') return 'success';
+  if (color === 'error') return 'danger';
+  if (color === 'accent') return 'primary';
+  if (color === 'info') return 'info';
+  return 'ghost';
 }
 
 // ── Sub-components ─────────────────────────────────────────────────────────────
@@ -133,17 +144,19 @@ function OrgPrRow({ pr, branchLinksData, onOpenWorkspace }: PrRowProps) {
       <div className="cell cell--ci" style={{ width: 32, flex: 'none' }}>
         {ci && <span className={`ci-icon ${ci.cls}`}>{ci.icon}</span>}
       </div>
-      <div className="cell cell--age" style={{ width: 50, flex: 'none' }}>
+      <div className="cell cell--age" style={{ width: 72, flex: 'none' }}>
         <span className="pr-meta-text">{formatRelativeTime(pr.updatedAt)}</span>
       </div>
       <div className="cell cell--action" style={{ width: 140, flex: 'none' }}>
         {action.type !== 'none' && action.label && (
-          <button
+          <TuiButton
+            variant={colorToVariant(action.color)}
+            size="sm"
             onClick={() => onOpenWorkspace(pr.repoPath ?? '')}
             title={action.label}
           >
             {action.label}
-          </button>
+          </TuiButton>
         )}
       </div>
     </div>

--- a/frontend/src/components/RepoDashboard.css
+++ b/frontend/src/components/RepoDashboard.css
@@ -45,6 +45,12 @@
   background: linear-gradient(to bottom, transparent, var(--bg));
   pointer-events: none;
   z-index: 1;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.dashboard-section--scroll.has-overflow::after {
+  opacity: 1;
 }
 
 .section-heading {
@@ -137,6 +143,8 @@
 
 .pr-cell--action {
   justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
 }
 
 .pr-title-link {
@@ -199,11 +207,14 @@
   opacity: 0.4;
 }
 
-.pr-role-text,
-.pr-age-text {
+.pr-role-text {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.pr-age-text {
+  white-space: nowrap;
 }
 
 .mobile-pr-card {

--- a/frontend/src/components/RepoDashboard.tsx
+++ b/frontend/src/components/RepoDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchDashboard } from '../lib/api.js';
 import { derivePrAction, buildPrStateInput } from '../lib/pr-state.js';
@@ -12,8 +12,10 @@ import type {
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useTelemetryStore } from '../lib/stores/telemetry.js';
 import { derivePrDotStatus } from '../lib/pr-status.js';
+import type { StatusColor } from '../lib/pr-state.js';
 import StatusDot from './StatusDot.js';
 import { TuiButton } from './TuiButton.js';
+import type { TuiButtonVariant } from './TuiButton.js';
 import { TuiProgress } from './TuiProgress.js';
 import './RepoDashboard.css';
 
@@ -62,7 +64,38 @@ function activityBranches(entry: ActivityEntry): string {
   return '(' + entry.branches.join(', ') + ')';
 }
 
-// ── Sub-components ─────────────────────────────────────────────────────────────
+function colorToVariant(color: StatusColor): TuiButtonVariant {
+  if (color === 'success') return 'success';
+  if (color === 'error') return 'danger';
+  if (color === 'accent') return 'primary';
+  if (color === 'info') return 'info';
+  return 'ghost';
+}
+
+/** Returns a ref + className for a section that should only show the scroll fade when content overflows. */
+function useScrollOverflow() {
+  const ref = useRef<HTMLElement>(null);
+  const [hasOverflow, setHasOverflow] = useState(false);
+
+  const check = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    setHasOverflow(el.scrollHeight > el.clientHeight + 4);
+  }, []);
+
+  useEffect(() => {
+    check();
+    const el = ref.current;
+    if (!el) return;
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [check]);
+
+  return { ref, hasOverflow };
+}
+
+// ── Sub-components ─────────────────────────────────────��───────────────────────
 
 interface UsageSectionProps {
   repoSessions: import('../lib/types.js').SessionSummary[];
@@ -216,8 +249,17 @@ interface ActivitySectionProps {
 }
 
 function ActivitySection({ data, isLoading }: ActivitySectionProps) {
+  const { ref: scrollRef, hasOverflow } = useScrollOverflow();
+  const sectionClass = [
+    'dashboard-section',
+    'dashboard-section--scroll',
+    hasOverflow && 'has-overflow',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
-    <section className="dashboard-section dashboard-section--scroll">
+    <section className={sectionClass} ref={scrollRef}>
       <div className="section-heading">recent activity</div>
       {isLoading ? (
         <div className="scroll-container">
@@ -294,7 +336,7 @@ function PrRow({ pr, onOpenPrSession, onPrAction }: PrRowProps) {
           {pr.role === 'author' ? 'Author' : 'Review'}
         </span>
       </div>
-      <div className="pr-cell pr-cell--age" style={{ width: 50, flex: 'none' }}>
+      <div className="pr-cell pr-cell--age" style={{ width: 72, flex: 'none' }}>
         <span className="pr-age-text">{formatRelativeTime(pr.updatedAt)}</span>
       </div>
       <div
@@ -303,7 +345,7 @@ function PrRow({ pr, onOpenPrSession, onPrAction }: PrRowProps) {
       >
         <div className="pr-row-actions">
           <TuiButton
-            variant="ghost"
+            variant="primary"
             size="icon"
             onClick={() => onOpenPrSession(pr)}
             title="Open session on this branch"
@@ -312,7 +354,7 @@ function PrRow({ pr, onOpenPrSession, onPrAction }: PrRowProps) {
           </TuiButton>
           {action.type !== 'none' && action.label && (
             <TuiButton
-              variant="ghost"
+              variant={colorToVariant(action.color)}
               size="sm"
               onClick={() => onPrAction(pr)}
               title={action.label}
@@ -439,6 +481,7 @@ export function RepoDashboard({
   const [searchQuery, setSearchQuery] = useState('');
   const sortBy = 'age';
   const sortDir: 'asc' | 'desc' = 'desc';
+  const { ref: prScrollRef, hasOverflow: prHasOverflow } = useScrollOverflow();
 
   const { data, isLoading, isError } = useQuery<DashboardData>({
     queryKey: ['dashboard', repoPath],
@@ -471,7 +514,16 @@ export function RepoDashboard({
       ) : (
         <>
           <UsageSection repoSessions={repoSessions} repoPath={repoPath} />
-          <section className="dashboard-section dashboard-section--scroll">
+          <section
+            className={[
+              'dashboard-section',
+              'dashboard-section--scroll',
+              prHasOverflow && 'has-overflow',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            ref={prScrollRef}
+          >
             <div className="section-heading">open pull requests</div>
             <PrListBody
               data={data}


### PR DESCRIPTION
## Summary

Fixes 4 PR table UI regressions in RepoDashboard and OrgDashboard introduced during the Svelte migration: missing button colors, truncated timestamps, misaligned action buttons, and a phantom scroll fade.

## Changes

- **RepoDashboard.tsx/OrgDashboard.tsx**: Added `colorToVariant()` helper to map `StatusColor` to `TuiButtonVariant` (success->green, error->red, etc.). Widened age column from 50px to 72px. OrgDashboard raw `<button>` replaced with `<TuiButton>`.
- **RepoDashboard.css/OrgDashboard.css**: Fixed action column alignment (`align-items: center; gap: 8px`). Removed text truncation on age cells. Made scroll fade conditional via `.has-overflow` class (default `opacity: 0`).
- **useScrollOverflow hook**: New `ResizeObserver`-based hook that detects content overflow and toggles the fade gradient.
- **Bug analysis**: Documented in `docs/bug-analyses/2026-04-03-pr-table-ui-regressions-bug-analysis.md`

## Testing

- Build passes (`npm run build`)
- All 4 issues addressed: button colors, column widths, alignment, conditional scroll fade
- Changes are CSS + display logic only, no API or data flow changes

## Linear

Closes [DYS-10](https://linear.app/dystudios/issue/DYS-10)

---
*Created with `/pr:author`*