### PR TITLE
feat: add workspace utility terminals

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,9 +8,11 @@ import {
   MAX_UTILITY_RAIL_WIDTH,
   MIN_UTILITY_RAIL_WIDTH,
   UTILITY_ICON_RAIL_WIDTH,
+  type WorkspaceUtilityRailState,
 } from './lib/stores/ui.js';
 import { useSessionsStore } from './lib/stores/sessions.js';
 import { useConfigStore } from './lib/stores/config.js';
+import { useToastStore } from './lib/stores/toasts.js';
 import { useBootStateStore } from './lib/stores/boot-state.js';
 import { useTelemetryStore } from './lib/stores/telemetry.js';
 import { sendPtyData } from './lib/ws.js';
@@ -26,7 +28,14 @@ import {
   initPushNotifications,
   resubscribeIfNeeded,
 } from './lib/notifications.js';
-import type { Repo, PullRequest } from './lib/types.js';
+import type { Repo, PullRequest, SessionSummary } from './lib/types.js';
+import { estimateTerminalDimensions } from './lib/utils.js';
+import { createSessionWithoutActivation } from './lib/session-utils.js';
+import { killSession } from './lib/api.js';
+import {
+  getMainWorkspaceSessions,
+  getUtilityTerminalSessions,
+} from './lib/utility-terminals.js';
 import { initAnalytics, destroyAnalytics, track } from './lib/analytics.js';
 import type { ActionContext } from './lib/actions/types.js';
 import { useEventSocket } from './hooks/useEventSocket.js';
