### PR TITLE
feat: expose web/tui mode selector for adapter-backed agents

### DIFF
--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -6,7 +6,7 @@ import { estimateTerminalDimensions } from '../../lib/utils.js';
 import { useConfigStore } from '../../lib/stores/config.js';
 import { useUiStore } from '../../lib/stores/ui.js';
 import { createAgentSession } from '../../lib/session-utils.js';
-import type { AgentType } from '../../lib/types.js';
+import type { AgentType, FrameworkInfo } from '../../lib/types.js';
 import './CustomizeSessionDialog.css';
 
 export interface CustomizeSessionDialogHandle {
@@ -22,9 +22,41 @@ interface Props {
   onSessionCreated?: (sessionId: string) => void;
 }
 
+type SessionLaunchMode = 'pty' | 'web';
+
+export interface SessionModeOption {
+  value: SessionLaunchMode;
+  label: string;
+}
+
+export function getSessionModeOptions(
+  frameworks: FrameworkInfo[],
+  selectedAgent: AgentType
+): SessionModeOption[] {
+  const selectedFramework = frameworks.find((f) => f.id === selectedAgent);
+  if (selectedFramework?.capabilities.supportsWebSessions === true) {
+    return [
+      { value: 'pty', label: 'tui' },
+      { value: 'web', label: 'web' },
+    ];
+  }
+  return [{ value: 'pty', label: 'tui' }];
+}
+
+export function defaultSessionModeForAgent(
+  frameworks: FrameworkInfo[],
+  selectedAgent: AgentType
+): SessionLaunchMode {
+  const supportsWeb = getSessionModeOptions(frameworks, selectedAgent).some(
+    (option) => option.value === 'web'
+  );
+  return selectedAgent === 'hermes' && supportsWeb ? 'web' : 'pty';
+}
+
 interface FormState {
   claudeArgsInput: string;
   selectedAgent: AgentType;
+  sessionMode: SessionLaunchMode;
   yoloMode: boolean;
   continueExisting: boolean;
 }
@@ -33,6 +65,7 @@ function defaultForm(): FormState {
   return {
     claudeArgsInput: '',
     selectedAgent: 'claude',
+    sessionMode: 'pty',
     yoloMode: false,
     continueExisting: false,
   };
@@ -51,7 +84,7 @@ async function createSessionFromForm(
     repoPath: workspacePath,
     worktreePath,
     type: 'agent',
-    mode: form.selectedAgent === 'hermes' ? 'web' : 'pty',
+    mode: form.sessionMode,
     continue: form.continueExisting,
     yolo: form.yoloMode,
     claudeArgs: claudeArgs.length > 0 ? claudeArgs : undefined,
@@ -83,6 +116,8 @@ function CustomizeSessionBody({
           },
         ];
 
+  const modeOptions = getSessionModeOptions(frameworkOptions, form.selectedAgent);
+
   return (
     <div className="customize-session-body-fields">
       {workspaceName && (
@@ -97,9 +132,16 @@ function CustomizeSessionBody({
           className="customize-session-dialog-select"
           data-track="dialog.customize-session.agent"
           value={form.selectedAgent}
-          onChange={(e) =>
-            onFormChange({ selectedAgent: e.currentTarget.value as AgentType })
-          }
+          onChange={(e) => {
+            const selectedAgent = e.currentTarget.value as AgentType;
+            onFormChange({
+              selectedAgent,
+              sessionMode: defaultSessionModeForAgent(
+                frameworkOptions,
+                selectedAgent
+              ),
+            });
+          }}
         >
           {frameworkOptions.map((framework) => (
             <option key={framework.id} value={framework.id}>
@@ -108,6 +150,30 @@ function CustomizeSessionBody({
           ))}
         </select>
       </div>
+      {modeOptions.length > 1 && (
+        <div className="customize-session-dialog-field">
+          <label className="customize-session-dialog-label" htmlFor="cs-mode">
+            interface
+          </label>
+          <select
+            id="cs-mode"
+            className="customize-session-dialog-select"
+            data-track="dialog.customize-session.mode"
+            value={form.sessionMode}
+            onChange={(e) =>
+              onFormChange({
+                sessionMode: e.currentTarget.value as SessionLaunchMode,
+              })
+            }
+          >
+            {modeOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
       <TuiCheckbox
         checked={form.continueExisting}
         onChange={(checked) => onFormChange({ continueExisting: checked })}
@@ -163,10 +229,12 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
         setWorkspaceName(workspace.name);
         await useConfigStore.getState().refreshConfig();
         const config = useConfigStore.getState();
+        const selectedAgent =
+          preselectedFramework ?? (config.defaultAgent as AgentType);
         setForm({
           claudeArgsInput: '',
-          selectedAgent:
-            preselectedFramework ?? (config.defaultAgent as AgentType),
+          selectedAgent,
+          sessionMode: defaultSessionModeForAgent(config.frameworks, selectedAgent),
           yoloMode: config.defaultYolo,
           continueExisting: config.defaultContinue,
         });

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -33,6 +33,7 @@ export interface FrameworkInfo {
     supportsYolo: boolean;
     supportsHooks: boolean;
     supportsTelemetry: boolean;
+    supportsWebSessions?: boolean;
   };
   eventSource: EventSourceType;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -2063,6 +2063,7 @@ async function main(): Promise<void> {
       repoPath,
       worktreePath,
       type = 'agent',
+      mode,
       agent,
       yolo,
       useTmux,
@@ -2081,6 +2082,7 @@ async function main(): Promise<void> {
       repoPath?: string;
       worktreePath?: string | null;
       type?: 'agent' | 'terminal';
+      mode?: 'pty' | 'web';
       agent?: AgentType;
       yolo?: boolean;
       useTmux?: boolean;
@@ -2187,8 +2189,11 @@ async function main(): Promise<void> {
     });
     const resolvedAgent = resolved.agent;
 
-    // Web-only agents bypass PTY and use ProtocolAdapter + WebSocket
-    if (resolvedAgent === 'hermes') {
+    // Web-mode agents bypass PTY and use ProtocolAdapter + WebSocket.
+    // Hermes remains web by default for backwards compatibility with the
+    // original native-Hermes launch path.
+    const requestedMode = mode ?? (resolvedAgent === 'hermes' ? 'web' : 'pty');
+    if (requestedMode === 'web') {
       const displayName = sessions.nextAgentName();
       try {
         const { session } = await sessions.createWeb({

--- a/server/types.ts
+++ b/server/types.ts
@@ -45,6 +45,7 @@ export interface AgentFramework {
     supportsYolo: boolean;
     supportsTelemetry: boolean;
     supportsAttachedRuntime: boolean;
+    supportsWebSessions?: boolean;
   };
 }
 
@@ -63,6 +64,7 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: true,
       supportsAttachedRuntime: false,
+      supportsWebSessions: true,
     },
   },
   codex: {
@@ -79,6 +81,7 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: false,
       supportsAttachedRuntime: false,
+      supportsWebSessions: true,
     },
   },
   opencode: {
@@ -113,6 +116,7 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: true,
       supportsAttachedRuntime: true,
+      supportsWebSessions: true,
     },
   },
   hermes: {
@@ -129,6 +133,7 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: true,
       supportsAttachedRuntime: false,
+      supportsWebSessions: true,
     },
   },
 };

--- a/test/customize-session-dialog.test.ts
+++ b/test/customize-session-dialog.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultSessionModeForAgent,
+  getSessionModeOptions,
+} from '../frontend/src/components/dialogs/CustomizeSessionDialog.js';
+import type { FrameworkInfo } from '../frontend/src/lib/types.js';
+
+function framework(id: string): FrameworkInfo {
+  return {
+    id,
+    displayName: id,
+    command: id,
+    capabilities: {
+      supportsContinue: true,
+      supportsYolo: true,
+      supportsHooks: true,
+      supportsTelemetry: false,
+      supportsWebSessions: ['claude', 'codex', 'opencode', 'hermes'].includes(id),
+    },
+    eventSource: 'hooks',
+  };
+}
+
+describe('CustomizeSessionDialog session mode options', () => {
+  it('shows tui and web for agents with web-session adapters', () => {
+    const frameworks = [framework('claude'), framework('codex'), framework('opencode')];
+
+    expect(getSessionModeOptions(frameworks, 'claude')).toEqual([
+      { value: 'pty', label: 'tui' },
+      { value: 'web', label: 'web' },
+    ]);
+  });
+
+  it('shows only tui for agents without web-session adapters', () => {
+    expect(getSessionModeOptions([framework('custom')], 'custom')).toEqual([
+      { value: 'pty', label: 'tui' },
+    ]);
+  });
+
+  it('defaults hermes to web and other agents to tui', () => {
+    expect(defaultSessionModeForAgent([framework('hermes')], 'hermes')).toBe('web');
+    expect(defaultSessionModeForAgent([framework('claude')], 'claude')).toBe('pty');
+  });
+});

--- a/test/hermes-session-api.e2e.test.ts
+++ b/test/hermes-session-api.e2e.test.ts
@@ -13,10 +13,10 @@ interface StartedServer {
   tmpDir: string;
 }
 
-function writeHermesStub(tmpDir: string, body: string): void {
+function writeAgentStub(tmpDir: string, agent: string, body: string): void {
   const binDir = path.join(tmpDir, 'bin');
   fs.mkdirSync(binDir, { recursive: true });
-  fs.writeFileSync(path.join(binDir, 'hermes'), body, { mode: 0o755 });
+  fs.writeFileSync(path.join(binDir, agent), body, { mode: 0o755 });
 }
 
 function writeWorkingHermesStub(tmpDir: string): void {
@@ -24,8 +24,9 @@ function writeWorkingHermesStub(tmpDir: string): void {
 
   // The adapter calls: hermes gateway run --port <port>
   // Our stub expects: node stub.js <port>
-  writeHermesStub(
+  writeAgentStub(
     tmpDir,
+    'hermes',
     `#!/usr/bin/env node
 const args = process.argv.slice(2);
 const portIdx = args.indexOf('--port');
@@ -154,11 +155,54 @@ test(
 );
 
 test(
+  'POST /sessions honors web mode for claude protocol adapter sessions',
+  async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-claude-api-e2e-'));
+    writeAgentStub(
+      tmpDir,
+      'claude',
+      `#!/usr/bin/env node
+process.stdin.resume();
+setInterval(() => {}, 1000);
+`
+    );
+    const server = await startRelayServer(tmpDir);
+
+    try {
+      const createRes = await fetch(`http://127.0.0.1:${server.port}/sessions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          repoPath: tmpDir,
+          type: 'agent',
+          agent: 'claude',
+          mode: 'web',
+        }),
+      });
+
+      expect(createRes.status).toBe(201);
+      const session = (await createRes.json()) as {
+        agent: string;
+        mode: string;
+        adapterType?: string;
+      };
+      expect(session.agent).toBe('claude');
+      expect(session.mode).toBe('web');
+      expect(session.adapterType).toBe('claude');
+    } finally {
+      await stopRelayServer(server);
+    }
+  },
+  20_000
+);
+
+test(
   'POST /sessions returns structured json when hermes gateway startup fails',
   async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hermes-api-e2e-'));
-    writeHermesStub(
+    writeAgentStub(
       tmpDir,
+      'hermes',
       `#!/usr/bin/env node
 process.stderr.write('mock hermes gateway failed to start\\n');
 process.exit(2);


### PR DESCRIPTION
## Summary
- Adds an `interface` dropdown to Customize Session for agents that advertise web-session adapters.
- Labels the UI choices as `tui` and `web`, while preserving the internal `pty`/`web` mode values.
- Marks Claude, Codex, OpenCode, and Hermes as supporting web sessions in framework capabilities.
- Makes `POST /sessions` honor `mode: 'web'` for any registered protocol adapter, not just Hermes.

## Why
Hermes had the only reachable web launch path even though Claude/Codex/OpenCode protocol adapters already exist. This made the frontend type support for `mode: 'web'` mostly fake. The dialog now exposes the choice where it is actually supported, and the backend route actually honors it. wild concept, i know.

## The Case Against
This is stacked on #293 (`fix/hermes-session-create-502`) because both changes touch the same Hermes web-session branch in `server/index.ts`. If #293 merges first, this PR should be retargeted to `nightly` or rebased.

The bigger product question is whether every adapter-backed web session is truly production-ready. Claude/Codex/OpenCode web sessions use the existing hook/adapter path and can now be launched, but this PR does not do a full UX audit of every event mapping. If one adapter has weaker streaming/approval behavior, this exposes it sooner.

## Risks and Mitigation
| Risk | Likelihood | Mitigation |
| --- | --- | --- |
| Users pick `web` for an adapter path that is less battle-tested than TUI | Medium | Only agents advertising `supportsWebSessions` get the dropdown; defaults remain `tui` except Hermes. |
| Backend accepts `mode: 'web'` for an agent with no adapter if called manually | Low | It fails through `sessions.createWeb()` / adapter registration and returns structured session-create error handling from #293. |
| Stacked branch confusion | Medium | PR base is explicitly #293's branch; retarget after #293 merges. |

## Verification
- `npm run build`
- `npx vitest run test/customize-session-dialog.test.ts test/hermes-session-api.e2e.test.ts test/hermes-adapter.e2e.test.ts`
- `npx eslint frontend/src/components/dialogs/CustomizeSessionDialog.tsx frontend/src/lib/types.ts server/index.ts server/types.ts test/hermes-session-api.e2e.test.ts test/customize-session-dialog.test.ts` (passes with existing `server/index.ts` duplicate-string warning)

## Notes
- I also tried the existing Playwright CustomizeSessionDialog spec. Local run is blocked by repo fixture/config assumptions (`/test-customize-session-dialog.html` falls through to the normal app with no repos), so I did not change that e2e file.
