### PR TITLE
feat: unified web chat foundation — ChatEvent types, ProtocolAdapter, WebSession

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ telemetry/
 # Test artifacts
 test-results/
 playwright-report/
+.omx/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ Relay IDE is a remote web interface for interacting with Claude Code CLI session
 Input: browser keystrokes, session management commands, clipboard images.
 Output: terminal rendering via xterm.js, real-time session state updates.
 
-The system has two compilation targets: a TypeScript + ESM backend (Express + node-pty + WebSocket) compiled to `dist/`, and a Svelte 5 frontend (runes + Vite) compiled to `dist/frontend/`.
+The system has two compilation targets: a TypeScript + ESM backend (Express + node-pty + WebSocket) compiled to `dist/`, and a React 19 frontend (Zustand + TanStack Query + Vite) compiled to `dist/frontend/`.
 
 ## Code Map
 
@@ -55,24 +55,25 @@ Thirty-four TypeScript modules compiled to `dist/server/` via `tsc`. Modules com
 
 ### `frontend/`
 
-Svelte 5 SPA built by Vite, output to `dist/frontend/`. Express serves the compiled output.
+React 19 SPA built by Vite, output to `dist/frontend/`. Express serves the compiled output.
 
-| Path                                  | Role                                                                                                                                                                                                                                                                                                                  |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `frontend/src/components/`            | Svelte 5 components (Terminal, Sidebar, WorkspaceItem, PrTopBar, SessionTabBar, RepoDashboard, Spotlight, dialogs, etc.)                                                                                                                                                                                              |
-| `frontend/src/lib/state/`             | Reactive state modules (`.svelte.ts` files) exporting state + mutations; includes pure logic modules (`display-state.ts` — 6-state display state machine, `sidebar-items.ts` — unified SidebarItem construction with reconciliation, `ui.svelte.ts` — left/right sidebar state, file viewer tabs, shared diff source) |
-| `frontend/src/lib/api.ts`             | REST API client functions                                                                                                                                                                                                                                                                                             |
-| `frontend/src/lib/ws.ts`              | WebSocket connection management (PTY relay + event channel)                                                                                                                                                                                                                                                           |
-| `frontend/src/lib/types.ts`           | Frontend TypeScript interfaces                                                                                                                                                                                                                                                                                        |
-| `frontend/src/lib/actions.ts`         | Shared Svelte actions (scroll-on-hover, longpress-click)                                                                                                                                                                                                                                                              |
-| `frontend/src/lib/actions/`           | Command center action registry: types, pure registry logic (`registry.ts`), reactive wrapper (`registry.svelte.ts`), and co-located action definitions in `definitions/`                                                                                                                                              |
-| `frontend/src/lib/notifications.ts`   | Browser Notification API wrapper, service worker registration, Web Push subscription                                                                                                                                                                                                                                  |
-| `frontend/src/lib/utils.ts`           | Shared utilities (path display, relative time formatting, device detection)                                                                                                                                                                                                                                           |
-| `frontend/src/lib/pr-state.ts`        | PR lifecycle state machine: derives action from PR state + CI + mergeable + unresolved comments                                                                                                                                                                                                                       |
-| `frontend/src/lib/file-tree-utils.ts` | Pure file tree functions: `buildChangedFilesTree`, `flattenVisibleNodes`, `findMostRecentlyChanged`, `parseLineReference`, status badge helpers                                                                                                                                                                       |
-| `frontend/src/lib/analytics.ts`       | Frontend analytics: batch event collection, `data-track` attribute integration                                                                                                                                                                                                                                        |
+| Path                                  | Role                                                                                                                                                                                        |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `frontend/src/components/`            | React 19 TSX components (Terminal, Sidebar, RepoItem, PrTopBar, SessionTabBar, RepoDashboard, CommandPalette, dialogs, etc.)                                                                |
+| `frontend/src/lib/state/`             | Pure logic modules (`display-state.ts` — 6-state display state machine, `sidebar-items.ts` — unified SidebarItem construction with reconciliation, `attention.ts` — state priority scoring) |
+| `frontend/src/hooks/`                 | React hooks for state and side effects (`useEventSocket`, `useSessionHandlers`, `useActionRegistry`, `useRepoAggregation`, etc.)                                                            |
+| `frontend/src/lib/api.ts`             | REST API client functions                                                                                                                                                                   |
+| `frontend/src/lib/ws.ts`              | WebSocket connection management (PTY relay + event channel)                                                                                                                                 |
+| `frontend/src/lib/types.ts`           | Frontend TypeScript interfaces                                                                                                                                                              |
+| `frontend/src/lib/actions.ts`         | Shared utility actions (scroll-on-hover, longpress-click)                                                                                                                                   |
+| `frontend/src/lib/actions/`           | Command center action registry: types, pure registry logic (`registry.ts`), reactive hook wrapper, and co-located action definitions in `definitions/`                                      |
+| `frontend/src/lib/notifications.ts`   | Browser Notification API wrapper, service worker registration, Web Push subscription                                                                                                        |
+| `frontend/src/lib/utils.ts`           | Shared utilities (path display, relative time formatting, device detection)                                                                                                                 |
+| `frontend/src/lib/pr-state.ts`        | PR lifecycle state machine: derives action from PR state + CI + mergeable + unresolved comments                                                                                             |
+| `frontend/src/lib/file-tree-utils.ts` | Pure file tree functions: `buildChangedFilesTree`, `flattenVisibleNodes`, `findMostRecentlyChanged`, `parseLineReference`, status badge helpers                                             |
+| `frontend/src/lib/analytics.ts`       | Frontend analytics: batch event collection, `data-track` attribute integration                                                                                                              |
 
-**Architecture Invariant:** The frontend does NOT vendor any libraries. xterm.js, xterm-addon-fit, and `@tanstack/svelte-query` are npm dependencies. State lives in `.svelte.ts` modules, not in component files (PR data is an exception — managed via svelte-query cache).
+**Architecture Invariant:** The frontend does NOT vendor any libraries. xterm.js, xterm-addon-fit, `react`, `zustand`, and `@tanstack/react-query` are npm dependencies. State lives in Zustand stores and React hooks, not in component files (PR data is an exception — managed via TanStack Query cache).
 
 ### `bin/`
 
@@ -99,7 +100,7 @@ Browser (xterm.js) <--WebSocket /ws/:id--> ws.ts <--PTY I/O--> node-pty <--spawn
 **Event channel:**
 
 ```
-Browser (Svelte)   <--WebSocket /ws/events-- ws.ts <-- watcher.ts (fs.watch on .worktrees/)
+Browser (React)    <--WebSocket /ws/events-- ws.ts <-- watcher.ts (fs.watch on .worktrees/)
                                                     <-- POST/DELETE /roots (manual broadcast)
 ```
 
@@ -191,4 +192,4 @@ Both channels require authentication via `token` cookie verified during HTTP upg
 | ADR-007 | WebSocket dual channels (PTY relay + event broadcast, debounced watcher)             |
 | ADR-008 | TypeScript + ESM (strict mode, .js extensions, node: prefix, Node >= 24)             |
 
-> ADR-002 (vanilla JS frontend) was superseded by the Svelte 5 migration. `hooks.ts` does not yet have a dedicated ADR.
+> ADR-002 (vanilla JS frontend) was superseded by the Svelte 5 migration, which was subsequently superseded by the React 19 migration. `hooks.ts` does not yet have a dedicated ADR.

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,126 +1,135 @@
 # Frontend
 
-Svelte 5 SPA for Relay IDE. Built with runes syntax, TypeScript, and Vite. The frontend provides terminal access, session management, and real-time worktree monitoring.
+React 19 SPA for Relay IDE. Built with TypeScript, Zustand, TanStack Query, and Vite. The frontend provides terminal access, session management, and real-time worktree monitoring.
 
 ## Current State
 
-- Svelte 5 with runes (`$state`, `$derived`, `$effect`, `$props()`) — TypeScript throughout
+- React 19 with hooks, Zustand 5 for state management, TanStack React Query 5 for server state — TypeScript throughout
 - Vite builds `frontend/` to `dist/frontend/`; Express serves compiled output
 - xterm.js consumed as npm dependency (`@xterm/xterm`, `@xterm/addon-fit`)
 - Mobile-first responsive design with touch toolbar (hidden on desktop)
 
 ## Component Map
 
