### PR TITLE
feat: add branch divergence API

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,6 +197,7 @@ This makes workspace, tab, and pane customization (#263) viable without losing p
 | `POST`   | `/webhooks/manage/repos/remove` | Remove a repo from the webhook-managed set (body: `{path}`)                                                                           |
 | `POST`   | `/webhooks/manage/backfill`     | Auto-provision webhooks for all repos that don't have one                                                                             |
 | `GET`    | `/workspaces/changed-files`     | List changed files in a repo (`?path=X&base=ref`)                                                                                     |
+| `GET`    | `/workspaces/divergence`        | Branch divergence, line delta, dirty summary, base candidates, and capped side-specific commits (`?path=X&base=ref`)                  |
 | `GET`    | `/workspaces/file-diff`         | Get unified diff for a single file (`?path=X&file=Y&base=ref`)                                                                        |
 
 ## WebSocket Channels

--- a/server/git.ts
+++ b/server/git.ts
@@ -1250,7 +1250,7 @@ async function buildBranchDivergence(
   const selectedBaseRef = base ?? baseCandidates[0]?.ref;
   const currentBranch = await getSymbolicCurrentBranch(root, exec);
 
-  let headSha: string | null = null;
+  let headSha: string | null;
   try {
     headSha = await getHeadSha(root, exec);
   } catch (err) {

--- a/server/git.ts
+++ b/server/git.ts
@@ -809,7 +809,6 @@ async function getFileDiff(
   return stdout;
 }
 
-
 const DIVERGENCE_TIMEOUT_MS = 10_000;
 const DIVERGENCE_COMMITS_LIMIT = 20;
 const DIVERGENCE_DIRTY_FILES_LIMIT = 50;
@@ -909,11 +908,19 @@ function isSafeBaseRef(ref: string | undefined): ref is string {
   if (ref.includes('\0')) return false;
   if (ref.startsWith('-')) return false;
   if (ref === '@') return false;
-  if (ref.includes('..') || ref.includes('@{') || ref.includes('//')) return false;
+  if (ref.includes('..') || ref.includes('@{') || ref.includes('//'))
+    return false;
   if (ref.startsWith('/') || ref.endsWith('/')) return false;
   if (ref.endsWith('.') || ref.endsWith('.lock')) return false;
   if (hasInvalidBaseRefChar(ref)) return false;
-  if (ref.split('/').some((part) => part.length === 0 || part.startsWith('.') || part.endsWith('.lock'))) {
+  if (
+    ref
+      .split('/')
+      .some(
+        (part) =>
+          part.length === 0 || part.startsWith('.') || part.endsWith('.lock')
+      )
+  ) {
     return false;
   }
   return true;
@@ -939,8 +946,10 @@ async function tryResolveCommitRef(
 ): Promise<string | null> {
   try {
     return await resolveCommitRef(repoPath, ref, exec);
-  } catch {
-    return null;
+  } catch (err) {
+    if (isTimeoutError(err)) throw err;
+    if (isGitRefNotFoundError(err)) return null;
+    throw err;
   }
 }
 
@@ -971,7 +980,8 @@ async function getBaseCandidates(
       { cwd: repoPath, timeout: DIVERGENCE_TIMEOUT_MS }
     );
     remoteDefaultRef = stdout.trim() || null;
-  } catch {
+  } catch (err) {
+    if (isTimeoutError(err)) throw err;
     // Optional candidate only.
   }
 
@@ -1001,7 +1011,8 @@ async function getBaseCandidates(
         await tryResolveCommitRef(repoPath, upstream, exec)
       );
     }
-  } catch {
+  } catch (err) {
+    if (isTimeoutError(err)) throw err;
     // Branch may not have upstream.
   }
 
@@ -1022,7 +1033,11 @@ async function getBaseCandidates(
     );
   }
 
-  const localDefaultSha = await tryResolveCommitRef(repoPath, defaultBranch, exec);
+  const localDefaultSha = await tryResolveCommitRef(
+    repoPath,
+    defaultBranch,
+    exec
+  );
   if (localDefaultSha) {
     addBaseCandidate(
       candidates,
@@ -1079,17 +1094,25 @@ async function getSymbolicCurrentBranch(
   exec: ExecFileAsyncLike
 ): Promise<string | null> {
   try {
-    const { stdout } = await exec('git', ['symbolic-ref', '--quiet', '--short', 'HEAD'], {
-      cwd: repoPath,
-      timeout: DIVERGENCE_TIMEOUT_MS,
-    });
+    const { stdout } = await exec(
+      'git',
+      ['symbolic-ref', '--quiet', '--short', 'HEAD'],
+      {
+        cwd: repoPath,
+        timeout: DIVERGENCE_TIMEOUT_MS,
+      }
+    );
     return stdout.trim() || null;
-  } catch {
+  } catch (err) {
+    if (isTimeoutError(err)) throw err;
     return null;
   }
 }
 
-function parseRevListCounts(stdout: string): { behindCount: number; aheadCount: number } {
+function parseRevListCounts(stdout: string): {
+  behindCount: number;
+  aheadCount: number;
+} {
   const [behindRaw, aheadRaw] = stdout.trim().split(/\s+/);
   const behindCount = parseInt(behindRaw ?? '0', 10);
   const aheadCount = parseInt(aheadRaw ?? '0', 10);
@@ -1365,13 +1388,10 @@ async function getBranchDivergence(
         error: 'git command timed out',
       });
     }
-    logger.warn(
-      '[git] branch divergence failed for',
-      repoPath,
-      errorText(err)
-    );
-    return emptyDivergenceSummary(repoPath, 'not_git', {
+    logger.warn('[git] branch divergence failed for', repoPath, errorText(err));
+    return emptyDivergenceSummary(repoPath, 'git_error', {
       error: errorText(err) || 'Failed to compute branch divergence',
+      warnings: ['git divergence failed inside repository'],
     });
   }
 }
@@ -1390,7 +1410,8 @@ async function getDefaultBranch(
     const ref = stdout.trim();
     const prefix = 'refs/remotes/origin/';
     if (ref.startsWith(prefix)) return ref.slice(prefix.length);
-  } catch {
+  } catch (err) {
+    if (isTimeoutError(err)) throw err;
     // Not set — fall through to heuristic
   }
 
@@ -1402,7 +1423,8 @@ async function getDefaultBranch(
         timeout: 5000,
       });
       return candidate;
-    } catch {
+    } catch (err) {
+      if (isTimeoutError(err)) throw err;
       // Not found — try next
     }
   }

--- a/server/git.ts
+++ b/server/git.ts
@@ -3,9 +3,17 @@ import { promisify } from 'node:util';
 
 import type {
   ActivityEntry,
+  BranchBaseCandidate,
+  BranchBaseCandidateSource,
+  BranchDivergenceCommit,
+  BranchDivergenceState,
+  BranchDivergenceSummary,
+  BranchLineDelta,
   BranchInfo,
   BranchLifecycleState,
   ChangedFile,
+  DirtyFileStatus,
+  DirtySummary,
   FileChangeStatus,
   PrInfo,
 } from './types.js';
@@ -801,6 +809,555 @@ async function getFileDiff(
   return stdout;
 }
 
