### PR TITLE
feat(node-link): persistent /hub/node-link reverse client

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -16,6 +16,8 @@ import {
 import { RELAY_NODE_LINK_PROTOCOL_VERSION } from '../shared/relay-node-protocol.js';
 import type { NodeManifest } from '../shared/node-manifest.js';
 import type { Config } from '../server/types.js';
+import { createNodeLinkClient } from '../server/node-link-client.js';
+import { collectLocalRepoInventory } from '../server/repo-inventory.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -54,6 +56,7 @@ Commands:
                                        Exchange a pair token and send one heartbeat
     install --hub <url> --pair-token <token> [--service auto|manual|launchd|systemd-user|wsl-systemd|wsl-manual]
                                        Pair the node, then install/start the local Relay-managed service when requested/available
+    link --hub <url>                   Open and hold the persistent /hub/node-link reverse WebSocket (foreground)
   worktree           Manage git worktrees (wraps git worktree)
     add [path] [-b branch] [--yolo]   Create worktree and launch Claude
     remove <path>                      Forward to git worktree remove
@@ -305,6 +308,77 @@ function validateNodeServiceMode(manifest: NodeManifest, mode: RequestedNodeServ
   }
 }
 
+function loadNodeCredential(): { nodeId: string; token: string } {
+  const credentialPath = path.join(service.CONFIG_DIR, 'node-credential.json');
+  if (!fs.existsSync(credentialPath)) {
+    logger.error(
+      `NODE_LINK_FAILED: no node credential at ${credentialPath}. Run 'relay-ide node connect' first.`
+    );
+    process.exit(1);
+  }
+  try {
+    const parsed = JSON.parse(fs.readFileSync(credentialPath, 'utf8')) as {
+      nodeId?: string;
+      token?: string;
+    };
+    if (!parsed.nodeId || !parsed.token) {
+      logger.error(`NODE_LINK_FAILED: malformed credential at ${credentialPath}.`);
+      process.exit(1);
+    }
+    return { nodeId: parsed.nodeId, token: parsed.token };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error(redactBootstrapSecrets(`NODE_LINK_FAILED: ${message}`));
+    process.exit(1);
+  }
+}
+
+async function runNodeLink(nodeArgs: string[]): Promise<void> {
+  const hubUrl = getNodeArg(nodeArgs, '--hub');
+  if (!hubUrl) {
+    logger.error('Usage: relay-ide node link --hub <url>');
+    process.exit(1);
+  }
+  const credential = loadNodeCredential();
+  const configPath = resolveConfigPath();
+  let config: Config | undefined;
+  try {
+    config = loadConfig(configPath) as Config;
+  } catch {
+    config = undefined;
+  }
+  const client = createNodeLinkClient({
+    hubUrl,
+    credential,
+    getManifest: () => getNodeManifest(),
+    getRepoInventory: async () => {
+      if (!config) return undefined;
+      try {
+        return await collectLocalRepoInventory({
+          config,
+          configPath,
+          nodeId: credential.nodeId,
+        });
+      } catch {
+        return undefined;
+      }
+    },
+  });
+  client.onStateChange((state) => {
+    logger.info(`node-link state: ${state}`);
+  });
+  const shutdown = (signal: string) => {
+    logger.info(`received ${signal}; closing node-link`);
+    void client.stop(`signal ${signal}`).then(() => process.exit(0));
+  };
+  process.once('SIGINT', () => shutdown('SIGINT'));
+  process.once('SIGTERM', () => shutdown('SIGTERM'));
+  client.start();
+  await new Promise<void>(() => {
+    /* hold foreground until signal */
+  });
+}
+
 type NodePairLifecycle = 'connect' | 'install';
 
 async function pairNode(nodeArgs: string[], lifecycle: NodePairLifecycle = 'connect'): Promise<void> {
@@ -430,6 +504,10 @@ if (command === 'node') {
     await runNodeDoctor(getNodeArg(nodeArgs, '--hub'));
     process.exit(0);
   }
+  if (subCommand === 'link') {
+    await runNodeLink(nodeArgs);
+    process.exit(0);
+  }
   if (subCommand === 'connect' || subCommand === 'install') {
     if (subCommand === 'install') {
       const serviceMode = parseNodeServiceMode(getNodeArg(nodeArgs, '--service') ?? 'auto');
@@ -455,7 +533,7 @@ if (command === 'node') {
       process.exit(0);
     }
   }
-  logger.error('Usage: relay-ide node <status|logs|doctor|connect|install>');
+  logger.error('Usage: relay-ide node <status|logs|doctor|connect|install|link>');
   process.exit(1);
 }
 

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -317,11 +317,18 @@ function loadNodeCredential(): { nodeId: string; token: string } {
     process.exit(1);
   }
   try {
-    const parsed = JSON.parse(fs.readFileSync(credentialPath, 'utf8')) as {
-      nodeId?: string;
-      token?: string;
-    };
-    if (!parsed.nodeId || !parsed.token) {
+    const raw = JSON.parse(fs.readFileSync(credentialPath, 'utf8')) as unknown;
+    if (typeof raw !== 'object' || raw === null) {
+      logger.error(`NODE_LINK_FAILED: malformed credential at ${credentialPath}.`);
+      process.exit(1);
+    }
+    const parsed = raw as { nodeId?: unknown; token?: unknown };
+    if (
+      typeof parsed.nodeId !== 'string' ||
+      !parsed.nodeId ||
+      typeof parsed.token !== 'string' ||
+      !parsed.token
+    ) {
       logger.error(`NODE_LINK_FAILED: malformed credential at ${credentialPath}.`);
       process.exit(1);
     }
@@ -364,18 +371,30 @@ async function runNodeLink(nodeArgs: string[]): Promise<void> {
       }
     },
   });
