### PR TITLE
Add relay hub pairing and node registry

### DIFF
--- a/server/hub-node-link.ts
+++ b/server/hub-node-link.ts
@@ -1,0 +1,153 @@
+import type * as http from 'node:http';
+import { WebSocket } from 'ws';
+import type { RawData } from 'ws';
+import type { HubNodeRegistry } from './hub-node-registry.js';
+import type { NodeManifest } from '../shared/node-manifest.js';
+import {
+  RELAY_NODE_LINK_PROTOCOL,
+  type HubNodeSummary,
+  type RelayNodeEnvelope,
+  type RelayNodeError,
+} from '../shared/relay-node-protocol.js';
+
+interface AuthenticatedNodeLink {
+  node: HubNodeSummary;
+  token: string;
+}
+
+function bearerToken(request: http.IncomingMessage): string | null {
+  const header = request.headers.authorization ?? '';
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || null;
+}
+
+export function authenticateHubNodeLink(
+  request: http.IncomingMessage,
+  registry: HubNodeRegistry | undefined
+): AuthenticatedNodeLink | null {
+  if (!registry) return null;
+  const token = bearerToken(request);
+  if (!token) return null;
+  const node = registry.authenticateCredential(token);
+  return node ? { node, token } : null;
+}
+
+function errorEnvelope(
+  nodeId: string,
+  request: Partial<RelayNodeEnvelope>,
+  error: RelayNodeError
+): RelayNodeEnvelope {
+  return {
+    protocol: RELAY_NODE_LINK_PROTOCOL,
+    protocolVersion: '1.0',
+    nodeId,
+    channel: 'control',
+    type: 'control.error',
+    timestamp: new Date().toISOString(),
+    ...(typeof request.requestId === 'string' ? { requestId: request.requestId } : {}),
+    error,
+  };
+}
+
+function invalidRequest(message: string): RelayNodeError {
+  return { code: 'INVALID_REQUEST', message, retryable: false };
+}
+
+function parseEnvelope(data: RawData): RelayNodeEnvelope | RelayNodeError {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(data.toString());
+  } catch {
+    return invalidRequest('node-link messages must be JSON envelopes');
+  }
+  if (typeof parsed !== 'object' || parsed === null) {
+    return invalidRequest('node-link message must be an object');
+  }
+  const envelope = parsed as Partial<RelayNodeEnvelope>;
+  if (
+    envelope.protocol !== RELAY_NODE_LINK_PROTOCOL ||
+    typeof envelope.protocolVersion !== 'string' ||
+    typeof envelope.nodeId !== 'string' ||
+    envelope.channel !== 'control' ||
+    typeof envelope.type !== 'string'
+  ) {
+    return invalidRequest('invalid relay-node-link control envelope');
+  }
+  return envelope as RelayNodeEnvelope;
+}
+
+function manifestFromPayload(payload: unknown): NodeManifest | undefined {
+  if (typeof payload !== 'object' || payload === null) return undefined;
+  const manifest = (payload as Record<string, unknown>)['manifest'];
+  if (typeof manifest !== 'object' || manifest === null) return undefined;
+  const candidate = manifest as Partial<NodeManifest>;
+  if (candidate.schemaVersion !== 1 || typeof candidate.hostname !== 'string') return undefined;
+  return manifest as NodeManifest;
+}
+
+function sendJson(ws: WebSocket, payload: RelayNodeEnvelope): void {
+  if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(payload));
+}
+
+export function handleHubNodeLink(
+  ws: WebSocket,
+  registry: HubNodeRegistry,
+  authenticatedNode: HubNodeSummary
+): void {
+  const authenticatedNodeId = authenticatedNode.nodeId;
+
+  ws.on('message', (data) => {
+    const parsed = parseEnvelope(data);
+    if ('code' in parsed) {
+      sendJson(ws, errorEnvelope(authenticatedNodeId, {}, parsed));
+      return;
+    }
+
+    if (parsed.nodeId !== authenticatedNodeId) {
+      sendJson(
+        ws,
+        errorEnvelope(
+          authenticatedNodeId,
+          parsed,
+          invalidRequest('nodeId does not match authenticated credential')
+        )
+      );
+      return;
+    }
+
+    if (parsed.type !== 'control.heartbeat' && parsed.type !== 'control.hello') {
+      sendJson(
+        ws,
+        errorEnvelope(
+          authenticatedNodeId,
+          parsed,
+          invalidRequest(`unsupported control message: ${parsed.type}`)
+        )
+      );
+      return;
+    }
+
+    try {
+      const node = registry.recordHeartbeat({
+        nodeId: authenticatedNodeId,
+        protocolVersion: parsed.protocolVersion,
+        ...(manifestFromPayload(parsed.payload) ? { manifest: manifestFromPayload(parsed.payload)! } : {}),
+      });
+      sendJson(ws, {
+        protocol: RELAY_NODE_LINK_PROTOCOL,
+        protocolVersion: '1.0',
+        nodeId: authenticatedNodeId,
+        channel: 'control',
+        type:
+          parsed.type === 'control.hello'
+            ? 'control.hello.result'
+            : 'control.heartbeat.ack',
+        ...(typeof parsed.requestId === 'string' ? { requestId: parsed.requestId } : {}),
+        timestamp: new Date().toISOString(),
+        payload: { node },
+      });
+    } catch (error) {
+      sendJson(ws, errorEnvelope(authenticatedNodeId, parsed, registry.errorBody(error).error));
+    }
+  });
+}

--- a/server/hub-node-link.ts
+++ b/server/hub-node-link.ts
@@ -2,9 +2,10 @@ import type * as http from 'node:http';
 import { WebSocket } from 'ws';
 import type { RawData } from 'ws';
 import type { HubNodeRegistry } from './hub-node-registry.js';
