### PR TITLE
feat: Claude Code fullscreen mode setting

### DIFF
--- a/frontend/src/components/Terminal.css
+++ b/frontend/src/components/Terminal.css
@@ -14,16 +14,15 @@
   padding: 4px;
 }
 
-/* Claude Code fullscreen: lock terminal to viewport height, no overflow scroll */
 .terminal-wrapper.terminal-fullscreen {
-  height: 100vh;
-  max-height: 100vh;
-  flex: none;
+  flex: 1;
+  min-height: 0;
   overflow: hidden;
 }
 
 .terminal-wrapper.terminal-fullscreen .terminal-container {
   height: 100%;
+  min-height: 0;
   overflow: hidden;
 }
 

--- a/frontend/src/components/Terminal.css
+++ b/frontend/src/components/Terminal.css
@@ -14,6 +14,19 @@
   padding: 4px;
 }
 
+/* Claude Code fullscreen: lock terminal to viewport height, no overflow scroll */
+.terminal-wrapper.terminal-fullscreen {
+  height: 100vh;
+  max-height: 100vh;
+  flex: none;
+  overflow: hidden;
+}
+
+.terminal-wrapper.terminal-fullscreen .terminal-container {
+  height: 100%;
+  overflow: hidden;
+}
+
 .terminal-wrapper.drag-over {
   outline: 2px dashed var(--accent);
   outline-offset: -2px;

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -14,6 +14,8 @@ import { connectPtySocket, sendPtyData, sendPtyResize } from '../lib/ws.js';
 import { isMobileDevice } from '../lib/utils.js';
 import { uploadImage } from '../lib/api.js';
 import { useUiStore, DEFAULT_TERMINAL_FONT_SIZE } from '../lib/stores/ui.js';
+import { useConfigStore } from '../lib/stores/config.js';
+import { useSessionsStore } from '../lib/stores/sessions.js';
 import { clampFontSize, zoomPercentage } from '../lib/terminal-zoom.js';
 import './Terminal.css';
 
@@ -922,6 +924,13 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
     const scrollbarRef = useRef<HTMLDivElement>(null);
     const thumbRef = useRef<HTMLDivElement>(null);
 
+    const claudeFullscreen = useConfigStore((s) => s.claudeFullscreen);
+    const activeAgent = useSessionsStore((s) =>
+      s.sessions.find((sess) => sess.id === sessionId)?.agent
+    );
+    const isFullscreenTerminal =
+      claudeFullscreen && activeAgent === 'claude';
+
     const { termRef, fit } = useTerminalSetup(
       containerRef,
       sessionId,
@@ -978,6 +987,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
       'terminal-wrapper',
       dragOver ? 'drag-over' : '',
       selectionMode ? 'selection-mode' : '',
+      isFullscreenTerminal ? 'terminal-fullscreen' : '',
     ]
       .filter(Boolean)
       .join(' ');

--- a/frontend/src/components/dialogs/SettingsDialog.css
+++ b/frontend/src/components/dialogs/SettingsDialog.css
@@ -55,6 +55,14 @@
   border-bottom: 1px solid var(--border);
 }
 
