### PR TITLE
feat: use personal xterm.js fork with WebGPU renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,14 @@ By default the app polls GitHub every 30 seconds for PR and CI status. Connect a
 - **Update notifications** — toast notification when a new version is available, with one-click update
 - **CLI self-update** — `relay-ide update` to update from npm
 
+## terminal renderer (xterm.js fork)
+
+relay-ide uses a [fork of xterm.js](https://github.com/donovan-yohan/xterm.js) instead of the official npm package. the fork adds the experimental WebGPU renderer ([xtermjs/xterm.js#5666](https://github.com/xtermjs/xterm.js/pull/5666)) and gives us the ability to patch terminal behavior for our use case.
+
+the fork stays as close to upstream as possible. you can verify the exact differences from upstream and reproduce the build artifacts yourself — see the fork's [FORK.md](https://github.com/donovan-yohan/xterm.js/blob/master/FORK.md) for details.
+
+the dependency in `package.json` is pinned to a specific commit hash so every install is deterministic and auditable.
+
 ## Architecture
 
 TypeScript + ESM backend (Express + node-pty + WebSocket) compiled to `dist/`. Svelte 5 frontend (runes + Vite) compiled to `dist/frontend/`.

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -9,6 +9,7 @@ import React, {
 import { Terminal as XTerminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
+import { WebgpuAddon } from '@xterm/addon-webgpu';
 import '@xterm/xterm/css/xterm.css';
 import { connectPtySocket, sendPtyData, sendPtyResize } from '../lib/ws.js';
 import { isMobileDevice } from '../lib/utils.js';
@@ -772,7 +773,29 @@ function useTerminalSetup(
     t.loadAddon(fa);
     t.loadAddon(new WebLinksAddon());
     registerFileLinkProvider(t, onFilePathClick);
-    t.open(container);
+    // Try WebGPU renderer first, fall back to default DOM renderer
+    let webgpuAddon: WebgpuAddon | undefined;
+    try {
+      webgpuAddon = new WebgpuAddon();
+      t.loadAddon(webgpuAddon);
+      t.open(container);
+    } catch (e) {
+      // eslint-disable-next-line no-console -- intentional: surface WebGPU fallback in devtools
+      console.warn('WebGPU renderer unavailable, using DOM renderer:', e);
+      webgpuAddon?.dispose();
+      webgpuAddon = undefined;
+    }
+    if (!t.element) {
+      // WebGPU failed or wasn't attempted — open with default renderer
+      t.open(container);
+    }
+    if (webgpuAddon) {
+      webgpuAddon.onContextLoss(() => {
+        // eslint-disable-next-line no-console -- intentional: surface GPU context loss in devtools
+        console.warn('WebGPU context lost, falling back to DOM renderer');
+        webgpuAddon?.dispose();
+      });
+    }
     registerEscapeSequenceSanitizers(t);
     if (isMobileDevice) applyMobilePatches(container, t);
     fa.fit();
@@ -838,6 +861,8 @@ function useTerminalSetup(
       // would never fire, connectPtySocket would never be called, and every
       // subsequent session would render blank.
       term.reset();
+      fitAddonRef.current?.fit();
+      term.refresh(0, term.rows - 1);
       connectPtySocket(
         sessionId,
         term,

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -775,18 +775,19 @@ function useTerminalSetup(
     registerFileLinkProvider(t, onFilePathClick);
     // Try WebGPU renderer first, fall back to default DOM renderer
     let webgpuAddon: WebgpuAddon | undefined;
-    try {
-      webgpuAddon = new WebgpuAddon();
-      t.loadAddon(webgpuAddon);
-      t.open(container);
-    } catch (e) {
-      // eslint-disable-next-line no-console -- intentional: surface WebGPU fallback in devtools
-      console.warn('WebGPU renderer unavailable, using DOM renderer:', e);
-      webgpuAddon?.dispose();
-      webgpuAddon = undefined;
+    if ('gpu' in navigator) {
+      try {
+        webgpuAddon = new WebgpuAddon();
+        t.loadAddon(webgpuAddon);
+        t.open(container);
+      } catch (e) {
+        // eslint-disable-next-line no-console -- intentional: surface WebGPU fallback in devtools
+        console.warn('WebGPU renderer unavailable, using DOM renderer:', e);
+        webgpuAddon?.dispose();
+        webgpuAddon = undefined;
+      }
     }
     if (!t.element) {
-      // WebGPU failed or wasn't attempted — open with default renderer
       t.open(container);
     }
     if (webgpuAddon) {

--- a/frontend/src/types/xterm-addon-webgpu.d.ts
+++ b/frontend/src/types/xterm-addon-webgpu.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Type declarations for @xterm/addon-webgpu, installed from our xterm.js fork.
+ * The addon isn't published to npm, so we declare the module here for TypeScript.
+ */
+declare module '@xterm/addon-webgpu' {
+  import type { Terminal, ITerminalAddon, IEvent } from '@xterm/xterm';
+
+  export class WebgpuAddon implements ITerminalAddon {
+    public textureAtlas?: HTMLCanvasElement;
+    public readonly onContextLoss: IEvent<void>;
+    public readonly onChangeTextureAtlas: IEvent<HTMLCanvasElement>;
+    public readonly onAddTextureAtlasCanvas: IEvent<HTMLCanvasElement>;
+    public readonly onRemoveTextureAtlasCanvas: IEvent<HTMLCanvasElement>;
+    constructor(options?: IWebgpuAddonOptions);
+    public activate(terminal: Terminal): void;
+    public dispose(): void;
+    public clearTextureAtlas(): void;
+  }
+
+  export interface IWebgpuAddonOptions {
+    customGlyphs?: boolean;
+    preserveDrawingBuffer?: boolean;
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
   resolve: {
     alias: {
       $lib: path.resolve(import.meta.dirname, 'src/lib'),
+      '@xterm/addon-webgpu': path.resolve(
+        import.meta.dirname,
+        '../node_modules/@xterm/xterm/addons/addon-webgpu'
+      ),
     },
   },
   build: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.96.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
-        "@xterm/xterm": "github:donovan-yohan/xterm.js#bc779a72",
+        "@xterm/xterm": "github:donovan-yohan/xterm.js#v6.0.0-relay.1",
         "better-sqlite3": "^12.8.0",
         "cookie-parser": "^1.4.7",
         "diff2html": "^3.4.56",
@@ -2441,7 +2441,7 @@
     },
     "node_modules/@xterm/xterm": {
       "version": "6.0.0",
-      "resolved": "git+ssh://git@github.com/donovan-yohan/xterm.js.git#bc779a7285d627482899e95079e89b07613fe729",
+      "resolved": "git+ssh://git@github.com/donovan-yohan/xterm.js.git#86ac44f3ff0efd0d3533d1cdc99f20a6f142b4dd",
       "license": "MIT",
       "workspaces": [
         "addons/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.96.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
-        "@xterm/xterm": "^6.0.0",
+        "@xterm/xterm": "github:donovan-yohan/xterm.js",
         "better-sqlite3": "^12.8.0",
         "cookie-parser": "^1.4.7",
         "diff2html": "^3.4.56",
@@ -2441,8 +2441,7 @@
     },
     "node_modules/@xterm/xterm": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
-      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "resolved": "git+ssh://git@github.com/donovan-yohan/xterm.js.git#bc779a7285d627482899e95079e89b07613fe729",
       "license": "MIT",
       "workspaces": [
         "addons/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tanstack/react-query": "^5.96.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
-        "@xterm/xterm": "github:donovan-yohan/xterm.js",
+        "@xterm/xterm": "github:donovan-yohan/xterm.js#bc779a72",
         "better-sqlite3": "^12.8.0",
         "cookie-parser": "^1.4.7",
         "diff2html": "^3.4.56",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@tanstack/react-query": "^5.96.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
-    "@xterm/xterm": "^6.0.0",
+    "@xterm/xterm": "github:donovan-yohan/xterm.js",
     "better-sqlite3": "^12.8.0",
     "cookie-parser": "^1.4.7",
     "diff2html": "^3.4.56",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@tanstack/react-query": "^5.96.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
-    "@xterm/xterm": "github:donovan-yohan/xterm.js#bc779a72",
+    "@xterm/xterm": "github:donovan-yohan/xterm.js#v6.0.0-relay.1",
     "better-sqlite3": "^12.8.0",
     "cookie-parser": "^1.4.7",
     "diff2html": "^3.4.56",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@tanstack/react-query": "^5.96.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
-    "@xterm/xterm": "github:donovan-yohan/xterm.js",
+    "@xterm/xterm": "github:donovan-yohan/xterm.js#bc779a72",
     "better-sqlite3": "^12.8.0",
     "cookie-parser": "^1.4.7",
     "diff2html": "^3.4.56",


### PR DESCRIPTION
## Summary
- Switch `@xterm/xterm` from npm registry to `donovan-yohan/xterm.js` fork for more control over terminal rendering behavior
- Integrate WebGPU renderer addon from xtermjs/xterm.js PR #5666 with automatic fallback to DOM renderer on unsupported browsers (iOS Safari, older Android)
- Fix terminal rendering artifacts (blank areas, stale text) when switching between session tabs by adding `fitAddon.fit()` + `terminal.refresh()` on session change

## Fork setup
The fork (`donovan-yohan/xterm.js`) has:
- Merged `webgpu2` branch from `Tyriar/xterm.js` (WebGPU renderer)
- Pre-built `lib/` artifacts committed (no `prepare` script needed on install)
- `.npmignore` updated to include `addon-webgpu` files

## Fallback strategy
- WebGPU → DOM renderer (automatic, no user action needed)
- `navigator.gpu` check on load; try-catch around instantiation
- `onContextLoss` listener for runtime GPU device loss

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (1277 tests)
- [x] `tsc --noEmit` passes
- [ ] Manual: verify WebGPU renderer loads on desktop Chrome/Firefox (check devtools console)
- [ ] Manual: verify DOM renderer fallback on iOS Safari
- [ ] Manual: verify tab switching no longer produces rendering artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)