-import type { NodeManifest } from '../shared/node-manifest.js';
+import { isNodeManifest, type NodeManifest } from '../shared/node-manifest.js';
 import {
   RELAY_NODE_LINK_PROTOCOL,
+  RELAY_NODE_LINK_PROTOCOL_VERSION,
   type HubNodeSummary,
   type RelayNodeEnvelope,
   type RelayNodeError,
@@ -39,7 +40,7 @@ function errorEnvelope(
 ): RelayNodeEnvelope {
   return {
     protocol: RELAY_NODE_LINK_PROTOCOL,
-    protocolVersion: '1.0',
+    protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
     nodeId,
     channel: 'control',
     type: 'control.error',
@@ -76,13 +77,12 @@ function parseEnvelope(data: RawData): RelayNodeEnvelope | RelayNodeError {
   return envelope as RelayNodeEnvelope;
 }
 
-function manifestFromPayload(payload: unknown): NodeManifest | undefined {
+function manifestFromPayload(payload: unknown): NodeManifest | RelayNodeError | undefined {
   if (typeof payload !== 'object' || payload === null) return undefined;
   const manifest = (payload as Record<string, unknown>)['manifest'];
-  if (typeof manifest !== 'object' || manifest === null) return undefined;
-  const candidate = manifest as Partial<NodeManifest>;
-  if (candidate.schemaVersion !== 1 || typeof candidate.hostname !== 'string') return undefined;
-  return manifest as NodeManifest;
+  if (manifest === undefined || manifest === null) return undefined;
+  if (!isNodeManifest(manifest)) return invalidRequest('manifest is malformed');
+  return manifest;
 }
 
 function sendJson(ws: WebSocket, payload: RelayNodeEnvelope): void {
@@ -128,14 +128,19 @@ export function handleHubNodeLink(
     }
 
     try {
+      const manifestResult = manifestFromPayload(parsed.payload);
+      if (manifestResult && 'code' in manifestResult) {
+        sendJson(ws, errorEnvelope(authenticatedNodeId, parsed, manifestResult));
+        return;
+      }
       const node = registry.recordHeartbeat({
         nodeId: authenticatedNodeId,
         protocolVersion: parsed.protocolVersion,
-        ...(manifestFromPayload(parsed.payload) ? { manifest: manifestFromPayload(parsed.payload)! } : {}),
+        ...(manifestResult ? { manifest: manifestResult } : {}),
       });
       sendJson(ws, {
         protocol: RELAY_NODE_LINK_PROTOCOL,
-        protocolVersion: '1.0',
+        protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
         nodeId: authenticatedNodeId,
         channel: 'control',
         type:

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -2,6 +2,7 @@ import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { NodeCapabilityProbe, NodeManifest } from '../shared/node-manifest.js';
+import { createLogger } from './logger.js';
 import {
   RELAY_NODE_LINK_PROTOCOL,
   RELAY_NODE_LINK_PROTOCOL_VERSION,
@@ -12,6 +13,8 @@ import {
   type RelayNodeError,
   type RelayNodeErrorCode,
 } from '../shared/relay-node-protocol.js';
+
+const logger = createLogger('hub-node-registry');
 
 interface StoredPairToken {
   tokenId: string;
@@ -49,7 +52,6 @@ export interface PairTokenResponse {
   tokenId: string;
   pairToken: string;
   expiresAt: string;
-  bootstrapCommand: string;
 }
 
 export interface PairExchangeInput {
@@ -108,13 +110,15 @@ function timingSafeEqualHex(a: string, b: string): boolean {
 }
 
 function assertCompatibleProtocol(protocolVersion: string): void {
-  const [major] = protocolVersion.split('.');
-  if (major !== '1') {
-    throw new HubNodeRegistryError(
-      'PROTOCOL_INCOMPATIBLE',
-      `relay-node-link protocol ${protocolVersion} is not compatible with hub protocol ${RELAY_NODE_LINK_PROTOCOL_VERSION}`
-    );
-  }
+  if (protocolVersion === RELAY_NODE_LINK_PROTOCOL_VERSION) return;
+  const [requestedMajor] = protocolVersion.split('.');
+  const [hubMajor] = RELAY_NODE_LINK_PROTOCOL_VERSION.split('.');
+  const code: RelayNodeErrorCode =
+    requestedMajor === hubMajor ? 'VERSION_SKEW' : 'PROTOCOL_INCOMPATIBLE';
+  throw new HubNodeRegistryError(
+    code,
+    `relay-node-link protocol ${protocolVersion} must exactly match hub protocol ${RELAY_NODE_LINK_PROTOCOL_VERSION}`
+  );
 }
 
 function countProbe(
@@ -166,15 +170,41 @@ function readRegistryFile(storagePath: string): RegistryFile {
   } catch (error) {
     const maybeNodeError = error as NodeJS.ErrnoException;
     if (maybeNodeError.code === 'ENOENT') return emptyRegistryFile();
+    if (error instanceof SyntaxError) {
+      quarantineCorruptRegistryFile(storagePath);
+      return emptyRegistryFile();
+    }
     throw error;
+  }
+}
+
+function quarantineCorruptRegistryFile(storagePath: string): void {
+  const quarantinePath = `${storagePath}.corrupt-${Date.now()}`;
+  try {
+    fs.renameSync(storagePath, quarantinePath);
+    logger.warn(
+      'hub node registry file is corrupt; quarantined file and starting with empty registry: %s',
+      quarantinePath
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(
+      'hub node registry file is corrupt; could not quarantine file and starting with empty registry: %s',
+      message
+    );
   }
 }
 
 function writeRegistryFile(storagePath: string, registry: RegistryFile): void {
   fs.mkdirSync(path.dirname(storagePath), { recursive: true });
   const tmpPath = `${storagePath}.${process.pid}.${Date.now()}.tmp`;
-  fs.writeFileSync(tmpPath, `${JSON.stringify(registry, null, 2)}\n`, { mode: 0o600 });
-  fs.renameSync(tmpPath, storagePath);
+  try {
+    fs.writeFileSync(tmpPath, `${JSON.stringify(registry)}\n`, { mode: 0o600 });
+    fs.renameSync(tmpPath, storagePath);
+  } catch (error) {
+    fs.rmSync(tmpPath, { force: true });
+    throw error;
+  }
 }
 
 function statusForNode(
@@ -255,7 +285,6 @@ export class HubNodeRegistry {
       tokenId,
       pairToken,
       expiresAt: expiresAt.toISOString(),
-      bootstrapCommand: `relay-ide node connect --pair-token ${pairToken}`,
     };
   }
 

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -1,0 +1,383 @@
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { NodeCapabilityProbe, NodeManifest } from '../shared/node-manifest.js';
+import {
+  RELAY_NODE_LINK_PROTOCOL,
+  RELAY_NODE_LINK_PROTOCOL_VERSION,
+  type HubNodeStatus,
+  type HubNodeSummary,
+  type NodeCapabilityManifestSummary,
+  type RelayNodeCredential,
+  type RelayNodeError,
+  type RelayNodeErrorCode,
+} from '../shared/relay-node-protocol.js';
+
+interface StoredPairToken {
+  tokenId: string;
+  tokenHash: string;
+  displayName?: string;
+  createdAt: string;
+  expiresAt: string;
+  usedAt?: string;
+}
+
+interface StoredNodeRecord {
+  nodeId: string;
+  credentialId: string;
+  credentialHash: string;
+  displayName: string;
+  hostname: string;
+  platform: string;
+  arch: string;
+  relayVersion: string;
+  protocolVersion: string;
+  capabilities: NodeCapabilityManifestSummary;
+  createdAt: string;
+  pairedAt: string;
+  lastSeenAt: string;
+  revokedAt?: string;
+}
+
+interface RegistryFile {
+  schemaVersion: 1;
+  pairTokens: StoredPairToken[];
+  nodes: StoredNodeRecord[];
+}
+
+export interface PairTokenResponse {
+  tokenId: string;
+  pairToken: string;
+  expiresAt: string;
+  bootstrapCommand: string;
+}
+
+export interface PairExchangeInput {
+  pairToken: string;
+  manifest: NodeManifest;
+  displayName?: string;
+  protocolVersion?: string;
+}
+
+export interface HeartbeatInput {
+  nodeId: string;
+  protocolVersion: string;
+  manifest?: NodeManifest;
+}
+
+export interface HubNodeRegistryOptions {
+  storagePath: string;
+  now?: () => Date;
+  staleMs?: number;
+  offlineMs?: number;
+}
+
+export const DEFAULT_PAIR_TOKEN_TTL_MS = 10 * 60 * 1000;
+export const DEFAULT_NODE_HEARTBEAT_TIMEOUTS = {
+  staleMs: 45 * 1000,
+  offlineMs: 90 * 1000,
+} as const;
+
+class HubNodeRegistryError extends Error {
+  readonly relayNodeError: RelayNodeError;
+
+  constructor(code: RelayNodeErrorCode, message: string, retryable = false) {
+    super(`${code}: ${message}`);
+    this.name = 'HubNodeRegistryError';
+    this.relayNodeError = { code, message, retryable };
+  }
+}
+
+function emptyRegistryFile(): RegistryFile {
+  return { schemaVersion: 1, pairTokens: [], nodes: [] };
+}
+
+function sha256(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function randomToken(prefix: string): string {
+  return `${prefix}_${crypto.randomBytes(24).toString('base64url')}`;
+}
+
+function timingSafeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'));
+}
+
+function assertCompatibleProtocol(protocolVersion: string): void {
+  const [major] = protocolVersion.split('.');
+  if (major !== '1') {
+    throw new HubNodeRegistryError(
+      'PROTOCOL_INCOMPATIBLE',
+      `relay-node-link protocol ${protocolVersion} is not compatible with hub protocol ${RELAY_NODE_LINK_PROTOCOL_VERSION}`
+    );
+  }
+}
+
+function countProbe(
+  totals: NodeCapabilityManifestSummary['totals'],
+  probe: NodeCapabilityProbe | undefined
+): void {
+  const status = probe?.status ?? 'unknown';
+  totals[status] += 1;
+}
+
+function summarizeCapabilities(manifest: NodeManifest): NodeCapabilityManifestSummary {
+  const totals = { available: 0, degraded: 0, unavailable: 0, unknown: 0 };
+  countProbe(totals, manifest.capabilities.tmux);
+  countProbe(totals, manifest.capabilities.git);
+  countProbe(totals, manifest.capabilities.clipboard);
+  countProbe(totals, manifest.capabilities.browserAutomation);
+  countProbe(totals, manifest.capabilities.githubCli);
+  countProbe(totals, manifest.capabilities.tailscale);
+  countProbe(totals, manifest.capabilities.ssh);
+
+  const agents: NodeCapabilityManifestSummary['agents'] = {};
+  for (const [id, probe] of Object.entries(manifest.capabilities.agents)) {
+    agents[id] = probe.status;
+    countProbe(totals, probe);
+  }
+
+  return {
+    totals,
+    agents,
+    serviceManager: manifest.serviceManager.kind,
+    wsl: manifest.wsl.detected,
+  };
+}
+
+function nodeDisplayName(displayName: string | undefined, manifest: NodeManifest): string {
+  const trimmed = displayName?.trim();
+  return trimmed || manifest.hostname;
+}
+
+function readRegistryFile(storagePath: string): RegistryFile {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(storagePath, 'utf8')) as Partial<RegistryFile>;
+    if (parsed.schemaVersion !== 1) return emptyRegistryFile();
+    return {
+      schemaVersion: 1,
+      pairTokens: Array.isArray(parsed.pairTokens) ? parsed.pairTokens : [],
+      nodes: Array.isArray(parsed.nodes) ? parsed.nodes : [],
+    };
+  } catch (error) {
+    const maybeNodeError = error as NodeJS.ErrnoException;
+    if (maybeNodeError.code === 'ENOENT') return emptyRegistryFile();
+    throw error;
+  }
+}
+
+function writeRegistryFile(storagePath: string, registry: RegistryFile): void {
+  fs.mkdirSync(path.dirname(storagePath), { recursive: true });
+  const tmpPath = `${storagePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.writeFileSync(tmpPath, `${JSON.stringify(registry, null, 2)}\n`, { mode: 0o600 });
+  fs.renameSync(tmpPath, storagePath);
+}
+
+function statusForNode(
+  node: StoredNodeRecord,
+  now: Date,
+  staleMs: number,
+  offlineMs: number
+): HubNodeStatus {
+  if (node.revokedAt) return 'revoked';
+  const ageMs = now.getTime() - Date.parse(node.lastSeenAt);
+  if (ageMs > offlineMs) return 'offline';
+  if (ageMs > staleMs) return 'stale';
+  return 'online';
+}
+
+function publicNode(
+  node: StoredNodeRecord,
+  status: HubNodeStatus
+): HubNodeSummary {
+  return {
+    nodeId: node.nodeId,
+    displayName: node.displayName,
+    hostname: node.hostname,
+    platform: node.platform,
+    arch: node.arch,
+    relayVersion: node.relayVersion,
+    protocolVersion: node.protocolVersion,
+    status,
+    capabilities: node.capabilities,
+    createdAt: node.createdAt,
+    pairedAt: node.pairedAt,
+    lastSeenAt: node.lastSeenAt,
+    credentialId: node.credentialId,
+  };
+}
+
+export class HubNodeRegistry {
+  readonly storagePath: string;
+  private now: () => Date;
+  private readonly staleMs: number;
+  private readonly offlineMs: number;
+  private state: RegistryFile;
+
+  constructor(options: HubNodeRegistryOptions) {
+    this.storagePath = options.storagePath;
+    this.now = options.now ?? (() => new Date());
+    this.staleMs = options.staleMs ?? DEFAULT_NODE_HEARTBEAT_TIMEOUTS.staleMs;
+    this.offlineMs = options.offlineMs ?? DEFAULT_NODE_HEARTBEAT_TIMEOUTS.offlineMs;
+    this.state = readRegistryFile(options.storagePath);
+  }
+
+  setNowForTest(now: () => Date): void {
+    this.now = now;
+  }
+
+  createPairToken(options: { displayName?: string; ttlMs?: number }): PairTokenResponse {
+    const createdAt = this.now();
+    const expiresAt = new Date(
+      createdAt.getTime() + (options.ttlMs ?? DEFAULT_PAIR_TOKEN_TTL_MS)
+    );
+    const pairToken = randomToken('pair');
+    const tokenId = randomToken('pt');
+    this.state.pairTokens.push({
+      tokenId,
+      tokenHash: sha256(pairToken),
+      ...(options.displayName ? { displayName: options.displayName } : {}),
+      createdAt: createdAt.toISOString(),
+      expiresAt: expiresAt.toISOString(),
+    });
+    this.persist();
+    return {
+      tokenId,
+      pairToken,
+      expiresAt: expiresAt.toISOString(),
+      bootstrapCommand: `relay-ide node connect --pair-token ${pairToken}`,
+    };
+  }
+
+  exchangePairToken(input: PairExchangeInput): {
+    credential: RelayNodeCredential;
+    node: HubNodeSummary;
+  } {
+    const protocolVersion = input.protocolVersion ?? RELAY_NODE_LINK_PROTOCOL_VERSION;
+    assertCompatibleProtocol(protocolVersion);
+    const tokenHash = sha256(input.pairToken);
+    const pairToken = this.state.pairTokens.find((candidate) =>
+      timingSafeEqualHex(candidate.tokenHash, tokenHash)
+    );
+    if (!pairToken) {
+      throw new HubNodeRegistryError('UNAUTHORIZED', 'pair token was not found');
+    }
+    if (pairToken.usedAt) {
+      throw new HubNodeRegistryError('TOKEN_ALREADY_USED', 'pair token has already been used');
+    }
+    const now = this.now();
+    if (Date.parse(pairToken.expiresAt) <= now.getTime()) {
+      throw new HubNodeRegistryError('TOKEN_EXPIRED', 'pair token expired');
+    }
+
+    const nodeId = randomToken('node');
+    const credentialId = randomToken('cred');
+    const secret = randomToken('secret');
+    const token = `${nodeId}.${secret}`;
+    const timestamp = now.toISOString();
+    const node: StoredNodeRecord = {
+      nodeId,
+      credentialId,
+      credentialHash: sha256(token),
+      displayName: nodeDisplayName(input.displayName ?? pairToken.displayName, input.manifest),
+      hostname: input.manifest.hostname,
+      platform: input.manifest.platform,
+      arch: input.manifest.arch,
+      relayVersion: input.manifest.relayVersion,
+      protocolVersion,
+      capabilities: summarizeCapabilities(input.manifest),
+      createdAt: timestamp,
+      pairedAt: timestamp,
+      lastSeenAt: timestamp,
+    };
+    pairToken.usedAt = timestamp;
+    this.state.nodes.push(node);
+    this.persist();
+    return {
+      credential: {
+        protocol: RELAY_NODE_LINK_PROTOCOL,
+        protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+        nodeId,
+        credentialId,
+        token,
+        issuedAt: timestamp,
+      },
+      node: publicNode(node, 'online'),
+    };
+  }
+
+  authenticateCredential(token: string): HubNodeSummary | null {
+    const tokenHash = sha256(token);
+    const [nodeId] = token.split('.', 1);
+    const node = this.state.nodes.find(
+      (candidate) =>
+        candidate.nodeId === nodeId &&
+        !candidate.revokedAt &&
+        timingSafeEqualHex(candidate.credentialHash, tokenHash)
+    );
+    if (!node) return null;
+    return publicNode(
+      node,
+      statusForNode(node, this.now(), this.staleMs, this.offlineMs)
+    );
+  }
+
+  recordHeartbeat(input: HeartbeatInput): HubNodeSummary {
+    assertCompatibleProtocol(input.protocolVersion);
+    const node = this.state.nodes.find((candidate) => candidate.nodeId === input.nodeId);
+    if (!node) throw new HubNodeRegistryError('NOT_FOUND', 'node is not paired');
+    if (node.revokedAt) throw new HubNodeRegistryError('NODE_REVOKED', 'node was revoked');
+    const now = this.now().toISOString();
+    node.lastSeenAt = now;
+    node.protocolVersion = input.protocolVersion;
+    if (input.manifest) {
+      node.hostname = input.manifest.hostname;
+      node.platform = input.manifest.platform;
+      node.arch = input.manifest.arch;
+      node.relayVersion = input.manifest.relayVersion;
+      node.capabilities = summarizeCapabilities(input.manifest);
+    }
+    this.persist();
+    return publicNode(node, 'online');
+  }
+
+  listNodes(): HubNodeSummary[] {
+    const now = this.now();
+    return this.state.nodes.map((node) =>
+      publicNode(node, statusForNode(node, now, this.staleMs, this.offlineMs))
+    );
+  }
+
+  revokeNode(nodeId: string): HubNodeSummary {
+    const node = this.state.nodes.find((candidate) => candidate.nodeId === nodeId);
+    if (!node) throw new HubNodeRegistryError('NOT_FOUND', 'node is not paired');
+    node.revokedAt = this.now().toISOString();
+    this.persist();
+    return publicNode(node, 'revoked');
+  }
+
+  errorBody(error: unknown): { error: RelayNodeError } {
+    if (error instanceof HubNodeRegistryError) {
+      return { error: error.relayNodeError };
+    }
+    return {
+      error: {
+        code: 'INTERNAL',
+        message: error instanceof Error ? error.message : 'internal hub node registry error',
+        retryable: true,
+      },
+    };
+  }
+
+  private persist(): void {
+    writeRegistryFile(this.storagePath, this.state);
+  }
+}
+
+export function createHubNodeRegistry(options: HubNodeRegistryOptions): HubNodeRegistry {
+  return new HubNodeRegistry(options);
+}
+
+export { HubNodeRegistryError, summarizeCapabilities };

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -70,6 +70,7 @@ export interface HubNodeRegistryOptions {
   now?: () => Date;
   staleMs?: number;
   offlineMs?: number;
+  heartbeatPersistDebounceMs?: number;
 }
 
 export const DEFAULT_PAIR_TOKEN_TTL_MS = 10 * 60 * 1000;
@@ -77,6 +78,7 @@ export const DEFAULT_NODE_HEARTBEAT_TIMEOUTS = {
   staleMs: 45 * 1000,
   offlineMs: 90 * 1000,
 } as const;
+export const DEFAULT_HEARTBEAT_PERSIST_DEBOUNCE_MS = 5 * 1000;
 
 class HubNodeRegistryError extends Error {
   readonly relayNodeError: RelayNodeError;
@@ -214,13 +216,19 @@ export class HubNodeRegistry {
   private now: () => Date;
   private readonly staleMs: number;
   private readonly offlineMs: number;
+  private readonly heartbeatPersistDebounceMs: number;
   private state: RegistryFile;
+  private heartbeatPersistTimer: NodeJS.Timeout | null = null;
+  private heartbeatPersistDirty = false;
+  private heartbeatPersistError: unknown = null;
 
   constructor(options: HubNodeRegistryOptions) {
     this.storagePath = options.storagePath;
     this.now = options.now ?? (() => new Date());
     this.staleMs = options.staleMs ?? DEFAULT_NODE_HEARTBEAT_TIMEOUTS.staleMs;
     this.offlineMs = options.offlineMs ?? DEFAULT_NODE_HEARTBEAT_TIMEOUTS.offlineMs;
+    this.heartbeatPersistDebounceMs =
+      options.heartbeatPersistDebounceMs ?? DEFAULT_HEARTBEAT_PERSIST_DEBOUNCE_MS;
     this.state = readRegistryFile(options.storagePath);
   }
 
@@ -339,8 +347,22 @@ export class HubNodeRegistry {
       node.relayVersion = input.manifest.relayVersion;
       node.capabilities = summarizeCapabilities(input.manifest);
     }
-    this.persist();
+    this.scheduleHeartbeatPersist();
     return publicNode(node, 'online');
+  }
+
+  async flushPendingHeartbeatPersist(): Promise<void> {
+    if (this.heartbeatPersistTimer) {
+      clearTimeout(this.heartbeatPersistTimer);
+      this.heartbeatPersistTimer = null;
+    }
+    this.flushHeartbeatPersistNow();
+
+    if (this.heartbeatPersistError) {
+      const error = this.heartbeatPersistError;
+      this.heartbeatPersistError = null;
+      throw error;
+    }
   }
 
   listNodes(): HubNodeSummary[] {
@@ -372,7 +394,43 @@ export class HubNodeRegistry {
   }
 
   private persist(): void {
+    this.cancelPendingHeartbeatPersist();
+    this.heartbeatPersistError = null;
     writeRegistryFile(this.storagePath, this.state);
+  }
+
+  private scheduleHeartbeatPersist(): void {
+    this.heartbeatPersistDirty = true;
+    if (this.heartbeatPersistTimer) return;
+    this.heartbeatPersistTimer = setTimeout(() => {
+      this.heartbeatPersistTimer = null;
+      try {
+        this.flushHeartbeatPersistNow();
+      } catch {
+        /* error is recorded for a later deterministic flush/retry */
+      }
+    }, this.heartbeatPersistDebounceMs);
+    this.heartbeatPersistTimer.unref?.();
+  }
+
+  private flushHeartbeatPersistNow(): void {
+    if (!this.heartbeatPersistDirty) return;
+    try {
+      writeRegistryFile(this.storagePath, this.state);
+      this.heartbeatPersistDirty = false;
+      this.heartbeatPersistError = null;
+    } catch (error) {
+      this.heartbeatPersistError = error;
+      throw error;
+    }
+  }
+
+  private cancelPendingHeartbeatPersist(): void {
+    if (this.heartbeatPersistTimer) {
+      clearTimeout(this.heartbeatPersistTimer);
+      this.heartbeatPersistTimer = null;
+    }
+    this.heartbeatPersistDirty = false;
   }
 }
 

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -1,7 +1,7 @@
 import * as express from 'express';
 import type { Request, Response } from 'express';
-import type { NodeManifest } from '../shared/node-manifest.js';
-import type { HubNodeRegistry } from './hub-node-registry.js';
+import { isNodeManifest, type NodeManifest } from '../shared/node-manifest.js';
+import { HubNodeRegistryError, type HubNodeRegistry } from './hub-node-registry.js';
 import type { RelayNodeError } from '../shared/relay-node-protocol.js';
 
 interface HubNodeRouterOptions {
@@ -50,12 +50,18 @@ function bodyRecord(req: Request): Record<string, unknown> {
     : {};
 }
 
-function manifestFromBody(body: Record<string, unknown>): NodeManifest | null {
+function manifestFromBody(body: Record<string, unknown>, required = false): NodeManifest | null {
   const manifest = body['manifest'];
-  if (typeof manifest !== 'object' || manifest === null) return null;
-  const candidate = manifest as Partial<NodeManifest>;
-  if (candidate.schemaVersion !== 1 || typeof candidate.hostname !== 'string') return null;
-  return manifest as NodeManifest;
+  if (manifest === undefined || manifest === null) {
+    if (required) {
+      throw new HubNodeRegistryError('INVALID_REQUEST', 'manifest is required');
+    }
+    return null;
+  }
+  if (!isNodeManifest(manifest)) {
+    throw new HubNodeRegistryError('INVALID_REQUEST', 'manifest is malformed');
+  }
+  return manifest;
 }
 
 function pairTtlMs(body: Record<string, unknown>): number | undefined {
@@ -87,18 +93,18 @@ export function createHubNodeRouter(options: HubNodeRouterOptions): express.Rout
   router.post('/hub/pairing/exchange', (req, res) => {
     const body = bodyRecord(req);
     const pairToken = body['pairToken'];
-    const manifest = manifestFromBody(body);
-    if (typeof pairToken !== 'string' || !manifest) {
+    if (typeof pairToken !== 'string') {
       res.status(400).json({
         error: {
           code: 'INVALID_REQUEST',
-          message: 'pairToken and manifest are required',
+          message: 'pairToken is required',
           retryable: false,
         },
       });
       return;
     }
     try {
+      const manifest = manifestFromBody(body, true)!;
       const protocolVersion =
         typeof body['protocolVersion'] === 'string' ? body['protocolVersion'] : undefined;
       const displayName =
@@ -141,11 +147,12 @@ export function createHubNodeRouter(options: HubNodeRouterOptions): express.Rout
       return;
     }
     try {
+      const manifest = manifestFromBody(body);
       res.json({
         node: registry.recordHeartbeat({
           nodeId: authenticated.nodeId,
           protocolVersion,
-          ...(manifestFromBody(body) ? { manifest: manifestFromBody(body)! } : {}),
+          ...(manifest ? { manifest } : {}),
         }),
       });
     } catch (error) {

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -1,0 +1,176 @@
+import * as express from 'express';
+import type { Request, Response } from 'express';
+import type { NodeManifest } from '../shared/node-manifest.js';
+import type { HubNodeRegistry } from './hub-node-registry.js';
+import type { RelayNodeError } from '../shared/relay-node-protocol.js';
+
+interface HubNodeRouterOptions {
+  registry: HubNodeRegistry;
+  requireAuth: express.RequestHandler;
+}
+
+function bearerToken(req: Request): string | null {
+  const header = req.header('authorization') ?? '';
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() || null;
+}
+
+function errorStatus(error: RelayNodeError): number {
+  switch (error.code) {
+    case 'UNAUTHORIZED':
+      return 401;
+    case 'TOKEN_EXPIRED':
+    case 'TOKEN_ALREADY_USED':
+    case 'PROTOCOL_INCOMPATIBLE':
+    case 'VERSION_SKEW':
+    case 'INVALID_REQUEST':
+      return 400;
+    case 'NODE_REVOKED':
+      return 403;
+    case 'NOT_FOUND':
+    case 'NODE_OFFLINE':
+      return 404;
+    default:
+      return 500;
+  }
+}
+
+function sendRegistryError(
+  registry: HubNodeRegistry,
+  res: Response,
+  error: unknown
+): void {
+  const body = registry.errorBody(error);
+  res.status(errorStatus(body.error)).json(body);
+}
+
+function bodyRecord(req: Request): Record<string, unknown> {
+  return typeof req.body === 'object' && req.body !== null
+    ? (req.body as Record<string, unknown>)
+    : {};
+}
+
+function manifestFromBody(body: Record<string, unknown>): NodeManifest | null {
+  const manifest = body['manifest'];
+  if (typeof manifest !== 'object' || manifest === null) return null;
+  const candidate = manifest as Partial<NodeManifest>;
+  if (candidate.schemaVersion !== 1 || typeof candidate.hostname !== 'string') return null;
+  return manifest as NodeManifest;
+}
+
+function pairTtlMs(body: Record<string, unknown>): number | undefined {
+  const ttlMs = body['ttlMs'];
+  if (typeof ttlMs === 'number' && Number.isFinite(ttlMs) && ttlMs > 0) return ttlMs;
+  const ttlSeconds = body['ttlSeconds'];
+  if (typeof ttlSeconds === 'number' && Number.isFinite(ttlSeconds) && ttlSeconds > 0) {
+    return Math.round(ttlSeconds * 1000);
+  }
+  return undefined;
+}
+
+export function createHubNodeRouter(options: HubNodeRouterOptions): express.Router {
+  const router = express.Router();
+  const { registry, requireAuth } = options;
+
+  router.post('/hub/pair-tokens', requireAuth, (req, res) => {
+    const body = bodyRecord(req);
+    const displayName =
+      typeof body['displayName'] === 'string' ? body['displayName'] : undefined;
+    const ttlMs = pairTtlMs(body);
+    const pairToken = registry.createPairToken({
+      ...(displayName ? { displayName } : {}),
+      ...(ttlMs !== undefined ? { ttlMs } : {}),
+    });
+    res.status(201).json(pairToken);
+  });
+
+  router.post('/hub/pairing/exchange', (req, res) => {
+    const body = bodyRecord(req);
+    const pairToken = body['pairToken'];
+    const manifest = manifestFromBody(body);
+    if (typeof pairToken !== 'string' || !manifest) {
+      res.status(400).json({
+        error: {
+          code: 'INVALID_REQUEST',
+          message: 'pairToken and manifest are required',
+          retryable: false,
+        },
+      });
+      return;
+    }
+    try {
+      const protocolVersion =
+        typeof body['protocolVersion'] === 'string' ? body['protocolVersion'] : undefined;
+      const displayName =
+        typeof body['displayName'] === 'string' ? body['displayName'] : undefined;
+      res.status(201).json(
+        registry.exchangePairToken({
+          pairToken,
+          manifest,
+          ...(displayName ? { displayName } : {}),
+          ...(protocolVersion ? { protocolVersion } : {}),
+        })
+      );
+    } catch (error) {
+      sendRegistryError(registry, res, error);
+    }
+  });
+
+  router.post('/hub/node-heartbeat', (req, res) => {
+    const token = bearerToken(req);
+    const authenticated = token ? registry.authenticateCredential(token) : null;
+    if (!authenticated) {
+      res.status(401).json({
+        error: { code: 'UNAUTHORIZED', message: 'invalid node credential', retryable: false },
+      });
+      return;
+    }
+    const body = bodyRecord(req);
+    const protocolVersion = body['protocolVersion'];
+    if (
+      body['nodeId'] !== authenticated.nodeId ||
+      typeof protocolVersion !== 'string'
+    ) {
+      res.status(400).json({
+        error: {
+          code: 'INVALID_REQUEST',
+          message: 'nodeId and protocolVersion are required',
+          retryable: false,
+        },
+      });
+      return;
+    }
+    try {
+      res.json({
+        node: registry.recordHeartbeat({
+          nodeId: authenticated.nodeId,
+          protocolVersion,
+          ...(manifestFromBody(body) ? { manifest: manifestFromBody(body)! } : {}),
+        }),
+      });
+    } catch (error) {
+      sendRegistryError(registry, res, error);
+    }
+  });
+
+  router.get('/nodes', requireAuth, (_req, res) => {
+    res.json({ nodes: registry.listNodes() });
+  });
+
+  router.delete('/nodes/:nodeId', requireAuth, (req, res) => {
+    const { nodeId } = req.params;
+    if (!nodeId) {
+      res.status(400).json({
+        error: { code: 'INVALID_REQUEST', message: 'nodeId is required', retryable: false },
+      });
+      return;
+    }
+    try {
+      res.json({ node: registry.revokeNode(nodeId) });
+    } catch (error) {
+      sendRegistryError(registry, res, error);
+    }
+  });
+
+  return router;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -980,6 +980,19 @@ async function main(): Promise<void> {
   const hubNodeRegistry = createHubNodeRegistry({
     storagePath: path.join(configDir, 'hub-node-registry.json'),
   });
+
+  async function flushHubNodeHeartbeatsBestEffort(context: string): Promise<void> {
+    try {
+      await hubNodeRegistry.flushPendingHeartbeatPersist();
+    } catch (err) {
+      logger.warn(
+        'Failed to flush pending hub node heartbeat state during %s; continuing lifecycle sequence: %s',
+        context,
+        err instanceof Error ? err.message : err
+      );
+    }
+  }
+
   await ensureTmuxAvailable();
 
   await initializePortAllocatorAndReconcile(
@@ -2596,7 +2609,7 @@ async function main(): Promise<void> {
       if (restarting) {
         stopEventBatching();
         stopTelemetry();
-        await hubNodeRegistry.flushPendingHeartbeatPersist();
+        await flushHubNodeHeartbeatsBestEffort('update restart');
         serializeAll(configDir, { reason: 'update' });
         flushRelayStateWrites();
         closeRelayStateDb();
@@ -2671,7 +2684,7 @@ async function main(): Promise<void> {
     refWatcher.close();
     gitWatcher.close();
     server.close();
-    await hubNodeRegistry.flushPendingHeartbeatPersist();
+    await flushHubNodeHeartbeatsBestEffort('graceful shutdown');
     // Serialize sessions before detaching the node-pty tmux clients. The tmux
     // sessions themselves must survive so startup can reattach to them.
     serializeAll(configDir, { reason: restartReason });

--- a/server/index.ts
+++ b/server/index.ts
@@ -101,6 +101,8 @@ import {
   getFrameworkWebAvailability,
 } from './frameworks.js';
 import { getNodeManifest } from './node-manifest.js';
+import { createHubNodeRegistry } from './hub-node-registry.js';
+import { createHubNodeRouter } from './hub-node-router.js';
 import type {
   AgentType,
   AutomationSettings,
@@ -975,6 +977,9 @@ async function main(): Promise<void> {
 
   const configDir = getConfigDir(CONFIG_PATH);
   initializeRuntimeDirectories(configDir);
+  const hubNodeRegistry = createHubNodeRegistry({
+    storagePath: path.join(configDir, 'hub-node-registry.json'),
+  });
   await ensureTmuxAvailable();
 
   await initializePortAllocatorAndReconcile(
@@ -1050,6 +1055,8 @@ async function main(): Promise<void> {
     }
     next();
   };
+
+  app.use(createHubNodeRouter({ registry: hubNodeRegistry, requireAuth }));
 
   const webhookManagerRouter = createWebhookManagerRouter({
     configPath: CONFIG_PATH,
@@ -1140,7 +1147,8 @@ async function main(): Promise<void> {
     watcher,
     CONFIG_PATH,
     process.env.NO_PIN === '1',
-    localRelayNode
+    localRelayNode,
+    hubNodeRegistry
   );
 
   const browserScopedToken = generateScopedToken();

--- a/server/index.ts
+++ b/server/index.ts
@@ -2596,6 +2596,7 @@ async function main(): Promise<void> {
       if (restarting) {
         stopEventBatching();
         stopTelemetry();
+        await hubNodeRegistry.flushPendingHeartbeatPersist();
         serializeAll(configDir, { reason: 'update' });
         flushRelayStateWrites();
         closeRelayStateDb();
@@ -2670,6 +2671,7 @@ async function main(): Promise<void> {
     refWatcher.close();
     gitWatcher.close();
     server.close();
+    await hubNodeRegistry.flushPendingHeartbeatPersist();
     // Serialize sessions before detaching the node-pty tmux clients. The tmux
     // sessions themselves must survive so startup can reattach to them.
     serializeAll(configDir, { reason: restartReason });

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -13,6 +13,8 @@ import { verifyCookieToken } from './auth.js';
 import { createAgentSessionSnapshotPatch } from './web-session-v2-state.js';
 import type { AgentApprovalDecisionV2 } from '../shared/agent-chat-protocol-v2.js';
 import type { LocalRelayNode } from './local-node.js';
+import type { HubNodeRegistry } from './hub-node-registry.js';
+import { authenticateHubNodeLink, handleHubNodeLink } from './hub-node-link.js';
 
 const logger = createLogger('ws');
 
@@ -276,7 +278,8 @@ function setupWebSocket(
   watcher: WorktreeWatcher | null,
   configPath?: string,
   noPinMode = false,
-  localNode?: LocalRelayNode
+  localNode?: LocalRelayNode,
+  hubNodeRegistry?: HubNodeRegistry
 ): {
   wss: WebSocketServer;
   broadcastEvent: (type: string, data?: Record<string, unknown>) => void;
@@ -362,6 +365,19 @@ function setupWebSocket(
   }
 
   server.on('upgrade', (request, socket, head) => {
+    if (request.url === '/hub/node-link') {
+      const authenticated = authenticateHubNodeLink(request, hubNodeRegistry);
+      if (!authenticated || !hubNodeRegistry) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+      wss.handleUpgrade(request, socket, head, (ws) => {
+        handleHubNodeLink(ws, hubNodeRegistry, authenticated.node);
+      });
+      return;
+    }
+
     if (!isAuthenticated(request.headers.cookie)) {
       socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
       socket.destroy();

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -365,7 +365,10 @@ function setupWebSocket(
   }
 
   server.on('upgrade', (request, socket, head) => {
-    if (request.url === '/hub/node-link') {
+    const requestPath = request.url
+      ? new URL(request.url, 'http://relay.local').pathname.replace(/\/$/, '')
+      : '';
+    if (requestPath === '/hub/node-link') {
       const authenticated = authenticateHubNodeLink(request, hubNodeRegistry);
       if (!authenticated || !hubNodeRegistry) {
         socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');

--- a/shared/node-manifest.ts
+++ b/shared/node-manifest.ts
@@ -80,14 +80,89 @@ function isCapabilityStatus(value: unknown): value is NodeCapabilityStatus {
   );
 }
 
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === 'string';
+}
+
+function isWslVersion(value: unknown): value is WslInfo['version'] {
+  return value === 1 || value === 2 || value === null;
+}
+
+function isServiceManagerKind(value: unknown): value is ServiceManagerKind {
+  return (
+    value === 'launchd' ||
+    value === 'systemd-user' ||
+    value === 'systemd-system' ||
+    value === 'wsl-systemd' ||
+    value === 'wsl-manual' ||
+    value === 'manual' ||
+    value === 'unsupported'
+  );
+}
+
+const requiredCapabilityKeys = [
+  'tmux',
+  'git',
+  'clipboard',
+  'browserAutomation',
+  'githubCli',
+  'tailscale',
+  'ssh',
+] as const;
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
 export function isNodeCapabilityProbe(value: unknown): value is NodeCapabilityProbe {
   if (!isRecord(value)) return false;
   return (
     typeof value['id'] === 'string' &&
     typeof value['label'] === 'string' &&
     isCapabilityStatus(value['status']) &&
-    typeof value['message'] === 'string'
+    typeof value['message'] === 'string' &&
+    isOptionalString(value['path']) &&
+    isOptionalString(value['version'])
   );
+}
+
+function isWslInfo(value: unknown): value is WslInfo {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value['detected'] === 'boolean' &&
+    isWslVersion(value['version']) &&
+    typeof value['systemd'] === 'boolean' &&
+    isOptionalString(value['distroName']) &&
+    isOptionalString(value['message'])
+  );
+}
+
+function isNodeServiceManager(value: unknown): value is NodeServiceManager {
+  if (!isRecord(value)) return false;
+  return (
+    isServiceManagerKind(value['kind']) &&
+    typeof value['label'] === 'string' &&
+    typeof value['supported'] === 'boolean' &&
+    typeof value['installable'] === 'boolean' &&
+    isOptionalString(value['servicePath']) &&
+    isOptionalString(value['unitName']) &&
+    isOptionalString(value['statusCommand']) &&
+    typeof value['installHint'] === 'string' &&
+    typeof value['uninstallHint'] === 'string' &&
+    typeof value['message'] === 'string' &&
+    isStringArray(value['caveats'])
+  );
+}
+
+function isNodeCapabilities(value: unknown): value is NodeCapabilities {
+  if (!isRecord(value)) return false;
+  for (const key of requiredCapabilityKeys) {
+    if (!isNodeCapabilityProbe(value[key])) return false;
+  }
+
+  const agents = value['agents'];
+  if (!isRecord(agents)) return false;
+  return Object.values(agents).every((probe) => isNodeCapabilityProbe(probe));
 }
 
 export function isNodeManifest(value: unknown): value is NodeManifest {
@@ -103,46 +178,9 @@ export function isNodeManifest(value: unknown): value is NodeManifest {
     return false;
   }
 
-  const wsl = value['wsl'];
-  if (
-    !isRecord(wsl) ||
-    typeof wsl['detected'] !== 'boolean' ||
-    typeof wsl['systemd'] !== 'boolean'
-  ) {
-    return false;
-  }
-
-  const serviceManager = value['serviceManager'];
-  if (
-    !isRecord(serviceManager) ||
-    typeof serviceManager['kind'] !== 'string' ||
-    typeof serviceManager['label'] !== 'string' ||
-    typeof serviceManager['supported'] !== 'boolean' ||
-    typeof serviceManager['installable'] !== 'boolean' ||
-    typeof serviceManager['installHint'] !== 'string' ||
-    typeof serviceManager['uninstallHint'] !== 'string' ||
-    typeof serviceManager['message'] !== 'string' ||
-    !Array.isArray(serviceManager['caveats'])
-  ) {
-    return false;
-  }
-
-  const capabilities = value['capabilities'];
-  if (!isRecord(capabilities)) return false;
-  const requiredCapabilityKeys = [
-    'tmux',
-    'git',
-    'clipboard',
-    'browserAutomation',
-    'githubCli',
-    'tailscale',
-    'ssh',
-  ] as const;
-  for (const key of requiredCapabilityKeys) {
-    if (!isNodeCapabilityProbe(capabilities[key])) return false;
-  }
-
-  const agents = capabilities['agents'];
-  if (!isRecord(agents)) return false;
-  return Object.values(agents).every((probe) => isNodeCapabilityProbe(probe));
+  return (
+    isWslInfo(value['wsl']) &&
+    isNodeServiceManager(value['serviceManager']) &&
+    isNodeCapabilities(value['capabilities'])
+  );
 }

--- a/shared/node-manifest.ts
+++ b/shared/node-manifest.ts
@@ -68,7 +68,7 @@ export interface NodeManifest {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function isCapabilityStatus(value: unknown): value is NodeCapabilityStatus {

--- a/shared/node-manifest.ts
+++ b/shared/node-manifest.ts
@@ -66,3 +66,83 @@ export interface NodeManifest {
   serviceManager: NodeServiceManager;
   capabilities: NodeCapabilities;
 }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isCapabilityStatus(value: unknown): value is NodeCapabilityStatus {
+  return (
+    value === 'available' ||
+    value === 'degraded' ||
+    value === 'unavailable' ||
+    value === 'unknown'
+  );
+}
+
+export function isNodeCapabilityProbe(value: unknown): value is NodeCapabilityProbe {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value['id'] === 'string' &&
+    typeof value['label'] === 'string' &&
+    isCapabilityStatus(value['status']) &&
+    typeof value['message'] === 'string'
+  );
+}
+
+export function isNodeManifest(value: unknown): value is NodeManifest {
+  if (!isRecord(value)) return false;
+  if (
+    value['schemaVersion'] !== 1 ||
+    typeof value['platform'] !== 'string' ||
+    typeof value['arch'] !== 'string' ||
+    typeof value['hostname'] !== 'string' ||
+    typeof value['relayVersion'] !== 'string' ||
+    typeof value['generatedAt'] !== 'string'
+  ) {
+    return false;
+  }
+
+  const wsl = value['wsl'];
+  if (
+    !isRecord(wsl) ||
+    typeof wsl['detected'] !== 'boolean' ||
+    typeof wsl['systemd'] !== 'boolean'
+  ) {
+    return false;
+  }
+
+  const serviceManager = value['serviceManager'];
+  if (
+    !isRecord(serviceManager) ||
+    typeof serviceManager['kind'] !== 'string' ||
+    typeof serviceManager['label'] !== 'string' ||
+    typeof serviceManager['supported'] !== 'boolean' ||
+    typeof serviceManager['installable'] !== 'boolean' ||
+    typeof serviceManager['installHint'] !== 'string' ||
+    typeof serviceManager['uninstallHint'] !== 'string' ||
+    typeof serviceManager['message'] !== 'string' ||
+    !Array.isArray(serviceManager['caveats'])
+  ) {
+    return false;
+  }
+
+  const capabilities = value['capabilities'];
+  if (!isRecord(capabilities)) return false;
+  const requiredCapabilityKeys = [
+    'tmux',
+    'git',
+    'clipboard',
+    'browserAutomation',
+    'githubCli',
+    'tailscale',
+    'ssh',
+  ] as const;
+  for (const key of requiredCapabilityKeys) {
+    if (!isNodeCapabilityProbe(capabilities[key])) return false;
+  }
+
+  const agents = capabilities['agents'];
+  if (!isRecord(agents)) return false;
+  return Object.values(agents).every((probe) => isNodeCapabilityProbe(probe));
+}

--- a/shared/relay-node-protocol.ts
+++ b/shared/relay-node-protocol.ts
@@ -1,0 +1,80 @@
+export const RELAY_NODE_LINK_PROTOCOL = 'relay-node-link' as const;
+export const RELAY_NODE_LINK_PROTOCOL_VERSION = '1.0' as const;
+
+export type RelayNodeLinkProtocol = typeof RELAY_NODE_LINK_PROTOCOL;
+export type RelayNodeProtocolVersion = string;
+
+export type RelayNodeChannel = 'control' | 'rpc' | 'events' | 'pty' | 'preview';
+
+export type RelayNodeErrorCode =
+  | 'UNAUTHORIZED'
+  | 'TOKEN_EXPIRED'
+  | 'TOKEN_ALREADY_USED'
+  | 'NODE_REVOKED'
+  | 'NODE_OFFLINE'
+  | 'NODE_BUSY'
+  | 'UNSUPPORTED_CAPABILITY'
+  | 'PROTOCOL_INCOMPATIBLE'
+  | 'VERSION_SKEW'
+  | 'NOT_FOUND'
+  | 'INVALID_REQUEST'
+  | 'INTERNAL';
+
+export interface RelayNodeError {
+  code: RelayNodeErrorCode;
+  message: string;
+  retryable: boolean;
+  details?: Record<string, unknown>;
+}
+
+export interface RelayNodeEnvelope {
+  protocol: RelayNodeLinkProtocol;
+  protocolVersion: RelayNodeProtocolVersion;
+  nodeId: string;
+  channel: RelayNodeChannel;
+  type: string;
+  requestId?: string;
+  streamId?: string;
+  timestamp: string;
+  payload?: unknown;
+  error?: RelayNodeError;
+}
+
+export interface RelayNodeCredential {
+  protocol: RelayNodeLinkProtocol;
+  protocolVersion: typeof RELAY_NODE_LINK_PROTOCOL_VERSION;
+  nodeId: string;
+  credentialId: string;
+  token: string;
+  issuedAt: string;
+}
+
+export type HubNodeStatus = 'online' | 'stale' | 'offline' | 'revoked';
+
+export interface NodeCapabilityManifestSummary {
+  totals: {
+    available: number;
+    degraded: number;
+    unavailable: number;
+    unknown: number;
+  };
+  agents: Record<string, 'available' | 'degraded' | 'unavailable' | 'unknown'>;
+  serviceManager: string;
+  wsl: boolean;
+}
+
+export interface HubNodeSummary {
+  nodeId: string;
+  displayName: string;
+  hostname: string;
+  platform: string;
+  arch: string;
+  relayVersion: string;
+  protocolVersion: string;
+  status: HubNodeStatus;
+  capabilities: NodeCapabilityManifestSummary;
+  createdAt: string;
+  pairedAt: string;
+  lastSeenAt: string;
+  credentialId: string;
+}

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -6,7 +6,7 @@ import {
   createHubNodeRegistry,
   DEFAULT_NODE_HEARTBEAT_TIMEOUTS,
 } from '../server/hub-node-registry.js';
-import type { NodeManifest } from '../shared/node-manifest.js';
+import { isNodeManifest, type NodeManifest } from '../shared/node-manifest.js';
 
 function manifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
   return {
@@ -88,7 +88,99 @@ function withTmpRegistry<T>(fn: (registry: ReturnType<typeof createHubNodeRegist
   }
 }
 
+function malformedManifest(mutator: (candidate: Record<string, unknown>) => void): unknown {
+  const candidate = JSON.parse(JSON.stringify(manifest())) as Record<string, unknown>;
+  mutator(candidate);
+  return candidate;
+}
+
 describe('hub node registry', () => {
+  it('rejects malformed nested node manifests at the shared runtime guard', () => {
+    const validWithOptionalStrings = manifest({
+      wsl: {
+        detected: true,
+        version: 2,
+        distroName: 'Ubuntu',
+        systemd: true,
+        message: 'wsl ready',
+      },
+      serviceManager: {
+        ...manifest().serviceManager,
+        servicePath: '/tmp/relay.plist',
+        unitName: 'relay.service',
+        statusCommand: 'systemctl --user status relay',
+        caveats: ['manual restart required'],
+      },
+      capabilities: {
+        ...manifest().capabilities,
+        tmux: {
+          ...manifest().capabilities.tmux,
+          path: '/usr/bin/tmux',
+          version: 'tmux 3.4',
+        },
+      },
+    });
+    expect(isNodeManifest(validWithOptionalStrings)).toBe(true);
+
+    const malformedCases: Array<[string, unknown]> = [
+      [
+        'capability path',
+        malformedManifest((candidate) => {
+          const capabilities = candidate['capabilities'] as Record<string, unknown>;
+          const tmux = capabilities['tmux'] as Record<string, unknown>;
+          tmux['path'] = 42;
+        }),
+      ],
+      [
+        'capability version',
+        malformedManifest((candidate) => {
+          const capabilities = candidate['capabilities'] as Record<string, unknown>;
+          const git = capabilities['git'] as Record<string, unknown>;
+          git['version'] = { text: 'git 2.0' };
+        }),
+      ],
+      [
+        'wsl version',
+        malformedManifest((candidate) => {
+          const wsl = candidate['wsl'] as Record<string, unknown>;
+          wsl['version'] = 3;
+        }),
+      ],
+      [
+        'wsl optional string',
+        malformedManifest((candidate) => {
+          const wsl = candidate['wsl'] as Record<string, unknown>;
+          wsl['distroName'] = false;
+        }),
+      ],
+      [
+        'service manager kind',
+        malformedManifest((candidate) => {
+          const serviceManager = candidate['serviceManager'] as Record<string, unknown>;
+          serviceManager['kind'] = 'launchctl';
+        }),
+      ],
+      [
+        'service manager optional string',
+        malformedManifest((candidate) => {
+          const serviceManager = candidate['serviceManager'] as Record<string, unknown>;
+          serviceManager['statusCommand'] = ['systemctl'];
+        }),
+      ],
+      [
+        'service manager caveats',
+        malformedManifest((candidate) => {
+          const serviceManager = candidate['serviceManager'] as Record<string, unknown>;
+          serviceManager['caveats'] = ['ok', 404];
+        }),
+      ],
+    ];
+
+    for (const [name, candidate] of malformedCases) {
+      expect(isNodeManifest(candidate), name).toBe(false);
+    }
+  });
+
   it('exchanges a one-time pair token for a durable credential without storing raw secret material', () => {
     withTmpRegistry((registry) => {
       const pair = registry.createPairToken({ displayName: 'Dev Mac' });

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -154,6 +154,13 @@ describe('hub node registry', () => {
         }),
       ],
       [
+        'agents record',
+        malformedManifest((candidate) => {
+          const capabilities = candidate['capabilities'] as Record<string, unknown>;
+          capabilities['agents'] = [];
+        }),
+      ],
+      [
         'service manager kind',
         malformedManifest((candidate) => {
           const serviceManager = candidate['serviceManager'] as Record<string, unknown>;

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -201,6 +201,57 @@ describe('hub node registry', () => {
     }
   });
 
+  it('debounces heartbeat persistence and flushes the latest node state deterministically', async () => {
+    const storagePath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hub-node-registry-')),
+      'nodes.json'
+    );
+    let now = new Date('2026-01-02T03:04:05.000Z');
+    try {
+      const registry = createHubNodeRegistry({
+        storagePath,
+        now: () => now,
+        heartbeatPersistDebounceMs: 60_000,
+      });
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      const persistedBeforeHeartbeat = JSON.parse(fs.readFileSync(storagePath, 'utf8')) as {
+        nodes: Array<{ lastSeenAt: string; hostname: string }>;
+      };
+
+      now = new Date('2026-01-02T03:05:05.000Z');
+      registry.recordHeartbeat({
+        nodeId: exchanged.node.nodeId,
+        protocolVersion: '1.0',
+        manifest: manifest({ hostname: 'heartbeat-host', relayVersion: '10.0.0' }),
+      });
+
+      const persistedImmediatelyAfterHeartbeat = JSON.parse(fs.readFileSync(storagePath, 'utf8')) as {
+        nodes: Array<{ lastSeenAt: string; hostname: string; relayVersion: string }>;
+      };
+      expect(persistedImmediatelyAfterHeartbeat.nodes[0]).toMatchObject({
+        lastSeenAt: persistedBeforeHeartbeat.nodes[0]?.lastSeenAt,
+        hostname: 'test-host',
+        relayVersion: '9.9.9',
+      });
+
+      await registry.flushPendingHeartbeatPersist();
+
+      const persistedAfterFlush = JSON.parse(fs.readFileSync(storagePath, 'utf8')) as {
+        nodes: Array<{ lastSeenAt: string; hostname: string; relayVersion: string }>;
+      };
+      expect(persistedAfterFlush.nodes[0]).toMatchObject({
+        lastSeenAt: '2026-01-02T03:05:05.000Z',
+        hostname: 'heartbeat-host',
+        relayVersion: '10.0.0',
+      });
+    } finally {
+      fs.rmSync(path.dirname(storagePath), { recursive: true, force: true });
+    }
+  });
+
   it('returns typed errors for expired tokens, bad credentials, and incompatible protocol versions', () => {
     withTmpRegistry((registry) => {
       const pair = registry.createPairToken({ ttlMs: 1 });

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -94,6 +94,7 @@ describe('hub node registry', () => {
       const pair = registry.createPairToken({ displayName: 'Dev Mac' });
       expect(pair.pairToken).toMatch(/^pair_/);
       expect(pair.expiresAt).toBe('2026-01-02T03:14:05.000Z');
+      expect(pair).not.toHaveProperty('bootstrapCommand');
 
       const exchanged = registry.exchangePairToken({
         pairToken: pair.pairToken,
@@ -158,6 +159,35 @@ describe('hub node registry', () => {
         hostname: 'persisted-host',
         status: 'online',
       });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('quarantines corrupt registry JSON and starts with empty replacement state', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hub-node-registry-'));
+    const storagePath = path.join(tmpDir, 'nodes.json');
+    const leakedSecret = 'pair_secret-from-corrupt-file';
+    fs.writeFileSync(storagePath, `{ "pairTokens": ["${leakedSecret}"],`);
+
+    try {
+      const registry = createHubNodeRegistry({
+        storagePath,
+        now: () => new Date('2026-01-02T03:04:05.000Z'),
+      });
+
+      expect(registry.listNodes()).toEqual([]);
+      expect(fs.existsSync(storagePath)).toBe(false);
+      const quarantined = fs.readdirSync(tmpDir).filter((name) => name.startsWith('nodes.json.corrupt-'));
+      expect(quarantined).toHaveLength(1);
+
+      registry.createPairToken({ displayName: 'replacement' });
+
+      const persisted = fs.readFileSync(storagePath, 'utf8');
+      const parsed = JSON.parse(persisted) as { pairTokens: unknown[]; nodes: unknown[] };
+      expect(parsed.pairTokens).toHaveLength(1);
+      expect(parsed.nodes).toEqual([]);
+      expect(persisted).not.toContain(leakedSecret);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -263,10 +293,19 @@ describe('hub node registry', () => {
       registry.setNowForTest(() => new Date('2026-01-02T03:04:07.000Z'));
       expect(registry.authenticateCredential('node_missing.bad')).toBeNull();
 
-      const fresh = registry.createPairToken({});
+      const minorSkew = registry.createPairToken({});
       expect(() =>
         registry.exchangePairToken({
-          pairToken: fresh.pairToken,
+          pairToken: minorSkew.pairToken,
+          manifest: manifest(),
+          protocolVersion: '1.1',
+        })
+      ).toThrow(/VERSION_SKEW/);
+
+      const incompatible = registry.createPairToken({});
+      expect(() =>
+        registry.exchangePairToken({
+          pairToken: incompatible.pairToken,
           manifest: manifest(),
           protocolVersion: '2.0',
         })

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -374,6 +374,37 @@ describe('hub node registry', () => {
     }
   });
 
+  it('still throws heartbeat persistence failures to explicit flush callers', async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hub-node-registry-'));
+    const storageDir = path.join(tmpRoot, 'registry-dir');
+    const storagePath = path.join(storageDir, 'nodes.json');
+    let now = new Date('2026-01-02T03:04:05.000Z');
+    try {
+      const registry = createHubNodeRegistry({
+        storagePath,
+        now: () => now,
+        heartbeatPersistDebounceMs: 60_000,
+      });
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+
+      fs.rmSync(storageDir, { recursive: true, force: true });
+      fs.writeFileSync(storageDir, 'not a directory');
+      now = new Date('2026-01-02T03:05:05.000Z');
+      registry.recordHeartbeat({
+        nodeId: exchanged.node.nodeId,
+        protocolVersion: '1.0',
+        manifest: manifest({ hostname: 'heartbeat-host', relayVersion: '10.0.0' }),
+      });
+
+      await expect(registry.flushPendingHeartbeatPersist()).rejects.toThrow();
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
   it('returns typed errors for expired tokens, bad credentials, and incompatible protocol versions', () => {
     withTmpRegistry((registry) => {
       const pair = registry.createPairToken({ ttlMs: 1 });

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -1,0 +1,225 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  createHubNodeRegistry,
+  DEFAULT_NODE_HEARTBEAT_TIMEOUTS,
+} from '../server/hub-node-registry.js';
+import type { NodeManifest } from '../shared/node-manifest.js';
+
+function manifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
+  return {
+    schemaVersion: 1,
+    platform: 'darwin',
+    arch: 'arm64',
+    hostname: 'test-host',
+    relayVersion: '9.9.9',
+    generatedAt: '2026-01-02T03:04:05.000Z',
+    wsl: { detected: false, version: null, systemd: false },
+    serviceManager: {
+      kind: 'launchd',
+      label: 'launchd',
+      supported: true,
+      installable: true,
+      installHint: 'install',
+      uninstallHint: 'uninstall',
+      message: 'ok',
+      caveats: [],
+    },
+    capabilities: {
+      tmux: { id: 'tmux', label: 'tmux', status: 'available', message: 'ok' },
+      git: { id: 'git', label: 'Git', status: 'available', message: 'ok' },
+      clipboard: {
+        id: 'clipboard',
+        label: 'Clipboard',
+        status: 'degraded',
+        message: 'file fallback',
+      },
+      browserAutomation: {
+        id: 'browserAutomation',
+        label: 'Browser automation',
+        status: 'available',
+        message: 'ok',
+      },
+      githubCli: {
+        id: 'githubCli',
+        label: 'GitHub CLI',
+        status: 'unavailable',
+        message: 'missing',
+      },
+      tailscale: {
+        id: 'tailscale',
+        label: 'Tailscale CLI',
+        status: 'available',
+        message: 'ok',
+      },
+      ssh: { id: 'ssh', label: 'SSH client', status: 'available', message: 'ok' },
+      agents: {
+        claude: {
+          id: 'claude',
+          label: 'Claude',
+          status: 'available',
+          message: 'ok',
+        },
+        codex: {
+          id: 'codex',
+          label: 'Codex',
+          status: 'unavailable',
+          message: 'missing',
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+function withTmpRegistry<T>(fn: (registry: ReturnType<typeof createHubNodeRegistry>) => T): T {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hub-node-registry-'));
+  try {
+    return fn(
+      createHubNodeRegistry({
+        storagePath: path.join(tmpDir, 'nodes.json'),
+        now: () => new Date('2026-01-02T03:04:05.000Z'),
+      })
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+describe('hub node registry', () => {
+  it('exchanges a one-time pair token for a durable credential without storing raw secret material', () => {
+    withTmpRegistry((registry) => {
+      const pair = registry.createPairToken({ displayName: 'Dev Mac' });
+      expect(pair.pairToken).toMatch(/^pair_/);
+      expect(pair.expiresAt).toBe('2026-01-02T03:14:05.000Z');
+
+      const exchanged = registry.exchangePairToken({
+        pairToken: pair.pairToken,
+        manifest: manifest(),
+        displayName: 'Dev Mac',
+      });
+
+      expect(exchanged.credential).toMatchObject({
+        protocol: 'relay-node-link',
+        protocolVersion: '1.0',
+        nodeId: exchanged.node.nodeId,
+      });
+      expect(exchanged.credential.token).toMatch(new RegExp(`^${exchanged.node.nodeId}\\.`));
+      expect(exchanged.node).toMatchObject({
+        displayName: 'Dev Mac',
+        hostname: 'test-host',
+        platform: 'darwin',
+        relayVersion: '9.9.9',
+        protocolVersion: '1.0',
+        status: 'online',
+        capabilities: {
+          totals: { available: 6, degraded: 1, unavailable: 2, unknown: 0 },
+          agents: { claude: 'available', codex: 'unavailable' },
+        },
+      });
+
+      expect(() =>
+        registry.exchangePairToken({ pairToken: pair.pairToken, manifest: manifest() })
+      ).toThrow(/TOKEN_ALREADY_USED/);
+
+      const persisted = fs.readFileSync(registry.storagePath, 'utf8');
+      expect(persisted).not.toContain(pair.pairToken);
+      expect(persisted).not.toContain(exchanged.credential.token);
+      expect(persisted).not.toContain(exchanged.credential.token.split('.')[1]!);
+    });
+  });
+
+  it('persists paired nodes and authenticates durable node credentials after reload', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hub-node-registry-'));
+    try {
+      const storagePath = path.join(tmpDir, 'nodes.json');
+      const registry = createHubNodeRegistry({
+        storagePath,
+        now: () => new Date('2026-01-02T03:04:05.000Z'),
+      });
+      const pair = registry.createPairToken({});
+      const exchanged = registry.exchangePairToken({
+        pairToken: pair.pairToken,
+        manifest: manifest({ hostname: 'persisted-host' }),
+      });
+
+      const reloaded = createHubNodeRegistry({
+        storagePath,
+        now: () => new Date('2026-01-02T03:04:06.000Z'),
+      });
+
+      expect(reloaded.authenticateCredential(exchanged.credential.token)?.nodeId).toBe(
+        exchanged.node.nodeId
+      );
+      expect(reloaded.listNodes()[0]).toMatchObject({
+        nodeId: exchanged.node.nodeId,
+        hostname: 'persisted-host',
+        status: 'online',
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('computes deterministic stale and offline states from heartbeat age', () => {
+    const storagePath = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hub-node-registry-')),
+      'nodes.json'
+    );
+    let now = new Date('2026-01-02T03:04:05.000Z');
+    try {
+      const registry = createHubNodeRegistry({ storagePath, now: () => now });
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+
+      now = new Date(
+        Date.parse(exchanged.node.lastSeenAt) + DEFAULT_NODE_HEARTBEAT_TIMEOUTS.staleMs + 1
+      );
+      expect(registry.listNodes()[0]?.status).toBe('stale');
+
+      now = new Date(
+        Date.parse(exchanged.node.lastSeenAt) + DEFAULT_NODE_HEARTBEAT_TIMEOUTS.offlineMs + 1
+      );
+      expect(registry.listNodes()[0]?.status).toBe('offline');
+
+      registry.recordHeartbeat({
+        nodeId: exchanged.node.nodeId,
+        protocolVersion: '1.0',
+        manifest: manifest({ relayVersion: '10.0.0' }),
+      });
+
+      expect(registry.listNodes()[0]).toMatchObject({
+        status: 'online',
+        relayVersion: '10.0.0',
+      });
+    } finally {
+      fs.rmSync(path.dirname(storagePath), { recursive: true, force: true });
+    }
+  });
+
+  it('returns typed errors for expired tokens, bad credentials, and incompatible protocol versions', () => {
+    withTmpRegistry((registry) => {
+      const pair = registry.createPairToken({ ttlMs: 1 });
+      registry.setNowForTest(() => new Date('2026-01-02T03:04:06.000Z'));
+      expect(() =>
+        registry.exchangePairToken({ pairToken: pair.pairToken, manifest: manifest() })
+      ).toThrow(/TOKEN_EXPIRED/);
+
+      registry.setNowForTest(() => new Date('2026-01-02T03:04:07.000Z'));
+      expect(registry.authenticateCredential('node_missing.bad')).toBeNull();
+
+      const fresh = registry.createPairToken({});
+      expect(() =>
+        registry.exchangePairToken({
+          pairToken: fresh.pairToken,
+          manifest: manifest(),
+          protocolVersion: '2.0',
+        })
+      ).toThrow(/PROTOCOL_INCOMPATIBLE/);
+    });
+  });
+});

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -103,6 +103,20 @@ describe('hub node routes and link', () => {
     expect(pairRes.status).toBe(201);
     const pair = (await pairRes.json()) as { pairToken: string; expiresAt: string };
     expect(pair.pairToken).toMatch(/^pair_/);
+    expect(pair).not.toHaveProperty('bootstrapCommand');
+
+    const malformedExchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        pairToken: pair.pairToken,
+        manifest: { schemaVersion: 1, hostname: 'partial' },
+      }),
+    });
+    expect(malformedExchangeRes.status).toBe(400);
+    expect(await malformedExchangeRes.json()).toMatchObject({
+      error: { code: 'INVALID_REQUEST', retryable: false },
+    });
 
     const exchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
       method: 'POST',
@@ -129,6 +143,23 @@ describe('hub node routes and link', () => {
     });
     expect(heartbeatRes.status).toBe(200);
 
+    const malformedHeartbeatRes = await fetch(`${base}/hub/node-heartbeat`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${exchange.credential.token}`,
+      },
+      body: JSON.stringify({
+        nodeId: exchange.credential.nodeId,
+        protocolVersion: '1.0',
+        manifest: { schemaVersion: 1, hostname: 'partial' },
+      }),
+    });
+    expect(malformedHeartbeatRes.status).toBe(400);
+    expect(await malformedHeartbeatRes.json()).toMatchObject({
+      error: { code: 'INVALID_REQUEST', retryable: false },
+    });
+
     const nodesRes = await fetch(`${base}/nodes`, { headers: { 'x-test-auth': 'yes' } });
     expect(nodesRes.status).toBe(200);
     const nodesBody = await nodesRes.text();
@@ -151,7 +182,7 @@ describe('hub node routes and link', () => {
     const port = await listen(server);
     cleanup.push(() => close(server));
 
-    const ws = new WebSocket(`ws://127.0.0.1:${port}/hub/node-link`, {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/hub/node-link?trace=test`, {
       headers: { authorization: `Bearer ${exchanged.credential.token}` },
     });
     cleanup.push(() => ws.close());
@@ -181,7 +212,26 @@ describe('hub node routes and link', () => {
       payload: { node: { hostname: 'linked-host', status: 'online' } },
     });
 
-    const error = new Promise<Record<string, unknown>>((resolve) => {
+    const skewError = new Promise<Record<string, unknown>>((resolve) => {
+      ws.once('message', (data) => resolve(JSON.parse(data.toString()) as Record<string, unknown>));
+    });
+    ws.send(
+      JSON.stringify({
+        protocol: 'relay-node-link',
+        protocolVersion: '1.1',
+        nodeId: exchanged.node.nodeId,
+        channel: 'control',
+        type: 'control.heartbeat',
+        timestamp: now.toISOString(),
+      })
+    );
+    expect(await skewError).toMatchObject({
+      channel: 'control',
+      type: 'control.error',
+      error: { code: 'VERSION_SKEW', retryable: false },
+    });
+
+    const incompatibleError = new Promise<Record<string, unknown>>((resolve) => {
       ws.once('message', (data) => resolve(JSON.parse(data.toString()) as Record<string, unknown>));
     });
     ws.send(
@@ -194,7 +244,7 @@ describe('hub node routes and link', () => {
         timestamp: now.toISOString(),
       })
     );
-    expect(await error).toMatchObject({
+    expect(await incompatibleError).toMatchObject({
       channel: 'control',
       type: 'control.error',
       error: { code: 'PROTOCOL_INCOMPATIBLE', retryable: false },

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -1,0 +1,203 @@
+import * as fs from 'node:fs';
+import http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import express from 'express';
+import { WebSocket } from 'ws';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createHubNodeRegistry } from '../server/hub-node-registry.js';
+import { createHubNodeRouter } from '../server/hub-node-router.js';
+import { setupWebSocket } from '../server/ws.js';
+import type { NodeManifest } from '../shared/node-manifest.js';
+
+function manifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
+  return {
+    schemaVersion: 1,
+    platform: 'linux',
+    arch: 'x64',
+    hostname: 'node-routes-host',
+    relayVersion: '0.1.0-test',
+    generatedAt: '2026-01-02T03:04:05.000Z',
+    wsl: { detected: false, version: null, systemd: false },
+    serviceManager: {
+      kind: 'systemd-user',
+      label: 'systemd user',
+      supported: true,
+      installable: true,
+      installHint: 'install',
+      uninstallHint: 'uninstall',
+      message: 'ok',
+      caveats: [],
+    },
+    capabilities: {
+      tmux: { id: 'tmux', label: 'tmux', status: 'available', message: 'ok' },
+      git: { id: 'git', label: 'Git', status: 'available', message: 'ok' },
+      clipboard: { id: 'clipboard', label: 'Clipboard', status: 'unknown', message: 'unknown' },
+      browserAutomation: {
+        id: 'browserAutomation',
+        label: 'Browser automation',
+        status: 'degraded',
+        message: 'missing deps',
+      },
+      githubCli: { id: 'githubCli', label: 'GitHub CLI', status: 'available', message: 'ok' },
+      tailscale: { id: 'tailscale', label: 'Tailscale CLI', status: 'unavailable', message: 'missing' },
+      ssh: { id: 'ssh', label: 'SSH client', status: 'available', message: 'ok' },
+      agents: {},
+    },
+    ...overrides,
+  };
+}
+
+function tmpRegistry(now = () => new Date('2026-01-02T03:04:05.000Z')) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hub-node-routes-'));
+  const registry = createHubNodeRegistry({ storagePath: path.join(tmpDir, 'nodes.json'), now });
+  return { tmpDir, registry };
+}
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing server address');
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+describe('hub node routes and link', () => {
+  const cleanup: Array<() => Promise<void> | void> = [];
+
+  afterEach(async () => {
+    while (cleanup.length > 0) await cleanup.pop()?.();
+  });
+
+  it('protects user-facing pair/list routes while allowing token exchange and bearer heartbeat', async () => {
+    const { tmpDir, registry } = tmpRegistry();
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const app = express();
+    app.use(express.json());
+    app.use(
+      createHubNodeRouter({
+        registry,
+        requireAuth: (req, res, next) => {
+          if (req.header('x-test-auth') === 'yes') next();
+          else res.status(401).json({ error: 'Unauthorized' });
+        },
+      })
+    );
+    const server = http.createServer(app);
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+    const base = `http://127.0.0.1:${port}`;
+
+    expect((await fetch(`${base}/hub/pair-tokens`, { method: 'POST' })).status).toBe(401);
+
+    const pairRes = await fetch(`${base}/hub/pair-tokens`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      body: JSON.stringify({ displayName: 'Route Node' }),
+    });
+    expect(pairRes.status).toBe(201);
+    const pair = (await pairRes.json()) as { pairToken: string; expiresAt: string };
+    expect(pair.pairToken).toMatch(/^pair_/);
+
+    const exchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pairToken: pair.pairToken, manifest: manifest() }),
+    });
+    expect(exchangeRes.status).toBe(201);
+    const exchange = (await exchangeRes.json()) as {
+      credential: { token: string; nodeId: string };
+      node: { nodeId: string };
+    };
+
+    const heartbeatRes = await fetch(`${base}/hub/node-heartbeat`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${exchange.credential.token}`,
+      },
+      body: JSON.stringify({
+        nodeId: exchange.credential.nodeId,
+        protocolVersion: '1.0',
+        manifest: manifest({ relayVersion: '0.1.1-test' }),
+      }),
+    });
+    expect(heartbeatRes.status).toBe(200);
+
+    const nodesRes = await fetch(`${base}/nodes`, { headers: { 'x-test-auth': 'yes' } });
+    expect(nodesRes.status).toBe(200);
+    const nodesBody = await nodesRes.text();
+    expect(nodesBody).toContain('0.1.1-test');
+    expect(nodesBody).not.toContain(pair.pairToken);
+    expect(nodesBody).not.toContain(exchange.credential.token);
+  });
+
+  it('accepts authenticated reverse websocket heartbeats and rejects incompatible protocol envelopes with typed errors', async () => {
+    let now = new Date('2026-01-02T03:04:05.000Z');
+    const { tmpDir, registry } = tmpRegistry(() => now);
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const exchanged = registry.exchangePairToken({
+      pairToken: registry.createPairToken({}).pairToken,
+      manifest: manifest(),
+    });
+
+    const server = http.createServer(express());
+    setupWebSocket(server, new Set(), null, undefined, false, undefined, registry);
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/hub/node-link`, {
+      headers: { authorization: `Bearer ${exchanged.credential.token}` },
+    });
+    cleanup.push(() => ws.close());
+    await new Promise<void>((resolve, reject) => {
+      ws.once('open', resolve);
+      ws.once('error', reject);
+    });
+
+    now = new Date('2026-01-02T03:04:10.000Z');
+    const ack = new Promise<Record<string, unknown>>((resolve) => {
+      ws.once('message', (data) => resolve(JSON.parse(data.toString()) as Record<string, unknown>));
+    });
+    ws.send(
+      JSON.stringify({
+        protocol: 'relay-node-link',
+        protocolVersion: '1.0',
+        nodeId: exchanged.node.nodeId,
+        channel: 'control',
+        type: 'control.heartbeat',
+        timestamp: now.toISOString(),
+        payload: { manifest: manifest({ hostname: 'linked-host' }) },
+      })
+    );
+    expect(await ack).toMatchObject({
+      channel: 'control',
+      type: 'control.heartbeat.ack',
+      payload: { node: { hostname: 'linked-host', status: 'online' } },
+    });
+
+    const error = new Promise<Record<string, unknown>>((resolve) => {
+      ws.once('message', (data) => resolve(JSON.parse(data.toString()) as Record<string, unknown>));
+    });
+    ws.send(
+      JSON.stringify({
+        protocol: 'relay-node-link',
+        protocolVersion: '2.0',
+        nodeId: exchanged.node.nodeId,
+        channel: 'control',
+        type: 'control.heartbeat',
+        timestamp: now.toISOString(),
+      })
+    );
+    expect(await error).toMatchObject({
+      channel: 'control',
+      type: 'control.error',
+      error: { code: 'PROTOCOL_INCOMPATIBLE', retryable: false },
+    });
+  });
+});

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -48,6 +48,14 @@ function manifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
   };
 }
 
+function nestedMalformedManifest(): unknown {
+  const candidate = JSON.parse(JSON.stringify(manifest())) as Record<string, unknown>;
+  const serviceManager = candidate['serviceManager'] as Record<string, unknown>;
+  serviceManager['kind'] = 'systemd';
+  serviceManager['caveats'] = ['ok', { text: 'not a string' }];
+  return candidate;
+}
+
 function tmpRegistry(now = () => new Date('2026-01-02T03:04:05.000Z')) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hub-node-routes-'));
   const registry = createHubNodeRegistry({ storagePath: path.join(tmpDir, 'nodes.json'), now });
@@ -118,6 +126,19 @@ describe('hub node routes and link', () => {
       error: { code: 'INVALID_REQUEST', retryable: false },
     });
 
+    const nestedMalformedExchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        pairToken: pair.pairToken,
+        manifest: nestedMalformedManifest(),
+      }),
+    });
+    expect(nestedMalformedExchangeRes.status).toBe(400);
+    expect(await nestedMalformedExchangeRes.json()).toMatchObject({
+      error: { code: 'INVALID_REQUEST', retryable: false },
+    });
+
     const exchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -157,6 +178,23 @@ describe('hub node routes and link', () => {
     });
     expect(malformedHeartbeatRes.status).toBe(400);
     expect(await malformedHeartbeatRes.json()).toMatchObject({
+      error: { code: 'INVALID_REQUEST', retryable: false },
+    });
+
+    const nestedMalformedHeartbeatRes = await fetch(`${base}/hub/node-heartbeat`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${exchange.credential.token}`,
+      },
+      body: JSON.stringify({
+        nodeId: exchange.credential.nodeId,
+        protocolVersion: '1.0',
+        manifest: nestedMalformedManifest(),
+      }),
+    });
+    expect(nestedMalformedHeartbeatRes.status).toBe(400);
+    expect(await nestedMalformedHeartbeatRes.json()).toMatchObject({
       error: { code: 'INVALID_REQUEST', retryable: false },
     });
 
@@ -210,6 +248,26 @@ describe('hub node routes and link', () => {
       channel: 'control',
       type: 'control.heartbeat.ack',
       payload: { node: { hostname: 'linked-host', status: 'online' } },
+    });
+
+    const malformedManifestError = new Promise<Record<string, unknown>>((resolve) => {
+      ws.once('message', (data) => resolve(JSON.parse(data.toString()) as Record<string, unknown>));
+    });
+    ws.send(
+      JSON.stringify({
+        protocol: 'relay-node-link',
+        protocolVersion: '1.0',
+        nodeId: exchanged.node.nodeId,
+        channel: 'control',
+        type: 'control.heartbeat',
+        timestamp: now.toISOString(),
+        payload: { manifest: nestedMalformedManifest() },
+      })
+    );
+    expect(await malformedManifestError).toMatchObject({
+      channel: 'control',
+      type: 'control.error',
+      error: { code: 'INVALID_REQUEST', retryable: false },
     });
 
     const skewError = new Promise<Record<string, unknown>>((resolve) => {

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -56,6 +56,13 @@ function nestedMalformedManifest(): unknown {
   return candidate;
 }
 
+function agentArrayManifest(): unknown {
+  const candidate = JSON.parse(JSON.stringify(manifest())) as Record<string, unknown>;
+  const capabilities = candidate['capabilities'] as Record<string, unknown>;
+  capabilities['agents'] = [];
+  return candidate;
+}
+
 function tmpRegistry(now = () => new Date('2026-01-02T03:04:05.000Z')) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hub-node-routes-'));
   const registry = createHubNodeRegistry({ storagePath: path.join(tmpDir, 'nodes.json'), now });
@@ -139,6 +146,19 @@ describe('hub node routes and link', () => {
       error: { code: 'INVALID_REQUEST', retryable: false },
     });
 
+    const agentArrayExchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        pairToken: pair.pairToken,
+        manifest: agentArrayManifest(),
+      }),
+    });
+    expect(agentArrayExchangeRes.status).toBe(400);
+    expect(await agentArrayExchangeRes.json()).toMatchObject({
+      error: { code: 'INVALID_REQUEST', retryable: false },
+    });
+
     const exchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -195,6 +215,23 @@ describe('hub node routes and link', () => {
     });
     expect(nestedMalformedHeartbeatRes.status).toBe(400);
     expect(await nestedMalformedHeartbeatRes.json()).toMatchObject({
+      error: { code: 'INVALID_REQUEST', retryable: false },
+    });
+
+    const agentArrayHeartbeatRes = await fetch(`${base}/hub/node-heartbeat`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${exchange.credential.token}`,
+      },
+      body: JSON.stringify({
+        nodeId: exchange.credential.nodeId,
+        protocolVersion: '1.0',
+        manifest: agentArrayManifest(),
+      }),
+    });
+    expect(agentArrayHeartbeatRes.status).toBe(400);
+    expect(await agentArrayHeartbeatRes.json()).toMatchObject({
       error: { code: 'INVALID_REQUEST', retryable: false },
     });
 

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -307,6 +307,26 @@ describe('hub node routes and link', () => {
       error: { code: 'INVALID_REQUEST', retryable: false },
     });
 
