### PR TITLE
test(server): add --bg first-run no-PIN regression test (#151)

### DIFF
--- a/test/server-startup.test.ts
+++ b/test/server-startup.test.ts
@@ -50,9 +50,16 @@ async function killAndWait(child: ChildProcess): Promise<void> {
   child.kill('SIGTERM');
   // Wait for the child to fully exit before cleaning up temp files.
   // Without this, SQLite WAL/SHM files may still be open, causing ENOTEMPTY.
-  await new Promise<void>((resolve) => {
-    child.on('exit', () => resolve());
-    setTimeout(resolve, 3000);
+  // Reject on timeout (not resolve) — a non-exiting server is a real bug and
+  // should fail the test loudly instead of racing with the rmSync in finally.
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Server did not exit within 3s of SIGTERM'));
+    }, 3000);
+    child.on('exit', () => {
+      clearTimeout(timeout);
+      resolve();
+    });
   });
 }
 

--- a/test/server-startup.test.ts
+++ b/test/server-startup.test.ts
@@ -1,8 +1,67 @@
 import { test, expect } from 'vitest';
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+
+const SERVER_SCRIPT = path.resolve(
+  import.meta.dirname,
+  '..',
+  'dist',
+  'server',
+  'index.js'
+);
+
+interface StartServerOpts {
+  env: Record<string, string>;
+}
+
+async function waitForListeningPort(
+  child: ChildProcess,
+  timeoutMs = 10_000
+): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`Server did not start within ${timeoutMs}ms`));
+    }, timeoutMs);
+    let stderr = '';
+
+    child.stdout?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      const match = text.match(/listening on [\w.]+:(\d+)/);
+      if (match) {
+        clearTimeout(timeout);
+        resolve(Number(match[1]));
+      }
+    });
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('exit', (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`Server exited with code ${code}. stderr: ${stderr}`));
+    });
+  });
+}
+
+async function killAndWait(child: ChildProcess): Promise<void> {
+  child.kill('SIGTERM');
+  // Wait for the child to fully exit before cleaning up temp files.
+  // Without this, SQLite WAL/SHM files may still be open, causing ENOTEMPTY.
+  await new Promise<void>((resolve) => {
+    child.on('exit', () => resolve());
+    setTimeout(resolve, 3000);
+  });
+}
+
+function startServer(opts: StartServerOpts): ChildProcess {
+  return spawn(process.execPath, [SERVER_SCRIPT], {
+    env: { ...process.env, ...opts.env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
 
 test('server starts without PIN in non-TTY mode and serves /auth/status', async () => {
   // Create a temporary config with no pinHash
@@ -10,51 +69,16 @@ test('server starts without PIN in non-TTY mode and serves /auth/status', async 
   const configPath = path.join(tmpDir, 'config.json');
   fs.writeFileSync(configPath, JSON.stringify({ port: 0, host: '127.0.0.1' }));
 
-  const serverScript = path.resolve(
-    import.meta.dirname,
-    '..',
-    'dist',
-    'server',
-    'index.js'
-  );
-
-  // Spawn server as a non-TTY child process (pipe = no TTY)
-  const child = spawn(process.execPath, [serverScript], {
+  const child = startServer({
     env: {
-      ...process.env,
       RELAY_IDE_CONFIG: configPath,
       RELAY_IDE_PORT: '0',
       NO_PIN: '1',
     },
-    stdio: ['pipe', 'pipe', 'pipe'],
   });
 
   try {
-    // Wait for the server to print the listening port
-    const port = await new Promise<number>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(new Error('Server did not start within 10s'));
-      }, 10_000);
-      let stderr = '';
-
-      child.stdout.on('data', (chunk: Buffer) => {
-        const text = chunk.toString();
-        const match = text.match(/listening on [\w.]+:(\d+)/);
-        if (match) {
-          clearTimeout(timeout);
-          resolve(Number(match[1]));
-        }
-      });
-
-      child.stderr.on('data', (chunk: Buffer) => {
-        stderr += chunk.toString();
-      });
-
-      child.on('exit', (code) => {
-        clearTimeout(timeout);
-        reject(new Error(`Server exited with code ${code}. stderr: ${stderr}`));
-      });
-    });
+    const port = await waitForListeningPort(child);
 
     // Hit GET /auth/status — should work without auth
     const res = await fetch(`http://127.0.0.1:${port}/auth/status`);
@@ -62,13 +86,46 @@ test('server starts without PIN in non-TTY mode and serves /auth/status', async 
     const body = (await res.json()) as { hasPIN: boolean };
     expect(body.hasPIN).toBe(false);
   } finally {
-    child.kill('SIGTERM');
-    // Wait for the child to fully exit before cleaning up temp files.
-    // Without this, SQLite WAL/SHM files may still be open, causing ENOTEMPTY.
-    await new Promise<void>((resolve) => {
-      child.on('exit', () => resolve());
-      setTimeout(resolve, 3000);
-    });
+    await killAndWait(child);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// Regression: relay-ide --bg first-run crash loop (#151)
+// When launchctl/systemd run the daemon in background mode (RELAY_IDE_BACKGROUND=1)
+// and no PIN is yet configured, the server must stay running and listen on the
+// configured port instead of throwing and exiting — otherwise the service manager
+// respawns it forever in a crash loop.
+test('--bg startup with no PIN configured does not crash-loop (#151)', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-bg-first-run-'));
+  // Intentionally do NOT write a config file — simulate true first-run.
+  const configPath = path.join(tmpDir, 'config.json');
+
+  const child = startServer({
+    env: {
+      RELAY_IDE_CONFIG: configPath,
+      RELAY_IDE_PORT: '0',
+      RELAY_IDE_BACKGROUND: '1',
+      // Force a fresh HOME so initFileLogging / telemetry / push key paths
+      // resolve under tmpDir instead of the developer's real config.
+      HOME: tmpDir,
+    },
+  });
+
+  try {
+    const port = await waitForListeningPort(child);
+
+    // /auth/status must report needs-setup (hasPIN=false), proving the server
+    // came up cleanly without a configured PIN.
+    const res = await fetch(`http://127.0.0.1:${port}/auth/status`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { hasPIN: boolean };
+    expect(body.hasPIN).toBe(false);
+
+    // Server must still be alive — if it had crashed, exitCode would be set.
+    expect(child.exitCode).toBeNull();
+  } finally {
+    await killAndWait(child);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- Add a regression test that spawns the server with \`RELAY_IDE_BACKGROUND=1\` and an empty config dir (no PIN, no config file), asserts that \`/auth/status\` returns \`hasPIN=false\`, and verifies the process is still alive.
- Refactor \`test/server-startup.test.ts\` to share spawn / port-wait / cleanup helpers between the existing NO_PIN test and the new \`--bg\` first-run test.

## Why not a code fix?
The actual hardening for \`relay-ide --bg\` first-run crash loop already landed on \`nightly\` via PR #288 (which superseded #287 and explains why #287 was closed unmerged on 2026-04-24). I reproduced the first-run scenario with an empty \`HOME\` and confirmed the server starts cleanly under \`RELAY_IDE_BACKGROUND=1\`, logs "No PIN configured", and stays listening instead of throwing. The existing test/server-startup.test.ts only covered the foreground \`NO_PIN=1\` path, leaving the exact crash-loop vector (launchctl \`KeepAlive\` + background-mode startup with no config) without a regression guard. This PR closes that gap.

Supersedes #287 (closed unmerged in favor of #288). Closes #151.

## Test plan
- [x] \`npm run build\`
- [x] \`npx vitest run test/server-startup.test.ts\` (both tests pass)
- [x] Manual smoke: \`HOME=\$(mktemp -d) RELAY_IDE_BACKGROUND=1 node dist/server/index.js\` listens cleanly and reports "No PIN configured"
- [x] eslint + prettier clean on the touched file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure for server startup validation
  * Added regression test to prevent background mode crashes during first-run startup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/454)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->