+
+const DIVERGENCE_TIMEOUT_MS = 10_000;
+const DIVERGENCE_COMMITS_LIMIT = 20;
+const DIVERGENCE_DIRTY_FILES_LIMIT = 50;
+const ZERO_LINE_DELTA: BranchLineDelta = {
+  additions: 0,
+  deletions: 0,
+  fileCount: 0,
+};
+
+const CLEAN_DIRTY_SUMMARY: DirtySummary = {
+  stagedCount: 0,
+  unstagedCount: 0,
+  untrackedCount: 0,
+  conflictedCount: 0,
+  files: [],
+  truncated: false,
+};
+
+const UNMERGED_STATUS_CODES = new Set([
+  'DD',
+  'AU',
+  'UD',
+  'UA',
+  'DU',
+  'AA',
+  'UU',
+]);
+
+function emptyDivergenceSummary(
+  repoPath: string,
+  state: BranchDivergenceState,
+  details: {
+    error?: string;
+    warnings?: string[];
+    currentBranch?: string | null;
+    headSha?: string | null;
+    selectedBase?: { ref: string; sha: string | null } | null;
+    baseCandidates?: BranchBaseCandidate[];
+    dirty?: DirtySummary;
+  } = {}
+): BranchDivergenceSummary {
+  return {
+    repoPath,
+    currentBranch: details.currentBranch ?? null,
+    headSha: details.headSha ?? null,
+    selectedBase: details.selectedBase ?? null,
+    baseCandidates: details.baseCandidates ?? [],
+    aheadCount: 0,
+    behindCount: 0,
+    lineDelta: { ...ZERO_LINE_DELTA },
+    dirty: details.dirty ?? { ...CLEAN_DIRTY_SUMMARY, files: [] },
+    commits: { ahead: [], behind: [] },
+    state,
+    ...(details.error ? { error: details.error } : {}),
+    warnings: details.warnings ?? [],
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+function errorText(error: unknown): string {
+  if (!error || typeof error !== 'object') return UNKNOWN_ERROR;
+  const err = error as { stderr?: string; stdout?: string; message?: string };
+  return (err.stderr ?? err.stdout ?? err.message ?? UNKNOWN_ERROR).trim();
+}
+
+function isTimeoutError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const err = error as {
+    code?: string | number;
+    signal?: string;
+    killed?: boolean;
+    message?: string;
+  };
+  const message = err.message ?? '';
+  return (
+    err.code === 'ETIMEDOUT' ||
+    err.signal === 'SIGTERM' ||
+    err.killed === true ||
+    message.includes('timed out') ||
+    message.includes('timeout')
+  );
+}
+
+function isSafeBaseRef(ref: string | undefined): ref is string {
+  if (typeof ref !== 'string') return false;
+  if (ref.trim() !== ref || ref.length === 0) return false;
+  if (ref.includes('\0')) return false;
+  if (ref.startsWith('-')) return false;
+  return true;
+}
+
+async function resolveCommitRef(
+  repoPath: string,
+  ref: string,
+  exec: ExecFileAsyncLike
+): Promise<string | null> {
+  const { stdout } = await exec(
+    'git',
+    ['rev-parse', '--verify', '--end-of-options', `${ref}^{commit}`],
+    { cwd: repoPath, timeout: DIVERGENCE_TIMEOUT_MS }
+  );
+  return stdout.trim() || null;
+}
+
+async function tryResolveCommitRef(
+  repoPath: string,
+  ref: string,
+  exec: ExecFileAsyncLike
+): Promise<string | null> {
+  try {
+    return await resolveCommitRef(repoPath, ref, exec);
+  } catch {
+    return null;
+  }
+}
+
+function addBaseCandidate(
+  candidates: BranchBaseCandidate[],
+  seen: Set<string>,
+  ref: string,
+  source: BranchBaseCandidateSource,
+  sha: string | null
+): void {
+  if (!ref || seen.has(ref)) return;
+  seen.add(ref);
+  candidates.push({ ref, label: ref, source, sha });
+}
+
+async function getBaseCandidates(
+  repoPath: string,
+  exec: ExecFileAsyncLike
+): Promise<BranchBaseCandidate[]> {
+  const candidates: BranchBaseCandidate[] = [];
+  const seen = new Set<string>();
+
+  let remoteDefaultRef: string | null = null;
+  try {
+    const { stdout } = await exec(
+      'git',
+      ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
+      { cwd: repoPath, timeout: DIVERGENCE_TIMEOUT_MS }
+    );
+    remoteDefaultRef = stdout.trim() || null;
+  } catch {
+    // Optional candidate only.
+  }
+
+  if (remoteDefaultRef) {
+    addBaseCandidate(
+      candidates,
+      seen,
+      remoteDefaultRef,
+      'remoteDefault',
+      await tryResolveCommitRef(repoPath, remoteDefaultRef, exec)
+    );
+  }
+
+  try {
+    const { stdout } = await exec(
+      'git',
+      ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'],
+      { cwd: repoPath, timeout: DIVERGENCE_TIMEOUT_MS }
+    );
+    const upstream = stdout.trim();
+    if (upstream) {
+      addBaseCandidate(
+        candidates,
+        seen,
+        upstream,
+        'upstream',
+        await tryResolveCommitRef(repoPath, upstream, exec)
+      );
+    }
+  } catch {
+    // Branch may not have upstream.
+  }
+
+  const defaultBranch = await getDefaultBranch(repoPath, exec);
+  const remoteDefaultBranch = `origin/${defaultBranch}`;
+  const remoteDefaultSha = await tryResolveCommitRef(
+    repoPath,
+    remoteDefaultBranch,
+    exec
+  );
+  if (remoteDefaultSha) {
+    addBaseCandidate(
+      candidates,
+      seen,
+      remoteDefaultBranch,
+      remoteDefaultRef ? 'remote' : 'remoteDefault',
+      remoteDefaultSha
+    );
+  }
+
+  const localDefaultSha = await tryResolveCommitRef(repoPath, defaultBranch, exec);
+  if (localDefaultSha) {
+    addBaseCandidate(
+      candidates,
+      seen,
+      defaultBranch,
+      'default',
+      localDefaultSha
+    );
+  }
+
+  for (const local of ['nightly', 'main', 'master']) {
+    const sha = await tryResolveCommitRef(repoPath, local, exec);
+    if (sha) addBaseCandidate(candidates, seen, local, 'local', sha);
+  }
+
+  for (const remote of ['origin/nightly', 'origin/main', 'origin/master']) {
+    const sha = await tryResolveCommitRef(repoPath, remote, exec);
+    if (sha) addBaseCandidate(candidates, seen, remote, 'remote', sha);
+  }
+
+  return candidates;
+}
+
+async function getRepoRootOrNull(
+  repoPath: string,
+  exec: ExecFileAsyncLike
+): Promise<string | null> {
+  try {
+    const { stdout } = await exec('git', ['rev-parse', '--show-toplevel'], {
+      cwd: repoPath,
+      timeout: DIVERGENCE_TIMEOUT_MS,
+    });
+    return stdout.trim() || repoPath;
+  } catch (err) {
+    if (isTimeoutError(err)) throw err;
+    return null;
+  }
+}
+
+async function getHeadSha(
+  repoPath: string,
+  exec: ExecFileAsyncLike
+): Promise<string | null> {
+  const { stdout } = await exec(
+    'git',
+    ['rev-parse', '--verify', '--end-of-options', 'HEAD^{commit}'],
+    { cwd: repoPath, timeout: DIVERGENCE_TIMEOUT_MS }
+  );
+  return stdout.trim() || null;
+}
+
+async function getSymbolicCurrentBranch(
+  repoPath: string,
+  exec: ExecFileAsyncLike
+): Promise<string | null> {
+  try {
+    const { stdout } = await exec('git', ['symbolic-ref', '--quiet', '--short', 'HEAD'], {
+      cwd: repoPath,
+      timeout: DIVERGENCE_TIMEOUT_MS,
+    });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function parseRevListCounts(stdout: string): { behindCount: number; aheadCount: number } {
+  const [behindRaw, aheadRaw] = stdout.trim().split(/\s+/);
+  const behindCount = parseInt(behindRaw ?? '0', 10);
+  const aheadCount = parseInt(aheadRaw ?? '0', 10);
+  return {
+    behindCount: Number.isFinite(behindCount) ? behindCount : 0,
+    aheadCount: Number.isFinite(aheadCount) ? aheadCount : 0,
+  };
+}
+
+async function getAheadBehindCounts(
+  repoPath: string,
+  base: string,
+  exec: ExecFileAsyncLike
+): Promise<{ behindCount: number; aheadCount: number }> {
+  const { stdout } = await exec(
+    'git',
+    ['rev-list', '--left-right', '--count', `${base}...HEAD`],
+    { cwd: repoPath, timeout: DIVERGENCE_TIMEOUT_MS }
+  );
+  return parseRevListCounts(stdout);
+}
+
+async function hasMergeBase(
+  repoPath: string,
+  base: string,
+  exec: ExecFileAsyncLike
+): Promise<boolean> {
+  try {
+    await exec('git', ['merge-base', '--', base, 'HEAD'], {
+      cwd: repoPath,
+      timeout: DIVERGENCE_TIMEOUT_MS,
+    });
+    return true;
+  } catch (err) {
+    if (isTimeoutError(err)) throw err;
+    return false;
+  }
+}
+
+async function getLineDelta(
+  repoPath: string,
+  base: string,
+  exec: ExecFileAsyncLike
+): Promise<BranchLineDelta> {
+  const { stdout } = await exec(
+    'git',
+    ['diff', '--numstat', FIND_RENAMES, `${base}...HEAD`],
+    { cwd: repoPath, timeout: DIVERGENCE_TIMEOUT_MS }
+  );
+
+  const delta: BranchLineDelta = { ...ZERO_LINE_DELTA };
+  for (const line of stdout.split('\n').filter(Boolean)) {
+    const [add, del] = line.split(TAB);
+    delta.fileCount += 1;
+    delta.additions += add === '-' ? 0 : parseInt(add ?? '0', 10) || 0;
+    delta.deletions += del === '-' ? 0 : parseInt(del ?? '0', 10) || 0;
+  }
+  return delta;
+}
+
+function dirtyStatusForCode(code: string): DirtyFileStatus {
+  const x = code[0] ?? ' ';
+  const y = code[1] ?? ' ';
+  if (code === '??') return 'untracked';
+  if (UNMERGED_STATUS_CODES.has(code)) return 'conflicted';
+  if (x === 'R' || y === 'R') return 'renamed';
+  if (x === 'D' || y === 'D') return 'deleted';
+  if (x === 'A' || y === 'A') return 'added';
+  return 'modified';
+}
+
+function parseDirtySummary(stdout: string): DirtySummary {
+  const parts = stdout.split('\0').filter(Boolean);
+  const dirty: DirtySummary = { ...CLEAN_DIRTY_SUMMARY, files: [] };
+
+  for (let i = 0; i < parts.length; i++) {
+    const entry = parts[i]!;
+    const code = entry.slice(0, 2);
+    const x = code[0] ?? ' ';
+    const y = code[1] ?? ' ';
+    const isUntracked = code === '??';
+    const isConflicted = UNMERGED_STATUS_CODES.has(code);
+    const isRename = x === 'R' || y === 'R';
+    const staged = !isUntracked && !isConflicted && x !== ' ';
+    const unstaged = !isUntracked && !isConflicted && y !== ' ';
+    const filePath = entry.slice(3);
+    let oldPath: string | undefined;
+
+    if (isRename) {
+      oldPath = parts[++i] ?? undefined;
+    }
+
+    if (isUntracked) dirty.untrackedCount += 1;
+    if (isConflicted) dirty.conflictedCount += 1;
+    if (staged) dirty.stagedCount += 1;
+    if (unstaged) dirty.unstagedCount += 1;
+
+    if (dirty.files.length < DIVERGENCE_DIRTY_FILES_LIMIT) {
+      dirty.files.push({
+        path: filePath,
+        ...(oldPath ? { oldPath } : {}),
+        status: dirtyStatusForCode(code),
+        staged,
+        unstaged,
+      });
+    } else {
+      dirty.truncated = true;
+    }
+  }
+
+  return dirty;
+}
+
+async function getDirtySummary(
+  repoPath: string,
+  exec: ExecFileAsyncLike
+): Promise<DirtySummary> {
+  const { stdout } = await exec('git', ['status', '--porcelain=v1', '-z'], {
+    cwd: repoPath,
+    timeout: DIVERGENCE_TIMEOUT_MS,
+  });
+  return parseDirtySummary(stdout);
+}
+
+function parseDivergenceCommits(stdout: string): BranchDivergenceCommit[] {
+  return stdout
+    .split('\x1e')
+    .map((record) => record.trim())
+    .filter(Boolean)
+    .map((record) => {
+      const [hash = '', shortHash = '', subject = '', author = '', date = ''] =
+        record.split('\x1f');
+      return { hash, shortHash, subject, author, date };
+    })
+    .filter((commit) => commit.hash && commit.shortHash);
+}
+
+async function getDivergenceCommits(
+  repoPath: string,
+  range: string,
+  exec: ExecFileAsyncLike,
+  limit = DIVERGENCE_COMMITS_LIMIT
+): Promise<BranchDivergenceCommit[]> {
+  const { stdout } = await exec(
+    'git',
+    [
+      'log',
+      `--max-count=${limit}`,
+      '--format=%H%x1f%h%x1f%s%x1f%an%x1f%aI%x1e',
+      range,
+    ],
+    { cwd: repoPath, timeout: DIVERGENCE_TIMEOUT_MS }
+  );
+  return parseDivergenceCommits(stdout);
+}
+
+async function buildBranchDivergence(
+  repoPath: string,
+  base: string | undefined,
+  exec: ExecFileAsyncLike
+): Promise<BranchDivergenceSummary> {
+  if (base !== undefined && !isSafeBaseRef(base)) {
+    return emptyDivergenceSummary(repoPath, 'invalid_base', {
+      error: 'invalid base ref',
+    });
+  }
+
+  const root = await getRepoRootOrNull(repoPath, exec);
+  if (!root) {
+    return emptyDivergenceSummary(repoPath, 'not_git', {
+      error: 'not a git repository',
+    });
+  }
+
+  const baseCandidates = await getBaseCandidates(root, exec);
+  const selectedBaseRef = base ?? baseCandidates[0]?.ref;
+  const currentBranch = await getSymbolicCurrentBranch(root, exec);
+
+  let headSha: string | null = null;
+  try {
+    headSha = await getHeadSha(root, exec);
+  } catch (err) {
+    if (isTimeoutError(err)) throw err;
+    return emptyDivergenceSummary(root, 'unborn', {
+      error: 'HEAD does not point to a commit',
+      currentBranch,
+      baseCandidates,
+    });
+  }
+
+  const dirty = await getDirtySummary(root, exec);
+
+  if (!selectedBaseRef) {
+    return emptyDivergenceSummary(root, 'missing_base', {
+      error: 'base ref not found',
+      currentBranch,
+      headSha,
+      baseCandidates,
+      dirty,
+    });
+  }
+
+  let selectedBaseSha: string | null;
+  try {
+    selectedBaseSha = await resolveCommitRef(root, selectedBaseRef, exec);
+  } catch (err) {
+    if (isTimeoutError(err)) throw err;
+    return emptyDivergenceSummary(root, 'missing_base', {
+      error: `base ref not found: ${selectedBaseRef}`,
+      currentBranch,
+      headSha,
+      baseCandidates,
+      selectedBase: { ref: selectedBaseRef, sha: null },
+      dirty,
+    });
+  }
+
+  if (!(await hasMergeBase(root, selectedBaseRef, exec))) {
+    return emptyDivergenceSummary(root, 'no_merge_base', {
+      error: `no merge base with ${selectedBaseRef}`,
+      currentBranch,
+      headSha,
+      baseCandidates,
+      selectedBase: { ref: selectedBaseRef, sha: selectedBaseSha },
+      dirty,
+    });
+  }
+
+  const { aheadCount, behindCount } = await getAheadBehindCounts(
+    root,
+    selectedBaseRef,
+    exec
+  );
+  const lineDelta = await getLineDelta(root, selectedBaseRef, exec);
+  const [ahead, behind] = await Promise.all([
+    getDivergenceCommits(root, `${selectedBaseRef}..HEAD`, exec),
+    getDivergenceCommits(root, `HEAD..${selectedBaseRef}`, exec),
+  ]);
+  const warnings = currentBranch ? [] : ['HEAD is detached'];
+  const state: BranchDivergenceState = currentBranch ? 'ok' : 'detached';
+
+  return {
+    repoPath: root,
+    currentBranch,
+    headSha,
+    selectedBase: { ref: selectedBaseRef, sha: selectedBaseSha },
+    baseCandidates,
+    aheadCount,
+    behindCount,
+    lineDelta,
+    dirty,
+    commits: { ahead, behind },
+    state,
+    warnings,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+async function getBranchDivergence(
+  repoPath: string,
+  options: {
+    base?: string;
+    exec?: ExecFileAsyncLike;
+  } = {}
+): Promise<BranchDivergenceSummary> {
+  const run: ExecFileAsyncLike =
+    options.exec || (execFileAsync as ExecFileAsyncLike);
+  try {
+    return await buildBranchDivergence(repoPath, options.base, run);
+  } catch (err) {
+    if (isTimeoutError(err)) {
+      return emptyDivergenceSummary(repoPath, 'timeout', {
+        error: 'git command timed out',
+      });
+    }
+    logger.warn(
+      '[git] branch divergence failed for',
+      repoPath,
+      errorText(err)
+    );
+    return emptyDivergenceSummary(repoPath, 'not_git', {
+      error: errorText(err) || 'Failed to compute branch divergence',
+    });
+  }
+}
+
 async function getDefaultBranch(
   repoPath: string,
   exec: ExecFileAsyncLike = execFileAsync as ExecFileAsyncLike
@@ -961,6 +1518,7 @@ export {
   pushBranch,
   getChangedFiles,
   getFileDiff,
+  getBranchDivergence,
   getDefaultBranch,
   ensureBranchLocal,
   isPrMerged,

--- a/server/git.ts
+++ b/server/git.ts
@@ -892,6 +892,20 @@ function isTimeoutError(error: unknown): boolean {
   );
 }
 
+function isNotGitRepositoryError(error: unknown): boolean {
+  const text = errorText(error).toLowerCase();
+  return (
+    text.includes('not a git repository') ||
+    text.includes('not a gitdir')
+  );
+}
+
+function isNoMergeBaseError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const err = error as { code?: string | number };
+  return err.code === 1 && errorText(error) === '';
+}
+
 function hasInvalidBaseRefChar(ref: string): boolean {
   for (const char of ref) {
     const code = char.charCodeAt(0);
@@ -1073,7 +1087,8 @@ async function getRepoRootOrNull(
     return stdout.trim() || repoPath;
   } catch (err) {
     if (isTimeoutError(err)) throw err;
-    return null;
+    if (isNotGitRepositoryError(err)) return null;
+    throw err;
   }
 }
 
@@ -1148,7 +1163,8 @@ async function hasMergeBase(
     return true;
   } catch (err) {
     if (isTimeoutError(err)) throw err;
-    return false;
+    if (isNoMergeBaseError(err)) return false;
+    throw err;
   }
 }
 

--- a/server/git.ts
+++ b/server/git.ts
@@ -893,11 +893,29 @@ function isTimeoutError(error: unknown): boolean {
   );
 }
 
+function hasInvalidBaseRefChar(ref: string): boolean {
+  for (const char of ref) {
+    const code = char.charCodeAt(0);
+    if (code <= 32 || code === 127 || '~^:?*[\\'.includes(char)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function isSafeBaseRef(ref: string | undefined): ref is string {
   if (typeof ref !== 'string') return false;
   if (ref.trim() !== ref || ref.length === 0) return false;
   if (ref.includes('\0')) return false;
   if (ref.startsWith('-')) return false;
+  if (ref === '@') return false;
+  if (ref.includes('..') || ref.includes('@{') || ref.includes('//')) return false;
+  if (ref.startsWith('/') || ref.endsWith('/')) return false;
+  if (ref.endsWith('.') || ref.endsWith('.lock')) return false;
+  if (hasInvalidBaseRefChar(ref)) return false;
+  if (ref.split('/').some((part) => part.length === 0 || part.startsWith('.') || part.endsWith('.lock'))) {
+    return false;
+  }
   return true;
 }
 

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -607,6 +607,7 @@ function setupEnvAndHooks(
         'TMPDIR',
         'TEMP',
         'TMP',
+        'TMUX_TMPDIR',
         'LANG',
         'LC_ALL',
         'USER',

--- a/server/types.ts
+++ b/server/types.ts
@@ -752,7 +752,6 @@ export interface FileDiffResponse {
   error?: string;
 }
 
-
 export type BranchDivergenceState =
   | 'ok'
   | 'not_git'
@@ -761,7 +760,8 @@ export type BranchDivergenceState =
   | 'detached'
   | 'unborn'
   | 'no_merge_base'
-  | 'timeout';
+  | 'timeout'
+  | 'git_error';
 
 export type BranchBaseCandidateSource =
   | 'remoteDefault'

--- a/server/types.ts
+++ b/server/types.ts
@@ -752,6 +752,93 @@ export interface FileDiffResponse {
   error?: string;
 }
 
+
+export type BranchDivergenceState =
+  | 'ok'
+  | 'not_git'
+  | 'invalid_base'
+  | 'missing_base'
+  | 'detached'
+  | 'unborn'
+  | 'no_merge_base'
+  | 'timeout';
+
+export type BranchBaseCandidateSource =
+  | 'remoteDefault'
+  | 'default'
+  | 'upstream'
+  | 'local'
+  | 'remote';
+
+export interface BranchBaseRef {
+  ref: string;
+  sha: string | null;
+}
+
+export interface BranchBaseCandidate extends BranchBaseRef {
+  label: string;
+  source: BranchBaseCandidateSource;
+}
+
+export interface BranchLineDelta {
+  additions: number;
+  deletions: number;
+  fileCount: number;
+}
+
+export type DirtyFileStatus =
+  | 'added'
+  | 'modified'
+  | 'deleted'
+  | 'renamed'
+  | 'untracked'
+  | 'conflicted';
+
+export interface DirtyFileSummary {
+  path: string;
+  oldPath?: string;
+  status: DirtyFileStatus;
+  staged: boolean;
+  unstaged: boolean;
+}
+
+export interface DirtySummary {
+  stagedCount: number;
+  unstagedCount: number;
+  untrackedCount: number;
+  conflictedCount: number;
+  files: DirtyFileSummary[];
+  truncated: boolean;
+}
+
+export interface BranchDivergenceCommit {
+  hash: string;
+  shortHash: string;
+  subject: string;
+  author: string;
+  date: string;
+}
+
+export interface BranchDivergenceSummary {
+  repoPath: string;
+  currentBranch: string | null;
+  headSha: string | null;
+  selectedBase: BranchBaseRef | null;
+  baseCandidates: BranchBaseCandidate[];
+  aheadCount: number;
+  behindCount: number;
+  lineDelta: BranchLineDelta;
+  dirty: DirtySummary;
+  commits: {
+    ahead: BranchDivergenceCommit[];
+    behind: BranchDivergenceCommit[];
+  };
+  state: BranchDivergenceState;
+  error?: string;
+  warnings: string[];
+  generatedAt: string;
+}
+
 // ── Session Analytics ──
 
 export interface SessionEvent {

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -35,6 +35,7 @@ import {
   pushBranch,
   getChangedFiles,
   getFileDiff,
+  getBranchDivergence,
   getDefaultBranch,
   ensureBranchLocal,
 } from './git.js';
@@ -1425,6 +1426,75 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
       ? resolved
       : null;
   }
+
+
+  // GET /workspaces/divergence — display-ready branch divergence summary
+  router.get('/divergence', async (req: Request, res: Response) => {
+    if (typeof req.query.path !== 'string') {
+      res.status(400).json({
+        repoPath: '',
+        currentBranch: null,
+        headSha: null,
+        selectedBase: null,
+        baseCandidates: [],
+        aheadCount: 0,
+        behindCount: 0,
+        lineDelta: { additions: 0, deletions: 0, fileCount: 0 },
+        dirty: {
+          stagedCount: 0,
+          unstagedCount: 0,
+          untrackedCount: 0,
+          conflictedCount: 0,
+          files: [],
+          truncated: false,
+        },
+        commits: { ahead: [], behind: [] },
+        state: 'not_git',
+        error: 'path parameter required',
+        warnings: [],
+        generatedAt: new Date().toISOString(),
+      });
+      return;
+    }
+
+    const resolvedRepo = validateWorkspaceAccess(req.query.path);
+    if (!resolvedRepo) {
+      res.status(403).json({
+        repoPath: path.resolve(req.query.path),
+        currentBranch: null,
+        headSha: null,
+        selectedBase: null,
+        baseCandidates: [],
+        aheadCount: 0,
+        behindCount: 0,
+        lineDelta: { additions: 0, deletions: 0, fileCount: 0 },
+        dirty: {
+          stagedCount: 0,
+          unstagedCount: 0,
+          untrackedCount: 0,
+          conflictedCount: 0,
+          files: [],
+          truncated: false,
+        },
+        commits: { ahead: [], behind: [] },
+        state: 'not_git',
+        error: ERR_PATH_NOT_IN_WORKSPACES,
+        warnings: [],
+        generatedAt: new Date().toISOString(),
+      });
+      return;
+    }
+
+    const base =
+      typeof req.query.base === 'string' ? req.query.base : undefined;
+    const options = base === undefined ? { exec } : { base, exec };
+    const summary = await getBranchDivergence(resolvedRepo, options);
+    if (summary.state === 'invalid_base') {
+      res.status(400).json(summary);
+      return;
+    }
+    res.json(summary);
+  });
 
   // GET /workspaces/changed-files — list changed files in a repo
   router.get('/changed-files', async (req: Request, res: Response) => {

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -1417,13 +1417,35 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
     }
   });
 
+  function realpathOrNull(candidate: string): string | null {
+    try {
+      return fs.realpathSync.native(path.resolve(candidate));
+    } catch {
+      return null;
+    }
+  }
+
+  function isPathInside(child: string, parent: string): boolean {
+    const relative = path.relative(parent, child);
+    return (
+      relative === '' ||
+      (relative !== '' &&
+        !relative.startsWith('..') &&
+        !path.isAbsolute(relative))
+    );
+  }
+
   function validateWorkspaceAccess(repoPath: string): string | null {
     const resolved = path.resolve(repoPath);
+    const realResolved = realpathOrNull(resolved);
+    if (!realResolved) return null;
+
     const allowed = getConfig().repos ?? [];
-    return allowed.some(
-      (p) => resolved === p || resolved.startsWith(p + path.sep)
-    )
-      ? resolved
+    return allowed.some((p) => {
+      const allowedReal = realpathOrNull(p);
+      return allowedReal ? isPathInside(realResolved, allowedReal) : false;
+    })
+      ? realResolved
       : null;
   }
 

--- a/test/git-divergence.test.ts
+++ b/test/git-divergence.test.ts
@@ -1,0 +1,179 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getBranchDivergence } from '../server/git.js';
+
+const execFileAsync = promisify(execFile);
+
+let tmpDir: string;
+let repoPath: string;
+
+async function git(args: string[], cwd = repoPath): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd, timeout: 10_000 });
+  return stdout;
+}
+
+function write(relPath: string, content: string): void {
+  const abs = path.join(repoPath, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, 'utf8');
+}
+
+async function commit(message: string): Promise<string> {
+  await git(['add', '-A']);
+  await git(['commit', '-m', message]);
+  return (await git(['rev-parse', 'HEAD'])).trim();
+}
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-git-divergence-'));
+  repoPath = path.join(tmpDir, 'repo');
+  fs.mkdirSync(repoPath, { recursive: true });
+  await git(['init', '--initial-branch=main']);
+  await git(['config', 'user.name', 'Relay Test']);
+  await git(['config', 'user.email', 'relay@example.test']);
+  write('base.txt', 'base\n');
+  await commit('initial commit');
+});
+
+// Keep tmp repos on failure? nope, this suite makes a ton of them. nuke it.
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('getBranchDivergence', () => {
+  it('reports a clean branch against the selected base without faking dirty state', async () => {
+    const summary = await getBranchDivergence(repoPath, { base: 'main' });
+
+    expect(summary.state).toBe('ok');
+    expect(summary.currentBranch).toBe('main');
+    expect(summary.selectedBase).toMatchObject({ ref: 'main' });
+    expect(summary.aheadCount).toBe(0);
+    expect(summary.behindCount).toBe(0);
+    expect(summary.lineDelta).toEqual({ additions: 0, deletions: 0, fileCount: 0 });
+    expect(summary.dirty).toMatchObject({
+      stagedCount: 0,
+      unstagedCount: 0,
+      untrackedCount: 0,
+      conflictedCount: 0,
+      files: [],
+    });
+    expect(summary.error).toBeUndefined();
+  });
+
+  it('uses side-specific ranges for ahead-only, behind-only, and diverged commit lists', async () => {
+    await git(['checkout', '-b', 'feature']);
+    write('feature.txt', 'feature\n');
+    await commit('feature commit');
+
+    let summary = await getBranchDivergence(repoPath, { base: 'main' });
+    expect(summary.state).toBe('ok');
+    expect(summary.aheadCount).toBe(1);
+    expect(summary.behindCount).toBe(0);
+    expect(summary.commits.ahead.map((c) => c.subject)).toEqual(['feature commit']);
+    expect(summary.commits.behind).toEqual([]);
+    expect(summary.lineDelta).toEqual({ additions: 1, deletions: 0, fileCount: 1 });
+
+    await git(['checkout', 'main']);
+    write('main.txt', 'main\n');
+    await commit('main commit');
+    await git(['checkout', 'feature']);
+
+    summary = await getBranchDivergence(repoPath, { base: 'main' });
+    expect(summary.state).toBe('ok');
+    expect(summary.aheadCount).toBe(1);
+    expect(summary.behindCount).toBe(1);
+    expect(summary.commits.ahead.map((c) => c.subject)).toEqual(['feature commit']);
+    expect(summary.commits.behind.map((c) => c.subject)).toEqual(['main commit']);
+  });
+
+  it('keeps binary numstat values numeric instead of returning NaN', async () => {
+    await git(['checkout', '-b', 'feature']);
+    fs.writeFileSync(path.join(repoPath, 'binary.dat'), Buffer.from([0, 1, 2, 3, 4]));
+    await commit('add binary');
+
+    const summary = await getBranchDivergence(repoPath, { base: 'main' });
+
+    expect(summary.state).toBe('ok');
+    expect(summary.lineDelta.fileCount).toBe(1);
+    expect(Number.isNaN(summary.lineDelta.additions)).toBe(false);
+    expect(Number.isNaN(summary.lineDelta.deletions)).toBe(false);
+  });
+
+  it('distinguishes staged, unstaged, untracked, deleted, renamed, and conflicted dirty files', async () => {
+    write('staged.txt', 'one\n');
+    write('unstaged.txt', 'one\n');
+    write('deleted.txt', 'one\n');
+    write('oldname.txt', 'one\n');
+    write('conflict.txt', 'base\n');
+    await commit('add dirty fixtures');
+
+    await git(['checkout', '-b', 'side']);
+    write('conflict.txt', 'side\n');
+    await commit('side conflict');
+    await git(['checkout', 'main']);
+    write('conflict.txt', 'main\n');
+    await commit('main conflict');
+    try {
+      await git(['merge', 'side']);
+    } catch {
+      // Expected: leave the repo in an unresolved conflict state for porcelain parsing.
+    }
+
+    write('staged.txt', 'one\nstaged\n');
+    await git(['add', 'staged.txt']);
+    write('unstaged.txt', 'one\nunstaged\n');
+    fs.unlinkSync(path.join(repoPath, 'deleted.txt'));
+    await git(['mv', 'oldname.txt', 'renamed.txt']);
+    write('untracked.txt', 'new\n');
+
+    const summary = await getBranchDivergence(repoPath, { base: 'main' });
+
+    expect(summary.dirty.stagedCount).toBeGreaterThanOrEqual(2);
+    expect(summary.dirty.unstagedCount).toBeGreaterThanOrEqual(2);
+    expect(summary.dirty.untrackedCount).toBe(1);
+    expect(summary.dirty.conflictedCount).toBe(1);
+    expect(summary.dirty.files.map((f) => f.status)).toEqual(
+      expect.arrayContaining(['modified', 'deleted', 'renamed', 'untracked', 'conflicted'])
+    );
+  });
+
+  it('returns explicit states for non-git repos, missing bases, and detached HEADs', async () => {
+    const nonGitPath = path.join(tmpDir, 'not-git');
+    fs.mkdirSync(nonGitPath);
+    expect((await getBranchDivergence(nonGitPath, { base: 'main' })).state).toBe('not_git');
+
+    const missingBase = await getBranchDivergence(repoPath, { base: 'does-not-exist' });
+    expect(missingBase.state).toBe('missing_base');
+    expect(missingBase.error).toContain('base ref not found');
+
+    const headSha = (await git(['rev-parse', 'HEAD'])).trim();
+    await git(['checkout', '--detach', headSha]);
+    const detached = await getBranchDivergence(repoPath, { base: 'main' });
+    expect(detached.state).toBe('detached');
+    expect(detached.currentBranch).toBeNull();
+    expect(detached.warnings).toContain('HEAD is detached');
+
+    await git(['checkout', 'main']);
+    await git(['checkout', '--orphan', 'orphan']);
+    await git(['rm', '-rf', '.']);
+    write('orphan.txt', 'orphan\n');
+    await commit('orphan root');
+    const noMergeBase = await getBranchDivergence(repoPath, { base: 'main' });
+    expect(noMergeBase.state).toBe('no_merge_base');
+    expect(noMergeBase.error).toContain('no merge base');
+  });
+
+  it('rejects unsafe base refs before running revision ranges', async () => {
+    for (const badRef of ['', '   ', '--upload-pack=/tmp/nope', 'main\0evil']) {
+      const summary = await getBranchDivergence(repoPath, { base: badRef });
+      expect(summary.state).toBe('invalid_base');
+      expect(summary.error).toBe('invalid base ref');
+    }
+  });
+});

--- a/test/git-divergence.test.ts
+++ b/test/git-divergence.test.ts
@@ -332,6 +332,30 @@ describe('getBranchDivergence', () => {
     expect(summary.error).toContain('index.lock');
   });
 
+  it('returns git_error instead of no_merge_base when merge-base has an internal git failure', async () => {
+    const summary = await getBranchDivergence(repoPath, {
+      base: 'main',
+      exec: createDivergenceExecMock({
+        internalErrorOn: (args) => args.join(' ') === 'merge-base -- main HEAD',
+      }),
+    });
+
+    expect(summary.state).toBe('git_error');
+    expect(summary.error).toContain('index.lock');
+  });
+
+  it('returns git_error instead of not_git when repo root detection has an internal git failure', async () => {
+    const summary = await getBranchDivergence(repoPath, {
+      base: 'main',
+      exec: createDivergenceExecMock({
+        internalErrorOn: (args) => args.join(' ') === 'rev-parse --show-toplevel',
+      }),
+    });
+
+    expect(summary.state).toBe('git_error');
+    expect(summary.error).toContain('index.lock');
+  });
+
   it('rejects unsafe base refs before running revision ranges', async () => {
     for (const badRef of [
       '',

--- a/test/git-divergence.test.ts
+++ b/test/git-divergence.test.ts
@@ -170,7 +170,17 @@ describe('getBranchDivergence', () => {
   });
 
   it('rejects unsafe base refs before running revision ranges', async () => {
-    for (const badRef of ['', '   ', '--upload-pack=/tmp/nope', 'main\0evil']) {
+    for (const badRef of [
+      '',
+      '   ',
+      '--upload-pack=/tmp/nope',
+      'main\0evil',
+      'HEAD~1',
+      'HEAD^',
+      'main..feature',
+      ':/initial',
+      'feature@{upstream}',
+    ]) {
       const summary = await getBranchDivergence(repoPath, { base: badRef });
       expect(summary.state).toBe('invalid_base');
       expect(summary.error).toBe('invalid base ref');

--- a/test/git-divergence.test.ts
+++ b/test/git-divergence.test.ts
@@ -9,7 +9,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getBranchDivergence } from '../server/git.js';
 
 const execFileAsync = promisify(execFile);
-
+type DivergenceExec = NonNullable<
+  Parameters<typeof getBranchDivergence>[1]
+>['exec'];
 let tmpDir: string;
 let repoPath: string;
 
@@ -28,6 +30,72 @@ async function commit(message: string): Promise<string> {
   await git(['add', '-A']);
   await git(['commit', '-m', message]);
   return (await git(['rev-parse', 'HEAD'])).trim();
+}
+
+function gitTimeoutError(): Error & { code: string; killed: boolean } {
+  return Object.assign(new Error('git command timed out'), {
+    code: 'ETIMEDOUT',
+    killed: true,
+  });
+}
+
+function gitInternalError(): Error & { stderr: string } {
+  return Object.assign(new Error('git failed'), {
+    stderr: 'fatal: unable to create .git/index.lock',
+  });
+}
+
+function gitRefMissingError(ref: string): Error & { stderr: string } {
+  return Object.assign(new Error(`git ref missing: ${ref}`), {
+    stderr: `fatal: ambiguous argument '${ref}': unknown revision or path not in the working tree`,
+  });
+}
+
+function ok(stdout = ''): { stdout: string; stderr: string } {
+  return { stdout, stderr: '' };
+}
+
+function createDivergenceExecMock(
+  options: {
+    timeoutOn?: (args: string[]) => boolean;
+    internalErrorOn?: (args: string[]) => boolean;
+    remoteDefaultRef?: string | null;
+  } = {}
+): DivergenceExec {
+  const sha = 'a'.repeat(40);
+
+  return async (file, args) => {
+    expect(file).toBe('git');
+
+    if (options.timeoutOn?.(args)) throw gitTimeoutError();
+    if (options.internalErrorOn?.(args)) throw gitInternalError();
+
+    const key = args.join(' ');
+    if (key === 'rev-parse --show-toplevel') return ok(repoPath);
+    if (key === 'symbolic-ref --short refs/remotes/origin/HEAD') {
+      if (options.remoteDefaultRef !== undefined)
+        return ok(`${options.remoteDefaultRef ?? ''}\n`);
+      throw gitRefMissingError('refs/remotes/origin/HEAD');
+    }
+    if (key === 'rev-parse --abbrev-ref --symbolic-full-name @{u}') {
+      throw gitRefMissingError('@{u}');
+    }
+    if (key === 'symbolic-ref refs/remotes/origin/HEAD') {
+      throw gitRefMissingError('refs/remotes/origin/HEAD');
+    }
+    if (key === 'rev-parse --verify refs/heads/main') return ok(`${sha}\n`);
+    if (key.startsWith('rev-parse --verify --end-of-options '))
+      return ok(`${sha}\n`);
+    if (key === 'symbolic-ref --quiet --short HEAD') return ok('feature\n');
+    if (key === 'status --porcelain=v1 -z') return ok('');
+    if (key === 'merge-base -- main HEAD') return ok('');
+    if (key === 'rev-list --left-right --count main...HEAD')
+      return ok('0\t0\n');
+    if (key === 'diff --numstat --find-renames main...HEAD') return ok('');
+    if (args[0] === 'log') return ok('');
+
+    throw new Error(`unexpected git command: ${key}`);
+  };
 }
 
 beforeEach(async () => {
@@ -55,7 +123,11 @@ describe('getBranchDivergence', () => {
     expect(summary.selectedBase).toMatchObject({ ref: 'main' });
     expect(summary.aheadCount).toBe(0);
     expect(summary.behindCount).toBe(0);
-    expect(summary.lineDelta).toEqual({ additions: 0, deletions: 0, fileCount: 0 });
+    expect(summary.lineDelta).toEqual({
+      additions: 0,
+      deletions: 0,
+      fileCount: 0,
+    });
     expect(summary.dirty).toMatchObject({
       stagedCount: 0,
       unstagedCount: 0,
@@ -75,9 +147,15 @@ describe('getBranchDivergence', () => {
     expect(summary.state).toBe('ok');
     expect(summary.aheadCount).toBe(1);
     expect(summary.behindCount).toBe(0);
-    expect(summary.commits.ahead.map((c) => c.subject)).toEqual(['feature commit']);
+    expect(summary.commits.ahead.map((c) => c.subject)).toEqual([
+      'feature commit',
+    ]);
     expect(summary.commits.behind).toEqual([]);
-    expect(summary.lineDelta).toEqual({ additions: 1, deletions: 0, fileCount: 1 });
+    expect(summary.lineDelta).toEqual({
+      additions: 1,
+      deletions: 0,
+      fileCount: 1,
+    });
 
     await git(['checkout', 'main']);
     write('main.txt', 'main\n');
@@ -88,13 +166,20 @@ describe('getBranchDivergence', () => {
     expect(summary.state).toBe('ok');
     expect(summary.aheadCount).toBe(1);
     expect(summary.behindCount).toBe(1);
-    expect(summary.commits.ahead.map((c) => c.subject)).toEqual(['feature commit']);
-    expect(summary.commits.behind.map((c) => c.subject)).toEqual(['main commit']);
+    expect(summary.commits.ahead.map((c) => c.subject)).toEqual([
+      'feature commit',
+    ]);
+    expect(summary.commits.behind.map((c) => c.subject)).toEqual([
+      'main commit',
+    ]);
   });
 
   it('keeps binary numstat values numeric instead of returning NaN', async () => {
     await git(['checkout', '-b', 'feature']);
-    fs.writeFileSync(path.join(repoPath, 'binary.dat'), Buffer.from([0, 1, 2, 3, 4]));
+    fs.writeFileSync(
+      path.join(repoPath, 'binary.dat'),
+      Buffer.from([0, 1, 2, 3, 4])
+    );
     await commit('add binary');
 
     const summary = await getBranchDivergence(repoPath, { base: 'main' });
@@ -139,16 +224,26 @@ describe('getBranchDivergence', () => {
     expect(summary.dirty.untrackedCount).toBe(1);
     expect(summary.dirty.conflictedCount).toBe(1);
     expect(summary.dirty.files.map((f) => f.status)).toEqual(
-      expect.arrayContaining(['modified', 'deleted', 'renamed', 'untracked', 'conflicted'])
+      expect.arrayContaining([
+        'modified',
+        'deleted',
+        'renamed',
+        'untracked',
+        'conflicted',
+      ])
     );
   });
 
   it('returns explicit states for non-git repos, missing bases, and detached HEADs', async () => {
     const nonGitPath = path.join(tmpDir, 'not-git');
     fs.mkdirSync(nonGitPath);
-    expect((await getBranchDivergence(nonGitPath, { base: 'main' })).state).toBe('not_git');
+    expect(
+      (await getBranchDivergence(nonGitPath, { base: 'main' })).state
+    ).toBe('not_git');
 
-    const missingBase = await getBranchDivergence(repoPath, { base: 'does-not-exist' });
+    const missingBase = await getBranchDivergence(repoPath, {
+      base: 'does-not-exist',
+    });
     expect(missingBase.state).toBe('missing_base');
     expect(missingBase.error).toContain('base ref not found');
 
@@ -167,6 +262,74 @@ describe('getBranchDivergence', () => {
     const noMergeBase = await getBranchDivergence(repoPath, { base: 'main' });
     expect(noMergeBase.state).toBe('no_merge_base');
     expect(noMergeBase.error).toContain('no merge base');
+  });
+
+  it('propagates timeout errors from optional base candidate discovery', async () => {
+    const summary = await getBranchDivergence(repoPath, {
+      base: 'main',
+      exec: createDivergenceExecMock({
+        timeoutOn: (args) =>
+          args.join(' ') === 'symbolic-ref --short refs/remotes/origin/HEAD',
+      }),
+    });
+
+    expect(summary.state).toBe('timeout');
+    expect(summary.error).toBe('git command timed out');
+  });
+
+  it('propagates timeout errors from base candidate commit resolution', async () => {
+    const summary = await getBranchDivergence(repoPath, {
+      base: 'main',
+      exec: createDivergenceExecMock({
+        remoteDefaultRef: 'origin/main',
+        timeoutOn: (args) =>
+          args.join(' ') ===
+          'rev-parse --verify --end-of-options origin/main^{commit}',
+      }),
+    });
+
+    expect(summary.state).toBe('timeout');
+    expect(summary.error).toBe('git command timed out');
+  });
+
+  it('propagates timeout errors from default branch detection', async () => {
+    const summary = await getBranchDivergence(repoPath, {
+      base: 'main',
+      exec: createDivergenceExecMock({
+        timeoutOn: (args) =>
+          args.join(' ') === 'symbolic-ref refs/remotes/origin/HEAD',
+      }),
+    });
+
+    expect(summary.state).toBe('timeout');
+    expect(summary.error).toBe('git command timed out');
+  });
+
+  it('propagates timeout errors from current branch detection instead of reporting detached HEAD', async () => {
+    const summary = await getBranchDivergence(repoPath, {
+      base: 'main',
+      exec: createDivergenceExecMock({
+        timeoutOn: (args) =>
+          args.join(' ') === 'symbolic-ref --quiet --short HEAD',
+      }),
+    });
+
+    expect(summary.state).toBe('timeout');
+    expect(summary.error).toBe('git command timed out');
+    expect(summary.warnings).not.toContain('HEAD is detached');
+  });
+
+  it('returns a distinct git_error state for internal git failures inside a confirmed repo', async () => {
+    const summary = await getBranchDivergence(repoPath, {
+      base: 'main',
+      exec: createDivergenceExecMock({
+        internalErrorOn: (args) =>
+          args.join(' ') === 'status --porcelain=v1 -z',
+      }),
+    });
+
+    expect(summary.state).toBe('git_error');
+    expect(summary.error).toContain('index.lock');
   });
 
   it('rejects unsafe base refs before running revision ranges', async () => {

--- a/test/pty-handler-multi-agent.test.ts
+++ b/test/pty-handler-multi-agent.test.ts
@@ -1,11 +1,24 @@
-import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  it,
+  expect,
+} from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import * as sessions from '../server/sessions.js';
 import type { PtySession } from '../server/types.js';
 
 const createdIds: string[] = [];
+const execFileAsync = promisify(execFile);
+const originalTmuxTmpdir = process.env.TMUX_TMPDIR;
+let tmuxTmpdir: string;
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -14,7 +27,7 @@ function delay(ms: number): Promise<void> {
 async function waitForScrollbackContains(
   sessionId: string,
   needle: string,
-  timeoutMs = 4000
+  timeoutMs = 8000
 ): Promise<string> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -31,6 +44,21 @@ async function waitForScrollbackContains(
 describe('PTY multi-agent hook/plugin wiring', () => {
   const originalHome = process.env.HOME;
   let testHome: string;
+
+  beforeAll(() => {
+    tmuxTmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ide-tmux-'));
+    process.env.TMUX_TMPDIR = tmuxTmpdir;
+  });
+
+  afterAll(async () => {
+    await execFileAsync('tmux', ['kill-server']).catch(() => {});
+    if (originalTmuxTmpdir === undefined) {
+      delete process.env.TMUX_TMPDIR;
+    } else {
+      process.env.TMUX_TMPDIR = originalTmuxTmpdir;
+    }
+    fs.rmSync(tmuxTmpdir, { recursive: true, force: true });
+  });
 
   beforeEach(() => {
     testHome = fs.mkdtempSync(

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, afterEach, expect } from 'vitest';
+import { describe, it, afterAll, afterEach, beforeAll, expect } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -18,6 +18,23 @@ import type { PtySession } from '../server/types.js';
 // Track created session IDs so we can clean up after each test
 const createdIds: string[] = [];
 const execFileAsync = promisify(execFile);
+const originalTmuxTmpdir = process.env.TMUX_TMPDIR;
+let tmuxTmpdir: string;
+
+beforeAll(() => {
+  tmuxTmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ide-tmux-'));
+  process.env.TMUX_TMPDIR = tmuxTmpdir;
+});
+
+afterAll(async () => {
+  await execFileAsync('tmux', ['kill-server']).catch(() => {});
+  if (originalTmuxTmpdir === undefined) {
+    delete process.env.TMUX_TMPDIR;
+  } else {
+    process.env.TMUX_TMPDIR = originalTmuxTmpdir;
+  }
+  fs.rmSync(tmuxTmpdir, { recursive: true, force: true });
+});
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/test/workspace-divergence-api.test.ts
+++ b/test/workspace-divergence-api.test.ts
@@ -88,6 +88,33 @@ describe('GET /workspaces/divergence', () => {
     expect(body).toMatchObject({ state: 'invalid_base', error: 'invalid base ref' });
   });
 
+  it('rejects symlink escapes from configured workspaces', async () => {
+    const externalRepo = path.join(tmpDir, 'external-repo');
+    fs.mkdirSync(externalRepo, { recursive: true });
+    await execFileAsync('git', ['init', '--initial-branch=main'], { cwd: externalRepo, timeout: 10_000 });
+    await execFileAsync('git', ['config', 'user.name', 'Relay Test'], { cwd: externalRepo, timeout: 10_000 });
+    await execFileAsync('git', ['config', 'user.email', 'relay@example.test'], {
+      cwd: externalRepo,
+      timeout: 10_000,
+    });
+    fs.writeFileSync(path.join(externalRepo, 'outside.txt'), 'outside\n', 'utf8');
+    await execFileAsync('git', ['add', '-A'], { cwd: externalRepo, timeout: 10_000 });
+    await execFileAsync('git', ['commit', '-m', 'outside commit'], {
+      cwd: externalRepo,
+      timeout: 10_000,
+    });
+
+    const linkPath = path.join(repoPath, 'linked-external');
+    fs.symlinkSync(externalRepo, linkPath, 'dir');
+
+    const res = await fetch(endpoint(linkPath, 'main'));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({
+      state: 'not_git',
+      error: 'path not in configured workspaces',
+    });
+  });
+
   it('returns a display-ready divergence summary for configured repo subpaths', async () => {
     await git(['checkout', '-b', 'feature']);
     write('src/feature.ts', 'export const feature = true;\n');

--- a/test/workspace-divergence-api.test.ts
+++ b/test/workspace-divergence-api.test.ts
@@ -1,0 +1,117 @@
+import express from 'express';
+import type { Server } from 'node:http';
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { DEFAULTS, saveConfig } from '../server/config.js';
+import { createWorkspaceRouter } from '../server/workspaces.js';
+
+const execFileAsync = promisify(execFile);
+
+let tmpDir: string;
+let configPath: string;
+let repoPath: string;
+let server: Server;
+let baseUrl: string;
+
+async function git(args: string[], cwd = repoPath): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd, timeout: 10_000 });
+  return stdout;
+}
+
+function write(relPath: string, content: string): void {
+  const abs = path.join(repoPath, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, 'utf8');
+}
+
+async function commit(message: string): Promise<void> {
+  await git(['add', '-A']);
+  await git(['commit', '-m', message]);
+}
+
+beforeEach(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'workspace-divergence-api-'));
+  configPath = path.join(tmpDir, 'config.json');
+  repoPath = path.join(tmpDir, 'repo');
+  fs.mkdirSync(repoPath, { recursive: true });
+  await git(['init', '--initial-branch=main']);
+  await git(['config', 'user.name', 'Relay Test']);
+  await git(['config', 'user.email', 'relay@example.test']);
+  write('base.txt', 'base\n');
+  await commit('initial commit');
+  saveConfig(configPath, { ...DEFAULTS, repos: [repoPath] });
+
+  const app = express();
+  app.use(express.json());
+  app.use('/workspaces', createWorkspaceRouter({ configPath }));
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', resolve);
+  });
+  const addr = server.address() as { port: number };
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server?.close(() => resolve()));
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function endpoint(repo = repoPath, base = 'main'): string {
+  return `${baseUrl}/workspaces/divergence?path=${encodeURIComponent(repo)}&base=${encodeURIComponent(base)}`;
+}
+
+describe('GET /workspaces/divergence', () => {
+  it('requires a configured workspace path', async () => {
+    const missingPath = await fetch(`${baseUrl}/workspaces/divergence`);
+    expect(missingPath.status).toBe(400);
+    expect(await missingPath.json()).toMatchObject({ state: 'not_git', error: 'path parameter required' });
+
+    const forbidden = await fetch(endpoint(path.join(tmpDir, 'other'), 'main'));
+    expect(forbidden.status).toBe(403);
+    expect(await forbidden.json()).toMatchObject({
+      state: 'not_git',
+      error: 'path not in configured workspaces',
+    });
+  });
+
+  it('rejects unsafe base refs before git commands', async () => {
+    const res = await fetch(endpoint(repoPath, '--upload-pack=/tmp/nope'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toMatchObject({ state: 'invalid_base', error: 'invalid base ref' });
+  });
+
+  it('returns a display-ready divergence summary for configured repo subpaths', async () => {
+    await git(['checkout', '-b', 'feature']);
+    write('src/feature.ts', 'export const feature = true;\n');
+    await commit('add feature');
+    write('dirty.txt', 'dirty\n');
+
+    const subdir = path.join(repoPath, 'src');
+    const res = await fetch(endpoint(subdir, 'main'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body).toMatchObject({
+      repoPath: fs.realpathSync(repoPath),
+      currentBranch: 'feature',
+      state: 'ok',
+      aheadCount: 1,
+      behindCount: 0,
+      selectedBase: { ref: 'main' },
+      lineDelta: { additions: 1, deletions: 0, fileCount: 1 },
+      dirty: { untrackedCount: 1 },
+    });
+    expect(body.headSha).toMatch(/^[0-9a-f]{40}$/);
+    expect(body.commits.ahead[0]).toMatchObject({ subject: 'add feature', author: 'Relay Test' });
+    expect(body.baseCandidates.map((c: { ref: string }) => c.ref)).toContain('main');
+    expect(typeof body.generatedAt).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `GET /workspaces/divergence?path=<repo-or-worktree>&base=<ref>` for display-ready branch divergence state.
- Computes base candidates, selected base resolution, ahead/behind counts, line delta, dirty summary, and capped side-specific commit lists.
- Adds backend response types, route wiring, architecture docs, and git/API tests for branch states, path/base validation, symlink escape rejection, and revspec rejection.

## Motivation
Issue #252 needs a backend contract the frontend can render without guessing from empty arrays or silently treating git errors as clean state.

Refs #252

## The Case Against
This might be wrong because:
- The divergence helper is intentionally broad and lives in `server/git.ts`; if this grows further, it should be split into a dedicated module rather than making `git.ts` an everything drawer.
- The endpoint returns explicit `state` values in the JSON body while most git-data failures still use HTTP 200 for displayable git states. Frontend code must key off `state`, not only HTTP status.
- `repoPath` comes from `git rev-parse --show-toplevel`, so macOS `/var` temp paths may normalize to `/private/var`. That is correct for git, but consumers should not string-compare against the query path.
- Base validation now intentionally rejects arbitrary revision expressions like `HEAD~1`, `HEAD^`, `main..feature`, and `:/regex`; if a future UI wants arbitrary revspec comparisons, it should add a separate explicitly-designed contract instead of loosening this endpoint casually.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
| --- | --- | --- |
| Unsafe base refs become shell/git options or revision-range tricks | Low | Base is rejected if empty/NUL/option-like or revspec/pathspec-like, then resolved via `git rev-parse --verify --end-of-options <ref>^{commit}` before range commands. |
| Symlink paths escape configured workspaces | Low | Workspace access now realpaths requested paths and configured roots before boundary checks; symlink escapes return 403. |
| Git failures display as clean branches | Low | Missing base, not-git, unborn, detached, no-merge-base, invalid-base, and timeout states are explicit. |
| Dirty status is conflated with divergence | Low | Dirty summary is computed separately from base-vs-HEAD counts/diff. |
| Binary numstat values become `NaN` | Low | `-` additions/deletions are normalized to 0 while still counting the file. |

## Verification
- `npx vitest run test/git-divergence.test.ts test/workspace-divergence-api.test.ts` — 10 tests passed after adding hardening regressions.
- `npx vitest run test/git-divergence.test.ts test/workspace-divergence-api.test.ts test/git-changed-files.test.ts` — 21 tests passed.
- `npm run build` — passed; Vite emitted existing chunk-size/dynamic-import warnings.
- `npm test` — passed (exit 0); existing test stderr noise only.
- Independent follow-up review passed after hardening; only non-blocking suggestion was to consider reusing the stricter ref validator in adjacent changed-files/file-diff routes later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added branch divergence endpoint returning ahead/behind counts, per-file line deltas, dirty-worktree summary, base-candidate list, and side-specific commit lists.

* **Bug Fixes / Security**
  * Tightened workspace path authorization using realpath containment to block path-traversal and symlink escapes.

* **Documentation**
  * API docs updated to describe the new divergence endpoint, parameters, and response payload.

* **Tests**
  * Comprehensive unit and integration tests covering divergence logic, dirty-state classification, error states, timeouts, and workspace access checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->