### PR TITLE
feat: sidenav status indicator redesign with shape language

### DIFF
--- a/frontend/src/components/RepoItem.css
+++ b/frontend/src/components/RepoItem.css
@@ -56,6 +56,16 @@
   flex-shrink: 0;
 }
 
+.repo-attention-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
 .initial-block {
   display: inline-flex;
   align-items: center;
@@ -243,34 +253,6 @@
   flex-shrink: 0;
 }
 
-.status-dot--running {
-  background: var(--status-success);
-}
-.status-dot--initializing {
-  background: #6b7280;
-}
-.status-dot--unseen-idle {
-  background: var(--status-warning);
-  box-shadow: 0 0 5px 1px rgba(251, 191, 36, 0.45);
-  animation: attention-glow 2s ease-in-out infinite;
-}
-.status-dot--seen-idle {
-  background: var(--status-info);
-}
-.status-dot--permission,
-.status-dot--needs-answer {
-  background: #eab308;
-  box-shadow: 0 0 5px 1px rgba(234, 179, 8, 0.45);
-  animation: attention-glow 1.5s ease-in-out infinite;
-}
-.status-dot--inactive {
-  background: transparent;
-  border: 1.5px solid var(--border);
-}
-.status-dot--error {
-  background: var(--status-error);
-}
-
 .session-row.inactive .session-name {
   color: var(--text-muted);
 }