@@ -191,20 +200,22 @@ function useTerminalDerivedState() {
   const allWorkspaceSessions = useMemo(
     () =>
       activeRepoPath
-        ? useSessionsStore.getState().getSessionsForRepo(activeRepoPath)
+        ? sessions
+            .filter((session) => session.repoPath === activeRepoPath)
+            .toSorted(
+              (a, b) =>
+                new Date(a.createdAt).getTime() -
+                new Date(b.createdAt).getTime()
+            )
         : [],
     [activeRepoPath, sessions]
   );
 
   const workspaceSessions = useMemo(
     () =>
-      (activeSession
+      activeSession
         ? allWorkspaceSessions.filter((s) => s.cwd === activeSession.cwd)
-        : allWorkspaceSessions
-      ).toSorted(
-        (a, b) =>
-          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-      ),
+        : allWorkspaceSessions,
     [activeSession, allWorkspaceSessions]
   );
 
@@ -227,8 +238,8 @@ function useTerminalDerivedState() {
     [activeSession]
   );
   const activeWorkspaceCwd = useMemo(
-    () => activeSession?.worktreePath ?? activeSession?.repoPath ?? '',
-    [activeSession]
+    () => activeSession?.worktreePath ?? activeSession?.repoPath ?? activeRepoPath ?? '',
+    [activeRepoPath, activeSession]
   );
   const fileViewerOpen = useMemo(() => openFileTabs.length > 0, [openFileTabs]);
 
@@ -247,6 +258,7 @@ function useTerminalDerivedState() {
     activeSessionId,
     activeSession,
     activeWorkspace,
+    allWorkspaceSessions,
     workspaceSessions,
     sessionTitle,
     activeSessionMode,
@@ -321,6 +333,155 @@ function SessionContent({
   );
 }
 
+const EMPTY_UTILITY_TERMINAL_IDS: string[] = [];
+
+function getUtilityTerminalIds(
+  railState: WorkspaceUtilityRailState
+): string[] {
+  return railState.utilityTerminalIds ?? EMPTY_UTILITY_TERMINAL_IDS;
+}
+
+function isUtilityRailResizable(state: WorkspaceUtilityRailState): boolean {
+  return state.visible && state.selectedRailTab !== null;
+}
+
+function toggleUtilityRailForWorkspace(
+  workspacePath: string,
+  toggleUtilityRailVisible: (workspacePath: string) => void
+): void {
+  if (workspacePath) toggleUtilityRailVisible(workspacePath);
+}
+
+interface UtilityTerminalHandlerOptions {
+  activeWorkspaceCwd: string;
+  activeWorkspace?: Repo | undefined;
+  activeSession?: SessionSummary | undefined;
+  addUtilityTerminal: (workspacePath: string, sessionId: string) => void;
+  selectUtilityTerminal: (workspacePath: string, sessionId: string) => void;
+  removeUtilityTerminal: (workspacePath: string, sessionId: string) => void;
+  promoteUtilityTerminal: (workspacePath: string, sessionId: string) => void;
+  onSelectSession: (id: string) => void;
+}
+
+function useUtilityTerminalHandlers({
+  activeWorkspaceCwd,
+  activeWorkspace,
+  activeSession,
+  addUtilityTerminal,
+  selectUtilityTerminal,
+  removeUtilityTerminal,
+  promoteUtilityTerminal,
+  onSelectSession,
+}: UtilityTerminalHandlerOptions) {
+  const handleCreateUtilityTerminal = useCallback(async () => {
+    if (!activeWorkspaceCwd) return;
+    const loadingKey = `utility-terminal:${activeWorkspaceCwd}`;
+    if (useSessionsStore.getState().isItemLoading(loadingKey)) return;
+    useSessionsStore.getState().setLoading(loadingKey);
+    try {
+      const { cols, rows } = estimateTerminalDimensions(
+        useUiStore.getState().terminalFontSize
+      );
+      const repoPath =
+        activeWorkspace?.path ?? activeSession?.repoPath ?? activeWorkspaceCwd;
+      const worktreePath = activeSession?.worktreePath ?? null;
+      const { session, error } = await createSessionWithoutActivation({
+        repoPath,
+        worktreePath,
+        type: 'terminal',
+        cols,
+        rows,
+      });
+      const isTerminalSession = session?.type === 'terminal';
+      if (isTerminalSession) {
+        addUtilityTerminal(activeWorkspaceCwd, session.id);
+        selectUtilityTerminal(activeWorkspaceCwd, session.id);
+        if (!error) {
+          useSessionsStore
+            .getState()
+            .initSessionNotification(
+              session.id,
+              useConfigStore.getState().defaultNotifications
+            );
+        }
+      }
+      if (error || (session && !isTerminalSession)) {
+        useToastStore
+          .getState()
+          .showToast(
+            error instanceof Error
+              ? error.message
+              : session && !isTerminalSession
+                ? 'created session was not a utility terminal'
+                : 'failed to create utility terminal'
+          );
+      }
+    } finally {
+      useSessionsStore.getState().clearLoading(loadingKey);
+    }
+  }, [
+    activeSession?.repoPath,
+    activeSession?.worktreePath,
+    activeWorkspace?.path,
+    activeWorkspaceCwd,
+    addUtilityTerminal,
+    selectUtilityTerminal,
+  ]);
+
+  const handleSelectUtilityTerminal = useCallback(
+    (sessionId: string) => {
+      if (activeWorkspaceCwd) selectUtilityTerminal(activeWorkspaceCwd, sessionId);
+    },
+    [activeWorkspaceCwd, selectUtilityTerminal]
+  );
+
+  const handleCloseUtilityTerminal = useCallback(
+    async (sessionId: string) => {
+      if (!activeWorkspaceCwd) return;
+      const previousRailState = useUiStore
+        .getState()
+        .getUtilityRailState(activeWorkspaceCwd);
+      removeUtilityTerminal(activeWorkspaceCwd, sessionId);
+      try {
+        await killSession(sessionId);
+        await useSessionsStore.getState().refreshAll();
+      } catch (error) {
+        useUiStore.setState({
+          utilityRailByWorkspace: {
+            ...useUiStore.getState().utilityRailByWorkspace,
+            [activeWorkspaceCwd]: previousRailState,
+          },
+        });
+        useUiStore.getState().saveUtilityRailState(activeWorkspaceCwd);
+        useToastStore
+          .getState()
+          .showToast(
+            error instanceof Error
+              ? error.message
+              : 'failed to close utility terminal'
+          );
+      }
+    },
+    [activeWorkspaceCwd, removeUtilityTerminal]
+  );
+
+  const handlePromoteUtilityTerminal = useCallback(
+    (sessionId: string) => {
+      if (!activeWorkspaceCwd) return;
+      promoteUtilityTerminal(activeWorkspaceCwd, sessionId);
+      onSelectSession(sessionId);
+    },
+    [activeWorkspaceCwd, onSelectSession, promoteUtilityTerminal]
+  );
+
+  return {
+    handleCreateUtilityTerminal,
+    handleSelectUtilityTerminal,
+    handleCloseUtilityTerminal,
+    handlePromoteUtilityTerminal,
+  };
+}
+
 // ─── TerminalAreaContent ──────────────────────────────────────────────────────
 // Extracted to reduce App's cyclomatic complexity. Accesses Zustand stores
 // directly to avoid a large prop surface; only truly local state/refs are passed.
@@ -368,6 +529,13 @@ function TerminalAreaContent({
   const hydrateUtilityRailState = useUiStore((s) => s.hydrateUtilityRailState);
   const setUtilityRailWidth = useUiStore((s) => s.setUtilityRailWidth);
   const saveUtilityRailState = useUiStore((s) => s.saveUtilityRailState);
+  const addUtilityTerminal = useUiStore((s) => s.addUtilityTerminal);
+  const selectUtilityTerminal = useUiStore((s) => s.selectUtilityTerminal);
+  const removeUtilityTerminal = useUiStore((s) => s.removeUtilityTerminal);
+  const promoteUtilityTerminal = useUiStore((s) => s.promoteUtilityTerminal);
+  const reconcileUtilityTerminals = useUiStore(
+    (s) => s.reconcileUtilityTerminals
+  );
   const toggleUtilityRailVisible = useUiStore(
     (s) => s.toggleUtilityRailVisible
   );
@@ -383,6 +551,7 @@ function TerminalAreaContent({
     activeSessionId,
     activeSession,
     activeWorkspace,
+    allWorkspaceSessions,
     workspaceSessions,
     sessionTitle,
     activeSessionMode,
@@ -479,11 +648,31 @@ function TerminalAreaContent({
     if (activeWorkspaceCwd) hydrateUtilityRailState(activeWorkspaceCwd);
   }, [activeWorkspaceCwd, hydrateUtilityRailState]);
 
+  useEffect(() => {
+    if (!activeWorkspaceCwd) return;
+    reconcileUtilityTerminals(
+      activeWorkspaceCwd,
+      new Set(
+        allWorkspaceSessions
+          .filter((session) => session.type === 'terminal')
+          .map((session) => session.id)
+      )
+    );
+  }, [activeWorkspaceCwd, allWorkspaceSessions, reconcileUtilityTerminals]);
+
   const utilityRailState =
     utilityRailWorkspaceState ?? DEFAULT_UTILITY_RAIL_STATE;
+  const utilityTerminalIds = getUtilityTerminalIds(utilityRailState);
+  const mainWorkspaceSessions = useMemo(
+    () => getMainWorkspaceSessions(workspaceSessions, utilityTerminalIds),
+    [workspaceSessions, utilityTerminalIds]
+  );
+  const utilityTerminalSessions = useMemo(
+    () => getUtilityTerminalSessions(allWorkspaceSessions, utilityTerminalIds),
+    [allWorkspaceSessions, utilityTerminalIds]
+  );
   const utilityRailWidth = utilityRailRenderedWidth(utilityRailState);
-  const utilityRailResizable =
-    utilityRailState.visible && utilityRailState.selectedRailTab !== null;
+  const utilityRailResizable = isUtilityRailResizable(utilityRailState);
 
   const handleUtilityRailWidthChange = useCallback(
     (width: number) => {
@@ -499,8 +688,24 @@ function TerminalAreaContent({
   }, [activeWorkspaceCwd, saveUtilityRailState, utilityRailResizable]);
 
   const handleToggleUtilityRail = useCallback(() => {
-    if (activeWorkspaceCwd) toggleUtilityRailVisible(activeWorkspaceCwd);
+    toggleUtilityRailForWorkspace(activeWorkspaceCwd, toggleUtilityRailVisible);
   }, [activeWorkspaceCwd, toggleUtilityRailVisible]);
+
+  const {
+    handleCreateUtilityTerminal,
+    handleSelectUtilityTerminal,
+    handleCloseUtilityTerminal,
+    handlePromoteUtilityTerminal,
+  } = useUtilityTerminalHandlers({
+    activeWorkspaceCwd,
+    ...(activeWorkspace ? { activeWorkspace } : {}),
+    ...(activeSession ? { activeSession } : {}),
+    addUtilityTerminal,
+    selectUtilityTerminal,
+    removeUtilityTerminal,
+    promoteUtilityTerminal,
+    onSelectSession,
+  });
 
   return (
     <div className="terminal-area">
@@ -593,7 +798,7 @@ function TerminalAreaContent({
                 <>
                   <WorkspaceArea
                     workspacePath={activeWorkspaceCwd}
-                    sessions={workspaceSessions}
+                    sessions={mainWorkspaceSessions}
                     onInjectReference={handleInjectReference}
                     onImageUpload={onImageUpload}
                     onCopyModeChange={handleCopyModeChange}
@@ -622,7 +827,7 @@ function TerminalAreaContent({
               ) : (
                 <>
                   <SessionTabBar
-                    sessions={workspaceSessions}
+                    sessions={mainWorkspaceSessions}
                     activeSessionId={activeSessionId}
                     onSelectSession={onSelectSession}
                     onCloseSession={onCloseSession}
@@ -676,7 +881,15 @@ function TerminalAreaContent({
                 workspacePath={activeWorkspaceCwd}
                 railState={utilityRailState}
                 activeSession={activeSession}
-                workspaceSessions={workspaceSessions}
+                workspaceSessions={mainWorkspaceSessions}
+                utilityTerminalSessions={utilityTerminalSessions}
+                onCreateUtilityTerminal={handleCreateUtilityTerminal}
+                onSelectUtilityTerminal={handleSelectUtilityTerminal}
+                onCloseUtilityTerminal={handleCloseUtilityTerminal}
+                onPromoteUtilityTerminal={handlePromoteUtilityTerminal}
+                onImageUpload={onImageUpload}
+                onCopyModeChange={handleCopyModeChange}
+                onFilePathClick={handleTerminalFilePathClick}
               />
             }
           />
@@ -759,8 +972,8 @@ export default function App() {
 
   // Active workspace cwd — use worktreePath/repoPath (stable root), not cwd which can drift
   const activeWorkspaceCwd = useMemo(
-    () => activeSession?.worktreePath ?? activeSession?.repoPath ?? '',
-    [activeSession]
+    () => activeSession?.worktreePath ?? activeSession?.repoPath ?? activeRepoPath ?? '',
+    [activeRepoPath, activeSession]
   );
 
   // ── Action context ─────────────────────────────────────────────────────────

--- a/frontend/src/components/WorkspaceUtilityRail.css
+++ b/frontend/src/components/WorkspaceUtilityRail.css
@@ -231,6 +231,107 @@
   font-size: var(--font-size-xs, 0.75rem);
 }
 
+.utility-terminal-panel {
+  height: 100%;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  background: var(--bg, #000);
+}
+
+.utility-terminal-toolbar {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: stretch;
+  gap: 6px;
+  padding: 6px;
+  border-bottom: 1px solid var(--border, #333);
+}
+
+.utility-terminal-tabs {
+  min-width: 0;
+  display: flex;
+  gap: 4px;
+  overflow-x: auto;
+}
+
+.utility-terminal-tab-shell {
+  min-width: 92px;
+  max-width: 160px;
+  height: 28px;
+  display: inline-flex;
+  align-items: stretch;
+  background: transparent;
+  border: 1px solid var(--border, #333);
+  border-radius: 0;
+  color: var(--text-muted, #888);
+}
+
+.utility-terminal-tab-shell:hover,
+.utility-terminal-tab-shell--active {
+  color: var(--text, #e0e0e0);
+  border-color: var(--accent, #d97757);
+}
+
+.utility-terminal-tab {
+  min-width: 0;
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 6px;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  color: inherit;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs, 0.75rem);
+  cursor: pointer;
+}
+
+.utility-terminal-title {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+}
+
+.utility-terminal-close {
+  width: 24px;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  border-left: 1px solid var(--border, #333);
+  border-radius: 0;
+  color: var(--text-muted, #888);
+  font-family: var(--font-mono, monospace);
+  line-height: 1;
+  cursor: pointer;
+}
+
+.utility-terminal-close:hover {
+  color: var(--status-error, #f87171);
+}
+
+.utility-terminal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 6px;
+  border-bottom: 1px solid var(--border, #333);
+}
+
+.utility-terminal-body {
+  min-height: 0;
+  min-width: 0;
+}
+
+.utility-terminal-body .terminal-wrapper {
+  height: 100%;
+}
+
 @media (max-width: 767px) {
   .workspace-utility-rail {
     flex: 1 1 auto;

--- a/frontend/src/components/WorkspaceUtilityRail.tsx
+++ b/frontend/src/components/WorkspaceUtilityRail.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useEffectEvent } from 'react';
 import type { SessionSummary } from '../lib/types.js';
 import {
   useUiStore,
@@ -13,7 +13,9 @@ import UtilityRailBranchPanel from './UtilityRailBranchPanel.js';
 import UtilityRailReviewPanel from './UtilityRailReviewPanel.js';
 import UtilityRailLogsPanel from './UtilityRailLogsPanel.js';
 import UtilityRailStatsPanel from './UtilityRailStatsPanel.js';
+import Terminal from './Terminal.js';
 import Tooltip from './Tooltip.js';
+import { getUtilityTerminalTitle } from '../lib/utility-terminals.js';
 import './WorkspaceUtilityRail.css';
 
 const TAB_META: Array<{
@@ -93,6 +95,16 @@ const TAB_META: Array<{
       </svg>
     ),
   },
+  {
+    id: 'terminal',
+    label: 'terminal',
+    icon: (
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M4 17l6-6-6-6" />
+        <path d="M12 19h8" />
+      </svg>
+    ),
+  },
 ];
 
 export interface WorkspaceUtilityRailProps {
@@ -100,7 +112,169 @@ export interface WorkspaceUtilityRailProps {
   railState: WorkspaceUtilityRailState;
   activeSession?: SessionSummary | undefined;
   workspaceSessions: SessionSummary[];
+  utilityTerminalSessions?: SessionSummary[];
   fileTreeSidebarRef?: React.RefObject<FileTreeHandle | null>;
+  onCreateUtilityTerminal?: () => void | Promise<void>;
+  onSelectUtilityTerminal?: (sessionId: string) => void;
+  onCloseUtilityTerminal?: (sessionId: string) => void | Promise<void>;
+  onPromoteUtilityTerminal?: (sessionId: string) => void;
+  onImageUpload?: (text: string, showInsert: boolean, path?: string) => void;
+  onCopyModeChange?: (active: boolean) => void;
+  onFilePathClick?: (path: string) => void;
+}
+
+interface UtilityRailTerminalPanelProps {
+  workspacePath: string;
+  railState: WorkspaceUtilityRailState;
+  sessions: SessionSummary[];
+  onCreateUtilityTerminal?: () => void | Promise<void>;
+  onSelectUtilityTerminal?: (sessionId: string) => void;
+  onCloseUtilityTerminal?: (sessionId: string) => void | Promise<void>;
+  onPromoteUtilityTerminal?: (sessionId: string) => void;
+  onImageUpload?: (text: string, showInsert: boolean, path?: string) => void;
+  onCopyModeChange?: (active: boolean) => void;
+  onFilePathClick?: (path: string) => void;
+}
+
+function UtilityRailTerminalPanel({
+  workspacePath,
+  railState,
+  sessions,
+  onCreateUtilityTerminal,
+  onSelectUtilityTerminal,
+  onCloseUtilityTerminal,
+  onPromoteUtilityTerminal,
+  onImageUpload,
+  onCopyModeChange,
+  onFilePathClick,
+}: UtilityRailTerminalPanelProps) {
+  const selectedSession =
+    sessions.find((session) => session.id === railState.selectedUtilityTerminalId) ??
+    sessions[0];
+  const notifyCopyModeInactive = useEffectEvent(() => {
+    onCopyModeChange?.(false);
+  });
+
+  useEffect(() => {
+    return () => notifyCopyModeInactive();
+  }, []);
+
+  const handleTerminalTabKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+      if (sessions.length === 0) return;
+      let nextIndex: number | null = null;
+      if (event.key === 'ArrowRight') {
+        nextIndex = (index + 1) % sessions.length;
+      } else if (event.key === 'ArrowLeft') {
+        nextIndex = (index - 1 + sessions.length) % sessions.length;
+      } else if (event.key === 'Home') {
+        nextIndex = 0;
+      } else if (event.key === 'End') {
+        nextIndex = sessions.length - 1;
+      }
+      if (nextIndex === null) return;
+      event.preventDefault();
+      const nextSession = sessions[nextIndex];
+      if (!nextSession) return;
+      onSelectUtilityTerminal?.(nextSession.id);
+      requestAnimationFrame(() => {
+        document.getElementById(`utility-terminal-tab-${nextSession.id}`)?.focus();
+      });
+    },
+    [onSelectUtilityTerminal, sessions]
+  );
+
+  return (
+    <div className="utility-terminal-panel">
+      <div className="utility-terminal-toolbar">
+        <div
+          className="utility-terminal-tabs"
+          role="tablist"
+          aria-label="utility terminals"
+        >
+          {sessions.map((session, index) => {
+            const title = getUtilityTerminalTitle(session, index, workspacePath);
+            const selected = session.id === selectedSession?.id;
+            return (
+              <div
+                key={session.id}
+                className={[
+                  'utility-terminal-tab-shell',
+                  selected && 'utility-terminal-tab-shell--active',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              >
+                <button
+                  id={`utility-terminal-tab-${session.id}`}
+                  className="utility-terminal-tab"
+                  type="button"
+                  role="tab"
+                  aria-selected={selected}
+                  aria-label={title}
+                  tabIndex={selected ? 0 : -1}
+                  onClick={() => onSelectUtilityTerminal?.(session.id)}
+                  onKeyDown={(event) =>
+                    handleTerminalTabKeyDown(event, index)
+                  }
+                >
+                  <span className="utility-terminal-title">{title}</span>
+                </button>
+                <button
+                  className="utility-terminal-close"
+                  type="button"
+                  aria-label={`close ${title}`}
+                  onClick={() => void onCloseUtilityTerminal?.(session.id)}
+                >
+                  ×
+                </button>
+              </div>
+            );
+          })}
+        </div>
+        <button
+          className="utility-panel-btn"
+          type="button"
+          onClick={() => void onCreateUtilityTerminal?.()}
+        >
+          + terminal
+        </button>
+      </div>
+      {selectedSession ? (
+        <>
+          <div className="utility-terminal-actions">
+            <button
+              className="utility-panel-btn"
+              type="button"
+              onClick={() => onPromoteUtilityTerminal?.(selectedSession.id)}
+            >
+              promote
+            </button>
+          </div>
+          <div className="utility-terminal-body">
+            <Terminal
+              sessionId={selectedSession.id}
+              useTmux={selectedSession.useTmux !== false}
+              {...(onImageUpload ? { onImageUpload } : {})}
+              {...(onCopyModeChange ? { onCopyModeChange } : {})}
+              {...(onFilePathClick ? { onFilePathClick } : {})}
+            />
+          </div>
+        </>
+      ) : (
+        <div className="utility-empty">
+          <p>no utility terminals yet.</p>
+          <button
+            className="utility-panel-btn"
+            type="button"
+            onClick={() => void onCreateUtilityTerminal?.()}
+          >
+            + terminal
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function utilityRailRenderedWidth(
@@ -115,7 +289,15 @@ export function WorkspaceUtilityRail({
   railState,
   activeSession,
   workspaceSessions,
+  utilityTerminalSessions = [],
   fileTreeSidebarRef,
+  onCreateUtilityTerminal,
+  onSelectUtilityTerminal,
+  onCloseUtilityTerminal,
+  onPromoteUtilityTerminal,
+  onImageUpload,
+  onCopyModeChange,
+  onFilePathClick,
 }: WorkspaceUtilityRailProps) {
   const setSelectedUtilityRailTab = useUiStore(
     (s) => s.setSelectedUtilityRailTab
@@ -242,6 +424,29 @@ export function WorkspaceUtilityRail({
               activeSession={activeSession}
               workspaceSessions={workspaceSessions}
             />
+          </div>
+          <div
+            id="utility-rail-panel-terminal"
+            className="utility-pane-panel"
+            role="tabpanel"
+            aria-labelledby="utility-rail-tab-terminal"
+            tabIndex={selectedTab === 'terminal' ? 0 : -1}
+            hidden={selectedTab !== 'terminal'}
+          >
+            {selectedTab === 'terminal' && (
+              <UtilityRailTerminalPanel
+                workspacePath={workspacePath}
+                railState={railState}
+                sessions={utilityTerminalSessions}
+                {...(onCreateUtilityTerminal ? { onCreateUtilityTerminal } : {})}
+                {...(onSelectUtilityTerminal ? { onSelectUtilityTerminal } : {})}
+                {...(onCloseUtilityTerminal ? { onCloseUtilityTerminal } : {})}
+                {...(onPromoteUtilityTerminal ? { onPromoteUtilityTerminal } : {})}
+                {...(onImageUpload ? { onImageUpload } : {})}
+                {...(onCopyModeChange ? { onCopyModeChange } : {})}
+                {...(onFilePathClick ? { onFilePathClick } : {})}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -573,8 +573,13 @@ export function useSessionHandlers({
       .sessions.find((s) => s.id === sessionId);
     if (!session) return;
 
-    // Kill the session
-    await killSession(sessionId);
+    // Kill the session. Archive still proceeds to worktree cleanup if the
+    // session was already gone or the backend close fails.
+    try {
+      await killSession(sessionId);
+    } catch (error) {
+      logger.warn('Failed to close session before archive:', error);
+    }
 
     // If worktree session, delete the worktree too
     if (session.worktreePath !== null) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -516,7 +516,8 @@ export async function createSession(body: {
 }
 
 export async function killSession(id: string): Promise<void> {
-  await fetch('/sessions/' + id, { method: 'DELETE' });
+  const res = await fetch('/sessions/' + id, { method: 'DELETE' });
+  if (!res.ok) throw await httpErrorFromResponse(res, 'Failed to close session');
 }
 
 export async function renameSession(

--- a/frontend/src/lib/session-utils.ts
+++ b/frontend/src/lib/session-utils.ts
@@ -64,6 +64,58 @@ export function getCurrentSessionContext(): CurrentSessionContext {
   };
 }
 
+function restoreSessionPlacement(
+  activeSessionId: string | null,
+  workspaceLastSession: Record<string, string>
+): void {
+  const liveIds = new Set(useSessionsStore.getState().sessions.map((s) => s.id));
+  useSessionsStore.setState({
+    activeSessionId:
+      activeSessionId && liveIds.has(activeSessionId) ? activeSessionId : null,
+    workspaceLastSession: Object.fromEntries(
+      Object.entries(workspaceLastSession).filter(([, id]) => liveIds.has(id))
+    ),
+  });
+}
+
+export async function createSessionWithoutActivation(
+  options: CreateAgentSessionOptions
+): Promise<CreateAgentSessionResult> {
+  const before = useSessionsStore.getState();
+  const activeSessionId = before.activeSessionId;
+  const workspaceLastSession = { ...before.workspaceLastSession };
+  try {
+    const session = await createSessionApi(options);
+    let refreshError: unknown = null;
+    try {
+      await useSessionsStore.getState().refreshAll();
+    } catch (error) {
+      refreshError = error;
+    }
+    restoreSessionPlacement(activeSessionId, workspaceLastSession);
+    return { session, error: refreshError };
+  } catch (error) {
+    if (error instanceof ConflictError) {
+      let refreshError: unknown = null;
+      try {
+        await useSessionsStore.getState().refreshAll();
+      } catch (caughtRefreshError) {
+        refreshError = caughtRefreshError;
+      }
+      const conflictingSessionId = error.sessionId;
+      const session = conflictingSessionId
+        ? useSessionsStore
+            .getState()
+            .sessions.find((existing) => existing.id === conflictingSessionId)
+        : undefined;
+      restoreSessionPlacement(activeSessionId, workspaceLastSession);
+      return { session, error: refreshError ?? error };
+    }
+
+    return { session: undefined, error };
+  }
+}
+
 export async function createAgentSession(
   options: CreateAgentSessionOptions
 ): Promise<CreateAgentSessionResult> {

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -41,7 +41,8 @@ export type UtilityRailTab =
   | 'branch'
   | 'review'
   | 'logs'
-  | 'stats';
+  | 'stats'
+  | 'terminal';
 
 export interface WorkspaceReviewState {
   activeFilePath: string | null;
@@ -71,6 +72,8 @@ export interface WorkspaceUtilityRailState {
   reviewFilePath?: string;
   filesMode?: 'changes' | 'all-files';
   branchBase?: string;
+  utilityTerminalIds?: string[];
+  selectedUtilityTerminalId?: string | null;
 }
 
 export interface OpenUtilityRailTabOptions {
@@ -202,6 +205,7 @@ const UTILITY_RAIL_TABS: UtilityRailTab[] = [
   'review',
   'logs',
   'stats',
+  'terminal',
 ];
 
 function isUtilityRailTab(value: unknown): value is UtilityRailTab {
@@ -287,6 +291,55 @@ function normalizeReviewState(
   return next;
 }
 
+function normalizeAnchoredPaneWidths(
+  value: Partial<Record<UtilityRailTab, number>> | undefined
+): Partial<Record<UtilityRailTab, number>> | undefined {
+  if (!value) return undefined;
+  const anchoredPaneWidths: Partial<Record<UtilityRailTab, number>> = {};
+  for (const tab of UTILITY_RAIL_TABS) {
+    const width = value[tab];
+    if (typeof width === 'number') {
+      anchoredPaneWidths[tab] = clampUtilityRailWidth(width);
+    }
+  }
+  return Object.keys(anchoredPaneWidths).length > 0
+    ? anchoredPaneWidths
+    : undefined;
+}
+
+function isUtilitySurfacePlacement(
+  placement: UtilitySurfacePlacement | undefined
+): placement is UtilitySurfacePlacement {
+  return (
+    !!placement &&
+    (placement.kind === 'rail' ||
+      (placement.kind === 'anchored-pane' &&
+        typeof placement.paneId === 'string'))
+  );
+}
+
+function normalizePlacements(
+  value: Partial<Record<UtilityRailTab, UtilitySurfacePlacement>> | undefined
+): Partial<Record<UtilityRailTab, UtilitySurfacePlacement>> | undefined {
+  if (!value) return undefined;
+  const placements: Partial<Record<UtilityRailTab, UtilitySurfacePlacement>> = {};
+  for (const tab of UTILITY_RAIL_TABS) {
+    const placement = value[tab];
+    if (isUtilitySurfacePlacement(placement)) placements[tab] = placement;
+  }
+  return Object.keys(placements).length > 0 ? placements : undefined;
+}
+
+function normalizeUtilityTerminalIds(ids: unknown): string[] | undefined {
+  if (!Array.isArray(ids)) return undefined;
+  const uniqueTerminalIds = Array.from(
+    new Set(
+      ids.filter((id): id is string => typeof id === 'string' && id.length > 0)
+    )
+  );
+  return uniqueTerminalIds.length > 0 ? uniqueTerminalIds : undefined;
+}
+
 function normalizeUtilityRailState(
   value: Partial<WorkspaceUtilityRailState> | null | undefined
 ): WorkspaceUtilityRailState {
@@ -301,33 +354,10 @@ function normalizeUtilityRailState(
       : next.selectedRailTab;
   next.width = clampUtilityRailWidth(value.width ?? next.width);
 
-  if (value.anchoredPaneWidths) {
-    const anchoredPaneWidths: Partial<Record<UtilityRailTab, number>> = {};
-    for (const tab of UTILITY_RAIL_TABS) {
-      const width = value.anchoredPaneWidths[tab];
-      if (typeof width === 'number')
-        anchoredPaneWidths[tab] = clampUtilityRailWidth(width);
-    }
-    if (Object.keys(anchoredPaneWidths).length > 0)
-      next.anchoredPaneWidths = anchoredPaneWidths;
-  }
-
-  if (value.placements) {
-    const placements: Partial<Record<UtilityRailTab, UtilitySurfacePlacement>> =
-      {};
-    for (const tab of UTILITY_RAIL_TABS) {
-      const placement = value.placements[tab];
-      if (
-        placement &&
-        (placement.kind === 'rail' ||
-          (placement.kind === 'anchored-pane' &&
-            typeof placement.paneId === 'string'))
-      ) {
-        placements[tab] = placement;
-      }
-    }
-    if (Object.keys(placements).length > 0) next.placements = placements;
-  }
+  const anchoredPaneWidths = normalizeAnchoredPaneWidths(value.anchoredPaneWidths);
+  if (anchoredPaneWidths) next.anchoredPaneWidths = anchoredPaneWidths;
+  const placements = normalizePlacements(value.placements);
+  if (placements) next.placements = placements;
 
   next.review = normalizeReviewState(value.review, value.reviewFilePath);
   if (next.review.activeFilePath !== null) {
@@ -340,7 +370,31 @@ function normalizeUtilityRailState(
     next.branchBase = value.branchBase;
   }
 
+  const utilityTerminalIds = normalizeUtilityTerminalIds(value.utilityTerminalIds);
+  if (utilityTerminalIds) {
+    next.utilityTerminalIds = utilityTerminalIds;
+    next.selectedUtilityTerminalId = utilityTerminalIds.includes(
+      value.selectedUtilityTerminalId ?? ''
+    )
+      ? (value.selectedUtilityTerminalId ?? null)
+      : utilityTerminalIds[0]!;
+  }
+
   return next;
+}
+
+function syncSelectedUtilityTerminal(
+  state: WorkspaceUtilityRailState
+): void {
+  const ids = state.utilityTerminalIds ?? [];
+  if (ids.length === 0) {
+    delete state.utilityTerminalIds;
+    delete state.selectedUtilityTerminalId;
+    return;
+  }
+  if (!state.selectedUtilityTerminalId || !ids.includes(state.selectedUtilityTerminalId)) {
+    state.selectedUtilityTerminalId = ids[0]!;
+  }
 }
 
 function loadUtilityRailState(
@@ -454,6 +508,14 @@ export interface UiState {
   setReviewDiffSource: (workspacePath: string, source: DiffSource) => void;
   setReviewDefaultBranch: (workspacePath: string, branch: string) => void;
   setReviewCurrentHunkIndex: (workspacePath: string, index: number) => void;
+  addUtilityTerminal: (workspacePath: string, sessionId: string) => void;
+  selectUtilityTerminal: (workspacePath: string, sessionId: string) => void;
+  removeUtilityTerminal: (workspacePath: string, sessionId: string) => void;
+  promoteUtilityTerminal: (workspacePath: string, sessionId: string) => void;
+  reconcileUtilityTerminals: (
+    workspacePath: string,
+    liveTerminalSessionIds: Set<string>
+  ) => void;
   openFileTabs: OpenFileTab[];
   activeFileTabKey: string | null;
   fileViewerRatio: number;
@@ -838,6 +900,93 @@ export const useUiStore = create<UiState>()((set, get) => ({
       },
     });
   },
+  addUtilityTerminal: (workspacePath, sessionId) => {
+    const nextState = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        const ids = state.utilityTerminalIds
+          ? [...state.utilityTerminalIds]
+          : [];
+        if (!ids.includes(sessionId)) ids.push(sessionId);
+        state.utilityTerminalIds = ids;
+        state.selectedUtilityTerminalId ??= ids[0] ?? sessionId;
+        state.visible = true;
+        state.selectedRailTab = 'terminal';
+        syncSelectedUtilityTerminal(state);
+      }
+    );
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: nextState,
+      },
+    });
+  },
+  selectUtilityTerminal: (workspacePath, sessionId) => {
+    const nextState = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        if (state.utilityTerminalIds?.includes(sessionId)) {
+          state.selectedUtilityTerminalId = sessionId;
+          state.visible = true;
+          state.selectedRailTab = 'terminal';
+        }
+      }
+    );
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: nextState,
+      },
+    });
+  },
+  removeUtilityTerminal: (workspacePath, sessionId) => {
+    const nextState = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        state.utilityTerminalIds = (state.utilityTerminalIds ?? []).filter(
+          (id) => id !== sessionId
+        );
+        if (state.selectedUtilityTerminalId === sessionId) {
+          state.selectedUtilityTerminalId = state.utilityTerminalIds[0] ?? null;
+        }
+        syncSelectedUtilityTerminal(state);
+      }
+    );
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: nextState,
+      },
+    });
+  },
+  promoteUtilityTerminal: (workspacePath, sessionId) => {
+    get().removeUtilityTerminal(workspacePath, sessionId);
+  },
+  reconcileUtilityTerminals: (workspacePath, liveTerminalSessionIds) => {
+    const current = get().utilityRailByWorkspace[workspacePath];
+    const loaded = current ?? loadUtilityRailState(workspacePath);
+    if (!loaded.utilityTerminalIds?.length) return;
+    const nextState = mutateUtilityRailState(
+      workspacePath,
+      current,
+      (state) => {
+        state.utilityTerminalIds = (state.utilityTerminalIds ?? []).filter((id) =>
+          liveTerminalSessionIds.has(id)
+        );
+        syncSelectedUtilityTerminal(state);
+      }
+    );
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: nextState,
+      },
+    });
+  },
   setFileDiffSource: (source) => set({ fileDiffSource: source }),
   setFileDiffDefaultBranch: (branch) => set({ fileDiffDefaultBranch: branch }),
   setLastChangedFiles: (files) => set({ lastChangedFiles: files }),
@@ -940,7 +1089,10 @@ export const useUiStore = create<UiState>()((set, get) => ({
     if (next.has(path)) next.delete(path);
     else next.add(path);
     try {
-      localStorage.setItem(COLLAPSED_WORKSPACES_KEY, JSON.stringify([...next]));
+      localStorage.setItem(
+        COLLAPSED_WORKSPACES_KEY,
+        JSON.stringify(Array.from(next))
+      );
     } catch {
       /* unavailable */
     }

--- a/frontend/src/lib/utility-terminals.ts
+++ b/frontend/src/lib/utility-terminals.ts
@@ -1,0 +1,43 @@
+import type { SessionSummary } from './types.js';
+
+export function getMainWorkspaceSessions(
+  sessions: SessionSummary[],
+  utilityTerminalIds: readonly string[] | undefined
+): SessionSummary[] {
+  if (!utilityTerminalIds?.length) return sessions;
+  const utilityIds = new Set(utilityTerminalIds);
+  return sessions.filter(
+    (session) => !(session.type === 'terminal' && utilityIds.has(session.id))
+  );
+}
+
+export function getUtilityTerminalSessions(
+  sessions: SessionSummary[],
+  utilityTerminalIds: readonly string[] | undefined
+): SessionSummary[] {
+  if (!utilityTerminalIds?.length) return [];
+  const byId = new Map(sessions.map((session) => [session.id, session]));
+  return utilityTerminalIds.flatMap((id) => {
+    const session = byId.get(id);
+    return session?.type === 'terminal' ? [session] : [];
+  });
+}
+
+function pathHint(session: SessionSummary, workspacePath: string): string | null {
+  const path = session.cwd || session.worktreePath || session.repoPath || workspacePath;
+  const cleaned = path.replace(/\/+$/, '');
+  const base = cleaned.split('/').filter(Boolean).at(-1);
+  return base || null;
+}
+
+export function getUtilityTerminalTitle(
+  session: SessionSummary,
+  index: number,
+  workspacePath: string
+): string {
+  const displayName = session.displayName?.trim();
+  if (displayName) return displayName;
+  const fallback = `terminal ${index + 1}`;
+  const hint = pathHint(session, workspacePath);
+  return hint ? `${fallback} · ${hint}` : fallback;
+}

--- a/test/session-utils.test.ts
+++ b/test/session-utils.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionSummary } from '../frontend/src/lib/types.js';
+
+const apiMocks = vi.hoisted(() => ({
+  createSession: vi.fn(),
+  fetchSessions: vi.fn(),
+  fetchWorktrees: vi.fn(),
+  fetchWorkspaces: vi.fn(),
+  fetchWorkspaceGroups: vi.fn(),
+  enrichBranches: vi.fn(),
+}));
+
+vi.mock('../frontend/src/lib/api.js', () => ({
+  ConflictError: class ConflictError extends Error {
+    sessionId: string;
+    constructor(sessionId: string) {
+      super('conflict');
+      this.sessionId = sessionId;
+    }
+  },
+  createSession: apiMocks.createSession,
+  fetchSessions: apiMocks.fetchSessions,
+  fetchWorktrees: apiMocks.fetchWorktrees,
+  fetchWorkspaces: apiMocks.fetchWorkspaces,
+  fetchWorkspaceGroups: apiMocks.fetchWorkspaceGroups,
+  enrichBranches: apiMocks.enrichBranches,
+}));
+
+const storage: Record<string, string> = {};
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: (key: string) => storage[key] ?? null,
+    setItem: (key: string, value: string) => {
+      storage[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete storage[key];
+    },
+  },
+  configurable: true,
+});
+
+import { ConflictError } from '../frontend/src/lib/api.js';
+import { createSessionWithoutActivation } from '../frontend/src/lib/session-utils.js';
+import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
+
+const originalRefreshAll = useSessionsStore.getState().refreshAll;
+
+function session(id: string, type: 'agent' | 'terminal' = 'terminal'): SessionSummary {
+  return {
+    id,
+    repoName: 'a',
+    repoPath: '/repo/a',
+    worktreePath: null,
+    cwd: '/repo/a',
+    status: 'active',
+    createdAt: '2026-05-05T00:00:00.000Z',
+    lastActivity: '2026-05-05T00:00:00.000Z',
+    branchName: 'nightly',
+    displayName: '',
+    idle: false,
+    agent: 'claude',
+    type,
+    mode: 'pty',
+    useTmux: true,
+  };
+}
+
+describe('createSessionWithoutActivation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of Object.keys(storage)) delete storage[key];
+    useSessionsStore.setState({
+      sessions: [session('main', 'agent')],
+      worktrees: [],
+      repos: [{ name: 'a', path: '/repo/a', isGitRepo: true, defaultBranch: 'nightly', currentBranch: 'nightly' }],
+      workspaceGroups: [],
+      activeSessionId: 'main',
+      workspaceLastSession: { '/repo/a': 'main' },
+      notificationSessions: {},
+      sidebarItems: [],
+      refreshAll: originalRefreshAll,
+    });
+    apiMocks.fetchWorktrees.mockResolvedValue([]);
+    apiMocks.fetchWorkspaces.mockResolvedValue([
+      { name: 'a', path: '/repo/a', isGitRepo: true, defaultBranch: 'nightly', currentBranch: 'nightly' },
+    ]);
+    apiMocks.fetchWorkspaceGroups.mockResolvedValue([]);
+  });
+
+  it('creates and refreshes a terminal session without changing active or recalled workspace session', async () => {
+    const created = session('utility');
+    apiMocks.createSession.mockResolvedValue(created);
+    apiMocks.fetchSessions.mockResolvedValue([session('main', 'agent'), created]);
+
+    const result = await createSessionWithoutActivation({
+      repoPath: '/repo/a',
+      worktreePath: null,
+      type: 'terminal',
+    });
+
+    expect(result.session?.id).toBe('utility');
+    expect(apiMocks.createSession).toHaveBeenCalledWith({
+      repoPath: '/repo/a',
+      worktreePath: null,
+      type: 'terminal',
+    });
+    expect(useSessionsStore.getState().activeSessionId).toBe('main');
+    expect(useSessionsStore.getState().workspaceLastSession['/repo/a']).toBe('main');
+    expect(storage['claude-remote-active-session']).toBe(undefined);
+  });
+
+  it('returns the created session and restores placement when refresh fails after create', async () => {
+    const created = session('utility');
+    const refreshError = new Error('refresh failed');
+    apiMocks.createSession.mockResolvedValue(created);
+    useSessionsStore.setState({
+      refreshAll: vi.fn().mockRejectedValue(refreshError),
+    });
+
+    const result = await createSessionWithoutActivation({
+      repoPath: '/repo/a',
+      type: 'terminal',
+    });
+
+    expect(result.session).toBe(created);
+    expect(result.error).toBe(refreshError);
+    expect(useSessionsStore.getState().activeSessionId).toBe('main');
+    expect(useSessionsStore.getState().workspaceLastSession['/repo/a']).toBe('main');
+  });
+
+  it('returns the conflicting session and ConflictError when refresh succeeds', async () => {
+    const conflict = new ConflictError('main');
+    apiMocks.createSession.mockRejectedValue(conflict);
+    apiMocks.fetchSessions.mockResolvedValue([session('main', 'agent')]);
+
+    const result = await createSessionWithoutActivation({
+      repoPath: '/repo/a',
+      type: 'terminal',
+    });
+
+    expect(result.session?.id).toBe('main');
+    expect(result.error).toBe(conflict);
+    expect(useSessionsStore.getState().activeSessionId).toBe('main');
+    expect(useSessionsStore.getState().workspaceLastSession['/repo/a']).toBe('main');
+  });
+
+  it('returns the conflicting session plus refresh error when conflict refresh fails', async () => {
+    const conflict = new ConflictError('main');
+    const refreshError = new Error('refresh failed');
+    apiMocks.createSession.mockRejectedValue(conflict);
+    useSessionsStore.setState({
+      refreshAll: vi.fn().mockRejectedValue(refreshError),
+    });
+
+    const result = await createSessionWithoutActivation({
+      repoPath: '/repo/a',
+      type: 'terminal',
+    });
+
+    expect(result.session?.id).toBe('main');
+    expect(result.error).toBe(refreshError);
+    expect(useSessionsStore.getState().activeSessionId).toBe('main');
+    expect(useSessionsStore.getState().workspaceLastSession['/repo/a']).toBe('main');
+  });
+
+  it('returns generic create errors without refreshing', async () => {
+    const createError = new Error('create failed');
+    const refreshAll = vi.fn();
+    apiMocks.createSession.mockRejectedValue(createError);
+    useSessionsStore.setState({ refreshAll });
+
+    const result = await createSessionWithoutActivation({
+      repoPath: '/repo/a',
+      type: 'terminal',
+    });
+
+    expect(result).toEqual({ session: undefined, error: createError });
+    expect(refreshAll).not.toHaveBeenCalled();
+  });
+});

--- a/test/stores/ui-store.test.ts
+++ b/test/stores/ui-store.test.ts
@@ -361,6 +361,82 @@ describe('ui Zustand store', () => {
         currentHunkIndex: 3,
       });
     });
+
+    it('tracks utility terminal membership, order, and selected id per workspace', () => {
+      useUiStore.getState().addUtilityTerminal('/repo/a', 'term-1');
+      useUiStore.getState().addUtilityTerminal('/repo/a', 'term-2');
+      useUiStore.getState().addUtilityTerminal('/repo/a', 'term-1');
+      useUiStore.getState().addUtilityTerminal('/repo/b', 'term-b');
+
+      expect(useUiStore.getState().getUtilityRailState('/repo/a')).toMatchObject({
+        selectedRailTab: 'terminal',
+        utilityTerminalIds: ['term-1', 'term-2'],
+        selectedUtilityTerminalId: 'term-1',
+      });
+      expect(useUiStore.getState().getUtilityRailState('/repo/b')).toMatchObject({
+        utilityTerminalIds: ['term-b'],
+        selectedUtilityTerminalId: 'term-b',
+      });
+      expect(storage['relay-utility-rail::/repo/a']).toContain(
+        '"utilityTerminalIds":["term-1","term-2"]'
+      );
+    });
+
+    it('selects, removes, promotes, and reconciles utility terminals without leaking stale ids', () => {
+      useUiStore.getState().addUtilityTerminal('/repo/a', 'term-1');
+      useUiStore.getState().addUtilityTerminal('/repo/a', 'term-2');
+      useUiStore.getState().selectUtilityTerminal('/repo/a', 'term-2');
+
+      expect(
+        useUiStore.getState().getUtilityRailState('/repo/a').selectedUtilityTerminalId
+      ).toBe('term-2');
+
+      useUiStore.getState().removeUtilityTerminal('/repo/a', 'term-2');
+      expect(useUiStore.getState().getUtilityRailState('/repo/a')).toMatchObject({
+        utilityTerminalIds: ['term-1'],
+        selectedUtilityTerminalId: 'term-1',
+      });
+
+      useUiStore.getState().addUtilityTerminal('/repo/a', 'term-3');
+      useUiStore.getState().promoteUtilityTerminal('/repo/a', 'term-1');
+      expect(useUiStore.getState().getUtilityRailState('/repo/a')).toMatchObject({
+        utilityTerminalIds: ['term-3'],
+        selectedUtilityTerminalId: 'term-3',
+      });
+
+      useUiStore.getState().reconcileUtilityTerminals('/repo/a', new Set(['term-9']));
+      expect(useUiStore.getState().getUtilityRailState('/repo/a')).not.toHaveProperty(
+        'utilityTerminalIds'
+      );
+      expect(
+        useUiStore.getState().getUtilityRailState('/repo/a')
+      ).not.toHaveProperty('selectedUtilityTerminalId');
+    });
+
+    it('reconciles stale persisted utility terminal ids after hydration', () => {
+      storage['relay-utility-rail::/repo/a'] = JSON.stringify({
+        visible: true,
+        selectedRailTab: 'terminal',
+        width: DEFAULT_UTILITY_RAIL_WIDTH,
+        utilityTerminalIds: ['stale-1', 'live-1', 'stale-2'],
+        selectedUtilityTerminalId: 'stale-1',
+      });
+
+      useUiStore.getState().hydrateUtilityRailState('/repo/a');
+      expect(useUiStore.getState().getUtilityRailState('/repo/a')).toMatchObject({
+        utilityTerminalIds: ['stale-1', 'live-1', 'stale-2'],
+        selectedUtilityTerminalId: 'stale-1',
+      });
+
+      useUiStore.getState().reconcileUtilityTerminals('/repo/a', new Set(['live-1']));
+      expect(useUiStore.getState().getUtilityRailState('/repo/a')).toMatchObject({
+        utilityTerminalIds: ['live-1'],
+        selectedUtilityTerminalId: 'live-1',
+      });
+      expect(storage['relay-utility-rail::/repo/a']).toContain(
+        '"utilityTerminalIds":["live-1"]'
+      );
+    });
   });
 
   describe('active workspace', () => {

--- a/test/utility-terminals.test.ts
+++ b/test/utility-terminals.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionSummary } from '../frontend/src/lib/types.js';
+import {
+  getMainWorkspaceSessions,
+  getUtilityTerminalSessions,
+  getUtilityTerminalTitle,
+} from '../frontend/src/lib/utility-terminals.js';
+
+function session(overrides: Partial<SessionSummary> & { id: string }): SessionSummary {
+  return {
+    id: overrides.id,
+    repoName: 'a',
+    repoPath: '/repo/a',
+    worktreePath: null,
+    cwd: '/repo/a',
+    status: 'active',
+    createdAt: '2026-05-05T00:00:00.000Z',
+    lastActivity: '2026-05-05T00:00:00.000Z',
+    branchName: 'nightly',
+    displayName: '',
+    idle: false,
+    agent: 'claude',
+    type: 'terminal',
+    mode: 'pty',
+    useTmux: true,
+    ...overrides,
+  };
+}
+
+describe('utility terminal placement helpers', () => {
+  it('keeps utility-owned terminal sessions out of main workspace sessions in persisted order', () => {
+    const sessions = [
+      session({ id: 'agent-1', type: 'agent' }),
+      session({ id: 'term-1' }),
+      session({ id: 'term-2' }),
+      session({ id: 'term-other-cwd', cwd: '/repo/a/.worktrees/other' }),
+    ];
+
+    expect(getMainWorkspaceSessions(sessions, ['term-2', 'term-1']).map((s) => s.id)).toEqual([
+      'agent-1',
+      'term-other-cwd',
+    ]);
+    expect(getUtilityTerminalSessions(sessions, ['term-2', 'term-1']).map((s) => s.id)).toEqual([
+      'term-2',
+      'term-1',
+    ]);
+  });
+
+  it('treats promotion as an exclusive move back to main workspace sessions', () => {
+    const sessions = [
+      session({ id: 'agent-1', type: 'agent' }),
+      session({ id: 'term-1' }),
+    ];
+
+    expect(getUtilityTerminalSessions(sessions, ['term-1']).map((s) => s.id)).toEqual([
+      'term-1',
+    ]);
+    expect(getMainWorkspaceSessions(sessions, ['term-1']).map((s) => s.id)).toEqual([
+      'agent-1',
+    ]);
+
+    expect(getUtilityTerminalSessions(sessions, []).map((s) => s.id)).toEqual([]);
+    expect(getMainWorkspaceSessions(sessions, []).map((s) => s.id)).toEqual([
+      'agent-1',
+      'term-1',
+    ]);
+  });
+
+  it('does not claim non-terminal or missing stale utility ids', () => {
+    const sessions = [
+      session({ id: 'agent-1', type: 'agent' }),
+      session({ id: 'term-1' }),
+    ];
+
+    expect(getUtilityTerminalSessions(sessions, ['missing', 'agent-1', 'term-1']).map((s) => s.id)).toEqual([
+      'term-1',
+    ]);
+    expect(getMainWorkspaceSessions(sessions, ['missing', 'agent-1', 'term-1']).map((s) => s.id)).toEqual([
+      'agent-1',
+    ]);
+  });
+
+  it('uses display names first and deterministic lowercase fallback titles otherwise', () => {
+    expect(
+      getUtilityTerminalTitle(session({ id: 'renamed', displayName: 'db shell' }), 0, '/repo/a')
+    ).toBe('db shell');
+    expect(getUtilityTerminalTitle(session({ id: 'plain' }), 1, '/repo/a')).toBe(
+      'terminal 2 · a'
+    );
+    expect(
+      getUtilityTerminalTitle(session({ id: 'wt', cwd: '/repo/a/.worktrees/mountain' }), 0, '/repo/a')
+    ).toBe('terminal 1 · mountain');
+  });
+});

--- a/test/workspace-utility-rail-terminal.test.ts
+++ b/test/workspace-utility-rail-terminal.test.ts
@@ -1,0 +1,215 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionSummary } from '../frontend/src/lib/types.js';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../frontend/src/components/UtilityRailFilesPanel.js', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'files-panel' }),
+}));
+vi.mock('../frontend/src/components/UtilityRailGitChangesPanel.js', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'changes-panel' }),
+}));
+vi.mock('../frontend/src/components/UtilityRailBranchPanel.js', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'branch-panel' }),
+}));
+vi.mock('../frontend/src/components/UtilityRailReviewPanel.js', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'review-panel' }),
+}));
+vi.mock('../frontend/src/components/UtilityRailLogsPanel.js', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'logs-panel' }),
+}));
+vi.mock('../frontend/src/components/UtilityRailStatsPanel.js', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'stats-panel' }),
+}));
+
+vi.mock('../frontend/src/components/Terminal.js', () => ({
+  default: ({ sessionId }: { sessionId: string | null }) =>
+    React.createElement('div', {
+      'data-testid': 'utility-terminal-mount',
+      'data-session-id': sessionId ?? '',
+    }),
+}));
+
+import { WorkspaceUtilityRail } from '../frontend/src/components/WorkspaceUtilityRail.js';
+import type { WorkspaceUtilityRailState } from '../frontend/src/lib/stores/ui.js';
+
+function session(overrides: Partial<SessionSummary> & { id: string }): SessionSummary {
+  return {
+    id: overrides.id,
+    repoName: 'a',
+    repoPath: '/repo/a',
+    worktreePath: null,
+    cwd: '/repo/a',
+    status: 'active',
+    createdAt: '2026-05-05T00:00:00.000Z',
+    lastActivity: '2026-05-05T00:00:00.000Z',
+    branchName: 'nightly',
+    displayName: '',
+    idle: false,
+    agent: 'claude',
+    type: 'terminal',
+    mode: 'pty',
+    useTmux: true,
+    ...overrides,
+  };
+}
+
+function railState(overrides: Partial<WorkspaceUtilityRailState> = {}): WorkspaceUtilityRailState {
+  return {
+    visible: true,
+    selectedRailTab: 'terminal',
+    width: 320,
+    utilityTerminalIds: ['term-1', 'term-2'],
+    selectedUtilityTerminalId: 'term-2',
+    ...overrides,
+  };
+}
+
+describe('WorkspaceUtilityRail utility terminal panel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('mounts only the selected utility terminal and wires close/promote callbacks', async () => {
+    const onCloseUtilityTerminal = vi.fn();
+    const onPromoteUtilityTerminal = vi.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(WorkspaceUtilityRail, {
+          workspacePath: '/repo/a',
+          railState: railState(),
+          activeSession: session({ id: 'agent-1', type: 'agent' }),
+          workspaceSessions: [session({ id: 'agent-1', type: 'agent' })],
+          utilityTerminalSessions: [
+            session({ id: 'term-1' }),
+            session({ id: 'term-2', displayName: 'db shell' }),
+          ],
+          onCloseUtilityTerminal,
+          onPromoteUtilityTerminal,
+        })
+      );
+    });
+
+    expect(
+      container
+        .querySelector('[data-testid="utility-terminal-mount"]')
+        ?.getAttribute('data-session-id')
+    ).toBe('term-2');
+    expect(container.textContent).toContain('terminal 1 · a');
+    expect(container.textContent).toContain('db shell');
+
+    await act(async () => {
+      (container.querySelector('button[aria-label="close db shell"]') as HTMLButtonElement).click();
+    });
+    expect(onCloseUtilityTerminal).toHaveBeenCalledWith('term-2');
+
+    await act(async () => {
+      (container.querySelector('.utility-terminal-actions button') as HTMLButtonElement).click();
+    });
+    expect(onPromoteUtilityTerminal).toHaveBeenCalledWith('term-2');
+  });
+
+  it('renders an empty state that creates utility terminals without mounting a PTY', async () => {
+    const onCreateUtilityTerminal = vi.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(WorkspaceUtilityRail, {
+          workspacePath: '/repo/a',
+          railState: railState({
+            utilityTerminalIds: [],
+            selectedUtilityTerminalId: null,
+          }),
+          workspaceSessions: [],
+          utilityTerminalSessions: [],
+          onCreateUtilityTerminal,
+        })
+      );
+    });
+
+    expect(container.textContent).toContain('no utility terminals yet.');
+    expect(container.querySelector('[data-testid="utility-terminal-mount"]')).toBeNull();
+
+    await act(async () => {
+      (container.querySelector('.utility-empty button') as HTMLButtonElement).click();
+    });
+    expect(onCreateUtilityTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears copy mode when the terminal panel unmounts', async () => {
+    const onCopyModeChange = vi.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(WorkspaceUtilityRail, {
+          workspacePath: '/repo/a',
+          railState: railState(),
+          workspaceSessions: [],
+          utilityTerminalSessions: [session({ id: 'term-1' })],
+          onCopyModeChange,
+        })
+      );
+    });
+
+    await act(async () => {
+      root.render(
+        React.createElement(WorkspaceUtilityRail, {
+          workspacePath: '/repo/a',
+          railState: railState({ selectedRailTab: 'logs' }),
+          workspaceSessions: [],
+          utilityTerminalSessions: [session({ id: 'term-1' })],
+          onCopyModeChange,
+        })
+      );
+    });
+
+    expect(onCopyModeChange).toHaveBeenCalledWith(false);
+  });
+
+  it('supports roving focus arrow keys for utility terminal tabs', async () => {
+    const onSelectUtilityTerminal = vi.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(WorkspaceUtilityRail, {
+          workspacePath: '/repo/a',
+          railState: railState({ selectedUtilityTerminalId: 'term-1' }),
+          workspaceSessions: [],
+          utilityTerminalSessions: [
+            session({ id: 'term-1' }),
+            session({ id: 'term-2' }),
+          ],
+          onSelectUtilityTerminal,
+        })
+      );
+    });
+
+    const firstTab = container.querySelector(
+      '#utility-terminal-tab-term-1'
+    ) as HTMLButtonElement;
+    const secondTab = container.querySelector(
+      '#utility-terminal-tab-term-2'
+    ) as HTMLButtonElement;
+    expect(firstTab.tabIndex).toBe(0);
+    expect(secondTab.tabIndex).toBe(-1);
+
+    await act(async () => {
+      firstTab.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true })
+      );
+    });
+
+    expect(onSelectUtilityTerminal).toHaveBeenCalledWith('term-2');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `terminal` tab to the workspace utility rail that renders utility terminal sessions with the existing `Terminal` component.
- Tracks utility terminal session IDs per workspace in the UI store, including select/remove/promote/reconcile behavior.
- Filters utility terminal sessions out of the main workspace session tabs/area so creating or selecting one does not steal activation from the main workspace flow.
- Adds helper, store, session utility, and component tests covering terminal filtering, non-activating terminal creation, stale-id reconciliation, promotion/exclusive ownership, and rail terminal rendering/actions.

