### PR TITLE
feat(hermes): restore web sessions through AgentPatchV2 bridge

### DIFF
--- a/server/protocol-adapters/index.ts
+++ b/server/protocol-adapters/index.ts
@@ -76,6 +76,20 @@ export const v2Adapters: Record<string, () => ProtocolAdapterV2> = {
       resume: false,
       telemetry: true,
     }),
+  hermes: () =>
+    new LegacyProtocolAdapterV2Bridge(new HermesProtocolAdapter(), {
+      text: true,
+      reasoning: true,
+      tools: true,
+      commandExecution: true,
+      fileChanges: true,
+      approvals: true,
+      slashCommands: false,
+      queue: false,
+      interrupt: true,
+      cancelQueued: false,
+      resume: false,
+    }),
 };
 
 export function createAdapterV2(agentType: string): ProtocolAdapterV2 {

--- a/test/server/protocol-adapters/hermes-adapter.test.ts
+++ b/test/server/protocol-adapters/hermes-adapter.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { createAdapterV2 } from '../../../server/protocol-adapters/index.js';
+import { LegacyProtocolAdapterV2Bridge } from '../../../server/protocol-adapters/legacy-v2-bridge.js';
+
+describe('Hermes V2 web adapter registration', () => {
+  it('registers hermes as a ProtocolAdapterV2 bridge while native gateway mapping is ported', () => {
+    const adapter = createAdapterV2('hermes');
+
+    expect(adapter).toBeInstanceOf(LegacyProtocolAdapterV2Bridge);
+    expect(adapter.agentType).toBe('hermes');
+    expect(adapter.capabilities).toMatchObject({
+      text: true,
+      commandExecution: true,
+      fileChanges: true,
+      approvals: true,
+      interrupt: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Registers Hermes as `ProtocolAdapterV2` via the temporary legacy bridge.
- Adds Hermes V2 registration/capability tests.

## Verification
- `npm test -- test/server/protocol-adapters/hermes-adapter.test.ts test/web-session-handler.test.ts test/web-session-v2.test.ts` ✅ (17 tests)
- `npm run check` ✅
- pre-push changed-tests hook ✅ (26 files, 327 tests)

## Stack
- Base: `stack/v2-opencode` / PR #311
- Next: `stack/v2-polish-telemetry` may target this branch.

## Temporary debt
- This restores Hermes web availability through a V1-to-V2 bridge. Native Hermes gateway event mapping should replace this bridge in a follow-up hardening pass.
