### PR TITLE
fix: restore sidenav drag-and-drop, collapse/expand, and double-click

### DIFF
--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -9,12 +9,13 @@ import type {
 import { isAttentionState } from '../lib/state/display-state.js';
 import { deriveColor } from '../lib/colors.js';
 import { derivePrDotStatus } from '../lib/pr-status.js';
-import { formatRelativeTimeCompact } from '../lib/utils.js';
+import { formatRelativeTimeCompact, isMobileDevice } from '../lib/utils.js';
 import StatusDot from './StatusDot.js';
 import { MarqueeText } from './MarqueeText.js';
 import ContextMenu from './ContextMenu.js';
 import './RepoItem.css';
 
+const DOUBLE_CLICK_DELAY_MS = 200;
 const EMPTY_SET = new Set<string>();
 const EMPTY_ARRAY: never[] = [];
 
@@ -70,7 +71,9 @@ export function groupDisplayName(
     }
     return 'default';
   }
-  const renamedSession = sessions.find((s) => s.displayName && s.displayName !== s.repoName);
+  const renamedSession = sessions.find(
+    (s) => s.displayName && s.displayName !== s.repoName
+  );
   if (renamedSession) return renamedSession.displayName;
   const branch = sessions.find((s) => s.branchName)?.branchName;
   const cwdName = sessions[0]?.cwd.split('/').pop();
