### PR TITLE
feat(claude-v2): native V2 protocol adapter

### DIFF
--- a/server/protocol-adapters/claude-v2-adapter.ts
+++ b/server/protocol-adapters/claude-v2-adapter.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from 'node:child_process';
 import { BaseProtocolAdapterV2 } from '../protocol-adapter-v2.js';
 import type {
   AdapterConfig,
@@ -7,9 +8,13 @@ import type {
   AgentInterruptInputV2,
   AgentSendMessageInputV2,
 } from '../protocol-adapter-v2.js';
-import type { AgentCapabilitySetV2 } from '../../shared/agent-chat-protocol-v2.js';
+import type {
+  AgentCapabilitySetV2,
+  AgentSessionLiveStateV2,
+} from '../../shared/agent-chat-protocol-v2.js';
 
 const NOT_IMPLEMENTED = 'not implemented';
+const DEFAULT_SESSION_ID = 'claude-v2-session';
 
 export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
   readonly agentType = 'claude';
@@ -36,27 +41,79 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
   };
 
   private _status: AdapterStatus = 'disconnected';
+  private config: AdapterConfig | null = null;
+  private activeProcess: ChildProcess | null = null;
+
   get status(): AdapterStatus {
     return this._status;
   }
 
-  async connect(_config: AdapterConfig): Promise<void> {
-    throw new Error(NOT_IMPLEMENTED);
+  async connect(config: AdapterConfig): Promise<void> {
+    this.config = config;
+    this._status = 'connected';
+    this.emitLiveState({
+      status: 'idle',
+      activeTurnId: null,
+      waitingOn: null,
+      activeRequestIds: [],
+      proposedPlanItemId: null,
+      queueLength: 0,
+      fastModeAvailable: false,
+      error: null,
+    });
   }
-  protected async onDisconnect(): Promise<void> {}
+
+  protected async onDisconnect(): Promise<void> {
+    this.killActiveProcess();
+    this._status = 'disconnected';
+  }
+
   async reconnect(): Promise<void> {
-    throw new Error(NOT_IMPLEMENTED);
+    if (this.config === null) {
+      throw new Error('Cannot reconnect before initial connect');
+    }
+    const config = this.config;
+    await this.disconnect();
+    await this.connect(config);
   }
+
   async sendMessage(_input: AgentSendMessageInputV2): Promise<void> {
     throw new Error(NOT_IMPLEMENTED);
   }
+
   async interrupt(_input: AgentInterruptInputV2): Promise<void> {
     throw new Error(NOT_IMPLEMENTED);
   }
+
   async respondToApproval(_input: AgentApprovalResponseInputV2): Promise<void> {
     throw new Error(NOT_IMPLEMENTED);
   }
+
   async respondToInput(_input: AgentInputResponseInputV2): Promise<void> {
     throw new Error(NOT_IMPLEMENTED);
+  }
+
+  private killActiveProcess(): void {
+    if (this.activeProcess !== null) {
+      try {
+        this.activeProcess.kill('SIGTERM');
+      } catch {
+        // Process may already be dead. Ignore.
+      }
+      this.activeProcess = null;
+    }
+  }
+
+  private emitLiveState(live: Partial<AgentSessionLiveStateV2>): void {
+    this.emitPatch({
+      type: 'agent-live-state-updated-v2',
+      sessionId: this.sessionId,
+      timestamp: new Date().toISOString(),
+      live,
+    });
+  }
+
+  private get sessionId(): string {
+    return this.config?.sessionId ?? DEFAULT_SESSION_ID;
   }
 }

--- a/server/protocol-adapters/claude-v2-adapter.ts
+++ b/server/protocol-adapters/claude-v2-adapter.ts
@@ -8,6 +8,7 @@ import type {
   AgentInterruptInputV2,
   AgentSendMessageInputV2,
 } from '../protocol-adapter-v2.js';
