### PR TITLE
feat: unify changed-file review workspace

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1168,7 +1168,13 @@ export default function App() {
         recentFiles={openFileTabs}
         onClose={() => setFilePickerOpen(false)}
         onSelect={(path, isChanged) => {
-          openFileTab(path, isChanged);
+          if (isChanged && activeWorkspaceCwd) {
+            useUiStore
+              .getState()
+              .openReviewWorkspace(activeWorkspaceCwd, { filePath: path });
+          } else {
+            openFileTab(path, isChanged);
+          }
           setFilePickerOpen(false);
         }}
       />

--- a/frontend/src/components/FileTree/FileTree.tsx
+++ b/frontend/src/components/FileTree/FileTree.tsx
@@ -103,14 +103,17 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
     });
 
     useEffect(() => {
-      if (defaultBranchQuery.data) {
-        setFileDiffDefaultBranch(defaultBranchQuery.data);
-        if (!reviewDefaultBranch || reviewDefaultBranch === 'main') {
-          setReviewDefaultBranch(workspacePath, defaultBranchQuery.data);
-        }
+      const branch = defaultBranchQuery.data;
+      if (!branch) return;
+      if (branch !== globalFileDiffDefaultBranch) {
+        setFileDiffDefaultBranch(branch);
+      }
+      if ((!reviewDefaultBranch || reviewDefaultBranch === 'main') && branch !== reviewDefaultBranch) {
+        setReviewDefaultBranch(workspacePath, branch);
       }
     }, [
       defaultBranchQuery.data,
+      globalFileDiffDefaultBranch,
       reviewDefaultBranch,
       setFileDiffDefaultBranch,
       setReviewDefaultBranch,

--- a/frontend/src/components/FileTree/FileTree.tsx
+++ b/frontend/src/components/FileTree/FileTree.tsx
@@ -70,12 +70,23 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
   function FileTree({ workspacePath }, ref) {
     const rightSidebarTab = useUiStore((s) => s.rightSidebarTab);
     const setRightSidebarTab = useUiStore((s) => s.setRightSidebarTab);
-    const fileDiffSource = useUiStore((s) => s.fileDiffSource);
-    const fileDiffDefaultBranch = useUiStore((s) => s.fileDiffDefaultBranch);
+    const reviewState = useUiStore(
+      (s) => s.utilityRailByWorkspace[workspacePath]?.review
+    );
+    const globalFileDiffSource = useUiStore((s) => s.fileDiffSource);
+    const globalFileDiffDefaultBranch = useUiStore(
+      (s) => s.fileDiffDefaultBranch
+    );
+    const fileDiffSource = reviewState?.diffSource ?? globalFileDiffSource;
+    const reviewDefaultBranch = reviewState?.defaultBranch;
+    const fileDiffDefaultBranch =
+      reviewDefaultBranch ?? globalFileDiffDefaultBranch;
     const setFileDiffDefaultBranch = useUiStore(
       (s) => s.setFileDiffDefaultBranch
     );
+    const setReviewDefaultBranch = useUiStore((s) => s.setReviewDefaultBranch);
     const openFileTab = useUiStore((s) => s.openFileTab);
+    const openReviewWorkspace = useUiStore((s) => s.openReviewWorkspace);
     const queryClient = useQueryClient();
 
     const base = useMemo(
@@ -94,8 +105,17 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
     useEffect(() => {
       if (defaultBranchQuery.data) {
         setFileDiffDefaultBranch(defaultBranchQuery.data);
+        if (!reviewDefaultBranch || reviewDefaultBranch === 'main') {
+          setReviewDefaultBranch(workspacePath, defaultBranchQuery.data);
+        }
       }
-    }, [defaultBranchQuery.data, setFileDiffDefaultBranch]);
+    }, [
+      defaultBranchQuery.data,
+      reviewDefaultBranch,
+      setFileDiffDefaultBranch,
+      setReviewDefaultBranch,
+      workspacePath,
+    ]);
 
     const query = useQuery<ChangedFilesResponse>({
       queryKey: changedFilesQueryKey(workspacePath, base),
@@ -235,11 +255,15 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
     });
 
     const activeFileTabKey = useUiStore((s) => s.activeFileTabKey);
+    const reviewFilePath = useUiStore(
+      (s) => s.utilityRailByWorkspace[workspacePath]?.review?.activeFilePath ?? null
+    );
     const selectedPath = useMemo(() => {
+      if (rightSidebarTab === 'changes') return reviewFilePath;
       if (!activeFileTabKey) return null;
       const idx = activeFileTabKey.indexOf('::');
       return idx >= 0 ? activeFileTabKey.slice(idx + 2) : activeFileTabKey;
-    }, [activeFileTabKey]);
+    }, [activeFileTabKey, reviewFilePath, rightSidebarTab]);
 
     // ── Click ──
     const handleNodeClick = useCallback(
@@ -254,9 +278,13 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
           return;
         }
         const isChanged = files.some((f) => f.path === node.path);
-        openFileTab(node.path, isChanged);
+        if (isChanged) {
+          openReviewWorkspace(workspacePath, { filePath: node.path });
+        } else {
+          openFileTab(node.path, false);
+        }
       },
