### PR TITLE
feat: add workspace utility rail

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -48,6 +48,7 @@ React 19 SPA for Relay IDE. Built with TypeScript, Zustand, TanStack Query, and 
 | `TuiButton.tsx`                      | TUI-styled button with box-drawing corner characters                                                                                                                 |
 | `TuiCheckbox.tsx`                    | Terminal-style `[x]`/`[ ]` checkbox component                                                                                                                        |
 | `TuiInput.tsx`                       | Terminal-style input with block cursor                                                                                                                               |
+| `Tooltip.tsx`                        | Design-system hover/focus tooltip for controls; can resolve labels/descriptions/shortcuts from command registry action IDs                                           |
 | `MarqueeText.tsx`                    | Horizontal scroll-on-hover for overflow text (Spotify-style)                                                                                                         |
 | `CipherText.tsx`                     | Cipher-decode loading/transition animation                                                                                                                           |
 | `Hint.tsx`                           | Progressive disclosure onboarding hint component                                                                                                                     |

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -11,50 +11,55 @@ React 19 SPA for Relay IDE. Built with TypeScript, Zustand, TanStack Query, and 
 
 ## Component Map
 
-| Component                            | Role                                                                                                                                                            |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `App.tsx`                            | Root layout: left sidebar + SplitPaneLayout (terminal / FileViewerPane / FileTreeSidebar) for session view; dashboard / PR top bar + tabs for non-session views |
-| `Sidebar.tsx`                        | Flat workspace list with command palette search                                                                                                                 |
-| `RepoItem.tsx`                       | Repo tree item: sessions, inactive worktrees, context menus, workspace group membership                                                                         |
-| `CommandPalette.tsx`                 | Terminal-style command palette with action registry                                                                                                             |
-| `PrTopBar.tsx`                       | Dynamic PR/CI bar with branch switcher, target branch switcher, diff stats, merge conflict detection, action buttons                                            |
-| `SessionTabBar.tsx`                  | Multi-tab session management per worktree (role=tablist)                                                                                                        |
-| `RepoDashboard.tsx`                  | Workspace dashboard: PRs with merge status, activity feed, CTAs                                                                                                 |
-| `BranchSwitcher.tsx`                 | Worktree-aware branch dropdown: filter, create new branch, jump-to-session links, agent-running guard                                                           |
-| `TargetBranchSwitcher.tsx`           | PR base branch dropdown: remote-only branches, changes base via `gh pr edit`                                                                                    |
-| `FileBrowser.tsx`                    | Lazy-loading tree-view filesystem browser with multi-select, filter, keyboard nav                                                                               |
-| `Terminal.tsx`                       | xterm.js terminal wrapper with WebSocket connection, escape sequence sanitization                                                                               |
-| `Toolbar.tsx`                        | Mobile touch toolbar for terminal interaction                                                                                                                   |
-| `MobileInput.tsx`                    | Event-intent mobile keyboard input handler                                                                                                                      |
-| `ContextMenu.tsx`                    | Universal "..." dropdown menu for session/item actions                                                                                                          |
-| `PinGate.tsx`                        | PIN authentication screen with PinInput component                                                                                                               |
-| `SessionIndicator.tsx`               | Unicode shape-based session state indicator (shapes + colors + pulse animations)                                                                                |
-| `SessionStatusBar.tsx`               | Multi-framework telemetry status bar (model, context %, tokens)                                                                                                 |
-| `AgentBadge.tsx`                     | Agent type indicator badge (Claude/Codex/OpenCode)                                                                                                              |
-| `FileTreeSidebar.tsx`                | Right sidebar: changes tab (git diff tree), all files tab (lazy filesystem browser)                                                                             |
-| `FileViewerPane.tsx`                 | File viewer pane: tab bar, DiffViewer for changed files, CodeBlock for raw files                                                                                |
-| `SplitPaneLayout.tsx`                | Resizable 3-pane layout (terminal / file viewer / right sidebar) with draggable resize handles                                                                  |
-| `DiffViewer.tsx`                     | Unified diff renderer with diff2html parsing and Shiki syntax highlighting                                                                                      |
-| `CodeBlock.tsx`                      | Shared Shiki syntax highlighting wrapper component                                                                                                              |
-| `OrgDashboard.tsx`                   | Cross-repo PR list and tickets panel with tab navigation                                                                                                        |
-| `TicketsPanel.tsx`                   | Multi-provider ticket list: GitHub Issues, Jira, Linear tabs                                                                                                    |
-| `TicketCard.tsx`                     | Individual ticket row: status dot, provider metadata, branch link, Start Work button                                                                            |
-| `StartWorkModal.tsx`                 | Start Work modal: ticket info, workspace selector, branch name input                                                                                            |
-| `TuiButton.tsx`                      | TUI-styled button with box-drawing corner characters                                                                                                            |
-| `TuiCheckbox.tsx`                    | Terminal-style `[x]`/`[ ]` checkbox component                                                                                                                   |
-| `TuiInput.tsx`                       | Terminal-style input with block cursor                                                                                                                          |
-| `MarqueeText.tsx`                    | Horizontal scroll-on-hover for overflow text (Spotify-style)                                                                                                    |
-| `CipherText.tsx`                     | Cipher-decode loading/transition animation                                                                                                                      |
-| `Hint.tsx`                           | Progressive disclosure onboarding hint component                                                                                                                |
-| `WorkspaceGroup.tsx`                 | Workspace container with color-coded border grouping                                                                                                            |
-| **Dialogs**                          |                                                                                                                                                                 |
-| `dialogs/DialogShell.tsx`            | Shared dialog wrapper (fullscreen/compact, terminal aesthetic, popover-based stacking)                                                                          |
-| `dialogs/SettingsDialog.tsx`         | Full settings dialog with TOC, sections, integrations                                                                                                           |
-| `dialogs/CustomizeSessionDialog.tsx` | Session creation/customization with agent selection, args, workspace                                                                                            |
-| `dialogs/AddWorkspaceDialog.tsx`     | Workspace path browser and add flow                                                                                                                             |
-| `dialogs/DeleteWorktreeDialog.tsx`   | Worktree deletion with dirty-check confirmation                                                                                                                 |
-| `dialogs/RenameWarningModal.tsx`     | Rename + PR warning: push, ignore, or undo                                                                                                                      |
-| `dialogs/WorkspaceEditor.tsx`        | Workspace entity editor: name, repo assignment, theme color                                                                                                     |
+| Component                            | Role                                                                                                                                                                 |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `App.tsx`                            | Root layout: left sidebar + SplitPaneLayout (terminal / FileViewerPane / WorkspaceUtilityRail) for session view; dashboard / PR top bar + tabs for non-session views |
+| `Sidebar.tsx`                        | Flat workspace list with command palette search                                                                                                                      |
+| `RepoItem.tsx`                       | Repo tree item: sessions, inactive worktrees, context menus, workspace group membership                                                                              |
+| `CommandPalette.tsx`                 | Terminal-style command palette with action registry                                                                                                                  |
+| `PrTopBar.tsx`                       | Dynamic PR/CI bar with branch switcher, target branch switcher, diff stats, merge conflict detection, action buttons                                                 |
+| `SessionTabBar.tsx`                  | Multi-tab session management per worktree (role=tablist)                                                                                                             |
+| `RepoDashboard.tsx`                  | Workspace dashboard: PRs with merge status, activity feed, CTAs                                                                                                      |
+| `BranchSwitcher.tsx`                 | Worktree-aware branch dropdown: filter, create new branch, jump-to-session links, agent-running guard                                                                |
+| `TargetBranchSwitcher.tsx`           | PR base branch dropdown: remote-only branches, changes base via `gh pr edit`                                                                                         |
+| `FileBrowser.tsx`                    | Lazy-loading tree-view filesystem browser with multi-select, filter, keyboard nav                                                                                    |
+| `Terminal.tsx`                       | xterm.js terminal wrapper with WebSocket connection, escape sequence sanitization                                                                                    |
+| `Toolbar.tsx`                        | Mobile touch toolbar for terminal interaction                                                                                                                        |
+| `MobileInput.tsx`                    | Event-intent mobile keyboard input handler                                                                                                                           |
+| `ContextMenu.tsx`                    | Universal "..." dropdown menu for session/item actions                                                                                                               |
+| `PinGate.tsx`                        | PIN authentication screen with PinInput component                                                                                                                    |
+| `SessionIndicator.tsx`               | Unicode shape-based session state indicator (shapes + colors + pulse animations)                                                                                     |
+| `SessionStatusBar.tsx`               | Multi-framework telemetry status bar (model, context %, tokens)                                                                                                      |
+| `AgentBadge.tsx`                     | Agent type indicator badge (Claude/Codex/OpenCode)                                                                                                                   |
+| `WorkspaceUtilityRail.tsx`           | Right utility rail: fixed icon strip, selected utility pane host, visible/hidden shell model                                                                         |
+| `UtilityRailFilesPanel.tsx`          | Files utility pane wrapper around changed files and lazy filesystem browsing                                                                                         |
+| `UtilityRailReviewPanel.tsx`         | Review utility pane: changed-file list, diff source controls, and embedded DiffViewer                                                                                |
+| `UtilityRailLogsPanel.tsx`           | Logs utility pane shell for current session/activity output                                                                                                          |
+| `UtilityRailStatsPanel.tsx`          | Stats utility pane using telemetry summaries for active session and workspace                                                                                        |
+| `FileTreeSidebar.tsx`                | Reusable files panel implementation: changes tab (git diff tree), all files tab (lazy filesystem browser)                                                            |
+| `FileViewerPane.tsx`                 | File viewer pane: tab bar, DiffViewer for changed files, CodeBlock for raw files                                                                                     |
+| `SplitPaneLayout.tsx`                | Resizable 3-pane layout (terminal / file viewer / utility rail) with draggable resize handles                                                                        |
+| `DiffViewer.tsx`                     | Unified diff renderer with diff2html parsing and Shiki syntax highlighting                                                                                           |
+| `CodeBlock.tsx`                      | Shared Shiki syntax highlighting wrapper component                                                                                                                   |
+| `OrgDashboard.tsx`                   | Cross-repo PR list and tickets panel with tab navigation                                                                                                             |
+| `TicketsPanel.tsx`                   | Multi-provider ticket list: GitHub Issues, Jira, Linear tabs                                                                                                         |
+| `TicketCard.tsx`                     | Individual ticket row: status dot, provider metadata, branch link, Start Work button                                                                                 |
+| `StartWorkModal.tsx`                 | Start Work modal: ticket info, workspace selector, branch name input                                                                                                 |
+| `TuiButton.tsx`                      | TUI-styled button with box-drawing corner characters                                                                                                                 |
+| `TuiCheckbox.tsx`                    | Terminal-style `[x]`/`[ ]` checkbox component                                                                                                                        |
+| `TuiInput.tsx`                       | Terminal-style input with block cursor                                                                                                                               |
+| `MarqueeText.tsx`                    | Horizontal scroll-on-hover for overflow text (Spotify-style)                                                                                                         |
+| `CipherText.tsx`                     | Cipher-decode loading/transition animation                                                                                                                           |
+| `Hint.tsx`                           | Progressive disclosure onboarding hint component                                                                                                                     |
+| `WorkspaceGroup.tsx`                 | Workspace container with color-coded border grouping                                                                                                                 |
+| **Dialogs**                          |                                                                                                                                                                      |
+| `dialogs/DialogShell.tsx`            | Shared dialog wrapper (fullscreen/compact, terminal aesthetic, popover-based stacking)                                                                               |
+| `dialogs/SettingsDialog.tsx`         | Full settings dialog with TOC, sections, integrations                                                                                                                |
+| `dialogs/CustomizeSessionDialog.tsx` | Session creation/customization with agent selection, args, workspace                                                                                                 |
+| `dialogs/AddWorkspaceDialog.tsx`     | Workspace path browser and add flow                                                                                                                                  |
+| `dialogs/DeleteWorktreeDialog.tsx`   | Worktree deletion with dirty-check confirmation                                                                                                                      |
+| `dialogs/RenameWarningModal.tsx`     | Rename + PR warning: push, ignore, or undo                                                                                                                           |
+| `dialogs/WorkspaceEditor.tsx`        | Workspace entity editor: name, repo assignment, theme color                                                                                                          |
 
 ## State Management
 
