### PR TITLE
fix: hide tab bar when mobile keyboard opens, reduce toolbar padding

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -367,6 +367,7 @@ function TerminalAreaContent({
                   onNewAgent={() => onQuickAgent()}
                   onNewTerminal={() => onQuickTerminal()}
                   onCustomize={() => onCustomize()}
+                  hidden={keyboardOpen}
                 />
 
                 <Terminal

--- a/frontend/src/components/SessionTabBar.css
+++ b/frontend/src/components/SessionTabBar.css
@@ -190,6 +190,10 @@
     height: 44px;
   }
 
+  .session-tab-bar.hidden {
+    display: none;
+  }
+
   .tab {
     height: 44px;
     padding: 0 12px;

--- a/frontend/src/components/SessionTabBar.tsx
+++ b/frontend/src/components/SessionTabBar.tsx
@@ -10,6 +10,7 @@ export interface SessionTabBarProps {
   onNewAgent: () => void;
   onNewTerminal: () => void;
   onCustomize: () => void;
+  hidden?: boolean;
 }
 
 const terminalSvg = (
@@ -83,7 +84,7 @@ function SessionTab({ session, tabName, isActive, onSelect, onClose, onCloseKeyD
   );
 }
 
-export function SessionTabBar({ sessions, activeSessionId, onSelectSession, onCloseSession, onNewAgent, onNewTerminal, onCustomize }: SessionTabBarProps) {
+export function SessionTabBar({ sessions, activeSessionId, onSelectSession, onCloseSession, onNewAgent, onNewTerminal, onCustomize, hidden = false }: SessionTabBarProps) {
   const [newMenuOpen, setNewMenuOpen] = useState(false);
   const [tabNames, setTabNames] = useState<Map<string, string>>(new Map());
   const nextAgentIndexRef = useRef(0);
@@ -125,7 +126,7 @@ export function SessionTabBar({ sessions, activeSessionId, onSelectSession, onCl
   };
 
   return (
-    <div className="session-tab-bar" role="tablist" aria-label="Sessions">
+    <div className={`session-tab-bar${hidden ? ' hidden' : ''}`} role="tablist" aria-label="Sessions">
       <div className="tabs-scroll">
         {sessions.map((session) => (
           <SessionTab

--- a/frontend/src/components/Toolbar.css
+++ b/frontend/src/components/Toolbar.css
@@ -51,3 +51,10 @@
 .tb-arrow {
   font-size: var(--font-size-base);
 }
+
+@media (max-width: 600px) {
+  .tb-btn {
+    padding: 4px 4px;
+    min-height: 36px;
+  }
+}


### PR DESCRIPTION
## Summary

- **Mobile keyboard UX:** Hide the session tab bar when the soft keyboard is open on mobile, reclaiming screen space for the terminal and input area
- **Toolbar compactness:** Reduce vertical padding and min-height on toolbar buttons for mobile (44px → 36px) so the toolbar takes up less room

## Test Coverage

No new application code paths — CSS-only changes with a boolean prop passthrough.

## Pre-Landing Review

No issues found.

## Test plan
- [x] All vitest tests pass (82 files, 1079 tests)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)