### PR TITLE
feat: expose web/tui mode selector for adapter-backed agents

### DIFF
--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -6,7 +6,7 @@ import { estimateTerminalDimensions } from '../../lib/utils.js';
 import { useConfigStore } from '../../lib/stores/config.js';
 import { useUiStore } from '../../lib/stores/ui.js';
 import { createAgentSession } from '../../lib/session-utils.js';
-import type { AgentType } from '../../lib/types.js';
+import type { AgentType, FrameworkInfo } from '../../lib/types.js';
 import './CustomizeSessionDialog.css';
 
 export interface CustomizeSessionDialogHandle {
@@ -22,9 +22,41 @@ interface Props {
   onSessionCreated?: (sessionId: string) => void;
 }
 
+type SessionLaunchMode = 'pty' | 'web';
+
+export interface SessionModeOption {
+  value: SessionLaunchMode;
+  label: string;
+}
+
+export function getSessionModeOptions(
+  frameworks: FrameworkInfo[],
+  selectedAgent: AgentType
+): SessionModeOption[] {
+  const selectedFramework = frameworks.find((f) => f.id === selectedAgent);
+  if (selectedFramework?.capabilities.supportsWebSessions === true) {
+    return [
+      { value: 'pty', label: 'tui' },
+      { value: 'web', label: 'web' },
+    ];
+  }
+  return [{ value: 'pty', label: 'tui' }];
+}
+
+export function defaultSessionModeForAgent(
+  frameworks: FrameworkInfo[],
+  selectedAgent: AgentType
+): SessionLaunchMode {
+  const supportsWeb = getSessionModeOptions(frameworks, selectedAgent).some(
+    (option) => option.value === 'web'
+  );
+  return selectedAgent === 'hermes' && supportsWeb ? 'web' : 'pty';
+}
+
 interface FormState {
   claudeArgsInput: string;
   selectedAgent: AgentType;
+  sessionMode: SessionLaunchMode;
   yoloMode: boolean;
   continueExisting: boolean;
 }
@@ -33,6 +65,7 @@ function defaultForm(): FormState {
   return {
     claudeArgsInput: '',
     selectedAgent: 'claude',
+    sessionMode: 'pty',
     yoloMode: false,
     continueExisting: false,
   };
@@ -51,7 +84,7 @@ async function createSessionFromForm(
     repoPath: workspacePath,
     worktreePath,
     type: 'agent',
-    mode: form.selectedAgent === 'hermes' ? 'web' : 'pty',
+    mode: form.sessionMode,
     continue: form.continueExisting,
     yolo: form.yoloMode,
     claudeArgs: claudeArgs.length > 0 ? claudeArgs : undefined,
@@ -80,8 +113,19 @@ function CustomizeSessionBody({
           {
             id: form.selectedAgent,
             displayName: form.selectedAgent,
-          },
+            command: form.selectedAgent,
+            capabilities: {
+              supportsContinue: false,
+              supportsYolo: false,
+              supportsHooks: false,
+              supportsTelemetry: false,
+              supportsWebSessions: false,
+            },
+            eventSource: 'parser',
+          } satisfies FrameworkInfo,
         ];
+
+  const modeOptions = getSessionModeOptions(frameworkOptions, form.selectedAgent);
 
   return (
     <div className="customize-session-body-fields">
@@ -97,9 +141,16 @@ function CustomizeSessionBody({
           className="customize-session-dialog-select"
           data-track="dialog.customize-session.agent"
           value={form.selectedAgent}
-          onChange={(e) =>
-            onFormChange({ selectedAgent: e.currentTarget.value as AgentType })
-          }
+          onChange={(e) => {
+            const selectedAgent = e.currentTarget.value as AgentType;
+            onFormChange({
+              selectedAgent,
+              sessionMode: defaultSessionModeForAgent(
+                frameworkOptions,
+                selectedAgent
+              ),
+            });
+          }}
         >
           {frameworkOptions.map((framework) => (
             <option key={framework.id} value={framework.id}>
@@ -108,6 +159,30 @@ function CustomizeSessionBody({
           ))}
         </select>
       </div>
+      {modeOptions.length > 1 && (
+        <div className="customize-session-dialog-field">
+          <label className="customize-session-dialog-label" htmlFor="cs-mode">
+            interface
+          </label>
+          <select
+            id="cs-mode"
+            className="customize-session-dialog-select"
+            data-track="dialog.customize-session.mode"
+            value={form.sessionMode}
+            onChange={(e) =>
+              onFormChange({
+                sessionMode: e.currentTarget.value as SessionLaunchMode,
+              })
+            }
+          >
+            {modeOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
       <TuiCheckbox
         checked={form.continueExisting}
         onChange={(checked) => onFormChange({ continueExisting: checked })}
@@ -163,10 +238,12 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
         setWorkspaceName(workspace.name);
         await useConfigStore.getState().refreshConfig();
         const config = useConfigStore.getState();
+        const selectedAgent =
+          preselectedFramework ?? (config.defaultAgent as AgentType);
         setForm({
           claudeArgsInput: '',
-          selectedAgent:
-            preselectedFramework ?? (config.defaultAgent as AgentType),
+          selectedAgent,
+          sessionMode: defaultSessionModeForAgent(config.frameworks, selectedAgent),
           yoloMode: config.defaultYolo,
           continueExisting: config.defaultContinue,
         });

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -33,6 +33,7 @@ export interface FrameworkInfo {
     supportsYolo: boolean;
     supportsHooks: boolean;
     supportsTelemetry: boolean;
+    supportsWebSessions?: boolean;
   };
   eventSource: EventSourceType;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -2190,19 +2190,23 @@ async function main(): Promise<void> {
     // Web-only agents bypass PTY and use ProtocolAdapter + WebSocket
     if (resolvedAgent === 'hermes') {
       const displayName = sessions.nextAgentName();
-      const { session } = await sessions.createWeb({
-        agentType: resolvedAgent,
-        cwd,
-        repoPath,
-        repoName: name,
-        worktreePath: worktreePath ?? null,
-        branchName: requestBranchName ?? '',
-        displayName,
-        port: startupConfig.port,
-        configDir,
-      });
-      gitWatcher.watch(session.cwd);
-      res.status(201).json(session);
+      try {
+        const { session } = await sessions.createWeb({
+          agentType: resolvedAgent,
+          cwd,
+          repoPath,
+          repoName: name,
+          worktreePath: worktreePath ?? null,
+          branchName: requestBranchName ?? '',
+          displayName,
+          port: startupConfig.port,
+          configDir,
+        });
+        gitWatcher.watch(session.cwd);
+        res.status(201).json(session);
+      } catch (err) {
+        sendSessionCreateError(res, err, freshConfig.maxPtySessions);
+      }
       return;
     }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -2063,6 +2063,7 @@ async function main(): Promise<void> {
       repoPath,
       worktreePath,
       type = 'agent',
+      mode,
       agent,
       yolo,
       useTmux,
@@ -2081,6 +2082,7 @@ async function main(): Promise<void> {
       repoPath?: string;
       worktreePath?: string | null;
       type?: 'agent' | 'terminal';
+      mode?: 'pty' | 'web';
       agent?: AgentType;
       yolo?: boolean;
       useTmux?: boolean;
@@ -2187,8 +2189,11 @@ async function main(): Promise<void> {
     });
     const resolvedAgent = resolved.agent;
 
-    // Web-only agents bypass PTY and use ProtocolAdapter + WebSocket
-    if (resolvedAgent === 'hermes') {
+    // Web-mode agents bypass PTY and use ProtocolAdapter + WebSocket.
+    // Hermes remains web by default for backwards compatibility with the
+    // original native-Hermes launch path.
+    const requestedMode = mode ?? (resolvedAgent === 'hermes' ? 'web' : 'pty');
+    if (requestedMode === 'web') {
       const displayName = sessions.nextAgentName();
       try {
         const { session } = await sessions.createWeb({

--- a/server/types.ts
+++ b/server/types.ts
@@ -45,6 +45,7 @@ export interface AgentFramework {
     supportsYolo: boolean;
     supportsTelemetry: boolean;
     supportsAttachedRuntime: boolean;
+    supportsWebSessions?: boolean;
   };
 }
 
@@ -63,6 +64,7 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: true,
       supportsAttachedRuntime: false,
+      supportsWebSessions: true,
     },
   },
   codex: {
@@ -79,6 +81,7 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: false,
       supportsAttachedRuntime: false,
+      supportsWebSessions: true,
     },
   },
   opencode: {
@@ -113,6 +116,7 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: true,
       supportsAttachedRuntime: true,
+      supportsWebSessions: true,
     },
   },
   hermes: {
@@ -129,6 +133,7 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: true,
       supportsAttachedRuntime: false,
+      supportsWebSessions: true,
     },
   },
 };

--- a/test/customize-session-dialog.test.ts
+++ b/test/customize-session-dialog.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultSessionModeForAgent,
+  getSessionModeOptions,
+} from '../frontend/src/components/dialogs/CustomizeSessionDialog.js';
+import type { FrameworkInfo } from '../frontend/src/lib/types.js';
+
+function framework(id: string): FrameworkInfo {
+  return {
+    id,
+    displayName: id,
+    command: id,
+    capabilities: {
+      supportsContinue: true,
+      supportsYolo: true,
+      supportsHooks: true,
+      supportsTelemetry: false,
+      supportsWebSessions: ['claude', 'codex', 'opencode', 'hermes'].includes(id),
+    },
+    eventSource: 'hooks',
+  };
+}
+
+describe('CustomizeSessionDialog session mode options', () => {
+  it('shows tui and web for agents with web-session adapters', () => {
+    const frameworks = [framework('claude'), framework('codex'), framework('opencode')];
+
+    expect(getSessionModeOptions(frameworks, 'claude')).toEqual([
+      { value: 'pty', label: 'tui' },
+      { value: 'web', label: 'web' },
+    ]);
+  });
+
+  it('shows only tui for agents without web-session adapters', () => {
+    expect(getSessionModeOptions([framework('custom')], 'custom')).toEqual([
+      { value: 'pty', label: 'tui' },
+    ]);
+  });
+
+  it('defaults hermes to web and other agents to tui', () => {
+    expect(defaultSessionModeForAgent([framework('hermes')], 'hermes')).toBe('web');
+    expect(defaultSessionModeForAgent([framework('claude')], 'claude')).toBe('pty');
+  });
+});

--- a/test/hermes-session-api.e2e.test.ts
+++ b/test/hermes-session-api.e2e.test.ts
@@ -1,52 +1,50 @@
 import { test, expect } from 'vitest';
 import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
 const __dirname = import.meta.dirname;
 
-/**
- * End-to-end API test for creating a Hermes web session.
- *
- * Spins up the compiled relay-ide server with a mock `hermes` binary in PATH,
- * calls POST /sessions with agent=hermes, and verifies the response
- * contains a web session with the correct agent type.
- */
-test('POST /sessions creates a hermes web session visible in the session list', async () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hermes-api-e2e-'));
-  const configPath = path.join(tmpDir, 'config.json');
+interface StartedServer {
+  child: ChildProcess;
+  port: number;
+  tmpDir: string;
+}
 
-  // Create a mock `hermes` binary that delegates to our stub
+function writeHermesStub(tmpDir: string, body: string): void {
   const binDir = path.join(tmpDir, 'bin');
   fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'hermes'), body, { mode: 0o755 });
+}
 
+function writeWorkingHermesStub(tmpDir: string): void {
   const stubPath = path.resolve(__dirname, 'fixtures', 'hermes-gateway-stub.cjs');
-  const hermesMock = path.join(binDir, 'hermes');
 
   // The adapter calls: hermes gateway run --port <port>
   // Our stub expects: node stub.js <port>
-  // So we write a tiny wrapper that extracts --port and forwards it.
-  fs.writeFileSync(
-    hermesMock,
+  writeHermesStub(
+    tmpDir,
     `#!/usr/bin/env node
 const args = process.argv.slice(2);
 const portIdx = args.indexOf('--port');
 const port = portIdx !== -1 ? args[portIdx + 1] : process.argv[2];
 process.argv = [process.argv[0], process.argv[1], port];
 require('${stubPath.replace(/\\/g, '\\\\')}');
-`,
-    { mode: 0o755 }
+`
   );
+}
 
+async function startRelayServer(tmpDir: string): Promise<StartedServer> {
+  const configPath = path.join(tmpDir, 'config.json');
   fs.writeFileSync(
     configPath,
     JSON.stringify({ port: 0, host: '127.0.0.1', repos: [tmpDir] })
   );
 
   const serverScript = path.resolve(__dirname, '..', 'dist', 'server', 'index.js');
-
-  const envPath = binDir + ':' + (process.env.PATH ?? '');
+  const envPath = path.join(tmpDir, 'bin') + ':' + (process.env.PATH ?? '');
   const child = spawn(process.execPath, [serverScript], {
     env: {
       ...process.env,
@@ -58,77 +56,137 @@ require('${stubPath.replace(/\\/g, '\\\\')}');
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
-  try {
-    // Wait for server to print its listening port
-    const port = await new Promise<number>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(new Error('Server did not start within 10s'));
-      }, 10_000);
-      let stderr = '';
+  const port = await new Promise<number>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Server did not start within 10s'));
+    }, 10_000);
+    let stderr = '';
 
-      child.stdout.on('data', (chunk: Buffer) => {
-        const text = chunk.toString();
-        const match = text.match(/listening on [\w.]+:(\d+)/);
-        if (match) {
-          clearTimeout(timeout);
-          resolve(Number(match[1]));
-        }
-      });
-
-      child.stderr.on('data', (chunk: Buffer) => {
-        stderr += chunk.toString();
-      });
-
-      child.on('exit', (code) => {
+    child.stdout?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      const match = text.match(/listening on [\w.]+:(\d+)/);
+      if (match) {
         clearTimeout(timeout);
-        reject(new Error(`Server exited with code ${code}. stderr: ${stderr}`));
+        resolve(Number(match[1]));
+      }
+    });
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('exit', (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`Server exited with code ${code}. stderr: ${stderr}`));
+    });
+  });
+
+  return { child, port, tmpDir };
+}
+
+async function stopRelayServer(server: StartedServer): Promise<void> {
+  server.child.kill('SIGTERM');
+  await new Promise<void>((resolve) => {
+    server.child.on('exit', () => resolve());
+    setTimeout(resolve, 3000);
+  });
+  fs.rmSync(server.tmpDir, { recursive: true, force: true });
+}
+
+/**
+ * End-to-end API test for creating a Hermes web session.
+ *
+ * Spins up the compiled relay-ide server with a mock `hermes` binary in PATH,
+ * calls POST /sessions with agent=hermes, and verifies the response
+ * contains a web session with the correct agent type.
+ */
+test(
+  'POST /sessions creates a hermes web session visible in the session list',
+  async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hermes-api-e2e-'));
+    writeWorkingHermesStub(tmpDir);
+    const server = await startRelayServer(tmpDir);
+
+    try {
+      // 1) Create a hermes session via the public API
+      const createRes = await fetch(`http://127.0.0.1:${server.port}/sessions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          repoPath: tmpDir,
+          type: 'agent',
+          agent: 'hermes',
+          mode: 'web',
+        }),
       });
-    });
 
-    // 1) Create a hermes session via the public API
-    const createRes = await fetch(`http://127.0.0.1:${port}/sessions`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        repoPath: tmpDir,
-        type: 'agent',
-        agent: 'hermes',
-        mode: 'web',
-      }),
-    });
+      expect(createRes.status).toBe(201);
+      const session = (await createRes.json()) as {
+        id: string;
+        agent: string;
+        mode: string;
+        status: string;
+        sessionType?: string;
+      };
 
-    expect(createRes.status).toBe(201);
-    const session = (await createRes.json()) as {
-      id: string;
-      agent: string;
-      mode: string;
-      status: string;
-      sessionType?: string;
-    };
+      expect(session.agent).toBe('hermes');
+      expect(session.mode).toBe('web');
+      expect(session.status).toBe('active');
 
-    expect(session.agent).toBe('hermes');
-    expect(session.mode).toBe('web');
-    expect(session.status).toBe('active');
+      // 2) Verify it appears in GET /sessions
+      const listRes = await fetch(`http://127.0.0.1:${server.port}/sessions`);
+      expect(listRes.status).toBe(200);
+      const sessions = (await listRes.json()) as Array<{
+        id: string;
+        agent: string;
+        mode: string;
+      }>;
 
-    // 2) Verify it appears in GET /sessions
-    const listRes = await fetch(`http://127.0.0.1:${port}/sessions`);
-    expect(listRes.status).toBe(200);
-    const sessions = (await listRes.json()) as Array<{
-      id: string;
-      agent: string;
-      mode: string;
-    }>;
+      const found = sessions.find((s) => s.id === session.id);
+      expect(found).toBeDefined();
+      expect(found!.agent).toBe('hermes');
+      expect(found!.mode).toBe('web');
+    } finally {
+      await stopRelayServer(server);
+    }
+  },
+  20_000
+);
 
