### PR TITLE
fix: unblock hook-backed tmux startup state

### DIFF
--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -823,6 +823,18 @@ function isParserOverrideAllowed(
   return false;
 }
 
+function shouldAcceptStartupParserState(
+  session: PtySession,
+  newState: AgentState,
+  lastHook: number | undefined
+): boolean {
+  return (
+    !lastHook &&
+    session.agentState === 'initializing' &&
+    newState !== 'initializing'
+  );
+}
+
 function handleParserStateUpdate(
   session: PtySession,
   newState: AgentState,
@@ -830,7 +842,18 @@ function handleParserStateUpdate(
   fireBackendStateIfChanged: ((session: PtySession) => void) | undefined
 ): void {
   if (session.hooksActive) {
-    if (!isParserOverrideAllowed(session, session._lastHookTime)) return;
+    const lastHook = session._lastHookTime;
+    const allowStartupParserState = shouldAcceptStartupParserState(
+      session,
+      newState,
+      lastHook
+    );
+    if (
+      !allowStartupParserState &&
+      !isParserOverrideAllowed(session, lastHook)
+    ) {
+      return;
+    }
   }
   session.agentState = newState;
   for (const cb of stateChangeCallbacks) cb(session.id, newState);

--- a/test/pty-handler-multi-agent.test.ts
+++ b/test/pty-handler-multi-agent.test.ts
@@ -149,6 +149,60 @@ describe('PTY multi-agent hook/plugin wiring', () => {
     expect(session.dataQuality).toBe('parser');
   });
 
+  it('uses parser startup signal for hook-backed tmux sessions before hooks fire', async () => {
+    const agentStub = path.join(testHome, 'claude-stub.sh');
+    fs.writeFileSync(
+      agentStub,
+      `#!/bin/sh
+while [ "$1" = "--settings" ]; do
+  shift 2
+done
+printf 'How can I help you today?\\n>\\n'
+sleep 10
+`,
+      'utf-8'
+    );
+    fs.chmodSync(agentStub, 0o755);
+
+    const result = sessions.create({
+      repoName: 'test-repo',
+      repoPath: '/tmp',
+      worktreePath: null,
+      cwd: '/tmp',
+      agent: 'claude',
+      args: [],
+      port: 4568,
+      hookToken: 'claude-hook-token',
+      configDir: '/tmp',
+      frameworks: {
+        claude: {
+          command: agentStub,
+          eventSource: 'hooks',
+          parserType: 'claude',
+          capabilities: {
+            supportsHooks: true,
+            supportsContinue: true,
+            supportsYolo: true,
+            supportsTelemetry: true,
+            supportsAttachedRuntime: true,
+            supportsWebSessions: true,
+          },
+        },
+      },
+    });
+    createdIds.push(result.id);
+
+    await waitForScrollbackContains(result.id, 'How can I help');
+    await delay(100);
+
+    const session = sessions.get(result.id) as PtySession;
+    expect(session.hooksActive).toBe(true);
+    expect(session.dataQuality).toBe('hooks');
+    expect(session.agentState, session.scrollback.join('')).toBe(
+      'waiting-for-input'
+    );
+  });
+
   it('injects framework.yoloEnv for opencode in yolo mode', async () => {
     const result = sessions.create({
       repoName: 'test-repo',


### PR DESCRIPTION
## Summary
- Allows a hook-backed PTY session to accept the parser's first non-initializing startup state before any hook event has fired.
- Adds a tmux-backed regression test where a Claude-like stub accepts `--settings`, prints the ready prompt, and verifies the session leaves `initializing` while hooks remain active.

## Motivation
Tmux-backed agent sessions can stay pinned to `initializing` because hook-active sessions suppress parser state updates for the first 30 seconds. If no startup hook arrives at prompt readiness, the backend never emits the ready/idle transition even though tmux and the agent process are alive.

## The Case Against
This change intentionally lets the parser win once during hook-backed startup before hooks have produced any event. That could be wrong if parser startup detection is noisy and reports `waiting-for-input` while the agent is still actually booting. I kept the exception narrow: it only applies when there is no prior hook timestamp, the current state is still `initializing`, and the parser reports a non-`initializing` state. After a hook arrives, the existing 30-second stale-hook override rules remain unchanged.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
| --- | --- | --- |
| Parser emits a false ready state during startup | Low/medium | Limited to the pre-first-hook initializing window; hook events still regain authority once received. |
| Hook-backed sessions regress to parser-driven behavior | Low | Existing suppression remains for every state after the initial parser transition unless hook data goes stale. |
| Codex/parserless agents still need hook or timer coverage | Medium | This PR fixes the confirmed parser suppression path and does not pretend to replace Codex hook delivery; parserless startup remains dependent on hooks/timer follow-up. |

## Verification
- `npm test -- test/pty-handler-multi-agent.test.ts` — 5 passed
- `npm run build` — passed; existing Vite chunk/dynamic-import warnings only
- `npm run lint` — passed with existing warnings only

Closes #340
