### PR TITLE
feat: scaffold belayer framework with GitHub Issues intake

### DIFF
--- a/.belayer/.gitignore
+++ b/.belayer/.gitignore
@@ -1,0 +1,2 @@
+# Belayer runtime state — never commit
+.internal/

--- a/.belayer/README.md
+++ b/.belayer/README.md
@@ -1,119 +1,119 @@
-# gstack Framework for Belayer
+# relay-ide Belayer Framework
 
-Belayer framework powered by gstack skills. Claude implements, Codex reviews (adversarial, isolated context), Claude ships. No custom scripts needed for the basic case — the pipeline is pure YAML.
+Custom belayer pipeline for relay-ide. OpenCode implements (with ultrawork/autopilot), Codex reviews (adversarial, isolated context), Claude ships. Review depth is auto-routed based on change classification.
 
 ## Prerequisites
 
-All tools must have gstack skills installed:
-
 ```bash
-# Claude Code CLI — install gstack skills
-# See: https://github.com/anthropics/gstack
-
-# OpenAI Codex CLI — install gstack skills
-npm i -g @openai/codex
-# gstack skills are discovered from .claude/skills/ or .agents/skills/
-
 # Belayer
 go install github.com/donovan-yohan/belayer/cmd/belayer@latest
+
+# Temporal (local dev)
+temporal server start-dev
+
+# OpenCode (implementation agent)
+# https://github.com/opencode-ai/opencode
+
+# Claude Code CLI (review routing + PR authoring)
+# https://docs.anthropic.com/en/docs/claude-code
+
+# OpenAI Codex CLI (adversarial review gates)
+npm i -g @openai/codex
+
+# GitHub CLI (issue intake)
+# https://cli.github.com
 ```
 
-Both Claude and Codex must have gstack set up so that skill invocations (/ship, $review, etc.) work in each agent.
+## GitHub Issues Workflow
+
+```
+backlog        →  refined       →  todo          →  [belayer]
+(rough idea)      (scoped)         (belayer-ready)   (implement → review → ship)
+                       │                                    │
+                       └── planning skill ──────────────────┘
+                           - writes implementation plan into issue body
+                           - checks in-flight todo/in-progress work for file overlap
+                           - if clean: promotes refined → todo
+                           - if conflict: adds "Blocked by #X" and waits
+```
+
+**Labels:**
+- `backlog` — rough idea, not yet scoped
+- `refined` — scoped, requirements clear, awaiting implementation plan
+- `todo` — planned, conflict-free, ready for belayer to pick up
+- `in-progress` — belayer has claimed this issue (added by belayer)
+
+**The planning skill** (runs upstream, not part of belayer pipeline):
+1. Takes a `refined` issue
+2. Reads code, writes file-level implementation plan into the issue body
+3. Checks all `todo` and `in-progress` issues for file/module overlap
+4. Promotes to `todo` if no conflicts, or adds dependency notes and waits
 
 ## Pipeline
 
 ```
-implement (Claude)  →  review (Codex, gate)  →  ship (Claude)
-     ↑                      |
-     └── on_retry ──────────┘
+[intake: todo issue] → implement (OpenCode) → review-router (Claude)
+                                                    │
+                      ┌─────────────────────────────┼─────────────────────────────────┐
+                      v                             v                                 v
+               full-feature-review          quick-bugfix-review               refactor-review
+               (5 dims, pass: 7.0)          (3 dims, pass: 7.0)              (4 dims, pass: 7.5)
+                      v                             v                                 v
+                 ship (Claude)                 ship (Claude)                      ship (Claude)
+                 → PR to nightly               → PR to nightly                   → PR to nightly
 ```
 
 ### implement
 
-- `vendor: claude`, `prompt: "Implement the design specification at $INPUT"`
-- Reads the design doc, implements the feature, writes tests, commits
-- Trusts agent competency — no micromanagement
+- `command: .belayer/scripts/implement.sh` (invokes OpenCode)
+- Prompt includes `/ultrawork` and `/autopilot` keywords for parallel agent orchestration
+- Receives the issue body as a spec file (implementation plan written by planning skill)
 
-### review (gate)
+### review-router
 
