### PR TITLE
Add environment picker launch flow

### DIFF
--- a/frontend/src/components/dialogs/CustomizeSessionDialog.css
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.css
@@ -50,3 +50,18 @@
   color: var(--text-muted);
   font-size: var(--font-size-sm);
 }
+
+.customize-session-environment-picker {
+  border: 1px solid var(--border);
+  border-radius: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+}
+
+.customize-session-environment-copy {
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
+}

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -6,7 +6,20 @@ import { estimateTerminalDimensions } from '../../lib/utils.js';
 import { useConfigStore } from '../../lib/stores/config.js';
 import { useUiStore } from '../../lib/stores/ui.js';
 import { createAgentSession } from '../../lib/session-utils.js';
-import type { AgentType, FrameworkInfo } from '../../lib/types.js';
+import { fetchHubNodes, fetchRepoInventory } from '../../lib/api.js';
+import type {
+  AgentType,
+  AggregatedRepoInventoryGroup,
+  AggregatedRepoInventoryResponse,
+  FrameworkInfo,
+  RepoInventoryRepoInstance,
+  RepoInventoryWorktreeInstance,
+} from '../../lib/types.js';
+import type {
+  HubNodeSummary,
+  NodeCapabilityStatus,
+} from '../../../../shared/relay-node-protocol.js';
+import { DEFAULT_LOCAL_NODE_ID, type NodeId } from '../../../../shared/identity.js';
 import './CustomizeSessionDialog.css';
 
 export interface CustomizeSessionDialogHandle {
@@ -80,6 +93,292 @@ export function defaultSessionModeForAgent(
   return selectedAgent === 'hermes' && supportsWeb ? 'web' : 'pty';
 }
 
+type EnvironmentChoice = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+  reason?: string;
+};
+
+export interface EnvironmentCheckoutChoice extends EnvironmentChoice {
+  nodeId: NodeId;
+  repoPath: string;
+  worktreePath: string | null;
+}
+
+export interface EnvironmentPickerModel {
+  showPicker: boolean;
+  repoChoices: EnvironmentChoice[];
+  nodeChoices: EnvironmentChoice[];
+  checkoutChoices: EnvironmentCheckoutChoice[];
+  selectedGroupId: string | null;
+  selectedNodeId: NodeId;
+  selectedCheckoutId: string | null;
+  selectedNodeReason: string | null;
+  resolved: {
+    nodeId: NodeId;
+    repoPath: string;
+    worktreePath: string | null;
+  };
+}
+
+export interface EnvironmentPickerInput {
+  inventory: AggregatedRepoInventoryResponse | null;
+  nodes: HubNodeSummary[];
+  selectedAgent: AgentType;
+  selectedGroupId: string | null;
+  selectedNodeId: NodeId | null;
+  selectedCheckoutId: string | null;
+  fallbackWorkspace: { name: string; path: string };
+  fallbackWorktreePath: string | null;
+}
+
+const CHECKOUT_ROOT_PREFIX = 'repo:';
+const CHECKOUT_WORKTREE_PREFIX = 'worktree:';
+
+function syntheticLocalNode(selectedAgent: AgentType): HubNodeSummary {
+  return {
+    nodeId: DEFAULT_LOCAL_NODE_ID,
+    displayName: 'local',
+    hostname: 'local',
+    platform: 'local',
+    arch: 'unknown',
+    relayVersion: 'local',
+    protocolVersion: 'local',
+    status: 'online',
+    connection: { route: 'local', status: 'connected' },
+    capabilities: {
+      totals: { available: 8, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        tmux: 'available',
+        git: 'available',
+        worktrees: 'available',
+        browserAutomation: 'available',
+        clipboardImage: 'available',
+        ssh: 'available',
+        tailscale: 'available',
+      },
+      agents: { [selectedAgent]: 'available' },
+      serviceManager: 'local',
+      wsl: false,
+    },
+    createdAt: '',
+    pairedAt: '',
+    lastSeenAt: '',
+    credentialId: 'local',
+  };
+}
+
+function fallbackGroupFor(
+  workspace: { name: string; path: string },
+  worktreePath: string | null
+): AggregatedRepoInventoryGroup {
+  const repoInstanceId = `${DEFAULT_LOCAL_NODE_ID}:${encodeURIComponent(workspace.path)}`;
+  const worktrees = worktreePath
+    ? [
+        {
+          worktreeInstanceId: `${DEFAULT_LOCAL_NODE_ID}:${encodeURIComponent(worktreePath)}`,
+          localPath: worktreePath,
+          branchName: null,
+          displayName: worktreePath.split('/').pop() || worktreePath,
+        } satisfies RepoInventoryWorktreeInstance,
+      ]
+    : [];
+  return {
+    groupId: repoInstanceId,
+    repoIdentity: null,
+    displayName: workspace.name,
+    selectedRemote: null,
+    remotes: [],
+    warnings: [],
+    instances: [
+      {
+        repoInstanceId,
+        nodeId: DEFAULT_LOCAL_NODE_ID,
+        localPath: workspace.path,
+        name: workspace.name,
+        isGitRepo: true,
+        defaultBranch: null,
+        currentBranch: null,
+        repoIdentity: null,
+        selectedRemote: null,
+        remotes: [],
+        repoIdentityWarnings: [],
+        worktrees,
+        reportedAt: '',
+      },
+    ],
+    identityDebug: {
+      groupedBy: 'repoInstanceId',
+      repoIdentity: null,
+      instanceCount: 1,
+      nodeIds: [DEFAULT_LOCAL_NODE_ID],
+    },
+  };
+}
+
+function findGroupForPath(
+  groups: AggregatedRepoInventoryGroup[],
+  path: string
+): AggregatedRepoInventoryGroup | undefined {
+  return groups.find((group) =>
+    group.instances.some(
+      (instance) =>
+        instance.localPath === path ||
+        instance.worktrees.some((worktree) => worktree.localPath === path)
+    )
+  );
+}
+
+function labelForRepo(group: AggregatedRepoInventoryGroup): string {
+  return group.repoIdentity
+    ? `${group.displayName} — ${group.repoIdentity}`
+    : `${group.displayName} — unidentified repo`;
+}
+
+function capabilityProblem(
+  capability: NodeCapabilityStatus | undefined,
+  name: string
+): string | null {
+  if (capability === undefined) return `${name} capability unknown`;
+  if (capability === 'available') return null;
+  return `${name} ${capability}`;
+}
+
+function nodeBlockReason(
+  node: HubNodeSummary | null,
+  selectedAgent: AgentType
+): string | null {
+  if (!node) return 'node availability unknown';
+  if (node.status === 'offline') return 'node is offline';
+  if (node.status === 'stale') return 'heartbeat is stale';
+  if (node.status === 'revoked') return 'node is revoked';
+  const shellProblem = capabilityProblem(node.capabilities.core.shell, 'shell');
+  if (shellProblem) return shellProblem;
+  const agentProblem = capabilityProblem(
+    node.capabilities.agents[selectedAgent],
+    selectedAgent
+  );
+  return agentProblem ? `${agentProblem} on ${node.displayName}` : null;
+}
+
+function uniqueInstancesByNode(
+  instances: RepoInventoryRepoInstance[]
+): RepoInventoryRepoInstance[] {
+  const seen = new Set<NodeId>();
+  return instances.filter((instance) => {
+    if (seen.has(instance.nodeId)) return false;
+    seen.add(instance.nodeId);
+    return true;
+  });
+}
+
+function checkoutChoicesFor(
+  instance: RepoInventoryRepoInstance | undefined,
+  disabledReason: string | null
+): EnvironmentCheckoutChoice[] {
+  if (!instance) return [];
+  const disabled = disabledReason ? { disabled: true, reason: disabledReason } : {};
+  return [
+    {
+      value: `${CHECKOUT_ROOT_PREFIX}${instance.repoInstanceId}`,
+      label: `default — ${instance.localPath}`,
+      nodeId: instance.nodeId,
+      repoPath: instance.localPath,
+      worktreePath: null,
+      ...disabled,
+    },
+    ...instance.worktrees.map((worktree) => ({
+      value: `${CHECKOUT_WORKTREE_PREFIX}${worktree.worktreeInstanceId}`,
+      label: `${worktree.branchName ?? worktree.displayName ?? 'worktree'} — ${worktree.localPath}`,
+      nodeId: instance.nodeId,
+      repoPath: instance.localPath,
+      worktreePath: worktree.localPath,
+      ...disabled,
+    })),
+  ];
+}
+
+export function buildEnvironmentPickerModel(
+  input: EnvironmentPickerInput
+): EnvironmentPickerModel {
+  const groups =
+    input.inventory?.groups.length ? input.inventory.groups : [
+      fallbackGroupFor(input.fallbackWorkspace, input.fallbackWorktreePath),
+    ];
+  const selectedGroup =
+    groups.find((group) => group.groupId === input.selectedGroupId) ??
+    findGroupForPath(groups, input.fallbackWorktreePath ?? input.fallbackWorkspace.path) ??
+    groups[0]!;
+  const nodeById = new Map(input.nodes.map((node) => [node.nodeId, node]));
+  if (!nodeById.has(DEFAULT_LOCAL_NODE_ID)) {
+    nodeById.set(DEFAULT_LOCAL_NODE_ID, syntheticLocalNode(input.selectedAgent));
+  }
+  const nodeChoices = uniqueInstancesByNode(selectedGroup.instances).map((instance) => {
+    const node = nodeById.get(instance.nodeId) ?? null;
+    const reason = nodeBlockReason(node, input.selectedAgent);
+    return {
+      value: instance.nodeId,
+      label: node?.displayName ?? instance.nodeId,
+      ...(reason ? { disabled: true, reason } : {}),
+    };
+  });
+  const selectedNodeChoice =
+    nodeChoices.find(
+      (choice) => choice.value === input.selectedNodeId && !choice.disabled
+    ) ?? nodeChoices.find((choice) => !choice.disabled) ?? nodeChoices[0];
+  const selectedNodeId = selectedNodeChoice?.value ?? DEFAULT_LOCAL_NODE_ID;
+  const selectedNodeReason = selectedNodeChoice?.reason ?? null;
+  const selectedInstance = selectedGroup.instances.find(
+    (instance) => instance.nodeId === selectedNodeId
+  );
+  const checkoutChoices = checkoutChoicesFor(selectedInstance, selectedNodeReason);
+  const selectedCheckout =
+    checkoutChoices.find(
+      (choice) => choice.value === input.selectedCheckoutId && !choice.disabled
+    ) ??
+    checkoutChoices.find(
+      (choice) =>
+        !choice.disabled && choice.worktreePath === input.fallbackWorktreePath
+    ) ??
+    checkoutChoices.find(
+      (choice) =>
+        !choice.disabled &&
+        !choice.worktreePath &&
+        choice.repoPath === input.fallbackWorkspace.path
+    ) ??
+    checkoutChoices.find((choice) => !choice.disabled) ??
+    checkoutChoices[0];
+  const resolved = selectedCheckout
+    ? {
+        nodeId: selectedCheckout.nodeId,
+        repoPath: selectedCheckout.repoPath,
+        worktreePath: selectedCheckout.worktreePath,
+      }
+    : {
+        nodeId: DEFAULT_LOCAL_NODE_ID,
+        repoPath: input.fallbackWorkspace.path,
+        worktreePath: input.fallbackWorktreePath,
+      };
+
+  return {
+    showPicker:
+      groups.length > 1 || nodeChoices.length > 1 || checkoutChoices.length > 1,
+    repoChoices: groups.map((group) => ({
+      value: group.groupId,
+      label: labelForRepo(group),
+    })),
+    nodeChoices,
+    checkoutChoices,
+    selectedGroupId: selectedGroup.groupId,
+    selectedNodeId,
+    selectedCheckoutId: selectedCheckout?.value ?? null,
+    selectedNodeReason,
+    resolved,
+  };
+}
+
 interface FormState {
   claudeArgsInput: string;
   selectedAgent: AgentType;
@@ -99,8 +398,7 @@ function defaultForm(): FormState {
 }
 
 async function createSessionFromForm(
-  workspacePath: string,
-  worktreePath: string | null,
+  environment: EnvironmentPickerModel['resolved'],
   form: FormState
 ) {
   const claudeArgs = form.claudeArgsInput.trim().split(/\s+/).filter(Boolean);
@@ -108,8 +406,9 @@ async function createSessionFromForm(
     useUiStore.getState().terminalFontSize
   );
   return createAgentSession({
-    repoPath: workspacePath,
-    worktreePath,
+    nodeId: environment.nodeId,
+    repoPath: environment.repoPath,
+    worktreePath: environment.worktreePath,
     type: 'agent',
     mode: form.sessionMode,
     continue: form.continueExisting,
@@ -124,13 +423,23 @@ async function createSessionFromForm(
 interface BodyProps {
   workspaceName: string;
   form: FormState;
+  environmentModel: EnvironmentPickerModel;
   onFormChange: (patch: Partial<FormState>) => void;
+  onEnvironmentChange: (patch: Partial<EnvironmentSelection>) => void;
+}
+
+interface EnvironmentSelection {
+  selectedGroupId: string | null;
+  selectedNodeId: NodeId | null;
+  selectedCheckoutId: string | null;
 }
 
 function CustomizeSessionBody({
   workspaceName,
   form,
+  environmentModel,
   onFormChange,
+  onEnvironmentChange,
 }: BodyProps) {
   const frameworks = useConfigStore((state) => state.frameworks);
   const frameworkOptions =
@@ -171,9 +480,119 @@ function CustomizeSessionBody({
       {workspaceName && (
         <p className="customize-session-workspace-name">— {workspaceName}</p>
       )}
+      {environmentModel.showPicker && (
+        <section
+          className="customize-session-environment-picker"
+          aria-label="environment picker"
+        >
+          <div className="customize-session-environment-copy">
+            choose repo identity, execution node, then node-local checkout.
+            no live cross-host pty migration or automatic filesystem sync.
+          </div>
+          {environmentModel.repoChoices.length > 1 && (
+            <div className="customize-session-dialog-field">
+              <label
+                className="customize-session-dialog-label"
+                htmlFor="cs-repo"
+              >
+                repo identity
+              </label>
+              <select
+                id="cs-repo"
+                className="customize-session-dialog-select"
+                data-track="dialog.customize-session.repo"
+                value={environmentModel.selectedGroupId ?? ''}
+                onChange={(e) =>
+                  onEnvironmentChange({
+                    selectedGroupId: e.currentTarget.value,
+                    selectedNodeId: null,
+                    selectedCheckoutId: null,
+                  })
+                }
+              >
+                {environmentModel.repoChoices.map((choice) => (
+                  <option key={choice.value} value={choice.value}>
+                    {choice.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          {environmentModel.nodeChoices.length > 1 && (
+            <div className="customize-session-dialog-field">
+              <label
+                className="customize-session-dialog-label"
+                htmlFor="cs-node"
+              >
+                execution node
+              </label>
+              <select
+                id="cs-node"
+                className="customize-session-dialog-select"
+                data-track="dialog.customize-session.node"
+                value={environmentModel.selectedNodeId}
+                onChange={(e) =>
+                  onEnvironmentChange({
+                    selectedNodeId: e.currentTarget.value,
+                    selectedCheckoutId: null,
+                  })
+                }
+              >
+                {environmentModel.nodeChoices.map((choice) => (
+                  <option
+                    key={choice.value}
+                    value={choice.value}
+                    disabled={choice.disabled}
+                  >
+                    {choice.label}
+                    {choice.reason ? ` — ${choice.reason}` : ''}
+                  </option>
+                ))}
+              </select>
+              {environmentModel.selectedNodeReason && (
+                <div className="customize-session-field-note">
+                  {environmentModel.selectedNodeReason}
+                </div>
+              )}
+            </div>
+          )}
+          {environmentModel.checkoutChoices.length > 1 && (
+            <div className="customize-session-dialog-field">
+              <label
+                className="customize-session-dialog-label"
+                htmlFor="cs-checkout"
+              >
+                node-local checkout
+              </label>
+              <select
+                id="cs-checkout"
+                className="customize-session-dialog-select"
+                data-track="dialog.customize-session.checkout"
+                value={environmentModel.selectedCheckoutId ?? ''}
+                onChange={(e) =>
+                  onEnvironmentChange({
+                    selectedCheckoutId: e.currentTarget.value,
+                  })
+                }
+              >
+                {environmentModel.checkoutChoices.map((choice) => (
+                  <option
+                    key={choice.value}
+                    value={choice.value}
+                    disabled={choice.disabled}
+                  >
+                    {choice.label}
+                    {choice.reason ? ` — ${choice.reason}` : ''}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+        </section>
+      )}
       <div className="customize-session-dialog-field">
         <label className="customize-session-dialog-label" htmlFor="cs-agent">
-          Coding agent
+          coding agent
         </label>
         <select
           id="cs-agent"
@@ -247,17 +666,17 @@ function CustomizeSessionBody({
         checked={form.continueExisting}
         onChange={(checked) => onFormChange({ continueExisting: checked })}
       >
-        Continue existing session
+        continue existing session
       </TuiCheckbox>
       <TuiCheckbox
         checked={form.yoloMode}
         onChange={(checked) => onFormChange({ yoloMode: checked })}
       >
-        Yolo mode (skip permission checks)
+        yolo mode (skip permission checks)
       </TuiCheckbox>
       <div className="customize-session-dialog-field">
         <label className="customize-session-dialog-label" htmlFor="cs-args">
-          Extra args (optional)
+          extra args (optional)
         </label>
         <input
           id="cs-args"
@@ -284,7 +703,27 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
     const [form, setForm] = useState<FormState>(defaultForm());
     const [creating, setCreating] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [inventory, setInventory] =
+      useState<AggregatedRepoInventoryResponse | null>(null);
+    const [nodes, setNodes] = useState<HubNodeSummary[]>([]);
+    const [environmentSelection, setEnvironmentSelection] =
+      useState<EnvironmentSelection>({
+        selectedGroupId: null,
+        selectedNodeId: null,
+        selectedCheckoutId: null,
+      });
     const frameworks = useConfigStore((state) => state.frameworks);
+
+    const environmentModel = buildEnvironmentPickerModel({
+      inventory,
+      nodes,
+      selectedAgent: form.selectedAgent,
+      selectedGroupId: environmentSelection.selectedGroupId,
+      selectedNodeId: environmentSelection.selectedNodeId,
+      selectedCheckoutId: environmentSelection.selectedCheckoutId,
+      fallbackWorkspace: { name: workspaceName, path: workspacePath },
+      fallbackWorktreePath: worktreePath,
+    });
 
     useImperativeHandle(ref, () => ({
       async open(
@@ -294,10 +733,27 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
       ) {
         setError(null);
         setForm(defaultForm());
+        setInventory(null);
+        setNodes([]);
+        setEnvironmentSelection({
+          selectedGroupId: null,
+          selectedNodeId: null,
+          selectedCheckoutId: null,
+        });
         setWorkspacePath(workspace.path);
         setWorktreePath(nextWorktreePath ?? null);
         setWorkspaceName(workspace.name);
+        const [inventoryResult, nodesResult] = await Promise.allSettled([
+          fetchRepoInventory(),
+          fetchHubNodes(),
+        ]);
         await useConfigStore.getState().refreshConfig();
+        if (inventoryResult.status === 'fulfilled') {
+          setInventory(inventoryResult.value);
+        }
+        if (nodesResult.status === 'fulfilled') {
+          setNodes(nodesResult.value);
+        }
         const config = useConfigStore.getState();
         const selectedAgent = selectLaunchAgent(
           config.frameworks,
@@ -346,8 +802,7 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
       setCreating(true);
       setError(null);
       const { session, error: submitError } = await createSessionFromForm(
-        workspacePath,
-        worktreePath,
+        environmentModel.resolved,
         form
       );
       try {
@@ -381,6 +836,7 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
           onClick={handleSubmit}
           disabled={
             !workspacePath ||
+            Boolean(environmentModel.selectedNodeReason) ||
             creating ||
             frameworks.some(
               (framework) =>
@@ -411,7 +867,11 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
         <CustomizeSessionBody
           workspaceName={workspaceName}
           form={form}
+          environmentModel={environmentModel}
           onFormChange={(patch) => setForm((f) => ({ ...f, ...patch }))}
+          onEnvironmentChange={(patch) =>
+            setEnvironmentSelection((selection) => ({ ...selection, ...patch }))
+          }
         />
       </DialogShell>
     );

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import { forwardRef, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import DialogShell, { type DialogShellHandle } from './DialogShell.js';
 import TuiButton from '../TuiButton.js';
 import TuiCheckbox from '../TuiCheckbox.js';
@@ -256,6 +256,8 @@ function nodeBlockReason(
   if (node.status === 'revoked') return 'node is revoked';
   const shellProblem = capabilityProblem(node.capabilities.core.shell, 'shell');
   if (shellProblem) return shellProblem;
+  const tmuxProblem = capabilityProblem(node.capabilities.core.tmux, 'tmux');
+  if (tmuxProblem) return `${tmuxProblem} on ${node.displayName}`;
   const agentProblem = capabilityProblem(
     node.capabilities.agents[selectedAgent],
     selectedAgent
@@ -275,12 +277,11 @@ function uniqueInstancesByNode(
 }
 
 function checkoutChoicesFor(
-  instance: RepoInventoryRepoInstance | undefined,
+  instances: RepoInventoryRepoInstance[],
   disabledReason: string | null
 ): EnvironmentCheckoutChoice[] {
-  if (!instance) return [];
   const disabled = disabledReason ? { disabled: true, reason: disabledReason } : {};
-  return [
+  return instances.flatMap((instance) => [
     {
       value: `${CHECKOUT_ROOT_PREFIX}${instance.repoInstanceId}`,
       label: `default — ${instance.localPath}`,
@@ -297,7 +298,7 @@ function checkoutChoicesFor(
       worktreePath: worktree.localPath,
       ...disabled,
     })),
-  ];
+  ]);
 }
 
 export function buildEnvironmentPickerModel(
@@ -330,10 +331,10 @@ export function buildEnvironmentPickerModel(
     ) ?? nodeChoices.find((choice) => !choice.disabled) ?? nodeChoices[0];
   const selectedNodeId = selectedNodeChoice?.value ?? DEFAULT_LOCAL_NODE_ID;
   const selectedNodeReason = selectedNodeChoice?.reason ?? null;
-  const selectedInstance = selectedGroup.instances.find(
+  const selectedNodeInstances = selectedGroup.instances.filter(
     (instance) => instance.nodeId === selectedNodeId
   );
-  const checkoutChoices = checkoutChoicesFor(selectedInstance, selectedNodeReason);
+  const checkoutChoices = checkoutChoicesFor(selectedNodeInstances, selectedNodeReason);
   const selectedCheckout =
     checkoutChoices.find(
       (choice) => choice.value === input.selectedCheckoutId && !choice.disabled
@@ -714,16 +715,30 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
       });
     const frameworks = useConfigStore((state) => state.frameworks);
 
-    const environmentModel = buildEnvironmentPickerModel({
-      inventory,
-      nodes,
-      selectedAgent: form.selectedAgent,
-      selectedGroupId: environmentSelection.selectedGroupId,
-      selectedNodeId: environmentSelection.selectedNodeId,
-      selectedCheckoutId: environmentSelection.selectedCheckoutId,
-      fallbackWorkspace: { name: workspaceName, path: workspacePath },
-      fallbackWorktreePath: worktreePath,
-    });
+    const environmentModel = useMemo(
+      () =>
+        buildEnvironmentPickerModel({
+          inventory,
+          nodes,
+          selectedAgent: form.selectedAgent,
+          selectedGroupId: environmentSelection.selectedGroupId,
+          selectedNodeId: environmentSelection.selectedNodeId,
+          selectedCheckoutId: environmentSelection.selectedCheckoutId,
+          fallbackWorkspace: { name: workspaceName, path: workspacePath },
+          fallbackWorktreePath: worktreePath,
+        }),
+      [
+        inventory,
+        nodes,
+        form.selectedAgent,
+        environmentSelection.selectedGroupId,
+        environmentSelection.selectedNodeId,
+        environmentSelection.selectedCheckoutId,
+        workspaceName,
+        workspacePath,
+        worktreePath,
+      ]
+    );
 
     useImperativeHandle(ref, () => ({
       async open(

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -365,7 +365,10 @@ export function buildEnvironmentPickerModel(
 
   return {
     showPicker:
-      groups.length > 1 || nodeChoices.length > 1 || checkoutChoices.length > 1,
+      groups.length > 1 ||
+      nodeChoices.length > 1 ||
+      checkoutChoices.length > 1 ||
+      Boolean(selectedNodeReason),
     repoChoices: groups.map((group) => ({
       value: group.groupId,
       label: labelForRepo(group),
@@ -519,7 +522,8 @@ function CustomizeSessionBody({
               </select>
             </div>
           )}
-          {environmentModel.nodeChoices.length > 1 && (
+          {(environmentModel.nodeChoices.length > 1 ||
+            environmentModel.selectedNodeReason) && (
             <div className="customize-session-dialog-field">
               <label
                 className="customize-session-dialog-label"

--- a/frontend/src/lib/session-utils.ts
+++ b/frontend/src/lib/session-utils.ts
@@ -3,8 +3,10 @@ import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
 import { resolveSessionByKey } from './session-keys.js';
 import type { Repo, SessionSummary } from './types.js';
+import type { NodeId } from '../../../shared/identity.js';
 
 export interface CreateAgentSessionOptions {
+  nodeId?: NodeId | undefined;
   repoPath: string;
   worktreePath?: string | null | undefined;
   type?: 'agent' | 'terminal' | undefined;

--- a/frontend/src/test-customize-session-dialog.tsx
+++ b/frontend/src/test-customize-session-dialog.tsx
@@ -122,8 +122,8 @@ function inventory(): AggregatedRepoInventoryResponse {
         identityDebug: {
           groupedBy: 'repoIdentity',
           repoIdentity: 'github.com/donovan-yohan/relay-ide',
-          instanceCount: 4,
-          nodeIds: ['local', 'linux', 'no-claude', 'offline'],
+          instanceCount: 5,
+          nodeIds: ['local', 'linux', 'no-claude', 'offline', 'no-tmux'],
         },
         instances: [
           {
@@ -193,6 +193,21 @@ function inventory(): AggregatedRepoInventoryResponse {
             worktrees: [],
             reportedAt: '2026-05-12T00:00:00.000Z',
           },
+          {
+            repoInstanceId: 'no-tmux:%2Fno-tmux%2Frelay-ide',
+            nodeId: 'no-tmux',
+            localPath: '/no-tmux/relay-ide',
+            name: 'relay-ide',
+            isGitRepo: true,
+            defaultBranch: 'nightly',
+            currentBranch: 'nightly',
+            repoIdentity: 'github.com/donovan-yohan/relay-ide',
+            selectedRemote: null,
+            remotes: [],
+            repoIdentityWarnings: [],
+            worktrees: [],
+            reportedAt: '2026-05-12T00:00:00.000Z',
+          },
         ],
       },
       {
@@ -236,6 +251,17 @@ function nodes(): HubNodeSummary[] {
     node(),
     node({ nodeId: 'linux', displayName: 'linux lab' }),
     node({ nodeId: 'offline', displayName: 'offline lab', status: 'offline' }),
+    node({
+      nodeId: 'no-tmux',
+      displayName: 'no tmux box',
+      capabilities: {
+        ...node().capabilities,
+        core: {
+          ...node().capabilities.core,
+          tmux: 'unavailable',
+        },
+      },
+    }),
     node({
       nodeId: 'no-claude',
       displayName: 'no claude box',

--- a/frontend/src/test-customize-session-dialog.tsx
+++ b/frontend/src/test-customize-session-dialog.tsx
@@ -13,7 +13,7 @@ import './components/dialogs/DialogShell.css';
 import './components/dialogs/CustomizeSessionDialog.css';
 
 const nativeFetch = window.fetch.bind(window);
-let scenario: 'multi' | 'single' = 'multi';
+let scenario: 'multi' | 'single' | 'single-disabled' = 'multi';
 let lastCreateRequest = '';
 
 function framework(id: string): FrameworkInfo {
@@ -69,7 +69,7 @@ function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
 }
 
 function inventory(): AggregatedRepoInventoryResponse {
-  if (scenario === 'single') {
+  if (scenario === 'single' || scenario === 'single-disabled') {
     return {
       generatedAt: '2026-05-12T00:00:00.000Z',
       reports: [],
@@ -246,6 +246,7 @@ function inventory(): AggregatedRepoInventoryResponse {
 }
 
 function nodes(): HubNodeSummary[] {
+  if (scenario === 'single-disabled') return [node({ status: 'offline' })];
   if (scenario === 'single') return [node()];
   return [
     node(),
@@ -364,6 +365,15 @@ function Harness() {
         }}
       >
         open single-node customize session
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          scenario = 'single-disabled';
+          void dialogRef.current?.open({ name: 'relay-ide', path: '/Users/kyle/relay-ide' });
+        }}
+      >
+        open single disabled-node customize session
       </button>
       <output data-testid="created-session">{createdSession}</output>
       <output data-testid="last-create-request">{lastCreateRequest}</output>

--- a/frontend/src/test-customize-session-dialog.tsx
+++ b/frontend/src/test-customize-session-dialog.tsx
@@ -1,0 +1,353 @@
+/* eslint-disable sonarjs/no-duplicate-string */
+import React, { useRef, useState } from 'react';
+import ReactDOM from 'react-dom/client';
+import CustomizeSessionDialog, {
+  type CustomizeSessionDialogHandle,
+} from './components/dialogs/CustomizeSessionDialog.js';
+import { useConfigStore } from './lib/stores/config.js';
+import type { FrameworkInfo } from './lib/types.js';
+import type { AggregatedRepoInventoryResponse } from '../../shared/repo-inventory.js';
+import type { HubNodeSummary } from '../../shared/relay-node-protocol.js';
+import './App.css';
+import './components/dialogs/DialogShell.css';
+import './components/dialogs/CustomizeSessionDialog.css';
+
+const nativeFetch = window.fetch.bind(window);
+let scenario: 'multi' | 'single' = 'multi';
+let lastCreateRequest = '';
+
+function framework(id: string): FrameworkInfo {
+  return {
+    id,
+    displayName: id,
+    command: id,
+    capabilities: {
+      supportsContinue: true,
+      supportsYolo: true,
+      supportsHooks: true,
+      supportsTelemetry: true,
+      supportsWebSessions: id === 'hermes',
+    },
+    eventSource: 'hooks',
+    availability: { installed: true, path: `/usr/local/bin/${id}` },
+  };
+}
+
+function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
+  return {
+    nodeId: 'local',
+    displayName: 'local mac',
+    hostname: 'local.local',
+    platform: 'darwin',
+    arch: 'arm64',
+    relayVersion: '0.1.0',
+    protocolVersion: '1.0',
+    status: 'online',
+    connection: { route: 'local', status: 'connected' },
+    capabilities: {
+      totals: { available: 10, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        tmux: 'available',
+        git: 'available',
+        worktrees: 'available',
+        browserAutomation: 'available',
+        clipboardImage: 'available',
+        ssh: 'available',
+        tailscale: 'available',
+      },
+      agents: { claude: 'available', codex: 'available' },
+      serviceManager: 'launchd',
+      wsl: false,
+    },
+    createdAt: '2026-05-12T00:00:00.000Z',
+    pairedAt: '2026-05-12T00:00:00.000Z',
+    lastSeenAt: '2026-05-12T00:00:00.000Z',
+    credentialId: 'cred-local',
+    ...overrides,
+  };
+}
+
+function inventory(): AggregatedRepoInventoryResponse {
+  if (scenario === 'single') {
+    return {
+      generatedAt: '2026-05-12T00:00:00.000Z',
+      reports: [],
+      groups: [
+        {
+          groupId: 'github.com/donovan-yohan/relay-ide',
+          repoIdentity: 'github.com/donovan-yohan/relay-ide',
+          displayName: 'relay-ide',
+          selectedRemote: null,
+          remotes: [],
+          warnings: [],
+          identityDebug: {
+            groupedBy: 'repoIdentity',
+            repoIdentity: 'github.com/donovan-yohan/relay-ide',
+            instanceCount: 1,
+            nodeIds: ['local'],
+          },
+          instances: [
+            {
+              repoInstanceId: 'local:%2FUsers%2Fkyle%2Frelay-ide',
+              nodeId: 'local',
+              localPath: '/Users/kyle/relay-ide',
+              name: 'relay-ide',
+              isGitRepo: true,
+              defaultBranch: 'nightly',
+              currentBranch: 'nightly',
+              repoIdentity: 'github.com/donovan-yohan/relay-ide',
+              selectedRemote: null,
+              remotes: [],
+              repoIdentityWarnings: [],
+              worktrees: [],
+              reportedAt: '2026-05-12T00:00:00.000Z',
+            },
+          ],
+        },
+      ],
+    };
+  }
+  return {
+    generatedAt: '2026-05-12T00:00:00.000Z',
+    reports: [],
+    groups: [
+      {
+        groupId: 'github.com/donovan-yohan/relay-ide',
+        repoIdentity: 'github.com/donovan-yohan/relay-ide',
+        displayName: 'relay-ide',
+        selectedRemote: null,
+        remotes: [],
+        warnings: [],
+        identityDebug: {
+          groupedBy: 'repoIdentity',
+          repoIdentity: 'github.com/donovan-yohan/relay-ide',
+          instanceCount: 4,
+          nodeIds: ['local', 'linux', 'no-claude', 'offline'],
+        },
+        instances: [
+          {
+            repoInstanceId: 'linux:%2Fsrv%2Frelay-ide',
+            nodeId: 'linux',
+            localPath: '/srv/relay-ide',
+            name: 'relay-ide',
+            isGitRepo: true,
+            defaultBranch: 'nightly',
+            currentBranch: 'nightly',
+            repoIdentity: 'github.com/donovan-yohan/relay-ide',
+            selectedRemote: null,
+            remotes: [],
+            repoIdentityWarnings: [],
+            worktrees: [
+              {
+                worktreeInstanceId: 'linux:%2Fsrv%2Frelay-ide%2F.worktrees%2Ffeature',
+                localPath: '/srv/relay-ide/.worktrees/feature',
+                branchName: 'feature/linux',
+                displayName: 'feature',
+              },
+            ],
+            reportedAt: '2026-05-12T00:00:00.000Z',
+          },
+          {
+            repoInstanceId: 'local:%2FUsers%2Fkyle%2Frelay-ide',
+            nodeId: 'local',
+            localPath: '/Users/kyle/relay-ide',
+            name: 'relay-ide',
+            isGitRepo: true,
+            defaultBranch: 'nightly',
+            currentBranch: 'nightly',
+            repoIdentity: 'github.com/donovan-yohan/relay-ide',
+            selectedRemote: null,
+            remotes: [],
+            repoIdentityWarnings: [],
+            worktrees: [],
+            reportedAt: '2026-05-12T00:00:00.000Z',
+          },
+          {
+            repoInstanceId: 'offline:%2Foffline%2Frelay-ide',
+            nodeId: 'offline',
+            localPath: '/offline/relay-ide',
+            name: 'relay-ide',
+            isGitRepo: true,
+            defaultBranch: 'nightly',
+            currentBranch: 'nightly',
+            repoIdentity: 'github.com/donovan-yohan/relay-ide',
+            selectedRemote: null,
+            remotes: [],
+            repoIdentityWarnings: [],
+            worktrees: [],
+            reportedAt: '2026-05-12T00:00:00.000Z',
+          },
+          {
+            repoInstanceId: 'no-claude:%2Fno-claude%2Frelay-ide',
+            nodeId: 'no-claude',
+            localPath: '/no-claude/relay-ide',
+            name: 'relay-ide',
+            isGitRepo: true,
+            defaultBranch: 'nightly',
+            currentBranch: 'nightly',
+            repoIdentity: 'github.com/donovan-yohan/relay-ide',
+            selectedRemote: null,
+            remotes: [],
+            repoIdentityWarnings: [],
+            worktrees: [],
+            reportedAt: '2026-05-12T00:00:00.000Z',
+          },
+        ],
+      },
+      {
+        groupId: 'github.com/example/tools',
+        repoIdentity: 'github.com/example/tools',
+        displayName: 'tools',
+        selectedRemote: null,
+        remotes: [],
+        warnings: [],
+        identityDebug: {
+          groupedBy: 'repoIdentity',
+          repoIdentity: 'github.com/example/tools',
+          instanceCount: 1,
+          nodeIds: ['local'],
+        },
+        instances: [
+          {
+            repoInstanceId: 'local:%2FUsers%2Fkyle%2Ftools',
+            nodeId: 'local',
+            localPath: '/Users/kyle/tools',
+            name: 'tools',
+            isGitRepo: true,
+            defaultBranch: 'main',
+            currentBranch: 'main',
+            repoIdentity: 'github.com/example/tools',
+            selectedRemote: null,
+            remotes: [],
+            repoIdentityWarnings: [],
+            worktrees: [],
+            reportedAt: '2026-05-12T00:00:00.000Z',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function nodes(): HubNodeSummary[] {
+  if (scenario === 'single') return [node()];
+  return [
+    node(),
+    node({ nodeId: 'linux', displayName: 'linux lab' }),
+    node({ nodeId: 'offline', displayName: 'offline lab', status: 'offline' }),
+    node({
+      nodeId: 'no-claude',
+      displayName: 'no claude box',
+      capabilities: {
+        ...node().capabilities,
+        agents: { claude: 'unavailable', codex: 'available' },
+      },
+    }),
+  ];
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+window.fetch = async (input, init) => {
+  const url = new URL(String(input), window.location.origin);
+  if (url.pathname === '/hub/repo-inventory') return jsonResponse(inventory());
+  if (url.pathname === '/nodes') return jsonResponse({ nodes: nodes() });
+  if (url.pathname === '/config/defaultContinue') return jsonResponse({ defaultContinue: false });
+  if (url.pathname === '/config/defaultYolo') return jsonResponse({ defaultYolo: false });
+  if (url.pathname === '/config/defaultAgent') return jsonResponse({ defaultAgent: 'claude' });
+  if (url.pathname === '/config/defaultNotifications') return jsonResponse({ defaultNotifications: true });
+  if (url.pathname === '/config/claudeFullscreen') return jsonResponse({ claudeFullscreen: true });
+  if (url.pathname === '/sessions' && init?.method === 'POST') {
+    lastCreateRequest = `${url.pathname} ${init.body ?? ''}`;
+    return jsonResponse({
+      id: 'local-session',
+      type: 'agent',
+      agent: 'claude',
+      repoName: 'relay-ide',
+      repoPath: '/Users/kyle/relay-ide',
+      worktreePath: null,
+      cwd: '/Users/kyle/relay-ide',
+      branchName: 'nightly',
+      displayName: 'default',
+      createdAt: '2026-05-12T00:00:00.000Z',
+      lastActivity: '2026-05-12T00:00:00.000Z',
+      idle: false,
+    });
+  }
+  if (url.pathname === '/hub/nodes/linux/sessions' && init?.method === 'POST') {
+    lastCreateRequest = `${url.pathname} ${init.body ?? ''}`;
+    return jsonResponse({
+      id: 'remote-session',
+      nodeId: 'linux',
+      globalSessionId: 'linux:remote-session',
+      type: 'agent',
+      agent: 'claude',
+      repoName: 'relay-ide',
+      repoPath: '/srv/relay-ide',
+      worktreePath: '/srv/relay-ide/.worktrees/feature',
+      cwd: '/srv/relay-ide/.worktrees/feature',
+      branchName: 'feature/linux',
+      displayName: 'feature/linux',
+      createdAt: '2026-05-12T00:00:00.000Z',
+      lastActivity: '2026-05-12T00:00:00.000Z',
+      idle: false,
+    });
+  }
+  if (url.pathname === '/sessions') return jsonResponse([]);
+  if (url.pathname === '/git/worktrees') return jsonResponse([]);
+  if (url.pathname === '/workspaces') {
+    return jsonResponse({ workspaces: [{ name: 'relay-ide', path: '/Users/kyle/relay-ide', isGitRepo: true, defaultBranch: 'nightly', currentBranch: 'nightly' }] });
+  }
+  if (url.pathname === '/workspace-groups') return jsonResponse([]);
+  return nativeFetch(input, init);
+};
+
+useConfigStore.setState({
+  defaultAgent: 'claude',
+  defaultContinue: false,
+  defaultYolo: false,
+  frameworks: [framework('claude'), framework('codex')],
+});
+
+function Harness() {
+  const dialogRef = useRef<CustomizeSessionDialogHandle>(null);
+  const [createdSession, setCreatedSession] = useState('');
+  return (
+    <div className="test-harness">
+      <button
+        type="button"
+        onClick={() => {
+          scenario = 'multi';
+          void dialogRef.current?.open({ name: 'relay-ide', path: '/Users/kyle/relay-ide' });
+        }}
+      >
+        open customize session
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          scenario = 'single';
+          void dialogRef.current?.open({ name: 'relay-ide', path: '/Users/kyle/relay-ide' });
+        }}
+      >
+        open single-node customize session
+      </button>
+      <output data-testid="created-session">{createdSession}</output>
+      <output data-testid="last-create-request">{lastCreateRequest}</output>
+      <CustomizeSessionDialog ref={dialogRef} onSessionCreated={setCreatedSession} />
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')!).render(
+  <React.StrictMode>
+    <Harness />
+  </React.StrictMode>
+);

--- a/frontend/test-customize-session-dialog.html
+++ b/frontend/test-customize-session-dialog.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CustomizeSessionDialog Test Page</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/test-customize-session-dialog.tsx"></script>
+  </body>
+</html>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,6 +32,10 @@ if (includeE2eFixtures) {
     import.meta.dirname,
     'test-full-page-diff.html'
   );
+  buildInputs['test-customize-session-dialog'] = resolve(
+    import.meta.dirname,
+    'test-customize-session-dialog.html'
+  );
 }
 
 export default defineConfig({

--- a/test/customize-session-dialog.test.ts
+++ b/test/customize-session-dialog.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildEnvironmentPickerModel,
   defaultSessionModeForAgent,
   getSessionModeOptions,
   isFrameworkAvailable,
@@ -8,6 +9,8 @@ import {
   selectLaunchAgent,
 } from '../frontend/src/components/dialogs/CustomizeSessionDialog.js';
 import type { FrameworkInfo } from '../frontend/src/lib/types.js';
+import type { AggregatedRepoInventoryResponse } from '../shared/repo-inventory.js';
+import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
 
 function framework(id: string, installed = true): FrameworkInfo {
   return {
@@ -27,6 +30,141 @@ function framework(id: string, installed = true): FrameworkInfo {
     availability: installed
       ? { installed: true, path: `/usr/local/bin/${id}` }
       : { installed: false, reason: `${id} CLI not found on PATH` },
+  };
+}
+
+function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
+  return {
+    nodeId: 'local',
+    displayName: 'local mac',
+    hostname: 'local.local',
+    platform: 'darwin',
+    arch: 'arm64',
+    relayVersion: '0.1.0',
+    protocolVersion: '1.0',
+    status: 'online',
+    connection: { route: 'local', status: 'connected' },
+    capabilities: {
+      totals: { available: 10, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        tmux: 'available',
+        git: 'available',
+        worktrees: 'available',
+        browserAutomation: 'available',
+        clipboardImage: 'available',
+        ssh: 'available',
+        tailscale: 'available',
+      },
+      agents: { claude: 'available', codex: 'available' },
+      serviceManager: 'launchd',
+      wsl: false,
+    },
+    createdAt: '2026-05-12T00:00:00.000Z',
+    pairedAt: '2026-05-12T00:00:00.000Z',
+    lastSeenAt: '2026-05-12T00:00:00.000Z',
+    credentialId: 'cred-local',
+    ...overrides,
+  };
+}
+
+function inventory(): AggregatedRepoInventoryResponse {
+  return {
+    generatedAt: '2026-05-12T00:00:00.000Z',
+    reports: [],
+    groups: [
+      {
+        groupId: 'github.com/donovan-yohan/relay-ide',
+        repoIdentity: 'github.com/donovan-yohan/relay-ide',
+        displayName: 'relay-ide',
+        selectedRemote: null,
+        remotes: [],
+        warnings: [],
+        identityDebug: {
+          groupedBy: 'repoIdentity',
+          repoIdentity: 'github.com/donovan-yohan/relay-ide',
+          instanceCount: 2,
+          nodeIds: ['local', 'linux'],
+        },
+        instances: [
+          {
+            repoInstanceId: 'linux:%2Fsrv%2Frelay-ide',
+            nodeId: 'linux',
+            localPath: '/srv/relay-ide',
+            name: 'relay-ide',
+            isGitRepo: true,
+            defaultBranch: 'nightly',
+            currentBranch: 'nightly',
+            repoIdentity: 'github.com/donovan-yohan/relay-ide',
+            selectedRemote: null,
+            remotes: [],
+            repoIdentityWarnings: [],
+            worktrees: [
+              {
+                worktreeInstanceId: 'linux:%2Fsrv%2Frelay-ide%2F.worktrees%2Ffeature',
+                localPath: '/srv/relay-ide/.worktrees/feature',
+                branchName: 'feature/linux',
+                displayName: 'feature',
+              },
+            ],
+            reportedAt: '2026-05-12T00:00:00.000Z',
+          },
+          {
+            repoInstanceId: 'local:%2FUsers%2Fkyle%2Frelay-ide',
+            nodeId: 'local',
+            localPath: '/Users/kyle/relay-ide',
+            name: 'relay-ide',
+            isGitRepo: true,
+            defaultBranch: 'nightly',
+            currentBranch: 'nightly',
+            repoIdentity: 'github.com/donovan-yohan/relay-ide',
+            selectedRemote: null,
+            remotes: [],
+            repoIdentityWarnings: [],
+            worktrees: [
+              {
+                worktreeInstanceId: 'local:%2FUsers%2Fkyle%2Frelay-ide%2F.worktrees%2Ffeature',
+                localPath: '/Users/kyle/relay-ide/.worktrees/feature',
+                branchName: 'feature/local',
+                displayName: 'feature',
+              },
+            ],
+            reportedAt: '2026-05-12T00:00:00.000Z',
+          },
+        ],
+      },
+      {
+        groupId: 'github.com/example/tools',
+        repoIdentity: 'github.com/example/tools',
+        displayName: 'tools',
+        selectedRemote: null,
+        remotes: [],
+        warnings: [],
+        identityDebug: {
+          groupedBy: 'repoIdentity',
+          repoIdentity: 'github.com/example/tools',
+          instanceCount: 1,
+          nodeIds: ['local'],
+        },
+        instances: [
+          {
+            repoInstanceId: 'local:%2FUsers%2Fkyle%2Ftools',
+            nodeId: 'local',
+            localPath: '/Users/kyle/tools',
+            name: 'tools',
+            isGitRepo: true,
+            defaultBranch: 'main',
+            currentBranch: 'main',
+            repoIdentity: 'github.com/example/tools',
+            selectedRemote: null,
+            remotes: [],
+            repoIdentityWarnings: [],
+            worktrees: [],
+            reportedAt: '2026-05-12T00:00:00.000Z',
+          },
+        ],
+      },
+    ],
   };
 }
 
@@ -91,5 +229,110 @@ describe('CustomizeSessionDialog session mode options', () => {
     const frameworks = [framework('claude', false), framework('codex', true)];
 
     expect(selectLaunchAgent(frameworks, 'claude')).toBe('codex');
+  });
+});
+
+describe('CustomizeSessionDialog environment picker model', () => {
+  it('keeps single-node local launch low-friction', () => {
+    const model = buildEnvironmentPickerModel({
+      inventory: null,
+      nodes: [],
+      selectedAgent: 'claude',
+      selectedGroupId: null,
+      selectedNodeId: null,
+      selectedCheckoutId: null,
+      fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
+      fallbackWorktreePath: null,
+    });
+
+    expect(model.showPicker).toBe(false);
+    expect(model.resolved).toEqual({
+      nodeId: 'local',
+      repoPath: '/Users/kyle/relay-ide',
+      worktreePath: null,
+    });
+  });
+
+  it('orders repo identity before node and checkout choices for multi-node inventory', () => {
+    const model = buildEnvironmentPickerModel({
+      inventory: inventory(),
+      nodes: [node(), node({ nodeId: 'linux', displayName: 'linux lab' })],
+      selectedAgent: 'claude',
+      selectedGroupId: 'github.com/donovan-yohan/relay-ide',
+      selectedNodeId: 'linux',
+      selectedCheckoutId: 'worktree:linux:%2Fsrv%2Frelay-ide%2F.worktrees%2Ffeature',
+      fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
+      fallbackWorktreePath: null,
+    });
+
+    expect(model.showPicker).toBe(true);
+    expect(model.repoChoices.map((choice) => choice.label)).toEqual([
+      'relay-ide — github.com/donovan-yohan/relay-ide',
+      'tools — github.com/example/tools',
+    ]);
+    expect(model.nodeChoices.map((choice) => choice.label)).toEqual([
+      'linux lab',
+      'local mac',
+    ]);
+    expect(model.checkoutChoices.map((choice) => choice.label)).toEqual([
+      'default — /srv/relay-ide',
+      'feature/linux — /srv/relay-ide/.worktrees/feature',
+    ]);
+    expect(model.resolved).toEqual({
+      nodeId: 'linux',
+      repoPath: '/srv/relay-ide',
+      worktreePath: '/srv/relay-ide/.worktrees/feature',
+    });
+  });
+
+  it('disables offline nodes with a clear reason', () => {
+    const model = buildEnvironmentPickerModel({
+      inventory: inventory(),
+      nodes: [
+        node(),
+        node({ nodeId: 'linux', displayName: 'linux lab', status: 'offline' }),
+      ],
+      selectedAgent: 'claude',
+      selectedGroupId: 'github.com/donovan-yohan/relay-ide',
+      selectedNodeId: 'linux',
+      selectedCheckoutId: null,
+      fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
+      fallbackWorktreePath: null,
+    });
+
+    expect(model.nodeChoices.find((choice) => choice.value === 'linux')).toMatchObject({
+      disabled: true,
+      reason: 'node is offline',
+    });
+    expect(model.resolved.nodeId).toBe('local');
+  });
+
+  it('disables nodes missing the selected agent capability', () => {
+    const model = buildEnvironmentPickerModel({
+      inventory: inventory(),
+      nodes: [
+        node(),
+        node({
+          nodeId: 'linux',
+          displayName: 'linux lab',
+          capabilities: {
+            ...node().capabilities,
+            agents: { claude: 'unavailable' },
+          },
+        }),
+      ],
+      selectedAgent: 'claude',
+      selectedGroupId: 'github.com/donovan-yohan/relay-ide',
+      selectedNodeId: 'linux',
+      selectedCheckoutId: null,
+      fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
+      fallbackWorktreePath: null,
+    });
+
+    expect(model.nodeChoices.find((choice) => choice.value === 'linux')).toMatchObject({
+      disabled: true,
+      reason: 'claude unavailable on linux lab',
+    });
+    expect(model.resolved.nodeId).toBe('local');
   });
 });

--- a/test/customize-session-dialog.test.ts
+++ b/test/customize-session-dialog.test.ts
@@ -335,4 +335,92 @@ describe('CustomizeSessionDialog environment picker model', () => {
     });
     expect(model.resolved.nodeId).toBe('local');
   });
+
+  it('keeps all same-node repo instance checkouts selectable', () => {
+    const repoInventory = inventory();
+    const relayGroup = repoInventory.groups[0]!;
+    relayGroup.instances.push({
+      repoInstanceId: 'local:%2FUsers%2Fkyle%2Frelay-ide-copy',
+      nodeId: 'local',
+      localPath: '/Users/kyle/relay-ide-copy',
+      name: 'relay-ide-copy',
+      isGitRepo: true,
+      defaultBranch: 'nightly',
+      currentBranch: 'feature/copy',
+      repoIdentity: 'github.com/donovan-yohan/relay-ide',
+      selectedRemote: null,
+      remotes: [],
+      repoIdentityWarnings: [],
+      worktrees: [
+        {
+          worktreeInstanceId:
+            'local:%2FUsers%2Fkyle%2Frelay-ide-copy%2F.worktrees%2Fcopy-feature',
+          localPath: '/Users/kyle/relay-ide-copy/.worktrees/copy-feature',
+          branchName: 'feature/copy-worktree',
+          displayName: 'copy-feature',
+        },
+      ],
+      reportedAt: '2026-05-12T00:00:00.000Z',
+    });
+
+    const model = buildEnvironmentPickerModel({
+      inventory: repoInventory,
+      nodes: [node(), node({ nodeId: 'linux', displayName: 'linux lab' })],
+      selectedAgent: 'claude',
+      selectedGroupId: 'github.com/donovan-yohan/relay-ide',
+      selectedNodeId: 'local',
+      selectedCheckoutId:
+        'worktree:local:%2FUsers%2Fkyle%2Frelay-ide-copy%2F.worktrees%2Fcopy-feature',
+      fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
+      fallbackWorktreePath: null,
+    });
+
+    expect(model.nodeChoices.filter((choice) => choice.value === 'local')).toHaveLength(1);
+    expect(model.checkoutChoices.map((choice) => choice.label)).toEqual([
+      'default — /Users/kyle/relay-ide',
+      'feature/local — /Users/kyle/relay-ide/.worktrees/feature',
+      'default — /Users/kyle/relay-ide-copy',
+      'feature/copy-worktree — /Users/kyle/relay-ide-copy/.worktrees/copy-feature',
+    ]);
+    expect(model.resolved).toEqual({
+      nodeId: 'local',
+      repoPath: '/Users/kyle/relay-ide-copy',
+      worktreePath: '/Users/kyle/relay-ide-copy/.worktrees/copy-feature',
+    });
+  });
+
+  it.each(['degraded', 'unavailable', 'unknown'] as const)(
+    'disables nodes when tmux is %s',
+    (tmuxStatus) => {
+      const model = buildEnvironmentPickerModel({
+        inventory: inventory(),
+        nodes: [
+          node(),
+          node({
+            nodeId: 'linux',
+            displayName: 'linux lab',
+            capabilities: {
+              ...node().capabilities,
+              core: {
+                ...node().capabilities.core,
+                tmux: tmuxStatus,
+              },
+            },
+          }),
+        ],
+        selectedAgent: 'claude',
+        selectedGroupId: 'github.com/donovan-yohan/relay-ide',
+        selectedNodeId: 'linux',
+        selectedCheckoutId: null,
+        fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
+        fallbackWorktreePath: null,
+      });
+
+      expect(model.nodeChoices.find((choice) => choice.value === 'linux')).toMatchObject({
+        disabled: true,
+        reason: `tmux ${tmuxStatus} on linux lab`,
+      });
+      expect(model.resolved.nodeId).toBe('local');
+    }
+  );
 });

--- a/test/customize-session-dialog.test.ts
+++ b/test/customize-session-dialog.test.ts
@@ -253,6 +253,45 @@ describe('CustomizeSessionDialog environment picker model', () => {
     });
   });
 
+  it('shows a picker reason when the only selected node is disabled', () => {
+    const repoInventory = inventory();
+    repoInventory.groups = [
+      {
+        ...repoInventory.groups[0]!,
+        identityDebug: {
+          ...repoInventory.groups[0]!.identityDebug,
+          instanceCount: 1,
+          nodeIds: ['local'],
+        },
+        instances: [
+          {
+            ...repoInventory.groups[0]!.instances[1]!,
+            worktrees: [],
+          },
+        ],
+      },
+    ];
+
+    const model = buildEnvironmentPickerModel({
+      inventory: repoInventory,
+      nodes: [node({ status: 'offline' })],
+      selectedAgent: 'claude',
+      selectedGroupId: 'github.com/donovan-yohan/relay-ide',
+      selectedNodeId: 'local',
+      selectedCheckoutId: null,
+      fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
+      fallbackWorktreePath: null,
+    });
+
+    expect(model.showPicker).toBe(true);
+    expect(model.selectedNodeReason).toBe('node is offline');
+    expect(model.nodeChoices).toHaveLength(1);
+    expect(model.nodeChoices[0]).toMatchObject({
+      disabled: true,
+      reason: 'node is offline',
+    });
+  });
+
   it('orders repo identity before node and checkout choices for multi-node inventory', () => {
     const model = buildEnvironmentPickerModel({
       inventory: inventory(),

--- a/test/e2e/components/CustomizeSessionDialog.spec.ts
+++ b/test/e2e/components/CustomizeSessionDialog.spec.ts
@@ -56,6 +56,10 @@ test.describe('CustomizeSessionDialog', () => {
     await expect(nodeOptions.filter({ hasText: 'no claude box' })).toContainText(
       'claude unavailable on no claude box'
     );
+    await expect(nodeOptions.filter({ hasText: 'no tmux box' })).toBeDisabled();
+    await expect(nodeOptions.filter({ hasText: 'no tmux box' })).toContainText(
+      'tmux unavailable on no tmux box'
+    );
   });
 
   test('keeps the single-node local path low-friction', async ({ page }) => {

--- a/test/e2e/components/CustomizeSessionDialog.spec.ts
+++ b/test/e2e/components/CustomizeSessionDialog.spec.ts
@@ -5,20 +5,70 @@ test.describe('CustomizeSessionDialog', () => {
     await page.goto('/test-customize-session-dialog.html');
   });
 
-  test('opens with agent select and session option checkboxes', async ({
-    page,
-  }) => {
-    await page.getByText('Open Customize Session').click();
+  test('opens with environment picker and session options', async ({ page }) => {
+    await page.getByText('open customize session').click();
     await expect(page.getByRole('dialog')).toBeVisible();
-    await expect(page.getByText('Customize Session')).toBeVisible();
-    await expect(page.getByLabel('Coding agent')).toBeVisible();
-    await expect(page.getByText('Continue existing session')).toBeVisible();
-    await expect(page.getByText('Yolo mode')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Customize Session' })).toBeVisible();
+    await expect(page.getByLabel('repo identity')).toBeVisible();
+    await expect(page.getByLabel('execution node')).toBeVisible();
+    await expect(page.getByLabel('node-local checkout')).toBeVisible();
+    await expect(page.getByLabel('coding agent')).toBeVisible();
+    await expect(page.getByText('continue existing session')).toBeVisible();
+    await expect(page.getByText('yolo mode')).toBeVisible();
     await expect(page.getByText('Launch in tmux')).toHaveCount(0);
   });
 
+  test('routes a multi-node checkout launch through the selected node', async ({
+    page,
+  }) => {
+    await page.getByText('open customize session').click();
+    await page.getByLabel('execution node').selectOption('linux');
+    await page
+      .getByLabel('node-local checkout')
+      .selectOption('worktree:linux:%2Fsrv%2Frelay-ide%2F.worktrees%2Ffeature');
+    await page.getByRole('button', { name: 'Start Session' }).click();
+
+    await expect(page.getByTestId('created-session')).toHaveText(
+      'remote-session'
+    );
+    await expect(page.getByTestId('last-create-request')).toContainText(
+      '/hub/nodes/linux/sessions'
+    );
+    await expect(page.getByTestId('last-create-request')).toContainText(
+      '"repoPath":"/srv/relay-ide"'
+    );
+    await expect(page.getByTestId('last-create-request')).toContainText(
+      '"worktreePath":"/srv/relay-ide/.worktrees/feature"'
+    );
+  });
+
+  test('shows disabled reasons for offline and capability-blocked nodes', async ({
+    page,
+  }) => {
+    await page.getByText('open customize session').click();
+    const nodeOptions = page.locator('#cs-node option');
+
+    await expect(nodeOptions.filter({ hasText: 'offline lab' })).toBeDisabled();
+    await expect(nodeOptions.filter({ hasText: 'offline lab' })).toContainText(
+      'node is offline'
+    );
+    await expect(nodeOptions.filter({ hasText: 'no claude box' })).toBeDisabled();
+    await expect(nodeOptions.filter({ hasText: 'no claude box' })).toContainText(
+      'claude unavailable on no claude box'
+    );
+  });
+
+  test('keeps the single-node local path low-friction', async ({ page }) => {
+    await page.getByText('open single-node customize session').click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(page.getByLabel('repo identity')).toHaveCount(0);
+    await expect(page.getByLabel('execution node')).toHaveCount(0);
+    await expect(page.getByLabel('node-local checkout')).toHaveCount(0);
+    await expect(page.getByLabel('coding agent')).toBeVisible();
+  });
+
   test('has Start Session and Cancel buttons', async ({ page }) => {
-    await page.getByText('Open Customize Session').click();
+    await page.getByText('open customize session').click();
     await expect(
       page.getByRole('button', { name: 'Start Session' })
     ).toBeVisible();
@@ -26,7 +76,7 @@ test.describe('CustomizeSessionDialog', () => {
   });
 
   test('screenshot', async ({ page }) => {
-    await page.getByText('Open Customize Session').click();
+    await page.getByText('open customize session').click();
     await page.screenshot({
       path: 'test/e2e/screenshots/customize-session-dialog.png',
     });

--- a/test/e2e/components/CustomizeSessionDialog.spec.ts
+++ b/test/e2e/components/CustomizeSessionDialog.spec.ts
@@ -71,6 +71,18 @@ test.describe('CustomizeSessionDialog', () => {
     await expect(page.getByLabel('coding agent')).toBeVisible();
   });
 
+  test('shows the disabled-node reason when the single-node picker is otherwise hidden', async ({
+    page,
+  }) => {
+    await page.getByText('open single disabled-node customize session').click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(page.getByLabel('repo identity')).toHaveCount(0);
+    await expect(page.getByLabel('execution node')).toBeVisible();
+    await expect(page.getByText('node is offline', { exact: true })).toBeVisible();
+    await expect(page.getByLabel('node-local checkout')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Start Session' })).toBeDisabled();
+  });
+
   test('has Start Session and Cancel buttons', async ({ page }) => {
     await page.getByText('open customize session').click();
     await expect(


### PR DESCRIPTION
## Summary
- add the customize-session environment picker for repo identity -> execution node -> node-local checkout/worktree selection
- route remote node launches through `/hub/nodes/:nodeId/sessions` while preserving the single-node local fast path
- add Vitest model coverage and Playwright fixture coverage for multi-node, disabled node, capability-disabled, single-node, and launch-routing behavior

## Verification
- `export NVM_DIR=/Users/donovanyohan/.nvm; source "$NVM_DIR/nvm.sh" && nvm use`
- `rtk npm run check`
- `rtk npm run build`
- `rtk npm test -- test/customize-session-dialog.test.ts test/action-coverage.test.ts`
- `launchctl bootout gui/$(id -u)/com.relay-ide 2>/dev/null || true; rtk npm run test:e2e -- test/e2e/components/CustomizeSessionDialog.spec.ts`

Refs #317.
Closes #389.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment picker in Customize Session dialog to choose repo identity, execution node, and node-local checkout; unavailable options show explicit reasons and can disable Start Session.
* **Style**
  * Added styling for the session environment picker and muted copy text.
* **Tests**
  * New unit and end-to-end tests covering picker behavior, resolution logic, and disabled-reason messaging.
* **Chores**
  * Added a test harness page/module and build entry for E2E/test harness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/407)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->