-  client.onStateChange((state) => {
-    logger.info(`node-link state: ${state}`);
-  });
-  const shutdown = (signal: string) => {
-    logger.info(`received ${signal}; closing node-link`);
-    void client.stop(`signal ${signal}`).then(() => process.exit(0));
-  };
-  process.once('SIGINT', () => shutdown('SIGINT'));
-  process.once('SIGTERM', () => shutdown('SIGTERM'));
-  client.start();
-  await new Promise<void>(() => {
-    /* hold foreground until signal */
+  await new Promise<void>((resolve) => {
+    let exiting = false;
+    const finish = (exitCode: number): void => {
+      if (exiting) return;
+      exiting = true;
+      const safetyTimer = setTimeout(() => process.exit(exitCode), 5_000);
+      safetyTimer.unref?.();
+      void client.stop().then(() => {
+        clearTimeout(safetyTimer);
+        resolve();
+        process.exit(exitCode);
+      });
+    };
+    client.onStateChange((state) => {
+      logger.info(`node-link state: ${state}`);
+      if (state === 'stopped') finish(0);
+    });
+    const shutdown = (signal: string) => {
+      logger.info(`received ${signal}; closing node-link`);
+      finish(0);
+    };
+    process.once('SIGINT', () => shutdown('SIGINT'));
+    process.once('SIGTERM', () => shutdown('SIGTERM'));
+    client.start();
   });
 }
 

--- a/docs/RELAY_NODE_BOOTSTRAP.md
+++ b/docs/RELAY_NODE_BOOTSTRAP.md
@@ -64,7 +64,24 @@ Supported `--service` values:
 | `manual`       | Any                  | Pair-only; no background service                                  |
 | `auto`         | Any                  | Detects platform and chooses the best supported mode              |
 
-> **Important:** Current bootstrap diagnostics pair credentials and install/start the generic Relay service only; they do **not** start or maintain the reverse WebSocket link `/hub/node-link`. Routed sessions still require a persistent node-side client that opens the reverse link.
+> **Important:** Bootstrap diagnostics pair credentials and install/start the generic Relay service. They do **not** start the reverse WebSocket link `/hub/node-link` themselves. Use `relay-ide node link --hub <url>` to hold the persistent reverse link in the foreground (or run it from your platform service manager).
+
+### Persistent /hub/node-link
+
+```bash
+relay-ide node link --hub https://hub.example.com
+```
+
+Behavior:
+
+- Loads the credential at `~/.config/relay-ide/node-credential.json` (run `node connect` first).
+- Opens an authenticated WebSocket to `<hub>/hub/node-link` and sends `control.hello` with the local manifest and repo inventory.
+- Sends a `control.heartbeat` every 20s over the same link. Hub reports the node as `online` while the link is up.
+- Reconnects with jittered exponential backoff (starts at 1s, caps at 60s) on transient close or socket error.
+- Exits permanently when the hub returns `NODE_REVOKED`, `UNAUTHORIZED`, or `PROTOCOL_INCOMPATIBLE`.
+- `SIGINT` / `SIGTERM` close the link cleanly.
+
+Node-side PTY and RPC handling are scaffolded but no-op in this slice; routed PTY/file/git RPC are follow-ups. Local Relay mode (no hub configured) still boots without attempting `/hub/node-link`.
 
 ### 3. Credential storage
 

--- a/docs/RELAY_NODE_BOOTSTRAP.md
+++ b/docs/RELAY_NODE_BOOTSTRAP.md
@@ -4,7 +4,7 @@ Operator guide for pairing, installing, updating, diagnosing, and unpairing Rela
 
 Relay uses one npm package for both roles. The packaging decision is documented in [Relay Hub/Node Packaging Decision](RELAY_HUB_NODE_PACKAGING.md): operators install `relay-ide` once, run the web server as `relay-ide hub`, and pair or bootstrap nodes with `relay-ide node ...`. Bare `relay-ide` and top-level `install/status/uninstall` remain back-compat hub aliases.
 
-Relay uses SSH and Tailscale SSH only for bootstrap, reachability checks, diagnostics, and emergency fallback. They are not the steady-state hub-node product API. Pairing and heartbeat bootstrap are implemented here; steady-state routed sessions still require a future persistent node-side client that opens `/hub/node-link` with the stored node credential. This bootstrap slice does not start or maintain `/hub/node-link`.
+Relay uses SSH and Tailscale SSH only for bootstrap, reachability checks, diagnostics, and emergency fallback. They are not the steady-state hub-node product API. Pairing and heartbeat bootstrap are handled by `relay-ide node connect` / `node install`; the persistent steady-state reverse WebSocket `/hub/node-link` is opened by `relay-ide node link --hub <url>` (foreground), which can be wrapped by your platform service manager. Bootstrap commands (`node connect`, `node install`) themselves do not open or maintain `/hub/node-link`.
 
 > This document is the runbook. For architecture and protocol details, see `docs/federated-relay.md`. For the generic Relay service install/uninstall (non-node), see `docs/references/deployment.md`.
 

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -128,7 +128,7 @@ relay-ide node install \
 
 Both commands exchange the pair token, receive a persistent credential, and send an initial heartbeat. `node install` additionally writes a launchd plist or systemd user unit and starts the service.
 
-> Current bootstrap diagnostics pair credentials and install/start the generic Relay service only; this slice does not start or maintain `/hub/node-link`. Routed sessions still require a persistent node-side client that opens the reverse link.
+> Bootstrap diagnostics pair credentials and install/start the generic Relay service. The persistent `/hub/node-link` reverse WebSocket is opened by `relay-ide node link --hub <url>` (foreground), which can be wrapped by your platform service manager.
 
 ### Step 3: Credential storage
 
@@ -153,7 +153,11 @@ Format:
 
 ### Step 4: Steady-state heartbeats
 
-A persistent node-side process reads `node-credential.json` and opens the reverse WebSocket to `/hub/node-link`, sending periodic `control.heartbeat` envelopes.
+```bash
+relay-ide node link --hub https://hub.example.com
+```
+
+`node link` reads `node-credential.json`, opens the reverse WebSocket to `/hub/node-link`, sends `control.hello` with manifest + repo inventory, and then emits a `control.heartbeat` every 20s. The hub reports the node `online` while the link is up. The client reconnects with jittered exponential backoff (1s → 60s cap) on transient close, and exits permanently on `NODE_REVOKED`, `UNAUTHORIZED`, or `PROTOCOL_INCOMPATIBLE`. Node-side PTY and RPC handlers are stubbed in this slice; routed PTY/file/git RPC arrive in follow-ups.
 
 ### Revocation
 

--- a/server/node-link-client.ts
+++ b/server/node-link-client.ts
@@ -27,8 +27,6 @@ export interface NodeLinkClientDeps {
   webSocketFactory?: NodeLinkWebSocketFactory;
   setTimeoutFn?: typeof setTimeout;
   clearTimeoutFn?: typeof clearTimeout;
-  setIntervalFn?: typeof setInterval;
-  clearIntervalFn?: typeof clearInterval;
   random?: () => number;
   logger?: Logger;
 }
@@ -99,8 +97,6 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
   const webSocketFactory = deps.webSocketFactory ?? defaultWebSocketFactory;
   const setTimer = deps.setTimeoutFn ?? setTimeout;
   const clearTimer = deps.clearTimeoutFn ?? clearTimeout;
-  const setIntervalImpl = deps.setIntervalFn ?? setInterval;
-  const clearIntervalImpl = deps.clearIntervalFn ?? clearInterval;
   const random = deps.random ?? Math.random;
   const linkUrl = toLinkUrl(deps.hubUrl);
   const headers = { Authorization: `Bearer ${deps.credential.token}` };
@@ -109,7 +105,7 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
   let ws: NodeLinkWebSocketLike | undefined;
   let reconnectAttempt = 0;
   let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
-  let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  let heartbeatTimer: ReturnType<typeof setTimeout> | undefined;
   let stopped = false;
   const stateHandlers = new Set<(state: NodeLinkState) => void>();
 
@@ -167,28 +163,46 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
     send(envelope('control', 'control.hello', { payload }));
   }
 