-- `vendor: codex`, `prompt: "$review"`
-- Runs gstack's full /review methodology via Codex (checklist, scope drift, confidence calibration)
-- H-as-feature: Codex is a different model in a different process with zero implementation context
-- Belayer auto-appends structured output instructions for gate-result.json
-- Scores three dimensions: code_quality, scope_compliance, production_readiness
+- `vendor: claude`, classifies the change and picks review depth
+- Routes to one of three subpipelines based on scope, risk, and change type
+
+### review gates (subpipelines)
+
+- `vendor: codex` (adversarial, zero implementation context)
+- Each subpipeline has tuned dimensions and thresholds for its change type
+- Score-then-route: Codex scores, belayer decides pass/retry/fail
 
 ### ship
 
-- `vendor: claude`, `prompt: "/ship"`
-- Runs gstack's /ship skill: version bump, changelog, push, create PR
+- `vendor: claude`, creates PR targeting nightly
+- Runs build + tests before pushing
 
-## How It Works
-
-The pipeline YAML defines agent nodes with `vendor` + `prompt`. Belayer resolves the vendor to the right CLI command, passes the prompt, and handles the output contract. No shell scripts needed.
-
-```yaml
-- name: implement
-  type: agent
-  vendor: claude
-  prompt: 'Implement the design specification at $INPUT'
-```
-
-Belayer translates this to:
+## Usage
 
 ```bash
-claude -p --dangerously-skip-permissions --output-format stream-json "Implement the design specification at /path/to/design.md"
+# Start Temporal worker
+belayer worker
+
+# Belayer polls for todo issues automatically via intake trigger
+# Or run manually:
+belayer climb "implement issue #170"
+
+# Check status
+belayer status
 ```
 
-For gate nodes, belayer auto-appends dimension scoring instructions to the prompt so the agent returns structured JSON that feeds into score-then-route.
+## File Structure
 
-## Extending
-
-### With carabiner (quality learning loop)
-
-When carabiner is available, add a custom `command:` to the implement node that calls `carabiner quality check` before prompting:
-
-```yaml
-- name: implement
-  type: node
-  command: .belayer/scripts/implement-with-carabiner.sh
 ```
-
-The `command:` field overrides `vendor` + `prompt` for nodes that need custom logic.
-
-### With /land-and-deploy (output verification)
-
-Add a post-ship node for merge + monitoring:
-
-```yaml
-- name: land
-  type: agent
-  vendor: claude
-  prompt: '/land-and-deploy'
-  input: { type: pr }
-  on_pass: stop
-```
-
-### Custom frameworks
-
-Copy this pipeline.yaml and change the vendors/prompts:
-
-```yaml
-# Gemini implements, Claude reviews
-- name: implement
-  type: agent
-  vendor: gemini
-  prompt: 'Implement the design at $INPUT'
-
-- name: review
-  type: gate
-  vendor: claude
-  prompt: '$review'
-```
-
-Any agent with gstack skills can fill any role.
-
-## Setup
-
-```bash
-belayer setup --framework gstack
+.belayer/
+  pipeline.yaml              # Main pipeline: implement → review-router
+  framework.yaml             # Framework metadata
+  scripts/
+    check-ready.sh           # Trigger: finds next todo issue from GitHub
+    implement.sh             # Node runner: invokes OpenCode
+  pipelines/
+    full-feature-review.yaml # 5-dim gate (quality, spec, prod, tests, arch)
+    quick-bugfix-review.yaml # 3-dim gate (correctness, regression, tests)
+    refactor-review.yaml     # 4-dim gate (behavior, arch, tests, migration)
+  prompts/
+    implement.md             # Implementation prompt (ultrawork/autopilot)
+    review.md                # Adversarial review prompt
+  .internal/                 # Gitignored runtime state
 ```

--- a/.belayer/framework.yaml
+++ b/.belayer/framework.yaml
@@ -6,5 +6,6 @@ requires:
   - claude (Claude Code CLI, for review routing and shipping)
   - codex (OpenAI Codex CLI, for review gates)
   - gh (GitHub CLI, for issue intake)
+  - jq (for JSON parsing in scripts)
   - node >= 24.0.0
   - npm (for build and test)