+import { emptyAgentSessionV2 } from '../../shared/agent-chat-protocol-v2.js';
 import type {
   AgentCapabilitySetV2,
   AgentItemV2,
@@ -16,6 +17,7 @@ import type {
 
 const NOT_IMPLEMENTED = 'not implemented';
 const DEFAULT_SESSION_ID = 'claude-v2-session';
+const ITEM_STARTED = 'agent-item-started-v2' as const;
 
 export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
   readonly agentType = 'claude';
@@ -47,6 +49,11 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
   private _currentTurnId: string | null = null;
   private blockIdx = 0;
   private streamBuffer = '';
+  private _providerSessionId: string | null = null;
+
+  private get providerSessionId(): string | null {
+    return this._providerSessionId;
+  }
 
   get status(): AdapterStatus {
     return this._status;
@@ -121,9 +128,48 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     const type = obj['type'];
     if (type === 'assistant') {
       this.handleAssistantBlock(obj);
+    } else if (type === 'system') {
+      this.handleSystem(obj);
     } else {
       this.emitProviderExtension(obj);
     }
+  }
+
+  private handleSystem(obj: Record<string, unknown>): void {
+    if (obj['subtype'] !== 'init') {
+      this.emitProviderExtension(obj);
+      return;
+    }
+    const sessionId = obj['session_id'];
+    if (typeof sessionId === 'string' && sessionId.length > 0) {
+      this._providerSessionId = sessionId;
+    }
+    this.emitSessionSnapshot(obj);
+  }
+
+  private emitSessionSnapshot(initObj: Record<string, unknown>): void {
+    const providerSession: Record<string, string> = {};
+    if (typeof initObj['session_id'] === 'string')
+      providerSession['sessionId'] = String(initObj['session_id']);
+    if (typeof initObj['model'] === 'string')
+      providerSession['model'] = String(initObj['model']);
+    if (typeof initObj['cwd'] === 'string')
+      providerSession['cwd'] = String(initObj['cwd']);
+
+    const session = emptyAgentSessionV2({
+      id: this.sessionId,
+      provider: 'claude',
+      cwd: this.config?.cwd ?? '',
+      capabilities: this.capabilities,
+      providerSession,
+    });
+
+    this.emitPatch({
+      type: 'agent-session-snapshot-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      session,
+    });
   }
 
   private handleAssistantBlock(obj: Record<string, unknown>): void {
@@ -148,7 +194,7 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     const itemId = `msg-${turnId}-${idx}`;
     const text = String(block['text'] ?? '');
     this.emitPatch({
-      type: 'agent-item-started-v2',
+      type: ITEM_STARTED,
       sessionId: this.sessionId,
       timestamp: this.now(),
       turnId,
@@ -193,7 +239,7 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     const itemId = `thinking-${turnId}-${idx}`;
     const summary = String(block['thinking'] ?? '');
     this.emitPatch({
-      type: 'agent-item-started-v2',
+      type: ITEM_STARTED,
       sessionId: this.sessionId,
       timestamp: this.now(),
       turnId,
@@ -272,7 +318,7 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     }
 
     this.emitPatch({
-      type: 'agent-item-started-v2',
+      type: ITEM_STARTED,
       sessionId: this.sessionId,
       timestamp: this.now(),
       turnId,
@@ -283,7 +329,7 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
   private emitProviderExtension(obj: Record<string, unknown>): void {
     if (this._currentTurnId === null) return;
     this.emitPatch({
-      type: 'agent-item-started-v2',
+      type: ITEM_STARTED,
       sessionId: this.sessionId,
       timestamp: this.now(),
       turnId: this._currentTurnId,

--- a/server/protocol-adapters/claude-v2-adapter.ts
+++ b/server/protocol-adapters/claude-v2-adapter.ts
@@ -1,3 +1,4 @@
+import { spawn as defaultSpawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
 import { BaseProtocolAdapterV2 } from '../protocol-adapter-v2.js';
 import type {
@@ -8,6 +9,7 @@ import type {
   AgentInterruptInputV2,
   AgentSendMessageInputV2,
 } from '../protocol-adapter-v2.js';
+import { cleanEnv } from '../utils.js';
 import { emptyAgentSessionV2 } from '../../shared/agent-chat-protocol-v2.js';
 import type {
   AgentCapabilitySetV2,
@@ -18,6 +20,12 @@ import type {
 const NOT_IMPLEMENTED = 'not implemented';
 const DEFAULT_SESSION_ID = 'claude-v2-session';
 const ITEM_STARTED = 'agent-item-started-v2' as const;
+
+type SpawnFn = typeof defaultSpawn;
+
+export interface ClaudeProtocolAdapterV2Options {
+  spawn?: SpawnFn;
+}
 
 export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
   readonly agentType = 'claude';
@@ -43,6 +51,7 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     rateLimits: true,
   };
 
+  private readonly spawnFn: SpawnFn;
   private _status: AdapterStatus = 'disconnected';
   private config: AdapterConfig | null = null;
   private activeProcess: ChildProcess | null = null;
@@ -50,6 +59,11 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
   private blockIdx = 0;
   private streamBuffer = '';
   private _providerSessionId: string | null = null;
+
+  constructor(options: ClaudeProtocolAdapterV2Options = {}) {
+    super();
+    this.spawnFn = options.spawn ?? defaultSpawn;
+  }
 
   private get providerSessionId(): string | null {
     return this._providerSessionId;
@@ -88,12 +102,65 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     await this.connect(config);
   }
 
-  async sendMessage(_input: AgentSendMessageInputV2): Promise<void> {
-    throw new Error(NOT_IMPLEMENTED);
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    if (this._status !== 'connected') {
+      throw new Error('Cannot send message before connect');
+    }
+
+    this._currentTurnId = input.turnId;
+    this.blockIdx = 0;
+
+    const startedAt = this.now();
+    this.emitPatch({
+      type: 'agent-turn-started-v2',
+      sessionId: this.sessionId,
+      timestamp: startedAt,
+      turn: {
+        id: input.turnId,
+        status: 'running',
+        inputMessageId: `user-${input.turnId}`,
+        items: [],
+        startedAt,
+      },
+    });
+    this.emitPatch({
+      type: ITEM_STARTED,
+      sessionId: this.sessionId,
+      timestamp: startedAt,
+      turnId: input.turnId,
+      item: {
+        type: 'userMessage',
+        id: `user-${input.turnId}`,
+        text: input.content,
+        status: 'completed',
+        startedAt,
+        completedAt: startedAt,
+      },
+    });
+    this.emitLiveState({
+      status: 'working',
+      activeTurnId: input.turnId,
+      error: null,
+    });
+
+    const args = this.buildSpawnArgs(input.content);
+    const env = this.buildSpawnEnv();
+    const cwd = this.config?.cwd ?? process.cwd();
+
+    const proc = this.spawnFn('claude', args, {
+      cwd,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    this.activeProcess = proc;
+
+    proc.stdout?.on('data', (chunk: Buffer) => {
+      this.handleStreamData(chunk.toString('utf8'));
+    });
   }
 
   async interrupt(_input: AgentInterruptInputV2): Promise<void> {
-    throw new Error(NOT_IMPLEMENTED);
+    this.killActiveProcess();
   }
 
   async respondToApproval(_input: AgentApprovalResponseInputV2): Promise<void> {
@@ -101,7 +168,33 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
   }
 
   async respondToInput(_input: AgentInputResponseInputV2): Promise<void> {
-    throw new Error(NOT_IMPLEMENTED);
+    // Claude has no structured input flow; intentionally no-op.
+  }
+
+  private buildSpawnArgs(prompt: string): string[] {
+    const args = [
+      '--output-format',
+      'stream-json',
+      '--print',
+      '-p',
+      prompt,
+      '--permission-mode',
+      'bypassPermissions',
+    ];
+    if (this._providerSessionId !== null) {
+      args.push('--resume', this._providerSessionId);
+    }
+    if (this.config?.model !== undefined) {
+      args.push('--model', this.config.model);
+    }
+    return args;
+  }
+
+  private buildSpawnEnv(): Record<string, string> {
+    const env = cleanEnv();
+    // Strip CLAUDECODE so a relay-launched claude doesn't refuse to nest under another claude.
+    delete env['CLAUDECODE'];
+    return env;
   }
 
   private now(): string {

--- a/server/protocol-adapters/claude-v2-adapter.ts
+++ b/server/protocol-adapters/claude-v2-adapter.ts
@@ -10,6 +10,7 @@ import type {
 } from '../protocol-adapter-v2.js';
 import type {
   AgentCapabilitySetV2,
+  AgentItemV2,
   AgentSessionLiveStateV2,
 } from '../../shared/agent-chat-protocol-v2.js';
 
@@ -43,6 +44,10 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
   private _status: AdapterStatus = 'disconnected';
   private config: AdapterConfig | null = null;
   private activeProcess: ChildProcess | null = null;
+  private _currentTurnId: string | null = null;
+  private blockIdx = 0;
+  private streamBuffer = '';
+  private startedItemIds = new Set<string>();
 
   get status(): AdapterStatus {
     return this._status;
@@ -91,6 +96,170 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
 
   async respondToInput(_input: AgentInputResponseInputV2): Promise<void> {
     throw new Error(NOT_IMPLEMENTED);
+  }
+
+  private now(): string {
+    return new Date().toISOString();
+  }
+
+  private handleStreamData(data: string): void {
+    this.streamBuffer += data;
+    const lines = this.streamBuffer.split('\n');
+    this.streamBuffer = lines.pop() ?? '';
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let obj: Record<string, unknown>;
+      try {
+        obj = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      this.dispatchStreamJson(obj);
+    }
+  }
+
+  private dispatchStreamJson(obj: Record<string, unknown>): void {
+    const type = obj['type'];
+    if (type === 'assistant') {
+      this.handleAssistantBlock(obj);
+    } else {
+      this.emitProviderExtension(obj);
+    }
+  }
+
+  private handleAssistantBlock(obj: Record<string, unknown>): void {
+    const turnId = this._currentTurnId;
+    if (turnId === null) return;
+    const message = obj['message'] as
+      | { content?: Array<Record<string, unknown>> }
+      | undefined;
+    for (const block of message?.content ?? []) {
+      const t = block['type'];
+      if (t === 'text') this.handleTextBlock(turnId, block);
+      else if (t === 'thinking') this.handleThinkingBlock(turnId, block);
+      else if (t === 'tool_use') this.handleToolUseBlock(turnId, block);
+    }
+  }
+
+  private handleTextBlock(
+    turnId: string,
+    block: Record<string, unknown>
+  ): void {
+    const idx = this.blockIdx++;
+    const itemId = `msg-${turnId}-${idx}`;
+    const text = String(block['text'] ?? '');
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      turnId,
+      item: {
+        type: 'assistantMessage',
+        id: itemId,
+        text: '',
+        phase: 'answer',
+        status: 'running',
+        startedAt: this.now(),
+      },
+    });
+    this.emitPatch({
+      type: 'agent-item-delta-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      turnId,
+      itemId,
+      delta: { text },
+    });
+    this.emitPatch({
+      type: 'agent-item-updated-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      turnId,
+      item: {
+        type: 'assistantMessage',
+        id: itemId,
+        text,
+        phase: 'answer',
+        status: 'completed',
+        completedAt: this.now(),
+      },
+    });
+  }
+
+  private handleThinkingBlock(
+    _turnId: string,
+    _block: Record<string, unknown>
+  ): void {
+    // Filled in step 1.3.C
+  }
+
+  private handleToolUseBlock(
+    turnId: string,
+    block: Record<string, unknown>
+  ): void {
+    const id = String(block['id'] ?? `tu-${this.blockIdx++}`);
+    const name = String(block['name'] ?? 'unknown');
+    const input = (block['input'] ?? {}) as Record<string, unknown>;
+
+    let item: AgentItemV2;
+    if (name === 'Bash') {
+      item = {
+        type: 'commandExecution',
+        id: `exec-${id}`,
+        command: String(input['command'] ?? ''),
+        output: '',
+        status: 'running',
+        startedAt: this.now(),
+      };
+    } else if (name === 'Edit' || name === 'Write' || name === 'MultiEdit') {
+      item = {
+        type: 'fileChange',
+        id: `file-${id}`,
+        paths: [
+          { path: String(input['file_path'] ?? input['filePath'] ?? '') },
+        ],
+        applyStatus: 'pending',
+        status: 'running',
+        startedAt: this.now(),
+      };
+    } else {
+      item = {
+        type: 'dynamicToolCall',
+        id: `tool-${id}`,
+        namespace: 'claude',
+        tool: name,
+        arguments: input,
+        status: 'running',
+        startedAt: this.now(),
+      };
+    }
+
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      turnId,
+      item,
+    });
+  }
+
+  private emitProviderExtension(obj: Record<string, unknown>): void {
+    if (this._currentTurnId === null) return;
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      turnId: this._currentTurnId,
+      item: {
+        type: 'providerExtension',
+        id: `ext-${Date.now()}-${this.blockIdx++}`,
+        namespace: 'claude',
+        payload: obj,
+        status: 'completed',
+        startedAt: this.now(),
+        completedAt: this.now(),
+      },
+    });
   }
 
   private killActiveProcess(): void {

--- a/server/protocol-adapters/claude-v2-adapter.ts
+++ b/server/protocol-adapters/claude-v2-adapter.ts
@@ -223,6 +223,8 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
       this.handleAssistantBlock(obj);
     } else if (type === 'system') {
       this.handleSystem(obj);
+    } else if (type === 'result') {
+      this.handleResult(obj);
     } else {
       this.emitProviderExtension(obj);
     }
@@ -436,6 +438,72 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
         completedAt: this.now(),
       },
     });
+  }
+
+  private handleResult(obj: Record<string, unknown>): void {
+    const turnId = this._currentTurnId;
+    if (turnId === null) return;
+
+    const subtype = String(obj['subtype'] ?? 'success');
+    const isError = subtype !== 'success' || obj['is_error'] === true;
+    const durationMs =
+      typeof obj['duration_ms'] === 'number' ? obj['duration_ms'] : 0;
+    const usage = obj['usage'] as Record<string, unknown> | undefined;
+
+    if (isError) {
+      this.emitPatch({
+        type: 'agent-error-v2',
+        sessionId: this.sessionId,
+        timestamp: this.now(),
+        message: typeof obj['error'] === 'string' ? obj['error'] : subtype,
+        turnId,
+      });
+    }
+
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      turnId,
+      status: isError ? 'failed' : 'completed',
+      completedAt: this.now(),
+      durationMs,
+      ...(usage !== undefined ? { usage: this.mapUsage(usage) } : {}),
+      ...(isError ? { error: subtype } : {}),
+    });
+
+    this._currentTurnId = null;
+    this.blockIdx = 0;
+    this.emitLiveState({
+      status: 'idle',
+      activeTurnId: null,
+      waitingOn: null,
+      activeRequestIds: [],
+      error: null,
+    });
+  }
+
+  private mapUsage(usage: Record<string, unknown>): {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  } {
+    const result: {
+      inputTokens?: number;
+      outputTokens?: number;
+      cacheReadTokens?: number;
+      cacheWriteTokens?: number;
+    } = {};
+    if (typeof usage['input_tokens'] === 'number')
+      result.inputTokens = usage['input_tokens'];
+    if (typeof usage['output_tokens'] === 'number')
+      result.outputTokens = usage['output_tokens'];
+    if (typeof usage['cache_read_input_tokens'] === 'number')
+      result.cacheReadTokens = usage['cache_read_input_tokens'];
+    if (typeof usage['cache_creation_input_tokens'] === 'number')
+      result.cacheWriteTokens = usage['cache_creation_input_tokens'];
+    return result;
   }
 
   private killActiveProcess(): void {

--- a/server/protocol-adapters/claude-v2-adapter.ts
+++ b/server/protocol-adapters/claude-v2-adapter.ts
@@ -47,7 +47,6 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
   private _currentTurnId: string | null = null;
   private blockIdx = 0;
   private streamBuffer = '';
-  private startedItemIds = new Set<string>();
 
   get status(): AdapterStatus {
     return this._status;

--- a/server/protocol-adapters/claude-v2-adapter.ts
+++ b/server/protocol-adapters/claude-v2-adapter.ts
@@ -187,10 +187,48 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
   }
 
   private handleThinkingBlock(
-    _turnId: string,
-    _block: Record<string, unknown>
+    turnId: string,
+    block: Record<string, unknown>
   ): void {
-    // Filled in step 1.3.C
+    const idx = this.blockIdx++;
+    const itemId = `thinking-${turnId}-${idx}`;
+    const summary = String(block['thinking'] ?? '');
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      turnId,
+      item: {
+        type: 'reasoning',
+        id: itemId,
+        summary: '',
+        visibility: 'summary',
+        status: 'running',
+        startedAt: this.now(),
+      },
+    });
+    this.emitPatch({
+      type: 'agent-item-delta-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      turnId,
+      itemId,
+      delta: { summary },
+    });
+    this.emitPatch({
+      type: 'agent-item-updated-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      turnId,
+      item: {
+        type: 'reasoning',
+        id: itemId,
+        summary,
+        visibility: 'summary',
+        status: 'completed',
+        completedAt: this.now(),
+      },
+    });
   }
 
   private handleToolUseBlock(

--- a/server/protocol-adapters/claude-v2-adapter.ts
+++ b/server/protocol-adapters/claude-v2-adapter.ts
@@ -1,0 +1,62 @@
+import { BaseProtocolAdapterV2 } from '../protocol-adapter-v2.js';
+import type {
+  AdapterConfig,
+  AdapterStatus,
+  AgentApprovalResponseInputV2,
+  AgentInputResponseInputV2,
+  AgentInterruptInputV2,
+  AgentSendMessageInputV2,
+} from '../protocol-adapter-v2.js';
+import type { AgentCapabilitySetV2 } from '../../shared/agent-chat-protocol-v2.js';
+
+const NOT_IMPLEMENTED = 'not implemented';
+
+export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
+  readonly agentType = 'claude';
+  readonly runtimeOwnership = 'spawned' as const;
+  readonly capabilities: AgentCapabilitySetV2 = {
+    text: true,
+    reasoning: true,
+    tools: true,
+    commandExecution: true,
+    fileChanges: true,
+    approvals: true,
+    questions: false,
+    plans: false,
+    slashCommands: true,
+    queue: true,
+    interrupt: true,
+    cancelQueued: false,
+    resume: true,
+    fork: false,
+    rollback: false,
+    compact: true,
+    telemetry: true,
+    rateLimits: true,
+  };
+
+  private _status: AdapterStatus = 'disconnected';
+  get status(): AdapterStatus {
+    return this._status;
+  }
+
+  async connect(_config: AdapterConfig): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  protected async onDisconnect(): Promise<void> {}
+  async reconnect(): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async sendMessage(_input: AgentSendMessageInputV2): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async interrupt(_input: AgentInterruptInputV2): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async respondToApproval(_input: AgentApprovalResponseInputV2): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+  async respondToInput(_input: AgentInputResponseInputV2): Promise<void> {
+    throw new Error(NOT_IMPLEMENTED);
+  }
+}

--- a/server/protocol-adapters/claude-v2-adapter.ts
+++ b/server/protocol-adapters/claude-v2-adapter.ts
@@ -58,6 +58,15 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
   private _currentTurnId: string | null = null;
   private blockIdx = 0;
   private streamBuffer = '';
+  private toolUseRegistry = new Map<
+    string,
+    {
+      itemId: string;
+      discriminator: 'commandExecution' | 'fileChange' | 'dynamicToolCall';
+      name: string;
+      input: Record<string, unknown>;
+    }
+  >();
   private _providerSessionId: string | null = null;
 
   constructor(options: ClaudeProtocolAdapterV2Options = {}) {
@@ -225,6 +234,8 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
       this.handleSystem(obj);
     } else if (type === 'result') {
       this.handleResult(obj);
+    } else if (type === 'user') {
+      this.handleUserBlock(obj);
     } else {
       this.emitProviderExtension(obj);
     }
@@ -380,7 +391,9 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     const input = (block['input'] ?? {}) as Record<string, unknown>;
 
     let item: AgentItemV2;
+    let discriminator: 'commandExecution' | 'fileChange' | 'dynamicToolCall';
     if (name === 'Bash') {
+      discriminator = 'commandExecution';
       item = {
         type: 'commandExecution',
         id: `exec-${id}`,
@@ -390,6 +403,7 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
         startedAt: this.now(),
       };
     } else if (name === 'Edit' || name === 'Write' || name === 'MultiEdit') {
+      discriminator = 'fileChange';
       item = {
         type: 'fileChange',
         id: `file-${id}`,
@@ -401,6 +415,7 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
         startedAt: this.now(),
       };
     } else {
+      discriminator = 'dynamicToolCall';
       item = {
         type: 'dynamicToolCall',
         id: `tool-${id}`,
@@ -411,6 +426,13 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
         startedAt: this.now(),
       };
     }
+
+    this.toolUseRegistry.set(id, {
+      itemId: item.id,
+      discriminator,
+      name,
+      input,
+    });
 
     this.emitPatch({
       type: ITEM_STARTED,
@@ -504,6 +526,124 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     if (typeof usage['cache_creation_input_tokens'] === 'number')
       result.cacheWriteTokens = usage['cache_creation_input_tokens'];
     return result;
+  }
+
+  private handleUserBlock(obj: Record<string, unknown>): void {
+    const turnId = this._currentTurnId;
+    if (turnId === null) return;
+    const message = obj['message'] as
+      | { content?: Array<Record<string, unknown>> }
+      | undefined;
+    for (const block of message?.content ?? []) {
+      if (block['type'] !== 'tool_result') continue;
+      this.handleToolResult(turnId, block);
+    }
+  }
+
+  private handleToolResult(
+    turnId: string,
+    block: Record<string, unknown>
+  ): void {
+    const toolUseId = String(block['tool_use_id'] ?? '');
+    const entry = this.toolUseRegistry.get(toolUseId);
+    if (entry === undefined) return;
+
+    const content = this.extractToolResultContent(block);
+    const isError = block['is_error'] === true;
+
+    const deltaField =
+      entry.discriminator === 'commandExecution'
+        ? 'output'
+        : entry.discriminator === 'fileChange'
+          ? 'patch'
+          : 'content';
+    this.emitPatch({
+      type: 'agent-item-delta-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      turnId,
+      itemId: entry.itemId,
+      delta: { [deltaField]: content } as {
+        output?: string;
+        patch?: string;
+        content?: string;
+      },
+    });
+
+    const updatedItem = this.buildToolUpdatedItem(entry, content, isError);
+    this.emitPatch({
+      type: 'agent-item-updated-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      turnId,
+      item: updatedItem,
+    });
+  }
+
+  private extractToolResultContent(block: Record<string, unknown>): string {
+    const content = block['content'];
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)) {
+      return content
+        .map((c) =>
+          typeof c === 'object' && c !== null && 'text' in c
+            ? String((c as { text: unknown }).text)
+            : ''
+        )
+        .join('');
+    }
+    return '';
+  }
+
+  private buildToolUpdatedItem(
+    entry: {
+      itemId: string;
+      discriminator: 'commandExecution' | 'fileChange' | 'dynamicToolCall';
+      name: string;
+      input: Record<string, unknown>;
+    },
+    content: string,
+    isError: boolean
+  ): AgentItemV2 {
+    const status: 'completed' | 'failed' = isError ? 'failed' : 'completed';
+    const completedAt = this.now();
+    if (entry.discriminator === 'commandExecution') {
+      return {
+        type: 'commandExecution',
+        id: entry.itemId,
+        command: String(entry.input['command'] ?? ''),
+        output: content,
+        status,
+        completedAt,
+      };
+    }
+    if (entry.discriminator === 'fileChange') {
+      return {
+        type: 'fileChange',
+        id: entry.itemId,
+        paths: [
+          {
+            path: String(
+              entry.input['file_path'] ?? entry.input['filePath'] ?? ''
+            ),
+          },
+        ],
+        ...(content.length > 0 ? { patch: content } : {}),
+        applyStatus: isError ? 'failed' : 'applied',
+        status,
+        completedAt,
+      };
+    }
+    return {
+      type: 'dynamicToolCall',
+      id: entry.itemId,
+      namespace: 'claude',
+      tool: entry.name,
+      arguments: entry.input,
+      result: content,
+      status,
+      completedAt,
+    };
   }
 
   private killActiveProcess(): void {

--- a/server/protocol-adapters/claude-v2-adapter.ts
+++ b/server/protocol-adapters/claude-v2-adapter.ts
@@ -166,6 +166,8 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
     proc.stdout?.on('data', (chunk: Buffer) => {
       this.handleStreamData(chunk.toString('utf8'));
     });
+    proc.on('exit', (code, signal) => this.handleChildExit(code, signal));
+    proc.on('error', (err) => this.handleChildError(err));
   }
 
   async interrupt(_input: AgentInterruptInputV2): Promise<void> {
@@ -644,6 +646,60 @@ export class ClaudeProtocolAdapterV2 extends BaseProtocolAdapterV2 {
       status,
       completedAt,
     };
+  }
+
+  private handleChildExit(
+    code: number | null,
+    _signal: NodeJS.Signals | null
+  ): void {
+    this.activeProcess = null;
+    if (code === 0 || code === null) return;
+    if (this._currentTurnId === null) return;
+    const turnId = this._currentTurnId;
+    this.emitPatch({
+      type: 'agent-error-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      message: `claude exited with code ${code}`,
+      turnId,
+    });
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      turnId,
+      status: 'failed',
+      completedAt: this.now(),
+      error: `exit code ${code}`,
+    });
+    this._currentTurnId = null;
+    this.blockIdx = 0;
+    this.emitLiveState({ status: 'idle', activeTurnId: null, error: null });
+  }
+
+  private handleChildError(err: Error): void {
+    this.activeProcess = null;
+    if (this._currentTurnId === null) return;
+    const turnId = this._currentTurnId;
+    this.emitPatch({
+      type: 'agent-error-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      message: err.message,
+      turnId,
+    });
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sessionId,
+      timestamp: this.now(),
+      turnId,
+      status: 'failed',
+      completedAt: this.now(),
+      error: err.message,
+    });
+    this._currentTurnId = null;
+    this.blockIdx = 0;
+    this.emitLiveState({ status: 'idle', activeTurnId: null, error: null });
   }
 
   private killActiveProcess(): void {

--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -8,6 +8,7 @@ import { OpenCodeProtocolAdapter } from './opencode-adapter.js';
 import { OpenCodeAttachedAdapter } from './opencode-attached-adapter.js';
 
 import { HermesProtocolAdapter } from './hermes-adapter.js';
+import { ClaudeProtocolAdapterV2 } from './claude-v2-adapter.js';
 
 export const adapters: Record<string, () => ProtocolAdapter> = {
   mock: () => new MockProtocolAdapter(),
@@ -29,6 +30,7 @@ export function createAdapter(agentType: string): ProtocolAdapter {
 
 export const v2Adapters: Record<string, () => ProtocolAdapterV2> = {
   mock: () => new MockProtocolAdapterV2(),
+  claude: () => new ClaudeProtocolAdapterV2(),
 };
 
 export function createAdapterV2(agentType: string): ProtocolAdapterV2 {

--- a/test/server/protocol-adapters/claude-v2-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-v2-adapter.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { ClaudeProtocolAdapterV2 } from '../../../server/protocol-adapters/claude-v2-adapter.js';
+
+describe('ClaudeProtocolAdapterV2 — identity', () => {
+  it('reports agentType = claude', () => {
+    const a = new ClaudeProtocolAdapterV2();
+    expect(a.agentType).toBe('claude');
+  });
+
+  it('reports runtimeOwnership = spawned', () => {
+    const a = new ClaudeProtocolAdapterV2();
+    expect(a.runtimeOwnership).toBe('spawned');
+  });
+
+  it('declares text/reasoning/tools/commandExecution/fileChanges/approvals capabilities', () => {
+    const a = new ClaudeProtocolAdapterV2();
+    expect(a.capabilities).toMatchObject({
+      text: true,
+      reasoning: true,
+      tools: true,
+      commandExecution: true,
+      fileChanges: true,
+      approvals: true,
+      interrupt: true,
+    });
+  });
+});

--- a/test/server/protocol-adapters/claude-v2-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-v2-adapter.test.ts
@@ -95,3 +95,52 @@ describe('ClaudeProtocolAdapterV2 — connect lifecycle', () => {
     expect(patches[0]?.sessionId).toBe('custom-id');
   });
 });
+
+describe('ClaudeProtocolAdapterV2 — stream-json buffering', () => {
+  it('ignores partial lines until newline arrives', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-1';
+
+    const handle = (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData.bind(adapter);
+    handle('{"type":"assistant","mess'); // partial — no patches yet
+    const beforeCount = patches.length;
+    handle('age":{"content":[{"type":"text","text":"hi"}]}}\n');
+    expect(patches.length).toBeGreaterThan(beforeCount);
+  });
+
+  it('drops malformed JSON lines without throwing', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-1';
+    const handle = (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData.bind(adapter);
+    expect(() => handle('not-json\n{"type":"unknown"}\n')).not.toThrow();
+  });
+
+  it('routes unknown stream-json types to providerExtension', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-1';
+    const handle = (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData.bind(adapter);
+    handle('{"type":"system","subtype":"init"}\n');
+    const ext = patches.find(
+      (p) =>
+        p.type === 'agent-item-started-v2' &&
+        p.item.type === 'providerExtension'
+    );
+    expect(ext).toBeDefined();
+  });
+});

--- a/test/server/protocol-adapters/claude-v2-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-v2-adapter.test.ts
@@ -144,3 +144,81 @@ describe('ClaudeProtocolAdapterV2 — stream-json buffering', () => {
     expect(ext).toBeDefined();
   });
 });
