### PR TITLE
feat: add worktree port allocator

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ The system has two compilation targets: a TypeScript + ESM backend (Express + no
 
 ### `server/`
 
-Thirty-four TypeScript modules compiled to `dist/server/` via `tsc`. Modules communicate via ESM `import` statements.
+Thirty-five TypeScript modules compiled to `dist/server/` via `tsc`. Modules communicate via ESM `import` statements.
 
 | Module                     | Role                                                                                                                                                                                                                                                               |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -38,6 +38,7 @@ Thirty-four TypeScript modules compiled to `dist/server/` via `tsc`. Modules com
 | `hooks.ts`                 | Claude Code hook HTTP endpoints: state detection (Stop, Notification, UserPromptSubmit), activity tracking (PreToolUse, PostToolUse), session cleanup (SessionEnd), and branch rename. Localhost-only with per-session token auth.                                 |
 | `types.ts`                 | Shared TypeScript interfaces (Session, Repo, Workspace entity, Config v4, WorkspaceLevelSettings, PR, CI, Activity types)                                                                                                                                          |
 | `analytics.ts`             | Local analytics: SQLite-backed event tracking, `trackEvent()`, batch ingest endpoint, DB size/clear endpoints                                                                                                                                                      |
+| `port-allocator.ts`        | Durable per-worktree port allocation, persisted assignments, `.env` managed-block reconciliation, and startup verification of allocated ports                                                                                                                      |
 | `review-poller.ts`         | PR review automation: polls GitHub notifications for review requests, creates worktrees, optionally starts review sessions                                                                                                                                         |
 | `output-parsers/`          | Vendor-extensible terminal output parsing for semantic agent state detection (AgentState), keyed by AgentType. Contains `index.ts` (registry + dispatch), `claude-parser.ts`, `codex-parser.ts`                                                                    |
 | `github-app.ts`            | GitHub OAuth App flow: authorization URL generation (with CSRF state), token exchange callback, connection status, disconnect                                                                                                                                      |
@@ -51,7 +52,7 @@ Thirty-four TypeScript modules compiled to `dist/server/` via `tsc`. Modules com
 | `ticket-transitions.ts`    | Automated ticket state machine: transitions GitHub Issues (labels) and Jira tickets (acli) through in-progress → code-review → ready-for-qa based on session creation and PR merge events                                                                          |
 | `agent-events.ts`          | Canonical agent event schema and thin adapter: normalizes lifecycle events (session, tool, permission, telemetry) across agent frameworks into a unified `AgentEvent` type                                                                                         |
 
-**Architecture Invariant:** `index.ts` is the composition root and MUST NOT be imported by other modules. Cross-module dependencies flow downward: `index.ts` imports all others; `ws.ts` may import `sessions`; `sessions.ts` imports `pty-handler`; `workspaces.ts` imports `git` and `config`; `hooks.ts` consumes `sessions`, `git`, `config`, and `push` via injected dependencies (not direct imports); all other modules are self-contained. **Exception:** `analytics.ts` and `push.ts` are pure output dependencies (fire-and-forget) imported by multiple modules — this is acceptable because they have no effect on callers' control flow. Each module owns a single concern and confines its npm dependencies (e.g., only `auth.ts` depends on crypto.scrypt, only `pty-handler.ts` depends on node-pty, only `analytics.ts` depends on better-sqlite3, only `push.ts` depends on web-push). The `output-parsers/` module confines all output-parsing logic and may depend on `types.ts` only — it MUST NOT import from `utils.ts` or any other server module. There are currently thirty-four server modules.
+**Architecture Invariant:** `index.ts` is the composition root and MUST NOT be imported by other modules. Cross-module dependencies flow downward: `index.ts` imports all others; `ws.ts` may import `sessions`; `sessions.ts` imports `pty-handler`; `workspaces.ts` imports `git` and `config`; `hooks.ts` consumes `sessions`, `git`, `config`, and `push` via injected dependencies (not direct imports); all other modules are self-contained. **Exception:** `analytics.ts` and `push.ts` are pure output dependencies (fire-and-forget) imported by multiple modules — this is acceptable because they have no effect on callers' control flow. Each module owns a single concern and confines its npm dependencies (e.g., only `auth.ts` depends on crypto.scrypt, only `pty-handler.ts` depends on node-pty, only `analytics.ts` depends on better-sqlite3, only `push.ts` depends on web-push). The `output-parsers/` module confines all output-parsing logic and may depend on `types.ts` only — it MUST NOT import from `utils.ts` or any other server module. There are currently thirty-five server modules.
 
 ### `frontend/`
 
@@ -184,7 +185,7 @@ Both channels require authentication via `token` cookie verified during HTTP upg
 
 | ADR     | Topic                                                                                |
 | ------- | ------------------------------------------------------------------------------------ |
-| ADR-001 | Modular server architecture (thirty-four modules, composition root, dependency flow) |
+| ADR-001 | Modular server architecture (thirty-five modules, composition root, dependency flow) |
 | ADR-003 | PTY session management (in-memory state, scrollback, CLAUDECODE stripping)           |
 | ADR-004 | PIN authentication (scrypt, cookie tokens, rate limiting)                            |
 | ADR-005 | Built-in test runner (node:test, no external framework)                              |

--- a/frontend/src/components/dialogs/WorkspaceEditor.css
+++ b/frontend/src/components/dialogs/WorkspaceEditor.css
@@ -155,3 +155,110 @@
   background: rgba(231, 76, 60, 0.08);
   border: 1px solid rgba(231, 76, 60, 0.25);
 }
