### PR TITLE
Add aggregated repo inventory

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -29,6 +29,7 @@ import type {
   AnalyticsRateLimitHistory,
   FrameworkInfo,
   BranchDivergenceSummary,
+  AggregatedRepoInventoryResponse,
 } from './types.js';
 import type { HubNodeSummary } from '../../../shared/relay-node-protocol.js';
 import { parseGlobalSessionId } from '../../../shared/identity.js';
@@ -306,6 +307,10 @@ export async function fetchWorktrees(): Promise<WorktreeInfo[]> {
 export async function fetchWorkspaces(): Promise<Repo[]> {
   const data = await json<{ workspaces: Repo[] }>(await fetch('/workspaces'));
   return data.workspaces;
+}
+
+export async function fetchRepoInventory(): Promise<AggregatedRepoInventoryResponse> {
+  return json<AggregatedRepoInventoryResponse>(await fetch('/hub/repo-inventory'));
 }
 
 export async function addWorkspace(path: string): Promise<void> {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -13,6 +13,13 @@ import type {
   DisplayState,
   BackendDisplayState,
 } from './state/display-state.js';
+export type {
+  AggregatedRepoInventoryGroup,
+  AggregatedRepoInventoryResponse,
+  RepoInventoryReport,
+  RepoInventoryRepoInstance,
+  RepoInventoryWorktreeInstance,
+} from '../../../shared/repo-inventory.js';
 
 export type PrDotStatus =
   | 'draft'

--- a/server/hub-node-link.ts
+++ b/server/hub-node-link.ts
@@ -3,6 +3,7 @@ import { WebSocket } from 'ws';
 import type { RawData } from 'ws';
 import type { HubNodeRegistry } from './hub-node-registry.js';
 import { isNodeManifest, type NodeManifest } from '../shared/node-manifest.js';
+import { isRepoInventoryReport, type RepoInventoryReport } from '../shared/repo-inventory.js';
 import {
   RELAY_NODE_LINK_PROTOCOL,
   RELAY_NODE_LINK_PROTOCOL_VERSION,
@@ -85,6 +86,14 @@ function manifestFromPayload(payload: unknown): NodeManifest | RelayNodeError | 
   return manifest;
 }
 
+function repoInventoryFromPayload(payload: unknown): RepoInventoryReport | RelayNodeError | undefined {
+  if (typeof payload !== 'object' || payload === null) return undefined;
+  const repoInventory = (payload as Record<string, unknown>)['repoInventory'];
+  if (repoInventory === undefined || repoInventory === null) return undefined;
+  if (!isRepoInventoryReport(repoInventory)) return invalidRequest('repoInventory is malformed');
+  return repoInventory;
+}
+
 function sendJson(ws: WebSocket, payload: RelayNodeEnvelope): void {
   if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(payload));
 }
@@ -133,10 +142,18 @@ export function handleHubNodeLink(
         sendJson(ws, errorEnvelope(authenticatedNodeId, parsed, manifestResult));
         return;
       }
+      const manifest = manifestResult as NodeManifest | undefined;
+      const repoInventoryResult = repoInventoryFromPayload(parsed.payload);
+      if (repoInventoryResult && 'code' in repoInventoryResult) {
+        sendJson(ws, errorEnvelope(authenticatedNodeId, parsed, repoInventoryResult));
+        return;
+      }
+      const repoInventory = repoInventoryResult as RepoInventoryReport | undefined;
       const node = registry.recordHeartbeat({
         nodeId: authenticatedNodeId,
         protocolVersion: parsed.protocolVersion,
-        ...(manifestResult ? { manifest: manifestResult } : {}),
+        ...(manifest ? { manifest } : {}),
+        ...(repoInventory ? { repoInventory } : {}),
       });
       sendJson(ws, {
         protocol: RELAY_NODE_LINK_PROTOCOL,

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -425,6 +425,12 @@ export class HubNodeRegistry {
       node.capabilities = summarizeCapabilities(input.manifest);
     }
     if (input.repoInventory) {
+      if (input.repoInventory.nodeId !== input.nodeId) {
+        throw new HubNodeRegistryError(
+          'INVALID_REQUEST',
+          'repoInventory.nodeId must match authenticated nodeId'
+        );
+      }
       node.repoInventory = input.repoInventory;
     }
     this.scheduleHeartbeatPersist();

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -2,6 +2,7 @@ import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { NodeCapabilityProbe, NodeManifest } from '../shared/node-manifest.js';
+import type { RepoInventoryReport } from '../shared/repo-inventory.js';
 import { createLogger } from './logger.js';
 import {
   RELAY_NODE_LINK_PROTOCOL,
@@ -39,6 +40,7 @@ interface StoredNodeRecord {
   relayVersion: string;
   protocolVersion: string;
   capabilities: NodeCapabilityManifestSummary;
+  repoInventory?: RepoInventoryReport;
   createdAt: string;
   pairedAt: string;
   lastSeenAt: string;
@@ -68,6 +70,7 @@ export interface HeartbeatInput {
   nodeId: string;
   protocolVersion: string;
   manifest?: NodeManifest;
+  repoInventory?: RepoInventoryReport;
 }
 
 export interface HubNodeRegistryOptions {
@@ -421,6 +424,9 @@ export class HubNodeRegistry {
       node.relayVersion = input.manifest.relayVersion;
       node.capabilities = summarizeCapabilities(input.manifest);
     }
+    if (input.repoInventory) {
+      node.repoInventory = input.repoInventory;
+    }
     this.scheduleHeartbeatPersist();
     return publicNode(node, 'online');
   }
@@ -444,6 +450,13 @@ export class HubNodeRegistry {
     return this.state.nodes.map((node) =>
       publicNode(node, statusForNode(node, now, this.staleMs, this.offlineMs))
     );
+  }
+
+  listRepoInventoryReports(options: { includeRevoked?: boolean } = {}): RepoInventoryReport[] {
+    return this.state.nodes
+      .filter((node) => options.includeRevoked || !node.revokedAt)
+      .map((node) => node.repoInventory)
+      .filter((report): report is RepoInventoryReport => Boolean(report));
   }
 
   revokeNode(nodeId: string): HubNodeSummary {

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -1,12 +1,18 @@
 import * as express from 'express';
 import type { Request, Response } from 'express';
 import { isNodeManifest, type NodeManifest } from '../shared/node-manifest.js';
+import {
+  aggregateRepoInventoryReports,
+  isRepoInventoryReport,
+  type RepoInventoryReport,
+} from '../shared/repo-inventory.js';
 import { HubNodeRegistryError, type HubNodeRegistry } from './hub-node-registry.js';
 import type { RelayNodeError } from '../shared/relay-node-protocol.js';
 
 interface HubNodeRouterOptions {
   registry: HubNodeRegistry;
   requireAuth: express.RequestHandler;
+  collectLocalRepoInventory?: () => Promise<RepoInventoryReport>;
 }
 
 function bearerToken(req: Request): string | null {
@@ -62,6 +68,15 @@ function manifestFromBody(body: Record<string, unknown>, required = false): Node
     throw new HubNodeRegistryError('INVALID_REQUEST', 'manifest is malformed');
   }
   return manifest;
+}
+
+function repoInventoryFromBody(body: Record<string, unknown>): RepoInventoryReport | null {
+  const repoInventory = body['repoInventory'];
+  if (repoInventory === undefined || repoInventory === null) return null;
+  if (!isRepoInventoryReport(repoInventory)) {
+    throw new HubNodeRegistryError('INVALID_REQUEST', 'repoInventory is malformed');
+  }
+  return repoInventory;
 }
 
 function pairTtlMs(body: Record<string, unknown>): number | undefined {
@@ -148,11 +163,13 @@ export function createHubNodeRouter(options: HubNodeRouterOptions): express.Rout
     }
     try {
       const manifest = manifestFromBody(body);
+      const repoInventory = repoInventoryFromBody(body);
       res.json({
         node: registry.recordHeartbeat({
           nodeId: authenticated.nodeId,
           protocolVersion,
           ...(manifest ? { manifest } : {}),
+          ...(repoInventory ? { repoInventory } : {}),
         }),
       });
     } catch (error) {
@@ -162,6 +179,18 @@ export function createHubNodeRouter(options: HubNodeRouterOptions): express.Rout
 
   router.get('/nodes', requireAuth, (_req, res) => {
     res.json({ nodes: registry.listNodes() });
+  });
+
+  router.get('/hub/repo-inventory', requireAuth, async (_req, res) => {
+    try {
+      const reports = [...registry.listRepoInventoryReports()];
+      if (options.collectLocalRepoInventory) {
+        reports.push(await options.collectLocalRepoInventory());
+      }
+      res.json(aggregateRepoInventoryReports(reports));
+    } catch (error) {
+      sendRegistryError(registry, res, error);
+    }
   });
 
   router.delete('/nodes/:nodeId', requireAuth, (req, res) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -103,6 +103,7 @@ import {
 import { getNodeManifest } from './node-manifest.js';
 import { createHubNodeRegistry } from './hub-node-registry.js';
 import { createHubNodeRouter } from './hub-node-router.js';
+import { collectLocalRepoInventory } from './repo-inventory.js';
 import type {
   AgentType,
   AutomationSettings,
@@ -1069,7 +1070,14 @@ async function main(): Promise<void> {
     next();
   };
 
-  app.use(createHubNodeRouter({ registry: hubNodeRegistry, requireAuth }));
+  app.use(
+    createHubNodeRouter({
+      registry: hubNodeRegistry,
+      requireAuth,
+      collectLocalRepoInventory: () =>
+        collectLocalRepoInventory({ config: getConfig(), configPath: CONFIG_PATH }),
+    })
+  );
 
   const webhookManagerRouter = createWebhookManagerRouter({
     configPath: CONFIG_PATH,

--- a/server/repo-inventory.ts
+++ b/server/repo-inventory.ts
@@ -1,0 +1,273 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import type { Config } from './types.js';
+import { readMeta } from './config.js';
+import { scanWorktrees } from './git-routes.js';
+import { detectGitRepo, resolveRepoIdentityFields, repoNameFromRemoteUrl } from './workspaces.js';
+import { extractOwnerRepo } from './git.js';
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  createRepoInstanceId,
+  createWorktreeInstanceId,
+  type NodeId,
+} from '../shared/identity.js';
+import type {
+  RepoInventoryDirtyFile,
+  RepoInventoryDirtySummary,
+  RepoInventoryDivergenceSummary,
+  RepoInventoryReport,
+  RepoInventoryRepoInstance,
+  RepoInventoryWorktreeInstance,
+} from '../shared/repo-inventory.js';
+
+const execFileAsync = promisify(execFile);
+const DIRTY_FILES_LIMIT = 25;
+
+type ExecFileAsyncLike = (
+  file: string,
+  args: string[],
+  options: { cwd: string; timeout?: number }
+) => Promise<{ stdout: string; stderr: string }>;
+
+export interface CollectLocalRepoInventoryDeps {
+  config: Config;
+  configPath: string;
+  nodeId?: NodeId;
+  now?: () => Date;
+  execFileAsync?: ExecFileAsyncLike;
+  readdirSync?: (dir: string) => Array<{ name: string; isDirectory: () => boolean }>;
+  statSync?: (path: string) => { isDirectory: () => boolean };
+}
+
+type CollectedRepoIdentityFields = Pick<
+  RepoInventoryRepoInstance,
+  'repoIdentity' | 'selectedRemote' | 'remotes' | 'repoIdentityWarnings'
+>;
+
+function dirtyFileStatus(code: string): RepoInventoryDirtyFile['status'] {
+  if (code === '??') return 'untracked';
+  if (code === 'DD' || code === 'AA' || code === 'UU' || code.includes('U')) return 'conflicted';
+  if (code.includes('R')) return 'renamed';
+  if (code.includes('D')) return 'deleted';
+  if (code.includes('A')) return 'added';
+  if (code.includes('M')) return 'modified';
+  return 'unknown';
+}
+
+function parseDirtyStatus(stdout: string): RepoInventoryDirtySummary {
+  const dirty: RepoInventoryDirtySummary = {
+    stagedCount: 0,
+    unstagedCount: 0,
+    untrackedCount: 0,
+    conflictedCount: 0,
+    files: [],
+    truncated: false,
+  };
+
+  for (const line of stdout.split('\n')) {
+    if (!line) continue;
+    const code = line.slice(0, 2);
+    const rawPath = line.slice(3).trim();
+    const x = code[0] ?? ' ';
+    const y = code[1] ?? ' ';
+    if (code === '??') dirty.untrackedCount += 1;
+    if (dirtyFileStatus(code) === 'conflicted') dirty.conflictedCount += 1;
+    if (x !== ' ' && x !== '?') dirty.stagedCount += 1;
+    if (y !== ' ' && y !== '?') dirty.unstagedCount += 1;
+
+    if (dirty.files.length < DIRTY_FILES_LIMIT) {
+      dirty.files.push({ path: rawPath, status: dirtyFileStatus(code) });
+    } else {
+      dirty.truncated = true;
+    }
+  }
+
+  return dirty;
+}
+
+async function getDirtySummary(
+  repoPath: string,
+  execAsync: ExecFileAsyncLike
+): Promise<RepoInventoryDirtySummary | null> {
+  try {
+    const { stdout } = await execAsync('git', ['status', '--porcelain'], {
+      cwd: repoPath,
+      timeout: 5000,
+    });
+    return parseDirtyStatus(stdout);
+  } catch {
+    return null;
+  }
+}
+
+async function getDivergenceSummary(
+  repoPath: string,
+  execAsync: ExecFileAsyncLike,
+  now: Date
+): Promise<RepoInventoryDivergenceSummary | null> {
+  try {
+    const [{ stdout: upstreamStdout }, { stdout: headStdout }] = await Promise.all([
+      execAsync('git', ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}'], {
+        cwd: repoPath,
+        timeout: 5000,
+      }),
+      execAsync('git', ['rev-parse', 'HEAD'], { cwd: repoPath, timeout: 5000 }),
+    ]);
+    const upstreamRef = upstreamStdout.trim() || null;
+    if (!upstreamRef) return null;
+    const { stdout: countsStdout } = await execAsync(
+      'git',
+      ['rev-list', '--left-right', '--count', `${upstreamRef}...HEAD`],
+      { cwd: repoPath, timeout: 5000 }
+    );
+    const [behindRaw, aheadRaw] = countsStdout.trim().split(/\s+/);
+    const behindCount = Number.parseInt(behindRaw ?? '0', 10);
+    const aheadCount = Number.parseInt(aheadRaw ?? '0', 10);
+    return {
+      upstreamRef,
+      behindCount: Number.isFinite(behindCount) ? behindCount : 0,
+      aheadCount: Number.isFinite(aheadCount) ? aheadCount : 0,
+      headSha: headStdout.trim() || null,
+      generatedAt: now.toISOString(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function currentBranchFor(
+  repoPath: string,
+  execAsync: ExecFileAsyncLike
+): Promise<string | null> {
+  try {
+    const { stdout } = await execAsync('git', ['symbolic-ref', '--short', 'HEAD'], {
+      cwd: repoPath,
+      timeout: 5000,
+    });
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function nameFromOrigin(
+  repoPath: string,
+  fallback: string,
+  execAsync: ExecFileAsyncLike
+): Promise<{ name: string; ownerRepo?: string }> {
+  try {
+    const { stdout } = await execAsync('git', ['remote', 'get-url', 'origin'], {
+      cwd: repoPath,
+      timeout: 5000,
+    });
+    const url = stdout.trim();
+    const remoteName = url ? repoNameFromRemoteUrl(url) : undefined;
+    const ownerRepo = url ? (extractOwnerRepo(url) ?? undefined) : undefined;
+    return {
+      name: remoteName ?? fallback,
+      ...(ownerRepo ? { ownerRepo } : {}),
+    };
+  } catch {
+    return { name: fallback };
+  }
+}
+
+async function worktreeInstanceFor(
+  worktree: {
+    path: string;
+    branchName: string;
+    displayName: string;
+    lastActivity: string;
+  },
+  nodeId: NodeId,
+  execAsync: ExecFileAsyncLike,
+  now: Date
+): Promise<RepoInventoryWorktreeInstance> {
+  const [dirty, divergence] = await Promise.all([
+    getDirtySummary(worktree.path, execAsync),
+    getDivergenceSummary(worktree.path, execAsync, now),
+  ]);
+  return {
+    worktreeInstanceId: createWorktreeInstanceId(nodeId, worktree.path),
+    localPath: worktree.path,
+    branchName: worktree.branchName || null,
+    displayName: worktree.displayName,
+    lastActivity: worktree.lastActivity,
+    dirty,
+    divergence,
+  };
+}
+
+export async function collectLocalRepoInventory(
+  deps: CollectLocalRepoInventoryDeps
+): Promise<RepoInventoryReport> {
+  const nodeId = deps.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  const now = deps.now?.() ?? new Date();
+  const execAsync = deps.execFileAsync ?? (execFileAsync as ExecFileAsyncLike);
+  const repos: RepoInventoryRepoInstance[] = [];
+
+  for (const repoPath of deps.config.repos ?? []) {
+    const workspaceExecAsync = execAsync as unknown as typeof execFileAsync;
+    const { isGitRepo, defaultBranch } = await detectGitRepo(repoPath, workspaceExecAsync);
+    const fallbackName = repoPath.split('/').filter(Boolean).pop() || repoPath;
+    const identityFields = (await resolveRepoIdentityFields(
+      repoPath,
+      isGitRepo,
+      workspaceExecAsync
+    )) as CollectedRepoIdentityFields;
+    const [{ name }, currentBranch, dirty, divergence, worktrees] = await Promise.all([
+      isGitRepo ? nameFromOrigin(repoPath, fallbackName, execAsync) : Promise.resolve({ name: fallbackName }),
+      isGitRepo ? currentBranchFor(repoPath, execAsync) : Promise.resolve(null),
+      isGitRepo ? getDirtySummary(repoPath, execAsync) : Promise.resolve(null),
+      isGitRepo ? getDivergenceSummary(repoPath, execAsync, now) : Promise.resolve(null),
+      isGitRepo
+        ? scanWorktrees(
+            {
+              getConfig: () => deps.config,
+              configPath: deps.configPath,
+              execFileAsync: execAsync,
+              readdirSync:
+                deps.readdirSync ??
+                ((_dir: string) =>
+                  // Lazy require would be worse here; scanner tests inject this.
+                  [] as Array<{ name: string; isDirectory: () => boolean }>),
+              statSync:
+                deps.statSync ??
+                (() => ({ isDirectory: () => false })),
+              readMeta: (configPath: string, worktreePath: string) => readMeta(configPath, worktreePath),
+            },
+            repoPath
+          )
+        : Promise.resolve([]),
+    ]);
+
+    const worktreeInstances = await Promise.all(
+      worktrees.map((worktree) => worktreeInstanceFor(worktree, nodeId, execAsync, now))
+    );
+
+    repos.push({
+      repoInstanceId: createRepoInstanceId(nodeId, repoPath),
+      nodeId,
+      localPath: repoPath,
+      name,
+      isGitRepo,
+      defaultBranch,
+      currentBranch,
+      repoIdentity: identityFields.repoIdentity,
+      selectedRemote: identityFields.selectedRemote,
+      remotes: identityFields.remotes,
+      repoIdentityWarnings: identityFields.repoIdentityWarnings,
+      dirty,
+      divergence,
+      worktrees: worktreeInstances,
+      reportedAt: now.toISOString(),
+    });
+  }
+
+  return {
+    nodeId,
+    generatedAt: now.toISOString(),
+    repos,
+  };
+}

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -444,7 +444,7 @@ export async function detectGitRepo(
   return { isGitRepo: true, defaultBranch };
 }
 
-async function resolveRepoIdentityFields(
+export async function resolveRepoIdentityFields(
   repoPath: string,
   isGitRepo: boolean,
   execAsync: typeof execFileAsync

--- a/shared/repo-inventory.ts
+++ b/shared/repo-inventory.ts
@@ -97,16 +97,34 @@ function isStringOrNull(value: unknown): value is string | null {
   return typeof value === 'string' || value === null;
 }
 
+const REPO_IDENTITY_WARNINGS = new Set<RepoIdentityWarning>([
+  'missing-remotes',
+  'multiple-remotes',
+  'malformed-remote-url',
+  'fork-upstream-ambiguity',
+  'selected-non-origin-remote',
+]);
+
+function isRemoteProviderOrNull(value: unknown): value is ResolvedRemoteIdentity['provider'] {
+  return value === 'github' || value === 'git' || value === null;
+}
+
+function isRepoIdentityWarning(value: unknown): value is RepoIdentityWarning {
+  return typeof value === 'string' && REPO_IDENTITY_WARNINGS.has(value as RepoIdentityWarning);
+}
+
 function isResolvedRemoteIdentity(value: unknown): value is ResolvedRemoteIdentity {
   if (!isRecord(value)) return false;
   return (
     typeof value.name === 'string' &&
     typeof value.url === 'string' &&
     isStringOrNull(value.identity) &&
+    isRemoteProviderOrNull(value.provider) &&
     isStringOrNull(value.host) &&
     isStringOrNull(value.path) &&
     isStringOrNull(value.owner) &&
-    isStringOrNull(value.repoName)
+    isStringOrNull(value.repoName) &&
+    (value.warning === undefined || isRepoIdentityWarning(value.warning))
   );
 }
 
@@ -134,7 +152,7 @@ function isRepoInventoryRepoInstance(value: unknown): value is RepoInventoryRepo
     Array.isArray(value.remotes) &&
     value.remotes.every(isResolvedRemoteIdentity) &&
     Array.isArray(value.repoIdentityWarnings) &&
-    value.repoIdentityWarnings.every((warning) => typeof warning === 'string') &&
+    value.repoIdentityWarnings.every(isRepoIdentityWarning) &&
     Array.isArray(value.worktrees) &&
     value.worktrees.every(isRepoInventoryWorktreeInstance) &&
     typeof value.reportedAt === 'string'

--- a/shared/repo-inventory.ts
+++ b/shared/repo-inventory.ts
@@ -1,0 +1,233 @@
+import type {
+  NodeId,
+  RepoIdentity,
+  RepoInstanceId,
+  WorktreeInstanceId,
+} from './identity.js';
+import type {
+  RepoIdentityWarning,
+  ResolvedRemoteIdentity,
+} from './repo-identity.js';
+
+export interface RepoInventoryDirtyFile {
+  path: string;
+  status: 'modified' | 'added' | 'deleted' | 'renamed' | 'untracked' | 'conflicted' | 'unknown';
+}
+
+export interface RepoInventoryDirtySummary {
+  stagedCount: number;
+  unstagedCount: number;
+  untrackedCount: number;
+  conflictedCount: number;
+  files: RepoInventoryDirtyFile[];
+  truncated: boolean;
+}
+
+export interface RepoInventoryDivergenceSummary {
+  upstreamRef: string | null;
+  aheadCount: number;
+  behindCount: number;
+  headSha?: string | null;
+  generatedAt?: string;
+  error?: string;
+}
+
+export interface RepoInventoryWorktreeInstance {
+  worktreeInstanceId: WorktreeInstanceId;
+  localPath: string;
+  branchName: string | null;
+  displayName?: string;
+  lastActivity?: string;
+  dirty?: RepoInventoryDirtySummary | null;
+  divergence?: RepoInventoryDivergenceSummary | null;
+  warnings?: string[];
+}
+
+export interface RepoInventoryRepoInstance {
+  repoInstanceId: RepoInstanceId;
+  nodeId: NodeId;
+  localPath: string;
+  name: string;
+  isGitRepo: boolean;
+  defaultBranch: string | null;
+  currentBranch: string | null;
+  repoIdentity: RepoIdentity | null;
+  selectedRemote: ResolvedRemoteIdentity | null;
+  remotes: ResolvedRemoteIdentity[];
+  repoIdentityWarnings: RepoIdentityWarning[];
+  dirty?: RepoInventoryDirtySummary | null;
+  divergence?: RepoInventoryDivergenceSummary | null;
+  worktrees: RepoInventoryWorktreeInstance[];
+  reportedAt: string;
+}
+
+export interface RepoInventoryReport {
+  nodeId: NodeId;
+  generatedAt: string;
+  repos: RepoInventoryRepoInstance[];
+}
+
+export interface AggregatedRepoInventoryGroup {
+  groupId: string;
+  repoIdentity: RepoIdentity | null;
+  displayName: string;
+  selectedRemote: ResolvedRemoteIdentity | null;
+  remotes: ResolvedRemoteIdentity[];
+  warnings: RepoIdentityWarning[];
+  instances: RepoInventoryRepoInstance[];
+  identityDebug: {
+    groupedBy: 'repoIdentity' | 'repoInstanceId';
+    repoIdentity: RepoIdentity | null;
+    instanceCount: number;
+    nodeIds: NodeId[];
+  };
+}
+
+export interface AggregatedRepoInventoryResponse {
+  generatedAt: string;
+  groups: AggregatedRepoInventoryGroup[];
+  reports: RepoInventoryReport[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringOrNull(value: unknown): value is string | null {
+  return typeof value === 'string' || value === null;
+}
+
+function isResolvedRemoteIdentity(value: unknown): value is ResolvedRemoteIdentity {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.name === 'string' &&
+    typeof value.url === 'string' &&
+    isStringOrNull(value.identity) &&
+    isStringOrNull(value.host) &&
+    isStringOrNull(value.path) &&
+    isStringOrNull(value.owner) &&
+    isStringOrNull(value.repoName)
+  );
+}
+
+function isRepoInventoryWorktreeInstance(value: unknown): value is RepoInventoryWorktreeInstance {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.worktreeInstanceId === 'string' &&
+    typeof value.localPath === 'string' &&
+    isStringOrNull(value.branchName)
+  );
+}
+
+function isRepoInventoryRepoInstance(value: unknown): value is RepoInventoryRepoInstance {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.repoInstanceId === 'string' &&
+    typeof value.nodeId === 'string' &&
+    typeof value.localPath === 'string' &&
+    typeof value.name === 'string' &&
+    typeof value.isGitRepo === 'boolean' &&
+    isStringOrNull(value.defaultBranch) &&
+    isStringOrNull(value.currentBranch) &&
+    isStringOrNull(value.repoIdentity) &&
+    (value.selectedRemote === null || isResolvedRemoteIdentity(value.selectedRemote)) &&
+    Array.isArray(value.remotes) &&
+    value.remotes.every(isResolvedRemoteIdentity) &&
+    Array.isArray(value.repoIdentityWarnings) &&
+    value.repoIdentityWarnings.every((warning) => typeof warning === 'string') &&
+    Array.isArray(value.worktrees) &&
+    value.worktrees.every(isRepoInventoryWorktreeInstance) &&
+    typeof value.reportedAt === 'string'
+  );
+}
+
+export function isRepoInventoryReport(value: unknown): value is RepoInventoryReport {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.nodeId === 'string' &&
+    typeof value.generatedAt === 'string' &&
+    Array.isArray(value.repos) &&
+    value.repos.every((repo) =>
+      isRepoInventoryRepoInstance(repo) && repo.nodeId === value.nodeId
+    )
+  );
+}
+
+function uniqueBy<T>(items: T[], keyFor: (item: T) => string | null): T[] {
+  const seen = new Set<string>();
+  const result: T[] = [];
+  for (const item of items) {
+    const key = keyFor(item);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    result.push(item);
+  }
+  return result;
+}
+
+function uniqueWarnings(instances: RepoInventoryRepoInstance[]): RepoIdentityWarning[] {
+  return Array.from(
+    new Set(instances.flatMap((instance) => instance.repoIdentityWarnings))
+  ).sort();
+}
+
+function displayNameFor(instances: RepoInventoryRepoInstance[]): string {
+  const selectedRemoteName = instances
+    .map((instance) => instance.selectedRemote?.repoName)
+    .find((name): name is string => Boolean(name));
+  return selectedRemoteName ?? instances[0]?.name ?? 'unknown repository';
+}
+
+export function aggregateRepoInventoryReports(
+  reports: RepoInventoryReport[],
+  now: Date = new Date()
+): AggregatedRepoInventoryResponse {
+  const groupsById = new Map<string, RepoInventoryRepoInstance[]>();
+
+  for (const report of reports) {
+    for (const instance of report.repos) {
+      const groupId = instance.repoIdentity ?? `unidentified:${instance.repoInstanceId}`;
+      const current = groupsById.get(groupId) ?? [];
+      current.push(instance);
+      groupsById.set(groupId, current);
+    }
+  }
+
+  const groups = Array.from(groupsById.entries()).map(([groupId, instances]) => {
+    const repoIdentity = instances[0]?.repoIdentity ?? null;
+    const remotes = uniqueBy(
+      instances.flatMap((instance) => instance.remotes),
+      (remote) => `${remote.name}:${remote.identity ?? remote.url}`
+    );
+    const selectedRemote = instances.find((instance) => instance.selectedRemote)?.selectedRemote ?? null;
+    const nodeIds = Array.from(new Set(instances.map((instance) => instance.nodeId))).sort();
+
+    return {
+      groupId,
+      repoIdentity,
+      displayName: displayNameFor(instances),
+      selectedRemote,
+      remotes,
+      warnings: uniqueWarnings(instances),
+      instances: [...instances].sort((a, b) =>
+        a.nodeId === b.nodeId
+          ? a.localPath.localeCompare(b.localPath)
+          : a.nodeId.localeCompare(b.nodeId)
+      ),
+      identityDebug: {
+        groupedBy: repoIdentity ? 'repoIdentity' : 'repoInstanceId',
+        repoIdentity,
+        instanceCount: instances.length,
+        nodeIds,
+      },
+    } satisfies AggregatedRepoInventoryGroup;
+  });
+
+  groups.sort((a, b) => a.displayName.localeCompare(b.displayName) || a.groupId.localeCompare(b.groupId));
+
+  return {
+    generatedAt: now.toISOString(),
+    groups,
+    reports,
+  };
+}

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -9,6 +9,7 @@ import { createHubNodeRegistry } from '../server/hub-node-registry.js';
 import { createHubNodeRouter } from '../server/hub-node-router.js';
 import { setupWebSocket } from '../server/ws.js';
 import type { NodeManifest } from '../shared/node-manifest.js';
+import type { RepoInventoryReport } from '../shared/repo-inventory.js';
 
 function manifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
   return {
@@ -67,6 +68,55 @@ function tmpRegistry(now = () => new Date('2026-01-02T03:04:05.000Z')) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hub-node-routes-'));
   const registry = createHubNodeRegistry({ storagePath: path.join(tmpDir, 'nodes.json'), now });
   return { tmpDir, registry };
+}
+
+function repoInventoryReport(nodeId: string, localPath: string): RepoInventoryReport {
+  const selectedRemote = {
+    name: 'origin',
+    url: 'git@github.com:donovan-yohan/relay-ide.git',
+    identity: 'github.com/donovan-yohan/relay-ide',
+    provider: 'github' as const,
+    host: 'github.com',
+    path: 'donovan-yohan/relay-ide',
+    owner: 'donovan-yohan',
+    repoName: 'relay-ide',
+  };
+  return {
+    nodeId,
+    generatedAt: '2026-01-02T03:04:05.000Z',
+    repos: [
+      {
+        repoInstanceId: `${encodeURIComponent(nodeId)}:${encodeURIComponent(localPath)}`,
+        nodeId,
+        localPath,
+        name: 'relay-ide',
+        isGitRepo: true,
+        defaultBranch: 'nightly',
+        currentBranch: 'feature/inventory',
+        repoIdentity: 'github.com/donovan-yohan/relay-ide',
+        selectedRemote,
+        remotes: [selectedRemote],
+        repoIdentityWarnings: [],
+        dirty: {
+          stagedCount: 0,
+          unstagedCount: 1,
+          untrackedCount: 0,
+          conflictedCount: 0,
+          files: [{ path: 'server/repo-inventory.ts', status: 'modified' }],
+          truncated: false,
+        },
+        divergence: { upstreamRef: 'origin/nightly', aheadCount: 2, behindCount: 1 },
+        worktrees: [
+          {
+            worktreeInstanceId: `${encodeURIComponent(nodeId)}:${encodeURIComponent(`${localPath}/.worktrees/a`)}`,
+            localPath: `${localPath}/.worktrees/a`,
+            branchName: 'feature/a',
+          },
+        ],
+        reportedAt: '2026-01-02T03:04:05.000Z',
+      },
+    ],
+  };
 }
 
 async function listen(server: http.Server): Promise<number> {
@@ -364,5 +414,56 @@ describe('hub node routes and link', () => {
       type: 'control.error',
       error: { code: 'PROTOCOL_INCOMPATIBLE', retryable: false },
     });
+  });
+
+  it('accepts heartbeat repo inventory and returns aggregated hub groups with local inventory', async () => {
+    const { tmpDir, registry } = tmpRegistry();
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const app = express();
+    app.use(express.json());
+    app.use(
+      createHubNodeRouter({
+        registry,
+        requireAuth: (req, res, next) => {
+          if (req.header('x-test-auth') === 'yes') next();
+          else res.status(401).json({ error: 'Unauthorized' });
+        },
+        collectLocalRepoInventory: async () => repoInventoryReport('local', '/Users/kyle/dev/relay-ide'),
+      })
+    );
+    const server = http.createServer(app);
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+    const base = `http://127.0.0.1:${port}`;
+
+    const pairToken = registry.createPairToken({}).pairToken;
+    const exchanged = registry.exchangePairToken({ pairToken, manifest: manifest() });
+    const heartbeat = await fetch(`${base}/hub/node-heartbeat`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${exchanged.credential.token}`,
+      },
+      body: JSON.stringify({
+        nodeId: exchanged.node.nodeId,
+        protocolVersion: '1.0',
+        repoInventory: repoInventoryReport(exchanged.node.nodeId, '/srv/repos/relay-ide'),
+      }),
+    });
+    expect(heartbeat.status).toBe(200);
+
+    const inventory = await fetch(`${base}/hub/repo-inventory`, {
+      headers: { 'x-test-auth': 'yes' },
+    });
+    expect(inventory.status).toBe(200);
+    const payload = (await inventory.json()) as {
+      groups: Array<{ repoIdentity: string | null; instances: Array<{ nodeId: string; localPath: string }> }>;
+    };
+    expect(payload.groups).toHaveLength(1);
+    expect(payload.groups[0]).toMatchObject({ repoIdentity: 'github.com/donovan-yohan/relay-ide' });
+    expect(payload.groups[0]?.instances.map((instance) => instance.localPath).sort()).toEqual([
+      '/Users/kyle/dev/relay-ide',
+      '/srv/repos/relay-ide',
+    ]);
   });
 });

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -466,4 +466,90 @@ describe('hub node routes and link', () => {
       '/srv/repos/relay-ide',
     ]);
   });
+
+  it('rejects heartbeat repo inventory for a different node id', async () => {
+    const { tmpDir, registry } = tmpRegistry();
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const app = express();
+    app.use(express.json());
+    app.use(
+      createHubNodeRouter({
+        registry,
+        requireAuth: (_req, res) => res.status(401).json({ error: 'Unauthorized' }),
+      })
+    );
+    const server = http.createServer(app);
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+    const base = `http://127.0.0.1:${port}`;
+
+    const exchanged = registry.exchangePairToken({
+      pairToken: registry.createPairToken({}).pairToken,
+      manifest: manifest(),
+    });
+    const response = await fetch(`${base}/hub/node-heartbeat`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${exchanged.credential.token}`,
+      },
+      body: JSON.stringify({
+        nodeId: exchanged.node.nodeId,
+        protocolVersion: '1.0',
+        repoInventory: repoInventoryReport('spoofed-node', '/srv/repos/relay-ide'),
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { code: 'INVALID_REQUEST', retryable: false },
+    });
+    expect(registry.listRepoInventoryReports()).toHaveLength(0);
+  });
+
+  it('rejects websocket heartbeat repo inventory for a different node id', async () => {
+    const now = new Date('2026-01-02T03:04:05.000Z');
+    const { tmpDir, registry } = tmpRegistry(() => now);
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const exchanged = registry.exchangePairToken({
+      pairToken: registry.createPairToken({}).pairToken,
+      manifest: manifest(),
+    });
+
+    const server = http.createServer(express());
+    setupWebSocket(server, new Set(), null, undefined, false, undefined, registry);
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/hub/node-link?trace=test`, {
+      headers: { authorization: `Bearer ${exchanged.credential.token}` },
+    });
+    cleanup.push(() => ws.close());
+    await new Promise<void>((resolve, reject) => {
+      ws.once('open', resolve);
+      ws.once('error', reject);
+    });
+
+    const mismatchError = new Promise<Record<string, unknown>>((resolve) => {
+      ws.once('message', (data) => resolve(JSON.parse(data.toString()) as Record<string, unknown>));
+    });
+    ws.send(
+      JSON.stringify({
+        protocol: 'relay-node-link',
+        protocolVersion: '1.0',
+        nodeId: exchanged.node.nodeId,
+        channel: 'control',
+        type: 'control.heartbeat',
+        timestamp: now.toISOString(),
+        payload: { repoInventory: repoInventoryReport('spoofed-node', '/srv/repos/relay-ide') },
+      })
+    );
+
+    expect(await mismatchError).toMatchObject({
+      channel: 'control',
+      type: 'control.error',
+      error: { code: 'INVALID_REQUEST', retryable: false },
+    });
+    expect(registry.listRepoInventoryReports()).toHaveLength(0);
+  });
 });

--- a/test/repo-inventory.test.ts
+++ b/test/repo-inventory.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  aggregateRepoInventoryReports,
+  isRepoInventoryReport,
+  type RepoInventoryRepoInstance,
+} from '../shared/repo-inventory.js';
+import { normalizeRemoteUrl, type ResolvedRemoteIdentity } from '../shared/repo-identity.js';
+
+function remote(name: string, url: string): ResolvedRemoteIdentity {
+  const normalized = normalizeRemoteUrl(url);
+  return {
+    name,
+    url,
+    identity: normalized.identity,
+    provider: normalized.provider,
+    host: normalized.host,
+    path: normalized.path,
+    owner: normalized.owner,
+    repoName: normalized.name,
+    ...(normalized.warning ? { warning: normalized.warning } : {}),
+  };
+}
+
+function repo(overrides: Partial<RepoInventoryRepoInstance>): RepoInventoryRepoInstance {
+  const selectedRemote = overrides.selectedRemote ?? remote('origin', 'git@github.com:donovan-yohan/relay-ide.git');
+  return {
+    repoInstanceId: overrides.repoInstanceId ?? `${overrides.nodeId ?? 'local'}:${encodeURIComponent(overrides.localPath ?? '/repo')}`,
+    nodeId: overrides.nodeId ?? 'local',
+    localPath: overrides.localPath ?? '/repo',
+    name: overrides.name ?? 'relay-ide',
+    isGitRepo: overrides.isGitRepo ?? true,
+    defaultBranch: overrides.defaultBranch ?? 'nightly',
+    currentBranch: overrides.currentBranch ?? 'nightly',
+    repoIdentity: 'repoIdentity' in overrides ? (overrides.repoIdentity ?? null) : selectedRemote.identity,
+    selectedRemote,
+    remotes: overrides.remotes ?? [selectedRemote],
+    repoIdentityWarnings: overrides.repoIdentityWarnings ?? [],
+    dirty: overrides.dirty ?? {
+      stagedCount: 0,
+      unstagedCount: 0,
+      untrackedCount: 0,
+      conflictedCount: 0,
+      files: [],
+      truncated: false,
+    },
+    divergence: overrides.divergence ?? {
+      upstreamRef: 'origin/nightly',
+      aheadCount: 0,
+      behindCount: 0,
+    },
+    worktrees: overrides.worktrees ?? [],
+    reportedAt: overrides.reportedAt ?? '2026-05-12T00:00:00.000Z',
+  };
+}
+
+describe('repo inventory aggregation', () => {
+  it('groups the same GitHub repo across SSH/HTTPS remotes and node-local paths', () => {
+    const macRemote = remote('origin', 'git@github.com:donovan-yohan/relay-ide.git');
+    const linuxRemote = remote('origin', 'https://github.com/donovan-yohan/relay-ide.git');
+    const result = aggregateRepoInventoryReports([
+      {
+        nodeId: 'macbook',
+        generatedAt: '2026-05-12T00:00:00.000Z',
+        repos: [
+          repo({
+            nodeId: 'macbook',
+            localPath: '/Users/kyle/dev/relay-ide',
+            repoInstanceId: 'macbook:%2FUsers%2Fkyle%2Fdev%2Frelay-ide',
+            selectedRemote: macRemote,
+            remotes: [macRemote],
+            worktrees: [
+              {
+                worktreeInstanceId: 'macbook:%2FUsers%2Fkyle%2Fdev%2Frelay-ide%2F.worktrees%2Fa',
+                localPath: '/Users/kyle/dev/relay-ide/.worktrees/a',
+                branchName: 'feature/a',
+                dirty: {
+                  stagedCount: 1,
+                  unstagedCount: 0,
+                  untrackedCount: 0,
+                  conflictedCount: 0,
+                  files: [{ path: 'server/a.ts', status: 'modified' }],
+                  truncated: false,
+                },
+              },
+            ],
+          }),
+        ],
+      },
+      {
+        nodeId: 'linux',
+        generatedAt: '2026-05-12T00:00:00.000Z',
+        repos: [
+          repo({
+            nodeId: 'linux',
+            localPath: '/srv/repos/relay-ide',
+            repoInstanceId: 'linux:%2Fsrv%2Frepos%2Frelay-ide',
+            selectedRemote: linuxRemote,
+            remotes: [linuxRemote],
+            currentBranch: 'main',
+          }),
+        ],
+      },
+    ]);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]).toMatchObject({
+      groupId: 'github.com/donovan-yohan/relay-ide',
+      repoIdentity: 'github.com/donovan-yohan/relay-ide',
+      identityDebug: {
+        groupedBy: 'repoIdentity',
+        instanceCount: 2,
+        nodeIds: ['linux', 'macbook'],
+      },
+    });
+    expect(result.groups[0]?.instances.map((instance) => [instance.nodeId, instance.localPath])).toEqual([
+      ['linux', '/srv/repos/relay-ide'],
+      ['macbook', '/Users/kyle/dev/relay-ide'],
+    ]);
+    expect(result.groups[0]?.instances[1]?.worktrees[0]).toMatchObject({
+      localPath: '/Users/kyle/dev/relay-ide/.worktrees/a',
+      branchName: 'feature/a',
+    });
+  });
+
+  it('does not collapse unrelated same-basename repos when remotes differ', () => {
+    const firstRemote = remote('origin', 'git@github.com:one/tools.git');
+    const secondRemote = remote('origin', 'git@github.com:two/tools.git');
+    const result = aggregateRepoInventoryReports([
+      {
+        nodeId: 'node-a',
+        generatedAt: '2026-05-12T00:00:00.000Z',
+        repos: [repo({ nodeId: 'node-a', name: 'tools', selectedRemote: firstRemote, remotes: [firstRemote] })],
+      },
+      {
+        nodeId: 'node-b',
+        generatedAt: '2026-05-12T00:00:00.000Z',
+        repos: [repo({ nodeId: 'node-b', name: 'tools', selectedRemote: secondRemote, remotes: [secondRemote] })],
+      },
+    ]);
+
+    expect(result.groups.map((group) => group.groupId).sort()).toEqual([
+      'github.com/one/tools',
+      'github.com/two/tools',
+    ]);
+  });
+
+  it('surfaces fork/upstream and malformed/missing remote warnings', () => {
+    const origin = remote('origin', 'git@github.com:donovan-yohan/relay-ide.git');
+    const upstream = remote('upstream', 'https://github.com/NousResearch/relay-ide.git');
+    const result = aggregateRepoInventoryReports([
+      {
+        nodeId: 'macbook',
+        generatedAt: '2026-05-12T00:00:00.000Z',
+        repos: [
+          repo({
+            nodeId: 'macbook',
+            selectedRemote: origin,
+            remotes: [origin, upstream],
+            repoIdentityWarnings: ['multiple-remotes', 'fork-upstream-ambiguity'],
+          }),
+          repo({
+            nodeId: 'macbook',
+            localPath: '/Users/kyle/dev/no-remote',
+            repoInstanceId: 'macbook:%2FUsers%2Fkyle%2Fdev%2Fno-remote',
+            name: 'no-remote',
+            repoIdentity: null,
+            selectedRemote: null,
+            remotes: [],
+            repoIdentityWarnings: ['missing-remotes'],
+          }),
+        ],
+      },
+    ]);
+
+    const relay = result.groups.find((group) => group.repoIdentity === 'github.com/donovan-yohan/relay-ide');
+    const missing = result.groups.find((group) => group.repoIdentity === null);
+    expect(relay?.warnings).toEqual(['fork-upstream-ambiguity', 'multiple-remotes']);
+    expect(missing).toMatchObject({
+      groupId: 'unidentified:macbook:%2FUsers%2Fkyle%2Fdev%2Fno-remote',
+      warnings: ['missing-remotes'],
+      identityDebug: { groupedBy: 'repoInstanceId' },
+    });
+  });
+
+  it('validates node reports before accepting heartbeat inventory payloads', () => {
+    const valid = {
+      nodeId: 'macbook',
+      generatedAt: '2026-05-12T00:00:00.000Z',
+      repos: [repo({ nodeId: 'macbook' })],
+    };
+    const invalid = {
+      ...valid,
+      repos: [{ ...valid.repos[0], nodeId: 'other-node' }],
+    };
+
+    expect(isRepoInventoryReport(valid)).toBe(true);
+    expect(isRepoInventoryReport(invalid)).toBe(false);
+  });
+});

--- a/test/repo-inventory.test.ts
+++ b/test/repo-inventory.test.ts
@@ -197,4 +197,38 @@ describe('repo inventory aggregation', () => {
     expect(isRepoInventoryReport(valid)).toBe(true);
     expect(isRepoInventoryReport(invalid)).toBe(false);
   });
+
+  it('rejects remote identities with malformed provider or warning values', () => {
+    const validRepo = repo({ nodeId: 'macbook' });
+    const valid = {
+      nodeId: 'macbook',
+      generatedAt: '2026-05-12T00:00:00.000Z',
+      repos: [validRepo],
+    };
+    const invalidProvider = {
+      ...valid,
+      repos: [
+        {
+          ...validRepo,
+          selectedRemote: { ...validRepo.selectedRemote, provider: 'svn' },
+          remotes: [{ ...validRepo.remotes[0], provider: 'svn' }],
+        },
+      ],
+    };
+    const invalidWarning = {
+      ...valid,
+      repos: [
+        {
+          ...validRepo,
+          selectedRemote: { ...validRepo.selectedRemote, warning: 'surprise-warning' },
+          remotes: [{ ...validRepo.remotes[0], warning: 'surprise-warning' }],
+          repoIdentityWarnings: ['surprise-warning'],
+        },
+      ],
+    };
+
+    expect(isRepoInventoryReport(valid)).toBe(true);
+    expect(isRepoInventoryReport(invalidProvider)).toBe(false);
+    expect(isRepoInventoryReport(invalidWarning)).toBe(false);
+  });
 });


### PR DESCRIPTION
Refs #317
Closes #387

## Summary
- add shared repo inventory report/group types and aggregation by canonical repo identity
- accept repo inventory on node heartbeat/link and expose /hub/repo-inventory with local inventory included
- collect local repo/worktree dirty/divergence metadata for environment picker clients

## Verification
- nvm use
- rtk npm run check
- rtk npm run build
- rtk npm test -- test/workspace-summary.test.ts test/workspaces-dashboard-cache.test.ts test/git-divergence.test.ts test/git-changed-files.test.ts
- rtk npm test -- test/hub-node-routes.test.ts test/repo-inventory.test.ts

## Caveats
- npm run check currently reports existing lint warnings only; no errors
- browser environment picker UI wiring is intentionally not included in this backend slice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository inventory tracking and reporting across the system; local collection added and aggregated via a new endpoint.
  * Frontend can fetch aggregated repository inventory.

* **Documentation**
  * Repository inventory types exposed for frontend use.

* **Bug Fixes**
  * Improved validation: malformed or mismatched repo inventory submissions are rejected.

* **Tests**
  * Added tests covering inventory aggregation and validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/404)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->