### PR TITLE
fix: prevent postinstall from killing server during web UI update

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -31,6 +31,11 @@ try {
 
 // ── Step 2: Auto-restart background service if running ──
 
+// When the update is triggered via the server's POST /update API, the server
+// handles its own graceful restart (serialize sessions, broadcast, exit for
+// launchd KeepAlive). Postinstall must NOT kill the server mid-request.
+const skipRestart = process.env.RELAY_IDE_SKIP_SERVICE_RESTART === '1';
+
 async function restartServiceIfRunning() {
   try {
     // Import service module from compiled dist
@@ -96,5 +101,7 @@ async function restartServiceIfRunning() {
   }
 }
 
-// Run restart check
-restartServiceIfRunning();
+// Run restart check (skipped when the server's POST /update API handles its own restart)
+if (!skipRestart) {
+  restartServiceIfRunning();
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1999,11 +1999,19 @@ async function main(): Promise<void> {
   });
 
   // POST /update — install latest version from npm
+  let updateInFlight = false;
   app.post('/update', requireAuth, async (_req, res) => {
+    if (updateInFlight) {
+      res.status(409).json({ ok: false, error: 'Update already in progress' });
+      return;
+    }
+    updateInFlight = true;
     try {
       const channel = startupConfig.updateChannel ?? 'stable';
       const tag = channel === 'nightly' ? 'nightly' : 'latest';
-      await execFileAsync('npm', ['install', '-g', `relay-ide@${tag}`]);
+      await execFileAsync('npm', ['install', '-g', `relay-ide@${tag}`], {
+        env: { ...process.env, RELAY_IDE_SKIP_SERVICE_RESTART: '1' },
+      });
       const restarting = serviceIsInstalled();
       if (restarting) {
         stopEventBatching();
@@ -2021,6 +2029,7 @@ async function main(): Promise<void> {
         }, 500);
       }
     } catch (err) {
+      updateInFlight = false;
       const message = err instanceof Error ? err.message : 'Update failed';
       res.status(500).json({ ok: false, error: message });
     }

--- a/server/index.ts
+++ b/server/index.ts
@@ -2027,6 +2027,8 @@ async function main(): Promise<void> {
           // Fallback if close hangs
           setTimeout(() => process.exit(0), 3000);
         }, 500);
+      } else {
+        updateInFlight = false;
       }
     } catch (err) {
       updateInFlight = false;


### PR DESCRIPTION
## Summary

- The `POST /update` handler runs `npm install -g relay-ide@nightly`, which triggers the package's `postinstall.js`. The postinstall script detects the running launchd service and calls `service.uninstall()` → `launchctl unload`, sending SIGTERM to the very server that initiated the update. The server dies mid-request, the client sees "Update failed", and if the orphaned postinstall fails to re-register the service, the server stays permanently dead.
- Passes `RELAY_IDE_SKIP_SERVICE_RESTART=1` env var to the npm child process so postinstall skips the service restart. The handler's existing graceful shutdown logic (serialize sessions, broadcast `server-restarting`, exit for launchd KeepAlive) handles the restart correctly.
- Adds an in-flight mutex on the update endpoint to prevent concurrent npm installs from double-triggering the shutdown sequence.

## Test plan

- [ ] Trigger "Update Now" from the web UI on a machine running relay-ide as a launchd service
- [ ] Verify the toast shows "Updated! Restarting server..." (not "Update failed")
- [ ] Verify the server comes back up within ~10 seconds and the page auto-reloads
- [ ] Verify `relay-ide update` from the CLI still works (postinstall restart NOT skipped)
- [ ] Verify manual `npm install -g relay-ide@nightly` still restarts the service via postinstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)