### PR TITLE
fix(474): default cwd to os.homedir() in node-side sessions.create

### DIFF
--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -1,3 +1,4 @@
+import * as os from 'node:os';
 import type { LocalRelayNode } from './local-node.js';
 import type { Logger } from './logger.js';
 import { createLogger } from './logger.js';
@@ -106,8 +107,12 @@ function parseSessionsCreateInput(
   if (repoPath !== undefined) input.repoPath = repoPath;
   const worktreePath = asNullableString(record['worktreePath']);
   if (worktreePath !== undefined) input.worktreePath = worktreePath;
-  const cwd = asString(record['cwd']);
-  if (cwd !== undefined) input.cwd = cwd;
+  // #474: routed creates from a remote browser often arrive without
+  // cwd because the frontend create-tab modal still assumes the hub's
+  // local repo state. Until #473's modal split lands, default to the
+  // node host's home directory so spawn() never receives undefined.
+  const cwd = asString(record['cwd']) ?? os.homedir();
+  input.cwd = cwd;
   const command = asString(record['command']);
   if (command !== undefined) input.command = command;
   const args = asStringArray(record['args']);

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -1,3 +1,4 @@
+import * as os from 'node:os';
 import { describe, expect, it, vi } from 'vitest';
 import { createNodeLinkRpcHost } from '../server/node-link-rpc-host.js';
 import type {
@@ -121,6 +122,22 @@ describe('node-link-rpc-host', () => {
     const replyPayload = reply.payload as { session: SessionSummary };
     expect(replyPayload.session.id).toBe('sess-1');
     expect(replyPayload.session).not.toHaveProperty('pid');
+  });
+
+  it('defaults missing cwd to os.homedir() so routed creates from the picker never spawn with undefined', () => {
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(envelope('sessions.create', { type: 'terminal' }), ctx);
+
+    expect(localRelayNode.sessions.create).toHaveBeenCalledTimes(1);
+    const createCall = (
+      localRelayNode.sessions.create as ReturnType<typeof vi.fn>
+    ).mock.calls[0]?.[0] as CreateParams;
+    expect(createCall.cwd).toBe(os.homedir());
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('sessions.create.result');
   });
 
   it('routes mode:"web" sessions through createWeb', async () => {


### PR DESCRIPTION
## Summary

Sub-issue of #473. Immediate unblock for the #443 cross-node terminal demo.

Selecting a paired remote node from the picker (#452) creates a session whose payload omits `cwd` because the frontend create-tab modal still assumes the hub's local repo state — there is no concept of "the remote node's filesystem" in the current UI. The hub forwards the empty payload to the node via `sessions.create` RPC; node-side spawn then calls `path.*` with `undefined` and crashes:

```
500 INTERNAL: The "path" argument must be of type string. Received undefined
```

This PR defaults missing `cwd` to the node host's `os.homedir()` at the RPC parser. Sensible default, trades a crash for "spawn in the user's home dir." Properly prompting for a remote cwd in the modal is #475 under epic #473.

## Changes

- `server/node-link-rpc-host.ts`: `parseSessionsCreateInput()` falls back to `os.homedir()` when `cwd` is missing instead of leaving it undefined.
- `test/node-link-rpc-host.test.ts`: +1 case asserting the default fires for routed creates from the picker.

## Reproducer

```bash
curl -X POST https://<hub>/hub/nodes/<nodeId>/sessions \
  -H "Content-Type: application/json" \
  -b "token=<cookie>" \
  -d '{"type":"terminal","agent":"claude"}'
```

Before: `500 INTERNAL`. After: `201` with a session created at the node user's home dir.

## Test plan

- [x] `npx vitest run test/node-link-rpc-host.test.ts` — 7/7 pass
- [x] `npm run build` — clean
- [ ] CI green
- [ ] Manual verify against live dev hub + paired laptop node

## Refs

- Parent: #473 (Tab as first-class surface — decouple repo/worktree assumption)
- Refs #443 (cross-node terminal panel epic)
- Refs #475 (frontend modal split — does the proper UX fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Sessions now default to the system's home directory when no working directory is specified during session creation.

* **Tests**
  * Added test coverage to verify that sessions properly default to the system's home directory when a working directory is not provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/477)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->