--- a/.belayer/framework.yaml
+++ b/.belayer/framework.yaml
@@ -1,6 +1,10 @@
-name: gstack
-description: Belayer framework powered by gstack skills. Uses /office-hours for intake, Claude Code for implementation, /review for gates, and /ship + /land-and-deploy for output.
+name: relay-ide
+description: Custom belayer framework for relay-ide. GitHub Issues intake, OpenCode for implementation (ultrawork/autopilot), Codex for adversarial review gates, Claude Code for review routing and PR authoring.
 version: 0.1.0
 requires:
-  - gstack (npm i -g @anthropic/gstack or vendor into .claude/skills/gstack)
-  - claude (Claude Code CLI)
+  - opencode (OpenCode CLI, for implementation)
+  - claude (Claude Code CLI, for review routing and shipping)
+  - codex (OpenAI Codex CLI, for review gates)
+  - gh (GitHub CLI, for issue intake)
+  - node >= 24.0.0
+  - npm (for build and test)

--- a/.belayer/pipeline.yaml
+++ b/.belayer/pipeline.yaml
@@ -17,7 +17,7 @@ nodes:
       Implement the GitHub issue spec. OpenCode with ultrawork/autopilot
       handles parallel execution. The issue body contains the full
       implementation plan written by the planning skill.
-    input: { type: file, key: design_doc }
+    input: { type: file, key: github-issue }
     output: { type: commit }
     on_pass: review-router
     on_fail: stop

--- a/.belayer/pipeline.yaml
+++ b/.belayer/pipeline.yaml
@@ -1,50 +1,72 @@
-name: gstack
+name: relay-ide
 
-# Trigger contract: how intake signals "ready to build"
-# Checks for APPROVED design docs in ~/.gstack/projects/
-# Can also be invoked explicitly: belayer submit --spec <path>
+# Trigger contract: checks GitHub Issues for todo-labeled issues
+# Workflow: backlog → refined → [planning skill] → todo → [belayer picks up]
 intake:
-  - name: design-doc
+  - name: github-issue
     type: trigger
     check: .belayer/scripts/check-ready.sh
 
 nodes:
-  # Implementation phase: self-resolving loop
-  # implement ↔ review is the build loop. Gates are implementation primitives.
+  # Implementation: receives a todo issue spec (planned upstream by the planning skill).
+  # Uses OpenCode with ultrawork/autopilot for parallel agent execution.
   - name: implement
-    type: agent
-    vendor: claude
-    prompt: 'Implement the design specification at %{INPUT}'
+    type: node
+    command: .belayer/scripts/implement.sh
+    description: |
+      Implement the GitHub issue spec. OpenCode with ultrawork/autopilot
+      handles parallel execution. The issue body contains the full
+      implementation plan written by the planning skill.
     input: { type: file, key: design_doc }
     output: { type: commit }
-    on_pass: review
+    on_pass: review-router
     on_fail: stop
+    max_retries: 3
 
-  - name: review
-    type: gate
-    vendor: codex
-    prompt: '$review'
-    input: { type: commit }
-    output: { type: gate_result }
-    dimensions:
-      - { name: code_quality, weight: 0.35 }
-      - { name: scope_compliance, weight: 0.30 }
-      - { name: production_readiness, weight: 0.35 }
-    thresholds: { pass: 7.0, retry: 4.0 }
-    on_pass: ship
-    on_retry: implement
+  # Review Router: classifies the change and routes to appropriate review depth.
+  # Each route is an isolated subpipeline with its own gate + ship.
+  - name: review-router
+    type: agent
+    vendor: claude
+    prompt: |
+      Read the diff at %{INPUT}. Classify this change for relay-ide
+      and choose the appropriate review depth.
+
+      Consider:
+      - Scope: how many modules touched (server/, src/components/, src/stores/)
+      - Risk: PTY management, auth, WebSocket, session state
+      - API surface: REST endpoints, WebSocket messages, config schema
+      - Frontend vs backend: React components vs Express routes
+      - Test coverage: vitest test additions or modifications
+    input: { type: commit, key: implement }
+    output: { type: route_result, path: .belayer/.internal/output/route-result.json }
+    routes:
+      mode: choose_one
+      options:
+        full-feature-review:
+          pipeline: .belayer/pipelines/full-feature-review.yaml
+          description: >
+            Broad or risky change spanning multiple modules.
+            Thorough review with 5 dimensions covering code quality,
+            spec compliance, production readiness, test coverage,
+            and relay-ide architecture patterns.
+        quick-bugfix-review:
+          pipeline: .belayer/pipelines/quick-bugfix-review.yaml
+          description: >
+            Small localized fix in a single module.
+            Lightweight review with 3 dimensions: correctness,
+            regression risk, and test coverage. 1 retry max.
+        refactor-review:
+          pipeline: .belayer/pipelines/refactor-review.yaml
+          description: >
+            Structural change with no new behavior.
+            Focus on behavioral preservation, architecture
+            improvement, and migration safety. Higher pass
+            threshold (7.5).
+    on_pass: stop
+    on_retry: self
     on_fail: stop
     max_retries: 2
 
