### PR TITLE
feat(workspace): split-tabs layout substrate (#263)

### DIFF
--- a/docs/plans/2026-04-23-issue-263-workspace-layout-first-slice.md
+++ b/docs/plans/2026-04-23-issue-263-workspace-layout-first-slice.md
@@ -1,0 +1,398 @@
+# Issue 263 Workspace Layout First Slice Autoplan
+
+Source issue: https://github.com/donovan-yohan/relay-ide/issues/263
+
+Branch reviewed: `nightly`
+
+Base branch: `nightly`
+
+## Plan Summary
+
+Build the first slice as a workspace layout substrate, not as full VSCode customization.
+
+The first slice should introduce a typed layout tree for the session workspace, a generic tab model that can represent agent sessions, terminal sessions, file tabs, diff tabs, html preview tabs, and review tabs, and a resizable main-pane renderer that can show those tabs in split groups. Drag-out behavior should be limited to moving a tab from its current group into a new split to the left, right, top, or bottom of the same main area.
+
+This intentionally does not tackle arbitrary side-bar docking, floating pop-outs, multiple sidebars on each side, persisted workspace customization, or a full PR/checks experience. Those are the larger epic.
+
+## Premises
+
+| Premise                                                | Assessment                                                                                                                                                           |
+| ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Relay should move toward VSCode-like customization     | Valid, but too large for one issue. The first slice needs to create the layout model that future customization uses.                                                 |
+| Agents, terminals, files, and diffs should all be tabs | Valid as a product direction. Today they are separate tab systems in `SessionTabBar` and `FileViewerPane`, so the first slice must normalize identity and rendering. |
+| Dragging should be built on existing dependencies      | Valid. `@dnd-kit/core` and `@dnd-kit/sortable` are already dependencies.                                                                                             |
+| Resizing should be user-visible in the first slice     | Valid. Issue #263 acceptance criteria require resizable split dividers. Use a proven panel-resize library rather than expanding custom pointer math.                 |
+| Sidebars should become dockable and reorderable now    | Too broad for the first slice. It belongs to the epic, after the main-area layout model exists.                                                                      |
+
+Premise gate recommendation: approve these premises. The only scope adjustment is to treat side-bar docking as follow-up work, not as part of the first implementation slice.
+
+## What Already Exists
+
+| Sub-problem             | Current code                                                                                                                               |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Hard-coded main layout  | `frontend/src/components/SplitPaneLayout.tsx` renders terminal, optional file viewer, and optional right sidebar as a fixed row.           |
+| Manual resize handles   | `SplitPaneLayout.tsx` owns pointer listeners and clamps file/right-sidebar sizes.                                                          |
+| Agent and terminal tabs | `frontend/src/components/SessionTabBar.tsx` renders session tabs from `SessionSummary[]`.                                                  |
+| File/diff/html tabs     | `frontend/src/components/FileViewerPane.tsx` renders `OpenFileTab[]` from `useUiStore`.                                                    |
+| File tab state          | `frontend/src/lib/stores/ui.ts` stores `openFileTabs`, `activeFileTabKey`, and file viewer ratio.                                          |
+| Right utility surface   | `frontend/src/components/FileTreeSidebar.tsx` already has `changes`, `all-files`, and `checks` tabs. Checks is currently placeholder text. |
+| Drag and drop library   | `@dnd-kit/core`, `@dnd-kit/sortable`, and `@dnd-kit/utilities` are already installed.                                                      |
+
+## Dream State Delta
+
+```text
+CURRENT
+  left sidebar: session/workspace browser
+  main: one active session terminal area
+  file viewer: optional right split owned by file tabs
+  right sidebar: changed/all-files/checks utility tree
+
+FIRST SLICE
+  left sidebar: unchanged
+  main: layout tree with resizable split groups
+  main tabs: sessions + file/diff/html/review descriptors can share tab chrome
+  drag-out: tab -> adjacent split inside main area
+  right sidebar: unchanged except it can open file/diff/review tabs into the main layout
+
+12-MONTH IDEAL
+  left/right dock areas can host multiple bars
+  bars can be reordered and moved between sides
+  main can split recursively and persist layout per workspace
+  files, diffs, agents, terminals, PRs, checks, logs, stats, and utility terminals are all typed tabs
+  views can be condensed, expanded, hidden, or moved without changing their underlying state
+```
+
+## Implementation Alternatives
+
+| Approach                                                                                               | Effort |   Risk | Pros                                                               | Cons                                                              | Decision |
+| ------------------------------------------------------------------------------------------------------ | -----: | -----: | ------------------------------------------------------------------ | ----------------------------------------------------------------- | -------- |
+| Patch `SplitPaneLayout` with drag targets and extra children                                           | Medium |   High | Smallest initial diff                                              | Locks the product deeper into terminal/file/sidebar special cases | Reject   |
+| Introduce a typed layout tree and render it with `react-resizable-panels`, using dnd-kit for tab moves | Medium | Medium | Matches future workspace customization while keeping slice bounded | Requires a small model migration and tests                        | Accept   |
+| Build a full dock manager for main plus sidebars                                                       |   High |   High | Closest to final vision                                            | Too much scope for first pass, hard to verify in one PR           | Defer    |
+
+Library decision: add `react-resizable-panels` for split resizing and use existing `@dnd-kit` for tab drag/drop. `react-split-pane` exists, but it is an older split-pane component with a less natural nested panel-group model for this feature.
+
+## Accepted First Slice
+
+### 0. Tmux Session Substrate Gate
+
+Issue #264 should be treated as session/process substrate work, not as UI layout work.
+
+The browser still uses xterm for terminal rendering. The server-side change is that Relay stops treating terminal sessions as mostly anonymous PTY streams and starts tying each PTY attachment to stable tmux session names, windows, or panes. That gives the UI stronger handles for "this terminal tab is attached to tmux target X" without making tmux responsible for the React layout.
+
+Recommendation: land #264 before the full "agents and terminals can appear in multiple main panes" version of #263. Relay's current frontend PTY path is effectively single-active-terminal oriented: `connectPtySocket(sessionId, term, ...)` replaces the global PTY websocket, and `sendPtyData(data)` writes to that global connection. Multiple live terminal panes need targeted input/output routing. Tmux gives us the backend identity layer for that routing.
+
+Tmux helps with:
+
+- stable session names instead of fragile process tracking
+- targeted `send-keys` for prompt/input injection
+- `capture-pane` for reading terminal state without parsing every ANSI stream
+- windows/panes as backend primitives for utility terminals
+- resurrection/restoration of sessions after Relay restarts
+
+Tmux does not replace:
+
+- xterm rendering in the browser
+- the React layout tree
+- tab identity and ownership rules
+- drag/drop target handling
+- pane resizing UI
+- side dock customization state
+
+First slice adjustment:
+
+- If #264 lands first, model session/terminal tabs as references to tmux-backed Relay sessions.
+- If #263 lands first, limit implementation to one mounted live terminal pane and allow file/diff/html tabs to split around it. Do not claim multi-live-terminal support until #264 or equivalent targeted PTY routing exists.
+
+### 1. Add Typed Workspace Tab Descriptors
+
+Create a small model, likely `frontend/src/lib/workspace-layout.ts`, with:
+
+```ts
+export type WorkspaceTab =
+  | { kind: 'session'; sessionId: string; sessionType: 'agent' | 'terminal' }
+  | {
+      kind: 'file';
+      filePath: string;
+      tabType: 'code' | 'diff' | 'html';
+      token?: string;
+    };
+
+export type WorkspacePane = {
+  id: string;
+  activeTabId: string | null;
+  tabs: WorkspaceTabInstance[];
+};
+
+export type WorkspaceLayoutNode =
+  | { type: 'pane'; pane: WorkspacePane }
+  | {
+      type: 'split';
+      direction: 'horizontal' | 'vertical';
+      sizes: number[];
+      children: WorkspaceLayoutNode[];
+    };
+```
+
+Rules:
+
+- Tab IDs are stable and deterministic for file tabs, using the existing `fileTabKey` identity.
+- Session tabs use session IDs.
+- A tab exists in exactly one pane.
+- Closing a tab removes it from its pane, then selects the nearest remaining tab.
+- Empty panes are pruned.
+- Split nodes with one child collapse.
+
+### 2. Add Pure Layout Reducers
+
+Add pure functions before touching UI rendering:
+
+- `createDefaultWorkspaceLayout(sessionTabs, fileTabs)`
+- `moveTabToPane(tabId, targetPaneId, index?)`
+- `splitPaneWithTab(sourcePaneId, tabId, direction, placement)`
+- `closeLayoutTab(tabId)`
+- `selectLayoutTab(paneId, tabId)`
+- `pruneLayout(layout)`
+
+This is the safety net. The feature is visual, but the expensive bugs will be state bugs.
+
+### 3. Add Main Workspace Layout Renderer
+
+Replace `SplitPaneLayout` for the center area with a new component, likely:
+
+- `frontend/src/components/WorkspaceLayout.tsx`
+- `frontend/src/components/WorkspacePane.tsx`
+- `frontend/src/components/WorkspaceTabBar.tsx`
+- `frontend/src/components/WorkspaceDropOverlay.tsx`
+
+`WorkspaceLayout` owns the recursive split rendering. Use `PanelGroup`, `Panel`, and `PanelResizeHandle` from `react-resizable-panels`.
+
+First slice rendering:
+
+- `session` tabs render the current `SessionContent`, `SessionStatusBar`, and `Toolbar` behavior.
+- `file` tabs render the existing `FileViewerPane` content path, but the old `FileViewerPane` should be split into tab chrome vs content so one pane can render one active file tab without owning every file tab.
+- The existing `SessionTabBar` can become a compatibility wrapper or be replaced by the generic `WorkspaceTabBar` only inside session view.
+
+### 4. Drag-Out Scope
+
+Support only:
+
+- Drag a tab within the same pane to reorder.
+- Drag a tab onto another pane tab bar to move it there.
+- Drag a tab to a pane edge drop zone to create a new split.
+
+Do not support:
+
+- Floating windows.
+- Dragging side-bar bars.
+- Dragging panes outside the main area.
+- Persisting custom layouts.
+- Arbitrary 3+ column sidebars.
+
+### 5. Keep Sidebars Stable
+
+Left sidebar stays as-is.
+
+Right sidebar stays as-is, including `changes`, `all-files`, and `checks`. Selecting a changed file or all-file entry should open a file/diff tab in the active main pane. This is enough to prove the main tab model without rebuilding the side utility rail.
+
+## NOT In Scope
+
+| Item                                               | Why deferred                                                                                                    |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Floating pop-out windows                           | Issue #263 already excludes this.                                                                               |
+| Layout persistence                                 | Issue #263 excludes this, and persistence should wait until the model settles.                                  |
+| Docking bars between left and right                | Larger epic work. Needs a side-bar model separate from main-pane tabs.                                          |
+| Multiple sidebars per side                         | Larger epic work. Requires dock-area state, not just main split state.                                          |
+| Condensed vs expanded panel modes                  | Larger epic work. Separate from hidden vs visible.                                                              |
+| Full PR view and GitHub Actions checks integration | Mentioned in the epic direction, but not needed to prove tab dragging and splitting.                            |
+| Removing all open/close animations globally        | Product direction accepted, but should be done when sidebars are redesigned, not bundled into this first slice. |
+
+## CEO Review
+
+### 0A Premise Challenge
+
+The right problem is not "drag tabs" by itself. The real problem is that Relay has several powerful surfaces that cannot share space. Users bounce between terminal, file diffs, sidebar tools, and PR context instead of arranging the job they are doing.
+
+The first slice should therefore create the composable workspace substrate. Dragging is the affordance. The product value is user-controlled arrangement.
+
+### 0B Existing Code Leverage
+
+Leverage `FileViewerPane` for file/diff/html content, `SessionContent` for session rendering, `SessionTabBar` naming/icon patterns, `useUiStore` for existing file-tab identity, and `@dnd-kit` for drag behavior. Replace the bespoke resizing math in `SplitPaneLayout` instead of extending it.
+
+### 0C Dream State Mapping
+
+The accepted first slice leaves side docking, PR/checks, condensed views, and persistence for later, but it creates the shared tab and layout vocabulary those features need.
+
+### 0D Mode
+
+Mode: selective expansion.
+
+Accepted expansion: add a generic tab descriptor model even though issue #263 only says drag tabs. This prevents a throwaway drag implementation.
+
+Rejected expansion: include left/right dock customization in the same PR. That is the larger epic.
+
+### Sections 1-11 Summary
+
+| Section              | Finding                                                                                                                               |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Architecture         | The current architecture is too special-cased. New layout tree required.                                                              |
+| Error and rescue     | Most errors are UI state errors: duplicate tabs, lost active tab, empty panes, invalid drop targets. Handle with pure reducer guards. |
+| Security             | No new server trust boundary if this remains client-side layout state. Do not let html preview sandbox rules loosen during refactor.  |
+| Data and interaction | Keyboard and touch behavior must not regress. Drag must have button/menu fallback for accessibility.                                  |
+| Code quality         | Split current file viewer into tab chrome and content renderer before trying to mount file tabs in multiple panes.                    |
+| Tests                | Reducer tests are mandatory. Component tests should cover drag result state without relying only on pointer simulation.               |
+| Performance          | Avoid remounting terminal sessions when moving tabs or resizing panes. This is the biggest risk.                                      |
+| Observability        | No telemetry required, but layout reducer should be easy to inspect in devtools.                                                      |
+| Deployment           | Client-only feature, standard nightly path.                                                                                           |
+| Long-term            | Reversible if the model stays isolated behind new components. Hard to reverse if it mutates `App.tsx` deeply.                         |
+| Design               | Use Relay's black, square, monospace TUI style. Drop zones should be thin border/edge indicators, not glossy overlays.                |
+
+## Design Review
+
+Initial design score: 6/10.
+
+The interaction direction is right, but the current issue underspecifies empty panes, drag target feedback, keyboard access, touch behavior, and what happens when terminal tabs move.
+
+| Pass                         | Score | Required fix                                                                                                                             |
+| ---------------------------- | ----: | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Information architecture     |  7/10 | Main area becomes the place where user work tabs live. Sidebars remain navigation/utility.                                               |
+| Interaction states           |  5/10 | Specify dragging, invalid drop, empty pane, single-tab close, loading diff, errored diff, no active session, and mobile fallback states. |
+| User journey                 |  7/10 | Start with "open file beside terminal" and "move terminal beside diff" as the two hero flows.                                            |
+| AI slop risk                 |  8/10 | Design language is already specific. Avoid generic IDE chrome and rounded tab pills.                                                     |
+| Design system alignment      |  8/10 | Use zero-radius tabs, 1px borders, lowercase labels, monochrome SVG icons.                                                               |
+| Responsive and accessibility |  5/10 | Desktop-first is fine, but keyboard fallback and mobile no-op behavior must be explicit.                                                 |
+| Unresolved decisions         |  6/10 | Need user call on whether first slice includes session tabs in the shared model or only file tabs. Recommendation: include sessions now. |
+
+Design decision: first slice should be desktop-first. On mobile, preserve current behavior and do not expose drag-out splits.
+
+## Engineering Review
+
+### Scope Challenge
+
+The issue touches at least these files:
+
+- `frontend/src/App.tsx`
+- `frontend/src/components/SplitPaneLayout.tsx`
+- `frontend/src/components/SplitPaneLayout.css`
+- `frontend/src/components/SessionTabBar.tsx`
+- `frontend/src/components/FileViewerPane.tsx`
+- `frontend/src/lib/stores/ui.ts`
+- new layout model/tests
+
+That is already a real feature. Adding side dock customization would push it into a rewrite. Do not do that in the first slice.
+
+### Architecture Diagram
+
+```text
+useSessionsStore                    useUiStore
+  sessions, activeSessionId           openFileTabs, activeFileTabKey
+          \                              /
+           \                            /
+            workspace tab descriptors
+                       |
+              workspace layout store
+                       |
+              WorkspaceLayout recursive renderer
+                 /          |           \
+        WorkspacePane   ResizeHandle   WorkspaceDropOverlay
+             |
+       WorkspaceTabBar
+             |
+       Active tab content
+        /              \
+  SessionContent     FileTabContent
+  Toolbar            DiffViewer / CodeBlock / HtmlTabView
+```
+
+### Test Diagram
+
+| Flow or branch                                               | Test type                            | Required coverage                                                           |
+| ------------------------------------------------------------ | ------------------------------------ | --------------------------------------------------------------------------- |
+| Create default layout from active session and open file tabs | Vitest reducer test                  | Session and file descriptors produce one main pane with stable active tab.  |
+| Drag file tab to right edge                                  | Vitest reducer test, component smoke | Layout becomes horizontal split with source and target panes.               |
+| Drag terminal tab to bottom edge                             | Vitest reducer test                  | Layout becomes vertical split without losing session ID.                    |
+| Move tab between existing panes                              | Vitest reducer test                  | Tab removed from source and appended to target.                             |
+| Close active tab in multi-tab pane                           | Vitest reducer test                  | Neighbor tab becomes active.                                                |
+| Close last tab in split pane                                 | Vitest reducer test                  | Empty pane pruned and split collapses if needed.                            |
+| Invalid drop target                                          | Vitest reducer test                  | State unchanged.                                                            |
+| Resize divider                                               | Component test if practical          | Panel sizes update without remounting active tab.                           |
+| Open changed file from right sidebar                         | Existing UI/store test extended      | File opens in active workspace pane, not a separate hard-coded file viewer. |
+| Mobile session view                                          | Playwright or component smoke        | Current single-pane behavior remains usable, drag affordances hidden.       |
+
+### Failure Modes Registry
+
+| Failure mode                                                         | Severity | Mitigation                                                                                      |
+| -------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| Moving a terminal tab remounts the terminal and drops live PTY state | Critical | Keep session rendering keyed by session ID and verify no forced new session is created.         |
+| Two mounted terminal panes fight over one global PTY websocket       | Critical | Land tmux-required session routing first, or restrict first slice to one mounted live terminal. |
+| File tab appears in two panes                                        | High     | Enforce single-owner invariant in pure reducers.                                                |
+| Closing a tab leaves activeTabId pointing at missing tab             | High     | Reducer selects neighbor or null.                                                               |
+| Empty split remains visible                                          | Medium   | `pruneLayout` collapses empty panes and single-child splits.                                    |
+| Drag overlay steals terminal pointer input                           | Medium   | Only activate DnD from tab handles, not pane body.                                              |
+| Mobile layout becomes unusable                                       | Medium   | Hide split drag affordances on mobile for first slice.                                          |
+| Existing right sidebar resize regresses                              | Medium   | Keep right sidebar path unchanged in this slice.                                                |
+
+### Performance
+
+Resizing will fire constantly. Use `react-resizable-panels` for layout size changes and keep terminal/diff content keyed so resizing does not trigger expensive remounts. Do not put live terminal content inside a component whose key changes when a tab moves.
+
+## Error And Rescue Registry
+
+| Error                     | Trigger                                | User-visible behavior                             | Test                                       |
+| ------------------------- | -------------------------------------- | ------------------------------------------------- | ------------------------------------------ |
+| `missing-tab`             | active tab no longer exists            | pane selects nearest available tab or empty state | reducer test                               |
+| `invalid-drop-target`     | drop over unsupported region           | drag cancels, layout unchanged                    | reducer test                               |
+| `empty-pane`              | last tab closed or moved out           | pane pruned, sibling expands                      | reducer test                               |
+| `unsupported-mobile-drag` | mobile/touch split drag in first slice | no drag-out affordance shown                      | component/e2e smoke                        |
+| `file-diff-fetch-error`   | existing diff load fails               | existing retry/close UI remains                   | existing FileViewerPane behavior preserved |
+
+## Decision Audit Trail
+
+| #   | Phase  | Decision                                                                    | Classification | Principle               | Rationale                                                                                 | Rejected                       |
+| --- | ------ | --------------------------------------------------------------------------- | -------------- | ----------------------- | ----------------------------------------------------------------------------------------- | ------------------------------ |
+| 1   | CEO    | First slice builds layout substrate, not complete VSCode customization      | Mechanical     | Boil lakes, flag oceans | Shared tab/pane model is a lake. Full docking system is an ocean.                         | Full sidebar docking now       |
+| 2   | CEO    | Include sessions and file/diff/html tabs in the shared tab descriptor model | Taste          | Choose completeness     | Issue says files, terminal, chat, review should work. File-only drag would be throwaway.  | File tabs only                 |
+| 3   | Eng    | Use `react-resizable-panels` for split resizing                             | Mechanical     | Do not reinvent         | Current pointer math is already special-cased and nested splits need a panel-group model. | Expand bespoke resize code     |
+| 4   | Design | Desktop-first drag-out, mobile preserves current single-pane behavior       | Mechanical     | Explicit over clever    | Mobile drag/split UX is a separate design problem.                                        | Force split UI onto mobile     |
+| 5   | Eng    | Keep sidebars stable in first slice                                         | Mechanical     | Pragmatic               | Proves the main layout model without entangling dock-area design.                         | Rebuild left/right docks now   |
+| 6   | Eng    | Add reducer tests before component drag tests                               | Mechanical     | Quality                 | State bugs are the highest-risk part of this feature.                                     | Rely only on pointer/e2e tests |
+
+## Deferred Epic Work
+
+Create or update follow-up GitHub issues for:
+
+- Dock areas: left and right sidebars can host multiple bars, reorder bars, and move bars between sides.
+- Sidebar visibility shortcuts and top-left/top-right icon controls.
+- Per-workspace layout persistence.
+- Condensed vs expanded view modes per pane.
+- PR review tab with branch diff against target branch.
+- GitHub Actions checks tab with status and logs.
+- Optional utility terminal pop-out and larger dedicated window.
+- Remove open/close animations where they fight customization.
+
+## Recommended First PR Checklist
+
+- [ ] Decide ordering with #264. Preferred: land tmux-hard-requirement first if #263 includes multiple live terminal panes.
+- [ ] Add `react-resizable-panels`.
+- [ ] Add `frontend/src/lib/workspace-layout.ts` with typed layout model and reducers.
+- [ ] Add `test/workspace-layout.test.ts` for tab move, split, close, prune, and invalid drop behavior.
+- [ ] Extract file-tab content rendering from `FileViewerPane` so a single tab can render inside any workspace pane.
+- [ ] Add `WorkspaceLayout`, `WorkspacePane`, `WorkspaceTabBar`, and `WorkspaceDropOverlay`.
+- [ ] Wire session view in `App.tsx` through the new main layout.
+- [ ] Keep `FileTreeSidebar` and left `Sidebar` behavior stable.
+- [ ] Add at least one browser/component smoke test for opening a changed file beside an active session.
+- [ ] Run `npm run build`, `npm test`, and targeted Vitest for the new reducer tests.
+
+## Review Scores
+
+- CEO: pass with scoped expansion. The feature is strategically right if it starts with the shared workspace model.
+- Design: 6/10 to 8/10 after the states and desktop-first constraints above.
+- Eng: pass with concerns. Main risk is terminal remounting and layout state bugs.
+
+## Final Recommendation
+
+First slice: "workspace layout substrate for main-pane tab splitting."
+
+Do not start with sidebars. Do not start with full docking. Do not start with persistence.
+
+Start by making the main area able to host mixed tab types in resizable split panes. Once that is real, sidebars and PR/checks become placement policy, not architecture.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -71,6 +71,7 @@ import AnalyticsDashboard from './components/AnalyticsDashboard.js';
 import SessionDetail from './components/SessionDetail.js';
 import FullPageDiff from './components/FullPageDiff.js';
 import FileViewerPane from './components/FileViewerPane.js';
+import WorkspaceFilesArea from './components/WorkspaceFilesArea.js';
 import { SplitPaneLayout } from './components/SplitPaneLayout.js';
 import WorkspaceUtilityRail, {
   utilityRailRenderedWidth,
@@ -374,6 +375,7 @@ function TerminalAreaContent({
   const fileViewerRatio = useUiStore((s) => s.fileViewerRatio);
   const saveFileViewerRatio = useUiStore((s) => s.saveFileViewerRatio);
   const openFileTab = useUiStore((s) => s.openFileTab);
+  const workspaceLayoutEnabled = useUiStore((s) => s.workspaceLayoutEnabled);
   const isItemLoading = useSessionsStore((s) => s.isItemLoading);
 
   // ── Derived state ──────────────────────────────────────────────────────────
@@ -629,10 +631,17 @@ function TerminalAreaContent({
               </>
             }
             fileViewer={
-              <FileViewerPane
-                workspacePath={activeWorkspaceCwd}
-                onInjectReference={handleInjectReference}
-              />
+              workspaceLayoutEnabled ? (
+                <WorkspaceFilesArea
+                  workspacePath={activeWorkspaceCwd}
+                  onInjectReference={handleInjectReference}
+                />
+              ) : (
+                <FileViewerPane
+                  workspacePath={activeWorkspaceCwd}
+                  onInjectReference={handleInjectReference}
+                />
+              )
             }
             rightSidebar={
               <WorkspaceUtilityRail

--- a/frontend/src/components/FileTabContent.css
+++ b/frontend/src/components/FileTabContent.css
@@ -1,0 +1,108 @@
+.file-tab-content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  background: var(--bg, #0a0a0a);
+}
+
+.file-tab-content__body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
+.file-tab-summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border, #1a1a1a);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.7rem;
+  color: var(--text-muted, #888);
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+  flex: 0 0 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.file-tab-summary__crumb {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.file-tab-summary__repo-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  color: var(--bg, #0a0a0a);
+  background: var(--accent, #d97757);
+  margin-right: 4px;
+  flex-shrink: 0;
+}
+
+.file-tab-summary__seg {
+  flex-shrink: 0;
+}
+
+.file-tab-summary__seg--name {
+  color: var(--text, #e6e6e6);
+}
+
+.file-tab-summary__sep {
+  color: var(--border, #2a2a2a);
+  flex-shrink: 0;
+}
+
+.file-tab-summary__pills {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.file-tab-summary__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 6px;
+  border: 1px solid var(--border, #2a2a2a);
+  font-size: 0.65rem;
+  color: var(--text-muted, #888);
+  background: transparent;
+}
+
+.file-tab-summary__pill--dirty {
+  color: var(--status-warning, #f59e0b);
+  border-color: currentColor;
+}
+
+.file-tab-summary__pill-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.file-tab-summary__pill--success {
+  color: var(--status-success, #34d399);
+  border-color: currentColor;
+}
+
+.file-tab-summary__pill--warn {
+  color: var(--status-warning, #f59e0b);
+  border-color: currentColor;
+}

--- a/frontend/src/components/FileTabContent.tsx
+++ b/frontend/src/components/FileTabContent.tsx
@@ -1,0 +1,371 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { fetchFileDiff } from '../lib/api.js';
+import { parseLineReference } from '../lib/file-tree-utils.js';
+import type { FileTabType } from '../lib/stores/ui.js';
+import type { WorkspaceTabSummary } from '../lib/workspace-summary.js';
+import CodeBlock from './CodeBlock.js';
+import DiffViewer from './DiffViewer.js';
+import './FileTabContent.css';
+
+const LANGUAGE_BY_EXT: Record<string, string> = {
+  ts: 'typescript',
+  tsx: 'tsx',
+  js: 'javascript',
+  jsx: 'jsx',
+  py: 'python',
+  rs: 'rust',
+  go: 'go',
+  rb: 'ruby',
+  css: 'css',
+  scss: 'scss',
+  html: 'html',
+  svelte: 'svelte',
+  json: 'json',
+  yaml: 'yaml',
+  yml: 'yaml',
+  md: 'markdown',
+  sh: 'bash',
+  bash: 'bash',
+  sql: 'sql',
+  graphql: 'graphql',
+};
+
+export function languageFromPath(filePath: string): string {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
+  return LANGUAGE_BY_EXT[ext] ?? 'text';
+}
+
+export function buildCacheKey(filePath: string, base: string | null): string {
+  return `${filePath}::${base ?? 'working'}`;
+}
+
+interface DiffCache {
+  diffCache: Map<string, string>;
+  loadingPaths: Set<string>;
+  errorPaths: Map<string, string>;
+  fetchDiff: (filePath: string, base: string | null) => void;
+  clearEntry: (key: string) => void;
+}
+
+export function useFileDiffCache(workspacePath: string): DiffCache {
+  const [diffCache, setDiffCache] = useState<Map<string, string>>(new Map());
+  const [loadingPaths, setLoadingPaths] = useState<Set<string>>(new Set());
+  const [errorPaths, setErrorPaths] = useState<Map<string, string>>(new Map());
+
+  const fetchDiff = useCallback(
+    (filePath: string, base: string | null) => {
+      const key = buildCacheKey(filePath, base);
+      if (diffCache.has(key) || loadingPaths.has(key)) return;
+      setLoadingPaths((prev) => new Set([...prev, key]));
+      fetchFileDiff(workspacePath, filePath, base ?? undefined)
+        .then(
+          (result) => {
+            if (result.error) {
+              setErrorPaths(
+                (prev) => new Map([...prev, [key, result.error as string]])
+              );
+            } else {
+              setDiffCache((prev) => new Map([...prev, [key, result.diff]]));
+            }
+          },
+          (err: unknown) => {
+            const msg =
+              err instanceof Error ? err.message : 'failed to load diff';
+            setErrorPaths((prev) => new Map([...prev, [key, msg]]));
+          }
+        )
+        .finally(() => {
+          setLoadingPaths((prev) => {
+            const next = new Set(prev);
+            next.delete(key);
+            return next;
+          });
+        });
+    },
+    [workspacePath, diffCache, loadingPaths]
+  );
+
+  const clearEntry = useCallback((key: string) => {
+    setDiffCache((prev) => {
+      const m = new Map(prev);
+      m.delete(key);
+      return m;
+    });
+    setErrorPaths((prev) => {
+      const m = new Map(prev);
+      m.delete(key);
+      return m;
+    });
+  }, []);
+
+  return { diffCache, loadingPaths, errorPaths, fetchDiff, clearEntry };
+}
+
+interface HtmlTabViewProps {
+  filePath: string;
+  fileName: string;
+  token: string;
+  refreshVersion?: number | undefined;
+}
+
+function HtmlTabView({
+  filePath,
+  fileName,
+  token,
+  refreshVersion,
+}: HtmlTabViewProps) {
+  const [sandboxDismissed, setSandboxDismissed] = useState(false);
+  const [lastPath, setLastPath] = useState('');
+
+  useEffect(() => {
+    if (filePath !== lastPath) {
+      setLastPath(filePath);
+      setSandboxDismissed(false);
+    }
+  }, [filePath, lastPath]);
+
+  useEffect(() => {
+    if (!sandboxDismissed) {
+      const timer = setTimeout(() => setSandboxDismissed(true), 4000);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [sandboxDismissed]);
+
+  const src = `/browser-content/${token}/${fileName}${refreshVersion ? `?v=${refreshVersion}` : ''}`;
+  return (
+    <div className="html-viewer">
+      {!sandboxDismissed && (
+        <div className="sandbox-notice">
+          <span className="notice-text">
+            rendered in sandbox · some web features may not work
+          </span>
+          <button
+            className="notice-dismiss"
+            onClick={() => setSandboxDismissed(true)}
+            aria-label="dismiss notice"
+          >
+            ×
+          </button>
+        </div>
+      )}
+      <iframe
+        src={src}
+        sandbox="allow-scripts"
+        title={`HTML preview: ${fileName}`}
+        className="html-iframe"
+      />
+    </div>
+  );
+}
+
+interface FileTabSummaryProps {
+  summary: WorkspaceTabSummary;
+}
+
+function FileTabSummaryHeader({ summary }: FileTabSummaryProps) {
+  const segments = summary.breadcrumb?.segments ?? [];
+  return (
+    <div className="file-tab-summary">
+      <div className="file-tab-summary__crumb">
+        {summary.breadcrumb?.repoLabel && (
+          <span
+            className="file-tab-summary__repo-badge"
+            style={
+              summary.breadcrumb.repoColor
+                ? { background: summary.breadcrumb.repoColor }
+                : undefined
+            }
+          >
+            {summary.breadcrumb.repoLabel}
+          </span>
+        )}
+        {segments.map((seg, i) => {
+          const last = i === segments.length - 1;
+          return (
+            <React.Fragment key={`${seg}-${i}`}>
+              <span
+                className={[
+                  'file-tab-summary__seg',
+                  last ? 'file-tab-summary__seg--name' : '',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              >
+                {seg}
+              </span>
+              {!last && <span className="file-tab-summary__sep">/</span>}
+            </React.Fragment>
+          );
+        })}
+      </div>
+      <div className="file-tab-summary__pills">
+        {summary.pills.map((pill, i) => (
+          <span
+            key={`${pill.label}-${i}`}
+            className={`file-tab-summary__pill file-tab-summary__pill--${pill.kind}`}
+          >
+            {pill.kind === 'dirty' && (
+              <span className="file-tab-summary__pill-dot" />
+            )}
+            {pill.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export interface FileTabContentProps {
+  filePath: string;
+  fileName: string;
+  tabType?: FileTabType | undefined;
+  token?: string | undefined;
+  isChanged: boolean;
+  refreshVersion?: number | undefined;
+
+  diff: string;
+  loading: boolean;
+  error: string | null;
+  diffViewMode: 'unified' | 'side-by-side';
+  wordWrap: boolean;
+
+  hasActiveSession: boolean;
+  onInjectReference?: ((reference: string) => void) | undefined;
+  onRetry: () => void;
+  onCloseTab: () => void;
+
+  renderDiff?:
+    | ((props: {
+        diff: string;
+        filePath: string;
+        mode: 'unified' | 'side-by-side';
+        wordWrap: boolean;
+      }) => React.ReactNode)
+    | undefined;
+  renderCode?:
+    | ((props: { code: string; language: string }) => React.ReactNode)
+    | undefined;
+
+  summary?: WorkspaceTabSummary | undefined;
+  showSummary?: boolean;
+}
+
+export function FileTabContent({
+  filePath,
+  fileName,
+  tabType,
+  token,
+  isChanged,
+  refreshVersion,
+  diff,
+  loading,
+  error,
+  diffViewMode,
+  wordWrap,
+  hasActiveSession,
+  onInjectReference,
+  onRetry,
+  onCloseTab,
+  renderDiff,
+  renderCode,
+  summary,
+  showSummary = true,
+}: FileTabContentProps) {
+  const handleDiffClick = useCallback(
+    (e: React.MouseEvent) => {
+      const target = e.target as HTMLElement;
+      const lineEl = target.closest('.line-number, .d2h-code-linenumber');
+      if (!lineEl || !hasActiveSession) return;
+      const lineNum = parseInt(lineEl.textContent?.trim() ?? '', 10);
+      if (!Number.isNaN(lineNum) && lineNum > 0) {
+        onInjectReference?.(parseLineReference(filePath, lineNum));
+      }
+    },
+    [filePath, hasActiveSession, onInjectReference]
+  );
+
+  const body = (() => {
+    if (loading) {
+      return (
+        <div className="loading-viewer">
+          <span className="spinner">&#x280B;</span> loading {fileName}...
+        </div>
+      );
+    }
+    if (error) {
+      return (
+        <div className="error-viewer">
+          <div className="error-text">failed to load diff: {error}</div>
+          <div className="error-actions">
+            <button className="retry-btn" onClick={onRetry}>
+              retry
+            </button>
+            <button className="close-btn" onClick={onCloseTab}>
+              close tab
+            </button>
+          </div>
+        </div>
+      );
+    }
+    if (tabType === 'html' && token) {
+      return (
+        <HtmlTabView
+          filePath={filePath}
+          fileName={fileName}
+          token={token}
+          refreshVersion={refreshVersion}
+        />
+      );
+    }
+    if (isChanged && diff) {
+      return (
+        <div className="diff-wrapper" onClick={handleDiffClick}>
+          {renderDiff ? (
+            renderDiff({ diff, filePath, mode: diffViewMode, wordWrap })
+          ) : (
+            <DiffViewer
+              diff={diff}
+              filePath={filePath}
+              mode={diffViewMode}
+              wordWrap={wordWrap}
+            />
+          )}
+        </div>
+      );
+    }
+    if (!isChanged) {
+      return (
+        <div
+          className={['raw-file', wordWrap ? 'word-wrap' : '']
+            .filter(Boolean)
+            .join(' ')}
+        >
+          {renderCode ? (
+            renderCode({
+              code: diff || '(empty file)',
+              language: languageFromPath(filePath),
+            })
+          ) : (
+            <CodeBlock
+              code={diff || '(empty file)'}
+              language={languageFromPath(filePath)}
+            />
+          )}
+        </div>
+      );
+    }
+    return <div className="empty-viewer">no diff available</div>;
+  })();
+
+  return (
+    <div className="file-tab-content">
+      {showSummary && summary && <FileTabSummaryHeader summary={summary} />}
+      <div className="file-tab-content__body" role="tabpanel">
+        {body}
+      </div>
+    </div>
+  );
+}
+
+export default FileTabContent;

--- a/frontend/src/components/FileTabContent.tsx
+++ b/frontend/src/components/FileTabContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { fetchFileDiff } from '../lib/api.js';
 import { parseLineReference } from '../lib/file-tree-utils.js';
 import type { FileTabType } from '../lib/stores/ui.js';
@@ -51,11 +51,18 @@ export function useFileDiffCache(workspacePath: string): DiffCache {
   const [diffCache, setDiffCache] = useState<Map<string, string>>(new Map());
   const [loadingPaths, setLoadingPaths] = useState<Set<string>>(new Set());
   const [errorPaths, setErrorPaths] = useState<Map<string, string>>(new Map());
+  // Tracks keys with an in-flight or already-cached fetch. A ref avoids the
+  // stale-closure dance of depending on `diffCache`/`loadingPaths` and stops
+  // duplicate fetches even when several `fetchDiff` calls land in the same
+  // microtask before state updates flush.
+  const inFlightRef = useRef<Set<string>>(new Set());
+  const cachedRef = useRef<Set<string>>(new Set());
 
   const fetchDiff = useCallback(
     (filePath: string, base: string | null) => {
       const key = buildCacheKey(filePath, base);
-      if (diffCache.has(key) || loadingPaths.has(key)) return;
+      if (cachedRef.current.has(key) || inFlightRef.current.has(key)) return;
+      inFlightRef.current.add(key);
       setLoadingPaths((prev) => new Set([...prev, key]));
       fetchFileDiff(workspacePath, filePath, base ?? undefined)
         .then(
@@ -65,6 +72,7 @@ export function useFileDiffCache(workspacePath: string): DiffCache {
                 (prev) => new Map([...prev, [key, result.error as string]])
               );
             } else {
+              cachedRef.current.add(key);
               setDiffCache((prev) => new Map([...prev, [key, result.diff]]));
             }
           },
@@ -75,6 +83,7 @@ export function useFileDiffCache(workspacePath: string): DiffCache {
           }
         )
         .finally(() => {
+          inFlightRef.current.delete(key);
           setLoadingPaths((prev) => {
             const next = new Set(prev);
             next.delete(key);
@@ -82,10 +91,11 @@ export function useFileDiffCache(workspacePath: string): DiffCache {
           });
         });
     },
-    [workspacePath, diffCache, loadingPaths]
+    [workspacePath]
   );
 
   const clearEntry = useCallback((key: string) => {
+    cachedRef.current.delete(key);
     setDiffCache((prev) => {
       const m = new Map(prev);
       m.delete(key);

--- a/frontend/src/components/FileViewerPane.tsx
+++ b/frontend/src/components/FileViewerPane.tsx
@@ -1,12 +1,14 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { useUiStore, fileTabKey } from '../lib/stores/ui.js';
+import React, { useCallback, useEffect, useMemo } from 'react';
+import { fileTabKey, useUiStore } from '../lib/stores/ui.js';
 import type { OpenFileTab } from '../lib/stores/ui.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
-import { fetchFileDiff } from '../lib/api.js';
 import { diffSourceToBase } from '../lib/diff-utils.js';
-import { parseLineReference } from '../lib/file-tree-utils.js';
-import DiffViewer from './DiffViewer.js';
-import CodeBlock from './CodeBlock.js';
+import {
+  buildCacheKey,
+  FileTabContent,
+  useFileDiffCache,
+  type FileTabContentProps,
+} from './FileTabContent.js';
 import './FileViewerPane.css';
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -14,85 +16,44 @@ import './FileViewerPane.css';
 export interface FileViewerPaneProps {
   workspacePath: string;
   onInjectReference?: (reference: string) => void;
-  renderDiff?: (props: {
-    diff: string;
-    filePath: string;
-    mode: 'unified' | 'side-by-side';
-    wordWrap: boolean;
-  }) => React.ReactNode;
-  renderCode?: (props: { code: string; language: string }) => React.ReactNode;
+  renderDiff?: FileTabContentProps['renderDiff'];
+  renderCode?: FileTabContentProps['renderCode'];
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 const CLOSE_SVG = (
-  <svg width="10" height="10" viewBox="0 0 10 10" fill="none"
-    stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" aria-hidden="true">
+  <svg
+    width="10"
+    height="10"
+    viewBox="0 0 10 10"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="square"
+    aria-hidden="true"
+  >
     <path d="M2 2l6 6M8 2l-6 6" />
   </svg>
 );
 
 const GLOBE_SVG = (
-  <svg width="14" height="14" viewBox="0 0 14 14" fill="none"
-    stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" aria-hidden="true">
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 14 14"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="square"
+    aria-hidden="true"
+  >
     <circle cx="7" cy="7" r="5.5" />
     <path d="M1.5 7h11M7 1.5c-1.5 2-2 3.5-2 5.5s.5 3.5 2 5.5M7 1.5c1.5 2 2 3.5 2 5.5s-.5 3.5-2 5.5" />
   </svg>
 );
 
-function languageFromPath(filePath: string): string {
-  const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
-  const map: Record<string, string> = {
-    ts: 'typescript', tsx: 'tsx', js: 'javascript', jsx: 'jsx',
-    py: 'python', rs: 'rust', go: 'go', rb: 'ruby',
-    css: 'css', scss: 'scss', html: 'html', svelte: 'svelte',
-    json: 'json', yaml: 'yaml', yml: 'yaml', md: 'markdown',
-    sh: 'bash', bash: 'bash', sql: 'sql', graphql: 'graphql',
-  };
-  return map[ext] ?? 'text';
-}
-
-function buildCacheKey(filePath: string, base: string | null): string {
-  return `${filePath}::${base ?? 'working'}`;
-}
-
-// ── useDiffCache hook ─────────────────────────────────────────────────────────
-
-function useDiffCache(workspacePath: string) {
-  const [diffCache, setDiffCache] = useState<Map<string, string>>(new Map());
-  const [loadingPaths, setLoadingPaths] = useState<Set<string>>(new Set());
-  const [errorPaths, setErrorPaths] = useState<Map<string, string>>(new Map());
-
-  const fetchDiff = useCallback((filePath: string, base: string | null) => {
-    const key = buildCacheKey(filePath, base);
-    if (diffCache.has(key) || loadingPaths.has(key)) return;
-    setLoadingPaths((prev) => new Set([...prev, key]));
-    fetchFileDiff(workspacePath, filePath, base ?? undefined).then(
-      (result) => {
-        if (result.error) {
-          setErrorPaths((prev) => new Map([...prev, [key, result.error as string]]));
-        } else {
-          setDiffCache((prev) => new Map([...prev, [key, result.diff]]));
-        }
-      },
-      (err: unknown) => {
-        const msg = err instanceof Error ? err.message : 'failed to load diff';
-        setErrorPaths((prev) => new Map([...prev, [key, msg]]));
-      }
-    ).finally(() => {
-      setLoadingPaths((prev) => { const next = new Set(prev); next.delete(key); return next; });
-    });
-  }, [workspacePath, diffCache, loadingPaths]);
-
-  const clearEntry = useCallback((key: string) => {
-    setDiffCache((prev) => { const m = new Map(prev); m.delete(key); return m; });
-    setErrorPaths((prev) => { const m = new Map(prev); m.delete(key); return m; });
-  }, []);
-
-  return { diffCache, loadingPaths, errorPaths, fetchDiff, clearEntry };
-}
-
-// ── useActiveSession hook ─────────────────────────────────────────────────────
+// ── useActiveSession hook (used for the "send to" pill in the tab bar) ───────
 
 function useActiveSession() {
   const sessions = useSessionsStore((s) => s.sessions);
@@ -119,98 +80,30 @@ interface TabItemProps {
 function TabItem({ tab, isActive, onTabClick, onCloseTab }: TabItemProps) {
   return (
     <div
-      className={['file-tab', isActive ? 'active' : ''].filter(Boolean).join(' ')}
-      role="tab" tabIndex={0} aria-selected={isActive}
+      className={['file-tab', isActive ? 'active' : '']
+        .filter(Boolean)
+        .join(' ')}
+      role="tab"
+      tabIndex={0}
+      aria-selected={isActive}
       onClick={() => onTabClick(tab)}
-      onKeyDown={(e) => { if (e.key === 'Enter') onTabClick(tab); }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') onTabClick(tab);
+      }}
       title={tab.filePath}
     >
       {tab.tabType === 'html' && <span className="tab-icon">{GLOBE_SVG}</span>}
       <span className="tab-name">{tab.fileName}</span>
       {tab.isChanged && <span className="tab-badge">M</span>}
-      <button className="tab-close" onClick={(e) => onCloseTab(tab, e)} aria-label={`close ${tab.fileName}`}>{CLOSE_SVG}</button>
+      <button
+        className="tab-close"
+        onClick={(e) => onCloseTab(tab, e)}
+        aria-label={`close ${tab.fileName}`}
+      >
+        {CLOSE_SVG}
+      </button>
     </div>
   );
-}
-
-interface HtmlTabViewProps { tab: OpenFileTab; }
-
-function HtmlTabView({ tab }: HtmlTabViewProps) {
-  const [sandboxDismissed, setSandboxDismissed] = useState(false);
-  const [lastPath, setLastPath] = useState('');
-  useEffect(() => {
-    if (tab.filePath !== lastPath) { setLastPath(tab.filePath); setSandboxDismissed(false); }
-  }, [tab.filePath, lastPath]);
-  useEffect(() => {
-    if (!sandboxDismissed) {
-      const timer = setTimeout(() => setSandboxDismissed(true), 4000);
-      return () => clearTimeout(timer);
-    }
-    return undefined;
-  }, [sandboxDismissed]);
-  const src = `/browser-content/${tab.token}/${tab.fileName}${tab.refreshVersion ? `?v=${tab.refreshVersion}` : ''}`;
-  return (
-    <div className="html-viewer">
-      {!sandboxDismissed && (
-        <div className="sandbox-notice">
-          <span className="notice-text">rendered in sandbox · some web features may not work</span>
-          <button className="notice-dismiss" onClick={() => setSandboxDismissed(true)} aria-label="dismiss notice">×</button>
-        </div>
-      )}
-      <iframe src={src} sandbox="allow-scripts" title={`HTML preview: ${tab.fileName}`} className="html-iframe" />
-    </div>
-  );
-}
-
-interface ContentAreaProps {
-  activeTab: OpenFileTab | undefined;
-  activeLoading: boolean;
-  activeError: string | null;
-  activeDiff: string;
-  diffViewMode: 'unified' | 'side-by-side';
-  wordWrap: boolean;
-  onRetry: () => void;
-  onCloseActiveTab: () => void;
-  onDiffClick: (e: React.MouseEvent) => void;
-  renderDiff?: FileViewerPaneProps['renderDiff'];
-  renderCode?: FileViewerPaneProps['renderCode'];
-}
-
-function ContentArea({
-  activeTab, activeLoading, activeError, activeDiff, diffViewMode, wordWrap,
-  onRetry, onCloseActiveTab, onDiffClick, renderDiff, renderCode,
-}: ContentAreaProps) {
-  if (!activeTab) return <div className="empty-viewer">select a file from the sidebar</div>;
-  if (activeLoading) return <div className="loading-viewer"><span className="spinner">&#x280B;</span> loading {activeTab.fileName}...</div>;
-  if (activeError) {
-    return (
-      <div className="error-viewer">
-        <div className="error-text">failed to load diff: {activeError}</div>
-        <div className="error-actions">
-          <button className="retry-btn" onClick={onRetry}>retry</button>
-          <button className="close-btn" onClick={onCloseActiveTab}>close tab</button>
-        </div>
-      </div>
-    );
-  }
-  if (activeTab.tabType === 'html' && activeTab.token) return <HtmlTabView tab={activeTab} />;
-  if (activeTab.isChanged && activeDiff) {
-    return (
-      <div className="diff-wrapper" onClick={onDiffClick}>
-        {renderDiff ? renderDiff({ diff: activeDiff, filePath: activeTab.filePath, mode: diffViewMode, wordWrap })
-          : <DiffViewer diff={activeDiff} filePath={activeTab.filePath} mode={diffViewMode} wordWrap={wordWrap} />}
-      </div>
-    );
-  }
-  if (!activeTab.isChanged) {
-    return (
-      <div className={['raw-file', wordWrap ? 'word-wrap' : ''].filter(Boolean).join(' ')}>
-        {renderCode ? renderCode({ code: activeDiff || '(empty file)', language: languageFromPath(activeTab.filePath) })
-          : <CodeBlock code={activeDiff || '(empty file)'} language={languageFromPath(activeTab.filePath)} />}
-      </div>
-    );
-  }
-  return <div className="empty-viewer">no diff available</div>;
 }
 
 // ── useFileViewerHandlers hook ────────────────────────────────────────────────
@@ -218,9 +111,7 @@ function ContentArea({
 function useFileViewerHandlers(
   activeTab: OpenFileTab | undefined,
   base: string | null,
-  hasActiveSession: boolean,
-  onInjectReference: ((r: string) => void) | undefined,
-  clearEntry: (key: string) => void,
+  clearEntry: (key: string) => void
 ) {
   const closeFileTab = useUiStore((s) => s.closeFileTab);
   const closeAllFileTabs = useUiStore((s) => s.closeAllFileTabs);
@@ -230,32 +121,29 @@ function useFileViewerHandlers(
   const fileDiffViewMode = useUiStore((s) => s.fileDiffViewMode);
   const fileWordWrap = useUiStore((s) => s.fileWordWrap);
 
-  const handleCloseTab = useCallback((tab: OpenFileTab, e: React.MouseEvent) => {
-    e.stopPropagation();
-    closeFileTab(tab.filePath, tab.tabType);
-    clearEntry(buildCacheKey(tab.filePath, base));
-  }, [closeFileTab, clearEntry, base]);
+  const handleCloseTab = useCallback(
+    (tab: OpenFileTab, e: React.MouseEvent) => {
+      e.stopPropagation();
+      closeFileTab(tab.filePath, tab.tabType);
+      clearEntry(buildCacheKey(tab.filePath, base));
+    },
+    [closeFileTab, clearEntry, base]
+  );
 
   const handleTabClick = useCallback((tab: OpenFileTab) => {
-    useUiStore.setState({ activeFileTabKey: fileTabKey(tab.filePath, tab.tabType) });
+    useUiStore.setState({
+      activeFileTabKey: fileTabKey(tab.filePath, tab.tabType),
+    });
   }, []);
-
-  const handleDiffClick = useCallback((e: React.MouseEvent) => {
-    const target = e.target as HTMLElement;
-    const lineEl = target.closest('.line-number, .d2h-code-linenumber');
-    if (!lineEl || !activeTab || !hasActiveSession) return;
-    const lineNum = parseInt(lineEl.textContent?.trim() ?? '', 10);
-    if (!Number.isNaN(lineNum) && lineNum > 0) {
-      onInjectReference?.(parseLineReference(activeTab.filePath, lineNum));
-    }
-  }, [activeTab, hasActiveSession, onInjectReference]);
 
   const handleRetry = useCallback(() => {
     if (activeTab) clearEntry(buildCacheKey(activeTab.filePath, base));
   }, [activeTab, base, clearEntry]);
 
   const handleRefresh = useCallback(() => {
-    if (activeTab?.tabType === 'html' && activeTab.filePath) refreshHtmlTab(activeTab.filePath);
+    if (activeTab?.tabType === 'html' && activeTab.filePath) {
+      refreshHtmlTab(activeTab.filePath);
+    }
   }, [activeTab, refreshHtmlTab]);
 
   const handleCloseActiveTab = useCallback(() => {
@@ -263,7 +151,9 @@ function useFileViewerHandlers(
   }, [activeTab, closeFileTab]);
 
   const handleToggleDiffViewMode = useCallback(() => {
-    setFileDiffViewMode(fileDiffViewMode === 'unified' ? 'side-by-side' : 'unified');
+    setFileDiffViewMode(
+      fileDiffViewMode === 'unified' ? 'side-by-side' : 'unified'
+    );
   }, [fileDiffViewMode, setFileDiffViewMode]);
 
   const handleToggleWordWrap = useCallback(() => {
@@ -271,35 +161,72 @@ function useFileViewerHandlers(
   }, [fileWordWrap, setFileWordWrap]);
 
   return {
-    handleCloseTab, handleTabClick, handleDiffClick, handleRetry, handleRefresh,
-    handleCloseActiveTab, handleToggleDiffViewMode, handleToggleWordWrap, closeAllFileTabs,
-    fileDiffViewMode, fileWordWrap,
+    handleCloseTab,
+    handleTabClick,
+    handleRetry,
+    handleRefresh,
+    handleCloseActiveTab,
+    handleToggleDiffViewMode,
+    handleToggleWordWrap,
+    closeAllFileTabs,
+    fileDiffViewMode,
+    fileWordWrap,
   };
 }
 
 // ── Main Component ────────────────────────────────────────────────────────────
 
-export function FileViewerPane({ workspacePath, onInjectReference, renderDiff, renderCode }: FileViewerPaneProps) {
+export function FileViewerPane({
+  workspacePath,
+  onInjectReference,
+  renderDiff,
+  renderCode,
+}: FileViewerPaneProps) {
   const openFileTabs = useUiStore((s) => s.openFileTabs);
   const activeFileTabKey = useUiStore((s) => s.activeFileTabKey);
   const fileDiffSource = useUiStore((s) => s.fileDiffSource);
   const fileDiffDefaultBranch = useUiStore((s) => s.fileDiffDefaultBranch);
-  const base = useMemo(() => diffSourceToBase(fileDiffSource, fileDiffDefaultBranch) ?? null, [fileDiffSource, fileDiffDefaultBranch]);
+  const base = useMemo(
+    () => diffSourceToBase(fileDiffSource, fileDiffDefaultBranch) ?? null,
+    [fileDiffSource, fileDiffDefaultBranch]
+  );
   const activeTab = useMemo(
-    () => openFileTabs.find((t) => fileTabKey(t.filePath, t.tabType) === activeFileTabKey),
+    () =>
+      openFileTabs.find(
+        (t) => fileTabKey(t.filePath, t.tabType) === activeFileTabKey
+      ),
     [openFileTabs, activeFileTabKey]
   );
-  const { diffCache, loadingPaths, errorPaths, fetchDiff, clearEntry } = useDiffCache(workspacePath);
-  const { hasActiveSession, activeSessionName } = useActiveSession();
-  const handlers = useFileViewerHandlers(activeTab, base, hasActiveSession, onInjectReference, clearEntry);
-  const { handleCloseTab, handleTabClick, handleDiffClick, handleRetry, handleRefresh,
-    handleCloseActiveTab, handleToggleDiffViewMode, handleToggleWordWrap, closeAllFileTabs,
-    fileDiffViewMode, fileWordWrap } = handlers;
 
-  const activeCacheKey = activeTab ? buildCacheKey(activeTab.filePath, base) : null;
-  const activeDiff = activeCacheKey ? diffCache.get(activeCacheKey) ?? '' : '';
-  const activeLoading = activeCacheKey ? loadingPaths.has(activeCacheKey) : false;
-  const activeError = activeCacheKey ? errorPaths.get(activeCacheKey) ?? null : null;
+  const { diffCache, loadingPaths, errorPaths, fetchDiff, clearEntry } =
+    useFileDiffCache(workspacePath);
+  const { hasActiveSession, activeSessionName } = useActiveSession();
+  const handlers = useFileViewerHandlers(activeTab, base, clearEntry);
+  const {
+    handleCloseTab,
+    handleTabClick,
+    handleRetry,
+    handleRefresh,
+    handleCloseActiveTab,
+    handleToggleDiffViewMode,
+    handleToggleWordWrap,
+    closeAllFileTabs,
+    fileDiffViewMode,
+    fileWordWrap,
+  } = handlers;
+
+  const activeCacheKey = activeTab
+    ? buildCacheKey(activeTab.filePath, base)
+    : null;
+  const activeDiff = activeCacheKey
+    ? (diffCache.get(activeCacheKey) ?? '')
+    : '';
+  const activeLoading = activeCacheKey
+    ? loadingPaths.has(activeCacheKey)
+    : false;
+  const activeError = activeCacheKey
+    ? (errorPaths.get(activeCacheKey) ?? null)
+    : null;
 
   useEffect(() => {
     if (!activeTab || activeTab.tabType === 'html') return;
@@ -313,36 +240,73 @@ export function FileViewerPane({ workspacePath, onInjectReference, renderDiff, r
           {openFileTabs.map((tab) => (
             <TabItem
               key={fileTabKey(tab.filePath, tab.tabType)}
-              tab={tab} isActive={activeFileTabKey === fileTabKey(tab.filePath, tab.tabType)}
-              onTabClick={handleTabClick} onCloseTab={handleCloseTab}
+              tab={tab}
+              isActive={
+                activeFileTabKey === fileTabKey(tab.filePath, tab.tabType)
+              }
+              onTabClick={handleTabClick}
+              onCloseTab={handleCloseTab}
             />
           ))}
         </div>
         <div className="tab-bar-actions">
-          <button className="diff-mode-btn" onClick={handleToggleWordWrap}>{fileWordWrap ? '[nowrap]' : '[wrap]'}</button>
+          <button className="diff-mode-btn" onClick={handleToggleWordWrap}>
+            {fileWordWrap ? '[nowrap]' : '[wrap]'}
+          </button>
           {activeTab?.isChanged && (
-            <button className="diff-mode-btn" onClick={handleToggleDiffViewMode}>
+            <button
+              className="diff-mode-btn"
+              onClick={handleToggleDiffViewMode}
+            >
               {fileDiffViewMode === 'unified' ? '[split]' : '[unified]'}
             </button>
           )}
           {activeTab?.tabType === 'html' && (
-            <button className="refresh-btn" onClick={handleRefresh}>[refresh]</button>
+            <button className="refresh-btn" onClick={handleRefresh}>
+              [refresh]
+            </button>
           )}
-          {openFileTabs.length > 1 && <button className="close-all-btn" onClick={closeAllFileTabs}>close all</button>}
-          <div className={['send-to-pill', !hasActiveSession ? 'disabled' : ''].filter(Boolean).join(' ')}>
+          {openFileTabs.length > 1 && (
+            <button className="close-all-btn" onClick={closeAllFileTabs}>
+              close all
+            </button>
+          )}
+          <div
+            className={['send-to-pill', !hasActiveSession ? 'disabled' : '']
+              .filter(Boolean)
+              .join(' ')}
+          >
             <span className="send-to-label">send to:</span>
             <span className="send-to-target">{activeSessionName}</span>
           </div>
         </div>
       </div>
-      <div className="file-content" role="tabpanel">
-        <ContentArea
-          activeTab={activeTab} activeLoading={activeLoading} activeError={activeError}
-          activeDiff={activeDiff} diffViewMode={fileDiffViewMode} wordWrap={fileWordWrap}
-          onRetry={handleRetry} onCloseActiveTab={handleCloseActiveTab} onDiffClick={handleDiffClick}
-          renderDiff={renderDiff} renderCode={renderCode}
+      {activeTab ? (
+        <FileTabContent
+          filePath={activeTab.filePath}
+          fileName={activeTab.fileName}
+          tabType={activeTab.tabType}
+          token={activeTab.token}
+          isChanged={activeTab.isChanged}
+          refreshVersion={activeTab.refreshVersion}
+          diff={activeDiff}
+          loading={activeLoading}
+          error={activeError}
+          diffViewMode={fileDiffViewMode}
+          wordWrap={fileWordWrap}
+          hasActiveSession={hasActiveSession}
+          onInjectReference={onInjectReference}
+          onRetry={handleRetry}
+          onCloseTab={handleCloseActiveTab}
+          renderDiff={renderDiff}
+          renderCode={renderCode}
+          showSummary={false}
         />
-      </div>
+      ) : (
+        <div className="file-content" role="tabpanel">
+          <div className="empty-viewer">select a file from the sidebar</div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/WorkspaceContentLayer.css
+++ b/frontend/src/components/WorkspaceContentLayer.css
@@ -1,0 +1,18 @@
+.ws-content-buffer {
+  position: fixed;
+  left: -99999px;
+  top: -99999px;
+  width: 800px;
+  height: 600px;
+  visibility: hidden;
+  pointer-events: none;
+  contain: strict;
+}
+
+.ws-tab-content-host {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}

--- a/frontend/src/components/WorkspaceContentLayer.tsx
+++ b/frontend/src/components/WorkspaceContentLayer.tsx
@@ -1,0 +1,111 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  listPanes,
+  workspaceTabId,
+  type WorkspaceTab,
+  type WorkspaceTabId,
+} from '../lib/workspace-layout.js';
+import {
+  getAllPaneBodyEls,
+  subscribeToPaneBodyEls,
+  useWorkspaceLayoutStore,
+} from '../lib/stores/workspace-layout-store.js';
+import './WorkspaceContentLayer.css';
+
+function usePaneBodyEls(): ReadonlyMap<string, HTMLElement | null> {
+  const [, force] = useState(0);
+  useEffect(() => subscribeToPaneBodyEls(() => force((v) => v + 1)), []);
+  return getAllPaneBodyEls();
+}
+
+interface TabPlacement {
+  tab: WorkspaceTab;
+  tabId: WorkspaceTabId;
+  paneId: string;
+  isActive: boolean;
+}
+
+export interface WorkspaceContentLayerProps {
+  renderTab: (tab: WorkspaceTab) => React.ReactNode;
+}
+
+export function WorkspaceContentLayer({
+  renderTab,
+}: WorkspaceContentLayerProps): React.ReactElement {
+  const layout = useWorkspaceLayoutStore((s) => s.layout);
+  const paneEls = usePaneBodyEls();
+  const bufferRef = useRef<HTMLDivElement | null>(null);
+  const [bufferEl, setBufferEl] = useState<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setBufferEl(bufferRef.current);
+  }, []);
+
+  const placements = useMemo<TabPlacement[]>(() => {
+    const out: TabPlacement[] = [];
+    for (const pane of listPanes(layout)) {
+      for (const tab of pane.tabs) {
+        const tabId = workspaceTabId(tab);
+        out.push({
+          tab,
+          tabId,
+          paneId: pane.id,
+          isActive: pane.activeTabId === tabId,
+        });
+      }
+    }
+    return out;
+  }, [layout]);
+
+  const [warmed, setWarmed] = useState<ReadonlySet<WorkspaceTabId>>(
+    () => new Set()
+  );
+
+  useEffect(() => {
+    setWarmed((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const { tabId, isActive } of placements) {
+        if (isActive && !next.has(tabId)) {
+          next.add(tabId);
+          changed = true;
+        }
+      }
+      const liveIds = new Set(placements.map((p) => p.tabId));
+      for (const id of next) {
+        if (!liveIds.has(id)) {
+          next.delete(id);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [placements]);
+
+  const shouldMount = (placement: TabPlacement): boolean => {
+    if (placement.tab.kind === 'session') return true;
+    return warmed.has(placement.tabId);
+  };
+
+  return (
+    <>
+      <div ref={bufferRef} className="ws-content-buffer" aria-hidden />
+      {placements.map((placement) => {
+        if (!shouldMount(placement)) return null;
+        const { tab, tabId, paneId, isActive } = placement;
+        const target = isActive ? (paneEls.get(paneId) ?? bufferEl) : bufferEl;
+        if (!target) return null;
+        return createPortal(
+          <div className="ws-tab-content-host" data-ws-tab={tabId}>
+            {renderTab(tab)}
+          </div>,
+          target,
+          tabId
+        );
+      })}
+    </>
+  );
+}
+
+export default WorkspaceContentLayer;

--- a/frontend/src/components/WorkspaceDropOverlay.css
+++ b/frontend/src/components/WorkspaceDropOverlay.css
@@ -1,0 +1,53 @@
+.ws-drop-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 4;
+}
+
+.ws-drop-edge {
+  position: absolute;
+  pointer-events: auto;
+  background: transparent;
+  transition: background 80ms ease;
+}
+
+.ws-drop-edge--over {
+  background: color-mix(in srgb, var(--accent, #d97757) 22%, transparent);
+  outline: 1px dashed var(--accent, #d97757);
+  outline-offset: -1px;
+}
+
+.ws-drop-edge--top {
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 50%;
+}
+
+.ws-drop-edge--bottom {
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 50%;
+}
+
+.ws-drop-edge--left {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 50%;
+}
+
+.ws-drop-edge--right {
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 50%;
+}
+
+@media (max-width: 720px) {
+  .ws-drop-overlay {
+    display: none;
+  }
+}

--- a/frontend/src/components/WorkspaceDropOverlay.tsx
+++ b/frontend/src/components/WorkspaceDropOverlay.tsx
@@ -1,0 +1,75 @@
+import { useDroppable } from '@dnd-kit/core';
+import type {
+  SplitDirection,
+  SplitPlacement,
+} from '../lib/workspace-layout.js';
+import './WorkspaceDropOverlay.css';
+
+type Edge = 'top' | 'bottom' | 'left' | 'right';
+
+interface EdgeSpec {
+  edge: Edge;
+  direction: SplitDirection;
+  placement: SplitPlacement;
+}
+
+const EDGES: EdgeSpec[] = [
+  { edge: 'top', direction: 'vertical', placement: 'before' },
+  { edge: 'bottom', direction: 'vertical', placement: 'after' },
+  { edge: 'left', direction: 'horizontal', placement: 'before' },
+  { edge: 'right', direction: 'horizontal', placement: 'after' },
+];
+
+interface EdgeZoneProps {
+  paneId: string;
+  edge: Edge;
+  direction: SplitDirection;
+  placement: SplitPlacement;
+}
+
+function EdgeZone({ paneId, edge, direction, placement }: EdgeZoneProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `edge:${paneId}:${edge}`,
+    data: { type: 'edge', paneId, direction, placement },
+  });
+  return (
+    <div
+      ref={setNodeRef}
+      className={[
+        'ws-drop-edge',
+        `ws-drop-edge--${edge}`,
+        isOver ? 'ws-drop-edge--over' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      aria-hidden
+    />
+  );
+}
+
+export interface WorkspaceDropOverlayProps {
+  paneId: string;
+  active: boolean;
+}
+
+export function WorkspaceDropOverlay({
+  paneId,
+  active,
+}: WorkspaceDropOverlayProps) {
+  if (!active) return null;
+  return (
+    <div className="ws-drop-overlay" aria-hidden>
+      {EDGES.map((spec) => (
+        <EdgeZone
+          key={spec.edge}
+          paneId={paneId}
+          edge={spec.edge}
+          direction={spec.direction}
+          placement={spec.placement}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default WorkspaceDropOverlay;

--- a/frontend/src/components/WorkspaceFilesArea.css
+++ b/frontend/src/components/WorkspaceFilesArea.css
@@ -1,0 +1,9 @@
+.ws-files-area {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
+  position: relative;
+}

--- a/frontend/src/components/WorkspaceFilesArea.tsx
+++ b/frontend/src/components/WorkspaceFilesArea.tsx
@@ -1,0 +1,264 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { fileTabKey, useUiStore } from '../lib/stores/ui.js';
+import type { OpenFileTab } from '../lib/stores/ui.js';
+import { diffSourceToBase } from '../lib/diff-utils.js';
+import {
+  listPanes,
+  workspaceTabId,
+  type WorkspaceTab,
+} from '../lib/workspace-layout.js';
+import { useWorkspaceLayoutStore } from '../lib/stores/workspace-layout-store.js';
+import type { SummaryContext } from '../lib/workspace-summary.js';
+import {
+  buildCacheKey,
+  FileTabContent,
+  useFileDiffCache,
+  type FileTabContentProps,
+} from './FileTabContent.js';
+import { WorkspaceLayout } from './WorkspaceLayout.js';
+import { WorkspaceContentLayer } from './WorkspaceContentLayer.js';
+import './WorkspaceFilesArea.css';
+
+function uiTabToWorkspaceTab(tab: OpenFileTab): WorkspaceTab {
+  return {
+    kind: 'file',
+    filePath: tab.filePath,
+    tabType: tab.tabType ?? 'code',
+    ...(tab.token ? { token: tab.token } : {}),
+  };
+}
+
+function uiTabId(tab: OpenFileTab): string {
+  return `file::${fileTabKey(tab.filePath, tab.tabType)}`;
+}
+
+interface FileTabContentBridgeProps {
+  tab: Extract<WorkspaceTab, { kind: 'file' }>;
+  workspacePath: string;
+  onInjectReference?: ((reference: string) => void) | undefined;
+  renderDiff?: FileTabContentProps['renderDiff'];
+  renderCode?: FileTabContentProps['renderCode'];
+}
+
+function FileTabContentBridge({
+  tab,
+  workspacePath,
+  onInjectReference,
+  renderDiff,
+  renderCode,
+}: FileTabContentBridgeProps) {
+  const fileDiffSource = useUiStore((s) => s.fileDiffSource);
+  const fileDiffDefaultBranch = useUiStore((s) => s.fileDiffDefaultBranch);
+  const fileDiffViewMode = useUiStore((s) => s.fileDiffViewMode);
+  const fileWordWrap = useUiStore((s) => s.fileWordWrap);
+  const closeFileTab = useUiStore((s) => s.closeFileTab);
+  const openFileTabs = useUiStore((s) => s.openFileTabs);
+
+  const base = useMemo(
+    () => diffSourceToBase(fileDiffSource, fileDiffDefaultBranch) ?? null,
+    [fileDiffSource, fileDiffDefaultBranch]
+  );
+
+  const cache = useFileDiffCache(workspacePath);
+  const cacheKey = buildCacheKey(tab.filePath, base);
+  const diff = cache.diffCache.get(cacheKey) ?? '';
+  const loading = cache.loadingPaths.has(cacheKey);
+  const error = cache.errorPaths.get(cacheKey) ?? null;
+
+  useEffect(() => {
+    if (tab.tabType === 'html') return;
+    cache.fetchDiff(tab.filePath, base);
+  }, [tab.filePath, tab.tabType, base, cache]);
+
+  const uiMatch = openFileTabs.find(
+    (t) =>
+      fileTabKey(t.filePath, t.tabType) ===
+      fileTabKey(tab.filePath, tab.tabType)
+  );
+  const fileName =
+    uiMatch?.fileName ?? tab.filePath.split('/').pop() ?? tab.filePath;
+  const isChanged = uiMatch?.isChanged ?? false;
+  const refreshVersion = uiMatch?.refreshVersion;
+
+  const handleRetry = useCallback(() => {
+    cache.clearEntry(cacheKey);
+  }, [cache, cacheKey]);
+
+  const handleCloseTab = useCallback(() => {
+    closeFileTab(tab.filePath, tab.tabType);
+  }, [closeFileTab, tab.filePath, tab.tabType]);
+
+  return (
+    <FileTabContent
+      filePath={tab.filePath}
+      fileName={fileName}
+      tabType={tab.tabType}
+      token={tab.token}
+      isChanged={isChanged}
+      refreshVersion={refreshVersion}
+      diff={diff}
+      loading={loading}
+      error={error}
+      diffViewMode={fileDiffViewMode}
+      wordWrap={fileWordWrap}
+      hasActiveSession={false}
+      onInjectReference={onInjectReference}
+      onRetry={handleRetry}
+      onCloseTab={handleCloseTab}
+      renderDiff={renderDiff}
+      renderCode={renderCode}
+      showSummary={false}
+    />
+  );
+}
+
+export interface WorkspaceFilesAreaProps {
+  workspacePath: string;
+  onInjectReference?: (reference: string) => void;
+  renderDiff?: FileTabContentProps['renderDiff'];
+  renderCode?: FileTabContentProps['renderCode'];
+}
+
+export function WorkspaceFilesArea({
+  workspacePath,
+  onInjectReference,
+  renderDiff,
+  renderCode,
+}: WorkspaceFilesAreaProps) {
+  const openFileTabs = useUiStore((s) => s.openFileTabs);
+  const activeFileTabKey = useUiStore((s) => s.activeFileTabKey);
+  const setUiState = useUiStore.setState;
+
+  const layout = useWorkspaceLayoutStore((s) => s.layout);
+  const activePaneId = useWorkspaceLayoutStore((s) => s.activePaneId);
+  const addTab = useWorkspaceLayoutStore((s) => s.addTab);
+  const closeTab = useWorkspaceLayoutStore((s) => s.closeTab);
+  const selectTab = useWorkspaceLayoutStore((s) => s.selectTab);
+  const resetLayout = useWorkspaceLayoutStore((s) => s.resetLayout);
+
+  // Initialize layout from current openFileTabs on first mount.
+  const initializedRef = useRef(false);
+  useEffect(() => {
+    if (initializedRef.current) return;
+    initializedRef.current = true;
+    resetLayout(openFileTabs.map(uiTabToWorkspaceTab));
+  }, [resetLayout, openFileTabs]);
+
+  // Sync ui.openFileTabs → workspace tabs (add/remove).
+  useEffect(() => {
+    if (!initializedRef.current) return;
+    const wsIds = new Set<string>();
+    const wsPaneById = new Map<string, string>();
+    for (const pane of listPanes(layout)) {
+      for (const t of pane.tabs) {
+        const id = workspaceTabId(t);
+        wsIds.add(id);
+        wsPaneById.set(id, pane.id);
+      }
+    }
+    const uiIds = new Set(openFileTabs.map(uiTabId));
+
+    for (const t of openFileTabs) {
+      const id = uiTabId(t);
+      if (!wsIds.has(id)) {
+        const targetPane =
+          activePaneId ??
+          (layout.type === 'pane' ? layout.id : listPanes(layout)[0]?.id);
+        if (targetPane) addTab(targetPane, uiTabToWorkspaceTab(t));
+      }
+    }
+    for (const id of wsIds) {
+      if (!uiIds.has(id)) closeTab(id);
+    }
+  }, [openFileTabs, layout, activePaneId, addTab, closeTab]);
+
+  // Workspace tab close → ui.closeFileTab (detect tabs removed from layout).
+  const prevLayoutTabIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const currentIds = new Set<string>();
+    for (const pane of listPanes(layout)) {
+      for (const t of pane.tabs) currentIds.add(workspaceTabId(t));
+    }
+    const prev = prevLayoutTabIdsRef.current;
+    const removed: string[] = [];
+    for (const id of prev) {
+      if (!currentIds.has(id)) removed.push(id);
+    }
+    prevLayoutTabIdsRef.current = currentIds;
+
+    for (const id of removed) {
+      if (!id.startsWith('file::')) continue;
+      const ftKey = id.slice('file::'.length);
+      const uiTab = useUiStore
+        .getState()
+        .openFileTabs.find((t) => fileTabKey(t.filePath, t.tabType) === ftKey);
+      if (uiTab) {
+        useUiStore.getState().closeFileTab(uiTab.filePath, uiTab.tabType);
+      }
+    }
+  }, [layout]);
+
+  // Sync ui.activeFileTabKey → workspace selection.
+  useEffect(() => {
+    if (!activeFileTabKey) return;
+    const targetId = `file::${activeFileTabKey}`;
+    for (const pane of listPanes(layout)) {
+      if (pane.tabs.some((t) => workspaceTabId(t) === targetId)) {
+        if (pane.activeTabId !== targetId) {
+          selectTab(pane.id, targetId);
+        }
+        return;
+      }
+    }
+  }, [activeFileTabKey, layout, selectTab]);
+
+  // Workspace pane active tab change → ui.activeFileTabKey.
+  useEffect(() => {
+    let activeFileTabId: string | null = null;
+    for (const pane of listPanes(layout)) {
+      if (pane.id === activePaneId && pane.activeTabId) {
+        activeFileTabId = pane.activeTabId;
+        break;
+      }
+    }
+    if (!activeFileTabId || !activeFileTabId.startsWith('file::')) return;
+    const ftKey = activeFileTabId.slice('file::'.length);
+    if (useUiStore.getState().activeFileTabKey !== ftKey) {
+      setUiState({ activeFileTabKey: ftKey });
+    }
+  }, [layout, activePaneId, setUiState]);
+
+  const summaryContext = useMemo<SummaryContext>(() => {
+    const changed = new Set(
+      openFileTabs.filter((t) => t.isChanged).map((t) => t.filePath)
+    );
+    return {
+      isFileChanged: (path) => changed.has(path),
+    };
+  }, [openFileTabs]);
+
+  const renderTab = useCallback(
+    (tab: WorkspaceTab) => {
+      if (tab.kind !== 'file') return null;
+      return (
+        <FileTabContentBridge
+          tab={tab}
+          workspacePath={workspacePath}
+          onInjectReference={onInjectReference}
+          renderDiff={renderDiff}
+          renderCode={renderCode}
+        />
+      );
+    },
+    [workspacePath, onInjectReference, renderDiff, renderCode]
+  );
+
+  return (
+    <div className="ws-files-area">
+      <WorkspaceLayout summaryContext={summaryContext} />
+      <WorkspaceContentLayer renderTab={renderTab} />
+    </div>
+  );
+}
+
+export default WorkspaceFilesArea;

--- a/frontend/src/components/WorkspaceFilesArea.tsx
+++ b/frontend/src/components/WorkspaceFilesArea.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { fileTabKey, useUiStore } from '../lib/stores/ui.js';
 import type { OpenFileTab } from '../lib/stores/ui.js';
+import { useSessionsStore } from '../lib/stores/sessions.js';
 import { diffSourceToBase } from '../lib/diff-utils.js';
 import {
   listPanes,
@@ -53,6 +54,9 @@ function FileTabContentBridge({
   const fileWordWrap = useUiStore((s) => s.fileWordWrap);
   const closeFileTab = useUiStore((s) => s.closeFileTab);
   const openFileTabs = useUiStore((s) => s.openFileTabs);
+  const sendToTargetSessionId = useUiStore((s) => s.sendToTargetSessionId);
+  const activeSessionId = useSessionsStore((s) => s.activeSessionId);
+  const hasActiveSession = (sendToTargetSessionId ?? activeSessionId) !== null;
 
   const base = useMemo(
     () => diffSourceToBase(fileDiffSource, fileDiffDefaultBranch) ?? null,
@@ -101,7 +105,7 @@ function FileTabContentBridge({
       error={error}
       diffViewMode={fileDiffViewMode}
       wordWrap={fileWordWrap}
-      hasActiveSession={false}
+      hasActiveSession={hasActiveSession}
       onInjectReference={onInjectReference}
       onRetry={handleRetry}
       onCloseTab={handleCloseTab}
@@ -144,36 +148,12 @@ export function WorkspaceFilesArea({
     resetLayout(openFileTabs.map(uiTabToWorkspaceTab));
   }, [resetLayout, openFileTabs]);
 
-  // Sync ui.openFileTabs → workspace tabs (add/remove).
-  useEffect(() => {
-    if (!initializedRef.current) return;
-    const wsIds = new Set<string>();
-    const wsPaneById = new Map<string, string>();
-    for (const pane of listPanes(layout)) {
-      for (const t of pane.tabs) {
-        const id = workspaceTabId(t);
-        wsIds.add(id);
-        wsPaneById.set(id, pane.id);
-      }
-    }
-    const uiIds = new Set(openFileTabs.map(uiTabId));
-
-    for (const t of openFileTabs) {
-      const id = uiTabId(t);
-      if (!wsIds.has(id)) {
-        const targetPane =
-          activePaneId ??
-          (layout.type === 'pane' ? layout.id : listPanes(layout)[0]?.id);
-        if (targetPane) addTab(targetPane, uiTabToWorkspaceTab(t));
-      }
-    }
-    for (const id of wsIds) {
-      if (!uiIds.has(id)) closeTab(id);
-    }
-  }, [openFileTabs, layout, activePaneId, addTab, closeTab]);
-
   // Workspace tab close → ui.closeFileTab (detect tabs removed from layout).
+  // Runs BEFORE the ui → workspace sync effect below so the recently-removed
+  // id set is populated before that effect would otherwise re-add the tab in
+  // the same commit (stale openFileTabs closure).
   const prevLayoutTabIdsRef = useRef<Set<string>>(new Set());
+  const recentlyRemovedIdsRef = useRef<Set<string>>(new Set());
   useEffect(() => {
     const currentIds = new Set<string>();
     for (const pane of listPanes(layout)) {
@@ -188,6 +168,7 @@ export function WorkspaceFilesArea({
 
     for (const id of removed) {
       if (!id.startsWith('file::')) continue;
+      recentlyRemovedIdsRef.current.add(id);
       const ftKey = id.slice('file::'.length);
       const uiTab = useUiStore
         .getState()
@@ -197,6 +178,37 @@ export function WorkspaceFilesArea({
       }
     }
   }, [layout]);
+
+  // Sync ui.openFileTabs → workspace tabs (add/remove).
+  useEffect(() => {
+    if (!initializedRef.current) return;
+    const wsIds = new Set<string>();
+    for (const pane of listPanes(layout)) {
+      for (const t of pane.tabs) wsIds.add(workspaceTabId(t));
+    }
+    const uiIds = new Set(openFileTabs.map(uiTabId));
+
+    for (const t of openFileTabs) {
+      const id = uiTabId(t);
+      if (wsIds.has(id)) continue;
+      // Suppress re-add for ids we just removed from layout — the ui store
+      // close has been dispatched but openFileTabs in this closure is stale.
+      if (recentlyRemovedIdsRef.current.has(id)) continue;
+      const targetPane =
+        activePaneId ??
+        (layout.type === 'pane' ? layout.id : listPanes(layout)[0]?.id);
+      if (targetPane) addTab(targetPane, uiTabToWorkspaceTab(t));
+    }
+    for (const id of wsIds) {
+      if (!uiIds.has(id)) closeTab(id);
+    }
+
+    // Once the ui store has caught up (the id is gone from openFileTabs),
+    // drop the suppression so future re-adds of the same path are allowed.
+    for (const id of Array.from(recentlyRemovedIdsRef.current)) {
+      if (!uiIds.has(id)) recentlyRemovedIdsRef.current.delete(id);
+    }
+  }, [openFileTabs, layout, activePaneId, addTab, closeTab]);
 
   // Sync ui.activeFileTabKey → workspace selection.
   useEffect(() => {

--- a/frontend/src/components/WorkspaceLayout.css
+++ b/frontend/src/components/WorkspaceLayout.css
@@ -1,0 +1,63 @@
+.ws-layout {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  background: var(--bg, #0a0a0a);
+  position: relative;
+}
+
+.ws-layout > [data-panel-group] {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+}
+
+.ws-resize-handle {
+  background: var(--border, #1a1a1a);
+  position: relative;
+  outline: none;
+  flex-shrink: 0;
+  transition: background 80ms ease;
+}
+
+.ws-resize-handle--horizontal {
+  width: 1px;
+  cursor: col-resize;
+}
+
+.ws-resize-handle--vertical {
+  height: 1px;
+  cursor: row-resize;
+}
+
+.ws-resize-handle:hover,
+.ws-resize-handle[data-resize-handle-active] {
+  background: var(--accent, #d97757);
+}
+
+.ws-resize-handle--horizontal::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -3px;
+  right: -3px;
+}
+
+.ws-resize-handle--vertical::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -3px;
+  bottom: -3px;
+}
+
+.ws-layout--dragging {
+  cursor: grabbing;
+}
+
+.ws-layout--dragging .ws-pane__body {
+  pointer-events: none;
+}

--- a/frontend/src/components/WorkspaceLayout.tsx
+++ b/frontend/src/components/WorkspaceLayout.tsx
@@ -1,0 +1,259 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+  type DragCancelEvent,
+} from '@dnd-kit/core';
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+import {
+  type SplitDirection,
+  type SplitPlacement,
+  type WorkspaceLayoutNode,
+  type WorkspaceTabId,
+} from '../lib/workspace-layout.js';
+import { useWorkspaceLayoutStore } from '../lib/stores/workspace-layout-store.js';
+import type { SummaryContext } from '../lib/workspace-summary.js';
+import { WorkspacePane } from './WorkspacePane.js';
+import './WorkspaceLayout.css';
+
+function useRafThrottle<Args extends unknown[]>(
+  fn: (...args: Args) => void
+): (...args: Args) => void {
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+  const rafId = useRef<number | null>(null);
+  const lastArgs = useRef<Args | null>(null);
+
+  useEffect(
+    () => () => {
+      if (rafId.current !== null) cancelAnimationFrame(rafId.current);
+      rafId.current = null;
+    },
+    []
+  );
+
+  return useCallback((...args: Args) => {
+    lastArgs.current = args;
+    if (rafId.current !== null) return;
+    rafId.current = requestAnimationFrame(() => {
+      rafId.current = null;
+      const args2 = lastArgs.current;
+      lastArgs.current = null;
+      if (args2) fnRef.current(...args2);
+    });
+  }, []);
+}
+
+interface DragData {
+  type: 'tab';
+  tabId: WorkspaceTabId;
+  sourcePaneId: string;
+}
+
+interface TabbarDropData {
+  type: 'tabbar';
+  paneId: string;
+}
+
+interface EdgeDropData {
+  type: 'edge';
+  paneId: string;
+  direction: SplitDirection;
+  placement: SplitPlacement;
+}
+
+type DropData = TabbarDropData | EdgeDropData;
+
+function nodeKey(node: WorkspaceLayoutNode): string {
+  if (node.type === 'pane') return `pane:${node.id}`;
+  return `split:${node.id}`;
+}
+
+interface RenderNodeProps {
+  node: WorkspaceLayoutNode;
+  activePaneId: string | null;
+  isDragActive: boolean;
+  summaryContext: SummaryContext;
+  splitSizes: Record<string, number[]>;
+  onAddTabRequest?: (paneId: string) => void;
+  onSplitLayout: (splitId: string, sizes: number[]) => void;
+}
+
+function RenderNode({
+  node,
+  activePaneId,
+  isDragActive,
+  summaryContext,
+  splitSizes,
+  onAddTabRequest,
+  onSplitLayout,
+}: RenderNodeProps): React.ReactElement {
+  if (node.type === 'pane') {
+    return (
+      <WorkspacePane
+        pane={node}
+        isActive={activePaneId === node.id}
+        isDragActive={isDragActive}
+        summaryContext={summaryContext}
+        {...(onAddTabRequest ? { onAddTabRequest } : {})}
+      />
+    );
+  }
+  const fallbackSize = 100 / node.children.length;
+  const persistedSizes = splitSizes[node.id];
+  return (
+    <PanelGroup
+      direction={node.direction}
+      onLayout={(sizes) => onSplitLayout(node.id, sizes)}
+      autoSaveId={undefined}
+    >
+      {node.children.map((child, i) => {
+        const size = persistedSizes?.[i] ?? fallbackSize;
+        return (
+          <React.Fragment key={nodeKey(child)}>
+            {i > 0 && (
+              <PanelResizeHandle
+                className={`ws-resize-handle ws-resize-handle--${node.direction}`}
+              />
+            )}
+            <Panel defaultSize={size} minSize={10}>
+              <RenderNode
+                node={child}
+                activePaneId={activePaneId}
+                isDragActive={isDragActive}
+                summaryContext={summaryContext}
+                splitSizes={splitSizes}
+                {...(onAddTabRequest ? { onAddTabRequest } : {})}
+                onSplitLayout={onSplitLayout}
+              />
+            </Panel>
+          </React.Fragment>
+        );
+      })}
+    </PanelGroup>
+  );
+}
+
+export interface WorkspaceLayoutProps {
+  summaryContext: SummaryContext;
+  onAddTabRequest?: (paneId: string) => void;
+}
+
+export function WorkspaceLayout({
+  summaryContext,
+  onAddTabRequest,
+}: WorkspaceLayoutProps): React.ReactElement {
+  const layout = useWorkspaceLayoutStore((s) => s.layout);
+  const activePaneId = useWorkspaceLayoutStore((s) => s.activePaneId);
+  const splitSizes = useWorkspaceLayoutStore((s) => s.splitSizes);
+  const moveTab = useWorkspaceLayoutStore((s) => s.moveTab);
+  const splitWithTab = useWorkspaceLayoutStore((s) => s.splitWithTab);
+  const setSplitSizes = useWorkspaceLayoutStore((s) => s.setSplitSizes);
+
+  const [isDragActive, setDragActive] = useState(false);
+  const [draggingTabId, setDraggingTabId] = useState<WorkspaceTabId | null>(
+    null
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 6 },
+    }),
+    useSensor(KeyboardSensor)
+  );
+
+  const handleDragStart = useCallback((evt: DragStartEvent) => {
+    setDragActive(true);
+    setDraggingTabId(String(evt.active.id));
+  }, []);
+
+  const handleDragCancel = useCallback((_evt: DragCancelEvent) => {
+    setDragActive(false);
+    setDraggingTabId(null);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (evt: DragEndEvent) => {
+      setDragActive(false);
+      setDraggingTabId(null);
+      const active = evt.active;
+      const over = evt.over;
+      if (!over || !active) return;
+      const dragData = active.data.current as DragData | undefined;
+      const dropData = over.data.current as DropData | undefined;
+      if (!dragData || dragData.type !== 'tab' || !dropData) return;
+
+      if (dropData.type === 'tabbar') {
+        if (dropData.paneId === dragData.sourcePaneId) return;
+        moveTab(dragData.tabId, dropData.paneId);
+        return;
+      }
+      if (dropData.type === 'edge') {
+        splitWithTab(
+          dropData.paneId,
+          dragData.tabId,
+          dropData.direction,
+          dropData.placement
+        );
+      }
+    },
+    [moveTab, splitWithTab]
+  );
+
+  const onSplitLayout = useRafThrottle(
+    useCallback(
+      (splitId: string, sizes: number[]) => {
+        setSplitSizes(splitId, sizes);
+      },
+      [setSplitSizes]
+    )
+  );
+
+  const dragContext = useMemo(
+    () => ({ isDragActive, draggingTabId }),
+    [isDragActive, draggingTabId]
+  );
+
+  return (
+    <div
+      className={[
+        'ws-layout',
+        dragContext.isDragActive ? 'ws-layout--dragging' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
+      >
+        <RenderNode
+          node={layout}
+          activePaneId={activePaneId}
+          isDragActive={isDragActive}
+          summaryContext={summaryContext}
+          splitSizes={splitSizes}
+          {...(onAddTabRequest ? { onAddTabRequest } : {})}
+          onSplitLayout={onSplitLayout}
+        />
+      </DndContext>
+    </div>
+  );
+}
+
+export default WorkspaceLayout;

--- a/frontend/src/components/WorkspaceLayoutDemo.css
+++ b/frontend/src/components/WorkspaceLayoutDemo.css
@@ -1,0 +1,129 @@
+.ws-demo {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg, #0a0a0a);
+  color: var(--text, #e6e6e6);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  z-index: 50;
+}
+
+.ws-demo__bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border, #1a1a1a);
+  font-size: 0.7rem;
+  color: var(--text-muted, #888);
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+  background: var(--bg-elev, #0d0d0d);
+}
+
+.ws-demo__brand {
+  color: var(--text, #e6e6e6);
+  font-weight: 600;
+}
+
+.ws-demo__sep {
+  opacity: 0.5;
+}
+
+.ws-demo__hint {
+  font-size: 0.65rem;
+}
+
+.ws-demo__spacer {
+  flex: 1;
+}
+
+.ws-demo__stat {
+  padding: 2px 8px;
+  border: 1px solid var(--border, #2a2a2a);
+}
+
+.ws-demo__btn {
+  padding: 3px 10px;
+  background: transparent;
+  border: 1px solid var(--border, #2a2a2a);
+  color: var(--text-muted, #888);
+  font-family: inherit;
+  font-size: 0.7rem;
+  text-transform: lowercase;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.ws-demo__btn:hover {
+  color: var(--text, #e6e6e6);
+  border-color: var(--accent, #d97757);
+}
+
+.ws-demo__main {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+  position: relative;
+}
+
+.ws-demo-mock {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  background: var(--bg, #0a0a0a);
+}
+
+.ws-demo-mock__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  font-size: 0.65rem;
+  color: var(--text-muted, #888);
+  border-bottom: 1px solid var(--border, #1a1a1a);
+  text-transform: lowercase;
+}
+
+.ws-demo-mock__label {
+  display: inline-block;
+  padding: 1px 6px;
+  border: 1px solid var(--border, #2a2a2a);
+  font-size: 0.6rem;
+}
+
+.ws-demo-mock__title {
+  color: var(--text, #e6e6e6);
+}
+
+.ws-demo-mock__meta {
+  margin-left: auto;
+  color: var(--text-muted, #666);
+}
+
+.ws-demo-mock__pill {
+  padding: 1px 6px;
+  border: 1px solid var(--status-warning, #f59e0b);
+  color: var(--status-warning, #f59e0b);
+  font-size: 0.6rem;
+}
+
+.ws-demo-mock__body {
+  flex: 1;
+  padding: 14px 18px;
+  overflow: auto;
+  font-size: 0.75rem;
+  color: var(--text, #c8c8c8);
+}
+
+.ws-demo-mock__body pre {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.5;
+}
+
+.ws-demo-mock--file .ws-demo-mock__body {
+  color: var(--text, #c8c8c8);
+}

--- a/frontend/src/components/WorkspaceLayoutDemo.css
+++ b/frontend/src/components/WorkspaceLayoutDemo.css
@@ -1,29 +1,36 @@
+/*
+ * Demo-only styling for the standalone `?workspaceDemo=1` route.
+ * All values come from DESIGN.md tokens (see App.css :root) — no ad-hoc
+ * colors / fonts / spacing. The demo follows the same TUI aesthetic as the
+ * production UI.
+ */
+
 .ws-demo {
   position: fixed;
   inset: 0;
   display: flex;
   flex-direction: column;
-  background: var(--bg, #0a0a0a);
-  color: var(--text, #e6e6e6);
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-mono);
   z-index: 50;
 }
 
 .ws-demo__bar {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 14px;
-  border-bottom: 1px solid var(--border, #1a1a1a);
-  font-size: 0.7rem;
-  color: var(--text-muted, #888);
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--border);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
   text-transform: lowercase;
   letter-spacing: 0.04em;
-  background: var(--bg-elev, #0d0d0d);
+  background: var(--surface);
 }
 
 .ws-demo__brand {
-  color: var(--text, #e6e6e6);
+  color: var(--text);
   font-weight: 600;
 }
 
@@ -32,7 +39,7 @@
 }
 
 .ws-demo__hint {
-  font-size: 0.65rem;
+  font-size: var(--font-size-xs);
 }
 
 .ws-demo__spacer {
@@ -40,25 +47,26 @@
 }
 
 .ws-demo__stat {
-  padding: 2px 8px;
-  border: 1px solid var(--border, #2a2a2a);
+  padding: var(--space-2xs) var(--space-sm);
+  border: 1px solid var(--border);
 }
 
 .ws-demo__btn {
-  padding: 3px 10px;
+  padding: var(--space-2xs) var(--space-sm);
   background: transparent;
-  border: 1px solid var(--border, #2a2a2a);
-  color: var(--text-muted, #888);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
   font-family: inherit;
-  font-size: 0.7rem;
+  font-size: var(--font-size-xs);
   text-transform: lowercase;
   cursor: pointer;
   text-decoration: none;
 }
 
 .ws-demo__btn:hover {
-  color: var(--text, #e6e6e6);
-  border-color: var(--accent, #d97757);
+  color: var(--text);
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 .ws-demo__main {
@@ -73,57 +81,53 @@
   flex-direction: column;
   flex: 1;
   min-height: 0;
-  background: var(--bg, #0a0a0a);
+  background: var(--bg);
 }
 
 .ws-demo-mock__head {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 14px;
-  font-size: 0.65rem;
-  color: var(--text-muted, #888);
-  border-bottom: 1px solid var(--border, #1a1a1a);
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
   text-transform: lowercase;
 }
 
 .ws-demo-mock__label {
   display: inline-block;
-  padding: 1px 6px;
-  border: 1px solid var(--border, #2a2a2a);
-  font-size: 0.6rem;
+  padding: 1px var(--space-xs);
+  border: 1px solid var(--border);
+  font-size: var(--font-size-xs);
 }
 
 .ws-demo-mock__title {
-  color: var(--text, #e6e6e6);
+  color: var(--text);
 }
 
 .ws-demo-mock__meta {
   margin-left: auto;
-  color: var(--text-muted, #666);
+  color: var(--text-muted);
 }
 
 .ws-demo-mock__pill {
-  padding: 1px 6px;
-  border: 1px solid var(--status-warning, #f59e0b);
-  color: var(--status-warning, #f59e0b);
-  font-size: 0.6rem;
+  padding: 1px var(--space-xs);
+  border: 1px solid var(--status-warning);
+  color: var(--status-warning);
+  font-size: var(--font-size-xs);
 }
 
 .ws-demo-mock__body {
   flex: 1;
-  padding: 14px 18px;
+  padding: var(--space-md) var(--space-lg);
   overflow: auto;
-  font-size: 0.75rem;
-  color: var(--text, #c8c8c8);
+  font-size: var(--font-size-sm);
+  color: var(--text);
 }
 
 .ws-demo-mock__body pre {
   margin: 0;
   white-space: pre-wrap;
   line-height: 1.5;
-}
-
-.ws-demo-mock--file .ws-demo-mock__body {
-  color: var(--text, #c8c8c8);
 }

--- a/frontend/src/components/WorkspaceLayoutDemo.tsx
+++ b/frontend/src/components/WorkspaceLayoutDemo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import type { SessionSummary } from '../lib/types.js';
 import { workspaceTabId, type WorkspaceTab } from '../lib/workspace-layout.js';
 import { useWorkspaceLayoutStore } from '../lib/stores/workspace-layout-store.js';
@@ -138,6 +138,7 @@ export function WorkspaceLayoutDemo() {
   const resetLayout = useWorkspaceLayoutStore((s) => s.resetLayout);
   const addTab = useWorkspaceLayoutStore((s) => s.addTab);
   const layout = useWorkspaceLayoutStore((s) => s.layout);
+  const mockTabCounterRef = useRef(0);
 
   useEffect(() => {
     resetLayout(MOCK_TABS);
@@ -163,7 +164,8 @@ export function WorkspaceLayoutDemo() {
   };
 
   const onAddTabRequest = (paneId: string) => {
-    const counter = (Math.random() * 1000) | 0;
+    mockTabCounterRef.current += 1;
+    const counter = mockTabCounterRef.current;
     const tab: WorkspaceTab = {
       kind: 'file',
       filePath: `mock/scratch-${counter}.ts`,

--- a/frontend/src/components/WorkspaceLayoutDemo.tsx
+++ b/frontend/src/components/WorkspaceLayoutDemo.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useMemo } from 'react';
+import type { SessionSummary } from '../lib/types.js';
+import { workspaceTabId, type WorkspaceTab } from '../lib/workspace-layout.js';
+import { useWorkspaceLayoutStore } from '../lib/stores/workspace-layout-store.js';
+import type { SummaryContext } from '../lib/workspace-summary.js';
+import { WorkspaceLayout } from './WorkspaceLayout.js';
+import { WorkspaceContentLayer } from './WorkspaceContentLayer.js';
+import './WorkspaceLayoutDemo.css';
+
+const DEMO_REPO_PATH = '/Users/demo/relay-ide';
+const NOW = new Date().toISOString();
+
+const MOCK_SESSIONS: SessionSummary[] = [
+  {
+    id: 'sess-claude-1',
+    type: 'agent',
+    agent: 'claude',
+    repoName: 'relay-ide',
+    repoPath: DEMO_REPO_PATH,
+    worktreePath: null,
+    cwd: DEMO_REPO_PATH,
+    branchName: 'feat/slash-commands',
+    displayName: 'add slash-command palette',
+    createdAt: NOW,
+    lastActivity: NOW,
+    idle: false,
+    agentState: 'processing',
+  },
+  {
+    id: 'sess-codex-1',
+    type: 'agent',
+    agent: 'codex',
+    repoName: 'relay-ide',
+    repoPath: DEMO_REPO_PATH,
+    worktreePath: null,
+    cwd: DEMO_REPO_PATH,
+    branchName: 'refactor/use-tokens',
+    displayName: 'refactor useComposerState',
+    createdAt: NOW,
+    lastActivity: NOW,
+    idle: false,
+    agentState: 'waiting-for-input',
+  },
+  {
+    id: 'sess-term-1',
+    type: 'terminal',
+    agent: 'bash',
+    repoName: 'relay-ide',
+    repoPath: DEMO_REPO_PATH,
+    worktreePath: null,
+    cwd: DEMO_REPO_PATH,
+    branchName: '',
+    displayName: 'pnpm dev',
+    createdAt: NOW,
+    lastActivity: NOW,
+    idle: false,
+  },
+];
+
+const MOCK_TABS: WorkspaceTab[] = [
+  { kind: 'session', sessionId: 'sess-claude-1', sessionType: 'agent' },
+  { kind: 'session', sessionId: 'sess-codex-1', sessionType: 'agent' },
+  { kind: 'session', sessionId: 'sess-term-1', sessionType: 'terminal' },
+  {
+    kind: 'file',
+    filePath: 'frontend/src/components/Composer.tsx',
+    tabType: 'code',
+  },
+  {
+    kind: 'file',
+    filePath: 'frontend/src/lib/useComposerState.ts',
+    tabType: 'code',
+  },
+  { kind: 'file', filePath: 'main…feat/slash-commands', tabType: 'diff' },
+  { kind: 'file', filePath: 'mock/preview.html', tabType: 'html' },
+];
+
+const CHANGED_FILES = new Set([
+  'frontend/src/components/Composer.tsx',
+  'frontend/src/lib/useComposerState.ts',
+]);
+
+function MockSessionContent({ session }: { session: SessionSummary }) {
+  return (
+    <div className="ws-demo-mock ws-demo-mock--session">
+      <div className="ws-demo-mock__head">
+        <span className="ws-demo-mock__label">
+          {session.type === 'terminal' ? 'terminal' : 'agent'}
+        </span>
+        <span className="ws-demo-mock__title">{session.displayName}</span>
+        <span className="ws-demo-mock__meta">
+          {session.agent} · {session.agentState ?? 'idle'}
+        </span>
+      </div>
+      <div className="ws-demo-mock__body">
+        <pre>{`session id: ${session.id}
+branch: ${session.branchName || '(none)'}
+cwd: ${session.cwd}
+last activity: ${new Date(session.lastActivity).toLocaleTimeString()}
+
+[mock content — replace with real <SessionContent /> in production wire]`}</pre>
+      </div>
+    </div>
+  );
+}
+
+function MockFileContent({
+  tab,
+}: {
+  tab: Extract<WorkspaceTab, { kind: 'file' }>;
+}) {
+  return (
+    <div className="ws-demo-mock ws-demo-mock--file">
+      <div className="ws-demo-mock__head">
+        <span className="ws-demo-mock__label">{tab.tabType}</span>
+        <span className="ws-demo-mock__title">{tab.filePath}</span>
+        {CHANGED_FILES.has(tab.filePath) && (
+          <span className="ws-demo-mock__pill">unsaved</span>
+        )}
+      </div>
+      <div className="ws-demo-mock__body">
+        <pre>{`path: ${tab.filePath}
+type: ${tab.tabType}
+
+[mock content — replace with real <FileTabContent /> in production wire]
+
+Try:
+  • drag this tab to another pane's tab bar to move it
+  • drag to a pane edge (top/bottom/left/right) to split
+  • close with × button
+  • click the + button on a tab bar to add a new mock tab`}</pre>
+      </div>
+    </div>
+  );
+}
+
+export function WorkspaceLayoutDemo() {
+  const resetLayout = useWorkspaceLayoutStore((s) => s.resetLayout);
+  const addTab = useWorkspaceLayoutStore((s) => s.addTab);
+  const layout = useWorkspaceLayoutStore((s) => s.layout);
+
+  useEffect(() => {
+    resetLayout(MOCK_TABS);
+  }, [resetLayout]);
+
+  const summaryContext = useMemo<SummaryContext>(
+    () => ({
+      findSession: (id) => MOCK_SESSIONS.find((s) => s.id === id),
+      isFileChanged: (path) => CHANGED_FILES.has(path),
+      repoLabel: 'R',
+      repoColor: '#d97757',
+    }),
+    []
+  );
+
+  const renderTab = (tab: WorkspaceTab) => {
+    if (tab.kind === 'session') {
+      const session = MOCK_SESSIONS.find((s) => s.id === tab.sessionId);
+      if (!session) return <div className="ws-demo-mock">unknown session</div>;
+      return <MockSessionContent session={session} />;
+    }
+    return <MockFileContent tab={tab} />;
+  };
+
+  const onAddTabRequest = (paneId: string) => {
+    const counter = (Math.random() * 1000) | 0;
+    const tab: WorkspaceTab = {
+      kind: 'file',
+      filePath: `mock/scratch-${counter}.ts`,
+      tabType: 'code',
+    };
+    addTab(paneId, tab);
+  };
+
+  const tabCount = useMemo(() => {
+    function count(node: typeof layout): number {
+      if (node.type === 'pane') return node.tabs.length;
+      return node.children.reduce((s, c) => s + count(c), 0);
+    }
+    return count(layout);
+  }, [layout]);
+
+  return (
+    <div className="ws-demo">
+      <header className="ws-demo__bar">
+        <span className="ws-demo__brand">workspace layout · demo</span>
+        <span className="ws-demo__sep">·</span>
+        <span className="ws-demo__hint">
+          drag tab onto another tab bar to move · onto an edge to split
+        </span>
+        <span className="ws-demo__spacer" />
+        <span className="ws-demo__stat">{tabCount} tabs</span>
+        <button className="ws-demo__btn" onClick={() => resetLayout(MOCK_TABS)}>
+          reset
+        </button>
+        <a className="ws-demo__btn" href="?">
+          exit demo
+        </a>
+      </header>
+      <main className="ws-demo__main">
+        <WorkspaceLayout
+          summaryContext={summaryContext}
+          onAddTabRequest={onAddTabRequest}
+        />
+        <WorkspaceContentLayer renderTab={renderTab} />
+      </main>
+    </div>
+  );
+}
+
+export default WorkspaceLayoutDemo;
+
+// Helper used during workspace tab id calc when seeding new tabs.
+export const _seedTabId = workspaceTabId;

--- a/frontend/src/components/WorkspacePane.css
+++ b/frontend/src/components/WorkspacePane.css
@@ -1,0 +1,159 @@
+.ws-pane {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  background: var(--bg, #0a0a0a);
+  position: relative;
+  isolation: isolate;
+}
+
+.ws-pane--active {
+  box-shadow: inset 0 0 0 1px var(--border, #1f1f1f);
+}
+
+.ws-pane__body-wrap {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.ws-pane__body {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
+.ws-pane__empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted, #666);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.75rem;
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+}
+
+.ws-pane__summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border, #1a1a1a);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.7rem;
+  color: var(--text-muted, #888);
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  flex: 0 0 auto;
+}
+
+.ws-pane__summary--session {
+  gap: 10px;
+}
+
+.ws-pane__summary-title {
+  color: var(--text, #e6e6e6);
+}
+
+.ws-pane__summary-meta {
+  color: var(--text-muted, #888);
+}
+
+.ws-pane__summary-dot {
+  width: 6px;
+  height: 6px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.ws-pane__summary-dot--live {
+  background: var(--status-success, #34d399);
+  animation: ws-pulse 1.4s infinite;
+}
+.ws-pane__summary-dot--attention {
+  background: var(--status-warning, #f59e0b);
+}
+.ws-pane__summary-dot--error {
+  background: var(--status-error, #ef4444);
+}
+.ws-pane__summary-dot--idle {
+  background: var(--text-muted, #555);
+}
+
+.ws-pane__summary-crumb {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.ws-pane__summary-repo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  font-size: 0.6rem;
+  font-weight: 600;
+  color: var(--bg, #0a0a0a);
+  background: var(--accent, #d97757);
+  margin-right: 4px;
+  flex-shrink: 0;
+}
+
+.ws-pane__summary-seg {
+  flex-shrink: 0;
+}
+.ws-pane__summary-seg--name {
+  color: var(--text, #e6e6e6);
+}
+.ws-pane__summary-sep {
+  color: var(--border, #2a2a2a);
+  flex-shrink: 0;
+}
+
+.ws-pane__summary-pills {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.ws-pane__summary-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 6px;
+  border: 1px solid var(--border, #2a2a2a);
+  font-size: 0.65rem;
+  color: var(--text-muted, #888);
+  background: transparent;
+}
+
+.ws-pane__summary-pill--dirty {
+  color: var(--status-warning, #f59e0b);
+  border-color: currentColor;
+}
+
+.ws-pane__summary-pill-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background: currentColor;
+  flex-shrink: 0;
+}

--- a/frontend/src/components/WorkspacePane.tsx
+++ b/frontend/src/components/WorkspacePane.tsx
@@ -1,0 +1,166 @@
+import React, { memo, useEffect, useRef } from 'react';
+import {
+  workspaceTabId,
+  type WorkspacePane as PaneModel,
+  type WorkspaceTab,
+  type WorkspaceTabId,
+} from '../lib/workspace-layout.js';
+import {
+  registerPaneBodyEl,
+  useWorkspaceLayoutStore,
+} from '../lib/stores/workspace-layout-store.js';
+import {
+  summaryForTab,
+  type SummaryContext,
+  type WorkspaceTabSummary,
+} from '../lib/workspace-summary.js';
+import { WorkspaceTabBar } from './WorkspaceTabBar.js';
+import { WorkspaceDropOverlay } from './WorkspaceDropOverlay.js';
+import './WorkspacePane.css';
+
+interface WorkspacePaneSummaryStripProps {
+  tab: WorkspaceTab;
+  summary: WorkspaceTabSummary;
+}
+
+function WorkspacePaneSummaryStrip({
+  tab,
+  summary,
+}: WorkspacePaneSummaryStripProps) {
+  if (tab.kind === 'file') {
+    const segments = summary.breadcrumb?.segments ?? [];
+    return (
+      <div className="ws-pane__summary ws-pane__summary--file">
+        <div className="ws-pane__summary-crumb">
+          {summary.breadcrumb?.repoLabel && (
+            <span
+              className="ws-pane__summary-repo"
+              style={
+                summary.breadcrumb.repoColor
+                  ? { background: summary.breadcrumb.repoColor }
+                  : undefined
+              }
+            >
+              {summary.breadcrumb.repoLabel}
+            </span>
+          )}
+          {segments.map((seg, i) => {
+            const last = i === segments.length - 1;
+            return (
+              <React.Fragment key={`${seg}-${i}`}>
+                <span
+                  className={[
+                    'ws-pane__summary-seg',
+                    last ? 'ws-pane__summary-seg--name' : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
+                >
+                  {seg}
+                </span>
+                {!last && <span className="ws-pane__summary-sep">/</span>}
+              </React.Fragment>
+            );
+          })}
+        </div>
+        <div className="ws-pane__summary-pills">
+          {summary.pills.map((pill, i) => (
+            <span
+              key={`${pill.label}-${i}`}
+              className={`ws-pane__summary-pill ws-pane__summary-pill--${pill.kind}`}
+            >
+              {pill.kind === 'dirty' && (
+                <span className="ws-pane__summary-pill-dot" />
+              )}
+              {pill.label}
+            </span>
+          ))}
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="ws-pane__summary ws-pane__summary--session">
+      <span className="ws-pane__summary-title">{summary.primary}</span>
+      {summary.meta && (
+        <span className="ws-pane__summary-meta">{summary.meta}</span>
+      )}
+      {summary.dot && (
+        <span
+          className={`ws-pane__summary-dot ws-pane__summary-dot--${summary.dot}`}
+        />
+      )}
+    </div>
+  );
+}
+
+export interface WorkspacePaneProps {
+  pane: PaneModel;
+  isActive: boolean;
+  isDragActive: boolean;
+  summaryContext: SummaryContext;
+  onAddTabRequest?: (paneId: string) => void;
+}
+
+function WorkspacePaneImpl({
+  pane,
+  isActive,
+  isDragActive,
+  summaryContext,
+  onAddTabRequest,
+}: WorkspacePaneProps) {
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const selectTab = useWorkspaceLayoutStore((s) => s.selectTab);
+  const closeTab = useWorkspaceLayoutStore((s) => s.closeTab);
+  const setActivePane = useWorkspaceLayoutStore((s) => s.setActivePane);
+
+  useEffect(() => {
+    registerPaneBodyEl(pane.id, bodyRef.current);
+    return () => registerPaneBodyEl(pane.id, null);
+  }, [pane.id]);
+
+  const activeTab = pane.tabs.find(
+    (t) => workspaceTabId(t) === pane.activeTabId
+  );
+  const activeSummary = activeTab
+    ? summaryForTab(activeTab, summaryContext)
+    : null;
+
+  const handleSelect = (tabId: WorkspaceTabId) => selectTab(pane.id, tabId);
+  const handleClose = (tabId: WorkspaceTabId) => closeTab(tabId);
+
+  return (
+    <div
+      className={['ws-pane', isActive ? 'ws-pane--active' : '']
+        .filter(Boolean)
+        .join(' ')}
+      onMouseDown={() => {
+        if (!isActive) setActivePane(pane.id);
+      }}
+    >
+      <WorkspaceTabBar
+        pane={pane}
+        summaryContext={summaryContext}
+        onSelectTab={handleSelect}
+        onCloseTab={handleClose}
+        {...(onAddTabRequest
+          ? { onAddTabRequest: () => onAddTabRequest(pane.id) }
+          : {})}
+      />
+      {activeTab && activeSummary && (
+        <WorkspacePaneSummaryStrip tab={activeTab} summary={activeSummary} />
+      )}
+      <div className="ws-pane__body-wrap">
+        <div className="ws-pane__body" ref={bodyRef} role="tabpanel">
+          {!activeTab && (
+            <div className="ws-pane__empty">empty pane · drop a tab here</div>
+          )}
+        </div>
+      </div>
+      <WorkspaceDropOverlay paneId={pane.id} active={isDragActive} />
+    </div>
+  );
+}
+
+export const WorkspacePane = memo(WorkspacePaneImpl);
+export default WorkspacePane;

--- a/frontend/src/components/WorkspaceTabBar.css
+++ b/frontend/src/components/WorkspaceTabBar.css
@@ -1,0 +1,197 @@
+.ws-tabs {
+  display: flex;
+  align-items: stretch;
+  height: 32px;
+  background: var(--bg, #0a0a0a);
+  border-bottom: 1px solid var(--border, #1a1a1a);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  flex: 0 0 auto;
+}
+
+.ws-tabs--drop-target {
+  background: color-mix(in srgb, var(--accent, #d97757) 8%, var(--bg, #0a0a0a));
+}
+
+.ws-tabs__spacer {
+  flex: 1;
+  border-bottom: 1px solid var(--border, #1a1a1a);
+  min-width: 0;
+}
+
+.ws-tabs__add {
+  flex: 0 0 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-right: 1px solid var(--border, #1a1a1a);
+  color: var(--text-muted, #888);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.ws-tabs__add:hover {
+  color: var(--text, #e6e6e6);
+  background: var(--bg-elev, #111);
+}
+
+.ws-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 100%;
+  padding: 0 10px;
+  border-right: 1px solid var(--border, #1a1a1a);
+  background: transparent;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.7rem;
+  color: var(--text-muted, #888);
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  max-width: 280px;
+  outline: none;
+  position: relative;
+}
+
+.ws-tab:hover {
+  background: var(--bg-elev, #111);
+  color: var(--text, #e6e6e6);
+}
+
+.ws-tab:focus-visible {
+  box-shadow: inset 0 0 0 1px var(--accent, #d97757);
+}
+
+.ws-tab--active {
+  background: var(--bg-active, #161616);
+  color: var(--text, #e6e6e6);
+  box-shadow: inset 0 -1px 0 0 var(--accent, #d97757);
+}
+
+.ws-tab--dragging {
+  opacity: 0.4;
+}
+
+.ws-tab__icon {
+  font-size: 0.75rem;
+  width: 16px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.ws-tab__icon--session-claude {
+  color: var(--accent, #d97757);
+}
+.ws-tab__icon--session-codex {
+  color: #34d399;
+}
+.ws-tab__icon--session-opencode {
+  color: #60a5fa;
+}
+.ws-tab__icon--session-hermes {
+  color: #a78bfa;
+}
+.ws-tab__icon--session-agent {
+  color: var(--text, #e6e6e6);
+}
+.ws-tab__icon--session-terminal {
+  color: var(--text, #e6e6e6);
+  font-size: 0.65rem;
+  letter-spacing: -1px;
+}
+.ws-tab__icon--file-diff {
+  color: var(--status-warning, #f59e0b);
+}
+.ws-tab__icon--file-html-preview {
+  color: #60a5fa;
+}
+
+.ws-tab__name {
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.ws-tab__meta {
+  flex: 0 0 auto;
+  color: var(--text-muted, #888);
+  font-size: 0.62rem;
+  border-left: 1px solid var(--border, #1a1a1a);
+  padding-left: 6px;
+  margin-left: 2px;
+  opacity: 0.85;
+}
+
+.ws-tab__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 0;
+  flex-shrink: 0;
+}
+
+.ws-tab__dot--live {
+  background: var(--status-success, #34d399);
+  animation: ws-pulse 1.4s infinite;
+}
+.ws-tab__dot--attention {
+  background: var(--status-warning, #f59e0b);
+}
+.ws-tab__dot--error {
+  background: var(--status-error, #ef4444);
+}
+.ws-tab__dot--idle {
+  background: var(--text-muted, #555);
+}
+
+@keyframes ws-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+.ws-tab__close {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  color: var(--text-muted, #666);
+  font-size: 0.85rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.6;
+  margin-left: 4px;
+}
+
+.ws-tab__close:hover {
+  background: var(--border, #2a2a2a);
+  color: var(--text, #e6e6e6);
+  opacity: 1;
+}
+
+@media (max-width: 720px) {
+  .ws-tab {
+    max-width: 180px;
+  }
+  .ws-tab__meta {
+    display: none;
+  }
+}

--- a/frontend/src/components/WorkspaceTabBar.tsx
+++ b/frontend/src/components/WorkspaceTabBar.tsx
@@ -105,6 +105,13 @@ function WorkspaceTabItem({
         className="ws-tab__close"
         aria-label={`close ${summary.primary}`}
         onPointerDown={(e) => e.stopPropagation()}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.stopPropagation();
+            e.preventDefault();
+            onClose();
+          }
+        }}
         onClick={(e) => {
           e.stopPropagation();
           onClose();

--- a/frontend/src/components/WorkspaceTabBar.tsx
+++ b/frontend/src/components/WorkspaceTabBar.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { useDraggable, useDroppable } from '@dnd-kit/core';
+import {
+  workspaceTabId,
+  type WorkspacePane,
+  type WorkspaceTab,
+  type WorkspaceTabId,
+} from '../lib/workspace-layout.js';
+import {
+  summaryForTab,
+  type SummaryContext,
+  type WorkspaceTabSummary,
+} from '../lib/workspace-summary.js';
+import './WorkspaceTabBar.css';
+
+const ICON_GLYPH: Record<WorkspaceTabSummary['icon'], string> = {
+  'session-claude': '✱',
+  'session-codex': '◆',
+  'session-opencode': '○',
+  'session-hermes': '△',
+  'session-agent': '✱',
+  'session-terminal': '›_',
+  'file-tsx': '⟨⟩',
+  'file-ts': 'TS',
+  'file-jsx': '⟨⟩',
+  'file-js': 'JS',
+  'file-py': 'PY',
+  'file-rs': 'RS',
+  'file-go': 'GO',
+  'file-css': '#',
+  'file-html': '<>',
+  'file-md': 'MD',
+  'file-json': '{}',
+  'file-generic': '·',
+  'file-diff': '±',
+  'file-html-preview': '⌬',
+};
+
+interface WorkspaceTabItemProps {
+  tab: WorkspaceTab;
+  paneId: string;
+  isActive: boolean;
+  summary: WorkspaceTabSummary;
+  onSelect: () => void;
+  onClose: () => void;
+}
+
+function WorkspaceTabItem({
+  tab,
+  paneId,
+  isActive,
+  summary,
+  onSelect,
+  onClose,
+}: WorkspaceTabItemProps) {
+  const tabId = workspaceTabId(tab);
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: tabId,
+    data: { type: 'tab', tabId, sourcePaneId: paneId },
+  });
+
+  const className = [
+    'ws-tab',
+    isActive ? 'ws-tab--active' : '',
+    isDragging ? 'ws-tab--dragging' : '',
+    `ws-tab--${tab.kind}`,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={className}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      title={summary.primary}
+      {...attributes}
+      {...listeners}
+      role="tab"
+      tabIndex={0}
+      aria-selected={isActive}
+    >
+      <span
+        className={`ws-tab__icon ws-tab__icon--${summary.icon}`}
+        aria-hidden
+      >
+        {ICON_GLYPH[summary.icon]}
+      </span>
+      <span className="ws-tab__name">{summary.primary}</span>
+      {summary.meta && <span className="ws-tab__meta">{summary.meta}</span>}
+      {summary.dot && (
+        <span
+          className={`ws-tab__dot ws-tab__dot--${summary.dot}`}
+          aria-hidden
+        />
+      )}
+      <button
+        type="button"
+        className="ws-tab__close"
+        aria-label={`close ${summary.primary}`}
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClose();
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+export interface WorkspaceTabBarProps {
+  pane: WorkspacePane;
+  summaryContext: SummaryContext;
+  onSelectTab: (tabId: WorkspaceTabId) => void;
+  onCloseTab: (tabId: WorkspaceTabId) => void;
+  onAddTabRequest?: () => void;
+}
+
+export function WorkspaceTabBar({
+  pane,
+  summaryContext,
+  onSelectTab,
+  onCloseTab,
+  onAddTabRequest,
+}: WorkspaceTabBarProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `tabbar:${pane.id}`,
+    data: { type: 'tabbar', paneId: pane.id },
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={['ws-tabs', isOver ? 'ws-tabs--drop-target' : '']
+        .filter(Boolean)
+        .join(' ')}
+      role="tablist"
+    >
+      {pane.tabs.map((tab) => {
+        const tabId = workspaceTabId(tab);
+        const summary = summaryForTab(tab, summaryContext);
+        return (
+          <WorkspaceTabItem
+            key={tabId}
+            tab={tab}
+            paneId={pane.id}
+            isActive={pane.activeTabId === tabId}
+            summary={summary}
+            onSelect={() => onSelectTab(tabId)}
+            onClose={() => onCloseTab(tabId)}
+          />
+        );
+      })}
+      {onAddTabRequest && (
+        <button
+          type="button"
+          className="ws-tabs__add"
+          aria-label="add tab"
+          onClick={onAddTabRequest}
+        >
+          +
+        </button>
+      )}
+      <span className="ws-tabs__spacer" aria-hidden />
+    </div>
+  );
+}
+
+export default WorkspaceTabBar;

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -10,6 +10,7 @@ const RIGHT_SIDEBAR_WIDTH_KEY = 'claude-remote-right-sidebar-width';
 const RIGHT_SIDEBAR_COLLAPSED_KEY = 'claude-remote-right-sidebar-collapsed';
 const UTILITY_RAIL_STATE_KEY_PREFIX = 'relay-utility-rail::';
 const FILE_VIEWER_WIDTH_KEY = 'claude-remote-file-viewer-width';
+const WORKSPACE_LAYOUT_KEY = 'claude-remote-workspace-layout-enabled';
 const DIFF_VIEW_MODE_KEY = 'claude-remote-diff-view-mode';
 const WORD_WRAP_KEY = 'claude-remote-word-wrap';
 const COLLAPSED_WORKSPACES_KEY = 'claude-remote-collapsed-workspaces';
@@ -126,6 +127,23 @@ function loadDiffViewMode(): DiffViewMode {
   const stored = ls(DIFF_VIEW_MODE_KEY);
   if (stored === 'unified' || stored === 'side-by-side') return stored;
   return 'unified';
+}
+
+function loadWorkspaceLayoutEnabled(): boolean {
+  if (typeof window !== 'undefined') {
+    const param = new URLSearchParams(window.location.search).get(
+      'workspaceLayout'
+    );
+    if (param === '1') {
+      lsSave(WORKSPACE_LAYOUT_KEY, 'true');
+      return true;
+    }
+    if (param === '0') {
+      lsRemove(WORKSPACE_LAYOUT_KEY);
+      return false;
+    }
+  }
+  return ls(WORKSPACE_LAYOUT_KEY) === 'true';
 }
 
 function loadTerminalFontSize(): number {
@@ -313,6 +331,8 @@ export interface UiState {
   rightSidebarCollapsed: boolean;
   rightSidebarWidth: number;
   rightSidebarTab: RightSidebarTab;
+  workspaceLayoutEnabled: boolean;
+  setWorkspaceLayoutEnabled: (enabled: boolean) => void;
   utilityRailByWorkspace: Record<string, WorkspaceUtilityRailState>;
   getUtilityRailState: (workspacePath: string) => WorkspaceUtilityRailState;
   hydrateUtilityRailState: (workspacePath: string) => void;
@@ -399,6 +419,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   rightSidebarCollapsed: ls(RIGHT_SIDEBAR_COLLAPSED_KEY) === 'true',
   rightSidebarWidth: loadRightSidebarWidth(),
   rightSidebarTab: 'changes',
+  workspaceLayoutEnabled: loadWorkspaceLayoutEnabled(),
   utilityRailByWorkspace: {},
   openFileTabs: [],
   activeFileTabKey: null,
@@ -411,6 +432,12 @@ export const useUiStore = create<UiState>()((set, get) => ({
 
   openSidebar: () => set({ sidebarOpen: true }),
   closeSidebar: () => set({ sidebarOpen: false }),
+
+  setWorkspaceLayoutEnabled: (enabled) => {
+    if (enabled) lsSave(WORKSPACE_LAYOUT_KEY, 'true');
+    else lsRemove(WORKSPACE_LAYOUT_KEY);
+    set({ workspaceLayoutEnabled: enabled });
+  },
 
   saveSidebarWidth: () => lsSave(SIDEBAR_WIDTH_KEY, String(get().sidebarWidth)),
 

--- a/frontend/src/lib/stores/workspace-layout-store.ts
+++ b/frontend/src/lib/stores/workspace-layout-store.ts
@@ -1,0 +1,217 @@
+import { create } from 'zustand';
+import {
+  addTabToPane,
+  closeLayoutTab,
+  collectSplitIds,
+  createDefaultWorkspaceLayout,
+  listPanes,
+  moveTabToPane,
+  selectLayoutTab,
+  splitPaneWithTab,
+  workspaceTabId,
+  type SplitDirection,
+  type SplitPlacement,
+  type WorkspaceLayoutNode,
+  type WorkspaceTab,
+  type WorkspaceTabId,
+} from '../workspace-layout.js';
+
+export type SplitSizes = Record<string, number[]>;
+
+interface WorkspaceLayoutState {
+  layout: WorkspaceLayoutNode;
+  activePaneId: string | null;
+  splitSizes: SplitSizes;
+
+  selectTab: (paneId: string, tabId: WorkspaceTabId) => void;
+  setActivePane: (paneId: string) => void;
+  closeTab: (tabId: WorkspaceTabId) => void;
+  moveTab: (
+    tabId: WorkspaceTabId,
+    targetPaneId: string,
+    targetIndex?: number
+  ) => void;
+  splitWithTab: (
+    sourcePaneId: string,
+    tabId: WorkspaceTabId,
+    direction: SplitDirection,
+    placement: SplitPlacement
+  ) => void;
+  addTab: (
+    paneId: string,
+    tab: WorkspaceTab,
+    opts?: { activate?: boolean; index?: number }
+  ) => void;
+  setSplitSizes: (splitId: string, sizes: number[]) => void;
+  resetLayout: (tabs: WorkspaceTab[]) => void;
+  setLayout: (layout: WorkspaceLayoutNode) => void;
+}
+
+function ensureValidActivePane(
+  layout: WorkspaceLayoutNode,
+  current: string | null
+): string | null {
+  const panes = listPanes(layout);
+  if (panes.length === 0) return null;
+  if (current && panes.some((p) => p.id === current)) return current;
+  return panes[0]?.id ?? null;
+}
+
+function gcSplitSizes(
+  layout: WorkspaceLayoutNode,
+  prev: SplitSizes
+): SplitSizes {
+  const liveIds = new Set(collectSplitIds(layout));
+  let changed = false;
+  const next: SplitSizes = {};
+  for (const id of Object.keys(prev)) {
+    if (liveIds.has(id)) {
+      next[id] = prev[id]!;
+    } else {
+      changed = true;
+    }
+  }
+  return changed ? next : prev;
+}
+
+const INITIAL_LAYOUT: WorkspaceLayoutNode = createDefaultWorkspaceLayout([]);
+
+export const useWorkspaceLayoutStore = create<WorkspaceLayoutState>()(
+  (set) => ({
+    layout: INITIAL_LAYOUT,
+    activePaneId: INITIAL_LAYOUT.type === 'pane' ? INITIAL_LAYOUT.id : null,
+    splitSizes: {},
+
+    selectTab: (paneId, tabId) =>
+      set((state) => ({
+        layout: selectLayoutTab(state.layout, paneId, tabId),
+        activePaneId: paneId,
+      })),
+
+    setActivePane: (paneId) => set({ activePaneId: paneId }),
+
+    closeTab: (tabId) =>
+      set((state) => {
+        const next = closeLayoutTab(state.layout, tabId);
+        return {
+          layout: next,
+          activePaneId: ensureValidActivePane(next, state.activePaneId),
+          splitSizes: gcSplitSizes(next, state.splitSizes),
+        };
+      }),
+
+    moveTab: (tabId, targetPaneId, targetIndex) =>
+      set((state) => {
+        const next = moveTabToPane(
+          state.layout,
+          tabId,
+          targetPaneId,
+          targetIndex
+        );
+        return {
+          layout: next,
+          activePaneId: ensureValidActivePane(next, targetPaneId),
+          splitSizes: gcSplitSizes(next, state.splitSizes),
+        };
+      }),
+
+    splitWithTab: (sourcePaneId, tabId, direction, placement) =>
+      set((state) => {
+        const next = splitPaneWithTab(
+          state.layout,
+          sourcePaneId,
+          tabId,
+          direction,
+          placement
+        );
+        return {
+          layout: next,
+          activePaneId: ensureValidActivePane(next, state.activePaneId),
+          splitSizes: gcSplitSizes(next, state.splitSizes),
+        };
+      }),
+
+    addTab: (paneId, tab, opts) =>
+      set((state) => {
+        const next = addTabToPane(state.layout, paneId, tab, opts);
+        return {
+          layout: next,
+          activePaneId: opts?.activate === false ? state.activePaneId : paneId,
+        };
+      }),
+
+    setSplitSizes: (splitId, sizes) =>
+      set((state) => {
+        const prev = state.splitSizes[splitId];
+        if (
+          prev &&
+          prev.length === sizes.length &&
+          prev.every((v, i) => v === sizes[i])
+        ) {
+          return state;
+        }
+        return {
+          splitSizes: { ...state.splitSizes, [splitId]: sizes },
+        };
+      }),
+
+    resetLayout: (tabs) => {
+      const layout = createDefaultWorkspaceLayout(tabs);
+      set({ layout, activePaneId: layout.id, splitSizes: {} });
+    },
+
+    setLayout: (layout) =>
+      set((state) => ({
+        layout,
+        activePaneId: ensureValidActivePane(layout, state.activePaneId),
+        splitSizes: gcSplitSizes(layout, state.splitSizes),
+      })),
+  })
+);
+
+const paneBodyElements = new Map<string, HTMLElement | null>();
+const paneBodyListeners = new Set<() => void>();
+
+export function registerPaneBodyEl(
+  paneId: string,
+  el: HTMLElement | null
+): void {
+  if (el === null) {
+    paneBodyElements.delete(paneId);
+  } else {
+    paneBodyElements.set(paneId, el);
+  }
+  paneBodyListeners.forEach((fn) => fn());
+}
+
+export function getPaneBodyEl(paneId: string): HTMLElement | null {
+  return paneBodyElements.get(paneId) ?? null;
+}
+
+export function subscribeToPaneBodyEls(fn: () => void): () => void {
+  paneBodyListeners.add(fn);
+  return () => paneBodyListeners.delete(fn);
+}
+
+export function getAllPaneBodyEls(): ReadonlyMap<string, HTMLElement | null> {
+  return paneBodyElements;
+}
+
+export function getActiveTabIdForPane(
+  state: WorkspaceLayoutState,
+  paneId: string
+): WorkspaceTabId | null {
+  const panes = listPanes(state.layout);
+  const pane = panes.find((p) => p.id === paneId);
+  return pane?.activeTabId ?? null;
+}
+
+export function findPaneIdForTab(
+  state: WorkspaceLayoutState,
+  tabId: WorkspaceTabId
+): string | null {
+  for (const pane of listPanes(state.layout)) {
+    if (pane.tabs.some((t) => workspaceTabId(t) === tabId)) return pane.id;
+  }
+  return null;
+}

--- a/frontend/src/lib/workspace-layout.ts
+++ b/frontend/src/lib/workspace-layout.ts
@@ -51,7 +51,8 @@ export function freshSplitId(prefix = 'split'): string {
   return `${prefix}-${_splitCounter}`;
 }
 
-export function _resetPaneCounter(): void {
+// Resets both the pane and split id counters. Test-only.
+export function _resetIdCounters(): void {
   _paneCounter = 0;
   _splitCounter = 0;
 }

--- a/frontend/src/lib/workspace-layout.ts
+++ b/frontend/src/lib/workspace-layout.ts
@@ -1,0 +1,345 @@
+import { fileTabKey, type FileTabType } from './stores/ui.js';
+
+export type WorkspaceTab =
+  | {
+      kind: 'session';
+      sessionId: string;
+      sessionType: 'agent' | 'terminal';
+    }
+  | {
+      kind: 'file';
+      filePath: string;
+      tabType: FileTabType;
+      token?: string;
+    };
+
+export type WorkspaceTabId = string;
+
+export function workspaceTabId(tab: WorkspaceTab): WorkspaceTabId {
+  if (tab.kind === 'session') return `session::${tab.sessionId}`;
+  return `file::${fileTabKey(tab.filePath, tab.tabType)}`;
+}
+
+export interface WorkspacePane {
+  type: 'pane';
+  id: string;
+  activeTabId: WorkspaceTabId | null;
+  tabs: WorkspaceTab[];
+}
+
+export type SplitDirection = 'horizontal' | 'vertical';
+export type SplitPlacement = 'before' | 'after';
+
+export interface WorkspaceSplit {
+  type: 'split';
+  id: string;
+  direction: SplitDirection;
+  children: WorkspaceLayoutNode[];
+}
+
+export type WorkspaceLayoutNode = WorkspacePane | WorkspaceSplit;
+
+let _paneCounter = 0;
+let _splitCounter = 0;
+export function freshPaneId(prefix = 'pane'): string {
+  _paneCounter += 1;
+  return `${prefix}-${_paneCounter}`;
+}
+
+export function freshSplitId(prefix = 'split'): string {
+  _splitCounter += 1;
+  return `${prefix}-${_splitCounter}`;
+}
+
+export function _resetPaneCounter(): void {
+  _paneCounter = 0;
+  _splitCounter = 0;
+}
+
+export function collectSplitIds(node: WorkspaceLayoutNode): string[] {
+  if (node.type === 'pane') return [];
+  return [node.id, ...node.children.flatMap(collectSplitIds)];
+}
+
+export function makePane(
+  tabs: WorkspaceTab[] = [],
+  opts?: { id?: string; activeTabId?: WorkspaceTabId | null }
+): WorkspacePane {
+  const id = opts?.id ?? freshPaneId();
+  const ids = tabs.map(workspaceTabId);
+  let active: WorkspaceTabId | null = opts?.activeTabId ?? null;
+  if (active && !ids.includes(active)) active = null;
+  if (!active && ids.length > 0) active = ids[0] ?? null;
+  return { type: 'pane', id, activeTabId: active, tabs };
+}
+
+interface TabLocation {
+  paneId: string;
+  index: number;
+}
+
+function findTabLocation(
+  node: WorkspaceLayoutNode,
+  tabId: WorkspaceTabId
+): TabLocation | null {
+  if (node.type === 'pane') {
+    const i = node.tabs.findIndex((t) => workspaceTabId(t) === tabId);
+    return i >= 0 ? { paneId: node.id, index: i } : null;
+  }
+  for (const child of node.children) {
+    const loc = findTabLocation(child, tabId);
+    if (loc) return loc;
+  }
+  return null;
+}
+
+function findPane(
+  node: WorkspaceLayoutNode,
+  paneId: string
+): WorkspacePane | null {
+  if (node.type === 'pane') return node.id === paneId ? node : null;
+  for (const child of node.children) {
+    const found = findPane(child, paneId);
+    if (found) return found;
+  }
+  return null;
+}
+
+export function listPanes(node: WorkspaceLayoutNode): WorkspacePane[] {
+  if (node.type === 'pane') return [node];
+  return node.children.flatMap(listPanes);
+}
+
+function mapPanes(
+  node: WorkspaceLayoutNode,
+  fn: (pane: WorkspacePane) => WorkspacePane
+): WorkspaceLayoutNode {
+  if (node.type === 'pane') return fn(node);
+  return { ...node, children: node.children.map((c) => mapPanes(c, fn)) };
+}
+
+function pickActiveAfterRemoval(
+  tabs: WorkspaceTab[],
+  removedIndex: number,
+  prevActive: WorkspaceTabId | null,
+  removedTabId: WorkspaceTabId
+): WorkspaceTabId | null {
+  if (prevActive !== removedTabId) return prevActive;
+  if (tabs.length === 0) return null;
+  const neighbor =
+    removedIndex >= tabs.length ? tabs[tabs.length - 1] : tabs[removedIndex];
+  return neighbor ? workspaceTabId(neighbor) : null;
+}
+
+export function selectLayoutTab(
+  layout: WorkspaceLayoutNode,
+  paneId: string,
+  tabId: WorkspaceTabId
+): WorkspaceLayoutNode {
+  return mapPanes(layout, (p) => {
+    if (p.id !== paneId) return p;
+    if (!p.tabs.some((t) => workspaceTabId(t) === tabId)) return p;
+    return { ...p, activeTabId: tabId };
+  });
+}
+
+export function closeLayoutTab(
+  layout: WorkspaceLayoutNode,
+  tabId: WorkspaceTabId
+): WorkspaceLayoutNode {
+  const next = mapPanes(layout, (p) => {
+    const idx = p.tabs.findIndex((t) => workspaceTabId(t) === tabId);
+    if (idx < 0) return p;
+    const tabs = p.tabs.slice();
+    tabs.splice(idx, 1);
+    return {
+      ...p,
+      tabs,
+      activeTabId: pickActiveAfterRemoval(tabs, idx, p.activeTabId, tabId),
+    };
+  });
+  return pruneLayout(next);
+}
+
+export function moveTabToPane(
+  layout: WorkspaceLayoutNode,
+  tabId: WorkspaceTabId,
+  targetPaneId: string,
+  targetIndex?: number
+): WorkspaceLayoutNode {
+  const loc = findTabLocation(layout, tabId);
+  if (!loc) return layout;
+  const target = findPane(layout, targetPaneId);
+  if (!target) return layout;
+
+  const sourcePane = findPane(layout, loc.paneId);
+  if (!sourcePane) return layout;
+  const tabObj = sourcePane.tabs[loc.index];
+  if (!tabObj) return layout;
+
+  if (loc.paneId === targetPaneId) {
+    const lastIndex = target.tabs.length - 1;
+    let dest = targetIndex ?? lastIndex;
+    dest = Math.max(0, Math.min(dest, lastIndex));
+    if (dest === loc.index) return layout;
+    const newTabs = target.tabs.slice();
+    const [removed] = newTabs.splice(loc.index, 1);
+    if (!removed) return layout;
+    newTabs.splice(dest, 0, removed);
+    return mapPanes(layout, (p) =>
+      p.id === targetPaneId
+        ? { ...p, tabs: newTabs, activeTabId: workspaceTabId(removed) }
+        : p
+    );
+  }
+
+  const next = mapPanes(layout, (p) => {
+    if (p.id === loc.paneId) {
+      const tabs = p.tabs.slice();
+      tabs.splice(loc.index, 1);
+      return {
+        ...p,
+        tabs,
+        activeTabId: pickActiveAfterRemoval(
+          tabs,
+          loc.index,
+          p.activeTabId,
+          tabId
+        ),
+      };
+    }
+    if (p.id === targetPaneId) {
+      const tabs = p.tabs.slice();
+      let dest = targetIndex ?? tabs.length;
+      dest = Math.max(0, Math.min(dest, tabs.length));
+      tabs.splice(dest, 0, tabObj);
+      return { ...p, tabs, activeTabId: workspaceTabId(tabObj) };
+    }
+    return p;
+  });
+  return pruneLayout(next);
+}
+
+export function splitPaneWithTab(
+  layout: WorkspaceLayoutNode,
+  targetPaneId: string,
+  tabId: WorkspaceTabId,
+  direction: SplitDirection,
+  placement: SplitPlacement
+): WorkspaceLayoutNode {
+  const target = findPane(layout, targetPaneId);
+  if (!target) return layout;
+  const tabLoc = findTabLocation(layout, tabId);
+  if (!tabLoc) return layout;
+  const sourcePane = findPane(layout, tabLoc.paneId);
+  if (!sourcePane) return layout;
+  const tab = sourcePane.tabs[tabLoc.index];
+  if (!tab) return layout;
+  // Same-pane single-tab: no-op (would just create empty source and prune back).
+  if (tabLoc.paneId === targetPaneId && target.tabs.length <= 1) return layout;
+
+  const newPane = makePane([tab]);
+  const sourcePaneIdLocal = tabLoc.paneId;
+  const sourceIndex = tabLoc.index;
+  const sameSourceAndTarget = sourcePaneIdLocal === targetPaneId;
+
+  function replace(node: WorkspaceLayoutNode): WorkspaceLayoutNode {
+    if (node.type === 'pane') {
+      if (node.id === targetPaneId) {
+        let tabs = node.tabs;
+        let activeId = node.activeTabId;
+        if (sameSourceAndTarget) {
+          const idx = node.tabs.findIndex((t) => workspaceTabId(t) === tabId);
+          tabs = node.tabs.slice();
+          tabs.splice(idx, 1);
+          activeId = pickActiveAfterRemoval(tabs, idx, node.activeTabId, tabId);
+        }
+        const targetWithoutTab: WorkspacePane = {
+          ...node,
+          tabs,
+          activeTabId: activeId,
+        };
+        const children =
+          placement === 'before'
+            ? [newPane, targetWithoutTab]
+            : [targetWithoutTab, newPane];
+        return { type: 'split', id: freshSplitId(), direction, children };
+      }
+      if (!sameSourceAndTarget && node.id === sourcePaneIdLocal) {
+        const tabs = node.tabs.slice();
+        tabs.splice(sourceIndex, 1);
+        return {
+          ...node,
+          tabs,
+          activeTabId: pickActiveAfterRemoval(
+            tabs,
+            sourceIndex,
+            node.activeTabId,
+            tabId
+          ),
+        };
+      }
+      return node;
+    }
+    return { ...node, children: node.children.map(replace) };
+  }
+  return pruneLayout(replace(layout));
+}
+
+export function pruneLayout(layout: WorkspaceLayoutNode): WorkspaceLayoutNode {
+  function visit(node: WorkspaceLayoutNode): WorkspaceLayoutNode | null {
+    if (node.type === 'pane') return node;
+    const kept: WorkspaceLayoutNode[] = [];
+    for (const c of node.children) {
+      const v = visit(c);
+      if (!v) continue;
+      if (v.type === 'pane' && v.tabs.length === 0) continue;
+      kept.push(v);
+    }
+    if (kept.length === 0) return null;
+    if (kept.length === 1) return kept[0] ?? null;
+    if (kept.length === node.children.length) {
+      const sameRefs = kept.every((c, i) => c === node.children[i]);
+      if (sameRefs) return node;
+    }
+    return { ...node, children: kept };
+  }
+  const out = visit(layout);
+  return out ?? layout;
+}
+
+export function addTabToPane(
+  layout: WorkspaceLayoutNode,
+  paneId: string,
+  tab: WorkspaceTab,
+  opts?: { activate?: boolean; index?: number }
+): WorkspaceLayoutNode {
+  const id = workspaceTabId(tab);
+  if (!findPane(layout, paneId)) return layout;
+  const existingLoc = findTabLocation(layout, id);
+  if (existingLoc) {
+    const moved = moveTabToPane(layout, id, paneId, opts?.index);
+    return opts?.activate === false
+      ? moved
+      : selectLayoutTab(moved, paneId, id);
+  }
+  return mapPanes(layout, (p) => {
+    if (p.id !== paneId) return p;
+    const tabs = p.tabs.slice();
+    let dest = opts?.index ?? tabs.length;
+    dest = Math.max(0, Math.min(dest, tabs.length));
+    tabs.splice(dest, 0, tab);
+    return {
+      ...p,
+      tabs,
+      activeTabId: opts?.activate === false ? p.activeTabId : id,
+    };
+  });
+}
+
+export function createDefaultWorkspaceLayout(
+  tabs: WorkspaceTab[],
+  activeTabId?: WorkspaceTabId | null
+): WorkspacePane {
+  return makePane(tabs, { activeTabId: activeTabId ?? null });
+}

--- a/frontend/src/lib/workspace-summary.ts
+++ b/frontend/src/lib/workspace-summary.ts
@@ -1,0 +1,177 @@
+import type { AgentState, SessionSummary } from './types.js';
+import type { WorkspaceTab } from './workspace-layout.js';
+
+export type SummaryIcon =
+  | 'session-claude'
+  | 'session-codex'
+  | 'session-opencode'
+  | 'session-hermes'
+  | 'session-agent'
+  | 'session-terminal'
+  | 'file-tsx'
+  | 'file-ts'
+  | 'file-jsx'
+  | 'file-js'
+  | 'file-py'
+  | 'file-rs'
+  | 'file-go'
+  | 'file-css'
+  | 'file-html'
+  | 'file-md'
+  | 'file-json'
+  | 'file-generic'
+  | 'file-diff'
+  | 'file-html-preview';
+
+export type SummaryDot = 'live' | 'attention' | 'idle' | 'error' | null;
+
+export interface SummaryPill {
+  kind: 'dirty' | 'info' | 'warn' | 'success';
+  label: string;
+}
+
+export interface WorkspaceTabSummary {
+  icon: SummaryIcon;
+  primary: string;
+  meta?: string;
+  pills: SummaryPill[];
+  dot: SummaryDot;
+  breadcrumb?: {
+    segments: string[];
+    repoLabel?: string;
+    repoColor?: string;
+  };
+}
+
+export interface SummaryContext {
+  findSession?: (id: string) => SessionSummary | undefined;
+  isFileChanged?: (filePath: string) => boolean;
+  fileLineCount?: (filePath: string) => number | undefined;
+  repoLabel?: string;
+  repoColor?: string;
+}
+
+const FILE_ICON_MAP: Record<string, SummaryIcon> = {
+  tsx: 'file-tsx',
+  ts: 'file-ts',
+  jsx: 'file-jsx',
+  js: 'file-js',
+  py: 'file-py',
+  rs: 'file-rs',
+  go: 'file-go',
+  css: 'file-css',
+  scss: 'file-css',
+  html: 'file-html',
+  md: 'file-md',
+  markdown: 'file-md',
+  json: 'file-json',
+};
+
+export function summaryForTab(
+  tab: WorkspaceTab,
+  ctx: SummaryContext = {}
+): WorkspaceTabSummary {
+  if (tab.kind === 'session') return summaryForSessionTab(tab, ctx);
+  return summaryForFileTab(tab, ctx);
+}
+
+function summaryForSessionTab(
+  tab: Extract<WorkspaceTab, { kind: 'session' }>,
+  ctx: SummaryContext
+): WorkspaceTabSummary {
+  const session = ctx.findSession?.(tab.sessionId);
+  const isTerminal = tab.sessionType === 'terminal';
+  const agent = session?.agent ?? '';
+  const icon = sessionIconFor(tab.sessionType, agent);
+  const primary =
+    session?.displayName ||
+    session?.branchName ||
+    (isTerminal ? 'terminal' : 'session');
+  const dot = sessionDot(session?.agentState, session?.idle);
+  const meta = sessionMeta(session, isTerminal);
+  return {
+    icon,
+    primary,
+    pills: [],
+    dot,
+    ...(meta !== undefined ? { meta } : {}),
+  };
+}
+
+function sessionIconFor(
+  type: 'agent' | 'terminal',
+  agent: string
+): SummaryIcon {
+  if (type === 'terminal') return 'session-terminal';
+  const a = agent.toLowerCase();
+  if (a.includes('claude')) return 'session-claude';
+  if (a.includes('codex')) return 'session-codex';
+  if (a.includes('opencode')) return 'session-opencode';
+  if (a.includes('hermes')) return 'session-hermes';
+  return 'session-agent';
+}
+
+function sessionDot(state?: AgentState, idle?: boolean): SummaryDot {
+  if (state === 'error') return 'error';
+  if (state === 'permission-prompt' || state === 'waiting-for-input') {
+    return 'attention';
+  }
+  if (state === 'processing') return 'live';
+  if (idle) return 'idle';
+  return null;
+}
+
+function sessionMeta(
+  session: SessionSummary | undefined,
+  isTerminal: boolean
+): string | undefined {
+  if (!session) return undefined;
+  const parts: string[] = [];
+  if (session.agent) parts.push(session.agent);
+  if (isTerminal && session.cwd) {
+    const last = session.cwd.split('/').filter(Boolean).pop();
+    if (last) parts.push(last);
+  }
+  if (session.agentState) parts.push(session.agentState);
+  return parts.length > 0 ? parts.join(' · ') : undefined;
+}
+
+function summaryForFileTab(
+  tab: Extract<WorkspaceTab, { kind: 'file' }>,
+  ctx: SummaryContext
+): WorkspaceTabSummary {
+  const segments = tab.filePath.split('/').filter(Boolean);
+  const fileName = segments[segments.length - 1] ?? tab.filePath;
+  const ext = fileName.split('.').pop()?.toLowerCase() ?? '';
+  const icon = fileIconFor(ext, tab.tabType);
+  const isChanged = ctx.isFileChanged?.(tab.filePath) ?? false;
+  const lines = ctx.fileLineCount?.(tab.filePath);
+
+  const pills: SummaryPill[] = [];
+  if (isChanged) pills.push({ kind: 'dirty', label: 'unsaved' });
+  if (tab.tabType === 'diff') pills.push({ kind: 'info', label: 'diff' });
+  if (tab.tabType === 'html') pills.push({ kind: 'info', label: 'preview' });
+  const langLabel = `${ext || 'file'}${lines !== undefined ? ` · ${lines} lines` : ''}`;
+  pills.push({ kind: 'info', label: langLabel });
+
+  return {
+    icon,
+    primary: fileName,
+    pills,
+    dot: null,
+    breadcrumb: {
+      segments,
+      ...(ctx.repoLabel !== undefined ? { repoLabel: ctx.repoLabel } : {}),
+      ...(ctx.repoColor !== undefined ? { repoColor: ctx.repoColor } : {}),
+    },
+  };
+}
+
+function fileIconFor(
+  ext: string,
+  tabType: 'code' | 'diff' | 'html'
+): SummaryIcon {
+  if (tabType === 'diff') return 'file-diff';
+  if (tabType === 'html') return 'file-html-preview';
+  return FILE_ICON_MAP[ext] ?? 'file-generic';
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import WorkspaceLayoutDemo from './components/WorkspaceLayoutDemo';
 import './App.css';
+
+const isWorkspaceDemo =
+  new URLSearchParams(window.location.search).get('workspaceDemo') === '1';
 
 ReactDOM.createRoot(document.getElementById('app')!).render(
   <React.StrictMode>
-    <App />
+    {isWorkspaceDemo ? <WorkspaceLayoutDemo /> : <App />}
   </React.StrictMode>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "node-pty": "^1.0.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-resizable-panels": "^2.1.9",
         "shiki": "^4.0.2",
         "smee-client": "^5.0.0",
         "web-push": "^3.6.7",
@@ -5872,6 +5873,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-resizable-panels": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-2.1.9.tgz",
+      "integrity": "sha512-z77+X08YDIrgAes4jl8xhnUu1LNIRp4+E7cv4xHmLOxxUPO/ML7PSrE813b90vj7xvQ1lcf7g2uA9GeMZonjhQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "node-pty": "^1.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-resizable-panels": "^2.1.9",
     "shiki": "^4.0.2",
     "smee-client": "^5.0.0",
     "web-push": "^3.6.7",

--- a/test/workspace-layout-store.test.ts
+++ b/test/workspace-layout-store.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
-  _resetPaneCounter,
+  _resetIdCounters,
   createDefaultWorkspaceLayout,
   workspaceTabId,
   type WorkspaceLayoutNode,
@@ -23,12 +23,13 @@ const fileTab = (path: string): WorkspaceTab => ({
 });
 
 beforeEach(() => {
-  _resetPaneCounter();
+  _resetIdCounters();
   const tabs: WorkspaceTab[] = [];
   const layout = createDefaultWorkspaceLayout(tabs);
   useWorkspaceLayoutStore.setState({
     layout,
     activePaneId: layout.id,
+    splitSizes: {},
   });
 });
 

--- a/test/workspace-layout-store.test.ts
+++ b/test/workspace-layout-store.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  _resetPaneCounter,
+  createDefaultWorkspaceLayout,
+  workspaceTabId,
+  type WorkspaceLayoutNode,
+  type WorkspacePane,
+  type WorkspaceSplit,
+  type WorkspaceTab,
+} from '../frontend/src/lib/workspace-layout.js';
+import { useWorkspaceLayoutStore } from '../frontend/src/lib/stores/workspace-layout-store.js';
+
+const sessionTab = (id: string): WorkspaceTab => ({
+  kind: 'session',
+  sessionId: id,
+  sessionType: 'agent',
+});
+
+const fileTab = (path: string): WorkspaceTab => ({
+  kind: 'file',
+  filePath: path,
+  tabType: 'code',
+});
+
+beforeEach(() => {
+  _resetPaneCounter();
+  const tabs: WorkspaceTab[] = [];
+  const layout = createDefaultWorkspaceLayout(tabs);
+  useWorkspaceLayoutStore.setState({
+    layout,
+    activePaneId: layout.id,
+  });
+});
+
+describe('workspace-layout-store', () => {
+  it('addTab adds tab to pane and activates by default', () => {
+    const { setLayout, addTab } = useWorkspaceLayoutStore.getState();
+    setLayout(createDefaultWorkspaceLayout([sessionTab('a')]));
+    const paneId = (useWorkspaceLayoutStore.getState().layout as WorkspacePane)
+      .id;
+    addTab(paneId, fileTab('b.ts'));
+    const layout = useWorkspaceLayoutStore.getState().layout as WorkspacePane;
+    expect(layout.tabs).toHaveLength(2);
+    expect(layout.activeTabId).toBe(workspaceTabId(fileTab('b.ts')));
+    expect(useWorkspaceLayoutStore.getState().activePaneId).toBe(paneId);
+  });
+
+  it('selectTab switches active tab and activePaneId', () => {
+    const { setLayout, selectTab } = useWorkspaceLayoutStore.getState();
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    setLayout(createDefaultWorkspaceLayout([a, b]));
+    const paneId = (useWorkspaceLayoutStore.getState().layout as WorkspacePane)
+      .id;
+    selectTab(paneId, workspaceTabId(b));
+    const layout = useWorkspaceLayoutStore.getState().layout as WorkspacePane;
+    expect(layout.activeTabId).toBe(workspaceTabId(b));
+    expect(useWorkspaceLayoutStore.getState().activePaneId).toBe(paneId);
+  });
+
+  it('splitWithTab promotes pane to split and updates activePaneId to remain valid', () => {
+    const { setLayout, splitWithTab } = useWorkspaceLayoutStore.getState();
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    setLayout(createDefaultWorkspaceLayout([a, b]));
+    const initialPaneId = (
+      useWorkspaceLayoutStore.getState().layout as WorkspacePane
+    ).id;
+    splitWithTab(initialPaneId, workspaceTabId(b), 'horizontal', 'after');
+    const layout = useWorkspaceLayoutStore.getState().layout;
+    expect(layout.type).toBe('split');
+    const split = layout as WorkspaceSplit;
+    expect(split.children).toHaveLength(2);
+    const activePaneId = useWorkspaceLayoutStore.getState().activePaneId;
+    const allPaneIds = (split.children as WorkspaceLayoutNode[])
+      .filter((c): c is WorkspacePane => c.type === 'pane')
+      .map((p) => p.id);
+    expect(allPaneIds.includes(activePaneId ?? '')).toBe(true);
+  });
+
+  it('moveTab transfers tab and updates activePaneId to target', () => {
+    const { setLayout, splitWithTab, moveTab } =
+      useWorkspaceLayoutStore.getState();
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    setLayout(createDefaultWorkspaceLayout([a, b]));
+    const initialPaneId = (
+      useWorkspaceLayoutStore.getState().layout as WorkspacePane
+    ).id;
+    splitWithTab(initialPaneId, workspaceTabId(b), 'horizontal', 'after');
+    const layout = useWorkspaceLayoutStore.getState().layout as WorkspaceSplit;
+    const left = layout.children[0] as WorkspacePane;
+    const right = layout.children[1] as WorkspacePane;
+    moveTab(workspaceTabId(a), right.id);
+    const after = useWorkspaceLayoutStore.getState().layout;
+    expect(after.type).toBe('pane');
+    expect((after as WorkspacePane).id).toBe(right.id);
+    expect((after as WorkspacePane).tabs).toHaveLength(2);
+    expect(useWorkspaceLayoutStore.getState().activePaneId).toBe(right.id);
+    void left;
+  });
+
+  it('closeTab prunes empty pane and reselects activePaneId', () => {
+    const { setLayout, splitWithTab, closeTab } =
+      useWorkspaceLayoutStore.getState();
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    setLayout(createDefaultWorkspaceLayout([a, b]));
+    const initialPaneId = (
+      useWorkspaceLayoutStore.getState().layout as WorkspacePane
+    ).id;
+    splitWithTab(initialPaneId, workspaceTabId(b), 'horizontal', 'after');
+    closeTab(workspaceTabId(b));
+    const after = useWorkspaceLayoutStore.getState().layout;
+    expect(after.type).toBe('pane');
+    expect((after as WorkspacePane).tabs).toHaveLength(1);
+    const activePaneId = useWorkspaceLayoutStore.getState().activePaneId;
+    expect(activePaneId).toBe((after as WorkspacePane).id);
+  });
+
+  it('setSplitSizes records sizes in sidecar keyed by splitId', () => {
+    const { setLayout, splitWithTab, setSplitSizes } =
+      useWorkspaceLayoutStore.getState();
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    setLayout(createDefaultWorkspaceLayout([a, b]));
+    const initialPaneId = (
+      useWorkspaceLayoutStore.getState().layout as WorkspacePane
+    ).id;
+    splitWithTab(initialPaneId, workspaceTabId(b), 'horizontal', 'after');
+    const split = useWorkspaceLayoutStore.getState().layout as WorkspaceSplit;
+    setSplitSizes(split.id, [70, 30]);
+    expect(useWorkspaceLayoutStore.getState().splitSizes[split.id]).toEqual([
+      70, 30,
+    ]);
+  });
+
+  it('GCs splitSizes entries when split is removed', () => {
+    const { setLayout, splitWithTab, setSplitSizes, closeTab } =
+      useWorkspaceLayoutStore.getState();
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    setLayout(createDefaultWorkspaceLayout([a, b]));
+    const initialPaneId = (
+      useWorkspaceLayoutStore.getState().layout as WorkspacePane
+    ).id;
+    splitWithTab(initialPaneId, workspaceTabId(b), 'horizontal', 'after');
+    const split = useWorkspaceLayoutStore.getState().layout as WorkspaceSplit;
+    setSplitSizes(split.id, [70, 30]);
+    closeTab(workspaceTabId(b));
+    expect(useWorkspaceLayoutStore.getState().layout.type).toBe('pane');
+    expect(
+      useWorkspaceLayoutStore.getState().splitSizes[split.id]
+    ).toBeUndefined();
+  });
+});

--- a/test/workspace-layout.test.ts
+++ b/test/workspace-layout.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
-  _resetPaneCounter,
+  _resetIdCounters,
   addTabToPane,
   closeLayoutTab,
   createDefaultWorkspaceLayout,
@@ -38,7 +38,7 @@ const fileTab = (
 const tid = (t: WorkspaceTab) => workspaceTabId(t);
 
 beforeEach(() => {
-  _resetPaneCounter();
+  _resetIdCounters();
 });
 
 describe('workspaceTabId', () => {

--- a/test/workspace-layout.test.ts
+++ b/test/workspace-layout.test.ts
@@ -1,0 +1,421 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  _resetPaneCounter,
+  addTabToPane,
+  closeLayoutTab,
+  createDefaultWorkspaceLayout,
+  listPanes,
+  makePane,
+  moveTabToPane,
+  pruneLayout,
+  selectLayoutTab,
+  splitPaneWithTab,
+  workspaceTabId,
+  type WorkspaceLayoutNode,
+  type WorkspacePane,
+  type WorkspaceSplit,
+  type WorkspaceTab,
+} from '../frontend/src/lib/workspace-layout.js';
+
+const sessionTab = (
+  id: string,
+  type: 'agent' | 'terminal' = 'agent'
+): WorkspaceTab => ({
+  kind: 'session',
+  sessionId: id,
+  sessionType: type,
+});
+
+const fileTab = (
+  path: string,
+  type: 'code' | 'diff' | 'html' = 'code'
+): WorkspaceTab => ({
+  kind: 'file',
+  filePath: path,
+  tabType: type,
+});
+
+const tid = (t: WorkspaceTab) => workspaceTabId(t);
+
+beforeEach(() => {
+  _resetPaneCounter();
+});
+
+describe('workspaceTabId', () => {
+  it('encodes session tabs', () => {
+    expect(tid(sessionTab('abc'))).toBe('session::abc');
+  });
+
+  it('encodes file tabs by tabType + path', () => {
+    expect(tid(fileTab('a.ts', 'code'))).toBe('file::code::a.ts');
+    expect(tid(fileTab('a.ts', 'diff'))).toBe('file::diff::a.ts');
+  });
+
+  it('disambiguates code and diff for same path', () => {
+    expect(tid(fileTab('a.ts', 'code'))).not.toBe(tid(fileTab('a.ts', 'diff')));
+  });
+});
+
+describe('makePane / createDefaultWorkspaceLayout', () => {
+  it('activates first tab when no activeTabId given', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const pane = makePane([a, b]);
+    expect(pane.activeTabId).toBe(tid(a));
+  });
+
+  it('honors explicit activeTabId if present in tabs', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const pane = makePane([a, b], { activeTabId: tid(b) });
+    expect(pane.activeTabId).toBe(tid(b));
+  });
+
+  it('falls back when activeTabId not in tab list', () => {
+    const a = sessionTab('a');
+    const pane = makePane([a], { activeTabId: 'session::ghost' });
+    expect(pane.activeTabId).toBe(tid(a));
+  });
+
+  it('createDefaultWorkspaceLayout makes a single pane', () => {
+    const layout = createDefaultWorkspaceLayout([
+      sessionTab('a'),
+      fileTab('b.ts'),
+    ]);
+    expect(layout.type).toBe('pane');
+    expect(layout.tabs).toHaveLength(2);
+  });
+});
+
+describe('selectLayoutTab', () => {
+  it('switches active tab when target exists in pane', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const layout = makePane([a, b]);
+    const next = selectLayoutTab(layout, layout.id, tid(b)) as WorkspacePane;
+    expect(next.activeTabId).toBe(tid(b));
+  });
+
+  it('no-op when target tab missing', () => {
+    const a = sessionTab('a');
+    const layout = makePane([a]);
+    const next = selectLayoutTab(
+      layout,
+      layout.id,
+      'session::ghost'
+    ) as WorkspacePane;
+    expect(next.activeTabId).toBe(tid(a));
+  });
+});
+
+describe('moveTabToPane', () => {
+  it('reorders within same pane', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const c = fileTab('c.ts');
+    const layout = makePane([a, b, c]);
+    const next = moveTabToPane(layout, tid(a), layout.id, 2) as WorkspacePane;
+    expect(next.tabs.map(tid)).toEqual([tid(b), tid(c), tid(a)]);
+    expect(next.activeTabId).toBe(tid(a));
+  });
+
+  it('moves tab between panes and activates in target', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const c = fileTab('c.ts');
+    const left = makePane([a, b], { id: 'L' });
+    const right = makePane([c], { id: 'R' });
+    const layout: WorkspaceSplit = {
+      type: 'split',
+      id: 's-test',
+      direction: 'horizontal',
+      children: [left, right],
+    };
+    const next = moveTabToPane(layout, tid(b), 'R') as WorkspaceSplit;
+    const panes = listPanes(next);
+    const lp = panes.find((p) => p.id === 'L')!;
+    const rp = panes.find((p) => p.id === 'R')!;
+    expect(lp.tabs.map(tid)).toEqual([tid(a)]);
+    expect(rp.tabs.map(tid)).toEqual([tid(c), tid(b)]);
+    expect(rp.activeTabId).toBe(tid(b));
+  });
+
+  it('clamps out-of-range targetIndex to end', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const layout = makePane([a, b]);
+    const next = moveTabToPane(layout, tid(a), layout.id, 99) as WorkspacePane;
+    expect(next.tabs.map(tid)).toEqual([tid(b), tid(a)]);
+  });
+
+  it('returns layout unchanged when tab missing', () => {
+    const layout = makePane([sessionTab('a')]);
+    const next = moveTabToPane(layout, 'session::ghost', layout.id);
+    expect(next).toBe(layout);
+  });
+
+  it('returns layout unchanged when target pane missing', () => {
+    const a = sessionTab('a');
+    const layout = makePane([a]);
+    const next = moveTabToPane(layout, tid(a), 'ghost-pane');
+    expect(next).toBe(layout);
+  });
+
+  it('prunes empty source pane after cross-pane move', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const left = makePane([a], { id: 'L' });
+    const right = makePane([b], { id: 'R' });
+    const layout: WorkspaceSplit = {
+      type: 'split',
+      id: 's-test',
+      direction: 'horizontal',
+      children: [left, right],
+    };
+    const next = moveTabToPane(layout, tid(a), 'R');
+    expect(next.type).toBe('pane');
+    expect((next as WorkspacePane).id).toBe('R');
+    expect((next as WorkspacePane).tabs.map(tid)).toEqual([tid(b), tid(a)]);
+  });
+});
+
+describe('splitPaneWithTab', () => {
+  it('creates horizontal split with new pane after source', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const layout = makePane([a, b], { id: 'L' });
+    const next = splitPaneWithTab(layout, 'L', tid(b), 'horizontal', 'after');
+    expect(next.type).toBe('split');
+    const split = next as WorkspaceSplit;
+    expect(split.direction).toBe('horizontal');
+    expect(split.children).toHaveLength(2);
+    expect(split.children[0].type).toBe('pane');
+    expect((split.children[0] as WorkspacePane).id).toBe('L');
+    expect((split.children[0] as WorkspacePane).tabs.map(tid)).toEqual([
+      tid(a),
+    ]);
+    expect((split.children[1] as WorkspacePane).tabs.map(tid)).toEqual([
+      tid(b),
+    ]);
+  });
+
+  it('creates vertical split with new pane before source', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const layout = makePane([a, b], { id: 'L' });
+    const next = splitPaneWithTab(layout, 'L', tid(a), 'vertical', 'before');
+    const split = next as WorkspaceSplit;
+    expect(split.direction).toBe('vertical');
+    expect((split.children[0] as WorkspacePane).tabs.map(tid)).toEqual([
+      tid(a),
+    ]);
+    expect((split.children[1] as WorkspacePane).id).toBe('L');
+    expect((split.children[1] as WorkspacePane).tabs.map(tid)).toEqual([
+      tid(b),
+    ]);
+  });
+
+  it('no-ops when same-pane and pane has only one tab', () => {
+    const a = sessionTab('a');
+    const layout = makePane([a], { id: 'L' });
+    const next = splitPaneWithTab(layout, 'L', tid(a), 'horizontal', 'after');
+    expect(next).toBe(layout);
+  });
+
+  it('no-ops when target pane missing', () => {
+    const layout = makePane([sessionTab('a'), fileTab('b.ts')]);
+    const next = splitPaneWithTab(
+      layout,
+      'ghost',
+      'session::a',
+      'horizontal',
+      'after'
+    );
+    expect(next).toBe(layout);
+  });
+
+  it('moves tab from foreign source pane into new split at target edge', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const c = fileTab('c.ts');
+    const left = makePane([a, b], { id: 'L' });
+    const right = makePane([c], { id: 'R' });
+    const layout: WorkspaceSplit = {
+      type: 'split',
+      id: 's-foreign',
+      direction: 'horizontal',
+      children: [left, right],
+    };
+    // Drag tab `a` from L onto R's right edge.
+    const next = splitPaneWithTab(layout, 'R', tid(a), 'horizontal', 'after');
+    // L should still exist with [b]; R should be split [R, newPane(a)].
+    const panes = listPanes(next);
+    const L = panes.find((p) => p.id === 'L')!;
+    const R = panes.find((p) => p.id === 'R')!;
+    const newPane = panes.find((p) => p.id !== 'L' && p.id !== 'R')!;
+    expect(L.tabs.map(tid)).toEqual([tid(b)]);
+    expect(R.tabs.map(tid)).toEqual([tid(c)]);
+    expect(newPane.tabs.map(tid)).toEqual([tid(a)]);
+  });
+
+  it('reselects neighbor in source when splitting active tab', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const layout = makePane([a, b], { id: 'L', activeTabId: tid(a) });
+    const next = splitPaneWithTab(layout, 'L', tid(a), 'horizontal', 'after');
+    const split = next as WorkspaceSplit;
+    const source = split.children[0] as WorkspacePane;
+    expect(source.activeTabId).toBe(tid(b));
+  });
+});
+
+describe('closeLayoutTab', () => {
+  it('selects neighbor when closing active tab', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const c = fileTab('c.ts');
+    const layout = makePane([a, b, c], { activeTabId: tid(b) });
+    const next = closeLayoutTab(layout, tid(b)) as WorkspacePane;
+    expect(next.tabs.map(tid)).toEqual([tid(a), tid(c)]);
+    expect(next.activeTabId).toBe(tid(c));
+  });
+
+  it('selects last when closing last active', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const layout = makePane([a, b], { activeTabId: tid(b) });
+    const next = closeLayoutTab(layout, tid(b)) as WorkspacePane;
+    expect(next.activeTabId).toBe(tid(a));
+  });
+
+  it('leaves activeTabId untouched when closing non-active tab', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const layout = makePane([a, b], { activeTabId: tid(a) });
+    const next = closeLayoutTab(layout, tid(b)) as WorkspacePane;
+    expect(next.activeTabId).toBe(tid(a));
+  });
+
+  it('keeps single empty pane as root', () => {
+    const a = sessionTab('a');
+    const layout = makePane([a]);
+    const next = closeLayoutTab(layout, tid(a)) as WorkspacePane;
+    expect(next.type).toBe('pane');
+    expect(next.tabs).toEqual([]);
+    expect(next.activeTabId).toBeNull();
+  });
+
+  it('prunes empty pane and collapses single-child split', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const left = makePane([a], { id: 'L' });
+    const right = makePane([b], { id: 'R' });
+    const layout: WorkspaceSplit = {
+      type: 'split',
+      id: 's-test',
+      direction: 'horizontal',
+      children: [left, right],
+    };
+    const next = closeLayoutTab(layout, tid(a));
+    expect(next.type).toBe('pane');
+    expect((next as WorkspacePane).id).toBe('R');
+    expect((next as WorkspacePane).tabs.map(tid)).toEqual([tid(b)]);
+  });
+});
+
+describe('pruneLayout', () => {
+  it('drops empty panes from splits', () => {
+    const a = sessionTab('a');
+    const empty = makePane([], { id: 'E' });
+    const filled = makePane([a], { id: 'F' });
+    const split: WorkspaceSplit = {
+      type: 'split',
+      id: 's-1',
+      direction: 'horizontal',
+      children: [empty, filled],
+    };
+    const next = pruneLayout(split) as WorkspacePane;
+    expect(next.type).toBe('pane');
+    expect(next.id).toBe('F');
+  });
+
+  it('drops one of three empty panes and keeps remaining children', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const split: WorkspaceSplit = {
+      type: 'split',
+      id: 's-2',
+      direction: 'horizontal',
+      children: [
+        makePane([], { id: 'E' }),
+        makePane([a], { id: 'F1' }),
+        makePane([b], { id: 'F2' }),
+      ],
+    };
+    const next = pruneLayout(split) as WorkspaceSplit;
+    expect(next.type).toBe('split');
+    expect(next.children).toHaveLength(2);
+    expect((next.children[0] as WorkspacePane).id).toBe('F1');
+    expect((next.children[1] as WorkspacePane).id).toBe('F2');
+  });
+
+  it('returns same reference when no pruning needed', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const split: WorkspaceSplit = {
+      type: 'split',
+      id: 's-3',
+      direction: 'vertical',
+      children: [makePane([a]), makePane([b])],
+    };
+    const next = pruneLayout(split);
+    expect(next).toBe(split);
+  });
+});
+
+describe('addTabToPane', () => {
+  it('appends tab and activates by default', () => {
+    const a = sessionTab('a');
+    const layout = makePane([a]);
+    const b = fileTab('b.ts');
+    const next = addTabToPane(layout, layout.id, b) as WorkspacePane;
+    expect(next.tabs.map(tid)).toEqual([tid(a), tid(b)]);
+    expect(next.activeTabId).toBe(tid(b));
+  });
+
+  it('moves existing tab from another pane on add', () => {
+    const a = sessionTab('a');
+    const b = fileTab('b.ts');
+    const left = makePane([a, b], { id: 'L' });
+    const right = makePane([fileTab('c.ts')], { id: 'R' });
+    const layout: WorkspaceLayoutNode = {
+      type: 'split',
+      id: 's-add',
+      direction: 'horizontal',
+      children: [left, right],
+    };
+    const next = addTabToPane(layout, 'R', b) as WorkspaceSplit;
+    const panes = listPanes(next);
+    const lp = panes.find((p) => p.id === 'L')!;
+    const rp = panes.find((p) => p.id === 'R')!;
+    expect(lp.tabs.map(tid)).toEqual([tid(a)]);
+    expect(rp.tabs.map(tid).includes(tid(b))).toBe(true);
+    expect(rp.activeTabId).toBe(tid(b));
+  });
+
+  it('respects activate=false', () => {
+    const a = sessionTab('a');
+    const layout = makePane([a]);
+    const b = fileTab('b.ts');
+    const next = addTabToPane(layout, layout.id, b, {
+      activate: false,
+    }) as WorkspacePane;
+    expect(next.activeTabId).toBe(tid(a));
+  });
+
+  it('returns layout unchanged when target pane missing', () => {
+    const layout = makePane([sessionTab('a')]);
+    const next = addTabToPane(layout, 'ghost', fileTab('b.ts'));
+    expect(next).toBe(layout);
+  });
+});

--- a/test/workspace-summary.test.ts
+++ b/test/workspace-summary.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionSummary } from '../frontend/src/lib/types.js';
+import { summaryForTab } from '../frontend/src/lib/workspace-summary.js';
+import type { WorkspaceTab } from '../frontend/src/lib/workspace-layout.js';
+
+const fileTab = (
+  filePath: string,
+  tabType: 'code' | 'diff' | 'html' = 'code'
+): WorkspaceTab => ({ kind: 'file', filePath, tabType });
+
+const sessionTab = (
+  id: string,
+  type: 'agent' | 'terminal' = 'agent'
+): WorkspaceTab => ({ kind: 'session', sessionId: id, sessionType: type });
+
+const session = (overrides: Partial<SessionSummary>): SessionSummary => ({
+  id: 's',
+  type: 'agent',
+  agent: 'claude',
+  repoName: 'relay-ide',
+  repoPath: '/r',
+  worktreePath: null,
+  cwd: '/r/relay-ide',
+  branchName: 'feat/x',
+  displayName: 'feat/x',
+  createdAt: '',
+  lastActivity: '',
+  idle: false,
+  ...overrides,
+});
+
+describe('summaryForTab — file kind', () => {
+  it('uses filename as primary and breadcrumb segments', () => {
+    const s = summaryForTab(fileTab('frontend/src/components/Composer.tsx'));
+    expect(s.primary).toBe('Composer.tsx');
+    expect(s.breadcrumb?.segments).toEqual([
+      'frontend',
+      'src',
+      'components',
+      'Composer.tsx',
+    ]);
+    expect(s.icon).toBe('file-tsx');
+  });
+
+  it('adds unsaved pill when isFileChanged returns true', () => {
+    const s = summaryForTab(fileTab('a.ts'), { isFileChanged: () => true });
+    expect(s.pills.some((p) => p.label === 'unsaved')).toBe(true);
+  });
+
+  it('adds diff pill + diff icon for diff tabType', () => {
+    const s = summaryForTab(fileTab('a.ts', 'diff'));
+    expect(s.icon).toBe('file-diff');
+    expect(s.pills.some((p) => p.label === 'diff')).toBe(true);
+  });
+
+  it('adds preview pill + html-preview icon for html tabType', () => {
+    const s = summaryForTab(fileTab('mock.html', 'html'));
+    expect(s.icon).toBe('file-html-preview');
+    expect(s.pills.some((p) => p.label === 'preview')).toBe(true);
+  });
+
+  it('appends line count to lang pill when provided', () => {
+    const s = summaryForTab(fileTab('a.ts'), { fileLineCount: () => 142 });
+    expect(s.pills.some((p) => p.label === 'ts · 142 lines')).toBe(true);
+  });
+
+  it('falls back to file-generic icon for unknown ext', () => {
+    const s = summaryForTab(fileTab('LICENSE'));
+    expect(s.icon).toBe('file-generic');
+  });
+
+  it('passes repoLabel and repoColor through breadcrumb', () => {
+    const s = summaryForTab(fileTab('a.ts'), {
+      repoLabel: 'R',
+      repoColor: '#d97757',
+    });
+    expect(s.breadcrumb?.repoLabel).toBe('R');
+    expect(s.breadcrumb?.repoColor).toBe('#d97757');
+  });
+});
+
+describe('summaryForTab — session kind', () => {
+  it('returns claude icon for claude agent sessions', () => {
+    const s = summaryForTab(sessionTab('s1'), {
+      findSession: () => session({ id: 's1', agent: 'claude' }),
+    });
+    expect(s.icon).toBe('session-claude');
+    expect(s.primary).toBe('feat/x');
+  });
+
+  it('returns codex icon for codex agent', () => {
+    const s = summaryForTab(sessionTab('s1'), {
+      findSession: () => session({ id: 's1', agent: 'codex' }),
+    });
+    expect(s.icon).toBe('session-codex');
+  });
+
+  it('returns terminal icon for terminal sessions regardless of agent', () => {
+    const s = summaryForTab(sessionTab('s1', 'terminal'), {
+      findSession: () => session({ id: 's1', type: 'terminal', agent: 'bash' }),
+    });
+    expect(s.icon).toBe('session-terminal');
+  });
+
+  it('uses displayName then branchName then fallback for primary', () => {
+    expect(
+      summaryForTab(sessionTab('s1'), {
+        findSession: () => session({ displayName: 'my session' }),
+      }).primary
+    ).toBe('my session');
+    expect(
+      summaryForTab(sessionTab('s1'), {
+        findSession: () =>
+          session({ displayName: '', branchName: 'feat/branch' }),
+      }).primary
+    ).toBe('feat/branch');
+    expect(
+      summaryForTab(sessionTab('s1'), {
+        findSession: () => undefined,
+      }).primary
+    ).toBe('session');
+    expect(
+      summaryForTab(sessionTab('s1', 'terminal'), {
+        findSession: () => undefined,
+      }).primary
+    ).toBe('terminal');
+  });
+
+  it('maps agentState to correct dot', () => {
+    const cases: Array<
+      [
+        'live' | 'attention' | 'error' | 'idle' | null,
+        ReturnType<typeof session>,
+      ]
+    > = [
+      ['error', session({ agentState: 'error' })],
+      ['attention', session({ agentState: 'permission-prompt' })],
+      ['attention', session({ agentState: 'waiting-for-input' })],
+      ['live', session({ agentState: 'processing' })],
+      ['idle', session({ idle: true })],
+      [null, session({})],
+    ];
+    for (const [expected, ses] of cases) {
+      const s = summaryForTab(sessionTab('s1'), { findSession: () => ses });
+      expect(s.dot).toBe(expected);
+    }
+  });
+
+  it('builds meta string from agent and state', () => {
+    const s = summaryForTab(sessionTab('s1'), {
+      findSession: () => session({ agent: 'claude', agentState: 'processing' }),
+    });
+    expect(s.meta).toBe('claude · processing');
+  });
+
+  it('appends cwd basename for terminal sessions', () => {
+    const s = summaryForTab(sessionTab('s1', 'terminal'), {
+      findSession: () =>
+        session({
+          type: 'terminal',
+          agent: 'bash',
+          cwd: '/Users/alice/code/relay-ide',
+        }),
+    });
+    expect(s.meta).toContain('relay-ide');
+  });
+
+  it('returns no meta when session is missing', () => {
+    const s = summaryForTab(sessionTab('s1'), { findSession: () => undefined });
+    expect(s.meta).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

First slice of #263 — workspace layout substrate for VSCode-style drag-out tabs and pane splitting.

Files-only behind a flag (`?workspaceLayout=1`). Sessions stay in the existing terminal slot until per-session PTY routing lands (#330). The substrate is the layout tree and tab vocabulary that future workspace customization (sidebar docking, persistence, multi-session panes, PR/checks tabs) will sit on top of.

## What ships

**Substrate (`frontend/src/lib/workspace-layout.ts`)**
- Typed model: `WorkspaceTab` (session | file), `WorkspacePane`, `WorkspaceSplit` (stable id), `WorkspaceLayoutNode`
- Pure reducers: select, close, move, splitWithTab, prune, addTab, createDefaultWorkspaceLayout, listPanes, collectSplitIds
- Single-owner invariant; empty-pane prune; single-child split collapse; clamp out-of-range index
- Edge drops accept foreign source panes (drop tab from A onto B's edge → new pane with that tab on B's targeted side)

**Store (`frontend/src/lib/stores/workspace-layout-store.ts`)**
- `useWorkspaceLayoutStore` wraps reducers as actions
- Sidecar `splitSizes: Record<splitId, number[]>` lives outside the tree; resize updates do not mutate the layout tree
- `gcSplitSizes` runs on every tree mutation to drop stale entries
- DOM registry (`registerPaneBodyEl` / `subscribeToPaneBodyEls`) for portal layer to find pane bodies

**UI components**
- `WorkspaceTabBar` — `@dnd-kit/useDraggable` per tab, `useDroppable` on bar; tab item matches files.html `.ws-tab` aesthetic (icon, name, meta strip, status dot, close ×)
- `WorkspacePane` — registers body el, renders TabBar + per-kind summary strip + body slot + drop overlay; `React.memo` to skip sibling-update re-renders
- `WorkspaceDropOverlay` — 4 quadrant zones tiling the full pane (50% × 50% each)
- `WorkspaceLayout` — recursive `PanelGroup`/`Panel`/`PanelResizeHandle` from `react-resizable-panels` v2; `DndContext` with `closestCenter` collision detection; `rAF`-throttled `setSplitSizes`
- `WorkspaceContentLayer` — portals tab content into pane bodies; lazy-mounts file/diff tabs on first activation; sessions mount eagerly (PTY liveness)

**Production wire (files-only)**
- `FileViewerPane` split into tab-bar chrome + `FileTabContent` (pure per-tab content renderer; exports `useFileDiffCache` + `buildCacheKey` + `languageFromPath`)
- `WorkspaceFilesArea` bridges `ui.openFileTabs` ↔ workspace layout store with idempotent bidirectional sync
- Per-tab `FileTabContentBridge` owns its diff cache, threading into shared `FileTabContent`
- `useUiStore.workspaceLayoutEnabled` flag persisted to localStorage; `?workspaceLayout=1` enables (and persists), `?workspaceLayout=0` disables
- `App.tsx` `fileViewer` slot picks `WorkspaceFilesArea` or legacy `FileViewerPane` by flag

**Demo**
- `WorkspaceLayoutDemo` mounted in `main.tsx` when `?workspaceDemo=1`; mock sessions + files exercise drag/split/move/close/resize without touching production paths

## Performance pulled out of this slice

The cheap mitigations baked into this slice: sidecar sizes (no tree churn on resize), per-pane memo (no sibling re-renders), `rAF`-throttle resize, lazy file-tab portal mount.

The bigger items live under epic #326 and ship separately:
- #327 — perf: add WebGL tier to xterm renderer chain (WebGPU → WebGL → DOM)
- #328 — perf: split sizes from layout tree, selectorize per-pane, throttle setSplitSizes (cheap parts done here)
- #329 — perf: lazy-mount file/diff tabs (done) + pause inactive xterm rendering (deferred post-wire)
- #330 — infra: per-session PTY routing for multi-live-terminal panes (gates sessions-as-tabs in workspace)
- #331 — perf: shiki GC for idle code tabs + scrollback global cap

## Out of scope (per #263 acceptance)

- Floating pop-out windows
- Layout persistence
- Sidebar docking / multi-bar dock areas
- Full PR/checks tab integration
- Sessions as workspace tabs (deferred until #330)

## Test plan

Tests (1665 pass, +21):
- 32 reducer tests in `test/workspace-layout.test.ts` — move, split-h, split-v, close active, close last, prune, collapse single, invalid drops, foreign-source edge drop
- 15 summary tests in `test/workspace-summary.test.ts` — file pills, session icons, agent state → dot mapping, terminal cwd basename
- 7 store tests in `test/workspace-layout-store.test.ts` — addTab/selectTab/splitWithTab/moveTab/closeTab/setSplitSizes sidecar set + GC

Manual verification — demo route (`?workspaceDemo=1`):
- [x] Drag tab to pane edge splits horizontally / vertically
- [x] Drag tab onto another pane's tab bar moves it
- [x] Close × selects neighbor tab; emptying a pane prunes it; single-child split collapses
- [x] Resize handle drag updates sizes; sidecar persists; no tree mutation
- [x] Add (+) creates a fresh mock tab in that pane
- [x] Reset button restores initial 7-tab layout
- [x] Mobile (<720px) hides edge overlay; tab bar still scrollable

Manual verification — production wire (`?workspaceLayout=1`):
- [ ] Open a file from the file tree — appears in workspace area
- [ ] Drag file tab to edge — splits
- [ ] Drag file tab between panes — moves; cross-pane diff state preserved (cache survives via portal lazy mount)
- [ ] Close tab via × — closes in `useUiStore.openFileTabs` too
- [ ] Activating tab in workspace updates `useUiStore.activeFileTabKey`
- [ ] `?workspaceLayout=0` reverts to legacy `FileViewerPane`
- [ ] Session/terminal flow unchanged

Build / lint / typecheck:
- [x] `tsc --noEmit -p frontend/tsconfig.json` clean
- [x] `npx eslint` clean on touched files (pre-existing App.tsx warnings unaffected)
- [x] `npm run build` clean (App bundle 844 KB; no significant size delta)
- [x] `npx vitest run` 1665/1665 pass across 131 files

## Plan

`docs/plans/2026-04-23-issue-263-workspace-layout-first-slice.md` — full CEO + Eng + Design review record + decision audit trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resizable multi-pane workspace layout with tab management
  * Drag-and-drop support for moving and reordering tabs between panes
  * Split pane creation with adjacent layout options
  * File tab content rendering with diff preview support
  * Tab status indicators with breadcrumb navigation
  * Feature flag to enable the new workspace layout system

* **Documentation**
  * Added detailed specification for workspace layout implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->