### PR TITLE
feat: define TelemetryAdapter interface and extract Claude adapter (#106, #107)

### DIFF
--- a/frontend/src/components/RepoDashboard.tsx
+++ b/frontend/src/components/RepoDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchDashboard } from '../lib/api.js';
 import { sortPrs } from '../lib/pr-utils.js';
@@ -26,6 +26,7 @@ export interface RepoDashboardProps {
   onFixConflicts: (pr: PullRequest) => void;
   onPrAction: (pr: PullRequest) => void;
   onOpenPrSession: (pr: PullRequest) => void;
+  hint?: React.ReactNode;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -146,61 +147,32 @@ function UsageSection({ repoSessions }: UsageSectionProps) {
             )}
           </span>
         </div>
-        {accountTelemetry && (
+        {accountTelemetry && accountTelemetry.rateLimits.length > 0 && (
           <>
-            <div className="usage-divider" />
-            <div className="usage-row">
-              <span className="usage-label">5h limit</span>
-              <span className="usage-bar">
-                <TuiProgress
-                  variant="bar"
-                  value={Math.max(
-                    0,
-                    Math.min(
-                      100,
-                      accountTelemetry.fiveHourUsedPercent >= 0
-                        ? accountTelemetry.fiveHourUsedPercent
-                        : 0
-                    )
-                  )}
-                  width={10}
-                />
-              </span>
-              <span className="usage-value">
-                {accountTelemetry.fiveHourUsedPercent >= 0
-                  ? `${Math.round(accountTelemetry.fiveHourUsedPercent)}% used`
-                  : '—'}
-              </span>
-              <span className="usage-meta">
-                resets {formatResetAt(accountTelemetry.fiveHourResetsAt)}
-              </span>
-            </div>
-            <div className="usage-row">
-              <span className="usage-label">7d limit</span>
-              <span className="usage-bar">
-                <TuiProgress
-                  variant="bar"
-                  value={Math.max(
-                    0,
-                    Math.min(
-                      100,
-                      accountTelemetry.sevenDayUsedPercent >= 0
-                        ? accountTelemetry.sevenDayUsedPercent
-                        : 0
-                    )
-                  )}
-                  width={10}
-                />
-              </span>
-              <span className="usage-value">
-                {accountTelemetry.sevenDayUsedPercent >= 0
-                  ? `${Math.round(accountTelemetry.sevenDayUsedPercent)}% used`
-                  : '—'}
-              </span>
-              <span className="usage-meta">
-                resets {formatResetAt(accountTelemetry.sevenDayResetsAt)}
-              </span>
-            </div>
+            {accountTelemetry.rateLimits.map((rl) => {
+              const label = rl.windowMinutes === 300 ? '5h limit' : rl.windowMinutes === 10080 ? '7d limit' : rl.name;
+              return (
+                <React.Fragment key={rl.name}>
+                  <div className="usage-divider" />
+                  <div className="usage-row">
+                    <span className="usage-label">{label}</span>
+                    <span className="usage-bar">
+                      <TuiProgress
+                        variant="bar"
+                        value={Math.max(0, Math.min(100, rl.usedPercent >= 0 ? rl.usedPercent : 0))}
+                        width={10}
+                      />
+                    </span>
+                    <span className="usage-value">
+                      {rl.usedPercent >= 0 ? `${Math.round(rl.usedPercent)}% used` : '—'}
+                    </span>
+                    <span className="usage-meta">
+                      resets {formatResetAt(rl.resetsAt)}
+                    </span>
+                  </div>
+                </React.Fragment>
+              );
+            })}
           </>
         )}
       </div>
@@ -354,6 +326,7 @@ export function RepoDashboard({
   onFixConflicts: _onFixConflicts,
   onPrAction,
   onOpenPrSession,
+  hint,
 }: RepoDashboardProps) {
   const sessions = useSessionsStore((s) => s.sessions);
   const repoSessions = useMemo(
@@ -390,6 +363,7 @@ export function RepoDashboard({
 
   return (
     <div className="repo-dashboard">
+      {hint && <div className="repo-dashboard__hint">{hint}</div>}
       {data && !data.isGitRepo ? (
         <div className="non-git-notice">
           <span className="non-git-msg">Not a git repository</span>

--- a/frontend/src/components/SessionStatusBar.tsx
+++ b/frontend/src/components/SessionStatusBar.tsx
@@ -60,11 +60,15 @@ function getContextLabel(telemetry: { contextPercent: number } | null): string {
   return `${'░'.repeat(BAR_WIDTH)} —%`;
 }
 
-function buildRateLimitLabel(accountTelemetry: { fiveHourUsedPercent: number; sevenDayUsedPercent: number } | null | undefined): string {
-  if (!accountTelemetry) return '—';
+function buildRateLimitLabel(accountTelemetry: import('../lib/types.js').AccountTelemetry | null | undefined): string {
+  if (!accountTelemetry || !accountTelemetry.rateLimits.length) return '—';
   const parts: string[] = [];
-  if (accountTelemetry.fiveHourUsedPercent >= 0) parts.push(`5h: ${Math.round(accountTelemetry.fiveHourUsedPercent)}%`);
-  if (accountTelemetry.sevenDayUsedPercent >= 0) parts.push(`7d: ${Math.round(accountTelemetry.sevenDayUsedPercent)}%`);
+  for (const rl of accountTelemetry.rateLimits) {
+    if (rl.usedPercent >= 0) {
+      const label = rl.windowMinutes === 300 ? '5h' : rl.windowMinutes === 10080 ? '7d' : rl.name;
+      parts.push(`${label}: ${Math.round(rl.usedPercent)}%`);
+    }
+  }
   return parts.length > 0 ? parts.join(' | ') : '—';
 }
 
@@ -114,7 +118,7 @@ export function SessionStatusBar({ sessionId, currentActivity = null }: SessionS
       <div className="status-right">
         <span
           className="status-rate-limits status-segment"
-          title={`${formatResetAt(accountTelemetry?.fiveHourResetsAt)} · ${formatResetAt(accountTelemetry?.sevenDayResetsAt)}`}
+          title={accountTelemetry?.rateLimits.map((rl) => formatResetAt(rl.resetsAt)).join(' · ') ?? '—'}
         >
           {rateLimitLabel}
         </span>

--- a/frontend/src/components/SessionStatusBar.tsx
+++ b/frontend/src/components/SessionStatusBar.tsx
@@ -118,7 +118,7 @@ export function SessionStatusBar({ sessionId, currentActivity = null }: SessionS
       <div className="status-right">
         <span
           className="status-rate-limits status-segment"
-          title={accountTelemetry?.rateLimits.map((rl) => formatResetAt(rl.resetsAt)).join(' · ') ?? '—'}
+          title={accountTelemetry?.rateLimits.length ? accountTelemetry.rateLimits.map((rl) => formatResetAt(rl.resetsAt)).join(' · ') : '—'}
         >
           {rateLimitLabel}
         </span>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -161,22 +161,9 @@ function normalizeAccountTelemetry(data: unknown): AccountTelemetry | null {
   const candidate = raw as Partial<AccountTelemetry>;
   if (typeof candidate.updatedAt !== 'string') return null;
   return {
-    fiveHourUsedPercent:
-      typeof candidate.fiveHourUsedPercent === 'number'
-        ? candidate.fiveHourUsedPercent
-        : -1,
-    fiveHourResetsAt:
-      typeof candidate.fiveHourResetsAt === 'string'
-        ? candidate.fiveHourResetsAt
-        : null,
-    sevenDayUsedPercent:
-      typeof candidate.sevenDayUsedPercent === 'number'
-        ? candidate.sevenDayUsedPercent
-        : -1,
-    sevenDayResetsAt:
-      typeof candidate.sevenDayResetsAt === 'string'
-        ? candidate.sevenDayResetsAt
-        : null,
+    framework: typeof candidate.framework === 'string' ? candidate.framework : 'unknown',
+    rateLimits: Array.isArray(candidate.rateLimits) ? candidate.rateLimits : [],
+    planType: typeof candidate.planType === 'string' ? candidate.planType : undefined,
     updatedAt: candidate.updatedAt,
   };
 }

--- a/frontend/src/lib/stores/telemetry.ts
+++ b/frontend/src/lib/stores/telemetry.ts
@@ -108,14 +108,9 @@ function normalizeSessionTelemetry(
 
 function normalizeAccountTelemetry(data: Partial<AccountTelemetry>): AccountTelemetry {
   return {
-    fiveHourUsedPercent:
-      typeof data.fiveHourUsedPercent === 'number' ? data.fiveHourUsedPercent : -1,
-    fiveHourResetsAt:
-      typeof data.fiveHourResetsAt === 'string' ? data.fiveHourResetsAt : null,
-    sevenDayUsedPercent:
-      typeof data.sevenDayUsedPercent === 'number' ? data.sevenDayUsedPercent : -1,
-    sevenDayResetsAt:
-      typeof data.sevenDayResetsAt === 'string' ? data.sevenDayResetsAt : null,
+    framework: typeof data.framework === 'string' ? data.framework : 'unknown',
+    rateLimits: Array.isArray(data.rateLimits) ? data.rateLimits : [],
+    planType: typeof data.planType === 'string' ? data.planType : undefined,
     updatedAt: typeof data.updatedAt === 'string' ? data.updatedAt : new Date().toISOString(),
   };
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -51,11 +51,17 @@ export interface SessionTelemetry {
 
 export type TelemetryData = SessionTelemetry;
 
+export interface RateLimitWindow {
+  name: string;
+  usedPercent: number;
+  resetsAt: string;
+  windowMinutes?: number;
+}
+
 export interface AccountTelemetry {
-  fiveHourUsedPercent: number;
-  fiveHourResetsAt: string | null;
-  sevenDayUsedPercent: number;
-  sevenDayResetsAt: string | null;
+  framework: string;
+  rateLimits: RateLimitWindow[];
+  planType?: string;
   updatedAt: string;
 }
 

--- a/server/adapters/claude-telemetry.ts
+++ b/server/adapters/claude-telemetry.ts
@@ -1,0 +1,193 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { AccountTelemetry, Session, TelemetryData } from '../types.js';
+import type { TelemetryAdapter, TelemetryDeps } from '../telemetry-adapter.js';
+import { registerTelemetryAdapter } from '../telemetry-adapter.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('telemetry:claude');
+
+type IncomingTelemetryData = Omit<TelemetryData, 'updatedAt'>;
+
+function asNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function asString(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function telemetryDir(configDir: string): string {
+  return path.join(configDir, 'telemetry');
+}
+
+function extractTelemetry(
+  sessionId: string,
+  payload: unknown
+): {
+  session: IncomingTelemetryData;
+  account: Omit<AccountTelemetry, 'framework' | 'updatedAt'> | null;
+} | null {
+  if (!payload || typeof payload !== 'object') return null;
+
+  const data = payload as Record<string, unknown>;
+  const contextWindow = (data.context_window ?? {}) as Record<string, unknown>;
+  const currentUsage = (contextWindow.current_usage ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const cost = (data.cost ?? {}) as Record<string, unknown>;
+  const rateLimits = (data.rate_limits ?? {}) as Record<string, unknown>;
+  const fiveHour = (rateLimits.five_hour ?? {}) as Record<string, unknown>;
+  const sevenDay = (rateLimits.seven_day ?? {}) as Record<string, unknown>;
+  const model = (data.model ?? {}) as Record<string, unknown>;
+
+  const session: IncomingTelemetryData = {
+    sessionId,
+    model: typeof model.display_name === 'string' ? model.display_name : null,
+    totalInputTokens: asNumber(contextWindow.total_input_tokens, 0),
+    totalOutputTokens: asNumber(contextWindow.total_output_tokens, 0),
+    totalCacheRead: asNumber(currentUsage.cache_read_input_tokens, 0),
+    totalCacheWrite: asNumber(currentUsage.cache_creation_input_tokens, 0),
+    reasoningOutputTokens: asNumber(
+      currentUsage.reasoning_output_tokens ?? data.reasoning_output_tokens,
+      0
+    ),
+    contextPercent: asNumber(contextWindow.used_percentage, -1),
+    contextWindowSize: asNumber(contextWindow.context_window_size, 0),
+    costUsd:
+      typeof cost.total_cost_usd === 'number' ? cost.total_cost_usd : null,
+    source: 'statusLine',
+  };
+
+  const account =
+    typeof fiveHour.used_percentage === 'number' ||
+    typeof sevenDay.used_percentage === 'number' ||
+    typeof fiveHour.resets_at === 'string' ||
+    typeof sevenDay.resets_at === 'string'
+      ? {
+          rateLimits: [
+            {
+              name: 'five_hour',
+              usedPercent: asNumber(fiveHour.used_percentage, -1),
+              resetsAt: asString(fiveHour.resets_at),
+              windowMinutes: 300,
+            },
+            {
+              name: 'seven_day',
+              usedPercent: asNumber(sevenDay.used_percentage, -1),
+              resetsAt: asString(sevenDay.resets_at),
+              windowMinutes: 10080,
+            },
+          ],
+        }
+      : null;
+
+  return { session, account };
+}
+
+export class ClaudeTelemetryAdapter implements TelemetryAdapter {
+  readonly framework = 'claude';
+
+  private deps: TelemetryDeps;
+  // Account telemetry is adapter-specific side channel — updated during collectSnapshot
+  private _accountTelemetry: AccountTelemetry | null = null;
+
+  constructor(deps: TelemetryDeps) {
+    this.deps = deps;
+  }
+
+  attach(_session: Session): void {
+    // No async setup needed for Claude — telemetry is read from files on demand
+  }
+
+  /**
+   * collectSnapshot reads the Claude telemetry JSON file for the session.
+   * As a side channel it also updates internal account telemetry state.
+   * Must stay under 5ms — synchronous file read only.
+   */
+  collectSnapshot(sessionId: string): TelemetryData | null {
+    const filePath = path.join(
+      telemetryDir(this.deps.configDir),
+      `${sessionId}.json`
+    );
+    let raw: string;
+    try {
+      raw = fs.readFileSync(filePath, 'utf-8');
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException;
+      if (error.code !== 'ENOENT') {
+        logger.warn(
+          `Failed to read telemetry for session ${sessionId}:`,
+          err
+        );
+      }
+      return null;
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(raw);
+    } catch (err) {
+      logger.warn(`Malformed telemetry JSON for session ${sessionId}:`, err);
+      return null;
+    }
+
+    const extracted = extractTelemetry(sessionId, payload);
+    if (!extracted) return null;
+
+    // Update internal account telemetry side channel (broadcast handled by telemetry.ts)
+    if (extracted.account) {
+      this._accountTelemetry = {
+        framework: 'claude',
+        rateLimits: extracted.account.rateLimits,
+        updatedAt: new Date().toISOString(),
+      };
+    }
+
+    return {
+      ...extracted.session,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  detach(_sessionId: string): void {
+    // No cleanup needed — stateless file reads
+  }
+
+  /** Returns the most recently observed account telemetry, or null if none seen yet. */
+  getAccountTelemetry(): AccountTelemetry | null {
+    return this._accountTelemetry;
+  }
+
+  /** Allows telemetry.ts to restore persisted account state on startup. */
+  setAccountTelemetry(data: AccountTelemetry | null): void {
+    this._accountTelemetry = data;
+  }
+}
+
+function sameAccountTelemetry(
+  a: AccountTelemetry,
+  b: AccountTelemetry
+): boolean {
+  if (a.rateLimits.length !== b.rateLimits.length) return false;
+  for (let i = 0; i < a.rateLimits.length; i++) {
+    const ar = a.rateLimits[i];
+    const br = b.rateLimits[i];
+    if (!ar || !br) return false;
+    if (
+      ar.name !== br.name ||
+      ar.usedPercent !== br.usedPercent ||
+      ar.resetsAt !== br.resetsAt
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export { sameAccountTelemetry };
+
+// Self-register when this module is imported
+registerTelemetryAdapter('claude', (deps) => new ClaudeTelemetryAdapter(deps));

--- a/server/adapters/claude-telemetry.ts
+++ b/server/adapters/claude-telemetry.ts
@@ -1,8 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import type { AccountTelemetry, Session, TelemetryData } from '../types.js';
-import type { TelemetryAdapter, TelemetryDeps } from '../telemetry-adapter.js';
+import type { AccountTelemetry, TelemetryData } from '../types.js';
+import type {
+  TelemetryAdapter,
+  TelemetryDeps,
+  TelemetrySession,
+} from '../telemetry-adapter.js';
 import { registerTelemetryAdapter } from '../telemetry-adapter.js';
 import { createLogger } from '../logger.js';
 
@@ -98,7 +102,7 @@ export class ClaudeTelemetryAdapter implements TelemetryAdapter {
     this.deps = deps;
   }
 
-  attach(_session: Session): void {
+  attach(_session: TelemetrySession): void {
     // No async setup needed for Claude — telemetry is read from files on demand
   }
 
@@ -157,37 +161,10 @@ export class ClaudeTelemetryAdapter implements TelemetryAdapter {
   }
 
   /** Returns the most recently observed account telemetry, or null if none seen yet. */
-  getAccountTelemetry(): AccountTelemetry | null {
+  collectAccountTelemetry(): AccountTelemetry | null {
     return this._accountTelemetry;
   }
-
-  /** Allows telemetry.ts to restore persisted account state on startup. */
-  setAccountTelemetry(data: AccountTelemetry | null): void {
-    this._accountTelemetry = data;
-  }
 }
-
-function sameAccountTelemetry(
-  a: AccountTelemetry,
-  b: AccountTelemetry
-): boolean {
-  if (a.rateLimits.length !== b.rateLimits.length) return false;
-  for (let i = 0; i < a.rateLimits.length; i++) {
-    const ar = a.rateLimits[i];
-    const br = b.rateLimits[i];
-    if (!ar || !br) return false;
-    if (
-      ar.name !== br.name ||
-      ar.usedPercent !== br.usedPercent ||
-      ar.resetsAt !== br.resetsAt
-    ) {
-      return false;
-    }
-  }
-  return true;
-}
-
-export { sameAccountTelemetry };
 
 // Self-register when this module is imported
 registerTelemetryAdapter('claude', (deps) => new ClaudeTelemetryAdapter(deps));

--- a/server/index.ts
+++ b/server/index.ts
@@ -961,13 +961,16 @@ async function main(): Promise<void> {
     const now = Date.now();
     if (now - lastRateLimitSnapshot < RATE_LIMIT_SNAPSHOT_INTERVAL) return;
     const account = getAccountTelemetry();
-    if (!account || account.fiveHourUsedPercent < 0) return;
+    if (!account || !account.rateLimits.length) return;
+    const fiveHour = account.rateLimits.find((rl) => rl.name === 'five_hour' || rl.windowMinutes === 300);
+    const sevenDay = account.rateLimits.find((rl) => rl.name === 'seven_day' || rl.windowMinutes === 10080);
+    if (!fiveHour || fiveHour.usedPercent < 0) return;
     lastRateLimitSnapshot = now;
     recordRateLimitSnapshot({
-      fiveHourPercent: account.fiveHourUsedPercent,
-      fiveHourResetsAt: account.fiveHourResetsAt,
-      sevenDayPercent: account.sevenDayUsedPercent,
-      sevenDayResetsAt: account.sevenDayResetsAt,
+      fiveHourPercent: fiveHour.usedPercent,
+      fiveHourResetsAt: fiveHour.resetsAt,
+      sevenDayPercent: sevenDay?.usedPercent ?? -1,
+      sevenDayResetsAt: sevenDay?.resetsAt ?? '',
       timestamp: new Date().toISOString(),
     });
   }, 60_000);

--- a/server/telemetry-adapter.ts
+++ b/server/telemetry-adapter.ts
@@ -1,0 +1,34 @@
+import type { Session, TelemetryData } from './types.js';
+
+export interface TelemetryAdapter {
+  readonly framework: string;
+  attach(session: Session): void;
+  collectSnapshot(sessionId: string): TelemetryData | null;
+  detach(sessionId: string): void;
+}
+
+export interface TelemetryDeps {
+  getActiveSessions: () => Array<Pick<Session, 'id'>>;
+  broadcastEvent: (type: string, data?: Record<string, unknown>) => void;
+  configDir: string;
+}
+
+const TELEMETRY_ADAPTERS = new Map<
+  string,
+  (deps: TelemetryDeps) => TelemetryAdapter
+>();
+
+export function getAdapterForFramework(
+  frameworkId: string,
+  deps: TelemetryDeps
+): TelemetryAdapter | null {
+  const factory = TELEMETRY_ADAPTERS.get(frameworkId);
+  return factory ? factory(deps) : null;
+}
+
+export function registerTelemetryAdapter(
+  frameworkId: string,
+  factory: (deps: TelemetryDeps) => TelemetryAdapter
+): void {
+  TELEMETRY_ADAPTERS.set(frameworkId, factory);
+}

--- a/server/telemetry-adapter.ts
+++ b/server/telemetry-adapter.ts
@@ -1,14 +1,17 @@
-import type { Session, TelemetryData } from './types.js';
+import type { AccountTelemetry, Session, TelemetryData } from './types.js';
+
+export type TelemetrySession = Pick<Session, 'id'>;
 
 export interface TelemetryAdapter {
   readonly framework: string;
-  attach(session: Session): void;
+  attach(session: TelemetrySession): void;
   collectSnapshot(sessionId: string): TelemetryData | null;
+  collectAccountTelemetry?(): AccountTelemetry | null;
   detach(sessionId: string): void;
 }
 
 export interface TelemetryDeps {
-  getActiveSessions: () => Array<Pick<Session, 'id'>>;
+  getActiveSessions: () => TelemetrySession[];
   broadcastEvent: (type: string, data?: Record<string, unknown>) => void;
   configDir: string;
 }

--- a/server/telemetry.ts
+++ b/server/telemetry.ts
@@ -4,7 +4,13 @@ import { Router } from 'express';
 import type { Request, Response } from 'express';
 
 import type { AccountTelemetry, Session, TelemetryData } from './types.js';
+import type { TelemetryAdapter, TelemetryDeps } from './telemetry-adapter.js';
+import { getAdapterForFramework } from './telemetry-adapter.js';
+import { ClaudeTelemetryAdapter } from './adapters/claude-telemetry.js';
 import { createLogger } from './logger.js';
+
+// Re-export TelemetryDeps from telemetry-adapter for backward compat
+export type { TelemetryDeps } from './telemetry-adapter.js';
 
 const logger = createLogger('telemetry');
 
@@ -16,38 +22,23 @@ interface PendingTelemetryFile {
   version: number;
   timestamp: string;
   sessions: Record<string, TelemetryData>;
-  account: AccountTelemetry | null;
+  account: Record<string, AccountTelemetry> | null;
 }
 
 type IncomingTelemetryData = Omit<TelemetryData, 'updatedAt'>;
-
-export interface TelemetryDeps {
-  getActiveSessions: () => Array<Pick<Session, 'id'>>;
-  broadcastEvent: (type: string, data?: Record<string, unknown>) => void;
-  configDir: string;
-}
 
 let activeDeps: TelemetryDeps | null = null;
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 let persistTimer: ReturnType<typeof setInterval> | null = null;
 let sessionTelemetry = new Map<string, TelemetryData>();
-let accountTelemetry: AccountTelemetry | null = null;
+// Map from frameworkId -> AccountTelemetry
+let accountTelemetryMap = new Map<string, AccountTelemetry>();
+// Per-session adapter instances (keyed by sessionId)
+let sessionAdapters = new Map<string, TelemetryAdapter>();
 let restoredPendingOnly = false;
-
-function telemetryDir(configDir: string): string {
-  return path.join(configDir, 'telemetry');
-}
 
 function pendingFilePath(configDir: string): string {
   return path.join(configDir, 'pending-telemetry.json');
-}
-
-function asNumber(value: unknown, fallback: number): number {
-  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
-}
-
-function asString(value: unknown, fallback = ''): string {
-  return typeof value === 'string' ? value : fallback;
 }
 
 function telemetryToObject(): Record<string, TelemetryData> {
@@ -66,6 +57,7 @@ function sameTelemetry(
     a.totalOutputTokens === b.totalOutputTokens &&
     a.totalCacheRead === b.totalCacheRead &&
     a.totalCacheWrite === b.totalCacheWrite &&
+    a.reasoningOutputTokens === b.reasoningOutputTokens &&
     a.contextPercent === b.contextPercent &&
     a.contextWindowSize === b.contextWindowSize &&
     a.costUsd === b.costUsd &&
@@ -74,67 +66,42 @@ function sameTelemetry(
 }
 
 function sameAccountTelemetry(
-  a: AccountTelemetry | null,
-  b: Omit<AccountTelemetry, 'updatedAt'>
+  a: AccountTelemetry | undefined,
+  b: AccountTelemetry
 ): boolean {
   if (!a) return false;
-  return (
-    a.fiveHourUsedPercent === b.fiveHourUsedPercent &&
-    a.fiveHourResetsAt === b.fiveHourResetsAt &&
-    a.sevenDayUsedPercent === b.sevenDayUsedPercent &&
-    a.sevenDayResetsAt === b.sevenDayResetsAt
-  );
+  if (a.framework !== b.framework) return false;
+  if (a.rateLimits.length !== b.rateLimits.length) return false;
+  for (let i = 0; i < a.rateLimits.length; i++) {
+    const ar = a.rateLimits[i];
+    const br = b.rateLimits[i];
+    if (!ar || !br) return false;
+    if (
+      ar.name !== br.name ||
+      ar.usedPercent !== br.usedPercent ||
+      ar.resetsAt !== br.resetsAt
+    ) {
+      return false;
+    }
+  }
+  return true;
 }
 
-function extractTelemetry(
-  sessionId: string,
-  payload: unknown
-): {
-  session: IncomingTelemetryData;
-  account: Omit<AccountTelemetry, 'updatedAt'> | null;
-} | null {
-  if (!payload || typeof payload !== 'object') return null;
-
-  const data = payload as Record<string, unknown>;
-  const contextWindow = (data.context_window ?? {}) as Record<string, unknown>;
-  const currentUsage = (contextWindow.current_usage ?? {}) as Record<
-    string,
-    unknown
-  >;
-  const cost = (data.cost ?? {}) as Record<string, unknown>;
-  const rateLimits = (data.rate_limits ?? {}) as Record<string, unknown>;
-  const fiveHour = (rateLimits.five_hour ?? {}) as Record<string, unknown>;
-  const sevenDay = (rateLimits.seven_day ?? {}) as Record<string, unknown>;
-  const model = (data.model ?? {}) as Record<string, unknown>;
-
-  const session: IncomingTelemetryData = {
-    sessionId,
-    model: typeof model.display_name === 'string' ? model.display_name : null,
-    totalInputTokens: asNumber(contextWindow.total_input_tokens, 0),
-    totalOutputTokens: asNumber(contextWindow.total_output_tokens, 0),
-    totalCacheRead: asNumber(currentUsage.cache_read_input_tokens, 0),
-    totalCacheWrite: asNumber(currentUsage.cache_creation_input_tokens, 0),
-    contextPercent: asNumber(contextWindow.used_percentage, -1),
-    contextWindowSize: asNumber(contextWindow.context_window_size, 0),
-    costUsd:
-      typeof cost.total_cost_usd === 'number' ? cost.total_cost_usd : null,
-    source: 'statusLine',
-  };
-
-  const account =
-    typeof fiveHour.used_percentage === 'number' ||
-    typeof sevenDay.used_percentage === 'number' ||
-    typeof fiveHour.resets_at === 'string' ||
-    typeof sevenDay.resets_at === 'string'
-      ? {
-          fiveHourUsedPercent: asNumber(fiveHour.used_percentage, -1),
-          fiveHourResetsAt: asString(fiveHour.resets_at),
-          sevenDayUsedPercent: asNumber(sevenDay.used_percentage, -1),
-          sevenDayResetsAt: asString(sevenDay.resets_at),
-        }
-      : null;
-
-  return { session, account };
+function createAdapterForSession(
+  session: Pick<Session, 'id'> & { agent?: string },
+  deps: TelemetryDeps
+): TelemetryAdapter | null {
+  try {
+    const frameworkId = (session as Session).agent ?? 'claude';
+    const adapter = getAdapterForFramework(frameworkId, deps);
+    if (adapter) {
+      adapter.attach(session as Session);
+    }
+    return adapter;
+  } catch (err) {
+    logger.warn(`Failed to create adapter for session ${session.id}:`, err);
+    return null;
+  }
 }
 
 function restorePendingTelemetry(configDir: string): void {
@@ -145,6 +112,13 @@ function restorePendingTelemetry(configDir: string): void {
     const pending = JSON.parse(
       fs.readFileSync(pendingPath, 'utf-8')
     ) as PendingTelemetryFile;
+
+    // Reject v1 files — new format (v2) required
+    if (pending.version !== 2) {
+      fs.unlinkSync(pendingPath);
+      return;
+    }
+
     const ageMs = Date.now() - new Date(pending.timestamp).getTime();
     if (!Number.isFinite(ageMs) || ageMs > STALE_THRESHOLD_MS) {
       fs.unlinkSync(pendingPath);
@@ -152,9 +126,18 @@ function restorePendingTelemetry(configDir: string): void {
     }
 
     sessionTelemetry = new Map(Object.entries(pending.sessions ?? {}));
-    accountTelemetry = pending.account ?? null;
+
+    // Restore account telemetry map (v2 format: Record<frameworkId, AccountTelemetry>)
+    if (pending.account && typeof pending.account === 'object') {
+      for (const [frameworkId, acct] of Object.entries(pending.account)) {
+        if (acct && typeof acct === 'object' && 'framework' in acct) {
+          accountTelemetryMap.set(frameworkId, acct as AccountTelemetry);
+        }
+      }
+    }
+
     restoredPendingOnly =
-      sessionTelemetry.size > 0 || accountTelemetry !== null;
+      sessionTelemetry.size > 0 || accountTelemetryMap.size > 0;
     fs.unlinkSync(pendingPath);
   } catch {
     try {
@@ -167,10 +150,13 @@ function restorePendingTelemetry(configDir: string): void {
 
 function persistPendingTelemetry(configDir: string): void {
   const payload: PendingTelemetryFile = {
-    version: 1,
+    version: 2,
     timestamp: new Date().toISOString(),
     sessions: telemetryToObject(),
-    account: accountTelemetry,
+    account:
+      accountTelemetryMap.size > 0
+        ? Object.fromEntries(accountTelemetryMap.entries())
+        : null,
   };
   const filePath = pendingFilePath(configDir);
 
@@ -195,66 +181,59 @@ function collectTelemetry(): void {
         sessionTelemetry.delete(sessionId);
       }
     }
+    // Detach and remove adapters for ended sessions
+    for (const [sessionId, adapter] of [...sessionAdapters.entries()]) {
+      if (!activeSessionIds.has(sessionId)) {
+        try {
+          adapter.detach(sessionId);
+        } catch {
+          /* ignore cleanup errors */
+        }
+        sessionAdapters.delete(sessionId);
+      }
+    }
   } else if (!restoredPendingOnly) {
     sessionTelemetry = new Map();
+    sessionAdapters.clear();
   }
 
   for (const session of activeSessions) {
-    const filePath = path.join(
-      telemetryDir(activeDeps.configDir),
-      `${session.id}.json`
-    );
-    let raw: string;
-    try {
-      raw = fs.readFileSync(filePath, 'utf-8');
-    } catch (err) {
-      const error = err as NodeJS.ErrnoException;
-      if (error.code !== 'ENOENT') {
-        logger.warn(
-          `[telemetry] Failed to read telemetry for session ${session.id}:`,
-          err
-        );
+    // Get or create adapter for this session
+    let adapter = sessionAdapters.get(session.id);
+    if (!adapter) {
+      adapter = createAdapterForSession(session, activeDeps) ?? undefined;
+      if (adapter) {
+        sessionAdapters.set(session.id, adapter);
       }
-      continue;
     }
 
-    let payload: unknown;
-    try {
-      payload = JSON.parse(raw);
-    } catch (err) {
-      logger.warn(
-        `[telemetry] Malformed telemetry JSON for session ${session.id}:`,
-        err
-      );
-      continue;
-    }
+    if (!adapter) continue;
 
-    const extracted = extractTelemetry(session.id, payload);
-    if (!extracted) continue;
+    const snapshot = adapter.collectSnapshot(session.id);
+    if (!snapshot) continue;
 
-    if (!sameTelemetry(sessionTelemetry.get(session.id), extracted.session)) {
-      const nextSessionTelemetry: TelemetryData = {
-        ...extracted.session,
-        updatedAt: new Date().toISOString(),
-      };
-      sessionTelemetry.set(session.id, nextSessionTelemetry);
+    const { updatedAt: _u, ...snapshotWithoutUpdatedAt } = snapshot;
+
+    if (!sameTelemetry(sessionTelemetry.get(session.id), snapshotWithoutUpdatedAt)) {
+      sessionTelemetry.set(session.id, snapshot);
       activeDeps.broadcastEvent('session-telemetry', {
         sessionId: session.id,
-        data: nextSessionTelemetry,
+        data: snapshot,
       });
     }
 
-    if (
-      extracted.account &&
-      !sameAccountTelemetry(accountTelemetry, extracted.account)
-    ) {
-      accountTelemetry = {
-        ...extracted.account,
-        updatedAt: new Date().toISOString(),
-      };
-      activeDeps.broadcastEvent('account-telemetry', {
-        data: accountTelemetry,
-      });
+    // Poll account telemetry from adapter (side channel)
+    if (adapter instanceof ClaudeTelemetryAdapter) {
+      const adapterAccount = adapter.getAccountTelemetry();
+      if (adapterAccount) {
+        const existing = accountTelemetryMap.get(adapterAccount.framework);
+        if (!sameAccountTelemetry(existing, adapterAccount)) {
+          accountTelemetryMap.set(adapterAccount.framework, adapterAccount);
+          activeDeps.broadcastEvent('account-telemetry', {
+            data: adapterAccount,
+          });
+        }
+      }
     }
   }
 }
@@ -283,9 +262,18 @@ export function stopTelemetry(): void {
   if (activeDeps) {
     persistPendingTelemetry(activeDeps.configDir);
   }
+  // Detach all adapters
+  for (const [sessionId, adapter] of sessionAdapters.entries()) {
+    try {
+      adapter.detach(sessionId);
+    } catch {
+      /* ignore */
+    }
+  }
   activeDeps = null;
   sessionTelemetry = new Map();
-  accountTelemetry = null;
+  accountTelemetryMap = new Map();
+  sessionAdapters = new Map();
   restoredPendingOnly = false;
 }
 
@@ -296,7 +284,12 @@ export function getTelemetryForSession(
 }
 
 export function getAccountTelemetry(): AccountTelemetry | null {
-  return accountTelemetry;
+  // Prefer 'claude' framework; fall back to first available
+  return (
+    accountTelemetryMap.get('claude') ??
+    accountTelemetryMap.values().next().value ??
+    null
+  );
 }
 
 export function createTelemetryRouter(): Router {
@@ -307,7 +300,7 @@ export function createTelemetryRouter(): Router {
   });
 
   router.get('/account', (_req: Request, res: Response) => {
-    res.json(accountTelemetry);
+    res.json(getAccountTelemetry());
   });
 
   router.get('/setup-status', (_req: Request, res: Response) => {

--- a/server/telemetry.ts
+++ b/server/telemetry.ts
@@ -3,10 +3,15 @@ import path from 'node:path';
 import { Router } from 'express';
 import type { Request, Response } from 'express';
 
-import type { AccountTelemetry, Session, TelemetryData } from './types.js';
-import type { TelemetryAdapter, TelemetryDeps } from './telemetry-adapter.js';
+import type { AccountTelemetry, TelemetryData } from './types.js';
+import type {
+  TelemetryAdapter,
+  TelemetryDeps,
+  TelemetrySession,
+} from './telemetry-adapter.js';
 import { getAdapterForFramework } from './telemetry-adapter.js';
-import { ClaudeTelemetryAdapter } from './adapters/claude-telemetry.js';
+// Side-effect import: registers the Claude adapter in the adapter registry
+import './adapters/claude-telemetry.js';
 import { createLogger } from './logger.js';
 
 // Re-export TelemetryDeps from telemetry-adapter for backward compat
@@ -72,30 +77,26 @@ function sameAccountTelemetry(
   if (!a) return false;
   if (a.framework !== b.framework) return false;
   if (a.rateLimits.length !== b.rateLimits.length) return false;
-  for (let i = 0; i < a.rateLimits.length; i++) {
-    const ar = a.rateLimits[i];
-    const br = b.rateLimits[i];
-    if (!ar || !br) return false;
-    if (
-      ar.name !== br.name ||
-      ar.usedPercent !== br.usedPercent ||
-      ar.resetsAt !== br.resetsAt
-    ) {
-      return false;
-    }
-  }
-  return true;
+  return b.rateLimits.every((br) => {
+    const ar = a.rateLimits.find((r) => r.name === br.name);
+    if (!ar) return false;
+    return (
+      ar.usedPercent === br.usedPercent &&
+      ar.resetsAt === br.resetsAt &&
+      ar.windowMinutes === br.windowMinutes
+    );
+  });
 }
 
 function createAdapterForSession(
-  session: Pick<Session, 'id'> & { agent?: string },
+  session: TelemetrySession & { agent?: string },
   deps: TelemetryDeps
 ): TelemetryAdapter | null {
   try {
-    const frameworkId = (session as Session).agent ?? 'claude';
+    const frameworkId = session.agent ?? 'claude';
     const adapter = getAdapterForFramework(frameworkId, deps);
     if (adapter) {
-      adapter.attach(session as Session);
+      adapter.attach(session);
     }
     return adapter;
   } catch (err) {
@@ -168,72 +169,83 @@ function persistPendingTelemetry(configDir: string): void {
   }
 }
 
+function pruneEndedSessions(activeSessionIds: Set<string>): void {
+  for (const sessionId of [...sessionTelemetry.keys()]) {
+    if (!activeSessionIds.has(sessionId)) {
+      sessionTelemetry.delete(sessionId);
+    }
+  }
+  for (const [sessionId, adapter] of [...sessionAdapters.entries()]) {
+    if (!activeSessionIds.has(sessionId)) {
+      try {
+        adapter.detach(sessionId);
+      } catch {
+        /* ignore cleanup errors */
+      }
+      sessionAdapters.delete(sessionId);
+    }
+  }
+}
+
+function getOrCreateAdapter(
+  session: TelemetrySession,
+  deps: TelemetryDeps
+): TelemetryAdapter | undefined {
+  let adapter = sessionAdapters.get(session.id);
+  if (!adapter) {
+    adapter = createAdapterForSession(session, deps) ?? undefined;
+    if (adapter) {
+      sessionAdapters.set(session.id, adapter);
+    }
+  }
+  return adapter;
+}
+
+function pollSessionTelemetry(
+  adapter: TelemetryAdapter,
+  sessionId: string,
+  deps: TelemetryDeps
+): void {
+  const snapshot = adapter.collectSnapshot(sessionId);
+  if (!snapshot) return;
+
+  const { updatedAt: _u, ...incoming } = snapshot;
+  if (!sameTelemetry(sessionTelemetry.get(sessionId), incoming)) {
+    sessionTelemetry.set(sessionId, snapshot);
+    deps.broadcastEvent('session-telemetry', { sessionId, data: snapshot });
+  }
+
+  const adapterAccount = adapter.collectAccountTelemetry?.();
+  if (
+    adapterAccount &&
+    !sameAccountTelemetry(
+      accountTelemetryMap.get(adapterAccount.framework),
+      adapterAccount
+    )
+  ) {
+    accountTelemetryMap.set(adapterAccount.framework, adapterAccount);
+    deps.broadcastEvent('account-telemetry', { data: adapterAccount });
+  }
+}
+
 function collectTelemetry(): void {
   if (!activeDeps) return;
 
   const activeSessions = activeDeps.getActiveSessions();
-  const activeSessionIds = new Set(activeSessions.map((session) => session.id));
+  const activeSessionIds = new Set(activeSessions.map((s) => s.id));
 
   if (activeSessionIds.size > 0) {
     restoredPendingOnly = false;
-    for (const sessionId of [...sessionTelemetry.keys()]) {
-      if (!activeSessionIds.has(sessionId)) {
-        sessionTelemetry.delete(sessionId);
-      }
-    }
-    // Detach and remove adapters for ended sessions
-    for (const [sessionId, adapter] of [...sessionAdapters.entries()]) {
-      if (!activeSessionIds.has(sessionId)) {
-        try {
-          adapter.detach(sessionId);
-        } catch {
-          /* ignore cleanup errors */
-        }
-        sessionAdapters.delete(sessionId);
-      }
-    }
+    pruneEndedSessions(activeSessionIds);
   } else if (!restoredPendingOnly) {
     sessionTelemetry = new Map();
     sessionAdapters.clear();
   }
 
   for (const session of activeSessions) {
-    // Get or create adapter for this session
-    let adapter = sessionAdapters.get(session.id);
-    if (!adapter) {
-      adapter = createAdapterForSession(session, activeDeps) ?? undefined;
-      if (adapter) {
-        sessionAdapters.set(session.id, adapter);
-      }
-    }
-
-    if (!adapter) continue;
-
-    const snapshot = adapter.collectSnapshot(session.id);
-    if (!snapshot) continue;
-
-    const { updatedAt: _u, ...snapshotWithoutUpdatedAt } = snapshot;
-
-    if (!sameTelemetry(sessionTelemetry.get(session.id), snapshotWithoutUpdatedAt)) {
-      sessionTelemetry.set(session.id, snapshot);
-      activeDeps.broadcastEvent('session-telemetry', {
-        sessionId: session.id,
-        data: snapshot,
-      });
-    }
-
-    // Poll account telemetry from adapter (side channel)
-    if (adapter instanceof ClaudeTelemetryAdapter) {
-      const adapterAccount = adapter.getAccountTelemetry();
-      if (adapterAccount) {
-        const existing = accountTelemetryMap.get(adapterAccount.framework);
-        if (!sameAccountTelemetry(existing, adapterAccount)) {
-          accountTelemetryMap.set(adapterAccount.framework, adapterAccount);
-          activeDeps.broadcastEvent('account-telemetry', {
-            data: adapterAccount,
-          });
-        }
-      }
+    const adapter = getOrCreateAdapter(session, activeDeps);
+    if (adapter) {
+      pollSessionTelemetry(adapter, session.id, activeDeps);
     }
   }
 }

--- a/server/types.ts
+++ b/server/types.ts
@@ -273,6 +273,7 @@ export interface TelemetryData {
   totalOutputTokens: number;
   totalCacheRead: number;
   totalCacheWrite: number;
+  reasoningOutputTokens: number;
   contextPercent: number;
   contextWindowSize: number;
   costUsd: number | null;
@@ -280,11 +281,17 @@ export interface TelemetryData {
   updatedAt: string;
 }
 
+export interface RateLimitWindow {
+  name: string;
+  usedPercent: number;
+  resetsAt: string;
+  windowMinutes?: number;
+}
+
 export interface AccountTelemetry {
-  fiveHourUsedPercent: number;
-  fiveHourResetsAt: string;
-  sevenDayUsedPercent: number;
-  sevenDayResetsAt: string;
+  framework: string;
+  rateLimits: RateLimitWindow[];
+  planType?: string;
   updatedAt: string;
 }
 

--- a/test/telemetry-sync.test.ts
+++ b/test/telemetry-sync.test.ts
@@ -34,10 +34,11 @@ function makeAccountTelemetry(
   overrides: Partial<AccountTelemetry> = {}
 ): AccountTelemetry {
   return {
-    fiveHourUsedPercent: 10,
-    fiveHourResetsAt: '2026-04-01T05:00:00.000Z',
-    sevenDayUsedPercent: 20,
-    sevenDayResetsAt: '2026-04-07T00:00:00.000Z',
+    framework: 'claude',
+    rateLimits: [
+      { name: 'five_hour', usedPercent: 10, resetsAt: '2026-04-01T05:00:00.000Z', windowMinutes: 300 },
+      { name: 'seven_day', usedPercent: 20, resetsAt: '2026-04-07T00:00:00.000Z', windowMinutes: 10080 },
+    ],
     updatedAt: '2026-04-01T00:00:00.000Z',
     ...overrides,
   };
@@ -50,7 +51,10 @@ describe('mergeSessionTelemetrySnapshot', () => {
       updatedAt: '2026-04-01T00:00:10.000Z',
     });
     const currentAccount = makeAccountTelemetry({
-      fiveHourUsedPercent: 55,
+      rateLimits: [
+        { name: 'five_hour', usedPercent: 55, resetsAt: '2026-04-01T05:00:00.000Z', windowMinutes: 300 },
+        { name: 'seven_day', usedPercent: 20, resetsAt: '2026-04-07T00:00:00.000Z', windowMinutes: 10080 },
+      ],
       updatedAt: '2026-04-01T00:00:10.000Z',
     });
 
@@ -70,7 +74,10 @@ describe('mergeSessionTelemetrySnapshot', () => {
     const mergedAccount = mergeAccountTelemetrySnapshot(
       currentAccount,
       makeAccountTelemetry({
-        fiveHourUsedPercent: 20,
+        rateLimits: [
+          { name: 'five_hour', usedPercent: 20, resetsAt: '2026-04-01T05:00:00.000Z', windowMinutes: 300 },
+          { name: 'seven_day', usedPercent: 20, resetsAt: '2026-04-07T00:00:00.000Z', windowMinutes: 10080 },
+        ],
         updatedAt: '2026-04-01T00:00:05.000Z',
       }),
       '2026-04-01T00:00:08.000Z'

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -118,6 +118,7 @@ test('parses session telemetry from the statusLine file', () => {
     totalOutputTokens: 3200,
     totalCacheRead: 5000,
     totalCacheWrite: 1000,
+    reasoningOutputTokens: 0,
     contextPercent: 7.8,
     contextWindowSize: 200000,
     costUsd: 0.42,
@@ -126,10 +127,11 @@ test('parses session telemetry from the statusLine file', () => {
   });
 
   expect(account).toEqual({
-    fiveHourUsedPercent: 22,
-    fiveHourResetsAt: '2026-03-31T19:30:00Z',
-    sevenDayUsedPercent: 8,
-    sevenDayResetsAt: '2026-04-03T00:00:00Z',
+    framework: 'claude',
+    rateLimits: [
+      { name: 'five_hour', usedPercent: 22, resetsAt: '2026-03-31T19:30:00Z', windowMinutes: 300 },
+      { name: 'seven_day', usedPercent: 8, resetsAt: '2026-04-03T00:00:00Z', windowMinutes: 10080 },
+    ],
     updatedAt: account?.updatedAt,
   });
 
@@ -153,7 +155,7 @@ test('missing statusLine file leaves telemetry undefined', () => {
 
 test('inactive sessions are pruned once active telemetry is available', () => {
   writePendingTelemetryFile(tmpDir, {
-    version: 1,
+    version: 2,
     timestamp: new Date().toISOString(),
     sessions: {
       stale: {
@@ -163,6 +165,7 @@ test('inactive sessions are pruned once active telemetry is available', () => {
         totalOutputTokens: 20,
         totalCacheRead: 30,
         totalCacheWrite: 40,
+        reasoningOutputTokens: 0,
         contextPercent: 11,
         contextWindowSize: 999,
         costUsd: 1.23,
@@ -196,8 +199,16 @@ test('malformed statusLine JSON is ignored without crashing', () => {
 });
 
 test('restores pending telemetry from disk on startup', () => {
+  const restoredAccount = {
+    framework: 'claude',
+    rateLimits: [
+      { name: 'five_hour', usedPercent: 44, resetsAt: '2026-03-31T19:30:00Z', windowMinutes: 300 },
+      { name: 'seven_day', usedPercent: 55, resetsAt: '2026-04-03T00:00:00Z', windowMinutes: 10080 },
+    ],
+    updatedAt: '2026-03-31T18:00:00Z',
+  };
   const restored = {
-    version: 1,
+    version: 2,
     timestamp: new Date().toISOString(),
     sessions: {
       restored: {
@@ -207,6 +218,7 @@ test('restores pending telemetry from disk on startup', () => {
         totalOutputTokens: 20,
         totalCacheRead: 30,
         totalCacheWrite: 40,
+        reasoningOutputTokens: 0,
         contextPercent: 11,
         contextWindowSize: 999,
         costUsd: 1.23,
@@ -214,13 +226,7 @@ test('restores pending telemetry from disk on startup', () => {
         updatedAt: '2026-03-31T18:00:00Z',
       },
     },
-    account: {
-      fiveHourUsedPercent: 44,
-      fiveHourResetsAt: '2026-03-31T19:30:00Z',
-      sevenDayUsedPercent: 55,
-      sevenDayResetsAt: '2026-04-03T00:00:00Z',
-      updatedAt: '2026-03-31T18:00:00Z',
-    },
+    account: { claude: restoredAccount },
   };
   const pendingPath = writePendingTelemetryFile(tmpDir, restored);
   const events: Array<{ type: string; data?: Record<string, unknown> }> = [];
@@ -234,20 +240,29 @@ test('restores pending telemetry from disk on startup', () => {
     totalOutputTokens: 20,
     totalCacheRead: 30,
     totalCacheWrite: 40,
+    reasoningOutputTokens: 0,
     contextPercent: 11,
     contextWindowSize: 999,
     costUsd: 1.23,
     source: 'statusLine',
     updatedAt: '2026-03-31T18:00:00Z',
   });
-  expect(getAccountTelemetry()).toEqual(restored.account);
+  expect(getAccountTelemetry()).toEqual(restoredAccount);
   expect(fs.existsSync(pendingPath)).toBe(false);
   expect(events.length).toBe(0);
 });
 
 test('GET /telemetry endpoints return session and account telemetry', async () => {
+  const restoredAccount = {
+    framework: 'claude',
+    rateLimits: [
+      { name: 'five_hour', usedPercent: 9, resetsAt: '2026-03-31T19:30:00Z', windowMinutes: 300 },
+      { name: 'seven_day', usedPercent: 18, resetsAt: '2026-04-03T00:00:00Z', windowMinutes: 10080 },
+    ],
+    updatedAt: '2026-03-31T18:00:00Z',
+  };
   const restored = {
-    version: 1,
+    version: 2,
     timestamp: new Date().toISOString(),
     sessions: {
       endpoint: {
@@ -257,6 +272,7 @@ test('GET /telemetry endpoints return session and account telemetry', async () =
         totalOutputTokens: 200,
         totalCacheRead: 300,
         totalCacheWrite: 400,
+        reasoningOutputTokens: 0,
         contextPercent: 12.5,
         contextWindowSize: 123456,
         costUsd: 4.56,
@@ -264,13 +280,7 @@ test('GET /telemetry endpoints return session and account telemetry', async () =
         updatedAt: '2026-03-31T18:00:00Z',
       },
     },
-    account: {
-      fiveHourUsedPercent: 9,
-      fiveHourResetsAt: '2026-03-31T19:30:00Z',
-      sevenDayUsedPercent: 18,
-      sevenDayResetsAt: '2026-04-03T00:00:00Z',
-      updatedAt: '2026-03-31T18:00:00Z',
-    },
+    account: { claude: restoredAccount },
   };
   writePendingTelemetryFile(tmpDir, restored);
   startTelemetry(makeDeps([], []));
@@ -299,6 +309,7 @@ test('GET /telemetry endpoints return session and account telemetry', async () =
         totalOutputTokens: 200,
         totalCacheRead: 300,
         totalCacheWrite: 400,
+        reasoningOutputTokens: 0,
         contextPercent: 12.5,
         contextWindowSize: 123456,
         costUsd: 4.56,
@@ -309,7 +320,7 @@ test('GET /telemetry endpoints return session and account telemetry', async () =
 
     const accountRes = await fetch(`${baseUrl}/telemetry/account`);
     expect(accountRes.status).toBe(200);
-    expect(await accountRes.json()).toEqual(restored.account);
+    expect(await accountRes.json()).toEqual(restoredAccount);
 
     const setupStatusRes = await fetch(`${baseUrl}/telemetry/setup-status`);
     expect(setupStatusRes.status).toBe(200);


### PR DESCRIPTION
## Summary

- Defines `TelemetryAdapter` interface and adapter registry (`server/telemetry-adapter.ts`) — separates adapter concerns from the poller loop
- Extracts Claude-specific telemetry logic into `ClaudeTelemetryAdapter` (`server/adapters/claude-telemetry.ts`) — pure refactor of existing file-read + JSON-parse logic
- Generalizes `AccountTelemetry` in `server/types.ts` and `frontend/src/lib/types.ts`: replaces Claude-specific `fiveHour*`/`sevenDay*` fields with `framework: string` + `rateLimits: RateLimitWindow[]`
- Adds `reasoningOutputTokens: number` to `TelemetryData`
- Refactors `server/telemetry.ts`: dispatches through adapter registry, `accountTelemetry` becomes `Map<frameworkId, AccountTelemetry>`, pending file version bumped 1→2 (v1 rejected on restore), `createAdapterForSession()` wrapped in try/catch so one bad adapter never kills the poll loop
- Updates all consumers: `server/index.ts`, `frontend/src/lib/api.ts`, `frontend/src/lib/stores/telemetry.ts`, `SessionStatusBar.tsx`, `RepoDashboard.tsx`
- Updates tests for new `AccountTelemetry` shape and version-2 pending files

Closes #106
Closes #107

## Test plan

- [x] `npm test` — 1090 tests pass (pre-existing failures in `worktrees.test.ts`, `browser-cli.test.ts`, `server-startup.test.ts`, `paths.test.ts` are unchanged from nightly baseline)
- [x] `tsc --noEmit` — zero TypeScript errors
- [x] Pre-push hook ran 237 changed tests, all green
- [ ] Manual: verify rate limit display in SessionStatusBar and RepoDashboard still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)