### PR TITLE
refactor(core): strip repo-inventory imports from core modules (#432)

### DIFF
--- a/server/features/repo-inventory.ts
+++ b/server/features/repo-inventory.ts
@@ -69,9 +69,13 @@ export function createRepoInventoryFeature(
     listInventoryReports: (options) => {
       const payloads = registry.listInventoryPayloads(options);
       const reports: RepoInventoryReport[] = [];
-      for (const { payload } of payloads) {
+      for (const { nodeId, payload } of payloads) {
         const parsed = parseStoredInventory(payload);
-        if (parsed) reports.push(parsed);
+        // Defensive read-side check: drop a stored payload whose
+        // self-reported nodeId disagrees with the record it was stored
+        // against. Guards aggregation against corrupted on-disk state
+        // or any path that bypassed the heartbeat-time validator.
+        if (parsed && parsed.nodeId === nodeId) reports.push(parsed);
       }
       return reports;
     },

--- a/server/features/repo-inventory.ts
+++ b/server/features/repo-inventory.ts
@@ -1,0 +1,82 @@
+import {
+  aggregateRepoInventoryReports,
+  isRepoInventoryReport,
+  type AggregatedRepoInventoryResponse,
+  type RepoInventoryReport,
+} from '../../shared/repo-inventory.js';
+import type { RelayNodeError } from '../../shared/relay-node-protocol.js';
+import type { HubNodeRegistry } from '../hub-node-registry.js';
+
+export interface InventoryValidationContext {
+  nodeId: string;
+}
+
+export type InventoryValidationResult =
+  | { ok: true; payload: RepoInventoryReport | undefined }
+  | { ok: false; error: RelayNodeError };
+
+function invalidRequest(message: string): RelayNodeError {
+  return { code: 'INVALID_REQUEST', message, retryable: false };
+}
+
+export function validateInventoryPayload(
+  payload: unknown,
+  ctx: InventoryValidationContext
+): InventoryValidationResult {
+  if (payload === undefined || payload === null) {
+    return { ok: true, payload: undefined };
+  }
+  if (!isRepoInventoryReport(payload)) {
+    return { ok: false, error: invalidRequest('repoInventory is malformed') };
+  }
+  if (payload.nodeId !== ctx.nodeId) {
+    return {
+      ok: false,
+      error: invalidRequest(
+        'repoInventory.nodeId must match authenticated nodeId'
+      ),
+    };
+  }
+  return { ok: true, payload };
+}
+
+export function parseStoredInventory(
+  payload: unknown
+): RepoInventoryReport | null {
+  if (payload === undefined || payload === null) return null;
+  return isRepoInventoryReport(payload) ? payload : null;
+}
+
+export interface RepoInventoryFeature {
+  validateInventoryPayload: (
+    payload: unknown,
+    ctx: InventoryValidationContext
+  ) => InventoryValidationResult;
+  listInventoryReports: (options?: {
+    includeRevoked?: boolean;
+  }) => RepoInventoryReport[];
+  aggregateInventoryReports: (
+    reports: RepoInventoryReport[],
+    now?: Date
+  ) => AggregatedRepoInventoryResponse;
+}
+
+export function createRepoInventoryFeature(
+  registry: HubNodeRegistry
+): RepoInventoryFeature {
+  return {
+    validateInventoryPayload,
+    listInventoryReports: (options) => {
+      const payloads = registry.listInventoryPayloads(options);
+      const reports: RepoInventoryReport[] = [];
+      for (const { payload } of payloads) {
+        const parsed = parseStoredInventory(payload);
+        if (parsed) reports.push(parsed);
+      }
+      return reports;
+    },
+    aggregateInventoryReports: aggregateRepoInventoryReports,
+  };
+}
+
+export type { RepoInventoryReport, AggregatedRepoInventoryResponse };

--- a/server/hub-node-link.ts
+++ b/server/hub-node-link.ts
@@ -5,10 +5,6 @@ import type { RawData } from 'ws';
 import type { HubNodeRegistry } from './hub-node-registry.js';
 import { isNodeManifest, type NodeManifest } from '../shared/node-manifest.js';
 import {
-  isRepoInventoryReport,
-  type RepoInventoryReport,
-} from '../shared/repo-inventory.js';
-import {
   RELAY_NODE_LINK_PROTOCOL,
   RELAY_NODE_LINK_PROTOCOL_VERSION,
   type HubNodeSummary,
@@ -147,15 +143,9 @@ function manifestFromPayload(
   return manifest;
 }
 
-function repoInventoryFromPayload(
-  payload: unknown
-): RepoInventoryReport | RelayNodeError | undefined {
+function extractInventoryPayload(payload: unknown): unknown {
   if (typeof payload !== 'object' || payload === null) return undefined;
-  const repoInventory = (payload as Record<string, unknown>)['repoInventory'];
-  if (repoInventory === undefined || repoInventory === null) return undefined;
-  if (!isRepoInventoryReport(repoInventory))
-    return invalidRequest('repoInventory is malformed');
-  return repoInventory;
+  return (payload as Record<string, unknown>)['repoInventory'];
 }
 
 function sendJson(ws: WebSocket, payload: RelayNodeEnvelope): void {
@@ -178,11 +168,35 @@ export class HubNodeLinkError extends Error {
   }
 }
 
+export type HubNodeLinkInventoryValidator = (
+  payload: unknown,
+  ctx: { nodeId: string }
+) => { ok: true; payload: unknown } | { ok: false; error: RelayNodeError };
+
+export interface HubNodeLinkManagerOptions {
+  inventoryValidator?: HubNodeLinkInventoryValidator;
+}
+
 export class HubNodeLinkManager {
   private readonly links = new Map<string, WebSocket>();
   private readonly pending = new Map<string, PendingRpc>();
   private readonly ptyStreams = new Map<string, BrowserPtyStream>();
   private readonly eventHandlers = new Set<NodeEventHandler>();
+  private readonly inventoryValidator?: HubNodeLinkInventoryValidator;
+
+  constructor(options: HubNodeLinkManagerOptions = {}) {
+    if (options.inventoryValidator) {
+      this.inventoryValidator = options.inventoryValidator;
+    }
+  }
+
+  validateInventoryPayload(
+    payload: unknown,
+    ctx: { nodeId: string }
+  ): { ok: true; payload: unknown } | { ok: false; error: RelayNodeError } {
+    if (!this.inventoryValidator) return { ok: true, payload };
+    return this.inventoryValidator(payload, ctx);
+  }
 
   registerNodeLink(nodeId: string, ws: WebSocket): void {
     const existing = this.links.get(nodeId);
@@ -397,8 +411,10 @@ export class HubNodeLinkManager {
   }
 }
 
-export function createHubNodeLinkManager(): HubNodeLinkManager {
-  return new HubNodeLinkManager();
+export function createHubNodeLinkManager(
+  options: HubNodeLinkManagerOptions = {}
+): HubNodeLinkManager {
+  return new HubNodeLinkManager(options);
 }
 
 export function handleHubNodeLink(
@@ -489,22 +505,27 @@ export function handleHubNodeLink(
         return;
       }
       const manifest = manifestResult as NodeManifest | undefined;
-      const repoInventoryResult = repoInventoryFromPayload(parsed.payload);
-      if (repoInventoryResult && 'code' in repoInventoryResult) {
+      const rawInventory = extractInventoryPayload(parsed.payload);
+      const inventoryValidation = nodeLinks
+        ? nodeLinks.validateInventoryPayload(rawInventory, {
+            nodeId: authenticatedNodeId,
+          })
+        : { ok: true as const, payload: rawInventory };
+      if (!inventoryValidation.ok) {
         sendJson(
           ws,
-          errorEnvelope(authenticatedNodeId, parsed, repoInventoryResult)
+          errorEnvelope(authenticatedNodeId, parsed, inventoryValidation.error)
         );
         return;
       }
-      const repoInventory = repoInventoryResult as
-        | RepoInventoryReport
-        | undefined;
+      const repoInventory = inventoryValidation.payload;
       const node = registry.recordHeartbeat({
         nodeId: authenticatedNodeId,
         protocolVersion: parsed.protocolVersion,
         ...(manifest ? { manifest } : {}),
-        ...(repoInventory ? { repoInventory } : {}),
+        ...(repoInventory !== undefined && repoInventory !== null
+          ? { repoInventory }
+          : {}),
       });
       sendJson(ws, {
         protocol: RELAY_NODE_LINK_PROTOCOL,

--- a/server/hub-node-link.ts
+++ b/server/hub-node-link.ts
@@ -194,7 +194,11 @@ export class HubNodeLinkManager {
     payload: unknown,
     ctx: { nodeId: string }
   ): { ok: true; payload: unknown } | { ok: false; error: RelayNodeError } {
-    if (!this.inventoryValidator) return { ok: true, payload };
+    // Safe-by-default: when no validator is wired, drop the payload
+    // rather than passing it through. Composition root wires the
+    // feature-layer validator in production; tests or misconfigured
+    // deployments get safe-empty.
+    if (!this.inventoryValidator) return { ok: true, payload: undefined };
     return this.inventoryValidator(payload, ctx);
   }
 
@@ -506,11 +510,15 @@ export function handleHubNodeLink(
       }
       const manifest = manifestResult as NodeManifest | undefined;
       const rawInventory = extractInventoryPayload(parsed.payload);
+      // Safe-by-default: when no validator is wired, drop any
+      // repoInventory payload rather than storing it unvalidated. This
+      // prevents nodeId spoofing or malformed payloads from reaching
+      // the registry on misconfigured deployments.
       const inventoryValidation = nodeLinks
         ? nodeLinks.validateInventoryPayload(rawInventory, {
             nodeId: authenticatedNodeId,
           })
-        : { ok: true as const, payload: rawInventory };
+        : { ok: true as const, payload: undefined };
       if (!inventoryValidation.ok) {
         sendJson(
           ws,

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -5,7 +5,6 @@ import type {
   NodeCapabilityProbe,
   NodeManifest,
 } from '../shared/node-manifest.js';
-import type { RepoInventoryReport } from '../shared/repo-inventory.js';
 import { createLogger } from './logger.js';
 import {
   RELAY_NODE_LINK_PROTOCOL,
@@ -44,7 +43,7 @@ interface StoredNodeRecord {
   relayVersion: string;
   protocolVersion: string;
   capabilities: NodeCapabilityManifestSummary;
-  repoInventory?: RepoInventoryReport;
+  repoInventory?: unknown;
   createdAt: string;
   pairedAt: string;
   lastSeenAt: string;
@@ -74,7 +73,12 @@ export interface HeartbeatInput {
   nodeId: string;
   protocolVersion: string;
   manifest?: NodeManifest;
-  repoInventory?: RepoInventoryReport;
+  repoInventory?: unknown;
+}
+
+export interface InventoryPayloadRecord {
+  nodeId: string;
+  payload: unknown;
 }
 
 export interface HubNodeRegistryOptions {
@@ -518,13 +522,7 @@ export class HubNodeRegistry {
       node.relayVersion = input.manifest.relayVersion;
       node.capabilities = summarizeCapabilities(input.manifest);
     }
-    if (input.repoInventory) {
-      if (input.repoInventory.nodeId !== input.nodeId) {
-        throw new HubNodeRegistryError(
-          'INVALID_REQUEST',
-          'repoInventory.nodeId must match authenticated nodeId'
-        );
-      }
+    if (input.repoInventory !== undefined && input.repoInventory !== null) {
       node.repoInventory = input.repoInventory;
     }
     this.scheduleHeartbeatPersist();
@@ -552,13 +550,16 @@ export class HubNodeRegistry {
     );
   }
 
-  listRepoInventoryReports(
+  listInventoryPayloads(
     options: { includeRevoked?: boolean } = {}
-  ): RepoInventoryReport[] {
+  ): InventoryPayloadRecord[] {
     return this.state.nodes
       .filter((node) => options.includeRevoked || !node.revokedAt)
-      .map((node) => node.repoInventory)
-      .filter((report): report is RepoInventoryReport => Boolean(report));
+      .filter(
+        (node) =>
+          node.repoInventory !== undefined && node.repoInventory !== null
+      )
+      .map((node) => ({ nodeId: node.nodeId, payload: node.repoInventory }));
   }
 
   revokeNode(nodeId: string): HubNodeSummary {

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -1,14 +1,12 @@
 import * as express from 'express';
 import type { Request, Response } from 'express';
 import { isNodeManifest, type NodeManifest } from '../shared/node-manifest.js';
-import {
-  aggregateRepoInventoryReports,
-  isRepoInventoryReport,
-  type RepoInventoryDirtySummary,
-  type RepoInventoryDivergenceSummary,
-  type RepoInventoryRepoInstance,
-  type RepoInventoryReport,
-  type RepoInventoryWorktreeInstance,
+import type {
+  RepoInventoryDirtySummary,
+  RepoInventoryDivergenceSummary,
+  RepoInventoryRepoInstance,
+  RepoInventoryReport,
+  RepoInventoryWorktreeInstance,
 } from '../shared/repo-inventory.js';
 import {
   HubNodeRegistryError,
@@ -24,6 +22,10 @@ import {
   type BootstrapServiceMode,
 } from '../shared/bootstrap-diagnostics.js';
 import { HubNodeLinkError, type HubNodeLinkManager } from './hub-node-link.js';
+import {
+  createRepoInventoryFeature,
+  type RepoInventoryFeature,
+} from './features/repo-inventory.js';
 import type { SessionSummary } from './types.js';
 import {
   createGlobalSessionId,
@@ -34,6 +36,7 @@ import {
 interface HubNodeRouterOptions {
   registry: HubNodeRegistry;
   requireAuth: express.RequestHandler;
+  repoInventoryFeature?: RepoInventoryFeature;
   collectLocalRepoInventory?: () => Promise<RepoInventoryReport>;
   nodeLinks?: HubNodeLinkManager;
 }
@@ -492,18 +495,18 @@ function manifestFromBody(
   return manifest;
 }
 
-function repoInventoryFromBody(
-  body: Record<string, unknown>
-): RepoInventoryReport | null {
+function validateInventoryFromBody(
+  feature: RepoInventoryFeature,
+  body: Record<string, unknown>,
+  nodeId: string
+): unknown {
   const repoInventory = body['repoInventory'];
-  if (repoInventory === undefined || repoInventory === null) return null;
-  if (!isRepoInventoryReport(repoInventory)) {
-    throw new HubNodeRegistryError(
-      'INVALID_REQUEST',
-      'repoInventory is malformed'
-    );
+  if (repoInventory === undefined || repoInventory === null) return undefined;
+  const result = feature.validateInventoryPayload(repoInventory, { nodeId });
+  if (!result.ok) {
+    throw new HubNodeRegistryError(result.error.code, result.error.message);
   }
-  return repoInventory;
+  return result.payload;
 }
 
 function pairTtlMs(body: Record<string, unknown>): number | undefined {
@@ -568,6 +571,8 @@ export function createHubNodeRouter(
 ): express.Router {
   const router = express.Router();
   const { registry, requireAuth } = options;
+  const repoInventoryFeature =
+    options.repoInventoryFeature ?? createRepoInventoryFeature(registry);
 
   router.post('/hub/pair-tokens', requireAuth, (req, res) => {
     const body = bodyRecord(req);
@@ -668,13 +673,19 @@ export function createHubNodeRouter(
     }
     try {
       const manifest = manifestFromBody(body);
-      const repoInventory = repoInventoryFromBody(body);
+      const repoInventory = validateInventoryFromBody(
+        repoInventoryFeature,
+        body,
+        authenticated.node.nodeId
+      );
       res.json({
         node: registry.recordHeartbeat({
           nodeId: authenticated.node.nodeId,
           protocolVersion,
           ...(manifest ? { manifest } : {}),
-          ...(repoInventory ? { repoInventory } : {}),
+          ...(repoInventory !== undefined && repoInventory !== null
+            ? { repoInventory }
+            : {}),
         }),
       });
     } catch (error) {
@@ -688,11 +699,11 @@ export function createHubNodeRouter(
 
   router.get('/hub/repo-inventory', requireAuth, async (_req, res) => {
     try {
-      const reports = [...registry.listRepoInventoryReports()];
+      const reports = [...repoInventoryFeature.listInventoryReports()];
       if (options.collectLocalRepoInventory) {
         reports.push(await options.collectLocalRepoInventory());
       }
-      res.json(aggregateRepoInventoryReports(reports));
+      res.json(repoInventoryFeature.aggregateInventoryReports(reports));
     } catch (error) {
       sendRegistryError(registry, res, error);
     }
@@ -756,7 +767,7 @@ export function createHubNodeRouter(
 
       const body = bodyRecord(req);
       try {
-        const reports = [...registry.listRepoInventoryReports()];
+        const reports = [...repoInventoryFeature.listInventoryReports()];
         if (options.collectLocalRepoInventory) {
           reports.push(await options.collectLocalRepoInventory());
         }

--- a/server/index.ts
+++ b/server/index.ts
@@ -104,6 +104,7 @@ import { getNodeManifest } from './node-manifest.js';
 import { createHubNodeRegistry } from './hub-node-registry.js';
 import { createHubNodeRouter } from './hub-node-router.js';
 import { createHubNodeLinkManager } from './hub-node-link.js';
+import { createRepoInventoryFeature } from './features/repo-inventory.js';
 import { collectLocalRepoInventory } from './repo-inventory.js';
 import type {
   AgentType,
@@ -982,9 +983,14 @@ async function main(): Promise<void> {
   const hubNodeRegistry = createHubNodeRegistry({
     storagePath: path.join(configDir, 'hub-node-registry.json'),
   });
-  const hubNodeLinks = createHubNodeLinkManager();
+  const repoInventoryFeature = createRepoInventoryFeature(hubNodeRegistry);
+  const hubNodeLinks = createHubNodeLinkManager({
+    inventoryValidator: repoInventoryFeature.validateInventoryPayload,
+  });
 
-  async function flushHubNodeHeartbeatsBestEffort(context: string): Promise<void> {
+  async function flushHubNodeHeartbeatsBestEffort(
+    context: string
+  ): Promise<void> {
     try {
       await hubNodeRegistry.flushPendingHeartbeatPersist();
     } catch (err) {
@@ -1077,8 +1083,12 @@ async function main(): Promise<void> {
       registry: hubNodeRegistry,
       nodeLinks: hubNodeLinks,
       requireAuth,
+      repoInventoryFeature,
       collectLocalRepoInventory: () =>
-        collectLocalRepoInventory({ config: getConfig(), configPath: CONFIG_PATH }),
+        collectLocalRepoInventory({
+          config: getConfig(),
+          configPath: CONFIG_PATH,
+        }),
     })
   );
 

--- a/server/node-link-client.ts
+++ b/server/node-link-client.ts
@@ -2,7 +2,6 @@ import { WebSocket, type RawData } from 'ws';
 import type { Logger } from './logger.js';
 import { createLogger } from './logger.js';
 import type { NodeManifest } from '../shared/node-manifest.js';
-import type { RepoInventoryReport } from '../shared/repo-inventory.js';
 import {
   RELAY_NODE_LINK_PROTOCOL,
   RELAY_NODE_LINK_PROTOCOL_VERSION,
@@ -33,7 +32,7 @@ export interface NodeLinkClientDeps {
   hubUrl: string;
   credential: NodeLinkCredential;
   getManifest: () => Promise<NodeManifest> | NodeManifest;
-  getRepoInventory?: () => Promise<RepoInventoryReport | undefined> | RepoInventoryReport | undefined;
+  getRepoInventory?: () => Promise<unknown> | unknown;
   heartbeatIntervalMs?: number;
   initialReconnectDelayMs?: number;
   maxReconnectDelayMs?: number;
@@ -101,15 +100,21 @@ function defaultWebSocketFactory(
   url: string,
   options: { headers: Record<string, string> }
 ): NodeLinkWebSocketLike {
-  return new WebSocket(url, { headers: options.headers }) as unknown as NodeLinkWebSocketLike;
+  return new WebSocket(url, {
+    headers: options.headers,
+  }) as unknown as NodeLinkWebSocketLike;
 }
 
 export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
   const logger = deps.logger ?? createLogger('node-link');
-  const heartbeatIntervalMs = deps.heartbeatIntervalMs ?? DEFAULTS.heartbeatIntervalMs;
-  const initialReconnectDelayMs = deps.initialReconnectDelayMs ?? DEFAULTS.initialReconnectDelayMs;
-  const maxReconnectDelayMs = deps.maxReconnectDelayMs ?? DEFAULTS.maxReconnectDelayMs;
-  const reconnectJitterMs = deps.reconnectJitterMs ?? DEFAULTS.reconnectJitterMs;
+  const heartbeatIntervalMs =
+    deps.heartbeatIntervalMs ?? DEFAULTS.heartbeatIntervalMs;
+  const initialReconnectDelayMs =
+    deps.initialReconnectDelayMs ?? DEFAULTS.initialReconnectDelayMs;
+  const maxReconnectDelayMs =
+    deps.maxReconnectDelayMs ?? DEFAULTS.maxReconnectDelayMs;
+  const reconnectJitterMs =
+    deps.reconnectJitterMs ?? DEFAULTS.reconnectJitterMs;
   const webSocketFactory = deps.webSocketFactory ?? defaultWebSocketFactory;
   const setTimer = deps.setTimeoutFn ?? setTimeout;
   const clearTimer = deps.clearTimeoutFn ?? clearTimeout;
@@ -164,7 +169,9 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
     if (deps.getRepoInventory) {
       try {
         const repoInventory = await deps.getRepoInventory();
-        if (repoInventory) payload['repoInventory'] = repoInventory;
+        if (repoInventory !== undefined && repoInventory !== null) {
+          payload['repoInventory'] = repoInventory;
+        }
       } catch (error) {
         logger.warn(
           `repo inventory collection failed: ${error instanceof Error ? error.message : String(error)}`
@@ -195,7 +202,11 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
     }
     void buildControlPayload()
       .then((payload) => {
-        if (stopped || ws !== inflightWs || inflightWs.readyState !== inflightWs.OPEN) {
+        if (
+          stopped ||
+          ws !== inflightWs ||
+          inflightWs.readyState !== inflightWs.OPEN
+        ) {
           return;
         }
         send(envelope('control', 'control.heartbeat', { payload }));
@@ -237,7 +248,9 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
     setState('reconnecting');
     const delay = nextReconnectDelay();
     reconnectAttempt += 1;
-    logger.info(`reconnect in ${delay}ms (attempt ${reconnectAttempt}): ${reason}`);
+    logger.info(
+      `reconnect in ${delay}ms (attempt ${reconnectAttempt}): ${reason}`
+    );
     reconnectTimer = setTimer(() => {
       reconnectTimer = undefined;
       connect();
@@ -247,7 +260,10 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
 
   function handleEnvelope(env: RelayNodeEnvelope): void {
     if (env.channel === 'control') {
-      if (env.type === 'control.hello.result' || env.type === 'control.heartbeat.ack') {
+      if (
+        env.type === 'control.hello.result' ||
+        env.type === 'control.heartbeat.ack'
+      ) {
         reconnectAttempt = 0;
         return;
       }

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -7,6 +7,8 @@ import { WebSocket } from 'ws';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createHubNodeRegistry } from '../server/hub-node-registry.js';
 import { createHubNodeRouter } from '../server/hub-node-router.js';
+import { createHubNodeLinkManager } from '../server/hub-node-link.js';
+import { createRepoInventoryFeature } from '../server/features/repo-inventory.js';
 import { setupWebSocket } from '../server/ws.js';
 import type { NodeManifest } from '../shared/node-manifest.js';
 import type { RepoInventoryReport } from '../shared/repo-inventory.js';
@@ -714,7 +716,7 @@ describe('hub node routes and link', () => {
     expect(await response.json()).toMatchObject({
       error: { code: 'INVALID_REQUEST', retryable: false },
     });
-    expect(registry.listRepoInventoryReports()).toHaveLength(0);
+    expect(registry.listInventoryPayloads()).toHaveLength(0);
   });
 
   it('rejects websocket heartbeat repo inventory for a different node id', async () => {
@@ -727,6 +729,10 @@ describe('hub node routes and link', () => {
     });
 
     const server = http.createServer(express());
+    const nodeLinks = createHubNodeLinkManager({
+      inventoryValidator:
+        createRepoInventoryFeature(registry).validateInventoryPayload,
+    });
     setupWebSocket(
       server,
       new Set(),
@@ -734,7 +740,8 @@ describe('hub node routes and link', () => {
       undefined,
       false,
       undefined,
-      registry
+      registry,
+      nodeLinks
     );
     const port = await listen(server);
     cleanup.push(() => close(server));
@@ -778,6 +785,6 @@ describe('hub node routes and link', () => {
       type: 'control.error',
       error: { code: 'INVALID_REQUEST', retryable: false },
     });
-    expect(registry.listRepoInventoryReports()).toHaveLength(0);
+    expect(registry.listInventoryPayloads()).toHaveLength(0);
   });
 });

--- a/test/repo-inventory-feature.test.ts
+++ b/test/repo-inventory-feature.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import http from 'node:http';
+import { WebSocket } from 'ws';
+import express from 'express';
 import { createHubNodeRegistry } from '../server/hub-node-registry.js';
+import { createHubNodeLinkManager } from '../server/hub-node-link.js';
+import { setupWebSocket } from '../server/ws.js';
 import {
   createRepoInventoryFeature,
   validateInventoryPayload,
@@ -10,6 +15,24 @@ import {
 } from '../server/features/repo-inventory.js';
 import type { RepoInventoryReport } from '../shared/repo-inventory.js';
 import type { NodeManifest } from '../shared/node-manifest.js';
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (typeof address !== 'object' || address === null) {
+        throw new Error('listen did not return an address');
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function close(server: http.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
 
 function manifest(): NodeManifest {
   return {
@@ -141,6 +164,28 @@ describe('repo-inventory feature', () => {
     }
   });
 
+  it('feature listInventoryReports drops a stored payload whose self-reported nodeId disagrees with the record it was stored against', () => {
+    const { tmpDir, registry } = tmpRegistry();
+    try {
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      const feature = createRepoInventoryFeature(registry);
+      // Bypass the validator by writing a mismatched payload directly
+      // through recordHeartbeat (simulates corrupted on-disk state or a
+      // path that skipped feature-layer validation).
+      registry.recordHeartbeat({
+        nodeId: exchanged.node.nodeId,
+        protocolVersion: '1.0',
+        repoInventory: report('different-node', '/srv/repos/relay-ide'),
+      });
+      expect(feature.listInventoryReports()).toHaveLength(0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('feature listInventoryReports skips malformed payloads silently', () => {
     const { tmpDir, registry } = tmpRegistry();
     try {
@@ -157,6 +202,79 @@ describe('repo-inventory feature', () => {
       expect(feature.listInventoryReports()).toHaveLength(0);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('WS heartbeat path drops repoInventory when no validator is wired (safe-by-default)', async () => {
+    const cleanup: Array<() => Promise<void> | void> = [];
+    try {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'relay-repo-inv-feat-ws-')
+      );
+      cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+      const registry = createHubNodeRegistry({
+        storagePath: path.join(tmpDir, 'nodes.json'),
+        now: () => new Date('2026-01-02T03:04:05.000Z'),
+      });
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      const server = http.createServer(express());
+      // Intentionally pass a link manager WITHOUT an inventoryValidator
+      // wired. Production composition root wires one; we want to prove
+      // the WS path refuses to persist an unvalidated payload.
+      const nodeLinks = createHubNodeLinkManager();
+      setupWebSocket(
+        server,
+        new Set(),
+        null,
+        undefined,
+        false,
+        undefined,
+        registry,
+        nodeLinks
+      );
+      const port = await listen(server);
+      cleanup.push(() => close(server));
+
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/hub/node-link`, {
+        headers: { authorization: `Bearer ${exchanged.credential.token}` },
+      });
+      cleanup.push(() => ws.close());
+      await new Promise<void>((resolve, reject) => {
+        ws.once('open', resolve);
+        ws.once('error', reject);
+      });
+
+      const ack = new Promise<Record<string, unknown>>((resolve) => {
+        ws.once('message', (data) =>
+          resolve(JSON.parse(data.toString()) as Record<string, unknown>)
+        );
+      });
+      ws.send(
+        JSON.stringify({
+          protocol: 'relay-node-link',
+          protocolVersion: '1.0',
+          nodeId: exchanged.node.nodeId,
+          channel: 'control',
+          type: 'control.heartbeat',
+          timestamp: '2026-01-02T03:04:10.000Z',
+          payload: {
+            repoInventory: report(
+              exchanged.node.nodeId,
+              '/srv/repos/relay-ide'
+            ),
+          },
+        })
+      );
+      const response = await ack;
+      expect(response.type).toBe('control.heartbeat.ack');
+      // Payload was accepted (heartbeat acked) but the registry must not
+      // hold any inventory because no validator was wired.
+      expect(registry.listInventoryPayloads()).toHaveLength(0);
+    } finally {
+      while (cleanup.length > 0) await cleanup.pop()?.();
     }
   });
 

--- a/test/repo-inventory-feature.test.ts
+++ b/test/repo-inventory-feature.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createHubNodeRegistry } from '../server/hub-node-registry.js';
+import {
+  createRepoInventoryFeature,
+  validateInventoryPayload,
+  parseStoredInventory,
+} from '../server/features/repo-inventory.js';
+import type { RepoInventoryReport } from '../shared/repo-inventory.js';
+import type { NodeManifest } from '../shared/node-manifest.js';
+
+function manifest(): NodeManifest {
+  return {
+    schemaVersion: 1,
+    platform: 'linux',
+    arch: 'x64',
+    hostname: 'node-feature-host',
+    relayVersion: '0.1.0-test',
+    generatedAt: '2026-01-02T03:04:05.000Z',
+    wsl: { detected: false, version: null, systemd: false },
+    serviceManager: {
+      kind: 'systemd-user',
+      label: 'systemd user',
+      supported: true,
+      installable: true,
+      installHint: 'install',
+      uninstallHint: 'uninstall',
+      message: 'ok',
+    },
+    capabilities: {
+      tmux: { status: 'available', message: 'tmux 3.4' },
+      git: { status: 'available', message: 'git 2.45.0' },
+      clipboard: { status: 'available', message: 'pbcopy' },
+      browserAutomation: { status: 'available', message: 'playwright ok' },
+      githubCli: { status: 'available', message: 'gh 2.51' },
+      tailscale: { status: 'available', message: 'tailscale 1.62' },
+      ssh: { status: 'available', message: 'OpenSSH 9.7' },
+      agents: {},
+    },
+  };
+}
+
+function report(nodeId: string, repoPath: string): RepoInventoryReport {
+  return {
+    nodeId,
+    generatedAt: '2026-01-02T03:04:05.000Z',
+    repos: [
+      {
+        repoInstanceId: `${nodeId}:${repoPath}`,
+        nodeId,
+        localPath: repoPath,
+        name: 'relay-ide',
+        isGitRepo: true,
+        defaultBranch: 'nightly',
+        currentBranch: 'nightly',
+        repoIdentity: 'github.com/donovan-yohan/relay-ide',
+        selectedRemote: null,
+        remotes: [],
+        repoIdentityWarnings: [],
+        worktrees: [],
+        reportedAt: '2026-01-02T03:04:05.000Z',
+      },
+    ],
+  };
+}
+
+function tmpRegistry() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-repo-inv-feat-'));
+  const registry = createHubNodeRegistry({
+    storagePath: path.join(tmpDir, 'nodes.json'),
+    now: () => new Date('2026-01-02T03:04:05.000Z'),
+  });
+  return { tmpDir, registry };
+}
+
+describe('repo-inventory feature', () => {
+  it('validateInventoryPayload accepts an undefined payload as a no-op pass-through', () => {
+    const result = validateInventoryPayload(undefined, { nodeId: 'node-a' });
+    expect(result).toEqual({ ok: true, payload: undefined });
+  });
+
+  it('validateInventoryPayload rejects malformed payloads', () => {
+    const result = validateInventoryPayload(
+      { not: 'a-report' },
+      {
+        nodeId: 'node-a',
+      }
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('INVALID_REQUEST');
+      expect(result.error.retryable).toBe(false);
+    }
+  });
+
+  it('validateInventoryPayload rejects nodeId mismatch', () => {
+    const result = validateInventoryPayload(report('node-a', '/a/repo'), {
+      nodeId: 'node-b',
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('INVALID_REQUEST');
+      expect(result.error.message).toContain('nodeId');
+    }
+  });
+
+  it('validateInventoryPayload returns the validated report when shape and nodeId match', () => {
+    const payload = report('node-a', '/a/repo');
+    const result = validateInventoryPayload(payload, { nodeId: 'node-a' });
+    expect(result).toEqual({ ok: true, payload });
+  });
+
+  it('parseStoredInventory accepts opaque payload and returns the typed report when valid', () => {
+    const payload = report('node-a', '/a/repo');
+    expect(parseStoredInventory(payload)).toEqual(payload);
+    expect(parseStoredInventory({ not: 'a-report' })).toBeNull();
+    expect(parseStoredInventory(undefined)).toBeNull();
+  });
+
+  it('feature listInventoryReports reads opaque payloads stored on the registry', () => {
+    const { tmpDir, registry } = tmpRegistry();
+    try {
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      const feature = createRepoInventoryFeature(registry);
+      const payload = report(exchanged.node.nodeId, '/srv/repos/relay-ide');
+      registry.recordHeartbeat({
+        nodeId: exchanged.node.nodeId,
+        protocolVersion: '1.0',
+        repoInventory: payload,
+      });
+      const reports = feature.listInventoryReports();
+      expect(reports).toHaveLength(1);
+      expect(reports[0]?.nodeId).toBe(exchanged.node.nodeId);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('feature listInventoryReports skips malformed payloads silently', () => {
+    const { tmpDir, registry } = tmpRegistry();
+    try {
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      const feature = createRepoInventoryFeature(registry);
+      registry.recordHeartbeat({
+        nodeId: exchanged.node.nodeId,
+        protocolVersion: '1.0',
+        repoInventory: { garbage: true },
+      });
+      expect(feature.listInventoryReports()).toHaveLength(0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('feature listInventoryReports excludes revoked nodes by default but can include them on request', () => {
+    const { tmpDir, registry } = tmpRegistry();
+    try {
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      const feature = createRepoInventoryFeature(registry);
+      registry.recordHeartbeat({
+        nodeId: exchanged.node.nodeId,
+        protocolVersion: '1.0',
+        repoInventory: report(exchanged.node.nodeId, '/srv/repos/relay-ide'),
+      });
+      registry.revokeNode(exchanged.node.nodeId);
+      expect(feature.listInventoryReports()).toHaveLength(0);
+      expect(
+        feature.listInventoryReports({ includeRevoked: true })
+      ).toHaveLength(1);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #432 / implements Group A of the ADR-015 core audit.
- Splits repo-inventory feature shape out of `server/hub-node-link.ts`, `server/node-link-client.ts`, `server/hub-node-registry.ts`, and the heartbeat-edge bits of `server/hub-node-router.ts` into a new `server/features/repo-inventory.ts`.
- Core modules now treat the payload as opaque `unknown`. Typed validation, persistence read-through, and aggregation move to the feature module. Composition root in `server/index.ts` wires once.

## Why this matters for the broader #425 epic

- Unblocks #434 (#425.3 — optional `repoPath`/`worktreePath`/`branchName` on `SessionSummary`): the same opaque-payload pattern applies to typed session payloads.
- Unblocks #445 (#425.7 — node-side `sessions.create` RPC handler): once core is opaque, the node-side handler can dispatch any opaque payload to its local `RelayNode.sessions.create` without needing a repo binding.
- Sets the precedent the remaining Group B–F sub-issues (#433, #435, #436, #437) follow.

## What changed

### New
- `server/features/repo-inventory.ts` — `validateInventoryPayload`, `parseStoredInventory`, `createRepoInventoryFeature(registry)` factory exposing `validateInventoryPayload`, `listInventoryReports`, `aggregateInventoryReports`.
- `test/repo-inventory-feature.test.ts` — covers the validator (undefined / malformed / nodeId mismatch / happy path), opaque parse, registry-bound listing, and `includeRevoked` behaviour.

### Core (opaque payload pass-through)
- `server/hub-node-link.ts` — drops `RepoInventoryReport` import. `HubNodeLinkManager` accepts an optional `inventoryValidator`. Heartbeat path delegates validation; on `ok: false` returns the typed error envelope, otherwise hands the (now opaque) payload to `registry.recordHeartbeat`.
- `server/node-link-client.ts` — drops the import. `getRepoInventory` callback becomes `() => Promise<unknown> | unknown`.
- `server/hub-node-registry.ts` — drops the import. `repoInventory` field becomes `unknown`. `HeartbeatInput.repoInventory` becomes `unknown`. The inline `repoInventory.nodeId !== input.nodeId` check is removed (the feature validator owns it). `listRepoInventoryReports` is replaced with `listInventoryPayloads(): { nodeId, payload }[]`.
- `server/hub-node-router.ts` — drops the runtime `isRepoInventoryReport` import and `repoInventoryFromBody` helper. Route inventory listing / aggregation through the injected `repoInventoryFeature`. The option is optional with a sensible default (`createRepoInventoryFeature(registry)`) so existing test wiring keeps working without rewrites. Cold-reopen type-only imports (`RepoInventoryRepoInstance`, `RepoInventoryWorktreeInstance`, etc.) stay in the file until #433 extracts those endpoints.
- `server/index.ts` — builds the feature, injects its `validateInventoryPayload` into the link manager, passes it to the router.

### Tests
- `test/hub-node-routes.test.ts` — WS heartbeat spoofing test now wires the link manager with the feature's validator, mirroring the composition root. Asserts on the renamed `registry.listInventoryPayloads()`.

## Out of scope (kept for #433+)

- The full extraction of `/hub/repo-inventory` and `/hub/nodes/:nodeId/sessions/reopen` from `hub-node-router.ts` into a feature router. The endpoints stay where they are; only their validation/listing path now goes through the feature. #433 will move the endpoints.
- Type-only imports used by cold-reopen helpers in `hub-node-router.ts` remain (they leave with the endpoints in #433).

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run test/hub-node-registry.test.ts test/hub-node-routes.test.ts test/hub-node-cold-transfer.test.ts test/hub-node-session-routing.test.ts test/multi-node-smoke.test.ts test/node-link-client.test.ts test/node-link-pty-host.test.ts test/hub-node-production-wiring.test.ts test/repo-inventory-feature.test.ts` → 54 / 54 pass.
- [x] Full `npm test` shows two pre-existing flakes in `test/git-divergence.test.ts` and `test/sessions.test.ts` (tmux/fs races, different failures on each run, not touching this diff). Otherwise green.
- [ ] CI green on PR.

## Risks

- Existing on-disk `hub-node-registry.json` files keep working: the `repoInventory` field name is unchanged, only the TS type narrows from `RepoInventoryReport` to `unknown`. Malformed stored payloads are now silently dropped on read (`parseStoredInventory` returns `null`) instead of crashing at load — covered by `test/repo-inventory-feature.test.ts`.
- The WS heartbeat path now requires a link manager with the validator wired for `repoInventory.nodeId` spoofing rejection. Production composition root and the updated spoofing test do this; ad-hoc test setups that exercise inventory submission over WS must wire the validator (or rely on the HTTP `/hub/node-heartbeat` path, which uses the router's default-feature fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
