### PR TITLE
fix: use PinInput for PIN gate to fix cursor alignment

### DIFF
--- a/frontend/src/components/PinGate.css
+++ b/frontend/src/components/PinGate.css
@@ -27,13 +27,6 @@
   font-size: var(--font-size-base);
 }
 
-.pin-container .tui-input {
-  padding: 16px 16px;
-  background: var(--surface);
-  font-size: var(--font-size-lg);
-  text-align: center;
-}
-
 .error {
   color: var(--accent);
   font-size: var(--font-size-base);

--- a/frontend/src/components/PinGate.tsx
+++ b/frontend/src/components/PinGate.tsx
@@ -4,6 +4,8 @@ import { TuiButton } from './TuiButton.js';
 import { PinInput } from './PinInput.js';
 import './PinGate.css';
 
+const MAX_PIN_LENGTH = 20;
+
 interface SetupFormProps {
   pinValue: string;
   confirmValue: string;
@@ -17,8 +19,8 @@ function SetupForm({ pinValue, confirmValue, onPinChange, onConfirmChange, onKey
   return (
     <>
       <p>set up a PIN to secure this instance</p>
-      <PinInput value={pinValue} onChange={onPinChange} onKeyDown={onKeyDown} placeholder="choose a PIN" autoFocus={true} maxLength={20} />
-      <PinInput value={confirmValue} onChange={onConfirmChange} onKeyDown={onKeyDown} placeholder="confirm PIN" maxLength={20} />
+      <PinInput value={pinValue} onChange={onPinChange} onKeyDown={onKeyDown} placeholder="choose a PIN" autoFocus={true} maxLength={MAX_PIN_LENGTH} />
+      <PinInput value={confirmValue} onChange={onConfirmChange} onKeyDown={onKeyDown} placeholder="confirm PIN" maxLength={MAX_PIN_LENGTH} />
       <TuiButton variant="primary" onClick={onSubmit}>set PIN</TuiButton>
     </>
   );
@@ -35,7 +37,7 @@ function UnlockForm({ pinValue, onPinChange, onKeyDown, onSubmit }: UnlockFormPr
   return (
     <>
       <p>enter PIN to continue</p>
-      <PinInput value={pinValue} onChange={onPinChange} onKeyDown={onKeyDown} placeholder="PIN" autoFocus={true} maxLength={20} />
+      <PinInput value={pinValue} onChange={onPinChange} onKeyDown={onKeyDown} placeholder="PIN" autoFocus={true} maxLength={MAX_PIN_LENGTH} />
       <TuiButton variant="primary" onClick={onSubmit}>unlock</TuiButton>
       <p className="hint">
         forgot your PIN? run <code>relay-ide pin reset</code> on the host machine

--- a/frontend/src/components/PinGate.tsx
+++ b/frontend/src/components/PinGate.tsx
@@ -1,10 +1,8 @@
 import React, { useState } from 'react';
 import { useAuthStore } from '../lib/stores/auth.js';
 import { TuiButton } from './TuiButton.js';
-import { TuiInput } from './TuiInput.js';
+import { PinInput } from './PinInput.js';
 import './PinGate.css';
-
-const PIN_INPUT_PROPS = { type: 'password' as const, inputMode: 'numeric' as const, maxLength: 20 };
 
 interface SetupFormProps {
   pinValue: string;
@@ -19,8 +17,8 @@ function SetupForm({ pinValue, confirmValue, onPinChange, onConfirmChange, onKey
   return (
     <>
       <p>set up a PIN to secure this instance</p>
-      <TuiInput {...PIN_INPUT_PROPS} value={pinValue} onChange={onPinChange} onKeyDown={onKeyDown} placeholder="choose a PIN" autoFocus={true} />
-      <TuiInput {...PIN_INPUT_PROPS} value={confirmValue} onChange={onConfirmChange} onKeyDown={onKeyDown} placeholder="confirm PIN" />
+      <PinInput value={pinValue} onChange={onPinChange} onKeyDown={onKeyDown} placeholder="choose a PIN" autoFocus={true} maxLength={20} />
+      <PinInput value={confirmValue} onChange={onConfirmChange} onKeyDown={onKeyDown} placeholder="confirm PIN" maxLength={20} />
       <TuiButton variant="primary" onClick={onSubmit}>set PIN</TuiButton>
     </>
   );
@@ -37,7 +35,7 @@ function UnlockForm({ pinValue, onPinChange, onKeyDown, onSubmit }: UnlockFormPr
   return (
     <>
       <p>enter PIN to continue</p>
-      <TuiInput {...PIN_INPUT_PROPS} value={pinValue} onChange={onPinChange} onKeyDown={onKeyDown} placeholder="PIN" autoFocus={true} />
+      <PinInput value={pinValue} onChange={onPinChange} onKeyDown={onKeyDown} placeholder="PIN" autoFocus={true} maxLength={20} />
       <TuiButton variant="primary" onClick={onSubmit}>unlock</TuiButton>
       <p className="hint">
         forgot your PIN? run <code>relay-ide pin reset</code> on the host machine

--- a/test/e2e/components/PinGate.spec.ts
+++ b/test/e2e/components/PinGate.spec.ts
@@ -18,7 +18,7 @@ test.describe('PinGate', () => {
     await expect(page.locator('.pin-container p').first()).toContainText(
       'set up a PIN'
     );
-    await expect(page.locator('.tui-input-wrapper')).toHaveCount(2);
+    await expect(page.locator('.pin-input')).toHaveCount(2);
   });
 
   test('renders error state', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Swapped `TuiInput` → `PinInput` in PinGate for both unlock and setup forms
- Removed dead `.pin-container .tui-input` CSS overrides (font-size, text-align, padding)
- Root cause: TuiInput's measurement span hardcodes `font-size: var(--font-size-base)`, so PinGate's CSS override to `--font-size-lg` caused the cursor to render above and to the right of the centered text
- PinInput renders dots and cursor as inline flex children with no measurement math, so centering works naturally

## Test plan
- [ ] Open PIN unlock screen, type a PIN — cursor should track inline with dots, vertically centered
- [ ] Open PIN setup screen — both "choose a PIN" and "confirm PIN" fields should have correct cursor alignment
- [ ] Verify cursor blinks when idle, stops blinking while typing
- [ ] Test on mobile viewport — cursor should still align correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)