### PR TITLE
feat(opencode): restore web sessions through AgentPatchV2 bridge

### DIFF
--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -46,6 +46,36 @@ export const v2Adapters: Record<string, () => ProtocolAdapterV2> = {
       telemetry: true,
       rateLimits: true,
     }),
+  opencode: () =>
+    new LegacyProtocolAdapterV2Bridge(new OpenCodeProtocolAdapter(), {
+      text: true,
+      reasoning: true,
+      tools: true,
+      commandExecution: true,
+      fileChanges: true,
+      approvals: true,
+      slashCommands: false,
+      queue: false,
+      interrupt: true,
+      cancelQueued: false,
+      resume: false,
+      telemetry: true,
+    }),
+  'opencode-attached': () =>
+    new LegacyProtocolAdapterV2Bridge(new OpenCodeAttachedAdapter(), {
+      text: true,
+      reasoning: true,
+      tools: true,
+      commandExecution: true,
+      fileChanges: true,
+      approvals: true,
+      slashCommands: false,
+      queue: false,
+      interrupt: true,
+      cancelQueued: false,
+      resume: false,
+      telemetry: true,
+    }),
 };
 
 export function createAdapterV2(agentType: string): ProtocolAdapterV2 {

--- a/test/server/protocol-adapters/opencode-adapter.test.ts
+++ b/test/server/protocol-adapters/opencode-adapter.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { createAdapterV2 } from '../../../server/protocol-adapters/index.js';
+import { LegacyProtocolAdapterV2Bridge } from '../../../server/protocol-adapters/legacy-v2-bridge.js';
+
+describe('OpenCode V2 web adapter registration', () => {
+  it('registers opencode as a ProtocolAdapterV2 bridge while native mapping is ported', () => {
+    const adapter = createAdapterV2('opencode');
+
+    expect(adapter).toBeInstanceOf(LegacyProtocolAdapterV2Bridge);
+    expect(adapter.agentType).toBe('opencode');
+    expect(adapter.capabilities).toMatchObject({
+      text: true,
+      commandExecution: true,
+      fileChanges: true,
+      approvals: true,
+      interrupt: true,
+      telemetry: true,
+    });
+  });
+
+  it('registers opencode-attached as a ProtocolAdapterV2 bridge', () => {
+    const adapter = createAdapterV2('opencode-attached');
+
+    expect(adapter).toBeInstanceOf(LegacyProtocolAdapterV2Bridge);
+    expect(adapter.agentType).toBe('opencode');
+  });
+});


### PR DESCRIPTION
## Summary
- Registers OpenCode and OpenCode attached sessions as `ProtocolAdapterV2` via the temporary legacy bridge.
- Adds OpenCode V2 registration/capability tests.

## Verification
- `npm test -- test/server/protocol-adapters/opencode-adapter.test.ts test/web-session-handler.test.ts test/web-session-v2.test.ts` ✅ (18 tests)
- `npm run check` ✅
- pre-push changed-tests hook ✅ (25 files, 326 tests)

## Stack
- Base: `stack/v2-codex` / PR #310
- Next: `stack/v2-hermes` will target this branch.

## Temporary debt
- This restores OpenCode web availability through a V1-to-V2 bridge. Native OpenCode public-server event mapping should replace this bridge in a follow-up hardening pass.
