### PR TITLE
fix: prevent blank screen on OpenCode sessions, add tailable log file

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -804,29 +804,24 @@ function useTerminalSetup(
   useEffect(() => {
     const term = termRef.current;
     if (sessionId && term && !companionMode) {
-      // Reset terminal modes before switching sessions:
-      // - Exit alternate screen buffer (?1049l)
-      // - Disable mouse tracking modes (?1000l normal, ?1002l button-event,
-      //   ?1003l any-event, ?1006l SGR format, ?1015l URXVT format)
-      // - Disable bracketed paste (?2004l)
-      // Without this, an app like OpenCode that enables mouse tracking will
-      // leave xterm.js generating mouse escape sequences that get echoed as
-      // garbage text in the next session's PTY.
-      term.write(
-        '\x1b[?1049l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1015l\x1b[?2004l',
+      // Full reset (RIS) — synchronously resets parser state, all terminal
+      // modes (mouse tracking, bracketed paste, alternate screen), and clears
+      // the screen. This replaces the previous term.write(escapeSequences)
+      // approach which relied on an async callback. If the parser was stuck
+      // waiting for a string terminator from an unterminated escape sequence
+      // (e.g. DCS/OSC from OpenCode's Bubble Tea TUI), the write callback
+      // would never fire, connectPtySocket would never be called, and every
+      // subsequent session would render blank.
+      term.reset();
+      connectPtySocket(
+        sessionId,
+        term,
         () => {
-          term.clear();
-          connectPtySocket(
-            sessionId,
-            term,
-            () => {
-              if (termRef.current)
-                sendPtyResize(termRef.current.cols, termRef.current.rows);
-            },
-            () => {
-              /* session ended */
-            }
-          );
+          if (termRef.current)
+            sendPtyResize(termRef.current.cols, termRef.current.rows);
+        },
+        () => {
+          /* session ended */
         }
       );
     }

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -13,11 +13,105 @@ export interface Logger {
   error(message: string, ...args: unknown[]): void;
 }
 
+// ── Server relay (batched) ──────────────────────────────────────────────────
+
+interface LogEntry {
+  ts: string;
+  level: LogLevel;
+  ns: string;
+  msg: string;
+}
+
+let relayQueue: LogEntry[] = [];
+let relayTimer: ReturnType<typeof setTimeout> | null = null;
+const RELAY_INTERVAL = 2000; // flush every 2s
+const RELAY_MAX_BATCH = 50;
+
+function scheduleRelay(): void {
+  if (relayTimer !== null) return;
+  relayTimer = setTimeout(flushRelay, RELAY_INTERVAL);
+}
+
+function flushRelay(): void {
+  relayTimer = null;
+  if (relayQueue.length === 0) return;
+  const batch = relayQueue.splice(0, RELAY_MAX_BATCH);
+  // Fire-and-forget — don't block the UI on log delivery
+  fetch('/api/frontend-log', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(batch),
+  }).catch(() => {
+    /* best effort */
+  });
+  // If there's still more queued, schedule another flush
+  if (relayQueue.length > 0) scheduleRelay();
+}
+
+function queueForRelay(
+  level: LogLevel,
+  namespace: string,
+  message: string
+): void {
+  relayQueue.push({
+    ts: new Date().toISOString(),
+    level,
+    ns: namespace,
+    msg: message,
+  });
+  // Cap queue to prevent unbounded growth if server is unreachable
+  if (relayQueue.length > 200) relayQueue.splice(0, relayQueue.length - 200);
+  scheduleRelay();
+}
+
+// ── Logger factory ──────────────────────────────────────────────────────────
+
+function formatArgs(message: string, args: unknown[]): string {
+  if (args.length === 0) return message;
+  let i = 0;
+  const formatted = message.replace(/%[sdjo%]/g, (match) => {
+    if (match === '%%') return '%';
+    if (i >= args.length) return match;
+    const arg = args[i++];
+    switch (match) {
+      case '%s':
+        return String(arg);
+      case '%d':
+        return String(Number(arg));
+      case '%j':
+        try {
+          return JSON.stringify(arg);
+        } catch {
+          return '[Circular]';
+        }
+      case '%o':
+        try {
+          return JSON.stringify(arg);
+        } catch {
+          return '[Circular]';
+        }
+      default:
+        return match;
+    }
+  });
+  // Append any remaining args
+  const remaining = args.slice(i);
+  if (remaining.length === 0) return formatted;
+  return (
+    formatted +
+    ' ' +
+    remaining
+      .map((a) => (typeof a === 'string' ? a : JSON.stringify(a)))
+      .join(' ')
+  );
+}
+
 /**
  * Creates a namespaced logger that prefixes each message with the namespace.
+ * Writes to both browser console and relays to the server log file.
  *
  * @param namespace - Namespace to prepend to every log message.
- * @returns A logger that delegates to `console.*`.
+ * @returns A logger that delegates to `console.*` and relays to server.
  */
 export function createLogger(namespace: string): Logger {
   const prefix = `[${namespace}]`;
@@ -25,6 +119,7 @@ export function createLogger(namespace: string): Logger {
   const log = (level: LogLevel, message: string, ...args: unknown[]): void => {
     // eslint-disable-next-line no-console
     console[level](`${prefix} ${message}`, ...args);
+    queueForRelay(level, namespace, formatArgs(message, args));
   };
 
   return {

--- a/frontend/src/lib/logger.ts
+++ b/frontend/src/lib/logger.ts
@@ -22,7 +22,7 @@ interface LogEntry {
   msg: string;
 }
 
-let relayQueue: LogEntry[] = [];
+const relayQueue: LogEntry[] = [];
 let relayTimer: ReturnType<typeof setTimeout> | null = null;
 const RELAY_INTERVAL = 2000; // flush every 2s
 const RELAY_MAX_BATCH = 50;

--- a/server/index.ts
+++ b/server/index.ts
@@ -107,7 +107,7 @@ import {
   generateScopedToken,
   cleanExpiredTokens,
 } from './browser-content.js';
-import { createLogger } from './logger.js';
+import { createLogger, initFileLogging } from './logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -599,6 +599,7 @@ async function main(): Promise<void> {
   push.ensureVapidKeys(startupConfig, CONFIG_PATH, saveConfig);
 
   const configDir = getConfigDir(CONFIG_PATH);
+  initFileLogging(path.join(configDir, 'logs'));
   fs.mkdirSync(path.join(configDir, 'telemetry'), { recursive: true });
   try {
     initAnalytics(configDir);
@@ -917,6 +918,28 @@ async function main(): Promise<void> {
   app.use('/analytics', requireAuth, createAnalyticsRouter(configDir));
   app.use('/api/analytics', requireAuth, createSessionAnalyticsRouter());
   app.use('/telemetry', requireAuth, createTelemetryRouter());
+
+  // POST /api/frontend-log — relay frontend logs to the server log file
+  app.post('/api/frontend-log', requireAuth, (req, res) => {
+    const entries = req.body as Array<{
+      ts?: string;
+      level?: string;
+      ns?: string;
+      msg?: string;
+    }>;
+    if (!Array.isArray(entries)) {
+      res.status(400).end();
+      return;
+    }
+    const frontendLogger = createLogger('frontend');
+    for (const e of entries.slice(0, 50)) {
+      const level = e.level === 'warn' || e.level === 'error' ? e.level : 'info';
+      const ns = typeof e.ns === 'string' ? e.ns : '?';
+      const msg = typeof e.msg === 'string' ? e.msg : '';
+      frontendLogger[level](`[${ns}] ${msg}`);
+    }
+    res.status(204).end();
+  });
 
   // GET /api/frameworks — returns available agent frameworks with capabilities
   app.get('/api/frameworks', requireAuth, (_req, res) => {

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { format } from 'node:util';
+
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 export interface Logger {
@@ -7,11 +11,64 @@ export interface Logger {
   error(message: string, ...args: unknown[]): void;
 }
 
+// ── File logging state ──────────────────────────────────────────────────────
+
+const MAX_LOG_SIZE = 5 * 1024 * 1024; // 5MB
+let logStream: fs.WriteStream | null = null;
+let logFilePath: string | null = null;
+let currentLogSize = 0;
+
+/**
+ * Initialize file-based logging. Call once at server startup after config dir
+ * is resolved. Logs are written to `<logDir>/relay-ide.log` and rotated to
+ * `.old` when they exceed MAX_LOG_SIZE.
+ *
+ * Loggers created before this call still work (console-only).
+ */
+export function initFileLogging(logDir: string): void {
+  fs.mkdirSync(logDir, { recursive: true });
+  logFilePath = path.join(logDir, 'relay-ide.log');
+
+  try {
+    currentLogSize = fs.statSync(logFilePath).size;
+  } catch {
+    currentLogSize = 0;
+  }
+
+  rotateIfNeeded();
+  logStream = fs.createWriteStream(logFilePath, { flags: 'a' });
+}
+
+function rotateIfNeeded(): void {
+  if (!logFilePath || currentLogSize < MAX_LOG_SIZE) return;
+  const oldPath = logFilePath + '.old';
+  try {
+    if (fs.existsSync(oldPath)) fs.unlinkSync(oldPath);
+    if (fs.existsSync(logFilePath)) fs.renameSync(logFilePath, oldPath);
+  } catch {
+    /* best effort */
+  }
+  currentLogSize = 0;
+}
+
+function writeToFile(line: string): void {
+  if (!logStream || !logFilePath) return;
+  logStream.write(line + '\n');
+  currentLogSize += line.length + 1;
+  if (currentLogSize >= MAX_LOG_SIZE) {
+    logStream.end();
+    rotateIfNeeded();
+    logStream = fs.createWriteStream(logFilePath, { flags: 'a' });
+  }
+}
+
+// ── Logger factory ──────────────────────────────────────────────────────────
+
 /**
  * Create a namespaced logger that prefixes all messages.
+ * Writes to both console and the log file (if initialized).
  *
  * @param namespace - Namespace used in the log prefix.
- * @returns A logger that delegates to `console.*`.
  */
 export function createLogger(namespace: string): Logger {
   const prefix = `[${namespace}]`;
@@ -19,6 +76,12 @@ export function createLogger(namespace: string): Logger {
   const log = (level: LogLevel, message: string, ...args: unknown[]): void => {
     // eslint-disable-next-line no-console
     console[level](`${prefix} ${message}`, ...args);
+
+    const timestamp = new Date().toISOString();
+    const formatted = args.length > 0 ? format(message, ...args) : message;
+    writeToFile(
+      `${timestamp} ${level.toUpperCase().padEnd(5)} ${prefix} ${formatted}`
+    );
   };
 
   return {


### PR DESCRIPTION
## Summary

- **Fix blank screen bug**: Replace async `term.write(escapeSequences, callback)` session-switch chain with synchronous `term.reset()`. If the xterm.js parser was stuck on an unterminated escape sequence from OpenCode's Bubble Tea TUI, the write callback never fired, `connectPtySocket` was never called, and every subsequent session rendered blank. `term.reset()` bypasses the write buffer entirely and resets the parser state machine to GROUND.
- **Add file-based logging**: Server logger now writes to `~/.config/relay-ide/logs/relay-ide.log` (5MB max, rotates to `.old`). Frontend logger batches logs every 2s and relays them to the server via `POST /api/frontend-log`. Both streams in one tailable file.

## Test plan

- [ ] Open an OpenCode session, verify it renders (not blank)
- [ ] Switch between OpenCode and Claude sessions, verify no blank screens
- [ ] Verify `tail -f ~/.config/relay-ide/logs/relay-ide.log` shows both server and frontend log entries
- [ ] Verify log file rotates when approaching 5MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)