### PR TITLE
Add cold reopen handoff route

### DIFF
--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -230,7 +230,7 @@ function sourceCheckoutLookup(source: Record<string, unknown>): SourceCheckoutLo
     ...(repoIdentity ? { repoIdentity } : {}),
     ...(branchName ? { branchName } : {}),
   };
-  return nodeId || repoInstanceId || worktreeInstanceId || repoPath || worktreePath ? lookup : null;
+  return Object.keys(lookup).length > 0 ? lookup : null;
 }
 
 function matchingWorktree(

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -630,13 +630,17 @@ export function createHubNodeRouter(options: HubNodeRouterOptions): express.Rout
     }
 
     const body = bodyRecord(req);
-    const target = findColdReopenTarget(registry.listRepoInventoryReports(), nodeId, body);
-    if ('code' in target) {
-      sendRelayError(res, target);
-      return;
-    }
-
     try {
+      const reports = [...registry.listRepoInventoryReports()];
+      if (options.collectLocalRepoInventory) {
+        reports.push(await options.collectLocalRepoInventory());
+      }
+      const target = findColdReopenTarget(reports, nodeId, body);
+      if ('code' in target) {
+        sendRelayError(res, target);
+        return;
+      }
+
       const sessionPayload = coldReopenSessionPayload(body, target);
       const payload = await options.nodeLinks.request(nodeId, 'sessions.create', sessionPayload);
       const session = scopedNodeSession(nodeId, sessionFromPayload(payload));

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -4,7 +4,11 @@ import { isNodeManifest, type NodeManifest } from '../shared/node-manifest.js';
 import {
   aggregateRepoInventoryReports,
   isRepoInventoryReport,
+  type RepoInventoryDirtySummary,
+  type RepoInventoryDivergenceSummary,
+  type RepoInventoryRepoInstance,
   type RepoInventoryReport,
+  type RepoInventoryWorktreeInstance,
 } from '../shared/repo-inventory.js';
 import { HubNodeRegistryError, type HubNodeRegistry } from './hub-node-registry.js';
 import {
@@ -67,8 +71,13 @@ function sendRegistryError(
   res.status(errorStatus(body.error)).json(body);
 }
 
-function relayError(code: RelayNodeError['code'], message: string, retryable = false): RelayNodeError {
-  return { code, message, retryable };
+function relayError(
+  code: RelayNodeError['code'],
+  message: string,
+  retryable = false,
+  details?: Record<string, unknown>
+): RelayNodeError {
+  return { code, message, retryable, ...(details ? { details } : {}) };
 }
 
 function sendRelayError(res: Response, error: RelayNodeError): void {
@@ -131,6 +140,262 @@ function bodyRecord(req: Request): Record<string, unknown> {
   return typeof req.body === 'object' && req.body !== null
     ? (req.body as Record<string, unknown>)
     : {};
+}
+
+interface ColdReopenWarning {
+  code:
+    | 'source-dirty-checkout'
+    | 'source-diverged-checkout'
+    | 'target-dirty-checkout'
+    | 'target-diverged-checkout';
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+interface ColdReopenTarget {
+  repo: RepoInventoryRepoInstance;
+  worktree: RepoInventoryWorktreeInstance | null;
+  branchName: string | null;
+  warnings: ColdReopenWarning[];
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function recordField(record: Record<string, unknown>, key: string): Record<string, unknown> {
+  const value = record[key];
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function dirtyCount(dirty: RepoInventoryDirtySummary | null | undefined): number {
+  if (!dirty) return 0;
+  return dirty.stagedCount + dirty.unstagedCount + dirty.untrackedCount + dirty.conflictedCount;
+}
+
+function isDiverged(divergence: RepoInventoryDivergenceSummary | null | undefined): boolean {
+  if (!divergence) return false;
+  return divergence.aheadCount > 0 || divergence.behindCount > 0;
+}
+
+function checkoutWarnings(
+  scope: 'source' | 'target',
+  checkout: RepoInventoryRepoInstance | RepoInventoryWorktreeInstance
+): ColdReopenWarning[] {
+  const warnings: ColdReopenWarning[] = [];
+  if (dirtyCount(checkout.dirty) > 0) {
+    warnings.push({
+      code: `${scope}-dirty-checkout`,
+      message: `${scope} checkout has uncommitted changes; cold reopen uses git/worktree state and will not migrate live process state`,
+      details: { dirty: checkout.dirty },
+    });
+  }
+  if (isDiverged(checkout.divergence)) {
+    warnings.push({
+      code: `${scope}-diverged-checkout`,
+      message: `${scope} checkout is ahead or behind its upstream; push/fetch before relying on this reopened session`,
+      details: { divergence: checkout.divergence },
+    });
+  }
+  return warnings;
+}
+
+interface SourceCheckoutLookup {
+  nodeId?: string;
+  repoInstanceId?: string;
+  worktreeInstanceId?: string;
+  repoPath?: string;
+  worktreePath?: string;
+  repoIdentity?: string;
+  branchName?: string;
+}
+
+function sourceCheckoutLookup(source: Record<string, unknown>): SourceCheckoutLookup | null {
+  const nodeId = stringField(source, 'nodeId');
+  const repoInstanceId = stringField(source, 'repoInstanceId');
+  const worktreeInstanceId = stringField(source, 'worktreeInstanceId');
+  const repoPath = stringField(source, 'repoPath');
+  const worktreePath = stringField(source, 'worktreePath');
+  const repoIdentity = stringField(source, 'repoIdentity');
+  const branchName = stringField(source, 'branchName');
+  const lookup: SourceCheckoutLookup = {
+    ...(nodeId ? { nodeId } : {}),
+    ...(repoInstanceId ? { repoInstanceId } : {}),
+    ...(worktreeInstanceId ? { worktreeInstanceId } : {}),
+    ...(repoPath ? { repoPath } : {}),
+    ...(worktreePath ? { worktreePath } : {}),
+    ...(repoIdentity ? { repoIdentity } : {}),
+    ...(branchName ? { branchName } : {}),
+  };
+  return nodeId || repoInstanceId || worktreeInstanceId || repoPath || worktreePath ? lookup : null;
+}
+
+function matchingWorktree(
+  repo: RepoInventoryRepoInstance,
+  lookup: SourceCheckoutLookup
+): RepoInventoryWorktreeInstance | undefined {
+  return repo.worktrees.find(
+    (candidate) =>
+      candidate.worktreeInstanceId === lookup.worktreeInstanceId ||
+      candidate.localPath === lookup.worktreePath
+  );
+}
+
+function matchingRepoCheckout(
+  repo: RepoInventoryRepoInstance,
+  lookup: SourceCheckoutLookup
+): RepoInventoryRepoInstance | RepoInventoryWorktreeInstance | null {
+  const worktree = matchingWorktree(repo, lookup);
+  if (worktree) return worktree;
+  if (lookup.repoInstanceId && repo.repoInstanceId === lookup.repoInstanceId) return repo;
+  if (lookup.repoPath && repo.localPath === lookup.repoPath) return repo;
+  if (lookup.repoIdentity && repo.repoIdentity === lookup.repoIdentity) {
+    return lookup.branchName
+      ? (repo.worktrees.find((candidate) => candidate.branchName === lookup.branchName) ?? repo)
+      : repo;
+  }
+  return null;
+}
+
+function findSourceCheckout(
+  reports: RepoInventoryReport[],
+  source: Record<string, unknown>
+): RepoInventoryRepoInstance | RepoInventoryWorktreeInstance | null {
+  const lookup = sourceCheckoutLookup(source);
+  if (!lookup) return null;
+
+  for (const report of reports) {
+    if (lookup.nodeId && report.nodeId !== lookup.nodeId) continue;
+    for (const repo of report.repos) {
+      const checkout = matchingRepoCheckout(repo, lookup);
+      if (checkout) return checkout;
+    }
+  }
+  return null;
+}
+
+function findColdReopenTarget(
+  reports: RepoInventoryReport[],
+  nodeId: string,
+  body: Record<string, unknown>
+): ColdReopenTarget | RelayNodeError {
+  const source = recordField(body, 'source');
+  const target = recordField(body, 'target');
+  const repoIdentity =
+    stringField(body, 'repoIdentity') ??
+    stringField(source, 'repoIdentity') ??
+    stringField(target, 'repoIdentity');
+  const branchName =
+    stringField(body, 'branchName') ??
+    stringField(source, 'branchName') ??
+    stringField(target, 'branchName') ??
+    null;
+  const targetRepoInstanceId = stringField(target, 'repoInstanceId');
+  const targetWorktreeInstanceId = stringField(target, 'worktreeInstanceId');
+  const targetRepoPath = stringField(target, 'repoPath');
+  const targetWorktreePath = stringField(target, 'worktreePath');
+
+  if (!repoIdentity && !targetRepoInstanceId && !targetRepoPath) {
+    return relayError(
+      'INVALID_REQUEST',
+      'source.repoIdentity or target.repoInstanceId is required for cold reopen'
+    );
+  }
+
+  const report = reports.find((candidate) => candidate.nodeId === nodeId);
+  if (!report) {
+    return relayError('NOT_FOUND', 'target node has not reported repo inventory', false, {
+      suggestedAction: 'pair-node-heartbeat-with-repo-inventory',
+      repoIdentity: repoIdentity ?? null,
+      targetNodeId: nodeId,
+    });
+  }
+
+  const repo = report.repos.find((candidate) => {
+    if (targetRepoInstanceId) return candidate.repoInstanceId === targetRepoInstanceId;
+    if (targetRepoPath) return candidate.localPath === targetRepoPath;
+    return candidate.repoIdentity === repoIdentity;
+  });
+
+  if (!repo) {
+    return relayError('NOT_FOUND', 'target node does not have this repository checkout', false, {
+      suggestedAction: 'clone-or-add-worktree',
+      repoIdentity: repoIdentity ?? null,
+      targetNodeId: nodeId,
+    });
+  }
+
+  const worktree =
+    repo.worktrees.find((candidate) => {
+      if (targetWorktreeInstanceId) return candidate.worktreeInstanceId === targetWorktreeInstanceId;
+      if (targetWorktreePath) return candidate.localPath === targetWorktreePath;
+      return branchName ? candidate.branchName === branchName : false;
+    }) ?? null;
+  const repoMatchesRequestedBranch = branchName !== null && repo.currentBranch === branchName;
+  if ((targetWorktreeInstanceId || targetWorktreePath || branchName) && !worktree && !repoMatchesRequestedBranch) {
+    return relayError('NOT_FOUND', 'target node does not have this branch/worktree checkout', false, {
+      suggestedAction: 'add-worktree-or-checkout-branch',
+      repoIdentity: repo.repoIdentity,
+      branchName,
+      targetNodeId: nodeId,
+    });
+  }
+
+  const sourceCheckout = findSourceCheckout(reports, source);
+  const warnings = [
+    ...(sourceCheckout ? checkoutWarnings('source', sourceCheckout) : []),
+    ...checkoutWarnings('target', worktree ?? repo),
+  ];
+
+  return { repo, worktree, branchName: worktree?.branchName ?? branchName, warnings };
+}
+
+function coldReopenPrompt(input: {
+  source: Record<string, unknown>;
+  target: ColdReopenTarget;
+  existingPrompt?: string;
+}): string {
+  const lines = [
+    'cold reopen handoff: this starts/reopens work on this node from git/worktree state. it is not a live tmux/PTY migration and no running process state was transferred.',
+    `target repo: ${input.target.repo.localPath}`,
+    ...(input.target.worktree ? [`target worktree: ${input.target.worktree.localPath}`] : []),
+    ...(input.target.branchName ? [`branch: ${input.target.branchName}`] : []),
+  ];
+  const sourceSessionId = stringField(input.source, 'sessionId');
+  if (sourceSessionId) lines.push(`source session: ${sourceSessionId}`);
+  if (input.target.warnings.length > 0) {
+    lines.push('warnings:');
+    for (const warning of input.target.warnings) lines.push(`- ${warning.message}`);
+  }
+  const handoff = lines.join('\n');
+  return input.existingPrompt ? `${input.existingPrompt}\n\n${handoff}` : handoff;
+}
+
+function coldReopenSessionPayload(
+  body: Record<string, unknown>,
+  target: ColdReopenTarget
+): Record<string, unknown> {
+  const source = recordField(body, 'source');
+  const payload = { ...body };
+  delete payload['source'];
+  delete payload['target'];
+  delete payload['repoIdentity'];
+  delete payload['sourceSession'];
+  payload['type'] = typeof payload['type'] === 'string' ? payload['type'] : 'agent';
+  payload['repoPath'] = target.repo.localPath;
+  payload['worktreePath'] = target.worktree?.localPath ?? null;
+  if (target.branchName) payload['branchName'] = target.branchName;
+  if (payload['continue'] === undefined) payload['continue'] = false;
+  const existingPrompt = typeof body['initialPrompt'] === 'string' ? body['initialPrompt'] : undefined;
+  payload['initialPrompt'] = coldReopenPrompt({
+    source,
+    target,
+    ...(existingPrompt !== undefined ? { existingPrompt } : {}),
+  });
+  return payload;
 }
 
 function manifestFromBody(body: Record<string, unknown>, required = false): NodeManifest | null {
@@ -322,6 +587,85 @@ export function createHubNodeRouter(options: HubNodeRouterOptions): express.Rout
       }
       res.json(aggregateRepoInventoryReports(reports));
     } catch (error) {
+      sendRegistryError(registry, res, error);
+    }
+  });
+
+  router.post('/hub/nodes/:nodeId/sessions/reopen', requireAuth, async (req, res) => {
+    const { nodeId } = req.params;
+    if (!nodeId) {
+      sendRelayError(res, relayError('INVALID_REQUEST', 'nodeId is required'));
+      return;
+    }
+    const node = registry.listNodes().find((candidate) => candidate.nodeId === nodeId);
+    if (!node || node.status === 'revoked') {
+      sendRelayError(res, relayError('NOT_FOUND', 'node is not paired'));
+      return;
+    }
+    if (node.protocolVersion !== RELAY_NODE_LINK_PROTOCOL_VERSION) {
+      const [nodeMajor] = node.protocolVersion.split('.');
+      const [hubMajor] = RELAY_NODE_LINK_PROTOCOL_VERSION.split('.');
+      sendRelayError(
+        res,
+        relayError(
+          nodeMajor === hubMajor ? 'VERSION_SKEW' : 'PROTOCOL_INCOMPATIBLE',
+          `relay-node-link protocol ${node.protocolVersion} must exactly match hub protocol ${RELAY_NODE_LINK_PROTOCOL_VERSION}`
+        )
+      );
+      return;
+    }
+    if (node.capabilities.core.tmux !== 'available') {
+      sendRelayError(
+        res,
+        relayError('NODE_UNSUPPORTED', `node ${nodeId} cannot host tmux-backed PTY sessions`)
+      );
+      return;
+    }
+    if (node.status !== 'online' || !options.nodeLinks?.hasActiveNode(nodeId)) {
+      sendRelayError(
+        res,
+        relayError('NODE_OFFLINE', `node ${nodeId} has no live reverse link`, true)
+      );
+      return;
+    }
+
+    const body = bodyRecord(req);
+    const target = findColdReopenTarget(registry.listRepoInventoryReports(), nodeId, body);
+    if ('code' in target) {
+      sendRelayError(res, target);
+      return;
+    }
+
+    try {
+      const sessionPayload = coldReopenSessionPayload(body, target);
+      const payload = await options.nodeLinks.request(nodeId, 'sessions.create', sessionPayload);
+      const session = scopedNodeSession(nodeId, sessionFromPayload(payload));
+      res.status(201).json({
+        session,
+        transfer: {
+          mode: 'cold-reopen',
+          livePtyMigrated: false,
+          message:
+            'cold reopen started a new session from git/worktree state; it did not migrate live tmux/PTY process state',
+          source: recordField(body, 'source'),
+          target: {
+            nodeId,
+            repoPath: target.repo.localPath,
+            worktreePath: target.worktree?.localPath ?? null,
+            branchName: target.branchName,
+            repoInstanceId: target.repo.repoInstanceId,
+            ...(target.worktree
+              ? { worktreeInstanceId: target.worktree.worktreeInstanceId }
+              : {}),
+          },
+          warnings: target.warnings,
+        },
+      });
+    } catch (error) {
+      if (error instanceof HubNodeLinkError) {
+        sendRelayError(res, error.relayNodeError);
+        return;
+      }
       sendRegistryError(registry, res, error);
     }
   });

--- a/test/hub-node-cold-transfer.test.ts
+++ b/test/hub-node-cold-transfer.test.ts
@@ -414,8 +414,86 @@ describe('hub cold transfer / reopen-on-other-node', () => {
       transfer: {
         livePtyMigrated: false,
         warnings: [
+          { code: 'source-dirty-checkout' },
+          { code: 'source-diverged-checkout' },
           { code: 'target-dirty-checkout' },
           { code: 'target-diverged-checkout' },
+        ],
+      },
+    });
+  });
+
+  it('surfaces source dirty/diverged warnings when only repoIdentity/branchName is provided', async () => {
+    const { base, wsBase } = await startHub();
+    const { token: sourceToken, nodeId: sourceNodeId } = await pairNode(base);
+    await heartbeatRepoInventory(
+      base,
+      sourceToken,
+      sourceNodeId,
+      repoInventoryReport(sourceNodeId, '/srv/relay-ide', {
+        worktrees: [
+          {
+            worktreeInstanceId: `${sourceNodeId}:${encodeURIComponent('/srv/relay-ide/.worktrees/feature-a')}`,
+            localPath: '/srv/relay-ide/.worktrees/feature-a',
+            branchName: 'feature/a',
+            dirty: {
+              stagedCount: 1,
+              unstagedCount: 1,
+              untrackedCount: 0,
+              conflictedCount: 0,
+              files: [{ path: 'server/hub-node-router.ts', status: 'modified' }],
+              truncated: false,
+            },
+            divergence: { upstreamRef: 'origin/nightly', aheadCount: 2, behindCount: 1 },
+          },
+        ],
+      })
+    );
+
+    const { token: targetToken, nodeId: targetNodeId } = await pairNode(base);
+    await heartbeatRepoInventory(base, targetToken, targetNodeId, repoInventoryReport(targetNodeId, '/srv/relay-ide'));
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${targetToken}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const createPromise = fetch(`${base}/hub/nodes/${encodeURIComponent(targetNodeId)}/sessions/reopen`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      body: JSON.stringify({
+        source: { repoIdentity: 'github.com/donovan-yohan/relay-ide', branchName: 'feature/a' },
+        type: 'agent',
+      }),
+    });
+    const request = await nextJson(nodeWs);
+    expect(request.payload).toMatchObject({
+      repoPath: '/srv/relay-ide',
+      worktreePath: '/srv/relay-ide/.worktrees/feature-a',
+      branchName: 'feature/a',
+    });
+    expect(JSON.stringify(request.payload)).toContain('cold reopen');
+    nodeWs.send(
+      JSON.stringify({
+        protocol: request.protocol,
+        protocolVersion: request.protocolVersion,
+        nodeId: targetNodeId,
+        channel: 'rpc',
+        type: 'sessions.create.result',
+        requestId: request.requestId,
+        timestamp: new Date().toISOString(),
+        payload: { session: { ...remoteSession(targetNodeId), nodeId: undefined, globalSessionId: undefined } },
+      })
+    );
+
+    const res = await createPromise;
+    expect(res.status).toBe(201);
+    expect(await res.json()).toMatchObject({
+      transfer: {
+        livePtyMigrated: false,
+        warnings: [
+          { code: 'source-dirty-checkout' },
+          { code: 'source-diverged-checkout' },
         ],
       },
     });

--- a/test/hub-node-cold-transfer.test.ts
+++ b/test/hub-node-cold-transfer.test.ts
@@ -1,0 +1,497 @@
+import * as fs from 'node:fs';
+import http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import express from 'express';
+import { WebSocket } from 'ws';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createHubNodeRegistry } from '../server/hub-node-registry.js';
+import { createHubNodeRouter } from '../server/hub-node-router.js';
+import { createHubNodeLinkManager } from '../server/hub-node-link.js';
+import { createLocalRelayNode } from '../server/local-node.js';
+import { setupWebSocket } from '../server/ws.js';
+import type { SessionSummary } from '../server/types.js';
+import type { NodeManifest } from '../shared/node-manifest.js';
+import type { RepoInventoryReport } from '../shared/repo-inventory.js';
+import type { RelayNodeEnvelope } from '../shared/relay-node-protocol.js';
+
+function manifest(): NodeManifest {
+  return {
+    schemaVersion: 1,
+    platform: 'linux',
+    arch: 'x64',
+    hostname: 'cold-transfer-node',
+    relayVersion: '0.1.0-test',
+    generatedAt: '2026-01-02T03:04:05.000Z',
+    wsl: { detected: false, version: null, systemd: false },
+    serviceManager: {
+      kind: 'systemd-user',
+      label: 'systemd user',
+      supported: true,
+      installable: true,
+      installHint: 'install',
+      uninstallHint: 'uninstall',
+      message: 'ok',
+      caveats: [],
+    },
+    capabilities: {
+      tmux: { id: 'tmux', label: 'tmux', status: 'available', message: 'ok' },
+      git: { id: 'git', label: 'Git', status: 'available', message: 'ok' },
+      clipboard: { id: 'clipboard', label: 'Clipboard', status: 'unknown', message: 'unknown' },
+      browserAutomation: {
+        id: 'browserAutomation',
+        label: 'Browser automation',
+        status: 'degraded',
+        message: 'missing deps',
+      },
+      githubCli: { id: 'githubCli', label: 'GitHub CLI', status: 'available', message: 'ok' },
+      tailscale: { id: 'tailscale', label: 'Tailscale CLI', status: 'unavailable', message: 'missing' },
+      ssh: { id: 'ssh', label: 'SSH client', status: 'available', message: 'ok' },
+      agents: {
+        claude: { id: 'claude', label: 'Claude', status: 'available', message: 'ok' },
+      },
+    },
+  };
+}
+
+const selectedRemote = {
+  name: 'origin',
+  url: 'git@github.com:donovan-yohan/relay-ide.git',
+  identity: 'github.com/donovan-yohan/relay-ide',
+  provider: 'github' as const,
+  host: 'github.com',
+  path: 'donovan-yohan/relay-ide',
+  owner: 'donovan-yohan',
+  repoName: 'relay-ide',
+};
+
+function repoInventoryReport(
+  nodeId: string,
+  localPath: string,
+  overrides: Partial<RepoInventoryReport['repos'][number]> = {}
+): RepoInventoryReport {
+  const worktrees = overrides.worktrees ?? [
+    {
+      worktreeInstanceId: `${nodeId}:${encodeURIComponent(`${localPath}/.worktrees/feature-a`)}`,
+      localPath: `${localPath}/.worktrees/feature-a`,
+      branchName: 'feature/a',
+      dirty: {
+        stagedCount: 0,
+        unstagedCount: 0,
+        untrackedCount: 0,
+        conflictedCount: 0,
+        files: [],
+        truncated: false,
+      },
+      divergence: { upstreamRef: 'origin/nightly', aheadCount: 0, behindCount: 0 },
+    },
+  ];
+
+  return {
+    nodeId,
+    generatedAt: '2026-01-02T03:04:05.000Z',
+    repos: [
+      {
+        repoInstanceId: `${nodeId}:${encodeURIComponent(localPath)}`,
+        nodeId,
+        localPath,
+        name: 'relay-ide',
+        isGitRepo: true,
+        defaultBranch: 'nightly',
+        currentBranch: 'nightly',
+        repoIdentity: 'github.com/donovan-yohan/relay-ide',
+        selectedRemote,
+        remotes: [selectedRemote],
+        repoIdentityWarnings: [],
+        dirty: {
+          stagedCount: 0,
+          unstagedCount: 0,
+          untrackedCount: 0,
+          conflictedCount: 0,
+          files: [],
+          truncated: false,
+        },
+        divergence: { upstreamRef: 'origin/nightly', aheadCount: 0, behindCount: 0 },
+        worktrees,
+        reportedAt: '2026-01-02T03:04:05.000Z',
+        ...overrides,
+      },
+    ],
+  };
+}
+
+function remoteSession(nodeId: string): SessionSummary {
+  return {
+    id: 'cold-reopen-session-1',
+    type: 'agent',
+    agent: 'claude',
+    mode: 'pty',
+    repoPath: '/srv/relay-ide',
+    worktreePath: '/srv/relay-ide/.worktrees/feature-a',
+    cwd: '/srv/relay-ide/.worktrees/feature-a',
+    repoName: 'relay-ide',
+    branchName: 'feature/a',
+    displayName: 'Agent 1',
+    createdAt: '2026-01-02T03:04:05.000Z',
+    lastActivity: '2026-01-02T03:04:05.000Z',
+    idle: false,
+    customCommand: null,
+    nodeId,
+    globalSessionId: `${nodeId}:cold-reopen-session-1`,
+    repoInstanceId: `${nodeId}:%2Fsrv%2Frelay-ide`,
+    worktreeInstanceId: `${nodeId}:%2Fsrv%2Frelay-ide%2F.worktrees%2Ffeature-a`,
+    useTmux: true,
+    tmuxSessionName: 'relay-ide-cold-reopen-session-1',
+    status: 'active',
+    needsBranchRename: false,
+    agentState: 'idle',
+  };
+}
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing server address');
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function waitForOpen(ws: WebSocket): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) return;
+  await new Promise<void>((resolve, reject) => {
+    ws.once('open', resolve);
+    ws.once('error', reject);
+  });
+}
+
+async function nextJson(ws: WebSocket): Promise<RelayNodeEnvelope> {
+  return await new Promise<RelayNodeEnvelope>((resolve) => {
+    ws.once('message', (data) => resolve(JSON.parse(data.toString()) as RelayNodeEnvelope));
+  });
+}
+
+describe('hub cold transfer / reopen-on-other-node', () => {
+  const cleanup: Array<() => Promise<void> | void> = [];
+
+  afterEach(async () => {
+    while (cleanup.length > 0) await cleanup.pop()?.();
+  });
+
+  async function startHub() {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hub-cold-transfer-'));
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const registry = createHubNodeRegistry({
+      storagePath: path.join(tmpDir, 'nodes.json'),
+      now: () => new Date('2026-01-02T03:04:05.000Z'),
+    });
+    const nodeLinks = createHubNodeLinkManager();
+    const app = express();
+    app.use(express.json());
+    app.use(
+      createHubNodeRouter({
+        registry,
+        nodeLinks,
+        requireAuth: (req, res, next) => {
+          if (req.header('x-test-auth') === 'yes') next();
+          else res.status(401).json({ error: 'Unauthorized' });
+        },
+      })
+    );
+    const server = http.createServer(app);
+    setupWebSocket(
+      server,
+      new Set(),
+      null,
+      undefined,
+      true,
+      createLocalRelayNode({ nodeId: 'hub-node' }),
+      registry,
+      nodeLinks
+    );
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+    return { base: `http://127.0.0.1:${port}`, wsBase: `ws://127.0.0.1:${port}` };
+  }
+
+  async function pairNode(base: string): Promise<{ token: string; nodeId: string }> {
+    const pairRes = await fetch(`${base}/hub/pair-tokens`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+    });
+    expect(pairRes.status).toBe(201);
+    const pair = (await pairRes.json()) as { pairToken: string };
+    const exchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pairToken: pair.pairToken, manifest: manifest() }),
+    });
+    expect(exchangeRes.status).toBe(201);
+    const exchange = (await exchangeRes.json()) as { credential: { token: string; nodeId: string } };
+    return exchange.credential;
+  }
+
+  async function heartbeatRepoInventory(
+    base: string,
+    token: string,
+    nodeId: string,
+    report: RepoInventoryReport
+  ): Promise<void> {
+    const res = await fetch(`${base}/hub/node-heartbeat`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      body: JSON.stringify({ nodeId, protocolVersion: '1.0', repoInventory: report }),
+    });
+    expect(res.status).toBe(200);
+  }
+
+  it('returns NODE_OFFLINE instead of pretending to migrate when target node has no live link', async () => {
+    const { base } = await startHub();
+    const { token, nodeId } = await pairNode(base);
+    await heartbeatRepoInventory(base, token, nodeId, repoInventoryReport(nodeId, '/srv/relay-ide'));
+
+    const res = await fetch(`${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions/reopen`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      body: JSON.stringify({
+        source: { repoIdentity: 'github.com/donovan-yohan/relay-ide', branchName: 'feature/a' },
+        type: 'agent',
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({
+      error: { code: 'NODE_OFFLINE', retryable: true },
+    });
+  });
+
+  it('returns a missing-checkout error with clone/worktree guidance when target lacks the repo', async () => {
+    const { base, wsBase } = await startHub();
+    const { token, nodeId } = await pairNode(base);
+    await heartbeatRepoInventory(
+      base,
+      token,
+      nodeId,
+      repoInventoryReport(nodeId, '/srv/other', { repoIdentity: 'github.com/example/other' })
+    );
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const res = await fetch(`${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions/reopen`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      body: JSON.stringify({
+        source: { repoIdentity: 'github.com/donovan-yohan/relay-ide', branchName: 'feature/a' },
+        type: 'agent',
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({
+      error: {
+        code: 'NOT_FOUND',
+        retryable: false,
+        details: {
+          suggestedAction: 'clone-or-add-worktree',
+          repoIdentity: 'github.com/donovan-yohan/relay-ide',
+          targetNodeId: nodeId,
+        },
+      },
+    });
+  });
+
+  it('returns a missing-checkout error when the repo exists but requested branch/worktree is absent', async () => {
+    const { base, wsBase } = await startHub();
+    const { token, nodeId } = await pairNode(base);
+    await heartbeatRepoInventory(
+      base,
+      token,
+      nodeId,
+      repoInventoryReport(nodeId, '/srv/relay-ide', {
+        worktrees: [],
+      })
+    );
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const res = await fetch(`${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions/reopen`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      body: JSON.stringify({
+        source: { repoIdentity: 'github.com/donovan-yohan/relay-ide', branchName: 'feature/a' },
+        type: 'agent',
+      }),
+    });
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({
+      error: {
+        code: 'NOT_FOUND',
+        retryable: false,
+        details: {
+          suggestedAction: 'add-worktree-or-checkout-branch',
+          repoIdentity: 'github.com/donovan-yohan/relay-ide',
+          branchName: 'feature/a',
+          targetNodeId: nodeId,
+        },
+      },
+    });
+  });
+
+  it('surfaces dirty and diverged checkout warnings while still reopening cold', async () => {
+    const { base, wsBase } = await startHub();
+    const { token, nodeId } = await pairNode(base);
+    await heartbeatRepoInventory(
+      base,
+      token,
+      nodeId,
+      repoInventoryReport(nodeId, '/srv/relay-ide', {
+        worktrees: [
+          {
+            worktreeInstanceId: `${nodeId}:${encodeURIComponent('/srv/relay-ide/.worktrees/feature-a')}`,
+            localPath: '/srv/relay-ide/.worktrees/feature-a',
+            branchName: 'feature/a',
+            dirty: {
+              stagedCount: 1,
+              unstagedCount: 1,
+              untrackedCount: 0,
+              conflictedCount: 0,
+              files: [{ path: 'server/hub-node-router.ts', status: 'modified' }],
+              truncated: false,
+            },
+            divergence: { upstreamRef: 'origin/nightly', aheadCount: 2, behindCount: 1 },
+          },
+        ],
+      })
+    );
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const createPromise = fetch(`${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions/reopen`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      body: JSON.stringify({
+        source: { repoIdentity: 'github.com/donovan-yohan/relay-ide', branchName: 'feature/a' },
+        type: 'agent',
+      }),
+    });
+    const request = await nextJson(nodeWs);
+    expect(request.payload).toMatchObject({
+      repoPath: '/srv/relay-ide',
+      worktreePath: '/srv/relay-ide/.worktrees/feature-a',
+      branchName: 'feature/a',
+    });
+    expect(JSON.stringify(request.payload)).toContain('cold reopen');
+    nodeWs.send(
+      JSON.stringify({
+        protocol: request.protocol,
+        protocolVersion: request.protocolVersion,
+        nodeId,
+        channel: 'rpc',
+        type: 'sessions.create.result',
+        requestId: request.requestId,
+        timestamp: new Date().toISOString(),
+        payload: { session: { ...remoteSession(nodeId), nodeId: undefined, globalSessionId: undefined } },
+      })
+    );
+
+    const res = await createPromise;
+    expect(res.status).toBe(201);
+    expect(await res.json()).toMatchObject({
+      transfer: {
+        livePtyMigrated: false,
+        warnings: [
+          { code: 'target-dirty-checkout' },
+          { code: 'target-diverged-checkout' },
+        ],
+      },
+    });
+  });
+
+  it('starts a new target-node session from matching repo/worktree state on the success path', async () => {
+    const { base, wsBase } = await startHub();
+    const { token, nodeId } = await pairNode(base);
+    await heartbeatRepoInventory(base, token, nodeId, repoInventoryReport(nodeId, '/srv/relay-ide'));
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const createPromise = fetch(`${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions/reopen`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      body: JSON.stringify({
+        source: {
+          nodeId: 'local',
+          repoIdentity: 'github.com/donovan-yohan/relay-ide',
+          branchName: 'feature/a',
+          sessionId: 'source-session-1',
+        },
+        type: 'agent',
+        agent: 'claude',
+      }),
+    });
+
+    const request = await nextJson(nodeWs);
+    expect(request).toMatchObject({
+      nodeId,
+      channel: 'rpc',
+      type: 'sessions.create',
+      payload: {
+        type: 'agent',
+        agent: 'claude',
+        repoPath: '/srv/relay-ide',
+        worktreePath: '/srv/relay-ide/.worktrees/feature-a',
+        branchName: 'feature/a',
+        continue: false,
+      },
+    });
+    expect(JSON.stringify(request.payload)).toContain('not a live tmux/PTY migration');
+    nodeWs.send(
+      JSON.stringify({
+        protocol: request.protocol,
+        protocolVersion: request.protocolVersion,
+        nodeId,
+        channel: 'rpc',
+        type: 'sessions.create.result',
+        requestId: request.requestId,
+        timestamp: new Date().toISOString(),
+        payload: { session: { ...remoteSession(nodeId), nodeId: undefined, globalSessionId: undefined } },
+      })
+    );
+
+    const res = await createPromise;
+    expect(res.status).toBe(201);
+    expect(await res.json()).toMatchObject({
+      session: {
+        id: 'cold-reopen-session-1',
+        nodeId,
+        globalSessionId: `${nodeId}:cold-reopen-session-1`,
+      },
+      transfer: {
+        mode: 'cold-reopen',
+        livePtyMigrated: false,
+        target: {
+          repoPath: '/srv/relay-ide',
+          worktreePath: '/srv/relay-ide/.worktrees/feature-a',
+          branchName: 'feature/a',
+        },
+        warnings: [],
+      },
+    });
+  });
+});

--- a/test/hub-node-cold-transfer.test.ts
+++ b/test/hub-node-cold-transfer.test.ts
@@ -182,7 +182,9 @@ describe('hub cold transfer / reopen-on-other-node', () => {
     while (cleanup.length > 0) await cleanup.pop()?.();
   });
 
-  async function startHub() {
+  async function startHub(options?: {
+    collectLocalRepoInventory?: () => Promise<RepoInventoryReport>;
+  }) {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hub-cold-transfer-'));
     cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
     const registry = createHubNodeRegistry({
@@ -200,6 +202,7 @@ describe('hub cold transfer / reopen-on-other-node', () => {
           if (req.header('x-test-auth') === 'yes') next();
           else res.status(401).json({ error: 'Unauthorized' });
         },
+        collectLocalRepoInventory: options?.collectLocalRepoInventory,
       })
     );
     const server = http.createServer(app);
@@ -560,6 +563,150 @@ describe('hub cold transfer / reopen-on-other-node', () => {
         nodeId,
         globalSessionId: `${nodeId}:cold-reopen-session-1`,
       },
+      transfer: {
+        mode: 'cold-reopen',
+        livePtyMigrated: false,
+        target: {
+          repoPath: '/srv/relay-ide',
+          worktreePath: '/srv/relay-ide/.worktrees/feature-a',
+          branchName: 'feature/a',
+        },
+        warnings: [],
+      },
+    });
+  });
+
+  it('surfaces source warnings when source checkout is on the hub node via local inventory', async () => {
+    const localNodeId = 'local';
+    const { base, wsBase } = await startHub({
+      collectLocalRepoInventory: async () =>
+        repoInventoryReport(localNodeId, '/Users/hub/relay-ide', {
+          worktrees: [
+            {
+              worktreeInstanceId: `${localNodeId}:${encodeURIComponent('/Users/hub/relay-ide/.worktrees/feature-a')}`,
+              localPath: '/Users/hub/relay-ide/.worktrees/feature-a',
+              branchName: 'feature/a',
+              dirty: {
+                stagedCount: 1,
+                unstagedCount: 1,
+                untrackedCount: 0,
+                conflictedCount: 0,
+                files: [{ path: 'server/hub-node-router.ts', status: 'modified' }],
+                truncated: false,
+              },
+              divergence: { upstreamRef: 'origin/nightly', aheadCount: 2, behindCount: 1 },
+            },
+          ],
+        }),
+    });
+    const { token, nodeId: targetNodeId } = await pairNode(base);
+    await heartbeatRepoInventory(base, token, targetNodeId, repoInventoryReport(targetNodeId, '/srv/relay-ide'));
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const createPromise = fetch(`${base}/hub/nodes/${encodeURIComponent(targetNodeId)}/sessions/reopen`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      body: JSON.stringify({
+        source: {
+          nodeId: localNodeId,
+          repoIdentity: 'github.com/donovan-yohan/relay-ide',
+          branchName: 'feature/a',
+        },
+        type: 'agent',
+      }),
+    });
+    const request = await nextJson(nodeWs);
+    expect(request.payload).toMatchObject({
+      repoPath: '/srv/relay-ide',
+      worktreePath: '/srv/relay-ide/.worktrees/feature-a',
+      branchName: 'feature/a',
+    });
+    expect(JSON.stringify(request.payload)).toContain('cold reopen');
+    nodeWs.send(
+      JSON.stringify({
+        protocol: request.protocol,
+        protocolVersion: request.protocolVersion,
+        nodeId: targetNodeId,
+        channel: 'rpc',
+        type: 'sessions.create.result',
+        requestId: request.requestId,
+        timestamp: new Date().toISOString(),
+        payload: { session: { ...remoteSession(targetNodeId), nodeId: undefined, globalSessionId: undefined } },
+      })
+    );
+
+    const res = await createPromise;
+    expect(res.status).toBe(201);
+    expect(await res.json()).toMatchObject({
+      transfer: {
+        livePtyMigrated: false,
+        warnings: [
+          { code: 'source-dirty-checkout' },
+          { code: 'source-diverged-checkout' },
+        ],
+      },
+    });
+  });
+
+  it('reopens cold when target inventory is only available via local collection', async () => {
+    let localReport: RepoInventoryReport | null = null;
+    const { base, wsBase } = await startHub({
+      collectLocalRepoInventory: async () => {
+        if (!localReport) throw new Error('localReport not set');
+        return localReport;
+      },
+    });
+    const { token, nodeId: targetNodeId } = await pairNode(base);
+    // keep the node online but do not heartbeat repo inventory into the registry
+    const heartbeatRes = await fetch(`${base}/hub/node-heartbeat`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+      body: JSON.stringify({ nodeId: targetNodeId, protocolVersion: '1.0' }),
+    });
+    expect(heartbeatRes.status).toBe(200);
+    localReport = repoInventoryReport(targetNodeId, '/srv/relay-ide');
+
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const createPromise = fetch(`${base}/hub/nodes/${encodeURIComponent(targetNodeId)}/sessions/reopen`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      body: JSON.stringify({
+        source: { repoIdentity: 'github.com/donovan-yohan/relay-ide', branchName: 'feature/a' },
+        type: 'agent',
+      }),
+    });
+    const request = await nextJson(nodeWs);
+    expect(request.payload).toMatchObject({
+      repoPath: '/srv/relay-ide',
+      worktreePath: '/srv/relay-ide/.worktrees/feature-a',
+      branchName: 'feature/a',
+    });
+    expect(JSON.stringify(request.payload)).toContain('cold reopen');
+    nodeWs.send(
+      JSON.stringify({
+        protocol: request.protocol,
+        protocolVersion: request.protocolVersion,
+        nodeId: targetNodeId,
+        channel: 'rpc',
+        type: 'sessions.create.result',
+        requestId: request.requestId,
+        timestamp: new Date().toISOString(),
+        payload: { session: { ...remoteSession(targetNodeId), nodeId: undefined, globalSessionId: undefined } },
+      })
+    );
+
+    const res = await createPromise;
+    expect(res.status).toBe(201);
+    expect(await res.json()).toMatchObject({
       transfer: {
         mode: 'cold-reopen',
         livePtyMigrated: false,


### PR DESCRIPTION
## Summary
- Adds `POST /hub/nodes/:nodeId/sessions/reopen` for cold transfer / reopen-on-other-node flows.
- Resolves the target checkout from repo inventory, rejects offline targets and missing repo/branch/worktree checkouts, and forwards `sessions.create` over the active node link.
- Returns explicit `transfer.mode = cold-reopen`, `livePtyMigrated = false`, and dirty/diverged checkout warnings so callers do not mistake this for PTY migration.
- Adds hub-level route coverage for offline target, missing checkout, dirty/diverged warnings, and the success path.

## Why
This is the MVP for moving work to another Relay node without pretending live tmux/PTY state can migrate. The hub uses the repo/worktree inventory it already receives from nodes, then starts a fresh session on the target with a cold-reopen handoff prompt.

## The Case Against
This change is intentionally not a real transfer system. It does not serialize terminal scrollback, agent process memory, tmux panes, environment variables, or uncommitted files. If a user expects literal session migration, this will disappoint them, so the API response and injected prompt repeat that no live PTY state moved. The target checkout matching also depends on inventory freshness; stale node inventory can reject a valid checkout or warn about dirty/diverged state that has since changed.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
| --- | --- | --- |
| Stale repo inventory chooses or rejects the wrong checkout | Medium | Route requires reported inventory and returns actionable missing-checkout details. |
| Users assume PTY/process state was transferred | Medium | Response includes `livePtyMigrated: false`; prompt says this is not live tmux/PTY migration. |
| Dirty/diverged work causes confusing reopened context | Medium | Dirty/diverged source/target warnings are surfaced in response and prompt. |
| Target node is paired but not actually connected | Medium | Route requires an active reverse node link before forwarding `sessions.create`. |

## Verification
- `rtk npm test -- test/hub-node-cold-transfer.test.ts test/hub-node-session-routing.test.ts test/hub-node-routes.test.ts` — 20 passed
- `rtk npm run check` — passed with 38 existing warnings, 0 errors
- `rtk npm run build` — passed

Refs #394
Closes #399


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authenticated cold-reopen on another node: creates a scoped session and returns a transfer object with mode, source/target details, computed warnings, and optional appended prompt.

* **Bug Fixes / UX**
  * Clear, structured errors with actionable guidance when destination node is offline or lacks the required repo/worktree/branch; relay errors may include additional details.

* **Tests**
  * End-to-end tests covering offline, missing repo/worktree/branch, dirty/diverged warnings, prompt handling, and successful cold-reopen flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/410)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->