### PR TITLE
test(sessions): replace fixed sleep with deterministic poll on restore-exit test (#449)

### DIFF
--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -21,7 +21,7 @@ import {
 } from '../server/pty-handler.js';
 import { serializeAll, restoreFromDisk } from '../server/sessions.js';
 import { AGENT_CONTINUE_ARGS, AGENT_YOLO_ARGS } from '../server/types.js';
-import type { PtySession, SessionSummary } from '../server/types.js';
+import type { PtySession } from '../server/types.js';
 
 // Track created session IDs so we can clean up after each test
 const createdIds: string[] = [];
@@ -1499,13 +1499,15 @@ describe('session persistence', () => {
     // not exited by the deadline. Restored sessions exit through a
     // dedicated branch in pty-handler.ts that flips status but does not
     // call fireSessionEnd, so polling is the cleanest signal here.
+    // Use sessions.get() inside the loop — O(1) map lookup, avoids the
+    // sessions.list() snapshot+sort cost on every iteration.
     const deadline = Date.now() + 15_000;
-    let found: SessionSummary | undefined;
     while (Date.now() < deadline) {
-      found = sessions.list().find((s) => s.id === 'restore-exit-test');
-      if (found?.status === 'disconnected') break;
-      await new Promise((resolve) => setTimeout(resolve, 25));
+      if (sessions.get('restore-exit-test')?.status === 'disconnected') break;
+      await delay(25);
     }
+
+    const found = sessions.list().find((s) => s.id === 'restore-exit-test');
 
     expect(found).toBeTruthy();
     expect(found!.status).toBe('disconnected');

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -1,4 +1,12 @@
-import { describe, it, afterAll, afterEach, beforeAll, expect, vi } from 'vitest';
+import {
+  describe,
+  it,
+  afterAll,
+  afterEach,
+  beforeAll,
+  expect,
+  vi,
+} from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -13,7 +21,7 @@ import {
 } from '../server/pty-handler.js';
 import { serializeAll, restoreFromDisk } from '../server/sessions.js';
 import { AGENT_CONTINUE_ARGS, AGENT_YOLO_ARGS } from '../server/types.js';
-import type { PtySession } from '../server/types.js';
+import type { PtySession, SessionSummary } from '../server/types.js';
 
 // Track created session IDs so we can clean up after each test
 const createdIds: string[] = [];
@@ -700,11 +708,7 @@ describe('sessions', () => {
       ).resolves.toBeTruthy();
       expect(fs.existsSync(sentinelPath)).toBe(true);
     } finally {
-      await execTmux([
-        'kill-session',
-        '-t',
-        tmuxSessionName,
-      ]).catch(() => {});
+      await execTmux(['kill-session', '-t', tmuxSessionName]).catch(() => {});
       fs.rmSync(runtimeDir, { recursive: true, force: true });
     }
   });
@@ -1167,10 +1171,7 @@ describe('session persistence', () => {
     const scrollbackDir = path.join(configDir, 'scrollback');
     fs.mkdirSync(scrollbackDir, { recursive: true });
     fs.writeFileSync(path.join(scrollbackDir, 'restore-ok.buf'), 'a output');
-    fs.writeFileSync(
-      path.join(scrollbackDir, 'restore-fails.buf'),
-      'b output'
-    );
+    fs.writeFileSync(path.join(scrollbackDir, 'restore-fails.buf'), 'b output');
 
     const restored = await restoreFromDisk(configDir);
 
@@ -1179,9 +1180,9 @@ describe('session persistence', () => {
     const failedOnlyPending = JSON.parse(
       fs.readFileSync(path.join(configDir, 'pending-sessions.json'), 'utf-8')
     );
-    expect(failedOnlyPending.sessions.map((s: { id: string }) => s.id)).toEqual([
-      'restore-fails',
-    ]);
+    expect(failedOnlyPending.sessions.map((s: { id: string }) => s.id)).toEqual(
+      ['restore-fails']
+    );
     expect(failedOnlyPending.timestamp).toBe(timestamp);
 
     serializeAll(configDir, { reason: 'dev-restart' });
@@ -1204,9 +1205,9 @@ describe('session persistence', () => {
     expect(failedRetry?.pendingSince).toBe(timestamp);
     expect(liveRetry?.pendingSince).toBe(retryPending.timestamp);
     expect(failedRetry?.hookToken).toBe('failed-token');
-    expect(fs.readFileSync(path.join(scrollbackDir, 'restore-fails.buf'), 'utf-8')).toBe(
-      'b output'
-    );
+    expect(
+      fs.readFileSync(path.join(scrollbackDir, 'restore-fails.buf'), 'utf-8')
+    ).toBe('b output');
   });
 
   it('serializeAll keeps fresh live sessions restorable when old preserved failures age out', async () => {
@@ -1303,7 +1304,10 @@ describe('session persistence', () => {
     );
     const scrollbackDir = path.join(configDir, 'scrollback');
     fs.mkdirSync(scrollbackDir, { recursive: true });
-    fs.writeFileSync(path.join(scrollbackDir, 'stale-failure.buf'), 'old output');
+    fs.writeFileSync(
+      path.join(scrollbackDir, 'stale-failure.buf'),
+      'old output'
+    );
 
     const s = sessions.create({
       repoName: 'test-repo',
@@ -1319,9 +1323,9 @@ describe('session persistence', () => {
     const retryPending = JSON.parse(
       fs.readFileSync(path.join(configDir, 'pending-sessions.json'), 'utf-8')
     );
-    expect(retryPending.sessions.map((session: { id: string }) => session.id)).toEqual([
-      s.id,
-    ]);
+    expect(
+      retryPending.sessions.map((session: { id: string }) => session.id)
+    ).toEqual([s.id]);
     expect(fs.existsSync(path.join(scrollbackDir, 'stale-failure.buf'))).toBe(
       false
     );
@@ -1489,12 +1493,20 @@ describe('session persistence', () => {
 
     await restoreFromDisk(configDir);
 
-    // Wait for PTY to exit
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    // Poll for the restored session's PTY (/bin/false) to exit and the
+    // status to flip to 'disconnected'. Previously this used a fixed
+    // 500ms sleep which flaked under CPU contention because the PTY had
+    // not exited by the deadline. Restored sessions exit through a
+    // dedicated branch in pty-handler.ts that flips status but does not
+    // call fireSessionEnd, so polling is the cleanest signal here.
+    const deadline = Date.now() + 15_000;
+    let found: SessionSummary | undefined;
+    while (Date.now() < deadline) {
+      found = sessions.list().find((s) => s.id === 'restore-exit-test');
+      if (found?.status === 'disconnected') break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
 
-    // Session should still be in the list with disconnected status
-    const list = sessions.list();
-    const found = list.find((s) => s.id === 'restore-exit-test');
     expect(found).toBeTruthy();
     expect(found!.status).toBe('disconnected');
   });


### PR DESCRIPTION
## Summary

- Closes #449.
- Replaces a 500ms fixed sleep with deterministic polling in `test/sessions.test.ts > restored session remains in list after PTY exits (disconnected status)`.
- Last pre-push race-condition blocker for the #425 autonomous sub-issue loop.

## Root cause

The test slept 500ms waiting for `/bin/false` to exit and the restored session's status to flip to `'disconnected'`. Under CPU contention (pre-push hook + parallel vitest workers + git object upload concurrent), the deadline fired before the PTY exited and `status` remained `'active'`.

`fileParallelism: false` for the file (added in PR #448) helped but did not fully fix the cross-project contention. The deeper issue is that restored sessions exit via a branch in `server/pty-handler.ts:~1145` that flips status but skips `runExitCleanup`, which means `sessions.onSessionEnd` is **not** a usable wake signal for this case.

## Fix

Poll `sessions.list()` every 25ms for up to 15 seconds, break on `'disconnected'`. Assertions unchanged.

```ts
const deadline = Date.now() + 15_000;
let found: SessionSummary | undefined;
while (Date.now() < deadline) {
  found = sessions.list().find((s) => s.id === 'restore-exit-test');
  if (found?.status === 'disconnected') break;
  await new Promise((resolve) => setTimeout(resolve, 25));
}
expect(found).toBeTruthy();
expect(found!.status).toBe('disconnected');
```

## Test plan

- [x] 3x consecutive `npx vitest run test/sessions.test.ts -t "restored session remains"` → 3/3 PASS.
- [x] Full `test/sessions.test.ts` (68 tests) → 68/68 PASS.
- [x] Pre-push hook ran on `git push` and accepted the change.
- [x] `npx tsc --noEmit` clean.

## Risks

- 15s timeout ceiling is more generous than the prior 500ms; in the happy path the loop breaks within ~50ms because `/bin/false` exits immediately. Slowest observed: ~30ms.
- No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
