### PR TITLE
fix: race condition in refreshAll overwriting sidebarItems updates (#135)

### DIFF
--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -275,7 +275,6 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
       activeSessionId,
       notificationSessions,
       workspaceLastSession,
-      sidebarItems,
     } = state;
 
     if (sResult.status === 'fulfilled') sessions = sResult.value;
@@ -325,12 +324,11 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
     // Read sidebarItems from current state to avoid race conditions with
     // handleUserViewed / handleBackendStateChanged that may have updated
     // them while we were awaiting the fetch.
-    const currentSidebarItems = get().sidebarItems;
-    sidebarItems = buildSidebarItems(
+    const sidebarItems = buildSidebarItems(
       sessions,
       worktrees,
       repos,
-      currentSidebarItems,
+      get().sidebarItems,
       isUnread
     );
 

--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -322,11 +322,15 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
     if (wsPruned) persistWorkspaceSessions(workspaceLastSession);
 
     const { isUnread } = useUnreadStore.getState();
+    // Read sidebarItems from current state to avoid race conditions with
+    // handleUserViewed / handleBackendStateChanged that may have updated
+    // them while we were awaiting the fetch.
+    const currentSidebarItems = get().sidebarItems;
     sidebarItems = buildSidebarItems(
       sessions,
       worktrees,
       repos,
-      sidebarItems,
+      currentSidebarItems,
       isUnread
     );
 


### PR DESCRIPTION
Fixes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition in sidebar item updates that occurred when multiple sidebar updates happened concurrently. The sidebar now correctly retrieves and uses the latest state when rebuilding items, ensuring more reliable and consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->