-| Component                                        | Role                                                                                                                                                                                                           |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `App.svelte`                                     | Root layout: left sidebar + SplitPaneLayout (terminal                                                                                                                                                          | FileViewerPane | FileTreeSidebar) for session view; dashboard / PR top bar + tabs for non-session views                                   |
-| `Sidebar.svelte`                                 | Flat workspace list with smart search, no tabs                                                                                                                                                                 |
-| `WorkspaceItem.svelte`                           | Workspace tree item: letter icon, sessions, inactive worktrees, context menus                                                                                                                                  |
-| `SmartSearch.svelte`                             | Terminal-style typeahead search with `>` prompt                                                                                                                                                                |
-| `PrTopBar.svelte`                                | Dynamic PR/CI bar with branch switcher, target branch switcher, hover-reveal icons (copy/rename), inline rename flow, diff stats, merge conflict detection, dual action buttons (resolve+review), archive flow |
-| `SessionTabBar.svelte`                           | Multi-tab session management per worktree (role=tablist)                                                                                                                                                       |
-| `RepoDashboard.svelte`                           | Workspace dashboard: PRs with merge status, activity feed, CTAs                                                                                                                                                |
-| `BranchSwitcher.svelte`                          | Worktree-aware branch dropdown: filter, create new branch, strikethrough for checked-out branches, jump-to-session links, agent-running guard                                                                  |
-| `TargetBranchSwitcher.svelte`                    | PR base branch dropdown: remote-only branches, changes base via `gh pr edit`                                                                                                                                   |
-| `FileBrowser.svelte`                             | Lazy-loading tree-view filesystem browser with multi-select, filter, keyboard nav                                                                                                                              |
-| `EmptyState.svelte`                              | Reusable empty state with icon, heading, description, CTA                                                                                                                                                      |
-| `Terminal.svelte`                                | xterm.js terminal wrapper with WebSocket connection                                                                                                                                                            |
-| `Toolbar.svelte`                                 | Mobile touch toolbar for terminal interaction                                                                                                                                                                  |
-| `MobileHeader.svelte`                            | Mobile header with session info                                                                                                                                                                                |
-| `ContextMenu.svelte`                             | Universal "..." dropdown menu for session/item actions                                                                                                                                                         |
-| `PinGate.svelte`                                 | PIN authentication screen                                                                                                                                                                                      |
-| `ImageToast.svelte`                              | Clipboard image paste feedback                                                                                                                                                                                 |
-| `UpdateToast.svelte`                             | Version update notification                                                                                                                                                                                    |
-| `AgentBadge.svelte`                              | Agent type indicator badge (Claude/Codex)                                                                                                                                                                      |
-| `SearchableSelect.svelte`                        | Searchable dropdown filter replacing native selects                                                                                                                                                            |
-| `SessionItem.svelte`                             | Session list item with status dot, context menu, metadata row                                                                                                                                                  |
-| `MobileInput.svelte`                             | Event-intent mobile keyboard input handler                                                                                                                                                                     |
-| `FileTreeSidebar.svelte`                         | Right sidebar: changes tab (git diff tree with M/A/D badges, aggregate stats), all files tab (lazy filesystem browser), checks tab (stubbed); shared diffSource via ui.svelte.ts                               |
-| `FileViewerPane.svelte`                          | File viewer pane: independent tab bar for open files, DiffViewer for changed files, CodeBlock for raw files, send-to-agent pill, diff-to-agent bridge (click line numbers to inject filepath:linenum)          |
-| `SplitPaneLayout.svelte`                         | Resizable 3-pane layout (terminal                                                                                                                                                                              | file viewer    | right sidebar) with draggable resize handles, localStorage-persisted widths, auto-collapse file viewer when no tabs open |
-| `ChangedFiles.svelte`                            | Collapsible changed files panel (superseded by FileTreeSidebar in session view, retained in codebase)                                                                                                          |
-| `DiffViewer.svelte`                              | Unified diff renderer with diff2html parsing and Shiki syntax highlighting                                                                                                                                     |
-| `CodeBlock.svelte`                               | Shared Shiki syntax highlighting wrapper component                                                                                                                                                             |
-| `OrgDashboard.svelte`                            | Cross-repo PR list and tickets panel with tab navigation                                                                                                                                                       |
-| `TicketsPanel.svelte`                            | Multi-provider ticket list: GitHub Issues, Jira, Linear tabs with skeleton loading and branch link indicators                                                                                                  |
-| `TicketCard.svelte`                              | Individual ticket row: status dot, provider-native metadata (labels/sprint/cycle/priority), branch link, Start Work button                                                                                     |
-| `StartWorkModal.svelte`                          | Start Work modal: ticket info, workspace selector (for Jira/Linear), branch name input, creates worktree session with ticket context                                                                           |
-| `StatusMappingModal.svelte`                      | Map workflow transition states (in-progress, code-review, ready-for-qa) to Jira transition IDs / Linear status IDs                                                                                             |
-| `dialogs/DialogShell.svelte`                     | Shared dialog wrapper (fullscreen/compact variants, terminal aesthetic, shared button/form CSS)                                                                                                                |
-| `dialogs/SettingRow.svelte`                      | Consistent setting row (name, description, action slot)                                                                                                                                                        |
-| `dialogs/SettingsToc.svelte`                     | Settings TOC drawer with IntersectionObserver scroll tracking                                                                                                                                                  |
-| `dialogs/integrations/GitHubIntegration.svelte`  | GitHub OAuth App connection panel within SettingsDialog                                                                                                                                                        |
-| `dialogs/integrations/WebhookIntegration.svelte` | GitHub webhook CRUD and smee proxy panel within SettingsDialog                                                                                                                                                 |
-| `dialogs/integrations/JiraIntegration.svelte`    | Jira connection and project config panel within SettingsDialog                                                                                                                                                 |
-| `dialogs/RenameWarningModal.svelte`              | Rename + PR warning: push renamed branch, ignore, or undo rename                                                                                                                                               |
-| `dialogs/WorkspaceEditor.svelte`                 | Workspace entity editor: name, repo assignment, theme color palette, delete — used in SettingsDialog workspaces section                                                                                        |
-| `dialogs/`                                       | Session customization, settings, workspace, and worktree deletion dialogs                                                                                                                                      |
+| Component                            | Role                                                                                                                                                            |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `App.tsx`                            | Root layout: left sidebar + SplitPaneLayout (terminal / FileViewerPane / FileTreeSidebar) for session view; dashboard / PR top bar + tabs for non-session views |
+| `Sidebar.tsx`                        | Flat workspace list with command palette search                                                                                                                 |
+| `RepoItem.tsx`                       | Repo tree item: sessions, inactive worktrees, context menus, workspace group membership                                                                         |
+| `CommandPalette.tsx`                 | Terminal-style command palette with action registry                                                                                                             |
+| `PrTopBar.tsx`                       | Dynamic PR/CI bar with branch switcher, target branch switcher, diff stats, merge conflict detection, action buttons                                            |
+| `SessionTabBar.tsx`                  | Multi-tab session management per worktree (role=tablist)                                                                                                        |
+| `RepoDashboard.tsx`                  | Workspace dashboard: PRs with merge status, activity feed, CTAs                                                                                                 |
+| `BranchSwitcher.tsx`                 | Worktree-aware branch dropdown: filter, create new branch, jump-to-session links, agent-running guard                                                           |
+| `TargetBranchSwitcher.tsx`           | PR base branch dropdown: remote-only branches, changes base via `gh pr edit`                                                                                    |
+| `FileBrowser.tsx`                    | Lazy-loading tree-view filesystem browser with multi-select, filter, keyboard nav                                                                               |
+| `Terminal.tsx`                       | xterm.js terminal wrapper with WebSocket connection, escape sequence sanitization                                                                               |
+| `Toolbar.tsx`                        | Mobile touch toolbar for terminal interaction                                                                                                                   |
+| `MobileInput.tsx`                    | Event-intent mobile keyboard input handler                                                                                                                      |
+| `ContextMenu.tsx`                    | Universal "..." dropdown menu for session/item actions                                                                                                          |
+| `PinGate.tsx`                        | PIN authentication screen with PinInput component                                                                                                               |
+| `SessionIndicator.tsx`               | Unicode shape-based session state indicator (shapes + colors + pulse animations)                                                                                |
+| `SessionStatusBar.tsx`               | Multi-framework telemetry status bar (model, context %, tokens)                                                                                                 |
+| `AgentBadge.tsx`                     | Agent type indicator badge (Claude/Codex/OpenCode)                                                                                                              |
+| `FileTreeSidebar.tsx`                | Right sidebar: changes tab (git diff tree), all files tab (lazy filesystem browser)                                                                             |
+| `FileViewerPane.tsx`                 | File viewer pane: tab bar, DiffViewer for changed files, CodeBlock for raw files                                                                                |
+| `SplitPaneLayout.tsx`                | Resizable 3-pane layout (terminal / file viewer / right sidebar) with draggable resize handles                                                                  |
+| `DiffViewer.tsx`                     | Unified diff renderer with diff2html parsing and Shiki syntax highlighting                                                                                      |
+| `CodeBlock.tsx`                      | Shared Shiki syntax highlighting wrapper component                                                                                                              |
+| `OrgDashboard.tsx`                   | Cross-repo PR list and tickets panel with tab navigation                                                                                                        |
+| `TicketsPanel.tsx`                   | Multi-provider ticket list: GitHub Issues, Jira, Linear tabs                                                                                                    |
+| `TicketCard.tsx`                     | Individual ticket row: status dot, provider metadata, branch link, Start Work button                                                                            |
+| `StartWorkModal.tsx`                 | Start Work modal: ticket info, workspace selector, branch name input                                                                                            |
+| `TuiButton.tsx`                      | TUI-styled button with box-drawing corner characters                                                                                                            |
+| `TuiCheckbox.tsx`                    | Terminal-style `[x]`/`[ ]` checkbox component                                                                                                                   |
+| `TuiInput.tsx`                       | Terminal-style input with block cursor                                                                                                                          |
+| `MarqueeText.tsx`                    | Horizontal scroll-on-hover for overflow text (Spotify-style)                                                                                                    |
+| `CipherText.tsx`                     | Cipher-decode loading/transition animation                                                                                                                      |
+| `Hint.tsx`                           | Progressive disclosure onboarding hint component                                                                                                                |
+| `WorkspaceGroup.tsx`                 | Workspace container with color-coded border grouping                                                                                                            |
+| **Dialogs**                          |                                                                                                                                                                 |
+| `dialogs/DialogShell.tsx`            | Shared dialog wrapper (fullscreen/compact, terminal aesthetic, popover-based stacking)                                                                          |
+| `dialogs/SettingsDialog.tsx`         | Full settings dialog with TOC, sections, integrations                                                                                                           |
+| `dialogs/CustomizeSessionDialog.tsx` | Session creation/customization with agent selection, args, workspace                                                                                            |
+| `dialogs/AddWorkspaceDialog.tsx`     | Workspace path browser and add flow                                                                                                                             |
+| `dialogs/DeleteWorktreeDialog.tsx`   | Worktree deletion with dirty-check confirmation                                                                                                                 |
+| `dialogs/RenameWarningModal.tsx`     | Rename + PR warning: push, ignore, or undo                                                                                                                      |
+| `dialogs/WorkspaceEditor.tsx`        | Workspace entity editor: name, repo assignment, theme color                                                                                                     |
 
 ## State Management
 
-State lives in `.svelte.ts` modules under `frontend/src/lib/state/` exporting reactive state and mutation functions. Components import state — they do not own it. PR data is managed via `@tanstack/svelte-query` v6 (cache + manual refresh), not in state modules.
+State is managed via Zustand stores and React hooks. Pure logic modules live under `frontend/src/lib/state/`. Server state (PRs, sessions) is managed via `@tanstack/react-query` v5.
 
