### PR TITLE
docs(agent-v2): add provider guide and provider-port skill

### DIFF
--- a/.agents/skills/add-provider/SKILL.md
+++ b/.agents/skills/add-provider/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: add-provider
+description: Add or port a relay-ide web-chat provider to AgentPatchV2. Use when implementing Codex, OpenCode, Hermes, or any new provider adapter for the web UI.
+---
+
+# Add AgentPatchV2 Provider
+
+Use this skill to port a provider to the normalized Agent Chat Protocol V2 web-chat path.
+
+## Required reading
+
+Before touching code, read:
+
+1. `docs/provider-guide.md`
+2. `docs/plans/2026-04-27-multi-provider-roadmap.md`
+3. `shared/agent-chat-protocol-v2.ts`
+4. `server/protocol-adapter-v2.ts`
+5. The most recent working provider adapter, currently `server/protocol-adapters/claude-adapter.ts`
+
+## Inputs
+
+Collect these facts:
+
+- Provider name and registry key.
+- Native transport: SDK, JSON-RPC, SSE, gateway, or process.
+- Native event inventory.
+- Capability set.
+- Approval/permission mechanism.
+- Interrupt mechanism.
+- Queue/cancel support.
+- Session resume identifier.
+
+## Mapping table
+
+Write a provider-specific mapping table before implementation:
+
+```markdown
+| Native event | V2 patch | Item type | Correlation key | Notes |
+| ------------ | -------- | --------- | --------------- | ----- |
+```
+
+Every native event must either map to a core V2 item/patch or to `providerExtension`.
+
+## Implementation steps
+
+1. Create `test/server/protocol-adapters/<provider>-adapter.test.ts`.
+2. Write failing golden trace tests for capabilities, init, text, tools, approvals, errors, queue, and unknown events.
+3. Implement `server/protocol-adapters/<provider>-adapter.ts` as a `BaseProtocolAdapterV2` subclass.
+4. Add a deterministic transport seam so tests never spawn the real CLI/server.
+5. Register the provider in `v2Adapters` in `server/protocol-adapters/index.ts`.
+6. Add provider extension renderers under `frontend/src/components/chat/extensions/<provider>/` only for provider-specific payloads.
+7. Restore/rewrite provider web-session tests to assert V2 patches, not V1 `ChatEvent`s.
+8. Delete replaced V1 code in the same PR when the adapter is fully native.
+
+## Verification
+
+Run:
+
+```bash
+npm test -- test/server/protocol-adapters/<provider>-adapter.test.ts
+npm test -- test/web-session-handler.test.ts test/web-session-v2.test.ts
+npm run check
+npm run build
+```
+
+Before opening PR, also run the pre-push hook by pushing from the provider worktree.
+
+## PR requirements
+
+The PR body must include:
+
+- Provider transport and event source.
+- Mapping coverage summary.
+- Capability set.
+- Verification output.
+- Any temporary bridge/deletion debt.
+- Stack base and next stack branch.

