### PR TITLE
fix(chat): coderabbit follow-up on PR #321 (post-merge)

### DIFF
--- a/frontend/src/components/chat/Composer.tsx
+++ b/frontend/src/components/chat/Composer.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import './Composer.css';
 import type {
   AgentCapabilitySetV2,
@@ -104,7 +110,10 @@ export const Composer: React.FC<ComposerProps> = ({
     if (el) setCaret(el.selectionStart ?? 0);
   }, []);
 
-  const commandIndex = slashCommands ? buildCommandIndex(slashCommands) : null;
+  const commandIndex = useMemo(
+    () => (slashCommands ? buildCommandIndex(slashCommands) : null),
+    [slashCommands]
+  );
 
   /** Submit-time validation per §4.4 */
   const validateAndSend = useCallback(
@@ -284,21 +293,31 @@ export const Composer: React.FC<ComposerProps> = ({
     ctxWindow > 0
       ? `${formatTokens(ctxUsed)} / ${formatTokens(ctxWindow)}`
       : '—';
-  const segments =
-    ctxWindow > 0
-      ? [
-          { name: 'input', tokens: ctxInputUncached, color: 'var(--accent)' },
-          { name: 'cached', tokens: ctxCached, color: 'var(--status-info)' },
-          { name: 'output', tokens: ctxOutput, color: 'var(--status-success)' },
-          {
-            name: 'reasoning',
-            tokens: ctxReasoning,
-            color: 'var(--status-warning)',
-          },
-        ]
-      : [];
-  const segmentPct = (n: number): number =>
-    ctxWindow > 0 ? Math.min(100, (n / ctxWindow) * 100) : 0;
+  const segments = useMemo(
+    () =>
+      ctxWindow > 0
+        ? [
+            { name: 'input', tokens: ctxInputUncached, color: 'var(--accent)' },
+            { name: 'cached', tokens: ctxCached, color: 'var(--status-info)' },
+            {
+              name: 'output',
+              tokens: ctxOutput,
+              color: 'var(--status-success)',
+            },
+            {
+              name: 'reasoning',
+              tokens: ctxReasoning,
+              color: 'var(--status-warning)',
+            },
+          ]
+        : [],
+    [ctxWindow, ctxInputUncached, ctxCached, ctxOutput, ctxReasoning]
+  );
+  const segmentPct = useCallback(
+    (n: number): number =>
+      ctxWindow > 0 ? Math.min(100, (n / ctxWindow) * 100) : 0,
+    [ctxWindow]
+  );
   const usedPct = segmentPct(ctxUsed);
   const [ctxPopOpen, setCtxPopOpen] = useState(false);
   const ctxAnchorRef = useRef<HTMLSpanElement>(null);
@@ -334,9 +353,10 @@ export const Composer: React.FC<ComposerProps> = ({
   );
 
   // Build overlay segments for composer highlight
-  const overlaySegments = commandIndex
-    ? renderInlineSkillTokens(draft, commandIndex)
-    : null;
+  const overlaySegments = useMemo(
+    () => (commandIndex ? renderInlineSkillTokens(draft, commandIndex) : null),
+    [commandIndex, draft]
+  );
 
   return (
     <div className="slash-anchor">

--- a/server/protocol-adapters/legacy-v2-bridge.ts
+++ b/server/protocol-adapters/legacy-v2-bridge.ts
@@ -60,15 +60,17 @@ export class LegacyProtocolAdapterV2Bridge extends BaseProtocolAdapterV2 {
     return this.inner.status;
   }
 
-  async connect(config: AdapterConfig): Promise<void> {
+  private subscribePatches(): void {
     this.unlisten?.();
-    this.unlisten = null;
-
     this.unlisten = this.inner.on((event) => {
       for (const patch of mapChatEventToAgentPatchV2(event)) {
         this.emitPatch(patch);
       }
     });
+  }
+
+  async connect(config: AdapterConfig): Promise<void> {
+    this.subscribePatches();
     try {
       await this.inner.connect(config);
     } catch (error) {
@@ -85,7 +87,14 @@ export class LegacyProtocolAdapterV2Bridge extends BaseProtocolAdapterV2 {
   }
 
   async reconnect(): Promise<void> {
-    await this.inner.reconnect();
+    this.subscribePatches();
+    try {
+      await this.inner.reconnect();
+    } catch (error) {
+      this.unlisten?.();
+      this.unlisten = null;
+      throw error;
+    }
   }
 
   async resumeSession(_sessionId: string): Promise<void> {

--- a/shared/agent-chat-protocol-v2.ts
+++ b/shared/agent-chat-protocol-v2.ts
@@ -573,14 +573,14 @@ export function isAgentPatchV2(value: unknown): value is AgentPatchV2 {
     case 'agent-session-updated-v2':
       return (
         (value.providerSession === undefined ||
-          isRecord(value.providerSession)) &&
+          isProviderSession(value.providerSession)) &&
         (value.capabilities === undefined || isRecord(value.capabilities)) &&
-        (value.config === undefined || isRecord(value.config)) &&
+        (value.config === undefined || isPartialSessionConfig(value.config)) &&
         (value.slashCommands === undefined ||
-          Array.isArray(value.slashCommands))
+          isSlashCommandArray(value.slashCommands))
       );
     case 'agent-live-state-updated-v2':
-      return isRecord(value.live);
+      return isPartialLiveState(value.live);
     case 'agent-turn-started-v2':
       return isTurn(value.turn);
     case 'agent-item-started-v2':
@@ -864,7 +864,16 @@ function appendStringField<K extends keyof AgentItemDeltaPatchV2['delta']>(
   const fragment = delta[key];
   const current = (item as unknown as Record<string, unknown>)[key];
 
-  if (typeof fragment !== 'string' || typeof current !== 'string') {
+  if (typeof fragment !== 'string') {
+    return item;
+  }
+  if (current === undefined) {
+    return {
+      ...item,
+      [key]: fragment,
+    } as AgentItemV2;
+  }
+  if (typeof current !== 'string') {
     return item;
   }
 
@@ -944,8 +953,95 @@ function isSession(value: unknown): value is AgentSessionV2 {
     typeof value.config.cwd === 'string' &&
     isLiveState(value.live) &&
     Array.isArray(value.turns) &&
-    value.turns.every(isTurn)
+    value.turns.every(isTurn) &&
+    (value.providerSession === undefined ||
+      isProviderSession(value.providerSession)) &&
+    (value.slashCommands === undefined ||
+      isSlashCommandArray(value.slashCommands))
   );
+}
+
+function isProviderSession(value: unknown): value is Record<string, string> {
+  if (!isRecord(value)) return false;
+  for (const v of Object.values(value)) {
+    if (typeof v !== 'string') return false;
+  }
+  return true;
+}
+
+function isPartialSessionConfig(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (value.cwd !== undefined && typeof value.cwd !== 'string') return false;
+  if (value.model !== undefined && typeof value.model !== 'string')
+    return false;
+  if (value.effort !== undefined && typeof value.effort !== 'string')
+    return false;
+  if (
+    value.permissionMode !== undefined &&
+    typeof value.permissionMode !== 'string'
+  ) {
+    return false;
+  }
+  if (
+    value.additionalDirectories !== undefined &&
+    !(
+      Array.isArray(value.additionalDirectories) &&
+      value.additionalDirectories.every((d) => typeof d === 'string')
+    )
+  ) {
+    return false;
+  }
+  if (value.providerOptions !== undefined && !isRecord(value.providerOptions)) {
+    return false;
+  }
+  return true;
+}
+
+function isSlashCommandArray(value: unknown): boolean {
+  return Array.isArray(value) && value.every(isSlashCommand);
+}
+
+function isSlashCommand(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (typeof value.name !== 'string') return false;
+  if (value.id !== undefined && typeof value.id !== 'string') return false;
+  if (value.description !== undefined && typeof value.description !== 'string')
+    return false;
+  if (
+    value.argumentHint !== undefined &&
+    typeof value.argumentHint !== 'string'
+  ) {
+    return false;
+  }
+  if (
+    value.aliases !== undefined &&
+    !(
+      Array.isArray(value.aliases) &&
+      value.aliases.every((a) => typeof a === 'string')
+    )
+  ) {
+    return false;
+  }
+  if (value.source !== undefined && typeof value.source !== 'string') {
+    return false;
+  }
+  if (
+    value.dispatch !== undefined &&
+    !(
+      value.dispatch === 'agent' ||
+      value.dispatch === 'relay-control' ||
+      value.dispatch === 'client'
+    )
+  ) {
+    return false;
+  }
+  if (
+    value.nativePrefix !== undefined &&
+    !(value.nativePrefix === '/' || value.nativePrefix === '$')
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function isLiveState(value: unknown): value is AgentSessionLiveStateV2 {
@@ -967,6 +1063,69 @@ function isLiveState(value: unknown): value is AgentSessionLiveStateV2 {
     typeof value.fastModeAvailable === 'boolean' &&
     (value.error === null || typeof value.error === 'string')
   );
+}
+
+function isPartialLiveState(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (
+    value.status !== undefined &&
+    !(typeof value.status === 'string' && LIVE_STATUSES.has(value.status))
+  ) {
+    return false;
+  }
+  if (
+    value.activeTurnId !== undefined &&
+    value.activeTurnId !== null &&
+    typeof value.activeTurnId !== 'string'
+  ) {
+    return false;
+  }
+  if (
+    value.waitingOn !== undefined &&
+    value.waitingOn !== null &&
+    !(
+      typeof value.waitingOn === 'string' &&
+      WAITING_ON_VALUES.has(value.waitingOn)
+    )
+  ) {
+    return false;
+  }
+  if (
+    value.activeRequestIds !== undefined &&
+    !(
+      Array.isArray(value.activeRequestIds) &&
+      value.activeRequestIds.every((r) => typeof r === 'string')
+    )
+  ) {
+    return false;
+  }
+  if (
+    value.proposedPlanItemId !== undefined &&
+    value.proposedPlanItemId !== null &&
+    typeof value.proposedPlanItemId !== 'string'
+  ) {
+    return false;
+  }
+  if (
+    value.queueLength !== undefined &&
+    typeof value.queueLength !== 'number'
+  ) {
+    return false;
+  }
+  if (
+    value.fastModeAvailable !== undefined &&
+    typeof value.fastModeAvailable !== 'boolean'
+  ) {
+    return false;
+  }
+  if (
+    value.error !== undefined &&
+    value.error !== null &&
+    typeof value.error !== 'string'
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function isDelta(value: unknown): value is AgentItemDeltaPatchV2['delta'] {


### PR DESCRIPTION
## Summary

Addresses outstanding CodeRabbit findings from the most recent re-review of PR #321 (merged into nightly as e94eb92). Originally PR #323 — auto-closed when base branch \`stack/web-session-sqlite\` was deleted on squash-merge of #322.

### Critical
- **legacy-v2-bridge.reconnect()** now re-establishes the inner adapter listener. Previously, after a disconnect/reconnect cycle, no patches were forwarded because \`onDisconnect\` cleared \`this.unlisten\`. Extracted shared \`subscribePatches()\` helper used by both \`connect()\` and \`reconnect()\`; both unwind the listener on failure.

### Major
- **appendStringField** seeds optional fields with the first delta fragment instead of dropping it. Previously \`detail\` / \`patch\` / \`content\` lost their first chunk if the started item omitted the field.
- **Wire validators tightened.** Malformed websocket payloads can no longer pass \`isAgentPatchV2\` and poison shared state:
  - \`agent-live-state-updated-v2\` validates each \`Partial<AgentSessionLiveStateV2>\` field shape via new \`isPartialLiveState\`.
  - \`agent-session-updated-v2\` validates \`providerSession\` (\`Record<string,string>\`), \`config\` keys, and \`slashCommands\` array shape.
  - \`isSession\` validates optional \`providerSession\` + \`slashCommands\`.

### Nitpicks
- Composer: memoize \`commandIndex\`, \`segments\`, \`segmentPct\`, \`overlaySegments\` to match React best practices and avoid rebuilding on every render.

## Skipped
- \`docs/ARCHITECTURE.md\` v2 protocol adapter doc update — separate scope, not blocking.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` 1600/1600 pass
- [x] \`npm run lint\` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)