-| Module               | Role                                                                                                                                                                                                                                                   |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `sessions.svelte.ts` | Session list, worktrees, repos (`Repo[]`), `SidebarItem[]` with display state machine, notification preferences, loading state; `getSessionsForRepo()` helper                                                                                          |
-| `display-state.ts`   | Pure display state machine: `transitionDisplayState(current, event) → newState`, `shouldNotify(from, to)` — 6 states: `initializing \| running \| unseen-idle \| seen-idle \| permission \| inactive`                                                  |
-| `sidebar-items.ts`   | Pure `buildSidebarItems()` function: merges sessions + worktrees + workspaces into `SidebarItem[]` with reconciliation                                                                                                                                 |
-| `config.svelte.ts`   | Global session defaults (continue, yolo, tmux, agent, notifications); shared by SettingsDialog, SessionList, NewSessionDialog                                                                                                                          |
-| `auth.svelte.ts`     | Authentication state (PIN check, cookie token)                                                                                                                                                                                                         |
-| `ui.svelte.ts`       | UI state: active tab, left sidebar (collapse/width), filters; right sidebar (visible, collapsed, width, active tab); file viewer (open tabs, ratio); shared `fileDiffSource`/`fileDiffDefaultBranch` synced between FileTreeSidebar and FileViewerPane |
-| `shiki.ts`           | Shiki highlighter singleton, custom TUI theme, language detection, lazy grammar loading                                                                                                                                                                |
-| `diff-summary.ts`    | Rule-based smart diff summaries (v1): function detection, hunk analysis, fallback +N/-N                                                                                                                                                                |
+### Pure Logic Modules (`frontend/src/lib/state/`)
+
+| Module             | Role                                                                                                                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `display-state.ts` | Pure display state machine: `transitionDisplayState(current, event) -> newState`, `shouldNotify(from, to)` — 6 states: initializing, running, unseen-idle, seen-idle, permission, inactive |
+| `sidebar-items.ts` | Pure `buildSidebarItems()` function: merges sessions + worktrees + workspaces into `SidebarItem[]` with reconciliation                                                                     |
+| `attention.ts`     | State priority scoring: `STATE_SCORES` mapping, `highestPriorityState()`, `isAttentionState()` for repo-level aggregation                                                                  |
+| `unread-logic.ts`  | Unread/attention state transition logic                                                                                                                                                    |
+| `toasts.store.ts`  | Toast notification state                                                                                                                                                                   |
+
+### Hooks (`frontend/src/hooks/`)
+
+| Hook                     | Role                                                                                |
+| ------------------------ | ----------------------------------------------------------------------------------- |
+| `useEventSocket.ts`      | WebSocket connection to `/ws/events` with auto-reconnect, heartbeat, event dispatch |
+| `useSessionHandlers.ts`  | Session CRUD operations, state transitions, PTY lifecycle                           |
+| `useActionRegistry.ts`   | Action registry integration for CommandPalette                                      |
+| `useRepoAggregation.ts`  | Aggregates session states per repo for sidebar indicators                           |
+| `useAppShortcuts.ts`     | Global keyboard shortcuts (Cmd+T, Cmd+K, etc.)                                      |
+| `useScrollOverflow.ts`   | Detects text overflow for MarqueeText behavior                                      |
+| `useUrlNav.ts`           | URL-based navigation state                                                          |
+| `useOnboardingHints.tsx` | Progressive disclosure hint system                                                  |
+| `useWhatsNew.tsx`        | What's-new feature announcements                                                    |
 
 ### Action Registry (`frontend/src/lib/actions/`)
 
-Typed action registry for the command palette. Actions are pure metadata (`ActionMeta`) defined in `definitions/` files, registered with handler closures in `App.svelte` via `registerGlobal()`. CommandPalette reads commands from the registry via `getAllActions()`.
+Typed action registry for the command palette. Actions are pure metadata (`ActionMeta`) defined in `definitions/` files, registered with handler closures in `App.tsx` via `registerGlobal()`. CommandPalette reads commands from the registry via `getAllActions()`.
 
-| Module                     | Role                                                                                                                                            |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `types.ts`                 | `Action`, `ActionMeta`, `ActionContext`, `ActionCategory` type definitions                                                                      |
-| `registry.ts`              | Pure Map-based registry — `registerGlobal`, `registerContextual`, `getAction`, `getAllActions`, `getActionsByCategory`. Testable with node:test |
-| `registry.svelte.ts`       | Thin Svelte 5 wrapper — `$state` version counter for reactive invalidation                                                                      |
-| `definitions/session.ts`   | Session actions (new-agent, new-terminal, close, kill, start-on-repo, start-on-ticket)                                                          |
-| `definitions/workspace.ts` | Workspace actions (add, new-worktree)                                                                                                           |
-| `definitions/pr.ts`        | PR/branch actions (create, push-branch, switch-branch)                                                                                          |
-| `definitions/settings.ts`  | Settings actions (open, connect-github, toggle-yolo, check-updates)                                                                             |
+| Module                     | Role                                                                                                                   |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `types.ts`                 | `Action`, `ActionMeta`, `ActionContext`, `ActionCategory` type definitions                                             |
+| `registry.ts`              | Pure Map-based registry — `registerGlobal`, `registerContextual`, `getAction`, `getAllActions`, `getActionsByCategory` |
+| `definitions/session.ts`   | Session actions (new-agent, new-terminal, close, kill, start-on-repo, start-on-ticket)                                 |
+| `definitions/workspace.ts` | Workspace actions (add, new-worktree)                                                                                  |
+| `definitions/pr.ts`        | PR/branch actions (create, push-branch, switch-branch)                                                                 |
+| `definitions/settings.ts`  | Settings actions (open, connect-github, toggle-yolo, check-updates)                                                    |
 
 ## Conventions
 
-- Scoped `<style>` blocks in each component; global CSS variables in `frontend/src/app.css`
-- Sidebar status dots driven by `SidebarItem.displayState`: green (`running`), blue (`seen-idle`), amber glow (`unseen-idle`), yellow pulse (`permission`), gray (`inactive`/`initializing`)
-- Display state machine enforces valid transitions — `seen-idle` can never become `unseen-idle` without going through `running` first. Backend emits single `session-backend-state-changed` event; frontend applies `transitionDisplayState()` to update dots
-- Loading state: tracked in `loadingItems` reactive state; `setLoading`/`clearLoading` wrap async actions (start, kill, delete); WorkspaceItem shows CSS shimmer overlay with `pointer-events: none`
-- Hover effects: fade mask on overflow text, scroll reveal animation
-- Avoid naming local variables `state` in `.svelte` files — conflicts with `$state` rune
-- `bind:this` refs used in `$effect` must be declared with `$state()` — plain `let` refs won't trigger effect re-runs in Svelte 5
+- CSS modules or scoped styles per component; global CSS variables in `frontend/src/app.css`
+- Sidebar session indicators driven by `SessionIndicator.tsx` with Unicode shape language: `●` running, `▶` idle, `◆◇` permission/needs-answer, `■` error, `─` inactive
+- Display state machine enforces valid transitions — `seen-idle` can never become `unseen-idle` without going through `running` first. Backend emits single `session-backend-state-changed` event; frontend applies `transitionDisplayState()` to update indicators
+- Loading state: tracked in component state; `setLoading`/`clearLoading` wrap async actions (start, kill, delete); RepoItem shows CSS shimmer overlay with `pointer-events: none`
+- Hover effects: MarqueeText for overflow text, scroll reveal animation
+- All UI follows DESIGN.md: monospace fonts, lowercase labels, no emoji, outline-only buttons, 0px border-radius
 
 ## WebSocket Reconnection
 
 - **Event socket** (`/ws/events`): auto-reconnect with fixed 3-second delay
 - **PTY socket** (`/ws/:sessionId`): exponential backoff (1s, 2s, 4s, 8s, capped at 10s, max 30 attempts)
-- **SDK socket** (`/ws/:sessionId`): separate reconnect counter from PTY; exponential backoff
 - Close code 1000 = session ended — no reconnect
 - Before PTY reconnect, client verifies session still exists via `GET /sessions`
 - `[Reconnecting...]` shown once to avoid terminal spam
 - All event WebSocket connections must have both `close` and `error` handlers
-- SDK reconnect replays stored events from server on reconnection
 
 ## Key Patterns
 
 - **Tab bar "+" dropdown** has three options: "New Agent" (instant create with workspace defaults via `createSession()`), "New Terminal" (instant create via `createSession()` with `type: 'terminal'`), "Customize..." (opens `CustomizeSessionDialog` which also calls `createSession()`). `Cmd/Ctrl+T` triggers instant agent creation. New tabs auto-name as "Agent 1", "Terminal 1" etc. and append rightmost
 - All session/item actions are accessed via a "..." context menu button (ContextMenu component). Menu items vary by state: Active → Rename, Kill; Inactive worktree → Customize, Resume, Resume (YOLO), Delete; Idle repo → Customize, New Worktree
 - "Customize" opens NewSessionDialog pre-filled with the item's workspace and branch (for worktrees). All session creation flows go through the single `createSession()` function → `POST /sessions`
-- Repo root items always display "default" as their name (unless the user has explicitly renamed the active session). Both active and idle repo entries in `WorkspaceItem.svelte` enforce this
+- Repo root items always display "default" as their name (unless the user has explicitly renamed the active session). Both active and idle repo entries in `RepoItem.tsx` enforce this
 - Session item secondary row order: timestamp → branch name → PR number → context menu (right-aligned via `.context-menu-spacer`). This applies to active sessions and inactive worktrees. Idle-repo entries show only the default branch name (no timestamp or PR). Diff stats appear in the primary row
-- PRs tab uses `PrRepoGroup` components — each repo group independently fetches PRs via `@tanstack/svelte-query` `createQuery` with `Accessor` pattern: `createQuery<T>(() => ({...}))` — the options must be wrapped in a function for Svelte 5 runes reactivity
+- PRs tab uses `PrRepoGroup` components — each repo group independently fetches PRs via `@tanstack/react-query` `useQuery`
 - Filters (root, repo, search) live below the tab bar
 - PR click cascade: active session → inactive worktree → create new worktree + session
 - Worktree naming convention: `mobile-<name>-<timestamp>`
 - Settings dialog close triggers `refreshAll()` for immediate sidebar update
-- All dialogs are built on `DialogShell.svelte` — use the `fullscreen` prop for the Settings modal and omit it for compact dialogs (AddWorkspace, CustomizeSession, DeleteWorktree). DialogShell uses `popover="manual"` + `showPopover()`/`hidePopover()` to guarantee top-layer stacking above xterm.js canvas elements (z-index alone is insufficient for canvas stacking contexts)
+- All dialogs are built on `DialogShell.tsx` — use the `fullscreen` prop for the Settings modal and omit it for compact dialogs (AddWorkspace, CustomizeSession, DeleteWorktree). DialogShell uses `popover="manual"` + `showPopover()`/`hidePopover()` to guarantee top-layer stacking above xterm.js canvas elements (z-index alone is insufficient for canvas stacking contexts)
 - Cookie TTL uses human-readable format: `s` (seconds), `m` (minutes), `h` (hours), `d` (days). Default: `24h`
-- **Right sidebar + file viewer split** — `SplitPaneLayout` wraps the session view with `FileTreeSidebar` (right, resizable/collapsible via Ctrl+B) and `FileViewerPane` (center, appears on demand when files are opened). Both share `fileDiffSource` and `fileDiffDefaultBranch` via `ui.svelte.ts` so switching diff source in the sidebar updates all open file viewer tabs. `openFileTab()`/`closeFileTab()` in `ui.svelte.ts` drive file viewer tab state
+- **Right sidebar + file viewer split** — `SplitPaneLayout` wraps the session view with `FileTreeSidebar` (right, resizable/collapsible via Ctrl+B) and `FileViewerPane` (center, appears on demand when files are opened). Both share `fileDiffSource` and `fileDiffDefaultBranch` via `UI hooks` so switching diff source in the sidebar updates all open file viewer tabs. `openFileTab()`/`closeFileTab()` in `UI hooks` drive file viewer tab state
 - Root directory scanning: one level deep for git repos, hidden directories excluded
 
 ## Mobile Touch & Input