--- a/docs/plans/2026-04-27-claude-v2-dogfood-log.md
+++ b/docs/plans/2026-04-27-claude-v2-dogfood-log.md
@@ -1,0 +1,32 @@
+# Claude V2 Dogfood Log
+
+This log starts with the implementation-session findings from the Claude Web UI V2 stack. Continue adding entries while using real Claude web sessions.
+
+## Initial implementation findings
+
+- `@anthropic-ai/claude-agent-sdk` version pinned: `0.2.119`.
+- SDK `query()` supports an async-generator seam suitable for deterministic tests.
+- Permission handling is best represented through `options.canUseTool`; relay bridges that promise with `respondToApproval()`.
+- Claude queue support is adapter-local FIFO; `cancelQueued` remains `false`.
+- Unknown SDK messages are visible as `providerExtension { namespace: 'claude' }` so dogfood can identify new renderer needs.
+
+## Events to exercise manually
+
+- [ ] text response
+- [ ] thinking/reasoning block
+- [ ] Bash tool use
+- [ ] Edit/Write/MultiEdit tool use
+- [ ] dynamic/non-core tool use
+- [ ] approval allow
+- [ ] approval allow-always
+- [ ] approval deny
+- [ ] interrupt active turn
+- [ ] queued message while active
+- [ ] SDK error/result failure
+- [ ] Claude-specific provider extension event
+
+## Unmapped event inventory
+
+| Date       | Raw signature | Namespace | Decision         | Follow-up         |
+| ---------- | ------------- | --------- | ---------------- | ----------------- |
+| 2026-04-27 | none yet      | claude    | continue dogfood | update this table |

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -1,0 +1,157 @@
+# AgentPatchV2 Provider Guide
+
+This guide captures the provider-port pattern extracted from the Claude Web UI V2 stack.
+
+## 1. Provider contract
+
+Every web-chat provider implements `ProtocolAdapterV2` from `server/protocol-adapter-v2.ts` and emits only `AgentPatchV2` patches from `shared/agent-chat-protocol-v2.ts`.
+
+Required lifecycle:
+
+1. `connect(config)` stores config, validates transport availability, emits either a snapshot or an idle live-state patch.
+2. `sendMessage({ turnId, content })` starts a turn when idle or queues FIFO when busy.
+3. Provider-native events map into normalized `agent-item-*` patches.
+4. `interrupt()` aborts active work and emits an interrupted turn completion.
+5. `respondToApproval()` resolves a pending provider permission request.
+6. `disconnect()` aborts active work, rejects queued sends, clears pending approvals, and closes the transport.
+
+## 2. Mapping table format
+
+Each provider design must include this table before implementation:
+
+| Native event         | V2 patch                                          | Item type           | Correlation key        | Notes                                             |
+| -------------------- | ------------------------------------------------- | ------------------- | ---------------------- | ------------------------------------------------- |
+| session/init         | `agent-session-snapshot-v2`                       | —                   | provider session id    | include capabilities and providerSession metadata |
+| user prompt accepted | `agent-turn-started-v2` + `agent-item-started-v2` | `userMessage`       | relay `turnId`         | user item id = `user-${turnId}`                   |
+| assistant text delta | `agent-item-delta-v2`                             | `assistantMessage`  | message/content id     | start item before first delta                     |
+| reasoning/thinking   | `agent-item-started-v2` or delta                  | `reasoning`         | content id             | default `visibility: 'summary'`                   |
+| shell command        | `agent-item-started-v2`/updated                   | `commandExecution`  | native tool id         | preserve command, cwd, output, exitCode           |
+| file edit/write      | `agent-item-started-v2`/updated                   | `fileChange`        | native tool id         | preserve paths, patch, applyStatus                |
+| generic tool         | `agent-item-started-v2`/updated                   | `dynamicToolCall`   | native tool id         | namespace = provider name                         |
+| permission request   | `agent-item-started-v2` + waiting live state      | `approval`          | request/tool id        | resume via `respondToApproval`                    |
+| completion           | `agent-turn-completed-v2` + idle live state       | —                   | turn id                | include usage when available                      |
+| unknown native event | `agent-item-started-v2`                           | `providerExtension` | generated extension id | namespace = provider name, payload = raw event    |
+
+## 3. Item ID conventions
+
+Use stable, deterministic ids so deltas and updates converge:
+
+- `userMessage`: `user-${turnId}`
+- `assistantMessage`: `msg-${turnId}-${blockIndex}` or native message id when unique and stable
+- `reasoning`: `thinking-${turnId}-${blockIndex}`
+- `commandExecution`: `exec-${nativeToolId}`
+- `fileChange`: `file-${nativeToolId}`
+- `dynamicToolCall`: `tool-${nativeToolId}`
+- `approval`: `approval-${requestId}`
+- `providerExtension`: `ext-${provider}-${turnId}-${counter}`
+
+Never use timestamps as the only id when the provider has a native correlation id.
+
+## 4. Capability declaration
+
+Declare capabilities in the adapter as static truth for the current implementation, not aspiration.
+
+Common semantics:
+
+- `queue`: adapter buffers sends while active.
+- `cancelQueued`: adapter can cancel a specific queued turn. Claude is `false`.
+- `interrupt`: active transport can be interrupted/aborted.
+- `approvals`: adapter can pause native execution and resume from `respondToApproval`.
+- `slashCommands`: provider supports slash command text or palette hints.
+- `resume`: provider session id can be used for continuation.
+- `telemetry` / `rateLimits`: adapter emits or exposes corresponding usage metadata.
+
+The UI gates affordances from `session.capabilities`. If a capability is false, do not render the control.
+
+## 5. providerExtension policy
+
+Map to core V2 when a shape is provider-agnostic and already exists in `AgentItemV2`.
+
+Use `providerExtension` when:
+
+- The event is provider-specific (`EnterPlanMode`, `FastModeUnavailable`, provider checkpoint notices).
+- The event is not yet understood but should remain visible for dogfood/debugging.
+- Adding a top-level patch would only serve one provider.
+
+Promotion rule: if two providers need the same extension shape, open a follow-up schema change to promote it into core V2.
+
+## 6. Renderer registration
+
+Provider extension renderers live under:
+
+```text
+frontend/src/components/chat/extensions/<provider>/
+```
+
+Register in:
+
+```text
+frontend/src/components/chat/extensions/registry.tsx
+```
+
+Requirements:
+
+- Fallback renderer must show namespace and raw payload kind.
+- Provider renderers must be isolated to their namespace.
+- A missing renderer must not break the timeline.
+- Tests should assert both known provider cards and fallback cards.
+
+## 7. Queue and approval pattern
+
+Queue:
+
+```ts
+if (activeTurnId !== null) {
+  queue.push(input);
+  emitLiveState({ status: 'working', activeTurnId, queueLength: queue.length });
+  return;
+}
+await startTurn(input);
+```
+
+Approval:
+
+1. Native permission event arrives.
+2. Emit `approval` item.
+3. Emit live state `{ status: 'waiting', waitingOn: 'approval', activeRequestIds: [requestId] }`.
+4. Store resolver in `Map<requestId, resolver>`.
+5. `respondToApproval()` resolves the native promise.
+6. Emit approval item update and live state back to `working`.
+7. Reject all pending resolvers on disconnect/interrupt.
+
+## 8. Testing pattern
+
+Each provider needs golden trace tests under `test/server/protocol-adapters/<provider>-adapter.test.ts`.
+
+Minimum cases:
+
+- capabilities match expected object
+- init/session snapshot
+- assistant text + delta + completion
+- reasoning/thinking
+- command execution
+- file change
+- dynamic tool
+- approval wait/resume
+- queue behavior
+- interrupt behavior
+- providerExtension fallback for unknown event
+- result error -> `agent-error-v2` + failed turn
+
+Use a deterministic dependency seam for provider transport. Tests should feed native events directly without spawning real CLIs.
+
+## 9. Stacked PR checklist
+
+For each provider:
+
+1. Create a branch from the previous stack branch.
+2. Write/commit provider mapping tests first and watch them fail.
+3. Implement adapter until targeted tests pass.
+4. Register provider in `v2Adapters`.
+5. Restore or rewrite provider web-session e2e tests.
+6. Run `npm run check`, targeted tests, and `npm run build`.
+7. Push and open a draft PR targeting the previous provider stack.
+
+## 10. Deletion policy
+
+When a provider is fully V2-native, delete replaced V1 code in the same provider stack. If a temporary bridge is used to keep the stack moving, the PR must explicitly label it as temporary and include the deletion target in its body.


### PR DESCRIPTION
## Summary
- Adds `docs/provider-guide.md` with the AgentPatchV2 provider-port recipe.
- Adds repo-local `.agents/skills/add-provider/SKILL.md` for future provider ports.
- Starts `docs/plans/2026-04-27-claude-v2-dogfood-log.md` with implementation-session findings and manual dogfood checklist.

## Verification
- `npm run check` ✅
- pre-commit `npm run check` ✅

## Stack
- Base: `stack/v2-v1-cutover` / PR #308
- Next: `stack/v2-codex` will target this branch.
