### PR TITLE
feat(443): cross-node terminal tabs — nodeId + picker + chrome

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -13,55 +13,55 @@ React 19 SPA for Relay IDE. Built with TypeScript, Zustand, TanStack Query, and 
 
 ## Component Map
 
-| Component                            | Role                                                                                                                                                                 |
-| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Component                            | Role                                                                                                                                                             |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `App.tsx`                            | Root layout: left sidebar + SplitPaneLayout hosting WorkspaceArea and WorkspaceUtilityRail for session view; dashboard / PR top bar + tabs for non-session views |
-| `Sidebar.tsx`                        | Flat workspace list with command palette search                                                                                                                      |
-| `RepoItem.tsx`                       | Repo tree item: sessions, inactive worktrees, context menus, workspace group membership                                                                              |
-| `CommandPalette.tsx`                 | Terminal-style command palette with action registry                                                                                                                  |
-| `PrTopBar.tsx`                       | Dynamic PR/CI bar with branch switcher, target branch switcher, diff stats, merge conflict detection, action buttons                                                 |
-| `RepoDashboard.tsx`                  | Workspace dashboard: PRs with merge status, activity feed, CTAs                                                                                                      |
-| `BranchSwitcher.tsx`                 | Worktree-aware branch dropdown: filter, create new branch, jump-to-session links, agent-running guard                                                                |
-| `TargetBranchSwitcher.tsx`           | PR base branch dropdown: remote-only branches, changes base via `gh pr edit`                                                                                         |
-| `FileBrowser.tsx`                    | Lazy-loading tree-view filesystem browser with multi-select, filter, keyboard nav                                                                                    |
-| `Terminal.tsx`                       | xterm.js terminal wrapper with WebSocket connection, escape sequence sanitization                                                                                    |
-| `Toolbar.tsx`                        | Mobile touch toolbar for terminal interaction                                                                                                                        |
-| `MobileInput.tsx`                    | Event-intent mobile keyboard input handler                                                                                                                           |
-| `ContextMenu.tsx`                    | Universal "..." dropdown menu for session/item actions                                                                                                               |
-| `PinGate.tsx`                        | PIN authentication screen with PinInput component                                                                                                                    |
-| `SessionIndicator.tsx`               | Unicode shape-based session state indicator (shapes + colors + pulse animations)                                                                                     |
-| `SessionStatusBar.tsx`               | Multi-framework telemetry status bar (model, context %, tokens)                                                                                                      |
-| `AgentBadge.tsx`                     | Agent type indicator badge (Claude/Codex/OpenCode)                                                                                                                   |
-| `WorkspaceUtilityRail.tsx`           | Right utility rail: fixed icon strip, selected utility pane host, visible/hidden shell model                                                                         |
-| `UtilityRailFilesPanel.tsx`          | Files utility pane wrapper around changed files and lazy filesystem browsing                                                                                         |
-| `UtilityRailReviewPanel.tsx`         | Review utility pane: changed-file list, diff source controls, and embedded DiffViewer                                                                                |
-| `UtilityRailLogsPanel.tsx`           | Logs utility pane shell for current session/activity output                                                                                                          |
-| `UtilityRailStatsPanel.tsx`          | Stats utility pane using telemetry summaries for active session and workspace                                                                                        |
-| `FileTreeSidebar.tsx`                | Reusable files panel implementation: changes tab (git diff tree), all files tab (lazy filesystem browser)                                                            |
-| `WorkspaceArea.tsx`                  | Workspace tab layout host for session, terminal, code, diff, and HTML tabs with draggable panes                                                                      |
-| `SplitPaneLayout.tsx`                | Resizable layout wrapper for the workspace area and utility rail with draggable resize handles                                                                        |
-| `DiffViewer.tsx`                     | Unified diff renderer with diff2html parsing and Shiki syntax highlighting                                                                                           |
-| `CodeBlock.tsx`                      | Shared Shiki syntax highlighting wrapper component                                                                                                                   |
-| `OrgDashboard.tsx`                   | Cross-repo PR list and tickets panel with tab navigation                                                                                                             |
-| `TicketsPanel.tsx`                   | Multi-provider ticket list: GitHub Issues, Jira, Linear tabs                                                                                                         |
-| `TicketCard.tsx`                     | Individual ticket row: status dot, provider metadata, branch link, Start Work button                                                                                 |
-| `StartWorkModal.tsx`                 | Start Work modal: ticket info, workspace selector, branch name input                                                                                                 |
-| `TuiButton.tsx`                      | TUI-styled button with box-drawing corner characters                                                                                                                 |
-| `TuiCheckbox.tsx`                    | Terminal-style `[x]`/`[ ]` checkbox component                                                                                                                        |
-| `TuiInput.tsx`                       | Terminal-style input with block cursor                                                                                                                               |
-| `Tooltip.tsx`                        | Design-system hover/focus tooltip for controls; can resolve labels/descriptions/shortcuts from command registry action IDs                                           |
-| `MarqueeText.tsx`                    | Horizontal scroll-on-hover for overflow text (Spotify-style)                                                                                                         |
-| `CipherText.tsx`                     | Cipher-decode loading/transition animation                                                                                                                           |
-| `Hint.tsx`                           | Progressive disclosure onboarding hint component                                                                                                                     |
-| `WorkspaceGroup.tsx`                 | Workspace container with color-coded border grouping                                                                                                                 |
-| **Dialogs**                          |                                                                                                                                                                      |
-| `dialogs/DialogShell.tsx`            | Shared dialog wrapper (fullscreen/compact, terminal aesthetic, popover-based stacking)                                                                               |
-| `dialogs/SettingsDialog.tsx`         | Full settings dialog with TOC, sections, integrations                                                                                                                |
-| `dialogs/CustomizeSessionDialog.tsx` | Session creation/customization with agent selection, args, workspace                                                                                                 |
-| `dialogs/AddWorkspaceDialog.tsx`     | Workspace path browser and add flow                                                                                                                                  |
-| `dialogs/DeleteWorktreeDialog.tsx`   | Worktree deletion with dirty-check confirmation                                                                                                                      |
-| `dialogs/RenameWarningModal.tsx`     | Rename + PR warning: push, ignore, or undo                                                                                                                           |
-| `dialogs/WorkspaceEditor.tsx`        | Workspace entity editor: name, repo assignment, theme color                                                                                                          |
+| `Sidebar.tsx`                        | Flat workspace list with command palette search                                                                                                                  |
+| `RepoItem.tsx`                       | Repo tree item: sessions, inactive worktrees, context menus, workspace group membership                                                                          |
+| `CommandPalette.tsx`                 | Terminal-style command palette with action registry                                                                                                              |
+| `PrTopBar.tsx`                       | Dynamic PR/CI bar with branch switcher, target branch switcher, diff stats, merge conflict detection, action buttons                                             |
+| `RepoDashboard.tsx`                  | Workspace dashboard: PRs with merge status, activity feed, CTAs                                                                                                  |
+| `BranchSwitcher.tsx`                 | Worktree-aware branch dropdown: filter, create new branch, jump-to-session links, agent-running guard                                                            |
+| `TargetBranchSwitcher.tsx`           | PR base branch dropdown: remote-only branches, changes base via `gh pr edit`                                                                                     |
+| `FileBrowser.tsx`                    | Lazy-loading tree-view filesystem browser with multi-select, filter, keyboard nav                                                                                |
+| `Terminal.tsx`                       | xterm.js terminal wrapper with WebSocket connection, escape sequence sanitization                                                                                |
+| `Toolbar.tsx`                        | Mobile touch toolbar for terminal interaction                                                                                                                    |
+| `MobileInput.tsx`                    | Event-intent mobile keyboard input handler                                                                                                                       |
+| `ContextMenu.tsx`                    | Universal "..." dropdown menu for session/item actions                                                                                                           |
+| `PinGate.tsx`                        | PIN authentication screen with PinInput component                                                                                                                |
+| `SessionIndicator.tsx`               | Unicode shape-based session state indicator (shapes + colors + pulse animations)                                                                                 |
+| `SessionStatusBar.tsx`               | Multi-framework telemetry status bar (model, context %, tokens)                                                                                                  |
+| `AgentBadge.tsx`                     | Agent type indicator badge (Claude/Codex/OpenCode)                                                                                                               |
+| `WorkspaceUtilityRail.tsx`           | Right utility rail: fixed icon strip, selected utility pane host, visible/hidden shell model                                                                     |
+| `UtilityRailFilesPanel.tsx`          | Files utility pane wrapper around changed files and lazy filesystem browsing                                                                                     |
+| `UtilityRailReviewPanel.tsx`         | Review utility pane: changed-file list, diff source controls, and embedded DiffViewer                                                                            |
+| `UtilityRailLogsPanel.tsx`           | Logs utility pane shell for current session/activity output                                                                                                      |
+| `UtilityRailStatsPanel.tsx`          | Stats utility pane using telemetry summaries for active session and workspace                                                                                    |
+| `FileTreeSidebar.tsx`                | Reusable files panel implementation: changes tab (git diff tree), all files tab (lazy filesystem browser)                                                        |
+| `WorkspaceArea.tsx`                  | Workspace tab layout host for session, terminal, code, diff, and HTML tabs with draggable panes                                                                  |
+| `SplitPaneLayout.tsx`                | Resizable layout wrapper for the workspace area and utility rail with draggable resize handles                                                                   |
+| `DiffViewer.tsx`                     | Unified diff renderer with diff2html parsing and Shiki syntax highlighting                                                                                       |
+| `CodeBlock.tsx`                      | Shared Shiki syntax highlighting wrapper component                                                                                                               |
+| `OrgDashboard.tsx`                   | Cross-repo PR list and tickets panel with tab navigation                                                                                                         |
+| `TicketsPanel.tsx`                   | Multi-provider ticket list: GitHub Issues, Jira, Linear tabs                                                                                                     |
+| `TicketCard.tsx`                     | Individual ticket row: status dot, provider metadata, branch link, Start Work button                                                                             |
+| `StartWorkModal.tsx`                 | Start Work modal: ticket info, workspace selector, branch name input                                                                                             |
+| `TuiButton.tsx`                      | TUI-styled button with box-drawing corner characters                                                                                                             |
+| `TuiCheckbox.tsx`                    | Terminal-style `[x]`/`[ ]` checkbox component                                                                                                                    |
+| `TuiInput.tsx`                       | Terminal-style input with block cursor                                                                                                                           |
+| `Tooltip.tsx`                        | Design-system hover/focus tooltip for controls; can resolve labels/descriptions/shortcuts from command registry action IDs                                       |
+| `MarqueeText.tsx`                    | Horizontal scroll-on-hover for overflow text (Spotify-style)                                                                                                     |
+| `CipherText.tsx`                     | Cipher-decode loading/transition animation                                                                                                                       |
+| `Hint.tsx`                           | Progressive disclosure onboarding hint component                                                                                                                 |
+| `WorkspaceGroup.tsx`                 | Workspace container with color-coded border grouping                                                                                                             |
+| **Dialogs**                          |                                                                                                                                                                  |
+| `dialogs/DialogShell.tsx`            | Shared dialog wrapper (fullscreen/compact, terminal aesthetic, popover-based stacking)                                                                           |
+| `dialogs/SettingsDialog.tsx`         | Full settings dialog with TOC, sections, integrations                                                                                                            |
+| `dialogs/CustomizeSessionDialog.tsx` | Session creation/customization with agent selection, args, workspace                                                                                             |
+| `dialogs/AddWorkspaceDialog.tsx`     | Workspace path browser and add flow                                                                                                                              |
+| `dialogs/DeleteWorktreeDialog.tsx`   | Worktree deletion with dirty-check confirmation                                                                                                                  |
+| `dialogs/RenameWarningModal.tsx`     | Rename + PR warning: push, ignore, or undo                                                                                                                       |
+| `dialogs/WorkspaceEditor.tsx`        | Workspace entity editor: name, repo assignment, theme color                                                                                                      |
 
 ## State Management
 
