### PR TITLE
frontend: add branch divergence rail panel

### DIFF
--- a/frontend/src/components/FileViewerPane.tsx
+++ b/frontend/src/components/FileViewerPane.tsx
@@ -192,10 +192,15 @@ export function FileViewerPane({
   const activeFileTabKey = useUiStore((s) => s.activeFileTabKey);
   const fileDiffSource = useUiStore((s) => s.fileDiffSource);
   const fileDiffDefaultBranch = useUiStore((s) => s.fileDiffDefaultBranch);
+  const openUtilityRailTab = useUiStore((s) => s.openUtilityRailTab);
   const base = useMemo(
     () => diffSourceToBase(fileDiffSource, fileDiffDefaultBranch) ?? null,
     [fileDiffSource, fileDiffDefaultBranch]
   );
+  const branchBase = fileDiffSource === 'branch' ? base : null;
+  const handleOpenBranchPanel = useCallback(() => {
+    openUtilityRailTab(workspacePath, 'branch', { branchBase });
+  }, [branchBase, openUtilityRailTab, workspacePath]);
   const activeTab = useMemo(
     () =>
       openFileTabs.find(
@@ -284,6 +289,11 @@ export function FileViewerPane({
               onClick={handleToggleDiffViewMode}
             >
               {fileDiffViewMode === 'unified' ? '[split]' : '[unified]'}
+            </button>
+          )}
+          {activeTab?.isChanged && (
+            <button className="diff-mode-btn" onClick={handleOpenBranchPanel}>
+              [branch]
             </button>
           )}
           {activeTab?.tabType === 'html' && (

--- a/frontend/src/components/SplitPaneLayout.css
+++ b/frontend/src/components/SplitPaneLayout.css
@@ -78,8 +78,8 @@
     position: fixed;
     top: 0;
     right: 0;
-    width: 85vw !important;
-    min-width: 85vw !important;
+    width: 100vw !important;
+    min-width: 100vw !important;
     height: 100vh;
     height: 100dvh;
     z-index: 200;
@@ -97,10 +97,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--surface);
-    border: none;
+    background: transparent;
+    border: 0;
     border-bottom: 1px solid var(--border);
     color: var(--text);
+    font-family: var(--font-mono, monospace);
     font-size: var(--font-size-lg);
     padding: 8px 12px;
     min-height: 44px;
@@ -109,7 +110,7 @@
   }
 
   .mobile-sidebar-close-btn:active {
-    background: var(--border);
+    background: var(--surface-hover, #141414);
   }
 
   .resize-handle {

--- a/frontend/src/components/SplitPaneLayout.tsx
+++ b/frontend/src/components/SplitPaneLayout.tsx
@@ -207,11 +207,11 @@ export function SplitPaneLayout({
           >
             <button
               className="mobile-sidebar-close-btn"
-              aria-label="Close file sidebar"
+              aria-label="close file sidebar"
               onClick={onToggleRightSidebar}
               type="button"
             >
-              ✕
+              x
             </button>
             {rightSidebar}
           </div>

--- a/frontend/src/components/UtilityRailBranchPanel.css
+++ b/frontend/src/components/UtilityRailBranchPanel.css
@@ -263,12 +263,47 @@
     display: grid;
   }
 
+  .branch-topbar,
+  .branch-base-row,
+  .branch-dirty,
+  .branch-state-detail,
+  .branch-warnings,
+  .branch-empty {
+    padding: 12px;
+  }
+
+  .branch-section__header {
+    min-height: 44px;
+    padding: 0 12px;
+  }
+
+  .branch-select,
+  .branch-button,
+  .branch-link {
+    min-height: 44px;
+  }
+
+  .branch-button,
+  .branch-link {
+    padding: 0 10px;
+  }
+
+  .branch-link-row {
+    gap: 8px;
+  }
+
   .branch-base-row {
     grid-template-columns: 1fr;
+    gap: 8px;
   }
 
   .branch-metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .branch-metric {
+    min-height: 56px;
+    padding: 10px 12px;
   }
 
   .branch-metric:nth-child(3n) {
@@ -277,5 +312,9 @@
 
   .branch-metric:nth-child(2n) {
     border-right: 0;
+  }
+
+  .branch-commit {
+    padding: 12px;
   }
 }

--- a/frontend/src/components/UtilityRailBranchPanel.css
+++ b/frontend/src/components/UtilityRailBranchPanel.css
@@ -1,0 +1,281 @@
+.branch-panel {
+  display: grid;
+  grid-template-rows: auto auto auto auto auto auto auto;
+  align-content: start;
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+  background: var(--bg, #000);
+  color: var(--text, #e0e0e0);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs, 0.75rem);
+}
+
+.branch-topbar,
+.branch-base-row,
+.branch-dirty,
+.branch-section__header {
+  border-bottom: 1px solid var(--border, #333);
+}
+
+.branch-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+  padding: 8px;
+}
+
+.branch-topbar__main {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.branch-title,
+.branch-section-label {
+  color: var(--text, #e0e0e0);
+}
+
+.branch-current,
+.branch-muted,
+.branch-empty-line {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted, #888);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.branch-muted--warn {
+  color: var(--status-warning, #fbbf24);
+}
+
+.branch-base-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 6px;
+  padding: 8px;
+}
+
+.branch-base-row label {
+  color: var(--text-muted, #888);
+}
+
+.branch-select,
+.branch-button,
+.branch-link {
+  border: 1px solid var(--border, #333);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted, #888);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs, 0.75rem);
+}
+
+.branch-select {
+  min-width: 0;
+  height: 28px;
+  padding: 0 6px;
+}
+
+.branch-button,
+.branch-link {
+  min-height: 28px;
+  cursor: pointer;
+}
+
+.branch-button:hover,
+.branch-link:hover,
+.branch-select:hover {
+  border-color: var(--accent, #d97757);
+  color: var(--text, #e0e0e0);
+}
+
+.branch-button:disabled,
+.branch-link:disabled,
+.branch-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.branch-state {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.branch-state--success {
+  color: var(--status-success, #4ade80);
+}
+
+.branch-state--warn {
+  color: var(--status-warning, #fbbf24);
+}
+
+.branch-state--error {
+  color: var(--status-error, #f87171);
+}
+
+.branch-state--clean {
+  color: var(--text-muted, #888);
+}
+
+.branch-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-bottom: 1px solid var(--border, #333);
+}
+
+.branch-metric {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  padding: 8px 6px;
+  border-right: 1px solid var(--border, #333);
+}
+
+.branch-metric:nth-child(3n) {
+  border-right: 0;
+}
+
+.branch-metric__value {
+  color: var(--text, #e0e0e0);
+  font-size: var(--font-size-sm, 0.8125rem);
+}
+
+.branch-metric__label {
+  color: var(--text-muted, #888);
+}
+
+.branch-metric--success .branch-metric__value {
+  color: var(--status-success, #4ade80);
+}
+
+.branch-metric--warning .branch-metric__value {
+  color: var(--status-warning, #fbbf24);
+}
+
+.branch-metric--error .branch-metric__value {
+  color: var(--status-error, #f87171);
+}
+
+.branch-state-detail,
+.branch-warnings,
+.branch-empty {
+  display: grid;
+  gap: 4px;
+  padding: 8px;
+  border-bottom: 1px solid var(--border, #333);
+  color: var(--text-muted, #888);
+}
+
+.branch-warnings {
+  color: var(--status-warning, #fbbf24);
+}
+
+.branch-dirty {
+  display: grid;
+  gap: 8px;
+  padding: 8px;
+}
+
+.branch-dirty > div:first-child {
+  display: grid;
+  gap: 2px;
+}
+
+.branch-link-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.branch-link {
+  padding: 0 6px;
+}
+
+.branch-section {
+  min-width: 0;
+}
+
+.branch-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 30px;
+  padding: 0 8px;
+  color: var(--text, #e0e0e0);
+}
+
+.branch-commit-list {
+  display: grid;
+}
+
+.branch-commit {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 4px 8px;
+  min-width: 0;
+  padding: 8px;
+  border-bottom: 1px solid var(--border, #333);
+}
+
+.branch-commit__hash {
+  color: var(--accent, #d97757);
+}
+
+.branch-commit__subject {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text, #e0e0e0);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.branch-commit__meta {
+  grid-column: 2;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted, #888);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.branch-empty-line {
+  padding: 8px;
+  border-bottom: 1px solid var(--border, #333);
+}
+
+@media (max-width: 520px) {
+  .branch-topbar,
+  .branch-dirty,
+  .branch-link-row {
+    align-items: stretch;
+  }
+
+  .branch-topbar,
+  .branch-link-row {
+    display: grid;
+  }
+
+  .branch-base-row {
+    grid-template-columns: 1fr;
+  }
+
+  .branch-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .branch-metric:nth-child(3n) {
+    border-right: 1px solid var(--border, #333);
+  }
+
+  .branch-metric:nth-child(2n) {
+    border-right: 0;
+  }
+}

--- a/frontend/src/components/UtilityRailBranchPanel.tsx
+++ b/frontend/src/components/UtilityRailBranchPanel.tsx
@@ -1,0 +1,358 @@
+import React, { useCallback, useEffect, useMemo } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { fetchDivergence } from '../lib/api.js';
+import { useUiStore } from '../lib/stores/ui.js';
+import type {
+  BranchDivergenceCommit,
+  BranchDivergenceState,
+  BranchDivergenceSummary,
+  DirtySummary,
+} from '../lib/types.js';
+import './UtilityRailBranchPanel.css';
+
+export interface UtilityRailBranchPanelProps {
+  workspacePath: string;
+}
+
+function divergenceKey(workspacePath: string, base: string | null) {
+  return ['workspaceDivergence', workspacePath, base ?? ''] as const;
+}
+
+function formatDate(date: string): string {
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return date;
+  return parsed.toLocaleDateString(undefined, {
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function dirtyTotal(dirty: DirtySummary): number {
+  return (
+    dirty.stagedCount +
+    dirty.unstagedCount +
+    dirty.untrackedCount +
+    dirty.conflictedCount
+  );
+}
+
+function stateLabel(data: BranchDivergenceSummary): string {
+  const dirty = dirtyTotal(data.dirty);
+  if (data.state !== 'ok') {
+    const labels: Record<BranchDivergenceState, string> = {
+      ok: 'ok',
+      not_git: 'not a git repo',
+      invalid_base: 'invalid base',
+      missing_base: 'missing base',
+      detached: 'detached head',
+      unborn: 'unborn branch',
+      no_merge_base: 'no merge base',
+      timeout: 'timeout',
+    };
+    return labels[data.state];
+  }
+  if (data.aheadCount === 0 && data.behindCount === 0 && dirty === 0) {
+    return 'clean branch';
+  }
+  if (data.aheadCount === 0 && data.behindCount === 0 && dirty > 0) {
+    return 'dirty tree only';
+  }
+  if (data.aheadCount > 0 && data.behindCount === 0) return 'ahead only';
+  if (data.aheadCount === 0 && data.behindCount > 0) return 'behind only';
+  return 'ahead and behind';
+}
+
+function statusClass(data: BranchDivergenceSummary): string {
+  if (data.state !== 'ok') return 'branch-state branch-state--error';
+  if (data.behindCount > 0) return 'branch-state branch-state--warn';
+  if (data.aheadCount > 0) return 'branch-state branch-state--success';
+  if (dirtyTotal(data.dirty) > 0) return 'branch-state branch-state--warn';
+  return 'branch-state branch-state--clean';
+}
+
+function Metric({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: React.ReactNode;
+  tone?: string;
+}) {
+  return (
+    <div className={`branch-metric${tone ? ` branch-metric--${tone}` : ''}`}>
+      <span className="branch-metric__value">{value}</span>
+      <span className="branch-metric__label">{label}</span>
+    </div>
+  );
+}
+
+function CommitList({
+  title,
+  commits,
+  empty,
+}: {
+  title: string;
+  commits: BranchDivergenceCommit[];
+  empty: string;
+}) {
+  return (
+    <section className="branch-section">
+      <header className="branch-section__header">
+        <span>{title}</span>
+        <span>{commits.length}</span>
+      </header>
+      {commits.length === 0 ? (
+        <div className="branch-empty-line">{empty}</div>
+      ) : (
+        <div className="branch-commit-list">
+          {commits.map((commit) => (
+            <div className="branch-commit" key={commit.hash}>
+              <span className="branch-commit__hash">{commit.shortHash}</span>
+              <span className="branch-commit__subject" title={commit.subject}>
+                {commit.subject}
+              </span>
+              <span className="branch-commit__meta">
+                {commit.author} · {formatDate(commit.date)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function EmptyOrError({ data }: { data: BranchDivergenceSummary }) {
+  const label = stateLabel(data);
+  if (data.state === 'ok' && (data.aheadCount > 0 || data.behindCount > 0)) {
+    return null;
+  }
+  return (
+    <div className="branch-state-detail">
+      <span>{label}</span>
+      {data.error ? <span>{data.error}</span> : null}
+      {data.state === 'ok' &&
+      data.lineDelta.fileCount === 0 &&
+      (data.aheadCount > 0 || data.behindCount > 0) ? (
+        <span>divergence with zero line delta</span>
+      ) : null}
+      {data.state === 'ok' && data.baseCandidates.length === 0 ? (
+        <span>no remote/default fallback found</span>
+      ) : null}
+    </div>
+  );
+}
+
+export function UtilityRailBranchPanel({
+  workspacePath,
+}: UtilityRailBranchPanelProps) {
+  const queryClient = useQueryClient();
+  const openUtilityRailTab = useUiStore((s) => s.openUtilityRailTab);
+  const setUtilityBranchBase = useUiStore((s) => s.setUtilityBranchBase);
+  const selectedBase = useUiStore(
+    (s) => s.getUtilityRailState(workspacePath).branchBase ?? null
+  );
+
+  const query = useQuery<BranchDivergenceSummary>({
+    queryKey: divergenceKey(workspacePath, selectedBase),
+    queryFn: async () =>
+      fetchDivergence(workspacePath, selectedBase ?? undefined),
+    enabled: Boolean(workspacePath),
+    staleTime: 5 * 1000,
+    retry: false,
+  });
+
+  const data = query.data;
+
+  useEffect(() => {
+    if (!data || selectedBase !== null) return;
+    const nextBase = data.selectedBase?.ref ?? data.baseCandidates[0]?.ref;
+    if (nextBase) setUtilityBranchBase(workspacePath, nextBase);
+  }, [data, selectedBase, setUtilityBranchBase, workspacePath]);
+
+  const dirtySummary = useMemo(() => {
+    if (!data) return '0 files';
+    const dirty = data.dirty;
+    const parts = [
+      dirty.stagedCount > 0 ? `${dirty.stagedCount} staged` : null,
+      dirty.unstagedCount > 0 ? `${dirty.unstagedCount} unstaged` : null,
+      dirty.untrackedCount > 0 ? `${dirty.untrackedCount} untracked` : null,
+      dirty.conflictedCount > 0 ? `${dirty.conflictedCount} conflicted` : null,
+    ].filter(Boolean);
+    if (parts.length === 0) return 'clean tree';
+    return parts.join(' · ');
+  }, [data]);
+
+  const refresh = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: divergenceKey(workspacePath, selectedBase),
+    });
+  }, [queryClient, selectedBase, workspacePath]);
+
+  const openChanges = useCallback(() => {
+    openUtilityRailTab(workspacePath, 'changes');
+  }, [openUtilityRailTab, workspacePath]);
+
+  const openReview = useCallback(() => {
+    openUtilityRailTab(workspacePath, 'review');
+  }, [openUtilityRailTab, workspacePath]);
+
+  if (query.isPending && !data) {
+    return (
+      <div className="branch-panel">
+        <div className="branch-topbar">
+          <span className="branch-title">divergence</span>
+          <span className="branch-muted">loading...</span>
+        </div>
+        <div className="branch-empty">loading branch state...</div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="branch-panel">
+        <div className="branch-topbar">
+          <span className="branch-title">divergence</span>
+          <button className="branch-button" type="button" onClick={refresh}>
+            retry
+          </button>
+        </div>
+        <div className="branch-empty">unable to load branch state</div>
+      </div>
+    );
+  }
+
+  const currentBase = selectedBase ?? data.selectedBase?.ref ?? '';
+  const baseOptions = data.baseCandidates;
+  const lineDelta = data.lineDelta;
+  const isZeroLineDivergence =
+    (data.aheadCount > 0 || data.behindCount > 0) &&
+    lineDelta.additions === 0 &&
+    lineDelta.deletions === 0 &&
+    lineDelta.fileCount === 0;
+
+  return (
+    <div className="branch-panel">
+      <div className="branch-topbar">
+        <div className="branch-topbar__main">
+          <span className="branch-title">divergence</span>
+          <span
+            className="branch-current"
+            title={data.currentBranch ?? 'detached head'}
+          >
+            {data.currentBranch ?? 'detached head'}
+          </span>
+        </div>
+        <button
+          className="branch-button"
+          type="button"
+          onClick={refresh}
+          aria-label="refresh branch divergence"
+        >
+          refresh
+        </button>
+      </div>
+
+      <div className="branch-base-row">
+        <label htmlFor="branch-base-select">base</label>
+        <select
+          id="branch-base-select"
+          className="branch-select"
+          value={currentBase}
+          onChange={(event) =>
+            setUtilityBranchBase(workspacePath, event.target.value || null)
+          }
+          disabled={baseOptions.length === 0}
+        >
+          {baseOptions.length === 0 ? (
+            <option value="">no base candidates</option>
+          ) : (
+            baseOptions.map((candidate) => (
+              <option
+                key={`${candidate.source}:${candidate.ref}`}
+                value={candidate.ref}
+              >
+                {candidate.label || candidate.ref}
+              </option>
+            ))
+          )}
+        </select>
+        <span className={statusClass(data)}>{stateLabel(data)}</span>
+        {query.isFetching ? (
+          <span className="branch-muted">refreshing</span>
+        ) : null}
+        {query.isStale ? (
+          <span className="branch-muted branch-muted--warn">stale</span>
+        ) : null}
+      </div>
+
+      <div className="branch-metrics" aria-label="branch metrics">
+        <Metric label="ahead" value={data.aheadCount} tone="success" />
+        <Metric label="behind" value={data.behindCount} tone="warning" />
+        <Metric label="files" value={lineDelta.fileCount} />
+        <Metric label="add" value={`+${lineDelta.additions}`} tone="success" />
+        <Metric label="del" value={`−${lineDelta.deletions}`} tone="error" />
+        <Metric label="dirty" value={dirtyTotal(data.dirty)} tone="warning" />
+        <Metric label="untracked" value={data.dirty.untrackedCount} />
+      </div>
+
+      <EmptyOrError data={data} />
+      {isZeroLineDivergence ? (
+        <div className="branch-state-detail">
+          divergence with zero line delta
+        </div>
+      ) : null}
+
+      {data.warnings.length > 0 || data.dirty.truncated ? (
+        <div className="branch-warnings">
+          {data.warnings.map((warning) => (
+            <span key={warning}>{warning}</span>
+          ))}
+          {data.dirty.truncated ? <span>dirty file list truncated</span> : null}
+        </div>
+      ) : null}
+
+      <section className="branch-dirty">
+        <div>
+          <span className="branch-section-label">dirty tree</span>
+          <span className="branch-muted">{dirtySummary}</span>
+        </div>
+        <div className="branch-link-row">
+          <button
+            className="branch-link"
+            type="button"
+            onClick={openChanges}
+            data-testid="branch-open-changes"
+          >
+            open changes
+          </button>
+          <button
+            className="branch-link"
+            type="button"
+            onClick={openReview}
+            data-testid="branch-open-review"
+          >
+            open review
+          </button>
+        </div>
+      </section>
+
+      <CommitList
+        title="head commits"
+        commits={data.commits.ahead}
+        empty="no head-only commits"
+      />
+      <CommitList
+        title="base commits"
+        commits={data.commits.behind}
+        empty="no base-only commits"
+      />
+    </div>
+  );
+}
+
+export default UtilityRailBranchPanel;

--- a/frontend/src/components/UtilityRailBranchPanel.tsx
+++ b/frontend/src/components/UtilityRailBranchPanel.tsx
@@ -228,6 +228,9 @@ export function UtilityRailBranchPanel({
 
   const currentBase = selectedBase ?? data.selectedBase?.ref ?? '';
   const baseOptions = data.baseCandidates;
+  const shouldShowMissingBaseOption =
+    Boolean(currentBase) &&
+    !baseOptions.some((candidate) => candidate.ref === currentBase);
   const lineDelta = data.lineDelta;
   const isZeroLineDivergence =
     (data.aheadCount > 0 || data.behindCount > 0) &&
@@ -266,9 +269,14 @@ export function UtilityRailBranchPanel({
           onChange={(event) =>
             setUtilityBranchBase(workspacePath, event.target.value || null)
           }
-          disabled={baseOptions.length === 0}
+          disabled={baseOptions.length === 0 && !shouldShowMissingBaseOption}
         >
-          {baseOptions.length === 0 ? (
+          {shouldShowMissingBaseOption ? (
+            <option value={currentBase} disabled>
+              {currentBase} (missing)
+            </option>
+          ) : null}
+          {baseOptions.length === 0 && !shouldShowMissingBaseOption ? (
             <option value="">no base candidates</option>
           ) : (
             baseOptions.map((candidate) => (

--- a/frontend/src/components/UtilityRailBranchPanel.tsx
+++ b/frontend/src/components/UtilityRailBranchPanel.tsx
@@ -50,6 +50,7 @@ function stateLabel(data: BranchDivergenceSummary): string {
       unborn: 'unborn branch',
       no_merge_base: 'no merge base',
       timeout: 'timeout',
+      git_error: 'git error',
     };
     return labels[data.state];
   }

--- a/frontend/src/components/UtilityRailGitChangesPanel.tsx
+++ b/frontend/src/components/UtilityRailGitChangesPanel.tsx
@@ -80,6 +80,7 @@ export function UtilityRailGitChangesPanel({
 }: UtilityRailGitChangesPanelProps) {
   const queryClient = useQueryClient();
   const openFileTab = useUiStore((s) => s.openFileTab);
+  const openUtilityRailTab = useUiStore((s) => s.openUtilityRailTab);
   const activeFileTabKey = useUiStore((s) => s.activeFileTabKey);
 
   const workingQuery = useQuery<ChangedFilesResponse>({
@@ -110,6 +111,10 @@ export function UtilityRailGitChangesPanel({
     queryClient.invalidateQueries({ queryKey: workingKey(workspacePath) });
     queryClient.invalidateQueries({ queryKey: stagedKey(workspacePath) });
   }, [queryClient, workspacePath]);
+
+  const openBranchPanel = useCallback(() => {
+    openUtilityRailTab(workspacePath, 'branch');
+  }, [openUtilityRailTab, workspacePath]);
 
   const groups = useMemo(() => {
     const working = workingQuery.data?.files ?? [];
@@ -149,6 +154,14 @@ export function UtilityRailGitChangesPanel({
       <div className="gc__hd">
         <span className="title">git changes</span>
         <span className="meta">{totalCount} files</span>
+        <button
+          type="button"
+          className="btn"
+          onClick={openBranchPanel}
+          title="branch divergence"
+        >
+          branch
+        </button>
         <button
           type="button"
           className="btn"

--- a/frontend/src/components/UtilityRailReviewPanel.tsx
+++ b/frontend/src/components/UtilityRailReviewPanel.tsx
@@ -32,6 +32,7 @@ export function UtilityRailReviewPanel({
   const fileDiffViewMode = useUiStore((s) => s.fileDiffViewMode);
   const setFileDiffSource = useUiStore((s) => s.setFileDiffSource);
   const setFileDiffViewMode = useUiStore((s) => s.setFileDiffViewMode);
+  const openUtilityRailTab = useUiStore((s) => s.openUtilityRailTab);
   const [defaultBranch, setDefaultBranch] = useState('main');
   const [files, setFiles] = useState<ChangedFile[]>([]);
   const [loading, setLoading] = useState(false);
@@ -138,6 +139,13 @@ export function UtilityRailReviewPanel({
     );
   }, [fileDiffViewMode, setFileDiffViewMode]);
 
+  const branchBase = fileDiffSource === 'branch' ? base : null;
+  const openBranchPanel = useCallback(() => {
+    openUtilityRailTab(workspacePath, 'branch', {
+      branchBase,
+    });
+  }, [branchBase, openUtilityRailTab, workspacePath]);
+
   return (
     <div className="utility-review-panel">
       <div className="utility-panel-toolbar">
@@ -146,6 +154,13 @@ export function UtilityRailReviewPanel({
           onchange={setFileDiffSource}
           defaultBranch={defaultBranch}
         />
+        <button
+          className="utility-panel-btn"
+          onClick={openBranchPanel}
+          type="button"
+        >
+          [branch]
+        </button>
         <button
           className="utility-panel-btn"
           onClick={handleModeToggle}

--- a/frontend/src/components/WorkspaceUtilityRail.css
+++ b/frontend/src/components/WorkspaceUtilityRail.css
@@ -192,3 +192,26 @@
   color: var(--text, #e0e0e0);
   font-size: var(--font-size-xs, 0.75rem);
 }
+
+@media (max-width: 767px) {
+  .workspace-utility-rail {
+    flex: 1 1 auto;
+    grid-template-columns: minmax(0, 1fr);
+    min-height: 0;
+  }
+
+  .workspace-utility-rail:not(.workspace-utility-rail--icons-only)
+    .utility-icon-rail {
+    display: none;
+  }
+
+  .workspace-utility-rail:not(.workspace-utility-rail--icons-only)
+    .utility-selected-pane {
+    border-right: 0;
+  }
+
+  .workspace-utility-rail--icons-only {
+    grid-template-columns: var(--utility-icon-rail-width, 48px);
+    justify-content: end;
+  }
+}

--- a/frontend/src/components/WorkspaceUtilityRail.tsx
+++ b/frontend/src/components/WorkspaceUtilityRail.tsx
@@ -9,6 +9,7 @@ import {
 import type { FileTreeHandle } from './FileTree/index.js';
 import UtilityRailFilesPanel from './UtilityRailFilesPanel.js';
 import UtilityRailGitChangesPanel from './UtilityRailGitChangesPanel.js';
+import UtilityRailBranchPanel from './UtilityRailBranchPanel.js';
 import UtilityRailReviewPanel from './UtilityRailReviewPanel.js';
 import UtilityRailLogsPanel from './UtilityRailLogsPanel.js';
 import UtilityRailStatsPanel from './UtilityRailStatsPanel.js';
@@ -41,6 +42,19 @@ const TAB_META: Array<{
         <circle cx="18" cy="12" r="2.5" />
         <path d="M6 8.5v7" />
         <path d="M6 6h6a4 4 0 0 1 4 4v.5" />
+      </svg>
+    ),
+  },
+  {
+    id: 'branch',
+    label: 'git branch',
+    actionId: 'workspace.open-branch-divergence',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="7" cy="6" r="2.5" />
+        <circle cx="17" cy="18" r="2.5" />
+        <path d="M7 8.5v9.5" />
+        <path d="M7 12h4a6 6 0 0 1 6 6" />
       </svg>
     ),
   },
@@ -180,6 +194,16 @@ export function WorkspaceUtilityRail({
             hidden={selectedTab !== 'changes'}
           >
             <UtilityRailGitChangesPanel workspacePath={workspacePath} />
+          </div>
+          <div
+            id="utility-rail-panel-branch"
+            className="utility-pane-panel"
+            role="tabpanel"
+            aria-labelledby="utility-rail-tab-branch"
+            tabIndex={selectedTab === 'branch' ? 0 : -1}
+            hidden={selectedTab !== 'branch'}
+          >
+            <UtilityRailBranchPanel workspacePath={workspacePath} />
           </div>
           <div
             id="utility-rail-panel-review"

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -443,6 +443,32 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
 
       // ── Diff view ────────────────────────────────────────────────────────────
       {
+        id: 'workspace.open-branch-divergence' as const,
+        label: 'open branch pane',
+        description: 'open the branch divergence utility pane',
+        category: 'workspace' as const,
+        shortcut: { key: 'mod+b' },
+        when: (ctx: ActionContext) => ctx.view === 'session',
+        handler: () => {
+          const currentActiveSessionId =
+            useSessionsStore.getState().activeSessionId;
+          const currentActiveSession = currentActiveSessionId
+            ? useSessionsStore
+                .getState()
+                .sessions.find((s) => s.id === currentActiveSessionId)
+            : undefined;
+          const ws =
+            currentActiveSession?.worktreePath ??
+            currentActiveSession?.repoPath ??
+            '';
+          if (ws) {
+            const ui = useUiStore.getState();
+            ui.openUtilityRailTab(ws, 'branch');
+            useUiStore.setState({ fullPageDiff: null });
+          }
+        },
+      },
+      {
         id: 'workspace.open-diff-view' as const,
         label: 'open review pane',
         description: 'open the review utility pane for changed files',

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -28,6 +28,7 @@ import type {
   AnalyticsToolBreakdown,
   AnalyticsRateLimitHistory,
   FrameworkInfo,
+  BranchDivergenceSummary,
 } from './types.js';
 
 export class ConflictError extends Error {
@@ -1075,6 +1076,73 @@ export async function fetchChangedFiles(
     };
   }
   return jsonEither<ChangedFilesResponse>(res);
+}
+
+function isBranchDivergenceSummary(
+  value: unknown
+): value is BranchDivergenceSummary {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<BranchDivergenceSummary>;
+  return (
+    typeof candidate.repoPath === 'string' &&
+    typeof candidate.aheadCount === 'number' &&
+    typeof candidate.behindCount === 'number' &&
+    Boolean(candidate.lineDelta) &&
+    Boolean(candidate.dirty) &&
+    Boolean(candidate.commits) &&
+    typeof candidate.state === 'string' &&
+    Array.isArray(candidate.baseCandidates) &&
+    Array.isArray(candidate.warnings) &&
+    typeof candidate.generatedAt === 'string'
+  );
+}
+
+function emptyDivergenceSummary(
+  repoPath: string,
+  error: string
+): BranchDivergenceSummary {
+  return {
+    repoPath,
+    currentBranch: null,
+    headSha: null,
+    selectedBase: null,
+    baseCandidates: [],
+    aheadCount: 0,
+    behindCount: 0,
+    lineDelta: { additions: 0, deletions: 0, fileCount: 0 },
+    dirty: {
+      stagedCount: 0,
+      unstagedCount: 0,
+      untrackedCount: 0,
+      conflictedCount: 0,
+      files: [],
+      truncated: false,
+    },
+    commits: { ahead: [], behind: [] },
+    state: 'missing_base',
+    error,
+    warnings: [],
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+export async function fetchDivergence(
+  repoPath: string,
+  base?: string
+): Promise<BranchDivergenceSummary> {
+  const params = new URLSearchParams({ path: repoPath });
+  if (base) params.set('base', base);
+  const res = await fetch('/workspaces/divergence?' + params.toString());
+  if (!res.ok) {
+    try {
+      const parsed = await jsonEither<unknown>(res);
+      if (isBranchDivergenceSummary(parsed)) return parsed;
+    } catch {
+      // Fall through to the generic transport fallback below.
+    }
+    return emptyDivergenceSummary(repoPath, `HTTP ${res.status}`);
+  }
+  return jsonEither<BranchDivergenceSummary>(res);
 }
 
 /** Swallows HTTP errors and returns `{ diff: '', error }` on failure. */

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -34,7 +34,13 @@ export const UTILITY_ICON_RAIL_WIDTH = 48;
 export type RightSidebarTab = 'changes' | 'all-files' | 'checks';
 export type FileTabType = 'diff' | 'code' | 'html';
 export type DiffViewMode = 'unified' | 'side-by-side';
-export type UtilityRailTab = 'files' | 'changes' | 'review' | 'logs' | 'stats';
+export type UtilityRailTab =
+  | 'files'
+  | 'changes'
+  | 'branch'
+  | 'review'
+  | 'logs'
+  | 'stats';
 export type UtilitySurfacePlacement =
   | { kind: 'rail' }
   | { kind: 'anchored-pane'; paneId: string };
@@ -47,10 +53,12 @@ export interface WorkspaceUtilityRailState {
   placements?: Partial<Record<UtilityRailTab, UtilitySurfacePlacement>>;
   reviewFilePath?: string;
   filesMode?: 'changes' | 'all-files';
+  branchBase?: string;
 }
 
 export interface OpenUtilityRailTabOptions {
   preserveSelectedTab?: boolean;
+  branchBase?: string | null;
 }
 
 export const DEFAULT_UTILITY_RAIL_STATE: WorkspaceUtilityRailState = {
@@ -173,6 +181,7 @@ function loadCollapsedWorkspaces(): Set<string> {
 const UTILITY_RAIL_TABS: UtilityRailTab[] = [
   'files',
   'changes',
+  'branch',
   'review',
   'logs',
   'stats',
@@ -253,6 +262,9 @@ function normalizeUtilityRailState(
     next.reviewFilePath = value.reviewFilePath;
   if (value.filesMode === 'changes' || value.filesMode === 'all-files') {
     next.filesMode = value.filesMode;
+  }
+  if (typeof value.branchBase === 'string' && value.branchBase.trim()) {
+    next.branchBase = value.branchBase;
   }
 
   return next;
@@ -346,6 +358,7 @@ export interface UiState {
     tab: UtilityRailTab,
     options?: OpenUtilityRailTabOptions
   ) => void;
+  setUtilityBranchBase: (workspacePath: string, base: string | null) => void;
   setUtilityRailVisible: (workspacePath: string, visible: boolean) => void;
   toggleUtilityRailVisible: (workspacePath: string) => void;
   setUtilityRailWidth: (workspacePath: string, width: number) => void;
@@ -515,6 +528,26 @@ export const useUiStore = create<UiState>()((set, get) => ({
       (state) => {
         state.visible = true;
         if (!options?.preserveSelectedTab) state.selectedRailTab = tab;
+        if (options?.branchBase !== undefined) {
+          if (options.branchBase?.trim()) state.branchBase = options.branchBase;
+          else delete state.branchBase;
+        }
+      }
+    );
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: next,
+      },
+    });
+  },
+  setUtilityBranchBase: (workspacePath, base) => {
+    const next = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        if (base?.trim()) state.branchBase = base;
+        else delete state.branchBase;
       }
     );
     set({

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -385,6 +385,92 @@ export interface FileDiffResponse {
   error?: string;
 }
 
+export type BranchDivergenceState =
+  | 'ok'
+  | 'not_git'
+  | 'invalid_base'
+  | 'missing_base'
+  | 'detached'
+  | 'unborn'
+  | 'no_merge_base'
+  | 'timeout';
+
+export type BranchBaseCandidateSource =
+  | 'remoteDefault'
+  | 'default'
+  | 'upstream'
+  | 'local'
+  | 'remote';
+
+export interface BranchBaseRef {
+  ref: string;
+  sha: string | null;
+}
+
+export interface BranchBaseCandidate extends BranchBaseRef {
+  label: string;
+  source: BranchBaseCandidateSource;
+}
+
+export interface BranchLineDelta {
+  additions: number;
+  deletions: number;
+  fileCount: number;
+}
+
+export type DirtyFileStatus =
+  | 'added'
+  | 'modified'
+  | 'deleted'
+  | 'renamed'
+  | 'untracked'
+  | 'conflicted';
+
+export interface DirtyFileSummary {
+  path: string;
+  oldPath?: string;
+  status: DirtyFileStatus;
+  staged: boolean;
+  unstaged: boolean;
+}
+
+export interface DirtySummary {
+  stagedCount: number;
+  unstagedCount: number;
+  untrackedCount: number;
+  conflictedCount: number;
+  files: DirtyFileSummary[];
+  truncated: boolean;
+}
+
+export interface BranchDivergenceCommit {
+  hash: string;
+  shortHash: string;
+  subject: string;
+  author: string;
+  date: string;
+}
+
+export interface BranchDivergenceSummary {
+  repoPath: string;
+  currentBranch: string | null;
+  headSha: string | null;
+  selectedBase: BranchBaseRef | null;
+  baseCandidates: BranchBaseCandidate[];
+  aheadCount: number;
+  behindCount: number;
+  lineDelta: BranchLineDelta;
+  dirty: DirtySummary;
+  commits: {
+    ahead: BranchDivergenceCommit[];
+    behind: BranchDivergenceCommit[];
+  };
+  state: BranchDivergenceState;
+  error?: string;
+  warnings: string[];
+  generatedAt: string;
+}
+
 export interface FileContentResponse {
   content: string;
   binary?: boolean;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -393,7 +393,8 @@ export type BranchDivergenceState =
   | 'detached'
   | 'unborn'
   | 'no_merge_base'
-  | 'timeout';
+  | 'timeout'
+  | 'git_error';
 
 export type BranchBaseCandidateSource =
   | 'remoteDefault'

--- a/frontend/src/test-utility-rail-branch-panel.css
+++ b/frontend/src/test-utility-rail-branch-panel.css
@@ -1,0 +1,20 @@
+.branch-panel-harness {
+  display: grid;
+  gap: 8px;
+  min-height: 100vh;
+  padding: 8px;
+  background: var(--bg, #000);
+  color: var(--text, #e0e0e0);
+  font-family: var(--font-mono, monospace);
+}
+
+.branch-panel-frame {
+  width: min(360px, calc(100vw - 16px));
+  height: 760px;
+  border: 1px solid var(--border, #333);
+}
+
+.branch-panel-harness output {
+  color: var(--text-muted, #888);
+  font-size: var(--font-size-xs, 0.75rem);
+}

--- a/frontend/src/test-utility-rail-branch-panel.tsx
+++ b/frontend/src/test-utility-rail-branch-panel.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import UtilityRailBranchPanel from './components/UtilityRailBranchPanel.js';
+import { useUiStore } from './lib/stores/ui.js';
+import type { BranchDivergenceSummary } from './lib/types.js';
+import './App.css';
+import './components/WorkspaceUtilityRail.css';
+import './components/UtilityRailBranchPanel.css';
+import './test-utility-rail-branch-panel.css';
+
+const nativeFetch = window.fetch.bind(window);
+
+function summaryFor(base: string | null): BranchDivergenceSummary {
+  const selected = base ?? 'origin/nightly';
+  return {
+    repoPath: '/fixture/repo',
+    currentBranch: 'feat/branch-panel',
+    headSha: 'aaaaaaaa',
+    selectedBase: { ref: selected, sha: 'bbbbbbbb' },
+    baseCandidates: [
+      {
+        ref: 'origin/nightly',
+        sha: 'bbbbbbbb',
+        label: 'origin/nightly',
+        source: 'remoteDefault',
+      },
+      {
+        ref: 'origin/main',
+        sha: 'cccccccc',
+        label: 'origin/main',
+        source: 'remote',
+      },
+    ],
+    aheadCount: selected === 'origin/main' ? 3 : 2,
+    behindCount: 1,
+    lineDelta: { additions: 42, deletions: 7, fileCount: 5 },
+    dirty: {
+      stagedCount: 1,
+      unstagedCount: 2,
+      untrackedCount: 1,
+      conflictedCount: 0,
+      files: [],
+      truncated: false,
+    },
+    commits: {
+      ahead: [
+        {
+          hash: 'aaaaaaaa11111111',
+          shortHash: 'aaaaaaaa',
+          subject: 'add branch panel',
+          author: 'ebi',
+          date: '2026-05-05T00:00:00.000Z',
+        },
+      ],
+      behind: [
+        {
+          hash: 'bbbbbbbb22222222',
+          shortHash: 'bbbbbbbb',
+          subject: 'backend contract',
+          author: 'donovan',
+          date: '2026-05-04T00:00:00.000Z',
+        },
+      ],
+    },
+    state: 'ok',
+    warnings: ['commit list truncated'],
+    generatedAt: '2026-05-05T00:00:00.000Z',
+  };
+}
+
+window.fetch = async (input, init) => {
+  const url = new URL(String(input), window.location.origin);
+  if (url.pathname === '/workspaces/divergence') {
+    const body = JSON.stringify(summaryFor(url.searchParams.get('base')));
+    return new Response(body, {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+  return nativeFetch(input, init);
+};
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false } },
+});
+
+function BranchPanelHarness() {
+  const branchBase = useUiStore(
+    (s) => s.getUtilityRailState('/fixture/repo').branchBase ?? ''
+  );
+
+  return (
+    <div className="branch-panel-harness">
+      <div className="branch-panel-frame">
+        <QueryClientProvider client={queryClient}>
+          <UtilityRailBranchPanel workspacePath="/fixture/repo" />
+        </QueryClientProvider>
+      </div>
+      <output data-testid="branch-base-state">{branchBase}</output>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')!).render(
+  <React.StrictMode>
+    <BranchPanelHarness />
+  </React.StrictMode>
+);

--- a/frontend/test-utility-rail-branch-panel.html
+++ b/frontend/test-utility-rail-branch-panel.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>UtilityRailBranchPanel Test Page</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/src/test-utility-rail-branch-panel.tsx"
+    ></script>
+  </body>
+</html>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,6 +10,19 @@ const xtermDir = path.dirname(
   fileURLToPath(import.meta.resolve('@xterm/xterm/package.json'))
 );
 const addonWebgpu = path.resolve(xtermDir, 'addons', 'addon-webgpu');
+const includeE2eFixtures = process.env.RELAY_IDE_E2E_FIXTURES === '1';
+
+const buildInputs: Record<string, string> = {
+  main: resolve(import.meta.dirname, 'index.html'),
+  'test-terminal': resolve(import.meta.dirname, 'test-terminal.html'),
+};
+
+if (includeE2eFixtures) {
+  buildInputs['test-utility-rail-branch-panel'] = resolve(
+    import.meta.dirname,
+    'test-utility-rail-branch-panel.html'
+  );
+}
 
 export default defineConfig({
   root: import.meta.dirname,
@@ -24,10 +37,7 @@ export default defineConfig({
     outDir: '../dist/frontend',
     emptyOutDir: true,
     rollupOptions: {
-      input: {
-        main: resolve(import.meta.dirname, 'index.html'),
-        'test-terminal': resolve(import.meta.dirname, 'test-terminal.html'),
-      },
+      input: buildInputs,
     },
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,9 +26,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: process.env.CI
-      ? `RELAY_IDE_PORT=${port} node dist/server/index.js`
-      : `RELAY_IDE_PORT=${port} npm run start`,
+    command: `RELAY_IDE_E2E_FIXTURES=1 RELAY_IDE_PORT=${port} npm run start`,
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,

--- a/test/divergence-api.test.ts
+++ b/test/divergence-api.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchDivergence } from '../frontend/src/lib/api.js';
+
+function mockFetch(response: unknown, ok = true, status = 200) {
+  const fetchMock = vi.fn(async () => ({
+    ok,
+    status,
+    text: async () => JSON.stringify(response),
+    json: async () => response,
+  })) as unknown as typeof fetch;
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock as unknown as ReturnType<typeof vi.fn>;
+}
+
+function divergenceSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    repoPath: '/repo with spaces',
+    currentBranch: 'feature/a',
+    headSha: 'abc123',
+    selectedBase: { ref: 'origin/nightly', sha: 'def456' },
+    baseCandidates: [],
+    aheadCount: 2,
+    behindCount: 1,
+    lineDelta: { additions: 12, deletions: 3, fileCount: 4 },
+    dirty: {
+      stagedCount: 1,
+      unstagedCount: 2,
+      untrackedCount: 1,
+      conflictedCount: 0,
+      files: [],
+      truncated: false,
+    },
+    commits: { ahead: [], behind: [] },
+    state: 'ok',
+    warnings: [],
+    generatedAt: '2026-05-05T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('fetchDivergence', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('requests the divergence endpoint with path and selected base', async () => {
+    const fetchMock = mockFetch(divergenceSummary());
+
+    const data = await fetchDivergence('/repo with spaces', 'origin/nightly');
+
+    expect(data.aheadCount).toBe(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = String(fetchMock.mock.calls[0]?.[0]);
+    expect(url).toContain('/workspaces/divergence?');
+    expect(url).toContain('path=%2Frepo+with+spaces');
+    expect(url).toContain('base=origin%2Fnightly');
+  });
+
+  it('preserves backend divergence summaries returned with HTTP errors', async () => {
+    mockFetch(
+      divergenceSummary({
+        repoPath: '/repo',
+        state: 'invalid_base',
+        error: 'base ref is not valid',
+        selectedBase: null,
+      }),
+      false,
+      400
+    );
+
+    const data = await fetchDivergence('/repo', 'not a ref');
+
+    expect(data).toMatchObject({
+      repoPath: '/repo',
+      state: 'invalid_base',
+      error: 'base ref is not valid',
+    });
+  });
+
+  it('returns fallback error data for non-summary non-ok responses', async () => {
+    mockFetch({ error: 'not found' }, false, 404);
+
+    const data = await fetchDivergence('/missing');
+
+    expect(data).toMatchObject({
+      repoPath: '/missing',
+      currentBranch: null,
+      selectedBase: null,
+      aheadCount: 0,
+      behindCount: 0,
+      state: 'missing_base',
+      error: 'HTTP 404',
+    });
+  });
+});

--- a/test/divergence-panel.test.ts
+++ b/test/divergence-panel.test.ts
@@ -242,6 +242,33 @@ describe('UtilityRailBranchPanel', () => {
     expect(container.textContent).toContain('missing-base-qa');
   });
 
+  it('renders backend git errors with the explicit error and warning text', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        const response = {
+          ...baseSummary,
+          state: 'git_error',
+          error: 'git merge-base failed: corrupt object',
+          warnings: ['branch state may be incomplete'],
+        } as BranchDivergenceSummary;
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify(response),
+          json: async () => response,
+        };
+      })
+    );
+
+    await act(async () => renderPanel(root, queryClient));
+    await waitForText(container, 'git merge-base failed: corrupt object');
+
+    expect(container.textContent).toContain('git error');
+    expect(container.textContent).toContain('git merge-base failed: corrupt object');
+    expect(container.textContent).toContain('branch state may be incomplete');
+  });
+
   it('describes clean, dirty-only, missing-base, and detached states clearly', async () => {
     const states: Array<Partial<BranchDivergenceSummary>> = [
       {

--- a/test/divergence-panel.test.ts
+++ b/test/divergence-panel.test.ts
@@ -209,6 +209,39 @@ describe('UtilityRailBranchPanel', () => {
     ).toBe('review');
   });
 
+  it('shows the persisted missing base in the selector instead of falling back visually', async () => {
+    useUiStore.getState().setUtilityBranchBase('/repo', 'missing-base-qa');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        const response: BranchDivergenceSummary = {
+          ...baseSummary,
+          selectedBase: null,
+          state: 'missing_base',
+          error: 'base ref not found: missing-base-qa',
+        };
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify(response),
+          json: async () => response,
+        };
+      })
+    );
+
+    await act(async () => renderPanel(root, queryClient));
+    await waitForText(container, 'base ref not found: missing-base-qa');
+
+    const select = container.querySelector('select') as HTMLSelectElement;
+    expect(select.value).toBe('missing-base-qa');
+    expect(
+      Array.from(select.options).some(
+        (option) => option.value === 'missing-base-qa' && option.disabled
+      )
+    ).toBe(true);
+    expect(container.textContent).toContain('missing-base-qa');
+  });
+
   it('describes clean, dirty-only, missing-base, and detached states clearly', async () => {
     const states: Array<Partial<BranchDivergenceSummary>> = [
       {

--- a/test/divergence-panel.test.ts
+++ b/test/divergence-panel.test.ts
@@ -1,0 +1,257 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const reactActGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+reactActGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+import UtilityRailBranchPanel from '../frontend/src/components/UtilityRailBranchPanel.js';
+import { useUiStore } from '../frontend/src/lib/stores/ui.js';
+import type { BranchDivergenceSummary } from '../frontend/src/lib/types.js';
+
+const baseSummary: BranchDivergenceSummary = {
+  repoPath: '/repo',
+  currentBranch: 'feat/branch-panel',
+  headSha: 'aaaaaaaa',
+  selectedBase: { ref: 'origin/nightly', sha: 'bbbbbbbb' },
+  baseCandidates: [
+    {
+      ref: 'origin/nightly',
+      sha: 'bbbbbbbb',
+      label: 'origin/nightly',
+      source: 'remoteDefault',
+    },
+    {
+      ref: 'origin/main',
+      sha: 'cccccccc',
+      label: 'origin/main',
+      source: 'remote',
+    },
+  ],
+  aheadCount: 2,
+  behindCount: 1,
+  lineDelta: { additions: 42, deletions: 7, fileCount: 5 },
+  dirty: {
+    stagedCount: 1,
+    unstagedCount: 2,
+    untrackedCount: 1,
+    conflictedCount: 0,
+    files: [
+      { path: 'src/app.ts', status: 'modified', staged: true, unstaged: false },
+      { path: 'notes.txt', status: 'untracked', staged: false, unstaged: true },
+    ],
+    truncated: false,
+  },
+  commits: {
+    ahead: [
+      {
+        hash: 'aaaaaaaa11111111',
+        shortHash: 'aaaaaaaa',
+        subject: 'add branch panel',
+        author: 'ebi',
+        date: '2026-05-05T00:00:00.000Z',
+      },
+    ],
+    behind: [
+      {
+        hash: 'bbbbbbbb22222222',
+        shortHash: 'bbbbbbbb',
+        subject: 'backend contract',
+        author: 'donovan',
+        date: '2026-05-04T00:00:00.000Z',
+      },
+    ],
+  },
+  state: 'ok',
+  warnings: ['commit list truncated'],
+  generatedAt: '2026-05-05T00:00:00.000Z',
+};
+
+function mockDivergenceFetch() {
+  const calls: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      calls.push(url);
+      const parsed = new URL(url, 'http://relay.test');
+      const selected = parsed.searchParams.get('base') ?? 'origin/nightly';
+      const response: BranchDivergenceSummary = {
+        ...baseSummary,
+        selectedBase: { ref: selected, sha: 'selected-sha' },
+      };
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify(response),
+        json: async () => response,
+      };
+    })
+  );
+  return calls;
+}
+
+async function flush() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await Promise.resolve();
+  });
+}
+
+async function waitForText(container: HTMLElement, pattern: string | RegExp) {
+  for (let i = 0; i < 20; i += 1) {
+    await flush();
+    const text = container.textContent ?? '';
+    if (
+      typeof pattern === 'string' ? text.includes(pattern) : pattern.test(text)
+    ) {
+      return;
+    }
+  }
+  expect(container.textContent ?? '').toMatch(pattern);
+}
+
+function renderPanel(root: Root, queryClient: QueryClient) {
+  root.render(
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(UtilityRailBranchPanel, { workspacePath: '/repo' })
+    )
+  );
+}
+
+describe('UtilityRailBranchPanel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    useUiStore.setState({ utilityRailByWorkspace: {} });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    queryClient.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders branch metrics, commit lists, warnings, and dirty-tree links', async () => {
+    mockDivergenceFetch();
+
+    await act(async () => renderPanel(root, queryClient));
+    await waitForText(container, 'feat/branch-panel');
+
+    expect(container.textContent).toContain('divergence');
+    expect(container.textContent).toContain('feat/branch-panel');
+    expect(container.textContent).toContain('ahead');
+    expect(container.textContent).toContain('2');
+    expect(container.textContent).toContain('+42');
+    expect(container.textContent).toContain('−7');
+    expect(container.textContent).toContain('add branch panel');
+    expect(container.textContent).toContain('backend contract');
+    expect(container.textContent).toContain('dirty tree');
+    expect(container.textContent).toContain('commit list truncated');
+  });
+
+  it('refetches when the user chooses a base candidate', async () => {
+    const calls = mockDivergenceFetch();
+
+    await act(async () => renderPanel(root, queryClient));
+    await waitForText(container, 'feat/branch-panel');
+
+    const select = container.querySelector('select') as HTMLSelectElement;
+    expect(select.value).toBe('origin/nightly');
+
+    await act(async () => {
+      select.value = 'origin/main';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+
+    expect(calls.some((url) => url.includes('base=origin%2Fmain'))).toBe(true);
+    expect(useUiStore.getState().getUtilityRailState('/repo').branchBase).toBe(
+      'origin/main'
+    );
+  });
+
+  it('opens existing changes and review rail surfaces from summary links', async () => {
+    mockDivergenceFetch();
+
+    await act(async () => renderPanel(root, queryClient));
+    await waitForText(container, 'feat/branch-panel');
+
+    const changesButton = container.querySelector(
+      '[data-testid="branch-open-changes"]'
+    ) as HTMLButtonElement;
+    await act(async () => changesButton.click());
+    expect(
+      useUiStore.getState().getUtilityRailState('/repo').selectedRailTab
+    ).toBe('changes');
+
+    const reviewButton = container.querySelector(
+      '[data-testid="branch-open-review"]'
+    ) as HTMLButtonElement;
+    await act(async () => reviewButton.click());
+    expect(
+      useUiStore.getState().getUtilityRailState('/repo').selectedRailTab
+    ).toBe('review');
+  });
+
+  it('describes clean, dirty-only, missing-base, and detached states clearly', async () => {
+    const states: Array<Partial<BranchDivergenceSummary>> = [
+      {
+        aheadCount: 0,
+        behindCount: 0,
+        lineDelta: { additions: 0, deletions: 0, fileCount: 0 },
+        dirty: {
+          ...baseSummary.dirty,
+          stagedCount: 0,
+          unstagedCount: 0,
+          untrackedCount: 0,
+          conflictedCount: 0,
+        },
+        commits: { ahead: [], behind: [] },
+      },
+      { aheadCount: 0, behindCount: 0, commits: { ahead: [], behind: [] } },
+      { state: 'missing_base', selectedBase: null, error: 'base not found' },
+      { state: 'detached', currentBranch: null, error: 'detached head' },
+    ];
+
+    for (const patch of states) {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => {
+          const response = { ...baseSummary, ...patch };
+          return {
+            ok: true,
+            status: 200,
+            text: async () => JSON.stringify(response),
+            json: async () => response,
+          };
+        })
+      );
+      queryClient.clear();
+      await act(async () => renderPanel(root, queryClient));
+      await waitForText(
+        container,
+        /clean branch|dirty tree|missing base|detached head/
+      );
+      expect(container.textContent).toMatch(
+        /clean branch|dirty tree|missing base|detached head/
+      );
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/test/e2e/components/UtilityRailBranchPanel.spec.ts
+++ b/test/e2e/components/UtilityRailBranchPanel.spec.ts
@@ -31,4 +31,24 @@ test.describe('UtilityRailBranchPanel React component', () => {
     );
     await expect(page.locator('.branch-metrics')).toContainText('3');
   });
+
+  test('keeps narrow viewport controls touch sized', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(page.locator('.branch-panel')).toBeVisible();
+
+    for (const selector of [
+      '#branch-base-select',
+      '.branch-topbar .branch-button',
+      '[data-testid="branch-open-changes"]',
+      '[data-testid="branch-open-review"]',
+    ]) {
+      const box = await page.locator(selector).boundingBox();
+      expect(box?.height).toBeGreaterThanOrEqual(44);
+    }
+
+    const metricColumns = await page.locator('.branch-metric').evaluateAll((els) =>
+      new Set(els.map((el) => Math.round(el.getBoundingClientRect().left))).size
+    );
+    expect(metricColumns).toBe(2);
+  });
 });

--- a/test/e2e/components/UtilityRailBranchPanel.spec.ts
+++ b/test/e2e/components/UtilityRailBranchPanel.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('UtilityRailBranchPanel React component', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/test-utility-rail-branch-panel.html');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('renders branch divergence metrics and commit lists', async ({
+    page,
+  }) => {
+    await expect(page.locator('.branch-panel')).toBeVisible();
+    await expect(page.getByText('divergence')).toBeVisible();
+    await expect(page.getByText('feat/branch-panel')).toBeVisible();
+    await expect(page.locator('.branch-metrics')).toContainText('ahead');
+    await expect(page.locator('.branch-metrics')).toContainText('+42');
+    await expect(page.getByText('add branch panel')).toBeVisible();
+    await expect(page.getByText('backend contract')).toBeVisible();
+    await expect(page.getByText('dirty tree')).toBeVisible();
+  });
+
+  test('refetches and persists base choice from selector', async ({ page }) => {
+    const baseSelect = page.locator('#branch-base-select');
+    await expect(baseSelect).toHaveValue('origin/nightly');
+
+    await baseSelect.selectOption('origin/main');
+
+    await expect(baseSelect).toHaveValue('origin/main');
+    await expect(page.getByTestId('branch-base-state')).toHaveText(
+      'origin/main'
+    );
+    await expect(page.locator('.branch-metrics')).toContainText('3');
+  });
+});

--- a/test/stores/ui-store.test.ts
+++ b/test/stores/ui-store.test.ts
@@ -156,13 +156,13 @@ describe('ui Zustand store', () => {
 
     it('openUtilityRailTab makes the rail visible and selects the requested tab', () => {
       useUiStore.getState().setUtilityRailVisible('/repo/a', false);
-      useUiStore.getState().openUtilityRailTab('/repo/a', 'files');
+      useUiStore.getState().openUtilityRailTab('/repo/a', 'branch');
 
       expect(
         useUiStore.getState().getUtilityRailState('/repo/a')
       ).toMatchObject({
         visible: true,
-        selectedRailTab: 'files',
+        selectedRailTab: 'branch',
       });
     });
 
@@ -178,6 +178,34 @@ describe('ui Zustand store', () => {
         visible: true,
         selectedRailTab: 'logs',
       });
+    });
+
+    it('stores the selected branch base when opening the branch rail', () => {
+      useUiStore.getState().openUtilityRailTab('/repo/a', 'branch', {
+        branchBase: 'origin/nightly',
+      });
+
+      expect(
+        useUiStore.getState().getUtilityRailState('/repo/a')
+      ).toMatchObject({
+        visible: true,
+        selectedRailTab: 'branch',
+        branchBase: 'origin/nightly',
+      });
+      expect(storage['relay-utility-rail::/repo/a']).toContain(
+        '"branchBase":"origin/nightly"'
+      );
+    });
+
+    it('setUtilityBranchBase updates a workspace branch comparison base', () => {
+      useUiStore.getState().setUtilityBranchBase('/repo/a', 'origin/main');
+
+      expect(
+        useUiStore.getState().getUtilityRailState('/repo/a').branchBase
+      ).toBe('origin/main');
+      expect(storage['relay-utility-rail::/repo/a']).toContain(
+        '"branchBase":"origin/main"'
+      );
     });
 
     it('clamps utility rail widths', () => {


### PR DESCRIPTION
## summary
- add a `branch` utility rail tab with a divergence panel backed by `GET /workspaces/divergence`
- show base selection, ahead/behind counts, line delta, dirty summary, commit lists, stale/error/empty states, and links into existing changes/review surfaces
- add API/types/store plumbing, command palette action (`mod+b`), file/review/change surface entry points, and branch-base persistence per workspace
- add Vitest coverage plus a Playwright component fixture gated behind `RELAY_IDE_E2E_FIXTURES=1` so the fixture page is not included in normal production builds

## stack
- stacked on backend API PR #345 / branch `feat/252-branch-divergence-api`
- target branch: `feat/252-branch-divergence-api`
- final landing target remains `nightly`

## verification
- `npx vitest run test/divergence-api.test.ts test/divergence-panel.test.ts test/stores/ui-store.test.ts` — 39 tests passed
- `npm run build` — passed; existing Vite chunk warnings only
- `npm run check` — passed with 0 errors / 38 existing warnings
- `launchctl bootout gui/$(id -u)/com.relay-ide 2>/dev/null || true && PLAYWRIGHT_PORT=3467 npm run test:e2e -- test/e2e/components/UtilityRailBranchPanel.spec.ts` — 2 tests passed
- `npm test` — 137 files / 1708 tests passed
- `npm run test:e2e` full suite attempted with `PLAYWRIGHT_PORT=4568`; not used as a gate because the existing project-wide e2e suite timed out after broad pre-existing harness/snapshot failures unrelated to this panel (`basic.spec`, missing darwin screenshots, component fixture pages showing the default error page)
- `git diff --cached --check` — passed before commit
- static added-diff scan for obvious hardcoded secrets/dangerous eval/shell patterns — no matches

Closes #252
Refs #250


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added branch divergence panel displaying comparison metrics (ahead/behind counts, file changes, additions/deletions)
  * New base branch selector with candidate options
  * Commit history display for both head and base branches
  * Dirty file tracking with warnings
  * New keyboard shortcut (Mod+B) to access branch divergence view

* **Improvements**
  * Enhanced mobile sidebar layout and styling
  * Updated mobile sidebar close button

<!-- end of auto-generated comment: release notes by coderabbit.ai -->