### PR TITLE
fix: intercept DECRQM escape sequences to prevent OpenCode blank screen

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -697,6 +697,29 @@ function registerEscapeSequenceSanitizers(t: XTerminal): void {
   // recognized by xterm.js. Swallow to prevent parser confusion.
   t.parser.registerOscHandler(66, () => true);
 
+  // DECRQM (DEC Request Mode) — Bubble Tea / OpenTUI probes terminal
+  // capabilities by sending CSI Ps $ p (ANSI) and CSI ? Ps $ p (DEC private).
+  // xterm.js v6's built-in requestMode handler crashes with "ReferenceError:
+  // s is not defined" because the pre-minified xterm.js webpack bundle gets
+  // double-minified by Vite/esbuild, breaking an internal variable reference.
+  // The uncaught error corrupts the parser, the term.write callback never
+  // fires, flow control pauses permanently, and the terminal goes blank.
+  // Intercept both DECRQM forms and respond with "not recognized" (Pm=0) so
+  // the TUI app gets a valid DECRPM response and falls back to defaults.
+  t.parser.registerCsiHandler({ intermediates: '$', final: 'p' }, (params) => {
+    const mode = params[0];
+    sendPtyData(`\x1b[${mode};0$y`);
+    return true;
+  });
+  t.parser.registerCsiHandler(
+    { prefix: '?', intermediates: '$', final: 'p' },
+    (params) => {
+      const mode = params[0];
+      sendPtyData(`\x1b[?${mode};0$y`);
+      return true;
+    }
+  );
+
   // Kitty graphics protocol — OpenTUI may probe for graphics support via
   // APC sequences (ESC _ G ... ESC \). No explicit APC sanitizer is registered
   // here; xterm.js handles unknown APC sequences gracefully in recent versions.

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -708,6 +708,7 @@ function registerEscapeSequenceSanitizers(t: XTerminal): void {
   // the TUI app gets a valid DECRPM response and falls back to defaults.
   t.parser.registerCsiHandler({ intermediates: '$', final: 'p' }, (params) => {
     const mode = params[0];
+    if (typeof mode !== 'number') return true;
     sendPtyData(`\x1b[${mode};0$y`);
     return true;
   });
@@ -715,6 +716,7 @@ function registerEscapeSequenceSanitizers(t: XTerminal): void {
     { prefix: '?', intermediates: '$', final: 'p' },
     (params) => {
       const mode = params[0];
+      if (typeof mode !== 'number') return true;
       sendPtyData(`\x1b[?${mode};0$y`);
       return true;
     }

--- a/test/decrqm-sanitizer.test.ts
+++ b/test/decrqm-sanitizer.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest';
+
+/**
+ * Regression test for the DECRQM escape-sequence sanitizer.
+ *
+ * xterm.js v6's built-in requestMode handler crashes when double-minified
+ * by Vite/esbuild (ReferenceError: s is not defined). OpenCode's Bubble Tea
+ * TUI sends DECRQM sequences to probe terminal capabilities, triggering the
+ * crash and rendering the terminal blank.
+ *
+ * The sanitizer in registerEscapeSequenceSanitizers intercepts DECRQM before
+ * the broken handler and responds with DECRPM "not recognized" (Pm=0).
+ *
+ * These tests exercise the handler logic directly (inlined from Terminal.tsx)
+ * since the frontend component requires a browser environment.
+ */
+
+// Inline the handler logic from registerEscapeSequenceSanitizers
+function makeAnsiDecrqmHandler(sendPtyData: (data: string) => void) {
+  return (params: (number | number[])[]) => {
+    const mode = params[0];
+    if (typeof mode !== 'number') return true;
+    sendPtyData(`\x1b[${mode};0$y`);
+    return true;
+  };
+}
+
+function makeDecPrivateDecrqmHandler(sendPtyData: (data: string) => void) {
+  return (params: (number | number[])[]) => {
+    const mode = params[0];
+    if (typeof mode !== 'number') return true;
+    sendPtyData(`\x1b[?${mode};0$y`);
+    return true;
+  };
+}
+
+describe('DECRQM sanitizer handlers', () => {
+  describe('ANSI mode handler (CSI Ps $ p)', () => {
+    it('responds with DECRPM "not recognized" for a valid mode', () => {
+      const send = vi.fn();
+      const handler = makeAnsiDecrqmHandler(send);
+
+      const result = handler([4]); // mode 4 = insert mode
+
+      expect(result).toBe(true);
+      expect(send).toHaveBeenCalledWith('\x1b[4;0$y');
+    });
+
+    it('swallows without response when params are empty', () => {
+      const send = vi.fn();
+      const handler = makeAnsiDecrqmHandler(send);
+
+      const result = handler([]);
+
+      expect(result).toBe(true);
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    it('swallows when params[0] is a subparam array', () => {
+      const send = vi.fn();
+      const handler = makeAnsiDecrqmHandler(send);
+
+      const result = handler([[1, 2]]);
+
+      expect(result).toBe(true);
+      expect(send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DEC private mode handler (CSI ? Ps $ p)', () => {
+    it('responds with DEC private DECRPM for mode 1000 (mouse tracking)', () => {
+      const send = vi.fn();
+      const handler = makeDecPrivateDecrqmHandler(send);
+
+      const result = handler([1000]);
+
+      expect(result).toBe(true);
+      expect(send).toHaveBeenCalledWith('\x1b[?1000;0$y');
+    });
+
+    it('responds for mode 2004 (bracketed paste)', () => {
+      const send = vi.fn();
+      const handler = makeDecPrivateDecrqmHandler(send);
+
+      const result = handler([2004]);
+
+      expect(result).toBe(true);
+      expect(send).toHaveBeenCalledWith('\x1b[?2004;0$y');
+    });
+
+    it('responds for mode 1049 (alternate screen)', () => {
+      const send = vi.fn();
+      const handler = makeDecPrivateDecrqmHandler(send);
+
+      const result = handler([1049]);
+
+      expect(result).toBe(true);
+      expect(send).toHaveBeenCalledWith('\x1b[?1049;0$y');
+    });
+
+    it('swallows without response when params are empty', () => {
+      const send = vi.fn();
+      const handler = makeDecPrivateDecrqmHandler(send);
+
+      const result = handler([]);
+
+      expect(result).toBe(true);
+      expect(send).not.toHaveBeenCalled();
+    });
+
+    it('always returns true to prevent the broken built-in handler', () => {
+      const send = vi.fn();
+      const handler = makeDecPrivateDecrqmHandler(send);
+
+      // Every call must return true to swallow the sequence
+      expect(handler([25])).toBe(true);
+      expect(handler([])).toBe(true);
+      expect(handler([[1, 2]])).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Intercepts DECRQM (DEC Request Mode) escape sequences in `registerEscapeSequenceSanitizers` before they reach xterm.js v6's broken built-in `requestMode` handler
- Root cause: xterm.js ships a pre-minified webpack bundle that gets double-minified by Vite/esbuild, breaking an internal variable reference (`ReferenceError: s is not defined`)
- OpenCode's Bubble Tea TUI sends DECRQM to probe terminal capabilities, triggering the crash which corrupts the parser, stalls flow control, and renders the terminal blank
- Responds with DECRPM "not recognized" (Pm=0) so the TUI gets a valid response and falls back to defaults

## Test plan

- [x] Built and ran on local port 3457 (no collision with prod on 3456)
- [x] Created OpenCode session via API — session renders the full Bubble Tea TUI
- [x] Verified via `/browse`: OpenCode logo, provider info, input prompt all visible
- [x] Sent "say hello world" to the agent — processed successfully, no blank screen
- [x] Console errors: zero `ReferenceError` crashes (only pre-existing 401 from auth probe)
- [x] All 88 test files, 1185 tests passing
- [x] Lint, prettier, TypeScript checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)