### PR TITLE
fix: close sidebar on mobile when tapping repo dashboard

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -294,7 +294,8 @@ export function Sidebar({
   const handleSelectWorkspace = useCallback((path: string) => {
     useUiStore.setState({ activeRepoPath: path });
     useSessionsStore.getState().setActiveSessionId(null);
-  }, []);
+    closeSidebar();
+  }, [closeSidebar]);
   const handleHomeBrand = useCallback(() => {
     useUiStore.getState().setActiveRepoPath(null);
     useUiStore.getState().setAnalyticsView(null);


### PR DESCRIPTION
## Summary
- `handleSelectWorkspace` in `Sidebar.tsx` was missing the `closeSidebar()` call that every other sidebar navigation handler already had
- Tapping a repo header on mobile would navigate to the dashboard but leave the sidebar covering the screen

## Test plan
- [ ] On mobile (or ≤600px viewport), open sidebar, tap a repo header — sidebar should close
- [ ] Verify desktop sidebar behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)