### PR TITLE
feat(node-link): wire node-side sessions.create RPC handler (#445)

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -18,6 +18,8 @@ import type { NodeManifest } from '../shared/node-manifest.js';
 import type { Config } from '../server/types.js';
 import { createNodeLinkClient } from '../server/node-link-client.js';
 import { createNodeLinkPtyHost } from '../server/node-link-pty-host.js';
+import { createNodeLinkRpcHost } from '../server/node-link-rpc-host.js';
+import { createLocalRelayNode } from '../server/local-node.js';
 import { collectLocalRepoInventory } from '../server/repo-inventory.js';
 
 const execFileAsync = promisify(execFile);
@@ -435,6 +437,8 @@ async function runNodeLink(nodeArgs: string[]): Promise<void> {
     config = undefined;
   }
   const ptyHost = createNodeLinkPtyHost({ nodeId: credential.nodeId });
+  const localRelayNode = createLocalRelayNode({ nodeId: credential.nodeId });
+  const rpcHost = createNodeLinkRpcHost({ localRelayNode });
   const client = createNodeLinkClient({
     hubUrl,
     credential,
@@ -452,6 +456,7 @@ async function runNodeLink(nodeArgs: string[]): Promise<void> {
       }
     },
     onPtyEnvelope: (envelope, ctx) => ptyHost.handle(envelope, ctx),
+    onRpcEnvelope: (envelope, ctx) => rpcHost.handle(envelope, ctx),
   });
   await new Promise<void>((resolve) => {
     let exiting = false;

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -1,0 +1,240 @@
+import type { LocalRelayNode } from './local-node.js';
+import type { Logger } from './logger.js';
+import { createLogger } from './logger.js';
+import type { CreateParams } from './sessions.js';
+import type { CreateWebParams } from './web-session-handler.js';
+import type {
+  NodeLinkChannelHandler,
+  NodeLinkEnvelopeHandlerContext,
+} from './node-link-client.js';
+import type {
+  RelayNodeEnvelope,
+  RelayNodeError,
+} from '../shared/relay-node-protocol.js';
+import type { SessionSummary } from './types.js';
+
+// Node-side RPC dispatcher. Hub initiates rpc/<type> requests over the
+// reverse WS; this module receives them, calls into the local
+// RelayNode, and sends back a `<type>.result` (or `<type>.error`)
+// envelope on the same `requestId`.
+//
+// First slice (#425.7): only `sessions.create` is wired. Other RPC
+// types fall through to an INVALID_REQUEST response so misrouted
+// envelopes don't silently hang the hub-side pending request.
+
+export interface NodeLinkRpcHostOptions {
+  localRelayNode: LocalRelayNode;
+  logger?: Logger;
+}
+
+export interface NodeLinkRpcHost {
+  handle: NodeLinkChannelHandler;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+    ? (value as string[])
+    : undefined;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function asNullableString(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  if (typeof value === 'string') return value;
+  return undefined;
+}
+
+interface SessionsCreateInput {
+  type: 'agent' | 'terminal';
+  mode?: 'pty' | 'web';
+  agent?: string;
+  repoPath?: string;
+  worktreePath?: string | null;
+  cwd?: string;
+  command?: string;
+  args?: string[];
+  displayName?: string;
+  branchName?: string;
+  customCommand?: string | null;
+  workspaceId?: string;
+  additionalDirs?: string[];
+  initialPrompt?: string;
+  useTmux?: boolean;
+  needsBranchRename?: boolean;
+  branchRenamePrompt?: string;
+  continue?: boolean;
+}
+
+function parseSessionsCreateInput(
+  raw: unknown
+): SessionsCreateInput | RelayNodeError {
+  const record = asRecord(raw);
+  if (!record) {
+    return invalidRequest('sessions.create payload must be an object');
+  }
+  const typeRaw = asString(record['type']);
+  if (typeRaw !== 'agent' && typeRaw !== 'terminal') {
+    return invalidRequest(
+      'sessions.create payload.type must be "agent" or "terminal"'
+    );
+  }
+  const modeRaw = asString(record['mode']);
+  if (modeRaw !== undefined && modeRaw !== 'pty' && modeRaw !== 'web') {
+    return invalidRequest(
+      'sessions.create payload.mode must be "pty" or "web" when set'
+    );
+  }
+  const input: SessionsCreateInput = { type: typeRaw };
+  if (modeRaw) input.mode = modeRaw;
+  const agent = asString(record['agent']);
+  if (agent !== undefined) input.agent = agent;
+  const repoPath = asString(record['repoPath']);
+  if (repoPath !== undefined) input.repoPath = repoPath;
+  const worktreePath = asNullableString(record['worktreePath']);
+  if (worktreePath !== undefined) input.worktreePath = worktreePath;
+  const cwd = asString(record['cwd']);
+  if (cwd !== undefined) input.cwd = cwd;
+  const command = asString(record['command']);
+  if (command !== undefined) input.command = command;
+  const args = asStringArray(record['args']);
+  if (args !== undefined) input.args = args;
+  const displayName = asString(record['displayName']);
+  if (displayName !== undefined) input.displayName = displayName;
+  const branchName = asString(record['branchName']);
+  if (branchName !== undefined) input.branchName = branchName;
+  const customCommand = asNullableString(record['customCommand']);
+  if (customCommand !== undefined) input.customCommand = customCommand;
+  const workspaceId = asString(record['workspaceId']);
+  if (workspaceId !== undefined) input.workspaceId = workspaceId;
+  const additionalDirs = asStringArray(record['additionalDirs']);
+  if (additionalDirs !== undefined) input.additionalDirs = additionalDirs;
+  const initialPrompt = asString(record['initialPrompt']);
+  if (initialPrompt !== undefined) input.initialPrompt = initialPrompt;
+  const useTmux = asBoolean(record['useTmux']);
+  if (useTmux !== undefined) input.useTmux = useTmux;
+  const needsBranchRename = asBoolean(record['needsBranchRename']);
+  if (needsBranchRename !== undefined)
+    input.needsBranchRename = needsBranchRename;
+  const branchRenamePrompt = asString(record['branchRenamePrompt']);
+  if (branchRenamePrompt !== undefined)
+    input.branchRenamePrompt = branchRenamePrompt;
+  const continueFlag = asBoolean(record['continue']);
+  if (continueFlag !== undefined) input.continue = continueFlag;
+  return input;
+}
+
+function invalidRequest(message: string): RelayNodeError {
+  return { code: 'INVALID_REQUEST', message, retryable: false };
+}
+
+function internalError(message: string): RelayNodeError {
+  return { code: 'INTERNAL', message, retryable: true };
+}
+
+function sessionSummaryFromCreateResult(value: unknown): SessionSummary {
+  // CreateResult is SessionSummary & { pid }. Strip pid before sending
+  // across the wire; hub-side isSessionSummary validator doesn't expect
+  // it and it leaks node-local OS detail.
+  const record = (value as Record<string, unknown>) ?? {};
+  const { pid: _pid, ...rest } = record;
+  void _pid;
+  return rest as unknown as SessionSummary;
+}
+
+function sendResultEnvelope(
+  ctx: NodeLinkEnvelopeHandlerContext,
+  envelope: RelayNodeEnvelope,
+  payload: unknown
+): void {
+  ctx.send(
+    ctx.buildEnvelope('rpc', `${envelope.type}.result`, {
+      ...(envelope.requestId ? { requestId: envelope.requestId } : {}),
+      payload,
+    })
+  );
+}
+
+function sendErrorEnvelope(
+  ctx: NodeLinkEnvelopeHandlerContext,
+  envelope: RelayNodeEnvelope,
+  error: RelayNodeError
+): void {
+  ctx.send(
+    ctx.buildEnvelope('rpc', `${envelope.type}.error`, {
+      ...(envelope.requestId ? { requestId: envelope.requestId } : {}),
+      error,
+    })
+  );
+}
+
+export function createNodeLinkRpcHost(
+  options: NodeLinkRpcHostOptions
+): NodeLinkRpcHost {
+  const logger = options.logger ?? createLogger('node-link-rpc');
+  const { localRelayNode } = options;
+
+  async function handleSessionsCreate(
+    envelope: RelayNodeEnvelope,
+    ctx: NodeLinkEnvelopeHandlerContext
+  ): Promise<void> {
+    const parsed = parseSessionsCreateInput(envelope.payload);
+    if ('code' in parsed) {
+      sendErrorEnvelope(ctx, envelope, parsed);
+      return;
+    }
+    try {
+      if (parsed.mode === 'web') {
+        const { session } = await localRelayNode.sessions.createWeb(
+          parsed as unknown as CreateWebParams
+        );
+        sendResultEnvelope(ctx, envelope, { session });
+        return;
+      }
+      const result = localRelayNode.sessions.create(
+        parsed as unknown as CreateParams
+      );
+      sendResultEnvelope(ctx, envelope, {
+        session: sessionSummaryFromCreateResult(result),
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error ?? 'unknown');
+      logger.error(`sessions.create failed: ${message}`);
+      sendErrorEnvelope(ctx, envelope, internalError(message));
+    }
+  }
+
+  function handle(
+    envelope: RelayNodeEnvelope,
+    ctx: NodeLinkEnvelopeHandlerContext
+  ): void {
+    if (envelope.channel !== 'rpc') return;
+    if (envelope.type === 'sessions.create') {
+      void handleSessionsCreate(envelope, ctx);
+      return;
+    }
+    logger.warn(
+      `unhandled rpc/${envelope.type} (requestId=${envelope.requestId ?? '?'})`
+    );
+    sendErrorEnvelope(
+      ctx,
+      envelope,
+      invalidRequest(`rpc method "${envelope.type}" is not implemented`)
+    );
+  }
+
+  return { handle };
+}

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createNodeLinkRpcHost } from '../server/node-link-rpc-host.js';
+import type {
+  RelayNodeEnvelope,
+  RelayNodeError,
+} from '../shared/relay-node-protocol.js';
+import {
+  RELAY_NODE_LINK_PROTOCOL,
+  RELAY_NODE_LINK_PROTOCOL_VERSION,
+} from '../shared/relay-node-protocol.js';
+import type { LocalRelayNode } from '../server/local-node.js';
+import type { CreateParams } from '../server/sessions.js';
+import type { CreateWebParams } from '../server/web-session-handler.js';
+import type { SessionSummary } from '../server/types.js';
+
+function summary(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 'sess-1',
+    type: 'terminal',
+    agent: 'claude',
+    mode: 'pty',
+    cwd: '/home/user',
+    repoName: '',
+    displayName: 'raw shell',
+    createdAt: '2026-01-02T03:04:05.000Z',
+    lastActivity: '2026-01-02T03:04:05.000Z',
+    idle: false,
+    customCommand: null,
+    status: 'active',
+    needsBranchRename: false,
+    agentState: 'idle',
+    ...overrides,
+  };
+}
+
+function envelope(
+  type: string,
+  payload: unknown,
+  overrides: Partial<RelayNodeEnvelope> = {}
+): RelayNodeEnvelope {
+  return {
+    protocol: RELAY_NODE_LINK_PROTOCOL,
+    protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+    nodeId: 'node-a',
+    channel: 'rpc',
+    type,
+    timestamp: '2026-01-02T03:04:05.000Z',
+    requestId: 'req-1',
+    payload,
+    ...overrides,
+  };
+}
+
+function context() {
+  const sent: RelayNodeEnvelope[] = [];
+  return {
+    sent,
+    ctx: {
+      send: (env: RelayNodeEnvelope) => sent.push(env),
+      buildEnvelope: (
+        channel: RelayNodeEnvelope['channel'],
+        type: string,
+        extras: Partial<RelayNodeEnvelope> = {}
+      ): RelayNodeEnvelope => ({
+        protocol: RELAY_NODE_LINK_PROTOCOL,
+        protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+        nodeId: 'node-a',
+        channel,
+        type,
+        timestamp: '2026-01-02T03:04:06.000Z',
+        ...extras,
+      }),
+    },
+  };
+}
+
+function fakeLocalNode(overrides: Partial<LocalRelayNode['sessions']> = {}) {
+  const stub: LocalRelayNode = {
+    nodeId: 'node-a',
+    environmentId: 'env-a' as never,
+    authority: () => ({ nodeId: 'node-a', environmentId: 'env-a' }) as never,
+    sessionEventScope: () => ({}) as never,
+    fileEventScope: () => ({}) as never,
+    sessions: {
+      list: () => [],
+      get: () => undefined,
+      create: vi.fn().mockReturnValue({ ...summary(), pid: 1234 }),
+      createWeb: vi
+        .fn()
+        .mockResolvedValue({ session: summary({ mode: 'web' }) }),
+      kill: () => {},
+      updateDisplayName: (id, displayName) => ({ id, displayName }),
+      write: () => {},
+      ...overrides,
+    } as LocalRelayNode['sessions'],
+  };
+  return stub;
+}
+
+describe('node-link-rpc-host', () => {
+  it('dispatches sessions.create to localRelayNode and strips pid from the response', () => {
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(
+      envelope('sessions.create', { type: 'terminal', cwd: '/home/user' }),
+      ctx
+    );
+
+    expect(localRelayNode.sessions.create).toHaveBeenCalledTimes(1);
+    expect(
+      (localRelayNode.sessions.create as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[0]
+    ).toMatchObject({ type: 'terminal', cwd: '/home/user' });
+    expect(sent).toHaveLength(1);
+    const reply = sent[0]!;
+    expect(reply.channel).toBe('rpc');
+    expect(reply.type).toBe('sessions.create.result');
+    expect(reply.requestId).toBe('req-1');
+    const replyPayload = reply.payload as { session: SessionSummary };
+    expect(replyPayload.session.id).toBe('sess-1');
+    expect(replyPayload.session).not.toHaveProperty('pid');
+  });
+
+  it('routes mode:"web" sessions through createWeb', async () => {
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(
+      envelope('sessions.create', { type: 'agent', mode: 'web' }),
+      ctx
+    );
+
+    // createWeb is async; flush microtasks.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(localRelayNode.sessions.createWeb).toHaveBeenCalledTimes(1);
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('sessions.create.result');
+    const payload = sent[0]!.payload as { session: SessionSummary };
+    expect(payload.session.mode).toBe('web');
+  });
+
+  it('responds with INVALID_REQUEST when payload is missing type', () => {
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(envelope('sessions.create', { cwd: '/home/user' }), ctx);
+
+    expect(localRelayNode.sessions.create).not.toHaveBeenCalled();
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('sessions.create.error');
+    const err = sent[0]!.error as RelayNodeError;
+    expect(err.code).toBe('INVALID_REQUEST');
+  });
+
+  it('responds with INTERNAL error when sessions.create throws', () => {
+    const localRelayNode = fakeLocalNode({
+      create: (() => {
+        throw new Error('boom');
+      }) as never,
+    });
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(envelope('sessions.create', { type: 'terminal' }), ctx);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('sessions.create.error');
+    const err = sent[0]!.error as RelayNodeError;
+    expect(err.code).toBe('INTERNAL');
+    expect(err.message).toContain('boom');
+  });
+
+  it('responds with INVALID_REQUEST for unimplemented rpc methods rather than silently hanging', () => {
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(envelope('manifest.refresh', {}), ctx);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('manifest.refresh.error');
+    const err = sent[0]!.error as RelayNodeError;
+    expect(err.code).toBe('INVALID_REQUEST');
+    expect(err.message).toContain('not implemented');
+  });
+
+  it('ignores envelopes from non-rpc channels', () => {
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(envelope('control.heartbeat', {}, { channel: 'control' }), ctx);
+
+    expect(sent).toHaveLength(0);
+    expect(localRelayNode.sessions.create).not.toHaveBeenCalled();
+  });
+});
+
+// Surface unused CreateParams/CreateWebParams type imports so the
+// editor doesn't strip them on auto-import cleanup; they document the
+// payload shape the host coerces to.
+void (null as unknown as CreateParams | undefined);
+void (null as unknown as CreateWebParams | undefined);


### PR DESCRIPTION
## Summary

- Closes #445 / #425.7.
- Closes the routed-session execution gap: the hub can now actually create sessions on paired nodes over the reverse WS link.

## Why this matters

Before this PR: hub calls `nodeLinks.request(nodeId, 'sessions.create', payload)` over the reverse link. The node-side client logs `received rpc/sessions.create but no handler registered` and the hub-side pending RPC times out at 10s. From the operator's perspective, `POST /hub/nodes/:nodeId/sessions` and the cold-reopen endpoint both hang then fail with `NODE_OFFLINE`-flavored timeouts.

After this PR: the same call round-trips. Node validates the payload, calls into its local `RelayNode.sessions.create`, and ships a typed `SessionSummary` back.

This is downstream of #434 (just merged): without optional `repoPath`/`worktreePath`/`branchName` on `SessionSummary`, the hub-side validator would reject non-repo session payloads. With both in place, raw-shell sessions on paired nodes (the foundation of #443's cross-node terminal panel) are end-to-end functional.

## Changes

### New
- `server/node-link-rpc-host.ts`: `createNodeLinkRpcHost({ localRelayNode })` returns a `handle()` that dispatches on `envelope.type`:
  - `sessions.create` — parses the payload, routes to `localRelayNode.sessions.create` (or `createWeb` for `mode: 'web'`), replies on the same `requestId` with `sessions.create.result` carrying a typed `SessionSummary`. Strips `pid` (CreateResult's node-local extra) before sending. Validates required `type` field (`'agent' | 'terminal'`) and rejects malformed payloads with `INVALID_REQUEST`. Spawn failures surface as `INTERNAL`.
  - any other `rpc` method — replies with `INVALID_REQUEST` carrying `"<method> is not implemented"` so misrouted envelopes can't silently hang the hub.
  - non-rpc envelopes — no-op (host is rpc-only).

### Wiring
- `bin/relay-ide.ts` `runNodeLink`: builds a local `RelayNode` keyed on the paired credential's `nodeId`, instantiates the RPC host, wires it via the previously-unused `onRpcEnvelope` hook on `createNodeLinkClient`.

### Tests
- `test/node-link-rpc-host.test.ts` (new, 6 cases):
  - PTY-mode `sessions.create` round-trip → `localRelayNode.sessions.create` called, `pid` stripped from response.
  - `mode: 'web'` route → `createWeb` called.
  - Missing `type` → `INVALID_REQUEST` error envelope.
  - Local `sessions.create` throw → `INTERNAL` error envelope.
  - Unimplemented rpc method (`manifest.refresh`) → `INVALID_REQUEST` error envelope (no silent hang).
  - Non-rpc channel → no-op, no `localRelayNode` interaction.

## Verification

- `npx tsc --noEmit` clean.
- 43/43 across rpc-host, pty-host, client, multi-node-smoke, session-routing, routes, production-wiring, cold-transfer.

## Out of scope

- File RPC handlers (`fs.read` / `fs.list` / `fs.stat` / `fs.write` / `fs.tail`) — separate epic #428.
- Manifest-refresh RPC, repo-listing RPC — separate sub-issues. Stubbed to `INVALID_REQUEST` so the hub gets a typed response instead of timing out.
- Session intent / scope (#426) — handler accepts whatever payload arrives; intent enforcement happens hub-side at routing.

## Risks

- Production-shape behavior depends on `localRelayNode.sessions.create` accepting whatever the hub forwards. Pre-#434 the hub validated repo fields strictly, so most payloads carried `repoPath` etc. Post-#434, non-repo payloads flow through. Verified in `test/node-link-rpc-host.test.ts` and (via the merged #457 PR) `test/hub-node-session-routing.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
