### PR TITLE
feat(claude): add native AgentPatchV2 web adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.119",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -61,6 +62,156 @@
       },
       "engines": {
         "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.119.tgz",
+      "integrity": "sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.81.0",
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.119",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.119"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.119.tgz",
+      "integrity": "sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.119.tgz",
+      "integrity": "sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.119.tgz",
+      "integrity": "sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.119.tgz",
+      "integrity": "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.119.tgz",
+      "integrity": "sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.119.tgz",
+      "integrity": "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.119.tgz",
+      "integrity": "sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.2.119",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.119.tgz",
+      "integrity": "sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.81.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.81.0.tgz",
+      "integrity": "sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -340,6 +491,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1053,6 +1213,18 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1149,6 +1321,380 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@playwright/test": {
@@ -2505,6 +3051,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
@@ -2983,6 +3568,23 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3615,6 +4217,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3632,6 +4252,22 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3978,6 +4614,15 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-void-elements": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
@@ -4095,6 +4740,15 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -4141,11 +4795,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4173,11 +4842,30 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -4706,6 +5394,15 @@
         "node": "*"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -4888,6 +5585,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/playwright": {
@@ -5193,6 +5899,15 @@
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -5260,6 +5975,55 @@
         "@rollup/rollup-win32-x64-gnu": "4.59.0",
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/safe-buffer": {
@@ -5795,6 +6559,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -6456,6 +7226,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "license": "MIT",
   "author": "Donovan Yohan",
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.119",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -1,151 +1,709 @@
-import crypto from 'node:crypto';
-import type { AdapterConfig } from '../protocol-adapter.js';
-import { BaseHookAdapter } from './base-hook-adapter.js';
-import type { HookEventPayload } from './base-hook-adapter.js';
-import { strField } from './adapter-utils.js';
+import { query as sdkQuery } from '@anthropic-ai/claude-agent-sdk';
+import type { CanUseTool, PermissionMode, PermissionResult } from '@anthropic-ai/claude-agent-sdk';
+import { BaseProtocolAdapterV2 } from '../protocol-adapter-v2.js';
+import type {
+  AdapterConfig,
+  AdapterStatus,
+  AgentApprovalResponseInputV2,
+  AgentInputResponseInputV2,
+  AgentInterruptInputV2,
+  AgentSendMessageInputV2,
+} from '../protocol-adapter-v2.js';
+import type {
+  AgentCapabilitySetV2,
+  AgentItemV2,
+  AgentSessionLiveStateV2,
+  AgentUsageV2,
+} from '../../shared/agent-chat-protocol-v2.js';
+import { emptyAgentSessionV2 } from '../../shared/agent-chat-protocol-v2.js';
 import { createLogger } from '../logger.js';
 
 const logger = createLogger('claude-adapter');
 
-export class ClaudeProtocolAdapter extends BaseHookAdapter {
+type QueryParams = {
+  prompt: string;
+  options?: {
+    abortController?: AbortController;
+    cwd?: string;
+    model?: string;
+    permissionMode?: PermissionMode;
+    additionalDirectories?: string[];
+    env?: Record<string, string | undefined>;
+    includePartialMessages?: boolean;
+    includeHookEvents?: boolean;
+    canUseTool?: CanUseTool;
+  };
+};
+
+export type ClaudeQuery = AsyncGenerator<unknown, void> & {
+  interrupt?: () => Promise<void>;
+  close?: () => void;
+};
+
+export type ClaudeQueryFunction = (params: QueryParams) => ClaudeQuery;
+
+interface QueuedClaudeMessage {
+  input: AgentSendMessageInputV2;
+  resolve: () => void;
+  reject: (err: unknown) => void;
+}
+
+const CLAUDE_CAPABILITIES: AgentCapabilitySetV2 = {
+  text: true,
+  reasoning: true,
+  tools: true,
+  commandExecution: true,
+  fileChanges: true,
+  approvals: true,
+  questions: false,
+  plans: false,
+  slashCommands: true,
+  queue: true,
+  interrupt: true,
+  cancelQueued: false,
+  resume: true,
+  fork: false,
+  rollback: false,
+  compact: true,
+  telemetry: true,
+  rateLimits: true,
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function objectField(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function contentBlocks(message: Record<string, unknown>): Record<string, unknown>[] {
+  const nativeMessage = objectField(message.message);
+  const content = nativeMessage.content;
+  if (!Array.isArray(content)) return [];
+  return content.filter(isRecord);
+}
+
+function usageFromResult(message: Record<string, unknown>): AgentUsageV2 {
+  const usage = objectField(message.usage);
+  const inputTokens = Number(usage.input_tokens ?? usage.inputTokens);
+  const outputTokens = Number(usage.output_tokens ?? usage.outputTokens);
+  const cacheReadTokens = Number(
+    usage.cache_read_input_tokens ?? usage.cacheReadInputTokens
+  );
+  const cacheWriteTokens = Number(
+    usage.cache_creation_input_tokens ?? usage.cacheCreationInputTokens
+  );
+  const costUsd = Number(message.total_cost_usd ?? message.totalCostUsd);
+
+  return {
+    ...(Number.isFinite(inputTokens) ? { inputTokens } : {}),
+    ...(Number.isFinite(outputTokens) ? { outputTokens } : {}),
+    ...(Number.isFinite(cacheReadTokens) ? { cacheReadTokens } : {}),
+    ...(Number.isFinite(cacheWriteTokens) ? { cacheWriteTokens } : {}),
+    ...(Number.isFinite(costUsd) ? { costUsd } : {}),
+  };
+}
+
+function targetFromToolInput(toolName: string, input: Record<string, unknown>): string {
+  if (toolName === 'Bash') return stringField(input.command, JSON.stringify(input));
+  return stringField(input.file_path ?? input.path, JSON.stringify(input));
+}
+
+function filePathsFromToolInput(input: Record<string, unknown>): Array<{ path: string; status?: string }> {
+  const paths: Array<{ path: string; status?: string }> = [];
+  const filePath = input.file_path ?? input.path;
+  if (typeof filePath === 'string') paths.push({ path: filePath, status: 'edited' });
+  const edits = input.edits;
+  if (Array.isArray(edits)) {
+    for (const edit of edits) {
+      if (isRecord(edit) && typeof edit.file_path === 'string') {
+        paths.push({ path: edit.file_path, status: 'edited' });
+      }
+    }
+  }
+  return paths.length > 0 ? paths : [{ path: 'unknown', status: 'pending' }];
+}
+
+function permissionMode(value: string | undefined): PermissionMode | undefined {
+  if (
+    value === 'default' ||
+    value === 'acceptEdits' ||
+    value === 'bypassPermissions' ||
+    value === 'plan' ||
+    value === 'dontAsk' ||
+    value === 'auto'
+  ) {
+    return value;
+  }
+  return undefined;
+}
+
+export class ClaudeProtocolAdapter extends BaseProtocolAdapterV2 {
   readonly agentType = 'claude';
+  readonly runtimeOwnership = 'spawned' as const;
+  readonly capabilities = CLAUDE_CAPABILITIES;
 
-  protected buildSpawnCommand(config: AdapterConfig): {
-    command: string;
-    args: string[];
-    env: Record<string, string>;
-  } {
-    const args = ['--output-format', 'stream-json'];
-    if (config.permissionMode) {
-      args.push('--allowedTools', config.permissionMode);
-    }
-    return {
-      command: 'claude',
-      args,
-      env: {
-        CLAUDE_CODE_NO_FLICKER: '1',
-        CLAUDE_CODE_HOOKS_URL: `http://127.0.0.1:${config.port}/hooks/agent-event`,
-        CLAUDE_CODE_HOOKS_TOKEN: config.hookToken,
-        CLAUDE_CODE_SESSION_ID: config.sessionId,
-      },
-    };
+  private _status: AdapterStatus = 'disconnected';
+  private config: AdapterConfig | null = null;
+  private activeTurnId: string | null = null;
+  private activeStartedAt: string | null = null;
+  private activeController: AbortController | null = null;
+  private activeQuery: ClaudeQuery | null = null;
+  private readonly queue: QueuedClaudeMessage[] = [];
+  private readonly pendingApprovals = new Map<
+    string,
+    (decision: AgentApprovalResponseInputV2['decision']) => void
+  >();
+  private completedActiveTurn = false;
+  private readonly queryFn: ClaudeQueryFunction;
+
+  constructor(queryFn: ClaudeQueryFunction = sdkQuery as unknown as ClaudeQueryFunction) {
+    super();
+    this.queryFn = queryFn;
   }
 
-  protected async setupHooks(_config: AdapterConfig): Promise<void> {
-    logger.info('Claude hooks configured via environment variables');
+  get status(): AdapterStatus {
+    return this._status;
   }
 
-  protected async cleanupHooks(_config: AdapterConfig): Promise<void> {
-    // No temp files to clean up for Claude
-  }
-
-  protected mapHookEvent(payload: HookEventPayload): void {
-    switch (payload.type) {
-      case 'assistant':
-        this.handleAssistant(payload);
-        break;
-      case 'tool.started':
-      case 'PreToolUse':
-        this.handleToolStarted(payload);
-        break;
-      case 'tool.finished':
-      case 'PostToolUse':
-        this.handleToolFinished(payload);
-        break;
-      case 'session.idle':
-      case 'Stop':
-        this.handleIdle();
-        break;
-      case 'permission.requested':
-      case 'notification':
-        this.handlePermission(payload);
-        break;
-      default:
-        logger.debug('Unhandled Claude hook event:', payload.type);
-    }
-  }
-
-  private handleAssistant(payload: HookEventPayload): void {
-    const content = payload.data?.['content'] as string | undefined;
-    if (!content) return;
-    const turnId = this._currentTurnId ?? 'turn-0';
-    this.fire({
-      type: 'chat:text-delta',
-      turnId,
-      messageId: `msg-${turnId}`,
-      delta: content,
-    });
-  }
-
-  private handleToolStarted(payload: HookEventPayload): void {
-    const turnId = this._currentTurnId ?? 'turn-0';
-    const tool = payload.data?.['tool'] as Record<string, unknown> | undefined;
-    this.fire({
-      type: 'chat:tool-call',
-      turnId,
-      toolCallId: strField(payload.data, 'toolCallId', crypto.randomUUID()),
-      toolName: String(
-        tool?.['name'] ?? strField(payload.data, 'toolName', 'unknown')
-      ),
-      description: String(tool?.['description'] ?? ''),
-      input: (tool?.['input'] ?? payload.data?.['input'] ?? {}) as Record<
-        string,
-        unknown
-      >,
-      status: 'running',
-    });
-  }
-
-  private handleToolFinished(payload: HookEventPayload): void {
-    const turnId = this._currentTurnId ?? 'turn-0';
-    const errorVal = payload.data?.['error'];
-    this.fire({
-      type: 'chat:tool-result',
-      turnId,
-      toolCallId: strField(payload.data, 'toolCallId'),
-      toolName: strField(payload.data, 'toolName', 'unknown'),
-      status: errorVal ? 'error' : 'completed',
-      output: strField(payload.data, 'output'),
-      durationMs: Number(payload.data?.['durationMs'] ?? 0),
-      ...(errorVal ? { error: String(errorVal) } : {}),
-    });
-  }
-
-  private handleIdle(): void {
-    if (this._currentTurnId) {
-      this.fire({
-        type: 'chat:turn-completed',
-        turnId: this._currentTurnId,
-        reason: 'completed',
-        durationMs: 0,
-        toolCallCount: 0,
-        messageCount: 1,
-      });
-      this._currentTurnId = null;
-    }
-    this.fire({ type: 'chat:session-status', status: 'idle' });
-  }
-
-  private handlePermission(payload: HookEventPayload): void {
-    if (
-      payload.data?.['type'] !== 'permission' &&
-      !payload.data?.['permission']
-    )
-      return;
-    const turnId = this._currentTurnId ?? 'turn-0';
-    this.fire({
-      type: 'chat:approval-request',
-      turnId,
-      requestId: strField(payload.data, 'requestId', crypto.randomUUID()),
-      kind: 'permission',
-      toolName: strField(payload.data, 'toolName', 'unknown'),
-      description: strField(payload.data, 'description'),
-      target: strField(payload.data, 'target'),
-    });
-    this.fire({
-      type: 'chat:session-status',
+  async connect(config: AdapterConfig): Promise<void> {
+    this.config = config;
+    this._status = 'connected';
+    this.emitSnapshot();
+    this.emitLiveState({
       status: 'idle',
-      waitingOn: 'approval',
+      activeTurnId: null,
+      waitingOn: null,
+      activeRequestIds: [],
+      proposedPlanItemId: null,
+      queueLength: 0,
+      fastModeAvailable: true,
+      error: null,
     });
+  }
+
+  protected async onDisconnect(): Promise<void> {
+    this.activeController?.abort();
+    this.activeQuery?.close?.();
+    this.rejectQueued(new Error('Claude adapter disconnected'));
+    this.pendingApprovals.clear();
+    this.activeTurnId = null;
+    this.activeStartedAt = null;
+    this.activeController = null;
+    this.activeQuery = null;
+    this._status = 'disconnected';
+  }
+
+  async reconnect(): Promise<void> {
+    if (!this.config) throw new Error('Cannot reconnect before connect');
+    const config = this.config;
+    await this.disconnect();
+    await this.connect(config);
+  }
+
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    if (this._status !== 'connected') {
+      throw new Error('Cannot send a Claude message before connect');
+    }
+
+    if (this.activeTurnId !== null) {
+      return new Promise((resolve, reject) => {
+        this.queue.push({ input, resolve, reject });
+        this.emitLiveState({
+          status: 'working',
+          activeTurnId: this.activeTurnId,
+          queueLength: this.queue.length,
+        });
+      });
+    }
+
+    return this.startTurn(input);
+  }
+
+  async interrupt(input: AgentInterruptInputV2): Promise<void> {
+    if (
+      this.activeTurnId !== null &&
+      (input.turnId === undefined || input.turnId === this.activeTurnId)
+    ) {
+      await this.activeQuery?.interrupt?.().catch((err: unknown) => {
+        logger.warn('Claude interrupt request failed:', err);
+      });
+      this.activeController?.abort();
+      this.completeActiveTurn('interrupted');
+      return;
+    }
+  }
+
+  async respondToApproval(input: AgentApprovalResponseInputV2): Promise<void> {
+    const resolver = this.pendingApprovals.get(input.requestId);
+    if (!resolver) return;
+    this.pendingApprovals.delete(input.requestId);
+    resolver(input.decision);
+  }
+
+  async respondToInput(_input: AgentInputResponseInputV2): Promise<void> {
+    // Claude Agent SDK questions are not mapped in this phase.
+  }
+
+  private async startTurn(input: AgentSendMessageInputV2): Promise<void> {
+    if (!this.config) throw new Error('Cannot start Claude turn before connect');
+
+    const startedAt = nowIso();
+    this.activeTurnId = input.turnId;
+    this.activeStartedAt = startedAt;
+    this.completedActiveTurn = false;
+    this.activeController = new AbortController();
+
+    this.emitPatch({
+      type: 'agent-turn-started-v2',
+      sessionId: this.config.sessionId,
+      timestamp: startedAt,
+      turn: {
+        id: input.turnId,
+        status: 'running',
+        inputMessageId: `user-${input.turnId}`,
+        items: [],
+        startedAt,
+      },
+    });
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.config.sessionId,
+      timestamp: startedAt,
+      turnId: input.turnId,
+      item: {
+        id: `user-${input.turnId}`,
+        type: 'userMessage',
+        text: input.content,
+        status: 'completed',
+        completedAt: startedAt,
+      },
+    });
+    this.emitLiveState({
+      status: 'working',
+      activeTurnId: input.turnId,
+      waitingOn: null,
+      activeRequestIds: [],
+      queueLength: this.queue.length,
+      error: null,
+    });
+
+    try {
+      const mode = permissionMode(this.config.permissionMode);
+      const query = this.queryFn({
+        prompt: input.content,
+        options: {
+          abortController: this.activeController,
+          cwd: this.config.cwd,
+          ...(this.config.model ? { model: this.config.model } : {}),
+          ...(mode ? { permissionMode: mode } : {}),
+          ...(Array.isArray(this.config.extra?.additionalDirectories)
+            ? {
+                additionalDirectories: this.config.extra
+                  .additionalDirectories as string[],
+              }
+            : {}),
+          env: {
+            ...process.env,
+            CLAUDE_CODE_ENTRYPOINT: 'sdk-ts',
+          },
+          includePartialMessages: true,
+          includeHookEvents: true,
+          canUseTool: this.handleCanUseTool,
+        },
+      });
+      this.activeQuery = query;
+
+      for await (const message of query) {
+        this.handleSdkMessage(input.turnId, message);
+      }
+
+      if (!this.completedActiveTurn) {
+        this.completeActiveTurn('completed');
+      }
+    } catch (err) {
+      if (!this.completedActiveTurn) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.emitPatch({
+          type: 'agent-error-v2',
+          sessionId: this.sessionId,
+          timestamp: nowIso(),
+          turnId: input.turnId,
+          message,
+        });
+        this.completeActiveTurn('failed', undefined, message);
+      }
+    } finally {
+      this.activeController = null;
+      this.activeQuery = null;
+      if (this.activeTurnId === input.turnId) {
+        this.activeTurnId = null;
+        this.activeStartedAt = null;
+      }
+      this.drainQueue();
+    }
+  }
+
+  private readonly handleCanUseTool: CanUseTool = async (toolName, input, options) => {
+    const turnId = this.activeTurnId ?? 'turn-unknown';
+    const requestId = options.toolUseID;
+    const target = targetFromToolInput(toolName, input);
+    const startedAt = nowIso();
+
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sessionId,
+      timestamp: startedAt,
+      turnId,
+      item: {
+        type: 'approval',
+        id: `approval-${requestId}`,
+        requestId,
+        kind: 'permission',
+        description: options.title ?? options.displayName ?? `Claude wants to use ${toolName}`,
+        target,
+        ...(options.description ? { detail: options.description } : {}),
+        status: 'pending',
+        startedAt,
+      },
+    });
+    this.emitLiveState({
+      status: 'waiting',
+      activeTurnId: turnId,
+      waitingOn: 'approval',
+      activeRequestIds: [requestId],
+      queueLength: this.queue.length,
+    });
+
+    const decision = await new Promise<AgentApprovalResponseInputV2['decision']>(
+      (resolve, reject) => {
+        this.pendingApprovals.set(requestId, resolve);
+        options.signal.addEventListener(
+          'abort',
+          () => {
+            this.pendingApprovals.delete(requestId);
+            reject(new Error('approval aborted'));
+          },
+          { once: true }
+        );
+      }
+    );
+
+    this.emitPatch({
+      type: 'agent-item-updated-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      turnId,
+      item: {
+        type: 'approval',
+        id: `approval-${requestId}`,
+        requestId,
+        kind: 'permission',
+        description: options.title ?? options.displayName ?? `Claude wants to use ${toolName}`,
+        target,
+        ...(options.description ? { detail: options.description } : {}),
+        decision,
+        respondedBy: 'user',
+        status: 'completed',
+        completedAt: nowIso(),
+      },
+    });
+    this.emitLiveState({
+      status: 'working',
+      activeTurnId: turnId,
+      waitingOn: null,
+      activeRequestIds: [],
+      queueLength: this.queue.length,
+    });
+
+    if (decision === 'deny') {
+      return {
+        behavior: 'deny',
+        message: 'Denied by user',
+        toolUseID: requestId,
+        decisionClassification: 'user_reject',
+      } satisfies PermissionResult;
+    }
+
+    return {
+      behavior: 'allow',
+      toolUseID: requestId,
+      ...(decision === 'allow-always' && options.suggestions
+        ? { updatedPermissions: options.suggestions }
+        : {}),
+      decisionClassification:
+        decision === 'allow-always' ? 'user_permanent' : 'user_temporary',
+    } satisfies PermissionResult;
+  };
+
+  private handleSdkMessage(turnId: string, message: unknown): void {
+    if (!isRecord(message)) return;
+
+    if (message.type === 'system' && message.subtype === 'init') {
+      this.emitSnapshot(stringField(message.session_id));
+      return;
+    }
+
+    if (message.type === 'assistant') {
+      this.handleAssistantMessage(turnId, message);
+      return;
+    }
+
+    if (message.type === 'result') {
+      if (message.subtype !== 'success') {
+        const errors = Array.isArray(message.errors) ? message.errors.join('\n') : 'Claude turn failed';
+        this.emitPatch({
+          type: 'agent-error-v2',
+          sessionId: this.sessionId,
+          timestamp: nowIso(),
+          turnId,
+          message: errors,
+        });
+        this.completeActiveTurn('failed', usageFromResult(message), errors);
+      } else {
+        this.completeActiveTurn('completed', usageFromResult(message));
+      }
+      return;
+    }
+
+    this.emitProviderExtension(turnId, message);
+  }
+
+  private handleAssistantMessage(turnId: string, message: Record<string, unknown>): void {
+    let blockIndex = 0;
+    for (const block of contentBlocks(message)) {
+      const type = block.type;
+      const itemIndex = blockIndex++;
+      if (type === 'text') {
+        const text = stringField(block.text);
+        const id = `msg-${turnId}-${itemIndex}`;
+        this.emitPatch({
+          type: 'agent-item-started-v2',
+          sessionId: this.sessionId,
+          timestamp: nowIso(),
+          turnId,
+          item: {
+            type: 'assistantMessage',
+            id,
+            text: '',
+            phase: 'answer',
+            status: 'running',
+            startedAt: nowIso(),
+            providerMessageId: stringField(objectField(message.message).id),
+          },
+        });
+        this.emitPatch({
+          type: 'agent-item-delta-v2',
+          sessionId: this.sessionId,
+          timestamp: nowIso(),
+          turnId,
+          itemId: id,
+          delta: { text },
+        });
+        this.emitPatch({
+          type: 'agent-item-updated-v2',
+          sessionId: this.sessionId,
+          timestamp: nowIso(),
+          turnId,
+          item: {
+            type: 'assistantMessage',
+            id,
+            text,
+            phase: 'answer',
+            status: 'completed',
+            completedAt: nowIso(),
+            providerMessageId: stringField(objectField(message.message).id),
+          },
+        });
+      } else if (type === 'thinking') {
+        this.emitPatch({
+          type: 'agent-item-started-v2',
+          sessionId: this.sessionId,
+          timestamp: nowIso(),
+          turnId,
+          item: {
+            type: 'reasoning',
+            id: `thinking-${turnId}-${itemIndex}`,
+            summary: stringField(block.thinking ?? block.text ?? block.summary),
+            visibility: 'summary',
+            status: 'completed',
+            completedAt: nowIso(),
+          },
+        });
+      } else if (type === 'tool_use') {
+        this.emitToolUse(turnId, block);
+      } else {
+        this.emitProviderExtension(turnId, block);
+      }
+    }
+  }
+
+  private emitToolUse(turnId: string, block: Record<string, unknown>): void {
+    const toolUseId = stringField(block.id, `unknown-${Date.now()}`);
+    const name = stringField(block.name, 'unknown');
+    const input = objectField(block.input);
+
+    if (name === 'Bash') {
+      this.emitPatch({
+        type: 'agent-item-started-v2',
+        sessionId: this.sessionId,
+        timestamp: nowIso(),
+        turnId,
+        item: {
+          type: 'commandExecution',
+          id: `exec-${toolUseId}`,
+          providerItemId: toolUseId,
+          command: stringField(input.command, JSON.stringify(input)),
+          output: '',
+          status: 'running',
+          startedAt: nowIso(),
+        },
+      });
+      return;
+    }
+
+    if (name === 'Edit' || name === 'Write' || name === 'MultiEdit') {
+      this.emitPatch({
+        type: 'agent-item-started-v2',
+        sessionId: this.sessionId,
+        timestamp: nowIso(),
+        turnId,
+        item: {
+          type: 'fileChange',
+          id: `file-${toolUseId}`,
+          providerItemId: toolUseId,
+          paths: filePathsFromToolInput(input),
+          applyStatus: 'pending',
+          status: 'pending',
+          startedAt: nowIso(),
+        },
+      });
+      return;
+    }
+
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      turnId,
+      item: {
+        type: 'dynamicToolCall',
+        id: `tool-${toolUseId}`,
+        providerItemId: toolUseId,
+        namespace: 'claude',
+        tool: name,
+        arguments: input,
+        status: 'running',
+        startedAt: nowIso(),
+      },
+    });
+  }
+
+  private completeActiveTurn(
+    status: 'completed' | 'interrupted' | 'failed',
+    usage?: AgentUsageV2,
+    error?: string
+  ): void {
+    if (this.completedActiveTurn || this.activeTurnId === null) return;
+    this.completedActiveTurn = true;
+    const completedAt = nowIso();
+    const durationMs = this.activeStartedAt
+      ? Date.now() - Date.parse(this.activeStartedAt)
+      : undefined;
+
+    this.emitPatch({
+      type: 'agent-turn-completed-v2',
+      sessionId: this.sessionId,
+      timestamp: completedAt,
+      turnId: this.activeTurnId,
+      status,
+      completedAt,
+      ...(durationMs !== undefined ? { durationMs } : {}),
+      ...(usage !== undefined ? { usage } : {}),
+      ...(error !== undefined ? { error } : {}),
+    });
+    this.emitLiveState({
+      status: this.queue.length > 0 ? 'working' : 'idle',
+      activeTurnId: null,
+      waitingOn: null,
+      activeRequestIds: [],
+      queueLength: this.queue.length,
+      error: error ?? null,
+    });
+  }
+
+  private drainQueue(): void {
+    if (this._status !== 'connected' || this.activeTurnId !== null) return;
+    const queued = this.queue.shift();
+    if (!queued) return;
+    this.startTurn(queued.input).then(queued.resolve, queued.reject);
+  }
+
+  private rejectQueued(err: unknown): void {
+    const queued = this.queue.splice(0);
+    for (const message of queued) message.reject(err);
+    if (queued.length > 0) this.emitLiveState({ queueLength: 0 });
+  }
+
+  private emitSnapshot(claudeSessionId?: string): void {
+    if (!this.config) return;
+    this.emitPatch({
+      type: 'agent-session-snapshot-v2',
+      sessionId: this.config.sessionId,
+      timestamp: nowIso(),
+      session: emptyAgentSessionV2({
+        id: this.config.sessionId,
+        provider: 'claude',
+        cwd: this.config.cwd,
+        capabilities: this.capabilities,
+        ...(claudeSessionId ? { providerSession: { claudeSessionId } } : {}),
+        config: {
+          ...(this.config.model ? { model: this.config.model } : {}),
+          ...(this.config.permissionMode
+            ? { permissionMode: this.config.permissionMode }
+            : {}),
+        },
+      }),
+    });
+  }
+
+  private emitProviderExtension(turnId: string, payload: Record<string, unknown>): void {
+    this.emitPatch({
+      type: 'agent-item-started-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      turnId,
+      item: {
+        type: 'providerExtension',
+        id: `ext-claude-${turnId}-${Date.now()}`,
+        namespace: 'claude',
+        payload,
+        status: 'completed',
+        startedAt: nowIso(),
+        completedAt: nowIso(),
+      },
+    });
+  }
+
+  private emitLiveState(live: Partial<AgentSessionLiveStateV2>): void {
+    this.emitPatch({
+      type: 'agent-live-state-updated-v2',
+      sessionId: this.sessionId,
+      timestamp: nowIso(),
+      live,
+    });
+  }
+
+  private get sessionId(): string {
+    return this.config?.sessionId ?? 'claude-v2-session';
   }
 }

--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -2,8 +2,8 @@ import type { ProtocolAdapter } from '../protocol-adapter.js';
 import type { ProtocolAdapterV2 } from '../protocol-adapter-v2.js';
 import { MockProtocolAdapter } from './mock-adapter.js';
 import { MockProtocolAdapterV2 } from './mock-v2-adapter.js';
-import { ClaudeProtocolAdapter } from './claude-adapter.js';
 import { CodexProtocolAdapter } from './codex-adapter.js';
+import { ClaudeProtocolAdapter } from './claude-adapter.js';
 import { OpenCodeProtocolAdapter } from './opencode-adapter.js';
 import { OpenCodeAttachedAdapter } from './opencode-attached-adapter.js';
 
@@ -11,7 +11,6 @@ import { HermesProtocolAdapter } from './hermes-adapter.js';
 
 export const adapters: Record<string, () => ProtocolAdapter> = {
   mock: () => new MockProtocolAdapter(),
-  claude: () => new ClaudeProtocolAdapter(),
   codex: () => new CodexProtocolAdapter(),
   opencode: () => new OpenCodeProtocolAdapter(),
   'opencode-attached': () => new OpenCodeAttachedAdapter(),
@@ -29,6 +28,7 @@ export function createAdapter(agentType: string): ProtocolAdapter {
 
 export const v2Adapters: Record<string, () => ProtocolAdapterV2> = {
   mock: () => new MockProtocolAdapterV2(),
+  claude: () => new ClaudeProtocolAdapter(),
 };
 
 export function createAdapterV2(agentType: string): ProtocolAdapterV2 {

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -3,7 +3,7 @@ import type { WebSession, Session } from './types.js';
 import type { AgentType } from './types.js';
 import type { ChatEvent } from '../shared/chat-events.js';
 import { createAdapter, createAdapterV2 } from './protocol-adapters/index.js';
-import type { AdapterConfig } from './protocol-adapter.js';
+import type { AdapterConfig, ProtocolAdapter } from './protocol-adapter.js';
 import type { ProtocolAdapterV2 } from './protocol-adapter-v2.js';
 import type { AgentPatchV2 } from '../shared/agent-chat-protocol-v2.js';
 import { createLogger } from './logger.js';
@@ -62,8 +62,10 @@ export async function createWebSession(
   onBackendStateChanged: (session: Session) => void
 ): Promise<{ session: WebSession }> {
   const id = params.id ?? crypto.randomBytes(8).toString('hex');
-  const adapter = createAdapter(params.agentType);
   const adapterV2 = tryCreateAdapterV2(params.agentType);
+  const adapter = adapterV2
+    ? createV2OnlyLegacyAdapter(params.agentType, adapterV2.runtimeOwnership)
+    : createAdapter(params.agentType);
   const activeRuntime = adapterV2 ?? adapter;
   const hookToken = params.hookToken ?? crypto.randomBytes(16).toString('hex');
 
@@ -205,6 +207,36 @@ export async function createWebSession(
   logger.info('web session created', { id, agentType: params.agentType });
 
   return { session };
+}
+
+function createV2OnlyLegacyAdapter(
+  agentType: string,
+  runtimeOwnership: 'spawned' | 'attached'
+): ProtocolAdapter {
+  return {
+    agentType,
+    runtimeOwnership,
+    status: 'connected',
+    async connect() {},
+    async disconnect() {},
+    async reconnect() {},
+    async createSession() {
+      return '';
+    },
+    async resumeSession() {},
+    async forkSession() {
+      return '';
+    },
+    async sendMessage() {
+      throw new Error(`${agentType} web sessions use ProtocolAdapterV2`);
+    },
+    async interrupt() {},
+    async respondToApproval() {},
+    async respondToInput() {},
+    on() {
+      return () => {};
+    },
+  };
 }
 
 function tryCreateAdapterV2(agentType: string): ProtocolAdapterV2 | undefined {

--- a/test/server/protocol-adapters/claude-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-adapter.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+import { ClaudeProtocolAdapter } from '../../../server/protocol-adapters/claude-adapter.js';
+import type { AdapterConfig } from '../../../server/protocol-adapter-v2.js';
+import type { ClaudeQueryFunction } from '../../../server/protocol-adapters/claude-adapter.js';
+import type { AgentPatchV2 } from '../../../shared/agent-chat-protocol-v2.js';
+
+const config: AdapterConfig = {
+  cwd: '/tmp/repo',
+  port: 3000,
+  sessionId: 'session-1',
+  hookToken: 'token',
+  configDir: '/tmp/config',
+  model: 'sonnet',
+};
+
+function collectPatches(adapter: ClaudeProtocolAdapter): AgentPatchV2[] {
+  const patches: AgentPatchV2[] = [];
+  adapter.onPatch((patch) => patches.push(patch));
+  return patches;
+}
+
+function makeQuery(messages: unknown[]): ClaudeQueryFunction {
+  return () => {
+    async function* generator() {
+      for (const message of messages) {
+        yield message;
+      }
+    }
+    const query = generator() as ReturnType<ClaudeQueryFunction>;
+    query.interrupt = async () => {};
+    query.close = () => {};
+    return query;
+  };
+}
+
+function waitFor(predicate: () => boolean, timeoutMs = 250): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const started = Date.now();
+    const tick = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - started > timeoutMs) {
+        reject(new Error('timed out waiting for Claude adapter condition'));
+        return;
+      }
+      setTimeout(tick, 1);
+    };
+    tick();
+  });
+}
+
+describe('ClaudeProtocolAdapter V2', () => {
+  it('advertises the claude v2 capability set', () => {
+    const adapter = new ClaudeProtocolAdapter(makeQuery([]));
+
+    expect(adapter.capabilities).toMatchObject({
+      text: true,
+      reasoning: true,
+      tools: true,
+      commandExecution: true,
+      fileChanges: true,
+      approvals: true,
+      queue: true,
+      interrupt: true,
+      cancelQueued: false,
+      resume: true,
+      compact: true,
+    });
+  });
+
+  it('maps SDK init, assistant text, and result messages to V2 patches', async () => {
+    const adapter = new ClaudeProtocolAdapter(
+      makeQuery([
+        {
+          type: 'system',
+          subtype: 'init',
+          session_id: 'claude-session-1',
+          cwd: '/tmp/repo',
+          model: 'sonnet',
+          tools: ['Bash', 'Edit'],
+          slash_commands: ['/compact'],
+        },
+        {
+          type: 'assistant',
+          message: {
+            id: 'msg-native-1',
+            content: [{ type: 'text', text: 'hello from claude' }],
+          },
+          session_id: 'claude-session-1',
+        },
+        {
+          type: 'result',
+          subtype: 'success',
+          duration_ms: 12,
+          total_cost_usd: 0.01,
+          usage: {
+            input_tokens: 10,
+            output_tokens: 20,
+            cache_read_input_tokens: 3,
+            cache_creation_input_tokens: 4,
+          },
+          session_id: 'claude-session-1',
+        },
+      ])
+    );
+    const patches = collectPatches(adapter);
+
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 'turn-1', content: 'hello' });
+    await waitFor(() => patches.some((patch) => patch.type === 'agent-turn-completed-v2'));
+
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-session-snapshot-v2',
+          session: expect.objectContaining({
+            provider: 'claude',
+            providerSession: { claudeSessionId: 'claude-session-1' },
+          }),
+        }),
+        expect.objectContaining({
+          type: 'agent-item-started-v2',
+          turnId: 'turn-1',
+          item: expect.objectContaining({
+            type: 'assistantMessage',
+            text: '',
+          }),
+        }),
+        expect.objectContaining({
+          type: 'agent-item-delta-v2',
+          turnId: 'turn-1',
+          delta: { text: 'hello from claude' },
+        }),
+        expect.objectContaining({
+          type: 'agent-turn-completed-v2',
+          turnId: 'turn-1',
+          status: 'completed',
+          usage: expect.objectContaining({
+            inputTokens: 10,
+            outputTokens: 20,
+            cacheReadTokens: 3,
+            cacheWriteTokens: 4,
+            costUsd: 0.01,
+          }),
+        }),
+      ])
+    );
+  });
+
+  it('maps SDK tool_use blocks to command, file, and dynamic tool items', async () => {
+    const adapter = new ClaudeProtocolAdapter(
+      makeQuery([
+        {
+          type: 'assistant',
+          message: {
+            id: 'msg-native-tools',
+            content: [
+              { type: 'thinking', thinking: 'inspect files' },
+              { type: 'tool_use', id: 'tool-bash', name: 'Bash', input: { command: 'npm test' } },
+              { type: 'tool_use', id: 'tool-edit', name: 'Edit', input: { file_path: 'src/a.ts' } },
+              { type: 'tool_use', id: 'tool-grep', name: 'Grep', input: { pattern: 'x' } },
+            ],
+          },
+          session_id: 'claude-session-1',
+        },
+        {
+          type: 'result',
+          subtype: 'success',
+          duration_ms: 1,
+          total_cost_usd: 0,
+          usage: {},
+          session_id: 'claude-session-1',
+        },
+      ])
+    );
+    const patches = collectPatches(adapter);
+
+    await adapter.connect(config);
+    await adapter.sendMessage({ turnId: 'turn-tools', content: 'tools' });
+    await waitFor(() => patches.some((patch) => patch.type === 'agent-turn-completed-v2'));
+
+    const itemTypes = patches
+      .filter((patch) => patch.type === 'agent-item-started-v2')
+      .map((patch) => patch.item.type);
+
+    expect(itemTypes).toEqual(
+      expect.arrayContaining(['reasoning', 'commandExecution', 'fileChange', 'dynamicToolCall'])
+    );
+  });
+
+  it('bridges SDK canUseTool approval through respondToApproval', async () => {
+    let capturedCanUseTool:
+      | NonNullable<Parameters<ClaudeQueryFunction>[0]['options']>['canUseTool']
+      | undefined;
+    const queryFn: ClaudeQueryFunction = (params) => {
+      capturedCanUseTool = params.options?.canUseTool;
+      async function* generator() {
+        const decision = await capturedCanUseTool?.('Bash', { command: 'npm test' }, {
+          signal: new AbortController().signal,
+          toolUseID: 'tool-approval',
+          title: 'Claude wants to run tests',
+          displayName: 'Run command',
+          description: 'npm test',
+        });
+        yield {
+          type: 'result',
+          subtype: decision?.behavior === 'allow' ? 'success' : 'error_during_execution',
+          duration_ms: 1,
+          total_cost_usd: 0,
+          usage: {},
+          errors: [],
+          session_id: 'claude-session-1',
+        };
+      }
+      const query = generator() as ReturnType<ClaudeQueryFunction>;
+      query.interrupt = async () => {};
+      query.close = () => {};
+      return query;
+    };
+    const adapter = new ClaudeProtocolAdapter(queryFn);
+    const patches = collectPatches(adapter);
+
+    await adapter.connect(config);
+    void adapter.sendMessage({ turnId: 'turn-approval', content: 'approval' });
+    await waitFor(() =>
+      patches.some(
+        (patch) => patch.type === 'agent-live-state-updated-v2' && patch.live.waitingOn === 'approval'
+      )
+    );
+
+    await adapter.respondToApproval({ requestId: 'tool-approval', decision: 'allow' });
+    await waitFor(() => patches.some((patch) => patch.type === 'agent-turn-completed-v2'));
+
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'agent-item-started-v2',
+          item: expect.objectContaining({
+            type: 'approval',
+            requestId: 'tool-approval',
+            target: 'npm test',
+          }),
+        }),
+        expect.objectContaining({
+          type: 'agent-item-updated-v2',
+          item: expect.objectContaining({
+            type: 'approval',
+            decision: 'allow',
+          }),
+        }),
+      ])
+    );
+  });
+});

