### PR TITLE
fix: explicitly set active session and add error handling when resuming inactive worktrees (#120)

### DIFF
--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -756,6 +756,10 @@ export function useSessionHandlers({
       });
       if (session?.id) {
         useUiStore.getState().setActiveRepoPath(wt.repoPath);
+        useSessionsStore.getState().setActiveSessionId(session.id);
+        useSessionsStore
+          .getState()
+          .rememberSessionForWorkspace(wt.repoPath, session.id);
         if (!(error instanceof ConflictError)) {
           useSessionsStore
             .getState()
@@ -775,6 +779,13 @@ export function useSessionHandlers({
               : 'failed to resume worktree session'
           );
       }
+    } catch (e) {
+      logger.error('Failed to resume worktree:', e);
+      useToastStore
+        .getState()
+        .showToast(
+          e instanceof Error ? e.message : 'failed to resume worktree session'
+        );
     } finally {
       useSessionsStore.getState().clearLoading(loadingKey);
     }


### PR DESCRIPTION
Fixes #120