### PR TITLE
feat: generate descriptive session names from first message

### DIFF
--- a/server/git.ts
+++ b/server/git.ts
@@ -240,6 +240,21 @@ function branchToDisplayName(branch: string): string {
   return words.charAt(0).toUpperCase() + words.slice(1);
 }
 
+/**
+ * Convert a descriptive phrase to a valid kebab-case git branch name.
+ * "Fix the mobile scroll overflow" → "fix-the-mobile-scroll-overflow"
+ * "Add user authentication"        → "add-user-authentication"
+ */
+function phraseToBranchName(phrase: string): string {
+  return phrase
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+}
+
 async function isBranchStale(
   repoPath: string,
   branch: string,
@@ -927,6 +942,7 @@ export {
   getCurrentBranch,
   getWorkingTreeDiff,
   branchToDisplayName,
+  phraseToBranchName,
   isBranchStale,
   extractOwnerRepo,
   buildRepoMap,

--- a/server/git.ts
+++ b/server/git.ts
@@ -226,21 +226,6 @@ async function getWorkingTreeDiff(
 }
 
 /**
- * Convert a git branch name to a human-readable display name.
- * "fix-mobile-scroll-bug" → "Fix mobile scroll bug"
- * "feature/add-auth"      → "Add auth"
- */
-function branchToDisplayName(branch: string): string {
-  const stripped = branch.replace(
-    /^(feature|fix|chore|refactor|docs|test|ci|build)\//i,
-    ''
-  );
-  const words = stripped.replace(/[-_]/g, ' ').trim();
-  if (!words) return branch;
-  return words.charAt(0).toUpperCase() + words.slice(1);
-}
-
-/**
  * Convert a descriptive phrase to a valid kebab-case git branch name.
  * "Fix the mobile scroll overflow" → "fix-the-mobile-scroll-overflow"
  * "Add user authentication"        → "add-user-authentication"
@@ -941,7 +926,6 @@ export {
   getCommitsAhead,
   getCurrentBranch,
   getWorkingTreeDiff,
-  branchToDisplayName,
   phraseToBranchName,
   isBranchStale,
   extractOwnerRepo,

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -9,7 +9,7 @@ import type { Request, Response } from 'express';
 import type { Session } from './types.js';
 import type { AgentState } from './output-parsers/index.js';
 import { stripAnsi, cleanEnv } from './utils.js';
-import { branchToDisplayName } from './git.js';
+import { phraseToBranchName } from './git.js';
 import { writeMeta } from './config.js';
 import { recordSessionEvent } from './analytics.js';
 import { createLogger } from './logger.js';
@@ -22,8 +22,15 @@ const logger = createLogger('hooks');
 // ---------------------------------------------------------------------------
 
 const LOCALHOST_ADDRS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
-const DEFAULT_RENAME_PROMPT =
-  'Output ONLY a short kebab-case git branch name (no explanation, no backticks, no prefix, just the name) that describes this task:';
+const DEFAULT_RENAME_PROMPT = `Output two lines (no explanation, no backticks, no quotes):
+Line 1: A short descriptive phrase (3-8 words) summarizing this task
+Line 2: A kebab-case git branch name for the same task
+
+Example:
+Fix sidebar disappearing on mobile
+fix-sidebar-disappearing-on-mobile
+
+Task:`;
 const RENAME_RETRY_DELAY_MS = 5000;
 const BRANCH_CHECK_DEBOUNCE_MS = 1000;
 
@@ -158,15 +165,33 @@ async function spawnBranchRename(
         { cwd: session.cwd, timeout: 30000, env }
       );
 
-      // Sanitize output
-      let branchName = stdout
+      // Parse two-line response: display name + branch name
+      const lines = stdout
         .replace(/`/g, '')
-        .replace(/[^a-zA-Z0-9-]/g, '-')
-        .replace(/-+/g, '-')
-        .replace(/^-+|-+$/g, '')
-        .toLowerCase()
-        .slice(0, 60);
+        .replace(/["']/g, '')
+        .trim()
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean);
 
+      if (!lines.length) continue;
+
+      let displayName = lines[0]!.slice(0, 80);
+      displayName =
+        displayName.charAt(0).toUpperCase() + displayName.slice(1);
+
+      // Use LLM-provided branch name if present, otherwise derive from phrase
+      let branchName: string;
+      if (lines.length >= 2) {
+        branchName = lines[1]!
+          .replace(/[^a-zA-Z0-9-]/g, '-')
+          .replace(/-+/g, '-')
+          .replace(/^-+|-+$/g, '')
+          .toLowerCase()
+          .slice(0, 60);
+      } else {
+        branchName = phraseToBranchName(displayName);
+      }
       if (!branchName) continue;
 
       // Check session still exists before renaming
@@ -177,7 +202,7 @@ async function spawnBranchRename(
       });
 
       session.branchName = branchName;
-      session.displayName = branchToDisplayName(branchName);
+      session.displayName = displayName;
       deps.broadcastEvent('session-renamed', {
         sessionId: session.id,
         branchName: session.branchName,

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -50,10 +50,6 @@ export interface HookDeps {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
 // Branch change detection — debounced per-session check via git
 // ---------------------------------------------------------------------------
 
@@ -176,22 +172,10 @@ async function spawnBranchRename(
 
       if (!lines.length) continue;
 
-      let displayName = lines[0]!.slice(0, 80);
-      displayName =
-        displayName.charAt(0).toUpperCase() + displayName.slice(1);
+      const raw = lines[0]!.slice(0, 80);
+      const displayName = raw.charAt(0).toUpperCase() + raw.slice(1);
 
-      // Use LLM-provided branch name if present, otherwise derive from phrase
-      let branchName: string;
-      if (lines.length >= 2) {
-        branchName = lines[1]!
-          .replace(/[^a-zA-Z0-9-]/g, '-')
-          .replace(/-+/g, '-')
-          .replace(/^-+|-+$/g, '')
-          .toLowerCase()
-          .slice(0, 60);
-      } else {
-        branchName = phraseToBranchName(displayName);
-      }
+      const branchName = phraseToBranchName(lines[1] ?? displayName);
       if (!branchName) continue;
 
       // Check session still exists before renaming

--- a/test/branch-rename.test.ts
+++ b/test/branch-rename.test.ts
@@ -1,6 +1,6 @@
 import { test, describe, expect } from 'vitest';
 import { MOUNTAIN_NAMES } from '../server/types.js';
-import { branchToDisplayName, phraseToBranchName } from '../server/git.js';
+import { phraseToBranchName } from '../server/git.js';
 
 describe('MOUNTAIN_NAMES', () => {
   test('contains 30 mountain names', () => {
@@ -29,28 +29,6 @@ describe('MOUNTAIN_NAMES', () => {
     expect(name1).toBe('whitney');
     expect(name2).toBe('hood');
     expect(name3).toBe('everest'); // wraps back to start
-  });
-});
-
-describe('branchToDisplayName', () => {
-  test('converts kebab-case to sentence case', () => {
-    expect(branchToDisplayName('fix-mobile-scroll-bug')).toBe(
-      'Fix mobile scroll bug'
-    );
-  });
-
-  test('strips common branch prefixes', () => {
-    expect(branchToDisplayName('feature/add-auth')).toBe('Add auth');
-    expect(branchToDisplayName('fix/api-timeout')).toBe('Api timeout');
-    expect(branchToDisplayName('chore/update-deps')).toBe('Update deps');
-  });
-
-  test('handles simple names', () => {
-    expect(branchToDisplayName('lhotse')).toBe('Lhotse');
-  });
-
-  test('handles underscores', () => {
-    expect(branchToDisplayName('fix_the_thing')).toBe('Fix the thing');
   });
 });
 

--- a/test/branch-rename.test.ts
+++ b/test/branch-rename.test.ts
@@ -1,6 +1,6 @@
 import { test, describe, expect } from 'vitest';
 import { MOUNTAIN_NAMES } from '../server/types.js';
-import { branchToDisplayName } from '../server/git.js';
+import { branchToDisplayName, phraseToBranchName } from '../server/git.js';
 
 describe('MOUNTAIN_NAMES', () => {
   test('contains 30 mountain names', () => {
@@ -51,5 +51,44 @@ describe('branchToDisplayName', () => {
 
   test('handles underscores', () => {
     expect(branchToDisplayName('fix_the_thing')).toBe('Fix the thing');
+  });
+});
+
+describe('phraseToBranchName', () => {
+  test('converts a phrase to kebab-case', () => {
+    expect(phraseToBranchName('Fix the mobile scroll overflow')).toBe(
+      'fix-the-mobile-scroll-overflow'
+    );
+  });
+
+  test('strips special characters', () => {
+    expect(phraseToBranchName("Add user's authentication!")).toBe(
+      'add-users-authentication'
+    );
+  });
+
+  test('collapses multiple spaces and hyphens', () => {
+    expect(phraseToBranchName('Fix  the   bug')).toBe('fix-the-bug');
+    expect(phraseToBranchName('fix--the--bug')).toBe('fix-the-bug');
+  });
+
+  test('trims leading and trailing hyphens', () => {
+    expect(phraseToBranchName(' -Fix the bug- ')).toBe('fix-the-bug');
+  });
+
+  test('truncates to 60 characters', () => {
+    const long =
+      'This is a very long descriptive phrase that should be truncated to sixty characters max';
+    const result = phraseToBranchName(long);
+    expect(result.length).toBeLessThanOrEqual(60);
+    expect(result).toBe(
+      'this-is-a-very-long-descriptive-phrase-that-should-be-trunca'
+    );
+  });
+
+  test('preserves numbers', () => {
+    expect(phraseToBranchName('Fix issue 42 in auth')).toBe(
+      'fix-issue-42-in-auth'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Session names were just humanized branch names (e.g. "Fix mobile scroll"), reading like slugs rather than descriptions
- LLM prompt now asks for both a descriptive phrase (session name) and a kebab-case branch name independently
- Falls back to `phraseToBranchName()` derivation if LLM only returns one line
- Added `phraseToBranchName` helper to `server/git.ts` with 6 unit tests

## Test plan
- [x] `test/branch-rename.test.ts` — 14 tests pass (6 new for `phraseToBranchName`)
- [x] `test/hooks-agent-event.test.ts` — 17 tests pass (no regressions)
- [x] Full build compiles cleanly
- [ ] Manual: create a new worktree session, verify session name is a natural phrase and branch is kebab-case

🤖 Generated with [Claude Code](https://claude.com/claude-code)