### PR TITLE
fix: DYS-11 — replace unstyled buttons with TuiButton in All Workspaces PR list

### DIFF
--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -441,3 +441,14 @@ When a server function uses nullish coalescing (`??`) to merge settings from mul
 When a server has a canonical settings resolution function (e.g., `resolveSessionSettings()` that merges global → workspace → repo → override), the frontend should not duplicate this logic by pre-filling overrides from its own partial view of the settings. The frontend's `configState` only has global defaults — it cannot see repo-level overrides. Sending global defaults as explicit overrides creates a shadow that the server's merge cascade cannot penetrate. Either (a) omit the fields and let the server resolve, or (b) fetch the merged settings from the server before populating UI defaults. The `fetchMergedWorkspaceSettings()` API exists for case (b).
 
 ---
+
+### L-20260403-migration-button-completeness: Framework migrations must audit ALL interactive elements — not just the primary action buttons
+
+- status: active
+- category: patterns
+- source: /harness:bug DYS-11 2026-04-03
+- branch: worktree-DYS-11
+
+When migrating a UI framework (e.g., Svelte → React), raw `<button>` elements in non-primary positions are the most likely elements to be left unconverted. The migration agent typically converts the "obvious" action buttons (PR row actions, form submits) but misses secondary buttons embedded in sub-components: error state retries, filter management delete buttons, confirmation inline actions. After any framework migration, run a grep for `<button` in all migrated component files and verify each instance either (a) uses the project's design-system button component (`TuiButton`), or (b) is an intentional pattern-exception with a CSS class that reproduces equivalent design-system styling (e.g., tab strip navigation). Bespoke CSS that re-implements button styling is a red flag — it means the component was migrated structurally but not visually.
+
+---

--- a/docs/bug-analyses/2026-04-03-unstyled-pr-list-buttons-bug-analysis.md
+++ b/docs/bug-analyses/2026-04-03-unstyled-pr-list-buttons-bug-analysis.md
@@ -1,0 +1,56 @@
+# Unstyled Buttons in All Workspaces PR List (DYS-11)
+
+**Date:** 2026-04-03
+**Severity:** Low-Medium (visual regression, no functional impact)
+**Status:** Fixed
+
+## Symptoms
+
+In the "All Workspaces" view (`OrgDashboard`), two button types rendered as default/unstyled HTML buttons instead of using the project's `TuiButton` component:
+
+1. **Preset delete buttons** — In the `PresetsRow` sub-component, buttons to delete named filter presets (e.g., "× my-filter") used a raw `<button>` with custom CSS class `.preset-delete-btn` instead of `TuiButton`.
+2. **Retry button** — In the `PrsTabError` sub-component, the "Retry" button shown on GitHub timeout errors used a raw `<button>` with custom CSS class `.retry-btn` instead of `TuiButton`.
+
+Both buttons had hand-written CSS that approximated the TuiButton styles, but bypassed the design system component entirely — resulting in visual inconsistency on hover states and missing semantic box-drawing corner interactions defined in DESIGN.md.
+
+## Root Cause
+
+The Svelte-to-React migration (Batch E1, commit `6bd9bd5`) converted `OrgDashboard.svelte` to `OrgDashboard.tsx` but did not replace all interactive elements with the `TuiButton` component. The React migration created raw `<button>` elements for several interactive buttons:
+
+- `OrgPrRow` action button (`<button onClick={...}>`) — partially remediated in DYS-10
+- `PresetsRow` delete buttons (`<button className="preset-delete-btn">`) — **this bug**
+- `PrsTabError` retry button (`<button className="retry-btn">`) — **this bug**
+
+DYS-10 fixed the PR row action button (`Open`, `Fix Conflicts`, etc.) in `OrgPrRow` but left the preset delete and retry buttons as raw elements with bespoke CSS. The bespoke CSS in `OrgDashboard.css` manually reproduced button styling using different hover colors and without TuiButton's box-drawing corner animation.
+
+## Evidence
+
+| File | Line | Issue |
+|------|------|-------|
+| `frontend/src/components/OrgDashboard.tsx` | ~205 | `<button className="preset-delete-btn">` in `PresetsRow` |
+| `frontend/src/components/OrgDashboard.tsx` | ~342 | `<button className="retry-btn">` in `PrsTabError` |
+| `frontend/src/components/OrgDashboard.css` | ~288-303 | `.preset-delete-btn` hand-written styles |
+| `frontend/src/components/OrgDashboard.css` | ~101-116 | `.retry-btn` hand-written styles |
+
+## Fix
+
+1. **`PresetsRow` delete buttons** — replaced `<button className="preset-delete-btn">` with `<TuiButton variant="danger" size="sm">`. Danger variant is correct per DESIGN.md (error-red border/text, neutral at rest) — delete is a destructive action.
+
+2. **`PrsTabError` retry button** — replaced `<button className="retry-btn">` with `<TuiButton variant="ghost" size="sm">`. Ghost variant is correct per DESIGN.md (muted border/text, secondary action).
+
+3. **CSS cleanup** — removed `.retry-btn` and `.preset-delete-btn` rule blocks from `OrgDashboard.css`, as they are now superseded by `TuiButton`'s own styles.
+
+## Variant Rationale
+
+- `variant="danger"` for preset delete: matches DESIGN.md — destructive actions use the error semantic color
+- `variant="ghost"` for retry: matches DESIGN.md — secondary/recovery actions use ghost (muted, non-prominent)
+
+## Impact
+
+- Visual-only regression, no functional or data impact
+- Only affects the "All Workspaces" tab (`OrgDashboard`) preset management and the GitHub timeout error state
+- The PR row action buttons (`Open`, `Fix Conflicts`, etc.) were already fixed in DYS-10
+
+## Architecture Note
+
+This is the third DYS-11-class issue caused by incomplete button conversion during the Svelte-to-React migration. The pattern of hand-writing custom button CSS instead of using `TuiButton` should be treated as a linting signal — a future ESLint rule could enforce `no-raw-button` in component files.

