### PR TITLE
fix: wire onResumeWorktree so inactive worktree sidebar clicks work

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -537,6 +537,7 @@ export default function App() {
     handlePrAction,
     handleOpenPrSession,
     handleDeleteWorktree,
+    handleResumeWorktree,
     handleNewSessionCreated,
     handleCloseSession,
   } = useSessionHandlers({
@@ -788,6 +789,7 @@ export default function App() {
           onAddWorkspace={handleAddWorkspace}
           onDeleteSession={handleCloseSession}
           onDeleteWorktree={handleDeleteWorktree}
+          onResumeWorktree={handleResumeWorktree}
           onLaunchWorkspaceSession={handleLaunchWorkspaceSession}
           onLaunchRepoSession={handleLaunchRepoSession}
           onOpenAnalytics={openAnalytics}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -74,6 +74,7 @@ interface UngroupedListProps {
   onOpenSettings: (workspace?: Repo) => void;
   onDeleteSession: ((id: string) => void) | undefined;
   onDeleteWorktree: ((wt: WorktreeInfo) => void) | undefined;
+  onResumeWorktree: ((wt: WorktreeInfo) => void) | undefined;
   onLaunchRepoSession: ((repoPath: string) => void) | undefined;
 }
 
@@ -89,6 +90,7 @@ function UngroupedList({
   onOpenSettings,
   onDeleteSession,
   onDeleteWorktree,
+  onResumeWorktree,
   onLaunchRepoSession,
 }: UngroupedListProps) {
   const getSessionsForRepo = useSessionsStore((s) => s.getSessionsForRepo);
@@ -123,6 +125,7 @@ function UngroupedList({
               onOpenSettings={onOpenSettings}
               onDeleteSession={onDeleteSession}
               onDeleteWorktree={onDeleteWorktree}
+              onResumeWorktree={onResumeWorktree}
               onLaunchRepoSession={onLaunchRepoSession}
               orgPrs={orgPrs}
               sidebarItems={sidebarItems}
@@ -171,6 +174,7 @@ interface WorkspaceGroupsListProps {
   onOpenSettings: (repo?: Repo) => void;
   onDeleteSession: ((id: string) => void) | undefined;
   onDeleteWorktree: ((wt: WorktreeInfo) => void) | undefined;
+  onResumeWorktree: ((wt: WorktreeInfo) => void) | undefined;
   onLaunchWorkspaceSession: ((workspaceId: string) => void) | undefined;
   onLaunchRepoSession: ((repoPath: string) => void) | undefined;
 }
@@ -190,6 +194,7 @@ function WorkspaceGroupsList({
   onOpenSettings,
   onDeleteSession,
   onDeleteWorktree,
+  onResumeWorktree,
   onLaunchWorkspaceSession,
   onLaunchRepoSession,
 }: WorkspaceGroupsListProps) {
@@ -225,6 +230,7 @@ function WorkspaceGroupsList({
             onOpenSettings={onOpenSettings}
             onDeleteSession={(id) => onDeleteSession?.(id)}
             onDeleteWorktree={(wt) => onDeleteWorktree?.(wt)}
+            onResumeWorktree={(wt) => onResumeWorktree?.(wt)}
             {...(onLaunchRepoSession ? { onLaunchRepoSession } : {})}
             orgPrs={orgPrs}
           />
@@ -243,6 +249,7 @@ export interface SidebarProps {
   onAddWorkspace: () => void;
   onDeleteSession?: (id: string) => void;
   onDeleteWorktree?: (wt: WorktreeInfo) => void;
+  onResumeWorktree?: (wt: WorktreeInfo) => void;
   onLaunchWorkspaceSession?: (workspaceId: string) => void;
   onLaunchRepoSession?: (repoPath: string) => void;
   onOpenAnalytics: () => void;
@@ -255,6 +262,7 @@ export function Sidebar({
   onAddWorkspace,
   onDeleteSession,
   onDeleteWorktree,
+  onResumeWorktree,
   onLaunchWorkspaceSession,
   onLaunchRepoSession,
   onOpenAnalytics,
@@ -397,6 +405,7 @@ export function Sidebar({
               onOpenSettings={onOpenSettings}
               onDeleteSession={onDeleteSession}
               onDeleteWorktree={onDeleteWorktree}
+              onResumeWorktree={onResumeWorktree}
               onLaunchWorkspaceSession={onLaunchWorkspaceSession}
               onLaunchRepoSession={onLaunchRepoSession}
             />
@@ -417,6 +426,7 @@ export function Sidebar({
                   onOpenSettings={onOpenSettings}
                   onDeleteSession={onDeleteSession}
                   onDeleteWorktree={onDeleteWorktree}
+                  onResumeWorktree={onResumeWorktree}
                   onLaunchRepoSession={onLaunchRepoSession}
                 />
               </>

--- a/frontend/src/components/WorkspaceGroup.tsx
+++ b/frontend/src/components/WorkspaceGroup.tsx
@@ -35,6 +35,7 @@ export interface WorkspaceGroupProps {
   onOpenSettings: (workspace?: Repo) => void;
   onDeleteSession?: ((id: string) => void) | undefined;
   onDeleteWorktree?: ((wt: WorktreeInfo) => void) | undefined;
+  onResumeWorktree?: ((wt: WorktreeInfo) => void) | undefined;
   onLaunchRepoSession?: ((repoPath: string) => void) | undefined;
   orgPrs?: PullRequest[];
   loadingItems?: Set<string> | undefined;
@@ -95,6 +96,7 @@ function GroupBody({
   onOpenSettings,
   onDeleteSession,
   onDeleteWorktree,
+  onResumeWorktree,
   onLaunchRepoSession,
 }: GroupBodyProps) {
   const sidebarItems = useSessionsStore((s) => s.sidebarItems);
@@ -154,6 +156,7 @@ function GroupBody({
             onOpenSettings={onOpenSettings}
             onDeleteSession={onDeleteSession}
             onDeleteWorktree={onDeleteWorktree}
+            onResumeWorktree={onResumeWorktree}
             onLaunchRepoSession={onLaunchRepoSession}
             orgPrs={orgPrs ?? []}
             loadingItems={loadingItems}
@@ -183,6 +186,7 @@ export function WorkspaceGroup({
   onOpenSettings,
   onDeleteSession,
   onDeleteWorktree,
+  onResumeWorktree,
   onLaunchRepoSession,
   orgPrs,
   loadingItems = EMPTY_SET,
@@ -236,6 +240,7 @@ export function WorkspaceGroup({
           onLaunchRepoSession={onLaunchRepoSession}
           onDeleteSession={onDeleteSession}
           onDeleteWorktree={onDeleteWorktree}
+          onResumeWorktree={onResumeWorktree}
           onToggleCollapse={onToggleCollapse}
           collapsed={collapsed}
           loading={loading}

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -732,6 +732,55 @@ export function useSessionHandlers({
     [terminalRef]
   );
 
+  const handleResumeWorktree = useCallback(async (wt: WorktreeInfo) => {
+    const loadingKey = wt.path;
+    if (useSessionsStore.getState().isItemLoading(loadingKey)) return;
+    useSessionsStore.getState().setLoading(loadingKey);
+    try {
+      const { cols, rows } = estimateTerminalDimensions();
+      const session = await createSession({
+        repoPath: wt.repoPath,
+        worktreePath: wt.path,
+        type: 'agent',
+        branchName: wt.branchName,
+        cols,
+        rows,
+      });
+      await useSessionsStore.getState().refreshAll();
+      if (session?.id) {
+        useSessionsStore.getState().setActiveSessionId(session.id);
+        useUiStore.getState().setActiveRepoPath(wt.repoPath);
+        useSessionsStore
+          .getState()
+          .initSessionNotification(
+            session.id,
+            useConfigStore.getState().defaultNotifications
+          );
+        useUiStore.getState().closeSidebar();
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error && 'sessionId' in err) {
+        const conflictErr = err as Error & { sessionId?: string };
+        await useSessionsStore.getState().refreshAll();
+        if (conflictErr.sessionId) {
+          useSessionsStore.getState().setActiveSessionId(conflictErr.sessionId);
+          useUiStore.getState().setActiveRepoPath(wt.repoPath);
+          useUiStore.getState().closeSidebar();
+        }
+      } else {
+        useToastStore
+          .getState()
+          .showToast(
+            err instanceof Error
+              ? err.message
+              : 'failed to resume worktree session'
+          );
+      }
+    } finally {
+      useSessionsStore.getState().clearLoading(loadingKey);
+    }
+  }, []);
+
   const handleCloseSession = useCallback((sessionId: string) => {
     // Kill session via API, then refresh
     fetch(`/sessions/${sessionId}`, { method: 'DELETE' }).then(() =>
@@ -776,6 +825,7 @@ export function useSessionHandlers({
     handlePrAction,
     handleOpenPrSession,
     handleDeleteWorktree,
+    handleResumeWorktree,
     handleNewSessionCreated,
     handleCloseSession,
   };


### PR DESCRIPTION
## Summary
- `onResumeWorktree` was declared on `RepoItem` but never passed from any parent component, making clicks on inactive worktree sidebar items a silent no-op
- Added `handleResumeWorktree` callback in `useSessionHandlers` that creates a new agent session targeting the worktree's path/branch (follows same pattern as `handleLaunchRepoSession` with loading state + conflict handling)
- Threaded the prop through `App → Sidebar → UngroupedList/WorkspaceGroupsList → WorkspaceGroup → RepoItem`

## Test plan
- [ ] Open sidebar with an inactive worktree (no active session, shows disconnected dot)
- [ ] Click the inactive worktree item — verify a new session is created and terminal opens
- [ ] Verify loading state shows "resuming..." text during session creation
- [ ] Verify 409 conflict (existing session) is handled gracefully
- [ ] Verify error toast appears on failure
- [ ] Verify existing active session clicks still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)