### PR TITLE
feat(444): view-spine data-model scaffold (Lane B)

### DIFF
--- a/shared/bench.ts
+++ b/shared/bench.ts
@@ -1,0 +1,50 @@
+// View-spine Bench scaffold (#444 Lane B). Replaces "worktree" as the cwd+env
+// layer; for repo-kind instances a Bench is a git worktree, for node-kind
+// instances it is an arbitrary cwd.
+
+import type { InstanceId } from './project.js';
+
+export type BenchId = string;
+
+export interface Bench {
+  id: BenchId;
+  instanceId: InstanceId;
+  // Anchored cwd within the instance host. Required — a Bench without a cwd
+  // is not a Bench, it's a Tab inheriting Instance defaults.
+  cwd: string;
+  // User-visible label. Branch name for git-worktree benches; free-form
+  // otherwise. The derivation rule lives at the UI layer.
+  label: string;
+  // Env overrides layered on top of Instance defaults. Empty record means
+  // "no override", not "clear env."
+  envOverrides: Record<string, string>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function hasValue(value: string): boolean {
+  return value.trim().length > 0;
+}
+
+export function createBenchId(instanceId: InstanceId, cwd: string): BenchId {
+  if (!hasValue(instanceId)) throw new Error('instanceId is required');
+  if (!hasValue(cwd)) throw new Error('cwd is required');
+  return `bench:${encodeURIComponent(instanceId)}:${encodeURIComponent(cwd)}`;
+}
+
+export function parseBenchId(
+  id: BenchId
+): { instanceId: InstanceId; cwd: string } | null {
+  if (!id.startsWith('bench:')) return null;
+  const rest = id.slice('bench:'.length);
+  const sep = rest.indexOf(':');
+  if (sep <= 0 || sep === rest.length - 1) return null;
+  try {
+    const instanceId = decodeURIComponent(rest.slice(0, sep));
+    const cwd = decodeURIComponent(rest.slice(sep + 1));
+    if (!hasValue(instanceId) || !hasValue(cwd)) return null;
+    return { instanceId, cwd };
+  } catch {
+    return null;
+  }
+}

--- a/shared/project.ts
+++ b/shared/project.ts
@@ -1,0 +1,148 @@
+// View-spine Project + Instance scaffold (#444 Lane B). Pure types + identity
+// helpers. Instance lives alongside Project because an Instance is a Project
+// realized on a host — same identity equivalence, different layer.
+
+import type { NodeId, RepoIdentity } from './identity.js';
+
+export type ProjectId = string;
+export type InstanceId = string;
+
+export type ProjectIdentity =
+  | { kind: 'repo'; remote: RepoIdentity }
+  | { kind: 'node'; nodeId: NodeId }
+  | { kind: 'agent'; providerId: string }
+  | { kind: 'playbook'; playbookId: string };
+
+export type ProjectIdentityKind = ProjectIdentity['kind'];
+
+export interface Project {
+  id: ProjectId;
+  identity: ProjectIdentity;
+  // User-facing display name. Falls back to derived label when blank; the
+  // derivation rule lives at the UI layer, not here.
+  name: string;
+  workspaceId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Instance {
+  id: InstanceId;
+  projectId: ProjectId;
+  // The host this instance lives on. For a `node` project this equals the
+  // identity's nodeId. For other kinds, host is the materialization site.
+  host: NodeId;
+  // Optional anchor path for repo-kind instances; null for agent/node/playbook.
+  localPath: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function hasValue(value: string): boolean {
+  return value.trim().length > 0;
+}
+
+function encodeIdentity(identity: ProjectIdentity): string {
+  switch (identity.kind) {
+    case 'repo':
+      if (!hasValue(identity.remote))
+        throw new Error('identity.remote is required');
+      return `repo:${encodeURIComponent(identity.remote)}`;
+    case 'node':
+      if (!hasValue(identity.nodeId))
+        throw new Error('identity.nodeId is required');
+      return `node:${encodeURIComponent(identity.nodeId)}`;
+    case 'agent':
+      if (!hasValue(identity.providerId))
+        throw new Error('identity.providerId is required');
+      return `agent:${encodeURIComponent(identity.providerId)}`;
+    case 'playbook':
+      if (!hasValue(identity.playbookId))
+        throw new Error('identity.playbookId is required');
+      return `playbook:${encodeURIComponent(identity.playbookId)}`;
+  }
+}
+
+export function createProjectId(identity: ProjectIdentity): ProjectId {
+  return `proj:${encodeIdentity(identity)}`;
+}
+
+export function parseProjectId(id: ProjectId): ProjectIdentity | null {
+  if (!id.startsWith('proj:')) return null;
+  const rest = id.slice('proj:'.length);
+  const sep = rest.indexOf(':');
+  if (sep <= 0 || sep === rest.length - 1) return null;
+  const kind = rest.slice(0, sep);
+  let payload: string;
+  try {
+    payload = decodeURIComponent(rest.slice(sep + 1));
+  } catch {
+    return null;
+  }
+  if (!hasValue(payload)) return null;
+  switch (kind) {
+    case 'repo':
+      return { kind: 'repo', remote: payload };
+    case 'node':
+      return { kind: 'node', nodeId: payload };
+    case 'agent':
+      return { kind: 'agent', providerId: payload };
+    case 'playbook':
+      return { kind: 'playbook', playbookId: payload };
+    default:
+      return null;
+  }
+}
+
+export function projectIdentityEquals(
+  a: ProjectIdentity,
+  b: ProjectIdentity
+): boolean {
+  if (a.kind !== b.kind) return false;
+  switch (a.kind) {
+    case 'repo':
+      return (
+        a.remote === (b as Extract<ProjectIdentity, { kind: 'repo' }>).remote
+      );
+    case 'node':
+      return (
+        a.nodeId === (b as Extract<ProjectIdentity, { kind: 'node' }>).nodeId
+      );
+    case 'agent':
+      return (
+        a.providerId ===
+        (b as Extract<ProjectIdentity, { kind: 'agent' }>).providerId
+      );
+    case 'playbook':
+      return (
+        a.playbookId ===
+        (b as Extract<ProjectIdentity, { kind: 'playbook' }>).playbookId
+      );
+  }
+}
+
+export function createInstanceId(
+  projectId: ProjectId,
+  host: NodeId
+): InstanceId {
+  if (!hasValue(projectId)) throw new Error('projectId is required');
+  if (!hasValue(host)) throw new Error('host is required');
+  return `inst:${encodeURIComponent(projectId)}:${encodeURIComponent(host)}`;
+}
+
+export function parseInstanceId(
+  id: InstanceId
+): { projectId: ProjectId; host: NodeId } | null {
+  if (!id.startsWith('inst:')) return null;
+  const rest = id.slice('inst:'.length);
+  const sep = rest.indexOf(':');
+  if (sep <= 0 || sep === rest.length - 1) return null;
+  try {
+    const projectId = decodeURIComponent(rest.slice(0, sep));
+    const host = decodeURIComponent(rest.slice(sep + 1));
+    if (!hasValue(projectId) || !hasValue(host)) return null;
+    return { projectId, host };
+  } catch {
+    return null;
+  }
+}

--- a/shared/workspace.ts
+++ b/shared/workspace.ts
@@ -1,0 +1,38 @@
+// View-spine data model (#444 Lane B): scaffold-only types + identity helpers.
+// No wiring yet — Lane A migration, server CRUD, and frontend render in follow-ups.
+
+export type WorkspaceId = string;
+
+export interface Workspace {
+  id: WorkspaceId;
+  name: string;
+  // Ordering within the workspace bar. Lower comes first. Float so reorder
+  // without renumber is feasible — same pattern as Bench/Tab follow-ups will use.
+  order: number;
+  // Project membership is stored as an ordered list of ProjectIds rather than
+  // an embedded Project[] so a Project can be referenced from a View without
+  // duplicating Workspace state.
+  projectIds: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+function hasValue(value: string): boolean {
+  return value.trim().length > 0;
+}
+
+export function createWorkspaceId(localId: string): WorkspaceId {
+  if (!hasValue(localId)) throw new Error('localId is required');
+  return `ws:${encodeURIComponent(localId)}`;
+}
+
+export function parseWorkspaceId(id: WorkspaceId): { localId: string } | null {
+  if (!id.startsWith('ws:')) return null;
+  try {
+    const localId = decodeURIComponent(id.slice('ws:'.length));
+    if (!hasValue(localId)) return null;
+    return { localId };
+  } catch {
+    return null;
+  }
+}

--- a/test/view-spine-identity.test.ts
+++ b/test/view-spine-identity.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+
+import { createBenchId, parseBenchId } from '../shared/bench.js';
+import {
+  createInstanceId,
+  createProjectId,
+  parseInstanceId,
+  parseProjectId,
+  projectIdentityEquals,
+  type ProjectIdentity,
+} from '../shared/project.js';
+import { createWorkspaceId, parseWorkspaceId } from '../shared/workspace.js';
+
+describe('workspace id helpers', () => {
+  it('round-trips ids with delimiters in the local part', () => {
+    const id = createWorkspaceId('Mt. Rainier: tier/1');
+    expect(id).toBe('ws:Mt.%20Rainier%3A%20tier%2F1');
+    expect(parseWorkspaceId(id)).toEqual({ localId: 'Mt. Rainier: tier/1' });
+  });
+
+  it('rejects malformed workspace ids', () => {
+    expect(parseWorkspaceId('not-prefixed')).toBeNull();
+    expect(parseWorkspaceId('ws:')).toBeNull();
+    expect(parseWorkspaceId('ws:%')).toBeNull();
+  });
+
+  it('throws when local id is blank', () => {
+    expect(() => createWorkspaceId('')).toThrow('localId is required');
+    expect(() => createWorkspaceId('   ')).toThrow('localId is required');
+  });
+});
+
+describe('project id helpers', () => {
+  it('encodes each identity kind under its own tag', () => {
+    expect(
+      createProjectId({ kind: 'repo', remote: 'github.com/foo/bar' })
+    ).toBe('proj:repo:github.com%2Ffoo%2Fbar');
+    expect(createProjectId({ kind: 'node', nodeId: 'macbook' })).toBe(
+      'proj:node:macbook'
+    );
+    expect(createProjectId({ kind: 'agent', providerId: 'claude:opus' })).toBe(
+      'proj:agent:claude%3Aopus'
+    );
+    expect(createProjectId({ kind: 'playbook', playbookId: 'pb/42' })).toBe(
+      'proj:playbook:pb%2F42'
+    );
+  });
+
+  it('round-trips identity through parseProjectId', () => {
+    const identities: ProjectIdentity[] = [
+      { kind: 'repo', remote: 'github.com/donovan-yohan/relay-ide' },
+      { kind: 'node', nodeId: 'wsl: ubuntu' },
+      { kind: 'agent', providerId: 'opencode' },
+      { kind: 'playbook', playbookId: 'pb/release' },
+    ];
+    for (const identity of identities) {
+      expect(parseProjectId(createProjectId(identity))).toEqual(identity);
+    }
+  });
+
+  it('rejects malformed or unknown-kind project ids', () => {
+    expect(parseProjectId('not-prefixed')).toBeNull();
+    expect(parseProjectId('proj:')).toBeNull();
+    expect(parseProjectId('proj:repo:')).toBeNull();
+    expect(parseProjectId('proj:unknown:foo')).toBeNull();
+    expect(parseProjectId('proj:repo:%')).toBeNull();
+  });
+
+  it('throws when identity payload is blank', () => {
+    expect(() => createProjectId({ kind: 'repo', remote: '' })).toThrow(
+      'identity.remote is required'
+    );
+    expect(() => createProjectId({ kind: 'node', nodeId: '   ' })).toThrow(
+      'identity.nodeId is required'
+    );
+    expect(() => createProjectId({ kind: 'agent', providerId: '' })).toThrow(
+      'identity.providerId is required'
+    );
+    expect(() => createProjectId({ kind: 'playbook', playbookId: '' })).toThrow(
+      'identity.playbookId is required'
+    );
+  });
+
+  it('compares identities by kind+payload', () => {
+    expect(
+      projectIdentityEquals(
+        { kind: 'repo', remote: 'github.com/foo/bar' },
+        { kind: 'repo', remote: 'github.com/foo/bar' }
+      )
+    ).toBe(true);
+    expect(
+      projectIdentityEquals(
+        { kind: 'repo', remote: 'github.com/foo/bar' },
+        { kind: 'repo', remote: 'github.com/foo/baz' }
+      )
+    ).toBe(false);
+    expect(
+      projectIdentityEquals(
+        { kind: 'repo', remote: 'github.com/foo/bar' },
+        { kind: 'node', nodeId: 'github.com/foo/bar' }
+      )
+    ).toBe(false);
+    expect(
+      projectIdentityEquals(
+        { kind: 'node', nodeId: 'macbook' },
+        { kind: 'node', nodeId: 'macbook' }
+      )
+    ).toBe(true);
+    expect(
+      projectIdentityEquals(
+        { kind: 'agent', providerId: 'claude' },
+        { kind: 'playbook', playbookId: 'claude' }
+      )
+    ).toBe(false);
+  });
+});
+
+describe('instance id helpers', () => {
+  it('round-trips projectId + host through createInstanceId', () => {
+    const projectId = createProjectId({
+      kind: 'repo',
+      remote: 'github.com/foo/bar',
+    });
+    const id = createInstanceId(projectId, 'macbook:dev');
+    expect(parseInstanceId(id)).toEqual({ projectId, host: 'macbook:dev' });
+  });
+
+  it('rejects malformed instance ids', () => {
+    expect(parseInstanceId('not-prefixed')).toBeNull();
+    expect(parseInstanceId('inst:')).toBeNull();
+    expect(parseInstanceId('inst::host')).toBeNull();
+    expect(parseInstanceId('inst:proj:%')).toBeNull();
+  });
+
+  it('throws when projectId or host is blank', () => {
+    expect(() => createInstanceId('', 'macbook')).toThrow(
+      'projectId is required'
+    );
+    expect(() => createInstanceId('proj:node:macbook', '')).toThrow(
+      'host is required'
+    );
+  });
+});
+
+describe('bench id helpers', () => {
+  it('round-trips instanceId + cwd', () => {
+    const instanceId = createInstanceId('proj:node:macbook', 'macbook');
+    const cwd = '/Users/me/repo/.worktrees/feature: one';
+    const id = createBenchId(instanceId, cwd);
+    expect(parseBenchId(id)).toEqual({ instanceId, cwd });
+  });
+
+  it('rejects malformed bench ids', () => {
+    expect(parseBenchId('not-prefixed')).toBeNull();
+    expect(parseBenchId('bench:')).toBeNull();
+    expect(parseBenchId('bench::/cwd')).toBeNull();
+    expect(parseBenchId('bench:inst%3Afoo:%')).toBeNull();
+  });
+
+  it('throws when instanceId or cwd is blank', () => {
+    expect(() => createBenchId('', '/tmp')).toThrow('instanceId is required');
+    expect(() => createBenchId('inst:foo:bar', '')).toThrow('cwd is required');
+  });
+});


### PR DESCRIPTION
## Summary

Lane B of the #444 epic — pure data-model scaffold for the six-layer view-spine information architecture. Types + identity helpers only, **no wiring, no migration, no UI**. Follow-up lanes hook these into the server / sidebar / migration runner.

- `shared/workspace.ts` — `Workspace` entity + `createWorkspaceId` / `parseWorkspaceId`.
- `shared/project.ts` — `Project`, `Instance`, and `ProjectIdentity` tagged union over `repo | node | agent | playbook`; `createProjectId`, `createInstanceId`, `projectIdentityEquals`.
- `shared/bench.ts` — `Bench` (cwd + env overrides) + `createBenchId` / `parseBenchId`. Replaces "worktree" as the cwd/env layer.
- `test/view-spine-identity.test.ts` — 14 tests: round-trip, malformed-id rejection, blank-input throw, identity equality across kinds.

Identity scheme follows the existing `shared/identity.ts` convention: `encodeURIComponent`-joined scoped ids, parsers that reject delimiter collisions. Project ids tag the kind (`proj:repo:…`, `proj:node:…`, etc.) so the union round-trips through a plain string.

## Conflict surface

Zero. All four files are net-new. The neighboring queue's #437 / `relay-node-protocol.ts` work touches a different file under `shared/`.

## Test plan

- [x] `npm run build` — green
- [x] `npx vitest run test/view-spine-identity.test.ts` — 14/14 pass
- [x] `eslint` over the four new files — clean
- [ ] CI green on PR
- [ ] Gemini review (monitored separately)

Refs #444. Supersedes none of the existing Lane B placeholders since this is the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)