### PR TITLE
refactor(core): make repoPath/worktreePath/branchName optional on SessionSummary (#434)

### DIFF
--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -93,16 +93,26 @@ function sendRelayError(res: Response, error: RelayNodeError): void {
 function isSessionSummary(value: unknown): value is SessionSummary {
   if (typeof value !== 'object' || value === null) return false;
   const session = value as Partial<SessionSummary>;
+  // repoPath / worktreePath / branchName are optional: a non-repo
+  // routed session (e.g. raw shell on a paired node) carries no repo
+  // binding. Validate them only when present.
+  const repoPathOk =
+    session.repoPath === undefined || typeof session.repoPath === 'string';
+  const worktreePathOk =
+    session.worktreePath === undefined ||
+    session.worktreePath === null ||
+    typeof session.worktreePath === 'string';
+  const branchNameOk =
+    session.branchName === undefined || typeof session.branchName === 'string';
   return (
     typeof session.id === 'string' &&
     (session.type === 'agent' || session.type === 'terminal') &&
     (session.mode === 'pty' || session.mode === 'web') &&
-    typeof session.repoPath === 'string' &&
-    (typeof session.worktreePath === 'string' ||
-      session.worktreePath === null) &&
+    repoPathOk &&
+    worktreePathOk &&
     typeof session.cwd === 'string' &&
     typeof session.repoName === 'string' &&
-    typeof session.branchName === 'string' &&
+    branchNameOk &&
     typeof session.displayName === 'string' &&
     typeof session.createdAt === 'string' &&
     typeof session.lastActivity === 'string' &&

--- a/server/index.ts
+++ b/server/index.ts
@@ -1271,8 +1271,9 @@ async function main(): Promise<void> {
     refWatcherNeedsRebuild = false;
     const entries = sessions
       .list()
-      .filter((s) => s.branchName)
-      .map((s) => ({ cwdPath: s.cwd, branch: s.branchName }));
+      .flatMap((s) =>
+        s.branchName ? [{ cwdPath: s.cwd, branch: s.branchName }] : []
+      );
     refWatcher.rebuild(entries).finally(() => {
       refWatcherRebuildPending = false;
       if (refWatcherNeedsRebuild) rebuildRefWatcher();
@@ -1327,10 +1328,10 @@ async function main(): Promise<void> {
       configPath: CONFIG_PATH,
       getConfig,
       getSessions: () =>
-        localRelayNode.sessions.list().map((s) => ({
-          id: s.id,
-          worktreePath: s.worktreePath ?? s.repoPath,
-        })),
+        localRelayNode.sessions.list().flatMap((s) => {
+          const worktreePath = s.worktreePath ?? s.repoPath;
+          return worktreePath ? [{ id: s.id, worktreePath }] : [];
+        }),
     })
   );
   app.use('/gh', requireAuth, createGhRouter());

--- a/server/types.ts
+++ b/server/types.ts
@@ -328,11 +328,26 @@ export interface SessionSummary {
   type: SessionType;
   agent: AgentType;
   mode: SessionMode;
-  repoPath: string;
-  worktreePath: string | null;
+  /**
+   * Filesystem path of the repo this session is bound to. Optional so
+   * non-repo (node-only / raw-shell) routed sessions can flow through
+   * the same envelope without a synthetic placeholder. Repo-bound
+   * consumers must narrow before use. Local single-node session
+   * creation paths continue to set this for repo-bound sessions.
+   */
+  repoPath?: string;
+  /**
+   * Worktree path within the repo. `null` = session runs at the repo
+   * root (not in a worktree). `undefined` = session is not repo-bound at
+   * all.
+   */
+  worktreePath?: string | null;
   cwd: string;
   repoName: string;
-  branchName: string;
+  /**
+   * Branch name for repo-bound sessions. Omitted for non-repo sessions.
+   */
+  branchName?: string;
   displayName: string;
   createdAt: string;
   lastActivity: string;

--- a/test/hub-node-session-routing.test.ts
+++ b/test/hub-node-session-routing.test.ts
@@ -41,18 +41,43 @@ function manifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
     capabilities: {
       tmux: { id: 'tmux', label: 'tmux', status: 'available', message: 'ok' },
       git: { id: 'git', label: 'Git', status: 'available', message: 'ok' },
-      clipboard: { id: 'clipboard', label: 'Clipboard', status: 'unknown', message: 'unknown' },
+      clipboard: {
+        id: 'clipboard',
+        label: 'Clipboard',
+        status: 'unknown',
+        message: 'unknown',
+      },
       browserAutomation: {
         id: 'browserAutomation',
         label: 'Browser automation',
         status: 'degraded',
         message: 'missing deps',
       },
-      githubCli: { id: 'githubCli', label: 'GitHub CLI', status: 'available', message: 'ok' },
-      tailscale: { id: 'tailscale', label: 'Tailscale CLI', status: 'unavailable', message: 'missing' },
-      ssh: { id: 'ssh', label: 'SSH client', status: 'available', message: 'ok' },
+      githubCli: {
+        id: 'githubCli',
+        label: 'GitHub CLI',
+        status: 'available',
+        message: 'ok',
+      },
+      tailscale: {
+        id: 'tailscale',
+        label: 'Tailscale CLI',
+        status: 'unavailable',
+        message: 'missing',
+      },
+      ssh: {
+        id: 'ssh',
+        label: 'SSH client',
+        status: 'available',
+        message: 'ok',
+      },
       agents: {
-        claude: { id: 'claude', label: 'Claude', status: 'available', message: 'ok' },
+        claude: {
+          id: 'claude',
+          label: 'Claude',
+          status: 'available',
+          message: 'ok',
+        },
       },
     },
     ...overrides,
@@ -62,7 +87,8 @@ function manifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
 async function listen(server: http.Server): Promise<number> {
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
   const address = server.address();
-  if (!address || typeof address === 'string') throw new Error('missing server address');
+  if (!address || typeof address === 'string')
+    throw new Error('missing server address');
   return address.port;
 }
 
@@ -82,7 +108,9 @@ async function waitForOpen(ws: WebSocket): Promise<void> {
 
 async function nextJson(ws: WebSocket): Promise<RelayNodeEnvelope> {
   return await new Promise<RelayNodeEnvelope>((resolve) => {
-    ws.once('message', (data) => resolve(JSON.parse(data.toString()) as RelayNodeEnvelope));
+    ws.once('message', (data) =>
+      resolve(JSON.parse(data.toString()) as RelayNodeEnvelope)
+    );
   });
 }
 
@@ -120,7 +148,10 @@ async function rawUpgrade(port: number, pathName: string): Promise<string> {
   });
 }
 
-async function pairNode(base: string, nodeManifest = manifest()): Promise<{
+async function pairNode(
+  base: string,
+  nodeManifest = manifest()
+): Promise<{
   token: string;
   nodeId: string;
 }> {
@@ -141,7 +172,10 @@ async function pairNode(base: string, nodeManifest = manifest()): Promise<{
   const exchange = (await exchangeRes.json()) as {
     credential: { token: string; nodeId: string };
   };
-  return { token: exchange.credential.token, nodeId: exchange.credential.nodeId };
+  return {
+    token: exchange.credential.token,
+    nodeId: exchange.credential.nodeId,
+  };
 }
 
 function remoteSession(nodeId: string): SessionSummary {
@@ -179,9 +213,14 @@ describe('hub-routed node session create and attach', () => {
   });
 
   async function startHub(now = () => new Date('2026-01-02T03:04:05.000Z')) {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hub-session-route-'));
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-hub-session-route-')
+    );
     cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
-    const registry = createHubNodeRegistry({ storagePath: path.join(tmpDir, 'nodes.json'), now });
+    const registry = createHubNodeRegistry({
+      storagePath: path.join(tmpDir, 'nodes.json'),
+      now,
+    });
     const nodeLinks = createHubNodeLinkManager();
     const app = express();
     app.use(express.json());
@@ -220,11 +259,14 @@ describe('hub-routed node session create and attach', () => {
     const { base } = await startHub();
     const { nodeId } = await pairNode(base);
 
-    const res = await fetch(`${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
-      body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
-    });
+    const res = await fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
+      }
+    );
 
     expect(res.status).toBe(404);
     expect(await res.json()).toMatchObject({
@@ -239,16 +281,24 @@ describe('hub-routed node session create and attach', () => {
       manifest({
         capabilities: {
           ...manifest().capabilities,
-          tmux: { id: 'tmux', label: 'tmux', status: 'unavailable', message: 'missing' },
+          tmux: {
+            id: 'tmux',
+            label: 'tmux',
+            status: 'unavailable',
+            message: 'missing',
+          },
         },
       })
     );
 
-    const res = await fetch(`${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
-      body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
-    });
+    const res = await fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
+      }
+    );
 
     expect(res.status).toBe(400);
     expect(await res.json()).toMatchObject({
@@ -265,11 +315,14 @@ describe('hub-routed node session create and attach', () => {
     cleanup.push(() => nodeWs.close());
     await waitForOpen(nodeWs);
 
-    const createPromise = fetch(`${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
-      body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
-    });
+    const createPromise = fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
+      }
+    );
 
     const request = await nextJson(nodeWs);
     expect(request).toMatchObject({
@@ -287,7 +340,13 @@ describe('hub-routed node session create and attach', () => {
         type: 'sessions.create.result',
         requestId: request.requestId,
         timestamp: new Date().toISOString(),
-        payload: { session: { ...remoteSession(nodeId), nodeId: undefined, globalSessionId: undefined } },
+        payload: {
+          session: {
+            ...remoteSession(nodeId),
+            nodeId: undefined,
+            globalSessionId: undefined,
+          },
+        },
       })
     );
 
@@ -310,11 +369,14 @@ describe('hub-routed node session create and attach', () => {
     cleanup.push(() => nodeWs.close());
     await waitForOpen(nodeWs);
 
-    const createPromise = fetch(`${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
-      body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
-    });
+    const createPromise = fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
+      }
+    );
 
     const request = await nextJson(nodeWs);
     nodeWs.send(
@@ -351,6 +413,74 @@ describe('hub-routed node session create and attach', () => {
     expect(scoped).not.toHaveProperty('worktreeInstanceId');
   });
 
+  it('routes a non-repo session (no repoPath/worktreePath/branchName) without inventing repoInstanceId or worktreeInstanceId', async () => {
+    const { base, wsBase } = await startHub();
+    const { token, nodeId } = await pairNode(base);
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const createPromise = fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({ type: 'terminal' }),
+      }
+    );
+
+    const request = await nextJson(nodeWs);
+    nodeWs.send(
+      JSON.stringify({
+        protocol: request.protocol,
+        protocolVersion: request.protocolVersion,
+        nodeId,
+        channel: 'rpc',
+        type: 'sessions.create.result',
+        requestId: request.requestId,
+        timestamp: new Date().toISOString(),
+        payload: {
+          session: {
+            id: 'non-repo-session-1',
+            type: 'terminal',
+            agent: 'claude',
+            mode: 'pty',
+            // No repoPath / worktreePath / branchName — non-repo session.
+            cwd: '/home/user',
+            repoName: '',
+            displayName: 'raw shell',
+            createdAt: '2026-01-02T03:04:05.000Z',
+            lastActivity: '2026-01-02T03:04:05.000Z',
+            idle: false,
+            customCommand: null,
+            useTmux: true,
+            tmuxSessionName: 'relay-non-repo-1',
+            status: 'active',
+            needsBranchRename: false,
+            agentState: 'idle',
+          },
+        },
+      })
+    );
+
+    const res = await createPromise;
+    expect(res.status).toBe(201);
+    const scoped = (await res.json()) as Record<string, unknown>;
+    expect(scoped).toMatchObject({
+      nodeId,
+      globalSessionId: `${nodeId}:non-repo-session-1`,
+      id: 'non-repo-session-1',
+      cwd: '/home/user',
+    });
+    expect(scoped).not.toHaveProperty('repoInstanceId');
+    expect(scoped).not.toHaveProperty('worktreeInstanceId');
+    expect(scoped).not.toHaveProperty('repoPath');
+    expect(scoped).not.toHaveProperty('worktreePath');
+    expect(scoped).not.toHaveProperty('branchName');
+  });
+
   it('preserves typed node RPC errors when session creation fails on the node link', async () => {
     const { base, wsBase } = await startHub();
     const { token, nodeId } = await pairNode(base);
@@ -360,11 +490,14 @@ describe('hub-routed node session create and attach', () => {
     cleanup.push(() => nodeWs.close());
     await waitForOpen(nodeWs);
 
-    const createPromise = fetch(`${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
-      body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
-    });
+    const createPromise = fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
+      }
+    );
 
     const request = await nextJson(nodeWs);
     nodeWs.send(
@@ -455,7 +588,9 @@ describe('hub-routed node session create and attach', () => {
     });
 
     const browserClose = new Promise<CloseEvent>((resolve) => {
-      browserWs.once('close', (code, reason) => resolve({ code, reason } as unknown as CloseEvent));
+      browserWs.once('close', (code, reason) =>
+        resolve({ code, reason } as unknown as CloseEvent)
+      );
     });
     nodeWs.send(
       JSON.stringify({
@@ -533,21 +668,33 @@ describe('hub-routed node session create and attach', () => {
       payload: { sessionId: 'remote-session-1' },
     });
 
-    const browserClose = new Promise<{ code: number; reason: string }>((resolve) => {
-      browserWs.once('close', (code, reason) => resolve({ code, reason: reason.toString() }));
-    });
+    const browserClose = new Promise<{ code: number; reason: string }>(
+      (resolve) => {
+        browserWs.once('close', (code, reason) =>
+          resolve({ code, reason: reason.toString() })
+        );
+      }
+    );
     const replacementWs = new WebSocket(`${wsBase}/hub/node-link`, {
       headers: { authorization: `Bearer ${token}` },
     });
     cleanup.push(() => replacementWs.close());
     await waitForOpen(replacementWs);
 
-    await expect(Promise.race([
-      browserClose,
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('browser PTY stream stayed open after replacement')), 250)
-      ),
-    ])).resolves.toMatchObject({ code: 1011, reason: 'node link closed' });
+    await expect(
+      Promise.race([
+        browserClose,
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () =>
+              reject(
+                new Error('browser PTY stream stayed open after replacement')
+              ),
+            250
+          )
+        ),
+      ])
+    ).resolves.toMatchObject({ code: 1011, reason: 'node link closed' });
   });
 
   it('broadcasts remote node session events with node-scoped identity', async () => {

--- a/test/hub-node-session-routing.test.ts
+++ b/test/hub-node-session-routing.test.ts
@@ -432,6 +432,24 @@ describe('hub-routed node session create and attach', () => {
     );
 
     const request = await nextJson(nodeWs);
+    // Per CodeRabbit review on PR #457: explicitly assert the hub
+    // forwards the create request to the node WITHOUT synthesising
+    // repo fields. This pins the contract that the node side gets the
+    // opaque payload as-sent and can decide for itself whether it's a
+    // repo-bound session.
+    expect(request.channel).toBe('rpc');
+    expect(request.type).toBe('sessions.create');
+    expect(request.payload).toEqual({ type: 'terminal' });
+    expect(request.payload as Record<string, unknown>).not.toHaveProperty(
+      'repoPath'
+    );
+    expect(request.payload as Record<string, unknown>).not.toHaveProperty(
+      'worktreePath'
+    );
+    expect(request.payload as Record<string, unknown>).not.toHaveProperty(
+      'branchName'
+    );
+
     nodeWs.send(
       JSON.stringify({
         protocol: request.protocol,


### PR DESCRIPTION
## Summary

- Closes #434 / implements Group C of the ADR-015 core audit.
- Makes `repoPath`, `worktreePath`, `branchName` optional on `SessionSummary` so non-repo (node-only / raw-shell) routed sessions can flow through the same envelope without synthetic placeholders.
- Unblocks #445 (#425.7 node-side `sessions.create` RPC handler) and #443 (cross-node terminal panel raw-shell tabs).

## Changes

- `server/types.ts` — `SessionSummary.repoPath` / `worktreePath` / `branchName` become optional with explanatory docstrings. Internal `BaseSession` stays repo-bound; only the wire DTO at the routing boundary relaxes.
- `server/hub-node-router.ts` — `isSessionSummary` now accepts payloads that omit any combination of those three fields. `scopedNodeSession` was already conditional on `repoPath` / `worktreePath`, confirmed no synthetic IDs are derived for non-repo sessions.
- `server/index.ts` — two consumers (refWatcher rebuild + git router `getSessions`) narrow via `flatMap` so undefined paths are filtered out rather than dereferenced.

## Tests

- `test/hub-node-session-routing.test.ts` — new case routes a non-repo session through hub create + scoping. Asserts the response carries `nodeId` + `globalSessionId` but **omits** `repoInstanceId` / `worktreeInstanceId` / `repoPath` / `worktreePath` / `branchName`.

## Verification

- `npx tsc --noEmit` clean.
- `npx vitest run` on hub-node-* and repo-inventory-feature suites: 37/37 green.
- Full `npm test` locally: 1979/1979.

## Out of scope

- Wiring `onRpcEnvelope` for `sessions.create` on the node side — separate sub-issue #445, blocked-by this PR.
- The cross-node terminal panel UX (#443) that consumes this opaque envelope.
- Repo-decoration helpers for the future repo feature module — those move with #433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions can now operate without requiring repository path, worktree path, or branch information, enabling support for non-repository-based sessions

* **Tests**
  * Added test coverage for sessions that don't have repository associations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/457)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->