+
+describe('ClaudeProtocolAdapterV2 — text blocks', () => {
+  it('emits item-started + item-delta + item-updated for a text block', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-1';
+
+    const line =
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'hello world' }] },
+      }) + '\n';
+    (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData(line);
+
+    const started = patches.find(
+      (p) =>
+        p.type === 'agent-item-started-v2' && p.item.type === 'assistantMessage'
+    );
+    expect(started).toMatchObject({
+      turnId: 'turn-1',
+      item: {
+        id: 'msg-turn-1-0',
+        text: '',
+        phase: 'answer',
+        status: 'running',
+      },
+    });
+    const delta = patches.find((p) => p.type === 'agent-item-delta-v2');
+    expect(delta).toMatchObject({
+      itemId: 'msg-turn-1-0',
+      delta: { text: 'hello world' },
+    });
+    const updated = patches.find(
+      (p) =>
+        p.type === 'agent-item-updated-v2' && p.item.type === 'assistantMessage'
+    );
+    expect(updated).toMatchObject({
+      item: { id: 'msg-turn-1-0', text: 'hello world', status: 'completed' },
+    });
+  });
+
+  it('uses incrementing block index for multiple text blocks in same turn', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-A';
+
+    const line =
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [
+            { type: 'text', text: 'first' },
+            { type: 'text', text: 'second' },
+          ],
+        },
+      }) + '\n';
+    (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData(line);
+
+    const ids = patches
+      .filter(
+        (p) =>
+          p.type === 'agent-item-started-v2' &&
+          p.item.type === 'assistantMessage'
+      )
+      .map((p) => (p as { item: { id: string } }).item.id);
+    expect(ids).toEqual(['msg-turn-A-0', 'msg-turn-A-1']);
+  });
+});