+
+/* Environment Ports Section */
+.workspace-editor__hint {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  margin: 0;
+  font-family: var(--font-mono, monospace);
+}
+
+.workspace-editor__hint code {
+  background: var(--border);
+  padding: 1px 4px;
+  border-radius: 2px;
+  font-family: inherit;
+}
+
+.workspace-editor__list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.workspace-editor__list-empty {
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.workspace-editor__list-empty code {
+  background: var(--border);
+  padding: 1px 4px;
+  border-radius: 2px;
+  font-family: var(--font-mono, monospace);
+  font-style: normal;
+}
+
+.workspace-editor__list-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+
+.workspace-editor__list-item-value {
+  flex: 1;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  color: var(--text);
+}
+
+.workspace-editor__list-item-remove {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+  opacity: 0.6;
+}
+
+.workspace-editor__list-item-remove:hover {
+  color: var(--status-error);
+  opacity: 1;
+}
+
+.workspace-editor__add-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.workspace-editor__add-input {
+  flex: 1;
+}
+
+.workspace-editor__add-input.workspace-editor__field-input--error {
+  border-color: var(--status-error);
+}
+
+.workspace-editor__add-btn {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  padding: 8px 16px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.workspace-editor__add-btn:hover:not(:disabled) {
+  background: var(--border);
+}
+
+.workspace-editor__add-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.workspace-editor__field-error {
+  font-size: var(--font-size-xs);
+  color: var(--status-error);
+  margin: 0;
+}

--- a/frontend/src/components/dialogs/WorkspaceEditor.tsx
+++ b/frontend/src/components/dialogs/WorkspaceEditor.tsx
@@ -15,9 +15,13 @@ export interface WorkspaceEditorValues {
   promptCreatePr: string;
   promptBranchRename: string;
   promptGeneral: string;
+  portVariables: string[];
 }
 
-type ChangeHandler = <K extends keyof WorkspaceEditorValues>(key: K, value: WorkspaceEditorValues[K]) => void;
+type ChangeHandler = <K extends keyof WorkspaceEditorValues>(
+  key: K,
+  value: WorkspaceEditorValues[K]
+) => void;
 
 interface Props {
   values: WorkspaceEditorValues;
@@ -25,6 +29,8 @@ interface Props {
   branches: BranchInfo[];
   overriddenKeys: string[];
   error?: string;
+  /** Called when validation state changes, with map of field -> error message (empty if valid) */
+  onValidationChange?: (errors: Record<string, string>) => void;
 }
 
 interface PromptGroupProps {
@@ -34,15 +40,34 @@ interface PromptGroupProps {
   onChange: (v: string) => void;
 }
 
-function PromptGroup({ label, value, placeholder, onChange }: PromptGroupProps) {
+function PromptGroup({
+  label,
+  value,
+  placeholder,
+  onChange,
+}: PromptGroupProps) {
   const [open, setOpen] = useState(false);
   return (
     <div className="workspace-editor__prompt-group">
-      <button className="workspace-editor__prompt-toggle" onClick={() => setOpen((v) => !v)} aria-expanded={open}>
-        <span className="workspace-editor__prompt-arrow">{open ? '▾' : '▸'}</span>
+      <button
+        className="workspace-editor__prompt-toggle"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <span className="workspace-editor__prompt-arrow">
+          {open ? '▾' : '▸'}
+        </span>
         {label}
       </button>
-      {open && <textarea className="workspace-editor__prompt-textarea" rows={3} placeholder={placeholder} value={value} onChange={(e) => onChange(e.currentTarget.value)} />}
+      {open && (
+        <textarea
+          className="workspace-editor__prompt-textarea"
+          rows={3}
+          placeholder={placeholder}
+          value={value}
+          onChange={(e) => onChange(e.currentTarget.value)}
+        />
+      )}
     </div>
   );
 }
@@ -58,28 +83,71 @@ function GitSettingsSection({ values, branches, onChange }: GitSectionProps) {
     <section className="workspace-editor__section">
       <h3 className="workspace-editor__section-label">git settings</h3>
       <div className="workspace-editor__field">
-        <label className="workspace-editor__field-label" htmlFor="ws-default-branch">Branch new worktrees from</label>
-        <select id="ws-default-branch" className="workspace-editor__field-select" value={values.defaultBranch} onChange={(e) => onChange('defaultBranch', e.currentTarget.value)}>
+        <label
+          className="workspace-editor__field-label"
+          htmlFor="ws-default-branch"
+        >
+          Branch new worktrees from
+        </label>
+        <select
+          id="ws-default-branch"
+          className="workspace-editor__field-select"
+          value={values.defaultBranch}
+          onChange={(e) => onChange('defaultBranch', e.currentTarget.value)}
+        >
           <option value="">-- auto --</option>
-          {branches.map((b) => <option key={b.name} value={b.name}>{b.name}</option>)}
-          {values.defaultBranch && !branches.some((b) => b.name === values.defaultBranch) && (
-            <option value={values.defaultBranch}>{values.defaultBranch}</option>
-          )}
+          {branches.map((b) => (
+            <option key={b.name} value={b.name}>
+              {b.name}
+            </option>
+          ))}
+          {values.defaultBranch &&
+            !branches.some((b) => b.name === values.defaultBranch) && (
+              <option value={values.defaultBranch}>
+                {values.defaultBranch}
+              </option>
+            )}
         </select>
       </div>
       <div className="workspace-editor__field">
-        <label className="workspace-editor__field-label" htmlFor="ws-remote">Remote origin</label>
-        <input id="ws-remote" type="text" className="workspace-editor__field-input" placeholder="origin" value={values.remote} onChange={(e) => onChange('remote', e.currentTarget.value)} />
+        <label className="workspace-editor__field-label" htmlFor="ws-remote">
+          Remote origin
+        </label>
+        <input
+          id="ws-remote"
+          type="text"
+          className="workspace-editor__field-input"
+          placeholder="origin"
+          value={values.remote}
+          onChange={(e) => onChange('remote', e.currentTarget.value)}
+        />
       </div>
       <div className="workspace-editor__field">
-        <label className="workspace-editor__field-label" htmlFor="ws-branch-prefix">Branch prefix</label>
-        <input id="ws-branch-prefix" type="text" className="workspace-editor__field-input" placeholder="e.g. dy/" value={values.branchPrefix} onChange={(e) => onChange('branchPrefix', e.currentTarget.value)} />
+        <label
+          className="workspace-editor__field-label"
+          htmlFor="ws-branch-prefix"
+        >
+          Branch prefix
+        </label>
+        <input
+          id="ws-branch-prefix"
+          type="text"
+          className="workspace-editor__field-input"
+          placeholder="e.g. dy/"
+          value={values.branchPrefix}
+          onChange={(e) => onChange('branchPrefix', e.currentTarget.value)}
+        />
       </div>
     </section>
   );
 }
 
-const SESSION_DEFAULT_KEYS = ['defaultAgent', 'defaultContinue', 'defaultYolo', 'launchInTmux'];
+const SESSION_DEFAULT_KEYS = [
+  'defaultAgent',
+  'defaultContinue',
+  'defaultYolo',
+  'launchInTmux',
+];
 
 interface SessionDefaultsSectionProps {
   values: WorkspaceEditorValues;
@@ -87,26 +155,64 @@ interface SessionDefaultsSectionProps {
   onChange: ChangeHandler;
 }
 
-function SessionDefaultsSection({ values, overriddenKeys, onChange }: SessionDefaultsSectionProps) {
-  const hasOverride = overriddenKeys.some((k) => SESSION_DEFAULT_KEYS.includes(k));
+function SessionDefaultsSection({
+  values,
+  overriddenKeys,
+  onChange,
+}: SessionDefaultsSectionProps) {
+  const hasOverride = overriddenKeys.some((k) =>
+    SESSION_DEFAULT_KEYS.includes(k)
+  );
   return (
     <section className="workspace-editor__section">
       <h3 className="workspace-editor__section-label">
         session defaults
-        {hasOverride && <span className="workspace-editor__override-badge">overridden</span>}
+        {hasOverride && (
+          <span className="workspace-editor__override-badge">overridden</span>
+        )}
       </h3>
       <div className="workspace-editor__inline-row">
-        <label className="workspace-editor__field-label" htmlFor="ws-agent">Default agent</label>
-        <select id="ws-agent" className={['workspace-editor__field-select', 'workspace-editor__field-select-inline'].join(' ')} value={values.defaultAgent} onChange={(e) => onChange('defaultAgent', e.currentTarget.value as 'claude' | 'codex' | 'opencode')}>
+        <label className="workspace-editor__field-label" htmlFor="ws-agent">
+          Default agent
+        </label>
+        <select
+          id="ws-agent"
+          className={[
+            'workspace-editor__field-select',
+            'workspace-editor__field-select-inline',
+          ].join(' ')}
+          value={values.defaultAgent}
+          onChange={(e) =>
+            onChange(
+              'defaultAgent',
+              e.currentTarget.value as 'claude' | 'codex' | 'opencode'
+            )
+          }
+        >
           <option value="claude">Claude</option>
           <option value="codex">Codex</option>
           <option value="opencode">OpenCode</option>
         </select>
       </div>
       <div className="workspace-editor__checkbox-row">
-        <TuiCheckbox checked={values.defaultContinue} onChange={(v) => onChange('defaultContinue', v)}>Continue</TuiCheckbox>
-        <TuiCheckbox checked={values.defaultYolo} onChange={(v) => onChange('defaultYolo', v)}>YOLO</TuiCheckbox>
-        <TuiCheckbox checked={values.launchInTmux} onChange={(v) => onChange('launchInTmux', v)}>Tmux</TuiCheckbox>
+        <TuiCheckbox
+          checked={values.defaultContinue}
+          onChange={(v) => onChange('defaultContinue', v)}
+        >
+          Continue
+        </TuiCheckbox>
+        <TuiCheckbox
+          checked={values.defaultYolo}
+          onChange={(v) => onChange('defaultYolo', v)}
+        >
+          YOLO
+        </TuiCheckbox>
+        <TuiCheckbox
+          checked={values.launchInTmux}
+          onChange={(v) => onChange('launchInTmux', v)}
+        >
+          Tmux
+        </TuiCheckbox>
       </div>
     </section>
   );
@@ -121,21 +227,217 @@ function PromptsSection({ values, onChange }: PromptsSectionProps) {
   return (
     <section className="workspace-editor__section">
       <h3 className="workspace-editor__section-label">prompts</h3>
-      <PromptGroup label="Code review preferences" value={values.promptCodeReview} placeholder="e.g. focus on security, error handling" onChange={(v) => onChange('promptCodeReview', v)} />
-      <PromptGroup label="Create PR preferences" value={values.promptCreatePr} placeholder="e.g. include test plan section" onChange={(v) => onChange('promptCreatePr', v)} />
-      <PromptGroup label="Branch rename preferences" value={values.promptBranchRename} placeholder="e.g. prefix with dy/, use conventional commits style" onChange={(v) => onChange('promptBranchRename', v)} />
-      <PromptGroup label="General preferences" value={values.promptGeneral} placeholder="e.g. use TypeScript, follow CLAUDE.md" onChange={(v) => onChange('promptGeneral', v)} />
+      <PromptGroup
+        label="Code review preferences"
+        value={values.promptCodeReview}
+        placeholder="e.g. focus on security, error handling"
+        onChange={(v) => onChange('promptCodeReview', v)}
+      />
+      <PromptGroup
+        label="Create PR preferences"
+        value={values.promptCreatePr}
+        placeholder="e.g. include test plan section"
+        onChange={(v) => onChange('promptCreatePr', v)}
+      />
+      <PromptGroup
+        label="Branch rename preferences"
+        value={values.promptBranchRename}
+        placeholder="e.g. prefix with dy/, use conventional commits style"
+        onChange={(v) => onChange('promptBranchRename', v)}
+      />
+      <PromptGroup
+        label="General preferences"
+        value={values.promptGeneral}
+        placeholder="e.g. use TypeScript, follow CLAUDE.md"
+        onChange={(v) => onChange('promptGeneral', v)}
+      />
     </section>
   );
 }
 
-export default function WorkspaceEditor({ values, onChange, branches, overriddenKeys, error }: Props) {
+/** Validation regex for env var names: must start with uppercase letter, followed by uppercase letters, digits, or underscores */
+const ENV_VAR_NAME_REGEX = /^[A-Z][A-Z0-9_]*$/;
+
+/** Validate a single env var name, returns error message or empty string if valid */
+export function validateEnvPortVarName(name: string): string {
+  if (!name.trim()) return 'Name cannot be empty';
+  if (!ENV_VAR_NAME_REGEX.test(name)) {
+    return 'Must start with uppercase letter and contain only A-Z, 0-9, _';
+  }
+  return '';
+}
+
+/** Validate all env port var names, returns map of index -> error message */
+export function validateEnvPortVarNames(
+  names: string[]
+): Record<number, string> {
+  const errors: Record<number, string> = {};
+  const seen = new Set<string>();
+
+  names.forEach((name, index) => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      return; // Empty entries are allowed (will be filtered on save)
+    }
+    if (!ENV_VAR_NAME_REGEX.test(trimmed)) {
+      errors[index] = 'Invalid format';
+    }
+    if (seen.has(trimmed)) {
+      errors[index] = 'Duplicate';
+    }
+    seen.add(trimmed);
+  });
+
+  return errors;
+}
+
+interface EnvironmentPortsSectionProps {
+  values: WorkspaceEditorValues;
+  onChange: ChangeHandler;
+  onValidationChange?: ((errors: Record<string, string>) => void) | undefined;
+}
+
+function EnvironmentPortsSection({
+  values,
+  onChange,
+  onValidationChange,
+}: EnvironmentPortsSectionProps) {
+  const [newName, setNewName] = useState('');
+  const [newNameError, setNewNameError] = useState('');
+
+  function handleAdd() {
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+
+    const validationError = validateEnvPortVarName(trimmed);
+    if (validationError) {
+      setNewNameError(validationError);
+      return;
+    }
+
+    if (values.portVariables.includes(trimmed)) {
+      setNewNameError('Already in list');
+      return;
+    }
+
+    const updated = [...values.portVariables, trimmed];
+    onChange('portVariables', updated);
+    setNewName('');
+    setNewNameError('');
+
+    // Validate all and report
+    const allErrors = validateEnvPortVarNames(updated);
+    onValidationChange?.(
+      Object.keys(allErrors).length > 0
+        ? { portVariables: `${Object.keys(allErrors).length} invalid entries` }
+        : {}
+    );
+  }
+
+  function handleRemove(index: number) {
+    const updated = values.portVariables.filter((_, i) => i !== index);
+    onChange('portVariables', updated);
+
+    // Validate remaining
+    const allErrors = validateEnvPortVarNames(updated);
+    onValidationChange?.(
+      Object.keys(allErrors).length > 0
+        ? { portVariables: `${Object.keys(allErrors).length} invalid entries` }
+        : {}
+    );
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAdd();
+    }
+  }
+
+  return (
+    <section className="workspace-editor__section">
+      <h3 className="workspace-editor__section-label">environment ports</h3>
+      <p className="workspace-editor__hint">
+        Environment variable names to scan for port allocation. Default:{' '}
+        <code>PORT</code>
+      </p>
+      <div className="workspace-editor__list">
+        {values.portVariables.length === 0 ? (
+          <div className="workspace-editor__list-empty">
+            using default: <code>PORT</code>
+          </div>
+        ) : (
+          values.portVariables.map((name, index) => (
+            <div key={index} className="workspace-editor__list-item">
+              <span className="workspace-editor__list-item-value">{name}</span>
+              <button
+                type="button"
+                className="workspace-editor__list-item-remove"
+                onClick={() => handleRemove(index)}
+                aria-label={`Remove ${name}`}
+              >
+                ×
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+      <div className="workspace-editor__add-row">
+        <input
+          type="text"
+          className={`workspace-editor__field-input workspace-editor__add-input${newNameError ? ' workspace-editor__field-input--error' : ''}`}
+          placeholder="e.g. SERVER_PORT"
+          value={newName}
+          onChange={(e) => {
+            setNewName(e.currentTarget.value);
+            setNewNameError('');
+          }}
+          onKeyDown={handleKeyDown}
+        />
+        <button
+          type="button"
+          className="workspace-editor__add-btn"
+          onClick={handleAdd}
+          disabled={!newName.trim()}
+        >
+          Add
+        </button>
+      </div>
+      {newNameError && (
+        <p className="workspace-editor__field-error">{newNameError}</p>
+      )}
+    </section>
+  );
+}
+
+export default function WorkspaceEditor({
+  values,
+  onChange,
+  branches,
+  overriddenKeys,
+  error,
+  onValidationChange,
+}: Props) {
   return (
     <div className="workspace-editor">
       {error && <p className="workspace-editor__error-msg">{error}</p>}
-      <GitSettingsSection values={values} branches={branches} onChange={onChange} />
+      <GitSettingsSection
+        values={values}
+        branches={branches}
+        onChange={onChange}
+      />
       <div className="workspace-editor__divider" />
-      <SessionDefaultsSection values={values} overriddenKeys={overriddenKeys} onChange={onChange} />
+      <SessionDefaultsSection
+        values={values}
+        overriddenKeys={overriddenKeys}
+        onChange={onChange}
+      />
+      <div className="workspace-editor__divider" />
+      <EnvironmentPortsSection
+        values={values}
+        onChange={onChange}
+        onValidationChange={onValidationChange}
+      />
       <div className="workspace-editor__divider" />
       <PromptsSection values={values} onChange={onChange} />
     </div>

--- a/frontend/src/components/dialogs/WorkspaceEditor.tsx
+++ b/frontend/src/components/dialogs/WorkspaceEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import TuiCheckbox from '../TuiCheckbox.js';
 import type { BranchInfo } from '../../lib/types.js';
 import './WorkspaceEditor.css';
@@ -305,6 +305,15 @@ function EnvironmentPortsSection({
   const [newName, setNewName] = useState('');
   const [newNameError, setNewNameError] = useState('');
 
+  useEffect(() => {
+    const allErrors = validateEnvPortVarNames(values.portVariables);
+    onValidationChange?.(
+      Object.keys(allErrors).length > 0
+        ? { portVariables: `${Object.keys(allErrors).length} invalid entries` }
+        : {}
+    );
+  }, [values.portVariables, onValidationChange]);
+
   function handleAdd() {
     const trimmed = newName.trim();
     if (!trimmed) return;
@@ -324,27 +333,11 @@ function EnvironmentPortsSection({
     onChange('portVariables', updated);
     setNewName('');
     setNewNameError('');
-
-    // Validate all and report
-    const allErrors = validateEnvPortVarNames(updated);
-    onValidationChange?.(
-      Object.keys(allErrors).length > 0
-        ? { portVariables: `${Object.keys(allErrors).length} invalid entries` }
-        : {}
-    );
   }
 
   function handleRemove(index: number) {
     const updated = values.portVariables.filter((_, i) => i !== index);
     onChange('portVariables', updated);
-
-    // Validate remaining
-    const allErrors = validateEnvPortVarNames(updated);
-    onValidationChange?.(
-      Object.keys(allErrors).length > 0
-        ? { portVariables: `${Object.keys(allErrors).length} invalid entries` }
-        : {}
-    );
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {

--- a/frontend/src/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/frontend/src/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -1,7 +1,18 @@
-import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import React, {
+  forwardRef,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
 import TuiButton from '../TuiButton.js';
-import WorkspaceEditor, { type WorkspaceEditorValues } from './WorkspaceEditor.js';
-import { updateWorkspaceSettings, fetchBranches, fetchMergedWorkspaceSettings } from '../../lib/api.js';
+import WorkspaceEditor, {
+  type WorkspaceEditorValues,
+} from './WorkspaceEditor.js';
+import {
+  updateWorkspaceSettings,
+  fetchBranches,
+  fetchMergedWorkspaceSettings,
+} from '../../lib/api.js';
 import type { WorkspaceSettings, BranchInfo } from '../../lib/types.js';
 import './WorkspaceSettingsDialog.css';
 
@@ -15,36 +26,78 @@ interface Props {
 }
 
 const EMPTY_VALUES: WorkspaceEditorValues = {
-  defaultBranch: '', remote: '', branchPrefix: '', defaultAgent: 'claude',
-  defaultContinue: false, defaultYolo: false, launchInTmux: false,
-  promptCodeReview: '', promptCreatePr: '', promptBranchRename: '', promptGeneral: '',
+  defaultBranch: '',
+  remote: '',
+  branchPrefix: '',
+  defaultAgent: 'claude',
+  defaultContinue: false,
+  defaultYolo: false,
+  launchInTmux: false,
+  promptCodeReview: '',
+  promptCreatePr: '',
+  promptBranchRename: '',
+  promptGeneral: '',
+  portVariables: [],
 };
 
-const SESSION_DEFAULT_KEYS = ['defaultAgent', 'defaultContinue', 'defaultYolo', 'launchInTmux'];
+const SESSION_DEFAULT_KEYS = [
+  'defaultAgent',
+  'defaultContinue',
+  'defaultYolo',
+  'launchInTmux',
+];
 
 function settingsToValues(s: WorkspaceSettings): WorkspaceEditorValues {
   return {
-    defaultBranch: s.defaultBranch ?? '', remote: s.remote ?? '', branchPrefix: s.branchPrefix ?? '',
-    defaultAgent: (s.defaultAgent === 'codex' ? 'codex' : 'claude') as 'claude' | 'codex', defaultContinue: s.defaultContinue ?? false,
-    defaultYolo: s.defaultYolo ?? false, launchInTmux: s.launchInTmux ?? false,
-    promptCodeReview: s.promptCodeReview ?? '', promptCreatePr: s.promptCreatePr ?? '',
-    promptBranchRename: s.promptBranchRename ?? '', promptGeneral: s.promptGeneral ?? '',
+    defaultBranch: s.defaultBranch ?? '',
+    remote: s.remote ?? '',
+    branchPrefix: s.branchPrefix ?? '',
+    defaultAgent: (s.defaultAgent === 'codex' ? 'codex' : 'claude') as
+      | 'claude'
+      | 'codex',
+    defaultContinue: s.defaultContinue ?? false,
+    defaultYolo: s.defaultYolo ?? false,
+    launchInTmux: s.launchInTmux ?? false,
+    promptCodeReview: s.promptCodeReview ?? '',
+    promptCreatePr: s.promptCreatePr ?? '',
+    promptBranchRename: s.promptBranchRename ?? '',
+    promptGeneral: s.promptGeneral ?? '',
+    portVariables: s.portVariables ?? [],
   };
 }
 
-function buildSavePayload(values: WorkspaceEditorValues, original: Record<string, unknown>) {
+function buildSavePayload(
+  values: WorkspaceEditorValues,
+  original: Record<string, unknown>
+) {
   const settings: Record<string, unknown> = {};
-  if (values.defaultAgent !== original['defaultAgent']) settings['defaultAgent'] = values.defaultAgent;
-  if (values.defaultContinue !== original['defaultContinue']) settings['defaultContinue'] = values.defaultContinue;
-  if (values.defaultYolo !== original['defaultYolo']) settings['defaultYolo'] = values.defaultYolo;
-  if (values.launchInTmux !== original['launchInTmux']) settings['launchInTmux'] = values.launchInTmux;
+  if (values.defaultAgent !== original['defaultAgent'])
+    settings['defaultAgent'] = values.defaultAgent;
+  if (values.defaultContinue !== original['defaultContinue'])
+    settings['defaultContinue'] = values.defaultContinue;
+  if (values.defaultYolo !== original['defaultYolo'])
+    settings['defaultYolo'] = values.defaultYolo;
+  if (values.launchInTmux !== original['launchInTmux'])
+    settings['launchInTmux'] = values.launchInTmux;
   if (values.defaultBranch) settings['defaultBranch'] = values.defaultBranch;
   if (values.remote) settings['remote'] = values.remote;
   if (values.branchPrefix) settings['branchPrefix'] = values.branchPrefix;
-  if (values.promptCodeReview) settings['promptCodeReview'] = values.promptCodeReview;
+  if (values.promptCodeReview)
+    settings['promptCodeReview'] = values.promptCodeReview;
   if (values.promptCreatePr) settings['promptCreatePr'] = values.promptCreatePr;
-  if (values.promptBranchRename) settings['promptBranchRename'] = values.promptBranchRename;
+  if (values.promptBranchRename)
+    settings['promptBranchRename'] = values.promptBranchRename;
   if (values.promptGeneral) settings['promptGeneral'] = values.promptGeneral;
+  // Filter out empty strings before saving env port var names
+  const filteredPortNames = values.portVariables.filter((n) => n.trim());
+  const originalPortVariables = Array.isArray(original['portVariables'])
+    ? (original['portVariables'] as string[])
+    : [];
+  if (filteredPortNames.length > 0) {
+    settings['portVariables'] = filteredPortNames;
+  } else if (originalPortVariables.length > 0) {
+    settings['portVariables'] = null;
+  }
   return settings;
 }
 
@@ -58,108 +111,219 @@ function DialogHeader({ workspaceName, onClose }: DialogHeaderProps) {
     <div className="workspace-settings-dialog-header">
       <h2 className="workspace-settings-dialog-title">
         <span className="workspace-settings-gear-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" width="14" height="14">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="square"
+            width="14"
+            height="14"
+          >
             <circle cx="12" cy="12" r="3" />
             <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1-1.51H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
           </svg>
         </span>
         {workspaceName}
       </h2>
-      <button className="workspace-settings-close-btn" aria-label="Close settings" onClick={onClose}>
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" width="14" height="14">
-          <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+      <button
+        className="workspace-settings-close-btn"
+        aria-label="Close settings"
+        onClick={onClose}
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="square"
+          width="14"
+          height="14"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
         </svg>
       </button>
     </div>
   );
 }
 
-const WorkspaceSettingsDialog = forwardRef<WorkspaceSettingsDialogHandle, Props>(
-  function WorkspaceSettingsDialog({ onRemoveWorkspace }, ref) {
-    const dialogRef = useRef<HTMLDialogElement>(null);
-    const [workspacePath, setWorkspacePath] = useState('');
-    const [workspaceName, setWorkspaceName] = useState('');
-    const [saving, setSaving] = useState(false);
-    const [error, setError] = useState('');
-    const [saveSuccess, setSaveSuccess] = useState(false);
-    const [branches, setBranches] = useState<BranchInfo[]>([]);
-    const [overriddenKeys, setOverriddenKeys] = useState<string[]>([]);
-    const [originalSettings, setOriginalSettings] = useState<Record<string, unknown>>({});
-    const [values, setValues] = useState<WorkspaceEditorValues>(EMPTY_VALUES);
+const WorkspaceSettingsDialog = forwardRef<
+  WorkspaceSettingsDialogHandle,
+  Props
+>(function WorkspaceSettingsDialog({ onRemoveWorkspace }, ref) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const [workspacePath, setWorkspacePath] = useState('');
+  const [workspaceName, setWorkspaceName] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [branches, setBranches] = useState<BranchInfo[]>([]);
+  const [overriddenKeys, setOverriddenKeys] = useState<string[]>([]);
+  const [originalSettings, setOriginalSettings] = useState<
+    Record<string, unknown>
+  >({});
+  const [values, setValues] = useState<WorkspaceEditorValues>(EMPTY_VALUES);
+  const [validationErrors, setValidationErrors] = useState<
+    Record<string, string>
+  >({});
 
-    useImperativeHandle(ref, () => ({
-      async open(path: string, name: string) {
-        setWorkspacePath(path); setWorkspaceName(name);
-        setError(''); setSaveSuccess(false); setSaving(false); setValues(EMPTY_VALUES);
-        dialogRef.current?.showModal();
-        try {
-          const [mergedResult, branchList] = await Promise.all([
-            fetchMergedWorkspaceSettings(path),
-            fetchBranches(path).catch(() => [] as BranchInfo[]),
-          ]);
-          setBranches(branchList);
-          setValues(settingsToValues(mergedResult.settings));
-          setOriginalSettings({ defaultAgent: mergedResult.settings.defaultAgent, defaultContinue: mergedResult.settings.defaultContinue, defaultYolo: mergedResult.settings.defaultYolo, launchInTmux: mergedResult.settings.launchInTmux });
-          setOverriddenKeys(mergedResult.overridden);
-        } catch {
-          setError('Failed to load workspace settings.');
-        }
-      },
-      close() { dialogRef.current?.close(); },
-    }));
-
-    function handleChange<K extends keyof WorkspaceEditorValues>(key: K, value: WorkspaceEditorValues[K]) {
-      setValues((prev) => ({ ...prev, [key]: value }));
-    }
-
-    async function handleSave() {
-      setSaving(true); setError(''); setSaveSuccess(false);
+  useImperativeHandle(ref, () => ({
+    async open(path: string, name: string) {
+      setWorkspacePath(path);
+      setWorkspaceName(name);
+      setError('');
+      setSaveSuccess(false);
+      setSaving(false);
+      setValues(EMPTY_VALUES);
+      setValidationErrors({});
+      dialogRef.current?.showModal();
       try {
-        const settings = buildSavePayload(values, originalSettings);
-        if (Object.keys(settings).length > 0) await updateWorkspaceSettings(workspacePath, settings);
-        setSaveSuccess(true);
-        setTimeout(() => setSaveSuccess(false), 2000);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to save settings.');
-      } finally { setSaving(false); }
+        const [mergedResult, branchList] = await Promise.all([
+          fetchMergedWorkspaceSettings(path),
+          fetchBranches(path).catch(() => [] as BranchInfo[]),
+        ]);
+        setBranches(branchList);
+        setValues(settingsToValues(mergedResult.settings));
+        setOriginalSettings({
+          defaultAgent: mergedResult.settings.defaultAgent,
+          defaultContinue: mergedResult.settings.defaultContinue,
+          defaultYolo: mergedResult.settings.defaultYolo,
+          launchInTmux: mergedResult.settings.launchInTmux,
+          portVariables: mergedResult.settings.portVariables ?? [],
+        });
+        setOverriddenKeys(mergedResult.overridden);
+      } catch {
+        setError('Failed to load workspace settings.');
+      }
+    },
+    close() {
+      dialogRef.current?.close();
+    },
+  }));
+
+  function handleChange<K extends keyof WorkspaceEditorValues>(
+    key: K,
+    value: WorkspaceEditorValues[K]
+  ) {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError('');
+    setSaveSuccess(false);
+    try {
+      const settings = buildSavePayload(values, originalSettings);
+      if (Object.keys(settings).length > 0)
+        await updateWorkspaceSettings(workspacePath, settings);
+      setSaveSuccess(true);
+      setTimeout(() => setSaveSuccess(false), 2000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save settings.');
+    } finally {
+      setSaving(false);
     }
+  }
 
-    async function handleResetSessionDefaults() {
-      setSaving(true); setError('');
-      try {
-        await updateWorkspaceSettings(workspacePath, { defaultAgent: null, defaultContinue: null, defaultYolo: null, launchInTmux: null } as unknown as Record<string, unknown>);
-        const merged = await fetchMergedWorkspaceSettings(workspacePath);
-        setValues(settingsToValues(merged.settings));
-        setOriginalSettings({ defaultAgent: merged.settings.defaultAgent, defaultContinue: merged.settings.defaultContinue, defaultYolo: merged.settings.defaultYolo, launchInTmux: merged.settings.launchInTmux });
-        setOverriddenKeys(merged.overridden);
-        setSaveSuccess(true);
-        setTimeout(() => setSaveSuccess(false), 2000);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to reset settings.');
-      } finally { setSaving(false); }
+  async function handleResetSessionDefaults() {
+    setSaving(true);
+    setError('');
+    try {
+      await updateWorkspaceSettings(workspacePath, {
+        defaultAgent: null,
+        defaultContinue: null,
+        defaultYolo: null,
+        launchInTmux: null,
+      } as unknown as Record<string, unknown>);
+      const merged = await fetchMergedWorkspaceSettings(workspacePath);
+      setValues(settingsToValues(merged.settings));
+      setOriginalSettings({
+        defaultAgent: merged.settings.defaultAgent,
+        defaultContinue: merged.settings.defaultContinue,
+        defaultYolo: merged.settings.defaultYolo,
+        launchInTmux: merged.settings.launchInTmux,
+        portVariables: merged.settings.portVariables ?? [],
+      });
+      setOverriddenKeys(merged.overridden);
+      setSaveSuccess(true);
+      setTimeout(() => setSaveSuccess(false), 2000);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to reset settings.'
+      );
+    } finally {
+      setSaving(false);
     }
+  }
 
-    const hasOverriddenDefaults = overriddenKeys.some((k) => SESSION_DEFAULT_KEYS.includes(k));
+  function handleValidationChange(errors: Record<string, string>) {
+    setValidationErrors(errors);
+  }
 
-    return (
-      <dialog ref={dialogRef} className="workspace-settings-dialog" onClick={(e) => { if (e.target === dialogRef.current) dialogRef.current?.close(); }}>
-        <div className="workspace-settings-dialog-content">
-          <DialogHeader workspaceName={workspaceName} onClose={() => dialogRef.current?.close()} />
-          <div className="workspace-settings-dialog-body">
-            <WorkspaceEditor values={values} onChange={handleChange} branches={branches} overriddenKeys={overriddenKeys} error={error} />
-          </div>
-          <div className="workspace-settings-dialog-footer">
-            <TuiButton variant="danger" onClick={() => { dialogRef.current?.close(); onRemoveWorkspace(workspacePath); }}>Remove Workspace</TuiButton>
-            <div className="workspace-settings-footer-right">
-              {hasOverriddenDefaults && <TuiButton variant="ghost" onClick={() => void handleResetSessionDefaults()} disabled={saving}>Reset to Global</TuiButton>}
-              {saveSuccess && <span className="workspace-settings-save-success">Saved</span>}
-              <TuiButton variant="primary" onClick={() => void handleSave()} disabled={saving}>{saving ? 'Saving\u2026' : 'Save'}</TuiButton>
-            </div>
+  const hasValidationErrors = Object.keys(validationErrors).length > 0;
+  const hasOverriddenDefaults = overriddenKeys.some((k) =>
+    SESSION_DEFAULT_KEYS.includes(k)
+  );
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="workspace-settings-dialog"
+      onClick={(e) => {
+        if (e.target === dialogRef.current) dialogRef.current?.close();
+      }}
+    >
+      <div className="workspace-settings-dialog-content">
+        <DialogHeader
+          workspaceName={workspaceName}
+          onClose={() => dialogRef.current?.close()}
+        />
+        <div className="workspace-settings-dialog-body">
+          <WorkspaceEditor
+            values={values}
+            onChange={handleChange}
+            branches={branches}
+            overriddenKeys={overriddenKeys}
+            error={error}
+            onValidationChange={handleValidationChange}
+          />
+        </div>
+        <div className="workspace-settings-dialog-footer">
+          <TuiButton
+            variant="danger"
+            onClick={() => {
+              dialogRef.current?.close();
+              onRemoveWorkspace(workspacePath);
+            }}
+          >
+            Remove Workspace
+          </TuiButton>
+          <div className="workspace-settings-footer-right">
+            {hasOverriddenDefaults && (
+              <TuiButton
+                variant="ghost"
+                onClick={() => void handleResetSessionDefaults()}
+                disabled={saving}
+              >
+                Reset to Global
+              </TuiButton>
+            )}
+            {saveSuccess && (
+              <span className="workspace-settings-save-success">Saved</span>
+            )}
+            <TuiButton
+              variant="primary"
+              onClick={() => void handleSave()}
+              disabled={saving || hasValidationErrors}
+            >
+              {saving ? 'Saving\u2026' : 'Save'}
+            </TuiButton>
           </div>
         </div>
-      </dialog>
-    );
-  },
-);
+      </div>
+    </dialog>
+  );
+});
 
 export default WorkspaceSettingsDialog;

--- a/frontend/src/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/frontend/src/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -88,8 +88,11 @@ function buildSavePayload(
   if (values.promptBranchRename)
     settings['promptBranchRename'] = values.promptBranchRename;
   if (values.promptGeneral) settings['promptGeneral'] = values.promptGeneral;
-  // Filter out empty strings before saving env port var names
-  const filteredPortNames = values.portVariables.filter((n) => n.trim());
+  // Normalize env port var names before saving by trimming, removing empties,
+  // and de-duplicating equivalent entries.
+  const filteredPortNames = Array.from(
+    new Set(values.portVariables.map((n) => n.trim()).filter(Boolean))
+  );
   const originalPortVariables = Array.isArray(original['portVariables'])
     ? (original['portVariables'] as string[])
     : [];

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -302,6 +302,8 @@ export interface WorkspaceSettings {
   promptFixConflicts?: string;
   promptStartWork?: string;
   nextMountainIndex?: number;
+  /** Environment variable names that should receive per-worktree allocated ports. */
+  portVariables?: string[];
 }
 
 export interface AutomationSettings {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "diff2html": "^3.4.56",
         "eslint-plugin-sonarjs": "^4.0.2",
         "express": "^4.21.0",
+        "get-port": "^7.1.0",
         "node-pty": "^1.0.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -3819,6 +3820,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-proto": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "diff2html": "^3.4.56",
     "eslint-plugin-sonarjs": "^4.0.2",
     "express": "^4.21.0",
+    "get-port": "^7.1.0",
     "node-pty": "^1.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/server/index.ts
+++ b/server/index.ts
@@ -207,6 +207,45 @@ function getRepoPortVariables(config: Config, repoPath: string): string[] {
   return normalizePortVariables(config.repoSettings?.[repoPath]?.portVariables);
 }
 
+function getAllocatorOrNull(): ReturnType<typeof getDefaultAllocator> | null {
+  try {
+    return getDefaultAllocator();
+  } catch {
+    return null;
+  }
+}
+
+function logPortReconciliationFailure(err: unknown): void {
+  logger.warn(
+    'Port reconciliation failed:',
+    err instanceof Error ? err.message : err
+  );
+}
+
+function setupProcessSignalHandlers(): void {
+  process.on('SIGPIPE', () => {});
+  process.on('SIGHUP', () => {});
+}
+
+async function initializePortAllocatorAndReconcile(
+  configPath: string,
+  getConfig: () => Config,
+  reconcilePortsForAllRepos: (repoPaths: string[]) => Promise<void>
+): Promise<void> {
+  try {
+    await initializeDefaultAllocator(configPath, logger);
+  } catch (err) {
+    logger.warn(
+      'Port allocator disabled: failed to initialize:',
+      err instanceof Error ? err.message : err
+    );
+  }
+
+  if (getAllocatorOrNull()) {
+    await reconcilePortsForAllRepos(getConfig().repos ?? []);
+  }
+}
+
 function scanAllRepos(rootDirs: string[]): RepoEntry[] {
   const repos: RepoEntry[] = [];
   for (const rootDir of rootDirs) {
@@ -580,15 +619,16 @@ async function initializePinConfig(startupConfig: Config): Promise<void> {
 }
 
 async function main(): Promise<void> {
-  // Ignore SIGPIPE: node-pty can propagate pipe breaks causing unexpected session exits
-  process.on('SIGPIPE', () => {});
-  // Ignore SIGHUP: keep server alive if controlling terminal disconnects
-  process.on('SIGHUP', () => {});
+  // Ignore SIGPIPE: node-pty can propagate pipe breaks causing unexpected session exits.
+  // Ignore SIGHUP: keep server alive if controlling terminal disconnects.
+  setupProcessSignalHandlers();
 
   ensureMetaDir(CONFIG_PATH);
 
   async function reconcilePortsForRepo(repoPath: string): Promise<void> {
-    const allocator = getDefaultAllocator();
+    const allocator = getAllocatorOrNull();
+    if (!allocator) return;
+
     const config = getConfig();
     const portVariables = normalizePortVariables(
       config.repoSettings?.[repoPath]?.portVariables
@@ -597,25 +637,46 @@ async function main(): Promise<void> {
     let worktrees: Awaited<ReturnType<typeof listNonMainWorktrees>>;
     try {
       worktrees = await listNonMainWorktrees(repoPath);
-    } catch {
+    } catch (err) {
+      logger.debug(
+        'Failed to list worktrees for port reconciliation:',
+        repoPath,
+        err instanceof Error ? err.message : err
+      );
       return;
     }
 
     const activeWorktreePaths = new Set(worktrees.map((wt) => wt.path));
     for (const worktree of worktrees) {
-      const ports = await allocator.reconcilePortsForWorktree(
-        repoPath,
-        worktree.path,
-        portVariables
-      );
-      upsertPortsInEnvFile(worktree.path, ports);
+      try {
+        const ports = await allocator.reconcilePortsForWorktree(
+          repoPath,
+          worktree.path,
+          portVariables
+        );
+        upsertPortsInEnvFile(worktree.path, ports);
+      } catch (err) {
+        logger.warn(
+          'Port reconciliation failed for worktree:',
+          worktree.path,
+          err instanceof Error ? err.message : err
+        );
+      }
     }
 
     for (const assignment of allocator.getAllAssignments()) {
       if (assignment.repoId !== repoPath) continue;
       if (activeWorktreePaths.has(assignment.worktreeId)) continue;
-      allocator.releasePortsForWorktree(repoPath, assignment.worktreeId);
-      removePortsFromEnvFile(assignment.worktreeId);
+      try {
+        allocator.releasePortsForWorktree(repoPath, assignment.worktreeId);
+        removePortsFromEnvFile(assignment.worktreeId);
+      } catch (err) {
+        logger.warn(
+          'Failed to clean up stale port assignment:',
+          assignment.worktreeId,
+          err instanceof Error ? err.message : err
+        );
+      }
     }
   }
 
@@ -623,6 +684,12 @@ async function main(): Promise<void> {
     for (const repoPath of repoPaths) {
       await reconcilePortsForRepo(repoPath);
     }
+  }
+
+  function queuePortReconciliation(repoPaths: string[]): void {
+    void reconcilePortsForAllRepos(repoPaths).catch(
+      logPortReconciliationFailure
+    );
   }
 
   // Runtime config — always reads fresh from disk.
@@ -666,17 +733,11 @@ async function main(): Promise<void> {
   initFileLogging(path.join(configDir, 'logs'));
   fs.mkdirSync(path.join(configDir, 'telemetry'), { recursive: true });
 
-  // Initialize port allocator for per-worktree port env injection
-  try {
-    await initializeDefaultAllocator(CONFIG_PATH, logger);
-  } catch (err) {
-    logger.warn(
-      'Port allocator disabled: failed to initialize:',
-      err instanceof Error ? err.message : err
-    );
-  }
-
-  await reconcilePortsForAllRepos(getConfig().repos ?? []);
+  await initializePortAllocatorAndReconcile(
+    CONFIG_PATH,
+    getConfig,
+    reconcilePortsForAllRepos
+  );
 
   try {
     initAnalytics(configDir);
@@ -837,7 +898,7 @@ async function main(): Promise<void> {
   branchWatcher.rebuild(getConfig().repos || []);
   watcher.on('worktrees-changed', () => {
     branchWatcher.rebuild(getConfig().repos || []);
-    void reconcilePortsForAllRepos(getConfig().repos || []);
+    queuePortReconciliation(getConfig().repos || []);
   });
 
   // Watch upstream tracking refs for push/fetch and broadcast ref-changed events
@@ -897,7 +958,7 @@ async function main(): Promise<void> {
           const repoPaths = getConfig().repos || [];
           watcher.rebuild(repoPaths);
           branchWatcher.rebuild(repoPaths);
-          void reconcilePortsForAllRepos(repoPaths);
+          queuePortReconciliation(repoPaths);
         } catch (err) {
           logger.error('Failed to rebuild workspace watchers:', err);
         }

--- a/server/index.ts
+++ b/server/index.ts
@@ -108,6 +108,13 @@ import {
   cleanExpiredTokens,
 } from './browser-content.js';
 import { createLogger, initFileLogging } from './logger.js';
+import {
+  initializeDefaultAllocator,
+  getDefaultAllocator,
+  normalizePortVariables,
+  removePortsFromEnvFile,
+  upsertPortsInEnvFile,
+} from './port-allocator.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -160,6 +167,8 @@ function execErrorMessage(err: unknown, fallback: string): string {
   return (e.stderr || e.message || fallback).trim();
 }
 
+const GIT_WORKTREE_LIST_ARGS = ['worktree', 'list', '--porcelain'] as const;
+
 type RepoEntry = { name: string; path: string; root: string };
 
 function scanReposInRoot(rootDir: string): RepoEntry[] {
@@ -183,6 +192,19 @@ function scanReposInRoot(rootDir: string): RepoEntry[] {
     }
   }
   return repos;
+}
+
+async function listNonMainWorktrees(
+  repoPath: string
+): Promise<ReturnType<typeof parseAllWorktrees>> {
+  const { stdout } = await execFileAsync('git', [...GIT_WORKTREE_LIST_ARGS], {
+    cwd: repoPath,
+  });
+  return parseAllWorktrees(stdout, repoPath).filter((wt) => !wt.isMain);
+}
+
+function getRepoPortVariables(config: Config, repoPath: string): string[] {
+  return normalizePortVariables(config.repoSettings?.[repoPath]?.portVariables);
 }
 
 function scanAllRepos(rootDirs: string[]): RepoEntry[] {
@@ -484,6 +506,8 @@ type AgentSessionParams = {
   branchRenamePrompt: string;
   computedInitialPrompt: string | undefined;
   claudeFullscreen: boolean;
+  /** Port env var names to inject for this worktree (from repo settings) */
+  portVariables?: string[] | undefined;
 };
 
 /** Creates an agent session record and writes worktree metadata if applicable. */
@@ -512,6 +536,8 @@ function createAgentSessionRecord(params: AgentSessionParams): CreateResult {
     ...(params.computedInitialPrompt != null && {
       initialPrompt: params.computedInitialPrompt,
     }),
+    // Pass port env var names for per-worktree port injection
+    portVariables: params.portVariables,
   });
 
   if (params.worktreePath) {
@@ -561,6 +587,44 @@ async function main(): Promise<void> {
 
   ensureMetaDir(CONFIG_PATH);
 
+  async function reconcilePortsForRepo(repoPath: string): Promise<void> {
+    const allocator = getDefaultAllocator();
+    const config = getConfig();
+    const portVariables = normalizePortVariables(
+      config.repoSettings?.[repoPath]?.portVariables
+    );
+
+    let worktrees: Awaited<ReturnType<typeof listNonMainWorktrees>>;
+    try {
+      worktrees = await listNonMainWorktrees(repoPath);
+    } catch {
+      return;
+    }
+
+    const activeWorktreePaths = new Set(worktrees.map((wt) => wt.path));
+    for (const worktree of worktrees) {
+      const ports = await allocator.reconcilePortsForWorktree(
+        repoPath,
+        worktree.path,
+        portVariables
+      );
+      upsertPortsInEnvFile(worktree.path, ports);
+    }
+
+    for (const assignment of allocator.getAllAssignments()) {
+      if (assignment.repoId !== repoPath) continue;
+      if (activeWorktreePaths.has(assignment.worktreeId)) continue;
+      allocator.releasePortsForWorktree(repoPath, assignment.worktreeId);
+      removePortsFromEnvFile(assignment.worktreeId);
+    }
+  }
+
+  async function reconcilePortsForAllRepos(repoPaths: string[]): Promise<void> {
+    for (const repoPath of repoPaths) {
+      await reconcilePortsForRepo(repoPath);
+    }
+  }
+
   // Runtime config — always reads fresh from disk.
   // Use this for ALL config access in route handlers, pollers, and event callbacks.
   let lastGoodConfig: Config | null = null;
@@ -601,6 +665,19 @@ async function main(): Promise<void> {
   const configDir = getConfigDir(CONFIG_PATH);
   initFileLogging(path.join(configDir, 'logs'));
   fs.mkdirSync(path.join(configDir, 'telemetry'), { recursive: true });
+
+  // Initialize port allocator for per-worktree port env injection
+  try {
+    await initializeDefaultAllocator(CONFIG_PATH, logger);
+  } catch (err) {
+    logger.warn(
+      'Port allocator disabled: failed to initialize:',
+      err instanceof Error ? err.message : err
+    );
+  }
+
+  await reconcilePortsForAllRepos(getConfig().repos ?? []);
+
   try {
     initAnalytics(configDir);
   } catch (err) {
@@ -760,6 +837,7 @@ async function main(): Promise<void> {
   branchWatcher.rebuild(getConfig().repos || []);
   watcher.on('worktrees-changed', () => {
     branchWatcher.rebuild(getConfig().repos || []);
+    void reconcilePortsForAllRepos(getConfig().repos || []);
   });
 
   // Watch upstream tracking refs for push/fetch and broadcast ref-changed events
@@ -819,6 +897,7 @@ async function main(): Promise<void> {
           const repoPaths = getConfig().repos || [];
           watcher.rebuild(repoPaths);
           branchWatcher.rebuild(repoPaths);
+          void reconcilePortsForAllRepos(repoPaths);
         } catch (err) {
           logger.error('Failed to rebuild workspace watchers:', err);
         }
@@ -1037,6 +1116,8 @@ async function main(): Promise<void> {
         const repoName =
           opts.repoPath.split('/').filter(Boolean).pop() || 'session';
         const displayName = sessions.nextAgentName();
+        // Get port env var names from repo settings for port injection
+        const portVariables = getRepoPortVariables(freshCfg, opts.repoPath);
         sessions.create({
           type: 'agent',
           agent: resolved.agent,
@@ -1058,6 +1139,8 @@ async function main(): Promise<void> {
           ...(opts.initialPrompt != null && {
             initialPrompt: opts.initialPrompt,
           }),
+          // Pass port env var names for per-worktree port injection
+          portVariables,
         });
       },
       broadcastEvent,
@@ -1735,6 +1818,16 @@ async function main(): Promise<void> {
       }
     }
 
+    try {
+      getDefaultAllocator().releasePortsForWorktree(repoPath, resolvedPath);
+      removePortsFromEnvFile(resolvedPath);
+    } catch (err) {
+      logger.warn(
+        '[worktrees] failed to release ports:',
+        err instanceof Error ? err.message : err
+      );
+    }
+
     // Clean up metadata file
     deleteMeta(CONFIG_PATH, worktreePath);
 
@@ -1817,6 +1910,7 @@ async function main(): Promise<void> {
     const safeRows = clampDimension(rows, 1, 200);
 
     const name = repoPath.split('/').filter(Boolean).pop() || 'session';
+    const portVariables = getRepoPortVariables(freshConfig, repoPath);
 
     if (type === 'terminal') {
       // Terminal session — bare shell
@@ -1835,6 +1929,8 @@ async function main(): Promise<void> {
         args: [],
         ...(safeCols != null && { cols: safeCols }),
         ...(safeRows != null && { rows: safeRows }),
+        // Pass port env var names for per-worktree port injection
+        portVariables,
       });
       gitWatcher.watch(session.cwd);
       res.status(201).json(session);
@@ -1909,6 +2005,7 @@ async function main(): Promise<void> {
       branchRenamePrompt: branchRenamePrompt ?? '',
       computedInitialPrompt,
       claudeFullscreen: freshConfig.claudeFullscreen,
+      portVariables,
     });
 
     gitWatcher.watch(session.cwd);

--- a/server/port-allocator.ts
+++ b/server/port-allocator.ts
@@ -70,8 +70,27 @@ export interface PortVerificationResult {
 export interface PortAllocatorOptions {
   /** Path to config.json (used to derive config directory) */
   configPath: string;
-  /** Optional logger for debug output */
-  logger?: { debug: (msg: string, ...args: unknown[]) => void } | undefined;
+  /** Optional logger for debug/warn output */
+  logger?:
+    | {
+        debug: (msg: string, ...args: unknown[]) => void;
+        warn?: (msg: string, ...args: unknown[]) => void;
+      }
+    | undefined;
+}
+
+type PortAllocatorLogger = NonNullable<PortAllocatorOptions['logger']>;
+
+function logWarn(
+  logger: PortAllocatorLogger | undefined,
+  message: string,
+  ...args: unknown[]
+): void {
+  if (logger?.warn) {
+    logger.warn(message, ...args);
+    return;
+  }
+  logger?.debug(message, ...args);
 }
 
 export function normalizePortVariables(
@@ -79,8 +98,10 @@ export function normalizePortVariables(
 ): string[] {
   const seen = new Set<string>();
   const normalized = (variableNames ?? [])
+    .filter((name): name is string => typeof name === 'string')
     .map((name) => name.trim())
     .filter(Boolean)
+    .filter((name) => /^[A-Z][A-Z0-9_]*$/.test(name))
     .filter((name) => {
       if (seen.has(name)) return false;
       seen.add(name);
@@ -174,7 +195,7 @@ export class PortAllocator {
    *
    * @param repoId - Repository identifier
    * @param worktreeId - Worktree identifier
-   * @returns Map of variable names to port numbers, or undefined if none allocated
+   * @returns Map of variable names to port numbers, or null if none allocated
    */
   getPortsForWorktree(
     repoId: string,
@@ -193,6 +214,14 @@ export class PortAllocator {
     return result;
   }
 
+  /**
+   * Reconcile a worktree's allocated ports against the currently requested
+   * variable set.
+   *
+   * Existing allocations are preserved for variables still requested, stale
+   * variable assignments are removed, and any newly requested variables are
+   * allocated fresh ports.
+   */
   async reconcilePortsForWorktree(
     repoId: string,
     worktreeId: string,
@@ -241,18 +270,33 @@ export class PortAllocator {
   // ── Private Methods ─────────────────────────────────────────────────────
 
   private loadAssignments(): PortAssignmentsFile {
+    if (!fs.existsSync(this.assignmentsPath)) {
+      return { version: 1, assignments: [] };
+    }
+
     try {
-      if (fs.existsSync(this.assignmentsPath)) {
-        const raw = fs.readFileSync(this.assignmentsPath, 'utf8');
-        const data = JSON.parse(raw) as PortAssignmentsFile;
-        if (data.version === 1 && Array.isArray(data.assignments)) {
-          return data;
-        }
+      const raw = fs.readFileSync(this.assignmentsPath, 'utf8');
+      const data = JSON.parse(raw) as PortAssignmentsFile;
+      if (data.version === 1 && Array.isArray(data.assignments)) {
+        return data;
       }
+      logWarn(
+        this.logger,
+        'Invalid port assignments file version or shape, starting fresh:',
+        this.assignmentsPath
+      );
     } catch (err) {
-      this.logger?.debug(
-        'Failed to load port assignments, starting fresh',
-        err
+      const backupPath = `${this.assignmentsPath}.corrupt-${Date.now()}`;
+      try {
+        fs.copyFileSync(this.assignmentsPath, backupPath);
+      } catch {
+        // Best-effort backup only.
+      }
+      logWarn(
+        this.logger,
+        'Failed to load port assignments, starting fresh:',
+        err,
+        backupPath ? `backup=${backupPath}` : ''
       );
     }
     return { version: 1, assignments: [] };
@@ -260,14 +304,19 @@ export class PortAllocator {
 
   private saveAssignments(): void {
     const dir = path.dirname(this.assignmentsPath);
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
+    try {
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      fs.writeFileSync(
+        this.assignmentsPath,
+        JSON.stringify(this.assignments, null, 2),
+        'utf8'
+      );
+    } catch (err) {
+      logWarn(this.logger, 'Failed to save port assignments:', err);
+      throw err;
     }
-    fs.writeFileSync(
-      this.assignmentsPath,
-      JSON.stringify(this.assignments, null, 2),
-      'utf8'
-    );
   }
 
   private async allocateSinglePort(
@@ -323,6 +372,10 @@ export class PortAllocator {
     }
 
     // Let get-port pick any available port outside our ranges
+    logWarn(
+      this.logger,
+      'All configured port ranges exhausted, falling back to OS-assigned port'
+    );
     return getPort();
   }
 

--- a/server/port-allocator.ts
+++ b/server/port-allocator.ts
@@ -1,0 +1,592 @@
+/**
+ * Port Allocator for Worktree Environments
+ *
+ * Provides durable port allocation with OS-level verification.
+ * Ports are persisted to port-assignments.json in the config directory.
+ *
+ * Port ranges:
+ * - Primary: 10000-10999 (1000 ports)
+ * - Overflow: 11000-11999 (1000 ports)
+ *
+ * .env block utilities manage relay-ide port variable blocks while preserving
+ * surrounding content.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import getPort from 'get-port';
+
+const DEFAULT_PORT_VARIABLES = ['PORT'];
+
+// ── Constants ─────────────────────────────────────────────────────────────
+
+/** Primary port range start (inclusive) */
+export const PORT_RANGE_START = 10000;
+/** Primary port range end (exclusive) */
+export const PORT_RANGE_END = 11000;
+/** Overflow port range start (inclusive) */
+export const OVERFLOW_RANGE_START = 11000;
+/** Overflow port range end (exclusive) */
+export const OVERFLOW_RANGE_END = 12000;
+
+/** Marker for .env managed block start */
+export const ENV_BLOCK_START =
+  '# --- relay-ide managed ports (do not edit) ---';
+/** Marker for .env managed block end */
+export const ENV_BLOCK_END = '# --- end relay-ide managed ports ---';
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+/**
+ * A single port assignment for a worktree variable.
+ */
+export interface PortAssignment {
+  repoId: string;
+  worktreeId: string;
+  variableName: string;
+  port: number;
+  verifiedAt: string; // ISO timestamp
+}
+
+/**
+ * All port assignments persisted to disk.
+ */
+export interface PortAssignmentsFile {
+  version: 1;
+  assignments: PortAssignment[];
+}
+
+/**
+ * Result of port verification check.
+ */
+export interface PortVerificationResult {
+  port: number;
+  available: boolean;
+}
+
+/**
+ * Options for creating a PortAllocator.
+ */
+export interface PortAllocatorOptions {
+  /** Path to config.json (used to derive config directory) */
+  configPath: string;
+  /** Optional logger for debug output */
+  logger?: { debug: (msg: string, ...args: unknown[]) => void } | undefined;
+}
+
+export function normalizePortVariables(
+  variableNames?: string[] | null
+): string[] {
+  const seen = new Set<string>();
+  const normalized = (variableNames ?? [])
+    .map((name) => name.trim())
+    .filter(Boolean)
+    .filter((name) => {
+      if (seen.has(name)) return false;
+      seen.add(name);
+      return true;
+    });
+  return normalized.length > 0 ? normalized : [...DEFAULT_PORT_VARIABLES];
+}
+
+// ── Port Allocator Class ──────────────────────────────────────────────────
+
+/**
+ * Manages durable port allocation for worktrees.
+ *
+ * Ports are allocated from the primary range (10000-10999) first,
+ * falling back to overflow range (11000-11999) if primary is exhausted.
+ *
+ * On initialization, existing assignments are verified against the OS
+ * and reassigned if the port is no longer available.
+ */
+export class PortAllocator {
+  private readonly assignmentsPath: string;
+  private readonly logger:
+    | { debug: (msg: string, ...args: unknown[]) => void }
+    | undefined;
+  private assignments: PortAssignmentsFile;
+  private initialized = false;
+
+  constructor(options: PortAllocatorOptions) {
+    this.assignmentsPath = path.join(
+      path.dirname(options.configPath),
+      'port-assignments.json'
+    );
+    this.logger = options.logger;
+    this.assignments = this.loadAssignments();
+  }
+
+  /**
+   * Initialize the allocator by verifying existing assignments.
+   * Must be called before any allocation operations if verification is needed.
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+
+    await this.verifyAndReassignPorts();
+    this.initialized = true;
+  }
+
+  /**
+   * Allocate ports for a worktree.
+   *
+   * @param repoId - Repository identifier
+   * @param worktreeId - Worktree identifier
+   * @param variableNames - Names of port variables (e.g., ['PORT', 'VITE_PORT'])
+   * @returns Map of variable names to allocated port numbers
+   */
+  async allocatePortsForWorktree(
+    repoId: string,
+    worktreeId: string,
+    variableNames: string[]
+  ): Promise<Record<string, number>> {
+    const requestedVariables = normalizePortVariables(variableNames);
+    const result: Record<string, number> = {};
+
+    for (const varName of requestedVariables) {
+      const port = await this.allocateSinglePort(repoId, worktreeId, varName);
+      result[varName] = port;
+    }
+
+    this.saveAssignments();
+    return result;
+  }
+
+  /**
+   * Release all ports for a worktree.
+   *
+   * @param repoId - Repository identifier
+   * @param worktreeId - Worktree identifier
+   */
+  releasePortsForWorktree(repoId: string, worktreeId: string): void {
+    const before = this.assignments.assignments.length;
+    this.assignments.assignments = this.assignments.assignments.filter(
+      (a) => !(a.repoId === repoId && a.worktreeId === worktreeId)
+    );
+    if (this.assignments.assignments.length !== before) {
+      this.saveAssignments();
+    }
+  }
+
+  /**
+   * Get all ports for a worktree.
+   *
+   * @param repoId - Repository identifier
+   * @param worktreeId - Worktree identifier
+   * @returns Map of variable names to port numbers, or undefined if none allocated
+   */
+  getPortsForWorktree(
+    repoId: string,
+    worktreeId: string
+  ): Record<string, number> | null {
+    const matching = this.assignments.assignments.filter(
+      (a) => a.repoId === repoId && a.worktreeId === worktreeId
+    );
+
+    if (matching.length === 0) return null;
+
+    const result: Record<string, number> = {};
+    for (const a of matching) {
+      result[a.variableName] = a.port;
+    }
+    return result;
+  }
+
+  async reconcilePortsForWorktree(
+    repoId: string,
+    worktreeId: string,
+    variableNames: string[]
+  ): Promise<Record<string, number>> {
+    const requestedVariables = new Set(normalizePortVariables(variableNames));
+    const preserved = this.assignments.assignments.filter(
+      (a) =>
+        a.repoId === repoId &&
+        a.worktreeId === worktreeId &&
+        requestedVariables.has(a.variableName)
+    );
+
+    this.assignments.assignments = this.assignments.assignments.filter(
+      (a) =>
+        a.repoId !== repoId ||
+        a.worktreeId !== worktreeId ||
+        requestedVariables.has(a.variableName)
+    );
+
+    const result: Record<string, number> = {};
+    for (const assignment of preserved) {
+      result[assignment.variableName] = assignment.port;
+    }
+
+    for (const variableName of requestedVariables) {
+      if (result[variableName] !== undefined) continue;
+      result[variableName] = await this.allocateSinglePort(
+        repoId,
+        worktreeId,
+        variableName
+      );
+    }
+
+    this.saveAssignments();
+    return result;
+  }
+
+  /**
+   * Get all port assignments (for introspection/testing).
+   */
+  getAllAssignments(): PortAssignment[] {
+    return [...this.assignments.assignments];
+  }
+
+  // ── Private Methods ─────────────────────────────────────────────────────
+
+  private loadAssignments(): PortAssignmentsFile {
+    try {
+      if (fs.existsSync(this.assignmentsPath)) {
+        const raw = fs.readFileSync(this.assignmentsPath, 'utf8');
+        const data = JSON.parse(raw) as PortAssignmentsFile;
+        if (data.version === 1 && Array.isArray(data.assignments)) {
+          return data;
+        }
+      }
+    } catch (err) {
+      this.logger?.debug(
+        'Failed to load port assignments, starting fresh',
+        err
+      );
+    }
+    return { version: 1, assignments: [] };
+  }
+
+  private saveAssignments(): void {
+    const dir = path.dirname(this.assignmentsPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(
+      this.assignmentsPath,
+      JSON.stringify(this.assignments, null, 2),
+      'utf8'
+    );
+  }
+
+  private async allocateSinglePort(
+    repoId: string,
+    worktreeId: string,
+    variableName: string
+  ): Promise<number> {
+    // Check if already allocated - trust in-memory state (OS verification only on initialize)
+    const existing = this.assignments.assignments.find(
+      (a) =>
+        a.repoId === repoId &&
+        a.worktreeId === worktreeId &&
+        a.variableName === variableName
+    );
+
+    if (existing) {
+      // Port is already assigned - return without OS re-verification
+      // OS verification happens during initialize() on startup
+      return existing.port;
+    }
+
+    // Find next available port
+    const usedPorts = new Set(this.assignments.assignments.map((a) => a.port));
+    const port = await this.findAvailablePort(usedPorts);
+
+    const assignment: PortAssignment = {
+      repoId,
+      worktreeId,
+      variableName,
+      port,
+      verifiedAt: new Date().toISOString(),
+    };
+    this.assignments.assignments.push(assignment);
+
+    return port;
+  }
+
+  private async findAvailablePort(usedPorts: Set<number>): Promise<number> {
+    // Try primary range first
+    for (let port = PORT_RANGE_START; port < PORT_RANGE_END; port++) {
+      if (!usedPorts.has(port)) {
+        const available = await this.isPortAvailable(port);
+        if (available) return port;
+      }
+    }
+
+    // Fall back to overflow range
+    for (let port = OVERFLOW_RANGE_START; port < OVERFLOW_RANGE_END; port++) {
+      if (!usedPorts.has(port)) {
+        const available = await this.isPortAvailable(port);
+        if (available) return port;
+      }
+    }
+
+    // Let get-port pick any available port outside our ranges
+    return getPort();
+  }
+
+  private async isPortAvailable(port: number): Promise<boolean> {
+    try {
+      const allocated = await getPort({ port });
+      return allocated === port;
+    } catch {
+      return false;
+    }
+  }
+
+  private async verifyAndReassignPorts(): Promise<void> {
+    const toReassign: PortAssignment[] = [];
+    const verified: PortAssignment[] = [];
+
+    for (const assignment of this.assignments.assignments) {
+      const available = await this.isPortAvailable(assignment.port);
+      if (available) {
+        assignment.verifiedAt = new Date().toISOString();
+        verified.push(assignment);
+      } else {
+        toReassign.push(assignment);
+      }
+    }
+
+    // Reassign ports that are no longer available
+    for (const assignment of toReassign) {
+      const usedPorts = new Set(verified.map((a) => a.port));
+      const newPort = await this.findAvailablePort(usedPorts);
+      assignment.port = newPort;
+      assignment.verifiedAt = new Date().toISOString();
+      verified.push(assignment);
+    }
+
+    this.assignments.assignments = verified;
+    if (toReassign.length > 0) {
+      this.saveAssignments();
+      this.logger?.debug(
+        `Reassigned ${toReassign.length} ports that were no longer available`
+      );
+    }
+  }
+}
+
+// ── .env Block Utilities ───────────────────────────────────────────────────
+
+/**
+ * Extract the relay-ide managed ports block from .env content.
+ *
+ * @param content - Full .env file content
+ * @returns Object with block content (if found) and surrounding content
+ */
+export function extractEnvBlock(content: string): {
+  block: string | null;
+  before: string;
+  after: string;
+} {
+  const startIdx = content.indexOf(ENV_BLOCK_START);
+  const endIdx = content.indexOf(ENV_BLOCK_END);
+
+  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
+    return { block: null, before: content, after: '' };
+  }
+
+  // Include the end marker in the block
+  const blockEnd = endIdx + ENV_BLOCK_END.length;
+  const block = content.slice(startIdx, blockEnd);
+  const before = content.slice(0, startIdx);
+  const after = content.slice(blockEnd);
+
+  return { block, before, after };
+}
+
+/**
+ * Upsert the relay-ide managed ports block in .env content.
+ *
+ * Preserves all content outside the marker block. Only modifies
+ * the content between the start and end markers.
+ *
+ * @param content - Full .env file content
+ * @param portMapping - Map of variable names to port values
+ * @returns Updated .env content with new block
+ */
+export function upsertEnvBlock(
+  content: string,
+  portMapping: Record<string, number>
+): string {
+  const { before, after } = extractEnvBlock(content);
+
+  // Build the new block content
+  const lines = [ENV_BLOCK_START];
+  for (const [varName, port] of Object.entries(portMapping).sort()) {
+    lines.push(`${varName}=${port}`);
+  }
+  lines.push(ENV_BLOCK_END);
+
+  const newBlock = lines.join('\n');
+
+  // Normalize whitespace around block
+  const normalizedBefore = before.trimEnd();
+  const normalizedAfter = after.trimStart();
+
+  // Assemble the new content
+  const parts: string[] = [];
+  if (normalizedBefore) {
+    parts.push(normalizedBefore);
+    parts.push(''); // Empty line before block
+  }
+  parts.push(newBlock);
+  if (normalizedAfter) {
+    parts.push(''); // Empty line after block
+    parts.push(normalizedAfter);
+  }
+
+  return parts.join('\n') + '\n';
+}
+
+/**
+ * Remove the relay-ide managed ports block from .env content.
+ *
+ * Preserves all content outside the marker block.
+ *
+ * @param content - Full .env file content
+ * @returns .env content with the managed block removed
+ */
+export function removeEnvBlock(content: string): string {
+  const { block, before, after } = extractEnvBlock(content);
+
+  if (!block) {
+    return content;
+  }
+
+  // Normalize whitespace
+  const normalizedBefore = before.trimEnd();
+  const normalizedAfter = after.trimStart();
+
+  const parts: string[] = [];
+  if (normalizedBefore) {
+    parts.push(normalizedBefore);
+  }
+  if (normalizedAfter) {
+    if (normalizedBefore) {
+      parts.push(''); // Empty line separator
+    }
+    parts.push(normalizedAfter);
+  }
+
+  const result = parts.join('\n');
+  return result ? result + '\n' : '';
+}
+
+/**
+ * Parse port variables from the relay-ide managed block.
+ *
+ * @param content - Full .env file content
+ * @returns Map of variable names to port values, or undefined if no block
+ */
+export function parseEnvBlock(content: string): Record<string, number> | null {
+  const { block } = extractEnvBlock(content);
+
+  if (!block) {
+    return null;
+  }
+
+  const result: Record<string, number> = {};
+  const lines = block.split('\n').slice(1, -1); // Remove markers
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+
+    const key = trimmed.slice(0, eqIdx).trim();
+    const value = trimmed.slice(eqIdx + 1).trim();
+
+    const port = parseInt(value, 10);
+    if (key && !isNaN(port) && port > 0) {
+      result[key] = port;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+export function upsertPortsInEnvFile(
+  worktreePath: string,
+  portMapping: Record<string, number>
+): void {
+  const envPath = path.join(worktreePath, '.env');
+  const current = fs.existsSync(envPath)
+    ? fs.readFileSync(envPath, 'utf8')
+    : '';
+  const next = upsertEnvBlock(current, portMapping);
+  fs.writeFileSync(envPath, next, 'utf8');
+}
+
+export function removePortsFromEnvFile(worktreePath: string): void {
+  const envPath = path.join(worktreePath, '.env');
+  if (!fs.existsSync(envPath)) return;
+  const current = fs.readFileSync(envPath, 'utf8');
+  const next = removeEnvBlock(current);
+  if (next.length === 0) {
+    fs.rmSync(envPath, { force: true });
+    return;
+  }
+  fs.writeFileSync(envPath, next, 'utf8');
+}
+
+// ── Standalone Verification Utility ───────────────────────────────────────
+
+/**
+ * Verify if a specific port is currently available on the system.
+ *
+ * @param port - Port number to check
+ * @returns Promise resolving to verification result
+ */
+export async function verifyPort(
+  port: number
+): Promise<PortVerificationResult> {
+  try {
+    const allocated = await getPort({ port });
+    return { port, available: allocated === port };
+  } catch {
+    return { port, available: false };
+  }
+}
+
+// ── Singleton for convenience (optional) ───────────────────────────────────
+
+let defaultAllocator: PortAllocator | null = null;
+
+/**
+ * Initialize the default port allocator.
+ *
+ * @param configPath - Path to config.json
+ * @param logger - Optional logger
+ */
+export async function initializeDefaultAllocator(
+  configPath: string,
+  logger?: PortAllocatorOptions['logger']
+): Promise<PortAllocator> {
+  defaultAllocator = new PortAllocator({ configPath, logger });
+  await defaultAllocator.initialize();
+  return defaultAllocator;
+}
+
+/**
+ * Get the default port allocator, or throw if not initialized.
+ */
+export function getDefaultAllocator(): PortAllocator {
+  if (!defaultAllocator) {
+    throw new Error(
+      'Default port allocator not initialized. Call initializeDefaultAllocator first.'
+    );
+  }
+  return defaultAllocator;
+}
+
+/**
+ * Reset the default allocator (for testing).
+ */
+export function resetDefaultAllocator(): void {
+  defaultAllocator = null;
+}

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -27,6 +27,7 @@ import type { OutputParser } from './output-parsers/index.js';
 import { installOpencodeRelayPlugin } from './opencode-relay.js';
 import { writeCodexHooksAdapter } from './codex-hooks-adapter.js';
 import { createLogger } from './logger.js';
+import { getDefaultAllocator, type PortAllocator } from './port-allocator.js';
 
 const IDLE_TIMEOUT_MS = 5000;
 const MAX_SCROLLBACK = 256 * 1024; // 256KB max
@@ -304,6 +305,10 @@ export type CreatePtyParams = {
   continuePolicy?: ContinuePolicy | undefined;
   frameworks?: Record<string, Partial<AgentFramework>> | undefined;
   claudeFullscreen?: boolean | undefined;
+  /** Environment variable names to inject with allocated ports (per-worktree) */
+  portVariables?: string[] | undefined;
+  /** Optional port allocator instance (uses default if not provided) */
+  portAllocator?: PortAllocator | undefined;
 };
 
 export type CreatePtyResult = SessionSummary & { pid: number | undefined };
@@ -386,6 +391,166 @@ function setupCodexHooks(
   }
 }
 
+type PortInjectionParams = {
+  repoPath: string;
+  worktreePath: string | null | undefined;
+  cwd: string;
+  portVariables?: string[] | undefined;
+  portAllocator?: PortAllocator | undefined;
+};
+
+/**
+ * Inject per-worktree allocated port environment variables into the PTY environment.
+ *
+ * Uses the port allocator to look up existing allocations for the worktree
+ * identified by worktreePath (or cwd if no worktree). Ports are injected as
+ * environment variables matching the configured port variable names.
+ */
+function injectPortEnvVars(
+  env: Record<string, string>,
+  params: PortInjectionParams
+): void {
+  const { repoPath, worktreePath, cwd, portVariables, portAllocator } = params;
+
+  // Skip if no port variable names configured
+  if (!portVariables || portVariables.length === 0) return;
+
+  // Get the port allocator - use provided instance or fall back to default
+  let allocator: PortAllocator;
+  try {
+    allocator = portAllocator ?? getDefaultAllocator();
+  } catch {
+    // Default allocator not initialized - skip silently
+    return;
+  }
+
+  // Derive worktree ID: use worktreePath if available, otherwise cwd
+  const worktreeId = worktreePath ?? cwd;
+  if (!worktreeId) return;
+
+  // Get existing port allocations (synchronous)
+  const portMapping = allocator.getPortsForWorktree(repoPath, worktreeId);
+  if (!portMapping) return;
+
+  // Inject allocated ports as environment variables
+  for (const [varName, port] of Object.entries(portMapping)) {
+    if (portVariables.includes(varName)) {
+      env[varName] = String(port);
+    }
+  }
+}
+
+function maybeInjectPortEnvVars(
+  env: Record<string, string>,
+  portInjectionParams?: PortInjectionParams
+): void {
+  if (!portInjectionParams) return;
+  injectPortEnvVars(env, portInjectionParams);
+}
+
+function maybeApplyYoloEnv(
+  env: Record<string, string>,
+  paramYolo: boolean | undefined,
+  framework: AgentFramework
+): void {
+  if (paramYolo && framework.yoloEnv) {
+    Object.assign(env, framework.yoloEnv);
+  }
+}
+
+function maybeSetupPluginHooks(
+  id: string,
+  effectiveEventSource: EventSourceType,
+  port: number | undefined,
+  hookToken: string,
+  hooksActive: boolean,
+  env: Record<string, string>
+): { hookToken: string; hooksActive: boolean } {
+  if (effectiveEventSource === 'plugin' && port !== undefined) {
+    return setupPluginHooks(id, port, hookToken, env);
+  }
+  return { hookToken, hooksActive };
+}
+
+function maybeSetupCodexHooks(
+  id: string,
+  framework: AgentFramework,
+  port: number | undefined,
+  hookToken: string,
+  hooksActive: boolean,
+  configDir: string | undefined,
+  env: Record<string, string>
+): { hookToken: string; hooksActive: boolean } {
+  if (framework.id === 'codex' && port !== undefined) {
+    return setupCodexHooks(
+      id,
+      port,
+      hookToken,
+      configDir ?? process.cwd(),
+      env
+    );
+  }
+  return { hookToken, hooksActive };
+}
+
+function maybeInjectClaudeHooks(
+  id: string,
+  framework: AgentFramework,
+  effectiveEventSource: EventSourceType,
+  command: string | undefined,
+  port: number | undefined,
+  hookToken: string,
+  configDir: string | undefined,
+  args: string[]
+): {
+  hookToken: string;
+  hooksActive: boolean;
+  settingsPath: string;
+  args: string[];
+} {
+  const shouldInjectHooks =
+    framework.id === 'claude' &&
+    framework.capabilities.supportsHooks &&
+    effectiveEventSource === 'hooks' &&
+    !command &&
+    port !== undefined;
+
+  if (!shouldInjectHooks) {
+    return { hookToken, hooksActive: false, settingsPath: '', args };
+  }
+
+  let nextHookToken = hookToken;
+  if (!nextHookToken) nextHookToken = crypto.randomBytes(32).toString('hex');
+  try {
+    const settingsPath = writeHooksSettingsFile(
+      id,
+      port,
+      nextHookToken,
+      configDir ?? process.cwd()
+    );
+    return {
+      hookToken: nextHookToken,
+      hooksActive: true,
+      settingsPath,
+      args: ['--settings', settingsPath, ...args],
+    };
+  } catch (err) {
+    logger.warn(`Failed to generate hooks settings for session ${id}:`, err);
+    return { hookToken: '', hooksActive: false, settingsPath: '', args };
+  }
+}
+
+function buildPortInjectionParams(
+  repoPath: string,
+  worktreePath: string | null,
+  cwd: string,
+  portVariables: string[] | undefined,
+  portAllocator: PortAllocator | undefined
+): PortInjectionParams | undefined {
+  if (!repoPath || (!portVariables && !portAllocator)) return undefined;
+  return { repoPath, worktreePath, cwd, portVariables, portAllocator };
+}
+
 function setupEnvAndHooks(
   id: string,
   framework: AgentFramework,
@@ -397,7 +562,8 @@ function setupEnvAndHooks(
   paramHookToken: string | undefined,
   paramHooksActive: boolean | undefined,
   paramClaudeFullscreen: boolean | undefined,
-  rawArgs: string[]
+  rawArgs: string[],
+  portInjectionParams?: PortInjectionParams
 ): HookSetupResult {
   const env = cleanEnv();
 
@@ -406,54 +572,51 @@ function setupEnvAndHooks(
   }
 
   let hookToken = paramHookToken ?? '';
-  let hooksActive = paramHooksActive ?? false;
-  let settingsPath = '';
   let args = rawArgs;
 
-  if (paramYolo && framework.yoloEnv) {
-    Object.assign(env, framework.yoloEnv);
-  }
+  maybeApplyYoloEnv(env, paramYolo, framework);
+  const pluginHookState = maybeSetupPluginHooks(
+    id,
+    effectiveEventSource,
+    port,
+    hookToken,
+    paramHooksActive ?? false,
+    env
+  );
+  hookToken = pluginHookState.hookToken;
 
-  if (effectiveEventSource === 'plugin' && port !== undefined) {
-    ({ hookToken, hooksActive } = setupPluginHooks(id, port, hookToken, env));
-  }
+  const codexHookState = maybeSetupCodexHooks(
+    id,
+    framework,
+    port,
+    hookToken,
+    pluginHookState.hooksActive,
+    configDir,
+    env
+  );
+  hookToken = codexHookState.hookToken;
 
-  if (framework.id === 'codex' && port !== undefined) {
-    ({ hookToken, hooksActive } = setupCodexHooks(
-      id,
-      port,
-      hookToken,
-      configDir ?? process.cwd(),
-      env
-    ));
-  }
+  const claudeHookState = maybeInjectClaudeHooks(
+    id,
+    framework,
+    effectiveEventSource,
+    command,
+    port,
+    hookToken,
+    configDir,
+    args
+  );
+  hookToken = claudeHookState.hookToken;
+  args = claudeHookState.args;
+  maybeInjectPortEnvVars(env, portInjectionParams);
 
-  const shouldInjectHooks =
-    framework.id === 'claude' &&
-    framework.capabilities.supportsHooks &&
-    effectiveEventSource === 'hooks' &&
-    !command &&
-    port !== undefined;
-
-  if (shouldInjectHooks) {
-    if (!hookToken) hookToken = crypto.randomBytes(32).toString('hex');
-    try {
-      settingsPath = writeHooksSettingsFile(
-        id,
-        port,
-        hookToken,
-        configDir ?? process.cwd()
-      );
-      args = ['--settings', settingsPath, ...args];
-      hooksActive = true;
-    } catch (err) {
-      logger.warn(`Failed to generate hooks settings for session ${id}:`, err);
-      hooksActive = false;
-      hookToken = '';
-    }
-  }
-
-  return { env, hookToken, hooksActive, settingsPath, args };
+  return {
+    env,
+    hookToken,
+    hooksActive: claudeHookState.hooksActive || codexHookState.hooksActive,
+    settingsPath: claudeHookState.settingsPath,
+    args,
+  };
 }
 
 function resolveSpawnTarget(
@@ -604,6 +767,7 @@ export function createPtySession(
     id,
     agent = 'claude',
     repoName,
+    repoPath,
     worktreePath = null,
     cwd,
     displayName,
@@ -623,6 +787,8 @@ export function createPtySession(
     hooksActive: paramHooksActive,
     frameworks,
     claudeFullscreen: paramClaudeFullscreen,
+    portVariables,
+    portAllocator,
   } = params;
 
   const createdAt = new Date().toISOString();
@@ -635,6 +801,15 @@ export function createPtySession(
     ? 'parser'
     : framework.eventSource;
 
+  // Prepare port injection params for setupEnvAndHooks
+  const portInjectionParams = buildPortInjectionParams(
+    repoPath,
+    worktreePath,
+    cwd,
+    portVariables,
+    portAllocator
+  );
+
   const hookSetup = setupEnvAndHooks(
     id,
     framework,
@@ -646,7 +821,8 @@ export function createPtySession(
     paramHookToken,
     paramHooksActive,
     paramClaudeFullscreen,
-    rawArgs
+    rawArgs,
+    portInjectionParams
   );
 
   const { env, hookToken, hooksActive, settingsPath } = hookSetup;

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -421,6 +421,7 @@ function injectPortEnvVars(
     allocator = portAllocator ?? getDefaultAllocator();
   } catch {
     // Default allocator not initialized - skip silently
+    logger.debug('Port env injection skipped: allocator not available');
     return;
   }
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -364,6 +364,9 @@ export interface WorkspaceSettings {
   webhookId?: number; // GitHub webhook ID for deletion tracking
   webhookEnabled?: boolean; // Per-workspace webhook toggle
   webhookError?: string; // 'not-admin' | 'not-found' | null
+
+  /** Environment variable names that should receive per-worktree allocated ports. */
+  portVariables?: string[];
 }
 
 export const MOUNTAIN_NAMES = [

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -17,6 +17,11 @@ import {
   writeMeta,
   readMeta,
 } from './config.js';
+import {
+  getDefaultAllocator,
+  normalizePortVariables,
+  upsertPortsInEnvFile,
+} from './port-allocator.js';
 import { findOrCreateWorktreeForBranch } from './watcher.js';
 import { trackEvent } from './analytics.js';
 import {
@@ -739,6 +744,7 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
       'defaultContinue',
       'defaultYolo',
       'launchInTmux',
+      'portVariables',
     ] as const) {
       if (wsOverrides[key] !== undefined) overridden.push(key);
     }
@@ -809,6 +815,14 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
     // Apply updates
     if (Object.keys(keysToUpdate).length > 0) {
       setRepoSettings(configPath, config, resolved, keysToUpdate);
+    }
+
+    if (keysToDelete.length > 0 || Object.keys(keysToUpdate).length > 0) {
+      try {
+        deps.onWorkspacesChanged?.();
+      } catch (err) {
+        logger.error(ERR_ON_WORKSPACES_CHANGED, err);
+      }
     }
 
     // Return the current raw repo settings
@@ -980,6 +994,15 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
           lastActivity: new Date().toISOString(),
           branchName: result.branchName,
         });
+        const portVariables = normalizePortVariables(
+          getRepoSettings(loadConfig(configPath), resolved).portVariables
+        );
+        const ports = await getDefaultAllocator().reconcilePortsForWorktree(
+          resolved,
+          result.worktreePath,
+          portVariables
+        );
+        upsertPortsInEnvFile(result.worktreePath, ports);
         if (!result.existing) {
           try {
             deps.onWorktreeCreated?.();
@@ -1059,6 +1082,13 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
       lastActivity: new Date().toISOString(),
       branchName,
     });
+
+    const ports = await getDefaultAllocator().reconcilePortsForWorktree(
+      resolved,
+      worktreePath,
+      normalizePortVariables(settings.portVariables)
+    );
+    upsertPortsInEnvFile(worktreePath, ports);
 
     try {
       deps.onWorktreeCreated?.();

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -56,6 +56,89 @@ const ERR_ON_WORKSPACES_CHANGED = 'onWorkspacesChanged failed:';
 const ERR_PATH_REQUIRED = 'path query parameter is required';
 const ERR_PATH_NOT_IN_WORKSPACES = 'path not in configured workspaces';
 
+function getAllocatorOrNull() {
+  try {
+    return getDefaultAllocator();
+  } catch {
+    return null;
+  }
+}
+
+async function reconcilePortsForWorktreeBestEffort(
+  resolvedRepoPath: string,
+  worktreePath: string,
+  portVariables: string[]
+): Promise<void> {
+  const allocator = getAllocatorOrNull();
+  if (!allocator) return;
+
+  const ports = await allocator.reconcilePortsForWorktree(
+    resolvedRepoPath,
+    worktreePath,
+    portVariables
+  );
+  upsertPortsInEnvFile(worktreePath, ports);
+}
+
+async function reconcileExistingBranchWorktreePorts(
+  resolved: string,
+  worktreePath: string,
+  configPath: string
+): Promise<void> {
+  const portVariables = normalizePortVariables(
+    getRepoSettings(loadConfig(configPath), resolved).portVariables
+  );
+  await reconcilePortsForWorktreeBestEffort(
+    resolved,
+    worktreePath,
+    portVariables
+  );
+}
+
+async function respondWithExistingBranchWorktree(
+  res: Response,
+  result: Awaited<ReturnType<typeof findOrCreateWorktreeForBranch>>,
+  resolved: string,
+  configPath: string,
+  onWorktreeCreated?: (() => void) | undefined
+): Promise<void> {
+  const meta = readMeta(configPath, result.worktreePath);
+  writeMeta(configPath, {
+    worktreePath: result.worktreePath,
+    displayName: meta?.displayName || result.dirName,
+    lastActivity: new Date().toISOString(),
+    branchName: result.branchName,
+  });
+  try {
+    await reconcileExistingBranchWorktreePorts(
+      resolved,
+      result.worktreePath,
+      configPath
+    );
+  } catch (err) {
+    logger.warn(
+      'Failed to reconcile ports or update .env for worktree; continuing without port injection:',
+      err instanceof Error ? err.message : err
+    );
+  }
+  if (!result.existing) {
+    try {
+      onWorktreeCreated?.();
+    } catch (err) {
+      logger.error(
+        'onWorktreeCreated callback failed:',
+        err instanceof Error ? err.message : err
+      );
+    }
+  }
+  res.json({
+    branchName: result.branchName,
+    mountainName: meta?.displayName || result.dirName,
+    worktreePath: result.worktreePath,
+    existing: result.existing,
+  });
+}
+
 /** Extract repo name from a git remote URL (SSH or HTTPS). */
 export function repoNameFromRemoteUrl(url: string): string | undefined {
   // Strip trailing slash before splitting so pop() gets the last real segment
@@ -987,38 +1070,13 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
         exec
       );
       if (!result.isMain) {
-        const meta = readMeta(configPath, result.worktreePath);
-        writeMeta(configPath, {
-          worktreePath: result.worktreePath,
-          displayName: meta?.displayName || result.dirName,
-          lastActivity: new Date().toISOString(),
-          branchName: result.branchName,
-        });
-        const portVariables = normalizePortVariables(
-          getRepoSettings(loadConfig(configPath), resolved).portVariables
-        );
-        const ports = await getDefaultAllocator().reconcilePortsForWorktree(
+        await respondWithExistingBranchWorktree(
+          res,
+          result,
           resolved,
-          result.worktreePath,
-          portVariables
+          configPath,
+          deps.onWorktreeCreated
         );
-        upsertPortsInEnvFile(result.worktreePath, ports);
-        if (!result.existing) {
-          try {
-            deps.onWorktreeCreated?.();
-          } catch (err) {
-            logger.error(
-              'onWorktreeCreated callback failed:',
-              err instanceof Error ? err.message : err
-            );
-          }
-        }
-        res.json({
-          branchName: result.branchName,
-          mountainName: meta?.displayName || result.dirName,
-          worktreePath: result.worktreePath,
-          existing: result.existing,
-        });
       } else {
         res.json({
           branchName: result.branchName,
@@ -1083,12 +1141,18 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
       branchName,
     });
 
-    const ports = await getDefaultAllocator().reconcilePortsForWorktree(
-      resolved,
-      worktreePath,
-      normalizePortVariables(settings.portVariables)
-    );
-    upsertPortsInEnvFile(worktreePath, ports);
+    try {
+      await reconcilePortsForWorktreeBestEffort(
+        resolved,
+        worktreePath,
+        normalizePortVariables(settings.portVariables)
+      );
+    } catch (err) {
+      logger.warn(
+        'Best-effort port reconciliation/.env update failed:',
+        err instanceof Error ? err.message : err
+      );
+    }
 
     try {
       deps.onWorktreeCreated?.();

--- a/test/port-allocator.test.ts
+++ b/test/port-allocator.test.ts
@@ -705,4 +705,31 @@ describe('Port allocator + .env block integration', () => {
     );
     expect(withoutPorts.trim()).toBe('EXISTING=true');
   });
+
+  test('removePortsFromEnvFile deletes block-only env files', () => {
+    const worktreeDir = fs.mkdtempSync(path.join(tmpDir, 'wt-'));
+    fs.writeFileSync(
+      path.join(worktreeDir, '.env'),
+      upsertEnvBlock('', { PORT: 10001 }),
+      'utf8'
+    );
+
+    removePortsFromEnvFile(worktreeDir);
+
+    expect(fs.existsSync(path.join(worktreeDir, '.env'))).toBe(false);
+  });
+
+  test('normalizePortVariables filters invalid and non-string values', () => {
+    expect(
+      normalizePortVariables([
+        ' PORT ',
+        'BAD-NAME',
+        '123BAD',
+        'API_PORT',
+      ] as unknown as string[])
+    ).toEqual(['PORT', 'API_PORT']);
+    expect(normalizePortVariables([123 as unknown as string, 'PORT'])).toEqual([
+      'PORT',
+    ]);
+  });
 });

--- a/test/port-allocator.test.ts
+++ b/test/port-allocator.test.ts
@@ -1,0 +1,708 @@
+import {
+  test,
+  beforeAll,
+  afterAll,
+  afterEach,
+  expect,
+  vi,
+  describe,
+} from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  PortAllocator,
+  initializeDefaultAllocator,
+  getDefaultAllocator,
+  resetDefaultAllocator,
+  verifyPort,
+  extractEnvBlock,
+  upsertEnvBlock,
+  removeEnvBlock,
+  parseEnvBlock,
+  normalizePortVariables,
+  upsertPortsInEnvFile,
+  removePortsFromEnvFile,
+  ENV_BLOCK_START,
+  ENV_BLOCK_END,
+  PORT_RANGE_START,
+  PORT_RANGE_END,
+  OVERFLOW_RANGE_START,
+  OVERFLOW_RANGE_END,
+} from '../server/port-allocator.js';
+
+let tmpDir!: string;
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ide-port-alloc-test-'));
+});
+
+afterEach(() => {
+  for (const entry of fs.readdirSync(tmpDir, { withFileTypes: true })) {
+    const fullPath = path.join(tmpDir, entry.name);
+    if (entry.isDirectory()) {
+      fs.rmSync(fullPath, { recursive: true, force: true });
+    } else {
+      fs.unlinkSync(fullPath);
+    }
+  }
+  resetDefaultAllocator();
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+// ── Port Allocator Tests ──────────────────────────────────────────────────
+
+describe('PortAllocator', () => {
+  test('allocates ports in primary range', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    const allocator = new PortAllocator({ configPath });
+    await allocator.initialize();
+
+    const ports = await allocator.allocatePortsForWorktree('repo-1', 'wt-1', [
+      'PORT',
+      'DEV_PORT',
+    ]);
+
+    expect(ports.PORT).toBeGreaterThanOrEqual(PORT_RANGE_START);
+    expect(ports.PORT).toBeLessThan(PORT_RANGE_END);
+    expect(ports.DEV_PORT).toBeGreaterThanOrEqual(PORT_RANGE_START);
+    expect(ports.DEV_PORT).toBeLessThan(PORT_RANGE_END);
+    expect(ports.PORT).not.toBe(ports.DEV_PORT);
+  });
+
+  test('persists assignments to port-assignments.json', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    const allocator = new PortAllocator({ configPath });
+    await allocator.initialize();
+
+    await allocator.allocatePortsForWorktree('repo-1', 'wt-1', ['PORT']);
+
+    const assignmentsPath = path.join(tmpDir, 'port-assignments.json');
+    expect(fs.existsSync(assignmentsPath)).toBe(true);
+
+    const raw = fs.readFileSync(assignmentsPath, 'utf8');
+    const data = JSON.parse(raw);
+    expect(data.version).toBe(1);
+    expect(data.assignments).toHaveLength(1);
+    expect(data.assignments[0].repoId).toBe('repo-1');
+    expect(data.assignments[0].worktreeId).toBe('wt-1');
+    expect(data.assignments[0].variableName).toBe('PORT');
+  });
+
+  test('loads existing assignments on construction', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    // Pre-create assignments file
+    const assignmentsPath = path.join(tmpDir, 'port-assignments.json');
+    const existingAssignments = {
+      version: 1,
+      assignments: [
+        {
+          repoId: 'repo-existing',
+          worktreeId: 'wt-existing',
+          variableName: 'PORT',
+          port: 10050,
+          verifiedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    };
+    fs.writeFileSync(
+      assignmentsPath,
+      JSON.stringify(existingAssignments),
+      'utf8'
+    );
+
+    const allocator = new PortAllocator({ configPath });
+    await allocator.initialize();
+
+    const ports = allocator.getPortsForWorktree('repo-existing', 'wt-existing');
+    expect(ports).toEqual({ PORT: 10050 });
+  });
+
+  test('getPortsForWorktree returns null for unknown worktree', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    const allocator = new PortAllocator({ configPath });
+    await allocator.initialize();
+
+    const ports = allocator.getPortsForWorktree('unknown-repo', 'unknown-wt');
+    expect(ports).toBeNull();
+  });
+
+  test('releasePortsForWorktree removes assignments', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    const allocator = new PortAllocator({ configPath });
+    await allocator.initialize();
+
+    await allocator.allocatePortsForWorktree('repo-1', 'wt-1', ['PORT']);
+    expect(allocator.getPortsForWorktree('repo-1', 'wt-1')).toBeDefined();
+
+    allocator.releasePortsForWorktree('repo-1', 'wt-1');
+    expect(allocator.getPortsForWorktree('repo-1', 'wt-1')).toBeNull();
+  });
+
+  test('releasePortsForWorktree does not affect other worktrees', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    const allocator = new PortAllocator({ configPath });
+    await allocator.initialize();
+
+    await allocator.allocatePortsForWorktree('repo-1', 'wt-1', ['PORT']);
+    await allocator.allocatePortsForWorktree('repo-1', 'wt-2', ['PORT']);
+
+    allocator.releasePortsForWorktree('repo-1', 'wt-1');
+
+    expect(allocator.getPortsForWorktree('repo-1', 'wt-1')).toBeNull();
+    expect(allocator.getPortsForWorktree('repo-1', 'wt-2')).toBeDefined();
+  });
+
+  test('returns same port for repeated allocation of same variable', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    const allocator = new PortAllocator({ configPath });
+    await allocator.initialize();
+
+    const ports1 = await allocator.allocatePortsForWorktree('repo-1', 'wt-1', [
+      'PORT',
+    ]);
+    const ports2 = await allocator.allocatePortsForWorktree('repo-1', 'wt-1', [
+      'PORT',
+    ]);
+
+    expect(ports1.PORT).toBe(ports2.PORT);
+  });
+
+  test('assigns different ports to different variables', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    const allocator = new PortAllocator({ configPath });
+    await allocator.initialize();
+
+    const ports = await allocator.allocatePortsForWorktree('repo-1', 'wt-1', [
+      'PORT',
+      'VITE_PORT',
+      'API_PORT',
+    ]);
+
+    const portValues = Object.values(ports);
+    const uniquePorts = new Set(portValues);
+    expect(uniquePorts.size).toBe(portValues.length);
+  });
+
+  test('assigns different ports to same variable across worktrees', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    const allocator = new PortAllocator({ configPath });
+    await allocator.initialize();
+
+    const ports1 = await allocator.allocatePortsForWorktree('repo-1', 'wt-1', [
+      'PORT',
+    ]);
+    const ports2 = await allocator.allocatePortsForWorktree('repo-1', 'wt-2', [
+      'PORT',
+    ]);
+
+    expect(ports1.PORT).not.toBe(ports2.PORT);
+  });
+
+  test('normalizePortVariables falls back to PORT and de-duplicates', () => {
+    expect(normalizePortVariables(undefined)).toEqual(['PORT']);
+    expect(normalizePortVariables([])).toEqual(['PORT']);
+    expect(normalizePortVariables([' PORT ', 'PORT', 'API_PORT'])).toEqual([
+      'PORT',
+      'API_PORT',
+    ]);
+  });
+
+  test('reconcilePortsForWorktree removes stale variables and adds new ones', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    const allocator = new PortAllocator({ configPath });
+    await allocator.initialize();
+
+    const initial = await allocator.allocatePortsForWorktree('repo-1', 'wt-1', [
+      'PORT',
+      'DEV_PORT',
+    ]);
+    const reconciled = await allocator.reconcilePortsForWorktree(
+      'repo-1',
+      'wt-1',
+      ['PORT', 'API_PORT']
+    );
+
+    expect(reconciled.PORT).toBe(initial.PORT);
+    expect(reconciled.API_PORT).toBeTypeOf('number');
+    expect(reconciled.DEV_PORT).toBeUndefined();
+  });
+});
+
+// ── Port Verification Tests ───────────────────────────────────────────────
+
+describe('PortAllocator port verification', () => {
+  test('initializes without error when no existing assignments', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    const allocator = new PortAllocator({ configPath });
+    await expect(allocator.initialize()).resolves.not.toThrow();
+  });
+
+  test('reassigns ports that are taken on startup', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    // Pre-create assignments with a port in primary range
+    const assignmentsPath = path.join(tmpDir, 'port-assignments.json');
+    const existingAssignments = {
+      version: 1,
+      assignments: [
+        {
+          repoId: 'repo-existing',
+          worktreeId: 'wt-existing',
+          variableName: 'PORT',
+          port: 10001, // Known port that might be taken
+          verifiedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    };
+    fs.writeFileSync(
+      assignmentsPath,
+      JSON.stringify(existingAssignments),
+      'utf8'
+    );
+
+    const allocator = new PortAllocator({ configPath });
+    await allocator.initialize();
+
+    const ports = allocator.getPortsForWorktree('repo-existing', 'wt-existing');
+    // Port should be in valid range (may be reassigned if 10001 was taken)
+    expect(ports?.PORT).toBeGreaterThanOrEqual(PORT_RANGE_START);
+    expect(ports?.PORT).toBeLessThan(OVERFLOW_RANGE_END);
+  });
+});
+
+// ── verifyPort standalone utility tests ───────────────────────────────────
+
+describe('verifyPort', () => {
+  test('returns available=true for free port', async () => {
+    // A high port in our range is very unlikely to be taken
+    const result = await verifyPort(10543);
+    expect(result.port).toBe(10543);
+    expect(result.available).toBe(true);
+  });
+
+  test('returns available=false for system port', async () => {
+    // Port 80 is a privileged port and typically requires root
+    const result = await verifyPort(80);
+    expect(result.port).toBe(80);
+    // On most systems this will be unavailable or will be denied
+    expect(typeof result.available).toBe('boolean');
+  });
+});
+
+// ── .env Block Utilities Tests ─────────────────────────────────────────────
+
+describe('extractEnvBlock', () => {
+  test('extracts block with markers', () => {
+    const content = `# Existing content
+SOME_VAR=value
+${ENV_BLOCK_START}
+PORT=10000
+${ENV_BLOCK_END}
+ANOTHER_VAR=foo
+`;
+
+    const result = extractEnvBlock(content);
+
+    expect(result.block).toBe(
+      `${ENV_BLOCK_START}\nPORT=10000\n${ENV_BLOCK_END}`
+    );
+    expect(result.before).toBe('# Existing content\nSOME_VAR=value\n');
+    expect(result.after.trim()).toBe('ANOTHER_VAR=foo');
+  });
+
+  test('returns null block when markers not found', () => {
+    const content = `SOME_VAR=value
+ANOTHER_VAR=foo`;
+
+    const result = extractEnvBlock(content);
+
+    expect(result.block).toBeNull();
+    expect(result.before).toBe(content);
+    expect(result.after).toBe('');
+  });
+
+  test('returns null block when only start marker found', () => {
+    const content = `SOME_VAR=value
+${ENV_BLOCK_START}
+PORT=10000`;
+
+    const result = extractEnvBlock(content);
+
+    expect(result.block).toBeNull();
+  });
+
+  test('returns null block when markers are reversed', () => {
+    const content = `${ENV_BLOCK_END}
+${ENV_BLOCK_START}
+PORT=10000`;
+
+    const result = extractEnvBlock(content);
+
+    expect(result.block).toBeNull();
+  });
+
+  test('handles empty content', () => {
+    const result = extractEnvBlock('');
+    expect(result.block).toBeNull();
+    expect(result.before).toBe('');
+    expect(result.after).toBe('');
+  });
+});
+
+describe('upsertEnvBlock', () => {
+  test('inserts block into empty content', () => {
+    const result = upsertEnvBlock('', { PORT: 10000, VITE_PORT: 10001 });
+
+    expect(result).toContain(ENV_BLOCK_START);
+    expect(result).toContain(ENV_BLOCK_END);
+    expect(result).toContain('PORT=10000');
+    expect(result).toContain('VITE_PORT=10001');
+  });
+
+  test('inserts block into content without existing block', () => {
+    const content = `# My project
+MY_VAR=value
+`;
+
+    const result = upsertEnvBlock(content, { PORT: 10050 });
+
+    expect(result).toContain('# My project');
+    expect(result).toContain('MY_VAR=value');
+    expect(result).toContain(ENV_BLOCK_START);
+    expect(result).toContain('PORT=10050');
+    expect(result).toContain(ENV_BLOCK_END);
+  });
+
+  test('replaces existing block', () => {
+    const content = `${ENV_BLOCK_START}
+PORT=10000
+${ENV_BLOCK_END}`;
+
+    const result = upsertEnvBlock(content, { PORT: 10099, API_PORT: 10100 });
+
+    expect(result).not.toContain('PORT=10000');
+    expect(result).toContain('PORT=10099');
+    expect(result).toContain('API_PORT=10100');
+  });
+
+  test('preserves content before and after block', () => {
+    const content = `# Header
+SECRET_KEY=abc123
+
+${ENV_BLOCK_START}
+PORT=10000
+${ENV_BLOCK_END}
+
+# Footer
+DEBUG=true`;
+
+    const result = upsertEnvBlock(content, { PORT: 10050 });
+
+    expect(result).toContain('# Header');
+    expect(result).toContain('SECRET_KEY=abc123');
+    expect(result).toContain('# Footer');
+    expect(result).toContain('DEBUG=true');
+  });
+
+  test('sorts variables alphabetically in block', () => {
+    const result = upsertEnvBlock('', {
+      ZEBRA_PORT: 10003,
+      ALPHA_PORT: 10001,
+      MIDDLE_PORT: 10002,
+    });
+
+    const lines = result.split('\n');
+    const blockStart = lines.findIndex((l) => l.includes(ENV_BLOCK_START));
+    const blockEnd = lines.findIndex((l) => l.includes(ENV_BLOCK_END));
+
+    // Get lines between markers
+    const varLines = lines.slice(blockStart + 1, blockEnd);
+
+    expect(varLines.length).toBe(3);
+    expect(varLines[0]).toContain('ALPHA_PORT');
+    expect(varLines[1]).toContain('MIDDLE_PORT');
+    expect(varLines[2]).toContain('ZEBRA_PORT');
+  });
+
+  test('handles multiple upsert iterations', () => {
+    let content = '';
+
+    content = upsertEnvBlock(content, { PORT: 10000 });
+    expect(content).toContain('PORT=10000');
+
+    content = upsertEnvBlock(content, { PORT: 10001, NEW_PORT: 10002 });
+    expect(content).toContain('PORT=10001');
+    expect(content).toContain('NEW_PORT=10002');
+    expect(content).not.toContain('PORT=10000');
+
+    // Should have only one block - escape special chars for regex
+    const escapedMarker = ENV_BLOCK_START.replace(/[()]/g, '\\$&');
+    const startCount = (content.match(new RegExp(escapedMarker, 'g')) || [])
+      .length;
+    expect(startCount).toBe(1);
+  });
+});
+
+describe('removeEnvBlock', () => {
+  test('removes block and preserves surrounding content', () => {
+    const content = `# Header
+MY_VAR=value
+
+${ENV_BLOCK_START}
+PORT=10000
+${ENV_BLOCK_END}
+
+# Footer
+DEBUG=true`;
+
+    const result = removeEnvBlock(content);
+
+    expect(result).not.toContain(ENV_BLOCK_START);
+    expect(result).not.toContain(ENV_BLOCK_END);
+    expect(result).not.toContain('PORT=10000');
+    expect(result).toContain('# Header');
+    expect(result).toContain('MY_VAR=value');
+    expect(result).toContain('# Footer');
+    expect(result).toContain('DEBUG=true');
+  });
+
+  test('returns empty string for block-only content', () => {
+    const content = `${ENV_BLOCK_START}
+PORT=10000
+${ENV_BLOCK_END}`;
+
+    const result = removeEnvBlock(content);
+    expect(result.trim()).toBe('');
+  });
+
+  test('returns unchanged content when no block exists', () => {
+    const content = `# My project
+MY_VAR=value`;
+
+    const result = removeEnvBlock(content);
+    expect(result).toBe(content);
+  });
+
+  test('handles empty content', () => {
+    const result = removeEnvBlock('');
+    expect(result).toBe('');
+  });
+});
+
+describe('parseEnvBlock', () => {
+  test('parses variables from block', () => {
+    const content = `${ENV_BLOCK_START}
+PORT=10000
+VITE_PORT=10001
+${ENV_BLOCK_END}`;
+
+    const result = parseEnvBlock(content);
+
+    expect(result).toEqual({
+      PORT: 10000,
+      VITE_PORT: 10001,
+    });
+  });
+
+  test('skips comments inside block', () => {
+    const content = `${ENV_BLOCK_START}
+# This is a comment
+PORT=10000
+# Another comment
+${ENV_BLOCK_END}`;
+
+    const result = parseEnvBlock(content);
+
+    expect(result).toEqual({ PORT: 10000 });
+  });
+
+  test('skips empty lines inside block', () => {
+    const content = `${ENV_BLOCK_START}
+
+PORT=10000
+
+${ENV_BLOCK_END}`;
+
+    const result = parseEnvBlock(content);
+
+    expect(result).toEqual({ PORT: 10000 });
+  });
+
+  test('returns null when no block found', () => {
+    const content = `PORT=10000
+SOME_VAR=value`;
+
+    const result = parseEnvBlock(content);
+
+    expect(result).toBeNull();
+  });
+
+  test('returns null for empty block', () => {
+    const content = `${ENV_BLOCK_START}
+${ENV_BLOCK_END}`;
+
+    const result = parseEnvBlock(content);
+
+    expect(result).toBeNull();
+  });
+
+  test('handles values with equals sign', () => {
+    const content = `${ENV_BLOCK_START}
+DATABASE_URL=postgres://user:pass@host:5432/db
+${ENV_BLOCK_END}`;
+
+    // This should parse as a string, not a number, so it's skipped
+    const result = parseEnvBlock(content);
+    expect(result).toBeNull(); // Non-numeric values are skipped
+  });
+
+  test('skips invalid port values', () => {
+    const content = `${ENV_BLOCK_START}
+PORT=abc
+ANOTHER_PORT=-1
+VALID_PORT=10000
+${ENV_BLOCK_END}`;
+
+    const result = parseEnvBlock(content);
+
+    expect(result).toEqual({ VALID_PORT: 10000 });
+  });
+});
+
+// ── Default Allocator Tests ───────────────────────────────────────────────
+
+describe('Default allocator singleton', () => {
+  test('initializeDefaultAllocator creates and initializes allocator', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    const allocator = await initializeDefaultAllocator(configPath);
+
+    expect(allocator).toBeInstanceOf(PortAllocator);
+    expect(getDefaultAllocator()).toBe(allocator);
+  });
+
+  test('getDefaultAllocator throws when not initialized', () => {
+    resetDefaultAllocator();
+
+    expect(() => getDefaultAllocator()).toThrow(
+      'Default port allocator not initialized'
+    );
+  });
+
+  test('resetDefaultAllocator clears singleton', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    await initializeDefaultAllocator(configPath);
+    expect(() => getDefaultAllocator()).not.toThrow();
+
+    resetDefaultAllocator();
+    expect(() => getDefaultAllocator()).toThrow();
+  });
+});
+
+// ─── Port Range Constants Tests ───────────────────────────────────────────
+
+describe('Port range constants', () => {
+  test('primary range is 10000-10999', () => {
+    expect(PORT_RANGE_START).toBe(10000);
+    expect(PORT_RANGE_END).toBe(11000);
+    expect(PORT_RANGE_END - PORT_RANGE_START).toBe(1000);
+  });
+
+  test('overflow range is 11000-11999', () => {
+    expect(OVERFLOW_RANGE_START).toBe(11000);
+    expect(OVERFLOW_RANGE_END).toBe(12000);
+    expect(OVERFLOW_RANGE_END - OVERFLOW_RANGE_START).toBe(1000);
+  });
+});
+
+// ─── Integration-ish Tests ────────────────────────────────────────────────
+
+describe('Port allocator + .env block integration', () => {
+  test('full workflow: allocate, upsert, parse, get, remove', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+
+    const allocator = new PortAllocator({ configPath });
+    await allocator.initialize();
+
+    // Allocate ports
+    const ports = await allocator.allocatePortsForWorktree(
+      'my-repo',
+      'feature-branch',
+      ['PORT', 'VITE_PORT']
+    );
+
+    // Create .env content
+    let envContent = upsertEnvBlock('', ports);
+    expect(envContent).toContain(`PORT=${ports.PORT}`);
+    expect(envContent).toContain(`VITE_PORT=${ports.VITE_PORT}`);
+
+    // Parse it back
+    const parsed = parseEnvBlock(envContent);
+    expect(parsed).toEqual(ports);
+
+    // Get ports from allocator
+    const storedPorts = allocator.getPortsForWorktree(
+      'my-repo',
+      'feature-branch'
+    );
+    expect(storedPorts).toEqual(ports);
+
+    // Release and remove
+    allocator.releasePortsForWorktree('my-repo', 'feature-branch');
+    envContent = removeEnvBlock(envContent);
+
+    expect(parseEnvBlock(envContent)).toBeNull();
+    expect(
+      allocator.getPortsForWorktree('my-repo', 'feature-branch')
+    ).toBeNull();
+  });
+
+  test('env file helpers write and remove managed block on disk', () => {
+    const worktreeDir = fs.mkdtempSync(path.join(tmpDir, 'wt-'));
+    fs.writeFileSync(path.join(worktreeDir, '.env'), 'EXISTING=true\n', 'utf8');
+
+    upsertPortsInEnvFile(worktreeDir, { PORT: 10001, API_PORT: 10002 });
+    const withPorts = fs.readFileSync(path.join(worktreeDir, '.env'), 'utf8');
+    expect(withPorts).toContain('EXISTING=true');
+    expect(withPorts).toContain('PORT=10001');
+    expect(withPorts).toContain('API_PORT=10002');
+
+    removePortsFromEnvFile(worktreeDir);
+    const withoutPorts = fs.readFileSync(
+      path.join(worktreeDir, '.env'),
+      'utf8'
+    );
+    expect(withoutPorts.trim()).toBe('EXISTING=true');
+  });
+});

--- a/test/workspace-editor-validation.test.ts
+++ b/test/workspace-editor-validation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest';
+import {
+  validateEnvPortVarName,
+  validateEnvPortVarNames,
+} from '../frontend/src/components/dialogs/WorkspaceEditor.js';
+
+describe('WorkspaceEditor env var validation', () => {
+  test('validateEnvPortVarName accepts valid names', () => {
+    expect(validateEnvPortVarName('PORT')).toBe('');
+    expect(validateEnvPortVarName('API_PORT')).toBe('');
+  });
+
+  test('validateEnvPortVarName rejects invalid names', () => {
+    expect(validateEnvPortVarName('')).toBe('Name cannot be empty');
+    expect(validateEnvPortVarName('port')).toContain('Must start');
+    expect(validateEnvPortVarName('123PORT')).toContain('Must start');
+    expect(validateEnvPortVarName('BAD-NAME')).toContain('Must start');
+  });
+
+  test('validateEnvPortVarNames reports invalid and duplicate entries', () => {
+    expect(
+      validateEnvPortVarNames(['PORT', 'BAD-NAME', 'PORT', 'API_PORT'])
+    ).toEqual({
+      1: 'Invalid format',
+      2: 'Duplicate',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a durable per-worktree port allocator with OS-level verification and managed `.env` block reconciliation
- inject configured port variables into PTY sessions and reconcile allocations on startup, worktree creation/deletion, and settings updates
- add workspace settings UI for editable environment port variable names and cover the allocator/env helpers with tests

## Test plan
- [x] `nvm use && npm run check`
- [x] `nvm use && npm test`
- [x] `nvm use && npm test -- --run test/analytics.test.ts test/session-analytics.test.ts test/stores/ui-store.test.ts test/stores/unread-store.test.ts`
- [x] `nvm use && npm test -- --run test/port-allocator.test.ts`

## Notes
- The earlier test failures were caused by running under Node 25 (ABI 141) while this repo is pinned to Node 24 via `.nvmrc`; rerunning under `nvm use` (Node 24 / ABI 137) fixed the native-module mismatch.

👾 Generated with [Letta Code](https://letta.com)