### PR TITLE
feat: unified PrRow component, fix missing org PRs, and row click-to-open

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ analytics.db-wal
 .claire/
 .desloppify/
 .lead/
+.omc/
 .opencode/
 .gstack/
 .worktrees/

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -140,11 +140,6 @@ function TerminalAreaContent({
   const openFileTab = useUiStore((s) => s.openFileTab);
   const analyticsView = useUiStore((s) => s.analyticsView);
   const setAnalyticsView = useUiStore((s) => s.setAnalyticsView);
-  const setActiveRepoPath = useUiStore((s) => s.setActiveRepoPath);
-  const setActiveSessionId = useSessionsStore((s) => s.setActiveSessionId);
-  const recallSessionForWorkspace = useSessionsStore(
-    (s) => s.recallSessionForWorkspace
-  );
   const sessions = useSessionsStore((s) => s.sessions);
   const repos = useSessionsStore((s) => s.repos);
   const activeSessionId = useSessionsStore((s) => s.activeSessionId);
@@ -306,15 +301,8 @@ function TerminalAreaContent({
 
       {viewMode === 'org' && (
         <OrgDashboard
-          onOpenWorkspace={(path) => {
-            setAnalyticsView(null);
-            setActiveRepoPath(path);
-            setActiveSessionId(recallSessionForWorkspace(path));
-          }}
-          onOpenSession={(id) => {
-            setAnalyticsView(null);
-            setActiveSessionId(id);
-          }}
+          onOpenPrSession={onOpenPrSession}
+          onPrAction={onPrAction}
         />
       )}
 

--- a/frontend/src/components/OrgDashboard.css
+++ b/frontend/src/components/OrgDashboard.css
@@ -52,7 +52,9 @@
   color: var(--text-muted);
   cursor: pointer;
   margin-bottom: -1px;
-  transition: color 0.12s, border-color 0.12s;
+  transition:
+    color 0.12s,
+    border-color 0.12s;
   white-space: nowrap;
   letter-spacing: 0.06em;
 }
@@ -98,149 +100,6 @@
   color: var(--status-error);
 }
 
-.cell {
-  display: flex;
-  align-items: center;
-  padding: 8px;
-  min-width: 0;
-}
-
-.cell--status {
-  justify-content: center;
-}
-
-.cell--title {
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 2px;
-}
-
-.cell--repo,
-.cell--role,
-.cell--age {
-  justify-content: flex-start;
-  overflow: hidden;
-}
-
-.cell--action {
-  justify-content: flex-end;
-  align-items: center;
-}
-
-.cell--ci {
-  justify-content: center;
-}
-
-.ci-icon { font-size: 12px; font-weight: bold; }
-.ci-pass { color: var(--status-success); }
-.ci-fail { color: var(--status-error); }
-.ci-pending { color: var(--status-warning); animation: pulse 1.5s ease-in-out infinite; }
-@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
-
-.pr-row-title-line {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-  width: 100%;
-}
-
-.pr-title-link {
-  font-size: var(--font-size-sm);
-  font-family: var(--font-mono);
-  color: var(--text);
-  text-decoration: none;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-  flex: 1;
-}
-
-.pr-title-link:hover {
-  color: var(--accent);
-  text-decoration: underline;
-}
-
-.pr-row-meta {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: var(--font-size-xs);
-  font-family: var(--font-mono);
-  color: var(--text-muted);
-  flex-wrap: wrap;
-}
-
-.pr-meta-text {
-  font-size: var(--font-size-xs);
-  font-family: var(--font-mono);
-  color: var(--text-muted);
-  white-space: nowrap;
-}
-
-.pr-sep {
-  opacity: 0.4;
-}
-
-.repo-chip {
-  display: inline-flex;
-  align-items: center;
-  padding: 2px 8px;
-  border-radius: 0;
-  font-size: var(--font-size-xs);
-  font-family: var(--font-mono);
-  font-weight: 700;
-  color: #000;
-  white-space: nowrap;
-  transition: opacity 0.12s;
-  line-height: 1.4;
-}
-
-.repo-chip:hover {
-  opacity: 0.8;
-}
-
-.ticket-chip {
-  display: inline-flex;
-  align-items: center;
-  padding: 2px 8px;
-  border-radius: 0;
-  font-size: var(--font-size-xs);
-  font-family: var(--font-mono);
-  font-weight: 600;
-  color: var(--text-muted);
-  background: var(--surface);
-  border: 1px solid var(--border);
-  white-space: nowrap;
-  line-height: 1.4;
-}
-
-.mobile-card {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 8px 8px;
-  width: 100%;
-}
-
-.mobile-card-line1 {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-}
-
-.mobile-card-line2 {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: var(--font-size-xs);
-  font-family: var(--font-mono);
-  color: var(--text-muted);
-  flex-wrap: wrap;
-}
-
 .presets-row {
   display: flex;
   align-items: center;
@@ -266,16 +125,6 @@
 .preset-select:hover {
   border-color: var(--accent);
   color: var(--text);
-}
-
-.pr-table-row {
-  display: flex;
-  align-items: center;
-  border-bottom: 1px solid var(--border);
-}
-
-.pr-table-row:hover {
-  background: var(--surface-hover);
 }
 
 @media (max-width: 600px) {

--- a/frontend/src/components/OrgDashboard.tsx
+++ b/frontend/src/components/OrgDashboard.tsx
@@ -7,13 +7,7 @@ import {
   savePreset,
   deletePreset,
 } from '../lib/api.js';
-import {
-  derivePrAction,
-  buildPrStateInput,
-  colorToVariant,
-} from '../lib/pr-state.js';
-import { prRoleLabel, sortPrs } from '../lib/pr-utils.js';
-import { formatRelativeTime } from '../lib/utils.js';
+import { sortPrs } from '../lib/pr-utils.js';
 import type {
   PullRequest,
   OrgPrsResponse,
@@ -21,36 +15,21 @@ import type {
   FilterPreset,
 } from '../lib/types.js';
 import TicketsPanel from './TicketsPanel.js';
-import { deriveColor } from '../lib/colors.js';
 import { derivePrDotStatus } from '../lib/pr-status.js';
-import StatusDot from './StatusDot.js';
 import { TuiButton } from './TuiButton.js';
+import { PrRow } from './PrRow.js';
 import './OrgDashboard.css';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export interface OrgDashboardProps {
-  onOpenWorkspace: (path: string) => void;
-  onOpenSession?: (sessionId: string) => void;
+  onOpenPrSession: (pr: PullRequest) => void;
+  onPrAction: (pr: PullRequest) => void;
 }
 
 type ActiveTab = 'prs' | 'tickets';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-interface CiIconResult {
-  icon: string;
-  cls: string;
-}
-
-function ciIcon(pr: PullRequest): CiIconResult | null {
-  if (!pr.ciStatus) return null;
-  if (pr.ciStatus === 'SUCCESS') return { icon: '✓', cls: 'ci-pass' };
-  if (pr.ciStatus === 'FAILURE' || pr.ciStatus === 'ERROR')
-    return { icon: '✗', cls: 'ci-fail' };
-  if (pr.ciStatus === 'PENDING') return { icon: '○', cls: 'ci-pending' };
-  return null;
-}
 
 function getTicketIdForPr(
   headRefName: string,
@@ -62,99 +41,6 @@ function getTicketIdForPr(
     }
   }
   return null;
-}
-
-// ── Sub-components ─────────────────────────────────────────────────────────────
-
-interface PrRowProps {
-  pr: PullRequest;
-  branchLinksData: BranchLinksResponse;
-  onOpenWorkspace: (path: string) => void;
-}
-
-function OrgPrRow({ pr, branchLinksData, onOpenWorkspace }: PrRowProps) {
-  const repoName = pr.repoName ?? '';
-  const chipColor = deriveColor(repoName);
-  const ticketId = getTicketIdForPr(pr.headRefName, branchLinksData);
-  const action = useMemo(() => {
-    const a = derivePrAction(buildPrStateInput(pr));
-    if (
-      a.type === 'merge-pr' ||
-      a.type === 'archive-merged' ||
-      a.type === 'archive-closed'
-    ) {
-      return { ...a, label: 'Open' };
-    }
-    return a;
-  }, [pr]);
-  const ci = ciIcon(pr);
-
-  return (
-    <div className="pr-table-row">
-      <div className="cell cell--status" style={{ width: 36, flex: 'none' }}>
-        <StatusDot status={derivePrDotStatus(pr)} />
-      </div>
-      <div className="cell cell--title" style={{ flex: 1 }}>
-        <div className="pr-row-title-line">
-          <a
-            className="pr-title-link"
-            href={pr.url}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {pr.title}
-          </a>
-        </div>
-        <div className="pr-row-meta">
-          <span className="pr-meta-text">#{pr.number}</span>
-          {ticketId && (
-            <>
-              <span className="pr-sep">·</span>
-              <span className="ticket-chip">{ticketId}</span>
-            </>
-          )}
-          <span className="pr-sep">·</span>
-          <span className="pr-meta-text">{prRoleLabel(pr)}</span>
-          <span className="pr-sep">·</span>
-          <span className="pr-meta-text">
-            {formatRelativeTime(pr.updatedAt)}
-          </span>
-        </div>
-      </div>
-      <div className="cell cell--repo" style={{ width: 100, flex: 'none' }}>
-        {repoName && (
-          <span
-            className="repo-chip"
-            style={{ background: chipColor }}
-            title={pr.repoPath ?? repoName}
-          >
-            {repoName}
-          </span>
-        )}
-      </div>
-      <div className="cell cell--role" style={{ width: 60, flex: 'none' }}>
-        <span className="pr-meta-text">{pr.role}</span>
-      </div>
-      <div className="cell cell--ci" style={{ width: 32, flex: 'none' }}>
-        {ci && <span className={`ci-icon ${ci.cls}`}>{ci.icon}</span>}
-      </div>
-      <div className="cell cell--age" style={{ width: 72, flex: 'none' }}>
-        <span className="pr-meta-text">{formatRelativeTime(pr.updatedAt)}</span>
-      </div>
-      <div className="cell cell--action" style={{ width: 140, flex: 'none' }}>
-        {action.type !== 'none' && action.label && (
-          <TuiButton
-            variant={colorToVariant(action.color)}
-            size="sm"
-            onClick={() => onOpenWorkspace(pr.repoPath ?? '')}
-            title={action.label}
-          >
-            {action.label}
-          </TuiButton>
-        )}
-      </div>
-    </div>
-  );
 }
 
 interface PresetsRowProps {
@@ -356,7 +242,8 @@ interface PrsTabContentProps {
   searchQuery: string;
   activeStatusChips: string[];
   setSearchQuery: (q: string) => void;
-  onOpenWorkspace: (path: string) => void;
+  onOpenPrSession: (pr: PullRequest) => void;
+  onPrAction: (pr: PullRequest) => void;
   onApplyPreset: (p: FilterPreset) => void;
   onSaveView: () => void;
   onDeletePreset: (p: FilterPreset) => void;
@@ -373,7 +260,8 @@ function PrsTabContent({
   searchQuery,
   activeStatusChips,
   setSearchQuery,
-  onOpenWorkspace,
+  onOpenPrSession,
+  onPrAction,
   onApplyPreset,
   onSaveView,
   onDeletePreset,
@@ -434,11 +322,14 @@ function PrsTabContent({
           <div className="state-message">{emptyMsg}</div>
         )}
         {processedPrs.map((pr) => (
-          <OrgPrRow
+          <PrRow
             key={pr.number}
             pr={pr}
-            branchLinksData={branchLinksData}
-            onOpenWorkspace={onOpenWorkspace}
+            onOpen={onOpenPrSession}
+            onAction={onPrAction}
+            ticketId={getTicketIdForPr(pr.headRefName, branchLinksData)}
+            showRepo
+            showCi
           />
         ))}
       </div>
@@ -449,10 +340,11 @@ function PrsTabContent({
 // ── PrsTab sub-component ──────────────────────────────────────────────────────
 
 interface PrsTabProps {
-  onOpenWorkspace: (path: string) => void;
+  onOpenPrSession: (pr: PullRequest) => void;
+  onPrAction: (pr: PullRequest) => void;
 }
 
-function PrsTab({ onOpenWorkspace }: PrsTabProps) {
+function PrsTab({ onOpenPrSession, onPrAction }: PrsTabProps) {
   const {
     data,
     isLoading,
@@ -489,7 +381,8 @@ function PrsTab({ onOpenWorkspace }: PrsTabProps) {
       searchQuery={searchQuery}
       activeStatusChips={activeStatusChips}
       setSearchQuery={setSearchQuery}
-      onOpenWorkspace={onOpenWorkspace}
+      onOpenPrSession={onOpenPrSession}
+      onPrAction={onPrAction}
       onApplyPreset={handleApplyPreset}
       onSaveView={() => void handleSaveCurrentView()}
       onDeletePreset={(p) => void handleDeletePreset(p)}
@@ -499,13 +392,16 @@ function PrsTab({ onOpenWorkspace }: PrsTabProps) {
 
 // ── Main Component ────────────────────────────────────────────────────────────
 
-export function OrgDashboard({ onOpenWorkspace }: OrgDashboardProps) {
+export function OrgDashboard({
+  onOpenPrSession,
+  onPrAction,
+}: OrgDashboardProps) {
   const [activeTab, setActiveTab] = useState<ActiveTab>('prs');
 
   return (
     <div className="org-dashboard">
       <div className="org-header">
-        <span className="org-title">All Workspaces</span>
+        <span className="org-title">all workspaces</span>
       </div>
       {/* tab-strip uses raw buttons intentionally — underline-indicator navigation, not TuiButton actions */}
       <div className="tab-strip">
@@ -529,7 +425,9 @@ export function OrgDashboard({ onOpenWorkspace }: OrgDashboardProps) {
           Tickets
         </button>
       </div>
-      {activeTab === 'prs' && <PrsTab onOpenWorkspace={onOpenWorkspace} />}
+      {activeTab === 'prs' && (
+        <PrsTab onOpenPrSession={onOpenPrSession} onPrAction={onPrAction} />
+      )}
       {activeTab === 'tickets' && <TicketsPanel />}
     </div>
   );

--- a/frontend/src/components/PrRow.css
+++ b/frontend/src/components/PrRow.css
@@ -1,0 +1,223 @@
+.pr-row {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.pr-row:hover {
+  background: var(--surface-hover);
+}
+
+.pr-row:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+}
+
+/* ── cells ─────────────────────────────────────────────── */
+
+.pr-row__status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  flex: none;
+  padding: 8px;
+}
+
+.pr-row__title {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  flex: 1;
+  padding: 8px;
+  min-width: 0;
+}
+
+.pr-row__title-line {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  width: 100%;
+}
+
+.pr-row__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-sm);
+  font-family: var(--font-mono);
+  color: var(--text);
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.pr-row__link:hover {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.pr-row__external-icon {
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.1s;
+  color: var(--text-muted);
+}
+
+.pr-row__link:hover .pr-row__external-icon {
+  opacity: 1;
+}
+
+.pr-row__meta {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  flex-wrap: wrap;
+}
+
+.pr-row__meta-text {
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.pr-row__sep {
+  opacity: 0.4;
+}
+
+.pr-row__ticket {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.pr-row__repo {
+  display: flex;
+  align-items: center;
+  width: 100px;
+  flex: none;
+  padding: 8px;
+  overflow: hidden;
+}
+
+.pr-row__repo-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  font-weight: 700;
+  color: #000;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.pr-row__role {
+  display: flex;
+  align-items: center;
+  width: 60px;
+  flex: none;
+  padding: 8px;
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.pr-row__role-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.pr-row__ci {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  flex: none;
+  padding: 8px;
+}
+
+.pr-row-ci {
+  font-size: 12px;
+  font-weight: bold;
+}
+
+.ci-pass {
+  color: var(--status-success);
+}
+.ci-fail {
+  color: var(--status-error);
+}
+.ci-pending {
+  color: var(--status-warning);
+  animation: pr-row-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pr-row-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.pr-row__age {
+  display: flex;
+  align-items: center;
+  width: 72px;
+  flex: none;
+  padding: 8px;
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.pr-row__age-text {
+  white-space: nowrap;
+}
+
+.pr-row__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  width: 160px;
+  flex: none;
+  padding: 8px;
+}
+
+/* ── responsive ────────────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .pr-row__repo,
+  .pr-row__role,
+  .pr-row__ci,
+  .pr-row__age {
+    display: none;
+  }
+
+  .pr-row__actions {
+    width: auto;
+  }
+}

--- a/frontend/src/components/PrRow.tsx
+++ b/frontend/src/components/PrRow.tsx
@@ -1,0 +1,209 @@
+import React, { useCallback, useMemo } from 'react';
+import {
+  derivePrAction,
+  buildPrStateInput,
+  colorToVariant,
+} from '../lib/pr-state.js';
+import { prRoleLabel } from '../lib/pr-utils.js';
+import { formatRelativeTime } from '../lib/utils.js';
+import { derivePrDotStatus } from '../lib/pr-status.js';
+import { deriveColor } from '../lib/colors.js';
+import type { PullRequest } from '../lib/types.js';
+import StatusDot from './StatusDot.js';
+import { TuiButton } from './TuiButton.js';
+import './PrRow.css';
+
+export interface PrRowProps {
+  pr: PullRequest;
+  /** Called when the row is clicked (open worktree session) */
+  onOpen: (pr: PullRequest) => void;
+  /** Called for the derived action button (review, fix conflicts, etc.) */
+  onAction?: (pr: PullRequest) => void;
+  /** Ticket ID to display as a chip */
+  ticketId?: string | null;
+  /** Show repo chip (org-wide view) */
+  showRepo?: boolean;
+  /** Show CI status column */
+  showCi?: boolean;
+}
+
+function CiIcon({ pr }: { pr: PullRequest }) {
+  if (!pr.ciStatus) return null;
+  if (pr.ciStatus === 'SUCCESS')
+    return <span className="pr-row-ci ci-pass">{'✓'}</span>;
+  if (pr.ciStatus === 'FAILURE' || pr.ciStatus === 'ERROR')
+    return <span className="pr-row-ci ci-fail">{'✗'}</span>;
+  if (pr.ciStatus === 'PENDING')
+    return <span className="pr-row-ci ci-pending">{'○'}</span>;
+  return null;
+}
+
+function ExternalLinkIcon() {
+  return (
+    <svg
+      className="pr-row-external-icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="square"
+      width="12"
+      height="12"
+      aria-hidden="true"
+    >
+      <path d="M6 2H2v12h12v-4" />
+      <path d="M9 1h6v6" />
+      <path d="M15 1L7 9" />
+    </svg>
+  );
+}
+
+function ChevronIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="square"
+      width="12"
+      height="12"
+      aria-hidden="true"
+    >
+      <path d="M6 3l5 5-5 5" />
+    </svg>
+  );
+}
+
+export function PrRow({
+  pr,
+  onOpen,
+  onAction,
+  ticketId,
+  showRepo = false,
+  showCi = false,
+}: PrRowProps) {
+  const action = useMemo(() => derivePrAction(buildPrStateInput(pr)), [pr]);
+  const repoName = pr.repoName ?? '';
+  const chipColor = showRepo ? deriveColor(repoName) : undefined;
+  const updatedAgo = formatRelativeTime(pr.updatedAt);
+
+  const handleRowClick = useCallback(
+    (e: React.MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('a, button')) return;
+      onOpen(pr);
+    },
+    [onOpen, pr]
+  );
+
+  const handleRowKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onOpen(pr);
+      }
+    },
+    [onOpen, pr]
+  );
+
+  const stopProp = useCallback(
+    (e: React.MouseEvent) => e.stopPropagation(),
+    []
+  );
+
+  return (
+    <div
+      className="pr-row"
+      onClick={handleRowClick}
+      onKeyDown={handleRowKeyDown}
+      role="button"
+      tabIndex={0}
+      aria-label={`Open ${pr.title}`}
+    >
+      <div className="pr-row__status">
+        <StatusDot status={derivePrDotStatus(pr)} />
+      </div>
+
+      <div className="pr-row__title">
+        <div className="pr-row__title-line">
+          <a
+            className="pr-row__link"
+            href={pr.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={stopProp}
+          >
+            {pr.title}
+            <ExternalLinkIcon />
+          </a>
+        </div>
+        <div className="pr-row__meta">
+          <span className="pr-row__meta-text">#{pr.number}</span>
+          {ticketId && (
+            <>
+              <span className="pr-row__sep">&middot;</span>
+              <span className="pr-row__ticket">{ticketId}</span>
+            </>
+          )}
+          <span className="pr-row__sep">&middot;</span>
+          <span className="pr-row__meta-text">{prRoleLabel(pr)}</span>
+          <span className="pr-row__sep">&middot;</span>
+          <span className="pr-row__meta-text">{updatedAgo}</span>
+        </div>
+      </div>
+
+      {showRepo && repoName && (
+        <div className="pr-row__repo">
+          <span
+            className="pr-row__repo-chip"
+            style={{ background: chipColor }}
+            title={pr.repoPath ?? repoName}
+          >
+            {repoName}
+          </span>
+        </div>
+      )}
+
+      <div className="pr-row__role">
+        <span className="pr-row__role-text">
+          {pr.role === 'author' ? 'author' : 'review'}
+        </span>
+      </div>
+
+      {showCi && (
+        <div className="pr-row__ci">
+          <CiIcon pr={pr} />
+        </div>
+      )}
+
+      <div className="pr-row__age">
+        <span className="pr-row__age-text">{updatedAgo}</span>
+      </div>
+
+      <div className="pr-row__actions" onClick={stopProp}>
+        {onAction && action.type !== 'none' && action.label && (
+          <TuiButton
+            variant={colorToVariant(action.color)}
+            size="sm"
+            onClick={() => onAction(pr)}
+            title={action.label}
+            disabled={action.type === 'checks-running'}
+          >
+            {action.label}
+          </TuiButton>
+        )}
+        <TuiButton
+          variant="ghost"
+          size="sm"
+          onClick={() => onOpen(pr)}
+          title="Open in worktree session"
+        >
+          open <ChevronIcon />
+        </TuiButton>
+      </div>
+    </div>
+  );
+}
+
+export default PrRow;

--- a/frontend/src/components/PrRow.tsx
+++ b/frontend/src/components/PrRow.tsx
@@ -41,7 +41,7 @@ function CiIcon({ pr }: { pr: PullRequest }) {
 function ExternalLinkIcon() {
   return (
     <svg
-      className="pr-row-external-icon"
+      className="pr-row__external-icon"
       viewBox="0 0 16 16"
       fill="none"
       stroke="currentColor"
@@ -99,6 +99,7 @@ export function PrRow({
 
   const handleRowKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      if (e.target !== e.currentTarget) return;
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         onOpen(pr);

--- a/frontend/src/components/RepoDashboard.css
+++ b/frontend/src/components/RepoDashboard.css
@@ -117,126 +117,6 @@
   margin: 4px 0;
 }
 
-.pr-cell {
-  display: flex;
-  align-items: center;
-  padding: 8px 8px;
-  min-width: 0;
-}
-
-.pr-cell--status {
-  justify-content: center;
-}
-
-.pr-cell--title {
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 4px;
-}
-
-.pr-cell--role,
-.pr-cell--age {
-  font-size: var(--font-size-xs);
-  font-family: var(--font-mono);
-  color: var(--text-muted);
-}
-
-.pr-cell--action {
-  justify-content: flex-end;
-  align-items: center;
-  gap: 8px;
-}
-
-.pr-title-link {
-  font-size: var(--font-size-sm);
-  font-family: var(--font-mono);
-  color: var(--text);
-  text-decoration: none;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-  max-width: 100%;
-}
-
-.pr-title-link:hover {
-  color: var(--accent);
-  text-decoration: underline;
-}
-
-.pr-row-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-shrink: 0;
-}
-
-.pr-session-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 0;
-  border: 1px solid var(--border);
-  background: transparent;
-  color: var(--text-muted);
-  font-size: var(--font-size-sm);
-  font-family: var(--font-mono);
-  cursor: pointer;
-  transition: background 0.12s, color 0.12s, border-color 0.12s;
-  flex-shrink: 0;
-}
-
-.pr-session-btn:hover {
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
-  border-color: var(--accent);
-  color: var(--accent);
-}
-
-.pr-row-meta {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: var(--font-size-xs);
-  font-family: var(--font-mono);
-  color: var(--text-muted);
-}
-
-.pr-sep {
-  opacity: 0.4;
-}
-
-.pr-role-text {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.pr-age-text {
-  white-space: nowrap;
-}
-
-.mobile-pr-card {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 12px 12px;
-  width: 100%;
-}
-
-.mobile-pr-top {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-}
-
-.mobile-pr-actions {
-  align-self: flex-end;
-  margin-top: 4px;
-}
-
 .activity-list {
   display: flex;
   flex-direction: column;
@@ -308,8 +188,13 @@
 }
 
 @keyframes skeleton-pulse {
-  0%, 100% { opacity: 0.4; }
-  50% { opacity: 0.7; }
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+  50% {
+    opacity: 0.7;
+  }
 }
 
 .skeleton-activity {

--- a/frontend/src/components/RepoDashboard.tsx
+++ b/frontend/src/components/RepoDashboard.tsx
@@ -1,13 +1,7 @@
-import React, { useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchDashboard } from '../lib/api.js';
-import {
-  derivePrAction,
-  buildPrStateInput,
-  colorToVariant,
-} from '../lib/pr-state.js';
-import { prRoleLabel, sortPrs } from '../lib/pr-utils.js';
-import { formatRelativeTime } from '../lib/utils.js';
+import { sortPrs } from '../lib/pr-utils.js';
 import type {
   PullRequest,
   ActivityEntry,
@@ -15,10 +9,9 @@ import type {
 } from '../lib/types.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useTelemetryStore } from '../lib/stores/telemetry.js';
-import { derivePrDotStatus } from '../lib/pr-status.js';
-import StatusDot from './StatusDot.js';
 import { TuiButton } from './TuiButton.js';
 import { TuiProgress } from './TuiProgress.js';
+import { PrRow } from './PrRow.js';
 import { useScrollOverflow } from '../hooks/useScrollOverflow.js';
 import './RepoDashboard.css';
 
@@ -267,80 +260,6 @@ function ActivitySection({ data, isLoading }: ActivitySectionProps) {
   );
 }
 
-interface PrRowProps {
-  pr: PullRequest;
-  onOpenPrSession: (pr: PullRequest) => void;
-  onPrAction: (pr: PullRequest) => void;
-}
-
-function PrRow({ pr, onOpenPrSession, onPrAction }: PrRowProps) {
-  const action = derivePrAction(buildPrStateInput(pr));
-  return (
-    <>
-      <div
-        className="pr-cell pr-cell--status"
-        style={{ width: 36, flex: 'none' }}
-      >
-        <StatusDot status={derivePrDotStatus(pr)} />
-      </div>
-      <div className="pr-cell pr-cell--title" style={{ flex: 1 }}>
-        <a
-          className="pr-title-link"
-          href={pr.url}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {pr.title}
-        </a>
-        <div className="pr-row-meta">
-          <span className="pr-num">#{pr.number}</span>
-          <span className="pr-sep">&middot;</span>
-          <span className="pr-role">{prRoleLabel(pr)}</span>
-          <span className="pr-sep">&middot;</span>
-          <span className="pr-time">{formatRelativeTime(pr.updatedAt)}</span>
-        </div>
-      </div>
-      <div
-        className="pr-cell pr-cell--role"
-        style={{ width: 60, flex: 'none' }}
-      >
-        <span className="pr-role-text">
-          {pr.role === 'author' ? 'Author' : 'Review'}
-        </span>
-      </div>
-      <div className="pr-cell pr-cell--age" style={{ width: 72, flex: 'none' }}>
-        <span className="pr-age-text">{formatRelativeTime(pr.updatedAt)}</span>
-      </div>
-      <div
-        className="pr-cell pr-cell--action"
-        style={{ width: 160, flex: 'none' }}
-      >
-        <div className="pr-row-actions">
-          <TuiButton
-            variant="primary"
-            size="icon"
-            onClick={() => onOpenPrSession(pr)}
-            title="Open session on this branch"
-          >
-            +
-          </TuiButton>
-          {action.type !== 'none' && action.label && (
-            <TuiButton
-              variant={colorToVariant(action.color)}
-              size="sm"
-              onClick={() => onPrAction(pr)}
-              title={action.label}
-              disabled={action.type === 'checks-running'}
-            >
-              {action.label}
-            </TuiButton>
-          )}
-        </div>
-      </div>
-    </>
-  );
-}
-
 // ── Helpers ─────────────────────────────────────────────────────────────────────
 
 interface PrListBodyProps {
@@ -411,20 +330,12 @@ function PrListBody({
       ) : (
         <div>
           {processedPrs.map((pr) => (
-            <div
+            <PrRow
               key={pr.number}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                borderBottom: '1px solid var(--border)',
-              }}
-            >
-              <PrRow
-                pr={pr}
-                onOpenPrSession={onOpenPrSession}
-                onPrAction={onPrAction}
-              />
-            </div>
+              pr={pr}
+              onOpen={onOpenPrSession}
+              onAction={onPrAction}
+            />
           ))}
         </div>
       )}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -296,7 +296,8 @@ export function Sidebar({
     useSessionsStore.getState().setActiveSessionId(null);
   }, []);
   const handleHomeBrand = useCallback(() => {
-    useUiStore.setState({ activeRepoPath: null });
+    useUiStore.getState().setActiveRepoPath(null);
+    useUiStore.getState().setAnalyticsView(null);
     useSessionsStore.getState().setActiveSessionId(null);
     closeSidebar();
   }, [closeSidebar]);

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -285,7 +285,9 @@ export function useSessionHandlers({
           workspace.name
         );
       } else {
-        useUiStore.getState().setActiveModal({ modal: 'settings', scrollToId: null });
+        useUiStore
+          .getState()
+          .setActiveModal({ modal: 'settings', scrollToId: null });
       }
     },
     [workspaceSettingsDialogRef]
@@ -372,14 +374,11 @@ export function useSessionHandlers({
   );
 
   const handleFixConflicts = useCallback(async (pr: PullRequest) => {
-    const currentRepoPath = useUiStore.getState().activeRepoPath;
-    const currentActiveWorkspace = currentRepoPath
-      ? useSessionsStore
-          .getState()
-          .repos.find((w) => w.path === currentRepoPath)
+    const repoPath = pr.repoPath ?? useUiStore.getState().activeRepoPath;
+    const currentActiveWorkspace = repoPath
+      ? useSessionsStore.getState().repos.find((w) => w.path === repoPath)
       : undefined;
-    if (!currentActiveWorkspace) return;
-    const repoPath = currentActiveWorkspace.path;
+    if (!currentActiveWorkspace || !repoPath) return;
 
     const currentSessions = useSessionsStore.getState().sessions;
     const currentWorktrees = useSessionsStore.getState().worktrees;
@@ -451,14 +450,11 @@ export function useSessionHandlers({
 
   const handleOpenPrBranch = useCallback(
     async (pr: PullRequest, prPrompt?: string) => {
-      const currentRepoPath = useUiStore.getState().activeRepoPath;
-      const currentActiveWorkspace = currentRepoPath
-        ? useSessionsStore
-            .getState()
-            .repos.find((w) => w.path === currentRepoPath)
+      const repoPath = pr.repoPath ?? useUiStore.getState().activeRepoPath;
+      const currentActiveWorkspace = repoPath
+        ? useSessionsStore.getState().repos.find((w) => w.path === repoPath)
         : undefined;
-      if (!currentActiveWorkspace) return;
-      const repoPath = currentActiveWorkspace.path;
+      if (!currentActiveWorkspace || !repoPath) return;
 
       const currentSessions = useSessionsStore.getState().sessions;
       const currentWorktrees = useSessionsStore.getState().worktrees;

--- a/server/org-dashboard.ts
+++ b/server/org-dashboard.ts
@@ -6,8 +6,8 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 
 import { loadConfig } from './config.js';
-import { extractOwnerRepo, buildRepoMap } from './git.js';
-import type { Config, PullRequest, PullRequestsResponse } from './types.js';
+import { buildRepoMap } from './git.js';
+import type { PullRequest, PullRequestsResponse } from './types.js';
 import { createLogger } from './logger.js';
 
 const execFileAsync = promisify(execFile);
@@ -99,98 +99,186 @@ function repoFromApiUrl(repositoryUrl: string): string | null {
  * Caller is responsible for mounting and applying auth middleware:
  *   app.use('/org-dashboard', requireAuth, createOrgDashboardRouter({ configPath }));
  */
+type ExecFn = typeof execFileAsync;
+
+function errorResponse(error: string): PullRequestsResponse {
+  return { prs: [], error };
+}
+
+function sortByUpdatedDesc(prs: PullRequest[]): void {
+  prs.sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  );
+}
+
+/** Map search API items to PullRequest[], filtering to known workspaces. */
+function mapSearchItemsToPrs(
+  items: GhSearchItem[],
+  repoMap: Map<string, string>,
+  currentUser: string,
+  state: 'OPEN' | 'MERGED'
+): PullRequest[] {
+  const prs: PullRequest[] = [];
+  for (const item of items) {
+    if (!item.pull_request) continue;
+    const ownerRepo = repoFromApiUrl(item.repository_url);
+    if (!ownerRepo) continue;
+    const wsPath = repoMap.get(ownerRepo.toLowerCase());
+    if (!wsPath) continue;
+
+    const isAuthor = item.user.login === currentUser;
+    prs.push({
+      number: item.number,
+      title: item.title,
+      url: item.html_url,
+      headRefName: item.pull_request?.head?.ref ?? '',
+      baseRefName: item.pull_request?.base?.ref ?? '',
+      state,
+      author: item.user.login,
+      role: isAuthor ? 'author' : 'reviewer',
+      updatedAt: item.updated_at,
+      additions: 0,
+      deletions: 0,
+      reviewDecision: null,
+      mergeable: null,
+      isDraft: false,
+      ciStatus: null,
+      repoName: path.basename(wsPath),
+      repoPath: wsPath,
+    });
+  }
+  return prs;
+}
+
+/** Resolve GitHub user login via `gh api`, with caching. */
+async function resolveGhUser(
+  exec: ExecFn,
+  cached: string | null
+): Promise<{ user: string } | { error: string }> {
+  if (cached) return { user: cached };
+  try {
+    const { stdout } = await exec('gh', ['api', 'user', '--jq', '.login'], {
+      timeout: GH_TIMEOUT_MS,
+    });
+    return { user: stdout.trim() };
+  } catch (err) {
+    const errCode = (err as NodeJS.ErrnoException).code;
+    return {
+      error: errCode === 'ENOENT' ? 'gh_not_in_path' : 'gh_not_authenticated',
+    };
+  }
+}
+
+/** Fetch open PRs via gh search API. Returns items or an error code. */
+async function fetchSearchPrs(
+  exec: ExecFn
+): Promise<{ items: GhSearchItem[] } | { error: string }> {
+  try {
+    const { stdout } = await exec(
+      'gh',
+      ['api', 'search/issues?q=is:pr+is:open+involves:@me&per_page=100'],
+      { timeout: GH_TIMEOUT_MS }
+    );
+    const parsed = JSON.parse(stdout) as GhSearchResponse;
+    return { items: parsed.items ?? [] };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const errCode = (err as NodeJS.ErrnoException).code;
+    if (msg.includes('ETIMEDOUT') || msg.includes('timed out'))
+      return { error: 'gh_timeout' };
+    if (errCode === 'ENOENT') return { error: 'gh_not_in_path' };
+    return { error: 'gh_not_authenticated' };
+  }
+}
+
+/** Best-effort: fetch recently merged PRs and fire ticket transition checks. */
+function fireTransitionChecks(
+  prs: PullRequest[],
+  repoMap: Map<string, string>,
+  currentUser: string,
+  exec: ExecFn,
+  deps: OrgDashboardDeps
+): void {
+  if (!deps.checkPrTransitions || !deps.getBranchLinks) return;
+
+  const run = async () => {
+    const transitionPrs = [...prs];
+    try {
+      const mergedSince = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .split('T')[0];
+      const { stdout } = await exec(
+        'gh',
+        [
+          'api',
+          `search/issues?q=is:pr+is:merged+merged:>=${mergedSince}+involves:@me&per_page=50`,
+        ],
+        { timeout: GH_TIMEOUT_MS }
+      );
+      const mergedResponse = JSON.parse(stdout) as GhSearchResponse;
+      transitionPrs.push(
+        ...mapSearchItemsToPrs(
+          mergedResponse.items ?? [],
+          repoMap,
+          currentUser,
+          'MERGED'
+        )
+      );
+    } catch {
+      // Merged PR fetch is best-effort
+    }
+    const links = await deps.getBranchLinks!();
+    await deps.checkPrTransitions!(transitionPrs, links);
+  };
+
+  run().catch(() => {});
+}
+
 export function createOrgDashboardRouter(deps: OrgDashboardDeps): Router {
   const { configPath } = deps;
   const exec = deps.execAsync ?? execFileAsync;
 
   const router = Router();
 
-  // Server-lifetime cache for GitHub user login
   let cachedUser: string | null = null;
-
-  // 60s in-memory cache for search results
   let cache: CacheEntry | null = null;
 
-  function getConfig(): Config {
-    return loadConfig(configPath);
-  }
-
-  // GET /org-dashboard/prs — list all open PRs involving the current user across all workspaces
   router.get('/prs', async (_req: Request, res: Response) => {
-    const config = getConfig();
+    const config = loadConfig(configPath);
     const workspacePaths = config.repos ?? [];
 
     if (workspacePaths.length === 0) {
-      const response: PullRequestsResponse = {
-        prs: [],
-        error: 'no_workspaces',
-      };
-      res.json(response);
+      res.json(errorResponse('no_workspaces'));
       return;
     }
 
-    // Return cached results if still fresh
     const now = Date.now();
     if (cache && now - cache.fetchedAt < CACHE_TTL_MS) {
-      const response: PullRequestsResponse = { prs: cache.prs };
-      res.json(response);
+      res.json({ prs: cache.prs } satisfies PullRequestsResponse);
       return;
     }
 
-    // Resolve GitHub user (cached for server lifetime)
-    if (!cachedUser) {
-      try {
-        const { stdout } = await exec('gh', ['api', 'user', '--jq', '.login'], {
-          timeout: GH_TIMEOUT_MS,
-        });
-        cachedUser = stdout.trim();
-      } catch (err) {
-        const errCode = (err as NodeJS.ErrnoException).code;
-        if (errCode === 'ENOENT') {
-          const response: PullRequestsResponse = {
-            prs: [],
-            error: 'gh_not_in_path',
-          };
-          res.json(response);
-          return;
-        }
-        const response: PullRequestsResponse = {
-          prs: [],
-          error: 'gh_not_authenticated',
-        };
-        res.json(response);
-        return;
-      }
+    const userResult = await resolveGhUser(exec, cachedUser);
+    if ('error' in userResult) {
+      res.json(errorResponse(userResult.error));
+      return;
     }
-
+    cachedUser = userResult.user;
     const currentUser = cachedUser;
 
-    // Build repo → workspace path map
     const repoMap = await buildRepoMap(workspacePaths, exec);
 
-    // Check for GraphQL path (GitHub App token)
+    // Try GraphQL path first (GitHub App token)
     const githubToken = config.github?.accessToken;
     if (githubToken && deps.fetchGraphQL) {
       try {
         const result = await deps.fetchGraphQL(githubToken, repoMap);
         cachedUser = result.username;
         const prs = result.prs;
-        prs.sort(
-          (a, b) =>
-            new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-        );
+        sortByUpdatedDesc(prs);
         cache = { prs, fetchedAt: now };
-
-        // Fire ticket transitions (same best-effort as below)
-        if (deps.checkPrTransitions && deps.getBranchLinks) {
-          deps
-            .getBranchLinks()
-            .then((links) => deps.checkPrTransitions!(prs, links))
-            .catch(() => {});
-        }
-
-        const response: PullRequestsResponse = { prs };
-        res.json(response);
+        fireTransitionChecks(prs, repoMap, cachedUser, exec, deps);
+        res.json({ prs } satisfies PullRequestsResponse);
         return;
       } catch (err) {
         logger.warn(
@@ -200,153 +288,25 @@ export function createOrgDashboardRouter(deps: OrgDashboardDeps): Router {
       }
     }
 
-    // Single gh search API call
-    let searchResponse: GhSearchResponse;
-    try {
-      const { stdout } = await exec(
-        'gh',
-        ['api', 'search/issues?q=is:pr+is:open+involves:@me&per_page=100'],
-        { timeout: GH_TIMEOUT_MS }
-      );
-      searchResponse = JSON.parse(stdout) as GhSearchResponse;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      const errCode = (err as NodeJS.ErrnoException).code;
-      if (msg.includes('ETIMEDOUT') || msg.includes('timed out')) {
-        const response: PullRequestsResponse = { prs: [], error: 'gh_timeout' };
-        res.json(response);
-        return;
-      }
-      if (errCode === 'ENOENT') {
-        const response: PullRequestsResponse = {
-          prs: [],
-          error: 'gh_not_in_path',
-        };
-        res.json(response);
-        return;
-      }
-      const response: PullRequestsResponse = {
-        prs: [],
-        error: 'gh_not_authenticated',
-      };
-      res.json(response);
+    // Fallback: gh search API
+    const searchResult = await fetchSearchPrs(exec);
+    if ('error' in searchResult) {
+      res.json(errorResponse(searchResult.error));
       return;
     }
 
-    const items = searchResponse.items ?? [];
-
-    // Filter to only repos matching workspace paths and map to PullRequest
-    const prs: PullRequest[] = [];
-
-    for (const item of items) {
-      // The search API can return non-PR issues — skip them
-      if (!item.pull_request) continue;
-
-      const ownerRepo = repoFromApiUrl(item.repository_url);
-      if (!ownerRepo) continue;
-
-      const wsPath = repoMap.get(ownerRepo.toLowerCase());
-      if (!wsPath) continue;
-
-      // Determine role
-      const isAuthor = item.user.login === currentUser;
-      const isReviewer =
-        !isAuthor &&
-        Array.isArray(item.requested_reviewers) &&
-        item.requested_reviewers.some((r) => r.login === currentUser);
-
-      if (!isAuthor && !isReviewer) continue;
-
-      const role: 'author' | 'reviewer' = isAuthor ? 'author' : 'reviewer';
-      const repoName = path.basename(wsPath);
-
-      prs.push({
-        number: item.number,
-        title: item.title,
-        url: item.html_url,
-        headRefName: item.pull_request?.head?.ref ?? '',
-        baseRefName: item.pull_request?.base?.ref ?? '',
-        state: 'OPEN',
-        author: item.user.login,
-        role,
-        updatedAt: item.updated_at,
-        additions: 0,
-        deletions: 0,
-        reviewDecision: null,
-        mergeable: null,
-        isDraft: false,
-        ciStatus: null,
-        repoName,
-        repoPath: wsPath,
-      });
-    }
-
-    // Sort by updatedAt descending
-    prs.sort(
-      (a, b) =>
-        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    const prs = mapSearchItemsToPrs(
+      searchResult.items,
+      repoMap,
+      currentUser,
+      'OPEN'
     );
-
-    // Update cache
+    sortByUpdatedDesc(prs);
     cache = { prs, fetchedAt: now };
 
-    // Fire ticket transitions check (best-effort, don't block response)
-    // Include recently merged PRs for MERGED->ready-for-qa transitions
-    if (deps.checkPrTransitions && deps.getBranchLinks) {
-      const transitionPrs = [...prs];
+    fireTransitionChecks(prs, repoMap, currentUser, exec, deps);
 
-      // Fetch recently merged PRs (last 7 days) for transition checks
-      try {
-        const mergedSince = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-          .toISOString()
-          .split('T')[0];
-        const { stdout: mergedStdout } = await exec(
-          'gh',
-          [
-            'api',
-            `search/issues?q=is:pr+is:merged+merged:>=${mergedSince}+involves:@me&per_page=50`,
-          ],
-          { timeout: GH_TIMEOUT_MS }
-        );
-        const mergedResponse = JSON.parse(mergedStdout) as GhSearchResponse;
-        for (const item of mergedResponse.items ?? []) {
-          if (!item.pull_request) continue;
-          const ownerRepo = repoFromApiUrl(item.repository_url);
-          if (!ownerRepo) continue;
-          const wsPath = repoMap.get(ownerRepo.toLowerCase());
-          if (!wsPath) continue;
-          transitionPrs.push({
-            number: item.number,
-            title: item.title,
-            url: item.html_url,
-            headRefName: item.pull_request?.head?.ref ?? '',
-            baseRefName: item.pull_request?.base?.ref ?? '',
-            state: 'MERGED',
-            author: item.user.login,
-            role: 'author',
-            updatedAt: item.updated_at,
-            additions: 0,
-            deletions: 0,
-            reviewDecision: null,
-            mergeable: null,
-            isDraft: false,
-            ciStatus: null,
-            repoName: path.basename(wsPath),
-            repoPath: wsPath,
-          });
-        }
-      } catch {
-        // Merged PR fetch is best-effort — don't block transitions
-      }
-
-      deps
-        .getBranchLinks()
-        .then((links) => deps.checkPrTransitions!(transitionPrs, links))
-        .catch(() => {});
-    }
-
-    const response: PullRequestsResponse = { prs };
-    res.json(response);
+    res.json({ prs } satisfies PullRequestsResponse);
   });
 
   return router;


### PR DESCRIPTION
## Summary

- Consolidate duplicate PR row implementations from OrgDashboard and RepoDashboard into a single shared `PrRow` component with consistent styling, hover states, keyboard accessibility, and external link icons
- Fix missing PRs on the All Workspaces homepage caused by over-aggressive server-side filtering (dropped PRs involving team reviews or past reviews)
- Fix Relay logo not navigating to `/` when clicked

## Changes

- **New `PrRow` component**: Shared row with status dot, external link icon, action buttons, "open" chevron button, and full row click-to-open behavior. Keyboard accessible (`role="button"`, `tabIndex`, Enter/Space)
- **Server fix**: Remove re-filtering of `involves:@me` results in `org-dashboard.ts` — trust GitHub's search relevance
- **Server refactor**: Extract helper functions from route handler to satisfy eslint complexity rules (was 46, limit 20)
- **Sidebar fix**: Clear `analyticsView` in `handleHomeBrand` so clicking Relay logo navigates to `/`
- **Session handlers**: Use `pr.repoPath` as primary source for org-level PR operations (no `activeRepoPath` dependency)
- **Cleanup**: Delete ~475 lines of duplicate CSS/TSX across both dashboards

## Testing

- All 1074 tests pass, 82 test files
- Build succeeds with no TypeScript errors
- ESLint passes on all changed files (complexity now under limits)

---
*Created with `/pr:author`*