--- a/test/server/protocol-adapters/claude-v2-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-v2-adapter.test.ts
@@ -1,6 +1,25 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import type { ChildProcess } from 'node:child_process';
 import { ClaudeProtocolAdapterV2 } from '../../../server/protocol-adapters/claude-v2-adapter.js';
 import type { AgentPatchV2 } from '../../../shared/agent-chat-protocol-v2.js';
+
+interface FakeChild extends EventEmitter {
+  stdout: PassThrough;
+  stderr: PassThrough;
+  stdin: PassThrough;
+  kill: (signal?: NodeJS.Signals | number) => boolean;
+}
+
+function makeFakeChild(): FakeChild {
+  const ee = new EventEmitter() as FakeChild;
+  ee.stdout = new PassThrough();
+  ee.stderr = new PassThrough();
+  ee.stdin = new PassThrough();
+  ee.kill = vi.fn(() => true);
+  return ee;
+}
 
 const baseConfig = {
   cwd: '/tmp',
@@ -485,5 +504,225 @@ describe('ClaudeProtocolAdapterV2 — system/init', () => {
           p.item.type === 'providerExtension'
       )
     ).toBeDefined();
+  });
+});
+
+describe('ClaudeProtocolAdapterV2 — sendMessage', () => {
+  it('throws if called before connect', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    await expect(
+      adapter.sendMessage({ turnId: 't1', content: 'hi' })
+    ).rejects.toThrow();
+  });
+
+  it('emits turn-started + userMessage item + working live state on send', async () => {
+    const fake = makeFakeChild();
+    const spawn = vi.fn(() => fake as unknown as ChildProcess);
+    const adapter = new ClaudeProtocolAdapterV2({ spawn });
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+
+    await adapter.sendMessage({ turnId: 'turn-X', content: 'hello' });
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(
+      patches.find((p) => p.type === 'agent-turn-started-v2')
+    ).toMatchObject({
+      turn: { id: 'turn-X', status: 'running', inputMessageId: 'user-turn-X' },
+    });
+    expect(
+      patches.find(
+        (p) =>
+          p.type === 'agent-item-started-v2' && p.item.type === 'userMessage'
+      )
+    ).toMatchObject({
+      turnId: 'turn-X',
+      item: { id: 'user-turn-X', text: 'hello', status: 'completed' },
+    });
+    expect(
+      patches.find(
+        (p) =>
+          p.type === 'agent-live-state-updated-v2' &&
+          p.live.status === 'working'
+      )
+    ).toBeDefined();
+  });
+
+  it('passes correct CLI args including --output-format stream-json and --permission-mode bypassPermissions', async () => {
+    const fake = makeFakeChild();
+    const spawn = vi.fn(() => fake as unknown as ChildProcess);
+    const adapter = new ClaudeProtocolAdapterV2({ spawn });
+    await adapter.connect(baseConfig);
+    await adapter.sendMessage({ turnId: 't', content: 'hi' });
+
+    const [cmd, args] = spawn.mock.calls[0] as unknown as [
+      string,
+      string[],
+      unknown,
+    ];
+    expect(cmd).toBe('claude');
+    expect(args).toEqual(
+      expect.arrayContaining([
+        '--output-format',
+        'stream-json',
+        '--print',
+        '-p',
+        'hi',
+        '--permission-mode',
+        'bypassPermissions',
+      ])
+    );
+  });
+
+  it('passes --resume when providerSessionId is set', async () => {
+    const fake = makeFakeChild();
+    const spawn = vi.fn(() => fake as unknown as ChildProcess);
+    const adapter = new ClaudeProtocolAdapterV2({ spawn });
+    await adapter.connect(baseConfig);
+    // Simulate prior turn capturing provider session id
+    (adapter as unknown as { _providerSessionId: string })._providerSessionId =
+      'claude-sess-1';
+    await adapter.sendMessage({ turnId: 't', content: 'continue' });
+
+    const [, args] = spawn.mock.calls[0] as unknown as [
+      string,
+      string[],
+      unknown,
+    ];
+    expect(args).toEqual(expect.arrayContaining(['--resume', 'claude-sess-1']));
+  });
+
+  it('passes --model when config.model is set', async () => {
+    const fake = makeFakeChild();
+    const spawn = vi.fn(() => fake as unknown as ChildProcess);
+    const adapter = new ClaudeProtocolAdapterV2({ spawn });
+    await adapter.connect({ ...baseConfig, model: 'claude-opus-4-7' });
+    await adapter.sendMessage({ turnId: 't', content: 'hi' });
+
+    const [, args] = spawn.mock.calls[0] as unknown as [
+      string,
+      string[],
+      unknown,
+    ];
+    expect(args).toEqual(
+      expect.arrayContaining(['--model', 'claude-opus-4-7'])
+    );
+  });
+
+  it('strips CLAUDECODE from spawn env', async () => {
+    const fake = makeFakeChild();
+    const spawn = vi.fn(() => fake as unknown as ChildProcess);
+    const prevEnv = process.env.CLAUDECODE;
+    process.env.CLAUDECODE = '1';
+    try {
+      const adapter = new ClaudeProtocolAdapterV2({ spawn });
+      await adapter.connect(baseConfig);
+      await adapter.sendMessage({ turnId: 't', content: 'hi' });
+      const [, , opts] = spawn.mock.calls[0] as unknown as [
+        string,
+        string[],
+        { env: Record<string, string> },
+      ];
+      expect(opts.env).not.toHaveProperty('CLAUDECODE');
+    } finally {
+      if (prevEnv === undefined) delete process.env.CLAUDECODE;
+      else process.env.CLAUDECODE = prevEnv;
+    }
+  });
+
+  it('pipes stdout chunks into handleStreamData (text block end-to-end)', async () => {
+    const fake = makeFakeChild();
+    const spawn = vi.fn(() => fake as unknown as ChildProcess);
+    const adapter = new ClaudeProtocolAdapterV2({ spawn });
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    await adapter.sendMessage({ turnId: 'turn-Y', content: 'q' });
+
+    const line =
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'answer' }] },
+      }) + '\n';
+    fake.stdout.write(Buffer.from(line, 'utf8'));
+
+    const delta = patches.find((p) => p.type === 'agent-item-delta-v2');
+    expect(delta).toMatchObject({ delta: { text: 'answer' } });
+  });
+
+  it('resets blockIdx to 0 at start of each new turn', async () => {
+    const fake1 = makeFakeChild();
+    const fake2 = makeFakeChild();
+    const spawn = vi.fn().mockReturnValueOnce(fake1).mockReturnValueOnce(fake2);
+    const adapter = new ClaudeProtocolAdapterV2({
+      spawn: spawn as unknown as typeof import('node:child_process').spawn,
+    });
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+
+    await adapter.sendMessage({ turnId: 'A', content: 'x' });
+    fake1.stdout.write(
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: '1' }] },
+      }) + '\n'
+    );
+    fake1.stdout.write(
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: '2' }] },
+      }) + '\n'
+    );
+
+    await adapter.sendMessage({ turnId: 'B', content: 'y' });
+    fake2.stdout.write(
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: '1' }] },
+      }) + '\n'
+    );
+
+    const turnBStartedIds = patches
+      .filter(
+        (p) =>
+          p.type === 'agent-item-started-v2' &&
+          'turnId' in p &&
+          p.turnId === 'B' &&
+          p.item.type === 'assistantMessage'
+      )
+      .map((p) => (p as { item: { id: string } }).item.id);
+    // First text block of turn B should have idx 0, not continue from turn A's counter
+    expect(turnBStartedIds[0]).toBe('msg-B-0');
+  });
+});
+
+describe('ClaudeProtocolAdapterV2 — interrupt', () => {
+  it('kills active process', async () => {
+    const fake = makeFakeChild();
+    const killSpy = fake.kill as ReturnType<typeof vi.fn>;
+    const spawn = vi.fn(() => fake as unknown as ChildProcess);
+    const adapter = new ClaudeProtocolAdapterV2({ spawn });
+    await adapter.connect(baseConfig);
+    await adapter.sendMessage({ turnId: 't', content: 'hi' });
+    await adapter.interrupt({ turnId: 't' });
+    expect(killSpy).toHaveBeenCalled();
+  });
+
+  it('no-op when no active process', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    await adapter.connect(baseConfig);
+    await expect(adapter.interrupt({})).resolves.toBeUndefined();
+  });
+});
+
+describe('ClaudeProtocolAdapterV2 — respondToInput', () => {
+  it('resolves silently (no-op for claude)', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    await adapter.connect(baseConfig);
+    await expect(
+      adapter.respondToInput({ requestId: 'r1', answers: {} })
+    ).resolves.toBeUndefined();
   });
 });

