### PR TITLE
fix: dialog content visible on mobile — CSS cascade override of dialog hidden state

### DIFF
--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -452,3 +452,39 @@ When a server has a canonical settings resolution function (e.g., `resolveSessio
 When migrating a UI framework (e.g., Svelte → React), raw `<button>` elements in non-primary positions are the most likely elements to be left unconverted. The migration agent typically converts the "obvious" action buttons (PR row actions, form submits) but misses secondary buttons embedded in sub-components: error state retries, filter management delete buttons, confirmation inline actions. After any framework migration, run a grep for `<button` in all migrated component files and verify each instance either (a) uses the project's design-system button component (`TuiButton`), or (b) is an intentional pattern-exception with a CSS class that reproduces equivalent design-system styling (e.g., tab strip navigation). Bespoke CSS that re-implements button styling is a red flag — it means the component was migrated structurally but not visually.
 
 ---
+
+### L-20260404-dialog-display-cascade: Never set `display` unconditionally on `<dialog>` elements — author CSS overrides the UA hidden state
+
+- status: active
+- category: debugging
+- scope: universal
+- source: /harness:bug 2026-04-04
+- branch: everest-24bf
+
+The HTML `<dialog>` element is hidden when not open via the browser's UA stylesheet: `dialog:not([open]) { display: none }`. If an author stylesheet sets `display: flex` (or `grid`, `block`, etc.) on the `<dialog>` element without qualifying with `[open]`, the author rule wins — because author stylesheets always beat UA stylesheets in the CSS cascade, regardless of specificity. The dialog content then renders in normal DOM flow even though `.showModal()` was never called. On mobile, where the main app container is `position: fixed`, the unintentionally-visible dialog paints on top of the app. Always either: (1) apply layout `display` only to `dialog[open]` or a child wrapper element, or (2) add an explicit `.dialog-class:not([open]) { display: none; }` rule alongside any `display` override.
+
+---
+
+### L-20260404-dialog-layout-wrapper: Apply layout properties to a child wrapper inside `<dialog>`, not the dialog element itself
+
+- status: active
+- category: architecture
+- scope: universal
+- source: /harness:bug 2026-04-04
+- branch: everest-24bf
+
+The `<dialog>` element has special browser-managed display semantics (hidden when not open, top-layer when modal). Setting layout properties (`display: flex`, `flex-direction`, `overflow`) directly on the `<dialog>` element risks overriding these semantics. Instead, structure dialog components as `<dialog><div class="wrapper">...</div></dialog>` and apply all layout CSS to the wrapper. The `<dialog>` element itself should only receive cosmetic properties (background, border, width, max-height) that don't interfere with the UA stylesheet's display management. This project's `WorkspaceSettingsDialog` follows this pattern correctly (`.workspace-settings-dialog-content` wrapper), while `DialogShell` applies `display: flex` directly to the `<dialog>`, causing the bug.
+
+---
+
+### L-20260404-dialog-visibility-test: Page-load tests should assert that no dialog content is visible without user interaction
+
+- status: active
+- category: testing
+- scope: repo
+- source: /harness:bug 2026-04-04
+- branch: everest-24bf
+
+When a project uses multiple `<dialog>` elements with custom CSS, add a structural test that runs after page boot and asserts: (1) `document.querySelectorAll('dialog[open]')` is empty, and (2) no dialog content is within the visible viewport. This catches CSS cascade issues where author styles accidentally override the UA's `display: none` for non-open dialogs. The test is especially important on mobile viewports where fixed-position main containers change paint order.
+
+---

--- a/docs/bug-analyses/2026-04-04-mobile-add-repo-modal-always-open-bug-analysis.md
+++ b/docs/bug-analyses/2026-04-04-mobile-add-repo-modal-always-open-bug-analysis.md
@@ -1,0 +1,104 @@
+# Bug Analysis: Add Repo modal always open on mobile after launching
+
+> **Status**: Confirmed | **Date**: 2026-04-04
+> **Severity**: High
+> **Affected Area**: `frontend/src/components/dialogs/DialogShell.css`
+
+## Symptoms
+- On mobile devices, the "add repo" modal content is visible immediately after launching the app, without any user interaction
+- The modal appears rendered in normal page flow, overlaying the main app content
+- On desktop, the same issue exists but is far less noticeable due to viewport size and stacking contexts
+
+## Reproduction Steps
+1. Open Relay IDE on a mobile device (or use mobile viewport in devtools)
+2. Observe the "add repo" dialog content rendered on screen immediately after boot
+3. No user action required — the dialog content is visible on page load
+
+## Root Cause
+
+**CSS cascade override of `<dialog>` hidden state.**
+
+`DialogShell.css:14` sets `display: flex` on `.dialog-shell`, the class applied directly to the `<dialog>` HTML element:
+
+```css
+/* DialogShell.css:12-16 */
+.dialog-shell {
+  ...
+  display: flex;
+  flex-direction: column;
+}
+```
+
+The HTML `<dialog>` element is hidden by default via the browser's UA stylesheet:
+```css
+/* Browser UA stylesheet */
+dialog:not([open]) {
+  display: none;
+}
+```
+
+**The CSS cascade resolves `display: flex` as the winner** because author stylesheets always take precedence over UA stylesheets, regardless of specificity. This causes ALL `<dialog>` elements using DialogShell to render their content in normal DOM flow even when `.showModal()` has not been called.
+
+### Why mobile-only (or much more visible on mobile)
+
+1. **Mobile layout creates paint-order issue** (`App.css:132-137`): On mobile, `.main-app` has `position: fixed; inset: 0`, removing it from normal flow. The dialog elements (siblings of `.main-app` in the DOM at `App.tsx:832-856`) are in normal flow and paint ON TOP of the fixed main-app due to later DOM order.
+
+2. **Dialog covers ~95% of mobile viewport**: `.dialog-shell--compact { width: min(var(--dialog-width, 460px), 95vw) }` — on a 375px mobile viewport, this is ~356px, covering nearly the entire screen.
+
+3. **Desktop mitigation**: The sidebar (`z-index: 100; position: relative`) creates a higher stacking context. The 520px dialog is a smaller fraction of a desktop viewport (~36% of 1440px). The issue technically exists on desktop but is far less prominent.
+
+## Evidence
+- `DialogShell.css:14` — `display: flex` set on `.dialog-shell` with no `[open]` qualifier
+- `DialogShell.tsx:117` — `<dialog>` element receives className `dialog-shell`
+- No `dialog:not([open]) { display: none }` rule exists anywhere in the author stylesheets (confirmed via grep)
+- `App.tsx:838-841` — `<AddWorkspaceDialog>` rendered outside `.main-app`, in normal DOM flow
+- `App.css:132-137` — mobile `.main-app` is `position: fixed`, causing paint-order inversion with sibling dialogs
+- `WorkspaceSettingsDialog.css:1-10` — comparison: this dialog does NOT set `display` on the `<dialog>` element and is unaffected
+
+## Impact Assessment
+- **All DialogShell-based dialogs are affected**: AddWorkspaceDialog, SettingsDialog, CustomizeSessionDialog, DeleteWorktreeDialog (4 dialogs total)
+- AddWorkspaceDialog is the most visible because it contains a FileBrowser with substantial content that renders on mount
+- `WorkspaceSettingsDialog` uses its own `<dialog>` element without overriding display — NOT affected
+- The issue makes the app appear broken on mobile first launch, directly impacting first-time user experience
+
+## Recommended Fix Direction
+
+Add a single CSS rule to `DialogShell.css` that restores the browser's intended hidden behavior:
+
+```css
+.dialog-shell:not([open]) {
+  display: none;
+}
+```
+
+This is a one-line fix that resolves the issue for all DialogShell-based dialogs at once.
+
+## Architecture Review
+
+### Systemic Spread
+- `DialogShell.css:14` — the single source of the bug, affecting all 4 DialogShell consumers:
+  - `AddWorkspaceDialog.tsx` (via `DialogShell` component)
+  - `SettingsDialog.tsx` (via `DialogShell` component)
+  - `CustomizeSessionDialog.tsx` (via `DialogShell` component)
+  - `DeleteWorktreeDialog.tsx` (via `DialogShell` component)
+- `WorkspaceSettingsDialog.tsx:145` — uses its own `<dialog>` element but does NOT set `display` on it → not affected
+- No other `<dialog>` elements exist in the codebase
+
+### Design Gap
+The `<dialog>` element has special display semantics — it's hidden by default via UA stylesheet, and this hiding relies on `display: none`. Any author-level `display` override on a `<dialog>` element breaks this semantic. The project has no convention or guard against this:
+
+- **Missing constraint**: The DialogShell component sets `display: flex` directly on the `<dialog>` element. The intent was layout (flex column), but the side effect was overriding the browser's hidden state.
+- **Better design**: Either always pair `display` overrides on `<dialog>` with an explicit `:not([open]) { display: none }` rule, or apply `display: flex` only to `dialog[open]` / to a child wrapper element (like `WorkspaceSettingsDialog` does with `.workspace-settings-dialog-content`).
+
+### Testing Gaps
+- **Missing test cases:** A visual regression test or Playwright assertion like "after boot, `document.querySelectorAll('dialog[open]')` should be empty and no dialog content should be visible" would catch this immediately.
+- **Infrastructure gaps:** No CSS-level tests or visual snapshot tests exist for dialog visibility states. Given the project has 5+ dialog components, a structural test that validates dialog hidden state on page load would prevent this class of bug.
+
+### Harness Context Gaps
+- `docs/FRONTEND.md` does not mention `<dialog>` display semantics or the constraint that `display` must not be unconditionally overridden on `<dialog>` elements.
+- `DESIGN.md` does not cover dialog component conventions.
+- These are minor gaps — the fix is simple and self-documenting. A one-line note in FRONTEND.md under component conventions would prevent recurrence.
+
+## Harness Trace
+
+Insufficient run history — harness trace unavailable (no `.harness/` runtime directory).

--- a/docs/bug-analyses/index.md
+++ b/docs/bug-analyses/index.md
@@ -2,3 +2,4 @@
 
 - [2026-04-03-pr-table-ui-regressions-bug-analysis](2026-04-03-pr-table-ui-regressions-bug-analysis.md) — PR table button alignment, truncated age columns, missing semantic button colors, and phantom scroll fade (2026-04-03)
 - [2026-04-03-unstyled-pr-list-buttons-bug-analysis](2026-04-03-unstyled-pr-list-buttons-bug-analysis.md) — Preset delete and retry buttons in All Workspaces PR list using raw HTML instead of TuiButton (DYS-11, 2026-04-03)
+- [2026-04-04-mobile-add-repo-modal-always-open-bug-analysis](2026-04-04-mobile-add-repo-modal-always-open-bug-analysis.md) — DialogShell display:flex overrides UA dialog:not([open]) hidden state, rendering all dialogs on mobile (2026-04-04)

--- a/frontend/src/components/dialogs/DialogShell.css
+++ b/frontend/src/components/dialogs/DialogShell.css
@@ -15,6 +15,12 @@
   flex-direction: column;
 }
 
+/* Restore UA hidden state — author `display: flex` overrides the browser's
+   `dialog:not([open]) { display: none }` because author beats UA in the cascade. */
+.dialog-shell:not([open]) {
+  display: none;
+}
+
 /* ── Compact variant ── */
 .dialog-shell--compact {
   width: min(var(--dialog-width, 460px), 95vw);


### PR DESCRIPTION
## Summary

- **Root cause**: `DialogShell.css` set `display: flex` on the `<dialog>` element, overriding the browser's UA `dialog:not([open]) { display: none }` rule (author stylesheets always beat UA in the cascade)
- All 4 DialogShell-based dialogs rendered content in normal DOM flow even when not opened via `.showModal()`
- On mobile, `.main-app` is `position: fixed` so the dialog siblings painted on top, covering ~95% of the viewport

## Changes

- **One-line CSS fix**: Added `.dialog-shell:not([open]) { display: none }` to restore intended hidden behavior
- **Bug analysis**: Full root cause investigation with architecture review in `docs/bug-analyses/`
- **3 learnings**: dialog display cascade (universal), dialog layout wrapper pattern (universal), page-load dialog visibility test (repo)

## Test plan

- [x] `npm run build` passes
- [x] All 1074 tests pass across 82 test files (`npm test`)
- [ ] Verify on mobile device: no dialog content visible on app launch
- [ ] Verify dialogs still open/close correctly via sidebar "add repo" button and settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)