### PR TITLE
feat(pty): per-session PTY routing for multi-pane terminals (#330)

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -181,7 +181,8 @@ function handleAlternateBufferScroll(
   touch: Touch,
   s: TouchScrollState,
   term: XTerminal,
-  lineHeight: number
+  lineHeight: number,
+  sendData: (data: string) => void
 ) {
   const incrementalDelta = s.contentLastTouchY - touch.clientY;
   s.contentLastTouchY = touch.clientY;
@@ -194,7 +195,7 @@ function handleAlternateBufferScroll(
   const row = Math.max(1, Math.round(term.rows / 2));
   const seq = `\x1b[<${button};${col};${row}M`;
   const count = Math.min(Math.abs(rawLines), 5);
-  for (let i = 0; i < count; i++) sendPtyData(seq);
+  for (let i = 0; i < count; i++) sendData(seq);
   void e;
 }
 
@@ -245,6 +246,7 @@ function useTouchScroll(
   scrollbarRef: React.RefObject<HTMLDivElement | null>,
   thumbTop: number,
   useTmux: boolean,
+  sendData: (data: string) => void,
   onCopyModeChange?: (active: boolean) => void
 ) {
   const [selectionMode, setSelectionMode] = useState(false);
@@ -279,11 +281,11 @@ function useTouchScroll(
     if (useTmux) {
       setInCopyMode(true);
       onCopyModeChange?.(true);
-      sendPtyData('\x02[');
+      sendData('\x02[');
       return;
     }
     doEnterSelectionMode(containerRef.current, setSelectionMode);
-  }, [containerRef, useTmux, onCopyModeChange]);
+  }, [containerRef, useTmux, onCopyModeChange, sendData]);
 
   const exitCopyMode = useCallback(() => {
     if (inCopyMode) {
@@ -365,7 +367,8 @@ function useTouchScroll(
     containerRef,
     scrollbarRef,
     stateRef,
-    selectionMode
+    selectionMode,
+    sendData
   );
 
   return {
@@ -385,7 +388,8 @@ function useTouchScrollListeners(
   containerRef: React.RefObject<HTMLDivElement | null>,
   scrollbarRef: React.RefObject<HTMLDivElement | null>,
   stateRef: React.RefObject<TouchScrollState>,
-  selectionMode: boolean
+  selectionMode: boolean,
+  sendData: (data: string) => void
 ) {
   useEffect(() => {
     if (!isMobileDevice) return undefined;
@@ -419,7 +423,7 @@ function useTouchScrollListeners(
       e.preventDefault();
       const lineHeight = container.clientHeight / term.rows;
       if (term.buffer.active.type === 'alternate') {
-        handleAlternateBufferScroll(e, touch, s, term, lineHeight);
+        handleAlternateBufferScroll(e, touch, s, term, lineHeight, sendData);
       } else {
         const lineDelta = deltaY / lineHeight;
         const maxScroll = term.buffer.active.baseY;
@@ -453,7 +457,7 @@ function useTouchScrollListeners(
       document.removeEventListener('touchend', handleTouchEnd);
       document.removeEventListener('touchcancel', handleTouchEnd);
     };
-  }, [termRef, containerRef, scrollbarRef, stateRef, selectionMode]);
+  }, [termRef, containerRef, scrollbarRef, stateRef, selectionMode, sendData]);
 }
 
 // ── useScrollbarClick hook ────────────────────────────────────────────────────
@@ -462,7 +466,8 @@ function useScrollbarClick(
   termRef: React.RefObject<XTerminal | null>,
   scrollbarRef: React.RefObject<HTMLDivElement | null>,
   thumbRef: React.RefObject<HTMLDivElement | null>,
-  thumbTop: number
+  thumbTop: number,
+  sendData: (data: string) => void
 ) {
   const scrollToY = useCallback(
     (clientY: number) => {
@@ -511,10 +516,10 @@ function useScrollbarClick(
           const button = dir === 'down' ? 65 : 64;
           const seq = `\x1b[<${button};${col};${row}M`;
           const count = Math.max(1, Math.round(term.rows / 2));
-          for (let i = 0; i < count; i++) sendPtyData(seq);
+          for (let i = 0; i < count; i++) sendData(seq);
         } else if (dir === 'bottom') {
           const seq = `\x1b[<65;${col};${row}M`;
-          for (let i = 0; i < term.rows; i++) sendPtyData(seq);
+          for (let i = 0; i < term.rows; i++) sendData(seq);
         }
       } else {
         if (dir === 'up') term.scrollPages(-1);
@@ -522,7 +527,7 @@ function useScrollbarClick(
         else if (dir === 'bottom') term.scrollToBottom();
       }
     },
-    [termRef]
+    [termRef, sendData]
   );
 
   return { onScrollbarClick, onScrollFabMouseDown };
@@ -692,7 +697,10 @@ function applyMobilePatches(container: HTMLDivElement, t: XTerminal) {
 
 // Extracted: register escape sequence sanitizers to prevent parser stalls
 // from non-standard sequences sent by OpenCode / OpenTUI.
-function registerEscapeSequenceSanitizers(t: XTerminal): void {
+function registerEscapeSequenceSanitizers(
+  t: XTerminal,
+  sendData: (data: string) => void
+): void {
   // Kitty keyboard protocol queries — OpenTUI sends these to detect keyboard
   // enhancement support. xterm.js <6.1 doesn't handle them, which can leave
   // the parser in a stuck state. Swallow silently.
@@ -716,7 +724,7 @@ function registerEscapeSequenceSanitizers(t: XTerminal): void {
   t.parser.registerCsiHandler({ intermediates: '$', final: 'p' }, (params) => {
     const mode = params[0];
     if (typeof mode !== 'number') return true;
-    sendPtyData(`\x1b[${mode};0$y`);
+    sendData(`\x1b[${mode};0$y`);
     return true;
   });
   t.parser.registerCsiHandler(
@@ -724,7 +732,7 @@ function registerEscapeSequenceSanitizers(t: XTerminal): void {
     (params) => {
       const mode = params[0];
       if (typeof mode !== 'number') return true;
-      sendPtyData(`\x1b[?${mode};0$y`);
+      sendData(`\x1b[?${mode};0$y`);
       return true;
     }
   );
@@ -745,6 +753,17 @@ function useTerminalSetup(
   const fitAddonRef = useRef<FitAddon | null>(null);
   const terminalFontSize = useUiStore((s) => s.terminalFontSize);
 
+  const sessionIdRef = useRef(sessionId);
+  sessionIdRef.current = sessionId;
+  const sendData = useCallback((data: string) => {
+    const id = sessionIdRef.current;
+    if (id) sendPtyData(id, data);
+  }, []);
+  const sendResize = useCallback((cols: number, rows: number) => {
+    const id = sessionIdRef.current;
+    if (id) sendPtyResize(id, cols, rows);
+  }, []);
+
   const fit = useCallback(() => {
     const term = termRef.current;
     const fa = fitAddonRef.current;
@@ -755,9 +774,9 @@ function useTerminalSetup(
     fa.fit();
     if (wasAtBottom) term.scrollToBottom();
     else term.scrollToLine(savedViewportY);
-    sendPtyResize(term.cols, term.rows);
+    sendResize(term.cols, term.rows);
     updateScrollbar();
-  }, [updateScrollbar]);
+  }, [updateScrollbar, sendResize]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -826,10 +845,10 @@ function useTerminalSetup(
     }
     // eslint-disable-next-line no-console -- intentional: log selected renderer once at terminal mount
     console.info(`xterm renderer: ${renderer}`);
-    registerEscapeSequenceSanitizers(t);
+    registerEscapeSequenceSanitizers(t, sendData);
     if (isMobileDevice) applyMobilePatches(container, t);
     fa.fit();
-    t.onData((data) => sendPtyData(data));
+    t.onData((data) => sendData(data));
     attachClipboardKeyHandler(t, isMac);
     t.parser.registerOscHandler(52, (data) => {
       const semicolonIdx = data.indexOf(';');
@@ -861,7 +880,7 @@ function useTerminalSetup(
           fa.fit();
           if (wasAtBottom) t.scrollToBottom();
           else t.scrollToLine(savedViewportY);
-          sendPtyResize(t.cols, t.rows);
+          sendResize(t.cols, t.rows);
           updateScrollbar();
         },
         isMobileDevice ? 150 : 0
@@ -898,7 +917,11 @@ function useTerminalSetup(
         term,
         () => {
           if (termRef.current)
-            sendPtyResize(termRef.current.cols, termRef.current.rows);
+            sendPtyResize(
+              sessionId,
+              termRef.current.cols,
+              termRef.current.rows
+            );
         },
         () => {
           /* session ended */
@@ -1031,6 +1054,13 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
     const scrollbarRef = useRef<HTMLDivElement>(null);
     const thumbRef = useRef<HTMLDivElement>(null);
 
+    const sessionIdRef = useRef(sessionId);
+    sessionIdRef.current = sessionId;
+    const sendData = useCallback((data: string) => {
+      const id = sessionIdRef.current;
+      if (id) sendPtyData(id, data);
+    }, []);
+
     const claudeFullscreen = useConfigStore((s) => s.claudeFullscreen);
     const activeAgent = useSessionsStore(
       (s) => s.sessions.find((sess) => sess.id === sessionId)?.agent
@@ -1065,13 +1095,15 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
       scrollbarRef,
       sbState.thumbTop,
       useTmux,
+      sendData,
       onCopyModeChange
     );
     const { onScrollbarClick, onScrollFabMouseDown } = useScrollbarClick(
       termRef,
       scrollbarRef,
       thumbRef,
-      sbState.thumbTop
+      sbState.thumbTop,
+      sendData
     );
     const {
       dragOver,

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -7,6 +7,7 @@ import type {
 } from './types.js';
 import { createLogger } from './logger.js';
 import { useSessionsStore } from './stores/sessions.js';
+import { useUiStore } from './stores/ui.js';
 
 const logger = createLogger('pty-ws');
 const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -79,42 +80,34 @@ export type EventMessage =
 type EventCallback = (msg: EventMessage) => void;
 type EventOpenCallback = () => void;
 
-let eventWs: WebSocket | null = null;
-let ptyWs: WebSocket | null = null;
-let pendingPtySocket: WebSocket | null = null;
 const MAX_RECONNECT_ATTEMPTS = 30;
+const PING_INTERVAL = 30_000;
+const PONG_TIMEOUT = 5_000;
+const PING_MSG = '{"type":"ping"}';
+const PONG_MSG = '{"type":"pong"}';
 
-let ptyReconnectTimer: ReturnType<typeof setTimeout> | null = null;
-let ptyReconnectAttempt = 0;
+// Flow control constants (string length / UTF-16 code units, ≈ bytes for mostly-ASCII)
+const HIGH_WATER_MARK = 512 * 1024;
+const LOW_WATER_MARK = 128 * 1024;
+const MAX_QUEUE_SIZE = 2 * 1024 * 1024;
+const BG_FLUSH_INTERVAL = 250;
 
-// Ping/pong state for zombie WebSocket detection
-let ptyPingTimer: ReturnType<typeof setInterval> | null = null;
-let ptyPongPending = false;
-let ptyPongTimeout: ReturnType<typeof setTimeout> | null = null;
+// ── Event socket (singleton; not per-session) ────────────────────────────────
+
+let eventWs: WebSocket | null = null;
 let eventPingTimer: ReturnType<typeof setInterval> | null = null;
 let eventPongPending = false;
 let eventPongTimeout: ReturnType<typeof setTimeout> | null = null;
 
-// Track last-known connection params for visibilitychange reconnection
-let lastPtySessionId: string | null = null;
-let lastPtyTerm: Terminal | null = null;
-let lastPtyOnResize: (() => void) | null = null;
-let lastPtyOnSessionEnd: (() => void) | null = null;
 let lastEventOnMessage: EventCallback | null = null;
 let lastEventOnOpen: EventOpenCallback | null = null;
 let lastOnAuthRequired: (() => void) | null = null;
-
-const PING_INTERVAL = 30_000; // 30s heartbeat
-const PONG_TIMEOUT = 5_000; // 5s to respond
-const PING_MSG = '{"type":"ping"}';
-const PONG_MSG = '{"type":"pong"}';
 
 export function connectEventSocket(
   onMessage: EventCallback,
   onOpen?: EventOpenCallback,
   onAuthRequired?: () => void
 ): void {
-  // Null onclose before close to prevent old socket from scheduling a reconnect
   if (eventWs) {
     eventWs.onclose = null;
     eventWs.close();
@@ -135,9 +128,7 @@ export function connectEventSocket(
 
   eventWs.onmessage = (event) => {
     const str = event.data as string;
-    // Any message clears pong pending state
     if (eventPongPending) clearEventPongTimeout();
-    // Handle pong responses silently
     if (str === PONG_MSG) return;
     try {
       onMessage(JSON.parse(str));
@@ -162,295 +153,13 @@ async function reconnectWithAuthCheck(): Promise<void> {
       return;
     }
   } catch {
-    // Server unreachable — keep trying to reconnect
+    /* keep trying */
   }
   if (lastEventOnMessage) {
     connectEventSocket(lastEventOnMessage, lastEventOnOpen ?? undefined);
   }
 }
 
-export function connectPtySocket(
-  sessionId: string,
-  term: Terminal,
-  onResize: () => void,
-  onSessionEnd: () => void
-): void {
-  if (ptyReconnectTimer) {
-    clearTimeout(ptyReconnectTimer);
-    ptyReconnectTimer = null;
-  }
-  ptyReconnectAttempt = 0;
-  clearPtyPing();
-
-  // Store connection params for visibilitychange reconnection
-  lastPtySessionId = sessionId;
-  lastPtyTerm = term;
-  lastPtyOnResize = onResize;
-  lastPtyOnSessionEnd = onSessionEnd;
-
-  // Close any socket still in CONNECTING state from a previous call
-  if (pendingPtySocket) {
-    pendingPtySocket.onopen = null;
-    pendingPtySocket.onmessage = null;
-    pendingPtySocket.onclose = null;
-    pendingPtySocket.onerror = null;
-    pendingPtySocket.close();
-    pendingPtySocket = null;
-  }
-
-  if (ptyWs) {
-    ptyWs.onclose = null;
-    ptyWs.close();
-    ptyWs = null;
-  }
-
-  const url = wsProtocol + '//' + location.host + '/ws/' + sessionId;
-  const socket = new WebSocket(url);
-  pendingPtySocket = socket;
-
-  socket.onopen = () => {
-    pendingPtySocket = null;
-    ptyWs = socket;
-    ptyReconnectAttempt = 0;
-    onResize();
-    startPtyPing();
-    useSessionsStore.getState().clearPtyReconnect(sessionId);
-  };
-
-  // Flow control constants (thresholds measured in string length / UTF-16 code units,
-  // which is close enough to bytes for mostly-ASCII terminal output)
-  const HIGH_WATER_MARK = 512 * 1024; // ~500KB — pause feeding xterm
-  const LOW_WATER_MARK = 128 * 1024; //  ~128KB — resume feeding xterm
-  const MAX_QUEUE_SIZE = 2 * 1024 * 1024; // ~2MB — cap queued data to prevent OOM
-  const BG_FLUSH_INTERVAL = 250; // ms — fallback flush interval when tab is hidden
-
-  // Per-connection write buffer state (scoped here; abandoned on next connectPtySocket call)
-  let writeQueue: string[] = [];
-  let queueSize = 0; // total string length queued but not yet handed to term.write
-  let pendingSize = 0; // string length handed to term.write but not yet processed
-  let paused = false;
-  let rafHandle: number | null = null;
-  let bgTimer: ReturnType<typeof setTimeout> | null = null;
-
-  function flushWriteQueue(): void {
-    rafHandle = null;
-    bgTimer = null;
-    if (writeQueue.length === 0) return;
-
-    // Coalesce all queued chunks into a single term.write call per frame
-    const combined = writeQueue.join('');
-    const combinedLen = combined.length;
-    writeQueue = [];
-    queueSize = 0;
-
-    pendingSize += combinedLen;
-    term.write(combined, () => {
-      pendingSize -= combinedLen;
-      // Resume if we were paused and the buffer has drained below the low-water mark
-      if (paused && pendingSize < LOW_WATER_MARK) {
-        paused = false;
-        logger.info(
-          'flow-control: LOW water mark reached, resuming (pending=%d, queued=%d)',
-          pendingSize,
-          writeQueue.length
-        );
-        scheduleFlush();
-      }
-    });
-
-    // Check pressure after handing off the coalesced write
-    if (pendingSize >= HIGH_WATER_MARK) {
-      paused = true;
-      logger.warn(
-        'flow-control: HIGH water mark hit, pausing (pending=%d)',
-        pendingSize
-      );
-    }
-  }
-
-  function scheduleFlush(): void {
-    if (rafHandle !== null || bgTimer !== null) return;
-    // RAF is throttled/paused in background tabs — use setTimeout fallback
-    if (document.hidden) {
-      bgTimer = setTimeout(flushWriteQueue, BG_FLUSH_INTERVAL);
-    } else {
-      rafHandle = requestAnimationFrame(flushWriteQueue);
-    }
-  }
-
-  socket.onmessage = (event) => {
-    const str = event.data as string;
-    // Any message from server clears pong pending state
-    if (ptyPongPending) clearPtyPongTimeout();
-    // Handle pong responses silently
-    if (str === PONG_MSG) return;
-
-    // Cap queue size to prevent unbounded memory growth
-    if (queueSize + str.length > MAX_QUEUE_SIZE) {
-      if (!paused) {
-        logger.warn(
-          'flow-control: queue cap reached (%d), dropping data',
-          queueSize
-        );
-      }
-      return;
-    }
-
-    writeQueue.push(str);
-    queueSize += str.length;
-    if (paused) {
-      logger.debug(
-        'flow-control: queued %d chars while paused (pending=%d, queue=%d)',
-        str.length,
-        pendingSize,
-        writeQueue.length
-      );
-    }
-    if (!paused) scheduleFlush();
-  };
-
-  socket.onclose = (event) => {
-    clearPtyPing();
-    // Cancel any pending flush for this socket
-    if (rafHandle !== null) {
-      cancelAnimationFrame(rafHandle);
-      rafHandle = null;
-    }
-    if (bgTimer !== null) {
-      clearTimeout(bgTimer);
-      bgTimer = null;
-    }
-    // Clear pending ref if this socket closed before onopen
-    if (pendingPtySocket === socket) pendingPtySocket = null;
-    // If this socket was superseded, ignore its close event
-    if (pendingPtySocket !== socket && ptyWs !== socket) return;
-    if (event.code === 1000) {
-      term.write('\r\n[Session ended]\r\n');
-      ptyWs = null;
-      useSessionsStore.getState().clearPtyReconnect(sessionId);
-      onSessionEnd();
-      return;
-    }
-    ptyWs = null;
-    useSessionsStore.getState().beginPtyReconnect(sessionId);
-    if (ptyReconnectAttempt === 0) term.write('\r\n[Reconnecting...]\r\n');
-    scheduleReconnect(sessionId, term, onResize, onSessionEnd);
-  };
-
-  socket.onerror = () => {};
-}
-
-function scheduleReconnect(
-  sessionId: string,
-  term: Terminal,
-  onResize: () => void,
-  onSessionEnd: () => void
-): void {
-  if (ptyReconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {
-    term.write(
-      '\r\n[Gave up reconnecting after ' +
-        MAX_RECONNECT_ATTEMPTS +
-        ' attempts]\r\n'
-    );
-    useSessionsStore.getState().clearPtyReconnect(sessionId);
-    return;
-  }
-  const delay = Math.min(1000 * 2 ** ptyReconnectAttempt, 10000);
-  ptyReconnectAttempt++;
-
-  ptyReconnectTimer = setTimeout(async () => {
-    ptyReconnectTimer = null;
-    try {
-      const authRes = await fetch('/auth/check');
-      if (authRes.status === 401) {
-        useSessionsStore.getState().clearPtyReconnect(sessionId);
-        lastOnAuthRequired?.();
-        return;
-      }
-      const res = await fetch('/sessions');
-      const sessionList = (await res.json()) as Array<{ id: string }>;
-      if (!sessionList.some((s) => s.id === sessionId)) {
-        term.write('\r\n[Session ended]\r\n');
-        useSessionsStore.getState().clearPtyReconnect(sessionId);
-        onSessionEnd();
-        return;
-      }
-      term.clear();
-      connectPtySocket(sessionId, term, onResize, onSessionEnd);
-    } catch {
-      scheduleReconnect(sessionId, term, onResize, onSessionEnd);
-    }
-  }, delay);
-}
-
-// ── Ping/pong heartbeat ──────────────────────────────────────────────────────
-
-// Send a ping to the PTY socket and schedule a reconnect if no pong arrives.
-function sendPtyPing(): void {
-  if (!ptyWs || ptyWs.readyState !== WebSocket.OPEN) return;
-  ptyPongPending = true;
-  try {
-    ptyWs.send(PING_MSG);
-  } catch {
-    forceReconnectPty();
-    return;
-  }
-  if (ptyPongTimeout) {
-    clearTimeout(ptyPongTimeout);
-    ptyPongTimeout = null;
-  }
-  ptyPongTimeout = setTimeout(() => {
-    ptyPongPending = false;
-    forceReconnectPty();
-  }, PONG_TIMEOUT);
-}
-
-function startPtyPing(): void {
-  ptyPingTimer = setInterval(sendPtyPing, PING_INTERVAL);
-}
-
-function clearPtyPing(): void {
-  if (ptyPingTimer) {
-    clearInterval(ptyPingTimer);
-    ptyPingTimer = null;
-  }
-  clearPtyPongTimeout();
-}
-
-function clearPtyPongTimeout(): void {
-  ptyPongPending = false;
-  if (ptyPongTimeout) {
-    clearTimeout(ptyPongTimeout);
-    ptyPongTimeout = null;
-  }
-}
-
-function forceReconnectPty(): void {
-  clearPtyPing();
-  if (ptyWs) {
-    ptyWs.onclose = null;
-    ptyWs.close();
-    ptyWs = null;
-  }
-  if (
-    lastPtySessionId &&
-    lastPtyTerm &&
-    lastPtyOnResize &&
-    lastPtyOnSessionEnd
-  ) {
-    useSessionsStore.getState().beginPtyReconnect(lastPtySessionId);
-    if (ptyReconnectAttempt === 0)
-      lastPtyTerm.write('\r\n[Reconnecting...]\r\n');
-    scheduleReconnect(
-      lastPtySessionId,
-      lastPtyTerm,
-      lastPtyOnResize,
-      lastPtyOnSessionEnd
-    );
-  }
-}
-
-// Send a ping to the event socket and schedule a reconnect if no pong arrives.
 function sendEventPing(): void {
   if (!eventWs || eventWs.readyState !== WebSocket.OPEN) return;
   eventPongPending = true;
@@ -460,10 +169,7 @@ function sendEventPing(): void {
     forceReconnectEvent();
     return;
   }
-  if (eventPongTimeout) {
-    clearTimeout(eventPongTimeout);
-    eventPongTimeout = null;
-  }
+  if (eventPongTimeout) clearTimeout(eventPongTimeout);
   eventPongTimeout = setTimeout(() => {
     eventPongPending = false;
     forceReconnectEvent();
@@ -500,19 +206,353 @@ function clearEventPongTimeout(): void {
   }
 }
 
+// ── Per-session PTY connection registry ──────────────────────────────────────
+
+interface PtyConnection {
+  sessionId: string;
+  ws: WebSocket | null;
+  pendingWs: WebSocket | null;
+  term: Terminal;
+  onResize: () => void;
+  onSessionEnd: () => void;
+
+  reconnectTimer: ReturnType<typeof setTimeout> | null;
+  reconnectAttempt: number;
+
+  pingTimer: ReturnType<typeof setInterval> | null;
+  pongPending: boolean;
+  pongTimeout: ReturnType<typeof setTimeout> | null;
+
+  writeQueue: string[];
+  queueSize: number;
+  pendingSize: number;
+  paused: boolean;
+  rafHandle: number | null;
+  bgTimer: ReturnType<typeof setTimeout> | null;
+}
+
+const ptyConnections = new Map<string, PtyConnection>();
+
+function getActiveSessionId(): string | null {
+  const sendTo = useUiStore.getState().sendToTargetSessionId;
+  if (sendTo) return sendTo;
+  return useSessionsStore.getState().activeSessionId;
+}
+
+function getActiveConnection(): PtyConnection | null {
+  const id = getActiveSessionId();
+  if (!id) return null;
+  return ptyConnections.get(id) ?? null;
+}
+
+function disposePtyConnectionResources(conn: PtyConnection): void {
+  clearPtyPing(conn);
+  if (conn.reconnectTimer) {
+    clearTimeout(conn.reconnectTimer);
+    conn.reconnectTimer = null;
+  }
+  if (conn.rafHandle !== null) {
+    cancelAnimationFrame(conn.rafHandle);
+    conn.rafHandle = null;
+  }
+  if (conn.bgTimer !== null) {
+    clearTimeout(conn.bgTimer);
+    conn.bgTimer = null;
+  }
+}
+
+function flushWriteQueue(conn: PtyConnection): void {
+  conn.rafHandle = null;
+  conn.bgTimer = null;
+  if (conn.writeQueue.length === 0) return;
+
+  const combined = conn.writeQueue.join('');
+  const combinedLen = combined.length;
+  conn.writeQueue = [];
+  conn.queueSize = 0;
+
+  conn.pendingSize += combinedLen;
+  conn.term.write(combined, () => {
+    conn.pendingSize -= combinedLen;
+    if (conn.paused && conn.pendingSize < LOW_WATER_MARK) {
+      conn.paused = false;
+      logger.info(
+        'flow-control: LOW water mark reached, resuming (session=%s, pending=%d, queued=%d)',
+        conn.sessionId,
+        conn.pendingSize,
+        conn.writeQueue.length
+      );
+      scheduleFlush(conn);
+    }
+  });
+
+  if (conn.pendingSize >= HIGH_WATER_MARK) {
+    conn.paused = true;
+    logger.warn(
+      'flow-control: HIGH water mark hit, pausing (session=%s, pending=%d)',
+      conn.sessionId,
+      conn.pendingSize
+    );
+  }
+}
+
+function scheduleFlush(conn: PtyConnection): void {
+  if (conn.rafHandle !== null || conn.bgTimer !== null) return;
+  if (document.hidden) {
+    conn.bgTimer = setTimeout(() => flushWriteQueue(conn), BG_FLUSH_INTERVAL);
+  } else {
+    conn.rafHandle = requestAnimationFrame(() => flushWriteQueue(conn));
+  }
+}
+
+export function connectPtySocket(
+  sessionId: string,
+  term: Terminal,
+  onResize: () => void,
+  onSessionEnd: () => void
+): void {
+  // Tear down any existing connection for this session.
+  const existing = ptyConnections.get(sessionId);
+  if (existing) {
+    disposePtyConnectionResources(existing);
+    if (existing.pendingWs) {
+      existing.pendingWs.onopen = null;
+      existing.pendingWs.onmessage = null;
+      existing.pendingWs.onclose = null;
+      existing.pendingWs.onerror = null;
+      existing.pendingWs.close();
+      existing.pendingWs = null;
+    }
+    if (existing.ws) {
+      existing.ws.onclose = null;
+      existing.ws.close();
+      existing.ws = null;
+    }
+  }
+
+  const conn: PtyConnection = {
+    sessionId,
+    ws: null,
+    pendingWs: null,
+    term,
+    onResize,
+    onSessionEnd,
+    reconnectTimer: null,
+    reconnectAttempt: 0,
+    pingTimer: null,
+    pongPending: false,
+    pongTimeout: null,
+    writeQueue: [],
+    queueSize: 0,
+    pendingSize: 0,
+    paused: false,
+    rafHandle: null,
+    bgTimer: null,
+  };
+  ptyConnections.set(sessionId, conn);
+
+  openPtySocket(conn);
+}
+
+function openPtySocket(conn: PtyConnection): void {
+  const url = wsProtocol + '//' + location.host + '/ws/' + conn.sessionId;
+  const socket = new WebSocket(url);
+  conn.pendingWs = socket;
+
+  socket.onopen = () => {
+    conn.pendingWs = null;
+    conn.ws = socket;
+    conn.reconnectAttempt = 0;
+    conn.onResize();
+    startPtyPing(conn);
+    useSessionsStore.getState().clearPtyReconnect(conn.sessionId);
+  };
+
+  socket.onmessage = (event) => {
+    const str = event.data as string;
+    if (conn.pongPending) clearPtyPongTimeout(conn);
+    if (str === PONG_MSG) return;
+
+    if (conn.queueSize + str.length > MAX_QUEUE_SIZE) {
+      if (!conn.paused) {
+        logger.warn(
+          'flow-control: queue cap reached (session=%s, queue=%d), dropping data',
+          conn.sessionId,
+          conn.queueSize
+        );
+      }
+      return;
+    }
+
+    conn.writeQueue.push(str);
+    conn.queueSize += str.length;
+    if (conn.paused) {
+      logger.debug(
+        'flow-control: queued %d chars while paused (session=%s, pending=%d, queue=%d)',
+        str.length,
+        conn.sessionId,
+        conn.pendingSize,
+        conn.writeQueue.length
+      );
+    }
+    if (!conn.paused) scheduleFlush(conn);
+  };
+
+  socket.onclose = (event) => {
+    clearPtyPing(conn);
+    if (conn.rafHandle !== null) {
+      cancelAnimationFrame(conn.rafHandle);
+      conn.rafHandle = null;
+    }
+    if (conn.bgTimer !== null) {
+      clearTimeout(conn.bgTimer);
+      conn.bgTimer = null;
+    }
+    if (conn.pendingWs === socket) conn.pendingWs = null;
+    if (conn.pendingWs !== socket && conn.ws !== socket) return;
+
+    if (event.code === 1000) {
+      conn.term.write('\r\n[Session ended]\r\n');
+      conn.ws = null;
+      useSessionsStore.getState().clearPtyReconnect(conn.sessionId);
+      ptyConnections.delete(conn.sessionId);
+      conn.onSessionEnd();
+      return;
+    }
+    conn.ws = null;
+    useSessionsStore.getState().beginPtyReconnect(conn.sessionId);
+    if (conn.reconnectAttempt === 0) {
+      conn.term.write('\r\n[Reconnecting...]\r\n');
+    }
+    scheduleReconnect(conn);
+  };
+
+  socket.onerror = () => {};
+}
+
+function scheduleReconnect(conn: PtyConnection): void {
+  if (conn.reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {
+    conn.term.write(
+      '\r\n[Gave up reconnecting after ' +
+        MAX_RECONNECT_ATTEMPTS +
+        ' attempts]\r\n'
+    );
+    useSessionsStore.getState().clearPtyReconnect(conn.sessionId);
+    return;
+  }
+  const delay = Math.min(1000 * 2 ** conn.reconnectAttempt, 10000);
+  conn.reconnectAttempt++;
+
+  conn.reconnectTimer = setTimeout(async () => {
+    conn.reconnectTimer = null;
+    try {
+      const authRes = await fetch('/auth/check');
+      if (authRes.status === 401) {
+        useSessionsStore.getState().clearPtyReconnect(conn.sessionId);
+        lastOnAuthRequired?.();
+        return;
+      }
+      const res = await fetch('/sessions');
+      const sessionList = (await res.json()) as Array<{ id: string }>;
+      if (!sessionList.some((s) => s.id === conn.sessionId)) {
+        conn.term.write('\r\n[Session ended]\r\n');
+        useSessionsStore.getState().clearPtyReconnect(conn.sessionId);
+        ptyConnections.delete(conn.sessionId);
+        conn.onSessionEnd();
+        return;
+      }
+      conn.term.clear();
+      openPtySocket(conn);
+    } catch {
+      scheduleReconnect(conn);
+    }
+  }, delay);
+}
+
+function sendPtyPing(conn: PtyConnection): void {
+  if (!conn.ws || conn.ws.readyState !== WebSocket.OPEN) return;
+  conn.pongPending = true;
+  try {
+    conn.ws.send(PING_MSG);
+  } catch {
+    forceReconnectPty(conn);
+    return;
+  }
+  if (conn.pongTimeout) {
+    clearTimeout(conn.pongTimeout);
+    conn.pongTimeout = null;
+  }
+  conn.pongTimeout = setTimeout(() => {
+    conn.pongPending = false;
+    forceReconnectPty(conn);
+  }, PONG_TIMEOUT);
+}
+
+function startPtyPing(conn: PtyConnection): void {
+  conn.pingTimer = setInterval(() => sendPtyPing(conn), PING_INTERVAL);
+}
+
+function clearPtyPing(conn: PtyConnection): void {
+  if (conn.pingTimer) {
+    clearInterval(conn.pingTimer);
+    conn.pingTimer = null;
+  }
+  clearPtyPongTimeout(conn);
+}
+
+function clearPtyPongTimeout(conn: PtyConnection): void {
+  conn.pongPending = false;
+  if (conn.pongTimeout) {
+    clearTimeout(conn.pongTimeout);
+    conn.pongTimeout = null;
+  }
+}
+
+function forceReconnectPty(conn: PtyConnection): void {
+  clearPtyPing(conn);
+  if (conn.ws) {
+    conn.ws.onclose = null;
+    conn.ws.close();
+    conn.ws = null;
+  }
+  useSessionsStore.getState().beginPtyReconnect(conn.sessionId);
+  if (conn.reconnectAttempt === 0) {
+    conn.term.write('\r\n[Reconnecting...]\r\n');
+  }
+  scheduleReconnect(conn);
+}
+
+export function disconnectPtySocket(sessionId: string): void {
+  const conn = ptyConnections.get(sessionId);
+  if (!conn) return;
+  disposePtyConnectionResources(conn);
+  if (conn.pendingWs) {
+    conn.pendingWs.onclose = null;
+    conn.pendingWs.close();
+    conn.pendingWs = null;
+  }
+  if (conn.ws) {
+    conn.ws.onclose = null;
+    conn.ws.close();
+    conn.ws = null;
+  }
+  ptyConnections.delete(sessionId);
+  useSessionsStore.getState().clearPtyReconnect(sessionId);
+}
+
 // ── Visibility change — proactive reconnection on mobile wake ────────────────
 
 document.addEventListener('visibilitychange', () => {
   if (document.visibilityState !== 'visible') return;
 
-  // PTY socket: if dead, force reconnect; if alive, probe with a ping
-  if (ptyWs && ptyWs.readyState !== WebSocket.OPEN) {
-    forceReconnectPty();
-  } else if (ptyWs) {
-    sendPtyPing();
+  for (const conn of ptyConnections.values()) {
+    if (conn.ws && conn.ws.readyState !== WebSocket.OPEN) {
+      forceReconnectPty(conn);
+    } else if (conn.ws) {
+      sendPtyPing(conn);
+    }
   }
 
-  // Event socket: if dead, force reconnect; if alive, probe with a ping
   if (eventWs && eventWs.readyState !== WebSocket.OPEN) {
     forceReconnectEvent();
   } else if (eventWs) {
@@ -522,16 +562,71 @@ document.addEventListener('visibilitychange', () => {
 
 // ── Public API ───────────────────────────────────────────────────────────────
 
-export function sendPtyData(data: string): void {
-  if (ptyWs && ptyWs.readyState === WebSocket.OPEN) ptyWs.send(data);
-}
-
-export function sendPtyResize(cols: number, rows: number): void {
-  if (ptyWs && ptyWs.readyState === WebSocket.OPEN) {
-    ptyWs.send(JSON.stringify({ type: 'resize', cols, rows }));
+export function sendPtyData(sessionId: string, data: string): void;
+export function sendPtyData(data: string): void;
+export function sendPtyData(arg1: string, arg2?: string): void {
+  let conn: PtyConnection | null;
+  let data: string;
+  if (arg2 !== undefined) {
+    conn = ptyConnections.get(arg1) ?? null;
+    data = arg2;
+  } else {
+    conn = getActiveConnection();
+    data = arg1;
+  }
+  if (conn?.ws && conn.ws.readyState === WebSocket.OPEN) {
+    conn.ws.send(data);
   }
 }
 
-export function isPtyConnected(): boolean {
-  return ptyWs !== null && ptyWs.readyState === WebSocket.OPEN;
+export function sendPtyResize(
+  sessionId: string,
+  cols: number,
+  rows: number
+): void;
+export function sendPtyResize(cols: number, rows: number): void;
+export function sendPtyResize(
+  arg1: string | number,
+  arg2: number,
+  arg3?: number
+): void {
+  let conn: PtyConnection | null;
+  let cols: number;
+  let rows: number;
+  if (typeof arg1 === 'string' && arg3 !== undefined) {
+    conn = ptyConnections.get(arg1) ?? null;
+    cols = arg2;
+    rows = arg3;
+  } else if (typeof arg1 === 'number') {
+    conn = getActiveConnection();
+    cols = arg1;
+    rows = arg2;
+  } else {
+    return;
+  }
+  if (conn?.ws && conn.ws.readyState === WebSocket.OPEN) {
+    conn.ws.send(JSON.stringify({ type: 'resize', cols, rows }));
+  }
+}
+
+export function isPtyConnected(sessionId?: string): boolean {
+  const conn = sessionId
+    ? (ptyConnections.get(sessionId) ?? null)
+    : getActiveConnection();
+  return !!conn?.ws && conn.ws.readyState === WebSocket.OPEN;
+}
+
+// ── Test-only helpers ────────────────────────────────────────────────────────
+
+/** @internal — exposed for tests to inspect/reset the connection registry. */
+export function _ptyConnectionsForTesting(): Map<string, PtyConnection> {
+  return ptyConnections;
+}
+
+/** @internal — exposed for tests to clear all connections without socket teardown. */
+export function _clearPtyConnectionsForTesting(): void {
+  for (const conn of ptyConnections.values()) {
+    disposePtyConnectionResources(conn);
+  }
+  ptyConnections.clear();
 }

--- a/test/ws-pty-routing.test.ts
+++ b/test/ws-pty-routing.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Terminal } from '@xterm/xterm';
+
+// We need to mock store imports BEFORE importing ws.ts
+const sessionsStore = {
+  activeSessionId: null as string | null,
+  beginPtyReconnect: vi.fn(),
+  clearPtyReconnect: vi.fn(),
+};
+const uiStore = {
+  sendToTargetSessionId: null as string | null,
+};
+
+vi.mock('../frontend/src/lib/stores/sessions.js', () => ({
+  useSessionsStore: {
+    getState: () => sessionsStore,
+  },
+}));
+vi.mock('../frontend/src/lib/stores/ui.js', () => ({
+  useUiStore: {
+    getState: () => uiStore,
+  },
+}));
+
+interface MockSocket {
+  url: string;
+  readyState: number;
+  onopen: ((ev: Event) => void) | null;
+  onmessage: ((ev: MessageEvent) => void) | null;
+  onclose: ((ev: CloseEvent) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  __triggerOpen: () => void;
+}
+
+const sockets: MockSocket[] = [];
+
+class FakeWebSocket {
+  static OPEN = 1;
+  static CLOSED = 3;
+  url: string;
+  readyState = 0;
+  onopen: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = FakeWebSocket.CLOSED;
+  });
+
+  constructor(url: string) {
+    this.url = url;
+    sockets.push(this as unknown as MockSocket);
+    Object.assign(this as unknown as MockSocket, {
+      __triggerOpen: () => {
+        this.readyState = FakeWebSocket.OPEN;
+        this.onopen?.({} as Event);
+      },
+    });
+  }
+}
+
+beforeEach(() => {
+  sockets.length = 0;
+  sessionsStore.activeSessionId = null;
+  sessionsStore.beginPtyReconnect.mockClear();
+  sessionsStore.clearPtyReconnect.mockClear();
+  uiStore.sendToTargetSessionId = null;
+  // @ts-expect-error — replace global
+  globalThis.WebSocket = FakeWebSocket;
+  vi.stubGlobal('location', {
+    protocol: 'http:',
+    host: 'localhost:3000',
+  });
+  vi.stubGlobal('document', {
+    addEventListener: vi.fn(),
+    visibilityState: 'visible',
+    hidden: false,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const fakeTerm = (): Terminal => {
+  return {
+    write: vi.fn(),
+    clear: vi.fn(),
+  } as unknown as Terminal;
+};
+
+async function importWs() {
+  vi.resetModules();
+  return await import('../frontend/src/lib/ws.js');
+}
+
+describe('per-session PTY routing', () => {
+  it('opens distinct sockets for distinct sessions', async () => {
+    const ws = await importWs();
+    const onResize = vi.fn();
+    const onEnd = vi.fn();
+    ws.connectPtySocket('sess-a', fakeTerm(), onResize, onEnd);
+    ws.connectPtySocket('sess-b', fakeTerm(), onResize, onEnd);
+    expect(sockets).toHaveLength(2);
+    expect(sockets[0]!.url).toContain('/ws/sess-a');
+    expect(sockets[1]!.url).toContain('/ws/sess-b');
+  });
+
+  it('routes sendPtyData to the matching session', async () => {
+    const ws = await importWs();
+    ws.connectPtySocket('sess-a', fakeTerm(), vi.fn(), vi.fn());
+    ws.connectPtySocket('sess-b', fakeTerm(), vi.fn(), vi.fn());
+    sockets[0]!.__triggerOpen();
+    sockets[1]!.__triggerOpen();
+    ws.sendPtyData('sess-a', 'hello-a');
+    ws.sendPtyData('sess-b', 'hello-b');
+    expect(sockets[0]!.send).toHaveBeenCalledWith('hello-a');
+    expect(sockets[1]!.send).toHaveBeenCalledWith('hello-b');
+    // Cross-talk check
+    const aCalls = sockets[0]!.send.mock.calls.map((c) => c[0]);
+    expect(aCalls.includes('hello-b')).toBe(false);
+  });
+
+  it('routes sendPtyResize per session', async () => {
+    const ws = await importWs();
+    ws.connectPtySocket('sess-a', fakeTerm(), vi.fn(), vi.fn());
+    ws.connectPtySocket('sess-b', fakeTerm(), vi.fn(), vi.fn());
+    sockets[0]!.__triggerOpen();
+    sockets[1]!.__triggerOpen();
+    ws.sendPtyResize('sess-a', 80, 24);
+    expect(sockets[0]!.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'resize', cols: 80, rows: 24 })
+    );
+    expect(sockets[1]!.send).not.toHaveBeenCalled();
+  });
+
+  it('isPtyConnected reports per-session state', async () => {
+    const ws = await importWs();
+    ws.connectPtySocket('sess-a', fakeTerm(), vi.fn(), vi.fn());
+    expect(ws.isPtyConnected('sess-a')).toBe(false);
+    sockets[0]!.__triggerOpen();
+    expect(ws.isPtyConnected('sess-a')).toBe(true);
+    expect(ws.isPtyConnected('sess-b')).toBe(false);
+  });
+
+  it('disconnectPtySocket cleans up only the target session', async () => {
+    const ws = await importWs();
+    ws.connectPtySocket('sess-a', fakeTerm(), vi.fn(), vi.fn());
+    ws.connectPtySocket('sess-b', fakeTerm(), vi.fn(), vi.fn());
+    sockets[0]!.__triggerOpen();
+    sockets[1]!.__triggerOpen();
+    ws.disconnectPtySocket('sess-a');
+    expect(sockets[0]!.close).toHaveBeenCalled();
+    expect(sockets[1]!.close).not.toHaveBeenCalled();
+    expect(ws.isPtyConnected('sess-a')).toBe(false);
+    expect(ws.isPtyConnected('sess-b')).toBe(true);
+  });
+
+  it('no-arg sendPtyData routes to sendToTargetSessionId when set', async () => {
+    const ws = await importWs();
+    ws.connectPtySocket('sess-a', fakeTerm(), vi.fn(), vi.fn());
+    ws.connectPtySocket('sess-b', fakeTerm(), vi.fn(), vi.fn());
+    sockets[0]!.__triggerOpen();
+    sockets[1]!.__triggerOpen();
+    uiStore.sendToTargetSessionId = 'sess-b';
+    ws.sendPtyData('to-active');
+    expect(sockets[1]!.send).toHaveBeenCalledWith('to-active');
+    expect(sockets[0]!.send).not.toHaveBeenCalled();
+  });
+
+  it('no-arg sendPtyData falls back to activeSessionId', async () => {
+    const ws = await importWs();
+    ws.connectPtySocket('sess-a', fakeTerm(), vi.fn(), vi.fn());
+    sockets[0]!.__triggerOpen();
+    sessionsStore.activeSessionId = 'sess-a';
+    ws.sendPtyData('to-active');
+    expect(sockets[0]!.send).toHaveBeenCalledWith('to-active');
+  });
+
+  it('no-arg sendPtyData is a no-op when no active target', async () => {
+    const ws = await importWs();
+    ws.connectPtySocket('sess-a', fakeTerm(), vi.fn(), vi.fn());
+    sockets[0]!.__triggerOpen();
+    expect(() => ws.sendPtyData('orphan')).not.toThrow();
+    expect(sockets[0]!.send).not.toHaveBeenCalled();
+  });
+
+  it('reconnecting one session does not affect siblings', async () => {
+    const ws = await importWs();
+    ws.connectPtySocket('sess-a', fakeTerm(), vi.fn(), vi.fn());
+    ws.connectPtySocket('sess-b', fakeTerm(), vi.fn(), vi.fn());
+    sockets[0]!.__triggerOpen();
+    sockets[1]!.__triggerOpen();
+    // Force-close A (non-clean code → triggers reconnect path)
+    sockets[0]!.readyState = FakeWebSocket.CLOSED;
+    sockets[0]!.onclose?.({ code: 1006 } as CloseEvent);
+    // B should still be operational
+    expect(ws.isPtyConnected('sess-b')).toBe(true);
+    ws.sendPtyData('sess-b', 'still-here');
+    expect(sockets[1]!.send).toHaveBeenCalledWith('still-here');
+  });
+
+  it('reopening a session replaces the prior socket', async () => {
+    const ws = await importWs();
+    ws.connectPtySocket('sess-a', fakeTerm(), vi.fn(), vi.fn());
+    ws.connectPtySocket('sess-a', fakeTerm(), vi.fn(), vi.fn());
+    expect(sockets[0]!.close).toHaveBeenCalled();
+    expect(sockets).toHaveLength(2);
+    expect(sockets[1]!.url).toContain('/ws/sess-a');
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the single-active PTY socket model with a per-session connection registry on the frontend. **Server-side was already per-session-aware** (`/ws/:sessionId` upgrade route, `WeakMap<WebSocket, Session>` keyed connections, independent `attachToPty(session.pty)` per WS), so no server changes are required.

This is the transport-layer prerequisite for sessions-as-tabs in the workspace layout shipped under #263 (PR #332). Until this lands, `connectPtySocket(...)` closes the previous singleton socket before opening a new one — multi-pane terminals would fight over one global write path.

> Branched off `feat/issue-327-xterm-webgl-tier` (PR #333) because both touch `Terminal.tsx`. Cleaner to land in sequence.

## Why server-side did not need changes

Confirmed in `server/ws.ts:354-407`:

- `^/ws/([a-f0-9]+)$` matched per upgrade — each connection routes to its own session
- `sessionMap: WeakMap<WebSocket, Session>` keys connections per-WS
- `attachToPty(session.pty)` runs per-WS with its own `onData` / `onExit` disposables; replays scrollback per-WS
- `session.onPtyReplacedCallbacks` already holds a per-WS handler so multiple WSs survive a PTY swap

The client was the bottleneck.

## Frontend ws.ts refactor

**Before:** module-level singletons — `let ptyWs: WebSocket | null`, `lastPtySessionId`, `lastPtyTerm`, etc. — and one set of flow-control / ping-pong / reconnect state.

**After:** `Map<sessionId, PtyConnection>` registry. Each `PtyConnection` carries its own:

- `ws` / `pendingWs`
- `writeQueue`, `queueSize`, `pendingSize`, `paused`, `rafHandle`, `bgTimer`
- `pingTimer`, `pongPending`, `pongTimeout`
- `reconnectTimer`, `reconnectAttempt`

**API:**

```ts
connectPtySocket(sessionId, term, onResize, onSessionEnd): void
disconnectPtySocket(sessionId): void   // NEW: explicit cleanup

sendPtyData(sessionId, data): void
sendPtyData(data): void                // backward-compat: routes to active session

sendPtyResize(sessionId, cols, rows): void
sendPtyResize(cols, rows): void        // backward-compat

isPtyConnected(sessionId?): boolean    // optional sessionId
```

The no-arg overloads route to `useUiStore.getState().sendToTargetSessionId ?? useSessionsStore.getState().activeSessionId`. Used by `App.tsx` (key sends, reference inject), `ImageToast.tsx`, and `MobileInput.tsx` — those are intentionally implicit-active-target callers.

**Visibility-change handler** now iterates `ptyConnections.values()` and probes/reconnects each, instead of relying on a single `lastPtyXxx` snapshot.

**Event socket logic untouched** — single global, not per-session.

## Frontend Terminal.tsx

- New `sendData` / `sendResize` closures read `sessionIdRef.current` so they stay stable across prop swaps but always target the current session id (avoids stale-closure issues with the long-lived terminal-mount effect).
- Threaded into `useTouchScroll`, `useTouchScrollListeners`, `useScrollbarClick`, `registerEscapeSequenceSanitizers`, and `handleAlternateBufferScroll`.
- `connectPtySocket` resize callback now passes `sessionId` explicitly.

## Test plan

`test/ws-pty-routing.test.ts` — 10 cases with `FakeWebSocket` mock + `vi.mock` for store imports:

- [x] distinct sockets per session
- [x] `sendPtyData(sessId, data)` routes only to that session
- [x] `sendPtyResize(sessId, cols, rows)` routes only to that session
- [x] `isPtyConnected(sessId)` reports per-session state
- [x] `disconnectPtySocket(sessId)` cleans up only the target; siblings stay live
- [x] no-arg `sendPtyData(data)` routes to `sendToTargetSessionId`
- [x] no-arg `sendPtyData(data)` falls back to `activeSessionId`
- [x] no-arg `sendPtyData(data)` is a no-op when no active target
- [x] closing one session does not affect siblings
- [x] reopening same `sessionId` replaces the prior socket

Verification:
- [x] `tsc --noEmit -p frontend/tsconfig.json` clean
- [x] `eslint` clean on touched files (only pre-existing Terminal.tsx warnings remain — line 898 huge mount effect is intentionally `// intentionally empty: terminal is created once per mount`, line 1144 pre-existing)
- [x] `npm run build` clean
- [x] Full `vitest run`: 1628/1628 pass (130 files; +10 new routing tests)

Manual verification (after #332 sessions-as-tabs follow-up enables it):
- [ ] Two live terminal panes side-by-side
- [ ] Type in pane A → only A's session receives input
- [ ] Resize pane A → only A's session resizes
- [ ] Pane B PTY exit → A still operational
- [ ] Backend restart → both panes reconnect via independent backoff timers

## Risk notes

- **PTY is the highest-risk subsystem.** All existing single-pane flows preserved via no-arg overloads; new per-session routing is additive at the API surface.
- **Memory:** each connection keeps its own writeQueue (cap 2 MB) and pendingSize. With 4 panes worst-case 8 MB; acceptable.
- **Reconnect storm:** if backend restarts, every active pane reconnects simultaneously. Existing exponential backoff per session (`Math.min(1000 * 2 ** attempt, 10000)`) handles. Each connection has its own counter.
- **Flow control per-conn:** worst case is one pane drowning in output and pausing only itself; siblings unaffected.

## Coordination

- Part of epic #326 (multi-pane workspace performance hardening)
- Branched off PR #333 (#327 WebGL tier). Land that first; this rebases cleanly afterward.
- Independent of PR #332 (#263 substrate). Both touch different files in `App.tsx`-adjacent areas (#332 added workspace components; this changes ws.ts and Terminal.tsx).
- Unblocks: sessions-as-tabs in workspace (eliminates the "one mounted live terminal" caveat in #263 first slice).
- Unblocks: #329 (xterm pause/resume on inactive) — only meaningful once multiple terminals can stay live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