--- a/test/server/protocol-adapters/claude-v2-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-v2-adapter.test.ts
@@ -135,7 +135,7 @@ describe('ClaudeProtocolAdapterV2 — stream-json buffering', () => {
     const handle = (
       adapter as unknown as { handleStreamData: (s: string) => void }
     ).handleStreamData.bind(adapter);
-    handle('{"type":"system","subtype":"init"}\n');
+    handle('{"type":"unknown-type"}\n');
     const ext = patches.find(
       (p) =>
         p.type === 'agent-item-started-v2' &&
@@ -411,5 +411,79 @@ describe('ClaudeProtocolAdapterV2 — tool_use blocks', () => {
         status: 'running',
       },
     });
+  });
+});
+
+describe('ClaudeProtocolAdapterV2 — system/init', () => {
+  it('captures session_id from system/init and emits snapshot with providerSession', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+
+    const handle = (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData.bind(adapter);
+    handle(
+      JSON.stringify({
+        type: 'system',
+        subtype: 'init',
+        session_id: 'abc-123',
+        model: 'claude-opus-4-7',
+        tools: ['Bash', 'Edit'],
+        cwd: '/proj',
+      }) + '\n'
+    );
+
+    const snapshot = patches.find(
+      (p) => p.type === 'agent-session-snapshot-v2'
+    );
+    expect(snapshot).toBeDefined();
+    expect(
+      snapshot && 'session' in snapshot && snapshot.session.providerSession
+    ).toMatchObject({
+      sessionId: 'abc-123',
+    });
+  });
+
+  it('exposes captured provider session id via getter for sendMessage --resume', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    await adapter.connect(baseConfig);
+    const handle = (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData.bind(adapter);
+    handle(
+      JSON.stringify({
+        type: 'system',
+        subtype: 'init',
+        session_id: 'xyz-789',
+      }) + '\n'
+    );
+    expect(
+      (adapter as unknown as { providerSessionId: string | null })
+        .providerSessionId
+    ).toBe('xyz-789');
+  });
+
+  it('non-init system events still route to providerExtension', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-1';
+    const handle = (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData.bind(adapter);
+    handle(
+      JSON.stringify({ type: 'system', subtype: 'something-else' }) + '\n'
+    );
+    expect(
+      patches.find(
+        (p) =>
+          p.type === 'agent-item-started-v2' &&
+          p.item.type === 'providerExtension'
+      )
+    ).toBeDefined();
   });
 });