--- a/test/web-chat-integration.test.ts
+++ b/test/web-chat-integration.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MockProtocolAdapter } from '../server/protocol-adapters/mock-adapter.js';
-import { createAdapter } from '../server/protocol-adapters/index.js';
+import {
+  createAdapter,
+  createAdapterV2,
+} from '../server/protocol-adapters/index.js';
 import { ClaudeProtocolAdapter } from '../server/protocol-adapters/claude-adapter.js';
 import { CodexProtocolAdapter } from '../server/protocol-adapters/codex-adapter.js';
 import { OpenCodeProtocolAdapter } from '../server/protocol-adapters/opencode-adapter.js';
@@ -447,8 +450,8 @@ describe('createAdapter - registry', () => {
     expect(adapter.agentType).toBe('mock');
   });
 
-  it('returns ClaudeProtocolAdapter for "claude"', () => {
-    const adapter = createAdapter('claude');
+  it('returns ClaudeProtocolAdapter as the v2 adapter for "claude"', () => {
+    const adapter = createAdapterV2('claude');
     expect(adapter).toBeInstanceOf(ClaudeProtocolAdapter);
     expect(adapter.agentType).toBe('claude');
   });


### PR DESCRIPTION
## Summary
- Adds native Claude `ProtocolAdapterV2` backed by `@anthropic-ai/claude-agent-sdk`.
- Maps SDK init, assistant text/thinking/tool_use, result, approvals, and unknown events into `AgentPatchV2`.
- Registers Claude in `v2Adapters` and routes Claude web sessions through V2 while preserving V1 fallback for remaining providers until Stack 3.
- Adds deterministic SDK-seam tests for Claude patch mapping and approval bridging.

## Verification
- `npm run build` ✅
- `npm test -- test/server/protocol-adapters/claude-adapter.test.ts test/web-session-handler.test.ts test/web-session-v2.test.ts test/web-chat-integration.test.ts` ✅ (51 tests)
- `npm run check` ✅

## Stack
- Base: `stack/v2-ui-mock` / PR #306
- Previous root: `feat/agent-chat-protocol-v2` / PR #305
- Existing PR #304 is superseded by this stack branch and should be closed once this PR is accepted.
- Next: `stack/v2-v1-cutover` will target this branch.
