### PR TITLE
feat(sessions): persist web sessions to relay-state.db

### DIFF
--- a/docs/plans/2026-04-29-web-session-persistence-sqlite.md
+++ b/docs/plans/2026-04-29-web-session-persistence-sqlite.md
@@ -12,26 +12,26 @@ PTY sessions stay on the JSON path for now. The sqlite store is web-only.
 
 ## Premises
 
-| Premise | Assessment |
-|---|---|
-| Relay should own the full transcript, not vendor history | Valid. Vendor `resume` continues model context but does not replay items; relay-injected items (errors, slash echoes, approval transcript) only exist on the relay side. |
-| Vendor session id is enough to resume model context | Valid for Claude SDK (`resume: claudeSessionId`) and Codex app-server (`thread/start` with `threadId`). OpenCode and Hermes already expose vendor session ids through `providerSession`. |
-| SQLite is the right substrate | Valid. `better-sqlite3` is already a dependency for `analytics.db`. Same WAL pattern, schema_version table, prepared statements. |
-| One DB file or two | Two: `analytics.db` is metrics, `relay-state.db` is canonical state. Different lifecycle, different backup posture, different access patterns. Avoid coupling. |
-| Per-patch row vs single blob | Single blob. `agent_session_v2_json` is the reduced-state canonical form; `applyAgentPatchV2` already produces it. Patches are wire-format, not storage-format. |
-| Resume failure UX | Show a `errorMessage` source=`client` in the timeline and leave session disconnected. No silent drop. No automatic new-session creation in this slice. |
+| Premise                                                  | Assessment                                                                                                                                                                               |
+| -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Relay should own the full transcript, not vendor history | Valid. Vendor `resume` continues model context but does not replay items; relay-injected items (errors, slash echoes, approval transcript) only exist on the relay side.                 |
+| Vendor session id is enough to resume model context      | Valid for Claude SDK (`resume: claudeSessionId`) and Codex app-server (`thread/start` with `threadId`). OpenCode and Hermes already expose vendor session ids through `providerSession`. |
+| SQLite is the right substrate                            | Valid. `better-sqlite3` is already a dependency for `analytics.db`. Same WAL pattern, schema_version table, prepared statements.                                                         |
+| One DB file or two                                       | Two: `analytics.db` is metrics, `relay-state.db` is canonical state. Different lifecycle, different backup posture, different access patterns. Avoid coupling.                           |
+| Per-patch row vs single blob                             | Single blob. `agent_session_v2_json` is the reduced-state canonical form; `applyAgentPatchV2` already produces it. Patches are wire-format, not storage-format.                          |
+| Resume failure UX                                        | Show a `errorMessage` source=`client` in the timeline and leave session disconnected. No silent drop. No automatic new-session creation in this slice.                                   |
 
 ## What Already Exists
 
-| Sub-problem | Current code |
-|---|---|
-| Web session in-memory state | `server/sessions.ts` — `WebSession.agentSessionV2`, `agentPatchesV2` populated via `applyWebSessionPatchV2` (`server/web-session-v2-state.ts`). |
-| Persistence write path | `server/sessions.ts:638 serializeWebSession`, `:670 serializeAll` writes to `pending-sessions.json`. Only fires on `SIGTERM` / `SIGINT` / update-restart. |
-| Persistence read path | `server/sessions.ts:970 restoreFromDisk` → `:916 restoreWebSession`. Stale-file wipe at 5min (`STALE_THRESHOLD_MS`). File unlinked after restore. |
-| SQLite infra | `server/analytics.ts` — `Database` open with `journal_mode=WAL`, `MIGRATIONS` array keyed by `schema_version` table, prepared statements module-scoped. |
-| Vendor resume capability | `AgentSessionV2.providerSession: Record<string, string>` carries vendor ids. `AgentCapabilitySetV2.resume?: boolean`. `useAgentChatSocket.resume()` and `agent-resume-v2` command already wire end-to-end. Claude adapter implements `connect({ resume })`. Codex native adapter handles `thread/start` with `threadId`. |
-| Resume UI | `frontend/src/components/chat/ChatView.tsx:81` `canResume` flag and `tl-resume-banner`. |
-| Error timeline | `errorMessage` item type with `source: 'agent' | 'client'`, rendered in `frontend/src/components/chat/Turn.tsx:112`. |
+| Sub-problem                 | Current code                                                                                                                                                                                                                                                                                                             |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Web session in-memory state | `server/sessions.ts` — `WebSession.agentSessionV2`, `agentPatchesV2` populated via `applyWebSessionPatchV2` (`server/web-session-v2-state.ts`).                                                                                                                                                                          |
+| Persistence write path      | `server/sessions.ts:638 serializeWebSession`, `:670 serializeAll` writes to `pending-sessions.json`. Only fires on `SIGTERM` / `SIGINT` / update-restart.                                                                                                                                                                |
+| Persistence read path       | `server/sessions.ts:970 restoreFromDisk` → `:916 restoreWebSession`. Stale-file wipe at 5min (`STALE_THRESHOLD_MS`). File unlinked after restore.                                                                                                                                                                        |
+| SQLite infra                | `server/analytics.ts` — `Database` open with `journal_mode=WAL`, `MIGRATIONS` array keyed by `schema_version` table, prepared statements module-scoped.                                                                                                                                                                  |
+| Vendor resume capability    | `AgentSessionV2.providerSession: Record<string, string>` carries vendor ids. `AgentCapabilitySetV2.resume?: boolean`. `useAgentChatSocket.resume()` and `agent-resume-v2` command already wire end-to-end. Claude adapter implements `connect({ resume })`. Codex native adapter handles `thread/start` with `threadId`. |
+| Resume UI                   | `frontend/src/components/chat/ChatView.tsx:81` `canResume` flag and `tl-resume-banner`.                                                                                                                                                                                                                                  |
+| Error timeline              | `errorMessage` item type with `source: 'agent' \| 'client'`, rendered in `frontend/src/components/chat/Turn.tsx:112`.                                                                                                                                                                                                    |
 
 ## What Will Change
 
@@ -91,8 +91,13 @@ Replace one-shot `serializeAll` for web sessions with two triggers:
 
 1. If `capabilities.resume === true` and `providerSession` non-empty → call `adapter.resume(providerSession[vendorKey])`.
 2. If resume rejects (any error from adapter), emit a synthetic `errorMessage` patch into the session timeline:
-   ```
-   { type: 'errorMessage', source: 'client', message: 'Resume failed: <vendor> session expired or rotated. Start a new session to continue.', context: 'resume' }
+   ```json
+   {
+     "type": "errorMessage",
+     "source": "client",
+     "message": "Resume failed: <vendor> session expired or rotated. Start a new session to continue.",
+     "context": "resume"
+   }
    ```
    Set `status: 'disconnected'` on the live state. Do not retry. Do not auto-create a fresh vendor session.
 3. UI consumes this via the existing `errorMessage` renderer; no new UI needed.
@@ -119,7 +124,7 @@ Test: vitest unit test `test/server/relay-state-db.test.ts` covers schema migrat
 
 1. Modify `restoreFromDisk` in `server/sessions.ts` to call `loadAllWebSessions()` after PTY restore.
 2. Remove web session serialization from `serializeWebSession` / `serializeAll` write path; keep PTY-only.
-3. One-time migration: on `initRelayStateDb`, if `pending-sessions.json` exists and contains `webSessions`, import them into the DB and rewrite the file with PTY sessions only. Log the migration.
+3. **DEFERRED** — JSON→SQLite import. Shipped behavior abandons legacy web entries from `pending-sessions.json` on first run rather than migrating them. Re-evaluate if user friction warrants implementing.
 4. Remove `STALE_THRESHOLD_MS` check from web restoration. PTY check stays.
 
 Test: integration test that writes a fake `pending-sessions.json` with mixed PTY + web sessions, runs init, verifies DB has web sessions and JSON file has only PTY.
@@ -148,13 +153,13 @@ Test: integration test that writes a fake `pending-sessions.json` with mixed PTY
 
 ## Risks
 
-| Risk | Mitigation |
-|---|---|
-| Write amplification from streaming deltas | 1s debounce per session id collapses ~hundreds of patches per turn into one write. |
-| DB corruption on hard kill | WAL mode + `synchronous = NORMAL` pragma. Acceptable durability tradeoff vs throughput. |
-| Vendor session id stale on long restart | Already a known caveat. Resume-failure path surfaces clearly to user, no silent breakage. |
-| Schema evolution | `schema_version` + `MIGRATIONS` array (same pattern as `analytics.ts`). Forward-only. |
-| Concurrent writes from multiple sessions | `better-sqlite3` is sync + serializes writes. WAL allows concurrent readers. No locking issue. |
+| Risk                                      | Mitigation                                                                                     |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Write amplification from streaming deltas | 1s debounce per session id collapses ~hundreds of patches per turn into one write.             |
+| DB corruption on hard kill                | WAL mode + `synchronous = NORMAL` pragma. Acceptable durability tradeoff vs throughput.        |
+| Vendor session id stale on long restart   | Already a known caveat. Resume-failure path surfaces clearly to user, no silent breakage.      |
+| Schema evolution                          | `schema_version` + `MIGRATIONS` array (same pattern as `analytics.ts`). Forward-only.          |
+| Concurrent writes from multiple sessions  | `better-sqlite3` is sync + serializes writes. WAL allows concurrent readers. No locking issue. |
 
 ## Open questions
 

--- a/docs/plans/2026-04-29-web-session-persistence-sqlite.md
+++ b/docs/plans/2026-04-29-web-session-persistence-sqlite.md
@@ -1,0 +1,163 @@
+# Web Session Persistence — SQLite Store
+
+Branch: TBD (suggest `feat/web-session-sqlite`)
+
+Base branch: `nightly`
+
+## Plan Summary
+
+Replace the one-shot JSON snapshot in `pending-sessions.json` with a SQLite-backed store for web (V2) sessions. Relay owns the canonical transcript (`agent_session_v2_json`); vendor session id is stored alongside as an opaque resume pointer. On reconnect, relay renders the blob immediately and calls `adapter.resume(vendor_session_id)` in the background. If resume fails (expired thread, rotated id, vendor rejection), relay surfaces a single `errorMessage` (source `client`) into the timeline and leaves the session disconnected — the user must start a fresh session. A future enhancement may add a "Continue here" path that opens a new vendor session and merges turns under the same relay session id; out of scope for this slice.
+
+PTY sessions stay on the JSON path for now. The sqlite store is web-only.
+
+## Premises
+
+| Premise | Assessment |
+|---|---|
+| Relay should own the full transcript, not vendor history | Valid. Vendor `resume` continues model context but does not replay items; relay-injected items (errors, slash echoes, approval transcript) only exist on the relay side. |
+| Vendor session id is enough to resume model context | Valid for Claude SDK (`resume: claudeSessionId`) and Codex app-server (`thread/start` with `threadId`). OpenCode and Hermes already expose vendor session ids through `providerSession`. |
+| SQLite is the right substrate | Valid. `better-sqlite3` is already a dependency for `analytics.db`. Same WAL pattern, schema_version table, prepared statements. |
+| One DB file or two | Two: `analytics.db` is metrics, `relay-state.db` is canonical state. Different lifecycle, different backup posture, different access patterns. Avoid coupling. |
+| Per-patch row vs single blob | Single blob. `agent_session_v2_json` is the reduced-state canonical form; `applyAgentPatchV2` already produces it. Patches are wire-format, not storage-format. |
+| Resume failure UX | Show a `errorMessage` source=`client` in the timeline and leave session disconnected. No silent drop. No automatic new-session creation in this slice. |
+
+## What Already Exists
+
+| Sub-problem | Current code |
+|---|---|
+| Web session in-memory state | `server/sessions.ts` — `WebSession.agentSessionV2`, `agentPatchesV2` populated via `applyWebSessionPatchV2` (`server/web-session-v2-state.ts`). |
+| Persistence write path | `server/sessions.ts:638 serializeWebSession`, `:670 serializeAll` writes to `pending-sessions.json`. Only fires on `SIGTERM` / `SIGINT` / update-restart. |
+| Persistence read path | `server/sessions.ts:970 restoreFromDisk` → `:916 restoreWebSession`. Stale-file wipe at 5min (`STALE_THRESHOLD_MS`). File unlinked after restore. |
+| SQLite infra | `server/analytics.ts` — `Database` open with `journal_mode=WAL`, `MIGRATIONS` array keyed by `schema_version` table, prepared statements module-scoped. |
+| Vendor resume capability | `AgentSessionV2.providerSession: Record<string, string>` carries vendor ids. `AgentCapabilitySetV2.resume?: boolean`. `useAgentChatSocket.resume()` and `agent-resume-v2` command already wire end-to-end. Claude adapter implements `connect({ resume })`. Codex native adapter handles `thread/start` with `threadId`. |
+| Resume UI | `frontend/src/components/chat/ChatView.tsx:81` `canResume` flag and `tl-resume-banner`. |
+| Error timeline | `errorMessage` item type with `source: 'agent' | 'client'`, rendered in `frontend/src/components/chat/Turn.tsx:112`. |
+
+## What Will Change
+
+### Schema
+
+```sql
+CREATE TABLE web_sessions (
+  id TEXT PRIMARY KEY,
+  vendor TEXT NOT NULL,
+  vendor_session_id TEXT,
+  cwd TEXT NOT NULL,
+  repo_path TEXT,
+  worktree_path TEXT,
+  branch_name TEXT,
+  display_name TEXT,
+  workspace_id TEXT,
+  agent_session_v2_json TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  last_activity INTEGER NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('active', 'disconnected', 'archived'))
+);
+CREATE INDEX idx_web_sessions_vendor_session ON web_sessions(vendor, vendor_session_id);
+CREATE INDEX idx_web_sessions_status_activity ON web_sessions(status, last_activity);
+```
+
+`agent_session_v2_json` holds the full `AgentSessionV2` shape — turns, items, capabilities, config, providerSession. Single source of truth for the web UI.
+
+`vendor_session_id` is a denormalized cache of the resume pointer; `agent_session_v2_json.providerSession` carries the same value. Index lets us find sessions by vendor id (debugging, multi-window dedup).
+
+### New module: `server/relay-state-db.ts`
+
+Mirrors `server/analytics.ts` shape:
+
+- `initRelayStateDb(configDir: string): void` — opens `<configDir>/relay-state.db`, runs migrations.
+- `closeRelayStateDb(): void`
+- `upsertWebSession(session: WebSession): void` — single prepared statement, writes everything from the in-memory session.
+- `loadAllWebSessions(): SerializedWebSession[]` — for restore.
+- `deleteWebSession(id: string): void` — for archived/closed.
+- `markStatus(id: string, status: 'active' | 'disconnected' | 'archived'): void`
+
+### Write path
+
+Replace one-shot `serializeAll` for web sessions with two triggers:
+
+1. **Debounced on patch.** In `applyWebSessionPatchV2` (`server/web-session-v2-state.ts`), after applying the patch, schedule `upsertWebSession(session)` via a 1s debounce keyed by session id. High-frequency streams (token-by-token deltas) collapse to one write per second per session.
+2. **On structural events.** Immediate `upsertWebSession` on session create, vendor session id assignment, status change, shutdown.
+
+`serializeAll` keeps writing PTY sessions to `pending-sessions.json`. Web sessions get removed from that file in this slice.
+
+### Read path
+
+`restoreFromDisk` calls `loadAllWebSessions()` after PTY restore. Each row is converted to `SerializedWebSession` and fed to existing `restoreWebSession`. No staleness wipe — DB rows persist indefinitely until user archives. Add `archived` status filter at load time.
+
+### Resume + failure surface
+
+`restoreWebSession` already calls `reconnectWebSession`. Extend that to:
+
+1. If `capabilities.resume === true` and `providerSession` non-empty → call `adapter.resume(providerSession[vendorKey])`.
+2. If resume rejects (any error from adapter), emit a synthetic `errorMessage` patch into the session timeline:
+   ```
+   { type: 'errorMessage', source: 'client', message: 'Resume failed: <vendor> session expired or rotated. Start a new session to continue.', context: 'resume' }
+   ```
+   Set `status: 'disconnected'` on the live state. Do not retry. Do not auto-create a fresh vendor session.
+3. UI consumes this via the existing `errorMessage` renderer; no new UI needed.
+
+### What goes away
+
+- `pending-sessions.json` web session entries (PTY entries stay).
+- 5-minute staleness wipe for web sessions.
+- Single-write-on-shutdown failure mode.
+
+## Slice-by-slice
+
+### Slice 1 — DB module + write path
+
+1. Add `server/relay-state-db.ts`. Mirror `analytics.ts` skeleton: `Database`, WAL pragma, `schema_version` table, `MIGRATIONS` array, prepared statements.
+2. Migration `1`: `CREATE TABLE web_sessions ...` plus indexes.
+3. Wire `initRelayStateDb(configDir)` into `initializeRuntimeDirectories` in `server/index.ts:798` next to `initFileLogging` and `initAnalytics`.
+4. Add debounced `upsertWebSession` call inside `applyWebSessionPatchV2`. Use a module-level `Map<sessionId, NodeJS.Timeout>` for debounce. Flush all timers on `gracefulShutdown`.
+5. Add immediate writes on `createWebSession`, `closeWebSession`, vendor session id assignment in adapters (when `providerSession` is updated).
+
+Test: vitest unit test `test/server/relay-state-db.test.ts` covers schema migration, upsert idempotence, load roundtrip.
+
+### Slice 2 — Read path + JSON migration
+
+1. Modify `restoreFromDisk` in `server/sessions.ts` to call `loadAllWebSessions()` after PTY restore.
+2. Remove web session serialization from `serializeWebSession` / `serializeAll` write path; keep PTY-only.
+3. One-time migration: on `initRelayStateDb`, if `pending-sessions.json` exists and contains `webSessions`, import them into the DB and rewrite the file with PTY sessions only. Log the migration.
+4. Remove `STALE_THRESHOLD_MS` check from web restoration. PTY check stays.
+
+Test: integration test that writes a fake `pending-sessions.json` with mixed PTY + web sessions, runs init, verifies DB has web sessions and JSON file has only PTY.
+
+### Slice 3 — Resume failure surface
+
+1. In `restoreWebSession`, wrap the `reconnectWebSession` call. On rejection, push a synthetic `errorMessage` patch into `agentSessionV2` and persist via existing `applyWebSessionPatchV2`.
+2. Set live state `status: 'disconnected'`, clear `activeTurnId`.
+3. Verify `ChatView.tsx` `canResume` still computes correctly post-failure (should: status disconnected + providerSession present → resume button shown again, user can retry manually).
+4. Add unit test for the failure path: stub adapter `connect` to reject with `resume failed`, assert `errorMessage` item appears with `source: 'client'`, `context: 'resume'`, and live status is `disconnected`.
+
+### Slice 4 — Cleanup + docs
+
+1. Drop `agentSessionV2` and `agentPatchesV2` fields from `SerializedWebSession` interface. Drop `webSessions` field from `PendingSessionsFile` once migration shipped.
+2. Bump `pending-sessions.json` version to 6 (PTY-only).
+3. Update `docs/ARCHITECTURE.md` — new "Web session persistence" subsection pointing at `relay-state.db`.
+4. Update `docs/DESIGN.md` if it references the old JSON path.
+
+## Out of scope
+
+- "Continue here" recovery (new vendor session merged into same relay session id on resume failure). Tracked separately.
+- Per-patch row table for forensic replay. Blob is sufficient for the foreseeable need.
+- Cross-vendor session search UI. DB schema supports it; UI surface is a follow-up.
+- PTY session migration to SQLite. Tmux session lifecycle differs; keep the JSON path.
+- Multi-device sync. Single-host store only.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Write amplification from streaming deltas | 1s debounce per session id collapses ~hundreds of patches per turn into one write. |
+| DB corruption on hard kill | WAL mode + `synchronous = NORMAL` pragma. Acceptable durability tradeoff vs throughput. |
+| Vendor session id stale on long restart | Already a known caveat. Resume-failure path surfaces clearly to user, no silent breakage. |
+| Schema evolution | `schema_version` + `MIGRATIONS` array (same pattern as `analytics.ts`). Forward-only. |
+| Concurrent writes from multiple sessions | `better-sqlite3` is sync + serializes writes. WAL allows concurrent readers. No locking issue. |
+
+## Open questions
+
+- Archive policy: when does a row move to `status='archived'`? On explicit user action only, or also on idle timeout? Recommend explicit-only for first slice.
+- Backup story: do we want an export command or rely on filesystem backup? Out of scope unless asked.
+- Telemetry: should `web_sessions` row count + last_activity feed analytics dashboards? Future enhancement.

--- a/server/index.ts
+++ b/server/index.ts
@@ -61,6 +61,11 @@ import {
   recordRateLimitSnapshot,
 } from './analytics.js';
 import {
+  initRelayStateDb,
+  closeRelayStateDb,
+  flushAllPendingWrites as flushRelayStateWrites,
+} from './relay-state-db.js';
+import {
   createWorkspaceRouter,
   clearPrCache,
   clearFilesListCache,
@@ -954,6 +959,15 @@ async function main(): Promise<void> {
     getConfig,
     reconcilePortsForAllRepos
   );
+
+  try {
+    initRelayStateDb(configDir);
+  } catch (err) {
+    logger.warn(
+      'Relay state DB disabled: failed to initialize:',
+      err instanceof Error ? err.message : err
+    );
+  }
 
   try {
     initAnalytics(configDir);
@@ -2540,6 +2554,8 @@ async function main(): Promise<void> {
         stopEventBatching();
         stopTelemetry();
         serializeAll(configDir);
+        flushRelayStateWrites();
+        closeRelayStateDb();
         broadcastEvent('server-restarting');
       }
       res.json({ ok: true, restarting });
@@ -2611,6 +2627,8 @@ async function main(): Promise<void> {
     // Serialize sessions before detaching the node-pty tmux clients. The tmux
     // sessions themselves must survive so startup can reattach to them.
     serializeAll(configDir);
+    flushRelayStateWrites();
+    closeRelayStateDb();
     for (const s of sessions.list()) {
       try {
         sessions.detachForRestart(s.id);

--- a/server/relay-state-db.ts
+++ b/server/relay-state-db.ts
@@ -102,7 +102,9 @@ export function initRelayStateDb(configDir: string): void {
   db.pragma('journal_mode = WAL');
   db.pragma('synchronous = NORMAL');
 
-  db.exec(`CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)`);
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)`
+  );
   const row = db.prepare('SELECT version FROM schema_version').get() as
     | { version: number }
     | undefined;
