### PR TITLE
fix: guard backend non-repo sessions

### DIFF
--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -23,6 +23,7 @@ import { formatShortcut } from '../lib/actions/shortcuts.js';
 import type { ActionContext, Action } from '../lib/actions/types.js';
 import { isMobileDevice, isMac } from '../lib/utils.js';
 import { scopedSessionKey } from '../lib/session-keys.js';
+import { buildSessionPaletteResults } from '../lib/command-palette-session-results.js';
 import './CommandPalette.css';
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -267,21 +268,8 @@ function buildResults(
       sublabel: ws.path,
       data: ws,
     });
-  for (const s of sessions
-    .filter(
-      (s) =>
-        s.displayName.toLowerCase().includes(q) ||
-        s.branchName.toLowerCase().includes(q) ||
-        s.repoName.toLowerCase().includes(q)
-    )
-    .slice(0, 5)) {
-    items.push({
-      type: 'session',
-      id: `sess-${s.id}`,
-      label: s.displayName || s.branchName || s.repoName,
-      sublabel: s.repoName,
-      data: s,
-    });
+  for (const result of buildSessionPaletteResults(q, sessions, 5)) {
+    items.push(result);
   }
   for (const pr of cachedPrs
     .filter(

--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -338,7 +338,8 @@ function SessionGroupRow({
                         onDeleteWorktree({
                           name: groupPath.split('/').pop() || '',
                           path: groupPath,
-                          repoName: rep.repoName,
+                          repoName:
+                            rep.repoName ?? repoPath.split('/').pop() ?? repoPath,
                           repoPath,
                           displayName: groupDisplayName(
                             groupPath,

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -256,7 +256,7 @@ function buildGroupedByPath(
   const unsorted = new Map<string, typeof activeSessions>();
   unsorted.set(workspacePath, []);
   for (const s of activeSessions) {
-    const groupKey = s.worktreePath ?? s.repoPath;
+    const groupKey = s.worktreePath ?? s.repoPath ?? workspacePath;
     const existing = unsorted.get(groupKey);
     if (existing) existing.push(s);
     else unsorted.set(groupKey, [s]);

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -64,7 +64,7 @@ function resolveAbsolutePathToRepoPath(value: string): string[] {
     if (
       sessionRoots.some((root) => root && pathIsAtOrUnder(absolutePath, root))
     ) {
-      paths.add(session.repoPath);
+      if (session.repoPath) paths.add(session.repoPath);
     }
   }
 

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -71,7 +71,7 @@ export function useSessionHandlers({
         sessionId
       );
       if (session) {
-        useUiStore.getState().setActiveRepoPath(session.repoPath);
+        useUiStore.getState().setActiveRepoPath(session.repoPath ?? null);
       }
       useSessionsStore.getState().handleUserViewed(sessionId);
       useUiStore.getState().closeSidebar();
@@ -95,10 +95,12 @@ export function useSessionHandlers({
       useSessionsStore.getState().setActiveSessionId(id);
       const session = resolveSessionByKey(useSessionsStore.getState().sessions, id);
       if (session) {
-        useSessionsStore
-          .getState()
-          .rememberSessionForWorkspace(session.repoPath, id);
-        useUiStore.getState().setActiveRepoPath(session.repoPath);
+        if (session.repoPath) {
+          useSessionsStore
+            .getState()
+            .rememberSessionForWorkspace(session.repoPath, id);
+        }
+        useUiStore.getState().setActiveRepoPath(session.repoPath ?? null);
       }
       useSessionsStore.getState().handleUserViewed(id);
       useUiStore.getState().closeSidebar();
@@ -334,7 +336,7 @@ export function useSessionHandlers({
         const result = await launchWorkspaceSession(workspaceId);
         await useSessionsStore.getState().refreshAll();
         useSessionsStore.getState().setActiveSessionId(result.id);
-        useUiStore.getState().setActiveRepoPath(result.repoPath);
+        useUiStore.getState().setActiveRepoPath(result.repoPath ?? null);
         useUiStore.getState().setActiveWorkspaceId(workspaceId);
         useUiStore.getState().closeSidebar();
 
@@ -393,8 +395,8 @@ export function useSessionHandlers({
       let newWorktree = false;
 
       if (existingSession) {
-        worktreePath = existingSession.worktreePath;
-        branchName = existingSession.branchName;
+        worktreePath = existingSession.worktreePath ?? null;
+        branchName = existingSession.branchName ?? pr.headRefName;
       } else if (existingWorktree) {
         worktreePath = existingWorktree.path;
         branchName = existingWorktree.branchName;
@@ -462,8 +464,8 @@ export function useSessionHandlers({
         let newWorktree = false;
 
         if (existingSession) {
-          worktreePath = existingSession.worktreePath;
-          branchName = existingSession.branchName;
+          worktreePath = existingSession.worktreePath ?? null;
+          branchName = existingSession.branchName ?? pr.headRefName;
         } else if (existingWorktree) {
           worktreePath = existingWorktree.path;
           branchName = existingWorktree.branchName;
@@ -531,8 +533,8 @@ export function useSessionHandlers({
         let newWorktree = false;
 
         if (existingSession) {
-          worktreePath = existingSession.worktreePath;
-          resolvedBranch = existingSession.branchName;
+          worktreePath = existingSession.worktreePath ?? null;
+          resolvedBranch = existingSession.branchName ?? branchName;
         } else if (existingWorktree) {
           worktreePath = existingWorktree.path;
           resolvedBranch = existingWorktree.branchName;
@@ -589,7 +591,7 @@ export function useSessionHandlers({
     }
 
     // If worktree session, delete the worktree too
-    if (session.worktreePath !== null) {
+    if (session.worktreePath && session.repoPath) {
       try {
         await deleteWorktree(session.worktreePath, session.repoPath);
       } catch {

--- a/frontend/src/lib/command-palette-session-results.ts
+++ b/frontend/src/lib/command-palette-session-results.ts
@@ -1,0 +1,31 @@
+import type { SessionSummary } from './types.js';
+
+export interface SessionPaletteResult {
+  type: 'session';
+  id: string;
+  label: string;
+  sublabel: string;
+  data: SessionSummary;
+}
+
+function searchableText(session: SessionSummary): string[] {
+  return [session.displayName, session.branchName ?? '', session.repoName ?? ''];
+}
+
+export function buildSessionPaletteResults(
+  query: string,
+  sessions: SessionSummary[],
+  limit = 5
+): SessionPaletteResult[] {
+  const q = query.toLowerCase();
+  return sessions
+    .filter((session) => searchableText(session).some((value) => value.toLowerCase().includes(q)))
+    .slice(0, limit)
+    .map((session) => ({
+      type: 'session',
+      id: `sess-${session.id}`,
+      label: session.displayName || session.branchName || session.repoName || session.cwd || session.id,
+      sublabel: session.repoName ?? '',
+      data: session,
+    }));
+}

--- a/frontend/src/lib/session-intent.ts
+++ b/frontend/src/lib/session-intent.ts
@@ -195,7 +195,7 @@ function resolveIssueIntent(
   // Use regex with word boundary to avoid false-positives (e.g., issue-12 matching issue-123)
   const issueBranchPattern = new RegExp(`issue-${issue.number}(?:-|$)`);
   const existingSession = sessions.find((s) =>
-    issueBranchPattern.test(s.branchName)
+    s.branchName ? issueBranchPattern.test(s.branchName) : false
   );
 
   if (existingSession) {

--- a/frontend/src/lib/state/sidebar-items.ts
+++ b/frontend/src/lib/state/sidebar-items.ts
@@ -7,6 +7,7 @@ import type {
 import type { BackendDisplayState, DisplayState } from './display-state.js';
 import { transitionDisplayState } from './display-state.js';
 import { sortByAttention } from './attention.js';
+import { scopedSessionKey } from '../session-keys.js';
 
 /**
  * Derive a BackendDisplayState from a session's agentState and idle flag.
@@ -140,6 +141,14 @@ function buildSidebarItem(
   };
 }
 
+function sessionGroupPath(session: SessionSummary): string {
+  return session.worktreePath ?? session.repoPath ?? `session:${scopedSessionKey(session)}`;
+}
+
+function sessionDisplayPath(session: SessionSummary, groupPath: string): string {
+  return session.repoPath ?? session.cwd ?? groupPath;
+}
+
 /**
  * Build the SidebarItems for a single workspace, appending them to `result`.
  * Returns the set of group paths that were handled so the caller can track orphans.
@@ -181,7 +190,7 @@ function buildItemsForWorkspace(
         kind,
         workspace.path,
         firstSession.displayName,
-        firstSession.branchName,
+        firstSession.branchName ?? '',
         mostRecentActivity(groupSessions),
         groupSessions,
         newBackendState,
@@ -254,13 +263,10 @@ export function buildSidebarItems(
   // Group sessions by their "group path" (worktreePath ?? repoPath)
   const sessionsByGroup = new Map<string, SessionSummary[]>();
   for (const session of sessions) {
-    const groupPath = session.worktreePath ?? session.repoPath;
-    const existing = sessionsByGroup.get(groupPath);
-    if (existing) {
-      existing.push(session);
-    } else {
-      sessionsByGroup.set(groupPath, [session]);
-    }
+    const groupPath = sessionGroupPath(session);
+    const groupSessions = sessionsByGroup.get(groupPath);
+    if (groupSessions) groupSessions.push(session);
+    else sessionsByGroup.set(groupPath, [session]);
   }
 
   // Track which group paths have been handled so we can detect orphan groups
@@ -293,9 +299,9 @@ export function buildSidebarItems(
       buildSidebarItem(
         groupPath,
         'worktree',
-        firstSession.repoPath,
+        sessionDisplayPath(firstSession, groupPath),
         firstSession.displayName,
-        firstSession.branchName,
+        firstSession.branchName ?? '',
         mostRecentActivity(groupSessions),
         groupSessions,
         newBackendState,

--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -255,7 +255,9 @@ function visibleRepoPaths(
   const paths = new Set<string>();
   for (const repo of state.repos) paths.add(repo.path);
   for (const wt of state.worktrees) paths.add(wt.repoPath);
-  for (const session of state.sessions) paths.add(session.repoPath);
+  for (const session of state.sessions) {
+    if (session.repoPath) paths.add(session.repoPath);
+  }
   return Array.from(paths);
 }
 
@@ -569,7 +571,7 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
     if (!workspace) return directSessions;
     const repoSet = new Set(workspace.repos);
     const repoSessions = sessions.filter(
-      (s) => !s.workspaceId && repoSet.has(s.repoPath)
+      (s) => !s.workspaceId && !!s.repoPath && repoSet.has(s.repoPath)
     );
     return [...directSessions, ...repoSessions];
   },

--- a/frontend/src/lib/stores/telemetry.ts
+++ b/frontend/src/lib/stores/telemetry.ts
@@ -208,6 +208,7 @@ export const useTelemetryStore = create<TelemetryState>()((set, get) => ({
     const { sessionTelemetryById } = get();
     const sessionsByRepo = new Map<string, SessionSummary[]>();
     for (const session of sessions) {
+      if (!session.repoPath) continue;
       const bucket = sessionsByRepo.get(session.repoPath) ?? [];
       bucket.push(session);
       sessionsByRepo.set(session.repoPath, bucket);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -147,11 +147,11 @@ export interface SessionSummary {
   type: 'agent' | 'terminal';
   agent: AgentType;
   mode?: 'pty' | 'web' | undefined;
-  repoName: string;
-  repoPath: string;
-  worktreePath: string | null;
+  repoName?: string;
+  repoPath?: string;
+  worktreePath?: string | null;
   cwd: string;
-  branchName: string;
+  branchName?: string;
   displayName: string;
   createdAt: string;
   lastActivity: string;

--- a/server/analytics.ts
+++ b/server/analytics.ts
@@ -90,10 +90,20 @@ const SCHEMA_V3 = `
 ALTER TABLE rate_limit_snapshots ADD COLUMN windows TEXT;
 `;
 
+const SCHEMA_V4 = `
+ALTER TABLE session_events ADD COLUMN node_id TEXT;
+ALTER TABLE session_events ADD COLUMN worktree_path TEXT;
+ALTER TABLE session_events ADD COLUMN branch_name TEXT;
+ALTER TABLE session_events ADD COLUMN session_category TEXT;
+CREATE INDEX IF NOT EXISTS idx_sevents_node ON session_events(node_id);
+CREATE INDEX IF NOT EXISTS idx_sevents_category ON session_events(session_category);
+`;
+
 const MIGRATIONS: Array<{ version: number; sql: string }> = [
   { version: 1, sql: SCHEMA_V1 },
   { version: 2, sql: SCHEMA_V2 },
   { version: 3, sql: SCHEMA_V3 },
+  { version: 4, sql: SCHEMA_V4 },
 ];
 
 const INSERT_SQL =
@@ -154,7 +164,10 @@ function ensureSessionStmts(): void {
   if (!db) return;
   if (!insertSessionEventStmt) {
     insertSessionEventStmt = db.prepare(
-      'INSERT INTO session_events (session_id, repo_path, event_type, event_data, timestamp) VALUES (?, ?, ?, ?, ?)'
+      `INSERT INTO session_events (
+        session_id, node_id, repo_path, worktree_path, branch_name,
+        session_category, event_type, event_data, timestamp
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
     );
   }
   if (!insertRateLimitStmt) {
@@ -185,7 +198,11 @@ export function flushEventBuffer(sessionId?: string): void {
     for (const e of events) {
       stmt.run(
         e.session_id,
+        e.node_id ?? null,
         e.repo_path ?? null,
+        e.worktree_path ?? null,
+        e.branch_name ?? null,
+        e.session_category ?? null,
         e.event_type,
         e.event_data ? JSON.stringify(e.event_data) : null,
         e.timestamp

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -12,6 +12,10 @@ import { stripAnsi, cleanEnv } from './utils.js';
 import { phraseToBranchName } from './git.js';
 import { writeMeta } from './config.js';
 import { recordSessionEvent } from './analytics.js';
+import {
+  buildSessionEvent,
+  hasConcreteRepoBinding,
+} from './session-attribution.js';
 import { forwardHookEvent } from './telemetry.js';
 import { createLogger } from './logger.js';
 
@@ -49,6 +53,7 @@ export interface HookDeps {
     session: { displayName: string; type: string }
   ) => void;
   configPath?: string;
+  executeBranchRename?: (session: Session, promptText: string) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -68,7 +73,7 @@ function scheduleBranchCheck(
   deps: HookDeps,
   delayMs = BRANCH_CHECK_DEBOUNCE_MS
 ): void {
-  if (!session.cwd) return;
+  if (!hasConcreteRepoBinding(session)) return;
   const existing = branchCheckTimers.get(session.id);
   if (existing) clearTimeout(existing);
 
@@ -194,13 +199,13 @@ function createAgentEventHandler(deps: HookDeps) {
     }
 
     // Record the event for analytics
-    recordSessionEvent({
-      session_id: sessionId,
-      repo_path: session.repoPath,
-      event_type: eventType,
-      ...(data !== undefined && { event_data: data }),
-      timestamp: timestamp || new Date().toISOString(),
-    });
+    recordSessionEvent(
+      buildSessionEvent(session, {
+        eventType,
+        ...(data !== undefined && { eventData: data }),
+        timestamp: timestamp || new Date().toISOString(),
+      })
+    );
 
     // Forward to telemetry adapter (e.g. Codex adapter uses this for transcript_path)
     if (data) {
@@ -374,12 +379,7 @@ export function createHooksRouter(deps: HookDeps): Router {
     const session = (req as unknown as Record<string, unknown>)
       ._hookSession as Session;
     setAgentState(session, 'idle', deps);
-    recordSessionEvent({
-      session_id: session.id,
-      repo_path: session.repoPath,
-      event_type: 'agent_stop',
-      timestamp: new Date().toISOString(),
-    });
+    recordSessionEvent(buildSessionEvent(session, { eventType: 'agent_stop' }));
     res.json({ ok: true });
   });
 
@@ -405,13 +405,12 @@ export function createHooksRouter(deps: HookDeps): Router {
       });
     }
 
-    recordSessionEvent({
-      session_id: session.id,
-      repo_path: session.repoPath,
-      event_type: 'notification',
-      event_data: { notificationType: type as string },
-      timestamp: new Date().toISOString(),
-    });
+    recordSessionEvent(
+      buildSessionEvent(session, {
+        eventType: 'notification',
+        eventData: { notificationType: type as string },
+      })
+    );
     res.json({ ok: true });
   });
 
@@ -421,20 +420,21 @@ export function createHooksRouter(deps: HookDeps): Router {
       ._hookSession as Session;
     setAgentState(session, 'processing', deps);
 
-    recordSessionEvent({
-      session_id: session.id,
-      repo_path: session.repoPath,
-      event_type: 'user_prompt',
-      timestamp: new Date().toISOString(),
-    });
+    recordSessionEvent(buildSessionEvent(session, { eventType: 'user_prompt' }));
 
     if (session.needsBranchRename === true) {
       session.needsBranchRename = false;
-      const promptText: string =
-        typeof req.body?.prompt === 'string' ? req.body.prompt : '';
-      spawnBranchRename(session, promptText, deps).catch((err) => {
-        logger.error('spawnBranchRename error:', err);
-      });
+      if (hasConcreteRepoBinding(session)) {
+        const promptText: string =
+          typeof req.body?.prompt === 'string' ? req.body.prompt : '';
+        const renameRunner =
+          deps.executeBranchRename ??
+          ((targetSession, prompt) =>
+            spawnBranchRename(targetSession, prompt, deps));
+        renameRunner(session, promptText).catch((err) => {
+          logger.error('spawnBranchRename error:', err);
+        });
+      }
     }
 
     res.json({ ok: true });
@@ -444,12 +444,7 @@ export function createHooksRouter(deps: HookDeps): Router {
   router.post('/session-end', (req: Request, res: Response) => {
     const session = (req as unknown as Record<string, unknown>)
       ._hookSession as Session;
-    recordSessionEvent({
-      session_id: session.id,
-      repo_path: session.repoPath,
-      event_type: 'session_end',
-      timestamp: new Date().toISOString(),
-    });
+    recordSessionEvent(buildSessionEvent(session, { eventType: 'session_end' }));
     // Acknowledge hook — PTY onExit owns actual cleanup and cleanedUp flag
     res.json({ ok: true });
   });
@@ -465,13 +460,12 @@ export function createHooksRouter(deps: HookDeps): Router {
     session.currentActivity =
       detail !== undefined ? { tool: toolName, detail } : { tool: toolName };
     deps.broadcastEvent('session-activity-changed', { sessionId: session.id });
-    recordSessionEvent({
-      session_id: session.id,
-      repo_path: session.repoPath,
-      event_type: 'tool_use',
-      event_data: { tool: toolName, target: detail },
-      timestamp: new Date().toISOString(),
-    });
+    recordSessionEvent(
+      buildSessionEvent(session, {
+        eventType: 'tool_use',
+        eventData: { tool: toolName, target: detail },
+      })
+    );
     res.json({ ok: true });
   });
 
@@ -487,12 +481,7 @@ export function createHooksRouter(deps: HookDeps): Router {
     if (session.agentState === AGENT_STATE_PERMISSION_PROMPT) {
       setAgentState(session, 'processing', deps);
     }
-    recordSessionEvent({
-      session_id: session.id,
-      repo_path: session.repoPath,
-      event_type: 'tool_complete',
-      timestamp: new Date().toISOString(),
-    });
+    recordSessionEvent(buildSessionEvent(session, { eventType: 'tool_complete' }));
     // Debounced branch check — catches git checkout/switch during tool execution
     scheduleBranchCheck(session, deps);
     res.json({ ok: true });

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -432,6 +432,7 @@ export function createHooksRouter(deps: HookDeps): Router {
           ((targetSession, prompt) =>
             spawnBranchRename(targetSession, prompt, deps));
         renameRunner(session, promptText).catch((err) => {
+          session.needsBranchRename = true;
           logger.error('spawnBranchRename error:', err);
         });
       }

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -107,6 +107,8 @@ export function isSessionSummary(value: unknown): value is SessionSummary {
     typeof session.worktreePath === 'string';
   const branchNameOk =
     session.branchName === undefined || typeof session.branchName === 'string';
+  const repoNameOk =
+    session.repoName === undefined || typeof session.repoName === 'string';
   return (
     typeof session.id === 'string' &&
     (session.type === 'agent' || session.type === 'terminal') &&
@@ -114,7 +116,7 @@ export function isSessionSummary(value: unknown): value is SessionSummary {
     repoPathOk &&
     worktreePathOk &&
     typeof session.cwd === 'string' &&
-    typeof session.repoName === 'string' &&
+    repoNameOk &&
     branchNameOk &&
     typeof session.displayName === 'string' &&
     typeof session.createdAt === 'string' &&

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -28,6 +28,7 @@ import { installOpenCodeRelayPlugin } from './opencode-relay.js';
 import { writeCodexHooksAdapter } from './codex-hooks-adapter.js';
 import { createLogger } from './logger.js';
 import { getDefaultAllocator, type PortAllocator } from './port-allocator.js';
+import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
 
 const IDLE_TIMEOUT_MS = 5000;
 const MAX_SCROLLBACK = 256 * 1024; // 256KB max
@@ -789,6 +790,7 @@ function buildSessionObject(
 
   return {
     id,
+    nodeId: DEFAULT_LOCAL_NODE_ID,
     type: type || 'agent',
     agent,
     mode: 'pty' as const,

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -795,7 +795,7 @@ function buildSessionObject(
     ...(repoPath ? { repoPath } : {}),
     ...(repoPath ? { worktreePath: worktreePath ?? null } : {}),
     ...(repoName ? { repoName } : {}),
-    ...(branchName ? { branchName } : {}),
+    ...(repoPath ? { branchName: branchName ?? '' } : {}),
     displayName: displayName || repoName || path.basename(cwd) || '',
     pty: ptyProcess,
     createdAt,
@@ -1179,7 +1179,9 @@ export function createPtySession(
       ? { worktreePath: session.worktreePath }
       : {}),
     ...(session.repoName ? { repoName: session.repoName } : {}),
-    ...(session.branchName ? { branchName: session.branchName } : {}),
+    ...(session.branchName !== undefined
+      ? { branchName: session.branchName }
+      : {}),
     displayName: session.displayName,
     pid: ptyProcess.pid,
     createdAt,

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -366,7 +366,7 @@ export type CreatePtyParams = {
   type?: SessionType | undefined;
   agent?: AgentType | undefined;
   repoName?: string | undefined;
-  repoPath: string;
+  repoPath?: string | undefined;
   worktreePath?: string | null | undefined;
   cwd: string;
   branchName?: string | undefined;
@@ -550,7 +550,7 @@ function injectPortEnvVars(
 }
 
 function buildPortInjectionParams(
-  repoPath: string,
+  repoPath: string | undefined,
   worktreePath: string | null,
   cwd: string,
   portVariables: string[] | undefined,
@@ -792,10 +792,10 @@ function buildSessionObject(
     type: type || 'agent',
     agent,
     mode: 'pty' as const,
-    repoPath: repoPath || '',
-    worktreePath: worktreePath ?? null,
-    repoName: repoName || '',
-    branchName: branchName || '',
+    ...(repoPath ? { repoPath } : {}),
+    ...(repoPath ? { worktreePath: worktreePath ?? null } : {}),
+    ...(repoName ? { repoName } : {}),
+    ...(branchName ? { branchName } : {}),
     displayName: displayName || repoName || path.basename(cwd) || '',
     pty: ptyProcess,
     createdAt,
@@ -1174,10 +1174,12 @@ export function createPtySession(
     type: session.type,
     agent: session.agent,
     mode: 'pty' as const,
-    repoPath: session.repoPath,
-    worktreePath: session.worktreePath,
-    repoName: session.repoName,
-    branchName: session.branchName,
+    ...(session.repoPath ? { repoPath: session.repoPath } : {}),
+    ...(session.worktreePath !== undefined
+      ? { worktreePath: session.worktreePath }
+      : {}),
+    ...(session.repoName ? { repoName: session.repoName } : {}),
+    ...(session.branchName ? { branchName: session.branchName } : {}),
     displayName: session.displayName,
     pid: ptyProcess.pid,
     createdAt,

--- a/server/relay-state-db.ts
+++ b/server/relay-state-db.ts
@@ -68,7 +68,7 @@ ON CONFLICT(id) DO UPDATE SET
 export interface WebSessionMeta {
   type: string;
   agent: string;
-  repoName: string;
+  repoName?: string;
   customCommand: string | null;
   runtimeOwnership: 'spawned' | 'attached';
   hookToken: string;
@@ -255,7 +255,7 @@ function writeUpsert(session: WebSession): void {
   const meta: WebSessionMeta = {
     type: session.type,
     agent: session.agent,
-    repoName: session.repoName,
+    ...(session.repoName ? { repoName: session.repoName } : {}),
     customCommand: session.customCommand ?? null,
     runtimeOwnership: session.runtimeOwnership,
     hookToken: session.hookToken,

--- a/server/session-attribution.ts
+++ b/server/session-attribution.ts
@@ -1,0 +1,71 @@
+import type { SessionEvent } from './types.js';
+import type { NodeId } from '../shared/identity.js';
+
+export type SessionCategory = 'repo' | 'worktree' | 'free';
+
+export interface SessionAttributionSource {
+  id: string;
+  repoPath?: string | null;
+  worktreePath?: string | null;
+  branchName?: string | null;
+  nodeId?: NodeId | string;
+}
+
+export interface BuildSessionEventOptions {
+  eventType: string;
+  eventData?: Record<string, unknown>;
+  timestamp?: string;
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+export function getSessionCategory(
+  session: Pick<SessionAttributionSource, 'repoPath' | 'worktreePath'>
+): SessionCategory {
+  if (!nonEmptyString(session.repoPath)) return 'free';
+  return nonEmptyString(session.worktreePath) ? 'worktree' : 'repo';
+}
+
+/**
+ * A concrete repo binding means git operations can safely use the session cwd.
+ * `worktreePath === null` is an intentional repo-root session; `undefined`
+ * means the tab is not repo-bound at all.
+ */
+export function hasConcreteRepoBinding(
+  session: Pick<SessionAttributionSource, 'repoPath' | 'worktreePath'> & {
+    cwd?: string | null;
+  }
+): boolean {
+  return (
+    nonEmptyString(session.repoPath) &&
+    session.worktreePath !== undefined &&
+    (session.worktreePath === null || nonEmptyString(session.worktreePath)) &&
+    nonEmptyString(session.cwd)
+  );
+}
+
+export function buildSessionEvent(
+  session: SessionAttributionSource,
+  options: BuildSessionEventOptions
+): SessionEvent {
+  const event: SessionEvent = {
+    session_id: session.id,
+    ...(nonEmptyString(session.nodeId) ? { node_id: session.nodeId } : {}),
+    ...(nonEmptyString(session.repoPath) ? { repo_path: session.repoPath } : {}),
+    ...(session.worktreePath === null
+      ? { worktree_path: null }
+      : nonEmptyString(session.worktreePath)
+        ? { worktree_path: session.worktreePath }
+        : {}),
+    ...(nonEmptyString(session.branchName)
+      ? { branch_name: session.branchName }
+      : {}),
+    session_category: getSessionCategory(session),
+    event_type: options.eventType,
+    ...(options.eventData !== undefined ? { event_data: options.eventData } : {}),
+    timestamp: options.timestamp ?? new Date().toISOString(),
+  };
+  return event;
+}

--- a/server/session-attribution.ts
+++ b/server/session-attribution.ts
@@ -1,5 +1,5 @@
 import type { SessionEvent } from './types.js';
-import type { NodeId } from '../shared/identity.js';
+import { DEFAULT_LOCAL_NODE_ID, type NodeId } from '../shared/identity.js';
 
 export type SessionCategory = 'repo' | 'worktree' | 'free';
 
@@ -52,7 +52,9 @@ export function buildSessionEvent(
 ): SessionEvent {
   const event: SessionEvent = {
     session_id: session.id,
-    ...(nonEmptyString(session.nodeId) ? { node_id: session.nodeId } : {}),
+    node_id: nonEmptyString(session.nodeId)
+      ? session.nodeId
+      : DEFAULT_LOCAL_NODE_ID,
     ...(nonEmptyString(session.repoPath) ? { repo_path: session.repoPath } : {}),
     ...(session.worktreePath === null
       ? { worktree_path: null }

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -413,7 +413,7 @@ function list(): SessionSummary[] {
             : {}),
           cwd: s.cwd,
           ...(s.repoName ? { repoName: s.repoName } : {}),
-          ...(s.branchName ? { branchName: s.branchName } : {}),
+          ...(s.branchName !== undefined ? { branchName: s.branchName } : {}),
           displayName: s.displayName,
           createdAt: s.createdAt,
           lastActivity: s.lastActivity,
@@ -750,7 +750,9 @@ function serializePtySession(
       : {}),
     cwd: session.cwd,
     ...(session.repoName ? { repoName: session.repoName } : {}),
-    ...(session.branchName ? { branchName: session.branchName } : {}),
+    ...(session.branchName !== undefined
+      ? { branchName: session.branchName }
+      : {}),
     displayName: session.displayName,
     createdAt: session.createdAt,
     lastActivity: session.lastActivity,

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -1061,14 +1061,20 @@ async function restoreWebSessionFromDb(
   // Restore persisted adapter runtime settings so the reconnected session
   // matches what was originally running rather than reverting to defaults.
   const persistedConfig = row.agentSessionV2.config;
+  const restoredRepoPath =
+    row.repoPath !== null && row.repoPath.length > 0 ? row.repoPath : undefined;
   const createParams: CreateWebParams = {
     id: row.id,
     agentType: row.meta.adapterType,
     cwd: row.cwd,
-    repoPath: row.repoPath ?? row.cwd,
-    repoName: row.meta.repoName,
-    worktreePath: row.worktreePath,
-    branchName: row.branchName ?? '',
+    ...(restoredRepoPath !== undefined
+      ? {
+          repoPath: restoredRepoPath,
+          ...(row.meta.repoName ? { repoName: row.meta.repoName } : {}),
+          worktreePath: row.worktreePath,
+          branchName: row.branchName ?? '',
+        }
+      : {}),
     displayName: row.displayName ?? '',
     port: defaultPort ?? 3456,
     configDir: defaultConfigDir ?? '',

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -53,6 +53,7 @@ import {
   recordSessionEvent,
   upsertSessionRollup,
 } from './analytics.js';
+import { buildSessionEvent } from './session-attribution.js';
 import { createLogger } from './logger.js';
 
 const execFileAsync = promisify(execFile);
@@ -63,11 +64,11 @@ interface SerializedPtySession {
   id: string;
   type: SessionType;
   agent: AgentType;
-  repoPath: string;
-  worktreePath: string | null;
+  repoPath?: string;
+  worktreePath?: string | null;
   cwd: string;
-  repoName: string;
-  branchName: string;
+  repoName?: string;
+  branchName?: string;
   displayName: string;
   createdAt: string;
   lastActivity: string;
@@ -355,16 +356,11 @@ function create({
   }
   fireSessionCreate(id, ptySession.cwd, ptySession.branchName);
   // Record session start for analytics
-  recordSessionEvent({
-    session_id: id,
-    repo_path: ptySession.repoPath,
-    event_type: 'session_start',
-    timestamp: new Date().toISOString(),
-  });
+  recordSessionEvent(buildSessionEvent(ptySession, { eventType: 'session_start' }));
   upsertSessionRollup({
     sessionId: id,
-    repoPath: ptySession.repoPath,
-    repoName: ptySession.repoName,
+    ...(ptySession.repoPath ? { repoPath: ptySession.repoPath } : {}),
+    ...(ptySession.repoName ? { repoName: ptySession.repoName } : {}),
     agentType: agent,
     startedAt: new Date().toISOString(),
   });
@@ -411,11 +407,13 @@ function list(): SessionSummary[] {
           type: s.type,
           agent: s.agent,
           mode: s.mode,
-          repoPath: s.repoPath,
-          worktreePath: s.worktreePath,
+          ...(s.repoPath ? { repoPath: s.repoPath } : {}),
+          ...(s.worktreePath !== undefined
+            ? { worktreePath: s.worktreePath }
+            : {}),
           cwd: s.cwd,
-          repoName: s.repoName,
-          branchName: s.branchName,
+          ...(s.repoName ? { repoName: s.repoName } : {}),
+          ...(s.branchName ? { branchName: s.branchName } : {}),
           displayName: s.displayName,
           createdAt: s.createdAt,
           lastActivity: s.lastActivity,
@@ -746,11 +744,13 @@ function serializePtySession(
     id: session.id,
     type: session.type,
     agent: session.agent,
-    repoPath: session.repoPath,
-    worktreePath: session.worktreePath,
+    ...(session.repoPath ? { repoPath: session.repoPath } : {}),
+    ...(session.worktreePath !== undefined
+      ? { worktreePath: session.worktreePath }
+      : {}),
     cwd: session.cwd,
-    repoName: session.repoName,
-    branchName: session.branchName,
+    ...(session.repoName ? { repoName: session.repoName } : {}),
+    ...(session.branchName ? { branchName: session.branchName } : {}),
     displayName: session.displayName,
     createdAt: session.createdAt,
     lastActivity: session.lastActivity,

--- a/server/types.ts
+++ b/server/types.ts
@@ -247,6 +247,8 @@ export const AGENT_YOLO_ARGS: Record<string, string[]> = Object.fromEntries(
 // Session types — discriminated union on `mode`
 interface BaseSession {
   id: string;
+  /** Execution node that owns this live session. */
+  nodeId?: NodeId;
   type: SessionType;
   agent: AgentType;
   mode: SessionMode;

--- a/server/types.ts
+++ b/server/types.ts
@@ -250,11 +250,21 @@ interface BaseSession {
   type: SessionType;
   agent: AgentType;
   mode: SessionMode;
-  repoPath: string;
-  worktreePath: string | null;
+  /**
+   * Filesystem path of the repo this session is bound to. Omitted for
+   * node-only/raw-shell sessions that are not associated with a checkout.
+   */
+  repoPath?: string;
+  /**
+   * Worktree path within the repo. `null` = repo-root session;
+   * `undefined` = no repo binding at all.
+   */
+  worktreePath?: string | null;
   cwd: string;
-  repoName: string;
-  branchName: string;
+  /** Human-readable repo name for repo-bound sessions. */
+  repoName?: string;
+  /** Branch name for repo-bound sessions. */
+  branchName?: string;
   displayName: string;
   createdAt: string;
   lastActivity: string;
@@ -356,7 +366,11 @@ export interface SessionSummary {
    */
   worktreePath?: string | null;
   cwd: string;
-  repoName: string;
+  /**
+   * Human-readable repo name for repo-bound sessions. Omitted for non-repo
+   * sessions that have no checkout binding.
+   */
+  repoName?: string;
   /**
    * Branch name for repo-bound sessions. Omitted for non-repo sessions.
    */
@@ -913,9 +927,15 @@ export interface BranchDivergenceSummary {
 
 // ── Session Analytics ──
 
+export type SessionEventCategory = 'repo' | 'worktree' | 'free';
+
 export interface SessionEvent {
   session_id: string;
+  node_id?: string;
   repo_path?: string;
+  worktree_path?: string | null;
+  branch_name?: string;
+  session_category?: SessionEventCategory;
   event_type: string;
   event_data?: Record<string, unknown>;
   timestamp: string;

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -19,10 +19,10 @@ export interface CreateWebParams {
   id?: string;
   agentType: string;
   cwd: string;
-  repoPath: string;
-  repoName: string;
+  repoPath?: string | undefined;
+  repoName?: string | undefined;
   worktreePath?: string | null;
-  branchName: string;
+  branchName?: string | undefined;
   displayName: string;
   port: number;
   configDir: string;
@@ -75,11 +75,11 @@ export async function createWebSession(
     id,
     type: 'agent',
     agent: params.agentType as AgentType,
-    repoPath: params.repoPath,
-    worktreePath: params.worktreePath ?? null,
+    ...(params.repoPath ? { repoPath: params.repoPath } : {}),
+    ...(params.repoPath ? { worktreePath: params.worktreePath ?? null } : {}),
     cwd: params.cwd,
-    repoName: params.repoName,
-    branchName: params.branchName,
+    ...(params.repoName ? { repoName: params.repoName } : {}),
+    ...(params.branchName ? { branchName: params.branchName } : {}),
     displayName: params.displayName,
     createdAt: new Date().toISOString(),
     lastActivity: new Date().toISOString(),

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -11,6 +11,7 @@ import {
   createInitialAgentSessionV2,
 } from './web-session-v2-state.js';
 import { upsertWebSessionNow } from './relay-state-db.js';
+import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
 
 const logger = createLogger('web-session');
 const MESSAGE_BUFFER_MAX = 1000;
@@ -73,6 +74,7 @@ export async function createWebSession(
   const session: WebSession = {
     mode: 'web',
     id,
+    nodeId: DEFAULT_LOCAL_NODE_ID,
     type: 'agent',
     agent: params.agentType as AgentType,
     ...(params.repoPath ? { repoPath: params.repoPath } : {}),

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -79,7 +79,7 @@ export async function createWebSession(
     ...(params.repoPath ? { worktreePath: params.worktreePath ?? null } : {}),
     cwd: params.cwd,
     ...(params.repoName ? { repoName: params.repoName } : {}),
-    ...(params.branchName ? { branchName: params.branchName } : {}),
+    ...(params.repoPath ? { branchName: params.branchName ?? '' } : {}),
     displayName: params.displayName,
     createdAt: new Date().toISOString(),
     lastActivity: new Date().toISOString(),

--- a/test/command-palette-session-fields.test.ts
+++ b/test/command-palette-session-fields.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { buildSessionPaletteResults } from '../frontend/src/lib/command-palette-session-results.js';
+import type { SessionSummary } from '../frontend/src/lib/types.js';
+import { makeSession } from './helpers/frontend-factories.js';
+
+function makeFreeSession(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  const {
+    repoName: _repoName,
+    repoPath: _repoPath,
+    worktreePath: _worktreePath,
+    branchName: _branchName,
+    ...session
+  } = makeSession({
+    id: 'free-session',
+    cwd: '/tmp/free-shell',
+    displayName: 'free shell',
+    ...overrides,
+  });
+  return session;
+}
+
+describe('buildSessionPaletteResults', () => {
+  it('filters and renders free sessions with omitted repo fields', () => {
+    const freeSession = makeFreeSession();
+
+    const results = buildSessionPaletteResults('free', [freeSession], 5);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      id: 'sess-free-session',
+      label: 'free shell',
+      sublabel: '',
+      data: freeSession,
+    });
+  });
+
+  it('preserves repo-bound branch and repo search behavior', () => {
+    const repoSession = makeSession({
+      id: 'repo-session',
+      repoName: 'relay-ide',
+      branchName: 'fix/null-repo',
+      displayName: 'repo tab',
+    });
+
+    expect(buildSessionPaletteResults('null-repo', [repoSession], 5)).toHaveLength(1);
+    expect(buildSessionPaletteResults('relay', [repoSession], 5)).toHaveLength(1);
+  });
+});

--- a/test/hooks-router.test.ts
+++ b/test/hooks-router.test.ts
@@ -4,8 +4,14 @@ import path from 'node:path';
 import os from 'node:os';
 import express from 'express';
 import http from 'node:http';
+import Database from 'better-sqlite3';
 import { createHooksRouter } from '../server/hooks.js';
-import { initAnalytics, closeAnalytics } from '../server/analytics.js';
+import {
+  initAnalytics,
+  closeAnalytics,
+  flushEventBuffer,
+  getDbPath,
+} from '../server/analytics.js';
 import type { Session } from '../server/types.js';
 
 function makeSession(overrides: Partial<Session> = {}): Session {
@@ -53,6 +59,7 @@ let port: number;
 let sessions: Map<string, Session>;
 let broadcastCalls: Array<{ type: string; data?: Record<string, unknown> }>;
 let backendStateCalls: Session[];
+let branchRenameCalls: Array<{ sessionId: string; promptText: string }>;
 let attentionCalls: Array<{
   sessionId: string;
   session: { displayName: string; type: string };
@@ -69,6 +76,7 @@ beforeAll(async () => {
   sessions = new Map();
   broadcastCalls = [];
   backendStateCalls = [];
+  branchRenameCalls = [];
   attentionCalls = [];
 
   const app = express();
@@ -79,6 +87,9 @@ beforeAll(async () => {
     fireBackendStateIfChanged: (s) => backendStateCalls.push(s),
     notifySessionAttention: (sessionId, session) =>
       attentionCalls.push({ sessionId, session }),
+    executeBranchRename: async (session, promptText) => {
+      branchRenameCalls.push({ sessionId: session.id, promptText });
+    },
   });
 
   app.use('/hooks', hooksRouter);
@@ -97,6 +108,7 @@ afterAll(() => {
 beforeEach(() => {
   broadcastCalls.length = 0;
   backendStateCalls.length = 0;
+  branchRenameCalls.length = 0;
   attentionCalls.length = 0;
 });
 
@@ -368,7 +380,74 @@ describe('POST /hooks/prompt-submit', () => {
 
     expect(res.status).toBe(200);
     expect(session.needsBranchRename).toBe(false);
+    expect(branchRenameCalls).toEqual([
+      { sessionId: 'prompt-002', promptText: 'add a feature' },
+    ]);
     sessions.delete('prompt-002');
+  });
+
+  it('skips branch rename for non-repo/free tabs with no checkout binding', async () => {
+    const session = makeSession({
+      id: 'prompt-free-001',
+      hookToken: 'tok',
+      repoPath: undefined as unknown as string,
+      worktreePath: undefined as unknown as null,
+      branchName: undefined as unknown as string,
+      repoName: undefined as unknown as string,
+      needsBranchRename: true,
+    });
+    sessions.set('prompt-free-001', session);
+
+    const res = await fetch(url('/prompt-submit', 'prompt-free-001', 'tok'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'free tab prompt' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(session.needsBranchRename).toBe(false);
+    expect(branchRenameCalls).toHaveLength(0);
+    sessions.delete('prompt-free-001');
+  });
+
+  it('records non-repo/free events with node attribution and null repo fields', async () => {
+    const session = makeSession({
+      id: 'prompt-free-analytics',
+      hookToken: 'tok',
+      repoPath: undefined as unknown as string,
+      worktreePath: undefined as unknown as null,
+      branchName: undefined as unknown as string,
+      repoName: undefined as unknown as string,
+      nodeId: 'node-free-1',
+    });
+    sessions.set('prompt-free-analytics', session);
+
+    const res = await fetch(url('/prompt-submit', 'prompt-free-analytics', 'tok'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'free analytics' }),
+    });
+    expect(res.status).toBe(200);
+
+    flushEventBuffer('prompt-free-analytics');
+    const db = new Database(getDbPath(tmpDir), { readonly: true });
+    const row = db
+      .prepare(
+        `SELECT session_id, node_id, repo_path, worktree_path, branch_name, session_category, event_type
+         FROM session_events WHERE session_id = ? AND event_type = 'user_prompt'`
+      )
+      .get('prompt-free-analytics') as Record<string, unknown>;
+    expect(row).toMatchObject({
+      session_id: 'prompt-free-analytics',
+      node_id: 'node-free-1',
+      repo_path: null,
+      worktree_path: null,
+      branch_name: null,
+      session_category: 'free',
+      event_type: 'user_prompt',
+    });
+    db.close();
+    sessions.delete('prompt-free-analytics');
   });
 
   it('leaves needsBranchRename=false untouched when already false', async () => {

--- a/test/hooks-router.test.ts
+++ b/test/hooks-router.test.ts
@@ -60,6 +60,7 @@ let sessions: Map<string, Session>;
 let broadcastCalls: Array<{ type: string; data?: Record<string, unknown> }>;
 let backendStateCalls: Session[];
 let branchRenameCalls: Array<{ sessionId: string; promptText: string }>;
+let branchRenameError: Error | null;
 let attentionCalls: Array<{
   sessionId: string;
   session: { displayName: string; type: string };
@@ -89,6 +90,7 @@ beforeAll(async () => {
       attentionCalls.push({ sessionId, session }),
     executeBranchRename: async (session, promptText) => {
       branchRenameCalls.push({ sessionId: session.id, promptText });
+      if (branchRenameError) throw branchRenameError;
     },
   });
 
@@ -109,6 +111,7 @@ beforeEach(() => {
   broadcastCalls.length = 0;
   backendStateCalls.length = 0;
   branchRenameCalls.length = 0;
+  branchRenameError = null;
   attentionCalls.length = 0;
 });
 
@@ -386,6 +389,30 @@ describe('POST /hooks/prompt-submit', () => {
     sessions.delete('prompt-002');
   });
 
+  it('restores needsBranchRename when injected rename runner rejects', async () => {
+    branchRenameError = new Error('rename failed');
+    const session = makeSession({
+      id: 'prompt-rename-failure',
+      hookToken: 'tok',
+      needsBranchRename: true,
+    });
+    sessions.set('prompt-rename-failure', session);
+
+    const res = await fetch(url('/prompt-submit', 'prompt-rename-failure', 'tok'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'add a feature' }),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(res.status).toBe(200);
+    expect(session.needsBranchRename).toBe(true);
+    expect(branchRenameCalls).toEqual([
+      { sessionId: 'prompt-rename-failure', promptText: 'add a feature' },
+    ]);
+    sessions.delete('prompt-rename-failure');
+  });
+
   it('skips branch rename for non-repo/free tabs with no checkout binding', async () => {
     const session = makeSession({
       id: 'prompt-free-001',
@@ -436,7 +463,8 @@ describe('POST /hooks/prompt-submit', () => {
         `SELECT session_id, node_id, repo_path, worktree_path, branch_name, session_category, event_type
          FROM session_events WHERE session_id = ? AND event_type = 'user_prompt'`
       )
-      .get('prompt-free-analytics') as Record<string, unknown>;
+      .get('prompt-free-analytics') as Record<string, unknown> | undefined;
+    expect(row).toBeDefined();
     expect(row).toMatchObject({
       session_id: 'prompt-free-analytics',
       node_id: 'node-free-1',

--- a/test/session-analytics.test.ts
+++ b/test/session-analytics.test.ts
@@ -64,7 +64,7 @@ test('initAnalytics creates rate_limit_snapshots table', () => {
   db.close();
 });
 
-test('initAnalytics creates schema_version table at version 3', () => {
+test('initAnalytics creates schema_version table at version 4', () => {
   initAnalytics(tmpDir);
   const db = new Database(getDbPath(tmpDir), { readonly: true });
   const tables = db
@@ -74,7 +74,7 @@ test('initAnalytics creates schema_version table at version 3', () => {
   const version = db.prepare('SELECT version FROM schema_version').get() as {
     version: number;
   };
-  expect(version.version).toBe(3);
+  expect(version.version).toBe(4);
   db.close();
 });
 

--- a/test/session-attribution.test.ts
+++ b/test/session-attribution.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
+import { buildSessionEvent } from '../server/session-attribution.js';
+
+describe('buildSessionEvent', () => {
+  it('defaults local production sessions to the local node id', () => {
+    expect(
+      buildSessionEvent(
+        {
+          id: 'free-session',
+        },
+        { eventType: 'session_start', timestamp: '2026-05-14T00:00:00.000Z' }
+      )
+    ).toMatchObject({
+      session_id: 'free-session',
+      node_id: DEFAULT_LOCAL_NODE_ID,
+      session_category: 'free',
+      event_type: 'session_start',
+    });
+  });
+
+  it('preserves an explicit node id when one is already attached', () => {
+    expect(
+      buildSessionEvent(
+        {
+          id: 'remote-session',
+          nodeId: 'node-b',
+          repoPath: '/repo',
+          worktreePath: null,
+          branchName: 'main',
+        },
+        { eventType: 'tool_complete', timestamp: '2026-05-14T00:00:00.000Z' }
+      )
+    ).toMatchObject({
+      session_id: 'remote-session',
+      node_id: 'node-b',
+      repo_path: '/repo',
+      worktree_path: null,
+      branch_name: 'main',
+      session_category: 'repo',
+    });
+  });
+});

--- a/test/sessions-web-restore.test.ts
+++ b/test/sessions-web-restore.test.ts
@@ -18,6 +18,7 @@ import type {
   AdapterStatus,
   ProtocolAdapterV2,
 } from '../server/protocol-adapter-v2.js';
+import { getSessionCategory } from '../server/session-attribution.js';
 
 const capabilities: AgentCapabilitySetV2 = {
   text: true,
@@ -190,6 +191,65 @@ describe('web session restore failure recovery', () => {
         )
       )
     ).toBe(true);
+    expect(upsertWebSessionNow).toHaveBeenLastCalledWith(session);
+  });
+
+  it('restores persisted free web sessions without synthesizing repo bindings', async () => {
+    loadAllWebSessions.mockReturnValueOnce([
+      {
+        id: 'web-restore-free',
+        vendor: 'claude',
+        vendorSessionId: 'stored-free-provider-session',
+        cwd: configDir,
+        repoPath: null,
+        worktreePath: null,
+        branchName: null,
+        displayName: 'free web restart session',
+        workspaceId: null,
+        agentSessionV2: emptyAgentSessionV2({
+          id: 'web-restore-free',
+          provider: 'claude',
+          cwd: configDir,
+          capabilities,
+          providerSession: { claudeSessionId: 'stored-free-provider-session' },
+        }),
+        meta: {
+          type: 'agent',
+          agent: 'claude',
+          customCommand: null,
+          runtimeOwnership: 'attached',
+          hookToken: 'free-restored-hook-token',
+          adapterType: 'claude',
+        },
+        createdAt: Date.now() - 10_000,
+        lastActivity: Date.now() - 5_000,
+        status: 'active',
+      },
+    ]);
+
+    const sessions = await import('../server/sessions.js');
+    sessions.configure({ port: 4567, configDir });
+
+    const restored = await sessions.restoreFromDisk(configDir);
+
+    expect(restored).toBe(1);
+    expect(resumeSession).toHaveBeenCalledWith('stored-free-provider-session');
+
+    const session = sessions.get('web-restore-free');
+    expect(session).toBeTruthy();
+    expect(session).not.toHaveProperty('repoPath');
+    expect(session).not.toHaveProperty('worktreePath');
+    expect(session).not.toHaveProperty('repoName');
+    expect(session).not.toHaveProperty('branchName');
+    expect(getSessionCategory(session!)).toBe('free');
+
+    const summary = sessions.list().find((s) => s.id === 'web-restore-free');
+    expect(summary).toBeDefined();
+    expect(summary).not.toHaveProperty('repoPath');
+    expect(summary).not.toHaveProperty('branchName');
+    expect(summary).not.toHaveProperty('repoInstanceId');
+    expect(summary).not.toHaveProperty('worktreeInstanceId');
+    expect(summary).toMatchObject({ mode: 'web', cwd: configDir });
     expect(upsertWebSessionNow).toHaveBeenLastCalledWith(session);
   });
 });

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -375,7 +375,7 @@ describe('sessions', () => {
     expect(session!.cwd).toBe('/tmp/workspace/.worktrees/my-branch');
   });
 
-  it('branchName defaults to empty string when branchName is not provided', () => {
+  it('omits branchName when branchName is not provided', () => {
     const result = sessions.create({
       type: 'agent',
       repoName: 'test-repo',
@@ -386,7 +386,38 @@ describe('sessions', () => {
       args: ['hello'],
     });
     createdIds.push(result.id);
-    expect(result.branchName).toBe('');
+
+    expect(result.branchName).toBeUndefined();
+    expect(result).not.toHaveProperty('branchName');
+
+    const listed = sessions.list().find((session) => session.id === result.id);
+    expect(listed).toBeDefined();
+    expect(listed!.branchName).toBeUndefined();
+    expect(listed).not.toHaveProperty('branchName');
+  });
+
+  it('preserves explicit branchName for repo-bound sessions', () => {
+    const result = sessions.create({
+      type: 'agent',
+      repoName: 'test-repo',
+      repoPath: '/tmp/workspace',
+      worktreePath: '/tmp/workspace/.worktrees/feature-branch',
+      cwd: '/tmp/workspace/.worktrees/feature-branch',
+      branchName: 'feature/branch',
+      command: '/bin/echo',
+      args: ['hello'],
+    });
+    createdIds.push(result.id);
+
+    expect(result.branchName).toBe('feature/branch');
+
+    const listed = sessions.list().find((session) => session.id === result.id);
+    expect(listed).toBeDefined();
+    expect(listed!.branchName).toBe('feature/branch');
+
+    const stored = sessions.get(result.id);
+    expect(stored).toBeDefined();
+    expect(stored!.branchName).toBe('feature/branch');
   });
 
   it('resolveTmuxSpawn returns correct tmux command and args', () => {

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -150,12 +150,14 @@ describe('sessions', () => {
     expect(result.globalSessionId).toBe(`local:${result.id}`);
     expect(result.repoInstanceId).toBeUndefined();
     expect(result.worktreeInstanceId).toBeUndefined();
+    expect(result).not.toHaveProperty('branchName');
 
     const listed = sessions.list().find((session) => session.id === result.id);
     expect(listed).toBeDefined();
     expect(listed?.globalSessionId).toBe(`local:${result.id}`);
     expect(listed?.repoInstanceId).toBeUndefined();
     expect(listed?.worktreeInstanceId).toBeUndefined();
+    expect(listed).not.toHaveProperty('branchName');
   });
 
   it('get returns session by id', () => {
@@ -375,7 +377,7 @@ describe('sessions', () => {
     expect(session!.cwd).toBe('/tmp/workspace/.worktrees/my-branch');
   });
 
-  it('omits branchName when branchName is not provided', () => {
+  it('branchName defaults to empty string when branchName is not provided', () => {
     const result = sessions.create({
       type: 'agent',
       repoName: 'test-repo',
@@ -387,13 +389,13 @@ describe('sessions', () => {
     });
     createdIds.push(result.id);
 
-    expect(result.branchName).toBeUndefined();
-    expect(result).not.toHaveProperty('branchName');
+    expect(result.branchName).toBe('');
+    expect(result).toHaveProperty('branchName');
 
     const listed = sessions.list().find((session) => session.id === result.id);
     expect(listed).toBeDefined();
-    expect(listed!.branchName).toBeUndefined();
-    expect(listed).not.toHaveProperty('branchName');
+    expect(listed!.branchName).toBe('');
+    expect(listed).toHaveProperty('branchName');
   });
 
   it('preserves explicit branchName for repo-bound sessions', () => {

--- a/test/sidebar-items.test.ts
+++ b/test/sidebar-items.test.ts
@@ -48,6 +48,32 @@ describe('buildSidebarItems', () => {
     expect(item.displayState).not.toBe('inactive');
   });
 
+  it('free session with omitted repo fields gets a stable sidebar item', () => {
+    const {
+      repoName: _repoName,
+      repoPath: _repoPath,
+      worktreePath: _worktreePath,
+      branchName: _branchName,
+      ...session
+    } = makeSession({
+      id: 'free-session',
+      cwd: '/tmp/free-shell',
+      displayName: 'free shell',
+    });
+
+    const items = buildSidebarItems([session], [], [], []);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      id: 'session:free-session',
+      path: 'session:free-session',
+      repoPath: '/tmp/free-shell',
+      displayName: 'free shell',
+      branchName: '',
+      sessions: [session],
+    });
+  });
+
   it('inactive worktree (no sessions) produces SidebarItem with inactive state', () => {
     const worktree = makeWorktree({ path: '/repo/wt1', repoPath: '/repo' });
     const workspace = makeWorkspace({ path: '/repo' });

--- a/test/web-session-handler.test.ts
+++ b/test/web-session-handler.test.ts
@@ -319,6 +319,41 @@ describe('createWebSession', () => {
     expect(session.id).toBe('custom-id');
   });
 
+  it('defaults repo-bound branchName to an empty string', async () => {
+    const { session } = await createWebSession(
+      {
+        agentType: 'mock',
+        cwd: '/repo',
+        repoPath: '/repo',
+        repoName: 'repo',
+        displayName: 'Test',
+        port: 3000,
+        configDir: '/config',
+      },
+      sessionsMap,
+      onBackendStateChanged
+    );
+
+    expect(session.branchName).toBe('');
+    expect(session).toHaveProperty('branchName');
+  });
+
+  it('omits branchName for non-repo web sessions', async () => {
+    const { session } = await createWebSession(
+      {
+        agentType: 'mock',
+        cwd: '/repo',
+        displayName: 'Test',
+        port: 3000,
+        configDir: '/config',
+      },
+      sessionsMap,
+      onBackendStateChanged
+    );
+
+    expect(session).not.toHaveProperty('branchName');
+  });
+
   it('updates agentState on turn lifecycle events', async () => {
     const { session } = await createWebSession(
       {


### PR DESCRIPTION
## Summary
- Makes backend session repo metadata optional across internal session/PTY/web persistence paths instead of synthesizing empty repo/worktree/branch placeholders.
- Adds `server/session-attribution.ts` to centralize concrete repo binding checks, repo/worktree/free categorization, and analytics event construction.
- Guards hook branch checks/first-prompt branch rename so non-repo/free sessions skip git operations cleanly.
- Extends session analytics schema to record node/worktree/branch/category attribution for nullable-repo sessions and adds regression coverage.

## Motivation
Cross-node and free-tab session flows can legitimately lack repo bindings. Several backend paths still treated repo metadata as load-bearing, which could crash branch/git operations or make analytics invent fake repo fields. This is a backend slice of the tab-as-first-class-surface migration.

Refs #473
Closes #480

## The Case Against
This change might be wrong because:
- Analytics schema v4 adds nullable columns only to `session_events`; downstream reporting that assumes repo-only rollups may still need a separate follow-up.
- `hasConcreteRepoBinding` intentionally requires `repoPath`, `cwd`, and a present `worktreePath` key (`null` for repo-root, string for worktree). If any existing repo-bound caller omits `worktreePath` accidentally, branch rename/checks will now skip rather than run.
- Web session creation now omits absent repo metadata instead of falling back to cwd/repo names, so UI consumers that still assume these fields exist need their own narrowing work.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
|------|------------|------------|
| Repo-bound branch rename accidentally skipped when metadata is incomplete | Medium | Regression tests cover concrete repo vs null-repo behavior; helper documents the required shape. |
| Analytics consumers miss free-session attribution | Low | New `session_category`, `node_id`, `worktree_path`, and `branch_name` columns preserve attribution without fake repo values. |
| Exact optional property regressions in TS | Medium | Build passes after removing explicit `undefined` assignments and synthetic placeholders. |

## Verification
- `rtk npm run build` passes.
- `rtk npm test -- test/hooks-router.test.ts test/session-analytics.test.ts test/telemetry.test.ts` passes: 3 files, 52 tests.
- `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved analytics with richer session attribution and explicit session categories (repo/worktree/free).
  * Command palette now surfaces session search results more reliably.

* **Chores**
  * Database schema updated to record node, worktree, branch, and session category.
  * Sessions and web/PTY flows now handle non-repo ("free") sessions correctly, omitting repo fields when absent.

* **Bug Fixes**
  * Branch-rename flow more robust: rename attempts are recorded and errors restore retry state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/483)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
