### PR TITLE
fix(chat): coderabbit follow-ups + tool_result lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ playwright-report/
 /.agents/.state.json
 /.agents/.state.lock
 /.agents-tmp/
+
+# Design system working files (local previews, screenshots, uploads)
+/docs/design-system/

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -566,6 +566,7 @@ export class ClaudeProtocolAdapter extends BaseProtocolAdapterV2 {
     this.sessionAbort?.abort();
     this.rejectQueued(new Error('Claude adapter disconnected'));
     this.pendingApprovals.clear();
+    this.activeToolUses.clear();
     if (this.consumeTask) {
       await this.consumeTask.catch(() => undefined);
     }
@@ -604,6 +605,7 @@ export class ClaudeProtocolAdapter extends BaseProtocolAdapterV2 {
     this.sessionAbort?.abort();
     this.rejectQueued(new Error('Claude adapter resuming'));
     this.pendingApprovals.clear();
+    this.activeToolUses.clear();
     if (this.consumeTask) {
       await this.consumeTask.catch(() => undefined);
     }

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -351,6 +351,56 @@ function filePathsFromToolInput(
   return paths.length > 0 ? paths : [{ path: 'unknown', status: 'pending' }];
 }
 
+function toolResultText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!isRecord(block)) continue;
+    if (stringField(block.type) === 'text') {
+      const text = stringField(block.text);
+      if (text) parts.push(text);
+    }
+  }
+  return parts.join('\n');
+}
+
+function patchFromFileResult(result: Record<string, unknown>): string {
+  const gitDiff = objectField(result.gitDiff);
+  const gitPatch = stringField(gitDiff.patch);
+  if (gitPatch) return gitPatch;
+
+  const hunks = result.structuredPatch;
+  if (!Array.isArray(hunks)) return '';
+  const out: string[] = [];
+  for (const hunk of hunks) {
+    if (!isRecord(hunk)) continue;
+    const oldStart = Number(hunk.oldStart) || 0;
+    const oldLines = Number(hunk.oldLines) || 0;
+    const newStart = Number(hunk.newStart) || 0;
+    const newLines = Number(hunk.newLines) || 0;
+    out.push(`@@ -${oldStart},${oldLines} +${newStart},${newLines} @@`);
+    const lines = hunk.lines;
+    if (Array.isArray(lines)) {
+      for (const line of lines) {
+        if (typeof line === 'string') out.push(line);
+      }
+    }
+  }
+  return out.join('\n');
+}
+
+function pathsFromFileResult(
+  result: Record<string, unknown>,
+  fallback: Array<{ path: string; status?: string }>
+): Array<{ path: string; status?: string }> {
+  const filePath = stringField(result.filePath);
+  if (!filePath) return fallback;
+  const gitDiff = objectField(result.gitDiff);
+  const status = stringField(gitDiff.status);
+  return [{ path: filePath, ...(status ? { status } : { status: 'edited' }) }];
+}
+
 function permissionMode(value: string | undefined): PermissionMode | undefined {
   if (
     value === 'default' ||
@@ -438,6 +488,16 @@ export class ClaudeProtocolAdapter extends BaseProtocolAdapterV2 {
   private readonly streamReasoningBuffers = new Map<string, string>();
   private streamProviderMessageId: string | null = null;
   private providerExtensionSeq = 0;
+  private readonly activeToolUses = new Map<
+    string,
+    {
+      kind: 'file' | 'exec' | 'dynamic';
+      toolName: string;
+      input: Record<string, unknown>;
+      command?: string;
+      paths?: Array<{ path: string; status?: string }>;
+    }
+  >();
 
   constructor(
     queryFn: ClaudeQueryFunction = sdkQuery as unknown as ClaudeQueryFunction
@@ -859,6 +919,12 @@ export class ClaudeProtocolAdapter extends BaseProtocolAdapterV2 {
       return;
     }
 
+    if (message.type === 'user') {
+      if (this.activeTurnId === null) return;
+      this.handleUserToolResults(this.activeTurnId, message);
+      return;
+    }
+
     if (message.type === 'result') {
       if (this.activeTurnId === null) return;
       const turnId = this.activeTurnId;
@@ -1120,12 +1186,112 @@ export class ClaudeProtocolAdapter extends BaseProtocolAdapterV2 {
     }
   }
 
+  private handleUserToolResults(
+    turnId: string,
+    message: Record<string, unknown>
+  ): void {
+    const toolUseResult = message.tool_use_result;
+    for (const block of contentBlocks(message)) {
+      if (stringField(block.type) !== 'tool_result') continue;
+      const toolUseId = stringField(block.tool_use_id);
+      if (!toolUseId) continue;
+      const tracked = this.activeToolUses.get(toolUseId);
+      if (!tracked) {
+        this.emitProviderExtension(turnId, block, 'debug');
+        continue;
+      }
+      this.activeToolUses.delete(toolUseId);
+      const isError = block.is_error === true;
+      const completedAt = nowIso();
+      const resultText = toolResultText(block.content);
+
+      if (tracked.kind === 'file') {
+        const result = isRecord(toolUseResult) ? toolUseResult : {};
+        const patch = patchFromFileResult(result);
+        const paths = pathsFromFileResult(result, tracked.paths ?? []);
+        const applyStatus = isError ? 'failed' : 'applied';
+        const status = isError ? 'failed' : 'completed';
+        this.emitPatch({
+          type: 'agent-item-updated-v2',
+          sessionId: this.sessionId,
+          timestamp: completedAt,
+          turnId,
+          item: {
+            type: 'fileChange',
+            id: `file-${toolUseId}`,
+            providerItemId: toolUseId,
+            paths,
+            ...(patch ? { patch } : {}),
+            applyStatus,
+            status,
+            completedAt,
+          },
+        });
+        continue;
+      }
+
+      if (tracked.kind === 'exec') {
+        const result = isRecord(toolUseResult) ? toolUseResult : {};
+        const stdout = stringField(result.stdout);
+        const stderr = stringField(result.stderr);
+        const output = stdout || stderr || resultText;
+        const status = isError ? 'failed' : 'completed';
+        this.emitPatch({
+          type: 'agent-item-updated-v2',
+          sessionId: this.sessionId,
+          timestamp: completedAt,
+          turnId,
+          item: {
+            type: 'commandExecution',
+            id: `exec-${toolUseId}`,
+            providerItemId: toolUseId,
+            command: tracked.command ?? '',
+            output,
+            ...(typeof result.interrupted === 'boolean'
+              ? { interactive: result.interrupted }
+              : {}),
+            status,
+            completedAt,
+          },
+        });
+        continue;
+      }
+
+      const status = isError ? 'failed' : 'completed';
+      this.emitPatch({
+        type: 'agent-item-updated-v2',
+        sessionId: this.sessionId,
+        timestamp: completedAt,
+        turnId,
+        item: {
+          type: 'dynamicToolCall',
+          id: `tool-${toolUseId}`,
+          providerItemId: toolUseId,
+          namespace: 'claude',
+          tool: tracked.toolName,
+          arguments: tracked.input,
+          ...(toolUseResult !== undefined ? { result: toolUseResult } : {}),
+          ...(resultText ? { content: resultText } : {}),
+          status,
+          completedAt,
+        },
+      });
+    }
+  }
+
   private emitToolUse(turnId: string, block: Record<string, unknown>): void {
     const toolUseId = stringField(block.id, `unknown-${Date.now()}`);
     const name = stringField(block.name, 'unknown');
     const input = objectField(block.input);
 
     if (name === 'Bash') {
+      const command = stringField(input.command, JSON.stringify(input));
+      this.activeToolUses.set(toolUseId, {
+        kind: 'exec',
+        toolName: name,
+        input,
+        command,
+      });
       this.emitPatch({
         type: 'agent-item-started-v2',
         sessionId: this.sessionId,
@@ -1135,7 +1301,7 @@ export class ClaudeProtocolAdapter extends BaseProtocolAdapterV2 {
           type: 'commandExecution',
           id: `exec-${toolUseId}`,
           providerItemId: toolUseId,
-          command: stringField(input.command, JSON.stringify(input)),
+          command,
           output: '',
           status: 'running',
           startedAt: nowIso(),
@@ -1145,6 +1311,13 @@ export class ClaudeProtocolAdapter extends BaseProtocolAdapterV2 {
     }
 
     if (name === 'Edit' || name === 'Write' || name === 'MultiEdit') {
+      const paths = filePathsFromToolInput(input);
+      this.activeToolUses.set(toolUseId, {
+        kind: 'file',
+        toolName: name,
+        input,
+        paths,
+      });
       this.emitPatch({
         type: 'agent-item-started-v2',
         sessionId: this.sessionId,
@@ -1154,7 +1327,7 @@ export class ClaudeProtocolAdapter extends BaseProtocolAdapterV2 {
           type: 'fileChange',
           id: `file-${toolUseId}`,
           providerItemId: toolUseId,
-          paths: filePathsFromToolInput(input),
+          paths,
           applyStatus: 'pending',
           status: 'pending',
           startedAt: nowIso(),
@@ -1163,6 +1336,11 @@ export class ClaudeProtocolAdapter extends BaseProtocolAdapterV2 {
       return;
     }
 
+    this.activeToolUses.set(toolUseId, {
+      kind: 'dynamic',
+      toolName: name,
+      input,
+    });
     this.emitPatch({
       type: 'agent-item-started-v2',
       sessionId: this.sessionId,
@@ -1212,6 +1390,7 @@ export class ClaudeProtocolAdapter extends BaseProtocolAdapterV2 {
     this.streamTextBuffers.clear();
     this.streamReasoningBuffers.clear();
     this.streamProviderMessageId = null;
+    this.activeToolUses.clear();
     this.emitLiveState({
       status: this.queue.length > 0 ? 'working' : 'idle',
       activeTurnId: null,

--- a/shared/agent-chat-protocol-v2.ts
+++ b/shared/agent-chat-protocol-v2.ts
@@ -971,7 +971,9 @@ function isProviderSession(value: unknown): value is Record<string, string> {
 
 function isPartialSessionConfig(value: unknown): boolean {
   if (!isRecord(value)) return false;
-  if (value.cwd !== undefined && typeof value.cwd !== 'string') return false;
+  // agent-session-updated-v2.config must not mutate cwd at runtime; reject any
+  // payload that tries to set it (even to undefined explicitly).
+  if (Object.hasOwn(value, 'cwd')) return false;
   if (value.model !== undefined && typeof value.model !== 'string')
     return false;
   if (value.effort !== undefined && typeof value.effort !== 'string')
@@ -1023,6 +1025,17 @@ function isSlashCommand(value: unknown): boolean {
     return false;
   }
   if (value.source !== undefined && typeof value.source !== 'string') {
+    return false;
+  }
+  if (value.sourceLabel !== undefined && typeof value.sourceLabel !== 'string')
+    return false;
+  if (value.namespace !== undefined && typeof value.namespace !== 'string')
+    return false;
+  if (value.path !== undefined && typeof value.path !== 'string') return false;
+  if (
+    value.collisionKey !== undefined &&
+    typeof value.collisionKey !== 'string'
+  ) {
     return false;
   }
   if (

--- a/test/agent-chat-protocol-v2.test.ts
+++ b/test/agent-chat-protocol-v2.test.ts
@@ -305,6 +305,64 @@ describe('Agent Chat Protocol v2', () => {
     });
   });
 
+  it('rejects agent-session-updated-v2 payloads that try to mutate cwd', () => {
+    expect(
+      isAgentPatchV2({
+        type: 'agent-session-updated-v2',
+        sessionId: 's1',
+        timestamp,
+        config: { cwd: '/etc/passwd' },
+      })
+    ).toBe(false);
+
+    // model-only updates remain valid.
+    expect(
+      isAgentPatchV2({
+        type: 'agent-session-updated-v2',
+        sessionId: 's1',
+        timestamp,
+        config: { model: 'sonnet' },
+      })
+    ).toBe(true);
+  });
+
+  it('rejects malformed slash command optional string fields', () => {
+    expect(
+      isAgentPatchV2({
+        type: 'agent-session-updated-v2',
+        sessionId: 's1',
+        timestamp,
+        slashCommands: [{ name: 'foo', collisionKey: 42 }],
+      })
+    ).toBe(false);
+
+    expect(
+      isAgentPatchV2({
+        type: 'agent-session-updated-v2',
+        sessionId: 's1',
+        timestamp,
+        slashCommands: [{ name: 'foo', sourceLabel: ['nope'] }],
+      })
+    ).toBe(false);
+
+    expect(
+      isAgentPatchV2({
+        type: 'agent-session-updated-v2',
+        sessionId: 's1',
+        timestamp,
+        slashCommands: [
+          {
+            name: 'foo',
+            collisionKey: 'project:foo',
+            sourceLabel: 'project',
+            namespace: 'project',
+            path: '.claude/commands/foo.md',
+          },
+        ],
+      })
+    ).toBe(true);
+  });
+
   it('creates transcript items from legacy-compatible deltas and updates', () => {
     const withTurn = applyAgentPatchV2(makeSession(), {
       type: 'agent-turn-started-v2',

--- a/test/server/protocol-adapters/claude-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-adapter.test.ts
@@ -146,7 +146,8 @@ function waitFor(predicate: () => boolean, timeoutMs = 500): Promise<void> {
 describe('ClaudeProtocolAdapter V2', () => {
   it('advertises the claude v2 capability set', () => {
     const adapter = new ClaudeProtocolAdapter((() => {
-      const gen: AsyncGenerator<unknown, void, unknown> = (async function* () {})();
+      const gen: AsyncGenerator<unknown, void, unknown> =
+        (async function* () {})();
       return gen as unknown as ReturnType<ClaudeQueryFunction>;
     }) as ClaudeQueryFunction);
 
@@ -199,13 +200,15 @@ describe('ClaudeProtocolAdapter V2', () => {
     await waitFor(() =>
       patches.some(
         (patch) =>
-          patch.type === 'agent-session-updated-v2' && patch.slashCommands !== undefined
+          patch.type === 'agent-session-updated-v2' &&
+          patch.slashCommands !== undefined
       )
     );
 
     const slashPatch = patches.find(
       (patch) =>
-        patch.type === 'agent-session-updated-v2' && patch.slashCommands !== undefined
+        patch.type === 'agent-session-updated-v2' &&
+        patch.slashCommands !== undefined
     );
     expect(slashPatch?.type).toBe('agent-session-updated-v2');
     expect(controller.initializationResultCalls).toBe(1);
@@ -224,11 +227,18 @@ describe('ClaudeProtocolAdapter V2', () => {
           aliases: ['rev'],
           source: 'sdk',
         }),
-        expect.objectContaining({ name: 'resume', aliases: ['continue'], source: 'relay' }),
+        expect.objectContaining({
+          name: 'resume',
+          aliases: ['continue'],
+          source: 'relay',
+        }),
       ])
     );
 
-    const sendPromise = adapter.sendMessage({ turnId: 'turn-1', content: 'hello' });
+    const sendPromise = adapter.sendMessage({
+      turnId: 'turn-1',
+      content: 'hello',
+    });
 
     await waitFor(() => controller.inputs.length > 0);
     expect(controller.inputs[0]).toMatchObject({
@@ -259,7 +269,9 @@ describe('ClaudeProtocolAdapter V2', () => {
     });
 
     await sendPromise;
-    await waitFor(() => patches.some((patch) => patch.type === 'agent-turn-completed-v2'));
+    await waitFor(() =>
+      patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+    );
 
     expect(patches).toEqual(
       expect.arrayContaining([
@@ -301,7 +313,11 @@ describe('ClaudeProtocolAdapter V2', () => {
     const patches = collectPatches(adapter);
     const controller = queryFn.current!;
     controller.supportedCommandsResult = [
-      { name: 'ticket', description: 'create a GitHub issue', argumentHint: '<title>' },
+      {
+        name: 'ticket',
+        description: 'create a GitHub issue',
+        argumentHint: '<title>',
+      },
       { name: 'scope', description: 'scope an issue', argumentHint: '' },
     ];
 
@@ -310,7 +326,8 @@ describe('ClaudeProtocolAdapter V2', () => {
     await waitFor(() =>
       patches.some(
         (patch) =>
-          patch.type === 'agent-session-updated-v2' && patch.slashCommands !== undefined
+          patch.type === 'agent-session-updated-v2' &&
+          patch.slashCommands !== undefined
       )
     );
 
@@ -318,7 +335,8 @@ describe('ClaudeProtocolAdapter V2', () => {
     expect(controller.supportedCommandsCalls).toBe(0);
     const slashPatch = patches.find(
       (patch) =>
-        patch.type === 'agent-session-updated-v2' && patch.slashCommands !== undefined
+        patch.type === 'agent-session-updated-v2' &&
+        patch.slashCommands !== undefined
     );
     expect(slashPatch?.type).toBe('agent-session-updated-v2');
     expect(slashPatch?.slashCommands).toEqual(
@@ -329,8 +347,16 @@ describe('ClaudeProtocolAdapter V2', () => {
           argumentHint: '<title>',
           source: 'sdk',
         }),
-        expect.objectContaining({ name: 'scope', description: 'scope an issue', source: 'sdk' }),
-        expect.objectContaining({ name: 'resume', aliases: ['continue'], source: 'relay' }),
+        expect.objectContaining({
+          name: 'scope',
+          description: 'scope an issue',
+          source: 'sdk',
+        }),
+        expect.objectContaining({
+          name: 'resume',
+          aliases: ['continue'],
+          source: 'relay',
+        }),
       ])
     );
 
@@ -362,7 +388,8 @@ describe('ClaudeProtocolAdapter V2', () => {
     await waitFor(() =>
       patches.some(
         (patch) =>
-          patch.type === 'agent-session-updated-v2' && patch.slashCommands !== undefined
+          patch.type === 'agent-session-updated-v2' &&
+          patch.slashCommands !== undefined
       )
     );
 
@@ -370,7 +397,8 @@ describe('ClaudeProtocolAdapter V2', () => {
     expect(controller.supportedCommandsCalls).toBe(0);
     const slashPatch = patches.find(
       (patch) =>
-        patch.type === 'agent-session-updated-v2' && patch.slashCommands !== undefined
+        patch.type === 'agent-session-updated-v2' &&
+        patch.slashCommands !== undefined
     );
     expect(slashPatch?.type).toBe('agent-session-updated-v2');
     expect(slashPatch?.slashCommands).toEqual(
@@ -448,7 +476,9 @@ describe('ClaudeProtocolAdapter V2', () => {
       session_id: 'claude-session-1',
     });
 
-    await waitFor(() => patches.some((patch) => patch.type === 'agent-turn-completed-v2'));
+    await waitFor(() =>
+      patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+    );
     const extensions = patches
       .filter((patch) => patch.type === 'agent-item-started-v2')
       .map((patch) => patch.item)
@@ -468,7 +498,8 @@ describe('ClaudeProtocolAdapter V2', () => {
     );
     expect(
       extensions.some(
-        (ext) => (ext.payload as Record<string, unknown>).type === 'stream_event'
+        (ext) =>
+          (ext.payload as Record<string, unknown>).type === 'stream_event'
       )
     ).toBe(false);
 
@@ -521,13 +552,17 @@ describe('ClaudeProtocolAdapter V2', () => {
     await second;
     await waitFor(
       () =>
-        patches.filter((patch) => patch.type === 'agent-turn-completed-v2').length === 2
+        patches.filter((patch) => patch.type === 'agent-turn-completed-v2')
+          .length === 2
     );
 
     const completedTurns = patches.filter(
       (patch) => patch.type === 'agent-turn-completed-v2'
     );
-    expect(completedTurns.map((patch) => patch.turnId)).toEqual(['turn-1', 'turn-2']);
+    expect(completedTurns.map((patch) => patch.turnId)).toEqual([
+      'turn-1',
+      'turn-2',
+    ]);
 
     await adapter.disconnect();
   });
@@ -545,7 +580,10 @@ describe('ClaudeProtocolAdapter V2', () => {
       session_id: 'claude-session-1',
     });
 
-    const sendPromise = adapter.sendMessage({ turnId: 'turn-tools', content: 'tools' });
+    const sendPromise = adapter.sendMessage({
+      turnId: 'turn-tools',
+      content: 'tools',
+    });
     await waitFor(() => controller.inputs.length === 1);
 
     controller.emit({
@@ -554,9 +592,24 @@ describe('ClaudeProtocolAdapter V2', () => {
         id: 'msg-native-tools',
         content: [
           { type: 'thinking', thinking: 'inspect files' },
-          { type: 'tool_use', id: 'tool-bash', name: 'Bash', input: { command: 'npm test' } },
-          { type: 'tool_use', id: 'tool-edit', name: 'Edit', input: { file_path: 'src/a.ts' } },
-          { type: 'tool_use', id: 'tool-grep', name: 'Grep', input: { pattern: 'x' } },
+          {
+            type: 'tool_use',
+            id: 'tool-bash',
+            name: 'Bash',
+            input: { command: 'npm test' },
+          },
+          {
+            type: 'tool_use',
+            id: 'tool-edit',
+            name: 'Edit',
+            input: { file_path: 'src/a.ts' },
+          },
+          {
+            type: 'tool_use',
+            id: 'tool-grep',
+            name: 'Grep',
+            input: { pattern: 'x' },
+          },
         ],
       },
       session_id: 'claude-session-1',
@@ -571,15 +624,309 @@ describe('ClaudeProtocolAdapter V2', () => {
     });
 
     await sendPromise;
-    await waitFor(() => patches.some((patch) => patch.type === 'agent-turn-completed-v2'));
+    await waitFor(() =>
+      patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+    );
 
     const itemTypes = patches
       .filter((patch) => patch.type === 'agent-item-started-v2')
       .map((patch) => patch.item.type);
 
     expect(itemTypes).toEqual(
-      expect.arrayContaining(['reasoning', 'commandExecution', 'fileChange', 'dynamicToolCall'])
+      expect.arrayContaining([
+        'reasoning',
+        'commandExecution',
+        'fileChange',
+        'dynamicToolCall',
+      ])
     );
+
+    await adapter.disconnect();
+  });
+
+  it('completes file change items with patch from tool_use_result', async () => {
+    const queryFn = makeScriptedQuery();
+    const adapter = new ClaudeProtocolAdapter(queryFn());
+    const patches = collectPatches(adapter);
+
+    await adapter.connect(config);
+    const controller = queryFn.current!;
+    controller.emit({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-1',
+    });
+
+    const sendPromise = adapter.sendMessage({
+      turnId: 'turn-edit',
+      content: 'edit it',
+    });
+    await waitFor(() => controller.inputs.length === 1);
+
+    controller.emit({
+      type: 'assistant',
+      message: {
+        id: 'msg-edit',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-edit-1',
+            name: 'Edit',
+            input: {
+              file_path: '/repo/test.md',
+              old_string: 'foo',
+              new_string: 'bar',
+            },
+          },
+        ],
+      },
+      session_id: 'claude-session-1',
+    });
+
+    controller.emit({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-edit-1',
+            content: 'Edited.',
+          },
+        ],
+      },
+      tool_use_result: {
+        filePath: '/repo/test.md',
+        oldString: 'foo',
+        newString: 'bar',
+        structuredPatch: [
+          {
+            oldStart: 1,
+            oldLines: 1,
+            newStart: 1,
+            newLines: 1,
+            lines: ['-foo', '+bar'],
+          },
+        ],
+        gitDiff: {
+          filename: 'test.md',
+          status: 'modified',
+          additions: 1,
+          deletions: 1,
+          changes: 2,
+          patch: '@@ -1,1 +1,1 @@\n-foo\n+bar',
+        },
+      },
+      session_id: 'claude-session-1',
+    });
+
+    controller.emit({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 1,
+      total_cost_usd: 0,
+      usage: {},
+      session_id: 'claude-session-1',
+    });
+
+    await sendPromise;
+    await waitFor(() =>
+      patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+    );
+
+    const updates = patches.filter(
+      (
+        patch
+      ): patch is Extract<AgentPatchV2, { type: 'agent-item-updated-v2' }> =>
+        patch.type === 'agent-item-updated-v2' &&
+        patch.item.type === 'fileChange'
+    );
+    expect(updates).toHaveLength(1);
+    const update = updates[0];
+    expect(update.item).toMatchObject({
+      id: 'file-tool-edit-1',
+      applyStatus: 'applied',
+      status: 'completed',
+    });
+    if (update.item.type !== 'fileChange')
+      throw new Error('expected fileChange');
+    expect(update.item.patch).toContain('-foo');
+    expect(update.item.patch).toContain('+bar');
+
+    await adapter.disconnect();
+  });
+
+  it('falls back to structuredPatch when gitDiff.patch is missing', async () => {
+    const queryFn = makeScriptedQuery();
+    const adapter = new ClaudeProtocolAdapter(queryFn());
+    const patches = collectPatches(adapter);
+
+    await adapter.connect(config);
+    const controller = queryFn.current!;
+    controller.emit({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-1',
+    });
+
+    const sendPromise = adapter.sendMessage({
+      turnId: 'turn-write',
+      content: 'write it',
+    });
+    await waitFor(() => controller.inputs.length === 1);
+
+    controller.emit({
+      type: 'assistant',
+      message: {
+        id: 'msg-write',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-write-1',
+            name: 'Write',
+            input: { file_path: '/repo/new.md', content: 'hello\nworld\n' },
+          },
+        ],
+      },
+      session_id: 'claude-session-1',
+    });
+
+    controller.emit({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-write-1',
+            content: 'File created.',
+          },
+        ],
+      },
+      tool_use_result: {
+        filePath: '/repo/new.md',
+        structuredPatch: [
+          {
+            oldStart: 0,
+            oldLines: 0,
+            newStart: 1,
+            newLines: 2,
+            lines: ['+hello', '+world'],
+          },
+        ],
+      },
+      session_id: 'claude-session-1',
+    });
+
+    controller.emit({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 1,
+      total_cost_usd: 0,
+      usage: {},
+      session_id: 'claude-session-1',
+    });
+
+    await sendPromise;
+    await waitFor(() =>
+      patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+    );
+
+    const update = patches.find(
+      (
+        patch
+      ): patch is Extract<AgentPatchV2, { type: 'agent-item-updated-v2' }> =>
+        patch.type === 'agent-item-updated-v2' &&
+        patch.item.type === 'fileChange'
+    );
+    expect(update).toBeDefined();
+    if (!update || update.item.type !== 'fileChange')
+      throw new Error('expected fileChange');
+    expect(update.item.patch).toContain('@@ -0,0 +1,2 @@');
+    expect(update.item.patch).toContain('+hello');
+    expect(update.item.patch).toContain('+world');
+    expect(update.item.applyStatus).toBe('applied');
+
+    await adapter.disconnect();
+  });
+
+  it('marks file change failed when tool_result is_error is true', async () => {
+    const queryFn = makeScriptedQuery();
+    const adapter = new ClaudeProtocolAdapter(queryFn());
+    const patches = collectPatches(adapter);
+
+    await adapter.connect(config);
+    const controller = queryFn.current!;
+    controller.emit({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-1',
+    });
+
+    const sendPromise = adapter.sendMessage({
+      turnId: 'turn-fail',
+      content: 'edit broken',
+    });
+    await waitFor(() => controller.inputs.length === 1);
+
+    controller.emit({
+      type: 'assistant',
+      message: {
+        id: 'msg-fail',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-edit-fail',
+            name: 'Edit',
+            input: { file_path: '/repo/missing.md' },
+          },
+        ],
+      },
+      session_id: 'claude-session-1',
+    });
+
+    controller.emit({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-edit-fail',
+            is_error: true,
+            content: 'File does not exist.',
+          },
+        ],
+      },
+      session_id: 'claude-session-1',
+    });
+
+    controller.emit({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 1,
+      total_cost_usd: 0,
+      usage: {},
+      session_id: 'claude-session-1',
+    });
+
+    await sendPromise;
+    await waitFor(() =>
+      patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+    );
+
+    const update = patches.find(
+      (
+        patch
+      ): patch is Extract<AgentPatchV2, { type: 'agent-item-updated-v2' }> =>
+        patch.type === 'agent-item-updated-v2' &&
+        patch.item.type === 'fileChange'
+    );
+    expect(update).toBeDefined();
+    if (!update || update.item.type !== 'fileChange')
+      throw new Error('expected fileChange');
+    expect(update.item.applyStatus).toBe('failed');
+    expect(update.item.status).toBe('failed');
 
     await adapter.disconnect();
   });
@@ -642,7 +989,9 @@ describe('ClaudeProtocolAdapter V2', () => {
       usage: {},
       session_id: 'claude-session-1',
     });
-    await waitFor(() => patches.some((patch) => patch.type === 'agent-turn-completed-v2'));
+    await waitFor(() =>
+      patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+    );
 
     expect(patches).toEqual(
       expect.arrayContaining([
@@ -692,14 +1041,29 @@ describe('ClaudeProtocolAdapter V2', () => {
     const decisionPromise = capturedCanUseTool?.(
       'Bash',
       { command: 'ls' },
-      { signal: new AbortController().signal, toolUseID: 'req-once', title: 'run ls' }
+      {
+        signal: new AbortController().signal,
+        toolUseID: 'req-once',
+        title: 'run ls',
+      }
     );
-    await adapter.respondToApproval({ requestId: 'req-once', decision: { kind: 'accept', scope: 'once' } });
+    await adapter.respondToApproval({
+      requestId: 'req-once',
+      decision: { kind: 'accept', scope: 'once' },
+    });
     const result = await decisionPromise;
     expect(result?.behavior).toBe('allow');
-    expect((result as { decisionClassification?: string }).decisionClassification).toBe('user_temporary');
+    expect(
+      (result as { decisionClassification?: string }).decisionClassification
+    ).toBe('user_temporary');
 
-    controller.emit({ type: 'result', subtype: 'success', duration_ms: 1, total_cost_usd: 0, usage: {} });
+    controller.emit({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 1,
+      total_cost_usd: 0,
+      usage: {},
+    });
     await adapter.disconnect();
   });
 
@@ -723,14 +1087,29 @@ describe('ClaudeProtocolAdapter V2', () => {
     const decisionPromise = capturedCanUseTool?.(
       'Bash',
       { command: 'ls' },
-      { signal: new AbortController().signal, toolUseID: 'req-perm', title: 'run ls' }
+      {
+        signal: new AbortController().signal,
+        toolUseID: 'req-perm',
+        title: 'run ls',
+      }
     );
-    await adapter.respondToApproval({ requestId: 'req-perm', decision: { kind: 'accept', scope: 'permanent' } });
+    await adapter.respondToApproval({
+      requestId: 'req-perm',
+      decision: { kind: 'accept', scope: 'permanent' },
+    });
     const result = await decisionPromise;
     expect(result?.behavior).toBe('allow');
-    expect((result as { decisionClassification?: string }).decisionClassification).toBe('user_permanent');
+    expect(
+      (result as { decisionClassification?: string }).decisionClassification
+    ).toBe('user_permanent');
 
-    controller.emit({ type: 'result', subtype: 'success', duration_ms: 1, total_cost_usd: 0, usage: {} });
+    controller.emit({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 1,
+      total_cost_usd: 0,
+      usage: {},
+    });
     await adapter.disconnect();
   });
 
@@ -754,13 +1133,26 @@ describe('ClaudeProtocolAdapter V2', () => {
     const decisionPromise = capturedCanUseTool?.(
       'Bash',
       { command: 'ls' },
-      { signal: new AbortController().signal, toolUseID: 'req-deny', title: 'run ls' }
+      {
+        signal: new AbortController().signal,
+        toolUseID: 'req-deny',
+        title: 'run ls',
+      }
     );
-    await adapter.respondToApproval({ requestId: 'req-deny', decision: { kind: 'decline' } });
+    await adapter.respondToApproval({
+      requestId: 'req-deny',
+      decision: { kind: 'decline' },
+    });
     const result = await decisionPromise;
     expect(result?.behavior).toBe('deny');
 
-    controller.emit({ type: 'result', subtype: 'success', duration_ms: 1, total_cost_usd: 0, usage: {} });
+    controller.emit({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 1,
+      total_cost_usd: 0,
+      usage: {},
+    });
     await adapter.disconnect();
   });
 
@@ -784,12 +1176,25 @@ describe('ClaudeProtocolAdapter V2', () => {
     const decisionPromise = capturedCanUseTool?.(
       'Bash',
       { command: 'ls' },
-      { signal: new AbortController().signal, toolUseID: 'req-cancel', title: 'run ls' }
+      {
+        signal: new AbortController().signal,
+        toolUseID: 'req-cancel',
+        title: 'run ls',
+      }
     );
-    await adapter.respondToApproval({ requestId: 'req-cancel', decision: { kind: 'cancel' } });
+    await adapter.respondToApproval({
+      requestId: 'req-cancel',
+      decision: { kind: 'cancel' },
+    });
     await expect(decisionPromise).rejects.toThrow(/cancel/i);
 
-    controller.emit({ type: 'result', subtype: 'success', duration_ms: 1, total_cost_usd: 0, usage: {} });
+    controller.emit({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 1,
+      total_cost_usd: 0,
+      usage: {},
+    });
     await adapter.disconnect();
   });
 
@@ -813,7 +1218,11 @@ describe('ClaudeProtocolAdapter V2', () => {
     const decisionPromise = capturedCanUseTool?.(
       'Bash',
       { command: 'ls' },
-      { signal: new AbortController().signal, toolUseID: 'req-scope', title: 'run ls' }
+      {
+        signal: new AbortController().signal,
+        toolUseID: 'req-scope',
+        title: 'run ls',
+      }
     );
     await adapter.respondToApproval({
       requestId: 'req-scope',
@@ -821,7 +1230,13 @@ describe('ClaudeProtocolAdapter V2', () => {
     });
     await expect(decisionPromise).rejects.toThrow(/session/i);
 
-    controller.emit({ type: 'result', subtype: 'success', duration_ms: 1, total_cost_usd: 0, usage: {} });
+    controller.emit({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 1,
+      total_cost_usd: 0,
+      usage: {},
+    });
     await adapter.disconnect();
   });
 
@@ -849,8 +1264,9 @@ describe('ClaudeProtocolAdapter V2', () => {
 
   it('resumeSession passes resume option to the SDK query and emits snapshot with providerSession', async () => {
     const queryFn = makeScriptedQuery();
-    const capturedOptions: Array<Parameters<ClaudeQueryFunction>[0]['options']> =
-      [];
+    const capturedOptions: Array<
+      Parameters<ClaudeQueryFunction>[0]['options']
+    > = [];
     const trackingFn: ClaudeQueryFunction = (params) => {
       capturedOptions.push(params.options);
       return queryFn()(params);
@@ -903,8 +1319,7 @@ describe('ClaudeProtocolAdapter V2', () => {
 
     const idlePatch = afterResumePatch.find(
       (p) =>
-        p.type === 'agent-live-state-updated-v2' &&
-        p.live.status === 'idle'
+        p.type === 'agent-live-state-updated-v2' && p.live.status === 'idle'
     );
     expect(idlePatch).toBeDefined();
 

--- a/test/server/protocol-adapters/claude-adapter.test.ts
+++ b/test/server/protocol-adapters/claude-adapter.test.ts
@@ -931,6 +931,437 @@ describe('ClaudeProtocolAdapter V2', () => {
     await adapter.disconnect();
   });
 
+  it('completes commandExecution items with stdout/stderr and interactive flag', async () => {
+    const queryFn = makeScriptedQuery();
+    const adapter = new ClaudeProtocolAdapter(queryFn());
+    const patches = collectPatches(adapter);
+
+    await adapter.connect(config);
+    const controller = queryFn.current!;
+    controller.emit({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-1',
+    });
+
+    const sendPromise = adapter.sendMessage({
+      turnId: 'turn-bash',
+      content: 'run it',
+    });
+    await waitFor(() => controller.inputs.length === 1);
+
+    controller.emit({
+      type: 'assistant',
+      message: {
+        id: 'msg-bash',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-bash-1',
+            name: 'Bash',
+            input: { command: 'echo hi' },
+          },
+        ],
+      },
+      session_id: 'claude-session-1',
+    });
+
+    controller.emit({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-bash-1',
+            content: 'hi',
+          },
+        ],
+      },
+      tool_use_result: {
+        stdout: 'hi\n',
+        stderr: '',
+        interrupted: true,
+      },
+      session_id: 'claude-session-1',
+    });
+
+    controller.emit({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 1,
+      total_cost_usd: 0,
+      usage: {},
+      session_id: 'claude-session-1',
+    });
+
+    await sendPromise;
+    await waitFor(() =>
+      patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+    );
+
+    const update = patches.find(
+      (
+        patch
+      ): patch is Extract<AgentPatchV2, { type: 'agent-item-updated-v2' }> =>
+        patch.type === 'agent-item-updated-v2' &&
+        patch.item.type === 'commandExecution'
+    );
+    expect(update).toBeDefined();
+    if (!update || update.item.type !== 'commandExecution')
+      throw new Error('expected commandExecution');
+    expect(update.item.command).toBe('echo hi');
+    expect(update.item.output).toBe('hi\n');
+    expect(update.item.status).toBe('completed');
+    expect(update.item.interactive).toBe(true);
+
+    await adapter.disconnect();
+  });
+
+  it('falls back to stderr then result text when stdout is empty', async () => {
+    const queryFn = makeScriptedQuery();
+    const adapter = new ClaudeProtocolAdapter(queryFn());
+    const patches = collectPatches(adapter);
+
+    await adapter.connect(config);
+    const controller = queryFn.current!;
+    controller.emit({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-1',
+    });
+
+    const sendPromise = adapter.sendMessage({
+      turnId: 'turn-bash-fail',
+      content: 'run failing',
+    });
+    await waitFor(() => controller.inputs.length === 1);
+
+    controller.emit({
+      type: 'assistant',
+      message: {
+        id: 'msg-bash-fail',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-bash-fail',
+            name: 'Bash',
+            input: { command: 'false' },
+          },
+        ],
+      },
+      session_id: 'claude-session-1',
+    });
+
+    controller.emit({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-bash-fail',
+            is_error: true,
+            content: 'command failed',
+          },
+        ],
+      },
+      tool_use_result: {
+        stdout: '',
+        stderr: 'boom\n',
+      },
+      session_id: 'claude-session-1',
+    });
+
+    controller.emit({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 1,
+      total_cost_usd: 0,
+      usage: {},
+      session_id: 'claude-session-1',
+    });
+
+    await sendPromise;
+    await waitFor(() =>
+      patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+    );
+
+    const update = patches.find(
+      (
+        patch
+      ): patch is Extract<AgentPatchV2, { type: 'agent-item-updated-v2' }> =>
+        patch.type === 'agent-item-updated-v2' &&
+        patch.item.type === 'commandExecution'
+    );
+    expect(update).toBeDefined();
+    if (!update || update.item.type !== 'commandExecution')
+      throw new Error('expected commandExecution');
+    expect(update.item.output).toBe('boom\n');
+    expect(update.item.status).toBe('failed');
+
+    await adapter.disconnect();
+  });
+
+  it('completes dynamicToolCall items with raw result and extracted text', async () => {
+    const queryFn = makeScriptedQuery();
+    const adapter = new ClaudeProtocolAdapter(queryFn());
+    const patches = collectPatches(adapter);
+
+    await adapter.connect(config);
+    const controller = queryFn.current!;
+    controller.emit({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-1',
+    });
+
+    const sendPromise = adapter.sendMessage({
+      turnId: 'turn-grep',
+      content: 'search',
+    });
+    await waitFor(() => controller.inputs.length === 1);
+
+    controller.emit({
+      type: 'assistant',
+      message: {
+        id: 'msg-grep',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-grep-1',
+            name: 'Grep',
+            input: { pattern: 'TODO' },
+          },
+        ],
+      },
+      session_id: 'claude-session-1',
+    });
+
+    controller.emit({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-grep-1',
+            content: [
+              { type: 'text', text: 'src/foo.ts:12: // TODO' },
+              { type: 'text', text: 'src/bar.ts:7: // TODO' },
+            ],
+          },
+        ],
+      },
+      tool_use_result: { matches: 2 },
+      session_id: 'claude-session-1',
+    });
+
+    controller.emit({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 1,
+      total_cost_usd: 0,
+      usage: {},
+      session_id: 'claude-session-1',
+    });
+
+    await sendPromise;
+    await waitFor(() =>
+      patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+    );
+
+    const update = patches.find(
+      (
+        patch
+      ): patch is Extract<AgentPatchV2, { type: 'agent-item-updated-v2' }> =>
+        patch.type === 'agent-item-updated-v2' &&
+        patch.item.type === 'dynamicToolCall'
+    );
+    expect(update).toBeDefined();
+    if (!update || update.item.type !== 'dynamicToolCall')
+      throw new Error('expected dynamicToolCall');
+    expect(update.item.tool).toBe('Grep');
+    expect(update.item.status).toBe('completed');
+    expect(update.item.result).toEqual({ matches: 2 });
+    expect(update.item.content).toContain('src/foo.ts:12');
+    expect(update.item.content).toContain('src/bar.ts:7');
+
+    await adapter.disconnect();
+  });
+
+  it('marks dynamicToolCall failed when tool_result is_error is true', async () => {
+    const queryFn = makeScriptedQuery();
+    const adapter = new ClaudeProtocolAdapter(queryFn());
+    const patches = collectPatches(adapter);
+
+    await adapter.connect(config);
+    const controller = queryFn.current!;
+    controller.emit({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-1',
+    });
+
+    const sendPromise = adapter.sendMessage({
+      turnId: 'turn-grep-fail',
+      content: 'search broken',
+    });
+    await waitFor(() => controller.inputs.length === 1);
+
+    controller.emit({
+      type: 'assistant',
+      message: {
+        id: 'msg-grep-fail',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-grep-fail',
+            name: 'Grep',
+            input: { pattern: '???' },
+          },
+        ],
+      },
+      session_id: 'claude-session-1',
+    });
+
+    controller.emit({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-grep-fail',
+            is_error: true,
+            content: 'invalid pattern',
+          },
+        ],
+      },
+      session_id: 'claude-session-1',
+    });
+
+    controller.emit({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 1,
+      total_cost_usd: 0,
+      usage: {},
+      session_id: 'claude-session-1',
+    });
+
+    await sendPromise;
+    await waitFor(() =>
+      patches.some((patch) => patch.type === 'agent-turn-completed-v2')
+    );
+
+    const update = patches.find(
+      (
+        patch
+      ): patch is Extract<AgentPatchV2, { type: 'agent-item-updated-v2' }> =>
+        patch.type === 'agent-item-updated-v2' &&
+        patch.item.type === 'dynamicToolCall'
+    );
+    expect(update).toBeDefined();
+    if (!update || update.item.type !== 'dynamicToolCall')
+      throw new Error('expected dynamicToolCall');
+    expect(update.item.status).toBe('failed');
+    expect(update.item.content).toBe('invalid pattern');
+
+    await adapter.disconnect();
+  });
+
+  it('clears tracked tool uses on disconnect so resumed sessions emit no stale completions', async () => {
+    const queryFn = makeScriptedQuery();
+    const adapter = new ClaudeProtocolAdapter(queryFn());
+    const patches = collectPatches(adapter);
+
+    await adapter.connect(config);
+    const controller = queryFn.current!;
+    controller.emit({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-1',
+    });
+
+    void adapter.sendMessage({
+      turnId: 'turn-teardown',
+      content: 'edit then drop',
+    });
+    await waitFor(() => controller.inputs.length === 1);
+
+    controller.emit({
+      type: 'assistant',
+      message: {
+        id: 'msg-teardown',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'tool-teardown-1',
+            name: 'Edit',
+            input: {
+              file_path: '/repo/dropped.md',
+              old_string: 'a',
+              new_string: 'b',
+            },
+          },
+        ],
+      },
+      session_id: 'claude-session-1',
+    });
+
+    await waitFor(() =>
+      patches.some(
+        (p) =>
+          p.type === 'agent-item-started-v2' &&
+          p.item.id === 'file-tool-teardown-1'
+      )
+    );
+
+    // Disconnect before tool_result arrives — drops the in-flight tool_use.
+    await adapter.disconnect();
+
+    const beforeReconnectCount = patches.length;
+
+    // Reconnect and emit a stale tool_result for the dropped tool_use_id.
+    await adapter.connect(config);
+    const controller2 = queryFn.current!;
+    controller2.emit({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'claude-session-2',
+    });
+    controller2.emit({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'tool-teardown-1',
+            content: 'late result',
+          },
+        ],
+      },
+      tool_use_result: { filePath: '/repo/dropped.md' },
+      session_id: 'claude-session-2',
+    });
+
+    // Give the adapter a tick to process; assert no fileChange completion was
+    // emitted for the dropped tool_use after reconnect.
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const newPatches = patches.slice(beforeReconnectCount);
+    const stale = newPatches.find(
+      (p) =>
+        p.type === 'agent-item-updated-v2' &&
+        p.item.type === 'fileChange' &&
+        p.item.id === 'file-tool-teardown-1'
+    );
+    expect(stale).toBeUndefined();
+
+    await adapter.disconnect();
+  });
+
   it('bridges SDK canUseTool approval through respondToApproval', async () => {
     const queryFn = makeScriptedQuery();
     let capturedCanUseTool:


### PR DESCRIPTION
## Summary

Follow-up fixes on top of #321:

- **Tool result lifecycle (claude-adapter):** Claude SDK delivers tool outcomes as `type: 'user'` messages with `tool_result` blocks. The adapter now tracks active tool uses by `tool_use_id` and emits `agent-item-updated-v2` patches when results arrive — so `fileChange`, `commandExecution`, and `dynamicToolCall` items actually transition to `completed`/`failed` instead of stalling at `pending`/`running`.
  - `fileChange`: patch from `gitDiff.patch`, falling back to a reconstructed unified diff from `structuredPatch`. `applyStatus` flips to `applied`/`failed` based on `is_error`.
  - `commandExecution`: stdout/stderr from `tool_use_result`; maps `interrupted` → `interactive`.
  - `dynamicToolCall`: forwards raw `result` + extracted text content.
  - `activeToolUses` map cleared on turn reset to avoid leaks across cancelled turns.
- **Earlier coderabbit findings (already on branch):**
  - `legacy-v2-bridge` reconnect re-establishes the inner adapter listener; shared `subscribePatches()` helper unwinds on failure.
  - `appendStringField` seeds optional fields with the first delta fragment instead of dropping it.
  - Tightened `isAgentPatchV2` wire validators (`agent-live-state-updated-v2`, `agent-session-updated-v2`, `isSession`) so malformed payloads can't poison shared state.
  - Composer memoizes `commandIndex`, `segments`, `segmentPct`, `overlaySegments`.
- **Chore:** gitignore `/docs/design-system/` working files (local previews/screenshots/uploads).

## Test plan

- [x] `npm test` — 167 passed (incl. 3 new claude-adapter tests covering `gitDiff.patch`, `structuredPatch` fallback, and `is_error` failure path)
- [x] `tsc --noEmit` (server + frontend) clean
- [x] `eslint .` — no new errors (warnings unchanged)
- [ ] Smoke-test a Claude session in the web chat: verify Edit/Write items show diff and complete, Bash items show output, MCP/dynamic tools resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable tracking and reporting of tool results (file edits, command executions, dynamic tool outputs) and clearing of stale in-flight tool uses.

* **Performance**
  * Reduced unnecessary recomputation in the chat composer for smoother typing and rendering.

* **Chores**
  * Ignored locally generated design system preview artifacts.

* **Tests**
  * New end-to-end and schema tests to validate tool result handling and session/patch validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->