### PR TITLE
fix: return structured errors for hermes launch failures

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -2190,19 +2190,23 @@ async function main(): Promise<void> {
     // Web-only agents bypass PTY and use ProtocolAdapter + WebSocket
     if (resolvedAgent === 'hermes') {
       const displayName = sessions.nextAgentName();
-      const { session } = await sessions.createWeb({
-        agentType: resolvedAgent,
-        cwd,
-        repoPath,
-        repoName: name,
-        worktreePath: worktreePath ?? null,
-        branchName: requestBranchName ?? '',
-        displayName,
-        port: startupConfig.port,
-        configDir,
-      });
-      gitWatcher.watch(session.cwd);
-      res.status(201).json(session);
+      try {
+        const { session } = await sessions.createWeb({
+          agentType: resolvedAgent,
+          cwd,
+          repoPath,
+          repoName: name,
+          worktreePath: worktreePath ?? null,
+          branchName: requestBranchName ?? '',
+          displayName,
+          port: startupConfig.port,
+          configDir,
+        });
+        gitWatcher.watch(session.cwd);
+        res.status(201).json(session);
+      } catch (err) {
+        sendSessionCreateError(res, err, freshConfig.maxPtySessions);
+      }
       return;
     }
 

--- a/test/hermes-session-api.e2e.test.ts
+++ b/test/hermes-session-api.e2e.test.ts
@@ -1,52 +1,50 @@
 import { test, expect } from 'vitest';
 import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
 const __dirname = import.meta.dirname;
 
-/**
- * End-to-end API test for creating a Hermes web session.
- *
- * Spins up the compiled relay-ide server with a mock `hermes` binary in PATH,
- * calls POST /sessions with agent=hermes, and verifies the response
- * contains a web session with the correct agent type.
- */
-test('POST /sessions creates a hermes web session visible in the session list', async () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hermes-api-e2e-'));
-  const configPath = path.join(tmpDir, 'config.json');
+interface StartedServer {
+  child: ChildProcess;
+  port: number;
+  tmpDir: string;
+}
 
-  // Create a mock `hermes` binary that delegates to our stub
+function writeHermesStub(tmpDir: string, body: string): void {
   const binDir = path.join(tmpDir, 'bin');
   fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'hermes'), body, { mode: 0o755 });
+}
 
+function writeWorkingHermesStub(tmpDir: string): void {
   const stubPath = path.resolve(__dirname, 'fixtures', 'hermes-gateway-stub.cjs');
-  const hermesMock = path.join(binDir, 'hermes');
 
   // The adapter calls: hermes gateway run --port <port>
   // Our stub expects: node stub.js <port>
-  // So we write a tiny wrapper that extracts --port and forwards it.
-  fs.writeFileSync(
-    hermesMock,
+  writeHermesStub(
+    tmpDir,
     `#!/usr/bin/env node
 const args = process.argv.slice(2);
 const portIdx = args.indexOf('--port');
 const port = portIdx !== -1 ? args[portIdx + 1] : process.argv[2];
 process.argv = [process.argv[0], process.argv[1], port];
 require('${stubPath.replace(/\\/g, '\\\\')}');
-`,
-    { mode: 0o755 }
+`
   );
+}
 
+async function startRelayServer(tmpDir: string): Promise<StartedServer> {
+  const configPath = path.join(tmpDir, 'config.json');
   fs.writeFileSync(
     configPath,
     JSON.stringify({ port: 0, host: '127.0.0.1', repos: [tmpDir] })
   );
 
   const serverScript = path.resolve(__dirname, '..', 'dist', 'server', 'index.js');
-
-  const envPath = binDir + ':' + (process.env.PATH ?? '');
+  const envPath = path.join(tmpDir, 'bin') + ':' + (process.env.PATH ?? '');
   const child = spawn(process.execPath, [serverScript], {
     env: {
       ...process.env,
@@ -58,77 +56,137 @@ require('${stubPath.replace(/\\/g, '\\\\')}');
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
-  try {
-    // Wait for server to print its listening port
-    const port = await new Promise<number>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(new Error('Server did not start within 10s'));
-      }, 10_000);
-      let stderr = '';
+  const port = await new Promise<number>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Server did not start within 10s'));
+    }, 10_000);
+    let stderr = '';
 
-      child.stdout.on('data', (chunk: Buffer) => {
-        const text = chunk.toString();
-        const match = text.match(/listening on [\w.]+:(\d+)/);
-        if (match) {
-          clearTimeout(timeout);
-          resolve(Number(match[1]));
-        }
-      });
-
-      child.stderr.on('data', (chunk: Buffer) => {
-        stderr += chunk.toString();
-      });
-
-      child.on('exit', (code) => {
+    child.stdout?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      const match = text.match(/listening on [\w.]+:(\d+)/);
+      if (match) {
         clearTimeout(timeout);
-        reject(new Error(`Server exited with code ${code}. stderr: ${stderr}`));
+        resolve(Number(match[1]));
+      }
+    });
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('exit', (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`Server exited with code ${code}. stderr: ${stderr}`));
+    });
+  });
+
+  return { child, port, tmpDir };
+}
+
+async function stopRelayServer(server: StartedServer): Promise<void> {
+  server.child.kill('SIGTERM');
+  await new Promise<void>((resolve) => {
+    server.child.on('exit', () => resolve());
+    setTimeout(resolve, 3000);
+  });
+  fs.rmSync(server.tmpDir, { recursive: true, force: true });
+}
+
+/**
+ * End-to-end API test for creating a Hermes web session.
+ *
+ * Spins up the compiled relay-ide server with a mock `hermes` binary in PATH,
+ * calls POST /sessions with agent=hermes, and verifies the response
+ * contains a web session with the correct agent type.
+ */
+test(
+  'POST /sessions creates a hermes web session visible in the session list',
+  async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hermes-api-e2e-'));
+    writeWorkingHermesStub(tmpDir);
+    const server = await startRelayServer(tmpDir);
+
+    try {
+      // 1) Create a hermes session via the public API
+      const createRes = await fetch(`http://127.0.0.1:${server.port}/sessions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          repoPath: tmpDir,
+          type: 'agent',
+          agent: 'hermes',
+          mode: 'web',
+        }),
       });
