### PR TITLE
fix: move port assignments state out of repo root

### DIFF
--- a/server/port-allocator.ts
+++ b/server/port-allocator.ts
@@ -2,7 +2,9 @@
  * Port Allocator for Worktree Environments
  *
  * Provides durable port allocation with OS-level verification.
- * Ports are persisted to port-assignments.json in the config directory.
+ * Ports are persisted to port-assignments.json under the user config
+ * directory, scoped by config/workspace identity so local dev state never
+ * lands in the repo root.
  *
  * Port ranges:
  * - Primary: 10000-10999 (1000 ports)
@@ -14,6 +16,8 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import * as crypto from 'node:crypto';
+import * as os from 'node:os';
 import getPort from 'get-port';
 
 const DEFAULT_PORT_VARIABLES = ['PORT'];
@@ -81,6 +85,54 @@ export interface PortAllocatorOptions {
 
 type PortAllocatorLogger = NonNullable<PortAllocatorOptions['logger']>;
 
+interface LoadedAssignments {
+  assignments: PortAssignmentsFile;
+  source: 'none' | 'current' | 'legacy';
+}
+
+function userConfigDir(): string {
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME?.trim();
+  const baseDir = xdgConfigHome || path.join(os.homedir(), '.config');
+  return path.join(baseDir, 'relay-ide');
+}
+
+function safeStateSlug(configPath: string): string {
+  const configDir = path.dirname(path.resolve(configPath));
+  const slug = path
+    .basename(configDir)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+  return slug || 'workspace';
+}
+
+function stateKeyForConfig(configPath: string): string {
+  const configDir = path.dirname(path.resolve(configPath));
+  const hash = crypto
+    .createHash('sha256')
+    .update(configDir)
+    .digest('hex')
+    .slice(0, 16);
+  return `${safeStateSlug(configPath)}-${hash}`;
+}
+
+export function resolvePortAssignmentsPath(configPath: string): string {
+  return path.join(
+    userConfigDir(),
+    'workspaces',
+    stateKeyForConfig(configPath),
+    'port-assignments.json'
+  );
+}
+
+export function resolveLegacyPortAssignmentsPath(configPath: string): string {
+  return path.join(
+    path.dirname(path.resolve(configPath)),
+    'port-assignments.json'
+  );
+}
+
 function logWarn(
   logger: PortAllocatorLogger | undefined,
   message: string,
@@ -123,6 +175,7 @@ export function normalizePortVariables(
  */
 export class PortAllocator {
   private readonly assignmentsPath: string;
+  private readonly legacyAssignmentsPath: string;
   private readonly logger:
     | { debug: (msg: string, ...args: unknown[]) => void }
     | undefined;
@@ -130,12 +183,20 @@ export class PortAllocator {
   private initialized = false;
 
   constructor(options: PortAllocatorOptions) {
-    this.assignmentsPath = path.join(
-      path.dirname(options.configPath),
-      'port-assignments.json'
+    this.assignmentsPath = resolvePortAssignmentsPath(options.configPath);
+    this.legacyAssignmentsPath = resolveLegacyPortAssignmentsPath(
+      options.configPath
     );
     this.logger = options.logger;
-    this.assignments = this.loadAssignments();
+    const loaded = this.loadAssignments();
+    this.assignments = loaded.assignments;
+    if (loaded.source === 'legacy') {
+      this.saveAssignments();
+      this.logger?.debug(
+        'Migrated legacy port assignments into user config state:',
+        this.assignmentsPath
+      );
+    }
   }
 
   /**
@@ -269,13 +330,27 @@ export class PortAllocator {
 
   // ── Private Methods ─────────────────────────────────────────────────────
 
-  private loadAssignments(): PortAssignmentsFile {
+  private loadAssignments(): LoadedAssignments {
     if (!fs.existsSync(this.assignmentsPath)) {
-      return { version: 1, assignments: [] };
+      if (
+        this.legacyAssignmentsPath !== this.assignmentsPath &&
+        fs.existsSync(this.legacyAssignmentsPath)
+      ) {
+        const legacy = this.readAssignmentsFile(this.legacyAssignmentsPath);
+        if (legacy) return { assignments: legacy, source: 'legacy' };
+      }
+      return { assignments: { version: 1, assignments: [] }, source: 'none' };
     }
 
+    const current = this.readAssignmentsFile(this.assignmentsPath);
+    if (current) return { assignments: current, source: 'current' };
+
+    return { assignments: { version: 1, assignments: [] }, source: 'none' };
+  }
+
+  private readAssignmentsFile(filePath: string): PortAssignmentsFile | null {
     try {
-      const raw = fs.readFileSync(this.assignmentsPath, 'utf8');
+      const raw = fs.readFileSync(filePath, 'utf8');
       const data = JSON.parse(raw) as PortAssignmentsFile;
       if (data.version === 1 && Array.isArray(data.assignments)) {
         return data;
@@ -283,12 +358,12 @@ export class PortAllocator {
       logWarn(
         this.logger,
         'Invalid port assignments file version or shape, starting fresh:',
-        this.assignmentsPath
+        filePath
       );
     } catch (err) {
-      const backupPath = `${this.assignmentsPath}.corrupt-${Date.now()}`;
+      const backupPath = `${filePath}.corrupt-${Date.now()}`;
       try {
-        fs.copyFileSync(this.assignmentsPath, backupPath);
+        fs.copyFileSync(filePath, backupPath);
       } catch {
         // Best-effort backup only.
       }
@@ -299,7 +374,7 @@ export class PortAllocator {
         backupPath ? `backup=${backupPath}` : ''
       );
     }
-    return { version: 1, assignments: [] };
+    return null;
   }
 
   private saveAssignments(): void {

--- a/test/port-allocator.test.ts
+++ b/test/port-allocator.test.ts
@@ -1,4 +1,12 @@
-import { test, beforeAll, afterAll, afterEach, expect, describe } from 'vitest';
+import {
+  test,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  afterEach,
+  expect,
+  describe,
+} from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -21,12 +29,19 @@ import {
   PORT_RANGE_END,
   OVERFLOW_RANGE_START,
   OVERFLOW_RANGE_END,
+  resolvePortAssignmentsPath,
+  resolveLegacyPortAssignmentsPath,
 } from '../server/port-allocator.js';
 
 let tmpDir!: string;
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
 
 beforeAll(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ide-port-alloc-test-'));
+});
+
+beforeEach(() => {
+  process.env.XDG_CONFIG_HOME = path.join(tmpDir, 'xdg-config');
 });
 
 afterEach(() => {
@@ -39,6 +54,11 @@ afterEach(() => {
     }
   }
   resetDefaultAllocator();
+  if (originalXdgConfigHome === undefined) {
+    delete process.env.XDG_CONFIG_HOME;
+  } else {
+    process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+  }
 });
 
 afterAll(() => {
@@ -76,8 +96,11 @@ describe('PortAllocator', () => {
 
     await allocator.allocatePortsForWorktree('repo-1', 'wt-1', ['PORT']);
 
-    const assignmentsPath = path.join(tmpDir, 'port-assignments.json');
+    const assignmentsPath = resolvePortAssignmentsPath(configPath);
     expect(fs.existsSync(assignmentsPath)).toBe(true);
+    expect(fs.existsSync(resolveLegacyPortAssignmentsPath(configPath))).toBe(
+      false
+    );
 
     const raw = fs.readFileSync(assignmentsPath, 'utf8');
     const data = JSON.parse(raw);
@@ -88,12 +111,59 @@ describe('PortAllocator', () => {
     expect(data.assignments[0].variableName).toBe('PORT');
   });
 
+  test('keys assignment paths by config/workspace identity under user config', () => {
+    const repoAConfigPath = path.join(tmpDir, 'repo-a', 'config.json');
+    const repoBConfigPath = path.join(tmpDir, 'repo-b', 'config.json');
+
+    const repoAPath = resolvePortAssignmentsPath(repoAConfigPath);
+    const repoBPath = resolvePortAssignmentsPath(repoBConfigPath);
+
+    expect(repoAPath).not.toBe(repoBPath);
+    expect(repoAPath).toContain(
+      path.join(tmpDir, 'xdg-config', 'relay-ide', 'workspaces')
+    );
+    expect(path.basename(repoAPath)).toBe('port-assignments.json');
+  });
+
+  test('migrates legacy repo-root assignments into user config state', async () => {
+    const configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
+    const legacyAssignmentsPath = resolveLegacyPortAssignmentsPath(configPath);
+    const assignmentsPath = resolvePortAssignmentsPath(configPath);
+    const existingAssignments = {
+      version: 1,
+      assignments: [
+        {
+          repoId: 'repo-legacy',
+          worktreeId: 'wt-legacy',
+          variableName: 'PORT',
+          port: 10060,
+          verifiedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    };
+    fs.writeFileSync(
+      legacyAssignmentsPath,
+      JSON.stringify(existingAssignments),
+      'utf8'
+    );
+
+    const allocator = new PortAllocator({ configPath });
+    await allocator.initialize();
+
+    expect(fs.existsSync(assignmentsPath)).toBe(true);
+    expect(fs.existsSync(legacyAssignmentsPath)).toBe(true);
+    expect(allocator.getPortsForWorktree('repo-legacy', 'wt-legacy')).toEqual({
+      PORT: 10060,
+    });
+  });
+
   test('loads existing assignments on construction', async () => {
     const configPath = path.join(tmpDir, 'config.json');
     fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
 
     // Pre-create assignments file
-    const assignmentsPath = path.join(tmpDir, 'port-assignments.json');
+    const assignmentsPath = resolvePortAssignmentsPath(configPath);
     const existingAssignments = {
       version: 1,
       assignments: [
@@ -106,6 +176,7 @@ describe('PortAllocator', () => {
         },
       ],
     };
+    fs.mkdirSync(path.dirname(assignmentsPath), { recursive: true });
     fs.writeFileSync(
       assignmentsPath,
       JSON.stringify(existingAssignments),
@@ -260,7 +331,7 @@ describe('PortAllocator port verification', () => {
     fs.writeFileSync(configPath, JSON.stringify({}), 'utf8');
 
     // Pre-create assignments with a port in primary range
-    const assignmentsPath = path.join(tmpDir, 'port-assignments.json');
+    const assignmentsPath = resolvePortAssignmentsPath(configPath);
     const existingAssignments = {
       version: 1,
       assignments: [
@@ -273,6 +344,7 @@ describe('PortAllocator port verification', () => {
         },
       ],
     };
+    fs.mkdirSync(path.dirname(assignmentsPath), { recursive: true });
     fs.writeFileSync(
       assignmentsPath,
       JSON.stringify(existingAssignments),


### PR DESCRIPTION
## Summary
- Move `PortAllocator` persistence from `path.dirname(configPath)/port-assignments.json` into `~/.config/relay-ide/workspaces/<config-dir-slug>-<hash>/port-assignments.json` (or `$XDG_CONFIG_HOME/relay-ide/...` when set).
- Add first-run migration from the legacy repo-root assignment file when the new user-state file does not exist.
- Add regression tests for user-config path selection, per-config scoping, legacy migration, and no repo-root write.

## Motivation
Local dev often uses `./config.json`, which made `port-assignments.json` land directly in the repository root and show up in `git status`. Runtime port state belongs in user config/state, not in the checked-out repo.

## The Case Against
This changes the production default state location too: existing `~/.config/relay-ide/port-assignments.json` will be copied into the new scoped `workspaces/.../port-assignments.json` path on first run, but the old file is intentionally left in place. That means users may briefly have two copies until they manually clean old state. The new scope key is based on the resolved config directory, not a first-class workspace id, because `PortAllocator` is initialized before individual workspace allocation calls and currently only receives `configPath` at construction.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
| --- | --- | --- |
| Existing assignments appear lost after the path move | Low | Legacy file is loaded and saved to the new path on first run when no new file exists. |
| Multiple checkouts with the same repo name collide | Low | Path includes a SHA-256 hash of the resolved config directory, not just the slug. |
| Old repo-root file remains visible in existing local dev checkouts | Medium | `.gitignore` already defensively ignores `port-assignments.json`; migration preserves old file instead of deleting user data. |
| XDG config overrides behave differently in tests/users' shells | Low | Resolver honors `$XDG_CONFIG_HOME` and falls back to `~/.config`, with regression coverage. |

## Verification
- `npm test -- test/port-allocator.test.ts` (48 passed)
- `npm run build` (passed; existing Vite chunk-size/dynamic-import warnings only)

Closes #320
