### PR TITLE
feat(node-link): node-side PTY attach handler

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -17,6 +17,7 @@ import { RELAY_NODE_LINK_PROTOCOL_VERSION } from '../shared/relay-node-protocol.
 import type { NodeManifest } from '../shared/node-manifest.js';
 import type { Config } from '../server/types.js';
 import { createNodeLinkClient } from '../server/node-link-client.js';
+import { createNodeLinkPtyHost } from '../server/node-link-pty-host.js';
 import { collectLocalRepoInventory } from '../server/repo-inventory.js';
 
 const execFileAsync = promisify(execFile);
@@ -354,6 +355,7 @@ async function runNodeLink(nodeArgs: string[]): Promise<void> {
   } catch {
     config = undefined;
   }
+  const ptyHost = createNodeLinkPtyHost({ nodeId: credential.nodeId });
   const client = createNodeLinkClient({
     hubUrl,
     credential,
@@ -370,12 +372,14 @@ async function runNodeLink(nodeArgs: string[]): Promise<void> {
         return undefined;
       }
     },
+    onPtyEnvelope: (envelope, ctx) => ptyHost.handle(envelope, ctx),
   });
   await new Promise<void>((resolve) => {
     let exiting = false;
     const finish = (exitCode: number): void => {
       if (exiting) return;
       exiting = true;
+      ptyHost.closeAll('node-link client stopping');
       const safetyTimer = setTimeout(() => process.exit(exitCode), 5_000);
       safetyTimer.unref?.();
       void client.stop().then(() => {

--- a/docs/RELAY_NODE_BOOTSTRAP.md
+++ b/docs/RELAY_NODE_BOOTSTRAP.md
@@ -81,7 +81,7 @@ Behavior:
 - Exits permanently when the hub returns `NODE_REVOKED`, `UNAUTHORIZED`, or `PROTOCOL_INCOMPATIBLE`.
 - `SIGINT` / `SIGTERM` close the link cleanly.
 
-Node-side PTY and RPC handling are scaffolded but no-op in this slice; routed PTY/file/git RPC are follow-ups. Local Relay mode (no hub configured) still boots without attempting `/hub/node-link`.
+`node link` also handles routed PTY traffic. When the hub calls `attachPty` for this node, it sends `pty.attach` over the link; the node spawns a real `node-pty` shell, forwards stdout/stderr as `pty.data` envelopes, and accepts inbound `pty.input` / `pty.resize` / `pty.detach`. Browser → hub → node-link → node PTY round-trips do not go through the local-mode PTY path. RPC method handlers (manifest refresh, repo listing) and file/git RPC remain follow-ups. Local Relay mode (no hub configured) still boots without attempting `/hub/node-link`.
 
 ### 3. Credential storage
 

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -157,7 +157,7 @@ Format:
 relay-ide node link --hub https://hub.example.com
 ```
 
-`node link` reads `node-credential.json`, opens the reverse WebSocket to `/hub/node-link`, sends `control.hello` with manifest + repo inventory, and then emits a `control.heartbeat` every 20s. The hub reports the node `online` while the link is up. The client reconnects with jittered exponential backoff (1s → 60s cap) on transient close, and exits permanently on `NODE_REVOKED`, `UNAUTHORIZED`, or `PROTOCOL_INCOMPATIBLE`. Node-side PTY and RPC handlers are stubbed in this slice; routed PTY/file/git RPC arrive in follow-ups.
+`node link` reads `node-credential.json`, opens the reverse WebSocket to `/hub/node-link`, sends `control.hello` with manifest + repo inventory, and then emits a `control.heartbeat` every 20s. The hub reports the node `online` while the link is up. The client reconnects with jittered exponential backoff (1s → 60s cap) on transient close, and exits permanently on `NODE_REVOKED`, `UNAUTHORIZED`, or `PROTOCOL_INCOMPATIBLE`. Routed PTY is handled end-to-end: hub `attachPty` → `pty.attach` over the reverse link → node-side `node-pty` spawn → `pty.data` / `pty.input` / `pty.resize` / `pty.detach` round-trip. Node-side RPC method handlers (manifest refresh, repo listing) and file/git RPC remain follow-ups.
 
 ### Revocation
 

--- a/server/node-link-client.ts
+++ b/server/node-link-client.ts
@@ -15,6 +15,20 @@ export interface NodeLinkCredential {
   token: string;
 }
 
+export interface NodeLinkEnvelopeHandlerContext {
+  send: (envelope: RelayNodeEnvelope) => void;
+  buildEnvelope: (
+    channel: RelayNodeEnvelope['channel'],
+    type: string,
+    extras?: Partial<RelayNodeEnvelope>
+  ) => RelayNodeEnvelope;
+}
+
+export type NodeLinkChannelHandler = (
+  envelope: RelayNodeEnvelope,
+  context: NodeLinkEnvelopeHandlerContext
+) => void;
+
 export interface NodeLinkClientDeps {
   hubUrl: string;
   credential: NodeLinkCredential;
@@ -29,6 +43,8 @@ export interface NodeLinkClientDeps {
   clearTimeoutFn?: typeof clearTimeout;
   random?: () => number;
   logger?: Logger;
+  onPtyEnvelope?: NodeLinkChannelHandler;
+  onRpcEnvelope?: NodeLinkChannelHandler;
 }
 
 export interface NodeLinkWebSocketLike {
@@ -249,10 +265,26 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
         return;
       }
     }
-    if (env.channel === 'pty' || env.channel === 'rpc') {
-      logger.debug(
-        `received ${env.channel}/${env.type}; node-side handler not implemented yet`
-      );
+    if (env.channel === 'pty') {
+      if (deps.onPtyEnvelope) {
+        deps.onPtyEnvelope(env, {
+          send,
+          buildEnvelope: envelope,
+        });
+        return;
+      }
+      logger.debug(`received pty/${env.type} but no handler registered`);
+      return;
+    }
+    if (env.channel === 'rpc') {
+      if (deps.onRpcEnvelope) {
+        deps.onRpcEnvelope(env, {
+          send,
+          buildEnvelope: envelope,
+        });
+        return;
+      }
+      logger.debug(`received rpc/${env.type} but no handler registered`);
       return;
     }
   }

--- a/server/node-link-pty-host.ts
+++ b/server/node-link-pty-host.ts
@@ -1,0 +1,282 @@
+import pty from 'node-pty';
+import type { IPty } from 'node-pty';
+import type { Logger } from './logger.js';
+import { createLogger } from './logger.js';
+import type { RelayNodeEnvelope } from '../shared/relay-node-protocol.js';
+
+const DEFAULT_COLS = 80;
+const DEFAULT_ROWS = 24;
+const DEFAULT_NAME = 'xterm-256color';
+const SCROLLBACK_BYTE_LIMIT = 256 * 1024;
+
+export interface NodeLinkPtyAttachInput {
+  sessionId?: unknown;
+  command?: unknown;
+  args?: unknown;
+  cols?: unknown;
+  rows?: unknown;
+  cwd?: unknown;
+  env?: unknown;
+}
+
+export interface NodeLinkPtyHostDeps {
+  spawn?: (command: string, args: string[], options: pty.IPtyForkOptions) => IPty;
+  defaultShell?: string;
+  defaultCwd?: string;
+  defaultEnv?: NodeJS.ProcessEnv;
+  logger?: Logger;
+}
+
+export interface NodeLinkPtyHostContext {
+  send: (envelope: RelayNodeEnvelope) => void;
+  buildEnvelope: (
+    channel: RelayNodeEnvelope['channel'],
+    type: string,
+    extras?: Partial<RelayNodeEnvelope>
+  ) => RelayNodeEnvelope;
+}
+
+export interface NodeLinkPtyHost {
+  handle(envelope: RelayNodeEnvelope, ctx: NodeLinkPtyHostContext): void;
+  closeAll(reason?: string): void;
+}
+
+interface ActiveStream {
+  streamId: string;
+  ptyProcess: IPty;
+  scrollback: string[];
+  scrollbackBytes: number;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}
+
+function asPositiveInt(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: string[] = [];
+  for (const item of value) {
+    if (typeof item !== 'string') return undefined;
+    out.push(item);
+  }
+  return out;
+}
+
+function asEnv(value: unknown): NodeJS.ProcessEnv | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const out: NodeJS.ProcessEnv = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v === 'string') out[k] = v;
+  }
+  return out;
+}
+
+function defaultLoginShell(): string {
+  return process.env['SHELL'] || '/bin/sh';
+}
+
+function sanitizeEnv(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const next = { ...base };
+  // Strip CLAUDECODE so nested Claude sessions don't reuse parent state.
+  delete next['CLAUDECODE'];
+  return next;
+}
+
+export interface NodeLinkPtyHostOptions extends NodeLinkPtyHostDeps {
+  nodeId: string;
+}
+
+export function createNodeLinkPtyHost(
+  options: NodeLinkPtyHostOptions
+): NodeLinkPtyHost {
+  const logger = options.logger ?? createLogger('node-link-pty');
+  const spawn = options.spawn ?? pty.spawn;
+  const defaultShell = options.defaultShell ?? defaultLoginShell();
+  const defaultCwd = options.defaultCwd ?? process.cwd();
+  const defaultEnv = options.defaultEnv ?? process.env;
+  const streams = new Map<string, ActiveStream>();
+  let currentCtx: NodeLinkPtyHostContext | undefined;
+
+  function sendData(streamId: string, data: string): void {
+    if (!currentCtx) return;
+    currentCtx.send(
+      currentCtx.buildEnvelope('pty', 'pty.data', {
+        streamId,
+        payload: { data },
+      })
+    );
+  }
+
+  function sendExit(streamId: string, exitCode: number, signal?: number): void {
+    if (!currentCtx) return;
+    currentCtx.send(
+      currentCtx.buildEnvelope('pty', 'pty.exit', {
+        streamId,
+        payload: { exitCode, signal: signal ?? null },
+      })
+    );
+  }
+
+  function sendError(streamId: string, message: string, retryable: boolean): void {
+    if (!currentCtx) return;
+    currentCtx.send(
+      currentCtx.buildEnvelope('pty', 'pty.error', {
+        streamId,
+        error: { code: 'INTERNAL', message, retryable },
+      })
+    );
+  }
+
+  function recordScrollback(stream: ActiveStream, chunk: string): void {
+    stream.scrollback.push(chunk);
+    stream.scrollbackBytes += chunk.length;
+    while (
+      stream.scrollbackBytes > SCROLLBACK_BYTE_LIMIT &&
+      stream.scrollback.length > 1
+    ) {
+      const dropped = stream.scrollback.shift();
+      stream.scrollbackBytes -= dropped?.length ?? 0;
+    }
+  }
+
+  function attach(streamId: string, input: NodeLinkPtyAttachInput): void {
+    if (streams.has(streamId)) {
+      logger.warn(`duplicate attach for streamId ${streamId}; ignoring`);
+      sendError(streamId, 'stream already attached', false);
+      return;
+    }
+    const command = asString(input.command) ?? defaultShell;
+    const args = asStringArray(input.args) ?? [];
+    const cols = asPositiveInt(input.cols) ?? DEFAULT_COLS;
+    const rows = asPositiveInt(input.rows) ?? DEFAULT_ROWS;
+    const cwd = asString(input.cwd) ?? defaultCwd;
+    const env = sanitizeEnv(asEnv(input.env) ?? defaultEnv);
+
+    let ptyProcess: IPty;
+    try {
+      ptyProcess = spawn(command, args, {
+        name: DEFAULT_NAME,
+        cols,
+        rows,
+        cwd,
+        env,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error(`pty spawn failed (${streamId}): ${message}`);
+      sendError(streamId, `pty spawn failed: ${message}`, false);
+      return;
+    }
+
+    const stream: ActiveStream = {
+      streamId,
+      ptyProcess,
+      scrollback: [],
+      scrollbackBytes: 0,
+    };
+    streams.set(streamId, stream);
+
+    ptyProcess.onData((chunk) => {
+      const live = streams.get(streamId);
+      if (!live || live.ptyProcess !== ptyProcess) return;
+      recordScrollback(live, chunk);
+      sendData(streamId, chunk);
+    });
+    ptyProcess.onExit(({ exitCode, signal }) => {
+      const live = streams.get(streamId);
+      if (!live || live.ptyProcess !== ptyProcess) return;
+      streams.delete(streamId);
+      sendExit(streamId, exitCode ?? 0, signal);
+    });
+  }
+
+  function input(streamId: string, data: unknown): void {
+    const stream = streams.get(streamId);
+    if (!stream) return;
+    if (typeof data !== 'string') return;
+    try {
+      stream.ptyProcess.write(data);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(`pty input failed (${streamId}): ${message}`);
+      sendError(streamId, `pty input failed: ${message}`, true);
+    }
+  }
+
+  function resize(streamId: string, cols: unknown, rows: unknown): void {
+    const stream = streams.get(streamId);
+    if (!stream) return;
+    const c = asPositiveInt(cols);
+    const r = asPositiveInt(rows);
+    if (!c || !r) return;
+    try {
+      stream.ptyProcess.resize(c, r);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(`pty resize failed (${streamId}): ${message}`);
+    }
+  }
+
+  function detach(streamId: string): void {
+    const stream = streams.get(streamId);
+    if (!stream) return;
+    streams.delete(streamId);
+    try {
+      stream.ptyProcess.kill();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(`pty kill failed (${streamId}): ${message}`);
+    }
+  }
+
+  function payloadRecord(payload: unknown): Record<string, unknown> {
+    return typeof payload === 'object' && payload !== null
+      ? (payload as Record<string, unknown>)
+      : {};
+  }
+
+  return {
+    handle(envelope: RelayNodeEnvelope, ctx: NodeLinkPtyHostContext): void {
+      if (envelope.channel !== 'pty') return;
+      if (typeof envelope.streamId !== 'string') return;
+      currentCtx = ctx;
+      const streamId = envelope.streamId;
+      const payload = payloadRecord(envelope.payload);
+      if (envelope.type === 'pty.attach') {
+        attach(streamId, payload as NodeLinkPtyAttachInput);
+        return;
+      }
+      if (envelope.type === 'pty.input') {
+        input(streamId, payload['data']);
+        return;
+      }
+      if (envelope.type === 'pty.resize') {
+        resize(streamId, payload['cols'], payload['rows']);
+        return;
+      }
+      if (envelope.type === 'pty.detach') {
+        detach(streamId);
+        return;
+      }
+    },
+    closeAll(reason?: string): void {
+      for (const stream of Array.from(streams.values())) {
+        streams.delete(stream.streamId);
+        try {
+          stream.ptyProcess.kill();
+        } catch {
+          /* best effort */
+        }
+        if (reason) {
+          sendError(stream.streamId, reason, false);
+        }
+      }
+    },
+  };
+}

--- a/server/node-link-pty-host.ts
+++ b/server/node-link-pty-host.ts
@@ -46,6 +46,7 @@ interface ActiveStream {
   ptyProcess: IPty;
   scrollback: string[];
   scrollbackBytes: number;
+  closing: boolean;
 }
 
 function asString(value: unknown): string | undefined {
@@ -68,10 +69,13 @@ function asStringArray(value: unknown): string[] | undefined {
   return out;
 }
 
+const UNSAFE_ENV_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 function asEnv(value: unknown): NodeJS.ProcessEnv | undefined {
   if (typeof value !== 'object' || value === null) return undefined;
-  const out: NodeJS.ProcessEnv = {};
+  const out = Object.create(null) as NodeJS.ProcessEnv;
   for (const [k, v] of Object.entries(value)) {
+    if (UNSAFE_ENV_KEYS.has(k)) continue;
     if (typeof v === 'string') out[k] = v;
   }
   return out;
@@ -82,9 +86,12 @@ function defaultLoginShell(): string {
 }
 
 function sanitizeEnv(base: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  const next = { ...base };
-  // Strip CLAUDECODE so nested Claude sessions don't reuse parent state.
-  delete next['CLAUDECODE'];
+  const next = Object.create(null) as NodeJS.ProcessEnv;
+  for (const [k, v] of Object.entries(base)) {
+    if (UNSAFE_ENV_KEYS.has(k)) continue;
+    if (k === 'CLAUDECODE') continue;
+    if (typeof v === 'string') next[k] = v;
+  }
   return next;
 }
 
@@ -134,14 +141,17 @@ export function createNodeLinkPtyHost(
   }
 
   function recordScrollback(stream: ActiveStream, chunk: string): void {
+    const chunkBytes = Buffer.byteLength(chunk, 'utf8');
     stream.scrollback.push(chunk);
-    stream.scrollbackBytes += chunk.length;
+    stream.scrollbackBytes += chunkBytes;
     while (
       stream.scrollbackBytes > SCROLLBACK_BYTE_LIMIT &&
       stream.scrollback.length > 1
     ) {
       const dropped = stream.scrollback.shift();
-      stream.scrollbackBytes -= dropped?.length ?? 0;
+      stream.scrollbackBytes -= dropped
+        ? Buffer.byteLength(dropped, 'utf8')
+        : 0;
     }
   }
 
@@ -179,12 +189,13 @@ export function createNodeLinkPtyHost(
       ptyProcess,
       scrollback: [],
       scrollbackBytes: 0,
+      closing: false,
     };
     streams.set(streamId, stream);
 
     ptyProcess.onData((chunk) => {
       const live = streams.get(streamId);
-      if (!live || live.ptyProcess !== ptyProcess) return;
+      if (!live || live.ptyProcess !== ptyProcess || live.closing) return;
       recordScrollback(live, chunk);
       sendData(streamId, chunk);
     });
@@ -226,12 +237,14 @@ export function createNodeLinkPtyHost(
   function detach(streamId: string): void {
     const stream = streams.get(streamId);
     if (!stream) return;
-    streams.delete(streamId);
+    stream.closing = true;
     try {
       stream.ptyProcess.kill();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logger.warn(`pty kill failed (${streamId}): ${message}`);
+      streams.delete(streamId);
+      sendExit(streamId, -1);
     }
   }
 
@@ -267,14 +280,16 @@ export function createNodeLinkPtyHost(
     },
     closeAll(reason?: string): void {
       for (const stream of Array.from(streams.values())) {
-        streams.delete(stream.streamId);
+        stream.closing = true;
+        if (reason) {
+          sendError(stream.streamId, reason, false);
+        }
         try {
           stream.ptyProcess.kill();
         } catch {
-          /* best effort */
-        }
-        if (reason) {
-          sendError(stream.streamId, reason, false);
+          // onExit will not fire; force terminal envelope and drop the stream.
+          streams.delete(stream.streamId);
+          sendExit(stream.streamId, -1);
         }
       }
     },

--- a/test/node-link-pty-host.test.ts
+++ b/test/node-link-pty-host.test.ts
@@ -1,0 +1,423 @@
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import type { WebSocket } from 'ws';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { IPty, IPtyForkOptions } from 'node-pty';
+import { createHubNodeRegistry } from '../server/hub-node-registry.js';
+import { createHubNodeLinkManager } from '../server/hub-node-link.js';
+import { setupWebSocket } from '../server/ws.js';
+import { createNodeLinkClient } from '../server/node-link-client.js';
+import { createNodeLinkPtyHost } from '../server/node-link-pty-host.js';
+import type { NodeManifest } from '../shared/node-manifest.js';
+import {
+  RELAY_NODE_LINK_PROTOCOL,
+  RELAY_NODE_LINK_PROTOCOL_VERSION,
+  type RelayNodeEnvelope,
+} from '../shared/relay-node-protocol.js';
+
+type DataHandler = (chunk: string) => void;
+type ExitHandler = (event: { exitCode: number; signal?: number }) => void;
+
+class FakePty {
+  cols: number;
+  rows: number;
+  written: string[] = [];
+  killed = false;
+  private dataHandlers: DataHandler[] = [];
+  private exitHandlers: ExitHandler[] = [];
+
+  constructor(cols: number, rows: number) {
+    this.cols = cols;
+    this.rows = rows;
+  }
+
+  onData(handler: DataHandler): { dispose: () => void } {
+    this.dataHandlers.push(handler);
+    return {
+      dispose: () => {
+        this.dataHandlers = this.dataHandlers.filter((h) => h !== handler);
+      },
+    };
+  }
+
+  onExit(handler: ExitHandler): { dispose: () => void } {
+    this.exitHandlers.push(handler);
+    return {
+      dispose: () => {
+        this.exitHandlers = this.exitHandlers.filter((h) => h !== handler);
+      },
+    };
+  }
+
+  write(data: string): void {
+    this.written.push(data);
+  }
+
+  resize(cols: number, rows: number): void {
+    this.cols = cols;
+    this.rows = rows;
+  }
+
+  kill(): void {
+    this.killed = true;
+  }
+
+  emitData(chunk: string): void {
+    for (const handler of this.dataHandlers.slice()) handler(chunk);
+  }
+
+  emitExit(exitCode: number, signal?: number): void {
+    for (const handler of this.exitHandlers.slice()) handler({ exitCode, signal });
+  }
+}
+
+function envelopeBuilder(nodeId: string) {
+  return (
+    channel: RelayNodeEnvelope['channel'],
+    type: string,
+    extras: Partial<RelayNodeEnvelope> = {}
+  ): RelayNodeEnvelope => ({
+    protocol: RELAY_NODE_LINK_PROTOCOL,
+    protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+    nodeId,
+    channel,
+    type,
+    timestamp: new Date().toISOString(),
+    ...extras,
+  });
+}
+
+describe('node link pty host (unit)', () => {
+  it('spawns on pty.attach, forwards data, kills on detach', () => {
+    let lastPty: FakePty | undefined;
+    const sent: RelayNodeEnvelope[] = [];
+    const host = createNodeLinkPtyHost({
+      nodeId: 'node-1',
+      spawn: (command: string, args: string[], options: IPtyForkOptions) => {
+        lastPty = new FakePty(options.cols ?? 80, options.rows ?? 24);
+        return lastPty as unknown as IPty;
+      },
+    });
+    const build = envelopeBuilder('node-1');
+    const ctx = {
+      send: (env: RelayNodeEnvelope) => sent.push(env),
+      buildEnvelope: build,
+    };
+
+    host.handle(
+      build('pty', 'pty.attach', {
+        streamId: 's1',
+        payload: { sessionId: 'session-a', cols: 100, rows: 30 },
+      }),
+      ctx
+    );
+    expect(lastPty).toBeDefined();
+    expect(lastPty!.cols).toBe(100);
+
+    lastPty!.emitData('hello');
+    expect(sent.map((e) => e.type)).toEqual(['pty.data']);
+    expect((sent[0]!.payload as { data: string }).data).toBe('hello');
+
+    host.handle(
+      build('pty', 'pty.input', {
+        streamId: 's1',
+        payload: { data: 'ls\n' },
+      }),
+      ctx
+    );
+    expect(lastPty!.written).toEqual(['ls\n']);
+
+    host.handle(
+      build('pty', 'pty.resize', {
+        streamId: 's1',
+        payload: { cols: 120, rows: 40 },
+      }),
+      ctx
+    );
+    expect(lastPty!.cols).toBe(120);
+    expect(lastPty!.rows).toBe(40);
+
+    host.handle(
+      build('pty', 'pty.detach', { streamId: 's1' }),
+      ctx
+    );
+    expect(lastPty!.killed).toBe(true);
+  });
+
+  it('emits pty.exit when the underlying pty exits', () => {
+    let lastPty: FakePty | undefined;
+    const sent: RelayNodeEnvelope[] = [];
+    const host = createNodeLinkPtyHost({
+      nodeId: 'node-1',
+      spawn: (_c, _a, options: IPtyForkOptions) => {
+        lastPty = new FakePty(options.cols ?? 80, options.rows ?? 24);
+        return lastPty as unknown as IPty;
+      },
+    });
+    const build = envelopeBuilder('node-1');
+    host.handle(
+      build('pty', 'pty.attach', { streamId: 's1', payload: {} }),
+      { send: (e) => sent.push(e), buildEnvelope: build }
+    );
+    lastPty!.emitExit(0);
+    const exit = sent.find((e) => e.type === 'pty.exit');
+    expect(exit).toBeDefined();
+    expect((exit!.payload as { exitCode: number }).exitCode).toBe(0);
+  });
+
+  it('emits pty.error when spawn throws', () => {
+    const sent: RelayNodeEnvelope[] = [];
+    const host = createNodeLinkPtyHost({
+      nodeId: 'node-1',
+      spawn: () => {
+        throw new Error('boom');
+      },
+    });
+    const build = envelopeBuilder('node-1');
+    host.handle(
+      build('pty', 'pty.attach', { streamId: 's1', payload: {} }),
+      { send: (e) => sent.push(e), buildEnvelope: build }
+    );
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('pty.error');
+    expect(sent[0]!.error?.code).toBe('INTERNAL');
+  });
+
+  it('rejects duplicate attach for the same streamId', () => {
+    const sent: RelayNodeEnvelope[] = [];
+    const ptys: FakePty[] = [];
+    const host = createNodeLinkPtyHost({
+      nodeId: 'node-1',
+      spawn: (_c, _a, options: IPtyForkOptions) => {
+        const p = new FakePty(options.cols ?? 80, options.rows ?? 24);
+        ptys.push(p);
+        return p as unknown as IPty;
+      },
+    });
+    const build = envelopeBuilder('node-1');
+    const ctx = { send: (e: RelayNodeEnvelope) => sent.push(e), buildEnvelope: build };
+    host.handle(
+      build('pty', 'pty.attach', { streamId: 's1', payload: {} }),
+      ctx
+    );
+    host.handle(
+      build('pty', 'pty.attach', { streamId: 's1', payload: {} }),
+      ctx
+    );
+    expect(ptys).toHaveLength(1);
+    const err = sent.find((e) => e.type === 'pty.error');
+    expect(err).toBeDefined();
+  });
+});
+
+function fakeManifest(): NodeManifest {
+  return {
+    schemaVersion: 1,
+    platform: 'linux',
+    arch: 'x64',
+    hostname: 'node-pty-host',
+    relayVersion: '0.1.0-test',
+    generatedAt: '2026-01-02T03:04:05.000Z',
+    wsl: { detected: false, version: null, systemd: false },
+    serviceManager: {
+      kind: 'systemd-user',
+      label: 'systemd user',
+      supported: true,
+      installable: true,
+      installHint: 'install',
+      uninstallHint: 'uninstall',
+      message: 'ok',
+      caveats: [],
+    },
+    capabilities: {
+      tmux: { id: 'tmux', label: 'tmux', status: 'available', message: 'ok' },
+      git: { id: 'git', label: 'Git', status: 'available', message: 'ok' },
+      clipboard: {
+        id: 'clipboard',
+        label: 'Clipboard',
+        status: 'unknown',
+        message: 'unknown',
+      },
+      browserAutomation: {
+        id: 'browserAutomation',
+        label: 'Browser automation',
+        status: 'degraded',
+        message: 'missing deps',
+      },
+      githubCli: {
+        id: 'githubCli',
+        label: 'GitHub CLI',
+        status: 'available',
+        message: 'ok',
+      },
+      tailscale: {
+        id: 'tailscale',
+        label: 'Tailscale CLI',
+        status: 'unavailable',
+        message: 'missing',
+      },
+      ssh: { id: 'ssh', label: 'SSH client', status: 'available', message: 'ok' },
+      agents: {},
+    },
+  };
+}
+
+function tmpRegistry(now = () => new Date('2026-01-02T03:04:05.000Z')) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-node-link-pty-'));
+  const registry = createHubNodeRegistry({
+    storagePath: path.join(tmpDir, 'nodes.json'),
+    now,
+  });
+  return { tmpDir, registry };
+}
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string')
+    throw new Error('missing server address');
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+describe('node link pty host (integration)', () => {
+  const cleanup: Array<() => Promise<void> | void> = [];
+
+  afterEach(async () => {
+    while (cleanup.length > 0) await cleanup.pop()?.();
+  });
+
+  it('round-trips PTY data through hub.attachPty -> node-link client -> fake pty', async () => {
+    const { tmpDir, registry } = tmpRegistry();
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const exchanged = registry.exchangePairToken({
+      pairToken: registry.createPairToken({}).pairToken,
+      manifest: fakeManifest(),
+    });
+
+    const linkManager = createHubNodeLinkManager();
+    const server = http.createServer(express());
+    setupWebSocket(
+      server,
+      new Set(),
+      null,
+      undefined,
+      false,
+      undefined,
+      registry,
+      linkManager
+    );
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+
+    let lastPty: FakePty | undefined;
+    const ptyHost = createNodeLinkPtyHost({
+      nodeId: exchanged.credential.nodeId,
+      spawn: (_c, _a, options: IPtyForkOptions) => {
+        lastPty = new FakePty(options.cols ?? 80, options.rows ?? 24);
+        return lastPty as unknown as IPty;
+      },
+    });
+
+    const client = createNodeLinkClient({
+      hubUrl: `http://127.0.0.1:${port}`,
+      credential: {
+        nodeId: exchanged.credential.nodeId,
+        token: exchanged.credential.token,
+      },
+      getManifest: () => fakeManifest(),
+      heartbeatIntervalMs: 60_000,
+      onPtyEnvelope: (envelope, ctx) => ptyHost.handle(envelope, ctx),
+    });
+    cleanup.push(() => client.stop());
+
+    const connected = new Promise<void>((resolve) => {
+      const off = client.onStateChange((state) => {
+        if (state === 'connected') {
+          off();
+          resolve();
+        }
+      });
+    });
+    client.start();
+    await connected;
+    // Wait briefly so hub registers the link before attach.
+    for (let i = 0; i < 50; i++) {
+      if (linkManager.hasActiveNode(exchanged.credential.nodeId)) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(linkManager.hasActiveNode(exchanged.credential.nodeId)).toBe(true);
+
+    const browserSent: string[] = [];
+    type StubListener = (...args: unknown[]) => void;
+    const stubListeners = new Map<string, StubListener[]>();
+    const browserStub = {
+      readyState: 1,
+      OPEN: 1,
+      send: (data: string) => {
+        browserSent.push(data);
+      },
+      on: (event: string, listener: StubListener) => {
+        const list = stubListeners.get(event) ?? [];
+        list.push(listener);
+        stubListeners.set(event, list);
+      },
+      once: (event: string, listener: StubListener) => {
+        const wrapper: StubListener = (...args) => {
+          const list = stubListeners.get(event) ?? [];
+          stubListeners.set(
+            event,
+            list.filter((l) => l !== wrapper)
+          );
+          listener(...args);
+        };
+        const list = stubListeners.get(event) ?? [];
+        list.push(wrapper);
+        stubListeners.set(event, list);
+      },
+      close: () => {
+        const list = stubListeners.get('close') ?? [];
+        for (const handler of list.slice()) handler(1000, Buffer.from(''));
+      },
+    } as unknown as WebSocket;
+
+    linkManager.attachPty(
+      exchanged.credential.nodeId,
+      'session-int',
+      browserStub
+    );
+
+    // Wait for the node-side PTY to be spawned.
+    for (let i = 0; i < 100; i++) {
+      if (lastPty) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(lastPty).toBeDefined();
+
+    // Simulate the PTY emitting output; expect the hub to forward to browser.
+    lastPty!.emitData('node-says-hi');
+    for (let i = 0; i < 100; i++) {
+      if (browserSent.length > 0) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(browserSent.length).toBeGreaterThan(0);
+    expect(browserSent.join('')).toContain('node-says-hi');
+
+    // Simulate browser typing -> input -> node PTY.
+    const messageListeners = stubListeners.get('message') ?? [];
+    for (const handler of messageListeners) handler('echo hi');
+    for (let i = 0; i < 100; i++) {
+      if (lastPty!.written.length > 0) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(lastPty!.written.join('')).toContain('echo hi');
+  });
+});

--- a/test/node-link-pty-host.test.ts
+++ b/test/node-link-pty-host.test.ts
@@ -145,6 +145,15 @@ describe('node link pty host (unit)', () => {
       ctx
     );
     expect(lastPty!.killed).toBe(true);
+
+    // After detach the host marks the stream closing but waits for onExit
+    // before deleting the entry + emitting pty.exit. Simulate the OS-level
+    // exit signal that kill() would normally produce.
+    const sentBeforeExit = sent.length;
+    lastPty!.emitExit(0, 15);
+    const exit = sent.slice(sentBeforeExit).find((e) => e.type === 'pty.exit');
+    expect(exit).toBeDefined();
+    expect((exit!.payload as { exitCode: number }).exitCode).toBe(0);
   });
 
   it('emits pty.exit when the underlying pty exits', () => {


### PR DESCRIPTION
Closes #418.

## Summary

Closes the routed-session gap left by #416. Hub-initiated `pty.attach` over `/hub/node-link` now spawns a real `node-pty` shell on the relay-node and round-trips data, input, resize, and detach. Unblocks the first end-to-end WSL2 routed-session test (#378 / #397).

## Changes

- **`server/node-link-pty-host.ts`** — new stream registry keyed by `streamId`.
  - `pty.attach` → `node-pty` spawn (defaults to `$SHELL` / `/bin/sh`, `cols`/`rows` from payload, `CLAUDECODE` stripped from env, custom `command`/`args`/`cwd`/`env` honored when provided).
  - Forwards stdout/stderr as `pty.data` envelopes on the reverse link.
  - Accepts `pty.input` and `pty.resize`.
  - `pty.detach` kills the process; PTY exit emits `pty.exit`.
  - Spawn or write failures emit typed `pty.error` envelopes.
  - 256KB scrollback cap per stream (FIFO trim).
- **`server/node-link-client.ts`** — extends the client with `onPtyEnvelope` / `onRpcEnvelope` hooks. Replaces the previous \"not implemented\" debug log with delegated dispatch + a `NodeLinkEnvelopeHandlerContext` giving the handler `send` plus an envelope builder bound to the link.
- **`bin/relay-ide.ts`** — `node link` constructs `createNodeLinkPtyHost`, wires it via `onPtyEnvelope`, and calls `closeAll` on shutdown so PTYs don't leak.
- **`docs/RELAY_NODE_BOOTSTRAP.md`**, **`docs/federated-relay.md`** — document the routed PTY round-trip.
- **`test/node-link-pty-host.test.ts`** — coverage:
  - unit: attach → data/input/resize/detach happy path, `pty.exit` emission, spawn-error `pty.error`, duplicate-attach rejection.
  - integration: real `HubNodeRegistry` + `setupWebSocket` + `HubNodeLinkManager`. `linkManager.attachPty(nodeId, sessionId, browserStub)` → node-link client → fake PTY. Verifies browser-stub receives PTY output and that browser-stub input arrives at the node PTY.

## Acceptance criteria (from #418)

- [x] Hub-initiated `pty.attach` on a live `/hub/node-link` spawns a PTY on the node.
- [x] Browser-side input arrives at node PTY (`pty.input`); node PTY output reaches browser (`pty.data`).
- [x] `pty.resize` reaches node PTY.
- [x] `pty.detach`, PTY exit, and shutdown all clean up the stream.
- [x] Spawn/write failures emit typed `pty.error` envelopes.
- [x] Local single-node mode unchanged (PTY host only runs under `node link`).
- [x] Tests cover attach/input/resize/detach + spawn-error path.

## Out of scope (follow-ups)

- RPC method handlers (manifest refresh, repo listing) — separate ticket.
- File/git RPC surface.
- Preview ports / port forwarding.
- Session resume / cold reattach across `node link` restarts.
- tmux wrap + framework env injection on the routed path — first slice uses a bare `$SHELL`.

## Validation

- `npm run build` — pass
- `npm run check` — pass (38 pre-existing warnings)
- `npm test -- test/node-link-pty-host.test.ts` — 5/5 pass (3 unit, 1 lifecycle, 1 integration)
- `npm test` full suite — 1961/1961 pass

## Refs

- Closes #418
- Refs #416 (persistent /hub/node-link)
- Refs #371 (protocol decision)
- Refs #385 (pairing/registry/heartbeat)
- Refs #317 (federated relay epic)
- Unblocks #378 / #397 real-host WSL2 routed-session test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PTY shell support added to the node link flow; node-link now spawns and manages terminal processes with attach/input/output/resize/detach handling.
  * PTY channels are routed through node-link so browser↔hub↔node terminal round-trips are supported.

* **Bug Fixes**
  * PTY resources are cleaned up on client shutdown and signal-triggered termination.

* **Documentation**
  * Clarified routed PTY behavior in node bootstrap and federated relay docs.

* **Tests**
  * Added comprehensive PTY test suite covering attach, I/O, resize, detach, and exit scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/419)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->