### PR TITLE
fix: gate unavailable Hermes web runtime

### DIFF
--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -27,10 +27,16 @@ type SessionLaunchMode = 'pty' | 'web';
 export interface SessionModeOption {
   value: SessionLaunchMode;
   label: string;
+  disabled?: boolean;
+  reason?: string;
 }
 
 export function isFrameworkAvailable(framework: FrameworkInfo): boolean {
   return framework.availability?.installed !== false;
+}
+
+export function isFrameworkWebAvailable(framework: FrameworkInfo): boolean {
+  return framework.webAvailability?.available !== false;
 }
 
 export function selectLaunchAgent(
@@ -48,9 +54,17 @@ export function getSessionModeOptions(
 ): SessionModeOption[] {
   const selectedFramework = frameworks.find((f) => f.id === selectedAgent);
   if (selectedFramework?.capabilities.supportsWebSessions === true) {
+    const webAvailable = isFrameworkWebAvailable(selectedFramework);
     return [
       { value: 'pty', label: 'tui' },
-      { value: 'web', label: 'web' },
+      {
+        value: 'web',
+        label: webAvailable ? 'web' : 'web (unavailable)',
+        ...(!webAvailable ? { disabled: true } : {}),
+        ...(selectedFramework.webAvailability?.reason
+          ? { reason: selectedFramework.webAvailability.reason }
+          : {}),
+      },
     ];
   }
   return [{ value: 'pty', label: 'tui' }];
@@ -61,7 +75,7 @@ export function defaultSessionModeForAgent(
   selectedAgent: AgentType
 ): SessionLaunchMode {
   const supportsWeb = getSessionModeOptions(frameworks, selectedAgent).some(
-    (option) => option.value === 'web'
+    (option) => option.value === 'web' && !option.disabled
   );
   return selectedAgent === 'hermes' && supportsWeb ? 'web' : 'pty';
 }
@@ -147,6 +161,10 @@ function CustomizeSessionBody({
   );
   const selectedUnavailable =
     selectedFramework && !isFrameworkAvailable(selectedFramework);
+  const selectedWebUnavailable =
+    selectedFramework &&
+    form.sessionMode === 'web' &&
+    !isFrameworkWebAvailable(selectedFramework);
 
   return (
     <div className="customize-session-body-fields">
@@ -208,11 +226,21 @@ function CustomizeSessionBody({
             }
           >
             {modeOptions.map((option) => (
-              <option key={option.value} value={option.value}>
+              <option
+                key={option.value}
+                value={option.value}
+                disabled={option.disabled}
+              >
                 {option.label}
               </option>
             ))}
           </select>
+          {selectedWebUnavailable && (
+            <div className="customize-session-field-note">
+              {selectedFramework.webAvailability?.reason ??
+                `${selectedFramework.displayName} web runtime is not available`}
+            </div>
+          )}
         </div>
       )}
       <TuiCheckbox
@@ -304,6 +332,17 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
         );
         return;
       }
+      if (
+        selectedFramework &&
+        form.sessionMode === 'web' &&
+        !isFrameworkWebAvailable(selectedFramework)
+      ) {
+        setError(
+          selectedFramework.webAvailability?.reason ??
+            `${selectedFramework.displayName} web runtime is not available`
+        );
+        return;
+      }
       setCreating(true);
       setError(null);
       const { session, error: submitError } = await createSessionFromForm(
@@ -346,7 +385,9 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
             frameworks.some(
               (framework) =>
                 framework.id === form.selectedAgent &&
-                !isFrameworkAvailable(framework)
+                (!isFrameworkAvailable(framework) ||
+                  (form.sessionMode === 'web' &&
+                    !isFrameworkWebAvailable(framework)))
             )
           }
         >

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -41,6 +41,11 @@ export interface FrameworkInfo {
     path?: string;
     reason?: string;
   };
+  webAvailability?: {
+    available: boolean;
+    endpoint?: string;
+    reason?: string;
+  };
 }
 
 export interface CurrentActivity {

--- a/server/frameworks.ts
+++ b/server/frameworks.ts
@@ -7,10 +7,17 @@ import {
   type AgentFramework,
   type EventSourceType,
 } from './types.js';
+import { probeHermesGatewayApi } from './protocol-adapters/hermes-adapter.js';
 
 export interface FrameworkAvailability {
   installed: boolean;
   path?: string;
+  reason?: string;
+}
+
+export interface FrameworkWebAvailability {
+  available: boolean;
+  endpoint?: string;
   reason?: string;
 }
 
@@ -21,6 +28,7 @@ export interface FrameworkClientInfo {
   capabilities: AgentFramework['capabilities'];
   eventSource: EventSourceType;
   availability: FrameworkAvailability;
+  webAvailability?: FrameworkWebAvailability;
 }
 
 function executableCandidates(
@@ -96,4 +104,41 @@ export function getFrameworkClientInfo(
     eventSource: framework.eventSource,
     availability: getFrameworkAvailability(framework, env),
   }));