--- a/server/chat-events.ts
+++ b/server/chat-events.ts
@@ -1,0 +1,361 @@
+// Canonical ChatEvent type system for the unified web chat interface.
+// ChatEvent is a SIBLING to AgentEvent — not a subtype. AgentEvent handles
+// session lifecycle; ChatEvent handles streaming content, tool calls, approvals,
+// and protocol-specific semantics.
+//
+// All agent backends (Codex, OpenCode, Claude Code) map their native protocol
+// messages into this canonical type system via ProtocolAdapters.
+
+export type ChatEventSource = 'codex' | 'opencode' | 'claude' | 'mock';
+
+export interface ChatEventBase {
+  sessionId: string;
+  timestamp: string;
+  source: ChatEventSource;
+}
+
+// ── Content Events ────────────────────────────────────────────────────────────
+
+/** Streaming text chunk from the agent (before message is complete) */
+export interface TextDeltaEvent extends ChatEventBase {
+  type: 'chat:text-delta';
+  turnId: string;
+  messageId: string;
+  delta: string;
+}
+
+/** Full message completed streaming */
+export interface MessageCompleteEvent extends ChatEventBase {
+  type: 'chat:message-complete';
+  turnId: string;
+  messageId: string;
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/** Thinking/reasoning trace from the agent */
+export interface ReasoningEvent extends ChatEventBase {
+  type: 'chat:reasoning';
+  turnId: string;
+  messageId: string;
+  content: string;
+  /** Whether this is a delta or the complete reasoning block */
+  isDelta: boolean;
+}
+
+/** Context was compacted / summarized by the agent */
+export interface CompactionEvent extends ChatEventBase {
+  type: 'chat:compaction';
+  /** Turn during which compaction occurred, if mid-turn */
+  turnId?: string;
+  summary: string;
+  tokensBefore: number;
+  tokensAfter: number;
+}
+
+// ── Tool Events ───────────────────────────────────────────────────────────────
+
+export type ToolCallStatus =
+  | 'pending'
+  | 'running'
+  | 'completed'
+  | 'error'
+  | 'declined';
+
+/** A tool call started */
+export interface ToolCallEvent extends ChatEventBase {
+  type: 'chat:tool-call';
+  turnId: string;
+  toolCallId: string;
+  toolName: string;
+  /** Human-readable description of what the tool is doing (Conductor-style) */
+  description: string;
+  input: Record<string, unknown>;
+  status: ToolCallStatus;
+}
+
+/** Streaming output from a running tool (e.g. bash stdout) */
+export interface ToolOutputDeltaEvent extends ChatEventBase {
+  type: 'chat:tool-output-delta';
+  turnId: string;
+  toolCallId: string;
+  delta: string;
+}
+
+/** Tool call completed (success or error) */
+export interface ToolResultEvent extends ChatEventBase {
+  type: 'chat:tool-result';
+  turnId: string;
+  toolCallId: string;
+  toolName: string;
+  status: ToolCallStatus;
+  output?: string;
+  exitCode?: number;
+  durationMs: number;
+  error?: string;
+}
+
+// Subset of FileChangeStatus from types.ts — omits 'untracked' (agents don't emit untracked-file events)
+export type FileChangeKind = 'added' | 'modified' | 'deleted' | 'renamed';
+
+/** File was created, modified, or deleted by the agent */
+export interface FileChangeEvent extends ChatEventBase {
+  type: 'chat:file-change';
+  turnId: string;
+  toolCallId: string;
+  path: string;
+  oldPath?: string;
+  kind: FileChangeKind;
+  additions: number;
+  deletions: number;
+  /** Unified diff content */
+  diff?: string;
+}
+
+// ── Approval Events ───────────────────────────────────────────────────────────
+
+export type ApprovalKind = 'command' | 'file' | 'permission' | 'mcp';
+
+/** Agent is requesting permission to perform an action */
+export interface ApprovalRequestEvent extends ChatEventBase {
+  type: 'chat:approval-request';
+  turnId: string;
+  requestId: string;
+  kind: ApprovalKind;
+  toolName: string;
+  description: string;
+  /** The command, file path, or resource being requested */
+  target: string;
+  /** Additional context (e.g. file contents, command arguments) */
+  detail?: string;
+  /** Auto-deny timeout in milliseconds (default: 300000 / 5min) */
+  timeoutMs?: number;
+}
+
+/** User's decision on an approval request */
+export interface ApprovalResponseEvent extends ChatEventBase {
+  type: 'chat:approval-response';
+  turnId: string;
+  requestId: string;
+  decision: 'allow' | 'allow-always' | 'deny';
+  respondedBy: 'user' | 'timeout';
+}
+
+export interface InputField {
+  id: string;
+  label: string;
+  type: 'text' | 'select' | 'multiselect' | 'confirm';
+  options?: string[];
+  defaultValue?: string | string[];
+}
+
+/** Agent is asking the user a question (structured form) */
+export interface InputRequestEvent extends ChatEventBase {
+  type: 'chat:input-request';
+  turnId: string;
+  requestId: string;
+  question: string;
+  fields: InputField[];
+}
+
+/** User's answers to an agent question */
+export interface InputResponseEvent extends ChatEventBase {
+  type: 'chat:input-response';
+  turnId: string;
+  requestId: string;
+  answers: Record<string, string[]>;
+}
+
+// ── Lifecycle Events ──────────────────────────────────────────────────────────
+
+/** Web session was created and agent is ready */
+export interface SessionStartedEvent extends ChatEventBase {
+  type: 'chat:session-started';
+  sessionId: string;
+  agentType: string;
+  model?: string;
+  /** Available slash commands from the agent */
+  availableCommands?: Array<{ name: string; description: string }>;
+}
+
+export type SessionStatusKind =
+  | 'idle'
+  | 'active'
+  | 'error'
+  | 'retry'
+  | 'disconnected';
+export type WaitingOn = 'user-input' | 'approval' | 'tool' | 'network';
+
+/** Agent session status changed */
+export interface SessionStatusEvent extends ChatEventBase {
+  type: 'chat:session-status';
+  status: SessionStatusKind;
+  waitingOn?: WaitingOn;
+  error?: string;
+}
+
+/** A new turn started (user sent a message) */
+export interface TurnStartedEvent extends ChatEventBase {
+  type: 'chat:turn-started';
+  turnId: string;
+  /** Index of this turn in the conversation (0-based) */
+  turnIndex: number;
+}
+
+export type TurnCompletionReason =
+  | 'completed'
+  | 'interrupted'
+  | 'failed'
+  | 'error';
+
+/** A turn finished */
+export interface TurnCompletedEvent extends ChatEventBase {
+  type: 'chat:turn-completed';
+  turnId: string;
+  reason: TurnCompletionReason;
+  durationMs: number;
+  toolCallCount: number;
+  messageCount: number;
+}
+
+export type ErrorKind =
+  | 'network'
+  | 'auth'
+  | 'rate-limit'
+  | 'timeout'
+  | 'protocol'
+  | 'unknown';
+
+/** An error occurred in the session */
+export interface ErrorEvent extends ChatEventBase {
+  type: 'chat:error';
+  kind: ErrorKind;
+  message: string;
+  retryable: boolean;
+  turnId?: string;
+}
+
+// ── Telemetry Events ──────────────────────────────────────────────────────────
+
+/** Token usage and cost information */
+export interface TelemetryEvent extends ChatEventBase {
+  type: 'chat:telemetry';
+  turnId?: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  costUsd: number | null;
+  contextPercent: number;
+  contextWindowSize: number;
+}
+
+/** Rate limit status */
+export interface RateLimitEvent extends ChatEventBase {
+  type: 'chat:rate-limit';
+  utilizationPercent: number;
+  resetsAt: string;
+  windowName: string;
+}
+
+// ── Union Type ────────────────────────────────────────────────────────────────
+
+export type ChatEvent =
+  | TextDeltaEvent
+  | MessageCompleteEvent
+  | ReasoningEvent
+  | CompactionEvent
+  | ToolCallEvent
+  | ToolOutputDeltaEvent
+  | ToolResultEvent
+  | FileChangeEvent
+  | ApprovalRequestEvent
+  | ApprovalResponseEvent
+  | InputRequestEvent
+  | InputResponseEvent
+  | SessionStartedEvent
+  | SessionStatusEvent
+  | TurnStartedEvent
+  | TurnCompletedEvent
+  | ErrorEvent
+  | TelemetryEvent
+  | RateLimitEvent;
+
+export type ChatEventType = ChatEvent['type'];
+
+// ── Type Guards ───────────────────────────────────────────────────────────────
+
+const VALID_SOURCES: ReadonlySet<string> = new Set([
+  'codex',
+  'opencode',
+  'claude',
+  'mock',
+]);
+
+const VALID_TYPES: ReadonlySet<string> = new Set([
+  'chat:text-delta',
+  'chat:message-complete',
+  'chat:reasoning',
+  'chat:compaction',
+  'chat:tool-call',
+  'chat:tool-output-delta',
+  'chat:tool-result',
+  'chat:file-change',
+  'chat:approval-request',
+  'chat:approval-response',
+  'chat:input-request',
+  'chat:input-response',
+  'chat:session-started',
+  'chat:session-status',
+  'chat:turn-started',
+  'chat:turn-completed',
+  'chat:error',
+  'chat:telemetry',
+  'chat:rate-limit',
+]);
+
+export function isChatEvent(event: unknown): event is ChatEvent {
+  return (
+    typeof event === 'object' &&
+    event !== null &&
+    typeof (event as ChatEventBase).sessionId === 'string' &&
+    typeof (event as ChatEventBase).timestamp === 'string' &&
+    typeof (event as { type?: unknown }).type === 'string' &&
+    VALID_TYPES.has((event as { type: string }).type) &&
+    VALID_SOURCES.has((event as ChatEventBase).source)
+  );
+}
+
+export function isApprovalRequestEvent(
+  e: ChatEvent
+): e is ApprovalRequestEvent {
+  return e.type === 'chat:approval-request';
+}
+
+export function isToolCallEvent(e: ChatEvent): e is ToolCallEvent {
+  return e.type === 'chat:tool-call';
+}
+
+export function isFileChangeEvent(e: ChatEvent): e is FileChangeEvent {
+  return e.type === 'chat:file-change';
+}
+
+export function isTelemetryEvent(e: ChatEvent): e is TelemetryEvent {
+  return e.type === 'chat:telemetry';
+}
+
+export function isLifecycleEvent(
+  e: ChatEvent
+): e is
+  | SessionStartedEvent
+  | SessionStatusEvent
+  | TurnStartedEvent
+  | TurnCompletedEvent {
+  return (
+    e.type === 'chat:session-started' ||
+    e.type === 'chat:session-status' ||
+    e.type === 'chat:turn-started' ||
+    e.type === 'chat:turn-completed'
+  );
+}

--- a/server/chat-events.ts
+++ b/server/chat-events.ts
@@ -6,7 +6,7 @@
 // All agent backends (Codex, OpenCode, Claude Code) map their native protocol
 // messages into this canonical type system via ProtocolAdapters.
 
-export type ChatEventSource = 'codex' | 'opencode' | 'claude' | 'mock';
+export type ChatEventSource = 'codex' | 'opencode' | 'claude';
 
 export interface ChatEventBase {
   sessionId: string;
@@ -290,7 +290,6 @@ const VALID_SOURCES: ReadonlySet<string> = new Set([
   'codex',
   'opencode',
   'claude',
-  'mock',
 ]);
 
 const VALID_TYPES: ReadonlySet<string> = new Set([

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -109,7 +109,9 @@ function setAgentState(
 ): void {
   session.agentState = state;
   deps.fireBackendStateIfChanged(session);
-  session._lastHookTime = Date.now();
+  if (session.mode === 'pty') {
+    session._lastHookTime = Date.now();
+  }
 
   // Check for branch changes on meaningful pauses (agent stopped or waiting for user)
   if (
@@ -181,6 +183,13 @@ function createAgentEventHandler(deps: HookDeps) {
       return;
     }
 
+    if (session.mode !== 'pty') {
+      res
+        .status(400)
+        .json({ error: 'Hooks are only supported for PTY sessions' });
+      return;
+    }
+
     if (session.hookToken !== token) {
       res.status(401).json({ error: 'Invalid token' });
       return;
@@ -225,7 +234,9 @@ async function spawnBranchRename(
   deps: HookDeps
 ): Promise<void> {
   const cleanedPrompt = stripAnsi(promptText).slice(0, 500);
-  const renamePrompt = session.branchRenamePrompt ?? DEFAULT_RENAME_PROMPT;
+  const renamePrompt =
+    (session.mode === 'pty' ? session.branchRenamePrompt : undefined) ??
+    DEFAULT_RENAME_PROMPT;
   const fullPrompt = renamePrompt + '\n\n' + cleanedPrompt;
   const env = cleanEnv();
 
@@ -340,6 +351,12 @@ export function createHooksRouter(deps: HookDeps): Router {
     const session = deps.getSession(sessionId);
     if (!session) {
       res.status(404).json({ error: 'Session not found' });
+      return;
+    }
+    if (session.mode !== 'pty') {
+      res
+        .status(400)
+        .json({ error: 'Hooks are only supported for PTY sessions' });
       return;
     }
     const tokenBuf = Buffer.from(token);

--- a/server/index.ts
+++ b/server/index.ts
@@ -1161,6 +1161,7 @@ async function main(): Promise<void> {
       if (session && session.type !== 'terminal') {
         // Dedup: if hooks fired an attention notification within last 10s, skip
         if (
+          session.mode === 'pty' &&
           session.hooksActive &&
           session.lastAttentionNotifiedAt &&
           Date.now() - session.lastAttentionNotifiedAt < 10000

--- a/server/protocol-adapter.ts
+++ b/server/protocol-adapter.ts
@@ -143,8 +143,11 @@ export abstract class BaseProtocolAdapter implements ProtocolAdapter {
    * override this method; implement onDisconnect() instead so cleanup is guaranteed.
    */
   async disconnect(): Promise<void> {
-    await this.onDisconnect();
-    this.handlers.clear();
+    try {
+      await this.onDisconnect();
+    } finally {
+      this.handlers.clear();
+    }
   }
 
   /** Subclass hook: tear down connections and release resources before handlers are cleared */

--- a/server/protocol-adapter.ts
+++ b/server/protocol-adapter.ts
@@ -1,0 +1,195 @@
+// ProtocolAdapter — the core abstraction for the unified web chat interface.
+// Each agent backend (Codex, OpenCode, Claude Code) implements this interface
+// to normalize their native protocol into the canonical ChatEvent type system.
+//
+// relay-ide server is the proxy — browsers never talk to agent backends directly.
+// Adapters connect to agent processes/servers and emit ChatEvents over the event bus.
+
+import { createLogger } from './logger.js';
+import type { ChatEvent } from './chat-events.js';
+
+const logger = createLogger('protocol-adapter');
+
+export interface AdapterConfig {
+  /** Working directory for the agent session */
+  cwd: string;
+  /** relay-ide server port (for hooks callbacks) */
+  port: number;
+  /** Relay session ID (ties adapter to WebSession) */
+  sessionId: string;
+  /** Token for authenticating inbound hook callbacks */
+  hookToken: string;
+  /** relay-ide config directory path */
+  configDir: string;
+  /** Agent permission mode (e.g. 'default' | 'acceptEdits' | 'bypassPermissions') */
+  permissionMode?: string;
+  /** Model override (e.g. 'claude-opus-4-6') */
+  model?: string;
+  /** Additional agent-specific configuration */
+  extra?: Record<string, unknown>;
+}
+
+export interface SessionOptions {
+  /** Resume an existing agent session by ID */
+  resumeSessionId?: string;
+  /** Additional context dirs to include in the agent's workspace */
+  additionalDirs?: string[];
+  /** Custom system prompt override */
+  systemPrompt?: string;
+}
+
+export interface Attachment {
+  type: 'file' | 'image' | 'url';
+  /** File path (for file/image) or URL (for url) */
+  path: string;
+  /** MIME type (optional, detected if omitted) */
+  mimeType?: string;
+}
+
+export type AdapterStatus =
+  | 'disconnected'
+  | 'connecting'
+  | 'connected'
+  | 'error';
+
+/** Handler for ChatEvents emitted by the adapter */
+export type ChatEventHandler = (event: ChatEvent) => void;
+
+/**
+ * ProtocolAdapter — implemented by each agent backend.
+ *
+ * Lifecycle: disconnected → connect() → connected → disconnect() → disconnected
+ * Reconnect is supported via reconnect() which reuses existing config.
+ */
+export interface ProtocolAdapter {
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  /** Connect to the agent backend and start the session */
+  connect(config: AdapterConfig): Promise<void>;
+
+  /** Gracefully disconnect and clean up resources */
+  disconnect(): Promise<void>;
+
+  /** Reconnect after a connection drop (reuses existing config) */
+  reconnect(): Promise<void>;
+
+  // ── User Actions ──────────────────────────────────────────────────────────
+
+  /**
+   * Send a user message to the agent to start a new turn.
+   * Emits TurnStartedEvent, then streaming content events.
+   */
+  sendMessage(
+    turnId: string,
+    content: string,
+    attachments?: Attachment[]
+  ): Promise<void>;
+
+  /** Interrupt the currently active turn */
+  interrupt(turnId: string): Promise<void>;
+
+  /** Respond to a pending approval request */
+  respondToApproval(
+    requestId: string,
+    decision: 'allow' | 'allow-always' | 'deny'
+  ): Promise<void>;
+
+  /** Respond to a structured input request from the agent */
+  respondToInput(
+    requestId: string,
+    answers: Record<string, string[]>
+  ): Promise<void>;
+
+  // ── Session Management ────────────────────────────────────────────────────
+
+  /** Create a new agent session in the given directory */
+  createSession(cwd: string, options?: SessionOptions): Promise<string>;
+
+  /** Resume an existing agent session */
+  resumeSession(sessionId: string): Promise<void>;
+
+  /** Fork the current session (returns new session ID) */
+  forkSession(sessionId: string): Promise<string>;
+
+  // ── Events ────────────────────────────────────────────────────────────────
+
+  /**
+   * Register a handler for ChatEvents emitted by this adapter.
+   * Returns an unsubscribe function.
+   */
+  on(handler: ChatEventHandler): () => void;
+
+  // ── State ─────────────────────────────────────────────────────────────────
+
+  /** Current connection status */
+  readonly status: AdapterStatus;
+
+  /** Agent type identifier (e.g. 'codex', 'opencode', 'claude', 'mock') */
+  readonly agentType: string;
+}
+
+/**
+ * Base class for ProtocolAdapter implementations.
+ * Handles event subscription management — subclasses call emit() to fire events.
+ */
+export abstract class BaseProtocolAdapter implements ProtocolAdapter {
+  private readonly handlers = new Set<ChatEventHandler>();
+
+  abstract connect(config: AdapterConfig): Promise<void>;
+
+  /**
+   * Gracefully disconnect and clean up resources.
+   * Calls onDisconnect() then clears all event handlers — subclasses must not
+   * override this method; implement onDisconnect() instead so cleanup is guaranteed.
+   */
+  async disconnect(): Promise<void> {
+    await this.onDisconnect();
+    this.handlers.clear();
+  }
+
+  /** Subclass hook: tear down connections and release resources before handlers are cleared */
+  protected abstract onDisconnect(): Promise<void>;
+
+  abstract reconnect(): Promise<void>;
+  abstract sendMessage(
+    turnId: string,
+    content: string,
+    attachments?: Attachment[]
+  ): Promise<void>;
+  abstract interrupt(turnId: string): Promise<void>;
+  abstract respondToApproval(
+    requestId: string,
+    decision: 'allow' | 'allow-always' | 'deny'
+  ): Promise<void>;
+  abstract respondToInput(
+    requestId: string,
+    answers: Record<string, string[]>
+  ): Promise<void>;
+  abstract createSession(
+    cwd: string,
+    options?: SessionOptions
+  ): Promise<string>;
+  abstract resumeSession(sessionId: string): Promise<void>;
+  abstract forkSession(sessionId: string): Promise<string>;
+  abstract readonly status: AdapterStatus;
+  abstract readonly agentType: string;
+
+  on(handler: ChatEventHandler): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  protected emit(event: ChatEvent): void {
+    // Snapshot to prevent issues if a handler adds/removes subscribers during dispatch
+    for (const handler of [...this.handlers]) {
+      try {
+        handler(event);
+      } catch (err) {
+        // Prevent one bad handler from breaking the event pipeline
+        logger.error(`[${this.agentType}] ChatEvent handler error:`, err);
+      }
+    }
+  }
+}

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -355,17 +355,20 @@ function list(): SessionSummary[] {
         lastActivity: s.lastActivity,
         idle: s.idle,
         customCommand: s.customCommand,
-        useTmux: s.useTmux,
-        tmuxSessionName: s.tmuxSessionName,
         status: s.status,
         needsBranchRename: !!s.needsBranchRename,
         agentState: s.agentState,
         currentActivity: s.currentActivity,
+        ...(s.mode === 'pty'
+          ? { useTmux: s.useTmux, tmuxSessionName: s.tmuxSessionName }
+          : {}),
         ...(s.workspaceId ? { workspaceId: s.workspaceId } : {}),
         ...(s.additionalDirs?.length
           ? { additionalDirs: s.additionalDirs }
           : {}),
-        ...(s.dataQuality !== undefined ? { dataQuality: s.dataQuality } : {}),
+        ...(s.mode === 'pty' && s.dataQuality !== undefined
+          ? { dataQuality: s.dataQuality }
+          : {}),
         ...(s._lastEmittedPermissionType !== undefined
           ? { permissionType: s._lastEmittedPermissionType }
           : {}),
@@ -389,13 +392,31 @@ function kill(id: string): void {
   if (!session) {
     throw new Error(`Session not found: ${id}`);
   }
-  try {
-    session.pty.kill('SIGTERM');
-  } catch {
-    // PTY may already be dead (e.g. disconnected sessions) — still delete from registry
-  }
-  if (session.tmuxSessionName) {
-    execFile('tmux', ['kill-session', '-t', session.tmuxSessionName], () => {});
+  if (session.mode === 'pty') {
+    try {
+      session.pty.kill('SIGTERM');
+    } catch {
+      // PTY may already be dead (e.g. disconnected sessions) — still delete from registry
+    }
+    if (session.tmuxSessionName) {
+      execFile(
+        'tmux',
+        ['kill-session', '-t', session.tmuxSessionName],
+        () => {}
+      );
+    }
+  } else {
+    // Web session: disconnect adapter (tears down network connections and event handlers)
+    session.adapter.disconnect().catch(() => {
+      // Adapter may already be disconnected — still proceed with cleanup
+    });
+    if (session.process) {
+      try {
+        session.process.kill('SIGTERM');
+      } catch {
+        /* may already be dead */
+      }
+    }
   }
   const durationS = Math.round(
     (Date.now() - new Date(session.createdAt).getTime()) / 1000
@@ -415,7 +436,11 @@ function kill(id: string): void {
   fireSessionEnd(id, session.cwd, session.branchName);
 
   // Clean up codex hooks adapter temp directory to avoid leaking temp files
-  if (session.agent === 'codex' && session.hooksActive) {
+  if (
+    session.mode === 'pty' &&
+    session.agent === 'codex' &&
+    session.hooksActive
+  ) {
     cleanupCodexHooksAdapter(id);
   }
 
@@ -424,7 +449,7 @@ function kill(id: string): void {
 
 function killAllTmuxSessions(): void {
   for (const session of sessions.values()) {
-    if (session.tmuxSessionName) {
+    if (session.mode === 'pty' && session.tmuxSessionName) {
       execFile(
         'tmux',
         ['kill-session', '-t', session.tmuxSessionName],
@@ -439,7 +464,11 @@ function resize(id: string, cols: number, rows: number): void {
   if (!session) {
     throw new Error(`Session not found: ${id}`);
   }
-  session.pty.resize(cols, rows);
+  if (session.mode === 'pty') {
+    session.pty.resize(cols, rows);
+  } else {
+    logger.warn(`resize() called on web session ${id} — no-op`);
+  }
 }
 
 function write(id: string, data: string): void {
@@ -447,7 +476,11 @@ function write(id: string, data: string): void {
   if (!session) {
     throw new Error(`Session not found: ${id}`);
   }
-  session.pty.write(data);
+  if (session.mode === 'pty') {
+    session.pty.write(data);
+  } else {
+    logger.warn(`write() called on web session ${id} — no-op`);
+  }
 }
 
 function nextTerminalName(): string {
@@ -465,41 +498,44 @@ function serializeAll(configDir: string): void {
   const serializedPty: SerializedPtySession[] = [];
 
   for (const session of sessions.values()) {
-    // Write scrollback to disk
-    const scrollbackPath = path.join(scrollbackDirPath, session.id + '.buf');
-    fs.writeFileSync(scrollbackPath, session.scrollback.join(''), 'utf-8');
+    // Web sessions are not persisted across restarts (adapter state is transient)
+    if (session.mode === 'pty') {
+      // Write scrollback to disk
+      const scrollbackPath = path.join(scrollbackDirPath, session.id + '.buf');
+      fs.writeFileSync(scrollbackPath, session.scrollback.join(''), 'utf-8');
 
-    serializedPty.push({
-      id: session.id,
-      type: session.type,
-      agent: session.agent,
-      repoPath: session.repoPath,
-      worktreePath: session.worktreePath,
-      cwd: session.cwd,
-      repoName: session.repoName,
-      branchName: session.branchName,
-      displayName: session.displayName,
-      createdAt: session.createdAt,
-      lastActivity: session.lastActivity,
-      useTmux: session.useTmux,
-      tmuxSessionName: session.tmuxSessionName || '',
-      customCommand: session.customCommand,
-      yolo: session.yolo,
-      claudeArgs: session.sessionArgs ?? session.claudeArgs,
-      hookToken: session.hookToken,
-      hooksActive: session.hooksActive,
-      continuePolicy: session.continuePolicy,
-      ...(session.needsBranchRename
-        ? { needsBranchRename: true as const }
-        : {}),
-      ...(session.branchRenamePrompt
-        ? { branchRenamePrompt: session.branchRenamePrompt }
-        : {}),
-      ...(session.workspaceId ? { workspaceId: session.workspaceId } : {}),
-      ...(session.additionalDirs?.length
-        ? { additionalDirs: session.additionalDirs }
-        : {}),
-    });
+      serializedPty.push({
+        id: session.id,
+        type: session.type,
+        agent: session.agent,
+        repoPath: session.repoPath,
+        worktreePath: session.worktreePath,
+        cwd: session.cwd,
+        repoName: session.repoName,
+        branchName: session.branchName,
+        displayName: session.displayName,
+        createdAt: session.createdAt,
+        lastActivity: session.lastActivity,
+        useTmux: session.useTmux,
+        tmuxSessionName: session.tmuxSessionName || '',
+        customCommand: session.customCommand,
+        yolo: session.yolo,
+        claudeArgs: session.sessionArgs ?? session.claudeArgs,
+        hookToken: session.hookToken,
+        hooksActive: session.hooksActive,
+        continuePolicy: session.continuePolicy,
+        ...(session.needsBranchRename
+          ? { needsBranchRename: true as const }
+          : {}),
+        ...(session.branchRenamePrompt
+          ? { branchRenamePrompt: session.branchRenamePrompt }
+          : {}),
+        ...(session.workspaceId ? { workspaceId: session.workspaceId } : {}),
+        ...(session.additionalDirs?.length
+          ? { additionalDirs: session.additionalDirs }
+          : {}),
+      });
+    }
   }
 
   const pending: PendingSessionsFile = {
@@ -786,7 +822,8 @@ async function restoreFromDisk(
 function activeTmuxSessionNames(): Set<string> {
   const names = new Set<string>();
   for (const session of sessions.values()) {
-    if (session.tmuxSessionName) names.add(session.tmuxSessionName);
+    if (session.mode === 'pty' && session.tmuxSessionName)
+      names.add(session.tmuxSessionName);
   }
   return names;
 }

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,5 +1,8 @@
 import type { IPty } from 'node-pty';
+import type { ChildProcess } from 'node:child_process'; // used by WebSession.process
 import type { OutputParser } from './output-parsers/index.js';
+import type { ProtocolAdapter } from './protocol-adapter.js';
+import type { ChatEvent } from './chat-events.js';
 
 export type AgentState =
   | 'initializing'
@@ -22,7 +25,7 @@ export type EventSourceType = 'hooks' | 'plugin' | 'parser' | 'timer';
 export type ContinuePolicy = 'always' | 'never';
 export type BranchLifecycleState = 'active' | 'stale' | 'merged';
 export type SessionStatus = 'active' | 'disconnected';
-export type SessionMode = 'pty';
+export type SessionMode = 'pty' | 'web';
 
 // ── Agent Framework Registry ──
 
@@ -206,6 +209,11 @@ interface BaseSession {
   agentState: AgentState;
   workspaceId?: string;
   additionalDirs?: string[];
+  // Shared mutable state (used by both PTY and web sessions)
+  currentActivity?: { tool: string; detail?: string } | undefined;
+  _lastEmittedBackendState?: BackendDisplayState | undefined;
+  _lastEmittedPermissionType?: 'approval' | 'question' | undefined;
+  lastAttentionNotifiedAt?: number | undefined;
 }
 
 export interface PtySession extends BaseSession {
@@ -223,10 +231,6 @@ export interface PtySession extends BaseSession {
   hooksActive: boolean;
   cleanedUp: boolean;
   _lastHookTime?: number | undefined;
-  _lastEmittedBackendState?: BackendDisplayState | undefined;
-  _lastEmittedPermissionType?: 'approval' | 'question' | undefined;
-  lastAttentionNotifiedAt?: number | undefined;
-  currentActivity?: { tool: string; detail?: string } | undefined;
   yolo: boolean;
   /** Framework-specific args (replaces deprecated claudeArgs) */
   sessionArgs?: string[];
@@ -237,7 +241,30 @@ export interface PtySession extends BaseSession {
   dataQuality?: EventSourceType;
 }
 
-export type Session = PtySession;
+export interface WebSession extends BaseSession {
+  mode: 'web';
+  /** Active protocol adapter for this agent backend */
+  adapter: ProtocolAdapter;
+  /**
+   * Agent type identifier (matches AgentFramework.id, e.g. 'codex' | 'opencode' | 'claude').
+   * Mirrors adapter.agentType — kept as a plain field so session summaries and logs
+   * can reference it without dereferencing the adapter object.
+   */
+  adapterType: string;
+  /**
+   * In-memory event buffer for replay on reconnect.
+   * Cap: 1000 events, FIFO eviction (approval events never dropped).
+   * TODO(PR#213): Enforce the cap when adapters start pushing events — use a bounded
+   * buffer helper rather than raw array push to guarantee the eviction policy.
+   */
+  messages: ChatEvent[];
+  /** Currently active turn ID, or null when idle */
+  currentTurnId: string | null;
+  /** Spawned agent subprocess (codex app-server, opencode serve, claude subprocess) */
+  process?: ChildProcess;
+}
+
+export type Session = PtySession | WebSession;
 
 // Summary type for REST API responses (no internal handles)
 export interface SessionSummary {
@@ -255,14 +282,17 @@ export interface SessionSummary {
   lastActivity: string;
   idle: boolean;
   customCommand: string | null;
-  useTmux: boolean;
-  tmuxSessionName: string;
+  /** PTY sessions only */
+  useTmux?: boolean;
+  /** PTY sessions only */
+  tmuxSessionName?: string;
   status: SessionStatus;
   needsBranchRename: boolean;
   agentState: AgentState;
   currentActivity?: { tool: string; detail?: string } | undefined;
   workspaceId?: string;
   additionalDirs?: string[];
+  /** PTY sessions only — tracks data quality of telemetry source */
   dataQuality?: EventSourceType;
   /** Tracks whether permission-prompt is for approval or question — preserves needs-answer state across refresh */
   permissionType?: 'approval' | 'question';

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -129,70 +129,78 @@ function setupWebSocket(
     const session = sessionMap.get(ws);
     if (!session) return;
 
-    let dataDisposable: { dispose(): void } | null = null;
-    let exitDisposable: { dispose(): void } | null = null;
+    if (session.mode === 'pty') {
+      let dataDisposable: { dispose(): void } | null = null;
+      let exitDisposable: { dispose(): void } | null = null;
 
-    const attachToPty = (ptyProcess: IPty): void => {
-      // Dispose previous handlers
-      dataDisposable?.dispose();
-      exitDisposable?.dispose();
+      const attachToPty = (ptyProcess: IPty): void => {
+        // Dispose previous handlers
+        dataDisposable?.dispose();
+        exitDisposable?.dispose();
 
-      // Replay scrollback
-      for (const chunk of session.scrollback) {
-        if (ws.readyState === ws.OPEN) ws.send(chunk);
-      }
-
-      dataDisposable = ptyProcess.onData((data) => {
-        if (ws.readyState === ws.OPEN) ws.send(data);
-      });
-
-      exitDisposable = ptyProcess.onExit(() => {
-        if (ws.readyState === ws.OPEN) ws.close(1000);
-      });
-    };
-
-    attachToPty(session.pty);
-
-    const ptyReplacedHandler = (newPty: IPty) => attachToPty(newPty);
-    session.onPtyReplacedCallbacks.push(ptyReplacedHandler);
-
-    let lastActivityBroadcast = 0;
-
-    ws.on('message', (msg) => {
-      const str = msg.toString();
-      try {
-        const parsed = JSON.parse(str);
-        if (parsed.type === 'ping') {
-          replyPing(ws);
-          return;
+        // Replay scrollback
+        for (const chunk of session.scrollback) {
+          if (ws.readyState === ws.OPEN) ws.send(chunk);
         }
-        if (parsed.type === 'resize' && parsed.cols && parsed.rows) {
-          sessions.resize(session.id, parsed.cols, parsed.rows);
-          return;
-        }
-      } catch (_) {
-        // ignore
-      }
-      // Use session.pty dynamically so writes go to current PTY
-      session.pty.write(str);
-      // Update activity timestamp on user input (throttled broadcast to avoid storm)
-      const now = Date.now();
-      session.lastActivity = new Date(now).toISOString();
-      if (now - lastActivityBroadcast >= 2000) {
-        lastActivityBroadcast = now;
-        broadcastEvent('session-activity-changed', {
-          sessionId: session.id,
-          timestamp: session.lastActivity,
+
+        dataDisposable = ptyProcess.onData((data) => {
+          if (ws.readyState === ws.OPEN) ws.send(data);
         });
-      }
-    });
 
-    ws.on('close', () => {
-      dataDisposable?.dispose();
-      exitDisposable?.dispose();
-      const idx = session.onPtyReplacedCallbacks.indexOf(ptyReplacedHandler);
-      if (idx !== -1) session.onPtyReplacedCallbacks.splice(idx, 1);
-    });
+        exitDisposable = ptyProcess.onExit(() => {
+          if (ws.readyState === ws.OPEN) ws.close(1000);
+        });
+      };
+
+      attachToPty(session.pty);
+
+      const ptyReplacedHandler = (newPty: IPty) => attachToPty(newPty);
+      session.onPtyReplacedCallbacks.push(ptyReplacedHandler);
+
+      let lastActivityBroadcast = 0;
+
+      ws.on('message', (msg) => {
+        const str = msg.toString();
+        try {
+          const parsed = JSON.parse(str);
+          if (parsed.type === 'ping') {
+            replyPing(ws);
+            return;
+          }
+          if (parsed.type === 'resize' && parsed.cols && parsed.rows) {
+            sessions.resize(session.id, parsed.cols, parsed.rows);
+            return;
+          }
+        } catch (_) {
+          // ignore
+        }
+        // Use session.pty dynamically so writes go to current PTY
+        session.pty.write(str);
+        // Update activity timestamp on user input (throttled broadcast to avoid storm)
+        const now = Date.now();
+        session.lastActivity = new Date(now).toISOString();
+        if (now - lastActivityBroadcast >= 2000) {
+          lastActivityBroadcast = now;
+          broadcastEvent('session-activity-changed', {
+            sessionId: session.id,
+            timestamp: session.lastActivity,
+          });
+        }
+      });
+
+      ws.on('close', () => {
+        dataDisposable?.dispose();
+        exitDisposable?.dispose();
+        const idx = session.onPtyReplacedCallbacks.indexOf(ptyReplacedHandler);
+        if (idx !== -1) session.onPtyReplacedCallbacks.splice(idx, 1);
+      });
+    } else {
+      // Web session — JSON relay will be wired by web-session-handler.ts (PR #213)
+      // Register a close handler now to avoid leaking the sessionMap entry
+      ws.on('close', () => {
+        sessionMap.delete(ws);
+      });
+    }
   });
 
   sessions.onBackendStateChange((sessionId, state, permissionType) => {

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -188,18 +188,21 @@ function setupWebSocket(
         }
       });
 
-      ws.on('close', () => {
+      const cleanup = () => {
         dataDisposable?.dispose();
         exitDisposable?.dispose();
         const idx = session.onPtyReplacedCallbacks.indexOf(ptyReplacedHandler);
         if (idx !== -1) session.onPtyReplacedCallbacks.splice(idx, 1);
-      });
+      };
+      ws.on('close', cleanup);
+      ws.on('error', cleanup);
     } else {
       // Web session — JSON relay will be wired by web-session-handler.ts (PR #213)
-      // Register a close handler now to avoid leaking the sessionMap entry
-      ws.on('close', () => {
+      const cleanup = () => {
         sessionMap.delete(ws);
-      });
+      };
+      ws.on('close', cleanup);
+      ws.on('error', cleanup);
     }
   });
 

--- a/test/chat-events.test.ts
+++ b/test/chat-events.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isChatEvent,
+  isApprovalRequestEvent,
+  isToolCallEvent,
+  isFileChangeEvent,
+  isTelemetryEvent,
+  isLifecycleEvent,
+} from '../server/chat-events.js';
+import type {
+  ChatEvent,
+  TextDeltaEvent,
+  ToolCallEvent,
+  ApprovalRequestEvent,
+  FileChangeEvent,
+  TelemetryEvent,
+  SessionStartedEvent,
+  TurnStartedEvent,
+  TurnCompletedEvent,
+  SessionStatusEvent,
+  ErrorEvent,
+} from '../server/chat-events.js';
+
+const BASE = {
+  sessionId: 'test-session',
+  timestamp: new Date().toISOString(),
+  source: 'mock' as const,
+};
+
+function makeTextDelta(overrides?: Partial<TextDeltaEvent>): TextDeltaEvent {
+  return {
+    ...BASE,
+    type: 'chat:text-delta',
+    turnId: 'turn-1',
+    messageId: 'msg-1',
+    delta: 'hello',
+    ...overrides,
+  };
+}
+
+function makeToolCall(overrides?: Partial<ToolCallEvent>): ToolCallEvent {
+  return {
+    ...BASE,
+    type: 'chat:tool-call',
+    turnId: 'turn-1',
+    toolCallId: 'tool-1',
+    toolName: 'Read',
+    description: 'Reading server/index.ts',
+    input: { file_path: 'server/index.ts' },
+    status: 'running',
+    ...overrides,
+  };
+}
+
+function makeApprovalRequest(
+  overrides?: Partial<ApprovalRequestEvent>
+): ApprovalRequestEvent {
+  return {
+    ...BASE,
+    type: 'chat:approval-request',
+    turnId: 'turn-1',
+    requestId: 'req-1',
+    kind: 'command',
+    toolName: 'Bash',
+    description: 'Run git status',
+    target: 'git status',
+    ...overrides,
+  };
+}
+
+function makeFileChange(overrides?: Partial<FileChangeEvent>): FileChangeEvent {
+  return {
+    ...BASE,
+    type: 'chat:file-change',
+    turnId: 'turn-1',
+    toolCallId: 'tool-1',
+    path: 'server/index.ts',
+    kind: 'modified',
+    additions: 5,
+    deletions: 2,
+    ...overrides,
+  };
+}
+
+function makeTelemetry(overrides?: Partial<TelemetryEvent>): TelemetryEvent {
+  return {
+    ...BASE,
+    type: 'chat:telemetry',
+    model: 'claude-sonnet-4-6',
+    inputTokens: 1000,
+    outputTokens: 200,
+    cacheReadTokens: 500,
+    cacheWriteTokens: 100,
+    costUsd: 0.01,
+    contextPercent: 12,
+    contextWindowSize: 200000,
+    ...overrides,
+  };
+}
+
+function makeSessionStarted(
+  overrides?: Partial<SessionStartedEvent>
+): SessionStartedEvent {
+  return {
+    ...BASE,
+    type: 'chat:session-started',
+    sessionId: 'test-session',
+    agentType: 'mock',
+    ...overrides,
+  };
+}
+
+describe('isChatEvent', () => {
+  it('returns true for valid ChatEvent objects', () => {
+    expect(isChatEvent(makeTextDelta())).toBe(true);
+    expect(isChatEvent(makeToolCall())).toBe(true);
+    expect(isChatEvent(makeApprovalRequest())).toBe(true);
+    expect(isChatEvent(makeTelemetry())).toBe(true);
+  });
+
+  it('returns false for null and primitives', () => {
+    expect(isChatEvent(null)).toBe(false);
+    expect(isChatEvent(undefined)).toBe(false);
+    expect(isChatEvent('string')).toBe(false);
+    expect(isChatEvent(42)).toBe(false);
+  });
+
+  it('returns false for objects missing required fields', () => {
+    expect(isChatEvent({})).toBe(false);
+    expect(isChatEvent({ sessionId: 'x', timestamp: 'y' })).toBe(false);
+    expect(
+      isChatEvent({ type: 'not-chat-type', sessionId: 'x', timestamp: 'y' })
+    ).toBe(false);
+  });
+
+  it('requires type to be a known ChatEvent type with valid source', () => {
+    // non-chat: prefix fails
+    expect(
+      isChatEvent({
+        type: 'session.started',
+        sessionId: 'x',
+        timestamp: 'y',
+        source: 'mock',
+      })
+    ).toBe(false);
+    // known type + valid source passes
+    expect(
+      isChatEvent({
+        type: 'chat:text-delta',
+        sessionId: 'x',
+        timestamp: 'y',
+        source: 'mock',
+      })
+    ).toBe(true);
+    // chat: prefix but unknown type fails (stricter than prefix-only check)
+    expect(
+      isChatEvent({
+        type: 'chat:nonexistent',
+        sessionId: 'x',
+        timestamp: 'y',
+        source: 'mock',
+      })
+    ).toBe(false);
+    // invalid source fails even with valid type
+    expect(
+      isChatEvent({
+        type: 'chat:text-delta',
+        sessionId: 'x',
+        timestamp: 'y',
+        source: 'unknown',
+      })
+    ).toBe(false);
+    // missing source fails
+    expect(
+      isChatEvent({ type: 'chat:text-delta', sessionId: 'x', timestamp: 'y' })
+    ).toBe(false);
+  });
+});
+
+describe('isApprovalRequestEvent', () => {
+  it('returns true only for approval-request events', () => {
+    const approval = makeApprovalRequest();
+    expect(isApprovalRequestEvent(approval)).toBe(true);
+  });
+
+  it('returns false for other event types', () => {
+    const events: ChatEvent[] = [
+      makeTextDelta(),
+      makeToolCall(),
+      makeFileChange(),
+      makeTelemetry(),
+    ];
+    for (const e of events) {
+      expect(isApprovalRequestEvent(e)).toBe(false);
+    }
+  });
+
+  it('enables narrowing to ApprovalRequestEvent fields', () => {
+    const e: ChatEvent = makeApprovalRequest({
+      kind: 'file',
+      target: '/etc/hosts',
+    });
+    if (isApprovalRequestEvent(e)) {
+      expect(e.kind).toBe('file');
+      expect(e.target).toBe('/etc/hosts');
+      expect(e.requestId).toBe('req-1');
+    } else {
+      throw new Error('Expected type guard to be true');
+    }
+  });
+});
+
+describe('isToolCallEvent', () => {
+  it('returns true only for tool-call events', () => {
+    expect(isToolCallEvent(makeToolCall())).toBe(true);
+  });
+
+  it('returns false for other event types', () => {
+    expect(isToolCallEvent(makeTextDelta())).toBe(false);
+    expect(isToolCallEvent(makeApprovalRequest())).toBe(false);
+  });
+
+  it('enables narrowing to ToolCallEvent fields', () => {
+    const e: ChatEvent = makeToolCall({
+      toolName: 'Bash',
+      status: 'completed',
+    });
+    if (isToolCallEvent(e)) {
+      expect(e.toolName).toBe('Bash');
+      expect(e.status).toBe('completed');
+      expect(e.toolCallId).toBe('tool-1');
+    } else {
+      throw new Error('Expected type guard to be true');
+    }
+  });
+});
+
+describe('isFileChangeEvent', () => {
+  it('returns true only for file-change events', () => {
+    expect(isFileChangeEvent(makeFileChange())).toBe(true);
+  });
+
+  it('returns false for other event types', () => {
+    expect(isFileChangeEvent(makeTextDelta())).toBe(false);
+    expect(isFileChangeEvent(makeToolCall())).toBe(false);
+  });
+
+  it('enables narrowing to FileChangeEvent fields', () => {
+    const e: ChatEvent = makeFileChange({
+      path: 'server/ws.ts',
+      kind: 'added',
+      additions: 10,
+    });
+    if (isFileChangeEvent(e)) {
+      expect(e.path).toBe('server/ws.ts');
+      expect(e.kind).toBe('added');
+      expect(e.additions).toBe(10);
+    } else {
+      throw new Error('Expected type guard to be true');
+    }
+  });
+});
+
+describe('isTelemetryEvent', () => {
+  it('returns true only for telemetry events', () => {
+    expect(isTelemetryEvent(makeTelemetry())).toBe(true);
+  });
+
+  it('returns false for other event types', () => {
+    expect(isTelemetryEvent(makeTextDelta())).toBe(false);
+    expect(isTelemetryEvent(makeToolCall())).toBe(false);
+  });
+
+  it('enables narrowing to TelemetryEvent fields', () => {
+    const e: ChatEvent = makeTelemetry({ costUsd: 0.05, inputTokens: 5000 });
+    if (isTelemetryEvent(e)) {
+      expect(e.costUsd).toBe(0.05);
+      expect(e.inputTokens).toBe(5000);
+      expect(e.model).toBe('claude-sonnet-4-6');
+    } else {
+      throw new Error('Expected type guard to be true');
+    }
+  });
+});
+
+describe('isLifecycleEvent', () => {
+  const lifecycleEvents: ChatEvent[] = [
+    makeSessionStarted(),
+    {
+      ...BASE,
+      type: 'chat:session-status',
+      status: 'idle',
+    } satisfies SessionStatusEvent,
+    {
+      ...BASE,
+      type: 'chat:turn-started',
+      turnId: 'turn-1',
+      turnIndex: 0,
+    } satisfies TurnStartedEvent,
+    {
+      ...BASE,
+      type: 'chat:turn-completed',
+      turnId: 'turn-1',
+      reason: 'completed',
+      durationMs: 5000,
+      toolCallCount: 3,
+      messageCount: 1,
+    } satisfies TurnCompletedEvent,
+  ];
+
+  it('returns true for all lifecycle event types', () => {
+    for (const e of lifecycleEvents) {
+      expect(isLifecycleEvent(e)).toBe(true);
+    }
+  });
+
+  it('returns false for non-lifecycle events', () => {
+    const nonLifecycle: ChatEvent[] = [
+      makeTextDelta(),
+      makeToolCall(),
+      makeApprovalRequest(),
+      makeFileChange(),
+      makeTelemetry(),
+      {
+        ...BASE,
+        type: 'chat:error',
+        kind: 'network',
+        message: 'timeout',
+        retryable: true,
+      } satisfies ErrorEvent,
+    ];
+    for (const e of nonLifecycle) {
+      expect(isLifecycleEvent(e)).toBe(false);
+    }
+  });
+});
+
+describe('ChatEvent discriminated union', () => {
+  it('all 19 event types have distinct type literals', () => {
+    const types = [
+      'chat:text-delta',
+      'chat:message-complete',
+      'chat:reasoning',
+      'chat:compaction',
+      'chat:tool-call',
+      'chat:tool-output-delta',
+      'chat:tool-result',
+      'chat:file-change',
+      'chat:approval-request',
+      'chat:approval-response',
+      'chat:input-request',
+      'chat:input-response',
+      'chat:session-started',
+      'chat:session-status',
+      'chat:turn-started',
+      'chat:turn-completed',
+      'chat:error',
+      'chat:telemetry',
+      'chat:rate-limit',
+    ];
+    // Each type literal is unique
+    const unique = new Set(types);
+    expect(unique.size).toBe(types.length);
+    // All start with 'chat:'
+    for (const t of types) {
+      expect(t.startsWith('chat:')).toBe(true);
+    }
+  });
+
+  it('ChatEventBase fields are present on all events', () => {
+    const events: ChatEvent[] = [
+      makeTextDelta(),
+      makeToolCall(),
+      makeApprovalRequest(),
+      makeTelemetry(),
+    ];
+    for (const e of events) {
+      expect(typeof e.sessionId).toBe('string');
+      expect(typeof e.timestamp).toBe('string');
+      expect(typeof e.source).toBe('string');
+    }
+  });
+});

--- a/test/chat-events.test.ts
+++ b/test/chat-events.test.ts
@@ -24,7 +24,7 @@ import type {
 const BASE = {
   sessionId: 'test-session',
   timestamp: new Date().toISOString(),
-  source: 'mock' as const,
+  source: 'claude' as const,
 };
 
 function makeTextDelta(overrides?: Partial<TextDeltaEvent>): TextDeltaEvent {
@@ -140,7 +140,7 @@ describe('isChatEvent', () => {
         type: 'session.started',
         sessionId: 'x',
         timestamp: 'y',
-        source: 'mock',
+        source: 'claude',
       })
     ).toBe(false);
     // known type + valid source passes
@@ -149,7 +149,7 @@ describe('isChatEvent', () => {
         type: 'chat:text-delta',
         sessionId: 'x',
         timestamp: 'y',
-        source: 'mock',
+        source: 'claude',
       })
     ).toBe(true);
     // chat: prefix but unknown type fails (stricter than prefix-only check)
@@ -158,7 +158,7 @@ describe('isChatEvent', () => {
         type: 'chat:nonexistent',
         sessionId: 'x',
         timestamp: 'y',
-        source: 'mock',
+        source: 'claude',
       })
     ).toBe(false);
     // invalid source fails even with valid type
@@ -168,6 +168,15 @@ describe('isChatEvent', () => {
         sessionId: 'x',
         timestamp: 'y',
         source: 'unknown',
+      })
+    ).toBe(false);
+    // 'mock' is test-only and not a valid production source
+    expect(
+      isChatEvent({
+        type: 'chat:text-delta',
+        sessionId: 'x',
+        timestamp: 'y',
+        source: 'mock',
       })
     ).toBe(false);
     // missing source fails


### PR DESCRIPTION
## Summary

Foundation layer for the unified web chat interface ([#209](https://github.com/donovan-yohan/relay-ide/issues/209)). Establishes the canonical type system and adapter contract that Codex, OpenCode, and Claude backends will implement.

- **`server/chat-events.ts`** — 19 ChatEvent types in a discriminated union (`chat:text-delta`, `chat:tool-call`, `chat:approval-request`, `chat:telemetry`, etc.). Type guards validate both `type` (against a `VALID_TYPES` set) and `source` — no unknown events slip through as `ChatEvent`.
- **`server/protocol-adapter.ts`** — `ProtocolAdapter` interface + `BaseProtocolAdapter` abstract class. Concrete `disconnect()` guarantees all event handlers are cleared via `onDisconnect()` hook pattern. `emit()` snapshots the handler set to prevent live-mutation bugs.
- **`server/types.ts`** — `SessionMode = 'pty' | 'web'`, new `WebSession` interface, `Session = PtySession | WebSession` discriminated union. Zero changes to `PtySession`.
- **PTY compatibility** — `sessions.ts`, `hooks.ts`, `ws.ts`, `index.ts` updated with `mode === 'pty'` guards. Every PTY-specific field access is narrowed. Hook endpoints return 400 for web sessions. `kill()` disconnects the adapter + kills the subprocess for web sessions.
- **`test/chat-events.test.ts`** — 20 tests: all 6 type guards, source/type validation, discriminated union shape.
- **Docs** — `ARCHITECTURE.md` and `FRONTEND.md` updated to reflect the completed React migration (Svelte → React).

Closes #211, closes #212.

## Test plan

- [ ] `tsc --noEmit` — clean
- [ ] `bun test test/chat-events.test.ts` — 20/20 pass
- [ ] Full suite `npx vitest run` — 90 files / 1213 tests pass
- [ ] No regressions on PTY sessions (all PTY paths guarded, WebSession only adds new code paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)