## Motivation
Workspace sessions need a lightweight terminal surface inside the utility rail for side-channel commands without polluting or activating the main workspace tab/session flow.

Closes #255

## The Case Against
This change might be wrong because:
- Utility terminals are still normal backend sessions with UI-side classification. If another client does not have the same persisted UI state, it will treat them like ordinary terminal sessions.
- The rail terminal panel mounts xterm only when the terminal tab is selected to avoid hidden sizing issues, but that means switching away unmounts the terminal component and depends on existing session/scrollback restoration behavior.
- Closing a utility terminal immediately removes it from UI state before the DELETE request completes. A failed close shows a toast, but the user may need to refresh/recreate the rail membership.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
|------|------------|------------|
| Stale utility terminal IDs persist after sessions die | Medium | Added `reconcileUtilityTerminals` against live terminal sessions and store hydration coverage. |
| Utility terminal creation steals active session focus | Medium | Added `createSessionWithoutActivation` and tests that restore active/workspace session placement. |
| Utility terminals appear in main workspace tab UI | Medium | Added `getMainWorkspaceSessions`/`getUtilityTerminalSessions` filtering and wired main views to main sessions only. |
| Hidden xterm sizing/websocket churn in non-terminal rail tabs | Low | Terminal panel content is conditionally mounted only while the terminal tab is active. |

## Verification
Local:
- `rtk npm run check` — passed with existing lint warnings only.
- `rtk npm run build` — passed with existing Vite chunk-size/dynamic/static import warnings only.
- `rtk npm test` — passed: 137 files / 1708 tests.
- `rtk npm test -- test/stores/ui-store.test.ts test/utility-terminals.test.ts test/session-utils.test.ts test/workspace-utility-rail-terminal.test.ts` — passed: 4 files / 40 tests.
- `git diff --check` — passed.

CI on PR #347:
- `ci` — passed.
- `e2e` — passed.
- `scan-commits` — passed.
- `sync-labels` — passed.

Note: I did not run local `npm run test:e2e`; the PR's GitHub Actions e2e job is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Utility terminal support: create, select, close, promote terminals from the terminal area and a dedicated terminal tab in the utility rail; header control to toggle the rail; per-workspace terminal placement and reconciliation.

* **Style**
  * New terminal panel styling, tabs, toolbar and empty-state visuals.

* **Bug Fixes**
  * Improved session-kill handling to avoid failing archive flows and surface clearer errors.

* **Tests**
  * Added comprehensive tests for session creation, UI store terminal behavior, utility-terminal helpers, and rail terminal UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->