@@ -117,7 +119,9 @@ export function initRelayStateDb(configDir: string): void {
         if (hadRow || currentVersion > 0) {
           db!.prepare('UPDATE schema_version SET version = ?').run(ver);
         } else {
-          db!.prepare('INSERT INTO schema_version (version) VALUES (?)').run(ver);
+          db!
+            .prepare('INSERT INTO schema_version (version) VALUES (?)')
+            .run(ver);
         }
       })();
       currentVersion = ver;
@@ -141,6 +145,7 @@ export function initRelayStateDb(configDir: string): void {
 
 export function closeRelayStateDb(): void {
   flushAllPendingWrites();
+  archivedIds.clear();
   if (db) {
     db.close();
     db = null;
@@ -151,16 +156,34 @@ export function closeRelayStateDb(): void {
   }
 }
 
-// ── Debounced write scheduler ─────────────────────────────────────────────
-
-const DEBOUNCE_MS = 1000;
-const pendingTimers = new Map<string, NodeJS.Timeout>();
-const pendingPayloads = new Map<string, () => void>();
+// ── Throttled write scheduler ─────────────────────────────────────────────
 
 /**
- * Schedule a debounced upsert. Multiple calls within {@link DEBOUNCE_MS} for
- * the same session id collapse into a single write that captures the latest
- * snapshot. Used during high-frequency streaming patches.
+ * Idle-debounce window: collapse a quiet-period burst into one write.
+ */
+const DEBOUNCE_MS = 1000;
+/**
+ * Hard cap on how long a session may go without being persisted while patches
+ * are still flowing. Pure debounce never fires under continuous streaming;
+ * this guarantees a snapshot lands on disk at least every {@link MAX_WAIT_MS}.
+ */
+const MAX_WAIT_MS = 1000;
+
+const pendingTimers = new Map<string, NodeJS.Timeout>();
+const pendingPayloads = new Map<string, () => void>();
+const firstScheduledAt = new Map<string, number>();
+/**
+ * Session ids whose row was explicitly archived. Subsequent upserts must not
+ * overwrite the archived status with a status derived from `live.status`,
+ * which would silently revive the session on the next patch.
+ */
+const archivedIds = new Set<string>();
+
+/**
+ * Schedule a debounce-with-maxWait upsert. The timer resets on each call
+ * (debounce) but is capped so the write always fires within {@link MAX_WAIT_MS}
+ * of the first scheduled call in a burst — protects against streams that
+ * never go quiet.
  */
 export function scheduleWebSessionUpsert(session: WebSession): void {
   if (!db || !upsertWebStmt) return;
@@ -168,15 +191,24 @@ export function scheduleWebSessionUpsert(session: WebSession): void {
   const id = session.id;
   pendingPayloads.set(id, () => writeUpsert(session));
 
+  const now = Date.now();
+  const firstAt = firstScheduledAt.get(id) ?? now;
+  if (!firstScheduledAt.has(id)) firstScheduledAt.set(id, now);
+
   const existing = pendingTimers.get(id);
   if (existing) clearTimeout(existing);
 
+  const elapsed = now - firstAt;
+  const remainingCap = Math.max(0, MAX_WAIT_MS - elapsed);
+  const delay = Math.min(DEBOUNCE_MS, remainingCap);
+
   const timer = setTimeout(() => {
     pendingTimers.delete(id);
+    firstScheduledAt.delete(id);
     const fn = pendingPayloads.get(id);
     pendingPayloads.delete(id);
     if (fn) fn();
-  }, DEBOUNCE_MS);
+  }, delay);
   pendingTimers.set(id, timer);
 }
 
@@ -192,6 +224,7 @@ export function upsertWebSessionNow(session: WebSession): void {
     clearTimeout(timer);
     pendingTimers.delete(session.id);
     pendingPayloads.delete(session.id);
+    firstScheduledAt.delete(session.id);
   }
   writeUpsert(session);
 }
@@ -210,6 +243,7 @@ export function flushAllPendingWrites(): void {
   }
   pendingTimers.clear();
   pendingPayloads.clear();
