### PR TITLE
fix: harden customize dialog open races

### DIFF
--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -713,6 +713,7 @@ function CustomizeSessionBody({
 const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
   function CustomizeSessionDialog({ onSessionCreated }, ref) {
     const shellRef = useRef<DialogShellHandle>(null);
+    const openRequestIdRef = useRef(0);
     const [workspacePath, setWorkspacePath] = useState('');
     const [worktreePath, setWorktreePath] = useState<string | null>(null);
     const [workspaceName, setWorkspaceName] = useState('');
@@ -761,6 +762,7 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
         nextWorktreePath?: string | null,
         preselectedFramework?: AgentType
       ) {
+        const requestId = ++openRequestIdRef.current;
         setError(null);
         setForm(defaultForm());
         setInventory(null);
@@ -777,7 +779,9 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
           fetchRepoInventory(),
           fetchHubNodes(),
         ]);
+        if (requestId !== openRequestIdRef.current) return;
         await useConfigStore.getState().refreshConfig();
+        if (requestId !== openRequestIdRef.current) return;
         if (inventoryResult.status === 'fulfilled') {
           setInventory(inventoryResult.value);
         }

--- a/test/customize-session-dialog-open-race.test.ts
+++ b/test/customize-session-dialog-open-race.test.ts
@@ -1,0 +1,277 @@
+// @vitest-environment happy-dom
+
+import React, { act, createRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import type { FrameworkInfo } from '../frontend/src/lib/types.js';
+import type { CustomizeSessionDialogHandle } from '../frontend/src/components/dialogs/CustomizeSessionDialog.js';
+import type { AggregatedRepoInventoryResponse } from '../shared/repo-inventory.js';
+import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
+
+const mocks = vi.hoisted(() => ({
+  fetchRepoInventory: vi.fn(),
+  fetchHubNodes: vi.fn(),
+  configState: {
+    defaultContinue: false,
+    defaultYolo: false,
+    defaultAgent: 'claude',
+    defaultNotifications: true,
+    claudeFullscreen: true,
+    frameworks: [] as FrameworkInfo[],
+    refreshConfig: vi.fn(),
+    loadFrameworks: vi.fn(),
+  },
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../frontend/src/lib/api.js', () => ({
+  fetchRepoInventory: mocks.fetchRepoInventory,
+  fetchHubNodes: mocks.fetchHubNodes,
+}));
+
+vi.mock('../frontend/src/lib/stores/config.js', () => {
+  const useConfigStore = (
+    selector: (state: typeof mocks.configState) => unknown
+  ) => selector(mocks.configState);
+  useConfigStore.getState = () => mocks.configState;
+  return { useConfigStore };
+});
+
+vi.mock('../frontend/src/lib/stores/ui.js', () => ({
+  useUiStore: {
+    getState: () => ({ terminalFontSize: 14 }),
+  },
+}));
+
+vi.mock('../frontend/src/lib/session-utils.js', () => ({
+  createAgentSession: vi.fn(),
+}));
+
+vi.mock('../frontend/src/components/dialogs/DialogShell.js', async () => {
+  const ReactModule = await import('react');
+  type DialogShellHandle = { open: () => void; close: () => void };
+  interface MockDialogShellProps {
+    title: string;
+    children: ReactModule.ReactNode;
+    footer?: ReactModule.ReactNode;
+  }
+  const DialogShell = ReactModule.forwardRef<
+    DialogShellHandle,
+    MockDialogShellProps
+  >(function MockDialogShell({ title, children, footer }, ref) {
+    const [open, setOpen] = ReactModule.useState(false);
+    ReactModule.useImperativeHandle(ref, () => ({
+      open: () => setOpen(true),
+      close: () => setOpen(false),
+    }));
+    return ReactModule.createElement(
+      'div',
+      { role: 'dialog', 'aria-label': title, 'data-open': String(open) },
+      open
+        ? ReactModule.createElement(
+            ReactModule.Fragment,
+            null,
+            children,
+            footer
+          )
+        : null
+    );
+  });
+  return { default: DialogShell };
+});
+
+const { default: CustomizeSessionDialog } =
+  await import('../frontend/src/components/dialogs/CustomizeSessionDialog.js');
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function framework(id: string): FrameworkInfo {
+  return {
+    id,
+    displayName: id,
+    command: id,
+    capabilities: {
+      supportsContinue: true,
+      supportsYolo: true,
+      supportsHooks: true,
+      supportsTelemetry: false,
+      supportsWebSessions: false,
+    },
+    eventSource: 'hooks',
+    availability: { installed: true, path: `/usr/local/bin/${id}` },
+  };
+}
+
+function node(): HubNodeSummary {
+  return {
+    nodeId: 'local',
+    displayName: 'local mac',
+    hostname: 'local.local',
+    platform: 'darwin',
+    arch: 'arm64',
+    relayVersion: '0.1.0',
+    protocolVersion: '1.0',
+    status: 'online',
+    connection: { route: 'local', status: 'connected' },
+    capabilities: {
+      totals: { available: 10, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        tmux: 'available',
+        git: 'available',
+        worktrees: 'available',
+        browserAutomation: 'available',
+        clipboardImage: 'available',
+        ssh: 'available',
+        tailscale: 'available',
+      },
+      agents: { claude: 'available' },
+      serviceManager: 'launchd',
+      wsl: false,
+    },
+    createdAt: '2026-05-12T00:00:00.000Z',
+    pairedAt: '2026-05-12T00:00:00.000Z',
+    lastSeenAt: '2026-05-12T00:00:00.000Z',
+    credentialId: 'cred-local',
+  };
+}
+
+function inventory(prefix: string): AggregatedRepoInventoryResponse {
+  return {
+    generatedAt: '2026-05-12T00:00:00.000Z',
+    reports: [],
+    groups: ['one', 'two'].map((suffix, index) => ({
+      groupId: `${prefix}-${suffix}`,
+      repoIdentity: `github.com/example/${prefix}-${suffix}`,
+      displayName: `${prefix}-${suffix}`,
+      selectedRemote: null,
+      remotes: [],
+      warnings: [],
+      identityDebug: {
+        groupedBy: 'repoIdentity',
+        repoIdentity: `github.com/example/${prefix}-${suffix}`,
+        instanceCount: 1,
+        nodeIds: ['local'],
+      },
+      instances: [
+        {
+          repoInstanceId: `local:%2Ftmp%2F${prefix}-${suffix}`,
+          nodeId: 'local',
+          localPath: `/tmp/${prefix}-${suffix}`,
+          name: `${prefix}-${suffix}`,
+          isGitRepo: true,
+          defaultBranch: 'nightly',
+          currentBranch: index === 0 ? 'nightly' : 'feature',
+          repoIdentity: `github.com/example/${prefix}-${suffix}`,
+          selectedRemote: null,
+          remotes: [],
+          repoIdentityWarnings: [],
+          worktrees: [],
+          reportedAt: '2026-05-12T00:00:00.000Z',
+        },
+      ],
+    })),
+  };
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('CustomizeSessionDialog open races', () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container?.remove();
+    container = null;
+    root = null;
+    vi.clearAllMocks();
+    mocks.configState.defaultContinue = false;
+    mocks.configState.defaultYolo = false;
+    mocks.configState.defaultAgent = 'claude';
+    mocks.configState.frameworks = [framework('claude')];
+  });
+
+  it('ignores stale inventory and config from an earlier overlapping open call', async () => {
+    mocks.configState.frameworks = [framework('claude')];
+    const firstInventory = deferred<AggregatedRepoInventoryResponse>();
+    const secondInventory = deferred<AggregatedRepoInventoryResponse>();
+    const firstNodes = deferred<HubNodeSummary[]>();
+    const secondNodes = deferred<HubNodeSummary[]>();
+    mocks.fetchRepoInventory
+      .mockReturnValueOnce(firstInventory.promise)
+      .mockReturnValueOnce(secondInventory.promise);
+    mocks.fetchHubNodes
+      .mockReturnValueOnce(firstNodes.promise)
+      .mockReturnValueOnce(secondNodes.promise);
+    mocks.configState.refreshConfig.mockResolvedValue(undefined);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    const ref = createRef<CustomizeSessionDialogHandle>();
+
+    await act(async () => {
+      root!.render(React.createElement(CustomizeSessionDialog, { ref }));
+    });
+
+    let firstOpen!: Promise<void>;
+    let secondOpen!: Promise<void>;
+    await act(async () => {
+      firstOpen = ref.current!.open({
+        name: 'stale workspace',
+        path: '/tmp/stale',
+      });
+      secondOpen = ref.current!.open({
+        name: 'latest workspace',
+        path: '/tmp/latest',
+      });
+    });
+
+    await act(async () => {
+      secondInventory.resolve(inventory('latest'));
+      secondNodes.resolve([node()]);
+      await secondOpen;
+    });
+    await flush();
+
+    expect(container.textContent).toContain('latest workspace');
+    expect(container.textContent).toContain(
+      'latest-one — github.com/example/latest-one'
+    );
+    expect(container.textContent).not.toContain(
+      'stale-one — github.com/example/stale-one'
+    );
+
+    await act(async () => {
+      firstInventory.resolve(inventory('stale'));
+      firstNodes.resolve([node()]);
+      await firstOpen;
+    });
+    await flush();
+
+    expect(container.textContent).toContain('latest workspace');
+    expect(container.textContent).toContain(
+      'latest-one — github.com/example/latest-one'
+    );
+    expect(container.textContent).not.toContain(
+      'stale-one — github.com/example/stale-one'
+    );
+  });
+});


### PR DESCRIPTION
## summary
- adds a request-id guard to `CustomizeSessionDialog.open()` so stale overlapping opens return before applying inventory, node, config, or form state
- adds happy-dom coverage that resolves the newer open first, then proves the older async result cannot overwrite the latest dialog state

## context
follow-up hardening for the non-blocking PR #407 review note about concurrent `open()` races. refs #317.

## verification
- `npx vitest run test/customize-session-dialog.test.ts test/customize-session-dialog-open-race.test.ts`
- `npm run build`

## risks
- low: stale opens now no-op after a newer open starts; normal single-open behavior is unchanged because its request id remains current


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition in the session customization dialog that could display outdated workspace entries when opened multiple times in rapid succession, ensuring only the latest selection is shown.

* **Tests**
  * Added test coverage to verify the dialog properly handles rapid sequential openings, ignores stale data, and only applies the most recent results.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/408)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/408)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->