### PR TITLE
docs(adrs): ADR-015 domain-agnostic core + ADR-016 node-to-node isolation

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -235,16 +235,26 @@ Both channels require authentication via `token` cookie verified during HTTP upg
 
 ## Architecture Decision Records
 
-> Normative constraints are summarized in the table below. The underlying ADR markdown files referenced here (`docs/adrs/`) were never committed to the repository — the table is authoritative. Regenerate with `/adr:update`.
+> Full ADR markdown lives under `docs/adrs/` for entries that have been
+> committed; older entries are summarized below until backfilled. Regenerate
+> with `/adr:update`.
 
-| ADR     | Topic                                                                                      |
-| ------- | ------------------------------------------------------------------------------------------ |
-| ADR-001 | Modular server architecture (composition root, dependency flow)                            |
-| ADR-003 | PTY session management (tmux substrate, in-memory state, scrollback, CLAUDECODE stripping) |
-| ADR-004 | PIN authentication (scrypt, cookie tokens, rate limiting)                                  |
-| ADR-005 | Vitest as unit/integration test runner (migrated from node:test 2026-04-03)                |
-| ADR-006 | Dual distribution (npm global + local dev, CLI flags via env vars)                         |
-| ADR-007 | WebSocket dual channels (PTY relay + event broadcast, debounced watcher)                   |
-| ADR-008 | TypeScript + ESM (strict mode, .js extensions, node: prefix, Node >= 24)                   |
+| ADR     | Topic                                                                                                                                                |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ADR-001 | Modular server architecture (composition root, dependency flow)                                                                                      |
+| ADR-003 | PTY session management (tmux substrate, in-memory state, scrollback, CLAUDECODE stripping)                                                           |
+| ADR-004 | PIN authentication (scrypt, cookie tokens, rate limiting)                                                                                            |
+| ADR-005 | Vitest as unit/integration test runner (migrated from node:test 2026-04-03)                                                                          |
+| ADR-006 | Dual distribution (npm global + local dev, CLI flags via env vars)                                                                                   |
+| ADR-007 | WebSocket dual channels (PTY relay + event broadcast, debounced watcher)                                                                             |
+| ADR-008 | TypeScript + ESM (strict mode, .js extensions, node: prefix, Node >= 24)                                                                             |
+| ADR-009 | Hub/Node Federation (hub accepts node registrations via reverse WebSocket; nodes own data plane; hub owns routing/aggregation)                       |
+| ADR-010 | Node-Initiated Outbound Links (nodes dial hub to avoid NAT/firewall inbound)                                                                         |
+| ADR-011 | Agent-driven browser automation (`server/agent-browser.ts`, Playwright)                                                                              |
+| ADR-012 | Pair-Token/Credential Lifecycle (short-lived pair token → persistent revocable node credential; SHA256 storage; immediate revocation)                |
+| ADR-013 | Capability Manifest (nodes self-report probes; hub gates routing on capability state)                                                                |
+| ADR-014 | Repo Identity Aggregation (canonical git/GitHub remote identity across nodes; local paths node-specific)                                             |
+| ADR-015 | Core relay primitives are domain-agnostic; repo/git is a feature layer ([`docs/adrs/ADR-015-core-primitives-domain-agnostic.md`](./adrs/ADR-015-core-primitives-domain-agnostic.md)) |
+| ADR-016 | Node-to-node isolation invariant; inter-node traffic flows through the hub ([`docs/adrs/ADR-016-node-to-node-isolation.md`](./adrs/ADR-016-node-to-node-isolation.md))               |
 
 > ADR-002 (vanilla JS frontend) was superseded by the Svelte 5 migration, which was subsequently superseded by the React 19 migration. `hooks.ts` does not yet have a dedicated ADR.

--- a/docs/adrs/ADR-015-core-primitives-domain-agnostic.md
+++ b/docs/adrs/ADR-015-core-primitives-domain-agnostic.md
@@ -47,8 +47,10 @@ core; the core does not depend on them.
 
 - `server/hub-node-link.ts`, `server/node-link-client.ts`,
   `server/node-link-pty-host.ts`
