### PR TITLE
fix(git): gate no-index diff on confirmed untracked status

### DIFF
--- a/server/git.ts
+++ b/server/git.ts
@@ -789,7 +789,7 @@ async function getFileDiff(
         return stdout;
       }
     } catch {
-      // If status check fails, fall through to --no-index
+      return stdout;
     }
 
     try {

--- a/test/git-changed-files.test.ts
+++ b/test/git-changed-files.test.ts
@@ -167,6 +167,25 @@ describe('getFileDiff', () => {
     expect(callCount).toBe(3);
   });
 
+  it('does not fall back to --no-index when untracked status cannot be confirmed', async () => {
+    let callCount = 0;
+    const diff = await getFileDiff(
+      '/tmp/repo',
+      'maybe-new-file.ts',
+      undefined,
+      async (_file, args) => {
+        callCount++;
+        if (callCount === 1) {
+          return { stdout: '', stderr: '' };
+        }
+        expect(args[0]).toBe('status');
+        throw new Error('status failed');
+      }
+    );
+    expect(diff).toBe('');
+    expect(callCount).toBe(2);
+  });
+
   it('throws on git failure', async () => {
     await expect(() =>
       getFileDiff('/tmp/repo', 'file.ts', undefined, async () => {


### PR DESCRIPTION
## Summary

- Salvages the one still-relevant fix from stale PR #337 onto a clean branch from current `nightly`.
- Makes `getFileDiff` fail closed when `git status --porcelain -- <file>` cannot confirm a path is untracked.
- Adds regression coverage so `git diff --no-index /dev/null <file>` only runs after untracked status is confirmed.

Supersedes #337.

## Why

The old #337 branch is polluted with obsolete lower-stack workspace/file-tree commits and is currently conflicting. Current `nightly` still has the actual sharp edge from the PR: if the status probe fails after an empty normal diff, the code falls through to `--no-index`, which can produce bogus full-file diffs for paths that were never confirmed to be untracked.

## The Case Against

This is intentionally more conservative. If `git status` fails transiently for a genuinely untracked file, the diff endpoint returns the original empty diff instead of attempting a no-index diff. That can hide an untracked file diff in that failure mode, but it avoids treating arbitrary or non-diffable paths as new-file diffs without Git confirmation.

## Verification

- `npm test -- test/git-changed-files.test.ts test/changed-files-api.test.ts` — 31/31 passing
- `npm run check` — passing with existing lint warnings only
