### PR TITLE
Harden dev restart session recovery

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -85,10 +85,7 @@ import { createIntegrationJiraRouter } from './integration-jira.js';
 import { startPolling, stopPolling } from './review-poller.js';
 import { createGitHubAppRouter } from './github-app.js';
 import { createWebhookRouter } from './webhooks.js';
-import {
-  createWebhookManagerRouter,
-  reloadSmee,
-} from './webhook-manager.js';
+import { createWebhookManagerRouter, reloadSmee } from './webhook-manager.js';
 import { fetchPrsGraphQL } from './github-graphql.js';
 import {
   createTelemetryRouter,
@@ -766,7 +763,9 @@ function sessionCreateFailureMessage(err: unknown): string {
   if (!(err instanceof Error)) return 'Failed to create session.';
   // Surface the underlying message so failures (codex spawn, app-server
   // handshake, thread/start, etc.) reach the UI instead of a generic banner.
-  return err.message ? `Failed to create session: ${err.message}` : 'Failed to create session.';
+  return err.message
+    ? `Failed to create session: ${err.message}`
+    : 'Failed to create session.';
 }
 
 /** Initializes the startup config PIN (migrates legacy hashes, prompts if needed). */
@@ -2556,7 +2555,7 @@ async function main(): Promise<void> {
       if (restarting) {
         stopEventBatching();
         stopTelemetry();
-        serializeAll(configDir);
+        serializeAll(configDir, { reason: 'update' });
         flushRelayStateWrites();
         closeRelayStateDb();
         broadcastEvent('server-restarting');
@@ -2629,7 +2628,9 @@ async function main(): Promise<void> {
     server.close();
     // Serialize sessions before detaching the node-pty tmux clients. The tmux
     // sessions themselves must survive so startup can reattach to them.
-    serializeAll(configDir);
+    serializeAll(configDir, {
+      reason: process.env.NO_PIN === '1' ? 'dev-restart' : 'signal-shutdown',
+    });
     flushRelayStateWrites();
     closeRelayStateDb();
     for (const s of sessions.list()) {

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -1234,11 +1234,6 @@ function pendingSessionsAgeMs(pending: PendingSessionsFile): number | null {
   return Date.now() - timestampMs;
 }
 
-function isPendingSessionsFileStale(pending: PendingSessionsFile): boolean {
-  const ageMs = pendingSessionsAgeMs(pending);
-  return ageMs === null || ageMs > STALE_THRESHOLD_MS;
-}
-
 function pendingSessionAgeMs(
   pending: PendingSessionsFile,
   session: SerializedPtySession

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -79,10 +79,24 @@ interface SerializedPtySession {
   additionalDirs?: string[];
 }
 
+type RestartReason =
+  | 'update'
+  | 'dev-restart'
+  | 'signal-shutdown'
+  | 'shutdown'
+  | 'crash-recovery'
+  | 'manual'
+  | 'unspecified';
+
 interface PendingSessionsFile {
   version: number; // now 6 — web sessions moved to relay-state.db
   timestamp: string;
+  reason?: RestartReason | string;
   sessions: SerializedPtySession[];
+}
+
+interface SerializeOptions {
+  reason?: RestartReason | string;
 }
 
 const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
@@ -579,12 +593,83 @@ function nextAgentName(): string {
   return `Agent ${++agentCounter}`;
 }
 
+function atomicWriteFileSync(filePath: string, data: string): void {
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    fs.writeFileSync(tmpPath, data, 'utf-8');
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  }
+}
+
+function pendingSessionsPath(configDir: string): string {
+  return path.join(configDir, 'pending-sessions.json');
+}
+
+function scrollbackDir(configDir: string): string {
+  return path.join(configDir, 'scrollback');
+}
+
+function writePendingSessionsFile(
+  configDir: string,
+  pending: PendingSessionsFile
+): void {
+  fs.mkdirSync(configDir, { recursive: true });
+  atomicWriteFileSync(
+    pendingSessionsPath(configDir),
+    JSON.stringify(pending, null, 2)
+  );
+}
+
+function pruneScrollbackFiles(
+  scrollbackDirPath: string,
+  keepSessionIds: Set<string>
+): number {
+  let pruned = 0;
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(scrollbackDirPath);
+  } catch {
+    return 0;
+  }
+
+  for (const entry of entries) {
+    if (!entry.endsWith('.buf')) continue;
+    const sessionId = entry.slice(0, -'.buf'.length);
+    if (keepSessionIds.has(sessionId)) continue;
+    try {
+      fs.rmSync(path.join(scrollbackDirPath, entry), { force: true });
+      pruned++;
+    } catch (err) {
+      logger.warn('failed to prune stale scrollback file %s: %s', entry, err);
+    }
+  }
+  return pruned;
+}
+
+function removeScrollbackDir(configDir: string, reason: string): void {
+  const dir = scrollbackDir(configDir);
+  if (!fs.existsSync(dir)) return;
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+    logger.info('removed scrollback dir after %s: %s', reason, dir);
+  } catch (err) {
+    logger.warn('failed to remove scrollback dir after %s: %s', reason, err);
+  }
+}
+
 function serializePtySession(
   session: PtySession,
   scrollbackDirPath: string
 ): SerializedPtySession {
   const scrollbackPath = path.join(scrollbackDirPath, session.id + '.buf');
-  fs.writeFileSync(scrollbackPath, session.scrollback.join(''), 'utf-8');
+  atomicWriteFileSync(scrollbackPath, session.scrollback.join(''));
 
   return {
     id: session.id,
@@ -617,16 +702,18 @@ function serializePtySession(
   };
 }
 
-function serializeAll(configDir: string): void {
-  const scrollbackDirPath = path.join(configDir, 'scrollback');
+function serializeAll(configDir: string, options: SerializeOptions = {}): void {
+  const scrollbackDirPath = scrollbackDir(configDir);
   fs.mkdirSync(scrollbackDirPath, { recursive: true });
 
   const serializedPty: SerializedPtySession[] = [];
+  let webSessionCount = 0;
 
   for (const session of sessions.values()) {
     if (session.mode === 'pty') {
       serializedPty.push(serializePtySession(session, scrollbackDirPath));
     } else {
+      webSessionCount++;
       // Web sessions persisted to relay-state.db on patch (debounced) +
       // structural events. Final shutdown snapshot for any not-yet-flushed
       // mutations is handled by upsertWebSessionNow before serializeAll.
@@ -634,16 +721,27 @@ function serializeAll(configDir: string): void {
     }
   }
 
+  const reason = options.reason ?? 'unspecified';
   const pending: PendingSessionsFile = {
     version: 6,
     timestamp: new Date().toISOString(),
+    reason,
     sessions: serializedPty,
   };
 
-  fs.writeFileSync(
-    path.join(configDir, 'pending-sessions.json'),
-    JSON.stringify(pending, null, 2),
-    'utf-8'
+  writePendingSessionsFile(configDir, pending);
+  const pruned = pruneScrollbackFiles(
+    scrollbackDirPath,
+    new Set(serializedPty.map((s) => s.id))
+  );
+
+  logger.info(
+    'serialized sessions for restart: reason=%s pty=%d web=%d prunedScrollback=%d configDir=%s',
+    reason,
+    serializedPty.length,
+    webSessionCount,
+    pruned,
+    configDir
   );
 }
 
@@ -663,8 +761,13 @@ function readPendingSessionsFile(
     return JSON.parse(
       fs.readFileSync(pendingPath, 'utf-8')
     ) as PendingSessionsFile;
-  } catch {
-    fs.unlinkSync(pendingPath);
+  } catch (err) {
+    logger.warn(
+      'failed to read pending sessions manifest %s: %s',
+      pendingPath,
+      err
+    );
+    removePendingSessionsFile(pendingPath);
     return null;
   }
 }
@@ -1055,74 +1158,162 @@ function syncDisplayNameCounters(): void {
   }
 }
 
-async function restoreFromDisk(
+function assertRestorableCwd(s: SerializedPtySession): void {
+  if (!s.cwd || !fs.existsSync(s.cwd)) {
+    throw new Error(`restore cwd is unavailable: ${s.cwd || '<empty>'}`);
+  }
+}
+
+function removePendingSessionsFile(pendingPath: string): void {
+  try {
+    fs.unlinkSync(pendingPath);
+  } catch {
+    /* ignore */
+  }
+}
+
+function pendingSessionsAgeMs(pending: PendingSessionsFile): number | null {
+  const timestampMs = Date.parse(pending.timestamp);
+  if (!Number.isFinite(timestampMs)) return null;
+  return Date.now() - timestampMs;
+}
+
+function isPendingSessionsFileStale(pending: PendingSessionsFile): boolean {
+  const ageMs = pendingSessionsAgeMs(pending);
+  return ageMs === null || ageMs > STALE_THRESHOLD_MS;
+}
+
+function migratePendingSessionsFile(
+  pending: PendingSessionsFile,
+  workspaces?: string[]
+): void {
+  if (pending.version <= 2) migrateV2ToV3(pending.sessions, workspaces ?? []);
+  if (pending.version <= 3) migrateV3ToV4(pending.sessions);
+}
+
+async function tryRestorePtySession(
+  s: SerializedPtySession,
+  pendingVersion: number,
+  scrollbackDirPath: string,
+  frameworks?: Record<string, Partial<AgentFramework>>
+): Promise<boolean> {
+  const initialScrollback = loadScrollback(scrollbackDirPath, s.id);
+  try {
+    if (pendingVersion >= 6) assertRestorableCwd(s);
+    const spawn = await resolveSessionSpawnParams(s, frameworks);
+    restoreSession(s, spawn, initialScrollback);
+    return true;
+  } catch (err) {
+    logger.error(`Failed to restore session ${s.id} (${s.displayName})`, err);
+    return false;
+  }
+}
+
+function preserveFailedPendingSessions(
+  configDir: string,
+  pending: PendingSessionsFile,
+  failedSessions: SerializedPtySession[]
+): void {
+  // Keep the original timestamp so repeatedly-failed restore records still age
+  // out under STALE_THRESHOLD_MS instead of being made fresh on every dev
+  // restart. Rapid restart loops retry within the window; genuinely stale
+  // failures are cleaned with their scrollback on a later startup.
+  writePendingSessionsFile(configDir, {
+    ...pending,
+    sessions: failedSessions,
+  });
+  pruneScrollbackFiles(
+    scrollbackDir(configDir),
+    new Set(failedSessions.map((s) => s.id))
+  );
+}
+
+async function restoreFreshPendingSessions(
+  configDir: string,
+  pending: PendingSessionsFile,
+  workspaces?: string[],
+  frameworks?: Record<string, Partial<AgentFramework>>
+): Promise<number> {
+  migratePendingSessionsFile(pending, workspaces);
+  const failedSessions: SerializedPtySession[] = [];
+  const scrollbackDirPath = scrollbackDir(configDir);
+  let restored = 0;
+
+  for (const s of pending.sessions) {
+    const ok = await tryRestorePtySession(
+      s,
+      pending.version,
+      scrollbackDirPath,
+      frameworks
+    );
+    if (ok) restored++;
+    else failedSessions.push(s);
+  }
+
+  if (failedSessions.length > 0) {
+    preserveFailedPendingSessions(configDir, pending, failedSessions);
+  } else {
+    removePendingSessionsFile(pendingSessionsPath(configDir));
+    removeScrollbackDir(configDir, 'successful pending restore');
+  }
+
+  return restored;
+}
+
+async function restorePendingSessionsFromDisk(
   configDir: string,
   workspaces?: string[],
   frameworks?: Record<string, Partial<AgentFramework>>
 ): Promise<number> {
-  let restored = 0;
-
-  const pendingPath = path.join(configDir, 'pending-sessions.json');
-  if (fs.existsSync(pendingPath)) {
-    const pending = readPendingSessionsFile(pendingPath);
-    if (
-      pending &&
-      Date.now() - new Date(pending.timestamp).getTime() <= STALE_THRESHOLD_MS
-    ) {
-      if (pending.version <= 2) {
-        migrateV2ToV3(pending.sessions, workspaces ?? []);
-      }
-      if (pending.version <= 3) {
-        migrateV3ToV4(pending.sessions);
-      }
-
-      const scrollbackDirPath = path.join(configDir, 'scrollback');
-      for (const s of pending.sessions) {
-        const scrollbackPath = path.join(scrollbackDirPath, s.id + '.buf');
-        const initialScrollback = loadScrollback(scrollbackDirPath, s.id);
-
-        const spawn = await resolveSessionSpawnParams(s, frameworks);
-
-        try {
-          restoreSession(s, spawn, initialScrollback);
-          restored++;
-        } catch (err) {
-          logger.error(
-            `Failed to restore session ${s.id} (${s.displayName})`,
-            err
-          );
-        }
-
-        try {
-          fs.unlinkSync(scrollbackPath);
-        } catch {
-          /* ignore */
-        }
-      }
-    }
-
-    try {
-      fs.unlinkSync(pendingPath);
-    } catch {
-      /* ignore */
-    }
-    // Recursively wipe scrollback dir. When pending was stale (or unreadable)
-    // per-session scrollback files weren't cleaned up by the restore loop;
-    // remove them here so stale buffers don't accumulate across restarts.
-    try {
-      fs.rmSync(path.join(configDir, 'scrollback'), {
-        recursive: true,
-        force: true,
-      });
-    } catch {
-      /* ignore */
-    }
+  const pendingPath = pendingSessionsPath(configDir);
+  if (!fs.existsSync(pendingPath)) {
+    removeScrollbackDir(configDir, 'missing pending manifest');
+    return 0;
   }
 
+  const pending = readPendingSessionsFile(pendingPath);
+  if (!pending) {
+    removeScrollbackDir(configDir, 'unreadable pending manifest');
+    return 0;
+  }
+
+  const ageMs = pendingSessionsAgeMs(pending);
+  logger.info(
+    'found pending sessions manifest: reason=%s version=%d pty=%d ageMs=%s configDir=%s',
+    pending.reason ?? 'unspecified',
+    pending.version,
+    pending.sessions.length,
+    ageMs === null ? 'invalid' : String(ageMs),
+    configDir
+  );
+
+  if (isPendingSessionsFileStale(pending)) {
+    logger.warn(
+      'discarding stale pending sessions manifest: reason=%s version=%d pty=%d ageMs=%s configDir=%s',
+      pending.reason ?? 'unspecified',
+      pending.version,
+      pending.sessions.length,
+      ageMs === null ? 'invalid' : String(ageMs),
+      configDir
+    );
+    removePendingSessionsFile(pendingPath);
+    removeScrollbackDir(configDir, 'stale pending manifest');
+    return 0;
+  }
+
+  return restoreFreshPendingSessions(
+    configDir,
+    pending,
+    workspaces,
+    frameworks
+  );
+}
+
+async function restoreWebSessionsFromDb(): Promise<number> {
+  let restored = 0;
   // Web sessions live in relay-state.db. No staleness wipe — DB rows persist
   // until user archives or closes the session.
-  const dbRows = loadAllWebSessions();
-  for (const row of dbRows) {
+  for (const row of loadAllWebSessions()) {
     try {
       await restoreWebSessionFromDb(row);
       restored++;
@@ -1133,10 +1324,22 @@ async function restoreFromDisk(
       );
     }
   }
-
-  syncDisplayNameCounters();
-
   return restored;
+}
+
+async function restoreFromDisk(
+  configDir: string,
+  workspaces?: string[],
+  frameworks?: Record<string, Partial<AgentFramework>>
+): Promise<number> {
+  const restoredPty = await restorePendingSessionsFromDisk(
+    configDir,
+    workspaces,
+    frameworks
+  );
+  const restoredWeb = await restoreWebSessionsFromDb();
+  syncDisplayNameCounters();
+  return restoredPty + restoredWeb;
 }
 
 /** Returns the set of tmux session names currently owned by restored sessions */

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -635,7 +635,20 @@ function pruneScrollbackFiles(
   let entries: string[];
   try {
     entries = fs.readdirSync(scrollbackDirPath);
-  } catch {
+  } catch (err) {
+    if (
+      err &&
+      typeof err === 'object' &&
+      'code' in err &&
+      err.code === 'ENOENT'
+    ) {
+      return 0;
+    }
+    logger.warn(
+      'failed to read scrollback dir for pruning %s: %s',
+      scrollbackDirPath,
+      err
+    );
     return 0;
   }
 
@@ -660,8 +673,34 @@ function removeScrollbackDir(configDir: string, reason: string): void {
     fs.rmSync(dir, { recursive: true, force: true });
     logger.info('removed scrollback dir after %s: %s', reason, dir);
   } catch (err) {
-    logger.warn('failed to remove scrollback dir after %s: %s', reason, err);
+    logger.warn(
+      'failed to remove scrollback dir after %s %s: %s',
+      reason,
+      dir,
+      err
+    );
   }
+}
+
+function preservedPendingRestoreFailures(
+  configDir: string,
+  serializedSessionIds: Set<string>
+): PendingSessionsFile | null {
+  const pendingPath = pendingSessionsPath(configDir);
+  if (!fs.existsSync(pendingPath)) return null;
+
+  const existing = readPendingSessionsFile(pendingPath);
+  if (!existing || isPendingSessionsFileStale(existing)) return null;
+
+  const sessionsToPreserve = existing.sessions.filter(
+    (session) => !serializedSessionIds.has(session.id)
+  );
+  if (sessionsToPreserve.length === 0) return null;
+
+  return {
+    ...existing,
+    sessions: sessionsToPreserve,
+  };
 }
 
 function serializePtySession(
@@ -721,24 +760,34 @@ function serializeAll(configDir: string, options: SerializeOptions = {}): void {
     }
   }
 
+  const serializedSessionIds = new Set(serializedPty.map((s) => s.id));
+  const preservedFailures = preservedPendingRestoreFailures(
+    configDir,
+    serializedSessionIds
+  );
+  const sessionsToWrite = preservedFailures
+    ? [...serializedPty, ...preservedFailures.sessions]
+    : serializedPty;
+
   const reason = options.reason ?? 'unspecified';
   const pending: PendingSessionsFile = {
-    version: 6,
-    timestamp: new Date().toISOString(),
+    version: Math.max(6, preservedFailures?.version ?? 6),
+    timestamp: preservedFailures?.timestamp ?? new Date().toISOString(),
     reason,
-    sessions: serializedPty,
+    sessions: sessionsToWrite,
   };
 
   writePendingSessionsFile(configDir, pending);
   const pruned = pruneScrollbackFiles(
     scrollbackDirPath,
-    new Set(serializedPty.map((s) => s.id))
+    new Set(sessionsToWrite.map((s) => s.id))
   );
 
   logger.info(
-    'serialized sessions for restart: reason=%s pty=%d web=%d prunedScrollback=%d configDir=%s',
+    'serialized sessions for restart: reason=%s pty=%d preservedFailedPty=%d web=%d prunedScrollback=%d configDir=%s',
     reason,
     serializedPty.length,
+    preservedFailures?.sessions.length ?? 0,
     webSessionCount,
     pruned,
     configDir

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -77,6 +77,7 @@ interface SerializedPtySession {
   continuePolicy?: ContinuePolicy;
   workspaceId?: string;
   additionalDirs?: string[];
+  pendingSince?: string;
 }
 
 type RestartReason =
@@ -690,11 +691,12 @@ function preservedPendingRestoreFailures(
   if (!fs.existsSync(pendingPath)) return null;
 
   const existing = readPendingSessionsFile(pendingPath);
-  if (!existing || isPendingSessionsFileStale(existing)) return null;
+  if (!existing) return null;
 
-  const sessionsToPreserve = existing.sessions.filter(
-    (session) => !serializedSessionIds.has(session.id)
-  );
+  const sessionsToPreserve = existing.sessions
+    .filter((session) => !serializedSessionIds.has(session.id))
+    .filter((session) => !isPendingSessionStale(existing, session))
+    .map((session) => withPendingSince(existing, session));
   if (sessionsToPreserve.length === 0) return null;
 
   return {
@@ -760,19 +762,24 @@ function serializeAll(configDir: string, options: SerializeOptions = {}): void {
     }
   }
 
+  const serializedAt = new Date().toISOString();
   const serializedSessionIds = new Set(serializedPty.map((s) => s.id));
   const preservedFailures = preservedPendingRestoreFailures(
     configDir,
     serializedSessionIds
   );
+  const freshSerializedPty = serializedPty.map((session) => ({
+    ...session,
+    pendingSince: serializedAt,
+  }));
   const sessionsToWrite = preservedFailures
-    ? [...serializedPty, ...preservedFailures.sessions]
-    : serializedPty;
+    ? [...freshSerializedPty, ...preservedFailures.sessions]
+    : freshSerializedPty;
 
   const reason = options.reason ?? 'unspecified';
   const pending: PendingSessionsFile = {
     version: Math.max(6, preservedFailures?.version ?? 6),
-    timestamp: preservedFailures?.timestamp ?? new Date().toISOString(),
+    timestamp: serializedAt,
     reason,
     sessions: sessionsToWrite,
   };
@@ -1232,6 +1239,33 @@ function isPendingSessionsFileStale(pending: PendingSessionsFile): boolean {
   return ageMs === null || ageMs > STALE_THRESHOLD_MS;
 }
 
+function pendingSessionAgeMs(
+  pending: PendingSessionsFile,
+  session: SerializedPtySession
+): number | null {
+  const timestampMs = Date.parse(session.pendingSince ?? pending.timestamp);
+  if (!Number.isFinite(timestampMs)) return null;
+  return Date.now() - timestampMs;
+}
+
+function isPendingSessionStale(
+  pending: PendingSessionsFile,
+  session: SerializedPtySession
+): boolean {
+  const ageMs = pendingSessionAgeMs(pending, session);
+  return ageMs === null || ageMs > STALE_THRESHOLD_MS;
+}
+
+function withPendingSince(
+  pending: PendingSessionsFile,
+  session: SerializedPtySession
+): SerializedPtySession {
+  return {
+    ...session,
+    pendingSince: session.pendingSince ?? pending.timestamp,
+  };
+}
+
 function migratePendingSessionsFile(
   pending: PendingSessionsFile,
   workspaces?: string[]
@@ -1267,13 +1301,16 @@ function preserveFailedPendingSessions(
   // out under STALE_THRESHOLD_MS instead of being made fresh on every dev
   // restart. Rapid restart loops retry within the window; genuinely stale
   // failures are cleaned with their scrollback on a later startup.
+  const retrySessions = failedSessions.map((session) =>
+    withPendingSince(pending, session)
+  );
   writePendingSessionsFile(configDir, {
     ...pending,
-    sessions: failedSessions,
+    sessions: retrySessions,
   });
   pruneScrollbackFiles(
     scrollbackDir(configDir),
-    new Set(failedSessions.map((s) => s.id))
+    new Set(retrySessions.map((s) => s.id))
   );
 }
 
@@ -1336,7 +1373,11 @@ async function restorePendingSessionsFromDisk(
     configDir
   );
 
-  if (isPendingSessionsFileStale(pending)) {
+  const freshSessions = pending.sessions
+    .filter((session) => !isPendingSessionStale(pending, session))
+    .map((session) => withPendingSince(pending, session));
+  const staleSessionCount = pending.sessions.length - freshSessions.length;
+  if (freshSessions.length === 0) {
     logger.warn(
       'discarding stale pending sessions manifest: reason=%s version=%d pty=%d ageMs=%s configDir=%s',
       pending.reason ?? 'unspecified',
@@ -1349,10 +1390,21 @@ async function restorePendingSessionsFromDisk(
     removeScrollbackDir(configDir, 'stale pending manifest');
     return 0;
   }
+  if (staleSessionCount > 0) {
+    logger.warn(
+      'dropping stale pending session records: reason=%s version=%d stalePty=%d freshPty=%d ageMs=%s configDir=%s',
+      pending.reason ?? 'unspecified',
+      pending.version,
+      staleSessionCount,
+      freshSessions.length,
+      ageMs === null ? 'invalid' : String(ageMs),
+      configDir
+    );
+  }
 
   return restoreFreshPendingSessions(
     configDir,
-    pending,
+    { ...pending, sessions: freshSessions },
     workspaces,
     frameworks
   );

--- a/test/pty-handler-multi-agent.test.ts
+++ b/test/pty-handler-multi-agent.test.ts
@@ -20,6 +20,16 @@ const execFileAsync = promisify(execFile);
 const originalTmuxTmpdir = process.env.TMUX_TMPDIR;
 let tmuxTmpdir: string;
 
+// Keep tmux cleanup pinned to this file's socket dir. Full-suite runs may have
+// other tmux-backed test files mutating process.env.TMUX_TMPDIR concurrently.
+function tmuxCommandEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, TMUX_TMPDIR: tmuxTmpdir };
+}
+
+function execTmux(args: string[]) {
+  return execFileAsync('tmux', args, { env: tmuxCommandEnv() });
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -51,7 +61,7 @@ describe('PTY multi-agent hook/plugin wiring', () => {
   });
 
   afterAll(async () => {
-    await execFileAsync('tmux', ['kill-server']).catch(() => {});
+    await execTmux(['kill-server']).catch(() => {});
     if (originalTmuxTmpdir === undefined) {
       delete process.env.TMUX_TMPDIR;
     } else {

--- a/test/sessions-web-restore.test.ts
+++ b/test/sessions-web-restore.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { emptyAgentSessionV2 } from '../shared/agent-chat-protocol-v2.js';
+import type {
+  AgentCapabilitySetV2,
+  AgentPatchV2,
+} from '../shared/agent-chat-protocol-v2.js';
+import type { LoadedWebSessionRow } from '../server/relay-state-db.js';
+import type {
+  AgentApprovalResponseInputV2,
+  AgentInputResponseInputV2,
+  AgentInterruptInputV2,
+  AgentPatchHandlerV2,
+  AgentSendMessageInputV2,
+  AdapterConfig,
+  AdapterStatus,
+  ProtocolAdapterV2,
+} from '../server/protocol-adapter-v2.js';
+
+const capabilities: AgentCapabilitySetV2 = {
+  text: true,
+  reasoning: true,
+  tools: true,
+  commandExecution: true,
+  fileChanges: true,
+  approvals: true,
+  questions: true,
+  plans: false,
+  slashCommands: false,
+  queue: false,
+  interrupt: true,
+  cancelQueued: false,
+  resume: true,
+  fork: false,
+  rollback: false,
+  compact: false,
+  telemetry: false,
+  rateLimits: false,
+  streaming: true,
+};
+
+const loadAllWebSessions = vi.fn<() => LoadedWebSessionRow[]>();
+const upsertWebSessionNow = vi.fn();
+const deleteWebSession = vi.fn();
+const scheduleWebSessionUpsert = vi.fn();
+const resumeSession = vi.fn();
+const reconnect = vi.fn();
+
+class RestoreFailureAdapter implements ProtocolAdapterV2 {
+  readonly agentType = 'claude';
+  readonly runtimeOwnership = 'attached' as const;
+  readonly capabilities = capabilities;
+  readonly status: AdapterStatus = 'connected';
+  private handlers = new Set<AgentPatchHandlerV2>();
+
+  async connect(_config: AdapterConfig): Promise<void> {}
+  async disconnect(): Promise<void> {
+    this.handlers.clear();
+  }
+  async reconnect(): Promise<void> {
+    await reconnect();
+  }
+  async resumeSession(sessionId: string): Promise<void> {
+    await resumeSession(sessionId);
+  }
+  async sendMessage(_input: AgentSendMessageInputV2): Promise<void> {}
+  async interrupt(_input: AgentInterruptInputV2): Promise<void> {}
+  async respondToApproval(
+    _input: AgentApprovalResponseInputV2
+  ): Promise<void> {}
+  async respondToInput(_input: AgentInputResponseInputV2): Promise<void> {}
+  onPatch(handler: AgentPatchHandlerV2): () => void {
+    this.handlers.add(handler);
+    return () => this.handlers.delete(handler);
+  }
+  emit(patch: AgentPatchV2): void {
+    for (const handler of this.handlers) handler(patch);
+  }
+}
+
+vi.mock('../server/relay-state-db.js', () => ({
+  loadAllWebSessions,
+  upsertWebSessionNow,
+  deleteWebSession,
+  scheduleWebSessionUpsert,
+}));
+
+vi.mock('../server/protocol-adapters/index.js', () => ({
+  createAdapterV2: () => new RestoreFailureAdapter(),
+}));
+
+describe('web session restore failure recovery', () => {
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-ide-web-restore-')
+    );
+    loadAllWebSessions.mockReset();
+    upsertWebSessionNow.mockReset();
+    deleteWebSession.mockReset();
+    scheduleWebSessionUpsert.mockReset();
+    reconnect.mockReset();
+    resumeSession.mockReset();
+  });
+
+  afterEach(async () => {
+    const sessions = await import('../server/sessions.js');
+    for (const session of sessions.list()) {
+      try {
+        sessions.kill(session.id);
+      } catch {
+        /* ignore */
+      }
+    }
+    fs.rmSync(configDir, { recursive: true, force: true });
+  });
+
+  it('restores persisted web metadata and surfaces resume failure as recoverable session state', async () => {
+    resumeSession.mockRejectedValueOnce(new Error('provider session expired'));
+    loadAllWebSessions.mockReturnValueOnce([
+      {
+        id: 'web-restore-failure',
+        vendor: 'claude',
+        vendorSessionId: 'stored-provider-session',
+        cwd: configDir,
+        repoPath: configDir,
+        worktreePath: null,
+        branchName: 'feature/restart',
+        displayName: 'web restart session',
+        workspaceId: 'workspace-1',
+        agentSessionV2: emptyAgentSessionV2({
+          id: 'web-restore-failure',
+          provider: 'claude',
+          cwd: configDir,
+          capabilities,
+          providerSession: { claudeSessionId: 'stored-provider-session' },
+          config: {
+            model: 'sonnet',
+            permissionMode: 'acceptEdits',
+          },
+        }),
+        meta: {
+          type: 'agent',
+          agent: 'claude',
+          repoName: 'relay-ide',
+          customCommand: null,
+          runtimeOwnership: 'attached',
+          hookToken: 'restored-hook-token',
+          adapterType: 'claude',
+          needsBranchRename: true,
+          additionalDirs: [path.join(configDir, 'extra')],
+        },
+        createdAt: Date.now() - 10_000,
+        lastActivity: Date.now() - 5_000,
+        status: 'active',
+      },
+    ]);
+
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({ port: 4567, configDir });
+
+    const restored = await sessions.restoreFromDisk(configDir);
+
+    expect(restored).toBe(1);
+    expect(resumeSession).toHaveBeenCalledWith('stored-provider-session');
+    expect(reconnect).not.toHaveBeenCalled();
+
+    const session = sessions.get('web-restore-failure');
+    expect(session).toBeTruthy();
+    expect(session!.mode).toBe('web');
+    if (session?.mode !== 'web') throw new Error('expected web session');
+    expect(session.hookToken).toBe('restored-hook-token');
+    expect(session.needsBranchRename).toBe(true);
+    expect(session.workspaceId).toBe('workspace-1');
+    expect(session.additionalDirs).toEqual([path.join(configDir, 'extra')]);
+    expect(session.status).toBe('disconnected');
+    expect(session.agentState).toBe('error');
+    expect(session.agentSessionV2.live.status).toBe('disconnected');
+    expect(session.agentSessionV2.live.error).toBe('resume failed');
+    expect(
+      session.agentSessionV2.turns.some((turn) =>
+        turn.items.some(
+          (item) =>
+            item.type === 'errorMessage' &&
+            item.context === 'resume' &&
+            item.message.includes('provider session expired')
+        )
+      )
+    ).toBe(true);
+    expect(upsertWebSessionNow).toHaveBeenLastCalledWith(session);
+  });
+});

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -826,13 +826,14 @@ describe('session persistence', () => {
     expect(session!.mode).toBe('pty');
     (session as PtySession).scrollback.push('hello world');
 
-    serializeAll(configDir);
+    serializeAll(configDir, { reason: 'dev-restart' });
 
     // Check pending-sessions.json
     const pendingPath = path.join(configDir, 'pending-sessions.json');
     expect(fs.existsSync(pendingPath)).toBeTruthy();
     const pending = JSON.parse(fs.readFileSync(pendingPath, 'utf-8'));
     expect(pending.version).toBe(6);
+    expect(pending.reason).toBe('dev-restart');
     expect(pending.timestamp).toBeTruthy();
     expect(pending.sessions.length).toBe(1);
     expect(pending.sessions[0].id).toBe(s.id);
@@ -844,6 +845,32 @@ describe('session persistence', () => {
     expect(fs.existsSync(scrollbackPath)).toBeTruthy();
     const scrollbackData = fs.readFileSync(scrollbackPath, 'utf-8');
     expect(scrollbackData).toContain('hello world');
+  });
+
+  it('serializeAll prunes scrollback files that are not in the new manifest', () => {
+    const configDir = createTmpDir();
+    const scrollbackDir = path.join(configDir, 'scrollback');
+    fs.mkdirSync(scrollbackDir, { recursive: true });
+    const orphanPath = path.join(scrollbackDir, 'orphan.buf');
+    fs.writeFileSync(orphanPath, 'stale output');
+
+    const s = sessions.create({
+      repoName: 'test-repo',
+      repoPath: '/tmp',
+      worktreePath: null,
+      cwd: '/tmp',
+      command: '/bin/cat',
+      args: [],
+    });
+    const session = sessions.get(s.id);
+    expect(session).toBeTruthy();
+    expect(session!.mode).toBe('pty');
+    (session as PtySession).scrollback.push('current output');
+
+    serializeAll(configDir, { reason: 'dev-restart' });
+
+    expect(fs.existsSync(path.join(scrollbackDir, `${s.id}.buf`))).toBe(true);
+    expect(fs.existsSync(orphanPath)).toBe(false);
   });
 
   it('restoreFromDisk restores sessions with original IDs', async () => {
@@ -927,12 +954,129 @@ describe('session persistence', () => {
       path.join(configDir, 'pending-sessions.json'),
       JSON.stringify(pending)
     );
+    fs.mkdirSync(path.join(configDir, 'scrollback'), { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, 'scrollback', 'stale-id.buf'),
+      'stale'
+    );
 
     const restored = await restoreFromDisk(configDir);
     expect(restored).toBe(0);
     expect(fs.existsSync(path.join(configDir, 'pending-sessions.json'))).toBe(
       false
     );
+    expect(fs.existsSync(path.join(configDir, 'scrollback'))).toBe(false);
+  });
+
+  it('restoreFromDisk removes malformed timestamp pending files and scrollback', async () => {
+    const configDir = createTmpDir();
+    const pending = {
+      version: 6,
+      timestamp: 'not-a-date',
+      reason: 'dev-restart',
+      sessions: [
+        {
+          id: 'bad-timestamp-id',
+          type: 'agent' as const,
+          agent: 'claude' as const,
+          repoPath: '/tmp',
+          worktreePath: null,
+          cwd: '/tmp',
+          repoName: 'test',
+          branchName: '',
+          displayName: 'bad timestamp',
+          createdAt: new Date().toISOString(),
+          lastActivity: new Date().toISOString(),
+          useTmux: true,
+          tmuxSessionName: 'relay-ide-bad-timestamp',
+          customCommand: '/bin/cat',
+        },
+      ],
+    };
+    fs.writeFileSync(
+      path.join(configDir, 'pending-sessions.json'),
+      JSON.stringify(pending)
+    );
+    const scrollbackDir = path.join(configDir, 'scrollback');
+    fs.mkdirSync(scrollbackDir, { recursive: true });
+    fs.writeFileSync(path.join(scrollbackDir, 'bad-timestamp-id.buf'), 'stale');
+
+    const restored = await restoreFromDisk(configDir);
+
+    expect(restored).toBe(0);
+    expect(fs.existsSync(path.join(configDir, 'pending-sessions.json'))).toBe(
+      false
+    );
+    expect(fs.existsSync(scrollbackDir)).toBe(false);
+  });
+
+  it('restoreFromDisk removes orphan scrollback when no pending manifest exists', async () => {
+    const configDir = createTmpDir();
+    const scrollbackDir = path.join(configDir, 'scrollback');
+    fs.mkdirSync(scrollbackDir, { recursive: true });
+    fs.writeFileSync(path.join(scrollbackDir, 'orphan.buf'), 'old output');
+
+    const restored = await restoreFromDisk(configDir);
+
+    expect(restored).toBe(0);
+    expect(fs.existsSync(scrollbackDir)).toBe(false);
+  });
+
+  it('restoreFromDisk keeps failed restore records and scrollback for a retry', async () => {
+    const configDir = createTmpDir();
+    const timestamp = new Date().toISOString();
+    const pending = {
+      version: 6,
+      reason: 'dev-restart',
+      timestamp,
+      sessions: [
+        {
+          id: 'restore-failure-kept',
+          type: 'agent' as const,
+          agent: 'claude' as const,
+          repoPath: '/tmp',
+          worktreePath: null,
+          cwd: path.join(configDir, 'missing-cwd'),
+          repoName: 'test',
+          branchName: '',
+          displayName: 'retry-me',
+          createdAt: timestamp,
+          lastActivity: timestamp,
+          useTmux: true,
+          tmuxSessionName: 'relay-ide-retry-me-failure',
+          customCommand: '/bin/cat',
+          hookToken: 'keep-token',
+          hooksActive: true,
+        },
+      ],
+    };
+    fs.writeFileSync(
+      path.join(configDir, 'pending-sessions.json'),
+      JSON.stringify(pending)
+    );
+    const scrollbackDir = path.join(configDir, 'scrollback');
+    fs.mkdirSync(scrollbackDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(scrollbackDir, 'restore-failure-kept.buf'),
+      'important output'
+    );
+
+    const restored = await restoreFromDisk(configDir);
+
+    expect(restored).toBe(0);
+    const retryPending = JSON.parse(
+      fs.readFileSync(path.join(configDir, 'pending-sessions.json'), 'utf-8')
+    );
+    expect(retryPending.sessions).toHaveLength(1);
+    expect(retryPending.timestamp).toBe(timestamp);
+    expect(retryPending.sessions[0].id).toBe('restore-failure-kept');
+    expect(retryPending.sessions[0].hookToken).toBe('keep-token');
+    expect(
+      fs.readFileSync(
+        path.join(scrollbackDir, 'restore-failure-kept.buf'),
+        'utf-8'
+      )
+    ).toBe('important output');
   });
 
   it('restoreFromDisk handles missing scrollback gracefully', async () => {

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, afterAll, afterEach, beforeAll, expect } from 'vitest';
+import { describe, it, afterAll, afterEach, beforeAll, expect, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -1163,17 +1163,103 @@ describe('session persistence', () => {
     const retryPending = JSON.parse(
       fs.readFileSync(path.join(configDir, 'pending-sessions.json'), 'utf-8')
     );
-    expect(retryPending.timestamp).toBe(timestamp);
-    expect(retryPending.sessions.map((s: { id: string }) => s.id).sort()).toEqual(
-      ['restore-fails', 'restore-ok']
-    );
-    expect(
-      retryPending.sessions.find((s: { id: string }) => s.id === 'restore-fails')
-        .hookToken
-    ).toBe('failed-token');
+    const retrySessions = retryPending.sessions as Array<{
+      id: string;
+      hookToken?: string;
+      pendingSince?: string;
+    }>;
+    expect(retryPending.timestamp).toBeTruthy();
+    expect(retrySessions.map((s) => s.id).sort()).toEqual([
+      'restore-fails',
+      'restore-ok',
+    ]);
+    const failedRetry = retrySessions.find((s) => s.id === 'restore-fails');
+    const liveRetry = retrySessions.find((s) => s.id === 'restore-ok');
+    expect(failedRetry?.pendingSince).toBe(timestamp);
+    expect(liveRetry?.pendingSince).toBe(retryPending.timestamp);
+    expect(failedRetry?.hookToken).toBe('failed-token');
     expect(fs.readFileSync(path.join(scrollbackDir, 'restore-fails.buf'), 'utf-8')).toBe(
       'b output'
     );
+  });
+
+  it('serializeAll keeps fresh live sessions restorable when old preserved failures age out', async () => {
+    const configDir = createTmpDir();
+    const nowMs = Date.now();
+    const nearlyStaleTime = new Date(
+      nowMs - (5 * 60 * 1000 - 1000)
+    ).toISOString();
+    const pending = {
+      version: 6,
+      reason: 'dev-restart',
+      timestamp: nearlyStaleTime,
+      sessions: [
+        pendingPtySession('old-restore-fails', {
+          cwd: path.join(configDir, 'missing-cwd'),
+          displayName: 'old failed restore',
+          tmuxSessionName: 'relay-ide-old-failed-restore',
+          pendingSince: nearlyStaleTime,
+        }),
+      ],
+    };
+    fs.writeFileSync(
+      path.join(configDir, 'pending-sessions.json'),
+      JSON.stringify(pending)
+    );
+    const scrollbackDir = path.join(configDir, 'scrollback');
+    fs.mkdirSync(scrollbackDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(scrollbackDir, 'old-restore-fails.buf'),
+      'old failed output'
+    );
+
+    const live = sessions.create({
+      repoName: 'test-repo',
+      repoPath: '/tmp',
+      worktreePath: null,
+      cwd: '/tmp',
+      command: '/bin/cat',
+      args: [],
+      displayName: 'fresh live session',
+    });
+    const liveSession = sessions.get(live.id);
+    expect(liveSession).toBeTruthy();
+    expect(liveSession!.mode).toBe('pty');
+    (liveSession as PtySession).scrollback.push('fresh output');
+
+    serializeAll(configDir, { reason: 'dev-restart' });
+
+    const serialized = JSON.parse(
+      fs.readFileSync(path.join(configDir, 'pending-sessions.json'), 'utf-8')
+    );
+    const serializedSessions = serialized.sessions as Array<{
+      id: string;
+      pendingSince?: string;
+    }>;
+    const serializedFailure = serializedSessions.find(
+      (session) => session.id === 'old-restore-fails'
+    );
+    const serializedLive = serializedSessions.find(
+      (session) => session.id === live.id
+    );
+    expect(serializedFailure?.pendingSince).toBe(nearlyStaleTime);
+    expect(serializedLive?.pendingSince).toBe(serialized.timestamp);
+
+    sessions.kill(live.id);
+    const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(nowMs + 2000);
+    try {
+      const restored = await restoreFromDisk(configDir);
+
+      expect(restored).toBe(1);
+      expect(sessions.get(live.id)).toBeTruthy();
+      expect(sessions.get('old-restore-fails')).toBeUndefined();
+      expect(fs.existsSync(path.join(configDir, 'pending-sessions.json'))).toBe(
+        false
+      );
+      expect(fs.existsSync(scrollbackDir)).toBe(false);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
   });
 
   it('serializeAll prunes stale failed restore records instead of refreshing them', () => {

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -21,13 +21,24 @@ const execFileAsync = promisify(execFile);
 const originalTmuxTmpdir = process.env.TMUX_TMPDIR;
 let tmuxTmpdir: string;
 
+// Tmux tests run in a full-suite worker pool while other files also mutate
+// process.env.TMUX_TMPDIR. Pin every tmux CLI assertion/cleanup to this file's
+// socket dir so another test file cannot accidentally kill or query our server.
+function tmuxCommandEnv(): NodeJS.ProcessEnv {
+  return { ...process.env, TMUX_TMPDIR: tmuxTmpdir };
+}
+
+function execTmux(args: string[]) {
+  return execFileAsync('tmux', args, { env: tmuxCommandEnv() });
+}
+
 beforeAll(() => {
   tmuxTmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ide-tmux-'));
   process.env.TMUX_TMPDIR = tmuxTmpdir;
 });
 
 afterAll(async () => {
-  await execFileAsync('tmux', ['kill-server']).catch(() => {});
+  await execTmux(['kill-server']).catch(() => {});
   if (originalTmuxTmpdir === undefined) {
     delete process.env.TMUX_TMPDIR;
   } else {
@@ -43,13 +54,13 @@ function delay(ms: number): Promise<void> {
 async function waitForTmuxSession(name: string): Promise<void> {
   for (let i = 0; i < 20; i++) {
     try {
-      await execFileAsync('tmux', ['has-session', '-t', name]);
+      await execTmux(['has-session', '-t', name]);
       return;
     } catch {
       await delay(50);
     }
   }
-  await execFileAsync('tmux', ['has-session', '-t', name]);
+  await execTmux(['has-session', '-t', name]);
 }
 
 async function waitForSessionRemoval(id: string): Promise<void> {
@@ -659,11 +670,11 @@ describe('sessions', () => {
       await waitForSessionRemoval(result.id);
 
       await expect(
-        execFileAsync('tmux', ['has-session', '-t', tmuxSessionName])
+        execTmux(['has-session', '-t', tmuxSessionName])
       ).resolves.toBeTruthy();
       expect(fs.existsSync(sentinelPath)).toBe(true);
     } finally {
-      await execFileAsync('tmux', [
+      await execTmux([
         'kill-session',
         '-t',
         tmuxSessionName,

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -808,6 +808,30 @@ describe('session persistence', () => {
     return tmpDir;
   }
 
+  function pendingPtySession(
+    id: string,
+    overrides: Record<string, unknown> = {}
+  ) {
+    const timestamp = new Date().toISOString();
+    return {
+      id,
+      type: 'agent' as const,
+      agent: 'claude' as const,
+      repoPath: '/tmp',
+      worktreePath: null,
+      cwd: '/tmp',
+      repoName: 'test',
+      branchName: '',
+      displayName: id,
+      createdAt: timestamp,
+      lastActivity: timestamp,
+      useTmux: true,
+      tmuxSessionName: `relay-ide-${id}`,
+      customCommand: '/bin/cat',
+      ...overrides,
+    };
+  }
+
   it('serializeAll writes pending-sessions.json and scrollback files', () => {
     const configDir = createTmpDir();
 
@@ -1077,6 +1101,107 @@ describe('session persistence', () => {
         'utf-8'
       )
     ).toBe('important output');
+  });
+
+  it('serializeAll preserves failed restore records across the next clean restart', async () => {
+    const configDir = createTmpDir();
+    const timestamp = new Date().toISOString();
+    const pending = {
+      version: 6,
+      reason: 'dev-restart',
+      timestamp,
+      sessions: [
+        pendingPtySession('restore-ok', {
+          displayName: 'restores cleanly',
+          tmuxSessionName: 'relay-ide-restores-cleanly',
+        }),
+        pendingPtySession('restore-fails', {
+          cwd: path.join(configDir, 'missing-cwd'),
+          displayName: 'fails transiently',
+          tmuxSessionName: 'relay-ide-fails-transiently',
+          hookToken: 'failed-token',
+        }),
+      ],
+    };
+    fs.writeFileSync(
+      path.join(configDir, 'pending-sessions.json'),
+      JSON.stringify(pending)
+    );
+    const scrollbackDir = path.join(configDir, 'scrollback');
+    fs.mkdirSync(scrollbackDir, { recursive: true });
+    fs.writeFileSync(path.join(scrollbackDir, 'restore-ok.buf'), 'a output');
+    fs.writeFileSync(
+      path.join(scrollbackDir, 'restore-fails.buf'),
+      'b output'
+    );
+
+    const restored = await restoreFromDisk(configDir);
+
+    expect(restored).toBe(1);
+    expect(sessions.get('restore-ok')).toBeTruthy();
+    const failedOnlyPending = JSON.parse(
+      fs.readFileSync(path.join(configDir, 'pending-sessions.json'), 'utf-8')
+    );
+    expect(failedOnlyPending.sessions.map((s: { id: string }) => s.id)).toEqual([
+      'restore-fails',
+    ]);
+    expect(failedOnlyPending.timestamp).toBe(timestamp);
+
+    serializeAll(configDir, { reason: 'dev-restart' });
+
+    const retryPending = JSON.parse(
+      fs.readFileSync(path.join(configDir, 'pending-sessions.json'), 'utf-8')
+    );
+    expect(retryPending.timestamp).toBe(timestamp);
+    expect(retryPending.sessions.map((s: { id: string }) => s.id).sort()).toEqual(
+      ['restore-fails', 'restore-ok']
+    );
+    expect(
+      retryPending.sessions.find((s: { id: string }) => s.id === 'restore-fails')
+        .hookToken
+    ).toBe('failed-token');
+    expect(fs.readFileSync(path.join(scrollbackDir, 'restore-fails.buf'), 'utf-8')).toBe(
+      'b output'
+    );
+  });
+
+  it('serializeAll prunes stale failed restore records instead of refreshing them', () => {
+    const configDir = createTmpDir();
+    const staleTime = new Date(Date.now() - 6 * 60 * 1000).toISOString();
+    const pending = {
+      version: 6,
+      reason: 'dev-restart',
+      timestamp: staleTime,
+      sessions: [pendingPtySession('stale-failure')],
+    };
+    fs.writeFileSync(
+      path.join(configDir, 'pending-sessions.json'),
+      JSON.stringify(pending)
+    );
+    const scrollbackDir = path.join(configDir, 'scrollback');
+    fs.mkdirSync(scrollbackDir, { recursive: true });
+    fs.writeFileSync(path.join(scrollbackDir, 'stale-failure.buf'), 'old output');
+
+    const s = sessions.create({
+      repoName: 'test-repo',
+      repoPath: '/tmp',
+      worktreePath: null,
+      cwd: '/tmp',
+      command: '/bin/cat',
+      args: [],
+    });
+
+    serializeAll(configDir, { reason: 'dev-restart' });
+
+    const retryPending = JSON.parse(
+      fs.readFileSync(path.join(configDir, 'pending-sessions.json'), 'utf-8')
+    );
+    expect(retryPending.sessions.map((session: { id: string }) => session.id)).toEqual([
+      s.id,
+    ]);
+    expect(fs.existsSync(path.join(scrollbackDir, 'stale-failure.buf'))).toBe(
+      false
+    );
   });
 
   it('restoreFromDisk handles missing scrollback gracefully', async () => {


### PR DESCRIPTION
## Summary
- harden pending-session restart serialization with atomic writes, explicit restart reason metadata, scrollback pruning, and clearer restore/stale-manifest logging
- preserve failed pending-session restore records briefly for retry while cleaning successful/stale/unreadable manifests and orphan scrollback
- add web-session restore coverage that preserves DB-backed metadata and surfaces provider resume failure as recoverable disconnected/error state

## Tests
- npm test -- test/sessions.test.ts test/sessions-web-restore.test.ts
- npm run check (passes; existing warnings only)
- npm run build

## Notes / caveats
- Signal shutdowns in `NO_PIN=1` dev mode are marked `dev-restart`; update restarts are marked `update`; other signal shutdowns are marked `signal-shutdown`.
- PTY pending manifests still use the existing 5-minute staleness window; failed restore records keep their original timestamp so repeated failed restores age out instead of living forever.

Closes #366
Refs #368


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved session restoration reliability when restarting the application
  * Enhanced error recovery for web session reconnection failures
  * Reduced risk of session data loss during unexpected shutdowns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->