### PR TITLE
Add identity foundations

### DIFF
--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,4 +1,15 @@
 import type {
+  GlobalSessionId,
+  NodeId,
+  RepoIdentity,
+  RepoInstanceId,
+  WorktreeInstanceId,
+} from '../../../shared/identity.js';
+import type {
+  RepoIdentityWarning,
+  ResolvedRemoteIdentity,
+} from '../../../shared/repo-identity.js';
+import type {
   DisplayState,
   BackendDisplayState,
 } from './state/display-state.js';
@@ -93,6 +104,17 @@ export interface Repo {
   isGitRepo: boolean;
   defaultBranch: string | null;
   currentBranch: string | null;
+  /** Node-local checkout path. Kept beside path for backward-compatible local mode consumers. */
+  localPath?: string;
+  /** Execution node that owns this checkout path. Local mode uses DEFAULT_LOCAL_NODE_ID. */
+  nodeId?: NodeId;
+  /** Canonical logical repository identity, derived from remotes when possible. */
+  repoIdentity?: RepoIdentity | null;
+  /** Node-scoped checkout instance id. Do not use path alone for cross-node identity. */
+  repoInstanceId?: RepoInstanceId;
+  selectedRemote?: ResolvedRemoteIdentity | null;
+  remotes?: ResolvedRemoteIdentity[];
+  repoIdentityWarnings?: RepoIdentityWarning[];
   webhookStatus?: RepoWebhookStatus;
   webhookError?: string;
   lastWebhookEventAt?: string;
@@ -120,6 +142,14 @@ export interface SessionSummary {
   createdAt: string;
   lastActivity: string;
   idle: boolean;
+  /** Execution node that owns this local session id. */
+  nodeId?: NodeId;
+  /** Node-scoped session id for hub/federated routing. */
+  globalSessionId?: GlobalSessionId;
+  /** Node-scoped checkout instance id for repoPath. */
+  repoInstanceId?: RepoInstanceId;
+  /** Node-scoped worktree/cwd instance id when this session runs in a worktree. */
+  worktreeInstanceId?: WorktreeInstanceId;
   useTmux?: boolean | undefined;
   status?: 'active' | 'disconnected' | undefined;
   agentState?: AgentState | undefined;
@@ -139,6 +169,10 @@ export interface WorktreeInfo {
   displayName: string;
   lastActivity: string;
   branchName: string;
+  nodeId?: NodeId;
+  repoIdentity?: RepoIdentity | null;
+  repoInstanceId?: RepoInstanceId;
+  worktreeInstanceId?: WorktreeInstanceId;
 }
 
 export interface RepoInfo {
@@ -356,6 +390,10 @@ export interface SidebarItem {
   displayState: DisplayState;
   lastKnownBackendState: BackendDisplayState | null;
   sessions: SessionSummary[];
+  nodeId?: NodeId;
+  repoIdentity?: RepoIdentity | null;
+  repoInstanceId?: RepoInstanceId;
+  worktreeInstanceId?: WorktreeInstanceId;
   isUnread?: boolean;
   prStatus?: PrDotStatus;
 }

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -142,13 +142,13 @@ function configure(opts: {
 
 function withLocalIdentity<T extends SessionSummary>(summary: T): T {
   const nodeId = DEFAULT_LOCAL_NODE_ID;
-  const repoPathForIdentity =
-    summary.repoPath || summary.cwd || summary.worktreePath || summary.id;
   return {
     ...summary,
     nodeId,
     globalSessionId: createGlobalSessionId(nodeId, summary.id),
-    repoInstanceId: createRepoInstanceId(nodeId, repoPathForIdentity),
+    ...(summary.repoPath
+      ? { repoInstanceId: createRepoInstanceId(nodeId, summary.repoPath) }
+      : {}),
     ...(summary.worktreePath
       ? {
           worktreeInstanceId: createWorktreeInstanceId(

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -41,6 +41,12 @@ import {
 } from './relay-state-db.js';
 import { applyWebSessionPatchV2 } from './web-session-v2-state.js';
 import { getWorkingTreeDiff } from './git.js';
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  createGlobalSessionId,
+  createRepoInstanceId,
+  createWorktreeInstanceId,
+} from '../shared/identity.js';
 import { getPrForBranch, isStalePr } from './gh.js';
 import {
   trackEvent,
@@ -132,6 +138,26 @@ function configure(opts: {
   defaultPort = opts.port;
   defaultForceOutputParser = opts.forceOutputParser;
   defaultConfigDir = opts.configDir;
+}
+
+function withLocalIdentity<T extends SessionSummary>(summary: T): T {
+  const nodeId = DEFAULT_LOCAL_NODE_ID;
+  const repoPathForIdentity =
+    summary.repoPath || summary.cwd || summary.worktreePath || summary.id;
+  return {
+    ...summary,
+    nodeId,
+    globalSessionId: createGlobalSessionId(nodeId, summary.id),
+    repoInstanceId: createRepoInstanceId(nodeId, repoPathForIdentity),
+    ...(summary.worktreePath
+      ? {
+          worktreeInstanceId: createWorktreeInstanceId(
+            nodeId,
+            summary.worktreePath
+          ),
+        }
+      : {}),
+  };
 }
 
 let terminalCounter = 0;
@@ -366,7 +392,10 @@ function create({
     };
     stateChangeCallbacks.push(promptHandler);
   }
-  return { ...result, needsBranchRename: !!ptySession.needsBranchRename };
+  return withLocalIdentity({
+    ...result,
+    needsBranchRename: !!ptySession.needsBranchRename,
+  });
 }
 
 function get(id: string): Session | undefined {
@@ -376,39 +405,40 @@ function get(id: string): Session | undefined {
 function list(): SessionSummary[] {
   return Array.from(sessions.values())
     .map(
-      (s): SessionSummary => ({
-        id: s.id,
-        type: s.type,
-        agent: s.agent,
-        mode: s.mode,
-        repoPath: s.repoPath,
-        worktreePath: s.worktreePath,
-        cwd: s.cwd,
-        repoName: s.repoName,
-        branchName: s.branchName,
-        displayName: s.displayName,
-        createdAt: s.createdAt,
-        lastActivity: s.lastActivity,
-        idle: s.idle,
-        customCommand: s.customCommand,
-        status: s.status,
-        needsBranchRename: !!s.needsBranchRename,
-        agentState: s.agentState,
-        currentActivity: s.currentActivity,
-        ...(s.mode === 'pty'
-          ? { useTmux: s.useTmux, tmuxSessionName: s.tmuxSessionName }
-          : {}),
-        ...(s.workspaceId ? { workspaceId: s.workspaceId } : {}),
-        ...(s.additionalDirs?.length
-          ? { additionalDirs: s.additionalDirs }
-          : {}),
-        ...(s.mode === 'pty' && s.dataQuality !== undefined
-          ? { dataQuality: s.dataQuality }
-          : {}),
-        ...(s._lastEmittedPermissionType !== undefined
-          ? { permissionType: s._lastEmittedPermissionType }
-          : {}),
-      })
+      (s): SessionSummary =>
+        withLocalIdentity({
+          id: s.id,
+          type: s.type,
+          agent: s.agent,
+          mode: s.mode,
+          repoPath: s.repoPath,
+          worktreePath: s.worktreePath,
+          cwd: s.cwd,
+          repoName: s.repoName,
+          branchName: s.branchName,
+          displayName: s.displayName,
+          createdAt: s.createdAt,
+          lastActivity: s.lastActivity,
+          idle: s.idle,
+          customCommand: s.customCommand,
+          status: s.status,
+          needsBranchRename: !!s.needsBranchRename,
+          agentState: s.agentState,
+          currentActivity: s.currentActivity,
+          ...(s.mode === 'pty'
+            ? { useTmux: s.useTmux, tmuxSessionName: s.tmuxSessionName }
+            : {}),
+          ...(s.workspaceId ? { workspaceId: s.workspaceId } : {}),
+          ...(s.additionalDirs?.length
+            ? { additionalDirs: s.additionalDirs }
+            : {}),
+          ...(s.mode === 'pty' && s.dataQuality !== undefined
+            ? { dataQuality: s.dataQuality }
+            : {}),
+          ...(s._lastEmittedPermissionType !== undefined
+            ? { permissionType: s._lastEmittedPermissionType }
+            : {}),
+        })
     )
     .sort((a, b) => b.lastActivity.localeCompare(a.lastActivity));
 }

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,4 +1,15 @@
 import type { IPty } from 'node-pty';
+import type {
+  GlobalSessionId,
+  NodeId,
+  RepoIdentity,
+  RepoInstanceId,
+  WorktreeInstanceId,
+} from '../shared/identity.js';
+import type {
+  RepoIdentityWarning,
+  ResolvedRemoteIdentity,
+} from '../shared/repo-identity.js';
 import type { OutputParser } from './output-parsers/index.js';
 import type { ProtocolAdapter } from './protocol-adapter.js';
 import type { ProtocolAdapterV2 } from './protocol-adapter-v2.js';
@@ -326,6 +337,14 @@ export interface SessionSummary {
   lastActivity: string;
   idle: boolean;
   customCommand: string | null;
+  /** Execution node that owns this local session id. */
+  nodeId?: NodeId;
+  /** Node-scoped session id for hub/federated routing. */
+  globalSessionId?: GlobalSessionId;
+  /** Node-scoped checkout instance id for repoPath. */
+  repoInstanceId?: RepoInstanceId;
+  /** Node-scoped worktree/cwd instance id when this session runs in a worktree. */
+  worktreeInstanceId?: WorktreeInstanceId;
   /** PTY sessions only */
   useTmux?: boolean;
   /** PTY sessions only */
@@ -667,7 +686,8 @@ export interface DashboardData {
   hasGhCli: boolean;
 }
 
-export type WebhookStatus = 'live' | 'manual' | 'limited' | 'error';
+export type RepoWebhookStatus = 'live' | 'manual' | 'limited' | 'error';
+export type WebhookStatus = RepoWebhookStatus;
 
 export interface Repo {
   path: string;
@@ -675,7 +695,18 @@ export interface Repo {
   isGitRepo: boolean;
   defaultBranch: string | null;
   currentBranch: string | null;
-  webhookStatus: WebhookStatus;
+  /** Node-local checkout path. Kept beside path for backward-compatible local mode consumers. */
+  localPath?: string;
+  /** Execution node that owns this checkout path. Local mode uses DEFAULT_LOCAL_NODE_ID. */
+  nodeId?: NodeId;
+  /** Canonical logical repository identity, derived from remotes when possible. */
+  repoIdentity?: RepoIdentity | null;
+  /** Node-scoped checkout instance id. Do not use path alone for cross-node identity. */
+  repoInstanceId?: RepoInstanceId;
+  selectedRemote?: ResolvedRemoteIdentity | null;
+  remotes?: ResolvedRemoteIdentity[];
+  repoIdentityWarnings?: RepoIdentityWarning[];
+  webhookStatus?: RepoWebhookStatus;
   webhookError?: string;
   lastWebhookEventAt?: string;
 }

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -898,12 +898,18 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
       const currentBranch = isGitRepo
         ? await getCurrentBranchForRepo(resolved)
         : null;
+      const identityFields = await resolveRepoIdentityFields(
+        resolved,
+        isGitRepo,
+        exec
+      );
       added.push({
         path: resolved,
         name: path.basename(resolved),
         isGitRepo,
         defaultBranch,
         currentBranch,
+        ...identityFields,
         ...getRepoWebhookFields(config, resolved),
       });
 

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -49,6 +49,14 @@ import type {
 import { MOUNTAIN_NAMES } from './types.js';
 import { getLastWebhookEventAt, getWebhookStatus } from './webhook-manager.js';
 import { createLogger } from './logger.js';
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  createRepoInstanceId,
+} from '../shared/identity.js';
+import {
+  parseGitRemoteVerbose,
+  resolveCanonicalRepoIdentity,
+} from '../shared/repo-identity.js';
 
 const execFileAsync = promisify(execFile);
 const logger = createLogger('workspaces');
@@ -436,6 +444,59 @@ export async function detectGitRepo(
   return { isGitRepo: true, defaultBranch };
 }
 
+async function resolveRepoIdentityFields(
+  repoPath: string,
+  isGitRepo: boolean,
+  execAsync: typeof execFileAsync
+): Promise<Pick<
+  Repo,
+  | 'localPath'
+  | 'nodeId'
+  | 'repoIdentity'
+  | 'repoInstanceId'
+  | 'selectedRemote'
+  | 'remotes'
+  | 'repoIdentityWarnings'
+>> {
+  const nodeId = DEFAULT_LOCAL_NODE_ID;
+  const base = {
+    localPath: repoPath,
+    nodeId,
+    repoInstanceId: createRepoInstanceId(nodeId, repoPath),
+  };
+
+  if (!isGitRepo) {
+    return {
+      ...base,
+      repoIdentity: null,
+      selectedRemote: null,
+      remotes: [],
+      repoIdentityWarnings: ['missing-remotes'],
+    };
+  }
+
+  try {
+    const { stdout } = await execAsync('git', ['remote', '-v'], { cwd: repoPath });
+    const resolution = resolveCanonicalRepoIdentity(parseGitRemoteVerbose(stdout));
+    return {
+      ...base,
+      repoIdentity: resolution.identity,
+      selectedRemote: resolution.selectedRemote,
+      remotes: resolution.remotes,
+      repoIdentityWarnings: resolution.warnings,
+    };
+  } catch {
+    const resolution = resolveCanonicalRepoIdentity([]);
+    return {
+      ...base,
+      repoIdentity: resolution.identity,
+      selectedRemote: resolution.selectedRemote,
+      remotes: resolution.remotes,
+      repoIdentityWarnings: resolution.warnings,
+    };
+  }
+}
+
 function expandTilde(p: string): string {
   if (p === '~' || p.startsWith('~/')) {
     const homeDir = os.homedir();
@@ -525,12 +586,15 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
           }
         }
 
+        const identityFields = await resolveRepoIdentityFields(p, isGitRepo, exec);
+
         return {
           path: p,
           name,
           isGitRepo,
           defaultBranch,
           currentBranch,
+          ...identityFields,
           ...getRepoWebhookFields(config, p, ownerRepo),
         };
       })
@@ -606,12 +670,18 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
         /* detached HEAD */
       }
     }
+    const identityFields = await resolveRepoIdentityFields(
+      resolved,
+      isGitRepo,
+      exec
+    );
     const workspace: Repo = {
       path: resolved,
       name: path.basename(resolved),
       isGitRepo,
       defaultBranch,
       currentBranch,
+      ...identityFields,
       ...getRepoWebhookFields(config, resolved),
     };
 
@@ -747,12 +817,14 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
             /* detached HEAD */
           }
         }
+        const identityFields = await resolveRepoIdentityFields(p, isGitRepo, exec);
         return {
           path: p,
           name,
           isGitRepo,
           defaultBranch,
           currentBranch,
+          ...identityFields,
           ...getRepoWebhookFields(config, p),
         };
       })

--- a/shared/identity.ts
+++ b/shared/identity.ts
@@ -1,0 +1,55 @@
+export type NodeId = string;
+export type LocalSessionId = string;
+export type GlobalSessionId = string;
+export type RepoIdentity = string;
+export type RepoInstanceId = string;
+export type WorktreeInstanceId = string;
+
+export const DEFAULT_LOCAL_NODE_ID: NodeId = 'local';
+
+function hasValue(value: string): boolean {
+  return value.trim().length > 0;
+}
+
+export function createGlobalSessionId(
+  nodeId: NodeId,
+  localSessionId: LocalSessionId
+): GlobalSessionId {
+  if (!hasValue(nodeId)) throw new Error('nodeId is required');
+  if (!hasValue(localSessionId)) throw new Error('localSessionId is required');
+  return `${encodeURIComponent(nodeId)}:${encodeURIComponent(localSessionId)}`;
+}
+
+export function parseGlobalSessionId(
+  globalSessionId: GlobalSessionId
+): { nodeId: NodeId; localSessionId: LocalSessionId } | null {
+  const separator = globalSessionId.indexOf(':');
+  if (separator <= 0 || separator === globalSessionId.length - 1) return null;
+
+  try {
+    const nodeId = decodeURIComponent(globalSessionId.slice(0, separator));
+    const localSessionId = decodeURIComponent(globalSessionId.slice(separator + 1));
+    if (!hasValue(nodeId) || !hasValue(localSessionId)) return null;
+    return { nodeId, localSessionId };
+  } catch {
+    return null;
+  }
+}
+
+export function createRepoInstanceId(
+  nodeId: NodeId,
+  localPath: string
+): RepoInstanceId {
+  if (!hasValue(nodeId)) throw new Error('nodeId is required');
+  if (!hasValue(localPath)) throw new Error('localPath is required');
+  return `${nodeId}:${localPath}`;
+}
+
+export function createWorktreeInstanceId(
+  nodeId: NodeId,
+  localPath: string
+): WorktreeInstanceId {
+  if (!hasValue(nodeId)) throw new Error('nodeId is required');
+  if (!hasValue(localPath)) throw new Error('localPath is required');
+  return `${nodeId}:${localPath}`;
+}

--- a/shared/identity.ts
+++ b/shared/identity.ts
@@ -11,45 +11,79 @@ function hasValue(value: string): boolean {
   return value.trim().length > 0;
 }
 
+function createScopedId(
+  nodeId: NodeId,
+  localId: string,
+  localIdName: string
+): string {
+  if (!hasValue(nodeId)) throw new Error('nodeId is required');
+  if (!hasValue(localId)) throw new Error(`${localIdName} is required`);
+  return `${encodeURIComponent(nodeId)}:${encodeURIComponent(localId)}`;
+}
+
+function parseScopedId(
+  scopedId: string
+): { nodeId: NodeId; localId: string } | null {
+  const separator = scopedId.indexOf(':');
+  if (
+    separator <= 0 ||
+    separator === scopedId.length - 1 ||
+    separator !== scopedId.lastIndexOf(':')
+  ) {
+    return null;
+  }
+
+  try {
+    const nodeId = decodeURIComponent(scopedId.slice(0, separator));
+    const localId = decodeURIComponent(scopedId.slice(separator + 1));
+    if (!hasValue(nodeId) || !hasValue(localId)) return null;
+    return { nodeId, localId };
+  } catch {
+    return null;
+  }
+}
+
 export function createGlobalSessionId(
   nodeId: NodeId,
   localSessionId: LocalSessionId
 ): GlobalSessionId {
-  if (!hasValue(nodeId)) throw new Error('nodeId is required');
-  if (!hasValue(localSessionId)) throw new Error('localSessionId is required');
-  return `${encodeURIComponent(nodeId)}:${encodeURIComponent(localSessionId)}`;
+  return createScopedId(nodeId, localSessionId, 'localSessionId');
 }
 
 export function parseGlobalSessionId(
   globalSessionId: GlobalSessionId
 ): { nodeId: NodeId; localSessionId: LocalSessionId } | null {
-  const separator = globalSessionId.indexOf(':');
-  if (separator <= 0 || separator === globalSessionId.length - 1) return null;
-
-  try {
-    const nodeId = decodeURIComponent(globalSessionId.slice(0, separator));
-    const localSessionId = decodeURIComponent(globalSessionId.slice(separator + 1));
-    if (!hasValue(nodeId) || !hasValue(localSessionId)) return null;
-    return { nodeId, localSessionId };
-  } catch {
-    return null;
-  }
+  const parsed = parseScopedId(globalSessionId);
+  if (!parsed) return null;
+  return { nodeId: parsed.nodeId, localSessionId: parsed.localId };
 }
 
 export function createRepoInstanceId(
   nodeId: NodeId,
   localPath: string
 ): RepoInstanceId {
-  if (!hasValue(nodeId)) throw new Error('nodeId is required');
-  if (!hasValue(localPath)) throw new Error('localPath is required');
-  return `${nodeId}:${localPath}`;
+  return createScopedId(nodeId, localPath, 'localPath');
+}
+
+export function parseRepoInstanceId(
+  repoInstanceId: RepoInstanceId
+): { nodeId: NodeId; localPath: string } | null {
+  const parsed = parseScopedId(repoInstanceId);
+  if (!parsed) return null;
+  return { nodeId: parsed.nodeId, localPath: parsed.localId };
 }
 
 export function createWorktreeInstanceId(
   nodeId: NodeId,
   localPath: string
 ): WorktreeInstanceId {
-  if (!hasValue(nodeId)) throw new Error('nodeId is required');
-  if (!hasValue(localPath)) throw new Error('localPath is required');
-  return `${nodeId}:${localPath}`;
+  return createScopedId(nodeId, localPath, 'localPath');
+}
+
+export function parseWorktreeInstanceId(
+  worktreeInstanceId: WorktreeInstanceId
+): { nodeId: NodeId; localPath: string } | null {
+  const parsed = parseScopedId(worktreeInstanceId);
+  if (!parsed) return null;
+  return { nodeId: parsed.nodeId, localPath: parsed.localId };
 }

--- a/shared/repo-identity.ts
+++ b/shared/repo-identity.ts
@@ -109,7 +109,7 @@ export function normalizeRemoteUrl(rawUrl: string): NormalizedRemoteIdentity {
   if (parsed.host === 'github.com') {
     const owner = segments[0]?.toLowerCase() ?? null;
     const name = segments[1]?.toLowerCase() ?? null;
-    if (!owner || !name) {
+    if (!owner || !name || segments.length !== 2) {
       return {
         identity: null,
         provider: null,

--- a/shared/repo-identity.ts
+++ b/shared/repo-identity.ts
@@ -1,0 +1,226 @@
+import type { RepoIdentity } from './identity.js';
+
+export type RemoteProvider = 'github' | 'git';
+export type RepoIdentityWarning =
+  | 'missing-remotes'
+  | 'multiple-remotes'
+  | 'malformed-remote-url'
+  | 'fork-upstream-ambiguity'
+  | 'selected-non-origin-remote';
+
+export interface RemoteDescriptor {
+  name: string;
+  url: string;
+}
+
+export interface NormalizedRemoteIdentity {
+  identity: RepoIdentity | null;
+  provider: RemoteProvider | null;
+  host: string | null;
+  path: string | null;
+  owner: string | null;
+  name: string | null;
+  warning?: RepoIdentityWarning;
+}
+
+export interface ResolvedRemoteIdentity extends RemoteDescriptor {
+  identity: RepoIdentity | null;
+  provider: RemoteProvider | null;
+  host: string | null;
+  path: string | null;
+  owner: string | null;
+  repoName: string | null;
+  warning?: RepoIdentityWarning;
+}
+
+export interface CanonicalRepoIdentityResolution {
+  identity: RepoIdentity | null;
+  selectedRemote: ResolvedRemoteIdentity | null;
+  remotes: ResolvedRemoteIdentity[];
+  warnings: RepoIdentityWarning[];
+}
+
+interface ParsedRemoteUrl {
+  host: string;
+  path: string;
+}
+
+function stripGitSuffix(remotePath: string): string {
+  return remotePath.replace(/^\/+/, '').replace(/\/+$/, '').replace(/\.git$/i, '');
+}
+
+function parseUrlRemote(rawUrl: string): ParsedRemoteUrl | null {
+  try {
+    const parsed = new URL(rawUrl);
+    if (!parsed.hostname) return null;
+    const remotePath = stripGitSuffix(parsed.pathname);
+    if (!remotePath) return null;
+    return { host: parsed.hostname.toLowerCase(), path: remotePath };
+  } catch {
+    return null;
+  }
+}
+
+function parseScpLikeRemote(rawUrl: string): ParsedRemoteUrl | null {
+  if (/\s/.test(rawUrl)) return null;
+  const match = rawUrl.match(/^(?:[^@/:]+@)?([^:/]+):(.+)$/);
+  const host = match?.[1]?.toLowerCase();
+  const rawPath = match?.[2];
+  if (!host || !rawPath) return null;
+  const remotePath = stripGitSuffix(rawPath);
+  if (!remotePath || remotePath.includes(':')) return null;
+  return { host, path: remotePath };
+}
+
+function parseRemote(rawUrl: string): ParsedRemoteUrl | null {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return null;
+  return parseUrlRemote(trimmed) ?? parseScpLikeRemote(trimmed);
+}
+
+export function normalizeRemoteUrl(rawUrl: string): NormalizedRemoteIdentity {
+  const parsed = parseRemote(rawUrl);
+  if (!parsed) {
+    return {
+      identity: null,
+      provider: null,
+      host: null,
+      path: null,
+      owner: null,
+      name: null,
+      warning: 'malformed-remote-url',
+    };
+  }
+
+  const segments = parsed.path.split('/').filter(Boolean);
+  const repoName = segments[segments.length - 1] ?? null;
+  if (!repoName) {
+    return {
+      identity: null,
+      provider: null,
+      host: parsed.host,
+      path: parsed.path,
+      owner: null,
+      name: null,
+      warning: 'malformed-remote-url',
+    };
+  }
+
+  if (parsed.host === 'github.com') {
+    const owner = segments[0]?.toLowerCase() ?? null;
+    const name = segments[1]?.toLowerCase() ?? null;
+    if (!owner || !name) {
+      return {
+        identity: null,
+        provider: null,
+        host: parsed.host,
+        path: parsed.path,
+        owner,
+        name,
+        warning: 'malformed-remote-url',
+      };
+    }
+    return {
+      identity: `github.com/${owner}/${name}`,
+      provider: 'github',
+      host: parsed.host,
+      path: `${owner}/${name}`,
+      owner,
+      name,
+    };
+  }
+
+  return {
+    identity: `${parsed.host}/${parsed.path}`,
+    provider: 'git',
+    host: parsed.host,
+    path: parsed.path,
+    owner: segments.length > 1 ? (segments[0] ?? null) : null,
+    name: repoName,
+  };
+}
+
+function toResolvedRemote(remote: RemoteDescriptor): ResolvedRemoteIdentity {
+  const normalized = normalizeRemoteUrl(remote.url);
+  return {
+    name: remote.name,
+    url: remote.url,
+    identity: normalized.identity,
+    provider: normalized.provider,
+    host: normalized.host,
+    path: normalized.path,
+    owner: normalized.owner,
+    repoName: normalized.name,
+    ...(normalized.warning ? { warning: normalized.warning } : {}),
+  };
+}
+
+function uniqueWarnings(warnings: RepoIdentityWarning[]): RepoIdentityWarning[] {
+  return Array.from(new Set(warnings));
+}
+
+/**
+ * Resolve a logical repository identity from configured remotes.
+ *
+ * Selection policy:
+ * - prefer a valid `origin` remote;
+ * - otherwise use the lexicographically first valid remote and warn;
+ * - never invent a canonical identity from the local path/basename.
+ *
+ * Warning policy is intentionally conservative for federated/node-aware Relay:
+ * multiple remotes are surfaced, malformed URLs are kept in the remote list,
+ * and different origin/upstream identities emit `fork-upstream-ambiguity` so
+ * callers can distinguish "this checkout path" from "the logical upstream".
+ */
+export function resolveCanonicalRepoIdentity(
+  remotes: RemoteDescriptor[]
+): CanonicalRepoIdentityResolution {
+  const normalizedRemotes = remotes.map(toResolvedRemote);
+  const validRemotes = normalizedRemotes.filter((remote) => remote.identity !== null);
+  const warnings: RepoIdentityWarning[] = [];
+
+  if (normalizedRemotes.length === 0) warnings.push('missing-remotes');
+  if (normalizedRemotes.length > 1) warnings.push('multiple-remotes');
+  if (normalizedRemotes.some((remote) => remote.warning === 'malformed-remote-url')) {
+    warnings.push('malformed-remote-url');
+  }
+
+  const origin = validRemotes.find((remote) => remote.name === 'origin');
+  const selected =
+    origin ??
+    Array.from(validRemotes).sort((a, b) => a.name.localeCompare(b.name))[0] ??
+    null;
+
+  if (selected && selected.name !== 'origin') {
+    warnings.push('selected-non-origin-remote');
+  }
+
+  const originRemote = validRemotes.find((remote) => remote.name === 'origin');
+  const upstreamRemote = validRemotes.find((remote) => remote.name === 'upstream');
+  if (
+    originRemote?.identity &&
+    upstreamRemote?.identity &&
+    originRemote.identity !== upstreamRemote.identity
+  ) {
+    warnings.push('fork-upstream-ambiguity');
+  }
+
+  return {
+    identity: selected?.identity ?? null,
+    selectedRemote: selected,
+    remotes: normalizedRemotes,
+    warnings: uniqueWarnings(warnings),
+  };
+}
+
+export function parseGitRemoteVerbose(stdout: string): RemoteDescriptor[] {
+  const byName = new Map<string, RemoteDescriptor>();
+  for (const line of stdout.split('\n')) {
+    const match = line.match(/^(\S+)\s+(\S+)\s+\((?:fetch|push)\)$/);
+    const remoteName = match?.[1];
+    const url = match?.[2];
+    if (!remoteName || !url || byName.has(remoteName)) continue;
+    byName.set(remoteName, { name: remoteName, url });
+  }
+  return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/test/identity.test.ts
+++ b/test/identity.test.ts
@@ -6,6 +6,8 @@ import {
   createRepoInstanceId,
   createWorktreeInstanceId,
   parseGlobalSessionId,
+  parseRepoInstanceId,
+  parseWorktreeInstanceId,
 } from '../shared/identity.js';
 
 describe('shared identity helpers', () => {
@@ -27,13 +29,44 @@ describe('shared identity helpers', () => {
     expect(parseGlobalSessionId('not-global')).toBeNull();
     expect(parseGlobalSessionId(':missing-node')).toBeNull();
     expect(parseGlobalSessionId('node:')).toBeNull();
+    expect(parseGlobalSessionId('node:session:raw-delimiter')).toBeNull();
+    expect(parseGlobalSessionId('node:%')).toBeNull();
   });
 
-  it('scopes repo and worktree instance ids by node plus local path', () => {
-    const repoInstanceId = createRepoInstanceId('desktop', '/src/relay-ide');
-    const worktreeInstanceId = createWorktreeInstanceId('desktop', '/src/relay-ide/.worktrees/a');
+  it('encodes repo and worktree instance ids before joining node and local path', () => {
+    const nodeId = 'desktop:node/with delimiter';
+    const repoPath = '/src/relay ide:main';
+    const worktreePath = '/src/relay ide/.worktrees/feature:one';
 
-    expect(repoInstanceId).toBe('desktop:/src/relay-ide');
-    expect(worktreeInstanceId).toBe('desktop:/src/relay-ide/.worktrees/a');
+    const repoInstanceId = createRepoInstanceId(nodeId, repoPath);
+    const worktreeInstanceId = createWorktreeInstanceId(nodeId, worktreePath);
+
+    expect(repoInstanceId).toBe(
+      'desktop%3Anode%2Fwith%20delimiter:%2Fsrc%2Frelay%20ide%3Amain'
+    );
+    expect(worktreeInstanceId).toBe(
+      'desktop%3Anode%2Fwith%20delimiter:%2Fsrc%2Frelay%20ide%2F.worktrees%2Ffeature%3Aone'
+    );
+    expect(parseRepoInstanceId(repoInstanceId)).toEqual({
+      nodeId,
+      localPath: repoPath,
+    });
+    expect(parseWorktreeInstanceId(worktreeInstanceId)).toEqual({
+      nodeId,
+      localPath: worktreePath,
+    });
+  });
+
+  it('rejects malformed repo and worktree instance ids', () => {
+    for (const malformed of [
+      'not-scoped',
+      ':missing-node',
+      'node:',
+      'node:/raw/path:with-colon',
+      'node:%',
+    ]) {
+      expect(parseRepoInstanceId(malformed)).toBeNull();
+      expect(parseWorktreeInstanceId(malformed)).toBeNull();
+    }
   });
 });

--- a/test/identity.test.ts
+++ b/test/identity.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  createGlobalSessionId,
+  createRepoInstanceId,
+  createWorktreeInstanceId,
+  parseGlobalSessionId,
+} from '../shared/identity.js';
+
+describe('shared identity helpers', () => {
+  it('uses a stable implicit local node for local mode', () => {
+    expect(DEFAULT_LOCAL_NODE_ID).toBe('local');
+  });
+
+  it('round-trips global session ids without assuming local ids are globally unique', () => {
+    const global = createGlobalSessionId('macbook', 'session:with/slashes');
+
+    expect(global).toBe('macbook:session%3Awith%2Fslashes');
+    expect(parseGlobalSessionId(global)).toEqual({
+      nodeId: 'macbook',
+      localSessionId: 'session:with/slashes',
+    });
+  });
+
+  it('rejects malformed global session ids', () => {
+    expect(parseGlobalSessionId('not-global')).toBeNull();
+    expect(parseGlobalSessionId(':missing-node')).toBeNull();
+    expect(parseGlobalSessionId('node:')).toBeNull();
+  });
+
+  it('scopes repo and worktree instance ids by node plus local path', () => {
+    const repoInstanceId = createRepoInstanceId('desktop', '/src/relay-ide');
+    const worktreeInstanceId = createWorktreeInstanceId('desktop', '/src/relay-ide/.worktrees/a');
+
+    expect(repoInstanceId).toBe('desktop:/src/relay-ide');
+    expect(worktreeInstanceId).toBe('desktop:/src/relay-ide/.worktrees/a');
+  });
+});

--- a/test/repo-identity.test.ts
+++ b/test/repo-identity.test.ts
@@ -38,6 +38,21 @@ describe('canonical repo identity', () => {
     });
   });
 
+  it('rejects GitHub remote urls with extra path segments', () => {
+    for (const url of [
+      'https://github.com/Owner/Repo/extra',
+      'https://github.com/Owner/Repo/tree/main',
+      'git@github.com:Owner/Repo/extra.git',
+    ]) {
+      expect(normalizeRemoteUrl(url)).toMatchObject({
+        identity: null,
+        provider: null,
+        host: 'github.com',
+        warning: 'malformed-remote-url',
+      });
+    }
+  });
+
   it('selects origin as primary and warns when upstream differs', () => {
     const resolved = resolveCanonicalRepoIdentity([
       { name: 'upstream', url: 'https://github.com/upstream/relay-ide.git' },

--- a/test/repo-identity.test.ts
+++ b/test/repo-identity.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  normalizeRemoteUrl,
+  resolveCanonicalRepoIdentity,
+} from '../shared/repo-identity.js';
+
+describe('canonical repo identity', () => {
+  it('normalizes common GitHub SSH/HTTPS forms to the same stable identity', () => {
+    for (const url of [
+      'git@github.com:Owner/Repo.git',
+      'https://github.com/Owner/Repo.git',
+      'ssh://git@github.com/Owner/Repo.git',
+    ]) {
+      expect(normalizeRemoteUrl(url)).toMatchObject({
+        identity: 'github.com/owner/repo',
+        provider: 'github',
+        host: 'github.com',
+        owner: 'owner',
+        name: 'repo',
+      });
+    }
+  });
+
+  it('keeps non-GitHub remote identity host/path based instead of basename based', () => {
+    expect(normalizeRemoteUrl('git@gitlab.example.com:Team/Repo.git')).toMatchObject({
+      identity: 'gitlab.example.com/Team/Repo',
+      provider: 'git',
+      host: 'gitlab.example.com',
+      path: 'Team/Repo',
+    });
+  });
+
+  it('returns a warning for malformed remote urls', () => {
+    expect(normalizeRemoteUrl('not a remote url')).toMatchObject({
+      identity: null,
+      warning: 'malformed-remote-url',
+    });
+  });
+
+  it('selects origin as primary and warns when upstream differs', () => {
+    const resolved = resolveCanonicalRepoIdentity([
+      { name: 'upstream', url: 'https://github.com/upstream/relay-ide.git' },
+      { name: 'origin', url: 'git@github.com:fork/relay-ide.git' },
+    ]);
+
+    expect(resolved.identity).toBe('github.com/fork/relay-ide');
+    expect(resolved.selectedRemote?.name).toBe('origin');
+    expect(resolved.warnings).toContain('multiple-remotes');
+    expect(resolved.warnings).toContain('fork-upstream-ambiguity');
+  });
+
+  it('falls back to a non-origin remote with an explicit warning', () => {
+    const resolved = resolveCanonicalRepoIdentity([
+      { name: 'upstream', url: 'https://github.com/acme/project.git' },
+    ]);
+
+    expect(resolved.identity).toBe('github.com/acme/project');
+    expect(resolved.selectedRemote?.name).toBe('upstream');
+    expect(resolved.warnings).toContain('selected-non-origin-remote');
+  });
+
+  it('reports missing remotes without inventing a basename identity', () => {
+    const resolved = resolveCanonicalRepoIdentity([]);
+
+    expect(resolved.identity).toBeNull();
+    expect(resolved.selectedRemote).toBeNull();
+    expect(resolved.warnings).toContain('missing-remotes');
+  });
+});

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -124,6 +124,32 @@ describe('sessions', () => {
     expect(list[0]?.id).toBe(result.id);
   });
 
+  it('does not synthesize repo instance identity without repoPath', () => {
+    const result = sessions.create({
+      repoName: 'shell-only',
+      repoPath: '',
+      worktreePath: null,
+      cwd: '/tmp',
+      command: '/bin/echo',
+      args: ['hello'],
+      cols: 80,
+      rows: 24,
+    });
+
+    createdIds.push(result.id);
+
+    expect(result.nodeId).toBe('local');
+    expect(result.globalSessionId).toBe(`local:${result.id}`);
+    expect(result.repoInstanceId).toBeUndefined();
+    expect(result.worktreeInstanceId).toBeUndefined();
+
+    const listed = sessions.list().find((session) => session.id === result.id);
+    expect(listed).toBeDefined();
+    expect(listed?.globalSessionId).toBe(`local:${result.id}`);
+    expect(listed?.repoInstanceId).toBeUndefined();
+    expect(listed?.worktreeInstanceId).toBeUndefined();
+  });
+
   it('get returns session by id', () => {
     const result = sessions.create({
       repoName: 'test-repo',

--- a/test/workspace-identity.test.ts
+++ b/test/workspace-identity.test.ts
@@ -57,12 +57,13 @@ function makeExec(remotes: Record<string, Array<{ name: string; url: string }>>)
   };
 }
 
-describe('GET /workspaces repo identity', () => {
+describe('workspace repo identity', () => {
   it('exposes canonical identity plus node-local path and instance ids', async () => {
     const repo = path.join(tmpDir, 'relay-ide');
     fs.mkdirSync(repo, { recursive: true });
     const configPath = makeTempConfig('identity', { repos: [repo] });
     const app = express();
+    app.use(express.json());
     app.use(
       '/workspaces',
       createWorkspaceRouter({
@@ -86,7 +87,7 @@ describe('GET /workspaces repo identity', () => {
       expect(workspace.localPath).toBe(repo);
       expect(workspace.nodeId).toBe('local');
       expect(workspace.repoIdentity).toBe('github.com/donovan-yohan/relay-ide');
-      expect(workspace.repoInstanceId).toBe(`local:${repo}`);
+      expect(workspace.repoInstanceId).toBe(`local:${encodeURIComponent(repo)}`);
       expect(workspace.selectedRemote?.name).toBe('origin');
       expect(workspace.repoIdentityWarnings).toContain('fork-upstream-ambiguity');
       expect(workspace.remotes).toEqual(
@@ -95,6 +96,56 @@ describe('GET /workspaces repo identity', () => {
           expect.objectContaining({ name: 'upstream', identity: 'github.com/nousresearch/relay-ide' }),
         ])
       );
+    } finally {
+      await close();
+    }
+  });
+
+  it('includes identity fields for POST /workspaces/bulk added repos', async () => {
+    const repo = path.join(tmpDir, 'bulk relay:repo');
+    fs.mkdirSync(repo, { recursive: true });
+    const configPath = makeTempConfig('bulk-identity', { repos: [] });
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/workspaces',
+      createWorkspaceRouter({
+        configPath,
+        execAsync: makeExec({
+          [repo]: [
+            { name: 'origin', url: 'git@github.com:donovan-yohan/relay-ide.git' },
+          ],
+        }) as any,
+      })
+    );
+    const { url, close } = await createTestServer(app);
+    try {
+      const response = await fetch(`${url}/workspaces/bulk`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ paths: [repo] }),
+      });
+      expect(response.status).toBe(201);
+      const payload = (await response.json()) as { added: any[]; errors: any[] };
+      const workspace = payload.added[0];
+
+      expect(payload.errors).toEqual([]);
+      expect(workspace.path).toBe(repo);
+      expect(workspace.localPath).toBe(repo);
+      expect(workspace.nodeId).toBe('local');
+      expect(workspace.repoIdentity).toBe('github.com/donovan-yohan/relay-ide');
+      expect(workspace.repoInstanceId).toBe(`local:${encodeURIComponent(repo)}`);
+      expect(workspace.selectedRemote?.name).toBe('origin');
+      expect(workspace.selectedRemote?.identity).toBe(
+        'github.com/donovan-yohan/relay-ide'
+      );
+      expect(workspace.remotes).toEqual([
+        expect.objectContaining({
+          name: 'origin',
+          identity: 'github.com/donovan-yohan/relay-ide',
+        }),
+      ]);
+      expect(workspace.repoIdentityWarnings).toEqual([]);
     } finally {
       await close();
     }

--- a/test/workspace-identity.test.ts
+++ b/test/workspace-identity.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import express from 'express';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { saveConfig, DEFAULTS } from '../server/config.js';
+import { createWorkspaceRouter } from '../server/workspaces.js';
+import type { Config } from '../server/types.js';
+import { createTestServer } from './helpers/test-server.js';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'workspace-identity-'));
+
+function makeTempConfig(name: string, overrides: Partial<Config>): string {
+  const configPath = path.join(tmpDir, `${name}.json`);
+  saveConfig(configPath, { ...DEFAULTS, ...overrides });
+  return configPath;
+}
+
+function makeExec(remotes: Record<string, Array<{ name: string; url: string }>>) {
+  return async (_file: string, args: string[], opts?: { cwd?: string }) => {
+    const cwd = opts?.cwd;
+    if (!cwd) throw new Error('cwd required');
+
+    if (args.join(' ') === 'rev-parse --git-dir') {
+      return { stdout: '.git\n', stderr: '' };
+    }
+
+    if (args.join(' ') === 'symbolic-ref refs/remotes/origin/HEAD --short') {
+      return { stdout: 'origin/nightly\n', stderr: '' };
+    }
+
+    if (args.join(' ') === 'remote -v') {
+      const repoRemotes = remotes[cwd] ?? [];
+      return {
+        stdout: repoRemotes
+          .flatMap((remote) => [
+            `${remote.name}\t${remote.url} (fetch)`,
+            `${remote.name}\t${remote.url} (push)`,
+          ])
+          .join('\n'),
+        stderr: '',
+      };
+    }
+
+    if (args.join(' ') === 'remote get-url origin') {
+      const remote = (remotes[cwd] ?? []).find((item) => item.name === 'origin');
+      if (!remote) throw new Error(`no origin for ${cwd}`);
+      return { stdout: `${remote.url}\n`, stderr: '' };
+    }
+
+    if (args.join(' ') === 'symbolic-ref --short HEAD') {
+      return { stdout: 'nightly\n', stderr: '' };
+    }
+
+    throw new Error(`unexpected git args: ${args.join(' ')}`);
+  };
+}
+
+describe('GET /workspaces repo identity', () => {
+  it('exposes canonical identity plus node-local path and instance ids', async () => {
+    const repo = path.join(tmpDir, 'relay-ide');
+    fs.mkdirSync(repo, { recursive: true });
+    const configPath = makeTempConfig('identity', { repos: [repo] });
+    const app = express();
+    app.use(
+      '/workspaces',
+      createWorkspaceRouter({
+        configPath,
+        execAsync: makeExec({
+          [repo]: [
+            { name: 'origin', url: 'git@github.com:donovan-yohan/relay-ide.git' },
+            { name: 'upstream', url: 'https://github.com/NousResearch/relay-ide.git' },
+          ],
+        }) as any,
+      })
+    );
+    const { url, close } = await createTestServer(app);
+    try {
+      const response = await fetch(`${url}/workspaces`);
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as { workspaces: any[] };
+      const workspace = payload.workspaces[0];
+
+      expect(workspace.path).toBe(repo);
+      expect(workspace.localPath).toBe(repo);
+      expect(workspace.nodeId).toBe('local');
+      expect(workspace.repoIdentity).toBe('github.com/donovan-yohan/relay-ide');
+      expect(workspace.repoInstanceId).toBe(`local:${repo}`);
+      expect(workspace.selectedRemote?.name).toBe('origin');
+      expect(workspace.repoIdentityWarnings).toContain('fork-upstream-ambiguity');
+      expect(workspace.remotes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'origin', identity: 'github.com/donovan-yohan/relay-ide' }),
+          expect.objectContaining({ name: 'upstream', identity: 'github.com/nousresearch/relay-ide' }),
+        ])
+      );
+    } finally {
+      await close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add shared identity primitives for node-scoped session, repo checkout, and worktree IDs
- add canonical repo identity resolution from git remotes with documented multi-remote fallback behavior
- surface local-mode identity fields on repo/session API summaries and shared frontend/backend types

## Tests
- npm run check
- npm test
- npm run build

Refs #317
Closes #372
Closes #373