@@ -283,16 +265,6 @@
 }
 .session-row.loading .session-name {
   color: var(--accent);
-}
-
-@keyframes attention-glow {
-  0%,
-  100% {
-    box-shadow: 0 0 3px 1px rgba(251, 191, 36, 0.3);
-  }
-  50% {
-    box-shadow: 0 0 7px 2px rgba(251, 191, 36, 0.6);
-  }
 }
 
 .session-name {

--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -11,8 +11,10 @@ import { deriveColor } from '../lib/colors.js';
 import { derivePrDotStatus } from '../lib/pr-status.js';
 import { formatRelativeTimeCompact, isMobileDevice } from '../lib/utils.js';
 import StatusDot from './StatusDot.js';
+import { SessionIndicator } from './SessionIndicator.js';
 import { MarqueeText } from './MarqueeText.js';
 import ContextMenu from './ContextMenu.js';
+import { useRepoAggregation } from '../hooks/useRepoAggregation.js';
 import './RepoItem.css';
 
 const DOUBLE_CLICK_DELAY_MS = 200;
@@ -178,7 +180,11 @@ function SessionGroupRow({
       onTouchMove={cancelLongPress}
     >
       <div className="session-row-primary">
-        <span className={`status-dot status-dot--${dotState}`} />
+        <SessionIndicator
+          state={
+            dotState as import('../lib/state/display-state.js').DisplayState
+          }
+        />
         <span
           className={['session-name', attention && 'bold']
             .filter(Boolean)
@@ -282,7 +288,7 @@ function InactiveRepoRow({
       }}
     >
       <div className="session-row-primary">
-        <span className="status-dot status-dot--inactive" />
+        <SessionIndicator state="inactive" />
         <span className="session-name">
           <MarqueeText>{isLoading ? 'starting...' : 'default'}</MarqueeText>
         </span>
@@ -344,6 +350,11 @@ export function RepoItem({
     [sidebarItems, repo.path]
   );
   const creatingWorktree = loadingItems.has(`new-worktree:${repo.path}`);
+  const { highestState, attentionCount } = useRepoAggregation(
+    repo.path,
+    sidebarItems,
+    loadingItems
+  );
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -416,6 +427,12 @@ export function RepoItem({
           <span className="repo-name">
             <MarqueeText>{repo.name}</MarqueeText>
           </span>
+          {highestState && attentionCount > 0 ? (
+            <span className="repo-attention-badge">
+              <SessionIndicator state={highestState} />
+              {attentionCount}
+            </span>
+          ) : null}
           {collapsed && totalItems > 0 ? (
             <span className="collapse-count">{totalItems}</span>
           ) : null}
@@ -501,7 +518,7 @@ export function RepoItem({
                 onTouchMove={cancelLongPress}
               >
                 <div className="session-row-primary">
-                  <span className="status-dot status-dot--inactive" />
+                  <SessionIndicator state="inactive" />
                   <span className="session-name">
                     <MarqueeText>
                       {isLoading

--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -6,7 +6,10 @@ import type {
   PullRequest,
   SidebarItem,
 } from '../lib/types.js';
-import { isAttentionState } from '../lib/state/display-state.js';
+import {
+  isAttentionState,
+  type DisplayState,
+} from '../lib/state/display-state.js';
 import { deriveColor } from '../lib/colors.js';
 import { derivePrDotStatus } from '../lib/pr-status.js';
 import { formatRelativeTimeCompact, isMobileDevice } from '../lib/utils.js';
@@ -142,7 +145,7 @@ interface SessionGroupRowProps {
   rep: SessionSummary;
   isSelected: boolean;
   attention: boolean;
-  dotState: string;
+  dotState: DisplayState;
   matchedPr: PullRequest | undefined;
   cancelLongPress: () => void;
   onSelectSession: (id: string) => void;
@@ -180,11 +183,7 @@ function SessionGroupRow({
       onTouchMove={cancelLongPress}
     >
       <div className="session-row-primary">
-        <SessionIndicator
-          state={
-            dotState as import('../lib/state/display-state.js').DisplayState
-          }
-        />
+        <SessionIndicator state={dotState} />
         <span
           className={['session-name', attention && 'bold']
             .filter(Boolean)

--- a/frontend/src/components/SessionIndicator.tsx
+++ b/frontend/src/components/SessionIndicator.tsx
@@ -1,17 +1,21 @@
 import type { DisplayState } from '../lib/state/display-state.js';
+import './SessionIndicator.css';
 
 interface SessionIndicatorProps {
   state: DisplayState;
 }
 
-const config: Record<DisplayState, { char: string; colorClass: string; bold: boolean }> = {
+const config: Record<
+  DisplayState,
+  { char: string; colorClass: string; bold: boolean }
+> = {
   initializing: { char: '●', colorClass: 'ind-green-dim', bold: false },
   running: { char: '●', colorClass: 'ind-green', bold: false },
-  'unseen-idle': { char: '▶', colorClass: 'ind-yellow', bold: false },
+  'unseen-idle': { char: '▶', colorClass: 'ind-yellow', bold: true },
   'seen-idle': { char: '▶', colorClass: 'ind-yellow-muted', bold: false },
   permission: { char: '◆', colorClass: 'ind-red', bold: true },
   'needs-answer': { char: '◇', colorClass: 'ind-red', bold: true },
-  error: { char: '■', colorClass: 'ind-red', bold: false },
+  error: { char: '■', colorClass: 'ind-red', bold: true },
   inactive: { char: '─', colorClass: 'ind-gray', bold: false },
 };
 

--- a/frontend/src/components/SessionIndicator.tsx
+++ b/frontend/src/components/SessionIndicator.tsx
@@ -5,7 +5,7 @@ interface SessionIndicatorProps {
   state: DisplayState;
 }
 
-const config: Record<
+export const config: Record<
   DisplayState,
   { char: string; colorClass: string; bold: boolean }
 > = {

--- a/frontend/src/hooks/useRepoAggregation.ts
+++ b/frontend/src/hooks/useRepoAggregation.ts
@@ -4,10 +4,47 @@ import type { DisplayState } from '../lib/state/display-state.js';
 import { isAttentionState } from '../lib/state/display-state.js';
 import { highestPriorityState } from '../lib/state/attention.js';
 
-interface RepoAggregation {
+export interface RepoAggregation {
   highestState: DisplayState | null;
   attentionCount: number;
   isLoading: boolean;
+}
+
+/** Pure function — testable without React. */
+export function aggregateRepo(
+  repoPath: string,
+  sidebarItems: SidebarItem[],
+  loadingItems?: Set<string>
+): RepoAggregation {
+  const repoItems = sidebarItems.filter((item) => item.repoPath === repoPath);
+
+  const hasRepoItemLoading = repoItems.some((item) =>
+    loadingItems?.has(item.path)
+  );
+  const hasRepoScopedLoading =
+    loadingItems?.has(`repo-session:${repoPath}`) ||
+    loadingItems?.has(`new-worktree:${repoPath}`);
+  const isLoading = hasRepoItemLoading || !!hasRepoScopedLoading;
+
+  if (isLoading) {
+    return {
+      highestState: 'initializing',
+      attentionCount: 0,
+      isLoading: true,
+    };
+  }
+
+  const states = repoItems.map((item) => item.displayState);
+  const highestState = highestPriorityState(states);
+  const attentionCount = repoItems.filter((item) =>
+    isAttentionState(item.displayState)
+  ).length;
+
+  return {
+    highestState,
+    attentionCount,
+    isLoading: false,
+  };
 }
 
 export function useRepoAggregation(
@@ -15,29 +52,8 @@ export function useRepoAggregation(
   sidebarItems: SidebarItem[],
   loadingItems?: Set<string>
 ): RepoAggregation {
-  return useMemo(() => {
-    const repoItems = sidebarItems.filter((item) => item.repoPath === repoPath);
-
-    const isLoading = repoItems.some((item) => loadingItems?.has(item.path));
-
-    if (isLoading) {
-      return {
-        highestState: 'initializing',
-        attentionCount: 0,
-        isLoading: true,
-      };
-    }
-
-    const states = repoItems.map((item) => item.displayState);
-    const highestState = highestPriorityState(states);
-    const attentionCount = repoItems.filter((item) =>
-      isAttentionState(item.displayState)
-    ).length;
-
-    return {
-      highestState,
-      attentionCount,
-      isLoading: false,
-    };
-  }, [repoPath, sidebarItems, loadingItems]);
+  return useMemo(
+    () => aggregateRepo(repoPath, sidebarItems, loadingItems),
+    [repoPath, sidebarItems, loadingItems]
+  );
 }

--- a/frontend/src/hooks/useRepoAggregation.ts
+++ b/frontend/src/hooks/useRepoAggregation.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+import type { SidebarItem } from '../lib/types.js';
+import type { DisplayState } from '../lib/state/display-state.js';
+import { isAttentionState } from '../lib/state/display-state.js';
+import { highestPriorityState } from '../lib/state/attention.js';
+
+interface RepoAggregation {
+  highestState: DisplayState | null;
+  attentionCount: number;
+  isLoading: boolean;
+}
+
+export function useRepoAggregation(
+  repoPath: string,
+  sidebarItems: SidebarItem[],
+  loadingItems?: Set<string>
+): RepoAggregation {
+  return useMemo(() => {
+    const repoItems = sidebarItems.filter((item) => item.repoPath === repoPath);
+
+    const isLoading = repoItems.some((item) => loadingItems?.has(item.path));
+
+    if (isLoading) {
+      return {
+        highestState: 'initializing',
+        attentionCount: 0,
+        isLoading: true,
+      };
+    }
+
+    const states = repoItems.map((item) => item.displayState);
+    const highestState = highestPriorityState(states);
+    const attentionCount = repoItems.filter((item) =>
+      isAttentionState(item.displayState)
+    ).length;
+
+    return {
+      highestState,
+      attentionCount,
+      isLoading: false,
+    };
+  }, [repoPath, sidebarItems, loadingItems]);
+}

--- a/frontend/src/lib/state/attention.ts
+++ b/frontend/src/lib/state/attention.ts
@@ -12,6 +12,20 @@ const STATE_SCORES: Record<DisplayState, number> = {
   inactive: 1,
 };
 
+/**
+ * Compute the highest priority state from an array of display states.
+ * Priority order (highest first): permission > needs-answer > error > unseen-idle > running > initializing > seen-idle > inactive
+ * Returns null if the array is empty.
+ */
+export function highestPriorityState(
+  states: DisplayState[]
+): DisplayState | null {
+  if (states.length === 0) return null;
+  return states.reduce((highest, state) =>
+    STATE_SCORES[state] > STATE_SCORES[highest] ? state : highest
+  );
+}
+
 function minutesSinceLastActivity(item: SidebarItem): number {
   if (!item.lastActivity) return Infinity;
   const ms = new Date(item.lastActivity).getTime();

--- a/frontend/src/lib/state/sidebar-items.ts
+++ b/frontend/src/lib/state/sidebar-items.ts
@@ -60,8 +60,10 @@ export function deriveBackendState(
 function initialDisplayState(sessions: SessionSummary[]): DisplayState {
   if (sessions.length === 0) return 'inactive';
   switch (deriveBackendState(sessions)) {
-    case 'permission':
-      return 'permission';
+    case 'permission': {
+      const hasQuestion = sessions.some((s) => s.permissionType === 'question');
+      return hasQuestion ? 'needs-answer' : 'permission';
+    }
     case 'error':
       return 'error';
     case 'running':

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -102,6 +102,8 @@ export interface SessionSummary {
   additionalDirs?: string[] | undefined;
   currentActivity?: CurrentActivity | undefined;
   dataQuality?: EventSourceType | undefined;
+  /** Tracks whether permission-prompt is for approval or question — preserves needs-answer state across refresh */
+  permissionType?: 'approval' | 'question';
 }
 
 export interface WorktreeInfo {

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -366,6 +366,9 @@ function list(): SessionSummary[] {
           ? { additionalDirs: s.additionalDirs }
           : {}),
         ...(s.dataQuality !== undefined ? { dataQuality: s.dataQuality } : {}),
+        ...(s._lastEmittedPermissionType !== undefined
+          ? { permissionType: s._lastEmittedPermissionType }
+          : {}),
       })
     )
     .sort((a, b) => b.lastActivity.localeCompare(a.lastActivity));

--- a/server/types.ts
+++ b/server/types.ts
@@ -264,6 +264,8 @@ export interface SessionSummary {
   workspaceId?: string;
   additionalDirs?: string[];
   dataQuality?: EventSourceType;
+  /** Tracks whether permission-prompt is for approval or question — preserves needs-answer state across refresh */
+  permissionType?: 'approval' | 'question';
 }
 
 export interface TelemetryData {

--- a/test/SessionIndicator.test.ts
+++ b/test/SessionIndicator.test.ts
@@ -1,18 +1,5 @@
 import { describe, it, expect } from 'vitest';
-
-const config: Record<
-  string,
-  { char: string; colorClass: string; bold: boolean }
-> = {
-  initializing: { char: '●', colorClass: 'ind-green-dim', bold: false },
-  running: { char: '●', colorClass: 'ind-green', bold: false },
-  'unseen-idle': { char: '▶', colorClass: 'ind-yellow', bold: true },
-  'seen-idle': { char: '▶', colorClass: 'ind-yellow-muted', bold: false },
-  permission: { char: '◆', colorClass: 'ind-red', bold: true },
-  'needs-answer': { char: '◇', colorClass: 'ind-red', bold: true },
-  error: { char: '■', colorClass: 'ind-red', bold: true },
-  inactive: { char: '─', colorClass: 'ind-gray', bold: false },
-};
+import { config } from '../frontend/src/components/SessionIndicator.js';
 
 describe('SessionIndicator shape language', () => {
   it('running uses filled circle (●) with green', () => {

--- a/test/SessionIndicator.test.ts
+++ b/test/SessionIndicator.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+
+const config: Record<
+  string,
+  { char: string; colorClass: string; bold: boolean }
+> = {
+  initializing: { char: '●', colorClass: 'ind-green-dim', bold: false },
+  running: { char: '●', colorClass: 'ind-green', bold: false },
+  'unseen-idle': { char: '▶', colorClass: 'ind-yellow', bold: true },
+  'seen-idle': { char: '▶', colorClass: 'ind-yellow-muted', bold: false },
+  permission: { char: '◆', colorClass: 'ind-red', bold: true },
+  'needs-answer': { char: '◇', colorClass: 'ind-red', bold: true },
+  error: { char: '■', colorClass: 'ind-red', bold: true },
+  inactive: { char: '─', colorClass: 'ind-gray', bold: false },
+};
+
+describe('SessionIndicator shape language', () => {
+  it('running uses filled circle (●) with green', () => {
+    expect(config.running).toEqual({
+      char: '●',
+      colorClass: 'ind-green',
+      bold: false,
+    });
+  });
+
+  it('initializing uses dimmed filled circle (●) with dim green', () => {
+    expect(config.initializing).toEqual({
+      char: '●',
+      colorClass: 'ind-green-dim',
+      bold: false,
+    });
+  });
+
+  it('unseen-idle uses triangle (▶) with yellow and bold', () => {
+    expect(config['unseen-idle']).toEqual({
+      char: '▶',
+      colorClass: 'ind-yellow',
+      bold: true,
+    });
+  });
+
+  it('seen-idle uses muted triangle (▶) with muted yellow', () => {
+    expect(config['seen-idle']).toEqual({
+      char: '▶',
+      colorClass: 'ind-yellow-muted',
+      bold: false,
+    });
+  });
+
+  it('permission uses filled diamond (◆) with red and bold', () => {
+    expect(config.permission).toEqual({
+      char: '◆',
+      colorClass: 'ind-red',
+      bold: true,
+    });
+  });
+
+  it('needs-answer uses hollow diamond (◇) with red and bold', () => {
+    expect(config['needs-answer']).toEqual({
+      char: '◇',
+      colorClass: 'ind-red',
+      bold: true,
+    });
+  });
+
+  it('error uses square (■) with red and bold', () => {
+    expect(config.error).toEqual({
+      char: '■',
+      colorClass: 'ind-red',
+      bold: true,
+    });
+  });
+
+  it('inactive uses dash (─) with gray', () => {
+    expect(config.inactive).toEqual({
+      char: '─',
+      colorClass: 'ind-gray',
+      bold: false,
+    });
+  });
+});
+
+describe('SessionIndicator pulse configuration', () => {
+  function getPulseClass(state: string): string {
+    if (state === 'permission' || state === 'needs-answer') return 'pulse-fast';
+    if (state === 'unseen-idle') return 'pulse-slow';
+    return '';
+  }
+
+  it('permission and needs-answer have fast pulse (1.4s)', () => {
+    expect(getPulseClass('permission')).toBe('pulse-fast');
+    expect(getPulseClass('needs-answer')).toBe('pulse-fast');
+  });
+
+  it('unseen-idle has slow pulse (2.5s)', () => {
+    expect(getPulseClass('unseen-idle')).toBe('pulse-slow');
+  });
+
+  it('error has no pulse', () => {
+    expect(getPulseClass('error')).toBe('');
+  });
+
+  it('running has no pulse', () => {
+    expect(getPulseClass('running')).toBe('');
+  });
+
+  it('inactive has no pulse', () => {
+    expect(getPulseClass('inactive')).toBe('');
+  });
+});

--- a/test/attention.test.ts
+++ b/test/attention.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   computeAttentionScore,
   sortByAttention,
+  highestPriorityState,
 } from '../frontend/src/lib/state/attention.js';
 import type { SidebarItem } from '../frontend/src/lib/types.js';
+import type { DisplayState } from '../frontend/src/lib/state/display-state.js';
 
 function makeScoreItem(
   overrides: Partial<SidebarItem> & {
@@ -141,5 +143,37 @@ describe('sortByAttention', () => {
     ];
     const sorted = sortByAttention(items);
     expect(sorted[0]!.id).toBe('b');
+  });
+});
+
+describe('highestPriorityState', () => {
+  it('returns null for empty array', () => {
+    expect(highestPriorityState([])).toBeNull();
+  });
+
+  it('returns the only state in a single-item array', () => {
+    expect(highestPriorityState(['running'])).toBe('running');
+  });
+
+  it('prioritizes permission > needs-answer > error > unseen-idle', () => {
+    const states: DisplayState[] = [
+      'unseen-idle',
+      'error',
+      'needs-answer',
+      'permission',
+      'running',
+    ];
+    expect(highestPriorityState(states)).toBe('permission');
+  });
+
+  it('prioritizes unseen-idle > running > initializing > seen-idle > inactive', () => {
+    const states: DisplayState[] = [
+      'inactive',
+      'seen-idle',
+      'initializing',
+      'running',
+      'unseen-idle',
+    ];
+    expect(highestPriorityState(states)).toBe('unseen-idle');
   });
 });

--- a/test/repo-aggregation.test.ts
+++ b/test/repo-aggregation.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { highestPriorityState } from '../frontend/src/lib/state/attention.js';
+import { isAttentionState } from '../frontend/src/lib/state/display-state.js';
+import type { DisplayState } from '../frontend/src/lib/state/display-state.js';
+import type { SidebarItem } from '../frontend/src/lib/types.js';
+
+function makeItem(
+  overrides: Partial<SidebarItem> & { displayState: DisplayState }
+): SidebarItem {
+  return {
+    id: 'test',
+    kind: 'worktree',
+    path: '/repo/wt',
+    repoPath: '/repo',
+    displayName: 'test',
+    branchName: 'main',
+    lastActivity: new Date().toISOString(),
+    lastKnownBackendState: null,
+    sessions: [],
+    ...overrides,
+  };
+}
+
+describe('highestPriorityState', () => {
+  it('returns null for empty array', () => {
+    expect(highestPriorityState([])).toBeNull();
+  });
+
+  it('returns the only state in a single-item array', () => {
+    expect(highestPriorityState(['running'])).toBe('running');
+  });
+
+  it('prioritizes permission > needs-answer > error > unseen-idle', () => {
+    const states: DisplayState[] = [
+      'unseen-idle',
+      'error',
+      'needs-answer',
+      'permission',
+      'running',
+    ];
+    expect(highestPriorityState(states)).toBe('permission');
+  });
+
+  it('prioritizes unseen-idle > running > initializing > seen-idle > inactive', () => {
+    const states: DisplayState[] = [
+      'inactive',
+      'seen-idle',
+      'initializing',
+      'running',
+      'unseen-idle',
+    ];
+    expect(highestPriorityState(states)).toBe('unseen-idle');
+  });
+});
+
+describe('repo aggregation logic', () => {
+  function aggregateRepo(
+    repoPath: string,
+    items: SidebarItem[],
+    loadingItems?: Set<string>
+  ) {
+    const repoItems = items.filter((item) => item.repoPath === repoPath);
+
+    const isLoading = repoItems.some((item) => loadingItems?.has(item.path));
+
+    if (isLoading) {
+      return {
+        highestState: 'initializing' as const,
+        attentionCount: 0,
+        isLoading: true,
+      };
+    }
+
+    const states = repoItems.map((item) => item.displayState);
+    const highestState = highestPriorityState(states);
+    const attentionCount = repoItems.filter((item) =>
+      isAttentionState(item.displayState)
+    ).length;
+
+    return {
+      highestState,
+      attentionCount,
+      isLoading: false,
+    };
+  }
+
+  it('filters items by repoPath', () => {
+    const items: SidebarItem[] = [
+      makeItem({ repoPath: '/repo1', displayState: 'permission' }),
+      makeItem({ repoPath: '/repo2', displayState: 'running' }),
+    ];
+    const result = aggregateRepo('/repo1', items);
+    expect(result.highestState).toBe('permission');
+    expect(result.attentionCount).toBe(1);
+  });
+
+  it('counts attention states correctly', () => {
+    const items: SidebarItem[] = [
+      makeItem({ id: '1', displayState: 'permission' }),
+      makeItem({ id: '2', path: '/repo/wt2', displayState: 'unseen-idle' }),
+      makeItem({ id: '3', path: '/repo/wt3', displayState: 'running' }),
+      makeItem({ id: '4', path: '/repo/wt4', displayState: 'error' }),
+    ];
+    const result = aggregateRepo('/repo', items);
+    expect(result.attentionCount).toBe(3);
+  });
+
+  it('returns initializing state when items are loading', () => {
+    const items: SidebarItem[] = [
+      makeItem({ path: '/repo/wt1', displayState: 'inactive' }),
+    ];
+    const loadingItems = new Set(['/repo/wt1']);
+    const result = aggregateRepo('/repo', items, loadingItems);
+    expect(result.highestState).toBe('initializing');
+    expect(result.attentionCount).toBe(0);
+    expect(result.isLoading).toBe(true);
+  });
+
+  it('computes highest priority state for mixed states', () => {
+    const items: SidebarItem[] = [
+      makeItem({ id: '1', path: '/repo/wt1', displayState: 'running' }),
+      makeItem({ id: '2', path: '/repo/wt2', displayState: 'permission' }),
+      makeItem({ id: '3', path: '/repo/wt3', displayState: 'unseen-idle' }),
+    ];
+    const result = aggregateRepo('/repo', items);
+    expect(result.highestState).toBe('permission');
+    expect(result.attentionCount).toBe(2);
+  });
+});

--- a/test/repo-aggregation.test.ts
+++ b/test/repo-aggregation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { aggregateRepo } from '../frontend/src/hooks/useRepoAggregation.js';
 import { highestPriorityState } from '../frontend/src/lib/state/attention.js';
-import { isAttentionState } from '../frontend/src/lib/state/display-state.js';
 import type { DisplayState } from '../frontend/src/lib/state/display-state.js';
 import type { SidebarItem } from '../frontend/src/lib/types.js';
 
@@ -53,37 +53,7 @@ describe('highestPriorityState', () => {
   });
 });
 
-describe('repo aggregation logic', () => {
-  function aggregateRepo(
-    repoPath: string,
-    items: SidebarItem[],
-    loadingItems?: Set<string>
-  ) {
-    const repoItems = items.filter((item) => item.repoPath === repoPath);
-
-    const isLoading = repoItems.some((item) => loadingItems?.has(item.path));
-
-    if (isLoading) {
-      return {
-        highestState: 'initializing' as const,
-        attentionCount: 0,
-        isLoading: true,
-      };
-    }
-
-    const states = repoItems.map((item) => item.displayState);
-    const highestState = highestPriorityState(states);
-    const attentionCount = repoItems.filter((item) =>
-      isAttentionState(item.displayState)
-    ).length;
-
-    return {
-      highestState,
-      attentionCount,
-      isLoading: false,
-    };
-  }
-
+describe('aggregateRepo', () => {
   it('filters items by repoPath', () => {
     const items: SidebarItem[] = [
       makeItem({ repoPath: '/repo1', displayState: 'permission' }),
@@ -113,6 +83,26 @@ describe('repo aggregation logic', () => {
     const result = aggregateRepo('/repo', items, loadingItems);
     expect(result.highestState).toBe('initializing');
     expect(result.attentionCount).toBe(0);
+    expect(result.isLoading).toBe(true);
+  });
+
+  it('detects repo-scoped loading keys', () => {
+    const items: SidebarItem[] = [
+      makeItem({ path: '/repo/wt1', displayState: 'running' }),
+    ];
+    const loadingItems = new Set(['new-worktree:/repo']);
+    const result = aggregateRepo('/repo', items, loadingItems);
+    expect(result.highestState).toBe('initializing');
+    expect(result.isLoading).toBe(true);
+  });
+
+  it('detects repo-session loading key', () => {
+    const items: SidebarItem[] = [
+      makeItem({ path: '/repo/wt1', displayState: 'running' }),
+    ];
+    const loadingItems = new Set(['repo-session:/repo']);
+    const result = aggregateRepo('/repo', items, loadingItems);
+    expect(result.highestState).toBe('initializing');
     expect(result.isLoading).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

Closes #122

- Replace plain color-only StatusDot spans with the rich `SessionIndicator` component (◆◇▶●■─) across all sidebar session rows
- Add repo-header aggregation showing highest-priority glyph + attention count (e.g. `relay-ide ◇2`) — visible whether expanded or collapsed so users always see at-a-glance status
- Fix needs-answer cold load bug by propagating `permissionType` through `SessionSummary` and using it in `initialDisplayState()` so the state survives page refresh
- Add `highestPriorityState()` to attention.ts and extract pure `aggregateRepo()` function from `useRepoAggregation` hook
- Remove ~35 lines of duplicate `.status-dot--*` CSS from RepoItem.css
- Fix `dotState` typing from `string` to `DisplayState` (removes unsafe cast)
- Detect repo-scoped loading keys (`repo-session:`, `new-worktree:`) in aggregation hook
- 14 new tests covering priority logic, repo aggregation (including repo-scoped loading), and shape config (imported from real component)

## Test plan

- [x] `npm test` — all tests pass
- [x] TypeScript type-check passes (both server + frontend tsconfig)
- [x] Lint + prettier pass via pre-commit hooks
- [ ] Visual QA: verify shape glyphs render correctly in sidebar rows
- [ ] Verify repo-header badge shows correct glyph + count
- [ ] Verify needs-answer state persists across page refresh
- [ ] Verify `prefers-reduced-motion` disables pulse animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)