@@ -343,12 +346,7 @@ export function RepoItem({
   const creatingWorktree = loadingItems.has(`new-worktree:${repo.path}`);
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Double-click to collapse: single click selects workspace, double click toggles collapse
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const isMobile = useMemo(
-    () => typeof window !== 'undefined' && window.matchMedia('(max-width: 600px)').matches,
-    []
-  );
 
   useEffect(() => {
     return () => {
@@ -357,7 +355,7 @@ export function RepoItem({
   }, []);
 
   const handleHeaderClick = useCallback(() => {
-    if (isMobile) {
+    if (isMobileDevice) {
       onSelectWorkspace(repo.path);
       return;
     }
@@ -369,9 +367,9 @@ export function RepoItem({
       clickTimerRef.current = setTimeout(() => {
         clickTimerRef.current = null;
         onSelectWorkspace(repo.path);
-      }, 200);
+      }, DOUBLE_CLICK_DELAY_MS);
     }
-  }, [isMobile, onSelectWorkspace, repo.path, onToggleCollapse]);
+  }, [onSelectWorkspace, repo.path, onToggleCollapse]);
 
   function cancelLongPress() {
     if (longPressTimerRef.current) {

--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import type {
   Repo,
   SessionSummary,
@@ -343,6 +343,36 @@ export function RepoItem({
   const creatingWorktree = loadingItems.has(`new-worktree:${repo.path}`);
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Double-click to collapse: single click selects workspace, double click toggles collapse
+  const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isMobile = useMemo(
+    () => typeof window !== 'undefined' && window.matchMedia('(max-width: 600px)').matches,
+    []
+  );
+
+  useEffect(() => {
+    return () => {
+      if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
+    };
+  }, []);
+
+  const handleHeaderClick = useCallback(() => {
+    if (isMobile) {
+      onSelectWorkspace(repo.path);
+      return;
+    }
+    if (clickTimerRef.current) {
+      clearTimeout(clickTimerRef.current);
+      clickTimerRef.current = null;
+      onToggleCollapse?.();
+    } else {
+      clickTimerRef.current = setTimeout(() => {
+        clickTimerRef.current = null;
+        onSelectWorkspace(repo.path);
+      }, 200);
+    }
+  }, [isMobile, onSelectWorkspace, repo.path, onToggleCollapse]);
+
   function cancelLongPress() {
     if (longPressTimerRef.current) {
       clearTimeout(longPressTimerRef.current);
@@ -368,7 +398,7 @@ export function RepoItem({
           .filter(Boolean)
           .join(' ')}
         data-track="sidebar.repo.click"
-        onClick={() => onSelectWorkspace(repo.path)}
+        onClick={handleHeaderClick}
       >
         <div className="repo-left">
           <span

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,7 +2,6 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from 'react';
 import { useQuery } from '@tanstack/react-query';
@@ -19,6 +18,24 @@ import { fetchOrgPrs } from '../lib/api.js';
 import WorkspaceGroup from './WorkspaceGroup.js';
 import RepoItem from './RepoItem.js';
 import { TuiButton } from './TuiButton.js';
+import {
+  DndContext,
+  closestCenter,
+  MouseSensor,
+  TouchSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  sortableKeyboardCoordinates,
+  useSortable,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import './Sidebar.css';
 
 // ── Resize hook ──
@@ -60,7 +77,22 @@ function useSidebarResize() {
   return { startResize, resetWidth };
 }
 
-// ── Ungrouped workspace list (no DnD in React version — order from store) ──
+// ── Sortable repo wrapper for DnD ──
+
+function SortableRepoWrapper({ id, children }: { id: string; children: React.ReactNode }) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition: transition ?? undefined,
+  };
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      {children}
+    </div>
+  );
+}
+
+// ── Ungrouped workspace list with DnD reorder ──
 
 interface UngroupedListProps {
   ungroupedRepos: Repo[];
@@ -95,45 +127,106 @@ function UngroupedList({
 }: UngroupedListProps) {
   const getSessionsForRepo = useSessionsStore((s) => s.getSessionsForRepo);
   const sidebarItems = useSessionsStore((s) => s.sidebarItems);
+  const reorderWorkspaces = useSessionsStore((s) => s.reorderWorkspaces);
+  const allRepos = useSessionsStore((s) => s.repos);
+  const workspaceGroups = useSessionsStore((s) => s.workspaceGroups);
+  const collapsedWorkspaces = useUiStore((s) => s.collapsedWorkspaces);
+  const toggleWorkspaceCollapse = useUiStore((s) => s.toggleWorkspaceCollapse);
+
+  // Local order for DnD — only re-sync when repos are added/removed
+  const [localOrder, setLocalOrder] = useState<string[]>([]);
+
+  useEffect(() => {
+    const incomingIds = ungroupedRepos.map((r) => r.path);
+    setLocalOrder((prev) => {
+      const prevSet = new Set(prev);
+      const incomingSet = new Set(incomingIds);
+      const added = incomingIds.some((id) => !prevSet.has(id));
+      const removed = prev.some((id) => !incomingSet.has(id));
+      if (added || removed || prev.length === 0) return incomingIds;
+      return prev;
+    });
+  }, [ungroupedRepos]);
+
+  const reposByPath = useMemo(
+    () => new Map(ungroupedRepos.map((r) => [r.path, r])),
+    [ungroupedRepos]
+  );
+
+  const orderedRepos = useMemo(
+    () => localOrder.map((p) => reposByPath.get(p)).filter((r): r is Repo => r !== undefined),
+    [localOrder, reposByPath]
+  );
+
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 500, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      setLocalOrder((prev) => {
+        const oldIndex = prev.indexOf(active.id as string);
+        const newIndex = prev.indexOf(over.id as string);
+        const newOrder = arrayMove(prev, oldIndex, newIndex);
+        const groupedPaths = new Set(workspaceGroups.flatMap((ws) => ws.repos));
+        const groupedOrder = allRepos
+          .filter((r) => groupedPaths.has(r.path))
+          .map((r) => r.path);
+        reorderWorkspaces([...groupedOrder, ...newOrder]);
+        return newOrder;
+      });
+    },
+    [allRepos, workspaceGroups, reorderWorkspaces]
+  );
 
   return (
-    <div className="sidebar-ungrouped-list">
-      {ungroupedRepos.map((repo) => {
-        const activeSessions = getSessionsForRepo(repo.path);
-        const activeWorktreePaths = new Set(
-          activeSessions.map((s) => s.worktreePath).filter(Boolean) as string[]
-        );
-        const inactiveWorktrees = worktrees.filter(
-          (wt) =>
-            wt.repoPath === repo.path &&
-            wt.path.startsWith(repo.path + '/') &&
-            !activeWorktreePaths.has(wt.path)
-        );
-        const groupedByPath = buildGroupedByPath(repo.path, activeSessions);
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={localOrder} strategy={verticalListSortingStrategy}>
+        <div className="sidebar-ungrouped-list">
+          {orderedRepos.map((repo) => {
+            const activeSessions = getSessionsForRepo(repo.path);
+            const activeWorktreePaths = new Set(
+              activeSessions.map((s) => s.worktreePath).filter(Boolean) as string[]
+            );
+            const inactiveWorktrees = worktrees.filter(
+              (wt) =>
+                wt.repoPath === repo.path &&
+                wt.path.startsWith(repo.path + '/') &&
+                !activeWorktreePaths.has(wt.path)
+            );
+            const groupedByPath = buildGroupedByPath(repo.path, activeSessions);
 
-        return (
-          <div key={repo.path}>
-            <RepoItem
-              repo={repo}
-              sessionGroups={groupedByPath}
-              inactiveWorktrees={inactiveWorktrees}
-              isActive={activeRepoPath === repo.path && !activeSessionId}
-              activeSessionId={activeSessionId ?? null}
-              onSelectWorkspace={onSelectWorkspace}
-              onSelectSession={onSelectSession}
-              onNewWorktree={onNewWorktree}
-              onOpenSettings={onOpenSettings}
-              onDeleteSession={onDeleteSession}
-              onDeleteWorktree={onDeleteWorktree}
-              onResumeWorktree={onResumeWorktree}
-              onLaunchRepoSession={onLaunchRepoSession}
-              orgPrs={orgPrs}
-              sidebarItems={sidebarItems}
-            />
-          </div>
-        );
-      })}
-    </div>
+            return (
+              <SortableRepoWrapper key={repo.path} id={repo.path}>
+                <RepoItem
+                  repo={repo}
+                  sessionGroups={groupedByPath}
+                  inactiveWorktrees={inactiveWorktrees}
+                  isActive={activeRepoPath === repo.path && !activeSessionId}
+                  activeSessionId={activeSessionId ?? null}
+                  onSelectWorkspace={onSelectWorkspace}
+                  onSelectSession={onSelectSession}
+                  onNewWorktree={onNewWorktree}
+                  onOpenSettings={onOpenSettings}
+                  onDeleteSession={onDeleteSession}
+                  onDeleteWorktree={onDeleteWorktree}
+                  onResumeWorktree={onResumeWorktree}
+                  onLaunchRepoSession={onLaunchRepoSession}
+                  orgPrs={orgPrs}
+                  sidebarItems={sidebarItems}
+                  collapsed={collapsedWorkspaces.has(repo.path)}
+                  onToggleCollapse={() => toggleWorkspaceCollapse(repo.path)}
+                />
+              </SortableRepoWrapper>
+            );
+          })}
+        </div>
+      </SortableContext>
+    </DndContext>
   );
 }
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
   useUiStore,
@@ -79,8 +74,15 @@ function useSidebarResize() {
 
 // ── Sortable repo wrapper for DnD ──
 
-function SortableRepoWrapper({ id, children }: { id: string; children: React.ReactNode }) {
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });
+function SortableRepoWrapper({
+  id,
+  children,
+}: {
+  id: string;
+  children: React.ReactNode;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id });
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition: transition ?? undefined,
@@ -154,13 +156,18 @@ function UngroupedList({
   );
 
   const orderedRepos = useMemo(
-    () => localOrder.map((p) => reposByPath.get(p)).filter((r): r is Repo => r !== undefined),
+    () =>
+      localOrder
+        .map((p) => reposByPath.get(p))
+        .filter((r): r is Repo => r !== undefined),
     [localOrder, reposByPath]
   );
 
   const sensors = useSensors(
     useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(TouchSensor, { activationConstraint: { delay: 500, tolerance: 5 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 500, tolerance: 5 },
+    }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 
@@ -168,29 +175,36 @@ function UngroupedList({
     (event: DragEndEvent) => {
       const { active, over } = event;
       if (!over || active.id === over.id) return;
-      setLocalOrder((prev) => {
-        const oldIndex = prev.indexOf(active.id as string);
-        const newIndex = prev.indexOf(over.id as string);
-        const newOrder = arrayMove(prev, oldIndex, newIndex);
-        const groupedPaths = new Set(workspaceGroups.flatMap((ws) => ws.repos));
-        const groupedOrder = allRepos
-          .filter((r) => groupedPaths.has(r.path))
-          .map((r) => r.path);
-        reorderWorkspaces([...groupedOrder, ...newOrder]);
-        return newOrder;
-      });
+      const oldIndex = localOrder.indexOf(active.id as string);
+      const newIndex = localOrder.indexOf(over.id as string);
+      const newOrder = arrayMove(localOrder, oldIndex, newIndex);
+      setLocalOrder(newOrder);
+      const groupedPaths = new Set(workspaceGroups.flatMap((ws) => ws.repos));
+      const groupedOrder = allRepos
+        .filter((r) => groupedPaths.has(r.path))
+        .map((r) => r.path);
+      reorderWorkspaces([...groupedOrder, ...newOrder]);
     },
-    [allRepos, workspaceGroups, reorderWorkspaces]
+    [localOrder, allRepos, workspaceGroups, reorderWorkspaces]
   );
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-      <SortableContext items={localOrder} strategy={verticalListSortingStrategy}>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={localOrder}
+        strategy={verticalListSortingStrategy}
+      >
         <div className="sidebar-ungrouped-list">
           {orderedRepos.map((repo) => {
             const activeSessions = getSessionsForRepo(repo.path);
             const activeWorktreePaths = new Set(
-              activeSessions.map((s) => s.worktreePath).filter(Boolean) as string[]
+              activeSessions
+                .map((s) => s.worktreePath)
+                .filter(Boolean) as string[]
             );
             const inactiveWorktrees = worktrees.filter(
               (wt) =>
@@ -392,11 +406,14 @@ export function Sidebar({
     () => new Map(repos.map((r) => [r.path, r])),
     [repos]
   );
-  const handleSelectWorkspace = useCallback((path: string) => {
-    useUiStore.setState({ activeRepoPath: path });
-    useSessionsStore.getState().setActiveSessionId(null);
-    closeSidebar();
-  }, [closeSidebar]);
+  const handleSelectWorkspace = useCallback(
+    (path: string) => {
+      useUiStore.setState({ activeRepoPath: path });
+      useSessionsStore.getState().setActiveSessionId(null);
+      closeSidebar();
+    },
+    [closeSidebar]
+  );
   const handleHomeBrand = useCallback(() => {
     useUiStore.getState().setActiveRepoPath(null);
     useUiStore.getState().setAnalyticsView(null);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@tanstack/react-query": "^5.96.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
@@ -48,7 +51,6 @@
         "happy-dom": "^20.8.9",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
-        "playwright": "^1.58.2",
         "prettier": "^3.8.1",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.58.0",
@@ -409,6 +411,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -5739,6 +5794,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
   "license": "MIT",
   "author": "Donovan Yohan",
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tanstack/react-query": "^5.96.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",


### PR DESCRIPTION
## Summary

- **Drag-and-drop reorder**: Adds `@dnd-kit/core` + `@dnd-kit/sortable` to restore sidebar repo reordering lost in Svelte → React migration. Uses `MouseSensor` (8px distance gate) and `TouchSensor` (500ms long-press) to match the original `svelte-dnd-action` behavior. Local order state syncs only on add/remove to preserve user's drag order across server polls.
- **Collapse/expand repos**: Wires the existing `collapsedWorkspaces` / `toggleWorkspaceCollapse` from the UI store to each `RepoItem` in the ungrouped list. The props existed on `RepoItem` but were never passed during migration.
- **Double-click to collapse** (closes #157): Ports the Svelte click timer pattern — single click selects workspace (200ms delay), double click toggles collapse. Mobile skips the delay for instant selection.

## Test plan

- [ ] Drag repos in the sidebar to reorder — order persists across page reload
- [ ] On mobile/touch: long-press (500ms) then drag to reorder
- [ ] Click the chevron on a repo to collapse/expand its sessions list
- [ ] Double-click a repo header to toggle collapse (desktop only)
- [ ] Single-click a repo header still selects the workspace (with ~200ms delay)
- [ ] On mobile: single tap selects immediately (no 200ms delay)
- [ ] Collapse state persists across page reload (stored in localStorage)
- [ ] Build succeeds: `npm run build`
- [ ] No test regressions (pre-existing PTY test failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)