-  function sendHeartbeat(): void {
+  function scheduleNextHeartbeat(): void {
+    if (stopped) return;
+    heartbeatTimer = setTimer(() => {
+      heartbeatTimer = undefined;
+      runHeartbeat();
+    }, heartbeatIntervalMs);
+    (heartbeatTimer as unknown as { unref?: () => void }).unref?.();
+  }
+
+  function runHeartbeat(): void {
+    const inflightWs = ws;
+    if (stopped || !inflightWs || inflightWs.readyState !== inflightWs.OPEN) {
+      return;
+    }
     void buildControlPayload()
       .then((payload) => {
+        if (stopped || ws !== inflightWs || inflightWs.readyState !== inflightWs.OPEN) {
+          return;
+        }
         send(envelope('control', 'control.heartbeat', { payload }));
       })
       .catch((error) => {
         logger.warn(
           `heartbeat payload build failed: ${error instanceof Error ? error.message : String(error)}`
         );
+      })
+      .finally(() => {
+        if (stopped || ws !== inflightWs) return;
+        scheduleNextHeartbeat();
       });
   }
 
   function startHeartbeat(): void {
     stopHeartbeat();
-    heartbeatTimer = setIntervalImpl(sendHeartbeat, heartbeatIntervalMs);
-    // unref so heartbeat does not keep node alive on its own
-    (heartbeatTimer as unknown as { unref?: () => void }).unref?.();
+    scheduleNextHeartbeat();
   }
 
   function stopHeartbeat(): void {
     if (!heartbeatTimer) return;
-    clearIntervalImpl(heartbeatTimer);
+    clearTimer(heartbeatTimer);
     heartbeatTimer = undefined;
   }
 
@@ -257,13 +271,25 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
     ws = socket;
 
     socket.on('open', () => {
+      if (stopped || ws !== socket) return;
       setState('connected');
       logger.info(`connected to ${linkUrl}`);
-      void sendHello();
+      sendHello().catch((error) => {
+        if (stopped || ws !== socket) return;
+        logger.warn(
+          `hello failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+        try {
+          socket.close(1011, 'hello failed');
+        } catch {
+          /* ignore */
+        }
+      });
       startHeartbeat();
     });
 
     socket.on('message', (data) => {
+      if (stopped || ws !== socket) return;
       let parsed: unknown;
       try {
         parsed = JSON.parse(data.toString());
@@ -283,9 +309,10 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
     });
 
     socket.on('close', (code, reason) => {
+      if (ws !== socket && !stopped) return;
       const reasonText = reason?.toString?.() ?? '';
       stopHeartbeat();
-      ws = undefined;
+      if (ws === socket) ws = undefined;
       if (stopped) {
         setState('stopped');
         return;
@@ -300,6 +327,7 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
     });
 
     socket.on('error', (err) => {
+      if (stopped || ws !== socket) return;
       logger.warn(`socket error: ${err.message}`);
     });
   }
@@ -312,14 +340,15 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
       reconnectTimer = undefined;
     }
     stopHeartbeat();
-    if (ws && ws.readyState === ws.OPEN) {
+    const current = ws;
+    ws = undefined;
+    if (current) {
       try {
-        ws.close(1000, reason ?? 'node-link client stop');
+        current.close(1000, reason ?? 'node-link client stop');
       } catch {
         /* ignore */
       }
     }
-    ws = undefined;
     setState('stopped');
   }
 

--- a/server/node-link-client.ts
+++ b/server/node-link-client.ts
@@ -1,0 +1,344 @@
+import { WebSocket, type RawData } from 'ws';
+import type { Logger } from './logger.js';
+import { createLogger } from './logger.js';
+import type { NodeManifest } from '../shared/node-manifest.js';
+import type { RepoInventoryReport } from '../shared/repo-inventory.js';
+import {
+  RELAY_NODE_LINK_PROTOCOL,
+  RELAY_NODE_LINK_PROTOCOL_VERSION,
+  type RelayNodeEnvelope,
+  type RelayNodeError,
+} from '../shared/relay-node-protocol.js';
+
+export interface NodeLinkCredential {
+  nodeId: string;
+  token: string;
+}
+
+export interface NodeLinkClientDeps {
+  hubUrl: string;
+  credential: NodeLinkCredential;
+  getManifest: () => Promise<NodeManifest> | NodeManifest;
+  getRepoInventory?: () => Promise<RepoInventoryReport | undefined> | RepoInventoryReport | undefined;
+  heartbeatIntervalMs?: number;
+  initialReconnectDelayMs?: number;
+  maxReconnectDelayMs?: number;
+  reconnectJitterMs?: number;
+  webSocketFactory?: NodeLinkWebSocketFactory;
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+  setIntervalFn?: typeof setInterval;
+  clearIntervalFn?: typeof clearInterval;
+  random?: () => number;
+  logger?: Logger;
+}
+
+export interface NodeLinkWebSocketLike {
+  on(event: 'open', listener: () => void): void;
+  on(event: 'message', listener: (data: RawData) => void): void;
+  on(event: 'close', listener: (code: number, reason: Buffer) => void): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  readonly readyState: number;
+  readonly OPEN: number;
+}
+
+export type NodeLinkWebSocketFactory = (
+  url: string,
+  options: { headers: Record<string, string> }
+) => NodeLinkWebSocketLike;
+
+export type NodeLinkState =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'stopped';
+
+export interface NodeLinkClient {
+  start(): void;
+  stop(reason?: string): Promise<void>;
+  getState(): NodeLinkState;
+  onStateChange(handler: (state: NodeLinkState) => void): () => void;
+}
+
+const DEFAULTS = {
+  heartbeatIntervalMs: 20_000,
+  initialReconnectDelayMs: 1_000,
+  maxReconnectDelayMs: 60_000,
+  reconnectJitterMs: 500,
+};
+
+const TERMINAL_ERROR_CODES = new Set<RelayNodeError['code']>([
+  'NODE_REVOKED',
+  'PROTOCOL_INCOMPATIBLE',
+  'UNAUTHORIZED',
+]);
+
+function toLinkUrl(hubUrl: string): string {
+  const url = new URL('/hub/node-link', hubUrl);
+  if (url.protocol === 'http:') url.protocol = 'ws:';
+  else if (url.protocol === 'https:') url.protocol = 'wss:';
+  return url.toString();
+}
+
+function defaultWebSocketFactory(
+  url: string,
+  options: { headers: Record<string, string> }
+): NodeLinkWebSocketLike {
+  return new WebSocket(url, { headers: options.headers }) as unknown as NodeLinkWebSocketLike;
+}
+
+export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
+  const logger = deps.logger ?? createLogger('node-link');
+  const heartbeatIntervalMs = deps.heartbeatIntervalMs ?? DEFAULTS.heartbeatIntervalMs;
+  const initialReconnectDelayMs = deps.initialReconnectDelayMs ?? DEFAULTS.initialReconnectDelayMs;
+  const maxReconnectDelayMs = deps.maxReconnectDelayMs ?? DEFAULTS.maxReconnectDelayMs;
+  const reconnectJitterMs = deps.reconnectJitterMs ?? DEFAULTS.reconnectJitterMs;
+  const webSocketFactory = deps.webSocketFactory ?? defaultWebSocketFactory;
+  const setTimer = deps.setTimeoutFn ?? setTimeout;
+  const clearTimer = deps.clearTimeoutFn ?? clearTimeout;
+  const setIntervalImpl = deps.setIntervalFn ?? setInterval;
+  const clearIntervalImpl = deps.clearIntervalFn ?? clearInterval;
+  const random = deps.random ?? Math.random;
+  const linkUrl = toLinkUrl(deps.hubUrl);
+  const headers = { Authorization: `Bearer ${deps.credential.token}` };
+
+  let state: NodeLinkState = 'idle';
+  let ws: NodeLinkWebSocketLike | undefined;
+  let reconnectAttempt = 0;
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+  let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  let stopped = false;
+  const stateHandlers = new Set<(state: NodeLinkState) => void>();
+
+  function setState(next: NodeLinkState): void {
+    if (state === next) return;
+    state = next;
+    for (const handler of Array.from(stateHandlers)) handler(next);
+  }
+
+  function envelope(
+    channel: RelayNodeEnvelope['channel'],
+    type: string,
+    extras: Partial<RelayNodeEnvelope> = {}
+  ): RelayNodeEnvelope {
+    return {
+      protocol: RELAY_NODE_LINK_PROTOCOL,
+      protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+      nodeId: deps.credential.nodeId,
+      channel,
+      type,
+      timestamp: new Date().toISOString(),
+      ...extras,
+    };
+  }
+
+  function send(payload: RelayNodeEnvelope): void {
+    if (!ws || ws.readyState !== ws.OPEN) return;
+    try {
+      ws.send(JSON.stringify(payload));
+    } catch (error) {
+      logger.warn(
+        `send failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  async function buildControlPayload(): Promise<Record<string, unknown>> {
+    const manifest = await deps.getManifest();
+    const payload: Record<string, unknown> = { manifest };
+    if (deps.getRepoInventory) {
+      try {
+        const repoInventory = await deps.getRepoInventory();
+        if (repoInventory) payload['repoInventory'] = repoInventory;
+      } catch (error) {
+        logger.warn(
+          `repo inventory collection failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+    return payload;
+  }
+
+  async function sendHello(): Promise<void> {
+    const payload = await buildControlPayload();
+    send(envelope('control', 'control.hello', { payload }));
+  }
+
+  function sendHeartbeat(): void {
+    void buildControlPayload()
+      .then((payload) => {
+        send(envelope('control', 'control.heartbeat', { payload }));
+      })
+      .catch((error) => {
+        logger.warn(
+          `heartbeat payload build failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+      });
+  }
+
+  function startHeartbeat(): void {
+    stopHeartbeat();
+    heartbeatTimer = setIntervalImpl(sendHeartbeat, heartbeatIntervalMs);
+    // unref so heartbeat does not keep node alive on its own
+    (heartbeatTimer as unknown as { unref?: () => void }).unref?.();
+  }
+
+  function stopHeartbeat(): void {
+    if (!heartbeatTimer) return;
+    clearIntervalImpl(heartbeatTimer);
+    heartbeatTimer = undefined;
+  }
+
+  function nextReconnectDelay(): number {
+    const exponent = Math.min(reconnectAttempt, 10);
+    const base = Math.min(
+      maxReconnectDelayMs,
+      initialReconnectDelayMs * 2 ** exponent
+    );
+    const jitter = Math.floor(random() * reconnectJitterMs);
+    return base + jitter;
+  }
+
+  function scheduleReconnect(reason: string): void {
+    if (stopped) return;
+    setState('reconnecting');
+    const delay = nextReconnectDelay();
+    reconnectAttempt += 1;
+    logger.info(`reconnect in ${delay}ms (attempt ${reconnectAttempt}): ${reason}`);
+    reconnectTimer = setTimer(() => {
+      reconnectTimer = undefined;
+      connect();
+    }, delay);
+    (reconnectTimer as unknown as { unref?: () => void }).unref?.();
+  }
+
+  function handleEnvelope(env: RelayNodeEnvelope): void {
+    if (env.channel === 'control') {
+      if (env.type === 'control.hello.result' || env.type === 'control.heartbeat.ack') {
+        reconnectAttempt = 0;
+        return;
+      }
+      if (env.type === 'control.error' && env.error) {
+        if (TERMINAL_ERROR_CODES.has(env.error.code)) {
+          logger.error(
+            `terminal error from hub (${env.error.code}): ${env.error.message}`
+          );
+          void stop(env.error.message);
+          return;
+        }
+        logger.warn(
+          `control.error from hub (${env.error.code}): ${env.error.message}`
+        );
+        return;
+      }
+    }
+    if (env.channel === 'pty' || env.channel === 'rpc') {
+      logger.debug(
+        `received ${env.channel}/${env.type}; node-side handler not implemented yet`
+      );
+      return;
+    }
+  }
+
+  function connect(): void {
+    if (stopped) return;
+    setState('connecting');
+    let socket: NodeLinkWebSocketLike;
+    try {
+      socket = webSocketFactory(linkUrl, { headers });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      scheduleReconnect(`dial threw: ${message}`);
+      return;
+    }
+    ws = socket;
+
+    socket.on('open', () => {
+      setState('connected');
+      logger.info(`connected to ${linkUrl}`);
+      void sendHello();
+      startHeartbeat();
+    });
+
+    socket.on('message', (data) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(data.toString());
+      } catch {
+        logger.warn('received non-JSON frame; ignoring');
+        return;
+      }
+      if (
+        typeof parsed !== 'object' ||
+        parsed === null ||
+        (parsed as { protocol?: unknown }).protocol !== RELAY_NODE_LINK_PROTOCOL
+      ) {
+        logger.warn('received frame with unexpected protocol; ignoring');
+        return;
+      }
+      handleEnvelope(parsed as RelayNodeEnvelope);
+    });
+
+    socket.on('close', (code, reason) => {
+      const reasonText = reason?.toString?.() ?? '';
+      stopHeartbeat();
+      ws = undefined;
+      if (stopped) {
+        setState('stopped');
+        return;
+      }
+      if (code === 4003) {
+        // hub-side revoke close
+        logger.error(`hub closed link with code ${code}: ${reasonText}`);
+        void stop(reasonText || 'closed by hub');
+        return;
+      }
+      scheduleReconnect(`socket closed (code=${code} reason=${reasonText})`);
+    });
+
+    socket.on('error', (err) => {
+      logger.warn(`socket error: ${err.message}`);
+    });
+  }
+
+  async function stop(reason?: string): Promise<void> {
+    if (stopped) return;
+    stopped = true;
+    if (reconnectTimer) {
+      clearTimer(reconnectTimer);
+      reconnectTimer = undefined;
+    }
+    stopHeartbeat();
+    if (ws && ws.readyState === ws.OPEN) {
+      try {
+        ws.close(1000, reason ?? 'node-link client stop');
+      } catch {
+        /* ignore */
+      }
+    }
+    ws = undefined;
+    setState('stopped');
+  }
+
+  function start(): void {
+    if (state !== 'idle') return;
+    stopped = false;
+    reconnectAttempt = 0;
+    connect();
+  }
+
+  function onStateChange(handler: (state: NodeLinkState) => void): () => void {
+    stateHandlers.add(handler);
+    return () => stateHandlers.delete(handler);
+  }
+
+  return {
+    start,
+    stop,
+    getState: () => state,
+    onStateChange,
+  };
+}

--- a/test/node-bootstrap-docs.test.ts
+++ b/test/node-bootstrap-docs.test.ts
@@ -34,8 +34,9 @@ describe('relay-node bootstrap docs', () => {
     const docs = readRepoFile('docs/RELAY_NODE_BOOTSTRAP.md');
 
     expect(docs).toContain(
-      'do **not** start or maintain the reverse WebSocket link `/hub/node-link`'
+      'Bootstrap commands (`node connect`, `node install`) themselves do not open or maintain `/hub/node-link`'
     );
+    expect(docs).toContain('relay-ide node link --hub');
     expect(cliSource).toContain('does not start or maintain /hub/node-link');
     expect(docs).not.toMatch(/node install[^\n]+establishes steady-state/i);
     expect(docs).not.toMatch(/install\/start creates steady-state/i);

--- a/test/node-link-client.test.ts
+++ b/test/node-link-client.test.ts
@@ -116,50 +116,32 @@ function fakeManifest(): NodeManifest {
 interface FakeTimerEnv {
   setTimeoutFn: typeof setTimeout;
   clearTimeoutFn: typeof clearTimeout;
-  setIntervalFn: typeof setInterval;
-  clearIntervalFn: typeof clearInterval;
   run(): void;
   scheduled(): Array<{ delay: number }>;
 }
 
 function fakeTimerEnv(): FakeTimerEnv {
-  const timers: Array<{ id: number; delay: number; fn: () => void; type: 'timeout' | 'interval' }> = [];
+  const timers: Array<{ id: number; delay: number; fn: () => void }> = [];
   let nextId = 1;
   const setTimeoutFn = ((fn: () => void, delay: number) => {
     const id = nextId++;
-    timers.push({ id, delay, fn, type: 'timeout' });
+    timers.push({ id, delay, fn });
     return id as unknown as ReturnType<typeof setTimeout>;
   }) as typeof setTimeout;
   const clearTimeoutFn = ((id: unknown) => {
     const idx = timers.findIndex((t) => t.id === id);
     if (idx >= 0) timers.splice(idx, 1);
   }) as typeof clearTimeout;
-  const setIntervalFn = ((fn: () => void, delay: number) => {
-    const id = nextId++;
-    timers.push({ id, delay, fn, type: 'interval' });
-    return id as unknown as ReturnType<typeof setInterval>;
-  }) as typeof setInterval;
-  const clearIntervalFn = ((id: unknown) => {
-    const idx = timers.findIndex((t) => t.id === id);
-    if (idx >= 0) timers.splice(idx, 1);
-  }) as typeof clearInterval;
   return {
     setTimeoutFn,
     clearTimeoutFn,
-    setIntervalFn,
-    clearIntervalFn,
     run() {
-      const due = timers.filter((t) => t.type === 'timeout');
-      for (const timer of due) {
-        const idx = timers.indexOf(timer);
-        if (idx >= 0) timers.splice(idx, 1);
-        timer.fn();
-      }
+      const due = timers.slice();
+      timers.length = 0;
+      for (const timer of due) timer.fn();
     },
     scheduled() {
-      return timers
-        .filter((t) => t.type === 'timeout')
-        .map((t) => ({ delay: t.delay }));
+      return timers.map((t) => ({ delay: t.delay }));
     },
   };
 }

--- a/test/node-link-client.test.ts
+++ b/test/node-link-client.test.ts
@@ -1,0 +1,410 @@
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import { WebSocket } from 'ws';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createHubNodeRegistry } from '../server/hub-node-registry.js';
+import { createHubNodeLinkManager } from '../server/hub-node-link.js';
+import { setupWebSocket } from '../server/ws.js';
+import {
+  createNodeLinkClient,
+  type NodeLinkWebSocketFactory,
+  type NodeLinkWebSocketLike,
+} from '../server/node-link-client.js';
+import type { NodeManifest } from '../shared/node-manifest.js';
+import {
+  RELAY_NODE_LINK_PROTOCOL,
+  RELAY_NODE_LINK_PROTOCOL_VERSION,
+  type RelayNodeEnvelope,
+} from '../shared/relay-node-protocol.js';
+
+type Listener = (...args: unknown[]) => void;
+
+class FakeSocket implements NodeLinkWebSocketLike {
+  readyState = 0;
+  readonly OPEN = 1;
+  readonly sent: string[] = [];
+  closed: { code?: number; reason?: string } | null = null;
+  private readonly listeners = new Map<string, Listener[]>();
+
+  on(event: 'open' | 'message' | 'close' | 'error', listener: Listener): void {
+    const list = this.listeners.get(event) ?? [];
+    list.push(listener);
+    this.listeners.set(event, list);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    if (this.closed) return;
+    this.closed = { code, reason };
+    this.emit('close', code ?? 1000, Buffer.from(reason ?? ''));
+  }
+
+  emit(event: string, ...args: unknown[]): void {
+    const list = this.listeners.get(event);
+    if (!list) return;
+    for (const listener of list.slice()) listener(...args);
+  }
+
+  open(): void {
+    this.readyState = this.OPEN;
+    this.emit('open');
+  }
+
+  push(envelope: RelayNodeEnvelope): void {
+    this.emit('message', Buffer.from(JSON.stringify(envelope)));
+  }
+}
+
+function fakeManifest(): NodeManifest {
+  return {
+    schemaVersion: 1,
+    platform: 'linux',
+    arch: 'x64',
+    hostname: 'node-link-host',
+    relayVersion: '0.1.0-test',
+    generatedAt: '2026-01-02T03:04:05.000Z',
+    wsl: { detected: false, version: null, systemd: false },
+    serviceManager: {
+      kind: 'systemd-user',
+      label: 'systemd user',
+      supported: true,
+      installable: true,
+      installHint: 'install',
+      uninstallHint: 'uninstall',
+      message: 'ok',
+      caveats: [],
+    },
+    capabilities: {
+      tmux: { id: 'tmux', label: 'tmux', status: 'available', message: 'ok' },
+      git: { id: 'git', label: 'Git', status: 'available', message: 'ok' },
+      clipboard: {
+        id: 'clipboard',
+        label: 'Clipboard',
+        status: 'unknown',
+        message: 'unknown',
+      },
+      browserAutomation: {
+        id: 'browserAutomation',
+        label: 'Browser automation',
+        status: 'degraded',
+        message: 'missing deps',
+      },
+      githubCli: {
+        id: 'githubCli',
+        label: 'GitHub CLI',
+        status: 'available',
+        message: 'ok',
+      },
+      tailscale: {
+        id: 'tailscale',
+        label: 'Tailscale CLI',
+        status: 'unavailable',
+        message: 'missing',
+      },
+      ssh: { id: 'ssh', label: 'SSH client', status: 'available', message: 'ok' },
+      agents: {},
+    },
+  };
+}
+
+interface FakeTimerEnv {
+  setTimeoutFn: typeof setTimeout;
+  clearTimeoutFn: typeof clearTimeout;
+  setIntervalFn: typeof setInterval;
+  clearIntervalFn: typeof clearInterval;
+  run(): void;
+  scheduled(): Array<{ delay: number }>;
+}
+
+function fakeTimerEnv(): FakeTimerEnv {
+  const timers: Array<{ id: number; delay: number; fn: () => void; type: 'timeout' | 'interval' }> = [];
+  let nextId = 1;
+  const setTimeoutFn = ((fn: () => void, delay: number) => {
+    const id = nextId++;
+    timers.push({ id, delay, fn, type: 'timeout' });
+    return id as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+  const clearTimeoutFn = ((id: unknown) => {
+    const idx = timers.findIndex((t) => t.id === id);
+    if (idx >= 0) timers.splice(idx, 1);
+  }) as typeof clearTimeout;
+  const setIntervalFn = ((fn: () => void, delay: number) => {
+    const id = nextId++;
+    timers.push({ id, delay, fn, type: 'interval' });
+    return id as unknown as ReturnType<typeof setInterval>;
+  }) as typeof setInterval;
+  const clearIntervalFn = ((id: unknown) => {
+    const idx = timers.findIndex((t) => t.id === id);
+    if (idx >= 0) timers.splice(idx, 1);
+  }) as typeof clearInterval;
+  return {
+    setTimeoutFn,
+    clearTimeoutFn,
+    setIntervalFn,
+    clearIntervalFn,
+    run() {
+      const due = timers.filter((t) => t.type === 'timeout');
+      for (const timer of due) {
+        const idx = timers.indexOf(timer);
+        if (idx >= 0) timers.splice(idx, 1);
+        timer.fn();
+      }
+    },
+    scheduled() {
+      return timers
+        .filter((t) => t.type === 'timeout')
+        .map((t) => ({ delay: t.delay }));
+    },
+  };
+}
+
+describe('node link client (unit)', () => {
+  it('sends control.hello with manifest after open', async () => {
+    const fake = new FakeSocket();
+    const factory: NodeLinkWebSocketFactory = () => fake;
+    const timers = fakeTimerEnv();
+    const client = createNodeLinkClient({
+      hubUrl: 'http://hub.test',
+      credential: { nodeId: 'node-1', token: 't' },
+      getManifest: () => fakeManifest(),
+      webSocketFactory: factory,
+      ...timers,
+    });
+    client.start();
+    fake.open();
+    await new Promise((r) => setImmediate(r));
+    expect(fake.sent).toHaveLength(1);
+    const env = JSON.parse(fake.sent[0]!) as RelayNodeEnvelope;
+    expect(env.protocol).toBe(RELAY_NODE_LINK_PROTOCOL);
+    expect(env.protocolVersion).toBe(RELAY_NODE_LINK_PROTOCOL_VERSION);
+    expect(env.nodeId).toBe('node-1');
+    expect(env.channel).toBe('control');
+    expect(env.type).toBe('control.hello');
+    expect((env.payload as { manifest: NodeManifest }).manifest.hostname).toBe(
+      'node-link-host'
+    );
+  });
+
+  it('schedules exponential backoff with jitter on close', async () => {
+    const sockets: FakeSocket[] = [];
+    const factory: NodeLinkWebSocketFactory = () => {
+      const s = new FakeSocket();
+      sockets.push(s);
+      return s;
+    };
+    const timers = fakeTimerEnv();
+    const client = createNodeLinkClient({
+      hubUrl: 'http://hub.test',
+      credential: { nodeId: 'node-1', token: 't' },
+      getManifest: () => fakeManifest(),
+      webSocketFactory: factory,
+      initialReconnectDelayMs: 100,
+      maxReconnectDelayMs: 10_000,
+      reconnectJitterMs: 0,
+      random: () => 0,
+      ...timers,
+    });
+    client.start();
+    expect(sockets).toHaveLength(1);
+    sockets[0]!.close(1006, 'lost');
+    expect(timers.scheduled().map((s) => s.delay)).toEqual([100]);
+    timers.run();
+    expect(sockets).toHaveLength(2);
+    sockets[1]!.close(1006, 'lost');
+    expect(timers.scheduled().map((s) => s.delay)).toEqual([200]);
+    void client.stop();
+  });
+
+  it('stops permanently on NODE_REVOKED control.error', async () => {
+    const fake = new FakeSocket();
+    const factory: NodeLinkWebSocketFactory = () => fake;
+    const timers = fakeTimerEnv();
+    const client = createNodeLinkClient({
+      hubUrl: 'http://hub.test',
+      credential: { nodeId: 'node-1', token: 't' },
+      getManifest: () => fakeManifest(),
+      webSocketFactory: factory,
+      ...timers,
+    });
+    client.start();
+    fake.open();
+    await new Promise((r) => setImmediate(r));
+    fake.push({
+      protocol: RELAY_NODE_LINK_PROTOCOL,
+      protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+      nodeId: 'node-1',
+      channel: 'control',
+      type: 'control.error',
+      timestamp: new Date().toISOString(),
+      error: { code: 'NODE_REVOKED', message: 'revoked', retryable: false },
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(client.getState()).toBe('stopped');
+    expect(timers.scheduled()).toEqual([]);
+  });
+});
+
+function tmpRegistry(now = () => new Date('2026-01-02T03:04:05.000Z')) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-node-link-client-'));
+  const registry = createHubNodeRegistry({
+    storagePath: path.join(tmpDir, 'nodes.json'),
+    now,
+  });
+  return { tmpDir, registry };
+}
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string')
+    throw new Error('missing server address');
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+describe('node link client (integration)', () => {
+  const cleanup: Array<() => Promise<void> | void> = [];
+
+  afterEach(async () => {
+    while (cleanup.length > 0) await cleanup.pop()?.();
+  });
+
+  it('establishes link against a real hub and marks node online via heartbeat', async () => {
+    let now = new Date('2026-01-02T03:04:05.000Z');
+    const { tmpDir, registry } = tmpRegistry(() => now);
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const exchanged = registry.exchangePairToken({
+      pairToken: registry.createPairToken({}).pairToken,
+      manifest: fakeManifest(),
+    });
+
+    const server = http.createServer(express());
+    setupWebSocket(
+      server,
+      new Set(),
+      null,
+      undefined,
+      false,
+      undefined,
+      registry,
+      createHubNodeLinkManager()
+    );
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+
+    now = new Date('2026-01-02T03:04:10.000Z');
+    const client = createNodeLinkClient({
+      hubUrl: `http://127.0.0.1:${port}`,
+      credential: {
+        nodeId: exchanged.credential.nodeId,
+        token: exchanged.credential.token,
+      },
+      getManifest: () => fakeManifest(),
+      heartbeatIntervalMs: 60_000,
+      initialReconnectDelayMs: 50,
+      maxReconnectDelayMs: 200,
+      reconnectJitterMs: 0,
+    });
+    cleanup.push(() => client.stop());
+
+    const connected = new Promise<void>((resolve) => {
+      const off = client.onStateChange((state) => {
+        if (state === 'connected') {
+          off();
+          resolve();
+        }
+      });
+    });
+    client.start();
+    await connected;
+
+    // Wait for hub to record heartbeat; poll registry briefly.
+    let online = false;
+    for (let i = 0; i < 100; i++) {
+      const summary = registry
+        .listNodes()
+        .find((n) => n.nodeId === exchanged.credential.nodeId);
+      if (summary && summary.status === 'online') {
+        online = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 20));
+    }
+    expect(online).toBe(true);
+  });
+
+  it('reconnects after a transient hub close', async () => {
+    const now = new Date('2026-01-02T03:04:05.000Z');
+    const { tmpDir, registry } = tmpRegistry(() => now);
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const exchanged = registry.exchangePairToken({
+      pairToken: registry.createPairToken({}).pairToken,
+      manifest: fakeManifest(),
+    });
+    const server = http.createServer(express());
+    setupWebSocket(
+      server,
+      new Set(),
+      null,
+      undefined,
+      false,
+      undefined,
+      registry,
+      createHubNodeLinkManager()
+    );
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+
+    const client = createNodeLinkClient({
+      hubUrl: `http://127.0.0.1:${port}`,
+      credential: {
+        nodeId: exchanged.credential.nodeId,
+        token: exchanged.credential.token,
+      },
+      getManifest: () => fakeManifest(),
+      initialReconnectDelayMs: 50,
+      maxReconnectDelayMs: 200,
+      reconnectJitterMs: 0,
+    });
+    cleanup.push(() => client.stop());
+
+    let connects = 0;
+    const reachedTwo = new Promise<void>((resolve) => {
+      const off = client.onStateChange((state) => {
+        if (state === 'connected') {
+          connects += 1;
+          if (connects === 1) {
+            // Force a remote close to trigger reconnect.
+            // Open a second client connection to the same node — hub-side
+            // registerNodeLink replaces the older socket with code 1012.
+            const replacement = new WebSocket(
+              `ws://127.0.0.1:${port}/hub/node-link`,
+              {
+                headers: { authorization: `Bearer ${exchanged.credential.token}` },
+              }
+            );
+            replacement.once('open', () => replacement.close());
+          }
+          if (connects === 2) {
+            off();
+            resolve();
+          }
+        }
+      });
+    });
+    client.start();
+    await reachedTwo;
+    expect(connects).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
Closes #416.

## Summary

Adds the node-side persistent `/hub/node-link` reverse WebSocket client. Paired nodes can now hold a live link to the hub instead of exiting after the one-shot pair heartbeat. This is the next slice after #385 (pairing + registry + heartbeat) and unblocks #378 / #397 real-host WSL2 routed-session testing.

## Changes

- **`server/node-link-client.ts`** — new node-side client.
  - Dials `<hub>/hub/node-link` with `Authorization: Bearer <node-credential>`.
  - Sends `control.hello` with manifest + repo inventory on open.
  - Sends `control.heartbeat` every 20s over the same link.
  - Jittered exponential reconnect on close/error (1s base, 60s cap).
  - Permanently stops on `NODE_REVOKED`, `UNAUTHORIZED`, `PROTOCOL_INCOMPATIBLE`, or hub close code `4003`.
  - Injectable WS factory + timer functions for deterministic tests.
- **`bin/relay-ide.ts`** — new `relay-ide node link --hub <url>` foreground command. Reads `~/.config/relay-ide/node-credential.json` (errors out clearly if missing). Wires SIGINT/SIGTERM to a clean close. Help text updated.
- **`docs/RELAY_NODE_BOOTSTRAP.md`** and **`docs/federated-relay.md`** — document `node link`, reconnect behavior, terminal error handling, and that node-side PTY/RPC handlers are still stubbed in this slice (follow-ups).
- **`test/node-link-client.test.ts`** — covers:
  - hello envelope shape on open (protocol, version, nodeId, channel, type, manifest).
  - jittered exponential backoff schedule across two reconnects (deterministic timers + random).
  - terminal stop on `NODE_REVOKED`.
  - integration: connects against a real `HubNodeRegistry` + `setupWebSocket`, observes hub marking the node `online` via heartbeat.
  - integration: reconnects after a hub-side `1012` replace close.

## Acceptance criteria (from #416)

- [x] Paired node can establish `/hub/node-link` using its stored credential.
- [x] Hub reports `online` while the link is up.
- [x] Reconnect with backoff covered by tests (deterministic unit + integration via hub-side replace).
- [x] Protocol/credential mismatch returns a typed error and the client stops.
- [x] Heartbeat travels over the persistent link.
- [x] Local mode (no hub) untouched — `node link` is opt-in.
- [x] Docs updated (`RELAY_NODE_BOOTSTRAP.md`, `federated-relay.md`).

## Out of scope (follow-ups)

- Node-side PTY attach handler (frames received and logged, no implementation).
- Node-side RPC method dispatch.
- File/git RPC surface.
- Preview ports / port forwarding.
- Service-manager auto-installation of `node link` as a managed unit (today users wrap it themselves or run foreground).

## Validation

- `npm run build` — pass
- `npm run check` — pass (38 pre-existing warnings only)
- `npm test -- test/node-link-client.test.ts` — 5/5 pass
- `npm test` full suite — 1955 pass, 1 pre-existing flake in `test/sessions.test.ts` unrelated to this change (passes in isolation)

## Refs

- Closes #416
- Refs #371 (protocol)
- Refs #385 (pairing/heartbeat groundwork)
- Refs #317 (federated relay epic)
- Unblocks #378 / #397 real-host WSL2 integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `relay-ide node link` command to establish and maintain persistent hub connectivity with automatic reconnection and exponential backoff, plus periodic heartbeat support for keeping nodes online and synchronized.

* **Documentation**
  * Updated documentation describing node bootstrap procedures, steady-state heartbeat synchronization, and hub communication behavior including reconnection strategies.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/417)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->