### PR TITLE
fix(codex): de-advertise web session capability until streaming mapped (#301)

### DIFF
--- a/docs/WEB_CHAT.md
+++ b/docs/WEB_CHAT.md
@@ -179,13 +179,22 @@ All messages are JSON-serialized `ChatEvent` objects. The server sends a snapsho
 
 ## Multi-Agent Integration Matrix
 
-| Agent       | Adapter    | Native Protocol                           | Status         |
-| ----------- | ---------- | ----------------------------------------- | -------------- |
-| Claude Code | `claude`   | `--output-format stream-json` + env hooks | ✅ Implemented |
-| Codex       | `codex`    | Hook file callbacks                       | ✅ Implemented |
-| OpenCode    | `opencode` | Relay plugin events                       | ✅ Implemented |
-| Hermes      | `hermes`   | Attached host gateway + SSE/REST          | ✅ Implemented |
-| Mock        | `mock`     | Programmable scenarios                    | ✅ Implemented |
+| Agent       | Adapter    | Native Protocol                           | Status                                   |
+| ----------- | ---------- | ----------------------------------------- | ---------------------------------------- |
+| Claude Code | `claude`   | `--output-format stream-json` + env hooks | ✅ Implemented                           |
+| Codex       | `codex`    | Hook file callbacks                       | ⚠️ De-advertised — see issue [#301][301] |
+| OpenCode    | `opencode` | Relay plugin events                       | ✅ Implemented                           |
+| Hermes      | `hermes`   | Attached host gateway + SSE/REST          | ✅ Implemented                           |
+| Mock        | `mock`     | Programmable scenarios                    | ✅ Implemented                           |
+
+[301]: https://github.com/donovan-yohan/relay-ide/issues/301
+
+> **Codex web mode status:** the Codex adapter maps lifecycle and tool events
+> but does not yet stream assistant text as `chat:text-delta`, so the browser
+> chat surface produces no visible response. The framework is therefore
+> registered with `supportsWebSessions: false` and the Customize Session
+> dialog only offers `tui` mode for Codex. The adapter and protocol plumbing
+> are retained for the eventual implementation tracked in issue #301.
 
 ## Creating a New Protocol Adapter
 

--- a/server/protocol-adapters/codex-native-adapter.ts
+++ b/server/protocol-adapters/codex-native-adapter.ts
@@ -27,6 +27,29 @@ import { createLogger } from '../logger.js';
 
 const logger = createLogger('codex-native-adapter');
 
+// ── Web-session capability status ──────────────────────────────────────────
+//
+// The Codex framework is currently advertised with `supportsWebSessions: false`
+// in `server/types.ts`. The adapter maps lifecycle events (turn started/ended,
+// tool calls, command execution, file changes) and reasoning deltas, but the
+// browser chat surface never receives assistant text as `chat:text-delta`
+// events, so a user typing a prompt sees no response in web mode.
+//
+// Issue: https://github.com/donovan-yohan/relay-ide/issues/301
+//
+// To re-advertise web sessions, both criteria must be met:
+//   1. Assistant text streaming is mapped end-to-end:
+//      `item/agentMessage/delta` → `chat:text-delta` (with matching
+//      `chat:text-start` / `chat:text-end` lifecycle events) so the UI can
+//      render incremental assistant output the same way it does for Claude.
+//   2. An e2e round-trip test (test/protocol-adapters/codex-*.test.ts or
+//      test/web-session-*.test.ts) asserts: prompt submitted → text-delta
+//      stream observed → completion patch emitted.
+//
+// The adapter is intentionally retained — only the capability advertisement
+// is flipped — so future work can pick up from here instead of re-deriving
+// the JSON-RPC plumbing.
+
 // ── Capability set ─────────────────────────────────────────────────────────
 
 const CODEX_CAPABILITIES: AgentCapabilitySetV2 = {

--- a/server/types.ts
+++ b/server/types.ts
@@ -98,7 +98,13 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: false,
       supportsAttachedRuntime: false,
-      supportsWebSessions: true,
+      // De-advertised pending full web-session implementation. See issue #301:
+      // the Codex protocol adapter maps lifecycle/tool events but does not
+      // stream assistant text deltas as `chat:text-delta`, so the web mode
+      // appeared installed but produced no chat output. Flip back to true
+      // only after (1) assistant text streaming is mapped end-to-end and
+      // (2) an e2e round-trip test covers prompt → text-delta → completion.
+      supportsWebSessions: false,
     },
   },
   opencode: {

--- a/test/customize-session-dialog.test.ts
+++ b/test/customize-session-dialog.test.ts
@@ -22,9 +22,9 @@ function framework(id: string, installed = true): FrameworkInfo {
       supportsYolo: true,
       supportsHooks: true,
       supportsTelemetry: false,
-      supportsWebSessions: ['claude', 'codex', 'opencode', 'hermes'].includes(
-        id
-      ),
+      // Codex is intentionally absent — its web-session capability is
+      // de-advertised pending a full implementation (issue #301).
+      supportsWebSessions: ['claude', 'opencode', 'hermes'].includes(id),
     },
     eventSource: 'hooks',
     availability: installed
@@ -101,7 +101,8 @@ function inventory(): AggregatedRepoInventoryResponse {
             repoIdentityWarnings: [],
             worktrees: [
               {
-                worktreeInstanceId: 'linux:%2Fsrv%2Frelay-ide%2F.worktrees%2Ffeature',
+                worktreeInstanceId:
+                  'linux:%2Fsrv%2Frelay-ide%2F.worktrees%2Ffeature',
                 localPath: '/srv/relay-ide/.worktrees/feature',
                 branchName: 'feature/linux',
                 displayName: 'feature',
@@ -123,7 +124,8 @@ function inventory(): AggregatedRepoInventoryResponse {
             repoIdentityWarnings: [],
             worktrees: [
               {
-                worktreeInstanceId: 'local:%2FUsers%2Fkyle%2Frelay-ide%2F.worktrees%2Ffeature',
+                worktreeInstanceId:
+                  'local:%2FUsers%2Fkyle%2Frelay-ide%2F.worktrees%2Ffeature',
                 localPath: '/Users/kyle/relay-ide/.worktrees/feature',
                 branchName: 'feature/local',
                 displayName: 'feature',
@@ -184,6 +186,14 @@ describe('CustomizeSessionDialog session mode options', () => {
 
   it('shows only tui for agents without web-session adapters', () => {
     expect(getSessionModeOptions([framework('custom')], 'custom')).toEqual([
+      { value: 'pty', label: 'tui' },
+    ]);
+  });
+
+  // Regression guard for issue #301: Codex's web mode is intentionally
+  // de-advertised until assistant text streaming is implemented.
+  it('shows only tui for codex (web mode de-advertised, see #301)', () => {
+    expect(getSessionModeOptions([framework('codex')], 'codex')).toEqual([
       { value: 'pty', label: 'tui' },
     ]);
   });
@@ -299,7 +309,8 @@ describe('CustomizeSessionDialog environment picker model', () => {
       selectedAgent: 'claude',
       selectedGroupId: 'github.com/donovan-yohan/relay-ide',
       selectedNodeId: 'linux',
-      selectedCheckoutId: 'worktree:linux:%2Fsrv%2Frelay-ide%2F.worktrees%2Ffeature',
+      selectedCheckoutId:
+        'worktree:linux:%2Fsrv%2Frelay-ide%2F.worktrees%2Ffeature',
       fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
       fallbackWorktreePath: null,
     });
@@ -339,7 +350,9 @@ describe('CustomizeSessionDialog environment picker model', () => {
       fallbackWorktreePath: null,
     });
 
-    expect(model.nodeChoices.find((choice) => choice.value === 'linux')).toMatchObject({
+    expect(
+      model.nodeChoices.find((choice) => choice.value === 'linux')
+    ).toMatchObject({
       disabled: true,
       reason: 'node is offline',
     });
@@ -368,7 +381,9 @@ describe('CustomizeSessionDialog environment picker model', () => {
       fallbackWorktreePath: null,
     });
 
-    expect(model.nodeChoices.find((choice) => choice.value === 'linux')).toMatchObject({
+    expect(
+      model.nodeChoices.find((choice) => choice.value === 'linux')
+    ).toMatchObject({
       disabled: true,
       reason: 'claude unavailable on linux lab',
     });
@@ -414,7 +429,9 @@ describe('CustomizeSessionDialog environment picker model', () => {
       fallbackWorktreePath: null,
     });
 
-    expect(model.nodeChoices.filter((choice) => choice.value === 'local')).toHaveLength(1);
+    expect(
+      model.nodeChoices.filter((choice) => choice.value === 'local')
+    ).toHaveLength(1);
     expect(model.checkoutChoices.map((choice) => choice.label)).toEqual([
       'default — /Users/kyle/relay-ide',
       'feature/local — /Users/kyle/relay-ide/.worktrees/feature',
@@ -455,7 +472,9 @@ describe('CustomizeSessionDialog environment picker model', () => {
         fallbackWorktreePath: null,
       });
 
-      expect(model.nodeChoices.find((choice) => choice.value === 'linux')).toMatchObject({
+      expect(
+        model.nodeChoices.find((choice) => choice.value === 'linux')
+      ).toMatchObject({
         disabled: true,
         reason: `tmux ${tmuxStatus} on linux lab`,
       });

--- a/test/framework-types.test.ts
+++ b/test/framework-types.test.ts
@@ -50,6 +50,11 @@ test('codex framework has correct values', () => {
   expect(codex.capabilities.supportsContinue).toBe(true);
   expect(codex.capabilities.supportsYolo).toBe(true);
   expect(codex.capabilities.supportsTelemetry).toBe(false);
+  // Regression guard for issue #301: Codex web sessions don't yet stream
+  // assistant text deltas, so the capability is intentionally de-advertised.
+  // Flip back to true only after the streaming gap is closed AND an e2e
+  // round-trip test asserts prompt → chat:text-delta → completion.
+  expect(codex.capabilities.supportsWebSessions).toBe(false);
 });
 
 test('opencode framework has correct values', () => {


### PR DESCRIPTION
## Summary

Per user choice on #301: codex web mode advertised `supportsWebSessions: true` but its protocol adapter never maps assistant text into `chat:text-delta`. Users who picked web mode saw lifecycle/tool events but no chat response. De-advertising rather than implementing now.

## Changes

- `server/types.ts`: flip `BUILTIN_FRAMEWORKS.codex.capabilities.supportsWebSessions` → `false` with a comment listing re-enablement criteria.
- `server/protocol-adapters/codex-native-adapter.ts`: doc block at top explaining the gap, pointing to #301, and listing two re-advertise criteria (text-delta mapping + e2e round-trip test). Adapter retained for future implementation.
- `test/customize-session-dialog.test.ts`: regression guard — codex no longer offered as a web session option.
- `test/framework-types.test.ts`: assert `codex.capabilities.supportsWebSessions === false`.
- `docs/WEB_CHAT.md`: integration matrix marks codex as "de-advertised" with link to #301.

## Test plan

- [x] `npm run build` — green
- [x] `npx vitest run test/customize-session-dialog.test.ts test/framework-types.test.ts` — 37/37 pass
- [ ] CI green

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)