### PR TITLE
test: deflake multi-agent PTY env wiring

### DIFF
--- a/test/pty-handler-multi-agent.test.ts
+++ b/test/pty-handler-multi-agent.test.ts
@@ -56,7 +56,7 @@ async function waitForScrollbackContains(
   const session = sessions.get(sessionId) as PtySession | undefined;
   throw new Error(
     `Timed out waiting for scrollback to contain: ${needle}. Last scrollback: ${JSON.stringify(
-      session?.scrollback.join('').slice(-1000) ?? '<missing session>'
+      session?.scrollback?.join('').slice(-1000) ?? '<missing session>'
     )}`
   );
 }
@@ -68,15 +68,22 @@ async function waitForFileContains(
 ): Promise<string> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (fs.existsSync(filePath)) {
+    try {
       const output = fs.readFileSync(filePath, 'utf-8');
       if (output.includes(needle)) return output;
+    } catch {
+      // File may not exist yet, or may be rewritten while polling.
     }
     await delay(50);
   }
-  const lastOutput = fs.existsSync(filePath)
-    ? fs.readFileSync(filePath, 'utf-8').slice(-1000)
-    : '<missing file>';
+  let lastOutput = '<missing file>';
+  try {
+    if (fs.existsSync(filePath)) {
+      lastOutput = fs.readFileSync(filePath, 'utf-8').slice(-1000);
+    }
+  } catch {
+    lastOutput = '<error reading file>';
+  }
   throw new Error(
     `Timed out waiting for ${filePath} to contain: ${needle}. Last contents: ${JSON.stringify(
       lastOutput

--- a/test/pty-handler-multi-agent.test.ts
+++ b/test/pty-handler-multi-agent.test.ts
@@ -34,10 +34,15 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const PTY_STARTUP_TIMEOUT_MS = 10000;
+
+// These assertions verify hook/env wiring, not tmux itself. The probe sessions
+// use tmuxAttach:true so node-pty runs the tiny probe process directly; real
+// tmux startup is covered in sessions.test.ts and was the source of CI flakes.
 async function waitForScrollbackContains(
   sessionId: string,
   needle: string,
-  timeoutMs = 8000
+  timeoutMs = PTY_STARTUP_TIMEOUT_MS
 ): Promise<string> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -48,13 +53,18 @@ async function waitForScrollbackContains(
     }
     await delay(50);
   }
-  throw new Error(`Timed out waiting for scrollback to contain: ${needle}`);
+  const session = sessions.get(sessionId) as PtySession | undefined;
+  throw new Error(
+    `Timed out waiting for scrollback to contain: ${needle}. Last scrollback: ${JSON.stringify(
+      session?.scrollback.join('').slice(-1000) ?? '<missing session>'
+    )}`
+  );
 }
 
 async function waitForFileContains(
   filePath: string,
   needle: string,
-  timeoutMs = 8000
+  timeoutMs = PTY_STARTUP_TIMEOUT_MS
 ): Promise<string> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -64,7 +74,14 @@ async function waitForFileContains(
     }
     await delay(50);
   }
-  throw new Error(`Timed out waiting for ${filePath} to contain: ${needle}`);
+  const lastOutput = fs.existsSync(filePath)
+    ? fs.readFileSync(filePath, 'utf-8').slice(-1000)
+    : '<missing file>';
+  throw new Error(
+    `Timed out waiting for ${filePath} to contain: ${needle}. Last contents: ${JSON.stringify(
+      lastOutput
+    )}`
+  );
 }
 
 describe('PTY multi-agent hook/plugin wiring', () => {
@@ -131,6 +148,7 @@ describe('PTY multi-agent hook/plugin wiring', () => {
           'setTimeout(()=>{},10000);',
         ].join(' '),
       ],
+      tmuxAttach: true,
       port,
       hookToken,
     });
@@ -167,6 +185,7 @@ describe('PTY multi-agent hook/plugin wiring', () => {
           'setTimeout(()=>{},10000);',
         ].join(' '),
       ],
+      tmuxAttach: true,
       port: 7777,
       hookToken: 'codex-token',
       configDir: '/tmp',
@@ -190,6 +209,7 @@ describe('PTY multi-agent hook/plugin wiring', () => {
       agent: 'claude',
       command: '/bin/cat',
       args: [],
+      tmuxAttach: true,
       frameworks: {
         claude: {
           eventSource: 'parser',
@@ -203,7 +223,7 @@ describe('PTY multi-agent hook/plugin wiring', () => {
     expect(session.dataQuality).toBe('parser');
   });
 
-  it('uses parser startup signal for hook-backed tmux sessions before hooks fire', async () => {
+  it('uses parser startup signal for hook-backed sessions before hooks fire', async () => {
     const agentStub = path.join(testHome, 'claude-stub.sh');
     fs.writeFileSync(
       agentStub,
@@ -225,6 +245,7 @@ sleep 10
       cwd: '/tmp',
       agent: 'claude',
       args: [],
+      tmuxAttach: true,
       port: 4568,
       hookToken: 'claude-hook-token',
       configDir: '/tmp',
@@ -278,6 +299,7 @@ sleep 10
           'setTimeout(()=>{},10000);',
         ].join(' '),
       ],
+      tmuxAttach: true,
     });
     createdIds.push(result.id);
 


### PR DESCRIPTION
## Summary
- Keep `test/pty-handler-multi-agent.test.ts` focused on hook/plugin/env wiring by running its tiny probe processes without the tmux wrapper (`tmuxAttach: true`).
- Preserve real tmux coverage in `test/sessions.test.ts`, where session attach/restore behavior is actually under test.
- Improve timeout diagnostics for scrollback/file polling so any future failure shows the last observed output instead of the useless “timed out” blob.

## Why
The flaky `opencode-yolo-env` assertion was waiting on a probe file produced by a tiny Node process, but the test routed that process through real tmux startup. Under full-suite load, that made the env-wiring assertion depend on tmux process scheduling instead of the yolo env logic. bro this is exactly the kind of test coupling that makes CI look haunted.

## The Case Against
This might be too narrow if we actually wanted every multi-agent hook/env test to exercise the tmux spawn path. I do not think we do: tmux compatibility is already covered by `sessions.test.ts`, and these tests assert generated config/env contents. If there is a tmux-specific env propagation bug, it should live in a tmux-focused test with isolated sockets, not in five hook wiring probes.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Reduces tmux-path coverage in this file | `test/sessions.test.ts` continues covering tmux session/restore behavior; this file now tests only hook/env wiring. |
| Hides future probe failures | Poll helpers now include last scrollback/file contents in timeout errors. |
| Direct PTY path differs from production interactive sessions | The assertions are config/env-level and still go through `sessions.create`; only the tmux wrapper is bypassed. |

## Verification
- `git diff --check`
- `npm run build`
- `npm test -- test/pty-handler-multi-agent.test.ts --reporter=dot`
- `npm test -- test/sessions.test.ts test/pty-handler-multi-agent.test.ts --reporter=dot` — 73 tests passed
- `npm test -- --reporter=dot` — 177 files / 1947 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased default test helper timeout to 10s for more reliable runs.
  * Improved timeout failure diagnostics to include the most recent output snippet (truncated) for easier debugging.
  * Updated test session attachment configuration to ensure sessions attach during relevant tests.
  * Minor wording tweak in a test description for clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/415)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/415)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->