### PR TITLE
feat(ui): add sidebar fleet status cues

### DIFF
--- a/frontend/src/components/RepoItem.css
+++ b/frontend/src/components/RepoItem.css
@@ -162,6 +162,38 @@
   color: var(--text);
 }
 
+.session-row.state-running:not(.selected) {
+  border-left-color: color-mix(in srgb, var(--status-success) 70%, transparent);
+}
+
+.session-row.state-initializing:not(.selected) {
+  border-left-color: color-mix(in srgb, var(--status-info) 65%, transparent);
+}
+
+.session-row.state-unseen-idle:not(.selected) {
+  border-left-color: color-mix(in srgb, var(--status-warning) 75%, transparent);
+}
+
+.session-row.state-permission:not(.selected),
+.session-row.state-needs-answer:not(.selected),
+.session-row.state-error:not(.selected) {
+  border-left-color: color-mix(in srgb, var(--status-error) 75%, transparent);
+}
+
+.session-row.attention.state-unseen-idle {
+  background: color-mix(in srgb, var(--status-warning) 6%, transparent);
+}
+
+.session-row.attention.state-permission,
+.session-row.attention.state-needs-answer,
+.session-row.attention.state-error {
+  background: color-mix(in srgb, var(--status-error) 6%, transparent);
+}
+
+.session-row.attention:hover {
+  background: var(--surface-hover);
+}
+
 .session-row.attention .session-name {
   font-weight: 700;
   color: var(--text);
@@ -195,6 +227,43 @@
   white-space: nowrap;
   flex-shrink: 0;
   opacity: 0.7;
+}
+
+.fleet-status {
+  display: inline-block;
+  max-width: 112px;
+  min-width: 0;
+  padding: 1px 4px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  font-size: var(--font-size-xs);
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+}
+
+.fleet-status.tone-active {
+  border-color: color-mix(in srgb, var(--status-success) 45%, transparent);
+  color: var(--status-success);
+}
+
+.fleet-status.tone-attention {
+  border-color: color-mix(in srgb, var(--status-warning) 55%, transparent);
+  color: var(--status-warning);
+}
+
+.fleet-status.tone-error {
+  border-color: color-mix(in srgb, var(--status-error) 55%, transparent);
+  color: var(--status-error);
+}
+
+.fleet-status.tone-idle,
+.fleet-status.tone-inactive {
+  border-color: var(--border);
+  color: var(--text-muted);
 }
 
 .row-menu-overlay {

--- a/frontend/src/components/RepoItem.css
+++ b/frontend/src/components/RepoItem.css
@@ -180,13 +180,13 @@
   border-left-color: color-mix(in srgb, var(--status-error) 75%, transparent);
 }
 
