### PR TITLE
feat(codex): restore web sessions through AgentPatchV2 bridge

### DIFF
--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -4,6 +4,7 @@ import { MockProtocolAdapter } from './mock-adapter.js';
 import { MockProtocolAdapterV2 } from './mock-v2-adapter.js';
 import { CodexProtocolAdapter } from './codex-adapter.js';
 import { ClaudeProtocolAdapter } from './claude-adapter.js';
+import { LegacyProtocolAdapterV2Bridge } from './legacy-v2-bridge.js';
 import { OpenCodeProtocolAdapter } from './opencode-adapter.js';
 import { OpenCodeAttachedAdapter } from './opencode-attached-adapter.js';
 
@@ -29,6 +30,22 @@ export function createAdapter(agentType: string): ProtocolAdapter {
 export const v2Adapters: Record<string, () => ProtocolAdapterV2> = {
   mock: () => new MockProtocolAdapterV2(),
   claude: () => new ClaudeProtocolAdapter(),
+  codex: () =>
+    new LegacyProtocolAdapterV2Bridge(new CodexProtocolAdapter(), {
+      text: true,
+      reasoning: true,
+      tools: true,
+      commandExecution: true,
+      fileChanges: true,
+      approvals: true,
+      slashCommands: false,
+      queue: false,
+      interrupt: true,
+      cancelQueued: false,
+      resume: false,
+      telemetry: true,
+      rateLimits: true,
+    }),
 };
 
 export function createAdapterV2(agentType: string): ProtocolAdapterV2 {

--- a/server/protocol-adapters/legacy-v2-bridge.ts
+++ b/server/protocol-adapters/legacy-v2-bridge.ts
@@ -1,0 +1,71 @@
+import type { ProtocolAdapter } from '../protocol-adapter.js';
+import { BaseProtocolAdapterV2 } from '../protocol-adapter-v2.js';
+import type {
+  AdapterConfig,
+  AdapterStatus,
+  AgentApprovalResponseInputV2,
+  AgentInputResponseInputV2,
+  AgentInterruptInputV2,
+  AgentSendMessageInputV2,
+} from '../protocol-adapter-v2.js';
+import type { AgentCapabilitySetV2 } from '../../shared/agent-chat-protocol-v2.js';
+import { mapChatEventToAgentPatchV2 } from '../../shared/agent-chat-v1-compat.js';
+
+export class LegacyProtocolAdapterV2Bridge extends BaseProtocolAdapterV2 {
+  readonly runtimeOwnership: 'spawned' | 'attached';
+  readonly agentType: string;
+
+  private unlisten: (() => void) | null = null;
+
+  constructor(
+    private readonly inner: ProtocolAdapter,
+    readonly capabilities: AgentCapabilitySetV2
+  ) {
+    super();
+    this.agentType = inner.agentType;
+    this.runtimeOwnership = inner.runtimeOwnership;
+  }
+
+  get status(): AdapterStatus {
+    return this.inner.status;
+  }
+
+  async connect(config: AdapterConfig): Promise<void> {
+    this.unlisten = this.inner.on((event) => {
+      for (const patch of mapChatEventToAgentPatchV2(event)) {
+        this.emitPatch(patch);
+      }
+    });
+    await this.inner.connect(config);
+  }
+
+  protected async onDisconnect(): Promise<void> {
+    this.unlisten?.();
+    this.unlisten = null;
+    await this.inner.disconnect();
+  }
+
+  async reconnect(): Promise<void> {
+    await this.inner.reconnect();
+  }
+
+  async sendMessage(input: AgentSendMessageInputV2): Promise<void> {
+    await this.inner.sendMessage(
+      input.turnId,
+      input.content,
+      input.attachments
+    );
+  }
+
+  async interrupt(input: AgentInterruptInputV2): Promise<void> {
+    await this.inner.interrupt(input.turnId ?? '');
+  }
+
+  async respondToApproval(input: AgentApprovalResponseInputV2): Promise<void> {
+    await this.inner.respondToApproval(input.requestId, input.decision);
+  }
+
+  async respondToInput(input: AgentInputResponseInputV2): Promise<void> {
+    await this.inner.respondToInput(input.requestId, input.answers);
+  }
+}

--- a/test/server/protocol-adapters/codex-adapter.test.ts
+++ b/test/server/protocol-adapters/codex-adapter.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { createAdapterV2 } from '../../../server/protocol-adapters/index.js';
+import { LegacyProtocolAdapterV2Bridge } from '../../../server/protocol-adapters/legacy-v2-bridge.js';
+
+describe('Codex V2 web adapter registration', () => {
+  it('registers codex as a ProtocolAdapterV2 bridge while native mapping is ported', () => {
+    const adapter = createAdapterV2('codex');
+
+    expect(adapter).toBeInstanceOf(LegacyProtocolAdapterV2Bridge);
+    expect(adapter.agentType).toBe('codex');
+    expect(adapter.capabilities).toMatchObject({
+      text: true,
+      commandExecution: true,
+      fileChanges: true,
+      approvals: true,
+      interrupt: true,
+      telemetry: true,
+      rateLimits: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Registers Codex as a `ProtocolAdapterV2` using a temporary compatibility bridge around the existing V1 adapter.
- Adds a reusable `LegacyProtocolAdapterV2Bridge` that maps legacy `ChatEvent`s to `AgentPatchV2`.
- Adds Codex V2 registration/capability coverage.

## Verification
- `npm test -- test/server/protocol-adapters/codex-adapter.test.ts test/web-session-handler.test.ts test/web-session-v2.test.ts` ✅ (17 tests)
- `npm run check` ✅

## Stack
- Base: `stack/v2-dogfood-guide` / PR #309
- Next: `stack/v2-opencode` will target this branch.

## Temporary debt
- This restores Codex web availability through a V1-to-V2 bridge. A future native Codex transport pass should replace the bridge with direct app-server JSON-RPC mapping and then delete the V1 Codex adapter.