+.settings-dialog-subsection-heading {
+  font-size: var(--font-size-sm);
+  color: var(--text);
+  margin: 0 0 8px;
+  padding: 0;
+  font-weight: normal;
+}
+
 .settings-dialog-search-input {
   background: var(--bg);
   border: 1px solid var(--border);

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -20,6 +20,7 @@ import {
   setDefaultYolo,
   setLaunchInTmux,
   setDefaultNotifications,
+  setClaudeFullscreen,
   checkVersion,
   triggerUpdate,
   fetchAnalyticsSize,
@@ -31,6 +32,7 @@ import {
   fetchDefaultYolo,
   fetchLaunchInTmux,
   fetchDefaultNotifications,
+  fetchClaudeFullscreen,
   fetchUpdateChannel,
   setUpdateChannel,
 } from '../../lib/api.js';
@@ -53,6 +55,7 @@ interface ConfigState {
   defaultYolo: boolean;
   launchInTmux: boolean;
   defaultNotifications: boolean;
+  claudeFullscreen: boolean;
 }
 
 const DEFAULT_CONFIG: ConfigState = {
@@ -61,10 +64,16 @@ const DEFAULT_CONFIG: ConfigState = {
   defaultYolo: false,
   launchInTmux: false,
   defaultNotifications: true,
+  claudeFullscreen: true,
 };
 
 const TOC_SECTIONS = [
   { id: 'section-general', label: 'general' },
+  {
+    id: 'section-agents',
+    label: 'agents',
+    children: [{ id: 'agent-claude-code', label: 'Claude Code' }],
+  },
   {
     id: 'section-integrations',
     label: 'integrations',
@@ -86,6 +95,7 @@ const SECTION_KEYWORDS: Record<string, string[]> = {
     'tmux',
     'notifications',
   ],
+  agents: ['claude', 'claude code', 'fullscreen', 'no flicker'],
   integrations: [
     'github',
     'webhooks',
@@ -100,7 +110,7 @@ const SECTION_KEYWORDS: Record<string, string[]> = {
 };
 
 async function loadConfig(): Promise<ConfigState> {
-  const [agent, cont, yolo, tmux, notif] = await Promise.all([
+  const [agent, cont, yolo, tmux, notif, fullscreen] = await Promise.all([
     fetchDefaultAgent().catch(() => DEFAULT_CONFIG.defaultAgent),
     fetchDefaultContinue().catch(() => DEFAULT_CONFIG.defaultContinue),
     fetchDefaultYolo().catch(() => DEFAULT_CONFIG.defaultYolo),
@@ -108,6 +118,7 @@ async function loadConfig(): Promise<ConfigState> {
     fetchDefaultNotifications().catch(
       () => DEFAULT_CONFIG.defaultNotifications
     ),
+    fetchClaudeFullscreen().catch(() => DEFAULT_CONFIG.claudeFullscreen),
   ]);
   return {
     defaultAgent: agent,
@@ -115,6 +126,7 @@ async function loadConfig(): Promise<ConfigState> {
     defaultYolo: yolo,
     launchInTmux: tmux,
     defaultNotifications: notif,
+    claudeFullscreen: fullscreen,
   };
 }
 
@@ -213,12 +225,24 @@ function useConfigHandlers(
       setError('Failed to update notifications default.');
     }
   }
+  async function handleClaudeFullscreenChange(v: boolean) {
+    const prev = config.claudeFullscreen;
+    setConfig((c) => ({ ...c, claudeFullscreen: v }));
+    setError('');
+    try {
+      await setClaudeFullscreen(v);
+    } catch {
+      setConfig((c) => ({ ...c, claudeFullscreen: prev }));
+      setError('Failed to update Claude fullscreen setting.');
+    }
+  }
   return {
     handleAgentChange,
     handleContinueChange,
     handleYoloChange,
     handleTmuxChange,
     handleNotifChange,
+    handleClaudeFullscreenChange,
   };
 }
 
@@ -417,6 +441,11 @@ const SettingsDialog = forwardRef<SettingsDialogHandle, SettingsDialogProps>(
               searchQuery={searchQuery}
               handlers={configHandlers}
             />
+            <AgentsSection
+              config={config}
+              searchQuery={searchQuery}
+              handlers={configHandlers}
+            />
             <IntegrationsSection
               searchQuery={searchQuery}
               githubConnected={githubConnected}
@@ -521,6 +550,37 @@ function GeneralSection({
           checked={config.defaultNotifications}
           onChange={(v) => void handlers.handleNotifChange(v)}
           disabled={notifDisabled}
+        />
+      </SettingRow>
+    </section>
+  );
+}
+
+function AgentsSection({
+  config,
+  searchQuery,
+  handlers,
+}: {
+  config: ConfigState;
+  searchQuery: string;
+  handlers: ConfigHandlers;
+}) {
+  return (
+    <section
+      id="section-agents"
+      className={sectionClass('section-agents', searchQuery)}
+    >
+      <h3 className="settings-dialog-section-heading">agents</h3>
+      <h4 id="agent-claude-code" className="settings-dialog-subsection-heading">
+        Claude Code
+      </h4>
+      <SettingRow
+        name="Fullscreen mode"
+        description="Lock terminal to viewport height — Claude handles scrolling internally"
+      >
+        <TuiCheckbox
+          checked={config.claudeFullscreen}
+          onChange={(v) => void handlers.handleClaudeFullscreenChange(v)}
         />
       </SettingRow>
     </section>

--- a/frontend/src/components/dialogs/SettingsDialog.tsx
+++ b/frontend/src/components/dialogs/SettingsDialog.tsx
@@ -37,6 +37,7 @@ import {
   setUpdateChannel,
 } from '../../lib/api.js';
 import { useSessionsStore } from '../../lib/stores/sessions.js';
+import { useConfigStore } from '../../lib/stores/config.js';
 import {
   requestPermission,
   getPermissionState,
@@ -231,6 +232,7 @@ function useConfigHandlers(
     setError('');
     try {
       await setClaudeFullscreen(v);
+      await useConfigStore.getState().refreshConfig();
     } catch {
       setConfig((c) => ({ ...c, claudeFullscreen: prev }));
       setError('Failed to update Claude fullscreen setting.');

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -581,6 +581,10 @@ export const fetchDefaultNotifications = () =>
   fetchConfigBool('defaultNotifications');
 export const setDefaultNotifications = (v: boolean) =>
   setConfigBool('defaultNotifications', v);
+export const fetchClaudeFullscreen = () =>
+  fetchConfigBool('claudeFullscreen');
+export const setClaudeFullscreen = (v: boolean) =>
+  setConfigBool('claudeFullscreen', v);
 
 export async function fetchVapidKey(): Promise<string | null> {
   try {

--- a/frontend/src/lib/stores/config.ts
+++ b/frontend/src/lib/stores/config.ts
@@ -7,6 +7,7 @@ export interface ConfigState {
   launchInTmux: boolean;
   defaultAgent: string;
   defaultNotifications: boolean;
+  claudeFullscreen: boolean;
   refreshConfig: () => Promise<void>;
 }
 
@@ -16,15 +17,17 @@ export const useConfigStore = create<ConfigState>()((set, get) => ({
   launchInTmux: false,
   defaultAgent: 'claude',
   defaultNotifications: true,
+  claudeFullscreen: true,
 
   refreshConfig: async () => {
     const s = get();
-    const [cont, yolo, tmux, agent, notif] = await Promise.all([
+    const [cont, yolo, tmux, agent, notif, fullscreen] = await Promise.all([
       api.fetchDefaultContinue().catch(() => s.defaultContinue),
       api.fetchDefaultYolo().catch(() => s.defaultYolo),
       api.fetchLaunchInTmux().catch(() => s.launchInTmux),
       api.fetchDefaultAgent().catch(() => s.defaultAgent),
       api.fetchDefaultNotifications().catch(() => s.defaultNotifications),
+      api.fetchClaudeFullscreen().catch(() => s.claudeFullscreen),
     ]);
     set({
       defaultContinue: cont,
@@ -32,6 +35,7 @@ export const useConfigStore = create<ConfigState>()((set, get) => ({
       launchInTmux: tmux,
       defaultAgent: agent,
       defaultNotifications: notif,
+      claudeFullscreen: fullscreen,
     });
   },
 }));

--- a/server/config.ts
+++ b/server/config.ts
@@ -39,6 +39,7 @@ export const DEFAULTS: Omit<
   defaultYolo: false,
   launchInTmux: false,
   defaultNotifications: true,
+  claudeFullscreen: true,
   updateChannel: 'stable',
 };
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -498,6 +498,7 @@ type AgentSessionParams = {
   needsBranchRename: boolean;
   branchRenamePrompt: string;
   computedInitialPrompt: string | undefined;
+  claudeFullscreen: boolean;
 };
 
 /** Creates an agent session record and writes worktree metadata if applicable. */
@@ -518,6 +519,7 @@ function createAgentSessionRecord(params: AgentSessionParams): CreateResult {
     yolo: params.resolvedYolo,
     claudeArgs: params.resolvedClaudeArgs,
     continuePolicy: params.resolvedContinuePolicy,
+    claudeFullscreen: params.claudeFullscreen,
     ...(params.safeCols != null && { cols: params.safeCols }),
     ...(params.safeRows != null && { rows: params.safeRows }),
     needsBranchRename: params.needsBranchRename,
@@ -1011,7 +1013,8 @@ async function main(): Promise<void> {
         branchName: string;
         initialPrompt?: string;
       }) => {
-        const resolved = resolveSessionSettings(getConfig(), opts.repoPath, {});
+        const freshCfg = getConfig();
+        const resolved = resolveSessionSettings(freshCfg, opts.repoPath, {});
         const repoName =
           opts.repoPath.split('/').filter(Boolean).pop() || 'session';
         const displayName = sessions.nextAgentName();
@@ -1032,6 +1035,7 @@ async function main(): Promise<void> {
           useTmux: resolved.useTmux,
           yolo: resolved.yolo,
           claudeArgs: resolved.claudeArgs,
+          claudeFullscreen: freshCfg.claudeFullscreen ?? true,
           ...(opts.initialPrompt != null && {
             initialPrompt: opts.initialPrompt,
           }),
@@ -1432,6 +1436,7 @@ async function main(): Promise<void> {
     await execFileAsync('tmux', ['-V']);
   });
   boolConfigEndpoints('defaultNotifications', true);
+  boolConfigEndpoints('claudeFullscreen', true);
   boolConfigEndpoints('autoProvision', false);
 
   // GET /config/automations — get automation settings
@@ -1878,6 +1883,7 @@ async function main(): Promise<void> {
       needsBranchRename: needsBranchRename ?? false,
       branchRenamePrompt: branchRenamePrompt ?? '',
       computedInitialPrompt,
+      claudeFullscreen: freshConfig.claudeFullscreen ?? true,
     });
 
     gitWatcher.watch(session.cwd);

--- a/server/index.ts
+++ b/server/index.ts
@@ -1035,7 +1035,7 @@ async function main(): Promise<void> {
           useTmux: resolved.useTmux,
           yolo: resolved.yolo,
           claudeArgs: resolved.claudeArgs,
-          claudeFullscreen: freshCfg.claudeFullscreen ?? true,
+          claudeFullscreen: freshCfg.claudeFullscreen,
           ...(opts.initialPrompt != null && {
             initialPrompt: opts.initialPrompt,
           }),
@@ -1883,7 +1883,7 @@ async function main(): Promise<void> {
       needsBranchRename: needsBranchRename ?? false,
       branchRenamePrompt: branchRenamePrompt ?? '',
       computedInitialPrompt,
-      claudeFullscreen: freshConfig.claudeFullscreen ?? true,
+      claudeFullscreen: freshConfig.claudeFullscreen,
     });
 
     gitWatcher.watch(session.cwd);

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -299,6 +299,7 @@ export type CreatePtyParams = {
   hooksActive?: boolean | undefined;
   continuePolicy?: ContinuePolicy | undefined;
   frameworks?: Record<string, Partial<AgentFramework>> | undefined;
+  claudeFullscreen?: boolean | undefined;
 };
 
 export type CreatePtyResult = SessionSummary & { pid: number | undefined };
@@ -341,6 +342,7 @@ export function createPtySession(
     hookToken: paramHookToken,
     hooksActive: paramHooksActive,
     frameworks,
+    claudeFullscreen: paramClaudeFullscreen,
   } = params;
 
   let args = rawArgs;
@@ -374,6 +376,12 @@ export function createPtySession(
     command || framework.commandOverride || framework.command;
 
   const env = cleanEnv();
+
+  // Inject CLAUDE_CODE_NO_FLICKER for Claude sessions when fullscreen mode is enabled.
+  // This tells Claude Code to use alternate-screen rendering (no flicker).
+  if (framework.id === 'claude' && paramClaudeFullscreen !== false) {
+    env.CLAUDE_CODE_NO_FLICKER = '1';
+  }
 
   // Inject Claude --settings hooks file for frameworks that use HTTP hook callbacks.
   // This is the Claude-specific hook mechanism; codex uses hooks.json (Task 7) and

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -377,9 +377,7 @@ export function createPtySession(
 
   const env = cleanEnv();
 
-  // Inject CLAUDE_CODE_NO_FLICKER for Claude sessions when fullscreen mode is enabled.
-  // This tells Claude Code to use alternate-screen rendering (no flicker).
-  if (framework.id === 'claude' && paramClaudeFullscreen !== false) {
+  if (framework.id === 'claude' && paramClaudeFullscreen === true) {
     env.CLAUDE_CODE_NO_FLICKER = '1';
   }
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -372,6 +372,7 @@ export interface Config {
   defaultYolo: boolean;
   launchInTmux: boolean;
   defaultNotifications: boolean;
+  claudeFullscreen: boolean;
   pinHash?: string | undefined;
   rootDirs?: string[] | undefined;
   workspaces?: Workspace[] | undefined;

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -25,6 +25,5 @@ export function semverLessThan(a: string, b: string): boolean {
 export function cleanEnv(): Record<string, string> {
   const env = Object.assign({}, process.env) as Record<string, string>;
   delete env.CLAUDECODE;
-  env.CLAUDE_CODE_NO_FLICKER = '1';
   return env;
 }


### PR DESCRIPTION
## Summary

- Adds a **Fullscreen mode** toggle under a new **Agents > Claude Code** section in global settings
- When enabled (default: `true`), the xterm terminal is locked to viewport height (`100vh`, no overflow scroll) for Claude sessions only — Claude handles scrolling internally via alternate screen mode
- The `CLAUDE_CODE_NO_FLICKER` env var (previously hardcoded) is now only injected when fullscreen mode is enabled and the session agent is Claude
- Other coding agents (Codex, OpenCode) are completely unaffected

## Changes

**Backend (5 files):**
- `server/types.ts` — add `claudeFullscreen` to `Config` interface
- `server/config.ts` — add `claudeFullscreen: true` to `DEFAULTS`
- `server/index.ts` — register `boolConfigEndpoints('claudeFullscreen', true)`, pass setting through session creation
- `server/pty-handler.ts` — accept `claudeFullscreen` param, conditionally inject `CLAUDE_CODE_NO_FLICKER` env var
- `server/utils.ts` — remove hardcoded `CLAUDE_CODE_NO_FLICKER` from `cleanEnv()`

**Frontend (6 files):**
- `frontend/src/lib/api.ts` — add `fetchClaudeFullscreen` / `setClaudeFullscreen` API helpers
- `frontend/src/lib/stores/config.ts` — add `claudeFullscreen` to Zustand config store
- `frontend/src/components/dialogs/SettingsDialog.tsx` — new Agents section with Claude Code subsection and fullscreen toggle
- `frontend/src/components/dialogs/SettingsDialog.css` — subsection heading style
- `frontend/src/components/Terminal.tsx` — apply `terminal-fullscreen` CSS class when Claude + fullscreen
- `frontend/src/components/Terminal.css` — `terminal-fullscreen` class locks height to viewport

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] All 1074 tests pass (`npm test`)
- [ ] Open Settings > Agents > Claude Code — verify fullscreen toggle is visible and defaults to on
- [ ] Toggle off — new Claude sessions should have normal scrollback behavior
- [ ] Toggle on — Claude sessions lock terminal to viewport height
- [ ] Create a Codex/OpenCode session — verify it behaves normally regardless of toggle state

🤖 Generated with [Claude Code](https://claude.com/claude-code)