-  # Output phase: shipping
-  - name: ship
-    type: agent
-    vendor: claude
-    prompt: 'Create a pull request for the changes on this branch. Include a summary of what was implemented, run any tests, and push to remote. Write the PR URL to .belayer/.internal/output/pr.json as {"url": "...", "number": N}.'
-    input: { type: commit }
-    output: { type: pr, path: .belayer/.internal/output/pr.json }
-    on_pass: stop
-    on_fail: stop
-
 safety:
-  max_concurrent_runs: 3
+  max_concurrent_runs: 2

--- a/.belayer/pipelines/full-feature-review.yaml
+++ b/.belayer/pipelines/full-feature-review.yaml
@@ -1,0 +1,33 @@
+name: full-feature-review
+
+nodes:
+  - name: code-review
+    type: agent
+    vendor: codex
+    prompt: "$review"
+    input: { type: commit }
+    output: { type: gate_result }
+    dimensions:
+      - { name: code_quality, weight: 0.20, description: "TypeScript correctness, ESM patterns, readability, project conventions" }
+      - { name: spec_compliance, weight: 0.20, description: "Does the implementation match the plan without scope creep?" }
+      - { name: production_readiness, weight: 0.20, description: "Error handling, PTY cleanup, WebSocket lifecycle, security" }
+      - { name: test_coverage, weight: 0.20, description: "Vitest tests for new behavior, edge cases, integration coverage" }
+      - { name: architecture, weight: 0.20, description: "Module boundaries (one concern per server module), frontend/backend separation" }
+    thresholds: { pass: 7.0, retry: 4.0 }
+    on_pass: ship
+    on_retry: self
+    on_fail: stop
+    max_retries: 2
+
+  - name: ship
+    type: agent
+    vendor: claude
+    prompt: |
+      Create a pull request targeting nightly for the completed feature.
+      Include a summary of what was implemented and any architectural decisions.
+      Run `npm run build` and `npm test` to verify before pushing.
+      Write the PR URL to .belayer/.internal/output/pr.json as {"url": "...", "number": N}.
+    input: { type: gate_result, key: code-review }
+    output: { type: pr, path: .belayer/.internal/output/pr.json }
+    on_pass: stop
+    on_fail: stop

--- a/.belayer/pipelines/quick-bugfix-review.yaml
+++ b/.belayer/pipelines/quick-bugfix-review.yaml
@@ -1,0 +1,31 @@
+name: quick-bugfix-review
+
+nodes:
+  - name: code-review
+    type: agent
+    vendor: codex
+    prompt: "$review"
+    input: { type: commit }
+    output: { type: gate_result }
+    dimensions:
+      - { name: correctness, weight: 0.50, description: "Does the fix address the bug without introducing new issues?" }
+      - { name: regression_risk, weight: 0.30, description: "Could this change break PTY, WebSocket, auth, or session state?" }
+      - { name: test_coverage, weight: 0.20, description: "Is the fix tested with vitest? Does it cover the reported scenario?" }
+    thresholds: { pass: 7.0, retry: 4.0 }
+    on_pass: ship
+    on_retry: self
+    on_fail: stop
+    max_retries: 1
+
+  - name: ship
+    type: agent
+    vendor: claude
+    prompt: |
+      Create a pull request targeting nightly for the bug fix.
+      Include what was broken and how it was fixed.
+      Run `npm run build` and `npm test` before pushing.
+      Write the PR URL to .belayer/.internal/output/pr.json as {"url": "...", "number": N}.
+    input: { type: gate_result, key: code-review }
+    output: { type: pr, path: .belayer/.internal/output/pr.json }
+    on_pass: stop
+    on_fail: stop

