### PR TITLE
feat: unified web chat interface — backend, frontend, adapters, and tests

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ import BootScreen from './components/BootScreen.js';
 import PinGate from './components/PinGate.js';
 import Sidebar from './components/Sidebar.js';
 import Terminal from './components/Terminal.js';
+import { ChatView } from './components/chat/ChatView.js';
 import type { TerminalHandle } from './components/Terminal.js';
 import PrTopBar from './components/PrTopBar.js';
 import SessionTabBar from './components/SessionTabBar.js';
@@ -214,6 +215,7 @@ function useTerminalDerivedState() {
     [activeSession, activeWorkspace]
   );
 
+  const activeSessionMode = useMemo(() => activeSession?.mode, [activeSession]);
   const activeSessionUseTmux = useMemo(
     () => activeSession?.useTmux ?? false,
     [activeSession]
@@ -241,6 +243,7 @@ function useTerminalDerivedState() {
     activeWorkspace,
     workspaceSessions,
     sessionTitle,
+    activeSessionMode,
     activeSessionUseTmux,
     activeWorkspaceCwd,
     fileViewerOpen,
@@ -273,6 +276,41 @@ function AnalyticsViewContent() {
     <AnalyticsDashboard
       onSelectSession={(id) => setAnalyticsView({ sessionId: id })}
       onClose={() => setAnalyticsView(null)}
+    />
+  );
+}
+
+// ─── SessionContent ──────────────────────────────────────────────────────────
+// Routes between ChatView (web sessions) and Terminal (PTY sessions).
+
+function SessionContent({
+  mode,
+  sessionId,
+  terminalRef,
+  onImageUpload,
+  useTmux,
+  onCopyModeChange,
+  onFilePathClick,
+}: {
+  mode?: 'pty' | 'web' | undefined;
+  sessionId: string | null;
+  terminalRef: React.RefObject<TerminalHandle | null>;
+  onImageUpload: (text: string, showInsert: boolean, path?: string) => void;
+  useTmux: boolean;
+  onCopyModeChange: (active: boolean) => void;
+  onFilePathClick: (path: string) => void;
+}) {
+  if (mode === 'web') {
+    return <ChatView sessionId={sessionId} />;
+  }
+  return (
+    <Terminal
+      ref={terminalRef}
+      sessionId={sessionId}
+      onImageUpload={onImageUpload}
+      useTmux={useTmux}
+      onCopyModeChange={onCopyModeChange}
+      onFilePathClick={onFilePathClick}
     />
   );
 }
@@ -338,6 +376,7 @@ function TerminalAreaContent({
     activeWorkspace,
     workspaceSessions,
     sessionTitle,
+    activeSessionMode,
     activeSessionUseTmux,
     activeWorkspaceCwd,
     fileViewerOpen,
@@ -505,9 +544,10 @@ function TerminalAreaContent({
                   hidden={keyboardOpen}
                 />
 
-                <Terminal
-                  ref={terminalRef}
+                <SessionContent
+                  mode={activeSessionMode}
                   sessionId={activeSessionId}
+                  terminalRef={terminalRef}
                   onImageUpload={onImageUpload}
                   useTmux={activeSessionUseTmux}
                   onCopyModeChange={handleCopyModeChange}

--- a/frontend/src/components/chat/ApprovalCard.css
+++ b/frontend/src/components/chat/ApprovalCard.css
@@ -1,0 +1,90 @@
+.approval-card {
+  border: 1px solid var(--status-warning);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.approval-card__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--status-warning);
+}
+
+.approval-card__tool {
+  color: var(--text);
+  font-weight: 500;
+}
+
+.approval-card__description {
+  color: var(--text-muted);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.approval-card__target {
+  padding: 6px 10px;
+  color: var(--text);
+  word-break: break-all;
+}
+
+.approval-card__detail {
+  padding: 0 10px 6px;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  word-break: break-all;
+}
+
+.approval-card__actions {
+  display: flex;
+  gap: 8px;
+  padding: 8px 10px;
+  border-top: 1px solid var(--border);
+}
+
+.approval-card__responded {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.approval-card__btn {
+  background: transparent;
+  border: 1px solid currentColor;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: 4px 10px;
+  text-transform: lowercase;
+  transition:
+    border-style 0.1s,
+    filter 0.1s,
+    background 0.1s;
+}
+
+.approval-card__btn:hover:not(:disabled) {
+  border-width: 3px;
+  border-style: double;
+  padding: 2px 8px;
+  filter: brightness(1.3);
+  background: color-mix(in srgb, currentColor 6%, transparent);
+}
+
+.approval-card__btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.approval-card__btn--allow {
+  color: var(--status-success);
+}
+
+.approval-card__btn--allow-always {
+  color: var(--text-muted);
+}
+
+.approval-card__btn--deny {
+  color: var(--status-error);
+}

--- a/frontend/src/components/chat/ApprovalCard.css
+++ b/frontend/src/components/chat/ApprovalCard.css
@@ -88,3 +88,9 @@
 .approval-card__btn--deny {
   color: var(--status-error);
 }
+
+@media (max-width: 767px) {
+  .approval-card__actions {
+    flex-direction: column;
+  }
+}

--- a/frontend/src/components/chat/ApprovalCard.tsx
+++ b/frontend/src/components/chat/ApprovalCard.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import './ApprovalCard.css';
+import type { ApprovalRequestEvent } from '../../../../server/chat-events.js';
+
+interface ApprovalCardProps {
+  event: ApprovalRequestEvent;
+  onApprove: (
+    requestId: string,
+    decision: 'allow' | 'allow-always' | 'deny'
+  ) => void;
+  responded?: boolean;
+  decision?: 'allow' | 'allow-always' | 'deny' | undefined;
+}
+
+export const ApprovalCard: React.FC<ApprovalCardProps> = ({
+  event,
+  onApprove,
+  responded = false,
+  decision,
+}) => {
+  return (
+    <div className="approval-card">
+      <div className="approval-card__header">
+        <span className="approval-card__tool">
+          {event.toolName.toLowerCase()}
+        </span>
+        {event.description && (
+          <span className="approval-card__description">
+            {event.description}
+          </span>
+        )}
+      </div>
+      <div className="approval-card__target">{event.target}</div>
+      {event.detail && (
+        <div className="approval-card__detail">{event.detail}</div>
+      )}
+      <div className="approval-card__actions">
+        {responded && decision ? (
+          <span className="approval-card__responded">{decision}</span>
+        ) : (
+          <>
+            <button
+              className="approval-card__btn approval-card__btn--allow"
+              type="button"
+              disabled={responded}
+              onClick={() => onApprove(event.requestId, 'allow')}
+            >
+              allow
+            </button>
+            <button
+              className="approval-card__btn approval-card__btn--allow-always"
+              type="button"
+              disabled={responded}
+              onClick={() => onApprove(event.requestId, 'allow-always')}
+            >
+              allow always
+            </button>
+            <button
+              className="approval-card__btn approval-card__btn--deny"
+              type="button"
+              disabled={responded}
+              onClick={() => onApprove(event.requestId, 'deny')}
+            >
+              deny
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ApprovalCard;

--- a/frontend/src/components/chat/ApprovalCard.tsx
+++ b/frontend/src/components/chat/ApprovalCard.tsx
@@ -19,7 +19,11 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({
   decision,
 }) => {
   return (
-    <div className="approval-card">
+    <div
+      className="approval-card"
+      role="alertdialog"
+      aria-label="permission request"
+    >
       <div className="approval-card__header">
         <span className="approval-card__tool">
           {event.toolName.toLowerCase()}
@@ -44,6 +48,7 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({
               type="button"
               disabled={responded}
               onClick={() => onApprove(event.requestId, 'allow')}
+              aria-label="allow command"
             >
               allow
             </button>
@@ -52,6 +57,7 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({
               type="button"
               disabled={responded}
               onClick={() => onApprove(event.requestId, 'allow-always')}
+              aria-label="allow command always"
             >
               allow always
             </button>
@@ -60,6 +66,7 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({
               type="button"
               disabled={responded}
               onClick={() => onApprove(event.requestId, 'deny')}
+              aria-label="deny command"
             >
               deny
             </button>

--- a/frontend/src/components/chat/ApprovalCard.tsx
+++ b/frontend/src/components/chat/ApprovalCard.tsx
@@ -21,7 +21,8 @@ export const ApprovalCard: React.FC<ApprovalCardProps> = ({
   return (
     <div
       className="approval-card"
-      role="alertdialog"
+      role="alert"
+      aria-live="assertive"
       aria-label="permission request"
     >
       <div className="approval-card__header">

--- a/frontend/src/components/chat/ChatView.css
+++ b/frontend/src/components/chat/ChatView.css
@@ -5,3 +5,9 @@
   background: var(--bg);
   overflow: hidden;
 }
+
+@media (max-width: 767px) {
+  .chat-view {
+    width: 100%;
+  }
+}

--- a/frontend/src/components/chat/ChatView.css
+++ b/frontend/src/components/chat/ChatView.css
@@ -1,0 +1,7 @@
+.chat-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg);
+  overflow: hidden;
+}

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -50,7 +50,7 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
   }, [events, interrupt]);
 
   return (
-    <div className="chat-view">
+    <div className="chat-view" role="main" aria-label="chat">
       <MessageTimeline events={events} onApprove={approve} />
       <Composer
         onSend={handleSend}

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -1,0 +1,64 @@
+import React, { useCallback, useMemo } from 'react';
+import './ChatView.css';
+import { useChatSocket } from '../../hooks/useChatSocket.js';
+import { MessageTimeline } from './MessageTimeline.js';
+import { Composer } from './Composer.js';
+import type { SessionStatusEvent } from '../../../../server/chat-events.js';
+
+interface ChatViewProps {
+  sessionId: string | null;
+}
+
+export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
+  const { events, sendMessage, interrupt, approve } = useChatSocket(sessionId);
+
+  // Determine if agent is active by looking at the latest session-status event
+  const isActive = useMemo(() => {
+    for (let i = events.length - 1; i >= 0; i--) {
+      const e = events[i];
+      if (e && e.type === 'chat:session-status') {
+        const status = (e as SessionStatusEvent).status;
+        return status === 'active';
+      }
+    }
+    return false;
+  }, [events]);
+
+  const handleSend = useCallback(
+    (content: string) => {
+      const turnId = crypto.randomUUID();
+      sendMessage(turnId, content);
+    },
+    [sendMessage]
+  );
+
+  const handleInterrupt = useCallback(() => {
+    // Find the latest active turnId
+    let latestTurnId = '';
+    for (let i = events.length - 1; i >= 0; i--) {
+      const e = events[i];
+      if (
+        e &&
+        'turnId' in e &&
+        typeof (e as { turnId?: string }).turnId === 'string'
+      ) {
+        latestTurnId = (e as { turnId: string }).turnId;
+        break;
+      }
+    }
+    interrupt(latestTurnId);
+  }, [events, interrupt]);
+
+  return (
+    <div className="chat-view">
+      <MessageTimeline events={events} onApprove={approve} />
+      <Composer
+        onSend={handleSend}
+        onInterrupt={handleInterrupt}
+        isActive={isActive}
+      />
+    </div>
+  );
+};
+
+export default ChatView;

--- a/frontend/src/components/chat/ChatView.tsx
+++ b/frontend/src/components/chat/ChatView.tsx
@@ -33,20 +33,19 @@ export const ChatView: React.FC<ChatViewProps> = ({ sessionId }) => {
   );
 
   const handleInterrupt = useCallback(() => {
-    // Find the latest active turnId
-    let latestTurnId = '';
+    // Find the latest active turnId — skip if none found
     for (let i = events.length - 1; i >= 0; i--) {
       const e = events[i];
       if (
         e &&
         'turnId' in e &&
-        typeof (e as { turnId?: string }).turnId === 'string'
+        typeof (e as { turnId?: string }).turnId === 'string' &&
+        (e as { turnId: string }).turnId.length > 0
       ) {
-        latestTurnId = (e as { turnId: string }).turnId;
-        break;
+        interrupt((e as { turnId: string }).turnId);
+        return;
       }
     }
-    interrupt(latestTurnId);
   }, [events, interrupt]);
 
   return (

--- a/frontend/src/components/chat/Composer.css
+++ b/frontend/src/components/chat/Composer.css
@@ -1,0 +1,71 @@
+.composer {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  flex-shrink: 0;
+}
+
+.composer__textarea {
+  flex: 1;
+  background: var(--bg);
+  color: var(--text);
+  border: none;
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  padding: 10px 12px;
+  resize: none;
+  outline: none;
+  line-height: 1.5;
+  overflow-y: auto;
+}
+
+.composer__textarea::placeholder {
+  color: var(--text-muted);
+}
+
+.composer__textarea:focus {
+  border-bottom-color: var(--accent);
+}
+
+.composer__textarea:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.composer__actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 6px 10px;
+}
+
+.composer__btn {
+  background: transparent;
+  border: 1px solid currentColor;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: 4px 12px;
+  text-transform: lowercase;
+  transition:
+    border-style 0.1s,
+    filter 0.1s,
+    background 0.1s;
+}
+
+.composer__btn:hover:not(:disabled) {
+  border-width: 3px;
+  border-style: double;
+  padding: 2px 10px;
+  filter: brightness(1.3);
+  background: color-mix(in srgb, currentColor 6%, transparent);
+}
+
+.composer__btn--send {
+  color: var(--accent);
+}
+
+.composer__btn--interrupt {
+  color: var(--status-error);
+}

--- a/frontend/src/components/chat/Composer.css
+++ b/frontend/src/components/chat/Composer.css
@@ -69,3 +69,13 @@
 .composer__btn--interrupt {
   color: var(--status-error);
 }
+
+@media (max-width: 767px) {
+  .composer__textarea {
+    padding: 8px 10px;
+  }
+
+  .composer__actions {
+    padding: 4px 8px;
+  }
+}

--- a/frontend/src/components/chat/Composer.tsx
+++ b/frontend/src/components/chat/Composer.tsx
@@ -58,7 +58,7 @@ export const Composer: React.FC<ComposerProps> = ({
   }, [onSend, resize]);
 
   return (
-    <div className="composer">
+    <div className="composer" role="form" aria-label="message composer">
       <textarea
         ref={textareaRef}
         className="composer__textarea"
@@ -67,6 +67,7 @@ export const Composer: React.FC<ComposerProps> = ({
         onInput={handleInput}
         rows={1}
         disabled={isActive}
+        aria-label="message input"
       />
       <div className="composer__actions">
         {isActive ? (
@@ -74,6 +75,7 @@ export const Composer: React.FC<ComposerProps> = ({
             className="composer__btn composer__btn--interrupt"
             type="button"
             onClick={onInterrupt}
+            aria-label="interrupt agent"
           >
             interrupt
           </button>
@@ -82,6 +84,7 @@ export const Composer: React.FC<ComposerProps> = ({
             className="composer__btn composer__btn--send"
             type="button"
             onClick={handleSendClick}
+            aria-label="send message"
           >
             send
           </button>

--- a/frontend/src/components/chat/Composer.tsx
+++ b/frontend/src/components/chat/Composer.tsx
@@ -1,0 +1,94 @@
+import React, { useRef, useEffect, useCallback } from 'react';
+import './Composer.css';
+
+interface ComposerProps {
+  onSend: (content: string) => void;
+  onInterrupt: () => void;
+  isActive: boolean;
+}
+
+export const Composer: React.FC<ComposerProps> = ({
+  onSend,
+  onInterrupt,
+  isActive,
+}) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const resize = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    const lineHeight = parseInt(getComputedStyle(el).lineHeight, 10) || 20;
+    const maxHeight = lineHeight * 6 + 32; // 6 lines + padding
+    el.style.height = Math.min(el.scrollHeight, maxHeight) + 'px';
+  }, []);
+
+  useEffect(() => {
+    resize();
+  }, [resize]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        const el = textareaRef.current;
+        if (!el) return;
+        const content = el.value.trim();
+        if (!content) return;
+        onSend(content);
+        el.value = '';
+        resize();
+      }
+    },
+    [onSend, resize]
+  );
+
+  const handleInput = useCallback(() => {
+    resize();
+  }, [resize]);
+
+  const handleSendClick = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    const content = el.value.trim();
+    if (!content) return;
+    onSend(content);
+    el.value = '';
+    resize();
+  }, [onSend, resize]);
+
+  return (
+    <div className="composer">
+      <textarea
+        ref={textareaRef}
+        className="composer__textarea"
+        placeholder="type a message..."
+        onKeyDown={handleKeyDown}
+        onInput={handleInput}
+        rows={1}
+        disabled={isActive}
+      />
+      <div className="composer__actions">
+        {isActive ? (
+          <button
+            className="composer__btn composer__btn--interrupt"
+            type="button"
+            onClick={onInterrupt}
+          >
+            interrupt
+          </button>
+        ) : (
+          <button
+            className="composer__btn composer__btn--send"
+            type="button"
+            onClick={handleSendClick}
+          >
+            send
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Composer;

--- a/frontend/src/components/chat/FileChangeCard.css
+++ b/frontend/src/components/chat/FileChangeCard.css
@@ -35,3 +35,11 @@
   font-size: var(--font-size-xs);
   white-space: nowrap;
 }
+
+@media (max-width: 767px) {
+  .file-change-card__path {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+}

--- a/frontend/src/components/chat/FileChangeCard.css
+++ b/frontend/src/components/chat/FileChangeCard.css
@@ -1,0 +1,37 @@
+.file-change-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 10px;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+.file-change-card__path {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-change-card__stats {
+  display: flex;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.file-change-card__additions {
+  color: var(--status-success);
+}
+
+.file-change-card__deletions {
+  color: var(--status-error);
+}
+
+.file-change-card__kind {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+}

--- a/frontend/src/components/chat/FileChangeCard.tsx
+++ b/frontend/src/components/chat/FileChangeCard.tsx
@@ -13,7 +13,7 @@ export const FileChangeCard: React.FC<FileChangeCardProps> = ({ event }) => {
       : event.path;
 
   return (
-    <div className="file-change-card" role="listitem">
+    <div className="file-change-card">
       <span className="file-change-card__path">{displayPath}</span>
       <span className="file-change-card__stats">
         {event.additions > 0 && (

--- a/frontend/src/components/chat/FileChangeCard.tsx
+++ b/frontend/src/components/chat/FileChangeCard.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import './FileChangeCard.css';
+import type { FileChangeEvent } from '../../../../server/chat-events.js';
+
+interface FileChangeCardProps {
+  event: FileChangeEvent;
+}
+
+export const FileChangeCard: React.FC<FileChangeCardProps> = ({ event }) => {
+  const displayPath =
+    event.kind === 'renamed' && event.oldPath
+      ? `${event.oldPath} -> ${event.path}`
+      : event.path;
+
+  return (
+    <div className="file-change-card">
+      <span className="file-change-card__path">{displayPath}</span>
+      <span className="file-change-card__stats">
+        {event.additions > 0 && (
+          <span className="file-change-card__additions">
+            +{event.additions}
+          </span>
+        )}
+        {event.deletions > 0 && (
+          <span className="file-change-card__deletions">
+            -{event.deletions}
+          </span>
+        )}
+      </span>
+      <span className="file-change-card__kind">{event.kind}</span>
+    </div>
+  );
+};
+
+export default FileChangeCard;

--- a/frontend/src/components/chat/FileChangeCard.tsx
+++ b/frontend/src/components/chat/FileChangeCard.tsx
@@ -13,7 +13,7 @@ export const FileChangeCard: React.FC<FileChangeCardProps> = ({ event }) => {
       : event.path;
 
   return (
-    <div className="file-change-card">
+    <div className="file-change-card" role="listitem">
       <span className="file-change-card__path">{displayPath}</span>
       <span className="file-change-card__stats">
         {event.additions > 0 && (

--- a/frontend/src/components/chat/MessageTimeline.css
+++ b/frontend/src/components/chat/MessageTimeline.css
@@ -62,3 +62,9 @@
   color: var(--text);
   word-break: break-word;
 }
+
+@media (max-width: 767px) {
+  .message-timeline__text {
+    max-width: 95%;
+  }
+}

--- a/frontend/src/components/chat/MessageTimeline.css
+++ b/frontend/src/components/chat/MessageTimeline.css
@@ -1,0 +1,64 @@
+.message-timeline {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.message-timeline--empty {
+  align-items: center;
+  justify-content: center;
+}
+
+.message-timeline__empty-label {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.message-timeline__turn {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.message-timeline__turn-header {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--border);
+}
+
+.message-timeline__text {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  line-height: 1.6;
+}
+
+.message-timeline__error {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding: 6px 10px;
+  border: 1px solid var(--status-error);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.message-timeline__error-kind {
+  color: var(--status-error);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+}
+
+.message-timeline__error-msg {
+  color: var(--text);
+  word-break: break-word;
+}

--- a/frontend/src/components/chat/MessageTimeline.tsx
+++ b/frontend/src/components/chat/MessageTimeline.tsx
@@ -1,0 +1,254 @@
+import React, { useEffect, useRef, useMemo } from 'react';
+import './MessageTimeline.css';
+import type {
+  ChatEvent,
+  ApprovalRequestEvent,
+  ApprovalResponseEvent,
+  ToolCallEvent,
+  FileChangeEvent,
+  ErrorEvent,
+} from '../../../../server/chat-events.js';
+import { ToolCard } from './ToolCard.js';
+import { FileChangeCard } from './FileChangeCard.js';
+import { ApprovalCard } from './ApprovalCard.js';
+
+interface MessageTimelineProps {
+  events: ChatEvent[];
+  onApprove: (
+    requestId: string,
+    decision: 'allow' | 'allow-always' | 'deny'
+  ) => void;
+}
+
+interface TurnGroup {
+  turnId: string;
+  turnIndex: number;
+  textByMessageId: Map<string, string>;
+  textMessageOrder: string[];
+  toolCalls: ToolCallEvent[];
+  fileChanges: FileChangeEvent[];
+  approvalRequests: ApprovalRequestEvent[];
+  approvalResponses: Map<string, ApprovalResponseEvent>;
+  errors: ErrorEvent[];
+}
+
+const NO_TURN = '__no_turn__';
+
+function emptyGroup(turnId: string, turnIndex: number): TurnGroup {
+  return {
+    turnId,
+    turnIndex,
+    textByMessageId: new Map(),
+    textMessageOrder: [],
+    toolCalls: [],
+    fileChanges: [],
+    approvalRequests: [],
+    approvalResponses: new Map(),
+    errors: [],
+  };
+}
+
+function getOrCreateGroup(
+  groupMap: Map<string, TurnGroup>,
+  groupOrder: string[],
+  id: string,
+  counter: { value: number }
+): TurnGroup {
+  let group = groupMap.get(id);
+  if (!group) {
+    group = emptyGroup(id, counter.value++);
+    groupMap.set(id, group);
+    groupOrder.push(id);
+  }
+  return group;
+}
+
+function routeEvent(
+  event: ChatEvent,
+  groupMap: Map<string, TurnGroup>,
+  groupOrder: string[],
+  counter: { value: number }
+): void {
+  const turnId =
+    'turnId' in event ? (event as { turnId?: string }).turnId : undefined;
+
+  switch (event.type) {
+    case 'chat:text-delta': {
+      const group = getOrCreateGroup(
+        groupMap,
+        groupOrder,
+        event.turnId,
+        counter
+      );
+      if (!group.textByMessageId.has(event.messageId)) {
+        group.textByMessageId.set(event.messageId, '');
+        group.textMessageOrder.push(event.messageId);
+      }
+      group.textByMessageId.set(
+        event.messageId,
+        (group.textByMessageId.get(event.messageId) ?? '') + event.delta
+      );
+      break;
+    }
+    case 'chat:tool-call': {
+      const group = getOrCreateGroup(
+        groupMap,
+        groupOrder,
+        event.turnId,
+        counter
+      );
+      const existing = group.toolCalls.findIndex(
+        (t) => t.toolCallId === event.toolCallId
+      );
+      if (existing >= 0) group.toolCalls[existing] = event;
+      else group.toolCalls.push(event);
+      break;
+    }
+    case 'chat:tool-result': {
+      const gid = turnId ?? NO_TURN;
+      const group = groupMap.get(gid);
+      if (group) {
+        const idx = group.toolCalls.findIndex(
+          (t) => t.toolCallId === event.toolCallId
+        );
+        if (idx >= 0)
+          group.toolCalls[idx] = {
+            ...group.toolCalls[idx]!,
+            status: event.status,
+          };
+      }
+      break;
+    }
+    case 'chat:file-change':
+      getOrCreateGroup(
+        groupMap,
+        groupOrder,
+        event.turnId,
+        counter
+      ).fileChanges.push(event);
+      break;
+    case 'chat:approval-request':
+      getOrCreateGroup(
+        groupMap,
+        groupOrder,
+        event.turnId,
+        counter
+      ).approvalRequests.push(event);
+      break;
+    case 'chat:approval-response':
+      if (turnId)
+        groupMap.get(turnId)?.approvalResponses.set(event.requestId, event);
+      break;
+    case 'chat:error':
+      getOrCreateGroup(
+        groupMap,
+        groupOrder,
+        event.turnId ?? NO_TURN,
+        counter
+      ).errors.push(event);
+      break;
+    default:
+      break;
+  }
+}
+
+function buildTurnGroups(events: ChatEvent[]): TurnGroup[] {
+  const groupMap = new Map<string, TurnGroup>();
+  const groupOrder: string[] = [];
+  const counter = { value: 0 };
+
+  // Pre-create groups from turn-started events
+  for (const event of events) {
+    if (event.type === 'chat:turn-started' && !groupMap.has(event.turnId)) {
+      groupMap.set(event.turnId, emptyGroup(event.turnId, event.turnIndex));
+      groupOrder.push(event.turnId);
+      counter.value = event.turnIndex + 1;
+    }
+  }
+
+  // Route all events into groups
+  for (const event of events) {
+    routeEvent(event, groupMap, groupOrder, counter);
+  }
+
+  return groupOrder.map((id) => groupMap.get(id)!);
+}
+
+export const MessageTimeline: React.FC<MessageTimelineProps> = ({
+  events,
+  onApprove,
+}) => {
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const groups = useMemo(() => buildTurnGroups(events), [events]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [events.length]);
+
+  if (groups.length === 0) {
+    return (
+      <div className="message-timeline message-timeline--empty">
+        <span className="message-timeline__empty-label">no messages yet</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="message-timeline">
+      {groups.map((group) => (
+        <div key={group.turnId} className="message-timeline__turn">
+          <div className="message-timeline__turn-header">
+            turn {group.turnIndex}
+          </div>
+
+          {/* Text content */}
+          {group.textMessageOrder.map((msgId) => {
+            const text = group.textByMessageId.get(msgId) ?? '';
+            if (!text) return null;
+            return (
+              <pre key={msgId} className="message-timeline__text">
+                {text}
+              </pre>
+            );
+          })}
+
+          {/* Tool calls */}
+          {group.toolCalls.map((tc) => (
+            <ToolCard key={tc.toolCallId} event={tc} />
+          ))}
+
+          {/* File changes */}
+          {group.fileChanges.map((fc, i) => (
+            <FileChangeCard key={`${fc.toolCallId}-${i}`} event={fc} />
+          ))}
+
+          {/* Approval requests */}
+          {group.approvalRequests.map((ar) => {
+            const response = group.approvalResponses.get(ar.requestId);
+            return (
+              <ApprovalCard
+                key={ar.requestId}
+                event={ar}
+                onApprove={onApprove}
+                responded={response !== undefined}
+                decision={response?.decision}
+              />
+            );
+          })}
+
+          {/* Errors */}
+          {group.errors.map((err, i) => (
+            <div key={i} className="message-timeline__error">
+              <span className="message-timeline__error-kind">{err.kind}</span>
+              <span className="message-timeline__error-msg">{err.message}</span>
+            </div>
+          ))}
+        </div>
+      ))}
+      <div ref={bottomRef} />
+    </div>
+  );
+};
+
+export default MessageTimeline;

--- a/frontend/src/components/chat/MessageTimeline.tsx
+++ b/frontend/src/components/chat/MessageTimeline.tsx
@@ -5,6 +5,7 @@ import type {
   ApprovalRequestEvent,
   ApprovalResponseEvent,
   ToolCallEvent,
+  ToolResultEvent,
   FileChangeEvent,
   ErrorEvent,
 } from '../../../../server/chat-events.js';
@@ -26,6 +27,7 @@ interface TurnGroup {
   textByMessageId: Map<string, string>;
   textMessageOrder: string[];
   toolCalls: ToolCallEvent[];
+  toolResults: Map<string, ToolResultEvent>;
   fileChanges: FileChangeEvent[];
   approvalRequests: ApprovalRequestEvent[];
   approvalResponses: Map<string, ApprovalResponseEvent>;
@@ -41,6 +43,7 @@ function emptyGroup(turnId: string, turnIndex: number): TurnGroup {
     textByMessageId: new Map(),
     textMessageOrder: [],
     toolCalls: [],
+    toolResults: new Map(),
     fileChanges: [],
     approvalRequests: [],
     approvalResponses: new Map(),
@@ -108,6 +111,7 @@ function routeEvent(
       const gid = turnId ?? NO_TURN;
       const group = groupMap.get(gid);
       if (group) {
+        group.toolResults.set(event.toolCallId, event);
         const idx = group.toolCalls.findIndex(
           (t) => t.toolCallId === event.toolCallId
         );
@@ -179,11 +183,20 @@ export const MessageTimeline: React.FC<MessageTimelineProps> = ({
   onApprove,
 }) => {
   const bottomRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const groups = useMemo(() => buildTurnGroups(events), [events]);
 
+  // Auto-scroll only when user is near the bottom (within 150px)
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const container = containerRef.current;
+    if (!container) return;
+    const nearBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight <
+      150;
+    if (nearBottom) {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
   }, [events.length]);
 
   if (groups.length === 0) {
@@ -201,6 +214,7 @@ export const MessageTimeline: React.FC<MessageTimelineProps> = ({
 
   return (
     <div
+      ref={containerRef}
       className="message-timeline"
       role="log"
       aria-live="polite"
@@ -230,7 +244,11 @@ export const MessageTimeline: React.FC<MessageTimelineProps> = ({
 
           {/* Tool calls */}
           {group.toolCalls.map((tc) => (
-            <ToolCard key={tc.toolCallId} event={tc} />
+            <ToolCard
+              key={tc.toolCallId}
+              event={tc}
+              result={group.toolResults.get(tc.toolCallId)}
+            />
           ))}
 
           {/* File changes */}

--- a/frontend/src/components/chat/MessageTimeline.tsx
+++ b/frontend/src/components/chat/MessageTimeline.tsx
@@ -188,16 +188,31 @@ export const MessageTimeline: React.FC<MessageTimelineProps> = ({
 
   if (groups.length === 0) {
     return (
-      <div className="message-timeline message-timeline--empty">
+      <div
+        className="message-timeline message-timeline--empty"
+        role="log"
+        aria-live="polite"
+        aria-label="message timeline"
+      >
         <span className="message-timeline__empty-label">no messages yet</span>
       </div>
     );
   }
 
   return (
-    <div className="message-timeline">
+    <div
+      className="message-timeline"
+      role="log"
+      aria-live="polite"
+      aria-label="message timeline"
+    >
       {groups.map((group) => (
-        <div key={group.turnId} className="message-timeline__turn">
+        <div
+          key={group.turnId}
+          className="message-timeline__turn"
+          role="group"
+          aria-label={`turn ${group.turnIndex}`}
+        >
           <div className="message-timeline__turn-header">
             turn {group.turnIndex}
           </div>

--- a/frontend/src/components/chat/ToolCard.css
+++ b/frontend/src/components/chat/ToolCard.css
@@ -86,6 +86,7 @@
   }
 
   .tool-card__body {
-    display: none;
+    max-height: 120px;
+    overflow: auto;
   }
 }

--- a/frontend/src/components/chat/ToolCard.css
+++ b/frontend/src/components/chat/ToolCard.css
@@ -1,0 +1,79 @@
+.tool-card {
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.tool-card__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.tool-card__header:hover {
+  background: var(--surface-hover);
+}
+
+.tool-card__name {
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.tool-card__description {
+  color: var(--text-muted);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tool-card__status {
+  margin-left: auto;
+  white-space: nowrap;
+  font-size: var(--font-size-xs);
+}
+
+.tool-card__status--pending {
+  color: var(--text-muted);
+}
+
+.tool-card__status--running {
+  color: var(--accent);
+}
+
+.tool-card__status--completed {
+  color: var(--status-success);
+}
+
+.tool-card__status--error {
+  color: var(--status-error);
+}
+
+.tool-card__status--declined {
+  color: var(--text-muted);
+}
+
+.tool-card__body {
+  border-top: 1px solid var(--border);
+  padding: 8px 10px;
+  background: var(--surface);
+}
+
+.tool-card__input {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-x: auto;
+}

--- a/frontend/src/components/chat/ToolCard.css
+++ b/frontend/src/components/chat/ToolCard.css
@@ -77,3 +77,15 @@
   word-break: break-all;
   overflow-x: auto;
 }
+
+@media (max-width: 767px) {
+  .tool-card__description {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+
+  .tool-card__body {
+    display: none;
+  }
+}

--- a/frontend/src/components/chat/ToolCard.css
+++ b/frontend/src/components/chat/ToolCard.css
@@ -65,7 +65,7 @@
 .tool-card__body {
   border-top: 1px solid var(--border);
   padding: 8px 10px;
-  background: var(--surface);
+  background: var(--bg);
 }
 
 .tool-card__input {

--- a/frontend/src/components/chat/ToolCard.tsx
+++ b/frontend/src/components/chat/ToolCard.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import './ToolCard.css';
+import type {
+  ToolCallEvent,
+  ToolCallStatus,
+} from '../../../../server/chat-events.js';
+
+interface ToolCardProps {
+  event: ToolCallEvent;
+}
+
+const EXPANDED_BY_DEFAULT = new Set(['bash', 'edit', 'multiedit', 'write']);
+
+function statusLabel(status: ToolCallStatus): string {
+  switch (status) {
+    case 'pending':
+      return 'pending';
+    case 'running':
+      return 'running';
+    case 'completed':
+      return 'completed';
+    case 'error':
+      return 'error';
+    case 'declined':
+      return 'declined';
+  }
+}
+
+function statusClass(status: ToolCallStatus): string {
+  switch (status) {
+    case 'pending':
+      return 'tool-card__status--pending';
+    case 'running':
+      return 'tool-card__status--running';
+    case 'completed':
+      return 'tool-card__status--completed';
+    case 'error':
+      return 'tool-card__status--error';
+    case 'declined':
+      return 'tool-card__status--declined';
+  }
+}
+
+export const ToolCard: React.FC<ToolCardProps> = ({ event }) => {
+  const defaultExpanded = EXPANDED_BY_DEFAULT.has(event.toolName.toLowerCase());
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  const hasInput = Object.keys(event.input).length > 0;
+
+  return (
+    <div className="tool-card">
+      <button
+        className="tool-card__header"
+        onClick={() => setExpanded((v) => !v)}
+        type="button"
+        aria-expanded={expanded}
+      >
+        <span className="tool-card__name">{event.toolName.toLowerCase()}</span>
+        {event.description && (
+          <span className="tool-card__description">{event.description}</span>
+        )}
+        <span className={`tool-card__status ${statusClass(event.status)}`}>
+          {statusLabel(event.status)}
+        </span>
+      </button>
+      {expanded && hasInput && (
+        <div className="tool-card__body">
+          <pre className="tool-card__input">
+            {JSON.stringify(event.input, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ToolCard;

--- a/frontend/src/components/chat/ToolCard.tsx
+++ b/frontend/src/components/chat/ToolCard.tsx
@@ -48,7 +48,11 @@ export const ToolCard: React.FC<ToolCardProps> = ({ event }) => {
   const hasInput = Object.keys(event.input).length > 0;
 
   return (
-    <div className="tool-card">
+    <div
+      className="tool-card"
+      role="article"
+      aria-label={event.toolName.toLowerCase()}
+    >
       <button
         className="tool-card__header"
         onClick={() => setExpanded((v) => !v)}

--- a/frontend/src/components/chat/ToolCard.tsx
+++ b/frontend/src/components/chat/ToolCard.tsx
@@ -13,21 +13,6 @@ interface ToolCardProps {
 
 const EXPANDED_BY_DEFAULT = new Set(['bash', 'edit', 'multiedit', 'write']);
 
-function statusLabel(status: ToolCallStatus): string {
-  switch (status) {
-    case 'pending':
-      return 'pending';
-    case 'running':
-      return 'running';
-    case 'completed':
-      return 'completed';
-    case 'error':
-      return 'error';
-    case 'declined':
-      return 'declined';
-  }
-}
-
 function statusClass(status: ToolCallStatus): string {
   switch (status) {
     case 'pending':
@@ -71,7 +56,7 @@ export const ToolCard: React.FC<ToolCardProps> = ({ event, result }) => {
           <span className="tool-card__duration">{durationLabel}</span>
         )}
         <span className={`tool-card__status ${statusClass(event.status)}`}>
-          {statusLabel(event.status)}
+          {event.status}
         </span>
       </button>
       {expanded && (

--- a/frontend/src/components/chat/ToolCard.tsx
+++ b/frontend/src/components/chat/ToolCard.tsx
@@ -3,10 +3,12 @@ import './ToolCard.css';
 import type {
   ToolCallEvent,
   ToolCallStatus,
+  ToolResultEvent,
 } from '../../../../server/chat-events.js';
 
 interface ToolCardProps {
   event: ToolCallEvent;
+  result?: ToolResultEvent | undefined;
 }
 
 const EXPANDED_BY_DEFAULT = new Set(['bash', 'edit', 'multiedit', 'write']);
@@ -41,11 +43,13 @@ function statusClass(status: ToolCallStatus): string {
   }
 }
 
-export const ToolCard: React.FC<ToolCardProps> = ({ event }) => {
+export const ToolCard: React.FC<ToolCardProps> = ({ event, result }) => {
   const defaultExpanded = EXPANDED_BY_DEFAULT.has(event.toolName.toLowerCase());
   const [expanded, setExpanded] = useState(defaultExpanded);
 
   const hasInput = Object.keys(event.input).length > 0;
+  const durationLabel =
+    result?.durationMs != null ? `${result.durationMs}ms` : null;
 
   return (
     <div
@@ -63,15 +67,26 @@ export const ToolCard: React.FC<ToolCardProps> = ({ event }) => {
         {event.description && (
           <span className="tool-card__description">{event.description}</span>
         )}
+        {durationLabel && (
+          <span className="tool-card__duration">{durationLabel}</span>
+        )}
         <span className={`tool-card__status ${statusClass(event.status)}`}>
           {statusLabel(event.status)}
         </span>
       </button>
-      {expanded && hasInput && (
+      {expanded && (
         <div className="tool-card__body">
-          <pre className="tool-card__input">
-            {JSON.stringify(event.input, null, 2)}
-          </pre>
+          {hasInput && (
+            <pre className="tool-card__input">
+              {JSON.stringify(event.input, null, 2)}
+            </pre>
+          )}
+          {result?.output && (
+            <pre className="tool-card__output">{result.output}</pre>
+          )}
+          {result?.error && (
+            <pre className="tool-card__error">{result.error}</pre>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/hooks/useChatSocket.ts
+++ b/frontend/src/hooks/useChatSocket.ts
@@ -11,7 +11,7 @@ const PONG_MSG = '{"type":"pong"}';
 export interface ChatSocketState {
   events: ChatEvent[];
   connected: boolean;
-  send: (msg: Record<string, unknown>) => void;
+  send: (msg: Record<string, unknown>) => boolean;
   sendMessage: (turnId: string, content: string) => void;
   interrupt: (turnId: string) => void;
   approve: (
@@ -47,11 +47,18 @@ export function useChatSocket(sessionId: string | null): ChatSocketState {
     pongPendingRef.current = false;
   }, []);
 
-  const send = useCallback((msg: Record<string, unknown>) => {
+  const send = useCallback((msg: Record<string, unknown>): boolean => {
     const ws = wsRef.current;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify(msg));
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      // eslint-disable-next-line no-console -- intentional: surface silent send failures in devtools
+      console.warn(
+        '[useChatSocket] send() dropped — WebSocket not open',
+        msg.type
+      );
+      return false;
     }
+    ws.send(JSON.stringify(msg));
+    return true;
   }, []);
 
   const sendMessage = useCallback(
@@ -107,7 +114,28 @@ export function useChatSocket(sessionId: string | null): ChatSocketState {
           pongPendingRef.current = true;
           try {
             wsRef.current.send(PING_MSG);
-          } catch {
+          } catch (err) {
+            // eslint-disable-next-line no-console -- intentional: surface ping failures in devtools
+            console.error(
+              '[useChatSocket] ping send failed, triggering reconnect',
+              err
+            );
+            clearPing();
+            if (wsRef.current) {
+              wsRef.current.onclose = null;
+              wsRef.current.close();
+              wsRef.current = null;
+            }
+            setConnected(false);
+            if (
+              sessionIdRef.current &&
+              reconnectAttemptRef.current < MAX_RECONNECT_ATTEMPTS
+            ) {
+              reconnectAttemptRef.current++;
+              reconnectTimerRef.current = setTimeout(() => {
+                if (sessionIdRef.current) connect(sessionIdRef.current);
+              }, RECONNECT_DELAY);
+            }
             return;
           }
           pongTimeoutRef.current = setTimeout(() => {
@@ -154,8 +182,13 @@ export function useChatSocket(sessionId: string | null): ChatSocketState {
           ) {
             setEvents((prev) => [...prev, parsed as ChatEvent]);
           }
-        } catch {
-          // ignore parse errors
+        } catch (err) {
+          // eslint-disable-next-line no-console -- intentional: surface malformed messages in devtools
+          console.warn(
+            '[useChatSocket] failed to parse WebSocket message:',
+            str.slice(0, 200),
+            err
+          );
         }
       };
 
@@ -177,7 +210,14 @@ export function useChatSocket(sessionId: string | null): ChatSocketState {
         }
       };
 
-      ws.onerror = () => {};
+      ws.onerror = (event) => {
+        // eslint-disable-next-line no-console -- intentional: surface WS errors in devtools
+        console.error(
+          '[useChatSocket] WebSocket error for session',
+          sid,
+          event
+        );
+      };
     },
     [clearPing]
   );

--- a/frontend/src/hooks/useChatSocket.ts
+++ b/frontend/src/hooks/useChatSocket.ts
@@ -1,0 +1,230 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { ChatEvent } from '../../../server/chat-events.js';
+
+const PING_INTERVAL = 30_000;
+const PONG_TIMEOUT = 5_000;
+const MAX_RECONNECT_ATTEMPTS = 10;
+const RECONNECT_DELAY = 3_000;
+const PING_MSG = '{"type":"ping"}';
+const PONG_MSG = '{"type":"pong"}';
+
+export interface ChatSocketState {
+  events: ChatEvent[];
+  connected: boolean;
+  send: (msg: Record<string, unknown>) => void;
+  sendMessage: (turnId: string, content: string) => void;
+  interrupt: (turnId: string) => void;
+  approve: (
+    requestId: string,
+    decision: 'allow' | 'allow-always' | 'deny'
+  ) => void;
+}
+
+export function useChatSocket(sessionId: string | null): ChatSocketState {
+  const [events, setEvents] = useState<ChatEvent[]>([]);
+  const [connected, setConnected] = useState(false);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectAttemptRef = useRef(0);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pongTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pongPendingRef = useRef(false);
+  const sessionIdRef = useRef(sessionId);
+  const unmountedRef = useRef(false);
+
+  sessionIdRef.current = sessionId;
+
+  const clearPing = useCallback(() => {
+    if (pingTimerRef.current) {
+      clearInterval(pingTimerRef.current);
+      pingTimerRef.current = null;
+    }
+    if (pongTimeoutRef.current) {
+      clearTimeout(pongTimeoutRef.current);
+      pongTimeoutRef.current = null;
+    }
+    pongPendingRef.current = false;
+  }, []);
+
+  const send = useCallback((msg: Record<string, unknown>) => {
+    const ws = wsRef.current;
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(msg));
+    }
+  }, []);
+
+  const sendMessage = useCallback(
+    (turnId: string, content: string) => {
+      send({ type: 'message', turnId, content });
+    },
+    [send]
+  );
+
+  const interrupt = useCallback(
+    (turnId: string) => {
+      send({ type: 'interrupt', turnId });
+    },
+    [send]
+  );
+
+  const approve = useCallback(
+    (requestId: string, decision: 'allow' | 'allow-always' | 'deny') => {
+      send({ type: 'approve', requestId, decision });
+    },
+    [send]
+  );
+
+  const connect = useCallback(
+    (sid: string) => {
+      if (unmountedRef.current) return;
+
+      // Close existing socket
+      if (wsRef.current) {
+        wsRef.current.onopen = null;
+        wsRef.current.onmessage = null;
+        wsRef.current.onclose = null;
+        wsRef.current.onerror = null;
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+      clearPing();
+
+      const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const url = wsProtocol + '//' + location.host + '/ws/' + sid;
+      const ws = new WebSocket(url);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        if (unmountedRef.current || wsRef.current !== ws) return;
+        reconnectAttemptRef.current = 0;
+        setConnected(true);
+
+        // Start ping heartbeat
+        pingTimerRef.current = setInterval(() => {
+          if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN)
+            return;
+          pongPendingRef.current = true;
+          try {
+            wsRef.current.send(PING_MSG);
+          } catch {
+            return;
+          }
+          pongTimeoutRef.current = setTimeout(() => {
+            pongPendingRef.current = false;
+            // Force reconnect on pong timeout
+            if (wsRef.current) {
+              wsRef.current.onclose = null;
+              wsRef.current.close();
+              wsRef.current = null;
+            }
+            setConnected(false);
+            if (
+              sessionIdRef.current &&
+              reconnectAttemptRef.current < MAX_RECONNECT_ATTEMPTS
+            ) {
+              reconnectAttemptRef.current++;
+              reconnectTimerRef.current = setTimeout(() => {
+                if (sessionIdRef.current) connect(sessionIdRef.current);
+              }, RECONNECT_DELAY);
+            }
+          }, PONG_TIMEOUT);
+        }, PING_INTERVAL);
+      };
+
+      ws.onmessage = (event) => {
+        if (wsRef.current !== ws) return;
+        const str = event.data as string;
+        if (pongPendingRef.current) {
+          if (pongTimeoutRef.current) {
+            clearTimeout(pongTimeoutRef.current);
+            pongTimeoutRef.current = null;
+          }
+          pongPendingRef.current = false;
+        }
+        if (str === PONG_MSG) return;
+        try {
+          const parsed: unknown = JSON.parse(str);
+          if (
+            parsed !== null &&
+            typeof parsed === 'object' &&
+            'type' in parsed &&
+            typeof (parsed as { type: unknown }).type === 'string' &&
+            (parsed as { type: string }).type.startsWith('chat:')
+          ) {
+            setEvents((prev) => [...prev, parsed as ChatEvent]);
+          }
+        } catch {
+          // ignore parse errors
+        }
+      };
+
+      ws.onclose = () => {
+        if (unmountedRef.current) return;
+        if (wsRef.current !== ws) return;
+        clearPing();
+        wsRef.current = null;
+        setConnected(false);
+
+        if (
+          sessionIdRef.current &&
+          reconnectAttemptRef.current < MAX_RECONNECT_ATTEMPTS
+        ) {
+          reconnectAttemptRef.current++;
+          reconnectTimerRef.current = setTimeout(() => {
+            if (sessionIdRef.current) connect(sessionIdRef.current);
+          }, RECONNECT_DELAY);
+        }
+      };
+
+      ws.onerror = () => {};
+    },
+    [clearPing]
+  );
+
+  useEffect(() => {
+    unmountedRef.current = false;
+    setEvents([]);
+    setConnected(false);
+
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+    reconnectAttemptRef.current = 0;
+
+    if (sessionId) {
+      connect(sessionId);
+    } else {
+      // Close existing socket when sessionId is null
+      if (wsRef.current) {
+        wsRef.current.onopen = null;
+        wsRef.current.onmessage = null;
+        wsRef.current.onclose = null;
+        wsRef.current.onerror = null;
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+      clearPing();
+    }
+
+    return () => {
+      unmountedRef.current = true;
+      clearPing();
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+      if (wsRef.current) {
+        wsRef.current.onopen = null;
+        wsRef.current.onmessage = null;
+        wsRef.current.onclose = null;
+        wsRef.current.onerror = null;
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+  }, [sessionId, connect, clearPing]);
+
+  return { events, connected, send, sendMessage, interrupt, approve };
+}

--- a/frontend/src/hooks/useChatSocket.ts
+++ b/frontend/src/hooks/useChatSocket.ts
@@ -56,7 +56,7 @@ export function useChatSocket(sessionId: string | null): ChatSocketState {
 
   const sendMessage = useCallback(
     (turnId: string, content: string) => {
-      send({ type: 'message', turnId, content });
+      send({ type: 'send-message', turnId, content });
     },
     [send]
   );

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -85,7 +85,7 @@ export interface SessionSummary {
   id: string;
   type: 'agent' | 'terminal';
   agent: AgentType;
-  mode?: 'pty' | undefined;
+  mode?: 'pty' | 'web' | undefined;
   repoName: string;
   repoPath: string;
   worktreePath: string | null;

--- a/server/chat-events.ts
+++ b/server/chat-events.ts
@@ -6,7 +6,7 @@
 // All agent backends (Codex, OpenCode, Claude Code) map their native protocol
 // messages into this canonical type system via ProtocolAdapters.
 
-export type ChatEventSource = 'codex' | 'opencode' | 'claude';
+export type ChatEventSource = 'codex' | 'opencode' | 'claude' | 'mock';
 
 export interface ChatEventBase {
   sessionId: string;
@@ -290,6 +290,7 @@ const VALID_SOURCES: ReadonlySet<string> = new Set([
   'codex',
   'opencode',
   'claude',
+  'mock',
 ]);
 
 const VALID_TYPES: ReadonlySet<string> = new Set([

--- a/server/protocol-adapters/adapter-utils.ts
+++ b/server/protocol-adapters/adapter-utils.ts
@@ -1,0 +1,19 @@
+/** Shared helpers for protocol adapters — extracts common field accessors. */
+
+export function strField(
+  data: Record<string, unknown> | undefined,
+  key: string,
+  fallback = ''
+): string {
+  return String(data?.[key] ?? fallback);
+}
+
+export function objField(
+  data: Record<string, unknown> | undefined,
+  key: string
+): Record<string, unknown> | undefined {
+  const val = data?.[key];
+  return typeof val === 'object' && val !== null
+    ? (val as Record<string, unknown>)
+    : undefined;
+}

--- a/server/protocol-adapters/base-hook-adapter.ts
+++ b/server/protocol-adapters/base-hook-adapter.ts
@@ -8,7 +8,7 @@ import type {
   SessionOptions,
   Attachment,
 } from '../protocol-adapter.js';
-import type { ChatEvent } from '../chat-events.js';
+import type { ChatEvent, ChatEventSource } from '../chat-events.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('hook-adapter');
@@ -136,14 +136,25 @@ export abstract class BaseHookAdapter extends BaseProtocolAdapter {
       throw new Error('Agent process stdin not available');
     }
     this._currentTurnId = turnId;
+    // Write first — only emit lifecycle events after successful write
+    try {
+      this._process.stdin.write(content + '\n');
+    } catch (err) {
+      this.fire({
+        type: 'chat:error',
+        kind: 'protocol',
+        message: `stdin write failed: ${err instanceof Error ? err.message : String(err)}`,
+        retryable: false,
+        turnId,
+      });
+      throw err;
+    }
     this.fire({ type: 'chat:session-status', status: 'active' });
     this.fire({
       type: 'chat:turn-started',
       turnId,
       turnIndex: this._turnCounter++,
     });
-    // Write the message to the agent's stdin
-    this._process.stdin.write(content + '\n');
   }
 
   async interrupt(_turnId: string): Promise<void> {
@@ -156,12 +167,19 @@ export abstract class BaseHookAdapter extends BaseProtocolAdapter {
     _requestId: string,
     decision: 'allow' | 'allow-always' | 'deny'
   ): Promise<void> {
-    if (this._process?.stdin?.writable) {
-      if (decision === 'allow' || decision === 'allow-always') {
-        this._process.stdin.write('y\n');
-      } else {
-        this._process.stdin.write('n\n');
-      }
+    if (!this._process?.stdin?.writable) {
+      this.fire({
+        type: 'chat:error',
+        kind: 'protocol',
+        message: 'Cannot deliver approval — agent stdin unavailable',
+        retryable: false,
+      });
+      throw new Error('Agent process stdin not available for approval');
+    }
+    if (decision === 'allow' || decision === 'allow-always') {
+      this._process.stdin.write('y\n');
+    } else {
+      this._process.stdin.write('n\n');
     }
   }
 
@@ -169,10 +187,17 @@ export abstract class BaseHookAdapter extends BaseProtocolAdapter {
     _requestId: string,
     answers: Record<string, string[]>
   ): Promise<void> {
-    if (this._process?.stdin?.writable) {
-      const firstAnswer = Object.values(answers)[0]?.[0];
-      if (firstAnswer) this._process.stdin.write(firstAnswer + '\n');
+    if (!this._process?.stdin?.writable) {
+      this.fire({
+        type: 'chat:error',
+        kind: 'protocol',
+        message: 'Cannot deliver input — agent stdin unavailable',
+        retryable: false,
+      });
+      throw new Error('Agent process stdin not available for input');
     }
+    const firstAnswer = Object.values(answers)[0]?.[0];
+    if (firstAnswer) this._process.stdin.write(firstAnswer + '\n');
   }
 
   async createSession(
@@ -190,18 +215,16 @@ export abstract class BaseHookAdapter extends BaseProtocolAdapter {
     return crypto.randomBytes(8).toString('hex');
   }
 
-  /** Helper to build full ChatEvent from partial (same pattern as MockProtocolAdapter) */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  protected fire(partial: {
-    type: ChatEvent['type'];
-    [key: string]: any;
-  }): void {
+  /** Helper to build full ChatEvent from partial fields. */
+  protected fire(
+    partial: { type: ChatEvent['type'] } & Record<string, unknown>
+  ): void {
     const sessionId = this._config?.sessionId ?? '';
     this.emit({
       ...partial,
       sessionId,
       timestamp: new Date().toISOString(),
-      source: this.agentType as 'codex' | 'opencode' | 'claude',
+      source: this.agentType as ChatEventSource,
     } as ChatEvent);
   }
 }

--- a/server/protocol-adapters/base-hook-adapter.ts
+++ b/server/protocol-adapters/base-hook-adapter.ts
@@ -1,0 +1,207 @@
+import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+import crypto from 'node:crypto';
+import { BaseProtocolAdapter } from '../protocol-adapter.js';
+import type {
+  AdapterConfig,
+  AdapterStatus,
+  SessionOptions,
+  Attachment,
+} from '../protocol-adapter.js';
+import type { ChatEvent } from '../chat-events.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('hook-adapter');
+
+/** Common hook event payload from all three agent backends */
+export interface HookEventPayload {
+  type: string;
+  sessionId?: string;
+  data?: Record<string, unknown>;
+}
+
+export abstract class BaseHookAdapter extends BaseProtocolAdapter {
+  protected _status: AdapterStatus = 'disconnected';
+  protected _config: AdapterConfig | null = null;
+  protected _process: ChildProcess | null = null;
+  protected _turnCounter = 0;
+  protected _currentTurnId: string | null = null;
+
+  get status(): AdapterStatus {
+    return this._status;
+  }
+
+  get process(): ChildProcess | null {
+    return this._process;
+  }
+
+  /** Subclasses implement to build spawn command + args + env */
+  protected abstract buildSpawnCommand(config: AdapterConfig): {
+    command: string;
+    args: string[];
+    env: Record<string, string>;
+  };
+
+  /** Subclasses implement to set up hook infrastructure (config files, plugins) */
+  protected abstract setupHooks(config: AdapterConfig): Promise<void>;
+
+  /** Subclasses implement to clean up hook infrastructure */
+  protected abstract cleanupHooks(config: AdapterConfig): Promise<void>;
+
+  /** Subclasses implement to map an incoming hook event to ChatEvents (call fire() directly) */
+  protected abstract mapHookEvent(payload: HookEventPayload): void;
+
+  async connect(config: AdapterConfig): Promise<void> {
+    this._config = config;
+    this._status = 'connecting';
+
+    await this.setupHooks(config);
+
+    const { command, args, env } = this.buildSpawnCommand(config);
+
+    this._process = spawn(command, args, {
+      cwd: config.cwd,
+      env: { ...process.env, ...env },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    this._process.on('exit', (code) => {
+      logger.info(`[${this.agentType}] process exited with code ${code}`);
+      if (this._status === 'connected') {
+        this._status = 'error';
+        this.fire({
+          type: 'chat:error',
+          kind: 'protocol',
+          message: `Agent process exited with code ${code}`,
+          retryable: true,
+        });
+        this.fire({ type: 'chat:session-status', status: 'disconnected' });
+      }
+    });
+
+    this._process.on('error', (err) => {
+      logger.error(`[${this.agentType}] process error:`, err);
+      this._status = 'error';
+      this.fire({
+        type: 'chat:error',
+        kind: 'protocol',
+        message: err.message,
+        retryable: false,
+      });
+    });
+
+    this._status = 'connected';
+    this.fire({
+      type: 'chat:session-started',
+      sessionId: config.sessionId,
+      agentType: this.agentType,
+    });
+    this.fire({ type: 'chat:session-status', status: 'idle' });
+  }
+
+  protected async onDisconnect(): Promise<void> {
+    if (this._process) {
+      try {
+        this._process.kill('SIGTERM');
+      } catch {
+        /* may already be dead */
+      }
+      this._process = null;
+    }
+    if (this._config) {
+      await this.cleanupHooks(this._config).catch(() => {});
+    }
+    this._status = 'disconnected';
+  }
+
+  async reconnect(): Promise<void> {
+    if (!this._config)
+      throw new Error('Cannot reconnect before initial connect');
+    const config = this._config;
+    await this.disconnect();
+    await this.connect(config);
+  }
+
+  /** Called by the web-session HTTP handler when a hook event arrives */
+  handleHookEvent(payload: HookEventPayload): void {
+    this.mapHookEvent(payload);
+  }
+
+  async sendMessage(
+    turnId: string,
+    content: string,
+    _attachments?: Attachment[]
+  ): Promise<void> {
+    if (!this._process?.stdin?.writable) {
+      throw new Error('Agent process stdin not available');
+    }
+    this._currentTurnId = turnId;
+    this.fire({ type: 'chat:session-status', status: 'active' });
+    this.fire({
+      type: 'chat:turn-started',
+      turnId,
+      turnIndex: this._turnCounter++,
+    });
+    // Write the message to the agent's stdin
+    this._process.stdin.write(content + '\n');
+  }
+
+  async interrupt(_turnId: string): Promise<void> {
+    if (this._process) {
+      this._process.kill('SIGINT');
+    }
+  }
+
+  async respondToApproval(
+    _requestId: string,
+    decision: 'allow' | 'allow-always' | 'deny'
+  ): Promise<void> {
+    if (this._process?.stdin?.writable) {
+      if (decision === 'allow' || decision === 'allow-always') {
+        this._process.stdin.write('y\n');
+      } else {
+        this._process.stdin.write('n\n');
+      }
+    }
+  }
+
+  async respondToInput(
+    _requestId: string,
+    answers: Record<string, string[]>
+  ): Promise<void> {
+    if (this._process?.stdin?.writable) {
+      const firstAnswer = Object.values(answers)[0]?.[0];
+      if (firstAnswer) this._process.stdin.write(firstAnswer + '\n');
+    }
+  }
+
+  async createSession(
+    _cwd: string,
+    _options?: SessionOptions
+  ): Promise<string> {
+    return this._config?.sessionId ?? crypto.randomBytes(8).toString('hex');
+  }
+
+  async resumeSession(_sessionId: string): Promise<void> {
+    // no-op — resume handled by spawn args
+  }
+
+  async forkSession(_sessionId: string): Promise<string> {
+    return crypto.randomBytes(8).toString('hex');
+  }
+
+  /** Helper to build full ChatEvent from partial (same pattern as MockProtocolAdapter) */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  protected fire(partial: {
+    type: ChatEvent['type'];
+    [key: string]: any;
+  }): void {
+    const sessionId = this._config?.sessionId ?? '';
+    this.emit({
+      ...partial,
+      sessionId,
+      timestamp: new Date().toISOString(),
+      source: this.agentType as 'codex' | 'opencode' | 'claude',
+    } as ChatEvent);
+  }
+}

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -1,0 +1,158 @@
+import crypto from 'node:crypto';
+import type { AdapterConfig } from '../protocol-adapter.js';
+import { BaseHookAdapter } from './base-hook-adapter.js';
+import type { HookEventPayload } from './base-hook-adapter.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('claude-adapter');
+
+function strField(
+  data: Record<string, unknown> | undefined,
+  key: string,
+  fallback = ''
+): string {
+  return String(data?.[key] ?? fallback);
+}
+
+export class ClaudeProtocolAdapter extends BaseHookAdapter {
+  readonly agentType = 'claude';
+
+  protected buildSpawnCommand(config: AdapterConfig): {
+    command: string;
+    args: string[];
+    env: Record<string, string>;
+  } {
+    const args = ['--output-format', 'stream-json'];
+    if (config.permissionMode) {
+      args.push('--allowedTools', config.permissionMode);
+    }
+    return {
+      command: 'claude',
+      args,
+      env: {
+        CLAUDE_CODE_NO_FLICKER: '1',
+        CLAUDE_CODE_HOOKS_URL: `http://127.0.0.1:${config.port}/hooks/agent-event`,
+        CLAUDE_CODE_HOOKS_TOKEN: config.hookToken,
+        CLAUDE_CODE_SESSION_ID: config.sessionId,
+      },
+    };
+  }
+
+  protected async setupHooks(_config: AdapterConfig): Promise<void> {
+    logger.info('Claude hooks configured via environment variables');
+  }
+
+  protected async cleanupHooks(_config: AdapterConfig): Promise<void> {
+    // No temp files to clean up for Claude
+  }
+
+  protected mapHookEvent(payload: HookEventPayload): void {
+    switch (payload.type) {
+      case 'assistant':
+        this.handleAssistant(payload);
+        break;
+      case 'tool.started':
+      case 'PreToolUse':
+        this.handleToolStarted(payload);
+        break;
+      case 'tool.finished':
+      case 'PostToolUse':
+        this.handleToolFinished(payload);
+        break;
+      case 'session.idle':
+      case 'Stop':
+        this.handleIdle();
+        break;
+      case 'permission.requested':
+      case 'notification':
+        this.handlePermission(payload);
+        break;
+      default:
+        logger.debug('Unhandled Claude hook event:', payload.type);
+    }
+  }
+
+  private handleAssistant(payload: HookEventPayload): void {
+    const content = payload.data?.['content'] as string | undefined;
+    if (!content) return;
+    const turnId = this._currentTurnId ?? 'turn-0';
+    this.fire({
+      type: 'chat:text-delta',
+      turnId,
+      messageId: `msg-${turnId}`,
+      delta: content,
+    });
+  }
+
+  private handleToolStarted(payload: HookEventPayload): void {
+    const turnId = this._currentTurnId ?? 'turn-0';
+    const tool = payload.data?.['tool'] as Record<string, unknown> | undefined;
+    this.fire({
+      type: 'chat:tool-call',
+      turnId,
+      toolCallId: strField(payload.data, 'toolCallId', crypto.randomUUID()),
+      toolName: String(
+        tool?.['name'] ?? strField(payload.data, 'toolName', 'unknown')
+      ),
+      description: String(tool?.['description'] ?? ''),
+      input: (tool?.['input'] ?? payload.data?.['input'] ?? {}) as Record<
+        string,
+        unknown
+      >,
+      status: 'running',
+    });
+  }
+
+  private handleToolFinished(payload: HookEventPayload): void {
+    const turnId = this._currentTurnId ?? 'turn-0';
+    const errorVal = payload.data?.['error'];
+    this.fire({
+      type: 'chat:tool-result',
+      turnId,
+      toolCallId: strField(payload.data, 'toolCallId'),
+      toolName: strField(payload.data, 'toolName', 'unknown'),
+      status: errorVal ? 'error' : 'completed',
+      output: strField(payload.data, 'output'),
+      durationMs: Number(payload.data?.['durationMs'] ?? 0),
+      ...(errorVal ? { error: String(errorVal) } : {}),
+    });
+  }
+
+  private handleIdle(): void {
+    if (this._currentTurnId) {
+      this.fire({
+        type: 'chat:turn-completed',
+        turnId: this._currentTurnId,
+        reason: 'completed',
+        durationMs: 0,
+        toolCallCount: 0,
+        messageCount: 1,
+      });
+      this._currentTurnId = null;
+    }
+    this.fire({ type: 'chat:session-status', status: 'idle' });
+  }
+
+  private handlePermission(payload: HookEventPayload): void {
+    if (
+      payload.data?.['type'] !== 'permission' &&
+      !payload.data?.['permission']
+    )
+      return;
+    const turnId = this._currentTurnId ?? 'turn-0';
+    this.fire({
+      type: 'chat:approval-request',
+      turnId,
+      requestId: strField(payload.data, 'requestId', crypto.randomUUID()),
+      kind: 'permission',
+      toolName: strField(payload.data, 'toolName', 'unknown'),
+      description: strField(payload.data, 'description'),
+      target: strField(payload.data, 'target'),
+    });
+    this.fire({
+      type: 'chat:session-status',
+      status: 'idle',
+      waitingOn: 'approval',
+    });
+  }
+}

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -2,17 +2,10 @@ import crypto from 'node:crypto';
 import type { AdapterConfig } from '../protocol-adapter.js';
 import { BaseHookAdapter } from './base-hook-adapter.js';
 import type { HookEventPayload } from './base-hook-adapter.js';
+import { strField } from './adapter-utils.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('claude-adapter');
-
-function strField(
-  data: Record<string, unknown> | undefined,
-  key: string,
-  fallback = ''
-): string {
-  return String(data?.[key] ?? fallback);
-}
 
 export class ClaudeProtocolAdapter extends BaseHookAdapter {
   readonly agentType = 'claude';

--- a/server/protocol-adapters/codex-adapter.ts
+++ b/server/protocol-adapters/codex-adapter.ts
@@ -6,17 +6,10 @@ import {
 } from '../codex-hooks-adapter.js';
 import { BaseHookAdapter } from './base-hook-adapter.js';
 import type { HookEventPayload } from './base-hook-adapter.js';
+import { strField } from './adapter-utils.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('codex-adapter');
-
-function strField(
-  data: Record<string, unknown> | undefined,
-  key: string,
-  fallback = ''
-): string {
-  return String(data?.[key] ?? fallback);
-}
 
 export class CodexProtocolAdapter extends BaseHookAdapter {
   readonly agentType = 'codex';

--- a/server/protocol-adapters/codex-adapter.ts
+++ b/server/protocol-adapters/codex-adapter.ts
@@ -1,0 +1,123 @@
+import crypto from 'node:crypto';
+import type { AdapterConfig } from '../protocol-adapter.js';
+import {
+  writeCodexHooksAdapter,
+  cleanupCodexHooksAdapter,
+} from '../codex-hooks-adapter.js';
+import { BaseHookAdapter } from './base-hook-adapter.js';
+import type { HookEventPayload } from './base-hook-adapter.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('codex-adapter');
+
+function strField(
+  data: Record<string, unknown> | undefined,
+  key: string,
+  fallback = ''
+): string {
+  return String(data?.[key] ?? fallback);
+}
+
+export class CodexProtocolAdapter extends BaseHookAdapter {
+  readonly agentType = 'codex';
+
+  private _codexConfigDir: string | null = null;
+
+  protected buildSpawnCommand(_config: AdapterConfig): {
+    command: string;
+    args: string[];
+    env: Record<string, string>;
+  } {
+    const env: Record<string, string> = {};
+    if (this._codexConfigDir) {
+      env['CODEX_CONFIG_DIR'] = this._codexConfigDir;
+    }
+    return { command: 'codex', args: [], env };
+  }
+
+  protected async setupHooks(config: AdapterConfig): Promise<void> {
+    this._codexConfigDir = writeCodexHooksAdapter(
+      config.sessionId,
+      config.port,
+      config.hookToken,
+      config.configDir
+    );
+    logger.info('Codex hooks adapter written to', this._codexConfigDir);
+  }
+
+  protected async cleanupHooks(config: AdapterConfig): Promise<void> {
+    cleanupCodexHooksAdapter(config.sessionId);
+    this._codexConfigDir = null;
+  }
+
+  protected mapHookEvent(payload: HookEventPayload): void {
+    switch (payload.type) {
+      case 'session.started':
+        logger.debug('Codex session.started received');
+        break;
+      case 'session.ended':
+        this.handleSessionEnded();
+        break;
+      case 'prompt.submitted':
+        this.fire({ type: 'chat:session-status', status: 'active' });
+        break;
+      case 'tool.started':
+        this.handleToolStarted(payload);
+        break;
+      case 'tool.finished':
+        this.handleToolFinished(payload);
+        break;
+      default:
+        logger.debug('Unhandled Codex hook event:', payload.type);
+    }
+  }
+
+  private handleSessionEnded(): void {
+    if (this._currentTurnId) {
+      this.fire({
+        type: 'chat:turn-completed',
+        turnId: this._currentTurnId,
+        reason: 'completed',
+        durationMs: 0,
+        toolCallCount: 0,
+        messageCount: 1,
+      });
+      this._currentTurnId = null;
+    }
+    this.fire({ type: 'chat:session-status', status: 'idle' });
+  }
+
+  private handleToolStarted(payload: HookEventPayload): void {
+    const turnId = this._currentTurnId ?? 'turn-0';
+    const tool = payload.data?.['tool'] as Record<string, unknown> | undefined;
+    this.fire({
+      type: 'chat:tool-call',
+      turnId,
+      toolCallId: strField(payload.data, 'toolCallId', crypto.randomUUID()),
+      toolName: String(
+        tool?.['name'] ?? strField(payload.data, 'toolName', 'unknown')
+      ),
+      description: String(tool?.['description'] ?? ''),
+      input: (tool?.['input'] ?? payload.data?.['input'] ?? {}) as Record<
+        string,
+        unknown
+      >,
+      status: 'running',
+    });
+  }
+
+  private handleToolFinished(payload: HookEventPayload): void {
+    const turnId = this._currentTurnId ?? 'turn-0';
+    const errorVal = payload.data?.['error'];
+    this.fire({
+      type: 'chat:tool-result',
+      turnId,
+      toolCallId: strField(payload.data, 'toolCallId'),
+      toolName: strField(payload.data, 'toolName', 'unknown'),
+      status: errorVal ? 'error' : 'completed',
+      output: strField(payload.data, 'output'),
+      durationMs: Number(payload.data?.['durationMs'] ?? 0),
+      ...(errorVal ? { error: String(errorVal) } : {}),
+    });
+  }
+}

--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -1,8 +1,14 @@
 import type { ProtocolAdapter } from '../protocol-adapter.js';
 import { MockProtocolAdapter } from './mock-adapter.js';
+import { ClaudeProtocolAdapter } from './claude-adapter.js';
+import { CodexProtocolAdapter } from './codex-adapter.js';
+import { OpencodeProtocolAdapter } from './opencode-adapter.js';
 
 export const adapters: Record<string, () => ProtocolAdapter> = {
   mock: () => new MockProtocolAdapter(),
+  claude: () => new ClaudeProtocolAdapter(),
+  codex: () => new CodexProtocolAdapter(),
+  opencode: () => new OpencodeProtocolAdapter(),
 };
 
 export function createAdapter(agentType: string): ProtocolAdapter {

--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -1,0 +1,15 @@
+import type { ProtocolAdapter } from '../protocol-adapter.js';
+import { MockProtocolAdapter } from './mock-adapter.js';
+
+export const adapters: Record<string, () => ProtocolAdapter> = {
+  mock: () => new MockProtocolAdapter(),
+};
+
+export function createAdapter(agentType: string): ProtocolAdapter {
+  const factory = adapters[agentType];
+  if (!factory)
+    throw new Error(
+      `No protocol adapter registered for agent type: ${agentType}`
+    );
+  return factory();
+}

--- a/server/protocol-adapters/mock-adapter.ts
+++ b/server/protocol-adapters/mock-adapter.ts
@@ -201,16 +201,15 @@ export class MockProtocolAdapter extends BaseProtocolAdapter {
 
   // ── Event Helper ──────────────────────────────────────────────────────────
 
-  // TypeScript cannot distribute Omit over discriminated unions, so we accept
-  // a loose type and cast to ChatEvent at the emit boundary.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private fire(partial: { type: ChatEvent['type']; [key: string]: any }): void {
+  private fire(
+    partial: { type: ChatEvent['type'] } & Record<string, unknown>
+  ): void {
     const sessionId = this._config?.sessionId ?? 'mock';
     this.emit({
       ...partial,
       sessionId,
       timestamp: nowIso(),
-      source: 'claude',
+      source: 'mock',
     } as ChatEvent);
   }
 

--- a/server/protocol-adapters/mock-adapter.ts
+++ b/server/protocol-adapters/mock-adapter.ts
@@ -1,0 +1,518 @@
+import crypto from 'node:crypto';
+import { BaseProtocolAdapter } from '../protocol-adapter.js';
+import type {
+  AdapterConfig,
+  AdapterStatus,
+  SessionOptions,
+} from '../protocol-adapter.js';
+import type { ChatEvent } from '../chat-events.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('mock-adapter');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(t);
+        reject(new DOMException('aborted', 'AbortError'));
+      },
+      { once: true }
+    );
+  });
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+interface ScenarioResult {
+  toolCallCount: number;
+  messageCount: number;
+  durationMs: number;
+}
+
+/** Configurable delays for mock scenarios — pass zeros in tests for instant playback */
+export interface MockAdapterDelays {
+  wordMs: number;
+  toolMs: number;
+  connectMs: number;
+  errorMs: number;
+}
+
+const DEFAULT_DELAYS: MockAdapterDelays = {
+  wordMs: 50,
+  toolMs: 100,
+  connectMs: 150,
+  errorMs: 500,
+};
+
+// ── MockProtocolAdapter ───────────────────────────────────────────────────────
+
+export class MockProtocolAdapter extends BaseProtocolAdapter {
+  readonly agentType = 'mock';
+
+  _status: AdapterStatus = 'disconnected';
+  _config: AdapterConfig | null = null;
+  _abortController: AbortController | null = null;
+  _pendingApprovals: Map<
+    string,
+    (decision: 'allow' | 'allow-always' | 'deny') => void
+  > = new Map();
+
+  private readonly delays: MockAdapterDelays;
+
+  constructor(delays: Partial<MockAdapterDelays> = {}) {
+    super();
+    this.delays = { ...DEFAULT_DELAYS, ...delays };
+  }
+
+  get status(): AdapterStatus {
+    return this._status;
+  }
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  async connect(config: AdapterConfig): Promise<void> {
+    this._config = config;
+    this._status = 'connecting';
+    await sleep(this.delays.connectMs);
+    this._status = 'connected';
+    this.fire({
+      type: 'chat:session-started',
+      sessionId: config.sessionId,
+      agentType: 'mock',
+    });
+    this.fire({
+      type: 'chat:session-status',
+      status: 'idle',
+    });
+  }
+
+  protected async onDisconnect(): Promise<void> {
+    this._abortController?.abort();
+    this._status = 'disconnected';
+  }
+
+  async reconnect(): Promise<void> {
+    if (!this._config)
+      throw new Error('Cannot reconnect before initial connect');
+    const config = this._config;
+    await this.disconnect();
+    await this.connect(config);
+  }
+
+  // ── User Actions ──────────────────────────────────────────────────────────
+
+  async sendMessage(
+    turnId: string,
+    content: string,
+    _attachments?: import('../protocol-adapter.js').Attachment[]
+  ): Promise<void> {
+    // Abort any in-flight turn before starting a new one
+    this._abortController?.abort();
+    const controller = new AbortController();
+    this._abortController = controller;
+    const signal = controller.signal;
+
+    const scenarioMatch = /scenario:(\S+)/i.exec(content);
+    const scenarioName = scenarioMatch?.[1] ?? 'happy-path';
+
+    const startMs = Date.now();
+
+    this.fire({ type: 'chat:session-status', status: 'active' });
+    this.fire({ type: 'chat:turn-started', turnId, turnIndex: 0 });
+
+    try {
+      const result = await this.runScenario(scenarioName, turnId, signal);
+      this.fire({
+        type: 'chat:turn-completed',
+        turnId,
+        reason: 'completed',
+        durationMs: result.durationMs,
+        toolCallCount: result.toolCallCount,
+        messageCount: result.messageCount,
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        this.fire({
+          type: 'chat:turn-completed',
+          turnId,
+          reason: 'interrupted',
+          durationMs: 0,
+          toolCallCount: 0,
+          messageCount: 0,
+        });
+      } else {
+        this.fire({
+          type: 'chat:turn-completed',
+          turnId,
+          reason: 'failed',
+          durationMs: Date.now() - startMs,
+          toolCallCount: 0,
+          messageCount: 0,
+        });
+      }
+    }
+
+    this.fire({ type: 'chat:session-status', status: 'idle' });
+  }
+
+  async interrupt(_turnId: string): Promise<void> {
+    this._abortController?.abort();
+  }
+
+  async respondToApproval(
+    requestId: string,
+    decision: 'allow' | 'allow-always' | 'deny'
+  ): Promise<void> {
+    const resolver = this._pendingApprovals.get(requestId);
+    if (resolver) {
+      resolver(decision);
+      this._pendingApprovals.delete(requestId);
+    }
+  }
+
+  async respondToInput(
+    _requestId: string,
+    _answers: Record<string, string[]>
+  ): Promise<void> {
+    // no-op for mock
+  }
+
+  async createSession(
+    _cwd: string,
+    _options?: SessionOptions
+  ): Promise<string> {
+    return 'mock-session-' + crypto.randomBytes(4).toString('hex');
+  }
+
+  async resumeSession(_sessionId: string): Promise<void> {
+    // no-op for mock
+  }
+
+  async forkSession(_sessionId: string): Promise<string> {
+    return 'mock-fork-' + crypto.randomBytes(4).toString('hex');
+  }
+
+  // ── Event Helper ──────────────────────────────────────────────────────────
+
+  // TypeScript cannot distribute Omit over discriminated unions, so we accept
+  // a loose type and cast to ChatEvent at the emit boundary.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private fire(partial: { type: ChatEvent['type']; [key: string]: any }): void {
+    const sessionId = this._config?.sessionId ?? 'mock';
+    this.emit({
+      ...partial,
+      sessionId,
+      timestamp: nowIso(),
+      source: 'claude',
+    } as ChatEvent);
+  }
+
+  /** Stream text word-by-word, then emit a MessageCompleteEvent */
+  private async streamText(
+    turnId: string,
+    messageId: string,
+    text: string,
+    signal: AbortSignal
+  ): Promise<void> {
+    for (const word of text.split(' ')) {
+      await sleep(this.delays.wordMs, signal);
+      this.fire({
+        type: 'chat:text-delta',
+        turnId,
+        messageId,
+        delta: word + ' ',
+      });
+    }
+    this.fire({
+      type: 'chat:message-complete',
+      turnId,
+      messageId,
+      role: 'assistant',
+      content: text,
+    });
+  }
+
+  // ── Scenarios ─────────────────────────────────────────────────────────────
+
+  private async runScenario(
+    name: string,
+    turnId: string,
+    signal: AbortSignal
+  ): Promise<ScenarioResult> {
+    switch (name) {
+      case 'happy-path':
+        return this.scenarioHappyPath(turnId, signal);
+      case 'tool-chain':
+        return this.scenarioToolChain(turnId, signal);
+      case 'approval-flow':
+        return this.scenarioApprovalFlow(turnId, signal);
+      case 'file-changes':
+        return this.scenarioFileChanges(turnId, signal);
+      case 'error-recovery':
+        return this.scenarioErrorRecovery(turnId, signal);
+      default:
+        logger.warn('Unknown mock scenario, falling back to happy-path', {
+          name,
+        });
+        return this.scenarioHappyPath(turnId, signal);
+    }
+  }
+
+  private async scenarioHappyPath(
+    turnId: string,
+    signal: AbortSignal
+  ): Promise<ScenarioResult> {
+    await this.streamText(
+      turnId,
+      'msg-happy-1',
+      'hello! this is a mock response.',
+      signal
+    );
+    return { toolCallCount: 0, messageCount: 1, durationMs: 500 };
+  }
+
+  private async scenarioToolChain(
+    turnId: string,
+    signal: AbortSignal
+  ): Promise<ScenarioResult> {
+    const messageId = 'msg-toolchain-1';
+
+    // Tool 1: Read
+    this.fire({
+      type: 'chat:tool-call',
+      turnId,
+      toolCallId: 'tool-1',
+      toolName: 'Read',
+      description: 'Reading server/index.ts',
+      input: { file_path: 'server/index.ts' },
+      status: 'running',
+    });
+    await sleep(this.delays.toolMs, signal);
+    for (const line of ['line 1\n', 'line 2\n', 'line 3\n']) {
+      this.fire({
+        type: 'chat:tool-output-delta',
+        turnId,
+        toolCallId: 'tool-1',
+        delta: line,
+      });
+    }
+    this.fire({
+      type: 'chat:tool-result',
+      turnId,
+      toolCallId: 'tool-1',
+      toolName: 'Read',
+      status: 'completed',
+      durationMs: 200,
+    });
+
+    // Tool 2: Bash
+    this.fire({
+      type: 'chat:tool-call',
+      turnId,
+      toolCallId: 'tool-2',
+      toolName: 'Bash',
+      description: 'Running git status',
+      input: { command: 'git status' },
+      status: 'running',
+    });
+    await sleep(this.delays.toolMs, signal);
+    this.fire({
+      type: 'chat:tool-result',
+      turnId,
+      toolCallId: 'tool-2',
+      toolName: 'Bash',
+      status: 'completed',
+      output: 'On branch main\nnothing to commit',
+      durationMs: 150,
+    });
+
+    await this.streamText(
+      turnId,
+      messageId,
+      'done! read the file and checked git status.',
+      signal
+    );
+    return { toolCallCount: 2, messageCount: 1, durationMs: 800 };
+  }
+
+  private async scenarioApprovalFlow(
+    turnId: string,
+    signal: AbortSignal
+  ): Promise<ScenarioResult> {
+    const messageId = 'msg-approval-1';
+
+    this.fire({
+      type: 'chat:tool-call',
+      turnId,
+      toolCallId: 'tool-1',
+      toolName: 'Bash',
+      description: 'Running dangerous command',
+      input: { command: 'rm -rf /tmp/test' },
+      status: 'pending',
+    });
+    this.fire({
+      type: 'chat:approval-request',
+      turnId,
+      requestId: 'req-1',
+      kind: 'command',
+      toolName: 'Bash',
+      description: 'Run: rm -rf /tmp/test',
+      target: 'rm -rf /tmp/test',
+      timeoutMs: 30000,
+    });
+
+    const decision = await new Promise<'allow' | 'allow-always' | 'deny'>(
+      (resolve, reject) => {
+        this._pendingApprovals.set('req-1', resolve);
+        signal.addEventListener(
+          'abort',
+          () => {
+            this._pendingApprovals.delete('req-1');
+            reject(new DOMException('aborted', 'AbortError'));
+          },
+          { once: true }
+        );
+      }
+    );
+
+    this.fire({
+      type: 'chat:approval-response',
+      turnId,
+      requestId: 'req-1',
+      decision,
+      respondedBy: 'user',
+    });
+
+    let responseText: string;
+    if (decision === 'allow' || decision === 'allow-always') {
+      this.fire({
+        type: 'chat:tool-call',
+        turnId,
+        toolCallId: 'tool-1',
+        toolName: 'Bash',
+        description: 'Running dangerous command',
+        input: { command: 'rm -rf /tmp/test' },
+        status: 'running',
+      });
+      await sleep(this.delays.toolMs * 2, signal);
+      this.fire({
+        type: 'chat:tool-result',
+        turnId,
+        toolCallId: 'tool-1',
+        toolName: 'Bash',
+        status: 'completed',
+        durationMs: 200,
+      });
+      responseText = 'ok, done.';
+    } else {
+      this.fire({
+        type: 'chat:tool-call',
+        turnId,
+        toolCallId: 'tool-1',
+        toolName: 'Bash',
+        description: 'Running dangerous command',
+        input: { command: 'rm -rf /tmp/test' },
+        status: 'declined',
+      });
+      this.fire({
+        type: 'chat:tool-result',
+        turnId,
+        toolCallId: 'tool-1',
+        toolName: 'Bash',
+        status: 'declined',
+        durationMs: 0,
+      });
+      responseText = 'understood, skipping.';
+    }
+
+    await this.streamText(turnId, messageId, responseText, signal);
+    return { toolCallCount: 1, messageCount: 1, durationMs: 500 };
+  }
+
+  private async scenarioFileChanges(
+    turnId: string,
+    signal: AbortSignal
+  ): Promise<ScenarioResult> {
+    const files = ['server/index.ts', 'server/ws.ts', 'server/sessions.ts'];
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i]!;
+      const toolCallId = `tool-${i + 1}`;
+      this.fire({
+        type: 'chat:tool-call',
+        turnId,
+        toolCallId,
+        toolName: 'Edit',
+        description: `Editing ${file}`,
+        input: { file_path: file },
+        status: 'running',
+      });
+      await sleep(this.delays.toolMs, signal);
+      this.fire({
+        type: 'chat:file-change',
+        turnId,
+        toolCallId,
+        path: file,
+        kind: 'modified',
+        additions: 5,
+        deletions: 2,
+      });
+      this.fire({
+        type: 'chat:tool-result',
+        turnId,
+        toolCallId,
+        toolName: 'Edit',
+        status: 'completed',
+        durationMs: 100,
+      });
+    }
+
+    await this.streamText(
+      turnId,
+      'msg-filechange-1',
+      'updated 3 files.',
+      signal
+    );
+    return { toolCallCount: 3, messageCount: 1, durationMs: 600 };
+  }
+
+  private async scenarioErrorRecovery(
+    turnId: string,
+    signal: AbortSignal
+  ): Promise<ScenarioResult> {
+    const messageId = 'msg-error-1';
+
+    this.fire({
+      type: 'chat:text-delta',
+      turnId,
+      messageId,
+      delta: 'starting task...',
+    });
+    await sleep(this.delays.toolMs * 2, signal);
+
+    this.fire({
+      type: 'chat:error',
+      kind: 'network',
+      message: 'connection to model timed out',
+      retryable: true,
+      turnId,
+    });
+
+    await sleep(this.delays.errorMs, signal);
+
+    await this.streamText(
+      turnId,
+      messageId,
+      'retrying... success! task complete.',
+      signal
+    );
+    return { toolCallCount: 0, messageCount: 1, durationMs: 1000 };
+  }
+}

--- a/server/protocol-adapters/opencode-adapter.ts
+++ b/server/protocol-adapters/opencode-adapter.ts
@@ -3,27 +3,10 @@ import type { AdapterConfig } from '../protocol-adapter.js';
 import { installOpencodeRelayPlugin } from '../opencode-relay.js';
 import { BaseHookAdapter } from './base-hook-adapter.js';
 import type { HookEventPayload } from './base-hook-adapter.js';
+import { strField, objField } from './adapter-utils.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('opencode-adapter');
-
-function strField(
-  data: Record<string, unknown> | undefined,
-  key: string,
-  fallback = ''
-): string {
-  return String(data?.[key] ?? fallback);
-}
-
-function objField(
-  data: Record<string, unknown> | undefined,
-  key: string
-): Record<string, unknown> | undefined {
-  const val = data?.[key];
-  return typeof val === 'object' && val !== null
-    ? (val as Record<string, unknown>)
-    : undefined;
-}
 
 export class OpencodeProtocolAdapter extends BaseHookAdapter {
   readonly agentType = 'opencode';

--- a/server/protocol-adapters/opencode-adapter.ts
+++ b/server/protocol-adapters/opencode-adapter.ts
@@ -1,0 +1,203 @@
+import crypto from 'node:crypto';
+import type { AdapterConfig } from '../protocol-adapter.js';
+import { installOpencodeRelayPlugin } from '../opencode-relay.js';
+import { BaseHookAdapter } from './base-hook-adapter.js';
+import type { HookEventPayload } from './base-hook-adapter.js';
+import { createLogger } from '../logger.js';
+
+const logger = createLogger('opencode-adapter');
+
+function strField(
+  data: Record<string, unknown> | undefined,
+  key: string,
+  fallback = ''
+): string {
+  return String(data?.[key] ?? fallback);
+}
+
+function objField(
+  data: Record<string, unknown> | undefined,
+  key: string
+): Record<string, unknown> | undefined {
+  const val = data?.[key];
+  return typeof val === 'object' && val !== null
+    ? (val as Record<string, unknown>)
+    : undefined;
+}
+
+export class OpencodeProtocolAdapter extends BaseHookAdapter {
+  readonly agentType = 'opencode';
+
+  protected buildSpawnCommand(config: AdapterConfig): {
+    command: string;
+    args: string[];
+    env: Record<string, string>;
+  } {
+    return {
+      command: 'opencode',
+      args: [],
+      env: {
+        CRC_RELAY_URL: `http://127.0.0.1:${config.port}`,
+        CRC_SESSION_ID: config.sessionId,
+        CRC_RELAY_TOKEN: config.hookToken,
+      },
+    };
+  }
+
+  protected async setupHooks(_config: AdapterConfig): Promise<void> {
+    const pluginPath = installOpencodeRelayPlugin();
+    logger.info('OpenCode relay plugin installed at', pluginPath);
+  }
+
+  protected async cleanupHooks(_config: AdapterConfig): Promise<void> {
+    // Plugin persists across sessions — no cleanup needed
+  }
+
+  protected mapHookEvent(payload: HookEventPayload): void {
+    switch (payload.type) {
+      case 'session.started':
+        logger.debug('OpenCode session.started received');
+        break;
+      case 'session.idle':
+        this.handleIdle();
+        break;
+      case 'state.changed':
+        this.handleStateChanged(payload);
+        break;
+      case 'permission.requested':
+        this.handlePermissionRequested(payload);
+        break;
+      case 'permission.resolved':
+        this.handlePermissionResolved();
+        break;
+      case 'tool.started':
+        this.handleToolStarted(payload);
+        break;
+      case 'tool.finished':
+        this.handleToolFinished(payload);
+        break;
+      case 'telemetry.updated':
+        this.handleTelemetry(payload);
+        break;
+      default:
+        logger.debug('Unhandled OpenCode hook event:', payload.type);
+    }
+  }
+
+  private handleIdle(): void {
+    if (this._currentTurnId) {
+      this.fire({
+        type: 'chat:turn-completed',
+        turnId: this._currentTurnId,
+        reason: 'completed',
+        durationMs: 0,
+        toolCallCount: 0,
+        messageCount: 1,
+      });
+      this._currentTurnId = null;
+    }
+    this.fire({ type: 'chat:session-status', status: 'idle' });
+  }
+
+  private handleStateChanged(payload: HookEventPayload): void {
+    if (payload.data?.['status'] !== 'error') return;
+    const errorMsg = strField(payload.data, 'error', 'Unknown error');
+    this.fire({
+      type: 'chat:error',
+      kind: 'unknown',
+      message: errorMsg,
+      retryable: true,
+    });
+    this.fire({ type: 'chat:session-status', status: 'error' });
+  }
+
+  private handlePermissionRequested(payload: HookEventPayload): void {
+    const turnId = this._currentTurnId ?? 'turn-0';
+    const permission = objField(payload.data, 'permission');
+    this.fire({
+      type: 'chat:approval-request',
+      turnId,
+      requestId: strField(payload.data, 'requestId', crypto.randomUUID()),
+      kind: 'permission',
+      toolName: String(
+        permission?.['tool'] ?? strField(payload.data, 'toolName', 'unknown')
+      ),
+      description: String(
+        permission?.['description'] ?? strField(payload.data, 'description')
+      ),
+      target: String(
+        permission?.['target'] ?? strField(payload.data, 'target')
+      ),
+    });
+    this.fire({
+      type: 'chat:session-status',
+      status: 'idle',
+      waitingOn: 'approval',
+    });
+  }
+
+  private handlePermissionResolved(): void {
+    if (this._currentTurnId) {
+      this.fire({ type: 'chat:session-status', status: 'active' });
+    }
+  }
+
+  private handleToolStarted(payload: HookEventPayload): void {
+    const turnId = this._currentTurnId ?? 'turn-0';
+    const tool = objField(payload.data, 'tool');
+    this.fire({
+      type: 'chat:tool-call',
+      turnId,
+      toolCallId: strField(payload.data, 'toolCallId', crypto.randomUUID()),
+      toolName: String(
+        tool?.['name'] ?? strField(payload.data, 'toolName', 'unknown')
+      ),
+      description: String(tool?.['description'] ?? ''),
+      input: (tool?.['input'] ?? payload.data?.['input'] ?? {}) as Record<
+        string,
+        unknown
+      >,
+      status: 'running',
+    });
+  }
+
+  private handleToolFinished(payload: HookEventPayload): void {
+    const turnId = this._currentTurnId ?? 'turn-0';
+    const result = objField(payload.data, 'result');
+    const tool = objField(payload.data, 'tool');
+    const errorVal = result?.['error'] ?? payload.data?.['error'];
+    this.fire({
+      type: 'chat:tool-result',
+      turnId,
+      toolCallId: strField(payload.data, 'toolCallId'),
+      toolName: String(
+        tool?.['name'] ?? strField(payload.data, 'toolName', 'unknown')
+      ),
+      status: errorVal ? 'error' : 'completed',
+      output: String(result?.['output'] ?? strField(payload.data, 'output')),
+      durationMs: Number(
+        result?.['durationMs'] ?? payload.data?.['durationMs'] ?? 0
+      ),
+      ...(errorVal ? { error: String(errorVal) } : {}),
+    });
+  }
+
+  private handleTelemetry(payload: HookEventPayload): void {
+    const message = objField(payload.data, 'message');
+    if (!message) return;
+    const tokens = objField(message, 'tokens');
+    if (!tokens) return;
+    this.fire({
+      type: 'chat:telemetry',
+      turnId: this._currentTurnId ?? undefined,
+      model: String(message['model'] ?? ''),
+      inputTokens: Number(tokens['input'] ?? 0),
+      outputTokens: Number(tokens['output'] ?? 0),
+      cacheReadTokens: Number(tokens['cache_read'] ?? 0),
+      cacheWriteTokens: Number(tokens['cache_write'] ?? 0),
+      costUsd: tokens['cost'] != null ? Number(tokens['cost']) : null,
+      contextPercent: 0,
+      contextWindowSize: 0,
+    });
+  }
+}

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -12,6 +12,7 @@ import type {
   SessionSummary,
   SessionMeta,
   SessionType,
+  WebSession,
 } from './types.js';
 export type { BackendDisplayState };
 import {
@@ -23,6 +24,10 @@ import {
 import { createPtySession, upgradeHooksSettings } from './pty-handler.js';
 import { cleanupCodexHooksAdapter } from './codex-hooks-adapter.js';
 import type { CreatePtyParams } from './pty-handler.js';
+import {
+  createWebSession,
+  type CreateWebParams,
+} from './web-session-handler.js';
 import { getWorkingTreeDiff } from './git.js';
 import { getPrForBranch, isStalePr } from './gh.js';
 import {
@@ -904,9 +909,33 @@ async function populateMetaCache(): Promise<void> {
   );
 }
 
+async function createWeb(
+  params: CreateWebParams
+): Promise<{ session: WebSession }> {
+  const result = await createWebSession(
+    params,
+    sessions,
+    fireBackendStateIfChanged
+  );
+  trackEvent({
+    category: 'session',
+    action: 'created',
+    target: result.session.id,
+    properties: {
+      agent: params.agentType,
+      type: 'agent',
+      workspace: params.repoPath,
+      mode: 'web',
+    },
+    session_id: result.session.id,
+  });
+  return result;
+}
+
 export {
   configure,
   create,
+  createWeb,
   get,
   list,
   kill,
@@ -929,3 +958,4 @@ export {
   AGENT_CONTINUE_ARGS,
   AGENT_YOLO_ARGS,
 };
+export type { CreateWebParams };

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -30,6 +30,9 @@ export interface CreateWebParams {
 
 export function pushToBuffer(session: WebSession, event: ChatEvent): void {
   if (session.messages.length >= MESSAGE_BUFFER_MAX) {
+    // Prefer evicting non-approval events so approval state is preserved for reconnecting clients.
+    // If the entire buffer is approvals (pathological case), fall back to FIFO eviction of the
+    // oldest approval to prevent unbounded growth — losing a stale approval is better than OOM.
     const evictIdx = session.messages.findIndex(
       (e) =>
         e.type !== 'chat:approval-request' &&
@@ -101,13 +104,28 @@ export async function createWebSession(
     } else if (event.type === 'chat:approval-request') {
       session.agentState = 'permission-prompt';
       onBackendStateChanged(session);
-    } else if (
-      event.type === 'chat:session-status' &&
-      event.status === 'idle'
-    ) {
-      session.agentState = 'idle';
-      session.idle = true;
+    } else if (event.type === 'chat:approval-response') {
+      session.agentState = 'processing';
+      session.idle = false;
       onBackendStateChanged(session);
+    } else if (event.type === 'chat:session-status') {
+      if (event.status === 'idle') {
+        session.agentState = 'idle';
+        session.idle = true;
+        onBackendStateChanged(session);
+      } else if (event.status === 'active') {
+        session.agentState = 'processing';
+        session.idle = false;
+        onBackendStateChanged(session);
+      } else if (event.status === 'error') {
+        session.agentState = 'error';
+        session.idle = true;
+        onBackendStateChanged(session);
+      } else if (event.status === 'disconnected') {
+        session.agentState = 'idle';
+        session.idle = true;
+        onBackendStateChanged(session);
+      }
     }
 
     session.lastActivity = new Date().toISOString();

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -1,0 +1,141 @@
+import crypto from 'node:crypto';
+import type { ChildProcess } from 'node:child_process';
+import type { WebSession, Session } from './types.js';
+import type { AgentType } from './types.js';
+import type { ChatEvent } from './chat-events.js';
+import { createAdapter } from './protocol-adapters/index.js';
+import type { AdapterConfig } from './protocol-adapter.js';
+import { createLogger } from './logger.js';
+
+const logger = createLogger('web-session');
+const MESSAGE_BUFFER_MAX = 1000;
+
+export interface CreateWebParams {
+  id?: string;
+  agentType: string;
+  cwd: string;
+  repoPath: string;
+  repoName: string;
+  worktreePath?: string | null;
+  branchName: string;
+  displayName: string;
+  port: number;
+  configDir: string;
+  permissionMode?: string;
+  model?: string;
+  workspaceId?: string;
+  additionalDirs?: string[];
+  process?: ChildProcess;
+}
+
+export function pushToBuffer(session: WebSession, event: ChatEvent): void {
+  if (session.messages.length >= MESSAGE_BUFFER_MAX) {
+    const evictIdx = session.messages.findIndex(
+      (e) =>
+        e.type !== 'chat:approval-request' &&
+        e.type !== 'chat:approval-response'
+    );
+    if (evictIdx !== -1) {
+      session.messages.splice(evictIdx, 1);
+    } else {
+      session.messages.shift();
+    }
+  }
+  session.messages.push(event);
+}
+
+export async function createWebSession(
+  params: CreateWebParams,
+  sessionsMap: Map<string, Session>,
+  onBackendStateChanged: (session: Session) => void
+): Promise<{ session: WebSession }> {
+  const id = params.id ?? crypto.randomBytes(8).toString('hex');
+  const adapter = createAdapter(params.agentType);
+
+  const session: WebSession = {
+    mode: 'web',
+    id,
+    type: 'agent',
+    agent: params.agentType as AgentType,
+    repoPath: params.repoPath,
+    worktreePath: params.worktreePath ?? null,
+    cwd: params.cwd,
+    repoName: params.repoName,
+    branchName: params.branchName,
+    displayName: params.displayName,
+    createdAt: new Date().toISOString(),
+    lastActivity: new Date().toISOString(),
+    idle: true,
+    customCommand: null,
+    status: 'active',
+    needsBranchRename: false,
+    agentState: 'initializing',
+    ...(params.workspaceId !== undefined
+      ? { workspaceId: params.workspaceId }
+      : {}),
+    ...(params.additionalDirs !== undefined
+      ? { additionalDirs: params.additionalDirs }
+      : {}),
+    adapter,
+    adapterType: params.agentType,
+    messages: [],
+    currentTurnId: null,
+    ...(params.process !== undefined ? { process: params.process } : {}),
+  };
+
+  sessionsMap.set(id, session);
+
+  adapter.on((event) => {
+    pushToBuffer(session, event);
+
+    if (event.type === 'chat:turn-started') {
+      session.currentTurnId = event.turnId;
+      session.agentState = 'processing';
+      session.idle = false;
+      onBackendStateChanged(session);
+    } else if (event.type === 'chat:turn-completed') {
+      session.currentTurnId = null;
+      session.agentState = 'idle';
+      session.idle = true;
+      onBackendStateChanged(session);
+    } else if (event.type === 'chat:approval-request') {
+      session.agentState = 'permission-prompt';
+      onBackendStateChanged(session);
+    } else if (
+      event.type === 'chat:session-status' &&
+      event.status === 'idle'
+    ) {
+      session.agentState = 'idle';
+      session.idle = true;
+      onBackendStateChanged(session);
+    }
+
+    session.lastActivity = new Date().toISOString();
+  });
+
+  const config: AdapterConfig = {
+    cwd: params.cwd,
+    port: params.port,
+    sessionId: id,
+    hookToken: crypto.randomBytes(16).toString('hex'),
+    configDir: params.configDir,
+    ...(params.permissionMode !== undefined
+      ? { permissionMode: params.permissionMode }
+      : {}),
+    ...(params.model !== undefined ? { model: params.model } : {}),
+  };
+
+  try {
+    await adapter.connect(config);
+  } catch (err) {
+    // Clean up zombie: remove from map and disconnect adapter to clear handlers
+    sessionsMap.delete(id);
+    await adapter.disconnect().catch(() => {});
+    session.agentState = 'error';
+    throw err;
+  }
+
+  logger.info('web session created', { id, agentType: params.agentType });
+
+  return { session };
+}

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -4,7 +4,11 @@ import type { IPty } from 'node-pty';
 import * as sessions from './sessions.js';
 import { WorktreeWatcher } from './watcher.js';
 import type { Session } from './types.js';
+import type { Attachment } from './protocol-adapter.js';
 import { trackEvent } from './analytics.js';
+import { createLogger } from './logger.js';
+
+const logger = createLogger('ws');
 
 function replyPing(ws: WebSocket): void {
   if (ws.readyState === ws.OPEN) ws.send('{"type":"pong"}');
@@ -197,8 +201,75 @@ function setupWebSocket(
       ws.on('close', cleanup);
       ws.on('error', cleanup);
     } else {
-      // Web session — JSON relay will be wired by web-session-handler.ts (PR #213)
+      // Web session — JSON relay
+      // Register the live listener BEFORE replaying the snapshot so no events
+      // are lost in the window between replay completion and listener registration.
+      const snapshot = [...session.messages];
+      const unlisten = session.adapter.on((event) => {
+        if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(event));
+      });
+      for (const event of snapshot) {
+        if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(event));
+      }
+
+      ws.on('message', (msg) => {
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(msg.toString()) as Record<string, unknown>;
+        } catch {
+          return;
+        }
+        switch (parsed['type']) {
+          case 'ping':
+            replyPing(ws);
+            break;
+          case 'send-message':
+            session.adapter
+              .sendMessage(
+                String(parsed['turnId'] ?? ''),
+                String(parsed['content'] ?? ''),
+                parsed['attachments'] as Attachment[] | undefined
+              )
+              .catch((err: unknown) => logger.error('sendMessage error:', err));
+            break;
+          case 'interrupt':
+            session.adapter
+              .interrupt(String(parsed['turnId'] ?? ''))
+              .catch((err: unknown) => logger.error('interrupt error:', err));
+            break;
+          case 'approve': {
+            const decision = parsed['decision'];
+            if (
+              decision !== 'allow' &&
+              decision !== 'allow-always' &&
+              decision !== 'deny'
+            ) {
+              logger.warn('ws: invalid approval decision', { decision });
+              break;
+            }
+            session.adapter
+              .respondToApproval(String(parsed['requestId'] ?? ''), decision)
+              .catch((err: unknown) =>
+                logger.error('respondToApproval error:', err)
+              );
+            break;
+          }
+          case 'input-response':
+            session.adapter
+              .respondToInput(
+                String(parsed['requestId'] ?? ''),
+                (parsed['answers'] as Record<string, string[]> | undefined) ??
+                  {}
+              )
+              .catch((err: unknown) =>
+                logger.error('respondToInput error:', err)
+              );
+            break;
+        }
+      });
+
       const cleanup = () => {
+        unlisten();
         sessionMap.delete(ws);
       };
       ws.on('close', cleanup);

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -14,6 +14,22 @@ function replyPing(ws: WebSocket): void {
   if (ws.readyState === ws.OPEN) ws.send('{"type":"pong"}');
 }
 
+function sendChatError(ws: WebSocket, context: string, err: unknown): void {
+  if (ws.readyState !== ws.OPEN) return;
+  const message = err instanceof Error ? err.message : String(err);
+  ws.send(
+    JSON.stringify({
+      type: 'chat:error',
+      kind: 'protocol',
+      message: `${context}: ${message}`,
+      retryable: false,
+      sessionId: '',
+      timestamp: new Date().toISOString(),
+      source: 'claude',
+    })
+  );
+}
+
 function parseCookies(
   cookieHeader: string | undefined
 ): Record<string, string> {
@@ -217,6 +233,10 @@ function setupWebSocket(
         try {
           parsed = JSON.parse(msg.toString()) as Record<string, unknown>;
         } catch {
+          logger.warn('web session: malformed JSON from client', {
+            sessionId: session.id,
+            preview: msg.toString().slice(0, 200),
+          });
           return;
         }
         switch (parsed['type']) {
@@ -230,12 +250,18 @@ function setupWebSocket(
                 String(parsed['content'] ?? ''),
                 parsed['attachments'] as Attachment[] | undefined
               )
-              .catch((err: unknown) => logger.error('sendMessage error:', err));
+              .catch((err: unknown) => {
+                logger.error('sendMessage error:', err);
+                sendChatError(ws, 'sendMessage failed', err);
+              });
             break;
           case 'interrupt':
             session.adapter
               .interrupt(String(parsed['turnId'] ?? ''))
-              .catch((err: unknown) => logger.error('interrupt error:', err));
+              .catch((err: unknown) => {
+                logger.error('interrupt error:', err);
+                sendChatError(ws, 'interrupt failed', err);
+              });
             break;
           case 'approve': {
             const decision = parsed['decision'];
@@ -249,9 +275,10 @@ function setupWebSocket(
             }
             session.adapter
               .respondToApproval(String(parsed['requestId'] ?? ''), decision)
-              .catch((err: unknown) =>
-                logger.error('respondToApproval error:', err)
-              );
+              .catch((err: unknown) => {
+                logger.error('respondToApproval error:', err);
+                sendChatError(ws, 'approval delivery failed', err);
+              });
             break;
           }
           case 'input-response':
@@ -261,9 +288,10 @@ function setupWebSocket(
                 (parsed['answers'] as Record<string, string[]> | undefined) ??
                   {}
               )
-              .catch((err: unknown) =>
-                logger.error('respondToInput error:', err)
-              );
+              .catch((err: unknown) => {
+                logger.error('respondToInput error:', err);
+                sendChatError(ws, 'input delivery failed', err);
+              });
             break;
         }
       });

--- a/test/adapter-map-hook-event.test.ts
+++ b/test/adapter-map-hook-event.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Tests for mapHookEvent() in all 3 real protocol adapters.
+ * Verifies that native hook payloads are correctly translated into canonical ChatEvents.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ClaudeProtocolAdapter } from '../server/protocol-adapters/claude-adapter.js';
+import { CodexProtocolAdapter } from '../server/protocol-adapters/codex-adapter.js';
+import { OpencodeProtocolAdapter } from '../server/protocol-adapters/opencode-adapter.js';
+import type { ChatEvent } from '../server/chat-events.js';
+import type { AdapterConfig } from '../server/protocol-adapter.js';
+
+vi.mock('../server/logger.js', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../server/sessions.js', () => ({
+  fireBackendStateIfChanged: vi.fn(),
+}));
+
+const BASE_CONFIG: AdapterConfig = {
+  cwd: '/repo',
+  port: 3000,
+  sessionId: 'sess-test',
+  hookToken: 'test-token',
+  configDir: '/config',
+};
+
+/** Collect events emitted by an adapter without spawning a process */
+function collectEvents(
+  adapter:
+    | ClaudeProtocolAdapter
+    | CodexProtocolAdapter
+    | OpencodeProtocolAdapter
+): ChatEvent[] {
+  const events: ChatEvent[] = [];
+  adapter.on((e) => events.push(e));
+  // Set internal config so fire() has a sessionId
+
+  (adapter as any)._config = BASE_CONFIG;
+
+  (adapter as any)._status = 'connected';
+  return events;
+}
+
+// ── Claude Adapter ───────────────────────────────────────────────────────────
+
+describe('ClaudeProtocolAdapter.mapHookEvent', () => {
+  let adapter: ClaudeProtocolAdapter;
+  let events: ChatEvent[];
+
+  beforeEach(() => {
+    adapter = new ClaudeProtocolAdapter();
+    events = collectEvents(adapter);
+    // Set a current turn so events have a turnId
+
+    (adapter as any)._currentTurnId = 'turn-1';
+  });
+
+  it('maps "assistant" payload to chat:text-delta', () => {
+    adapter.handleHookEvent({
+      type: 'assistant',
+      sessionId: 'sess-test',
+      data: { content: 'Hello world' },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('chat:text-delta');
+    const evt = events[0] as ChatEvent & { delta: string };
+    expect(evt.delta).toBe('Hello world');
+  });
+
+  it('ignores assistant payload with no content', () => {
+    adapter.handleHookEvent({
+      type: 'assistant',
+      sessionId: 'sess-test',
+      data: {},
+    });
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('maps "tool.started" / "PreToolUse" to chat:tool-call', () => {
+    for (const type of ['tool.started', 'PreToolUse']) {
+      events.length = 0;
+      adapter.handleHookEvent({
+        type,
+        sessionId: 'sess-test',
+        data: {
+          toolCallId: 'tc-1',
+          tool: {
+            name: 'Bash',
+            description: 'Run command',
+            input: { command: 'ls' },
+          },
+        },
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.type).toBe('chat:tool-call');
+      const evt = events[0] as ChatEvent & { toolName: string; status: string };
+      expect(evt.toolName).toBe('Bash');
+      expect(evt.status).toBe('running');
+    }
+  });
+
+  it('maps "tool.finished" / "PostToolUse" to chat:tool-result', () => {
+    for (const type of ['tool.finished', 'PostToolUse']) {
+      events.length = 0;
+      adapter.handleHookEvent({
+        type,
+        sessionId: 'sess-test',
+        data: {
+          toolCallId: 'tc-1',
+          toolName: 'Bash',
+          output: 'file.txt',
+          durationMs: 150,
+        },
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.type).toBe('chat:tool-result');
+      const evt = events[0] as ChatEvent & {
+        status: string;
+        durationMs: number;
+      };
+      expect(evt.status).toBe('completed');
+      expect(evt.durationMs).toBe(150);
+    }
+  });
+
+  it('maps tool.finished with error to error status', () => {
+    adapter.handleHookEvent({
+      type: 'tool.finished',
+      sessionId: 'sess-test',
+      data: {
+        toolCallId: 'tc-1',
+        toolName: 'Bash',
+        error: 'command not found',
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    const evt = events[0] as ChatEvent & { status: string; error: string };
+    expect(evt.status).toBe('error');
+    expect(evt.error).toBe('command not found');
+  });
+
+  it('maps "session.idle" / "Stop" to turn-completed + session-status idle', () => {
+    for (const type of ['session.idle', 'Stop']) {
+      events.length = 0;
+      // Reset turn
+
+      (adapter as any)._currentTurnId = 'turn-x';
+
+      adapter.handleHookEvent({ type, sessionId: 'sess-test' });
+
+      const types = events.map((e) => e.type);
+      expect(types).toContain('chat:turn-completed');
+      expect(types).toContain('chat:session-status');
+    }
+  });
+
+  it('maps "permission.requested" to chat:approval-request', () => {
+    adapter.handleHookEvent({
+      type: 'permission.requested',
+      sessionId: 'sess-test',
+      data: {
+        type: 'permission',
+        requestId: 'req-1',
+        toolName: 'Bash',
+        description: 'Run rm',
+        target: 'rm -rf /tmp',
+      },
+    });
+
+    expect(events).toHaveLength(2); // approval-request + session-status
+    expect(events[0]!.type).toBe('chat:approval-request');
+    const evt = events[0] as ChatEvent & { toolName: string; target: string };
+    expect(evt.toolName).toBe('Bash');
+    expect(evt.target).toBe('rm -rf /tmp');
+  });
+});
+
+// ── Codex Adapter ────────────────────────────────────────────────────────────
+
+describe('CodexProtocolAdapter.mapHookEvent', () => {
+  let adapter: CodexProtocolAdapter;
+  let events: ChatEvent[];
+
+  beforeEach(() => {
+    adapter = new CodexProtocolAdapter();
+    events = collectEvents(adapter);
+
+    (adapter as any)._currentTurnId = 'turn-1';
+  });
+
+  it('maps "tool.started" to chat:tool-call', () => {
+    adapter.handleHookEvent({
+      type: 'tool.started',
+      sessionId: 'sess-test',
+      data: {
+        toolCallId: 'tc-1',
+        tool: {
+          name: 'Edit',
+          description: 'Edit file',
+          input: { path: 'foo.ts' },
+        },
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('chat:tool-call');
+    const evt = events[0] as ChatEvent & { toolName: string };
+    expect(evt.toolName).toBe('Edit');
+  });
+
+  it('maps "tool.finished" to chat:tool-result', () => {
+    adapter.handleHookEvent({
+      type: 'tool.finished',
+      sessionId: 'sess-test',
+      data: {
+        toolCallId: 'tc-1',
+        toolName: 'Edit',
+        output: 'done',
+        durationMs: 200,
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('chat:tool-result');
+  });
+
+  it('maps "session.ended" to turn-completed + session-status idle', () => {
+    adapter.handleHookEvent({ type: 'session.ended', sessionId: 'sess-test' });
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain('chat:turn-completed');
+    expect(types).toContain('chat:session-status');
+  });
+
+  it('maps "prompt.submitted" to session-status active', () => {
+    adapter.handleHookEvent({
+      type: 'prompt.submitted',
+      sessionId: 'sess-test',
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('chat:session-status');
+    const evt = events[0] as ChatEvent & { status: string };
+    expect(evt.status).toBe('active');
+  });
+});
+
+// ── OpenCode Adapter ─────────────────────────────────────────────────────────
+
+describe('OpencodeProtocolAdapter.mapHookEvent', () => {
+  let adapter: OpencodeProtocolAdapter;
+  let events: ChatEvent[];
+
+  beforeEach(() => {
+    adapter = new OpencodeProtocolAdapter();
+    events = collectEvents(adapter);
+
+    (adapter as any)._currentTurnId = 'turn-1';
+  });
+
+  it('maps "tool.started" to chat:tool-call', () => {
+    adapter.handleHookEvent({
+      type: 'tool.started',
+      sessionId: 'sess-test',
+      data: {
+        toolCallId: 'tc-1',
+        tool: { name: 'Read', description: 'Read file', input: {} },
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('chat:tool-call');
+  });
+
+  it('maps "tool.finished" to chat:tool-result with nested result', () => {
+    adapter.handleHookEvent({
+      type: 'tool.finished',
+      sessionId: 'sess-test',
+      data: {
+        toolCallId: 'tc-1',
+        tool: { name: 'Read' },
+        result: { output: 'file content', durationMs: 100 },
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('chat:tool-result');
+    const evt = events[0] as ChatEvent & { output: string; durationMs: number };
+    expect(evt.output).toBe('file content');
+    expect(evt.durationMs).toBe(100);
+  });
+
+  it('maps "session.idle" to turn-completed + session-status idle', () => {
+    adapter.handleHookEvent({ type: 'session.idle', sessionId: 'sess-test' });
+
+    const types = events.map((e) => e.type);
+    expect(types).toContain('chat:turn-completed');
+    expect(types).toContain('chat:session-status');
+  });
+
+  it('maps "state.changed" with error status to chat:error', () => {
+    adapter.handleHookEvent({
+      type: 'state.changed',
+      sessionId: 'sess-test',
+      data: { status: 'error', error: 'model timeout' },
+    });
+
+    expect(events).toHaveLength(2); // chat:error + session-status
+    expect(events[0]!.type).toBe('chat:error');
+    const evt = events[0] as ChatEvent & { message: string };
+    expect(evt.message).toBe('model timeout');
+  });
+
+  it('ignores "state.changed" with non-error status', () => {
+    adapter.handleHookEvent({
+      type: 'state.changed',
+      sessionId: 'sess-test',
+      data: { status: 'active' },
+    });
+
+    expect(events).toHaveLength(0);
+  });
+
+  it('maps "permission.requested" to chat:approval-request', () => {
+    adapter.handleHookEvent({
+      type: 'permission.requested',
+      sessionId: 'sess-test',
+      data: {
+        requestId: 'req-1',
+        permission: { tool: 'Bash', description: 'Run ls', target: '/tmp' },
+      },
+    });
+
+    expect(events).toHaveLength(2); // approval-request + session-status
+    expect(events[0]!.type).toBe('chat:approval-request');
+    const evt = events[0] as ChatEvent & { toolName: string };
+    expect(evt.toolName).toBe('Bash');
+  });
+
+  it('maps "permission.resolved" to session-status active', () => {
+    adapter.handleHookEvent({
+      type: 'permission.resolved',
+      sessionId: 'sess-test',
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('chat:session-status');
+    const evt = events[0] as ChatEvent & { status: string };
+    expect(evt.status).toBe('active');
+  });
+
+  it('maps "telemetry.updated" to chat:telemetry', () => {
+    adapter.handleHookEvent({
+      type: 'telemetry.updated',
+      sessionId: 'sess-test',
+      data: {
+        message: {
+          model: 'gpt-4',
+          tokens: { input: 100, output: 50, cache_read: 10, cache_write: 5 },
+        },
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('chat:telemetry');
+    const evt = events[0] as ChatEvent & { model: string; inputTokens: number };
+    expect(evt.model).toBe('gpt-4');
+    expect(evt.inputTokens).toBe(100);
+  });
+});

--- a/test/chat-events.test.ts
+++ b/test/chat-events.test.ts
@@ -170,7 +170,7 @@ describe('isChatEvent', () => {
         source: 'unknown',
       })
     ).toBe(false);
-    // 'mock' is test-only and not a valid production source
+    // 'mock' is a valid source (used by MockProtocolAdapter)
     expect(
       isChatEvent({
         type: 'chat:text-delta',
@@ -178,7 +178,7 @@ describe('isChatEvent', () => {
         timestamp: 'y',
         source: 'mock',
       })
-    ).toBe(false);
+    ).toBe(true);
     // missing source fails
     expect(
       isChatEvent({ type: 'chat:text-delta', sessionId: 'x', timestamp: 'y' })

--- a/test/helpers/web-chat-fixtures.ts
+++ b/test/helpers/web-chat-fixtures.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared test fixtures for web chat / web-session tests.
+ * Centralizes makeWebSession, makeBaseEvent, makeApproval, and common constants.
+ */
+import { MockProtocolAdapter } from '../../server/protocol-adapters/mock-adapter.js';
+import type {
+  ChatEvent,
+  ApprovalRequestEvent,
+} from '../../server/chat-events.js';
+import type { WebSession } from '../../server/types.js';
+import type { AdapterConfig } from '../../server/protocol-adapter.js';
+
+export const ZERO_DELAYS = { wordMs: 0, toolMs: 0, connectMs: 0, errorMs: 0 };
+
+export const BASE_CONFIG: AdapterConfig = {
+  cwd: '/repo',
+  port: 3000,
+  sessionId: 'sess-integration',
+  hookToken: 'test-token',
+  configDir: '/config',
+};
+
+export function makeWebSession(
+  overrides: Partial<WebSession> = {}
+): WebSession {
+  return {
+    mode: 'web',
+    id: 'sess-1',
+    type: 'agent',
+    agent: 'mock',
+    repoPath: '/repo',
+    worktreePath: null,
+    cwd: '/repo',
+    repoName: 'repo',
+    branchName: 'main',
+    displayName: 'Test',
+    createdAt: new Date().toISOString(),
+    lastActivity: new Date().toISOString(),
+    idle: true,
+    customCommand: null,
+    status: 'active',
+    needsBranchRename: false,
+    agentState: 'idle',
+    adapter: new MockProtocolAdapter(ZERO_DELAYS),
+    adapterType: 'mock',
+    messages: [],
+    currentTurnId: null,
+    ...overrides,
+  } as WebSession;
+}
+
+export function makeBaseEvent(overrides: Partial<ChatEvent> = {}): ChatEvent {
+  return {
+    type: 'chat:text-delta',
+    sessionId: 'test',
+    timestamp: new Date().toISOString(),
+    source: 'claude',
+    turnId: 'turn-1',
+    messageId: 'msg-1',
+    delta: 'hello',
+    ...overrides,
+  } as ChatEvent;
+}
+
+export function makeApproval(requestId = 'req-1'): ApprovalRequestEvent {
+  return {
+    type: 'chat:approval-request',
+    sessionId: 'test',
+    timestamp: new Date().toISOString(),
+    source: 'claude',
+    turnId: 'turn-1',
+    requestId,
+    kind: 'command',
+    toolName: 'Bash',
+    description: 'Run something',
+    target: 'something',
+  };
+}
+
+/** Connect a MockProtocolAdapter and return an events array (cleared of connect events). */
+export async function connectAndClear(
+  adapter: MockProtocolAdapter
+): Promise<ChatEvent[]> {
+  const events: ChatEvent[] = [];
+  adapter.on((e) => events.push(e));
+  await adapter.connect(BASE_CONFIG);
+  events.length = 0;
+  return events;
+}

--- a/test/web-chat-integration.test.ts
+++ b/test/web-chat-integration.test.ts
@@ -6,11 +6,18 @@ import { CodexProtocolAdapter } from '../server/protocol-adapters/codex-adapter.
 import { OpencodeProtocolAdapter } from '../server/protocol-adapters/opencode-adapter.js';
 import { pushToBuffer } from '../server/web-session-handler.js';
 import { isChatEvent } from '../server/chat-events.js';
-import type { ChatEvent, ApprovalRequestEvent } from '../server/chat-events.js';
-import type { WebSession } from '../server/types.js';
+import type { ChatEvent } from '../server/chat-events.js';
 import type { HookEventPayload } from '../server/protocol-adapters/base-hook-adapter.js';
 import { BaseHookAdapter } from '../server/protocol-adapters/base-hook-adapter.js';
 import type { AdapterConfig } from '../server/protocol-adapter.js';
+import {
+  ZERO_DELAYS,
+  BASE_CONFIG,
+  makeWebSession,
+  makeBaseEvent,
+  makeApproval,
+  connectAndClear,
+} from './helpers/web-chat-fixtures.js';
 
 vi.mock('../server/logger.js', () => ({
   createLogger: () => ({
@@ -24,85 +31,6 @@ vi.mock('../server/logger.js', () => ({
 vi.mock('../server/sessions.js', () => ({
   fireBackendStateIfChanged: vi.fn(),
 }));
-
-// ── Constants ─────────────────────────────────────────────────────────────────
-
-const ZERO_DELAYS = { wordMs: 0, toolMs: 0, connectMs: 0, errorMs: 0 };
-
-const BASE_CONFIG: AdapterConfig = {
-  cwd: '/repo',
-  port: 3000,
-  sessionId: 'sess-integration',
-  hookToken: 'test-token',
-  configDir: '/config',
-};
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function makeWebSession(overrides: Partial<WebSession> = {}): WebSession {
-  return {
-    mode: 'web',
-    id: 'sess-1',
-    type: 'agent',
-    agent: 'mock',
-    repoPath: '/repo',
-    worktreePath: null,
-    cwd: '/repo',
-    repoName: 'repo',
-    branchName: 'main',
-    displayName: 'Test',
-    createdAt: new Date().toISOString(),
-    lastActivity: new Date().toISOString(),
-    idle: true,
-    customCommand: null,
-    status: 'active',
-    needsBranchRename: false,
-    agentState: 'idle',
-    adapter: new MockProtocolAdapter(ZERO_DELAYS),
-    adapterType: 'mock',
-    messages: [],
-    currentTurnId: null,
-    ...overrides,
-  } as WebSession;
-}
-
-function makeBaseEvent(overrides: Partial<ChatEvent> = {}): ChatEvent {
-  return {
-    type: 'chat:text-delta',
-    sessionId: 'test',
-    timestamp: new Date().toISOString(),
-    source: 'claude',
-    turnId: 'turn-1',
-    messageId: 'msg-1',
-    delta: 'hello',
-    ...overrides,
-  } as ChatEvent;
-}
-
-function makeApproval(requestId = 'req-1'): ApprovalRequestEvent {
-  return {
-    type: 'chat:approval-request',
-    sessionId: 'test',
-    timestamp: new Date().toISOString(),
-    source: 'claude',
-    turnId: 'turn-1',
-    requestId,
-    kind: 'command',
-    toolName: 'Bash',
-    description: 'Run something',
-    target: 'something',
-  };
-}
-
-async function connectAndClear(
-  adapter: MockProtocolAdapter
-): Promise<ChatEvent[]> {
-  const events: ChatEvent[] = [];
-  adapter.on((e) => events.push(e));
-  await adapter.connect(BASE_CONFIG);
-  events.length = 0;
-  return events;
-}
 
 // ── 1. Mock adapter scenario contract tests ───────────────────────────────────
 

--- a/test/web-chat-integration.test.ts
+++ b/test/web-chat-integration.test.ts
@@ -1,0 +1,699 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MockProtocolAdapter } from '../server/protocol-adapters/mock-adapter.js';
+import { createAdapter } from '../server/protocol-adapters/index.js';
+import { ClaudeProtocolAdapter } from '../server/protocol-adapters/claude-adapter.js';
+import { CodexProtocolAdapter } from '../server/protocol-adapters/codex-adapter.js';
+import { OpencodeProtocolAdapter } from '../server/protocol-adapters/opencode-adapter.js';
+import { pushToBuffer } from '../server/web-session-handler.js';
+import { isChatEvent } from '../server/chat-events.js';
+import type { ChatEvent, ApprovalRequestEvent } from '../server/chat-events.js';
+import type { WebSession } from '../server/types.js';
+import type { HookEventPayload } from '../server/protocol-adapters/base-hook-adapter.js';
+import { BaseHookAdapter } from '../server/protocol-adapters/base-hook-adapter.js';
+import type { AdapterConfig } from '../server/protocol-adapter.js';
+
+vi.mock('../server/logger.js', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('../server/sessions.js', () => ({
+  fireBackendStateIfChanged: vi.fn(),
+}));
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const ZERO_DELAYS = { wordMs: 0, toolMs: 0, connectMs: 0, errorMs: 0 };
+
+const BASE_CONFIG: AdapterConfig = {
+  cwd: '/repo',
+  port: 3000,
+  sessionId: 'sess-integration',
+  hookToken: 'test-token',
+  configDir: '/config',
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeWebSession(overrides: Partial<WebSession> = {}): WebSession {
+  return {
+    mode: 'web',
+    id: 'sess-1',
+    type: 'agent',
+    agent: 'mock',
+    repoPath: '/repo',
+    worktreePath: null,
+    cwd: '/repo',
+    repoName: 'repo',
+    branchName: 'main',
+    displayName: 'Test',
+    createdAt: new Date().toISOString(),
+    lastActivity: new Date().toISOString(),
+    idle: true,
+    customCommand: null,
+    status: 'active',
+    needsBranchRename: false,
+    agentState: 'idle',
+    adapter: new MockProtocolAdapter(ZERO_DELAYS),
+    adapterType: 'mock',
+    messages: [],
+    currentTurnId: null,
+    ...overrides,
+  } as WebSession;
+}
+
+function makeBaseEvent(overrides: Partial<ChatEvent> = {}): ChatEvent {
+  return {
+    type: 'chat:text-delta',
+    sessionId: 'test',
+    timestamp: new Date().toISOString(),
+    source: 'claude',
+    turnId: 'turn-1',
+    messageId: 'msg-1',
+    delta: 'hello',
+    ...overrides,
+  } as ChatEvent;
+}
+
+function makeApproval(requestId = 'req-1'): ApprovalRequestEvent {
+  return {
+    type: 'chat:approval-request',
+    sessionId: 'test',
+    timestamp: new Date().toISOString(),
+    source: 'claude',
+    turnId: 'turn-1',
+    requestId,
+    kind: 'command',
+    toolName: 'Bash',
+    description: 'Run something',
+    target: 'something',
+  };
+}
+
+async function connectAndClear(
+  adapter: MockProtocolAdapter
+): Promise<ChatEvent[]> {
+  const events: ChatEvent[] = [];
+  adapter.on((e) => events.push(e));
+  await adapter.connect(BASE_CONFIG);
+  events.length = 0;
+  return events;
+}
+
+// ── 1. Mock adapter scenario contract tests ───────────────────────────────────
+
+describe('mock adapter scenarios - contract tests', () => {
+  describe('happy-path scenario', () => {
+    it('emits correct event sequence', async () => {
+      const adapter = new MockProtocolAdapter(ZERO_DELAYS);
+      const events = await connectAndClear(adapter);
+
+      await adapter.sendMessage('turn-1', 'scenario:happy-path');
+
+      const types = events.map((e) => e.type);
+
+      expect(types[0]).toBe('chat:session-status'); // active
+      expect(types[1]).toBe('chat:turn-started');
+      expect(types.some((t) => t === 'chat:text-delta')).toBe(true);
+      expect(types.some((t) => t === 'chat:message-complete')).toBe(true);
+      expect(types.some((t) => t === 'chat:turn-completed')).toBe(true);
+      expect(types[types.length - 1]).toBe('chat:session-status'); // idle at end
+
+      const sessionStatus = events.filter(
+        (e) => e.type === 'chat:session-status'
+      );
+      expect(sessionStatus).toHaveLength(2);
+      if (sessionStatus[0]?.type === 'chat:session-status') {
+        expect(sessionStatus[0].status).toBe('active');
+      }
+      if (sessionStatus[1]?.type === 'chat:session-status') {
+        expect(sessionStatus[1].status).toBe('idle');
+      }
+
+      const turnStarted = events.find((e) => e.type === 'chat:turn-started');
+      expect(turnStarted).toBeDefined();
+      if (turnStarted?.type === 'chat:turn-started') {
+        expect(turnStarted.turnId).toBe('turn-1');
+      }
+
+      const turnCompleted = events.find(
+        (e) => e.type === 'chat:turn-completed'
+      );
+      expect(turnCompleted).toBeDefined();
+      if (turnCompleted?.type === 'chat:turn-completed') {
+        expect(turnCompleted.reason).toBe('completed');
+        expect(turnCompleted.toolCallCount).toBe(0);
+        expect(turnCompleted.messageCount).toBe(1);
+      }
+    });
+  });
+
+  describe('tool-chain scenario', () => {
+    it('emits tool-call, tool-output-delta, and tool-result events', async () => {
+      const adapter = new MockProtocolAdapter(ZERO_DELAYS);
+      const events = await connectAndClear(adapter);
+
+      await adapter.sendMessage('turn-1', 'scenario:tool-chain');
+
+      const types = events.map((e) => e.type);
+
+      expect(types.some((t) => t === 'chat:tool-call')).toBe(true);
+      expect(types.some((t) => t === 'chat:tool-output-delta')).toBe(true);
+      expect(types.some((t) => t === 'chat:tool-result')).toBe(true);
+
+      const toolCalls = events.filter((e) => e.type === 'chat:tool-call');
+      expect(toolCalls.length).toBeGreaterThanOrEqual(2);
+
+      // Verify tool-1 Read call
+      const readCall = toolCalls.find(
+        (e) => e.type === 'chat:tool-call' && e.toolName === 'Read'
+      );
+      expect(readCall).toBeDefined();
+      if (readCall?.type === 'chat:tool-call') {
+        expect(readCall.toolCallId).toBe('tool-1');
+      }
+
+      // Verify tool-2 Bash call
+      const bashCall = toolCalls.find(
+        (e) => e.type === 'chat:tool-call' && e.toolName === 'Bash'
+      );
+      expect(bashCall).toBeDefined();
+
+      // Verify output deltas belong to tool-1
+      const deltas = events.filter((e) => e.type === 'chat:tool-output-delta');
+      expect(deltas.length).toBeGreaterThanOrEqual(1);
+      if (deltas[0]?.type === 'chat:tool-output-delta') {
+        expect(deltas[0].toolCallId).toBe('tool-1');
+      }
+
+      const turnCompleted = events.find(
+        (e) => e.type === 'chat:turn-completed'
+      );
+      if (turnCompleted?.type === 'chat:turn-completed') {
+        expect(turnCompleted.reason).toBe('completed');
+        expect(turnCompleted.toolCallCount).toBe(2);
+        expect(turnCompleted.messageCount).toBe(1);
+      }
+    });
+  });
+
+  describe('approval-flow scenario', () => {
+    it('includes approval-request, pauses until respondToApproval, then approval-response', async () => {
+      const adapter = new MockProtocolAdapter(ZERO_DELAYS);
+      const events = await connectAndClear(adapter);
+
+      const sendPromise = adapter.sendMessage(
+        'turn-1',
+        'scenario:approval-flow'
+      );
+
+      // Wait for approval-request
+      await vi.waitFor(() => {
+        expect(events.some((e) => e.type === 'chat:approval-request')).toBe(
+          true
+        );
+      });
+
+      // turn-completed must NOT yet be emitted
+      expect(events.some((e) => e.type === 'chat:turn-completed')).toBe(false);
+
+      // Respond
+      await adapter.respondToApproval('req-1', 'allow');
+      await sendPromise;
+
+      const approvalReq = events.find(
+        (e) => e.type === 'chat:approval-request'
+      );
+      expect(approvalReq).toBeDefined();
+      if (approvalReq?.type === 'chat:approval-request') {
+        expect(approvalReq.requestId).toBe('req-1');
+        expect(approvalReq.kind).toBe('command');
+        expect(approvalReq.toolName).toBe('Bash');
+      }
+
+      const approvalResp = events.find(
+        (e) => e.type === 'chat:approval-response'
+      );
+      expect(approvalResp).toBeDefined();
+      if (approvalResp?.type === 'chat:approval-response') {
+        expect(approvalResp.requestId).toBe('req-1');
+        expect(approvalResp.decision).toBe('allow');
+      }
+
+      const turnCompleted = events.find(
+        (e) => e.type === 'chat:turn-completed'
+      );
+      if (turnCompleted?.type === 'chat:turn-completed') {
+        expect(turnCompleted.reason).toBe('completed');
+        expect(turnCompleted.toolCallCount).toBe(1);
+      }
+    });
+  });
+
+  describe('file-changes scenario', () => {
+    it('emits file-change events with correct paths', async () => {
+      const adapter = new MockProtocolAdapter(ZERO_DELAYS);
+      const events = await connectAndClear(adapter);
+
+      await adapter.sendMessage('turn-1', 'scenario:file-changes');
+
+      const fileChanges = events.filter((e) => e.type === 'chat:file-change');
+      expect(fileChanges).toHaveLength(3);
+
+      const expectedPaths = [
+        'server/index.ts',
+        'server/ws.ts',
+        'server/sessions.ts',
+      ];
+
+      for (const change of fileChanges) {
+        if (change.type === 'chat:file-change') {
+          expect(expectedPaths).toContain(change.path);
+          expect(change.kind).toBe('modified');
+          expect(change.additions).toBe(5);
+          expect(change.deletions).toBe(2);
+        }
+      }
+
+      const turnCompleted = events.find(
+        (e) => e.type === 'chat:turn-completed'
+      );
+      if (turnCompleted?.type === 'chat:turn-completed') {
+        expect(turnCompleted.toolCallCount).toBe(3);
+      }
+    });
+  });
+
+  describe('error-recovery scenario', () => {
+    it('emits error event with retryable=true', async () => {
+      const adapter = new MockProtocolAdapter(ZERO_DELAYS);
+      const events = await connectAndClear(adapter);
+
+      await adapter.sendMessage('turn-1', 'scenario:error-recovery');
+
+      const errorEvent = events.find((e) => e.type === 'chat:error');
+      expect(errorEvent).toBeDefined();
+      if (errorEvent?.type === 'chat:error') {
+        expect(errorEvent.retryable).toBe(true);
+        expect(errorEvent.kind).toBe('network');
+        expect(errorEvent.message).toBe('connection to model timed out');
+      }
+
+      // scenario recovers and completes successfully
+      const turnCompleted = events.find(
+        (e) => e.type === 'chat:turn-completed'
+      );
+      expect(turnCompleted).toBeDefined();
+      if (turnCompleted?.type === 'chat:turn-completed') {
+        expect(turnCompleted.reason).toBe('completed');
+      }
+    });
+  });
+});
+
+// ── 2. Event type guard contract tests ───────────────────────────────────────
+
+describe('isChatEvent type guard - all mock adapter events pass', () => {
+  it('every event from happy-path passes isChatEvent()', async () => {
+    const adapter = new MockProtocolAdapter(ZERO_DELAYS);
+    const events: ChatEvent[] = [];
+    adapter.on((e) => events.push(e));
+    await adapter.connect(BASE_CONFIG);
+    await adapter.sendMessage('turn-1', 'scenario:happy-path');
+
+    expect(events.length).toBeGreaterThan(0);
+    for (const event of events) {
+      expect(isChatEvent(event)).toBe(true);
+    }
+  });
+
+  it('every event from tool-chain passes isChatEvent()', async () => {
+    const adapter = new MockProtocolAdapter(ZERO_DELAYS);
+    const events: ChatEvent[] = [];
+    adapter.on((e) => events.push(e));
+    await adapter.connect(BASE_CONFIG);
+    await adapter.sendMessage('turn-1', 'scenario:tool-chain');
+
+    expect(events.length).toBeGreaterThan(0);
+    for (const event of events) {
+      expect(isChatEvent(event)).toBe(true);
+    }
+  });
+
+  it('every event from approval-flow passes isChatEvent()', async () => {
+    const adapter = new MockProtocolAdapter(ZERO_DELAYS);
+    const events: ChatEvent[] = [];
+    adapter.on((e) => events.push(e));
+    await adapter.connect(BASE_CONFIG);
+
+    const sendPromise = adapter.sendMessage('turn-1', 'scenario:approval-flow');
+    await vi.waitFor(() =>
+      expect(events.some((e) => e.type === 'chat:approval-request')).toBe(true)
+    );
+    await adapter.respondToApproval('req-1', 'allow');
+    await sendPromise;
+
+    expect(events.length).toBeGreaterThan(0);
+    for (const event of events) {
+      expect(isChatEvent(event)).toBe(true);
+    }
+  });
+
+  it('every event from file-changes passes isChatEvent()', async () => {
+    const adapter = new MockProtocolAdapter(ZERO_DELAYS);
+    const events: ChatEvent[] = [];
+    adapter.on((e) => events.push(e));
+    await adapter.connect(BASE_CONFIG);
+    await adapter.sendMessage('turn-1', 'scenario:file-changes');
+
+    expect(events.length).toBeGreaterThan(0);
+    for (const event of events) {
+      expect(isChatEvent(event)).toBe(true);
+    }
+  });
+
+  it('every event from error-recovery passes isChatEvent()', async () => {
+    const adapter = new MockProtocolAdapter(ZERO_DELAYS);
+    const events: ChatEvent[] = [];
+    adapter.on((e) => events.push(e));
+    await adapter.connect(BASE_CONFIG);
+    await adapter.sendMessage('turn-1', 'scenario:error-recovery');
+
+    expect(events.length).toBeGreaterThan(0);
+    for (const event of events) {
+      expect(isChatEvent(event)).toBe(true);
+    }
+  });
+
+  it('rejects non-ChatEvent objects', () => {
+    expect(isChatEvent(null)).toBe(false);
+    expect(isChatEvent(undefined)).toBe(false);
+    expect(isChatEvent({ type: 'chat:text-delta' })).toBe(false); // missing sessionId, timestamp, source
+    expect(
+      isChatEvent({
+        type: 'not-a-type',
+        sessionId: 's',
+        timestamp: 't',
+        source: 'claude',
+      })
+    ).toBe(false);
+    expect(
+      isChatEvent({
+        type: 'chat:text-delta',
+        sessionId: 's',
+        timestamp: 't',
+        source: 'unknown-source',
+      })
+    ).toBe(false);
+  });
+});
+
+// ── 3. Buffer contract tests ──────────────────────────────────────────────────
+
+describe('pushToBuffer - integration with real event sequences', () => {
+  it('buffers all events from happy-path run', async () => {
+    const adapter = new MockProtocolAdapter(ZERO_DELAYS);
+    const session = makeWebSession({ adapter });
+    adapter.on((e) => pushToBuffer(session, e));
+
+    await adapter.connect(BASE_CONFIG);
+    await adapter.sendMessage('turn-1', 'scenario:happy-path');
+
+    expect(session.messages.length).toBeGreaterThan(0);
+    // connect emits session-started + session-status(idle)
+    // sendMessage emits: session-status(active), turn-started, N text-deltas, message-complete, turn-completed, session-status(idle)
+    expect(
+      session.messages.some((e) => e.type === 'chat:session-started')
+    ).toBe(true);
+    expect(session.messages.some((e) => e.type === 'chat:turn-started')).toBe(
+      true
+    );
+    expect(session.messages.some((e) => e.type === 'chat:text-delta')).toBe(
+      true
+    );
+    expect(
+      session.messages.some((e) => e.type === 'chat:message-complete')
+    ).toBe(true);
+    expect(session.messages.some((e) => e.type === 'chat:turn-completed')).toBe(
+      true
+    );
+  });
+
+  it('maintains cap at 1000 when events exceed limit', () => {
+    const session = makeWebSession();
+
+    // Fill to exactly 1000
+    for (let i = 0; i < 1000; i++) {
+      session.messages.push(makeBaseEvent({ delta: `chunk-${i}` }));
+    }
+    expect(session.messages).toHaveLength(1000);
+
+    // Push 10 more — should evict oldest each time, staying at 1000
+    for (let i = 0; i < 10; i++) {
+      pushToBuffer(session, makeBaseEvent({ delta: `overflow-${i}` }));
+    }
+    expect(session.messages).toHaveLength(1000);
+  });
+
+  it('preserves approval events during eviction', () => {
+    const session = makeWebSession();
+
+    // Fill to 999 with text-delta events then add one approval
+    for (let i = 0; i < 999; i++) {
+      session.messages.push(makeBaseEvent({ delta: `chunk-${i}` }));
+    }
+    const approval = makeApproval('req-preserved');
+    session.messages.push(approval);
+    expect(session.messages).toHaveLength(1000);
+
+    // Push more events — non-approval should be evicted, approval preserved
+    for (let i = 0; i < 5; i++) {
+      pushToBuffer(session, makeBaseEvent({ delta: `new-${i}` }));
+    }
+
+    expect(session.messages).toHaveLength(1000);
+    // The approval must still be in the buffer
+    expect(session.messages.some((e) => e === approval)).toBe(true);
+    // Text deltas at end are the new ones
+    const lastFive = session.messages.slice(-5);
+    for (let i = 0; i < 5; i++) {
+      expect(lastFive[i]?.type).toBe('chat:text-delta');
+    }
+  });
+
+  it('buffers approval events from approval-flow scenario without loss', async () => {
+    const adapter = new MockProtocolAdapter(ZERO_DELAYS);
+    const session = makeWebSession({ adapter });
+    adapter.on((e) => pushToBuffer(session, e));
+
+    await adapter.connect(BASE_CONFIG);
+
+    const sendPromise = adapter.sendMessage('turn-1', 'scenario:approval-flow');
+    await vi.waitFor(() =>
+      expect(
+        session.messages.some((e) => e.type === 'chat:approval-request')
+      ).toBe(true)
+    );
+    await adapter.respondToApproval('req-1', 'allow');
+    await sendPromise;
+
+    expect(
+      session.messages.some((e) => e.type === 'chat:approval-request')
+    ).toBe(true);
+    expect(
+      session.messages.some((e) => e.type === 'chat:approval-response')
+    ).toBe(true);
+  });
+});
+
+// ── 4. Adapter registry tests ─────────────────────────────────────────────────
+
+describe('createAdapter - registry', () => {
+  it('returns MockProtocolAdapter for "mock"', () => {
+    const adapter = createAdapter('mock');
+    expect(adapter).toBeInstanceOf(MockProtocolAdapter);
+    expect(adapter.agentType).toBe('mock');
+  });
+
+  it('returns ClaudeProtocolAdapter for "claude"', () => {
+    const adapter = createAdapter('claude');
+    expect(adapter).toBeInstanceOf(ClaudeProtocolAdapter);
+    expect(adapter.agentType).toBe('claude');
+  });
+
+  it('returns CodexProtocolAdapter for "codex"', () => {
+    const adapter = createAdapter('codex');
+    expect(adapter).toBeInstanceOf(CodexProtocolAdapter);
+    expect(adapter.agentType).toBe('codex');
+  });
+
+  it('returns OpencodeProtocolAdapter for "opencode"', () => {
+    const adapter = createAdapter('opencode');
+    expect(adapter).toBeInstanceOf(OpencodeProtocolAdapter);
+    expect(adapter.agentType).toBe('opencode');
+  });
+
+  it('throws for unknown agent type', () => {
+    expect(() => createAdapter('unknown')).toThrow(
+      'No protocol adapter registered for agent type: unknown'
+    );
+  });
+
+  it('throws for empty string agent type', () => {
+    expect(() => createAdapter('')).toThrow(
+      'No protocol adapter registered for agent type: '
+    );
+  });
+
+  it('each call returns a new instance', () => {
+    const a = createAdapter('mock');
+    const b = createAdapter('mock');
+    expect(a).not.toBe(b);
+  });
+});
+
+// ── 5. BaseHookAdapter lifecycle tests ────────────────────────────────────────
+
+/**
+ * Minimal concrete subclass of BaseHookAdapter for lifecycle testing.
+ * Does not spawn a real process — overrides connect() entirely.
+ */
+class TestHookAdapter extends BaseHookAdapter {
+  readonly agentType = 'test-hook';
+
+  mapHookEventSpy = vi.fn();
+  disconnectSpy = vi.fn();
+  connectSpy = vi.fn();
+
+  protected buildSpawnCommand(_config: AdapterConfig) {
+    return { command: 'echo', args: ['ok'], env: {} };
+  }
+
+  protected async setupHooks(_config: AdapterConfig): Promise<void> {}
+  protected async cleanupHooks(_config: AdapterConfig): Promise<void> {}
+
+  protected mapHookEvent(payload: HookEventPayload): void {
+    this.mapHookEventSpy(payload);
+  }
+
+  // Override connect to avoid actually spawning a process
+  override async connect(config: AdapterConfig): Promise<void> {
+    this.connectSpy(config);
+    this._config = config;
+    this._status = 'connected';
+    this.fire({
+      type: 'chat:session-started',
+      sessionId: config.sessionId,
+      agentType: this.agentType,
+    });
+    this.fire({ type: 'chat:session-status', status: 'idle' });
+  }
+
+  // Override onDisconnect to track calls without process cleanup
+  protected override async onDisconnect(): Promise<void> {
+    this.disconnectSpy();
+    this._status = 'disconnected';
+  }
+}
+
+describe('BaseHookAdapter - lifecycle', () => {
+  let adapter: TestHookAdapter;
+
+  beforeEach(() => {
+    adapter = new TestHookAdapter();
+  });
+
+  it('handleHookEvent calls mapHookEvent with the payload', () => {
+    const payload: HookEventPayload = {
+      type: 'PreToolUse',
+      sessionId: 'sess-1',
+      data: { tool: 'Bash' },
+    };
+
+    adapter.handleHookEvent(payload);
+
+    expect(adapter.mapHookEventSpy).toHaveBeenCalledOnce();
+    expect(adapter.mapHookEventSpy).toHaveBeenCalledWith(payload);
+  });
+
+  it('handleHookEvent can be called multiple times', () => {
+    const payloads: HookEventPayload[] = [
+      { type: 'PreToolUse', sessionId: 'sess-1' },
+      { type: 'PostToolUse', sessionId: 'sess-1' },
+      { type: 'Stop', sessionId: 'sess-1' },
+    ];
+
+    for (const p of payloads) {
+      adapter.handleHookEvent(p);
+    }
+
+    expect(adapter.mapHookEventSpy).toHaveBeenCalledTimes(3);
+    expect(adapter.mapHookEventSpy.mock.calls[0]![0]).toEqual(payloads[0]);
+    expect(adapter.mapHookEventSpy.mock.calls[1]![0]).toEqual(payloads[1]);
+    expect(adapter.mapHookEventSpy.mock.calls[2]![0]).toEqual(payloads[2]);
+  });
+
+  it('reconnect() calls disconnect() then connect() in order', async () => {
+    const callOrder: string[] = [];
+    adapter.disconnectSpy.mockImplementation(() => {
+      callOrder.push('disconnect');
+    });
+    adapter.connectSpy.mockImplementation(() => {
+      callOrder.push('connect');
+    });
+
+    await adapter.connect(BASE_CONFIG);
+    callOrder.length = 0; // reset after initial connect
+
+    await adapter.reconnect();
+
+    expect(callOrder).toEqual(['disconnect', 'connect']);
+  });
+
+  it('reconnect() restores connected status', async () => {
+    await adapter.connect(BASE_CONFIG);
+    expect(adapter.status).toBe('connected');
+
+    await adapter.reconnect();
+
+    expect(adapter.status).toBe('connected');
+  });
+
+  it('reconnect() throws if connect was never called', async () => {
+    await expect(adapter.reconnect()).rejects.toThrow(
+      'Cannot reconnect before initial connect'
+    );
+  });
+
+  it('disconnect() clears event handlers', async () => {
+    await adapter.connect(BASE_CONFIG);
+
+    const received: ChatEvent[] = [];
+    adapter.on((e) => received.push(e));
+
+    await adapter.disconnect();
+
+    // After disconnect, handlers are cleared — fire() on subclass should not reach them
+    adapter.handleHookEvent({ type: 'test' });
+    expect(received).toHaveLength(0);
+  });
+
+  it('initial status is disconnected', () => {
+    expect(adapter.status).toBe('disconnected');
+  });
+
+  it('status is connected after connect()', async () => {
+    await adapter.connect(BASE_CONFIG);
+    expect(adapter.status).toBe('connected');
+  });
+
+  it('status is disconnected after disconnect()', async () => {
+    await adapter.connect(BASE_CONFIG);
+    await adapter.disconnect();
+    expect(adapter.status).toBe('disconnected');
+  });
+});

--- a/test/web-session-handler.test.ts
+++ b/test/web-session-handler.test.ts
@@ -5,8 +5,13 @@ import {
 } from '../server/web-session-handler.js';
 import { createAdapter } from '../server/protocol-adapters/index.js';
 import { MockProtocolAdapter } from '../server/protocol-adapters/mock-adapter.js';
-import type { WebSession, Session } from '../server/types.js';
+import type { Session } from '../server/types.js';
 import type { ChatEvent, ApprovalRequestEvent } from '../server/chat-events.js';
+import {
+  makeWebSession,
+  makeBaseEvent,
+  makeApproval,
+} from './helpers/web-chat-fixtures.js';
 
 vi.mock('../server/logger.js', () => ({
   createLogger: () => ({
@@ -21,63 +26,6 @@ vi.mock('../server/logger.js', () => ({
 vi.mock('../server/sessions.js', () => ({
   fireBackendStateIfChanged: vi.fn(),
 }));
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function makeBaseEvent(overrides: Partial<ChatEvent> = {}): ChatEvent {
-  return {
-    type: 'chat:text-delta',
-    sessionId: 'test',
-    timestamp: new Date().toISOString(),
-    source: 'claude',
-    turnId: 'turn-1',
-    messageId: 'msg-1',
-    delta: 'hello',
-    ...overrides,
-  } as ChatEvent;
-}
-
-function makeApproval(requestId = 'req-1'): ApprovalRequestEvent {
-  return {
-    type: 'chat:approval-request',
-    sessionId: 'test',
-    timestamp: new Date().toISOString(),
-    source: 'claude',
-    turnId: 'turn-1',
-    requestId,
-    kind: 'command',
-    toolName: 'Bash',
-    description: 'Run something',
-    target: 'something',
-  };
-}
-
-function makeWebSession(overrides: Partial<WebSession> = {}): WebSession {
-  return {
-    mode: 'web',
-    id: 'sess-1',
-    type: 'agent',
-    agent: 'mock',
-    repoPath: '/repo',
-    worktreePath: null,
-    cwd: '/repo',
-    repoName: 'repo',
-    branchName: 'main',
-    displayName: 'Test',
-    createdAt: new Date().toISOString(),
-    lastActivity: new Date().toISOString(),
-    idle: true,
-    customCommand: null,
-    status: 'active',
-    needsBranchRename: false,
-    agentState: 'idle',
-    adapter: new MockProtocolAdapter(),
-    adapterType: 'mock',
-    messages: [],
-    currentTurnId: null,
-    ...overrides,
-  } as WebSession;
-}
 
 // ── pushToBuffer ──────────────────────────────────────────────────────────────
 

--- a/test/web-session-handler.test.ts
+++ b/test/web-session-handler.test.ts
@@ -1,0 +1,425 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  pushToBuffer,
+  createWebSession,
+} from '../server/web-session-handler.js';
+import { createAdapter } from '../server/protocol-adapters/index.js';
+import { MockProtocolAdapter } from '../server/protocol-adapters/mock-adapter.js';
+import type { WebSession, Session } from '../server/types.js';
+import type { ChatEvent, ApprovalRequestEvent } from '../server/chat-events.js';
+
+vi.mock('../server/logger.js', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+// Mock sessions.fireBackendStateIfChanged since web-session-handler imports it
+vi.mock('../server/sessions.js', () => ({
+  fireBackendStateIfChanged: vi.fn(),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBaseEvent(overrides: Partial<ChatEvent> = {}): ChatEvent {
+  return {
+    type: 'chat:text-delta',
+    sessionId: 'test',
+    timestamp: new Date().toISOString(),
+    source: 'claude',
+    turnId: 'turn-1',
+    messageId: 'msg-1',
+    delta: 'hello',
+    ...overrides,
+  } as ChatEvent;
+}
+
+function makeApproval(requestId = 'req-1'): ApprovalRequestEvent {
+  return {
+    type: 'chat:approval-request',
+    sessionId: 'test',
+    timestamp: new Date().toISOString(),
+    source: 'claude',
+    turnId: 'turn-1',
+    requestId,
+    kind: 'command',
+    toolName: 'Bash',
+    description: 'Run something',
+    target: 'something',
+  };
+}
+
+function makeWebSession(overrides: Partial<WebSession> = {}): WebSession {
+  return {
+    mode: 'web',
+    id: 'sess-1',
+    type: 'agent',
+    agent: 'mock',
+    repoPath: '/repo',
+    worktreePath: null,
+    cwd: '/repo',
+    repoName: 'repo',
+    branchName: 'main',
+    displayName: 'Test',
+    createdAt: new Date().toISOString(),
+    lastActivity: new Date().toISOString(),
+    idle: true,
+    customCommand: null,
+    status: 'active',
+    needsBranchRename: false,
+    agentState: 'idle',
+    adapter: new MockProtocolAdapter(),
+    adapterType: 'mock',
+    messages: [],
+    currentTurnId: null,
+    ...overrides,
+  } as WebSession;
+}
+
+// ── pushToBuffer ──────────────────────────────────────────────────────────────
+
+describe('pushToBuffer', () => {
+  it('pushes events into the messages array', () => {
+    const session = makeWebSession();
+    const event = makeBaseEvent();
+    pushToBuffer(session, event);
+    expect(session.messages).toHaveLength(1);
+    expect(session.messages[0]).toBe(event);
+  });
+
+  it('evicts oldest non-approval event when at cap (1000)', () => {
+    const session = makeWebSession();
+    // Fill to 999 with text-delta events
+    for (let i = 0; i < 999; i++) {
+      session.messages.push(makeBaseEvent({ delta: `chunk-${i}` }));
+    }
+    // Push one approval event (should not be evicted)
+    const approval = makeApproval('req-evict-test');
+    session.messages.push(approval);
+    expect(session.messages).toHaveLength(1000);
+
+    // Now push one more — should evict the FIRST text-delta (index 0), not the approval
+    const newEvent = makeBaseEvent({ delta: 'new' });
+    pushToBuffer(session, newEvent);
+
+    expect(session.messages).toHaveLength(1000);
+    // chunk-0 (index 0) was evicted; chunk-1 is now at index 0
+    expect(session.messages[0]?.type).toBe('chat:text-delta');
+    // The approval (was at index 999) is now at index 998
+    expect(session.messages[998]).toBe(approval);
+    // New event is at the end
+    expect(session.messages[session.messages.length - 1]).toBe(newEvent);
+  });
+
+  it('evicts oldest non-approval event (first non-approval wins)', () => {
+    const session = makeWebSession();
+    // Approval first, then text events to fill to 1000
+    const approval = makeApproval('req-1');
+    session.messages.push(approval);
+    for (let i = 0; i < 999; i++) {
+      session.messages.push(makeBaseEvent({ delta: `chunk-${i}` }));
+    }
+    expect(session.messages).toHaveLength(1000);
+
+    // Push another event — evict first non-approval (chunk-0 at index 1)
+    const newEvent = makeBaseEvent({ delta: 'new' });
+    pushToBuffer(session, newEvent);
+
+    expect(session.messages).toHaveLength(1000);
+    // Approval at index 0 should survive
+    expect(session.messages[0]).toBe(approval);
+    // New event at end
+    expect(session.messages[session.messages.length - 1]).toBe(newEvent);
+  });
+
+  it('shifts from front when all events are approvals', () => {
+    const session = makeWebSession();
+    // Fill with 1000 approval events
+    for (let i = 0; i < 1000; i++) {
+      session.messages.push(makeApproval(`req-${i}`));
+    }
+    const newEvent = makeApproval('req-overflow');
+    pushToBuffer(session, newEvent);
+
+    expect(session.messages).toHaveLength(1000);
+    // First approval (req-0) should be gone, new one at end
+    expect((session.messages[0] as ApprovalRequestEvent).requestId).toBe(
+      'req-1'
+    );
+    expect(
+      (session.messages[session.messages.length - 1] as ApprovalRequestEvent)
+        .requestId
+    ).toBe('req-overflow');
+  });
+});
+
+// ── createAdapter ─────────────────────────────────────────────────────────────
+
+describe('createAdapter', () => {
+  it('returns a MockProtocolAdapter for agent type "mock"', () => {
+    const adapter = createAdapter('mock');
+    expect(adapter).toBeInstanceOf(MockProtocolAdapter);
+    expect(adapter.agentType).toBe('mock');
+  });
+
+  it('throws for unknown agent types', () => {
+    expect(() => createAdapter('unknown-agent')).toThrow(
+      'No protocol adapter registered for agent type: unknown-agent'
+    );
+  });
+
+  it('throws for empty string agent type', () => {
+    expect(() => createAdapter('')).toThrow(
+      'No protocol adapter registered for agent type: '
+    );
+  });
+});
+
+// ── MockProtocolAdapter ───────────────────────────────────────────────────────
+
+describe('MockProtocolAdapter - happy-path scenario', () => {
+  it('emits the correct event sequence', async () => {
+    const adapter = new MockProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((e) => events.push(e));
+
+    await adapter.connect({
+      cwd: '/repo',
+      port: 3000,
+      sessionId: 'sess-1',
+      hookToken: 'tok',
+      configDir: '/config',
+    });
+
+    events.length = 0; // clear connect events
+
+    await adapter.sendMessage('turn-1', 'hello');
+
+    const types = events.map((e) => e.type);
+    expect(types[0]).toBe('chat:session-status'); // active
+    expect(types[1]).toBe('chat:turn-started');
+    expect(types.some((t) => t === 'chat:text-delta')).toBe(true);
+    expect(types.some((t) => t === 'chat:message-complete')).toBe(true);
+    expect(types.some((t) => t === 'chat:turn-completed')).toBe(true);
+    // Last event should be session-status idle
+    expect(types[types.length - 1]).toBe('chat:session-status');
+
+    const turnCompleted = events.find((e) => e.type === 'chat:turn-completed');
+    expect(turnCompleted).toBeDefined();
+    if (turnCompleted?.type === 'chat:turn-completed') {
+      expect(turnCompleted.reason).toBe('completed');
+      expect(turnCompleted.toolCallCount).toBe(0);
+      expect(turnCompleted.messageCount).toBe(1);
+    }
+  });
+});
+
+describe('MockProtocolAdapter - interrupt', () => {
+  it('stops emission and emits turn-completed with reason interrupted', async () => {
+    const adapter = new MockProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((e) => events.push(e));
+
+    await adapter.connect({
+      cwd: '/repo',
+      port: 3000,
+      sessionId: 'sess-1',
+      hookToken: 'tok',
+      configDir: '/config',
+    });
+    events.length = 0;
+
+    // Start sendMessage but don't await — interrupt immediately
+    const sendPromise = adapter.sendMessage('turn-1', 'scenario:happy-path');
+
+    // Interrupt after a tick
+    await new Promise((r) => setTimeout(r, 10));
+    await adapter.interrupt('turn-1');
+
+    await sendPromise;
+
+    const turnCompleted = events.find((e) => e.type === 'chat:turn-completed');
+    expect(turnCompleted).toBeDefined();
+    if (turnCompleted?.type === 'chat:turn-completed') {
+      expect(turnCompleted.reason).toBe('interrupted');
+      expect(turnCompleted.durationMs).toBe(0);
+    }
+  });
+});
+
+describe('MockProtocolAdapter - approval-flow scenario', () => {
+  it('pauses until respondToApproval is called', async () => {
+    const adapter = new MockProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((e) => events.push(e));
+
+    await adapter.connect({
+      cwd: '/repo',
+      port: 3000,
+      sessionId: 'sess-1',
+      hookToken: 'tok',
+      configDir: '/config',
+    });
+    events.length = 0;
+
+    const sendPromise = adapter.sendMessage('turn-1', 'scenario:approval-flow');
+
+    // Wait for approval-request to arrive
+    await vi.waitFor(() => {
+      expect(events.some((e) => e.type === 'chat:approval-request')).toBe(true);
+    });
+
+    // Confirm turn-completed has NOT been emitted yet (still waiting)
+    expect(events.some((e) => e.type === 'chat:turn-completed')).toBe(false);
+
+    // Respond to approval
+    await adapter.respondToApproval('req-1', 'allow');
+
+    await sendPromise;
+
+    const turnCompleted = events.find((e) => e.type === 'chat:turn-completed');
+    expect(turnCompleted).toBeDefined();
+    if (turnCompleted?.type === 'chat:turn-completed') {
+      expect(turnCompleted.reason).toBe('completed');
+      expect(turnCompleted.toolCallCount).toBe(1);
+    }
+
+    const approvalResponse = events.find(
+      (e) => e.type === 'chat:approval-response'
+    );
+    expect(approvalResponse).toBeDefined();
+    if (approvalResponse?.type === 'chat:approval-response') {
+      expect(approvalResponse.decision).toBe('allow');
+    }
+  });
+
+  it('handles deny decision correctly', async () => {
+    const adapter = new MockProtocolAdapter();
+    const events: ChatEvent[] = [];
+    adapter.on((e) => events.push(e));
+
+    await adapter.connect({
+      cwd: '/repo',
+      port: 3000,
+      sessionId: 'sess-1',
+      hookToken: 'tok',
+      configDir: '/config',
+    });
+    events.length = 0;
+
+    const sendPromise = adapter.sendMessage('turn-1', 'scenario:approval-flow');
+
+    await vi.waitFor(() => {
+      expect(events.some((e) => e.type === 'chat:approval-request')).toBe(true);
+    });
+
+    await adapter.respondToApproval('req-1', 'deny');
+    await sendPromise;
+
+    const approvalResponse = events.find(
+      (e) => e.type === 'chat:approval-response'
+    );
+    if (approvalResponse?.type === 'chat:approval-response') {
+      expect(approvalResponse.decision).toBe('deny');
+    }
+
+    // Check for declined tool result
+    const toolResults = events.filter((e) => e.type === 'chat:tool-result');
+    expect(
+      toolResults.some(
+        (e) => e.type === 'chat:tool-result' && e.status === 'declined'
+      )
+    ).toBe(true);
+  });
+});
+
+// ── createWebSession ──────────────────────────────────────────────────────────
+
+describe('createWebSession', () => {
+  let sessionsMap: Map<string, Session>;
+  let onBackendStateChanged: (session: Session) => void;
+
+  beforeEach(() => {
+    sessionsMap = new Map();
+    onBackendStateChanged = vi.fn() as unknown as (session: Session) => void;
+  });
+
+  it('creates a web session and adds it to sessionsMap', async () => {
+    const { session } = await createWebSession(
+      {
+        agentType: 'mock',
+        cwd: '/repo',
+        repoPath: '/repo',
+        repoName: 'repo',
+        branchName: 'main',
+        displayName: 'Test Session',
+        port: 3000,
+        configDir: '/config',
+      },
+      sessionsMap,
+      onBackendStateChanged
+    );
+
+    expect(session.mode).toBe('web');
+    expect(session.adapterType).toBe('mock');
+    expect(sessionsMap.has(session.id)).toBe(true);
+    expect(sessionsMap.get(session.id)).toBe(session);
+  });
+
+  it('uses provided id if given', async () => {
+    const { session } = await createWebSession(
+      {
+        id: 'custom-id',
+        agentType: 'mock',
+        cwd: '/repo',
+        repoPath: '/repo',
+        repoName: 'repo',
+        branchName: 'main',
+        displayName: 'Test',
+        port: 3000,
+        configDir: '/config',
+      },
+      sessionsMap,
+      onBackendStateChanged
+    );
+
+    expect(session.id).toBe('custom-id');
+  });
+
+  it('updates agentState on turn lifecycle events', async () => {
+    const { session } = await createWebSession(
+      {
+        agentType: 'mock',
+        cwd: '/repo',
+        repoPath: '/repo',
+        repoName: 'repo',
+        branchName: 'main',
+        displayName: 'Test',
+        port: 3000,
+        configDir: '/config',
+      },
+      sessionsMap,
+      onBackendStateChanged
+    );
+
+    // After connect, agentState should be 'idle' (from chat:session-status idle event)
+    expect(session.agentState).toBe('idle');
+
+    // Send a message and check state transitions
+    const sendPromise = session.adapter.sendMessage('turn-1', 'hello');
+
+    // Wait for turn-started to fire
+    await vi.waitFor(() => {
+      expect(session.agentState).toBe('processing');
+    });
+
+    await sendPromise;
+
+    expect(session.agentState).toBe('idle');
+    expect(session.idle).toBe(true);
+    expect(session.currentTurnId).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Full implementation of the unified web chat interface ([#209](https://github.com/donovan-yohan/relay-ide/issues/209)). Builds on the foundation in #224.

### Backend (#213, #214)
- `web-session-handler.ts` — WebSession creation, 1000-event bounded buffer, adapter wiring
- `protocol-adapters/mock-adapter.ts` — 5 scenarios with configurable delays
- `protocol-adapters/index.ts` — Adapter registry
- `ws.ts` — JSON relay with snapshot-then-listener reconnect pattern, decision validation

### Frontend (#218-#221)
- `useChatSocket.ts` — WebSocket hook with auto-reconnect, ping/pong
- `ChatView.tsx` — Container composing MessageTimeline + Composer
- `MessageTimeline.tsx` — Turn-grouped event rendering (text, tools, files, approvals, errors)
- `ToolCard.tsx`, `FileChangeCard.tsx`, `ApprovalCard.tsx` — Chat event card components
- `Composer.tsx` — Auto-resize textarea, Enter to send, interrupt when active
- `App.tsx` — SessionContent routes ChatView vs Terminal by mode

### Real Adapters (#215-#217)
- `base-hook-adapter.ts` — Shared subprocess spawn/lifecycle, stdin messaging
- `claude-adapter.ts` — Claude Code via hook env vars
- `codex-adapter.ts` — Codex via bash relay script (reuses writeCodexHooksAdapter)
- `opencode-adapter.ts` — OpenCode via TS plugin (reuses installOpencodeRelayPlugin)

### Polish (#222, #223)
- ARIA roles/labels on all chat components
- Responsive CSS (< 768px): truncation, stacked buttons, width caps
- 31 integration tests: scenario contracts, type guard contracts, buffer contracts, registry, lifecycle

Closes #213, closes #214, closes #215, closes #216, closes #217, closes #218, closes #219, closes #220, closes #221, closes #222, closes #223.

## Test plan
- [ ] `tsc --noEmit` — clean (both tsconfigs)
- [ ] 65 new tests (14 unit + 31 integration + 20 chat-events)
- [ ] Full suite passes with no regressions on PTY sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)