### PR TITLE
test(core): parameterize agent IDs in manifest fixtures (#437)

### DIFF
--- a/test/helpers/manifest-fixtures.ts
+++ b/test/helpers/manifest-fixtures.ts
@@ -75,7 +75,9 @@ function defaultCapabilities(
 /**
  * Build a NodeManifest fixture with the supplied agent list (defaults
  * to an empty list — explicit ids are the point of #437). `overrides`
- * shallow-merges over the produced manifest.
+ * shallow-merges at the manifest top level, with a one-level-deep
+ * merge for `capabilities` so a partial override (e.g. just `clipboard`)
+ * doesn't wipe the agents map or the other default probes.
  */
 export function buildManifestWithAgents(
   options: ManifestFixtureOptions = {}
@@ -101,5 +103,13 @@ export function buildManifestWithAgents(
     },
     capabilities: defaultCapabilities(agents),
   };
-  return { ...base, ...options.overrides };
+  const overrides = options.overrides ?? {};
+  return {
+    ...base,
+    ...overrides,
+    capabilities: {
+      ...base.capabilities,
+      ...(overrides.capabilities ?? {}),
+    },
+  };
 }

--- a/test/helpers/manifest-fixtures.ts
+++ b/test/helpers/manifest-fixtures.ts
@@ -1,0 +1,105 @@
+import type {
+  NodeCapabilityProbe,
+  NodeCapabilityStatus,
+  NodeManifest,
+} from '../../shared/node-manifest.js';
+
+// Parameterized test fixture for `NodeManifest`. Tests pass an explicit
+// list of agent ids so the framework set is part of the input — not a
+// hardcoded global. Core / registry / smoke tests no longer assume
+// Claude / Codex / OpenCode / Hermes are baked into the platform.
+
+export interface AgentInput {
+  id: string;
+  label?: string;
+  status?: NodeCapabilityStatus;
+  message?: string;
+}
+
+export interface ManifestFixtureOptions {
+  agents?: AgentInput[];
+  overrides?: Partial<NodeManifest>;
+}
+
+function agentProbe(input: AgentInput): NodeCapabilityProbe {
+  return {
+    id: input.id,
+    label: input.label ?? input.id,
+    status: input.status ?? 'available',
+    message: input.message ?? 'ok',
+  };
+}
+
+function defaultCapabilities(
+  agents: AgentInput[]
+): NodeManifest['capabilities'] {
+  return {
+    tmux: { id: 'tmux', label: 'tmux', status: 'available', message: 'ok' },
+    git: { id: 'git', label: 'Git', status: 'available', message: 'ok' },
+    clipboard: {
+      id: 'clipboard',
+      label: 'Clipboard',
+      status: 'degraded',
+      message: 'file fallback',
+    },
+    browserAutomation: {
+      id: 'browserAutomation',
+      label: 'Browser automation',
+      status: 'available',
+      message: 'ok',
+    },
+    githubCli: {
+      id: 'githubCli',
+      label: 'GitHub CLI',
+      status: 'unavailable',
+      message: 'missing',
+    },
+    tailscale: {
+      id: 'tailscale',
+      label: 'Tailscale CLI',
+      status: 'available',
+      message: 'ok',
+    },
+    ssh: {
+      id: 'ssh',
+      label: 'SSH client',
+      status: 'available',
+      message: 'ok',
+    },
+    agents: Object.fromEntries(
+      agents.map((agent) => [agent.id, agentProbe(agent)])
+    ),
+  };
+}
+
+/**
+ * Build a NodeManifest fixture with the supplied agent list (defaults
+ * to an empty list — explicit ids are the point of #437). `overrides`
+ * shallow-merges over the produced manifest.
+ */
+export function buildManifestWithAgents(
+  options: ManifestFixtureOptions = {}
+): NodeManifest {
+  const agents = options.agents ?? [];
+  const base: NodeManifest = {
+    schemaVersion: 1,
+    platform: 'darwin',
+    arch: 'arm64',
+    hostname: 'test-host',
+    relayVersion: '9.9.9',
+    generatedAt: '2026-01-02T03:04:05.000Z',
+    wsl: { detected: false, version: null, systemd: false },
+    serviceManager: {
+      kind: 'launchd',
+      label: 'launchd',
+      supported: true,
+      installable: true,
+      installHint: 'install',
+      uninstallHint: 'uninstall',
+      message: 'ok',
+      caveats: [],
+    },
+    capabilities: defaultCapabilities(agents),
+  };
+  return { ...base, ...options.overrides };
+}

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -7,76 +7,23 @@ import {
   DEFAULT_NODE_HEARTBEAT_TIMEOUTS,
 } from '../server/hub-node-registry.js';
 import { isNodeManifest, type NodeManifest } from '../shared/node-manifest.js';
+import { buildManifestWithAgents } from './helpers/manifest-fixtures.js';
+
+// Test-local agent list. Specific ids are an INPUT to the fixture,
+// not a hardcoded global assumption baked into the core. Each test
+// asserts round-trip behavior on whatever it supplies here.
+const TEST_AGENTS = [
+  { id: 'claude', label: 'Claude', status: 'available' as const },
+  {
+    id: 'codex',
+    label: 'Codex',
+    status: 'unavailable' as const,
+    message: 'missing',
+  },
+];
 
 function manifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
-  return {
-    schemaVersion: 1,
-    platform: 'darwin',
-    arch: 'arm64',
-    hostname: 'test-host',
-    relayVersion: '9.9.9',
-    generatedAt: '2026-01-02T03:04:05.000Z',
-    wsl: { detected: false, version: null, systemd: false },
-    serviceManager: {
-      kind: 'launchd',
-      label: 'launchd',
-      supported: true,
-      installable: true,
-      installHint: 'install',
-      uninstallHint: 'uninstall',
-      message: 'ok',
-      caveats: [],
-    },
-    capabilities: {
-      tmux: { id: 'tmux', label: 'tmux', status: 'available', message: 'ok' },
-      git: { id: 'git', label: 'Git', status: 'available', message: 'ok' },
-      clipboard: {
-        id: 'clipboard',
-        label: 'Clipboard',
-        status: 'degraded',
-        message: 'file fallback',
-      },
-      browserAutomation: {
-        id: 'browserAutomation',
-        label: 'Browser automation',
-        status: 'available',
-        message: 'ok',
-      },
-      githubCli: {
-        id: 'githubCli',
-        label: 'GitHub CLI',
-        status: 'unavailable',
-        message: 'missing',
-      },
-      tailscale: {
-        id: 'tailscale',
-        label: 'Tailscale CLI',
-        status: 'available',
-        message: 'ok',
-      },
-      ssh: {
-        id: 'ssh',
-        label: 'SSH client',
-        status: 'available',
-        message: 'ok',
-      },
-      agents: {
-        claude: {
-          id: 'claude',
-          label: 'Claude',
-          status: 'available',
-          message: 'ok',
-        },
-        codex: {
-          id: 'codex',
-          label: 'Codex',
-          status: 'unavailable',
-          message: 'missing',
-        },
-      },
-    },
-    ...overrides,
-  };
+  return buildManifestWithAgents({ agents: TEST_AGENTS, overrides });
 }
 
 function withTmpRegistry<T>(

--- a/test/multi-node-smoke.test.ts
+++ b/test/multi-node-smoke.test.ts
@@ -18,34 +18,54 @@ import {
   type HubNodeSummary,
   type RelayNodeEnvelope,
 } from '../shared/relay-node-protocol.js';
+import { buildManifestWithAgents } from './helpers/manifest-fixtures.js';
 
 const LOCAL_SESSION_ID = 'duplicate-local-session';
+
+// Test-local agent list. Specific ids are an INPUT to the fixture so
+// the smoke harness doesn't carry a hardcoded global assumption about
+// which frameworks the platform ships.
+const SMOKE_AGENTS = [
+  { id: 'claude', label: 'Claude', status: 'available' as const },
+  {
+    id: 'codex',
+    label: 'Codex',
+    status: 'degraded' as const,
+    message: 'test double',
+  },
+];
 
 function manifest(
   name: string,
   overrides: Partial<NodeManifest> = {}
 ): NodeManifest {
-  return {
-    schemaVersion: 1,
-    platform: 'linux',
-    arch: 'x64',
-    hostname: name,
-    relayVersion: '0.1.0-smoke',
-    generatedAt: '2026-01-02T03:04:05.000Z',
-    wsl: { detected: false, version: null, systemd: false },
-    serviceManager: {
-      kind: 'systemd-user',
-      label: 'systemd user',
-      supported: true,
-      installable: true,
-      installHint: 'install',
-      uninstallHint: 'uninstall',
-      message: 'ok',
-      caveats: [],
+  const base = buildManifestWithAgents({
+    agents: SMOKE_AGENTS,
+    overrides: {
+      platform: 'linux',
+      arch: 'x64',
+      hostname: name,
+      relayVersion: '0.1.0-smoke',
+      serviceManager: {
+        kind: 'systemd-user',
+        label: 'systemd user',
+        supported: true,
+        installable: true,
+        installHint: 'install',
+        uninstallHint: 'uninstall',
+        message: 'ok',
+        caveats: [],
+      },
     },
+  });
+  // The smoke harness needs a couple capability-status tweaks relative
+  // to the helper's defaults (clipboard available, browserAutomation
+  // degraded, tailscale unavailable, githubCli available). Apply them
+  // here so the harness intent stays self-contained.
+  return {
+    ...base,
     capabilities: {
-      tmux: { id: 'tmux', label: 'tmux', status: 'available', message: 'ok' },
-      git: { id: 'git', label: 'Git', status: 'available', message: 'ok' },
+      ...base.capabilities,
       clipboard: {
         id: 'clipboard',
         label: 'Clipboard',
@@ -69,26 +89,6 @@ function manifest(
         label: 'Tailscale CLI',
         status: 'unavailable',
         message: 'missing',
-      },
-      ssh: {
-        id: 'ssh',
-        label: 'SSH client',
-        status: 'available',
-        message: 'ok',
-      },
-      agents: {
-        claude: {
-          id: 'claude',
-          label: 'Claude',
-          status: 'available',
-          message: 'ok',
-        },
-        codex: {
-          id: 'codex',
-          label: 'Codex',
-          status: 'degraded',
-          message: 'test double',
-        },
       },
     },
     ...overrides,

--- a/test/node-manifest.test.ts
+++ b/test/node-manifest.test.ts
@@ -41,9 +41,13 @@ describe('node manifest', () => {
           githubCli: { status: 'unavailable' },
         },
       });
-      expect(Object.keys(manifest.capabilities.agents)).toEqual(
-        expect.arrayContaining(['claude', 'codex', 'opencode', 'hermes'])
-      );
+      // Core manifest no longer hardcodes a specific framework set.
+      // Whichever framework registry is configured at runtime supplies
+      // the agent map; this test just asserts the shape is well-formed.
+      for (const [id, probe] of Object.entries(manifest.capabilities.agents)) {
+        expect(probe.id).toBe(id);
+        expect(probe.status).toMatch(/available|degraded|unavailable|unknown/);
+      }
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -95,9 +99,7 @@ describe('node manifest', () => {
       pathMode: 'windows-mount',
       windowsPath: '\\\\wsl.localhost\\Ubuntu\\mnt\\c\\Users\\dev\\relay-ide',
     });
-    expect(['wsl-systemd', 'wsl-manual']).toContain(
-      manifest.wsl.lifecycleMode
-    );
+    expect(['wsl-systemd', 'wsl-manual']).toContain(manifest.wsl.lifecycleMode);
     expect(manifest.wsl.caveats?.join(' ')).toMatch(/not native Windows/i);
     expect(manifest.wsl.caveats?.join(' ')).toMatch(/capability-gated/i);
     expect(['wsl-systemd', 'wsl-manual']).toContain(

--- a/test/node-manifest.test.ts
+++ b/test/node-manifest.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { getNodeManifest, probeCommand } from '../server/node-manifest.js';
+import type { NodeCapabilityStatus } from '../shared/relay-node-protocol.js';
 
 describe('node manifest', () => {
   it('reports platform, service manager, and degraded missing tool probes without throwing', async () => {
@@ -43,10 +44,20 @@ describe('node manifest', () => {
       });
       // Core manifest no longer hardcodes a specific framework set.
       // Whichever framework registry is configured at runtime supplies
-      // the agent map; this test just asserts the shape is well-formed.
-      for (const [id, probe] of Object.entries(manifest.capabilities.agents)) {
+      // the agent map; this test asserts the shape is well-formed and
+      // that the probe ran (at least one entry) without pinning to
+      // specific ids.
+      const agentEntries = Object.entries(manifest.capabilities.agents);
+      expect(agentEntries.length).toBeGreaterThan(0);
+      const allowedStatuses: NodeCapabilityStatus[] = [
+        'available',
+        'degraded',
+        'unavailable',
+        'unknown',
+      ];
+      for (const [id, probe] of agentEntries) {
         expect(probe.id).toBe(id);
-        expect(probe.status).toMatch(/available|degraded|unavailable|unknown/);
+        expect(allowedStatuses).toContain(probe.status);
       }
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Closes #437 / Group F of the ADR-015 core audit.
- Drops hardcoded `claude / codex / opencode / hermes` assertions from manifest test fixtures. Agent ids become explicit test inputs rather than globals baked into the platform.
- Adds `test/helpers/manifest-fixtures.ts` with `buildManifestWithAgents(options)`.

## Why

Audit Group F flagged three sites where tests assumed a specific framework set:

- `test/node-manifest.test.ts:45` — `expect.arrayContaining(['claude', 'codex', 'opencode', 'hermes'])` against `manifest.capabilities.agents`. That assertion ties core test coverage to the *current* framework registry; once #437's CLI gateway + agent-adapters work (or operator-configured framework registries) lands, that list rots.
- `test/hub-node-registry.test.ts:63-76 + 264` — manifest fixture + round-trip assertion using hardcoded `claude / codex` ids.
- `test/multi-node-smoke.test.ts:79-92` — same fixture pattern.

Combined with #436 (framework probing moved to a feature decorator), the platform itself no longer names specific framework ids. The tests now reflect that contract.

## Changes

### New
- `test/helpers/manifest-fixtures.ts` — `buildManifestWithAgents({ agents, overrides })` factory. Agents are test input; helper defaults are empty list. Capability fields keep sane defaults that match the prior fixture shape, and `overrides` shallow-merges over the result.

### Refactor
- `test/node-manifest.test.ts` — replaces the `arrayContaining` assertion with a shape check that validates each entry of `manifest.capabilities.agents` regardless of id.
- `test/hub-node-registry.test.ts` — routes the local `manifest()` helper through `buildManifestWithAgents`. Test-local `TEST_AGENTS = [{ id: 'claude', ... }, { id: 'codex', ... }]` is the explicit input; the round-trip assertions on `claude / codex` are now asserting "what I passed in came back out," not "platform always includes these ids."
- `test/multi-node-smoke.test.ts` — same approach with `SMOKE_AGENTS`. Harness-specific capability overrides (clipboard / browserAutomation / githubCli / tailscale) preserved.

## Tests

- `npx vitest run` on the three touched test files: 16/16 PASS.
- `npx tsc --noEmit` clean.

## Out of scope

- Adding more frameworks to the registry. Helpers accept any id; nothing in core or tests now blocks new ids.
- Refactoring all other test files that mention specific agent ids (e.g. session-creation tests using `agent: 'claude'`). Those are legitimately testing one framework's behavior, not asserting platform globals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
