### PR TITLE
fix: CI workflow consistency and lint safety for filenames with spaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
 
       - name: Lint changed files
         run: |
-          FILES=$(git diff --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- '*.ts' '*.tsx' '*.js' '*.mjs' '*.cjs')
+          FILES=$(git diff -z --name-only --diff-filter=ACMR origin/${{ github.base_ref }}...HEAD -- '*.ts' '*.tsx' '*.js' '*.mjs' '*.cjs')
           if [ -n "$FILES" ]; then
-            echo "$FILES" | xargs npx eslint
+            printf '%s' "$FILES" | xargs -0 npx eslint
           else
             echo "No lintable files changed"
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
 
       - run: npm run build
 
-      - run: npx vitest run
+      - run: npm test
 
       # Stable: publish as @latest (default)
       - name: Publish stable


### PR DESCRIPTION
## Summary
- Make publish workflow use `npm test` instead of `npx vitest run` for consistency with CI
- Fix CI lint step to handle filenames with spaces using null-delimited pipeline (`git diff -z` + `xargs -0`)
- Verified Husky v9+ hooks don't need bootstrap line (hooks are plain shell scripts)

Follow-up to #181.

## Test plan
- [ ] Verify CI workflow runs correctly on this PR
- [ ] Verify publish workflow test step matches CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)