+    const agentArrayManifestError = new Promise<Record<string, unknown>>((resolve) => {
+      ws.once('message', (data) => resolve(JSON.parse(data.toString()) as Record<string, unknown>));
+    });
+    ws.send(
+      JSON.stringify({
+        protocol: 'relay-node-link',
+        protocolVersion: '1.0',
+        nodeId: exchanged.node.nodeId,
+        channel: 'control',
+        type: 'control.heartbeat',
+        timestamp: now.toISOString(),
+        payload: { manifest: agentArrayManifest() },
+      })
+    );
+    expect(await agentArrayManifestError).toMatchObject({
+      channel: 'control',
+      type: 'control.error',
+      error: { code: 'INVALID_REQUEST', retryable: false },
+    });
+
     const skewError = new Promise<Record<string, unknown>>((resolve) => {
       ws.once('message', (data) => resolve(JSON.parse(data.toString()) as Record<string, unknown>));
     });


### PR DESCRIPTION
## Summary
- add shared relay-node-link protocol types and constants
- add file-backed hub node registry for one-time pair tokens, durable node credentials, manifest summaries, heartbeats, stale/offline/revoked status, and protocol mismatch errors
- mount authenticated hub registry routes and route `WS /hub/node-link` through node credential auth/heartbeat handling