--- a/.belayer/pipelines/refactor-review.yaml
+++ b/.belayer/pipelines/refactor-review.yaml
@@ -1,0 +1,33 @@
+name: refactor-review
+
+nodes:
+  - name: code-review
+    type: agent
+    vendor: codex
+    prompt: "$review"
+    input: { type: commit }
+    output: { type: gate_result }
+    dimensions:
+      - { name: behavioral_preservation, weight: 0.35, description: "Does the refactor preserve all existing behavior? No functional changes to PTY, WebSocket, or auth." }
+      - { name: architecture_improvement, weight: 0.30, description: "Does the new structure improve modularity? Are server modules still single-concern?" }
+      - { name: test_coverage, weight: 0.20, description: "Are existing vitest tests still passing? Were tests added for restructured code?" }
+      - { name: migration_safety, weight: 0.15, description: "Can this be deployed without breaking existing relay-ide installations?" }
+    thresholds: { pass: 7.5, retry: 5.0 }
+    on_pass: ship
+    on_retry: self
+    on_fail: stop
+    max_retries: 2
+
+  - name: ship
+    type: agent
+    vendor: claude
+    prompt: |
+      Create a pull request targeting nightly for the refactor.
+      Emphasize this is a structural change with no new behavior.
+      Include before/after architecture notes.
+      Run `npm run build` and `npm test` before pushing.
+      Write the PR URL to .belayer/.internal/output/pr.json as {"url": "...", "number": N}.
+    input: { type: gate_result, key: code-review }
+    output: { type: pr, path: .belayer/.internal/output/pr.json }
+    on_pass: stop
+    on_fail: stop

--- a/.belayer/prompts/implement.md
+++ b/.belayer/prompts/implement.md
@@ -1,0 +1,42 @@
+You are an implementation agent for relay-ide, a remote web interface for Claude Code CLI sessions.
+
+Use /ultrawork and /autopilot to execute this task efficiently with parallel agent orchestration.
+
+## Project Context
+
+- **Backend**: TypeScript + ESM, Express, node-pty, WebSocket (34 server modules under server/)
+- **Frontend**: React 19, Zustand stores, TanStack Query, Vite
+- **Tests**: vitest — run with `npm test`
+- **Build**: `npm run build`
+- **Node**: >= 24.0.0, all imports use .js extensions, Node builtins use node: prefix
+
+## Your Task
+
+Implement the specification at %{INPUT}. The issue body contains the full implementation plan — files to change, approach, and acceptance criteria.
+
+### Rules
+
+1. **Read before writing** — always read a file before modifying it
+2. **Follow the spec** — implement what the spec says, nothing more
+3. **Write tests** — add or update vitest tests for every behavioral change
+4. **Build must pass** — run `npm run build` and fix any TypeScript errors
+5. **Tests must pass** — run `npm test` and fix any failures
+6. **Commit your work** — make atomic commits with descriptive messages
+7. **No scope creep** — don't refactor adjacent code, add comments to unchanged code, or improve things not in the spec
+
+### Relay-IDE Specific Patterns
+
+- CLAUDECODE env var must be stripped from PTY env
+- Scrollback buffer capped at 256KB per session (FIFO trimming)
+- Config at ~/.config/relay-ide/config.json (global) or ./config.json (local)
+- PIN auth flow — see docs/DESIGN.md
+- WebSocket message types are defined in shared types
+- All server modules own one concern — don't merge responsibilities
+
+### Commit Convention
+
+- `feat:` for new features
+- `fix:` for bug fixes
+- `refactor:` for structural changes
+- `test:` for test-only changes
+- Include issue reference when applicable (e.g., `feat: add X (#123)`)

