### PR TITLE
feat: delete worktrees from active session menu with dirty-check

### DIFF
--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -142,6 +142,7 @@ interface SessionGroupRowProps {
   cancelLongPress: () => void;
   onSelectSession: (id: string) => void;
   onDeleteSession?: ((id: string) => void) | undefined;
+  onDeleteWorktree?: ((wt: WorktreeInfo) => void) | undefined;
   repoPath: string;
 }
 
@@ -156,6 +157,7 @@ function SessionGroupRow({
   cancelLongPress,
   onSelectSession,
   onDeleteSession,
+  onDeleteWorktree,
   repoPath,
 }: SessionGroupRowProps) {
   return (
@@ -198,15 +200,41 @@ function SessionGroupRow({
           </span>
         ) : null}
       </div>
-      {onDeleteSession ? (
+      {onDeleteSession || (onDeleteWorktree && groupPath !== repoPath) ? (
         <div className="row-menu-overlay">
           <ContextMenu
             items={[
-              {
-                label: 'close session',
-                action: () => onDeleteSession(rep.id),
-                danger: true,
-              },
+              ...(onDeleteSession
+                ? [
+                    {
+                      label: 'close session',
+                      action: () => onDeleteSession(rep.id),
+                      danger: true,
+                    },
+                  ]
+                : []),
+              ...(onDeleteWorktree && groupPath !== repoPath
+                ? [
+                    {
+                      label: 'delete worktree',
+                      action: () =>
+                        onDeleteWorktree({
+                          name: groupPath.split('/').pop() || '',
+                          path: groupPath,
+                          repoName: rep.repoName,
+                          repoPath,
+                          displayName: groupDisplayName(
+                            groupPath,
+                            repoPath,
+                            groupSessions
+                          ),
+                          lastActivity: rep.lastActivity,
+                          branchName: rep.branchName || '',
+                        }),
+                      danger: true,
+                    },
+                  ]
+                : []),
             ]}
           />
         </div>
@@ -409,6 +437,7 @@ export function RepoItem({
                   cancelLongPress={cancelLongPress}
                   onSelectSession={onSelectSession}
                   onDeleteSession={onDeleteSession}
+                  onDeleteWorktree={onDeleteWorktree}
                   repoPath={repo.path}
                 />
               );

--- a/frontend/src/components/dialogs/DeleteWorktreeDialog.tsx
+++ b/frontend/src/components/dialogs/DeleteWorktreeDialog.tsx
@@ -12,7 +12,7 @@ import type { WorktreeInfo } from '../../lib/types.js';
 import './DeleteWorktreeDialog.css';
 
 export interface DeleteWorktreeDialogHandle {
-  open(wt: WorktreeInfo, hasActiveSessions?: boolean): void;
+  open(wt: WorktreeInfo, hasActiveSessions: boolean): void;
   close(): void;
 }
 
@@ -22,12 +22,12 @@ const DeleteWorktreeDialog = forwardRef<DeleteWorktreeDialogHandle>(
     const [worktree, setWorktree] = useState<WorktreeInfo | null>(null);
     const [error, setError] = useState('');
     const [deleting, setDeleting] = useState(false);
-    const [activeSessions, setActiveSessions] = useState(false);
+    const [hasActiveSessions, setHasActiveSessions] = useState(false);
 
     useImperativeHandle(ref, () => ({
-      open(wt: WorktreeInfo, hasActiveSessions?: boolean) {
+      open(wt: WorktreeInfo, hasActiveSessions: boolean) {
         setWorktree(wt);
-        setActiveSessions(hasActiveSessions ?? false);
+        setHasActiveSessions(hasActiveSessions);
         setError('');
         setDeleting(false);
         shellRef.current?.open();
@@ -91,7 +91,7 @@ const DeleteWorktreeDialog = forwardRef<DeleteWorktreeDialogHandle>(
               <p className="delete-worktree-warning-msg">
                 This worktree has uncommitted changes that will be lost.
               </p>
-              {activeSessions && (
+              {hasActiveSessions && (
                 <p className="delete-worktree-warning-msg">
                   Active sessions will be terminated.
                 </p>

--- a/frontend/src/components/dialogs/DeleteWorktreeDialog.tsx
+++ b/frontend/src/components/dialogs/DeleteWorktreeDialog.tsx
@@ -12,7 +12,7 @@ import type { WorktreeInfo } from '../../lib/types.js';
 import './DeleteWorktreeDialog.css';
 
 export interface DeleteWorktreeDialogHandle {
-  open(wt: WorktreeInfo): void;
+  open(wt: WorktreeInfo, hasActiveSessions?: boolean): void;
   close(): void;
 }
 
@@ -22,10 +22,12 @@ const DeleteWorktreeDialog = forwardRef<DeleteWorktreeDialogHandle>(
     const [worktree, setWorktree] = useState<WorktreeInfo | null>(null);
     const [error, setError] = useState('');
     const [deleting, setDeleting] = useState(false);
+    const [activeSessions, setActiveSessions] = useState(false);
 
     useImperativeHandle(ref, () => ({
-      open(wt: WorktreeInfo) {
+      open(wt: WorktreeInfo, hasActiveSessions?: boolean) {
         setWorktree(wt);
+        setActiveSessions(hasActiveSessions ?? false);
         setError('');
         setDeleting(false);
         shellRef.current?.open();
@@ -41,7 +43,7 @@ const DeleteWorktreeDialog = forwardRef<DeleteWorktreeDialogHandle>(
       setError('');
       useSessionsStore.getState().setLoading(worktree.path);
       try {
-        await deleteWorktree(worktree.path, worktree.repoPath);
+        await deleteWorktree(worktree.path, worktree.repoPath, true);
         shellRef.current?.close();
       } catch (err: unknown) {
         setError(
@@ -87,8 +89,13 @@ const DeleteWorktreeDialog = forwardRef<DeleteWorktreeDialogHandle>(
               </p>
               <p className="delete-worktree-wt-path">{worktree.path}</p>
               <p className="delete-worktree-warning-msg">
-                This action cannot be undone.
+                This worktree has uncommitted changes that will be lost.
               </p>
+              {activeSessions && (
+                <p className="delete-worktree-warning-msg">
+                  Active sessions will be terminated.
+                </p>
+              )}
             </>
           )}
           {error && <p className="delete-worktree-error-msg">{error}</p>}

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -12,6 +12,7 @@ import {
   createWorktree,
   createSession,
   fetchWorkspaceSettings,
+  fetchWorktreeStatus,
   killSession,
   deleteWorktree,
   renameSession as renameSessionApi,
@@ -711,8 +712,28 @@ export function useSessionHandlers({
   );
 
   const handleDeleteWorktree = useCallback(
-    (wt: WorktreeInfo) => {
-      deleteWorktreeDialogRef.current?.open(wt);
+    async (wt: WorktreeInfo) => {
+      try {
+        const status = await fetchWorktreeStatus(wt.path);
+        const hasActive = status.activeSessions.length > 0;
+        if (status.hasUncommittedChanges) {
+          deleteWorktreeDialogRef.current?.open(wt, hasActive);
+        } else {
+          useSessionsStore.getState().setLoading(wt.path);
+          try {
+            await deleteWorktree(wt.path, wt.repoPath, hasActive);
+          } finally {
+            useSessionsStore.getState().clearLoading(wt.path);
+          }
+        }
+      } catch (err) {
+        useToastStore
+          .getState()
+          .showToast(
+            err instanceof Error ? err.message : 'Failed to delete worktree',
+            'error'
+          );
+      }
     },
     [deleteWorktreeDialogRef]
   );

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -721,7 +721,11 @@ export function useSessionHandlers({
         } else {
           useSessionsStore.getState().setLoading(wt.path);
           try {
-            await deleteWorktree(wt.path, wt.repoPath, hasActive);
+            if (hasActive) {
+              await deleteWorktree(wt.path, wt.repoPath, true);
+            } else {
+              await deleteWorktree(wt.path, wt.repoPath);
+            }
           } finally {
             useSessionsStore.getState().clearLoading(wt.path);
           }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -466,14 +466,25 @@ export async function renameSession(
   });
 }
 
+export async function fetchWorktreeStatus(
+  worktreePath: string
+): Promise<{ activeSessions: string[]; hasUncommittedChanges: boolean }> {
+  return json(
+    await fetch(
+      '/worktrees/status?path=' + encodeURIComponent(worktreePath)
+    )
+  );
+}
+
 export async function deleteWorktree(
   worktreePath: string,
-  repoPath: string
+  repoPath: string,
+  force?: boolean
 ): Promise<void> {
   const res = await fetch('/worktrees', {
     method: 'DELETE',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ worktreePath, repoPath }),
+    body: JSON.stringify({ worktreePath, repoPath, force }),
   });
   if (!res.ok) {
     throw new Error(await parseErrorBody(res, 'Failed to delete worktree'));

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -469,11 +469,18 @@ export async function renameSession(
 export async function fetchWorktreeStatus(
   worktreePath: string
 ): Promise<{ activeSessions: string[]; hasUncommittedChanges: boolean }> {
-  return json(
-    await fetch(
-      '/worktrees/status?path=' + encodeURIComponent(worktreePath)
-    )
+  const res = await fetch(
+    '/worktrees/status?path=' + encodeURIComponent(worktreePath)
   );
+  if (!res.ok) {
+    throw new Error(
+      await parseErrorBody(res, 'Failed to fetch worktree status')
+    );
+  }
+  return (await res.json()) as {
+    activeSessions: string[];
+    hasUncommittedChanges: boolean;
+  };
 }
 
 export async function deleteWorktree(


### PR DESCRIPTION
## Summary
- Add "delete worktree" option to the context menu for **active** worktree sessions (previously only available on inactive worktrees)
- Before deleting, check worktree status via `GET /worktrees/status`: if clean, delete immediately without confirmation; if uncommitted changes exist, show a warning dialog
- Pass `force` flag to handle both dirty worktrees (`git worktree remove --force`) and active session termination

## Changes
- **`api.ts`** — Added `fetchWorktreeStatus()`, added `force` param to `deleteWorktree()`
- **`useSessionHandlers.ts`** — `handleDeleteWorktree` now checks status first, branches on uncommitted changes
- **`DeleteWorktreeDialog.tsx`** — Shows uncommitted changes warning, always passes `force: true` (dialog only opens for dirty worktrees), shows active sessions warning when applicable
- **`RepoItem.tsx`** — Added `onDeleteWorktree` to `SessionGroupRow`, constructs `WorktreeInfo` from session data for worktree sessions (`groupPath !== repoPath`)

## Test plan
- [ ] Right-click active session on a worktree → context menu shows both "close session" and "delete worktree"
- [ ] Right-click active session on repo root → context menu shows only "close session" (no delete worktree)
- [ ] Delete a clean worktree (no uncommitted changes) → deletes immediately, no dialog
- [ ] Delete a dirty worktree (uncommitted changes) → shows warning dialog with "uncommitted changes will be lost"
- [ ] Delete a dirty worktree with active sessions → dialog also warns about session termination
- [ ] Cancel the warning dialog → worktree is preserved
- [ ] Confirm the warning dialog → worktree is deleted, sessions killed if active
- [ ] Delete worktree from inactive worktree row → same behavior (status check first)
- [ ] Error during deletion → toast notification shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)