### PR TITLE
perf(terminal): add WebGL tier to xterm renderer chain (#327)

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -10,6 +10,7 @@ import { Terminal as XTerminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import { WebgpuAddon } from '@xterm/addon-webgpu';
+import { WebglAddon } from '@xterm/addon-webgl';
 import '@xterm/xterm/css/xterm.css';
 import { connectPtySocket, sendPtyData, sendPtyResize } from '../lib/ws.js';
 import { isMobileDevice } from '../lib/utils.js';
@@ -17,11 +18,12 @@ import { uploadImage } from '../lib/api.js';
 import { useUiStore, DEFAULT_TERMINAL_FONT_SIZE } from '../lib/stores/ui.js';
 import { useConfigStore } from '../lib/stores/config.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
+import { clampFontSize, zoomPercentage } from '../lib/terminal-zoom.js';
 import {
-  clampFontSize,
-  zoomPercentage,
-  shouldUseWebGpuRenderer,
-} from '../lib/terminal-zoom.js';
+  detectRendererContext,
+  pickTerminalRenderer,
+  type TerminalRenderer,
+} from '../lib/terminal-renderer.js';
 import './Terminal.css';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -777,30 +779,53 @@ function useTerminalSetup(
     t.loadAddon(fa);
     t.loadAddon(new WebLinksAddon());
     registerFileLinkProvider(t, onFilePathClick);
-    // Try WebGPU renderer first, fall back to default DOM renderer
-    let webgpuAddon: WebgpuAddon | undefined;
-    if (shouldUseWebGpuRenderer('gpu' in navigator, isMobileDevice)) {
+
+    // Pick renderer: WebGPU → WebGL → DOM
+    const renderCtx = detectRendererContext(navigator, isMobileDevice);
+    let renderer: TerminalRenderer = pickTerminalRenderer(renderCtx);
+    let gpuAddon: WebgpuAddon | WebglAddon | undefined;
+
+    if (renderer === 'webgpu') {
       try {
-        webgpuAddon = new WebgpuAddon();
-        t.loadAddon(webgpuAddon);
+        const a = new WebgpuAddon();
+        t.loadAddon(a);
         t.open(container);
+        gpuAddon = a;
       } catch (e) {
-        // eslint-disable-next-line no-console -- intentional: surface WebGPU fallback in devtools
-        console.warn('WebGPU renderer unavailable, using DOM renderer:', e);
-        webgpuAddon?.dispose();
-        webgpuAddon = undefined;
+        // eslint-disable-next-line no-console -- intentional: surface renderer fallback in devtools
+        console.warn('WebGPU renderer unavailable, falling back to WebGL:', e);
+        gpuAddon?.dispose();
+        gpuAddon = undefined;
+        renderer =
+          renderCtx.hasWebgl2 && !renderCtx.isGpuBlocklisted ? 'webgl' : 'dom';
+      }
+    }
+    if (renderer === 'webgl' && !gpuAddon) {
+      try {
+        const a = new WebglAddon();
+        t.loadAddon(a);
+        if (!t.element) t.open(container);
+        gpuAddon = a;
+      } catch (e) {
+        // eslint-disable-next-line no-console -- intentional: surface renderer fallback in devtools
+        console.warn('WebGL renderer unavailable, falling back to DOM:', e);
+        gpuAddon?.dispose();
+        gpuAddon = undefined;
+        renderer = 'dom';
       }
     }
     if (!t.element) {
       t.open(container);
     }
-    if (webgpuAddon) {
-      webgpuAddon.onContextLoss(() => {
+    if (gpuAddon) {
+      gpuAddon.onContextLoss(() => {
         // eslint-disable-next-line no-console -- intentional: surface GPU context loss in devtools
-        console.warn('WebGPU context lost, falling back to DOM renderer');
-        webgpuAddon?.dispose();
+        console.warn(`${renderer} context lost, falling back to DOM renderer`);
+        gpuAddon?.dispose();
       });
     }
+    // eslint-disable-next-line no-console -- intentional: log selected renderer once at terminal mount
+    console.info(`xterm renderer: ${renderer}`);
     registerEscapeSequenceSanitizers(t);
     if (isMobileDevice) applyMobilePatches(container, t);
     fa.fit();

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -786,30 +786,31 @@ function useTerminalSetup(
     let gpuAddon: WebgpuAddon | WebglAddon | undefined;
 
     if (renderer === 'webgpu') {
+      let a: WebgpuAddon | undefined;
       try {
-        const a = new WebgpuAddon();
+        a = new WebgpuAddon();
         t.loadAddon(a);
         t.open(container);
         gpuAddon = a;
       } catch (e) {
         // eslint-disable-next-line no-console -- intentional: surface renderer fallback in devtools
         console.warn('WebGPU renderer unavailable, falling back to WebGL:', e);
-        gpuAddon?.dispose();
+        a?.dispose();
         gpuAddon = undefined;
-        renderer =
-          renderCtx.hasWebgl2 && !renderCtx.isGpuBlocklisted ? 'webgl' : 'dom';
+        renderer = pickTerminalRenderer({ ...renderCtx, hasGpu: false });
       }
     }
     if (renderer === 'webgl' && !gpuAddon) {
+      let a: WebglAddon | undefined;
       try {
-        const a = new WebglAddon();
+        a = new WebglAddon();
         t.loadAddon(a);
         if (!t.element) t.open(container);
         gpuAddon = a;
       } catch (e) {
         // eslint-disable-next-line no-console -- intentional: surface renderer fallback in devtools
         console.warn('WebGL renderer unavailable, falling back to DOM:', e);
-        gpuAddon?.dispose();
+        a?.dispose();
         gpuAddon = undefined;
         renderer = 'dom';
       }

--- a/frontend/src/lib/terminal-renderer.ts
+++ b/frontend/src/lib/terminal-renderer.ts
@@ -1,0 +1,63 @@
+export type TerminalRenderer = 'webgpu' | 'webgl' | 'dom';
+
+export interface RendererPickContext {
+  hasGpu: boolean;
+  isMobile: boolean;
+  hasWebgl2: boolean;
+  isGpuBlocklisted: boolean;
+}
+
+/**
+ * Pick the best terminal renderer for the current environment.
+ *
+ * Order: WebGPU (modern Chrome/Edge/Safari 18+, desktop only) →
+ *        WebGL  (universal: iOS Safari, Android Chrome, Firefox, older Chromium) →
+ *        DOM    (final fallback for blocklisted GPUs / no-GPU environments)
+ */
+export function pickTerminalRenderer(
+  ctx: RendererPickContext
+): TerminalRenderer {
+  if (ctx.hasGpu && !ctx.isMobile) return 'webgpu';
+  if (ctx.hasWebgl2 && !ctx.isGpuBlocklisted) return 'webgl';
+  return 'dom';
+}
+
+const BLOCKLISTED_RENDERER_SUBSTRINGS = [
+  'swiftshader',
+  'llvmpipe',
+  'microsoft basic',
+];
+
+/** Detect software-rendered or Microsoft Basic GPU drivers via WEBGL_debug_renderer_info. */
+export function isGpuBlocklisted(): boolean {
+  if (typeof document === 'undefined') return false;
+  try {
+    const canvas = document.createElement('canvas');
+    const gl =
+      (canvas.getContext('webgl2') as WebGL2RenderingContext | null) ??
+      (canvas.getContext('webgl') as WebGLRenderingContext | null);
+    if (!gl) return false;
+    const debug = gl.getExtension('WEBGL_debug_renderer_info');
+    if (!debug) return false;
+    const renderer = gl.getParameter(
+      (debug as { UNMASKED_RENDERER_WEBGL: number }).UNMASKED_RENDERER_WEBGL
+    );
+    if (typeof renderer !== 'string') return false;
+    const r = renderer.toLowerCase();
+    return BLOCKLISTED_RENDERER_SUBSTRINGS.some((s) => r.includes(s));
+  } catch {
+    return false;
+  }
+}
+
+export function detectRendererContext(
+  nav: Pick<Navigator, never> & { gpu?: unknown },
+  isMobile: boolean
+): RendererPickContext {
+  return {
+    hasGpu: 'gpu' in nav,
+    isMobile,
+    hasWebgl2: typeof WebGL2RenderingContext !== 'undefined',
+    isGpuBlocklisted: isGpuBlocklisted(),
+  };
+}

--- a/frontend/src/lib/terminal-renderer.ts
+++ b/frontend/src/lib/terminal-renderer.ts
@@ -28,30 +28,35 @@ const BLOCKLISTED_RENDERER_SUBSTRINGS = [
   'microsoft basic',
 ];
 
+let cachedBlocklist: boolean | undefined;
+
 /** Detect software-rendered or Microsoft Basic GPU drivers via WEBGL_debug_renderer_info. */
 export function isGpuBlocklisted(): boolean {
+  if (cachedBlocklist !== undefined) return cachedBlocklist;
   if (typeof document === 'undefined') return false;
   try {
     const canvas = document.createElement('canvas');
     const gl =
       (canvas.getContext('webgl2') as WebGL2RenderingContext | null) ??
       (canvas.getContext('webgl') as WebGLRenderingContext | null);
-    if (!gl) return false;
+    if (!gl) return (cachedBlocklist = false);
     const debug = gl.getExtension('WEBGL_debug_renderer_info');
-    if (!debug) return false;
+    if (!debug) return (cachedBlocklist = false);
     const renderer = gl.getParameter(
       (debug as { UNMASKED_RENDERER_WEBGL: number }).UNMASKED_RENDERER_WEBGL
     );
-    if (typeof renderer !== 'string') return false;
+    if (typeof renderer !== 'string') return (cachedBlocklist = false);
     const r = renderer.toLowerCase();
-    return BLOCKLISTED_RENDERER_SUBSTRINGS.some((s) => r.includes(s));
+    return (cachedBlocklist = BLOCKLISTED_RENDERER_SUBSTRINGS.some((s) =>
+      r.includes(s)
+    ));
   } catch {
-    return false;
+    return (cachedBlocklist = false);
   }
 }
 
 export function detectRendererContext(
-  nav: Pick<Navigator, never> & { gpu?: unknown },
+  nav: Navigator,
   isMobile: boolean
 ): RendererPickContext {
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tanstack/react-query": "^5.96.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
+        "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "github:donovan-yohan/xterm.js#v6.0.0-relay.1",
         "better-sqlite3": "^12.8.0",
         "cookie-parser": "^1.4.7",
@@ -2986,6 +2987,12 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
       "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-webgl": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.19.0.tgz",
+      "integrity": "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==",
       "license": "MIT"
     },
     "node_modules/@xterm/xterm": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@tanstack/react-query": "^5.96.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
+    "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "github:donovan-yohan/xterm.js#v6.0.0-relay.1",
     "better-sqlite3": "^12.8.0",
     "cookie-parser": "^1.4.7",

--- a/test/terminal-renderer.test.ts
+++ b/test/terminal-renderer.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import {
+  pickTerminalRenderer,
+  type RendererPickContext,
+} from '../frontend/src/lib/terminal-renderer.js';
+
+const ctx = (
+  overrides: Partial<RendererPickContext> = {}
+): RendererPickContext => ({
+  hasGpu: false,
+  isMobile: false,
+  hasWebgl2: false,
+  isGpuBlocklisted: false,
+  ...overrides,
+});
+
+describe('pickTerminalRenderer', () => {
+  it('returns webgpu on desktop with GPU', () => {
+    expect(pickTerminalRenderer(ctx({ hasGpu: true, hasWebgl2: true }))).toBe(
+      'webgpu'
+    );
+  });
+
+  it('skips webgpu on mobile, falls to webgl when webgl2 available', () => {
+    expect(
+      pickTerminalRenderer(
+        ctx({ hasGpu: true, isMobile: true, hasWebgl2: true })
+      )
+    ).toBe('webgl');
+  });
+
+  it('returns webgl when no webgpu but webgl2 available and not blocklisted', () => {
+    expect(pickTerminalRenderer(ctx({ hasWebgl2: true }))).toBe('webgl');
+  });
+
+  it('returns dom when GPU blocklisted (SwiftShader/LLVMpipe)', () => {
+    expect(
+      pickTerminalRenderer(ctx({ hasWebgl2: true, isGpuBlocklisted: true }))
+    ).toBe('dom');
+  });
+
+  it('returns dom when blocklisted on mobile too', () => {
+    expect(
+      pickTerminalRenderer(
+        ctx({ isMobile: true, hasWebgl2: true, isGpuBlocklisted: true })
+      )
+    ).toBe('dom');
+  });
+
+  it('returns dom when no webgl2 and no webgpu', () => {
+    expect(pickTerminalRenderer(ctx())).toBe('dom');
+  });
+
+  it('returns dom on mobile when webgl2 unavailable (very old)', () => {
+    expect(pickTerminalRenderer(ctx({ isMobile: true, hasGpu: true }))).toBe(
+      'dom'
+    );
+  });
+
+  it('prefers webgpu over webgl when both available on desktop', () => {
+    expect(
+      pickTerminalRenderer(
+        ctx({ hasGpu: true, hasWebgl2: true, isGpuBlocklisted: true })
+      )
+    ).toBe('webgpu');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the renderer gap on browsers and devices that lack WebGPU support. Renderer chain becomes:

```
WebGPU (modern Chrome/Edge/Safari 18+, desktop only)
  ↓ unsupported / mobile / load failed
WebGL  (universal: iOS Safari, Android Chrome, Firefox, older Chromium)
  ↓ blocklisted GPU / SwiftShader / load failed
DOM    (final fallback)
```

Previously the chain was WebGPU → DOM, so Firefox / older Safari / iOS users with no WebGPU dropped straight to the DOM renderer (~10× slower than GPU paths). Single terminal was tolerable; multi-pane workspace terminals (#263 substrate, full multi-live wiring after #330) would not be.

## Why this is needed before sessions land in the workspace

Today there is one active terminal at a time, so DOM fallback is fine. Once #330 (per-session PTY routing) lands and #263 grows session tabs, a four-pane workspace on Firefox will have four DOM-rendered terminals fighting for paint time. WebGL fills the gap.

WebGL also gives a separate GPU context pool — when WebGPU exhausts (Chrome caps around 16 contexts per page), we degrade to WebGL instead of collapsing all the way to DOM.

## Implementation

**New `frontend/src/lib/terminal-renderer.ts`:**

- `pickTerminalRenderer(ctx)` — pure picker, returns `'webgpu' | 'webgl' | 'dom'`
- `isGpuBlocklisted()` — queries `WEBGL_debug_renderer_info` for SwiftShader / LLVMpipe / Microsoft Basic Render Driver substrings, returns true for software fallback drivers (DOM is faster than software-rasterized WebGL anyway)
- `detectRendererContext(navigator, isMobile)` — packages picker inputs

**`Terminal.tsx`:**

- Replaces the WebGPU-only branch with the 3-tier chain
- Single GPU addon variable typed `WebgpuAddon | WebglAddon | undefined`
- WebGPU load failure downgrades to WebGL when available, else DOM
- WebGL load failure downgrades to DOM
- `onContextLoss` disposes the active GPU addon
- Logs the selected renderer once per terminal mount for debug visibility

**Dependencies:**

- Adds `@xterm/addon-webgl@^0.19.0` from npm registry. This version dropped the `xterm@^5.0.0` peer dep restriction and works with the fork's xterm v6.
- Fork (`donovan-yohan/xterm.js#v6.0.0-relay.1`) continues to ship its own `@xterm/addon-webgpu` from `node_modules/@xterm/xterm/addons/addon-webgpu`. No fork change needed.

## Bundle size

App bundle grows ~113 KB (844 KB → 957 KB unminified). Could be deferred via dynamic `import()` so the WebGL addon only loads on browsers that need it. Filed mentally as a follow-up; not blocking — the gain on the affected browsers far outweighs the bundle delta.

## Test plan

- [x] `test/terminal-renderer.test.ts` — 8 picker test cases covering all combinations of GPU availability, mobile flag, WebGL2 support, and blocklist state
- [x] Existing `test/webgpu-renderer-guard.test.ts` left in place; `shouldUseWebGpuRenderer` retained for backward compatibility (no longer used by `Terminal.tsx` but stays exported)
- [x] `tsc --noEmit -p frontend/tsconfig.json` clean
- [x] `npm run build` clean
- [x] Full vitest 1617/1618 (1 unrelated flake in session-restore test re-passed on isolated rerun)

Manual verification (after merge / on a deployed build):
- [ ] Chrome desktop: console logs `xterm renderer: webgpu`, terminal renders normally
- [ ] Firefox desktop: logs `xterm renderer: webgl`
- [ ] Safari iOS: logs `xterm renderer: webgl`, multi-pane terminals scroll smoothly
- [ ] Linux with SwiftShader (`chrome --use-gl=swiftshader`): logs `xterm renderer: dom`
- [ ] Force WebGPU context loss in DevTools: addon disposes; terminal continues without renderer (fallback path)

## Related

- Part of epic #326 (multi-pane workspace performance hardening)
- Independent of #263 (workspace layout substrate); can land in any order

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal now intelligently selects the optimal rendering backend based on device and browser capabilities, automatically falling back to compatible alternatives for improved performance and device support.

* **Tests**
  * Added comprehensive test suite for renderer selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->