### PR TITLE
fix: sidebar shows branch name instead of session display name for worktrees

### DIFF
--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -70,9 +70,12 @@ export function groupDisplayName(
     }
     return 'default';
   }
+  const firstSession = sessions[0];
+  const wasRenamed = firstSession?.displayName && firstSession.displayName !== firstSession.repoName;
+  if (wasRenamed) return firstSession.displayName;
   const branch = sessions.find((s) => s.branchName)?.branchName;
-  const cwdName = sessions[0]?.cwd.split('/').pop();
-  return branch || cwdName || sessions[0]?.repoName || 'unknown';
+  const cwdName = firstSession?.cwd.split('/').pop();
+  return branch || cwdName || firstSession?.repoName || 'unknown';
 }
 
 interface PrStatusBadgeProps {

--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -70,12 +70,11 @@ export function groupDisplayName(
     }
     return 'default';
   }
-  const firstSession = sessions[0];
-  const wasRenamed = firstSession?.displayName && firstSession.displayName !== firstSession.repoName;
-  if (wasRenamed) return firstSession.displayName;
+  const renamedSession = sessions.find((s) => s.displayName && s.displayName !== s.repoName);
+  if (renamedSession) return renamedSession.displayName;
   const branch = sessions.find((s) => s.branchName)?.branchName;
-  const cwdName = firstSession?.cwd.split('/').pop();
-  return branch || cwdName || firstSession?.repoName || 'unknown';
+  const cwdName = sessions[0]?.cwd.split('/').pop();
+  return branch || cwdName || sessions[0]?.repoName || 'unknown';
 }
 
 interface PrStatusBadgeProps {

--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -259,6 +259,17 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
       sessions: state.sessions.map((s) =>
         s.id === sessionId ? { ...s, branchName, displayName } : s
       ),
+      sidebarItems: state.sidebarItems.map((item) => {
+        if (!item.sessions.some((s) => s.id === sessionId)) return item;
+        return {
+          ...item,
+          branchName,
+          displayName,
+          sessions: item.sessions.map((s) =>
+            s.id === sessionId ? { ...s, branchName, displayName } : s
+          ),
+        };
+      }),
     }));
   },
 

--- a/test/group-display-name.test.ts
+++ b/test/group-display-name.test.ts
@@ -66,6 +66,61 @@ describe('groupDisplayName', () => {
     );
   });
 