--- a/.belayer/prompts/review.md
+++ b/.belayer/prompts/review.md
@@ -1,5 +1,29 @@
-You are an adversarial code reviewer. Your job is to find problems, not confirm quality.
+You are an adversarial code reviewer for relay-ide. Your job is to find problems, not confirm quality.
 
-Review the code changes described below. Be thorough, honest, and specific.
+## Project Context
 
-%{INPUT}
+- TypeScript + ESM backend (Express, node-pty, WebSocket)
+- React 19 frontend (Zustand, TanStack Query, Vite)
+- Tests: vitest
+- Key risk areas: PTY lifecycle, session state, WebSocket, PIN auth, scrollback buffers
+
+## Review the Code
+
+Review the changes at %{INPUT}. Be thorough, honest, and specific.
+
+### What to Check
+
+- **Correctness**: Does it do what it claims? Edge cases handled?
+- **TypeScript**: Proper types, no `any` abuse, ESM imports with .js extensions
+- **Security**: No command injection, XSS, or auth bypass. CLAUDECODE env stripped from PTY.
+- **Tests**: Are new behaviors tested? Do tests actually assert meaningful things?
+- **Architecture**: Does it respect module boundaries (34 server modules, each one concern)?
+- **Frontend**: React 19 patterns, proper store usage, no stale closures
+- **Performance**: No unbounded buffers, memory leaks, or missing cleanup in PTY/WebSocket handlers
+- **Design system**: If UI changes, does it follow DESIGN.md? (TUI aesthetic, all lowercase, no emoji, box-drawing)
+
+### What NOT to Flag
+
+- Style preferences that don't affect correctness
+- Missing comments on self-documenting code
+- Theoretical future improvements

--- a/.belayer/scripts/check-ready.sh
+++ b/.belayer/scripts/check-ready.sh
@@ -17,18 +17,13 @@ INTERNAL_DIR=".belayer/.internal/input"
 
 mkdir -p "$INTERNAL_DIR"
 
-# Find todo issues sorted by creation date (oldest first).
-# No --limit so we get all todo issues for correct oldest-first selection.
-ISSUE_JSON=$(gh issue list \
-  --repo "$REPO" \
-  --label "todo" \
-  --state open \
-  --json number,title,body,labels 2>/dev/null) || exit 1
+# Fetch the 5 oldest todo issues in one API call (created asc, small page).
+# Enough headroom to filter out in-progress without over-fetching.
+ISSUE_JSON=$(gh api "repos/$REPO/issues?labels=todo&state=open&sort=created&direction=asc&per_page=5" 2>/dev/null) || exit 1
 
-# Filter out issues already claimed (in-progress label), pick the oldest
+# Filter out issues already claimed (in-progress label), pick the first (oldest)
 AVAILABLE=$(echo "$ISSUE_JSON" | jq -r '
   [.[] | select(.labels | map(.name) | index("in-progress") | not)]
-  | sort_by(.number)
   | first // empty
 ')
 

--- a/.belayer/scripts/check-ready.sh
+++ b/.belayer/scripts/check-ready.sh
@@ -8,21 +8,24 @@ set -euo pipefail
 # Workflow: backlog → refined → [planning skill] → todo → [belayer picks up]
 # Issues in "todo" are guaranteed conflict-free by the planning skill.
 
+for cmd in gh jq; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: $cmd is required but not found" >&2; exit 1; }
+done
+
 REPO="donovan-yohan/relay-ide"
 INTERNAL_DIR=".belayer/.internal/input"
 
 mkdir -p "$INTERNAL_DIR"
 
-# Find the oldest todo issue not already in progress
-# The planning skill ensures todo issues have no blocking conflicts.
+# Find todo issues sorted by creation date (oldest first).
+# No --limit so we get all todo issues for correct oldest-first selection.
 ISSUE_JSON=$(gh issue list \
   --repo "$REPO" \
   --label "todo" \
   --state open \
-  --json number,title,body,labels \
-  --limit 10 2>/dev/null) || exit 1
+  --json number,title,body,labels 2>/dev/null) || exit 1
 