--- a/test/server/protocol-adapters/claude-v2-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-v2-adapter.test.ts
@@ -222,3 +222,51 @@ describe('ClaudeProtocolAdapterV2 — text blocks', () => {
     expect(ids).toEqual(['msg-turn-A-0', 'msg-turn-A-1']);
   });
 });
+
+describe('ClaudeProtocolAdapterV2 — thinking blocks', () => {
+  it('emits item-started + item-delta + item-updated for a thinking block', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-2';
+
+    const line =
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'thinking', thinking: 'thinking text' }] },
+      }) + '\n';
+    (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData(line);
+
+    const started = patches.find(
+      (p) => p.type === 'agent-item-started-v2' && p.item.type === 'reasoning'
+    );
+    expect(started).toMatchObject({
+      turnId: 'turn-2',
+      item: {
+        id: 'thinking-turn-2-0',
+        summary: '',
+        visibility: 'summary',
+        status: 'running',
+      },
+    });
+    const delta = patches.find((p) => p.type === 'agent-item-delta-v2');
+    expect(delta).toMatchObject({
+      itemId: 'thinking-turn-2-0',
+      delta: { summary: 'thinking text' },
+    });
+    const updated = patches.find(
+      (p) => p.type === 'agent-item-updated-v2' && p.item.type === 'reasoning'
+    );
+    expect(updated).toMatchObject({
+      item: {
+        id: 'thinking-turn-2-0',
+        summary: 'thinking text',
+        status: 'completed',
+      },
+    });
+  });
+});

