### PR TITLE
test(infra): pin subprocess-heavy test files to a serial vitest project (#447)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,9 +2,14 @@ import { defineConfig } from 'vitest/config';
 
 // Files that spawn many real `git` / `tmux` subprocesses and race
 // under default vitest file-parallelism — timeouts fire deterministically
-// when many child processes contend for CPU. Pinned to a singleFork
-// project so they run sequentially regardless of how many other test
-// files are in flight; everything else stays parallel.
+// when many child processes contend for CPU. Routed to a project with
+// `fileParallelism: false` so files in this group run one at a time;
+// everything else stays in the parallel pool.
+//
+// Note: `testTimeout` does NOT inherit from the top-level `test` config
+// into vitest 4 projects (verified empirically — removing it from
+// projects let tests fail at exactly 5000ms, the vitest default).
+// Re-declared on each project; keep them in sync.
 const SERIAL_SUBPROCESS_FILES = [
   'test/git-divergence.test.ts',
   'test/git-watcher.test.ts',
@@ -12,17 +17,16 @@ const SERIAL_SUBPROCESS_FILES = [
   'test/sessions.test.ts',
 ];
 
+const PROJECT_TEST_TIMEOUT_MS = 30_000;
+
 export default defineConfig({
   test: {
-    environment: 'node',
-    testTimeout: 30_000,
     projects: [
       {
         test: {
           name: 'serial-subprocess',
           include: SERIAL_SUBPROCESS_FILES,
-          environment: 'node',
-          testTimeout: 30_000,
+          testTimeout: PROJECT_TEST_TIMEOUT_MS,
           fileParallelism: false,
         },
       },
@@ -31,8 +35,7 @@ export default defineConfig({
           name: 'parallel',
           include: ['test/**/*.test.ts'],
           exclude: ['test/e2e/**', ...SERIAL_SUBPROCESS_FILES],
-          environment: 'node',
-          testTimeout: 30_000,
+          testTimeout: PROJECT_TEST_TIMEOUT_MS,
         },
       },
     ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,40 @@
 import { defineConfig } from 'vitest/config';
 
+// Files that spawn many real `git` / `tmux` subprocesses and race
+// under default vitest file-parallelism — timeouts fire deterministically
+// when many child processes contend for CPU. Pinned to a singleFork
+// project so they run sequentially regardless of how many other test
+// files are in flight; everything else stays parallel.
+const SERIAL_SUBPROCESS_FILES = [
+  'test/git-divergence.test.ts',
+  'test/git-watcher.test.ts',
+  'test/workspace-divergence-api.test.ts',
+  'test/sessions.test.ts',
+];
+
 export default defineConfig({
   test: {
-    include: ['test/**/*.test.ts'],
-    exclude: ['test/e2e/**'],
     environment: 'node',
     testTimeout: 30_000,
+    projects: [
+      {
+        test: {
+          name: 'serial-subprocess',
+          include: SERIAL_SUBPROCESS_FILES,
+          environment: 'node',
+          testTimeout: 30_000,
+          fileParallelism: false,
+        },
+      },
+      {
+        test: {
+          name: 'parallel',
+          include: ['test/**/*.test.ts'],
+          exclude: ['test/e2e/**', ...SERIAL_SUBPROCESS_FILES],
+          environment: 'node',
+          testTimeout: 30_000,
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Summary

- Closes #447. Pins four subprocess-heavy test files to a serial vitest project so they don't race under default file parallelism.
- Unblocks the autonomous #425 loop (every #425 sub-issue PR touches `server/index.ts` composition root and re-runs the suite under contention).

## Root cause

`test/git-divergence.test.ts`, `test/git-watcher.test.ts`, `test/workspace-divergence-api.test.ts`, and `test/sessions.test.ts` each spawn many real `git` / `tmux` subprocesses. Under default vitest file parallelism, many files run concurrently; child-process timeouts (1–5s) fire deterministically when CPU is contended. Failures bunch on "propagates timeout errors from default branch detection / current branch detection / merge-base resolution / etc." — not real bugs.

Each of these files passes 1/1 when run in isolation. They are useful tests covering real product surface (branch divergence + dirty signals shown in the UI, file watchers backing the live update bus, workspace divergence REST API, tmux session lifecycle).

## Fix

Vitest 4 `projects` config splits the suite into two pools:

```ts
projects: [
  {
    test: {
      name: 'serial-subprocess',
      include: SERIAL_SUBPROCESS_FILES,   // the four flaky files
      fileParallelism: false,
    },
  },
  {
    test: {
      name: 'parallel',
      include: ['test/**/*.test.ts'],
      exclude: ['test/e2e/**', ...SERIAL_SUBPROCESS_FILES],
    },
  },
]
```

The `serial-subprocess` pool runs those four files sequentially; everything else stays parallel.

## Test plan

- [x] `npx vitest run` (full suite, default invocation) → 1968 / 1968 passing.
- [x] `npx vitest run --changed <merge-base>` (pre-push hook simulation) → clean.
- [x] Pre-push hook itself ran on this branch's `git push -u` and passed.
- [x] `npx tsc --noEmit` clean.
- [x] Prettier-clean.

## Risks

- Full-suite wall time may grow a few seconds since the four files no longer interleave with other parallel files. Subjectively unchanged in measurement; the suite was already gated by those slow files.
- If a future test file is added that has similar subprocess-contention behavior, it'll need to be added to `SERIAL_SUBPROCESS_FILES`. Comment in the config explains the criterion.

## Followups

- After merge: close #447, comment on #425 noting the autonomous loop can resume on #434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Restructured test configuration to optimize test execution patterns. Tests with heavy resource requirements now run sequentially to prevent timeout issues, while other tests continue to execute in parallel.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/448)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->