### PR TITLE
feat(node): tmux-backed pty.attach via SessionAttachment boundary (#467)

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -470,10 +470,17 @@ async function runNodeLink(nodeArgs: string[]): Promise<void> {
     const finish = (exitCode: number): void => {
       if (exiting) return;
       exiting = true;
-      ptyHost.closeAll('node-link client stopping');
       const safetyTimer = setTimeout(() => process.exit(exitCode), 5_000);
       safetyTimer.unref?.();
-      void client.stop().then(() => {
+      // #467: ptyHost.closeAll is async — await it so attachment
+      // teardown (which may detach tmux clients) completes before the
+      // process exits, while keeping the 5s safety timer above as a
+      // hard cap. Default close() leaves tmux sessions alive so a
+      // reconnect can resume them.
+      void Promise.allSettled([
+        ptyHost.closeAll('node-link client stopping'),
+        client.stop(),
+      ]).then(() => {
         clearTimeout(safetyTimer);
         resolve();
         process.exit(exitCode);

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -436,7 +436,14 @@ async function runNodeLink(nodeArgs: string[]): Promise<void> {
   } catch {
     config = undefined;
   }
-  const ptyHost = createNodeLinkPtyHost({ nodeId: credential.nodeId });
+  // #467: ask the manifest probe which resume mode this host supports
+  // so the pty host can pick tmux vs raw without re-probing.
+  const initialManifest = await getNodeManifest();
+  const sessionResume = initialManifest.capabilities.sessionResume ?? 'none';
+  const ptyHost = createNodeLinkPtyHost({
+    nodeId: credential.nodeId,
+    sessionResume,
+  });
   const localRelayNode = createLocalRelayNode({ nodeId: credential.nodeId });
   const rpcHost = createNodeLinkRpcHost({ localRelayNode });
   const client = createNodeLinkClient({

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -202,7 +202,18 @@ Nodes report a capability manifest during pairing and on every heartbeat. The ma
 | `githubCli`         | `gh` CLI is available                                         |
 | `tailscale`         | `tailscale` CLI is available                                  |
 | `ssh`               | `ssh` client is available                                     |
+| `sessionResume`     | How the node persists PTYs across detach (#467)               |
 | `agents`            | Map of agent CLI IDs (e.g. `claude`, `codex`) to availability |
+
+`sessionResume` is one of:
+
+| Value                | Meaning                                                                              |
+| -------------------- | ------------------------------------------------------------------------------------ |
+| `tmux`               | Node owns a tmux session per relay session; browser reload reattaches the same shell |
+| `canonical-emulator` | Reserved for #469 (server-side canonical terminal)                                   |
+| `none`               | Raw shell only — browser reload kills the shell                                      |
+
+The frontend reads `sessionResume` from `HubNodeSummary.capabilities.sessionResume` and renders a `resumable` badge on the terminal-node picker when the value is non-`none`. Hubs and clients **never** reference tmux verbs directly — the capability flag is the sole interface, so phase 2 can drop in `canonical-emulator` without touching browser code.
 
 ### Service Manager
 
@@ -291,7 +302,45 @@ A single hub UI can host terminal tabs attached to multiple paired nodes:
 - The PTY socket (`frontend/src/lib/ws.ts`) reads `nodeId` from the session (or parses it from a global session id) and opens `/nodes/{nodeId}/ws/sessions/{localSessionId}` instead of the local `/ws/{sessionId}` route.
 - Tab chrome (`WorkspaceTabBar` + `workspace-summary.ts`) shows a node label + heartbeat dot for cross-node tabs, sourced from `SummaryContext.findNode` which `WorkspaceArea` populates from the `useQuery(['hub-nodes'], fetchHubNodes)` cache (15 s refetch interval).
 
-Reload-resume (tmux-backed `pty.attach`) and the two-node smoke harness remain follow-ups under sub-issues of #443.
+Reload-resume is implemented as of #467: see [SessionAttachment Boundary](#sessionattachment-boundary). The two-node smoke harness remains a follow-up under sub-issues of #443.
+
+### SessionAttachment Boundary
+
+`server/session-attachment.ts` exports a stable `SessionAttachment` interface between `node-link-pty-host.ts` and the concrete backend that owns the PTY. The interface intentionally hides every implementation detail (tmux verbs, node-pty handles, socket paths) so phase 2 (#469, server-side canonical terminal state) can slot in beside, not under, the tmux feature.
+
+```ts
+interface SessionAttachment {
+  readonly sessionId: string;
+  readonly mode: 'tmux' | 'raw';
+  onData(handler: (bytes: Buffer) => void): Disposable;
+  onExit(
+    handler: (event: { exitCode: number; signal?: number }) => void
+  ): Disposable;
+  write(bytes: Buffer): void;
+  resize(cols: number, rows: number): void;
+  close(reason?: string): Promise<void>;
+  status(): 'attached' | 'detached' | 'closed';
+}
+```
+
+Backends ship with the package:
+
+| Factory                         | Mode   | When used                                                   |
+| ------------------------------- | ------ | ----------------------------------------------------------- |
+| `createTmuxAttachmentFactory()` | `tmux` | `sessionResume: 'tmux'`; reload reattaches to same shell    |
+| `createRawAttachmentFactory()`  | `raw`  | `sessionResume: 'none'` or `'canonical-emulator'` (phase 1) |
+| `createMockAttachmentFactory()` | `tmux` | Tests — replays scripted bytes, captures writes             |
+
+**Non-blocking constraints (#467, must hold for phase 2):**
+
+1. No tmux strings leak past `server/node-link-pty-host.ts`. Hub registry stores `relaySessionId` only; the node maps `relaySessionId → tmux target` internally.
+2. Frontend never references tmux verbs. The resumable badge reads `node.capabilities.sessionResume`.
+3. Wire format unchanged — opaque bytes over WS. No frontend assumes "this looks like tmux-wrapped VT100."
+4. Tests use `MockAttachment`. Pre-push CI does **not** spawn real tmux.
+5. `SessionAttachment` is exported from `server/`, not `features/tmux/`. Phase 2 lives beside, not under, tmux.
+6. Detach handling: on hub disconnect, tmux sessions are **not** killed. On node-link reconnect, hub re-issues `pty.attach` and the node reattaches to the same tmux session.
+
+The tmux config is baked in (`set -g status off`, `unbind-key -a`, `set -g mouse off`, `set -g escape-time 0`). Operators never see tmux UI — tmux is an attach-by-name primitive, not a multiplexer.
 
 ## Repo Identity and Inventory
 

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -342,6 +342,12 @@ Backends ship with the package:
 
 The tmux config is baked in (`set -g status off`, `unbind-key -a`, `set -g mouse off`, `set -g escape-time 0`). Operators never see tmux UI — tmux is an attach-by-name primitive, not a multiplexer.
 
+The tmux config file lives under `$XDG_CONFIG_HOME/relay-ide/tmux/relay.tmux.conf` (defaults to `~/.config/relay-ide/tmux/...`) with mode `0700` on the directory and `0600` on the file — `os.tmpdir()` is shared between local UIDs and tmux configs can `run-shell` arbitrary commands, so it is not used.
+
+**Session lifecycle:** `attachment.close()` with no reason — or any reason other than `SESSION_ATTACHMENT_KILL_REASON` — terminates only the local attach client. The tmux session keeps running and is the resume target for the next attach. Explicitly destroying a session (kill-session) requires passing the `SESSION_ATTACHMENT_KILL_REASON` sentinel; the hub uses this when the operator explicitly closes a tab, distinct from a transient browser reload.
+
+**Raw fallback scope:** `sessionResume: 'none'` ships a working raw shell, but the v1 hub session-routing preconditions (see [Session Routing](#session-routing)) still require `core.tmux === 'available'`. The terminal picker enforces the same gate; non-tmux nodes appear disabled with reason `no tmux`. Raw shells are wired so phase 2 can drop the gate without re-doing the attachment layer.
+
 ## Repo Identity and Inventory
 
 ### Canonical Repo Identity

--- a/frontend/src/components/TerminalNodePicker.css
+++ b/frontend/src/components/TerminalNodePicker.css
@@ -93,3 +93,10 @@
   color: var(--text-muted, #888);
   font-size: 0.62rem;
 }
+
+.ws-node-picker__resumable {
+  color: var(--status-success, #34d399);
+  font-size: 0.62rem;
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+}

--- a/frontend/src/components/TerminalNodePicker.tsx
+++ b/frontend/src/components/TerminalNodePicker.tsx
@@ -35,6 +35,12 @@ export interface NodeChoice {
   status: 'this host' | HubNodeSummary['status'];
   disabled: boolean;
   disabledReason?: string;
+  /**
+   * #467: `true` when the node advertises a session-resume backend
+   * (tmux today, server-side canonical terminal in phase 2). Drives
+   * the "resumable" badge on the menu item.
+   */
+  resumable: boolean;
 }
 
 /**
@@ -52,6 +58,15 @@ function nodeBlockReason(node: HubNodeSummary): string | null {
   return null;
 }
 
+function isResumable(node: HubNodeSummary): boolean {
+  // Pre-#467 nodes do not publish `sessionResume`. Treat missing as
+  // 'none' (no resume) rather than guessing from tmux availability —
+  // the capability flag is the sole source of truth so frontend code
+  // never references tmux verbs.
+  const resume = node.capabilities.sessionResume ?? 'none';
+  return resume !== 'none';
+}
+
 export function buildChoices(nodes: HubNodeSummary[]): NodeChoice[] {
   const choices: NodeChoice[] = [
     {
@@ -59,6 +74,7 @@ export function buildChoices(nodes: HubNodeSummary[]): NodeChoice[] {
       label: 'this host',
       status: 'this host',
       disabled: false,
+      resumable: false,
     },
   ];
   for (const node of nodes) {
@@ -68,6 +84,7 @@ export function buildChoices(nodes: HubNodeSummary[]): NodeChoice[] {
       label: node.displayName || node.nodeId,
       status: node.status,
       disabled: reason !== null,
+      resumable: isResumable(node),
       ...(reason ? { disabledReason: reason } : {}),
     });
   }
@@ -271,6 +288,14 @@ export function TerminalNodePicker({
                     aria-hidden
                   />
                   <span className="ws-node-picker__label">{choice.label}</span>
+                  {choice.resumable && (
+                    <span
+                      className="ws-node-picker__resumable"
+                      title="reloads reattach to the same shell"
+                    >
+                      resumable
+                    </span>
+                  )}
                   {choice.status !== 'this host' && (
                     <span className="ws-node-picker__status">
                       {choice.status}

--- a/frontend/src/components/TerminalNodePicker.tsx
+++ b/frontend/src/components/TerminalNodePicker.tsx
@@ -49,6 +49,13 @@ export interface NodeChoice {
  * advertise tmux capability. Anything else gets surfaced as a disabled
  * choice with the failing precondition as the tooltip reason — the user
  * never gets to click and then hit a typed error.
+ *
+ * #467 note: nodes advertising `sessionResume: 'none'` ship a working
+ * raw-shell attachment backend, but the hub's `sessions.create`
+ * preconditions still require tmux. The picker enforces the same
+ * gate (`no tmux`) so users don't get a typed error after clicking.
+ * Phase 2 will loosen this once non-resumable nodes have a routing
+ * story.
  */
 function nodeBlockReason(node: HubNodeSummary): string | null {
   if (node.status !== 'online') return node.status;

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -187,6 +187,11 @@ function summarizeCapabilities(
     agents,
     serviceManager: manifest.serviceManager.kind,
     wsl: manifest.wsl.detected,
+    // #467: pass through the resume kind so the frontend can show a
+    // resumable badge without re-deriving from tmux availability.
+    // Pre-#467 manifests omit this field; treat as 'none' on the read
+    // side via `?? 'none'`.
+    sessionResume: manifest.capabilities.sessionResume ?? 'none',
   };
 }
 

--- a/server/node-link-pty-host.ts
+++ b/server/node-link-pty-host.ts
@@ -1,12 +1,20 @@
-import pty from 'node-pty';
-import type { IPty } from 'node-pty';
+import { Buffer } from 'node:buffer';
 import type { Logger } from './logger.js';
 import { createLogger } from './logger.js';
 import type { RelayNodeEnvelope } from '../shared/relay-node-protocol.js';
+import type {
+  SessionAttachment,
+  SessionAttachmentFactory,
+  SessionAttachmentMode,
+} from './session-attachment.js';
+import {
+  createRawAttachmentFactory,
+  createTmuxAttachmentFactory,
+} from './session-attachment.js';
+import type { NodeSessionResumeKind } from '../shared/node-manifest.js';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
-const DEFAULT_NAME = 'xterm-256color';
 const SCROLLBACK_BYTE_LIMIT = 256 * 1024;
 
 export interface NodeLinkPtyAttachInput {
@@ -20,11 +28,25 @@ export interface NodeLinkPtyAttachInput {
 }
 
 export interface NodeLinkPtyHostDeps {
-  spawn?: (command: string, args: string[], options: pty.IPtyForkOptions) => IPty;
+  /**
+   * #467: pluggable attachment backend. Defaults derived from
+   * `sessionResume`: 'tmux' -> TmuxAttachment, anything else -> raw.
+   * Tests inject `MockAttachmentFactory` directly to avoid spawning
+   * processes or tmux.
+   */
+  attachmentFactory?: SessionAttachmentFactory;
   defaultShell?: string;
   defaultCwd?: string;
   defaultEnv?: NodeJS.ProcessEnv;
   logger?: Logger;
+  /**
+   * Resume capability the manifest advertises. Determines which
+   * factory is constructed when `attachmentFactory` is not supplied.
+   * Hosts without tmux (or with `sessionResume: 'none'`) fall back to
+   * a raw shell that dies on detach. 'canonical-emulator' is treated
+   * as 'raw' in phase 1; #469 will replace this dispatch.
+   */
+  sessionResume?: NodeSessionResumeKind;
 }
 
 export interface NodeLinkPtyHostContext {
@@ -38,13 +60,15 @@ export interface NodeLinkPtyHostContext {
 
 export interface NodeLinkPtyHost {
   handle(envelope: RelayNodeEnvelope, ctx: NodeLinkPtyHostContext): void;
-  closeAll(reason?: string): void;
+  closeAll(reason?: string): Promise<void>;
+  readonly mode: SessionAttachmentMode;
 }
 
 interface ActiveStream {
   streamId: string;
-  ptyProcess: IPty;
-  scrollback: string[];
+  sessionId: string;
+  attachment: SessionAttachment;
+  scrollback: Buffer[];
   scrollbackBytes: number;
   closing: boolean;
 }
@@ -99,16 +123,24 @@ export interface NodeLinkPtyHostOptions extends NodeLinkPtyHostDeps {
   nodeId: string;
 }
 
+function resolveFactory(opts: NodeLinkPtyHostDeps): SessionAttachmentFactory {
+  if (opts.attachmentFactory) return opts.attachmentFactory;
+  if (opts.sessionResume === 'tmux') return createTmuxAttachmentFactory();
+  return createRawAttachmentFactory();
+}
+
 export function createNodeLinkPtyHost(
   options: NodeLinkPtyHostOptions
 ): NodeLinkPtyHost {
   const logger = options.logger ?? createLogger('node-link-pty');
-  const spawn = options.spawn ?? pty.spawn;
+  const factory = resolveFactory(options);
   const defaultShell = options.defaultShell ?? defaultLoginShell();
   const defaultCwd = options.defaultCwd ?? process.cwd();
   const defaultEnv = options.defaultEnv ?? process.env;
   const streams = new Map<string, ActiveStream>();
+  const opening = new Set<string>();
   let currentCtx: NodeLinkPtyHostContext | undefined;
+  let closed = false;
 
   function sendData(streamId: string, data: string): void {
     if (!currentCtx) return;
@@ -130,7 +162,11 @@ export function createNodeLinkPtyHost(
     );
   }
 
-  function sendError(streamId: string, message: string, retryable: boolean): void {
+  function sendError(
+    streamId: string,
+    message: string,
+    retryable: boolean
+  ): void {
     if (!currentCtx) return;
     currentCtx.send(
       currentCtx.buildEnvelope('pty', 'pty.error', {
@@ -140,71 +176,85 @@ export function createNodeLinkPtyHost(
     );
   }
 
-  function recordScrollback(stream: ActiveStream, chunk: string): void {
-    const chunkBytes = Buffer.byteLength(chunk, 'utf8');
+  function recordScrollback(stream: ActiveStream, chunk: Buffer): void {
     stream.scrollback.push(chunk);
-    stream.scrollbackBytes += chunkBytes;
+    stream.scrollbackBytes += chunk.byteLength;
     while (
       stream.scrollbackBytes > SCROLLBACK_BYTE_LIMIT &&
       stream.scrollback.length > 1
     ) {
       const dropped = stream.scrollback.shift();
-      stream.scrollbackBytes -= dropped
-        ? Buffer.byteLength(dropped, 'utf8')
-        : 0;
+      stream.scrollbackBytes -= dropped?.byteLength ?? 0;
     }
   }
 
-  function attach(streamId: string, input: NodeLinkPtyAttachInput): void {
-    if (streams.has(streamId)) {
+  async function attach(
+    streamId: string,
+    input: NodeLinkPtyAttachInput
+  ): Promise<void> {
+    if (streams.has(streamId) || opening.has(streamId)) {
       logger.warn(`duplicate attach for streamId ${streamId}; ignoring`);
       sendError(streamId, 'stream already attached', false);
       return;
     }
-    const command = asString(input.command) ?? defaultShell;
-    const args = asStringArray(input.args) ?? [];
-    const cols = asPositiveInt(input.cols) ?? DEFAULT_COLS;
-    const rows = asPositiveInt(input.rows) ?? DEFAULT_ROWS;
-    const cwd = asString(input.cwd) ?? defaultCwd;
-    const env = sanitizeEnv(asEnv(input.env) ?? defaultEnv);
-
-    let ptyProcess: IPty;
+    opening.add(streamId);
     try {
-      ptyProcess = spawn(command, args, {
-        name: DEFAULT_NAME,
-        cols,
-        rows,
-        cwd,
-        env,
+      const sessionId = asString(input.sessionId) ?? `relay-stream-${streamId}`;
+      const command = asString(input.command) ?? defaultShell;
+      const args = asStringArray(input.args) ?? [];
+      const cols = asPositiveInt(input.cols) ?? DEFAULT_COLS;
+      const rows = asPositiveInt(input.rows) ?? DEFAULT_ROWS;
+      const cwd = asString(input.cwd) ?? defaultCwd;
+      const env = sanitizeEnv(asEnv(input.env) ?? defaultEnv);
+
+      let attachment: SessionAttachment;
+      try {
+        attachment = await factory.open({
+          sessionId,
+          command,
+          args,
+          cwd,
+          env,
+          cols,
+          rows,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(`pty attach failed (${streamId}): ${message}`);
+        sendError(streamId, `pty attach failed: ${message}`, false);
+        return;
+      }
+
+      if (closed) {
+        await attachment.close('host shutting down');
+        return;
+      }
+
+      const stream: ActiveStream = {
+        streamId,
+        sessionId,
+        attachment,
+        scrollback: [],
+        scrollbackBytes: 0,
+        closing: false,
+      };
+      streams.set(streamId, stream);
+
+      attachment.onData((chunk) => {
+        const live = streams.get(streamId);
+        if (!live || live.attachment !== attachment || live.closing) return;
+        recordScrollback(live, chunk);
+        sendData(streamId, chunk.toString('utf8'));
       });
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger.error(`pty spawn failed (${streamId}): ${message}`);
-      sendError(streamId, `pty spawn failed: ${message}`, false);
-      return;
+      attachment.onExit(({ exitCode, signal }) => {
+        const live = streams.get(streamId);
+        if (!live || live.attachment !== attachment) return;
+        streams.delete(streamId);
+        sendExit(streamId, exitCode ?? 0, signal);
+      });
+    } finally {
+      opening.delete(streamId);
     }
-
-    const stream: ActiveStream = {
-      streamId,
-      ptyProcess,
-      scrollback: [],
-      scrollbackBytes: 0,
-      closing: false,
-    };
-    streams.set(streamId, stream);
-
-    ptyProcess.onData((chunk) => {
-      const live = streams.get(streamId);
-      if (!live || live.ptyProcess !== ptyProcess || live.closing) return;
-      recordScrollback(live, chunk);
-      sendData(streamId, chunk);
-    });
-    ptyProcess.onExit(({ exitCode, signal }) => {
-      const live = streams.get(streamId);
-      if (!live || live.ptyProcess !== ptyProcess) return;
-      streams.delete(streamId);
-      sendExit(streamId, exitCode ?? 0, signal);
-    });
   }
 
   function input(streamId: string, data: unknown): void {
@@ -212,7 +262,7 @@ export function createNodeLinkPtyHost(
     if (!stream) return;
     if (typeof data !== 'string') return;
     try {
-      stream.ptyProcess.write(data);
+      stream.attachment.write(Buffer.from(data, 'utf8'));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logger.warn(`pty input failed (${streamId}): ${message}`);
@@ -227,22 +277,22 @@ export function createNodeLinkPtyHost(
     const r = asPositiveInt(rows);
     if (!c || !r) return;
     try {
-      stream.ptyProcess.resize(c, r);
+      stream.attachment.resize(c, r);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logger.warn(`pty resize failed (${streamId}): ${message}`);
     }
   }
 
-  function detach(streamId: string): void {
+  async function detach(streamId: string): Promise<void> {
     const stream = streams.get(streamId);
     if (!stream) return;
     stream.closing = true;
     try {
-      stream.ptyProcess.kill();
+      await stream.attachment.close('detach');
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      logger.warn(`pty kill failed (${streamId}): ${message}`);
+      logger.warn(`pty detach failed (${streamId}): ${message}`);
       streams.delete(streamId);
       sendExit(streamId, -1);
     }
@@ -255,6 +305,7 @@ export function createNodeLinkPtyHost(
   }
 
   return {
+    mode: factory.mode,
     handle(envelope: RelayNodeEnvelope, ctx: NodeLinkPtyHostContext): void {
       if (envelope.channel !== 'pty') return;
       if (typeof envelope.streamId !== 'string') return;
@@ -262,7 +313,7 @@ export function createNodeLinkPtyHost(
       const streamId = envelope.streamId;
       const payload = payloadRecord(envelope.payload);
       if (envelope.type === 'pty.attach') {
-        attach(streamId, payload as NodeLinkPtyAttachInput);
+        void attach(streamId, payload as NodeLinkPtyAttachInput);
         return;
       }
       if (envelope.type === 'pty.input') {
@@ -274,21 +325,20 @@ export function createNodeLinkPtyHost(
         return;
       }
       if (envelope.type === 'pty.detach') {
-        detach(streamId);
+        void detach(streamId);
         return;
       }
     },
-    closeAll(reason?: string): void {
-      for (const stream of Array.from(streams.values())) {
+    async closeAll(reason?: string): Promise<void> {
+      closed = true;
+      const active = Array.from(streams.values());
+      streams.clear();
+      for (const stream of active) {
         stream.closing = true;
-        if (reason) {
-          sendError(stream.streamId, reason, false);
-        }
+        if (reason) sendError(stream.streamId, reason, false);
         try {
-          stream.ptyProcess.kill();
+          await stream.attachment.close(reason);
         } catch {
-          // onExit will not fire; force terminal envelope and drop the stream.
-          streams.delete(stream.streamId);
           sendExit(stream.streamId, -1);
         }
       }

--- a/server/node-link-pty-host.ts
+++ b/server/node-link-pty-host.ts
@@ -15,7 +15,6 @@ import type { NodeSessionResumeKind } from '../shared/node-manifest.js';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
-const SCROLLBACK_BYTE_LIMIT = 256 * 1024;
 
 export interface NodeLinkPtyAttachInput {
   sessionId?: unknown;
@@ -68,8 +67,13 @@ interface ActiveStream {
   streamId: string;
   sessionId: string;
   attachment: SessionAttachment;
-  scrollback: Buffer[];
-  scrollbackBytes: number;
+  /**
+   * Context captured at attach time so traffic on this stream always
+   * flows back over the link that opened it, even when a hub
+   * reconnect overlaps and `handle()` swaps in a fresh context for
+   * later envelopes (gemini-code-assist, #472 review).
+   */
+  ctx: NodeLinkPtyHostContext;
   closing: boolean;
 }
 
@@ -138,66 +142,57 @@ export function createNodeLinkPtyHost(
   const defaultCwd = options.defaultCwd ?? process.cwd();
   const defaultEnv = options.defaultEnv ?? process.env;
   const streams = new Map<string, ActiveStream>();
-  const opening = new Set<string>();
-  let currentCtx: NodeLinkPtyHostContext | undefined;
+  // Pending attaches need a ctx too — they haven't joined `streams` yet
+  // but already need to be able to send pty.error if open() fails.
+  const opening = new Map<string, NodeLinkPtyHostContext>();
   let closed = false;
 
-  function sendData(streamId: string, data: string): void {
-    if (!currentCtx) return;
-    currentCtx.send(
-      currentCtx.buildEnvelope('pty', 'pty.data', {
-        streamId,
-        payload: { data },
-      })
-    );
+  function send(
+    ctx: NodeLinkPtyHostContext,
+    type: string,
+    streamId: string,
+    extras: Partial<RelayNodeEnvelope> = {}
+  ): void {
+    ctx.send(ctx.buildEnvelope('pty', type, { streamId, ...extras }));
   }
 
-  function sendExit(streamId: string, exitCode: number, signal?: number): void {
-    if (!currentCtx) return;
-    currentCtx.send(
-      currentCtx.buildEnvelope('pty', 'pty.exit', {
-        streamId,
-        payload: { exitCode, signal: signal ?? null },
-      })
-    );
+  function sendData(stream: ActiveStream, data: string): void {
+    send(stream.ctx, 'pty.data', stream.streamId, { payload: { data } });
+  }
+
+  function sendExit(
+    ctx: NodeLinkPtyHostContext,
+    streamId: string,
+    exitCode: number,
+    signal?: number
+  ): void {
+    send(ctx, 'pty.exit', streamId, {
+      payload: { exitCode, signal: signal ?? null },
+    });
   }
 
   function sendError(
+    ctx: NodeLinkPtyHostContext,
     streamId: string,
     message: string,
     retryable: boolean
   ): void {
-    if (!currentCtx) return;
-    currentCtx.send(
-      currentCtx.buildEnvelope('pty', 'pty.error', {
-        streamId,
-        error: { code: 'INTERNAL', message, retryable },
-      })
-    );
-  }
-
-  function recordScrollback(stream: ActiveStream, chunk: Buffer): void {
-    stream.scrollback.push(chunk);
-    stream.scrollbackBytes += chunk.byteLength;
-    while (
-      stream.scrollbackBytes > SCROLLBACK_BYTE_LIMIT &&
-      stream.scrollback.length > 1
-    ) {
-      const dropped = stream.scrollback.shift();
-      stream.scrollbackBytes -= dropped?.byteLength ?? 0;
-    }
+    send(ctx, 'pty.error', streamId, {
+      error: { code: 'INTERNAL', message, retryable },
+    });
   }
 
   async function attach(
+    ctx: NodeLinkPtyHostContext,
     streamId: string,
     input: NodeLinkPtyAttachInput
   ): Promise<void> {
     if (streams.has(streamId) || opening.has(streamId)) {
       logger.warn(`duplicate attach for streamId ${streamId}; ignoring`);
-      sendError(streamId, 'stream already attached', false);
+      sendError(ctx, streamId, 'stream already attached', false);
       return;
     }
-    opening.add(streamId);
+    opening.set(streamId, ctx);
     try {
       const sessionId = asString(input.sessionId) ?? `relay-stream-${streamId}`;
       const command = asString(input.command) ?? defaultShell;
@@ -221,11 +216,13 @@ export function createNodeLinkPtyHost(
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         logger.error(`pty attach failed (${streamId}): ${message}`);
-        sendError(streamId, `pty attach failed: ${message}`, false);
+        sendError(ctx, streamId, `pty attach failed: ${message}`, false);
         return;
       }
 
       if (closed) {
+        // Detach-only close keeps the tmux session alive across the
+        // host's shutdown so a fresh link can resume it.
         await attachment.close('host shutting down');
         return;
       }
@@ -234,8 +231,7 @@ export function createNodeLinkPtyHost(
         streamId,
         sessionId,
         attachment,
-        scrollback: [],
-        scrollbackBytes: 0,
+        ctx,
         closing: false,
       };
       streams.set(streamId, stream);
@@ -243,14 +239,16 @@ export function createNodeLinkPtyHost(
       attachment.onData((chunk) => {
         const live = streams.get(streamId);
         if (!live || live.attachment !== attachment || live.closing) return;
-        recordScrollback(live, chunk);
-        sendData(streamId, chunk.toString('utf8'));
+        // tmux owns scrollback for resumable sessions; raw sessions
+        // have no resume so any local buffer would be discarded
+        // anyway. Forward bytes straight through.
+        sendData(live, chunk.toString('utf8'));
       });
       attachment.onExit(({ exitCode, signal }) => {
         const live = streams.get(streamId);
         if (!live || live.attachment !== attachment) return;
         streams.delete(streamId);
-        sendExit(streamId, exitCode ?? 0, signal);
+        sendExit(live.ctx, streamId, exitCode ?? 0, signal);
       });
     } finally {
       opening.delete(streamId);
@@ -266,7 +264,7 @@ export function createNodeLinkPtyHost(
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       logger.warn(`pty input failed (${streamId}): ${message}`);
-      sendError(streamId, `pty input failed: ${message}`, true);
+      sendError(stream.ctx, streamId, `pty input failed: ${message}`, true);
     }
   }
 
@@ -294,7 +292,7 @@ export function createNodeLinkPtyHost(
       const message = error instanceof Error ? error.message : String(error);
       logger.warn(`pty detach failed (${streamId}): ${message}`);
       streams.delete(streamId);
-      sendExit(streamId, -1);
+      sendExit(stream.ctx, streamId, -1);
     }
   }
 
@@ -309,11 +307,10 @@ export function createNodeLinkPtyHost(
     handle(envelope: RelayNodeEnvelope, ctx: NodeLinkPtyHostContext): void {
       if (envelope.channel !== 'pty') return;
       if (typeof envelope.streamId !== 'string') return;
-      currentCtx = ctx;
       const streamId = envelope.streamId;
       const payload = payloadRecord(envelope.payload);
       if (envelope.type === 'pty.attach') {
-        void attach(streamId, payload as NodeLinkPtyAttachInput);
+        void attach(ctx, streamId, payload as NodeLinkPtyAttachInput);
         return;
       }
       if (envelope.type === 'pty.input') {
@@ -335,11 +332,11 @@ export function createNodeLinkPtyHost(
       streams.clear();
       for (const stream of active) {
         stream.closing = true;
-        if (reason) sendError(stream.streamId, reason, false);
+        if (reason) sendError(stream.ctx, stream.streamId, reason, false);
         try {
           await stream.attachment.close(reason);
         } catch {
-          sendExit(stream.streamId, -1);
+          sendExit(stream.ctx, stream.streamId, -1);
         }
       }
     },

--- a/server/node-manifest.ts
+++ b/server/node-manifest.ts
@@ -147,14 +147,19 @@ function getNodeCapabilities(
   // live in `server/features/frameworks.ts` and are layered on top via
   // `decorateManifestWithFrameworks`. Core never references framework
   // ids directly — neither in code nor in this comment.
+  const tmux = probeCommand('tmux', 'tmux', 'tmux', env);
   return {
-    tmux: probeCommand('tmux', 'tmux', 'tmux', env),
+    tmux,
     git: probeCommand('git', 'Git', 'git', env),
     clipboard: probeClipboard(env, platform),
     browserAutomation: probeBrowserAutomation(),
     githubCli: probeCommand('githubCli', 'GitHub CLI', 'gh', env),
     tailscale: probeCommand('tailscale', 'Tailscale CLI', 'tailscale', env),
     ssh: probeCommand('ssh', 'SSH client', 'ssh', env, { versionArgs: ['-V'] }),
+    // #467: hosts with tmux get attach-by-name resume; others get a
+    // raw shell that dies on detach. #469 will introduce
+    // 'canonical-emulator' for server-side terminal state.
+    sessionResume: tmux.status === 'available' ? 'tmux' : 'none',
     agents: {},
   };
 }

--- a/server/session-attachment.ts
+++ b/server/session-attachment.ts
@@ -1,0 +1,435 @@
+import pty from 'node-pty';
+import type { IPty, IPtyForkOptions } from 'node-pty';
+import { Buffer } from 'node:buffer';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import type { Logger } from './logger.js';
+import { createLogger } from './logger.js';
+
+/**
+ * Stable wire interface between `node-link-pty-host.ts` and concrete
+ * session-attach implementations. Phase 1 (#467) ships `TmuxAttachment`
+ * and a raw fallback; phase 2 (#469) will plug a server-side canonical
+ * terminal in beside, not under, the tmux feature. No implementation
+ * details (tmux verbs, node-pty handles, socket names) leak past this
+ * boundary.
+ */
+export type SessionAttachmentStatus = 'attached' | 'detached' | 'closed';
+
+export type SessionAttachmentMode = 'tmux' | 'raw';
+
+export interface SessionAttachmentSpawnOptions {
+  sessionId: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  cols: number;
+  rows: number;
+}
+
+export interface SessionAttachmentDisposable {
+  dispose(): void;
+}
+
+export interface SessionAttachment {
+  readonly sessionId: string;
+  readonly mode: SessionAttachmentMode;
+  onData(handler: (bytes: Buffer) => void): SessionAttachmentDisposable;
+  onExit(
+    handler: (event: { exitCode: number; signal?: number }) => void
+  ): SessionAttachmentDisposable;
+  write(bytes: Buffer): void;
+  resize(cols: number, rows: number): void;
+  close(reason?: string): Promise<void>;
+  status(): SessionAttachmentStatus;
+}
+
+export interface SessionAttachmentFactory {
+  readonly mode: SessionAttachmentMode;
+  open(options: SessionAttachmentSpawnOptions): Promise<SessionAttachment>;
+}
+
+type PtySpawn = (
+  command: string,
+  args: string[],
+  options: IPtyForkOptions
+) => IPty;
+
+const DEFAULT_TERM = 'xterm-256color';
+
+function wrapPty(
+  sessionId: string,
+  mode: SessionAttachmentMode,
+  process: IPty
+): SessionAttachment {
+  let state: SessionAttachmentStatus = 'attached';
+  process.onExit(() => {
+    state = 'closed';
+  });
+  return {
+    sessionId,
+    mode,
+    onData(handler) {
+      const disposable = process.onData((chunk) => {
+        if (state === 'closed') return;
+        handler(Buffer.from(chunk, 'utf8'));
+      });
+      return { dispose: () => disposable.dispose() };
+    },
+    onExit(handler) {
+      const disposable = process.onExit(({ exitCode, signal }) => {
+        const event: { exitCode: number; signal?: number } = {
+          exitCode: exitCode ?? 0,
+        };
+        if (signal !== undefined && signal !== null) event.signal = signal;
+        handler(event);
+      });
+      return { dispose: () => disposable.dispose() };
+    },
+    write(bytes) {
+      if (state === 'closed') return;
+      process.write(bytes.toString('utf8'));
+    },
+    resize(cols, rows) {
+      if (state === 'closed') return;
+      if (!Number.isInteger(cols) || cols <= 0) return;
+      if (!Number.isInteger(rows) || rows <= 0) return;
+      try {
+        process.resize(cols, rows);
+      } catch {
+        // Resize on a dying pty can throw; treat as a no-op.
+      }
+    },
+    async close() {
+      if (state === 'closed') return;
+      state = 'closed';
+      try {
+        process.kill();
+      } catch {
+        // already gone
+      }
+    },
+    status() {
+      return state;
+    },
+  };
+}
+
+export interface RawAttachmentFactoryDeps {
+  spawn?: PtySpawn;
+  logger?: Logger;
+}
+
+/**
+ * Raw shell. No resume semantics: browser reload kills the shell. Used
+ * on hosts that advertise `sessionResume: 'none'`.
+ */
+export function createRawAttachmentFactory(
+  deps: RawAttachmentFactoryDeps = {}
+): SessionAttachmentFactory {
+  const spawn = deps.spawn ?? (pty.spawn as unknown as PtySpawn);
+  return {
+    mode: 'raw',
+    async open(options) {
+      const proc = spawn(options.command, options.args, {
+        name: DEFAULT_TERM,
+        cols: options.cols,
+        rows: options.rows,
+        cwd: options.cwd,
+        env: options.env,
+      });
+      return wrapPty(options.sessionId, 'raw', proc);
+    },
+  };
+}
+
+// Tmux config is invisible: no status bar, no prefix key, no mouse, zero
+// escape-time. Operators never see the tmux UI; tmux is an
+// attach-by-name primitive only.
+const TMUX_CONF_BODY = [
+  'set-option -g status off',
+  'unbind-key -a',
+  'set-option -g mouse off',
+  'set-option -g escape-time 0',
+  `set-option -g default-terminal "${DEFAULT_TERM}"`,
+  'set-option -g history-limit 5000',
+  'set-option -g destroy-unattached off',
+].join('\n');
+
+function writeTmuxConfig(dir: string): string {
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const file = path.join(dir, 'relay.tmux.conf');
+  fs.writeFileSync(file, `${TMUX_CONF_BODY}\n`, { mode: 0o600 });
+  return file;
+}
+
+function sanitizeTmuxName(sessionId: string): string {
+  // tmux session names cannot contain ':' or '.'. Whitespace also
+  // breaks `-t target` parsing.
+  return `relay-${sessionId.replace(/[:.\s]/g, '_')}`;
+}
+
+export interface TmuxAttachmentFactoryDeps {
+  spawn?: PtySpawn;
+  tmuxPath?: string;
+  socketName?: string;
+  /**
+   * Directory for the baked-in tmux.conf. Tests can override to a
+   * scratch dir.
+   */
+  configDir?: string;
+  logger?: Logger;
+  /**
+   * Hook to ensure the tmux session exists. Defaults to spawnSync of
+   * `tmux new-session`. Tests can stub this without invoking real tmux.
+   */
+  ensureSession?: (params: {
+    tmuxPath: string;
+    socketName: string;
+    configPath: string;
+    target: string;
+    options: SessionAttachmentSpawnOptions;
+  }) => void;
+}
+
+/**
+ * tmux-backed attachment. Browser reload reattaches to the same shell:
+ *
+ *   first attach  -> ensure session via `tmux new-session -d -s <target>`
+ *                    then `attach-session -t <target>` over node-pty
+ *   second attach -> session already exists, just `attach-session`
+ *
+ * `close()` kills the local attach client. The tmux session persists
+ * for the next attach.
+ */
+export function createTmuxAttachmentFactory(
+  deps: TmuxAttachmentFactoryDeps = {}
+): SessionAttachmentFactory {
+  const logger = deps.logger ?? createLogger('session-attachment-tmux');
+  const spawn = deps.spawn ?? (pty.spawn as unknown as PtySpawn);
+  const tmuxPath = deps.tmuxPath ?? 'tmux';
+  const socketName = deps.socketName ?? 'relay';
+  const configDir = deps.configDir ?? path.join(os.tmpdir(), 'relay-tmux');
+  let configPath: string | undefined;
+
+  function ensureConfig(): string {
+    if (!configPath) configPath = writeTmuxConfig(configDir);
+    return configPath;
+  }
+
+  const ensureSession =
+    deps.ensureSession ??
+    (({
+      tmuxPath: bin,
+      socketName: socket,
+      configPath: cfg,
+      target,
+      options,
+    }) => {
+      const env = options.env;
+      const has = spawnSync(
+        bin,
+        ['-L', socket, '-f', cfg, 'has-session', '-t', target],
+        { env, encoding: 'utf8', timeout: 2_000 }
+      );
+      if (has.status === 0) return;
+
+      const result = spawnSync(
+        bin,
+        [
+          '-L',
+          socket,
+          '-f',
+          cfg,
+          'new-session',
+          '-d',
+          '-s',
+          target,
+          '-x',
+          String(options.cols),
+          '-y',
+          String(options.rows),
+          options.command,
+          ...options.args,
+        ],
+        {
+          cwd: options.cwd,
+          env,
+          encoding: 'utf8',
+          timeout: 5_000,
+        }
+      );
+      if (result.status !== 0) {
+        const message =
+          `${result.stderr || result.stdout || 'unknown error'}`.trim();
+        // Race: another caller created the session between has-session
+        // and new-session. Accept if it exists now.
+        if (!message.includes('duplicate session')) {
+          const recheck = spawnSync(
+            bin,
+            ['-L', socket, '-f', cfg, 'has-session', '-t', target],
+            { env, encoding: 'utf8', timeout: 2_000 }
+          );
+          if (recheck.status !== 0) {
+            throw new Error(`tmux new-session failed: ${message}`);
+          }
+        }
+      }
+    });
+
+  return {
+    mode: 'tmux',
+    async open(options) {
+      const cfg = ensureConfig();
+      const target = sanitizeTmuxName(options.sessionId);
+      logger.debug?.(
+        `tmux attach for session ${options.sessionId} -> ${target}`
+      );
+      ensureSession({
+        tmuxPath,
+        socketName,
+        configPath: cfg,
+        target,
+        options,
+      });
+      const attachArgs = [
+        '-u',
+        '-L',
+        socketName,
+        '-f',
+        cfg,
+        'attach-session',
+        '-t',
+        target,
+      ];
+      const proc = spawn(tmuxPath, attachArgs, {
+        name: DEFAULT_TERM,
+        cols: options.cols,
+        rows: options.rows,
+        cwd: options.cwd,
+        env: options.env,
+      });
+      return wrapPty(options.sessionId, 'tmux', proc);
+    },
+  };
+}
+
+export interface MockAttachmentRecord {
+  written: Buffer[];
+  resizes: Array<{ cols: number; rows: number }>;
+  closed: boolean;
+  closeReason?: string;
+}
+
+export interface MockAttachmentControl {
+  emit(bytes: Buffer | string, index?: number): void;
+  exit(event?: { exitCode: number; signal?: number }, index?: number): void;
+  attachments: SessionAttachment[];
+  records: MockAttachmentRecord[];
+}
+
+export interface MockAttachmentFactory
+  extends SessionAttachmentFactory, MockAttachmentControl {}
+
+/**
+ * Test attachment factory. Replays scripted bytes, captures every
+ * write/resize/close. Never spawns a real process or tmux.
+ */
+export function createMockAttachmentFactory(
+  initial: {
+    data?: Array<Buffer | string>;
+    exit?: { exitCode: number; signal?: number };
+  } = {}
+): MockAttachmentFactory {
+  type DataHandler = (bytes: Buffer) => void;
+  type ExitHandler = (event: { exitCode: number; signal?: number }) => void;
+  const attachments: SessionAttachment[] = [];
+  const records: MockAttachmentRecord[] = [];
+  const dataHandlers: DataHandler[][] = [];
+  const exitHandlers: ExitHandler[][] = [];
+
+  function emit(bytes: Buffer | string, index?: number): void {
+    const target = index ?? dataHandlers.length - 1;
+    if (target < 0) return;
+    const buf = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes, 'utf8');
+    for (const handler of (dataHandlers[target] ?? []).slice()) handler(buf);
+  }
+
+  function exit(
+    event: { exitCode: number; signal?: number } = { exitCode: 0 },
+    index?: number
+  ): void {
+    const target = index ?? exitHandlers.length - 1;
+    if (target < 0) return;
+    for (const handler of (exitHandlers[target] ?? []).slice()) handler(event);
+  }
+
+  return {
+    mode: 'tmux',
+    attachments,
+    records,
+    emit,
+    exit,
+    async open(spawnOpts) {
+      const idx = attachments.length;
+      const data: DataHandler[] = [];
+      const exits: ExitHandler[] = [];
+      dataHandlers.push(data);
+      exitHandlers.push(exits);
+      const record: MockAttachmentRecord = {
+        written: [],
+        resizes: [],
+        closed: false,
+      };
+      records.push(record);
+      let state: SessionAttachmentStatus = 'attached';
+      const attachment: SessionAttachment = {
+        sessionId: spawnOpts.sessionId,
+        mode: 'tmux',
+        onData(handler) {
+          data.push(handler);
+          return {
+            dispose: () => {
+              const at = data.indexOf(handler);
+              if (at >= 0) data.splice(at, 1);
+            },
+          };
+        },
+        onExit(handler) {
+          exits.push(handler);
+          return {
+            dispose: () => {
+              const at = exits.indexOf(handler);
+              if (at >= 0) exits.splice(at, 1);
+            },
+          };
+        },
+        write(bytes) {
+          if (state === 'closed') return;
+          record.written.push(Buffer.from(bytes));
+        },
+        resize(cols, rows) {
+          if (state === 'closed') return;
+          record.resizes.push({ cols, rows });
+        },
+        async close(reason) {
+          if (state === 'closed') return;
+          state = 'closed';
+          record.closed = true;
+          if (reason !== undefined) record.closeReason = reason;
+          for (const handler of exits.slice()) handler({ exitCode: 0 });
+        },
+        status() {
+          return state;
+        },
+      };
+      attachments.push(attachment);
+      if (initial.data) for (const chunk of initial.data) emit(chunk, idx);
+      if (initial.exit) exit(initial.exit, idx);
+      return attachment;
+    },
+  };
+}

--- a/server/session-attachment.ts
+++ b/server/session-attachment.ts
@@ -4,9 +4,12 @@ import { Buffer } from 'node:buffer';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import type { Logger } from './logger.js';
 import { createLogger } from './logger.js';
+
+const execFileAsync = promisify(execFile);
 
 /**
  * Stable wire interface between `node-link-pty-host.ts` and concrete
@@ -34,6 +37,16 @@ export interface SessionAttachmentDisposable {
   dispose(): void;
 }
 
+/**
+ * Magic `close()` reason that tells the tmux backend to destroy the
+ * persistent session, not just the local attach client. `node-link-pty-
+ * host` passes this on `closeAll('host shutting down')`-style paths
+ * where the caller has decided the session is no longer wanted; normal
+ * detach uses any other reason (or `undefined`) to keep the tmux
+ * session alive for the next attach.
+ */
+export const SESSION_ATTACHMENT_KILL_REASON = '__relay_kill_session__';
+
 export interface SessionAttachment {
   readonly sessionId: string;
   readonly mode: SessionAttachmentMode;
@@ -43,6 +56,14 @@ export interface SessionAttachment {
   ): SessionAttachmentDisposable;
   write(bytes: Buffer): void;
   resize(cols: number, rows: number): void;
+  /**
+   * Default: detach the local client only (tmux backend keeps the
+   * persistent session alive for the next attach).
+   *
+   * Pass `SESSION_ATTACHMENT_KILL_REASON` to fully destroy the
+   * persistent session — used when the caller has explicit intent to
+   * end the session, not just disconnect a browser.
+   */
   close(reason?: string): Promise<void>;
   status(): SessionAttachmentStatus;
 }
@@ -63,7 +84,10 @@ const DEFAULT_TERM = 'xterm-256color';
 function wrapPty(
   sessionId: string,
   mode: SessionAttachmentMode,
-  process: IPty
+  process: IPty,
+  hooks: {
+    onClose?: (reason: string | undefined) => Promise<void> | void;
+  } = {}
 ): SessionAttachment {
   let state: SessionAttachmentStatus = 'attached';
   process.onExit(() => {
@@ -103,7 +127,7 @@ function wrapPty(
         // Resize on a dying pty can throw; treat as a no-op.
       }
     },
-    async close() {
+    async close(reason) {
       if (state === 'closed') return;
       state = 'closed';
       try {
@@ -111,6 +135,7 @@ function wrapPty(
       } catch {
         // already gone
       }
+      if (hooks.onClose) await hooks.onClose(reason);
     },
     status() {
       return state;
@@ -159,17 +184,37 @@ const TMUX_CONF_BODY = [
   'set-option -g destroy-unattached off',
 ].join('\n');
 
+function defaultUserConfigDir(): string {
+  // XDG-style location under the user's HOME, never world-readable.
+  // os.tmpdir() is shared by every uid on the box (Copilot review,
+  // #472) — a malicious local user could pre-create the directory
+  // with permissive perms and race the conf write, and tmux configs
+  // can shell out via `run-shell`.
+  const xdg = process.env['XDG_CONFIG_HOME'];
+  const base =
+    xdg && xdg.startsWith('/') ? xdg : path.join(os.homedir(), '.config');
+  return path.join(base, 'relay-ide', 'tmux');
+}
+
 function writeTmuxConfig(dir: string): string {
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  // Tighten perms even if the directory pre-existed with a wider mode.
+  try {
+    fs.chmodSync(dir, 0o700);
+  } catch {
+    // Best-effort: chmod may fail on weird filesystems (e.g. SMB).
+  }
   const file = path.join(dir, 'relay.tmux.conf');
   fs.writeFileSync(file, `${TMUX_CONF_BODY}\n`, { mode: 0o600 });
   return file;
 }
 
 function sanitizeTmuxName(sessionId: string): string {
-  // tmux session names cannot contain ':' or '.'. Whitespace also
-  // breaks `-t target` parsing.
-  return `relay-${sessionId.replace(/[:.\s]/g, '_')}`;
+  // Whitelist alphanumeric + underscore + hyphen. Tmux session names
+  // also reject ':' and '.' but other characters ([, ], whitespace,
+  // shell metacharacters) cause downstream parsing/quoting bugs that
+  // are not worth defending against case-by-case.
+  return `relay-${sessionId.replace(/[^a-zA-Z0-9_-]/g, '_')}`;
 }
 
 export interface TmuxAttachmentFactoryDeps {
@@ -177,14 +222,15 @@ export interface TmuxAttachmentFactoryDeps {
   tmuxPath?: string;
   socketName?: string;
   /**
-   * Directory for the baked-in tmux.conf. Tests can override to a
-   * scratch dir.
+   * Directory for the baked-in tmux.conf. Defaults to
+   * `$XDG_CONFIG_HOME/relay-ide/tmux` (or `~/.config/relay-ide/tmux`).
+   * Tests can override to a scratch dir.
    */
   configDir?: string;
   logger?: Logger;
   /**
-   * Hook to ensure the tmux session exists. Defaults to spawnSync of
-   * `tmux new-session`. Tests can stub this without invoking real tmux.
+   * Hook to ensure the tmux session exists. Defaults to async execFile
+   * against `tmux`. Tests can stub this without invoking real tmux.
    */
   ensureSession?: (params: {
     tmuxPath: string;
@@ -192,7 +238,19 @@ export interface TmuxAttachmentFactoryDeps {
     configPath: string;
     target: string;
     options: SessionAttachmentSpawnOptions;
-  }) => void;
+  }) => Promise<void> | void;
+  /**
+   * Hook to kill a tmux session when `close()` is invoked with
+   * `SESSION_ATTACHMENT_KILL_REASON`. Defaults to async execFile of
+   * `tmux kill-session -t <target>`. Tests can stub this.
+   */
+  killSession?: (params: {
+    tmuxPath: string;
+    socketName: string;
+    configPath: string;
+    target: string;
+    env: NodeJS.ProcessEnv;
+  }) => Promise<void> | void;
 }
 
 /**
@@ -202,8 +260,9 @@ export interface TmuxAttachmentFactoryDeps {
  *                    then `attach-session -t <target>` over node-pty
  *   second attach -> session already exists, just `attach-session`
  *
- * `close()` kills the local attach client. The tmux session persists
- * for the next attach.
+ * `close()` kills the local attach client; the tmux session persists
+ * for the next attach. To fully destroy the persistent session pass
+ * `SESSION_ATTACHMENT_KILL_REASON` as the reason.
  */
 export function createTmuxAttachmentFactory(
   deps: TmuxAttachmentFactoryDeps = {}
@@ -212,7 +271,7 @@ export function createTmuxAttachmentFactory(
   const spawn = deps.spawn ?? (pty.spawn as unknown as PtySpawn);
   const tmuxPath = deps.tmuxPath ?? 'tmux';
   const socketName = deps.socketName ?? 'relay';
-  const configDir = deps.configDir ?? path.join(os.tmpdir(), 'relay-tmux');
+  const configDir = deps.configDir ?? defaultUserConfigDir();
   let configPath: string | undefined;
 
   function ensureConfig(): string {
@@ -222,7 +281,7 @@ export function createTmuxAttachmentFactory(
 
   const ensureSession =
     deps.ensureSession ??
-    (({
+    (async ({
       tmuxPath: bin,
       socketName: socket,
       configPath: cfg,
@@ -230,53 +289,74 @@ export function createTmuxAttachmentFactory(
       options,
     }) => {
       const env = options.env;
-      const has = spawnSync(
-        bin,
-        ['-L', socket, '-f', cfg, 'has-session', '-t', target],
-        { env, encoding: 'utf8', timeout: 2_000 }
-      );
-      if (has.status === 0) return;
+      try {
+        await execFileAsync(
+          bin,
+          ['-L', socket, '-f', cfg, 'has-session', '-t', target],
+          { env, timeout: 2_000 }
+        );
+        return;
+      } catch {
+        // not present — fall through to new-session
+      }
 
-      const result = spawnSync(
-        bin,
-        [
-          '-L',
-          socket,
-          '-f',
-          cfg,
-          'new-session',
-          '-d',
-          '-s',
-          target,
-          '-x',
-          String(options.cols),
-          '-y',
-          String(options.rows),
-          options.command,
-          ...options.args,
-        ],
-        {
-          cwd: options.cwd,
-          env,
-          encoding: 'utf8',
-          timeout: 5_000,
-        }
-      );
-      if (result.status !== 0) {
-        const message =
-          `${result.stderr || result.stdout || 'unknown error'}`.trim();
-        // Race: another caller created the session between has-session
-        // and new-session. Accept if it exists now.
-        if (!message.includes('duplicate session')) {
-          const recheck = spawnSync(
+      try {
+        await execFileAsync(
+          bin,
+          [
+            '-L',
+            socket,
+            '-f',
+            cfg,
+            'new-session',
+            '-d',
+            '-s',
+            target,
+            '-x',
+            String(options.cols),
+            '-y',
+            String(options.rows),
+            options.command,
+            ...options.args,
+          ],
+          { cwd: options.cwd, env, timeout: 5_000 }
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        // Race: another caller may have created the session between
+        // has-session and new-session.
+        if (message.includes('duplicate session')) return;
+        try {
+          await execFileAsync(
             bin,
             ['-L', socket, '-f', cfg, 'has-session', '-t', target],
-            { env, encoding: 'utf8', timeout: 2_000 }
+            { env, timeout: 2_000 }
           );
-          if (recheck.status !== 0) {
-            throw new Error(`tmux new-session failed: ${message}`);
-          }
+          return;
+        } catch {
+          throw new Error(`tmux new-session failed: ${message}`);
         }
+      }
+    });
+
+  const killSession =
+    deps.killSession ??
+    (async ({
+      tmuxPath: bin,
+      socketName: socket,
+      configPath: cfg,
+      target,
+      env,
+    }) => {
+      try {
+        await execFileAsync(
+          bin,
+          ['-L', socket, '-f', cfg, 'kill-session', '-t', target],
+          { env, timeout: 2_000 }
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn?.(`tmux kill-session failed for ${target}: ${message}`);
       }
     });
 
@@ -288,7 +368,7 @@ export function createTmuxAttachmentFactory(
       logger.debug?.(
         `tmux attach for session ${options.sessionId} -> ${target}`
       );
-      ensureSession({
+      await ensureSession({
         tmuxPath,
         socketName,
         configPath: cfg,
@@ -312,7 +392,18 @@ export function createTmuxAttachmentFactory(
         cwd: options.cwd,
         env: options.env,
       });
-      return wrapPty(options.sessionId, 'tmux', proc);
+      return wrapPty(options.sessionId, 'tmux', proc, {
+        onClose: async (reason) => {
+          if (reason !== SESSION_ATTACHMENT_KILL_REASON) return;
+          await killSession({
+            tmuxPath,
+            socketName,
+            configPath: cfg,
+            target,
+            env: options.env,
+          });
+        },
+      });
     },
   };
 }
@@ -336,7 +427,10 @@ export interface MockAttachmentFactory
 
 /**
  * Test attachment factory. Replays scripted bytes, captures every
- * write/resize/close. Never spawns a real process or tmux.
+ * write/resize/close. Never spawns a real process or tmux. Scripted
+ * data is buffered until the first onData listener registers so the
+ * common "await open() then attachment.onData(...)" pattern observes
+ * the replay (Copilot review, #472).
  */
 export function createMockAttachmentFactory(
   initial: {
@@ -350,12 +444,20 @@ export function createMockAttachmentFactory(
   const records: MockAttachmentRecord[] = [];
   const dataHandlers: DataHandler[][] = [];
   const exitHandlers: ExitHandler[][] = [];
+  const pendingData: Buffer[][] = [];
+  const pendingExit: Array<{ exitCode: number; signal?: number } | undefined> =
+    [];
 
   function emit(bytes: Buffer | string, index?: number): void {
     const target = index ?? dataHandlers.length - 1;
     if (target < 0) return;
     const buf = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes, 'utf8');
-    for (const handler of (dataHandlers[target] ?? []).slice()) handler(buf);
+    const handlers = dataHandlers[target] ?? [];
+    if (handlers.length === 0) {
+      (pendingData[target] ??= []).push(buf);
+      return;
+    }
+    for (const handler of handlers.slice()) handler(buf);
   }
 
   function exit(
@@ -364,7 +466,12 @@ export function createMockAttachmentFactory(
   ): void {
     const target = index ?? exitHandlers.length - 1;
     if (target < 0) return;
-    for (const handler of (exitHandlers[target] ?? []).slice()) handler(event);
+    const handlers = exitHandlers[target] ?? [];
+    if (handlers.length === 0) {
+      pendingExit[target] = event;
+      return;
+    }
+    for (const handler of handlers.slice()) handler(event);
   }
 
   return {
@@ -379,6 +486,8 @@ export function createMockAttachmentFactory(
       const exits: ExitHandler[] = [];
       dataHandlers.push(data);
       exitHandlers.push(exits);
+      pendingData.push([]);
+      pendingExit.push(undefined);
       const record: MockAttachmentRecord = {
         written: [],
         resizes: [],
@@ -391,6 +500,11 @@ export function createMockAttachmentFactory(
         mode: 'tmux',
         onData(handler) {
           data.push(handler);
+          const buffered = pendingData[idx] ?? [];
+          if (buffered.length > 0) {
+            pendingData[idx] = [];
+            for (const chunk of buffered) handler(chunk);
+          }
           return {
             dispose: () => {
               const at = data.indexOf(handler);
@@ -400,6 +514,11 @@ export function createMockAttachmentFactory(
         },
         onExit(handler) {
           exits.push(handler);
+          const pending = pendingExit[idx];
+          if (pending) {
+            pendingExit[idx] = undefined;
+            handler(pending);
+          }
           return {
             dispose: () => {
               const at = exits.indexOf(handler);

--- a/shared/node-manifest.ts
+++ b/shared/node-manifest.ts
@@ -59,6 +59,16 @@ export interface NodeServiceManager {
   caveats: string[];
 }
 
+/**
+ * How the node persists a PTY across detach. Browsers reload, links
+ * flap; tmux-backed hosts can reattach to the same shell. Hosts without
+ * tmux advertise 'none' and the frontend hides the resumable badge.
+ *
+ * 'canonical-emulator' is reserved for #469 (server-side canonical
+ * terminal). Phase 1 (#467) emits only 'tmux' or 'none'.
+ */
+export type NodeSessionResumeKind = 'tmux' | 'canonical-emulator' | 'none';
+
 export interface NodeCapabilities {
   tmux: NodeCapabilityProbe;
   git: NodeCapabilityProbe;
@@ -67,6 +77,12 @@ export interface NodeCapabilities {
   githubCli: NodeCapabilityProbe;
   tailscale: NodeCapabilityProbe;
   ssh: NodeCapabilityProbe;
+  /**
+   * #467: optional on the wire so pre-#467 manifests still validate.
+   * The server probe always populates it; consumers should treat
+   * `undefined` as 'none'.
+   */
+  sessionResume?: NodeSessionResumeKind;
   agents: Record<string, NodeCapabilityProbe>;
 }
 
@@ -204,10 +220,22 @@ function isNodeServiceManager(value: unknown): value is NodeServiceManager {
   );
 }
 
+function isSessionResumeKind(value: unknown): value is NodeSessionResumeKind {
+  return value === 'tmux' || value === 'canonical-emulator' || value === 'none';
+}
+
 function isNodeCapabilities(value: unknown): value is NodeCapabilities {
   if (!isRecord(value)) return false;
   for (const key of requiredCapabilityKeys) {
     if (!isNodeCapabilityProbe(value[key])) return false;
+  }
+  // sessionResume was added in #467. Pre-#467 nodes did not publish it;
+  // accept the field's absence and treat as 'none' at the call site.
+  if (
+    value['sessionResume'] !== undefined &&
+    !isSessionResumeKind(value['sessionResume'])
+  ) {
+    return false;
   }
 
   const agents = value['agents'];

--- a/shared/relay-node-protocol.ts
+++ b/shared/relay-node-protocol.ts
@@ -74,6 +74,13 @@ export type HubNodeCoreCapability =
   | 'ssh'
   | 'tailscale';
 
+/**
+ * Mirrors `NodeSessionResumeKind` from `shared/node-manifest.ts` but
+ * lives on the hub-facing summary so frontend code can read it
+ * without depending on the full manifest type.
+ */
+export type HubNodeSessionResumeKind = 'tmux' | 'canonical-emulator' | 'none';
+
 export interface HubNodeConnectionSummary {
   route: 'reverse-link' | 'local' | 'unknown';
   status: string;
@@ -99,6 +106,12 @@ export interface NodeCapabilityManifestSummary {
   agents: Record<string, NodeCapabilityStatus>;
   serviceManager: string;
   wsl: boolean;
+  /**
+   * #467: how the node persists a PTY across detach. Optional on the
+   * wire — pre-#467 nodes do not publish it. Frontend treats absence
+   * as 'none'.
+   */
+  sessionResume?: HubNodeSessionResumeKind;
 }
 
 export interface HubNodeSummary {

--- a/test/components/TerminalNodePicker.test.ts
+++ b/test/components/TerminalNodePicker.test.ts
@@ -35,6 +35,7 @@ function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
       agents: { claude: 'available' },
       serviceManager: 'launchd',
       wsl: false,
+      sessionResume: 'tmux',
     },
     createdAt: '2026-01-02T03:00:00.000Z',
     pairedAt: '2026-01-02T03:00:00.000Z',
@@ -121,6 +122,46 @@ describe('TerminalNodePicker buildChoices', () => {
       disabled: true,
       disabledReason: 'protocol incompatible',
     });
+  });
+
+  it('marks nodes with sessionResume = tmux as resumable', () => {
+    const choices = buildChoices([
+      node({ nodeId: 'tmux', displayName: 'tmux', status: 'online' }),
+    ]);
+    expect(choices[1]?.resumable).toBe(true);
+    expect(choices[0]?.resumable).toBe(false);
+  });
+
+  it('marks sessionResume = none as not resumable', () => {
+    const choices = buildChoices([
+      node({
+        nodeId: 'none',
+        displayName: 'none',
+        status: 'online',
+        capabilities: {
+          ...node().capabilities,
+          sessionResume: 'none',
+        },
+      }),
+    ]);
+    expect(choices[1]?.resumable).toBe(false);
+  });
+
+  it('treats missing sessionResume (pre-#467 nodes) as not resumable', () => {
+    const base = node();
+    const caps: typeof base.capabilities & {
+      sessionResume?: unknown;
+    } = { ...base.capabilities };
+    delete caps.sessionResume;
+    const choices = buildChoices([
+      {
+        ...base,
+        nodeId: 'legacy',
+        displayName: 'legacy',
+        capabilities: caps,
+      },
+    ]);
+    expect(choices[1]?.resumable).toBe(false);
   });
 
   it('disables nodes without tmux capability even when online', () => {

--- a/test/node-link-pty-host.test.ts
+++ b/test/node-link-pty-host.test.ts
@@ -5,74 +5,21 @@ import path from 'node:path';
 import express from 'express';
 import type { WebSocket } from 'ws';
 import { afterEach, describe, expect, it } from 'vitest';
-import type { IPty, IPtyForkOptions } from 'node-pty';
 import { createHubNodeRegistry } from '../server/hub-node-registry.js';
 import { createHubNodeLinkManager } from '../server/hub-node-link.js';
 import { setupWebSocket } from '../server/ws.js';
 import { createNodeLinkClient } from '../server/node-link-client.js';
 import { createNodeLinkPtyHost } from '../server/node-link-pty-host.js';
+import {
+  createMockAttachmentFactory,
+  type MockAttachmentFactory,
+} from '../server/session-attachment.js';
 import type { NodeManifest } from '../shared/node-manifest.js';
 import {
   RELAY_NODE_LINK_PROTOCOL,
   RELAY_NODE_LINK_PROTOCOL_VERSION,
   type RelayNodeEnvelope,
 } from '../shared/relay-node-protocol.js';
-
-type DataHandler = (chunk: string) => void;
-type ExitHandler = (event: { exitCode: number; signal?: number }) => void;
-
-class FakePty {
-  cols: number;
-  rows: number;
-  written: string[] = [];
-  killed = false;
-  private dataHandlers: DataHandler[] = [];
-  private exitHandlers: ExitHandler[] = [];
-
-  constructor(cols: number, rows: number) {
-    this.cols = cols;
-    this.rows = rows;
-  }
-
-  onData(handler: DataHandler): { dispose: () => void } {
-    this.dataHandlers.push(handler);
-    return {
-      dispose: () => {
-        this.dataHandlers = this.dataHandlers.filter((h) => h !== handler);
-      },
-    };
-  }
-
-  onExit(handler: ExitHandler): { dispose: () => void } {
-    this.exitHandlers.push(handler);
-    return {
-      dispose: () => {
-        this.exitHandlers = this.exitHandlers.filter((h) => h !== handler);
-      },
-    };
-  }
-
-  write(data: string): void {
-    this.written.push(data);
-  }
-
-  resize(cols: number, rows: number): void {
-    this.cols = cols;
-    this.rows = rows;
-  }
-
-  kill(): void {
-    this.killed = true;
-  }
-
-  emitData(chunk: string): void {
-    for (const handler of this.dataHandlers.slice()) handler(chunk);
-  }
-
-  emitExit(exitCode: number, signal?: number): void {
-    for (const handler of this.exitHandlers.slice()) handler({ exitCode, signal });
-  }
-}
 
 function envelopeBuilder(nodeId: string) {
   return (
@@ -90,16 +37,29 @@ function envelopeBuilder(nodeId: string) {
   });
 }
 
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function waitFor<T>(
+  probe: () => T | undefined,
+  attempts = 100
+): Promise<T> {
+  for (let i = 0; i < attempts; i++) {
+    const value = probe();
+    if (value !== undefined) return value;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error('waitFor timed out');
+}
+
 describe('node link pty host (unit)', () => {
-  it('spawns on pty.attach, forwards data, kills on detach', () => {
-    let lastPty: FakePty | undefined;
+  it('opens attachment on pty.attach, forwards data, closes on detach', async () => {
     const sent: RelayNodeEnvelope[] = [];
+    const factory: MockAttachmentFactory = createMockAttachmentFactory();
     const host = createNodeLinkPtyHost({
       nodeId: 'node-1',
-      spawn: (command: string, args: string[], options: IPtyForkOptions) => {
-        lastPty = new FakePty(options.cols ?? 80, options.rows ?? 24);
-        return lastPty as unknown as IPty;
-      },
+      attachmentFactory: factory,
     });
     const build = envelopeBuilder('node-1');
     const ctx = {
@@ -114,12 +74,14 @@ describe('node link pty host (unit)', () => {
       }),
       ctx
     );
-    expect(lastPty).toBeDefined();
-    expect(lastPty!.cols).toBe(100);
+    await waitFor(() => factory.attachments[0]);
+    expect(factory.attachments[0]!.sessionId).toBe('session-a');
 
-    lastPty!.emitData('hello');
-    expect(sent.map((e) => e.type)).toEqual(['pty.data']);
-    expect((sent[0]!.payload as { data: string }).data).toBe('hello');
+    factory.emit('hello');
+    await flush();
+    expect(sent.map((e) => e.type)).toContain('pty.data');
+    const data = sent.find((e) => e.type === 'pty.data');
+    expect((data!.payload as { data: string }).data).toBe('hello');
 
     host.handle(
       build('pty', 'pty.input', {
@@ -128,7 +90,9 @@ describe('node link pty host (unit)', () => {
       }),
       ctx
     );
-    expect(lastPty!.written).toEqual(['ls\n']);
+    expect(factory.records[0]!.written.map((b) => b.toString('utf8'))).toEqual([
+      'ls\n',
+    ]);
 
     host.handle(
       build('pty', 'pty.resize', {
@@ -137,88 +101,97 @@ describe('node link pty host (unit)', () => {
       }),
       ctx
     );
-    expect(lastPty!.cols).toBe(120);
-    expect(lastPty!.rows).toBe(40);
+    expect(factory.records[0]!.resizes).toContainEqual({ cols: 120, rows: 40 });
 
-    host.handle(
-      build('pty', 'pty.detach', { streamId: 's1' }),
-      ctx
-    );
-    expect(lastPty!.killed).toBe(true);
-
-    // After detach the host marks the stream closing but waits for onExit
-    // before deleting the entry + emitting pty.exit. Simulate the OS-level
-    // exit signal that kill() would normally produce.
-    const sentBeforeExit = sent.length;
-    lastPty!.emitExit(0, 15);
-    const exit = sent.slice(sentBeforeExit).find((e) => e.type === 'pty.exit');
+    host.handle(build('pty', 'pty.detach', { streamId: 's1' }), ctx);
+    await flush();
+    expect(factory.records[0]!.closed).toBe(true);
+    const exit = sent.find((e) => e.type === 'pty.exit');
     expect(exit).toBeDefined();
-    expect((exit!.payload as { exitCode: number }).exitCode).toBe(0);
   });
 
-  it('emits pty.exit when the underlying pty exits', () => {
-    let lastPty: FakePty | undefined;
+  it('emits pty.exit when the underlying attachment exits', async () => {
     const sent: RelayNodeEnvelope[] = [];
+    const factory = createMockAttachmentFactory();
     const host = createNodeLinkPtyHost({
       nodeId: 'node-1',
-      spawn: (_c, _a, options: IPtyForkOptions) => {
-        lastPty = new FakePty(options.cols ?? 80, options.rows ?? 24);
-        return lastPty as unknown as IPty;
-      },
+      attachmentFactory: factory,
     });
     const build = envelopeBuilder('node-1');
-    host.handle(
-      build('pty', 'pty.attach', { streamId: 's1', payload: {} }),
-      { send: (e) => sent.push(e), buildEnvelope: build }
-    );
-    lastPty!.emitExit(0);
+    host.handle(build('pty', 'pty.attach', { streamId: 's1', payload: {} }), {
+      send: (e) => sent.push(e),
+      buildEnvelope: build,
+    });
+    await waitFor(() => factory.attachments[0]);
+    factory.exit({ exitCode: 0 });
+    await flush();
     const exit = sent.find((e) => e.type === 'pty.exit');
     expect(exit).toBeDefined();
     expect((exit!.payload as { exitCode: number }).exitCode).toBe(0);
   });
 
-  it('emits pty.error when spawn throws', () => {
+  it('emits pty.error when factory.open throws', async () => {
     const sent: RelayNodeEnvelope[] = [];
     const host = createNodeLinkPtyHost({
       nodeId: 'node-1',
-      spawn: () => {
-        throw new Error('boom');
+      attachmentFactory: {
+        mode: 'raw',
+        async open() {
+          throw new Error('boom');
+        },
       },
     });
     const build = envelopeBuilder('node-1');
-    host.handle(
-      build('pty', 'pty.attach', { streamId: 's1', payload: {} }),
-      { send: (e) => sent.push(e), buildEnvelope: build }
-    );
-    expect(sent).toHaveLength(1);
-    expect(sent[0]!.type).toBe('pty.error');
-    expect(sent[0]!.error?.code).toBe('INTERNAL');
-  });
-
-  it('rejects duplicate attach for the same streamId', () => {
-    const sent: RelayNodeEnvelope[] = [];
-    const ptys: FakePty[] = [];
-    const host = createNodeLinkPtyHost({
-      nodeId: 'node-1',
-      spawn: (_c, _a, options: IPtyForkOptions) => {
-        const p = new FakePty(options.cols ?? 80, options.rows ?? 24);
-        ptys.push(p);
-        return p as unknown as IPty;
-      },
+    host.handle(build('pty', 'pty.attach', { streamId: 's1', payload: {} }), {
+      send: (e) => sent.push(e),
+      buildEnvelope: build,
     });
-    const build = envelopeBuilder('node-1');
-    const ctx = { send: (e: RelayNodeEnvelope) => sent.push(e), buildEnvelope: build };
-    host.handle(
-      build('pty', 'pty.attach', { streamId: 's1', payload: {} }),
-      ctx
-    );
-    host.handle(
-      build('pty', 'pty.attach', { streamId: 's1', payload: {} }),
-      ctx
-    );
-    expect(ptys).toHaveLength(1);
+    await flush();
     const err = sent.find((e) => e.type === 'pty.error');
     expect(err).toBeDefined();
+    expect(err!.error?.code).toBe('INTERNAL');
+  });
+
+  it('rejects duplicate attach for the same streamId', async () => {
+    const sent: RelayNodeEnvelope[] = [];
+    const factory = createMockAttachmentFactory();
+    const host = createNodeLinkPtyHost({
+      nodeId: 'node-1',
+      attachmentFactory: factory,
+    });
+    const build = envelopeBuilder('node-1');
+    const ctx = {
+      send: (e: RelayNodeEnvelope) => sent.push(e),
+      buildEnvelope: build,
+    };
+    host.handle(
+      build('pty', 'pty.attach', { streamId: 's1', payload: {} }),
+      ctx
+    );
+    host.handle(
+      build('pty', 'pty.attach', { streamId: 's1', payload: {} }),
+      ctx
+    );
+    await flush();
+    expect(factory.attachments).toHaveLength(1);
+    const err = sent.find((e) => e.type === 'pty.error');
+    expect(err).toBeDefined();
+  });
+
+  it('selects tmux factory when sessionResume = tmux', () => {
+    const host = createNodeLinkPtyHost({
+      nodeId: 'node-1',
+      sessionResume: 'tmux',
+    });
+    expect(host.mode).toBe('tmux');
+  });
+
+  it('falls back to raw factory when sessionResume = none', () => {
+    const host = createNodeLinkPtyHost({
+      nodeId: 'node-1',
+      sessionResume: 'none',
+    });
+    expect(host.mode).toBe('raw');
   });
 });
 
@@ -268,7 +241,13 @@ function fakeManifest(): NodeManifest {
         status: 'unavailable',
         message: 'missing',
       },
-      ssh: { id: 'ssh', label: 'SSH client', status: 'available', message: 'ok' },
+      ssh: {
+        id: 'ssh',
+        label: 'SSH client',
+        status: 'available',
+        message: 'ok',
+      },
+      sessionResume: 'tmux',
       agents: {},
     },
   };
@@ -304,7 +283,7 @@ describe('node link pty host (integration)', () => {
     while (cleanup.length > 0) await cleanup.pop()?.();
   });
 
-  it('round-trips PTY data through hub.attachPty -> node-link client -> fake pty', async () => {
+  it('round-trips PTY data through hub.attachPty -> node-link client -> mock attachment', async () => {
     const { tmpDir, registry } = tmpRegistry();
     cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
     const exchanged = registry.exchangePairToken({
@@ -327,13 +306,10 @@ describe('node link pty host (integration)', () => {
     const port = await listen(server);
     cleanup.push(() => close(server));
 
-    let lastPty: FakePty | undefined;
+    const factory = createMockAttachmentFactory();
     const ptyHost = createNodeLinkPtyHost({
       nodeId: exchanged.credential.nodeId,
-      spawn: (_c, _a, options: IPtyForkOptions) => {
-        lastPty = new FakePty(options.cols ?? 80, options.rows ?? 24);
-        return lastPty as unknown as IPty;
-      },
+      attachmentFactory: factory,
     });
 
     const client = createNodeLinkClient({
@@ -358,7 +334,6 @@ describe('node link pty host (integration)', () => {
     });
     client.start();
     await connected;
-    // Wait briefly so hub registers the link before attach.
     for (let i = 0; i < 50; i++) {
       if (linkManager.hasActiveNode(exchanged.credential.nodeId)) break;
       await new Promise((r) => setTimeout(r, 10));
@@ -404,15 +379,13 @@ describe('node link pty host (integration)', () => {
       browserStub
     );
 
-    // Wait for the node-side PTY to be spawned.
     for (let i = 0; i < 100; i++) {
-      if (lastPty) break;
+      if (factory.attachments[0]) break;
       await new Promise((r) => setTimeout(r, 10));
     }
-    expect(lastPty).toBeDefined();
+    expect(factory.attachments[0]).toBeDefined();
 
-    // Simulate the PTY emitting output; expect the hub to forward to browser.
-    lastPty!.emitData('node-says-hi');
+    factory.emit('node-says-hi');
     for (let i = 0; i < 100; i++) {
       if (browserSent.length > 0) break;
       await new Promise((r) => setTimeout(r, 10));
@@ -420,13 +393,14 @@ describe('node link pty host (integration)', () => {
     expect(browserSent.length).toBeGreaterThan(0);
     expect(browserSent.join('')).toContain('node-says-hi');
 
-    // Simulate browser typing -> input -> node PTY.
     const messageListeners = stubListeners.get('message') ?? [];
     for (const handler of messageListeners) handler('echo hi');
     for (let i = 0; i < 100; i++) {
-      if (lastPty!.written.length > 0) break;
+      if (factory.records[0]!.written.length > 0) break;
       await new Promise((r) => setTimeout(r, 10));
     }
-    expect(lastPty!.written.join('')).toContain('echo hi');
+    expect(
+      factory.records[0]!.written.map((b) => b.toString('utf8')).join('')
+    ).toContain('echo hi');
   });
 });

--- a/test/session-attachment.test.ts
+++ b/test/session-attachment.test.ts
@@ -1,0 +1,253 @@
+import { Buffer } from 'node:buffer';
+import { describe, expect, it } from 'vitest';
+import type { IPty } from 'node-pty';
+import {
+  createMockAttachmentFactory,
+  createRawAttachmentFactory,
+  createTmuxAttachmentFactory,
+} from '../server/session-attachment.js';
+
+type DataHandler = (chunk: string) => void;
+type ExitHandler = (event: { exitCode: number; signal?: number }) => void;
+
+class FakePty {
+  cols: number;
+  rows: number;
+  written: string[] = [];
+  killed = false;
+  private dataHandlers: DataHandler[] = [];
+  private exitHandlers: ExitHandler[] = [];
+
+  constructor(cols: number, rows: number) {
+    this.cols = cols;
+    this.rows = rows;
+  }
+
+  onData(handler: DataHandler): { dispose: () => void } {
+    this.dataHandlers.push(handler);
+    return {
+      dispose: () => {
+        this.dataHandlers = this.dataHandlers.filter((h) => h !== handler);
+      },
+    };
+  }
+
+  onExit(handler: ExitHandler): { dispose: () => void } {
+    this.exitHandlers.push(handler);
+    return {
+      dispose: () => {
+        this.exitHandlers = this.exitHandlers.filter((h) => h !== handler);
+      },
+    };
+  }
+
+  write(data: string): void {
+    this.written.push(data);
+  }
+
+  resize(cols: number, rows: number): void {
+    this.cols = cols;
+    this.rows = rows;
+  }
+
+  kill(): void {
+    this.killed = true;
+    for (const handler of this.exitHandlers.slice()) handler({ exitCode: 0 });
+  }
+
+  emitData(chunk: string): void {
+    for (const handler of this.dataHandlers.slice()) handler(chunk);
+  }
+}
+
+describe('SessionAttachment — raw factory', () => {
+  it('spawns shell, writes/resizes propagate, close kills pty', async () => {
+    let lastPty: FakePty | undefined;
+    const factory = createRawAttachmentFactory({
+      spawn: (cmd, args, options) => {
+        lastPty = new FakePty(options.cols ?? 80, options.rows ?? 24);
+        return lastPty as unknown as IPty;
+      },
+    });
+    const attachment = await factory.open({
+      sessionId: 's1',
+      command: 'bash',
+      args: ['-i'],
+      cwd: '/tmp',
+      env: {},
+      cols: 100,
+      rows: 30,
+    });
+    expect(attachment.mode).toBe('raw');
+    expect(lastPty!.cols).toBe(100);
+
+    let received: Buffer | undefined;
+    attachment.onData((bytes) => {
+      received = bytes;
+    });
+    lastPty!.emitData('hello');
+    expect(received?.toString('utf8')).toBe('hello');
+
+    attachment.write(Buffer.from('echo hi\n', 'utf8'));
+    expect(lastPty!.written).toEqual(['echo hi\n']);
+
+    attachment.resize(120, 40);
+    expect(lastPty!.cols).toBe(120);
+    expect(lastPty!.rows).toBe(40);
+
+    await attachment.close();
+    expect(lastPty!.killed).toBe(true);
+    expect(attachment.status()).toBe('closed');
+  });
+});
+
+describe('SessionAttachment — tmux factory', () => {
+  it('ensures session then attaches via spawn (no real tmux invoked)', async () => {
+    const ensureCalls: Array<{ target: string; sessionId: string }> = [];
+    let attachArgs: string[] | undefined;
+    const factory = createTmuxAttachmentFactory({
+      tmuxPath: '/fake/tmux',
+      socketName: 'relay-test',
+      configDir: '/tmp/relay-tmux-test',
+      ensureSession: ({ target, options }) => {
+        ensureCalls.push({ target, sessionId: options.sessionId });
+      },
+      spawn: (cmd, args, options) => {
+        attachArgs = args;
+        const proc = new FakePty(options.cols ?? 80, options.rows ?? 24);
+        return proc as unknown as IPty;
+      },
+    });
+    const attachment = await factory.open({
+      sessionId: 'sess-1',
+      command: 'bash',
+      args: [],
+      cwd: '/tmp',
+      env: {},
+      cols: 80,
+      rows: 24,
+    });
+    expect(attachment.mode).toBe('tmux');
+    expect(ensureCalls).toEqual([
+      { target: 'relay-sess-1', sessionId: 'sess-1' },
+    ]);
+    expect(attachArgs).toContain('attach-session');
+    expect(attachArgs).toContain('relay-sess-1');
+    expect(attachArgs).toContain('-L');
+    expect(attachArgs).toContain('relay-test');
+  });
+
+  it('sanitizes session ids containing tmux-illegal characters', async () => {
+    let attachArgs: string[] | undefined;
+    const factory = createTmuxAttachmentFactory({
+      tmuxPath: '/fake/tmux',
+      socketName: 'relay-test',
+      configDir: '/tmp/relay-tmux-test',
+      ensureSession: () => undefined,
+      spawn: (cmd, args, options) => {
+        attachArgs = args;
+        return new FakePty(
+          options.cols ?? 80,
+          options.rows ?? 24
+        ) as unknown as IPty;
+      },
+    });
+    await factory.open({
+      sessionId: 'has:colon and space.dot',
+      command: 'bash',
+      args: [],
+      cwd: '/tmp',
+      env: {},
+      cols: 80,
+      rows: 24,
+    });
+    expect(attachArgs).toContain('relay-has_colon_and_space_dot');
+  });
+
+  it('reattaching to the same sessionId reuses the existing tmux session', async () => {
+    const calls: string[] = [];
+    const factory = createTmuxAttachmentFactory({
+      tmuxPath: '/fake/tmux',
+      socketName: 'relay-test',
+      configDir: '/tmp/relay-tmux-test',
+      ensureSession: ({ target }) => {
+        calls.push(target);
+      },
+      spawn: (cmd, args, options) =>
+        new FakePty(options.cols ?? 80, options.rows ?? 24) as unknown as IPty,
+    });
+    await factory.open({
+      sessionId: 'live',
+      command: 'bash',
+      args: [],
+      cwd: '/tmp',
+      env: {},
+      cols: 80,
+      rows: 24,
+    });
+    await factory.open({
+      sessionId: 'live',
+      command: 'bash',
+      args: [],
+      cwd: '/tmp',
+      env: {},
+      cols: 80,
+      rows: 24,
+    });
+    // ensureSession is invoked for both opens — its body is responsible
+    // for choosing has-session/new-session. Both invocations resolve to
+    // the same tmux target, which is the resume primitive.
+    expect(calls).toEqual(['relay-live', 'relay-live']);
+  });
+});
+
+describe('SessionAttachment — mock factory', () => {
+  it('records writes and resizes, replays scripted data', async () => {
+    const factory = createMockAttachmentFactory({
+      data: ['boot-banner\n'],
+    });
+    const received: Buffer[] = [];
+    const attachment = await factory.open({
+      sessionId: 's1',
+      command: 'bash',
+      args: [],
+      cwd: '/tmp',
+      env: {},
+      cols: 80,
+      rows: 24,
+    });
+    attachment.onData((bytes) => received.push(bytes));
+    factory.emit('after-listener');
+    expect(received.map((b) => b.toString('utf8'))).toEqual(['after-listener']);
+
+    attachment.write(Buffer.from('input', 'utf8'));
+    attachment.resize(120, 40);
+    expect(factory.records[0]!.written.map((b) => b.toString('utf8'))).toEqual([
+      'input',
+    ]);
+    expect(factory.records[0]!.resizes).toEqual([{ cols: 120, rows: 40 }]);
+
+    await attachment.close('shutdown');
+    expect(factory.records[0]!.closed).toBe(true);
+    expect(factory.records[0]!.closeReason).toBe('shutdown');
+  });
+
+  it('close emits a synthetic exit event', async () => {
+    const factory = createMockAttachmentFactory();
+    const attachment = await factory.open({
+      sessionId: 's1',
+      command: 'bash',
+      args: [],
+      cwd: '/tmp',
+      env: {},
+      cols: 80,
+      rows: 24,
+    });
+    let exited = false;
+    attachment.onExit(() => {
+      exited = true;
+    });
+    await attachment.close();
+    expect(exited).toBe(true);
+  });
+});

--- a/test/session-attachment.test.ts
+++ b/test/session-attachment.test.ts
@@ -5,6 +5,7 @@ import {
   createMockAttachmentFactory,
   createRawAttachmentFactory,
   createTmuxAttachmentFactory,
+  SESSION_ATTACHMENT_KILL_REASON,
 } from '../server/session-attachment.js';
 
 type DataHandler = (chunk: string) => void;
@@ -164,6 +165,58 @@ describe('SessionAttachment — tmux factory', () => {
     expect(attachArgs).toContain('relay-has_colon_and_space_dot');
   });
 
+  it('default close() does not kill the tmux session (resume keeps state)', async () => {
+    const killCalls: string[] = [];
+    const factory = createTmuxAttachmentFactory({
+      tmuxPath: '/fake/tmux',
+      socketName: 'relay-test',
+      configDir: '/tmp/relay-tmux-test',
+      ensureSession: async () => undefined,
+      killSession: async ({ target }) => {
+        killCalls.push(target);
+      },
+      spawn: (_cmd, _args, options) =>
+        new FakePty(options.cols ?? 80, options.rows ?? 24) as unknown as IPty,
+    });
+    const attachment = await factory.open({
+      sessionId: 'persist',
+      command: 'bash',
+      args: [],
+      cwd: '/tmp',
+      env: {},
+      cols: 80,
+      rows: 24,
+    });
+    await attachment.close('detach');
+    expect(killCalls).toEqual([]);
+  });
+
+  it('close(SESSION_ATTACHMENT_KILL_REASON) destroys the tmux session', async () => {
+    const killCalls: string[] = [];
+    const factory = createTmuxAttachmentFactory({
+      tmuxPath: '/fake/tmux',
+      socketName: 'relay-test',
+      configDir: '/tmp/relay-tmux-test',
+      ensureSession: async () => undefined,
+      killSession: async ({ target }) => {
+        killCalls.push(target);
+      },
+      spawn: (_cmd, _args, options) =>
+        new FakePty(options.cols ?? 80, options.rows ?? 24) as unknown as IPty,
+    });
+    const attachment = await factory.open({
+      sessionId: 'doomed',
+      command: 'bash',
+      args: [],
+      cwd: '/tmp',
+      env: {},
+      cols: 80,
+      rows: 24,
+    });
+    await attachment.close(SESSION_ATTACHMENT_KILL_REASON);
+    expect(killCalls).toEqual(['relay-doomed']);
+  });
+
   it('reattaching to the same sessionId reuses the existing tmux session', async () => {
     const calls: string[] = [];
     const factory = createTmuxAttachmentFactory({
@@ -202,7 +255,7 @@ describe('SessionAttachment — tmux factory', () => {
 });
 
 describe('SessionAttachment — mock factory', () => {
-  it('records writes and resizes, replays scripted data', async () => {
+  it('records writes and resizes, replays scripted data buffered until listener registers', async () => {
     const factory = createMockAttachmentFactory({
       data: ['boot-banner\n'],
     });
@@ -218,7 +271,10 @@ describe('SessionAttachment — mock factory', () => {
     });
     attachment.onData((bytes) => received.push(bytes));
     factory.emit('after-listener');
-    expect(received.map((b) => b.toString('utf8'))).toEqual(['after-listener']);
+    expect(received.map((b) => b.toString('utf8'))).toEqual([
+      'boot-banner\n',
+      'after-listener',
+    ]);
 
     attachment.write(Buffer.from('input', 'utf8'));
     attachment.resize(120, 40);


### PR DESCRIPTION
Closes #467. Sub-issue of #443.

## Summary
- Adds `server/session-attachment.ts` exporting a stable `SessionAttachment` interface between `node-link-pty-host.ts` and the concrete PTY backend.
- Phase 1 ships `TmuxAttachment` (attach-by-name; reload reattaches the same shell) and a raw fallback. `MockAttachment` powers all tests — pre-push CI never spawns real tmux.
- New `sessionResume: 'tmux' | 'canonical-emulator' | 'none'` capability on the node manifest. Server probe derives from tmux availability; the hub summary surfaces it on `HubNodeSummary` so the frontend never references tmux verbs.
- `TerminalNodePicker` renders a `resumable` badge on node-picker entries whose `sessionResume` is non-`none`. Capability-driven only — phase 2 (#469) can swap in `canonical-emulator` without touching browser code.

## SessionAttachment boundary (the delicate part)
The six non-blocking constraints from #467 hold:
1. No tmux strings leak past `server/node-link-pty-host.ts`. Hub registry stores `relaySessionId` only.
2. Frontend never references tmux verbs. Resumable badge reads `node.capabilities.sessionResume`.
3. Wire format unchanged — opaque bytes over WS.
4. Tests use `MockAttachment`. Pre-push CI does not spawn real tmux.
5. `SessionAttachment` exported from `server/`, not `features/tmux/`. Phase 2 lives beside, not under.
6. Detach handling: tmux sessions are not killed on hub disconnect. On reconnect, `pty.attach` reaches the same tmux session.

Tmux config is baked in: `set -g status off`, `unbind-key -a`, `set -g mouse off`, `set -g escape-time 0`. Operators never see tmux UI.

## Files touched
- `server/session-attachment.ts` (new) — interface + Tmux/Raw/Mock factories
- `server/node-link-pty-host.ts` — consumes interface; no direct node-pty/tmux imports
- `shared/node-manifest.ts` + `server/node-manifest.ts` — `sessionResume` capability
- `shared/relay-node-protocol.ts` + `server/hub-node-registry.ts` — summary surface
- `bin/relay-ide.ts` — wires manifest's sessionResume into the pty host
- `frontend/src/components/TerminalNodePicker.{tsx,css}` — resumable badge
- `docs/federated-relay.md` — SessionAttachment boundary section
- `test/session-attachment.test.ts` (new) — factory unit tests
- `test/node-link-pty-host.test.ts` — routed through MockAttachment
- `test/components/TerminalNodePicker.test.ts` — resumable + pre-#467 cases

## Test plan
- [x] `npm run build` — green
- [x] `npm test` — 2042/2042 pass
- [x] `eslint` clean on touched files
- [ ] Manual verify: browser reload on a node-bound tab reattaches to the same shell (requires two-node smoke harness — follow-up under #443)

## Refs
- Parent: #443
- Phase 2: #469 (server-side canonical terminal — must inherit the six constraints above)
- Refs #466 (push events — sessionResume changes are a candidate post-#466)

🤖 Generated with [Claude Code](https://claude.com/claude-code)