### PR TITLE
Guard utility rail by active tab context

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,6 +40,7 @@ import {
   getMainWorkspaceSessions,
   getUtilityTerminalSessions,
 } from './lib/utility-terminals.js';
+import { deriveUtilityRailContext } from './lib/utility-rail-context.js';
 import { initAnalytics, destroyAnalytics, track } from './lib/analytics.js';
 import type { ActionContext } from './lib/actions/types.js';
 import { useEventSocket } from './hooks/useEventSocket.js';
@@ -235,6 +236,7 @@ function useTerminalDerivedState() {
     () =>
       activeSession?.worktreePath ??
       activeSession?.repoPath ??
+      activeSession?.cwd ??
       activeRepoPath ??
       '',
     [activeRepoPath, activeSession]
@@ -311,6 +313,7 @@ function toggleUtilityRailForWorkspace(
 
 interface UtilityTerminalHandlerOptions {
   activeWorkspaceCwd: string;
+  utilityRailStateKey: string;
   activeWorkspace?: Repo | undefined;
   activeSession?: SessionSummary | undefined;
   addUtilityTerminal: (workspacePath: string, sessionId: string) => void;
@@ -322,6 +325,7 @@ interface UtilityTerminalHandlerOptions {
 
 function useUtilityTerminalHandlers({
   activeWorkspaceCwd,
+  utilityRailStateKey,
   activeWorkspace,
   activeSession,
   addUtilityTerminal,
@@ -331,8 +335,8 @@ function useUtilityTerminalHandlers({
   onSelectSession,
 }: UtilityTerminalHandlerOptions) {
   const handleCreateUtilityTerminal = useCallback(async () => {
-    if (!activeWorkspaceCwd) return;
-    const loadingKey = `utility-terminal:${activeWorkspaceCwd}`;
+    if (!activeWorkspaceCwd || !utilityRailStateKey) return;
+    const loadingKey = `utility-terminal:${utilityRailStateKey}`;
     if (useSessionsStore.getState().isItemLoading(loadingKey)) return;
     useSessionsStore.getState().setLoading(loadingKey);
     try {
@@ -351,8 +355,8 @@ function useUtilityTerminalHandlers({
       });
       const isTerminalSession = session?.type === 'terminal';
       if (isTerminalSession) {
-        addUtilityTerminal(activeWorkspaceCwd, session.id);
-        selectUtilityTerminal(activeWorkspaceCwd, session.id);
+        addUtilityTerminal(utilityRailStateKey, session.id);
+        selectUtilityTerminal(utilityRailStateKey, session.id);
         if (!error) {
           useSessionsStore
             .getState()
@@ -383,23 +387,24 @@ function useUtilityTerminalHandlers({
     activeWorkspaceCwd,
     addUtilityTerminal,
     selectUtilityTerminal,
+    utilityRailStateKey,
   ]);
 
   const handleSelectUtilityTerminal = useCallback(
     (sessionId: string) => {
-      if (activeWorkspaceCwd)
-        selectUtilityTerminal(activeWorkspaceCwd, sessionId);
+      if (utilityRailStateKey)
+        selectUtilityTerminal(utilityRailStateKey, sessionId);
     },
-    [activeWorkspaceCwd, selectUtilityTerminal]
+    [selectUtilityTerminal, utilityRailStateKey]
   );
 
   const handleCloseUtilityTerminal = useCallback(
     async (sessionId: string) => {
-      if (!activeWorkspaceCwd) return;
+      if (!utilityRailStateKey) return;
       const previousRailState = useUiStore
         .getState()
-        .getUtilityRailState(activeWorkspaceCwd);
-      removeUtilityTerminal(activeWorkspaceCwd, sessionId);
+        .getUtilityRailState(utilityRailStateKey);
+      removeUtilityTerminal(utilityRailStateKey, sessionId);
       try {
         const session = resolveSessionByKey(
           useSessionsStore.getState().sessions,
@@ -411,10 +416,10 @@ function useUtilityTerminalHandlers({
         useUiStore.setState({
           utilityRailByWorkspace: {
             ...useUiStore.getState().utilityRailByWorkspace,
-            [activeWorkspaceCwd]: previousRailState,
+            [utilityRailStateKey]: previousRailState,
           },
         });
-        useUiStore.getState().saveUtilityRailState(activeWorkspaceCwd);
+        useUiStore.getState().saveUtilityRailState(utilityRailStateKey);
         useToastStore
           .getState()
           .showToast(
@@ -424,16 +429,16 @@ function useUtilityTerminalHandlers({
           );
       }
     },
-    [activeWorkspaceCwd, removeUtilityTerminal]
+    [removeUtilityTerminal, utilityRailStateKey]
   );
 
   const handlePromoteUtilityTerminal = useCallback(
     (sessionId: string) => {
-      if (!activeWorkspaceCwd) return;
-      promoteUtilityTerminal(activeWorkspaceCwd, sessionId);
+      if (!utilityRailStateKey) return;
+      promoteUtilityTerminal(utilityRailStateKey, sessionId);
       onSelectSession(sessionId);
     },
-    [activeWorkspaceCwd, onSelectSession, promoteUtilityTerminal]
+    [onSelectSession, promoteUtilityTerminal, utilityRailStateKey]
   );
 
   return {
@@ -512,9 +517,19 @@ function TerminalAreaContent({
     repos,
     sessions,
   } = useTerminalDerivedState();
+  const utilityRailContext = useMemo(
+    () =>
+      deriveUtilityRailContext({
+        activeRepoPath,
+        ...(activeWorkspace ? { activeWorkspace } : {}),
+        ...(activeSession ? { activeSession } : {}),
+      }),
+    [activeRepoPath, activeSession, activeWorkspace]
+  );
+  const utilityRailStateKey = utilityRailContext.stateKey;
   const utilityRailWorkspaceState = useUiStore((s) =>
-    activeWorkspaceCwd
-      ? s.utilityRailByWorkspace[activeWorkspaceCwd]
+    utilityRailStateKey
+      ? s.utilityRailByWorkspace[utilityRailStateKey]
       : undefined
   );
 
@@ -580,10 +595,26 @@ function TerminalAreaContent({
       const cwd =
         currentActiveSession?.worktreePath ??
         currentActiveSession?.repoPath ??
+        currentActiveSession?.cwd ??
         '';
       const relative = resolveTerminalFilePath(clickedPath, cwd);
       if (relative !== null) {
-        if (cwd) useUiStore.getState().openUtilityRailTab(cwd, 'files');
+        const currentActiveRepoPath = useUiStore.getState().activeRepoPath;
+        const currentWorkspace = currentActiveRepoPath
+          ? sessionsState.repos.find((repo) => repo.path === currentActiveRepoPath)
+          : undefined;
+        const currentRailContext = deriveUtilityRailContext({
+          activeRepoPath: currentActiveRepoPath,
+          ...(currentWorkspace ? { activeWorkspace: currentWorkspace } : {}),
+          ...(currentActiveSession
+            ? { activeSession: currentActiveSession }
+            : {}),
+        });
+        if (currentRailContext.stateKey) {
+          useUiStore
+            .getState()
+            .openUtilityRailTab(currentRailContext.stateKey, 'files');
+        }
         openFileTab(relative, false);
       }
     },
@@ -591,20 +622,20 @@ function TerminalAreaContent({
   );
 
   useEffect(() => {
-    if (activeWorkspaceCwd) hydrateUtilityRailState(activeWorkspaceCwd);
-  }, [activeWorkspaceCwd, hydrateUtilityRailState]);
+    if (utilityRailStateKey) hydrateUtilityRailState(utilityRailStateKey);
+  }, [hydrateUtilityRailState, utilityRailStateKey]);
 
   useEffect(() => {
-    if (!activeWorkspaceCwd) return;
+    if (!utilityRailStateKey) return;
     reconcileUtilityTerminals(
-      activeWorkspaceCwd,
+      utilityRailStateKey,
       new Set(
         allWorkspaceSessions
           .filter((session) => session.type === 'terminal')
           .map((session) => session.id)
       )
     );
-  }, [activeWorkspaceCwd, allWorkspaceSessions, reconcileUtilityTerminals]);
+  }, [allWorkspaceSessions, reconcileUtilityTerminals, utilityRailStateKey]);
 
   const utilityRailState =
     utilityRailWorkspaceState ?? DEFAULT_UTILITY_RAIL_STATE;
@@ -622,20 +653,20 @@ function TerminalAreaContent({
 
   const handleUtilityRailWidthChange = useCallback(
     (width: number) => {
-      if (!activeWorkspaceCwd || !utilityRailResizable) return;
-      setUtilityRailWidth(activeWorkspaceCwd, width - UTILITY_ICON_RAIL_WIDTH);
+      if (!utilityRailStateKey || !utilityRailResizable) return;
+      setUtilityRailWidth(utilityRailStateKey, width - UTILITY_ICON_RAIL_WIDTH);
     },
-    [activeWorkspaceCwd, setUtilityRailWidth, utilityRailResizable]
+    [setUtilityRailWidth, utilityRailResizable, utilityRailStateKey]
   );
 
   const handleUtilityRailResizeEnd = useCallback(() => {
-    if (activeWorkspaceCwd && utilityRailResizable)
-      saveUtilityRailState(activeWorkspaceCwd);
-  }, [activeWorkspaceCwd, saveUtilityRailState, utilityRailResizable]);
+    if (utilityRailStateKey && utilityRailResizable)
+      saveUtilityRailState(utilityRailStateKey);
+  }, [saveUtilityRailState, utilityRailResizable, utilityRailStateKey]);
 
   const handleToggleUtilityRail = useCallback(() => {
-    toggleUtilityRailForWorkspace(activeWorkspaceCwd, toggleUtilityRailVisible);
-  }, [activeWorkspaceCwd, toggleUtilityRailVisible]);
+    toggleUtilityRailForWorkspace(utilityRailStateKey, toggleUtilityRailVisible);
+  }, [toggleUtilityRailVisible, utilityRailStateKey]);
 
   const {
     handleCreateUtilityTerminal,
@@ -644,6 +675,7 @@ function TerminalAreaContent({
     handlePromoteUtilityTerminal,
   } = useUtilityTerminalHandlers({
     activeWorkspaceCwd,
+    utilityRailStateKey,
     ...(activeWorkspace ? { activeWorkspace } : {}),
     ...(activeSession ? { activeSession } : {}),
     addUtilityTerminal,
@@ -717,7 +749,7 @@ function TerminalAreaContent({
         <>
           <PrTopBar
             workspacePath={activeRepoPath ?? ''}
-            utilityRailWorkspacePath={activeWorkspaceCwd}
+            utilityRailWorkspacePath={utilityRailStateKey}
             branchName={activeSession?.branchName ?? ''}
             sessionId={activeSessionId}
             agentRunning={activeSession?.agentState === 'processing'}
@@ -770,7 +802,8 @@ function TerminalAreaContent({
             rightSidebar={
               <WorkspaceUtilityRail
                 fileTreeSidebarRef={fileTreeSidebarRef}
-                workspacePath={activeWorkspaceCwd}
+                workspacePath={utilityRailStateKey}
+                resourceContext={utilityRailContext}
                 railState={utilityRailState}
                 activeSession={activeSession}
                 workspaceSessions={mainWorkspaceSessions}
@@ -882,11 +915,13 @@ export default function App() {
     [activeSessionId, sessions]
   );
 
-  // Active workspace cwd — use worktreePath/repoPath (stable root), not cwd which can drift
+  // Active workspace cwd — prefer stable repo/worktree roots, falling back to cwd
+  // for free terminal tabs that are not bound to a repo.
   const activeWorkspaceCwd = useMemo(
     () =>
       activeSession?.worktreePath ??
       activeSession?.repoPath ??
+      activeSession?.cwd ??
       activeRepoPath ??
       '',
     [activeRepoPath, activeSession]

--- a/frontend/src/components/FileTree/FileTree.tsx
+++ b/frontend/src/components/FileTree/FileTree.tsx
@@ -34,6 +34,7 @@ export interface FileTreeHandle {
 
 export interface FileTreeProps {
   workspacePath: string;
+  stateKey?: string;
   changedFilesData?: string[];
 }
 
@@ -67,11 +68,12 @@ function defaultBranchQueryKey(workspacePath: string) {
 }
 
 export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
-  function FileTree({ workspacePath }, ref) {
+  function FileTree({ workspacePath, stateKey }, ref) {
+    const workspaceStateKey = stateKey ?? workspacePath;
     const rightSidebarTab = useUiStore((s) => s.rightSidebarTab);
     const setRightSidebarTab = useUiStore((s) => s.setRightSidebarTab);
     const reviewState = useUiStore(
-      (s) => s.utilityRailByWorkspace[workspacePath]?.review
+      (s) => s.utilityRailByWorkspace[workspaceStateKey]?.review
     );
     const globalFileDiffSource = useUiStore((s) => s.fileDiffSource);
     const globalFileDiffDefaultBranch = useUiStore(
@@ -109,7 +111,7 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
         setFileDiffDefaultBranch(branch);
       }
       if ((!reviewDefaultBranch || reviewDefaultBranch === 'main') && branch !== reviewDefaultBranch) {
-        setReviewDefaultBranch(workspacePath, branch);
+        setReviewDefaultBranch(workspaceStateKey, branch);
       }
     }, [
       defaultBranchQuery.data,
@@ -117,7 +119,7 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
       reviewDefaultBranch,
       setFileDiffDefaultBranch,
       setReviewDefaultBranch,
-      workspacePath,
+      workspaceStateKey,
     ]);
 
     const query = useQuery<ChangedFilesResponse>({
@@ -259,7 +261,7 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
 
     const activeFileTabKey = useUiStore((s) => s.activeFileTabKey);
     const reviewFilePath = useUiStore(
-      (s) => s.utilityRailByWorkspace[workspacePath]?.review?.activeFilePath ?? null
+      (s) => s.utilityRailByWorkspace[workspaceStateKey]?.review?.activeFilePath ?? null
     );
     const selectedPath = useMemo(() => {
       if (rightSidebarTab === 'changes') return reviewFilePath;
@@ -282,7 +284,7 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
         }
         const isChanged = files.some((f) => f.path === node.path);
         if (isChanged) {
-          openReviewWorkspace(workspacePath, { filePath: node.path });
+          openReviewWorkspace(workspaceStateKey, { filePath: node.path });
         } else {
           openFileTab(node.path, false);
         }

--- a/frontend/src/components/FileTree/FileTree.tsx
+++ b/frontend/src/components/FileTree/FileTree.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../lib/api.js';
 import { useUiStore, type RightSidebarTab } from '../../lib/stores/ui.js';
 import type { ChangedFile, FileChangeStatus } from '../../lib/types.js';
+import type { UtilityRailDisabledReason } from '../../lib/utility-rail-context.js';
 import { FileTreeRow } from './FileTreeRow.js';
 import './file-tree.css';
 
@@ -35,6 +36,8 @@ export interface FileTreeHandle {
 export interface FileTreeProps {
   workspacePath: string;
   stateKey?: string;
+  gitWorkspacePath?: string;
+  gitDisabledReason?: UtilityRailDisabledReason | null;
   changedFilesData?: string[];
 }
 
@@ -59,6 +62,12 @@ interface ChangedFilesResponse {
   error?: string;
 }
 
+const EMPTY_CHANGED_FILES_AGGREGATE = {
+  additions: 0,
+  deletions: 0,
+  fileCount: 0,
+};
+
 function changedFilesQueryKey(workspacePath: string, base: string) {
   return ['changedFiles', workspacePath, base] as const;
 }
@@ -68,8 +77,13 @@ function defaultBranchQueryKey(workspacePath: string) {
 }
 
 export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
-  function FileTree({ workspacePath, stateKey }, ref) {
+  function FileTree(
+    { workspacePath, stateKey, gitWorkspacePath, gitDisabledReason },
+    ref
+  ) {
     const workspaceStateKey = stateKey ?? workspacePath;
+    const effectiveGitWorkspacePath = gitWorkspacePath ?? workspacePath;
+    const gitEnabled = Boolean(effectiveGitWorkspacePath) && !gitDisabledReason;
     const rightSidebarTab = useUiStore((s) => s.rightSidebarTab);
     const setRightSidebarTab = useUiStore((s) => s.setRightSidebarTab);
     const reviewState = useUiStore(
@@ -97,9 +111,9 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
     );
 
     const defaultBranchQuery = useQuery<string>({
-      queryKey: defaultBranchQueryKey(workspacePath),
-      queryFn: () => fetchDefaultBranch(workspacePath),
-      enabled: Boolean(workspacePath),
+      queryKey: defaultBranchQueryKey(effectiveGitWorkspacePath),
+      queryFn: () => fetchDefaultBranch(effectiveGitWorkspacePath),
+      enabled: gitEnabled,
       staleTime: 5 * 60 * 1000,
       retry: false,
     });
@@ -123,13 +137,13 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
     ]);
 
     const query = useQuery<ChangedFilesResponse>({
-      queryKey: changedFilesQueryKey(workspacePath, base),
+      queryKey: changedFilesQueryKey(effectiveGitWorkspacePath, base),
       queryFn: async () => {
-        const data = await fetchChangedFiles(workspacePath, base);
+        const data = await fetchChangedFiles(effectiveGitWorkspacePath, base);
         if (data.error) throw new Error(data.error);
         return data;
       },
-      enabled: Boolean(workspacePath),
+      enabled: gitEnabled,
       staleTime: 2 * 1000,
       retry: false,
     });
@@ -180,23 +194,33 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
     }, [allFilesLoading, allFilesTree.length, loadAllFiles, rightSidebarTab]);
 
     const refresh = useCallback(() => {
-      queryClient.invalidateQueries({
-        queryKey: changedFilesQueryKey(workspacePath, base),
-      });
-      queryClient.invalidateQueries({
-        queryKey: defaultBranchQueryKey(workspacePath),
-      });
+      if (gitEnabled) {
+        queryClient.invalidateQueries({
+          queryKey: changedFilesQueryKey(effectiveGitWorkspacePath, base),
+        });
+        queryClient.invalidateQueries({
+          queryKey: defaultBranchQueryKey(effectiveGitWorkspacePath),
+        });
+      }
       if (rightSidebarTab === 'all-files') void loadAllFiles();
-    }, [base, loadAllFiles, queryClient, rightSidebarTab, workspacePath]);
+    }, [
+      base,
+      effectiveGitWorkspacePath,
+      gitEnabled,
+      loadAllFiles,
+      queryClient,
+      rightSidebarTab,
+    ]);
 
     useImperativeHandle(ref, () => ({ refresh }), [refresh]);
 
-    const files = useMemo(() => query.data?.files ?? [], [query.data?.files]);
-    const aggregate = query.data?.aggregate ?? {
-      additions: 0,
-      deletions: 0,
-      fileCount: 0,
-    };
+    const files = useMemo(
+      () => (gitEnabled ? (query.data?.files ?? []) : []),
+      [gitEnabled, query.data?.files]
+    );
+    const aggregate = gitEnabled
+      ? (query.data?.aggregate ?? EMPTY_CHANGED_FILES_AGGREGATE)
+      : EMPTY_CHANGED_FILES_AGGREGATE;
 
     // ── Filter + tree-state ──
     const [filterText, setFilterText] = useState('');
@@ -289,7 +313,7 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
           openFileTab(node.path, false);
         }
       },
-      [files, openFileTab, openReviewWorkspace, workspacePath]
+      [files, openFileTab, openReviewWorkspace, workspaceStateKey]
     );
 
     const toggleAllFilesDir = useCallback(
@@ -359,8 +383,9 @@ export const FileTree = forwardRef<FileTreeHandle, FileTreeProps>(
       [visibleNodes, focusedIndex, handleNodeClick]
     );
 
-    const isLoading = query.isPending && files.length === 0;
-    const errorMsg = query.error instanceof Error ? query.error.message : null;
+    const isLoading = gitEnabled && query.isPending && files.length === 0;
+    const errorMsg =
+      gitEnabled && query.error instanceof Error ? query.error.message : null;
 
     function renderAllFilesNode(
       entries: BrowseEntry[],

--- a/frontend/src/components/UtilityRailBranchPanel.tsx
+++ b/frontend/src/components/UtilityRailBranchPanel.tsx
@@ -12,6 +12,7 @@ import './UtilityRailBranchPanel.css';
 
 export interface UtilityRailBranchPanelProps {
   workspacePath: string;
+  stateKey?: string;
 }
 
 function divergenceKey(workspacePath: string, base: string | null) {
@@ -149,12 +150,14 @@ function EmptyOrError({ data }: { data: BranchDivergenceSummary }) {
 
 export function UtilityRailBranchPanel({
   workspacePath,
+  stateKey,
 }: UtilityRailBranchPanelProps) {
+  const workspaceStateKey = stateKey ?? workspacePath;
   const queryClient = useQueryClient();
   const openUtilityRailTab = useUiStore((s) => s.openUtilityRailTab);
   const setUtilityBranchBase = useUiStore((s) => s.setUtilityBranchBase);
   const selectedBase = useUiStore(
-    (s) => s.getUtilityRailState(workspacePath).branchBase ?? null
+    (s) => s.getUtilityRailState(workspaceStateKey).branchBase ?? null
   );
 
   const query = useQuery<BranchDivergenceSummary>({
@@ -171,8 +174,8 @@ export function UtilityRailBranchPanel({
   useEffect(() => {
     if (!data || selectedBase !== null) return;
     const nextBase = data.selectedBase?.ref ?? data.baseCandidates[0]?.ref;
-    if (nextBase) setUtilityBranchBase(workspacePath, nextBase);
-  }, [data, selectedBase, setUtilityBranchBase, workspacePath]);
+    if (nextBase) setUtilityBranchBase(workspaceStateKey, nextBase);
+  }, [data, selectedBase, setUtilityBranchBase, workspaceStateKey]);
 
   const dirtySummary = useMemo(() => {
     if (!data) return '0 files';
@@ -194,12 +197,12 @@ export function UtilityRailBranchPanel({
   }, [queryClient, selectedBase, workspacePath]);
 
   const openChanges = useCallback(() => {
-    openUtilityRailTab(workspacePath, 'changes');
-  }, [openUtilityRailTab, workspacePath]);
+    openUtilityRailTab(workspaceStateKey, 'changes');
+  }, [openUtilityRailTab, workspaceStateKey]);
 
   const openReview = useCallback(() => {
-    openUtilityRailTab(workspacePath, 'review');
-  }, [openUtilityRailTab, workspacePath]);
+    openUtilityRailTab(workspaceStateKey, 'review');
+  }, [openUtilityRailTab, workspaceStateKey]);
 
   if (query.isPending && !data) {
     return (
@@ -268,7 +271,7 @@ export function UtilityRailBranchPanel({
           className="branch-select"
           value={currentBase}
           onChange={(event) =>
-            setUtilityBranchBase(workspacePath, event.target.value || null)
+            setUtilityBranchBase(workspaceStateKey, event.target.value || null)
           }
           disabled={baseOptions.length === 0 && !shouldShowMissingBaseOption}
         >

--- a/frontend/src/components/UtilityRailFilesPanel.tsx
+++ b/frontend/src/components/UtilityRailFilesPanel.tsx
@@ -4,14 +4,22 @@ import './WorkspaceUtilityRail.css';
 
 export interface UtilityRailFilesPanelProps {
   workspacePath: string;
+  stateKey?: string;
   fileTreeSidebarRef?: React.RefObject<FileTreeHandle | null>;
 }
 
 export function UtilityRailFilesPanel({
   workspacePath,
+  stateKey,
   fileTreeSidebarRef,
 }: UtilityRailFilesPanelProps) {
-  return <FileTree ref={fileTreeSidebarRef} workspacePath={workspacePath} />;
+  return (
+    <FileTree
+      ref={fileTreeSidebarRef}
+      workspacePath={workspacePath}
+      stateKey={stateKey}
+    />
+  );
 }
 
 export default UtilityRailFilesPanel;

--- a/frontend/src/components/UtilityRailFilesPanel.tsx
+++ b/frontend/src/components/UtilityRailFilesPanel.tsx
@@ -13,11 +13,13 @@ export function UtilityRailFilesPanel({
   stateKey,
   fileTreeSidebarRef,
 }: UtilityRailFilesPanelProps) {
+  const stateKeyProps = stateKey === undefined ? {} : { stateKey };
+
   return (
     <FileTree
       ref={fileTreeSidebarRef}
       workspacePath={workspacePath}
-      stateKey={stateKey}
+      {...stateKeyProps}
     />
   );
 }

--- a/frontend/src/components/UtilityRailFilesPanel.tsx
+++ b/frontend/src/components/UtilityRailFilesPanel.tsx
@@ -1,24 +1,35 @@
 import React from 'react';
 import { FileTree, type FileTreeHandle } from './FileTree/index.js';
+import type { UtilityRailDisabledReason } from '../lib/utility-rail-context.js';
 import './WorkspaceUtilityRail.css';
 
 export interface UtilityRailFilesPanelProps {
   workspacePath: string;
   stateKey?: string;
+  gitWorkspacePath?: string;
+  gitDisabledReason?: UtilityRailDisabledReason | null;
   fileTreeSidebarRef?: React.RefObject<FileTreeHandle | null>;
 }
 
 export function UtilityRailFilesPanel({
   workspacePath,
   stateKey,
+  gitWorkspacePath,
+  gitDisabledReason,
   fileTreeSidebarRef,
 }: UtilityRailFilesPanelProps) {
   const stateKeyProps = stateKey === undefined ? {} : { stateKey };
+  const gitWorkspacePathProps =
+    gitWorkspacePath === undefined ? {} : { gitWorkspacePath };
+  const gitDisabledReasonProps =
+    gitDisabledReason === undefined ? {} : { gitDisabledReason };
 
   return (
     <FileTree
       ref={fileTreeSidebarRef}
       workspacePath={workspacePath}
+      {...gitWorkspacePathProps}
+      {...gitDisabledReasonProps}
       {...stateKeyProps}
     />
   );

--- a/frontend/src/components/UtilityRailGitChangesPanel.tsx
+++ b/frontend/src/components/UtilityRailGitChangesPanel.tsx
@@ -7,6 +7,7 @@ import './UtilityRailGitChangesPanel.css';
 
 export interface UtilityRailGitChangesPanelProps {
   workspacePath: string;
+  stateKey?: string;
 }
 
 interface ChangedFilesResponse {
@@ -77,12 +78,14 @@ function FileRow({ file, selected, onClick }: RowProps) {
 
 export function UtilityRailGitChangesPanel({
   workspacePath,
+  stateKey,
 }: UtilityRailGitChangesPanelProps) {
+  const workspaceStateKey = stateKey ?? workspacePath;
   const queryClient = useQueryClient();
   const openUtilityRailTab = useUiStore((s) => s.openUtilityRailTab);
   const openReviewWorkspace = useUiStore((s) => s.openReviewWorkspace);
   const reviewFilePath = useUiStore(
-    (s) => s.utilityRailByWorkspace[workspacePath]?.review?.activeFilePath ?? null
+    (s) => s.utilityRailByWorkspace[workspaceStateKey]?.review?.activeFilePath ?? null
   );
 
   const workingQuery = useQuery<ChangedFilesResponse>({
@@ -115,8 +118,8 @@ export function UtilityRailGitChangesPanel({
   }, [queryClient, workspacePath]);
 
   const openBranchPanel = useCallback(() => {
-    openUtilityRailTab(workspacePath, 'branch');
-  }, [openUtilityRailTab, workspacePath]);
+    openUtilityRailTab(workspaceStateKey, 'branch');
+  }, [openUtilityRailTab, workspaceStateKey]);
 
   const groups = useMemo(() => {
     const working = workingQuery.data?.files ?? [];
@@ -130,16 +133,16 @@ export function UtilityRailGitChangesPanel({
 
   const handleStagedClick = useCallback(
     (file: ChangedFile) => {
-      openReviewWorkspace(workspacePath, { filePath: file.path, base: 'cached' });
+      openReviewWorkspace(workspaceStateKey, { filePath: file.path, base: 'cached' });
     },
-    [openReviewWorkspace, workspacePath]
+    [openReviewWorkspace, workspaceStateKey]
   );
 
   const handleWorkingClick = useCallback(
     (file: ChangedFile) => {
-      openReviewWorkspace(workspacePath, { filePath: file.path, base: '' });
+      openReviewWorkspace(workspaceStateKey, { filePath: file.path, base: '' });
     },
-    [openReviewWorkspace, workspacePath]
+    [openReviewWorkspace, workspaceStateKey]
   );
 
   const selectedPath = reviewFilePath;

--- a/frontend/src/components/UtilityRailReviewPanel.tsx
+++ b/frontend/src/components/UtilityRailReviewPanel.tsx
@@ -22,6 +22,7 @@ import './WorkspaceUtilityRail.css';
 
 export interface UtilityRailReviewPanelProps {
   workspacePath: string;
+  stateKey?: string;
   reviewState?: WorkspaceReviewState | undefined;
   onRequestClose?: (() => void) | undefined;
   active?: boolean | undefined;
@@ -67,13 +68,15 @@ function sourceLabel(source: DiffSource, defaultBranch: string): string {
 
 export function UtilityRailReviewPanel({
   workspacePath,
+  stateKey,
   reviewState,
   onRequestClose,
   active = true,
 }: UtilityRailReviewPanelProps) {
+  const workspaceStateKey = stateKey ?? workspacePath;
   const queryClient = useQueryClient();
   const storeReviewState = useUiStore(
-    (s) => s.utilityRailByWorkspace[workspacePath]?.review
+    (s) => s.utilityRailByWorkspace[workspaceStateKey]?.review
   );
   const fileDiffViewMode = useUiStore((s) => s.fileDiffViewMode);
   const setFileDiffViewMode = useUiStore((s) => s.setFileDiffViewMode);
@@ -116,9 +119,9 @@ export function UtilityRailReviewPanel({
       (review.defaultBranch === 'main' || review.defaultBranch === '') &&
       branch !== review.defaultBranch
     ) {
-      setReviewDefaultBranch(workspacePath, branch);
+      setReviewDefaultBranch(workspaceStateKey, branch);
     }
-  }, [defaultBranchQuery.data, review.defaultBranch, setReviewDefaultBranch, workspacePath]);
+  }, [defaultBranchQuery.data, review.defaultBranch, setReviewDefaultBranch, workspaceStateKey, workspacePath]);
 
   const filesQuery = useQuery<ChangedFilesResponse>({
     queryKey: changedFilesQueryKey(workspacePath, base),
@@ -143,8 +146,8 @@ export function UtilityRailReviewPanel({
     if (activeFilePath && files.some((file) => file.path === activeFilePath)) {
       return;
     }
-    setReviewActiveFile(workspacePath, files[0]?.path ?? null);
-  }, [activeFilePath, files, filesQuery.isError, filesQuery.isPending, setReviewActiveFile, workspacePath]);
+    setReviewActiveFile(workspaceStateKey, files[0]?.path ?? null);
+  }, [activeFilePath, files, filesQuery.isError, filesQuery.isPending, setReviewActiveFile, workspaceStateKey, workspacePath]);
 
   const {
     diff: fileDiff,
@@ -177,16 +180,16 @@ export function UtilityRailReviewPanel({
 
   const handleSelectFile = useCallback(
     (file: ChangedFile) => {
-      setReviewActiveFile(workspacePath, file.path);
+      setReviewActiveFile(workspaceStateKey, file.path);
     },
-    [setReviewActiveFile, workspacePath]
+    [setReviewActiveFile, workspaceStateKey]
   );
 
   const handleSourceChange = useCallback(
     (source: DiffSource) => {
-      setReviewDiffSource(workspacePath, source);
+      setReviewDiffSource(workspaceStateKey, source);
     },
-    [setReviewDiffSource, workspacePath]
+    [setReviewDiffSource, workspaceStateKey]
   );
 
   const handleModeToggle = useCallback(() => {
@@ -197,10 +200,10 @@ export function UtilityRailReviewPanel({
 
   const branchBase = review.diffSource === 'branch' ? base : null;
   const openBranchPanel = useCallback(() => {
-    openUtilityRailTab(workspacePath, 'branch', {
+    openUtilityRailTab(workspaceStateKey, 'branch', {
       branchBase,
     });
-  }, [branchBase, openUtilityRailTab, workspacePath]);
+  }, [branchBase, openUtilityRailTab, workspaceStateKey]);
 
   const scrollToHunk = useCallback(
     (delta: number) => {
@@ -212,10 +215,10 @@ export function UtilityRailReviewPanel({
         0,
         Math.min(hunks.length - 1, review.currentHunkIndex + delta)
       );
-      setReviewCurrentHunkIndex(workspacePath, target);
+      setReviewCurrentHunkIndex(workspaceStateKey, target);
       hunks[target]?.scrollIntoView({ block: 'center', behavior: 'smooth' });
     },
-    [review.currentHunkIndex, setReviewCurrentHunkIndex, workspacePath]
+    [review.currentHunkIndex, setReviewCurrentHunkIndex, workspaceStateKey]
   );
 
   const handleKeyDown = useCallback(
@@ -238,11 +241,11 @@ export function UtilityRailReviewPanel({
         if (onRequestClose) {
           onRequestClose();
         } else {
-          useUiStore.getState().setSelectedUtilityRailTab(workspacePath, null);
+          useUiStore.getState().setSelectedUtilityRailTab(workspaceStateKey, null);
         }
       }
     },
-    [onRequestClose, scrollToHunk, workspacePath]
+    [onRequestClose, scrollToHunk, workspaceStateKey]
   );
 
   useEffect(() => {

--- a/frontend/src/components/WorkspaceUtilityRail.css
+++ b/frontend/src/components/WorkspaceUtilityRail.css
@@ -27,8 +27,30 @@
   font-size: var(--font-size-xs, 0.75rem);
 }
 
+.utility-pane-context {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding: 0 8px;
+  overflow: hidden;
+  border-bottom: 1px solid var(--border, #333);
+  white-space: nowrap;
+}
+
+.utility-pane-context span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.utility-repo-badge {
+  flex: none;
+  color: var(--accent, #d97757);
+}
+
 .utility-pane-body {
-  height: 100%;
+  height: calc(100% - 28px);
   min-height: 0;
   min-width: 0;
   overflow: hidden;

--- a/frontend/src/components/WorkspaceUtilityRail.tsx
+++ b/frontend/src/components/WorkspaceUtilityRail.tsx
@@ -7,6 +7,10 @@ import {
   UTILITY_ICON_RAIL_WIDTH,
 } from '../lib/stores/ui.js';
 import type { FileTreeHandle } from './FileTree/index.js';
+import type {
+  UtilityRailDisabledReason,
+  UtilityRailResourceContext,
+} from '../lib/utility-rail-context.js';
 import UtilityRailFilesPanel from './UtilityRailFilesPanel.js';
 import UtilityRailGitChangesPanel from './UtilityRailGitChangesPanel.js';
 import UtilityRailBranchPanel from './UtilityRailBranchPanel.js';
@@ -109,7 +113,13 @@ const TAB_META: Array<{
 ];
 
 export interface WorkspaceUtilityRailProps {
+  /** Key used for persisted rail UI state. */
   workspacePath: string;
+  /**
+   * Paths/capabilities used by resource-fetching panels. Defaults to
+   * workspacePath for local legacy behavior.
+   */
+  resourceContext?: UtilityRailResourceContext;
   railState: WorkspaceUtilityRailState;
   activeSession?: SessionSummary | undefined;
   workspaceSessions: SessionSummary[];
@@ -122,6 +132,54 @@ export interface WorkspaceUtilityRailProps {
   onImageUpload?: (text: string, showInsert: boolean, path?: string) => void;
   onCopyModeChange?: (active: boolean) => void;
   onFilePathClick?: (path: string) => void;
+}
+
+interface UtilityRailDisabledStateProps {
+  reason: UtilityRailDisabledReason;
+  displayWorkspacePath: string;
+}
+
+function disabledStateCopy(
+  reason: UtilityRailDisabledReason
+): { title: string; detail: string } {
+  switch (reason) {
+    case 'remote-files-unavailable':
+      return {
+        title: 'remote files unavailable',
+        detail: 'remote file browsing is disabled until remote file rpc lands.',
+      };
+    case 'remote-git-unavailable':
+      return {
+        title: 'remote git unavailable',
+        detail: 'git panels are disabled for remote tabs until remote file rpc lands.',
+      };
+    case 'no-git-context':
+      return {
+        title: 'no git context',
+        detail: 'git panels are available on repo and worktree tabs.',
+      };
+    case 'no-workspace-context':
+      return {
+        title: 'no workspace context',
+        detail: 'select a repo, worktree, or local folder tab first.',
+      };
+  }
+}
+
+function UtilityRailDisabledState({
+  reason,
+  displayWorkspacePath,
+}: UtilityRailDisabledStateProps) {
+  const copy = disabledStateCopy(reason);
+  return (
+    <div className="utility-empty" role="status">
+      <p>{copy.title}</p>
+      <span className="utility-muted">{copy.detail}</span>
+      {displayWorkspacePath ? (
+        <span className="utility-muted">{displayWorkspacePath}</span>
+      ) : null}
+    </div>
+  );
 }
 
 interface UtilityRailTerminalPanelProps {
@@ -293,6 +351,7 @@ export function utilityRailRenderedWidth(
 
 export function WorkspaceUtilityRail({
   workspacePath,
+  resourceContext,
   railState,
   activeSession,
   workspaceSessions,
@@ -312,6 +371,70 @@ export function WorkspaceUtilityRail({
   const openUtilityRailTab = useUiStore((s) => s.openUtilityRailTab);
   const fullPageDiff = useUiStore((s) => s.fullPageDiff);
   const selectedTab = railState.selectedRailTab;
+  const displayWorkspacePath =
+    resourceContext?.displayWorkspacePath ?? workspacePath;
+  const anchorLabel = resourceContext?.anchorLabel ?? displayWorkspacePath;
+  const fileWorkspacePath = resourceContext?.files.workspacePath ?? workspacePath;
+  const fileDisabledReason = resourceContext?.files.disabledReason ?? null;
+  const gitWorkspacePath = resourceContext?.git.workspacePath ?? workspacePath;
+  const gitDisabledReason = resourceContext?.git.disabledReason ?? null;
+  const repoBadge =
+    resourceContext?.repoBadge ?? (gitWorkspacePath ? 'repo' : null);
+
+  const renderFilesPanel = () => {
+    if (fileDisabledReason) {
+      return (
+        <UtilityRailDisabledState
+          reason={fileDisabledReason}
+          displayWorkspacePath={displayWorkspacePath}
+        />
+      );
+    }
+    return (
+      <UtilityRailFilesPanel
+        workspacePath={fileWorkspacePath}
+        stateKey={workspacePath}
+        {...(fileTreeSidebarRef ? { fileTreeSidebarRef } : {})}
+      />
+    );
+  };
+
+  const renderGitPanel = (
+    panel: 'changes' | 'branch' | 'review'
+  ): React.ReactNode => {
+    if (gitDisabledReason) {
+      return (
+        <UtilityRailDisabledState
+          reason={gitDisabledReason}
+          displayWorkspacePath={displayWorkspacePath}
+        />
+      );
+    }
+    if (panel === 'changes') {
+      return (
+        <UtilityRailGitChangesPanel
+          workspacePath={gitWorkspacePath}
+          stateKey={workspacePath}
+        />
+      );
+    }
+    if (panel === 'branch') {
+      return (
+        <UtilityRailBranchPanel
+          workspacePath={gitWorkspacePath}
+          stateKey={workspacePath}
+        />
+      );
+    }
+    return (
+      <UtilityRailReviewPanel
+        workspacePath={gitWorkspacePath}
+        stateKey={workspacePath}
+        reviewState={railState.review}
+        active={selectedTab === 'review' && !fullPageDiff}
+      />
+    );
+  };
 
   const handleTabClick = useCallback(
     (tab: UtilityRailTab) => {
@@ -361,6 +484,12 @@ export function WorkspaceUtilityRail({
         .join(' ')}
     >
       <div className="utility-selected-pane">
+        <div className="utility-pane-context" title={displayWorkspacePath}>
+          <span>{anchorLabel}</span>
+          {repoBadge ? (
+            <span className="utility-repo-badge">[{repoBadge}]</span>
+          ) : null}
+        </div>
         <div className="utility-pane-body">
           <div
             id="utility-rail-panel-files"
@@ -370,10 +499,7 @@ export function WorkspaceUtilityRail({
             tabIndex={selectedTab === 'files' ? 0 : -1}
             hidden={selectedTab !== 'files'}
           >
-            <UtilityRailFilesPanel
-              workspacePath={workspacePath}
-              {...(fileTreeSidebarRef ? { fileTreeSidebarRef } : {})}
-            />
+            {renderFilesPanel()}
           </div>
           <div
             id="utility-rail-panel-changes"
@@ -383,7 +509,7 @@ export function WorkspaceUtilityRail({
             tabIndex={selectedTab === 'changes' ? 0 : -1}
             hidden={selectedTab !== 'changes'}
           >
-            <UtilityRailGitChangesPanel workspacePath={workspacePath} />
+            {renderGitPanel('changes')}
           </div>
           <div
             id="utility-rail-panel-branch"
@@ -393,7 +519,7 @@ export function WorkspaceUtilityRail({
             tabIndex={selectedTab === 'branch' ? 0 : -1}
             hidden={selectedTab !== 'branch'}
           >
-            <UtilityRailBranchPanel workspacePath={workspacePath} />
+            {renderGitPanel('branch')}
           </div>
           <div
             id="utility-rail-panel-review"
@@ -403,11 +529,7 @@ export function WorkspaceUtilityRail({
             tabIndex={selectedTab === 'review' ? 0 : -1}
             hidden={selectedTab !== 'review'}
           >
-            <UtilityRailReviewPanel
-              workspacePath={workspacePath}
-              reviewState={railState.review}
-              active={selectedTab === 'review' && !fullPageDiff}
-            />
+            {renderGitPanel('review')}
           </div>
           <div
             id="utility-rail-panel-logs"

--- a/frontend/src/components/WorkspaceUtilityRail.tsx
+++ b/frontend/src/components/WorkspaceUtilityRail.tsx
@@ -353,17 +353,21 @@ export function utilityRailRenderedWidth(
 
 interface UtilityRailFilesPaneContentProps {
   workspacePath: string;
+  gitWorkspacePath: string;
   stateKey: string;
   displayWorkspacePath: string;
   disabledReason: UtilityRailDisabledReason | null;
-  fileTreeSidebarRef?: React.RefObject<FileTreeHandle | null> | undefined;
+  gitDisabledReason: UtilityRailDisabledReason | null;
+  fileTreeSidebarRef: React.RefObject<FileTreeHandle | null> | undefined;
 }
 
 function UtilityRailFilesPaneContent({
   workspacePath,
+  gitWorkspacePath,
   stateKey,
   displayWorkspacePath,
   disabledReason,
+  gitDisabledReason,
   fileTreeSidebarRef,
 }: UtilityRailFilesPaneContentProps) {
   if (disabledReason) {
@@ -378,6 +382,8 @@ function UtilityRailFilesPaneContent({
   return (
     <UtilityRailFilesPanel
       workspacePath={workspacePath}
+      gitWorkspacePath={gitWorkspacePath}
+      gitDisabledReason={gitDisabledReason}
       stateKey={stateKey}
       {...(fileTreeSidebarRef ? { fileTreeSidebarRef } : {})}
     />
@@ -491,9 +497,11 @@ function UtilityRailPaneBody({
       content: (
         <UtilityRailFilesPaneContent
           workspacePath={fileWorkspacePath}
+          gitWorkspacePath={gitWorkspacePath}
           stateKey={workspacePath}
           displayWorkspacePath={displayWorkspacePath}
           disabledReason={fileDisabledReason}
+          gitDisabledReason={gitDisabledReason}
           fileTreeSidebarRef={fileTreeSidebarRef}
         />
       ),

--- a/frontend/src/components/WorkspaceUtilityRail.tsx
+++ b/frontend/src/components/WorkspaceUtilityRail.tsx
@@ -124,7 +124,7 @@ export interface WorkspaceUtilityRailProps {
   activeSession?: SessionSummary | undefined;
   workspaceSessions: SessionSummary[];
   utilityTerminalSessions?: SessionSummary[];
-  fileTreeSidebarRef?: React.RefObject<FileTreeHandle | null>;
+  fileTreeSidebarRef?: React.RefObject<FileTreeHandle | null> | undefined;
   onCreateUtilityTerminal?: () => void | Promise<void>;
   onSelectUtilityTerminal?: (sessionId: string) => void;
   onCloseUtilityTerminal?: (sessionId: string) => void | Promise<void>;
@@ -186,13 +186,15 @@ interface UtilityRailTerminalPanelProps {
   workspacePath: string;
   railState: WorkspaceUtilityRailState;
   sessions: SessionSummary[];
-  onCreateUtilityTerminal?: () => void | Promise<void>;
-  onSelectUtilityTerminal?: (sessionId: string) => void;
-  onCloseUtilityTerminal?: (sessionId: string) => void | Promise<void>;
-  onPromoteUtilityTerminal?: (sessionId: string) => void;
-  onImageUpload?: (text: string, showInsert: boolean, path?: string) => void;
-  onCopyModeChange?: (active: boolean) => void;
-  onFilePathClick?: (path: string) => void;
+  onCreateUtilityTerminal?: (() => void | Promise<void>) | undefined;
+  onSelectUtilityTerminal?: ((sessionId: string) => void) | undefined;
+  onCloseUtilityTerminal?: ((sessionId: string) => void | Promise<void>) | undefined;
+  onPromoteUtilityTerminal?: ((sessionId: string) => void) | undefined;
+  onImageUpload?:
+    | ((text: string, showInsert: boolean, path?: string) => void)
+    | undefined;
+  onCopyModeChange?: ((active: boolean) => void) | undefined;
+  onFilePathClick?: ((path: string) => void) | undefined;
 }
 
 function UtilityRailTerminalPanel({
@@ -349,6 +351,247 @@ export function utilityRailRenderedWidth(
   return UTILITY_ICON_RAIL_WIDTH + (state.selectedRailTab ? state.width : 0);
 }
 
+interface UtilityRailFilesPaneContentProps {
+  workspacePath: string;
+  stateKey: string;
+  displayWorkspacePath: string;
+  disabledReason: UtilityRailDisabledReason | null;
+  fileTreeSidebarRef?: React.RefObject<FileTreeHandle | null> | undefined;
+}
+
+function UtilityRailFilesPaneContent({
+  workspacePath,
+  stateKey,
+  displayWorkspacePath,
+  disabledReason,
+  fileTreeSidebarRef,
+}: UtilityRailFilesPaneContentProps) {
+  if (disabledReason) {
+    return (
+      <UtilityRailDisabledState
+        reason={disabledReason}
+        displayWorkspacePath={displayWorkspacePath}
+      />
+    );
+  }
+
+  return (
+    <UtilityRailFilesPanel
+      workspacePath={workspacePath}
+      stateKey={stateKey}
+      {...(fileTreeSidebarRef ? { fileTreeSidebarRef } : {})}
+    />
+  );
+}
+
+interface UtilityRailGitPaneContentProps {
+  panel: 'changes' | 'branch' | 'review';
+  workspacePath: string;
+  stateKey: string;
+  displayWorkspacePath: string;
+  disabledReason: UtilityRailDisabledReason | null;
+  reviewState: WorkspaceUtilityRailState['review'];
+  active: boolean;
+}
+
+function UtilityRailGitPaneContent({
+  panel,
+  workspacePath,
+  stateKey,
+  displayWorkspacePath,
+  disabledReason,
+  reviewState,
+  active,
+}: UtilityRailGitPaneContentProps): React.ReactNode {
+  if (disabledReason) {
+    return (
+      <UtilityRailDisabledState
+        reason={disabledReason}
+        displayWorkspacePath={displayWorkspacePath}
+      />
+    );
+  }
+
+  switch (panel) {
+    case 'changes':
+      return (
+        <UtilityRailGitChangesPanel
+          workspacePath={workspacePath}
+          stateKey={stateKey}
+        />
+      );
+    case 'branch':
+      return (
+        <UtilityRailBranchPanel workspacePath={workspacePath} stateKey={stateKey} />
+      );
+    case 'review':
+      return (
+        <UtilityRailReviewPanel
+          workspacePath={workspacePath}
+          stateKey={stateKey}
+          reviewState={reviewState}
+          active={active}
+        />
+      );
+  }
+}
+
+interface UtilityRailPaneBodyProps {
+  selectedTab: UtilityRailTab | null;
+  workspacePath: string;
+  fileWorkspacePath: string;
+  gitWorkspacePath: string;
+  displayWorkspacePath: string;
+  fileDisabledReason: UtilityRailDisabledReason | null;
+  gitDisabledReason: UtilityRailDisabledReason | null;
+  railState: WorkspaceUtilityRailState;
+  activeSession: SessionSummary | undefined;
+  workspaceSessions: SessionSummary[];
+  utilityTerminalSessions: SessionSummary[];
+  fullPageDiff: boolean;
+  fileTreeSidebarRef: React.RefObject<FileTreeHandle | null> | undefined;
+  onCreateUtilityTerminal: (() => void | Promise<void>) | undefined;
+  onSelectUtilityTerminal: ((sessionId: string) => void) | undefined;
+  onCloseUtilityTerminal:
+    | ((sessionId: string) => void | Promise<void>)
+    | undefined;
+  onPromoteUtilityTerminal: ((sessionId: string) => void) | undefined;
+  onImageUpload:
+    | ((text: string, showInsert: boolean, path?: string) => void)
+    | undefined;
+  onCopyModeChange: ((active: boolean) => void) | undefined;
+  onFilePathClick: ((path: string) => void) | undefined;
+}
+
+function UtilityRailPaneBody({
+  selectedTab,
+  workspacePath,
+  fileWorkspacePath,
+  gitWorkspacePath,
+  displayWorkspacePath,
+  fileDisabledReason,
+  gitDisabledReason,
+  railState,
+  activeSession,
+  workspaceSessions,
+  utilityTerminalSessions,
+  fullPageDiff,
+  fileTreeSidebarRef,
+  onCreateUtilityTerminal,
+  onSelectUtilityTerminal,
+  onCloseUtilityTerminal,
+  onPromoteUtilityTerminal,
+  onImageUpload,
+  onCopyModeChange,
+  onFilePathClick,
+}: UtilityRailPaneBodyProps) {
+  const panels: Array<{ id: UtilityRailTab; content: React.ReactNode }> = [
+    {
+      id: 'files',
+      content: (
+        <UtilityRailFilesPaneContent
+          workspacePath={fileWorkspacePath}
+          stateKey={workspacePath}
+          displayWorkspacePath={displayWorkspacePath}
+          disabledReason={fileDisabledReason}
+          fileTreeSidebarRef={fileTreeSidebarRef}
+        />
+      ),
+    },
+    {
+      id: 'changes',
+      content: (
+        <UtilityRailGitPaneContent
+          panel="changes"
+          workspacePath={gitWorkspacePath}
+          stateKey={workspacePath}
+          displayWorkspacePath={displayWorkspacePath}
+          disabledReason={gitDisabledReason}
+          reviewState={railState.review}
+          active={selectedTab === 'review' && !fullPageDiff}
+        />
+      ),
+    },
+    {
+      id: 'branch',
+      content: (
+        <UtilityRailGitPaneContent
+          panel="branch"
+          workspacePath={gitWorkspacePath}
+          stateKey={workspacePath}
+          displayWorkspacePath={displayWorkspacePath}
+          disabledReason={gitDisabledReason}
+          reviewState={railState.review}
+          active={selectedTab === 'review' && !fullPageDiff}
+        />
+      ),
+    },
+    {
+      id: 'review',
+      content: (
+        <UtilityRailGitPaneContent
+          panel="review"
+          workspacePath={gitWorkspacePath}
+          stateKey={workspacePath}
+          displayWorkspacePath={displayWorkspacePath}
+          disabledReason={gitDisabledReason}
+          reviewState={railState.review}
+          active={selectedTab === 'review' && !fullPageDiff}
+        />
+      ),
+    },
+    {
+      id: 'logs',
+      content: <UtilityRailLogsPanel activeSession={activeSession} />,
+    },
+    {
+      id: 'stats',
+      content: (
+        <UtilityRailStatsPanel
+          activeSession={activeSession}
+          workspaceSessions={workspaceSessions}
+        />
+      ),
+    },
+    {
+      id: 'terminal',
+      content:
+        selectedTab === 'terminal' ? (
+          <UtilityRailTerminalPanel
+            workspacePath={workspacePath}
+            railState={railState}
+            sessions={utilityTerminalSessions}
+            onCreateUtilityTerminal={onCreateUtilityTerminal}
+            onSelectUtilityTerminal={onSelectUtilityTerminal}
+            onCloseUtilityTerminal={onCloseUtilityTerminal}
+            onPromoteUtilityTerminal={onPromoteUtilityTerminal}
+            onImageUpload={onImageUpload}
+            onCopyModeChange={onCopyModeChange}
+            onFilePathClick={onFilePathClick}
+          />
+        ) : null,
+    },
+  ];
+
+  return (
+    <div className="utility-pane-body">
+      {panels.map((panel) => (
+        <div
+          key={panel.id}
+          id={`utility-rail-panel-${panel.id}`}
+          className="utility-pane-panel"
+          role="tabpanel"
+          aria-labelledby={`utility-rail-tab-${panel.id}`}
+          tabIndex={selectedTab === panel.id ? 0 : -1}
+          hidden={selectedTab !== panel.id}
+        >
+          {panel.content}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function WorkspaceUtilityRail({
   workspacePath,
   resourceContext,
@@ -380,61 +623,6 @@ export function WorkspaceUtilityRail({
   const gitDisabledReason = resourceContext?.git.disabledReason ?? null;
   const repoBadge =
     resourceContext?.repoBadge ?? (gitWorkspacePath ? 'repo' : null);
-
-  const renderFilesPanel = () => {
-    if (fileDisabledReason) {
-      return (
-        <UtilityRailDisabledState
-          reason={fileDisabledReason}
-          displayWorkspacePath={displayWorkspacePath}
-        />
-      );
-    }
-    return (
-      <UtilityRailFilesPanel
-        workspacePath={fileWorkspacePath}
-        stateKey={workspacePath}
-        {...(fileTreeSidebarRef ? { fileTreeSidebarRef } : {})}
-      />
-    );
-  };
-
-  const renderGitPanel = (
-    panel: 'changes' | 'branch' | 'review'
-  ): React.ReactNode => {
-    if (gitDisabledReason) {
-      return (
-        <UtilityRailDisabledState
-          reason={gitDisabledReason}
-          displayWorkspacePath={displayWorkspacePath}
-        />
-      );
-    }
-    if (panel === 'changes') {
-      return (
-        <UtilityRailGitChangesPanel
-          workspacePath={gitWorkspacePath}
-          stateKey={workspacePath}
-        />
-      );
-    }
-    if (panel === 'branch') {
-      return (
-        <UtilityRailBranchPanel
-          workspacePath={gitWorkspacePath}
-          stateKey={workspacePath}
-        />
-      );
-    }
-    return (
-      <UtilityRailReviewPanel
-        workspacePath={gitWorkspacePath}
-        stateKey={workspacePath}
-        reviewState={railState.review}
-        active={selectedTab === 'review' && !fullPageDiff}
-      />
-    );
-  };
 
   const handleTabClick = useCallback(
     (tab: UtilityRailTab) => {
@@ -490,100 +678,28 @@ export function WorkspaceUtilityRail({
             <span className="utility-repo-badge">[{repoBadge}]</span>
           ) : null}
         </div>
-        <div className="utility-pane-body">
-          <div
-            id="utility-rail-panel-files"
-            className="utility-pane-panel"
-            role="tabpanel"
-            aria-labelledby="utility-rail-tab-files"
-            tabIndex={selectedTab === 'files' ? 0 : -1}
-            hidden={selectedTab !== 'files'}
-          >
-            {renderFilesPanel()}
-          </div>
-          <div
-            id="utility-rail-panel-changes"
-            className="utility-pane-panel"
-            role="tabpanel"
-            aria-labelledby="utility-rail-tab-changes"
-            tabIndex={selectedTab === 'changes' ? 0 : -1}
-            hidden={selectedTab !== 'changes'}
-          >
-            {renderGitPanel('changes')}
-          </div>
-          <div
-            id="utility-rail-panel-branch"
-            className="utility-pane-panel"
-            role="tabpanel"
-            aria-labelledby="utility-rail-tab-branch"
-            tabIndex={selectedTab === 'branch' ? 0 : -1}
-            hidden={selectedTab !== 'branch'}
-          >
-            {renderGitPanel('branch')}
-          </div>
-          <div
-            id="utility-rail-panel-review"
-            className="utility-pane-panel"
-            role="tabpanel"
-            aria-labelledby="utility-rail-tab-review"
-            tabIndex={selectedTab === 'review' ? 0 : -1}
-            hidden={selectedTab !== 'review'}
-          >
-            {renderGitPanel('review')}
-          </div>
-          <div
-            id="utility-rail-panel-logs"
-            className="utility-pane-panel"
-            role="tabpanel"
-            aria-labelledby="utility-rail-tab-logs"
-            tabIndex={selectedTab === 'logs' ? 0 : -1}
-            hidden={selectedTab !== 'logs'}
-          >
-            <UtilityRailLogsPanel activeSession={activeSession} />
-          </div>
-          <div
-            id="utility-rail-panel-stats"
-            className="utility-pane-panel"
-            role="tabpanel"
-            aria-labelledby="utility-rail-tab-stats"
-            tabIndex={selectedTab === 'stats' ? 0 : -1}
-            hidden={selectedTab !== 'stats'}
-          >
-            <UtilityRailStatsPanel
-              activeSession={activeSession}
-              workspaceSessions={workspaceSessions}
-            />
-          </div>
-          <div
-            id="utility-rail-panel-terminal"
-            className="utility-pane-panel"
-            role="tabpanel"
-            aria-labelledby="utility-rail-tab-terminal"
-            tabIndex={selectedTab === 'terminal' ? 0 : -1}
-            hidden={selectedTab !== 'terminal'}
-          >
-            {selectedTab === 'terminal' && (
-              <UtilityRailTerminalPanel
-                workspacePath={workspacePath}
-                railState={railState}
-                sessions={utilityTerminalSessions}
-                {...(onCreateUtilityTerminal
-                  ? { onCreateUtilityTerminal }
-                  : {})}
-                {...(onSelectUtilityTerminal
-                  ? { onSelectUtilityTerminal }
-                  : {})}
-                {...(onCloseUtilityTerminal ? { onCloseUtilityTerminal } : {})}
-                {...(onPromoteUtilityTerminal
-                  ? { onPromoteUtilityTerminal }
-                  : {})}
-                {...(onImageUpload ? { onImageUpload } : {})}
-                {...(onCopyModeChange ? { onCopyModeChange } : {})}
-                {...(onFilePathClick ? { onFilePathClick } : {})}
-              />
-            )}
-          </div>
-        </div>
+        <UtilityRailPaneBody
+          selectedTab={selectedTab}
+          workspacePath={workspacePath}
+          fileWorkspacePath={fileWorkspacePath}
+          gitWorkspacePath={gitWorkspacePath}
+          displayWorkspacePath={displayWorkspacePath}
+          fileDisabledReason={fileDisabledReason}
+          gitDisabledReason={gitDisabledReason}
+          railState={railState}
+          activeSession={activeSession}
+          workspaceSessions={workspaceSessions}
+          utilityTerminalSessions={utilityTerminalSessions}
+          fullPageDiff={fullPageDiff !== null}
+          fileTreeSidebarRef={fileTreeSidebarRef}
+          onCreateUtilityTerminal={onCreateUtilityTerminal}
+          onSelectUtilityTerminal={onSelectUtilityTerminal}
+          onCloseUtilityTerminal={onCloseUtilityTerminal}
+          onPromoteUtilityTerminal={onPromoteUtilityTerminal}
+          onImageUpload={onImageUpload}
+          onCopyModeChange={onCopyModeChange}
+          onFilePathClick={onFilePathClick}
+        />
       </div>
       <div
         className="utility-icon-rail"

--- a/frontend/src/lib/utility-rail-context.ts
+++ b/frontend/src/lib/utility-rail-context.ts
@@ -1,0 +1,124 @@
+import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
+import type { Repo, SessionSummary } from './types.js';
+
+export type UtilityRailDisabledReason =
+  | 'remote-files-unavailable'
+  | 'remote-git-unavailable'
+  | 'no-git-context'
+  | 'no-workspace-context';
+
+export interface UtilityRailResourcePath {
+  workspacePath: string;
+  disabledReason: UtilityRailDisabledReason | null;
+}
+
+export interface UtilityRailResourceContext {
+  displayWorkspacePath: string;
+  anchorLabel: string;
+  repoBadge: string | null;
+  files: UtilityRailResourcePath;
+  git: UtilityRailResourcePath;
+}
+
+export interface DerivedUtilityRailContext extends UtilityRailResourceContext {
+  stateKey: string;
+}
+
+export interface DeriveUtilityRailContextOptions {
+  activeRepoPath?: string | null | undefined;
+  activeWorkspace?: Repo | undefined;
+  activeSession?: SessionSummary | undefined;
+}
+
+function isRemoteNode(nodeId: string | undefined): boolean {
+  return Boolean(nodeId && nodeId !== DEFAULT_LOCAL_NODE_ID);
+}
+
+function remoteStateKey(nodeId: string, workspacePath: string): string {
+  return `node:${nodeId}:${workspacePath}`;
+}
+
+function deriveActivePath({
+  activeRepoPath,
+  activeWorkspace,
+  activeSession,
+}: DeriveUtilityRailContextOptions): string {
+  return (
+    activeSession?.worktreePath ??
+    activeSession?.repoPath ??
+    activeSession?.cwd ??
+    activeWorkspace?.path ??
+    activeRepoPath ??
+    ''
+  );
+}
+
+function hasRepoBoundSession(activeSession: SessionSummary | undefined): boolean {
+  return Boolean(activeSession?.worktreePath || activeSession?.repoPath);
+}
+
+function hasGitContext(
+  activeSession: SessionSummary | undefined,
+  activeWorkspace: Repo | undefined
+): boolean {
+  if (activeSession) {
+    if (!hasRepoBoundSession(activeSession)) return false;
+    return activeWorkspace?.isGitRepo !== false;
+  }
+  return Boolean(activeWorkspace?.isGitRepo);
+}
+
+function formatAnchorLabel(nodeLabel: string, workspacePath: string): string {
+  return workspacePath ? `${nodeLabel} · ${workspacePath}` : nodeLabel;
+}
+
+export function deriveUtilityRailContext(
+  options: DeriveUtilityRailContextOptions
+): DerivedUtilityRailContext {
+  const { activeSession, activeWorkspace } = options;
+  const displayWorkspacePath = deriveActivePath(options);
+  const nodeId = activeSession?.nodeId ?? activeWorkspace?.nodeId;
+  const remote = isRemoteNode(nodeId);
+  const nodeLabel = remote ? (nodeId as string) : 'local';
+  const stateKey = remote
+    ? remoteStateKey(nodeId as string, displayWorkspacePath)
+    : displayWorkspacePath;
+
+  if (!displayWorkspacePath) {
+    return {
+      stateKey,
+      displayWorkspacePath,
+      anchorLabel: formatAnchorLabel(nodeLabel, displayWorkspacePath),
+      repoBadge: null,
+      files: { workspacePath: '', disabledReason: 'no-workspace-context' },
+      git: { workspacePath: '', disabledReason: 'no-workspace-context' },
+    };
+  }
+
+  if (remote) {
+    return {
+      stateKey,
+      displayWorkspacePath,
+      anchorLabel: formatAnchorLabel(nodeLabel, displayWorkspacePath),
+      repoBadge: null,
+      files: { workspacePath: '', disabledReason: 'remote-files-unavailable' },
+      git: { workspacePath: '', disabledReason: 'remote-git-unavailable' },
+    };
+  }
+
+  const gitWorkspacePath = hasGitContext(activeSession, activeWorkspace)
+    ? displayWorkspacePath
+    : '';
+
+  return {
+    stateKey,
+    displayWorkspacePath,
+    anchorLabel: formatAnchorLabel(nodeLabel, displayWorkspacePath),
+    repoBadge: gitWorkspacePath ? 'repo' : null,
+    files: { workspacePath: displayWorkspacePath, disabledReason: null },
+    git: {
+      workspacePath: gitWorkspacePath,
+      disabledReason: gitWorkspacePath ? null : 'no-git-context',
+    },
+  };
+}

--- a/test/components/FileTree.test.ts
+++ b/test/components/FileTree.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flush() {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+const mocks = vi.hoisted(() => ({
+  browseFsDirectory: vi.fn(async (workspacePath: string) => ({
+    resolved: workspacePath,
+    entries: [],
+    truncated: false,
+    total: 0,
+  })),
+  fetchChangedFiles: vi.fn(async () => ({
+    files: [],
+    aggregate: { additions: 0, deletions: 0, fileCount: 0 },
+  })),
+  fetchDefaultBranch: vi.fn(async () => 'nightly'),
+}));
+
+vi.mock('../../frontend/src/lib/api.js', () => ({
+  browseFsDirectory: mocks.browseFsDirectory,
+  fetchChangedFiles: mocks.fetchChangedFiles,
+  fetchDefaultBranch: mocks.fetchDefaultBranch,
+}));
+
+import { FileTree } from '../../frontend/src/components/FileTree/index.js';
+import {
+  clearUtilityRailStateCacheForTesting,
+  useUiStore,
+} from '../../frontend/src/lib/stores/ui.js';
+
+function resetUiStore() {
+  clearUtilityRailStateCacheForTesting();
+  useUiStore.setState({
+    rightSidebarTab: 'changes',
+    fileDiffSource: 'working',
+    fileDiffDefaultBranch: 'main',
+    utilityRailByWorkspace: {},
+    openFileTabs: [],
+    activeFileTabKey: null,
+  });
+}
+
+describe('FileTree git fetch guards', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetUiStore();
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    queryClient.clear();
+  });
+
+  async function renderTree(props: React.ComponentProps<typeof FileTree>) {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(FileTree, props)
+        )
+      );
+    });
+
+    await act(async () => {
+      await flush();
+      await flush();
+    });
+  }
+
+  it('does not issue git-dependent requests for free local folders', async () => {
+    await renderTree({
+      workspacePath: '/tmp/free-folder',
+      gitWorkspacePath: '',
+      gitDisabledReason: 'no-git-context',
+    });
+
+    expect(mocks.fetchDefaultBranch).not.toHaveBeenCalled();
+    expect(mocks.fetchChangedFiles).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('no changes');
+    expect(container.textContent).not.toContain('HTTP 403');
+  });
+
+  it('uses the dedicated git workspace path for changed-files requests', async () => {
+    await renderTree({
+      workspacePath: '/tmp/free-folder',
+      gitWorkspacePath: '/repo/a',
+      gitDisabledReason: null,
+    });
+
+    expect(mocks.fetchDefaultBranch).toHaveBeenCalledWith('/repo/a');
+    expect(mocks.fetchChangedFiles).toHaveBeenCalledWith('/repo/a', '');
+  });
+});

--- a/test/utility-rail-context.test.ts
+++ b/test/utility-rail-context.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { deriveUtilityRailContext } from '../frontend/src/lib/utility-rail-context.js';
+import type { Repo, SessionSummary } from '../frontend/src/lib/types.js';
+
+function repo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    path: '/hub/repo',
+    name: 'repo',
+    isGitRepo: true,
+    defaultBranch: 'nightly',
+    currentBranch: 'feature',
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 's1',
+    type: 'agent',
+    agent: 'claude',
+    repoName: 'repo',
+    repoPath: '/hub/repo',
+    worktreePath: null,
+    cwd: '/hub/repo',
+    branchName: 'feature',
+    displayName: 'repo',
+    createdAt: '2026-05-14T00:00:00.000Z',
+    lastActivity: '2026-05-14T00:00:00.000Z',
+    idle: false,
+    ...overrides,
+  };
+}
+
+describe('deriveUtilityRailContext', () => {
+  it('keeps local repo/worktree tabs keyed and fetched by their active cwd', () => {
+    const context = deriveUtilityRailContext({
+      activeRepoPath: '/hub/repo',
+      activeWorkspace: repo(),
+      activeSession: session({ worktreePath: '/hub/repo/.worktrees/feature', cwd: '/hub/repo/.worktrees/feature' }),
+    });
+
+    expect(context.stateKey).toBe('/hub/repo/.worktrees/feature');
+    expect(context.displayWorkspacePath).toBe('/hub/repo/.worktrees/feature');
+    expect(context.files.workspacePath).toBe('/hub/repo/.worktrees/feature');
+    expect(context.git.workspacePath).toBe('/hub/repo/.worktrees/feature');
+    expect(context.files.disabledReason).toBeNull();
+    expect(context.git.disabledReason).toBeNull();
+  });
+
+  it('does not expose hub-local repo paths to file or git widgets for a remote active tab', () => {
+    const context = deriveUtilityRailContext({
+      activeRepoPath: '/hub/repo',
+      activeWorkspace: repo(),
+      activeSession: session({
+        id: 'remote-1',
+        nodeId: 'linux-box',
+        repoPath: undefined,
+        worktreePath: null,
+        cwd: '/home/me/repo',
+      }),
+    });
+
+    expect(context.stateKey).toBe('node:linux-box:/home/me/repo');
+    expect(context.displayWorkspacePath).toBe('/home/me/repo');
+    expect(context.files.workspacePath).toBe('');
+    expect(context.git.workspacePath).toBe('');
+    expect(context.files.disabledReason).toBe('remote-files-unavailable');
+    expect(context.git.disabledReason).toBe('remote-git-unavailable');
+  });
+
+  it('distinguishes the same remote cwd on different nodes', () => {
+    const a = deriveUtilityRailContext({
+      activeRepoPath: '/hub/repo',
+      activeWorkspace: repo(),
+      activeSession: session({ nodeId: 'node-a', repoPath: undefined, cwd: '/src/repo' }),
+    });
+    const b = deriveUtilityRailContext({
+      activeRepoPath: '/hub/repo',
+      activeWorkspace: repo(),
+      activeSession: session({ nodeId: 'node-b', repoPath: undefined, cwd: '/src/repo' }),
+    });
+
+    expect(a.stateKey).toBe('node:node-a:/src/repo');
+    expect(b.stateKey).toBe('node:node-b:/src/repo');
+    expect(a.stateKey).not.toBe(b.stateKey);
+  });
+
+  it('uses the free local cwd for files but disables git widgets without errors', () => {
+    const context = deriveUtilityRailContext({
+      activeRepoPath: '/hub/repo',
+      activeWorkspace: repo(),
+      activeSession: session({
+        id: 'free-1',
+        repoPath: undefined,
+        worktreePath: null,
+        cwd: '/tmp/free-folder',
+        branchName: undefined,
+      }),
+    });
+
+    expect(context.stateKey).toBe('/tmp/free-folder');
+    expect(context.displayWorkspacePath).toBe('/tmp/free-folder');
+    expect(context.files.workspacePath).toBe('/tmp/free-folder');
+    expect(context.files.disabledReason).toBeNull();
+    expect(context.git.workspacePath).toBe('');
+    expect(context.git.disabledReason).toBe('no-git-context');
+  });
+
+  it('treats selected non-git repos as file-browsable but not git-capable', () => {
+    const context = deriveUtilityRailContext({
+      activeRepoPath: '/folders/plain',
+      activeWorkspace: repo({ path: '/folders/plain', isGitRepo: false, currentBranch: null, defaultBranch: null }),
+      activeSession: undefined,
+    });
+
+    expect(context.stateKey).toBe('/folders/plain');
+    expect(context.files.workspacePath).toBe('/folders/plain');
+    expect(context.git.workspacePath).toBe('');
+    expect(context.git.disabledReason).toBe('no-git-context');
+  });
+});

--- a/test/workspace-utility-rail-context.test.ts
+++ b/test/workspace-utility-rail-context.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionSummary } from '../frontend/src/lib/types.js';
+import type { WorkspaceUtilityRailState } from '../frontend/src/lib/stores/ui.js';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('../frontend/src/components/UtilityRailFilesPanel.js', () => ({
+  default: ({ workspacePath, stateKey }: { workspacePath: string; stateKey?: string }) =>
+    React.createElement('div', {
+      'data-testid': 'files-panel',
+      'data-workspace-path': workspacePath,
+      'data-state-key': stateKey ?? '',
+    }),
+}));
+vi.mock('../frontend/src/components/UtilityRailGitChangesPanel.js', () => ({
+  default: ({ workspacePath, stateKey }: { workspacePath: string; stateKey?: string }) =>
+    React.createElement('div', {
+      'data-testid': 'changes-panel',
+      'data-workspace-path': workspacePath,
+      'data-state-key': stateKey ?? '',
+    }),
+}));
+vi.mock('../frontend/src/components/UtilityRailBranchPanel.js', () => ({
+  default: ({ workspacePath, stateKey }: { workspacePath: string; stateKey?: string }) =>
+    React.createElement('div', {
+      'data-testid': 'branch-panel',
+      'data-workspace-path': workspacePath,
+      'data-state-key': stateKey ?? '',
+    }),
+}));
+vi.mock('../frontend/src/components/UtilityRailReviewPanel.js', () => ({
+  default: ({ workspacePath, stateKey }: { workspacePath: string; stateKey?: string }) =>
+    React.createElement('div', {
+      'data-testid': 'review-panel',
+      'data-workspace-path': workspacePath,
+      'data-state-key': stateKey ?? '',
+    }),
+}));
+vi.mock('../frontend/src/components/UtilityRailLogsPanel.js', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'logs-panel' }),
+}));
+vi.mock('../frontend/src/components/UtilityRailStatsPanel.js', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'stats-panel' }),
+}));
+vi.mock('../frontend/src/components/Terminal.js', () => ({
+  default: ({ sessionId }: { sessionId: string | null }) =>
+    React.createElement('div', {
+      'data-testid': 'utility-terminal-mount',
+      'data-session-id': sessionId ?? '',
+    }),
+}));
+
+import { WorkspaceUtilityRail } from '../frontend/src/components/WorkspaceUtilityRail.js';
+
+function session(overrides: Partial<SessionSummary> & { id: string }): SessionSummary {
+  return {
+    id: overrides.id,
+    repoName: 'a',
+    repoPath: '/repo/a',
+    worktreePath: null,
+    cwd: '/repo/a',
+    status: 'active',
+    createdAt: '2026-05-05T00:00:00.000Z',
+    lastActivity: '2026-05-05T00:00:00.000Z',
+    branchName: 'nightly',
+    displayName: '',
+    idle: false,
+    agent: 'claude',
+    type: 'terminal',
+    mode: 'pty',
+    useTmux: true,
+    ...overrides,
+  };
+}
+
+function railState(selectedRailTab: WorkspaceUtilityRailState['selectedRailTab']): WorkspaceUtilityRailState {
+  return {
+    visible: true,
+    selectedRailTab,
+    width: 320,
+  };
+}
+
+describe('WorkspaceUtilityRail resource context guards', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('passes local repo paths through to file and git panels while keeping the separate rail state key', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(WorkspaceUtilityRail, {
+          workspacePath: 'node:local:/repo/a',
+          resourceContext: {
+            displayWorkspacePath: '/repo/a',
+            anchorLabel: 'local · /repo/a',
+            repoBadge: 'repo',
+            files: { workspacePath: '/repo/a', disabledReason: null },
+            git: { workspacePath: '/repo/a', disabledReason: null },
+          },
+          railState: railState('changes'),
+          activeSession: session({ id: 'agent-1', type: 'agent' }),
+          workspaceSessions: [session({ id: 'agent-1', type: 'agent' })],
+        })
+      );
+    });
+
+    const changes = container.querySelector('[data-testid="changes-panel"]');
+    expect(changes?.getAttribute('data-workspace-path')).toBe('/repo/a');
+    expect(changes?.getAttribute('data-state-key')).toBe('node:local:/repo/a');
+  });
+
+  it('shows a remote files unavailable state instead of mounting the local file tree', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(WorkspaceUtilityRail, {
+          workspacePath: 'node:linux-box:/home/me/repo',
+          resourceContext: {
+            displayWorkspacePath: '/home/me/repo',
+            anchorLabel: 'linux-box · /home/me/repo',
+            repoBadge: null,
+            files: { workspacePath: '', disabledReason: 'remote-files-unavailable' },
+            git: { workspacePath: '', disabledReason: 'remote-git-unavailable' },
+          },
+          railState: railState('files'),
+          activeSession: session({ id: 'remote-1', type: 'terminal', nodeId: 'linux-box', repoPath: undefined, cwd: '/home/me/repo' }),
+          workspaceSessions: [],
+        })
+      );
+    });
+
+    expect(container.querySelector('[data-testid="files-panel"]')).toBeNull();
+    expect(container.textContent).toContain('remote files unavailable');
+    expect(container.textContent).toContain('/home/me/repo');
+  });
+
+  it('shows a normal no-git empty state for free local tabs instead of mounting git panels', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(WorkspaceUtilityRail, {
+          workspacePath: '/tmp/free-folder',
+          resourceContext: {
+            displayWorkspacePath: '/tmp/free-folder',
+            anchorLabel: 'local · /tmp/free-folder',
+            repoBadge: null,
+            files: { workspacePath: '/tmp/free-folder', disabledReason: null },
+            git: { workspacePath: '', disabledReason: 'no-git-context' },
+          },
+          railState: railState('branch'),
+          activeSession: session({ id: 'free-1', type: 'terminal', repoPath: undefined, cwd: '/tmp/free-folder' }),
+          workspaceSessions: [],
+        })
+      );
+    });
+
+    expect(container.querySelector('[data-testid="branch-panel"]')).toBeNull();
+    expect(container.textContent).toContain('no git context');
+    expect(container.textContent).toContain('/tmp/free-folder');
+  });
+});

--- a/test/workspace-utility-rail-context.test.ts
+++ b/test/workspace-utility-rail-context.test.ts
@@ -9,11 +9,23 @@ import type { WorkspaceUtilityRailState } from '../frontend/src/lib/stores/ui.js
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 vi.mock('../frontend/src/components/UtilityRailFilesPanel.js', () => ({
-  default: ({ workspacePath, stateKey }: { workspacePath: string; stateKey?: string }) =>
+  default: ({
+    workspacePath,
+    stateKey,
+    gitWorkspacePath,
+    gitDisabledReason,
+  }: {
+    workspacePath: string;
+    stateKey?: string;
+    gitWorkspacePath?: string;
+    gitDisabledReason?: string | null;
+  }) =>
     React.createElement('div', {
       'data-testid': 'files-panel',
       'data-workspace-path': workspacePath,
       'data-state-key': stateKey ?? '',
+      'data-git-workspace-path': gitWorkspacePath ?? '',
+      'data-git-disabled-reason': gitDisabledReason ?? '',
     }),
 }));
 vi.mock('../frontend/src/components/UtilityRailGitChangesPanel.js', () => ({
@@ -170,5 +182,32 @@ describe('WorkspaceUtilityRail resource context guards', () => {
     expect(container.querySelector('[data-testid="branch-panel"]')).toBeNull();
     expect(container.textContent).toContain('no git context');
     expect(container.textContent).toContain('/tmp/free-folder');
+  });
+
+  it('mounts the local free files panel with git fetches disabled', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(WorkspaceUtilityRail, {
+          workspacePath: '/tmp/free-folder',
+          resourceContext: {
+            displayWorkspacePath: '/tmp/free-folder',
+            anchorLabel: 'local · /tmp/free-folder',
+            repoBadge: null,
+            files: { workspacePath: '/tmp/free-folder', disabledReason: null },
+            git: { workspacePath: '', disabledReason: 'no-git-context' },
+          },
+          railState: railState('files'),
+          activeSession: session({ id: 'free-1', type: 'terminal', repoPath: undefined, cwd: '/tmp/free-folder' }),
+          workspaceSessions: [],
+        })
+      );
+    });
+
+    const files = container.querySelector('[data-testid="files-panel"]');
+    expect(files?.getAttribute('data-workspace-path')).toBe('/tmp/free-folder');
+    expect(files?.getAttribute('data-state-key')).toBe('/tmp/free-folder');
+    expect(files?.getAttribute('data-git-workspace-path')).toBe('');
+    expect(files?.getAttribute('data-git-disabled-reason')).toBe('no-git-context');
+    expect(container.textContent).not.toContain('HTTP 403');
   });
 });


### PR DESCRIPTION
## Summary
- Derive a utility rail active-tab context with node-aware state keys and separate resource fetch paths.
- Guard files/git/branch/review panels with deliberate remote/free/non-git empty states instead of stale local repo fetches.
- Keep local free-folder file browsing available while disabling git-only changed/default-branch requests for no-git contexts.
- Add compact rail anchor chrome plus tests for local repo, remote node, and free/non-git tabs.

## Verification
- `npm test -- test/utility-rail-context.test.ts test/workspace-utility-rail-context.test.ts test/workspace-utility-rail-terminal.test.ts test/components/FileTree.test.ts` — 4 files / 15 tests passed.
- `npm run check` — passed, 0 errors; existing repo lint warnings only.
- `npm run build` — passed, existing Vite chunk-size warning only.
- GitHub checks on `cd503272a93b377f6b4ddaacb7d710cf54159046`: `ci`, `e2e`, `scan-commits`, `sync-labels`, and CodeRabbit all passed.

Refs #473
Closes #479
