### PR TITLE
refactor(core): extract repo HTTP endpoints into feature router (#433)

### DIFF
--- a/server/features/repo-router.ts
+++ b/server/features/repo-router.ts
@@ -1,0 +1,166 @@
+import * as express from 'express';
+import { type HubNodeRegistry } from '../hub-node-registry.js';
+import {
+  RELAY_NODE_LINK_PROTOCOL_VERSION,
+  type RelayNodeError,
+} from '../../shared/relay-node-protocol.js';
+import { HubNodeLinkError, type HubNodeLinkManager } from '../hub-node-link.js';
+import {
+  bodyRecord,
+  coldReopenSessionPayload,
+  findColdReopenTarget,
+  recordField,
+  relayError,
+  scopedNodeSession,
+  sendRelayError,
+  sendRegistryError,
+  sessionFromPayload,
+} from '../hub-node-router.js';
+import type { RepoInventoryFeature } from './repo-inventory.js';
+import type { RepoInventoryReport } from '../../shared/repo-inventory.js';
+
+export interface RepoFeatureRouterOptions {
+  registry: HubNodeRegistry;
+  requireAuth: express.RequestHandler;
+  repoInventoryFeature: RepoInventoryFeature;
+  collectLocalRepoInventory?: () => Promise<RepoInventoryReport>;
+  nodeLinks?: HubNodeLinkManager;
+}
+
+// Repo-feature HTTP surface. These routes used to live in
+// `hub-node-router.ts` mixed in with pairing / heartbeat / node-list
+// concerns. Per #425.2 / #433 they move here so the core router stays
+// repo-agnostic.
+//
+// Endpoints:
+// - GET  /hub/repo-inventory                      → aggregate repo inventory across nodes
+// - POST /hub/nodes/:nodeId/sessions/reopen       → cold-reopen a session on a target node from inventory state
+//
+// Pure routing (pairing, heartbeat, node list/lifecycle, direct
+// sessions create) stays in `hub-node-router.ts`.
+export function createRepoFeatureRouter(
+  options: RepoFeatureRouterOptions
+): express.Router {
+  const router = express.Router();
+  const { registry, requireAuth, repoInventoryFeature } = options;
+
+  router.get('/hub/repo-inventory', requireAuth, async (_req, res) => {
+    try {
+      const reports = [...repoInventoryFeature.listInventoryReports()];
+      if (options.collectLocalRepoInventory) {
+        reports.push(await options.collectLocalRepoInventory());
+      }
+      res.json(repoInventoryFeature.aggregateInventoryReports(reports));
+    } catch (error) {
+      sendRegistryError(registry, res, error);
+    }
+  });
+
+  router.post(
+    '/hub/nodes/:nodeId/sessions/reopen',
+    requireAuth,
+    async (req, res) => {
+      const { nodeId } = req.params;
+      if (!nodeId) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'nodeId is required')
+        );
+        return;
+      }
+      const node = registry
+        .listNodes()
+        .find((candidate) => candidate.nodeId === nodeId);
+      if (!node || node.status === 'revoked') {
+        sendRelayError(res, relayError('NOT_FOUND', 'node is not paired'));
+        return;
+      }
+      if (node.protocolVersion !== RELAY_NODE_LINK_PROTOCOL_VERSION) {
+        const [nodeMajor] = node.protocolVersion.split('.');
+        const [hubMajor] = RELAY_NODE_LINK_PROTOCOL_VERSION.split('.');
+        sendRelayError(
+          res,
+          relayError(
+            nodeMajor === hubMajor ? 'VERSION_SKEW' : 'PROTOCOL_INCOMPATIBLE',
+            `relay-node-link protocol ${node.protocolVersion} must exactly match hub protocol ${RELAY_NODE_LINK_PROTOCOL_VERSION}`
+          )
+        );
+        return;
+      }
+      if (node.capabilities.core.tmux !== 'available') {
+        sendRelayError(
+          res,
+          relayError(
+            'NODE_UNSUPPORTED',
+            `node ${nodeId} cannot host tmux-backed PTY sessions`
+          )
+        );
+        return;
+      }
+      if (
+        node.status !== 'online' ||
+        !options.nodeLinks?.hasActiveNode(nodeId)
+      ) {
+        sendRelayError(
+          res,
+          relayError(
+            'NODE_OFFLINE',
+            `node ${nodeId} has no live reverse link`,
+            true
+          )
+        );
+        return;
+      }
+
+      const body = bodyRecord(req);
+      try {
+        const reports = [...repoInventoryFeature.listInventoryReports()];
+        if (options.collectLocalRepoInventory) {
+          reports.push(await options.collectLocalRepoInventory());
+        }
+        const target = findColdReopenTarget(reports, nodeId, body);
+        if ('code' in target) {
+          sendRelayError(res, target as RelayNodeError);
+          return;
+        }
+
+        const sessionPayload = coldReopenSessionPayload(body, target);
+        const payload = await options.nodeLinks.request(
+          nodeId,
+          'sessions.create',
+          sessionPayload
+        );
+        const session = scopedNodeSession(nodeId, sessionFromPayload(payload));
+        res.status(201).json({
+          session,
+          transfer: {
+            mode: 'cold-reopen',
+            livePtyMigrated: false,
+            message:
+              'cold reopen started a new session from git/worktree state; it did not migrate live tmux/PTY process state',
+            source: recordField(body, 'source'),
+            target: {
+              nodeId,
+              repoPath: target.repo.localPath,
+              worktreePath: target.worktree?.localPath ?? null,
+              branchName: target.branchName,
+              repoInstanceId: target.repo.repoInstanceId,
+              ...(target.worktree
+                ? { worktreeInstanceId: target.worktree.worktreeInstanceId }
+                : {}),
+            },
+            warnings: target.warnings,
+          },
+        });
+      } catch (error) {
+        if (error instanceof HubNodeLinkError) {
+          sendRelayError(res, error.relayNodeError);
+          return;
+        }
+        sendRegistryError(registry, res, error);
+      }
+    }
+  );
+
+  return router;
+}

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -47,7 +47,10 @@ function bearerToken(req: Request): string | null {
   return match?.[1]?.trim() || null;
 }
 
