### PR TITLE
fix: reset terminal modes on session switch to prevent mouse tracking leak

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -784,7 +784,17 @@ function useTerminalSetup(
   useEffect(() => {
     const term = termRef.current;
     if (sessionId && term && !companionMode) {
-      term.write('\x1b[?1049l');
+      // Reset terminal modes before switching sessions:
+      // - Exit alternate screen buffer (?1049l)
+      // - Disable mouse tracking modes (?1000l normal, ?1002l button-event,
+      //   ?1003l any-event, ?1006l SGR format, ?1015l URXVT format)
+      // - Disable bracketed paste (?2004l)
+      // Without this, an app like OpenCode that enables mouse tracking will
+      // leave xterm.js generating mouse escape sequences that get echoed as
+      // garbage text in the next session's PTY.
+      term.write(
+        '\x1b[?1049l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l\x1b[?2004l'
+      );
       term.clear();
       connectPtySocket(
         sessionId,

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -793,18 +793,20 @@ function useTerminalSetup(
       // leave xterm.js generating mouse escape sequences that get echoed as
       // garbage text in the next session's PTY.
       term.write(
-        '\x1b[?1049l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l\x1b[?2004l'
-      );
-      term.clear();
-      connectPtySocket(
-        sessionId,
-        term,
+        '\x1b[?1049l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l\x1b[?2004l',
         () => {
-          if (termRef.current)
-            sendPtyResize(termRef.current.cols, termRef.current.rows);
-        },
-        () => {
-          /* session ended */
+          term.clear();
+          connectPtySocket(
+            sessionId,
+            term,
+            () => {
+              if (termRef.current)
+                sendPtyResize(termRef.current.cols, termRef.current.rows);
+            },
+            () => {
+              /* session ended */
+            }
+          );
         }
       );
     }


### PR DESCRIPTION
## Summary
- OpenCode enables SGR mouse tracking (`\x1b[?1006h` + `\x1b[?1003h`), which persists in the shared xterm.js instance across session switches
- Without resetting these modes, every subsequent PTY echoes mouse escape sequences as garbage text (`^[[<35;88;40M...`)
- Adds a comprehensive mode reset (mouse tracking, bracketed paste, alt screen) when switching sessions in `Terminal.tsx`

## Test plan
- [ ] Open an OpenCode session, verify it renders normally
- [ ] Switch to a different session (Claude, shell, etc.) — no garbage text
- [ ] Switch back to the OpenCode session — still works
- [ ] Verify mouse interactions don't produce escape sequence garbage in non-mouse-tracking sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)