### PR TITLE
fix: broadcast worktrees-changed on creation so other devices update

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -826,6 +826,7 @@ async function main(): Promise<void> {
   // Mount workspace router — rebuild watchers when workspaces are added or removed
   const workspaceRouter = createWorkspaceRouter({
     configPath: CONFIG_PATH,
+    onWorktreeCreated: () => broadcastEvent('worktrees-changed'),
     onWorkspacesChanged: () => {
       setImmediate(() => {
         try {

--- a/server/watcher.ts
+++ b/server/watcher.ts
@@ -185,6 +185,12 @@ export class WorktreeWatcher extends EventEmitter {
     this._closeAll();
 
     for (const rootDir of rootDirs) {
+      // config.repos stores individual repo paths — watch directly if rootDir is a repo
+      if (fs.existsSync(path.join(rootDir, '.git'))) {
+        this._watchRepo(rootDir);
+        continue;
+      }
+      // Fallback: rootDir may be a parent directory containing repos
       let entries: fs.Dirent[];
       try {
         entries = fs.readdirSync(rootDir, { withFileTypes: true });
@@ -271,6 +277,12 @@ export class BranchWatcher {
     this._closeAll();
 
     for (const rootDir of rootDirs) {
+      // config.repos stores individual repo paths — watch directly if rootDir is a repo
+      if (fs.existsSync(path.join(rootDir, '.git'))) {
+        this._watchRepoHeads(rootDir);
+        continue;
+      }
+      // Fallback: rootDir may be a parent directory containing repos
       let entries: fs.Dirent[];
       try {
         entries = fs.readdirSync(rootDir, { withFileTypes: true });

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -975,7 +975,16 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
           lastActivity: new Date().toISOString(),
           branchName: result.branchName,
         });
-        if (!result.existing) deps.onWorktreeCreated?.();
+        if (!result.existing) {
+          try {
+            deps.onWorktreeCreated?.();
+          } catch (err) {
+            logger.error(
+              'onWorktreeCreated callback failed:',
+              err instanceof Error ? err.message : err
+            );
+          }
+        }
         res.json({
           branchName: result.branchName,
           mountainName: meta?.displayName || result.dirName,
@@ -1046,7 +1055,11 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
       branchName,
     });
 
-    deps.onWorktreeCreated?.();
+    try {
+      deps.onWorktreeCreated?.();
+    } catch (err) {
+      logger.error('onWorktreeCreated callback failed:', err);
+    }
     res.json({ branchName, mountainName, worktreePath });
   });
 

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -105,6 +105,8 @@ export interface WorkspaceDeps {
   execAsync?: typeof execFileAsync;
   /** Called after any workspace mutation (add, remove, reorder, bulk-add) so watchers can rebuild */
   onWorkspacesChanged?: () => void;
+  /** Called after a worktree is created so all connected clients refresh */
+  onWorktreeCreated?: () => void;
 }
 
 // Exported helpers
@@ -973,6 +975,7 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
           lastActivity: new Date().toISOString(),
           branchName: result.branchName,
         });
+        if (!result.existing) deps.onWorktreeCreated?.();
         res.json({
           branchName: result.branchName,
           mountainName: meta?.displayName || result.dirName,
@@ -1043,6 +1046,7 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
       branchName,
     });
 
+    deps.onWorktreeCreated?.();
     res.json({ branchName, mountainName, worktreePath });
   });
 

--- a/test/worktrees.test.ts
+++ b/test/worktrees.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
 import {
   WORKTREE_DIRS,
   isValidWorktreePath,
   parseWorktreeListPorcelain,
   parseAllWorktrees,
   findOrCreateWorktreeForBranch,
+  WorktreeWatcher,
 } from '../server/watcher.js';
 import { MOUNTAIN_NAMES } from '../server/types.js';
 import { generateTmuxSessionName } from '../server/pty-handler.js';
@@ -661,5 +665,65 @@ describe('findOrCreateWorktreeForBranch', () => {
     expect(result.existing).toBe(false);
     expect(result.isMain).toBe(false);
     expect(result.branchName).toBe('feat/new');
+  });
+});
+
+describe('WorktreeWatcher.rebuild', () => {
+  let tmpDir: string;
+  let repoDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-watcher-test-'));
+    repoDir = path.join(tmpDir, 'my-repo');
+    fs.mkdirSync(path.join(repoDir, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(repoDir, '.worktrees'), { recursive: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('emits worktrees-changed when given individual repo paths (not parent dirs)', async () => {
+    const watcher = new WorktreeWatcher();
+    let emitted = false;
+
+    watcher.on('worktrees-changed', () => {
+      emitted = true;
+    });
+
+    // Pass individual repo path (how config.repos actually stores paths)
+    watcher.rebuild([repoDir]);
+
+    // Create a new directory in .worktrees/ to simulate worktree creation
+    fs.mkdirSync(path.join(repoDir, '.worktrees', 'test-branch'));
+
+    // fs.watch debounce is 500ms — wait 800ms for it to fire
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    watcher.close();
+    expect(emitted).toBe(true);
+  });
+
+  it('does not emit for repos without .worktrees when given individual repo paths', async () => {
+    const bareRepo = path.join(tmpDir, 'bare-repo');
+    fs.mkdirSync(path.join(bareRepo, '.git'), { recursive: true });
+
+    const watcher = new WorktreeWatcher();
+    let emitted = false;
+
+    watcher.on('worktrees-changed', () => {
+      emitted = true;
+    });
+
+    // Repo exists but no .worktrees dir — watcher should watch repo root for dir creation
+    watcher.rebuild([bareRepo]);
+
+    // Create .worktrees/ dir (simulates first worktree setup)
+    fs.mkdirSync(path.join(bareRepo, '.worktrees'));
+
+    await new Promise((resolve) => setTimeout(resolve, 800));
+
+    watcher.close();
+    expect(emitted).toBe(true);
   });
 });

--- a/test/worktrees.test.ts
+++ b/test/worktrees.test.ts
@@ -704,7 +704,7 @@ describe('WorktreeWatcher.rebuild', () => {
     expect(emitted).toBe(true);
   });
 
-  it('does not emit for repos without .worktrees when given individual repo paths', async () => {
+  it('emits when .worktrees is first created in a repo given as individual path', async () => {
     const bareRepo = path.join(tmpDir, 'bare-repo');
     fs.mkdirSync(path.join(bareRepo, '.git'), { recursive: true });
 


### PR DESCRIPTION
## Summary

When a user creates a worktree from one device, other connected devices don't see it until they manually refresh. Two reinforcing bugs: the filesystem watcher was completely inert (never set up any watchers), and the creation endpoint never broadcast the change event.

## Changes

- **Watcher fix** (`server/watcher.ts`): `WorktreeWatcher.rebuild()` and `BranchWatcher.rebuild()` now check if each `config.repos` entry is itself a git repo before falling back to subdirectory scanning. Previously they treated individual repo paths as parent directories, found no repos, and created zero `fs.watch()` instances.
- **Explicit broadcast** (`server/workspaces.ts`, `server/index.ts`): Added `onWorktreeCreated` callback to `WorkspaceDeps`, called after successful worktree creation in both the new-branch and existing-branch paths. Wired to `broadcastEvent('worktrees-changed')` in index.ts, matching the existing pattern in `DELETE /worktrees`.
- **Regression tests** (`test/worktrees.test.ts`): 2 new tests verifying the watcher emits `worktrees-changed` when given individual repo paths.

## Testing

- Full test suite: 82 files, 1081 tests passing
- New regression tests confirm watcher fires for individual repo paths (the actual config format)
- Build clean

---
*Created with `/pr:author`*