### PR TITLE
feat: add remote node cwd session lane

### DIFF
--- a/frontend/src/components/WorkspaceArea.css
+++ b/frontend/src/components/WorkspaceArea.css
@@ -26,3 +26,52 @@
   font-size: 0.75rem;
   text-transform: lowercase;
 }
+
+.ws-remote-terminal-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ws-remote-terminal-copy,
+.ws-remote-terminal-note {
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 1.4;
+}
+
+.ws-remote-terminal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ws-remote-terminal-label {
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.ws-remote-terminal-input {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  box-sizing: border-box;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-base);
+  padding: 8px;
+  width: 100%;
+}
+
+.ws-remote-terminal-error {
+  border: 1px solid color-mix(in srgb, var(--status-error) 40%, transparent);
+  color: var(--status-error);
+  font-size: var(--font-size-sm);
+  padding: 8px;
+}
+
+.ws-remote-terminal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/frontend/src/components/WorkspaceArea.tsx
+++ b/frontend/src/components/WorkspaceArea.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
 import { ConflictError, fetchHubNodes } from '../lib/api.js';
+import { defaultRemoteCwd } from '../lib/remote-node-cwd.js';
 import { createLogger } from '../lib/logger.js';
 import {
   createAgentSession,
@@ -456,12 +457,38 @@ export function WorkspaceArea({
           // the pane whose `+` was used before the create call so the
           // layout reconciler routes the tab to the correct pane.
           setActivePane(paneId);
-          const { session, error } = await createAgentSession({
-            repoPath: currentActiveWorkspace.path,
-            worktreePath: currentWorktreePath,
-            type: 'terminal',
-            ...(nodeId && nodeId !== DEFAULT_LOCAL_NODE_ID && { nodeId }),
-          });
+          const isRemoteNode = nodeId !== DEFAULT_LOCAL_NODE_ID;
+          const remoteCwd = isRemoteNode
+            ? defaultRemoteCwd(
+                hubNodes?.find((node) => node.nodeId === nodeId)?.homeDir,
+                nodeId
+              )
+            : '';
+          if (isRemoteNode && !remoteCwd) {
+            workspaceLogger.warn(
+              'remote terminal node has no remembered cwd or homeDir',
+              { nodeId }
+            );
+            useToastStore
+              .getState()
+              .showToast('remote cwd is required for this node');
+            return;
+          }
+          const { session, error } = await createAgentSession(
+            isRemoteNode
+              ? {
+                  type: 'terminal',
+                  nodeId,
+                  cwd: remoteCwd,
+                  sessionLane: 'remote-cwd',
+                }
+              : {
+                  repoPath: currentActiveWorkspace.path,
+                  worktreePath: currentWorktreePath,
+                  type: 'terminal',
+                  sessionLane: 'local-repo',
+                }
+          );
           if (error && !(error instanceof ConflictError)) {
             workspaceLogger.error('failed to create terminal session', error);
             useToastStore
@@ -478,7 +505,7 @@ export function WorkspaceArea({
         }}
       />
     ),
-    [setActivePane]
+    [setActivePane, hubNodes]
   );
 
   const renderTab = useCallback(

--- a/frontend/src/components/WorkspaceArea.tsx
+++ b/frontend/src/components/WorkspaceArea.tsx
@@ -1,8 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
 import { ConflictError, fetchHubNodes } from '../lib/api.js';
-import { defaultRemoteCwd } from '../lib/remote-node-cwd.js';
+import {
+  cleanCwd,
+  defaultRemoteCwd,
+  rememberRemoteCwd,
+} from '../lib/remote-node-cwd.js';
 import { createLogger } from '../lib/logger.js';
 import {
   createAgentSession,
@@ -12,6 +16,8 @@ import type { SummaryNodeInfo } from '../lib/workspace-summary.js';
 import { fileTabKey, useUiStore } from '../lib/stores/ui.js';
 import { useToastStore } from '../lib/stores/toasts.js';
 import { TerminalNodePicker } from './TerminalNodePicker.js';
+import DialogShell, { type DialogShellHandle } from './dialogs/DialogShell.js';
+import TuiButton from './TuiButton.js';
 import type { OpenFileTab } from '../lib/stores/ui.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { diffSourceToBase } from '../lib/diff-utils.js';
@@ -230,6 +236,109 @@ function SessionContentMount({
   );
 }
 
+type RemoteTerminalLane = 'remote-cwd' | 'remote-home';
+
+interface PendingRemoteTerminal {
+  nodeId: string;
+  label: string;
+  homeDir?: string | undefined;
+}
+
+interface RemoteTerminalCwdDialogProps {
+  request: PendingRemoteTerminal | null;
+  creating: boolean;
+  error: string | null;
+  onClose: () => void;
+  onSubmit: (cwd: string, lane: RemoteTerminalLane) => void;
+}
+
+function RemoteTerminalCwdDialog({
+  request,
+  creating,
+  error,
+  onClose,
+  onSubmit,
+}: RemoteTerminalCwdDialogProps) {
+  const shellRef = useRef<DialogShellHandle>(null);
+  const [cwd, setCwd] = useState('');
+  const homeDir = cleanCwd(request?.homeDir);
+  const nodeLabel = request?.label ?? 'remote node';
+
+  useEffect(() => {
+    if (!request) {
+      shellRef.current?.close();
+      return;
+    }
+    setCwd(defaultRemoteCwd(homeDir, request.nodeId));
+    shellRef.current?.open();
+  }, [homeDir, request]);
+
+  const footer = (
+    <div className="ws-remote-terminal-footer">
+      <TuiButton variant="ghost" onClick={onClose} disabled={creating}>
+        cancel
+      </TuiButton>
+      <TuiButton
+        variant="ghost"
+        data-track="workspace.remote-terminal.start-home"
+        onClick={() => onSubmit(homeDir, 'remote-home')}
+        disabled={!homeDir || creating}
+      >
+        start in home
+      </TuiButton>
+      <TuiButton
+        variant="primary"
+        data-track="workspace.remote-terminal.create"
+        onClick={() => onSubmit(cwd, 'remote-cwd')}
+        disabled={!cleanCwd(cwd) || creating}
+      >
+        {creating ? 'starting...' : 'start terminal'}
+      </TuiButton>
+    </div>
+  );
+
+  return (
+    <DialogShell
+      ref={shellRef}
+      width="460px"
+      title="remote terminal cwd"
+      footer={footer}
+      onClose={onClose}
+    >
+      <div className="ws-remote-terminal-fields">
+        {error && (
+          <div className="ws-remote-terminal-error" role="alert">
+            {error}
+          </div>
+        )}
+        <div className="ws-remote-terminal-copy">
+          choose the node-local directory before creating a terminal on{' '}
+          {nodeLabel}.
+        </div>
+        <div className="ws-remote-terminal-field">
+          <label className="ws-remote-terminal-label" htmlFor="ws-remote-cwd">
+            cwd on {nodeLabel}
+          </label>
+          <input
+            id="ws-remote-cwd"
+            type="text"
+            className="ws-remote-terminal-input"
+            data-track="workspace.remote-terminal.cwd"
+            placeholder={homeDir || 'absolute path on remote node'}
+            value={cwd}
+            onChange={(event) => setCwd(event.currentTarget.value)}
+            autoComplete="off"
+          />
+          <div className="ws-remote-terminal-note">
+            remote terminals start directly in this directory. use start in home
+            to skip remembering a cwd.
+          </div>
+        </div>
+      </div>
+    </DialogShell>
+  );
+}
+
 // ── Main WorkspaceArea component ─────────────────────────────────────────────
 
 export interface WorkspaceAreaProps {
@@ -437,6 +546,63 @@ export function WorkspaceArea({
   }, [openFileTabs, sessions, nodeIndex]);
 
   const setActivePane = useWorkspaceLayoutStore((s) => s.setActivePane);
+  const [pendingRemoteTerminal, setPendingRemoteTerminal] =
+    useState<PendingRemoteTerminal | null>(null);
+  const [remoteTerminalCreating, setRemoteTerminalCreating] = useState(false);
+  const [remoteTerminalError, setRemoteTerminalError] = useState<string | null>(
+    null
+  );
+
+  const closeRemoteTerminalDialog = useCallback(() => {
+    if (remoteTerminalCreating) return;
+    setPendingRemoteTerminal(null);
+    setRemoteTerminalError(null);
+  }, [remoteTerminalCreating]);
+
+  const createRemoteTerminal = useCallback(
+    async (cwd: string, lane: RemoteTerminalLane) => {
+      if (!pendingRemoteTerminal || remoteTerminalCreating) return;
+      const remoteCwd = cleanCwd(cwd);
+      if (!remoteCwd) {
+        setRemoteTerminalError('cwd is required for remote terminal sessions');
+        return;
+      }
+      setRemoteTerminalCreating(true);
+      setRemoteTerminalError(null);
+      try {
+        const { session, error } = await createAgentSession({
+          type: 'terminal',
+          nodeId: pendingRemoteTerminal.nodeId,
+          cwd: remoteCwd,
+          sessionLane: lane,
+        });
+        if (error && !(error instanceof ConflictError)) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : 'failed to create terminal session';
+          workspaceLogger.error(
+            'failed to create remote terminal session',
+            error
+          );
+          setRemoteTerminalError(message);
+          useToastStore.getState().showToast(message);
+          return;
+        }
+        if (lane === 'remote-cwd') {
+          rememberRemoteCwd(pendingRemoteTerminal.nodeId, remoteCwd);
+        }
+        setPendingRemoteTerminal(null);
+        if (session?.id) {
+          useSessionsStore.getState().setActiveSessionId(session.id);
+        }
+      } finally {
+        setRemoteTerminalCreating(false);
+      }
+    },
+    [pendingRemoteTerminal, remoteTerminalCreating]
+  );
+
   const renderAddControl = useCallback(
     (paneId: string) => (
       <TerminalNodePicker
@@ -458,37 +624,24 @@ export function WorkspaceArea({
           // layout reconciler routes the tab to the correct pane.
           setActivePane(paneId);
           const isRemoteNode = nodeId !== DEFAULT_LOCAL_NODE_ID;
-          const remoteCwd = isRemoteNode
-            ? defaultRemoteCwd(
-                hubNodes?.find((node) => node.nodeId === nodeId)?.homeDir,
-                nodeId
-              )
-            : '';
-          if (isRemoteNode && !remoteCwd) {
-            workspaceLogger.warn(
-              'remote terminal node has no remembered cwd or homeDir',
-              { nodeId }
+          if (isRemoteNode) {
+            const node = hubNodes?.find(
+              (candidate) => candidate.nodeId === nodeId
             );
-            useToastStore
-              .getState()
-              .showToast('remote cwd is required for this node');
+            setRemoteTerminalError(null);
+            setPendingRemoteTerminal({
+              nodeId,
+              label: node?.displayName || nodeId,
+              ...(node?.homeDir ? { homeDir: node.homeDir } : {}),
+            });
             return;
           }
-          const { session, error } = await createAgentSession(
-            isRemoteNode
-              ? {
-                  type: 'terminal',
-                  nodeId,
-                  cwd: remoteCwd,
-                  sessionLane: 'remote-cwd',
-                }
-              : {
-                  repoPath: currentActiveWorkspace.path,
-                  worktreePath: currentWorktreePath,
-                  type: 'terminal',
-                  sessionLane: 'local-repo',
-                }
-          );
+          const { session, error } = await createAgentSession({
+            repoPath: currentActiveWorkspace.path,
+            worktreePath: currentWorktreePath,
+            type: 'terminal',
+            sessionLane: 'local-repo',
+          });
           if (error && !(error instanceof ConflictError)) {
             workspaceLogger.error('failed to create terminal session', error);
             useToastStore
@@ -557,6 +710,13 @@ export function WorkspaceArea({
         renderAddControl={renderAddControl}
       />
       <WorkspaceContentLayer renderTab={renderTab} />
+      <RemoteTerminalCwdDialog
+        request={pendingRemoteTerminal}
+        creating={remoteTerminalCreating}
+        error={remoteTerminalError}
+        onClose={closeRemoteTerminalDialog}
+        onSubmit={(cwd, lane) => void createRemoteTerminal(cwd, lane)}
+      />
     </div>
   );
 }

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -1,5 +1,6 @@
 import {
   forwardRef,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -144,6 +145,40 @@ export interface EnvironmentPickerInput {
 
 const CHECKOUT_ROOT_PREFIX = 'repo:';
 const CHECKOUT_WORKTREE_PREFIX = 'worktree:';
+const REMOTE_NODE_CWD_STORAGE_PREFIX = 'relay-ide.remote-node-cwd.';
+
+function cleanCwd(value: string | undefined): string {
+  return value?.trim() ?? '';
+}
+
+function remoteNodeCwdStorageKey(nodeId: NodeId): string {
+  return `${REMOTE_NODE_CWD_STORAGE_PREFIX}${nodeId}`;
+}
+
+function readRememberedRemoteCwd(nodeId: NodeId): string | null {
+  try {
+    const remembered = window.localStorage.getItem(
+      remoteNodeCwdStorageKey(nodeId)
+    );
+    return remembered?.trim() ? remembered : null;
+  } catch {
+    return null;
+  }
+}
+
+function rememberRemoteCwd(nodeId: NodeId, cwd: string): void {
+  const trimmed = cleanCwd(cwd);
+  if (!trimmed) return;
+  try {
+    window.localStorage.setItem(remoteNodeCwdStorageKey(nodeId), trimmed);
+  } catch {
+    // localStorage can be unavailable in private contexts; launching still works.
+  }
+}
+
+function defaultRemoteCwd(homeDir: string | undefined, nodeId: NodeId): string {
+  return readRememberedRemoteCwd(nodeId) ?? cleanCwd(homeDir);
+}
 
 function syntheticLocalNode(selectedAgent: AgentType): HubNodeSummary {
   return {
@@ -437,17 +472,16 @@ function defaultForm(): FormState {
 
 async function createSessionFromForm(
   environment: EnvironmentPickerModel['resolved'],
-  form: FormState
+  form: FormState,
+  remoteCwd?: string
 ) {
   const claudeArgs = form.claudeArgsInput.trim().split(/\s+/).filter(Boolean);
   const { cols, rows } = estimateTerminalDimensions(
     useUiStore.getState().terminalFontSize
   );
-  return createAgentSession({
+  const baseOptions = {
     nodeId: environment.nodeId,
-    repoPath: environment.repoPath,
-    worktreePath: environment.worktreePath,
-    type: 'agent',
+    type: 'agent' as const,
     mode: form.sessionMode,
     continue: form.continueExisting,
     yolo: form.yoloMode,
@@ -455,6 +489,17 @@ async function createSessionFromForm(
     agent: form.selectedAgent,
     cols,
     rows,
+  };
+  if (environment.nodeId !== DEFAULT_LOCAL_NODE_ID) {
+    return createAgentSession({
+      ...baseOptions,
+      cwd: cleanCwd(remoteCwd),
+    });
+  }
+  return createAgentSession({
+    ...baseOptions,
+    repoPath: environment.repoPath,
+    worktreePath: environment.worktreePath,
   });
 }
 
@@ -462,8 +507,11 @@ interface BodyProps {
   workspaceName: string;
   form: FormState;
   environmentModel: EnvironmentPickerModel;
+  selectedRemoteNode: HubNodeSummary | null;
+  remoteCwd: string;
   onFormChange: (patch: Partial<FormState>) => void;
   onEnvironmentChange: (patch: Partial<EnvironmentSelection>) => void;
+  onRemoteCwdChange: (cwd: string) => void;
 }
 
 interface EnvironmentSelection {
@@ -476,8 +524,11 @@ function CustomizeSessionBody({
   workspaceName,
   form,
   environmentModel,
+  selectedRemoteNode,
+  remoteCwd,
   onFormChange,
   onEnvironmentChange,
+  onRemoteCwdChange,
 }: BodyProps) {
   const frameworks = useConfigStore((state) => state.frameworks);
   const frameworkOptions =
@@ -512,6 +563,11 @@ function CustomizeSessionBody({
     selectedFramework &&
     form.sessionMode === 'web' &&
     !isFrameworkWebAvailable(selectedFramework);
+  const remoteNodeSelected =
+    environmentModel.selectedNodeId !== DEFAULT_LOCAL_NODE_ID;
+  const remoteNodeLabel =
+    selectedRemoteNode?.displayName ?? environmentModel.selectedNodeId;
+  const remoteHomeDir = cleanCwd(selectedRemoteNode?.homeDir);
 
   return (
     <div className="customize-session-body-fields">
@@ -595,38 +651,62 @@ function CustomizeSessionBody({
               )}
             </div>
           )}
-          {environmentModel.checkoutChoices.length > 1 && (
+          {remoteNodeSelected && (
             <div className="customize-session-dialog-field">
               <label
                 className="customize-session-dialog-label"
-                htmlFor="cs-checkout"
+                htmlFor="cs-remote-cwd"
               >
-                node-local checkout
+                cwd on {remoteNodeLabel}
               </label>
-              <select
-                id="cs-checkout"
-                className="customize-session-dialog-select"
-                data-track="dialog.customize-session.checkout"
-                value={environmentModel.selectedCheckoutId ?? ''}
-                onChange={(e) =>
-                  onEnvironmentChange({
-                    selectedCheckoutId: e.currentTarget.value,
-                  })
-                }
-              >
-                {environmentModel.checkoutChoices.map((choice) => (
-                  <option
-                    key={choice.value}
-                    value={choice.value}
-                    disabled={choice.disabled}
-                  >
-                    {choice.label}
-                    {choice.reason ? ` — ${choice.reason}` : ''}
-                  </option>
-                ))}
-              </select>
+              <input
+                id="cs-remote-cwd"
+                type="text"
+                className="customize-session-dialog-input"
+                data-track="dialog.customize-session.remote-cwd"
+                placeholder={remoteHomeDir || 'absolute path on remote node'}
+                value={remoteCwd}
+                onChange={(e) => onRemoteCwdChange(e.currentTarget.value)}
+                autoComplete="off"
+              />
+              <div className="customize-session-field-note">
+                remote sessions start directly in this node-local directory.
+              </div>
             </div>
           )}
+          {!remoteNodeSelected &&
+            environmentModel.checkoutChoices.length > 1 && (
+              <div className="customize-session-dialog-field">
+                <label
+                  className="customize-session-dialog-label"
+                  htmlFor="cs-checkout"
+                >
+                  node-local checkout
+                </label>
+                <select
+                  id="cs-checkout"
+                  className="customize-session-dialog-select"
+                  data-track="dialog.customize-session.checkout"
+                  value={environmentModel.selectedCheckoutId ?? ''}
+                  onChange={(e) =>
+                    onEnvironmentChange({
+                      selectedCheckoutId: e.currentTarget.value,
+                    })
+                  }
+                >
+                  {environmentModel.checkoutChoices.map((choice) => (
+                    <option
+                      key={choice.value}
+                      value={choice.value}
+                      disabled={choice.disabled}
+                    >
+                      {choice.label}
+                      {choice.reason ? ` — ${choice.reason}` : ''}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
         </section>
       )}
       <div className="customize-session-dialog-field">
@@ -746,6 +826,7 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
     const [inventory, setInventory] =
       useState<AggregatedRepoInventoryResponse | null>(null);
     const [nodes, setNodes] = useState<HubNodeSummary[]>([]);
+    const [remoteCwd, setRemoteCwd] = useState('');
     const [environmentSelection, setEnvironmentSelection] =
       useState<EnvironmentSelection>({
         selectedGroupId: null,
@@ -779,6 +860,29 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
       ]
     );
 
+    const remoteNodeSelected =
+      environmentModel.selectedNodeId !== DEFAULT_LOCAL_NODE_ID;
+    const selectedRemoteNode = remoteNodeSelected
+      ? (nodes.find(
+          (node) => node.nodeId === environmentModel.selectedNodeId
+        ) ?? null)
+      : null;
+    const selectedRemoteHome = cleanCwd(selectedRemoteNode?.homeDir);
+
+    useEffect(() => {
+      if (!remoteNodeSelected) {
+        setRemoteCwd('');
+        return;
+      }
+      setRemoteCwd(
+        defaultRemoteCwd(selectedRemoteHome, environmentModel.selectedNodeId)
+      );
+    }, [
+      environmentModel.selectedNodeId,
+      remoteNodeSelected,
+      selectedRemoteHome,
+    ]);
+
     useImperativeHandle(ref, () => ({
       async open(
         workspace: { name: string; path: string },
@@ -790,6 +894,7 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
         setForm(defaultForm());
         setInventory(null);
         setNodes([]);
+        setRemoteCwd('');
         setEnvironmentSelection({
           selectedGroupId: null,
           selectedNodeId: null,
@@ -833,7 +938,10 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
       },
     }));
 
-    async function handleSubmit() {
+    async function handleSubmit(
+      remoteCwdOverride?: string,
+      rememberCwd = true
+    ) {
       if (!workspacePath || creating) return;
       const selectedFramework = frameworks.find(
         (framework) => framework.id === form.selectedAgent
@@ -856,11 +964,19 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
         );
         return;
       }
+      const cwdForRemote = remoteNodeSelected
+        ? cleanCwd(remoteCwdOverride ?? remoteCwd)
+        : undefined;
+      if (remoteNodeSelected && !cwdForRemote) {
+        setError('cwd is required for remote node sessions');
+        return;
+      }
       setCreating(true);
       setError(null);
       const { session, error: submitError } = await createSessionFromForm(
         environmentModel.resolved,
-        form
+        form,
+        cwdForRemote
       );
       try {
         if (submitError && !session) {
@@ -870,6 +986,9 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
               : 'Failed to create session'
           );
           return;
+        }
+        if (remoteNodeSelected && cwdForRemote && rememberCwd) {
+          rememberRemoteCwd(environmentModel.selectedNodeId, cwdForRemote);
         }
         shellRef.current?.close();
         if (session?.id) onSessionCreated?.(session.id);
@@ -887,13 +1006,24 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
         >
           Cancel
         </TuiButton>
+        {remoteNodeSelected && (
+          <TuiButton
+            variant="ghost"
+            data-track="dialog.customize-session.start-in-home"
+            onClick={() => void handleSubmit(selectedRemoteHome, false)}
+            disabled={!workspacePath || !selectedRemoteHome || creating}
+          >
+            Start in Home
+          </TuiButton>
+        )}
         <TuiButton
           variant="primary"
           data-track="dialog.customize-session.create"
-          onClick={handleSubmit}
+          onClick={() => void handleSubmit()}
           disabled={
             !workspacePath ||
             Boolean(environmentModel.selectedNodeReason) ||
+            (remoteNodeSelected && !cleanCwd(remoteCwd)) ||
             creating ||
             frameworks.some(
               (framework) =>
@@ -925,10 +1055,13 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
           workspaceName={workspaceName}
           form={form}
           environmentModel={environmentModel}
+          selectedRemoteNode={selectedRemoteNode}
+          remoteCwd={remoteCwd}
           onFormChange={(patch) => setForm((f) => ({ ...f, ...patch }))}
           onEnvironmentChange={(patch) =>
             setEnvironmentSelection((selection) => ({ ...selection, ...patch }))
           }
+          onRemoteCwdChange={setRemoteCwd}
         />
       </DialogShell>
     );

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -542,13 +542,17 @@ async function createSessionFromForm(
   remoteCwd?: string
 ) {
   const claudeArgs = form.claudeArgsInput.trim().split(/\s+/).filter(Boolean);
+  const remoteNodeSelected = environment.nodeId !== DEFAULT_LOCAL_NODE_ID;
+  const sessionMode: SessionLaunchMode = remoteNodeSelected
+    ? 'pty'
+    : form.sessionMode;
   const { cols, rows } = estimateTerminalDimensions(
     useUiStore.getState().terminalFontSize
   );
   const baseOptions = {
     nodeId: environment.nodeId,
     type: 'agent' as const,
-    mode: form.sessionMode,
+    mode: sessionMode,
     continue: form.continueExisting,
     yolo: form.yoloMode,
     claudeArgs: claudeArgs.length > 0 ? claudeArgs : undefined,
@@ -557,7 +561,7 @@ async function createSessionFromForm(
     cols,
     rows,
   };
-  if (environment.nodeId !== DEFAULT_LOCAL_NODE_ID) {
+  if (remoteNodeSelected) {
     return createAgentSession({
       ...baseOptions,
       cwd: cleanCwd(remoteCwd),
@@ -617,10 +621,11 @@ function CustomizeSessionBody({
           } satisfies FrameworkInfo,
         ];
 
-  const modeOptions = getSessionModeOptions(
-    frameworkOptions,
-    form.selectedAgent
-  );
+  const remoteNodeSelected =
+    environmentModel.selectedNodeId !== DEFAULT_LOCAL_NODE_ID;
+  const modeOptions = remoteNodeSelected
+    ? ([{ value: 'pty', label: 'tui' }] satisfies SessionModeOption[])
+    : getSessionModeOptions(frameworkOptions, form.selectedAgent);
   const selectedFramework = frameworkOptions.find(
     (framework) => framework.id === form.selectedAgent
   );
@@ -630,8 +635,6 @@ function CustomizeSessionBody({
     selectedFramework &&
     form.sessionMode === 'web' &&
     !isFrameworkWebAvailable(selectedFramework);
-  const remoteNodeSelected =
-    environmentModel.selectedNodeId !== DEFAULT_LOCAL_NODE_ID;
   const remoteNodeLabel =
     selectedRemoteNode?.displayName ?? environmentModel.selectedNodeId;
   const remoteHomeDir = cleanCwd(selectedRemoteNode?.homeDir);

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -330,19 +330,29 @@ function checkoutChoicesFor(
   ]);
 }
 
-export function buildEnvironmentPickerModel(
+function environmentGroupsFor(
   input: EnvironmentPickerInput
-): EnvironmentPickerModel {
-  const groups = input.inventory?.groups.length
+): AggregatedRepoInventoryGroup[] {
+  return input.inventory?.groups.length
     ? input.inventory.groups
     : [fallbackGroupFor(input.fallbackWorkspace, input.fallbackWorktreePath)];
-  const selectedGroup =
+}
+
+function selectedEnvironmentGroup(
+  groups: AggregatedRepoInventoryGroup[],
+  input: EnvironmentPickerInput
+): AggregatedRepoInventoryGroup {
+  return (
     groups.find((group) => group.groupId === input.selectedGroupId) ??
     findGroupForPath(
       groups,
       input.fallbackWorktreePath ?? input.fallbackWorkspace.path
     ) ??
-    groups[0]!;
+    groups[0]!
+  );
+}
+
+function nodeMapFor(input: EnvironmentPickerInput): Map<NodeId, HubNodeSummary> {
   const nodeById = new Map(input.nodes.map((node) => [node.nodeId, node]));
   if (!nodeById.has(DEFAULT_LOCAL_NODE_ID)) {
     nodeById.set(
@@ -350,14 +360,33 @@ export function buildEnvironmentPickerModel(
       syntheticLocalNode(input.selectedAgent)
     );
   }
-  const nodeChoiceIds = [
+  return nodeById;
+}
+
+function nodeLabel(nodeId: NodeId, node: HubNodeSummary | null): string {
+  if (nodeId === DEFAULT_LOCAL_NODE_ID) return node?.displayName ?? 'local';
+  return node?.displayName ?? nodeId;
+}
+
+function nodeChoiceIdsFor(
+  selectedGroup: AggregatedRepoInventoryGroup,
+  nodes: HubNodeSummary[]
+): NodeId[] {
+  return [
     ...uniqueInstancesByNode(selectedGroup.instances).map(
       (instance) => instance.nodeId
     ),
-    ...input.nodes.map((node) => node.nodeId),
+    ...nodes.map((node) => node.nodeId),
   ];
+}
+
+function nodeChoicesFor(
+  selectedGroup: AggregatedRepoInventoryGroup,
+  input: EnvironmentPickerInput,
+  nodeById: Map<NodeId, HubNodeSummary>
+): EnvironmentChoice[] {
   const seenNodeChoices = new Set<NodeId>();
-  const nodeChoices = nodeChoiceIds.flatMap((nodeId) => {
+  return nodeChoiceIdsFor(selectedGroup, input.nodes).flatMap((nodeId) => {
     if (seenNodeChoices.has(nodeId)) return [];
     seenNodeChoices.add(nodeId);
     const node = nodeById.get(nodeId) ?? null;
@@ -365,33 +394,28 @@ export function buildEnvironmentPickerModel(
     return [
       {
         value: nodeId,
-        label:
-          nodeId === DEFAULT_LOCAL_NODE_ID
-            ? (node?.displayName ?? 'local')
-            : (node?.displayName ?? nodeId),
+        label: nodeLabel(nodeId, node),
         ...(reason ? { disabled: true, reason } : {}),
       },
     ];
   });
-  const explicitlySelectedNodeChoice = nodeChoices.find(
-    (choice) => choice.value === input.selectedNodeId
-  );
-  const firstEnabledNodeChoice = nodeChoices.find((choice) => !choice.disabled);
-  const selectedNodeChoice =
-    explicitlySelectedNodeChoice &&
-    (!explicitlySelectedNodeChoice.disabled || !firstEnabledNodeChoice)
-      ? explicitlySelectedNodeChoice
-      : (firstEnabledNodeChoice ?? explicitlySelectedNodeChoice ?? nodeChoices[0]);
-  const selectedNodeId = selectedNodeChoice?.value ?? DEFAULT_LOCAL_NODE_ID;
-  const selectedNodeReason = selectedNodeChoice?.reason ?? null;
-  const selectedNodeInstances = selectedGroup.instances.filter(
-    (instance) => instance.nodeId === selectedNodeId
-  );
-  const checkoutChoices = checkoutChoicesFor(
-    selectedNodeInstances,
-    selectedNodeReason
-  );
-  const selectedCheckout =
+}
+
+function selectedNodeChoiceFor(
+  nodeChoices: EnvironmentChoice[],
+  selectedNodeId: NodeId | null
+): EnvironmentChoice | undefined {
+  const explicit = nodeChoices.find((choice) => choice.value === selectedNodeId);
+  const firstEnabled = nodeChoices.find((choice) => !choice.disabled);
+  if (explicit && (!explicit.disabled || !firstEnabled)) return explicit;
+  return firstEnabled ?? explicit ?? nodeChoices[0];
+}
+
+function selectedCheckoutFor(
+  checkoutChoices: EnvironmentCheckoutChoice[],
+  input: EnvironmentPickerInput
+): EnvironmentCheckoutChoice | undefined {
+  return (
     checkoutChoices.find(
       (choice) => choice.value === input.selectedCheckoutId && !choice.disabled
     ) ??
@@ -406,32 +430,79 @@ export function buildEnvironmentPickerModel(
         choice.repoPath === input.fallbackWorkspace.path
     ) ??
     checkoutChoices.find((choice) => !choice.disabled) ??
-    checkoutChoices[0];
-  const resolved =
-    selectedNodeId !== DEFAULT_LOCAL_NODE_ID
-      ? {
-          nodeId: selectedNodeId,
-          repoPath: selectedCheckout?.repoPath ?? '',
-          worktreePath: selectedCheckout?.worktreePath ?? null,
-        }
-      : selectedCheckout
-        ? {
-            nodeId: selectedCheckout.nodeId,
-            repoPath: selectedCheckout.repoPath,
-            worktreePath: selectedCheckout.worktreePath,
-          }
-        : {
-            nodeId: DEFAULT_LOCAL_NODE_ID,
-            repoPath: input.fallbackWorkspace.path,
-            worktreePath: input.fallbackWorktreePath,
-          };
+    checkoutChoices[0]
+  );
+}
+
+function resolveEnvironment(
+  selectedNodeId: NodeId,
+  selectedCheckout: EnvironmentCheckoutChoice | undefined,
+  input: EnvironmentPickerInput
+): EnvironmentPickerModel['resolved'] {
+  if (selectedNodeId !== DEFAULT_LOCAL_NODE_ID) {
+    return {
+      nodeId: selectedNodeId,
+      repoPath: selectedCheckout?.repoPath ?? '',
+      worktreePath: selectedCheckout?.worktreePath ?? null,
+    };
+  }
+  if (selectedCheckout) {
+    return {
+      nodeId: selectedCheckout.nodeId,
+      repoPath: selectedCheckout.repoPath,
+      worktreePath: selectedCheckout.worktreePath,
+    };
+  }
+  return {
+    nodeId: DEFAULT_LOCAL_NODE_ID,
+    repoPath: input.fallbackWorkspace.path,
+    worktreePath: input.fallbackWorktreePath,
+  };
+}
+
+function shouldShowEnvironmentPicker(
+  groups: AggregatedRepoInventoryGroup[],
+  nodeChoices: EnvironmentChoice[],
+  checkoutChoices: EnvironmentCheckoutChoice[],
+  selectedNodeReason: string | null
+): boolean {
+  return (
+    groups.length > 1 ||
+    nodeChoices.length > 1 ||
+    checkoutChoices.length > 1 ||
+    Boolean(selectedNodeReason)
+  );
+}
+
+export function buildEnvironmentPickerModel(
+  input: EnvironmentPickerInput
+): EnvironmentPickerModel {
+  const groups = environmentGroupsFor(input);
+  const selectedGroup = selectedEnvironmentGroup(groups, input);
+  const nodeById = nodeMapFor(input);
+  const nodeChoices = nodeChoicesFor(selectedGroup, input, nodeById);
+  const selectedNodeChoice = selectedNodeChoiceFor(
+    nodeChoices,
+    input.selectedNodeId
+  );
+  const selectedNodeId = selectedNodeChoice?.value ?? DEFAULT_LOCAL_NODE_ID;
+  const selectedNodeReason = selectedNodeChoice?.reason ?? null;
+  const selectedNodeInstances = selectedGroup.instances.filter(
+    (instance) => instance.nodeId === selectedNodeId
+  );
+  const checkoutChoices = checkoutChoicesFor(
+    selectedNodeInstances,
+    selectedNodeReason
+  );
+  const selectedCheckout = selectedCheckoutFor(checkoutChoices, input);
 
   return {
-    showPicker:
-      groups.length > 1 ||
-      nodeChoices.length > 1 ||
-      checkoutChoices.length > 1 ||
-      Boolean(selectedNodeReason),
+    showPicker: shouldShowEnvironmentPicker(
+      groups,
+      nodeChoices,
+      checkoutChoices,
+      selectedNodeReason
+    ),
     repoChoices: groups.map((group) => ({
       value: group.groupId,
       label: labelForRepo(group),
@@ -442,7 +513,7 @@ export function buildEnvironmentPickerModel(
     selectedNodeId,
     selectedCheckoutId: selectedCheckout?.value ?? null,
     selectedNodeReason,
-    resolved,
+    resolved: resolveEnvironment(selectedNodeId, selectedCheckout, input),
   };
 }
 

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -14,6 +14,11 @@ import { useConfigStore } from '../../lib/stores/config.js';
 import { useUiStore } from '../../lib/stores/ui.js';
 import { createAgentSession } from '../../lib/session-utils.js';
 import { fetchHubNodes, fetchRepoInventory } from '../../lib/api.js';
+import {
+  cleanCwd,
+  defaultRemoteCwd,
+  rememberRemoteCwd,
+} from '../../lib/remote-node-cwd.js';
 import type {
   AgentType,
   AggregatedRepoInventoryGroup,
@@ -146,40 +151,6 @@ export interface EnvironmentPickerInput {
 
 const CHECKOUT_ROOT_PREFIX = 'repo:';
 const CHECKOUT_WORKTREE_PREFIX = 'worktree:';
-const REMOTE_NODE_CWD_STORAGE_PREFIX = 'relay-ide.remote-node-cwd.';
-
-function cleanCwd(value: string | undefined): string {
-  return value?.trim() ?? '';
-}
-
-function remoteNodeCwdStorageKey(nodeId: NodeId): string {
-  return `${REMOTE_NODE_CWD_STORAGE_PREFIX}${nodeId}`;
-}
-
-function readRememberedRemoteCwd(nodeId: NodeId): string | null {
-  try {
-    const remembered = window.localStorage.getItem(
-      remoteNodeCwdStorageKey(nodeId)
-    );
-    return remembered?.trim() ? remembered : null;
-  } catch {
-    return null;
-  }
-}
-
-function rememberRemoteCwd(nodeId: NodeId, cwd: string): void {
-  const trimmed = cleanCwd(cwd);
-  if (!trimmed) return;
-  try {
-    window.localStorage.setItem(remoteNodeCwdStorageKey(nodeId), trimmed);
-  } catch {
-    // localStorage can be unavailable in private contexts; launching still works.
-  }
-}
-
-function defaultRemoteCwd(homeDir: string | undefined, nodeId: NodeId): string {
-  return readRememberedRemoteCwd(nodeId) ?? cleanCwd(homeDir);
-}
 
 function syntheticLocalNode(selectedAgent: AgentType): HubNodeSummary {
   return {
@@ -379,23 +350,38 @@ export function buildEnvironmentPickerModel(
       syntheticLocalNode(input.selectedAgent)
     );
   }
-  const nodeChoices = uniqueInstancesByNode(selectedGroup.instances).map(
-    (instance) => {
-      const node = nodeById.get(instance.nodeId) ?? null;
-      const reason = nodeBlockReason(node, input.selectedAgent);
-      return {
-        value: instance.nodeId,
-        label: node?.displayName ?? instance.nodeId,
+  const nodeChoiceIds = [
+    ...uniqueInstancesByNode(selectedGroup.instances).map(
+      (instance) => instance.nodeId
+    ),
+    ...input.nodes.map((node) => node.nodeId),
+  ];
+  const seenNodeChoices = new Set<NodeId>();
+  const nodeChoices = nodeChoiceIds.flatMap((nodeId) => {
+    if (seenNodeChoices.has(nodeId)) return [];
+    seenNodeChoices.add(nodeId);
+    const node = nodeById.get(nodeId) ?? null;
+    const reason = nodeBlockReason(node, input.selectedAgent);
+    return [
+      {
+        value: nodeId,
+        label:
+          nodeId === DEFAULT_LOCAL_NODE_ID
+            ? (node?.displayName ?? 'local')
+            : (node?.displayName ?? nodeId),
         ...(reason ? { disabled: true, reason } : {}),
-      };
-    }
+      },
+    ];
+  });
+  const explicitlySelectedNodeChoice = nodeChoices.find(
+    (choice) => choice.value === input.selectedNodeId
   );
+  const firstEnabledNodeChoice = nodeChoices.find((choice) => !choice.disabled);
   const selectedNodeChoice =
-    nodeChoices.find(
-      (choice) => choice.value === input.selectedNodeId && !choice.disabled
-    ) ??
-    nodeChoices.find((choice) => !choice.disabled) ??
-    nodeChoices[0];
+    explicitlySelectedNodeChoice &&
+    (!explicitlySelectedNodeChoice.disabled || !firstEnabledNodeChoice)
+      ? explicitlySelectedNodeChoice
+      : (firstEnabledNodeChoice ?? explicitlySelectedNodeChoice ?? nodeChoices[0]);
   const selectedNodeId = selectedNodeChoice?.value ?? DEFAULT_LOCAL_NODE_ID;
   const selectedNodeReason = selectedNodeChoice?.reason ?? null;
   const selectedNodeInstances = selectedGroup.instances.filter(
@@ -421,17 +407,24 @@ export function buildEnvironmentPickerModel(
     ) ??
     checkoutChoices.find((choice) => !choice.disabled) ??
     checkoutChoices[0];
-  const resolved = selectedCheckout
-    ? {
-        nodeId: selectedCheckout.nodeId,
-        repoPath: selectedCheckout.repoPath,
-        worktreePath: selectedCheckout.worktreePath,
-      }
-    : {
-        nodeId: DEFAULT_LOCAL_NODE_ID,
-        repoPath: input.fallbackWorkspace.path,
-        worktreePath: input.fallbackWorktreePath,
-      };
+  const resolved =
+    selectedNodeId !== DEFAULT_LOCAL_NODE_ID
+      ? {
+          nodeId: selectedNodeId,
+          repoPath: selectedCheckout?.repoPath ?? '',
+          worktreePath: selectedCheckout?.worktreePath ?? null,
+        }
+      : selectedCheckout
+        ? {
+            nodeId: selectedCheckout.nodeId,
+            repoPath: selectedCheckout.repoPath,
+            worktreePath: selectedCheckout.worktreePath,
+          }
+        : {
+            nodeId: DEFAULT_LOCAL_NODE_ID,
+            repoPath: input.fallbackWorkspace.path,
+            worktreePath: input.fallbackWorktreePath,
+          };
 
   return {
     showPicker:
@@ -577,7 +570,7 @@ function CustomizeSessionBody({
       {workspaceName && (
         <p className="customize-session-workspace-name">— {workspaceName}</p>
       )}
-      {environmentModel.showPicker && (
+      {(environmentModel.showPicker || remoteNodeSelected) && (
         <section
           className="customize-session-environment-picker"
           aria-label="environment picker"
@@ -967,6 +960,10 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
         );
         return;
       }
+      if (environmentModel.selectedNodeReason) {
+        setError(environmentModel.selectedNodeReason);
+        return;
+      }
       const cwdForRemote = remoteNodeSelected
         ? cleanCwd(remoteCwdOverride ?? remoteCwd)
         : undefined;
@@ -981,13 +978,13 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
           ? 'remote-cwd'
           : 'remote-home'
         : 'local-repo';
-      const { session, error: submitError } = await createSessionFromForm(
-        environmentModel.resolved,
-        form,
-        sessionLane,
-        cwdForRemote
-      );
       try {
+        const { session, error: submitError } = await createSessionFromForm(
+          environmentModel.resolved,
+          form,
+          sessionLane,
+          cwdForRemote
+        );
         if (submitError && !session) {
           setError(
             submitError instanceof Error
@@ -1020,7 +1017,12 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
             variant="ghost"
             data-track="dialog.customize-session.start-in-home"
             onClick={() => void handleSubmit(selectedRemoteHome, false)}
-            disabled={!workspacePath || !selectedRemoteHome || creating}
+            disabled={
+              !workspacePath ||
+              !selectedRemoteHome ||
+              Boolean(environmentModel.selectedNodeReason) ||
+              creating
+            }
           >
             Start in Home
           </TuiButton>

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -30,6 +30,7 @@ import {
   DEFAULT_LOCAL_NODE_ID,
   type NodeId,
 } from '../../../../shared/identity.js';
+import type { SessionLane } from '../../../../shared/session-lane.js';
 import './CustomizeSessionDialog.css';
 
 export interface CustomizeSessionDialogHandle {
@@ -473,6 +474,7 @@ function defaultForm(): FormState {
 async function createSessionFromForm(
   environment: EnvironmentPickerModel['resolved'],
   form: FormState,
+  sessionLane: SessionLane,
   remoteCwd?: string
 ) {
   const claudeArgs = form.claudeArgsInput.trim().split(/\s+/).filter(Boolean);
@@ -487,6 +489,7 @@ async function createSessionFromForm(
     yolo: form.yoloMode,
     claudeArgs: claudeArgs.length > 0 ? claudeArgs : undefined,
     agent: form.selectedAgent,
+    sessionLane,
     cols,
     rows,
   };
@@ -973,9 +976,15 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
       }
       setCreating(true);
       setError(null);
+      const sessionLane: SessionLane = remoteNodeSelected
+        ? rememberCwd
+          ? 'remote-cwd'
+          : 'remote-home'
+        : 'local-repo';
       const { session, error: submitError } = await createSessionFromForm(
         environmentModel.resolved,
         form,
+        sessionLane,
         cwdForRemote
       );
       try {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -37,6 +37,7 @@ import {
   parseGlobalSessionId,
   type NodeId,
 } from '../../../shared/identity.js';
+import type { SessionLane } from '../../../shared/session-lane.js';
 
 export class ConflictError extends Error {
   sessionId: string;
@@ -559,6 +560,7 @@ export async function createSession(body: {
   needsBranchRename?: boolean | undefined;
   newWorktree?: boolean | undefined;
   branchRenamePrompt?: string | undefined;
+  sessionLane?: SessionLane | undefined;
   ticketContext?: {
     ticketId: string;
     title: string;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -144,9 +144,9 @@ async function httpErrorFromResponse(
         ? data.message
         : typeof structuredError?.['message'] === 'string'
           ? structuredError['message']
-        : typeof data.error === 'string'
-          ? httpErrorMessage(res.status, data.error)
-          : httpErrorMessage(res.status, fallback);
+          : typeof data.error === 'string'
+            ? httpErrorMessage(res.status, data.error)
+            : httpErrorMessage(res.status, fallback);
     return new HttpError(res.status, message, code, retryable);
   } catch {
     return new HttpError(res.status, httpErrorMessage(res.status, fallback));
@@ -247,7 +247,12 @@ function normalizeTelemetrySessions(data: unknown): SessionTelemetry[] {
       return Object.entries(value.sessions as Record<string, unknown>).flatMap(
         ([sessionId, raw]) => {
           if (!raw || typeof raw !== 'object') return [];
-          return [normalizeTelemetryMapEntry(sessionId, raw as Record<string, unknown>)];
+          return [
+            normalizeTelemetryMapEntry(
+              sessionId,
+              raw as Record<string, unknown>
+            ),
+          ];
         }
       );
     }
@@ -257,7 +262,9 @@ function normalizeTelemetrySessions(data: unknown): SessionTelemetry[] {
       return normalizeTelemetrySessions(value.data);
     return Object.entries(value).flatMap(([sessionId, raw]) => {
       if (!raw || typeof raw !== 'object') return [];
-      return [normalizeTelemetryMapEntry(sessionId, raw as Record<string, unknown>)];
+      return [
+        normalizeTelemetryMapEntry(sessionId, raw as Record<string, unknown>),
+      ];
     });
   }
   return [];
@@ -332,7 +339,9 @@ export async function fetchWorkspaces(): Promise<Repo[]> {
 }
 
 export async function fetchRepoInventory(): Promise<AggregatedRepoInventoryResponse> {
-  return json<AggregatedRepoInventoryResponse>(await fetch('/hub/repo-inventory'));
+  return json<AggregatedRepoInventoryResponse>(
+    await fetch('/hub/repo-inventory')
+  );
 }
 
 export async function addWorkspace(path: string): Promise<void> {
@@ -534,8 +543,9 @@ export async function enrichBranches(
 
 export async function createSession(body: {
   nodeId?: NodeId | undefined;
-  repoPath: string;
+  repoPath?: string | undefined;
   worktreePath?: string | null | undefined;
+  cwd?: string | undefined;
   type?: 'agent' | 'terminal' | undefined;
   mode?: 'pty' | 'web' | undefined;
   continue?: boolean | undefined;
@@ -583,7 +593,8 @@ export async function createSession(body: {
 
 export async function killSession(id: string): Promise<void> {
   const res = await fetch('/sessions/' + id, { method: 'DELETE' });
-  if (!res.ok) throw await httpErrorFromResponse(res, 'Failed to close session');
+  if (!res.ok)
+    throw await httpErrorFromResponse(res, 'Failed to close session');
 }
 
 export async function renameSession(

--- a/frontend/src/lib/remote-node-cwd.ts
+++ b/frontend/src/lib/remote-node-cwd.ts
@@ -1,0 +1,39 @@
+import type { NodeId } from '../../../shared/identity.js';
+
+const REMOTE_NODE_CWD_STORAGE_PREFIX = 'relay-ide.remote-node-cwd.';
+
+export function cleanCwd(value: string | undefined): string {
+  return value?.trim() ?? '';
+}
+
+export function remoteNodeCwdStorageKey(nodeId: NodeId): string {
+  return `${REMOTE_NODE_CWD_STORAGE_PREFIX}${nodeId}`;
+}
+
+export function readRememberedRemoteCwd(nodeId: NodeId): string | null {
+  try {
+    const remembered = window.localStorage.getItem(
+      remoteNodeCwdStorageKey(nodeId)
+    );
+    return remembered?.trim() ? remembered : null;
+  } catch {
+    return null;
+  }
+}
+
+export function rememberRemoteCwd(nodeId: NodeId, cwd: string): void {
+  const trimmed = cleanCwd(cwd);
+  if (!trimmed) return;
+  try {
+    window.localStorage.setItem(remoteNodeCwdStorageKey(nodeId), trimmed);
+  } catch {
+    // localStorage can be unavailable in private contexts; launching still works.
+  }
+}
+
+export function defaultRemoteCwd(
+  homeDir: string | undefined,
+  nodeId: NodeId
+): string {
+  return readRememberedRemoteCwd(nodeId) ?? cleanCwd(homeDir);
+}

--- a/frontend/src/lib/session-utils.ts
+++ b/frontend/src/lib/session-utils.ts
@@ -4,6 +4,7 @@ import { useUiStore } from './stores/ui.js';
 import { resolveSessionByKey } from './session-keys.js';
 import type { Repo, SessionSummary } from './types.js';
 import type { NodeId } from '../../../shared/identity.js';
+import type { SessionLane } from '../../../shared/session-lane.js';
 
 export interface CreateAgentSessionOptions {
   nodeId?: NodeId | undefined;
@@ -23,6 +24,7 @@ export interface CreateAgentSessionOptions {
   needsBranchRename?: boolean | undefined;
   newWorktree?: boolean | undefined;
   branchRenamePrompt?: string | undefined;
+  sessionLane?: SessionLane | undefined;
   ticketContext?: {
     ticketId: string;
     title: string;

--- a/frontend/src/lib/session-utils.ts
+++ b/frontend/src/lib/session-utils.ts
@@ -7,8 +7,9 @@ import type { NodeId } from '../../../shared/identity.js';
 
 export interface CreateAgentSessionOptions {
   nodeId?: NodeId | undefined;
-  repoPath: string;
+  repoPath?: string | undefined;
   worktreePath?: string | null | undefined;
+  cwd?: string | undefined;
   type?: 'agent' | 'terminal' | undefined;
   mode?: 'pty' | 'web' | undefined;
   continue?: boolean | undefined;

--- a/frontend/src/test-customize-session-dialog.tsx
+++ b/frontend/src/test-customize-session-dialog.tsx
@@ -38,6 +38,7 @@ function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
     nodeId: 'local',
     displayName: 'local mac',
     hostname: 'local.local',
+    homeDir: '/Users/kyle',
     platform: 'darwin',
     arch: 'arm64',
     relayVersion: '0.1.0',
@@ -262,7 +263,7 @@ function nodes(): HubNodeSummary[] {
   if (scenario === 'single') return [node()];
   return [
     node(),
-    node({ nodeId: 'linux', displayName: 'linux lab' }),
+    node({ nodeId: 'linux', displayName: 'linux lab', homeDir: '/home/linux' }),
     node({ nodeId: 'offline', displayName: 'offline lab', status: 'offline' }),
     node({
       nodeId: 'no-tmux',
@@ -327,18 +328,15 @@ window.fetch = async (input, init) => {
   }
   if (url.pathname === '/hub/nodes/linux/sessions' && init?.method === 'POST') {
     lastCreateRequest = `${url.pathname} ${init.body ?? ''}`;
+    const body = JSON.parse(String(init.body ?? '{}')) as { cwd?: string };
     return jsonResponse({
-      id: 'remote-session',
+      id: body.cwd === '/home/linux' ? 'remote-home-session' : 'remote-session',
       nodeId: 'linux',
       globalSessionId: 'linux:remote-session',
       type: 'agent',
       agent: 'claude',
-      repoName: 'relay-ide',
-      repoPath: '/srv/relay-ide',
-      worktreePath: '/srv/relay-ide/.worktrees/feature',
-      cwd: '/srv/relay-ide/.worktrees/feature',
-      branchName: 'feature/linux',
-      displayName: 'feature/linux',
+      cwd: body.cwd ?? '/home/linux',
+      displayName: 'linux shell',
       createdAt: '2026-05-12T00:00:00.000Z',
       lastActivity: '2026-05-12T00:00:00.000Z',
       idle: false,

--- a/frontend/src/test-customize-session-dialog.tsx
+++ b/frontend/src/test-customize-session-dialog.tsx
@@ -13,7 +13,12 @@ import './components/dialogs/DialogShell.css';
 import './components/dialogs/CustomizeSessionDialog.css';
 
 const nativeFetch = window.fetch.bind(window);
-let scenario: 'multi' | 'single' | 'single-disabled' = 'multi';
+let scenario:
+  | 'multi'
+  | 'multi-hermes'
+  | 'single'
+  | 'single-hermes'
+  | 'single-disabled' = 'multi';
 let lastCreateRequest = '';
 
 function framework(id: string): FrameworkInfo {
@@ -68,7 +73,7 @@ function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
         tailscale: 'available',
       },
       worktrees: 'available',
-      agents: { claude: 'available', codex: 'available' },
+      agents: { claude: 'available', codex: 'available', hermes: 'available' },
       serviceManager: 'launchd',
       wsl: false,
     },
@@ -81,7 +86,11 @@ function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
 }
 
 function inventory(): AggregatedRepoInventoryResponse {
-  if (scenario === 'single' || scenario === 'single-disabled') {
+  if (
+    scenario === 'single' ||
+    scenario === 'single-hermes' ||
+    scenario === 'single-disabled'
+  ) {
     return {
       generatedAt: '2026-05-12T00:00:00.000Z',
       reports: [],
@@ -260,7 +269,7 @@ function inventory(): AggregatedRepoInventoryResponse {
 
 function nodes(): HubNodeSummary[] {
   if (scenario === 'single-disabled') return [node({ status: 'offline' })];
-  if (scenario === 'single') return [node()];
+  if (scenario === 'single' || scenario === 'single-hermes') return [node()];
   return [
     node(),
     node({ nodeId: 'linux', displayName: 'linux lab', homeDir: '/home/linux' }),
@@ -304,17 +313,23 @@ window.fetch = async (input, init) => {
   if (url.pathname === '/config/defaultYolo')
     return jsonResponse({ defaultYolo: false });
   if (url.pathname === '/config/defaultAgent')
-    return jsonResponse({ defaultAgent: 'claude' });
+    return jsonResponse({
+      defaultAgent:
+        scenario === 'multi-hermes' || scenario === 'single-hermes'
+          ? 'hermes'
+          : 'claude',
+    });
   if (url.pathname === '/config/defaultNotifications')
     return jsonResponse({ defaultNotifications: true });
   if (url.pathname === '/config/claudeFullscreen')
     return jsonResponse({ claudeFullscreen: true });
   if (url.pathname === '/sessions' && init?.method === 'POST') {
     lastCreateRequest = `${url.pathname} ${init.body ?? ''}`;
+    const body = JSON.parse(String(init.body ?? '{}')) as { agent?: string };
     return jsonResponse({
       id: 'local-session',
       type: 'agent',
-      agent: 'claude',
+      agent: body.agent ?? 'claude',
       repoName: 'relay-ide',
       repoPath: '/Users/kyle/relay-ide',
       worktreePath: null,
@@ -328,13 +343,16 @@ window.fetch = async (input, init) => {
   }
   if (url.pathname === '/hub/nodes/linux/sessions' && init?.method === 'POST') {
     lastCreateRequest = `${url.pathname} ${init.body ?? ''}`;
-    const body = JSON.parse(String(init.body ?? '{}')) as { cwd?: string };
+    const body = JSON.parse(String(init.body ?? '{}')) as {
+      agent?: string;
+      cwd?: string;
+    };
     return jsonResponse({
       id: body.cwd === '/home/linux' ? 'remote-home-session' : 'remote-session',
       nodeId: 'linux',
       globalSessionId: 'linux:remote-session',
       type: 'agent',
-      agent: 'claude',
+      agent: body.agent ?? 'claude',
       cwd: body.cwd ?? '/home/linux',
       displayName: 'linux shell',
       createdAt: '2026-05-12T00:00:00.000Z',
@@ -365,7 +383,7 @@ useConfigStore.setState({
   defaultAgent: 'claude',
   defaultContinue: false,
   defaultYolo: false,
-  frameworks: [framework('claude'), framework('codex')],
+  frameworks: [framework('claude'), framework('codex'), framework('hermes')],
 });
 
 function Harness() {
@@ -388,6 +406,18 @@ function Harness() {
       <button
         type="button"
         onClick={() => {
+          scenario = 'multi-hermes';
+          void dialogRef.current?.open({
+            name: 'relay-ide',
+            path: '/Users/kyle/relay-ide',
+          });
+        }}
+      >
+        open web-capable remote customize session
+      </button>
+      <button
+        type="button"
+        onClick={() => {
           scenario = 'single';
           void dialogRef.current?.open({
             name: 'relay-ide',
@@ -396,6 +426,18 @@ function Harness() {
         }}
       >
         open single-node customize session
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          scenario = 'single-hermes';
+          void dialogRef.current?.open({
+            name: 'relay-ide',
+            path: '/Users/kyle/relay-ide',
+          });
+        }}
+      >
+        open local web-capable customize session
       </button>
       <button
         type="button"

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -37,6 +37,7 @@ interface StoredNodeRecord {
   credentialHash: string;
   displayName: string;
   hostname: string;
+  homeDir?: string;
   platform: string;
   arch: string;
   relayVersion: string;
@@ -300,6 +301,7 @@ function publicNode(
     nodeId: node.nodeId,
     displayName: node.displayName,
     hostname: node.hostname,
+    ...(node.homeDir ? { homeDir: node.homeDir } : {}),
     platform: node.platform,
     arch: node.arch,
     relayVersion: node.relayVersion,
@@ -439,6 +441,7 @@ export class HubNodeRegistry {
         input.manifest
       ),
       hostname: input.manifest.hostname,
+      ...(input.manifest.homeDir ? { homeDir: input.manifest.homeDir } : {}),
       platform: input.manifest.platform,
       arch: input.manifest.arch,
       relayVersion: input.manifest.relayVersion,
@@ -518,6 +521,8 @@ export class HubNodeRegistry {
     node.protocolVersion = input.protocolVersion;
     if (input.manifest) {
       node.hostname = input.manifest.hostname;
+      if (input.manifest.homeDir) node.homeDir = input.manifest.homeDir;
+      else delete node.homeDir;
       node.platform = input.manifest.platform;
       node.arch = input.manifest.arch;
       node.relayVersion = input.manifest.relayVersion;

--- a/server/index.ts
+++ b/server/index.ts
@@ -119,6 +119,7 @@ import type {
   TicketContext,
   WorkspaceSettings,
 } from './types.js';
+import type { SessionLane } from '../shared/session-lane.js';
 import { resolveFramework } from './types.js';
 import { semverLessThan, clampDimension } from './utils.js';
 import {
@@ -673,6 +674,7 @@ type AgentSessionParams = {
   branchRenamePrompt: string;
   computedInitialPrompt: string | undefined;
   claudeFullscreen: boolean;
+  sessionLane: SessionLane | undefined;
   /** Port env var names to inject for this worktree (from repo settings) */
   portVariables?: string[] | undefined;
 };
@@ -684,6 +686,7 @@ type TerminalSessionParams = {
   cwd: string;
   safeCols: number | undefined;
   safeRows: number | undefined;
+  sessionLane: SessionLane | undefined;
   portVariables?: string[] | undefined;
 };
 
@@ -705,6 +708,7 @@ function createTerminalSessionRecord(
     args: [],
     ...(params.safeCols != null && { cols: params.safeCols }),
     ...(params.safeRows != null && { rows: params.safeRows }),
+    ...(params.sessionLane ? { sessionLane: params.sessionLane } : {}),
     portVariables: params.portVariables,
   });
 }
@@ -730,6 +734,7 @@ function createAgentSessionRecord(params: AgentSessionParams): CreateResult {
     claudeFullscreen: params.claudeFullscreen,
     ...(params.safeCols != null && { cols: params.safeCols }),
     ...(params.safeRows != null && { rows: params.safeRows }),
+    ...(params.sessionLane ? { sessionLane: params.sessionLane } : {}),
     needsBranchRename: params.needsBranchRename,
     branchRenamePrompt: params.branchRenamePrompt,
     ...(params.computedInitialPrompt != null && {
@@ -2316,6 +2321,7 @@ async function main(): Promise<void> {
       initialPrompt,
       continue: explicitContinue,
       continuePolicy: explicitContinuePolicy,
+      sessionLane,
       ticketContext,
     } = req.body as {
       repoPath?: string;
@@ -2335,6 +2341,7 @@ async function main(): Promise<void> {
       initialPrompt?: string;
       continue?: boolean;
       continuePolicy?: ContinuePolicy;
+      sessionLane?: SessionLane;
       ticketContext?: {
         ticketId: string;
         title: string;
@@ -2391,6 +2398,7 @@ async function main(): Promise<void> {
           cwd,
           safeCols,
           safeRows,
+          sessionLane,
           portVariables,
         });
       } catch (err) {
@@ -2452,6 +2460,7 @@ async function main(): Promise<void> {
           displayName,
           port: startupConfig.port,
           configDir,
+          sessionLane,
         });
         gitWatcher.watch(session.cwd);
         res.status(201).json(session);
@@ -2515,6 +2524,7 @@ async function main(): Promise<void> {
         branchRenamePrompt: branchRenamePrompt ?? '',
         computedInitialPrompt,
         claudeFullscreen: freshConfig.claudeFullscreen,
+        sessionLane,
         portVariables,
       });
     } catch (err) {

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -3,7 +3,6 @@ import type { LocalRelayNode } from './local-node.js';
 import type { Logger } from './logger.js';
 import { createLogger } from './logger.js';
 import type { CreateParams } from './sessions.js';
-import type { CreateWebParams } from './web-session-handler.js';
 import type {
   NodeLinkChannelHandler,
   NodeLinkEnvelopeHandlerContext,
@@ -214,10 +213,11 @@ export function createNodeLinkRpcHost(
     }
     try {
       if (parsed.mode === 'web') {
-        const { session } = await localRelayNode.sessions.createWeb(
-          parsed as unknown as CreateWebParams
+        sendErrorEnvelope(
+          ctx,
+          envelope,
+          invalidRequest('remote node web sessions are not supported')
         );
-        sendResultEnvelope(ctx, envelope, { session });
         return;
       }
       const result = localRelayNode.sessions.create(

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -12,6 +12,7 @@ import type {
   RelayNodeEnvelope,
   RelayNodeError,
 } from '../shared/relay-node-protocol.js';
+import { isSessionLane, type SessionLane } from '../shared/session-lane.js';
 import type { SessionSummary } from './types.js';
 
 // Node-side RPC dispatcher. Hub initiates rpc/<type> requests over the
@@ -78,6 +79,7 @@ interface SessionsCreateInput {
   needsBranchRename?: boolean;
   branchRenamePrompt?: string;
   continue?: boolean;
+  sessionLane?: SessionLane;
 }
 
 function parseSessionsCreateInput(
@@ -100,7 +102,7 @@ function parseSessionsCreateInput(
     );
   }
   const input: SessionsCreateInput = { type: typeRaw };
-  if (modeRaw) input.mode = modeRaw;
+  if (modeRaw === 'pty' || modeRaw === 'web') input.mode = modeRaw;
   const agent = asString(record['agent']);
   if (agent !== undefined) input.agent = agent;
   const repoPath = asString(record['repoPath']);
@@ -139,6 +141,15 @@ function parseSessionsCreateInput(
     input.branchRenamePrompt = branchRenamePrompt;
   const continueFlag = asBoolean(record['continue']);
   if (continueFlag !== undefined) input.continue = continueFlag;
+  const sessionLane = record['sessionLane'];
+  if (sessionLane !== undefined) {
+    if (!isSessionLane(sessionLane)) {
+      return invalidRequest(
+        'sessions.create payload.sessionLane must be local-repo, remote-cwd, or remote-home when set'
+      );
+    }
+    input.sessionLane = sessionLane;
+  }
   return input;
 }
 

--- a/server/node-manifest.ts
+++ b/server/node-manifest.ts
@@ -25,6 +25,7 @@ interface NodeManifestOptions {
   platform?: NodeJS.Platform;
   arch?: string;
   hostname?: string;
+  homeDir?: string;
   relayVersion?: string;
   cwd?: string;
 }
@@ -180,6 +181,7 @@ async function getCoreNodeManifest(
     platform,
     arch: options.arch ?? os.arch(),
     hostname: options.hostname ?? os.hostname(),
+    homeDir: options.homeDir ?? os.homedir(),
     relayVersion: options.relayVersion ?? getRelayVersion(),
     generatedAt: (options.now ?? new Date()).toISOString(),
     wsl,

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -29,6 +29,7 @@ import { writeCodexHooksAdapter } from './codex-hooks-adapter.js';
 import { createLogger } from './logger.js';
 import { getDefaultAllocator, type PortAllocator } from './port-allocator.js';
 import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
+import type { SessionLane } from '../shared/session-lane.js';
 
 const IDLE_TIMEOUT_MS = 5000;
 const MAX_SCROLLBACK = 256 * 1024; // 256KB max
@@ -383,6 +384,7 @@ export type CreatePtyParams = {
   tmuxDisplayName?: string | undefined;
   tmuxAttach?: boolean | undefined;
   sessionCustomCommand?: string | null | undefined;
+  sessionLane?: SessionLane | undefined;
   initialScrollback?: string[] | undefined;
   restored?: boolean | undefined;
   port?: number | undefined;

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -55,6 +55,7 @@ import {
 } from './analytics.js';
 import { buildSessionEvent } from './session-attribution.js';
 import { createLogger } from './logger.js';
+import type { SessionLane } from '../shared/session-lane.js';
 
 const execFileAsync = promisify(execFile);
 const logger = createLogger('sessions');
@@ -116,6 +117,7 @@ export type CreateParams = Omit<CreatePtyParams, 'id' | 'callbacks'> & {
   initialPrompt?: string;
   workspaceId?: string;
   additionalDirs?: string[];
+  sessionLane?: SessionLane;
 };
 
 export type CreateResult = SessionSummary & { pid: number | undefined };
@@ -336,6 +338,7 @@ function create({
       type: rest.type ?? 'agent',
       workspace: rest.repoPath,
       mode: rest.command ? 'terminal' : 'agent',
+      ...(rest.sessionLane ? { sessionLane: rest.sessionLane } : {}),
     },
     session_id: id,
   });
@@ -1579,6 +1582,7 @@ async function createWeb(
       type: 'agent',
       workspace: params.repoPath,
       mode: 'web',
+      ...(params.sessionLane ? { sessionLane: params.sessionLane } : {}),
     },
     session_id: result.session.id,
   });

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -12,6 +12,7 @@ import {
 } from './web-session-v2-state.js';
 import { upsertWebSessionNow } from './relay-state-db.js';
 import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
+import type { SessionLane } from '../shared/session-lane.js';
 
 const logger = createLogger('web-session');
 const MESSAGE_BUFFER_MAX = 1000;
@@ -29,6 +30,7 @@ export interface CreateWebParams {
   configDir: string;
   permissionMode?: string;
   model?: string;
+  sessionLane?: SessionLane | undefined;
   workspaceId?: string;
   additionalDirs?: string[];
   runtimeOwnership?: 'spawned' | 'attached';

--- a/shared/node-manifest.ts
+++ b/shared/node-manifest.ts
@@ -91,6 +91,7 @@ export interface NodeManifest {
   platform: string;
   arch: string;
   hostname: string;
+  homeDir?: string;
   relayVersion: string;
   generatedAt: string;
   wsl: WslInfo;
@@ -250,6 +251,7 @@ export function isNodeManifest(value: unknown): value is NodeManifest {
     typeof value['platform'] !== 'string' ||
     typeof value['arch'] !== 'string' ||
     typeof value['hostname'] !== 'string' ||
+    !isOptionalString(value['homeDir']) ||
     typeof value['relayVersion'] !== 'string' ||
     typeof value['generatedAt'] !== 'string'
   ) {

--- a/shared/relay-node-protocol.ts
+++ b/shared/relay-node-protocol.ts
@@ -118,6 +118,7 @@ export interface HubNodeSummary {
   nodeId: string;
   displayName: string;
   hostname: string;
+  homeDir?: string;
   platform: string;
   arch: string;
   relayVersion: string;

--- a/shared/session-lane.ts
+++ b/shared/session-lane.ts
@@ -1,0 +1,10 @@
+export const SESSION_LANES = ['local-repo', 'remote-cwd', 'remote-home'] as const;
+
+export type SessionLane = (typeof SESSION_LANES)[number];
+
+export function isSessionLane(value: unknown): value is SessionLane {
+  return (
+    typeof value === 'string' &&
+    (SESSION_LANES as readonly string[]).includes(value)
+  );
+}

--- a/test/api-error.test.ts
+++ b/test/api-error.test.ts
@@ -86,12 +86,44 @@ describe('frontend api errors', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    await createSession({ nodeId: 'node-a', repoPath: '/repo', type: 'terminal' });
+    await createSession({
+      nodeId: 'node-a',
+      repoPath: '/repo',
+      type: 'terminal',
+      sessionLane: 'remote-cwd',
+    });
 
     expect(fetchMock).toHaveBeenCalledWith('/hub/nodes/node-a/sessions', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ repoPath: '/repo', type: 'terminal' }),
+      body: JSON.stringify({
+        repoPath: '/repo',
+        type: 'terminal',
+        sessionLane: 'remote-cwd',
+      }),
+    });
+  });
+
+  it('preserves local session lane markers in create payloads', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ id: 'local-session-1' }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await createSession({ repoPath: '/repo', type: 'agent', sessionLane: 'local-repo' });
+
+    expect(fetchMock).toHaveBeenCalledWith('/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        repoPath: '/repo',
+        type: 'agent',
+        sessionLane: 'local-repo',
+      }),
     });
   });
 

--- a/test/customize-session-dialog-open-race.test.ts
+++ b/test/customize-session-dialog-open-race.test.ts
@@ -11,6 +11,7 @@ import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
 const mocks = vi.hoisted(() => ({
   fetchRepoInventory: vi.fn(),
   fetchHubNodes: vi.fn(),
+  createAgentSession: vi.fn(),
   configState: {
     defaultContinue: false,
     defaultYolo: false,
@@ -41,13 +42,14 @@ vi.mock('../frontend/src/lib/stores/config.js', () => {
 });
 
 vi.mock('../frontend/src/lib/stores/ui.js', () => ({
+  DEFAULT_TERMINAL_FONT_SIZE: 14,
   useUiStore: {
     getState: () => ({ terminalFontSize: 14 }),
   },
 }));
 
 vi.mock('../frontend/src/lib/session-utils.js', () => ({
-  createAgentSession: vi.fn(),
+  createAgentSession: mocks.createAgentSession,
 }));
 
 vi.mock('../frontend/src/components/dialogs/DialogShell.js', async () => {
@@ -86,6 +88,9 @@ vi.mock('../frontend/src/components/dialogs/DialogShell.js', async () => {
 const { default: CustomizeSessionDialog } =
   await import('../frontend/src/components/dialogs/CustomizeSessionDialog.js');
 
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (error: unknown) => void;
@@ -113,7 +118,7 @@ function framework(id: string): FrameworkInfo {
   };
 }
 
-function node(): HubNodeSummary {
+function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
   return {
     nodeId: 'local',
     displayName: 'local mac',
@@ -143,6 +148,7 @@ function node(): HubNodeSummary {
     pairedAt: '2026-05-12T00:00:00.000Z',
     lastSeenAt: '2026-05-12T00:00:00.000Z',
     credentialId: 'cred-local',
+    ...overrides,
   };
 }
 
@@ -184,6 +190,79 @@ function inventory(prefix: string): AggregatedRepoInventoryResponse {
   };
 }
 
+function remoteLaneInventory(): AggregatedRepoInventoryResponse {
+  const localInstance = {
+    repoInstanceId: 'local:%2Ftmp%2Fremote-lane',
+    nodeId: 'local',
+    localPath: '/tmp/remote-lane',
+    name: 'remote-lane',
+    isGitRepo: true,
+    defaultBranch: 'nightly',
+    currentBranch: 'nightly',
+    repoIdentity: 'github.com/example/remote-lane',
+    selectedRemote: null,
+    remotes: [],
+    repoIdentityWarnings: [],
+    worktrees: [],
+    reportedAt: '2026-05-12T00:00:00.000Z',
+  };
+  return {
+    generatedAt: '2026-05-12T00:00:00.000Z',
+    reports: [],
+    groups: [
+      {
+        groupId: 'github.com/example/remote-lane',
+        repoIdentity: 'github.com/example/remote-lane',
+        displayName: 'remote-lane',
+        selectedRemote: null,
+        remotes: [],
+        warnings: [],
+        identityDebug: {
+          groupedBy: 'repoIdentity',
+          repoIdentity: 'github.com/example/remote-lane',
+          instanceCount: 2,
+          nodeIds: ['local', 'remote'],
+        },
+        instances: [
+          localInstance,
+          {
+            ...localInstance,
+            repoInstanceId: 'remote:%2Fsrv%2Fremote-lane',
+            nodeId: 'remote',
+            localPath: '/srv/remote-lane',
+          },
+        ],
+      },
+    ],
+  };
+}
+
+async function renderAndOpen(
+  workspace: { name: string; path: string },
+  inventoryResponse: AggregatedRepoInventoryResponse,
+  nodes: HubNodeSummary[]
+) {
+  mocks.configState.frameworks = [framework('claude')];
+  mocks.fetchRepoInventory.mockResolvedValue(inventoryResponse);
+  mocks.fetchHubNodes.mockResolvedValue(nodes);
+  mocks.configState.refreshConfig.mockResolvedValue(undefined);
+  mocks.createAgentSession.mockResolvedValue({ session: { id: 'sess-1' } });
+
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  const ref = createRef<CustomizeSessionDialogHandle>();
+
+  await act(async () => {
+    root!.render(React.createElement(CustomizeSessionDialog, { ref }));
+  });
+  await act(async () => {
+    await ref.current!.open(workspace);
+  });
+  await flush();
+  return container;
+}
+
 async function flush() {
   await act(async () => {
     await Promise.resolve();
@@ -192,9 +271,6 @@ async function flush() {
 }
 
 describe('CustomizeSessionDialog open races', () => {
-  let container: HTMLDivElement | null = null;
-  let root: Root | null = null;
-
   afterEach(() => {
     act(() => root?.unmount());
     container?.remove();
@@ -205,6 +281,89 @@ describe('CustomizeSessionDialog open races', () => {
     mocks.configState.defaultYolo = false;
     mocks.configState.defaultAgent = 'claude';
     mocks.configState.frameworks = [framework('claude')];
+  });
+
+  it('marks local repo launches with the local-repo lane', async () => {
+    const el = await renderAndOpen(
+      { name: 'local-one', path: '/tmp/local-one' },
+      inventory('local'),
+      [node()]
+    );
+
+    await act(async () => {
+      (el.querySelector('[data-track="dialog.customize-session.create"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(mocks.createAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodeId: 'local',
+        repoPath: '/tmp/local-one',
+        sessionLane: 'local-repo',
+      })
+    );
+  });
+
+  it('marks remote cwd launches with the remote-cwd lane', async () => {
+    const el = await renderAndOpen(
+      { name: 'remote-lane', path: '/tmp/remote-lane' },
+      remoteLaneInventory(),
+      [
+        node(),
+        node({ nodeId: 'remote', displayName: 'remote box', homeDir: '/home/relay' }),
+      ]
+    );
+
+    await act(async () => {
+      const select = el.querySelector('#cs-node') as HTMLSelectElement;
+      select.value = 'remote';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+
+    await act(async () => {
+      (el.querySelector('[data-track="dialog.customize-session.create"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(mocks.createAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodeId: 'remote',
+        cwd: '/home/relay',
+        sessionLane: 'remote-cwd',
+      })
+    );
+  });
+
+  it('marks remote home launches with the remote-home lane', async () => {
+    const el = await renderAndOpen(
+      { name: 'remote-lane', path: '/tmp/remote-lane' },
+      remoteLaneInventory(),
+      [
+        node(),
+        node({ nodeId: 'remote', displayName: 'remote box', homeDir: '/home/relay' }),
+      ]
+    );
+
+    await act(async () => {
+      const select = el.querySelector('#cs-node') as HTMLSelectElement;
+      select.value = 'remote';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+
+    await act(async () => {
+      (el.querySelector('[data-track="dialog.customize-session.start-in-home"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(mocks.createAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nodeId: 'remote',
+        cwd: '/home/relay',
+        sessionLane: 'remote-home',
+      })
+    );
   });
 
   it('ignores stale inventory and config from an earlier overlapping open call', async () => {

--- a/test/customize-session-dialog-open-race.test.ts
+++ b/test/customize-session-dialog-open-race.test.ts
@@ -237,6 +237,49 @@ function remoteLaneInventory(): AggregatedRepoInventoryResponse {
   };
 }
 
+function remoteOnlyInventory(): AggregatedRepoInventoryResponse {
+  const remoteInstance = {
+    repoInstanceId: 'remote:%2Fsrv%2Fremote-only',
+    nodeId: 'remote',
+    localPath: '/srv/remote-only',
+    name: 'remote-only',
+    isGitRepo: true,
+    defaultBranch: 'nightly',
+    currentBranch: 'nightly',
+    repoIdentity: 'github.com/example/remote-only',
+    selectedRemote: null,
+    remotes: [],
+    repoIdentityWarnings: [],
+    worktrees: [],
+    reportedAt: '2026-05-12T00:00:00.000Z',
+  };
+  return {
+    generatedAt: '2026-05-12T00:00:00.000Z',
+    reports: [],
+    groups: [
+      {
+        groupId: 'github.com/example/remote-only',
+        repoIdentity: 'github.com/example/remote-only',
+        displayName: 'remote-only',
+        selectedRemote: null,
+        remotes: [],
+        warnings: [],
+        identityDebug: {
+          groupedBy: 'repoIdentity',
+          repoIdentity: 'github.com/example/remote-only',
+          instanceCount: 1,
+          nodeIds: ['remote'],
+        },
+        instances: [remoteInstance],
+      },
+    ],
+  };
+}
+
+function localOnlyInventory(): AggregatedRepoInventoryResponse {
+  return inventory('local-only');
+}
+
 async function renderAndOpen(
   workspace: { name: string; path: string },
   inventoryResponse: AggregatedRepoInventoryResponse,
@@ -364,6 +407,109 @@ describe('CustomizeSessionDialog open races', () => {
         sessionLane: 'remote-home',
       })
     );
+  });
+
+  it('shows cwd and sends cwd-only payload for a single remote-only inventory', async () => {
+    const el = await renderAndOpen(
+      { name: 'remote-only', path: '/srv/remote-only' },
+      remoteOnlyInventory(),
+      [
+        node({
+          nodeId: 'remote',
+          displayName: 'remote box',
+          homeDir: '/home/relay',
+        }),
+      ]
+    );
+
+    const cwdInput = el.querySelector('#cs-remote-cwd') as HTMLInputElement;
+    expect(cwdInput).toBeTruthy();
+    expect(cwdInput.value).toBe('/home/relay');
+
+    await act(async () => {
+      (el.querySelector('[data-track="dialog.customize-session.create"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    const payload = mocks.createAgentSession.mock.calls.at(-1)?.[0];
+    expect(payload).toMatchObject({
+      nodeId: 'remote',
+      cwd: '/home/relay',
+      sessionLane: 'remote-cwd',
+    });
+    expect(payload).not.toHaveProperty('repoPath');
+    expect(payload).not.toHaveProperty('worktreePath');
+  });
+
+  it('lets a paired node without repo inventory use the remote cwd lane', async () => {
+    const el = await renderAndOpen(
+      { name: 'local-only-one', path: '/tmp/local-only-one' },
+      localOnlyInventory(),
+      [
+        node(),
+        node({
+          nodeId: 'remote',
+          displayName: 'remote box',
+          homeDir: '/home/relay',
+        }),
+      ]
+    );
+
+    await act(async () => {
+      const select = el.querySelector('#cs-node') as HTMLSelectElement;
+      select.value = 'remote';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+
+    const cwdInput = el.querySelector('#cs-remote-cwd') as HTMLInputElement;
+    expect(cwdInput).toBeTruthy();
+    expect(cwdInput.value).toBe('/home/relay');
+
+    await act(async () => {
+      (el.querySelector('[data-track="dialog.customize-session.create"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    const payload = mocks.createAgentSession.mock.calls.at(-1)?.[0];
+    expect(payload).toMatchObject({
+      nodeId: 'remote',
+      cwd: '/home/relay',
+      sessionLane: 'remote-cwd',
+    });
+    expect(payload).not.toHaveProperty('repoPath');
+    expect(payload).not.toHaveProperty('worktreePath');
+  });
+
+  it('disables Start in Home for a blocked selected remote node', async () => {
+    const el = await renderAndOpen(
+      { name: 'remote-only', path: '/srv/remote-only' },
+      remoteOnlyInventory(),
+      [
+        node({
+          nodeId: 'remote',
+          displayName: 'remote box',
+          status: 'offline',
+          homeDir: '/home/relay',
+        }),
+      ]
+    );
+
+    await flush();
+
+    const startInHome = el.querySelector(
+      '[data-track="dialog.customize-session.start-in-home"]'
+    ) as HTMLButtonElement;
+    expect(startInHome.disabled).toBe(true);
+
+    // Try the click path anyway to preserve the no-create regression assertion;
+    // happy-dom/browser disabled buttons do not dispatch onClick.
+    await act(async () => {
+      startInHome.click();
+    });
+    await flush();
+
+    expect(mocks.createAgentSession).not.toHaveBeenCalled();
   });
 
   it('ignores stale inventory and config from an earlier overlapping open call', async () => {

--- a/test/customize-session-dialog.test.ts
+++ b/test/customize-session-dialog.test.ts
@@ -397,6 +397,101 @@ describe('CustomizeSessionDialog environment picker model', () => {
     expect(model.resolved.nodeId).toBe('local');
   });
 
+  it('includes a paired node without repo inventory as a remote target', () => {
+    const repoInventory = inventory();
+    repoInventory.groups = [
+      {
+        ...repoInventory.groups[1]!,
+        instances: [repoInventory.groups[1]!.instances[0]!],
+      },
+    ];
+
+    const model = buildEnvironmentPickerModel({
+      inventory: repoInventory,
+      nodes: [
+        node(),
+        node({ nodeId: 'remote-free', displayName: 'remote free' }),
+      ],
+      selectedAgent: 'claude',
+      selectedGroupId: 'github.com/example/tools',
+      selectedNodeId: 'remote-free',
+      selectedCheckoutId: null,
+      fallbackWorkspace: { name: 'tools', path: '/Users/kyle/tools' },
+      fallbackWorktreePath: null,
+    });
+
+    expect(model.nodeChoices.map((choice) => choice.value)).toContain(
+      'remote-free'
+    );
+    expect(model.selectedNodeId).toBe('remote-free');
+    expect(model.selectedNodeReason).toBeNull();
+    expect(model.resolved).toEqual({
+      nodeId: 'remote-free',
+      repoPath: '',
+      worktreePath: null,
+    });
+  });
+
+  it('keeps a single remote-only inventory on the remote cwd lane', () => {
+    const repoInventory = inventory();
+    repoInventory.groups = [
+      {
+        ...repoInventory.groups[0]!,
+        identityDebug: {
+          ...repoInventory.groups[0]!.identityDebug,
+          instanceCount: 1,
+          nodeIds: ['linux'],
+        },
+        instances: [repoInventory.groups[0]!.instances[0]!],
+      },
+    ];
+
+    const model = buildEnvironmentPickerModel({
+      inventory: repoInventory,
+      nodes: [node({ nodeId: 'linux', displayName: 'linux lab' })],
+      selectedAgent: 'claude',
+      selectedGroupId: 'github.com/donovan-yohan/relay-ide',
+      selectedNodeId: null,
+      selectedCheckoutId: null,
+      fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
+      fallbackWorktreePath: null,
+    });
+
+    expect(model.selectedNodeId).toBe('linux');
+    expect(model.selectedNodeReason).toBeNull();
+    expect(model.resolved.nodeId).toBe('linux');
+  });
+
+  it('keeps an explicitly selected blocked remote node blocked when no enabled target exists', () => {
+    const repoInventory = inventory();
+    repoInventory.groups = [
+      {
+        ...repoInventory.groups[0]!,
+        identityDebug: {
+          ...repoInventory.groups[0]!.identityDebug,
+          instanceCount: 1,
+          nodeIds: ['linux'],
+        },
+        instances: [repoInventory.groups[0]!.instances[0]!],
+      },
+    ];
+
+    const model = buildEnvironmentPickerModel({
+      inventory: repoInventory,
+      nodes: [node({ nodeId: 'linux', displayName: 'linux lab', status: 'offline' })],
+      selectedAgent: 'claude',
+      selectedGroupId: 'github.com/donovan-yohan/relay-ide',
+      selectedNodeId: 'linux',
+      selectedCheckoutId: null,
+      fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
+      fallbackWorktreePath: null,
+    });
+
+    expect(model.selectedNodeId).toBe('linux');
+    expect(model.selectedNodeReason).toBe('node is offline');
+    expect(model.resolved.nodeId).toBe('linux');
+  });
+
   it('keeps all same-node repo instance checkouts selectable', () => {
     const repoInventory = inventory();
     const relayGroup = repoInventory.groups[0]!;

--- a/test/e2e/components/CustomizeSessionDialog.spec.ts
+++ b/test/e2e/components/CustomizeSessionDialog.spec.ts
@@ -5,27 +5,51 @@ test.describe('CustomizeSessionDialog', () => {
     await page.goto('/test-customize-session-dialog.html');
   });
 
-  test('opens with environment picker and session options', async ({ page }) => {
+  test('opens with environment picker and session options', async ({
+    page,
+  }) => {
     await page.getByText('open customize session').click();
     await expect(page.getByRole('dialog')).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Customize Session' })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Customize Session' })
+    ).toBeVisible();
     await expect(page.getByLabel('repo identity')).toBeVisible();
     await expect(page.getByLabel('execution node')).toBeVisible();
-    await expect(page.getByLabel('node-local checkout')).toBeVisible();
+    await expect(page.getByLabel('node-local checkout')).toHaveCount(0);
+    await expect(page.getByLabel('cwd on linux lab')).toBeVisible();
     await expect(page.getByLabel('coding agent')).toBeVisible();
     await expect(page.getByText('continue existing session')).toBeVisible();
     await expect(page.getByText('yolo mode')).toBeVisible();
     await expect(page.getByText('Launch in tmux')).toHaveCount(0);
   });
 
-  test('routes a multi-node checkout launch through the selected node', async ({
+  test('local-repo lane keeps repo checkout payload unchanged', async ({
+    page,
+  }) => {
+    await page.getByText('open single-node customize session').click();
+    await page.getByRole('button', { name: 'Start Session' }).click();
+
+    await expect(page.getByTestId('created-session')).toHaveText(
+      'local-session'
+    );
+    await expect(page.getByTestId('last-create-request')).toContainText(
+      '/sessions'
+    );
+    await expect(page.getByTestId('last-create-request')).toContainText(
+      '"repoPath":"/Users/kyle/relay-ide"'
+    );
+  });
+
+  test('remote-node lane uses free-text cwd and omits repo fields', async ({
     page,
   }) => {
     await page.getByText('open customize session').click();
     await page.getByLabel('execution node').selectOption('linux');
-    await page
-      .getByLabel('node-local checkout')
-      .selectOption('worktree:linux:%2Fsrv%2Frelay-ide%2F.worktrees%2Ffeature');
+    await expect(page.getByLabel('node-local checkout')).toHaveCount(0);
+    await expect(page.getByLabel('cwd on linux lab')).toHaveValue(
+      '/home/linux'
+    );
+    await page.getByLabel('cwd on linux lab').fill('/srv/manual-cwd');
     await page.getByRole('button', { name: 'Start Session' }).click();
 
     await expect(page.getByTestId('created-session')).toHaveText(
@@ -35,10 +59,38 @@ test.describe('CustomizeSessionDialog', () => {
       '/hub/nodes/linux/sessions'
     );
     await expect(page.getByTestId('last-create-request')).toContainText(
-      '"repoPath":"/srv/relay-ide"'
+      '"cwd":"/srv/manual-cwd"'
+    );
+    await expect(page.getByTestId('last-create-request')).not.toContainText(
+      'repoPath'
+    );
+    await expect(page.getByTestId('last-create-request')).not.toContainText(
+      'worktreePath'
+    );
+  });
+
+  test('free remote lane starts in node home and remembers cwd per node', async ({
+    page,
+  }) => {
+    await page.getByText('open customize session').click();
+    await page.getByLabel('execution node').selectOption('linux');
+    await page.getByLabel('cwd on linux lab').fill('/opt/remember-me');
+    await page.getByRole('button', { name: 'Start Session' }).click();
+    await expect(page.getByTestId('last-create-request')).toContainText(
+      '"cwd":"/opt/remember-me"'
+    );
+
+    await page.getByText('open customize session').click();
+    await page.getByLabel('execution node').selectOption('linux');
+    await expect(page.getByLabel('cwd on linux lab')).toHaveValue(
+      '/opt/remember-me'
+    );
+    await page.getByRole('button', { name: 'Start in Home' }).click();
+    await expect(page.getByTestId('created-session')).toHaveText(
+      'remote-home-session'
     );
     await expect(page.getByTestId('last-create-request')).toContainText(
-      '"worktreePath":"/srv/relay-ide/.worktrees/feature"'
+      '"cwd":"/home/linux"'
     );
   });
 
@@ -52,10 +104,12 @@ test.describe('CustomizeSessionDialog', () => {
     await expect(nodeOptions.filter({ hasText: 'offline lab' })).toContainText(
       'node is offline'
     );
-    await expect(nodeOptions.filter({ hasText: 'no claude box' })).toBeDisabled();
-    await expect(nodeOptions.filter({ hasText: 'no claude box' })).toContainText(
-      'claude unavailable on no claude box'
-    );
+    await expect(
+      nodeOptions.filter({ hasText: 'no claude box' })
+    ).toBeDisabled();
+    await expect(
+      nodeOptions.filter({ hasText: 'no claude box' })
+    ).toContainText('claude unavailable on no claude box');
     await expect(nodeOptions.filter({ hasText: 'no tmux box' })).toBeDisabled();
     await expect(nodeOptions.filter({ hasText: 'no tmux box' })).toContainText(
       'tmux unavailable on no tmux box'
@@ -78,9 +132,13 @@ test.describe('CustomizeSessionDialog', () => {
     await expect(page.getByRole('dialog')).toBeVisible();
     await expect(page.getByLabel('repo identity')).toHaveCount(0);
     await expect(page.getByLabel('execution node')).toBeVisible();
-    await expect(page.getByText('node is offline', { exact: true })).toBeVisible();
+    await expect(
+      page.getByText('node is offline', { exact: true })
+    ).toBeVisible();
     await expect(page.getByLabel('node-local checkout')).toHaveCount(0);
-    await expect(page.getByRole('button', { name: 'Start Session' })).toBeDisabled();
+    await expect(
+      page.getByRole('button', { name: 'Start Session' })
+    ).toBeDisabled();
   });
 
   test('has Start Session and Cancel buttons', async ({ page }) => {

--- a/test/e2e/components/CustomizeSessionDialog.spec.ts
+++ b/test/e2e/components/CustomizeSessionDialog.spec.ts
@@ -40,6 +40,28 @@ test.describe('CustomizeSessionDialog', () => {
     );
   });
 
+  test('local web-capable default agents keep web session payloads', async ({
+    page,
+  }) => {
+    await page.getByText('open local web-capable customize session').click();
+    await expect(page.getByLabel('coding agent')).toHaveValue('hermes');
+    await expect(page.getByLabel('interface')).toHaveValue('web');
+    await page.getByRole('button', { name: 'Start Session' }).click();
+
+    await expect(page.getByTestId('last-create-request')).toContainText(
+      '/sessions'
+    );
+    await expect(page.getByTestId('last-create-request')).toContainText(
+      '"agent":"hermes"'
+    );
+    await expect(page.getByTestId('last-create-request')).toContainText(
+      '"mode":"web"'
+    );
+    await expect(page.getByTestId('last-create-request')).toContainText(
+      '"repoPath":"/Users/kyle/relay-ide"'
+    );
+  });
+
   test('remote-node lane uses free-text cwd and omits repo fields', async ({
     page,
   }) => {
@@ -66,6 +88,33 @@ test.describe('CustomizeSessionDialog', () => {
     );
     await expect(page.getByTestId('last-create-request')).not.toContainText(
       'worktreePath'
+    );
+  });
+
+  test('remote-node lane coerces web-capable default agents to pty payloads', async ({
+    page,
+  }) => {
+    await page.getByText('open web-capable remote customize session').click();
+    await page.getByLabel('execution node').selectOption('linux');
+    await expect(page.getByLabel('coding agent')).toHaveValue('hermes');
+    await expect(page.getByLabel('interface')).toHaveCount(0);
+    await page.getByLabel('cwd on linux lab').fill('/srv/hermes-cwd');
+    await page.getByRole('button', { name: 'Start Session' }).click();
+
+    await expect(page.getByTestId('last-create-request')).toContainText(
+      '/hub/nodes/linux/sessions'
+    );
+    await expect(page.getByTestId('last-create-request')).toContainText(
+      '"agent":"hermes"'
+    );
+    await expect(page.getByTestId('last-create-request')).toContainText(
+      '"mode":"pty"'
+    );
+    await expect(page.getByTestId('last-create-request')).not.toContainText(
+      '"mode":"web"'
+    );
+    await expect(page.getByTestId('last-create-request')).not.toContainText(
+      'repoPath'
     );
   });
 

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -176,7 +176,7 @@ describe('hub node registry', () => {
 
       const exchanged = registry.exchangePairToken({
         pairToken: pair.pairToken,
-        manifest: manifest(),
+        manifest: manifest({ homeDir: '/Users/dev' }),
         displayName: 'Dev Mac',
       });
 
@@ -191,6 +191,7 @@ describe('hub node registry', () => {
       expect(exchanged.node).toMatchObject({
         displayName: 'Dev Mac',
         hostname: 'test-host',
+        homeDir: '/Users/dev',
         platform: 'darwin',
         relayVersion: '9.9.9',
         protocolVersion: '1.0',

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -148,24 +148,32 @@ describe('node-link-rpc-host', () => {
     expect(sent[0]!.type).toBe('sessions.create.result');
   });
 
-  it('routes mode:"web" sessions through createWeb', async () => {
+  it('rejects incomplete mode:"web" remote session creates before dispatch', async () => {
     const localRelayNode = fakeLocalNode();
     const host = createNodeLinkRpcHost({ localRelayNode });
     const { sent, ctx } = context();
 
     host.handle(
-      envelope('sessions.create', { type: 'agent', mode: 'web' }),
+      envelope('sessions.create', {
+        type: 'agent',
+        mode: 'web',
+        agent: 'hermes',
+        cwd: '/home/user',
+      }),
       ctx
     );
 
-    // createWeb is async; flush microtasks.
+    // Keep the async flush so this fails if a future implementation
+    // reintroduces the createWeb dispatch path.
     await new Promise((resolve) => setImmediate(resolve));
 
-    expect(localRelayNode.sessions.createWeb).toHaveBeenCalledTimes(1);
+    expect(localRelayNode.sessions.create).not.toHaveBeenCalled();
+    expect(localRelayNode.sessions.createWeb).not.toHaveBeenCalled();
     expect(sent).toHaveLength(1);
-    expect(sent[0]!.type).toBe('sessions.create.result');
-    const payload = sent[0]!.payload as { session: SessionSummary };
-    expect(payload.session.mode).toBe('web');
+    expect(sent[0]!.type).toBe('sessions.create.error');
+    const err = sent[0]!.error as RelayNodeError;
+    expect(err.code).toBe('INVALID_REQUEST');
+    expect(err.message).toContain('remote node web sessions are not supported');
   });
 
   it('rejects invalid session lane markers before dispatch', () => {

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -105,7 +105,11 @@ describe('node-link-rpc-host', () => {
     const { sent, ctx } = context();
 
     host.handle(
-      envelope('sessions.create', { type: 'terminal', cwd: '/home/user' }),
+      envelope('sessions.create', {
+        type: 'terminal',
+        cwd: '/home/user',
+        sessionLane: 'remote-cwd',
+      }),
       ctx
     );
 
@@ -113,7 +117,11 @@ describe('node-link-rpc-host', () => {
     expect(
       (localRelayNode.sessions.create as ReturnType<typeof vi.fn>).mock
         .calls[0]?.[0]
-    ).toMatchObject({ type: 'terminal', cwd: '/home/user' });
+    ).toMatchObject({
+      type: 'terminal',
+      cwd: '/home/user',
+      sessionLane: 'remote-cwd',
+    });
     expect(sent).toHaveLength(1);
     const reply = sent[0]!;
     expect(reply.channel).toBe('rpc');
@@ -158,6 +166,24 @@ describe('node-link-rpc-host', () => {
     expect(sent[0]!.type).toBe('sessions.create.result');
     const payload = sent[0]!.payload as { session: SessionSummary };
     expect(payload.session.mode).toBe('web');
+  });
+
+  it('rejects invalid session lane markers before dispatch', () => {
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(
+      envelope('sessions.create', { type: 'terminal', sessionLane: 'banana' }),
+      ctx
+    );
+
+    expect(localRelayNode.sessions.create).not.toHaveBeenCalled();
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('sessions.create.error');
+    const err = sent[0]!.error as RelayNodeError;
+    expect(err.code).toBe('INVALID_REQUEST');
+    expect(err.message).toContain('payload.sessionLane');
   });
 
   it('responds with INVALID_REQUEST when payload is missing type', () => {

--- a/test/node-manifest.test.ts
+++ b/test/node-manifest.test.ts
@@ -23,6 +23,7 @@ describe('node manifest', () => {
         platform: 'darwin',
         arch: 'arm64',
         hostname: 'relay-test-node',
+        homeDir: '/Users/tester',
         relayVersion: '9.9.9-test',
         now: new Date('2026-01-02T03:04:05.000Z'),
       });
@@ -32,6 +33,7 @@ describe('node manifest', () => {
         platform: 'darwin',
         arch: 'arm64',
         hostname: 'relay-test-node',
+        homeDir: '/Users/tester',
         relayVersion: '9.9.9-test',
         generatedAt: '2026-01-02T03:04:05.000Z',
         wsl: { detected: false, version: null, systemd: false },

--- a/test/workspace-area-node-picker.test.ts
+++ b/test/workspace-area-node-picker.test.ts
@@ -59,10 +59,14 @@ vi.mock('../frontend/src/lib/stores/ui.js', () => {
     closeFileTab: vi.fn(),
     sendToTargetSessionId: null,
   };
-  const useUiStore = (selector: (s: typeof state) => unknown) => selector(state);
+  const useUiStore = (selector: (s: typeof state) => unknown) =>
+    selector(state);
   useUiStore.getState = () => state;
   useUiStore.setState = vi.fn();
-  return { useUiStore, fileTabKey: (path: string, type?: string) => `${type ?? 'code'}:${path}` };
+  return {
+    useUiStore,
+    fileTabKey: (path: string, type?: string) => `${type ?? 'code'}:${path}`,
+  };
 });
 
 vi.mock('../frontend/src/lib/stores/sessions.js', () => {
@@ -98,8 +102,18 @@ vi.mock('../frontend/src/lib/stores/workspace-layout-store.js', () => {
 });
 
 vi.mock('../frontend/src/lib/workspace-layout.js', () => ({
-  listPanes: (layout: { type: string; id: string; tabs: unknown[]; activeTabId: string | null }) => [layout],
-  workspaceTabId: (tab: { kind: string; sessionId?: string; filePath?: string; tabType?: string }) =>
+  listPanes: (layout: {
+    type: string;
+    id: string;
+    tabs: unknown[];
+    activeTabId: string | null;
+  }) => [layout],
+  workspaceTabId: (tab: {
+    kind: string;
+    sessionId?: string;
+    filePath?: string;
+    tabType?: string;
+  }) =>
     tab.kind === 'session'
       ? `session::${tab.sessionId}`
       : `file::${tab.tabType ?? 'code'}:${tab.filePath}`,
@@ -124,15 +138,32 @@ vi.mock('../frontend/src/components/WorkspaceContentLayer.js', async () => {
 vi.mock('../frontend/src/components/TerminalNodePicker.js', async () => {
   const ReactModule = await import('react');
   return {
-    TerminalNodePicker: ({ onSelect }: { onSelect: (nodeId: string) => void }) =>
+    TerminalNodePicker: ({
+      onSelect,
+    }: {
+      onSelect: (nodeId: string) => void;
+    }) =>
       ReactModule.createElement(
-        'button',
-        {
-          type: 'button',
-          'data-track': 'workspace.add-terminal.remote',
-          onClick: () => onSelect('remote'),
-        },
-        'remote'
+        'div',
+        null,
+        ReactModule.createElement(
+          'button',
+          {
+            type: 'button',
+            'data-track': 'workspace.add-terminal.local',
+            onClick: () => onSelect('local'),
+          },
+          'local'
+        ),
+        ReactModule.createElement(
+          'button',
+          {
+            type: 'button',
+            'data-track': 'workspace.add-terminal.remote',
+            onClick: () => onSelect('remote'),
+          },
+          'remote'
+        )
       ),
   };
 });
@@ -152,9 +183,8 @@ vi.mock('../frontend/src/components/chat/ChatView.js', async () => {
   return { ChatView: () => ReactModule.createElement('div') };
 });
 
-const { WorkspaceArea } = await import(
-  '../frontend/src/components/WorkspaceArea.js'
-);
+const { WorkspaceArea } =
+  await import('../frontend/src/components/WorkspaceArea.js');
 
 function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
   return {
@@ -198,6 +228,15 @@ function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
   };
 }
 
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value'
+  )?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
 let root: Root | null = null;
 let container: HTMLDivElement | null = null;
 
@@ -218,13 +257,7 @@ afterEach(async () => {
 });
 
 describe('WorkspaceArea terminal node picker', () => {
-  it('creates remote terminals with cwd and session lane instead of repo fields', async () => {
-    mocks.hubNodes = [node()];
-    mocks.createAgentSession.mockResolvedValue({
-      session: { id: 'remote-session' },
-      error: null,
-    });
-
+  async function renderWorkspaceArea() {
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -240,6 +273,16 @@ describe('WorkspaceArea terminal node picker', () => {
         })
       );
     });
+  }
+
+  it('opens remote cwd entry before creating remote terminal sessions', async () => {
+    mocks.hubNodes = [node()];
+    mocks.createAgentSession.mockResolvedValue({
+      session: { id: 'remote-session' },
+      error: null,
+    });
+
+    await renderWorkspaceArea();
 
     await act(async () => {
       (
@@ -250,14 +293,76 @@ describe('WorkspaceArea terminal node picker', () => {
     });
 
     expect(mocks.setActivePane).toHaveBeenCalledWith('pane-1');
+    expect(mocks.createAgentSession).not.toHaveBeenCalled();
+
+    const cwdInput = container!.querySelector(
+      '[data-track="workspace.remote-terminal.cwd"]'
+    ) as HTMLInputElement;
+    expect(cwdInput).toBeTruthy();
+    expect(cwdInput.value).toBe('/home/relay');
+
+    await act(async () => {
+      setInputValue(cwdInput, '/srv/relay');
+    });
+
+    await act(async () => {
+      (
+        container!.querySelector(
+          '[data-track="workspace.remote-terminal.create"]'
+        ) as HTMLButtonElement
+      ).click();
+    });
+
+    const payload = mocks.createAgentSession.mock.calls.at(-1)?.[0];
+    expect(payload).toMatchObject({
+      type: 'terminal',
+      nodeId: 'remote',
+      cwd: '/srv/relay',
+      sessionLane: 'remote-cwd',
+    });
+    expect(payload).not.toHaveProperty('repoPath');
+    expect(payload).not.toHaveProperty('worktreePath');
+    expect(mocks.setActiveSessionId).toHaveBeenCalledWith('remote-session');
+  });
+
+  it('allows remote terminal starts in remote home without repo fields', async () => {
+    mocks.hubNodes = [node()];
+    mocks.createAgentSession.mockResolvedValue({
+      session: { id: 'remote-home-session' },
+      error: null,
+    });
+
+    await renderWorkspaceArea();
+
+    await act(async () => {
+      (
+        container!.querySelector(
+          '[data-track="workspace.add-terminal.remote"]'
+        ) as HTMLButtonElement
+      ).click();
+    });
+
+    expect(mocks.createAgentSession).not.toHaveBeenCalled();
+
+    await act(async () => {
+      (
+        container!.querySelector(
+          '[data-track="workspace.remote-terminal.start-home"]'
+        ) as HTMLButtonElement
+      ).click();
+    });
+
     const payload = mocks.createAgentSession.mock.calls.at(-1)?.[0];
     expect(payload).toMatchObject({
       type: 'terminal',
       nodeId: 'remote',
       cwd: '/home/relay',
-      sessionLane: 'remote-cwd',
+      sessionLane: 'remote-home',
     });
     expect(payload).not.toHaveProperty('repoPath');
     expect(payload).not.toHaveProperty('worktreePath');
+    expect(mocks.setActiveSessionId).toHaveBeenCalledWith(
+      'remote-home-session'
+    );
   });
 });

--- a/test/workspace-area-node-picker.test.ts
+++ b/test/workspace-area-node-picker.test.ts
@@ -1,0 +1,263 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  createAgentSession: vi.fn(),
+  setActivePane: vi.fn(),
+  refreshAll: vi.fn(),
+  setActiveSessionId: vi.fn(),
+  showToast: vi.fn(),
+  activeWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
+  worktreePath: '/Users/kyle/relay-ide/.worktrees/feature',
+  hubNodes: [] as HubNodeSummary[],
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: mocks.hubNodes }),
+}));
+
+vi.mock('../frontend/src/lib/api.js', () => ({
+  ConflictError: class ConflictError extends Error {},
+  fetchHubNodes: vi.fn(),
+}));
+
+vi.mock('../frontend/src/lib/session-utils.js', () => ({
+  createAgentSession: mocks.createAgentSession,
+  getCurrentSessionContext: () => ({
+    currentRepoPath: mocks.activeWorkspace.path,
+    currentActiveWorkspace: mocks.activeWorkspace,
+    currentActiveSession: mocks.worktreePath
+      ? { id: 'sess-active', worktreePath: mocks.worktreePath }
+      : undefined,
+    currentWorktreePath: mocks.worktreePath,
+  }),
+}));
+
+vi.mock('../frontend/src/lib/stores/toasts.js', () => ({
+  useToastStore: {
+    getState: () => ({ showToast: mocks.showToast }),
+  },
+}));
+
+vi.mock('../frontend/src/lib/stores/ui.js', () => {
+  const state = {
+    openFileTabs: [],
+    activeFileTabKey: null,
+    utilityRailByWorkspace: {},
+    fileDiffSource: 'workspace',
+    fileDiffDefaultBranch: null,
+    fileDiffViewMode: 'unified',
+    fileWordWrap: false,
+    closeFileTab: vi.fn(),
+    sendToTargetSessionId: null,
+  };
+  const useUiStore = (selector: (s: typeof state) => unknown) => selector(state);
+  useUiStore.getState = () => state;
+  useUiStore.setState = vi.fn();
+  return { useUiStore, fileTabKey: (path: string, type?: string) => `${type ?? 'code'}:${path}` };
+});
+
+vi.mock('../frontend/src/lib/stores/sessions.js', () => {
+  const state = {
+    activeSessionId: 'sess-active',
+    sessions: [],
+    repos: [mocks.activeWorkspace],
+    workspaceLastSession: {},
+    refreshAll: mocks.refreshAll,
+    setActiveSessionId: mocks.setActiveSessionId,
+  };
+  const useSessionsStore = (selector: (s: typeof state) => unknown) =>
+    selector(state);
+  useSessionsStore.getState = () => state;
+  useSessionsStore.setState = vi.fn();
+  return { useSessionsStore };
+});
+
+vi.mock('../frontend/src/lib/stores/workspace-layout-store.js', () => {
+  const state = {
+    layout: { type: 'pane', id: 'pane-1', tabs: [], activeTabId: null },
+    activePaneId: 'pane-1',
+    addTab: vi.fn(),
+    closeTab: vi.fn(),
+    selectTab: vi.fn(),
+    resetLayout: vi.fn(),
+    setActivePane: mocks.setActivePane,
+  };
+  const useWorkspaceLayoutStore = (selector: (s: typeof state) => unknown) =>
+    selector(state);
+  useWorkspaceLayoutStore.getState = () => state;
+  return { useWorkspaceLayoutStore };
+});
+
+vi.mock('../frontend/src/lib/workspace-layout.js', () => ({
+  listPanes: (layout: { type: string; id: string; tabs: unknown[]; activeTabId: string | null }) => [layout],
+  workspaceTabId: (tab: { kind: string; sessionId?: string; filePath?: string; tabType?: string }) =>
+    tab.kind === 'session'
+      ? `session::${tab.sessionId}`
+      : `file::${tab.tabType ?? 'code'}:${tab.filePath}`,
+}));
+
+vi.mock('../frontend/src/components/WorkspaceLayout.js', async () => {
+  const ReactModule = await import('react');
+  return {
+    WorkspaceLayout: ({
+      renderAddControl,
+    }: {
+      renderAddControl: (paneId: string) => React.ReactNode;
+    }) => ReactModule.createElement('div', null, renderAddControl('pane-1')),
+  };
+});
+
+vi.mock('../frontend/src/components/WorkspaceContentLayer.js', async () => {
+  const ReactModule = await import('react');
+  return { WorkspaceContentLayer: () => ReactModule.createElement('div') };
+});
+
+vi.mock('../frontend/src/components/TerminalNodePicker.js', async () => {
+  const ReactModule = await import('react');
+  return {
+    TerminalNodePicker: ({ onSelect }: { onSelect: (nodeId: string) => void }) =>
+      ReactModule.createElement(
+        'button',
+        {
+          type: 'button',
+          'data-track': 'workspace.add-terminal.remote',
+          onClick: () => onSelect('remote'),
+        },
+        'remote'
+      ),
+  };
+});
+
+vi.mock('../frontend/src/components/FileTabContent.js', async () => {
+  const ReactModule = await import('react');
+  return { FileTabContent: () => ReactModule.createElement('div') };
+});
+
+vi.mock('../frontend/src/components/Terminal.js', async () => {
+  const ReactModule = await import('react');
+  return { Terminal: () => ReactModule.createElement('div') };
+});
+
+vi.mock('../frontend/src/components/chat/ChatView.js', async () => {
+  const ReactModule = await import('react');
+  return { ChatView: () => ReactModule.createElement('div') };
+});
+
+const { WorkspaceArea } = await import(
+  '../frontend/src/components/WorkspaceArea.js'
+);
+
+function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
+  return {
+    nodeId: 'remote',
+    displayName: 'remote box',
+    hostname: 'remote.local',
+    platform: 'linux',
+    arch: 'arm64',
+    relayVersion: '0.1.0',
+    protocolVersion: '1.0',
+    status: 'online',
+    homeDir: '/home/relay',
+    connection: { route: 'reverse-link', status: 'connected' },
+    trust: { state: 'trusted', level: 'privileged-local-user', warning: '' },
+    credentialState: 'active',
+    version: {
+      state: 'compatible',
+      nodeProtocolVersion: '1.0',
+      hubProtocolVersion: '1.0',
+    },
+    capabilities: {
+      totals: { available: 10, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        tmux: 'available',
+        git: 'available',
+        browserAutomation: 'available',
+        clipboardImage: 'available',
+        ssh: 'available',
+        tailscale: 'available',
+      },
+      agents: { claude: 'available' },
+      serviceManager: 'launchd',
+      wsl: false,
+    },
+    createdAt: '2026-05-12T00:00:00.000Z',
+    pairedAt: '2026-05-12T00:00:00.000Z',
+    lastSeenAt: '2026-05-12T00:00:00.000Z',
+    credentialId: 'cred-remote',
+    ...overrides,
+  };
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(async () => {
+  await act(async () => {
+    root?.unmount();
+  });
+  container?.remove();
+  root = null;
+  container = null;
+  mocks.createAgentSession.mockReset();
+  mocks.setActivePane.mockReset();
+  mocks.refreshAll.mockReset();
+  mocks.setActiveSessionId.mockReset();
+  mocks.showToast.mockReset();
+  mocks.hubNodes = [];
+  window.localStorage.clear();
+});
+
+describe('WorkspaceArea terminal node picker', () => {
+  it('creates remote terminals with cwd and session lane instead of repo fields', async () => {
+    mocks.hubNodes = [node()];
+    mocks.createAgentSession.mockResolvedValue({
+      session: { id: 'remote-session' },
+      error: null,
+    });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        React.createElement(WorkspaceArea, {
+          workspacePath: mocks.activeWorkspace.path,
+          sessions: [],
+          onImageUpload: vi.fn(),
+          onCopyModeChange: vi.fn(),
+          onFilePathClick: vi.fn(),
+          onCloseSession: vi.fn(),
+        })
+      );
+    });
+
+    await act(async () => {
+      (
+        container!.querySelector(
+          '[data-track="workspace.add-terminal.remote"]'
+        ) as HTMLButtonElement
+      ).click();
+    });
+
+    expect(mocks.setActivePane).toHaveBeenCalledWith('pane-1');
+    const payload = mocks.createAgentSession.mock.calls.at(-1)?.[0];
+    expect(payload).toMatchObject({
+      type: 'terminal',
+      nodeId: 'remote',
+      cwd: '/home/relay',
+      sessionLane: 'remote-cwd',
+    });
+    expect(payload).not.toHaveProperty('repoPath');
+    expect(payload).not.toHaveProperty('worktreePath');
+  });
+});


### PR DESCRIPTION
## Summary
- Splits Customize Session remote-node creation away from the repo/worktree checkout lane.
- Adds a remote cwd text input that defaults to the node home dir from manifest and remembers last-used cwd per node in localStorage.
- Sends remote session creation as `nodeId + cwd` without repo fields, while keeping the local-repo payload unchanged.
- Propagates `homeDir` through node manifests and hub node summaries so the frontend can seed remote cwd defaults.
- Expands component/e2e/backend tests for local-repo, remote-cwd, and home/free remote lanes.

## Motivation
Issue #475 needs the tab creation modal to stop assuming every session is anchored to a local repo/worktree. Remote node sessions need a node-local cwd path instead.

## The Case Against
This change might be wrong because:
- The v1 remote cwd control is free text, so invalid remote paths are still only caught by remote session creation rather than prevalidated in the modal.
- `homeDir` is optional for backwards compatibility, so older nodes without refreshed manifests may require manual cwd entry.
- localStorage persistence is browser-local and per-node only; it intentionally does not sync across devices or users.

If remote file RPC lands soon (#428), this input should probably become a picker-backed field while preserving this payload shape.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
| --- | --- | --- |
| Local repo flow regresses | Low | E2E keeps the local payload assertion for `/sessions` + `repoPath`. |
| Remote session accidentally sends repo fields | Medium | E2E asserts remote payload hits `/hub/nodes/:nodeId/sessions` with cwd and without repo/worktree fields. |
| Missing node home dir breaks defaults | Low | `homeDir` is optional and cwd input falls back to manual absolute path entry. |
| Remembered cwd masks updated node home | Medium | Added "Start in Home" action that bypasses persistence for a home-dir launch. |

## Verification
- `rtk npm test -- test/node-manifest.test.ts test/hub-node-registry.test.ts` — 14 passed.
- `rtk npm run test:e2e -- test/e2e/components/CustomizeSessionDialog.spec.ts` — 9 passed.
- `rtk npm run build` — passed.
- `git push -u origin HEAD` pre-push changed-test sweep — 40 files, 235 tests passed.

Closes #475
Refs #473


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create terminal sessions on remote nodes with custom working directory selection
  * App remembers your selected working directory per remote node for quick access
  * Option to start remote terminals in a remote node's home directory

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/481)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->