### PR TITLE
chore(hooks): exclude subprocess-heavy test files from pre-push (#451)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -19,13 +19,24 @@ if [ -z "$CHANGED_FILES" ]; then
   exit 0
 fi
 
+# Excluded from pre-push: subprocess-heavy files that race their own
+# `git` / `tmux` child-process timeouts under push-time CPU contention
+# (the push itself is uploading objects while vitest workers spawn).
+# Each of these files passes 1/1 in isolation and in CI's full
+# `npm test` (which uses the within-project parallel pool). Keeping
+# them in CI as the gate; skipping in pre-push avoids false negatives
+# that block clean code.
+PREPUSH_VITEST_EXCLUDES="--exclude test/git-divergence.test.ts --exclude test/git-watcher.test.ts --exclude test/workspace-divergence-api.test.ts"
+
 if [ "$IS_WORKTREE" = "yes" ]; then
   # Worktree: run only changed tests, exclude env-sensitive
   # Single quotes required: prevents ! history expansion + preserves \[ for regex
   echo "relay-ide: worktree detected, running changed tests only"
-  npx vitest run --changed "$CHANGED_BASE" --testNamePattern '^(?!.*\[needs:git-init\])'
+  # shellcheck disable=SC2086 # word splitting intentional for --exclude flags
+  npx vitest run --changed "$CHANGED_BASE" $PREPUSH_VITEST_EXCLUDES --testNamePattern '^(?!.*\[needs:git-init\])'
 else
   # Main tree: run changed tests only
   # Full suite runs in CI (npm test) and locally (npm test)
-  npx vitest run --changed "$CHANGED_BASE"
+  # shellcheck disable=SC2086 # word splitting intentional for --exclude flags
+  npx vitest run --changed "$CHANGED_BASE" $PREPUSH_VITEST_EXCLUDES
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -26,7 +26,20 @@ fi
 # `npm test` (which uses the within-project parallel pool). Keeping
 # them in CI as the gate; skipping in pre-push avoids false negatives
 # that block clean code.
-PREPUSH_VITEST_EXCLUDES="--exclude test/git-divergence.test.ts --exclude test/git-watcher.test.ts --exclude test/workspace-divergence-api.test.ts"
+#
+# Many of these files are also listed in `vitest.config.ts` under
+# `SERIAL_SUBPROCESS_FILES`. Keep the two lists in sync when adding or
+# removing a subprocess-heavy test file.
+PREPUSH_EXCLUDE_FILES="
+test/git-divergence.test.ts
+test/git-watcher.test.ts
+test/workspace-divergence-api.test.ts
+"
+
+PREPUSH_VITEST_EXCLUDES=""
+for file in $PREPUSH_EXCLUDE_FILES; do
+  PREPUSH_VITEST_EXCLUDES="$PREPUSH_VITEST_EXCLUDES --exclude $file"
+done
 
 if [ "$IS_WORKTREE" = "yes" ]; then
   # Worktree: run only changed tests, exclude env-sensitive


### PR DESCRIPTION
## Summary

- Excludes three subprocess-heavy test files from the pre-push hook so it stops false-negative-blocking clean code.
- CI on GitHub still runs them (uses `npm test` with the default within-project pool).

## Why

The pre-push hook runs `vitest run --changed BASE` while `git` is uploading objects to the remote in parallel. Three test files spawn many real `git` / `tmux` subprocesses with tight per-call timeouts and reliably flake under that load:

- `test/git-divergence.test.ts`
- `test/git-watcher.test.ts`
- `test/workspace-divergence-api.test.ts`

Each passes 1/1 in isolation. Full `npm test` reports 1979/1979. The pre-push gate is meant to catch regressions in the diff, not flake on transient host load. PR #450 fixed one related flake in `test/sessions.test.ts` via a deterministic poll; that one is no longer in the flaky set.

## Change

```diff
+ PREPUSH_VITEST_EXCLUDES="--exclude test/git-divergence.test.ts --exclude test/git-watcher.test.ts --exclude test/workspace-divergence-api.test.ts"
  if [ "$IS_WORKTREE" = "yes" ]; then
    echo "relay-ide: worktree detected, running changed tests only"
-   npx vitest run --changed "$CHANGED_BASE" --testNamePattern '^(?!.*\[needs:git-init\])'
+   npx vitest run --changed "$CHANGED_BASE" $PREPUSH_VITEST_EXCLUDES --testNamePattern '^(?!.*\[needs:git-init\])'
  else
-   npx vitest run --changed "$CHANGED_BASE"
+   npx vitest run --changed "$CHANGED_BASE" $PREPUSH_VITEST_EXCLUDES
  fi
```

## Test plan

- [x] Pre-push hook on this branch ran and passed (skipped vitest entirely — no test-related files changed in this diff).
- [x] CI on this PR will run `npm test` (default config, includes the excluded files via the within-project parallel pool). Passing CI = the excluded tests are still healthy.

## Risks

- The excluded files won't catch regressions at pre-push time; CI is the gate. Acceptable because: (a) the hook was already failing on these for reasons unrelated to the diff, (b) GitHub CI is the canonical gate for merge, (c) the local hook's role is to catch fast feedback, not be a second CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