+  // ── Multi-session groups ─────────────────────────────────────────────
+
+  it('multi-session group uses renamed session regardless of array order', () => {
+    const unrenamed = makeSession({
+      id: 's1',
+      worktreePath: '/repo/wt1',
+      repoName: 'relay-ide',
+      displayName: 'relay-ide',
+      branchName: 'fix-sidebar-bug',
+      cwd: '/repo/wt1',
+      lastActivity: '2026-04-05T12:00:00Z',
+    });
+    const renamed = makeSession({
+      id: 's2',
+      worktreePath: '/repo/wt1',
+      repoName: 'relay-ide',
+      displayName: 'Fix sidebar disappearing on mobile',
+      branchName: 'fix-sidebar-bug',
+      cwd: '/repo/wt1',
+      lastActivity: '2026-04-05T11:00:00Z',
+    });
+    // Renamed session is second — should still be found
+    expect(groupDisplayName('/repo/wt1', '/repo', [unrenamed, renamed])).toBe(
+      'Fix sidebar disappearing on mobile'
+    );
+    // Reversed order — same result
+    expect(groupDisplayName('/repo/wt1', '/repo', [renamed, unrenamed])).toBe(
+      'Fix sidebar disappearing on mobile'
+    );
+  });
+
+  it('multi-session group falls back to branchName when no session is renamed', () => {
+    const s1 = makeSession({
+      id: 's1',
+      worktreePath: '/repo/wt1',
+      repoName: 'relay-ide',
+      displayName: 'relay-ide',
+      branchName: 'fix-sidebar-bug',
+      cwd: '/repo/wt1',
+    });
+    const s2 = makeSession({
+      id: 's2',
+      worktreePath: '/repo/wt1',
+      repoName: 'relay-ide',
+      displayName: '',
+      branchName: 'fix-sidebar-bug',
+      cwd: '/repo/wt1',
+    });
+    expect(groupDisplayName('/repo/wt1', '/repo', [s1, s2])).toBe(
+      'fix-sidebar-bug'
+    );
+  });
+
+  // ── Fallbacks ──────────────────────────────────────────────────────────
+
   it('worktree session falls back to cwd basename when no branchName', () => {
     const session = makeSession({
       worktreePath: '/repo/wt1',

--- a/test/group-display-name.test.ts
+++ b/test/group-display-name.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { groupDisplayName } from '../frontend/src/components/RepoItem.js';
+import { makeSession } from './helpers/frontend-factories.js';
+
+describe('groupDisplayName', () => {
+  // ── Repo-root sessions ──────────────────────────────────────────────────
+
+  it('repo-root session with displayName different from repoName uses displayName', () => {
+    const session = makeSession({
+      worktreePath: null,
+      repoName: 'relay-ide',
+      displayName: 'Fix sidebar disappearing on mobile',
+    });
+    expect(groupDisplayName('/repo', '/repo', [session])).toBe(
+      'Fix sidebar disappearing on mobile'
+    );
+  });
+
+  it('repo-root session with displayName matching repoName returns "default"', () => {
+    const session = makeSession({
+      worktreePath: null,
+      repoName: 'relay-ide',
+      displayName: 'relay-ide',
+    });
+    expect(groupDisplayName('/repo', '/repo', [session])).toBe('default');
+  });
+
+  // ── Worktree sessions ──────────────────────────────────────────────────
+
+  it('worktree session uses displayName when it differs from repoName', () => {
+    const session = makeSession({
+      worktreePath: '/repo/wt1',
+      repoName: 'relay-ide',
+      displayName: 'Fix sidebar disappearing on mobile',
+      branchName: 'fix-sidebar-disappearing-on-mobile',
+      cwd: '/repo/wt1',
+    });
+    expect(groupDisplayName('/repo/wt1', '/repo', [session])).toBe(
+      'Fix sidebar disappearing on mobile'
+    );
+  });
+
+  it('worktree session falls back to branchName when displayName matches repoName', () => {
+    const session = makeSession({
+      worktreePath: '/repo/wt1',
+      repoName: 'relay-ide',
+      displayName: 'relay-ide',
+      branchName: 'fix-sidebar-bug',
+      cwd: '/repo/wt1',
+    });
+    expect(groupDisplayName('/repo/wt1', '/repo', [session])).toBe(
+      'fix-sidebar-bug'
+    );
+  });
+
+  it('worktree session falls back to branchName when displayName is empty', () => {
+    const session = makeSession({
+      worktreePath: '/repo/wt1',
+      repoName: 'relay-ide',
+      displayName: '',
+      branchName: 'fix-sidebar-bug',
+      cwd: '/repo/wt1',
+    });
+    expect(groupDisplayName('/repo/wt1', '/repo', [session])).toBe(
+      'fix-sidebar-bug'
+    );
+  });
+
+  it('worktree session falls back to cwd basename when no branchName', () => {
+    const session = makeSession({
+      worktreePath: '/repo/wt1',
+      repoName: 'relay-ide',
+      displayName: 'relay-ide',
+      branchName: '',
+      cwd: '/repo/wt1',
+    });
+    expect(groupDisplayName('/repo/wt1', '/repo', [session])).toBe('wt1');
+  });
+});


### PR DESCRIPTION
## Summary

Worktree sessions in the sidebar displayed the raw kebab-case branch name (e.g., "hide-tab-bar-mobile-reduce-padd") instead of the descriptive session name generated by PR #163. The root cause was a DRY violation: displayName/branchName were stored in three separate copies that got out of sync, and the rendering function ignored displayName entirely for worktree sessions.

## Changes

- **RepoItem.tsx**: `groupDisplayName()` now checks `displayName` for worktree sessions (same logic repo-root sessions already used), falling back to branchName only when displayName hasn't been set
- **sessions.ts**: `renameSession()` now propagates updates to all three data copies (sessions[], sidebarItems top-level fields, and sidebarItems embedded sessions[]) — matching the pattern `handleBranchChanged` already followed
- **test/group-display-name.test.ts**: 6 regression tests covering both repo-root and worktree display name derivation

## Testing

- 6 new tests verify worktree sessions use displayName when available, fall back to branchName when not
- Full test suite: 1080/1085 pass (5 pre-existing failures from missing build artifacts in worktree)
- Verified `groupDisplayName` returns descriptive name for worktree sessions and "default" for unnamed repo-root sessions

---
*Created with `/pr:author`*