+}
+
+export async function getFrameworkClientInfoWithRuntime(
+  frameworkOverrides?: Record<string, Partial<AgentFramework>>,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<FrameworkClientInfo[]> {
+  const frameworks = getFrameworkClientInfo(frameworkOverrides, env);
+  return Promise.all(
+    frameworks.map(async (framework) => {
+      if (framework.id !== 'hermes' || !framework.availability.installed) {
+        return framework;
+      }
+      const probe = await probeHermesGatewayApi(undefined, 300);
+      return {
+        ...framework,
+        webAvailability: {
+          available: probe.available,
+          endpoint: probe.endpoint,
+          ...(probe.reason ? { reason: probe.reason } : {}),
+        },
+      };
+    })
+  );
+}
+
+export async function getFrameworkWebAvailability(
+  framework: AgentFramework
+): Promise<FrameworkWebAvailability> {
+  if (framework.id !== 'hermes') {
+    return { available: true };
+  }
+  const probe = await probeHermesGatewayApi(undefined, 500);
+  return {
+    available: probe.available,
+    endpoint: probe.endpoint,
+    ...(probe.reason ? { reason: probe.reason } : {}),
+  };
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -93,7 +93,8 @@ import {
 } from './telemetry.js';
 import {
   getFrameworkAvailability,
-  getFrameworkClientInfo,
+  getFrameworkClientInfoWithRuntime,
+  getFrameworkWebAvailability,
 } from './frameworks.js';
 import type {
   AgentType,
@@ -547,6 +548,39 @@ function validateAgentFrameworkAvailable(
           err instanceof Error
             ? err.message
             : `Unknown agent: ${resolvedAgent}`,
+        agent: resolvedAgent,
+      },
+    };
+  }
+}
+
+async function validateAgentWebRuntimeAvailable(
+  config: Config,
+  resolvedAgent: AgentType
+): Promise<AgentAvailabilityValidation> {
+  try {
+    const framework = resolveFramework(
+      config.frameworks ? { frameworks: config.frameworks } : {},
+      resolvedAgent
+    );
+    const availability = await getFrameworkWebAvailability(framework);
+    if (availability.available) return { ok: true };
+    return {
+      ok: false,
+      body: {
+        error: 'agent_unavailable',
+        message:
+          availability.reason ??
+          `${framework.displayName} web runtime is not available on this host.`,
+        agent: resolvedAgent,
+      },
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      body: {
+        error: 'unknown_agent',
+        message: err instanceof Error ? err.message : String(err),
         agent: resolvedAgent,
       },
     };
@@ -1319,8 +1353,10 @@ async function main(): Promise<void> {
   });
 
   // GET /api/frameworks — returns available agent frameworks with capabilities
-  app.get('/api/frameworks', requireAuth, (_req, res) => {
-    const frameworks = getFrameworkClientInfo(getConfig().frameworks);
+  app.get('/api/frameworks', requireAuth, async (_req, res) => {
+    const frameworks = await getFrameworkClientInfoWithRuntime(
+      getConfig().frameworks
+    );
     res.json({ frameworks });
   });
 
@@ -2281,6 +2317,14 @@ async function main(): Promise<void> {
     // original native-Hermes launch path.
     const requestedMode = mode ?? (resolvedAgent === 'hermes' ? 'web' : 'pty');
     if (requestedMode === 'web') {
+      const webAvailability = await validateAgentWebRuntimeAvailable(
+        freshConfig,
+        resolvedAgent
+      );
+      if (!webAvailability.ok) {
+        res.status(400).json(webAvailability.body);
+        return;
+      }
       const displayName = sessions.nextAgentName();
       try {
         const { session } = await sessions.createWeb({

--- a/server/protocol-adapters/hermes-adapter.ts
+++ b/server/protocol-adapters/hermes-adapter.ts
@@ -18,10 +18,18 @@ interface SseEvent {
   data: Record<string, unknown>;
 }
 
-interface HermesGatewaySettings {
+export interface HermesGatewaySettings {
   endpoint: string;
   apiKey: string | null;
   source: string;
+}
+
+export interface HermesGatewayProbeResult {
+  available: boolean;
+  endpoint: string;
+  source: string;
+  retryable: boolean;
+  reason?: string;
 }
 
 const DEFAULT_HERMES_ENDPOINT = 'http://127.0.0.1:8642';
@@ -122,7 +130,7 @@ function endpointFromApiServerEnv(
   return `http://${host}:${port}`;
 }
 
-function resolveGatewaySettings(
+export function resolveHermesGatewaySettings(
   extra: Record<string, unknown> | undefined
 ): HermesGatewaySettings {
   const fileEnv = readHermesEnv();
@@ -149,6 +157,104 @@ function resolveGatewaySettings(
         ? 'environment'
         : 'default',
   };
+}
+
+async function fetchWithTimeout(
+  url: string,
+  headers: Record<string, string>,
+  timeoutMs: number
+): Promise<Response> {
+  return fetch(url, {
+    headers,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+}
+
+function gatewayHeaders(apiKey: string | null): Record<string, string> {
+  return apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
+}
+
+export async function probeHermesGatewayApi(
+  extra: Record<string, unknown> | undefined,
+  timeoutMs = 500
+): Promise<HermesGatewayProbeResult> {
+  const settings = resolveHermesGatewaySettings(extra);
+  const headers = gatewayHeaders(settings.apiKey);
+
+  try {
+    const health = await fetchWithTimeout(
+      `${settings.endpoint}/health`,
+      headers,
+      timeoutMs
+    );
+    if (health.status === 401 || health.status === 403) {
+      return {
+        available: false,
+        endpoint: settings.endpoint,
+        source: settings.source,
+        retryable: false,
+        reason: `Hermes gateway at ${settings.endpoint} rejected Relay authentication. Set HERMES_API_TOKEN to the gateway API_SERVER_KEY.`,
+      };
+    }
+    if (!health.ok) {
+      return {
+        available: false,
+        endpoint: settings.endpoint,
+        source: settings.source,
+        retryable: health.status >= 500,
+        reason: `Hermes gateway health check failed at ${settings.endpoint}: HTTP ${health.status}`,
+      };
+    }
+
+    const models = await fetchWithTimeout(
+      `${settings.endpoint}/v1/models`,
+      headers,
+      timeoutMs
+    );
+    if (models.status === 401 || models.status === 403) {
+      return {
+        available: false,
+        endpoint: settings.endpoint,
+        source: settings.source,
+        retryable: false,
+        reason: `Hermes API server at ${settings.endpoint} rejected Relay authentication. Set HERMES_API_TOKEN to the gateway API_SERVER_KEY.`,
+      };
+    }
+    if (models.status === 404) {
+      return {
+        available: false,
+        endpoint: settings.endpoint,
+        source: settings.source,
+        retryable: false,
+        reason: `Hermes gateway is reachable at ${settings.endpoint}, but the Responses API is not enabled there. Start the host Hermes gateway with API_SERVER_ENABLED=1, or set HERMES_API_ENDPOINT to the Hermes API server.`,
+      };
+    }
+    if (!models.ok) {
+      return {
+        available: false,
+        endpoint: settings.endpoint,
+        source: settings.source,
+        retryable: models.status >= 500,
+        reason: `Hermes API server probe failed at ${settings.endpoint}: HTTP ${models.status}`,
+      };
+    }
+
+    return {
+      available: true,
+      endpoint: settings.endpoint,
+      source: settings.source,
+      retryable: false,
+    };
+  } catch (err) {
+    const lastError = err instanceof Error ? err.message : String(err);
+    return {
+      available: false,
+      endpoint: settings.endpoint,
+      source: settings.source,
+      retryable: true,
+      reason: `Hermes gateway API is not reachable at ${settings.endpoint} (${settings.source}). Start the host Hermes gateway with API_SERVER_ENABLED=1, or set HERMES_API_ENDPOINT for relay-ide. Last error: ${lastError}`,
+    };
+  }
 }
 
 function parseToolArguments(value: unknown): Record<string, unknown> {
@@ -200,7 +306,7 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
     this._lastResponseId = null;
     this._turnCounter = 0;
 
-    const settings = resolveGatewaySettings(config.extra);
+    const settings = resolveHermesGatewaySettings(config.extra);
     this._endpoint = settings.endpoint;
     this._apiKey = settings.apiKey;
     this._settingsSource = settings.source;
@@ -393,46 +499,28 @@ export class HermesProtocolAdapter extends BaseProtocolAdapter {
   ): Record<string, string> {
     return {
       ...headers,
-      ...(this._apiKey ? { Authorization: `Bearer ${this._apiKey}` } : {}),
+      ...gatewayHeaders(this._apiKey),
     };
   }
 
   private async waitForGateway(): Promise<void> {
-    const healthUrl = `${this.baseUrl()}/health`;
     const deadline = Date.now() + 3000;
-    let lastStatus: number | null = null;
-    let lastError: string | null = null;
+    let lastReason: string | undefined;
 
     while (Date.now() < deadline) {
-      try {
-        const res = await fetch(healthUrl, {
-          headers: this.headers(),
-          signal: AbortSignal.timeout(500),
-        });
-        lastStatus = res.status;
-        if (res.ok) {
-          logger.info('Hermes API server reachable at', this._endpoint);
-          return;
-        }
-        if (res.status === 401 || res.status === 403) {
-          break;
-        }
-      } catch (err) {
-        lastError = err instanceof Error ? err.message : String(err);
+      const probe = await probeHermesGatewayApi(this._config?.extra, 500);
+      lastReason = probe.reason;
+      if (probe.available) {
+        logger.info('Hermes API server reachable at', this._endpoint);
+        return;
       }
+      if (!probe.retryable) break;
       await new Promise((r) => setTimeout(r, 200));
     }
 
-    if (lastStatus === 401 || lastStatus === 403) {
-      throw new Error(
-        `Hermes gateway at ${this._endpoint} rejected Relay authentication. Set HERMES_API_TOKEN to the gateway API_SERVER_KEY.`
-      );
-    }
-
     throw new Error(
-      `Hermes gateway API is not reachable at ${this._endpoint} (${this._settingsSource}). Start the host Hermes gateway with API_SERVER_ENABLED=1, or set HERMES_API_ENDPOINT for relay-ide.${
-        lastError ? ` Last error: ${lastError}` : ''
-      }`
+      lastReason ??
+        `Hermes gateway API is not reachable at ${this._endpoint} (${this._settingsSource}). Start the host Hermes gateway with API_SERVER_ENABLED=1, or set HERMES_API_ENDPOINT for relay-ide.`
     );
   }
 

--- a/test/customize-session-dialog.test.ts
+++ b/test/customize-session-dialog.test.ts
@@ -4,6 +4,7 @@ import {
   defaultSessionModeForAgent,
   getSessionModeOptions,
   isFrameworkAvailable,
+  isFrameworkWebAvailable,
   selectLaunchAgent,
 } from '../frontend/src/components/dialogs/CustomizeSessionDialog.js';
 import type { FrameworkInfo } from '../frontend/src/lib/types.js';
@@ -56,6 +57,27 @@ describe('CustomizeSessionDialog session mode options', () => {
     expect(defaultSessionModeForAgent([framework('claude')], 'claude')).toBe(
       'pty'
     );
+  });
+
+  it('disables web mode when an installed agent runtime is unavailable', () => {
+    const hermes = framework('hermes');
+    hermes.webAvailability = {
+      available: false,
+      reason: 'Hermes API server is not reachable',
+    };
+
+    expect(isFrameworkAvailable(hermes)).toBe(true);
+    expect(isFrameworkWebAvailable(hermes)).toBe(false);
+    expect(getSessionModeOptions([hermes], 'hermes')).toEqual([
+      { value: 'pty', label: 'tui' },
+      {
+        value: 'web',
+        label: 'web (unavailable)',
+        disabled: true,
+        reason: 'Hermes API server is not reachable',
+      },
+    ]);
+    expect(defaultSessionModeForAgent([hermes], 'hermes')).toBe('pty');
   });
 
   it('treats missing legacy availability as available', () => {

--- a/test/fixtures/hermes-gateway-stub.cjs
+++ b/test/fixtures/hermes-gateway-stub.cjs
@@ -51,6 +51,12 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  if (parsed.pathname === '/v1/models') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ data: [{ id: 'hermes-stub' }] }));
+    return;
+  }
+
   // OpenAI-compatible Responses streaming endpoint
   if (parsed.pathname === '/v1/responses') {
     let body = '';

--- a/test/frameworks-api.test.ts
+++ b/test/frameworks-api.test.ts
@@ -1,6 +1,9 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import express from 'express';
-import { getFrameworkClientInfo } from '../server/frameworks.js';
+import { getFrameworkClientInfoWithRuntime } from '../server/frameworks.js';
 import { createTestServer } from './helpers/test-server.js';
 
 // ---------------------------------------------------------------------------
@@ -10,14 +13,38 @@ import { createTestServer } from './helpers/test-server.js';
 
 let baseUrl: string;
 let closeServer: () => Promise<void>;
+let closeHermesProbeServer: () => Promise<void>;
+let fakeBinDir: string;
+let hermesProbeUrl: string;
+let originalHermesEndpoint: string | undefined;
+let originalPath: string | undefined;
 
 beforeAll(async () => {
+  originalHermesEndpoint = process.env.HERMES_API_ENDPOINT;
+  originalPath = process.env.PATH;
+  fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-frameworks-'));
+  const fakeHermes = path.join(fakeBinDir, 'hermes');
+  fs.writeFileSync(fakeHermes, '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(fakeHermes, 0o755);
+
+  const hermesProbeApp = express();
+  hermesProbeApp.get('/health', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+  const hermesProbeServer = await createTestServer(hermesProbeApp);
+  hermesProbeUrl = hermesProbeServer.url;
+  closeHermesProbeServer = hermesProbeServer.close;
+  process.env.HERMES_API_ENDPOINT = hermesProbeUrl;
+
   const app = express();
   app.use(express.json());
 
   // Register the same route logic as server/index.ts will expose
-  app.get('/api/frameworks', (_req, res) => {
-    const frameworks = getFrameworkClientInfo();
+  app.get('/api/frameworks', async (_req, res) => {
+    const frameworks = await getFrameworkClientInfoWithRuntime(undefined, {
+      ...process.env,
+      PATH: `${fakeBinDir}${path.delimiter}${originalPath ?? ''}`,
+    });
     res.json({ frameworks });
   });
 
@@ -26,7 +53,17 @@ beforeAll(async () => {
   closeServer = result.close;
 });
 
-afterAll(() => closeServer());
+afterAll(async () => {
+  await closeServer();
+  await closeHermesProbeServer();
+  if (originalHermesEndpoint === undefined) {
+    delete process.env.HERMES_API_ENDPOINT;
+  } else {
+    process.env.HERMES_API_ENDPOINT = originalHermesEndpoint;
+  }
+  process.env.PATH = originalPath;
+  fs.rmSync(fakeBinDir, { recursive: true, force: true });
+});
 
 function url(p: string): string {
   return `${baseUrl}${p}`;
@@ -111,6 +148,32 @@ describe('GET /api/frameworks', () => {
     const opencode = body.frameworks.find((f) => f.id === 'opencode');
     expect(opencode).toBeTruthy();
     expect(opencode!.eventSource).toBe('plugin');
+  });
+
+  it('surfaces Hermes web runtime availability from the async route', async () => {
+    const res = await fetch(url('/api/frameworks'));
+    const body = (await res.json()) as {
+      frameworks: Array<{
+        id: string;
+        availability?: { installed: boolean; path?: string };
+        webAvailability?: {
+          available: boolean;
+          endpoint?: string;
+          reason?: string;
+        };
+      }>;
+    };
+    const hermes = body.frameworks.find((f) => f.id === 'hermes');
+    expect(hermes).toBeTruthy();
+    expect(hermes!.availability?.installed).toBe(true);
+    expect(hermes!.availability?.path).toBe(path.join(fakeBinDir, 'hermes'));
+    expect(hermes!.webAvailability).toMatchObject({
+      available: false,
+      endpoint: hermesProbeUrl,
+    });
+    expect(hermes!.webAvailability?.reason).toContain(
+      'Responses API is not enabled'
+    );
   });
 
   it('does not include internal fields like parserType or continueArgs', async () => {

--- a/test/hermes-session-api.e2e.test.ts
+++ b/test/hermes-session-api.e2e.test.ts
@@ -293,10 +293,11 @@ process.exit(0);
       }),
     });
 
-    expect(createRes.status).toBe(500);
+    expect(createRes.status).toBe(400);
     expect(createRes.headers.get('content-type')).toContain('application/json');
     await expect(createRes.json()).resolves.toMatchObject({
-      error: 'session_create_failed',
+      error: 'agent_unavailable',
+      agent: 'hermes',
       message: expect.stringContaining('Hermes gateway API is not reachable'),
     });
   } finally {


### PR DESCRIPTION
## Summary
- probe the host Hermes gateway for both `/health` and `/v1/models` before treating Hermes web sessions as available
- expose Hermes web runtime availability through `/api/frameworks` and gray out unavailable web mode in the customize dialog
- reject Hermes web session creation with `400 agent_unavailable` instead of creating a broken session when the host Responses API server is missing

## Testing
- npm run check
- npm test
- npm test -- test/hermes-session-api.e2e.test.ts test/hermes-adapter.e2e.test.ts test/customize-session-dialog.test.ts
- npm run build
- browser QA via /browse against local dev server on `http://localhost:3457`: selected Hermes and verified `web (gateway unavailable)` is disabled; created an OpenCode web session and verified the sent message `relay-opencode-browser-visible-check` appears in the chat timeline
- observed prod logs during testing; prod is still logging old OpenCode `Unhandled OpenCode event: undefined` lines from the currently running global service

## Issues
Refs #112
Refs #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web session mode now dynamically detects gateway availability and displays disabled status with reasons when unavailable.
  * Session creation validation prevents creation when web mode is selected but the gateway is inaccessible.

* **Bug Fixes**
  * Improved error handling and messaging for framework availability checks during session creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->