### PR TITLE
fix(mobile): skip WebGPU renderer on mobile to fix black terminal (#236)

### DIFF
--- a/docs/LEARNINGS.md
+++ b/docs/LEARNINGS.md
@@ -488,3 +488,39 @@ The `<dialog>` element has special browser-managed display semantics (hidden whe
 When a project uses multiple `<dialog>` elements with custom CSS, add a structural test that runs after page boot and asserts: (1) `document.querySelectorAll('dialog[open]')` is empty, and (2) no dialog content is within the visible viewport. This catches CSS cascade issues where author styles accidentally override the UA's `display: none` for non-open dialogs. The test is especially important on mobile viewports where fixed-position main containers change paint order.
 
 ---
+
+### L-20260412-gpu-feature-detection: `'gpu' in navigator` detects API availability, not rendering capability — GPU renderer selection must verify actual output
+
+- status: active
+- category: architecture
+- scope: universal
+- source: /harness:bug 2026-04-12
+- branch: nightly
+
+When using a GPU-accelerated renderer (WebGPU, WebGL) with a DOM fallback, the feature detection guard (`'gpu' in navigator`, `!!window.WebGLRenderingContext`) only confirms the browser exposes the API — not that the GPU can actually render the content. On mobile devices, the API may be present but the GPU pipeline silently produces no output due to driver limitations, incomplete implementations, or capability gaps. The try/catch around addon loading only catches synchronous errors, but GPU initialization is async (`requestAdapter()`, `requestDevice()`). Either: (1) gate GPU renderers on device class (skip on mobile entirely), (2) verify rendering after async init completes (e.g., canary write + pixel readback), or (3) use an async-aware fallback that waits for the init promise before committing. Never treat "addon loaded without throwing" as "rendering works."
+
+---
+
+### L-20260412-sync-catch-async-init: try/catch around async-initializing addons only catches constructor errors — async failures need separate handling
+
+- status: active
+- category: debugging
+- scope: universal
+- source: /harness:bug 2026-04-12
+- branch: nightly
+
+When a library addon has a synchronous `activate()` method that starts an async initialization internally (e.g., xterm.js WebGPU addon calls `_initializeWebgpu()` with `await requestAdapter()`), wrapping the `loadAddon()` call in try/catch gives a false sense of safety. The catch block fires for constructor errors and synchronous activate failures, but the actual initialization happens in a fire-and-forget async path. If the async init fails, no error propagates to the caller. Additionally, checking for a DOM element (`t.element`) after `t.open()` only proves the DOM was created, not that the renderer works. When using addons with async initialization: (1) check if the addon exposes a ready/error event, (2) add a post-init verification step, or (3) at minimum gate the addon on known-good environments rather than relying on the catch.
+
+---
+
+### L-20260412-mobile-gpu-renderer: Mobile devices should not use GPU-accelerated terminal renderers — use DOM rendering as the default
+
+- status: active
+- category: patterns
+- scope: repo
+- source: /harness:bug 2026-04-12
+- branch: nightly
+
+In relay-ide's Terminal.tsx, the WebGPU renderer addon should be skipped when `isMobileDevice` is true. Mobile GPU drivers have significantly less mature WebGPU support than desktop, and silent rendering failures (black canvas with working cursor) are indistinguishable from a broken terminal. The DOM renderer works reliably on all mobile browsers. When adding GPU-accelerated features that have a DOM fallback, always include a device-class check alongside the API feature detection: `if ('gpu' in navigator && !isMobileDevice)`.
+
+---

--- a/docs/bug-analyses/2026-04-12-mobile-terminal-black-screen-bug-analysis.md
+++ b/docs/bug-analyses/2026-04-12-mobile-terminal-black-screen-bug-analysis.md
@@ -1,0 +1,137 @@
+# Bug Analysis: Mobile terminal content invisible — black screen, cursor only
+
+> **Status**: Confirmed | **Date**: 2026-04-12
+> **Severity**: High
+> **Affected Area**: `frontend/src/components/Terminal.tsx` — WebGPU renderer initialization
+> **Issue**: [#236](https://github.com/donovan-yohan/relay-ide/issues/236)
+
+## Symptoms
+
+- Terminal area renders entirely black on Android mobile
+- Cursor is visible and positioned correctly
+- Typing input works (characters advance the cursor)
+- Status bar (`-% [idle]`) is visible at bottom
+- All terminal content/output (prompt, command history, Claude Code output) is invisible
+
+## Reproduction Steps
+
+1. Open relay-ide on an Android mobile device (Chrome 121+)
+2. Navigate to a Claude Code session
+3. Observe the terminal area — black screen with only cursor visible
+
+## Root Cause
+
+The WebGPU renderer addon (`@xterm/addon-webgpu`) is loaded on Android mobile Chrome where it either silently fails to render text or initializes with a non-functional GPU pipeline. The fallback to the DOM renderer never activates because the synchronous initialization succeeds.
+
+### Detailed Trace
+
+The renderer selection logic in `Terminal.tsx:776-799`:
+
+```typescript
+// Try WebGPU renderer first, fall back to default DOM renderer
+let webgpuAddon: WebgpuAddon | undefined;
+if ('gpu' in navigator) {
+  // ← truthy on Android Chrome 121+
+  try {
+    webgpuAddon = new WebgpuAddon();
+    t.loadAddon(webgpuAddon); // ← activate() is synchronous — succeeds
+    t.open(container); // ← creates DOM element — succeeds
+  } catch (e) {
+    // Only catches SYNCHRONOUS errors
+    webgpuAddon?.dispose();
+    webgpuAddon = undefined;
+  }
+}
+if (!t.element) {
+  // ← t.element EXISTS — DOM fallback skipped
+  t.open(container);
+}
+```
+
+The WebGPU addon's `activate()` method is synchronous, but it starts `_initializeWebgpu()` asynchronously:
+
+```javascript
+async _initializeWebgpu() {
+  let t = navigator.gpu;
+  let r = await t?.requestAdapter();   // ← async — may return null on mobile
+  if (!r) { this._onContextLoss.fire(); return; }
+  this._device = await r.requestDevice();
+  // ... canvas setup
+}
+```
+
+**Two failure modes on Android mobile:**
+
+1. **`requestAdapter()` returns null**: The `onContextLoss` handler fires, disposes the addon. But the terminal may not properly restore its DOM renderer after the WebGPU addon has already replaced the render service during `activate()`.
+
+2. **`requestAdapter()` succeeds but rendering silently fails**: WebGPU initializes "successfully" (device created, canvas set up), but the GPU pipeline does not actually paint text to the canvas. Mobile GPU drivers have known issues with WebGPU text rendering. The `onContextLoss` handler never fires because there is no explicit GPU context loss — the context exists, it just produces no visible output.
+
+**Why cursor is visible but text isn't:** In xterm.js with a GPU renderer addon, the cursor is rendered as a DOM element with CSS animation, while text content is rendered on a GPU-accelerated canvas. When the canvas fails to paint, only the text disappears.
+
+**Why status bar is visible:** The status bar is a React component outside of xterm.js, unaffected by the terminal renderer.
+
+**Why input works:** The data flow (keyboard → `sendPtyData()`) is independent of rendering.
+
+## Evidence
+
+- **Commit `ae620c5`** (2026-04-09): Introduced WebGPU renderer addon — 2 days before bug report
+- **`Terminal.tsx:778`**: Guard `'gpu' in navigator` — truthy on Android Chrome 121+ (released Jan 2024)
+- **`Terminal.tsx:776-792`**: try/catch only catches synchronous errors; async `_initializeWebgpu()` failures are uncaught
+- **`Terminal.tsx:790-792`**: DOM fallback checks `!t.element` which is always truthy after `t.open(container)` on line 782
+- **WebGPU addon source**: `activate()` sync, `_initializeWebgpu()` async with `await requestAdapter()`
+- **No `@xterm/addon-webgpu` in package.json**: Bundled inside custom xterm fork, resolved via Vite alias at `frontend/vite.config.ts:12-14`
+
+## Impact Assessment
+
+- **All mobile users on Android Chrome** are affected — terminal is completely unusable
+- Desktop users unaffected (WebGPU likely works correctly with desktop GPU drivers)
+- iOS Safari unaffected (`navigator.gpu` does not exist, guard short-circuits)
+- Severity is high: terminal is the core interaction surface of relay-ide
+
+## Recommended Fix Direction
+
+**Immediate fix**: Skip WebGPU on mobile devices entirely:
+
+```typescript
+if ('gpu' in navigator && !isMobileDevice) {
+```
+
+Mobile devices should use the default DOM renderer which works reliably.
+
+**Robust fix**: Add async error handling for WebGPU initialization — even on desktop, the async init can fail. Options:
+
+1. Wrap the addon activation in a timeout that verifies text actually rendered after N ms
+2. Use a "canary write" — write a known string, read it back from the buffer, verify the canvas painted it
+3. Listen for the addon's internal ready event before committing to the WebGPU renderer
+
+## Architecture Review
+
+### Systemic Spread
+
+None — isolated to this call site. The WebGPU addon is loaded in exactly one place (`Terminal.tsx:776-799`). No other components attempt GPU-accelerated rendering.
+
+### Design Gap
+
+**The `'gpu' in navigator` feature detection is too coarse for renderer selection.** The presence of `navigator.gpu` indicates the browser _exposes_ the WebGPU API, not that the GPU can reliably render a terminal text atlas. Feature detection for GPU rendering should verify actual rendering capability, not just API availability. The current pattern — sync try/catch around async initialization with a "check element exists" fallback — structurally cannot catch async or silent rendering failures.
+
+A better design would be:
+
+1. **Device-class gating**: Skip GPU renderers on mobile entirely (mobile GPUs are a different capability tier)
+2. **Verified initialization**: After loading the addon, verify that a test frame actually painted visible content before committing to the renderer
+3. **Async-aware fallback**: The fallback decision must happen after the async initialization completes, not based on synchronous state
+
+### Testing Gaps
+
+- **Missing test cases**: No test verifies renderer fallback behavior. A test that mocks `navigator.gpu` as present but `requestAdapter()` returning null would catch failure mode 1. A test that verifies terminal content is visible after initialization would catch failure mode 2.
+- **Infrastructure gaps**: No e2e tests run on mobile viewports or with mobile user agents. The existing `test/e2e/components/Terminal.spec.ts` does not test renderer selection. There are zero tests for the WebGPU addon integration despite it being a new feature added 2 days prior.
+
+### Harness Context Gaps
+
+- **ARCHITECTURE.md** mentions "xterm.js renders output in browser" (line 114) but says nothing about the WebGPU renderer, the fallback chain, or mobile rendering behavior
+- **FRONTEND.md** does not mention the WebGPU addon, Vite alias for `@xterm/addon-webgpu`, or the custom xterm fork
+- **CLAUDE.md** does not mention the custom xterm.js fork or its implications for terminal rendering
+- No documentation captures the renderer selection strategy or its mobile limitations
+
+## Harness Trace
+
+Insufficient run history — harness trace unavailable. The `.harness/` runtime directory does not exist in this repository.

--- a/docs/bug-analyses/index.md
+++ b/docs/bug-analyses/index.md
@@ -4,3 +4,4 @@
 - [2026-04-03-unstyled-pr-list-buttons-bug-analysis](2026-04-03-unstyled-pr-list-buttons-bug-analysis.md) — Preset delete and retry buttons in All Workspaces PR list using raw HTML instead of TuiButton (DYS-11, 2026-04-03)
 - [2026-04-04-mobile-add-repo-modal-always-open-bug-analysis](2026-04-04-mobile-add-repo-modal-always-open-bug-analysis.md) — DialogShell display:flex overrides UA dialog:not([open]) hidden state, rendering all dialogs on mobile (2026-04-04)
 - [2026-04-04-delete-worktree-modal-stuck-bug-analysis](2026-04-04-delete-worktree-modal-stuck-bug-analysis.md) — Delete Worktree modal stays open after successful deletion due to missing state reset and race condition (DYS-59, 2026-04-04)
+- [2026-04-12-mobile-terminal-black-screen-bug-analysis](2026-04-12-mobile-terminal-black-screen-bug-analysis.md) — WebGPU renderer silently fails on Android mobile, producing black terminal with visible cursor (#236, 2026-04-12)

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -775,7 +775,7 @@ function useTerminalSetup(
     registerFileLinkProvider(t, onFilePathClick);
     // Try WebGPU renderer first, fall back to default DOM renderer
     let webgpuAddon: WebgpuAddon | undefined;
-    if ('gpu' in navigator) {
+    if ('gpu' in navigator && !isMobileDevice) {
       try {
         webgpuAddon = new WebgpuAddon();
         t.loadAddon(webgpuAddon);

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -17,7 +17,11 @@ import { uploadImage } from '../lib/api.js';
 import { useUiStore, DEFAULT_TERMINAL_FONT_SIZE } from '../lib/stores/ui.js';
 import { useConfigStore } from '../lib/stores/config.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
-import { clampFontSize, zoomPercentage } from '../lib/terminal-zoom.js';
+import {
+  clampFontSize,
+  zoomPercentage,
+  shouldUseWebGpuRenderer,
+} from '../lib/terminal-zoom.js';
 import './Terminal.css';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -775,7 +779,7 @@ function useTerminalSetup(
     registerFileLinkProvider(t, onFilePathClick);
     // Try WebGPU renderer first, fall back to default DOM renderer
     let webgpuAddon: WebgpuAddon | undefined;
-    if ('gpu' in navigator && !isMobileDevice) {
+    if (shouldUseWebGpuRenderer('gpu' in navigator, isMobileDevice)) {
       try {
         webgpuAddon = new WebgpuAddon();
         t.loadAddon(webgpuAddon);

--- a/frontend/src/lib/terminal-zoom.ts
+++ b/frontend/src/lib/terminal-zoom.ts
@@ -16,6 +16,14 @@ export function zoomPercentage(fontSize: number): number {
   return Math.round((fontSize / DEFAULT_TERMINAL_FONT_SIZE) * 100);
 }
 
+/** Decide whether to attempt the WebGPU renderer. */
+export function shouldUseWebGpuRenderer(
+  hasGpu: boolean,
+  isMobile: boolean
+): boolean {
+  return hasGpu && !isMobile;
+}
+
 export function scaledTerminalDimensions(
   windowWidth: number,
   windowHeight: number,

--- a/test/webgpu-renderer-guard.test.ts
+++ b/test/webgpu-renderer-guard.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { shouldUseWebGpuRenderer } from '../frontend/src/lib/terminal-zoom.js';
+
+describe('shouldUseWebGpuRenderer', () => {
+  it('returns true when GPU is available and not mobile', () => {
+    expect(shouldUseWebGpuRenderer(true, false)).toBe(true);
+  });
+
+  it('returns false when GPU is available but on mobile', () => {
+    expect(shouldUseWebGpuRenderer(true, true)).toBe(false);
+  });
+
+  it('returns false when GPU is not available on desktop', () => {
+    expect(shouldUseWebGpuRenderer(false, false)).toBe(false);
+  });
+
+  it('returns false when GPU is not available on mobile', () => {
+    expect(shouldUseWebGpuRenderer(false, true)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Skip WebGPU renderer on mobile devices (`!isMobileDevice` guard) to fix #236
- On Android Chrome 121+, `navigator.gpu` exists so the WebGPU addon loads, but the GPU canvas silently fails to render text — producing a black screen with only the cursor visible
- Mobile now uses the reliable DOM renderer; desktop continues to use WebGPU

## Root Cause

The WebGPU addon's `activate()` is synchronous but starts `_initializeWebgpu()` asynchronously (`await requestAdapter()`). The try/catch only catches sync errors, and the `!t.element` fallback never triggers because `t.open()` already created the DOM. On mobile, the GPU pipeline either returns no adapter or initializes but silently fails to paint text.

See `docs/bug-analyses/2026-04-12-mobile-terminal-black-screen-bug-analysis.md` for full investigation.

## Test plan

- [ ] Open relay-ide on Android mobile Chrome — terminal should render text (was black screen)
- [ ] Open relay-ide on desktop Chrome — terminal should still use WebGPU renderer (no regression)
- [ ] Open relay-ide on iOS Safari — terminal should work as before (navigator.gpu absent, guard short-circuits)
- [ ] Verify cursor, input, and status bar all work on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)