-.session-row.attention.state-unseen-idle {
+.session-row.attention.state-unseen-idle:not(.selected) {
   background: color-mix(in srgb, var(--status-warning) 6%, transparent);
 }
 
-.session-row.attention.state-permission,
-.session-row.attention.state-needs-answer,
-.session-row.attention.state-error {
+.session-row.attention.state-permission:not(.selected),
+.session-row.attention.state-needs-answer:not(.selected),
+.session-row.attention.state-error:not(.selected) {
   background: color-mix(in srgb, var(--status-error) 6%, transparent);
 }
 

--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -120,8 +120,15 @@ const STATUS_LABELS: Record<DisplayState, Omit<SidebarFleetStatus, 'title'>> = {
   inactive: { label: 'inactive', tone: 'inactive' },
 };
 
-function compactStatusText(value: string, maxLength = 42): string {
-  const normalized = value.replace(/\s+/g, ' ').trim().toLowerCase();
+function compactStatusText(
+  value: string,
+  maxLength = 42,
+  preserveCase = false
+): string {
+  const normalizedValue = value.replace(/\s+/g, ' ').trim();
+  const normalized = preserveCase
+    ? normalizedValue
+    : normalizedValue.toLowerCase();
   if (normalized.length <= maxLength) return normalized;
   return `${normalized.slice(0, maxLength - 1)}…`;
 }
@@ -130,14 +137,20 @@ function formatCurrentActivity(session: SessionSummary): string | null {
   const activity = session.currentActivity;
   if (!activity?.tool) return null;
 
-  const tool = compactStatusText(activity.tool, 18);
-  const detail = activity.detail ? compactStatusText(activity.detail, 32) : '';
+  const tool = compactStatusText(activity.tool, 18, true);
+  const detail = activity.detail
+    ? compactStatusText(activity.detail, 32, true)
+    : '';
   return detail ? `${tool}: ${detail}` : tool;
 }
 
 function findStatusActivity(sessions: SessionSummary[]): string | null {
-  const sessionWithActivity = sessions.find((session) => session.currentActivity);
-  return sessionWithActivity ? formatCurrentActivity(sessionWithActivity) : null;
+  const sessionWithActivity = sessions.find(
+    (session) => session.currentActivity
+  );
+  return sessionWithActivity
+    ? formatCurrentActivity(sessionWithActivity)
+    : null;
 }
 
 export function deriveSessionFleetStatus(

--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -101,6 +101,65 @@ export function groupDisplayName(
   return branch || cwdName || sessions[0]?.repoName || 'unknown';
 }
 
+type FleetStatusTone = 'active' | 'attention' | 'idle' | 'inactive' | 'error';
+
+export interface SidebarFleetStatus {
+  label: string;
+  tone: FleetStatusTone;
+  title: string;
+}
+
+const STATUS_LABELS: Record<DisplayState, Omit<SidebarFleetStatus, 'title'>> = {
+  initializing: { label: 'starting', tone: 'active' },
+  running: { label: 'running', tone: 'active' },
+  'unseen-idle': { label: 'done unread', tone: 'attention' },
+  'seen-idle': { label: 'idle', tone: 'idle' },
+  permission: { label: 'approval needed', tone: 'attention' },
+  'needs-answer': { label: 'answer needed', tone: 'attention' },
+  error: { label: 'error', tone: 'error' },
+  inactive: { label: 'inactive', tone: 'inactive' },
+};
+
+function compactStatusText(value: string, maxLength = 42): string {
+  const normalized = value.replace(/\s+/g, ' ').trim().toLowerCase();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength - 1)}…`;
+}
+
+function formatCurrentActivity(session: SessionSummary): string | null {
+  const activity = session.currentActivity;
+  if (!activity?.tool) return null;
+
+  const tool = compactStatusText(activity.tool, 18);
+  const detail = activity.detail ? compactStatusText(activity.detail, 32) : '';
+  return detail ? `${tool}: ${detail}` : tool;
+}
+
+function findStatusActivity(sessions: SessionSummary[]): string | null {
+  const sessionWithActivity = sessions.find((session) => session.currentActivity);
+  return sessionWithActivity ? formatCurrentActivity(sessionWithActivity) : null;
+}
+
+export function deriveSessionFleetStatus(
+  displayState: DisplayState,
+  sessions: SessionSummary[]
+): SidebarFleetStatus {
+  const base = STATUS_LABELS[displayState];
+  const activity = findStatusActivity(sessions);
+  const shouldShowActivity =
+    activity &&
+    (displayState === 'running' ||
+      displayState === 'initializing' ||
+      displayState === 'seen-idle' ||
+      displayState === 'unseen-idle');
+  const label = shouldShowActivity ? `${base.label} · ${activity}` : base.label;
+  return {
+    ...base,
+    label,
+    title: `fleet status: ${label}`,
+  };
+}
+
 interface PrStatusBadgeProps {
   pr: PullRequest;
 }
@@ -186,10 +245,13 @@ function SessionGroupRow({
   onViewHistory,
   repoPath,
 }: SessionGroupRowProps) {
+  const fleetStatus = deriveSessionFleetStatus(dotState, groupSessions);
+
   return (
     <li
       className={[
         'session-row',
+        `state-${dotState}`,
         isSelected && 'selected',
         attention && 'attention',
       ]
@@ -217,6 +279,12 @@ function SessionGroupRow({
         {matchedPr ? <PrStatusBadge pr={matchedPr} /> : null}
       </div>
       <div className="session-row-secondary">
+        <span
+          className={`fleet-status tone-${fleetStatus.tone}`}
+          title={fleetStatus.title}
+        >
+          {fleetStatus.label}
+        </span>
         <span className="secondary-time">
           {formatRelativeTimeCompact(rep.lastActivity)}
         </span>
@@ -312,7 +380,12 @@ function InactiveRepoRow({
   const displayLabel = repoCurrentBranch || 'default';
   return (
     <li
-      className={['session-row', 'inactive', isLoading && 'loading']
+      className={[
+        'session-row',
+        'inactive',
+        isLoading ? 'state-initializing' : 'state-inactive',
+        isLoading && 'loading',
+      ]
         .filter(Boolean)
         .join(' ')}
       data-track="sidebar.repo.click"
@@ -327,6 +400,12 @@ function InactiveRepoRow({
         </span>
       </div>
       <div className="session-row-secondary">
+        <span
+          className={`fleet-status tone-${isLoading ? 'active' : 'inactive'}`}
+          title={`fleet status: ${isLoading ? 'starting' : 'inactive'}`}
+        >
+          {isLoading ? 'starting' : 'inactive'}
+        </span>
         {lastActivity ? (
           <span className="secondary-time">
             {formatRelativeTimeCompact(lastActivity)}
@@ -558,7 +637,12 @@ export function RepoItem({
             return (
               <li
                 key={wt.path}
-                className={['session-row', 'inactive', isLoading && 'loading']
+                className={[
+                  'session-row',
+                  'inactive',
+                  isLoading ? 'state-initializing' : 'state-inactive',
+                  isLoading && 'loading',
+                ]
                   .filter(Boolean)
                   .join(' ')}
                 data-track="sidebar.worktree.click"
@@ -579,6 +663,12 @@ export function RepoItem({
                   </span>
                 </div>
                 <div className="session-row-secondary">
+                  <span
+                    className={`fleet-status tone-${isLoading ? 'active' : 'inactive'}`}
+                    title={`fleet status: ${isLoading ? 'resuming' : 'inactive'}`}
+                  >
+                    {isLoading ? 'resuming' : 'inactive'}
+                  </span>
                   {wt.lastActivity ? (
                     <span className="secondary-time">
                       {formatRelativeTimeCompact(wt.lastActivity)}

--- a/test/sidebar-fleet-status.test.ts
+++ b/test/sidebar-fleet-status.test.ts
@@ -1,6 +1,12 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { deriveSessionFleetStatus } from '../frontend/src/components/RepoItem.js';
 import { makeSession } from './helpers/frontend-factories.js';
+
+const repoItemCss = readFileSync(
+  new URL('../frontend/src/components/RepoItem.css', import.meta.url),
+  'utf8'
+);
 
 const activeToolSession = makeSession({
   currentActivity: { tool: 'Bash', detail: 'npm run build' },
@@ -9,25 +15,31 @@ const activeToolSession = makeSession({
 describe('deriveSessionFleetStatus', () => {
   it('surfaces running current activity as a compact active status', () => {
     expect(deriveSessionFleetStatus('running', [activeToolSession])).toEqual({
-      label: 'running · bash: npm run build',
+      label: 'running · Bash: npm run build',
       tone: 'active',
-      title: 'fleet status: running · bash: npm run build',
+      title: 'fleet status: running · Bash: npm run build',
     });
   });
 
   it('uses explicit waiting labels for approval and answer states', () => {
-    expect(deriveSessionFleetStatus('permission', [activeToolSession])).toMatchObject({
+    expect(
+      deriveSessionFleetStatus('permission', [activeToolSession])
+    ).toMatchObject({
       label: 'approval needed',
       tone: 'attention',
     });
-    expect(deriveSessionFleetStatus('needs-answer', [activeToolSession])).toMatchObject({
+    expect(
+      deriveSessionFleetStatus('needs-answer', [activeToolSession])
+    ).toMatchObject({
       label: 'answer needed',
       tone: 'attention',
     });
   });
 
   it('keeps completed unread sessions attention-worthy', () => {
-    expect(deriveSessionFleetStatus('unseen-idle', [makeSession()])).toMatchObject({
+    expect(
+      deriveSessionFleetStatus('unseen-idle', [makeSession()])
+    ).toMatchObject({
       label: 'done unread',
       tone: 'attention',
     });
@@ -38,13 +50,26 @@ describe('deriveSessionFleetStatus', () => {
       makeSession({
         currentActivity: {
           tool: 'Very Long Tool Name That Should Be Cut Down',
-          detail: 'editing\nfrontend/src/components/RepoItem.tsx with extra trailing text',
+          detail:
+            'editing\nfrontend/src/components/RepoItem.tsx with extra trailing text',
         },
       }),
     ]);
 
     expect(status.label).toBe(
-      'running · very long tool na…: editing frontend/src/components…'
+      'running · Very Long Tool Na…: editing frontend/src/components…'
+    );
+  });
+
+  it('scopes attention row backgrounds away from selected rows', () => {
+    expect(repoItemCss).toMatch(
+      /\.session-row\.attention\.state-unseen-idle:not\(\.selected\)\s*\{\s*background:/
+    );
+    expect(repoItemCss).toMatch(
+      /\.session-row\.attention\.state-permission:not\(\.selected\),\s*\.session-row\.attention\.state-needs-answer:not\(\.selected\),\s*\.session-row\.attention\.state-error:not\(\.selected\)\s*\{\s*background:/
+    );
+    expect(repoItemCss).not.toMatch(
+      /\.session-row\.attention\.state-(?:unseen-idle|permission|needs-answer|error)(?!:not\(\.selected\))\s*(?:,|\{)/
     );
   });
 });

--- a/test/sidebar-fleet-status.test.ts
+++ b/test/sidebar-fleet-status.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { deriveSessionFleetStatus } from '../frontend/src/components/RepoItem.js';
+import { makeSession } from './helpers/frontend-factories.js';
+
+const activeToolSession = makeSession({
+  currentActivity: { tool: 'Bash', detail: 'npm run build' },
+});
+
+describe('deriveSessionFleetStatus', () => {
+  it('surfaces running current activity as a compact active status', () => {
+    expect(deriveSessionFleetStatus('running', [activeToolSession])).toEqual({
+      label: 'running · bash: npm run build',
+      tone: 'active',
+      title: 'fleet status: running · bash: npm run build',
+    });
+  });
+
+  it('uses explicit waiting labels for approval and answer states', () => {
+    expect(deriveSessionFleetStatus('permission', [activeToolSession])).toMatchObject({
+      label: 'approval needed',
+      tone: 'attention',
+    });
+    expect(deriveSessionFleetStatus('needs-answer', [activeToolSession])).toMatchObject({
+      label: 'answer needed',
+      tone: 'attention',
+    });
+  });
+
+  it('keeps completed unread sessions attention-worthy', () => {
+    expect(deriveSessionFleetStatus('unseen-idle', [makeSession()])).toMatchObject({
+      label: 'done unread',
+      tone: 'attention',
+    });
+  });
+
+  it('normalizes noisy activity details before showing them in the sidebar', () => {
+    const status = deriveSessionFleetStatus('running', [
+      makeSession({
+        currentActivity: {
+          tool: 'Very Long Tool Name That Should Be Cut Down',
+          detail: 'editing\nfrontend/src/components/RepoItem.tsx with extra trailing text',
+        },
+      }),
+    ]);
+
+    expect(status.label).toBe(
+      'running · very long tool na…: editing frontend/src/components…'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds compact fleet-status chips to sidebar session rows using existing display state and `currentActivity` data.
- Adds state-colored left rails for running, initializing, unread-done, approval/question, and error rows.
- Adds inactive/loading chips for repo-root and inactive worktree rows so active vs inactive/resuming states scan faster.
- Covers the status derivation helper with focused Vitest cases.

## Motivation
Relay already tracks display state, attention state, and current activity, but the left sidebar mostly exposed that as a small glyph plus recency. This narrow slice makes the sidebar answer “what is this agent doing, and does it need me?” without adding backend events or turning each row into a dashboard.

## The Case Against
This may be the wrong first slice if the desired fleet view is ultimately repo-level aggregation rather than per-row chips. The chip also competes for horizontal space in dense sidebars; long tool details are intentionally truncated, so this is a cue, not a full activity log. I did not add dirty/diverged branch health because that data is not already available in this component, and inventing a new backend substrate would violate the issue’s narrow-slice constraint.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
|------|------------|------------|
| Sidebar rows become too visually noisy | Medium | Uses lowercase monospace outline chips, 0px radius, existing semantic tokens, and compact truncation. |
| Mobile/dense rows lose useful branch text | Medium | The chip has a fixed max width and ellipsis; existing 44/48px row targets are preserved. |
| Activity text is misleading for attention states | Low | Approval/question/error labels take priority over activity detail. |
| State rail conflicts with selected row accent | Low | State rail only applies when the row is not selected. |

## Verification
- `npm test -- test/sidebar-fleet-status.test.ts test/group-display-name.test.ts`
- `npm test -- test/sidebar-fleet-status.test.ts test/group-display-name.test.ts test/attention.test.ts test/sidebar-items.test.ts`
- `npm run build`
- Manual design check against `DESIGN.md`: lowercase labels, monospace text, outline-only chip borders, no emoji, 0px radius, existing semantic colors only.

Closes #254
