### PR TITLE
Harden relay node trust lifecycle

### DIFF
--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -147,6 +147,17 @@ function syntheticLocalNode(selectedAgent: AgentType): HubNodeSummary {
     protocolVersion: 'local',
     status: 'online',
     connection: { route: 'local', status: 'connected' },
+    trust: {
+      state: 'trusted',
+      level: 'privileged-local-user',
+      warning: '',
+    },
+    credentialState: 'active',
+    version: {
+      state: 'compatible',
+      nodeProtocolVersion: 'local',
+      hubProtocolVersion: '1.0',
+    },
     capabilities: {
       totals: { available: 8, degraded: 0, unavailable: 0, unknown: 0 },
       core: {

--- a/frontend/src/test-customize-session-dialog.tsx
+++ b/frontend/src/test-customize-session-dialog.tsx
@@ -44,6 +44,17 @@ function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
     protocolVersion: '1.0',
     status: 'online',
     connection: { route: 'local', status: 'connected' },
+    trust: {
+      state: 'trusted',
+      level: 'privileged-local-user',
+      warning: 'test node is trusted',
+    },
+    credentialState: 'active',
+    version: {
+      state: 'compatible',
+      nodeProtocolVersion: '1.0',
+      hubProtocolVersion: '1.0',
+    },
     capabilities: {
       totals: { available: 10, degraded: 0, unavailable: 0, unknown: 0 },
       core: {

--- a/server/hub-node-link.ts
+++ b/server/hub-node-link.ts
@@ -378,6 +378,21 @@ export function handleHubNodeLink(
 ): void {
   const authenticatedNodeId = authenticatedNode.nodeId;
   nodeLinks?.registerNodeLink(authenticatedNodeId, ws);
+  const unsubscribeRevoked = registry.onNodeRevoked((nodeId) => {
+    if (nodeId !== authenticatedNodeId) return;
+    sendJson(
+      ws,
+      errorEnvelope(authenticatedNodeId, {}, {
+        code: 'NODE_REVOKED',
+        message: 'node credential was revoked',
+        retryable: false,
+      })
+    );
+    ws.close(4003, 'node revoked');
+  });
+  const cleanup = () => unsubscribeRevoked();
+  ws.on('close', cleanup);
+  ws.on('error', cleanup);
 
   ws.on('message', (data) => {
     const parsed = parseEnvelope(data);

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -9,6 +9,7 @@ import {
   RELAY_NODE_LINK_PROTOCOL_VERSION,
   type HubNodeStatus,
   type HubNodeSummary,
+  type HubNodeVersionState,
   type NodeCapabilityManifestSummary,
   type NodeCapabilityStatus,
   type RelayNodeCredential,
@@ -87,6 +88,13 @@ export const DEFAULT_NODE_HEARTBEAT_TIMEOUTS = {
   offlineMs: 90 * 1000,
 } as const;
 export const DEFAULT_HEARTBEAT_PERSIST_DEBOUNCE_MS = 5 * 1000;
+const PRIVILEGED_NODE_WARNING =
+  'A paired Relay node is trusted to act as the local OS user on that machine.';
+
+export type CredentialAuthResult =
+  | { ok: true; node: HubNodeSummary }
+  | { ok: false; error: RelayNodeError };
+type NodeRevokedListener = (nodeId: string) => void;
 
 class HubNodeRegistryError extends Error {
   readonly relayNodeError: RelayNodeError;
@@ -260,6 +268,13 @@ function normalizeCapabilitySummary(
   };
 }
 
+function versionState(protocolVersion: string): HubNodeVersionState {
+  if (protocolVersion === RELAY_NODE_LINK_PROTOCOL_VERSION) return 'compatible';
+  const [nodeMajor] = protocolVersion.split('.');
+  const [hubMajor] = RELAY_NODE_LINK_PROTOCOL_VERSION.split('.');
+  return nodeMajor === hubMajor ? 'version-skew' : 'incompatible';
+}
+
 function publicNode(
   node: StoredNodeRecord,
   status: HubNodeStatus
@@ -274,6 +289,17 @@ function publicNode(
     protocolVersion: node.protocolVersion,
     status,
     connection: connectionSummary(status),
+    trust: {
+      state: node.revokedAt ? 'revoked' : 'trusted',
+      level: 'privileged-local-user',
+      warning: PRIVILEGED_NODE_WARNING,
+    },
+    credentialState: node.revokedAt ? 'revoked' : 'active',
+    version: {
+      state: versionState(node.protocolVersion),
+      nodeProtocolVersion: node.protocolVersion,
+      hubProtocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+    },
     capabilities: normalizeCapabilitySummary(node.capabilities),
     createdAt: node.createdAt,
     pairedAt: node.pairedAt,
@@ -299,6 +325,7 @@ export class HubNodeRegistry {
   private heartbeatPersistTimer: NodeJS.Timeout | null = null;
   private heartbeatPersistDirty = false;
   private heartbeatPersistError: unknown = null;
+  private readonly nodeRevokedListeners = new Set<NodeRevokedListener>();
 
   constructor(options: HubNodeRegistryOptions) {
     this.storagePath = options.storagePath;
@@ -312,6 +339,13 @@ export class HubNodeRegistry {
 
   setNowForTest(now: () => Date): void {
     this.now = now;
+  }
+
+  onNodeRevoked(listener: NodeRevokedListener): () => void {
+    this.nodeRevokedListeners.add(listener);
+    return () => {
+      this.nodeRevokedListeners.delete(listener);
+    };
   }
 
   createPairToken(options: { displayName?: string; ttlMs?: number }): PairTokenResponse {
@@ -394,19 +428,33 @@ export class HubNodeRegistry {
   }
 
   authenticateCredential(token: string): HubNodeSummary | null {
+    const result = this.authenticateCredentialDetailed(token);
+    return result.ok ? result.node : null;
+  }
+
+  authenticateCredentialDetailed(token: string): CredentialAuthResult {
     const tokenHash = sha256(token);
     const [nodeId] = token.split('.', 1);
-    const node = this.state.nodes.find(
-      (candidate) =>
-        candidate.nodeId === nodeId &&
-        !candidate.revokedAt &&
-        timingSafeEqualHex(candidate.credentialHash, tokenHash)
-    );
-    if (!node) return null;
-    return publicNode(
-      node,
-      statusForNode(node, this.now(), this.staleMs, this.offlineMs)
-    );
+    const node = this.state.nodes.find((candidate) => candidate.nodeId === nodeId);
+    if (!node || !timingSafeEqualHex(node.credentialHash, tokenHash)) {
+      return {
+        ok: false,
+        error: { code: 'UNAUTHORIZED', message: 'invalid node credential', retryable: false },
+      };
+    }
+    if (node.revokedAt) {
+      return {
+        ok: false,
+        error: { code: 'NODE_REVOKED', message: 'node credential was revoked', retryable: false },
+      };
+    }
+    return {
+      ok: true,
+      node: publicNode(
+        node,
+        statusForNode(node, this.now(), this.staleMs, this.offlineMs)
+      ),
+    };
   }
 
   recordHeartbeat(input: HeartbeatInput): HubNodeSummary {
@@ -468,8 +516,12 @@ export class HubNodeRegistry {
   revokeNode(nodeId: string): HubNodeSummary {
     const node = this.state.nodes.find((candidate) => candidate.nodeId === nodeId);
     if (!node) throw new HubNodeRegistryError('NOT_FOUND', 'node is not paired');
-    node.revokedAt = this.now().toISOString();
-    this.persist();
+    const alreadyRevoked = Boolean(node.revokedAt);
+    if (!alreadyRevoked) {
+      node.revokedAt = this.now().toISOString();
+      this.persist();
+      this.notifyNodeRevoked(nodeId);
+    }
     return publicNode(node, 'revoked');
   }
 
@@ -484,6 +536,10 @@ export class HubNodeRegistry {
         retryable: true,
       },
     };
+  }
+
+  private notifyNodeRevoked(nodeId: string): void {
+    this.nodeRevokedListeners.forEach((listener) => listener(nodeId));
   }
 
   private persist(): void {

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -539,7 +539,16 @@ export class HubNodeRegistry {
   }
 
   private notifyNodeRevoked(nodeId: string): void {
-    this.nodeRevokedListeners.forEach((listener) => listener(nodeId));
+    this.nodeRevokedListeners.forEach((listener) => {
+      try {
+        listener(nodeId);
+      } catch {
+        logger.warn(
+          'hub node revoke listener failed; continuing revoke notifications for node %s',
+          nodeId
+        );
+      }
+    });
   }
 
   private persist(): void {

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -264,17 +264,25 @@ export function createHubNodeRouter(options: HubNodeRouterOptions): express.Rout
 
   router.post('/hub/node-heartbeat', (req, res) => {
     const token = bearerToken(req);
-    const authenticated = token ? registry.authenticateCredential(token) : null;
+    const authenticated = token ? registry.authenticateCredentialDetailed(token) : null;
     if (!authenticated) {
-      res.status(401).json({
-        error: { code: 'UNAUTHORIZED', message: 'invalid node credential', retryable: false },
-      });
+      const error = {
+        code: 'UNAUTHORIZED' as const,
+        message: 'invalid node credential',
+        retryable: false,
+      };
+      res.status(errorStatus(error)).json({ error });
+      return;
+    }
+    if (authenticated.ok === false) {
+      const { error } = authenticated;
+      res.status(errorStatus(error)).json({ error });
       return;
     }
     const body = bodyRecord(req);
     const protocolVersion = body['protocolVersion'];
     if (
-      body['nodeId'] !== authenticated.nodeId ||
+      body['nodeId'] !== authenticated.node.nodeId ||
       typeof protocolVersion !== 'string'
     ) {
       res.status(400).json({
@@ -291,7 +299,7 @@ export function createHubNodeRouter(options: HubNodeRouterOptions): express.Rout
       const repoInventory = repoInventoryFromBody(body);
       res.json({
         node: registry.recordHeartbeat({
-          nodeId: authenticated.nodeId,
+          nodeId: authenticated.node.nodeId,
           protocolVersion,
           ...(manifest ? { manifest } : {}),
           ...(repoInventory ? { repoInventory } : {}),

--- a/shared/relay-node-protocol.ts
+++ b/shared/relay-node-protocol.ts
@@ -51,6 +51,10 @@ export interface RelayNodeCredential {
 }
 
 export type HubNodeStatus = 'online' | 'stale' | 'offline' | 'revoked';
+export type HubNodeCredentialState = 'active' | 'revoked';
+export type HubNodeTrustState = 'trusted' | 'revoked';
+export type HubNodeTrustLevel = 'privileged-local-user';
+export type HubNodeVersionState = 'compatible' | 'version-skew' | 'incompatible';
 
 export type NodeCapabilityStatus =
   | 'available'
@@ -96,6 +100,17 @@ export interface HubNodeSummary {
   protocolVersion: string;
   status: HubNodeStatus;
   connection: HubNodeConnectionSummary;
+  trust: {
+    state: HubNodeTrustState;
+    level: HubNodeTrustLevel;
+    warning: string;
+  };
+  credentialState: HubNodeCredentialState;
+  version: {
+    state: HubNodeVersionState;
+    nodeProtocolVersion: string;
+    hubProtocolVersion: typeof RELAY_NODE_LINK_PROTOCOL_VERSION;
+  };
   capabilities: NodeCapabilityManifestSummary;
   createdAt: string;
   pairedAt: string;

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   createHubNodeRegistry,
   DEFAULT_NODE_HEARTBEAT_TIMEOUTS,
@@ -456,6 +456,43 @@ describe('hub node registry', () => {
         })
       ).toThrow(/NODE_REVOKED/);
     });
+  });
+
+  it('isolates revoke listener exceptions and continues notifying later listeners', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      withTmpRegistry((registry) => {
+        const exchanged = registry.exchangePairToken({
+          pairToken: registry.createPairToken({}).pairToken,
+          manifest: manifest(),
+        });
+        const notifiedNodeIds: string[] = [];
+
+        registry.onNodeRevoked(() => {
+          throw new Error('listener should not leak');
+        });
+        registry.onNodeRevoked((nodeId) => {
+          notifiedNodeIds.push(nodeId);
+        });
+
+        expect(() => registry.revokeNode(exchanged.node.nodeId)).not.toThrow();
+
+        expect(notifiedNodeIds).toEqual([exchanged.node.nodeId]);
+        expect(registry.listNodes()[0]).toMatchObject({
+          nodeId: exchanged.node.nodeId,
+          status: 'revoked',
+          credentialState: 'revoked',
+        });
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(
+            '[hub-node-registry] hub node revoke listener failed; continuing revoke notifications for node %s'
+          ),
+          exchanged.node.nodeId
+        );
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('returns typed errors for expired tokens, bad credentials, and incompatible protocol versions', () => {

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -214,6 +214,17 @@ describe('hub node registry', () => {
         relayVersion: '9.9.9',
         protocolVersion: '1.0',
         status: 'online',
+        trust: {
+          state: 'trusted',
+          level: 'privileged-local-user',
+          warning: expect.stringContaining('local OS user'),
+        },
+        credentialState: 'active',
+        version: {
+          state: 'compatible',
+          nodeProtocolVersion: '1.0',
+          hubProtocolVersion: '1.0',
+        },
         capabilities: {
           totals: { available: 6, degraded: 1, unavailable: 2, unknown: 0 },
           agents: { claude: 'available', codex: 'unavailable' },
@@ -410,6 +421,41 @@ describe('hub node registry', () => {
     } finally {
       fs.rmSync(tmpRoot, { recursive: true, force: true });
     }
+  });
+
+  it('revokes node credentials with typed trust state and rejects later heartbeats', () => {
+    withTmpRegistry((registry) => {
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+
+      const revoked = registry.revokeNode(exchanged.node.nodeId);
+
+      expect(revoked).toMatchObject({
+        nodeId: exchanged.node.nodeId,
+        status: 'revoked',
+        credentialState: 'revoked',
+        trust: {
+          state: 'revoked',
+          level: 'privileged-local-user',
+          warning: expect.stringContaining('local OS user'),
+        },
+      });
+      expect(registry.listNodes()[0]).toMatchObject({
+        nodeId: exchanged.node.nodeId,
+        status: 'revoked',
+        credentialState: 'revoked',
+      });
+      expect(registry.authenticateCredential(exchanged.credential.token)).toBeNull();
+      expect(() =>
+        registry.recordHeartbeat({
+          nodeId: exchanged.node.nodeId,
+          protocolVersion: '1.0',
+          manifest: manifest(),
+        })
+      ).toThrow(/NODE_REVOKED/);
+    });
   });
 
   it('returns typed errors for expired tokens, bad credentials, and incompatible protocol versions', () => {

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -346,8 +346,42 @@ describe('hub node routes and link', () => {
     expect(nodesRes.status).toBe(200);
     const nodesBody = await nodesRes.text();
     expect(nodesBody).toContain('0.1.1-test');
+    expect(nodesBody).toContain('privileged-local-user');
+    expect(nodesBody).toContain('local OS user');
     expect(nodesBody).not.toContain(pair.pairToken);
     expect(nodesBody).not.toContain(exchange.credential.token);
+
+    const revokeRes = await fetch(`${base}/nodes/${exchange.node.nodeId}`, {
+      method: 'DELETE',
+      headers: { 'x-test-auth': 'yes' },
+    });
+    expect(revokeRes.status).toBe(200);
+    expect(await revokeRes.json()).toMatchObject({
+      node: {
+        nodeId: exchange.node.nodeId,
+        status: 'revoked',
+        credentialState: 'revoked',
+        trust: { state: 'revoked', level: 'privileged-local-user' },
+      },
+    });
+
+    const revokedHeartbeatRes = await fetch(`${base}/hub/node-heartbeat`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${exchange.credential.token}`,
+      },
+      body: JSON.stringify({
+        nodeId: exchange.credential.nodeId,
+        protocolVersion: '1.0',
+      }),
+    });
+    const revokedHeartbeatBody = await revokedHeartbeatRes.text();
+    expect(revokedHeartbeatRes.status).toBe(403);
+    expect(JSON.parse(revokedHeartbeatBody)).toMatchObject({
+      error: { code: 'NODE_REVOKED', retryable: false },
+    });
+    expect(revokedHeartbeatBody).not.toContain(exchange.credential.token);
   });
 
   it('accepts authenticated reverse websocket heartbeats and rejects incompatible protocol envelopes with typed errors', async () => {
@@ -471,6 +505,20 @@ describe('hub node routes and link', () => {
       type: 'control.error',
       error: { code: 'PROTOCOL_INCOMPATIBLE', retryable: false },
     });
+
+    const revokedError = new Promise<Record<string, unknown>>((resolve) => {
+      ws.once('message', (data) => resolve(JSON.parse(data.toString()) as Record<string, unknown>));
+    });
+    const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+      ws.once('close', (code, reason) => resolve({ code, reason: reason.toString() }));
+    });
+    registry.revokeNode(exchanged.node.nodeId);
+    expect(await revokedError).toMatchObject({
+      channel: 'control',
+      type: 'control.error',
+      error: { code: 'NODE_REVOKED', retryable: false },
+    });
+    expect(await closed).toEqual({ code: 4003, reason: 'node revoked' });
   });
 
   it('accepts heartbeat repo inventory and returns aggregated hub groups with local inventory', async () => {


### PR DESCRIPTION
## Summary
- Adds explicit node trust, credential, and protocol-version state fields to hub node summaries.
- Makes revoked credentials produce typed `NODE_REVOKED` heartbeat failures instead of collapsing into generic unauthorized.
- Closes already-open reverse node-link sockets on revoke with a typed control error and private close reason.
- Extends registry/routes/websocket tests for revocation, redaction, typed trust state, and live socket closure.

## Motivation
Issue #396 hardens the first federated Relay pairing slice so a paired node is clearly modeled as privileged local-user access, and revocation takes effect beyond future REST heartbeats.

## The Case Against
- This adds API fields to `HubNodeSummary`; consumers treating node summaries as exact shapes could need updates, though current frontend code does not consume these fields yet.
- Existing `/hub/node-link` websocket handshake still returns HTTP 401 for credentials that are already revoked before connection. The typed `NODE_REVOKED` error is visible for active sockets and REST heartbeat after revoke.
- Revocation closes live sockets in-process only. If multiple hub processes share the registry file later, they will need cross-process revoke broadcast.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
| --- | --- | --- |
| Token/credential leak in responses | Low | Tests assert list and revoke heartbeat bodies omit pair/credential material. |
| Live node-link survives revoke | Medium | Registry revoke listeners now send `NODE_REVOKED` and close matching sockets; regression covers it. |
| API compatibility | Low | New summary fields are additive; old fields remain unchanged. |

## Verification
- `rtk npm test -- test/hub-node-registry.test.ts test/hub-node-routes.test.ts` passes (11/11)
- `rtk npm run check` passes (0 errors; existing warnings only)
- `rtk npm run build` passes

Refs #394
Closes #396


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node revocation detection that notifies clients and closes connections on revoked credentials
  * Enriched node responses with trust, credential state, and protocol version compatibility
  * Subscription API for node-revoked listeners

* **Bug Fixes**
  * Improved credential authentication with clearer, structured failure results

* **Tests**
  * Added tests for revocation lifecycle, listener resilience, heartbeat rejection, and enhanced node metadata

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/402)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->