--- a/docs/bug-analyses/index.md
+++ b/docs/bug-analyses/index.md
@@ -3,3 +3,4 @@
 - [2026-04-03-pr-table-ui-regressions-bug-analysis](2026-04-03-pr-table-ui-regressions-bug-analysis.md) — PR table button alignment, truncated age columns, missing semantic button colors, and phantom scroll fade (2026-04-03)
 - [2026-04-03-add-repo-modal-focus-shift-bug-analysis](2026-04-03-add-repo-modal-focus-shift-bug-analysis.md) — Add Repo modal content shifts on checkbox focus (DYS-8, 2026-04-03)
 - [2026-04-03-add-repo-modal-not-closing-bug-analysis](2026-04-03-add-repo-modal-not-closing-bug-analysis.md) — Dialog not closing after submit due to CSS cascade conflict (DYS-9, 2026-04-03)
+- [2026-04-03-unstyled-pr-list-buttons-bug-analysis](2026-04-03-unstyled-pr-list-buttons-bug-analysis.md) — Preset delete and retry buttons in All Workspaces PR list using raw HTML instead of TuiButton (DYS-11, 2026-04-03)

--- a/frontend/src/components/OrgDashboard.css
+++ b/frontend/src/components/OrgDashboard.css
@@ -98,23 +98,6 @@
   color: var(--status-error);
 }
 
-.retry-btn {
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: 0;
-  color: var(--text-muted);
-  font-size: var(--font-size-xs);
-  font-family: var(--font-mono);
-  cursor: pointer;
-  padding: 4px 8px;
-  transition: border-color 0.12s, color 0.12s;
-}
-
-.retry-btn:hover {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-
 .cell {
   display: flex;
   align-items: center;
@@ -283,24 +266,6 @@
 .preset-select:hover {
   border-color: var(--accent);
   color: var(--text);
-}
-
-.preset-delete-btn {
-  font-size: var(--font-size-xs);
-  font-family: var(--font-mono);
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 0;
-  color: var(--text-muted);
-  padding: 4px 8px;
-  cursor: pointer;
-  transition: border-color 0.12s, color 0.12s;
-  white-space: nowrap;
-}
-
-.preset-delete-btn:hover {
-  border-color: var(--status-error, #e05555);
-  color: var(--status-error, #e05555);
 }
 
 .pr-table-row {

--- a/frontend/src/components/OrgDashboard.tsx
+++ b/frontend/src/components/OrgDashboard.tsx
@@ -202,14 +202,15 @@ function PresetsRow({ presets, onApply, onSave, onDelete }: PresetsRowProps) {
       {presets
         .filter((p) => !p.builtIn)
         .map((p) => (
-          <button
+          <TuiButton
             key={p.name}
-            className="preset-delete-btn"
+            variant="danger"
+            size="sm"
             title={`Delete preset: ${p.name}`}
             onClick={() => onDelete(p)}
           >
             × {p.name}
-          </button>
+          </TuiButton>
         ))}
     </div>
   );
@@ -339,9 +340,9 @@ function PrsTabError({ errorCode, onRetry }: PrsTabErrorProps) {
     return (
       <div className="state-message state-message--error">
         <span>GitHub is taking too long. Try again.</span>
-        <button className="retry-btn" onClick={onRetry}>
+        <TuiButton variant="ghost" size="sm" onClick={onRetry}>
           Retry
-        </button>
+        </TuiButton>
       </div>
     );
   }
@@ -512,6 +513,7 @@ export function OrgDashboard({ onOpenWorkspace }: OrgDashboardProps) {
       <div className="org-header">
         <span className="org-title">All Workspaces</span>
       </div>
+      {/* tab-strip uses raw buttons intentionally — underline-indicator navigation, not TuiButton actions */}
       <div className="tab-strip">
         <button
           className={['tab-btn', activeTab === 'prs' ? 'tab-btn--active' : '']

--- a/frontend/src/components/OrgDashboard.tsx
+++ b/frontend/src/components/OrgDashboard.tsx
@@ -209,7 +209,7 @@ function PresetsRow({ presets, onApply, onSave, onDelete }: PresetsRowProps) {
             title={`Delete preset: ${p.name}`}
             onClick={() => onDelete(p)}
           >
-            × {p.name}
+            × <span style={{ textTransform: 'none' }}>{p.name}</span>
           </TuiButton>
         ))}
     </div>


### PR DESCRIPTION
## Summary

Replaces raw `<button>` elements with the `TuiButton` design-system component in the OrgDashboard "All Workspaces" view. These were missed during the Svelte-to-React migration (Batch E1).

## Changes

- **OrgDashboard.tsx**: Replaced `<button className="preset-delete-btn">` with `<TuiButton variant="danger" size="sm">` and `<button className="retry-btn">` with `<TuiButton variant="ghost" size="sm">`
- **OrgDashboard.css**: Removed orphaned `.preset-delete-btn` and `.retry-btn` CSS rules
- **Docs**: Added bug analysis and migration completeness learning

## Testing

- All 1074 tests pass
- Build succeeds
- Tab strip buttons intentionally left as raw buttons (underline-indicator navigation pattern, documented with comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)