### PR TITLE
fix(claude): de-advertise web session capability pending e2e verification (#300)

### DIFF
--- a/docs/WEB_CHAT.md
+++ b/docs/WEB_CHAT.md
@@ -181,14 +181,25 @@ All messages are JSON-serialized `ChatEvent` objects. The server sends a snapsho
 
 | Agent       | Adapter    | Native Protocol                           | Status                                   |
 | ----------- | ---------- | ----------------------------------------- | ---------------------------------------- |
-| Claude Code | `claude`   | `--output-format stream-json` + env hooks | ✅ Implemented                           |
+| Claude Code | `claude`   | `--output-format stream-json` + env hooks | ⚠️ De-advertised — see issue [#300][300] |
 | Codex       | `codex`    | Hook file callbacks                       | ⚠️ De-advertised — see issue [#301][301] |
 | OpenCode    | `opencode` | Relay plugin events                       | ✅ Implemented                           |
 | Hermes      | `hermes`   | Attached host gateway + SSE/REST          | ✅ Implemented                           |
 | Mock        | `mock`     | Programmable scenarios                    | ✅ Implemented                           |
 
+[300]: https://github.com/donovan-yohan/relay-ide/issues/300
 [301]: https://github.com/donovan-yohan/relay-ide/issues/301
 
+> **Claude web sessions (issue #300):** The `ClaudeProtocolAdapter` exists in
+> `server/protocol-adapters/claude-adapter.ts` but is not advertised as a
+> web-session capability and `POST /sessions` with `agent: 'claude', mode: 'web'`
+> returns a `400 agent_unavailable`. The current implementation is a
+> hook-backed spawned-CLI adapter that has not been verified end-to-end for
+> real assistant text streaming or round-trip behavior. Re-enabling requires
+> (1) real protocol verification with no synthetic event sources,
+> (2) assistant text streaming verified against live Claude output, and
+> (3) an end-to-end round-trip test passing reliably in CI.
+>
 > **Codex web mode status:** the Codex adapter maps lifecycle and tool events
 > but does not yet stream assistant text as `chat:text-delta`, so the browser
 > chat surface produces no visible response. The framework is therefore

--- a/server/frameworks.ts
+++ b/server/frameworks.ts
@@ -132,6 +132,16 @@ export async function getFrameworkClientInfoWithRuntime(
 export async function getFrameworkWebAvailability(
   framework: AgentFramework
 ): Promise<FrameworkWebAvailability> {
+  // Claude web sessions are de-advertised pending end-to-end verification.
+  // See issue #300. The hook-backed spawned-CLI adapter exists but has not
+  // been verified for real assistant text streaming or e2e round-trip.
+  if (framework.id === 'claude') {
+    return {
+      available: false,
+      reason:
+        'Claude web sessions are not yet verified end-to-end (see issue #300). Use the tui (PTY) mode instead.',
+    };
+  }
   if (framework.id !== 'hermes') {
     return { available: true };
   }

--- a/server/frameworks.ts
+++ b/server/frameworks.ts
@@ -129,17 +129,25 @@ export async function getFrameworkClientInfoWithRuntime(
   );
 }
 
+// Reasons surfaced when a framework's `supportsWebSessions` capability is
+// false. Keep entries here keyed by framework id; the fallback below covers
+// any framework that simply doesn't declare web support yet.
+const WEB_DEADVERTISE_REASONS: Record<string, string> = {
+  claude:
+    'Claude web sessions are not yet verified end-to-end (see issue #300). Use the tui (PTY) mode instead.',
+  codex:
+    'Codex web sessions do not yet stream chat responses (see issue #301). Use the tui (PTY) mode instead.',
+};
+
 export async function getFrameworkWebAvailability(
   framework: AgentFramework
 ): Promise<FrameworkWebAvailability> {
-  // Claude web sessions are de-advertised pending end-to-end verification.
-  // See issue #300. The hook-backed spawned-CLI adapter exists but has not
-  // been verified for real assistant text streaming or e2e round-trip.
-  if (framework.id === 'claude') {
+  if (!framework.capabilities.supportsWebSessions) {
     return {
       available: false,
       reason:
-        'Claude web sessions are not yet verified end-to-end (see issue #300). Use the tui (PTY) mode instead.',
+        WEB_DEADVERTISE_REASONS[framework.id] ??
+        `${framework.displayName} web sessions are not currently available.`,
     };
   }
   if (framework.id !== 'hermes') {

--- a/server/protocol-adapters/claude-adapter.ts
+++ b/server/protocol-adapters/claude-adapter.ts
@@ -459,6 +459,27 @@ class StreamInputController {
   }
 }
 
+/**
+ * ClaudeProtocolAdapter — hook-backed spawned-CLI adapter for Claude Code.
+ *
+ * STATUS: De-advertised (issue #300).
+ *
+ * This adapter is currently NOT advertised as a web-session capability
+ * (see BUILTIN_FRAMEWORKS.claude.capabilities.supportsWebSessions=false in
+ * server/types.ts and the explicit availability gate in
+ * server/frameworks.ts#getFrameworkWebAvailability). The implementation
+ * spawns `claude` via the Anthropic Agent SDK and maps SDK events to v2
+ * ChatEvents, but it has NOT been verified end-to-end for production use.
+ *
+ * Re-enabling criteria (per issue #300):
+ *   1. Real protocol verification — no synthetic/forged event sources.
+ *   2. Assistant text streaming verified against live Claude output.
+ *   3. End-to-end round-trip test (prompt -> assistant text -> completion)
+ *      passing reliably in CI.
+ *
+ * The adapter code is intentionally retained so future implementation
+ * work has a starting point. Do not delete without coordination on #300.
+ */
 export class ClaudeProtocolAdapter extends BaseProtocolAdapterV2 {
   readonly agentType = 'claude';
   readonly runtimeOwnership = 'spawned' as const;

--- a/server/types.ts
+++ b/server/types.ts
@@ -81,7 +81,14 @@ export const BUILTIN_FRAMEWORKS: Record<BuiltinFrameworkId, AgentFramework> = {
       supportsYolo: true,
       supportsTelemetry: true,
       supportsAttachedRuntime: true,
-      supportsWebSessions: true,
+      // De-advertised pending end-to-end verification of the Claude web
+      // session protocol. See issue #300. The ClaudeProtocolAdapter exists
+      // in server/protocol-adapters/claude-adapter.ts but has not been
+      // verified for real assistant text streaming and round-trip behavior.
+      // Re-enable only after: real protocol verification (no synthetic
+      // event sources), assistant text streaming, and an end-to-end
+      // round-trip test all pass.
+      supportsWebSessions: false,
     },
   },
   codex: {

--- a/test/customize-session-dialog.test.ts
+++ b/test/customize-session-dialog.test.ts
@@ -13,6 +13,8 @@ import type { AggregatedRepoInventoryResponse } from '../shared/repo-inventory.j
 import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
 
 function framework(id: string, installed = true): FrameworkInfo {
+  // Mirrors BUILTIN_FRAMEWORKS in server/types.ts. Claude web sessions are
+  // de-advertised pending end-to-end verification (issue #300).
   return {
     id,
     displayName: id,
@@ -22,9 +24,10 @@ function framework(id: string, installed = true): FrameworkInfo {
       supportsYolo: true,
       supportsHooks: true,
       supportsTelemetry: false,
-      // Codex is intentionally absent — its web-session capability is
-      // de-advertised pending a full implementation (issue #301).
-      supportsWebSessions: ['claude', 'opencode', 'hermes'].includes(id),
+      // Claude + Codex are both intentionally absent — their web-session
+      // capabilities are de-advertised pending full implementations
+      // (issues #300 and #301).
+      supportsWebSessions: ['opencode', 'hermes'].includes(id),
     },
     eventSource: 'hooks',
     availability: installed
@@ -171,13 +174,9 @@ function inventory(): AggregatedRepoInventoryResponse {
 
 describe('CustomizeSessionDialog session mode options', () => {
   it('shows tui and web for agents with web-session adapters', () => {
-    const frameworks = [
-      framework('claude'),
-      framework('codex'),
-      framework('opencode'),
-    ];
+    const frameworks = [framework('opencode'), framework('hermes')];
 
-    expect(getSessionModeOptions(frameworks, 'claude')).toEqual([
+    expect(getSessionModeOptions(frameworks, 'opencode')).toEqual([
       { value: 'pty', label: 'tui' },
       { value: 'web', label: 'web' },
     ]);
@@ -193,6 +192,15 @@ describe('CustomizeSessionDialog session mode options', () => {
   // de-advertised until assistant text streaming is implemented.
   it('shows only tui for codex (web mode de-advertised, see #301)', () => {
     expect(getSessionModeOptions([framework('codex')], 'codex')).toEqual([
+      { value: 'pty', label: 'tui' },
+    ]);
+  });
+
+  // Regression guard for issue #300: Claude web sessions are de-advertised
+  // pending end-to-end verification. The session-mode dropdown must NOT
+  // surface a "web" option when Claude is selected.
+  it('shows only tui for claude (web de-advertised pending issue #300)', () => {
+    expect(getSessionModeOptions([framework('claude')], 'claude')).toEqual([
       { value: 'pty', label: 'tui' },
     ]);
   });

--- a/test/framework-types.test.ts
+++ b/test/framework-types.test.ts
@@ -32,6 +32,15 @@ test('claude framework has correct values', () => {
   expect(claude.capabilities.supportsTelemetry).toBe(true);
 });
 
+// Regression guard: see issue #300. Claude web sessions are de-advertised
+// pending end-to-end verification of the protocol adapter. Do not flip this
+// to `true` without satisfying the criteria documented in
+// server/protocol-adapters/claude-adapter.ts.
+test('claude does NOT advertise web-session capability (issue #300)', () => {
+  const claude = BUILTIN_FRAMEWORKS['claude'];
+  expect(claude.capabilities.supportsWebSessions).toBe(false);
+});
+
 test('codex framework has correct values', () => {
   const codex = BUILTIN_FRAMEWORKS['codex'];
   expect(codex.id).toBe('codex');

--- a/test/hermes-session-api.e2e.test.ts
+++ b/test/hermes-session-api.e2e.test.ts
@@ -225,7 +225,11 @@ process.exit(0);
   }
 }, 20_000);
 
-test('POST /sessions honors web mode for claude protocol adapter sessions', async () => {
+// Regression guard for issue #300: Claude web sessions are de-advertised
+// pending end-to-end verification of the protocol adapter. A POST /sessions
+// request for `claude` in `mode: 'web'` must be rejected with a structured
+// `agent_unavailable` error and a message that references the gap.
+test('POST /sessions rejects claude web mode (de-advertised, issue #300)', async () => {
   const tmpDir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'relay-claude-api-e2e-')
   );
@@ -251,15 +255,16 @@ setInterval(() => {}, 1000);
       }),
     });
 
-    expect(createRes.status).toBe(201);
-    const session = (await createRes.json()) as {
-      agent: string;
-      mode: string;
-      adapterType?: string;
+    expect(createRes.status).toBe(400);
+    expect(createRes.headers.get('content-type')).toContain('application/json');
+    const body = (await createRes.json()) as {
+      error?: string;
+      message?: string;
+      agent?: string;
     };
-    expect(session.agent).toBe('claude');
-    expect(session.mode).toBe('web');
-    expect(session.adapterType).toBe('claude');
+    expect(body.error).toBe('agent_unavailable');
+    expect(body.agent).toBe('claude');
+    expect(body.message ?? '').toMatch(/300|not yet verified|end-to-end/i);
   } finally {
     await stopRelayServer(server);
   }

--- a/test/pty-handler-multi-agent.test.ts
+++ b/test/pty-handler-multi-agent.test.ts
@@ -267,7 +267,10 @@ sleep 10
             supportsYolo: true,
             supportsTelemetry: true,
             supportsAttachedRuntime: true,
-            supportsWebSessions: true,
+            // Claude web sessions are de-advertised pending end-to-end
+            // verification (issue #300). This PTY test does not exercise
+            // web mode but mirrors BUILTIN_FRAMEWORKS for consistency.
+            supportsWebSessions: false,
           },
         },
       },
@@ -301,7 +304,7 @@ sleep 10
           "const fs=require('node:fs');",
           `const probePath=${JSON.stringify(probePath)};`,
           "const cfg=process.env.OPENCODE_CONFIG_CONTENT||'';",
-          "fs.writeFileSync(probePath,cfg);",
+          'fs.writeFileSync(probePath,cfg);',
           "console.log('OPENCODE_CONFIG_CONTENT='+cfg);",
           'setTimeout(()=>{},10000);',
         ].join(' '),


### PR DESCRIPTION
## Summary

Per user choice on #300: Claude web mode is advertised as capable, but the implementation is only a hook-backed spawned CLI adapter — not verified end-to-end against real Claude web chat behavior. De-advertising rather than implementing now.

## Changes

- `server/types.ts`: drop Claude from web-session-capable advertisement.
- `server/frameworks.ts`: capability registration reflects the change.
- `server/protocol-adapters/claude-adapter.ts`: doc block explaining the gap, pointing to #300, listing re-advertise criteria (protocol verification + assistant text streaming + e2e round-trip test). Adapter retained.
- Tests: regression-guard assertions in `customize-session-dialog.test.ts`, `framework-types.test.ts`, `pty-handler-multi-agent.test.ts`, `hermes-session-api.e2e.test.ts` — Claude no longer offered as web session option.
- `docs/WEB_CHAT.md`: integration matrix marks Claude as "de-advertised" with link to #300.

## Test plan

- [x] `npm run build` — green
- [x] `npx vitest run` on touched test files — 43/43 pass
- [ ] CI green

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Claude web sessions are temporarily unavailable pending verification and end-to-end protocol testing.
  * Enhanced error responses when frameworks don't support web session capabilities.

* **Documentation**
  * Updated integration matrix reflecting Claude web session de-advertisement status.
  * Added verification requirements and testing procedures for web session protocols.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/459)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->