### PR TITLE
feat: handle backend reconnect ui state

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -106,6 +106,22 @@ body {
   overflow: hidden;
 }
 
+.backend-connection-banner {
+  position: fixed;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 500;
+  border: 1px solid var(--status-warning);
+  background: var(--bg);
+  color: var(--status-warning);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1;
+  padding: 6px 10px;
+  pointer-events: none;
+}
+
 .sidebar-overlay {
   display: none;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -779,6 +779,23 @@ function TerminalAreaContent({
   );
 }
 
+function BackendConnectionBanner({
+  status,
+}: {
+  status: 'connected' | 'reconnecting' | 'restarting';
+}) {
+  if (status === 'connected') return null;
+  const label =
+    status === 'restarting'
+      ? 'backend restarting — reconnecting'
+      : 'backend unavailable — reconnecting';
+  return (
+    <div className="backend-connection-banner" role="status">
+      {label}
+    </div>
+  );
+}
+
 // ─── App Component ────────────────────────────────────────────────────────────
 
 export default function App() {
@@ -804,6 +821,9 @@ export default function App() {
   const sessions = useSessionsStore((s) => s.sessions);
   const repos = useSessionsStore((s) => s.repos);
   const activeSessionId = useSessionsStore((s) => s.activeSessionId);
+  const backendConnectionStatus = useSessionsStore(
+    (s) => s.backendConnectionStatus
+  );
   const setActiveSessionId = useSessionsStore((s) => s.setActiveSessionId);
   const recallSessionForWorkspace = useSessionsStore(
     (s) => s.recallSessionForWorkspace
@@ -1155,6 +1175,7 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <div className="main-app" ref={mainAppRef}>
+        <BackendConnectionBanner status={backendConnectionStatus} />
         {/* Sidebar overlay (mobile) */}
         {sidebarOpen && (
           <div className="sidebar-overlay" onClick={closeSidebar} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,10 @@ import {
   UTILITY_ICON_RAIL_WIDTH,
   type WorkspaceUtilityRailState,
 } from './lib/stores/ui.js';
-import { useSessionsStore } from './lib/stores/sessions.js';
+import {
+  useSessionsStore,
+  type BackendConnectionStatus,
+} from './lib/stores/sessions.js';
 import { useConfigStore } from './lib/stores/config.js';
 import { useToastStore } from './lib/stores/toasts.js';
 import { useBootStateStore } from './lib/stores/boot-state.js';
@@ -782,7 +785,7 @@ function TerminalAreaContent({
 function BackendConnectionBanner({
   status,
 }: {
-  status: 'connected' | 'reconnecting' | 'restarting';
+  status: BackendConnectionStatus;
 }) {
   if (status === 'connected') return null;
   const label =

--- a/frontend/src/components/Terminal.css
+++ b/frontend/src/components/Terminal.css
@@ -132,3 +132,18 @@
 .zoom-overlay.visible {
   opacity: 1;
 }
+
+.terminal-reconnect-banner {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 2;
+  border: 1px solid var(--status-warning);
+  background: var(--bg);
+  color: var(--status-warning);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1;
+  padding: 4px 8px;
+  pointer-events: none;
+}

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -1073,10 +1073,9 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
     const activeAgent = useSessionsStore(
       (s) => s.sessions.find((sess) => sess.id === sessionId)?.agent
     );
-    const reconnectingPtySessionId = useSessionsStore(
-      (s) => s.reconnectingPtySessionId
+    const isPtyReconnecting = useSessionsStore((s) =>
+      sessionId ? s.reconnectingPtySessionIds[sessionId] === true : false
     );
-    const isPtyReconnecting = reconnectingPtySessionId === sessionId;
     const isFullscreenTerminal =
       (claudeFullscreen && activeAgent === 'claude') || useTmux;
 

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -1076,6 +1076,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
     const reconnectingPtySessionId = useSessionsStore(
       (s) => s.reconnectingPtySessionId
     );
+    const isPtyReconnecting = reconnectingPtySessionId === sessionId;
     const isFullscreenTerminal =
       (claudeFullscreen && activeAgent === 'claude') || useTmux;
 
@@ -1142,12 +1143,10 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
     useEffect(() => {
       if (
         sessionId &&
-        reconnectingPtySessionId === sessionId &&
+        isPtyReconnecting &&
         termRef.current &&
         !companionMode
       ) {
-        const term = termRef.current;
-        term.reset();
         const container = containerRef.current;
         if (container) {
           const viewport =
@@ -1157,11 +1156,11 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
           }
         }
         fit();
-        term.refresh(0, term.rows - 1);
+        termRef.current.refresh(0, termRef.current.rows - 1);
       }
     }, [
       sessionId,
-      reconnectingPtySessionId,
+      isPtyReconnecting,
       companionMode,
       isFullscreenTerminal,
       fit,
@@ -1260,6 +1259,11 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
               .join(' ')}
           >
             {zoomText}
+          </div>
+        )}
+        {isPtyReconnecting && !companionMode && (
+          <div className="terminal-reconnect-banner" role="status">
+            reconnecting pty
           </div>
         )}
       </div>

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -128,6 +128,13 @@ function invalidatePrQueries(queryClient: QueryClient): void {
   queryClient.invalidateQueries({ queryKey: ['org-prs'] });
 }
 
+function invalidateReconnectQueries(queryClient: QueryClient): void {
+  invalidatePrQueries(queryClient);
+  queryClient.invalidateQueries({ queryKey: ['files-list'] });
+  queryClient.invalidateQueries({ queryKey: ['changedFiles'] });
+  queryClient.invalidateQueries({ queryKey: ['fileDiff'] });
+}
+
 function forceRefreshRepos(repoPaths: string[], source: 'webhook' | 'manual') {
   for (const repoPath of repoPaths) {
     void useSessionsStore.getState().forceRefresh(repoPath, source);
@@ -153,6 +160,16 @@ export function useEventSocket({
     ): void {
       invalidatePrQueries(queryClient);
       forceRefreshRepos(repoPaths, source);
+    }
+
+    async function refreshAfterReconnect(): Promise<void> {
+      const sessions = useSessionsStore.getState();
+      sessions.setBackendConnectionStatus('connected');
+      await sessions.refreshAll();
+      invalidateReconnectQueries(queryClient);
+      throttledChangedFilesRefresh();
+      void sessions.ensureFreshAll(0);
+      void useTelemetryStore.getState().refreshTelemetry();
     }
 
     /** Throttled invalidation for bursty webhook PR/CI events. */
@@ -274,6 +291,7 @@ export function useEventSocket({
       },
       'server-restarting': () => {
         const state = useSessionsStore.getState();
+        state.setBackendConnectionStatus('restarting');
         const activeSessionId = state.activeSessionId;
         if (activeSessionId) {
           const activeSession = state.sessions.find(
@@ -293,13 +311,27 @@ export function useEventSocket({
       },
       () => {
         if (eventSocketOpened) {
-          void useSessionsStore.getState().ensureFreshAll(0);
+          void refreshAfterReconnect();
+        } else {
+          useSessionsStore
+            .getState()
+            .setBackendConnectionStatus('connected');
+          void useTelemetryStore.getState().refreshTelemetry();
         }
         eventSocketOpened = true;
-        void useTelemetryStore.getState().refreshTelemetry();
       },
       () => {
         useAuthStore.getState().deauthenticate();
+      },
+      (status) => {
+        const sessions = useSessionsStore.getState();
+        if (
+          status === 'reconnecting' &&
+          sessions.backendConnectionStatus === 'restarting'
+        ) {
+          return;
+        }
+        sessions.setBackendConnectionStatus(status);
       }
     );
 

--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -157,7 +157,7 @@ export interface SessionsState {
   sidebarItems: SidebarItem[];
   enrichmentResults: Record<string, BranchEnrichment>;
   repoEnrichmentMeta: Record<string, RepoEnrichmentMeta>;
-  reconnectingPtySessionId: string | null;
+  reconnectingPtySessionIds: Record<string, true>;
   backendConnectionStatus: BackendConnectionStatus;
   // Actions
   setActiveSessionId: (id: string | null) => void;
@@ -254,7 +254,7 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
   sidebarItems: [],
   enrichmentResults: {},
   repoEnrichmentMeta: {},
-  reconnectingPtySessionId: null,
+  reconnectingPtySessionIds: {},
   backendConnectionStatus: 'connected',
 
   setActiveSessionId: (id) => {
@@ -652,13 +652,30 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
   },
 
   beginPtyReconnect: (sessionId: string) => {
-    set({ reconnectingPtySessionId: sessionId });
+    set((state) => {
+      if (state.reconnectingPtySessionIds[sessionId]) return state;
+      return {
+        reconnectingPtySessionIds: {
+          ...state.reconnectingPtySessionIds,
+          [sessionId]: true,
+        },
+      };
+    });
   },
 
   clearPtyReconnect: (sessionId?: string) => {
-    const current = get().reconnectingPtySessionId;
-    if (sessionId === undefined || current === sessionId) {
-      set({ reconnectingPtySessionId: null });
-    }
+    set((state) => {
+      if (sessionId === undefined) {
+        if (Object.keys(state.reconnectingPtySessionIds).length === 0) {
+          return state;
+        }
+        return { reconnectingPtySessionIds: {} };
+      }
+
+      if (!state.reconnectingPtySessionIds[sessionId]) return state;
+      const next = { ...state.reconnectingPtySessionIds };
+      delete next[sessionId];
+      return { reconnectingPtySessionIds: next };
+    });
   },
 }));

--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -31,6 +31,10 @@ const BOOT_FETCH_TIMEOUT_MS = 10_000;
 export const DEFAULT_ENRICHMENT_TTL_MS = 600_000;
 
 export type RepoEnrichmentSource = 'webhook' | 'manual';
+export type BackendConnectionStatus =
+  | 'connected'
+  | 'reconnecting'
+  | 'restarting';
 export interface RepoEnrichmentMeta {
   lastEnrichedAt: number;
   source: RepoEnrichmentSource;
@@ -154,6 +158,7 @@ export interface SessionsState {
   enrichmentResults: Record<string, BranchEnrichment>;
   repoEnrichmentMeta: Record<string, RepoEnrichmentMeta>;
   reconnectingPtySessionId: string | null;
+  backendConnectionStatus: BackendConnectionStatus;
   // Actions
   setActiveSessionId: (id: string | null) => void;
   rememberSessionForWorkspace: (
@@ -199,6 +204,7 @@ export interface SessionsState {
   clearLoading: (key: string) => void;
   isItemLoading: (key: string) => boolean;
   reorderWorkspaces: (paths: string[]) => Promise<void>;
+  setBackendConnectionStatus: (status: BackendConnectionStatus) => void;
   beginPtyReconnect: (sessionId: string) => void;
   clearPtyReconnect: (sessionId?: string) => void;
 }
@@ -249,6 +255,7 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
   enrichmentResults: {},
   repoEnrichmentMeta: {},
   reconnectingPtySessionId: null,
+  backendConnectionStatus: 'connected',
 
   setActiveSessionId: (id) => {
     saveActiveSessionId(id);
@@ -635,6 +642,13 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
   reorderWorkspaces: async (paths) => {
     const updated = await api.reorderWorkspaces(paths);
     set({ repos: updated });
+  },
+
+  setBackendConnectionStatus: (status) => {
+    set((state) => {
+      if (state.backendConnectionStatus === status) return state;
+      return { backendConnectionStatus: status };
+    });
   },
 
   beginPtyReconnect: (sessionId: string) => {

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -79,6 +79,8 @@ export type EventMessage =
 
 type EventCallback = (msg: EventMessage) => void;
 type EventOpenCallback = () => void;
+export type EventConnectionStatus = 'connected' | 'reconnecting';
+type EventConnectionStatusCallback = (status: EventConnectionStatus) => void;
 
 const MAX_RECONNECT_ATTEMPTS = 30;
 const PING_INTERVAL = 30_000;
@@ -103,11 +105,14 @@ let eventPongTimeout: ReturnType<typeof setTimeout> | null = null;
 let lastEventOnMessage: EventCallback | null = null;
 let lastEventOnOpen: EventOpenCallback | null = null;
 let lastOnAuthRequired: (() => void) | null = null;
+let lastEventOnStatus: EventConnectionStatusCallback | null = null;
+let serverRestartAuthGraceUntil = 0;
 
 export function connectEventSocket(
   onMessage: EventCallback,
   onOpen?: EventOpenCallback,
-  onAuthRequired?: () => void
+  onAuthRequired?: () => void,
+  onStatus?: EventConnectionStatusCallback
 ): void {
   if (eventWs) {
     eventWs.onclose = null;
@@ -117,6 +122,7 @@ export function connectEventSocket(
   lastEventOnMessage = onMessage;
   lastEventOnOpen = onOpen ?? null;
   lastOnAuthRequired = onAuthRequired ?? lastOnAuthRequired;
+  lastEventOnStatus = onStatus ?? lastEventOnStatus;
   clearEventPing();
 
   const url = wsProtocol + '//' + location.host + '/ws/events';
@@ -124,6 +130,7 @@ export function connectEventSocket(
 
   eventWs.onopen = () => {
     startEventPing();
+    lastEventOnStatus?.('connected');
     onOpen?.();
   };
 
@@ -134,7 +141,7 @@ export function connectEventSocket(
     try {
       const msg = JSON.parse(str) as EventMessage;
       if (msg.type === 'server-restarting') {
-        markPtyConnectionsForServerRestart();
+        markServerRestarting();
       }
       onMessage(msg);
     } catch {
@@ -144,6 +151,7 @@ export function connectEventSocket(
 
   eventWs.onclose = () => {
     clearEventPing();
+    lastEventOnStatus?.('reconnecting');
     setTimeout(() => void reconnectWithAuthCheck(), 3000);
   };
 
@@ -154,6 +162,10 @@ async function reconnectWithAuthCheck(): Promise<void> {
   try {
     const res = await fetch('/auth/check');
     if (res.status === 401) {
+      if (isWithinServerRestartGrace()) {
+        setTimeout(() => void reconnectWithAuthCheck(), 1000);
+        return;
+      }
       lastOnAuthRequired?.();
       return;
     }
@@ -161,7 +173,12 @@ async function reconnectWithAuthCheck(): Promise<void> {
     /* keep trying */
   }
   if (lastEventOnMessage) {
-    connectEventSocket(lastEventOnMessage, lastEventOnOpen ?? undefined);
+    connectEventSocket(
+      lastEventOnMessage,
+      lastEventOnOpen ?? undefined,
+      lastOnAuthRequired ?? undefined,
+      lastEventOnStatus ?? undefined
+    );
   }
 }
 
@@ -183,6 +200,7 @@ function sendEventPing(): void {
 
 function forceReconnectEvent(): void {
   clearEventPing();
+  lastEventOnStatus?.('reconnecting');
   if (eventWs) {
     eventWs.onclose = null;
     eventWs.close();
@@ -239,6 +257,18 @@ interface PtyConnection {
 
 const ptyConnections = new Map<string, PtyConnection>();
 
+function isWithinServerRestartGrace(): boolean {
+  return serverRestartAuthGraceUntil > Date.now();
+}
+
+function markServerRestarting(): void {
+  markPtyConnectionsForServerRestart();
+  serverRestartAuthGraceUntil = Math.max(
+    serverRestartAuthGraceUntil,
+    Date.now() + SERVER_RESTART_CLEAN_CLOSE_RECONNECT_WINDOW_MS
+  );
+}
+
 function markPtyConnectionsForServerRestart(): void {
   const reconnectUntil =
     Date.now() + SERVER_RESTART_CLEAN_CLOSE_RECONNECT_WINDOW_MS;
@@ -260,7 +290,7 @@ function shouldReconnectCleanPtyClose(conn: PtyConnection): boolean {
 function beginPtyReconnect(conn: PtyConnection): void {
   useSessionsStore.getState().beginPtyReconnect(conn.sessionId);
   if (conn.reconnectAttempt === 0) {
-    conn.term.write('\r\n[Reconnecting...]\r\n');
+    conn.term.write('\r\n[reconnecting...]\r\n');
   }
   scheduleReconnect(conn);
 }
@@ -455,7 +485,7 @@ function openPtySocket(conn: PtyConnection): void {
     }
 
     if (event.code === 1000) {
-      conn.term.write('\r\n[Session ended]\r\n');
+      conn.term.write('\r\n[session ended]\r\n');
       useSessionsStore.getState().clearPtyReconnect(conn.sessionId);
       ptyConnections.delete(conn.sessionId);
       conn.onSessionEnd();
@@ -470,7 +500,7 @@ function openPtySocket(conn: PtyConnection): void {
 function scheduleReconnect(conn: PtyConnection): void {
   if (conn.reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {
     conn.term.write(
-      '\r\n[Gave up reconnecting after ' +
+      '\r\n[gave up reconnecting after ' +
         MAX_RECONNECT_ATTEMPTS +
         ' attempts]\r\n'
     );
@@ -485,6 +515,10 @@ function scheduleReconnect(conn: PtyConnection): void {
     try {
       const authRes = await fetch('/auth/check');
       if (authRes.status === 401) {
+        if (isWithinServerRestartGrace()) {
+          scheduleReconnect(conn);
+          return;
+        }
         useSessionsStore.getState().clearPtyReconnect(conn.sessionId);
         lastOnAuthRequired?.();
         return;
@@ -492,13 +526,12 @@ function scheduleReconnect(conn: PtyConnection): void {
       const res = await fetch('/sessions');
       const sessionList = (await res.json()) as Array<{ id: string }>;
       if (!sessionList.some((s) => s.id === conn.sessionId)) {
-        conn.term.write('\r\n[Session ended]\r\n');
+        conn.term.write('\r\n[session ended]\r\n');
         useSessionsStore.getState().clearPtyReconnect(conn.sessionId);
         ptyConnections.delete(conn.sessionId);
         conn.onSessionEnd();
         return;
       }
-      conn.term.clear();
       openPtySocket(conn);
     } catch {
       scheduleReconnect(conn);

--- a/test/hooks/useEventSocket.test.ts
+++ b/test/hooks/useEventSocket.test.ts
@@ -8,10 +8,17 @@ const effectState = vi.hoisted(() => ({
 const wsMock = vi.hoisted(() => ({
   onMessage: undefined as undefined | ((msg: EventMessage) => void),
   onOpen: undefined as undefined | (() => void),
+  onConnectionState: undefined as undefined | ((state: string) => void),
   connectEventSocket: vi.fn(
-    (onMessage: (msg: EventMessage) => void, onOpen?: () => void) => {
+    (
+      onMessage: (msg: EventMessage) => void,
+      onOpen?: () => void,
+      _onAuthRequired?: () => void,
+      onConnectionState?: (state: string) => void
+    ) => {
       wsMock.onMessage = onMessage;
       wsMock.onOpen = onOpen;
+      wsMock.onConnectionState = onConnectionState;
     }
   ),
 }));
@@ -25,10 +32,16 @@ const storeMock = vi.hoisted(() => ({
   handleBranchChanged: vi.fn(),
   handleActivityChanged: vi.fn(),
   beginPtyReconnect: vi.fn(),
+  setBackendConnectionStatus: vi.fn(),
+  backendConnectionStatus: 'connected' as
+    | 'connected'
+    | 'reconnecting'
+    | 'restarting',
   activeSessionId: null as string | null,
   sessions: [] as Array<{
     id: string;
     repoPath: string;
+    mode?: 'pty' | 'web';
     worktreePath?: string | null;
     cwd?: string;
   }>,
@@ -94,21 +107,23 @@ describe('useEventSocket repo-scoped refresh', () => {
     effectState.cleanup = undefined;
     wsMock.onMessage = undefined;
     wsMock.onOpen = undefined;
+    wsMock.onConnectionState = undefined;
     storeMock.activeSessionId = null;
+    storeMock.backendConnectionStatus = 'connected';
     storeMock.sessions = [];
     storeMock.worktrees = [];
   });
 
-  function mount(): void {
+  function mount(queryClient = { invalidateQueries: vi.fn() } as any): void {
     useEventSocket({
       authAuthenticated: true,
-      queryClient: { invalidateQueries: vi.fn() } as any,
+      queryClient,
       throttledChangedFilesRefresh: vi.fn(),
       setChangedFilesData: vi.fn(),
     });
   }
 
-  it('forces all visible repo enrichment on websocket reconnect after the initial open', () => {
+  it('forces all visible repo enrichment on websocket reconnect after the initial open', async () => {
     mount();
 
     wsMock.onOpen?.();
@@ -116,8 +131,80 @@ describe('useEventSocket repo-scoped refresh', () => {
 
     wsMock.onOpen?.();
 
-    expect(storeMock.ensureFreshAll).toHaveBeenCalledWith(0);
+    await vi.waitFor(() =>
+      expect(storeMock.ensureFreshAll).toHaveBeenCalledWith(0)
+    );
     expect(telemetryMock.refreshTelemetry).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes sessions, worktrees, dashboard, and file data after websocket reconnect', async () => {
+    const queryClient = { invalidateQueries: vi.fn() } as any;
+    const changedFilesRefresh = vi.fn();
+    useEventSocket({
+      authAuthenticated: true,
+      queryClient,
+      throttledChangedFilesRefresh: changedFilesRefresh,
+      setChangedFilesData: vi.fn(),
+    });
+
+    wsMock.onOpen?.();
+    wsMock.onOpen?.();
+    await vi.waitFor(() => expect(storeMock.refreshAll).toHaveBeenCalled());
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['dashboard'],
+    });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['files-list'],
+    });
+    expect(changedFilesRefresh).toHaveBeenCalled();
+  });
+
+  it('marks backend restart state and preserves the active pty session for reconnect', () => {
+    storeMock.activeSessionId = 'sess-a';
+    storeMock.sessions = [
+      { id: 'sess-a', repoPath: '/repos/relay-ide', mode: 'pty' },
+    ];
+    mount();
+
+    wsMock.onMessage?.({ type: 'server-restarting', reason: 'dev-restart' });
+
+    expect(storeMock.setBackendConnectionStatus).toHaveBeenCalledWith(
+      'restarting'
+    );
+    expect(storeMock.beginPtyReconnect).toHaveBeenCalledWith('sess-a');
+  });
+
+  it('mirrors event socket reconnect status without auth fallback', () => {
+    mount();
+
+    wsMock.onConnectionState?.('reconnecting');
+    wsMock.onConnectionState?.('connected');
+
+    expect(storeMock.setBackendConnectionStatus).toHaveBeenNthCalledWith(
+      1,
+      'reconnecting'
+    );
+    expect(storeMock.setBackendConnectionStatus).toHaveBeenNthCalledWith(
+      2,
+      'connected'
+    );
+  });
+
+  it('keeps the explicit restarting label until reconnect succeeds', () => {
+    mount();
+
+    wsMock.onMessage?.({ type: 'server-restarting', reason: 'dev-restart' });
+    storeMock.backendConnectionStatus = 'restarting';
+    wsMock.onConnectionState?.('reconnecting');
+    wsMock.onConnectionState?.('connected');
+
+    expect(storeMock.setBackendConnectionStatus).not.toHaveBeenCalledWith(
+      'reconnecting'
+    );
+    expect(storeMock.setBackendConnectionStatus).toHaveBeenLastCalledWith(
+      'connected'
+    );
   });
 
   it('throttles pr-updated events but force-refreshes only repos listed in the payload', () => {

--- a/test/stores/sessions-logic.test.ts
+++ b/test/stores/sessions-logic.test.ts
@@ -277,73 +277,88 @@ describe('sessions store pure logic', () => {
   });
 
   describe('PTY reconnect state', () => {
+    type PtyReconnectIds = Record<string, true>;
     type PtyReconnectAction =
       | { type: 'begin'; sessionId: string }
       | { type: 'clear'; sessionId?: string };
 
     function applyPtyReconnectTransition(
-      currentId: string | null,
+      currentIds: PtyReconnectIds,
       action: PtyReconnectAction
-    ): string | null {
+    ): PtyReconnectIds {
       if (action.type === 'begin') {
-        return action.sessionId;
+        return { ...currentIds, [action.sessionId]: true };
       }
 
-      if (action.sessionId === undefined || currentId === action.sessionId) {
-        return null;
-      }
+      if (action.sessionId === undefined) return {};
+      if (!currentIds[action.sessionId]) return currentIds;
 
-      return currentId;
+      const next = { ...currentIds };
+      delete next[action.sessionId];
+      return next;
     }
 
     function beginPtyReconnect(
-      currentId: string | null,
+      currentIds: PtyReconnectIds,
       sessionId: string
-    ): string | null {
-      return applyPtyReconnectTransition(currentId, {
+    ): PtyReconnectIds {
+      return applyPtyReconnectTransition(currentIds, {
         type: 'begin',
         sessionId,
       });
     }
 
     function clearPtyReconnect(
-      currentId: string | null,
+      currentIds: PtyReconnectIds,
       sessionId?: string
-    ): string | null {
-      return applyPtyReconnectTransition(currentId, {
+    ): PtyReconnectIds {
+      return applyPtyReconnectTransition(currentIds, {
         type: 'clear',
         sessionId,
       });
     }
 
-    it('beginPtyReconnect sets the reconnecting session ID', () => {
-      const result = beginPtyReconnect(null, 'session-a');
-      expect(result).toBe('session-a');
+    function isPtyReconnecting(
+      currentIds: PtyReconnectIds,
+      sessionId: string | null
+    ): boolean {
+      return sessionId ? currentIds[sessionId] === true : false;
+    }
+
+    it('beginPtyReconnect adds the reconnecting session ID', () => {
+      const result = beginPtyReconnect({}, 'session-a');
+      expect(result).toEqual({ 'session-a': true });
     });
 
-    it('beginPtyReconnect replaces previous session ID', () => {
-      const result = beginPtyReconnect('session-a', 'session-b');
-      expect(result).toBe('session-b');
+    it('beginPtyReconnect preserves prior reconnecting session IDs', () => {
+      const result = beginPtyReconnect({ 'session-a': true }, 'session-b');
+      expect(result).toEqual({ 'session-a': true, 'session-b': true });
     });
 
-    it('clearPtyReconnect clears when sessionId matches', () => {
-      const result = clearPtyReconnect('session-a', 'session-a');
-      expect(result).toBeNull();
+    it('clearPtyReconnect clears only the matching sessionId', () => {
+      const result = clearPtyReconnect(
+        { 'session-a': true, 'session-b': true },
+        'session-a'
+      );
+      expect(result).toEqual({ 'session-b': true });
     });
 
-    it('clearPtyReconnect keeps current when sessionId does not match', () => {
-      const result = clearPtyReconnect('session-a', 'session-b');
-      expect(result).toBe('session-a');
+    it('clearPtyReconnect keeps current state when sessionId does not match', () => {
+      const current: PtyReconnectIds = { 'session-a': true };
+      const result = clearPtyReconnect(current, 'session-b');
+      expect(result).toBe(current);
     });
 
     it('clearPtyReconnect clears unconditionally when no sessionId provided', () => {
-      const result = clearPtyReconnect('session-a');
-      expect(result).toBeNull();
+      const result = clearPtyReconnect({ 'session-a': true, 'session-b': true });
+      expect(result).toEqual({});
     });
 
-    it('clearPtyReconnect is a no-op when already null', () => {
-      const result = clearPtyReconnect(null, 'session-a');
-      expect(result).toBeNull();
+    it('isPtyReconnecting guards null session IDs', () => {
+      const current: PtyReconnectIds = { 'session-a': true };
+      expect(isPtyReconnecting(current, 'session-a')).toBe(true);
+      expect(isPtyReconnecting(current, 'session-b')).toBe(false);
+      expect(isPtyReconnecting(current, null)).toBe(false);
     });
   });
 });

--- a/test/ws-pty-routing.test.ts
+++ b/test/ws-pty-routing.test.ts
@@ -213,6 +213,23 @@ describe('per-session PTY routing', () => {
     expect(sockets[1]!.url).toContain('/ws/sess-a');
   });
 
+  it('marks every live PTY reconnecting when the server restarts', async () => {
+    const ws = await importWs();
+    ws.connectPtySocket('sess-a', fakeTerm(), vi.fn(), vi.fn());
+    ws.connectPtySocket('sess-b', fakeTerm(), vi.fn(), vi.fn());
+    sockets[0]!.__triggerOpen();
+    sockets[1]!.__triggerOpen();
+
+    ws.connectEventSocket(vi.fn());
+    sockets[2]!.onmessage?.({
+      data: JSON.stringify({ type: 'server-restarting', reason: 'dev-restart' }),
+    } as MessageEvent);
+
+    expect(sessionsStore.beginPtyReconnect).toHaveBeenCalledTimes(2);
+    expect(sessionsStore.beginPtyReconnect).toHaveBeenCalledWith('sess-a');
+    expect(sessionsStore.beginPtyReconnect).toHaveBeenCalledWith('sess-b');
+  });
+
   it('reconnects an open PTY after server-restarting followed by clean close', async () => {
     vi.useFakeTimers();
     vi.stubGlobal(
@@ -238,7 +255,7 @@ describe('per-session PTY routing', () => {
     sockets[0]!.readyState = FakeWebSocket.CLOSED;
     sockets[0]!.onclose?.({ code: 1000 } as CloseEvent);
 
-    expect(term.write).not.toHaveBeenCalledWith('\r\n[Session ended]\r\n');
+    expect(term.write).not.toHaveBeenCalledWith('\r\n[session ended]\r\n');
     expect(onEnd).not.toHaveBeenCalled();
     expect(sessionsStore.beginPtyReconnect).toHaveBeenCalledWith('sess-a');
 

--- a/test/ws-pty-routing.test.ts
+++ b/test/ws-pty-routing.test.ts
@@ -244,8 +244,32 @@ describe('per-session PTY routing', () => {
 
     await vi.advanceTimersByTimeAsync(1000);
 
-    expect(term.clear).toHaveBeenCalled();
+    expect(term.clear).not.toHaveBeenCalled();
     expect(sockets).toHaveLength(3);
     expect(sockets[2]!.url).toContain('/ws/sess-a');
+  });
+
+  it('does not invoke auth fallback for 401 checks during the restart grace window', async () => {
+    vi.useFakeTimers();
+    const onAuthRequired = vi.fn();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        if (url === '/auth/check') return { status: 401 };
+        throw new Error(`unexpected fetch ${url}`);
+      })
+    );
+
+    const ws = await importWs();
+    ws.connectEventSocket(vi.fn(), vi.fn(), onAuthRequired);
+    sockets[0]!.onmessage?.({
+      data: JSON.stringify({ type: 'server-restarting', reason: 'dev-restart' }),
+    } as MessageEvent);
+    sockets[0]!.readyState = FakeWebSocket.CLOSED;
+    sockets[0]!.onclose?.({ code: 1006 } as CloseEvent);
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(onAuthRequired).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Adds a first-class backend connection status (`connected`, `reconnecting`, `restarting`) in the session store and surfaces concise lowercase banners in the app and terminal surfaces.
- Refreshes sessions, worktrees, PR/dashboard/file-related queries after the event socket reconnects so stale sidebar/status data is replaced after backend restarts.
- Preserves PTY terminal scrollback while reconnecting, reattaches visible PTY sockets by session id, and suppresses auth redirects during the server restart grace window.
- Adds regression coverage for restart events, reconnect refresh, PTY preservation, and restart-label precedence.

## Workspace Guard
- `pwd`: `/Users/donovanyohan/Documents/Programs/personal/relay-ide/.worktrees/kanban-365-reconnect-ui-state`
- `git rev-parse --show-toplevel`: `/Users/donovanyohan/Documents/Programs/personal/relay-ide/.worktrees/kanban-365-reconnect-ui-state`
- `git remote get-url origin`: `git@github.com:donovan-yohan/relay-ide.git`
- `git status --short --branch`: `## kanban/365-reconnect-ui-state...origin/nightly`

## Motivation
Backend restarts are expected during dev/reload workflows, but the frontend previously treated brief unavailability like a broken app: terminal panes could reset, cached lists could stay stale, and auth fallback could fire during a normal restart window. This turns restart/reconnect into explicit UI state instead of chaos wearing a trench coat.

## The Case Against
This change might be wrong because:
- The reconnect refresh fan-out may invalidate more queries than strictly necessary after every event socket reconnect.
- The auth grace window depends on receiving the shaped `server-restarting` event before failed requests hit auth fallback.
- Preserving terminal scrollback avoids data loss visually, but it also means stale text remains visible while the PTY is reconnecting; the overlay has to carry that ambiguity.
- The app-level banner is intentionally minimal and global, but without a browser smoke run there is still some risk of layout overlap in narrow panes.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
| --- | --- | --- |
| UI flickers from `restarting` to `reconnecting` during clean restarts | Medium | Status hierarchy keeps the explicit `restarting` label until connected. |
| Stale data after reconnect | Medium | Reconnect callback refreshes Zustand session/worktree state and invalidates relevant TanStack queries. |
| PTY output loss on reconnect | Medium | Removed terminal reset during reconnect and added a reconnecting banner instead. |
| Accidental auth redirect during restart | Medium | WebSocket restart grace suppresses 401 fallback while the backend is expected to be unavailable. |

## Verification
- `rtk npm test -- test/hooks/useEventSocket.test.ts test/ws-pty-routing.test.ts` — 21 tests passed.
- `rtk npm run check` — passed with 0 errors, 36 existing warnings.
- `rtk npm run build` — passed.
- `git diff --check` — passed.
- Static added-line secret scan — no findings.
- Manual browser smoke not run in this worker session; covered with targeted reconnect/PTY tests and production build.

Closes #365
Refs #368


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual banner for backend connection status (connected / reconnecting / restarting).
  * Terminal reconnection indicator shown during PTY reconnects.

* **Improvements**
  * Better recovery after server restarts with refined connection-state handling.
  * Broader data refresh on websocket reconnects (sessions, files, dashboard).
  * Auth grace period during restart to avoid premature re-auth prompts.

* **Tests**
  * Extended tests covering restart/reconnect and multi-PTY reconnect scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/383)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->