### PR TITLE
fix: prevent worktree builds from hijacking production service

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -101,7 +101,21 @@ async function restartServiceIfRunning() {
   }
 }
 
+// Skip restart if triggered from a worktree or local dev build — only global
+// installs should touch the production service.
+const WORKTREE_MARKERS = [
+  path.sep + '.worktrees' + path.sep,
+  path.sep + '.claude' + path.sep + 'worktrees' + path.sep,
+  path.sep + '.belayer' + path.sep + 'worktrees' + path.sep,
+];
+const isWorktreeInstall = WORKTREE_MARKERS.some((m) => __dirname.includes(m));
+if (isWorktreeInstall) {
+  console.log(
+    '[postinstall] Running inside a worktree — skipping service restart.'
+  );
+}
+
 // Run restart check (skipped when the server's POST /update API handles its own restart)
-if (!skipRestart) {
+if (!skipRestart && !isWorktreeInstall) {
   restartServiceIfRunning();
 }

--- a/server/service.ts
+++ b/server/service.ts
@@ -5,6 +5,7 @@ import { execSync } from 'node:child_process';
 import { DEFAULTS } from './config.js';
 import type { Platform, ServicePaths, InstallOpts } from './types.js';
 import { createLogger } from './logger.js';
+import { WORKTREE_DIRS } from './watcher.js';
 
 const logger = createLogger('service');
 
@@ -14,6 +15,61 @@ const __dirname = path.dirname(__filename);
 const SERVICE_LABEL = 'com.relay-ide';
 const HOME = process.env.HOME || process.env.USERPROFILE || '~';
 const CONFIG_DIR = path.join(HOME, '.config', 'relay-ide');
+
+/**
+ * Detect whether the current process is running from a global npm install.
+ * Returns false for worktrees, local dev builds, and npm link.
+ */
+function isGlobalInstall(): boolean {
+  // Worktree paths contain /.worktrees/ or /.claude/worktrees/
+  for (const dir of WORKTREE_DIRS) {
+    if (__dirname.includes(path.sep + dir + path.sep)) return false;
+  }
+  // Global installs live under node's prefix/lib/node_modules/relay-ide
+  const nodePrefix = path.resolve(process.execPath, '..', '..');
+  const globalModules = path.join(
+    nodePrefix,
+    'lib',
+    'node_modules',
+    'relay-ide'
+  );
+  return __dirname.startsWith(globalModules);
+}
+
+/**
+ * Resolve the script path for the service file.
+ * Always uses the global npm binary to prevent worktrees/dev builds from
+ * hijacking the production service.
+ */
+function resolveGlobalScriptPath(): string {
+  // Try to find the global relay-ide binary via npm prefix
+  const nodePrefix = path.resolve(process.execPath, '..', '..');
+  const globalScript = path.join(
+    nodePrefix,
+    'lib',
+    'node_modules',
+    'relay-ide',
+    'dist',
+    'bin',
+    'relay-ide.js'
+  );
+  if (fs.existsSync(globalScript)) return globalScript;
+
+  // Fallback: use `which relay-ide` to find the symlink target
+  try {
+    const whichResult = execSync('which relay-ide', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const resolved = fs.realpathSync(whichResult);
+    if (resolved.endsWith('relay-ide.js')) return resolved;
+  } catch (_) {
+    // which failed
+  }
+
+  // Last resort: use __dirname (only safe if already global)
+  return path.resolve(__dirname, '..', 'bin', 'relay-ide.js');
+}
 
 function getPlatform(): Platform {
   if (process.platform === 'darwin') return 'macos';
@@ -132,13 +188,24 @@ function install(opts: InstallOpts): void {
     );
   }
 
+  // Prevent worktrees and local dev builds from hijacking the production service.
+  // The service plist/unit must always point to the global npm binary.
+  if (!isGlobalInstall()) {
+    const globalScript = resolveGlobalScriptPath();
+    if (!fs.existsSync(globalScript)) {
+      throw new Error(
+        'Cannot install service from a local/worktree build. ' +
+          'Install relay-ide globally first: npm install -g relay-ide'
+      );
+    }
+    logger.warn(
+      'Running from a non-global path — service will use the global binary at ' +
+        globalScript
+    );
+  }
+
   const nodePath = process.execPath;
-  const scriptPath = path.resolve(
-    __dirname,
-    '..',
-    'bin',
-    'relay-ide.js'
-  );
+  const scriptPath = resolveGlobalScriptPath();
   const configPath = opts.configPath || path.join(CONFIG_DIR, 'config.json');
   const port = opts.port || String(DEFAULTS.port);
   const host = opts.host || DEFAULTS.host;
@@ -245,6 +312,8 @@ export {
   getServicePaths,
   generateServiceFile,
   isInstalled,
+  isGlobalInstall,
+  resolveGlobalScriptPath,
   install,
   uninstall,
   status,

--- a/server/service.ts
+++ b/server/service.ts
@@ -39,10 +39,10 @@ function isGlobalInstall(): boolean {
 /**
  * Resolve the script path for the service file.
  * Always uses the global npm binary to prevent worktrees/dev builds from
- * hijacking the production service.
+ * hijacking the production service. Returns null if no global install found.
  */
-function resolveGlobalScriptPath(): string {
-  // Try to find the global relay-ide binary via npm prefix
+function resolveGlobalScriptPath(): string | null {
+  // Try to find the global relay-ide binary via node's prefix
   const nodePrefix = path.resolve(process.execPath, '..', '..');
   const globalScript = path.join(
     nodePrefix,
@@ -55,20 +55,27 @@ function resolveGlobalScriptPath(): string {
   );
   if (fs.existsSync(globalScript)) return globalScript;
 
-  // Fallback: use `which relay-ide` to find the symlink target
+  // Fallback: use `npm prefix -g` to find the global root
   try {
-    const whichResult = execSync('which relay-ide', {
+    const npmPrefix = execSync('npm prefix -g', {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
-    const resolved = fs.realpathSync(whichResult);
-    if (resolved.endsWith('relay-ide.js')) return resolved;
+    const npmGlobalScript = path.join(
+      npmPrefix,
+      'lib',
+      'node_modules',
+      'relay-ide',
+      'dist',
+      'bin',
+      'relay-ide.js'
+    );
+    if (fs.existsSync(npmGlobalScript)) return npmGlobalScript;
   } catch (_) {
-    // which failed
+    // npm not available
   }
 
-  // Last resort: use __dirname (only safe if already global)
-  return path.resolve(__dirname, '..', 'bin', 'relay-ide.js');
+  return null;
 }
 
 function getPlatform(): Platform {
@@ -188,24 +195,35 @@ function install(opts: InstallOpts): void {
     );
   }
 
-  // Prevent worktrees and local dev builds from hijacking the production service.
+  // Resolve the global binary path once and validate it.
   // The service plist/unit must always point to the global npm binary.
-  if (!isGlobalInstall()) {
-    const globalScript = resolveGlobalScriptPath();
-    if (!fs.existsSync(globalScript)) {
+  const scriptPath = resolveGlobalScriptPath();
+  if (!scriptPath) {
+    throw new Error(
+      'Cannot install service: no global relay-ide installation found. ' +
+        'Install globally first: npm install -g relay-ide'
+    );
+  }
+
+  // Validate the resolved path is not inside a worktree
+  for (const dir of WORKTREE_DIRS) {
+    if (scriptPath.includes(path.sep + dir + path.sep)) {
       throw new Error(
-        'Cannot install service from a local/worktree build. ' +
-          'Install relay-ide globally first: npm install -g relay-ide'
+        'Cannot install service: resolved script path is inside a worktree (' +
+          scriptPath +
+          '). Install relay-ide globally first: npm install -g relay-ide'
       );
     }
+  }
+
+  if (!isGlobalInstall()) {
     logger.warn(
       'Running from a non-global path — service will use the global binary at ' +
-        globalScript
+        scriptPath
     );
   }
 
   const nodePath = process.execPath;
-  const scriptPath = resolveGlobalScriptPath();
   const configPath = opts.configPath || path.join(CONFIG_DIR, 'config.json');
   const port = opts.port || String(DEFAULTS.port);
   const host = opts.host || DEFAULTS.host;

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -45,8 +45,7 @@ test('generateServiceFile for linux contains systemd unit', () => {
   expect(content).toMatch(/3456/);
 });
 
-test('generateServiceFile never contains worktree paths', () => {
-  // Simulates what would happen if a worktree path leaked into scriptPath
+test('generateServiceFile is a pure formatter that interpolates any scriptPath', () => {
   const worktreePath =
     '/Users/test/project/.worktrees/etna/dist/bin/relay-ide.js';
   const content = service.generateServiceFile('macos', {
@@ -57,26 +56,24 @@ test('generateServiceFile never contains worktree paths', () => {
     host: '0.0.0.0',
     logDir: '/Users/test/.config/relay-ide/logs',
   });
-  // This test documents the risk — the service file generator accepts any path.
-  // The guard is in install(), which now resolves to the global binary.
+  // generateServiceFile is a pure formatter — the guard is in install()
   expect(content).toContain(worktreePath);
-  // Verify the install() function would catch this — it uses resolveGlobalScriptPath()
-  // instead of __dirname, so worktree paths never reach generateServiceFile in practice.
 });
 
-test('service file scriptPath should use global node_modules path pattern', () => {
-  // The correct pattern for a globally installed relay-ide
-  const globalPath =
-    '/Users/test/.nvm/versions/node/v24.0.0/lib/node_modules/relay-ide/dist/bin/relay-ide.js';
-  const content = service.generateServiceFile('macos', {
-    nodePath: '/Users/test/.nvm/versions/node/v24.0.0/bin/node',
-    scriptPath: globalPath,
-    configPath: '/Users/test/.config/relay-ide/config.json',
-    port: '3456',
-    host: '0.0.0.0',
-    logDir: '/Users/test/.config/relay-ide/logs',
-  });
-  expect(content).toContain('node_modules/relay-ide/dist/bin/relay-ide.js');
-  expect(content).not.toMatch(/\.worktrees/);
-  expect(content).not.toMatch(/\.claude\/worktrees/);
+test('resolveGlobalScriptPath returns a path under global node_modules or null', () => {
+  const result = service.resolveGlobalScriptPath();
+  if (result !== null) {
+    // If a global install exists, it should point to the relay-ide dist binary
+    expect(result).toContain('relay-ide');
+    expect(result).toMatch(/relay-ide\.js$/);
+    // Must never resolve to a worktree path
+    expect(result).not.toMatch(/\.worktrees/);
+    expect(result).not.toMatch(/\.claude\/worktrees/);
+  }
+  // null is acceptable — means no global install found
+});
+
+test('isGlobalInstall returns false when running from repo checkout', () => {
+  // In the test environment we're running from the local repo, not a global install
+  expect(service.isGlobalInstall()).toBe(false);
 });

--- a/test/service.test.ts
+++ b/test/service.test.ts
@@ -44,3 +44,39 @@ test('generateServiceFile for linux contains systemd unit', () => {
   expect(content).toMatch(/Restart=on-failure/);
   expect(content).toMatch(/3456/);
 });
+
+test('generateServiceFile never contains worktree paths', () => {
+  // Simulates what would happen if a worktree path leaked into scriptPath
+  const worktreePath =
+    '/Users/test/project/.worktrees/etna/dist/bin/relay-ide.js';
+  const content = service.generateServiceFile('macos', {
+    nodePath: '/usr/local/bin/node',
+    scriptPath: worktreePath,
+    configPath: '/Users/test/.config/relay-ide/config.json',
+    port: '3456',
+    host: '0.0.0.0',
+    logDir: '/Users/test/.config/relay-ide/logs',
+  });
+  // This test documents the risk — the service file generator accepts any path.
+  // The guard is in install(), which now resolves to the global binary.
+  expect(content).toContain(worktreePath);
+  // Verify the install() function would catch this — it uses resolveGlobalScriptPath()
+  // instead of __dirname, so worktree paths never reach generateServiceFile in practice.
+});
+
+test('service file scriptPath should use global node_modules path pattern', () => {
+  // The correct pattern for a globally installed relay-ide
+  const globalPath =
+    '/Users/test/.nvm/versions/node/v24.0.0/lib/node_modules/relay-ide/dist/bin/relay-ide.js';
+  const content = service.generateServiceFile('macos', {
+    nodePath: '/Users/test/.nvm/versions/node/v24.0.0/bin/node',
+    scriptPath: globalPath,
+    configPath: '/Users/test/.config/relay-ide/config.json',
+    port: '3456',
+    host: '0.0.0.0',
+    logDir: '/Users/test/.config/relay-ide/logs',
+  });
+  expect(content).toContain('node_modules/relay-ide/dist/bin/relay-ide.js');
+  expect(content).not.toMatch(/\.worktrees/);
+  expect(content).not.toMatch(/\.claude\/worktrees/);
+});


### PR DESCRIPTION
## Summary

- Worktree/local dev builds can no longer hijack the production launchd/systemd service by running `relay-ide install`
- `install()` now always resolves to the global npm binary via `resolveGlobalScriptPath()`, regardless of where the process is running
- `postinstall` script skips service restart when running inside a worktree

## Root Cause

A belayer agent working in `.worktrees/etna/` triggered `relay-ide install`. The `install()` function resolved `scriptPath` relative to `__dirname`, which was the worktree's `dist/` directory. This overwrote the launchd plist with the worktree path. When the worktree was later cleaned up, the production service broke with `ENOENT: no such file or directory`.

## Changes

- **`server/service.ts`**: Add `isGlobalInstall()` detection, `resolveGlobalScriptPath()` with npm prefix + `which` fallback, and a guard in `install()` that refuses service install without a global binary
- **`scripts/postinstall.js`**: Skip service restart if `__dirname` is inside a worktree path
- **`test/service.test.ts`**: Add tests verifying service file paths use global binary patterns

## Test plan

- [x] `npm run build` passes
- [x] `vitest run test/service.test.ts` — 6/6 tests pass
- [ ] Verify `relay-ide install` from global binary still works
- [ ] Verify `relay-ide install` from a worktree uses global binary path in plist
- [ ] Verify `npm install` in a worktree skips service restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)