-function errorStatus(error: RelayNodeError): number {
+// Shared utilities exported for the repo feature router (and any other
+// hub-side router that needs to surface relay-node-protocol errors
+// consistently). Pure functions — no router or registry state.
+export function errorStatus(error: RelayNodeError): number {
   switch (error.code) {
     case 'UNAUTHORIZED':
       return 401;
@@ -68,7 +71,7 @@ function errorStatus(error: RelayNodeError): number {
   }
 }
 
-function sendRegistryError(
+export function sendRegistryError(
   registry: HubNodeRegistry,
   res: Response,
   error: unknown
@@ -77,7 +80,7 @@ function sendRegistryError(
   res.status(errorStatus(body.error)).json(body);
 }
 
-function relayError(
+export function relayError(
   code: RelayNodeError['code'],
   message: string,
   retryable = false,
@@ -86,11 +89,11 @@ function relayError(
   return { code, message, retryable, ...(details ? { details } : {}) };
 }
 
-function sendRelayError(res: Response, error: RelayNodeError): void {
+export function sendRelayError(res: Response, error: RelayNodeError): void {
   res.status(errorStatus(error)).json({ error });
 }
 
-function isSessionSummary(value: unknown): value is SessionSummary {
+export function isSessionSummary(value: unknown): value is SessionSummary {
   if (typeof value !== 'object' || value === null) return false;
   const session = value as Partial<SessionSummary>;
   // repoPath / worktreePath / branchName are optional: a non-repo
@@ -125,7 +128,7 @@ function isSessionSummary(value: unknown): value is SessionSummary {
   );
 }
 
-function scopedNodeSession(
+export function scopedNodeSession(
   nodeId: string,
   session: SessionSummary
 ): SessionSummary {
@@ -153,7 +156,7 @@ function scopedNodeSession(
   };
 }
 
-function sessionFromPayload(payload: unknown): SessionSummary {
+export function sessionFromPayload(payload: unknown): SessionSummary {
   if (typeof payload !== 'object' || payload === null) {
     throw new HubNodeRegistryError(
       'INVALID_REQUEST',
@@ -170,13 +173,13 @@ function sessionFromPayload(payload: unknown): SessionSummary {
   return session;
 }
 
-function bodyRecord(req: Request): Record<string, unknown> {
+export function bodyRecord(req: Request): Record<string, unknown> {
   return typeof req.body === 'object' && req.body !== null
     ? (req.body as Record<string, unknown>)
     : {};
 }
 
-interface ColdReopenWarning {
+export interface ColdReopenWarning {
   code:
     | 'source-dirty-checkout'
     | 'source-diverged-checkout'
@@ -186,7 +189,7 @@ interface ColdReopenWarning {
   details?: Record<string, unknown>;
 }
 
-interface ColdReopenTarget {
+export interface ColdReopenTarget {
   repo: RepoInventoryRepoInstance;
   worktree: RepoInventoryWorktreeInstance | null;
   branchName: string | null;
@@ -201,7 +204,7 @@ function stringField(
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
 
-function recordField(
+export function recordField(
   record: Record<string, unknown>,
   key: string
 ): Record<string, unknown> {
@@ -331,7 +334,7 @@ function findSourceCheckout(
   return null;
 }
 
-function findColdReopenTarget(
+export function findColdReopenTarget(
   reports: RepoInventoryReport[],
   nodeId: string,
   body: Record<string, unknown>
@@ -460,7 +463,7 @@ function coldReopenPrompt(input: {
     : handoff;
 }
 
-function coldReopenSessionPayload(
+export function coldReopenSessionPayload(
   body: Record<string, unknown>,
   target: ColdReopenTarget
 ): Record<string, unknown> {
@@ -707,123 +710,10 @@ export function createHubNodeRouter(
     res.json({ nodes: registry.listNodes() });
   });
 
-  router.get('/hub/repo-inventory', requireAuth, async (_req, res) => {
-    try {
-      const reports = [...repoInventoryFeature.listInventoryReports()];
-      if (options.collectLocalRepoInventory) {
-        reports.push(await options.collectLocalRepoInventory());
-      }
-      res.json(repoInventoryFeature.aggregateInventoryReports(reports));
-    } catch (error) {
-      sendRegistryError(registry, res, error);
-    }
-  });
-
-  router.post(
-    '/hub/nodes/:nodeId/sessions/reopen',
-    requireAuth,
-    async (req, res) => {
-      const { nodeId } = req.params;
-      if (!nodeId) {
-        sendRelayError(
-          res,
-          relayError('INVALID_REQUEST', 'nodeId is required')
-        );
-        return;
-      }
-      const node = registry
-        .listNodes()
-        .find((candidate) => candidate.nodeId === nodeId);
-      if (!node || node.status === 'revoked') {
-        sendRelayError(res, relayError('NOT_FOUND', 'node is not paired'));
-        return;
-      }
-      if (node.protocolVersion !== RELAY_NODE_LINK_PROTOCOL_VERSION) {
-        const [nodeMajor] = node.protocolVersion.split('.');
-        const [hubMajor] = RELAY_NODE_LINK_PROTOCOL_VERSION.split('.');
-        sendRelayError(
-          res,
-          relayError(
-            nodeMajor === hubMajor ? 'VERSION_SKEW' : 'PROTOCOL_INCOMPATIBLE',
-            `relay-node-link protocol ${node.protocolVersion} must exactly match hub protocol ${RELAY_NODE_LINK_PROTOCOL_VERSION}`
-          )
-        );
-        return;
-      }
-      if (node.capabilities.core.tmux !== 'available') {
-        sendRelayError(
-          res,
-          relayError(
-            'NODE_UNSUPPORTED',
-            `node ${nodeId} cannot host tmux-backed PTY sessions`
-          )
-        );
-        return;
-      }
-      if (
-        node.status !== 'online' ||
-        !options.nodeLinks?.hasActiveNode(nodeId)
-      ) {
-        sendRelayError(
-          res,
-          relayError(
-            'NODE_OFFLINE',
-            `node ${nodeId} has no live reverse link`,
-            true
-          )
-        );
-        return;
-      }
-
-      const body = bodyRecord(req);
-      try {
-        const reports = [...repoInventoryFeature.listInventoryReports()];
-        if (options.collectLocalRepoInventory) {
-          reports.push(await options.collectLocalRepoInventory());
-        }
-        const target = findColdReopenTarget(reports, nodeId, body);
-        if ('code' in target) {
-          sendRelayError(res, target);
-          return;
-        }
-
-        const sessionPayload = coldReopenSessionPayload(body, target);
-        const payload = await options.nodeLinks.request(
-          nodeId,
-          'sessions.create',
-          sessionPayload
-        );
-        const session = scopedNodeSession(nodeId, sessionFromPayload(payload));
-        res.status(201).json({
-          session,
-          transfer: {
-            mode: 'cold-reopen',
-            livePtyMigrated: false,
-            message:
-              'cold reopen started a new session from git/worktree state; it did not migrate live tmux/PTY process state',
-            source: recordField(body, 'source'),
-            target: {
-              nodeId,
-              repoPath: target.repo.localPath,
-              worktreePath: target.worktree?.localPath ?? null,
-              branchName: target.branchName,
-              repoInstanceId: target.repo.repoInstanceId,
-              ...(target.worktree
-                ? { worktreeInstanceId: target.worktree.worktreeInstanceId }
-                : {}),
-            },
-            warnings: target.warnings,
-          },
-        });
-      } catch (error) {
-        if (error instanceof HubNodeLinkError) {
-          sendRelayError(res, error.relayNodeError);
-          return;
-        }
-        sendRegistryError(registry, res, error);
-      }
-    }
-  );
+  // Repo-feature endpoints (GET /hub/repo-inventory + POST
+  // /hub/nodes/:nodeId/sessions/reopen) used to live here. Per #425.2 /
+  // #433 they moved to `server/features/repo-router.ts`. Composition
+  // root mounts both routers.
 
   router.post('/hub/nodes/:nodeId/sessions', requireAuth, async (req, res) => {
     const { nodeId } = req.params;

--- a/server/index.ts
+++ b/server/index.ts
@@ -105,6 +105,7 @@ import { createHubNodeRegistry } from './hub-node-registry.js';
 import { createHubNodeRouter } from './hub-node-router.js';
 import { createHubNodeLinkManager } from './hub-node-link.js';
 import { createRepoInventoryFeature } from './features/repo-inventory.js';
+import { createRepoFeatureRouter } from './features/repo-router.js';
 import { collectLocalRepoInventory } from './repo-inventory.js';
 import type {
   AgentType,
@@ -1078,17 +1079,27 @@ async function main(): Promise<void> {
     next();
   };
 
+  const collectLocalInventory = () =>
+    collectLocalRepoInventory({
+      config: getConfig(),
+      configPath: CONFIG_PATH,
+    });
   app.use(
     createHubNodeRouter({
       registry: hubNodeRegistry,
       nodeLinks: hubNodeLinks,
       requireAuth,
       repoInventoryFeature,
-      collectLocalRepoInventory: () =>
-        collectLocalRepoInventory({
-          config: getConfig(),
-          configPath: CONFIG_PATH,
-        }),
+      collectLocalRepoInventory: collectLocalInventory,
+    })
+  );
+  app.use(
+    createRepoFeatureRouter({
+      registry: hubNodeRegistry,
+      nodeLinks: hubNodeLinks,
+      requireAuth,
+      repoInventoryFeature,
+      collectLocalRepoInventory: collectLocalInventory,
     })
   );
 

--- a/test/hub-node-cold-transfer.test.ts
+++ b/test/hub-node-cold-transfer.test.ts
@@ -7,6 +7,8 @@ import { WebSocket } from 'ws';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createHubNodeRegistry } from '../server/hub-node-registry.js';
 import { createHubNodeRouter } from '../server/hub-node-router.js';
+import { createRepoFeatureRouter } from '../server/features/repo-router.js';
+import { createRepoInventoryFeature } from '../server/features/repo-inventory.js';
 import { createHubNodeLinkManager } from '../server/hub-node-link.js';
 import { createLocalRelayNode } from '../server/local-node.js';
 import { setupWebSocket } from '../server/ws.js';
@@ -232,14 +234,26 @@ describe('hub cold transfer / reopen-on-other-node', () => {
     const nodeLinks = createHubNodeLinkManager();
     const app = express();
     app.use(express.json());
+    const requireAuth: express.RequestHandler = (req, res, next) => {
+      if (req.header('x-test-auth') === 'yes') next();
+      else res.status(401).json({ error: 'Unauthorized' });
+    };
+    const repoInventoryFeature = createRepoInventoryFeature(registry);
     app.use(
       createHubNodeRouter({
         registry,
         nodeLinks,
-        requireAuth: (req, res, next) => {
-          if (req.header('x-test-auth') === 'yes') next();
-          else res.status(401).json({ error: 'Unauthorized' });
-        },
+        requireAuth,
+        repoInventoryFeature,
+        collectLocalRepoInventory: options?.collectLocalRepoInventory,
+      })
+    );
+    app.use(
+      createRepoFeatureRouter({
+        registry,
+        nodeLinks,
+        requireAuth,
+        repoInventoryFeature,
         collectLocalRepoInventory: options?.collectLocalRepoInventory,
       })
     );

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -7,6 +7,7 @@ import { WebSocket } from 'ws';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createHubNodeRegistry } from '../server/hub-node-registry.js';
 import { createHubNodeRouter } from '../server/hub-node-router.js';
+import { createRepoFeatureRouter } from '../server/features/repo-router.js';
 import { createHubNodeLinkManager } from '../server/hub-node-link.js';
 import { createRepoInventoryFeature } from '../server/features/repo-inventory.js';
 import { setupWebSocket } from '../server/ws.js';
@@ -618,15 +619,27 @@ describe('hub node routes and link', () => {
     cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
     const app = express();
     app.use(express.json());
+    const requireAuth: express.RequestHandler = (req, res, next) => {
+      if (req.header('x-test-auth') === 'yes') next();
+      else res.status(401).json({ error: 'Unauthorized' });
+    };
+    const repoInventoryFeature = createRepoInventoryFeature(registry);
+    const collect = async () =>
+      repoInventoryReport('local', '/Users/kyle/dev/relay-ide');
     app.use(
       createHubNodeRouter({
         registry,
-        requireAuth: (req, res, next) => {
-          if (req.header('x-test-auth') === 'yes') next();
-          else res.status(401).json({ error: 'Unauthorized' });
-        },
-        collectLocalRepoInventory: async () =>
-          repoInventoryReport('local', '/Users/kyle/dev/relay-ide'),
+        requireAuth,
+        repoInventoryFeature,
+        collectLocalRepoInventory: collect,
+      })
+    );
+    app.use(
+      createRepoFeatureRouter({
+        registry,
+        requireAuth,
+        repoInventoryFeature,
+        collectLocalRepoInventory: collect,
       })
     );
     const server = http.createServer(app);


### PR DESCRIPTION
## Summary

- Closes #433 / Group B of the ADR-015 core audit.
- Two repo-feature-layer endpoints moved out of `server/hub-node-router.ts` into a new `server/features/repo-router.ts`:
  - `GET /hub/repo-inventory`
  - `POST /hub/nodes/:nodeId/sessions/reopen` (cold reopen)
- Pure routing (pairing, heartbeat, node list/lifecycle, direct sessions create) stays in `hub-node-router.ts`.

## Why

Audit Group B: `hub-node-router.ts` mixed pure routing with feature-layer concerns. The cold-reopen flow alone pulls in `RepoInventoryWorktreeInstance`, `repoIdentity`, branch divergence + dirty-state warnings — none of which the core hub needs to understand. Separating the routers makes the core surface what it actually is (pairing + lifecycle + opaque session dispatch), and lets the repo feature module own its endpoints + helpers in one place.

## Change shape

```
server/hub-node-router.ts (slim)
├─ routes: pair-tokens, pairing/exchange, node-heartbeat, /nodes, sessions create, /nodes/:id DELETE
└─ EXPORTS shared helpers used by both routers:
   errorStatus, sendRelayError, sendRegistryError, relayError,
   isSessionSummary, scopedNodeSession, sessionFromPayload,
   bodyRecord, recordField, findColdReopenTarget,
   coldReopenSessionPayload, ColdReopenWarning, ColdReopenTarget

server/features/repo-router.ts (new)
├─ routes: /hub/repo-inventory, /hub/nodes/:id/sessions/reopen
└─ imports shared helpers from hub-node-router

server/index.ts (composition root)
├─ build feature once
├─ mount createHubNodeRouter(...)
└─ mount createRepoFeatureRouter(...)
```

## Tests

- `test/hub-node-cold-transfer.test.ts` and `test/hub-node-routes.test.ts` updated: they previously mounted only `createHubNodeRouter`; now mount `createRepoFeatureRouter` alongside it so the moved endpoints respond. Mirrors the composition-root wiring.
- 37/37 tests across cold-transfer, routes, session-routing, multi-node-smoke, repo-inventory-feature, production-wiring. tsc clean.

## Out of scope

- Splitting the shared helpers into a third `server/hub-shared.ts` module. Today they live in `hub-node-router.ts` and are exported; that's enough decoupling for the audit goal. If a third router needs them later, a clean extraction is a small follow-up.
- Refactoring `coldReopenSessionPayload`'s synthesized `repoPath`/`worktreePath` fields. Those still match the wire-shape the node side expects (#445 sessions.create handler accepts them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized hub server routing architecture to improve code reusability across router modules.
  * Extracted and consolidated shared error handling and session management utilities for consistent reuse across endpoints.

* **Tests**
  * Updated integration tests to accommodate the restructured router organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/464)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->