### PR TITLE
Route remote session closes through node links

### DIFF
--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -288,6 +288,16 @@ GET /nodes/{nodeId}/ws/sessions/{sessionId}
 
 This upgrades to a WebSocket. The hub proxies PTY I/O between the browser and the node's reverse-link `pty` channel. Resize events are sent as JSON (`{ type: 'resize', cols, rows }`) and forwarded to the node.
 
+### Closing a remote session
+
+Remote tab close/delete uses the hub route:
+
+```http
+DELETE /hub/nodes/{nodeId}/sessions/{sessionId}
+```
+
+The hub forwards that request over the selected node's reverse WebSocket as the `sessions.kill` RPC. The `{sessionId}` is the node-local session id paired with the `{nodeId}` path segment; hub-local sessions still close through `DELETE /sessions/{id}`. After the node-side kill completes, aggregated `GET /sessions` results should no longer include the closed remote session.
+
 ### Node-Scoped Events
 
 Session lifecycle events (idle changes, file changes, session ended) are scoped by node ID so the hub can broadcast them to clients with the correct environment context. The `shared/node-boundary.ts` module handles creating node-scoped event payloads.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -460,7 +460,7 @@ interface TerminalAreaContentProps {
   onOpenPrSession: (pr: PullRequest) => void;
   onArchive: () => Promise<void>;
   onSelectSession: (id: string) => void;
-  onCloseSession: (sessionId: string) => void;
+  onCloseSession: (sessionId: string, nodeId?: string) => void;
   onSessionCreated: (sessionId: string) => void;
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,10 +34,7 @@ import {
 import type { Repo, PullRequest, SessionSummary } from './lib/types.js';
 import { estimateTerminalDimensions } from './lib/utils.js';
 import { createSessionWithoutActivation } from './lib/session-utils.js';
-import {
-  resolveSessionByKey,
-  scopedSessionKey,
-} from './lib/session-keys.js';
+import { resolveSessionByKey, scopedSessionKey } from './lib/session-keys.js';
 import { killSession } from './lib/api.js';
 import {
   getMainWorkspaceSessions,
@@ -193,7 +190,9 @@ function useTerminalDerivedState() {
 
   const activeSession = useMemo(
     () =>
-      activeSessionId ? resolveSessionByKey(sessions, activeSessionId) : undefined,
+      activeSessionId
+        ? resolveSessionByKey(sessions, activeSessionId)
+        : undefined,
     [activeSessionId, sessions]
   );
 
@@ -233,7 +232,11 @@ function useTerminalDerivedState() {
   );
 
   const activeWorkspaceCwd = useMemo(
-    () => activeSession?.worktreePath ?? activeSession?.repoPath ?? activeRepoPath ?? '',
+    () =>
+      activeSession?.worktreePath ??
+      activeSession?.repoPath ??
+      activeRepoPath ??
+      '',
     [activeRepoPath, activeSession]
   );
 
@@ -291,9 +294,7 @@ function AnalyticsViewContent() {
 
 const EMPTY_UTILITY_TERMINAL_IDS: string[] = [];
 
-function getUtilityTerminalIds(
-  railState: WorkspaceUtilityRailState
-): string[] {
+function getUtilityTerminalIds(railState: WorkspaceUtilityRailState): string[] {
   return railState.utilityTerminalIds ?? EMPTY_UTILITY_TERMINAL_IDS;
 }
 
@@ -386,7 +387,8 @@ function useUtilityTerminalHandlers({
 
   const handleSelectUtilityTerminal = useCallback(
     (sessionId: string) => {
-      if (activeWorkspaceCwd) selectUtilityTerminal(activeWorkspaceCwd, sessionId);
+      if (activeWorkspaceCwd)
+        selectUtilityTerminal(activeWorkspaceCwd, sessionId);
     },
     [activeWorkspaceCwd, selectUtilityTerminal]
   );
@@ -399,7 +401,11 @@ function useUtilityTerminalHandlers({
         .getUtilityRailState(activeWorkspaceCwd);
       removeUtilityTerminal(activeWorkspaceCwd, sessionId);
       try {
-        await killSession(sessionId);
+        const session = resolveSessionByKey(
+          useSessionsStore.getState().sessions,
+          sessionId
+        );
+        await killSession(session?.id ?? sessionId, session?.nodeId);
         await useSessionsStore.getState().refreshAll();
       } catch (error) {
         useUiStore.setState({
@@ -543,7 +549,10 @@ function TerminalAreaContent({
   const handleCopyModeChange = useCallback((active: boolean) => {
     setCopyModeActive(active);
   }, []);
-  const getToolbarTerminalHandle = useCallback(() => getActiveTerminalHandle(), []);
+  const getToolbarTerminalHandle = useCallback(
+    () => getActiveTerminalHandle(),
+    []
+  );
 
   const handleExitCopyMode = useCallback(() => {
     getToolbarTerminalHandle()?.exitCopyMode();
@@ -867,13 +876,19 @@ export default function App() {
   // activeSession and activeWorkspaceCwd are needed for FilePicker
   const activeSession = useMemo(
     () =>
-      activeSessionId ? resolveSessionByKey(sessions, activeSessionId) : undefined,
+      activeSessionId
+        ? resolveSessionByKey(sessions, activeSessionId)
+        : undefined,
     [activeSessionId, sessions]
   );
 
   // Active workspace cwd — use worktreePath/repoPath (stable root), not cwd which can drift
   const activeWorkspaceCwd = useMemo(
-    () => activeSession?.worktreePath ?? activeSession?.repoPath ?? activeRepoPath ?? '',
+    () =>
+      activeSession?.worktreePath ??
+      activeSession?.repoPath ??
+      activeRepoPath ??
+      '',
     [activeRepoPath, activeSession]
   );
 
@@ -1109,7 +1124,10 @@ export default function App() {
       navRefreshMounted.current = true;
       return;
     }
-    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') {
+    if (
+      typeof document !== 'undefined' &&
+      document.visibilityState !== 'visible'
+    ) {
       return;
     }
 

--- a/frontend/src/components/WorkspaceArea.tsx
+++ b/frontend/src/components/WorkspaceArea.tsx
@@ -30,6 +30,7 @@ import { useWorkspaceLayoutStore } from '../lib/stores/workspace-layout-store.js
 import type { SummaryContext } from '../lib/workspace-summary.js';
 import type { SessionSummary } from '../lib/types.js';
 import { resolveSessionByKey, scopedSessionKey } from '../lib/session-keys.js';
+import { resolveWorkspaceSessionCloseTarget } from '../lib/workspace-session-close.js';
 import { FileTabContent, type FileTabContentProps } from './FileTabContent.js';
 import { useFileDiff, useInvalidateFileDiff } from '../hooks/useFileDiff.js';
 import { useFileContent } from '../hooks/useFileContent.js';
@@ -69,7 +70,8 @@ function sessionTabId(session: SessionSummary): string {
 
 function propagateLayoutSideRemoval(
   id: string,
-  onCloseSession: (sessionId: string) => void
+  removedTab: WorkspaceTab | undefined,
+  onCloseSession: (sessionId: string, nodeId?: string) => void
 ): void {
   if (id.startsWith('file::')) {
     const ftKey = id.slice('file::'.length);
@@ -82,7 +84,12 @@ function propagateLayoutSideRemoval(
   }
 
   if (id.startsWith('session::')) {
-    onCloseSession(id.slice('session::'.length));
+    const closeTarget = resolveWorkspaceSessionCloseTarget(
+      removedTab ? [removedTab] : [],
+      id,
+      useSessionsStore.getState().sessions
+    );
+    if (closeTarget) onCloseSession(closeTarget.sessionId, closeTarget.nodeId);
   }
 }
 
@@ -348,7 +355,7 @@ export interface WorkspaceAreaProps {
   onImageUpload: (text: string, showInsert: boolean, path?: string) => void;
   onCopyModeChange: (active: boolean) => void;
   onFilePathClick: (path: string) => void;
-  onCloseSession: (sessionId: string) => void;
+  onCloseSession: (sessionId: string, nodeId?: string) => void;
   renderDiff?: FileTabContentProps['renderDiff'];
   renderCode?: FileTabContentProps['renderCode'];
 }
@@ -397,23 +404,34 @@ export function WorkspaceArea({
   // layout get added to the active pane. No long-lived suppression set —
   // the per-cycle `removedThisCycle` set is rebuilt from prev vs current.
   const prevLayoutTabIdsRef = useRef<Set<string>>(new Set());
+  const prevLayoutTabsRef = useRef<Map<string, WorkspaceTab>>(new Map());
   useEffect(() => {
     if (!initializedRef.current) return;
 
     const wsIds = new Set<string>();
+    const wsTabs = new Map<string, WorkspaceTab>();
     for (const pane of listPanes(layout)) {
-      for (const t of pane.tabs) wsIds.add(workspaceTabId(t));
+      for (const t of pane.tabs) {
+        const id = workspaceTabId(t);
+        wsIds.add(id);
+        wsTabs.set(id, t);
+      }
     }
     const prev = prevLayoutTabIdsRef.current;
+    const prevTabs = prevLayoutTabsRef.current;
     const removedFromLayout = new Set<string>();
     for (const id of prev) {
       if (!wsIds.has(id)) removedFromLayout.add(id);
     }
     prevLayoutTabIdsRef.current = wsIds;
+    prevLayoutTabsRef.current = wsTabs;
 
     // Propagate layout-side removals (workspace × button) to the owning store.
+    // Use the previous tab object so remote session removals still retain
+    // nodeId/local-session fallback data after refreshAll drops them from
+    // useSessionsStore.
     for (const id of removedFromLayout) {
-      propagateLayoutSideRemoval(id, onCloseSession);
+      propagateLayoutSideRemoval(id, prevTabs.get(id), onCloseSession);
     }
 
     // Re-read after potential ui mutation above.

--- a/frontend/src/components/WorkspacePane.tsx
+++ b/frontend/src/components/WorkspacePane.tsx
@@ -9,17 +9,11 @@ import {
   registerPaneBodyEl,
   useWorkspaceLayoutStore,
 } from '../lib/stores/workspace-layout-store.js';
-import { useSessionsStore } from '../lib/stores/sessions.js';
-import { killSession } from '../lib/api.js';
-import { resolveWorkspaceSessionCloseTarget } from '../lib/workspace-session-close.js';
-import { createLogger } from '../lib/logger.js';
 import {
   summaryForTab,
   type SummaryContext,
   type WorkspaceTabSummary,
 } from '../lib/workspace-summary.js';
-
-const logger = createLogger('workspace-pane');
 import { WorkspaceTabBar } from './WorkspaceTabBar.js';
 import { WorkspaceDropOverlay } from './WorkspaceDropOverlay.js';
 import './WorkspacePane.css';
@@ -135,23 +129,7 @@ function WorkspacePaneImpl({
     : null;
 
   const handleSelect = (tabId: WorkspaceTabId) => selectTab(pane.id, tabId);
-  const handleClose = async (tabId: WorkspaceTabId) => {
-    if (tabId.startsWith('session::')) {
-      const sessionId = tabId.slice('session::'.length);
-      try {
-        const closeTarget = resolveWorkspaceSessionCloseTarget(
-          pane.tabs,
-          tabId,
-          useSessionsStore.getState().sessions
-        );
-        if (closeTarget) {
-          await killSession(closeTarget.sessionId, closeTarget.nodeId);
-        }
-      } catch (err) {
-        logger.error('Failed to kill session', sessionId, err);
-      }
-      await useSessionsStore.getState().refreshAll();
-    }
+  const handleClose = (tabId: WorkspaceTabId) => {
     closeTab(tabId);
   };
 

--- a/frontend/src/components/WorkspacePane.tsx
+++ b/frontend/src/components/WorkspacePane.tsx
@@ -11,6 +11,7 @@ import {
 } from '../lib/stores/workspace-layout-store.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { killSession } from '../lib/api.js';
+import { resolveSessionByKey } from '../lib/session-keys.js';
 import { createLogger } from '../lib/logger.js';
 import {
   summaryForTab,
@@ -138,7 +139,11 @@ function WorkspacePaneImpl({
     if (tabId.startsWith('session::')) {
       const sessionId = tabId.slice('session::'.length);
       try {
-        await killSession(sessionId);
+        const session = resolveSessionByKey(
+          useSessionsStore.getState().sessions,
+          sessionId
+        );
+        await killSession(session?.id ?? sessionId, session?.nodeId);
       } catch (err) {
         logger.error('Failed to kill session', sessionId, err);
       }

--- a/frontend/src/components/WorkspacePane.tsx
+++ b/frontend/src/components/WorkspacePane.tsx
@@ -11,7 +11,7 @@ import {
 } from '../lib/stores/workspace-layout-store.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { killSession } from '../lib/api.js';
-import { resolveSessionByKey } from '../lib/session-keys.js';
+import { resolveWorkspaceSessionCloseTarget } from '../lib/workspace-session-close.js';
 import { createLogger } from '../lib/logger.js';
 import {
   summaryForTab,
@@ -139,11 +139,14 @@ function WorkspacePaneImpl({
     if (tabId.startsWith('session::')) {
       const sessionId = tabId.slice('session::'.length);
       try {
-        const session = resolveSessionByKey(
-          useSessionsStore.getState().sessions,
-          sessionId
+        const closeTarget = resolveWorkspaceSessionCloseTarget(
+          pane.tabs,
+          tabId,
+          useSessionsStore.getState().sessions
         );
-        await killSession(session?.id ?? sessionId, session?.nodeId);
+        if (closeTarget) {
+          await killSession(closeTarget.sessionId, closeTarget.nodeId);
+        }
       } catch (err) {
         logger.error('Failed to kill session', sessionId, err);
       }

--- a/frontend/src/components/WorkspaceTabBar.css
+++ b/frontend/src/components/WorkspaceTabBar.css
@@ -124,7 +124,11 @@
 }
 
 .ws-tab__meta {
-  flex: 0 0 auto;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--text-muted, #888);
   font-size: 0.62rem;
   border-left: 1px solid var(--border, #1a1a1a);

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -91,7 +91,11 @@ import { createLogger } from '../lib/logger.js';
 import type { Action, ActionContext } from '../lib/actions/types.js';
 import type { Repo } from '../lib/types.js';
 import { createAgentSession } from '../lib/session-utils.js';
-import { resolveSessionByKey, scopedSessionKey } from '../lib/session-keys.js';
+import {
+  resolveSessionByKey,
+  resolveSessionCloseTarget,
+  scopedSessionKey,
+} from '../lib/session-keys.js';
 import { getActiveTerminalHandle } from '../lib/terminal-refs.js';
 import type { CustomizeSessionDialogHandle } from '../components/dialogs/CustomizeSessionDialog.js';
 import type { DeleteWorktreeDialogHandle } from '../components/dialogs/DeleteWorktreeDialog.js';
@@ -195,12 +199,12 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
         handler: async () => {
           const id = useSessionsStore.getState().activeSessionId;
           if (id) {
-            const session = resolveSessionByKey(
+            const { sessionId, nodeId } = resolveSessionCloseTarget(
               useSessionsStore.getState().sessions,
               id
             );
             try {
-              await killSession(session?.id ?? id, session?.nodeId);
+              await killSession(sessionId, nodeId);
             } catch (err) {
               logger.error('Failed to kill session', err);
             }

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -91,10 +91,7 @@ import { createLogger } from '../lib/logger.js';
 import type { Action, ActionContext } from '../lib/actions/types.js';
 import type { Repo } from '../lib/types.js';
 import { createAgentSession } from '../lib/session-utils.js';
-import {
-  resolveSessionByKey,
-  scopedSessionKey,
-} from '../lib/session-keys.js';
+import { resolveSessionByKey, scopedSessionKey } from '../lib/session-keys.js';
 import { getActiveTerminalHandle } from '../lib/terminal-refs.js';
 import type { CustomizeSessionDialogHandle } from '../components/dialogs/CustomizeSessionDialog.js';
 import type { DeleteWorktreeDialogHandle } from '../components/dialogs/DeleteWorktreeDialog.js';
@@ -203,7 +200,7 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
               id
             );
             try {
-              await killSession(session?.id ?? id);
+              await killSession(session?.id ?? id, session?.nodeId);
             } catch (err) {
               logger.error('Failed to kill session', err);
             }

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -93,7 +93,10 @@ export function useSessionHandlers({
     (id: string) => {
       setAnalyticsView(null);
       useSessionsStore.getState().setActiveSessionId(id);
-      const session = resolveSessionByKey(useSessionsStore.getState().sessions, id);
+      const session = resolveSessionByKey(
+        useSessionsStore.getState().sessions,
+        id
+      );
       if (session) {
         if (session.repoPath) {
           useSessionsStore
@@ -585,7 +588,7 @@ export function useSessionHandlers({
     // Kill the session. Archive still proceeds to worktree cleanup if the
     // session was already gone or the backend close fails.
     try {
-      await killSession(session.id);
+      await killSession(session.id, session.nodeId);
     } catch (error) {
       logger.warn('Failed to close session before archive:', error);
     }
@@ -747,20 +750,17 @@ export function useSessionHandlers({
     [deleteWorktreeDialogRef]
   );
 
-  const handleNewSessionCreated = useCallback(
-    (sessionId: string) => {
-      useSessionsStore.getState().setActiveSessionId(sessionId);
-      useSessionsStore
-        .getState()
-        .initSessionNotification(
-          sessionId,
-          useConfigStore.getState().defaultNotifications
-        );
-      useUiStore.getState().closeSidebar();
-      focusActiveTerminalSoon();
-    },
-    []
-  );
+  const handleNewSessionCreated = useCallback((sessionId: string) => {
+    useSessionsStore.getState().setActiveSessionId(sessionId);
+    useSessionsStore
+      .getState()
+      .initSessionNotification(
+        sessionId,
+        useConfigStore.getState().defaultNotifications
+      );
+    useUiStore.getState().closeSidebar();
+    focusActiveTerminalSoon();
+  }, []);
 
   const handleResumeWorktree = useCallback(async (wt: WorktreeInfo) => {
     const loadingKey = wt.path;
@@ -820,14 +820,17 @@ export function useSessionHandlers({
     const targetSession = resolveSessionByKey(state.sessions, sessionId);
     const localSessionId = targetSession?.id ?? sessionId;
     // Kill session via API, then refresh
-    fetch(`/sessions/${localSessionId}`, { method: 'DELETE' }).then(() =>
-      useSessionsStore.getState().refreshAll()
-    );
+    void killSession(localSessionId, targetSession?.nodeId)
+      .catch((error) => {
+        logger.error('Failed to close session:', error);
+      })
+      .finally(() => useSessionsStore.getState().refreshAll());
     const currentActiveSessionId = state.activeSessionId;
     const isClosingActive =
       currentActiveSessionId !== null &&
       targetSession !== undefined &&
-      resolveSessionByKey(state.sessions, currentActiveSessionId) === targetSession;
+      resolveSessionByKey(state.sessions, currentActiveSessionId) ===
+        targetSession;
     if (isClosingActive) {
       // Select next available session in this workspace
       const currentActiveSession = targetSession;

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 import type React from 'react';
-import { parseGlobalSessionId } from '../../../shared/identity.js';
 import { createLogger } from '../lib/logger.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
@@ -28,7 +27,10 @@ import {
   createAgentSession,
   getCurrentSessionContext,
 } from '../lib/session-utils.js';
-import { resolveSessionByKey } from '../lib/session-keys.js';
+import {
+  resolveSessionByKey,
+  resolveSessionCloseTarget,
+} from '../lib/session-keys.js';
 import type { SessionIntent, PickerItem } from '../lib/session-intent.js';
 import { issueToBranchName } from '../lib/session-intent.js';
 import { getActiveTerminalHandle } from '../lib/terminal-refs.js';
@@ -819,15 +821,11 @@ export function useSessionHandlers({
   const handleCloseSession = useCallback(
     (sessionId: string, nodeId?: string) => {
       const state = useSessionsStore.getState();
-      const targetSession = resolveSessionByKey(state.sessions, sessionId);
-      let localSessionId = targetSession?.id ?? sessionId;
-      const targetNodeId = targetSession?.nodeId ?? nodeId;
-      if (!targetSession && targetNodeId) {
-        const parsed = parseGlobalSessionId(sessionId);
-        if (parsed?.nodeId === targetNodeId) {
-          localSessionId = parsed.localSessionId;
-        }
-      }
+      const {
+        session: targetSession,
+        sessionId: localSessionId,
+        nodeId: targetNodeId,
+      } = resolveSessionCloseTarget(state.sessions, sessionId, nodeId);
       // Kill session via API, then refresh
       void killSession(localSessionId, targetNodeId)
         .catch((error) => {
@@ -851,7 +849,9 @@ export function useSessionHandlers({
           ? allWs.filter((s) => s.cwd === currentActiveSession.cwd)
           : allWs;
         const remaining = sameDir.filter((s) => s !== targetSession);
-        useSessionsStore.getState().setActiveSessionId(remaining[0]?.id ?? null);
+        useSessionsStore
+          .getState()
+          .setActiveSessionId(remaining[0]?.id ?? null);
       }
     },
     []

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import type React from 'react';
+import { parseGlobalSessionId } from '../../../shared/identity.js';
 import { createLogger } from '../lib/logger.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
@@ -815,36 +816,46 @@ export function useSessionHandlers({
     }
   }, []);
 
-  const handleCloseSession = useCallback((sessionId: string) => {
-    const state = useSessionsStore.getState();
-    const targetSession = resolveSessionByKey(state.sessions, sessionId);
-    const localSessionId = targetSession?.id ?? sessionId;
-    // Kill session via API, then refresh
-    void killSession(localSessionId, targetSession?.nodeId)
-      .catch((error) => {
-        logger.error('Failed to close session:', error);
-      })
-      .finally(() => useSessionsStore.getState().refreshAll());
-    const currentActiveSessionId = state.activeSessionId;
-    const isClosingActive =
-      currentActiveSessionId !== null &&
-      targetSession !== undefined &&
-      resolveSessionByKey(state.sessions, currentActiveSessionId) ===
-        targetSession;
-    if (isClosingActive) {
-      // Select next available session in this workspace
-      const currentActiveSession = targetSession;
-      const currentRepoPath = useUiStore.getState().activeRepoPath;
-      const allWs = currentRepoPath
-        ? useSessionsStore.getState().getSessionsForRepo(currentRepoPath)
-        : [];
-      const sameDir = currentActiveSession
-        ? allWs.filter((s) => s.cwd === currentActiveSession.cwd)
-        : allWs;
-      const remaining = sameDir.filter((s) => s !== targetSession);
-      useSessionsStore.getState().setActiveSessionId(remaining[0]?.id ?? null);
-    }
-  }, []);
+  const handleCloseSession = useCallback(
+    (sessionId: string, nodeId?: string) => {
+      const state = useSessionsStore.getState();
+      const targetSession = resolveSessionByKey(state.sessions, sessionId);
+      let localSessionId = targetSession?.id ?? sessionId;
+      const targetNodeId = targetSession?.nodeId ?? nodeId;
+      if (!targetSession && targetNodeId) {
+        const parsed = parseGlobalSessionId(sessionId);
+        if (parsed?.nodeId === targetNodeId) {
+          localSessionId = parsed.localSessionId;
+        }
+      }
+      // Kill session via API, then refresh
+      void killSession(localSessionId, targetNodeId)
+        .catch((error) => {
+          logger.error('Failed to close session:', error);
+        })
+        .finally(() => useSessionsStore.getState().refreshAll());
+      const currentActiveSessionId = state.activeSessionId;
+      const isClosingActive =
+        currentActiveSessionId !== null &&
+        targetSession !== undefined &&
+        resolveSessionByKey(state.sessions, currentActiveSessionId) ===
+          targetSession;
+      if (isClosingActive) {
+        // Select next available session in this workspace
+        const currentActiveSession = targetSession;
+        const currentRepoPath = useUiStore.getState().activeRepoPath;
+        const allWs = currentRepoPath
+          ? useSessionsStore.getState().getSessionsForRepo(currentRepoPath)
+          : [];
+        const sameDir = currentActiveSession
+          ? allWs.filter((s) => s.cwd === currentActiveSession.cwd)
+          : allWs;
+        const remaining = sameDir.filter((s) => s !== targetSession);
+        useSessionsStore.getState().setActiveSessionId(remaining[0]?.id ?? null);
+      }
+    },
+    []
+  );
 
   return {
     navigateToDashboard,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -593,8 +593,15 @@ export async function createSession(body: {
   return json<SessionSummary>(res);
 }
 
-export async function killSession(id: string): Promise<void> {
-  const res = await fetch('/sessions/' + id, { method: 'DELETE' });
+export async function killSession(
+  id: string,
+  nodeId?: NodeId | string
+): Promise<void> {
+  const sessionPath =
+    nodeId && nodeId !== DEFAULT_LOCAL_NODE_ID
+      ? `/hub/nodes/${encodeURIComponent(nodeId)}/sessions/${encodeURIComponent(id)}`
+      : `/sessions/${encodeURIComponent(id)}`;
+  const res = await fetch(sessionPath, { method: 'DELETE' });
   if (!res.ok)
     throw await httpErrorFromResponse(res, 'Failed to close session');
 }

--- a/frontend/src/lib/session-keys.ts
+++ b/frontend/src/lib/session-keys.ts
@@ -1,4 +1,7 @@
-import { createGlobalSessionId } from '../../../shared/identity.js';
+import {
+  createGlobalSessionId,
+  parseGlobalSessionId,
+} from '../../../shared/identity.js';
 import type { SessionSummary } from './types.js';
 
 type SessionIdentity = Pick<
@@ -39,6 +42,34 @@ export function resolveSessionByKey<T extends SessionIdentity>(
     legacyMatches.flatMap((session) => (session.nodeId ? [session.nodeId] : []))
   );
   return matchingNodes.size <= 1 ? legacyMatches[0] : undefined;
+}
+
+export interface SessionCloseTarget<T extends SessionIdentity> {
+  session: T | undefined;
+  sessionId: string;
+  nodeId?: string;
+}
+
+export function resolveSessionCloseTarget<T extends SessionIdentity>(
+  sessions: T[],
+  sessionKey: string,
+  nodeId?: string
+): SessionCloseTarget<T> {
+  const session = resolveSessionByKey(sessions, sessionKey);
+  let sessionId = session?.id ?? sessionKey;
+  let targetNodeId = session?.nodeId ?? nodeId;
+
+  if (!session) {
+    const parsed = parseGlobalSessionId(sessionKey);
+    if (parsed && (!targetNodeId || parsed.nodeId === targetNodeId)) {
+      sessionId = parsed.localSessionId;
+      targetNodeId = parsed.nodeId;
+    }
+  }
+
+  return targetNodeId
+    ? { session, sessionId, nodeId: targetNodeId }
+    : { session, sessionId };
 }
 
 export function resolveSessionKey(

--- a/frontend/src/lib/workspace-session-close.ts
+++ b/frontend/src/lib/workspace-session-close.ts
@@ -1,0 +1,34 @@
+import { parseGlobalSessionId } from '../../../shared/identity.js';
+import type { SessionSummary } from './types.js';
+import type { WorkspaceTab, WorkspaceTabId } from './workspace-layout.js';
+import { workspaceTabId } from './workspace-layout.js';
+import { resolveSessionByKey } from './session-keys.js';
+
+export interface WorkspaceSessionCloseTarget {
+  sessionId: string;
+  nodeId?: string;
+}
+
+export function resolveWorkspaceSessionCloseTarget(
+  tabs: WorkspaceTab[],
+  tabId: WorkspaceTabId,
+  sessions: Pick<SessionSummary, 'id' | 'nodeId' | 'globalSessionId'>[]
+): WorkspaceSessionCloseTarget | null {
+  if (!tabId.startsWith('session::')) return null;
+
+  const sessionKey = tabId.slice('session::'.length);
+  const tab = tabs.find((t) => workspaceTabId(t) === tabId);
+  const tabNodeId = tab?.kind === 'session' ? tab.nodeId : undefined;
+  const session = resolveSessionByKey(sessions, sessionKey);
+  const nodeId = session?.nodeId ?? tabNodeId;
+  const parsedTabSession = tabNodeId ? parseGlobalSessionId(sessionKey) : null;
+  const fallbackSessionId =
+    parsedTabSession && parsedTabSession.nodeId === tabNodeId
+      ? parsedTabSession.localSessionId
+      : sessionKey;
+
+  return {
+    sessionId: session?.id ?? fallbackSessionId,
+    ...(nodeId ? { nodeId } : {}),
+  };
+}

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -782,6 +782,74 @@ export function createHubNodeRouter(
     }
   });
 
+  router.delete(
+    '/hub/nodes/:nodeId/sessions/:sessionId',
+    requireAuth,
+    async (req, res) => {
+      const { nodeId, sessionId } = req.params;
+      if (!nodeId) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'nodeId is required')
+        );
+        return;
+      }
+      if (!sessionId) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'sessionId is required')
+        );
+        return;
+      }
+      const node = registry
+        .listNodes()
+        .find((candidate) => candidate.nodeId === nodeId);
+      if (!node || node.status === 'revoked') {
+        sendRelayError(res, relayError('NOT_FOUND', 'node is not paired'));
+        return;
+      }
+      if (node.protocolVersion !== RELAY_NODE_LINK_PROTOCOL_VERSION) {
+        const [nodeMajor] = node.protocolVersion.split('.');
+        const [hubMajor] = RELAY_NODE_LINK_PROTOCOL_VERSION.split('.');
+        sendRelayError(
+          res,
+          relayError(
+            nodeMajor === hubMajor ? 'VERSION_SKEW' : 'PROTOCOL_INCOMPATIBLE',
+            `relay-node-link protocol ${node.protocolVersion} must exactly match hub protocol ${RELAY_NODE_LINK_PROTOCOL_VERSION}`
+          )
+        );
+        return;
+      }
+      if (
+        node.status !== 'online' ||
+        !options.nodeLinks?.hasActiveNode(nodeId)
+      ) {
+        sendRelayError(
+          res,
+          relayError(
+            'NODE_OFFLINE',
+            `node ${nodeId} has no live reverse link`,
+            true
+          )
+        );
+        return;
+      }
+
+      try {
+        await options.nodeLinks.request(nodeId, 'sessions.kill', {
+          id: sessionId,
+        });
+        res.json({ ok: true });
+      } catch (error) {
+        if (error instanceof HubNodeLinkError) {
+          sendRelayError(res, error.relayNodeError);
+          return;
+        }
+        sendRegistryError(registry, res, error);
+      }
+    }
+  );
+
   router.delete('/nodes/:nodeId', requireAuth, (req, res) => {
     const { nodeId } = req.params;
     if (!nodeId) {

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -19,7 +19,8 @@ import type { SessionSummary } from './types.js';
 // RelayNode, and sends back a `<type>.result` (or `<type>.error`)
 // envelope on the same `requestId`.
 //
-// Wired today: `sessions.create` (#425.7) and `sessions.list` (#465).
+// Wired today: `sessions.create` (#425.7), `sessions.list` (#465),
+// and `sessions.kill` (#478).
 // Other RPC types fall through to an INVALID_REQUEST response so
 // misrouted envelopes don't silently hang the hub-side pending
 // request.
@@ -160,6 +161,25 @@ function internalError(message: string): RelayNodeError {
   return { code: 'INTERNAL', message, retryable: true };
 }
 
+function notFound(message: string): RelayNodeError {
+  return { code: 'NOT_FOUND', message, retryable: false };
+}
+
+function parseSessionIdPayload(
+  rpcName: string,
+  raw: unknown
+): string | RelayNodeError {
+  const record = asRecord(raw);
+  if (!record) {
+    return invalidRequest(`${rpcName} payload must be an object`);
+  }
+  const id = asString(record['id']);
+  if (!id) {
+    return invalidRequest(`${rpcName} payload.id must be a non-empty string`);
+  }
+  return id;
+}
+
 function sessionSummaryFromCreateResult(value: unknown): SessionSummary {
   // CreateResult is SessionSummary & { pid }. Strip pid before sending
   // across the wire; hub-side isSessionSummary validator doesn't expect
@@ -252,6 +272,32 @@ export function createNodeLinkRpcHost(
     }
   }
 
+  function handleSessionsKill(
+    envelope: RelayNodeEnvelope,
+    ctx: NodeLinkEnvelopeHandlerContext
+  ): void {
+    const id = parseSessionIdPayload('sessions.kill', envelope.payload);
+    if (typeof id !== 'string') {
+      sendErrorEnvelope(ctx, envelope, id);
+      return;
+    }
+    try {
+      localRelayNode.sessions.kill(id);
+      sendResultEnvelope(ctx, envelope, { ok: true });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error ?? 'unknown');
+      logger.error(`sessions.kill failed: ${message}`);
+      sendErrorEnvelope(
+        ctx,
+        envelope,
+        message.toLowerCase().includes('not found')
+          ? notFound(message)
+          : internalError(message)
+      );
+    }
+  }
+
   function handle(
     envelope: RelayNodeEnvelope,
     ctx: NodeLinkEnvelopeHandlerContext
@@ -263,6 +309,10 @@ export function createNodeLinkRpcHost(
     }
     if (envelope.type === 'sessions.list') {
       handleSessionsList(envelope, ctx);
+      return;
+    }
+    if (envelope.type === 'sessions.kill') {
+      handleSessionsKill(envelope, ctx);
       return;
     }
     logger.warn(

--- a/test/api-error.test.ts
+++ b/test/api-error.test.ts
@@ -80,7 +80,7 @@ describe('frontend api errors', () => {
     });
   });
 
-  it('posts selected remote node session creates to the hub route without leaking nodeId to the node payload', async () => {
+  it('posts selected remote cwd session creates to the hub route without local repo fields', async () => {
     const fetchMock = vi.fn(
       async () =>
         new Response(JSON.stringify({ id: 'remote-session-1' }), {
@@ -92,7 +92,7 @@ describe('frontend api errors', () => {
 
     await createSession({
       nodeId: 'node-a',
-      repoPath: '/repo',
+      cwd: '/home/relay/project',
       type: 'terminal',
       sessionLane: 'remote-cwd',
     });
@@ -101,7 +101,7 @@ describe('frontend api errors', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        repoPath: '/repo',
+        cwd: '/home/relay/project',
         type: 'terminal',
         sessionLane: 'remote-cwd',
       }),

--- a/test/api-error.test.ts
+++ b/test/api-error.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { createSession, HttpError } from '../frontend/src/lib/api.js';
+import {
+  createSession,
+  HttpError,
+  killSession,
+} from '../frontend/src/lib/api.js';
 
 describe('frontend api errors', () => {
   afterEach(() => {
@@ -124,6 +128,41 @@ describe('frontend api errors', () => {
         type: 'agent',
         sessionLane: 'local-repo',
       }),
+    });
+  });
+
+  it('deletes selected remote node sessions through the hub route', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await killSession('remote-session-1', 'node-a');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/hub/nodes/node-a/sessions/remote-session-1',
+      { method: 'DELETE' }
+    );
+  });
+
+  it('keeps local session delete on the local sessions route', async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await killSession('local-session-1');
+
+    expect(fetchMock).toHaveBeenCalledWith('/sessions/local-session-1', {
+      method: 'DELETE',
     });
   });
 

--- a/test/hub-node-session-routing.test.ts
+++ b/test/hub-node-session-routing.test.ts
@@ -360,6 +360,66 @@ describe('hub-routed node session create and attach', () => {
     });
   });
 
+  it('routes remote session delete to the selected connected node', async () => {
+    const { base, wsBase } = await startHub();
+    const { token, nodeId } = await pairNode(base);
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const deletePromise = fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions/remote-session-1`,
+      {
+        method: 'DELETE',
+        headers: { 'x-test-auth': 'yes' },
+      }
+    );
+
+    const request = await nextJson(nodeWs);
+    expect(request).toMatchObject({
+      nodeId,
+      channel: 'rpc',
+      type: 'sessions.kill',
+      payload: { id: 'remote-session-1' },
+    });
+    nodeWs.send(
+      JSON.stringify({
+        protocol: request.protocol,
+        protocolVersion: request.protocolVersion,
+        nodeId,
+        channel: 'rpc',
+        type: 'sessions.kill.result',
+        requestId: request.requestId,
+        timestamp: new Date().toISOString(),
+        payload: { ok: true },
+      })
+    );
+
+    const res = await deletePromise;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('returns NODE_OFFLINE when deleting a remote session on a node with no live reverse link', async () => {
+    const { base } = await startHub();
+    const { nodeId } = await pairNode(base);
+
+    const res = await fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions/remote-session-1`,
+      {
+        method: 'DELETE',
+        headers: { 'x-test-auth': 'yes' },
+      }
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({
+      error: { code: 'NODE_OFFLINE', retryable: true },
+    });
+  });
+
   it('does not trust node-provided scoped identity fields when worktree scope is absent', async () => {
     const { base, wsBase } = await startHub();
     const { token, nodeId } = await pairNode(base);

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -194,6 +194,55 @@ describe('node-link-rpc-host', () => {
     expect(err.message).toContain('payload.sessionLane');
   });
 
+  it('dispatches sessions.kill to localRelayNode', () => {
+    const localRelayNode = fakeLocalNode({ kill: vi.fn() });
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(envelope('sessions.kill', { id: 'sess-1' }), ctx);
+
+    expect(localRelayNode.sessions.kill).toHaveBeenCalledWith('sess-1');
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      channel: 'rpc',
+      type: 'sessions.kill.result',
+      requestId: 'req-1',
+      payload: { ok: true },
+    });
+  });
+
+  it('responds with INVALID_REQUEST when sessions.kill payload is missing id', () => {
+    const localRelayNode = fakeLocalNode({ kill: vi.fn() });
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(envelope('sessions.kill', {}), ctx);
+
+    expect(localRelayNode.sessions.kill).not.toHaveBeenCalled();
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('sessions.kill.error');
+    const err = sent[0]!.error as RelayNodeError;
+    expect(err.code).toBe('INVALID_REQUEST');
+  });
+
+  it('responds with NOT_FOUND when sessions.kill cannot find the session', () => {
+    const localRelayNode = fakeLocalNode({
+      kill: (() => {
+        throw new Error('Session not found: sess-missing');
+      }) as never,
+    });
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(envelope('sessions.kill', { id: 'sess-missing' }), ctx);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('sessions.kill.error');
+    const err = sent[0]!.error as RelayNodeError;
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.retryable).toBe(false);
+  });
+
   it('responds with INVALID_REQUEST when payload is missing type', () => {
     const localRelayNode = fakeLocalNode();
     const host = createNodeLinkRpcHost({ localRelayNode });

--- a/test/session-lifecycle-handlers.test.ts
+++ b/test/session-lifecycle-handlers.test.ts
@@ -189,6 +189,34 @@ describe('session lifecycle handlers', () => {
     expect(refreshAll).toHaveBeenCalled();
   });
 
+  it('uses caller-provided node identity when a remote close races a store refresh', async () => {
+    const fetchMock = stubSuccessfulFetch();
+    useSessionsStore.setState({ sessions: [], activeSessionId: null });
+
+    let handlers: SessionHandlers | undefined;
+    await act(async () => {
+      root!.render(
+        React.createElement(SessionHandlersHarness, {
+          onReady: (next) => {
+            handlers = next;
+          },
+        })
+      );
+    });
+
+    handlers!.handleCloseSession('node-a:remote-session-1', 'node-a');
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/hub/nodes/node-a/sessions/remote-session-1',
+      { method: 'DELETE' }
+    );
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/sessions/remote-session-1',
+      expect.anything()
+    );
+  });
+
   it('keeps tab close for local sessions on the local sessions endpoint', async () => {
     const fetchMock = stubSuccessfulFetch();
     const local = makeSession({ id: 'local-session-1' });

--- a/test/session-lifecycle-handlers.test.ts
+++ b/test/session-lifecycle-handlers.test.ts
@@ -1,0 +1,284 @@
+// @vitest-environment happy-dom
+
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionSummary } from '../frontend/src/lib/types.js';
+import { useSessionHandlers } from '../frontend/src/hooks/useSessionHandlers.js';
+import { useActionRegistry } from '../frontend/src/hooks/useActionRegistry.js';
+import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
+import {
+  _resetForTesting,
+  getAction,
+} from '../frontend/src/lib/actions/registry.js';
+
+vi.mock('../frontend/src/components/dialogs/CustomizeSessionDialog.js', () => ({
+  isFrameworkAvailable: () => true,
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const originalRefreshAll = useSessionsStore.getState().refreshAll;
+
+function makeSession(
+  overrides: Partial<SessionSummary> & { id: string }
+): SessionSummary {
+  return {
+    id: overrides.id,
+    type: 'agent',
+    agent: 'claude',
+    mode: 'pty',
+    repoName: 'relay-ide',
+    repoPath: '/repo/relay-ide',
+    worktreePath: null,
+    cwd: '/repo/relay-ide',
+    branchName: 'nightly',
+    displayName: overrides.id,
+    createdAt: '2026-05-14T00:00:00.000Z',
+    lastActivity: '2026-05-14T00:00:00.000Z',
+    idle: false,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+}
+
+function stubSuccessfulFetch(): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async (_input: RequestInfo | URL) =>
+    jsonResponse({ ok: true })
+  );
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+async function flushPromises(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+type SessionHandlers = ReturnType<typeof useSessionHandlers>;
+
+function SessionHandlersHarness({
+  onReady,
+}: {
+  onReady: (handlers: SessionHandlers) => void;
+}) {
+  const handlers = useSessionHandlers({
+    customizeDialogRef: React.createRef(),
+    deleteWorktreeDialogRef: React.createRef(),
+    workspaceSettingsDialogRef: React.createRef(),
+    setAnalyticsView: vi.fn(),
+  });
+  onReady(handlers);
+  return null;
+}
+
+function ActionRegistryHarness() {
+  useActionRegistry({
+    handleQuickAgent: vi.fn(),
+    handleQuickTerminal: vi.fn(),
+    handleCloseSession: vi.fn(),
+    handleSelectSession: vi.fn(),
+    handleNewWorktree: vi.fn(),
+    handleOpenSettings: vi.fn(),
+    handleRenameActiveSession: vi.fn(),
+    handleArchive: vi.fn(),
+    navigateToDashboard: vi.fn(),
+    customizeDialogRef: React.createRef(),
+    deleteWorktreeDialogRef: React.createRef(),
+    workspaceSettingsDialogRef: React.createRef(),
+    setFilePickerOpen: vi.fn(),
+  });
+  return null;
+}
+
+describe('session lifecycle handlers', () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+  let refreshAll: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    _resetForTesting();
+    refreshAll = vi.fn(async () => undefined);
+    useSessionsStore.setState({
+      sessions: [],
+      worktrees: [],
+      repos: [],
+      workspaceGroups: [],
+      activeSessionId: null,
+      sidebarItems: [],
+      enrichmentResults: {},
+      repoEnrichmentMeta: {},
+      reconnectingPtySessionIds: {},
+      backendConnectionStatus: 'connected',
+      refreshAll: refreshAll as unknown as typeof originalRefreshAll,
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container?.remove();
+    root = null;
+    container = null;
+    _resetForTesting();
+    useSessionsStore.setState({
+      sessions: [],
+      worktrees: [],
+      repos: [],
+      workspaceGroups: [],
+      activeSessionId: null,
+      sidebarItems: [],
+      enrichmentResults: {},
+      repoEnrichmentMeta: {},
+      reconnectingPtySessionIds: {},
+      backendConnectionStatus: 'connected',
+      refreshAll: originalRefreshAll,
+    });
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('routes tab close for remote sessions through the owning node', async () => {
+    const fetchMock = stubSuccessfulFetch();
+    const remote = makeSession({
+      id: 'remote-session-1',
+      nodeId: 'node-a',
+      globalSessionId: 'node-a:remote-session-1',
+    });
+    useSessionsStore.setState({
+      sessions: [remote],
+      activeSessionId: remote.globalSessionId,
+    });
+
+    let handlers: SessionHandlers | undefined;
+    await act(async () => {
+      root!.render(
+        React.createElement(SessionHandlersHarness, {
+          onReady: (next) => {
+            handlers = next;
+          },
+        })
+      );
+    });
+
+    handlers!.handleCloseSession(remote.globalSessionId!);
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/hub/nodes/node-a/sessions/remote-session-1',
+      { method: 'DELETE' }
+    );
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/sessions/node-a:remote-session-1',
+      expect.anything()
+    );
+    expect(refreshAll).toHaveBeenCalled();
+  });
+
+  it('keeps tab close for local sessions on the local sessions endpoint', async () => {
+    const fetchMock = stubSuccessfulFetch();
+    const local = makeSession({ id: 'local-session-1' });
+    useSessionsStore.setState({
+      sessions: [local],
+      activeSessionId: local.id,
+    });
+
+    let handlers: SessionHandlers | undefined;
+    await act(async () => {
+      root!.render(
+        React.createElement(SessionHandlersHarness, {
+          onReady: (next) => {
+            handlers = next;
+          },
+        })
+      );
+    });
+
+    handlers!.handleCloseSession(local.id);
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledWith('/sessions/local-session-1', {
+      method: 'DELETE',
+    });
+  });
+
+  it('routes archive cleanup for remote sessions through the owning node', async () => {
+    const fetchMock = stubSuccessfulFetch();
+    const remote = makeSession({
+      id: 'archive-session-1',
+      nodeId: 'node-a',
+      globalSessionId: 'node-a:archive-session-1',
+    });
+    useSessionsStore.setState({
+      sessions: [remote],
+      activeSessionId: remote.globalSessionId,
+    });
+
+    let handlers: SessionHandlers | undefined;
+    await act(async () => {
+      root!.render(
+        React.createElement(SessionHandlersHarness, {
+          onReady: (next) => {
+            handlers = next;
+          },
+        })
+      );
+    });
+
+    await act(async () => {
+      await handlers!.handleArchive();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/hub/nodes/node-a/sessions/archive-session-1',
+      { method: 'DELETE' }
+    );
+  });
+
+  it('routes command-palette kill for remote sessions through the owning node', async () => {
+    const fetchMock = stubSuccessfulFetch();
+    const remote = makeSession({
+      id: 'palette-session-1',
+      nodeId: 'node-a',
+      globalSessionId: 'node-a:palette-session-1',
+    });
+    useSessionsStore.setState({
+      sessions: [remote],
+      activeSessionId: remote.globalSessionId,
+    });
+
+    await act(async () => {
+      root!.render(React.createElement(ActionRegistryHarness));
+    });
+    await flushPromises();
+
+    const action = getAction('session.kill');
+    expect(action).toBeDefined();
+    await act(async () => {
+      await action!.handler({
+        view: 'session',
+        sessionId: remote.globalSessionId,
+      });
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/hub/nodes/node-a/sessions/palette-session-1',
+      { method: 'DELETE' }
+    );
+    expect(refreshAll).toHaveBeenCalled();
+  });
+});

--- a/test/session-lifecycle-handlers.test.ts
+++ b/test/session-lifecycle-handlers.test.ts
@@ -217,6 +217,37 @@ describe('session lifecycle handlers', () => {
     );
   });
 
+  it('infers the owning node from a stale scoped active-session close', async () => {
+    const fetchMock = stubSuccessfulFetch();
+    useSessionsStore.setState({
+      sessions: [],
+      activeSessionId: 'node-a:remote-session-1',
+    });
+
+    let handlers: SessionHandlers | undefined;
+    await act(async () => {
+      root!.render(
+        React.createElement(SessionHandlersHarness, {
+          onReady: (next) => {
+            handlers = next;
+          },
+        })
+      );
+    });
+
+    handlers!.handleCloseSession('node-a:remote-session-1');
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/hub/nodes/node-a/sessions/remote-session-1',
+      { method: 'DELETE' }
+    );
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/sessions/node-a%3Aremote-session-1',
+      expect.anything()
+    );
+  });
+
   it('keeps tab close for local sessions on the local sessions endpoint', async () => {
     const fetchMock = stubSuccessfulFetch();
     const local = makeSession({ id: 'local-session-1' });
@@ -306,6 +337,38 @@ describe('session lifecycle handlers', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       '/hub/nodes/node-a/sessions/palette-session-1',
       { method: 'DELETE' }
+    );
+    expect(refreshAll).toHaveBeenCalled();
+  });
+
+  it('routes stale command-palette kill for scoped active sessions through the owning node', async () => {
+    const fetchMock = stubSuccessfulFetch();
+    useSessionsStore.setState({
+      sessions: [],
+      activeSessionId: 'node-a:remote-session-1',
+    });
+
+    await act(async () => {
+      root!.render(React.createElement(ActionRegistryHarness));
+    });
+    await flushPromises();
+
+    const action = getAction('session.kill');
+    expect(action).toBeDefined();
+    await act(async () => {
+      await action!.handler({
+        view: 'session',
+        sessionId: 'node-a:remote-session-1',
+      });
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/hub/nodes/node-a/sessions/remote-session-1',
+      { method: 'DELETE' }
+    );
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/sessions/node-a%3Aremote-session-1',
+      expect.anything()
     );
     expect(refreshAll).toHaveBeenCalled();
   });

--- a/test/workspace-session-close.test.ts
+++ b/test/workspace-session-close.test.ts
@@ -1,7 +1,34 @@
+// @vitest-environment happy-dom
+
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { killSession } from '../frontend/src/lib/api.js';
+import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
+import { useUiStore } from '../frontend/src/lib/stores/ui.js';
+import { useWorkspaceLayoutStore } from '../frontend/src/lib/stores/workspace-layout-store.js';
 import { resolveWorkspaceSessionCloseTarget } from '../frontend/src/lib/workspace-session-close.js';
+import type { SessionSummary } from '../frontend/src/lib/types.js';
 import type { WorkspaceTab } from '../frontend/src/lib/workspace-layout.js';
+import { WorkspaceArea } from '../frontend/src/components/WorkspaceArea.js';
+
+vi.mock('../frontend/src/components/Terminal.js', () => ({
+  Terminal: () => null,
+}));
+
+vi.mock('../frontend/src/components/chat/ChatView.js', () => ({
+  ChatView: () => null,
+}));
+
+vi.mock('../frontend/src/components/TerminalNodePicker.js', () => ({
+  TerminalNodePicker: () => null,
+}));
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const originalRefreshAll = useSessionsStore.getState().refreshAll;
 
 function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -86,5 +113,119 @@ describe('resolveWorkspaceSessionCloseTarget', () => {
     expect(fetchMock).toHaveBeenCalledWith('/sessions/local-session-1', {
       method: 'DELETE',
     });
+  });
+});
+
+function makeRemoteSession(): SessionSummary {
+  const now = new Date(0).toISOString();
+  return {
+    id: 'remote-session-1',
+    type: 'terminal',
+    agent: 'terminal',
+    repoName: 'relay-ide',
+    repoPath: '/repo',
+    worktreePath: null,
+    cwd: '/repo',
+    branchName: 'nightly',
+    displayName: 'remote-session-1',
+    createdAt: now,
+    lastActivity: now,
+    idle: false,
+    nodeId: 'node-a',
+    globalSessionId: 'node-a:remote-session-1',
+  };
+}
+
+function resetWorkspaceAreaTestStores(sessions: SessionSummary[] = []): void {
+  useSessionsStore.setState({
+    sessions,
+    activeSessionId: sessions[0]?.globalSessionId ?? sessions[0]?.id ?? null,
+    refreshAll: originalRefreshAll,
+  });
+  useUiStore.setState({ openFileTabs: [], activeFileTabKey: null });
+  useWorkspaceLayoutStore.getState().resetLayout([]);
+}
+
+describe('WorkspaceArea session tab close routing', () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement | null = null;
+
+  afterEach(async () => {
+    await act(async () => {
+      root?.unmount();
+    });
+    root = null;
+    container?.remove();
+    container = null;
+    resetWorkspaceAreaTestStores();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps node routing when the session store clears before a workspace tab close propagates', async () => {
+    const fetchMock = stubSuccessfulFetch();
+    const session = makeRemoteSession();
+    resetWorkspaceAreaTestStores([session]);
+    useSessionsStore.setState({ refreshAll: vi.fn(async () => {}) });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(WorkspaceArea, {
+            workspacePath: '/repo',
+            sessions: [session],
+            onImageUpload: () => {},
+            onCopyModeChange: () => {},
+            onFilePathClick: () => {},
+            onCloseSession: (sessionId: string, nodeId?: string) => {
+              void killSession(sessionId, nodeId);
+            },
+          })
+        )
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      useSessionsStore.setState({ sessions: [], activeSessionId: null });
+    });
+    const closeButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="close remote-session-1"]'
+    );
+
+    expect(closeButton).not.toBeNull();
+    await act(async () => {
+      closeButton!.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const deleteCalls = fetchMock.mock.calls.filter(
+      ([, init]) => (init as RequestInit | undefined)?.method === 'DELETE'
+    );
+    expect(deleteCalls).toEqual([
+      [
+        '/hub/nodes/node-a/sessions/remote-session-1',
+        { method: 'DELETE' },
+      ],
+    ]);
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/sessions/node-a%3Aremote-session-1',
+      expect.anything()
+    );
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/sessions/remote-session-1',
+      expect.anything()
+    );
   });
 });

--- a/test/workspace-session-close.test.ts
+++ b/test/workspace-session-close.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { killSession } from '../frontend/src/lib/api.js';
+import { resolveWorkspaceSessionCloseTarget } from '../frontend/src/lib/workspace-session-close.js';
+import type { WorkspaceTab } from '../frontend/src/lib/workspace-layout.js';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+}
+
+function stubSuccessfulFetch(): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async (_input: RequestInfo | URL) =>
+    jsonResponse({ ok: true })
+  );
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+describe('resolveWorkspaceSessionCloseTarget', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('uses a remote workspace tab nodeId when the sessions store is empty', async () => {
+    const fetchMock = stubSuccessfulFetch();
+    const tabs: WorkspaceTab[] = [
+      {
+        kind: 'session',
+        sessionId: 'node-a:remote-session-1',
+        sessionType: 'terminal',
+        nodeId: 'node-a',
+      },
+    ];
+
+    const target = resolveWorkspaceSessionCloseTarget(
+      tabs,
+      'session::node-a:remote-session-1',
+      []
+    );
+
+    expect(target).toEqual({
+      sessionId: 'remote-session-1',
+      nodeId: 'node-a',
+    });
+
+    await killSession(target!.sessionId, target!.nodeId);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/hub/nodes/node-a/sessions/remote-session-1',
+      { method: 'DELETE' }
+    );
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/sessions/node-a%3Aremote-session-1',
+      expect.anything()
+    );
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/sessions/node-a:remote-session-1',
+      expect.anything()
+    );
+  });
+
+  it('preserves local tab close routing when the tab has no nodeId', async () => {
+    const fetchMock = stubSuccessfulFetch();
+    const tabs: WorkspaceTab[] = [
+      {
+        kind: 'session',
+        sessionId: 'local-session-1',
+        sessionType: 'agent',
+      },
+    ];
+
+    const target = resolveWorkspaceSessionCloseTarget(
+      tabs,
+      'session::local-session-1',
+      []
+    );
+
+    expect(target).toEqual({ sessionId: 'local-session-1' });
+
+    await killSession(target!.sessionId, target!.nodeId);
+
+    expect(fetchMock).toHaveBeenCalledWith('/sessions/local-session-1', {
+      method: 'DELETE',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add hub DELETE routing for `/hub/nodes/:nodeId/sessions/:sessionId` through `HubNodeLinkManager.request(..., 'sessions.kill', ...)`
- add node RPC host support for `sessions.kill`, including invalid payload and not-found error mapping
- update frontend close/delete calls to resolve session node identity and preserve local `/sessions/:id` behavior

## Tests
- `rtk npm test -- test/hub-node-session-routing.test.ts test/node-link-rpc-host.test.ts test/api-error.test.ts`
- `rtk npm run build`
- push hook changed-test suite: 32 files / 194 tests passed

Closes #478


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for closing remote sessions via the hub in federated deployments, with proper routing through reverse WebSocket connections.

* **Documentation**
  * Added "Closing a remote session" section explaining session termination behavior for both remote and local sessions.

* **Tests**
  * Added comprehensive test coverage for remote session deletion, hub routing, and lifecycle handlers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/482)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->