### PR TITLE
docs(federated-dev): per-machine synced-checkout workflow + dev:node + --version source tag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Relay Agentic Development Environment — remote web interface for Claude Code C
 | Self-hosting    | `docs/SELF_HOSTING.md`             | Build Relay with Relay using isolated dev config/ports/tmux                 |
 | Hub/node pkg    | `docs/RELAY_HUB_NODE_PACKAGING.md` | Hub vs node command shape, npm package decision, install/update commands    |
 | Node bootstrap  | `docs/RELAY_NODE_BOOTSTRAP.md`     | Pair/install/update/unpair nodes for federated Relay, bootstrap diagnostics |
+| Federated dev   | `docs/FEDERATED_DEV.md`            | Cross-machine dev workflow: synced git checkouts, `dev:node`, version skew  |
 | Federated Relay | `docs/federated-relay.md`          | Hub/node architecture, pairing, routing, ADRs                               |
 | Learnings       | `docs/LEARNINGS.md`                | Persistent cross-session learnings                                          |
 | Project skills  | `.chalk/skills/<name>/SKILL.md`    | Repo-local skills (see §Skills)                                             |

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -2,7 +2,7 @@
 /* eslint-disable no-console -- CLI entry point, user-facing stdout/stderr output */
 import path from 'node:path';
 import fs from 'node:fs';