--- a/test/server/protocol-adapters/claude-v2-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-v2-adapter.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { ClaudeProtocolAdapterV2 } from '../../../server/protocol-adapters/claude-v2-adapter.js';
+import type { AgentPatchV2 } from '../../../shared/agent-chat-protocol-v2.js';
+
+const baseConfig = {
+  cwd: '/tmp',
+  port: 0,
+  sessionId: 's1',
+  hookToken: 't',
+  configDir: '/tmp/cfg',
+};
 
 describe('ClaudeProtocolAdapterV2 — identity', () => {
   it('reports agentType = claude', () => {
@@ -23,5 +32,66 @@ describe('ClaudeProtocolAdapterV2 — identity', () => {
       approvals: true,
       interrupt: true,
     });
+  });
+});
+
+describe('ClaudeProtocolAdapterV2 — connect lifecycle', () => {
+  it('connect transitions to status=connected and emits idle live state', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+
+    await adapter.connect(baseConfig);
+
+    expect(adapter.status).toBe('connected');
+    const live = patches.find((p) => p.type === 'agent-live-state-updated-v2');
+    expect(live).toMatchObject({
+      sessionId: 's1',
+      live: {
+        status: 'idle',
+        activeTurnId: null,
+        waitingOn: null,
+        activeRequestIds: [],
+        queueLength: 0,
+        error: null,
+      },
+    });
+  });
+
+  it('disconnect transitions to status=disconnected', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    await adapter.connect(baseConfig);
+    await adapter.disconnect();
+    expect(adapter.status).toBe('disconnected');
+  });
+
+  it('reconnect cycles disconnect → connect and re-emits idle live state', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    await adapter.connect(baseConfig);
+    await adapter.reconnect();
+
+    // Trigger another connect to verify post-reconnect emission still works.
+    // Subscribe after disconnect so the handler is not cleared by it.
+    await adapter.disconnect();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    expect(adapter.status).toBe('connected');
+    expect(
+      patches.find((p) => p.type === 'agent-live-state-updated-v2')
+    ).toBeDefined();
+  });
+
+  it('reconnect before initial connect throws', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    await expect(adapter.reconnect()).rejects.toThrow(/cannot reconnect/i);
+  });
+
+  it('emits patches with sessionId taken from connect config', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect({ ...baseConfig, sessionId: 'custom-id' });
+    expect(patches[0]?.sessionId).toBe('custom-id');
   });
 });

--- a/test/server/protocol-adapters/claude-v2-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-v2-adapter.test.ts
@@ -948,3 +948,61 @@ describe('ClaudeProtocolAdapterV2 — tool_result blocks', () => {
     ).toBeUndefined();
   });
 });
+
+describe('ClaudeProtocolAdapterV2 — child exit/error', () => {
+  it('non-zero exit emits error + turn-completed failed', async () => {
+    const fake = makeFakeChild();
+    const spawn = vi.fn(() => fake as unknown as ChildProcess);
+    const adapter = new ClaudeProtocolAdapterV2({ spawn });
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    await adapter.sendMessage({ turnId: 't', content: 'q' });
+
+    fake.emit('exit', 1, null);
+
+    expect(patches.find((p) => p.type === 'agent-error-v2')).toMatchObject({
+      message: expect.stringContaining('exit'),
+    });
+    expect(
+      patches.find((p) => p.type === 'agent-turn-completed-v2')
+    ).toMatchObject({
+      status: 'failed',
+    });
+  });
+
+  it('zero exit does NOT emit failure (result event handles success)', async () => {
+    const fake = makeFakeChild();
+    const spawn = vi.fn(() => fake as unknown as ChildProcess);
+    const adapter = new ClaudeProtocolAdapterV2({ spawn });
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    await adapter.sendMessage({ turnId: 't', content: 'q' });
+
+    fake.emit('exit', 0, null);
+
+    expect(patches.find((p) => p.type === 'agent-error-v2')).toBeUndefined();
+  });
+
+  it('spawn error event emits error + turn-completed failed', async () => {
+    const fake = makeFakeChild();
+    const spawn = vi.fn(() => fake as unknown as ChildProcess);
+    const adapter = new ClaudeProtocolAdapterV2({ spawn });
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    await adapter.sendMessage({ turnId: 't', content: 'q' });
+
+    fake.emit('error', new Error('ENOENT'));
+
+    expect(patches.find((p) => p.type === 'agent-error-v2')).toMatchObject({
+      message: 'ENOENT',
+    });
+    expect(
+      patches.find((p) => p.type === 'agent-turn-completed-v2')
+    ).toMatchObject({
+      status: 'failed',
+    });
+  });
+});

--- a/test/server/protocol-adapters/claude-v2-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-v2-adapter.test.ts
@@ -726,3 +726,96 @@ describe('ClaudeProtocolAdapterV2 — respondToInput', () => {
     ).resolves.toBeUndefined();
   });
 });
+
+describe('ClaudeProtocolAdapterV2 — result event', () => {
+  it('success result emits agent-turn-completed-v2 with usage', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-R';
+
+    const handle = (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData.bind(adapter);
+    handle(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        duration_ms: 1234,
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_read_input_tokens: 20,
+          cache_creation_input_tokens: 10,
+        },
+      }) + '\n'
+    );
+
+    const completed = patches.find((p) => p.type === 'agent-turn-completed-v2');
+    expect(completed).toMatchObject({
+      turnId: 'turn-R',
+      status: 'completed',
+      durationMs: 1234,
+      usage: {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: 20,
+        cacheWriteTokens: 10,
+      },
+    });
+  });
+
+  it('non-success result emits failed status + error message', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-R';
+
+    const handle = (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData.bind(adapter);
+    handle(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'error_during_execution',
+        duration_ms: 5,
+      }) + '\n'
+    );
+
+    const errPatch = patches.find((p) => p.type === 'agent-error-v2');
+    const completed = patches.find((p) => p.type === 'agent-turn-completed-v2');
+    expect(errPatch).toBeDefined();
+    expect(completed).toMatchObject({ status: 'failed' });
+  });
+
+  it('result clears _currentTurnId and emits idle live state', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-R';
+
+    const handle = (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData.bind(adapter);
+    handle(
+      JSON.stringify({ type: 'result', subtype: 'success', duration_ms: 1 }) +
+        '\n'
+    );
+
+    expect(
+      (adapter as unknown as { _currentTurnId: string | null })._currentTurnId
+    ).toBeNull();
+    const lastLive = [...patches]
+      .reverse()
+      .find((p) => p.type === 'agent-live-state-updated-v2');
+    expect(lastLive).toMatchObject({
+      live: { status: 'idle', activeTurnId: null },
+    });
+  });
+});

--- a/test/server/protocol-adapters/claude-v2-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-v2-adapter.test.ts
@@ -270,3 +270,146 @@ describe('ClaudeProtocolAdapterV2 — thinking blocks', () => {
     });
   });
 });
