### PR TITLE
Make tmux env redaction test deterministic

### DIFF
--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -109,7 +109,7 @@ function writeTmuxEnvWrapper(
   command: string,
   args: string[],
   env: NodeJS.ProcessEnv
-): { command: string; args: string[] } {
+): { command: string; args: string[]; wrapperPath: string } {
   const dir = path.join(os.tmpdir(), 'relay-ide', id);
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   const wrapperPath = tmuxEnvWrapperPath(id);
@@ -131,7 +131,25 @@ exec "$@"
     { encoding: 'utf-8', mode: 0o700 }
   );
   fs.chmodSync(wrapperPath, 0o700);
-  return { command: '/bin/sh', args: [wrapperPath, command, ...args] };
+  return {
+    command: '/bin/sh',
+    args: [wrapperPath, command, ...args],
+    wrapperPath,
+  };
+}
+
+export function resolveTmuxWrappedSpawn(
+  id: string,
+  command: string,
+  args: string[],
+  tmuxSessionName: string,
+  env: NodeJS.ProcessEnv
+): { command: string; args: string[]; wrapperPath: string } {
+  const wrapped = writeTmuxEnvWrapper(id, command, args, env);
+  return {
+    ...resolveTmuxSpawn(wrapped.command, wrapped.args, tmuxSessionName),
+    wrapperPath: wrapped.wrapperPath,
+  };
 }
 
 function shellQuote(value: string): string {
@@ -708,11 +726,12 @@ function resolveSpawnTarget(
       tmuxSessionName,
     };
   } else {
-    const wrapped = writeTmuxEnvWrapper(id, resolvedCommand, args, env);
-    const tmux = resolveTmuxSpawn(
-      wrapped.command,
-      wrapped.args,
-      tmuxSessionName
+    const tmux = resolveTmuxWrappedSpawn(
+      id,
+      resolvedCommand,
+      args,
+      tmuxSessionName,
+      env
     );
     return {
       spawnCommand: tmux.command,
@@ -1183,16 +1202,12 @@ function tryRetrySpawn(
   if (ctx.useTmux && ctx.tmuxSessionName) {
     const retryTmuxName = ctx.tmuxSessionName + '-retry';
     session.tmuxSessionName = retryTmuxName;
-    const wrapped = writeTmuxEnvWrapper(
+    const tmux = resolveTmuxWrappedSpawn(
       ctx.id,
       ctx.resolvedCommand,
       retryArgs,
+      retryTmuxName,
       ctx.env
-    );
-    const tmux = resolveTmuxSpawn(
-      wrapped.command,
-      wrapped.args,
-      retryTmuxName
     );
     retryCommand = tmux.command;
     retrySpawnArgs = tmux.args;

--- a/test/pty-handler-multi-agent.test.ts
+++ b/test/pty-handler-multi-agent.test.ts
@@ -2,13 +2,10 @@ import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 import * as sessions from '../server/sessions.js';
 import type { PtySession } from '../server/types.js';
 
 const createdIds: string[] = [];
-const execFileAsync = promisify(execFile);
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -179,45 +176,5 @@ describe('PTY multi-agent hook/plugin wiring', () => {
       'OPENCODE_CONFIG_CONTENT='
     );
     expect(output).toMatch(/OPENCODE_CONFIG_CONTENT=.*"permission"/);
-  });
-
-  it('keeps inherited sensitive env out of tmux argv while preserving child env', async () => {
-    const originalToken = process.env.GITHUB_TOKEN;
-    process.env.GITHUB_TOKEN = 'relay-secret-token-for-tmux-test';
-    try {
-      const result = sessions.create({
-        repoName: 'test-repo',
-        repoPath: '/tmp',
-        worktreePath: null,
-        cwd: '/tmp',
-        agent: 'claude',
-        command: process.execPath,
-        args: [
-          '-e',
-          [
-            "console.log('GITHUB_TOKEN_PRESENT='+(!!process.env.GITHUB_TOKEN&&process.env.GITHUB_TOKEN.startsWith('relay-secret-token')));",
-            'setTimeout(()=>{},10000);',
-          ].join(' '),
-        ],
-      });
-      createdIds.push(result.id);
-
-      const output = await waitForScrollbackContains(
-        result.id,
-        'GITHUB_TOKEN_PRESENT=true'
-      );
-      expect(output).toContain('GITHUB_TOKEN_PRESENT=true');
-
-      const { stdout } = await execFileAsync('ps', ['axo', 'command=']);
-      const tmuxCommandLines = stdout
-        .split('\n')
-        .filter((line) => line.includes(result.tmuxSessionName ?? ''));
-      expect(tmuxCommandLines.join('\n')).not.toContain(
-        'relay-secret-token-for-tmux-test'
-      );
-    } finally {
-      if (originalToken === undefined) delete process.env.GITHUB_TOKEN;
-      else process.env.GITHUB_TOKEN = originalToken;
-    }
   });
 });

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -7,6 +7,7 @@ import { promisify } from 'node:util';
 import * as sessions from '../server/sessions.js';
 import {
   resolveTmuxSpawn,
+  resolveTmuxWrappedSpawn,
   generateTmuxSessionName,
   getTmuxPrefix,
 } from '../server/pty-handler.js';
@@ -379,6 +380,44 @@ describe('sessions', () => {
     expect(result.args.indexOf('RELAY_IDE_TOKEN=abc123')).toBeLessThan(
       result.args.indexOf('-s')
     );
+  });
+
+  it('resolveTmuxWrappedSpawn keeps inherited secrets in the child wrapper, not tmux argv', () => {
+    const secret = 'relay-secret-token-for-tmux-test';
+    const result = resolveTmuxWrappedSpawn(
+      'tmux-wrapper-env-test',
+      'node',
+      ['-e', 'console.log(process.env.GITHUB_TOKEN)'],
+      'test-session',
+      {
+        GITHUB_TOKEN: secret,
+        RELAY_IDE_TOKEN: 'relay-token',
+        SAFE_ENV: 'safe-value',
+        'bad-env-name': 'ignored',
+        EMPTY_VALUE: undefined,
+      }
+    );
+
+    try {
+      const argv = result.args.join('\0');
+      expect(argv).not.toContain(secret);
+      expect(argv).not.toContain('GITHUB_TOKEN=');
+      expect(argv).not.toContain('RELAY_IDE_TOKEN=relay-token');
+      expect(argv).toContain(result.wrapperPath);
+
+      const wrapper = fs.readFileSync(result.wrapperPath, 'utf8');
+      expect(wrapper).toContain(`export GITHUB_TOKEN='${secret}'`);
+      expect(wrapper).toContain("export RELAY_IDE_TOKEN='relay-token'");
+      expect(wrapper).toContain("export SAFE_ENV='safe-value'");
+      expect(wrapper).not.toContain('bad-env-name');
+      expect(wrapper).not.toContain('EMPTY_VALUE');
+      expect(fs.statSync(result.wrapperPath).mode & 0o777).toBe(0o700);
+    } finally {
+      fs.rmSync(path.dirname(result.wrapperPath), {
+        recursive: true,
+        force: true,
+      });
+    }
   });
 
   it('generateTmuxSessionName has correct prefix', () => {


### PR DESCRIPTION
## Summary
- replaces the flaky PTY scrollback/ps assertion for tmux env redaction with deterministic wrapper/argv inspection
- exposes the tmux wrapper spawn builder so production and tests exercise the same path
- keeps regression coverage that inherited secrets reach the child wrapper without appearing in tmux argv

## Validation
- npm run check
- npx vitest run test/sessions.test.ts test/pty-handler-multi-agent.test.ts
- npm test
- npm run build

Note: local full-suite validation initially hit the known better-sqlite3 Node ABI mismatch; `npm rebuild better-sqlite3` fixed the local environment, and the rerun passed.