### PR TITLE
feat: onboarding experience and hint system (#138)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,9 @@ import { useConfigStore } from './lib/stores/config.js';
 import { useBootStateStore } from './lib/stores/boot-state.js';
 import { useTelemetryStore } from './lib/stores/telemetry.js';
 import { sendPtyData } from './lib/ws.js';
+import { useOnboardingHints, HINT_NO_REPOS, HINT_REPO_ADDED_NO_SESSIONS } from './hooks/useOnboardingHints.js';
+import { useHintsStore } from './lib/stores/hints.js';
+import { Hint } from './components/Hint.js';
 import {
   initNotifications,
   initPushNotifications,
@@ -145,6 +148,25 @@ function TerminalAreaContent({
   const repos = useSessionsStore((s) => s.repos);
   const activeSessionId = useSessionsStore((s) => s.activeSessionId);
   const isItemLoading = useSessionsStore((s) => s.isItemLoading);
+
+  // ── Onboarding hints ──────────────────────────────────────────────────────
+  const prevSessionCountRef = useRef(sessions.length);
+  const [sessionJustStarted, setSessionJustStarted] = useState(false);
+  useEffect(() => {
+    if (sessions.length > prevSessionCountRef.current) {
+      setSessionJustStarted(true);
+      setTimeout(() => setSessionJustStarted(false), 100);
+    }
+    prevSessionCountRef.current = sessions.length;
+  }, [sessions.length]);
+
+  const { markSeen: markHintSeen } = useHintsStore();
+  const onboardingHints = useOnboardingHints({
+    hasRepos: repos.length > 0,
+    hasActiveSessions: sessions.length > 0,
+    sessionJustStarted,
+    commandPaletteJustOpened: false,
+  });
 
   const [copyModeActive, setCopyModeActive] = useState(false);
 
@@ -297,6 +319,17 @@ function TerminalAreaContent({
           description="point to any folder on your machine. git repos get pr tracking and branch management."
           actionLabel="+ add repo"
           onAction={onAddWorkspace}
+          hint={
+            onboardingHints.showNoReposHint ? (
+              <Hint
+                id={HINT_NO_REPOS}
+                variant="inline-text"
+                onDismiss={() => markHintSeen(HINT_NO_REPOS)}
+              >
+                relay-ide manages claude code sessions across your repos.
+              </Hint>
+            ) : undefined
+          }
         />
       )}
 
@@ -339,6 +372,17 @@ function TerminalAreaContent({
           onFixConflicts={onFixConflicts}
           onPrAction={onPrAction}
           onOpenPrSession={onOpenPrSession}
+          hint={
+            onboardingHints.showRepoAddedHint ? (
+              <Hint
+                id={HINT_REPO_ADDED_NO_SESSIONS}
+                variant="border"
+                onDismiss={() => markHintSeen(HINT_REPO_ADDED_NO_SESSIONS)}
+              >
+                start a session to begin working with claude code in this repo.
+              </Hint>
+            ) : undefined
+          }
         />
       )}
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -90,6 +90,163 @@ initNotifications((sessionId: string, sessionType: string) => {
   _navigateToSessionFn?.(sessionId, sessionType);
 });
 
+// ─── useTerminalOnboardingHints ───────────────────────────────────────────────
+// Tracks session/repo count transitions and returns onboarding hint state.
+// Extracted to reduce TerminalAreaContent's cyclomatic complexity.
+
+function useTerminalOnboardingHints(reposLength: number, sessionsLength: number) {
+  const prevSessionCountRef = useRef(sessionsLength);
+  const prevReposCountRef = useRef(reposLength);
+  const prevSessionsTotalRef = useRef(sessionsLength);
+  const [sessionJustStarted, setSessionJustStarted] = useState(false);
+  const markHintSeen = useHintsStore((s) => s.markSeen);
+
+  useEffect(() => {
+    if (sessionsLength > prevSessionCountRef.current) {
+      setSessionJustStarted(true);
+      const timeoutId = setTimeout(() => setSessionJustStarted(false), 100);
+      prevSessionCountRef.current = sessionsLength;
+      return () => { clearTimeout(timeoutId); };
+    }
+    prevSessionCountRef.current = sessionsLength;
+  }, [sessionsLength]);
+
+  useEffect(() => {
+    if (prevReposCountRef.current === 0 && reposLength > 0) {
+      markHintSeen(HINT_NO_REPOS);
+    }
+    prevReposCountRef.current = reposLength;
+  }, [reposLength, markHintSeen]);
+
+  useEffect(() => {
+    if (prevSessionsTotalRef.current === 0 && sessionsLength > 0) {
+      markHintSeen(HINT_REPO_ADDED_NO_SESSIONS);
+    }
+    prevSessionsTotalRef.current = sessionsLength;
+  }, [sessionsLength, markHintSeen]);
+
+  return { sessionJustStarted, markHintSeen };
+}
+
+// ─── resolveTerminalFilePath ──────────────────────────────────────────────────
+// Converts an absolute or relative terminal file path to a repo-relative path.
+// Returns null if the path cannot be resolved within the cwd.
+
+function resolveTerminalFilePath(clickedPath: string, cwd: string): string | null {
+  if (!cwd) return null;
+  let relative = clickedPath;
+  if (clickedPath.startsWith(cwd + '/')) {
+    relative = clickedPath.slice(cwd.length + 1);
+  } else if (clickedPath.startsWith('/')) {
+    return null;
+  } else if (clickedPath.startsWith('./')) {
+    relative = clickedPath.slice(2);
+  }
+  while (relative.startsWith('./')) {
+    relative = relative.slice(2);
+  }
+  return relative;
+}
+
+// ─── useTerminalDerivedState ──────────────────────────────────────────────────
+// Computes derived session/workspace values used by TerminalAreaContent.
+
+function useTerminalDerivedState() {
+  const activeRepoPath = useUiStore((s) => s.activeRepoPath);
+  const openFileTabs = useUiStore((s) => s.openFileTabs);
+  const analyticsView = useUiStore((s) => s.analyticsView);
+  const sessions = useSessionsStore((s) => s.sessions);
+  const repos = useSessionsStore((s) => s.repos);
+  const activeSessionId = useSessionsStore((s) => s.activeSessionId);
+
+  const activeWorkspace = useMemo(
+    () => (activeRepoPath ? repos.find((w) => w.path === activeRepoPath) : undefined),
+    [activeRepoPath, repos]
+  );
+
+  const activeSession = useMemo(
+    () => (activeSessionId ? sessions.find((s) => s.id === activeSessionId) : undefined),
+    [activeSessionId, sessions]
+  );
+
+  const allWorkspaceSessions = useMemo(
+    () => (activeRepoPath ? useSessionsStore.getState().getSessionsForRepo(activeRepoPath) : []),
+    [activeRepoPath, sessions]
+  );
+
+  const workspaceSessions = useMemo(
+    () =>
+      (activeSession
+        ? allWorkspaceSessions.filter((s) => s.cwd === activeSession.cwd)
+        : allWorkspaceSessions
+      ).toSorted((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()),
+    [activeSession, allWorkspaceSessions]
+  );
+
+  const hasActiveSession = useMemo(
+    () => !!activeSession && !!activeRepoPath && activeSession.repoPath === activeRepoPath,
+    [activeSession, activeRepoPath]
+  );
+
+  const sessionTitle = useMemo(
+    () => activeSession?.displayName || activeWorkspace?.name || 'Relay',
+    [activeSession, activeWorkspace]
+  );
+
+  const activeSessionUseTmux = useMemo(() => activeSession?.useTmux ?? false, [activeSession]);
+  const activeWorkspaceCwd = useMemo(
+    () => activeSession?.worktreePath ?? activeSession?.repoPath ?? '',
+    [activeSession]
+  );
+  const fileViewerOpen = useMemo(() => openFileTabs.length > 0, [openFileTabs]);
+
+  const viewMode = useMemo<'empty' | 'org' | 'dashboard' | 'session' | 'analytics'>(() => {
+    if (analyticsView !== null) return 'analytics';
+    if (!repos.length) return 'empty';
+    if (!activeRepoPath) return 'org';
+    if (!hasActiveSession) return 'dashboard';
+    return 'session';
+  }, [analyticsView, repos.length, activeRepoPath, hasActiveSession]);
+
+  return {
+    activeRepoPath,
+    activeSessionId,
+    activeSession,
+    activeWorkspace,
+    workspaceSessions,
+    sessionTitle,
+    activeSessionUseTmux,
+    activeWorkspaceCwd,
+    fileViewerOpen,
+    viewMode,
+    analyticsView,
+    repos,
+    sessions,
+  };
+}
+
+// ─── AnalyticsViewContent ─────────────────────────────────────────────────────
+// Renders the analytics or session-detail view. Extracted to reduce complexity.
+
+function AnalyticsViewContent() {
+  const analyticsView = useUiStore((s) => s.analyticsView);
+  const setAnalyticsView = useUiStore((s) => s.setAnalyticsView);
+  if (typeof analyticsView === 'object' && analyticsView !== null && 'sessionId' in analyticsView) {
+    return (
+      <SessionDetail
+        sessionId={analyticsView.sessionId}
+        onBack={() => setAnalyticsView('dashboard')}
+      />
+    );
+  }
+  return (
+    <AnalyticsDashboard
+      onSelectSession={(id) => setAnalyticsView({ sessionId: id })}
+      onClose={() => setAnalyticsView(null)}
+    />
+  );
+}
+
 // ─── TerminalAreaContent ──────────────────────────────────────────────────────
 // Extracted to reduce App's cyclomatic complexity. Accesses Zustand stores
 // directly to avoid a large prop surface; only truly local state/refs are passed.
@@ -131,111 +288,43 @@ function TerminalAreaContent({
   onSelectSession,
   onCloseSession,
 }: TerminalAreaContentProps) {
-  // Store access
+  // Store access (layout / sidebar values not in derived state hook)
   const openSidebar = useUiStore((s) => s.openSidebar);
   const keyboardOpen = useUiStore((s) => s.keyboardOpen);
-  const activeRepoPath = useUiStore((s) => s.activeRepoPath);
   const rightSidebarCollapsed = useUiStore((s) => s.rightSidebarCollapsed);
   const rightSidebarWidth = useUiStore((s) => s.rightSidebarWidth);
   const saveRightSidebarWidth = useUiStore((s) => s.saveRightSidebarWidth);
   const fileViewerRatio = useUiStore((s) => s.fileViewerRatio);
   const saveFileViewerRatio = useUiStore((s) => s.saveFileViewerRatio);
-  const openFileTabs = useUiStore((s) => s.openFileTabs);
   const openFileTab = useUiStore((s) => s.openFileTab);
-  const analyticsView = useUiStore((s) => s.analyticsView);
   const setAnalyticsView = useUiStore((s) => s.setAnalyticsView);
-  const sessions = useSessionsStore((s) => s.sessions);
-  const repos = useSessionsStore((s) => s.repos);
-  const activeSessionId = useSessionsStore((s) => s.activeSessionId);
   const isItemLoading = useSessionsStore((s) => s.isItemLoading);
 
-  // ── Onboarding hints ──────────────────────────────────────────────────────
-  const prevSessionCountRef = useRef(sessions.length);
-  const [sessionJustStarted, setSessionJustStarted] = useState(false);
-  useEffect(() => {
-    if (sessions.length > prevSessionCountRef.current) {
-      setSessionJustStarted(true);
-      setTimeout(() => setSessionJustStarted(false), 100);
-    }
-    prevSessionCountRef.current = sessions.length;
-  }, [sessions.length]);
+  // ── Derived state ──────────────────────────────────────────────────────────
+  const {
+    activeRepoPath,
+    activeSessionId,
+    activeSession,
+    activeWorkspace,
+    workspaceSessions,
+    sessionTitle,
+    activeSessionUseTmux,
+    activeWorkspaceCwd,
+    fileViewerOpen,
+    viewMode,
+    repos,
+    sessions,
+  } = useTerminalDerivedState();
 
-  const { markSeen: markHintSeen } = useHintsStore();
+  // ── Onboarding hints ──────────────────────────────────────────────────────
+  const { sessionJustStarted } = useTerminalOnboardingHints(repos.length, sessions.length);
+
   const onboardingHints = useOnboardingHints({
     hasRepos: repos.length > 0,
     hasActiveSessions: sessions.length > 0,
     sessionJustStarted,
     commandPaletteJustOpened: false,
   });
-
-  const [copyModeActive, setCopyModeActive] = useState(false);
-
-  const activeWorkspace = useMemo(
-    () =>
-      activeRepoPath ? repos.find((w) => w.path === activeRepoPath) : undefined,
-    [activeRepoPath, repos]
-  );
-
-  const activeSession = useMemo(
-    () =>
-      activeSessionId
-        ? sessions.find((s) => s.id === activeSessionId)
-        : undefined,
-    [activeSessionId, sessions]
-  );
-
-  const allWorkspaceSessions = useMemo(
-    () =>
-      activeRepoPath
-        ? useSessionsStore.getState().getSessionsForRepo(activeRepoPath)
-        : [],
-    [activeRepoPath, sessions]
-  );
-
-  const workspaceSessions = useMemo(
-    () =>
-      (activeSession
-        ? allWorkspaceSessions.filter((s) => s.cwd === activeSession.cwd)
-        : allWorkspaceSessions
-      ).toSorted(
-        (a, b) =>
-          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-      ),
-    [activeSession, allWorkspaceSessions]
-  );
-
-  const hasActiveSession = useMemo(
-    () =>
-      !!activeSession &&
-      !!activeRepoPath &&
-      activeSession.repoPath === activeRepoPath,
-    [activeSession, activeRepoPath]
-  );
-
-  const sessionTitle = useMemo(
-    () => activeSession?.displayName || activeWorkspace?.name || 'Relay',
-    [activeSession, activeWorkspace]
-  );
-
-  const activeSessionUseTmux = useMemo(
-    () => activeSession?.useTmux ?? false,
-    [activeSession]
-  );
-  const activeWorkspaceCwd = useMemo(
-    () => activeSession?.worktreePath ?? activeSession?.repoPath ?? '',
-    [activeSession]
-  );
-  const fileViewerOpen = useMemo(() => openFileTabs.length > 0, [openFileTabs]);
-
-  const viewMode = useMemo<
-    'empty' | 'org' | 'dashboard' | 'session' | 'analytics'
-  >(() => {
-    if (analyticsView !== null) return 'analytics';
-    if (!repos.length) return 'empty';
-    if (!activeRepoPath) return 'org';
-    if (!hasActiveSession) return 'dashboard';
-    return 'session';
-  }, [analyticsView, repos.length, activeRepoPath, hasActiveSession]);
 
   const handleSendKey = useCallback((key: string) => {
     sendPtyData(key);
@@ -276,30 +365,13 @@ function TerminalAreaContent({
   );
   const handleTerminalFilePathClick = useCallback(
     (clickedPath: string) => {
-      const currentActiveSessionId =
-        useSessionsStore.getState().activeSessionId;
+      const currentActiveSessionId = useSessionsStore.getState().activeSessionId;
       const currentActiveSession = currentActiveSessionId
-        ? useSessionsStore
-            .getState()
-            .sessions.find((s) => s.id === currentActiveSessionId)
+        ? useSessionsStore.getState().sessions.find((s) => s.id === currentActiveSessionId)
         : undefined;
-      const cwd =
-        currentActiveSession?.worktreePath ??
-        currentActiveSession?.repoPath ??
-        '';
-      if (!cwd) return;
-      let relative = clickedPath;
-      if (clickedPath.startsWith(cwd + '/')) {
-        relative = clickedPath.slice(cwd.length + 1);
-      } else if (clickedPath.startsWith('/')) {
-        return;
-      } else if (clickedPath.startsWith('./')) {
-        relative = clickedPath.slice(2);
-      }
-      while (relative.startsWith('./')) {
-        relative = relative.slice(2);
-      }
-      openFileTab(relative, false);
+      const cwd = currentActiveSession?.worktreePath ?? currentActiveSession?.repoPath ?? '';
+      const relative = resolveTerminalFilePath(clickedPath, cwd);
+      if (relative !== null) openFileTab(relative, false);
     },
     [openFileTab]
   );
@@ -324,7 +396,6 @@ function TerminalAreaContent({
               <Hint
                 id={HINT_NO_REPOS}
                 variant="inline-text"
-                onDismiss={() => markHintSeen(HINT_NO_REPOS)}
               >
                 relay-ide manages claude code sessions across your repos.
               </Hint>
@@ -340,23 +411,7 @@ function TerminalAreaContent({
         />
       )}
 
-      {viewMode === 'analytics' && (
-        <>
-          {typeof analyticsView === 'object' &&
-          analyticsView !== null &&
-          'sessionId' in analyticsView ? (
-            <SessionDetail
-              sessionId={analyticsView.sessionId}
-              onBack={() => setAnalyticsView('dashboard')}
-            />
-          ) : (
-            <AnalyticsDashboard
-              onSelectSession={(id) => setAnalyticsView({ sessionId: id })}
-              onClose={() => setAnalyticsView(null)}
-            />
-          )}
-        </>
-      )}
+      {viewMode === 'analytics' && <AnalyticsViewContent />}
 
       {viewMode === 'dashboard' && (
         <RepoDashboard
@@ -377,7 +432,6 @@ function TerminalAreaContent({
               <Hint
                 id={HINT_REPO_ADDED_NO_SESSIONS}
                 variant="border"
-                onDismiss={() => markHintSeen(HINT_REPO_ADDED_NO_SESSIONS)}
               >
                 start a session to begin working with claude code in this repo.
               </Hint>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -95,37 +95,33 @@ initNotifications((sessionId: string, sessionType: string) => {
 // Extracted to reduce TerminalAreaContent's cyclomatic complexity.
 
 function useTerminalOnboardingHints(reposLength: number, sessionsLength: number) {
-  const prevSessionCountRef = useRef(sessionsLength);
-  const prevReposCountRef = useRef(reposLength);
-  const prevSessionsTotalRef = useRef(sessionsLength);
+  const prevSessionsRef = useRef(sessionsLength);
+  const prevReposRef = useRef(reposLength);
   const [sessionJustStarted, setSessionJustStarted] = useState(false);
   const markHintSeen = useHintsStore((s) => s.markSeen);
 
   useEffect(() => {
-    if (sessionsLength > prevSessionCountRef.current) {
+    const prev = prevSessionsRef.current;
+    if (sessionsLength > prev) {
       setSessionJustStarted(true);
       const timeoutId = setTimeout(() => setSessionJustStarted(false), 100);
-      prevSessionCountRef.current = sessionsLength;
+      prevSessionsRef.current = sessionsLength;
       return () => { clearTimeout(timeoutId); };
     }
-    prevSessionCountRef.current = sessionsLength;
-  }, [sessionsLength]);
-
-  useEffect(() => {
-    if (prevReposCountRef.current === 0 && reposLength > 0) {
-      markHintSeen(HINT_NO_REPOS);
-    }
-    prevReposCountRef.current = reposLength;
-  }, [reposLength, markHintSeen]);
-
-  useEffect(() => {
-    if (prevSessionsTotalRef.current === 0 && sessionsLength > 0) {
+    if (prev === 0 && sessionsLength > 0) {
       markHintSeen(HINT_REPO_ADDED_NO_SESSIONS);
     }
-    prevSessionsTotalRef.current = sessionsLength;
+    prevSessionsRef.current = sessionsLength;
   }, [sessionsLength, markHintSeen]);
 
-  return { sessionJustStarted, markHintSeen };
+  useEffect(() => {
+    if (prevReposRef.current === 0 && reposLength > 0) {
+      markHintSeen(HINT_NO_REPOS);
+    }
+    prevReposRef.current = reposLength;
+  }, [reposLength, markHintSeen]);
+
+  return { sessionJustStarted };
 }
 
 // ─── resolveTerminalFilePath ──────────────────────────────────────────────────

--- a/frontend/src/components/EmptyState.css
+++ b/frontend/src/components/EmptyState.css
@@ -32,3 +32,11 @@
   color: var(--text-muted);
   line-height: 1.5;
 }
+
+.empty-hint {
+  width: 100%;
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  text-align: left;
+}

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -8,6 +8,7 @@ export interface EmptyStateProps {
   description?: string;
   actionLabel?: string;
   onAction?: () => void;
+  hint?: React.ReactNode;
 }
 
 export function EmptyState({
@@ -16,6 +17,7 @@ export function EmptyState({
   description,
   actionLabel,
   onAction,
+  hint,
 }: EmptyStateProps) {
   return (
     <div className="empty-state">
@@ -28,6 +30,8 @@ export function EmptyState({
       <div className="empty-heading">{heading}</div>
 
       {description && <p className="empty-description">{description}</p>}
+
+      {hint && <div className="empty-hint">{hint}</div>}
 
       {actionLabel && onAction && (
         <TuiButton variant="primary" onClick={onAction}>

--- a/frontend/src/components/Hint.css
+++ b/frontend/src/components/Hint.css
@@ -1,0 +1,91 @@
+/* ── Border hint ─────────────────────────────────────────────────────────────── */
+
+.hint-border {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  padding: 10px 12px;
+  background: color-mix(in srgb, var(--accent) 4%, transparent);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+}
+
+.hint-border__content {
+  flex: 1;
+  line-height: 1.5;
+}
+
+.hint-border__dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: var(--font-size-base);
+  line-height: 1;
+  padding: 0 2px;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  opacity: 0.6;
+}
+
+.hint-border__dismiss:hover {
+  opacity: 1;
+  color: var(--text);
+}
+
+/* Collapse to inline on mobile */
+@media (max-width: 767px) {
+  .hint-border {
+    border: none;
+    background: none;
+    padding: 4px 0;
+    font-size: var(--font-size-xs);
+  }
+}
+
+/* ── Toast hint ──────────────────────────────────────────────────────────────── */
+
+.hint-toast {
+  /* Inherits .notification-card base from NotificationStack.css */
+}
+
+.hint-toast__text {
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+}
+
+.hint-toast__dismiss {
+  /* Inherits .notification-card__dismiss */
+}
+
+/* ── Inline-text hint ────────────────────────────────────────────────────────── */
+
+.hint-inline-text {
+  display: inline;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+}
+
+.hint-inline-text__content {
+  margin-right: 4px;
+}
+
+.hint-inline-text__dismiss {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  padding: 0 2px;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  opacity: 0.6;
+  vertical-align: middle;
+}
+
+.hint-inline-text__dismiss:hover {
+  opacity: 1;
+  color: var(--text);
+}

--- a/frontend/src/components/Hint.tsx
+++ b/frontend/src/components/Hint.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useHintsStore } from '../lib/stores/hints.js';
 import { addNotification, removeNotification } from '../lib/stores/notifications.js';
 import './Hint.css';
@@ -20,11 +20,20 @@ function HintToast({ id, children, onDismiss }: Omit<HintProps, 'variant'>) {
   const canShowHint = useHintsStore((s) => s.canShowHint);
   const incrementActive = useHintsStore((s) => s.incrementActive);
   const decrementActive = useHintsStore((s) => s.decrementActive);
+  // Track whether this instance has already decremented to avoid double-decrement
+  const decrementedRef = useRef(false);
 
   useEffect(() => {
     if (isHintSeen(id) || !canShowHint()) return;
 
     incrementActive();
+
+    const safeDecrement = () => {
+      if (!decrementedRef.current) {
+        decrementedRef.current = true;
+        decrementActive();
+      }
+    };
 
     const notifId = `hint-toast-${id}`;
     addNotification({
@@ -41,7 +50,7 @@ function HintToast({ id, children, onDismiss }: Omit<HintProps, 'variant'>) {
             aria-label="dismiss hint"
             onClick={() => {
               markSeen(id);
-              decrementActive();
+              safeDecrement();
               removeNotification(notifId);
               onDismiss?.();
             }}
@@ -52,7 +61,7 @@ function HintToast({ id, children, onDismiss }: Omit<HintProps, 'variant'>) {
       ),
       onDismiss: () => {
         markSeen(id);
-        decrementActive();
+        safeDecrement();
         onDismiss?.();
       },
     });
@@ -60,11 +69,9 @@ function HintToast({ id, children, onDismiss }: Omit<HintProps, 'variant'>) {
     return () => {
       // If the component unmounts without explicit dismiss, clean up
       removeNotification(notifId);
-      decrementActive();
+      safeDecrement();
     };
-    // Only run once on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id]);
+  }, [id, isHintSeen, canShowHint, incrementActive, decrementActive, markSeen, children, onDismiss]);
 
   return null;
 }
@@ -77,28 +84,32 @@ function HintBorder({ id, children, onDismiss }: Omit<HintProps, 'variant'>) {
   const canShowHint = useHintsStore((s) => s.canShowHint);
   const incrementActive = useHintsStore((s) => s.incrementActive);
   const decrementActive = useHintsStore((s) => s.decrementActive);
+  // Track whether incrementActive was called so we only decrement if we incremented
+  const incrementedRef = useRef(false);
 
   useEffect(() => {
     if (!isHintSeen(id) && canShowHint()) {
+      incrementedRef.current = true;
       incrementActive();
     }
     return () => {
-      if (!isHintSeen(id)) {
+      if (incrementedRef.current) {
+        incrementedRef.current = false;
         decrementActive();
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id]);
+  }, [id, isHintSeen, canShowHint, incrementActive, decrementActive]);
 
   if (isHintSeen(id)) return null;
-  if (!canShowHint() && !isHintSeen(id)) {
-    // Still render if already incremented (canShowHint changes after increment)
-    // So we only gate on initial render before increment
-  }
+  // Don't render if the throttle prevented incrementing (hint was not shown)
+  if (!incrementedRef.current) return null;
 
   function handleDismiss() {
     markSeen(id);
-    decrementActive();
+    if (incrementedRef.current) {
+      incrementedRef.current = false;
+      decrementActive();
+    }
     onDismiss?.();
   }
 

--- a/frontend/src/components/Hint.tsx
+++ b/frontend/src/components/Hint.tsx
@@ -71,7 +71,7 @@ function HintToast({ id, children, onDismiss }: Omit<HintProps, 'variant'>) {
       removeNotification(notifId);
       safeDecrement();
     };
-  }, [id, isHintSeen, canShowHint, incrementActive, decrementActive, markSeen, children, onDismiss]);
+  }, [id, isHintSeen, canShowHint, incrementActive, decrementActive, markSeen, onDismiss]);
 
   return null;
 }
@@ -157,13 +157,10 @@ function HintInlineText({ id, children, onDismiss }: Omit<HintProps, 'variant'>)
 // ── Main export ───────────────────────────────────────────────────────────────
 
 export function Hint({ id, variant, children, onDismiss }: HintProps) {
-  if (variant === 'toast') {
-    return <HintToast id={id} onDismiss={onDismiss}>{children}</HintToast>;
-  }
-  if (variant === 'border') {
-    return <HintBorder id={id} onDismiss={onDismiss}>{children}</HintBorder>;
-  }
-  return <HintInlineText id={id} onDismiss={onDismiss}>{children}</HintInlineText>;
+  const props = { id, children, ...(onDismiss ? { onDismiss } : {}) };
+  if (variant === 'toast') return <HintToast {...props} />;
+  if (variant === 'border') return <HintBorder {...props} />;
+  return <HintInlineText {...props} />;
 }
 
 export default Hint;

--- a/frontend/src/components/Hint.tsx
+++ b/frontend/src/components/Hint.tsx
@@ -1,0 +1,158 @@
+import React, { useEffect } from 'react';
+import { useHintsStore } from '../lib/stores/hints.js';
+import { addNotification, removeNotification } from '../lib/stores/notifications.js';
+import './Hint.css';
+
+export type HintVariant = 'border' | 'toast' | 'inline-text';
+
+export interface HintProps {
+  id: string;
+  variant: HintVariant;
+  children: React.ReactNode;
+  onDismiss?: () => void;
+}
+
+// ── Toast variant ─────────────────────────────────────────────────────────────
+
+function HintToast({ id, children, onDismiss }: Omit<HintProps, 'variant'>) {
+  const markSeen = useHintsStore((s) => s.markSeen);
+  const isHintSeen = useHintsStore((s) => s.isHintSeen);
+  const canShowHint = useHintsStore((s) => s.canShowHint);
+  const incrementActive = useHintsStore((s) => s.incrementActive);
+  const decrementActive = useHintsStore((s) => s.decrementActive);
+
+  useEffect(() => {
+    if (isHintSeen(id) || !canShowHint()) return;
+
+    incrementActive();
+
+    const notifId = `hint-toast-${id}`;
+    addNotification({
+      id: notifId,
+      type: 'info',
+      dismissible: true,
+      content: () => (
+        <div className="notification-card hint-toast">
+          <span className="notification-card__text hint-toast__text">
+            {children}
+          </span>
+          <button
+            className="notification-card__dismiss hint-toast__dismiss"
+            aria-label="dismiss hint"
+            onClick={() => {
+              markSeen(id);
+              decrementActive();
+              removeNotification(notifId);
+              onDismiss?.();
+            }}
+          >
+            ×
+          </button>
+        </div>
+      ),
+      onDismiss: () => {
+        markSeen(id);
+        decrementActive();
+        onDismiss?.();
+      },
+    });
+
+    return () => {
+      // If the component unmounts without explicit dismiss, clean up
+      removeNotification(notifId);
+      decrementActive();
+    };
+    // Only run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  return null;
+}
+
+// ── Border variant ────────────────────────────────────────────────────────────
+
+function HintBorder({ id, children, onDismiss }: Omit<HintProps, 'variant'>) {
+  const markSeen = useHintsStore((s) => s.markSeen);
+  const isHintSeen = useHintsStore((s) => s.isHintSeen);
+  const canShowHint = useHintsStore((s) => s.canShowHint);
+  const incrementActive = useHintsStore((s) => s.incrementActive);
+  const decrementActive = useHintsStore((s) => s.decrementActive);
+
+  useEffect(() => {
+    if (!isHintSeen(id) && canShowHint()) {
+      incrementActive();
+    }
+    return () => {
+      if (!isHintSeen(id)) {
+        decrementActive();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  if (isHintSeen(id)) return null;
+  if (!canShowHint() && !isHintSeen(id)) {
+    // Still render if already incremented (canShowHint changes after increment)
+    // So we only gate on initial render before increment
+  }
+
+  function handleDismiss() {
+    markSeen(id);
+    decrementActive();
+    onDismiss?.();
+  }
+
+  return (
+    <div className="hint-border" role="status" aria-live="polite">
+      <div className="hint-border__content">{children}</div>
+      <button
+        className="hint-border__dismiss"
+        aria-label="dismiss hint"
+        onClick={handleDismiss}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+// ── Inline-text variant ───────────────────────────────────────────────────────
+
+function HintInlineText({ id, children, onDismiss }: Omit<HintProps, 'variant'>) {
+  const markSeen = useHintsStore((s) => s.markSeen);
+  const isHintSeen = useHintsStore((s) => s.isHintSeen);
+
+  if (isHintSeen(id)) return null;
+
+  function handleDismiss() {
+    markSeen(id);
+    onDismiss?.();
+  }
+
+  return (
+    <span className="hint-inline-text" role="status" aria-live="polite">
+      <span className="hint-inline-text__content">{children}</span>
+      <button
+        className="hint-inline-text__dismiss"
+        aria-label="dismiss hint"
+        onClick={handleDismiss}
+      >
+        ×
+      </button>
+    </span>
+  );
+}
+
+// ── Main export ───────────────────────────────────────────────────────────────
+
+export function Hint({ id, variant, children, onDismiss }: HintProps) {
+  if (variant === 'toast') {
+    return <HintToast id={id} onDismiss={onDismiss}>{children}</HintToast>;
+  }
+  if (variant === 'border') {
+    return <HintBorder id={id} onDismiss={onDismiss}>{children}</HintBorder>;
+  }
+  return <HintInlineText id={id} onDismiss={onDismiss}>{children}</HintInlineText>;
+}
+
+export default Hint;

--- a/frontend/src/components/RepoDashboard.tsx
+++ b/frontend/src/components/RepoDashboard.tsx
@@ -13,6 +13,7 @@ import { TuiButton } from './TuiButton.js';
 import { TuiProgress } from './TuiProgress.js';
 import { PrRow } from './PrRow.js';
 import { useScrollOverflow } from '../hooks/useScrollOverflow.js';
+import { formatCompact, formatResetAt } from '../lib/utils.js';
 import './RepoDashboard.css';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -30,31 +31,6 @@ export interface RepoDashboardProps {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function compactCount(value: number): string {
-  if (value < 1000) return String(Math.round(value));
-  if (value < 1_000_000)
-    return `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)}k`;
-  return `${(value / 1_000_000).toFixed(value >= 10_000_000 ? 0 : 1)}M`;
-}
-
-function formatResetAt(value: string | null | undefined): string {
-  if (!value) return '—';
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '—';
-  const now = new Date();
-  const sameDay =
-    date.getFullYear() === now.getFullYear() &&
-    date.getMonth() === now.getMonth() &&
-    date.getDate() === now.getDate();
-  if (sameDay)
-    return date.toLocaleTimeString([], {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    });
-  return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
-}
 
 function activityBranches(entry: ActivityEntry): string {
   if (!entry.branches || entry.branches.length === 0) return '';
@@ -119,11 +95,11 @@ function UsageSection({ repoSessions }: UsageSectionProps) {
         <div className="usage-row">
           <span className="usage-label">relay tokens</span>
           <span className="usage-value">
-            ↓{compactCount(repoTelemetry.totalInputTokens)} ↑
-            {compactCount(repoTelemetry.totalOutputTokens)}
+            ↓{formatCompact(repoTelemetry.totalInputTokens)} ↑
+            {formatCompact(repoTelemetry.totalOutputTokens)}
           </span>
           <span className="usage-meta">
-            cache: {compactCount(repoTelemetry.totalCacheRead)} read
+            cache: {formatCompact(repoTelemetry.totalCacheRead)} read
           </span>
         </div>
         <div className="usage-row">

--- a/frontend/src/components/RepoDashboard.tsx
+++ b/frontend/src/components/RepoDashboard.tsx
@@ -147,32 +147,42 @@ function UsageSection({ repoSessions }: UsageSectionProps) {
             )}
           </span>
         </div>
-        {accountTelemetry && accountTelemetry.rateLimits.length > 0 && (
+        {accountTelemetry && (
           <>
-            {accountTelemetry.rateLimits.map((rl) => {
-              const label = rl.windowMinutes === 300 ? '5h limit' : rl.windowMinutes === 10080 ? '7d limit' : rl.name;
-              return (
-                <React.Fragment key={rl.name}>
-                  <div className="usage-divider" />
-                  <div className="usage-row">
-                    <span className="usage-label">{label}</span>
-                    <span className="usage-bar">
-                      <TuiProgress
-                        variant="bar"
-                        value={Math.max(0, Math.min(100, rl.usedPercent >= 0 ? rl.usedPercent : 0))}
-                        width={10}
-                      />
-                    </span>
-                    <span className="usage-value">
-                      {rl.usedPercent >= 0 ? `${Math.round(rl.usedPercent)}% used` : '—'}
-                    </span>
-                    <span className="usage-meta">
-                      resets {formatResetAt(rl.resetsAt)}
-                    </span>
-                  </div>
-                </React.Fragment>
-              );
-            })}
+            <div className="usage-divider" />
+            <div className="usage-row">
+              <span className="usage-label">5h limit</span>
+              <span className="usage-bar">
+                <TuiProgress
+                  variant="bar"
+                  value={Math.max(0, Math.min(100, accountTelemetry.fiveHourUsedPercent >= 0 ? accountTelemetry.fiveHourUsedPercent : 0))}
+                  width={10}
+                />
+              </span>
+              <span className="usage-value">
+                {accountTelemetry.fiveHourUsedPercent >= 0 ? `${Math.round(accountTelemetry.fiveHourUsedPercent)}% used` : '—'}
+              </span>
+              <span className="usage-meta">
+                resets {formatResetAt(accountTelemetry.fiveHourResetsAt)}
+              </span>
+            </div>
+            <div className="usage-divider" />
+            <div className="usage-row">
+              <span className="usage-label">7d limit</span>
+              <span className="usage-bar">
+                <TuiProgress
+                  variant="bar"
+                  value={Math.max(0, Math.min(100, accountTelemetry.sevenDayUsedPercent >= 0 ? accountTelemetry.sevenDayUsedPercent : 0))}
+                  width={10}
+                />
+              </span>
+              <span className="usage-value">
+                {accountTelemetry.sevenDayUsedPercent >= 0 ? `${Math.round(accountTelemetry.sevenDayUsedPercent)}% used` : '—'}
+              </span>
+              <span className="usage-meta">
+                resets {formatResetAt(accountTelemetry.sevenDayResetsAt)}
+              </span>
+            </div>
           </>
         )}
       </div>

--- a/frontend/src/components/SessionStatusBar.tsx
+++ b/frontend/src/components/SessionStatusBar.tsx
@@ -1,6 +1,7 @@
 import { useUiStore } from '../lib/stores/ui.js';
 import { useTelemetryStore } from '../lib/stores/telemetry.js';
 import type { CurrentActivity } from '../lib/types.js';
+import { formatCompact, formatResetAt } from '../lib/utils.js';
 import './SessionStatusBar.css';
 
 export interface SessionStatusBarProps {
@@ -10,34 +11,9 @@ export interface SessionStatusBarProps {
 
 const BAR_WIDTH = 10;
 
-function formatCompact(value: number | null | undefined): string {
-  if (value === null || value === undefined || Number.isNaN(value)) return '—';
-  const abs = Math.abs(value);
-  if (abs < 1000) return String(Math.round(value));
-  if (abs < 1_000_000) return `${(value / 1000).toFixed(abs >= 10_000 ? 0 : 1)}k`;
-  if (abs < 1_000_000_000) return `${(value / 1_000_000).toFixed(abs >= 10_000_000 ? 0 : 1)}M`;
-  return `${(value / 1_000_000_000).toFixed(1)}B`;
-}
-
 function formatCurrency(value: number | null | undefined): string {
   if (value === null || value === undefined || Number.isNaN(value)) return '~$—';
   return `~$${value.toFixed(2)}`;
-}
-
-function formatResetAt(value: string | null | undefined): string {
-  if (!value) return '—';
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '—';
-  const now = new Date();
-  const sameDay =
-    date.getFullYear() === now.getFullYear() &&
-    date.getMonth() === now.getMonth() &&
-    date.getDate() === now.getDate();
-  if (sameDay) {
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
-  }
-  const sameYear = date.getFullYear() === now.getFullYear();
-  return date.toLocaleDateString([], sameYear ? { month: 'short', day: 'numeric' } : { month: 'short', day: 'numeric', year: '2-digit' });
 }
 
 function barForPercent(value: number): string {

--- a/frontend/src/components/TuiButton.css
+++ b/frontend/src/components/TuiButton.css
@@ -81,6 +81,24 @@ a.tui-btn--disabled {
   pointer-events: none;
 }
 
+/* Shortcut label */
+.tui-btn__shortcut {
+  margin-left: 8px;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  background: none;
+  border: none;
+  padding: 0;
+  opacity: 0.7;
+}
+
+@media (max-width: 767px) {
+  .tui-btn__shortcut {
+    display: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .tui-btn {
     transition: none;

--- a/frontend/src/components/TuiButton.tsx
+++ b/frontend/src/components/TuiButton.tsx
@@ -9,6 +9,7 @@ export interface TuiButtonProps {
   disabled?: boolean;
   type?: 'button' | 'submit' | 'reset';
   href?: string;
+  shortcut?: string;
   onClick?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
   onMouseEnter?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
   onMouseLeave?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
@@ -23,6 +24,7 @@ export const TuiButton: React.FC<TuiButtonProps> = ({
   disabled = false,
   type = 'button',
   href,
+  shortcut,
   onClick,
   onMouseEnter,
   onMouseLeave,
@@ -41,6 +43,10 @@ export const TuiButton: React.FC<TuiButtonProps> = ({
     .filter(Boolean)
     .join(' ');
 
+  const shortcutEl = shortcut ? (
+    <kbd className="tui-btn__shortcut">{shortcut}</kbd>
+  ) : null;
+
   if (href) {
     return (
       <a
@@ -54,6 +60,7 @@ export const TuiButton: React.FC<TuiButtonProps> = ({
         {...(rest as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
       >
         {children}
+        {shortcutEl}
       </a>
     );
   }
@@ -69,6 +76,7 @@ export const TuiButton: React.FC<TuiButtonProps> = ({
       {...(rest as React.ButtonHTMLAttributes<HTMLButtonElement>)}
     >
       {children}
+      {shortcutEl}
     </button>
   );
 };

--- a/frontend/src/hooks/useOnboardingHints.tsx
+++ b/frontend/src/hooks/useOnboardingHints.tsx
@@ -10,6 +10,50 @@ export const HINT_FIRST_SESSION_RUNNING = 'onboarding-first-session-running';
 export const HINT_REMOTE_ACCESS = 'onboarding-remote-access';
 export const HINT_COMMAND_PALETTE = 'onboarding-command-palette';
 
+// ── Toast helper ─────────────────────────────────────────────────────────────
+// Fires a hint toast via the notification system with proper decrement guards.
+
+function fireHintToast(hintId: string, text: string): void {
+  const { incrementActive } = useHintsStore.getState();
+  incrementActive();
+
+  const notifId = `hint-notif-${hintId}`;
+  let decremented = false;
+  const safeDecrement = () => {
+    if (decremented) return;
+    decremented = true;
+    useHintsStore.getState().decrementActive();
+  };
+
+  addNotification({
+    id: notifId,
+    type: 'info',
+    dismissible: true,
+    content: () => (
+      <div className="notification-card hint-toast">
+        <span className="notification-card__text hint-toast__text">
+          {text}
+        </span>
+        <button
+          className="notification-card__dismiss"
+          aria-label="dismiss hint"
+          onClick={() => {
+            useHintsStore.getState().markSeen(hintId);
+            safeDecrement();
+            removeNotification(notifId);
+          }}
+        >
+          ×
+        </button>
+      </div>
+    ),
+    onDismiss: () => {
+      useHintsStore.getState().markSeen(hintId);
+      safeDecrement();
+    },
+  });
+}
+
 // ── Hook ──────────────────────────────────────────────────────────────────────
 
 export interface OnboardingHintsOptions {
@@ -25,8 +69,8 @@ export function useOnboardingHints({
   sessionJustStarted,
   commandPaletteJustOpened,
 }: OnboardingHintsOptions) {
-  const { isHintSeen, markSeen, canShowHint, incrementActive, decrementActive } =
-    useHintsStore.getState();
+  const isHintSeen = useHintsStore((s) => s.isHintSeen);
+  const markSeen = useHintsStore((s) => s.markSeen);
 
   const sessionToastFiredRef = useRef(false);
   const remoteToastFiredRef = useRef(false);
@@ -37,84 +81,24 @@ export function useOnboardingHints({
     if (sessionToastFiredRef.current) return;
     if (isHintSeen(HINT_FIRST_SESSION_RUNNING)) return;
 
-    // Store the remote timer ID so we can clear it on unmount
     let remoteTimerId: ReturnType<typeof setTimeout> | null = null;
 
     const timer = setTimeout(() => {
-      // Bypass canShowHint() for onboarding toasts — the throttle is meant for
-      // visual border hints, not toasts that go through the notification system.
       sessionToastFiredRef.current = true;
-      incrementActive();
-
-      const notifId = `hint-notif-${HINT_FIRST_SESSION_RUNNING}`;
-      addNotification({
-        id: notifId,
-        type: 'info',
-        dismissible: true,
-        content: () => {
-          const { markSeen: ms, decrementActive: da } = useHintsStore.getState();
-          return (
-            <div className="notification-card hint-toast">
-              <span className="notification-card__text hint-toast__text">
-                session is live. try cmd+k for the command palette, or [+] in the tab bar.
-              </span>
-              <button
-                className="notification-card__dismiss"
-                aria-label="dismiss hint"
-                onClick={() => {
-                  ms(HINT_FIRST_SESSION_RUNNING);
-                  da();
-                  removeNotification(notifId);
-                }}
-              >
-                ×
-              </button>
-            </div>
-          );
-        },
-        onDismiss: () => {
-          markSeen(HINT_FIRST_SESSION_RUNNING);
-          decrementActive();
-        },
-      });
+      fireHintToast(
+        HINT_FIRST_SESSION_RUNNING,
+        'session is live. try cmd+k for the command palette, or [+] in the tab bar.',
+      );
 
       // Queue remote access toast after another gap
       if (!isHintSeen(HINT_REMOTE_ACCESS)) {
         remoteTimerId = setTimeout(() => {
           if (remoteToastFiredRef.current) return;
           remoteToastFiredRef.current = true;
-          incrementActive();
-          const remoteNotifId = `hint-notif-${HINT_REMOTE_ACCESS}`;
-          addNotification({
-            id: remoteNotifId,
-            type: 'info',
-            dismissible: true,
-            content: () => {
-              const { markSeen: ms2, decrementActive: da2 } = useHintsStore.getState();
-              return (
-                <div className="notification-card hint-toast">
-                  <span className="notification-card__text hint-toast__text">
-                    relay-ide is accessible from any device — see settings &gt; advanced for the remote access url.
-                  </span>
-                  <button
-                    className="notification-card__dismiss"
-                    aria-label="dismiss hint"
-                    onClick={() => {
-                      ms2(HINT_REMOTE_ACCESS);
-                      da2();
-                      removeNotification(remoteNotifId);
-                    }}
-                  >
-                    ×
-                  </button>
-                </div>
-              );
-            },
-            onDismiss: () => {
-              markSeen(HINT_REMOTE_ACCESS);
-              decrementActive();
-            },
-          });
+          fireHintToast(
+            HINT_REMOTE_ACCESS,
+            'relay-ide is accessible from any device — see settings > advanced for the remote access url.',
+          );
         }, 12_000);
       }
     }, 2_000);
@@ -123,14 +107,13 @@ export function useOnboardingHints({
       clearTimeout(timer);
       if (remoteTimerId !== null) clearTimeout(remoteTimerId);
     };
-  }, [sessionJustStarted, isHintSeen, markSeen, canShowHint, incrementActive, decrementActive]);
+  }, [sessionJustStarted, isHintSeen]);
 
   // Step 4: command palette first open
   useEffect(() => {
     if (!commandPaletteJustOpened) return;
     if (isHintSeen(HINT_COMMAND_PALETTE)) return;
     markSeen(HINT_COMMAND_PALETTE);
-    // The inline hint in CommandPalette is handled by the Hint component directly
   }, [commandPaletteJustOpened, isHintSeen, markSeen]);
 
   return {

--- a/frontend/src/hooks/useOnboardingHints.tsx
+++ b/frontend/src/hooks/useOnboardingHints.tsx
@@ -37,9 +37,12 @@ export function useOnboardingHints({
     if (sessionToastFiredRef.current) return;
     if (isHintSeen(HINT_FIRST_SESSION_RUNNING)) return;
 
-    const timer = setTimeout(() => {
-      if (!canShowHint()) return;
+    // Store the remote timer ID so we can clear it on unmount
+    let remoteTimerId: ReturnType<typeof setTimeout> | null = null;
 
+    const timer = setTimeout(() => {
+      // Bypass canShowHint() for onboarding toasts — the throttle is meant for
+      // visual border hints, not toasts that go through the notification system.
       sessionToastFiredRef.current = true;
       incrementActive();
 
@@ -77,8 +80,7 @@ export function useOnboardingHints({
 
       // Queue remote access toast after another gap
       if (!isHintSeen(HINT_REMOTE_ACCESS)) {
-        setTimeout(() => {
-          if (!canShowHint()) return;
+        remoteTimerId = setTimeout(() => {
           if (remoteToastFiredRef.current) return;
           remoteToastFiredRef.current = true;
           incrementActive();
@@ -117,9 +119,11 @@ export function useOnboardingHints({
       }
     }, 2_000);
 
-    return () => clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionJustStarted]);
+    return () => {
+      clearTimeout(timer);
+      if (remoteTimerId !== null) clearTimeout(remoteTimerId);
+    };
+  }, [sessionJustStarted, isHintSeen, markSeen, canShowHint, incrementActive, decrementActive]);
 
   // Step 4: command palette first open
   useEffect(() => {
@@ -127,8 +131,7 @@ export function useOnboardingHints({
     if (isHintSeen(HINT_COMMAND_PALETTE)) return;
     markSeen(HINT_COMMAND_PALETTE);
     // The inline hint in CommandPalette is handled by the Hint component directly
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [commandPaletteJustOpened]);
+  }, [commandPaletteJustOpened, isHintSeen, markSeen]);
 
   return {
     showNoReposHint: !hasRepos && !isHintSeen(HINT_NO_REPOS),

--- a/frontend/src/hooks/useOnboardingHints.tsx
+++ b/frontend/src/hooks/useOnboardingHints.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useRef } from 'react';
+import { useHintsStore } from '../lib/stores/hints.js';
+import { addNotification, removeNotification } from '../lib/stores/notifications.js';
+
+// ── Hint IDs ──────────────────────────────────────────────────────────────────
+
+export const HINT_NO_REPOS = 'onboarding-no-repos';
+export const HINT_REPO_ADDED_NO_SESSIONS = 'onboarding-repo-added-no-sessions';
+export const HINT_FIRST_SESSION_RUNNING = 'onboarding-first-session-running';
+export const HINT_REMOTE_ACCESS = 'onboarding-remote-access';
+export const HINT_COMMAND_PALETTE = 'onboarding-command-palette';
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+export interface OnboardingHintsOptions {
+  hasRepos: boolean;
+  hasActiveSessions: boolean;
+  sessionJustStarted: boolean;
+  commandPaletteJustOpened: boolean;
+}
+
+export function useOnboardingHints({
+  hasRepos,
+  hasActiveSessions,
+  sessionJustStarted,
+  commandPaletteJustOpened,
+}: OnboardingHintsOptions) {
+  const { isHintSeen, markSeen, canShowHint, incrementActive, decrementActive } =
+    useHintsStore.getState();
+
+  const sessionToastFiredRef = useRef(false);
+  const remoteToastFiredRef = useRef(false);
+
+  // Step 3: session just started — fire two toasts (main + remote access)
+  useEffect(() => {
+    if (!sessionJustStarted) return;
+    if (sessionToastFiredRef.current) return;
+    if (isHintSeen(HINT_FIRST_SESSION_RUNNING)) return;
+
+    const timer = setTimeout(() => {
+      if (!canShowHint()) return;
+
+      sessionToastFiredRef.current = true;
+      incrementActive();
+
+      const notifId = `hint-notif-${HINT_FIRST_SESSION_RUNNING}`;
+      addNotification({
+        id: notifId,
+        type: 'info',
+        dismissible: true,
+        content: () => {
+          const { markSeen: ms, decrementActive: da } = useHintsStore.getState();
+          return (
+            <div className="notification-card hint-toast">
+              <span className="notification-card__text hint-toast__text">
+                session is live. try cmd+k for the command palette, or [+] in the tab bar.
+              </span>
+              <button
+                className="notification-card__dismiss"
+                aria-label="dismiss hint"
+                onClick={() => {
+                  ms(HINT_FIRST_SESSION_RUNNING);
+                  da();
+                  removeNotification(notifId);
+                }}
+              >
+                ×
+              </button>
+            </div>
+          );
+        },
+        onDismiss: () => {
+          markSeen(HINT_FIRST_SESSION_RUNNING);
+          decrementActive();
+        },
+      });
+
+      // Queue remote access toast after another gap
+      if (!isHintSeen(HINT_REMOTE_ACCESS)) {
+        setTimeout(() => {
+          if (!canShowHint()) return;
+          if (remoteToastFiredRef.current) return;
+          remoteToastFiredRef.current = true;
+          incrementActive();
+          const remoteNotifId = `hint-notif-${HINT_REMOTE_ACCESS}`;
+          addNotification({
+            id: remoteNotifId,
+            type: 'info',
+            dismissible: true,
+            content: () => {
+              const { markSeen: ms2, decrementActive: da2 } = useHintsStore.getState();
+              return (
+                <div className="notification-card hint-toast">
+                  <span className="notification-card__text hint-toast__text">
+                    relay-ide is accessible from any device — see settings &gt; advanced for the remote access url.
+                  </span>
+                  <button
+                    className="notification-card__dismiss"
+                    aria-label="dismiss hint"
+                    onClick={() => {
+                      ms2(HINT_REMOTE_ACCESS);
+                      da2();
+                      removeNotification(remoteNotifId);
+                    }}
+                  >
+                    ×
+                  </button>
+                </div>
+              );
+            },
+            onDismiss: () => {
+              markSeen(HINT_REMOTE_ACCESS);
+              decrementActive();
+            },
+          });
+        }, 12_000);
+      }
+    }, 2_000);
+
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionJustStarted]);
+
+  // Step 4: command palette first open
+  useEffect(() => {
+    if (!commandPaletteJustOpened) return;
+    if (isHintSeen(HINT_COMMAND_PALETTE)) return;
+    markSeen(HINT_COMMAND_PALETTE);
+    // The inline hint in CommandPalette is handled by the Hint component directly
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [commandPaletteJustOpened]);
+
+  return {
+    showNoReposHint: !hasRepos && !isHintSeen(HINT_NO_REPOS),
+    showRepoAddedHint:
+      hasRepos && !hasActiveSessions && !isHintSeen(HINT_REPO_ADDED_NO_SESSIONS),
+    showCommandPaletteHint:
+      commandPaletteJustOpened && !isHintSeen(HINT_COMMAND_PALETTE),
+  };
+}
+
+export default useOnboardingHints;

--- a/frontend/src/hooks/useWhatsNew.tsx
+++ b/frontend/src/hooks/useWhatsNew.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from 'react';
+import { WHATS_NEW } from '../lib/whats-new.js';
+import { addNotification, removeNotification } from '../lib/stores/notifications.js';
+import { useHintsStore } from '../lib/stores/hints.js';
+
+const WHATS_NEW_SEEN_KEY = 'relay-ide:whats-new-seen';
+const MAX_TOASTS_PER_LOAD = 2;
+
+function loadSeenVersion(): string | null {
+  try {
+    return localStorage.getItem(WHATS_NEW_SEEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function saveSeenVersion(version: string): void {
+  try {
+    localStorage.setItem(WHATS_NEW_SEEN_KEY, version);
+  } catch {
+    /* unavailable */
+  }
+}
+
+export function useWhatsNew(currentVersion: string) {
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (firedRef.current) return;
+
+    // Suppress during onboarding (if there are no seen hints yet, user is new)
+    const { seenIds, canShowHint, incrementActive } = useHintsStore.getState();
+    const isOnboarding = seenIds.size === 0;
+    if (isOnboarding) return;
+
+    const seenVersion = loadSeenVersion();
+
+    // Only show for exact version match and only once per version
+    if (seenVersion === currentVersion) return;
+    const features = WHATS_NEW[currentVersion];
+    if (!features) {
+      saveSeenVersion(currentVersion);
+      return;
+    }
+
+    firedRef.current = true;
+    saveSeenVersion(currentVersion);
+
+    const featureEntries = Object.entries(features).slice(0, MAX_TOASTS_PER_LOAD);
+    let shown = 0;
+
+    for (const [featureId, description] of featureEntries) {
+      if (shown >= MAX_TOASTS_PER_LOAD) break;
+      if (!canShowHint()) break;
+
+      incrementActive();
+      shown++;
+
+      const notifId = `whats-new-${currentVersion}-${featureId}`;
+      addNotification({
+        id: notifId,
+        type: 'info',
+        dismissible: true,
+        content: () => {
+          const { decrementActive } = useHintsStore.getState();
+          return (
+            <div className="notification-card hint-toast">
+              <span className="notification-card__text hint-toast__text">
+                {description}
+              </span>
+              <button
+                className="notification-card__dismiss"
+                aria-label="dismiss"
+                onClick={() => {
+                  decrementActive();
+                  removeNotification(notifId);
+                }}
+              >
+                ×
+              </button>
+            </div>
+          );
+        },
+        onDismiss: () => {
+          useHintsStore.getState().decrementActive();
+        },
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentVersion]);
+}
+
+export default useWhatsNew;

--- a/frontend/src/hooks/useWhatsNew.tsx
+++ b/frontend/src/hooks/useWhatsNew.tsx
@@ -29,7 +29,7 @@ export function useWhatsNew(currentVersion: string) {
     if (firedRef.current) return;
 
     // Suppress during onboarding (if there are no seen hints yet, user is new)
-    const { seenIds, canShowHint, incrementActive } = useHintsStore.getState();
+    const { seenIds, incrementActive } = useHintsStore.getState();
     const isOnboarding = seenIds.size === 0;
     if (isOnboarding) return;
 
@@ -51,41 +51,40 @@ export function useWhatsNew(currentVersion: string) {
 
     for (const [featureId, description] of featureEntries) {
       if (shown >= MAX_TOASTS_PER_LOAD) break;
-      // What's-new toasts bypass canShowHint() — cap at MAX_TOASTS_PER_LOAD
-      // directly instead of relying on the hint throttle (which uses MIN_GAP_MS
-      // and would suppress the second toast).
 
       incrementActive();
       shown++;
 
       const notifId = `whats-new-${currentVersion}-${featureId}`;
+      let decremented = false;
+      const safeDecrement = () => {
+        if (decremented) return;
+        decremented = true;
+        useHintsStore.getState().decrementActive();
+      };
+
       addNotification({
         id: notifId,
         type: 'info',
         dismissible: true,
-        content: () => {
-          const { decrementActive } = useHintsStore.getState();
-          return (
-            <div className="notification-card hint-toast">
-              <span className="notification-card__text hint-toast__text">
-                {description}
-              </span>
-              <button
-                className="notification-card__dismiss"
-                aria-label="dismiss"
-                onClick={() => {
-                  decrementActive();
-                  removeNotification(notifId);
-                }}
-              >
-                ×
-              </button>
-            </div>
-          );
-        },
-        onDismiss: () => {
-          useHintsStore.getState().decrementActive();
-        },
+        content: () => (
+          <div className="notification-card hint-toast">
+            <span className="notification-card__text hint-toast__text">
+              {description}
+            </span>
+            <button
+              className="notification-card__dismiss"
+              aria-label="dismiss"
+              onClick={() => {
+                safeDecrement();
+                removeNotification(notifId);
+              }}
+            >
+              ×
+            </button>
+          </div>
+        ),
+        onDismiss: safeDecrement,
       });
     }
   }, [currentVersion]);

--- a/frontend/src/hooks/useWhatsNew.tsx
+++ b/frontend/src/hooks/useWhatsNew.tsx
@@ -51,7 +51,9 @@ export function useWhatsNew(currentVersion: string) {
 
     for (const [featureId, description] of featureEntries) {
       if (shown >= MAX_TOASTS_PER_LOAD) break;
-      if (!canShowHint()) break;
+      // What's-new toasts bypass canShowHint() — cap at MAX_TOASTS_PER_LOAD
+      // directly instead of relying on the hint throttle (which uses MIN_GAP_MS
+      // and would suppress the second toast).
 
       incrementActive();
       shown++;
@@ -86,7 +88,6 @@ export function useWhatsNew(currentVersion: string) {
         },
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentVersion]);
 }
 

--- a/frontend/src/lib/stores/hints.ts
+++ b/frontend/src/lib/stores/hints.ts
@@ -1,0 +1,81 @@
+import { create } from 'zustand';
+
+const STORAGE_KEY = 'relay-ide:hints-seen';
+const MAX_ACTIVE_HINTS = 2;
+const MIN_GAP_MS = 10_000;
+
+// ── localStorage helpers ───────────────────────────────────────────────────────
+
+function loadSeenHints(): Set<string> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return new Set(JSON.parse(raw) as string[]);
+  } catch {
+    /* private browsing or parse error — use in-memory fallback */
+  }
+  return new Set();
+}
+
+function saveSeenHints(ids: Set<string>): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...ids]));
+  } catch {
+    /* unavailable — in-memory only */
+  }
+}
+
+// ── Store interface ────────────────────────────────────────────────────────────
+
+export interface HintsState {
+  seenIds: Set<string>;
+  activeHintCount: number;
+  lastShownAt: number | null;
+  markSeen: (id: string) => void;
+  isHintSeen: (id: string) => boolean;
+  resetAllHints: () => void;
+  canShowHint: () => boolean;
+  incrementActive: () => void;
+  decrementActive: () => void;
+}
+
+export const useHintsStore = create<HintsState>()((set, get) => ({
+  seenIds: loadSeenHints(),
+  activeHintCount: 0,
+  lastShownAt: null,
+
+  markSeen: (id) => {
+    const next = new Set(get().seenIds);
+    next.add(id);
+    saveSeenHints(next);
+    set({ seenIds: next });
+  },
+
+  isHintSeen: (id) => get().seenIds.has(id),
+
+  resetAllHints: () => {
+    const empty = new Set<string>();
+    saveSeenHints(empty);
+    set({ seenIds: empty, activeHintCount: 0, lastShownAt: null });
+  },
+
+  canShowHint: () => {
+    const { activeHintCount, lastShownAt } = get();
+    if (activeHintCount >= MAX_ACTIVE_HINTS) return false;
+    if (lastShownAt !== null && Date.now() - lastShownAt < MIN_GAP_MS)
+      return false;
+    return true;
+  },
+
+  incrementActive: () =>
+    set((s) => ({
+      activeHintCount: s.activeHintCount + 1,
+      lastShownAt: Date.now(),
+    })),
+
+  decrementActive: () =>
+    set((s) => ({
+      activeHintCount: Math.max(0, s.activeHintCount - 1),
+    })),
+}));
+
+export default useHintsStore;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -84,6 +84,22 @@ export function formatCompact(value: number | null | undefined): string {
   return `${(value / 1_000_000_000).toFixed(1)}B`;
 }
 
+export function formatResetAt(value: string | null | undefined): string {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  const now = new Date();
+  const sameDay =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+  if (sameDay) {
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+  }
+  const sameYear = date.getFullYear() === now.getFullYear();
+  return date.toLocaleDateString([], sameYear ? { month: 'short', day: 'numeric' } : { month: 'short', day: 'numeric', year: '2-digit' });
+}
+
 export function formatDuration(seconds: number | null | undefined): string {
   if (seconds === null || seconds === undefined || Number.isNaN(seconds))
     return '---';

--- a/frontend/src/lib/whats-new.ts
+++ b/frontend/src/lib/whats-new.ts
@@ -1,0 +1,19 @@
+/**
+ * what's-new registry
+ *
+ * Keys are exact version strings. Each entry maps feature IDs to short
+ * description strings shown as toasts on first visit after an upgrade.
+ *
+ * Rules:
+ * - exact version match only (no semver comparison)
+ * - max 2 toasts per page load (enforced by useWhatsNew hook)
+ * - suppressed during active onboarding
+ */
+export const WHATS_NEW: Record<string, Record<string, string>> = {
+  '0.1.0': {
+    'remote-access': 'relay-ide is running. access from any device on your network via the remote access url in settings.',
+    'command-palette': 'try cmd+k to open the command palette — search repos, sessions, prs, and settings.',
+  },
+};
+
+export default WHATS_NEW;


### PR DESCRIPTION
## Summary

- Adds `useHintsStore` (Zustand) with localStorage persistence, rate-limiting (max 2 active hints, 10s gap), and `markSeen`/`canShowHint` primitives
- Adds `<Hint>` component with three variants: `border` (inline banner), `toast` (notification stack), `inline-text` (compact beside CTA)
- Adds `useOnboardingHints` hook driving a 4-step progressive disclosure flow: no-repos → repo-added → first-session → remote-access
- Adds `useWhatsNew` hook for version-keyed upgrade toasts (suppressed during onboarding)
- Adds `whats-new.ts` registry (v0.1.0 seed entries)
- Wires hints into `EmptyState` and `RepoDashboard` via a `hint?: React.ReactNode` prop
- Renamed `.ts` hook files containing JSX to `.tsx`

## Test plan

- [ ] Fresh install (no localStorage): empty state shows inline-text hint beside "+ add repo"
- [ ] After adding first repo (no sessions): RepoDashboard shows border hint at top
- [ ] Starting first session fires toast after ~2s; remote-access toast fires ~12s later
- [ ] Dismissing any hint marks it seen and it never reappears (check localStorage key `relay-ide:hints-seen`)
- [ ] Returning user (hints already seen): no hints shown on load
- [ ] `useHintsStore.resetAllHints()` from devtools resets all hints
- [ ] Build passes: `npm run build`
- [ ] Tests pass: `npm test`

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)