### PR TITLE
feat: add hub node dashboard

### DIFF
--- a/frontend/src/components/HubNodeDashboard.css
+++ b/frontend/src/components/HubNodeDashboard.css
@@ -1,0 +1,182 @@
+.hub-node-dashboard {
+  border-bottom: 1px solid var(--border);
+  padding: 8px 12px 10px;
+  font-family: var(--font-mono);
+}
+
+.hub-node-dashboard-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.hub-node-dashboard-title {
+  color: var(--text);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+}
+
+.hub-node-dashboard-summary {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  margin-top: 2px;
+  line-height: 1.35;
+}
+
+.hub-node-dashboard-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hub-node-card {
+  border: 1px solid var(--border);
+  border-radius: 0;
+  padding: 8px;
+  background: transparent;
+}
+
+.hub-node-card.status-online.attachable {
+  border-color: color-mix(in srgb, var(--status-success) 35%, var(--border));
+}
+
+.hub-node-card.status-stale,
+.hub-node-card.status-revoked {
+  border-color: color-mix(in srgb, var(--status-warning) 35%, var(--border));
+}
+
+.hub-node-card.status-offline {
+  border-color: color-mix(in srgb, var(--status-error) 35%, var(--border));
+  opacity: 0.78;
+}
+
+.hub-node-card.blocked:not(.status-offline) {
+  border-color: color-mix(in srgb, var(--status-warning) 35%, var(--border));
+}
+
+.hub-node-card-main {
+  display: grid;
+  grid-template-columns: var(--icon-slot-width) minmax(0, 1fr);
+  gap: 0;
+  align-items: start;
+}
+
+.hub-node-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-top: 5px;
+  background: var(--text-muted);
+}
+
+.hub-node-status-dot.status-online {
+  background: var(--status-success);
+}
+
+.hub-node-status-dot.status-stale,
+.hub-node-status-dot.status-revoked {
+  background: var(--status-warning);
+}
+
+.hub-node-status-dot.status-offline {
+  background: var(--status-error);
+}
+
+.hub-node-card-text {
+  min-width: 0;
+}
+
+.hub-node-card-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.hub-node-card-title {
+  color: var(--text);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hub-node-status-label {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.hub-node-card-meta {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hub-node-readiness,
+.hub-node-warning {
+  margin-top: 6px;
+  padding-left: var(--icon-slot-width);
+  font-size: var(--font-size-xs);
+  line-height: 1.35;
+}
+
+.hub-node-readiness {
+  color: var(--status-success);
+}
+
+.hub-node-card.blocked .hub-node-readiness {
+  color: var(--status-warning);
+}
+
+.hub-node-card.status-offline .hub-node-readiness {
+  color: var(--status-error);
+}
+
+.hub-node-warning {
+  color: var(--status-warning);
+}
+
+.hub-node-capabilities {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding-left: var(--icon-slot-width);
+  margin-top: 8px;
+}
+
+.hub-node-capability {
+  border: 1px solid var(--border);
+  border-radius: 0;
+  padding: 1px 4px;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  line-height: 1.35;
+  text-transform: lowercase;
+}
+
+.hub-node-capability.status-available {
+  border-color: color-mix(in srgb, var(--status-success) 45%, var(--border));
+  color: var(--status-success);
+}
+
+.hub-node-capability.status-degraded,
+.hub-node-capability.status-unknown {
+  border-color: color-mix(in srgb, var(--status-warning) 45%, var(--border));
+  color: var(--status-warning);
+}
+
+.hub-node-capability.status-unavailable {
+  border-color: color-mix(in srgb, var(--status-error) 45%, var(--border));
+  color: var(--status-error);
+  opacity: 0.85;
+}

--- a/frontend/src/components/HubNodeDashboard.tsx
+++ b/frontend/src/components/HubNodeDashboard.tsx
@@ -1,0 +1,113 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { HubNodeSummary } from '../../../shared/relay-node-protocol.js';
+import { RELAY_NODE_LINK_PROTOCOL_VERSION } from '../../../shared/relay-node-protocol.js';
+import { fetchHubNodes } from '../lib/api.js';
+import {
+  deriveHubNodeDashboardRows,
+  hubNodeDashboardSummary,
+} from '../lib/state/node-dashboard.js';
+import './HubNodeDashboard.css';
+
+export interface HubNodeDashboardProps {
+  nodes: HubNodeSummary[];
+  now?: Date;
+  expectedProtocolVersion?: string;
+}
+
+export function HubNodeDashboard({
+  nodes,
+  now,
+  expectedProtocolVersion = RELAY_NODE_LINK_PROTOCOL_VERSION,
+}: HubNodeDashboardProps) {
+  const deriveOptions = useMemo(
+    () => ({ ...(now ? { now } : {}), expectedProtocolVersion }),
+    [now, expectedProtocolVersion]
+  );
+  const rows = useMemo(
+    () => deriveHubNodeDashboardRows(nodes, deriveOptions),
+    [nodes, deriveOptions]
+  );
+  const summary = useMemo(
+    () => hubNodeDashboardSummary(nodes, deriveOptions),
+    [nodes, deriveOptions]
+  );
+
+  if (rows.length === 0) return null;
+
+  return (
+    <section className="hub-node-dashboard" aria-label="hub nodes">
+      <div className="hub-node-dashboard-header">
+        <div>
+          <div className="hub-node-dashboard-title">nodes</div>
+          <div className="hub-node-dashboard-summary">{summary}</div>
+        </div>
+      </div>
+      <div className="hub-node-dashboard-list">
+        {rows.map((row) => (
+          <article
+            key={row.nodeId}
+            className={[
+              'hub-node-card',
+              `status-${row.statusTone}`,
+              row.attachable ? 'attachable' : 'blocked',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+          >
+            <div className="hub-node-card-main">
+              <span
+                className={`hub-node-status-dot status-${row.statusTone}`}
+                aria-hidden="true"
+              />
+              <div className="hub-node-card-text">
+                <div className="hub-node-card-title-row">
+                  <span className="hub-node-card-title">{row.displayName}</span>
+                  <span className="hub-node-status-label">{row.status}</span>
+                </div>
+                <div className="hub-node-card-meta">{row.hostLabel}</div>
+                <div className="hub-node-card-meta">
+                  last seen {row.lastSeenLabel} · {row.routeLabel}
+                </div>
+              </div>
+            </div>
+
+            <div className="hub-node-readiness">
+              {row.disabledReason ?? row.workReadiness}
+            </div>
+            {row.versionWarning && (
+              <div className="hub-node-warning">{row.versionWarning}</div>
+            )}
+
+            <div className="hub-node-capabilities" aria-label={`${row.displayName} capabilities`}>
+              {row.capabilityHints.map((hint) => (
+                <span
+                  key={hint.key}
+                  className={`hub-node-capability status-${hint.status}`}
+                  title={`${hint.label}: ${hint.status}`}
+                >
+                  {hint.label}
+                </span>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function HubNodeDashboardPanel() {
+  const { data: nodes } = useQuery({
+    queryKey: ['hub-nodes'],
+    queryFn: fetchHubNodes,
+    staleTime: 15_000,
+    refetchInterval: 15_000,
+    retry: false,
+  });
+
+  if (!nodes || nodes.length === 0) return null;
+  return <HubNodeDashboard nodes={nodes} />;
+}
+
+export default HubNodeDashboard;

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import { useSessionsStore } from '../lib/stores/sessions.js';
 import type { Repo, WorktreeInfo, PullRequest } from '../lib/types.js';
 import { fetchOrgPrs } from '../lib/api.js';
 import WorkspaceGroup from './WorkspaceGroup.js';
+import { HubNodeDashboardPanel } from './HubNodeDashboard.js';
 import RepoItem from './RepoItem.js';
 import { SessionHistoryPanel } from './SessionHistoryPanel.js';
 import { TuiButton } from './TuiButton.js';
@@ -540,6 +541,7 @@ export function Sidebar({
             />
           ) : (
             <div className="sidebar-workspace-list">
+              <HubNodeDashboardPanel />
               <WorkspaceGroupsList
                 sortedGroups={sortedGroups}
                 reposByPath={reposByPath}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -30,6 +30,7 @@ import type {
   FrameworkInfo,
   BranchDivergenceSummary,
 } from './types.js';
+import type { HubNodeSummary } from '../../../shared/relay-node-protocol.js';
 import { parseGlobalSessionId } from '../../../shared/identity.js';
 
 export class ConflictError extends Error {
@@ -170,6 +171,11 @@ export async function setupPin(pin: string, confirm: string): Promise<void> {
 
 export async function fetchSessions(): Promise<SessionSummary[]> {
   return json<SessionSummary[]>(await fetch('/sessions'));
+}
+
+export async function fetchHubNodes(): Promise<HubNodeSummary[]> {
+  const data = await json<{ nodes?: HubNodeSummary[] }>(await fetch('/nodes'));
+  return Array.isArray(data.nodes) ? data.nodes : [];
 }
 
 function normalizeTelemetryMapEntry(

--- a/frontend/src/lib/state/node-dashboard.ts
+++ b/frontend/src/lib/state/node-dashboard.ts
@@ -1,0 +1,186 @@
+import {
+  RELAY_NODE_LINK_PROTOCOL_VERSION,
+  type HubNodeStatus,
+  type HubNodeSummary,
+  type NodeCapabilityStatus,
+} from '../../../../shared/relay-node-protocol.js';
+
+type CapabilityTone = NodeCapabilityStatus;
+
+export interface HubNodeCapabilityHint {
+  key: string;
+  label: string;
+  status: CapabilityTone;
+}
+
+export interface HubNodeDashboardRow {
+  nodeId: string;
+  displayName: string;
+  hostname: string;
+  hostLabel: string;
+  status: HubNodeStatus;
+  statusTone: 'online' | 'stale' | 'offline' | 'revoked';
+  routeLabel: string;
+  lastSeenLabel: string;
+  relayVersion: string;
+  protocolVersion: string;
+  versionWarning: string | null;
+  capabilityHints: HubNodeCapabilityHint[];
+  attachable: boolean;
+  workReadiness: string;
+  disabledReason: string | null;
+}
+
+interface DeriveOptions {
+  now?: Date;
+  expectedProtocolVersion?: string;
+}
+
+const readinessCapabilities = ['shell', 'tmux', 'git', 'worktrees'] as const;
+
+function formatRelativeTime(iso: string, now: Date): string {
+  const timestamp = Date.parse(iso);
+  if (!Number.isFinite(timestamp)) return 'unknown';
+  const seconds = Math.max(0, Math.floor((now.getTime() - timestamp) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function fallbackStatus(status: NodeCapabilityStatus | undefined): NodeCapabilityStatus {
+  return status ?? 'unknown';
+}
+
+function aggregateAgentStatus(agents: Record<string, NodeCapabilityStatus>): NodeCapabilityStatus {
+  const statuses = Object.values(agents);
+  if (statuses.length === 0) return 'unknown';
+  if (statuses.includes('available')) return 'available';
+  if (statuses.includes('degraded')) return 'degraded';
+  if (statuses.includes('unknown')) return 'unknown';
+  return 'unavailable';
+}
+
+function serviceManagerStatus(kind: string): NodeCapabilityStatus {
+  if (kind === 'unsupported') return 'unavailable';
+  if (kind === 'manual' || kind === 'wsl-manual') return 'degraded';
+  return kind ? 'available' : 'unknown';
+}
+
+function blockerLabel(label: string, status: NodeCapabilityStatus): string | null {
+  if (status === 'available') return null;
+  return `${label} ${status}`;
+}
+
+function disabledReason(
+  node: HubNodeSummary,
+  capabilityHints: HubNodeCapabilityHint[]
+): string | null {
+  if (node.status === 'revoked') return 'not attachable: node was revoked';
+  if (node.status === 'offline') return 'not attachable: node is offline';
+  if (node.status === 'stale') return 'not attachable: heartbeat is stale';
+
+  const blockers = readinessCapabilities.flatMap((key) => {
+    const hint = capabilityHints.find((candidate) => candidate.key === key);
+    const label = hint?.label ?? key;
+    const status = hint?.status ?? 'unknown';
+    const blocker = blockerLabel(label, status);
+    return blocker ? [blocker] : [];
+  });
+
+  const agentHint = capabilityHints.find((candidate) => candidate.key === 'agents');
+  if (agentHint && agentHint.status !== 'available') {
+    const blocker = blockerLabel(agentHint.label, agentHint.status);
+    if (blocker) blockers.push(blocker);
+  }
+
+  if (blockers.length > 0) return `work disabled: ${blockers.join('; ')}`;
+  return null;
+}
+
+function capabilityHints(node: HubNodeSummary): HubNodeCapabilityHint[] {
+  const core = node.capabilities.core;
+  const agents = aggregateAgentStatus(node.capabilities.agents ?? {});
+  return [
+    { key: 'shell', label: 'shell', status: fallbackStatus(core?.shell) },
+    { key: 'tmux', label: 'tmux', status: fallbackStatus(core?.tmux) },
+    { key: 'git', label: 'git', status: fallbackStatus(core?.git) },
+    { key: 'worktrees', label: 'worktrees', status: fallbackStatus(core?.worktrees) },
+    { key: 'agents', label: 'agents', status: agents },
+    {
+      key: 'browserAutomation',
+      label: 'browser',
+      status: fallbackStatus(core?.browserAutomation),
+    },
+    {
+      key: 'clipboardImage',
+      label: 'clipboard',
+      status: fallbackStatus(core?.clipboardImage),
+    },
+    { key: 'ssh', label: 'ssh', status: fallbackStatus(core?.ssh) },
+    { key: 'tailscale', label: 'tailscale', status: fallbackStatus(core?.tailscale) },
+    {
+      key: 'serviceManager',
+      label: 'service',
+      status: serviceManagerStatus(node.capabilities.serviceManager),
+    },
+  ];
+}
+
+export function deriveHubNodeDashboardRows(
+  nodes: HubNodeSummary[],
+  options: DeriveOptions = {}
+): HubNodeDashboardRow[] {
+  const now = options.now ?? new Date();
+  const expectedProtocolVersion =
+    options.expectedProtocolVersion ?? RELAY_NODE_LINK_PROTOCOL_VERSION;
+
+  return nodes.map((node) => {
+    const hints = capabilityHints(node);
+    const reason = disabledReason(node, hints);
+    const route = node.connection?.route ?? 'unknown';
+    const routeStatus = node.connection?.status ?? node.status;
+    const versionWarning =
+      node.protocolVersion === expectedProtocolVersion
+        ? null
+        : `protocol ${node.protocolVersion} != hub ${expectedProtocolVersion}`;
+
+    return {
+      nodeId: node.nodeId,
+      displayName: node.displayName,
+      hostname: node.hostname,
+      hostLabel: `${node.hostname} · ${node.platform}/${node.arch}`,
+      status: node.status,
+      statusTone: node.status,
+      routeLabel: `${route} · ${routeStatus}`,
+      lastSeenLabel: formatRelativeTime(node.lastSeenAt, now),
+      relayVersion: node.relayVersion,
+      protocolVersion: node.protocolVersion,
+      versionWarning,
+      capabilityHints: hints,
+      attachable: reason === null,
+      workReadiness: reason === null ? 'ready to work' : 'blocked',
+      disabledReason: reason,
+    };
+  });
+}
+
+export function hubNodeDashboardSummary(
+  nodes: HubNodeSummary[],
+  options: DeriveOptions = {}
+): string {
+  const rows = deriveHubNodeDashboardRows(nodes, options);
+  const ready = rows.filter((row) => row.attachable).length;
+  const offlineOrStale = rows.filter(
+    (row) => row.status === 'offline' || row.status === 'stale' || row.status === 'revoked'
+  ).length;
+  const blockedByCapabilities = rows.filter(
+    (row) =>
+      !row.attachable &&
+      row.disabledReason?.startsWith('work disabled:')
+  ).length;
+
+  return `${ready}/${rows.length} nodes ready · ${blockedByCapabilities} blocked by capabilities · ${offlineOrStale} offline/stale`;
+}

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -9,12 +9,15 @@ import {
   type HubNodeStatus,
   type HubNodeSummary,
   type NodeCapabilityManifestSummary,
+  type NodeCapabilityStatus,
   type RelayNodeCredential,
   type RelayNodeError,
   type RelayNodeErrorCode,
 } from '../shared/relay-node-protocol.js';
 
 const logger = createLogger('hub-node-registry');
+const REVERSE_LINK_ROUTE = 'reverse-link' as const;
+const UNKNOWN_CAPABILITY_STATUS = 'unknown' as const;
 
 interface StoredPairToken {
   tokenId: string;
@@ -147,10 +150,25 @@ function summarizeCapabilities(manifest: NodeManifest): NodeCapabilityManifestSu
 
   return {
     totals,
+    core: {
+      shell: 'available',
+      tmux: manifest.capabilities.tmux.status,
+      git: manifest.capabilities.git.status,
+      worktrees: worktreeCapabilityStatus(manifest.capabilities.git.status),
+      browserAutomation: manifest.capabilities.browserAutomation.status,
+      clipboardImage: manifest.capabilities.clipboard.status,
+      ssh: manifest.capabilities.ssh.status,
+      tailscale: manifest.capabilities.tailscale.status,
+    },
     agents,
     serviceManager: manifest.serviceManager.kind,
     wsl: manifest.wsl.detected,
   };
+}
+
+function worktreeCapabilityStatus(gitStatus: NodeCapabilityStatus): NodeCapabilityStatus {
+  if (gitStatus === 'available') return 'available';
+  return gitStatus;
 }
 
 function nodeDisplayName(displayName: string | undefined, manifest: NodeManifest): string {
@@ -220,6 +238,25 @@ function statusForNode(
   return 'online';
 }
 
+function normalizeCapabilitySummary(
+  capabilities: NodeCapabilityManifestSummary
+): NodeCapabilityManifestSummary {
+  if (capabilities.core) return capabilities;
+  return {
+    ...capabilities,
+    core: {
+      shell: UNKNOWN_CAPABILITY_STATUS,
+      tmux: UNKNOWN_CAPABILITY_STATUS,
+      git: UNKNOWN_CAPABILITY_STATUS,
+      worktrees: UNKNOWN_CAPABILITY_STATUS,
+      browserAutomation: UNKNOWN_CAPABILITY_STATUS,
+      clipboardImage: UNKNOWN_CAPABILITY_STATUS,
+      ssh: UNKNOWN_CAPABILITY_STATUS,
+      tailscale: UNKNOWN_CAPABILITY_STATUS,
+    },
+  };
+}
+
 function publicNode(
   node: StoredNodeRecord,
   status: HubNodeStatus
@@ -233,12 +270,20 @@ function publicNode(
     relayVersion: node.relayVersion,
     protocolVersion: node.protocolVersion,
     status,
-    capabilities: node.capabilities,
+    connection: connectionSummary(status),
+    capabilities: normalizeCapabilitySummary(node.capabilities),
     createdAt: node.createdAt,
     pairedAt: node.pairedAt,
     lastSeenAt: node.lastSeenAt,
     credentialId: node.credentialId,
   };
+}
+
+function connectionSummary(status: HubNodeStatus): HubNodeSummary['connection'] {
+  if (status === 'online') return { route: REVERSE_LINK_ROUTE, status: 'connected' };
+  if (status === 'stale') return { route: REVERSE_LINK_ROUTE, status: 'stale heartbeat' };
+  if (status === 'offline') return { route: REVERSE_LINK_ROUTE, status: 'offline' };
+  return { route: REVERSE_LINK_ROUTE, status: 'revoked' };
 }
 
 export class HubNodeRegistry {

--- a/shared/relay-node-protocol.ts
+++ b/shared/relay-node-protocol.ts
@@ -51,6 +51,27 @@ export interface RelayNodeCredential {
 
 export type HubNodeStatus = 'online' | 'stale' | 'offline' | 'revoked';
 
+export type NodeCapabilityStatus =
+  | 'available'
+  | 'degraded'
+  | 'unavailable'
+  | 'unknown';
+
+export type HubNodeCoreCapability =
+  | 'shell'
+  | 'tmux'
+  | 'git'
+  | 'worktrees'
+  | 'browserAutomation'
+  | 'clipboardImage'
+  | 'ssh'
+  | 'tailscale';
+
+export interface HubNodeConnectionSummary {
+  route: 'reverse-link' | 'local' | 'unknown';
+  status: string;
+}
+
 export interface NodeCapabilityManifestSummary {
   totals: {
     available: number;
@@ -58,7 +79,8 @@ export interface NodeCapabilityManifestSummary {
     unavailable: number;
     unknown: number;
   };
-  agents: Record<string, 'available' | 'degraded' | 'unavailable' | 'unknown'>;
+  core: Record<HubNodeCoreCapability, NodeCapabilityStatus>;
+  agents: Record<string, NodeCapabilityStatus>;
   serviceManager: string;
   wsl: boolean;
 }
@@ -72,6 +94,7 @@ export interface HubNodeSummary {
   relayVersion: string;
   protocolVersion: string;
   status: HubNodeStatus;
+  connection: HubNodeConnectionSummary;
   capabilities: NodeCapabilityManifestSummary;
   createdAt: string;
   pairedAt: string;

--- a/test/components/HubNodeDashboard.test.ts
+++ b/test/components/HubNodeDashboard.test.ts
@@ -1,0 +1,103 @@
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import type { HubNodeSummary } from '../../shared/relay-node-protocol.js';
+import { HubNodeDashboard } from '../../frontend/src/components/HubNodeDashboard.js';
+
+const now = new Date('2026-01-02T03:05:00.000Z');
+
+function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
+  return {
+    nodeId: 'node-1',
+    displayName: 'dev mac',
+    hostname: 'dev-mac.local',
+    platform: 'darwin',
+    arch: 'arm64',
+    relayVersion: '9.9.9',
+    protocolVersion: '1.0',
+    status: 'online',
+    connection: { route: 'reverse-link', status: 'connected' },
+    capabilities: {
+      totals: { available: 11, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        tmux: 'available',
+        git: 'available',
+        worktrees: 'available',
+        browserAutomation: 'available',
+        clipboardImage: 'available',
+        ssh: 'available',
+        tailscale: 'available',
+      },
+      agents: { claude: 'available', codex: 'available' },
+      serviceManager: 'launchd',
+      wsl: false,
+    },
+    createdAt: '2026-01-02T03:00:00.000Z',
+    pairedAt: '2026-01-02T03:00:00.000Z',
+    lastSeenAt: '2026-01-02T03:04:30.000Z',
+    credentialId: 'cred-1',
+    ...overrides,
+  };
+}
+
+describe('HubNodeDashboard', () => {
+  it('renders nothing in boring local mode when the hub has no nodes', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(HubNodeDashboard, { nodes: [], now })
+    );
+
+    expect(html).toBe('');
+  });
+
+  it('shows online, stale/offline, degraded capability, and version warning states', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(HubNodeDashboard, {
+        now,
+        expectedProtocolVersion: '1.0',
+        nodes: [
+          node({ displayName: 'ready mac' }),
+          node({ nodeId: 'stale', displayName: 'stale linux', status: 'stale' }),
+          node({ nodeId: 'offline', displayName: 'offline lab', status: 'offline' }),
+          node({
+            nodeId: 'degraded',
+            displayName: 'thin client',
+            protocolVersion: '2.0',
+            capabilities: {
+              ...node().capabilities,
+              totals: { available: 8, degraded: 1, unavailable: 2, unknown: 0 },
+              core: {
+                ...node().capabilities.core,
+                tmux: 'degraded',
+                git: 'unavailable',
+                worktrees: 'unavailable',
+              },
+            },
+          }),
+        ],
+      })
+    );
+
+    expect(html).toContain('nodes');
+    expect(html).toContain('1/4 nodes ready');
+    expect(html).toContain('ready mac');
+    expect(html).toContain('ready to work');
+    expect(html).toContain('stale linux');
+    expect(html).toContain('not attachable: heartbeat is stale');
+    expect(html).toContain('offline lab');
+    expect(html).toContain('not attachable: node is offline');
+    expect(html).toContain('thin client');
+    expect(html).toContain('work disabled: tmux degraded; git unavailable; worktrees unavailable');
+    expect(html).toContain('protocol 2.0 != hub 1.0');
+    expect(html).toContain('shell');
+    expect(html).toContain('tmux');
+    expect(html).toContain('git');
+    expect(html).toContain('worktrees');
+    expect(html).toContain('agents');
+    expect(html).toContain('browser');
+    expect(html).toContain('clipboard');
+    expect(html).toContain('ssh');
+    expect(html).toContain('tailscale');
+    expect(html).toContain('service');
+  });
+});

--- a/test/stores/node-dashboard.test.ts
+++ b/test/stores/node-dashboard.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import type { HubNodeSummary } from '../../shared/relay-node-protocol.js';
+import {
+  deriveHubNodeDashboardRows,
+  hubNodeDashboardSummary,
+} from '../../frontend/src/lib/state/node-dashboard.js';
+
+const now = new Date('2026-01-02T03:05:00.000Z');
+
+function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
+  return {
+    nodeId: 'node-1',
+    displayName: 'dev mac',
+    hostname: 'dev-mac.local',
+    platform: 'darwin',
+    arch: 'arm64',
+    relayVersion: '9.9.9',
+    protocolVersion: '1.0',
+    status: 'online',
+    connection: { route: 'reverse-link', status: 'connected' },
+    capabilities: {
+      totals: { available: 11, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        tmux: 'available',
+        git: 'available',
+        worktrees: 'available',
+        browserAutomation: 'available',
+        clipboardImage: 'available',
+        ssh: 'available',
+        tailscale: 'available',
+      },
+      agents: { claude: 'available', codex: 'available' },
+      serviceManager: 'launchd',
+      wsl: false,
+    },
+    createdAt: '2026-01-02T03:00:00.000Z',
+    pairedAt: '2026-01-02T03:00:00.000Z',
+    lastSeenAt: '2026-01-02T03:04:30.000Z',
+    credentialId: 'cred-1',
+    ...overrides,
+  };
+}
+
+describe('hub node dashboard state', () => {
+  it('marks online nodes with shell, tmux, git, and agent CLIs as ready to work', () => {
+    const [row] = deriveHubNodeDashboardRows([node()], { now });
+
+    expect(row).toMatchObject({
+      nodeId: 'node-1',
+      status: 'online',
+      statusTone: 'online',
+      attachable: true,
+      workReadiness: 'ready to work',
+      disabledReason: null,
+      routeLabel: 'reverse-link · connected',
+      lastSeenLabel: '30s ago',
+      versionWarning: null,
+    });
+    expect(row.capabilityHints.map((hint) => `${hint.label}:${hint.status}`)).toEqual([
+      'shell:available',
+      'tmux:available',
+      'git:available',
+      'worktrees:available',
+      'agents:available',
+      'browser:available',
+      'clipboard:available',
+      'ssh:available',
+      'tailscale:available',
+      'service:available',
+    ]);
+  });
+
+  it('keeps stale and offline nodes visible but not attachable', () => {
+    const rows = deriveHubNodeDashboardRows(
+      [
+        node({ nodeId: 'node-stale', displayName: 'stale box', status: 'stale' }),
+        node({ nodeId: 'node-offline', displayName: 'offline box', status: 'offline' }),
+      ],
+      { now }
+    );
+
+    expect(rows.map((row) => [row.displayName, row.attachable, row.disabledReason])).toEqual([
+      ['stale box', false, 'not attachable: heartbeat is stale'],
+      ['offline box', false, 'not attachable: node is offline'],
+    ]);
+  });
+
+  it('annotates degraded capabilities that block work actions', () => {
+    const [row] = deriveHubNodeDashboardRows(
+      [
+        node({
+          capabilities: {
+            ...node().capabilities,
+            totals: { available: 8, degraded: 1, unavailable: 2, unknown: 0 },
+            core: {
+              ...node().capabilities.core,
+              tmux: 'degraded',
+              git: 'unavailable',
+              worktrees: 'unavailable',
+            },
+          },
+        }),
+      ],
+      { now }
+    );
+
+    expect(row.attachable).toBe(false);
+    expect(row.disabledReason).toBe('work disabled: tmux degraded; git unavailable; worktrees unavailable');
+    expect(row.capabilityHints).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: 'tmux', status: 'degraded' }),
+        expect.objectContaining({ label: 'git', status: 'unavailable' }),
+        expect.objectContaining({ label: 'worktrees', status: 'unavailable' }),
+      ])
+    );
+  });
+
+  it('surfaces protocol version warnings separately from availability', () => {
+    const [row] = deriveHubNodeDashboardRows(
+      [node({ protocolVersion: '1.1', relayVersion: '9.9.0' })],
+      { now, expectedProtocolVersion: '1.0' }
+    );
+
+    expect(row.attachable).toBe(true);
+    expect(row.versionWarning).toBe('protocol 1.1 != hub 1.0');
+  });
+
+  it('summarizes which machines can currently do work', () => {
+    const summary = hubNodeDashboardSummary(
+      [
+        node({ nodeId: 'ready' }),
+        node({ nodeId: 'offline', status: 'offline' }),
+        node({
+          nodeId: 'degraded',
+          capabilities: {
+            ...node().capabilities,
+            core: { ...node().capabilities.core, git: 'unavailable' },
+          },
+        }),
+      ],
+      { now }
+    );
+
+    expect(summary).toBe('1/3 nodes ready · 1 blocked by capabilities · 1 offline/stale');
+  });
+});


### PR DESCRIPTION
## Summary
- adds a sidebar hub node dashboard backed by `/nodes`
- exposes node connection state, last-seen labels, protocol warnings, and work-readiness/capability chips
- extends hub node summaries with connection/core capability data and normalizes older registry records
- adds pure state derivation tests plus SSR component coverage

Refs #317.
Closes #386.

## Verification
- `nvm use` attempted; local nvm does not have `v24`, but system Node is `v24.13.1`
- `rtk npm run check` passed with 0 errors and existing warnings
- `rtk npm test -- test/hub-node-registry.test.ts test/hub-node-routes.test.ts test/components/Tooltip.test.ts test/stores/ui-store.test.ts test/sidebar-fleet-status.test.ts test/stores/node-dashboard.test.ts test/components/HubNodeDashboard.test.ts` passed, 64/64 tests
- `rtk npm run build` passed; Vite emitted the existing >500 kB chunk warning

## Risk notes
- persisted node registry records created before this change are backfilled with `unknown` core capability statuses at serialization time
- protocol version mismatch is surfaced as a warning, not as an attachability blocker
- dashboard stays hidden when `/nodes` returns no nodes, preserving the local/single-node fast path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Hub Node Dashboard displaying connected hub nodes with real-time status indicators (online, stale, offline), capability availability, last-seen timestamps, and protocol version compatibility alerts in the sidebar.

* **Tests**
  * Added comprehensive test coverage for Hub Node Dashboard components and state logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/403)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->