### PR TITLE
refactor(core): move framework probing into feature module (#436)

### DIFF
--- a/server/features/frameworks.ts
+++ b/server/features/frameworks.ts
@@ -1,0 +1,106 @@
+import type { Config } from '../types.js';
+import {
+  getFrameworkClientInfoWithRuntime,
+  type FrameworkClientInfo,
+} from '../frameworks.js';
+import type {
+  NodeCapabilityProbe,
+  NodeManifest,
+} from '../../shared/node-manifest.js';
+
+// Framework / agent capability probing. Lives outside core because
+// "what counts as an agent framework" is feature-layer policy (Claude /
+// Codex / OpenCode / Hermes today; arbitrary IDs once #437 lands).
+//
+// Core builds a manifest with `agents: {}`. This feature decorates the
+// manifest by populating the `agents` map after probing the configured
+// framework registry. Callers wire it in via the composition root or
+// via the back-compat helper `getNodeManifestWithFrameworks` below.
+
+function frameworkProbeFromClientInfo(
+  framework: FrameworkClientInfo
+): NodeCapabilityProbe {
+  const availability = framework.availability;
+  if (!availability?.installed) {
+    return {
+      id: framework.id,
+      label: framework.displayName,
+      status: 'unavailable',
+      message:
+        availability?.reason ?? `${framework.displayName} is not installed.`,
+    };
+  }
+  if (framework.webAvailability && !framework.webAvailability.available) {
+    return {
+      id: framework.id,
+      label: framework.displayName,
+      status: 'degraded',
+      message:
+        framework.webAvailability.reason ??
+        'CLI is installed but web runtime probe failed.',
+      ...(availability.path ? { path: availability.path } : {}),
+    };
+  }
+  return {
+    id: framework.id,
+    label: framework.displayName,
+    status: 'available',
+    message: `${framework.displayName} CLI is available.`,
+    ...(availability.path ? { path: availability.path } : {}),
+  };
+}
+
+export async function probeFrameworks(
+  config: Pick<Config, 'frameworks'> | undefined,
+  env: NodeJS.ProcessEnv
+): Promise<Record<string, NodeCapabilityProbe>> {
+  try {
+    const frameworks = await getFrameworkClientInfoWithRuntime(
+      config?.frameworks,
+      env
+    );
+    return Object.fromEntries(
+      frameworks.map((framework) => [
+        framework.id,
+        frameworkProbeFromClientInfo(framework),
+      ])
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      frameworks: {
+        id: 'frameworks',
+        label: 'Agent framework registry',
+        status: 'degraded',
+        message: `Agent framework probes failed non-fatally: ${message}`,
+      },
+    };
+  }
+}
+
+export interface FrameworkDecorationOptions {
+  config?: Pick<Config, 'frameworks'> | undefined;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Decorate a core manifest (one whose `capabilities.agents` is empty)
+ * with the probed framework registry. Returns a new manifest object;
+ * input is not mutated.
+ */
+export async function decorateManifestWithFrameworks(
+  manifest: NodeManifest,
+  options: FrameworkDecorationOptions = {}
+): Promise<NodeManifest> {
+  const env = options.env ?? process.env;
+  const agents = await probeFrameworks(options.config, env);
+  return {
+    ...manifest,
+    capabilities: {
+      ...manifest.capabilities,
+      agents,
+    },
+  };
+}
+
+export { frameworkProbeFromClientInfo };

--- a/server/features/frameworks.ts
+++ b/server/features/frameworks.ts
@@ -9,13 +9,16 @@ import type {
 } from '../../shared/node-manifest.js';
 
 // Framework / agent capability probing. Lives outside core because
-// "what counts as an agent framework" is feature-layer policy (Claude /
-// Codex / OpenCode / Hermes today; arbitrary IDs once #437 lands).
+// "what counts as an agent framework" is feature-layer policy
+// (arbitrary IDs once #437 lands; today the registry ships with a
+// default set).
 //
 // Core builds a manifest with `agents: {}`. This feature decorates the
 // manifest by populating the `agents` map after probing the configured
-// framework registry. Callers wire it in via the composition root or
-// via the back-compat helper `getNodeManifestWithFrameworks` below.
+// framework registry. Callers wire the decorator in via the
+// composition root, or use the back-compat helper `getNodeManifest`
+// exported from `server/node-manifest.ts` which calls
+// `decorateManifestWithFrameworks` below.
 
 function frameworkProbeFromClientInfo(
   framework: FrameworkClientInfo

--- a/server/node-manifest.ts
+++ b/server/node-manifest.ts
@@ -145,8 +145,8 @@ function getNodeCapabilities(
 ): NodeCapabilities {
   // Core probes only host-tool availability. Agent / framework probes
   // live in `server/features/frameworks.ts` and are layered on top via
-  // `decorateManifestWithFrameworks`. Core never names Claude, Codex,
-  // OpenCode, Hermes, or any other framework id.
+  // `decorateManifestWithFrameworks`. Core never references framework
+  // ids directly — neither in code nor in this comment.
   return {
     tmux: probeCommand('tmux', 'tmux', 'tmux', env),
     git: probeCommand('git', 'Git', 'git', env),

--- a/server/node-manifest.ts
+++ b/server/node-manifest.ts
@@ -5,11 +5,9 @@ import { spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import type { Config } from './types.js';
-import {
-  getFrameworkClientInfoWithRuntime,
-  resolveExecutablePath,
-} from './frameworks.js';
+import { resolveExecutablePath } from './frameworks.js';
 import { detectServiceManager, detectWslInfo } from './service.js';
+import { decorateManifestWithFrameworks } from './features/frameworks.js';
 import type {
   NodeCapabilities,
   NodeCapabilityProbe,
@@ -141,75 +139,14 @@ function probeBrowserAutomation(): NodeCapabilityProbe {
   }
 }
 
-function frameworkProbeFromClientInfo(framework: {
-  id: string;
-  displayName: string;
-  availability?: { installed: boolean; path?: string; reason?: string };
-  webAvailability?: { available: boolean; reason?: string };
-}): NodeCapabilityProbe {
-  const availability = framework.availability;
-  if (!availability?.installed) {
-    return {
-      id: framework.id,
-      label: framework.displayName,
-      status: 'unavailable',
-      message:
-        availability?.reason ?? `${framework.displayName} is not installed.`,
-    };
-  }
-  if (framework.webAvailability && !framework.webAvailability.available) {
-    return {
-      id: framework.id,
-      label: framework.displayName,
-      status: 'degraded',
-      message:
-        framework.webAvailability.reason ??
-        'CLI is installed but web runtime probe failed.',
-      ...(availability.path ? { path: availability.path } : {}),
-    };
-  }
-  return {
-    id: framework.id,
-    label: framework.displayName,
-    status: 'available',
-    message: `${framework.displayName} CLI is available.`,
-    ...(availability.path ? { path: availability.path } : {}),
-  };
-}
-
-async function probeAgents(
-  config: Pick<Config, 'frameworks'> | undefined,
-  env: NodeJS.ProcessEnv
-): Promise<Record<string, NodeCapabilityProbe>> {
-  try {
-    const frameworks = await getFrameworkClientInfoWithRuntime(
-      config?.frameworks,
-      env
-    );
-    return Object.fromEntries(
-      frameworks.map((framework) => [
-        framework.id,
-        frameworkProbeFromClientInfo(framework),
-      ])
-    );
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return {
-      frameworks: {
-        id: 'frameworks',
-        label: 'Agent framework registry',
-        status: 'degraded',
-        message: `Agent framework probes failed non-fatally: ${message}`,
-      },
-    };
-  }
-}
-
-async function getNodeCapabilities(
-  config: Pick<Config, 'frameworks'> | undefined,
+function getNodeCapabilities(
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform = process.platform
-): Promise<NodeCapabilities> {
+): NodeCapabilities {
+  // Core probes only host-tool availability. Agent / framework probes
+  // live in `server/features/frameworks.ts` and are layered on top via
+  // `decorateManifestWithFrameworks`. Core never names Claude, Codex,
+  // OpenCode, Hermes, or any other framework id.
   return {
     tmux: probeCommand('tmux', 'tmux', 'tmux', env),
     git: probeCommand('git', 'Git', 'git', env),
@@ -218,11 +155,11 @@ async function getNodeCapabilities(
     githubCli: probeCommand('githubCli', 'GitHub CLI', 'gh', env),
     tailscale: probeCommand('tailscale', 'Tailscale CLI', 'tailscale', env),
     ssh: probeCommand('ssh', 'SSH client', 'ssh', env, { versionArgs: ['-V'] }),
-    agents: await probeAgents(config, env),
+    agents: {},
   };
 }
 
-async function getNodeManifest(
+async function getCoreNodeManifest(
   options: NodeManifestOptions = {}
 ): Promise<NodeManifest> {
   const env = options.env ?? process.env;
@@ -242,15 +179,34 @@ async function getNodeManifest(
     generatedAt: (options.now ?? new Date()).toISOString(),
     wsl,
     serviceManager,
-    capabilities: await getNodeCapabilities(options.config, env, platform),
+    capabilities: getNodeCapabilities(env, platform),
   };
 }
 
+/**
+ * Build a manifest with framework / agent probes applied. This is the
+ * back-compat entry point that pre-#436 callers used. Internally it
+ * builds a core manifest then layers the frameworks feature on top, so
+ * callers that don't need agent probing (or want to inject their own
+ * decoration order) can call `getCoreNodeManifest` + decorate
+ * themselves.
+ */
+async function getNodeManifest(
+  options: NodeManifestOptions = {}
+): Promise<NodeManifest> {
+  const env = options.env ?? process.env;
+  const manifest = await getCoreNodeManifest(options);
+  return decorateManifestWithFrameworks(manifest, {
+    config: options.config,
+    env,
+  });
+}
+
 export {
+  getCoreNodeManifest,
   getNodeManifest,
   getNodeCapabilities,
   probeCommand,
   probeClipboard,
   probeBrowserAutomation,
-  probeAgents,
 };

--- a/test/features-frameworks.test.ts
+++ b/test/features-frameworks.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decorateManifestWithFrameworks,
+  probeFrameworks,
+} from '../server/features/frameworks.js';
+import {
+  getCoreNodeManifest,
+  getNodeManifest,
+} from '../server/node-manifest.js';
+
+describe('frameworks feature', () => {
+  it('core manifest has an empty agents map (no framework knowledge)', async () => {
+    const manifest = await getCoreNodeManifest({
+      env: process.env,
+      hostname: 'core-host',
+      relayVersion: '0.1.0-test',
+    });
+    expect(manifest.capabilities.agents).toEqual({});
+  });
+
+  it('decorateManifestWithFrameworks layers an agents map onto a core manifest', async () => {
+    const core = await getCoreNodeManifest({
+      env: process.env,
+      hostname: 'core-host',
+      relayVersion: '0.1.0-test',
+    });
+    expect(core.capabilities.agents).toEqual({});
+
+    const decorated = await decorateManifestWithFrameworks(core, {
+      env: process.env,
+    });
+    // The default framework registry always reports at least one
+    // entry (claude / codex / opencode / hermes by default; even
+    // unavailable ones surface as 'unavailable' probes). Don't assert
+    // specific ids here — that's #437's job.
+    expect(Object.keys(decorated.capabilities.agents).length).toBeGreaterThan(
+      0
+    );
+    // Input not mutated.
+    expect(core.capabilities.agents).toEqual({});
+  });
+
+  it('getNodeManifest (back-compat entry) returns a decorated manifest matching the old shape', async () => {
+    const manifest = await getNodeManifest({
+      env: process.env,
+      hostname: 'compat-host',
+      relayVersion: '0.1.0-test',
+    });
+    expect(Object.keys(manifest.capabilities.agents).length).toBeGreaterThan(0);
+    // Other capability fields still present.
+    expect(manifest.capabilities.tmux).toBeDefined();
+    expect(manifest.capabilities.git).toBeDefined();
+  });
+
+  it('probeFrameworks returns a probe map keyed by framework id', async () => {
+    const probes = await probeFrameworks(undefined, process.env);
+    for (const [id, probe] of Object.entries(probes)) {
+      expect(probe.id).toBe(id);
+      expect(probe.status).toMatch(/available|degraded|unavailable|unknown/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #436 / implements Group E of the ADR-015 core audit.
- Moves framework / agent probing out of `server/node-manifest.ts` into a new `server/features/frameworks.ts` decorator. Core never names Claude / Codex / OpenCode / Hermes (or any other framework id) again.

## Why

Audit Group E: core manifest knew about the framework registry by import. `getNodeCapabilities` returned `agents: <probe map>` keyed by framework id, which is feature-layer policy. Once #437 parameterizes test fixtures and the CLI gateway / agent-adapters work pulls forward, the framework set becomes operator-configurable; core shouldn't pre-bake it.

## Change shape

```
server/features/frameworks.ts (new)
├─ probeFrameworks(config, env) → Record<id, NodeCapabilityProbe>
├─ frameworkProbeFromClientInfo(framework) → NodeCapabilityProbe
└─ decorateManifestWithFrameworks(manifest, options) → NodeManifest

server/node-manifest.ts (refactor)
├─ getNodeCapabilities(env, platform): NodeCapabilities  // agents: {}
├─ getCoreNodeManifest(options): NodeManifest             // no framework knowledge
└─ getNodeManifest(options): NodeManifest                 // back-compat: core + decorator
```

`getNodeManifest` continues to return the same shape pre-#436 callers expect, so `bin/relay-ide.ts` and consumers don't migrate yet. Callers that want a strictly core (non-decorated) manifest can switch to `getCoreNodeManifest`.

## Tests

- New `test/features-frameworks.test.ts` (4 tests): core has empty agents, decorator layers correctly without mutating input, back-compat shape matches, probe map keys match their entry ids.
- Existing `test/node-manifest.test.ts`, `test/hub-node-registry.test.ts`, `test/multi-node-smoke.test.ts`, `test/hub-node-production-wiring.test.ts` all green.

Verification: 21/21 targeted tests pass. `npx tsc --noEmit` clean.

## Out of scope

- #437 (parameterize hardcoded agent IDs in test fixtures) — separate PR, builds on this.
- Composition-root wiring for feature injection — current callers use the back-compat `getNodeManifest`. Composition wiring lands when a caller needs to choose a non-default decorator order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