-    });
 
-    // 1) Create a hermes session via the public API
-    const createRes = await fetch(`http://127.0.0.1:${port}/sessions`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        repoPath: tmpDir,
-        type: 'agent',
-        agent: 'hermes',
-        mode: 'web',
-      }),
-    });
+      expect(createRes.status).toBe(201);
+      const session = (await createRes.json()) as {
+        id: string;
+        agent: string;
+        mode: string;
+        status: string;
+        sessionType?: string;
+      };
 
-    expect(createRes.status).toBe(201);
-    const session = (await createRes.json()) as {
-      id: string;
-      agent: string;
-      mode: string;
-      status: string;
-      sessionType?: string;
-    };
+      expect(session.agent).toBe('hermes');
+      expect(session.mode).toBe('web');
+      expect(session.status).toBe('active');
 
-    expect(session.agent).toBe('hermes');
-    expect(session.mode).toBe('web');
-    expect(session.status).toBe('active');
+      // 2) Verify it appears in GET /sessions
+      const listRes = await fetch(`http://127.0.0.1:${server.port}/sessions`);
+      expect(listRes.status).toBe(200);
+      const sessions = (await listRes.json()) as Array<{
+        id: string;
+        agent: string;
+        mode: string;
+      }>;
 
-    // 2) Verify it appears in GET /sessions
-    const listRes = await fetch(`http://127.0.0.1:${port}/sessions`);
-    expect(listRes.status).toBe(200);
-    const sessions = (await listRes.json()) as Array<{
-      id: string;
-      agent: string;
-      mode: string;
-    }>;
+      const found = sessions.find((s) => s.id === session.id);
+      expect(found).toBeDefined();
+      expect(found!.agent).toBe('hermes');
+      expect(found!.mode).toBe('web');
+    } finally {
+      await stopRelayServer(server);
+    }
+  },
+  20_000
+);
 
-    const found = sessions.find((s) => s.id === session.id);
-    expect(found).toBeDefined();
-    expect(found!.agent).toBe('hermes');
-    expect(found!.mode).toBe('web');
-  } finally {
-    child.kill('SIGTERM');
-    await new Promise<void>((resolve) => {
-      child.on('exit', () => resolve());
-      setTimeout(resolve, 3000);
-    });
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
+test(
+  'POST /sessions returns structured json when hermes gateway startup fails',
+  async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hermes-api-e2e-'));
+    writeHermesStub(
+      tmpDir,
+      `#!/usr/bin/env node
+process.stderr.write('mock hermes gateway failed to start\\n');
+process.exit(2);
+`
+    );
+    const server = await startRelayServer(tmpDir);
+
+    try {
+      const createRes = await fetch(`http://127.0.0.1:${server.port}/sessions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          repoPath: tmpDir,
+          type: 'agent',
+          agent: 'hermes',
+          mode: 'web',
+        }),
+      });
+
+      expect(createRes.status).toBe(500);
+      expect(createRes.headers.get('content-type')).toContain('application/json');
+      await expect(createRes.json()).resolves.toMatchObject({
+        error: 'session_create_failed',
+        message: 'Failed to create session.',
+      });
+    } finally {
+      await stopRelayServer(server);
+    }
+  },
+  20_000
+);


### PR DESCRIPTION
## Summary
- Wrap the Hermes `sessions.createWeb()` path in the same session-create error handling used by PTY sessions.
- Add a regression test where the mocked `hermes` gateway exits during launch and `/sessions` returns structured JSON instead of letting the async route reject.
- Refactor the Hermes session API e2e setup into small helpers so the success and failure cases share the same compiled-server harness.

## Why
The native Hermes integration landed in #291, but the Hermes web-session branch bypassed the existing `sendSessionCreateError()` guard. If gateway startup failed, the request could bubble out of the route and surface to the client as a gateway/proxy-style failure instead of a normal API error.

## The Case Against
This is intentionally narrow. It does **not** make Hermes gateway startup succeed if the local Hermes binary/config is broken; it only makes the API fail cleanly. If users still cannot launch Hermes after this, the next bug is inside the Hermes adapter/gateway startup contract, not the `/sessions` route error boundary.

The failure regression test waits for the adapter's existing 10s gateway readiness timeout, so it adds ~10s to this targeted e2e file. That's annoying, but it verifies the real route behavior against the compiled server instead of mocking away the bug.

## Risks and Mitigation
| Risk | Likelihood | Mitigation |
| --- | --- | --- |
| Generic 500 hides the underlying Hermes startup cause from UI users | Medium | The server logs the original error; this PR preserves existing `sendSessionCreateError()` behavior rather than inventing a new error format. |
| E2E runtime increases | Medium | Scoped to `test/hermes-session-api.e2e.test.ts`; targeted run is still ~12s. |
| Catch accidentally swallows successful session creation side effects | Low | `gitWatcher.watch()` and 201 response stay inside the success path; failure returns immediately after structured error. |

## Verification
- `npm run build`
- `npx vitest run test/hermes-session-api.e2e.test.ts test/hermes-adapter.e2e.test.ts`
- `npx eslint server/index.ts test/hermes-session-api.e2e.test.ts` (passes with existing `server/index.ts` duplicate-string warning)