-    const found = sessions.find((s) => s.id === session.id);
-    expect(found).toBeDefined();
-    expect(found!.agent).toBe('hermes');
-    expect(found!.mode).toBe('web');
-  } finally {
-    child.kill('SIGTERM');
-    await new Promise<void>((resolve) => {
-      child.on('exit', () => resolve());
-      setTimeout(resolve, 3000);
-    });
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-});
+test(
+  'POST /sessions returns structured json when hermes gateway startup fails',
+  async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hermes-api-e2e-'));
+    writeHermesStub(
+      tmpDir,
+      `#!/usr/bin/env node
+process.stderr.write('mock hermes gateway failed to start\\n');
+process.exit(2);
+`
+    );
+    const server = await startRelayServer(tmpDir);
+
+    try {
+      const createRes = await fetch(`http://127.0.0.1:${server.port}/sessions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          repoPath: tmpDir,
+          type: 'agent',
+          agent: 'hermes',
+          mode: 'web',
+        }),
+      });
+
+      expect(createRes.status).toBe(500);
+      expect(createRes.headers.get('content-type')).toContain('application/json');
+      await expect(createRes.json()).resolves.toMatchObject({
+        error: 'session_create_failed',
+        message: 'Failed to create session.',
+      });
+    } finally {
+      await stopRelayServer(server);
+    }
+  },
+  20_000
+);

--- a/test/hermes-session-api.e2e.test.ts
+++ b/test/hermes-session-api.e2e.test.ts
@@ -13,10 +13,10 @@ interface StartedServer {
   tmpDir: string;
 }
 
-function writeHermesStub(tmpDir: string, body: string): void {
+function writeAgentStub(tmpDir: string, agent: string, body: string): void {
   const binDir = path.join(tmpDir, 'bin');
   fs.mkdirSync(binDir, { recursive: true });
-  fs.writeFileSync(path.join(binDir, 'hermes'), body, { mode: 0o755 });
+  fs.writeFileSync(path.join(binDir, agent), body, { mode: 0o755 });
 }
 
 function writeWorkingHermesStub(tmpDir: string): void {
@@ -24,8 +24,9 @@ function writeWorkingHermesStub(tmpDir: string): void {
 
   // The adapter calls: hermes gateway run --port <port>
   // Our stub expects: node stub.js <port>
-  writeHermesStub(
+  writeAgentStub(
     tmpDir,
+    'hermes',
     `#!/usr/bin/env node
 const args = process.argv.slice(2);
 const portIdx = args.indexOf('--port');
@@ -154,11 +155,54 @@ test(
 );
 
 test(
+  'POST /sessions honors web mode for claude protocol adapter sessions',
+  async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-claude-api-e2e-'));
+    writeAgentStub(
+      tmpDir,
+      'claude',
+      `#!/usr/bin/env node
+process.stdin.resume();
+setInterval(() => {}, 1000);
+`
+    );
+    const server = await startRelayServer(tmpDir);
+
+    try {
+      const createRes = await fetch(`http://127.0.0.1:${server.port}/sessions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          repoPath: tmpDir,
+          type: 'agent',
+          agent: 'claude',
+          mode: 'web',
+        }),
+      });
+
+      expect(createRes.status).toBe(201);
+      const session = (await createRes.json()) as {
+        agent: string;
+        mode: string;
+        adapterType?: string;
+      };
+      expect(session.agent).toBe('claude');
+      expect(session.mode).toBe('web');
+      expect(session.adapterType).toBe('claude');
+    } finally {
+      await stopRelayServer(server);
+    }
+  },
+  20_000
+);
+
+test(
   'POST /sessions returns structured json when hermes gateway startup fails',
   async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hermes-api-e2e-'));
-    writeHermesStub(
+    writeAgentStub(
       tmpDir,
+      'hermes',
       `#!/usr/bin/env node
 process.stderr.write('mock hermes gateway failed to start\\n');
 process.exit(2);


### PR DESCRIPTION
## Summary
- Adds an `interface` dropdown to Customize Session for adapter-backed agents, with `tui` and `web` options.
- Marks Claude, Codex, OpenCode, and Hermes as supporting web sessions in framework capabilities.
- Makes `POST /sessions` honor `mode: 'web'` for any registered protocol adapter instead of only Hermes.
- Includes the Hermes launch failure fix from #293 so the standalone PR returns structured JSON errors when gateway startup fails.

## Why
The UI already had type-level support for `mode: 'web'`, but only Hermes could actually reach the web-session path. Claude/Codex/OpenCode had registered protocol adapters but no UI entry point. This makes the selector real instead of fake wiring, because apparently we enjoy shipping Schrödinger features.

## Supersedes
- Supersedes #293
- Supersedes #295

## The Case Against
This exposes Claude/Codex/OpenCode web sessions that are less battle-tested than the default TUI/tmux path. The default remains `tui` for those agents, and only agents with `supportsWebSessions` show the dropdown. Hermes keeps its `web` default.

This PR intentionally combines the #293 structured-error fix with the mode selector so it can land cleanly against `nightly` as a standalone PR. Slightly bigger diff, less stacked-PR nonsense.

## Risks and Mitigation
| Risk | Likelihood | Mitigation |
| --- | --- | --- |
| Users pick `web` for a weaker adapter path | Medium | Defaults remain `tui` except Hermes; dropdown only appears for advertised web-session support. |
| Manual API callers request `web` for unknown adapters | Low | Adapter creation fails through existing createWeb path and returns structured error handling. |
| Extra e2e runtime | Medium | Regression test is scoped to Hermes/session API and targeted suite still runs in ~12s locally. |

## Verification
- `npm run build`
- `npx vitest run test/customize-session-dialog.test.ts test/hermes-session-api.e2e.test.ts test/hermes-adapter.e2e.test.ts`
- `npx eslint frontend/src/components/dialogs/CustomizeSessionDialog.tsx frontend/src/lib/types.ts server/index.ts server/types.ts test/hermes-session-api.e2e.test.ts test/customize-session-dialog.test.ts` (passes with existing `server/index.ts` duplicate-string warning)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now select between different session interface types (TUI or Web) when creating sessions, with availability based on agent capabilities.
  * Session interface defaults are intelligently determined when switching agents.

* **Bug Fixes**
  * Improved error handling for web session creation failures.

* **Tests**
  * Added test coverage for session mode selection logic and end-to-end session creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->