-      [files, openFileTab]
+      [files, openFileTab, openReviewWorkspace, workspacePath]
     );
 
     const toggleAllFilesDir = useCallback(

--- a/frontend/src/components/FileViewerPane.tsx
+++ b/frontend/src/components/FileViewerPane.tsx
@@ -190,9 +190,15 @@ export function FileViewerPane({
 }: FileViewerPaneProps) {
   const openFileTabs = useUiStore((s) => s.openFileTabs);
   const activeFileTabKey = useUiStore((s) => s.activeFileTabKey);
-  const fileDiffSource = useUiStore((s) => s.fileDiffSource);
-  const fileDiffDefaultBranch = useUiStore((s) => s.fileDiffDefaultBranch);
+  const reviewState = useUiStore(
+    (s) => s.utilityRailByWorkspace[workspacePath]?.review
+  );
+  const globalFileDiffSource = useUiStore((s) => s.fileDiffSource);
+  const globalFileDiffDefaultBranch = useUiStore((s) => s.fileDiffDefaultBranch);
   const openUtilityRailTab = useUiStore((s) => s.openUtilityRailTab);
+  const fileDiffSource = reviewState?.diffSource ?? globalFileDiffSource;
+  const fileDiffDefaultBranch =
+    reviewState?.defaultBranch ?? globalFileDiffDefaultBranch;
   const base = useMemo(
     () => diffSourceToBase(fileDiffSource, fileDiffDefaultBranch) ?? null,
     [fileDiffSource, fileDiffDefaultBranch]

--- a/frontend/src/components/FullPageDiff.tsx
+++ b/frontend/src/components/FullPageDiff.tsx
@@ -25,6 +25,7 @@ export function FullPageDiff({
     useUiStore.getState().openReviewWorkspace(workspacePath, {
       ...(initialFile ? { filePath: initialFile } : {}),
       ...(initialBase !== undefined ? { base: initialBase } : {}),
+      preserveFullPageDiff: true,
     });
   }, [initialBase, initialFile, workspacePath]);
 

--- a/frontend/src/components/FullPageDiff.tsx
+++ b/frontend/src/components/FullPageDiff.tsx
@@ -1,24 +1,7 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { DiffFileSidebar } from './DiffFileSidebar.js';
-import type { DiffFileSidebarHandle } from './DiffFileSidebar.js';
-import { fetchChangedFiles, fetchFileDiff, fetchDefaultBranch } from '../lib/api.js';
-import { generateFileSummary } from '../lib/diff-summary.js';
-import { diffSourceToBase } from '../lib/diff-utils.js';
-import type { ChangedFile, DiffSource } from '../lib/types.js';
+import React, { useEffect } from 'react';
+import { useUiStore } from '../lib/stores/ui.js';
+import UtilityRailReviewPanel from './UtilityRailReviewPanel.js';
 import './FullPageDiff.css';
-
-// Stub DiffViewer and DiffSourceToggle until they are migrated
-const DiffViewer = React.lazy(() =>
-  import('./DiffViewer.js').catch(() => ({
-    default: () => <div className="fpd-empty">diff viewer not available</div>,
-  }))
-);
-
-const DiffSourceToggle = React.lazy(() =>
-  import('./DiffSourceToggle.js').catch(() => ({
-    default: () => <></>,
-  }))
-);
 
 export interface FullPageDiffProps {
   workspacePath: string;
@@ -27,188 +10,46 @@ export interface FullPageDiffProps {
   onClose: () => void;
 }
 
-function deriveInitialDiffSource(initialBase?: string): DiffSource {
-  if (initialBase === 'cached') return 'staged';
-  if (initialBase) return 'branch';
-  return 'working';
-}
-
-function useFullPageDiffData(workspacePath: string, base: string) {
-  const [files, setFiles] = useState<ChangedFile[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [fileDiff, setFileDiff] = useState('');
-  const [diffLoading, setDiffLoading] = useState(false);
-  const [summary, setSummary] = useState('');
-
-  const loadFiles = useCallback(
-    async (activeFilePath: string | null, onFilesFetched: (files: ChangedFile[]) => void) => {
-      setLoading(true);
-      try {
-        const data = await fetchChangedFiles(workspacePath, base);
-        setFiles(data.files);
-        onFilesFetched(data.files);
-      } catch {
-        setFiles([]);
-        onFilesFetched([]);
-      } finally {
-        setLoading(false);
-      }
-    },
-    [workspacePath, base]
-  );
-
-  const loadDiff = useCallback(
-    async (filePath: string, currentFiles: ChangedFile[]) => {
-      setDiffLoading(true);
-      setSummary('');
-      try {
-        const data = await fetchFileDiff(workspacePath, filePath, base);
-        setFileDiff(data.diff);
-        const file = currentFiles.find((f) => f.path === filePath);
-        if (file && data.diff) {
-          setSummary(generateFileSummary(data.diff, filePath, file.status));
-        }
-      } catch {
-        setFileDiff('');
-      } finally {
-        setDiffLoading(false);
-      }
-    },
-    [workspacePath, base]
-  );
-
-  return { files, loading, fileDiff, diffLoading, summary, loadFiles, loadDiff };
-}
-
-// ── Main component ──
-
-export function FullPageDiff({ workspacePath, initialFile, initialBase, onClose }: FullPageDiffProps) {
-  const [diffSource, setDiffSource] = useState<DiffSource>(deriveInitialDiffSource(initialBase));
-  const [defaultBranch, setDefaultBranch] = useState(
-    initialBase && initialBase !== 'cached' ? initialBase : 'main'
-  );
-  const [diffMode, setDiffMode] = useState<'unified' | 'side-by-side'>('unified');
-  const [activeFilePath, setActiveFilePath] = useState<string | null>(initialFile ?? null);
-  const [hunkCount, setHunkCount] = useState(0);
-  const [currentHunkIndex, setCurrentHunkIndex] = useState(-1);
-  const sidebarRef = useRef<DiffFileSidebarHandle>(null);
-  const filesRef = useRef<ChangedFile[]>([]);
-
-  const base = useMemo(() => diffSourceToBase(diffSource, defaultBranch) ?? '', [diffSource, defaultBranch]);
-
-  const { files, loading, fileDiff, diffLoading, summary, loadFiles, loadDiff } = useFullPageDiffData(
-    workspacePath,
-    base
-  );
-
-  filesRef.current = files;
-
+/**
+ * Compatibility entry point for older diff deep links.
+ * The real review state now lives in the workspace utility rail store and the
+ * body reuses UtilityRailReviewPanel so there is only one review model.
+ */
+export function FullPageDiff({
+  workspacePath,
+  initialFile,
+  initialBase,
+  onClose,
+}: FullPageDiffProps) {
   useEffect(() => {
-    loadFiles(activeFilePath, (fetched) => {
-      setActiveFilePath((prev) => {
-        if (!prev || !fetched.some((f) => f.path === prev)) {
-          return fetched.length > 0 ? fetched[0]!.path : null;
-        }
-        return prev;
-      });
+    useUiStore.getState().openReviewWorkspace(workspacePath, {
+      ...(initialFile ? { filePath: initialFile } : {}),
+      ...(initialBase !== undefined ? { base: initialBase } : {}),
     });
-  }, [base, loadFiles]);
+  }, [initialBase, initialFile, workspacePath]);
 
-  useEffect(() => {
-    if (activeFilePath) loadDiff(activeFilePath, filesRef.current);
-  }, [activeFilePath, base, loadDiff]);
-
-  useEffect(() => {
-    if (workspacePath && defaultBranch === 'main') {
-      fetchDefaultBranch(workspacePath).then((b) => setDefaultBranch(b)).catch(() => undefined);
-    }
-  }, [workspacePath, defaultBranch]);
-
-  const scrollToHunk = useCallback(
-    (delta: number) => {
-      const hunks = document.querySelectorAll('.fpd-main .hunk-header');
-      const visibleCount = hunks.length;
-      if (visibleCount === 0) return;
-      const target = currentHunkIndex + delta;
-      if (target < 0 || target >= visibleCount) return;
-      setCurrentHunkIndex(target);
-      hunks[target]!.scrollIntoView({ block: 'center', behavior: 'smooth' });
-    },
-    [currentHunkIndex]
+  const reviewState = useUiStore(
+    (s) => s.utilityRailByWorkspace[workspacePath]?.review
   );
-
-  useEffect(() => {
-    function handleKeydown(e: KeyboardEvent) {
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
-      if (e.key === 'Escape') { e.preventDefault(); onClose(); return; }
-      if (e.key === 'j') { e.preventDefault(); sidebarRef.current?.moveFocus(1); }
-      else if (e.key === 'k') { e.preventDefault(); sidebarRef.current?.moveFocus(-1); }
-      else if (e.key === 'n') { e.preventDefault(); scrollToHunk(1); }
-      else if (e.key === 'p') { e.preventDefault(); scrollToHunk(-1); }
-    }
-    document.addEventListener('keydown', handleKeydown);
-    return () => document.removeEventListener('keydown', handleKeydown);
-  }, [onClose, scrollToHunk]);
-
-  const handleSelectFile = useCallback((file: ChangedFile) => setActiveFilePath(file.path), []);
-  const handleHunkCount = useCallback((c: number) => { setHunkCount(c); setCurrentHunkIndex(-1); }, []);
-  const handleModeToggle = useCallback(() => setDiffMode((m) => (m === 'unified' ? 'side-by-side' : 'unified')), []);
+  const title = reviewState?.activeFilePath ?? 'review workspace';
 
   return (
-    <div className="full-page-diff">
+    <div className="full-page-diff full-page-diff--compat">
       <div className="fpd-header">
         <button className="fpd-close-btn" onClick={onClose} aria-label="close diff view">
           [x] close
         </button>
-        <span className="fpd-title">
-          {activeFilePath ? (
-            <>
-              {activeFilePath}
-              {summary && <span className="fpd-summary"> — {summary}</span>}
-            </>
-          ) : (
-            'diff view'
-          )}
-        </span>
-        <div className="fpd-controls">
-          <React.Suspense fallback={null}>
-            <DiffSourceToggle
-              value={diffSource}
-              onchange={(s: DiffSource) => setDiffSource(s)}
-              defaultBranch={defaultBranch}
-            />
-          </React.Suspense>
-          <button className="fpd-mode-toggle" onClick={handleModeToggle} title="toggle unified/side-by-side">
-            {diffMode === 'unified' ? '[split]' : '[unified]'}
-          </button>
-        </div>
+        <span className="fpd-title">{title}</span>
+        <span className="fpd-summary">utility rail review workspace</span>
       </div>
       <div className="fpd-body">
-        <DiffFileSidebar ref={sidebarRef} files={files} activeFile={activeFilePath} onSelectFile={handleSelectFile} />
-        <div className="fpd-main">
-          {activeFilePath ? (
-            <React.Suspense fallback={<div className="fpd-empty">loading...</div>}>
-              <DiffViewer
-                diff={fileDiff}
-                filePath={activeFilePath}
-                loading={diffLoading}
-                mode={diffMode}
-                onHunkCount={handleHunkCount}
-              />
-            </React.Suspense>
-          ) : loading ? (
-            <div className="fpd-empty">loading files...</div>
-          ) : (
-            <div className="fpd-empty">no files changed</div>
-          )}
+        <div className="fpd-main fpd-main--review">
+          <UtilityRailReviewPanel
+            workspacePath={workspacePath}
+            reviewState={reviewState}
+            onRequestClose={onClose}
+          />
         </div>
-      </div>
-      <div className="fpd-footer">
-        <span className="fpd-hint">j/k navigate files</span>
-        <span className="fpd-hint">n/p jump hunks</span>
-        <span className="fpd-hint">esc close</span>
-        <span style={{ display: 'none' }}>{hunkCount}</span>
       </div>
     </div>
   );

--- a/frontend/src/components/UtilityRailGitChangesPanel.tsx
+++ b/frontend/src/components/UtilityRailGitChangesPanel.tsx
@@ -79,9 +79,11 @@ export function UtilityRailGitChangesPanel({
   workspacePath,
 }: UtilityRailGitChangesPanelProps) {
   const queryClient = useQueryClient();
-  const openFileTab = useUiStore((s) => s.openFileTab);
   const openUtilityRailTab = useUiStore((s) => s.openUtilityRailTab);
-  const activeFileTabKey = useUiStore((s) => s.activeFileTabKey);
+  const openReviewWorkspace = useUiStore((s) => s.openReviewWorkspace);
+  const reviewFilePath = useUiStore(
+    (s) => s.utilityRailByWorkspace[workspacePath]?.review?.activeFilePath ?? null
+  );
 
   const workingQuery = useQuery<ChangedFilesResponse>({
     queryKey: workingKey(workspacePath),
@@ -126,18 +128,21 @@ export function UtilityRailGitChangesPanel({
     return { staged, changes, untracked };
   }, [workingQuery.data?.files, stagedQuery.data?.files]);
 
-  const handleClick = useCallback(
+  const handleStagedClick = useCallback(
     (file: ChangedFile) => {
-      openFileTab(file.path, true, 'diff');
+      openReviewWorkspace(workspacePath, { filePath: file.path, base: 'cached' });
     },
-    [openFileTab]
+    [openReviewWorkspace, workspacePath]
   );
 
-  const selectedPath = useMemo(() => {
-    if (!activeFileTabKey) return null;
-    const idx = activeFileTabKey.indexOf('::');
-    return idx >= 0 ? activeFileTabKey.slice(idx + 2) : activeFileTabKey;
-  }, [activeFileTabKey]);
+  const handleWorkingClick = useCallback(
+    (file: ChangedFile) => {
+      openReviewWorkspace(workspacePath, { filePath: file.path, base: '' });
+    },
+    [openReviewWorkspace, workspacePath]
+  );
+
+  const selectedPath = reviewFilePath;
 
   const isLoading = workingQuery.isPending && !workingQuery.data;
   const errorMsg =
@@ -198,7 +203,7 @@ export function UtilityRailGitChangesPanel({
                     key={`s-${f.path}`}
                     file={f}
                     selected={selectedPath === f.path}
-                    onClick={handleClick}
+                    onClick={handleStagedClick}
                   />
                 ))}
               </section>
@@ -214,7 +219,7 @@ export function UtilityRailGitChangesPanel({
                     key={`c-${f.path}`}
                     file={f}
                     selected={selectedPath === f.path}
-                    onClick={handleClick}
+                    onClick={handleWorkingClick}
                   />
                 ))}
               </section>
@@ -232,7 +237,7 @@ export function UtilityRailGitChangesPanel({
                     key={`u-${f.path}`}
                     file={f}
                     selected={selectedPath === f.path}
-                    onClick={handleClick}
+                    onClick={handleWorkingClick}
                   />
                 ))}
               </section>

--- a/frontend/src/components/UtilityRailReviewPanel.tsx
+++ b/frontend/src/components/UtilityRailReviewPanel.tsx
@@ -3,135 +3,187 @@ import React, {
   useEffect,
   useMemo,
   useRef,
-  useState,
 } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { ChangedFile } from '../lib/types.js';
-import {
-  fetchChangedFiles,
-  fetchDefaultBranch,
-  fetchFileDiff,
-} from '../lib/api.js';
+import { fetchChangedFiles, fetchDefaultBranch } from '../lib/api.js';
 import { diffSourceToBase } from '../lib/diff-utils.js';
 import { generateFileSummary } from '../lib/diff-summary.js';
-import { useUiStore } from '../lib/stores/ui.js';
+import { useFileDiff } from '../hooks/useFileDiff.js';
+import {
+  useUiStore,
+  type DiffSource,
+  type WorkspaceReviewState,
+} from '../lib/stores/ui.js';
 import DiffSourceToggle from './DiffSourceToggle.js';
 import DiffViewer from './DiffViewer.js';
-import { DiffFileSidebar } from './DiffFileSidebar.js';
+import { DiffFileSidebar, type DiffFileSidebarHandle } from './DiffFileSidebar.js';
 import './WorkspaceUtilityRail.css';
 
 export interface UtilityRailReviewPanelProps {
   workspacePath: string;
-  reviewFilePath?: string | undefined;
+  reviewState?: WorkspaceReviewState | undefined;
+  onRequestClose?: (() => void) | undefined;
+}
+
+interface ChangedFilesResponse {
+  files: ChangedFile[];
+  aggregate: { additions: number; deletions: number; fileCount: number };
+  error?: string;
+}
+
+const EMPTY_CHANGED_FILES: ChangedFile[] = [];
+
+function changedFilesQueryKey(workspacePath: string, base: string) {
+  return ['changedFiles', workspacePath, base] as const;
+}
+
+function defaultBranchQueryKey(workspacePath: string) {
+  return ['defaultBranch', workspacePath] as const;
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return (
+    tag === 'INPUT' ||
+    tag === 'TEXTAREA' ||
+    tag === 'SELECT' ||
+    target.isContentEditable ||
+    Boolean(target.closest('[role="textbox"], [data-terminal-root], .xterm'))
+  );
+}
+
+function sourceLabel(source: DiffSource, defaultBranch: string): string {
+  if (source === 'staged') return 'staged';
+  if (source === 'branch') return `vs ${defaultBranch}`;
+  return 'working tree';
 }
 
 export function UtilityRailReviewPanel({
   workspacePath,
-  reviewFilePath,
+  reviewState,
+  onRequestClose,
 }: UtilityRailReviewPanelProps) {
-  const fileDiffSource = useUiStore((s) => s.fileDiffSource);
+  const queryClient = useQueryClient();
+  const storeReviewState = useUiStore(
+    (s) => s.utilityRailByWorkspace[workspacePath]?.review
+  );
   const fileDiffViewMode = useUiStore((s) => s.fileDiffViewMode);
-  const setFileDiffSource = useUiStore((s) => s.setFileDiffSource);
   const setFileDiffViewMode = useUiStore((s) => s.setFileDiffViewMode);
   const openUtilityRailTab = useUiStore((s) => s.openUtilityRailTab);
-  const [defaultBranch, setDefaultBranch] = useState('main');
-  const [files, setFiles] = useState<ChangedFile[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [diffLoading, setDiffLoading] = useState(false);
-  const [activeFilePath, setActiveFilePath] = useState<string | null>(
-    reviewFilePath ?? null
+  const openReviewWorkspace = useUiStore((s) => s.openReviewWorkspace);
+  const setReviewActiveFile = useUiStore((s) => s.setReviewActiveFile);
+  const setReviewDiffSource = useUiStore((s) => s.setReviewDiffSource);
+  const setReviewDefaultBranch = useUiStore((s) => s.setReviewDefaultBranch);
+  const setReviewCurrentHunkIndex = useUiStore(
+    (s) => s.setReviewCurrentHunkIndex
   );
-  const [fileDiff, setFileDiff] = useState('');
-  const [summary, setSummary] = useState('');
-  const filesRef = useRef<ChangedFile[]>([]);
+  const sidebarRef = useRef<DiffFileSidebarHandle>(null);
+  const diffScrollerRef = useRef<HTMLDivElement | null>(null);
 
+  const review = reviewState ??
+    storeReviewState ?? {
+      activeFilePath: null,
+      diffSource: 'working' as const,
+      defaultBranch: 'main',
+      currentHunkIndex: -1,
+    };
+  const activeFilePath = review.activeFilePath;
   const base = useMemo(
-    () => diffSourceToBase(fileDiffSource, defaultBranch) ?? '',
-    [fileDiffSource, defaultBranch]
+    () => diffSourceToBase(review.diffSource, review.defaultBranch) ?? '',
+    [review.diffSource, review.defaultBranch]
   );
 
   useEffect(() => {
-    filesRef.current = files;
-  }, [files]);
-
-  useEffect(() => {
-    setActiveFilePath(reviewFilePath ?? null);
-  }, [reviewFilePath, workspacePath]);
-
-  useEffect(() => {
     if (!workspacePath) return;
-    let cancelled = false;
-    setLoading(true);
-    fetchChangedFiles(workspacePath, base)
-      .then((data) => {
-        if (cancelled) return;
-        setFiles(data.files);
-        setActiveFilePath((prev) => {
-          if (prev && data.files.some((file) => file.path === prev))
-            return prev;
-          return data.files[0]?.path ?? null;
-        });
-      })
-      .catch(() => {
-        if (!cancelled) setFiles([]);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [workspacePath, base]);
+    openReviewWorkspace(workspacePath, { preserveSelectedTab: true });
+  }, [openReviewWorkspace, workspacePath]);
+
+  const defaultBranchQuery = useQuery<string>({
+    queryKey: defaultBranchQueryKey(workspacePath),
+    queryFn: () => fetchDefaultBranch(workspacePath),
+    enabled: Boolean(workspacePath),
+    staleTime: 5 * 60 * 1000,
+    retry: false,
+  });
 
   useEffect(() => {
-    if (!workspacePath) return;
-    let cancelled = false;
-    setDefaultBranch('main');
-    fetchDefaultBranch(workspacePath)
-      .then((branch) => {
-        if (!cancelled) setDefaultBranch(branch);
-      })
-      .catch(() => undefined);
-    return () => {
-      cancelled = true;
-    };
-  }, [workspacePath]);
+    const branch = defaultBranchQuery.data;
+    if (!workspacePath || !branch) return;
+    if (review.defaultBranch === 'main' || review.defaultBranch === '') {
+      setReviewDefaultBranch(workspacePath, branch);
+    }
+  }, [defaultBranchQuery.data, review.defaultBranch, setReviewDefaultBranch, workspacePath]);
+
+  const filesQuery = useQuery<ChangedFilesResponse>({
+    queryKey: changedFilesQueryKey(workspacePath, base),
+    queryFn: async () => {
+      const data = await fetchChangedFiles(workspacePath, base || undefined);
+      if (data.error) throw new Error(data.error);
+      return data;
+    },
+    enabled: Boolean(workspacePath),
+    staleTime: 2 * 1000,
+    retry: false,
+  });
+
+  const files = filesQuery.data?.files ?? EMPTY_CHANGED_FILES;
+  const activeFile = useMemo(
+    () => files.find((file) => file.path === activeFilePath),
+    [activeFilePath, files]
+  );
 
   useEffect(() => {
-    if (!workspacePath || !activeFilePath) {
-      setFileDiff('');
-      setSummary('');
+    if (!workspacePath || filesQuery.isPending || filesQuery.isError) return;
+    if (activeFilePath && files.some((file) => file.path === activeFilePath)) {
       return;
     }
-    let cancelled = false;
-    setDiffLoading(true);
-    setSummary('');
-    fetchFileDiff(workspacePath, activeFilePath, base)
-      .then((data) => {
-        if (cancelled) return;
-        setFileDiff(data.diff);
-        const activeFile = filesRef.current.find(
-          (file) => file.path === activeFilePath
-        );
-        if (activeFile && data.diff) {
-          setSummary(
-            generateFileSummary(data.diff, activeFilePath, activeFile.status)
-          );
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setFileDiff('');
-      })
-      .finally(() => {
-        if (!cancelled) setDiffLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [workspacePath, activeFilePath, base]);
+    setReviewActiveFile(workspacePath, files[0]?.path ?? null);
+  }, [activeFilePath, files, filesQuery.isError, filesQuery.isPending, setReviewActiveFile, workspacePath]);
 
-  const handleSelectFile = useCallback((file: ChangedFile) => {
-    setActiveFilePath(file.path);
-  }, []);
+  const {
+    diff: fileDiff,
+    loading: diffLoading,
+    error: diffError,
+  } = useFileDiff(
+    {
+      workspacePath,
+      filePath: activeFilePath ?? '',
+      base: base || null,
+    },
+    { enabled: Boolean(activeFilePath) }
+  );
+
+  const summary = useMemo(() => {
+    if (!activeFilePath || !activeFile || !fileDiff) return '';
+    return generateFileSummary(fileDiff, activeFilePath, activeFile.status);
+  }, [activeFile, activeFilePath, fileDiff]);
+
+  const refresh = useCallback(() => {
+    queryClient.invalidateQueries({
+      queryKey: changedFilesQueryKey(workspacePath, base),
+    });
+    if (activeFilePath) {
+      queryClient.invalidateQueries({
+        queryKey: ['fileDiff', workspacePath, activeFilePath, base || null],
+      });
+    }
+  }, [activeFilePath, base, queryClient, workspacePath]);
+
+  const handleSelectFile = useCallback(
+    (file: ChangedFile) => {
+      setReviewActiveFile(workspacePath, file.path);
+    },
+    [setReviewActiveFile, workspacePath]
+  );
+
+  const handleSourceChange = useCallback(
+    (source: DiffSource) => {
+      setReviewDiffSource(workspacePath, source);
+    },
+    [setReviewDiffSource, workspacePath]
+  );
 
   const handleModeToggle = useCallback(() => {
     setFileDiffViewMode(
@@ -139,21 +191,87 @@ export function UtilityRailReviewPanel({
     );
   }, [fileDiffViewMode, setFileDiffViewMode]);
 
-  const branchBase = fileDiffSource === 'branch' ? base : null;
+  const branchBase = review.diffSource === 'branch' ? base : null;
   const openBranchPanel = useCallback(() => {
     openUtilityRailTab(workspacePath, 'branch', {
       branchBase,
     });
   }, [branchBase, openUtilityRailTab, workspacePath]);
 
+  const scrollToHunk = useCallback(
+    (delta: number) => {
+      const root = diffScrollerRef.current;
+      if (!root) return;
+      const hunks = root.querySelectorAll('.hunk-header');
+      if (hunks.length === 0) return;
+      const target = Math.max(
+        0,
+        Math.min(hunks.length - 1, review.currentHunkIndex + delta)
+      );
+      setReviewCurrentHunkIndex(workspacePath, target);
+      hunks[target]?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    },
+    [review.currentHunkIndex, setReviewCurrentHunkIndex, workspacePath]
+  );
+
+  useEffect(() => {
+    setReviewCurrentHunkIndex(workspacePath, -1);
+  }, [activeFilePath, base, setReviewCurrentHunkIndex, workspacePath]);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (isTypingTarget(event.target)) return;
+      if (event.key === 'j' || event.key === 'ArrowDown') {
+        event.preventDefault();
+        sidebarRef.current?.moveFocus(1);
+      } else if (event.key === 'k' || event.key === 'ArrowUp') {
+        event.preventDefault();
+        sidebarRef.current?.moveFocus(-1);
+      } else if (event.key === 'n') {
+        event.preventDefault();
+        scrollToHunk(1);
+      } else if (event.key === 'p') {
+        event.preventDefault();
+        scrollToHunk(-1);
+      } else if (event.key === 'Escape') {
+        event.preventDefault();
+        if (onRequestClose) {
+          onRequestClose();
+        } else {
+          useUiStore.getState().setSelectedUtilityRailTab(workspacePath, null);
+        }
+      }
+    },
+    [onRequestClose, scrollToHunk, workspacePath]
+  );
+
+  const filesError =
+    filesQuery.error instanceof Error ? filesQuery.error.message : null;
+  const emptyLabel =
+    review.diffSource === 'staged'
+      ? 'no staged changes'
+      : review.diffSource === 'branch'
+        ? `no changes against ${review.defaultBranch}`
+        : 'no changed files';
+
   return (
-    <div className="utility-review-panel">
+    <div
+      className="utility-review-panel"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      aria-label="review workspace"
+    >
       <div className="utility-panel-toolbar">
-        <DiffSourceToggle
-          value={fileDiffSource}
-          onchange={setFileDiffSource}
-          defaultBranch={defaultBranch}
-        />
+        <div className="utility-review-source">
+          <DiffSourceToggle
+            value={review.diffSource}
+            onchange={handleSourceChange}
+            defaultBranch={review.defaultBranch}
+          />
+          <span className="utility-review-source-label">
+            {sourceLabel(review.diffSource, review.defaultBranch)}
+          </span>
+        </div>
         <button
           className="utility-panel-btn"
           onClick={openBranchPanel}
@@ -165,44 +283,82 @@ export function UtilityRailReviewPanel({
           className="utility-panel-btn"
           onClick={handleModeToggle}
           type="button"
+          aria-label="toggle diff view mode"
         >
           {fileDiffViewMode === 'unified' ? '[split]' : '[unified]'}
+        </button>
+        <button
+          className="utility-panel-btn"
+          onClick={refresh}
+          type="button"
+          aria-label="retry review load"
+        >
+          retry
         </button>
       </div>
       <div className="utility-review-body">
         <div className="utility-review-files">
-          {loading ? (
+          {filesQuery.isPending ? (
             <div className="utility-empty">loading files...</div>
+          ) : filesError ? (
+            <div className="utility-empty utility-error">
+              {filesError}
+              <button type="button" className="utility-panel-btn" onClick={refresh}>
+                retry
+              </button>
+            </div>
           ) : files.length === 0 ? (
-            <div className="utility-empty">no changed files</div>
+            <div className="utility-empty">{emptyLabel}</div>
           ) : (
             <DiffFileSidebar
+              ref={sidebarRef}
               files={files}
               activeFile={activeFilePath}
               onSelectFile={handleSelectFile}
             />
           )}
         </div>
-        <div className="utility-review-diff">
+        <div className="utility-review-diff" ref={diffScrollerRef}>
           {activeFilePath ? (
             <>
               <div className="utility-review-title">
                 <span>{activeFilePath}</span>
-                {summary ? (
-                  <span className="utility-muted">{summary}</span>
-                ) : null}
+                <span className="utility-review-title-meta">
+                  {summary ? (
+                    <span className="utility-muted">{summary}</span>
+                  ) : null}
+                  <span className="utility-muted">
+                    {fileDiffViewMode} · {sourceLabel(review.diffSource, review.defaultBranch)}
+                  </span>
+                </span>
               </div>
-              <DiffViewer
-                diff={fileDiff}
-                filePath={activeFilePath}
-                loading={diffLoading}
-                mode={fileDiffViewMode}
-              />
+              {diffError ? (
+                <div className="utility-empty utility-error">
+                  {diffError}
+                  <button type="button" className="utility-panel-btn" onClick={refresh}>
+                    retry
+                  </button>
+                </div>
+              ) : (
+                <DiffViewer
+                  diff={fileDiff}
+                  filePath={activeFilePath}
+                  loading={diffLoading}
+                  mode={fileDiffViewMode}
+                />
+              )}
             </>
+          ) : filesQuery.isPending ? (
+            <div className="utility-empty">loading diff...</div>
           ) : (
             <div className="utility-empty">select a file</div>
           )}
         </div>
+      </div>
+      <div className="utility-review-footer" aria-label="review keyboard shortcuts">
+        <span>j/k or arrows files</span>
+        <span>n/p hunks</span>
+        <span>esc close pane</span>
       </div>
     </div>
   );

--- a/frontend/src/components/UtilityRailReviewPanel.tsx
+++ b/frontend/src/components/UtilityRailReviewPanel.tsx
@@ -24,6 +24,7 @@ export interface UtilityRailReviewPanelProps {
   workspacePath: string;
   reviewState?: WorkspaceReviewState | undefined;
   onRequestClose?: (() => void) | undefined;
+  active?: boolean | undefined;
 }
 
 interface ChangedFilesResponse {
@@ -50,7 +51,11 @@ function isTypingTarget(target: EventTarget | null): boolean {
     tag === 'TEXTAREA' ||
     tag === 'SELECT' ||
     target.isContentEditable ||
-    Boolean(target.closest('[role="textbox"], [data-terminal-root], .xterm'))
+    Boolean(
+      target.closest(
+        '[role="textbox"], [data-terminal-root], .xterm, .palette, .palette-overlay'
+      )
+    )
   );
 }
 
@@ -64,6 +69,7 @@ export function UtilityRailReviewPanel({
   workspacePath,
   reviewState,
   onRequestClose,
+  active = true,
 }: UtilityRailReviewPanelProps) {
   const queryClient = useQueryClient();
   const storeReviewState = useUiStore(
@@ -72,7 +78,6 @@ export function UtilityRailReviewPanel({
   const fileDiffViewMode = useUiStore((s) => s.fileDiffViewMode);
   const setFileDiffViewMode = useUiStore((s) => s.setFileDiffViewMode);
   const openUtilityRailTab = useUiStore((s) => s.openUtilityRailTab);
-  const openReviewWorkspace = useUiStore((s) => s.openReviewWorkspace);
   const setReviewActiveFile = useUiStore((s) => s.setReviewActiveFile);
   const setReviewDiffSource = useUiStore((s) => s.setReviewDiffSource);
   const setReviewDefaultBranch = useUiStore((s) => s.setReviewDefaultBranch);
@@ -80,6 +85,7 @@ export function UtilityRailReviewPanel({
     (s) => s.setReviewCurrentHunkIndex
   );
   const sidebarRef = useRef<DiffFileSidebarHandle>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const diffScrollerRef = useRef<HTMLDivElement | null>(null);
 
   const review = reviewState ??
@@ -95,11 +101,6 @@ export function UtilityRailReviewPanel({
     [review.diffSource, review.defaultBranch]
   );
 
-  useEffect(() => {
-    if (!workspacePath) return;
-    openReviewWorkspace(workspacePath, { preserveSelectedTab: true });
-  }, [openReviewWorkspace, workspacePath]);
-
   const defaultBranchQuery = useQuery<string>({
     queryKey: defaultBranchQueryKey(workspacePath),
     queryFn: () => fetchDefaultBranch(workspacePath),
@@ -111,7 +112,10 @@ export function UtilityRailReviewPanel({
   useEffect(() => {
     const branch = defaultBranchQuery.data;
     if (!workspacePath || !branch) return;
-    if (review.defaultBranch === 'main' || review.defaultBranch === '') {
+    if (
+      (review.defaultBranch === 'main' || review.defaultBranch === '') &&
+      branch !== review.defaultBranch
+    ) {
       setReviewDefaultBranch(workspacePath, branch);
     }
   }, [defaultBranchQuery.data, review.defaultBranch, setReviewDefaultBranch, workspacePath]);
@@ -214,12 +218,8 @@ export function UtilityRailReviewPanel({
     [review.currentHunkIndex, setReviewCurrentHunkIndex, workspacePath]
   );
 
-  useEffect(() => {
-    setReviewCurrentHunkIndex(workspacePath, -1);
-  }, [activeFilePath, base, setReviewCurrentHunkIndex, workspacePath]);
-
   const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
+    (event: KeyboardEvent | React.KeyboardEvent<HTMLDivElement>) => {
       if (isTypingTarget(event.target)) return;
       if (event.key === 'j' || event.key === 'ArrowDown') {
         event.preventDefault();
@@ -245,6 +245,15 @@ export function UtilityRailReviewPanel({
     [onRequestClose, scrollToHunk, workspacePath]
   );
 
+  useEffect(() => {
+    if (!active) return;
+    const onDocumentKeyDown = (event: KeyboardEvent) => {
+      handleKeyDown(event);
+    };
+    document.addEventListener('keydown', onDocumentKeyDown);
+    return () => document.removeEventListener('keydown', onDocumentKeyDown);
+  }, [active, handleKeyDown]);
+
   const filesError =
     filesQuery.error instanceof Error ? filesQuery.error.message : null;
   const emptyLabel =
@@ -256,9 +265,9 @@ export function UtilityRailReviewPanel({
 
   return (
     <div
+      ref={panelRef}
       className="utility-review-panel"
-      tabIndex={0}
-      onKeyDown={handleKeyDown}
+      tabIndex={-1}
       aria-label="review workspace"
     >
       <div className="utility-panel-toolbar">

--- a/frontend/src/components/WorkspaceArea.tsx
+++ b/frontend/src/components/WorkspaceArea.tsx
@@ -81,8 +81,14 @@ function FileTabContentBridge({
   renderDiff,
   renderCode,
 }: FileTabContentBridgeProps) {
-  const fileDiffSource = useUiStore((s) => s.fileDiffSource);
-  const fileDiffDefaultBranch = useUiStore((s) => s.fileDiffDefaultBranch);
+  const reviewState = useUiStore(
+    (s) => s.utilityRailByWorkspace[workspacePath]?.review
+  );
+  const globalFileDiffSource = useUiStore((s) => s.fileDiffSource);
+  const globalFileDiffDefaultBranch = useUiStore((s) => s.fileDiffDefaultBranch);
+  const fileDiffSource = reviewState?.diffSource ?? globalFileDiffSource;
+  const fileDiffDefaultBranch =
+    reviewState?.defaultBranch ?? globalFileDiffDefaultBranch;
   const fileDiffViewMode = useUiStore((s) => s.fileDiffViewMode);
   const fileWordWrap = useUiStore((s) => s.fileWordWrap);
   const closeFileTab = useUiStore((s) => s.closeFileTab);

--- a/frontend/src/components/WorkspaceUtilityRail.css
+++ b/frontend/src/components/WorkspaceUtilityRail.css
@@ -91,9 +91,14 @@
 
 .utility-review-panel {
   display: grid;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: auto 1fr auto;
   height: 100%;
   min-height: 0;
+}
+
+.utility-review-panel:focus {
+  outline: 1px solid var(--accent, #d97757);
+  outline-offset: -1px;
 }
 
 .utility-panel-toolbar {
@@ -102,6 +107,27 @@
   gap: 8px;
   padding: 6px 8px;
   border-bottom: 1px solid var(--border, #333);
+}
+
+.utility-review-source {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+  flex: 1;
+}
+
+.utility-review-source-label,
+.utility-review-title-meta,
+.utility-review-footer {
+  color: var(--text-muted, #888);
+  font-size: var(--font-size-xs, 0.75rem);
+}
+
+.utility-review-title-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
 }
 
 .utility-panel-btn {
@@ -134,6 +160,18 @@
 .utility-review-diff {
   min-height: 0;
   overflow: auto;
+}
+
+.utility-review-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 6px 8px;
+  border-top: 1px solid var(--border, #333);
+}
+
+.utility-error {
+  color: var(--status-error, #f87171);
 }
 
 .utility-review-title {

--- a/frontend/src/components/WorkspaceUtilityRail.tsx
+++ b/frontend/src/components/WorkspaceUtilityRail.tsx
@@ -215,7 +215,7 @@ export function WorkspaceUtilityRail({
           >
             <UtilityRailReviewPanel
               workspacePath={workspacePath}
-              reviewFilePath={railState.reviewFilePath}
+              reviewState={railState.review}
             />
           </div>
           <div

--- a/frontend/src/components/WorkspaceUtilityRail.tsx
+++ b/frontend/src/components/WorkspaceUtilityRail.tsx
@@ -121,6 +121,7 @@ export function WorkspaceUtilityRail({
     (s) => s.setSelectedUtilityRailTab
   );
   const openUtilityRailTab = useUiStore((s) => s.openUtilityRailTab);
+  const fullPageDiff = useUiStore((s) => s.fullPageDiff);
   const selectedTab = railState.selectedRailTab;
 
   const handleTabClick = useCallback(
@@ -216,6 +217,7 @@ export function WorkspaceUtilityRail({
             <UtilityRailReviewPanel
               workspacePath={workspacePath}
               reviewState={railState.review}
+              active={selectedTab === 'review' && !fullPageDiff}
             />
           </div>
           <div

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -489,8 +489,7 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
             '';
           if (ws) {
             const ui = useUiStore.getState();
-            ui.openUtilityRailTab(ws, 'review');
-            useUiStore.setState({ fullPageDiff: null });
+            ui.openReviewWorkspace(ws);
           }
         },
       },

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -107,6 +107,12 @@ export function useEventSocket({
         if (activeWs === msg.workspacePath) {
           throttledChangedFilesRefresh();
           queryClient.invalidateQueries({ queryKey: ['files-list'] });
+          queryClient.invalidateQueries({
+            queryKey: ['changedFiles', msg.workspacePath],
+          });
+          queryClient.invalidateQueries({
+            queryKey: ['fileDiff', msg.workspacePath],
+          });
           if (msg.changedFiles) {
             setChangedFilesData(msg.changedFiles);
           }

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -33,6 +33,7 @@ export const UTILITY_ICON_RAIL_WIDTH = 48;
 
 export type RightSidebarTab = 'changes' | 'all-files' | 'checks';
 export type FileTabType = 'diff' | 'code' | 'html';
+export type DiffSource = 'working' | 'staged' | 'branch';
 export type DiffViewMode = 'unified' | 'side-by-side';
 export type UtilityRailTab =
   | 'files'
@@ -41,6 +42,19 @@ export type UtilityRailTab =
   | 'review'
   | 'logs'
   | 'stats';
+
+export interface WorkspaceReviewState {
+  activeFilePath: string | null;
+  diffSource: DiffSource;
+  defaultBranch: string;
+  currentHunkIndex: number;
+}
+
+export interface OpenReviewWorkspaceOptions {
+  filePath?: string;
+  base?: string;
+  preserveSelectedTab?: boolean;
+}
 export type UtilitySurfacePlacement =
   | { kind: 'rail' }
   | { kind: 'anchored-pane'; paneId: string };
@@ -51,6 +65,8 @@ export interface WorkspaceUtilityRailState {
   width: number;
   anchoredPaneWidths?: Partial<Record<UtilityRailTab, number>>;
   placements?: Partial<Record<UtilityRailTab, UtilitySurfacePlacement>>;
+  review?: WorkspaceReviewState;
+  /** @deprecated migrated into review.activeFilePath */
   reviewFilePath?: string;
   filesMode?: 'changes' | 'all-files';
   branchBase?: string;
@@ -212,8 +228,62 @@ export function clearUtilityRailStateCacheForTesting(): void {
   utilityRailStateCache.clear();
 }
 
+function defaultReviewState(): WorkspaceReviewState {
+  return {
+    activeFilePath: null,
+    diffSource: 'working',
+    defaultBranch: 'main',
+    currentHunkIndex: -1,
+  };
+}
+
 function defaultUtilityRailState(): WorkspaceUtilityRailState {
-  return { ...DEFAULT_UTILITY_RAIL_STATE };
+  return { ...DEFAULT_UTILITY_RAIL_STATE, review: defaultReviewState() };
+}
+
+function deriveReviewStateFromBase(
+  base: string | undefined,
+  current: WorkspaceReviewState
+): Pick<WorkspaceReviewState, 'diffSource' | 'defaultBranch'> {
+  if (base === undefined) {
+    return {
+      diffSource: current.diffSource,
+      defaultBranch: current.defaultBranch,
+    };
+  }
+  if (base === 'cached') {
+    return { diffSource: 'staged', defaultBranch: current.defaultBranch };
+  }
+  if (base) {
+    return { diffSource: 'branch', defaultBranch: base };
+  }
+  return { diffSource: 'working', defaultBranch: current.defaultBranch };
+}
+
+function normalizeReviewState(
+  value: Partial<WorkspaceReviewState> | null | undefined,
+  legacyFilePath?: string
+): WorkspaceReviewState {
+  const next = defaultReviewState();
+  if (typeof legacyFilePath === 'string') next.activeFilePath = legacyFilePath;
+  if (!value) return next;
+  if (typeof value.activeFilePath === 'string' || value.activeFilePath === null) {
+    next.activeFilePath = value.activeFilePath;
+  }
+  if (
+    value.diffSource === 'working' ||
+    value.diffSource === 'staged' ||
+    value.diffSource === 'branch'
+  ) {
+    next.diffSource = value.diffSource;
+  }
+  if (typeof value.defaultBranch === 'string' && value.defaultBranch.trim()) {
+    next.defaultBranch = value.defaultBranch;
+  }
+  if (typeof value.currentHunkIndex === 'number') {
+    next.currentHunkIndex = Math.max(-1, Math.trunc(value.currentHunkIndex));
+  }
+  return next;
 }
 
 function normalizeUtilityRailState(
@@ -258,8 +328,10 @@ function normalizeUtilityRailState(
     if (Object.keys(placements).length > 0) next.placements = placements;
   }
 
-  if (typeof value.reviewFilePath === 'string')
-    next.reviewFilePath = value.reviewFilePath;
+  next.review = normalizeReviewState(value.review, value.reviewFilePath);
+  if (next.review.activeFilePath !== null) {
+    next.reviewFilePath = next.review.activeFilePath;
+  }
   if (value.filesMode === 'changes' || value.filesMode === 'all-files') {
     next.filesMode = value.filesMode;
   }
@@ -373,6 +445,14 @@ export interface UiState {
     tab: UtilityRailTab,
     placement: UtilitySurfacePlacement
   ) => void;
+  openReviewWorkspace: (
+    workspacePath: string,
+    options?: OpenReviewWorkspaceOptions
+  ) => void;
+  setReviewActiveFile: (workspacePath: string, filePath: string | null) => void;
+  setReviewDiffSource: (workspacePath: string, source: DiffSource) => void;
+  setReviewDefaultBranch: (workspacePath: string, branch: string) => void;
+  setReviewCurrentHunkIndex: (workspacePath: string, index: number) => void;
   openFileTabs: OpenFileTab[];
   activeFileTabKey: string | null;
   fileViewerRatio: number;
@@ -636,6 +716,113 @@ export const useUiStore = create<UiState>()((set, get) => ({
         const next = state.placements ? { ...state.placements } : {};
         next[tab] = placement;
         state.placements = next;
+      }
+    );
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: nextState,
+      },
+    });
+  },
+  openReviewWorkspace: (workspacePath, options) => {
+    const nextState = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        state.visible = true;
+        if (!options?.preserveSelectedTab) state.selectedRailTab = 'review';
+        const current = normalizeReviewState(state.review, state.reviewFilePath);
+        const derived = deriveReviewStateFromBase(options?.base, current);
+        state.review = {
+          ...current,
+          ...derived,
+          activeFilePath: options?.filePath ?? current.activeFilePath,
+          currentHunkIndex: -1,
+        };
+        if (state.review.activeFilePath) {
+          state.reviewFilePath = state.review.activeFilePath;
+        } else {
+          delete state.reviewFilePath;
+        }
+      }
+    );
+    set({
+      fullPageDiff: null,
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: nextState,
+      },
+    });
+  },
+  setReviewActiveFile: (workspacePath, filePath) => {
+    const nextState = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        const current = normalizeReviewState(state.review, state.reviewFilePath);
+        state.review = {
+          ...current,
+          activeFilePath: filePath,
+          currentHunkIndex: -1,
+        };
+        if (filePath) state.reviewFilePath = filePath;
+        else delete state.reviewFilePath;
+      }
+    );
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: nextState,
+      },
+    });
+  },
+  setReviewDiffSource: (workspacePath, source) => {
+    const nextState = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        const current = normalizeReviewState(state.review, state.reviewFilePath);
+        state.review = { ...current, diffSource: source, currentHunkIndex: -1 };
+      }
+    );
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: nextState,
+      },
+    });
+  },
+  setReviewDefaultBranch: (workspacePath, branch) => {
+    const nextState = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        const current = normalizeReviewState(state.review, state.reviewFilePath);
+        state.review = {
+          ...current,
+          defaultBranch: branch || 'main',
+          currentHunkIndex: -1,
+        };
+      }
+    );
+    set({
+      utilityRailByWorkspace: {
+        ...get().utilityRailByWorkspace,
+        [workspacePath]: nextState,
+      },
+    });
+  },
+  setReviewCurrentHunkIndex: (workspacePath, index) => {
+    const nextState = mutateUtilityRailState(
+      workspacePath,
+      get().utilityRailByWorkspace[workspacePath],
+      (state) => {
+        const current = normalizeReviewState(state.review, state.reviewFilePath);
+        state.review = {
+          ...current,
+          currentHunkIndex: Math.max(-1, Math.trunc(index)),
+        };
       }
     );
     set({

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -54,6 +54,7 @@ export interface OpenReviewWorkspaceOptions {
   filePath?: string;
   base?: string;
   preserveSelectedTab?: boolean;
+  preserveFullPageDiff?: boolean;
 }
 export type UtilitySurfacePlacement =
   | { kind: 'rail' }
@@ -734,11 +735,16 @@ export const useUiStore = create<UiState>()((set, get) => ({
         if (!options?.preserveSelectedTab) state.selectedRailTab = 'review';
         const current = normalizeReviewState(state.review, state.reviewFilePath);
         const derived = deriveReviewStateFromBase(options?.base, current);
+        const activeFilePath = options?.filePath ?? current.activeFilePath;
+        const shouldResetHunkIndex =
+          activeFilePath !== current.activeFilePath ||
+          derived.diffSource !== current.diffSource ||
+          derived.defaultBranch !== current.defaultBranch;
         state.review = {
           ...current,
           ...derived,
-          activeFilePath: options?.filePath ?? current.activeFilePath,
-          currentHunkIndex: -1,
+          activeFilePath,
+          currentHunkIndex: shouldResetHunkIndex ? -1 : current.currentHunkIndex,
         };
         if (state.review.activeFilePath) {
           state.reviewFilePath = state.review.activeFilePath;
@@ -748,7 +754,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
       }
     );
     set({
-      fullPageDiff: null,
+      ...(options?.preserveFullPageDiff ? {} : { fullPageDiff: null }),
       utilityRailByWorkspace: {
         ...get().utilityRailByWorkspace,
         [workspacePath]: nextState,

--- a/frontend/src/test-full-page-diff.tsx
+++ b/frontend/src/test-full-page-diff.tsx
@@ -73,19 +73,24 @@ window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
   return originalFetch(input, init);
 };
 
-useUiStore.getState().openReviewWorkspace(workspacePath, { filePath: 'src/a.ts' });
+useUiStore.setState({
+  fullPageDiff: { workspacePath, file: 'src/a.ts' },
+});
 
 const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
 function Harness() {
-  const [visible, setVisible] = React.useState(true);
-  return visible ? (
+  const fullPageDiff = useUiStore((state) => state.fullPageDiff);
+  return fullPageDiff ? (
     <QueryClientProvider client={queryClient}>
-      <FullPageDiff
-        workspacePath={workspacePath}
-        initialFile="src/a.ts"
-        onClose={() => setVisible(false)}
-      />
+      <div className="full-page-diff-overlay">
+        <FullPageDiff
+          workspacePath={fullPageDiff.workspacePath}
+          {...(fullPageDiff.file !== undefined ? { initialFile: fullPageDiff.file } : {})}
+          {...(fullPageDiff.base !== undefined ? { initialBase: fullPageDiff.base } : {})}
+          onClose={() => useUiStore.setState({ fullPageDiff: null })}
+        />
+      </div>
     </QueryClientProvider>
   ) : (
     <div className="utility-empty">closed</div>

--- a/frontend/src/test-full-page-diff.tsx
+++ b/frontend/src/test-full-page-diff.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { FullPageDiff } from './components/FullPageDiff.js';
+import { useUiStore } from './lib/stores/ui.js';
+import './App.css';
+
+type MockChangedFile = {
+  path: string;
+  status: 'modified' | 'added' | 'deleted';
+  additions: number;
+  deletions: number;
+};
+
+const workspacePath = '/tmp/relay-review-workspace';
+const changedFilesByBase: Record<string, MockChangedFile[]> = {
+  working: [
+    { path: 'src/a.ts', status: 'modified', additions: 2, deletions: 1 },
+    { path: 'src/b.ts', status: 'added', additions: 4, deletions: 0 },
+  ],
+  cached: [{ path: 'src/staged.ts', status: 'modified', additions: 1, deletions: 1 }],
+  nightly: [{ path: 'src/base.ts', status: 'deleted', additions: 0, deletions: 3 }],
+};
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function diffFor(filePath: string, base: string | null): string {
+  return [
+    `diff --git a/${filePath} b/${filePath}`,
+    'index 1111111..2222222 100644',
+    `--- a/${filePath}`,
+    `+++ b/${filePath}`,
+    '@@ -1,3 +1,3 @@',
+    `-old ${filePath}`,
+    `+new ${filePath}`,
+    ` context ${base ?? 'working'}`,
+  ].join('\n');
+}
+
+const originalFetch = window.fetch.bind(window);
+window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+  const rawUrl = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+  const url = new URL(rawUrl, window.location.origin);
+
+  if (url.pathname === '/workspaces/default-branch') {
+    return jsonResponse({ branch: 'nightly' });
+  }
+
+  if (url.pathname === '/workspaces/changed-files') {
+    const base = url.searchParams.get('base') ?? 'working';
+    const files = changedFilesByBase[base] ?? [];
+    return jsonResponse({
+      files,
+      aggregate: {
+        additions: files.reduce((sum, file) => sum + file.additions, 0),
+        deletions: files.reduce((sum, file) => sum + file.deletions, 0),
+        fileCount: files.length,
+      },
+    });
+  }
+
+  if (url.pathname === '/workspaces/file-diff') {
+    const filePath = url.searchParams.get('file') ?? 'src/a.ts';
+    const base = url.searchParams.get('base');
+    return jsonResponse({ diff: diffFor(filePath, base) });
+  }
+
+  return originalFetch(input, init);
+};
+
+useUiStore.getState().openReviewWorkspace(workspacePath, { filePath: 'src/a.ts' });
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+function Harness() {
+  const [visible, setVisible] = React.useState(true);
+  return visible ? (
+    <QueryClientProvider client={queryClient}>
+      <FullPageDiff
+        workspacePath={workspacePath}
+        initialFile="src/a.ts"
+        onClose={() => setVisible(false)}
+      />
+    </QueryClientProvider>
+  ) : (
+    <div className="utility-empty">closed</div>
+  );
+}
+
+createRoot(document.getElementById('app')!).render(<Harness />);

--- a/frontend/test-full-page-diff.html
+++ b/frontend/test-full-page-diff.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>full page diff harness</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/test-full-page-diff.tsx"></script>
+  </body>
+</html>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,6 +22,10 @@ if (includeE2eFixtures) {
     import.meta.dirname,
     'test-utility-rail-branch-panel.html'
   );
+  buildInputs['test-full-page-diff'] = resolve(
+    import.meta.dirname,
+    'test-full-page-diff.html'
+  );
 }
 
 export default defineConfig({

--- a/test/components/UtilityRailReviewPanel.test.ts
+++ b/test/components/UtilityRailReviewPanel.test.ts
@@ -89,13 +89,16 @@ describe('UtilityRailReviewPanel', () => {
     queryClient.clear();
   });
 
-  it('selects changed files in place and persists review selection per workspace', async () => {
+  async function renderPanel(props: Record<string, unknown> = {}) {
     await act(async () => {
       root.render(
         React.createElement(
           QueryClientProvider,
           { client: queryClient },
-          React.createElement(UtilityRailReviewPanel, { workspacePath: '/repo/a' })
+          React.createElement(UtilityRailReviewPanel, {
+            workspacePath: '/repo/a',
+            ...props,
+          })
         )
       );
     });
@@ -104,6 +107,10 @@ describe('UtilityRailReviewPanel', () => {
       await flush();
       await flush();
     });
+  }
+
+  it('selects changed files in place and persists review selection per workspace', async () => {
+    await renderPanel();
 
     const button = Array.from(container.querySelectorAll('.sidebar-file')).find((el) =>
       el.textContent?.includes('b.ts')
@@ -122,5 +129,57 @@ describe('UtilityRailReviewPanel', () => {
     });
     expect(useUiStore.getState().openFileTabs).toEqual([]);
     expect(container.querySelector('.mock-diff-viewer')?.getAttribute('data-file')).toBe('src/b.ts');
+  });
+
+  it('handles review shortcuts immediately after opening without manually focusing the panel', async () => {
+    const onRequestClose = vi.fn();
+    await renderPanel({ onRequestClose });
+
+    expect(document.activeElement).not.toBe(container.querySelector('.utility-review-panel'));
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'j', bubbles: true, cancelable: true }));
+      await flush();
+    });
+
+    expect(useUiStore.getState().getUtilityRailState('/repo/a').review).toMatchObject({
+      activeFilePath: 'src/b.ts',
+    });
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+      await flush();
+    });
+
+    expect(onRequestClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores review shortcuts while the review surface is inactive', async () => {
+    await renderPanel({ active: false });
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'j', bubbles: true, cancelable: true }));
+      await flush();
+    });
+
+    expect(useUiStore.getState().getUtilityRailState('/repo/a').review).toMatchObject({
+      activeFilePath: 'src/a.ts',
+    });
+  });
+
+  it('ignores review shortcuts that originate from typing targets', async () => {
+    await renderPanel();
+    const input = document.createElement('input');
+    container.appendChild(input);
+    input.focus();
+
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'j', bubbles: true, cancelable: true }));
+      await flush();
+    });
+
+    expect(useUiStore.getState().getUtilityRailState('/repo/a').review).toMatchObject({
+      activeFilePath: 'src/a.ts',
+    });
   });
 });

--- a/test/components/UtilityRailReviewPanel.test.ts
+++ b/test/components/UtilityRailReviewPanel.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChangedFile } from '../../frontend/src/lib/types.js';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flush() {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+const mocks = vi.hoisted(() => {
+  const files: ChangedFile[] = [
+    { path: 'src/a.ts', status: 'modified', additions: 2, deletions: 1 },
+    { path: 'src/b.ts', status: 'added', additions: 4, deletions: 0 },
+  ];
+  return {
+    fetchChangedFiles: vi.fn(async (_workspacePath: string, _base?: string) => ({
+      files,
+      aggregate: { additions: 6, deletions: 1, fileCount: 2 },
+    })),
+    fetchDefaultBranch: vi.fn(async () => 'nightly'),
+    fetchFileDiff: vi.fn(async (_workspacePath: string, filePath: string) => ({
+      diff: `diff --git a/${filePath} b/${filePath}\n@@ -1 +1 @@\n-old\n+new`,
+    })),
+  };
+});
+
+vi.mock('../../frontend/src/lib/api.js', () => ({
+  fetchChangedFiles: mocks.fetchChangedFiles,
+  fetchDefaultBranch: mocks.fetchDefaultBranch,
+  fetchFileDiff: mocks.fetchFileDiff,
+}));
+
+vi.mock('../../frontend/src/components/DiffViewer.js', () => ({
+  default: ({ filePath, diff, loading }: { filePath: string; diff: string; loading: boolean }) =>
+    React.createElement(
+      'div',
+      {
+        className: 'mock-diff-viewer',
+        'data-file': filePath,
+        'data-loading': String(loading),
+      },
+      diff
+    ),
+}));
+
+import { UtilityRailReviewPanel } from '../../frontend/src/components/UtilityRailReviewPanel.js';
+import {
+  clearUtilityRailStateCacheForTesting,
+  useUiStore,
+} from '../../frontend/src/lib/stores/ui.js';
+
+function resetUiStore() {
+  clearUtilityRailStateCacheForTesting();
+  useUiStore.setState({
+    fullPageDiff: null,
+    fileDiffSource: 'working',
+    fileDiffDefaultBranch: 'main',
+    fileDiffViewMode: 'unified',
+    utilityRailByWorkspace: {},
+    openFileTabs: [],
+    activeFileTabKey: null,
+  });
+}
+
+describe('UtilityRailReviewPanel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetUiStore();
+    useUiStore.getState().openReviewWorkspace('/repo/a', { filePath: 'src/a.ts' });
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    queryClient.clear();
+  });
+
+  it('selects changed files in place and persists review selection per workspace', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(UtilityRailReviewPanel, { workspacePath: '/repo/a' })
+        )
+      );
+    });
+
+    await act(async () => {
+      await flush();
+      await flush();
+    });
+
+    const button = Array.from(container.querySelectorAll('.sidebar-file')).find((el) =>
+      el.textContent?.includes('b.ts')
+    ) as HTMLButtonElement | undefined;
+    expect(button).toBeTruthy();
+
+    await act(async () => {
+      button!.click();
+      await flush();
+    });
+
+    expect(useUiStore.getState().getUtilityRailState('/repo/a').review).toMatchObject({
+      activeFilePath: 'src/b.ts',
+      diffSource: 'working',
+      defaultBranch: 'nightly',
+    });
+    expect(useUiStore.getState().openFileTabs).toEqual([]);
+    expect(container.querySelector('.mock-diff-viewer')?.getAttribute('data-file')).toBe('src/b.ts');
+  });
+});

--- a/test/e2e/components/FullPageDiff.spec.ts
+++ b/test/e2e/components/FullPageDiff.spec.ts
@@ -41,8 +41,13 @@ test.describe('FullPageDiff review workspace compatibility entry', () => {
     await expect(page.locator('.diff-viewer')).toContainText('context cached');
   });
 
-  test('preserves keyboard review navigation inside the panel', async ({ page }) => {
-    await page.locator('.utility-review-panel').focus();
+  test('keeps the real store-guarded compatibility overlay mounted after seeding review state', async ({ page }) => {
+    await expect(page.locator('.full-page-diff')).toBeVisible();
+    await page.waitForTimeout(0);
+    await expect(page.locator('.full-page-diff')).toBeVisible();
+  });
+
+  test('preserves keyboard review navigation immediately after opening', async ({ page }) => {
     await page.keyboard.press('j');
 
     await expect(page.getByRole('option', { name: /b\.ts/ })).toHaveAttribute(

--- a/test/e2e/components/FullPageDiff.spec.ts
+++ b/test/e2e/components/FullPageDiff.spec.ts
@@ -1,37 +1,57 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('FullPageDiff', () => {
-  test('renders correctly', async ({ page }) => {
-    await page.goto('/test-full-page-diff.html');
-    await page.waitForSelector('#app');
-  });
-
-  test('shows header with close button', async ({ page }) => {
+test.describe('FullPageDiff review workspace compatibility entry', () => {
+  test.beforeEach(async ({ page }) => {
     await page.goto('/test-full-page-diff.html');
     await page.waitForSelector('.full-page-diff');
+  });
+
+  test('shows the compatibility header and unified review panel', async ({ page }) => {
     await expect(page.locator('.fpd-header')).toBeVisible();
-    await expect(page.locator('.fpd-close-btn')).toBeVisible();
     await expect(page.locator('.fpd-close-btn')).toContainText('[x] close');
+    await expect(page.locator('.fpd-summary')).toContainText('utility rail review workspace');
+    await expect(page.locator('.utility-review-panel')).toBeVisible();
+    await expect(page.locator('.utility-review-footer')).toContainText('j/k or arrows files');
   });
 
-  test('shows footer with keyboard hints', async ({ page }) => {
-    await page.goto('/test-full-page-diff.html');
-    await page.waitForSelector('.full-page-diff');
-    await expect(page.locator('.fpd-footer')).toBeVisible();
-    const hints = page.locator('.fpd-hint');
-    await expect(hints.first()).toBeVisible();
+  test('selects a changed file and updates the diff in place', async ({ page }) => {
+    await expect(page.getByRole('option', { name: /a\.ts/ })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+
+    await page.getByRole('option', { name: /b\.ts/ }).click();
+
+    await expect(page.getByRole('option', { name: /b\.ts/ })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    await expect(page.locator('.utility-review-title')).toContainText('src/b.ts');
+    await expect(page.locator('.diff-viewer')).toContainText('new src/b.ts');
   });
 
-  test('shows body with sidebar and main pane', async ({ page }) => {
-    await page.goto('/test-full-page-diff.html');
-    await page.waitForSelector('.full-page-diff');
-    await expect(page.locator('.fpd-body')).toBeVisible();
-    await expect(page.locator('.fpd-main')).toBeVisible();
+  test('switches diff source and falls back to the available file list', async ({ page }) => {
+    await page.getByRole('radio', { name: 'staged' }).click();
+
+    await expect(page.getByRole('option', { name: /staged\.ts/ })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    await expect(page.locator('.utility-review-title')).toContainText('src/staged.ts');
+    await expect(page.locator('.diff-viewer')).toContainText('context cached');
   });
 
-  test('mode toggle button is visible', async ({ page }) => {
-    await page.goto('/test-full-page-diff.html');
-    await page.waitForSelector('.full-page-diff');
-    await expect(page.locator('.fpd-mode-toggle')).toBeVisible();
+  test('preserves keyboard review navigation inside the panel', async ({ page }) => {
+    await page.locator('.utility-review-panel').focus();
+    await page.keyboard.press('j');
+
+    await expect(page.getByRole('option', { name: /b\.ts/ })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.full-page-diff')).toHaveCount(0);
+    await expect(page.locator('.utility-empty')).toContainText('closed');
   });
 });

--- a/test/stores/ui-store.test.ts
+++ b/test/stores/ui-store.test.ts
@@ -322,6 +322,45 @@ describe('ui Zustand store', () => {
         },
       });
     });
+
+    it('openReviewWorkspace can seed review state without clearing the full-page overlay guard', () => {
+      useUiStore.setState({
+        fullPageDiff: { workspacePath: '/repo/a', file: 'src/changed.ts' },
+      });
+
+      useUiStore.getState().openReviewWorkspace('/repo/a', {
+        filePath: 'src/changed.ts',
+        preserveFullPageDiff: true,
+      });
+
+      expect(useUiStore.getState().fullPageDiff).toEqual({
+        workspacePath: '/repo/a',
+        file: 'src/changed.ts',
+      });
+      expect(useUiStore.getState().getUtilityRailState('/repo/a')).toMatchObject({
+        selectedRailTab: 'review',
+        review: { activeFilePath: 'src/changed.ts' },
+      });
+    });
+
+    it('openReviewWorkspace preserves hunk navigation when only revealing the current review panel', () => {
+      useUiStore.getState().openReviewWorkspace('/repo/a', {
+        filePath: 'src/changed.ts',
+        base: 'develop',
+      });
+      useUiStore.getState().setReviewCurrentHunkIndex('/repo/a', 3);
+
+      useUiStore.getState().openReviewWorkspace('/repo/a', {
+        preserveSelectedTab: true,
+      });
+
+      expect(useUiStore.getState().getUtilityRailState('/repo/a').review).toMatchObject({
+        activeFilePath: 'src/changed.ts',
+        diffSource: 'branch',
+        defaultBranch: 'develop',
+        currentHunkIndex: 3,
+      });
+    });
   });
 
   describe('active workspace', () => {

--- a/test/stores/ui-store.test.ts
+++ b/test/stores/ui-store.test.ts
@@ -122,15 +122,27 @@ describe('ui Zustand store', () => {
       const a = useUiStore.getState().getUtilityRailState('/repo/a');
       const b = useUiStore.getState().getUtilityRailState('/repo/b');
 
-      expect(a).toEqual({
+      expect(a).toMatchObject({
         visible: true,
         selectedRailTab: null,
         width: DEFAULT_UTILITY_RAIL_WIDTH,
+        review: {
+          activeFilePath: null,
+          diffSource: 'working',
+          defaultBranch: 'main',
+          currentHunkIndex: -1,
+        },
       });
-      expect(b).toEqual({
+      expect(b).toMatchObject({
         visible: true,
         selectedRailTab: null,
         width: DEFAULT_UTILITY_RAIL_WIDTH,
+        review: {
+          activeFilePath: null,
+          diffSource: 'working',
+          defaultBranch: 'main',
+          currentHunkIndex: -1,
+        },
       });
 
       useUiStore.getState().setSelectedUtilityRailTab('/repo/a', 'review');
@@ -143,7 +155,7 @@ describe('ui Zustand store', () => {
         selectedRailTab: 'review',
         width: MAX_UTILITY_RAIL_WIDTH,
       });
-      expect(useUiStore.getState().getUtilityRailState('/repo/b')).toEqual({
+      expect(useUiStore.getState().getUtilityRailState('/repo/b')).toMatchObject({
         visible: true,
         selectedRailTab: null,
         width: DEFAULT_UTILITY_RAIL_WIDTH,
@@ -259,6 +271,54 @@ describe('ui Zustand store', () => {
             kind: 'anchored-pane',
             paneId: 'pane-1',
           },
+        },
+      });
+    });
+
+    it('stores review file, source, default branch, and hunk per workspace', () => {
+      useUiStore.getState().openReviewWorkspace('/repo/a', {
+        filePath: 'src/a.ts',
+        base: 'develop',
+      });
+      useUiStore.getState().setReviewActiveFile('/repo/a', 'src/a2.ts');
+      useUiStore.getState().setReviewCurrentHunkIndex('/repo/a', 2);
+      useUiStore.getState().openReviewWorkspace('/repo/b', {
+        filePath: 'src/b.ts',
+        base: 'cached',
+      });
+
+      expect(useUiStore.getState().getUtilityRailState('/repo/a')).toMatchObject({
+        selectedRailTab: 'review',
+        review: {
+          activeFilePath: 'src/a2.ts',
+          diffSource: 'branch',
+          defaultBranch: 'develop',
+          currentHunkIndex: 2,
+        },
+      });
+      expect(useUiStore.getState().getUtilityRailState('/repo/b')).toMatchObject({
+        selectedRailTab: 'review',
+        review: {
+          activeFilePath: 'src/b.ts',
+          diffSource: 'staged',
+          defaultBranch: 'main',
+          currentHunkIndex: -1,
+        },
+      });
+    });
+
+    it('openReviewWorkspace keeps workspace review navigation in the rail without file tabs', () => {
+      useUiStore.getState().openReviewWorkspace('/repo/a', {
+        filePath: 'src/changed.ts',
+      });
+
+      expect(useUiStore.getState().openFileTabs).toEqual([]);
+      expect(useUiStore.getState().getUtilityRailState('/repo/a')).toMatchObject({
+        visible: true,
+        selectedRailTab: 'review',
+        review: {
+          activeFilePath: 'src/changed.ts',
+          diffSource: 'working',
         },
       });
     });


### PR DESCRIPTION
## Summary
- Adds workspace-scoped utility-rail review state for active changed file, diff source, default branch/base, and hunk position.
- Makes `UtilityRailReviewPanel` the canonical changed-file review surface with source switching, changed-file selection, inline diff rendering, fallback selection, and keyboard file/hunk affordances.
- Routes changed-file entry points from the file tree, file picker, Git Changes panel, action registry, and legacy FullPageDiff into the unified review workspace instead of spawning disconnected diff tabs.
- Demotes `FullPageDiff` to a compatibility shell that preserves the existing header/close entry and embeds the unified review panel.

## Motivation
Issue #253 asks for one coherent review workspace in the utility rail. The prior flows split review state across changed files, file tabs, file viewer panes, and a standalone full-page diff surface, which made source/base changes and file navigation drift between surfaces.

## The Case Against
This change might be wrong because:
- `UtilityRailReviewPanel` and `FullPageDiff` were substantially reshaped, so subtle keyboard/focus regressions are possible outside the covered e2e harness.
- Existing persisted UI state may include deprecated `reviewFilePath`; the migration path is preserved, but older edge-case persisted shapes may still normalize differently than before.
- The e2e coverage uses a lightweight FullPageDiff harness added to Vite instead of the full app shell, so it validates compatibility behavior but not every production navigation path end-to-end.
- The hunk controls currently preserve affordance/state but do not implement full scroll-to-hunk semantics beyond the existing diff rendering constraints.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
|------|------------|------------|
| Review state leaks between workspaces | Low | Store actions and tests scope review state by workspace path. |
| Staged files open as working diffs | Low | Git Changes staged rows explicitly pass `base: cached`; working/untracked rows pass working base. |
| FullPageDiff users lose keyboard flow | Medium | Compatibility wrapper embeds the review panel and targeted Playwright covers header, selection, source switching, and keyboard navigation. |
| Persisted UI state breaks | Low | Deprecated `reviewFilePath` remains supported and migrates into `review.activeFilePath`. |

## Verification
- `rtk npm test -- test/stores/ui-store.test.ts test/components/UtilityRailReviewPanel.test.ts` passed (33 tests).
- `rtk npm run build` passed.
- `rtk npm test` passed (135 files, 1701 tests).
- `rtk npm run test:e2e -- test/e2e/components/FullPageDiff.spec.ts` passed (4 tests).
- `git diff --check` passed.

Closes #253