-# Filter out issues that have an "in-progress" label (already claimed by belayer)
+# Filter out issues already claimed (in-progress label), pick the oldest
 AVAILABLE=$(echo "$ISSUE_JSON" | jq -r '
   [.[] | select(.labels | map(.name) | index("in-progress") | not)]
   | sort_by(.number)
@@ -35,13 +38,16 @@ ISSUE_NUMBER=$(echo "$AVAILABLE" | jq -r '.number')
 ISSUE_TITLE=$(echo "$AVAILABLE" | jq -r '.title')
 ISSUE_BODY=$(echo "$AVAILABLE" | jq -r '.body')
 
-# Write the issue as a spec file for the implement node
+# Write the issue as a spec file for the implement node.
+# Use printf to avoid shell expansion of issue content (security).
 SPEC_FILE="$INTERNAL_DIR/issue-${ISSUE_NUMBER}.md"
-cat > "$SPEC_FILE" <<SPEC
-# Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
+{
+  printf '# Issue #%s: %s\n\n' "$ISSUE_NUMBER" "$ISSUE_TITLE"
+  printf '%s\n' "$ISSUE_BODY"
+} > "$SPEC_FILE"
 
-${ISSUE_BODY}
-SPEC
+# Claim the issue so concurrent runs don't pick the same one
+gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "in-progress" 2>/dev/null || true
 
 # Output the artifact path
 echo "$SPEC_FILE"

--- a/.belayer/scripts/check-ready.sh
+++ b/.belayer/scripts/check-ready.sh
@@ -1,33 +1,48 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Belayer gstack framework: trigger contract
-# Checks for APPROVED design docs in the gstack projects directory.
+# Belayer relay-ide framework: trigger contract
+# Checks GitHub Issues for the next todo-labeled issue ready for implementation.
 # Returns exit 0 + artifact path on stdout if ready, exit 1 if not.
+#
+# Workflow: backlog → refined → [planning skill] → todo → [belayer picks up]
+# Issues in "todo" are guaranteed conflict-free by the planning skill.
 
-# Resolve project slug from git remote
-SLUG=$(git remote get-url origin 2>/dev/null \
-  | sed 's|.*[:/]\([^/]*/[^/]*\)\.git$|\1|;s|.*[:/]\([^/]*/[^/]*\)$|\1|' \
-  | tr '/' '-' \
-  | tr -cd 'a-zA-Z0-9._-') || true
-SLUG="${SLUG:-$(basename "$(pwd)" | tr -cd 'a-zA-Z0-9._-')}"
+REPO="donovan-yohan/relay-ide"
+INTERNAL_DIR=".belayer/.internal/input"
 
-PROJECTS_DIR="$HOME/.gstack/projects/$SLUG"
+mkdir -p "$INTERNAL_DIR"
 
-[ -d "$PROJECTS_DIR" ] || exit 1
+# Find the oldest todo issue not already in progress
+# The planning skill ensures todo issues have no blocking conflicts.
+ISSUE_JSON=$(gh issue list \
+  --repo "$REPO" \
+  --label "todo" \
+  --state open \
+  --json number,title,body,labels \
+  --limit 10 2>/dev/null) || exit 1
 
-CONSUMED_FILE="$PROJECTS_DIR/.consumed"
+# Filter out issues that have an "in-progress" label (already claimed by belayer)
+AVAILABLE=$(echo "$ISSUE_JSON" | jq -r '
+  [.[] | select(.labels | map(.name) | index("in-progress") | not)]
+  | sort_by(.number)
+  | first // empty
+')
 
-# Find most recent APPROVED design doc not yet consumed
-for doc in $(ls -t "$PROJECTS_DIR"/*-design-*.md 2>/dev/null); do
-  if grep -q "^Status: APPROVED" "$doc" 2>/dev/null; then
-    BASENAME=$(basename "$doc")
-    if ! grep -qF "$BASENAME" "$CONSUMED_FILE" 2>/dev/null; then
-      # Output the artifact path. Consumption is owned by the caller (belayer poller).
-      echo "$doc"
-      exit 0
-    fi
-  fi
-done
+[ -n "$AVAILABLE" ] || exit 1
 
-exit 1
+ISSUE_NUMBER=$(echo "$AVAILABLE" | jq -r '.number')
+ISSUE_TITLE=$(echo "$AVAILABLE" | jq -r '.title')
+ISSUE_BODY=$(echo "$AVAILABLE" | jq -r '.body')
+
+# Write the issue as a spec file for the implement node
+SPEC_FILE="$INTERNAL_DIR/issue-${ISSUE_NUMBER}.md"
+cat > "$SPEC_FILE" <<SPEC
+# Issue #${ISSUE_NUMBER}: ${ISSUE_TITLE}
+
+${ISSUE_BODY}
+SPEC
+
+# Output the artifact path
+echo "$SPEC_FILE"
+exit 0

--- a/.belayer/scripts/implement.sh
+++ b/.belayer/scripts/implement.sh
@@ -6,6 +6,10 @@ set -euo pipefail
 #
 # Reads node-context.json for the spec file path, then delegates to opencode.
 
+for cmd in jq opencode; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: $cmd is required but not found" >&2; exit 1; }
+done
+
 CONTEXT_FILE=".belayer/.internal/input/node-context.json"
 
 if [ ! -f "$CONTEXT_FILE" ]; then

--- a/.belayer/scripts/implement.sh
+++ b/.belayer/scripts/implement.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Belayer relay-ide framework: implementation node runner
+# Invokes OpenCode with ultrawork/autopilot for parallel agent execution.
+#
+# Reads node-context.json for the spec file path, then delegates to opencode.
+
+CONTEXT_FILE=".belayer/.internal/input/node-context.json"
+
+if [ ! -f "$CONTEXT_FILE" ]; then
+  echo "ERROR: node-context.json not found at $CONTEXT_FILE" >&2
+  exit 1
+fi
+
+# Extract the input artifact path from node context
+INPUT_PATH=$(jq -r '.input.path // .input.description // empty' "$CONTEXT_FILE")
+
+if [ -z "$INPUT_PATH" ]; then
+  echo "ERROR: no input path found in node context" >&2
+  exit 1
+fi
+
+# Read the prompt template
+PROMPT_FILE=".belayer/prompts/implement.md"
+if [ -f "$PROMPT_FILE" ]; then
+  PROMPT=$(cat "$PROMPT_FILE")
+  # Replace %{INPUT} with actual path
+  PROMPT="${PROMPT//%\{INPUT\}/$INPUT_PATH}"
+else
+  PROMPT="Implement the specification at $INPUT_PATH. Use /ultrawork and /autopilot for parallel execution."
+fi
+
+# Invoke OpenCode with the prompt
+# OpenCode reads CLAUDE.md/AGENTS.md and activates ultrawork/autopilot from keywords in the prompt
+exec opencode --prompt "$PROMPT"


### PR DESCRIPTION
## Summary

- Scaffolds custom `.belayer/` framework for relay-ide (spike #169)
- Pipeline: OpenCode implements (ultrawork/autopilot) → Claude routes review → Codex adversarial gates → Claude ships PR
- Intake triggers from `todo`-labeled GitHub Issues instead of gstack design docs
- Adds `refined` label for the middle state in `backlog → refined → todo` workflow
- Planning and file-overlap conflict detection happen upstream (not a belayer concern)

## Files

| File | Purpose |
|------|---------|
| `pipeline.yaml` | Main pipeline: implement → review-router |
| `framework.yaml` | Framework metadata + dependency list |
| `scripts/check-ready.sh` | Trigger: finds next `todo` issue from GitHub |
| `scripts/implement.sh` | Node runner: invokes OpenCode with ultrawork/autopilot |
| `pipelines/*.yaml` | 3 review subpipelines (feature, bugfix, refactor) |
| `prompts/implement.md` | Implementation prompt (relay-ide specific) |
| `prompts/review.md` | Adversarial review prompt |
| `README.md` | Framework docs with workflow diagram |

## Test plan

- [ ] Install belayer CLI and verify `pipeline.yaml` passes validation
- [ ] Test `check-ready.sh` against a `todo`-labeled issue
- [ ] Dry-run `belayer climb` with Temporal to verify end-to-end flow
- [ ] Tune review gate thresholds after initial runs

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)