### PR TITLE
feat(sidebar): add session history browser (#210)

### DIFF
--- a/frontend/src/components/RepoItem.css
+++ b/frontend/src/components/RepoItem.css
@@ -366,4 +366,8 @@
   .row-menu-overlay {
     opacity: 1;
   }
+
+  .session-history-btn {
+    opacity: 1;
+  }
 }

--- a/frontend/src/components/RepoItem.css
+++ b/frontend/src/components/RepoItem.css
@@ -212,6 +212,39 @@
   opacity: 1;
 }
 
+.session-history-btn {
+  position: absolute;
+  right: 36px;
+  top: 0;
+  bottom: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 0;
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  transition:
+    background 0.1s,
+    color 0.1s;
+  background: none;
+  border: none;
+  padding: 0;
+  opacity: 0;
+}
+
+.session-row:hover .session-history-btn {
+  opacity: 1;
+}
+
+.session-history-btn:hover {
+  background: var(--border);
+  color: var(--text);
+}
+
 .sidebar-pr-status {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -290,6 +290,7 @@ interface InactiveRepoRowProps {
   sidebarItemById: Map<string, SidebarItem>;
   loadingItems: Set<string>;
   onLaunchRepoSession?: ((repoPath: string) => void) | undefined;
+  onViewHistory?: ((repoPath: string) => void) | undefined;
 }
 
 function InactiveRepoRow({
@@ -300,6 +301,7 @@ function InactiveRepoRow({
   sidebarItemById,
   loadingItems,
   onLaunchRepoSession,
+  onViewHistory,
 }: InactiveRepoRowProps) {
   const repoLoadingKey = `repo-session:${repoPath}`;
   const isLoading = loadingItems.has(repoLoadingKey);
@@ -336,6 +338,19 @@ function InactiveRepoRow({
             </span>
           ) : null}
         </div>
+      ) : null}
+      {onViewHistory ? (
+        <button
+          className="session-history-btn"
+          title="View session history"
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onViewHistory(repoPath);
+          }}
+        >
+          {historySvg}
+        </button>
       ) : null}
     </li>
   );
@@ -529,6 +544,7 @@ export function RepoItem({
                   sidebarItemById={sidebarItemById}
                   loadingItems={loadingItems}
                   onLaunchRepoSession={onLaunchRepoSession}
+                  onViewHistory={onViewHistory}
                 />
               );
             }

--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -167,6 +167,7 @@ interface SessionGroupRowProps {
   onSelectSession: (id: string) => void;
   onDeleteSession?: ((id: string) => void) | undefined;
   onDeleteWorktree?: ((wt: WorktreeInfo) => void) | undefined;
+  onViewHistory?: ((repoPath: string) => void) | undefined;
   repoPath: string;
 }
 
@@ -182,6 +183,7 @@ function SessionGroupRow({
   onSelectSession,
   onDeleteSession,
   onDeleteWorktree,
+  onViewHistory,
   repoPath,
 }: SessionGroupRowProps) {
   return (
@@ -262,6 +264,19 @@ function SessionGroupRow({
             ]}
           />
         </div>
+      ) : null}
+      {onViewHistory ? (
+        <button
+          className="session-history-btn"
+          title="View session history"
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onViewHistory(repoPath);
+          }}
+        >
+          {historySvg}
+        </button>
       ) : null}
     </li>
   );
@@ -454,19 +469,6 @@ export function RepoItem({
           ) : null}
         </div>
         <div className="repo-actions">
-          {onViewHistory && (
-            <button
-              className="action-btn"
-              title="View session history"
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                onViewHistory(repo.path);
-              }}
-            >
-              {historySvg}
-            </button>
-          )}
           <button
             className="action-btn"
             title="Settings"
