### PR TITLE
fix: add per-repo enrichment freshness

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,6 +39,7 @@ import {
 import { initAnalytics, destroyAnalytics, track } from './lib/analytics.js';
 import type { ActionContext } from './lib/actions/types.js';
 import { useEventSocket } from './hooks/useEventSocket.js';
+import { useVisibilityRefresh } from './hooks/useVisibilityRefresh.js';
 import { useAppShortcuts } from './hooks/useAppShortcuts.js';
 import { useActionRegistry } from './hooks/useActionRegistry.js';
 import { useSessionHandlers } from './hooks/useSessionHandlers.js';
@@ -959,6 +960,7 @@ export default function App() {
     typeof setTimeout
   > | null>(null);
   const bootRefreshDone = useRef(false);
+  const navRefreshMounted = useRef(false);
 
   // ── Derived state ──────────────────────────────────────────────────────────
   // activeSession and activeWorkspaceCwd are needed for FilePicker
@@ -1156,8 +1158,8 @@ export default function App() {
 
       if (isInitialBoot) {
         finishBoot();
-        // Backfill PR info and staleness via batch enrichment
-        useSessionsStore.getState().enrichSidebarBranches();
+        // Backfill PR info and staleness via per-repo enrichment.
+        useSessionsStore.getState().ensureFreshAll(0);
       }
 
       // Restore navigation state from the URL path (or fall back to ?session= for legacy links)
@@ -1201,6 +1203,24 @@ export default function App() {
 
     runRefresh();
   }, [authAuthenticated, loadFrameworks]);
+
+  useVisibilityRefresh(authAuthenticated);
+
+  useEffect(() => {
+    if (!authAuthenticated) return;
+    if (!navRefreshMounted.current) {
+      navRefreshMounted.current = true;
+      return;
+    }
+    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') {
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      void useSessionsStore.getState().ensureFreshAll();
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [authAuthenticated, activeRepoPath, activeSessionId]);
 
   // ── Event socket ───────────────────────────────────────────────────────────
   useEventSocket({

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -15,6 +15,76 @@ export interface UseEventSocketParams {
   setChangedFilesData: (files: string[]) => void;
 }
 
+function isAbsolutePath(value: string): boolean {
+  return value.startsWith('/');
+}
+
+function normalizeOwnerRepo(value: string): string {
+  return value.toLowerCase().replace(/\.git$/, '');
+}
+
+function repoNameFromOwnerRepo(value: string): string {
+  const normalized = normalizeOwnerRepo(value);
+  return normalized.split('/').pop() ?? normalized;
+}
+
+function resolveRepoPaths(values: string[]): string[] {
+  const state = useSessionsStore.getState();
+  const knownRepos = state.repos ?? [];
+  const paths = new Set<string>();
+
+  for (const value of values) {
+    if (!value) continue;
+    if (isAbsolutePath(value)) {
+      paths.add(value);
+      continue;
+    }
+
+    const normalized = normalizeOwnerRepo(value);
+    const repoName = repoNameFromOwnerRepo(value);
+    for (const repo of knownRepos) {
+      const pathName = repo.path.split('/').pop()?.toLowerCase();
+      if (
+        repo.name.toLowerCase() === normalized ||
+        repo.name.toLowerCase() === repoName ||
+        pathName === repoName
+      ) {
+        paths.add(repo.path);
+      }
+    }
+  }
+
+  return Array.from(paths);
+}
+
+function repoPathsFromPrOrCiMessage(
+  msg: Extract<EventMessage, { type: 'pr-updated' | 'ci-updated' }>
+): string[] {
+  return resolveRepoPaths([
+    ...(msg.workspacePaths ?? []),
+    ...(msg.repos ?? []),
+    ...(msg.repo ? [msg.repo] : []),
+  ]);
+}
+
+function sessionRepoPath(sessionId: string | undefined): string | undefined {
+  if (!sessionId) return undefined;
+  return useSessionsStore
+    .getState()
+    .sessions.find((session) => session.id === sessionId)?.repoPath;
+}
+
+function invalidatePrQueries(queryClient: QueryClient): void {
+  queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+  queryClient.invalidateQueries({ queryKey: ['org-prs'] });
+}
+
+function forceRefreshRepos(repoPaths: string[], source: 'webhook' | 'manual') {
+  for (const repoPath of repoPaths) {
+    void useSessionsStore.getState().forceRefresh(repoPath, source);
+  }
+}
+
 export function useEventSocket({
   authAuthenticated,
   queryClient,
@@ -24,23 +94,27 @@ export function useEventSocket({
   useEffect(() => {
     if (!authAuthenticated) return;
 
-    const refChangedTimers = new Map<string, ReturnType<typeof setTimeout>>();
     let pollInvalidateTimer: ReturnType<typeof setTimeout> | null = null;
+    let eventSocketOpened = false;
+    const pendingWebhookRepos = new Set<string>();
 
-    function invalidatePrData(): void {
-      queryClient.invalidateQueries({ queryKey: ['dashboard'] });
-      queryClient.invalidateQueries({ queryKey: ['org-prs'] });
-      useSessionsStore.getState().enrichSidebarBranches();
+    function invalidateScopedPrData(
+      repoPaths: string[],
+      source: 'webhook' | 'manual'
+    ): void {
+      invalidatePrQueries(queryClient);
+      forceRefreshRepos(repoPaths, source);
     }
 
-    /** Throttled invalidation for poll-based events (pr-updated/ci-updated).
-     *  Schedules one invalidation 500ms after the first event; subsequent
-     *  events within the window are dropped. */
-    function throttledPollInvalidate(): void {
+    /** Throttled invalidation for bursty webhook PR/CI events. */
+    function throttledWebhookInvalidate(repoPaths: string[]): void {
+      for (const repoPath of repoPaths) pendingWebhookRepos.add(repoPath);
       if (pollInvalidateTimer) return;
       pollInvalidateTimer = setTimeout(() => {
         pollInvalidateTimer = null;
-        invalidatePrData();
+        const repos = Array.from(pendingWebhookRepos);
+        pendingWebhookRepos.clear();
+        invalidateScopedPrData(repos, 'webhook');
       }, 500);
     }
 
@@ -62,37 +136,32 @@ export function useEventSocket({
           );
       },
       'session-renamed': (msg) => {
+        const repoPath = sessionRepoPath(msg.sessionId);
         useSessionsStore
           .getState()
           .renameSession(msg.sessionId, msg.branchName, msg.displayName);
-        invalidatePrData();
+        if (repoPath) invalidateScopedPrData([repoPath], 'manual');
       },
       'session-branch-changed': (msg) => {
+        const repoPath = msg.cwdPath ?? sessionRepoPath(msg.sessionId);
         useSessionsStore
           .getState()
           .handleBranchChanged(msg.sessionId, msg.branch);
+        if (repoPath) invalidateScopedPrData([repoPath], 'manual');
       },
-      'session-ended': () => {
-        invalidatePrData();
+      'session-ended': (msg) => {
+        const repoPath = msg.cwd ?? sessionRepoPath(msg.sessionId);
+        if (repoPath) invalidateScopedPrData([repoPath], 'manual');
         useSessionsStore.getState().refreshAll();
       },
       'ref-changed': (msg) => {
-        const key = msg.cwdPath;
-        const existing = refChangedTimers.get(key);
-        if (existing) clearTimeout(existing);
-        refChangedTimers.set(
-          key,
-          setTimeout(() => {
-            refChangedTimers.delete(key);
-            invalidatePrData();
-          }, 5000)
-        );
+        invalidateScopedPrData([msg.cwdPath], 'manual');
       },
-      'pr-updated': () => {
-        throttledPollInvalidate();
+      'pr-updated': (msg) => {
+        throttledWebhookInvalidate(repoPathsFromPrOrCiMessage(msg));
       },
-      'ci-updated': () => {
-        throttledPollInvalidate();
+      'ci-updated': (msg) => {
+        throttledWebhookInvalidate(repoPathsFromPrOrCiMessage(msg));
       },
       'files-changed': (msg) => {
         const currentActiveSessionId =
@@ -168,6 +237,10 @@ export function useEventSocket({
         if (handler) (handler as (msg: EventMessage) => void)(msg);
       },
       () => {
+        if (eventSocketOpened) {
+          void useSessionsStore.getState().ensureFreshAll(0);
+        }
+        eventSocketOpened = true;
         void useTelemetryStore.getState().refreshTelemetry();
       },
       () => {
@@ -176,8 +249,7 @@ export function useEventSocket({
     );
 
     return () => {
-      for (const timer of refChangedTimers.values()) clearTimeout(timer);
-      refChangedTimers.clear();
+      pendingWebhookRepos.clear();
       if (pollInvalidateTimer) {
         clearTimeout(pollInvalidateTimer);
         pollInvalidateTimer = null;

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -28,6 +28,53 @@ function repoNameFromOwnerRepo(value: string): string {
   return normalized.split('/').pop() ?? normalized;
 }
 
+function normalizePath(value: string): string {
+  if (value === '/') return value;
+  return value.replace(/\/+$/, '');
+}
+
+function pathIsAtOrUnder(path: string, root: string): boolean {
+  const normalizedPath = normalizePath(path);
+  const normalizedRoot = normalizePath(root);
+  return (
+    normalizedPath === normalizedRoot ||
+    normalizedPath.startsWith(`${normalizedRoot}/`)
+  );
+}
+
+function resolveAbsolutePathToRepoPath(value: string): string[] {
+  const state = useSessionsStore.getState();
+  const paths = new Set<string>();
+  const absolutePath = normalizePath(value);
+
+  for (const worktree of state.worktrees ?? []) {
+    if (pathIsAtOrUnder(absolutePath, worktree.path)) {
+      paths.add(worktree.repoPath);
+    }
+  }
+
+  for (const session of state.sessions ?? []) {
+    const sessionRoots = [
+      session.worktreePath ?? undefined,
+      session.cwd,
+      session.repoPath,
+    ];
+    if (
+      sessionRoots.some((root) => root && pathIsAtOrUnder(absolutePath, root))
+    ) {
+      paths.add(session.repoPath);
+    }
+  }
+
+  for (const repo of state.repos ?? []) {
+    if (pathIsAtOrUnder(absolutePath, repo.path)) {
+      paths.add(repo.path);
+    }
+  }
+
+  return paths.size > 0 ? Array.from(paths) : [absolutePath];
+}
+
 function resolveRepoPaths(values: string[]): string[] {
   const state = useSessionsStore.getState();
   const knownRepos = state.repos ?? [];
@@ -36,7 +83,9 @@ function resolveRepoPaths(values: string[]): string[] {
   for (const value of values) {
     if (!value) continue;
     if (isAbsolutePath(value)) {
-      paths.add(value);
+      for (const repoPath of resolveAbsolutePathToRepoPath(value)) {
+        paths.add(repoPath);
+      }
       continue;
     }
 
@@ -143,19 +192,25 @@ export function useEventSocket({
         if (repoPath) invalidateScopedPrData([repoPath], 'manual');
       },
       'session-branch-changed': (msg) => {
-        const repoPath = msg.cwdPath ?? sessionRepoPath(msg.sessionId);
+        const repoPaths = resolveRepoPaths([
+          msg.cwdPath ?? '',
+          sessionRepoPath(msg.sessionId) ?? '',
+        ]);
         useSessionsStore
           .getState()
           .handleBranchChanged(msg.sessionId, msg.branch);
-        if (repoPath) invalidateScopedPrData([repoPath], 'manual');
+        if (repoPaths.length > 0) invalidateScopedPrData(repoPaths, 'manual');
       },
       'session-ended': (msg) => {
-        const repoPath = msg.cwd ?? sessionRepoPath(msg.sessionId);
-        if (repoPath) invalidateScopedPrData([repoPath], 'manual');
+        const repoPaths = resolveRepoPaths([
+          msg.cwd ?? '',
+          sessionRepoPath(msg.sessionId) ?? '',
+        ]);
+        if (repoPaths.length > 0) invalidateScopedPrData(repoPaths, 'manual');
         useSessionsStore.getState().refreshAll();
       },
       'ref-changed': (msg) => {
-        invalidateScopedPrData([msg.cwdPath], 'manual');
+        invalidateScopedPrData(resolveRepoPaths([msg.cwdPath]), 'manual');
       },
       'pr-updated': (msg) => {
         throttledWebhookInvalidate(repoPathsFromPrOrCiMessage(msg));

--- a/frontend/src/hooks/useVisibilityRefresh.ts
+++ b/frontend/src/hooks/useVisibilityRefresh.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import {
+  DEFAULT_ENRICHMENT_TTL_MS,
+  useSessionsStore,
+} from '../lib/stores/sessions.js';
+
+function isVisible(): boolean {
+  return typeof document === 'undefined' || document.visibilityState === 'visible';
+}
+
+export function useVisibilityRefresh(authAuthenticated: boolean): void {
+  useEffect(() => {
+    if (!authAuthenticated || typeof document === 'undefined') return;
+
+    const handleVisibilityChange = () => {
+      if (!isVisible()) return;
+      void useSessionsStore
+        .getState()
+        .ensureFreshAll(DEFAULT_ENRICHMENT_TTL_MS);
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [authAuthenticated]);
+}

--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -28,6 +28,18 @@ const WORKSPACE_SESSIONS_KEY = 'claude-remote-workspace-sessions';
 const logger = createLogger('sessions');
 
 const BOOT_FETCH_TIMEOUT_MS = 10_000;
+export const DEFAULT_ENRICHMENT_TTL_MS = 600_000;
+
+export type RepoEnrichmentSource = 'webhook' | 'manual';
+export interface RepoEnrichmentMeta {
+  lastEnrichedAt: number;
+  source: RepoEnrichmentSource;
+}
+
+type BranchEnrichment = {
+  pr: import('../types.js').PrInfo | null;
+  stale: boolean;
+};
 
 // ── localStorage helpers ───────────────────────────────────────────────────
 function loadActiveSessionId(): string | null {
@@ -139,10 +151,8 @@ export interface SessionsState {
   loadingItems: Record<string, boolean>;
   notificationSessions: Record<string, boolean>;
   sidebarItems: SidebarItem[];
-  enrichmentResults: Record<
-    string,
-    { pr: import('../types.js').PrInfo | null; stale: boolean }
-  >;
+  enrichmentResults: Record<string, BranchEnrichment>;
+  repoEnrichmentMeta: Record<string, RepoEnrichmentMeta>;
   reconnectingPtySessionId: string | null;
   // Actions
   setActiveSessionId: (id: string | null) => void;
@@ -152,6 +162,12 @@ export interface SessionsState {
   ) => void;
   recallSessionForWorkspace: (workspacePath: string) => string | null;
   enrichSidebarBranches: () => Promise<void>;
+  ensureFresh: (repoPath: string, maxAgeMs?: number) => Promise<void>;
+  ensureFreshAll: (maxAgeMs?: number) => Promise<void>;
+  forceRefresh: (
+    repoPath: string,
+    source?: RepoEnrichmentSource
+  ) => Promise<void>;
   getEnrichment: (
     repoPath: string,
     branchName: string
@@ -187,6 +203,39 @@ export interface SessionsState {
   clearPtyReconnect: (sessionId?: string) => void;
 }
 
+function repoBranchEntriesFor(
+  state: Pick<SessionsState, 'sessions' | 'worktrees'>,
+  repoPath: string
+): Array<{ repoPath: string; branchName: string }> {
+  const seen = new Set<string>();
+  const branches: Array<{ repoPath: string; branchName: string }> = [];
+  const add = (branchName: string | null | undefined) => {
+    if (!branchName) return;
+    const key = `${repoPath}::${branchName}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    branches.push({ repoPath, branchName });
+  };
+
+  for (const wt of state.worktrees) {
+    if (wt.repoPath === repoPath) add(wt.branchName);
+  }
+  for (const session of state.sessions) {
+    if (session.repoPath === repoPath) add(session.branchName);
+  }
+  return branches;
+}
+
+function visibleRepoPaths(
+  state: Pick<SessionsState, 'repos' | 'sessions' | 'worktrees'>
+): string[] {
+  const paths = new Set<string>();
+  for (const repo of state.repos) paths.add(repo.path);
+  for (const wt of state.worktrees) paths.add(wt.repoPath);
+  for (const session of state.sessions) paths.add(session.repoPath);
+  return Array.from(paths);
+}
+
 export const useSessionsStore = create<SessionsState>()((set, get) => ({
   sessions: [],
   worktrees: [],
@@ -198,6 +247,7 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
   notificationSessions: loadNotificationPrefs(),
   sidebarItems: [],
   enrichmentResults: {},
+  repoEnrichmentMeta: {},
   reconnectingPtySessionId: null,
 
   setActiveSessionId: (id) => {
@@ -226,17 +276,52 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
   },
 
   enrichSidebarBranches: async () => {
-    const { worktrees } = get();
-    const branches = worktrees.map((wt) => ({
-      repoPath: wt.repoPath,
-      branchName: wt.branchName,
-    }));
-    if (branches.length === 0) return;
+    await get().ensureFreshAll(0);
+  },
+
+  ensureFresh: async (repoPath, maxAgeMs = DEFAULT_ENRICHMENT_TTL_MS) => {
+    const meta = get().repoEnrichmentMeta[repoPath];
+    if (meta && maxAgeMs > 0 && Date.now() - meta.lastEnrichedAt < maxAgeMs) {
+      return;
+    }
+    await get().forceRefresh(repoPath, 'manual');
+  },
+
+  ensureFreshAll: async (maxAgeMs = DEFAULT_ENRICHMENT_TTL_MS) => {
+    const repos = visibleRepoPaths(get());
+    await Promise.all(repos.map((repoPath) => get().ensureFresh(repoPath, maxAgeMs)));
+  },
+
+  forceRefresh: async (repoPath, source = 'manual') => {
+    const branches = repoBranchEntriesFor(get(), repoPath);
+    if (branches.length === 0) {
+      set((state) => ({
+        repoEnrichmentMeta: {
+          ...state.repoEnrichmentMeta,
+          [repoPath]: { lastEnrichedAt: Date.now(), source },
+        },
+      }));
+      return;
+    }
+
     try {
       const data = await api.enrichBranches(branches);
-      set({ enrichmentResults: data.results });
+      set((state) => {
+        const prefix = `${repoPath}::`;
+        const nextResults: Record<string, BranchEnrichment> = {};
+        for (const [key, value] of Object.entries(state.enrichmentResults)) {
+          if (!key.startsWith(prefix)) nextResults[key] = value;
+        }
+        return {
+          enrichmentResults: { ...nextResults, ...data.results },
+          repoEnrichmentMeta: {
+            ...state.repoEnrichmentMeta,
+            [repoPath]: { lastEnrichedAt: Date.now(), source },
+          },
+        };
+      });
     } catch (err) {
-      logger.warn('enrichSidebarBranches failed', err);
+      logger.warn('forceRefresh failed', err);
     }
   },
 

--- a/test/hooks/useEventSocket.test.ts
+++ b/test/hooks/useEventSocket.test.ts
@@ -26,7 +26,13 @@ const storeMock = vi.hoisted(() => ({
   handleActivityChanged: vi.fn(),
   beginPtyReconnect: vi.fn(),
   activeSessionId: null as string | null,
-  sessions: [] as Array<{ id: string; repoPath: string; worktreePath?: string | null }>,
+  sessions: [] as Array<{
+    id: string;
+    repoPath: string;
+    worktreePath?: string | null;
+    cwd?: string;
+  }>,
+  worktrees: [] as Array<{ path: string; repoPath: string }>,
   repos: [
     { path: '/repos/relay-ide', name: 'relay-ide' },
     { path: '/repos/hermes-agent', name: 'hermes-agent' },
@@ -90,6 +96,7 @@ describe('useEventSocket repo-scoped refresh', () => {
     wsMock.onOpen = undefined;
     storeMock.activeSessionId = null;
     storeMock.sessions = [];
+    storeMock.worktrees = [];
   });
 
   function mount(): void {
@@ -124,8 +131,16 @@ describe('useEventSocket repo-scoped refresh', () => {
     vi.advanceTimersByTime(500);
 
     expect(storeMock.forceRefresh).toHaveBeenCalledTimes(2);
-    expect(storeMock.forceRefresh).toHaveBeenNthCalledWith(1, '/repos/relay-ide', 'webhook');
-    expect(storeMock.forceRefresh).toHaveBeenNthCalledWith(2, '/repos/hermes-agent', 'webhook');
+    expect(storeMock.forceRefresh).toHaveBeenNthCalledWith(
+      1,
+      '/repos/relay-ide',
+      'webhook'
+    );
+    expect(storeMock.forceRefresh).toHaveBeenNthCalledWith(
+      2,
+      '/repos/hermes-agent',
+      'webhook'
+    );
     expect(storeMock.ensureFreshAll).not.toHaveBeenCalled();
   });
 
@@ -142,15 +157,79 @@ describe('useEventSocket repo-scoped refresh', () => {
     });
     wsMock.onMessage?.({ type: 'ref-changed', cwdPath: '/repos/hermes-agent' });
 
-    expect(storeMock.forceRefresh).toHaveBeenCalledWith('/repos/relay-ide', 'manual');
-    expect(storeMock.forceRefresh).toHaveBeenCalledWith('/repos/hermes-agent', 'manual');
+    expect(storeMock.forceRefresh).toHaveBeenCalledWith(
+      '/repos/relay-ide',
+      'manual'
+    );
+    expect(storeMock.forceRefresh).toHaveBeenCalledWith(
+      '/repos/hermes-agent',
+      'manual'
+    );
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('maps worktree event paths back to the canonical repo before force-refreshing', () => {
+    storeMock.worktrees = [
+      {
+        path: '/repos/relay-ide/.worktrees/feature-a',
+        repoPath: '/repos/relay-ide',
+      },
+    ];
+    storeMock.sessions = [
+      {
+        id: 's1',
+        repoPath: '/repos/relay-ide',
+        worktreePath: '/repos/relay-ide/.worktrees/feature-a',
+        cwd: '/repos/relay-ide/.worktrees/feature-a/packages/app',
+      },
+    ];
+    mount();
+
+    wsMock.onMessage?.({
+      type: 'session-branch-changed',
+      sessionId: 's1',
+      branch: 'feature',
+      cwdPath: '/repos/relay-ide/.worktrees/feature-a',
+    });
+    wsMock.onMessage?.({
+      type: 'session-ended',
+      sessionId: 's1',
+      cwd: '/repos/relay-ide/.worktrees/feature-a/packages/app/src',
+    });
+    wsMock.onMessage?.({
+      type: 'ref-changed',
+      cwdPath: '/repos/relay-ide/.worktrees/feature-a',
+    });
+
+    expect(storeMock.forceRefresh).toHaveBeenCalledTimes(3);
+    expect(storeMock.forceRefresh).toHaveBeenNthCalledWith(
+      1,
+      '/repos/relay-ide',
+      'manual'
+    );
+    expect(storeMock.forceRefresh).toHaveBeenNthCalledWith(
+      2,
+      '/repos/relay-ide',
+      'manual'
+    );
+    expect(storeMock.forceRefresh).toHaveBeenNthCalledWith(
+      3,
+      '/repos/relay-ide',
+      'manual'
+    );
+    expect(storeMock.forceRefresh).not.toHaveBeenCalledWith(
+      '/repos/relay-ide/.worktrees/feature-a',
+      'manual'
+    );
   });
 
   it('cleanup cancels pending pr/ci throttle timers', () => {
     mount();
 
-    wsMock.onMessage?.({ type: 'ci-updated', workspacePaths: ['/repos/relay-ide'] });
+    wsMock.onMessage?.({
+      type: 'ci-updated',
+      workspacePaths: ['/repos/relay-ide'],
+    });
     expect(vi.getTimerCount()).toBe(1);
 
     if (effectState.cleanup) effectState.cleanup();

--- a/test/hooks/useEventSocket.test.ts
+++ b/test/hooks/useEventSocket.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EventMessage } from '../../frontend/src/lib/ws.js';
+
+const effectState = vi.hoisted(() => ({
+  cleanup: undefined as void | (() => void),
+}));
+
+const wsMock = vi.hoisted(() => ({
+  onMessage: undefined as undefined | ((msg: EventMessage) => void),
+  onOpen: undefined as undefined | (() => void),
+  connectEventSocket: vi.fn(
+    (onMessage: (msg: EventMessage) => void, onOpen?: () => void) => {
+      wsMock.onMessage = onMessage;
+      wsMock.onOpen = onOpen;
+    }
+  ),
+}));
+
+const storeMock = vi.hoisted(() => ({
+  refreshAll: vi.fn(),
+  ensureFreshAll: vi.fn(),
+  forceRefresh: vi.fn(),
+  handleBackendStateChanged: vi.fn(),
+  renameSession: vi.fn(),
+  handleBranchChanged: vi.fn(),
+  handleActivityChanged: vi.fn(),
+  beginPtyReconnect: vi.fn(),
+  activeSessionId: null as string | null,
+  sessions: [] as Array<{ id: string; repoPath: string; worktreePath?: string | null }>,
+  repos: [
+    { path: '/repos/relay-ide', name: 'relay-ide' },
+    { path: '/repos/hermes-agent', name: 'hermes-agent' },
+  ],
+}));
+
+const telemetryMock = vi.hoisted(() => ({
+  refreshTelemetry: vi.fn(),
+  handleSessionTelemetryEvent: vi.fn(),
+  handleAccountTelemetryEvent: vi.fn(),
+}));
+
+const authMock = vi.hoisted(() => ({ deauthenticate: vi.fn() }));
+const uiMock = vi.hoisted(() => ({
+  openHtmlTab: vi.fn(),
+  refreshHtmlTab: vi.fn(),
+}));
+
+vi.mock('react', () => ({
+  useEffect: (effect: () => void | (() => void)) => {
+    effectState.cleanup = effect();
+  },
+}));
+
+vi.mock('../../frontend/src/lib/ws.js', () => ({
+  connectEventSocket: wsMock.connectEventSocket,
+}));
+
+vi.mock('../../frontend/src/lib/stores/sessions.js', () => ({
+  useSessionsStore: {
+    getState: () => storeMock,
+  },
+}));
+
+vi.mock('../../frontend/src/lib/stores/telemetry.js', () => ({
+  useTelemetryStore: {
+    getState: () => telemetryMock,
+  },
+}));
+
+vi.mock('../../frontend/src/lib/stores/auth.js', () => ({
+  useAuthStore: {
+    getState: () => authMock,
+  },
+}));
+
+vi.mock('../../frontend/src/lib/stores/ui.js', () => ({
+  useUiStore: {
+    getState: () => uiMock,
+  },
+}));
+
+import { useEventSocket } from '../../frontend/src/hooks/useEventSocket.js';
+
+describe('useEventSocket repo-scoped refresh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    effectState.cleanup = undefined;
+    wsMock.onMessage = undefined;
+    wsMock.onOpen = undefined;
+    storeMock.activeSessionId = null;
+    storeMock.sessions = [];
+  });
+
+  function mount(): void {
+    useEventSocket({
+      authAuthenticated: true,
+      queryClient: { invalidateQueries: vi.fn() } as any,
+      throttledChangedFilesRefresh: vi.fn(),
+      setChangedFilesData: vi.fn(),
+    });
+  }
+
+  it('forces all visible repo enrichment on websocket reconnect after the initial open', () => {
+    mount();
+
+    wsMock.onOpen?.();
+    expect(storeMock.ensureFreshAll).not.toHaveBeenCalled();
+
+    wsMock.onOpen?.();
+
+    expect(storeMock.ensureFreshAll).toHaveBeenCalledWith(0);
+    expect(telemetryMock.refreshTelemetry).toHaveBeenCalledTimes(2);
+  });
+
+  it('throttles pr-updated events but force-refreshes only repos listed in the payload', () => {
+    mount();
+
+    wsMock.onMessage?.({
+      type: 'pr-updated',
+      workspacePaths: ['/repos/relay-ide'],
+      repos: ['donovan-yohan/hermes-agent'],
+    });
+    vi.advanceTimersByTime(500);
+
+    expect(storeMock.forceRefresh).toHaveBeenCalledTimes(2);
+    expect(storeMock.forceRefresh).toHaveBeenNthCalledWith(1, '/repos/relay-ide', 'webhook');
+    expect(storeMock.forceRefresh).toHaveBeenNthCalledWith(2, '/repos/hermes-agent', 'webhook');
+    expect(storeMock.ensureFreshAll).not.toHaveBeenCalled();
+  });
+
+  it('force-refreshes the affected repo for session end, branch change, and ref change without a debounce timer', () => {
+    storeMock.sessions = [{ id: 's1', repoPath: '/repos/relay-ide' }];
+    mount();
+
+    wsMock.onMessage?.({ type: 'session-ended', sessionId: 's1' });
+    wsMock.onMessage?.({
+      type: 'session-branch-changed',
+      sessionId: 's1',
+      branch: 'feature',
+      cwdPath: '/repos/relay-ide',
+    });
+    wsMock.onMessage?.({ type: 'ref-changed', cwdPath: '/repos/hermes-agent' });
+
+    expect(storeMock.forceRefresh).toHaveBeenCalledWith('/repos/relay-ide', 'manual');
+    expect(storeMock.forceRefresh).toHaveBeenCalledWith('/repos/hermes-agent', 'manual');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('cleanup cancels pending pr/ci throttle timers', () => {
+    mount();
+
+    wsMock.onMessage?.({ type: 'ci-updated', workspacePaths: ['/repos/relay-ide'] });
+    expect(vi.getTimerCount()).toBe(1);
+
+    if (effectState.cleanup) effectState.cleanup();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/test/hooks/useVisibilityRefresh.test.ts
+++ b/test/hooks/useVisibilityRefresh.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const effectState = vi.hoisted(() => ({
+  cleanup: undefined as void | (() => void),
+}));
+
+const storeMock = vi.hoisted(() => ({
+  ensureFreshAll: vi.fn(),
+}));
+
+vi.mock('react', () => ({
+  useEffect: (effect: () => void | (() => void)) => {
+    effectState.cleanup = effect();
+  },
+}));
+
+vi.mock('../../frontend/src/lib/stores/sessions.js', () => ({
+  DEFAULT_ENRICHMENT_TTL_MS: 600_000,
+  useSessionsStore: {
+    getState: () => storeMock,
+  },
+}));
+
+import { useVisibilityRefresh } from '../../frontend/src/hooks/useVisibilityRefresh.js';
+
+describe('useVisibilityRefresh', () => {
+  let listeners: Record<string, () => void>;
+  let visibilityState = 'visible';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    effectState.cleanup = undefined;
+    listeners = {};
+    visibilityState = 'visible';
+    vi.stubGlobal('document', {
+      addEventListener: vi.fn((event: string, handler: () => void) => {
+        listeners[event] = handler;
+      }),
+      removeEventListener: vi.fn((event: string) => {
+        delete listeners[event];
+      }),
+      get visibilityState() {
+        return visibilityState;
+      },
+    });
+  });
+
+  it('refreshes stale repos when the tab becomes visible', () => {
+    useVisibilityRefresh(true);
+
+    visibilityState = 'visible';
+    listeners.visibilitychange?.();
+
+    expect(storeMock.ensureFreshAll).toHaveBeenCalledWith(600_000);
+  });
+
+  it('does not refresh while the tab is inactive and removes the listener on cleanup', () => {
+    useVisibilityRefresh(true);
+
+    visibilityState = 'hidden';
+    listeners.visibilitychange?.();
+
+    expect(storeMock.ensureFreshAll).not.toHaveBeenCalled();
+    if (effectState.cleanup) effectState.cleanup();
+    expect(listeners.visibilitychange).toBeUndefined();
+  });
+});

--- a/test/stores/sessions-enrichment.test.ts
+++ b/test/stores/sessions-enrichment.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiMocks = vi.hoisted(() => ({
+  enrichBranches: vi.fn(),
+  fetchSessions: vi.fn(),
+  fetchWorktrees: vi.fn(),
+  fetchWorkspaces: vi.fn(),
+  fetchWorkspaceGroups: vi.fn(),
+}));
+
+vi.mock('../../frontend/src/lib/api.js', () => ({
+  enrichBranches: apiMocks.enrichBranches,
+  fetchSessions: apiMocks.fetchSessions,
+  fetchWorktrees: apiMocks.fetchWorktrees,
+  fetchWorkspaces: apiMocks.fetchWorkspaces,
+  fetchWorkspaceGroups: apiMocks.fetchWorkspaceGroups,
+}));
+
+const storage: Record<string, string> = {};
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: (key: string) => storage[key] ?? null,
+    setItem: (key: string, value: string) => {
+      storage[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete storage[key];
+    },
+  },
+  configurable: true,
+});
+
+import { useSessionsStore } from '../../frontend/src/lib/stores/sessions.js';
+
+const repoA = {
+  name: 'relay-ide',
+  path: '/repos/relay-ide',
+  isGitRepo: true,
+  defaultBranch: 'nightly',
+  currentBranch: 'nightly',
+};
+const repoB = {
+  name: 'hermes-agent',
+  path: '/repos/hermes-agent',
+  isGitRepo: true,
+  defaultBranch: 'dy-main',
+  currentBranch: 'dy-main',
+};
+
+function resetStore(): void {
+  useSessionsStore.setState({
+    sessions: [],
+    worktrees: [
+      {
+        name: 'feature-a',
+        path: '/repos/relay-ide/.worktrees/feature-a',
+        repoName: 'relay-ide',
+        repoPath: repoA.path,
+        displayName: 'feature-a',
+        lastActivity: '2026-05-07T00:00:00.000Z',
+        branchName: 'feature-a',
+      },
+      {
+        name: 'feature-b',
+        path: '/repos/hermes-agent/.worktrees/feature-b',
+        repoName: 'hermes-agent',
+        repoPath: repoB.path,
+        displayName: 'feature-b',
+        lastActivity: '2026-05-07T00:00:00.000Z',
+        branchName: 'feature-b',
+      },
+    ],
+    repos: [repoA, repoB],
+    workspaceGroups: [],
+    enrichmentResults: {},
+    repoEnrichmentMeta: {},
+  });
+}
+
+describe('sessions repo enrichment freshness', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-07T00:00:00.000Z'));
+    vi.clearAllMocks();
+    resetStore();
+    apiMocks.enrichBranches.mockResolvedValue({ results: {} });
+  });
+
+  it('ensureFresh skips a repo inside ttl and fetches it again after ttl expires', async () => {
+    apiMocks.enrichBranches
+      .mockResolvedValueOnce({
+        results: {
+          [`${repoA.path}::feature-a`]: { pr: null, stale: false },
+        },
+      })
+      .mockResolvedValueOnce({ results: {} });
+
+    await (useSessionsStore.getState() as any).ensureFresh(repoA.path, 600_000);
+    expect(apiMocks.enrichBranches).toHaveBeenCalledTimes(1);
+    expect(apiMocks.enrichBranches).toHaveBeenLastCalledWith([
+      { repoPath: repoA.path, branchName: 'feature-a' },
+    ]);
+
+    vi.setSystemTime(new Date('2026-05-07T00:05:00.000Z'));
+    await (useSessionsStore.getState() as any).ensureFresh(repoA.path, 600_000);
+    expect(apiMocks.enrichBranches).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date('2026-05-07T00:11:00.000Z'));
+    await (useSessionsStore.getState() as any).ensureFresh(repoA.path, 600_000);
+    expect(apiMocks.enrichBranches).toHaveBeenCalledTimes(2);
+  });
+
+  it('forceRefresh bypasses a fresh ttl window for one repo only', async () => {
+    await (useSessionsStore.getState() as any).ensureFresh(repoA.path, 600_000);
+    await (useSessionsStore.getState() as any).forceRefresh(repoA.path);
+
+    expect(apiMocks.enrichBranches).toHaveBeenCalledTimes(2);
+    expect(apiMocks.enrichBranches).toHaveBeenLastCalledWith([
+      { repoPath: repoA.path, branchName: 'feature-a' },
+    ]);
+  });
+
+  it('ensureFreshAll calls stale visible repos without fanning out through one global enrichment request', async () => {
+    await (useSessionsStore.getState() as any).ensureFresh(repoA.path, 600_000);
+    vi.setSystemTime(new Date('2026-05-07T00:05:00.000Z'));
+
+    await (useSessionsStore.getState() as any).ensureFreshAll(600_000);
+
+    expect(apiMocks.enrichBranches).toHaveBeenCalledTimes(2);
+    expect(apiMocks.enrichBranches).toHaveBeenLastCalledWith([
+      { repoPath: repoB.path, branchName: 'feature-b' },
+    ]);
+  });
+
+  it('records webhook metadata even when the affected repo has no local branches to enrich', async () => {
+    useSessionsStore.setState({ worktrees: [] });
+
+    await (useSessionsStore.getState() as any).forceRefresh(repoA.path, 'webhook');
+
+    expect(apiMocks.enrichBranches).not.toHaveBeenCalled();
+    expect(useSessionsStore.getState().repoEnrichmentMeta[repoA.path]).toEqual({
+      lastEnrichedAt: Date.now(),
+      source: 'webhook',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds per-repo `repoEnrichmentMeta` plus `ensureFresh(maxAgeMs)`, `ensureFreshAll(maxAgeMs)`, and `forceRefresh(repoPath, source)` to replace global sidebar branch enrichment fanout.
- Scopes websocket PR/CI/session/ref invalidation to affected repo paths, keeps the 500ms burst throttle for webhook PR/CI events, and forces all repo enrichment only on actual websocket reconnects.
- Adds visibilitychange and navigation refresh triggers that only call TTL-gated `ensureFreshAll` while the tab is visible.

Closes #356
Refs #353

## Verification
- `npm test -- test/stores/sessions-enrichment.test.ts test/hooks/useEventSocket.test.ts test/hooks/useVisibilityRefresh.test.ts --reporter=dot` (pass, 10 tests)
- `npm test -- test/stores/sessions-enrichment.test.ts test/hooks/useEventSocket.test.ts test/hooks/useVisibilityRefresh.test.ts test/stores/sessions-logic.test.ts --reporter=dot` (pass, 32 tests)
- `npm run build` (pass, Vite chunk-size warnings only)
- `npm test -- --reporter=dot` (pass, 148 files / 1774 tests; existing stderr noise only)
- `npm run lint -- frontend/src/lib/stores/sessions.ts frontend/src/hooks/useEventSocket.ts frontend/src/hooks/useVisibilityRefresh.ts frontend/src/App.tsx test/stores/sessions-enrichment.test.ts test/hooks/useEventSocket.test.ts test/hooks/useVisibilityRefresh.test.ts` (pass with existing warnings; no errors)

## The Case Against
This change might be wrong because:
- Repo identity in websocket payloads is still mixed: some events carry absolute workspace paths, some carry owner/repo names. The frontend resolves owner/repo by repo name/path basename, which is pragmatic but not collision-proof if two configured repos share the same basename.
- Initial socket open deliberately does not call `ensureFreshAll(0)` so initial mount fetches once. If the server reconnect path ever constructs a fresh hook instance instead of reusing the existing callback closure, reconnect refresh could be skipped until the next visibility/nav trigger.
- `ensureFreshAll` now includes active session branches as well as worktree branches. That is more complete than the previous worktree-only enrichment, but it may add one branch entry for active root sessions that were previously not enriched.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
| --- | --- | --- |
| owner/repo basename collision refreshes more than intended | low | webhook payloads with `workspacePaths` remain exact; tests cover workspacePaths plus owner/repo mapping |
| duplicate boot enrichment calls regress request reduction | medium | initial websocket open is explicitly ignored for `ensureFreshAll`; App initial boot remains the single force fetch |
| stale per-repo enrichment results survive branch changes | low | `forceRefresh` clears prior enrichment keys for that repo before merging fresh results |
| timer leak from webhook throttling or visibility listener | low | cleanup tests cover throttled websocket timer and visibility listener removal |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session data automatically refreshes when you return to an inactive browser tab, keeping information current without manual action.

* **Improvements**
  * Optimized PR and CI status update handling with repository-scoped refresh logic for improved performance and responsiveness.
  * Enhanced data freshness controls to minimize unnecessary updates across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->