-import { execFile, spawn } from 'node:child_process';
+import { execFile, execFileSync, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import * as service from '../server/service.js';
@@ -84,8 +84,41 @@ if (args.includes('--version') || args.includes('-v')) {
   const pkg = JSON.parse(
     fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf-8')
   ) as { version: string };
-  console.log(pkg.version);
+  const sourceTag = describeSourceCheckout();
+  console.log(sourceTag ? `${pkg.version} (${sourceTag})` : pkg.version);
   process.exit(0);
+}
+
+function describeSourceCheckout(): string | undefined {
+  // dist/bin/relay-ide.js -> repo root is two levels up
+  const repoRoot = path.resolve(__dirname, '../..');
+  const gitDir = path.join(repoRoot, '.git');
+  if (!fs.existsSync(gitDir)) return undefined;
+  try {
+    const head = execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
+      cwd: repoRoot,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    let dirty = '';
+    try {
+      const status = execFileSync(
+        'git',
+        ['status', '--porcelain', '--untracked-files=no'],
+        {
+          cwd: repoRoot,
+          encoding: 'utf-8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }
+      );
+      if (status.trim()) dirty = '-dirty';
+    } catch {
+      /* ignore */
+    }
+    return `source ${head}${dirty}`;
+  } catch {
+    return undefined;
+  }
 }
 
 function getArg(flag: string): string | undefined {
@@ -178,7 +211,9 @@ if (command === 'manifest') {
   }
 
   const manifest = await getNodeManifest(config ? { config } : {});
-  console.log(JSON.stringify(manifest, null, args.includes('--compact') ? 0 : 2));
+  console.log(
+    JSON.stringify(manifest, null, args.includes('--compact') ? 0 : 2)
+  );
   process.exit(0);
 }
 
@@ -205,7 +240,9 @@ function serviceLogHints(kind: string, mode: 'hub' | 'node'): string[] {
     ];
   }
   if (mode === 'hub') {
-    return ['manual mode has no Relay-managed service logs; run relay-ide hub in the foreground'];
+    return [
+      'manual mode has no Relay-managed service logs; run relay-ide hub in the foreground',
+    ];
   }
   return [
     'manual mode has no Relay-managed service logs; node connect only pairs credentials and exits',
@@ -239,9 +276,13 @@ function printHubLogs(): void {
 async function printNodeStatus(): Promise<void> {
   const manifest = await getNodeManifest();
   const st = service.status();
-  logger.info(`Node host: ${manifest.hostname} (${manifest.platform}/${manifest.arch})`);
+  logger.info(
+    `Node host: ${manifest.hostname} (${manifest.platform}/${manifest.arch})`
+  );
   logger.info(`Relay version: ${manifest.relayVersion}`);
-  logger.info(`Service manager: ${manifest.serviceManager.label} (${manifest.serviceManager.kind})`);
+  logger.info(
+    `Service manager: ${manifest.serviceManager.label} (${manifest.serviceManager.kind})`
+  );
   logger.info(manifest.serviceManager.message);
   logger.info(`Local service installed: ${st.installed ? 'yes' : 'no'}`);
   logger.info(`Local service running: ${st.running ? 'yes' : 'no'}`);
@@ -250,13 +291,18 @@ async function printNodeStatus(): Promise<void> {
 
 async function printNodeLogs(): Promise<void> {
   const manifest = await getNodeManifest();
-  logger.info(`Log hints for ${manifest.serviceManager.label} (${manifest.serviceManager.kind}):`);
-  for (const hint of serviceLogHints(manifest.serviceManager.kind, 'node')) logger.info(hint);
+  logger.info(
+    `Log hints for ${manifest.serviceManager.label} (${manifest.serviceManager.kind}):`
+  );
+  for (const hint of serviceLogHints(manifest.serviceManager.kind, 'node'))
+    logger.info(hint);
 }
 
 async function runNodeDoctor(hubUrl: string | undefined): Promise<void> {
   const manifest = await getNodeManifest();
-  logger.info(`Local manifest: ${manifest.hostname} ${manifest.platform}/${manifest.arch}`);
+  logger.info(
+    `Local manifest: ${manifest.hostname} ${manifest.platform}/${manifest.arch}`
+  );
   logger.info(`Service manager: ${manifest.serviceManager.kind}`);
   if (!manifest.serviceManager.supported) {
     const diagnostic = BOOTSTRAP_DIAGNOSTICS.find(
@@ -278,7 +324,11 @@ async function runNodeDoctor(hubUrl: string | undefined): Promise<void> {
       (entry) => entry.code === 'NODE_CONNECT_FAILED'
     );
     const message = error instanceof Error ? error.message : String(error);
-    logger.error(redactBootstrapSecrets(`${diagnostic?.code}: ${diagnostic?.meaning} (${message})`));
+    logger.error(
+      redactBootstrapSecrets(
+        `${diagnostic?.code}: ${diagnostic?.meaning} (${message})`
+      )
+    );
     process.exit(1);
   }
 }
@@ -287,24 +337,47 @@ function nodeEndpoint(hubUrl: string, pathname: string): string {
   return new URL(pathname, hubUrl).toString();
 }
 
-type RequestedNodeServiceMode = 'auto' | 'manual' | 'launchd' | 'systemd-user' | 'wsl-systemd' | 'wsl-manual';
-const requestedNodeServiceModes: RequestedNodeServiceMode[] = ['auto', 'manual', 'launchd', 'systemd-user', 'wsl-systemd', 'wsl-manual'];
+type RequestedNodeServiceMode =
+  | 'auto'
+  | 'manual'
+  | 'launchd'
+  | 'systemd-user'
+  | 'wsl-systemd'
+  | 'wsl-manual';
+const requestedNodeServiceModes: RequestedNodeServiceMode[] = [
+  'auto',
+  'manual',
+  'launchd',
+  'systemd-user',
+  'wsl-systemd',
+  'wsl-manual',
+];
 
 function parseNodeServiceMode(value: string): RequestedNodeServiceMode {
-  if (requestedNodeServiceModes.includes(value as RequestedNodeServiceMode)) return value as RequestedNodeServiceMode;
-  logger.error(`Invalid --service ${value}. Expected one of: ${requestedNodeServiceModes.join(', ')}`);
+  if (requestedNodeServiceModes.includes(value as RequestedNodeServiceMode))
+    return value as RequestedNodeServiceMode;
+  logger.error(
+    `Invalid --service ${value}. Expected one of: ${requestedNodeServiceModes.join(', ')}`
+  );
   process.exit(1);
 }
 
-function validateNodeServiceMode(manifest: NodeManifest, mode: RequestedNodeServiceMode): void {
+function validateNodeServiceMode(
+  manifest: NodeManifest,
+  mode: RequestedNodeServiceMode
+): void {
   if (mode === 'auto' || mode === 'manual') return;
   if (mode === 'wsl-manual') {
     if (manifest.wsl.detected && manifest.wsl.version === 2) return;
-    logger.error('SERVICE_MANAGER_UNSUPPORTED: --service wsl-manual requires running relay-ide inside a WSL2 distro. Native Windows relay-node is unsupported.');
+    logger.error(
+      'SERVICE_MANAGER_UNSUPPORTED: --service wsl-manual requires running relay-ide inside a WSL2 distro. Native Windows relay-node is unsupported.'
+    );
     process.exit(1);
   }
   if (mode !== manifest.serviceManager.kind) {
-    logger.error(`SERVICE_MANAGER_UNSUPPORTED: --service ${mode} requested, but this node reports ${manifest.serviceManager.kind}. ${manifest.serviceManager.installHint}`);
+    logger.error(
+      `SERVICE_MANAGER_UNSUPPORTED: --service ${mode} requested, but this node reports ${manifest.serviceManager.kind}. ${manifest.serviceManager.installHint}`
+    );
     process.exit(1);
   }
 }
@@ -320,7 +393,9 @@ function loadNodeCredential(): { nodeId: string; token: string } {
   try {
     const raw = JSON.parse(fs.readFileSync(credentialPath, 'utf8')) as unknown;
     if (typeof raw !== 'object' || raw === null) {
-      logger.error(`NODE_LINK_FAILED: malformed credential at ${credentialPath}.`);
+      logger.error(
+        `NODE_LINK_FAILED: malformed credential at ${credentialPath}.`
+      );
       process.exit(1);
     }
     const parsed = raw as { nodeId?: unknown; token?: unknown };
@@ -330,7 +405,9 @@ function loadNodeCredential(): { nodeId: string; token: string } {
       typeof parsed.token !== 'string' ||
       !parsed.token
     ) {
-      logger.error(`NODE_LINK_FAILED: malformed credential at ${credentialPath}.`);
+      logger.error(
+        `NODE_LINK_FAILED: malformed credential at ${credentialPath}.`
+      );
       process.exit(1);
     }
     return { nodeId: parsed.nodeId, token: parsed.token };
@@ -404,67 +481,102 @@ async function runNodeLink(nodeArgs: string[]): Promise<void> {
 
 type NodePairLifecycle = 'connect' | 'install';
 
-async function pairNode(nodeArgs: string[], lifecycle: NodePairLifecycle = 'connect'): Promise<void> {
+async function pairNode(
+  nodeArgs: string[],
+  lifecycle: NodePairLifecycle = 'connect'
+): Promise<void> {
   const hubUrl = getNodeArg(nodeArgs, '--hub');
   const pairToken = getNodeArg(nodeArgs, '--pair-token');
   if (!hubUrl || !pairToken) {
-    logger.error('Usage: relay-ide node connect --hub <url> --pair-token <token>');
+    logger.error(
+      'Usage: relay-ide node connect --hub <url> --pair-token <token>'
+    );
     process.exit(1);
   }
 
   try {
     const manifest = await getNodeManifest();
-    const exchangeRes = await fetch(nodeEndpoint(hubUrl, '/hub/pairing/exchange'), {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        pairToken,
-        manifest,
-        protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
-      }),
-    });
+    const exchangeRes = await fetch(
+      nodeEndpoint(hubUrl, '/hub/pairing/exchange'),
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          pairToken,
+          manifest,
+          protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+        }),
+      }
+    );
     const exchange = (await exchangeRes.json()) as {
       credential?: { token: string; nodeId: string };
       node?: { displayName: string };
       error?: { code: string; message: string };
     };
     if (!exchangeRes.ok || !exchange.credential) {
-      const code = exchange.error?.code === 'TOKEN_EXPIRED' ? 'PAIR_TOKEN_EXPIRED' : 'PAIR_TOKEN_INVALID';
-      logger.error(redactBootstrapSecrets(`${code}: ${exchange.error?.message ?? 'pairing failed'}`));
+      const code =
+        exchange.error?.code === 'TOKEN_EXPIRED'
+          ? 'PAIR_TOKEN_EXPIRED'
+          : 'PAIR_TOKEN_INVALID';
+      logger.error(
+        redactBootstrapSecrets(
+          `${code}: ${exchange.error?.message ?? 'pairing failed'}`
+        )
+      );
       process.exit(1);
     }
 
     fs.mkdirSync(service.CONFIG_DIR, { recursive: true });
-    const credentialPath = path.join(service.CONFIG_DIR, 'node-credential.json');
-    fs.writeFileSync(credentialPath, `${JSON.stringify(exchange.credential, null, 2)}\n`, {
-      mode: 0o600,
-    });
+    const credentialPath = path.join(
+      service.CONFIG_DIR,
+      'node-credential.json'
+    );
+    fs.writeFileSync(
+      credentialPath,
+      `${JSON.stringify(exchange.credential, null, 2)}\n`,
+      {
+        mode: 0o600,
+      }
+    );
     fs.chmodSync(credentialPath, 0o600);
 
-    const heartbeatRes = await fetch(nodeEndpoint(hubUrl, '/hub/node-heartbeat'), {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        authorization: `Bearer ${exchange.credential.token}`,
-      },
-      body: JSON.stringify({
-        nodeId: exchange.credential.nodeId,
-        protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
-        manifest,
-      }),
-    });
+    const heartbeatRes = await fetch(
+      nodeEndpoint(hubUrl, '/hub/node-heartbeat'),
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${exchange.credential.token}`,
+        },
+        body: JSON.stringify({
+          nodeId: exchange.credential.nodeId,
+          protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+          manifest,
+        }),
+      }
+    );
     if (!heartbeatRes.ok) {
       const body = await heartbeatRes.text();
-      logger.error(redactBootstrapSecrets(`NODE_CONNECT_FAILED: heartbeat rejected: ${body}`));
+      logger.error(
+        redactBootstrapSecrets(
+          `NODE_CONNECT_FAILED: heartbeat rejected: ${body}`
+        )
+      );
       process.exit(1);
     }
 
-    logger.info(`Node paired as ${exchange.node?.displayName ?? exchange.credential.nodeId}.`);
+    logger.info(
+      `Node paired as ${exchange.node?.displayName ?? exchange.credential.nodeId}.`
+    );
     logger.info(`Credential saved to ${credentialPath}.`);
     if (lifecycle === 'install') {
-      logger.info('Sent initial heartbeat; node install is pairing plus local service setup only and does not start or maintain /hub/node-link.');
+      logger.info(
+        'Sent initial heartbeat; node install is pairing plus local service setup only and does not start or maintain /hub/node-link.'
+      );
     } else {
-      logger.info('Sent initial heartbeat; node connect is pair-only and exits without starting /hub/node-link.');
+      logger.info(
+        'Sent initial heartbeat; node connect is pair-only and exits without starting /hub/node-link.'
+      );
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -493,7 +605,10 @@ if (command === 'hub') {
     runServiceCommand(printHubStatus);
   } else if (subCommand === 'logs') {
     runServiceCommand(printHubLogs);
-  } else if (hubArgs.includes('--bg') && (!subCommand || subCommand.startsWith('-'))) {
+  } else if (
+    hubArgs.includes('--bg') &&
+    (!subCommand || subCommand.startsWith('-'))
+  ) {
     runServiceCommand(() => {
       process.env['RELAY_IDE_BACKGROUND'] = '1';
       service.install({
@@ -507,7 +622,9 @@ if (command === 'hub') {
     // Fall through to the default server startup path below. Keeping this as
     // an alias preserves bare `relay-ide` while making the runtime role explicit.
   } else {
-    logger.error('Usage: relay-ide hub [install|uninstall|status|logs] [--port <port>] [--host <host>] [--config <path>]');
+    logger.error(
+      'Usage: relay-ide hub [install|uninstall|status|logs] [--port <port>] [--host <host>] [--config <path>]'
+    );
     process.exit(1);
   }
 }
@@ -533,14 +650,20 @@ if (command === 'node') {
   }
   if (subCommand === 'connect' || subCommand === 'install') {
     if (subCommand === 'install') {
-      const serviceMode = parseNodeServiceMode(getNodeArg(nodeArgs, '--service') ?? 'auto');
+      const serviceMode = parseNodeServiceMode(
+        getNodeArg(nodeArgs, '--service') ?? 'auto'
+      );
       const manifest = await getNodeManifest();
       validateNodeServiceMode(manifest, serviceMode);
       logger.info(`Bootstrap service mode requested: ${serviceMode}`);
-      logger.info('SSH/Tailscale are bootstrap transports only; current bootstrap does not establish a persistent /hub/node-link.');
+      logger.info(
+        'SSH/Tailscale are bootstrap transports only; current bootstrap does not establish a persistent /hub/node-link.'
+      );
       await pairNode(nodeArgs, 'install');
       if (serviceMode === 'manual' || serviceMode === 'wsl-manual') {
-        logger.info('Manual service mode requested; paired credentials only. No foreground node process was started.');
+        logger.info(
+          'Manual service mode requested; paired credentials only. No foreground node process was started.'
+        );
         process.exit(0);
       }
       runServiceCommand(() => {
@@ -556,7 +679,9 @@ if (command === 'node') {
       process.exit(0);
     }
   }
-  logger.error('Usage: relay-ide node <status|logs|doctor|connect|install|link>');
+  logger.error(
+    'Usage: relay-ide node <status|logs|doctor|connect|install|link>'
+  );
   process.exit(1);
 }
 
@@ -565,9 +690,7 @@ if (command === 'worktree') {
   const subCommand = wtArgs[0];
 
   if (!subCommand) {
-    logger.error(
-      'Usage: relay-ide worktree <add|remove|list> [options]'
-    );
+    logger.error('Usage: relay-ide worktree <add|remove|list> [options]');
     process.exit(1);
   }
 
@@ -662,9 +785,7 @@ if (command === 'pin') {
 
   const configPath = resolveConfigPath();
   if (!fs.existsSync(configPath)) {
-    logger.error(
-      'No config file found. Run relay-ide first to create one.'
-    );
+    logger.error('No config file found. Run relay-ide first to create one.');
     process.exit(1);
   }
 
@@ -773,7 +894,9 @@ if (
       if (st.manager.statusCommand) {
         logger.info(`Status command: ${st.manager.statusCommand}`);
       }
-      logger.info(st.installed ? st.manager.uninstallHint : st.manager.installHint);
+      logger.info(
+        st.installed ? st.manager.uninstallHint : st.manager.installHint
+      );
       for (const caveat of st.manager.caveats) logger.info(caveat);
     });
   } else {

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -99,6 +99,7 @@ function describeSourceCheckout(): string | undefined {
       cwd: repoRoot,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 2000,
     }).trim();
     let dirty = '';
     try {
@@ -109,6 +110,7 @@ function describeSourceCheckout(): string | undefined {
           cwd: repoRoot,
           encoding: 'utf-8',
           stdio: ['ignore', 'pipe', 'ignore'],
+          timeout: 2000,
         }
       );
       if (status.trim()) dirty = '-dirty';

--- a/docs/FEDERATED_DEV.md
+++ b/docs/FEDERATED_DEV.md
@@ -1,0 +1,174 @@
+# Federated Relay — Development Workflow
+
+How to develop relay-ide when more than one machine is involved (hub on one
+box, paired relay-node on another, browser on a third). The single-machine
+self-host flow is documented in [`SELF_HOSTING.md`](./SELF_HOSTING.md); this
+doc covers cross-machine iteration.
+
+End-user installs (`npm install -g relay-ide@nightly` / `@latest`) are
+documented in [`RELAY_NODE_BOOTSTRAP.md`](./RELAY_NODE_BOOTSTRAP.md) and
+[`RELAY_HUB_NODE_PACKAGING.md`](./RELAY_HUB_NODE_PACKAGING.md). Those flows
+are the production shape. Federated dev uses the same package, different
+source.
+
+## TL;DR
+
+- One package: `relay-ide`. Hub vs node is a subcommand role, not a separate
+  install.
+- For development: **synced git checkout per machine**. Each box clones the
+  repo. After a protocol-affecting change, every machine runs
+  `scripts/dev-resync.sh` (pull + `npm ci` + `npm run build` + `npm link`).
+- `relay-ide --version` prints the git short SHA when run from a source
+  checkout, so version skew across the fleet is visible in logs and on the
+  hub UI.
+- `npm run dev:node -- --hub <url>` is the node-side equivalent of
+  `npm run dev` for the hub. Builds + runs `relay-ide node link` from
+  `dist/`.
+- The `@nightly` npm dist-tag is the production fast-channel. **There is no
+  `@dev` tag.** Cross-machine dev uses source, not extra npm publishes.
+
+## Dev scenarios
+
+Pick the cheapest path per scenario; do not pay protocol-skew tax when only
+one side changed.
+
+| Scenario              | What changes                                  | Cross-machine action                                                                                                     |
+| --------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Hub-only              | Routing, registry, repo aggregation, hub UI   | Restart hub on the devbox. Paired nodes keep running stable nightly. No node-side changes.                               |
+| Frontend-only         | React UI, styles, frontend state              | `npm run dev` (or `dev:self`) on the hub host. Vite HMR. Nodes untouched.                                                |
+| Node-only             | `node-link-pty-host`, node manifest probes    | Pull + build + restart `relay-ide node link` on the affected node host(s). Hub keeps running.                            |
+| Protocol (both sides) | Envelope shape, channels, capability manifest | Resync every machine. Match git SHAs before bringing the link back up. `relay-ide --version` exposes any skew in output. |
+
+## Path of least resistance
+
+For multi-developer work or anything that touches the wire protocol, treat
+the fleet as multiple checkouts of the same branch:
+
+1. Each machine clones the repo once into its own working dir.
+2. After any protocol-affecting commit:
+   ```bash
+   scripts/dev-resync.sh
+   ```
+   This wraps `git pull --ff-only` → `npm ci` → `npm run build` →
+   `npm link --force`. Run it on every host you want to keep in step.
+3. Restart whichever role each host is playing (`relay-ide hub` /
+   `relay-ide node link --hub <url>`).
+4. Confirm version match with `relay-ide --version` on each host. A clean
+   checkout prints `0.1.x (source <sha>)`; uncommitted edits print
+   `<sha>-dirty`. Skew between hosts is the first thing to suspect when a
+   link refuses to come up.
+
+Flags:
+
+- `scripts/dev-resync.sh --no-pull` — skip the `git pull` (already pulled).
+- `scripts/dev-resync.sh --no-link` — skip `npm link` (keep the global
+  install pointing at npm-installed `@nightly`).
+
+## Running the hub from source
+
+The hub-side flows are unchanged from [`SELF_HOSTING.md`](./SELF_HOSTING.md):
+
+```bash
+# Foreground hub on isolated config/ports, source dev outside production Relay.
+npm run dev
+
+# Foreground hub on allocator-chosen ports, for nesting Relay inside Relay.
+npm run dev:self
+
+# Split: backend only, frontend served by Vite.
+npm run dev:backend
+npm run dev:vite
+
+# Production-shape startup: build + run the same compiled binary the npm
+# package ships, but from this checkout.
+npm start
+```
+
+All hub modes serve the browser at the configured port. The hub stays
+running while you iterate on a node host.
+
+## Running the node from source
+
+Pair the node host once against the dev hub (this writes the credential):
+
+```bash
+relay-ide node connect --hub http://<hub>:3456 --pair-token <pair-token>
+```
+
+Then run the persistent reverse link from this checkout:
+
+```bash
+npm run dev:node -- --hub http://<hub>:3456
+```
+
+The script builds the server (`npm run build:server`) and execs
+`node dist/bin/relay-ide.js node link --hub <url>`. It runs in the
+foreground; `SIGINT`/`SIGTERM` close the link cleanly.
+
+Equivalent without the npm wrapper:
+
+```bash
+npm run build
+node dist/bin/relay-ide.js node link --hub http://<hub>:3456
+```
+
+If you want `relay-ide` itself (anywhere on the PATH) to resolve to this
+checkout, run `npm link --force` once. `scripts/dev-resync.sh` does this
+for you.
+
+## Source-version visibility
+
+When `relay-ide` is run from a source checkout (i.e. `.git` exists at the
+package root), `--version` reports `<version> (source <short-sha>)` and
+appends `-dirty` if `git status --porcelain` shows uncommitted edits. Use
+it on every host before debugging a link issue:
+
+```bash
+relay-ide --version
+# 0.1.0 (source a1b2c3d)
+# 0.1.0 (source a1b2c3d-dirty)
+# 0.1.0                          ← installed from npm, no .git nearby
+```
+
+Hub-side logs surface the node-reported `relayVersion` on link
+establishment, so the asymmetric case (one side from npm, other from
+source) is recoverable from logs even without shelling in.
+
+## Protocol-skew note
+
+The hub enforces an exact-string match on
+`RELAY_NODE_LINK_PROTOCOL_VERSION` (`shared/relay-node-protocol.ts`). If
+you bump that constant in a protocol-affecting commit, every host must
+rebuild before the link comes back up. Symptoms of skew:
+
+- Node-side log: `terminal error from hub (PROTOCOL_INCOMPATIBLE): …`
+- Hub-side log: typed `PROTOCOL_INCOMPATIBLE` error in the audit stream.
+- `relay-ide node doctor --hub <url>` flags the mismatch.
+
+Resync every host before chasing other causes.
+
+## When to publish, not link
+
+`npm link` and `scripts/dev-resync.sh` are right for fast iteration on
+your own fleet. Publish through the existing flow (`@nightly` dist-tag,
+documented in [`docs/references/deployment.md`](./references/deployment.md))
+when:
+
+- You need a fleet-wide install that survives a reboot without a checkout.
+- You want to verify the real install path (npm tarball shape, postinstall
+  prebuilt binary handling, etc.).
+- A non-developer host needs to participate (no git/node toolchain).
+
+`@nightly` is fast enough for this. There is intentionally no `@dev`
+dist-tag.
+
+## See also
+
+- [`SELF_HOSTING.md`](./SELF_HOSTING.md) — single-machine self-host (Relay
+  inside Relay).
+- [`RELAY_NODE_BOOTSTRAP.md`](./RELAY_NODE_BOOTSTRAP.md) — pair / install /
+  doctor flows for nodes (npm-installed shape).
+- [`RELAY_HUB_NODE_PACKAGING.md`](./RELAY_HUB_NODE_PACKAGING.md) — packaging
+  decision, hub/node command shape.
+- [`federated-relay.md`](./federated-relay.md) — hub/node architecture,
+  pairing, routing, ADRs.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev:self": "npm run build:server && node dist/bin/relay-ide.js dev --self-host",
     "dev:backend": "npm run build:server && RELAY_IDE_CONFIG=./config.dev.json NO_PIN=1 RELAY_IDE_HOST=${RELAY_IDE_DEV_BACKEND_HOST:-127.0.0.1} RELAY_IDE_PORT=${RELAY_IDE_DEV_BACKEND_PORT:-3457} node dist/server/index.js",
     "dev:vite": "vite --config frontend/vite.config.ts --host ${RELAY_IDE_DEV_FRONTEND_HOST:-127.0.0.1} --port ${RELAY_IDE_DEV_FRONTEND_PORT:-5173}",
+    "dev:node": "npm run build:server && node dist/bin/relay-ide.js node link",
     "start": "npm run build && node dist/server/index.js",
     "sandbox": "npm run build && node dist/scripts/sandbox-cli.js",
     "sandbox:dev": "node dist/scripts/sandbox-cli.js",

--- a/scripts/dev-resync.sh
+++ b/scripts/dev-resync.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Per-machine resync helper for the synced-git-checkout federated dev workflow.
+# Pulls the current branch, reinstalls, rebuilds, and refreshes the global
+# `relay-ide` symlink so subsequent CLI invocations run from this checkout.
+#
+# Usage:
+#   scripts/dev-resync.sh              # pull current branch, rebuild, npm link
+#   scripts/dev-resync.sh --no-pull    # skip git pull (already pulled)
+#   scripts/dev-resync.sh --no-link    # skip npm link (don't shadow global install)
+#
+# See docs/FEDERATED_DEV.md for the full workflow.
+
+set -euo pipefail
+
+DO_PULL=1
+DO_LINK=1
+for arg in "$@"; do
+  case "$arg" in
+    --no-pull) DO_PULL=0 ;;
+    --no-link) DO_LINK=0 ;;
+    --help|-h)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown flag: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ "$DO_PULL" = "1" ]; then
+  echo "==> git pull"
+  git pull --ff-only
+fi
+
+echo "==> npm ci"
+npm ci
+
+echo "==> npm run build"
+npm run build
+
+if [ "$DO_LINK" = "1" ]; then
+  echo "==> npm link --force"
+  npm link --force
+fi
+
+VERSION_OUT="$(node dist/bin/relay-ide.js --version)"
+echo "==> relay-ide --version reports: $VERSION_OUT"
+echo "done."

--- a/scripts/dev-resync.sh
+++ b/scripts/dev-resync.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 # Per-machine resync helper for the synced-git-checkout federated dev workflow.
-# Pulls the current branch, reinstalls, rebuilds, and refreshes the global
-# `relay-ide` symlink so subsequent CLI invocations run from this checkout.
-#
-# Usage:
-#   scripts/dev-resync.sh              # pull current branch, rebuild, npm link
-#   scripts/dev-resync.sh --no-pull    # skip git pull (already pulled)
-#   scripts/dev-resync.sh --no-link    # skip npm link (don't shadow global install)
-#
 # See docs/FEDERATED_DEV.md for the full workflow.
 
 set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Per-machine resync helper for the synced-git-checkout federated dev workflow.
+Pulls the current branch, reinstalls, rebuilds, and refreshes the global
+`relay-ide` symlink so subsequent CLI invocations run from this checkout.
+
+Usage:
+  scripts/dev-resync.sh              # pull current branch, rebuild, npm link
+  scripts/dev-resync.sh --no-pull    # skip git pull (already pulled)
+  scripts/dev-resync.sh --no-link    # skip npm link (don't shadow global install)
+  scripts/dev-resync.sh --help       # print this message
+USAGE
+}
 
 DO_PULL=1
 DO_LINK=1
@@ -19,11 +25,12 @@ for arg in "$@"; do
     --no-pull) DO_PULL=0 ;;
     --no-link) DO_LINK=0 ;;
     --help|-h)
-      sed -n '2,12p' "$0"
+      usage
       exit 0
       ;;
     *)
       echo "unknown flag: $arg" >&2
+      usage >&2
       exit 2
       ;;
   esac

--- a/test/federated-dev-docs.test.ts
+++ b/test/federated-dev-docs.test.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+}
+
+describe('federated dev workflow surfaces', () => {
+  it('docs/FEDERATED_DEV.md exists and references the path-C synced checkout flow', () => {
+    const doc = read('docs/FEDERATED_DEV.md');
+    expect(doc).toContain('synced git checkout per machine');
+    expect(doc).toContain('scripts/dev-resync.sh');
+    expect(doc).toContain('npm run dev:node');
+    expect(doc).toMatch(/There is no\s+`@dev` tag/);
+    expect(doc).toMatch(/intentionally no\s+`@dev`/);
+    expect(doc).toContain('(source <short-sha>)');
+    expect(doc).toContain('PROTOCOL_INCOMPATIBLE');
+  });
+
+  it('doc map indexes the new doc from AGENTS.md / CLAUDE.md', () => {
+    const map = read('AGENTS.md');
+    expect(map).toContain('docs/FEDERATED_DEV.md');
+    expect(map).toContain('Federated dev');
+  });
+
+  it('package.json declares dev:node script', () => {
+    const pkg = JSON.parse(read('package.json')) as {
+      scripts: Record<string, string>;
+    };
+    expect(pkg.scripts['dev:node']).toBeDefined();
+    expect(pkg.scripts['dev:node']).toContain('node link');
+  });
+
+  it('scripts/dev-resync.sh is committed and executable shape', () => {
+    const script = read('scripts/dev-resync.sh');
+    expect(script.startsWith('#!/usr/bin/env bash')).toBe(true);
+    expect(script).toContain('git pull --ff-only');
+    expect(script).toContain('npm ci');
+    expect(script).toContain('npm run build');
+    expect(script).toContain('npm link --force');
+  });
+});

--- a/test/hub-node-packaging.test.ts
+++ b/test/hub-node-packaging.test.ts
@@ -163,9 +163,10 @@ describe('hub/node packaging decision', () => {
     const uninstallIndex = hubSource.indexOf("subCommand === 'uninstall'");
     const statusIndex = hubSource.indexOf("subCommand === 'status'");
     const logsIndex = hubSource.indexOf("subCommand === 'logs'");
-    const bgFallbackIndex = hubSource.indexOf(
-      "hubArgs.includes('--bg') && (!subCommand || subCommand.startsWith('-'))"
+    const bgFallbackMatch = hubSource.match(
+      /hubArgs\.includes\('--bg'\)\s*&&\s*\(!subCommand\s*\|\|\s*subCommand\.startsWith\('-'\)\)/
     );
+    const bgFallbackIndex = bgFallbackMatch?.index ?? -1;
 
     expect(installIndex).toBeGreaterThanOrEqual(0);
     expect(uninstallIndex).toBeGreaterThan(installIndex);
@@ -180,11 +181,12 @@ describe('hub/node packaging decision', () => {
     const hubEnd = cliSource.indexOf("if (command === 'node')", hubStart);
     const hubSource = cliSource.slice(hubStart, hubEnd);
 
-    const bgFallbackIndex = hubSource.indexOf(
-      "hubArgs.includes('--bg') && (!subCommand || subCommand.startsWith('-'))"
+    const bgFallbackMatch = hubSource.match(
+      /hubArgs\.includes\('--bg'\)\s*&&\s*\(!subCommand\s*\|\|\s*subCommand\.startsWith\('-'\)\)/
     );
+    const bgFallbackIndex = bgFallbackMatch?.index ?? -1;
     const foregroundHubIndex = hubSource.indexOf(
-      "!subCommand || subCommand.startsWith('-')",
+      "} else if (!subCommand || subCommand.startsWith('-')) {",
       bgFallbackIndex + 1
     );
     const usageIndex = hubSource.indexOf(
@@ -210,17 +212,29 @@ describe('hub/node packaging decision', () => {
 
   it('rejects unknown node install --service values before pairing or service install', () => {
     const cliSource = readRepoFile('bin/relay-ide.ts');
-    const serviceModeDefinitionIndex = cliSource.indexOf('type RequestedNodeServiceMode');
-    const serviceModeParserIndex = cliSource.indexOf('function parseNodeServiceMode', serviceModeDefinitionIndex);
-    const serviceModeUsageIndex = cliSource.indexOf(
-      "const serviceMode = parseNodeServiceMode(getNodeArg(nodeArgs, '--service') ?? 'auto');",
-      serviceModeParserIndex
+    const serviceModeDefinitionIndex = cliSource.indexOf(
+      'type RequestedNodeServiceMode'
     );
+    const serviceModeParserIndex = cliSource.indexOf(
+      'function parseNodeServiceMode',
+      serviceModeDefinitionIndex
+    );
+    const serviceModeUsageMatch = cliSource
+      .slice(serviceModeParserIndex)
+      .match(
+        /const serviceMode = parseNodeServiceMode\(\s*getNodeArg\(nodeArgs,\s*'--service'\)\s*\?\?\s*'auto'\s*\);/
+      );
+    const serviceModeUsageIndex = serviceModeUsageMatch
+      ? serviceModeParserIndex + (serviceModeUsageMatch.index ?? 0)
+      : -1;
     const pairNodeIndex = cliSource.indexOf(
       "await pairNode(nodeArgs, 'install');",
       serviceModeUsageIndex
     );
-    const validationSource = cliSource.slice(serviceModeDefinitionIndex, pairNodeIndex);
+    const validationSource = cliSource.slice(
+      serviceModeDefinitionIndex,
+      pairNodeIndex
+    );
 
     expect(serviceModeDefinitionIndex).toBeGreaterThanOrEqual(0);
     expect(serviceModeParserIndex).toBeGreaterThan(serviceModeDefinitionIndex);


### PR DESCRIPTION
## Summary

Documents the cross-machine dev workflow (hub on one box, paired node on another) that the existing single-machine `SELF_HOSTING.md` does not cover. Picks **synced git checkout per machine** as the canonical approach over a new `@dev` npm dist-tag — `@nightly` already covers the publish-and-install case when needed, and a third tag is not justified for this scale.

## Changes

- **`docs/FEDERATED_DEV.md` (new)** — four dev scenarios (hub-only, frontend-only, node-only, protocol), the synced-checkout path, hub/node from-source commands, source-version visibility, protocol-skew recovery, and when to publish vs link.
- **`bin/relay-ide.ts`** — `--version` now appends `(source <short-sha>[-dirty])` when run from a git checkout. Skew across the fleet is visible in every CLI/log output. npm-installed copies (no `.git` nearby) still print the bare version.
- **`package.json`** — new `dev:node` script wrapping `node dist/bin/relay-ide.js node link`. Run with `npm run dev:node -- --hub <url>`.
- **`scripts/dev-resync.sh` (new)** — one-command per-machine resync wrapper (`git pull --ff-only && npm ci && npm run build && npm link --force`). Flags: `--no-pull`, `--no-link`.
- **`AGENTS.md` (= `CLAUDE.md` symlink)** — doc map indexes the new doc.
- **`test/federated-dev-docs.test.ts`** — keeps the doc, script, and `package.json` script in sync.
- **`test/hub-node-packaging.test.ts`** — tolerates prettier line-wrapping of the CLI source. The existing tests indexOf'd specific single-line literals that broke once the file grew large enough for prettier to wrap.

## Why no `@dev` tag

`@nightly` already publishes on every push to `nightly`. A third dist-tag adds infra without unlocking a faster iteration path: source-link via `scripts/dev-resync.sh` is faster, and any change that genuinely needs the publish round-trip is a change we'd land on `nightly` anyway. Documented in `FEDERATED_DEV.md` § *When to publish, not link*.

## Validation

```
> relay-ide --version
0.1.0 (source 348f344-dirty)
```

- `npm run build` — pass.
- `npm run check` — pass (38 pre-existing warnings, none in changed files).
- `npm test -- test/federated-dev-docs.test.ts` — 4/4 pass.
- `npm test -- test/hub-node-packaging.test.ts` — 7/7 pass.
- `npm test` full suite — 1968 pass / 1 pre-existing `sessions.test.ts` flake (passes in isolation, unrelated).

## Refs

- Refs ADR-009 (Hub/Node Federation), ADR-010 (node-initiated outbound).
- Builds on #411 (hub/node packaging decision), #416 (persistent /hub/node-link), #418/#419 (node-side PTY host).
- Unblocks the three-machine dogfood bring-up (browser on MacBook → hub on Linux devbox → routed PTY on WSL2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for multi-machine federated development workflows using hub and node

* **New Features**
  * Enhanced `--version` command to display git source and dirty state information

* **Chores**
  * Added development scripts for synchronized multi-machine setup
  * Added test coverage for federated development environment consistency

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/442)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->