@@ -129,7 +134,7 @@ Typed action registry for the command palette. Actions are pure metadata (`Actio
 - Settings dialog close triggers `refreshAll()` for immediate sidebar update
 - All dialogs are built on `DialogShell.tsx` — use the `fullscreen` prop for the Settings modal and omit it for compact dialogs (AddWorkspace, CustomizeSession, DeleteWorktree). DialogShell uses `popover="manual"` + `showPopover()`/`hidePopover()` to guarantee top-layer stacking above xterm.js canvas elements (z-index alone is insufficient for canvas stacking contexts)
 - Cookie TTL uses human-readable format: `s` (seconds), `m` (minutes), `h` (hours), `d` (days). Default: `24h`
-- **Right sidebar + file viewer split** — `SplitPaneLayout` wraps the session view with `FileTreeSidebar` (right, resizable/collapsible via Ctrl+B) and `FileViewerPane` (center, appears on demand when files are opened). Both share `fileDiffSource` and `fileDiffDefaultBranch` via `UI hooks` so switching diff source in the sidebar updates all open file viewer tabs. `openFileTab()`/`closeFileTab()` in `UI hooks` drive file viewer tab state
+- **Utility rail + file viewer split** — `SplitPaneLayout` wraps the session view with `WorkspaceUtilityRail` (right, visible/hidden via the PR top-bar toggle) and `FileViewerPane` (center, appears on demand when files are opened). The rail has a fixed-width icon strip at the far right; the selected utility pane renders immediately to its left, and clicking the active icon clears the selected pane while keeping the icon strip. Utility rail state is persisted per workspace path in the UI store with stable tab identities for future draggable/anchored panes. `openFileTab()`/`closeFileTab()` in `UI hooks` drive file viewer tab state.
 - Root directory scanning: one level deep for git repos, hidden directories excluded
 
 ## Mobile Touch & Input

--- a/docs/plans/2026-04-24-issue-251-utility-rail-implementation.md
+++ b/docs/plans/2026-04-24-issue-251-utility-rail-implementation.md
@@ -1,0 +1,396 @@
+# Issue 251 Utility Rail Implementation Spec
+
+Source issue: https://github.com/donovan-yohan/relay-ide/issues/251
+
+HTML sketch: `docs/plans/issue-251-utility-rail-layout-sketch.html`
+
+Branch reviewed: `nightly`
+
+Base commit reviewed: `d5c62ff`
+
+## Goal
+
+Introduce a persistent workspace utility rail that consolidates secondary workspace tools into one coherent surface without closing off the larger layout vision: tabs and panes should eventually be collectible, draggable, split out, resized, grouped, ungrouped, and rearranged.
+
+This issue should not become a one-off "better file sidebar." It should create the utility surface vocabulary that later workspace layout work can promote into a fully rearrangeable pane system.
+
+## Larger Vision Constraint
+
+Relay is moving toward a workspace where every useful surface can become a tab or pane:
+
+- agent sessions
+- terminal sessions
+- files
+- diffs and review
+- logs and output
+- stats, cost, context, and session telemetry
+- utility terminals
+
+Long term, these surfaces should be movable between groups, dragged out into adjacent panes, resized, shown, hidden, regrouped, and ungrouped. Issue #251 should therefore model utility tabs with stable identities and panel boundaries instead of hard-coding them as special cases inside `FileTreeSidebar`.
+
+The right utility rail is the default home for utility surfaces, not their permanent container. The icon rail is always docked at the far right when visible. The selected utility pane appears immediately to the left of that icon rail. In the larger workspace model, users should be able to drag any utility icon out of the rail and anchor that full pane elsewhere in the workspace.
+
+## Sidebar Display Model
+
+The right utility rail should use the same visible/hidden shell model that should later apply to the left sidebar:
+
+| Mode      | Behavior                                                                                                                                                  |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `visible` | Right rail is present. The far-right icon strip is always visible; if a utility icon is selected, its pane renders immediately to the left of the strip.  |
+| `hidden`  | Right rail takes no layout width; the main area gets maximum space. A top-corner toggle remains available, matching today's right-sidebar button pattern. |
+
+There is no separate expanded/collapsed mode. The icon strip plus hover tooltips is enough. If the user clicks the currently active icon again, Relay clears the selected utility pane and leaves only the icon strip visible. If the user hides the rail, both the icon strip and utility content disappear.
+
+The first implementation should treat the right rail as the proving ground for this model. The left sidebar can adopt the same state language later.
+
+The icon strip has two jobs:
+
+- Click an icon to make that utility surface the selected right-side pane. Click the same active icon again to clear the selected pane.
+- Drag an icon out to promote that utility surface into an anchored full pane in the future layout system.
+
+Example target behavior:
+
+1. The rail has `git diff`, `PR`, and `file browser` icons.
+2. The selected right-side pane is `git diff`, rendered immediately left of the icon rail.
+3. The user drags `file browser` out of the rail and anchors it as its own pane.
+4. The layout becomes `[file browser][git diff][icon rail]`.
+5. The user clicks the remaining `PR` icon in the rail.
+6. The rail-selected pane swaps from `git diff` to `PR`, producing `[file browser][PR][icon rail]`.
+
+The anchored `file browser` pane is no longer competing for the rail-selected pane unless the user docks it back into the rail. Its icon may remain visible as a focus/dock control later, but its placement is different from rail-hosted utility tabs.
+
+If drag-out is not implemented in the first #251 PR, the component and state model should still expose stable utility tab identities so the later drag/drop implementation does not need to reinterpret the rail.
+
+Resize invariant:
+
+- Anchored panes have their own width and resize handle.
+- The rail-selected pane has its own width and resize handle.
+- These widths are independent, so resizing `[file browser]` does not resize `[PR]`.
+- The far-right icon rail is fixed width and never resizes.
+- Hiding the rail removes the fixed icon rail and rail-selected pane, but does not destroy anchored pane widths.
+
+Border invariant:
+
+- Adjacent panes share a single 1px divider.
+- Do not render visual gaps or double borders between `[anchored pane][rail-selected pane][icon rail]`.
+- Resize handles sit on the shared divider and may increase hit target invisibly, but the visible line remains one pixel.
+- Hovering or dragging a resize handle can recolor the shared divider; it should not widen the divider or push panes apart.
+
+## Animation Constraint
+
+Reduce sliding and dynamic layout animation. This is a dev tool; layout should take the space it owns immediately.
+
+Use immediate reflow for:
+
+- opening and closing the utility rail
+- resizing panes
+- switching utility tabs
+- moving future tabs between pane groups
+- expanding a pane to claim available workspace space
+
+Keep only lightweight affordances where they communicate state without delaying layout:
+
+- hover/focus color changes
+- active tab border changes
+- loading spinners or text state
+- short status flashes for changed files
+
+Avoid width/transform slide transitions for primary layout changes. Mobile drawer behavior may still need a direct off-canvas fallback, but desktop workspace layout should not slide.
+
+## Current Code
+
+| Concern                        | Current implementation                                                                                                                    |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Session workspace shell        | `frontend/src/App.tsx` renders session mode with `SplitPaneLayout`.                                                                       |
+| Three-pane layout              | `frontend/src/components/SplitPaneLayout.tsx` hard-codes terminal, optional file viewer, and optional right sidebar.                      |
+| Existing right sidebar state   | `frontend/src/lib/stores/ui.ts` stores `rightSidebarCollapsed`, `rightSidebarWidth`, and `rightSidebarTab`.                               |
+| Existing recover toggle        | `frontend/src/components/PrTopBar.tsx` renders the top-right sidebar toggle button.                                                       |
+| Existing right sidebar content | `frontend/src/components/FileTreeSidebar.tsx` owns `changes`, `all-files`, and placeholder `checks` tabs.                                 |
+| File tabs                      | `frontend/src/lib/stores/ui.ts` stores `openFileTabs` and `activeFileTabKey`; `FileViewerPane.tsx` owns tab chrome and content rendering. |
+| Full diff route                | `FullPageDiff.tsx` is still a modal/full-page overlay via `fullPageDiff`, causing view-mode jumps.                                        |
+| Stats data                     | `useTelemetryStore` can summarize session telemetry; `SessionStatusBar` renders per-session model/context/tokens/cost.                    |
+
+## Implementation Plan
+
+> Generated by `/scope`-style planning on 2026-04-24
+
+### Files to Change
+
+```files
+frontend/src/lib/stores/ui.ts -- replace narrow rightSidebarTab state with workspace-scoped utility rail state and openUtilityRailTab actions
+frontend/src/components/SplitPaneLayout.tsx -- keep the existing three-pane shell but rename/right-size props around a generic utility rail boundary
+frontend/src/components/SplitPaneLayout.css -- remove desktop slide transitions and style immediate rail reflow
+frontend/src/App.tsx -- wire utility rail actions into file/review opens and render WorkspaceUtilityRail in session mode
+frontend/src/hooks/useActionRegistry.ts -- route "open review"/diff actions to the review utility tab instead of only fullPageDiff
+frontend/src/components/PrTopBar.tsx -- update the top-corner rail toggle to hide/show the entire right rail
+frontend/src/components/WorkspaceUtilityRail.tsx -- NEW: utility rail shell, fixed icon strip, visibility toggle behavior, resize handles, and panel host
+frontend/src/components/WorkspaceUtilityRail.css -- NEW: TUI-native rail styles with no desktop layout slide animation
+frontend/src/components/UtilityRailFilesPanel.tsx -- NEW: files/changes panel wrapper around existing FileTreeSidebar behavior
+frontend/src/components/UtilityRailReviewPanel.tsx -- NEW: review panel using existing changed-files/diff APIs and DiffViewer without full-page navigation
+frontend/src/components/UtilityRailLogsPanel.tsx -- NEW: logs/output panel shell backed by current session/activity data, ready for richer streams later
+frontend/src/components/UtilityRailStatsPanel.tsx -- NEW: stats panel using telemetry store summaries for current workspace/session context
+frontend/src/components/FileTreeSidebar.tsx -- split reusable file-tree panel logic from old right-sidebar tab chrome or adapt it behind UtilityRailFilesPanel
+frontend/src/components/FileViewerPane.tsx -- expose reusable file tab/content pieces where utility review/file actions need to target pane-compatible tabs
+test/stores/ui-store.test.ts -- add workspace-scoped utility rail state, tab open, persistence, and migration coverage
+test/e2e/components/WorkspaceUtilityRail.spec.ts -- NEW: component coverage for tabs, direct-open behavior, selected-pane toggle, visibility, and immediate layout states
+test/e2e/components/SplitPaneLayout.spec.ts -- update expectations for generic utility rail sizing and no desktop slide behavior
+docs/FRONTEND.md -- update component map and key pattern for workspace utility rail
+docs/plans/2026-04-24-issue-251-utility-rail-implementation.md -- this implementation spec
+```
+
+### State Model
+
+Add a utility rail model in `ui.ts` that is still small enough for #251 but compatible with future pane collection:
+
+```ts
+export type UtilityRailTab = 'files' | 'review' | 'logs' | 'stats';
+export type UtilitySurfacePlacement =
+  | { kind: 'rail' }
+  | { kind: 'anchored-pane'; paneId: string };
+
+export interface WorkspaceUtilityRailState {
+  visible: boolean;
+  selectedRailTab: UtilityRailTab | null;
+  width: number;
+  anchoredPaneWidths?: Partial<Record<UtilityRailTab, number>>;
+  placements?: Partial<Record<UtilityRailTab, UtilitySurfacePlacement>>;
+  reviewFilePath?: string;
+  filesMode?: 'changes' | 'all-files';
+}
+```
+
+Persist it per workspace path, not globally:
+
+```text
+relay-utility-rail::<workspacePath>
+```
+
+Expose actions:
+
+- `getUtilityRailState(workspacePath)`
+- `setSelectedUtilityRailTab(workspacePath, tab | null)`
+- `openUtilityRailTab(workspacePath, tab, options?)`
+- `setUtilityRailVisible(workspacePath, visible)`
+- `toggleUtilityRailVisible(workspacePath)`
+- `setUtilityRailWidth(workspacePath, width)`
+- `setAnchoredUtilityPaneWidth(workspacePath, tab, width)`
+- `setUtilitySurfacePlacement(workspacePath, tab, placement)`
+
+`openUtilityRailTab()` should make the rail visible and select the requested tab unless the caller explicitly asks to preserve the current selected tab. This gives existing actions a single integration point.
+
+Click behavior:
+
+- Click an inactive rail icon: set `selectedRailTab` to that tab and make the rail visible.
+- Click the active rail icon: set `selectedRailTab` to `null`; keep the rail visible as an icon-only strip.
+- Click the top-corner toggle: set `visible` to `false` or restore it to `true`.
+
+`placements` is a future-compatibility hook. #251 does not need to render anchored panes, but the rail should be able to understand that a utility surface may later live outside the default rail-selected pane.
+
+Default placement is `{ kind: 'rail' }`. `selectedRailTab` selects among rail-hosted surfaces only. If `files` is anchored in its own pane, clicking `review` should swap the rail-selected pane to review rather than disturbing the anchored files pane.
+
+Suggested constants:
+
+```ts
+export const DEFAULT_UTILITY_RAIL_WIDTH = 320;
+export const MIN_UTILITY_RAIL_WIDTH = 220;
+export const MAX_UTILITY_RAIL_WIDTH = 640;
+export const UTILITY_ICON_RAIL_WIDTH = 48;
+```
+
+## Accepted First Slice
+
+### 1. Create The Utility Rail Shell
+
+Build `WorkspaceUtilityRail` as the replacement conceptual owner for the current right sidebar.
+
+It should render:
+
+- a vertical activity-bar-style tab strip for `files`, `review`, `logs`, and `stats`
+- a panel host that keeps mounted tab panels where that preserves context
+- visible and hidden rail states
+- active-icon toggle behavior that can clear the selected utility pane
+- controls for hiding and restoring the rail
+- accessible icon buttons and tooltip labels
+- no desktop slide animation
+
+Visible mode should always keep the icon strip docked at the far right. When `selectedRailTab` is non-null, the selected pane appears immediately to the left of the icon strip. When `selectedRailTab` is `null`, only the icon strip remains visible. Hidden mode should remove both the icon strip and selected pane from layout entirely while keeping the top-corner toggle in `PrTopBar` visible.
+
+The activity strip should use icon buttons with hover tooltips rather than persistent text labels. Use the Relay design language: lowercase labels in tooltips, monospace, 0px radius, 1px borders, pure black surfaces, no emoji, and outline-only controls. Use monochrome SVG icons, not emoji.
+
+The selected icon owns the pane immediately left of the icon rail. Selecting `review` means that pane is review; selecting `stats` means that pane is stats. This is the mental model to preserve when utility surfaces later become draggable panes.
+
+If a utility surface is dragged out and anchored elsewhere, the rail-selected pane continues to be controlled by the active rail-hosted icon. For example, `[file browser][git diff][icon rail]` can become `[file browser][PR][icon rail]` by clicking the `PR` icon while the anchored file browser remains in place.
+
+### 2. Keep Layout Boundary Stable But Rename The Concept
+
+`SplitPaneLayout` can remain as the immediate layout wrapper for this issue, but its right child should be treated as `utilityRail`, not `rightSidebar`.
+
+Do not try to implement all draggable pane grouping in #251. Instead:
+
+- isolate the utility rail as a pane-like child with a clear identity
+- keep the resize handle behavior
+- make resize available only when `visible === true` and `selectedRailTab !== null`
+- keep anchored utility pane resize handles independent from the rail-selected pane resize handle
+- keep the far-right icon rail fixed at `UTILITY_ICON_RAIL_WIDTH`
+- render shared single-pixel dividers between adjacent panes, not double borders or gutters
+- use `UTILITY_ICON_RAIL_WIDTH` when visible with no selected pane
+- use zero width when hidden
+- avoid slide transitions on desktop
+- keep terminal as the primary workspace surface
+- keep file viewer as-is until #263-style main pane tabs take over
+
+This lets #251 land without conflicting with the larger workspace layout substrate.
+
+### 3. Replace `FileTreeSidebar` Tab Ownership
+
+`FileTreeSidebar` currently owns both tab chrome and file tree content. Move toward this boundary:
+
+- `WorkspaceUtilityRail` owns utility tabs.
+- `UtilityRailFilesPanel` owns files/changes content.
+- `FileTreeSidebar` either becomes the files panel implementation or is split into reusable `ChangesTree` / `AllFilesTree` pieces.
+
+The `files` tab should preserve current behavior:
+
+- changed files tree
+- all files tree
+- diff source toggle
+- file count
+- changed-file refresh on event socket updates
+- clicking a file opens the existing file viewer tab
+
+### 4. Add Review As A First-Class Utility Tab
+
+The `review` tab is the representative hard case. It should use existing APIs and components:
+
+- `fetchChangedFiles`
+- `fetchFileDiff`
+- `fetchDefaultBranch`
+- `DiffViewer`
+- `DiffFileSidebar` or equivalent file list behavior
+- existing diff source state
+
+It should not require new backend routes.
+
+It should not replace the full future review workspace. The first implementation should make review available inside the rail so actions can open review context without jumping into `FullPageDiff`.
+
+Minimum useful review behavior:
+
+- list changed files for the current workspace/worktree
+- select a file
+- render a unified diff in the rail
+- support direct-open from an action with an initial file
+- preserve selected file when switching away and back
+
+### 5. Add Logs And Stats As Real Shell Tabs
+
+`logs` and `stats` should be first-class tabs even if their first content is intentionally modest.
+
+`logs` first slice:
+
+- show current session identity
+- show current activity from `activeSession.currentActivity`
+- reserve a stable output/log region
+- make the panel boundary ready for later event streams or utility terminal output
+
+`stats` first slice:
+
+- show current session telemetry when a session is active
+- show workspace aggregate telemetry using `useTelemetryStore.summarizeSessionSetTelemetry`
+- include model, context %, tokens, cost, and rate-limit fields where available
+
+Avoid new analytics APIs unless the existing store cannot answer a required field.
+
+### 6. Wire Existing Actions To Utility Tabs
+
+Existing actions should open the relevant rail tab directly:
+
+- file tree file click: open `files`, then open file tab
+- terminal file path click: open `files`, then open file tab
+- command palette/open review: open `review`
+- full-page diff action: prefer `review` utility tab for in-workspace use; keep `FullPageDiff` only as a fallback or legacy route until replaced
+- future logs/stats commands: call `openUtilityRailTab`
+
+This is the most important acceptance path: users should not experience view-mode jumps when they ask for secondary workspace context.
+
+### 7. Design For Future Pane Collection
+
+Do not implement full drag/drop pane collection in #251, but structure the rail so it can become a pane source later.
+
+Useful constraints:
+
+- Each utility tab has a stable id.
+- Each utility icon can be represented as a drag source.
+- Each utility panel is independently renderable.
+- The rail shell does not know panel internals.
+- Panel state is keyed by workspace path and tab id.
+- Opening a tab is expressed as an action, not as direct component state mutation.
+- Rail visibility and selected pane are explicit (`visible`, `selectedRailTab`) instead of inferred from width.
+- The rail can eventually be represented as a `WorkspacePane` child in the #263 layout tree.
+- Dragging an icon out should eventually create or focus a full anchored pane for that utility tab.
+- When a utility tab is anchored elsewhere, it no longer competes for the rail-selected pane until it is docked back.
+- The icon strip can still act as the canonical launcher/focus/dock control for anchored surfaces later.
+
+## Not In Scope
+
+| Item                                  | Why deferred                                                                                                       |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Full drag/drop pane collection        | Belongs to #263-style workspace layout substrate. #251 should only preserve stable utility icon identities for it. |
+| Arbitrary pane grouping/ungrouping UI | Must be designed across all tab types, not just the utility rail.                                                  |
+| Utility terminal implementation       | Issue #255 owns terminal tabs in the utility surface. #251 should leave a clean host boundary.                     |
+| New runtime/session types             | Explicit non-goal of #251.                                                                                         |
+| Replacing session tab model           | Larger layout work. #251 only prepares compatibility.                                                              |
+| Rebuilding every file/diff feature    | Explicit non-goal. Reuse current data sources and components.                                                      |
+| Animated sidebar/drawer polish        | Product direction is immediate layout occupancy, not animated sliding.                                             |
+
+## Verification
+
+Run focused checks:
+
+```bash
+npx vitest run test/stores/ui-store.test.ts
+npx playwright test test/e2e/components/WorkspaceUtilityRail.spec.ts test/e2e/components/SplitPaneLayout.spec.ts
+npm run check
+```
+
+Manual QA:
+
+- Open a session and verify terminal remains primary.
+- Open changed files and confirm the utility rail selects `files`.
+- Open review from command palette and confirm it opens the `review` tab without leaving session view.
+- Switch between `files`, `review`, `logs`, and `stats`; confirm panel state is preserved.
+- Resize the selected utility pane and anchored utility panes independently; reload the workspace and confirm widths persist for that workspace only.
+- Click an inactive rail icon and confirm its pane appears immediately left of the fixed icon strip.
+- Click the active rail icon again and confirm the selected pane disappears while the fixed icon strip remains.
+- Hide the rail and confirm both the icon strip and selected pane take no layout width, then restore it from the top-corner button.
+- Confirm anchored panes remain in place and keep their own widths when the rail-selected pane changes.
+- Confirm desktop rail open/close takes layout space immediately with no slide animation.
+- Confirm mobile fallback still allows access to the utility rail without covering terminal input permanently.
+
+## Acceptance Criteria
+
+- [ ] Relay has one utility rail surface for secondary workspace tools.
+- [ ] Utility rail state is persisted per workspace.
+- [ ] Existing actions can open the relevant utility tab directly.
+- [ ] The rail supports `files`, `review`, `logs`, and `stats` as first-class tabs.
+- [ ] The rail has explicit visible/hidden state and a nullable selected utility pane.
+- [ ] The visible rail always keeps a fixed-width icon strip docked at the far right.
+- [ ] Clicking the active icon clears the selected pane and leaves only the fixed icon strip visible.
+- [ ] Hidden mode gives the main area maximum space while preserving a top-corner restore toggle.
+- [ ] The selected utility icon determines the pane immediately left of the icon rail.
+- [ ] Utility icons have stable identities suitable for future drag-out pane anchoring.
+- [ ] The spec supports anchored utility surfaces such as `[file browser][git diff][icon rail]`, where clicking another rail icon swaps only the rail-selected pane.
+- [ ] Anchored utility panes and the rail-selected pane have independent resize handles and persisted widths.
+- [ ] The shell has a stable host boundary for future utility terminal tabs.
+- [ ] Desktop layout changes use immediate reflow, not sliding layout animation.
+- [ ] The tab/panel model is compatible with future draggable, groupable, resizable panes.
+- [ ] No new backend runtime/session type is introduced.
+
+## Risk Notes
+
+- `FileTreeSidebar` currently mixes rail tab chrome and file-tree content; splitting it incorrectly could regress changed-file refresh and file selection.
+- `FullPageDiff` is still reachable through `fullPageDiff` store state; action routing needs a careful migration so keyboard shortcuts and command palette actions do not fork behavior.
+- `FileViewerPane` owns both file tab chrome and content rendering. Avoid deep refactors here unless necessary; #251 should prepare the boundary, not complete #263.
+- Utility rail persistence must be workspace-scoped. A global active tab would feel wrong when switching repos.
+- Do not reintroduce a separate collapsed mode. Visible rail with `selectedRailTab: null` gives the icon-only behavior without adding another display state.
+- The fixed icon rail must stay fixed width. Width persistence applies to content panes, not the activity strip.
+- Removing layout animation should be targeted. Keep useful loading/status animations; remove sliding reflow for primary workspace structure.

--- a/docs/plans/issue-251-utility-rail-layout-sketch.html
+++ b/docs/plans/issue-251-utility-rail-layout-sketch.html
@@ -1,0 +1,771 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>relay utility rail sketch</title>
+    <style>
+      :root {
+        --bg: #000;
+        --border: #333;
+        --text: #e0e0e0;
+        --muted: #888;
+        --accent: #d97757;
+        --info: #60a5fa;
+        --success: #4ade80;
+        --error: #f87171;
+        --anchored-width: 320px;
+        --selected-width: 320px;
+        --icon-rail-width: 48px;
+        --handle-width: 1px;
+        font-family:
+          'SF Mono', 'Cascadia Code', 'JetBrains Mono', 'Fira Code', Consolas,
+          monospace;
+        color: var(--text);
+        background: var(--bg);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        height: 100vh;
+        background: var(--bg);
+        color: var(--text);
+        font-size: 13px;
+        letter-spacing: 0;
+        overflow: hidden;
+      }
+
+      button {
+        font: inherit;
+        color: inherit;
+      }
+
+      .app {
+        height: 100vh;
+        display: grid;
+        grid-template-columns: 240px 1fr;
+      }
+
+      .left-sidebar {
+        border-right: 1px solid var(--border);
+        display: grid;
+        grid-template-rows: 44px 1fr;
+        min-width: 0;
+      }
+
+      .brand {
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        padding: 0 16px;
+        color: var(--muted);
+      }
+
+      .repo-list {
+        padding: 8px;
+      }
+
+      .repo {
+        border: 1px solid var(--border);
+        padding: 10px 8px;
+        margin-bottom: 8px;
+        color: var(--muted);
+      }
+
+      .repo.active {
+        color: var(--text);
+        border-color: var(--accent);
+      }
+
+      .workspace {
+        display: grid;
+        grid-template-rows: 44px 1fr;
+        min-width: 0;
+        min-height: 0;
+      }
+
+      .top-bar {
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        min-width: 0;
+      }
+
+      .top-left {
+        display: flex;
+        align-items: center;
+        min-width: 0;
+      }
+
+      .branch {
+        height: 44px;
+        border-right: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        padding: 0 14px;
+        color: var(--muted);
+      }
+
+      .branch strong {
+        color: var(--text);
+        font-weight: 500;
+      }
+
+      .controls {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 0 10px;
+      }
+
+      .top-actions {
+        display: flex;
+        align-items: center;
+        border-left: 1px solid var(--border);
+      }
+
+      .btn,
+      .icon-btn {
+        height: 32px;
+        min-width: 32px;
+        background: transparent;
+        border: 1px solid var(--border);
+        color: var(--muted);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0 8px;
+        border-radius: 0;
+        cursor: pointer;
+      }
+
+      .btn.active,
+      .icon-btn.active {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+
+      .btn:hover,
+      .icon-btn:hover {
+        background: color-mix(in srgb, var(--accent) 10%, transparent);
+        color: var(--text);
+      }
+
+      .workspace-body {
+        min-height: 0;
+        min-width: 0;
+        display: grid;
+        grid-template-columns:
+          minmax(320px, 1fr)
+          var(--anchored-width)
+          var(--handle-width)
+          var(--selected-width)
+          var(--handle-width)
+          var(--icon-rail-width);
+      }
+
+      .workspace-body.no-anchor {
+        grid-template-columns:
+          minmax(320px, 1fr)
+          0
+          0
+          var(--selected-width)
+          var(--handle-width)
+          var(--icon-rail-width);
+      }
+
+      .workspace-body.no-selected {
+        grid-template-columns:
+          minmax(320px, 1fr)
+          var(--anchored-width)
+          var(--handle-width)
+          0
+          0
+          var(--icon-rail-width);
+      }
+
+      .workspace-body.no-anchor.no-selected {
+        grid-template-columns: minmax(320px, 1fr) 0 0 0 0 var(--icon-rail-width);
+      }
+
+      .workspace-body.rail-hidden {
+        grid-template-columns: minmax(320px, 1fr) 0 0 0 0 0;
+      }
+
+      .main-terminal {
+        grid-column: 1;
+        min-width: 0;
+        min-height: 0;
+        display: grid;
+        grid-template-rows: 38px 1fr 28px;
+        border-right: 1px solid var(--border);
+      }
+
+      .session-tabs {
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        min-width: 0;
+      }
+
+      .tab {
+        height: 38px;
+        border-right: 1px solid var(--border);
+        padding: 0 14px;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        color: var(--muted);
+      }
+
+      .tab.active {
+        color: var(--text);
+        box-shadow: inset 0 -1px 0 var(--accent);
+      }
+
+      .terminal {
+        padding: 14px;
+        overflow: hidden;
+        color: #cfcfcf;
+        line-height: 1.5;
+      }
+
+      .prompt {
+        color: var(--success);
+      }
+
+      .status {
+        border-top: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        color: var(--muted);
+        padding: 0 10px;
+        font-size: 12px;
+      }
+
+      .pane {
+        min-width: 0;
+        min-height: 0;
+        display: grid;
+        grid-template-rows: 38px 1fr;
+        border-right: 0;
+        overflow: hidden;
+      }
+
+      .anchored-pane {
+        grid-column: 2;
+      }
+
+      .anchored-handle {
+        grid-column: 3;
+      }
+
+      .selected-pane {
+        grid-column: 4;
+      }
+
+      .selected-handle {
+        grid-column: 5;
+      }
+
+      .workspace-body.no-anchor .anchored-pane,
+      .workspace-body.no-anchor .anchored-handle,
+      .workspace-body.no-selected .selected-pane,
+      .workspace-body.no-selected .selected-handle,
+      .workspace-body.rail-hidden .anchored-pane,
+      .workspace-body.rail-hidden .selected-pane,
+      .workspace-body.rail-hidden .icon-rail,
+      .workspace-body.rail-hidden .resize-handle {
+        display: none;
+      }
+
+      .pane-header {
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 10px;
+        color: var(--muted);
+        min-width: 0;
+      }
+
+      .pane-title {
+        color: var(--text);
+        white-space: nowrap;
+      }
+
+      .pane-body {
+        min-height: 0;
+        overflow: hidden;
+        padding: 10px;
+      }
+
+      .resize-handle {
+        background: var(--bg);
+        border-right: 1px solid var(--border);
+        cursor: col-resize;
+        min-width: var(--handle-width);
+      }
+
+      .resize-handle:hover,
+      .resize-handle.dragging {
+        border-right-color: var(--accent);
+      }
+
+      .file-list,
+      .diff-list,
+      .pr-list {
+        display: grid;
+        gap: 6px;
+      }
+
+      .row {
+        border: 1px solid var(--border);
+        min-height: 32px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 0 8px;
+        color: var(--muted);
+        white-space: nowrap;
+        overflow: hidden;
+      }
+
+      .row span:first-child {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .row.active {
+        border-color: var(--accent);
+        color: var(--text);
+      }
+
+      .diff-code {
+        border: 1px solid var(--border);
+        margin-top: 10px;
+        padding: 10px;
+        color: var(--muted);
+        line-height: 1.55;
+        height: 260px;
+        overflow: hidden;
+      }
+
+      .plus {
+        color: var(--success);
+      }
+
+      .minus {
+        color: var(--error);
+      }
+
+      .muted {
+        color: var(--muted);
+      }
+
+      .icon-rail {
+        grid-column: 6;
+        width: var(--icon-rail-width);
+        background: #030303;
+        display: grid;
+        grid-template-rows: auto 1fr auto;
+      }
+
+      .activity-icons {
+        display: grid;
+      }
+
+      .activity-btn {
+        width: var(--icon-rail-width);
+        height: 48px;
+        background: transparent;
+        border: 0;
+        border-bottom: 1px solid var(--border);
+        color: var(--muted);
+        display: grid;
+        place-items: center;
+        cursor: pointer;
+        border-radius: 0;
+        position: relative;
+      }
+
+      .activity-btn.active {
+        color: var(--accent);
+        box-shadow: inset 2px 0 0 var(--accent);
+      }
+
+      .activity-btn.detached {
+        color: var(--info);
+      }
+
+      .activity-btn.detached::after {
+        content: '';
+        position: absolute;
+        right: 8px;
+        bottom: 8px;
+        width: 6px;
+        height: 6px;
+        border: 1px solid currentColor;
+        background: var(--bg);
+      }
+
+      .activity-btn:hover {
+        background: #141414;
+        color: var(--text);
+      }
+
+      svg {
+        width: 18px;
+        height: 18px;
+        stroke: currentColor;
+        fill: none;
+        stroke-width: 1.6;
+        stroke-linecap: square;
+        stroke-linejoin: miter;
+      }
+
+      .tiny {
+        font-size: 11px;
+        color: var(--muted);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="app">
+      <aside class="left-sidebar">
+        <div class="brand">relay-ide</div>
+        <div class="repo-list">
+          <div class="repo active">
+            relay-ide<br /><span class="tiny">agent 1 - current</span>
+          </div>
+          <div class="repo">chalk-bag<br /><span class="tiny">idle</span></div>
+          <div class="repo">belayer<br /><span class="tiny">review</span></div>
+        </div>
+      </aside>
+
+      <main class="workspace">
+        <div class="top-bar">
+          <div class="top-left">
+            <div class="branch">branch&nbsp;<strong>nightly</strong></div>
+            <div class="controls">
+              <button class="btn active" id="toggle-rail">rail visible</button>
+              <button class="btn" id="detach-files">
+                pull file browser out
+              </button>
+              <button class="btn" id="clear-selected">
+                clear selected pane
+              </button>
+            </div>
+          </div>
+          <div class="top-actions">
+            <button class="icon-btn" title="refresh">
+              <svg viewBox="0 0 24 24">
+                <path d="M20 12a8 8 0 1 1-8-8" />
+                <path d="M12 1l8 3-5 5" />
+              </svg>
+            </button>
+            <button
+              class="icon-btn active"
+              id="restore-rail"
+              title="hide or restore right rail"
+            >
+              <svg viewBox="0 0 24 24">
+                <rect x="3" y="4" width="18" height="16" />
+                <path d="M15 4v16" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="workspace-body no-anchor" id="workspace-body">
+          <section class="main-terminal">
+            <div class="session-tabs">
+              <div class="tab active">&gt; agent 1</div>
+              <div class="tab">&gt; terminal 1</div>
+              <div class="tab">+</div>
+            </div>
+            <div class="terminal">
+              <div><span class="prompt">relay-ide %</span> npm run check</div>
+              <div class="muted">typechecking frontend/src/components...</div>
+              <div class="muted">watching workspace changes...</div>
+              <br />
+              <div>
+                <span class="prompt">agent:</span> reviewing utility rail shell
+                boundaries
+              </div>
+            </div>
+            <div class="status">
+              <span>sonnet - [#####.....] 52% - down 10k up 2k - ~$0.18</span>
+              <span>rate 5h: 41%</span>
+            </div>
+          </section>
+
+          <section class="pane anchored-pane" id="anchored-pane">
+            <div class="pane-header">
+              <span class="pane-title">file browser</span>
+              <span class="tiny">anchored pane</span>
+            </div>
+            <div class="pane-body">
+              <div class="file-list">
+                <div class="row active">
+                  <span>frontend/src/App.tsx</span><span>M</span>
+                </div>
+                <div class="row">
+                  <span>frontend/src/lib/stores/ui.ts</span><span>M</span>
+                </div>
+                <div class="row">
+                  <span>frontend/src/components</span><span>dir</span>
+                </div>
+                <div class="row"><span>docs/plans</span><span>dir</span></div>
+              </div>
+            </div>
+          </section>
+
+          <div
+            class="resize-handle anchored-handle"
+            data-resize="anchored"
+          ></div>
+
+          <section class="pane selected-pane" id="selected-pane">
+            <div class="pane-header">
+              <span class="pane-title" id="selected-title">git diff</span>
+              <span class="tiny">rail-selected pane</span>
+            </div>
+            <div class="pane-body" id="selected-body"></div>
+          </section>
+
+          <div
+            class="resize-handle selected-handle"
+            data-resize="selected"
+          ></div>
+
+          <aside class="icon-rail" id="icon-rail">
+            <div class="activity-icons">
+              <button
+                class="activity-btn"
+                data-tab="files"
+                title="file browser"
+              >
+                <svg viewBox="0 0 24 24">
+                  <path d="M5 3h10l4 4v14H5z" />
+                  <path d="M15 3v5h5" />
+                </svg>
+              </button>
+              <button
+                class="activity-btn active"
+                data-tab="diff"
+                title="git diff"
+              >
+                <svg viewBox="0 0 24 24">
+                  <path d="M7 4v16" />
+                  <path d="M17 4v16" />
+                  <path d="M7 8h10" />
+                  <path d="M7 16h10" />
+                </svg>
+              </button>
+              <button class="activity-btn" data-tab="pr" title="PR">
+                <svg viewBox="0 0 24 24">
+                  <circle cx="7" cy="6" r="2" />
+                  <circle cx="17" cy="18" r="2" />
+                  <path d="M7 8v10" />
+                  <path d="M9 6h4a4 4 0 0 1 4 4v6" />
+                </svg>
+              </button>
+              <button class="activity-btn" data-tab="stats" title="stats">
+                <svg viewBox="0 0 24 24">
+                  <path d="M5 19V9" />
+                  <path d="M12 19V5" />
+                  <path d="M19 19v-7" />
+                </svg>
+              </button>
+            </div>
+            <div></div>
+            <button class="activity-btn" data-tab="more" title="more">
+              ...
+            </button>
+          </aside>
+        </div>
+      </main>
+    </div>
+
+    <script>
+      const workspaceBody = document.querySelector('#workspace-body');
+      const selectedTitle = document.querySelector('#selected-title');
+      const selectedBody = document.querySelector('#selected-body');
+      const activityButtons = [
+        ...document.querySelectorAll('.activity-btn[data-tab]'),
+      ];
+      const detachFiles = document.querySelector('#detach-files');
+      const clearSelected = document.querySelector('#clear-selected');
+      const toggleRail = document.querySelector('#toggle-rail');
+      const restoreRail = document.querySelector('#restore-rail');
+      let railVisible = true;
+      let filesAnchored = false;
+      let selectedTab = 'diff';
+
+      const panels = {
+        files: {
+          title: 'file browser',
+          html: `
+            <div class="file-list">
+              <div class="row active"><span>frontend/src/App.tsx</span><span>M</span></div>
+              <div class="row"><span>frontend/src/components/WorkspaceUtilityRail.tsx</span><span>new</span></div>
+              <div class="row"><span>frontend/src/components/UtilityRailReviewPanel.tsx</span><span>new</span></div>
+              <div class="row"><span>docs/plans</span><span>dir</span></div>
+            </div>
+          `,
+        },
+        diff: {
+          title: 'git diff',
+          html: `
+            <div class="diff-list">
+              <div class="row active"><span>App.tsx</span><span class="plus">+34</span></div>
+              <div class="row"><span>ui.ts</span><span class="plus">+58</span></div>
+              <div class="row"><span>WorkspaceUtilityRail.tsx</span><span class="plus">new</span></div>
+            </div>
+            <div class="diff-code">
+              <div class="minus">- rightSidebarCollapsed: boolean</div>
+              <div class="plus">+ railVisible: boolean</div>
+              <div class="plus">+ selectedRailTab: UtilityRailTab | null</div>
+              <div class="plus">+ icon rail remains fixed width at the far right</div>
+            </div>
+          `,
+        },
+        pr: {
+          title: 'PR',
+          html: `
+            <div class="pr-list">
+              <div class="row active"><span>#251 utility rail</span><span class="plus">open</span></div>
+              <div class="row"><span>checks</span><span class="muted">3 pending</span></div>
+              <div class="row"><span>review</span><span class="muted">not requested</span></div>
+            </div>
+            <div class="diff-code">
+              <div>rail-selected pane swapped from git diff to PR.</div>
+              <div>anchored file browser remains beside it.</div>
+              <div>fixed icon rail stays rightmost.</div>
+            </div>
+          `,
+        },
+        stats: {
+          title: 'stats',
+          html: `
+            <div class="file-list">
+              <div class="row"><span>context</span><span>52%</span></div>
+              <div class="row"><span>tokens</span><span>down 10k up 2k</span></div>
+              <div class="row"><span>cost</span><span>~$0.18</span></div>
+              <div class="row"><span>rate 5h</span><span>41%</span></div>
+            </div>
+          `,
+        },
+      };
+
+      function updateClasses() {
+        workspaceBody.classList.toggle('no-anchor', !filesAnchored);
+        workspaceBody.classList.toggle('no-selected', selectedTab === null);
+        workspaceBody.classList.toggle('rail-hidden', !railVisible);
+        toggleRail.classList.toggle('active', railVisible);
+        toggleRail.textContent = railVisible ? 'rail visible' : 'rail hidden';
+        restoreRail.classList.toggle('active', railVisible);
+      }
+
+      function setSelected(tab) {
+        if (tab === 'files' && filesAnchored) return;
+        if (selectedTab === tab) selectedTab = null;
+        else selectedTab = tab;
+        if (!railVisible) railVisible = true;
+        if (selectedTab) {
+          const panel = panels[selectedTab];
+          selectedTitle.textContent = panel.title;
+          selectedBody.innerHTML = panel.html;
+        }
+        activityButtons.forEach((btn) => {
+          btn.classList.toggle('active', btn.dataset.tab === selectedTab);
+          btn.classList.toggle(
+            'detached',
+            btn.dataset.tab === 'files' && filesAnchored
+          );
+        });
+        updateClasses();
+      }
+
+      function setRailVisible(next) {
+        railVisible = next;
+        updateClasses();
+      }
+
+      activityButtons.forEach((btn) => {
+        btn.addEventListener('click', () => setSelected(btn.dataset.tab));
+      });
+
+      detachFiles.addEventListener('click', () => {
+        filesAnchored = !filesAnchored;
+        detachFiles.textContent = filesAnchored
+          ? 'dock file browser'
+          : 'pull file browser out';
+        if (filesAnchored && selectedTab === 'files') selectedTab = 'diff';
+        if (selectedTab) {
+          selectedTitle.textContent = panels[selectedTab].title;
+          selectedBody.innerHTML = panels[selectedTab].html;
+        }
+        activityButtons.forEach((btn) => {
+          btn.classList.toggle('active', btn.dataset.tab === selectedTab);
+          btn.classList.toggle(
+            'detached',
+            btn.dataset.tab === 'files' && filesAnchored
+          );
+        });
+        updateClasses();
+      });
+
+      clearSelected.addEventListener('click', () => {
+        selectedTab = null;
+        activityButtons.forEach((btn) => btn.classList.remove('active'));
+        updateClasses();
+      });
+
+      toggleRail.addEventListener('click', () => setRailVisible(!railVisible));
+      restoreRail.addEventListener('click', () => setRailVisible(!railVisible));
+
+      function attachResize(handle) {
+        let startX = 0;
+        let startWidth = 0;
+        let target = handle.dataset.resize;
+        handle.addEventListener('pointerdown', (event) => {
+          startX = event.clientX;
+          startWidth = parseFloat(
+            getComputedStyle(document.documentElement).getPropertyValue(
+              target === 'anchored' ? '--anchored-width' : '--selected-width'
+            )
+          );
+          handle.classList.add('dragging');
+          handle.setPointerCapture(event.pointerId);
+        });
+        handle.addEventListener('pointermove', (event) => {
+          if (!handle.classList.contains('dragging')) return;
+          const delta = event.clientX - startX;
+          const next = Math.max(220, Math.min(640, startWidth + delta));
+          document.documentElement.style.setProperty(
+            target === 'anchored' ? '--anchored-width' : '--selected-width',
+            `${next}px`
+          );
+        });
+        handle.addEventListener('pointerup', (event) => {
+          handle.classList.remove('dragging');
+          handle.releasePointerCapture(event.pointerId);
+        });
+      }
+
+      document.querySelectorAll('.resize-handle').forEach(attachResize);
+      selectedBody.innerHTML = panels.diff.html;
+      updateClasses();
+    </script>
+  </body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useAuthStore } from './lib/stores/auth.js';
 import {
   useUiStore,
+  DEFAULT_UTILITY_RAIL_STATE,
   MAX_UTILITY_RAIL_WIDTH,
   MIN_UTILITY_RAIL_WIDTH,
   UTILITY_ICON_RAIL_WIDTH,
@@ -364,9 +365,9 @@ function TerminalAreaContent({
   // Store access (layout / sidebar values not in derived state hook)
   const openSidebar = useUiStore((s) => s.openSidebar);
   const keyboardOpen = useUiStore((s) => s.keyboardOpen);
-  const utilityRailByWorkspace = useUiStore((s) => s.utilityRailByWorkspace);
-  const getUtilityRailState = useUiStore((s) => s.getUtilityRailState);
+  const hydrateUtilityRailState = useUiStore((s) => s.hydrateUtilityRailState);
   const setUtilityRailWidth = useUiStore((s) => s.setUtilityRailWidth);
+  const saveUtilityRailState = useUiStore((s) => s.saveUtilityRailState);
   const toggleUtilityRailVisible = useUiStore(
     (s) => s.toggleUtilityRailVisible
   );
@@ -391,6 +392,11 @@ function TerminalAreaContent({
     repos,
     sessions,
   } = useTerminalDerivedState();
+  const utilityRailWorkspaceState = useUiStore((s) =>
+    activeWorkspaceCwd
+      ? s.utilityRailByWorkspace[activeWorkspaceCwd]
+      : undefined
+  );
 
   // ── Onboarding hints ──────────────────────────────────────────────────────
   const { sessionJustStarted } = useTerminalOnboardingHints(
@@ -467,9 +473,12 @@ function TerminalAreaContent({
     [openFileTab]
   );
 
+  useEffect(() => {
+    if (activeWorkspaceCwd) hydrateUtilityRailState(activeWorkspaceCwd);
+  }, [activeWorkspaceCwd, hydrateUtilityRailState]);
+
   const utilityRailState =
-    utilityRailByWorkspace[activeWorkspaceCwd] ??
-    getUtilityRailState(activeWorkspaceCwd);
+    utilityRailWorkspaceState ?? DEFAULT_UTILITY_RAIL_STATE;
   const utilityRailWidth = utilityRailRenderedWidth(utilityRailState);
   const utilityRailResizable =
     utilityRailState.visible && utilityRailState.selectedRailTab !== null;
@@ -481,6 +490,11 @@ function TerminalAreaContent({
     },
     [activeWorkspaceCwd, setUtilityRailWidth, utilityRailResizable]
   );
+
+  const handleUtilityRailResizeEnd = useCallback(() => {
+    if (activeWorkspaceCwd && utilityRailResizable)
+      saveUtilityRailState(activeWorkspaceCwd);
+  }, [activeWorkspaceCwd, saveUtilityRailState, utilityRailResizable]);
 
   const handleToggleUtilityRail = useCallback(() => {
     if (activeWorkspaceCwd) toggleUtilityRailVisible(activeWorkspaceCwd);
@@ -562,6 +576,7 @@ function TerminalAreaContent({
             rightSidebarWidth={utilityRailWidth}
             fileViewerRatio={fileViewerRatio}
             onRightSidebarWidthChange={handleUtilityRailWidthChange}
+            onRightSidebarResizeEnd={handleUtilityRailResizeEnd}
             onFileViewerRatioChange={saveFileViewerRatio}
             onToggleRightSidebar={handleToggleUtilityRail}
             rightSidebarResizable={utilityRailResizable}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,13 @@
+import type React from 'react';
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useAuthStore } from './lib/stores/auth.js';
-import { useUiStore } from './lib/stores/ui.js';
+import {
+  useUiStore,
+  MAX_UTILITY_RAIL_WIDTH,
+  MIN_UTILITY_RAIL_WIDTH,
+  UTILITY_ICON_RAIL_WIDTH,
+} from './lib/stores/ui.js';
 import { useSessionsStore } from './lib/stores/sessions.js';
 import { useConfigStore } from './lib/stores/config.js';
 import { useBootStateStore } from './lib/stores/boot-state.js';
@@ -65,10 +71,10 @@ import SessionDetail from './components/SessionDetail.js';
 import FullPageDiff from './components/FullPageDiff.js';
 import FileViewerPane from './components/FileViewerPane.js';
 import { SplitPaneLayout } from './components/SplitPaneLayout.js';
-import {
-  FileTreeSidebar,
-  type FileTreeSidebarHandle,
-} from './components/FileTreeSidebar.js';
+import WorkspaceUtilityRail, {
+  utilityRailRenderedWidth,
+} from './components/WorkspaceUtilityRail.js';
+import type { FileTreeSidebarHandle } from './components/FileTreeSidebar.js';
 
 import './App.css';
 
@@ -358,12 +364,12 @@ function TerminalAreaContent({
   // Store access (layout / sidebar values not in derived state hook)
   const openSidebar = useUiStore((s) => s.openSidebar);
   const keyboardOpen = useUiStore((s) => s.keyboardOpen);
-  const rightSidebarCollapsed = useUiStore((s) => s.rightSidebarCollapsed);
-  const toggleRightSidebarCollapsed = useUiStore(
-    (s) => s.toggleRightSidebarCollapsed
+  const utilityRailByWorkspace = useUiStore((s) => s.utilityRailByWorkspace);
+  const getUtilityRailState = useUiStore((s) => s.getUtilityRailState);
+  const setUtilityRailWidth = useUiStore((s) => s.setUtilityRailWidth);
+  const toggleUtilityRailVisible = useUiStore(
+    (s) => s.toggleUtilityRailVisible
   );
-  const rightSidebarWidth = useUiStore((s) => s.rightSidebarWidth);
-  const saveRightSidebarWidth = useUiStore((s) => s.saveRightSidebarWidth);
   const fileViewerRatio = useUiStore((s) => s.fileViewerRatio);
   const saveFileViewerRatio = useUiStore((s) => s.saveFileViewerRatio);
   const openFileTab = useUiStore((s) => s.openFileTab);
@@ -453,10 +459,32 @@ function TerminalAreaContent({
         currentActiveSession?.repoPath ??
         '';
       const relative = resolveTerminalFilePath(clickedPath, cwd);
-      if (relative !== null) openFileTab(relative, false);
+      if (relative !== null) {
+        if (cwd) useUiStore.getState().openUtilityRailTab(cwd, 'files');
+        openFileTab(relative, false);
+      }
     },
     [openFileTab]
   );
+
+  const utilityRailState =
+    utilityRailByWorkspace[activeWorkspaceCwd] ??
+    getUtilityRailState(activeWorkspaceCwd);
+  const utilityRailWidth = utilityRailRenderedWidth(utilityRailState);
+  const utilityRailResizable =
+    utilityRailState.visible && utilityRailState.selectedRailTab !== null;
+
+  const handleUtilityRailWidthChange = useCallback(
+    (width: number) => {
+      if (!activeWorkspaceCwd || !utilityRailResizable) return;
+      setUtilityRailWidth(activeWorkspaceCwd, width - UTILITY_ICON_RAIL_WIDTH);
+    },
+    [activeWorkspaceCwd, setUtilityRailWidth, utilityRailResizable]
+  );
+
+  const handleToggleUtilityRail = useCallback(() => {
+    if (activeWorkspaceCwd) toggleUtilityRailVisible(activeWorkspaceCwd);
+  }, [activeWorkspaceCwd, toggleUtilityRailVisible]);
 
   return (
     <div className="terminal-area">
@@ -464,7 +492,7 @@ function TerminalAreaContent({
         title={sessionTitle}
         onMenuClick={openSidebar}
         onCommandClick={() => setSpotlightOpen(true)}
-        onRightSidebarClick={toggleRightSidebarCollapsed}
+        onRightSidebarClick={handleToggleUtilityRail}
         hidden={keyboardOpen}
       />
 
@@ -522,6 +550,7 @@ function TerminalAreaContent({
         <>
           <PrTopBar
             workspacePath={activeRepoPath ?? ''}
+            utilityRailWorkspacePath={activeWorkspaceCwd}
             branchName={activeSession?.branchName ?? ''}
             sessionId={activeSessionId}
             agentRunning={activeSession?.agentState === 'processing'}
@@ -529,12 +558,19 @@ function TerminalAreaContent({
           />
           <SplitPaneLayout
             fileViewerOpen={fileViewerOpen}
-            rightSidebarCollapsed={rightSidebarCollapsed}
-            rightSidebarWidth={rightSidebarWidth}
+            rightSidebarCollapsed={!utilityRailState.visible}
+            rightSidebarWidth={utilityRailWidth}
             fileViewerRatio={fileViewerRatio}
-            onRightSidebarWidthChange={saveRightSidebarWidth}
+            onRightSidebarWidthChange={handleUtilityRailWidthChange}
             onFileViewerRatioChange={saveFileViewerRatio}
-            onToggleRightSidebar={toggleRightSidebarCollapsed}
+            onToggleRightSidebar={handleToggleUtilityRail}
+            rightSidebarResizable={utilityRailResizable}
+            rightSidebarMinWidth={
+              MIN_UTILITY_RAIL_WIDTH + UTILITY_ICON_RAIL_WIDTH
+            }
+            rightSidebarMaxWidth={
+              MAX_UTILITY_RAIL_WIDTH + UTILITY_ICON_RAIL_WIDTH
+            }
             terminal={
               <>
                 <SessionTabBar
@@ -584,11 +620,14 @@ function TerminalAreaContent({
               />
             }
             rightSidebar={
-              <FileTreeSidebar
-                ref={fileTreeSidebarRef}
+              <WorkspaceUtilityRail
+                fileTreeSidebarRef={fileTreeSidebarRef}
                 workspacePath={activeWorkspaceCwd}
+                railState={utilityRailState}
                 changedFilesData={changedFilesData}
                 onFileSelect={handleFileSelect}
+                activeSession={activeSession}
+                workspaceSessions={workspaceSessions}
               />
             }
           />

--- a/frontend/src/components/PrTopBar.tsx
+++ b/frontend/src/components/PrTopBar.tsx
@@ -24,6 +24,7 @@ import './PrTopBar.css';
 
 export interface PrTopBarProps {
   workspacePath: string;
+  utilityRailWorkspacePath?: string;
   branchName: string;
   sessionId: string | null;
   agentRunning?: boolean;
@@ -321,6 +322,7 @@ function BranchSection({
 }
 
 interface PrActionsProps {
+  utilityRailWorkspacePath: string;
   isRefreshing: boolean;
   prLoading: boolean;
   prAction: PrAction;
@@ -330,6 +332,7 @@ interface PrActionsProps {
 }
 
 function PrActions({
+  utilityRailWorkspacePath,
   isRefreshing,
   prLoading,
   prAction,
@@ -337,10 +340,16 @@ function PrActions({
   onRefresh,
   onAction,
 }: PrActionsProps) {
-  const rightSidebarCollapsed = useUiStore((s) => s.rightSidebarCollapsed);
-  const toggleRightSidebarCollapsed = useUiStore(
-    (s) => s.toggleRightSidebarCollapsed
+  const utilityRailByWorkspace = useUiStore((s) => s.utilityRailByWorkspace);
+  const getUtilityRailState = useUiStore((s) => s.getUtilityRailState);
+  const toggleUtilityRailVisible = useUiStore(
+    (s) => s.toggleUtilityRailVisible
   );
+  const utilityRailState = utilityRailWorkspacePath
+    ? (utilityRailByWorkspace[utilityRailWorkspacePath] ??
+      getUtilityRailState(utilityRailWorkspacePath))
+    : null;
+  const utilityRailVisible = utilityRailState?.visible ?? true;
 
   return (
     <div className="bar-right">
@@ -408,13 +417,14 @@ function PrActions({
       )}
       <button
         className="sidebar-toggle-btn"
-        onClick={toggleRightSidebarCollapsed}
+        onClick={() => {
+          if (utilityRailWorkspacePath)
+            toggleUtilityRailVisible(utilityRailWorkspacePath);
+        }}
         aria-label={
-          rightSidebarCollapsed ? 'Show file sidebar' : 'Hide file sidebar'
+          utilityRailVisible ? 'Hide utility rail' : 'Show utility rail'
         }
-        title={
-          rightSidebarCollapsed ? 'Show file sidebar' : 'Hide file sidebar'
-        }
+        title={utilityRailVisible ? 'Hide utility rail' : 'Show utility rail'}
         type="button"
       >
         <svg
@@ -481,6 +491,7 @@ function deriveBarClass(pr: PrInfo | null): string {
 
 export function PrTopBar({
   workspacePath,
+  utilityRailWorkspacePath = workspacePath,
   branchName,
   sessionId,
   agentRunning = false,
@@ -601,6 +612,7 @@ export function PrTopBar({
         </>
       ) : null}
       <PrActions
+        utilityRailWorkspacePath={utilityRailWorkspacePath}
         isRefreshing={isRefreshing}
         prLoading={prLoading}
         prAction={prAction}

--- a/frontend/src/components/PrTopBar.tsx
+++ b/frontend/src/components/PrTopBar.tsx
@@ -20,6 +20,7 @@ import BranchSwitcher from './BranchSwitcher.js';
 import TargetBranchSwitcher from './TargetBranchSwitcher.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import RenameWarningModal from './dialogs/RenameWarningModal.js';
+import Tooltip from './Tooltip.js';
 import './PrTopBar.css';
 
 export interface PrTopBarProps {
@@ -268,29 +269,37 @@ function BranchSection({
             onSwitch={onBranchSwitch}
           />
           <div className="hover-icons">
-            <button
-              className="hover-icon"
-              onClick={onCopy}
-              title={copyFeedback ? 'Copied!' : 'Copy branch name'}
-              aria-label="Copy branch name"
-              type="button"
+            <Tooltip
+              label={copyFeedback ? 'copied' : 'copy branch name'}
+              actionId="pr.copy-branch-name"
             >
-              {copyFeedback ? COPY_SVG_CHECK : COPY_SVG_DEFAULT}
-            </button>
-            <button
-              className="hover-icon"
-              onClick={rename.startRename}
-              disabled={agentRunning}
-              title={
+              <button
+                className="hover-icon"
+                onClick={onCopy}
+                aria-label="Copy branch name"
+                type="button"
+              >
+                {copyFeedback ? COPY_SVG_CHECK : COPY_SVG_DEFAULT}
+              </button>
+            </Tooltip>
+            <Tooltip
+              label={
                 agentRunning
-                  ? 'Unavailable while agent is running'
-                  : 'Rename branch'
+                  ? 'unavailable while agent is running'
+                  : 'rename branch'
               }
-              aria-label="Rename branch"
-              type="button"
+              actionId="pr.rename-branch"
             >
-              {RENAME_SVG}
-            </button>
+              <button
+                className="hover-icon"
+                onClick={rename.startRename}
+                disabled={agentRunning}
+                aria-label="Rename branch"
+                type="button"
+              >
+                {RENAME_SVG}
+              </button>
+            </Tooltip>
           </div>
         </div>
       )}
@@ -353,39 +362,40 @@ function PrActions({
 
   return (
     <div className="bar-right">
-      <button
-        className={['refresh-btn', isRefreshing && 'refreshing']
-          .filter(Boolean)
-          .join(' ')}
-        onClick={onRefresh}
-        disabled={isRefreshing}
-        aria-label="Refresh PR data"
-        title="Refresh PR data"
-        type="button"
-      >
-        <svg
-          width="12"
-          height="12"
-          viewBox="0 0 16 16"
-          fill="none"
-          aria-hidden="true"
+      <Tooltip label="refresh PR data" actionId="pr.refresh">
+        <button
+          className={['refresh-btn', isRefreshing && 'refreshing']
+            .filter(Boolean)
+            .join(' ')}
+          onClick={onRefresh}
+          disabled={isRefreshing}
+          aria-label="Refresh PR data"
+          type="button"
         >
-          <path
-            d="M14 8A6 6 0 1 1 8 2"
-            stroke="currentColor"
-            strokeWidth="1.8"
-            strokeLinecap="round"
-          />
-          <path
-            d="M8 0L14 2L12 4"
-            stroke="currentColor"
-            strokeWidth="1.8"
-            strokeLinecap="round"
-            strokeLinejoin="round"
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 16 16"
             fill="none"
-          />
-        </svg>
-      </button>
+            aria-hidden="true"
+          >
+            <path
+              d="M14 8A6 6 0 1 1 8 2"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+            />
+            <path
+              d="M8 0L14 2L12 4"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+            />
+          </svg>
+        </button>
+      </Tooltip>
       {prLoading ? (
         <CipherText text="loading" loading={true} />
       ) : (
@@ -415,46 +425,49 @@ function PrActions({
           ) : null}
         </>
       )}
-      <button
-        className="sidebar-toggle-btn"
-        onClick={() => {
-          if (utilityRailWorkspacePath)
-            toggleUtilityRailVisible(utilityRailWorkspacePath);
-        }}
-        aria-label={
-          utilityRailVisible ? 'Hide utility rail' : 'Show utility rail'
-        }
-        title={utilityRailVisible ? 'Hide utility rail' : 'Show utility rail'}
-        type="button"
+      <Tooltip
+        label={utilityRailVisible ? 'hide utility rail' : 'show utility rail'}
       >
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 16 16"
-          fill="none"
-          aria-hidden="true"
+        <button
+          className="sidebar-toggle-btn"
+          onClick={() => {
+            if (utilityRailWorkspacePath)
+              toggleUtilityRailVisible(utilityRailWorkspacePath);
+          }}
+          aria-label={
+            utilityRailVisible ? 'Hide utility rail' : 'Show utility rail'
+          }
+          type="button"
         >
-          <rect
-            x="1"
-            y="2"
+          <svg
             width="14"
-            height="12"
-            stroke="currentColor"
-            strokeWidth="1.5"
+            height="14"
+            viewBox="0 0 16 16"
             fill="none"
-            strokeLinecap="square"
-          />
-          <line
-            x1="10"
-            y1="2"
-            x2="10"
-            y2="14"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="square"
-          />
-        </svg>
-      </button>
+            aria-hidden="true"
+          >
+            <rect
+              x="1"
+              y="2"
+              width="14"
+              height="12"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              fill="none"
+              strokeLinecap="square"
+            />
+            <line
+              x1="10"
+              y1="2"
+              x2="10"
+              y2="14"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="square"
+            />
+          </svg>
+        </button>
+      </Tooltip>
     </div>
   );
 }

--- a/frontend/src/components/PrTopBar.tsx
+++ b/frontend/src/components/PrTopBar.tsx
@@ -18,7 +18,7 @@ import CipherText from './CipherText.js';
 import TuiButton from './TuiButton.js';
 import BranchSwitcher from './BranchSwitcher.js';
 import TargetBranchSwitcher from './TargetBranchSwitcher.js';
-import { useUiStore } from '../lib/stores/ui.js';
+import { DEFAULT_UTILITY_RAIL_STATE, useUiStore } from '../lib/stores/ui.js';
 import RenameWarningModal from './dialogs/RenameWarningModal.js';
 import Tooltip from './Tooltip.js';
 import './PrTopBar.css';
@@ -349,14 +349,21 @@ function PrActions({
   onRefresh,
   onAction,
 }: PrActionsProps) {
-  const utilityRailByWorkspace = useUiStore((s) => s.utilityRailByWorkspace);
-  const getUtilityRailState = useUiStore((s) => s.getUtilityRailState);
+  const workspaceUtilityRailState = useUiStore((s) =>
+    utilityRailWorkspacePath
+      ? s.utilityRailByWorkspace[utilityRailWorkspacePath]
+      : undefined
+  );
+  const hydrateUtilityRailState = useUiStore((s) => s.hydrateUtilityRailState);
   const toggleUtilityRailVisible = useUiStore(
     (s) => s.toggleUtilityRailVisible
   );
+  useEffect(() => {
+    if (utilityRailWorkspacePath)
+      hydrateUtilityRailState(utilityRailWorkspacePath);
+  }, [hydrateUtilityRailState, utilityRailWorkspacePath]);
   const utilityRailState = utilityRailWorkspacePath
-    ? (utilityRailByWorkspace[utilityRailWorkspacePath] ??
-      getUtilityRailState(utilityRailWorkspacePath))
+    ? (workspaceUtilityRailState ?? DEFAULT_UTILITY_RAIL_STATE)
     : null;
   const utilityRailVisible = utilityRailState?.visible ?? true;
 

--- a/frontend/src/components/SplitPaneLayout.css
+++ b/frontend/src/components/SplitPaneLayout.css
@@ -25,29 +25,17 @@
   flex-shrink: 0;
   height: 100%;
   overflow: hidden;
-  background: var(--surface);
-  border-left: 1px solid var(--border);
+  background: var(--bg);
 }
 
 .resize-handle {
-  width: 6px;
+  width: 1px;
   position: relative;
   z-index: 5;
   flex-shrink: 0;
   cursor: col-resize;
   touch-action: none;
-  transition: background-color 0.15s ease;
-}
-
-.resize-handle::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 3px;
-  width: 1px;
   background: var(--border, #333);
-  pointer-events: none;
 }
 
 .resize-handle:hover,
@@ -55,27 +43,18 @@
   background-color: var(--accent, #d97757);
 }
 
-/* Collapsed resize handle — still visible so users can drag to expand */
 .resize-handle.collapsed {
-  width: 2px;
+  width: 0;
   background: transparent;
 }
 
-.resize-handle.collapsed::after {
-  left: 0;
-  width: 1px;
+.resize-handle.disabled {
+  cursor: default;
 }
 
-.resize-handle.collapsed:hover,
-.resize-handle.collapsed.active {
-  background: var(--accent, #d97757);
-}
-
-/* Collapsed right sidebar on desktop */
 .pane-right-sidebar.collapsed {
   width: 0 !important;
   min-width: 0;
-  border-left: none;
   overflow: hidden;
 }
 

--- a/frontend/src/components/SplitPaneLayout.css
+++ b/frontend/src/components/SplitPaneLayout.css
@@ -38,6 +38,15 @@
   background: var(--border, #333);
 }
 
+.resize-handle::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -4px;
+  right: -4px;
+}
+
 .resize-handle:hover,
 .resize-handle.active {
   background-color: var(--accent, #d97757);
@@ -50,6 +59,11 @@
 
 .resize-handle.disabled {
   cursor: default;
+}
+
+.resize-handle.disabled:hover,
+.resize-handle.disabled.active {
+  background-color: var(--border, #333);
 }
 
 .pane-right-sidebar.collapsed {

--- a/frontend/src/components/SplitPaneLayout.tsx
+++ b/frontend/src/components/SplitPaneLayout.tsx
@@ -23,6 +23,7 @@ export interface SplitPaneLayoutProps {
   /** Current file viewer ratio (0-1) */
   fileViewerRatio?: number;
   onRightSidebarWidthChange?: (width: number) => void;
+  onRightSidebarResizeEnd?: (width: number) => void;
   onFileViewerRatioChange?: (ratio: number) => void;
   onToggleRightSidebar?: () => void;
   rightSidebarResizable?: boolean;
@@ -39,6 +40,7 @@ export function SplitPaneLayout({
   rightSidebarWidth: externalRightSidebarWidth,
   fileViewerRatio: externalFileViewerRatio,
   onRightSidebarWidthChange,
+  onRightSidebarResizeEnd,
   onFileViewerRatioChange,
   onToggleRightSidebar,
   rightSidebarResizable = true,
@@ -66,6 +68,8 @@ export function SplitPaneLayout({
   draggingRef.current = dragging;
   const rightSidebarEffectiveWidthRef = useRef(rightSidebarEffectiveWidth);
   rightSidebarEffectiveWidthRef.current = rightSidebarEffectiveWidth;
+  const rightSidebarWidthValueRef = useRef(rightSidebarWidthValue);
+  rightSidebarWidthValueRef.current = rightSidebarWidthValue;
 
   const handlePointerDown = useCallback(
     (handle: DragHandle, e: React.PointerEvent<HTMLDivElement>) => {
@@ -96,6 +100,7 @@ export function SplitPaneLayout({
           Math.min(rightSidebarMaxWidth, newRightWidth)
         );
         setInternalRightSidebarWidth(clamped);
+        rightSidebarWidthValueRef.current = clamped;
         onRightSidebarWidthChange?.(clamped);
       } else if (currentDragging === FILE_VIEWER_HANDLE) {
         const rsw = rightSidebarEffectiveWidthRef.current;
@@ -114,6 +119,9 @@ export function SplitPaneLayout({
     }
 
     function onUp() {
+      if (draggingRef.current === RIGHT_SIDEBAR_HANDLE) {
+        onRightSidebarResizeEnd?.(rightSidebarWidthValueRef.current);
+      }
       setDragging(null);
     }
 
@@ -126,6 +134,7 @@ export function SplitPaneLayout({
   }, [
     dragging,
     onRightSidebarWidthChange,
+    onRightSidebarResizeEnd,
     onFileViewerRatioChange,
     rightSidebarMaxWidth,
     rightSidebarMinWidth,

--- a/frontend/src/components/SplitPaneLayout.tsx
+++ b/frontend/src/components/SplitPaneLayout.tsx
@@ -5,6 +5,10 @@ const MIN_RIGHT_SIDEBAR_WIDTH = 200;
 const MAX_RIGHT_SIDEBAR_WIDTH = 600;
 const MIN_TERMINAL_WIDTH = 300;
 const MIN_FILE_VIEWER_WIDTH = 300;
+const RIGHT_SIDEBAR_HANDLE = 'right-sidebar';
+const FILE_VIEWER_HANDLE = 'file-viewer';
+
+type DragHandle = typeof RIGHT_SIDEBAR_HANDLE | typeof FILE_VIEWER_HANDLE;
 
 export interface SplitPaneLayoutProps {
   terminal: React.ReactNode;
@@ -21,6 +25,9 @@ export interface SplitPaneLayoutProps {
   onRightSidebarWidthChange?: (width: number) => void;
   onFileViewerRatioChange?: (ratio: number) => void;
   onToggleRightSidebar?: () => void;
+  rightSidebarResizable?: boolean;
+  rightSidebarMinWidth?: number;
+  rightSidebarMaxWidth?: number;
 }
 
 export function SplitPaneLayout({
@@ -34,17 +41,25 @@ export function SplitPaneLayout({
   onRightSidebarWidthChange,
   onFileViewerRatioChange,
   onToggleRightSidebar,
+  rightSidebarResizable = true,
+  rightSidebarMinWidth = MIN_RIGHT_SIDEBAR_WIDTH,
+  rightSidebarMaxWidth = MAX_RIGHT_SIDEBAR_WIDTH,
 }: SplitPaneLayoutProps) {
-  const [internalRightSidebarWidth, setInternalRightSidebarWidth] = useState(320);
+  const [internalRightSidebarWidth, setInternalRightSidebarWidth] =
+    useState(320);
   const [internalFileViewerRatio, setInternalFileViewerRatio] = useState(0.4);
-  const [dragging, setDragging] = useState<'right-sidebar' | 'file-viewer' | null>(null);
+  const [dragging, setDragging] = useState<DragHandle | null>(null);
 
-  const rightSidebarWidthValue = externalRightSidebarWidth ?? internalRightSidebarWidth;
-  const fileViewerRatioValue = externalFileViewerRatio ?? internalFileViewerRatio;
+  const rightSidebarWidthValue =
+    externalRightSidebarWidth ?? internalRightSidebarWidth;
+  const fileViewerRatioValue =
+    externalFileViewerRatio ?? internalFileViewerRatio;
 
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const rightSidebarEffectiveWidth = rightSidebarCollapsed ? 0 : rightSidebarWidthValue;
+  const rightSidebarEffectiveWidth = rightSidebarCollapsed
+    ? 0
+    : rightSidebarWidthValue;
 
   // Use refs for values needed in document-level listeners
   const draggingRef = useRef(dragging);
@@ -53,9 +68,9 @@ export function SplitPaneLayout({
   rightSidebarEffectiveWidthRef.current = rightSidebarEffectiveWidth;
 
   const handlePointerDown = useCallback(
-    (handle: 'right-sidebar' | 'file-viewer', e: React.PointerEvent<HTMLDivElement>) => {
+    (handle: DragHandle, e: React.PointerEvent<HTMLDivElement>) => {
       e.preventDefault();
-      if (handle === 'right-sidebar' && rightSidebarCollapsed) {
+      if (handle === RIGHT_SIDEBAR_HANDLE && rightSidebarCollapsed) {
         onToggleRightSidebar?.();
       }
       setDragging(handle);
@@ -73,17 +88,25 @@ export function SplitPaneLayout({
       const rect = container.getBoundingClientRect();
       const currentDragging = draggingRef.current;
 
-      if (currentDragging === 'right-sidebar') {
+      if (currentDragging === RIGHT_SIDEBAR_HANDLE) {
+        if (!rightSidebarResizable) return;
         const newRightWidth = rect.right - e.clientX;
-        const clamped = Math.max(MIN_RIGHT_SIDEBAR_WIDTH, Math.min(MAX_RIGHT_SIDEBAR_WIDTH, newRightWidth));
+        const clamped = Math.max(
+          rightSidebarMinWidth,
+          Math.min(rightSidebarMaxWidth, newRightWidth)
+        );
         setInternalRightSidebarWidth(clamped);
         onRightSidebarWidthChange?.(clamped);
-      } else if (currentDragging === 'file-viewer') {
+      } else if (currentDragging === FILE_VIEWER_HANDLE) {
         const rsw = rightSidebarEffectiveWidthRef.current;
         const available = rect.width - rsw;
         const fileViewerWidth = rect.right - rsw - e.clientX;
         const terminalWidth = e.clientX - rect.left;
-        if (terminalWidth < MIN_TERMINAL_WIDTH || fileViewerWidth < MIN_FILE_VIEWER_WIDTH) return;
+        if (
+          terminalWidth < MIN_TERMINAL_WIDTH ||
+          fileViewerWidth < MIN_FILE_VIEWER_WIDTH
+        )
+          return;
         const ratio = fileViewerWidth / available;
         setInternalFileViewerRatio(ratio);
         onFileViewerRatioChange?.(ratio);
@@ -100,13 +123,22 @@ export function SplitPaneLayout({
       document.removeEventListener('pointermove', onMove);
       document.removeEventListener('pointerup', onUp);
     };
-  }, [dragging, onRightSidebarWidthChange, onFileViewerRatioChange]);
+  }, [
+    dragging,
+    onRightSidebarWidthChange,
+    onFileViewerRatioChange,
+    rightSidebarMaxWidth,
+    rightSidebarMinWidth,
+    rightSidebarResizable,
+  ]);
 
   return (
     <div className="split-pane-layout" ref={containerRef}>
       <div
         className="pane-terminal"
-        style={{ flex: fileViewerOpen ? String(1 - fileViewerRatioValue) : '1' }}
+        style={{
+          flex: fileViewerOpen ? String(1 - fileViewerRatioValue) : '1',
+        }}
       >
         {terminal}
       </div>
@@ -114,10 +146,15 @@ export function SplitPaneLayout({
       {fileViewerOpen ? (
         <>
           <div
-            className={['resize-handle', dragging === 'file-viewer' && 'active'].filter(Boolean).join(' ')}
+            className={[
+              'resize-handle',
+              dragging === FILE_VIEWER_HANDLE && 'active',
+            ]
+              .filter(Boolean)
+              .join(' ')}
             role="separator"
             aria-label="resize terminal and file viewer"
-            onPointerDown={(e) => handlePointerDown('file-viewer', e)}
+            onPointerDown={(e) => handlePointerDown(FILE_VIEWER_HANDLE, e)}
           />
           <div
             className="pane-file-viewer"
@@ -134,20 +171,30 @@ export function SplitPaneLayout({
             className={[
               'resize-handle',
               'resize-handle-right',
-              dragging === 'right-sidebar' && 'active',
+              dragging === RIGHT_SIDEBAR_HANDLE && 'active',
               rightSidebarCollapsed && 'collapsed',
-            ].filter(Boolean).join(' ')}
+              !rightSidebarResizable && 'disabled',
+            ]
+              .filter(Boolean)
+              .join(' ')}
             role="separator"
             aria-label="resize right sidebar"
-            onPointerDown={(e) => handlePointerDown('right-sidebar', e)}
+            onPointerDown={(e) => {
+              if (rightSidebarResizable)
+                handlePointerDown(RIGHT_SIDEBAR_HANDLE, e);
+            }}
           />
           <div
             className={[
               'pane-right-sidebar',
               rightSidebarCollapsed && 'collapsed',
               !rightSidebarCollapsed && 'mobile-open',
-            ].filter(Boolean).join(' ')}
-            style={{ width: rightSidebarCollapsed ? 0 : rightSidebarWidthValue }}
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            style={{
+              width: rightSidebarCollapsed ? 0 : rightSidebarWidthValue,
+            }}
           >
             <button
               className="mobile-sidebar-close-btn"

--- a/frontend/src/components/Tooltip.css
+++ b/frontend/src/components/Tooltip.css
@@ -1,0 +1,92 @@
+.tui-tooltip {
+  position: relative;
+  display: inline-flex;
+  min-width: 0;
+}
+
+.tui-tooltip__bubble {
+  position: absolute;
+  z-index: 1000;
+  display: grid;
+  gap: 4px;
+  min-width: max-content;
+  max-width: 260px;
+  padding: 6px 8px;
+  background: var(--bg, #000);
+  border: 1px solid var(--border, #333);
+  color: var(--text, #e0e0e0);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs, 0.75rem);
+  line-height: 1.35;
+  border-radius: 0;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  white-space: normal;
+}
+
+.tui-tooltip:hover .tui-tooltip__bubble,
+.tui-tooltip:focus-within .tui-tooltip__bubble {
+  opacity: 1;
+  visibility: visible;
+}
+
+.tui-tooltip--top .tui-tooltip__bubble {
+  left: 50%;
+  bottom: calc(100% + 6px);
+  transform: translateX(-50%);
+}
+
+.tui-tooltip--right .tui-tooltip__bubble {
+  top: 50%;
+  left: calc(100% + 6px);
+  transform: translateY(-50%);
+}
+
+.tui-tooltip--bottom .tui-tooltip__bubble {
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.tui-tooltip--left .tui-tooltip__bubble {
+  top: 50%;
+  right: calc(100% + 6px);
+  transform: translateY(-50%);
+}
+
+.tui-tooltip__main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.tui-tooltip__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tui-tooltip__shortcut {
+  flex-shrink: 0;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs, 0.75rem);
+  color: var(--text-muted, #888);
+  border: 1px solid var(--border, #333);
+  padding: 1px 6px;
+  border-radius: 0;
+  background: transparent;
+}
+
+.tui-tooltip__description {
+  color: var(--text-muted, #888);
+  max-width: 240px;
+}
+
+@media (pointer: coarse) {
+  .tui-tooltip__bubble {
+    display: none;
+  }
+}

--- a/frontend/src/components/Tooltip.css
+++ b/frontend/src/components/Tooltip.css
@@ -26,7 +26,7 @@
 }
 
 .tui-tooltip:hover .tui-tooltip__bubble,
-.tui-tooltip:focus-within .tui-tooltip__bubble {
+.tui-tooltip:has(:focus-visible) .tui-tooltip__bubble {
   opacity: 1;
   visibility: visible;
 }

--- a/frontend/src/components/Tooltip.tsx
+++ b/frontend/src/components/Tooltip.tsx
@@ -1,0 +1,75 @@
+import React, { useId } from 'react';
+import { getAction } from '../lib/actions/registry.js';
+import { formatShortcut } from '../lib/actions/shortcuts.js';
+import { isMac } from '../lib/utils.js';
+import './Tooltip.css';
+
+export type TooltipSide = 'top' | 'right' | 'bottom' | 'left';
+
+export interface TooltipProps {
+  children: React.ReactElement;
+  label?: string;
+  description?: string;
+  actionId?: string;
+  shortcut?: string;
+  side?: TooltipSide;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function Tooltip({
+  children,
+  label,
+  description,
+  actionId,
+  shortcut,
+  side = 'top',
+  disabled = false,
+  className = '',
+}: TooltipProps) {
+  const tooltipId = useId();
+  const action = actionId ? getAction(actionId) : undefined;
+  const tooltipLabel = label ?? action?.label;
+  const tooltipDescription = description ?? action?.description;
+  const shortcutKey = shortcut ?? action?.shortcut?.key;
+  const formattedShortcut = shortcutKey
+    ? formatShortcut(shortcutKey, isMac)
+    : null;
+
+  if (
+    disabled ||
+    (!tooltipLabel && !tooltipDescription && !formattedShortcut)
+  ) {
+    return children;
+  }
+
+  const child = React.cloneElement(children, {
+    'aria-describedby': tooltipId,
+    title: undefined,
+  } as Partial<React.HTMLAttributes<HTMLElement>>);
+
+  return (
+    <span
+      className={['tui-tooltip', `tui-tooltip--${side}`, className]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      {child}
+      <span id={tooltipId} role="tooltip" className="tui-tooltip__bubble">
+        <span className="tui-tooltip__main">
+          {tooltipLabel ? (
+            <span className="tui-tooltip__label">{tooltipLabel}</span>
+          ) : null}
+          {formattedShortcut ? (
+            <kbd className="tui-tooltip__shortcut">{formattedShortcut}</kbd>
+          ) : null}
+        </span>
+        {tooltipDescription ? (
+          <span className="tui-tooltip__description">{tooltipDescription}</span>
+        ) : null}
+      </span>
+    </span>
+  );
+}
+
+export default Tooltip;

--- a/frontend/src/components/TuiButton.tsx
+++ b/frontend/src/components/TuiButton.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
+import Tooltip from './Tooltip.js';
+import type { TooltipSide } from './Tooltip.js';
 import './TuiButton.css';
 
-export type TuiButtonVariant = 'primary' | 'ghost' | 'danger' | 'success' | 'info';
+export type TuiButtonVariant =
+  | 'primary'
+  | 'ghost'
+  | 'danger'
+  | 'success'
+  | 'info';
 
 export interface TuiButtonProps {
   variant?: TuiButtonVariant;
@@ -10,9 +17,20 @@ export interface TuiButtonProps {
   type?: 'button' | 'submit' | 'reset';
   href?: string;
   shortcut?: string;
-  onClick?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
-  onMouseEnter?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
-  onMouseLeave?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
+  tooltip?: string;
+  tooltipDescription?: string;
+  tooltipActionId?: string;
+  tooltipShortcut?: string;
+  tooltipSide?: TooltipSide;
+  onClick?: (
+    e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>
+  ) => void;
+  onMouseEnter?: (
+    e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>
+  ) => void;
+  onMouseLeave?: (
+    e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>
+  ) => void;
   className?: string;
   children: React.ReactNode;
   [key: string]: unknown;
@@ -25,6 +43,11 @@ export const TuiButton: React.FC<TuiButtonProps> = ({
   type = 'button',
   href,
   shortcut,
+  tooltip,
+  tooltipDescription,
+  tooltipActionId,
+  tooltipShortcut,
+  tooltipSide,
   onClick,
   onMouseEnter,
   onMouseLeave,
@@ -47,8 +70,30 @@ export const TuiButton: React.FC<TuiButtonProps> = ({
     <kbd className="tui-btn__shortcut">{shortcut}</kbd>
   ) : null;
 
-  if (href) {
+  function withTooltip(element: React.ReactElement) {
+    if (
+      !tooltip &&
+      !tooltipDescription &&
+      !tooltipActionId &&
+      !tooltipShortcut
+    ) {
+      return element;
+    }
     return (
+      <Tooltip
+        {...(tooltip ? { label: tooltip } : {})}
+        {...(tooltipDescription ? { description: tooltipDescription } : {})}
+        {...(tooltipActionId ? { actionId: tooltipActionId } : {})}
+        {...(tooltipShortcut ? { shortcut: tooltipShortcut } : {})}
+        {...(tooltipSide ? { side: tooltipSide } : {})}
+      >
+        {element}
+      </Tooltip>
+    );
+  }
+
+  if (href) {
+    return withTooltip(
       <a
         className={classes}
         href={href}
@@ -65,7 +110,7 @@ export const TuiButton: React.FC<TuiButtonProps> = ({
     );
   }
 
-  return (
+  return withTooltip(
     <button
       className={classes}
       type={type}

--- a/frontend/src/components/UtilityRailFilesPanel.tsx
+++ b/frontend/src/components/UtilityRailFilesPanel.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import {
+  FileTreeSidebar,
+  type FileTreeSidebarHandle,
+} from './FileTreeSidebar.js';
+import './WorkspaceUtilityRail.css';
+
+export interface UtilityRailFilesPanelProps {
+  workspacePath: string;
+  changedFilesData: string[];
+  onFileSelect: (filePath: string, isChanged: boolean) => void;
+  fileTreeSidebarRef?: React.RefObject<FileTreeSidebarHandle | null>;
+}
+
+export function UtilityRailFilesPanel({
+  workspacePath,
+  changedFilesData,
+  onFileSelect,
+  fileTreeSidebarRef,
+}: UtilityRailFilesPanelProps) {
+  return (
+    <FileTreeSidebar
+      ref={fileTreeSidebarRef}
+      workspacePath={workspacePath}
+      changedFilesData={changedFilesData}
+      onFileSelect={onFileSelect}
+    />
+  );
+}
+
+export default UtilityRailFilesPanel;

--- a/frontend/src/components/UtilityRailLogsPanel.tsx
+++ b/frontend/src/components/UtilityRailLogsPanel.tsx
@@ -1,0 +1,42 @@
+import type { SessionSummary } from '../lib/types.js';
+import './WorkspaceUtilityRail.css';
+
+export interface UtilityRailLogsPanelProps {
+  activeSession?: SessionSummary | undefined;
+}
+
+export function UtilityRailLogsPanel({
+  activeSession,
+}: UtilityRailLogsPanelProps) {
+  const activity = activeSession?.currentActivity;
+  return (
+    <div className="utility-simple-panel">
+      <div className="utility-kv-row">
+        <span>session</span>
+        <span>{activeSession?.displayName ?? activeSession?.id ?? 'none'}</span>
+      </div>
+      <div className="utility-kv-row">
+        <span>branch</span>
+        <span>{activeSession?.branchName ?? '-'}</span>
+      </div>
+      <div className="utility-kv-row">
+        <span>state</span>
+        <span>{activeSession?.agentState ?? 'idle'}</span>
+      </div>
+      <div className="utility-log-box">
+        {activity ? (
+          <>
+            <div>{activity.tool}</div>
+            {activity.detail ? (
+              <div className="utility-muted">{activity.detail}</div>
+            ) : null}
+          </>
+        ) : (
+          <div className="utility-muted">no current output event</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default UtilityRailLogsPanel;

--- a/frontend/src/components/UtilityRailReviewPanel.tsx
+++ b/frontend/src/components/UtilityRailReviewPanel.tsx
@@ -1,0 +1,184 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type { ChangedFile } from '../lib/types.js';
+import {
+  fetchChangedFiles,
+  fetchDefaultBranch,
+  fetchFileDiff,
+} from '../lib/api.js';
+import { diffSourceToBase } from '../lib/diff-utils.js';
+import { generateFileSummary } from '../lib/diff-summary.js';
+import { useUiStore } from '../lib/stores/ui.js';
+import DiffSourceToggle from './DiffSourceToggle.js';
+import DiffViewer from './DiffViewer.js';
+import { DiffFileSidebar } from './DiffFileSidebar.js';
+import './WorkspaceUtilityRail.css';
+
+export interface UtilityRailReviewPanelProps {
+  workspacePath: string;
+}
+
+export function UtilityRailReviewPanel({
+  workspacePath,
+}: UtilityRailReviewPanelProps) {
+  const fileDiffSource = useUiStore((s) => s.fileDiffSource);
+  const fileDiffDefaultBranch = useUiStore((s) => s.fileDiffDefaultBranch);
+  const fileDiffViewMode = useUiStore((s) => s.fileDiffViewMode);
+  const setFileDiffSource = useUiStore((s) => s.setFileDiffSource);
+  const setFileDiffDefaultBranch = useUiStore(
+    (s) => s.setFileDiffDefaultBranch
+  );
+  const setFileDiffViewMode = useUiStore((s) => s.setFileDiffViewMode);
+  const railState = useUiStore((s) => s.getUtilityRailState(workspacePath));
+  const [files, setFiles] = useState<ChangedFile[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [diffLoading, setDiffLoading] = useState(false);
+  const [activeFilePath, setActiveFilePath] = useState<string | null>(
+    railState.reviewFilePath ?? null
+  );
+  const [fileDiff, setFileDiff] = useState('');
+  const [summary, setSummary] = useState('');
+  const filesRef = useRef<ChangedFile[]>([]);
+  filesRef.current = files;
+
+  const base = useMemo(
+    () => diffSourceToBase(fileDiffSource, fileDiffDefaultBranch) ?? '',
+    [fileDiffSource, fileDiffDefaultBranch]
+  );
+
+  useEffect(() => {
+    if (!workspacePath) return;
+    let cancelled = false;
+    setLoading(true);
+    fetchChangedFiles(workspacePath, base)
+      .then((data) => {
+        if (cancelled) return;
+        setFiles(data.files);
+        setActiveFilePath((prev) => {
+          if (prev && data.files.some((file) => file.path === prev))
+            return prev;
+          return data.files[0]?.path ?? null;
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setFiles([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspacePath, base]);
+
+  useEffect(() => {
+    if (!workspacePath || fileDiffDefaultBranch !== 'main') return;
+    fetchDefaultBranch(workspacePath)
+      .then(setFileDiffDefaultBranch)
+      .catch(() => undefined);
+  }, [workspacePath, fileDiffDefaultBranch, setFileDiffDefaultBranch]);
+
+  useEffect(() => {
+    if (!workspacePath || !activeFilePath) {
+      setFileDiff('');
+      setSummary('');
+      return;
+    }
+    let cancelled = false;
+    setDiffLoading(true);
+    setSummary('');
+    fetchFileDiff(workspacePath, activeFilePath, base)
+      .then((data) => {
+        if (cancelled) return;
+        setFileDiff(data.diff);
+        const activeFile = filesRef.current.find(
+          (file) => file.path === activeFilePath
+        );
+        if (activeFile && data.diff) {
+          setSummary(
+            generateFileSummary(data.diff, activeFilePath, activeFile.status)
+          );
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setFileDiff('');
+      })
+      .finally(() => {
+        if (!cancelled) setDiffLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [workspacePath, activeFilePath, base]);
+
+  const handleSelectFile = useCallback((file: ChangedFile) => {
+    setActiveFilePath(file.path);
+  }, []);
+
+  const handleModeToggle = useCallback(() => {
+    setFileDiffViewMode(
+      fileDiffViewMode === 'unified' ? 'side-by-side' : 'unified'
+    );
+  }, [fileDiffViewMode, setFileDiffViewMode]);
+
+  return (
+    <div className="utility-review-panel">
+      <div className="utility-panel-toolbar">
+        <DiffSourceToggle
+          value={fileDiffSource}
+          onchange={setFileDiffSource}
+          defaultBranch={fileDiffDefaultBranch}
+        />
+        <button
+          className="utility-panel-btn"
+          onClick={handleModeToggle}
+          type="button"
+        >
+          {fileDiffViewMode === 'unified' ? '[split]' : '[unified]'}
+        </button>
+      </div>
+      <div className="utility-review-body">
+        <div className="utility-review-files">
+          {loading ? (
+            <div className="utility-empty">loading files...</div>
+          ) : files.length === 0 ? (
+            <div className="utility-empty">no changed files</div>
+          ) : (
+            <DiffFileSidebar
+              files={files}
+              activeFile={activeFilePath}
+              onSelectFile={handleSelectFile}
+            />
+          )}
+        </div>
+        <div className="utility-review-diff">
+          {activeFilePath ? (
+            <>
+              <div className="utility-review-title">
+                <span>{activeFilePath}</span>
+                {summary ? (
+                  <span className="utility-muted">{summary}</span>
+                ) : null}
+              </div>
+              <DiffViewer
+                diff={fileDiff}
+                filePath={activeFilePath}
+                loading={diffLoading}
+                mode={fileDiffViewMode}
+              />
+            </>
+          ) : (
+            <div className="utility-empty">select a file</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default UtilityRailReviewPanel;

--- a/frontend/src/components/UtilityRailReviewPanel.tsx
+++ b/frontend/src/components/UtilityRailReviewPanel.tsx
@@ -21,35 +21,40 @@ import './WorkspaceUtilityRail.css';
 
 export interface UtilityRailReviewPanelProps {
   workspacePath: string;
+  reviewFilePath?: string | undefined;
 }
 
 export function UtilityRailReviewPanel({
   workspacePath,
+  reviewFilePath,
 }: UtilityRailReviewPanelProps) {
   const fileDiffSource = useUiStore((s) => s.fileDiffSource);
-  const fileDiffDefaultBranch = useUiStore((s) => s.fileDiffDefaultBranch);
   const fileDiffViewMode = useUiStore((s) => s.fileDiffViewMode);
   const setFileDiffSource = useUiStore((s) => s.setFileDiffSource);
-  const setFileDiffDefaultBranch = useUiStore(
-    (s) => s.setFileDiffDefaultBranch
-  );
   const setFileDiffViewMode = useUiStore((s) => s.setFileDiffViewMode);
-  const railState = useUiStore((s) => s.getUtilityRailState(workspacePath));
+  const [defaultBranch, setDefaultBranch] = useState('main');
   const [files, setFiles] = useState<ChangedFile[]>([]);
   const [loading, setLoading] = useState(false);
   const [diffLoading, setDiffLoading] = useState(false);
   const [activeFilePath, setActiveFilePath] = useState<string | null>(
-    railState.reviewFilePath ?? null
+    reviewFilePath ?? null
   );
   const [fileDiff, setFileDiff] = useState('');
   const [summary, setSummary] = useState('');
   const filesRef = useRef<ChangedFile[]>([]);
-  filesRef.current = files;
 
   const base = useMemo(
-    () => diffSourceToBase(fileDiffSource, fileDiffDefaultBranch) ?? '',
-    [fileDiffSource, fileDiffDefaultBranch]
+    () => diffSourceToBase(fileDiffSource, defaultBranch) ?? '',
+    [fileDiffSource, defaultBranch]
   );
+
+  useEffect(() => {
+    filesRef.current = files;
+  }, [files]);
+
+  useEffect(() => {
+    setActiveFilePath(reviewFilePath ?? null);
+  }, [reviewFilePath, workspacePath]);
 
   useEffect(() => {
     if (!workspacePath) return;
@@ -77,11 +82,18 @@ export function UtilityRailReviewPanel({
   }, [workspacePath, base]);
 
   useEffect(() => {
-    if (!workspacePath || fileDiffDefaultBranch !== 'main') return;
+    if (!workspacePath) return;
+    let cancelled = false;
+    setDefaultBranch('main');
     fetchDefaultBranch(workspacePath)
-      .then(setFileDiffDefaultBranch)
+      .then((branch) => {
+        if (!cancelled) setDefaultBranch(branch);
+      })
       .catch(() => undefined);
-  }, [workspacePath, fileDiffDefaultBranch, setFileDiffDefaultBranch]);
+    return () => {
+      cancelled = true;
+    };
+  }, [workspacePath]);
 
   useEffect(() => {
     if (!workspacePath || !activeFilePath) {
@@ -132,7 +144,7 @@ export function UtilityRailReviewPanel({
         <DiffSourceToggle
           value={fileDiffSource}
           onchange={setFileDiffSource}
-          defaultBranch={fileDiffDefaultBranch}
+          defaultBranch={defaultBranch}
         />
         <button
           className="utility-panel-btn"

--- a/frontend/src/components/UtilityRailStatsPanel.tsx
+++ b/frontend/src/components/UtilityRailStatsPanel.tsx
@@ -1,0 +1,93 @@
+import type { SessionSummary } from '../lib/types.js';
+import { useTelemetryStore } from '../lib/stores/telemetry.js';
+import { formatCompact } from '../lib/utils.js';
+import './WorkspaceUtilityRail.css';
+
+export interface UtilityRailStatsPanelProps {
+  activeSession?: SessionSummary | undefined;
+  workspaceSessions: SessionSummary[];
+}
+
+function formatMoney(value: number | null): string {
+  return value === null ? '~$-' : `~$${value.toFixed(2)}`;
+}
+
+function formatPercent(value: number | null): string {
+  return value === null ? '-%' : `${Math.round(value)}%`;
+}
+
+export function UtilityRailStatsPanel({
+  activeSession,
+  workspaceSessions,
+}: UtilityRailStatsPanelProps) {
+  const summarizeSessionSetTelemetry = useTelemetryStore(
+    (s) => s.summarizeSessionSetTelemetry
+  );
+  const summarizeSessionTelemetry = useTelemetryStore(
+    (s) => s.summarizeSessionTelemetry
+  );
+  const aggregate = summarizeSessionSetTelemetry(workspaceSessions);
+  const activeTelemetry = activeSession
+    ? summarizeSessionTelemetry(activeSession.id)
+    : null;
+
+  return (
+    <div className="utility-simple-panel">
+      <div className="utility-section-title">active session</div>
+      <div className="utility-kv-row">
+        <span>model</span>
+        <span>{activeTelemetry?.model ?? '-'}</span>
+      </div>
+      <div className="utility-kv-row">
+        <span>context</span>
+        <span>
+          {activeTelemetry && activeTelemetry.contextPercent >= 0
+            ? `${Math.round(activeTelemetry.contextPercent)}%`
+            : '-%'}
+        </span>
+      </div>
+      <div className="utility-kv-row">
+        <span>tokens</span>
+        <span>
+          d
+          {activeTelemetry
+            ? formatCompact(activeTelemetry.totalInputTokens)
+            : '-'}{' '}
+          u
+          {activeTelemetry
+            ? formatCompact(activeTelemetry.totalOutputTokens)
+            : '-'}
+        </span>
+      </div>
+      <div className="utility-kv-row">
+        <span>cost</span>
+        <span>{formatMoney(activeTelemetry?.costUsd ?? null)}</span>
+      </div>
+
+      <div className="utility-section-title">workspace</div>
+      <div className="utility-kv-row">
+        <span>tracked</span>
+        <span>
+          {aggregate.trackedSessions}/{aggregate.totalSessions}
+        </span>
+      </div>
+      <div className="utility-kv-row">
+        <span>max context</span>
+        <span>{formatPercent(aggregate.maxContextPercent)}</span>
+      </div>
+      <div className="utility-kv-row">
+        <span>tokens</span>
+        <span>
+          d{formatCompact(aggregate.totalInputTokens)} u
+          {formatCompact(aggregate.totalOutputTokens)}
+        </span>
+      </div>
+      <div className="utility-kv-row">
+        <span>cost</span>
+        <span>{formatMoney(aggregate.totalCostUsd)}</span>
+      </div>
+    </div>
+  );
+}
+
+export default UtilityRailStatsPanel;

--- a/frontend/src/components/UtilityRailStatsPanel.tsx
+++ b/frontend/src/components/UtilityRailStatsPanel.tsx
@@ -49,7 +49,7 @@ export function UtilityRailStatsPanel({
       <div className="utility-kv-row">
         <span>tokens</span>
         <span>
-          d
+          d{' '}
           {activeTelemetry
             ? formatCompact(activeTelemetry.totalInputTokens)
             : '-'}{' '}
@@ -78,7 +78,7 @@ export function UtilityRailStatsPanel({
       <div className="utility-kv-row">
         <span>tokens</span>
         <span>
-          d{formatCompact(aggregate.totalInputTokens)} u
+          d {formatCompact(aggregate.totalInputTokens)} u{' '}
           {formatCompact(aggregate.totalOutputTokens)}
         </span>
       </div>

--- a/frontend/src/components/WorkspaceUtilityRail.css
+++ b/frontend/src/components/WorkspaceUtilityRail.css
@@ -1,0 +1,210 @@
+.workspace-utility-rail {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--utility-icon-rail-width, 48px);
+  height: 100%;
+  min-width: 0;
+  background: var(--bg, #000);
+}
+
+.workspace-utility-rail--icons-only {
+  grid-template-columns: var(--utility-icon-rail-width, 48px);
+}
+
+.utility-selected-pane {
+  min-width: 0;
+  height: 100%;
+  display: grid;
+  grid-template-rows: 38px 1fr;
+  overflow: hidden;
+  border-right: 1px solid var(--border, #333);
+}
+
+.workspace-utility-rail--icons-only .utility-selected-pane {
+  display: none;
+}
+
+.utility-pane-header {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 10px;
+  border-bottom: 1px solid var(--border, #333);
+}
+
+.utility-pane-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text, #e0e0e0);
+  font-size: var(--font-size-sm, 0.8125rem);
+  font-weight: 600;
+}
+
+.utility-pane-context,
+.utility-muted {
+  color: var(--text-muted, #888);
+  font-size: var(--font-size-xs, 0.75rem);
+}
+
+.utility-pane-body {
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.utility-icon-rail {
+  height: 100%;
+  background: var(--bg, #000);
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  min-width: var(--utility-icon-rail-width, 48px);
+}
+
+.utility-icon-group {
+  display: grid;
+}
+
+.utility-icon-btn {
+  width: var(--utility-icon-rail-width, 48px);
+  height: 48px;
+  display: grid;
+  place-items: center;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--border, #333);
+  color: var(--text-muted, #888);
+  cursor: pointer;
+  border-radius: 0;
+}
+
+.utility-icon-btn:hover {
+  background: var(--surface-hover, #141414);
+  color: var(--text, #e0e0e0);
+}
+
+.utility-icon-btn.active {
+  color: var(--accent, #d97757);
+  box-shadow: inset 2px 0 0 var(--accent, #d97757);
+}
+
+.utility-icon-btn svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: square;
+  stroke-linejoin: miter;
+}
+
+.utility-icon-btn--bottom {
+  align-self: end;
+  font-size: var(--font-size-sm, 0.8125rem);
+}
+
+.utility-review-panel {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100%;
+  min-height: 0;
+}
+
+.utility-panel-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border, #333);
+}
+
+.utility-panel-btn {
+  background: transparent;
+  border: 1px solid var(--border, #333);
+  color: var(--text-muted, #888);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs, 0.75rem);
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.utility-panel-btn:hover {
+  color: var(--text, #e0e0e0);
+  border-color: var(--accent, #d97757);
+}
+
+.utility-review-body {
+  min-height: 0;
+  display: grid;
+  grid-template-rows: minmax(120px, 34%) 1fr;
+}
+
+.utility-review-files {
+  min-height: 0;
+  overflow: auto;
+  border-bottom: 1px solid var(--border, #333);
+}
+
+.utility-review-diff {
+  min-height: 0;
+  overflow: auto;
+}
+
+.utility-review-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border, #333);
+  color: var(--text, #e0e0e0);
+  font-size: var(--font-size-xs, 0.75rem);
+}
+
+.utility-empty {
+  padding: 12px 8px;
+  color: var(--text-muted, #888);
+  font-size: var(--font-size-xs, 0.75rem);
+}
+
+.utility-simple-panel {
+  padding: 10px;
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  height: 100%;
+  overflow: auto;
+}
+
+.utility-section-title {
+  margin-top: 8px;
+  color: var(--text, #e0e0e0);
+  font-size: var(--font-size-xs, 0.75rem);
+}
+
+.utility-kv-row {
+  min-height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--border, #333);
+  padding: 0 8px;
+  color: var(--text-muted, #888);
+  font-size: var(--font-size-xs, 0.75rem);
+}
+
+.utility-kv-row span:last-child {
+  color: var(--text, #e0e0e0);
+  text-align: right;
+}
+
+.utility-log-box {
+  min-height: 160px;
+  border: 1px solid var(--border, #333);
+  padding: 8px;
+  color: var(--text, #e0e0e0);
+  font-size: var(--font-size-xs, 0.75rem);
+}

--- a/frontend/src/components/WorkspaceUtilityRail.css
+++ b/frontend/src/components/WorkspaceUtilityRail.css
@@ -55,6 +55,16 @@
   overflow: hidden;
 }
 
+.utility-pane-panel {
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+.utility-pane-panel[hidden] {
+  display: none;
+}
+
 .utility-icon-rail {
   height: 100%;
   background: var(--bg, #000);
@@ -94,15 +104,10 @@
   width: 18px;
   height: 18px;
   fill: none;
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-width: 1.5;
   stroke-linecap: square;
   stroke-linejoin: miter;
-}
-
-.utility-icon-btn--bottom {
-  align-self: end;
-  font-size: var(--font-size-sm, 0.8125rem);
 }
 
 .utility-review-panel {

--- a/frontend/src/components/WorkspaceUtilityRail.tsx
+++ b/frontend/src/components/WorkspaceUtilityRail.tsx
@@ -1,0 +1,198 @@
+import React, { useCallback } from 'react';
+import type { SessionSummary } from '../lib/types.js';
+import {
+  useUiStore,
+  type UtilityRailTab,
+  type WorkspaceUtilityRailState,
+  UTILITY_ICON_RAIL_WIDTH,
+} from '../lib/stores/ui.js';
+import type { FileTreeSidebarHandle } from './FileTreeSidebar.js';
+import UtilityRailFilesPanel from './UtilityRailFilesPanel.js';
+import UtilityRailReviewPanel from './UtilityRailReviewPanel.js';
+import UtilityRailLogsPanel from './UtilityRailLogsPanel.js';
+import UtilityRailStatsPanel from './UtilityRailStatsPanel.js';
+import './WorkspaceUtilityRail.css';
+
+const TAB_META: Array<{
+  id: UtilityRailTab;
+  label: string;
+  icon: React.ReactNode;
+}> = [
+  {
+    id: 'files',
+    label: 'file browser',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M5 3h10l4 4v14H5z" />
+        <path d="M15 3v5h5" />
+      </svg>
+    ),
+  },
+  {
+    id: 'review',
+    label: 'git diff',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M7 4v16" />
+        <path d="M17 4v16" />
+        <path d="M7 8h10" />
+        <path d="M7 16h10" />
+      </svg>
+    ),
+  },
+  {
+    id: 'logs',
+    label: 'logs',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M5 5h14" />
+        <path d="M5 12h14" />
+        <path d="M5 19h10" />
+      </svg>
+    ),
+  },
+  {
+    id: 'stats',
+    label: 'stats',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M5 19V9" />
+        <path d="M12 19V5" />
+        <path d="M19 19v-7" />
+      </svg>
+    ),
+  },
+];
+
+export interface WorkspaceUtilityRailProps {
+  workspacePath: string;
+  railState: WorkspaceUtilityRailState;
+  changedFilesData: string[];
+  onFileSelect: (filePath: string, isChanged: boolean) => void;
+  activeSession?: SessionSummary | undefined;
+  workspaceSessions: SessionSummary[];
+  fileTreeSidebarRef?: React.RefObject<FileTreeSidebarHandle | null>;
+}
+
+export function utilityRailRenderedWidth(
+  state: WorkspaceUtilityRailState
+): number {
+  if (!state.visible) return 0;
+  return UTILITY_ICON_RAIL_WIDTH + (state.selectedRailTab ? state.width : 0);
+}
+
+export function WorkspaceUtilityRail({
+  workspacePath,
+  railState,
+  changedFilesData,
+  onFileSelect,
+  activeSession,
+  workspaceSessions,
+  fileTreeSidebarRef,
+}: WorkspaceUtilityRailProps) {
+  const setSelectedUtilityRailTab = useUiStore(
+    (s) => s.setSelectedUtilityRailTab
+  );
+  const openUtilityRailTab = useUiStore((s) => s.openUtilityRailTab);
+
+  const handleTabClick = useCallback(
+    (tab: UtilityRailTab) => {
+      if (railState.selectedRailTab === tab) {
+        setSelectedUtilityRailTab(workspacePath, null);
+      } else {
+        openUtilityRailTab(workspacePath, tab);
+      }
+    },
+    [
+      openUtilityRailTab,
+      railState.selectedRailTab,
+      setSelectedUtilityRailTab,
+      workspacePath,
+    ]
+  );
+
+  if (!railState.visible) return null;
+
+  return (
+    <div
+      className={[
+        'workspace-utility-rail',
+        !railState.selectedRailTab && 'workspace-utility-rail--icons-only',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      {railState.selectedRailTab ? (
+        <div className="utility-selected-pane">
+          <div className="utility-pane-header">
+            <span className="utility-pane-title">
+              {TAB_META.find((tab) => tab.id === railState.selectedRailTab)
+                ?.label ?? railState.selectedRailTab}
+            </span>
+            <span className="utility-pane-context">rail-selected pane</span>
+          </div>
+          <div className="utility-pane-body">
+            {railState.selectedRailTab === 'files' ? (
+              <UtilityRailFilesPanel
+                workspacePath={workspacePath}
+                changedFilesData={changedFilesData}
+                onFileSelect={onFileSelect}
+                {...(fileTreeSidebarRef ? { fileTreeSidebarRef } : {})}
+              />
+            ) : null}
+            {railState.selectedRailTab === 'review' ? (
+              <UtilityRailReviewPanel workspacePath={workspacePath} />
+            ) : null}
+            {railState.selectedRailTab === 'logs' ? (
+              <UtilityRailLogsPanel activeSession={activeSession} />
+            ) : null}
+            {railState.selectedRailTab === 'stats' ? (
+              <UtilityRailStatsPanel
+                activeSession={activeSession}
+                workspaceSessions={workspaceSessions}
+              />
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+      <div
+        className="utility-icon-rail"
+        style={{ width: UTILITY_ICON_RAIL_WIDTH }}
+        role="tablist"
+        aria-label="utility rail"
+      >
+        <div className="utility-icon-group">
+          {TAB_META.map((tab) => (
+            <button
+              key={tab.id}
+              className={[
+                'utility-icon-btn',
+                railState.selectedRailTab === tab.id && 'active',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+              type="button"
+              role="tab"
+              aria-selected={railState.selectedRailTab === tab.id}
+              aria-label={tab.label}
+              title={tab.label}
+              onClick={() => handleTabClick(tab.id)}
+            >
+              {tab.icon}
+            </button>
+          ))}
+        </div>
+        <button
+          className="utility-icon-btn utility-icon-btn--bottom"
+          type="button"
+          aria-label="more utility tools"
+          title="more"
+        >
+          ...
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default WorkspaceUtilityRail;

--- a/frontend/src/components/WorkspaceUtilityRail.tsx
+++ b/frontend/src/components/WorkspaceUtilityRail.tsx
@@ -97,21 +97,43 @@ export function WorkspaceUtilityRail({
     (s) => s.setSelectedUtilityRailTab
   );
   const openUtilityRailTab = useUiStore((s) => s.openUtilityRailTab);
+  const selectedTab = railState.selectedRailTab;
+  const selectedMeta = TAB_META.find((tab) => tab.id === selectedTab);
 
   const handleTabClick = useCallback(
     (tab: UtilityRailTab) => {
-      if (railState.selectedRailTab === tab) {
+      if (selectedTab === tab) {
         setSelectedUtilityRailTab(workspacePath, null);
       } else {
         openUtilityRailTab(workspacePath, tab);
       }
     },
-    [
-      openUtilityRailTab,
-      railState.selectedRailTab,
-      setSelectedUtilityRailTab,
-      workspacePath,
-    ]
+    [openUtilityRailTab, selectedTab, setSelectedUtilityRailTab, workspacePath]
+  );
+
+  const handleTabKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>, tab: UtilityRailTab) => {
+      const currentIndex = TAB_META.findIndex((item) => item.id === tab);
+      let nextIndex: number | null = null;
+      if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+        nextIndex = (currentIndex + 1) % TAB_META.length;
+      } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+        nextIndex = (currentIndex - 1 + TAB_META.length) % TAB_META.length;
+      } else if (event.key === 'Home') {
+        nextIndex = 0;
+      } else if (event.key === 'End') {
+        nextIndex = TAB_META.length - 1;
+      }
+      if (nextIndex === null) return;
+      event.preventDefault();
+      const nextTab = TAB_META[nextIndex]?.id;
+      if (!nextTab) return;
+      openUtilityRailTab(workspacePath, nextTab);
+      requestAnimationFrame(() => {
+        document.getElementById(`utility-rail-tab-${nextTab}`)?.focus();
+      });
+    },
+    [openUtilityRailTab, workspacePath]
   );
 
   if (!railState.visible) return null;
@@ -125,38 +147,66 @@ export function WorkspaceUtilityRail({
         .filter(Boolean)
         .join(' ')}
     >
-      {railState.selectedRailTab ? (
-        <div className="utility-selected-pane">
-          <div className="utility-pane-header">
-            <span className="utility-pane-title">
-              {TAB_META.find((tab) => tab.id === railState.selectedRailTab)
-                ?.label ?? railState.selectedRailTab}
-            </span>
+      <div className="utility-selected-pane">
+        <div className="utility-pane-header">
+          <span className="utility-pane-title">
+            {selectedMeta?.label ?? selectedTab ?? ''}
+          </span>
+        </div>
+        <div className="utility-pane-body">
+          <div
+            id="utility-rail-panel-files"
+            className="utility-pane-panel"
+            role="tabpanel"
+            aria-labelledby="utility-rail-tab-files"
+            tabIndex={selectedTab === 'files' ? 0 : -1}
+            hidden={selectedTab !== 'files'}
+          >
+            <UtilityRailFilesPanel
+              workspacePath={workspacePath}
+              changedFilesData={changedFilesData}
+              onFileSelect={onFileSelect}
+              {...(fileTreeSidebarRef ? { fileTreeSidebarRef } : {})}
+            />
           </div>
-          <div className="utility-pane-body">
-            {railState.selectedRailTab === 'files' ? (
-              <UtilityRailFilesPanel
-                workspacePath={workspacePath}
-                changedFilesData={changedFilesData}
-                onFileSelect={onFileSelect}
-                {...(fileTreeSidebarRef ? { fileTreeSidebarRef } : {})}
-              />
-            ) : null}
-            {railState.selectedRailTab === 'review' ? (
-              <UtilityRailReviewPanel workspacePath={workspacePath} />
-            ) : null}
-            {railState.selectedRailTab === 'logs' ? (
-              <UtilityRailLogsPanel activeSession={activeSession} />
-            ) : null}
-            {railState.selectedRailTab === 'stats' ? (
-              <UtilityRailStatsPanel
-                activeSession={activeSession}
-                workspaceSessions={workspaceSessions}
-              />
-            ) : null}
+          <div
+            id="utility-rail-panel-review"
+            className="utility-pane-panel"
+            role="tabpanel"
+            aria-labelledby="utility-rail-tab-review"
+            tabIndex={selectedTab === 'review' ? 0 : -1}
+            hidden={selectedTab !== 'review'}
+          >
+            <UtilityRailReviewPanel
+              workspacePath={workspacePath}
+              reviewFilePath={railState.reviewFilePath}
+            />
+          </div>
+          <div
+            id="utility-rail-panel-logs"
+            className="utility-pane-panel"
+            role="tabpanel"
+            aria-labelledby="utility-rail-tab-logs"
+            tabIndex={selectedTab === 'logs' ? 0 : -1}
+            hidden={selectedTab !== 'logs'}
+          >
+            <UtilityRailLogsPanel activeSession={activeSession} />
+          </div>
+          <div
+            id="utility-rail-panel-stats"
+            className="utility-pane-panel"
+            role="tabpanel"
+            aria-labelledby="utility-rail-tab-stats"
+            tabIndex={selectedTab === 'stats' ? 0 : -1}
+            hidden={selectedTab !== 'stats'}
+          >
+            <UtilityRailStatsPanel
+              activeSession={activeSession}
+              workspaceSessions={workspaceSessions}
+            />
           </div>
         </div>
-      ) : null}
+      </div>
       <div
         className="utility-icon-rail"
         style={{ width: UTILITY_ICON_RAIL_WIDTH }}
@@ -172,32 +222,26 @@ export function WorkspaceUtilityRail({
               side="left"
             >
               <button
+                id={`utility-rail-tab-${tab.id}`}
                 className={[
                   'utility-icon-btn',
-                  railState.selectedRailTab === tab.id && 'active',
+                  selectedTab === tab.id && 'active',
                 ]
                   .filter(Boolean)
                   .join(' ')}
                 type="button"
                 role="tab"
-                aria-selected={railState.selectedRailTab === tab.id}
+                aria-selected={selectedTab === tab.id}
+                aria-controls={`utility-rail-panel-${tab.id}`}
                 aria-label={tab.label}
                 onClick={() => handleTabClick(tab.id)}
+                onKeyDown={(event) => handleTabKeyDown(event, tab.id)}
               >
                 {tab.icon}
               </button>
             </Tooltip>
           ))}
         </div>
-        <Tooltip label="more utility tools" side="left">
-          <button
-            className="utility-icon-btn utility-icon-btn--bottom"
-            type="button"
-            aria-label="more utility tools"
-          >
-            ...
-          </button>
-        </Tooltip>
       </div>
     </div>
   );

--- a/frontend/src/components/WorkspaceUtilityRail.tsx
+++ b/frontend/src/components/WorkspaceUtilityRail.tsx
@@ -132,7 +132,6 @@ export function WorkspaceUtilityRail({
               {TAB_META.find((tab) => tab.id === railState.selectedRailTab)
                 ?.label ?? railState.selectedRailTab}
             </span>
-            <span className="utility-pane-context">rail-selected pane</span>
           </div>
           <div className="utility-pane-body">
             {railState.selectedRailTab === 'files' ? (

--- a/frontend/src/components/WorkspaceUtilityRail.tsx
+++ b/frontend/src/components/WorkspaceUtilityRail.tsx
@@ -11,11 +11,13 @@ import UtilityRailFilesPanel from './UtilityRailFilesPanel.js';
 import UtilityRailReviewPanel from './UtilityRailReviewPanel.js';
 import UtilityRailLogsPanel from './UtilityRailLogsPanel.js';
 import UtilityRailStatsPanel from './UtilityRailStatsPanel.js';
+import Tooltip from './Tooltip.js';
 import './WorkspaceUtilityRail.css';
 
 const TAB_META: Array<{
   id: UtilityRailTab;
   label: string;
+  actionId?: string;
   icon: React.ReactNode;
 }> = [
   {
@@ -31,6 +33,7 @@ const TAB_META: Array<{
   {
     id: 'review',
     label: 'git diff',
+    actionId: 'workspace.open-diff-view',
     icon: (
       <svg viewBox="0 0 24 24" aria-hidden="true">
         <path d="M7 4v16" />
@@ -163,33 +166,39 @@ export function WorkspaceUtilityRail({
       >
         <div className="utility-icon-group">
           {TAB_META.map((tab) => (
-            <button
+            <Tooltip
               key={tab.id}
-              className={[
-                'utility-icon-btn',
-                railState.selectedRailTab === tab.id && 'active',
-              ]
-                .filter(Boolean)
-                .join(' ')}
-              type="button"
-              role="tab"
-              aria-selected={railState.selectedRailTab === tab.id}
-              aria-label={tab.label}
-              title={tab.label}
-              onClick={() => handleTabClick(tab.id)}
+              label={tab.label}
+              {...(tab.actionId ? { actionId: tab.actionId } : {})}
+              side="left"
             >
-              {tab.icon}
-            </button>
+              <button
+                className={[
+                  'utility-icon-btn',
+                  railState.selectedRailTab === tab.id && 'active',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+                type="button"
+                role="tab"
+                aria-selected={railState.selectedRailTab === tab.id}
+                aria-label={tab.label}
+                onClick={() => handleTabClick(tab.id)}
+              >
+                {tab.icon}
+              </button>
+            </Tooltip>
           ))}
         </div>
-        <button
-          className="utility-icon-btn utility-icon-btn--bottom"
-          type="button"
-          aria-label="more utility tools"
-          title="more"
-        >
-          ...
-        </button>
+        <Tooltip label="more utility tools" side="left">
+          <button
+            className="utility-icon-btn utility-icon-btn--bottom"
+            type="button"
+            aria-label="more utility tools"
+          >
+            ...
+          </button>
+        </Tooltip>
       </div>
     </div>
   );

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -443,8 +443,8 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
       // ── Diff view ────────────────────────────────────────────────────────────
       {
         id: 'workspace.open-diff-view' as const,
-        label: 'open diff view',
-        description: 'open full-page diff viewer for changed files',
+        label: 'open review pane',
+        description: 'open the review utility pane for changed files',
         category: 'workspace' as const,
         shortcut: { key: 'd' },
         when: (ctx: ActionContext) => ctx.view === 'session',
@@ -457,8 +457,14 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
                 .sessions.find((s) => s.id === currentActiveSessionId)
             : undefined;
           const ws =
-            currentActiveSession?.cwd ?? currentActiveSession?.repoPath ?? '';
-          if (ws) useUiStore.setState({ fullPageDiff: { workspacePath: ws } });
+            currentActiveSession?.worktreePath ??
+            currentActiveSession?.repoPath ??
+            '';
+          if (ws) {
+            const ui = useUiStore.getState();
+            ui.openUtilityRailTab(ws, 'review');
+            useUiStore.setState({ fullPageDiff: null });
+          }
         },
       },
       {

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -52,6 +52,12 @@ export interface OpenUtilityRailTabOptions {
   preserveSelectedTab?: boolean;
 }
 
+export const DEFAULT_UTILITY_RAIL_STATE: WorkspaceUtilityRailState = {
+  visible: true,
+  selectedRailTab: null,
+  width: DEFAULT_UTILITY_RAIL_WIDTH,
+};
+
 export function fileTabKey(filePath: string, tabType?: FileTabType): string {
   return `${tabType ?? 'code'}::${filePath}`;
 }
@@ -172,12 +178,14 @@ function utilityRailStorageKey(workspacePath: string): string {
   return `${UTILITY_RAIL_STATE_KEY_PREFIX}${workspacePath}`;
 }
 
+const utilityRailStateCache = new Map<string, WorkspaceUtilityRailState>();
+
+export function clearUtilityRailStateCacheForTesting(): void {
+  utilityRailStateCache.clear();
+}
+
 function defaultUtilityRailState(): WorkspaceUtilityRailState {
-  return {
-    visible: true,
-    selectedRailTab: null,
-    width: DEFAULT_UTILITY_RAIL_WIDTH,
-  };
+  return { ...DEFAULT_UTILITY_RAIL_STATE };
 }
 
 function normalizeUtilityRailState(
@@ -234,18 +242,28 @@ function normalizeUtilityRailState(
 function loadUtilityRailState(
   workspacePath: string
 ): WorkspaceUtilityRailState {
+  const cached = utilityRailStateCache.get(workspacePath);
+  if (cached) return cached;
   const stored = ls(utilityRailStorageKey(workspacePath));
-  if (!stored) return defaultUtilityRailState();
+  if (!stored) {
+    const state = defaultUtilityRailState();
+    utilityRailStateCache.set(workspacePath, state);
+    return state;
+  }
   try {
-    return normalizeUtilityRailState(
+    const state = normalizeUtilityRailState(
       JSON.parse(stored) as Partial<WorkspaceUtilityRailState>
     );
+    utilityRailStateCache.set(workspacePath, state);
+    return state;
   } catch {
-    return defaultUtilityRailState();
+    const state = defaultUtilityRailState();
+    utilityRailStateCache.set(workspacePath, state);
+    return state;
   }
 }
 
-function saveUtilityRailState(
+function persistUtilityRailState(
   workspacePath: string,
   state: WorkspaceUtilityRailState
 ): void {
@@ -254,12 +272,17 @@ function saveUtilityRailState(
 
 function mutateUtilityRailState(
   workspacePath: string,
-  mutate: (state: WorkspaceUtilityRailState) => void
+  currentState: WorkspaceUtilityRailState | undefined,
+  mutate: (state: WorkspaceUtilityRailState) => void,
+  persist = true
 ): WorkspaceUtilityRailState {
-  const next = loadUtilityRailState(workspacePath);
+  const next = normalizeUtilityRailState(
+    currentState ?? loadUtilityRailState(workspacePath)
+  );
   mutate(next);
   const normalized = normalizeUtilityRailState(next);
-  saveUtilityRailState(workspacePath, normalized);
+  utilityRailStateCache.set(workspacePath, normalized);
+  if (persist) persistUtilityRailState(workspacePath, normalized);
   return normalized;
 }
 
@@ -292,6 +315,7 @@ export interface UiState {
   rightSidebarTab: RightSidebarTab;
   utilityRailByWorkspace: Record<string, WorkspaceUtilityRailState>;
   getUtilityRailState: (workspacePath: string) => WorkspaceUtilityRailState;
+  hydrateUtilityRailState: (workspacePath: string) => void;
   setSelectedUtilityRailTab: (
     workspacePath: string,
     tab: UtilityRailTab | null
@@ -304,6 +328,7 @@ export interface UiState {
   setUtilityRailVisible: (workspacePath: string, visible: boolean) => void;
   toggleUtilityRailVisible: (workspacePath: string) => void;
   setUtilityRailWidth: (workspacePath: string, width: number) => void;
+  saveUtilityRailState: (workspacePath: string) => void;
   setAnchoredUtilityPaneWidth: (
     workspacePath: string,
     tab: UtilityRailTab,
@@ -430,10 +455,24 @@ export const useUiStore = create<UiState>()((set, get) => ({
   getUtilityRailState: (workspacePath) =>
     get().utilityRailByWorkspace[workspacePath] ??
     loadUtilityRailState(workspacePath),
-  setSelectedUtilityRailTab: (workspacePath, tab) => {
-    const next = mutateUtilityRailState(workspacePath, (state) => {
-      state.selectedRailTab = tab;
+  hydrateUtilityRailState: (workspacePath) => {
+    if (!workspacePath || get().utilityRailByWorkspace[workspacePath]) return;
+    const next = loadUtilityRailState(workspacePath);
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: next,
+      },
     });
+  },
+  setSelectedUtilityRailTab: (workspacePath, tab) => {
+    const next = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        state.selectedRailTab = tab;
+      }
+    );
     set({
       utilityRailByWorkspace: {
         ...get().utilityRailByWorkspace,
@@ -442,10 +481,14 @@ export const useUiStore = create<UiState>()((set, get) => ({
     });
   },
   openUtilityRailTab: (workspacePath, tab, options) => {
-    const next = mutateUtilityRailState(workspacePath, (state) => {
-      state.visible = true;
-      if (!options?.preserveSelectedTab) state.selectedRailTab = tab;
-    });
+    const next = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        state.visible = true;
+        if (!options?.preserveSelectedTab) state.selectedRailTab = tab;
+      }
+    );
     set({
       utilityRailByWorkspace: {
         ...get().utilityRailByWorkspace,
@@ -454,9 +497,13 @@ export const useUiStore = create<UiState>()((set, get) => ({
     });
   },
   setUtilityRailVisible: (workspacePath, visible) => {
-    const next = mutateUtilityRailState(workspacePath, (state) => {
-      state.visible = visible;
-    });
+    const next = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        state.visible = visible;
+      }
+    );
     set({
       utilityRailByWorkspace: {
         ...get().utilityRailByWorkspace,
@@ -465,9 +512,13 @@ export const useUiStore = create<UiState>()((set, get) => ({
     });
   },
   toggleUtilityRailVisible: (workspacePath) => {
-    const next = mutateUtilityRailState(workspacePath, (state) => {
-      state.visible = !state.visible;
-    });
+    const next = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        state.visible = !state.visible;
+      }
+    );
     set({
       utilityRailByWorkspace: {
         ...get().utilityRailByWorkspace,
@@ -476,9 +527,14 @@ export const useUiStore = create<UiState>()((set, get) => ({
     });
   },
   setUtilityRailWidth: (workspacePath, width) => {
-    const next = mutateUtilityRailState(workspacePath, (state) => {
-      state.width = clampUtilityRailWidth(width);
-    });
+    const next = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        state.width = clampUtilityRailWidth(width);
+      },
+      false
+    );
     set({
       utilityRailByWorkspace: {
         ...get().utilityRailByWorkspace,
@@ -486,14 +542,24 @@ export const useUiStore = create<UiState>()((set, get) => ({
       },
     });
   },
+  saveUtilityRailState: (workspacePath) => {
+    const state =
+      get().utilityRailByWorkspace[workspacePath] ??
+      loadUtilityRailState(workspacePath);
+    persistUtilityRailState(workspacePath, state);
+  },
   setAnchoredUtilityPaneWidth: (workspacePath, tab, width) => {
-    const nextState = mutateUtilityRailState(workspacePath, (state) => {
-      const next = state.anchoredPaneWidths
-        ? { ...state.anchoredPaneWidths }
-        : {};
-      next[tab] = clampUtilityRailWidth(width);
-      state.anchoredPaneWidths = next;
-    });
+    const nextState = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        const next = state.anchoredPaneWidths
+          ? { ...state.anchoredPaneWidths }
+          : {};
+        next[tab] = clampUtilityRailWidth(width);
+        state.anchoredPaneWidths = next;
+      }
+    );
     set({
       utilityRailByWorkspace: {
         ...get().utilityRailByWorkspace,
@@ -502,11 +568,15 @@ export const useUiStore = create<UiState>()((set, get) => ({
     });
   },
   setUtilitySurfacePlacement: (workspacePath, tab, placement) => {
-    const nextState = mutateUtilityRailState(workspacePath, (state) => {
-      const next = state.placements ? { ...state.placements } : {};
-      next[tab] = placement;
-      state.placements = next;
-    });
+    const nextState = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        const next = state.placements ? { ...state.placements } : {};
+        next[tab] = placement;
+        state.placements = next;
+      }
+    );
     set({
       utilityRailByWorkspace: {
         ...get().utilityRailByWorkspace,

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -8,6 +8,7 @@ const ACTIVE_WORKSPACE_GROUP_KEY = 'claude-remote-active-workspace-group';
 const TERMINAL_FONT_SIZE_KEY = 'claude-remote-terminal-font-size';
 const RIGHT_SIDEBAR_WIDTH_KEY = 'claude-remote-right-sidebar-width';
 const RIGHT_SIDEBAR_COLLAPSED_KEY = 'claude-remote-right-sidebar-collapsed';
+const UTILITY_RAIL_STATE_KEY_PREFIX = 'relay-utility-rail::';
 const FILE_VIEWER_WIDTH_KEY = 'claude-remote-file-viewer-width';
 const DIFF_VIEW_MODE_KEY = 'claude-remote-diff-view-mode';
 const WORD_WRAP_KEY = 'claude-remote-word-wrap';
@@ -24,10 +25,32 @@ export const DEFAULT_RIGHT_SIDEBAR_WIDTH = 220;
 export const MIN_RIGHT_SIDEBAR_WIDTH = 160;
 export const MAX_RIGHT_SIDEBAR_WIDTH = 400;
 export const DEFAULT_FILE_VIEWER_RATIO = 0.35;
+export const DEFAULT_UTILITY_RAIL_WIDTH = 320;
+export const MIN_UTILITY_RAIL_WIDTH = 220;
+export const MAX_UTILITY_RAIL_WIDTH = 640;
+export const UTILITY_ICON_RAIL_WIDTH = 48;
 
 export type RightSidebarTab = 'changes' | 'all-files' | 'checks';
 export type FileTabType = 'diff' | 'code' | 'html';
 export type DiffViewMode = 'unified' | 'side-by-side';
+export type UtilityRailTab = 'files' | 'review' | 'logs' | 'stats';
+export type UtilitySurfacePlacement =
+  | { kind: 'rail' }
+  | { kind: 'anchored-pane'; paneId: string };
+
+export interface WorkspaceUtilityRailState {
+  visible: boolean;
+  selectedRailTab: UtilityRailTab | null;
+  width: number;
+  anchoredPaneWidths?: Partial<Record<UtilityRailTab, number>>;
+  placements?: Partial<Record<UtilityRailTab, UtilitySurfacePlacement>>;
+  reviewFilePath?: string;
+  filesMode?: 'changes' | 'all-files';
+}
+
+export interface OpenUtilityRailTabOptions {
+  preserveSelectedTab?: boolean;
+}
 
 export function fileTabKey(filePath: string, tabType?: FileTabType): string {
   return `${tabType ?? 'code'}::${filePath}`;
@@ -123,6 +146,123 @@ function loadCollapsedWorkspaces(): Set<string> {
   return new Set();
 }
 
+const UTILITY_RAIL_TABS: UtilityRailTab[] = [
+  'files',
+  'review',
+  'logs',
+  'stats',
+];
+
+function isUtilityRailTab(value: unknown): value is UtilityRailTab {
+  return (
+    typeof value === 'string' &&
+    UTILITY_RAIL_TABS.includes(value as UtilityRailTab)
+  );
+}
+
+function clampUtilityRailWidth(width: number): number {
+  if (!Number.isFinite(width)) return DEFAULT_UTILITY_RAIL_WIDTH;
+  return Math.min(
+    MAX_UTILITY_RAIL_WIDTH,
+    Math.max(MIN_UTILITY_RAIL_WIDTH, Math.round(width))
+  );
+}
+
+function utilityRailStorageKey(workspacePath: string): string {
+  return `${UTILITY_RAIL_STATE_KEY_PREFIX}${workspacePath}`;
+}
+
+function defaultUtilityRailState(): WorkspaceUtilityRailState {
+  return {
+    visible: true,
+    selectedRailTab: null,
+    width: DEFAULT_UTILITY_RAIL_WIDTH,
+  };
+}
+
+function normalizeUtilityRailState(
+  value: Partial<WorkspaceUtilityRailState> | null | undefined
+): WorkspaceUtilityRailState {
+  const next = defaultUtilityRailState();
+  if (!value) return next;
+
+  next.visible = value.visible ?? next.visible;
+  next.selectedRailTab = isUtilityRailTab(value.selectedRailTab)
+    ? value.selectedRailTab
+    : value.selectedRailTab === null
+      ? null
+      : next.selectedRailTab;
+  next.width = clampUtilityRailWidth(value.width ?? next.width);
+
+  if (value.anchoredPaneWidths) {
+    const anchoredPaneWidths: Partial<Record<UtilityRailTab, number>> = {};
+    for (const tab of UTILITY_RAIL_TABS) {
+      const width = value.anchoredPaneWidths[tab];
+      if (typeof width === 'number')
+        anchoredPaneWidths[tab] = clampUtilityRailWidth(width);
+    }
+    if (Object.keys(anchoredPaneWidths).length > 0)
+      next.anchoredPaneWidths = anchoredPaneWidths;
+  }
+
+  if (value.placements) {
+    const placements: Partial<Record<UtilityRailTab, UtilitySurfacePlacement>> =
+      {};
+    for (const tab of UTILITY_RAIL_TABS) {
+      const placement = value.placements[tab];
+      if (
+        placement &&
+        (placement.kind === 'rail' ||
+          (placement.kind === 'anchored-pane' &&
+            typeof placement.paneId === 'string'))
+      ) {
+        placements[tab] = placement;
+      }
+    }
+    if (Object.keys(placements).length > 0) next.placements = placements;
+  }
+
+  if (typeof value.reviewFilePath === 'string')
+    next.reviewFilePath = value.reviewFilePath;
+  if (value.filesMode === 'changes' || value.filesMode === 'all-files') {
+    next.filesMode = value.filesMode;
+  }
+
+  return next;
+}
+
+function loadUtilityRailState(
+  workspacePath: string
+): WorkspaceUtilityRailState {
+  const stored = ls(utilityRailStorageKey(workspacePath));
+  if (!stored) return defaultUtilityRailState();
+  try {
+    return normalizeUtilityRailState(
+      JSON.parse(stored) as Partial<WorkspaceUtilityRailState>
+    );
+  } catch {
+    return defaultUtilityRailState();
+  }
+}
+
+function saveUtilityRailState(
+  workspacePath: string,
+  state: WorkspaceUtilityRailState
+): void {
+  lsSave(utilityRailStorageKey(workspacePath), JSON.stringify(state));
+}
+
+function mutateUtilityRailState(
+  workspacePath: string,
+  mutate: (state: WorkspaceUtilityRailState) => void
+): WorkspaceUtilityRailState {
+  const next = loadUtilityRailState(workspacePath);
+  mutate(next);
+  const normalized = normalizeUtilityRailState(next);
+  saveUtilityRailState(workspacePath, normalized);
+  return normalized;
+}
+
 export type AnalyticsView = 'dashboard' | { sessionId: string } | null;
 
 export type ActiveModal =
@@ -150,6 +290,30 @@ export interface UiState {
   rightSidebarCollapsed: boolean;
   rightSidebarWidth: number;
   rightSidebarTab: RightSidebarTab;
+  utilityRailByWorkspace: Record<string, WorkspaceUtilityRailState>;
+  getUtilityRailState: (workspacePath: string) => WorkspaceUtilityRailState;
+  setSelectedUtilityRailTab: (
+    workspacePath: string,
+    tab: UtilityRailTab | null
+  ) => void;
+  openUtilityRailTab: (
+    workspacePath: string,
+    tab: UtilityRailTab,
+    options?: OpenUtilityRailTabOptions
+  ) => void;
+  setUtilityRailVisible: (workspacePath: string, visible: boolean) => void;
+  toggleUtilityRailVisible: (workspacePath: string) => void;
+  setUtilityRailWidth: (workspacePath: string, width: number) => void;
+  setAnchoredUtilityPaneWidth: (
+    workspacePath: string,
+    tab: UtilityRailTab,
+    width: number
+  ) => void;
+  setUtilitySurfacePlacement: (
+    workspacePath: string,
+    tab: UtilityRailTab,
+    placement: UtilitySurfacePlacement
+  ) => void;
   openFileTabs: OpenFileTab[];
   activeFileTabKey: string | null;
   fileViewerRatio: number;
@@ -210,6 +374,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   rightSidebarCollapsed: ls(RIGHT_SIDEBAR_COLLAPSED_KEY) === 'true',
   rightSidebarWidth: loadRightSidebarWidth(),
   rightSidebarTab: 'changes',
+  utilityRailByWorkspace: {},
   openFileTabs: [],
   activeFileTabKey: null,
   fileViewerRatio: loadFileViewerRatio(),
@@ -262,6 +427,93 @@ export const useUiStore = create<UiState>()((set, get) => ({
   },
 
   setRightSidebarTab: (tab) => set({ rightSidebarTab: tab }),
+  getUtilityRailState: (workspacePath) =>
+    get().utilityRailByWorkspace[workspacePath] ??
+    loadUtilityRailState(workspacePath),
+  setSelectedUtilityRailTab: (workspacePath, tab) => {
+    const next = mutateUtilityRailState(workspacePath, (state) => {
+      state.selectedRailTab = tab;
+    });
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: next,
+      },
+    });
+  },
+  openUtilityRailTab: (workspacePath, tab, options) => {
+    const next = mutateUtilityRailState(workspacePath, (state) => {
+      state.visible = true;
+      if (!options?.preserveSelectedTab) state.selectedRailTab = tab;
+    });
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: next,
+      },
+    });
+  },
+  setUtilityRailVisible: (workspacePath, visible) => {
+    const next = mutateUtilityRailState(workspacePath, (state) => {
+      state.visible = visible;
+    });
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: next,
+      },
+    });
+  },
+  toggleUtilityRailVisible: (workspacePath) => {
+    const next = mutateUtilityRailState(workspacePath, (state) => {
+      state.visible = !state.visible;
+    });
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: next,
+      },
+    });
+  },
+  setUtilityRailWidth: (workspacePath, width) => {
+    const next = mutateUtilityRailState(workspacePath, (state) => {
+      state.width = clampUtilityRailWidth(width);
+    });
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: next,
+      },
+    });
+  },
+  setAnchoredUtilityPaneWidth: (workspacePath, tab, width) => {
+    const nextState = mutateUtilityRailState(workspacePath, (state) => {
+      const next = state.anchoredPaneWidths
+        ? { ...state.anchoredPaneWidths }
+        : {};
+      next[tab] = clampUtilityRailWidth(width);
+      state.anchoredPaneWidths = next;
+    });
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: nextState,
+      },
+    });
+  },
+  setUtilitySurfacePlacement: (workspacePath, tab, placement) => {
+    const nextState = mutateUtilityRailState(workspacePath, (state) => {
+      const next = state.placements ? { ...state.placements } : {};
+      next[tab] = placement;
+      state.placements = next;
+    });
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: nextState,
+      },
+    });
+  },
   setFileDiffSource: (source) => set({ fileDiffSource: source }),
   setFileDiffDefaultBranch: (branch) => set({ fileDiffDefaultBranch: branch }),
   setLastChangedFiles: (files) => set({ lastChangedFiles: files }),

--- a/test/components/Tooltip.test.ts
+++ b/test/components/Tooltip.test.ts
@@ -1,0 +1,59 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, beforeEach, expect, it } from 'vitest';
+import Tooltip from '../../frontend/src/components/Tooltip.js';
+import TuiButton from '../../frontend/src/components/TuiButton.js';
+import {
+  _resetForTesting,
+  registerGlobal,
+} from '../../frontend/src/lib/actions/registry.js';
+import type { Action } from '../../frontend/src/lib/actions/types.js';
+
+function registerAction(action: Action) {
+  _resetForTesting();
+  registerGlobal([action]);
+}
+
+describe('Tooltip', () => {
+  beforeEach(() => {
+    _resetForTesting();
+  });
+
+  it('uses command registry labels and shortcut formatting for action tooltips', () => {
+    registerAction({
+      id: 'workspace.open-diff-view',
+      label: 'open review pane',
+      description: 'open the review utility pane for changed files',
+      category: 'workspace',
+      shortcut: { key: 'mod+d' },
+      handler: () => {},
+    });
+
+    const html = renderToStaticMarkup(
+      React.createElement(
+        Tooltip,
+        { actionId: 'workspace.open-diff-view' },
+        React.createElement('button', { type: 'button' }, 'review')
+      )
+    );
+
+    expect(html).toContain('open review pane');
+    expect(html).toContain('open the review utility pane for changed files');
+    expect(html).toMatch(/⌘D|ctrl\+D/);
+    expect(html).not.toContain('title=');
+  });
+
+  it('lets TuiButton expose the same tooltip contract', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(
+        TuiButton,
+        { tooltip: 'refresh PR data', tooltipShortcut: 'mod+r' },
+        'refresh'
+      )
+    );
+
+    expect(html).toContain('refresh PR data');
+    expect(html).toMatch(/⌘R|ctrl\+R/);
+    expect(html).toContain('tui-tooltip');
+  });
+});

--- a/test/components/Tooltip.test.ts
+++ b/test/components/Tooltip.test.ts
@@ -1,4 +1,6 @@
 import React from 'react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, beforeEach, expect, it } from 'vitest';
 import Tooltip from '../../frontend/src/components/Tooltip.js';
@@ -55,5 +57,15 @@ describe('Tooltip', () => {
     expect(html).toContain('refresh PR data');
     expect(html).toMatch(/⌘R|ctrl\+R/);
     expect(html).toContain('tui-tooltip');
+  });
+
+  it('does not keep tooltips open from mouse-click focus', () => {
+    const css = readFileSync(
+      resolve(process.cwd(), 'frontend/src/components/Tooltip.css'),
+      'utf8'
+    );
+
+    expect(css).not.toContain(':focus-within');
+    expect(css).toContain(':focus-visible');
   });
 });

--- a/test/pr-top-bar-action.test.ts
+++ b/test/pr-top-bar-action.test.ts
@@ -25,6 +25,11 @@ vi.mock('../frontend/src/lib/ws.js', () => ({
 }));
 
 vi.mock('../frontend/src/lib/stores/ui.js', () => ({
+  DEFAULT_UTILITY_RAIL_STATE: {
+    visible: true,
+    selectedRailTab: null,
+    width: 320,
+  },
   useUiStore: (selector: (state: unknown) => unknown) =>
     selector({
       utilityRailByWorkspace: {},
@@ -33,6 +38,7 @@ vi.mock('../frontend/src/lib/stores/ui.js', () => ({
         selectedRailTab: null,
         width: 320,
       }),
+      hydrateUtilityRailState: vi.fn(),
       toggleUtilityRailVisible: vi.fn(),
     }),
 }));

--- a/test/pr-top-bar-action.test.ts
+++ b/test/pr-top-bar-action.test.ts
@@ -27,8 +27,13 @@ vi.mock('../frontend/src/lib/ws.js', () => ({
 vi.mock('../frontend/src/lib/stores/ui.js', () => ({
   useUiStore: (selector: (state: unknown) => unknown) =>
     selector({
-      rightSidebarCollapsed: false,
-      toggleRightSidebarCollapsed: vi.fn(),
+      utilityRailByWorkspace: {},
+      getUtilityRailState: () => ({
+        visible: true,
+        selectedRailTab: null,
+        width: 320,
+      }),
+      toggleUtilityRailVisible: vi.fn(),
     }),
 }));
 
@@ -43,7 +48,8 @@ vi.mock('../frontend/src/components/TargetBranchSwitcher.js', () => ({
 }));
 
 vi.mock('../frontend/src/components/CipherText.js', () => ({
-  default: ({ text }: { text: string }) => React.createElement('span', null, text),
+  default: ({ text }: { text: string }) =>
+    React.createElement('span', null, text),
 }));
 
 vi.mock('../frontend/src/components/dialogs/RenameWarningModal.js', () => ({

--- a/test/stores/ui-store.test.ts
+++ b/test/stores/ui-store.test.ts
@@ -31,6 +31,9 @@ import {
   DEFAULT_RIGHT_SIDEBAR_WIDTH,
   DEFAULT_FILE_VIEWER_RATIO,
   DEFAULT_TERMINAL_FONT_SIZE,
+  DEFAULT_UTILITY_RAIL_WIDTH,
+  MIN_UTILITY_RAIL_WIDTH,
+  MAX_UTILITY_RAIL_WIDTH,
 } from '../../frontend/src/lib/stores/ui.js';
 
 function resetStore() {
@@ -54,6 +57,7 @@ function resetStore() {
     rightSidebarCollapsed: false,
     rightSidebarWidth: DEFAULT_RIGHT_SIDEBAR_WIDTH,
     rightSidebarTab: 'changes',
+    utilityRailByWorkspace: {},
     openFileTabs: [],
     activeFileTabKey: null,
     fileViewerRatio: DEFAULT_FILE_VIEWER_RATIO,
@@ -108,6 +112,106 @@ describe('ui Zustand store', () => {
     it('toggleRightSidebarCollapsed persists to localStorage', () => {
       useUiStore.getState().toggleRightSidebarCollapsed();
       expect(storage['claude-remote-right-sidebar-collapsed']).toBe('true');
+    });
+  });
+
+  describe('utility rail', () => {
+    it('stores utility rail state per workspace path', () => {
+      const a = useUiStore.getState().getUtilityRailState('/repo/a');
+      const b = useUiStore.getState().getUtilityRailState('/repo/b');
+
+      expect(a).toEqual({
+        visible: true,
+        selectedRailTab: null,
+        width: DEFAULT_UTILITY_RAIL_WIDTH,
+      });
+      expect(b).toEqual({
+        visible: true,
+        selectedRailTab: null,
+        width: DEFAULT_UTILITY_RAIL_WIDTH,
+      });
+
+      useUiStore.getState().setSelectedUtilityRailTab('/repo/a', 'review');
+      useUiStore.getState().setUtilityRailWidth('/repo/a', 999);
+
+      expect(
+        useUiStore.getState().getUtilityRailState('/repo/a')
+      ).toMatchObject({
+        visible: true,
+        selectedRailTab: 'review',
+        width: MAX_UTILITY_RAIL_WIDTH,
+      });
+      expect(useUiStore.getState().getUtilityRailState('/repo/b')).toEqual({
+        visible: true,
+        selectedRailTab: null,
+        width: DEFAULT_UTILITY_RAIL_WIDTH,
+      });
+      expect(storage['relay-utility-rail::/repo/a']).toContain(
+        '"selectedRailTab":"review"'
+      );
+      expect(storage['relay-utility-rail::/repo/b']).toBe(undefined);
+    });
+
+    it('openUtilityRailTab makes the rail visible and selects the requested tab', () => {
+      useUiStore.getState().setUtilityRailVisible('/repo/a', false);
+      useUiStore.getState().openUtilityRailTab('/repo/a', 'files');
+
+      expect(
+        useUiStore.getState().getUtilityRailState('/repo/a')
+      ).toMatchObject({
+        visible: true,
+        selectedRailTab: 'files',
+      });
+    });
+
+    it('openUtilityRailTab can preserve the current selected tab', () => {
+      useUiStore.getState().setSelectedUtilityRailTab('/repo/a', 'logs');
+      useUiStore.getState().openUtilityRailTab('/repo/a', 'stats', {
+        preserveSelectedTab: true,
+      });
+
+      expect(
+        useUiStore.getState().getUtilityRailState('/repo/a')
+      ).toMatchObject({
+        visible: true,
+        selectedRailTab: 'logs',
+      });
+    });
+
+    it('clamps utility rail widths', () => {
+      useUiStore.getState().setUtilityRailWidth('/repo/a', 100);
+      expect(useUiStore.getState().getUtilityRailState('/repo/a').width).toBe(
+        MIN_UTILITY_RAIL_WIDTH
+      );
+
+      useUiStore.getState().setUtilityRailWidth('/repo/a', 999);
+      expect(useUiStore.getState().getUtilityRailState('/repo/a').width).toBe(
+        MAX_UTILITY_RAIL_WIDTH
+      );
+    });
+
+    it('clamps anchored utility pane widths and stores placements', () => {
+      useUiStore
+        .getState()
+        .setAnchoredUtilityPaneWidth('/repo/a', 'review', 10);
+      useUiStore.getState().setUtilitySurfacePlacement('/repo/a', 'review', {
+        kind: 'anchored-pane',
+        paneId: 'pane-1',
+      });
+
+      expect(
+        useUiStore.getState().getUtilityRailState('/repo/a')
+      ).toMatchObject({
+        anchoredPaneWidths: {
+          review: MIN_UTILITY_RAIL_WIDTH,
+        },
+        placements: {
+          review: {
+            kind: 'anchored-pane',
+            paneId: 'pane-1',
+          },
+        },
+      });
     });
   });
 

--- a/test/stores/ui-store.test.ts
+++ b/test/stores/ui-store.test.ts
@@ -34,10 +34,12 @@ import {
   DEFAULT_UTILITY_RAIL_WIDTH,
   MIN_UTILITY_RAIL_WIDTH,
   MAX_UTILITY_RAIL_WIDTH,
+  clearUtilityRailStateCacheForTesting,
 } from '../../frontend/src/lib/stores/ui.js';
 
 function resetStore() {
   for (const key of Object.keys(storage)) delete storage[key];
+  clearUtilityRailStateCacheForTesting();
   useUiStore.setState({
     sidebarOpen: false,
     sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
@@ -188,6 +190,25 @@ describe('ui Zustand store', () => {
       expect(useUiStore.getState().getUtilityRailState('/repo/a').width).toBe(
         MAX_UTILITY_RAIL_WIDTH
       );
+    });
+
+    it('persists utility rail width only when saved', () => {
+      useUiStore.getState().hydrateUtilityRailState('/repo/a');
+      useUiStore.getState().setUtilityRailWidth('/repo/a', 999);
+
+      expect(storage['relay-utility-rail::/repo/a']).toBe(undefined);
+
+      useUiStore.getState().saveUtilityRailState('/repo/a');
+      expect(storage['relay-utility-rail::/repo/a']).toContain(
+        `"width":${MAX_UTILITY_RAIL_WIDTH}`
+      );
+    });
+
+    it('returns a stable default utility rail state before hydration', () => {
+      const first = useUiStore.getState().getUtilityRailState('/repo/a');
+      const second = useUiStore.getState().getUtilityRailState('/repo/a');
+
+      expect(second).toBe(first);
     });
 
     it('clamps anchored utility pane widths and stores placements', () => {


### PR DESCRIPTION
## Summary
- Add workspace-scoped utility rail state with visible/hidden shell, selected tab, fixed icon rail width, persisted pane widths, and future placement metadata.
- Replace the old session right-sidebar host with `WorkspaceUtilityRail`, including files, review, logs, and stats utility panes.
- Route diff/review opening into the review utility pane and update the top-bar toggle to hide/show the whole rail for the active workspace root.
- Add a reusable `Tooltip` design-system component that resolves labels/descriptions/shortcuts from command registry action IDs, wire it through `TuiButton`, and replace native tooltips on the new rail/top-bar controls.
- Remove desktop right-sidebar slide/gutter behavior in favor of immediate reflow and shared 1px dividers.
- Address review feedback by scoping review default-branch lookup per workspace, hydrating/caching rail state before render use, keeping rail panels mounted, expanding resize hit targets, and persisting rail width only on drag end.
- Document the implementation spec, HTML layout sketch, and frontend component map.

Closes #251

## Verification
- `npm run check`
- `npx vitest run test/stores/ui-store.test.ts test/actions/registry.test.ts test/action-coverage.test.ts`
- `npx vitest run test/pr-top-bar-action.test.ts`
- `npx vitest run test/components/Tooltip.test.ts test/pr-top-bar-action.test.ts test/actions/shortcuts.test.ts`
- `npx vitest run test/stores/ui-store.test.ts test/components/Tooltip.test.ts test/pr-top-bar-action.test.ts`
- `npm run build`
- pre-push changed tests: 6 files, 59 tests passed
- latest pre-push changed tests after review-fix commit: 7 files, 64 tests passed

## Notes
- The first slice keeps stable utility tab/placement state for future drag-out panes but does not render anchored panes yet.
- Build emits existing chunk-size/dynamic-import warnings around diff components because the new review pane statically uses `DiffViewer` and `DiffSourceToggle`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a workspace-scoped utility rail with tabs for files, review/diff, logs, and stats; icon-strip behavior clears selection on repeated clicks.
  * Tooltips added across UI (including action labels and shortcuts); buttons can show formatted shortcuts.
  * Terminal file clicks open the rail’s files tab before opening files.

* **Documentation**
  * Added detailed spec, layout sketch, and integration plan for the utility rail.

* **Refactor**
  * Replaced legacy right sidebar with the utility rail; diff actions now prefer the in-rail review pane.

* **Tests**
  * Added tests for tooltip behavior and utility-rail state persistence and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->