Refs #317
Closes #385

## Tests
- `nvm use`
- `rtk npm run check` (passes; existing lint warnings only)
- `rtk npm run build`
- `rtk npm test -- test/hub-node-registry.test.ts test/hub-node-routes.test.ts`
- `rtk npm test -- test/sessions.test.ts test/ws-pty-routing.test.ts`
- `rtk npm test`

## Notes / risks
- registry persists at `<configDir>/hub-node-registry.json`; pair tokens and node credential secrets are stored hashed, but issued token/credential values are only returned to the caller at creation/exchange time
- node revocation marks the credential revoked for future auth; closing an already-open node-link on revoke remains a follow-up for the connection manager slice
- this intentionally does not implement dashboard UI, repo inventory aggregation, or hub-routed session/PTY RPC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hub node registry for pairing, credential exchange, status (online/stale/offline) tracking, heartbeat persistence, and revocation
  * HTTP API for creating pair tokens, exchanging credentials, recording heartbeats, listing and deleting nodes
  * Authenticated WebSocket link for hub-node control messages (hello/heartbeat) with structured error responses
  * Standardized relay node protocol plus manifest validation and capability summaries

* **Tests**
  * Unit and integration tests covering registry persistence, routes, websockets, heartbeats, and error cases

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/401)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/401)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->