+
+describe('ClaudeProtocolAdapterV2 — tool_use blocks', () => {
+  function makeToolUse(
+    name: string,
+    input: Record<string, unknown>,
+    id = 'toolu_x'
+  ) {
+    return (
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'tool_use', id, name, input }] },
+      }) + '\n'
+    );
+  }
+
+  it('Bash → commandExecution item with exec- prefix', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-T';
+    (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData(makeToolUse('Bash', { command: 'ls -la' }, 'toolu_b1'));
+
+    const started = patches.find(
+      (p) =>
+        p.type === 'agent-item-started-v2' && p.item.type === 'commandExecution'
+    );
+    expect(started).toMatchObject({
+      item: {
+        id: 'exec-toolu_b1',
+        command: 'ls -la',
+        output: '',
+        status: 'running',
+      },
+    });
+  });
+
+  it('Edit → fileChange item with file- prefix and paths', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-T';
+    (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData(
+      makeToolUse('Edit', { file_path: 'src/foo.ts' }, 'toolu_e1')
+    );
+
+    const started = patches.find(
+      (p) => p.type === 'agent-item-started-v2' && p.item.type === 'fileChange'
+    );
+    expect(started).toMatchObject({
+      item: {
+        id: 'file-toolu_e1',
+        paths: [{ path: 'src/foo.ts' }],
+        applyStatus: 'pending',
+      },
+    });
+  });
+
+  it('Write → fileChange', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-T';
+    (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData(
+      makeToolUse(
+        'Write',
+        { file_path: 'src/bar.ts', content: 'x' },
+        'toolu_w1'
+      )
+    );
+
+    expect(
+      patches.find(
+        (p) =>
+          p.type === 'agent-item-started-v2' && p.item.type === 'fileChange'
+      )
+    ).toBeDefined();
+  });
+
+  it('MultiEdit → fileChange', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-T';
+    (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData(
+      makeToolUse(
+        'MultiEdit',
+        { file_path: 'src/baz.ts', edits: [] },
+        'toolu_m1'
+      )
+    );
+
+    expect(
+      patches.find(
+        (p) =>
+          p.type === 'agent-item-started-v2' && p.item.type === 'fileChange'
+      )
+    ).toBeDefined();
+  });
+
+  it('Other tool → dynamicToolCall with namespace=claude and tool name', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-T';
+    (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData(
+      makeToolUse('Read', { file_path: 'src/foo.ts' }, 'toolu_r1')
+    );
+
+    const started = patches.find(
+      (p) =>
+        p.type === 'agent-item-started-v2' && p.item.type === 'dynamicToolCall'
+    );
+    expect(started).toMatchObject({
+      item: {
+        id: 'tool-toolu_r1',
+        namespace: 'claude',
+        tool: 'Read',
+        arguments: { file_path: 'src/foo.ts' },
+        status: 'running',
+      },
+    });
+  });
+});

--- a/test/server/protocol-adapters/claude-v2-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-v2-adapter.test.ts
@@ -819,3 +819,132 @@ describe('ClaudeProtocolAdapterV2 — result event', () => {
     });
   });
 });
+
+describe('ClaudeProtocolAdapterV2 — tool_result blocks', () => {
+  function feed(adapter: ClaudeProtocolAdapterV2, line: string): void {
+    (
+      adapter as unknown as { handleStreamData: (s: string) => void }
+    ).handleStreamData(line + '\n');
+  }
+  function toolUseLine(
+    name: string,
+    id: string,
+    input: Record<string, unknown>
+  ): string {
+    return JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', id, name, input }] },
+    });
+  }
+  function toolResultLine(
+    toolUseId: string,
+    content: string,
+    isError = false
+  ): string {
+    return JSON.stringify({
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: toolUseId,
+            content,
+            is_error: isError,
+          },
+        ],
+      },
+    });
+  }
+
+  it('Bash tool_result → output delta + commandExecution completed', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-X';
+
+    feed(adapter, toolUseLine('Bash', 'tu_b1', { command: 'ls' }));
+    feed(adapter, toolResultLine('tu_b1', 'file1\nfile2'));
+
+    const delta = patches.find(
+      (p) =>
+        p.type === 'agent-item-delta-v2' &&
+        (p as { itemId: string }).itemId === 'exec-tu_b1'
+    );
+    expect(delta).toMatchObject({ delta: { output: 'file1\nfile2' } });
+    const updated = patches.find(
+      (p) =>
+        p.type === 'agent-item-updated-v2' &&
+        p.item.type === 'commandExecution' &&
+        p.item.id === 'exec-tu_b1'
+    );
+    expect(updated).toMatchObject({
+      item: { output: 'file1\nfile2', status: 'completed' },
+    });
+  });
+
+  it('Edit tool_result is_error → fileChange failed/applyStatus failed', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-X';
+
+    feed(
+      adapter,
+      toolUseLine('Edit', 'tu_e1', {
+        file_path: 'src/foo.ts',
+        old_string: 'a',
+        new_string: 'b',
+      })
+    );
+    feed(adapter, toolResultLine('tu_e1', 'String not found', true));
+
+    const updated = patches.find(
+      (p) => p.type === 'agent-item-updated-v2' && p.item.type === 'fileChange'
+    );
+    expect(updated).toMatchObject({
+      item: { id: 'file-tu_e1', applyStatus: 'failed', status: 'failed' },
+    });
+  });
+
+  it('generic tool_result → dynamicToolCall completed with result', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-X';
+
+    feed(adapter, toolUseLine('Read', 'tu_r1', { file_path: 'a.txt' }));
+    feed(adapter, toolResultLine('tu_r1', 'file contents'));
+
+    const updated = patches.find(
+      (p) =>
+        p.type === 'agent-item-updated-v2' && p.item.type === 'dynamicToolCall'
+    );
+    expect(updated).toMatchObject({
+      item: {
+        id: 'tool-tu_r1',
+        tool: 'Read',
+        result: 'file contents',
+        status: 'completed',
+      },
+    });
+  });
+
+  it('tool_result with unknown tool_use_id is ignored', async () => {
+    const adapter = new ClaudeProtocolAdapterV2();
+    const patches: AgentPatchV2[] = [];
+    adapter.onPatch((p) => patches.push(p));
+    await adapter.connect(baseConfig);
+    (adapter as unknown as { _currentTurnId: string })._currentTurnId =
+      'turn-X';
+    feed(adapter, toolResultLine('unknown_id', 'data'));
+    expect(
+      patches.find((p) => p.type === 'agent-item-delta-v2')
+    ).toBeUndefined();
+  });
+});

--- a/test/server/protocol-adapters/index.test.ts
+++ b/test/server/protocol-adapters/index.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { createAdapterV2 } from '../../../server/protocol-adapters/index.js';
+import { ClaudeProtocolAdapterV2 } from '../../../server/protocol-adapters/claude-v2-adapter.js';
+import { MockProtocolAdapterV2 } from '../../../server/protocol-adapters/mock-v2-adapter.js';
+
+describe('createAdapterV2', () => {
+  it('returns MockProtocolAdapterV2 for "mock"', () => {
+    expect(createAdapterV2('mock')).toBeInstanceOf(MockProtocolAdapterV2);
+  });
+
+  it('returns ClaudeProtocolAdapterV2 for "claude"', () => {
+    expect(createAdapterV2('claude')).toBeInstanceOf(ClaudeProtocolAdapterV2);
+  });
+
+  it('throws on unknown agent type', () => {
+    expect(() => createAdapterV2('definitely-not-real')).toThrow(
+      /v2 protocol adapter/i
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Native Claude V2 protocol adapter (`server/protocol-adapters/claude-v2-adapter.ts`)
- Spawn-per-turn semantics: each `sendMessage` spawns `claude --output-format stream-json --print`
- Maps stream-json text/thinking/tool_use blocks to `assistantMessage`/`reasoning`/`commandExecution`|`fileChange`|`dynamicToolCall` items
- `tool_result` blocks update tool items with output/patch/content
- `result` event closes turn with usage; non-zero child exit and error events emit `agent-turn-completed-v2(failed)`
- Captures provider session id from `system/init` for future `--resume` support
- Registered in v2Adapters factory map

## Phase 1 of 7 in V1→V2 port plan
See `docs/plans/2026-04-26-v1-to-v2-port.md`. V1 ChatEvent path remains active alongside V2; cutover happens in Phase 5.

## Out of scope (deferred)
- Hook-based approval flow (uses `--permission-mode bypassPermissions` for now)
- Capability runtime support for `approvals`, `compact`, `fork`, `rollback` (capability flags declare future contract)

## Test plan
- [x] 43 unit tests pass (adapter behavior)
- [x] Factory registry test passes (3 tests)
- [x] Full project test suite green (1483/1494 pass; 11 failures are pre-existing dist-not-compiled infrastructure tests unrelated to V2)
- [ ] Browser QA deferred to Phase 6 (cutover + multi-provider QA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)