### PR TITLE
feat: show repo source freshness indicators (#357)

### DIFF
--- a/frontend/src/components/PrTopBar.css
+++ b/frontend/src/components/PrTopBar.css
@@ -80,19 +80,21 @@
   width: 22px;
   height: 22px;
   border-radius: 0;
-  border: none;
+  border: 1px solid var(--border);
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
   padding: 0;
   transition:
     color 0.12s,
-    background 0.12s;
+    background 0.12s,
+    border-color 0.12s;
 }
 
 .refresh-btn:hover:not(:disabled) {
   color: var(--text);
-  background: var(--border);
+  border-color: var(--text-muted);
+  background: color-mix(in srgb, var(--text-muted) 10%, transparent);
 }
 
 .refresh-btn:disabled {
@@ -110,6 +112,26 @@
   to {
     transform: rotate(360deg);
   }
+}
+
+.source-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  max-width: 220px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+}
+
+.source-label {
+  color: var(--text-muted);
+}
+
+.source-updated {
+  color: color-mix(in srgb, var(--text-muted) 78%, transparent);
 }
 
 .bar-merged {
@@ -224,7 +246,8 @@
 
   .target-section,
   .bar-middle,
-  .diff-stats {
+  .diff-stats,
+  .source-updated {
     display: none;
   }
 

--- a/frontend/src/components/PrTopBar.tsx
+++ b/frontend/src/components/PrTopBar.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
+  createRepoWebhook,
   fetchPrForBranchOrNull,
   fetchCiStatusOrNull,
   fetchCurrentBranch,
@@ -13,12 +14,15 @@ import {
   colorToVariant,
 } from '../lib/pr-state.js';
 import type { PrAction } from '../lib/pr-state.js';
-import type { PrInfo, CiStatus } from '../lib/types.js';
+import type { PrInfo, CiStatus, RepoWebhookStatus } from '../lib/types.js';
 import CipherText from './CipherText.js';
+import RepoSourceDot from './RepoSourceDot.js';
 import TuiButton from './TuiButton.js';
 import BranchSwitcher from './BranchSwitcher.js';
 import TargetBranchSwitcher from './TargetBranchSwitcher.js';
 import { DEFAULT_UTILITY_RAIL_STATE, useUiStore } from '../lib/stores/ui.js';
+import { useSessionsStore } from '../lib/stores/sessions.js';
+import { formatRelativeTime } from '../lib/utils.js';
 import RenameWarningModal from './dialogs/RenameWarningModal.js';
 import Tooltip from './Tooltip.js';
 import './PrTopBar.css';
@@ -39,7 +43,7 @@ interface PrDataState {
   ci: CiStatus | null;
   isRefreshing: boolean;
   prLoading: boolean;
-  refresh: () => void;
+  refresh: () => Promise<void>;
 }
 
 function usePrData(
@@ -79,9 +83,7 @@ function usePrData(
     ci,
     isRefreshing,
     prLoading,
-    refresh: () => {
-      void fetchPrAndCi();
-    },
+    refresh: fetchPrAndCi,
   };
 }
 
@@ -330,23 +332,75 @@ function BranchSection({
   );
 }
 
+interface SourceIndicatorProps {
+  status: RepoWebhookStatus;
+  error?: string | undefined;
+  lastEnrichedAt?: number | undefined;
+  onManualSetup: () => void;
+  onRetry: () => void;
+}
+
+function sourceLabel(status: RepoWebhookStatus): string {
+  if (status === 'live') return 'live';
+  if (status === 'manual') return 'manual';
+  if (status === 'limited') return 'limited';
+  return 'webhook broken';
+}
+
+function SourceIndicator({
+  status,
+  error,
+  lastEnrichedAt,
+  onManualSetup,
+  onRetry,
+}: SourceIndicatorProps) {
+  const updatedText = lastEnrichedAt
+    ? `updated ${formatRelativeTime(new Date(lastEnrichedAt).toISOString())}`
+    : 'updated never';
+
+  return (
+    <span className="source-indicator" data-testid="pr-source-indicator">
+      <RepoSourceDot
+        status={status}
+        error={error}
+        onManualSetup={onManualSetup}
+        onRetry={onRetry}
+      />
+      <span className="source-label">{sourceLabel(status)}</span>
+      <span className="source-updated">· {updatedText}</span>
+    </span>
+  );
+}
+
 interface PrActionsProps {
   utilityRailWorkspacePath: string;
+  sourceStatus: RepoWebhookStatus;
+  sourceError?: string | undefined;
+  sourceLastEnrichedAt?: number | undefined;
+  sourceRefreshing: boolean;
   isRefreshing: boolean;
   prLoading: boolean;
   prAction: PrAction;
   secondaryAction: PrAction | null;
-  onRefresh: () => void;
+  onSourceRefresh: () => void;
+  onManualSetup: () => void;
+  onWebhookRetry: () => void;
   onAction: (action?: PrAction) => void;
 }
 
 function PrActions({
   utilityRailWorkspacePath,
+  sourceStatus,
+  sourceError,
+  sourceLastEnrichedAt,
+  sourceRefreshing,
   isRefreshing,
   prLoading,
   prAction,
   secondaryAction,
-  onRefresh,
+  onSourceRefresh,
+  onManualSetup,
+  onWebhookRetry,
   onAction,
 }: PrActionsProps) {
   const workspaceUtilityRailState = useUiStore((s) =>
@@ -369,14 +423,35 @@ function PrActions({
 
   return (
     <div className="bar-right">
-      <Tooltip label="refresh PR data" actionId="pr.refresh">
+      <SourceIndicator
+        status={sourceStatus}
+        error={sourceError}
+        lastEnrichedAt={sourceLastEnrichedAt}
+        onManualSetup={onManualSetup}
+        onRetry={onWebhookRetry}
+      />
+      <Tooltip
+        label={
+          sourceStatus === 'error'
+            ? 'retry webhook provisioning'
+            : 'refresh repo data'
+        }
+        actionId="pr.refresh"
+      >
         <button
-          className={['refresh-btn', isRefreshing && 'refreshing']
+          className={[
+            'refresh-btn',
+            (isRefreshing || sourceRefreshing) && 'refreshing',
+          ]
             .filter(Boolean)
             .join(' ')}
-          onClick={onRefresh}
-          disabled={isRefreshing}
-          aria-label="Refresh PR data"
+          onClick={onSourceRefresh}
+          disabled={isRefreshing || sourceRefreshing}
+          aria-label={
+            sourceStatus === 'error'
+              ? 'Retry webhook provisioning'
+              : 'Refresh repo data'
+          }
           type="button"
         >
           <svg
@@ -535,6 +610,14 @@ export function PrTopBar({
     currentBranch,
     sessionId
   );
+  const [sourceRefreshing, setSourceRefreshing] = useState(false);
+  const repo = useSessionsStore((s) =>
+    s.repos.find((candidate) => candidate.path === workspacePath)
+  );
+  const repoMeta = useSessionsStore((s) => s.repoEnrichmentMeta[workspacePath]);
+  const forceRefresh = useSessionsStore((s) => s.forceRefresh);
+  const sourceStatus: RepoWebhookStatus =
+    repo?.webhookStatus ?? (repoMeta?.source === 'webhook' ? 'live' : 'manual');
   const rename = useRename(
     workspacePath,
     currentBranch,
@@ -578,6 +661,30 @@ export function PrTopBar({
       setTimeout(() => setCopyFeedback(false), 1500);
     } catch {
       /* clipboard may not be available */
+    }
+  }
+
+  function handleManualSetup() {
+    useUiStore
+      .getState()
+      .setActiveModal({ modal: 'settings', scrollToId: 'integration-webhooks' });
+  }
+
+  async function retryWebhookSetup() {
+    if (!workspacePath) return;
+    await createRepoWebhook(workspacePath);
+    await useSessionsStore.getState().refreshAll();
+  }
+
+  async function handleSourceRefresh() {
+    if (!workspacePath) return;
+    setSourceRefreshing(true);
+    try {
+      if (sourceStatus === 'error') await retryWebhookSetup();
+      await forceRefresh(workspacePath, 'manual');
+      await refresh();
+    } finally {
+      setSourceRefreshing(false);
     }
   }
 
@@ -633,11 +740,17 @@ export function PrTopBar({
       ) : null}
       <PrActions
         utilityRailWorkspacePath={utilityRailWorkspacePath}
+        sourceStatus={sourceStatus}
+        sourceError={repo?.webhookError}
+        sourceLastEnrichedAt={repoMeta?.lastEnrichedAt}
+        sourceRefreshing={sourceRefreshing}
         isRefreshing={isRefreshing}
         prLoading={prLoading}
         prAction={prAction}
         secondaryAction={secondaryAction}
-        onRefresh={refresh}
+        onSourceRefresh={() => void handleSourceRefresh()}
+        onManualSetup={handleManualSetup}
+        onWebhookRetry={() => void retryWebhookSetup()}
         onAction={handleActionClick}
       />
       {rename.renameWarning ? (

--- a/frontend/src/components/PrTopBar.tsx
+++ b/frontend/src/components/PrTopBar.tsx
@@ -14,6 +14,7 @@ import {
   colorToVariant,
 } from '../lib/pr-state.js';
 import type { PrAction } from '../lib/pr-state.js';
+import { deriveRepoWebhookStatus } from '../lib/repo-source.js';
 import type { PrInfo, CiStatus, RepoWebhookStatus } from '../lib/types.js';
 import CipherText from './CipherText.js';
 import RepoSourceDot from './RepoSourceDot.js';
@@ -21,6 +22,7 @@ import TuiButton from './TuiButton.js';
 import BranchSwitcher from './BranchSwitcher.js';
 import TargetBranchSwitcher from './TargetBranchSwitcher.js';
 import { DEFAULT_UTILITY_RAIL_STATE, useUiStore } from '../lib/stores/ui.js';
+import { showToast } from '../lib/stores/toasts.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { formatRelativeTime } from '../lib/utils.js';
 import RenameWarningModal from './dialogs/RenameWarningModal.js';
@@ -612,12 +614,12 @@ export function PrTopBar({
   );
   const [sourceRefreshing, setSourceRefreshing] = useState(false);
   const repo = useSessionsStore((s) =>
-    s.repos.find((candidate) => candidate.path === workspacePath)
+    s.repos.find((r) => r.path === workspacePath)
   );
   const repoMeta = useSessionsStore((s) => s.repoEnrichmentMeta[workspacePath]);
   const forceRefresh = useSessionsStore((s) => s.forceRefresh);
-  const sourceStatus: RepoWebhookStatus =
-    repo?.webhookStatus ?? (repoMeta?.source === 'webhook' ? 'live' : 'manual');
+  const sourceStatus: RepoWebhookStatus = deriveRepoWebhookStatus(repo, repoMeta);
+
   const rename = useRename(
     workspacePath,
     currentBranch,
@@ -672,8 +674,14 @@ export function PrTopBar({
 
   async function retryWebhookSetup() {
     if (!workspacePath) return;
-    await createRepoWebhook(workspacePath);
-    await useSessionsStore.getState().refreshAll();
+    try {
+      await createRepoWebhook(workspacePath);
+      await useSessionsStore.getState().refreshAll();
+    } catch (error) {
+      showToast(
+        error instanceof Error ? error.message : 'failed to retry webhook setup'
+      );
+    }
   }
 
   async function handleSourceRefresh() {
@@ -683,6 +691,10 @@ export function PrTopBar({
       if (sourceStatus === 'error') await retryWebhookSetup();
       await forceRefresh(workspacePath, 'manual');
       await refresh();
+    } catch (error) {
+      showToast(
+        error instanceof Error ? error.message : 'failed to refresh repo data'
+      );
     } finally {
       setSourceRefreshing(false);
     }

--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -21,6 +21,8 @@ import { MarqueeText } from './MarqueeText.js';
 import ContextMenu from './ContextMenu.js';
 import { useRepoAggregation } from '../hooks/useRepoAggregation.js';
 import { createRepoWebhook } from '../lib/api.js';
+import { deriveRepoWebhookStatus } from '../lib/repo-source.js';
+import { showToast } from '../lib/stores/toasts.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import './RepoItem.css';
@@ -516,17 +518,22 @@ export function RepoItem({
     [sidebarItems, repo.path]
   );
   const creatingWorktree = loadingItems.has(`new-worktree:${repo.path}`);
-  const webhookStatus = repo.webhookStatus ?? 'manual';
+  const repoMeta = useSessionsStore((s) => s.repoEnrichmentMeta[repo.path]);
+  const webhookStatus = deriveRepoWebhookStatus(repo, repoMeta);
   const openWebhookSetup = useCallback(() => {
     useUiStore
       .getState()
       .setActiveModal({ modal: 'settings', scrollToId: 'integration-webhooks' });
   }, []);
-  const retryWebhookSetup = useCallback(() => {
-    void (async () => {
+  const retryWebhookSetup = useCallback(async () => {
+    try {
       await createRepoWebhook(repo.path);
       await useSessionsStore.getState().refreshAll();
-    })();
+    } catch (error) {
+      showToast(
+        error instanceof Error ? error.message : 'failed to retry webhook setup'
+      );
+    }
   }, [repo.path]);
   const { highestState, attentionCount } = useRepoAggregation(
     repo.path,

--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import type {
   Repo,
+  RepoWebhookStatus,
   SessionSummary,
   WorktreeInfo,
   PullRequest,
@@ -15,9 +16,13 @@ import { derivePrDotStatus } from '../lib/pr-status.js';
 import { formatRelativeTimeCompact, isMobileDevice } from '../lib/utils.js';
 import StatusDot from './StatusDot.js';
 import { SessionIndicator } from './SessionIndicator.js';
+import RepoSourceDot from './RepoSourceDot.js';
 import { MarqueeText } from './MarqueeText.js';
 import ContextMenu from './ContextMenu.js';
 import { useRepoAggregation } from '../hooks/useRepoAggregation.js';
+import { createRepoWebhook } from '../lib/api.js';
+import { useSessionsStore } from '../lib/stores/sessions.js';
+import { useUiStore } from '../lib/stores/ui.js';
 import './RepoItem.css';
 
 const DOUBLE_CLICK_DELAY_MS = 200;
@@ -292,12 +297,14 @@ function SessionGroupRow({
         {matchedPr ? <PrStatusBadge pr={matchedPr} /> : null}
       </div>
       <div className="session-row-secondary">
-        <span
-          className={`fleet-status tone-${fleetStatus.tone}`}
-          title={fleetStatus.title}
-        >
-          {fleetStatus.label}
-        </span>
+        {dotState !== 'running' && dotState !== 'initializing' ? (
+          <span
+            className={`fleet-status tone-${fleetStatus.tone}`}
+            title={fleetStatus.title}
+          >
+            {fleetStatus.label}
+          </span>
+        ) : null}
         <span className="secondary-time">
           {formatRelativeTimeCompact(rep.lastActivity)}
         </span>
@@ -368,8 +375,12 @@ interface InactiveRepoRowProps {
   repoPath: string;
   repoCurrentBranch: string | null;
   repoDefaultBranch: string | null;
+  webhookStatus: RepoWebhookStatus;
+  webhookError?: string | undefined;
   sidebarItemById: Map<string, SidebarItem>;
   loadingItems: Set<string>;
+  onWebhookSetup: () => void;
+  onWebhookRetry: () => void;
   onLaunchRepoSession?: ((repoPath: string) => void) | undefined;
   onViewHistory?: ((repoPath: string) => void) | undefined;
 }
@@ -379,8 +390,12 @@ function InactiveRepoRow({
   repoPath,
   repoCurrentBranch,
   repoDefaultBranch,
+  webhookStatus,
+  webhookError,
   sidebarItemById,
   loadingItems,
+  onWebhookSetup,
+  onWebhookRetry,
   onLaunchRepoSession,
   onViewHistory,
 }: InactiveRepoRowProps) {
@@ -407,18 +422,28 @@ function InactiveRepoRow({
       }}
     >
       <div className="session-row-primary">
-        <SessionIndicator state="inactive" />
+        <span className="repo-source-stack">
+          <SessionIndicator state={isLoading ? 'initializing' : 'inactive'} />
+          <RepoSourceDot
+            status={webhookStatus}
+            error={webhookError}
+            onManualSetup={onWebhookSetup}
+            onRetry={onWebhookRetry}
+          />
+        </span>
         <span className="session-name">
           <MarqueeText>{isLoading ? 'starting...' : displayLabel}</MarqueeText>
         </span>
       </div>
       <div className="session-row-secondary">
-        <span
-          className={`fleet-status tone-${isLoading ? 'active' : 'inactive'}`}
-          title={`fleet status: ${isLoading ? 'starting' : 'inactive'}`}
-        >
-          {isLoading ? 'starting' : 'inactive'}
-        </span>
+        {!isLoading ? (
+          <span
+            className="fleet-status tone-inactive"
+            title="fleet status: inactive"
+          >
+            inactive
+          </span>
+        ) : null}
         {lastActivity ? (
           <span className="secondary-time">
             {formatRelativeTimeCompact(lastActivity)}
@@ -491,6 +516,18 @@ export function RepoItem({
     [sidebarItems, repo.path]
   );
   const creatingWorktree = loadingItems.has(`new-worktree:${repo.path}`);
+  const webhookStatus = repo.webhookStatus ?? 'manual';
+  const openWebhookSetup = useCallback(() => {
+    useUiStore
+      .getState()
+      .setActiveModal({ modal: 'settings', scrollToId: 'integration-webhooks' });
+  }, []);
+  const retryWebhookSetup = useCallback(() => {
+    void (async () => {
+      await createRepoWebhook(repo.path);
+      await useSessionsStore.getState().refreshAll();
+    })();
+  }, [repo.path]);
   const { highestState, attentionCount } = useRepoAggregation(
     repo.path,
     sidebarItems,
@@ -636,8 +673,12 @@ export function RepoItem({
                   repoPath={repo.path}
                   repoCurrentBranch={repo.currentBranch}
                   repoDefaultBranch={repo.defaultBranch}
+                  webhookStatus={webhookStatus}
+                  webhookError={repo.webhookError}
                   sidebarItemById={sidebarItemById}
                   loadingItems={loadingItems}
+                  onWebhookSetup={openWebhookSetup}
+                  onWebhookRetry={retryWebhookSetup}
                   onLaunchRepoSession={onLaunchRepoSession}
                   onViewHistory={onViewHistory}
                 />
@@ -666,7 +707,15 @@ export function RepoItem({
                 onTouchMove={cancelLongPress}
               >
                 <div className="session-row-primary">
-                  <SessionIndicator state="inactive" />
+                  <span className="repo-source-stack">
+                    <SessionIndicator state={isLoading ? 'initializing' : 'inactive'} />
+                    <RepoSourceDot
+                      status={webhookStatus}
+                      error={repo.webhookError}
+                      onManualSetup={openWebhookSetup}
+                      onRetry={retryWebhookSetup}
+                    />
+                  </span>
                   <span className="session-name">
                     <MarqueeText>
                       {isLoading
@@ -676,12 +725,14 @@ export function RepoItem({
                   </span>
                 </div>
                 <div className="session-row-secondary">
-                  <span
-                    className={`fleet-status tone-${isLoading ? 'active' : 'inactive'}`}
-                    title={`fleet status: ${isLoading ? 'resuming' : 'inactive'}`}
-                  >
-                    {isLoading ? 'resuming' : 'inactive'}
-                  </span>
+                  {!isLoading ? (
+                    <span
+                      className="fleet-status tone-inactive"
+                      title="fleet status: inactive"
+                    >
+                      inactive
+                    </span>
+                  ) : null}
                   {wt.lastActivity ? (
                     <span className="secondary-time">
                       {formatRelativeTimeCompact(wt.lastActivity)}

--- a/frontend/src/components/RepoSourceDot.css
+++ b/frontend/src/components/RepoSourceDot.css
@@ -1,0 +1,62 @@
+.repo-source-dot {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 10px;
+  height: 10px;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  line-height: 1;
+  color: var(--text-muted);
+  user-select: none;
+}
+
+.repo-source-dot--live {
+  color: var(--status-success);
+}
+
+.repo-source-dot--manual,
+.repo-source-dot--limited {
+  color: var(--text-muted);
+}
+
+.repo-source-dot--error {
+  color: var(--status-warning);
+  font-weight: 700;
+}
+
+.repo-source-dot--clickable {
+  cursor: pointer;
+}
+
+.repo-source-dot--clickable:hover,
+.repo-source-dot--clickable:focus-visible {
+  color: var(--text);
+  outline: 1px solid var(--border);
+  outline-offset: 2px;
+}
+
+.repo-source-dot__lock {
+  position: absolute;
+  right: -5px;
+  bottom: -3px;
+  width: 7px;
+  height: 7px;
+  color: var(--text-muted);
+  stroke: currentColor;
+  stroke-width: 1;
+  stroke-linecap: square;
+  stroke-linejoin: miter;
+}
+
+.repo-source-stack {
+  display: inline-flex;
+  width: 12px;
+  flex-shrink: 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+}

--- a/frontend/src/components/RepoSourceDot.css
+++ b/frontend/src/components/RepoSourceDot.css
@@ -45,7 +45,7 @@
   width: 7px;
   height: 7px;
   color: var(--text-muted);
-  stroke: currentColor;
+  stroke: currentcolor;
   stroke-width: 1;
   stroke-linecap: square;
   stroke-linejoin: miter;

--- a/frontend/src/components/RepoSourceDot.tsx
+++ b/frontend/src/components/RepoSourceDot.tsx
@@ -1,10 +1,11 @@
 import type { KeyboardEvent } from 'react';
+import type { RepoWebhookStatus } from '../lib/types.js';
 import './RepoSourceDot.css';
 
-export type RepoSourceStatus = 'live' | 'manual' | 'limited' | 'error';
+export type RepoSourceStatus = RepoWebhookStatus;
 
 export interface RepoSourceDotProps {
-  status: RepoSourceStatus;
+  status: RepoWebhookStatus;
   error?: string | undefined;
   onManualSetup?: (() => void) | undefined;
   onRetry?: (() => void) | undefined;
@@ -41,10 +42,10 @@ export function RepoSourceDot({
   };
   const handleKeyDown = (event: KeyboardEvent<HTMLSpanElement>) => {
     if (!actionable) return;
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      handleAction();
-    }
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    event.stopPropagation();
+    handleAction();
   };
 
   return (
@@ -67,11 +68,7 @@ export function RepoSourceDot({
         event.stopPropagation();
         handleAction();
       }}
-      onKeyDown={(event) => {
-        if (!actionable) return;
-        event.stopPropagation();
-        handleKeyDown(event);
-      }}
+      onKeyDown={handleKeyDown}
     >
       {glyphFor(status)}
       {status === 'limited' ? (

--- a/frontend/src/components/RepoSourceDot.tsx
+++ b/frontend/src/components/RepoSourceDot.tsx
@@ -1,0 +1,91 @@
+import type { KeyboardEvent } from 'react';
+import './RepoSourceDot.css';
+
+export type RepoSourceStatus = 'live' | 'manual' | 'limited' | 'error';
+
+export interface RepoSourceDotProps {
+  status: RepoSourceStatus;
+  error?: string | undefined;
+  onManualSetup?: (() => void) | undefined;
+  onRetry?: (() => void) | undefined;
+  className?: string | undefined;
+}
+
+function labelFor(status: RepoSourceStatus, error?: string): string {
+  if (status === 'live') return 'live via webhook';
+  if (status === 'manual') return 'manual fetch · enable webhook for live updates';
+  if (status === 'limited') return 'manual fetch · no admin on this repo';
+  return `webhook broken: ${error || 'setup failed'} · click to retry`;
+}
+
+function glyphFor(status: RepoSourceStatus): string {
+  if (status === 'live') return '●';
+  if (status === 'error') return '!';
+  if (status === 'limited') return '○';
+  return '○';
+}
+
+export function RepoSourceDot({
+  status,
+  error,
+  onManualSetup,
+  onRetry,
+  className,
+}: RepoSourceDotProps) {
+  const label = labelFor(status, error);
+  const actionable =
+    (status === 'manual' && onManualSetup) || (status === 'error' && onRetry);
+  const handleAction = () => {
+    if (status === 'manual') onManualSetup?.();
+    else if (status === 'error') onRetry?.();
+  };
+  const handleKeyDown = (event: KeyboardEvent<HTMLSpanElement>) => {
+    if (!actionable) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleAction();
+    }
+  };
+
+  return (
+    <span
+      className={[
+        'repo-source-dot',
+        `repo-source-dot--${status}`,
+        actionable && 'repo-source-dot--clickable',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      data-testid="repo-source-dot"
+      title={label}
+      aria-label={label}
+      role={actionable ? 'button' : 'img'}
+      tabIndex={actionable ? 0 : undefined}
+      onClick={(event) => {
+        if (!actionable) return;
+        event.stopPropagation();
+        handleAction();
+      }}
+      onKeyDown={(event) => {
+        if (!actionable) return;
+        event.stopPropagation();
+        handleKeyDown(event);
+      }}
+    >
+      {glyphFor(status)}
+      {status === 'limited' ? (
+        <svg
+          className="repo-source-dot__lock"
+          viewBox="0 0 8 8"
+          aria-hidden="true"
+        >
+          <rect x="1.5" y="3.5" width="5" height="3" fill="none" />
+          <path d="M2.5 3.5V2.5a1.5 1.5 0 0 1 3 0v1" fill="none" />
+        </svg>
+      ) : null}
+    </span>
+  );
+}
+
+export default RepoSourceDot;

--- a/frontend/src/components/SessionIndicator.tsx
+++ b/frontend/src/components/SessionIndicator.tsx
@@ -21,7 +21,7 @@ export const config: Record<
 
 export function getPulseClass(state: DisplayState): string {
   if (state === 'permission' || state === 'needs-answer') return 'pulse-fast';
-  if (state === 'unseen-idle') return 'pulse-slow';
+  if (state === 'unseen-idle' || state === 'initializing') return 'pulse-slow';
   return '';
 }
 

--- a/frontend/src/lib/repo-source.ts
+++ b/frontend/src/lib/repo-source.ts
@@ -1,0 +1,12 @@
+import type { Repo, RepoWebhookStatus } from './types.js';
+
+interface RepoEnrichmentSourceMeta {
+  source?: 'webhook' | 'manual' | undefined;
+}
+
+export function deriveRepoWebhookStatus(
+  repo: Pick<Repo, 'webhookStatus'> | null | undefined,
+  meta?: RepoEnrichmentSourceMeta | null
+): RepoWebhookStatus {
+  return repo?.webhookStatus ?? (meta?.source === 'webhook' ? 'live' : 'manual');
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -85,12 +85,17 @@ export interface AccountTelemetry {
   updatedAt: string;
 }
 
+export type RepoWebhookStatus = 'live' | 'manual' | 'limited' | 'error';
+
 export interface Repo {
   path: string;
   name: string;
   isGitRepo: boolean;
   defaultBranch: string | null;
   currentBranch: string | null;
+  webhookStatus?: RepoWebhookStatus;
+  webhookError?: string;
+  lastWebhookEventAt?: string;
 }
 
 export interface Workspace {

--- a/test/pr-top-bar-action.test.ts
+++ b/test/pr-top-bar-action.test.ts
@@ -10,18 +10,47 @@ const mocks = vi.hoisted(() => ({
   fetchCiStatusOrNull: vi.fn(),
   fetchCurrentBranch: vi.fn(),
   renameBranch: vi.fn(),
+  createRepoWebhook: vi.fn(),
   sendPtyData: vi.fn(),
+  forceRefresh: vi.fn(),
+  refreshAll: vi.fn(),
+  repos: [] as Array<{
+    path: string;
+    name: string;
+    isGitRepo: boolean;
+    defaultBranch: string | null;
+    currentBranch: string | null;
+    webhookStatus?: 'live' | 'manual' | 'limited' | 'error';
+    webhookError?: string;
+  }>,
+  repoEnrichmentMeta: {} as Record<
+    string,
+    { lastEnrichedAt: number; source: 'webhook' | 'manual' }
+  >,
 }));
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 vi.mock('../frontend/src/lib/api.js', () => ({
   fetchPrForBranchOrNull: mocks.fetchPrForBranchOrNull,
   fetchCiStatusOrNull: mocks.fetchCiStatusOrNull,
   fetchCurrentBranch: mocks.fetchCurrentBranch,
   renameBranch: mocks.renameBranch,
+  createRepoWebhook: mocks.createRepoWebhook,
 }));
 
 vi.mock('../frontend/src/lib/ws.js', () => ({
   sendPtyData: mocks.sendPtyData,
+}));
+
+vi.mock('../frontend/src/lib/stores/sessions.js', () => ({
+  useSessionsStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      repos: mocks.repos,
+      repoEnrichmentMeta: mocks.repoEnrichmentMeta,
+      forceRefresh: mocks.forceRefresh,
+      refreshAll: mocks.refreshAll,
+    }),
 }));
 
 vi.mock('../frontend/src/lib/stores/ui.js', () => ({
@@ -40,6 +69,7 @@ vi.mock('../frontend/src/lib/stores/ui.js', () => ({
       }),
       hydrateUtilityRailState: vi.fn(),
       toggleUtilityRailVisible: vi.fn(),
+      setActiveModal: vi.fn(),
     }),
 }));
 
@@ -110,6 +140,10 @@ describe('PrTopBar actions', () => {
     container = null;
     vi.restoreAllMocks();
     vi.clearAllMocks();
+    mocks.repos.splice(0);
+    Object.keys(mocks.repoEnrichmentMeta).forEach((key) => {
+      delete mocks.repoEnrichmentMeta[key];
+    });
   });
 
   it('opens mergeable PRs in a new tab without archiving the session', async () => {
@@ -149,5 +183,54 @@ describe('PrTopBar actions', () => {
     );
     expect(onArchive).not.toHaveBeenCalled();
     expect(mocks.sendPtyData).not.toHaveBeenCalled();
+  });
+
+  it('renders source freshness and calls forceRefresh from the manual refresh button', async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.repos.push({
+      path: '/repo',
+      name: 'repo',
+      isGitRepo: true,
+      defaultBranch: 'nightly',
+      currentBranch: 'fix/115-merge-button',
+      webhookStatus: 'manual',
+    });
+    mocks.repoEnrichmentMeta['/repo'] = {
+      lastEnrichedAt: Date.now() - 4 * 60 * 1000,
+      source: 'manual',
+    };
+    mocks.fetchPrForBranchOrNull.mockResolvedValue(samplePr());
+    mocks.fetchCiStatusOrNull.mockResolvedValue(passingCi());
+    mocks.forceRefresh.mockResolvedValue(undefined);
+
+    await act(async () => {
+      root.render(
+        React.createElement(PrTopBar, {
+          workspacePath: '/repo',
+          branchName: 'fix/115-merge-button',
+          sessionId: 'session-1',
+        })
+      );
+    });
+    await flushEffects();
+
+    const source = container.querySelector('[data-testid="pr-source-indicator"]');
+    expect(source?.textContent).toContain('manual');
+    expect(source?.textContent).toContain('updated 4m ago');
+
+    const refreshButton = container.querySelector(
+      'button[aria-label="Refresh repo data"]'
+    ) as HTMLButtonElement | null;
+    expect(refreshButton).toBeTruthy();
+
+    await act(async () => {
+      refreshButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.forceRefresh).toHaveBeenCalledWith('/repo', 'manual');
   });
 });

--- a/test/pr-top-bar-action.test.ts
+++ b/test/pr-top-bar-action.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   sendPtyData: vi.fn(),
   forceRefresh: vi.fn(),
   refreshAll: vi.fn(),
+  showToast: vi.fn(),
   repos: [] as Array<{
     path: string;
     name: string;
@@ -29,7 +30,9 @@ const mocks = vi.hoisted(() => ({
   >,
 }));
 
-globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 vi.mock('../frontend/src/lib/api.js', () => ({
   fetchPrForBranchOrNull: mocks.fetchPrForBranchOrNull,
@@ -41,6 +44,10 @@ vi.mock('../frontend/src/lib/api.js', () => ({
 
 vi.mock('../frontend/src/lib/ws.js', () => ({
   sendPtyData: mocks.sendPtyData,
+}));
+
+vi.mock('../frontend/src/lib/stores/toasts.js', () => ({
+  showToast: mocks.showToast,
 }));
 
 vi.mock('../frontend/src/lib/stores/sessions.js', () => ({
@@ -140,6 +147,7 @@ describe('PrTopBar actions', () => {
     container = null;
     vi.restoreAllMocks();
     vi.clearAllMocks();
+    vi.useRealTimers();
     mocks.repos.splice(0);
     Object.keys(mocks.repoEnrichmentMeta).forEach((key) => {
       delete mocks.repoEnrichmentMeta[key];
@@ -197,8 +205,11 @@ describe('PrTopBar actions', () => {
       currentBranch: 'fix/115-merge-button',
       webhookStatus: 'manual',
     });
+    const baseTime = 1_700_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(baseTime);
     mocks.repoEnrichmentMeta['/repo'] = {
-      lastEnrichedAt: Date.now() - 4 * 60 * 1000,
+      lastEnrichedAt: baseTime - 4 * 60 * 1000,
       source: 'manual',
     };
     mocks.fetchPrForBranchOrNull.mockResolvedValue(samplePr());
@@ -231,6 +242,52 @@ describe('PrTopBar actions', () => {
       await Promise.resolve();
     });
 
+    expect(mocks.forceRefresh).toHaveBeenCalledWith('/repo', 'manual');
+  });
+
+  it('reports webhook retry failures while still forcing a manual refresh', async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.repos.push({
+      path: '/repo',
+      name: 'repo',
+      isGitRepo: true,
+      defaultBranch: 'nightly',
+      currentBranch: 'fix/115-merge-button',
+      webhookStatus: 'error',
+      webhookError: 'hook failed',
+    });
+    mocks.fetchPrForBranchOrNull.mockResolvedValue(samplePr());
+    mocks.fetchCiStatusOrNull.mockResolvedValue(passingCi());
+    mocks.createRepoWebhook.mockRejectedValue(new Error('webhook denied'));
+    mocks.forceRefresh.mockResolvedValue(undefined);
+
+    await act(async () => {
+      root.render(
+        React.createElement(PrTopBar, {
+          workspacePath: '/repo',
+          branchName: 'fix/115-merge-button',
+          sessionId: 'session-1',
+        })
+      );
+    });
+    await flushEffects();
+
+    const retryButton = container.querySelector(
+      'button[aria-label="Retry webhook provisioning"]'
+    ) as HTMLButtonElement | null;
+    expect(retryButton).toBeTruthy();
+
+    await act(async () => {
+      retryButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.createRepoWebhook).toHaveBeenCalledWith('/repo');
+    expect(mocks.showToast).toHaveBeenCalledWith('webhook denied');
     expect(mocks.forceRefresh).toHaveBeenCalledWith('/repo', 'manual');
   });
 });

--- a/test/repo-item-source-indicator.test.ts
+++ b/test/repo-item-source-indicator.test.ts
@@ -7,7 +7,9 @@ import { RepoItem } from '../frontend/src/components/RepoItem.js';
 import type { Repo, SidebarItem } from '../frontend/src/lib/types.js';
 import { makeSession, makeWorktree } from './helpers/frontend-factories.js';
 
-(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 const noop = vi.fn();
 
@@ -62,14 +64,21 @@ describe('RepoItem source indicators', () => {
       cwd: '/path/to/worktree',
       branchName: 'feat/test',
     });
-    const sessionGroups = new Map([[session.worktreePath ?? session.repoPath, [session]]]);
+    const sessionGroups = new Map([
+      [session.worktreePath ?? session.repoPath, [session]],
+    ]);
 
     await act(async () => {
       root.render(
         React.createElement(RepoItem, {
           repo: makeRepo({ webhookStatus: 'limited' }),
           sessionGroups,
-          inactiveWorktrees: [makeWorktree({ path: '/path/to/inactive', branchName: 'feat/inactive' })],
+          inactiveWorktrees: [
+            makeWorktree({
+              path: '/path/to/inactive',
+              branchName: 'feat/inactive',
+            }),
+          ],
           isActive: false,
           activeSessionId: null,
           onSelectWorkspace: noop,
@@ -84,13 +93,19 @@ describe('RepoItem source indicators', () => {
 
     const rows = Array.from(container.querySelectorAll('.session-row'));
     expect(rows).toHaveLength(2);
-    expect(rows[0]?.querySelector('[data-testid="repo-source-dot"]')).toBeNull();
+    expect(
+      rows[0]?.querySelector('[data-testid="repo-source-dot"]')
+    ).toBeNull();
 
-    const inactiveSource = rows[1]?.querySelector('[data-testid="repo-source-dot"]');
-    expect(inactiveSource?.getAttribute('title')).toBe('manual fetch · no admin on this repo');
-    expect(inactiveSource?.outerHTML).toMatchInlineSnapshot(
-      `"<span class=\"repo-source-dot repo-source-dot--limited\" data-testid=\"repo-source-dot\" title=\"manual fetch · no admin on this repo\" aria-label=\"manual fetch · no admin on this repo\" role=\"img\">○<svg class=\"repo-source-dot__lock\" viewBox=\"0 0 8 8\" aria-hidden=\"true\"><rect x=\"1.5\" y=\"3.5\" width=\"5\" height=\"3\" fill=\"none\"></rect><path d=\"M2.5 3.5V2.5a1.5 1.5 0 0 1 3 0v1\" fill=\"none\"></path></svg></span>"`
+    const inactiveSource = rows[1]?.querySelector(
+      '[data-testid="repo-source-dot"]'
     );
+    expect(inactiveSource?.getAttribute('title')).toBe(
+      'manual fetch · no admin on this repo'
+    );
+    expect(
+      inactiveSource?.querySelector('.repo-source-dot__lock')
+    ).toBeTruthy();
   });
 
   it('does not render starting or in-progress chips for loading rows', async () => {
@@ -114,7 +129,9 @@ describe('RepoItem source indicators', () => {
       );
     });
 
-    expect(container.querySelector('.state-initializing .pulse-slow')).toBeTruthy();
+    expect(
+      container.querySelector('.state-initializing .pulse-slow')
+    ).toBeTruthy();
     const chipText = Array.from(container.querySelectorAll('.fleet-status'))
       .map((node) => node.textContent?.trim())
       .join(' ');

--- a/test/repo-item-source-indicator.test.ts
+++ b/test/repo-item-source-indicator.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RepoItem } from '../frontend/src/components/RepoItem.js';
+import type { Repo, SidebarItem } from '../frontend/src/lib/types.js';
+import { makeSession, makeWorktree } from './helpers/frontend-factories.js';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const noop = vi.fn();
+
+function makeRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    path: '/path/to/repo',
+    name: 'repo',
+    isGitRepo: true,
+    defaultBranch: 'nightly',
+    currentBranch: 'nightly',
+    ...overrides,
+  };
+}
+
+function makeSidebarItem(overrides: Partial<SidebarItem> = {}): SidebarItem {
+  return {
+    id: '/path/to/worktree',
+    kind: 'worktree',
+    path: '/path/to/worktree',
+    repoPath: '/path/to/repo',
+    displayName: 'feat/test',
+    branchName: 'feat/test',
+    lastActivity: '2026-03-29T00:00:00Z',
+    displayState: 'running',
+    lastKnownBackendState: 'running',
+    sessions: [],
+    ...overrides,
+  };
+}
+
+describe('RepoItem source indicators', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it('renders source dots for branch rows but not active session rows', async () => {
+    const session = makeSession({
+      id: 'sess-1',
+      repoPath: '/path/to/repo',
+      worktreePath: '/path/to/worktree',
+      cwd: '/path/to/worktree',
+      branchName: 'feat/test',
+    });
+    const sessionGroups = new Map([[session.worktreePath ?? session.repoPath, [session]]]);
+
+    await act(async () => {
+      root.render(
+        React.createElement(RepoItem, {
+          repo: makeRepo({ webhookStatus: 'limited' }),
+          sessionGroups,
+          inactiveWorktrees: [makeWorktree({ path: '/path/to/inactive', branchName: 'feat/inactive' })],
+          isActive: false,
+          activeSessionId: null,
+          onSelectWorkspace: noop,
+          onSelectSession: noop,
+          onNewWorktree: noop,
+          onOpenSettings: noop,
+          onResumeWorktree: noop,
+          sidebarItems: [makeSidebarItem()],
+        })
+      );
+    });
+
+    const rows = Array.from(container.querySelectorAll('.session-row'));
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.querySelector('[data-testid="repo-source-dot"]')).toBeNull();
+
+    const inactiveSource = rows[1]?.querySelector('[data-testid="repo-source-dot"]');
+    expect(inactiveSource?.getAttribute('title')).toBe('manual fetch · no admin on this repo');
+    expect(inactiveSource?.outerHTML).toMatchInlineSnapshot(
+      `"<span class=\"repo-source-dot repo-source-dot--limited\" data-testid=\"repo-source-dot\" title=\"manual fetch · no admin on this repo\" aria-label=\"manual fetch · no admin on this repo\" role=\"img\">○<svg class=\"repo-source-dot__lock\" viewBox=\"0 0 8 8\" aria-hidden=\"true\"><rect x=\"1.5\" y=\"3.5\" width=\"5\" height=\"3\" fill=\"none\"></rect><path d=\"M2.5 3.5V2.5a1.5 1.5 0 0 1 3 0v1\" fill=\"none\"></path></svg></span>"`
+    );
+  });
+
+  it('does not render starting or in-progress chips for loading rows', async () => {
+    const loadingItems = new Set(['/path/to/worktree']);
+
+    await act(async () => {
+      root.render(
+        React.createElement(RepoItem, {
+          repo: makeRepo(),
+          sessionGroups: new Map(),
+          inactiveWorktrees: [makeWorktree()],
+          isActive: false,
+          activeSessionId: null,
+          onSelectWorkspace: noop,
+          onSelectSession: noop,
+          onNewWorktree: noop,
+          onOpenSettings: noop,
+          onResumeWorktree: noop,
+          loadingItems,
+        })
+      );
+    });
+
+    expect(container.querySelector('.state-initializing .pulse-slow')).toBeTruthy();
+    const chipText = Array.from(container.querySelectorAll('.fleet-status'))
+      .map((node) => node.textContent?.trim())
+      .join(' ');
+    expect(chipText).not.toContain('starting');
+    expect(chipText).not.toContain('in-progress');
+    expect(chipText).not.toContain('resuming');
+  });
+});

--- a/test/repo-source-dot.test.ts
+++ b/test/repo-source-dot.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import RepoSourceDot from '../frontend/src/components/RepoSourceDot.js';
+import { getPulseClass } from '../frontend/src/components/SessionIndicator.js';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('RepoSourceDot', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function renderDot(
+    props: React.ComponentProps<typeof RepoSourceDot>
+  ): Promise<HTMLElement> {
+    await act(async () => {
+      root.render(React.createElement(RepoSourceDot, props));
+    });
+    const dot = container.querySelector('[data-testid="repo-source-dot"]');
+    expect(dot).toBeTruthy();
+    return dot as HTMLElement;
+  }
+
+  it('renders visual states with lowercase tooltip labels', async () => {
+    const states = [
+      ['live', 'live via webhook'],
+      ['manual', 'manual fetch · enable webhook for live updates'],
+      ['limited', 'manual fetch · no admin on this repo'],
+      ['error', 'webhook broken: not-found · click to retry'],
+    ] as const;
+
+    const rendered: string[] = [];
+    for (const [state, title] of states) {
+      const dot = await renderDot({
+        status: state,
+        error: state === 'error' ? 'not-found' : undefined,
+      });
+      expect(dot.getAttribute('title')).toBe(title);
+      expect(dot.getAttribute('aria-label')).toBe(title);
+      expect(dot.className).toContain(`repo-source-dot--${state}`);
+      rendered.push(dot.outerHTML);
+    }
+
+    expect(rendered).toMatchInlineSnapshot(`
+      [
+        "<span class=\"repo-source-dot repo-source-dot--live\" data-testid=\"repo-source-dot\" title=\"live via webhook\" aria-label=\"live via webhook\" role=\"img\">●</span>",
+        "<span class=\"repo-source-dot repo-source-dot--manual\" data-testid=\"repo-source-dot\" title=\"manual fetch · enable webhook for live updates\" aria-label=\"manual fetch · enable webhook for live updates\" role=\"img\">○</span>",
+        "<span class=\"repo-source-dot repo-source-dot--limited\" data-testid=\"repo-source-dot\" title=\"manual fetch · no admin on this repo\" aria-label=\"manual fetch · no admin on this repo\" role=\"img\">○<svg class=\"repo-source-dot__lock\" viewBox=\"0 0 8 8\" aria-hidden=\"true\"><rect x=\"1.5\" y=\"3.5\" width=\"5\" height=\"3\" fill=\"none\"></rect><path d=\"M2.5 3.5V2.5a1.5 1.5 0 0 1 3 0v1\" fill=\"none\"></path></svg></span>",
+        "<span class=\"repo-source-dot repo-source-dot--error\" data-testid=\"repo-source-dot\" title=\"webhook broken: not-found · click to retry\" aria-label=\"webhook broken: not-found · click to retry\" role=\"img\">!</span>",
+      ]
+    `);
+  });
+
+  it('only enables click actions for manual and error states', async () => {
+    const onManual = vi.fn();
+    const onRetry = vi.fn();
+
+    const manual = await renderDot({ status: 'manual', onManualSetup: onManual, onRetry });
+    manual.click();
+    expect(onManual).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+
+    const limited = await renderDot({ status: 'limited', onManualSetup: onManual, onRetry });
+    limited.click();
+    expect(onManual).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+
+    const error = await renderDot({ status: 'error', onManualSetup: onManual, onRetry });
+    error.click();
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets non-actionable states bubble clicks to the row', async () => {
+    const onRowClick = vi.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(
+          'button',
+          { type: 'button', onClick: onRowClick },
+          React.createElement(RepoSourceDot, { status: 'limited' })
+        )
+      );
+    });
+
+    const dot = container.querySelector('[data-testid="repo-source-dot"]') as HTMLElement | null;
+    expect(dot).toBeTruthy();
+    expect(dot?.getAttribute('tabindex')).toBeNull();
+
+    dot?.click();
+
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SessionIndicator boot animation', () => {
+  it('pulses initializing sessions so starting chips are redundant', () => {
+    expect(getPulseClass('initializing')).toBe('pulse-slow');
+  });
+});

--- a/test/repo-source-dot.test.ts
+++ b/test/repo-source-dot.test.ts
@@ -114,6 +114,38 @@ describe('RepoSourceDot', () => {
 
     expect(onRowClick).toHaveBeenCalledTimes(1);
   });
+
+  it('only stops handled keyboard actions for actionable dots', async () => {
+    const onManual = vi.fn();
+    const onParentKeyDown = vi.fn();
+    await act(async () => {
+      root.render(
+        React.createElement(
+          'div',
+          { onKeyDown: onParentKeyDown },
+          React.createElement(RepoSourceDot, {
+            status: 'manual',
+            onManualSetup: onManual,
+          })
+        )
+      );
+    });
+
+    const dot = container.querySelector(
+      '[data-testid="repo-source-dot"]'
+    ) as HTMLElement | null;
+    expect(dot).toBeTruthy();
+
+    dot?.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+    expect(onParentKeyDown).toHaveBeenCalledTimes(1);
+    expect(onManual).not.toHaveBeenCalled();
+
+    dot?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    );
+    expect(onParentKeyDown).toHaveBeenCalledTimes(1);
+    expect(onManual).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('SessionIndicator boot animation', () => {

--- a/test/repo-source-dot.test.ts
+++ b/test/repo-source-dot.test.ts
@@ -6,7 +6,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import RepoSourceDot from '../frontend/src/components/RepoSourceDot.js';
 import { getPulseClass } from '../frontend/src/components/SessionIndicator.js';
 
-(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 describe('RepoSourceDot', () => {
   let container: HTMLDivElement;
@@ -42,7 +44,6 @@ describe('RepoSourceDot', () => {
       ['error', 'webhook broken: not-found · click to retry'],
     ] as const;
 
-    const rendered: string[] = [];
     for (const [state, title] of states) {
       const dot = await renderDot({
         status: state,
@@ -51,34 +52,42 @@ describe('RepoSourceDot', () => {
       expect(dot.getAttribute('title')).toBe(title);
       expect(dot.getAttribute('aria-label')).toBe(title);
       expect(dot.className).toContain(`repo-source-dot--${state}`);
-      rendered.push(dot.outerHTML);
+      expect(dot.textContent).toBe(
+        state === 'live' ? '●' : state === 'error' ? '!' : '○'
+      );
+      expect(dot.querySelector('.repo-source-dot__lock')).toBe(
+        state === 'limited' ? dot.querySelector('svg') : null
+      );
     }
-
-    expect(rendered).toMatchInlineSnapshot(`
-      [
-        "<span class=\"repo-source-dot repo-source-dot--live\" data-testid=\"repo-source-dot\" title=\"live via webhook\" aria-label=\"live via webhook\" role=\"img\">●</span>",
-        "<span class=\"repo-source-dot repo-source-dot--manual\" data-testid=\"repo-source-dot\" title=\"manual fetch · enable webhook for live updates\" aria-label=\"manual fetch · enable webhook for live updates\" role=\"img\">○</span>",
-        "<span class=\"repo-source-dot repo-source-dot--limited\" data-testid=\"repo-source-dot\" title=\"manual fetch · no admin on this repo\" aria-label=\"manual fetch · no admin on this repo\" role=\"img\">○<svg class=\"repo-source-dot__lock\" viewBox=\"0 0 8 8\" aria-hidden=\"true\"><rect x=\"1.5\" y=\"3.5\" width=\"5\" height=\"3\" fill=\"none\"></rect><path d=\"M2.5 3.5V2.5a1.5 1.5 0 0 1 3 0v1\" fill=\"none\"></path></svg></span>",
-        "<span class=\"repo-source-dot repo-source-dot--error\" data-testid=\"repo-source-dot\" title=\"webhook broken: not-found · click to retry\" aria-label=\"webhook broken: not-found · click to retry\" role=\"img\">!</span>",
-      ]
-    `);
   });
 
   it('only enables click actions for manual and error states', async () => {
     const onManual = vi.fn();
     const onRetry = vi.fn();
 
-    const manual = await renderDot({ status: 'manual', onManualSetup: onManual, onRetry });
+    const manual = await renderDot({
+      status: 'manual',
+      onManualSetup: onManual,
+      onRetry,
+    });
     manual.click();
     expect(onManual).toHaveBeenCalledTimes(1);
     expect(onRetry).not.toHaveBeenCalled();
 
-    const limited = await renderDot({ status: 'limited', onManualSetup: onManual, onRetry });
+    const limited = await renderDot({
+      status: 'limited',
+      onManualSetup: onManual,
+      onRetry,
+    });
     limited.click();
     expect(onManual).toHaveBeenCalledTimes(1);
     expect(onRetry).not.toHaveBeenCalled();
 
-    const error = await renderDot({ status: 'error', onManualSetup: onManual, onRetry });
+    const error = await renderDot({
+      status: 'error',
+      onManualSetup: onManual,
+      onRetry,
+    });
     error.click();
     expect(onRetry).toHaveBeenCalledTimes(1);
   });
@@ -95,7 +104,9 @@ describe('RepoSourceDot', () => {
       );
     });
 
-    const dot = container.querySelector('[data-testid="repo-source-dot"]') as HTMLElement | null;
+    const dot = container.querySelector(
+      '[data-testid="repo-source-dot"]'
+    ) as HTMLElement | null;
     expect(dot).toBeTruthy();
     expect(dot?.getAttribute('tabindex')).toBeNull();
 


### PR DESCRIPTION
## Summary
- add `RepoSourceDot` for live/manual/limited/error webhook source states with lowercase tooltips and keyboard-safe actions
- show the source dot stack on sidebar branch rows while keeping active session rows to the activity indicator only
- add PR top-bar source freshness, updated time, manual refresh spinner, webhook setup, and retry/re-provision actions
- remove redundant loading/in-progress chips from sidebar rows; initializing rows now rely on the pulsing activity indicator

Closes #357
Refs #353

## Verification
- `npm test -- test/repo-source-dot.test.ts test/repo-item-source-indicator.test.ts test/pr-top-bar-action.test.ts` — pass, 8 tests
- `npm run build` — pass

## The Case Against
- This relies on the repo-level `webhookStatus` and `repoEnrichmentMeta` added by the prior webhook-first refresh work; if a workspace path is not identical to the configured repo path, the top bar may fall back to `manual` until store path canonicalization catches up.
- The sidebar source dot is intentionally branch-row-only for inactive/default worktree rows; active session rows keep just the activity dot per the issue, but that means a currently open branch does not repeat source state in the row.
- The manual setup flow jumps to the existing settings/webhooks section instead of launching a dedicated per-repo setup modal; if we want repo-scoped setup prompts later, this should be split out.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
|---|---:|---|
| Source state looks clickable when it should not | Low | limited/live states do not get tab focus or actions; tests cover non-actionable bubbling and limited rendering |
| Refresh button hides PR refresh behavior | Medium | button calls `forceRefresh(repoPath, 'manual')` and then refreshes PR/CI state so the top bar stays fresh |
| Sidebar loses useful status text | Low | only running/initializing chips are removed; attention/idle/error/inactive chips remain, and initializing gets pulse animation |
| Visual drift from DESIGN.md | Low | CSS uses monospace, lowercase labels, zero radius, semantic colors, outline/ghost refresh control |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository source status indicator (live/manual/limited/error) with “updated X ago”
  * Improved refresh controls: webhook retry, manual setup flow, and combined source+data refresh
  * Repo-level source dot indicators across lists and rows, including lock for limited access

* **Style**
  * Refresh button and source indicator styling and responsive tweaks

* **Tests**
  * Added tests covering source indicators, refresh flows, and keyboard/interaction behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->