-- `server/hub-node-registry.ts`, `server/hub-node-router.ts` (routing only;
-  no repo semantics)
+- `server/hub-node-registry.ts`
+- Routing-only surface of `server/hub-node-router.ts` (envelope dispatch,
+  node lookup, RPC method registration). See note below; this file is
+  currently mixed.
 - `server/node-manifest.ts` (capability probes for tmux, git binary
   availability, agent CLIs — *availability*, not repo state)
 - `shared/relay-node-protocol.ts`
@@ -58,13 +60,25 @@ core; the core does not depend on them.
 
 ### Feature layer (consumes core, does not bleed into it)
 
-- Repo inventory + aggregation: `server/repo-inventory.ts`,
-  `server/hub-node-router.ts` repo endpoints, divergence summaries.
+- Repo inventory + aggregation: `server/repo-inventory.ts`, the repo-aware
+  endpoints currently inside `server/hub-node-router.ts` (see note below),
+  divergence summaries.
 - Worktree management: `server/watcher.ts`, `bin/relay-ide.ts` worktree
   subcommand.
 - Agent framework registry, framework-specific spawn defaults.
 - Workspace groupings (#103) when shipped.
 - IDE-specific UI state under `frontend/`.
+
+### Mixed-responsibility module: `server/hub-node-router.ts`
+
+`server/hub-node-router.ts` currently combines two responsibilities: pure
+routing (core) and repo-aware HTTP endpoints (feature). This is intentional
+debt acknowledged by this ADR. The refactor that splits it lives in #425:
+the routing core stays in this module (or moves to a renamed
+`server/hub-router.ts`), and repo aggregation endpoints move into the repo
+feature module and are mounted by the hub composition root. Until then,
+PRs touching this file must be tagged with the responsibility they modify
+and must not deepen the coupling.
 
 ### Rules new code must follow
 

--- a/docs/adrs/ADR-015-core-primitives-domain-agnostic.md
+++ b/docs/adrs/ADR-015-core-primitives-domain-agnostic.md
@@ -1,0 +1,109 @@
+# ADR-015: Core relay primitives are domain-agnostic; repo/git is a feature layer
+
+- **Status:** Accepted
+- **Date:** 2026-05-12
+- **Refs:** #420, #103, #317
+- **Supersedes:** none
+
+## Context
+
+Relay started as a remote IDE for Claude Code sessions. The platform has since
+grown a federated hub/node substrate (#317, #371, #385, #416, #418) whose
+primitives — paired nodes, persistent `/hub/node-link`, routed PTY, RPC
+channel, capability manifest, file ops (forthcoming) — are general-purpose
+remote-fleet primitives that do not require a git repo or an IDE frontend.
+
+Future work depends on this generality:
+
+- A CLI gateway exposing primitives to arbitrary agents (Claude tool-use,
+  Codex function-calls, Hermes, scripts).
+- File RPC for fleet-wide remote file inspection.
+- Workspaces / multi-repo groupings (#103) as a feature-layer concept rather
+  than a core requirement.
+- Hosts that participate in the fleet without serving a programming use case
+  at all (build farms, content boxes, home automation, future).
+
+Today the core makes implicit assumptions that block that future:
+
+- Heartbeat and manifest carry repo inventory as a first-class field.
+- Session creation pulls in framework registry, agent commands, and tmux
+  defaults.
+- Worktree scanning, divergence summaries, and git status are wired into
+  manifest probes.
+- "Workspace" is used to mean both "a paired node's set of repos" and "a
+  grouping of repos for the IDE UI."
+
+Each assumption is fine for the IDE use case but constrains the broader
+platform story and bleeds repo/IDE semantics into modules that should be
+generic.
+
+## Decision
+
+The relay core is domain-agnostic. Repo, git, worktree, framework, and
+workspace logic live in a clearly named **feature layer** that consumes the
+core; the core does not depend on them.
+
+### Core (must remain domain-agnostic)
+
+- `server/hub-node-link.ts`, `server/node-link-client.ts`,
+  `server/node-link-pty-host.ts`
+- `server/hub-node-registry.ts`, `server/hub-node-router.ts` (routing only;
+  no repo semantics)
+- `server/node-manifest.ts` (capability probes for tmux, git binary
+  availability, agent CLIs — *availability*, not repo state)
+- `shared/relay-node-protocol.ts`
+- `shared/node-manifest.ts`
+- Session, node, and stream identifiers are opaque strings as far as the core
+  is concerned.
+
+### Feature layer (consumes core, does not bleed into it)
+
+- Repo inventory + aggregation: `server/repo-inventory.ts`,
+  `server/hub-node-router.ts` repo endpoints, divergence summaries.
+- Worktree management: `server/watcher.ts`, `bin/relay-ide.ts` worktree
+  subcommand.
+- Agent framework registry, framework-specific spawn defaults.
+- Workspace groupings (#103) when shipped.
+- IDE-specific UI state under `frontend/`.
+
+### Rules new code must follow
+
+1. Core APIs accept opaque identifiers (`sessionId`, `nodeId`, `path`).
+   They must not encode "this path is a repo root" or "this session belongs
+   to a git worktree" in their contracts.
+2. Heartbeat and manifest envelopes may carry feature-layer payloads (repo
+   inventory, framework probes), but the core registry must not require them
+   to be present. A node with zero repos and no framework CLI must be a
+   valid first-class participant.
+3. New `/hub/...` REST routes that operate on repo data live in the repo
+   feature module and are mounted by the hub composition root, not embedded
+   in the core registry/router modules.
+4. New protocol channels (PTY, RPC, files) are core. Verbs that carry
+   repo/git semantics on top of those channels are feature-layer.
+5. PRs that touch the listed core modules and add repo/git/IDE semantics
+   must be redirected to a feature-layer module or rejected.
+
+## Consequences
+
+- **Positive.** Generic hosts (no repos, no IDE use case) can join the fleet
+  with no special handling. CLI gateway, file RPC, and future agent
+  adapters compose over a stable, narrow core. Plugin model for agents is
+  cleaner because the integration contract does not assume repos.
+- **Positive.** Repo/git/workspace features evolve independently of the
+  routing/PTY/RPC plumbing.
+- **Negative.** Existing modules need an audit and partial refactor (tracked
+  in #425). Several manifest fields move from "required" to "optional
+  feature payload."
+- **Negative.** Some routes that look natural to put in the core registry
+  (e.g., a `/nodes/:id/repos` endpoint) now require explicit mounting from
+  the feature layer. Slightly more wiring up front.
+
+## Compliance and review
+
+- `/adr:review` should fail PRs that introduce repo/git/worktree/framework
+  imports into the core modules listed above.
+- New `epic`-labeled work that touches these modules must reference this ADR
+  in its PR description.
+- Re-evaluate this ADR if the platform commits to a single use case (very
+  unlikely) or if a downstream constraint forces tight coupling (e.g., a
+  routing optimization that genuinely requires repo identity).

--- a/docs/adrs/ADR-016-node-to-node-isolation.md
+++ b/docs/adrs/ADR-016-node-to-node-isolation.md
@@ -1,0 +1,100 @@
+# ADR-016: Node-to-node isolation invariant; all inter-node traffic flows through the hub
+
+- **Status:** Accepted
+- **Date:** 2026-05-12
+- **Refs:** #421, #317, #416
+- **Supersedes:** none
+
+## Context
+
+The relay fleet pairs an arbitrary number of relay-nodes to a single
+relay-hub. Each node:
+
+- Knows the hub URL and its own persistent credential.
+- Opens an outbound WebSocket to `/hub/node-link` (#416).
+- Receives hub-initiated PTY attach (#418), heartbeat, and (planned) RPC
+  envelopes over the reverse link.
+
+Nodes today have no peer addressability. They do not learn other nodes'
+hostnames, credentials, or endpoints. The hub authenticates each link
+independently and routes envelopes by `nodeId`. This property already exists
+implicitly in the protocol.
+
+Future work will pressure this property:
+
+- Aggregating fleet-wide views (e.g., "search across all paired nodes").
+- File transfer between two paired hosts via the hub.
+- Orchestration where one node's job-output triggers work on another node.
+- Agent dispatch verbs ("run this on whichever node is best").
+
+Each of those is reasonable, but a naive implementation that lets one node
+ask the hub to "execute on behalf of peer node X" creates a lateral
+movement vector: a compromised node would gain a foothold on every other
+paired node. Tailscale ACLs and OS-level credentials mitigate transport
+exposure, but only an architectural invariant at the application layer
+prevents an in-protocol back door from being added later.
+
+## Decision
+
+Inter-node operations are not first-class. Relay-nodes never address peer
+nodes, and the hub does not expose a protocol surface that lets one node
+request execution on behalf of another.
+
+### Invariant (must hold)
+
+1. A relay-node's outbound link carries traffic for that node only. Its
+   credential authenticates exactly one node identity.
+2. The hub never proxies a request from node A so that node B sees node A
+   as the requester. Hub-side authorization always identifies the requester
+   as a hub-level peer (a browser session, a CLI-gateway invocation, an
+   agent adapter), never as another relay-node.
+3. Aggregation verbs that touch multiple nodes (search, list, dispatch) run
+   as hub-mediated fan-out. The hub authorizes each per-node leg
+   independently with hub-level credentials. Per-node legs cannot reference
+   peer node responses as authorization.
+4. Future cross-node features (file copy, job triggers, etc.) are
+   implemented as two independent hub-issued operations (read from node A,
+   write to node B) chained at the hub level, not as a single envelope that
+   names two nodes.
+5. The hub does not synthesize or relay credentials for one node to be used
+   in another node's context.
+
+### Out of scope of this ADR
+
+- Transport-layer security (TLS, Tailscale ACLs). Those are defense-in-depth
+  layers below this invariant. This ADR is the application-layer rule.
+- Multi-hub federation. If multiple hubs federate in the future, the same
+  invariant applies at each hop.
+- Operator UX for cross-node workflows. The invariant constrains the
+  protocol and routing, not how users see fleet-wide views.
+
+## Consequences
+
+- **Positive.** A compromised node's blast radius is bounded by the node
+  itself. The compromised node cannot impersonate or drive peer nodes
+  through the hub.
+- **Positive.** Hub-side authorization stays uniform: every routed request
+  has a hub-level identity. Audit log entries (see #427) carry one
+  unambiguous requester per operation.
+- **Positive.** Cross-node features remain composable via the hub's
+  primitives without inventing a "node-acts-as" surface that would couple
+  authorization to the node identity space.
+- **Negative.** Some operations cost one extra hub hop (e.g., file copy
+  between nodes flows browser/CLI → hub → node A read → hub → node B
+  write, rather than node A → node B direct). Acceptable for the security
+  property gained.
+- **Negative.** Future "agent on node A wants to call a tool on node B"
+  scenarios must be expressed as hub-mediated dispatch, which means agents
+  on nodes do not have a back-channel to peers. This is intentional.
+
+## Compliance and review
+
+- `/adr:review` should fail PRs that:
+  - Add a protocol field naming a peer node in an envelope sent by a node.
+  - Add a hub-side route that takes "actAsNodeId" or accepts a node
+    credential as authorization for routing to a different node.
+  - Add node-side outbound calls to anything other than the hub URL.
+- This invariant is referenced by #427 (security backbone) and #429 (CLI
+  gateway). PRs in those epics must demonstrate compliance.
+- Re-evaluate this ADR only if a concrete operational need cannot be met by
+  hub-mediated composition, and only after a documented threat-model review.

--- a/docs/adrs/ADR-016-node-to-node-isolation.md
+++ b/docs/adrs/ADR-016-node-to-node-isolation.md
@@ -93,7 +93,11 @@ request execution on behalf of another.
   - Add a protocol field naming a peer node in an envelope sent by a node.
   - Add a hub-side route that takes "actAsNodeId" or accepts a node
     credential as authorization for routing to a different node.
-  - Add node-side outbound calls to anything other than the hub URL.
+  - Add node-side outbound calls that target peer relay-nodes or
+    fleet-internal addresses (Tailscale peer endpoints, hub-mediated
+    cross-node URLs, etc.). Outbound calls to external services (agent
+    CLIs reaching their providers, Playwright fetching public URLs per
+    ADR-011, package registries, etc.) are not constrained by this ADR.
 - This invariant is referenced by #427 (security backbone) and #429 (CLI
   gateway). PRs in those epics must demonstrate compliance.
 - Re-evaluate this ADR only if a concrete operational need cannot be met by

--- a/test/adrs-docs.test.ts
+++ b/test/adrs-docs.test.ts
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+function readRepoFile(rel: string): string {
+  return fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+}
+
+describe('committed ADRs', () => {
+  it('ADR-015 (core primitives domain-agnostic) is committed and indexed', () => {
+    const adr = readRepoFile('docs/adrs/ADR-015-core-primitives-domain-agnostic.md');
+    expect(adr).toMatch(/^# ADR-015:/m);
+    expect(adr).toContain('Status:** Accepted');
+    expect(adr).toContain('domain-agnostic');
+    expect(adr).toContain('feature layer');
+    expect(adr).toContain('hub-node-link.ts');
+
+    const arch = readRepoFile('docs/ARCHITECTURE.md');
+    expect(arch).toContain('ADR-015-core-primitives-domain-agnostic.md');
+  });
+
+  it('ADR-016 (node-to-node isolation invariant) is committed and indexed', () => {
+    const adr = readRepoFile('docs/adrs/ADR-016-node-to-node-isolation.md');
+    expect(adr).toMatch(/^# ADR-016:/m);
+    expect(adr).toContain('Status:** Accepted');
+    expect(adr).toContain('inter-node traffic flows through the hub');
+    expect(adr).toContain('never proxies a request from node A');
+
+    const arch = readRepoFile('docs/ARCHITECTURE.md');
+    expect(arch).toContain('ADR-016-node-to-node-isolation.md');
+  });
+
+  it('ARCHITECTURE.md drops the "never committed" disclaimer once ADR files land', () => {
+    const arch = readRepoFile('docs/ARCHITECTURE.md');
+    expect(arch).not.toContain('were never committed to the repository');
+  });
+});


### PR DESCRIPTION
Closes #420. Closes #421.

## Summary

Lands the two architectural invariants that gate the broader fleet-platform repositioning work (#425, #426, #427, #428, #429, #430).

- **ADR-015** — Core relay primitives are domain-agnostic; repo/git is a feature layer.
- **ADR-016** — Node-to-node isolation; all inter-node traffic flows through the hub.

## Changes

- `docs/adrs/ADR-015-core-primitives-domain-agnostic.md` — full ADR. Lists core modules (`server/hub-node-link.ts`, `server/node-link-client.ts`, `server/node-link-pty-host.ts`, `server/hub-node-registry.ts`, `server/hub-node-router.ts` routing, `server/node-manifest.ts`, protocol types) that must stay generic, vs feature-layer modules (`server/repo-inventory.ts`, worktree code, framework registry, workspaces) that may consume the core. Five rules for new code.
- `docs/adrs/ADR-016-node-to-node-isolation.md` — full ADR. Five-rule invariant: node credentials authenticate exactly one node, hub never proxies node-A-as-requester to node-B, aggregation runs as hub-mediated fan-out, cross-node features chain at the hub, hub never synthesizes credentials across nodes.
- `docs/ARCHITECTURE.md` — indexes both new ADRs and backfills the table with ADR-009..014 that already lived inline in `docs/federated-relay.md`. Drops the stale \"never committed to the repository\" note.
- `test/adrs-docs.test.ts` — asserts both ADR files exist, headers + status + key invariant phrases are present, both files are referenced from `ARCHITECTURE.md`, and the stale disclaimer stays removed.

## Out of scope

- Refactor of `server/` to actually obey ADR-015 — that is #425.
- Security backbone implementation (capability bits, audit log, two-token confirmation) — that is #427.
- ADR-009..014 full markdown backfill. Their inline summaries in `docs/federated-relay.md` remain authoritative; can be expanded to full markdown later.

## Validation

- `npm run build` — pass
- `npm run check` — pass (38 pre-existing warnings)
- `npm test -- test/adrs-docs.test.ts` — 3/3 pass
- `npm test` full suite — 1959/1959 pass

## Refs

- Closes #420 (ADR: domain-agnostic core)
- Closes #421 (ADR: node-to-node isolation)
- Blocks #425, #427 (downstream epics now reference these invariants)
- Refs #317, #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated architecture documentation with new Architecture Decision Records (ADRs 009-016) reflecting expanded relay design decisions.
  * Published ADR-015: Core relay primitives remain domain-agnostic; repository and workspace concerns delegated to a feature layer.
  * Published ADR-016: Defined node-to-node isolation invariant for relay fleet with single hub configuration.

* **Tests**
  * Added validation tests for committed architecture decision records.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/431)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->