### PR TITLE
fix: center PIN cursor and auto-deauth on server restart

### DIFF
--- a/frontend/src/components/TuiInput.css
+++ b/frontend/src/components/TuiInput.css
@@ -59,8 +59,6 @@
   opacity: 0.7;
   pointer-events: none;
   line-height: 1;
-  /* Offset by input padding */
-  margin-left: 8px;
 }
 
 .tui-cursor.blinking {

--- a/frontend/src/components/TuiInput.tsx
+++ b/frontend/src/components/TuiInput.tsx
@@ -58,7 +58,28 @@ export const TuiInput: React.FC<TuiInputProps> = ({
       : (value ?? '').slice(0, selStart);
 
     measureRef.current.textContent = textBeforeCursor || '';
-    setCursorLeft(measureRef.current.offsetWidth);
+    const textBeforeCursorWidth = measureRef.current.offsetWidth;
+
+    const computedStyle = window.getComputedStyle(inputRef.current);
+    const paddingLeft = parseFloat(computedStyle.paddingLeft) || 0;
+
+    let left = paddingLeft + textBeforeCursorWidth;
+
+    if (computedStyle.textAlign === 'center') {
+      const fullText = type === 'password'
+        ? '\u2022'.repeat((value ?? '').length)
+        : (value ?? '');
+      measureRef.current.textContent = fullText;
+      const fullTextWidth = measureRef.current.offsetWidth;
+
+      const paddingRight = parseFloat(computedStyle.paddingRight) || 0;
+      const contentWidth = inputRef.current.clientWidth - paddingLeft - paddingRight;
+      const centerOffset = (contentWidth - fullTextWidth) / 2;
+
+      left = paddingLeft + centerOffset + textBeforeCursorWidth;
+    }
+
+    setCursorLeft(left);
     setCursorHeight(inputRef.current.offsetHeight || 16);
   }, [type, value]);
 

--- a/frontend/src/components/TuiInput.tsx
+++ b/frontend/src/components/TuiInput.tsx
@@ -62,8 +62,9 @@ export const TuiInput: React.FC<TuiInputProps> = ({
 
     const computedStyle = window.getComputedStyle(inputRef.current);
     const paddingLeft = parseFloat(computedStyle.paddingLeft) || 0;
+    const borderLeft = parseFloat(computedStyle.borderLeftWidth) || 0;
 
-    let left = paddingLeft + textBeforeCursorWidth;
+    let left = borderLeft + paddingLeft + textBeforeCursorWidth;
 
     if (computedStyle.textAlign === 'center') {
       const fullText = type === 'password'
@@ -76,7 +77,7 @@ export const TuiInput: React.FC<TuiInputProps> = ({
       const contentWidth = inputRef.current.clientWidth - paddingLeft - paddingRight;
       const centerOffset = (contentWidth - fullTextWidth) / 2;
 
-      left = paddingLeft + centerOffset + textBeforeCursorWidth;
+      left = borderLeft + paddingLeft + centerOffset + textBeforeCursorWidth;
     }
 
     setCursorLeft(left);

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import type { QueryClient } from '@tanstack/react-query';
 import { connectEventSocket } from '../lib/ws.js';
 import type { EventMessage } from '../lib/ws.js';
+import { useAuthStore } from '../lib/stores/auth.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useTelemetryStore } from '../lib/stores/telemetry.js';
 import { useUiStore } from '../lib/stores/ui.js';
@@ -122,6 +123,10 @@ export function useEventSocket({
       'browser-tab-refreshed': (msg) => {
         useUiStore.getState().refreshHtmlTab(msg.filePath);
       },
+      'server-restarting': () => {
+        // Server is about to shut down (in-app update). Auth will be
+        // invalidated on restart; the reconnect auth check handles it.
+      },
     };
 
     connectEventSocket(
@@ -131,6 +136,9 @@ export function useEventSocket({
       },
       () => {
         void useTelemetryStore.getState().refreshTelemetry();
+      },
+      () => {
+        useAuthStore.getState().deauthenticate();
       },
     );
 

--- a/frontend/src/lib/stores/auth.ts
+++ b/frontend/src/lib/stores/auth.ts
@@ -14,6 +14,7 @@ export interface AuthState {
   checkExistingAuth: () => Promise<void>;
   submitPin: (pin: string) => Promise<void>;
   setupNewPin: (pin: string, confirm: string) => Promise<void>;
+  deauthenticate: () => void;
 }
 
 export const useAuthStore = create<AuthState>()((set) => ({
@@ -59,6 +60,10 @@ export const useAuthStore = create<AuthState>()((set) => ({
       const pinError = err instanceof Error ? err.message : 'Failed to set PIN';
       set({ pinError });
     }
+  },
+
+  deauthenticate: () => {
+    set({ authenticated: false, pinError: null, checking: false });
   },
 }));
 

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -55,7 +55,8 @@ export type EventMessage =
       data: AccountTelemetry | Record<string, unknown> | null;
     }
   | { type: 'browser-tab-opened'; filePath: string; token: string }
-  | { type: 'browser-tab-refreshed'; filePath: string };
+  | { type: 'browser-tab-refreshed'; filePath: string }
+  | { type: 'server-restarting' };
 
 type EventCallback = (msg: EventMessage) => void;
 type EventOpenCallback = () => void;
@@ -83,6 +84,7 @@ let lastPtyOnResize: (() => void) | null = null;
 let lastPtyOnSessionEnd: (() => void) | null = null;
 let lastEventOnMessage: EventCallback | null = null;
 let lastEventOnOpen: EventOpenCallback | null = null;
+let lastOnAuthRequired: (() => void) | null = null;
 
 const PING_INTERVAL = 30_000; // 30s heartbeat
 const PONG_TIMEOUT = 5_000; // 5s to respond
@@ -91,7 +93,8 @@ const PONG_MSG = '{"type":"pong"}';
 
 export function connectEventSocket(
   onMessage: EventCallback,
-  onOpen?: EventOpenCallback
+  onOpen?: EventOpenCallback,
+  onAuthRequired?: () => void
 ): void {
   // Null onclose before close to prevent old socket from scheduling a reconnect
   if (eventWs) {
@@ -101,6 +104,7 @@ export function connectEventSocket(
   }
   lastEventOnMessage = onMessage;
   lastEventOnOpen = onOpen ?? null;
+  lastOnAuthRequired = onAuthRequired ?? lastOnAuthRequired;
   clearEventPing();
 
   const url = wsProtocol + '//' + location.host + '/ws/events';
@@ -126,10 +130,25 @@ export function connectEventSocket(
 
   eventWs.onclose = () => {
     clearEventPing();
-    setTimeout(() => connectEventSocket(onMessage, onOpen), 3000);
+    setTimeout(() => void reconnectWithAuthCheck(), 3000);
   };
 
   eventWs.onerror = () => {};
+}
+
+async function reconnectWithAuthCheck(): Promise<void> {
+  try {
+    const res = await fetch('/sessions');
+    if (res.status === 401) {
+      lastOnAuthRequired?.();
+      return;
+    }
+  } catch {
+    // Server unreachable — keep trying to reconnect
+  }
+  if (lastEventOnMessage) {
+    connectEventSocket(lastEventOnMessage, lastEventOnOpen ?? undefined);
+  }
 }
 
 export function connectPtySocket(
@@ -229,6 +248,10 @@ function scheduleReconnect(
     ptyReconnectTimer = null;
     try {
       const res = await fetch('/sessions');
+      if (res.status === 401) {
+        lastOnAuthRequired?.();
+        return;
+      }
       const sessionList = (await res.json()) as Array<{ id: string }>;
       if (!sessionList.some((s) => s.id === sessionId)) {
         term.write('\r\n[Session ended]\r\n');
@@ -336,8 +359,7 @@ function forceReconnectEvent(): void {
     eventWs.close();
     eventWs = null;
   }
-  if (lastEventOnMessage)
-    connectEventSocket(lastEventOnMessage, lastEventOnOpen ?? undefined);
+  setTimeout(() => void reconnectWithAuthCheck(), 1000);
 }
 
 function startEventPing(): void {

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -138,7 +138,7 @@ export function connectEventSocket(
 
 async function reconnectWithAuthCheck(): Promise<void> {
   try {
-    const res = await fetch('/sessions');
+    const res = await fetch('/auth/check');
     if (res.status === 401) {
       lastOnAuthRequired?.();
       return;
@@ -247,11 +247,12 @@ function scheduleReconnect(
   ptyReconnectTimer = setTimeout(async () => {
     ptyReconnectTimer = null;
     try {
-      const res = await fetch('/sessions');
-      if (res.status === 401) {
+      const authRes = await fetch('/auth/check');
+      if (authRes.status === 401) {
         lastOnAuthRequired?.();
         return;
       }
+      const res = await fetch('/sessions');
       const sessionList = (await res.json()) as Array<{ id: string }>;
       if (!sessionList.some((s) => s.id === sessionId)) {
         term.write('\r\n[Session ended]\r\n');

--- a/server/index.ts
+++ b/server/index.ts
@@ -1153,6 +1153,11 @@ async function main(): Promise<void> {
     }
   });
 
+  // GET /auth/check — lightweight auth probe (no side effects)
+  app.get('/auth/check', requireAuth, (_req, res) => {
+    res.json({ ok: true });
+  });
+
   // GET /auth/status — no auth required, tells frontend if PIN is configured
   app.get('/auth/status', (_req, res) => {
     const config = getConfig();

--- a/server/index.ts
+++ b/server/index.ts
@@ -2015,12 +2015,16 @@ async function main(): Promise<void> {
         stopEventBatching();
         stopTelemetry();
         serializeAll(configDir);
+        broadcastEvent('server-restarting');
       }
       res.json({ ok: true, restarting });
       if (restarting) {
-        server.close(() => process.exit(0));
-        // Fallback if close hangs
-        setTimeout(() => process.exit(0), 3000);
+        // Brief delay to let the broadcast reach clients
+        setTimeout(() => {
+          server.close(() => process.exit(0));
+          // Fallback if close hangs
+          setTimeout(() => process.exit(0), 3000);
+        }, 500);
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Update failed';


### PR DESCRIPTION
## Summary
- **PIN cursor fix**: TuiInput cursor positioning now computes left offset dynamically from `getComputedStyle`, handling `text-align: center` and variable padding. Previously the cursor was stuck at the top-left of the PIN input because the calculation assumed left-aligned text with hardcoded 8px padding.
- **Reconnect auth fix**: WS reconnect paths (event socket + PTY) now check HTTP auth status before re-establishing the WebSocket. If the server returns 401 (tokens cleared after restart), the client calls `deauthenticate()` to show the PIN page instead of looping forever on "reconnecting".
- **Server restart broadcast**: Server broadcasts `server-restarting` event before shutdown during in-app updates, with a 500ms delay to let the message reach clients.

## Test plan
- [ ] Open PIN gate → cursor should be centered with the dots, not stuck at top-left
- [ ] Type/delete characters → cursor follows centered position correctly
- [ ] Trigger in-app update via Update toast → client should show PIN page after server restarts
- [ ] Kill server process externally while client is connected → client should detect 401 on reconnect and show PIN page
- [ ] Normal WS disconnects (network blip) should still reconnect normally when auth is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)