### PR TITLE
feat: multi-framework telemetry in status bar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -518,6 +518,7 @@ function TerminalAreaContent({
                   <SessionStatusBar
                     sessionId={activeSessionId}
                     currentActivity={activeSession?.currentActivity ?? null}
+                    framework={activeSession?.agent}
                   />
                 )}
 

--- a/frontend/src/components/RepoDashboard.tsx
+++ b/frontend/src/components/RepoDashboard.tsx
@@ -46,7 +46,8 @@ interface UsageSectionProps {
 
 function UsageSection({ repoSessions }: UsageSectionProps) {
   const summarize = useTelemetryStore((s) => s.summarizeSessionSetTelemetry);
-  const accountTelemetry = useTelemetryStore((s) => s.accountTelemetry);
+  const getAccountTelemetry = useTelemetryStore((s) => s.getAccountTelemetry);
+  const accountTelemetry = getAccountTelemetry();
   const repoTelemetry = useMemo(
     () => summarize(repoSessions),
     [summarize, repoSessions]

--- a/frontend/src/components/SessionStatusBar.css
+++ b/frontend/src/components/SessionStatusBar.css
@@ -40,8 +40,26 @@
 .status-cost,
 .status-tokens,
 .status-activity,
-.status-rate-limits {
+.status-rate-limits,
+.status-framework {
   color: var(--text-muted);
+}
+
+.status-framework {
+  text-transform: lowercase;
+  min-width: 60px;
+}
+
+.status-framework--claude {
+  color: var(--color-coral);
+}
+
+.status-framework--codex {
+  color: var(--color-green);
+}
+
+.status-framework--opencode {
+  color: var(--color-purple);
 }
 
 .status-context {
@@ -73,7 +91,8 @@
   .status-model,
   .status-tokens,
   .status-cost,
-  .status-rate-limits {
+  .status-rate-limits,
+  .status-framework {
     display: none;
   }
 

--- a/frontend/src/components/SessionStatusBar.tsx
+++ b/frontend/src/components/SessionStatusBar.tsx
@@ -7,12 +7,14 @@ import './SessionStatusBar.css';
 export interface SessionStatusBarProps {
   sessionId: string | null;
   currentActivity?: CurrentActivity | null;
+  framework?: string | null | undefined;
 }
 
 const BAR_WIDTH = 10;
 
 function formatCurrency(value: number | null | undefined): string {
-  if (value === null || value === undefined || Number.isNaN(value)) return '~$—';
+  if (value === null || value === undefined || Number.isNaN(value))
+    return '~$—';
   return `~$${value.toFixed(2)}`;
 }
 
@@ -36,29 +38,43 @@ function getContextLabel(telemetry: { contextPercent: number } | null): string {
   return `${'░'.repeat(BAR_WIDTH)} —%`;
 }
 
-function buildRateLimitLabel(accountTelemetry: import('../lib/types.js').AccountTelemetry | null | undefined): string {
+function buildRateLimitLabel(
+  accountTelemetry:
+    | import('../lib/types.js').AccountTelemetry
+    | null
+    | undefined
+): string {
   if (!accountTelemetry || !accountTelemetry.rateLimits.length) return '—';
   const parts: string[] = [];
   for (const rl of accountTelemetry.rateLimits) {
     if (rl.usedPercent >= 0) {
-      const label = rl.windowMinutes === 300 ? '5h' : rl.windowMinutes === 10080 ? '7d' : rl.name;
-      parts.push(`${label}: ${Math.round(rl.usedPercent)}%`);
+      parts.push(`${rl.name}: ${Math.round(rl.usedPercent)}%`);
     }
   }
   return parts.length > 0 ? parts.join(' | ') : '—';
 }
 
-export function SessionStatusBar({ sessionId, currentActivity = null }: SessionStatusBarProps) {
+export function SessionStatusBar({
+  sessionId,
+  currentActivity = null,
+  framework,
+}: SessionStatusBarProps) {
   const keyboardOpen = useUiStore((s) => s.keyboardOpen);
   const sessionTelemetryById = useTelemetryStore((s) => s.sessionTelemetryById);
-  const accountTelemetry = useTelemetryStore((s) => s.accountTelemetry);
+  const getAccountTelemetry = useTelemetryStore((s) => s.getAccountTelemetry);
+  const accountTelemetry = getAccountTelemetry(framework ?? undefined);
+  const frameworkLabel = framework ?? 'claude';
 
-  const telemetry = sessionId ? sessionTelemetryById[sessionId] ?? null : null;
+  const telemetry = sessionId
+    ? (sessionTelemetryById[sessionId] ?? null)
+    : null;
   const contextTone = getContextTone(telemetry);
   const contextLabel = getContextLabel(telemetry);
 
   const contextClass =
-    contextTone === 'ok' ? 'status-context status-segment' : `status-context status-segment status-context--${contextTone}`;
+    contextTone === 'ok'
+      ? 'status-context status-segment'
+      : `status-context status-segment status-context--${contextTone}`;
 
   const activityLabel = currentActivity
     ? `${currentActivity.tool}${currentActivity.detail ? `: ${currentActivity.detail}` : ''}`
@@ -84,7 +100,15 @@ export function SessionStatusBar({ sessionId, currentActivity = null }: SessionS
           {telemetry ? formatCompact(telemetry.totalOutputTokens) : '—'}
         </span>
         <span className="status-cost status-segment" title={telemetryTitle}>
-          {telemetry ? formatCurrency(telemetry.costUsd) : '~$—'}
+          {telemetry && telemetry.costUsd !== null
+            ? formatCurrency(telemetry.costUsd)
+            : '~$—'}
+        </span>
+        <span
+          className="status-framework status-segment"
+          title={`Framework: ${frameworkLabel}`}
+        >
+          {frameworkLabel}
         </span>
         <span className="status-activity status-segment" title={activityLabel}>
           [{activityLabel}]
@@ -94,7 +118,13 @@ export function SessionStatusBar({ sessionId, currentActivity = null }: SessionS
       <div className="status-right">
         <span
           className="status-rate-limits status-segment"
-          title={accountTelemetry?.rateLimits.length ? accountTelemetry.rateLimits.map((rl) => formatResetAt(rl.resetsAt)).join(' · ') : '—'}
+          title={
+            accountTelemetry?.rateLimits.length
+              ? accountTelemetry.rateLimits
+                  .map((rl) => formatResetAt(rl.resetsAt))
+                  .join(' · ')
+              : '—'
+          }
         >
           {rateLimitLabel}
         </span>

--- a/frontend/src/components/SessionStatusBar.tsx
+++ b/frontend/src/components/SessionStatusBar.tsx
@@ -63,7 +63,7 @@ export function SessionStatusBar({
   const sessionTelemetryById = useTelemetryStore((s) => s.sessionTelemetryById);
   const getAccountTelemetry = useTelemetryStore((s) => s.getAccountTelemetry);
   const accountTelemetry = getAccountTelemetry(framework ?? undefined);
-  const frameworkLabel = framework ?? 'claude';
+  const frameworkLabel = framework ?? accountTelemetry?.framework ?? 'claude';
 
   const telemetry = sessionId
     ? (sessionTelemetryById[sessionId] ?? null)
@@ -105,7 +105,7 @@ export function SessionStatusBar({
             : '~$—'}
         </span>
         <span
-          className="status-framework status-segment"
+          className={`status-framework status-segment status-framework--${frameworkLabel}`}
           title={`Framework: ${frameworkLabel}`}
         >
           {frameworkLabel}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -161,9 +161,11 @@ function normalizeAccountTelemetry(data: unknown): AccountTelemetry | null {
   const candidate = raw as Partial<AccountTelemetry>;
   if (typeof candidate.updatedAt !== 'string') return null;
   return {
-    framework: typeof candidate.framework === 'string' ? candidate.framework : 'unknown',
+    framework:
+      typeof candidate.framework === 'string' ? candidate.framework : 'unknown',
     rateLimits: Array.isArray(candidate.rateLimits) ? candidate.rateLimits : [],
-    planType: typeof candidate.planType === 'string' ? candidate.planType : undefined,
+    planType:
+      typeof candidate.planType === 'string' ? candidate.planType : undefined,
     updatedAt: candidate.updatedAt,
   };
 }
@@ -174,10 +176,30 @@ export async function fetchSessionTelemetry(): Promise<SessionTelemetry[]> {
   return normalizeTelemetrySessions(data);
 }
 
-export async function fetchAccountTelemetry(): Promise<AccountTelemetry | null> {
+export async function fetchAccountTelemetry(): Promise<Record<
+  string,
+  AccountTelemetry
+> | null> {
   const res = await fetch('/telemetry/account');
   const data = await jsonOrNull<unknown>(res);
-  return normalizeAccountTelemetry(data);
+  if (!data || typeof data !== 'object') return null;
+
+  const result: Record<string, AccountTelemetry> = {};
+  for (const [framework, telemetry] of Object.entries(
+    data as Record<string, unknown>
+  )) {
+    if (
+      telemetry &&
+      typeof telemetry === 'object' &&
+      'framework' in telemetry
+    ) {
+      const normalized = normalizeAccountTelemetry(
+        telemetry as Partial<AccountTelemetry>
+      );
+      if (normalized) result[framework] = normalized;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : null;
 }
 
 export async function fetchTelemetrySetupStatus(): Promise<{
@@ -586,8 +608,7 @@ export const fetchDefaultNotifications = () =>
   fetchConfigBool('defaultNotifications');
 export const setDefaultNotifications = (v: boolean) =>
   setConfigBool('defaultNotifications', v);
-export const fetchClaudeFullscreen = () =>
-  fetchConfigBool('claudeFullscreen');
+export const fetchClaudeFullscreen = () => fetchConfigBool('claudeFullscreen');
 export const setClaudeFullscreen = (v: boolean) =>
   setConfigBool('claudeFullscreen', v);
 

--- a/frontend/src/lib/stores/telemetry.ts
+++ b/frontend/src/lib/stores/telemetry.ts
@@ -7,7 +7,6 @@ import type {
   SessionTelemetry,
 } from '../types.js';
 import {
-  mergeAccountTelemetrySnapshot,
   mergeAccountTelemetryByFrameworkSnapshot,
   mergeSessionTelemetrySnapshot,
   pickNewerAccountTelemetry,
@@ -350,7 +349,7 @@ export const useTelemetryStore = create<TelemetryState>()((set, get) => ({
       updates.accountTelemetryByFramework =
         mergeAccountTelemetryByFrameworkSnapshot(
           accountTelemetryByFramework,
-          accountResult.value ?? {},
+          accountResult.value,
           requestStartedAt
         );
     }

--- a/frontend/src/lib/stores/telemetry.ts
+++ b/frontend/src/lib/stores/telemetry.ts
@@ -8,6 +8,7 @@ import type {
 } from '../types.js';
 import {
   mergeAccountTelemetrySnapshot,
+  mergeAccountTelemetryByFrameworkSnapshot,
   mergeSessionTelemetrySnapshot,
   pickNewerAccountTelemetry,
   pickNewerSessionTelemetry,
@@ -143,7 +144,7 @@ function normalizeAccountTelemetry(
 
 export interface TelemetryState {
   sessionTelemetryById: Record<string, SessionTelemetry>;
-  accountTelemetry: AccountTelemetry | null;
+  accountTelemetryByFramework: Record<string, AccountTelemetry>;
   telemetrySetupInstalled: boolean | null;
   summarizeSessionSetTelemetry: (
     sessions: SessionSummary[]
@@ -160,7 +161,11 @@ export interface TelemetryState {
   ) => void;
   clearSessionTelemetry: (sessionId: string) => void;
   pruneSessionTelemetry: (activeSessionIds: Iterable<string>) => void;
-  setAccountTelemetrySnapshot: (data: AccountTelemetry | null) => void;
+  setAccountTelemetrySnapshot: (
+    data: Record<string, AccountTelemetry> | null,
+    requestStartedAt?: string
+  ) => void;
+  getAccountTelemetry: (framework?: string) => AccountTelemetry | null;
   setTelemetrySetupInstalled: (installed: boolean | null) => void;
   handleSessionTelemetryEvent: (
     sessionId: string,
@@ -174,7 +179,7 @@ export interface TelemetryState {
 
 export const useTelemetryStore = create<TelemetryState>()((set, get) => ({
   sessionTelemetryById: {},
-  accountTelemetry: null,
+  accountTelemetryByFramework: {},
   telemetrySetupInstalled: null,
 
   summarizeSessionSetTelemetry: (sessions) =>
@@ -266,16 +271,24 @@ export const useTelemetryStore = create<TelemetryState>()((set, get) => ({
     if (changed) set({ sessionTelemetryById: next });
   },
 
-  setAccountTelemetrySnapshot: (data) => {
+  setAccountTelemetrySnapshot: (data, requestStartedAt) => {
+    const { accountTelemetryByFramework } = get();
+    const requestTime = requestStartedAt ?? new Date().toISOString();
     if (!data) {
-      set({ accountTelemetry: null });
+      set({
+        accountTelemetryByFramework: mergeAccountTelemetryByFrameworkSnapshot(
+          accountTelemetryByFramework,
+          null,
+          requestTime
+        ),
+      });
       return;
     }
-    const { accountTelemetry } = get();
     set({
-      accountTelemetry: pickNewerAccountTelemetry(
-        accountTelemetry,
-        normalizeAccountTelemetry(data)
+      accountTelemetryByFramework: mergeAccountTelemetryByFrameworkSnapshot(
+        accountTelemetryByFramework,
+        data,
+        requestTime
       ),
     });
   },
@@ -292,15 +305,22 @@ export const useTelemetryStore = create<TelemetryState>()((set, get) => ({
 
   handleAccountTelemetryEvent: (data) => {
     if (!data || typeof data !== 'object') {
-      set({ accountTelemetry: null });
+      set({ accountTelemetryByFramework: {} });
       return;
     }
-    const { accountTelemetry } = get();
+    const normalized = normalizeAccountTelemetry(
+      data as Partial<AccountTelemetry>
+    );
+    const framework = normalized.framework;
+    const { accountTelemetryByFramework } = get();
+    const existing = accountTelemetryByFramework[framework] ?? null;
+    const merged = pickNewerAccountTelemetry(existing, normalized);
+    if (existing === merged) return;
     set({
-      accountTelemetry: pickNewerAccountTelemetry(
-        accountTelemetry,
-        normalizeAccountTelemetry(data as Partial<AccountTelemetry>)
-      ),
+      accountTelemetryByFramework: {
+        ...accountTelemetryByFramework,
+        [framework]: merged,
+      },
     });
   },
 
@@ -313,7 +333,7 @@ export const useTelemetryStore = create<TelemetryState>()((set, get) => ({
         api.fetchTelemetrySetupStatus(),
       ]);
 
-    const { sessionTelemetryById, accountTelemetry } = get();
+    const { sessionTelemetryById, accountTelemetryByFramework } = get();
 
     const updates: Partial<TelemetryState> = {};
     if (sessionResult.status === 'fulfilled') {
@@ -327,16 +347,29 @@ export const useTelemetryStore = create<TelemetryState>()((set, get) => ({
       );
     }
     if (accountResult.status === 'fulfilled') {
-      updates.accountTelemetry = mergeAccountTelemetrySnapshot(
-        accountTelemetry,
-        accountResult.value,
-        requestStartedAt
-      );
+      updates.accountTelemetryByFramework =
+        mergeAccountTelemetryByFrameworkSnapshot(
+          accountTelemetryByFramework,
+          accountResult.value ?? {},
+          requestStartedAt
+        );
     }
     if (setupResult.status === 'fulfilled') {
       updates.telemetrySetupInstalled = setupResult.value.installed;
     }
     if (Object.keys(updates).length > 0) set(updates);
+  },
+
+  getAccountTelemetry: (framework) => {
+    const { accountTelemetryByFramework } = get();
+    if (framework) {
+      return accountTelemetryByFramework[framework] ?? null;
+    }
+    return (
+      accountTelemetryByFramework['claude'] ??
+      Object.values(accountTelemetryByFramework)[0] ??
+      null
+    );
   },
 }));
 

--- a/frontend/src/lib/telemetry-sync.ts
+++ b/frontend/src/lib/telemetry-sync.ts
@@ -64,3 +64,48 @@ export function mergeAccountTelemetrySnapshot(
     ? current
     : null;
 }
+
+export function mergeAccountTelemetryByFrameworkSnapshot(
+  currentByFramework: Record<string, AccountTelemetry>,
+  incomingByFramework: Record<string, AccountTelemetry> | null,
+  requestStartedAt: string
+): Record<string, AccountTelemetry> {
+  if (!incomingByFramework) {
+    const requestStartedMs = parseUpdatedAt(requestStartedAt);
+    const result: Record<string, AccountTelemetry> = {};
+    for (const [framework, telemetry] of Object.entries(currentByFramework)) {
+      if (parseUpdatedAt(telemetry.updatedAt) > requestStartedMs) {
+        result[framework] = telemetry;
+      }
+    }
+    return result;
+  }
+
+  const result: Record<string, AccountTelemetry> = {};
+  const allFrameworks = new Set([
+    ...Object.keys(currentByFramework),
+    ...Object.keys(incomingByFramework),
+  ]);
+
+  for (const framework of allFrameworks) {
+    const current = currentByFramework[framework];
+    const incoming = incomingByFramework[framework];
+    const selected = pickNewerAccountTelemetryByFramework(current, incoming);
+    if (selected) result[framework] = selected;
+  }
+
+  return result;
+}
+
+export function pickNewerAccountTelemetryByFramework(
+  current: AccountTelemetry | undefined,
+  incoming: AccountTelemetry | undefined
+): AccountTelemetry | undefined {
+  if (!current) return incoming;
+  if (!incoming) return current;
+
+  const currentTimestamp = parseUpdatedAt(current.updatedAt);
+  const incomingTimestamp = parseUpdatedAt(incoming.updatedAt);
+
+  return incomingTimestamp >= currentTimestamp ? incoming : current;
+}

--- a/frontend/src/lib/telemetry-sync.ts
+++ b/frontend/src/lib/telemetry-sync.ts
@@ -81,17 +81,22 @@ export function mergeAccountTelemetryByFrameworkSnapshot(
     return result;
   }
 
+  const requestStartedMs = parseUpdatedAt(requestStartedAt);
   const result: Record<string, AccountTelemetry> = {};
-  const allFrameworks = new Set([
-    ...Object.keys(currentByFramework),
-    ...Object.keys(incomingByFramework),
-  ]);
+  const incomingKeys = new Set(Object.keys(incomingByFramework));
 
-  for (const framework of allFrameworks) {
+  for (const framework of incomingKeys) {
     const current = currentByFramework[framework];
     const incoming = incomingByFramework[framework];
     const selected = pickNewerAccountTelemetryByFramework(current, incoming);
     if (selected) result[framework] = selected;
+  }
+
+  for (const [framework, telemetry] of Object.entries(currentByFramework)) {
+    if (incomingKeys.has(framework)) continue;
+    if (parseUpdatedAt(telemetry.updatedAt) > requestStartedMs) {
+      result[framework] = telemetry;
+    }
   }
 
   return result;

--- a/server/index.ts
+++ b/server/index.ts
@@ -960,10 +960,19 @@ async function main(): Promise<void> {
   setInterval(() => {
     const now = Date.now();
     if (now - lastRateLimitSnapshot < RATE_LIMIT_SNAPSHOT_INTERVAL) return;
-    const account = getAccountTelemetry();
-    if (!account || !account.rateLimits.length) return;
-    const fiveHour = account.rateLimits.find((rl) => rl.name === 'five_hour' || rl.windowMinutes === 300);
-    const sevenDay = account.rateLimits.find((rl) => rl.name === 'seven_day' || rl.windowMinutes === 10080);
+    const account = Object.values(getAccountTelemetry())
+      .filter((entry) => entry.rateLimits.length > 0)
+      .sort(
+        (a, b) =>
+          new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+      )[0];
+    if (!account) return;
+    const fiveHour = account.rateLimits.find(
+      (rl) => rl.name === 'five_hour' || rl.windowMinutes === 300
+    );
+    const sevenDay = account.rateLimits.find(
+      (rl) => rl.name === 'seven_day' || rl.windowMinutes === 10080
+    );
     if (!fiveHour || fiveHour.usedPercent < 0) return;
     lastRateLimitSnapshot = now;
     recordRateLimitSnapshot({

--- a/server/telemetry.ts
+++ b/server/telemetry.ts
@@ -295,13 +295,8 @@ export function getTelemetryForSession(
   return sessionTelemetry.get(sessionId);
 }
 
-export function getAccountTelemetry(): AccountTelemetry | null {
-  // Prefer 'claude' framework; fall back to first available
-  return (
-    accountTelemetryMap.get('claude') ??
-    accountTelemetryMap.values().next().value ??
-    null
-  );
+export function getAccountTelemetry(): Record<string, AccountTelemetry> {
+  return Object.fromEntries(accountTelemetryMap.entries());
 }
 
 export function createTelemetryRouter(): Router {

--- a/test/e2e/components/SessionStatusBar.spec.tsx
+++ b/test/e2e/components/SessionStatusBar.spec.tsx
@@ -12,13 +12,14 @@ test.describe('SessionStatusBar React component', () => {
   }) => {
     const bar = page.locator('#active-root .session-status-bar').first();
     await expect(bar).toBeVisible();
+    await expect(bar.locator('.status-framework')).toContainText('claude');
     await expect(bar).toContainText('claude-4.5');
     await expect(bar).toContainText('███████░░░ 67%');
     await expect(bar).toContainText('↓12k ↑3.2k');
     await expect(bar).toContainText('~$12.34');
     await expect(bar).toContainText('[edit: frontend/src/App.svelte]');
     await expect(bar.locator('.status-rate-limits')).toHaveText(
-      '5h: 42% | 7d: 63%'
+      'five_hour: 42% | seven_day: 63%'
     );
   });
 
@@ -53,5 +54,24 @@ test.describe('SessionStatusBar React component', () => {
       maxDiffPixels: 100,
       threshold: 0.2,
     });
+  });
+
+  test('displays framework badge with correct styling', async ({ page }) => {
+    const bar = page.locator('#active-root .session-status-bar').first();
+    const frameworkBadge = bar.locator('.status-framework');
+
+    await expect(frameworkBadge).toBeVisible();
+    await expect(frameworkBadge).toContainText('claude');
+    await expect(frameworkBadge).toHaveClass(/status-framework--claude/);
+  });
+
+  test('renders different frameworks with different colors', async ({
+    page,
+  }) => {
+    const bar = page.locator('#codex-root .session-status-bar').first();
+    const frameworkBadge = bar.locator('.status-framework');
+
+    await expect(frameworkBadge).toContainText('codex');
+    await expect(frameworkBadge).toHaveClass(/status-framework--codex/);
   });
 });

--- a/test/telemetry-api.test.ts
+++ b/test/telemetry-api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, test, expect } from 'vitest';
 
 import {
   fetchSessionTelemetry,
+  fetchAccountTelemetry,
   fetchTelemetrySetupStatus,
 } from '../frontend/src/lib/api.js';
 
@@ -66,4 +67,101 @@ test('fetchTelemetrySetupStatus returns installed flag from the server response'
     })) as typeof globalThis.fetch;
 
   expect(await fetchTelemetrySetupStatus()).toEqual({ installed: true });
+});
+
+test('fetchAccountTelemetry handles map-based responses', async () => {
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        claude: {
+          framework: 'claude',
+          rateLimits: [
+            {
+              name: 'five_hour',
+              usedPercent: 42,
+              resetsAt: '2026-03-31T19:30:00Z',
+              windowMinutes: 300,
+            },
+            {
+              name: 'seven_day',
+              usedPercent: 63,
+              resetsAt: '2026-04-03T00:00:00Z',
+              windowMinutes: 10080,
+            },
+          ],
+          updatedAt: '2026-04-01T00:00:00Z',
+        },
+        codex: {
+          framework: 'codex',
+          rateLimits: [
+            {
+              name: 'five_hour',
+              usedPercent: 10,
+              resetsAt: '2026-03-31T19:30:00Z',
+              windowMinutes: 300,
+            },
+          ],
+          updatedAt: '2026-04-01T00:00:00Z',
+        },
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    )) as typeof globalThis.fetch;
+
+  const result = await fetchAccountTelemetry();
+
+  expect(result).toEqual({
+    claude: {
+      framework: 'claude',
+      rateLimits: [
+        {
+          name: 'five_hour',
+          usedPercent: 42,
+          resetsAt: '2026-03-31T19:30:00Z',
+          windowMinutes: 300,
+        },
+        {
+          name: 'seven_day',
+          usedPercent: 63,
+          resetsAt: '2026-04-03T00:00:00Z',
+          windowMinutes: 10080,
+        },
+      ],
+      updatedAt: '2026-04-01T00:00:00Z',
+    },
+    codex: {
+      framework: 'codex',
+      rateLimits: [
+        {
+          name: 'five_hour',
+          usedPercent: 10,
+          resetsAt: '2026-03-31T19:30:00Z',
+          windowMinutes: 300,
+        },
+      ],
+      updatedAt: '2026-04-01T00:00:00Z',
+    },
+  });
+});
+
+test('fetchAccountTelemetry returns null for empty maps', async () => {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as typeof globalThis.fetch;
+
+  expect(await fetchAccountTelemetry()).toBeNull();
+});
+
+test('fetchAccountTelemetry returns null for invalid responses', async () => {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(null), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })) as typeof globalThis.fetch;
+
+  expect(await fetchAccountTelemetry()).toBeNull();
 });

--- a/test/telemetry-sync.test.ts
+++ b/test/telemetry-sync.test.ts
@@ -6,6 +6,7 @@ import type {
 } from '../frontend/src/lib/types.js';
 import {
   mergeAccountTelemetrySnapshot,
+  mergeAccountTelemetryByFrameworkSnapshot,
   mergeSessionTelemetrySnapshot,
 } from '../frontend/src/lib/telemetry-sync.js';
 
@@ -36,8 +37,18 @@ function makeAccountTelemetry(
   return {
     framework: 'claude',
     rateLimits: [
-      { name: 'five_hour', usedPercent: 10, resetsAt: '2026-04-01T05:00:00.000Z', windowMinutes: 300 },
-      { name: 'seven_day', usedPercent: 20, resetsAt: '2026-04-07T00:00:00.000Z', windowMinutes: 10080 },
+      {
+        name: 'five_hour',
+        usedPercent: 10,
+        resetsAt: '2026-04-01T05:00:00.000Z',
+        windowMinutes: 300,
+      },
+      {
+        name: 'seven_day',
+        usedPercent: 20,
+        resetsAt: '2026-04-07T00:00:00.000Z',
+        windowMinutes: 10080,
+      },
     ],
     updatedAt: '2026-04-01T00:00:00.000Z',
     ...overrides,
@@ -52,8 +63,18 @@ describe('mergeSessionTelemetrySnapshot', () => {
     });
     const currentAccount = makeAccountTelemetry({
       rateLimits: [
-        { name: 'five_hour', usedPercent: 55, resetsAt: '2026-04-01T05:00:00.000Z', windowMinutes: 300 },
-        { name: 'seven_day', usedPercent: 20, resetsAt: '2026-04-07T00:00:00.000Z', windowMinutes: 10080 },
+        {
+          name: 'five_hour',
+          usedPercent: 55,
+          resetsAt: '2026-04-01T05:00:00.000Z',
+          windowMinutes: 300,
+        },
+        {
+          name: 'seven_day',
+          usedPercent: 20,
+          resetsAt: '2026-04-07T00:00:00.000Z',
+          windowMinutes: 10080,
+        },
       ],
       updatedAt: '2026-04-01T00:00:10.000Z',
     });
@@ -75,8 +96,18 @@ describe('mergeSessionTelemetrySnapshot', () => {
       currentAccount,
       makeAccountTelemetry({
         rateLimits: [
-          { name: 'five_hour', usedPercent: 20, resetsAt: '2026-04-01T05:00:00.000Z', windowMinutes: 300 },
-          { name: 'seven_day', usedPercent: 20, resetsAt: '2026-04-07T00:00:00.000Z', windowMinutes: 10080 },
+          {
+            name: 'five_hour',
+            usedPercent: 20,
+            resetsAt: '2026-04-01T05:00:00.000Z',
+            windowMinutes: 300,
+          },
+          {
+            name: 'seven_day',
+            usedPercent: 20,
+            resetsAt: '2026-04-07T00:00:00.000Z',
+            windowMinutes: 10080,
+          },
         ],
         updatedAt: '2026-04-01T00:00:05.000Z',
       }),
@@ -102,5 +133,104 @@ describe('mergeSessionTelemetrySnapshot', () => {
 
     expect(Object.keys(mergedSessions)).toEqual(['session-2']);
     expect(mergedSessions['session-2']).toEqual(currentSession);
+  });
+});
+
+describe('mergeAccountTelemetryByFrameworkSnapshot', () => {
+  it('merges per-framework telemetry correctly', () => {
+    const current = {
+      claude: makeAccountTelemetry({
+        framework: 'claude',
+        rateLimits: [
+          {
+            name: 'five_hour',
+            usedPercent: 60,
+            resetsAt: '2026-04-01T05:00:00.000Z',
+            windowMinutes: 300,
+          },
+        ],
+        updatedAt: '2026-04-01T00:00:10.000Z',
+      }),
+    };
+    const incoming = {
+      codex: makeAccountTelemetry({
+        framework: 'codex',
+        rateLimits: [
+          {
+            name: 'five_hour',
+            usedPercent: 30,
+            resetsAt: '2026-04-01T05:00:00.000Z',
+            windowMinutes: 300,
+          },
+        ],
+        updatedAt: '2026-04-01T00:00:15.000Z',
+      }),
+    };
+
+    const merged = mergeAccountTelemetryByFrameworkSnapshot(
+      current,
+      incoming,
+      '2026-04-01T00:00:08.000Z'
+    );
+
+    expect(Object.keys(merged).sort()).toEqual(['claude', 'codex']);
+    expect(merged.claude).toEqual(current.claude);
+    expect(merged.codex).toEqual(incoming.codex);
+  });
+
+  it('prefers newer telemetry per framework', () => {
+    const current = {
+      claude: makeAccountTelemetry({
+        framework: 'claude',
+        rateLimits: [
+          {
+            name: 'five_hour',
+            usedPercent: 60,
+            resetsAt: '2026-04-01T05:00:00.000Z',
+            windowMinutes: 300,
+          },
+        ],
+        updatedAt: '2026-04-01T00:00:10.000Z',
+      }),
+    };
+    const incoming = {
+      claude: makeAccountTelemetry({
+        framework: 'claude',
+        rateLimits: [
+          {
+            name: 'five_hour',
+            usedPercent: 70,
+            resetsAt: '2026-04-01T05:00:00.000Z',
+            windowMinutes: 300,
+          },
+        ],
+        updatedAt: '2026-04-01T00:00:12.000Z',
+      }),
+    };
+
+    const merged = mergeAccountTelemetryByFrameworkSnapshot(
+      current,
+      incoming,
+      '2026-04-01T00:00:08.000Z'
+    );
+
+    expect(merged.claude).toEqual(incoming.claude);
+  });
+
+  it('handles empty maps', () => {
+    expect(
+      mergeAccountTelemetryByFrameworkSnapshot(
+        {},
+        null,
+        '2026-04-01T00:00:00.000Z'
+      )
+    ).toEqual({});
+    expect(
+      mergeAccountTelemetryByFrameworkSnapshot(
+        {},
+        {},
+        '2026-04-01T00:00:00.000Z'
+      )
+    ).toEqual({});
   });
 });

--- a/test/telemetry.test.ts
+++ b/test/telemetry.test.ts
@@ -127,12 +127,24 @@ test('parses session telemetry from the statusLine file', () => {
   });
 
   expect(account).toEqual({
-    framework: 'claude',
-    rateLimits: [
-      { name: 'five_hour', usedPercent: 22, resetsAt: '2026-03-31T19:30:00Z', windowMinutes: 300 },
-      { name: 'seven_day', usedPercent: 8, resetsAt: '2026-04-03T00:00:00Z', windowMinutes: 10080 },
-    ],
-    updatedAt: account?.updatedAt,
+    claude: {
+      framework: 'claude',
+      rateLimits: [
+        {
+          name: 'five_hour',
+          usedPercent: 22,
+          resetsAt: '2026-03-31T19:30:00Z',
+          windowMinutes: 300,
+        },
+        {
+          name: 'seven_day',
+          usedPercent: 8,
+          resetsAt: '2026-04-03T00:00:00Z',
+          windowMinutes: 10080,
+        },
+      ],
+      updatedAt: account?.claude?.updatedAt,
+    },
   });
 
   expect(
@@ -149,7 +161,7 @@ test('missing statusLine file leaves telemetry undefined', () => {
   startTelemetry(makeDeps(['missing-session'], events));
 
   expect(getTelemetryForSession('missing-session')).toBe(undefined);
-  expect(getAccountTelemetry()).toBe(null);
+  expect(getAccountTelemetry()).toEqual({});
   expect(events.length).toBe(0);
 });
 
@@ -194,7 +206,7 @@ test('malformed statusLine JSON is ignored without crashing', () => {
   }).not.toThrow();
 
   expect(getTelemetryForSession('bad-session')).toBe(undefined);
-  expect(getAccountTelemetry()).toBe(null);
+  expect(getAccountTelemetry()).toEqual({});
   expect(events.length).toBe(0);
 });
 
@@ -202,8 +214,18 @@ test('restores pending telemetry from disk on startup', () => {
   const restoredAccount = {
     framework: 'claude',
     rateLimits: [
-      { name: 'five_hour', usedPercent: 44, resetsAt: '2026-03-31T19:30:00Z', windowMinutes: 300 },
-      { name: 'seven_day', usedPercent: 55, resetsAt: '2026-04-03T00:00:00Z', windowMinutes: 10080 },
+      {
+        name: 'five_hour',
+        usedPercent: 44,
+        resetsAt: '2026-03-31T19:30:00Z',
+        windowMinutes: 300,
+      },
+      {
+        name: 'seven_day',
+        usedPercent: 55,
+        resetsAt: '2026-04-03T00:00:00Z',
+        windowMinutes: 10080,
+      },
     ],
     updatedAt: '2026-03-31T18:00:00Z',
   };
@@ -247,7 +269,7 @@ test('restores pending telemetry from disk on startup', () => {
     source: 'statusLine',
     updatedAt: '2026-03-31T18:00:00Z',
   });
-  expect(getAccountTelemetry()).toEqual(restoredAccount);
+  expect(getAccountTelemetry()).toEqual({ claude: restoredAccount });
   expect(fs.existsSync(pendingPath)).toBe(false);
   expect(events.length).toBe(0);
 });
@@ -256,8 +278,18 @@ test('GET /telemetry endpoints return session and account telemetry', async () =
   const restoredAccount = {
     framework: 'claude',
     rateLimits: [
-      { name: 'five_hour', usedPercent: 9, resetsAt: '2026-03-31T19:30:00Z', windowMinutes: 300 },
-      { name: 'seven_day', usedPercent: 18, resetsAt: '2026-04-03T00:00:00Z', windowMinutes: 10080 },
+      {
+        name: 'five_hour',
+        usedPercent: 9,
+        resetsAt: '2026-03-31T19:30:00Z',
+        windowMinutes: 300,
+      },
+      {
+        name: 'seven_day',
+        usedPercent: 18,
+        resetsAt: '2026-04-03T00:00:00Z',
+        windowMinutes: 10080,
+      },
     ],
     updatedAt: '2026-03-31T18:00:00Z',
   };
@@ -320,7 +352,7 @@ test('GET /telemetry endpoints return session and account telemetry', async () =
 
     const accountRes = await fetch(`${baseUrl}/telemetry/account`);
     expect(accountRes.status).toBe(200);
-    expect(await accountRes.json()).toEqual(restoredAccount);
+    expect(await accountRes.json()).toEqual({ claude: restoredAccount });
 
     const setupStatusRes = await fetch(`${baseUrl}/telemetry/setup-status`);
     expect(setupStatusRes.status).toBe(200);


### PR DESCRIPTION
## Summary

- Change account telemetry from single-value to per-framework `Record<string, AccountTelemetry>` map across server, API client, and Zustand store
- Add framework indicator badge to `SessionStatusBar` with per-agent color coding (claude/codex/opencode)
- Handle `null costUsd` gracefully (Codex/OpenCode don't report cost)
- Derive rate limit labels from `rl.name` instead of hardcoded window-minute values

Closes #172

## Test plan

- [ ] Verify status bar shows "claude" badge for Claude sessions
- [ ] Verify rate limit labels show `five_hour` / `seven_day` names instead of `5h` / `7d`
- [ ] Verify cost displays `~$—` when `costUsd` is null
- [ ] Run `npm test` — unit tests for telemetry store, API client, sync logic, and server endpoint updated
- [ ] E2E tests cover framework badge rendering and multi-framework color classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)