@@ -137,6 +137,7 @@ Typed action registry for the command palette. Actions are pure metadata (`Actio
 - All dialogs are built on `DialogShell.tsx` — use the `fullscreen` prop for the Settings modal and omit it for compact dialogs (AddWorkspace, CustomizeSession, DeleteWorktree). DialogShell uses `popover="manual"` + `showPopover()`/`hidePopover()` to guarantee top-layer stacking above xterm.js canvas elements (z-index alone is insufficient for canvas stacking contexts)
 - Cookie TTL uses human-readable format: `s` (seconds), `m` (minutes), `h` (hours), `d` (days). Default: `24h`
 - **Utility rail + workspace tabs** — `SplitPaneLayout` wraps the session view with `WorkspaceArea` (session/file/diff/html tabs) and `WorkspaceUtilityRail` (right, visible/hidden via the PR top-bar toggle). The rail has a fixed-width icon strip at the far right; the selected utility pane renders immediately to its left, and clicking the active icon clears the selected pane while keeping the icon strip. Utility rail state is persisted per workspace path in the UI store; `openFileTab()`/`closeFileTab()` drive file tabs inside WorkspaceArea.
+- **Cross-node terminal tabs (#443)** — `WorkspaceTab` session variant carries an optional `nodeId`. When set, `ws.ts` `connectPtySocket` routes via `/nodes/:nodeId/ws/sessions/:sessionId` (resolved through `parseGlobalSessionId` or `session.nodeId`). `WorkspaceTabBar` renders a per-tab node badge (label + heartbeat dot) sourced from `SummaryContext.findNode`, which `WorkspaceArea` populates from `useQuery(['hub-nodes'], fetchHubNodes)`. The tab-bar `+` button is replaced by `TerminalNodePicker` — a dropdown listing "this host" plus paired nodes; only `online` nodes are selectable. Choosing a node calls `createAgentSession({ type: 'terminal', nodeId })`; the layout reconciler picks the new session up via `sessions[]` → `sessionToWorkspaceTab` (which copies `session.nodeId` onto the tab).
 - Root directory scanning: one level deep for git repos, hidden directories excluded
 
 ## Mobile Touch & Input

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -281,6 +281,18 @@ This upgrades to a WebSocket. The hub proxies PTY I/O between the browser and th
 
 Session lifecycle events (idle changes, file changes, session ended) are scoped by node ID so the hub can broadcast them to clients with the correct environment context. The `shared/node-boundary.ts` module handles creating node-scoped event payloads.
 
+### Cross-Node Terminal Panel (Lane A of #443)
+
+A single hub UI can host terminal tabs attached to multiple paired nodes:
+
+- `WorkspaceTab` (`frontend/src/lib/workspace-layout.ts`) session variant carries an optional `nodeId`. Hub-local sessions omit it; routed sessions populate it from `SessionSummary.nodeId`.
+- The `+` control in `WorkspaceTabBar` is rendered by `TerminalNodePicker`, which fetches `/nodes` via `fetchHubNodes()` and lists `this host` plus paired nodes. Only `online` nodes are selectable; `stale`/`offline`/`revoked` rows are disabled and surface the heartbeat status as the tooltip reason.
+- Selecting a node calls `createAgentSession({ type: 'terminal', nodeId })`, which routes through `POST /hub/nodes/{nodeId}/sessions` and returns a node-scoped `SessionSummary`. The layout reconciler picks the new session up; `sessionToWorkspaceTab` copies `session.nodeId` onto the tab.
+- The PTY socket (`frontend/src/lib/ws.ts`) reads `nodeId` from the session (or parses it from a global session id) and opens `/nodes/{nodeId}/ws/sessions/{localSessionId}` instead of the local `/ws/{sessionId}` route.
+- Tab chrome (`WorkspaceTabBar` + `workspace-summary.ts`) shows a node label + heartbeat dot for cross-node tabs, sourced from `SummaryContext.findNode` which `WorkspaceArea` populates from the `useQuery(['hub-nodes'], fetchHubNodes)` cache (15 s refetch interval).
+
+Reload-resume (tmux-backed `pty.attach`) and the two-node smoke harness remain follow-ups under sub-issues of #443.
+
 ## Repo Identity and Inventory
 
 ### Canonical Repo Identity

--- a/frontend/src/components/TerminalNodePicker.css
+++ b/frontend/src/components/TerminalNodePicker.css
@@ -1,0 +1,87 @@
+.ws-node-picker {
+  position: relative;
+  display: inline-flex;
+  align-items: stretch;
+  height: 100%;
+}
+
+.ws-node-picker__menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 50;
+  min-width: 200px;
+  margin-top: 2px;
+  background: var(--bg-elev, #111);
+  border: 1px solid var(--border, #2a2a2a);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.72rem;
+  padding: 4px 0;
+  box-shadow: 0 4px 14px rgb(0 0 0 / 50%);
+}
+
+.ws-node-picker__hint {
+  padding: 4px 10px;
+  color: var(--text-muted, #888);
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+  border-bottom: 1px solid var(--border, #1a1a1a);
+}
+
+.ws-node-picker__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 10px;
+  background: transparent;
+  border: 0;
+  color: var(--text, #e6e6e6);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  text-transform: lowercase;
+}
+
+.ws-node-picker__item:hover:not(:disabled) {
+  background: var(--bg-active, #161616);
+}
+
+.ws-node-picker__item:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.ws-node-picker__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 0;
+  flex-shrink: 0;
+}
+
+.ws-node-picker__dot--local {
+  background: var(--text-muted, #888);
+}
+.ws-node-picker__dot--online {
+  background: var(--status-success, #34d399);
+}
+.ws-node-picker__dot--stale {
+  background: var(--status-warning, #f59e0b);
+}
+.ws-node-picker__dot--offline,
+.ws-node-picker__dot--revoked {
+  background: var(--status-error, #ef4444);
+}
+
+.ws-node-picker__label {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.ws-node-picker__status {
+  color: var(--text-muted, #888);
+  font-size: 0.62rem;
+}

--- a/frontend/src/components/TerminalNodePicker.css
+++ b/frontend/src/components/TerminalNodePicker.css
@@ -43,8 +43,17 @@
   text-transform: lowercase;
 }
 
-.ws-node-picker__item:hover:not(:disabled) {
+.ws-node-picker__item:hover:not(:disabled),
+.ws-node-picker__item--focused:not(:disabled) {
   background: var(--bg-active, #161616);
+}
+
+.ws-node-picker__menu:focus {
+  outline: none;
+}
+
+.ws-node-picker__item--focused {
+  box-shadow: inset 0 0 0 1px var(--accent, #d97757);
 }
 
 .ws-node-picker__item:disabled {

--- a/frontend/src/components/TerminalNodePicker.css
+++ b/frontend/src/components/TerminalNodePicker.css
@@ -6,12 +6,11 @@
 }
 
 .ws-node-picker__menu {
-  position: absolute;
-  top: 100%;
-  right: 0;
+  /* Portal-rendered: top/right are set inline from the trigger rect so the
+     menu escapes the tab bar's overflow clipping. */
+  position: fixed;
   z-index: 50;
   min-width: 200px;
-  margin-top: 2px;
   background: var(--bg-elev, #111);
   border: 1px solid var(--border, #2a2a2a);
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);

--- a/frontend/src/components/TerminalNodePicker.tsx
+++ b/frontend/src/components/TerminalNodePicker.tsx
@@ -1,4 +1,11 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { fetchHubNodes } from '../lib/api.js';
 import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
@@ -51,6 +58,17 @@ export function buildChoices(nodes: HubNodeSummary[]): NodeChoice[] {
   return choices;
 }
 
+export function firstEnabledIndex(
+  choices: NodeChoice[],
+  from = 0,
+  step = 1
+): number {
+  for (let i = from; i >= 0 && i < choices.length; i += step) {
+    if (!choices[i]?.disabled) return i;
+  }
+  return -1;
+}
+
 export function TerminalNodePicker({
   onSelect,
   triggerLabel = '+',
@@ -58,7 +76,10 @@ export function TerminalNodePicker({
   triggerClassName,
 }: TerminalNodePickerProps): React.ReactElement {
   const [open, setOpen] = useState(false);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const optionIdPrefix = useId();
   useClickOutside(wrapperRef, () => setOpen(false), open);
 
   const { data: nodes = [] } = useQuery({
@@ -70,6 +91,29 @@ export function TerminalNodePicker({
 
   const choices = useMemo(() => buildChoices(nodes), [nodes]);
 
+  const optionId = useCallback(
+    (i: number) => `${optionIdPrefix}-opt-${i}`,
+    [optionIdPrefix]
+  );
+
+  // Reset focus to the first enabled option when the menu opens or the
+  // choice set changes (paired nodes arrive after the menu is opened).
+  useEffect(() => {
+    if (!open) {
+      setFocusedIndex(-1);
+      return;
+    }
+    setFocusedIndex((prev) => {
+      if (prev >= 0 && !choices[prev]?.disabled) return prev;
+      return firstEnabledIndex(choices, 0, 1);
+    });
+  }, [open, choices]);
+
+  // Focus the listbox container so the keyboard handler receives ArrowUp/Down.
+  useEffect(() => {
+    if (open) listRef.current?.focus();
+  }, [open]);
+
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
@@ -79,10 +123,48 @@ export function TerminalNodePicker({
     return () => window.removeEventListener('keydown', onKey);
   }, [open]);
 
-  const handleSelect = (choice: NodeChoice) => {
-    if (choice.disabled) return;
-    setOpen(false);
-    onSelect(choice.nodeId);
+  const handleSelect = useCallback(
+    (choice: NodeChoice | undefined) => {
+      if (!choice || choice.disabled) return;
+      setOpen(false);
+      onSelect(choice.nodeId);
+    },
+    [onSelect]
+  );
+
+  const moveFocus = useCallback(
+    (direction: 1 | -1) => {
+      setFocusedIndex((prev) => {
+        const start =
+          prev < 0
+            ? direction === 1
+              ? 0
+              : choices.length - 1
+            : prev + direction;
+        const next = firstEnabledIndex(choices, start, direction);
+        return next >= 0 ? next : prev;
+      });
+    },
+    [choices]
+  );
+
+  const handleListKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      moveFocus(1);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      moveFocus(-1);
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setFocusedIndex(firstEnabledIndex(choices, 0, 1));
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      setFocusedIndex(firstEnabledIndex(choices, choices.length - 1, -1));
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleSelect(choices[focusedIndex]);
+    }
   };
 
   return (
@@ -98,34 +180,53 @@ export function TerminalNodePicker({
         {triggerLabel}
       </button>
       {open && (
-        <div role="listbox" className="ws-node-picker__menu">
+        <div
+          ref={listRef}
+          role="listbox"
+          tabIndex={-1}
+          className="ws-node-picker__menu"
+          aria-activedescendant={
+            focusedIndex >= 0 ? optionId(focusedIndex) : undefined
+          }
+          onKeyDown={handleListKeyDown}
+        >
           <div className="ws-node-picker__hint">new terminal on…</div>
-          {choices.map((choice) => (
-            <button
-              key={choice.nodeId}
-              type="button"
-              role="option"
-              aria-selected={false}
-              aria-disabled={choice.disabled}
-              disabled={choice.disabled}
-              className="ws-node-picker__item"
-              onClick={() => handleSelect(choice)}
-              title={
-                choice.disabledReason
-                  ? `node ${choice.label} is ${choice.disabledReason}`
-                  : undefined
-              }
-            >
-              <span
-                className={`ws-node-picker__dot ws-node-picker__dot--${choice.status === 'this host' ? 'local' : choice.status}`}
-                aria-hidden
-              />
-              <span className="ws-node-picker__label">{choice.label}</span>
-              {choice.status !== 'this host' && (
-                <span className="ws-node-picker__status">{choice.status}</span>
-              )}
-            </button>
-          ))}
+          {choices.map((choice, i) => {
+            const isFocused = i === focusedIndex;
+            return (
+              <button
+                key={choice.nodeId}
+                id={optionId(i)}
+                type="button"
+                role="option"
+                aria-selected={isFocused}
+                aria-disabled={choice.disabled}
+                disabled={choice.disabled}
+                className={`ws-node-picker__item${isFocused ? ' ws-node-picker__item--focused' : ''}`}
+                onClick={() => handleSelect(choice)}
+                onMouseEnter={() => {
+                  if (!choice.disabled) setFocusedIndex(i);
+                }}
+                tabIndex={-1}
+                {...(choice.disabledReason
+                  ? {
+                      title: `node ${choice.label} is ${choice.disabledReason}`,
+                    }
+                  : {})}
+              >
+                <span
+                  className={`ws-node-picker__dot ws-node-picker__dot--${choice.status === 'this host' ? 'local' : choice.status}`}
+                  aria-hidden
+                />
+                <span className="ws-node-picker__label">{choice.label}</span>
+                {choice.status !== 'this host' && (
+                  <span className="ws-node-picker__status">
+                    {choice.status}
+                  </span>
+                )}
+              </button>
+            );
+          })}
         </div>
       )}
     </div>

--- a/frontend/src/components/TerminalNodePicker.tsx
+++ b/frontend/src/components/TerminalNodePicker.tsx
@@ -2,22 +2,23 @@ import React, {
   useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { useQuery } from '@tanstack/react-query';
 import { fetchHubNodes } from '../lib/api.js';
 import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
 import type { HubNodeSummary } from '../../../shared/relay-node-protocol.js';
-import useClickOutside from '../hooks/useClickOutside.js';
 import './TerminalNodePicker.css';
 
 export interface TerminalNodePickerProps {
   /**
-   * Invoked with the chosen nodeId. Pass DEFAULT_LOCAL_NODE_ID for "this host".
-   * Empty fires when picker has no remote nodes — the caller may default to
-   * hub-local without prompting.
+   * Called with the chosen nodeId — DEFAULT_LOCAL_NODE_ID for "this host",
+   * or a paired node's id for cross-node terminals. Only fires when the
+   * user selects an enabled (online + capability-ready) choice.
    */
   onSelect: (nodeId: string) => void;
   /** Label for the trigger button. */
@@ -36,6 +37,21 @@ export interface NodeChoice {
   disabledReason?: string;
 }
 
+/**
+ * Mirrors the hub-side preconditions documented in `docs/federated-relay.md`
+ * §Session Routing: a node must be online, version-matched to the hub, and
+ * advertise tmux capability. Anything else gets surfaced as a disabled
+ * choice with the failing precondition as the tooltip reason — the user
+ * never gets to click and then hit a typed error.
+ */
+function nodeBlockReason(node: HubNodeSummary): string | null {
+  if (node.status !== 'online') return node.status;
+  if (node.version.state === 'incompatible') return 'protocol incompatible';
+  if (node.version.state === 'version-skew') return 'version skew';
+  if (node.capabilities.core.tmux !== 'available') return 'no tmux';
+  return null;
+}
+
 export function buildChoices(nodes: HubNodeSummary[]): NodeChoice[] {
   const choices: NodeChoice[] = [
     {
@@ -46,13 +62,13 @@ export function buildChoices(nodes: HubNodeSummary[]): NodeChoice[] {
     },
   ];
   for (const node of nodes) {
-    const online = node.status === 'online';
+    const reason = nodeBlockReason(node);
     choices.push({
       nodeId: node.nodeId,
       label: node.displayName || node.nodeId,
       status: node.status,
-      disabled: !online,
-      ...(online ? {} : { disabledReason: node.status }),
+      disabled: reason !== null,
+      ...(reason ? { disabledReason: reason } : {}),
     });
   }
   return choices;
@@ -77,10 +93,29 @@ export function TerminalNodePicker({
 }: TerminalNodePickerProps): React.ReactElement {
   const [open, setOpen] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(-1);
+  const [menuPos, setMenuPos] = useState<{ top: number; right: number } | null>(
+    null
+  );
   const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
   const optionIdPrefix = useId();
-  useClickOutside(wrapperRef, () => setOpen(false), open);
+
+  // Click-outside: menu is portal-rendered, so we explicitly inspect both
+  // the trigger wrapper and the menu listbox to keep them as a single
+  // logical surface.
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target) return;
+      if (wrapperRef.current?.contains(target)) return;
+      if (listRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    window.addEventListener('mousedown', onPointerDown);
+    return () => window.removeEventListener('mousedown', onPointerDown);
+  }, [open]);
 
   const { data: nodes = [] } = useQuery({
     queryKey: ['hub-nodes'],
@@ -109,10 +144,36 @@ export function TerminalNodePicker({
     });
   }, [open, choices]);
 
+  // Position the portal-rendered menu under the trigger and keep it in sync
+  // with scroll/resize while open. Anchoring via fixed coords avoids the
+  // tab bar's `overflow: hidden` clipping that an in-flow absolute child
+  // would suffer from.
+  useLayoutEffect(() => {
+    if (!open) {
+      setMenuPos(null);
+      return;
+    }
+    const update = () => {
+      const rect = triggerRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      setMenuPos({
+        top: rect.bottom + 2,
+        right: window.innerWidth - rect.right,
+      });
+    };
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
+  }, [open]);
+
   // Focus the listbox container so the keyboard handler receives ArrowUp/Down.
   useEffect(() => {
-    if (open) listRef.current?.focus();
-  }, [open]);
+    if (open && menuPos) listRef.current?.focus();
+  }, [open, menuPos]);
 
   useEffect(() => {
     if (!open) return;
@@ -167,9 +228,66 @@ export function TerminalNodePicker({
     }
   };
 
+  const menu =
+    open && menuPos
+      ? createPortal(
+          <div
+            ref={listRef}
+            role="listbox"
+            tabIndex={-1}
+            className="ws-node-picker__menu"
+            style={{ top: menuPos.top, right: menuPos.right }}
+            {...(focusedIndex >= 0
+              ? { 'aria-activedescendant': optionId(focusedIndex) }
+              : {})}
+            onKeyDown={handleListKeyDown}
+          >
+            <div className="ws-node-picker__hint">new terminal on…</div>
+            {choices.map((choice, i) => {
+              const isFocused = i === focusedIndex;
+              return (
+                <button
+                  key={choice.nodeId}
+                  id={optionId(i)}
+                  type="button"
+                  role="option"
+                  aria-selected={isFocused}
+                  aria-disabled={choice.disabled}
+                  disabled={choice.disabled}
+                  className={`ws-node-picker__item${isFocused ? ' ws-node-picker__item--focused' : ''}`}
+                  onClick={() => handleSelect(choice)}
+                  onMouseEnter={() => {
+                    if (!choice.disabled) setFocusedIndex(i);
+                  }}
+                  tabIndex={-1}
+                  {...(choice.disabledReason
+                    ? {
+                        title: `node ${choice.label} is ${choice.disabledReason}`,
+                      }
+                    : {})}
+                >
+                  <span
+                    className={`ws-node-picker__dot ws-node-picker__dot--${choice.status === 'this host' ? 'local' : choice.status}`}
+                    aria-hidden
+                  />
+                  <span className="ws-node-picker__label">{choice.label}</span>
+                  {choice.status !== 'this host' && (
+                    <span className="ws-node-picker__status">
+                      {choice.status}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>,
+          document.body
+        )
+      : null;
+
   return (
     <div ref={wrapperRef} className="ws-node-picker">
       <button
+        ref={triggerRef}
         type="button"
         className={triggerClassName ?? 'ws-tabs__add'}
         aria-haspopup="listbox"
@@ -179,56 +297,7 @@ export function TerminalNodePicker({
       >
         {triggerLabel}
       </button>
-      {open && (
-        <div
-          ref={listRef}
-          role="listbox"
-          tabIndex={-1}
-          className="ws-node-picker__menu"
-          aria-activedescendant={
-            focusedIndex >= 0 ? optionId(focusedIndex) : undefined
-          }
-          onKeyDown={handleListKeyDown}
-        >
-          <div className="ws-node-picker__hint">new terminal on…</div>
-          {choices.map((choice, i) => {
-            const isFocused = i === focusedIndex;
-            return (
-              <button
-                key={choice.nodeId}
-                id={optionId(i)}
-                type="button"
-                role="option"
-                aria-selected={isFocused}
-                aria-disabled={choice.disabled}
-                disabled={choice.disabled}
-                className={`ws-node-picker__item${isFocused ? ' ws-node-picker__item--focused' : ''}`}
-                onClick={() => handleSelect(choice)}
-                onMouseEnter={() => {
-                  if (!choice.disabled) setFocusedIndex(i);
-                }}
-                tabIndex={-1}
-                {...(choice.disabledReason
-                  ? {
-                      title: `node ${choice.label} is ${choice.disabledReason}`,
-                    }
-                  : {})}
-              >
-                <span
-                  className={`ws-node-picker__dot ws-node-picker__dot--${choice.status === 'this host' ? 'local' : choice.status}`}
-                  aria-hidden
-                />
-                <span className="ws-node-picker__label">{choice.label}</span>
-                {choice.status !== 'this host' && (
-                  <span className="ws-node-picker__status">
-                    {choice.status}
-                  </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
-      )}
+      {menu}
     </div>
   );
 }

--- a/frontend/src/components/TerminalNodePicker.tsx
+++ b/frontend/src/components/TerminalNodePicker.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { fetchHubNodes } from '../lib/api.js';
+import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
+import type { HubNodeSummary } from '../../../shared/relay-node-protocol.js';
+import useClickOutside from '../hooks/useClickOutside.js';
+import './TerminalNodePicker.css';
+
+export interface TerminalNodePickerProps {
+  /**
+   * Invoked with the chosen nodeId. Pass DEFAULT_LOCAL_NODE_ID for "this host".
+   * Empty fires when picker has no remote nodes — the caller may default to
+   * hub-local without prompting.
+   */
+  onSelect: (nodeId: string) => void;
+  /** Label for the trigger button. */
+  triggerLabel?: string;
+  /** Optional ARIA label for the trigger. */
+  triggerAriaLabel?: string;
+  /** Optional className for the trigger. */
+  triggerClassName?: string;
+}
+
+export interface NodeChoice {
+  nodeId: string;
+  label: string;
+  status: 'this host' | HubNodeSummary['status'];
+  disabled: boolean;
+  disabledReason?: string;
+}
+
+export function buildChoices(nodes: HubNodeSummary[]): NodeChoice[] {
+  const choices: NodeChoice[] = [
+    {
+      nodeId: DEFAULT_LOCAL_NODE_ID,
+      label: 'this host',
+      status: 'this host',
+      disabled: false,
+    },
+  ];
+  for (const node of nodes) {
+    const online = node.status === 'online';
+    choices.push({
+      nodeId: node.nodeId,
+      label: node.displayName || node.nodeId,
+      status: node.status,
+      disabled: !online,
+      ...(online ? {} : { disabledReason: node.status }),
+    });
+  }
+  return choices;
+}
+
+export function TerminalNodePicker({
+  onSelect,
+  triggerLabel = '+',
+  triggerAriaLabel = 'add terminal on node',
+  triggerClassName,
+}: TerminalNodePickerProps): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  useClickOutside(wrapperRef, () => setOpen(false), open);
+
+  const { data: nodes = [] } = useQuery({
+    queryKey: ['hub-nodes'],
+    queryFn: fetchHubNodes,
+    enabled: open,
+    refetchOnWindowFocus: false,
+  });
+
+  const choices = useMemo(() => buildChoices(nodes), [nodes]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open]);
+
+  const handleSelect = (choice: NodeChoice) => {
+    if (choice.disabled) return;
+    setOpen(false);
+    onSelect(choice.nodeId);
+  };
+
+  return (
+    <div ref={wrapperRef} className="ws-node-picker">
+      <button
+        type="button"
+        className={triggerClassName ?? 'ws-tabs__add'}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={triggerAriaLabel}
+        onClick={() => setOpen((v) => !v)}
+      >
+        {triggerLabel}
+      </button>
+      {open && (
+        <div role="listbox" className="ws-node-picker__menu">
+          <div className="ws-node-picker__hint">new terminal on…</div>
+          {choices.map((choice) => (
+            <button
+              key={choice.nodeId}
+              type="button"
+              role="option"
+              aria-selected={false}
+              aria-disabled={choice.disabled}
+              disabled={choice.disabled}
+              className="ws-node-picker__item"
+              onClick={() => handleSelect(choice)}
+              title={
+                choice.disabledReason
+                  ? `node ${choice.label} is ${choice.disabledReason}`
+                  : undefined
+              }
+            >
+              <span
+                className={`ws-node-picker__dot ws-node-picker__dot--${choice.status === 'this host' ? 'local' : choice.status}`}
+                aria-hidden
+              />
+              <span className="ws-node-picker__label">{choice.label}</span>
+              {choice.status !== 'this host' && (
+                <span className="ws-node-picker__status">{choice.status}</span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TerminalNodePicker;

--- a/frontend/src/components/WorkspaceArea.tsx
+++ b/frontend/src/components/WorkspaceArea.tsx
@@ -1,5 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
+import { ConflictError, fetchHubNodes } from '../lib/api.js';
+import { createLogger } from '../lib/logger.js';
+import { createAgentSession } from '../lib/session-utils.js';
+import type { SummaryNodeInfo } from '../lib/workspace-summary.js';
 import { fileTabKey, useUiStore } from '../lib/stores/ui.js';
+import { useToastStore } from '../lib/stores/toasts.js';
+import { TerminalNodePicker } from './TerminalNodePicker.js';
 import type { OpenFileTab } from '../lib/stores/ui.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { diffSourceToBase } from '../lib/diff-utils.js';
@@ -21,6 +29,8 @@ import { Terminal } from './Terminal.js';
 import { ChatView } from './chat/ChatView.js';
 import './WorkspaceArea.css';
 
+const workspaceLogger = createLogger('workspace-area');
+
 function uiTabToWorkspaceTab(tab: OpenFileTab): WorkspaceTab {
   return {
     kind: 'file',
@@ -39,6 +49,7 @@ function sessionToWorkspaceTab(session: SessionSummary): WorkspaceTab {
     kind: 'session',
     sessionId: scopedSessionKey(session),
     sessionType: session.type,
+    ...(session.nodeId ? { nodeId: session.nodeId } : {}),
   };
 }
 
@@ -389,6 +400,26 @@ export function WorkspaceArea({
     }
   }, [layout, activePaneId, setUiState, setActiveSessionId]);
 
+  const hubNodesQuery = useQuery({
+    queryKey: ['hub-nodes'],
+    queryFn: fetchHubNodes,
+    refetchInterval: 15_000,
+    refetchOnWindowFocus: false,
+  });
+  const hubNodes = hubNodesQuery.data;
+
+  const nodeIndex = useMemo<Map<string, SummaryNodeInfo>>(() => {
+    const map = new Map<string, SummaryNodeInfo>();
+    if (!hubNodes) return map;
+    for (const node of hubNodes) {
+      map.set(node.nodeId, {
+        label: node.displayName || node.nodeId,
+        status: node.status,
+      });
+    }
+    return map;
+  }, [hubNodes]);
+
   const summaryContext = useMemo<SummaryContext>(() => {
     const changed = new Set(
       openFileTabs.filter((t) => t.isChanged).map((t) => t.filePath)
@@ -397,8 +428,37 @@ export function WorkspaceArea({
     return {
       isFileChanged: (path) => changed.has(path),
       findSession,
+      findNode: (id) => nodeIndex.get(id),
     };
-  }, [openFileTabs, sessions]);
+  }, [openFileTabs, sessions, nodeIndex]);
+
+  const renderAddControl = useCallback(
+    (_paneId: string) => (
+      <TerminalNodePicker
+        onSelect={async (nodeId) => {
+          const { session, error } = await createAgentSession({
+            repoPath: workspacePath,
+            type: 'terminal',
+            ...(nodeId && nodeId !== DEFAULT_LOCAL_NODE_ID ? { nodeId } : {}),
+          });
+          if (error && !(error instanceof ConflictError)) {
+            workspaceLogger.error('failed to create terminal session', error);
+            useToastStore
+              .getState()
+              .showToast(
+                error instanceof Error
+                  ? error.message
+                  : 'failed to create terminal session'
+              );
+          }
+          if (session?.id) {
+            useSessionsStore.getState().setActiveSessionId(session.id);
+          }
+        }}
+      />
+    ),
+    [workspacePath]
+  );
 
   const renderTab = useCallback(
     (tab: WorkspaceTab) => {
@@ -444,7 +504,10 @@ export function WorkspaceArea({
 
   return (
     <div className="ws-area">
-      <WorkspaceLayout summaryContext={summaryContext} />
+      <WorkspaceLayout
+        summaryContext={summaryContext}
+        renderAddControl={renderAddControl}
+      />
       <WorkspaceContentLayer renderTab={renderTab} />
     </div>
   );

--- a/frontend/src/components/WorkspaceArea.tsx
+++ b/frontend/src/components/WorkspaceArea.tsx
@@ -3,7 +3,10 @@ import { useQuery } from '@tanstack/react-query';
 import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
 import { ConflictError, fetchHubNodes } from '../lib/api.js';
 import { createLogger } from '../lib/logger.js';
-import { createAgentSession } from '../lib/session-utils.js';
+import {
+  createAgentSession,
+  getCurrentSessionContext,
+} from '../lib/session-utils.js';
 import type { SummaryNodeInfo } from '../lib/workspace-summary.js';
 import { fileTabKey, useUiStore } from '../lib/stores/ui.js';
 import { useToastStore } from '../lib/stores/toasts.js';
@@ -432,12 +435,30 @@ export function WorkspaceArea({
     };
   }, [openFileTabs, sessions, nodeIndex]);
 
+  const setActivePane = useWorkspaceLayoutStore((s) => s.setActivePane);
   const renderAddControl = useCallback(
-    (_paneId: string) => (
+    (paneId: string) => (
       <TerminalNodePicker
         onSelect={async (nodeId) => {
+          // Resolve repoPath + worktreePath from the live session context.
+          // workspacePath is the active worktree's cwd, which the
+          // `/sessions` route would reject as a repoPath; mirror the same
+          // split that handleQuickTerminal uses.
+          const { currentActiveWorkspace, currentWorktreePath } =
+            getCurrentSessionContext();
+          if (!currentActiveWorkspace) {
+            workspaceLogger.warn(
+              'no active workspace — cannot create terminal'
+            );
+            return;
+          }
+          // The new session lands in whichever pane is active; activate
+          // the pane whose `+` was used before the create call so the
+          // layout reconciler routes the tab to the correct pane.
+          setActivePane(paneId);
           const { session, error } = await createAgentSession({
-            repoPath: workspacePath,
+            repoPath: currentActiveWorkspace.path,
+            worktreePath: currentWorktreePath,
             type: 'terminal',
             ...(nodeId && nodeId !== DEFAULT_LOCAL_NODE_ID && { nodeId }),
           });
@@ -457,7 +478,7 @@ export function WorkspaceArea({
         }}
       />
     ),
-    [workspacePath]
+    [setActivePane]
   );
 
   const renderTab = useCallback(

--- a/frontend/src/components/WorkspaceArea.tsx
+++ b/frontend/src/components/WorkspaceArea.tsx
@@ -439,7 +439,7 @@ export function WorkspaceArea({
           const { session, error } = await createAgentSession({
             repoPath: workspacePath,
             type: 'terminal',
-            ...(nodeId && nodeId !== DEFAULT_LOCAL_NODE_ID ? { nodeId } : {}),
+            ...(nodeId && nodeId !== DEFAULT_LOCAL_NODE_ID && { nodeId }),
           });
           if (error && !(error instanceof ConflictError)) {
             workspaceLogger.error('failed to create terminal session', error);

--- a/frontend/src/components/WorkspaceLayout.tsx
+++ b/frontend/src/components/WorkspaceLayout.tsx
@@ -88,6 +88,7 @@ interface RenderNodeProps {
   summaryContext: SummaryContext;
   splitSizes: Record<string, number[]>;
   onAddTabRequest?: (paneId: string) => void;
+  renderAddControl?: (paneId: string) => React.ReactNode;
   onSplitLayout: (splitId: string, sizes: number[]) => void;
 }
 
@@ -98,6 +99,7 @@ function RenderNode({
   summaryContext,
   splitSizes,
   onAddTabRequest,
+  renderAddControl,
   onSplitLayout,
 }: RenderNodeProps): React.ReactElement {
   if (node.type === 'pane') {
@@ -108,6 +110,7 @@ function RenderNode({
         isDragActive={isDragActive}
         summaryContext={summaryContext}
         {...(onAddTabRequest ? { onAddTabRequest } : {})}
+        {...(renderAddControl ? { renderAddControl } : {})}
       />
     );
   }
@@ -136,6 +139,7 @@ function RenderNode({
                 summaryContext={summaryContext}
                 splitSizes={splitSizes}
                 {...(onAddTabRequest ? { onAddTabRequest } : {})}
+                {...(renderAddControl ? { renderAddControl } : {})}
                 onSplitLayout={onSplitLayout}
               />
             </Panel>
@@ -149,11 +153,13 @@ function RenderNode({
 export interface WorkspaceLayoutProps {
   summaryContext: SummaryContext;
   onAddTabRequest?: (paneId: string) => void;
+  renderAddControl?: (paneId: string) => React.ReactNode;
 }
 
 export function WorkspaceLayout({
   summaryContext,
   onAddTabRequest,
+  renderAddControl,
 }: WorkspaceLayoutProps): React.ReactElement {
   const layout = useWorkspaceLayoutStore((s) => s.layout);
   const activePaneId = useWorkspaceLayoutStore((s) => s.activePaneId);
@@ -249,6 +255,7 @@ export function WorkspaceLayout({
           summaryContext={summaryContext}
           splitSizes={splitSizes}
           {...(onAddTabRequest ? { onAddTabRequest } : {})}
+          {...(renderAddControl ? { renderAddControl } : {})}
           onSplitLayout={onSplitLayout}
         />
       </DndContext>

--- a/frontend/src/components/WorkspacePane.tsx
+++ b/frontend/src/components/WorkspacePane.tsx
@@ -105,6 +105,7 @@ export interface WorkspacePaneProps {
   isDragActive: boolean;
   summaryContext: SummaryContext;
   onAddTabRequest?: (paneId: string) => void;
+  renderAddControl?: (paneId: string) => React.ReactNode;
 }
 
 function WorkspacePaneImpl({
@@ -113,6 +114,7 @@ function WorkspacePaneImpl({
   isDragActive,
   summaryContext,
   onAddTabRequest,
+  renderAddControl,
 }: WorkspacePaneProps) {
   const bodyRef = useRef<HTMLDivElement | null>(null);
   const selectTab = useWorkspaceLayoutStore((s) => s.selectTab);
@@ -161,6 +163,9 @@ function WorkspacePaneImpl({
         onCloseTab={handleClose}
         {...(onAddTabRequest
           ? { onAddTabRequest: () => onAddTabRequest(pane.id) }
+          : {})}
+        {...(renderAddControl
+          ? { renderAddControl: () => renderAddControl(pane.id) }
           : {})}
       />
       {activeTab && activeSummary && (

--- a/frontend/src/components/WorkspaceTabBar.css
+++ b/frontend/src/components/WorkspaceTabBar.css
@@ -133,6 +133,56 @@
   opacity: 0.85;
 }
 
+.ws-tab__node {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  padding: 0 6px;
+  margin-left: 2px;
+  font-size: 0.62rem;
+  color: var(--text-muted, #888);
+  border-left: 1px solid var(--border, #1a1a1a);
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+  max-width: 96px;
+  overflow: hidden;
+}
+
+.ws-tab__node-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 0;
+  flex-shrink: 0;
+}
+
+.ws-tab__node-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.ws-tab__node-dot--online {
+  background: var(--status-success, #34d399);
+}
+.ws-tab__node-dot--stale {
+  background: var(--status-warning, #f59e0b);
+}
+.ws-tab__node-dot--offline,
+.ws-tab__node-dot--revoked {
+  background: var(--status-error, #ef4444);
+}
+.ws-tab__node-dot--unknown {
+  background: var(--text-muted, #555);
+}
+
+@media (max-width: 720px) {
+  .ws-tab__node {
+    display: none;
+  }
+}
+
 .ws-tab__dot {
   width: 6px;
   height: 6px;

--- a/frontend/src/components/WorkspaceTabBar.tsx
+++ b/frontend/src/components/WorkspaceTabBar.tsx
@@ -94,6 +94,18 @@ function WorkspaceTabItem({
       </span>
       <span className="ws-tab__name">{summary.primary}</span>
       {summary.meta && <span className="ws-tab__meta">{summary.meta}</span>}
+      {summary.nodeBadge && (
+        <span
+          className={`ws-tab__node ws-tab__node--${summary.nodeBadge.status}`}
+          title={`node: ${summary.nodeBadge.label} (${summary.nodeBadge.status})`}
+        >
+          <span
+            className={`ws-tab__node-dot ws-tab__node-dot--${summary.nodeBadge.status}`}
+            aria-hidden
+          />
+          <span className="ws-tab__node-label">{summary.nodeBadge.label}</span>
+        </span>
+      )}
       {summary.dot && (
         <span
           className={`ws-tab__dot ws-tab__dot--${summary.dot}`}
@@ -129,6 +141,8 @@ export interface WorkspaceTabBarProps {
   onSelectTab: (tabId: WorkspaceTabId) => void;
   onCloseTab: (tabId: WorkspaceTabId) => void;
   onAddTabRequest?: () => void;
+  /** Optional render-prop for the add-tab control (e.g. a node picker). */
+  renderAddControl?: () => React.ReactNode;
 }
 
 export function WorkspaceTabBar({
@@ -137,6 +151,7 @@ export function WorkspaceTabBar({
   onSelectTab,
   onCloseTab,
   onAddTabRequest,
+  renderAddControl,
 }: WorkspaceTabBarProps) {
   const { setNodeRef, isOver } = useDroppable({
     id: `tabbar:${pane.id}`,
@@ -166,16 +181,18 @@ export function WorkspaceTabBar({
           />
         );
       })}
-      {onAddTabRequest && (
-        <button
-          type="button"
-          className="ws-tabs__add"
-          aria-label="add tab"
-          onClick={onAddTabRequest}
-        >
-          +
-        </button>
-      )}
+      {renderAddControl
+        ? renderAddControl()
+        : onAddTabRequest && (
+            <button
+              type="button"
+              className="ws-tabs__add"
+              aria-label="add tab"
+              onClick={onAddTabRequest}
+            >
+              +
+            </button>
+          )}
       <span className="ws-tabs__spacer" aria-hidden />
     </div>
   );

--- a/frontend/src/lib/workspace-layout.ts
+++ b/frontend/src/lib/workspace-layout.ts
@@ -1,3 +1,4 @@
+import type { NodeId } from '../../../shared/identity.js';
 import { fileTabKey, type FileTabType } from './stores/ui.js';
 
 export type WorkspaceTab =
@@ -5,6 +6,13 @@ export type WorkspaceTab =
       kind: 'session';
       sessionId: string;
       sessionType: 'agent' | 'terminal';
+      /**
+       * Execution node this session is attached to. Omitted for hub-local
+       * sessions. When set, the WS resolver routes via
+       * `/nodes/:nodeId/ws/sessions/:sessionId` and the tab chrome shows the
+       * node label + online indicator.
+       */
+      nodeId?: NodeId;
     }
   | {
       kind: 'file';

--- a/frontend/src/lib/workspace-summary.ts
+++ b/frontend/src/lib/workspace-summary.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
+import type { HubNodeStatus } from '../../../shared/relay-node-protocol.js';
 import type { AgentState, SessionSummary } from './types.js';
 import type { WorkspaceTab } from './workspace-layout.js';
 
@@ -30,12 +32,22 @@ export interface SummaryPill {
   label: string;
 }
 
+export interface NodeBadge {
+  label: string;
+  status: HubNodeStatus | 'unknown';
+}
+
 export interface WorkspaceTabSummary {
   icon: SummaryIcon;
   primary: string;
   meta?: string;
   pills: SummaryPill[];
   dot: SummaryDot;
+  /**
+   * Populated on session tabs that target a non-local execution node.
+   * Drives the cross-node label + heartbeat indicator in the tab chrome.
+   */
+  nodeBadge?: NodeBadge;
   breadcrumb?: {
     segments: string[];
     repoLabel?: string;
@@ -43,10 +55,20 @@ export interface WorkspaceTabSummary {
   };
 }
 
+export interface SummaryNodeInfo {
+  label: string;
+  status: HubNodeStatus;
+}
+
 export interface SummaryContext {
   findSession?: (id: string) => SessionSummary | undefined;
   isFileChanged?: (filePath: string) => boolean;
   fileLineCount?: (filePath: string) => number | undefined;
+  /**
+   * Lookup for cross-node session tabs. Returns the node's display label
+   * and current heartbeat status, or undefined when not yet known.
+   */
+  findNode?: (nodeId: string) => SummaryNodeInfo | undefined;
   repoLabel?: string;
   repoColor?: string;
 }
@@ -89,13 +111,27 @@ function summaryForSessionTab(
     (isTerminal ? 'terminal' : 'session');
   const dot = sessionDot(session?.agentState, session?.idle);
   const meta = sessionMeta(session, isTerminal);
+  const nodeBadge = nodeBadgeFor(tab.nodeId ?? session?.nodeId, ctx);
   return {
     icon,
     primary,
     pills: [],
     dot,
     ...(meta !== undefined ? { meta } : {}),
+    ...(nodeBadge ? { nodeBadge } : {}),
   };
+}
+
+function nodeBadgeFor(
+  nodeId: string | undefined,
+  ctx: SummaryContext
+): NodeBadge | undefined {
+  if (!nodeId || nodeId === DEFAULT_LOCAL_NODE_ID) return undefined;
+  const info = ctx.findNode?.(nodeId);
+  if (!info) {
+    return { label: nodeId, status: 'unknown' };
+  }
+  return { label: info.label, status: info.status };
 }
 
 function sessionIconFor(

--- a/test/components/TerminalNodePicker.test.ts
+++ b/test/components/TerminalNodePicker.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import type { HubNodeSummary } from '../../shared/relay-node-protocol.js';
+import { buildChoices } from '../../frontend/src/components/TerminalNodePicker.js';
+
+function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
+  return {
+    nodeId: 'node-1',
+    displayName: 'dev mac',
+    hostname: 'dev-mac.local',
+    platform: 'darwin',
+    arch: 'arm64',
+    relayVersion: '9.9.9',
+    protocolVersion: '1.0',
+    status: 'online',
+    connection: { route: 'reverse-link', status: 'connected' },
+    trust: { state: 'trusted', level: 'standard', warning: '' },
+    credentialState: 'active',
+    version: {
+      state: 'match',
+      nodeProtocolVersion: '1.0',
+      hubProtocolVersion: '1.0',
+    },
+    capabilities: {
+      totals: { available: 11, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        tmux: 'available',
+        git: 'available',
+        worktrees: 'available',
+        browserAutomation: 'available',
+        clipboardImage: 'available',
+        ssh: 'available',
+        tailscale: 'available',
+      },
+      agents: { claude: 'available' },
+      serviceManager: 'launchd',
+      wsl: false,
+    },
+    createdAt: '2026-01-02T03:00:00.000Z',
+    pairedAt: '2026-01-02T03:00:00.000Z',
+    lastSeenAt: '2026-01-02T03:04:30.000Z',
+    credentialId: 'cred-1',
+    ...overrides,
+  } as HubNodeSummary;
+}
+
+describe('TerminalNodePicker buildChoices', () => {
+  it('always includes a "this host" entry first', () => {
+    const choices = buildChoices([]);
+    expect(choices).toHaveLength(1);
+    expect(choices[0]?.label).toBe('this host');
+    expect(choices[0]?.nodeId).toBe('local');
+    expect(choices[0]?.disabled).toBe(false);
+  });
+
+  it('appends online nodes after the local entry as enabled choices', () => {
+    const choices = buildChoices([
+      node({ nodeId: 'mac', displayName: 'mac', status: 'online' }),
+    ]);
+    expect(choices.map((c) => c.nodeId)).toEqual(['local', 'mac']);
+    expect(choices[1]?.disabled).toBe(false);
+    expect(choices[1]?.status).toBe('online');
+  });
+
+  it('disables non-online nodes and surfaces the status as reason', () => {
+    const choices = buildChoices([
+      node({ nodeId: 'stale', displayName: 'stale', status: 'stale' }),
+      node({ nodeId: 'offline', displayName: 'offline', status: 'offline' }),
+      node({ nodeId: 'revoked', displayName: 'revoked', status: 'revoked' }),
+    ]);
+    expect(choices[1]).toMatchObject({
+      disabled: true,
+      disabledReason: 'stale',
+    });
+    expect(choices[2]).toMatchObject({
+      disabled: true,
+      disabledReason: 'offline',
+    });
+    expect(choices[3]).toMatchObject({
+      disabled: true,
+      disabledReason: 'revoked',
+    });
+  });
+
+  it('falls back to nodeId when displayName is empty', () => {
+    const choices = buildChoices([node({ nodeId: 'm1', displayName: '' })]);
+    expect(choices[1]?.label).toBe('m1');
+  });
+});

--- a/test/components/TerminalNodePicker.test.ts
+++ b/test/components/TerminalNodePicker.test.ts
@@ -16,7 +16,7 @@ function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
     trust: { state: 'trusted', level: 'standard', warning: '' },
     credentialState: 'active',
     version: {
-      state: 'match',
+      state: 'compatible',
       nodeProtocolVersion: '1.0',
       hubProtocolVersion: '1.0',
     },
@@ -85,6 +85,59 @@ describe('TerminalNodePicker buildChoices', () => {
   it('falls back to nodeId when displayName is empty', () => {
     const choices = buildChoices([node({ nodeId: 'm1', displayName: '' })]);
     expect(choices[1]?.label).toBe('m1');
+  });
+
+  it('disables nodes with version skew even when online', () => {
+    const choices = buildChoices([
+      node({
+        nodeId: 'skew',
+        displayName: 'skew',
+        version: {
+          state: 'version-skew',
+          nodeProtocolVersion: '1.1',
+          hubProtocolVersion: '1.0',
+        },
+      }),
+    ]);
+    expect(choices[1]).toMatchObject({
+      disabled: true,
+      disabledReason: 'version skew',
+    });
+  });
+
+  it('disables nodes with incompatible protocol versions', () => {
+    const choices = buildChoices([
+      node({
+        nodeId: 'incompat',
+        displayName: 'incompat',
+        version: {
+          state: 'incompatible',
+          nodeProtocolVersion: '2.0',
+          hubProtocolVersion: '1.0',
+        },
+      }),
+    ]);
+    expect(choices[1]).toMatchObject({
+      disabled: true,
+      disabledReason: 'protocol incompatible',
+    });
+  });
+
+  it('disables nodes without tmux capability even when online', () => {
+    const choices = buildChoices([
+      node({
+        nodeId: 'thin',
+        displayName: 'thin',
+        capabilities: {
+          ...node().capabilities,
+          core: { ...node().capabilities.core, tmux: 'unavailable' },
+        },
+      }),
+    ]);
+    expect(choices[1]).toMatchObject({
+      disabled: true,
+      disabledReason: 'no tmux',
+    });
   });
 });
 

--- a/test/components/TerminalNodePicker.test.ts
+++ b/test/components/TerminalNodePicker.test.ts
@@ -87,3 +87,35 @@ describe('TerminalNodePicker buildChoices', () => {
     expect(choices[1]?.label).toBe('m1');
   });
 });
+
+import { firstEnabledIndex } from '../../frontend/src/components/TerminalNodePicker.js';
+
+describe('TerminalNodePicker firstEnabledIndex', () => {
+  const local = buildChoices([])[0]!;
+  const onlineMac = buildChoices([
+    node({ nodeId: 'mac', displayName: 'mac', status: 'online' }),
+  ])[1]!;
+  const offlineWsl = buildChoices([
+    node({ nodeId: 'wsl', displayName: 'wsl', status: 'offline' }),
+  ])[1]!;
+
+  it('returns the first enabled index when stepping forward', () => {
+    expect(firstEnabledIndex([offlineWsl, local, onlineMac], 0, 1)).toBe(1);
+  });
+
+  it('returns the first enabled index when stepping backward', () => {
+    expect(firstEnabledIndex([offlineWsl, local, onlineMac], 2, -1)).toBe(2);
+    expect(firstEnabledIndex([offlineWsl, local, onlineMac], 1, -1)).toBe(1);
+    expect(firstEnabledIndex([offlineWsl, local], 1, -1)).toBe(1);
+  });
+
+  it('returns -1 when no choice is enabled in the direction', () => {
+    expect(firstEnabledIndex([offlineWsl], 0, 1)).toBe(-1);
+    expect(firstEnabledIndex([offlineWsl, offlineWsl], 0, 1)).toBe(-1);
+  });
+
+  it('handles out-of-range starts', () => {
+    expect(firstEnabledIndex([local, onlineMac], 5, 1)).toBe(-1);
+    expect(firstEnabledIndex([local, onlineMac], -1, 1)).toBe(-1);
+  });
+});

--- a/test/workspace-layout.test.ts
+++ b/test/workspace-layout.test.ts
@@ -26,6 +26,17 @@ const sessionTab = (
   sessionType: type,
 });
 
+const nodeSessionTab = (
+  id: string,
+  nodeId: string,
+  type: 'agent' | 'terminal' = 'terminal'
+): WorkspaceTab => ({
+  kind: 'session',
+  sessionId: id,
+  sessionType: type,
+  nodeId,
+});
+
 const fileTab = (
   path: string,
   type: 'code' | 'diff' | 'html' = 'code'
@@ -53,6 +64,39 @@ describe('workspaceTabId', () => {
 
   it('disambiguates code and diff for same path', () => {
     expect(tid(fileTab('a.ts', 'code'))).not.toBe(tid(fileTab('a.ts', 'diff')));
+  });
+});
+
+describe('session tab nodeId', () => {
+  it('preserves nodeId through addTabToPane', () => {
+    const tab = nodeSessionTab('s1', 'wsl');
+    const layout = createDefaultWorkspaceLayout([]);
+    const next = addTabToPane(layout, layout.id, tab);
+    const panes = listPanes(next);
+    const stored = panes[0]!.tabs.find((t) => tid(t) === tid(tab));
+    expect(stored).toBeDefined();
+    expect(stored && 'nodeId' in stored && stored.nodeId).toBe('wsl');
+  });
+
+  it('shares tabId across panes regardless of nodeId (sessionId is canonical key)', () => {
+    const tab = nodeSessionTab('s1', 'wsl');
+    expect(tid(tab)).toBe('session::s1');
+  });
+
+  it('moveTabToPane carries nodeId with the tab', () => {
+    const tab = nodeSessionTab('s1', 'mac');
+    const a = makePane([tab], { id: 'pa' });
+    const b = makePane([], { id: 'pb' });
+    const split: WorkspaceLayoutNode = {
+      type: 'split',
+      id: 'sp',
+      direction: 'horizontal',
+      children: [a, b],
+    };
+    const moved = moveTabToPane(split, tid(tab), 'pb');
+    const target = listPanes(moved).find((p) => p.id === 'pb')!;
+    const carried = target.tabs[0];
+    expect(carried && 'nodeId' in carried && carried.nodeId).toBe('mac');
   });
 });
 

--- a/test/workspace-summary.test.ts
+++ b/test/workspace-summary.test.ts
@@ -170,3 +170,53 @@ describe('summaryForTab — session kind', () => {
     expect(s.meta).toBeUndefined();
   });
 });
+
+describe('summaryForTab — nodeBadge', () => {
+  const remoteTab = (id: string, nodeId: string): WorkspaceTab => ({
+    kind: 'session',
+    sessionId: id,
+    sessionType: 'terminal',
+    nodeId,
+  });
+
+  it('returns nodeBadge when tab.nodeId is non-local and node is known', () => {
+    const s = summaryForTab(remoteTab('s1', 'wsl-host'), {
+      findNode: () => ({ label: 'WSL', status: 'online' }),
+    });
+    expect(s.nodeBadge).toEqual({ label: 'WSL', status: 'online' });
+  });
+
+  it('falls back to nodeId label when findNode has no entry', () => {
+    const s = summaryForTab(remoteTab('s1', 'wsl-host'), {});
+    expect(s.nodeBadge).toEqual({ label: 'wsl-host', status: 'unknown' });
+  });
+
+  it('omits nodeBadge for hub-local sessions', () => {
+    const s = summaryForTab(remoteTab('s1', 'local'), {
+      findNode: () => ({ label: 'this host', status: 'online' }),
+    });
+    expect(s.nodeBadge).toBeUndefined();
+  });
+
+  it('omits nodeBadge when tab has no nodeId and session has none', () => {
+    const s = summaryForTab(sessionTab('s1'), {
+      findSession: () => session({ id: 's1' }),
+    });
+    expect(s.nodeBadge).toBeUndefined();
+  });
+
+  it('reads nodeId from session when tab.nodeId is unset', () => {
+    const s = summaryForTab(sessionTab('s1', 'terminal'), {
+      findSession: () => session({ id: 's1', type: 'terminal', nodeId: 'mac' }),
+      findNode: () => ({ label: 'macbook', status: 'stale' }),
+    });
+    expect(s.nodeBadge).toEqual({ label: 'macbook', status: 'stale' });
+  });
+
+  it('marks offline nodes in the badge status', () => {
+    const s = summaryForTab(remoteTab('s1', 'wsl-host'), {
+      findNode: () => ({ label: 'WSL', status: 'offline' }),
+    });
+    expect(s.nodeBadge?.status).toBe('offline');
+  });
+});


### PR DESCRIPTION
## Summary

Smallest demo-shaped slice of #443 Lane A: hub UI can spawn terminal tabs on paired relay-nodes from a single browser session. WS routing per node was already in place; this PR ships the tab-state, picker UI, and tab chrome that turns it into a user-visible feature.

- `WorkspaceTab` session variant gains optional `nodeId`. Propagated from `SessionSummary` via `sessionToWorkspaceTab`.
- New `TerminalNodePicker` replaces the `WorkspaceTabBar` `+` button. Lists `this host` plus paired nodes from `fetchHubNodes()`; mirrors the hub-side preconditions (online + version-compatible + tmux capability) — failing preconditions surface as disabled rows with the reason as tooltip. Menu is portal-rendered so it escapes the tab bar's `overflow: hidden`. Full keyboard nav (ArrowUp/Down/Home/End/Enter/Space) + `aria-activedescendant`.
- Selecting a node activates the originating pane, then calls `createAgentSession({ type: 'terminal', repoPath, worktreePath, nodeId })`, which routes through `POST /hub/nodes/{nodeId}/sessions`.
- Tab chrome gains a per-tab node badge (label + heartbeat dot) sourced from a new `SummaryContext.findNode`. `WorkspaceArea` populates it from `useQuery(['hub-nodes'], fetchHubNodes)` on a 15 s refetch interval. CSS hides the badge on narrow viewports.
- No backend changes — `connectPtySocket` already builds `/nodes/:id/ws/sessions/:id` from `session.nodeId` or a parsed global session id.

## Out of scope (#443 sub-issues, follow-ups)

Frontend Lane A only. Backend gaps that surfaced during review:

- Node-side `sessions.create` RPC handler — `/hub/nodes/:id/sessions` forwards `sessions.create` over the reverse link; node currently only implements the `pty.attach` path. End-to-end remote creation needs that handler (or a switch to client-minted session ids + opaque `pty.attach`).
- Node-aware DELETE — closing a routed tab currently calls local `/sessions/:id`, leaving the remote PTY alive.
- Aggregated cross-node session list — `fetchSessions()` reads the local `/sessions` list only; node-scoped sessions returned by `/hub/nodes/:id/sessions` are not currently merged into the store.
- tmux-backed `pty.attach` for reload-resume
- two-node smoke harness in `test/`

## Acceptance criteria mapped to #443

- [x] Workspace state (Zustand) carries `nodeId` per terminal tab.
- [x] Frontend WS resolver picks `/nodes/:nodeId/ws/sessions/:sessionId` when `nodeId` is set (pre-existing in `ws.ts`).
- [x] Tab chrome shows node label + online dot driven by heartbeat status.
- [x] Node picker dropdown lists paired online nodes plus a "this host" entry; non-online + version-skewed + non-tmux nodes are disabled with reason.
- [ ] Browser reload reattaches to the same shell (tmux sub-issue — deferred).
- [ ] Two-node smoke test (deferred).
- [x] `docs/federated-relay.md` + `docs/FRONTEND.md` updated.

## Test plan

- [x] `npm run check` clean (tsc on server + frontend, eslint — 0 errors).
- [x] `npm run build` succeeds.
- [x] New unit tests: `test/workspace-summary.test.ts` (nodeBadge), `test/workspace-layout.test.ts` (nodeId round-trip), `test/components/TerminalNodePicker.test.ts` (buildChoices capability gating + firstEnabledIndex keyboard helper).
- [x] Full `npm test` passes (1 flaky tmux test unrelated; passes on rerun).
- [ ] Manual demo with two paired nodes (macbook + WSL) — blocked on backend `sessions.create` RPC; will follow as a sub-issue.

## Review feedback addressed

Gemini (c1fc786):
- HIGH a11y → fixed in aabefe5 (keyboard nav + aria-activedescendant)
- nodeId spread simplification → fixed in aabefe5
- conditional prop spread / breakpoint var → rejected with rationale (`exactOptionalPropertyTypes: true`; no design tokens)

Copilot (aabefe5):
- Picker capability gating → fixed in a3a1f1c
- Portal-render menu → fixed in a3a1f1c
- paneId routing → fixed in a3a1f1c
- repoPath/worktreePath split → fixed in a3a1f1c
- onSelect JSDoc → fixed in a3a1f1c
- Node-aware close + remote sessions.create → deferred (backend, out of scope for Lane A)

Refs #443