@@ -512,6 +514,7 @@ export function RepoItem({
                   onSelectSession={onSelectSession}
                   onDeleteSession={onDeleteSession}
                   onDeleteWorktree={onDeleteWorktree}
+                  onViewHistory={onViewHistory}
                   repoPath={repo.path}
                 />
               );

--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -38,6 +38,7 @@ export interface RepoItemProps {
   onDeleteWorktree?: ((wt: WorktreeInfo) => void) | undefined;
   onResumeWorktree?: ((wt: WorktreeInfo) => void) | undefined;
   onLaunchRepoSession?: ((repoPath: string) => void) | undefined;
+  onViewHistory?: ((repoPath: string) => void) | undefined;
   orgPrs?: PullRequest[];
   sidebarItems?: SidebarItem[];
   collapsed?: boolean;
@@ -56,7 +57,22 @@ const settingsSvg = (
     height="14"
   >
     <circle cx="12" cy="12" r="3" />
-    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1-1.51V15H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1-1.51V15H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06-.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06-.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+  </svg>
+);
+
+const historySvg = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="square"
+    width="14"
+    height="14"
+  >
+    <polyline points="12 8 12 12 16 14" />
+    <circle cx="12" cy="12" r="9" />
   </svg>
 );
 
@@ -324,6 +340,7 @@ export function RepoItem({
   onDeleteWorktree,
   onResumeWorktree,
   onLaunchRepoSession,
+  onViewHistory,
   orgPrs = EMPTY_ARRAY,
   sidebarItems = EMPTY_ARRAY,
   collapsed = false,
@@ -437,6 +454,19 @@ export function RepoItem({
           ) : null}
         </div>
         <div className="repo-actions">
+          {onViewHistory && (
+            <button
+              className="action-btn"
+              title="View session history"
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onViewHistory(repo.path);
+              }}
+            >
+              {historySvg}
+            </button>
+          )}
           <button
             className="action-btn"
             title="Settings"

--- a/frontend/src/components/SessionHistoryPanel.css
+++ b/frontend/src/components/SessionHistoryPanel.css
@@ -1,0 +1,170 @@
+.session-history-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg);
+}
+
+.session-history-header {
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  gap: 12px;
+}
+
+.back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 4px 0;
+  align-self: flex-start;
+  transition: color 0.12s;
+}
+
+.back-btn:hover {
+  color: var(--text);
+}
+
+.history-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--text);
+  font-family: var(--font-mono);
+  margin: 0;
+}
+
+.history-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+}
+
+.session-history-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 0;
+}
+
+.history-loading,
+.history-error,
+.history-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.history-error {
+  color: var(--error);
+}
+
+.history-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.history-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.group-header {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.group-sessions {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.history-session-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 10px 12px;
+  cursor: pointer;
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  transition: background 0.1s;
+  border-left: 3px solid transparent;
+}
+
+.history-session-item:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+  border-left-color: var(--accent);
+}
+
+.session-primary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.session-name {
+  font-weight: 500;
+  color: var(--text);
+  font-family: var(--font-mono);
+}
+
+.session-time {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  flex-shrink: 0;
+}
+
+.session-secondary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.session-stats {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+@media (max-width: 768px) {
+  .session-history-header {
+    padding: 8px 12px;
+    gap: 8px;
+  }
+
+  .history-title {
+    font-size: var(--font-size-xs);
+  }
+
+  .history-session-item {
+    padding: 8px 12px;
+  }
+}

--- a/frontend/src/components/SessionHistoryPanel.tsx
+++ b/frontend/src/components/SessionHistoryPanel.tsx
@@ -1,0 +1,236 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import type { AnalyticsSessionSummary } from '../lib/types.js';
+import { fetchAnalyticsSessions } from '../lib/api.js';
+import { formatRelativeTimeCompact } from '../lib/utils.js';
+import './SessionHistoryPanel.css';
+
+const historySvg = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="square"
+    width="14"
+    height="14"
+  >
+    <polyline points="12 8 12 12 16 14" />
+    <circle cx="12" cy="12" r="9" />
+  </svg>
+);
+
+const backSvg = (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="square"
+    width="14"
+    height="14"
+  >
+    <line x1="19" y1="12" x2="5" y2="12" />
+    <polyline points="12 19 5 12 12 5" />
+  </svg>
+);
+
+const AGENT_DISPLAY_NAMES: Record<string, string> = {
+  claude: 'Claude',
+  codex: 'Codex',
+  opencode: 'OpenCode',
+  gemini: 'Gemini',
+};
+
+function getAgentDisplayName(agentType: string | null): string {
+  if (!agentType) return 'Unknown';
+  return AGENT_DISPLAY_NAMES[agentType] ?? agentType;
+}
+
+interface GroupedSessions {
+  agentType: string;
+  displayName: string;
+  sessions: AnalyticsSessionSummary[];
+}
+
+function groupSessionsByAgent(
+  sessions: AnalyticsSessionSummary[]
+): GroupedSessions[] {
+  const groups = new Map<string, AnalyticsSessionSummary[]>();
+
+  for (const session of sessions) {
+    const agent = session.agentType ?? 'unknown';
+    const existing = groups.get(agent);
+    if (existing) {
+      existing.push(session);
+    } else {
+      groups.set(agent, [session]);
+    }
+  }
+
+  for (const [agent, agentSessions] of groups) {
+    agentSessions.sort(
+      (a, b) =>
+        new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
+    );
+    groups.set(agent, agentSessions);
+  }
+
+  return Array.from(groups.entries())
+    .map(([agentType, sessions]) => ({
+      agentType,
+      displayName: getAgentDisplayName(agentType),
+      sessions,
+    }))
+    .sort((a, b) => {
+      const aLatest = a.sessions[0]?.startedAt ?? '';
+      const bLatest = b.sessions[0]?.startedAt ?? '';
+      return new Date(bLatest).getTime() - new Date(aLatest).getTime();
+    });
+}
+
+export interface SessionHistoryPanelProps {
+  repoPath: string;
+  repoName: string;
+  onBack: () => void;
+  onSelectSession?: (sessionId: string) => void;
+}
+
+export function SessionHistoryPanel({
+  repoPath,
+  repoName,
+  onBack,
+  onSelectSession,
+}: SessionHistoryPanelProps) {
+  const [sessions, setSessions] = useState<AnalyticsSessionSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSessions() {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await fetchAnalyticsSessions({
+          repo: repoPath,
+          limit: 100,
+          sort: 'started_at:desc',
+        });
+        if (!cancelled) {
+          setSessions(response.sessions);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : 'Failed to load history'
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadSessions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [repoPath]);
+
+  const groupedSessions = useMemo(
+    () => groupSessionsByAgent(sessions),
+    [sessions]
+  );
+
+  return (
+    <div className="session-history-panel">
+      <div className="session-history-header">
+        <button
+          className="back-btn"
+          onClick={onBack}
+          aria-label="Back to sidebar"
+        >
+          {backSvg}
+          <span>Back</span>
+        </button>
+        <h3 className="history-title">
+          <span className="history-icon">{historySvg}</span>
+          Session History: {repoName}
+        </h3>
+      </div>
+
+      <div className="session-history-content">
+        {loading ? (
+          <div className="history-loading">Loading history...</div>
+        ) : error ? (
+          <div className="history-error">{error}</div>
+        ) : sessions.length === 0 ? (
+          <div className="history-empty">
+            <p>No session history found for this repository.</p>
+          </div>
+        ) : (
+          <div className="history-groups">
+            {groupedSessions.map((group) => (
+              <div key={group.agentType} className="history-group">
+                <h4 className="group-header">{group.displayName}</h4>
+                <ul className="group-sessions">
+                  {group.sessions.map((session) => (
+                    <li
+                      key={session.sessionId}
+                      className="history-session-item"
+                      onClick={() => onSelectSession?.(session.sessionId)}
+                      role="button"
+                      tabIndex={0}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          onSelectSession?.(session.sessionId);
+                        }
+                      }}
+                    >
+                      <div className="session-primary">
+                        <span className="session-name">
+                          {session.sessionId.slice(0, 8)}
+                        </span>
+                        <span className="session-time">
+                          {formatRelativeTimeCompact(session.startedAt)}
+                        </span>
+                      </div>
+                      <div className="session-secondary">
+                        {session.turnCount > 0 && (
+                          <span className="session-stats">
+                            {session.turnCount} turns
+                          </span>
+                        )}
+                        {session.durationSeconds !== null &&
+                          session.durationSeconds > 0 && (
+                            <span className="session-stats">
+                              {formatDuration(session.durationSeconds)}
+                            </span>
+                          )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  return `${minutes}m`;
+}
+
+export default SessionHistoryPanel;

--- a/frontend/src/components/SessionHistoryPanel.tsx
+++ b/frontend/src/components/SessionHistoryPanel.tsx
@@ -70,7 +70,8 @@ function groupSessionsByAgent(
   for (const [agent, agentSessions] of groups) {
     agentSessions.sort(
       (a, b) =>
-        new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
+        new Date(b.endedAt ?? b.startedAt).getTime() -
+        new Date(a.endedAt ?? a.startedAt).getTime()
     );
     groups.set(agent, agentSessions);
   }
@@ -82,8 +83,10 @@ function groupSessionsByAgent(
       sessions,
     }))
     .sort((a, b) => {
-      const aLatest = a.sessions[0]?.startedAt ?? '';
-      const bLatest = b.sessions[0]?.startedAt ?? '';
+      const aSession = a.sessions[0];
+      const bSession = b.sessions[0];
+      const aLatest = aSession?.endedAt ?? aSession?.startedAt ?? '';
+      const bLatest = bSession?.endedAt ?? bSession?.startedAt ?? '';
       return new Date(bLatest).getTime() - new Date(aLatest).getTime();
     });
 }
@@ -115,7 +118,7 @@ export function SessionHistoryPanel({
         const response = await fetchAnalyticsSessions({
           repo: repoPath,
           limit: 100,
-          sort: 'started_at:desc',
+          sort: 'ended_at',
         });
         if (!cancelled) {
           setSessions(response.sessions);
@@ -195,7 +198,9 @@ export function SessionHistoryPanel({
                           {session.sessionId.slice(0, 8)}
                         </span>
                         <span className="session-time">
-                          {formatRelativeTimeCompact(session.startedAt)}
+                          {formatRelativeTimeCompact(
+                            session.endedAt ?? session.startedAt
+                          )}
                         </span>
                       </div>
                       <div className="session-secondary">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ import type { Repo, WorktreeInfo, PullRequest } from '../lib/types.js';
 import { fetchOrgPrs } from '../lib/api.js';
 import WorkspaceGroup from './WorkspaceGroup.js';
 import RepoItem from './RepoItem.js';
+import { SessionHistoryPanel } from './SessionHistoryPanel.js';
 import { TuiButton } from './TuiButton.js';
 import {
   DndContext,
@@ -110,6 +111,7 @@ interface UngroupedListProps {
   onDeleteWorktree: ((wt: WorktreeInfo) => void) | undefined;
   onResumeWorktree: ((wt: WorktreeInfo) => void) | undefined;
   onLaunchRepoSession: ((repoPath: string) => void) | undefined;
+  onViewHistory: ((repoPath: string) => void) | undefined;
 }
 
 function UngroupedList({
@@ -126,6 +128,7 @@ function UngroupedList({
   onDeleteWorktree,
   onResumeWorktree,
   onLaunchRepoSession,
+  onViewHistory,
 }: UngroupedListProps) {
   const getSessionsForRepo = useSessionsStore((s) => s.getSessionsForRepo);
   const sidebarItems = useSessionsStore((s) => s.sidebarItems);
@@ -230,6 +233,7 @@ function UngroupedList({
                   onDeleteWorktree={onDeleteWorktree}
                   onResumeWorktree={onResumeWorktree}
                   onLaunchRepoSession={onLaunchRepoSession}
+                  onViewHistory={onViewHistory}
                   orgPrs={orgPrs}
                   sidebarItems={sidebarItems}
                   collapsed={collapsedWorkspaces.has(repo.path)}
@@ -284,6 +288,7 @@ interface WorkspaceGroupsListProps {
   onResumeWorktree: ((wt: WorktreeInfo) => void) | undefined;
   onLaunchWorkspaceSession: ((workspaceId: string) => void) | undefined;
   onLaunchRepoSession: ((repoPath: string) => void) | undefined;
+  onViewHistory: ((repoPath: string) => void) | undefined;
 }
 
 function WorkspaceGroupsList({
@@ -304,6 +309,7 @@ function WorkspaceGroupsList({
   onResumeWorktree,
   onLaunchWorkspaceSession,
   onLaunchRepoSession,
+  onViewHistory,
 }: WorkspaceGroupsListProps) {
   const getSessionsForWorkspaceGroup = useSessionsStore(
     (s) => s.getSessionsForWorkspaceGroup
@@ -338,6 +344,7 @@ function WorkspaceGroupsList({
             onDeleteSession={(id) => onDeleteSession?.(id)}
             onDeleteWorktree={(wt) => onDeleteWorktree?.(wt)}
             onResumeWorktree={(wt) => onResumeWorktree?.(wt)}
+            onViewHistory={onViewHistory}
             {...(onLaunchRepoSession ? { onLaunchRepoSession } : {})}
             orgPrs={orgPrs}
           />
@@ -345,6 +352,28 @@ function WorkspaceGroupsList({
       })}
     </>
   );
+}
+
+function useHistoryView(reposByPath: Map<string, Repo>) {
+  const [historyRepoPath, setHistoryRepoPath] = useState<string | null>(null);
+
+  const handleViewHistory = useCallback((repoPath: string) => {
+    setHistoryRepoPath(repoPath);
+  }, []);
+
+  const handleCloseHistory = useCallback(() => {
+    setHistoryRepoPath(null);
+  }, []);
+
+  const historyRepo = historyRepoPath
+    ? reposByPath.get(historyRepoPath)
+    : undefined;
+
+  return {
+    historyRepo,
+    handleViewHistory,
+    handleCloseHistory,
+  };
 }
 
 // ── Main Sidebar ──
@@ -431,6 +460,9 @@ export function Sidebar({
     setCollapsedGroups((prev) => ({ ...prev, [id]: !prev[id] }));
   }, []);
 
+  const { historyRepo, handleViewHistory, handleCloseHistory } =
+    useHistoryView(reposByPath);
+
   return (
     <aside
       className={[
@@ -499,61 +531,71 @@ export function Sidebar({
       </div>
       {!sidebarCollapsed && (
         <>
-          <div className="sidebar-workspace-list">
-            <WorkspaceGroupsList
-              sortedGroups={sortedGroups}
-              reposByPath={reposByPath}
-              worktrees={worktrees}
-              activeRepoPath={activeRepoPath}
-              activeSessionId={activeSessionId ?? null}
-              orgPrs={orgPrs}
-              collapsedGroups={collapsedGroups}
-              onToggleGroupCollapse={handleToggleGroupCollapse}
-              onSelectWorkspace={handleSelectWorkspace}
-              onSelectSession={onSelectSession}
-              onNewWorktree={onNewWorktree}
-              onOpenSettings={onOpenSettings}
-              onDeleteSession={onDeleteSession}
-              onDeleteWorktree={onDeleteWorktree}
-              onResumeWorktree={onResumeWorktree}
-              onLaunchWorkspaceSession={onLaunchWorkspaceSession}
-              onLaunchRepoSession={onLaunchRepoSession}
+          {historyRepo ? (
+            <SessionHistoryPanel
+              repoPath={historyRepo.path}
+              repoName={historyRepo.name}
+              onBack={handleCloseHistory}
             />
-            {ungroupedRepos.length > 0 && (
-              <>
-                {workspaceGroups.length > 0 && (
-                  <div className="sidebar-ungrouped-label">ungrouped</div>
-                )}
-                <UngroupedList
-                  ungroupedRepos={ungroupedRepos}
-                  activeRepoPath={activeRepoPath}
-                  activeSessionId={activeSessionId ?? null}
-                  worktrees={worktrees}
-                  orgPrs={orgPrs}
-                  onSelectWorkspace={handleSelectWorkspace}
-                  onSelectSession={onSelectSession}
-                  onNewWorktree={onNewWorktree}
-                  onOpenSettings={onOpenSettings}
-                  onDeleteSession={onDeleteSession}
-                  onDeleteWorktree={onDeleteWorktree}
-                  onResumeWorktree={onResumeWorktree}
-                  onLaunchRepoSession={onLaunchRepoSession}
-                />
-              </>
-            )}
-            {repos.length === 0 && (
-              <div className="sidebar-empty-state">
-                <span>no repos</span>
-              </div>
-            )}
-            {workspaceGroups.length === 0 &&
-              ungroupedRepos.length === 0 &&
-              repos.length > 0 && (
-                <div className="sidebar-empty-workspace-hint">
-                  <span>no workspaces yet</span>
+          ) : (
+            <div className="sidebar-workspace-list">
+              <WorkspaceGroupsList
+                sortedGroups={sortedGroups}
+                reposByPath={reposByPath}
+                worktrees={worktrees}
+                activeRepoPath={activeRepoPath}
+                activeSessionId={activeSessionId ?? null}
+                orgPrs={orgPrs}
+                collapsedGroups={collapsedGroups}
+                onToggleGroupCollapse={handleToggleGroupCollapse}
+                onSelectWorkspace={handleSelectWorkspace}
+                onSelectSession={onSelectSession}
+                onNewWorktree={onNewWorktree}
+                onOpenSettings={onOpenSettings}
+                onDeleteSession={onDeleteSession}
+                onDeleteWorktree={onDeleteWorktree}
+                onResumeWorktree={onResumeWorktree}
+                onLaunchWorkspaceSession={onLaunchWorkspaceSession}
+                onLaunchRepoSession={onLaunchRepoSession}
+                onViewHistory={handleViewHistory}
+              />
+              {ungroupedRepos.length > 0 && (
+                <>
+                  {workspaceGroups.length > 0 && (
+                    <div className="sidebar-ungrouped-label">ungrouped</div>
+                  )}
+                  <UngroupedList
+                    ungroupedRepos={ungroupedRepos}
+                    activeRepoPath={activeRepoPath}
+                    activeSessionId={activeSessionId ?? null}
+                    worktrees={worktrees}
+                    orgPrs={orgPrs}
+                    onSelectWorkspace={handleSelectWorkspace}
+                    onSelectSession={onSelectSession}
+                    onNewWorktree={onNewWorktree}
+                    onOpenSettings={onOpenSettings}
+                    onDeleteSession={onDeleteSession}
+                    onDeleteWorktree={onDeleteWorktree}
+                    onResumeWorktree={onResumeWorktree}
+                    onLaunchRepoSession={onLaunchRepoSession}
+                    onViewHistory={handleViewHistory}
+                  />
+                </>
+              )}
+              {repos.length === 0 && (
+                <div className="sidebar-empty-state">
+                  <span>no repos</span>
                 </div>
               )}
-          </div>
+              {workspaceGroups.length === 0 &&
+                ungroupedRepos.length === 0 &&
+                repos.length > 0 && (
+                  <div className="sidebar-empty-workspace-hint">
+                    <span>no workspaces yet</span>
+                  </div>
+                )}
+            </div>
+          )}
           <div className="sidebar-footer-row">
             <TuiButton
               variant="primary"

--- a/frontend/src/components/WorkspaceGroup.tsx
+++ b/frontend/src/components/WorkspaceGroup.tsx
@@ -37,6 +37,7 @@ export interface WorkspaceGroupProps {
   onDeleteWorktree?: ((wt: WorktreeInfo) => void) | undefined;
   onResumeWorktree?: ((wt: WorktreeInfo) => void) | undefined;
   onLaunchRepoSession?: ((repoPath: string) => void) | undefined;
+  onViewHistory?: ((repoPath: string) => void) | undefined;
   orgPrs?: PullRequest[] | undefined;
   loadingItems?: Set<string> | undefined;
 }
@@ -98,6 +99,7 @@ function GroupBody({
   onDeleteWorktree,
   onResumeWorktree,
   onLaunchRepoSession,
+  onViewHistory,
 }: GroupBodyProps) {
   const sidebarItems = useSessionsStore((s) => s.sidebarItems);
   return (
@@ -158,6 +160,7 @@ function GroupBody({
             onDeleteWorktree={onDeleteWorktree}
             onResumeWorktree={onResumeWorktree}
             onLaunchRepoSession={onLaunchRepoSession}
+            onViewHistory={onViewHistory}
             orgPrs={orgPrs ?? []}
             loadingItems={loadingItems}
             sidebarItems={sidebarItems}
@@ -188,6 +191,7 @@ export function WorkspaceGroup({
   onDeleteWorktree,
   onResumeWorktree,
   onLaunchRepoSession,
+  onViewHistory,
   orgPrs,
   loadingItems = EMPTY_SET,
 }: WorkspaceGroupProps) {
@@ -238,6 +242,7 @@ export function WorkspaceGroup({
           onNewWorktree={onNewWorktree}
           onOpenSettings={onOpenSettings}
           onLaunchRepoSession={onLaunchRepoSession}
+          onViewHistory={onViewHistory}
           onDeleteSession={onDeleteSession}
           onDeleteWorktree={onDeleteWorktree}
           onResumeWorktree={onResumeWorktree}

--- a/server/analytics.ts
+++ b/server/analytics.ts
@@ -213,10 +213,7 @@ function findWindowPercent(
 ): number | null {
   for (const w of windows) {
     const name = (w.name ?? '').toLowerCase();
-    if (
-      w.windowMinutes === targetMinutes ||
-      name.includes(namePattern)
-    ) {
+    if (w.windowMinutes === targetMinutes || name.includes(namePattern)) {
       return w.usedPercent ?? null;
     }
   }
@@ -951,6 +948,7 @@ export function createSessionAnalyticsRouter(): Router {
 
     const validSorts: Record<string, string> = {
       started_at: 'started_at DESC',
+      ended_at: 'ended_at DESC',
       tokens: 'total_input_tokens DESC',
       duration: 'duration_seconds DESC',
     };
@@ -1241,9 +1239,11 @@ export function createSessionAnalyticsRouter(): Router {
         return {
           timestamp: r.timestamp,
           fiveHourPercent:
-            r.five_hour_percent ?? findWindowPercent(windows ?? [], 'five_hour', 300),
+            r.five_hour_percent ??
+            findWindowPercent(windows ?? [], 'five_hour', 300),
           sevenDayPercent:
-            r.seven_day_percent ?? findWindowPercent(windows ?? [], 'seven_day', 10080),
+            r.seven_day_percent ??
+            findWindowPercent(windows ?? [], 'seven_day', 10080),
           windows,
         };
       }),


### PR DESCRIPTION
Implements ticket #210 - Sidebar Session History Browser.

Features:
- History button on session rows (hover-visible desktop, always visible mobile)
- History button on inactive repo rows
- Sessions grouped by agent (Claude, Codex, OpenCode, Gemini)
- Sorted by last activity (endedAt)
- Back button to return to sidebar
- Empty state support

Files: SessionHistoryPanel.tsx/css, RepoItem.tsx, Sidebar.tsx, WorkspaceGroup.tsx, server/analytics.ts

Verification: All 1280 tests pass, TypeScript clean, build successful

Closes #210