+  firstScheduledAt.clear();
 }
 
 function writeUpsert(session: WebSession): void {
@@ -261,7 +295,9 @@ export function deleteWebSession(id: string): void {
     clearTimeout(timer);
     pendingTimers.delete(id);
     pendingPayloads.delete(id);
+    firstScheduledAt.delete(id);
   }
+  archivedIds.delete(id);
   try {
     deleteWebStmt.run(id);
   } catch (err) {
@@ -274,6 +310,18 @@ export function markWebSessionStatus(
   status: 'active' | 'disconnected' | 'archived'
 ): void {
   if (!db || !markStatusStmt) return;
+  if (status === 'archived') {
+    archivedIds.add(id);
+    const timer = pendingTimers.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      pendingTimers.delete(id);
+      pendingPayloads.delete(id);
+      firstScheduledAt.delete(id);
+    }
+  } else {
+    archivedIds.delete(id);
+  }
   try {
     markStatusStmt.run(status, Date.now(), id);
   } catch (err) {
@@ -304,7 +352,9 @@ export function loadAllWebSessions(): LoadedWebSessionRow[] {
   const out: LoadedWebSessionRow[] = [];
   for (const row of rows) {
     try {
-      const agentSession = JSON.parse(row.agent_session_v2_json) as AgentSessionV2;
+      const agentSession = JSON.parse(
+        row.agent_session_v2_json
+      ) as AgentSessionV2;
       const meta = JSON.parse(row.meta_json) as WebSessionMeta;
       out.push({
         id: row.id,
@@ -343,6 +393,7 @@ function pickVendorSessionId(session: AgentSessionV2): string | null {
 function deriveStatus(
   session: WebSession
 ): 'active' | 'disconnected' | 'archived' {
+  if (archivedIds.has(session.id)) return 'archived';
   const live = session.agentSessionV2.live.status;
   if (live === 'disconnected') return 'disconnected';
   return 'active';

--- a/server/relay-state-db.ts
+++ b/server/relay-state-db.ts
@@ -1,0 +1,357 @@
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import type { WebSession } from './types.js';
+import type { AgentSessionV2 } from '../shared/agent-chat-protocol-v2.js';
+import { createLogger } from './logger.js';
+
+const logger = createLogger('relay-state-db');
+
+let db: Database.Database | null = null;
+let upsertWebStmt: Database.Statement | null = null;
+let deleteWebStmt: Database.Statement | null = null;
+let markStatusStmt: Database.Statement | null = null;
+let loadAllWebStmt: Database.Statement | null = null;
+
+const SCHEMA_V1 = `
+CREATE TABLE IF NOT EXISTS web_sessions (
+  id                    TEXT PRIMARY KEY,
+  vendor                TEXT NOT NULL,
+  vendor_session_id     TEXT,
+  cwd                   TEXT NOT NULL,
+  repo_path             TEXT,
+  worktree_path         TEXT,
+  branch_name           TEXT,
+  display_name          TEXT,
+  workspace_id          TEXT,
+  agent_session_v2_json TEXT NOT NULL,
+  meta_json             TEXT NOT NULL,
+  created_at            INTEGER NOT NULL,
+  last_activity         INTEGER NOT NULL,
+  status                TEXT NOT NULL CHECK (status IN ('active', 'disconnected', 'archived'))
+);
+CREATE INDEX IF NOT EXISTS idx_web_sessions_vendor_session
+  ON web_sessions(vendor, vendor_session_id);
+CREATE INDEX IF NOT EXISTS idx_web_sessions_status_activity
+  ON web_sessions(status, last_activity);
+`;
+
+const MIGRATIONS: Array<{ version: number; sql: string }> = [
+  { version: 1, sql: SCHEMA_V1 },
+];
+
+const UPSERT_SQL = `
+INSERT INTO web_sessions (
+  id, vendor, vendor_session_id, cwd, repo_path, worktree_path, branch_name,
+  display_name, workspace_id, agent_session_v2_json, meta_json,
+  created_at, last_activity, status
+) VALUES (
+  @id, @vendor, @vendorSessionId, @cwd, @repoPath, @worktreePath, @branchName,
+  @displayName, @workspaceId, @agentSessionV2Json, @metaJson,
+  @createdAt, @lastActivity, @status
+)
+ON CONFLICT(id) DO UPDATE SET
+  vendor                = excluded.vendor,
+  vendor_session_id     = excluded.vendor_session_id,
+  cwd                   = excluded.cwd,
+  repo_path             = excluded.repo_path,
+  worktree_path         = excluded.worktree_path,
+  branch_name           = excluded.branch_name,
+  display_name          = excluded.display_name,
+  workspace_id          = excluded.workspace_id,
+  agent_session_v2_json = excluded.agent_session_v2_json,
+  meta_json             = excluded.meta_json,
+  last_activity         = excluded.last_activity,
+  status                = excluded.status
+`;
+
+/** Fields restored alongside the agent session blob. */
+export interface WebSessionMeta {
+  type: string;
+  agent: string;
+  repoName: string;
+  customCommand: string | null;
+  runtimeOwnership: 'spawned' | 'attached';
+  hookToken: string;
+  adapterType: string;
+  needsBranchRename?: boolean;
+  additionalDirs?: string[];
+}
+
+export interface LoadedWebSessionRow {
+  id: string;
+  vendor: string;
+  vendorSessionId: string | null;
+  cwd: string;
+  repoPath: string | null;
+  worktreePath: string | null;
+  branchName: string | null;
+  displayName: string | null;
+  workspaceId: string | null;
+  agentSessionV2: AgentSessionV2;
+  meta: WebSessionMeta;
+  createdAt: number;
+  lastActivity: number;
+  status: 'active' | 'disconnected' | 'archived';
+}
+
+export function initRelayStateDb(configDir: string): void {
+  if (db) closeRelayStateDb();
+
+  const dbPath = path.join(configDir, 'relay-state.db');
+  db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+
+  db.exec(`CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)`);
+  const row = db.prepare('SELECT version FROM schema_version').get() as
+    | { version: number }
+    | undefined;
+  let currentVersion = row?.version ?? 0;
+  const hadRow = row !== undefined;
+
+  for (const migration of MIGRATIONS) {
+    if (migration.version > currentVersion) {
+      const ver = migration.version;
+      db.transaction(() => {
+        db!.exec(migration.sql);
+        if (hadRow || currentVersion > 0) {
+          db!.prepare('UPDATE schema_version SET version = ?').run(ver);
+        } else {
+          db!.prepare('INSERT INTO schema_version (version) VALUES (?)').run(ver);
+        }
+      })();
+      currentVersion = ver;
+    }
+  }
+
+  upsertWebStmt = db.prepare(UPSERT_SQL);
+  deleteWebStmt = db.prepare('DELETE FROM web_sessions WHERE id = ?');
+  markStatusStmt = db.prepare(
+    'UPDATE web_sessions SET status = ?, last_activity = ? WHERE id = ?'
+  );
+  loadAllWebStmt = db.prepare(
+    `SELECT id, vendor, vendor_session_id, cwd, repo_path, worktree_path,
+            branch_name, display_name, workspace_id, agent_session_v2_json,
+            meta_json, created_at, last_activity, status
+     FROM web_sessions
+     WHERE status != 'archived'
+     ORDER BY last_activity ASC`
+  );
+}
+
+export function closeRelayStateDb(): void {
+  flushAllPendingWrites();
+  if (db) {
+    db.close();
+    db = null;
+    upsertWebStmt = null;
+    deleteWebStmt = null;
+    markStatusStmt = null;
+    loadAllWebStmt = null;
+  }
+}
+
+// ── Debounced write scheduler ─────────────────────────────────────────────
+
+const DEBOUNCE_MS = 1000;
+const pendingTimers = new Map<string, NodeJS.Timeout>();
+const pendingPayloads = new Map<string, () => void>();
+
+/**
+ * Schedule a debounced upsert. Multiple calls within {@link DEBOUNCE_MS} for
+ * the same session id collapse into a single write that captures the latest
+ * snapshot. Used during high-frequency streaming patches.
+ */
+export function scheduleWebSessionUpsert(session: WebSession): void {
+  if (!db || !upsertWebStmt) return;
+
+  const id = session.id;
+  pendingPayloads.set(id, () => writeUpsert(session));
+
+  const existing = pendingTimers.get(id);
+  if (existing) clearTimeout(existing);
+
+  const timer = setTimeout(() => {
+    pendingTimers.delete(id);
+    const fn = pendingPayloads.get(id);
+    pendingPayloads.delete(id);
+    if (fn) fn();
+  }, DEBOUNCE_MS);
+  pendingTimers.set(id, timer);
+}
+
+/**
+ * Immediate write, bypassing debounce. Use on structural events
+ * (session create, vendor session id assignment, status change, shutdown).
+ */
+export function upsertWebSessionNow(session: WebSession): void {
+  if (!db || !upsertWebStmt) return;
+
+  const timer = pendingTimers.get(session.id);
+  if (timer) {
+    clearTimeout(timer);
+    pendingTimers.delete(session.id);
+    pendingPayloads.delete(session.id);
+  }
+  writeUpsert(session);
+}
+
+export function flushAllPendingWrites(): void {
+  for (const [id, timer] of pendingTimers.entries()) {
+    clearTimeout(timer);
+    const fn = pendingPayloads.get(id);
+    if (fn) {
+      try {
+        fn();
+      } catch (err) {
+        logger.warn('flush write failed for %s: %s', id, err);
+      }
+    }
+  }
+  pendingTimers.clear();
+  pendingPayloads.clear();
+}
+
+function writeUpsert(session: WebSession): void {
+  if (!upsertWebStmt) return;
+
+  const vendor = session.agentSessionV2.provider;
+  const vendorSessionId = pickVendorSessionId(session.agentSessionV2);
+
+  const meta: WebSessionMeta = {
+    type: session.type,
+    agent: session.agent,
+    repoName: session.repoName,
+    customCommand: session.customCommand ?? null,
+    runtimeOwnership: session.runtimeOwnership,
+    hookToken: session.hookToken,
+    adapterType: session.adapterType,
+    ...(session.needsBranchRename ? { needsBranchRename: true as const } : {}),
+    ...(session.additionalDirs?.length
+      ? { additionalDirs: session.additionalDirs }
+      : {}),
+  };
+
+  try {
+    upsertWebStmt.run({
+      id: session.id,
+      vendor,
+      vendorSessionId,
+      cwd: session.cwd,
+      repoPath: session.repoPath ?? null,
+      worktreePath: session.worktreePath ?? null,
+      branchName: session.branchName ?? null,
+      displayName: session.displayName ?? null,
+      workspaceId: session.workspaceId ?? null,
+      agentSessionV2Json: JSON.stringify(session.agentSessionV2),
+      metaJson: JSON.stringify(meta),
+      createdAt: toEpochMs(session.createdAt),
+      lastActivity: toEpochMs(session.lastActivity),
+      status: deriveStatus(session),
+    });
+  } catch (err) {
+    logger.warn('upsert failed for %s: %s', session.id, err);
+  }
+}
+
+export function deleteWebSession(id: string): void {
+  if (!db || !deleteWebStmt) return;
+  const timer = pendingTimers.get(id);
+  if (timer) {
+    clearTimeout(timer);
+    pendingTimers.delete(id);
+    pendingPayloads.delete(id);
+  }
+  try {
+    deleteWebStmt.run(id);
+  } catch (err) {
+    logger.warn('delete failed for %s: %s', id, err);
+  }
+}
+
+export function markWebSessionStatus(
+  id: string,
+  status: 'active' | 'disconnected' | 'archived'
+): void {
+  if (!db || !markStatusStmt) return;
+  try {
+    markStatusStmt.run(status, Date.now(), id);
+  } catch (err) {
+    logger.warn('markStatus failed for %s: %s', id, err);
+  }
+}
+
+export function loadAllWebSessions(): LoadedWebSessionRow[] {
+  if (!db || !loadAllWebStmt) return [];
+
+  const rows = loadAllWebStmt.all() as Array<{
+    id: string;
+    vendor: string;
+    vendor_session_id: string | null;
+    cwd: string;
+    repo_path: string | null;
+    worktree_path: string | null;
+    branch_name: string | null;
+    display_name: string | null;
+    workspace_id: string | null;
+    agent_session_v2_json: string;
+    meta_json: string;
+    created_at: number;
+    last_activity: number;
+    status: 'active' | 'disconnected' | 'archived';
+  }>;
+
+  const out: LoadedWebSessionRow[] = [];
+  for (const row of rows) {
+    try {
+      const agentSession = JSON.parse(row.agent_session_v2_json) as AgentSessionV2;
+      const meta = JSON.parse(row.meta_json) as WebSessionMeta;
+      out.push({
+        id: row.id,
+        vendor: row.vendor,
+        vendorSessionId: row.vendor_session_id,
+        cwd: row.cwd,
+        repoPath: row.repo_path,
+        worktreePath: row.worktree_path,
+        branchName: row.branch_name,
+        displayName: row.display_name,
+        workspaceId: row.workspace_id,
+        agentSessionV2: agentSession,
+        meta,
+        createdAt: row.created_at,
+        lastActivity: row.last_activity,
+        status: row.status,
+      });
+    } catch (err) {
+      logger.warn('failed to parse row %s: %s', row.id, err);
+    }
+  }
+  return out;
+}
+
+function pickVendorSessionId(session: AgentSessionV2): string | null {
+  const ps = session.providerSession;
+  if (!ps) return null;
+  // Take the first defined value. Each adapter stores at most one resume id
+  // under a vendor-specific key (claudeSessionId, threadId, etc.).
+  for (const value of Object.values(ps)) {
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return null;
+}
+
+function deriveStatus(
+  session: WebSession
+): 'active' | 'disconnected' | 'archived' {
+  const live = session.agentSessionV2.live.status;
+  if (live === 'disconnected') return 'disconnected';
+  return 'active';
+}
+
+function toEpochMs(value: string | number | Date | undefined): number {
+  if (value === undefined) return Date.now();
+  if (typeof value === 'number') return value;
+  if (value instanceof Date) return value.getTime();
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -899,6 +899,33 @@ async function restoreWebSessionFromDb(
     session.needsBranchRename = true;
   }
 
+  // Restore top-level metadata from the row so sessions.list() ordering,
+  // duration calculations, and backend-state display reflect the persisted
+  // session rather than the freshly-created blank wrapper.
+  session.createdAt = new Date(row.createdAt).toISOString();
+  session.lastActivity = new Date(row.lastActivity).toISOString();
+  session.status = row.status === 'archived' ? 'disconnected' : row.status;
+
+  // Derive runtime state from the persisted live snapshot, mirroring the
+  // mapping in web-session-handler's adapter listener.
+  const live = session.agentSessionV2.live;
+  session.currentTurnId = live.activeTurnId;
+  if (live.status === 'working') {
+    session.agentState = 'processing';
+    session.idle = false;
+  } else if (live.status === 'waiting') {
+    session.agentState =
+      live.waitingOn === 'approval' ? 'permission-prompt' : 'waiting-for-input';
+    session.idle = false;
+  } else if (live.status === 'error') {
+    session.agentState = 'error';
+    session.idle = true;
+  } else {
+    session.agentState = 'idle';
+    session.idle = true;
+  }
+  fireBackendStateIfChanged(session);
+
   // Persist immediately so the freshly-restored row reflects current state
   // (vendor may not assign a new id, but live status flips).
   upsertWebSessionNow(session);
@@ -1052,10 +1079,16 @@ async function restoreFromDisk(
     } catch {
       /* ignore */
     }
+    // Recursively wipe scrollback dir. When pending was stale (or unreadable)
+    // per-session scrollback files weren't cleaned up by the restore loop;
+    // remove them here so stale buffers don't accumulate across restarts.
     try {
-      fs.rmdirSync(path.join(configDir, 'scrollback'));
+      fs.rmSync(path.join(configDir, 'scrollback'), {
+        recursive: true,
+        force: true,
+      });
     } catch {
-      /* ignore — may not be empty */
+      /* ignore */
     }
   }
 

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -867,6 +867,9 @@ function restoreSession(
 async function restoreWebSessionFromDb(
   row: import('./relay-state-db.js').LoadedWebSessionRow
 ): Promise<void> {
+  // Restore persisted adapter runtime settings so the reconnected session
+  // matches what was originally running rather than reverting to defaults.
+  const persistedConfig = row.agentSessionV2.config;
   const createParams: CreateWebParams = {
     id: row.id,
     agentType: row.meta.adapterType,
@@ -884,12 +887,26 @@ async function restoreWebSessionFromDb(
     ...(row.meta.additionalDirs !== undefined
       ? { additionalDirs: row.meta.additionalDirs }
       : {}),
+    ...(persistedConfig.model !== undefined
+      ? { model: persistedConfig.model }
+      : {}),
+    ...(persistedConfig.permissionMode !== undefined
+      ? { permissionMode: persistedConfig.permissionMode }
+      : {}),
+    ...(persistedConfig.providerOptions !== undefined
+      ? { extra: persistedConfig.providerOptions }
+      : {}),
   };
 
+  // skipInitialPersist=true: createWebSession would otherwise overwrite the
+  // persisted DB row with a freshly-initialized blank transcript before we
+  // copy back agentSessionV2 below — a process death in that window would
+  // lose the session.
   const { session } = await createWebSession(
     createParams,
     sessions,
-    fireBackendStateIfChanged
+    fireBackendStateIfChanged,
+    { skipInitialPersist: true }
   );
 
   // Replace the freshly-created blank transcript with the persisted one.
@@ -984,6 +1001,16 @@ function surfaceResumeFailure(session: WebSession, err: unknown): void {
       },
     };
   applyWebSessionPatchV2(session, liveStatePatch);
+
+  // Keep top-level session state in sync so sessions.list() and backend-state
+  // listeners see the disconnected state immediately rather than the stale
+  // pre-failure values until the next reload.
+  session.status = 'disconnected';
+  session.agentState = 'error';
+  session.idle = true;
+  session.currentTurnId = null;
+  fireBackendStateIfChanged(session);
+
   upsertWebSessionNow(session);
 }
 

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -34,6 +34,12 @@ import {
   reconnectWebSession,
   type CreateWebParams,
 } from './web-session-handler.js';
+import {
+  loadAllWebSessions,
+  deleteWebSession,
+  upsertWebSessionNow,
+} from './relay-state-db.js';
+import { applyWebSessionPatchV2 } from './web-session-v2-state.js';
 import { getWorkingTreeDiff } from './git.js';
 import { getPrForBranch, isStalePr } from './gh.js';
 import {
@@ -73,38 +79,10 @@ interface SerializedPtySession {
   additionalDirs?: string[];
 }
 
-interface SerializedWebSession {
-  id: string;
-  type: SessionType;
-  agent: AgentType;
-  repoPath: string;
-  worktreePath: string | null;
-  cwd: string;
-  repoName: string;
-  branchName: string;
-  displayName: string;
-  createdAt: string;
-  lastActivity: string;
-  customCommand: string | null;
-  runtimeOwnership: 'spawned' | 'attached';
-  hookToken: string;
-  adapterType: string;
-  needsBranchRename?: boolean;
-  workspaceId?: string;
-  additionalDirs?: string[];
-  /** Messages buffer persisted for replay (up to 1000 events) */
-  messages?: import('../shared/chat-events.js').ChatEvent[];
-  /** Canonical v2 state persisted for web-chat reconnect/restore */
-  agentSessionV2?: import('../shared/agent-chat-protocol-v2.js').AgentSessionV2;
-  /** Recent v2 patches persisted for reconnect catch-up */
-  agentPatchesV2?: import('../shared/agent-chat-protocol-v2.js').AgentPatchV2[];
-}
-
 interface PendingSessionsFile {
-  version: number; // now 5
+  version: number; // now 6 — web sessions moved to relay-state.db
   timestamp: string;
   sessions: SerializedPtySession[];
-  webSessions?: SerializedWebSession[];
 }
 
 const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
@@ -483,6 +461,10 @@ function kill(id: string): void {
     cleanupCodexHooksAdapter(id);
   }
 
+  if (session.mode === 'web') {
+    deleteWebSession(id);
+  }
+
   sessions.delete(id);
 }
 
@@ -635,58 +617,27 @@ function serializePtySession(
   };
 }
 
-function serializeWebSession(session: WebSession): SerializedWebSession {
-  return {
-    id: session.id,
-    type: session.type,
-    agent: session.agent,
-    repoPath: session.repoPath,
-    worktreePath: session.worktreePath,
-    cwd: session.cwd,
-    repoName: session.repoName,
-    branchName: session.branchName,
-    displayName: session.displayName,
-    createdAt: session.createdAt,
-    lastActivity: session.lastActivity,
-    customCommand: session.customCommand,
-    runtimeOwnership: session.runtimeOwnership,
-    hookToken: session.hookToken,
-    adapterType: session.adapterType,
-    ...(session.needsBranchRename ? { needsBranchRename: true as const } : {}),
-    ...(session.workspaceId ? { workspaceId: session.workspaceId } : {}),
-    ...(session.additionalDirs?.length
-      ? { additionalDirs: session.additionalDirs }
-      : {}),
-    ...(session.messages.length
-      ? { messages: session.messages.slice(-1000) }
-      : {}),
-    agentSessionV2: session.agentSessionV2,
-    ...(session.agentPatchesV2.length
-      ? { agentPatchesV2: session.agentPatchesV2.slice(-1000) }
-      : {}),
-  };
-}
-
 function serializeAll(configDir: string): void {
   const scrollbackDirPath = path.join(configDir, 'scrollback');
   fs.mkdirSync(scrollbackDirPath, { recursive: true });
 
   const serializedPty: SerializedPtySession[] = [];
-  const serializedWeb: SerializedWebSession[] = [];
 
   for (const session of sessions.values()) {
     if (session.mode === 'pty') {
       serializedPty.push(serializePtySession(session, scrollbackDirPath));
     } else {
-      serializedWeb.push(serializeWebSession(session));
+      // Web sessions persisted to relay-state.db on patch (debounced) +
+      // structural events. Final shutdown snapshot for any not-yet-flushed
+      // mutations is handled by upsertWebSessionNow before serializeAll.
+      upsertWebSessionNow(session);
     }
   }
 
   const pending: PendingSessionsFile = {
-    version: 5,
+    version: 6,
     timestamp: new Date().toISOString(),
     sessions: serializedPty,
-    webSessions: serializedWeb,
   };
 
   fs.writeFileSync(
@@ -913,23 +864,25 @@ function restoreSession(
   create(createParams);
 }
 
-async function restoreWebSession(s: SerializedWebSession): Promise<void> {
+async function restoreWebSessionFromDb(
+  row: import('./relay-state-db.js').LoadedWebSessionRow
+): Promise<void> {
   const createParams: CreateWebParams = {
-    id: s.id,
-    agentType: s.adapterType,
-    cwd: s.cwd,
-    repoPath: s.repoPath,
-    repoName: s.repoName,
-    worktreePath: s.worktreePath,
-    branchName: s.branchName,
-    displayName: s.displayName,
+    id: row.id,
+    agentType: row.meta.adapterType,
+    cwd: row.cwd,
+    repoPath: row.repoPath ?? row.cwd,
+    repoName: row.meta.repoName,
+    worktreePath: row.worktreePath,
+    branchName: row.branchName ?? '',
+    displayName: row.displayName ?? '',
     port: defaultPort ?? 3456,
     configDir: defaultConfigDir ?? '',
-    runtimeOwnership: s.runtimeOwnership,
-    hookToken: s.hookToken,
-    ...(s.workspaceId !== undefined ? { workspaceId: s.workspaceId } : {}),
-    ...(s.additionalDirs !== undefined
-      ? { additionalDirs: s.additionalDirs }
+    runtimeOwnership: row.meta.runtimeOwnership,
+    hookToken: row.meta.hookToken,
+    ...(row.workspaceId !== null ? { workspaceId: row.workspaceId } : {}),
+    ...(row.meta.additionalDirs !== undefined
+      ? { additionalDirs: row.meta.additionalDirs }
       : {}),
   };
 
@@ -939,21 +892,63 @@ async function restoreWebSession(s: SerializedWebSession): Promise<void> {
     fireBackendStateIfChanged
   );
 
-  // Restore persisted message buffer so reconnecting clients see transcript
-  if (s.messages && s.messages.length > 0) {
-    session.messages = s.messages.slice(-1000);
-  }
-  if (s.agentSessionV2) {
-    session.agentSessionV2 = s.agentSessionV2;
-  }
-  if (s.agentPatchesV2 && s.agentPatchesV2.length > 0) {
-    session.agentPatchesV2 = s.agentPatchesV2.slice(-1000);
+  // Replace the freshly-created blank transcript with the persisted one.
+  session.agentSessionV2 = row.agentSessionV2;
+  session.customCommand = row.meta.customCommand;
+  if (row.meta.needsBranchRename) {
+    session.needsBranchRename = true;
   }
 
-  // If the adapter supports resume and we have a stored provider session ID,
-  // reconnect via resumeSession so the provider reattaches to the prior conversation.
-  // This replaces the fresh connect done by createWebSession above.
-  await reconnectWebSession(session);
+  // Persist immediately so the freshly-restored row reflects current state
+  // (vendor may not assign a new id, but live status flips).
+  upsertWebSessionNow(session);
+
+  // If the adapter supports resume and we have a stored vendor session ID,
+  // reconnect via resumeSession so the provider continues the conversation.
+  // On failure, surface a single client-source errorMessage into the timeline
+  // and leave session disconnected — user must start a fresh session.
+  try {
+    await reconnectWebSession(session);
+  } catch (err) {
+    surfaceResumeFailure(session, err);
+  }
+}
+
+function surfaceResumeFailure(session: WebSession, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  const timestamp = new Date().toISOString();
+  const errorPatch: import('../shared/agent-chat-protocol-v2.js').AgentItemStartedPatchV2 = {
+    type: 'agent-item-started-v2',
+    sessionId: session.id,
+    timestamp,
+    turnId: session.agentSessionV2.live.activeTurnId ?? 'resume-failed',
+    item: {
+      type: 'errorMessage',
+      id: `error-resume-${timestamp}`,
+      message: `Resume failed: ${session.adapterType} session expired or rotated. Start a new session to continue. (${message})`,
+      source: 'client',
+      context: 'resume',
+      status: 'completed',
+      startedAt: timestamp,
+      completedAt: timestamp,
+    },
+  };
+  applyWebSessionPatchV2(session, errorPatch);
+
+  const liveStatePatch: import('../shared/agent-chat-protocol-v2.js').AgentLiveStateUpdatedPatchV2 = {
+    type: 'agent-live-state-updated-v2',
+    sessionId: session.id,
+    timestamp,
+    live: {
+      status: 'disconnected',
+      activeTurnId: null,
+      waitingOn: null,
+      activeRequestIds: [],
+      error: 'resume failed',
+    },
+  };
+  applyWebSessionPatchV2(session, liveStatePatch);
+  upsertWebSessionNow(session);
 }
 
 function syncDisplayNameCounters(): void {
@@ -972,71 +967,72 @@ async function restoreFromDisk(
   workspaces?: string[],
   frameworks?: Record<string, Partial<AgentFramework>>
 ): Promise<number> {
-  const pendingPath = path.join(configDir, 'pending-sessions.json');
-  if (!fs.existsSync(pendingPath)) return 0;
-
-  const pending = readPendingSessionsFile(pendingPath);
-  if (!pending) return 0;
-
-  // Ignore stale files (>5 minutes old)
-  if (Date.now() - new Date(pending.timestamp).getTime() > STALE_THRESHOLD_MS) {
-    fs.unlinkSync(pendingPath);
-    return 0;
-  }
-
-  if (pending.version <= 2) {
-    migrateV2ToV3(pending.sessions, workspaces ?? []);
-  }
-
-  if (pending.version <= 3) {
-    migrateV3ToV4(pending.sessions);
-  }
-
-  const scrollbackDirPath = path.join(configDir, 'scrollback');
   let restored = 0;
 
-  for (const s of pending.sessions) {
-    const scrollbackPath = path.join(scrollbackDirPath, s.id + '.buf');
-    const initialScrollback = loadScrollback(scrollbackDirPath, s.id);
+  const pendingPath = path.join(configDir, 'pending-sessions.json');
+  if (fs.existsSync(pendingPath)) {
+    const pending = readPendingSessionsFile(pendingPath);
+    if (
+      pending &&
+      Date.now() - new Date(pending.timestamp).getTime() <= STALE_THRESHOLD_MS
+    ) {
+      if (pending.version <= 2) {
+        migrateV2ToV3(pending.sessions, workspaces ?? []);
+      }
+      if (pending.version <= 3) {
+        migrateV3ToV4(pending.sessions);
+      }
 
-    const spawn = await resolveSessionSpawnParams(s, frameworks);
+      const scrollbackDirPath = path.join(configDir, 'scrollback');
+      for (const s of pending.sessions) {
+        const scrollbackPath = path.join(scrollbackDirPath, s.id + '.buf');
+        const initialScrollback = loadScrollback(scrollbackDirPath, s.id);
 
-    try {
-      restoreSession(s, spawn, initialScrollback);
-      restored++;
-    } catch (err) {
-      logger.error(`Failed to restore session ${s.id} (${s.displayName})`, err);
+        const spawn = await resolveSessionSpawnParams(s, frameworks);
+
+        try {
+          restoreSession(s, spawn, initialScrollback);
+          restored++;
+        } catch (err) {
+          logger.error(
+            `Failed to restore session ${s.id} (${s.displayName})`,
+            err
+          );
+        }
+
+        try {
+          fs.unlinkSync(scrollbackPath);
+        } catch {
+          /* ignore */
+        }
+      }
     }
 
     try {
-      fs.unlinkSync(scrollbackPath);
+      fs.unlinkSync(pendingPath);
     } catch {
       /* ignore */
     }
-  }
-
-  // Restore web sessions (v5+)
-  for (const s of pending.webSessions ?? []) {
     try {
-      await restoreWebSession(s);
-      restored++;
-    } catch (err) {
-      logger.error(
-        `Failed to restore web session ${s.id} (${s.displayName})`,
-        err
-      );
+      fs.rmdirSync(path.join(configDir, 'scrollback'));
+    } catch {
+      /* ignore — may not be empty */
     }
   }
 
-  try {
-    fs.unlinkSync(pendingPath);
-  } catch {
-    /* ignore */
-  }
-  try {
-    fs.rmdirSync(path.join(configDir, 'scrollback'));
-  } catch {
-    /* ignore — may not be empty */
+  // Web sessions live in relay-state.db. No staleness wipe — DB rows persist
+  // until user archives or closes the session.
+  const dbRows = loadAllWebSessions();
+  for (const row of dbRows) {
+    try {
+      await restoreWebSessionFromDb(row);
+      restored++;
+    } catch (err) {
+      logger.error(
+        `Failed to restore web session ${row.id} (${row.displayName ?? '<unnamed>'})`,
+        err
+      );
+    }
   }
 
   syncDisplayNameCounters();

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -917,38 +917,77 @@ async function restoreWebSessionFromDb(
 function surfaceResumeFailure(session: WebSession, err: unknown): void {
   const message = err instanceof Error ? err.message : String(err);
   const timestamp = new Date().toISOString();
-  const errorPatch: import('../shared/agent-chat-protocol-v2.js').AgentItemStartedPatchV2 = {
-    type: 'agent-item-started-v2',
-    sessionId: session.id,
-    timestamp,
-    turnId: session.agentSessionV2.live.activeTurnId ?? 'resume-failed',
-    item: {
-      type: 'errorMessage',
-      id: `error-resume-${timestamp}`,
-      message: `Resume failed: ${session.adapterType} session expired or rotated. Start a new session to continue. (${message})`,
-      source: 'client',
-      context: 'resume',
-      status: 'completed',
-      startedAt: timestamp,
-      completedAt: timestamp,
-    },
-  };
+
+  // applyAgentPatchV2 only updates existing turns. After restore the active
+  // turn is normally null, so we must aim the error at an existing turn (the
+  // last one we have on the timeline) or synthesize a turn first when the
+  // session has no turns yet. This mirrors the agent-error-v2 fallback.
+  const targetTurnId = resolveResumeFailureTurnId(session, timestamp);
+
+  const errorPatch: import('../shared/agent-chat-protocol-v2.js').AgentItemStartedPatchV2 =
+    {
+      type: 'agent-item-started-v2',
+      sessionId: session.id,
+      timestamp,
+      turnId: targetTurnId,
+      item: {
+        type: 'errorMessage',
+        id: `error-resume-${timestamp}`,
+        message: `Resume failed: ${session.adapterType} session expired or rotated. Start a new session to continue. (${message})`,
+        source: 'client',
+        context: 'resume',
+        status: 'completed',
+        startedAt: timestamp,
+        completedAt: timestamp,
+      },
+    };
   applyWebSessionPatchV2(session, errorPatch);
 
-  const liveStatePatch: import('../shared/agent-chat-protocol-v2.js').AgentLiveStateUpdatedPatchV2 = {
-    type: 'agent-live-state-updated-v2',
-    sessionId: session.id,
-    timestamp,
-    live: {
-      status: 'disconnected',
-      activeTurnId: null,
-      waitingOn: null,
-      activeRequestIds: [],
-      error: 'resume failed',
-    },
-  };
+  const liveStatePatch: import('../shared/agent-chat-protocol-v2.js').AgentLiveStateUpdatedPatchV2 =
+    {
+      type: 'agent-live-state-updated-v2',
+      sessionId: session.id,
+      timestamp,
+      live: {
+        status: 'disconnected',
+        activeTurnId: null,
+        waitingOn: null,
+        activeRequestIds: [],
+        error: 'resume failed',
+      },
+    };
   applyWebSessionPatchV2(session, liveStatePatch);
   upsertWebSessionNow(session);
+}
+
+function resolveResumeFailureTurnId(
+  session: WebSession,
+  timestamp: string
+): string {
+  const live = session.agentSessionV2.live.activeTurnId;
+  if (typeof live === 'string' && live.length > 0) return live;
+
+  const turns = session.agentSessionV2.turns;
+  const lastTurn = turns[turns.length - 1];
+  if (lastTurn) return lastTurn.id;
+
+  const syntheticTurnId = `resume-failed-${timestamp}`;
+  const turnPatch: import('../shared/agent-chat-protocol-v2.js').AgentTurnStartedPatchV2 =
+    {
+      type: 'agent-turn-started-v2',
+      sessionId: session.id,
+      timestamp,
+      turn: {
+        id: syntheticTurnId,
+        status: 'failed',
+        inputMessageId: '',
+        items: [],
+        startedAt: timestamp,
+        completedAt: timestamp,
+      },
+    };
+  applyWebSessionPatchV2(session, turnPatch);
+  return syntheticTurnId;
 }
 
 function syncDisplayNameCounters(): void {

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -10,7 +10,7 @@ import {
   applyWebSessionPatchV2,
   createInitialAgentSessionV2,
 } from './web-session-v2-state.js';
-import { upsertWebSessionNow, deleteWebSession } from './relay-state-db.js';
+import { upsertWebSessionNow } from './relay-state-db.js';
 
 const logger = createLogger('web-session');
 const MESSAGE_BUFFER_MAX = 1000;
@@ -201,12 +201,15 @@ export async function reconnectWebSession(session: WebSession): Promise<void> {
     });
     await adapterV2.resumeSession(providerSessionId);
   } else {
-    logger.info('reconnecting web session (no resume capability or no stored id)', {
-      id: session.id,
-      agentType: session.adapterType,
-      hasResume: capabilities.resume,
-      hasProviderId: Boolean(providerSessionId),
-    });
+    logger.info(
+      'reconnecting web session (no resume capability or no stored id)',
+      {
+        id: session.id,
+        agentType: session.adapterType,
+        hasResume: capabilities.resume,
+        hasProviderId: Boolean(providerSessionId),
+      }
+    );
     await adapterV2.reconnect();
   }
 }

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -10,6 +10,7 @@ import {
   applyWebSessionPatchV2,
   createInitialAgentSessionV2,
 } from './web-session-v2-state.js';
+import { upsertWebSessionNow, deleteWebSession } from './relay-state-db.js';
 
 const logger = createLogger('web-session');
 const MESSAGE_BUFFER_MAX = 1000;
@@ -149,6 +150,8 @@ export async function createWebSession(
   }
 
   logger.info('web session created', { id, agentType: params.agentType });
+
+  upsertWebSessionNow(session);
 
   return { session };
 }

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -58,7 +58,8 @@ export function pushToBuffer(session: WebSession, event: ChatEvent): void {
 export async function createWebSession(
   params: CreateWebParams,
   sessionsMap: Map<string, Session>,
-  onBackendStateChanged: (session: Session) => void
+  onBackendStateChanged: (session: Session) => void,
+  options: { skipInitialPersist?: boolean } = {}
 ): Promise<{ session: WebSession }> {
   const id = params.id ?? crypto.randomBytes(8).toString('hex');
   const adapterV2 = createAdapterV2(params.agentType);
@@ -151,7 +152,12 @@ export async function createWebSession(
 
   logger.info('web session created', { id, agentType: params.agentType });
 
-  upsertWebSessionNow(session);
+  // Restore path passes skipInitialPersist=true so the freshly-created blank
+  // transcript doesn't overwrite the persisted row before sessions.ts copies
+  // back agentSessionV2.
+  if (!options.skipInitialPersist) {
+    upsertWebSessionNow(session);
+  }
 
   return { session };
 }

--- a/server/web-session-v2-state.ts
+++ b/server/web-session-v2-state.ts
@@ -7,6 +7,7 @@ import {
 } from '../shared/agent-chat-protocol-v2.js';
 import type { AgentCapabilitySetV2 } from '../shared/agent-chat-protocol-v2.js';
 import type { WebSession } from './types.js';
+import { scheduleWebSessionUpsert } from './relay-state-db.js';
 
 const AGENT_PATCH_BUFFER_MAX = 1000;
 
@@ -54,6 +55,7 @@ export function applyWebSessionPatchV2(
 ): void {
   session.agentSessionV2 = applyAgentPatchV2(session.agentSessionV2, patch);
   pushAgentPatchToBuffer(session, patch);
+  scheduleWebSessionUpsert(session);
 }
 
 export function pushAgentPatchToBuffer(

--- a/test/server/relay-state-db.test.ts
+++ b/test/server/relay-state-db.test.ts
@@ -1,0 +1,164 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  initRelayStateDb,
+  closeRelayStateDb,
+  upsertWebSessionNow,
+  scheduleWebSessionUpsert,
+  flushAllPendingWrites,
+  loadAllWebSessions,
+  deleteWebSession,
+  markWebSessionStatus,
+} from '../../server/relay-state-db.js';
+import type { WebSession } from '../../server/types.js';
+import { emptyAgentSessionV2 } from '../../shared/agent-chat-protocol-v2.js';
+
+vi.mock('../../server/logger.js', () => ({
+  createLogger: () => ({
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+function fakeWebSession(overrides: Partial<WebSession> = {}): WebSession {
+  const base = {
+    mode: 'web' as const,
+    id: 'sess-1',
+    type: 'agent' as const,
+    agent: 'claude' as WebSession['agent'],
+    repoPath: '/repo',
+    worktreePath: null,
+    cwd: '/repo',
+    repoName: 'repo',
+    branchName: 'main',
+    displayName: 'Agent 1',
+    createdAt: new Date('2026-04-29T00:00:00Z').toISOString(),
+    lastActivity: new Date('2026-04-29T00:00:01Z').toISOString(),
+    idle: true,
+    customCommand: null,
+    status: 'active' as const,
+    needsBranchRename: false,
+    agentState: 'initializing' as const,
+    adapter: {
+      disconnect: () => Promise.resolve(),
+    } as unknown as WebSession['adapter'],
+    adapterV2: {
+      disconnect: () => Promise.resolve(),
+    } as unknown as WebSession['adapterV2'],
+    adapterType: 'claude',
+    agentSessionV2: emptyAgentSessionV2({
+      id: 'sess-1',
+      provider: 'claude',
+      cwd: '/repo',
+      capabilities: { resume: true },
+      providerSession: { claudeSessionId: 'claude-abc' },
+    }),
+    agentPatchesV2: [],
+    protocolVersion: 2 as const,
+    messages: [],
+    currentTurnId: null,
+    runtimeOwnership: 'spawned' as const,
+    hookToken: 'tok',
+    hooksActive: true,
+  };
+  return { ...base, ...overrides } as WebSession;
+}
+
+describe('relay-state-db', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-state-db-'));
+    initRelayStateDb(dir);
+  });
+
+  afterEach(() => {
+    closeRelayStateDb();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('upserts and round-trips a web session', () => {
+    const session = fakeWebSession();
+    upsertWebSessionNow(session);
+
+    const rows = loadAllWebSessions();
+    expect(rows).toHaveLength(1);
+    const row = rows[0]!;
+    expect(row.id).toBe('sess-1');
+    expect(row.vendor).toBe('claude');
+    expect(row.vendorSessionId).toBe('claude-abc');
+    expect(row.agentSessionV2.id).toBe('sess-1');
+    expect(row.meta.adapterType).toBe('claude');
+    expect(row.status).toBe('active');
+  });
+
+  it('overwrites on second upsert (same id)', () => {
+    const session = fakeWebSession();
+    upsertWebSessionNow(session);
+
+    const updated = fakeWebSession({ displayName: 'Renamed' });
+    upsertWebSessionNow(updated);
+
+    const rows = loadAllWebSessions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.displayName).toBe('Renamed');
+  });
+
+  it('debounces scheduled upserts and flushes on demand', async () => {
+    const session = fakeWebSession();
+    scheduleWebSessionUpsert(session);
+
+    expect(loadAllWebSessions()).toHaveLength(0);
+
+    flushAllPendingWrites();
+    expect(loadAllWebSessions()).toHaveLength(1);
+  });
+
+  it('immediate upsert cancels pending debounce for the same id', () => {
+    const session = fakeWebSession();
+    scheduleWebSessionUpsert(session);
+    upsertWebSessionNow({ ...session, displayName: 'Forced' } as WebSession);
+
+    flushAllPendingWrites();
+
+    const rows = loadAllWebSessions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.displayName).toBe('Forced');
+  });
+
+  it('deleteWebSession removes the row', () => {
+    const session = fakeWebSession();
+    upsertWebSessionNow(session);
+    expect(loadAllWebSessions()).toHaveLength(1);
+
+    deleteWebSession(session.id);
+    expect(loadAllWebSessions()).toHaveLength(0);
+  });
+
+  it('markWebSessionStatus archived hides row from load', () => {
+    const session = fakeWebSession();
+    upsertWebSessionNow(session);
+
+    markWebSessionStatus(session.id, 'archived');
+    expect(loadAllWebSessions()).toHaveLength(0);
+  });
+
+  it('persists empty providerSession as null vendor_session_id', () => {
+    const session = fakeWebSession();
+    session.agentSessionV2 = emptyAgentSessionV2({
+      id: 'sess-1',
+      provider: 'claude',
+      cwd: '/repo',
+      capabilities: {},
+    });
+    upsertWebSessionNow(session);
+
+    const rows = loadAllWebSessions();
+    expect(rows[0]!.vendorSessionId).toBeNull();
+  });
+});

--- a/test/server/relay-state-db.test.ts
+++ b/test/server/relay-state-db.test.ts
@@ -148,6 +148,37 @@ describe('relay-state-db', () => {
     expect(loadAllWebSessions()).toHaveLength(0);
   });
 
+  it('archived status survives subsequent upserts', () => {
+    const session = fakeWebSession();
+    upsertWebSessionNow(session);
+    markWebSessionStatus(session.id, 'archived');
+
+    // Simulate a late patch arriving after archive — must not revive.
+    upsertWebSessionNow({ ...session, displayName: 'Late' } as WebSession);
+
+    expect(loadAllWebSessions()).toHaveLength(0);
+  });
+
+  it('throttle bound: scheduled writes fire even under continuous bursts', async () => {
+    const session = fakeWebSession();
+
+    // Hammer the scheduler — pure debounce would never fire under this load.
+    for (let i = 0; i < 5; i++) {
+      scheduleWebSessionUpsert({
+        ...session,
+        displayName: `iter-${i}`,
+      } as WebSession);
+      await new Promise((r) => setTimeout(r, 200));
+    }
+
+    // Within ~MAX_WAIT_MS (1000ms) the first burst should have flushed.
+    await new Promise((r) => setTimeout(r, 200));
+
+    const rows = loadAllWebSessions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.displayName).toMatch(/^iter-/);
+  });
+
   it('persists empty providerSession as null vendor_session_id', () => {
     const session = fakeWebSession();
     session.agentSessionV2 = emptyAgentSessionV2({

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -815,7 +815,7 @@ describe('session persistence', () => {
     const pendingPath = path.join(configDir, 'pending-sessions.json');
     expect(fs.existsSync(pendingPath)).toBeTruthy();
     const pending = JSON.parse(fs.readFileSync(pendingPath, 'utf-8'));
-    expect(pending.version).toBe(5);
+    expect(pending.version).toBe(6);
     expect(pending.timestamp).toBeTruthy();
     expect(pending.sessions.length).toBe(1);
     expect(pending.sessions[0].id).toBe(s.id);
@@ -1199,7 +1199,7 @@ describe('session persistence', () => {
     const pending = JSON.parse(
       fs.readFileSync(path.join(configDir, 'pending-sessions.json'), 'utf-8')
     );
-    expect(pending.version).toBe(5);
+    expect(pending.version).toBe(6);
     expect(pending.sessions[0].yolo).toBe(true);
 
     await restoreFromDisk(configDir);
@@ -1429,7 +1429,7 @@ describe('session persistence', () => {
     const pendingPath = path.join(configDir, 'pending-sessions.json');
     expect(fs.existsSync(pendingPath)).toBeTruthy();
     const pending = JSON.parse(fs.readFileSync(pendingPath, 'utf-8'));
-    expect(pending.version).toBe(5);
+    expect(pending.version).toBe(6);
     expect(pending.sessions[0].repoPath).toBe('/tmp');
     expect('workspacePath' in pending.sessions[0]).toBe(false);
   });


### PR DESCRIPTION
## Summary

Stacked on #321. Persists web (V2) session transcript + metadata to a new SQLite store at `<configDir>/relay-state.db`. PTY sessions stay on the JSON path; `pending-sessions.json` bumped to v6 (PTY-only).

Plan: `docs/plans/2026-04-29-web-session-persistence-sqlite.md`.

### Why

Prior path:
- Flushed only on graceful shutdown (`SIGTERM`/`SIGINT` or update-restart).
- Wiped any state file older than 5 minutes on startup.
- Lost everything on hard kill / crash.

Restarts mid-session wiped chat history. Web sessions need a real store.

### What changed

- New `server/relay-state-db.ts`. `web_sessions` table, single row per session, full `agent_session_v2_json` blob plus denormalized `vendor_session_id`. WAL + `synchronous = NORMAL`. Schema versioned, mirrors `analytics.ts` pattern.
- 1s debounced `scheduleWebSessionUpsert` collapses streaming-delta storms; immediate `upsertWebSessionNow` for structural events (create/close/vendor-id assignment/shutdown).
- `applyWebSessionPatchV2` wired to schedule upserts.
- `restoreFromDisk` loads web sessions from the DB; PTY path unchanged.
- Resume failure surface: when `adapter.resume()` rejects on restore, push a synthetic `errorMessage` (`source: client`, `context: resume`) into the timeline and flip live status to `disconnected`. User sees it in the chat itself, not as a silent drop. Per #318, "Continue here" recovery is deferred.

### What was deferred

- "Continue here" recovery on resume failure — #318.
- PTY migration to SQLite + vendor session import — #319.

### Tests

- New `test/server/relay-state-db.test.ts` — 7 cases: roundtrip, idempotent upsert, debounce + flush, immediate-cancels-debounce, delete, archive hides row, null vendor id.
- `test/sessions.test.ts` bumped to assert v6.
- 1598/1598 pass.

### Migration

Per agreement, no migration shipped — fresh data starts here. Old `pending-sessions.json` web entries (if any) are simply abandoned on first run with this PR.

## Test plan

- [x] All vitest pass.
- [ ] Restart server mid-session; verify chat history survives.
- [ ] Hard-kill server (SIGKILL); verify state from last debounced flush survives.
- [ ] Stale `claudeSessionId` triggers resume failure → verify `errorMessage` appears + status `disconnected`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Web sessions now persist to SQLite database instead of JSON files for improved reliability.
  * Server automatically flushes pending session updates on shutdown and restart.

* **Documentation**
  * Added planning documentation for web session SQLite migration strategy.

* **Tests**
  * Added comprehensive test suite for database persistence layer and updated session persistence tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->