### PR TITLE
docs: prune cleanup — fix module counts, add REVIEW_GUIDANCE to map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,13 +26,14 @@ Always read `DESIGN.md` before making any visual or UI decisions. All font choic
 | Design        | `docs/DESIGN.md`       | Backend patterns, auth flow, PTY management, session types             |
 | Frontend      | `docs/FRONTEND.md`     | React 19 components, state management (Zustand + TanStack Query)       |
 | Quality       | `docs/QUALITY.md`      | Test runner, test files, isolation patterns                            |
+| Review        | `docs/REVIEW_GUIDANCE.md` | Review agent config, question bank, escape log                      |
 | References    | `docs/references/`     | Deployment guide, review agent setup                                   |
 | Learnings     | `docs/LEARNINGS.md`    | Persistent cross-session learnings (architecture, debugging, patterns) |
 | Work Tracking | GitHub Issues          | Bugs, features, spikes, epics — use `/ticket` skill or `gh issue`      |
 
 ## Key Patterns
 
-- Fifty-six server modules under `server/` (including `adapters/`, `output-parsers/`, `protocol-adapters/` subdirs), each owning one concern — update ADRs when adding modules
+- 58 server modules under `server/` (including `adapters/`, `output-parsers/`, `protocol-adapters/` subdirs), each owning one concern — update ADRs when adding modules
 - `node-pty` requires native compilation; `postinstall` script fixes prebuilt binaries on macOS
 - `CLAUDECODE` env var must be stripped from PTY env to allow nesting Claude sessions
 - Scrollback buffer capped at 256KB per session; oldest chunks trimmed first (FIFO)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ The system has two compilation targets: a TypeScript + ESM backend (Express + no
 
 ### `server/`
 
-Forty TypeScript modules (plus `adapters/`, `output-parsers/`, and `protocol-adapters/` subdirectories) compiled to `dist/server/` via `tsc`. Modules communicate via ESM `import` statements.
+58 TypeScript modules (including `adapters/`, `output-parsers/`, and `protocol-adapters/` subdirectories) compiled to `dist/server/` via `tsc`. Modules communicate via ESM `import` statements.
 
 | Module                                  | Role                                                                                                                                                                                                                                                               |
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -71,7 +71,7 @@ Compiled by both `tsconfig.json` (server build) and `frontend/tsconfig.json` (Vi
 | `chat-events.ts`           | `ChatEvent` discriminated union and type guards — the wire protocol for web-chat transcripts                                                         |
 | `mobile-input-pipeline.ts` | Pure-function event-intent pipeline for mobile virtual keyboard input — consumed by the React `MobileInput` component; unit-tested via JSON fixtures |
 
-**Architecture Invariant:** `index.ts` is the composition root and MUST NOT be imported by other modules. Cross-module dependencies flow downward: `index.ts` imports all others; `ws.ts` may import `sessions`; `sessions.ts` imports `pty-handler`; `workspaces.ts` imports `git` and `config`; `hooks.ts` receives `sessions`, `git`, `config`, `analytics`, `telemetry`, and `push` via a `HookDeps` injection seam (composition root wires them; `hooks.ts` does statically import those modules to type the deps but does not invoke them directly from module scope); all other modules are self-contained. **Exception:** `analytics.ts`, `push.ts`, and `logger.ts` are pure output dependencies (fire-and-forget) imported by multiple modules — this is acceptable because they have no effect on callers' control flow. Each module owns a single concern and confines its npm dependencies (e.g., only `auth.ts` depends on crypto.scrypt, only `pty-handler.ts` depends on node-pty, only `analytics.ts` depends on better-sqlite3, only `push.ts` depends on web-push). The `output-parsers/` module confines all output-parsing logic and may depend on `types.ts` only — it MUST NOT import from `utils.ts` or any other server module. There are currently forty server modules (plus three subdirectories).
+**Architecture Invariant:** `index.ts` is the composition root and MUST NOT be imported by other modules. Cross-module dependencies flow downward: `index.ts` imports all others; `ws.ts` may import `sessions`; `sessions.ts` imports `pty-handler`; `workspaces.ts` imports `git` and `config`; `hooks.ts` receives `sessions`, `git`, `config`, `analytics`, `telemetry`, and `push` via a `HookDeps` injection seam (composition root wires them; `hooks.ts` does statically import those modules to type the deps but does not invoke them directly from module scope); all other modules are self-contained. **Exception:** `analytics.ts`, `push.ts`, and `logger.ts` are pure output dependencies (fire-and-forget) imported by multiple modules — this is acceptable because they have no effect on callers' control flow. Each module owns a single concern and confines its npm dependencies (e.g., only `auth.ts` depends on crypto.scrypt, only `pty-handler.ts` depends on node-pty, only `analytics.ts` depends on better-sqlite3, only `push.ts` depends on web-push). The `output-parsers/` module confines all output-parsing logic and may depend on `types.ts` only — it MUST NOT import from `utils.ts` or any other server module. There are currently 58 server modules, including modules in the `adapters/`, `output-parsers/`, and `protocol-adapters/` subdirectories.
 
 ### `frontend/`
 
@@ -203,7 +203,7 @@ Both channels require authentication via `token` cookie verified during HTTP upg
 
 | ADR     | Topic                                                                          |
 | ------- | ------------------------------------------------------------------------------ |
-| ADR-001 | Modular server architecture (forty modules, composition root, dependency flow) |
+| ADR-001 | Modular server architecture (58 modules, composition root, dependency flow) |
 | ADR-003 | PTY session management (in-memory state, scrollback, CLAUDECODE stripping)     |
 | ADR-004 | PIN authentication (scrypt, cookie tokens, rate limiting)                      |
 | ADR-005 | Vitest as unit/integration test runner (migrated from node:test 2026-04-03)    |

--- a/docs/REVIEW_GUIDANCE.md
+++ b/docs/REVIEW_GUIDANCE.md
@@ -22,7 +22,7 @@ See `docs/references/review-agent-setup.md` for full config field reference.
 
 ### Architecture
 
-- Does this change respect the one-concern-per-module boundary? (27 server modules, each owning a single concern)
+- Does this change respect the one-concern-per-module boundary? (58 server modules, each owning a single concern)
 - If a new server module is added, is the module count updated in `ARCHITECTURE.md` and the ADRs?
 - Does cross-module dependency flow downward? (`index.ts` is the composition root — no other module may import it)
 - Does this maintain TypeScript + ESM conventions (`.js` extensions on relative imports, `node:` prefix on builtins)?
@@ -48,8 +48,8 @@ See `docs/references/review-agent-setup.md` for full config field reference.
 
 - Are new server modules accompanied by test files in `test/`?
 - Do mobile input changes include fixture-based tests in `test/fixtures/mobile-input/`?
-- Does `npm test` pass cleanly? (runs `tsc` + `node --test`)
-- Does `npm run build` succeed? (`node-pty` requires native compilation — `postinstall` script handles macOS prebuilt binaries)
+- Does `npm test` pass cleanly? (runs `vitest run` — `node-pty` is a native addon and may compile if no compatible prebuild is available; `postinstall` fixes macOS ARM64 `spawn-helper` permissions)
+- Does `npm run build` succeed? (`node-pty` is a native addon and may compile if no compatible prebuild is available; `postinstall` fixes macOS ARM64 `spawn-helper` permissions)
 
 ## Escape Log
 


### PR DESCRIPTION
Fixes documentation drift identified in harness prune report (2026-04-23).

## Changes
- CLAUDE.md: fix server module count (56 → 58) and add REVIEW_GUIDANCE.md to Documentation Map
- ARCHITECTURE.md: fix module count references (forty → 58) in 3 places
- REVIEW_GUIDANCE.md: fix module count (27 → 58) and update test runner reference (node --test → vitest run)

## No-op items (resolved by prior rebase)
- docs/exec-plans/ directory and PLANS.md no longer exist on nightly; archive/reconcile/triage items already resolved
- docs/design-docs/ directory no longer exists; orphan design doc item already resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system documentation to reflect current codebase state
  * Revised review guidance and test execution procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->