### PR TITLE
fix: cache GitHub PR and CI lookups

### DIFF
--- a/server/gh.ts
+++ b/server/gh.ts
@@ -25,16 +25,44 @@ type ExecFileAsyncLike = (
 
 const PR_CACHE_POSITIVE_TTL_MS = 60_000; // 60s — same as org-dashboard
 const PR_CACHE_NEGATIVE_TTL_MS = 300_000; // 5 min — "no PR" rarely changes without user action
+const BATCH_PR_CACHE_TTL_MS = 60_000;
+const CI_STATUS_CACHE_TTL_MS = 30_000;
 
 interface PrCacheEntry {
   result: PrInfo | null;
   fetchedAt: number;
 }
 
+interface BatchPrCacheEntry {
+  result: Map<string, PrInfo>;
+  fetchedAt: number;
+}
+
+type CiStatusResult = (CiStatus & { authError?: boolean }) | null;
+
+interface CiStatusCacheEntry {
+  result: CiStatusResult;
+  fetchedAt: number;
+}
+
 const prCache = new Map<string, PrCacheEntry>();
+const batchPrCache = new Map<string, BatchPrCacheEntry>();
+const batchPrInFlight = new Map<string, Promise<Map<string, PrInfo>>>();
+const ciStatusCache = new Map<string, CiStatusCacheEntry>();
+const ciStatusInFlight = new Map<string, Promise<CiStatusResult>>();
+let batchPrCacheVersion = 0;
+let ciStatusCacheVersion = 0;
 
 function prCacheKey(repoPath: string, branch: string): string {
   return `${repoPath}:${branch}`;
+}
+
+function ciStatusCacheKey(repoPath: string, branch: string): string {
+  return `${repoPath}:${branch}`;
+}
+
+function clonePrMap(prMap: Map<string, PrInfo>): Map<string, PrInfo> {
+  return new Map(prMap);
 }
 
 function getPrCached(
@@ -62,14 +90,86 @@ function setPrCached(
   prCache.set(prCacheKey(repoPath, branch), { result, fetchedAt: Date.now() });
 }
 
+function getBatchPrCached(repoPath: string): Map<string, PrInfo> | undefined {
+  const entry = batchPrCache.get(repoPath);
+  if (!entry) return undefined;
+  if (Date.now() - entry.fetchedAt > BATCH_PR_CACHE_TTL_MS) {
+    batchPrCache.delete(repoPath);
+    return undefined;
+  }
+  return clonePrMap(entry.result);
+}
+
+function setBatchPrCached(repoPath: string, result: Map<string, PrInfo>): void {
+  batchPrCache.set(repoPath, {
+    result: clonePrMap(result),
+    fetchedAt: Date.now(),
+  });
+}
+
+function getCiStatusCached(
+  repoPath: string,
+  branch: string
+): CiStatusResult | undefined {
+  const key = ciStatusCacheKey(repoPath, branch);
+  const entry = ciStatusCache.get(key);
+  if (!entry) return undefined;
+  if (Date.now() - entry.fetchedAt > CI_STATUS_CACHE_TTL_MS) {
+    ciStatusCache.delete(key);
+    return undefined;
+  }
+  return entry.result;
+}
+
+function setCiStatusCached(
+  repoPath: string,
+  branch: string,
+  result: CiStatusResult
+): void {
+  ciStatusCache.set(ciStatusCacheKey(repoPath, branch), {
+    result,
+    fetchedAt: Date.now(),
+  });
+}
+
+/** Clear batch PR cache entries. If repoPath is given, only clears that repo. */
+function clearBatchPrCache(repoPath?: string): void {
+  batchPrCacheVersion++;
+  if (!repoPath) {
+    batchPrCache.clear();
+    batchPrInFlight.clear();
+    return;
+  }
+  batchPrCache.delete(repoPath);
+  batchPrInFlight.delete(repoPath);
+}
+
+/** Clear CI status cache entries. If repoPath is given, only clears entries for that repo. */
+function clearCiStatusCache(repoPath?: string): void {
+  ciStatusCacheVersion++;
+  if (!repoPath) {
+    ciStatusCache.clear();
+    ciStatusInFlight.clear();
+    return;
+  }
+  const prefix = `${repoPath}:`;
+  for (const key of Array.from(ciStatusCache.keys())) {
+    if (key.startsWith(prefix)) ciStatusCache.delete(key);
+  }
+  for (const key of Array.from(ciStatusInFlight.keys())) {
+    if (key.startsWith(prefix)) ciStatusInFlight.delete(key);
+  }
+}
+
 /** Clear PR cache entries. If repoPath is given, only clears entries for that repo. */
 function clearPrCache(repoPath?: string): void {
+  clearBatchPrCache(repoPath);
   if (!repoPath) {
     prCache.clear();
     return;
   }
   const prefix = `${repoPath}:`;
-  for (const key of prCache.keys()) {
+  for (const key of Array.from(prCache.keys())) {
     if (key.startsWith(prefix)) prCache.delete(key);
   }
 }
@@ -151,9 +251,39 @@ async function getCiStatus(
   options: {
     exec?: ExecFileAsyncLike;
   } = {}
-): Promise<(CiStatus & { authError?: boolean }) | null> {
+): Promise<CiStatusResult> {
+  const cached = getCiStatusCached(repoPath, branch);
+  if (cached !== undefined) return cached;
+
+  const key = ciStatusCacheKey(repoPath, branch);
+  const inFlight = ciStatusInFlight.get(key);
+  if (inFlight) return inFlight;
+
   const run: ExecFileAsyncLike =
     options.exec || (execFileAsync as ExecFileAsyncLike);
+  const cacheVersion = ciStatusCacheVersion;
+
+  const promise = fetchCiStatus(repoPath, branch, run)
+    .then((result) => {
+      if (cacheVersion === ciStatusCacheVersion) {
+        setCiStatusCached(repoPath, branch, result);
+      }
+      return result;
+    })
+    .finally(() => {
+      if (ciStatusInFlight.get(key) === promise) {
+        ciStatusInFlight.delete(key);
+      }
+    });
+  ciStatusInFlight.set(key, promise);
+  return promise;
+}
+
+async function fetchCiStatus(
+  repoPath: string,
+  branch: string,
+  run: ExecFileAsyncLike
+): Promise<CiStatusResult> {
 
   let stdout: string;
   let stderr: string;
@@ -258,66 +388,93 @@ async function batchGetPrsForRepo(
   repoPath: string,
   options: { exec?: ExecFileAsyncLike } = {}
 ): Promise<Map<string, PrInfo>> {
+  const cached = getBatchPrCached(repoPath);
+  if (cached) return cached;
+
+  const inFlight = batchPrInFlight.get(repoPath);
+  if (inFlight) return inFlight;
+
   const run: ExecFileAsyncLike =
     options.exec || (execFileAsync as ExecFileAsyncLike);
+  const cacheVersion = batchPrCacheVersion;
+  const promise = fetchBatchPrsForRepo(repoPath, run)
+    .then((result) => {
+      if (cacheVersion === batchPrCacheVersion) {
+        setBatchPrCached(repoPath, result);
+      }
+      return clonePrMap(result);
+    })
+    .catch((err: unknown) => {
+      logger.warn(
+        '[gh] batchGetPrsForRepo failed for',
+        repoPath,
+        err instanceof Error ? err.message : err
+      );
+      return new Map<string, PrInfo>();
+    })
+    .finally(() => {
+      if (batchPrInFlight.get(repoPath) === promise) {
+        batchPrInFlight.delete(repoPath);
+      }
+    });
+  batchPrInFlight.set(repoPath, promise);
+  return promise;
+}
+
+async function fetchBatchPrsForRepo(
+  repoPath: string,
+  run: ExecFileAsyncLike
+): Promise<Map<string, PrInfo>> {
   const prMap = new Map<string, PrInfo>();
 
-  try {
-    const { stdout } = await run(
-      'gh',
-      [
-        'pr',
-        'list',
-        '--state',
-        'all',
-        '--limit',
-        '100',
-        '--json',
-        'number,title,url,state,headRefName,baseRefName,reviewDecision,isDraft,additions,deletions,mergeable,updatedAt',
-      ],
-      { cwd: repoPath, timeout: 10000 }
-    );
+  const { stdout } = await run(
+    'gh',
+    [
+      'pr',
+      'list',
+      '--state',
+      'all',
+      '--limit',
+      '100',
+      '--json',
+      'number,title,url,state,headRefName,baseRefName,reviewDecision,isDraft,additions,deletions,mergeable,updatedAt',
+    ],
+    { cwd: repoPath, timeout: 10000 }
+  );
 
-    if (!stdout.trim()) return prMap;
+  if (!stdout.trim()) return prMap;
 
-    const prs = JSON.parse(stdout) as Array<{
-      number: number;
-      title: string;
-      url: string;
-      state: string;
-      headRefName: string;
-      baseRefName: string;
-      isDraft: boolean;
-      reviewDecision: string | null;
-      additions: number;
-      deletions: number;
-      mergeable: string;
-      updatedAt: string;
-    }>;
+  const prs = JSON.parse(stdout) as Array<{
+    number: number;
+    title: string;
+    url: string;
+    state: string;
+    headRefName: string;
+    baseRefName: string;
+    isDraft: boolean;
+    reviewDecision: string | null;
+    additions: number;
+    deletions: number;
+    mergeable: string;
+    updatedAt: string;
+  }>;
 
-    for (const data of prs) {
-      prMap.set(data.headRefName, {
-        number: data.number,
-        title: data.title,
-        url: data.url,
-        state: data.state as PrInfo['state'],
-        headRefName: data.headRefName,
-        baseRefName: data.baseRefName,
-        isDraft: data.isDraft,
-        reviewDecision: data.reviewDecision ?? null,
-        additions: data.additions ?? 0,
-        deletions: data.deletions ?? 0,
-        mergeable: (data.mergeable as PrInfo['mergeable']) ?? 'UNKNOWN',
-        unresolvedCommentCount: 0,
-        updatedAt: data.updatedAt ?? '',
-      });
-    }
-  } catch (err) {
-    logger.warn(
-      '[gh] batchGetPrsForRepo failed for',
-      repoPath,
-      err instanceof Error ? err.message : err
-    );
+  for (const data of prs) {
+    prMap.set(data.headRefName, {
+      number: data.number,
+      title: data.title,
+      url: data.url,
+      state: data.state as PrInfo['state'],
+      headRefName: data.headRefName,
+      baseRefName: data.baseRefName,
+      isDraft: data.isDraft,
+      reviewDecision: data.reviewDecision ?? null,
+      additions: data.additions ?? 0,
+      deletions: data.deletions ?? 0,
+      mergeable: (data.mergeable as PrInfo['mergeable']) ?? 'UNKNOWN',
+      unresolvedCommentCount: 0,
+      updatedAt: data.updatedAt ?? '',
+    });
   }
 
   return prMap;
@@ -437,4 +594,6 @@ export {
   getPrCached,
   setPrCached,
   clearPrCache,
+  clearBatchPrCache,
+  clearCiStatusCache,
 };

--- a/server/index.ts
+++ b/server/index.ts
@@ -69,7 +69,9 @@ import {
   createWorkspaceRouter,
   clearPrCache,
   clearFilesListCache,
+  clearDashboardPrCache,
 } from './workspaces.js';
+import { clearCiStatusCache } from './gh.js';
 import { createWorkspaceGroupsRouter } from './workspace-groups.js';
 import { createOrgDashboardRouter } from './org-dashboard.js';
 import { createIntegrationGitHubRouter } from './integration-github.js';
@@ -1130,14 +1132,19 @@ async function main(): Promise<void> {
   // Wire up the delegate used by the webhook router (mounted before broadcastEvent was available).
   // Smart polling includes workspace paths, so clear those caches without flushing every repo.
   broadcastEventDelegate = (type, data) => {
-    if (type === 'pr-updated') {
+    if (type === 'pr-updated' || type === 'ci-updated') {
       const workspacePaths = data?.workspacePaths;
       if (Array.isArray(workspacePaths)) {
         for (const workspacePath of workspacePaths) {
-          if (typeof workspacePath === 'string') clearPrCache(workspacePath);
+          if (typeof workspacePath !== 'string') continue;
+          clearDashboardPrCache(workspacePath);
+          if (type === 'pr-updated') clearPrCache(workspacePath);
+          if (type === 'ci-updated') clearCiStatusCache(workspacePath);
         }
       } else {
-        clearPrCache();
+        clearDashboardPrCache();
+        if (type === 'pr-updated') clearPrCache();
+        if (type === 'ci-updated') clearCiStatusCache();
       }
     }
     broadcastEvent(type, data);

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -188,6 +188,169 @@ export function clearFilesListCache(workspacePath?: string): void {
 
 const BROWSE_MAX_ENTRIES = 100;
 const BULK_MAX_PATHS = 50;
+const DASHBOARD_PR_CACHE_TTL_MS = 60_000;
+
+const DASHBOARD_PR_FIELDS =
+  'number,title,url,headRefName,baseRefName,state,author,updatedAt,additions,deletions,reviewDecision,mergeable,mergeStateStatus,isDraft';
+
+type ExecAsyncLike = (
+  file: string,
+  args: string[],
+  options: { cwd: string; timeout?: number }
+) => Promise<{ stdout: string; stderr: string }>;
+
+interface DashboardPrCacheEntry {
+  pullRequests: PullRequestsResponse;
+  fetchedAt: number;
+}
+
+const dashboardPrCache = new Map<string, DashboardPrCacheEntry>();
+const dashboardPrInFlight = new Map<
+  string,
+  Promise<PullRequestsResponse>
+>();
+let dashboardPrCacheVersion = 0;
+
+export function clearDashboardPrCache(repoPath?: string): void {
+  dashboardPrCacheVersion++;
+  if (!repoPath) {
+    dashboardPrCache.clear();
+    dashboardPrInFlight.clear();
+    return;
+  }
+  dashboardPrCache.delete(repoPath);
+  dashboardPrInFlight.delete(repoPath);
+}
+
+function mapRawDashboardPr(
+  raw: Record<string, unknown>,
+  role: 'author' | 'reviewer',
+  fallbackAuthor: string
+): PullRequest {
+  return {
+    number: raw.number as number,
+    title: raw.title as string,
+    url: raw.url as string,
+    headRefName: raw.headRefName as string,
+    baseRefName: (raw.baseRefName as string) ?? '',
+    state: raw.state as 'OPEN' | 'CLOSED' | 'MERGED',
+    author: (raw.author as { login?: string })?.login ?? fallbackAuthor,
+    role,
+    updatedAt: raw.updatedAt as string,
+    additions: (raw.additions as number) ?? 0,
+    deletions: (raw.deletions as number) ?? 0,
+    reviewDecision:
+      (raw.reviewDecision as
+        | 'APPROVED'
+        | 'CHANGES_REQUESTED'
+        | 'REVIEW_REQUIRED'
+        | null) ?? null,
+    mergeable:
+      (raw.mergeable as 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN' | null) ??
+      null,
+    isDraft: (raw.isDraft as boolean) ?? false,
+    ciStatus: null,
+  };
+}
+
+function getDashboardPrCached(repoPath: string): PullRequestsResponse | null {
+  const entry = dashboardPrCache.get(repoPath);
+  if (!entry) return null;
+  if (Date.now() - entry.fetchedAt > DASHBOARD_PR_CACHE_TTL_MS) {
+    dashboardPrCache.delete(repoPath);
+    return null;
+  }
+  return entry.pullRequests;
+}
+
+async function fetchDashboardPullRequests(
+  repoPath: string,
+  currentUser: string,
+  exec: ExecAsyncLike
+): Promise<PullRequestsResponse> {
+  const [authored, reviewing] = await Promise.all([
+    fetchDashboardPrsForRole(repoPath, currentUser, 'author', exec),
+    fetchDashboardPrsForRole(repoPath, currentUser, 'reviewer', exec),
+  ]);
+
+  const seen = new Set(authored.map((pr) => pr.number));
+  const combined = [
+    ...authored,
+    ...reviewing.filter((pr) => !seen.has(pr.number)),
+  ];
+
+  combined.sort(
+    (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  );
+
+  return { prs: combined };
+}
+
+async function fetchDashboardPrsForRole(
+  repoPath: string,
+  currentUser: string,
+  role: 'author' | 'reviewer',
+  exec: ExecAsyncLike
+): Promise<PullRequest[]> {
+  const roleArgs =
+    role === 'author'
+      ? ['--author', currentUser]
+      : ['--search', `review-requested:${currentUser}`];
+  try {
+    const { stdout } = await exec(
+      'gh',
+      [
+        'pr',
+        'list',
+        ...roleArgs,
+        '--state',
+        'open',
+        '--limit',
+        '30',
+        '--json',
+        DASHBOARD_PR_FIELDS,
+      ],
+      { cwd: repoPath }
+    );
+    const fallbackAuthor = role === 'author' ? currentUser : '';
+    return (JSON.parse(stdout) as Array<Record<string, unknown>>).map((pr) =>
+      mapRawDashboardPr(pr, role, fallbackAuthor)
+    );
+  } catch {
+    return [];
+  }
+}
+
+function getDashboardPullRequests(
+  repoPath: string,
+  currentUser: string,
+  exec: ExecAsyncLike
+): Promise<PullRequestsResponse> {
+  const cached = getDashboardPrCached(repoPath);
+  if (cached) return Promise.resolve(cached);
+
+  const inFlight = dashboardPrInFlight.get(repoPath);
+  if (inFlight) return inFlight;
+
+  const cacheVersion = dashboardPrCacheVersion;
+  const promise = fetchDashboardPullRequests(repoPath, currentUser, exec)
+    .then((pullRequests) => {
+      if (cacheVersion === dashboardPrCacheVersion) {
+        dashboardPrCache.set(repoPath, {
+          pullRequests,
+          fetchedAt: Date.now(),
+        });
+      }
+      return pullRequests;
+    })
+    .finally(() => {
+      if (dashboardPrInFlight.get(repoPath) === promise) {
+        dashboardPrInFlight.delete(repoPath);
+      }
+    });
+  dashboardPrInFlight.set(repoPath, promise);
+  return promise;
+}
 
 export { clearPrCacheImpl as clearPrCache };
 
@@ -670,11 +833,8 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
       return;
     }
 
-    const fields =
-      'number,title,url,headRefName,baseRefName,state,author,updatedAt,additions,deletions,reviewDecision,mergeable,mergeStateStatus,isDraft';
-
     // Get current GitHub user
-    let currentUser = '';
+    let currentUser: string;
     try {
       const { stdout: whoami } = await exec(
         'gh',
@@ -691,106 +851,11 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
       return;
     }
 
-    // Helper to map raw gh JSON to PullRequest
-    function mapRawPr(
-      raw: Record<string, unknown>,
-      role: 'author' | 'reviewer',
-      fallbackAuthor: string
-    ): PullRequest {
-      return {
-        number: raw.number as number,
-        title: raw.title as string,
-        url: raw.url as string,
-        headRefName: raw.headRefName as string,
-        baseRefName: (raw.baseRefName as string) ?? '',
-        state: raw.state as 'OPEN' | 'CLOSED' | 'MERGED',
-        author: (raw.author as { login?: string })?.login ?? fallbackAuthor,
-        role,
-        updatedAt: raw.updatedAt as string,
-        additions: (raw.additions as number) ?? 0,
-        deletions: (raw.deletions as number) ?? 0,
-        reviewDecision:
-          (raw.reviewDecision as
-            | 'APPROVED'
-            | 'CHANGES_REQUESTED'
-            | 'REVIEW_REQUIRED'
-            | null) ?? null,
-        mergeable:
-          (raw.mergeable as 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN' | null) ??
-          null,
-        isDraft: (raw.isDraft as boolean) ?? false,
-        ciStatus: null,
-      };
-    }
-
-    // Fetch authored + review-requested PRs in parallel
-    const [authored, reviewing] = await Promise.all([
-      (async (): Promise<PullRequest[]> => {
-        try {
-          const { stdout } = await exec(
-            'gh',
-            [
-              'pr',
-              'list',
-              '--author',
-              currentUser,
-              '--state',
-              'open',
-              '--limit',
-              '30',
-              '--json',
-              fields,
-            ],
-            { cwd: repoPath }
-          );
-          return (JSON.parse(stdout) as Array<Record<string, unknown>>).map(
-            (pr) => mapRawPr(pr, 'author', currentUser)
-          );
-        } catch {
-          return [];
-        }
-      })(),
-      (async (): Promise<PullRequest[]> => {
-        try {
-          const { stdout } = await exec(
-            'gh',
-            [
-              'pr',
-              'list',
-              '--search',
-              `review-requested:${currentUser}`,
-              '--state',
-              'open',
-              '--limit',
-              '30',
-              '--json',
-              fields,
-            ],
-            { cwd: repoPath }
-          );
-          return (JSON.parse(stdout) as Array<Record<string, unknown>>).map(
-            (pr) => mapRawPr(pr, 'reviewer', '')
-          );
-        } catch {
-          return [];
-        }
-      })(),
-    ]);
-
-    // Deduplicate: if a PR appears in both, keep as 'author'
-    const seen = new Set(authored.map((pr) => pr.number));
-    const combined = [
-      ...authored,
-      ...reviewing.filter((pr) => !seen.has(pr.number)),
-    ];
-
-    // Sort by updatedAt descending
-    combined.sort(
-      (a, b) =>
-        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+    const pullRequests = await getDashboardPullRequests(
+      repoPath,
+      currentUser,
+      exec as ExecAsyncLike
     );
-
-    const pullRequests: PullRequestsResponse = { prs: combined };
 
     // Fetch branches for the repo
     let branches: string[] = [];

--- a/test/gh-cache.test.ts
+++ b/test/gh-cache.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  batchGetPrsForRepo,
+  clearBatchPrCache,
+  clearCiStatusCache,
+  getCiStatus,
+} from '../server/gh.js';
+
+type ExecFn = (
+  file: string,
+  args: string[],
+  options: { cwd: string; timeout?: number }
+) => Promise<{ stdout: string; stderr: string }>;
+
+const prList = JSON.stringify([
+  {
+    number: 42,
+    title: 'Cache me',
+    url: 'https://github.com/o/r/pull/42',
+    state: 'OPEN',
+    headRefName: 'feat/cache',
+    baseRefName: 'nightly',
+    isDraft: false,
+    reviewDecision: null,
+    additions: 1,
+    deletions: 0,
+    mergeable: 'MERGEABLE',
+    updatedAt: '2026-01-01T00:00:00Z',
+  },
+]);
+
+const checks = JSON.stringify([
+  { name: 'build', state: 'COMPLETED', conclusion: 'SUCCESS' },
+]);
+
+beforeEach(() => {
+  clearBatchPrCache();
+  clearCiStatusCache();
+});
+
+describe('batchGetPrsForRepo cache', () => {
+  it('returns a cached result within the ttl without spawning gh again', async () => {
+    let calls = 0;
+    const exec: ExecFn = async () => {
+      calls += 1;
+      return { stdout: prList, stderr: '' };
+    };
+
+    const first = await batchGetPrsForRepo('/repos/one', { exec });
+    const second = await batchGetPrsForRepo('/repos/one', { exec });
+
+    expect(first.get('feat/cache')?.number).toBe(42);
+    expect(second.get('feat/cache')?.number).toBe(42);
+    expect(calls).toBe(1);
+  });
+
+  it('deduplicates concurrent calls for the same repo path', async () => {
+    let calls = 0;
+    let resolveExec: ((value: { stdout: string; stderr: string }) => void) | null =
+      null;
+    const exec: ExecFn = async () => {
+      calls += 1;
+      return new Promise((resolve) => {
+        resolveExec = resolve;
+      });
+    };
+
+    const first = batchGetPrsForRepo('/repos/one', { exec });
+    const second = batchGetPrsForRepo('/repos/one', { exec });
+
+    expect(calls).toBe(1);
+    resolveExec?.({ stdout: prList, stderr: '' });
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(firstResult.get('feat/cache')?.number).toBe(42);
+    expect(secondResult.get('feat/cache')?.number).toBe(42);
+    expect(calls).toBe(1);
+  });
+
+  it('misses after repo invalidation', async () => {
+    let calls = 0;
+    const exec: ExecFn = async () => {
+      calls += 1;
+      return { stdout: prList, stderr: '' };
+    };
+
+    await batchGetPrsForRepo('/repos/one', { exec });
+    clearBatchPrCache('/repos/one');
+    await batchGetPrsForRepo('/repos/one', { exec });
+
+    expect(calls).toBe(2);
+  });
+
+  it('does not let an invalidated in-flight lookup repopulate the cache', async () => {
+    let calls = 0;
+    let resolveExec: ((value: { stdout: string; stderr: string }) => void) | null =
+      null;
+    const exec: ExecFn = async () => {
+      calls += 1;
+      return new Promise((resolve) => {
+        resolveExec = resolve;
+      });
+    };
+
+    const first = batchGetPrsForRepo('/repos/one', { exec });
+    clearBatchPrCache('/repos/one');
+    resolveExec?.({ stdout: prList, stderr: '' });
+    await first;
+
+    const second = batchGetPrsForRepo('/repos/one', { exec });
+    resolveExec?.({ stdout: prList, stderr: '' });
+    await second;
+
+    expect(calls).toBe(2);
+  });
+
+  it('keeps a newer in-flight lookup after an invalidated older lookup settles', async () => {
+    let calls = 0;
+    const resolvers: Array<
+      (value: { stdout: string; stderr: string }) => void
+    > = [];
+    const exec: ExecFn = async () => {
+      calls += 1;
+      return new Promise((resolve) => {
+        resolvers.push(resolve);
+      });
+    };
+
+    const first = batchGetPrsForRepo('/repos/one', { exec });
+    clearBatchPrCache('/repos/one');
+    const second = batchGetPrsForRepo('/repos/one', { exec });
+
+    expect(calls).toBe(2);
+    resolvers[0]?.({ stdout: prList, stderr: '' });
+    await first;
+
+    const third = batchGetPrsForRepo('/repos/one', { exec });
+    expect(calls).toBe(2);
+
+    resolvers[1]?.({ stdout: prList, stderr: '' });
+    await expect(Promise.all([second, third])).resolves.toHaveLength(2);
+    expect(calls).toBe(2);
+  });
+});
+
+describe('getCiStatus cache', () => {
+  it('returns a cached status within the ttl without spawning gh again', async () => {
+    let calls = 0;
+    const exec: ExecFn = async () => {
+      calls += 1;
+      return { stdout: checks, stderr: '' };
+    };
+
+    const first = await getCiStatus('/repos/one', 'feat/cache', { exec });
+    const second = await getCiStatus('/repos/one', 'feat/cache', { exec });
+
+    expect(first).toEqual({ total: 1, passing: 1, failing: 0, pending: 0 });
+    expect(second).toEqual(first);
+    expect(calls).toBe(1);
+  });
+
+  it('deduplicates concurrent calls for the same repo path and branch', async () => {
+    let calls = 0;
+    let resolveExec: ((value: { stdout: string; stderr: string }) => void) | null =
+      null;
+    const exec: ExecFn = async () => {
+      calls += 1;
+      return new Promise((resolve) => {
+        resolveExec = resolve;
+      });
+    };
+
+    const first = getCiStatus('/repos/one', 'feat/cache', { exec });
+    const second = getCiStatus('/repos/one', 'feat/cache', { exec });
+
+    expect(calls).toBe(1);
+    resolveExec?.({ stdout: checks, stderr: '' });
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { total: 1, passing: 1, failing: 0, pending: 0 },
+      { total: 1, passing: 1, failing: 0, pending: 0 },
+    ]);
+    expect(calls).toBe(1);
+  });
+
+  it('misses after repo invalidation', async () => {
+    let calls = 0;
+    const exec: ExecFn = async () => {
+      calls += 1;
+      return { stdout: checks, stderr: '' };
+    };
+
+    await getCiStatus('/repos/one', 'feat/cache', { exec });
+    clearCiStatusCache('/repos/one');
+    await getCiStatus('/repos/one', 'feat/cache', { exec });
+
+    expect(calls).toBe(2);
+  });
+
+  it('keeps a newer in-flight lookup after an invalidated older lookup settles', async () => {
+    let calls = 0;
+    const resolvers: Array<
+      (value: { stdout: string; stderr: string }) => void
+    > = [];
+    const exec: ExecFn = async () => {
+      calls += 1;
+      return new Promise((resolve) => {
+        resolvers.push(resolve);
+      });
+    };
+
+    const first = getCiStatus('/repos/one', 'feat/cache', { exec });
+    clearCiStatusCache('/repos/one');
+    const second = getCiStatus('/repos/one', 'feat/cache', { exec });
+
+    expect(calls).toBe(2);
+    resolvers[0]?.({ stdout: checks, stderr: '' });
+    await first;
+
+    const third = getCiStatus('/repos/one', 'feat/cache', { exec });
+    expect(calls).toBe(2);
+
+    resolvers[1]?.({ stdout: checks, stderr: '' });
+    await expect(Promise.all([second, third])).resolves.toHaveLength(2);
+    expect(calls).toBe(2);
+  });
+});

--- a/test/workspaces-dashboard-cache.test.ts
+++ b/test/workspaces-dashboard-cache.test.ts
@@ -1,0 +1,158 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import express from 'express';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createWorkspaceRouter,
+  clearDashboardPrCache,
+  type WorkspaceDeps,
+} from '../server/workspaces.js';
+import { DEFAULTS, saveConfig } from '../server/config.js';
+import { createTestServer } from './helpers/test-server.js';
+
+type ExecFn = NonNullable<WorkspaceDeps['execAsync']>;
+type ExecResult = { stdout: string; stderr: string };
+
+let tmpDir = '';
+let configPath = '';
+let repoPath = '';
+
+beforeEach(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dashboard-cache-test-'));
+  configPath = path.join(tmpDir, 'config.json');
+  repoPath = path.join(tmpDir, 'repo');
+  fs.mkdirSync(repoPath, { recursive: true });
+  saveConfig(configPath, { ...DEFAULTS, repos: [repoPath] });
+  clearDashboardPrCache();
+});
+
+afterAll(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function fetchDashboard(
+  exec: ExecFn
+): Promise<{ pullRequests: { prs: Array<{ number: number; title: string }> } }> {
+  const app = express();
+  app.use(express.json());
+  app.use('/workspaces', createWorkspaceRouter({ configPath, execAsync: exec }));
+  const server = await createTestServer(app);
+  try {
+    const params = new URLSearchParams({ path: repoPath });
+    const res = await fetch(`${server.url}/workspaces/dashboard?${params}`);
+    expect(res.status).toBe(200);
+    return (await res.json()) as Promise<{
+      pullRequests: { prs: Array<{ number: number; title: string }> };
+    }>;
+  } finally {
+    await server.close();
+  }
+}
+
+function makeDashboardExec(counter: { prListCalls: number }): ExecFn {
+  return async (file, args) => {
+    if (file === 'gh' && args[0] === 'api' && args[1] === 'user') {
+      return { stdout: 'me\n', stderr: '' };
+    }
+    if (file === 'gh' && args[0] === 'pr' && args[1] === 'list') {
+      counter.prListCalls += 1;
+      const role = args.includes('--author') ? 'author' : 'reviewer';
+      const prs =
+        role === 'author'
+          ? [
+              {
+                number: counter.prListCalls,
+                title: `pr call ${counter.prListCalls}`,
+                url: 'https://github.com/o/r/pull/1',
+                headRefName: 'feat/cache',
+                baseRefName: 'nightly',
+                state: 'OPEN',
+                author: { login: 'me' },
+                updatedAt: '2026-01-01T00:00:00Z',
+                additions: 1,
+                deletions: 0,
+                reviewDecision: null,
+                mergeable: 'MERGEABLE',
+                isDraft: false,
+              },
+            ]
+          : [];
+      return { stdout: JSON.stringify(prs), stderr: '' };
+    }
+    throw new Error(`unexpected exec: ${file} ${args.join(' ')}`);
+  };
+}
+
+describe('/workspaces/dashboard PR cache', () => {
+  it('caches the combined PR result by repo path until invalidated', async () => {
+    const counter = { prListCalls: 0 };
+    const exec = makeDashboardExec(counter);
+
+    const first = await fetchDashboard(exec);
+    const second = await fetchDashboard(exec);
+
+    expect(first.pullRequests.prs[0]?.title).toBe('pr call 1');
+    expect(second.pullRequests.prs[0]?.title).toBe('pr call 1');
+    expect(counter.prListCalls).toBe(2);
+
+    clearDashboardPrCache(repoPath);
+    const third = await fetchDashboard(exec);
+
+    expect(third.pullRequests.prs[0]?.title).toBe('pr call 3');
+    expect(counter.prListCalls).toBe(4);
+  });
+
+  it('deduplicates concurrent combined PR lookups for the same repo path', async () => {
+    const counter = { prListCalls: 0 };
+    const exec = makeDashboardExec(counter);
+
+    const [first, second] = await Promise.all([
+      fetchDashboard(exec),
+      fetchDashboard(exec),
+    ]);
+
+    expect(first.pullRequests.prs[0]?.title).toBe('pr call 1');
+    expect(second.pullRequests.prs[0]?.title).toBe('pr call 1');
+    expect(counter.prListCalls).toBe(2);
+  });
+
+  it('keeps a newer in-flight lookup after an invalidated older lookup settles', async () => {
+    const prListResolvers: Array<(value: ExecResult) => void> = [];
+    let prListCalls = 0;
+    const exec: ExecFn = async (file, args) => {
+      if (file === 'gh' && args[0] === 'api' && args[1] === 'user') {
+        return { stdout: 'me\n', stderr: '' };
+      }
+      if (file === 'gh' && args[0] === 'pr' && args[1] === 'list') {
+        prListCalls += 1;
+        return new Promise((resolve) => {
+          prListResolvers.push(resolve);
+        });
+      }
+      throw new Error(`unexpected exec: ${file} ${args.join(' ')}`);
+    };
+
+    const first = fetchDashboard(exec);
+    await vi.waitFor(() => expect(prListCalls).toBe(2));
+    clearDashboardPrCache(repoPath);
+    const second = fetchDashboard(exec);
+    await vi.waitFor(() => expect(prListCalls).toBe(4));
+
+    prListResolvers[0]?.({ stdout: '[]', stderr: '' });
+    prListResolvers[1]?.({ stdout: '[]', stderr: '' });
+    await first;
+
+    const third = fetchDashboard(exec);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(prListCalls).toBe(4);
+
+    prListResolvers[2]?.({ stdout: '[]', stderr: '' });
+    prListResolvers[3]?.({ stdout: '[]', stderr: '' });
+    await expect(Promise.all([second, third])).resolves.toHaveLength(2);
+    expect(prListCalls).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
- Add 60s TTL caching and in-flight Promise deduplication for `batchGetPrsForRepo(repoPath)`.
- Add 30s TTL caching and in-flight Promise deduplication for `getCiStatus(repoPath, branch)`.
- Add 60s dashboard PR-list caching for `/workspaces/dashboard` so repeated dashboard loads do not spawn duplicate `gh pr list` subprocesses.
- Invalidate PR/dashboard caches on `pr-updated` and CI/dashboard caches on `ci-updated`, scoped by `workspacePaths` when present.
- Guard cache invalidation races with cache-version counters and current-promise checks so invalidated/older in-flight requests cannot repopulate or delete newer cache work after resolving.

Closes #354
Refs #353

## Verification
- `npm test -- test/gh-cache.test.ts test/gh-routes.test.ts test/workspaces-dashboard-cache.test.ts --reporter=dot` — passed, 17 tests.
- `npm run check` — passed with existing warnings only.
- `npm run build` — passed.
- `npm test` — passed, 144 files / 1763 tests.
- `git diff --check` — passed.

## The Case Against
- These caches intentionally trade freshness for fewer `gh` subprocesses. The TTLs are short and webhook/smart-poll invalidation should keep normal UI flows fresh, but users without timely webhook/poll events can still see PR/CI/dashboard data up to 30–60 seconds stale.
- Dashboard caching is keyed by repo path and assumes the current GitHub user for that repo is stable during the TTL. If someone changes auth identity while Relay is running, dashboard PR data may lag until cache expiry or invalidation.
- Cache invalidation currently reacts to `pr-updated` and `ci-updated` events flowing through the existing broadcast delegate. If a future route mutates PR/CI state without emitting those events, it may need an explicit cache clear too.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
| --- | --- | --- |
| stale PR/CI/dashboard data | medium | short TTLs plus event-driven invalidation for webhook/smart-poll updates |
| duplicate subprocesses under concurrent requests | low after this change | in-flight Promise maps coalesce same-key calls |
| invalidated in-flight promise repopulates stale cache | low after this change | cache-version counters tested with regression coverage |
| older in-flight promise deletes newer in-flight entry | low after this change | finally handlers only delete the map entry if it still points at the same promise |
| cached `Map` mutation leaks between callers | low | batch PR cache returns cloned maps |

## Operational Notes
- No migrations or config changes.
- Existing `gh api user` lookup in the dashboard route is still uncached; this PR focuses on the heavier repeated PR/CI/dashboard list calls from #354.
