### PR TITLE
Add node-scoped event boundaries

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,10 @@ import {
 import type { Repo, PullRequest, SessionSummary } from './lib/types.js';
 import { estimateTerminalDimensions } from './lib/utils.js';
 import { createSessionWithoutActivation } from './lib/session-utils.js';
+import {
+  resolveSessionByKey,
+  scopedSessionKey,
+} from './lib/session-keys.js';
 import { killSession } from './lib/api.js';
 import {
   getMainWorkspaceSessions,
@@ -189,9 +193,7 @@ function useTerminalDerivedState() {
 
   const activeSession = useMemo(
     () =>
-      activeSessionId
-        ? sessions.find((s) => s.id === activeSessionId)
-        : undefined,
+      activeSessionId ? resolveSessionByKey(sessions, activeSessionId) : undefined,
     [activeSessionId, sessions]
   );
 
@@ -561,12 +563,10 @@ function TerminalAreaContent({
   }, [getToolbarTerminalHandle]);
   const handleTerminalFilePathClick = useCallback(
     (clickedPath: string) => {
-      const currentActiveSessionId =
-        useSessionsStore.getState().activeSessionId;
+      const sessionsState = useSessionsStore.getState();
+      const currentActiveSessionId = sessionsState.activeSessionId;
       const currentActiveSession = currentActiveSessionId
-        ? useSessionsStore
-            .getState()
-            .sessions.find((s) => s.id === currentActiveSessionId)
+        ? resolveSessionByKey(sessionsState.sessions, currentActiveSessionId)
         : undefined;
       const cwd =
         currentActiveSession?.worktreePath ??
@@ -867,9 +867,7 @@ export default function App() {
   // activeSession and activeWorkspaceCwd are needed for FilePicker
   const activeSession = useMemo(
     () =>
-      activeSessionId
-        ? sessions.find((s) => s.id === activeSessionId)
-        : undefined,
+      activeSessionId ? resolveSessionByKey(sessions, activeSessionId) : undefined,
     [activeSessionId, sessions]
   );
 
@@ -1080,7 +1078,7 @@ export default function App() {
         !sessionParam &&
         currentSessions.length === 1
       ) {
-        handleSelectSession(currentSessions[0]!.id);
+        handleSelectSession(scopedSessionKey(currentSessions[0]!));
       }
 
       // Initialize notifications for existing sessions

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -22,6 +22,7 @@ import { getAllActions } from '../lib/actions/registry.js';
 import { formatShortcut } from '../lib/actions/shortcuts.js';
 import type { ActionContext, Action } from '../lib/actions/types.js';
 import { isMobileDevice, isMac } from '../lib/utils.js';
+import { scopedSessionKey } from '../lib/session-keys.js';
 import './CommandPalette.css';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -471,7 +472,7 @@ function usePaletteHandlers(
       if (item.type === 'workspace')
         onSelectWorkspace((item.data as Repo).path);
       else if (item.type === 'session')
-        onSelectSession((item.data as SessionSummary).id);
+        onSelectSession(scopedSessionKey(item.data as SessionSummary));
       else if (item.type === 'attention' || item.type === 'pr')
         onSelectPr(item.data as PullRequest);
       else if (item.type === 'setting')

--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -24,6 +24,7 @@ import { createRepoWebhook } from '../lib/api.js';
 import { deriveRepoWebhookStatus } from '../lib/repo-source.js';
 import { showToast } from '../lib/stores/toasts.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
+import { scopedSessionKey, sessionKeyMatches } from '../lib/session-keys.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import './RepoItem.css';
 
@@ -278,7 +279,7 @@ function SessionGroupRow({
         .filter(Boolean)
         .join(' ')}
       data-track="sidebar.session.click"
-      onClick={() => onSelectSession(rep.id)}
+      onClick={() => onSelectSession(scopedSessionKey(rep))}
       onTouchEnd={cancelLongPress}
       onTouchMove={cancelLongPress}
     >
@@ -646,9 +647,9 @@ export function RepoItem({
             const isRepoRoot = groupPath === repo.path;
             if (rep) {
               const matchedPr = findPr(groupSessions[0]?.branchName ?? '');
-              const isSelected = groupSessions.some(
-                (s) => activeSessionId === s.id
-              );
+              const isSelected =
+                activeSessionId !== null &&
+                groupSessions.some((s) => sessionKeyMatches(s, activeSessionId));
               const sidebarItem = sidebarItemById.get(groupPath);
               const attention =
                 sidebarItem !== undefined &&

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -25,6 +25,7 @@ import { useUiStore, DEFAULT_TERMINAL_FONT_SIZE } from '../lib/stores/ui.js';
 import { useConfigStore } from '../lib/stores/config.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { clampFontSize, zoomPercentage } from '../lib/terminal-zoom.js';
+import { resolveSessionByKey } from '../lib/session-keys.js';
 import {
   detectRendererContext,
   pickTerminalRenderer,
@@ -44,7 +45,10 @@ export interface TerminalHandle {
 }
 
 export interface TerminalProps {
+  /** Local session id used by legacy REST endpoints such as image upload. */
   sessionId: string | null;
+  /** Scoped node/global key used for terminal handles and PTY routing. */
+  sessionKey?: string | null;
   onImageUpload?: (text: string, showInsert: boolean, path?: string) => void;
   useTmux?: boolean;
   onCopyModeChange?: (active: boolean) => void;
@@ -751,7 +755,7 @@ function registerEscapeSequenceSanitizers(
 
 function useTerminalSetup(
   containerRef: React.RefObject<HTMLDivElement | null>,
-  sessionId: string | null,
+  ptySessionKey: string | null,
   companionMode: boolean,
   onFilePathClick: ((path: string) => void) | undefined,
   updateScrollbar: () => void
@@ -760,14 +764,14 @@ function useTerminalSetup(
   const fitAddonRef = useRef<FitAddon | null>(null);
   const terminalFontSize = useUiStore((s) => s.terminalFontSize);
 
-  const sessionIdRef = useRef(sessionId);
-  sessionIdRef.current = sessionId;
+  const ptySessionKeyRef = useRef(ptySessionKey);
+  ptySessionKeyRef.current = ptySessionKey;
   const sendData = useCallback((data: string) => {
-    const id = sessionIdRef.current;
+    const id = ptySessionKeyRef.current;
     if (id) sendPtyData(id, data);
   }, []);
   const sendResize = useCallback((cols: number, rows: number) => {
-    const id = sessionIdRef.current;
+    const id = ptySessionKeyRef.current;
     if (id) sendPtyResize(id, cols, rows);
   }, []);
 
@@ -905,10 +909,10 @@ function useTerminalSetup(
     };
   }, []); // intentionally empty: terminal is created once per mount
 
-  // React to sessionId changes
+  // React to ptySessionKey changes
   useEffect(() => {
     const term = termRef.current;
-    if (!sessionId || !term || companionMode) return undefined;
+    if (!ptySessionKey || !term || companionMode) return undefined;
 
     // Full reset (RIS) — synchronously resets parser state, all terminal
     // modes (mouse tracking, bracketed paste, alternate screen), and clears
@@ -922,11 +926,15 @@ function useTerminalSetup(
     fitAddonRef.current?.fit();
     term.refresh(0, term.rows - 1);
     connectPtySocket(
-      sessionId,
+      ptySessionKey,
       term,
       () => {
         if (termRef.current)
-          sendPtyResize(sessionId, termRef.current.cols, termRef.current.rows);
+          sendPtyResize(
+            ptySessionKey,
+            termRef.current.cols,
+            termRef.current.rows
+          );
       },
       () => {
         /* session ended */
@@ -934,9 +942,9 @@ function useTerminalSetup(
     );
 
     return () => {
-      disconnectPtySocket(sessionId);
+      disconnectPtySocket(ptySessionKey);
     };
-  }, [sessionId, companionMode]);
+  }, [ptySessionKey, companionMode]);
 
   return { termRef, fitAddonRef, fit };
 }
@@ -1050,6 +1058,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
   function Terminal(
     {
       sessionId,
+      sessionKey,
       onImageUpload,
       useTmux = true,
       onCopyModeChange,
@@ -1061,27 +1070,30 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
     const containerRef = useRef<HTMLDivElement>(null);
     const scrollbarRef = useRef<HTMLDivElement>(null);
     const thumbRef = useRef<HTMLDivElement>(null);
+    const ptySessionKey = sessionKey ?? sessionId;
 
-    const sessionIdRef = useRef(sessionId);
-    sessionIdRef.current = sessionId;
+    const ptySessionKeyRef = useRef(ptySessionKey);
+    ptySessionKeyRef.current = ptySessionKey;
     const sendData = useCallback((data: string) => {
-      const id = sessionIdRef.current;
+      const id = ptySessionKeyRef.current;
       if (id) sendPtyData(id, data);
     }, []);
 
     const claudeFullscreen = useConfigStore((s) => s.claudeFullscreen);
     const activeAgent = useSessionsStore(
-      (s) => s.sessions.find((sess) => sess.id === sessionId)?.agent
+      (s) => resolveSessionByKey(s.sessions, ptySessionKey)?.agent
     );
     const isPtyReconnecting = useSessionsStore((s) =>
-      sessionId ? s.reconnectingPtySessionIds[sessionId] === true : false
+      ptySessionKey
+        ? s.reconnectingPtySessionIds[ptySessionKey] === true
+        : false
     );
     const isFullscreenTerminal =
       (claudeFullscreen && activeAgent === 'claude') || useTmux;
 
     const { termRef, fit } = useTerminalSetup(
       containerRef,
-      sessionId,
+      ptySessionKey,
       companionMode,
       onFilePathClick,
       () => updateSb()
@@ -1134,14 +1146,14 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
     useImperativeHandle(ref, () => handle, [handle]);
 
     useEffect(() => {
-      if (!sessionId) return undefined;
-      setTerminalHandle(sessionId, handle);
-      return () => setTerminalHandle(sessionId, null);
-    }, [sessionId, handle]);
+      if (!ptySessionKey) return undefined;
+      setTerminalHandle(ptySessionKey, handle);
+      return () => setTerminalHandle(ptySessionKey, null);
+    }, [ptySessionKey, handle]);
 
     useEffect(() => {
       if (
-        sessionId &&
+        ptySessionKey &&
         isPtyReconnecting &&
         termRef.current &&
         !companionMode
@@ -1158,7 +1170,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(
         termRef.current.refresh(0, termRef.current.rows - 1);
       }
     }, [
-      sessionId,
+      ptySessionKey,
       isPtyReconnecting,
       companionMode,
       isFullscreenTerminal,

--- a/frontend/src/components/UtilityRailStatsPanel.tsx
+++ b/frontend/src/components/UtilityRailStatsPanel.tsx
@@ -28,7 +28,7 @@ export function UtilityRailStatsPanel({
   );
   const aggregate = summarizeSessionSetTelemetry(workspaceSessions);
   const activeTelemetry = activeSession
-    ? summarizeSessionTelemetry(activeSession.id)
+    ? summarizeSessionTelemetry(activeSession)
     : null;
 
   return (

--- a/frontend/src/components/WorkspaceArea.tsx
+++ b/frontend/src/components/WorkspaceArea.tsx
@@ -11,10 +11,7 @@ import {
 import { useWorkspaceLayoutStore } from '../lib/stores/workspace-layout-store.js';
 import type { SummaryContext } from '../lib/workspace-summary.js';
 import type { SessionSummary } from '../lib/types.js';
-import {
-  resolveSessionByKey,
-  scopedSessionKey,
-} from '../lib/session-keys.js';
+import { resolveSessionByKey, scopedSessionKey } from '../lib/session-keys.js';
 import { FileTabContent, type FileTabContentProps } from './FileTabContent.js';
 import { useFileDiff, useInvalidateFileDiff } from '../hooks/useFileDiff.js';
 import { useFileContent } from '../hooks/useFileContent.js';
@@ -89,7 +86,9 @@ function FileTabContentBridge({
     (s) => s.utilityRailByWorkspace[workspacePath]?.review
   );
   const globalFileDiffSource = useUiStore((s) => s.fileDiffSource);
-  const globalFileDiffDefaultBranch = useUiStore((s) => s.fileDiffDefaultBranch);
+  const globalFileDiffDefaultBranch = useUiStore(
+    (s) => s.fileDiffDefaultBranch
+  );
   const fileDiffSource = reviewState?.diffSource ?? globalFileDiffSource;
   const fileDiffDefaultBranch =
     reviewState?.defaultBranch ?? globalFileDiffDefaultBranch;
@@ -206,6 +205,7 @@ function SessionContentMount({
     <div className="ws-session-mount ws-session-mount--pty">
       <Terminal
         sessionId={session.id}
+        sessionKey={scopedSessionKey(session)}
         useTmux={session.useTmux !== false}
         onImageUpload={onImageUpload}
         onCopyModeChange={onCopyModeChange}

--- a/frontend/src/components/WorkspaceArea.tsx
+++ b/frontend/src/components/WorkspaceArea.tsx
@@ -11,6 +11,10 @@ import {
 import { useWorkspaceLayoutStore } from '../lib/stores/workspace-layout-store.js';
 import type { SummaryContext } from '../lib/workspace-summary.js';
 import type { SessionSummary } from '../lib/types.js';
+import {
+  resolveSessionByKey,
+  scopedSessionKey,
+} from '../lib/session-keys.js';
 import { FileTabContent, type FileTabContentProps } from './FileTabContent.js';
 import { useFileDiff, useInvalidateFileDiff } from '../hooks/useFileDiff.js';
 import { useFileContent } from '../hooks/useFileContent.js';
@@ -36,13 +40,13 @@ function uiTabId(tab: OpenFileTab): string {
 function sessionToWorkspaceTab(session: SessionSummary): WorkspaceTab {
   return {
     kind: 'session',
-    sessionId: session.id,
+    sessionId: scopedSessionKey(session),
     sessionType: session.type,
   };
 }
 
 function sessionTabId(session: SessionSummary): string {
-  return `session::${session.id}`;
+  return `session::${scopedSessionKey(session)}`;
 }
 
 function propagateLayoutSideRemoval(
@@ -389,7 +393,7 @@ export function WorkspaceArea({
     const changed = new Set(
       openFileTabs.filter((t) => t.isChanged).map((t) => t.filePath)
     );
-    const findSession = (id: string) => sessions.find((s) => s.id === id);
+    const findSession = (id: string) => resolveSessionByKey(sessions, id);
     return {
       isFileChanged: (path) => changed.has(path),
       findSession,
@@ -409,7 +413,7 @@ export function WorkspaceArea({
           />
         );
       }
-      const session = sessions.find((s) => s.id === tab.sessionId);
+      const session = resolveSessionByKey(sessions, tab.sessionId);
       if (!session) {
         return (
           <div className="ws-session-mount ws-session-mount--missing">

--- a/frontend/src/components/WorkspaceGroup.tsx
+++ b/frontend/src/components/WorkspaceGroup.tsx
@@ -7,6 +7,7 @@ import type {
   PullRequest,
 } from '../lib/types.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
+import { scopedSessionKey } from '../lib/session-keys.js';
 import { deriveColor } from '../lib/colors.js';
 import CipherText from './CipherText.js';
 import TuiButton from './TuiButton.js';
@@ -135,7 +136,7 @@ export function WorkspaceGroup({
                 <li
                   key={session.id}
                   className="ws-session-row"
-                  onClick={() => onSelectSession(session.id)}
+                  onClick={() => onSelectSession(scopedSessionKey(session))}
                 >
                   <span className="ws-badge">workspace</span>
                   <span className="ws-session-name">{session.displayName}</span>

--- a/frontend/src/components/WorkspaceGroup.tsx
+++ b/frontend/src/components/WorkspaceGroup.tsx
@@ -134,7 +134,7 @@ export function WorkspaceGroup({
             <ul className="workspace-sessions">
               {workspaceSessions.map((session) => (
                 <li
-                  key={session.id}
+                  key={scopedSessionKey(session)}
                   className="ws-session-row"
                   onClick={() => onSelectSession(scopedSessionKey(session))}
                 >

--- a/frontend/src/components/WorkspaceUtilityRail.tsx
+++ b/frontend/src/components/WorkspaceUtilityRail.tsx
@@ -16,6 +16,7 @@ import UtilityRailStatsPanel from './UtilityRailStatsPanel.js';
 import Terminal from './Terminal.js';
 import Tooltip from './Tooltip.js';
 import { getUtilityTerminalTitle } from '../lib/utility-terminals.js';
+import { scopedSessionKey } from '../lib/session-keys.js';
 import './WorkspaceUtilityRail.css';
 
 const TAB_META: Array<{
@@ -149,8 +150,9 @@ function UtilityRailTerminalPanel({
   onFilePathClick,
 }: UtilityRailTerminalPanelProps) {
   const selectedSession =
-    sessions.find((session) => session.id === railState.selectedUtilityTerminalId) ??
-    sessions[0];
+    sessions.find(
+      (session) => session.id === railState.selectedUtilityTerminalId
+    ) ?? sessions[0];
   const notifyCopyModeInactive = useEffectEvent(() => {
     onCopyModeChange?.(false);
   });
@@ -178,7 +180,9 @@ function UtilityRailTerminalPanel({
       if (!nextSession) return;
       onSelectUtilityTerminal?.(nextSession.id);
       requestAnimationFrame(() => {
-        document.getElementById(`utility-terminal-tab-${nextSession.id}`)?.focus();
+        document
+          .getElementById(`utility-terminal-tab-${nextSession.id}`)
+          ?.focus();
       });
     },
     [onSelectUtilityTerminal, sessions]
@@ -193,7 +197,11 @@ function UtilityRailTerminalPanel({
           aria-label="utility terminals"
         >
           {sessions.map((session, index) => {
-            const title = getUtilityTerminalTitle(session, index, workspacePath);
+            const title = getUtilityTerminalTitle(
+              session,
+              index,
+              workspacePath
+            );
             const selected = session.id === selectedSession?.id;
             return (
               <div
@@ -214,9 +222,7 @@ function UtilityRailTerminalPanel({
                   aria-label={title}
                   tabIndex={selected ? 0 : -1}
                   onClick={() => onSelectUtilityTerminal?.(session.id)}
-                  onKeyDown={(event) =>
-                    handleTerminalTabKeyDown(event, index)
-                  }
+                  onKeyDown={(event) => handleTerminalTabKeyDown(event, index)}
                 >
                   <span className="utility-terminal-title">{title}</span>
                 </button>
@@ -254,6 +260,7 @@ function UtilityRailTerminalPanel({
           <div className="utility-terminal-body">
             <Terminal
               sessionId={selectedSession.id}
+              sessionKey={scopedSessionKey(selectedSession)}
               useTmux={selectedSession.useTmux !== false}
               {...(onImageUpload ? { onImageUpload } : {})}
               {...(onCopyModeChange ? { onCopyModeChange } : {})}
@@ -438,10 +445,16 @@ export function WorkspaceUtilityRail({
                 workspacePath={workspacePath}
                 railState={railState}
                 sessions={utilityTerminalSessions}
-                {...(onCreateUtilityTerminal ? { onCreateUtilityTerminal } : {})}
-                {...(onSelectUtilityTerminal ? { onSelectUtilityTerminal } : {})}
+                {...(onCreateUtilityTerminal
+                  ? { onCreateUtilityTerminal }
+                  : {})}
+                {...(onSelectUtilityTerminal
+                  ? { onSelectUtilityTerminal }
+                  : {})}
                 {...(onCloseUtilityTerminal ? { onCloseUtilityTerminal } : {})}
-                {...(onPromoteUtilityTerminal ? { onPromoteUtilityTerminal } : {})}
+                {...(onPromoteUtilityTerminal
+                  ? { onPromoteUtilityTerminal }
+                  : {})}
                 {...(onImageUpload ? { onImageUpload } : {})}
                 {...(onCopyModeChange ? { onCopyModeChange } : {})}
                 {...(onFilePathClick ? { onFilePathClick } : {})}

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -91,7 +91,10 @@ import { createLogger } from '../lib/logger.js';
 import type { Action, ActionContext } from '../lib/actions/types.js';
 import type { Repo } from '../lib/types.js';
 import { createAgentSession } from '../lib/session-utils.js';
-import { resolveSessionByKey } from '../lib/session-keys.js';
+import {
+  resolveSessionByKey,
+  scopedSessionKey,
+} from '../lib/session-keys.js';
 import { getActiveTerminalHandle } from '../lib/terminal-refs.js';
 import type { CustomizeSessionDialogHandle } from '../components/dialogs/CustomizeSessionDialog.js';
 import type { DeleteWorktreeDialogHandle } from '../components/dialogs/DeleteWorktreeDialog.js';
@@ -195,8 +198,12 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
         handler: async () => {
           const id = useSessionsStore.getState().activeSessionId;
           if (id) {
+            const session = resolveSessionByKey(
+              useSessionsStore.getState().sessions,
+              id
+            );
             try {
-              await killSession(id);
+              await killSession(session?.id ?? id);
             } catch (err) {
               logger.error('Failed to kill session', err);
             }
@@ -395,11 +402,11 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
           );
           if (wsSessions.length === 0) return;
           const idx = wsSessions.findIndex(
-            (s) => s.id === currentActiveSessionId
+            (s) => scopedSessionKey(s) === currentActiveSessionId
           );
           const prev =
             idx <= 0 ? wsSessions[wsSessions.length - 1] : wsSessions[idx - 1];
-          if (prev) handleSelectSession(prev.id);
+          if (prev) handleSelectSession(scopedSessionKey(prev));
         },
       },
       {
@@ -427,13 +434,13 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
           );
           if (wsSessions.length === 0) return;
           const idx = wsSessions.findIndex(
-            (s) => s.id === currentActiveSessionId
+            (s) => scopedSessionKey(s) === currentActiveSessionId
           );
           const next =
             idx === -1 || idx === wsSessions.length - 1
               ? wsSessions[0]
               : wsSessions[idx + 1];
-          if (next) handleSelectSession(next.id);
+          if (next) handleSelectSession(scopedSessionKey(next));
         },
       },
       {

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -91,6 +91,7 @@ import { createLogger } from '../lib/logger.js';
 import type { Action, ActionContext } from '../lib/actions/types.js';
 import type { Repo } from '../lib/types.js';
 import { createAgentSession } from '../lib/session-utils.js';
+import { resolveSessionByKey } from '../lib/session-keys.js';
 import { getActiveTerminalHandle } from '../lib/terminal-refs.js';
 import type { CustomizeSessionDialogHandle } from '../components/dialogs/CustomizeSessionDialog.js';
 import type { DeleteWorktreeDialogHandle } from '../components/dialogs/DeleteWorktreeDialog.js';
@@ -252,9 +253,10 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
           const currentActiveSessionId =
             useSessionsStore.getState().activeSessionId;
           const currentActiveSession = currentActiveSessionId
-            ? useSessionsStore
-                .getState()
-                .sessions.find((s) => s.id === currentActiveSessionId)
+            ? resolveSessionByKey(
+                useSessionsStore.getState().sessions,
+                currentActiveSessionId
+              )
             : undefined;
           const currentRepoPath = useUiStore.getState().activeRepoPath;
           const allWs = currentRepoPath
@@ -338,7 +340,7 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
         handler: () => {
           const state = useSessionsStore.getState();
           const currentActiveSession = state.activeSessionId
-            ? state.sessions.find((s) => s.id === state.activeSessionId)
+            ? resolveSessionByKey(state.sessions, state.activeSessionId)
             : undefined;
           const wt = state.worktrees.find(
             (w) => w.path === currentActiveSession?.worktreePath
@@ -375,9 +377,10 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
             useSessionsStore.getState().activeSessionId;
           const currentRepoPath = useUiStore.getState().activeRepoPath;
           const currentActiveSession = currentActiveSessionId
-            ? useSessionsStore
-                .getState()
-                .sessions.find((s) => s.id === currentActiveSessionId)
+            ? resolveSessionByKey(
+                useSessionsStore.getState().sessions,
+                currentActiveSessionId
+              )
             : undefined;
           const allWs = currentRepoPath
             ? useSessionsStore.getState().getSessionsForRepo(currentRepoPath)
@@ -406,9 +409,10 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
             useSessionsStore.getState().activeSessionId;
           const currentRepoPath = useUiStore.getState().activeRepoPath;
           const currentActiveSession = currentActiveSessionId
-            ? useSessionsStore
-                .getState()
-                .sessions.find((s) => s.id === currentActiveSessionId)
+            ? resolveSessionByKey(
+                useSessionsStore.getState().sessions,
+                currentActiveSessionId
+              )
             : undefined;
           const allWs = currentRepoPath
             ? useSessionsStore.getState().getSessionsForRepo(currentRepoPath)
@@ -451,9 +455,10 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
           const currentActiveSessionId =
             useSessionsStore.getState().activeSessionId;
           const currentActiveSession = currentActiveSessionId
-            ? useSessionsStore
-                .getState()
-                .sessions.find((s) => s.id === currentActiveSessionId)
+            ? resolveSessionByKey(
+                useSessionsStore.getState().sessions,
+                currentActiveSessionId
+              )
             : undefined;
           const ws =
             currentActiveSession?.worktreePath ??
@@ -477,9 +482,10 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
           const currentActiveSessionId =
             useSessionsStore.getState().activeSessionId;
           const currentActiveSession = currentActiveSessionId
-            ? useSessionsStore
-                .getState()
-                .sessions.find((s) => s.id === currentActiveSessionId)
+            ? resolveSessionByKey(
+                useSessionsStore.getState().sessions,
+                currentActiveSessionId
+              )
             : undefined;
           const ws =
             currentActiveSession?.worktreePath ??
@@ -520,9 +526,7 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
             ? state.repos.find((repo) => repo.path === currentRepoPath)
             : undefined;
           const activeSession = state.activeSessionId
-            ? state.sessions.find(
-                (session) => session.id === state.activeSessionId
-              )
+            ? resolveSessionByKey(state.sessions, state.activeSessionId)
             : undefined;
 
           if (!workspace) return;

--- a/frontend/src/hooks/useAppShortcuts.ts
+++ b/frontend/src/hooks/useAppShortcuts.ts
@@ -7,6 +7,7 @@ import { setupShortcutListener } from '../lib/actions/shortcuts.js';
 import { getAllActions } from '../lib/actions/registry.js';
 import { getActiveTerminalHandle } from '../lib/terminal-refs.js';
 import type { ActionContext } from '../lib/actions/types.js';
+import { resolveSessionByKey, scopedSessionKey } from '../lib/session-keys.js';
 
 export interface UseAppShortcutsParams {
   handleSelectSession: (id: string) => void;
@@ -42,7 +43,7 @@ function isActiveElementInput(): boolean {
 
 function getActiveSession() {
   const { activeSessionId, sessions } = useSessionsStore.getState();
-  return activeSessionId ? sessions.find((s) => s.id === activeSessionId) : undefined;
+  return activeSessionId ? resolveSessionByKey(sessions, activeSessionId) : undefined;
 }
 
 // Cmd/Ctrl+1-9: switch to the nth tab in the active workspace.
@@ -63,7 +64,7 @@ function handleTabSwitch(e: KeyboardEvent, handleSelectSession: (id: string) => 
   e.preventDefault();
   const n = parseInt(e.key, 10);
   const target = n === 9 ? wsSessions[wsSessions.length - 1] : wsSessions[n - 1];
-  if (target) handleSelectSession(target.id);
+  if (target) handleSelectSession(scopedSessionKey(target));
   return true;
 }
 

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -7,6 +7,7 @@ import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useTelemetryStore } from '../lib/stores/telemetry.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import type { AccountTelemetry, SessionTelemetry } from '../lib/types.js';
+import type { SessionEventScope } from '../../../shared/node-boundary.js';
 
 export interface UseEventSocketParams {
   authAuthenticated: boolean;
@@ -116,11 +117,33 @@ function repoPathsFromPrOrCiMessage(
   ]);
 }
 
-function sessionRepoPath(sessionId: string | undefined): string | undefined {
+function sessionRepoPath(
+  sessionId: string | undefined,
+  scope?: SessionEventScope
+): string | undefined {
   if (!sessionId) return undefined;
-  return useSessionsStore
-    .getState()
-    .sessions.find((session) => session.id === sessionId)?.repoPath;
+  return useSessionsStore.getState().sessions.find((session) => {
+    if (scope?.globalSessionId) {
+      return session.globalSessionId === scope.globalSessionId;
+    }
+    if (scope?.nodeId) {
+      return session.id === sessionId && session.nodeId === scope.nodeId;
+    }
+    return session.id === sessionId;
+  })?.repoPath;
+}
+
+function eventSessionScope(msg: {
+  nodeId?: string;
+  globalSessionId?: string;
+  localSessionId?: string;
+  sessionId?: string;
+}): SessionEventScope {
+  return {
+    ...(msg.nodeId ? { nodeId: msg.nodeId } : {}),
+    ...(msg.globalSessionId ? { globalSessionId: msg.globalSessionId } : {}),
+    ...(msg.localSessionId ? { localSessionId: msg.localSessionId } : {}),
+  };
 }
 
 function invalidatePrQueries(queryClient: QueryClient): void {
@@ -198,30 +221,34 @@ export function useEventSocket({
           .handleBackendStateChanged(
             msg.sessionId,
             msg.state,
-            msg.permissionType
+            msg.permissionType,
+            eventSessionScope(msg)
           );
       },
       'session-renamed': (msg) => {
-        const repoPath = sessionRepoPath(msg.sessionId);
+        const scope = eventSessionScope(msg);
+        const repoPath = sessionRepoPath(msg.sessionId, scope);
         useSessionsStore
           .getState()
-          .renameSession(msg.sessionId, msg.branchName, msg.displayName);
+          .renameSession(msg.sessionId, msg.branchName, msg.displayName, scope);
         if (repoPath) invalidateScopedPrData([repoPath], 'manual');
       },
       'session-branch-changed': (msg) => {
+        const scope = eventSessionScope(msg);
         const repoPaths = resolveRepoPaths([
           msg.cwdPath ?? '',
-          sessionRepoPath(msg.sessionId) ?? '',
+          sessionRepoPath(msg.sessionId, scope) ?? '',
         ]);
         useSessionsStore
           .getState()
-          .handleBranchChanged(msg.sessionId, msg.branch);
+          .handleBranchChanged(msg.sessionId, msg.branch, scope);
         if (repoPaths.length > 0) invalidateScopedPrData(repoPaths, 'manual');
       },
       'session-ended': (msg) => {
+        const scope = eventSessionScope(msg);
         const repoPaths = resolveRepoPaths([
           msg.cwd ?? '',
-          sessionRepoPath(msg.sessionId) ?? '',
+          sessionRepoPath(msg.sessionId, scope) ?? '',
         ]);
         if (repoPaths.length > 0) invalidateScopedPrData(repoPaths, 'manual');
         useSessionsStore.getState().refreshAll();
@@ -265,7 +292,8 @@ export function useEventSocket({
           .handleActivityChanged(
             msg.sessionId,
             msg.timestamp,
-            msg.currentActivity ?? undefined
+            msg.currentActivity ?? undefined,
+            eventSessionScope(msg)
           );
       },
       'session-telemetry': (msg) => {
@@ -313,9 +341,7 @@ export function useEventSocket({
         if (eventSocketOpened) {
           void refreshAfterReconnect();
         } else {
-          useSessionsStore
-            .getState()
-            .setBackendConnectionStatus('connected');
+          useSessionsStore.getState().setBackendConnectionStatus('connected');
           void useTelemetryStore.getState().refreshTelemetry();
         }
         eventSocketOpened = true;

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -3,6 +3,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import { connectEventSocket } from '../lib/ws.js';
 import type { EventMessage } from '../lib/ws.js';
 import { useAuthStore } from '../lib/stores/auth.js';
+import { resolveSessionByKey } from '../lib/session-keys.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useTelemetryStore } from '../lib/stores/telemetry.js';
 import { useUiStore } from '../lib/stores/ui.js';
@@ -266,12 +267,10 @@ export function useEventSocket({
         throttledWebhookInvalidate(repoPathsFromPrOrCiMessage(msg));
       },
       'files-changed': (msg) => {
-        const currentActiveSessionId =
-          useSessionsStore.getState().activeSessionId;
+        const sessionsState = useSessionsStore.getState();
+        const currentActiveSessionId = sessionsState.activeSessionId;
         const currentActiveSession = currentActiveSessionId
-          ? useSessionsStore
-              .getState()
-              .sessions.find((s) => s.id === currentActiveSessionId)
+          ? resolveSessionByKey(sessionsState.sessions, currentActiveSessionId)
           : undefined;
         const activeWs =
           currentActiveSession?.worktreePath ?? currentActiveSession?.repoPath;
@@ -326,8 +325,9 @@ export function useEventSocket({
         state.setBackendConnectionStatus('restarting');
         const activeSessionId = state.activeSessionId;
         if (activeSessionId) {
-          const activeSession = state.sessions.find(
-            (s) => s.id === activeSessionId
+          const activeSession = resolveSessionByKey(
+            state.sessions,
+            activeSessionId
           );
           if (activeSession && activeSession.mode === 'pty') {
             state.beginPtyReconnect(activeSessionId);

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -139,10 +139,13 @@ function eventSessionScope(msg: {
   localSessionId?: string;
   sessionId?: string;
 }): SessionEventScope {
+  const localSessionId = msg.localSessionId ?? msg.sessionId;
   return {
+    ...(localSessionId
+      ? { sessionId: localSessionId, localSessionId }
+      : {}),
     ...(msg.nodeId ? { nodeId: msg.nodeId } : {}),
     ...(msg.globalSessionId ? { globalSessionId: msg.globalSessionId } : {}),
-    ...(msg.localSessionId ? { localSessionId: msg.localSessionId } : {}),
   };
 }
 
@@ -301,7 +304,8 @@ export function useEventSocket({
           .getState()
           .handleSessionTelemetryEvent(
             msg.sessionId,
-            msg.data as SessionTelemetry | Record<string, unknown>
+            msg.data as SessionTelemetry | Record<string, unknown>,
+            eventSessionScope(msg)
           );
       },
       'account-telemetry': (msg) => {

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -81,9 +81,11 @@ export function useSessionHandlers({
 
   const handleRenameActiveSession = useCallback(async () => {
     const name = prompt('rename session:');
-    const id = useSessionsStore.getState().activeSessionId;
-    if (name?.trim() && id) {
-      await renameSessionApi(id, name.trim());
+    const state = useSessionsStore.getState();
+    const id = state.activeSessionId;
+    const session = id ? resolveSessionByKey(state.sessions, id) : undefined;
+    if (name?.trim() && session) {
+      await renameSessionApi(session.id, name.trim());
     }
   }, []);
 
@@ -242,11 +244,10 @@ export function useSessionHandlers({
           .getState()
           .repos.find((w) => w.path === currentRepoPath)
       : undefined;
-    const currentActiveSessionId = useSessionsStore.getState().activeSessionId;
+    const sessionsState = useSessionsStore.getState();
+    const currentActiveSessionId = sessionsState.activeSessionId;
     const currentActiveSession = currentActiveSessionId
-      ? useSessionsStore
-          .getState()
-          .sessions.find((s) => s.id === currentActiveSessionId)
+      ? resolveSessionByKey(sessionsState.sessions, currentActiveSessionId)
       : undefined;
     if (currentActiveWorkspace) {
       customizeDialogRef.current?.open(
@@ -573,17 +574,16 @@ export function useSessionHandlers({
   );
 
   const handleArchive = useCallback(async () => {
-    const sessionId = useSessionsStore.getState().activeSessionId;
+    const sessionState = useSessionsStore.getState();
+    const sessionId = sessionState.activeSessionId;
     if (!sessionId) return;
-    const session = useSessionsStore
-      .getState()
-      .sessions.find((s) => s.id === sessionId);
+    const session = resolveSessionByKey(sessionState.sessions, sessionId);
     if (!session) return;
 
     // Kill the session. Archive still proceeds to worktree cleanup if the
     // session was already gone or the backend close fails.
     try {
-      await killSession(sessionId);
+      await killSession(session.id);
     } catch (error) {
       logger.warn('Failed to close session before archive:', error);
     }

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -27,6 +27,7 @@ import {
   createAgentSession,
   getCurrentSessionContext,
 } from '../lib/session-utils.js';
+import { resolveSessionByKey } from '../lib/session-keys.js';
 import type { SessionIntent, PickerItem } from '../lib/session-intent.js';
 import { issueToBranchName } from '../lib/session-intent.js';
 import { getActiveTerminalHandle } from '../lib/terminal-refs.js';
@@ -65,9 +66,10 @@ export function useSessionHandlers({
   const navigateToSession = useCallback(
     (sessionId: string, _sessionType: string) => {
       useSessionsStore.getState().setActiveSessionId(sessionId);
-      const session = useSessionsStore
-        .getState()
-        .sessions.find((s) => s.id === sessionId);
+      const session = resolveSessionByKey(
+        useSessionsStore.getState().sessions,
+        sessionId
+      );
       if (session) {
         useUiStore.getState().setActiveRepoPath(session.repoPath);
       }
@@ -89,9 +91,7 @@ export function useSessionHandlers({
     (id: string) => {
       setAnalyticsView(null);
       useSessionsStore.getState().setActiveSessionId(id);
-      const session = useSessionsStore
-        .getState()
-        .sessions.find((s) => s.id === id);
+      const session = resolveSessionByKey(useSessionsStore.getState().sessions, id);
       if (session) {
         useSessionsStore
           .getState()
@@ -814,16 +814,21 @@ export function useSessionHandlers({
   }, []);
 
   const handleCloseSession = useCallback((sessionId: string) => {
+    const state = useSessionsStore.getState();
+    const targetSession = resolveSessionByKey(state.sessions, sessionId);
+    const localSessionId = targetSession?.id ?? sessionId;
     // Kill session via API, then refresh
-    fetch(`/sessions/${sessionId}`, { method: 'DELETE' }).then(() =>
+    fetch(`/sessions/${localSessionId}`, { method: 'DELETE' }).then(() =>
       useSessionsStore.getState().refreshAll()
     );
-    const currentActiveSessionId = useSessionsStore.getState().activeSessionId;
-    if (currentActiveSessionId === sessionId) {
+    const currentActiveSessionId = state.activeSessionId;
+    const isClosingActive =
+      currentActiveSessionId !== null &&
+      targetSession !== undefined &&
+      resolveSessionByKey(state.sessions, currentActiveSessionId) === targetSession;
+    if (isClosingActive) {
       // Select next available session in this workspace
-      const currentActiveSession = useSessionsStore
-        .getState()
-        .sessions.find((s) => s.id === currentActiveSessionId);
+      const currentActiveSession = targetSession;
       const currentRepoPath = useUiStore.getState().activeRepoPath;
       const allWs = currentRepoPath
         ? useSessionsStore.getState().getSessionsForRepo(currentRepoPath)
@@ -831,7 +836,7 @@ export function useSessionHandlers({
       const sameDir = currentActiveSession
         ? allWs.filter((s) => s.cwd === currentActiveSession.cwd)
         : allWs;
-      const remaining = sameDir.filter((s) => s.id !== sessionId);
+      const remaining = sameDir.filter((s) => s !== targetSession);
       useSessionsStore.getState().setActiveSessionId(remaining[0]?.id ?? null);
     }
   }, []);

--- a/frontend/src/hooks/useUrlNav.ts
+++ b/frontend/src/hooks/useUrlNav.ts
@@ -2,6 +2,10 @@ import { useEffect, useRef, useCallback } from 'react';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import {
+  resolveSessionByKey,
+  scopedSessionKey,
+} from '../lib/session-keys.js';
+import {
   parseRoute,
   buildPath,
   parseModal,
@@ -43,16 +47,18 @@ export function useUrlNav() {
         useUiStore.getState().setAnalyticsView(null);
         break;
 
-      case 'session':
+      case 'session': {
         useUiStore.getState().setActiveRepoPath(route.repoPath);
-        if (currentSessions.some((s) => s.id === route.sessionId)) {
-          useSessionsStore.getState().setActiveSessionId(route.sessionId);
+        const session = resolveSessionByKey(currentSessions, route.sessionId);
+        if (session) {
+          useSessionsStore.getState().setActiveSessionId(scopedSessionKey(session));
         } else {
           // Session no longer exists — fall back to repo view and fix URL
           useSessionsStore.getState().setActiveSessionId(null);
         }
         useUiStore.getState().setAnalyticsView(null);
         break;
+      }
 
       case 'analytics':
         useUiStore.getState().setAnalyticsView('dashboard');
@@ -120,15 +126,19 @@ export function useUrlNav() {
           useUiStore.getState().setAnalyticsView(null);
           break;
 
-        case 'session':
+        case 'session': {
           useUiStore.getState().setActiveRepoPath(route.repoPath);
-          if (currentSessions.some((s) => s.id === route.sessionId)) {
-            useSessionsStore.getState().setActiveSessionId(route.sessionId);
+          const session = resolveSessionByKey(currentSessions, route.sessionId);
+          if (session) {
+            useSessionsStore
+              .getState()
+              .setActiveSessionId(scopedSessionKey(session));
           } else {
             useSessionsStore.getState().setActiveSessionId(null);
           }
           useUiStore.getState().setAnalyticsView(null);
           break;
+        }
 
         case 'analytics':
           useUiStore.getState().setAnalyticsView('dashboard');

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -30,6 +30,7 @@ import type {
   FrameworkInfo,
   BranchDivergenceSummary,
 } from './types.js';
+import { parseGlobalSessionId } from '../../../shared/identity.js';
 
 export class ConflictError extends Error {
   sessionId: string;
@@ -171,6 +172,34 @@ export async function fetchSessions(): Promise<SessionSummary[]> {
   return json<SessionSummary[]>(await fetch('/sessions'));
 }
 
+function normalizeTelemetryMapEntry(
+  mapKey: string,
+  raw: Record<string, unknown>
+): SessionTelemetry {
+  const parsed = parseGlobalSessionId(mapKey);
+  const rawSessionId =
+    typeof raw.sessionId === 'string' ? raw.sessionId : undefined;
+  return {
+    ...(raw as Omit<SessionTelemetry, 'sessionId'>),
+    sessionId: rawSessionId ?? parsed?.localSessionId ?? mapKey,
+    ...(typeof raw.localSessionId === 'string'
+      ? {}
+      : parsed
+        ? { localSessionId: parsed.localSessionId }
+        : {}),
+    ...(typeof raw.nodeId === 'string'
+      ? {}
+      : parsed
+        ? { nodeId: parsed.nodeId }
+        : {}),
+    ...(typeof raw.globalSessionId === 'string'
+      ? {}
+      : parsed
+        ? { globalSessionId: mapKey }
+        : {}),
+  };
+}
+
 function normalizeTelemetrySessions(data: unknown): SessionTelemetry[] {
   if (Array.isArray(data)) {
     return data.filter(
@@ -189,9 +218,7 @@ function normalizeTelemetrySessions(data: unknown): SessionTelemetry[] {
       return Object.entries(value.sessions as Record<string, unknown>).flatMap(
         ([sessionId, raw]) => {
           if (!raw || typeof raw !== 'object') return [];
-          return [
-            { sessionId, ...(raw as Omit<SessionTelemetry, 'sessionId'>) },
-          ];
+          return [normalizeTelemetryMapEntry(sessionId, raw as Record<string, unknown>)];
         }
       );
     }
@@ -201,7 +228,7 @@ function normalizeTelemetrySessions(data: unknown): SessionTelemetry[] {
       return normalizeTelemetrySessions(value.data);
     return Object.entries(value).flatMap(([sessionId, raw]) => {
       if (!raw || typeof raw !== 'object') return [];
-      return [{ sessionId, ...(raw as Omit<SessionTelemetry, 'sessionId'>) }];
+      return [normalizeTelemetryMapEntry(sessionId, raw as Record<string, unknown>)];
     });
   }
   return [];

--- a/frontend/src/lib/session-keys.ts
+++ b/frontend/src/lib/session-keys.ts
@@ -1,0 +1,57 @@
+import { createGlobalSessionId } from '../../../shared/identity.js';
+import type { SessionSummary } from './types.js';
+
+type SessionIdentity = Pick<
+  SessionSummary,
+  'id' | 'nodeId' | 'globalSessionId'
+>;
+
+export function scopedSessionKey(session: SessionIdentity): string {
+  if (session.globalSessionId) return session.globalSessionId;
+  if (session.nodeId) return createGlobalSessionId(session.nodeId, session.id);
+  return session.id;
+}
+
+export function sessionKeyMatches(
+  session: SessionIdentity,
+  sessionKey: string
+): boolean {
+  if (scopedSessionKey(session) === sessionKey) return true;
+  if (session.nodeId || session.globalSessionId) return false;
+  return session.id === sessionKey;
+}
+
+export function resolveSessionByKey<T extends SessionIdentity>(
+  sessions: T[],
+  sessionKey: string | null | undefined
+): T | undefined {
+  if (!sessionKey) return undefined;
+
+  const scopedMatch = sessions.find(
+    (session) => scopedSessionKey(session) === sessionKey
+  );
+  if (scopedMatch) return scopedMatch;
+
+  const legacyMatches = sessions.filter((session) => session.id === sessionKey);
+  if (legacyMatches.length === 1) return legacyMatches[0];
+
+  const matchingNodes = new Set(
+    legacyMatches.flatMap((session) => (session.nodeId ? [session.nodeId] : []))
+  );
+  return matchingNodes.size <= 1 ? legacyMatches[0] : undefined;
+}
+
+export function resolveSessionKey(
+  sessions: SessionIdentity[],
+  sessionKey: string
+): string {
+  const session = resolveSessionByKey(sessions, sessionKey);
+  return session ? scopedSessionKey(session) : sessionKey;
+}
+
+export function isLiveSessionKey(
+  sessions: SessionIdentity[],
+  sessionKey: string
+): boolean {
+  return resolveSessionByKey(sessions, sessionKey) !== undefined;
+}

--- a/frontend/src/lib/session-utils.ts
+++ b/frontend/src/lib/session-utils.ts
@@ -1,6 +1,7 @@
 import { ConflictError, createSession as createSessionApi } from './api.js';
 import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
+import { resolveSessionByKey } from './session-keys.js';
 import type { Repo, SessionSummary } from './types.js';
 
 export interface CreateAgentSessionOptions {
@@ -51,9 +52,7 @@ export function getCurrentSessionContext(): CurrentSessionContext {
       )
     : undefined;
   const currentActiveSession = sessionsStore.activeSessionId
-    ? sessionsStore.sessions.find(
-        (session) => session.id === sessionsStore.activeSessionId
-      )
+    ? resolveSessionByKey(sessionsStore.sessions, sessionsStore.activeSessionId)
     : undefined;
 
   return {
@@ -68,12 +67,16 @@ function restoreSessionPlacement(
   activeSessionId: string | null,
   workspaceLastSession: Record<string, string>
 ): void {
-  const liveIds = new Set(useSessionsStore.getState().sessions.map((s) => s.id));
+  const liveSessions = useSessionsStore.getState().sessions;
   useSessionsStore.setState({
     activeSessionId:
-      activeSessionId && liveIds.has(activeSessionId) ? activeSessionId : null,
+      activeSessionId && resolveSessionByKey(liveSessions, activeSessionId)
+        ? activeSessionId
+        : null,
     workspaceLastSession: Object.fromEntries(
-      Object.entries(workspaceLastSession).filter(([, id]) => liveIds.has(id))
+      Object.entries(workspaceLastSession).filter(([, id]) =>
+        Boolean(resolveSessionByKey(liveSessions, id))
+      )
     ),
   });
 }
@@ -104,9 +107,10 @@ export async function createSessionWithoutActivation(
       }
       const conflictingSessionId = error.sessionId;
       const session = conflictingSessionId
-        ? useSessionsStore
-            .getState()
-            .sessions.find((existing) => existing.id === conflictingSessionId)
+        ? resolveSessionByKey(
+            useSessionsStore.getState().sessions,
+            conflictingSessionId
+          )
         : undefined;
       restoreSessionPlacement(activeSessionId, workspaceLastSession);
       return { session, error: refreshError ?? error };
@@ -129,9 +133,10 @@ export async function createAgentSession(
       await useSessionsStore.getState().refreshAll();
       const conflictingSessionId = error.sessionId;
       const session = conflictingSessionId
-        ? useSessionsStore
-            .getState()
-            .sessions.find((existing) => existing.id === conflictingSessionId)
+        ? resolveSessionByKey(
+            useSessionsStore.getState().sessions,
+            conflictingSessionId
+          )
         : undefined;
       if (conflictingSessionId) {
         useSessionsStore.getState().setActiveSessionId(conflictingSessionId);

--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -22,6 +22,11 @@ import {
 import { shouldMarkUnread } from '../state/unread-logic.js';
 import { useUnreadStore } from './unread.js';
 import {
+  isLiveSessionKey,
+  resolveSessionKey,
+  scopedSessionKey,
+} from '../session-keys.js';
+import {
   sessionEventMatches,
   type SessionEventScope,
 } from '../../../../shared/node-boundary.js';
@@ -264,6 +269,74 @@ function sessionMatchesEventScope(
   });
 }
 
+function sessionsShareScopedIdentity(
+  left: SessionSummary,
+  right: SessionSummary
+): boolean {
+  if (left.globalSessionId && right.globalSessionId) {
+    return left.globalSessionId === right.globalSessionId;
+  }
+
+  if (left.nodeId && right.nodeId) {
+    return left.nodeId === right.nodeId && left.id === right.id;
+  }
+
+  if (left.globalSessionId || right.globalSessionId || left.nodeId || right.nodeId) {
+    return false;
+  }
+
+  return left.id === right.id;
+}
+
+function isLegacyLocalSessionIdUnambiguous(
+  sessions: SessionSummary[],
+  sessionId: string
+): boolean {
+  const matchingNodes = new Set<string>();
+  let matches = 0;
+  for (const session of sessions) {
+    if (session.id !== sessionId) continue;
+    matches += 1;
+    if (session.nodeId) matchingNodes.add(session.nodeId);
+  }
+  return matches <= 1 || matchingNodes.size <= 1;
+}
+
+function storedSessionIdMatchesSession(
+  session: SessionSummary,
+  storedId: string,
+  sessions: SessionSummary[]
+): boolean {
+  if (
+    (session.globalSessionId || session.nodeId) &&
+    storedId === scopedSessionKey(session)
+  ) {
+    return true;
+  }
+
+  return (
+    session.id === storedId && isLegacyLocalSessionIdUnambiguous(sessions, storedId)
+  );
+}
+
+function notificationEnabledForSession(
+  session: SessionSummary,
+  notificationSessions: Record<string, boolean>,
+  sessions: SessionSummary[]
+): boolean {
+  if (
+    (session.globalSessionId || session.nodeId) &&
+    notificationSessions[scopedSessionKey(session)]
+  ) {
+    return true;
+  }
+
+  return (
+    notificationSessions[session.id] === true &&
+    isLegacyLocalSessionIdUnambiguous(sessions, session.id)
+  );
+}
+
 export const useSessionsStore = create<SessionsState>()((set, get) => ({
   sessions: [],
   worktrees: [],
@@ -280,12 +353,14 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
   backendConnectionStatus: 'connected',
 
   setActiveSessionId: (id) => {
-    saveActiveSessionId(id);
-    set({ activeSessionId: id });
+    const key = id === null ? null : resolveSessionKey(get().sessions, id);
+    saveActiveSessionId(key);
+    set({ activeSessionId: key });
   },
 
   rememberSessionForWorkspace: (workspacePath, sessionId) => {
-    const next = { ...get().workspaceLastSession, [workspacePath]: sessionId };
+    const key = resolveSessionKey(get().sessions, sessionId);
+    const next = { ...get().workspaceLastSession, [workspacePath]: key };
     persistWorkspaceSessions(next);
     set({ workspaceLastSession: next });
   },
@@ -294,14 +369,14 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
     const { workspaceLastSession, sessions } = get();
     const id = workspaceLastSession[workspacePath];
     if (!id) return null;
-    if (!sessions.some((s) => s.id === id)) {
+    if (!isLiveSessionKey(sessions, id)) {
       const next = { ...workspaceLastSession };
       delete next[workspacePath];
       persistWorkspaceSessions(next);
       set({ workspaceLastSession: next });
       return null;
     }
-    return id;
+    return resolveSessionKey(sessions, id);
   },
 
   enrichSidebarBranches: async () => {
@@ -409,17 +484,28 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
         wgResult.reason
       );
 
-    const activeIds = new Set(sessions.map((s) => s.id));
+    const hasSessionIdentity = (id: string): boolean =>
+      sessions.some((session) =>
+        storedSessionIdMatchesSession(session, id, sessions)
+      );
 
-    if (activeSessionId !== null && !activeIds.has(activeSessionId)) {
-      activeSessionId = null;
-      saveActiveSessionId(null);
+    if (activeSessionId !== null) {
+      if (!hasSessionIdentity(activeSessionId)) {
+        activeSessionId = null;
+        saveActiveSessionId(null);
+      } else {
+        const resolved = resolveSessionKey(sessions, activeSessionId);
+        if (resolved !== activeSessionId) {
+          activeSessionId = resolved;
+          saveActiveSessionId(resolved);
+        }
+      }
     }
 
     let notifPruned = false;
     notificationSessions = { ...notificationSessions };
     for (const id of Object.keys(notificationSessions)) {
-      if (!activeIds.has(id)) {
+      if (!hasSessionIdentity(id)) {
         delete notificationSessions[id];
         notifPruned = true;
       }
@@ -429,9 +515,15 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
     let wsPruned = false;
     workspaceLastSession = { ...workspaceLastSession };
     for (const [path, id] of Object.entries(workspaceLastSession)) {
-      if (!activeIds.has(id)) {
+      if (!hasSessionIdentity(id)) {
         delete workspaceLastSession[path];
         wsPruned = true;
+      } else {
+        const resolved = resolveSessionKey(sessions, id);
+        if (resolved !== id) {
+          workspaceLastSession[path] = resolved;
+          wsPruned = true;
+        }
       }
     }
     if (wsPruned) persistWorkspaceSessions(workspaceLastSession);
@@ -583,7 +675,7 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
           return item;
 
         const updatedSessions = sessions.filter((s) =>
-          item.sessions.some((is) => is.id === s.id)
+          item.sessions.some((is) => sessionsShareScopedIdentity(is, s))
         );
         const aggregateState = deriveBackendState(updatedSessions);
         if (aggregateState === item.lastKnownBackendState) return item;
@@ -604,7 +696,11 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
 
         let isUnread = item.isUnread;
         if (newDisplayState !== oldDisplayState) {
-          const isViewing = item.sessions.some((s) => s.id === activeSessionId);
+          const isViewing =
+            activeSessionId !== null &&
+            item.sessions.some((s) =>
+              storedSessionIdMatchesSession(s, activeSessionId, state.sessions)
+            );
           if (isViewing) {
             useUnreadStore.getState().markRead(item.id);
             isUnread = false;
@@ -618,10 +714,21 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
             const notifySession =
               item.sessions.find((s) =>
                 sessionMatchesEventScope(s, sessionId, scope)
-              ) ?? item.sessions.find((s) => notificationSessions[s.id]);
+              ) ??
+              item.sessions.find((s) =>
+                notificationEnabledForSession(
+                  s,
+                  notificationSessions,
+                  state.sessions
+                )
+              );
             if (
               notifySession &&
-              notificationSessions[notifySession.id] &&
+              notificationEnabledForSession(
+                notifySession,
+                notificationSessions,
+                state.sessions
+              ) &&
               shouldFireNotification()
             ) {
               fireNotification(notifySession);
@@ -663,15 +770,17 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
   },
 
   setNotificationEnabled: (sessionId, enabled) => {
-    const next = { ...get().notificationSessions, [sessionId]: enabled };
+    const key = resolveSessionKey(get().sessions, sessionId);
+    const next = { ...get().notificationSessions, [key]: enabled };
     saveNotificationPrefs(next);
     set({ notificationSessions: next });
   },
 
   initSessionNotification: (sessionId, defaultEnabled) => {
     const { notificationSessions } = get();
-    if (!(sessionId in notificationSessions)) {
-      const next = { ...notificationSessions, [sessionId]: defaultEnabled };
+    const key = resolveSessionKey(get().sessions, sessionId);
+    if (!(key in notificationSessions)) {
+      const next = { ...notificationSessions, [key]: defaultEnabled };
       saveNotificationPrefs(next);
       set({ notificationSessions: next });
     }

--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -23,6 +23,7 @@ import { shouldMarkUnread } from '../state/unread-logic.js';
 import { useUnreadStore } from './unread.js';
 import {
   isLiveSessionKey,
+  resolveSessionByKey,
   resolveSessionKey,
   scopedSessionKey,
 } from '../session-keys.js';
@@ -749,24 +750,27 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
   },
 
   handleUserViewed: (sessionId, scope) => {
-    set((state) => ({
-      sidebarItems: state.sidebarItems.map((item) => {
-        if (
-          !item.sessions.some((s) =>
-            sessionMatchesEventScope(s, sessionId, scope)
-          )
-        )
-          return item;
-        useUnreadStore.getState().markRead(item.id);
-        return {
-          ...item,
-          displayState: transitionDisplayState(item.displayState, {
-            type: 'user-viewed',
-          }),
-          isUnread: false,
-        };
-      }),
-    }));
+    set((state) => {
+      const viewedSession = resolveSessionByKey(state.sessions, sessionId);
+      const matchesViewedSession = (session: SessionSummary): boolean =>
+        viewedSession
+          ? sessionsShareScopedIdentity(session, viewedSession)
+          : sessionMatchesEventScope(session, sessionId, scope);
+
+      return {
+        sidebarItems: state.sidebarItems.map((item) => {
+          if (!item.sessions.some(matchesViewedSession)) return item;
+          useUnreadStore.getState().markRead(item.id);
+          return {
+            ...item,
+            displayState: transitionDisplayState(item.displayState, {
+              type: 'user-viewed',
+            }),
+            isUnread: false,
+          };
+        }),
+      };
+    });
   },
 
   setNotificationEnabled: (sessionId, enabled) => {

--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -21,6 +21,10 @@ import {
 } from '../state/sidebar-items.js';
 import { shouldMarkUnread } from '../state/unread-logic.js';
 import { useUnreadStore } from './unread.js';
+import {
+  sessionEventMatches,
+  type SessionEventScope,
+} from '../../../../shared/node-boundary.js';
 
 const NOTIFICATIONS_STORAGE_KEY = 'claude-remote-notifications';
 const ACTIVE_SESSION_KEY = 'claude-remote-active-session';
@@ -183,20 +187,27 @@ export interface SessionsState {
   renameSession: (
     sessionId: string,
     branchName: string,
-    displayName: string
+    displayName: string,
+    scope?: SessionEventScope
   ) => void;
-  handleBranchChanged: (sessionId: string, branch: string) => void;
+  handleBranchChanged: (
+    sessionId: string,
+    branch: string,
+    scope?: SessionEventScope
+  ) => void;
   handleActivityChanged: (
     sessionId: string,
     timestamp?: string,
-    currentActivity?: CurrentActivity | null
+    currentActivity?: CurrentActivity | null,
+    scope?: SessionEventScope
   ) => void;
   handleBackendStateChanged: (
     sessionId: string,
     backendState: BackendDisplayState,
-    permissionType?: 'approval' | 'question'
+    permissionType?: 'approval' | 'question',
+    scope?: SessionEventScope
   ) => void;
-  handleUserViewed: (sessionId: string) => void;
+  handleUserViewed: (sessionId: string, scope?: SessionEventScope) => void;
   setNotificationEnabled: (sessionId: string, enabled: boolean) => void;
   initSessionNotification: (sessionId: string, defaultEnabled: boolean) => void;
   getNotificationSessionIds: () => string[];
@@ -240,6 +251,17 @@ function visibleRepoPaths(
   for (const wt of state.worktrees) paths.add(wt.repoPath);
   for (const session of state.sessions) paths.add(session.repoPath);
   return Array.from(paths);
+}
+
+function sessionMatchesEventScope(
+  session: SessionSummary,
+  sessionId: string,
+  scope?: SessionEventScope
+): boolean {
+  return sessionEventMatches(session, {
+    sessionId,
+    ...(scope ?? {}),
+  });
 }
 
 export const useSessionsStore = create<SessionsState>()((set, get) => ({
@@ -296,7 +318,9 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
 
   ensureFreshAll: async (maxAgeMs = DEFAULT_ENRICHMENT_TTL_MS) => {
     const repos = visibleRepoPaths(get());
-    await Promise.all(repos.map((repoPath) => get().ensureFresh(repoPath, maxAgeMs)));
+    await Promise.all(
+      repos.map((repoPath) => get().ensureFresh(repoPath, maxAgeMs))
+    );
   },
 
   forceRefresh: async (repoPath, source = 'manual') => {
@@ -457,60 +481,78 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
     return [...directSessions, ...repoSessions];
   },
 
-  renameSession: (sessionId, branchName, displayName) => {
+  renameSession: (sessionId, branchName, displayName, scope) => {
     set((state) => ({
       sessions: state.sessions.map((s) =>
-        s.id === sessionId ? { ...s, branchName, displayName } : s
+        sessionMatchesEventScope(s, sessionId, scope)
+          ? { ...s, branchName, displayName }
+          : s
       ),
       sidebarItems: state.sidebarItems.map((item) => {
-        if (!item.sessions.some((s) => s.id === sessionId)) return item;
+        if (
+          !item.sessions.some((s) =>
+            sessionMatchesEventScope(s, sessionId, scope)
+          )
+        )
+          return item;
         return {
           ...item,
           branchName,
           displayName,
           sessions: item.sessions.map((s) =>
-            s.id === sessionId ? { ...s, branchName, displayName } : s
+            sessionMatchesEventScope(s, sessionId, scope)
+              ? { ...s, branchName, displayName }
+              : s
           ),
         };
       }),
     }));
   },
 
-  handleBranchChanged: (sessionId, branch) => {
+  handleBranchChanged: (sessionId, branch, scope) => {
     set((state) => ({
       sessions: state.sessions.map((s) =>
-        s.id === sessionId ? { ...s, branchName: branch } : s
+        sessionMatchesEventScope(s, sessionId, scope)
+          ? { ...s, branchName: branch }
+          : s
       ),
       sidebarItems: state.sidebarItems.map((item) =>
-        item.sessions.some((s) => s.id === sessionId)
+        item.sessions.some((s) => sessionMatchesEventScope(s, sessionId, scope))
           ? { ...item, branchName: branch }
           : item
       ),
     }));
-    if (!get().sessions.some((s) => s.id === sessionId)) {
+    if (
+      !get().sessions.some((s) => sessionMatchesEventScope(s, sessionId, scope))
+    ) {
       logger.debug('handleBranchChanged: session not found', sessionId);
     }
   },
 
-  handleActivityChanged: (sessionId, timestamp, currentActivity) => {
+  handleActivityChanged: (sessionId, timestamp, currentActivity, scope) => {
     const now = timestamp || new Date().toISOString();
     set((state) => ({
       sessions: state.sessions.map((s) => {
-        if (s.id !== sessionId) return s;
+        if (!sessionMatchesEventScope(s, sessionId, scope)) return s;
         const updated = { ...s, lastActivity: now };
         if (currentActivity !== undefined)
           updated.currentActivity = currentActivity ?? undefined;
         return updated;
       }),
       sidebarItems: state.sidebarItems.map((item) =>
-        item.sessions.some((s) => s.id === sessionId)
+        item.sessions.some((s) => sessionMatchesEventScope(s, sessionId, scope))
           ? { ...item, lastActivity: now }
           : item
       ),
     }));
   },
 
-  handleBackendStateChanged: (sessionId, backendState, permissionType) => {
+  handleBackendStateChanged: (
+    sessionId,
+    backendState,
+    permissionType,
+    scope
+  ) => {
     set((state) => {
       const agentStateMap: Record<
         BackendDisplayState,
@@ -523,7 +565,7 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
         initializing: 'initializing',
       };
       const sessions = state.sessions.map((s) => {
-        if (s.id !== sessionId) return s;
+        if (!sessionMatchesEventScope(s, sessionId, scope)) return s;
         return {
           ...s,
           idle: backendState === 'idle',
@@ -533,7 +575,12 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
 
       const { activeSessionId, notificationSessions } = state;
       const sidebarItems = state.sidebarItems.map((item) => {
-        if (!item.sessions.some((s) => s.id === sessionId)) return item;
+        if (
+          !item.sessions.some((s) =>
+            sessionMatchesEventScope(s, sessionId, scope)
+          )
+        )
+          return item;
 
         const updatedSessions = sessions.filter((s) =>
           item.sessions.some((is) => is.id === s.id)
@@ -561,14 +608,17 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
           if (isViewing) {
             useUnreadStore.getState().markRead(item.id);
             isUnread = false;
-          } else if (shouldMarkUnread(oldDisplayState, newDisplayState, false)) {
+          } else if (
+            shouldMarkUnread(oldDisplayState, newDisplayState, false)
+          ) {
             useUnreadStore.getState().markUnread(item.id);
             isUnread = true;
           }
           if (shouldNotify(oldDisplayState, newDisplayState)) {
             const notifySession =
-              item.sessions.find((s) => s.id === sessionId) ??
-              item.sessions.find((s) => notificationSessions[s.id]);
+              item.sessions.find((s) =>
+                sessionMatchesEventScope(s, sessionId, scope)
+              ) ?? item.sessions.find((s) => notificationSessions[s.id]);
             if (
               notifySession &&
               notificationSessions[notifySession.id] &&
@@ -591,10 +641,15 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
     });
   },
 
-  handleUserViewed: (sessionId) => {
+  handleUserViewed: (sessionId, scope) => {
     set((state) => ({
       sidebarItems: state.sidebarItems.map((item) => {
-        if (!item.sessions.some((s) => s.id === sessionId)) return item;
+        if (
+          !item.sessions.some((s) =>
+            sessionMatchesEventScope(s, sessionId, scope)
+          )
+        )
+          return item;
         useUnreadStore.getState().markRead(item.id);
         return {
           ...item,

--- a/frontend/src/lib/stores/telemetry.ts
+++ b/frontend/src/lib/stores/telemetry.ts
@@ -6,12 +6,18 @@ import type {
   SessionSummary,
   SessionTelemetry,
 } from '../types.js';
+import type { SessionEventScope } from '../../../../shared/node-boundary.js';
 import {
   mergeAccountTelemetryByFrameworkSnapshot,
   mergeSessionTelemetrySnapshot,
   pickNewerAccountTelemetry,
   pickNewerSessionTelemetry,
 } from '../telemetry-sync.js';
+import {
+  telemetrySessionKeyFromScope,
+  telemetrySessionKeyFromSession,
+  telemetrySessionKeyFromTelemetry,
+} from '../telemetry-session-key.js';
 
 export interface TelemetryAggregate {
   trackedSessions: number;
@@ -65,7 +71,8 @@ function buildAggregate(
   let contextPercentCount = 0;
 
   for (const session of sessions) {
-    const telemetry = telemetryById[session.id];
+    const telemetryKey = telemetrySessionKeyFromSession(session);
+    const telemetry = telemetryById[telemetryKey] ?? telemetryById[session.id];
     if (!telemetry) continue;
     aggregate.trackedSessions += 1;
     aggregate.totalInputTokens += telemetry.totalInputTokens || 0;
@@ -95,10 +102,17 @@ function buildAggregate(
 
 function normalizeSessionTelemetry(
   sessionId: string,
-  data: Partial<SessionTelemetry>
+  data: Partial<SessionTelemetry>,
+  scope?: SessionEventScope
 ): SessionTelemetry {
+  const localSessionId = data.localSessionId ?? scope?.localSessionId ?? sessionId;
+  const nodeId = data.nodeId ?? scope?.nodeId;
+  const globalSessionId = data.globalSessionId ?? scope?.globalSessionId;
   return {
-    sessionId,
+    sessionId: localSessionId,
+    ...(localSessionId ? { localSessionId } : {}),
+    ...(nodeId ? { nodeId } : {}),
+    ...(globalSessionId ? { globalSessionId } : {}),
     model:
       typeof data.model === 'string' || data.model === null
         ? (data.model ?? null)
@@ -152,14 +166,19 @@ export interface TelemetryState {
     repos: Repo[],
     sessions: SessionSummary[]
   ) => OrgTelemetrySummary;
-  summarizeSessionTelemetry: (sessionId: string) => SessionTelemetry | null;
+  summarizeSessionTelemetry: (
+    session: string | SessionSummary,
+    scope?: SessionEventScope
+  ) => SessionTelemetry | null;
   setSessionTelemetry: (data: SessionTelemetry) => void;
   setSessionTelemetryBatch: (
     items: SessionTelemetry[],
     requestStartedAt?: string
   ) => void;
-  clearSessionTelemetry: (sessionId: string) => void;
-  pruneSessionTelemetry: (activeSessionIds: Iterable<string>) => void;
+  clearSessionTelemetry: (sessionId: string, scope?: SessionEventScope) => void;
+  pruneSessionTelemetry: (
+    activeSessions: Iterable<string | SessionSummary>
+  ) => void;
   setAccountTelemetrySnapshot: (
     data: Record<string, AccountTelemetry> | null,
     requestStartedAt?: string
@@ -168,7 +187,8 @@ export interface TelemetryState {
   setTelemetrySetupInstalled: (installed: boolean | null) => void;
   handleSessionTelemetryEvent: (
     sessionId: string,
-    data: SessionTelemetry | Record<string, unknown>
+    data: SessionTelemetry | Record<string, unknown>,
+    scope?: SessionEventScope
   ) => void;
   handleAccountTelemetryEvent: (
     data: AccountTelemetry | Record<string, unknown> | null
@@ -200,9 +220,10 @@ export const useTelemetryStore = create<TelemetryState>()((set, get) => ({
         sessionTelemetryById
       ),
     }));
-    const outsideRelaySessions = sessions.filter(
-      (s) => !sessionTelemetryById[s.id]
-    );
+    const outsideRelaySessions = sessions.filter((session) => {
+      const telemetryKey = telemetrySessionKeyFromSession(session);
+      return !sessionTelemetryById[telemetryKey] && !sessionTelemetryById[session.id];
+    });
     const outsideRelay = buildAggregate(
       outsideRelaySessions,
       sessionTelemetryById
@@ -211,21 +232,29 @@ export const useTelemetryStore = create<TelemetryState>()((set, get) => ({
     return { repos: repoSummaries, outsideRelay };
   },
 
-  summarizeSessionTelemetry: (sessionId) =>
-    get().sessionTelemetryById[sessionId] ?? null,
+  summarizeSessionTelemetry: (session, scope) => {
+    const { sessionTelemetryById } = get();
+    if (typeof session === 'string') {
+      const telemetryKey = telemetrySessionKeyFromScope(session, scope);
+      return sessionTelemetryById[telemetryKey] ?? sessionTelemetryById[session] ?? null;
+    }
+    const telemetryKey = telemetrySessionKeyFromSession(session);
+    return sessionTelemetryById[telemetryKey] ?? sessionTelemetryById[session.id] ?? null;
+  },
 
   setSessionTelemetry: (data) => {
     const { sessionTelemetryById } = get();
     const normalized = normalizeSessionTelemetry(data.sessionId, data);
+    const telemetryKey = telemetrySessionKeyFromTelemetry(normalized);
     const next = pickNewerSessionTelemetry(
-      sessionTelemetryById[normalized.sessionId],
+      sessionTelemetryById[telemetryKey],
       normalized
     );
-    if (sessionTelemetryById[normalized.sessionId] === next) return;
+    if (sessionTelemetryById[telemetryKey] === next) return;
     set({
       sessionTelemetryById: {
         ...sessionTelemetryById,
-        [normalized.sessionId]: next,
+        [telemetryKey]: next,
       },
     });
   },
@@ -247,22 +276,34 @@ export const useTelemetryStore = create<TelemetryState>()((set, get) => ({
     });
   },
 
-  clearSessionTelemetry: (sessionId) => {
+  clearSessionTelemetry: (sessionId, scope) => {
     const { sessionTelemetryById } = get();
-    if (!(sessionId in sessionTelemetryById)) return;
+    const telemetryKey = telemetrySessionKeyFromScope(sessionId, scope);
+    if (!(telemetryKey in sessionTelemetryById) && !(sessionId in sessionTelemetryById)) {
+      return;
+    }
     const next = { ...sessionTelemetryById };
+    delete next[telemetryKey];
     delete next[sessionId];
     set({ sessionTelemetryById: next });
   },
 
-  pruneSessionTelemetry: (activeSessionIds) => {
+  pruneSessionTelemetry: (activeSessions) => {
     const { sessionTelemetryById } = get();
-    const allowed = new Set(activeSessionIds);
+    const allowed = new Set<string>();
+    for (const session of Array.from(activeSessions)) {
+      if (typeof session === 'string') {
+        allowed.add(session);
+      } else {
+        allowed.add(telemetrySessionKeyFromSession(session));
+        allowed.add(session.id);
+      }
+    }
     const next: Record<string, SessionTelemetry> = {};
     let changed = false;
-    for (const [sessionId, telemetry] of Object.entries(sessionTelemetryById)) {
-      if (allowed.has(sessionId)) {
-        next[sessionId] = telemetry;
+    for (const [telemetryKey, telemetry] of Object.entries(sessionTelemetryById)) {
+      if (allowed.has(telemetryKey)) {
+        next[telemetryKey] = telemetry;
       } else {
         changed = true;
       }
@@ -295,10 +336,14 @@ export const useTelemetryStore = create<TelemetryState>()((set, get) => ({
   setTelemetrySetupInstalled: (installed) =>
     set({ telemetrySetupInstalled: installed }),
 
-  handleSessionTelemetryEvent: (sessionId, data) => {
+  handleSessionTelemetryEvent: (sessionId, data, scope) => {
     if (!data || typeof data !== 'object') return;
     get().setSessionTelemetry(
-      normalizeSessionTelemetry(sessionId, data as Partial<SessionTelemetry>)
+      normalizeSessionTelemetry(
+        sessionId,
+        data as Partial<SessionTelemetry>,
+        scope
+      )
     );
   },
 

--- a/frontend/src/lib/telemetry-session-key.ts
+++ b/frontend/src/lib/telemetry-session-key.ts
@@ -1,0 +1,52 @@
+import {
+  createGlobalSessionId,
+  type GlobalSessionId,
+  type LocalSessionId,
+  type NodeId,
+} from '../../../shared/identity.js';
+import {
+  sessionScopeFromEvent,
+  type SessionEventScope,
+} from '../../../shared/node-boundary.js';
+import type { SessionSummary, SessionTelemetry } from './types.js';
+
+export type TelemetrySessionScope = Pick<
+  SessionTelemetry,
+  'sessionId' | 'localSessionId' | 'nodeId' | 'globalSessionId'
+>;
+
+function scopedKeyFor(
+  localSessionId: LocalSessionId,
+  nodeId?: NodeId,
+  globalSessionId?: GlobalSessionId
+): string {
+  if (globalSessionId) return globalSessionId;
+  if (nodeId) return createGlobalSessionId(nodeId, localSessionId);
+  return localSessionId;
+}
+
+export function telemetrySessionKeyFromScope(
+  sessionId: string,
+  scope?: SessionEventScope
+): string {
+  const normalized = sessionScopeFromEvent({ sessionId, ...(scope ?? {}) });
+  const localSessionId = normalized.localSessionId ?? normalized.sessionId;
+  if (!localSessionId) return sessionId;
+  return scopedKeyFor(
+    localSessionId,
+    normalized.nodeId,
+    normalized.globalSessionId
+  );
+}
+
+export function telemetrySessionKeyFromSession(
+  session: Pick<SessionSummary, 'id' | 'nodeId' | 'globalSessionId'>
+): string {
+  return scopedKeyFor(session.id, session.nodeId, session.globalSessionId);
+}
+
+export function telemetrySessionKeyFromTelemetry(
+  telemetry: TelemetrySessionScope
+): string {
+  return telemetrySessionKeyFromScope(telemetry.sessionId, telemetry);
+}

--- a/frontend/src/lib/telemetry-sync.ts
+++ b/frontend/src/lib/telemetry-sync.ts
@@ -1,4 +1,5 @@
 import type { AccountTelemetry, SessionTelemetry } from './types.js';
+import { telemetrySessionKeyFromTelemetry } from './telemetry-session-key.js';
 
 function parseUpdatedAt(value: string | null | undefined): number {
   if (!value) return 0;
@@ -36,17 +37,18 @@ export function mergeSessionTelemetrySnapshot(
   const incomingIds = new Set<string>();
 
   for (const incoming of incomingSessions) {
-    incomingIds.add(incoming.sessionId);
-    next[incoming.sessionId] = pickNewerSessionTelemetry(
-      currentSessions[incoming.sessionId],
+    const telemetryKey = telemetrySessionKeyFromTelemetry(incoming);
+    incomingIds.add(telemetryKey);
+    next[telemetryKey] = pickNewerSessionTelemetry(
+      currentSessions[telemetryKey],
       incoming
     );
   }
 
-  for (const [sessionId, current] of Object.entries(currentSessions)) {
-    if (incomingIds.has(sessionId)) continue;
+  for (const [telemetryKey, current] of Object.entries(currentSessions)) {
+    if (incomingIds.has(telemetryKey)) continue;
     if (parseUpdatedAt(current.updatedAt) > requestStartedMs) {
-      next[sessionId] = current;
+      next[telemetryKey] = current;
     }
   }
 
@@ -85,7 +87,7 @@ export function mergeAccountTelemetryByFrameworkSnapshot(
   const result: Record<string, AccountTelemetry> = {};
   const incomingKeys = new Set(Object.keys(incomingByFramework));
 
-  for (const framework of incomingKeys) {
+  for (const framework of Array.from(incomingKeys)) {
     const current = currentByFramework[framework];
     const incoming = incomingByFramework[framework];
     const selected = pickNewerAccountTelemetryByFramework(current, incoming);

--- a/frontend/src/lib/terminal-refs.ts
+++ b/frontend/src/lib/terminal-refs.ts
@@ -1,4 +1,5 @@
 import type { TerminalHandle } from '../components/Terminal.js';
+import { resolveSessionByKey } from './session-keys.js';
 import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
 
@@ -33,7 +34,8 @@ export function getActiveTerminalHandle(): TerminalHandle | null {
     useUiStore.getState().sendToTargetSessionId ??
     useSessionsStore.getState().activeSessionId;
   if (!id) return null;
-  return handles.get(id) ?? null;
+  const session = resolveSessionByKey(useSessionsStore.getState().sessions, id);
+  return handles.get(session?.id ?? id) ?? null;
 }
 
 /** @internal — exposed for tests */

--- a/frontend/src/lib/terminal-refs.ts
+++ b/frontend/src/lib/terminal-refs.ts
@@ -1,5 +1,5 @@
 import type { TerminalHandle } from '../components/Terminal.js';
-import { resolveSessionByKey } from './session-keys.js';
+import { resolveSessionByKey, scopedSessionKey } from './session-keys.js';
 import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
 
@@ -35,7 +35,7 @@ export function getActiveTerminalHandle(): TerminalHandle | null {
     useSessionsStore.getState().activeSessionId;
   if (!id) return null;
   const session = resolveSessionByKey(useSessionsStore.getState().sessions, id);
-  return handles.get(session?.id ?? id) ?? null;
+  return handles.get(session ? scopedSessionKey(session) : id) ?? null;
 }
 
 /** @internal — exposed for tests */

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -65,7 +65,14 @@ export interface CurrentActivity {
 }
 
 export interface SessionTelemetry {
+  /** Node-local session id. Kept for legacy single-node consumers. */
   sessionId: string;
+  /** Node-local session id when a scoped event carries both local and global ids. */
+  localSessionId?: string;
+  /** Execution node that owns this telemetry sample. */
+  nodeId?: NodeId;
+  /** Node-scoped session id for collision-free telemetry keying. */
+  globalSessionId?: GlobalSessionId;
   model: string | null;
   totalInputTokens: number;
   totalOutputTokens: number;

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -12,8 +12,12 @@ import type {
   NodeScopedSessionEvent,
 } from '../../../shared/node-boundary.js';
 import type { NodeId } from '../../../shared/identity.js';
+import {
+  createGlobalSessionId,
+  parseGlobalSessionId,
+} from '../../../shared/identity.js';
 import { createLogger } from './logger.js';
-import { resolveSessionByKey } from './session-keys.js';
+import { resolveSessionByKey, resolveSessionKey } from './session-keys.js';
 import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
 
@@ -252,7 +256,10 @@ function clearEventPongTimeout(): void {
 // ── Per-session PTY connection registry ──────────────────────────────────────
 
 interface PtyConnection {
+  /** Scoped registry key for the mounted frontend terminal. */
   sessionId: string;
+  /** Legacy local id used by the current single-node /ws/:sessionId endpoint. */
+  localSessionId: string;
   ws: WebSocket | null;
   pendingWs: WebSocket | null;
   term: Terminal;
@@ -315,15 +322,32 @@ function beginPtyReconnect(conn: PtyConnection): void {
   scheduleReconnect(conn);
 }
 
+function resolvePtyTarget(sessionKey: string): {
+  registryKey: string;
+  localSessionId: string;
+} {
+  const sessions = useSessionsStore.getState().sessions;
+  const session = resolveSessionByKey(sessions, sessionKey);
+  if (session) {
+    return {
+      registryKey: resolveSessionKey(sessions, sessionKey),
+      localSessionId: session.id,
+    };
+  }
+
+  const parsedGlobalSessionId = parseGlobalSessionId(sessionKey);
+  return {
+    registryKey: sessionKey,
+    localSessionId: parsedGlobalSessionId?.localSessionId ?? sessionKey,
+  };
+}
+
 function getActiveSessionId(): string | null {
   const sessionKey =
     useUiStore.getState().sendToTargetSessionId ??
     useSessionsStore.getState().activeSessionId;
   if (!sessionKey) return null;
-  return (
-    resolveSessionByKey(useSessionsStore.getState().sessions, sessionKey)?.id ??
-    sessionKey
-  );
+  return resolvePtyTarget(sessionKey).registryKey;
 }
 
 function getActiveConnection(): PtyConnection | null {
@@ -398,8 +422,9 @@ export function connectPtySocket(
   onResize: () => void,
   onSessionEnd: () => void
 ): void {
-  // Tear down any existing connection for this session.
-  const existing = ptyConnections.get(sessionId);
+  const { registryKey, localSessionId } = resolvePtyTarget(sessionId);
+  // Tear down any existing connection for this scoped terminal target.
+  const existing = ptyConnections.get(registryKey);
   if (existing) {
     disposePtyConnectionResources(existing);
     if (existing.pendingWs) {
@@ -418,7 +443,8 @@ export function connectPtySocket(
   }
 
   const conn: PtyConnection = {
-    sessionId,
+    sessionId: registryKey,
+    localSessionId,
     ws: null,
     pendingWs: null,
     term,
@@ -437,13 +463,22 @@ export function connectPtySocket(
     rafHandle: null,
     bgTimer: null,
   };
-  ptyConnections.set(sessionId, conn);
+  ptyConnections.set(registryKey, conn);
 
   openPtySocket(conn);
 }
 
 function openPtySocket(conn: PtyConnection): void {
-  const url = wsProtocol + '//' + location.host + '/ws/' + conn.sessionId;
+  // Remote node PTY proxying is intentionally deferred server-side for now.
+  // Keep the WebSocket path on the legacy local endpoint while keying the
+  // frontend registry by conn.sessionId so hub-fed duplicate local ids do not
+  // overwrite each other's mounted terminal connection state.
+  const url =
+    wsProtocol +
+    '//' +
+    location.host +
+    '/ws/' +
+    encodeURIComponent(conn.localSessionId);
   const socket = new WebSocket(url);
   conn.pendingWs = socket;
 
@@ -549,8 +584,21 @@ function scheduleReconnect(conn: PtyConnection): void {
         return;
       }
       const res = await fetch('/sessions');
-      const sessionList = (await res.json()) as Array<{ id: string }>;
-      if (!sessionList.some((s) => s.id === conn.sessionId)) {
+      const sessionList = (await res.json()) as Array<{
+        id: string;
+        nodeId?: string;
+        globalSessionId?: string;
+      }>;
+      if (
+        !sessionList.some(
+          (s) =>
+            s.globalSessionId === conn.sessionId ||
+            (s.nodeId
+              ? (s.globalSessionId ?? createGlobalSessionId(s.nodeId, s.id)) ===
+                conn.sessionId
+              : s.id === conn.localSessionId)
+        )
+      ) {
         conn.term.write('\r\n[session ended]\r\n');
         useSessionsStore.getState().clearPtyReconnect(conn.sessionId);
         ptyConnections.delete(conn.sessionId);
@@ -614,7 +662,8 @@ function forceReconnectPty(conn: PtyConnection): void {
 }
 
 export function disconnectPtySocket(sessionId: string): void {
-  const conn = ptyConnections.get(sessionId);
+  const registryKey = resolvePtyTarget(sessionId).registryKey;
+  const conn = ptyConnections.get(registryKey);
   if (!conn) return;
   disposePtyConnectionResources(conn);
   if (conn.pendingWs) {
@@ -627,8 +676,8 @@ export function disconnectPtySocket(sessionId: string): void {
     conn.ws.close();
     conn.ws = null;
   }
-  ptyConnections.delete(sessionId);
-  useSessionsStore.getState().clearPtyReconnect(sessionId);
+  ptyConnections.delete(conn.sessionId);
+  useSessionsStore.getState().clearPtyReconnect(conn.sessionId);
 }
 
 // ── Visibility change — proactive reconnection on mobile wake ────────────────
@@ -659,7 +708,7 @@ export function sendPtyData(arg1: string, arg2?: string): void {
   let conn: PtyConnection | null;
   let data: string;
   if (arg2 !== undefined) {
-    conn = ptyConnections.get(arg1) ?? null;
+    conn = ptyConnections.get(resolvePtyTarget(arg1).registryKey) ?? null;
     data = arg2;
   } else {
     conn = getActiveConnection();
@@ -685,7 +734,7 @@ export function sendPtyResize(
   let cols: number;
   let rows: number;
   if (typeof arg1 === 'string' && arg3 !== undefined) {
-    conn = ptyConnections.get(arg1) ?? null;
+    conn = ptyConnections.get(resolvePtyTarget(arg1).registryKey) ?? null;
     cols = arg2;
     rows = arg3;
   } else if (typeof arg1 === 'number') {
@@ -702,7 +751,7 @@ export function sendPtyResize(
 
 export function isPtyConnected(sessionId?: string): boolean {
   const conn = sessionId
-    ? (ptyConnections.get(sessionId) ?? null)
+    ? (ptyConnections.get(resolvePtyTarget(sessionId).registryKey) ?? null)
     : getActiveConnection();
   return !!conn?.ws && conn.ws.readyState === WebSocket.OPEN;
 }

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -5,6 +5,13 @@ import type {
   CurrentActivity,
   SessionTelemetry,
 } from './types.js';
+import type {
+  EnvironmentAuthority,
+  EnvironmentId,
+  NodeScopedFileEvent,
+  NodeScopedSessionEvent,
+} from '../../../shared/node-boundary.js';
+import type { NodeId } from '../../../shared/identity.js';
 import { createLogger } from './logger.js';
 import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
@@ -14,32 +21,40 @@ const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
 
 // Discriminated union for WebSocket event messages.
 // Each event type declares only its required fields.
+type NodeScopedEvent = Partial<{
+  nodeId: NodeId;
+  environmentId: EnvironmentId;
+  authority: EnvironmentAuthority;
+}>;
+type SessionScopedEvent = NodeScopedEvent & Partial<NodeScopedSessionEvent>;
+type FileScopedEvent = NodeScopedEvent & Partial<NodeScopedFileEvent>;
+
 export type EventMessage =
-  | { type: 'worktrees-changed' }
-  | {
+  | ({ type: 'worktrees-changed' } & NodeScopedEvent)
+  | ({
       type: 'session-backend-state-changed';
       sessionId: string;
       state: BackendDisplayState;
       permissionType?: 'approval' | 'question';
-    }
-  | {
+    } & SessionScopedEvent)
+  | ({
       type: 'session-renamed';
       sessionId: string;
       branchName: string;
       displayName: string;
-    }
-  | {
+    } & SessionScopedEvent)
+  | ({
       type: 'session-branch-changed';
       sessionId: string;
       branch: string;
       cwdPath?: string;
-    }
-  | {
+    } & SessionScopedEvent)
+  | ({
       type: 'session-ended';
       sessionId?: string;
       cwd?: string;
       branchName?: string;
-    }
+    } & SessionScopedEvent)
   | { type: 'ref-changed'; cwdPath: string; branch?: string; repo?: string }
   | {
       type: 'pr-updated';
@@ -57,18 +72,22 @@ export type EventMessage =
       repos?: string[];
       workspacePaths?: string[];
     }
-  | { type: 'files-changed'; workspacePath: string; changedFiles?: string[] }
-  | {
+  | ({
+      type: 'files-changed';
+      workspacePath: string;
+      changedFiles?: string[];
+    } & FileScopedEvent)
+  | ({
       type: 'session-activity-changed';
       sessionId: string;
       timestamp?: string;
       currentActivity?: CurrentActivity | null;
-    }
-  | {
+    } & SessionScopedEvent)
+  | ({
       type: 'session-telemetry';
       sessionId: string;
       data: SessionTelemetry | Record<string, unknown>;
-    }
+    } & SessionScopedEvent)
   | {
       type: 'account-telemetry';
       data: AccountTelemetry | Record<string, unknown> | null;

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -13,6 +13,7 @@ import type {
 } from '../../../shared/node-boundary.js';
 import type { NodeId } from '../../../shared/identity.js';
 import { createLogger } from './logger.js';
+import { resolveSessionByKey } from './session-keys.js';
 import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
 
@@ -315,9 +316,14 @@ function beginPtyReconnect(conn: PtyConnection): void {
 }
 
 function getActiveSessionId(): string | null {
-  const sendTo = useUiStore.getState().sendToTargetSessionId;
-  if (sendTo) return sendTo;
-  return useSessionsStore.getState().activeSessionId;
+  const sessionKey =
+    useUiStore.getState().sendToTargetSessionId ??
+    useSessionsStore.getState().activeSessionId;
+  if (!sessionKey) return null;
+  return (
+    resolveSessionByKey(useSessionsStore.getState().sessions, sessionKey)?.id ??
+    sessionKey
+  );
 }
 
 function getActiveConnection(): PtyConnection | null {

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,7 @@ import type { CreateResult } from './sessions.js';
 import { AGENT_CONTINUE_ARGS, AGENT_YOLO_ARGS } from './types.js';
 import { getTmuxPrefix } from './pty-handler.js';
 import { setupWebSocket } from './ws.js';
+import { createLocalRelayNode } from './local-node.js';
 import {
   WorktreeWatcher,
   BranchWatcher,
@@ -133,6 +134,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const execFileAsync = promisify(execFile);
 const logger = createLogger('index');
+const localRelayNode = createLocalRelayNode();
 
 // When run via CLI bin, config lives in ~/.config/relay-ide/
 // When run directly (development), fall back to local config.json
@@ -680,7 +682,7 @@ function createTerminalSessionRecord(
 ): CreateResult {
   const shell = process.env.SHELL || '/bin/sh';
   const displayName = sessions.nextTerminalName();
-  return sessions.create({
+  return localRelayNode.sessions.create({
     type: 'terminal',
     agent: 'claude' as AgentType,
     repoName: params.repoName,
@@ -699,7 +701,7 @@ function createTerminalSessionRecord(
 
 /** Creates an agent session record and writes worktree metadata if applicable. */
 function createAgentSessionRecord(params: AgentSessionParams): CreateResult {
-  const session = sessions.create({
+  const session = localRelayNode.sessions.create({
     type: 'agent',
     agent: params.resolvedAgent,
     repoName: params.repoName,
@@ -740,7 +742,7 @@ function createAgentSessionRecord(params: AgentSessionParams): CreateResult {
 }
 
 function activePtySessionCount(): number {
-  return countActivePtySessions(sessions.list());
+  return countActivePtySessions(localRelayNode.sessions.list());
 }
 
 function sendPtyCapacityError(
@@ -1137,7 +1139,8 @@ async function main(): Promise<void> {
     authenticatedTokens,
     watcher,
     CONFIG_PATH,
-    process.env.NO_PIN === '1'
+    process.env.NO_PIN === '1',
+    localRelayNode
   );
 
   const browserScopedToken = generateScopedToken();
@@ -1182,11 +1185,11 @@ async function main(): Promise<void> {
 
   // Watch .git/HEAD files for branch changes and update active sessions
   const branchWatcher = new BranchWatcher((cwdPath, newBranch) => {
-    for (const session of sessions.list()) {
+    for (const session of localRelayNode.sessions.list()) {
       // Match by worktreePath or repoPath — session.cwd can drift to subdirectories
       const groupPath = session.worktreePath ?? session.repoPath;
       if (groupPath === cwdPath) {
-        const raw = sessions.get(session.id);
+        const raw = localRelayNode.sessions.get(session.id);
         if (raw) {
           raw.branchName = newBranch;
           broadcastEvent('session-renamed', {
@@ -1281,7 +1284,7 @@ async function main(): Promise<void> {
       configPath: CONFIG_PATH,
       getConfig,
       getSessions: () =>
-        sessions.list().map((s) => ({
+        localRelayNode.sessions.list().map((s) => ({
           id: s.id,
           worktreePath: s.worktreePath ?? s.repoPath,
         })),
@@ -1316,7 +1319,7 @@ async function main(): Promise<void> {
     configPath: CONFIG_PATH,
     getActiveBranchNames: () => {
       const map = new Map<string, Set<string>>();
-      for (const s of sessions.list()) {
+      for (const s of localRelayNode.sessions.list()) {
         if (!s.branchName) continue;
         // Use repoPath so all sessions (main worktree and sub-worktrees) group correctly
         const wsRoot = s.repoPath || s.cwd;
@@ -1411,7 +1414,7 @@ async function main(): Promise<void> {
   if (restoredCount > 0) {
     logger.info(`Restored ${restoredCount} session(s) from previous update.`);
     // Start git watching for restored sessions
-    for (const session of sessions.list()) {
+    for (const session of localRelayNode.sessions.list()) {
       gitWatcher.watch(session.cwd);
     }
   }
@@ -1484,7 +1487,7 @@ async function main(): Promise<void> {
         const displayName = sessions.nextAgentName();
         // Get port env var names from repo settings for port injection
         const portVariables = getRepoPortVariables(freshCfg, opts.repoPath);
-        sessions.create({
+        localRelayNode.sessions.create({
           type: 'agent',
           agent: resolved.agent,
           repoName,
@@ -1603,7 +1606,7 @@ async function main(): Promise<void> {
       prevState === 'running' &&
       (state === 'idle' || state === 'permission')
     ) {
-      const session = sessions.get(sessionId);
+      const session = localRelayNode.sessions.get(sessionId);
       if (session && session.type !== 'terminal') {
         // Dedup: if hooks fired an attention notification within last 10s, skip
         if (
@@ -1761,7 +1764,7 @@ async function main(): Promise<void> {
   const branchRefreshCache = new Map<string, number>(); // sessionId -> last refresh timestamp
   const BRANCH_REFRESH_INTERVAL_MS = 10_000;
   app.get('/sessions', requireAuth, async (_req, res) => {
-    const allSessions = sessions.list();
+    const allSessions = localRelayNode.sessions.list();
     const now = Date.now();
 
     // Prune cache entries for sessions that no longer exist
@@ -1787,7 +1790,7 @@ async function main(): Promise<void> {
           const liveBranch = stdout.trim();
           if (liveBranch && liveBranch !== s.branchName) {
             s.branchName = liveBranch;
-            const raw = sessions.get(s.id);
+            const raw = localRelayNode.sessions.get(s.id);
             if (raw) raw.branchName = liveBranch;
           }
         } catch {
@@ -1882,7 +1885,7 @@ async function main(): Promise<void> {
     }
 
     // Check for active sessions in this worktree
-    const allSessions = sessions.list();
+    const allSessions = localRelayNode.sessions.list();
     const activeSessions = allSessions
       .filter((s) => s.worktreePath === resolved || s.cwd === resolved)
       .map((s) => s.id);
@@ -2158,7 +2161,7 @@ async function main(): Promise<void> {
     if (force) {
       for (const sessionId of worktreeSessions) {
         try {
-          sessions.kill(sessionId);
+          localRelayNode.sessions.kill(sessionId);
         } catch (err) {
           logger.warn(
             `[worktrees] failed to kill session ${sessionId}:`,
@@ -2366,7 +2369,7 @@ async function main(): Promise<void> {
       }
       const displayName = sessions.nextAgentName();
       try {
-        const { session } = await sessions.createWeb({
+        const { session } = await localRelayNode.sessions.createWeb({
           agentType: resolvedAgent,
           cwd,
           repoPath,
@@ -2461,8 +2464,8 @@ async function main(): Promise<void> {
   app.delete('/sessions/:id', requireAuth, (req, res) => {
     const id = req.params['id'] as string;
     try {
-      const sessionToDelete = sessions.get(id);
-      sessions.kill(id);
+      const sessionToDelete = localRelayNode.sessions.get(id);
+      localRelayNode.sessions.kill(id);
       push.removeSession(id);
       if (sessionToDelete) gitWatcher.unwatch(sessionToDelete.cwd);
       res.json({ ok: true });
@@ -2480,8 +2483,11 @@ async function main(): Promise<void> {
     }
     try {
       const id = req.params['id'] as string;
-      const updated = sessions.updateDisplayName(id, displayName);
-      const session = sessions.get(id);
+      const updated = localRelayNode.sessions.updateDisplayName(
+        id,
+        displayName
+      );
+      const session = localRelayNode.sessions.get(id);
       if (session) {
         writeMeta(CONFIG_PATH, {
           worktreePath: session.cwd,
@@ -2518,7 +2524,7 @@ async function main(): Promise<void> {
       return;
     }
     const sessionId = req.params['id'] as string;
-    if (!sessions.get(sessionId)) {
+    if (!localRelayNode.sessions.get(sessionId)) {
       res.status(404).json({ error: 'Session not found' });
       return;
     }
@@ -2537,7 +2543,7 @@ async function main(): Promise<void> {
       }
 
       if (clipboardSet) {
-        sessions.write(sessionId, '\x16');
+        localRelayNode.sessions.write(sessionId, '\x16');
       }
 
       res.json({ path: filePath, clipboardSet });
@@ -2661,7 +2667,7 @@ async function main(): Promise<void> {
     serializeAll(configDir, { reason: restartReason });
     flushRelayStateWrites();
     closeRelayStateDb();
-    for (const s of sessions.list()) {
+    for (const s of localRelayNode.sessions.list()) {
       try {
         sessions.detachForRestart(s.id);
       } catch {

--- a/server/local-node.ts
+++ b/server/local-node.ts
@@ -1,0 +1,90 @@
+import * as sessionsModule from './sessions.js';
+import type { CreateResult } from './sessions.js';
+import type { CreateParams } from './sessions.js';
+import type { CreateWebParams } from './web-session-handler.js';
+import type { Session, SessionSummary } from './types.js';
+import {
+  DEFAULT_LOCAL_ENVIRONMENT_ID,
+  createLocalEventAuthority,
+  createNodeScopedFileEvent,
+  createNodeScopedSessionEvent,
+  type EnvironmentId,
+  type NodeEventAuthority,
+  type NodeScopedFileEvent,
+  type NodeScopedSessionEvent,
+} from '../shared/node-boundary.js';
+import { DEFAULT_LOCAL_NODE_ID, type NodeId } from '../shared/identity.js';
+
+export interface NodeSessionBoundary {
+  list(): SessionSummary[];
+  get(id: string): Session | undefined;
+  create(params: CreateParams): CreateResult;
+  createWeb(params: CreateWebParams): Promise<{ session: SessionSummary }>;
+  kill(id: string): void;
+  updateDisplayName(
+    id: string,
+    displayName: string
+  ): { id: string; displayName: string };
+  write(id: string, data: string): void;
+}
+
+type LocalRelayNodeSessionOverrides = Partial<{
+  [K in keyof NodeSessionBoundary]: (
+    ...args: Parameters<NodeSessionBoundary[K]>
+  ) => ReturnType<NodeSessionBoundary[K]>;
+}>;
+
+export interface LocalRelayNodeDeps {
+  sessions?: LocalRelayNodeSessionOverrides;
+  nodeId?: NodeId;
+  environmentId?: EnvironmentId;
+}
+
+export interface LocalRelayNode {
+  nodeId: NodeId;
+  environmentId: EnvironmentId;
+  authority(): NodeEventAuthority;
+  sessionEventScope(sessionId: string): NodeScopedSessionEvent;
+  fileEventScope(input: {
+    workspacePath: string;
+    worktreePath?: string | null;
+  }): NodeScopedFileEvent;
+  sessions: NodeSessionBoundary;
+}
+
+const defaultSessionBoundary: NodeSessionBoundary = {
+  list: sessionsModule.list,
+  get: sessionsModule.get,
+  create: sessionsModule.create,
+  createWeb: sessionsModule.createWeb,
+  kill: sessionsModule.kill,
+  updateDisplayName: sessionsModule.updateDisplayName,
+  write: sessionsModule.write,
+};
+
+export function createLocalRelayNode(
+  deps: LocalRelayNodeDeps = {}
+): LocalRelayNode {
+  const nodeId = deps.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  const environmentId = deps.environmentId ?? DEFAULT_LOCAL_ENVIRONMENT_ID;
+  const sessionBoundary = {
+    ...defaultSessionBoundary,
+    ...deps.sessions,
+  } as NodeSessionBoundary;
+
+  return {
+    nodeId,
+    environmentId,
+    authority: () => createLocalEventAuthority({ nodeId, environmentId }),
+    sessionEventScope: (sessionId: string) =>
+      createNodeScopedSessionEvent(sessionId, { nodeId, environmentId }),
+    fileEventScope: ({ workspacePath, worktreePath }) =>
+      createNodeScopedFileEvent({
+        workspacePath,
+        ...(worktreePath !== undefined ? { worktreePath } : {}),
+        nodeId,
+        environmentId,
+      }),
+    sessions: sessionBoundary,
+  };
+}

--- a/server/telemetry-adapter.ts
+++ b/server/telemetry-adapter.ts
@@ -1,7 +1,11 @@
 import type { AccountTelemetry, Session, TelemetryData } from './types.js';
+import type { GlobalSessionId, NodeId } from '../shared/identity.js';
 import type { AgentEventAdapter } from './agent-events.js';
 
-export type TelemetrySession = Pick<Session, 'id'>;
+export type TelemetrySession = Pick<Session, 'id'> & {
+  nodeId?: NodeId;
+  globalSessionId?: GlobalSessionId;
+};
 
 export interface TelemetryAdapter {
   readonly framework: string;

--- a/server/telemetry.ts
+++ b/server/telemetry.ts
@@ -17,6 +17,7 @@ import './adapters/codex-telemetry.js';
 // Side-effect import: registers the OpenCode adapter in the adapter registry
 import './adapters/opencode-telemetry.js';
 import { createLogger } from './logger.js';
+import { createGlobalSessionId } from '../shared/identity.js';
 
 const logger = createLogger('telemetry');
 
@@ -48,7 +49,25 @@ function pendingFilePath(configDir: string): string {
 }
 
 function telemetryToObject(): Record<string, TelemetryData> {
-  return Object.fromEntries(sessionTelemetry.entries());
+  const activeSessionsById = new Map(
+    (activeDeps?.getActiveSessions() ?? []).map((session) => [session.id, session])
+  );
+  const result: Record<string, TelemetryData> = {};
+  for (const [sessionId, telemetry] of Array.from(sessionTelemetry.entries())) {
+    const session = activeSessionsById.get(sessionId);
+    const globalSessionId =
+      session?.globalSessionId ??
+      (session?.nodeId ? createGlobalSessionId(session.nodeId, sessionId) : undefined);
+    const telemetryKey = globalSessionId ?? sessionId;
+    result[telemetryKey] = {
+      ...telemetry,
+      sessionId,
+      ...(globalSessionId || session?.nodeId ? { localSessionId: sessionId } : {}),
+      ...(session?.nodeId ? { nodeId: session.nodeId } : {}),
+      ...(globalSessionId ? { globalSessionId } : {}),
+    };
+  }
+  return result;
 }
 
 function sameTelemetry(

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,6 +1,7 @@
 import type { IPty } from 'node-pty';
 import type {
   GlobalSessionId,
+  LocalSessionId,
   NodeId,
   RepoIdentity,
   RepoInstanceId,
@@ -362,7 +363,14 @@ export interface SessionSummary {
 }
 
 export interface TelemetryData {
+  /** Node-local session id. Kept for legacy single-node consumers. */
   sessionId: string;
+  /** Node-local session id when a scoped payload carries both local and global ids. */
+  localSessionId?: LocalSessionId;
+  /** Execution node that owns this telemetry sample. */
+  nodeId?: NodeId;
+  /** Node-scoped session id for collision-free telemetry keying. */
+  globalSessionId?: GlobalSessionId;
   model: string | null;
   totalInputTokens: number;
   totalOutputTokens: number;

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -302,9 +302,12 @@ function setupWebSocket(
   function scopedEventPayload(
     data: Record<string, unknown> | undefined
   ): Record<string, unknown> | undefined {
-    if (!data || !localNode) return data;
+    if (!localNode) return data;
 
-    const payload: Record<string, unknown> = { ...data };
+    const payload: Record<string, unknown> = {
+      ...(data ?? {}),
+      ...localNode.authority(),
+    };
     const sessionId = payload['sessionId'];
     if (typeof sessionId === 'string') {
       Object.assign(payload, localNode.sessionEventScope(sessionId));

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -12,6 +12,7 @@ import { loadConfig } from './config.js';
 import { verifyCookieToken } from './auth.js';
 import { createAgentSessionSnapshotPatch } from './web-session-v2-state.js';
 import type { AgentApprovalDecisionV2 } from '../shared/agent-chat-protocol-v2.js';
+import type { LocalRelayNode } from './local-node.js';
 
 const logger = createLogger('ws');
 
@@ -106,13 +107,22 @@ function parseApprovalDecision(
   if (kind === 'cancel') return { kind: 'cancel' };
   if (kind === 'accept') {
     const scope = d['scope'];
-    const result: Extract<AgentApprovalDecisionV2, { kind: 'accept' }> = { kind: 'accept' };
-    if (scope === 'once' || scope === 'session' || scope === 'turn' || scope === 'permanent') {
+    const result: Extract<AgentApprovalDecisionV2, { kind: 'accept' }> = {
+      kind: 'accept',
+    };
+    if (
+      scope === 'once' ||
+      scope === 'session' ||
+      scope === 'turn' ||
+      scope === 'permanent'
+    ) {
       result.scope = scope;
     }
     const amendments = d['amendments'];
     if (Array.isArray(amendments)) {
-      result.amendments = amendments as AgentApprovalDecisionV2 extends { amendments?: infer A }
+      result.amendments = amendments as AgentApprovalDecisionV2 extends {
+        amendments?: infer A;
+      }
         ? NonNullable<A>
         : never;
     }
@@ -265,7 +275,8 @@ function setupWebSocket(
   authenticatedTokens: Set<string>,
   watcher: WorktreeWatcher | null,
   configPath?: string,
-  noPinMode = false
+  noPinMode = false,
+  localNode?: LocalRelayNode
 ): {
   wss: WebSocketServer;
   broadcastEvent: (type: string, data?: Record<string, unknown>) => void;
@@ -288,8 +299,33 @@ function setupWebSocket(
     }
   }
 
+  function scopedEventPayload(
+    data: Record<string, unknown> | undefined
+  ): Record<string, unknown> | undefined {
+    if (!data || !localNode) return data;
+
+    const payload: Record<string, unknown> = { ...data };
+    const sessionId = payload['sessionId'];
+    if (typeof sessionId === 'string') {
+      Object.assign(payload, localNode.sessionEventScope(sessionId));
+    }
+
+    const workspacePath = payload['workspacePath'];
+    if (typeof workspacePath === 'string') {
+      const fileScopeInput = {
+        workspacePath,
+        ...(typeof payload['worktreePath'] === 'string'
+          ? { worktreePath: payload['worktreePath'] }
+          : {}),
+      };
+      Object.assign(payload, localNode.fileEventScope(fileScopeInput));
+    }
+
+    return payload;
+  }
+
   function broadcastEvent(type: string, data?: Record<string, unknown>): void {
-    const msg = JSON.stringify({ type, ...data });
+    const msg = JSON.stringify({ type, ...scopedEventPayload(data) });
     for (const client of eventClients) {
       if (client.readyState === client.OPEN) {
         client.send(msg);

--- a/shared/node-boundary.ts
+++ b/shared/node-boundary.ts
@@ -1,0 +1,216 @@
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  createGlobalSessionId,
+  createRepoInstanceId,
+  createWorktreeInstanceId,
+  type GlobalSessionId,
+  type LocalSessionId,
+  type NodeId,
+  type RepoInstanceId,
+  type WorktreeInstanceId,
+} from './identity.js';
+
+export type EnvironmentId = string;
+export type EnvironmentAuthority = 'local-node';
+
+export const DEFAULT_LOCAL_ENVIRONMENT_ID: EnvironmentId = 'local';
+
+export interface NodeEventAuthority {
+  nodeId: NodeId;
+  environmentId: EnvironmentId;
+  authority: EnvironmentAuthority;
+}
+
+export interface NodeScopedSessionEvent extends NodeEventAuthority {
+  sessionId: LocalSessionId;
+  localSessionId: LocalSessionId;
+  globalSessionId: GlobalSessionId;
+}
+
+export interface NodeScopedFileEvent extends NodeEventAuthority {
+  workspacePath: string;
+  repoInstanceId?: RepoInstanceId;
+  worktreePath?: string;
+  worktreeInstanceId?: WorktreeInstanceId;
+}
+
+export interface SessionScopeCandidate {
+  id?: LocalSessionId;
+  sessionId?: LocalSessionId;
+  localSessionId?: LocalSessionId;
+  nodeId?: NodeId;
+  globalSessionId?: GlobalSessionId;
+}
+
+export interface SessionEventScope {
+  sessionId?: LocalSessionId;
+  localSessionId?: LocalSessionId;
+  nodeId?: NodeId;
+  globalSessionId?: GlobalSessionId;
+}
+
+export type NodeSessionOperation =
+  | 'sessions.list'
+  | 'sessions.get'
+  | 'sessions.create'
+  | 'sessions.kill'
+  | 'sessions.write'
+  | 'sessions.resize';
+
+export type NodeFileOperation =
+  | 'files.read'
+  | 'files.write'
+  | 'files.list'
+  | 'files.watch';
+
+export type NodeGitOperation =
+  | 'git.status'
+  | 'git.diff'
+  | 'git.branch'
+  | 'git.worktree';
+
+export interface NodeScopedRequest<
+  TPayload = unknown,
+> extends NodeEventAuthority {
+  requestId?: string;
+  payload?: TPayload;
+}
+
+export interface NodeSessionRequest<
+  TPayload = unknown,
+> extends NodeScopedRequest<TPayload> {
+  operation: NodeSessionOperation;
+  sessionId?: LocalSessionId;
+  globalSessionId?: GlobalSessionId;
+}
+
+export interface NodeFileRequest<
+  TPayload = unknown,
+> extends NodeScopedRequest<TPayload> {
+  operation: NodeFileOperation;
+  workspacePath: string;
+  repoInstanceId?: RepoInstanceId;
+  worktreePath?: string;
+  worktreeInstanceId?: WorktreeInstanceId;
+}
+
+export interface NodeGitRequest<
+  TPayload = unknown,
+> extends NodeScopedRequest<TPayload> {
+  operation: NodeGitOperation;
+  workspacePath: string;
+  repoInstanceId?: RepoInstanceId;
+  worktreePath?: string;
+  worktreeInstanceId?: WorktreeInstanceId;
+}
+
+export function nodeSessionWebSocketPath(
+  nodeId: NodeId,
+  sessionId: LocalSessionId
+): string {
+  return `/nodes/${encodeURIComponent(nodeId)}/ws/sessions/${encodeURIComponent(
+    sessionId
+  )}`;
+}
+
+export function createLocalEventAuthority(
+  overrides: Partial<Pick<NodeEventAuthority, 'nodeId' | 'environmentId'>> = {}
+): NodeEventAuthority {
+  return {
+    nodeId: overrides.nodeId ?? DEFAULT_LOCAL_NODE_ID,
+    environmentId: overrides.environmentId ?? DEFAULT_LOCAL_ENVIRONMENT_ID,
+    authority: 'local-node',
+  };
+}
+
+export function createNodeScopedSessionEvent(
+  sessionId: LocalSessionId,
+  overrides: Partial<Pick<NodeEventAuthority, 'nodeId' | 'environmentId'>> = {}
+): NodeScopedSessionEvent {
+  const authority = createLocalEventAuthority(overrides);
+  return {
+    ...authority,
+    sessionId,
+    localSessionId: sessionId,
+    globalSessionId: createGlobalSessionId(authority.nodeId, sessionId),
+  };
+}
+
+export function createNodeScopedFileEvent({
+  workspacePath,
+  worktreePath,
+  nodeId,
+  environmentId,
+}: {
+  workspacePath: string;
+  worktreePath?: string | null;
+  nodeId?: NodeId;
+  environmentId?: EnvironmentId;
+}): NodeScopedFileEvent {
+  const authority = createLocalEventAuthority({
+    ...(nodeId !== undefined ? { nodeId } : {}),
+    ...(environmentId !== undefined ? { environmentId } : {}),
+  });
+  return {
+    ...authority,
+    workspacePath,
+    ...(workspacePath
+      ? {
+          repoInstanceId: createRepoInstanceId(authority.nodeId, workspacePath),
+        }
+      : {}),
+    ...(worktreePath
+      ? {
+          worktreePath,
+          worktreeInstanceId: createWorktreeInstanceId(
+            authority.nodeId,
+            worktreePath
+          ),
+        }
+      : {}),
+  };
+}
+
+function localSessionIdOf(
+  value: SessionScopeCandidate | SessionEventScope
+): string | undefined {
+  return (
+    value.localSessionId ??
+    value.sessionId ??
+    ('id' in value ? value.id : undefined)
+  );
+}
+
+export function sessionEventMatches(
+  candidate: SessionScopeCandidate,
+  event: SessionEventScope
+): boolean {
+  if (event.globalSessionId) {
+    return candidate.globalSessionId === event.globalSessionId;
+  }
+
+  const candidateLocalId = localSessionIdOf(candidate);
+  const eventLocalId = localSessionIdOf(event);
+  if (!candidateLocalId || !eventLocalId || candidateLocalId !== eventLocalId) {
+    return false;
+  }
+
+  if (event.nodeId) {
+    return candidate.nodeId === event.nodeId;
+  }
+
+  return true;
+}
+
+export function sessionScopeFromEvent(
+  event: SessionEventScope
+): SessionEventScope {
+  const localSessionId = localSessionIdOf(event);
+  return {
+    ...(localSessionId ? { sessionId: localSessionId, localSessionId } : {}),
+    ...(event.nodeId ? { nodeId: event.nodeId } : {}),
+    ...(event.globalSessionId
+      ? { globalSessionId: event.globalSessionId }
+      : {}),
+  };
+}

--- a/test/hooks/useEventSocket.test.ts
+++ b/test/hooks/useEventSocket.test.ts
@@ -310,6 +310,34 @@ describe('useEventSocket repo-scoped refresh', () => {
     );
   });
 
+  it('passes node/global session scope through telemetry events', () => {
+    mount();
+    const telemetry = {
+      sessionId: 'same-local-id',
+      totalInputTokens: 22,
+    };
+
+    wsMock.onMessage?.({
+      type: 'session-telemetry',
+      sessionId: 'same-local-id',
+      localSessionId: 'same-local-id',
+      nodeId: 'node-b',
+      globalSessionId: 'node-b:same-local-id',
+      data: telemetry,
+    });
+
+    expect(telemetryMock.handleSessionTelemetryEvent).toHaveBeenCalledWith(
+      'same-local-id',
+      telemetry,
+      {
+        sessionId: 'same-local-id',
+        localSessionId: 'same-local-id',
+        nodeId: 'node-b',
+        globalSessionId: 'node-b:same-local-id',
+      }
+    );
+  });
+
   it('cleanup cancels pending pr/ci throttle timers', () => {
     mount();
 

--- a/test/node-boundary.test.ts
+++ b/test/node-boundary.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_LOCAL_ENVIRONMENT_ID,
+  createLocalEventAuthority,
+  createNodeScopedFileEvent,
+  createNodeScopedSessionEvent,
+  nodeSessionWebSocketPath,
+  sessionEventMatches,
+} from '../shared/node-boundary.js';
+
+import { createLocalRelayNode } from '../server/local-node.js';
+import type {
+  CreateParams,
+  CreateResult,
+  CreateWebParams,
+} from '../server/sessions.js';
+
+describe('node boundary primitives', () => {
+  it('declares a stable local environment authority for local mode events', () => {
+    expect(DEFAULT_LOCAL_ENVIRONMENT_ID).toBe('local');
+    expect(createLocalEventAuthority()).toEqual({
+      nodeId: 'local',
+      environmentId: 'local',
+      authority: 'local-node',
+    });
+  });
+
+  it('creates node-scoped session event references without changing the local id', () => {
+    const event = createNodeScopedSessionEvent('abc123', {
+      nodeId: 'desktop:one',
+      environmentId: 'dev',
+    });
+
+    expect(event).toEqual({
+      nodeId: 'desktop:one',
+      environmentId: 'dev',
+      authority: 'local-node',
+      sessionId: 'abc123',
+      localSessionId: 'abc123',
+      globalSessionId: 'desktop%3Aone:abc123',
+    });
+    expect(
+      sessionEventMatches(
+        { id: 'abc123', nodeId: 'other', globalSessionId: 'other:abc123' },
+        event
+      )
+    ).toBe(false);
+    expect(
+      sessionEventMatches(
+        {
+          id: 'abc123',
+          nodeId: 'desktop:one',
+          globalSessionId: 'desktop%3Aone:abc123',
+        },
+        event
+      )
+    ).toBe(true);
+  });
+
+  it('keeps file/worktree events scoped to the node-owned path instances', () => {
+    expect(
+      createNodeScopedFileEvent({
+        workspacePath: '/repos/relay-ide',
+        worktreePath: '/repos/relay-ide/.worktrees/a',
+        nodeId: 'node/a',
+      })
+    ).toEqual({
+      nodeId: 'node/a',
+      environmentId: 'local',
+      authority: 'local-node',
+      workspacePath: '/repos/relay-ide',
+      repoInstanceId: 'node%2Fa:%2Frepos%2Frelay-ide',
+      worktreePath: '/repos/relay-ide/.worktrees/a',
+      worktreeInstanceId: 'node%2Fa:%2Frepos%2Frelay-ide%2F.worktrees%2Fa',
+    });
+  });
+
+  it('identifies the future node-owned session websocket route shape', () => {
+    expect(nodeSessionWebSocketPath('node/a', 'session one')).toBe(
+      '/nodes/node%2Fa/ws/sessions/session%20one'
+    );
+  });
+
+  it('exposes a local relay-node facade over injected session operations', () => {
+    const calls: string[] = [];
+    const node = createLocalRelayNode({
+      sessions: {
+        list: () => {
+          calls.push('list');
+          return [];
+        },
+        get: (id: string) => {
+          calls.push(`get:${id}`);
+          return undefined;
+        },
+        create: (params: CreateParams): CreateResult => {
+          calls.push('create');
+          return { id: params.id ?? 'created' } as CreateResult;
+        },
+        createWeb: async (params: CreateWebParams) => {
+          calls.push('createWeb');
+          return { session: { id: params.id ?? 'web' } as CreateResult };
+        },
+        kill: (id: string) => {
+          calls.push(`kill:${id}`);
+        },
+        updateDisplayName: (id: string, displayName: string) => {
+          calls.push(`update:${id}:${displayName}`);
+          return { id, displayName };
+        },
+        write: (id: string, data: string) => {
+          calls.push(`write:${id}:${data}`);
+        },
+      },
+    });
+
+    expect(node.nodeId).toBe('local');
+    expect(node.environmentId).toBe('local');
+    expect(node.sessions.list()).toEqual([]);
+    expect(node.sessions.get('s1')).toBeUndefined();
+    expect(node.sessions.create({ id: 's1' } as CreateParams)).toEqual({
+      id: 's1',
+    });
+    expect(node.sessions.updateDisplayName('s1', 'renamed')).toEqual({
+      id: 's1',
+      displayName: 'renamed',
+    });
+    node.sessions.write('s1', 'x');
+    node.sessions.kill('s1');
+
+    expect(calls).toEqual([
+      'list',
+      'get:s1',
+      'create',
+      'update:s1:renamed',
+      'write:s1:x',
+      'kill:s1',
+    ]);
+  });
+});

--- a/test/stores/sessions-node-scope.test.ts
+++ b/test/stores/sessions-node-scope.test.ts
@@ -8,12 +8,22 @@ const apiMocks = vi.hoisted(() => ({
   fetchWorkspaceGroups: vi.fn(),
 }));
 
+const notificationMocks = vi.hoisted(() => ({
+  fireNotification: vi.fn(),
+  shouldFireNotification: vi.fn(() => true),
+}));
+
 vi.mock('../../frontend/src/lib/api.js', () => ({
   enrichBranches: apiMocks.enrichBranches,
   fetchSessions: apiMocks.fetchSessions,
   fetchWorktrees: apiMocks.fetchWorktrees,
   fetchWorkspaces: apiMocks.fetchWorkspaces,
   fetchWorkspaceGroups: apiMocks.fetchWorkspaceGroups,
+}));
+
+vi.mock('../../frontend/src/lib/notifications.js', () => ({
+  fireNotification: notificationMocks.fireNotification,
+  shouldFireNotification: notificationMocks.shouldFireNotification,
 }));
 
 const storage: Record<string, string> = {};
@@ -35,6 +45,7 @@ import type {
   SidebarItem,
 } from '../../frontend/src/lib/types.js';
 import { useSessionsStore } from '../../frontend/src/lib/stores/sessions.js';
+import { useUnreadStore } from '../../frontend/src/lib/stores/unread.js';
 
 const nodeASession: SessionSummary = {
   id: 'same-local-id',
@@ -86,6 +97,7 @@ describe('sessions store node-scoped events', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-11T00:00:00.000Z'));
     vi.clearAllMocks();
+    useUnreadStore.setState({ unreadItems: new Set() });
     useSessionsStore.setState({
       sessions: [nodeASession, nodeBSession],
       worktrees: [],
@@ -117,6 +129,47 @@ describe('sessions store node-scoped events', () => {
       sessions.find((s) => s.globalSessionId === 'node-b:same-local-id')
         ?.agentState
     ).toBe('idle');
+  });
+
+
+
+  it('scopes sidebar aggregate state when duplicate local ids collide across nodes', () => {
+    (useSessionsStore.getState().handleBackendStateChanged as any)(
+      'same-local-id',
+      'idle',
+      undefined,
+      { nodeId: 'node-b', globalSessionId: 'node-b:same-local-id' }
+    );
+
+    const sidebarItems = useSessionsStore.getState().sidebarItems;
+    const nodeAItem = sidebarItems.find((item) => item.nodeId === 'node-a');
+    const nodeBItem = sidebarItems.find((item) => item.nodeId === 'node-b');
+
+    expect(nodeAItem?.lastKnownBackendState).toBe('running');
+    expect(nodeAItem?.displayState).toBe('running');
+    expect(nodeBItem?.lastKnownBackendState).toBe('idle');
+    expect(nodeBItem?.displayState).toBe('unseen-idle');
+  });
+
+  it('does not treat an ambiguous bare active session id as viewing a sibling node item', () => {
+    useSessionsStore.setState({ activeSessionId: 'same-local-id' });
+
+    (useSessionsStore.getState().handleBackendStateChanged as any)(
+      'same-local-id',
+      'permission',
+      'approval',
+      { nodeId: 'node-b', globalSessionId: 'node-b:same-local-id' }
+    );
+
+    const sidebarItems = useSessionsStore.getState().sidebarItems;
+    const nodeAItem = sidebarItems.find((item) => item.nodeId === 'node-a');
+    const nodeBItem = sidebarItems.find((item) => item.nodeId === 'node-b');
+
+    expect(nodeAItem?.displayState).toBe('running');
+    expect(nodeAItem?.isUnread).toBeFalsy();
+    expect(nodeBItem?.displayState).toBe('permission');
+    expect(nodeBItem?.isUnread).toBe(true);
+    expect(useUnreadStore.getState().isUnread(nodeBItem!.id)).toBe(true);
   });
 
   it('renames only the scoped session when nodeId disambiguates a duplicate local id', () => {

--- a/test/stores/sessions-node-scope.test.ts
+++ b/test/stores/sessions-node-scope.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiMocks = vi.hoisted(() => ({
+  enrichBranches: vi.fn(),
+  fetchSessions: vi.fn(),
+  fetchWorktrees: vi.fn(),
+  fetchWorkspaces: vi.fn(),
+  fetchWorkspaceGroups: vi.fn(),
+}));
+
+vi.mock('../../frontend/src/lib/api.js', () => ({
+  enrichBranches: apiMocks.enrichBranches,
+  fetchSessions: apiMocks.fetchSessions,
+  fetchWorktrees: apiMocks.fetchWorktrees,
+  fetchWorkspaces: apiMocks.fetchWorkspaces,
+  fetchWorkspaceGroups: apiMocks.fetchWorkspaceGroups,
+}));
+
+const storage: Record<string, string> = {};
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: (key: string) => storage[key] ?? null,
+    setItem: (key: string, value: string) => {
+      storage[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete storage[key];
+    },
+  },
+  configurable: true,
+});
+
+import type {
+  SessionSummary,
+  SidebarItem,
+} from '../../frontend/src/lib/types.js';
+import { useSessionsStore } from '../../frontend/src/lib/stores/sessions.js';
+
+const nodeASession: SessionSummary = {
+  id: 'same-local-id',
+  type: 'agent',
+  agent: 'claude',
+  mode: 'pty',
+  repoName: 'relay-ide',
+  repoPath: '/node-a/relay-ide',
+  worktreePath: null,
+  cwd: '/node-a/relay-ide',
+  branchName: 'main',
+  displayName: 'node a',
+  createdAt: '2026-05-11T00:00:00.000Z',
+  lastActivity: '2026-05-11T00:00:00.000Z',
+  idle: false,
+  nodeId: 'node-a',
+  globalSessionId: 'node-a:same-local-id',
+  agentState: 'processing',
+};
+
+const nodeBSession: SessionSummary = {
+  ...nodeASession,
+  repoPath: '/node-b/relay-ide',
+  cwd: '/node-b/relay-ide',
+  displayName: 'node b',
+  nodeId: 'node-b',
+  globalSessionId: 'node-b:same-local-id',
+};
+
+function sidebarItem(session: SessionSummary): SidebarItem {
+  return {
+    id: `session::${session.globalSessionId}`,
+    kind: 'repo',
+    path: session.repoPath,
+    repoPath: session.repoPath,
+    displayName: session.displayName,
+    branchName: session.branchName,
+    lastActivity: session.lastActivity,
+    displayState: 'running',
+    lastKnownBackendState: 'running',
+    sessions: [session],
+    nodeId: session.nodeId,
+    repoInstanceId: session.repoInstanceId,
+  };
+}
+
+describe('sessions store node-scoped events', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T00:00:00.000Z'));
+    vi.clearAllMocks();
+    useSessionsStore.setState({
+      sessions: [nodeASession, nodeBSession],
+      worktrees: [],
+      repos: [],
+      workspaceGroups: [],
+      activeSessionId: null,
+      sidebarItems: [sidebarItem(nodeASession), sidebarItem(nodeBSession)],
+      enrichmentResults: {},
+      repoEnrichmentMeta: {},
+      reconnectingPtySessionIds: {},
+      backendConnectionStatus: 'connected',
+    });
+  });
+
+  it('updates only the matching global session when local ids collide across nodes', () => {
+    (useSessionsStore.getState().handleBackendStateChanged as any)(
+      'same-local-id',
+      'idle',
+      undefined,
+      { nodeId: 'node-b', globalSessionId: 'node-b:same-local-id' }
+    );
+
+    const sessions = useSessionsStore.getState().sessions;
+    expect(
+      sessions.find((s) => s.globalSessionId === 'node-a:same-local-id')
+        ?.agentState
+    ).toBe('processing');
+    expect(
+      sessions.find((s) => s.globalSessionId === 'node-b:same-local-id')
+        ?.agentState
+    ).toBe('idle');
+  });
+
+  it('renames only the scoped session when nodeId disambiguates a duplicate local id', () => {
+    (useSessionsStore.getState().renameSession as any)(
+      'same-local-id',
+      'feature-b',
+      'renamed b',
+      { nodeId: 'node-b' }
+    );
+
+    const sessions = useSessionsStore.getState().sessions;
+    expect(sessions.find((s) => s.nodeId === 'node-a')?.displayName).toBe(
+      'node a'
+    );
+    expect(sessions.find((s) => s.nodeId === 'node-b')?.displayName).toBe(
+      'renamed b'
+    );
+  });
+});

--- a/test/stores/sessions-node-scope.test.ts
+++ b/test/stores/sessions-node-scope.test.ts
@@ -188,4 +188,85 @@ describe('sessions store node-scoped events', () => {
       'renamed b'
     );
   });
+
+  it('treats a scoped active session id as viewing only that node item', () => {
+    useSessionsStore.setState({ activeSessionId: 'node-b:same-local-id' });
+
+    (useSessionsStore.getState().handleBackendStateChanged as any)(
+      'same-local-id',
+      'permission',
+      'approval',
+      { nodeId: 'node-b', globalSessionId: 'node-b:same-local-id' }
+    );
+
+    const sidebarItems = useSessionsStore.getState().sidebarItems;
+    const nodeAItem = sidebarItems.find((item) => item.nodeId === 'node-a');
+    const nodeBItem = sidebarItems.find((item) => item.nodeId === 'node-b');
+
+    expect(nodeAItem?.displayState).toBe('running');
+    expect(nodeAItem?.isUnread).toBeFalsy();
+    expect(nodeBItem?.displayState).toBe('permission');
+    expect(nodeBItem?.isUnread).toBe(false);
+    expect(useUnreadStore.getState().isUnread(nodeBItem!.id)).toBe(false);
+  });
+
+  it('marks only the scoped viewed session read', () => {
+    const nodeBItem = useSessionsStore
+      .getState()
+      .sidebarItems.find((item) => item.nodeId === 'node-b')!;
+    useUnreadStore.getState().markUnread(nodeBItem.id);
+    useSessionsStore.setState((state) => ({
+      sidebarItems: state.sidebarItems.map((item) =>
+        item.nodeId === 'node-b'
+          ? { ...item, displayState: 'permission', isUnread: true }
+          : item
+      ),
+    }));
+
+    useSessionsStore.getState().handleUserViewed('node-b:same-local-id');
+
+    const sidebarItems = useSessionsStore.getState().sidebarItems;
+    const nodeAItem = sidebarItems.find((item) => item.nodeId === 'node-a');
+    const updatedNodeBItem = sidebarItems.find((item) => item.nodeId === 'node-b');
+
+    expect(nodeAItem?.displayState).toBe('running');
+    expect(nodeAItem?.isUnread).toBeFalsy();
+    expect(updatedNodeBItem?.isUnread).toBe(false);
+    expect(useUnreadStore.getState().isUnread(nodeBItem.id)).toBe(false);
+  });
+
+  it('does not apply legacy bare notification prefs to ambiguous node-scoped sessions', () => {
+    useSessionsStore.setState({
+      activeSessionId: null,
+      notificationSessions: { 'same-local-id': true },
+    });
+
+    (useSessionsStore.getState().handleBackendStateChanged as any)(
+      'same-local-id',
+      'permission',
+      'approval',
+      { nodeId: 'node-b', globalSessionId: 'node-b:same-local-id' }
+    );
+
+    expect(notificationMocks.fireNotification).not.toHaveBeenCalled();
+  });
+
+  it('prunes ambiguous bare session-keyed maps during refreshAll', async () => {
+    apiMocks.fetchSessions.mockResolvedValue([nodeASession, nodeBSession]);
+    apiMocks.fetchWorktrees.mockResolvedValue([]);
+    apiMocks.fetchWorkspaces.mockResolvedValue([]);
+    apiMocks.fetchWorkspaceGroups.mockResolvedValue([]);
+
+    useSessionsStore.setState({
+      activeSessionId: 'same-local-id',
+      notificationSessions: { 'same-local-id': true },
+      workspaceLastSession: { '/node-b/relay-ide': 'same-local-id' },
+    });
+
+    await useSessionsStore.getState().refreshAll();
+
+    expect(useSessionsStore.getState().activeSessionId).toBe(null);
+    expect(useSessionsStore.getState().notificationSessions).toEqual({});
+    expect(useSessionsStore.getState().workspaceLastSession).toEqual({});
+  });
 });

--- a/test/stores/telemetry-node-scope.test.ts
+++ b/test/stores/telemetry-node-scope.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../frontend/src/lib/api.js', () => ({
+  fetchSessionTelemetry: vi.fn(),
+  fetchAccountTelemetry: vi.fn(),
+  fetchTelemetrySetupStatus: vi.fn(),
+}));
+
+import type {
+  SessionSummary,
+  SessionTelemetry,
+} from '../../frontend/src/lib/types.js';
+import { useTelemetryStore } from '../../frontend/src/lib/stores/telemetry.js';
+
+const nodeASession: SessionSummary = {
+  id: 'same-local-id',
+  type: 'agent',
+  agent: 'claude',
+  mode: 'pty',
+  repoName: 'relay-ide',
+  repoPath: '/node-a/relay-ide',
+  worktreePath: null,
+  cwd: '/node-a/relay-ide',
+  branchName: 'main',
+  displayName: 'node a',
+  createdAt: '2026-05-11T00:00:00.000Z',
+  lastActivity: '2026-05-11T00:00:00.000Z',
+  idle: false,
+  nodeId: 'node-a',
+  globalSessionId: 'node-a:same-local-id',
+};
+
+const nodeBSession: SessionSummary = {
+  ...nodeASession,
+  repoPath: '/node-b/relay-ide',
+  cwd: '/node-b/relay-ide',
+  displayName: 'node b',
+  nodeId: 'node-b',
+  globalSessionId: 'node-b:same-local-id',
+};
+
+function makeTelemetry(
+  overrides: Partial<SessionTelemetry> = {}
+): SessionTelemetry {
+  return {
+    sessionId: 'same-local-id',
+    model: 'Claude Sonnet 4',
+    totalInputTokens: 10,
+    totalOutputTokens: 20,
+    totalCacheRead: 30,
+    totalCacheWrite: 40,
+    contextPercent: 12,
+    contextWindowSize: 200000,
+    costUsd: 0.5,
+    turnCount: 1,
+    subagentCount: 0,
+    source: 'statusLine',
+    updatedAt: '2026-05-11T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('telemetry store node-scoped sessions', () => {
+  beforeEach(() => {
+    useTelemetryStore.setState({
+      sessionTelemetryById: {},
+      accountTelemetryByFramework: {},
+      telemetrySetupInstalled: null,
+    });
+  });
+
+  it('keeps telemetry separate when local session ids collide across nodes', () => {
+    const state = useTelemetryStore.getState();
+
+    state.handleSessionTelemetryEvent(
+      'same-local-id',
+      makeTelemetry({ totalInputTokens: 11 }),
+      {
+        sessionId: 'same-local-id',
+        localSessionId: 'same-local-id',
+        nodeId: 'node-a',
+        globalSessionId: 'node-a:same-local-id',
+      }
+    );
+    state.handleSessionTelemetryEvent(
+      'same-local-id',
+      makeTelemetry({ totalInputTokens: 22 }),
+      {
+        sessionId: 'same-local-id',
+        localSessionId: 'same-local-id',
+        nodeId: 'node-b',
+        globalSessionId: 'node-b:same-local-id',
+      }
+    );
+
+    const latest = useTelemetryStore.getState();
+    expect(Object.keys(latest.sessionTelemetryById).sort()).toEqual([
+      'node-a:same-local-id',
+      'node-b:same-local-id',
+    ]);
+    expect(
+      latest.summarizeSessionTelemetry(nodeASession)?.totalInputTokens
+    ).toBe(11);
+    expect(
+      latest.summarizeSessionTelemetry(nodeBSession)?.totalInputTokens
+    ).toBe(22);
+    expect(
+      latest.summarizeSessionSetTelemetry([nodeASession, nodeBSession])
+    ).toMatchObject({
+      trackedSessions: 2,
+      totalSessions: 2,
+      totalInputTokens: 33,
+    });
+  });
+
+  it('merges and prunes batch snapshots using scoped telemetry keys', () => {
+    const state = useTelemetryStore.getState();
+
+    state.setSessionTelemetryBatch(
+      [
+        makeTelemetry({
+          nodeId: 'node-a',
+          globalSessionId: 'node-a:same-local-id',
+          totalInputTokens: 11,
+        }),
+        makeTelemetry({
+          nodeId: 'node-b',
+          globalSessionId: 'node-b:same-local-id',
+          totalInputTokens: 22,
+        }),
+      ],
+      '2026-05-11T00:00:00.000Z'
+    );
+
+    expect(Object.keys(useTelemetryStore.getState().sessionTelemetryById).sort())
+      .toEqual(['node-a:same-local-id', 'node-b:same-local-id']);
+
+    useTelemetryStore.getState().pruneSessionTelemetry([nodeBSession]);
+
+    const latest = useTelemetryStore.getState();
+    expect(Object.keys(latest.sessionTelemetryById)).toEqual([
+      'node-b:same-local-id',
+    ]);
+    expect(latest.summarizeSessionTelemetry(nodeASession)).toBeNull();
+    expect(latest.summarizeSessionTelemetry(nodeBSession)?.totalInputTokens).toBe(
+      22
+    );
+  });
+});

--- a/test/telemetry-api.test.ts
+++ b/test/telemetry-api.test.ts
@@ -59,6 +59,44 @@ test('fetchSessionTelemetry handles plain object-map responses', async () => {
   ]);
 });
 
+test('fetchSessionTelemetry handles globally scoped object-map responses', async () => {
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        sessions: {
+          'node-a:same-local-id': {
+            model: 'Claude Sonnet 4',
+            totalInputTokens: 10,
+            totalOutputTokens: 20,
+            totalCacheRead: 30,
+            totalCacheWrite: 40,
+            contextPercent: 12,
+            contextWindowSize: 200000,
+            costUsd: 0.5,
+            turnCount: 1,
+            subagentCount: 2,
+            source: 'statusLine',
+            updatedAt: '2026-04-01T00:00:00.000Z',
+          },
+        },
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    )) as typeof globalThis.fetch;
+
+  const result = await fetchSessionTelemetry();
+
+  expect(result[0]).toMatchObject({
+    sessionId: 'same-local-id',
+    localSessionId: 'same-local-id',
+    nodeId: 'node-a',
+    globalSessionId: 'node-a:same-local-id',
+    totalInputTokens: 10,
+  });
+});
+
 test('fetchTelemetrySetupStatus returns installed flag from the server response', async () => {
   globalThis.fetch = (async () =>
     new Response(JSON.stringify({ installed: true }), {

--- a/test/terminal-refs.test.ts
+++ b/test/terminal-refs.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sessionsStore = {
+  sessions: [] as Array<{
+    id: string;
+    nodeId?: string;
+    globalSessionId?: string;
+  }>,
+  activeSessionId: null as string | null,
+};
+const uiStore = {
+  sendToTargetSessionId: null as string | null,
+};
+
+vi.mock('../frontend/src/lib/stores/sessions.js', () => ({
+  useSessionsStore: {
+    getState: () => sessionsStore,
+  },
+}));
+vi.mock('../frontend/src/lib/stores/ui.js', () => ({
+  useUiStore: {
+    getState: () => uiStore,
+  },
+}));
+
+import {
+  _clearTerminalHandlesForTesting,
+  getActiveTerminalHandle,
+  getTerminalHandle,
+  setTerminalHandle,
+} from '../frontend/src/lib/terminal-refs.js';
+
+type TestTerminalHandle = NonNullable<Parameters<typeof setTerminalHandle>[1]>;
+
+const handle = (name: string): TestTerminalHandle =>
+  ({
+    getTerm: vi.fn(() => null),
+    focusTerm: vi.fn(),
+    fitTerm: vi.fn(),
+    exitCopyMode: vi.fn(),
+    handleImageUpload: vi.fn(async () => undefined),
+    name,
+  }) as unknown as TestTerminalHandle;
+
+describe('terminal refs scoped identity', () => {
+  beforeEach(() => {
+    _clearTerminalHandlesForTesting();
+    sessionsStore.sessions = [];
+    sessionsStore.activeSessionId = null;
+    uiStore.sendToTargetSessionId = null;
+  });
+
+  it('preserves legacy local-id handle lookup', () => {
+    const localHandle = handle('local');
+    setTerminalHandle('local-session', localHandle);
+
+    sessionsStore.activeSessionId = 'local-session';
+
+    expect(getTerminalHandle('local-session')).toBe(localHandle);
+    expect(getActiveTerminalHandle()).toBe(localHandle);
+  });
+
+  it('routes scoped active ids to scoped handles without collapsing duplicate local ids', () => {
+    const nodeAHandle = handle('node-a');
+    const nodeBHandle = handle('node-b');
+    sessionsStore.sessions = [
+      {
+        id: 'same-local-id',
+        nodeId: 'node-a',
+        globalSessionId: 'node-a:same-local-id',
+      },
+      {
+        id: 'same-local-id',
+        nodeId: 'node-b',
+        globalSessionId: 'node-b:same-local-id',
+      },
+    ];
+    setTerminalHandle('node-a:same-local-id', nodeAHandle);
+    setTerminalHandle('node-b:same-local-id', nodeBHandle);
+
+    sessionsStore.activeSessionId = 'node-b:same-local-id';
+    expect(getActiveTerminalHandle()).toBe(nodeBHandle);
+
+    uiStore.sendToTargetSessionId = 'node-a:same-local-id';
+    expect(getActiveTerminalHandle()).toBe(nodeAHandle);
+  });
+
+  it('does not guess a handle for ambiguous bare local ids across nodes', () => {
+    const nodeAHandle = handle('node-a');
+    const nodeBHandle = handle('node-b');
+    sessionsStore.sessions = [
+      {
+        id: 'same-local-id',
+        nodeId: 'node-a',
+        globalSessionId: 'node-a:same-local-id',
+      },
+      {
+        id: 'same-local-id',
+        nodeId: 'node-b',
+        globalSessionId: 'node-b:same-local-id',
+      },
+    ];
+    setTerminalHandle('node-a:same-local-id', nodeAHandle);
+    setTerminalHandle('node-b:same-local-id', nodeBHandle);
+
+    sessionsStore.activeSessionId = 'same-local-id';
+
+    expect(getActiveTerminalHandle()).toBe(null);
+  });
+});

--- a/test/ws-node-scope.test.ts
+++ b/test/ws-node-scope.test.ts
@@ -1,0 +1,53 @@
+import { EventEmitter, once } from 'node:events';
+import * as http from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+import { WebSocket } from 'ws';
+import { createLocalRelayNode } from '../server/local-node.js';
+import { setupWebSocket } from '../server/ws.js';
+import type { WorktreeWatcher } from '../server/watcher.js';
+
+const cleanupFns: Array<() => void> = [];
+
+afterEach(() => {
+  for (const cleanup of cleanupFns.splice(0)) cleanup();
+});
+
+describe('node-scoped websocket broadcasts', () => {
+  it('adds local authority to no-payload worktrees-changed events', async () => {
+    const server = http.createServer();
+    const watcher = new EventEmitter();
+    const { wss } = setupWebSocket(
+      server,
+      new Set<string>(),
+      watcher as unknown as WorktreeWatcher,
+      undefined,
+      true,
+      createLocalRelayNode({ nodeId: 'node-a', environmentId: 'env-a' })
+    );
+
+    cleanupFns.push(() => wss.close());
+    cleanupFns.push(() => server.close());
+
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('server did not listen on a tcp port');
+    }
+
+    const client = new WebSocket(`ws://127.0.0.1:${address.port}/ws/events`);
+    cleanupFns.push(() => client.close());
+    await once(client, 'open');
+
+    const messagePromise = once(client, 'message');
+    watcher.emit('worktrees-changed');
+    const [raw] = await messagePromise;
+    const payload = JSON.parse(raw.toString()) as Record<string, unknown>;
+
+    expect(payload).toMatchObject({
+      type: 'worktrees-changed',
+      nodeId: 'node-a',
+      environmentId: 'env-a',
+      authority: 'local-node',
+    });
+  });
+});

--- a/test/ws-pty-routing.test.ts
+++ b/test/ws-pty-routing.test.ts
@@ -3,6 +3,11 @@ import type { Terminal } from '@xterm/xterm';
 
 // We need to mock store imports BEFORE importing ws.ts
 const sessionsStore = {
+  sessions: [] as Array<{
+    id: string;
+    nodeId?: string;
+    globalSessionId?: string;
+  }>,
   activeSessionId: null as string | null,
   beginPtyReconnect: vi.fn(),
   clearPtyReconnect: vi.fn(),
@@ -64,6 +69,7 @@ class FakeWebSocket {
 
 beforeEach(() => {
   sockets.length = 0;
+  sessionsStore.sessions = [];
   sessionsStore.activeSessionId = null;
   sessionsStore.beginPtyReconnect.mockClear();
   sessionsStore.clearPtyReconnect.mockClear();
@@ -179,6 +185,22 @@ describe('per-session PTY routing', () => {
     sessionsStore.activeSessionId = 'sess-a';
     ws.sendPtyData('to-active');
     expect(sockets[0]!.send).toHaveBeenCalledWith('to-active');
+  });
+
+  it('no-arg sendPtyData resolves a scoped activeSessionId to its PTY socket', async () => {
+    const ws = await importWs();
+    ws.connectPtySocket('local-session', fakeTerm(), vi.fn(), vi.fn());
+    sockets[0]!.__triggerOpen();
+    sessionsStore.sessions = [
+      {
+        id: 'local-session',
+        nodeId: 'node-a',
+        globalSessionId: 'node-a:local-session',
+      },
+    ];
+    sessionsStore.activeSessionId = 'node-a:local-session';
+    ws.sendPtyData('to-scoped-active');
+    expect(sockets[0]!.send).toHaveBeenCalledWith('to-scoped-active');
   });
 
   it('no-arg sendPtyData is a no-op when no active target', async () => {

--- a/test/ws-pty-routing.test.ts
+++ b/test/ws-pty-routing.test.ts
@@ -189,8 +189,6 @@ describe('per-session PTY routing', () => {
 
   it('no-arg sendPtyData resolves a scoped activeSessionId to its PTY socket', async () => {
     const ws = await importWs();
-    ws.connectPtySocket('local-session', fakeTerm(), vi.fn(), vi.fn());
-    sockets[0]!.__triggerOpen();
     sessionsStore.sessions = [
       {
         id: 'local-session',
@@ -198,9 +196,43 @@ describe('per-session PTY routing', () => {
         globalSessionId: 'node-a:local-session',
       },
     ];
+    ws.connectPtySocket('local-session', fakeTerm(), vi.fn(), vi.fn());
+    sockets[0]!.__triggerOpen();
     sessionsStore.activeSessionId = 'node-a:local-session';
     ws.sendPtyData('to-scoped-active');
     expect(sockets[0]!.send).toHaveBeenCalledWith('to-scoped-active');
+  });
+
+  it('keeps duplicate local ids in separate scoped PTY connection slots', async () => {
+    const ws = await importWs();
+    sessionsStore.sessions = [
+      {
+        id: 'same-local-id',
+        nodeId: 'node-a',
+        globalSessionId: 'node-a:same-local-id',
+      },
+      {
+        id: 'same-local-id',
+        nodeId: 'node-b',
+        globalSessionId: 'node-b:same-local-id',
+      },
+    ];
+
+    ws.connectPtySocket('node-a:same-local-id', fakeTerm(), vi.fn(), vi.fn());
+    ws.connectPtySocket('node-b:same-local-id', fakeTerm(), vi.fn(), vi.fn());
+    sockets[0]!.__triggerOpen();
+    sockets[1]!.__triggerOpen();
+
+    expect(sockets).toHaveLength(2);
+    expect(sockets[0]!.url).toContain('/ws/same-local-id');
+    expect(sockets[1]!.url).toContain('/ws/same-local-id');
+    uiStore.sendToTargetSessionId = 'node-b:same-local-id';
+    ws.sendPtyData('to-node-b');
+
+    expect(sockets[1]!.send).toHaveBeenCalledWith('to-node-b');
+    expect(sockets[0]!.send).not.toHaveBeenCalledWith('to-node-b');
+    expect(ws.isPtyConnected('node-a:same-local-id')).toBe(true);
+    expect(ws.isPtyConnected('node-b:same-local-id')).toBe(true);
   });
 
   it('no-arg sendPtyData is a no-op when no active target', async () => {
@@ -244,7 +276,10 @@ describe('per-session PTY routing', () => {
 
     ws.connectEventSocket(vi.fn());
     sockets[2]!.onmessage?.({
-      data: JSON.stringify({ type: 'server-restarting', reason: 'dev-restart' }),
+      data: JSON.stringify({
+        type: 'server-restarting',
+        reason: 'dev-restart',
+      }),
     } as MessageEvent);
 
     expect(sessionsStore.beginPtyReconnect).toHaveBeenCalledTimes(2);
@@ -272,7 +307,10 @@ describe('per-session PTY routing', () => {
 
     ws.connectEventSocket(vi.fn());
     sockets[1]!.onmessage?.({
-      data: JSON.stringify({ type: 'server-restarting', reason: 'dev-restart' }),
+      data: JSON.stringify({
+        type: 'server-restarting',
+        reason: 'dev-restart',
+      }),
     } as MessageEvent);
     sockets[0]!.readyState = FakeWebSocket.CLOSED;
     sockets[0]!.onclose?.({ code: 1000 } as CloseEvent);
@@ -302,7 +340,10 @@ describe('per-session PTY routing', () => {
     const ws = await importWs();
     ws.connectEventSocket(vi.fn(), vi.fn(), onAuthRequired);
     sockets[0]!.onmessage?.({
-      data: JSON.stringify({ type: 'server-restarting', reason: 'dev-restart' }),
+      data: JSON.stringify({
+        type: 'server-restarting',
+        reason: 'dev-restart',
+      }),
     } as MessageEvent);
     sockets[0]!.readyState = FakeWebSocket.CLOSED;
     sockets[0]!.onclose?.({ code: 1006 } as CloseEvent);


### PR DESCRIPTION
## Summary
- add shared node-boundary primitives for node/environment/session/file event scope, future node-owned request shapes, and node websocket route identity
- route local server session operations through a LocalRelayNode facade and enrich WebSocket broadcasts with nodeId/environmentId/globalSessionId/repo instance metadata
- update frontend event message types and session store/socket routing so scoped events prefer globalSessionId, then nodeId + local sessionId, with legacy local-id fallback

## Tests
- npm run build
- rtk npm run check
- rtk npm test -- test/node-boundary.test.ts test/stores/sessions-node-scope.test.ts
- rtk npm test -- test/sessions.test.ts test/ws-pty-routing.test.ts test/hooks/useEventSocket.test.ts test/stores/sessions-enrichment.test.ts
- rtk npm test

Refs #317
Closes #374
Closes #375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scoped session/event handling for correct session targeting across nodes/environments
  * Environment-aware WebSocket broadcasts and telemetry so session data and notifications map to the right session

* **Bug Fixes**
  * Resolve ambiguous session IDs to prevent cross-node updates and incorrect unread/viewed states

* **Tests**
  * Expanded test coverage for node-scoped sessions, telemetry, and websocket broadcasts

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/393)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->