### PR TITLE
docs: define six-layer vocabulary source of truth

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,6 +12,44 @@ Output: terminal rendering via xterm.js, real-time session state updates.
 
 The system has two compilation targets: a TypeScript + ESM backend (Express + node-pty + tmux + WebSocket) compiled to `dist/`, and a React 19 frontend (Zustand + TanStack Query + Vite) compiled to `dist/frontend/`.
 
+## Six-Layer Vocabulary Contract (#444)
+
+Relay's product information architecture is now described as **View -> Workspace -> Project -> Instance -> Bench -> Tab**. This vocabulary is a source-of-truth for docs and implementation planning; it does not mean every layer must be visible in every UI state. The single-repo golden path should stay compact, while remote, non-repo, and multi-node states expose the layer needed to avoid false repo/worktree assumptions.
+
+| Layer         | What it answers                                       | Current / compatibility boundary                                                                                                                                                                                       |
+| ------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **View**      | What lens am I looking through?                       | A filter or presentation across tabs/projects/workers. Views are not durable storage unless a future saved-view feature says so.                                                                                       |
+| **Workspace** | What am I organizing?                                 | A user-owned grouping of Projects and pins. Do not use Workspace as the universal name for a filesystem path or repo checkout. Existing `/workspaces` routes remain legacy repo-folder compatibility during migration. |
+| **Project**   | What is being worked on?                              | Canonical identity: commonly a git remote, but also node, agent-provider, playbook, or other target kinds. Use `repo` only when the affordance is specifically git/PR/branch/remote.                                   |
+| **Instance**  | Where is that Project realized?                       | A host/node realization of a Project. Existing repo instance IDs such as `(nodeId, repoPath)` are git-specific Instance compatibility shapes.                                                                          |
+| **Bench**     | Which cwd + environment is active inside an Instance? | Generalizes git worktrees. Existing `worktreePath` and worktree instance IDs stay valid for git Bench compatibility and destructive git-worktree operations.                                                           |
+| **Tab**       | What leaf surface is active?                          | Terminal, agent chat, file, diff, or preview surface. Existing session/stream IDs remain process and routing identity, not the primary user-facing IA label.                                                           |
+
+**Project = what; Worker = who.** Workers/agents are dynamic decoration on a Bench or Tab (`currentWorkers`, `activeWorker`, `mode`), not a structural tree node between Project and Instance. `Project.identity.kind = 'agent'` means agent-as-target/configuration, not the active worker doing the work.
+
+### Internal and compatibility identities
+
+Keep these names precise where they describe implemented plumbing:
+
+- `globalSessionId` remains an internal stream/routing identifier for hub/node session lookup and reconnect. It should not become primary user-facing copy.
+- `repoInstanceId`, `worktreeInstanceId`, `repoPath`, and `worktreePath` remain compatibility fields while shared/server/frontend contracts migrate.
+- `repo`, `branch`, `remote`, and `worktree` remain correct inside git-specific docs, routes, widgets, and destructive operations. The anti-pattern is treating them as universal IA terms for every Tab.
+
+### First-wave implementation lanes
+
+1. **Docs/source of truth:** keep this contract, `docs/FRONTEND.md`, and `docs/federated-relay.md` aligned before broad code changes.
+2. **Compatibility adapters:** add helpers that map legacy `repoPath`/`worktreePath`/workspace storage keys into Project/Instance/Bench/Tab view models without destructive localStorage or persistence migration.
+3. **Copy-only UI pass:** update low-risk visible copy to stop saying repo/worktree/session when the state may be remote, free/non-git, or tab-scoped. Preserve git nouns for literal git affordances.
+4. **Backend/shared contracts:** introduce new Workspace/Project/Instance/Bench entities and route wrappers while keeping legacy API fields readable.
+5. **Frontend IA migration:** migrate sidebar, command palette, create-tab, restore/resume, and utility rail consumers behind tab/context adapters, coordinated with #473.
+
+### Explicit non-goals for this docs slice
+
+- No dumb repo-wide rename of `workspace`, `repo`, `worktree`, or `session`.
+- No full #473 right-rail/create-tab migration in this PR.
+- No #428 remote file RPC guarantee; remote file browsing can stay unavailable until that work lands.
+- No Worker/Agent tree node. Worker remains decoration and can later power a Worker-focused View.
+
 ## Code Map
 
 ### `server/`
@@ -21,8 +59,8 @@ The system has two compilation targets: a TypeScript + ESM backend (Express + no
 | Module                                  | Role                                                                                                                                                                                                                                                               |
 | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `index.ts`                              | Composition root: Express app, REST routes, auth middleware, static serving                                                                                                                                                                                        |
-| `workspaces.ts`                         | Repo CRUD, Express Router: dashboard, settings, CI status, branch switch, path autocomplete                                                                                                                                                                        |
-| `workspace-groups.ts`                   | Workspace grouping entity CRUD: Express Router at `/workspace-groups` for create/read/update/delete/reorder workspace entities                                                                                                                                     |
+| `workspaces.ts`                         | Legacy repo-folder compatibility router: dashboard, settings, CI status, branch switch, path autocomplete. These `/workspaces` routes are not the future six-layer Workspace entity source of truth.                                                               |
+| `workspace-groups.ts`                   | Current workspace grouping CRUD for user-organized repo groups; compatibility surface until six-layer Workspace/Project persistence lands.                                                                                                                         |
 | `sessions.ts`                           | Session registry: routes `create()` to pty-handler, lifecycle ops, restore/reattach, idle sweep                                                                                                                                                                    |
 | `pty-handler.ts`                        | PTY session creation via node-pty attached to tmux, scrollback buffering (256KB), tmux session naming, continue-retry                                                                                                                                              |
 | `git.ts`                                | Git/GitHub CLI integration: branches, activity feed, CI status, PR lookup, branch switch, branch lifecycle state computation (`ensureBranchLocal`, `isPrMerged`, `computeBranchLifecycleState`); exports `extractOwnerRepo` and `buildRepoMap` for webhook-manager |
@@ -35,7 +73,7 @@ The system has two compilation targets: a TypeScript + ESM backend (Express + no
 | `service.ts`                            | Background service install/uninstall/status (launchd on macOS, systemd on Linux)                                                                                                                                                                                   |
 | `push.ts`                               | Web Push notification management (VAPID keys, subscription registry, SDK event enrichment)                                                                                                                                                                         |
 | `hooks.ts`                              | Claude Code hook HTTP endpoints: state detection (Stop, Notification, UserPromptSubmit), activity tracking (PreToolUse, PostToolUse), session cleanup (SessionEnd), and branch rename. Localhost-only with per-session token auth.                                 |
-| `types.ts`                              | Shared TypeScript interfaces (Session, Repo, Workspace entity, Config v4, WorkspaceLevelSettings, PR, CI, Activity types)                                                                                                                                          |
+| `types.ts`                              | Shared TypeScript interfaces, including legacy `Session`, `Repo`, `Workspace`, `repoPath`, and `worktreePath` compatibility shapes that map toward Project/Instance/Bench/Tab view models.                                                                         |
 | `analytics.ts`                          | Local analytics: SQLite-backed event tracking, `trackEvent()`, batch ingest endpoint, DB size/clear endpoints                                                                                                                                                      |
 | `port-allocator.ts`                     | Durable per-worktree port allocation, persisted assignments, `.env` managed-block reconciliation, and startup verification of allocated ports                                                                                                                      |
 | `review-poller.ts`                      | PR review automation: polls GitHub notifications for review requests, creates worktrees, optionally starts review sessions                                                                                                                                         |
@@ -159,7 +197,7 @@ Tmux session names are stable and human-readable:
 - On startup, the server checks whether the named tmux session still exists. If it does, Relay reattaches with `tmux -u attach-session -t <name>`. If it does not, agent sessions fall back to agent-specific continue args and create a fresh tmux-backed process.
 - `sessions.ts` exposes targeted tmux helpers (`sendTmuxKeys`, `sendTmuxText`, `captureTmuxPane`) so future workspace panes can address a specific tmux-backed process by session id instead of relying only on the currently attached PTY stream.
 
-This makes workspace, tab, and pane customization (#263) viable without losing process ownership. Browser-level tabs and panes can be rearranged freely while the underlying tmux session remains the stable process identity for reconnect, restore, resize, copy-mode, and cleanup.
+This makes Tab and pane customization (#263) viable without losing process ownership; the tmux/session name is process substrate, while the browser Tab is the user-visible leaf surface. Browser-level tabs and panes can be rearranged freely while the underlying tmux session remains the stable process identity for reconnect, restore, resize, copy-mode, and cleanup.
 
 ## REST API
 
@@ -167,15 +205,15 @@ This makes workspace, tab, and pane customization (#263) viable without losing p
 | -------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `POST`   | `/auth`                         | Authenticate with PIN, returns session cookie                                                                                                       |
 | `GET`    | `/sessions`                     | List active sessions                                                                                                                                |
-| `POST`   | `/sessions`                     | Create session (agent or terminal, in workspace root or worktree)                                                                                   |
+| `POST`   | `/sessions`                     | Create an agent/terminal process stream that backs a Tab, using legacy repo/worktree path fields when provided                                      |
 | `PATCH`  | `/sessions/:id`                 | Rename session                                                                                                                                      |
 | `DELETE` | `/sessions/:id`                 | Terminate session                                                                                                                                   |
 | `POST`   | `/sessions/:id/image`           | Upload clipboard image                                                                                                                              |
 | `GET`    | `/branches`                     | List local and remote branches                                                                                                                      |
 | `GET`    | `/worktrees`                    | List inactive Claude Code worktrees                                                                                                                 |
 | `DELETE` | `/worktrees`                    | Remove worktree, prune refs, delete branch                                                                                                          |
-| `GET`    | `/workspaces`                   | List configured workspace folders with git info                                                                                                     |
-| `POST`   | `/workspaces`                   | Add workspace folder (body: `{path}`)                                                                                                               |
+| `GET`    | `/workspaces`                   | Legacy: list configured repo/workspace folders with git info; not the future Workspace entity CRUD                                                  |
+| `POST`   | `/workspaces`                   | Legacy: add a repo/folder path (body: `{path}`)                                                                                                     |
 | `DELETE` | `/workspaces`                   | Remove workspace folder                                                                                                                             |
 | `GET`    | `/workspaces/dashboard`         | Aggregated PRs + activity for a workspace (`?path=X`)                                                                                               |
 | `GET`    | `/workspaces/settings`          | Per-workspace settings (`?path=X`)                                                                                                                  |
@@ -186,7 +224,7 @@ This makes workspace, tab, and pane customization (#263) viable without losing p
 | `GET`    | `/workspaces/browse`            | Browse filesystem directories (and files with `includeFiles=true`) for tree UI (`?path=X&prefix=Y&showHidden=bool&includeFiles=bool`)               |
 | `POST`   | `/workspaces/bulk`              | Add multiple workspace paths at once (body: `{paths}`)                                                                                              |
 | `GET`    | `/workspaces/autocomplete`      | Path prefix autocomplete (`?prefix=X`)                                                                                                              |
-| `POST`   | `/workspaces/worktree`          | Create worktree with mountain name (`?path=X`)                                                                                                      |
+| `POST`   | `/workspaces/worktree`          | Git-specific Bench compatibility: create a worktree with mountain name (`?path=X`)                                                                  |
 | `GET`    | `/workspaces/current-branch`    | Current checked-out branch (`?path=X`)                                                                                                              |
 | `GET`    | `/api/node/manifest`            | Local node manifest: platform/arch/hostname/version, WSL, service manager, and non-fatal capability/tool probes; CLI mirror is `relay-ide manifest` |
 | `POST`   | `/hub/pair-tokens`              | Create a short-lived relay-node pair token with redacted-safe SSH/Tailscale/local bootstrap command variants                                        |
@@ -239,21 +277,21 @@ Both channels require authentication via `token` cookie verified during HTTP upg
 > committed; older entries are summarized below until backfilled. Regenerate
 > with `/adr:update`.
 
-| ADR     | Topic                                                                                                                                                |
-| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ADR-001 | Modular server architecture (composition root, dependency flow)                                                                                      |
-| ADR-003 | PTY session management (tmux substrate, in-memory state, scrollback, CLAUDECODE stripping)                                                           |
-| ADR-004 | PIN authentication (scrypt, cookie tokens, rate limiting)                                                                                            |
-| ADR-005 | Vitest as unit/integration test runner (migrated from node:test 2026-04-03)                                                                          |
-| ADR-006 | Dual distribution (npm global + local dev, CLI flags via env vars)                                                                                   |
-| ADR-007 | WebSocket dual channels (PTY relay + event broadcast, debounced watcher)                                                                             |
-| ADR-008 | TypeScript + ESM (strict mode, .js extensions, node: prefix, Node >= 24)                                                                             |
-| ADR-009 | Hub/Node Federation (hub accepts node registrations via reverse WebSocket; nodes own data plane; hub owns routing/aggregation)                       |
-| ADR-010 | Node-Initiated Outbound Links (nodes dial hub to avoid NAT/firewall inbound)                                                                         |
-| ADR-011 | Agent-driven browser automation (`server/agent-browser.ts`, Playwright)                                                                              |
-| ADR-012 | Pair-Token/Credential Lifecycle (short-lived pair token → persistent revocable node credential; SHA256 storage; immediate revocation)                |
-| ADR-013 | Capability Manifest (nodes self-report probes; hub gates routing on capability state)                                                                |
-| ADR-014 | Repo Identity Aggregation (canonical git/GitHub remote identity across nodes; local paths node-specific)                                             |
+| ADR     | Topic                                                                                                                                                                                |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ADR-001 | Modular server architecture (composition root, dependency flow)                                                                                                                      |
+| ADR-003 | PTY session management (tmux substrate, in-memory state, scrollback, CLAUDECODE stripping)                                                                                           |
+| ADR-004 | PIN authentication (scrypt, cookie tokens, rate limiting)                                                                                                                            |
+| ADR-005 | Vitest as unit/integration test runner (migrated from node:test 2026-04-03)                                                                                                          |
+| ADR-006 | Dual distribution (npm global + local dev, CLI flags via env vars)                                                                                                                   |
+| ADR-007 | WebSocket dual channels (PTY relay + event broadcast, debounced watcher)                                                                                                             |
+| ADR-008 | TypeScript + ESM (strict mode, .js extensions, node: prefix, Node >= 24)                                                                                                             |
+| ADR-009 | Hub/Node Federation (hub accepts node registrations via reverse WebSocket; nodes own data plane; hub owns routing/aggregation)                                                       |
+| ADR-010 | Node-Initiated Outbound Links (nodes dial hub to avoid NAT/firewall inbound)                                                                                                         |
+| ADR-011 | Agent-driven browser automation (`server/agent-browser.ts`, Playwright)                                                                                                              |
+| ADR-012 | Pair-Token/Credential Lifecycle (short-lived pair token → persistent revocable node credential; SHA256 storage; immediate revocation)                                                |
+| ADR-013 | Capability Manifest (nodes self-report probes; hub gates routing on capability state)                                                                                                |
+| ADR-014 | Repo Identity Aggregation (canonical git/GitHub remote identity across nodes; local paths node-specific)                                                                             |
 | ADR-015 | Core relay primitives are domain-agnostic; repo/git is a feature layer ([`docs/adrs/ADR-015-core-primitives-domain-agnostic.md`](./adrs/ADR-015-core-primitives-domain-agnostic.md)) |
 | ADR-016 | Node-to-node isolation invariant; inter-node traffic flows through the hub ([`docs/adrs/ADR-016-node-to-node-isolation.md`](./adrs/ADR-016-node-to-node-isolation.md))               |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,14 +18,14 @@ Relay's product information architecture is now described as **View -> Workspace
 
 | Layer         | What it answers                                       | Current / compatibility boundary                                                                                                                                                                                       |
 | ------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **View**      | What lens am I looking through?                       | A filter or presentation across tabs/projects/workers. Views are not durable storage unless a future saved-view feature says so.                                                                                       |
+| **View**      | What lens am I looking through?                       | A filter or presentation across tabs/projects/workers. Views are not durable storage unless a future saved-view feature defines that persistence.                                                                      |
 | **Workspace** | What am I organizing?                                 | A user-owned grouping of Projects and pins. Do not use Workspace as the universal name for a filesystem path or repo checkout. Existing `/workspaces` routes remain legacy repo-folder compatibility during migration. |
 | **Project**   | What is being worked on?                              | Canonical identity: commonly a git remote, but also node, agent-provider, playbook, or other target kinds. Use `repo` only when the affordance is specifically git/PR/branch/remote.                                   |
 | **Instance**  | Where is that Project realized?                       | A host/node realization of a Project. Existing repo instance IDs such as `(nodeId, repoPath)` are git-specific Instance compatibility shapes.                                                                          |
 | **Bench**     | Which cwd + environment is active inside an Instance? | Generalizes git worktrees. Existing `worktreePath` and worktree instance IDs stay valid for git Bench compatibility and destructive git-worktree operations.                                                           |
 | **Tab**       | What leaf surface is active?                          | Terminal, agent chat, file, diff, or preview surface. Existing session/stream IDs remain process and routing identity, not the primary user-facing IA label.                                                           |
 
-**Project = what; Worker = who.** Workers/agents are dynamic decoration on a Bench or Tab (`currentWorkers`, `activeWorker`, `mode`), not a structural tree node between Project and Instance. `Project.identity.kind = 'agent'` means agent-as-target/configuration, not the active worker doing the work.
+**Project = what; Worker = who.** Worker/agent status should remain dynamic decoration on a Bench or Tab, not a structural tree node between Project and Instance. Future decoration fields may include names like `currentWorkers`, `activeWorker`, or `mode`, but those are not a shipped shared contract yet. `Project.identity.kind = 'agent'` means agent-as-target/configuration, not the active worker doing the work.
 
 ### Internal and compatibility identities
 
@@ -45,7 +45,7 @@ Keep these names precise where they describe implemented plumbing:
 
 ### Explicit non-goals for this docs slice
 
-- No dumb repo-wide rename of `workspace`, `repo`, `worktree`, or `session`.
+- No blanket repo-wide rename of `workspace`, `repo`, `worktree`, or `session`.
 - No full #473 right-rail/create-tab migration in this PR.
 - No #428 remote file RPC guarantee; remote file browsing can stay unavailable until that work lands.
 - No Worker/Agent tree node. Worker remains decoration and can later power a Worker-focused View.
@@ -205,7 +205,7 @@ This makes Tab and pane customization (#263) viable without losing process owner
 | -------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `POST`   | `/auth`                         | Authenticate with PIN, returns session cookie                                                                                                       |
 | `GET`    | `/sessions`                     | List active sessions                                                                                                                                |
-| `POST`   | `/sessions`                     | Create an agent/terminal process stream that backs a Tab, using legacy repo/worktree path fields when provided                                      |
+| `POST`   | `/sessions`                     | Create local agent/terminal Tab process; current local contract requires `repoPath`, with `worktreePath` selecting cwd when set                     |
 | `PATCH`  | `/sessions/:id`                 | Rename session                                                                                                                                      |
 | `DELETE` | `/sessions/:id`                 | Terminate session                                                                                                                                   |
 | `POST`   | `/sessions/:id/image`           | Upload clipboard image                                                                                                                              |
@@ -232,6 +232,7 @@ This makes Tab and pane customization (#263) viable without losing process owner
 | `POST`   | `/hub/node-heartbeat`           | Authenticated relay-node heartbeat using the persistent node credential                                                                             |
 | `GET`    | `/nodes`                        | List paired nodes with heartbeat status, reverse-link connection state, and capability summary                                                      |
 | `DELETE` | `/nodes/:nodeId`                | Revoke a paired node credential                                                                                                                     |
+| `POST`   | `/hub/nodes/:nodeId/sessions`   | Route session creation to an online node; RPC body uses `repoPath`, `worktreePath`, and `cwd`                                                       |
 | `GET`    | `/version`                      | Check for npm updates                                                                                                                               |
 | `POST`   | `/update`                       | Self-update via npm                                                                                                                                 |
 | `GET`    | `/config/defaultAgent`          | Get default coding agent                                                                                                                            |

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -24,7 +24,7 @@ Frontend copy and state should use the six-layer model as its mental model: **Vi
 | **Bench**     | cwd + environment within an Instance.                                                                   | Existing worktrees are git Bench compatibility. Use worktree copy only for literal git worktree operations.                                               |
 | **Tab**       | The active leaf surface: terminal, agent chat, file, diff, or preview.                                  | `WorkspaceTab`, session ids, and PTY streams are implementation details that back the user-visible Tab.                                                   |
 
-Worker/agent status is decoration, not hierarchy: **Project = what; Worker = who**. Badges like active worker, human-driven/agent-driven/co-driven mode, and currentWorkers should attach to Bench/Tab surfaces. Do not add a Worker tree node. `Project.identity.kind = 'agent'` means configuring an agent target, not showing an active worker.
+Worker/agent status is decoration, not hierarchy: **Project = what; Worker = who**. Future badges or view-model fields for active worker, human-driven/agent-driven/co-driven mode, or current workers should attach to Bench/Tab surfaces after their contract ships. Do not add a Worker tree node. `Project.identity.kind = 'agent'` means configuring an agent target, not showing an active worker.
 
 ### State-key and copy rules during migration
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -11,13 +11,43 @@ React 19 SPA for Relay IDE. Built with TypeScript, Zustand, TanStack Query, and 
 - xterm.js consumed as npm dependency (`@xterm/xterm`, `@xterm/addon-fit`); it remains the browser renderer while tmux owns the server-side session/process substrate
 - Mobile-first responsive design with touch toolbar (hidden on desktop)
 
+## Product Vocabulary and Tab Context (#444)
+
+Frontend copy and state should use the six-layer model as its mental model: **View -> Workspace -> Project -> Instance -> Bench -> Tab**. In code, many APIs still expose `repoPath`, `worktreePath`, `SessionSummary`, and old workspace storage keys; treat those as compatibility contracts until server/shared migrations land.
+
+| Term          | Frontend meaning                                                                                        | Current implementation boundary                                                                                                                           |
+| ------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **View**      | The active lens/filter, such as recent tabs, all sessions, this host, or a workspace-scoped view.       | Current sidebar and command palette filters are view-like but not yet saved View entities.                                                                |
+| **Workspace** | User-owned organization: named grouping, project pins, and lenses.                                      | Existing workspace groups and `/workspaces` repo-folder APIs are legacy compatibility. Do not present a repo path as the whole Workspace.                 |
+| **Project**   | The durable target: usually a repo, but eventually also node, agent provider, playbook, or saved query. | Existing repo rows are repo-kind Projects. Git labels remain correct for PRs, branches, remotes, and repo badges.                                         |
+| **Instance**  | A Project on a node/host.                                                                               | Existing `(nodeId, repoPath)` repo instances are git-specific Instance compatibility. Prefer host labels in compact chrome if “Instance” is too abstract. |
+| **Bench**     | cwd + environment within an Instance.                                                                   | Existing worktrees are git Bench compatibility. Use worktree copy only for literal git worktree operations.                                               |
+| **Tab**       | The active leaf surface: terminal, agent chat, file, diff, or preview.                                  | `WorkspaceTab`, session ids, and PTY streams are implementation details that back the user-visible Tab.                                                   |
+
+Worker/agent status is decoration, not hierarchy: **Project = what; Worker = who**. Badges like active worker, human-driven/agent-driven/co-driven mode, and currentWorkers should attach to Bench/Tab surfaces. Do not add a Worker tree node. `Project.identity.kind = 'agent'` means configuring an agent target, not showing an active worker.
+
+### State-key and copy rules during migration
+
+- Preserve legacy localStorage/API keys such as `claude-remote-active-workspace`, `claude-remote-workspace-sessions`, `relay-utility-rail::<path>`, `repoPath`, `worktreePath`, and `globalSessionId`; add adapter/view-model names around them instead of destructive renames.
+- The active context is the active **Tab** plus optional Project/Instance/Bench/repo binding. Avoid global “active repo” copy unless the tab actually has a repo binding.
+- The utility rail is tab-contextual. Its header and unavailable states should describe the active tab anchor: local repo tab, remote node tab, or free/non-git tab.
+- “Not a git repo”, “remote files unavailable until file RPC lands”, and “no pinned projects” are normal empty/unavailable states, not red failure states.
+- PR/git widgets read from explicit workspace pins and active-tab anchors; they must not silently fall back to a stale local repo when a remote/free tab is active.
+
+### First-wave implementation lane map
+
+1. Add vocabulary/view-model adapters for active tab anchor, project path/repo binding, utility-rail state key, and last-session recall while reading old storage keys.
+2. Make a copy-only pass on low-risk surfaces: add/connect flow, sidebar empty states, command palette placeholders/actions, and right-rail unavailable messages.
+3. Defer full #473 right-rail/create-tab migration, #428 remote file RPC, and broad sidebar IA reshaping to their own implementation PRs.
+4. Keep destructive git worktree actions and git/PR panels using git words where they are literal.
+
 ## Component Map
 
 | Component                            | Role                                                                                                                                                             |
 | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `App.tsx`                            | Root layout: left sidebar + SplitPaneLayout hosting WorkspaceArea and WorkspaceUtilityRail for session view; dashboard / PR top bar + tabs for non-session views |
-| `Sidebar.tsx`                        | Flat workspace list with command palette search                                                                                                                  |
-| `RepoItem.tsx`                       | Repo tree item: sessions, inactive worktrees, context menus, workspace group membership                                                                          |
+| `Sidebar.tsx`                        | Current repo/workspace-group navigation surface; migration target is View -> Workspace -> Project -> Instance -> Bench with progressive disclosure               |
+| `RepoItem.tsx`                       | Repo-kind Project/Bench compatibility row: sessions/tabs, inactive git worktrees, context menus, workspace group membership                                      |
 | `CommandPalette.tsx`                 | Terminal-style command palette with action registry                                                                                                              |
 | `PrTopBar.tsx`                       | Dynamic PR/CI bar with branch switcher, target branch switcher, diff stats, merge conflict detection, action buttons                                             |
 | `RepoDashboard.tsx`                  | Workspace dashboard: PRs with merge status, activity feed, CTAs                                                                                                  |
@@ -32,13 +62,13 @@ React 19 SPA for Relay IDE. Built with TypeScript, Zustand, TanStack Query, and 
 | `SessionIndicator.tsx`               | Unicode shape-based session state indicator (shapes + colors + pulse animations)                                                                                 |
 | `SessionStatusBar.tsx`               | Multi-framework telemetry status bar (model, context %, tokens)                                                                                                  |
 | `AgentBadge.tsx`                     | Agent type indicator badge (Claude/Codex/OpenCode)                                                                                                               |
-| `WorkspaceUtilityRail.tsx`           | Right utility rail: fixed icon strip, selected utility pane host, visible/hidden shell model                                                                     |
+| `WorkspaceUtilityRail.tsx`           | Tab-contextual right utility rail: fixed icon strip, selected utility pane host, visible/hidden shell model; file/git panes require an active-tab anchor         |
 | `UtilityRailFilesPanel.tsx`          | Files utility pane wrapper around changed files and lazy filesystem browsing                                                                                     |
 | `UtilityRailReviewPanel.tsx`         | Review utility pane: changed-file list, diff source controls, and embedded DiffViewer                                                                            |
 | `UtilityRailLogsPanel.tsx`           | Logs utility pane shell for current session/activity output                                                                                                      |
 | `UtilityRailStatsPanel.tsx`          | Stats utility pane using telemetry summaries for active session and workspace                                                                                    |
 | `FileTreeSidebar.tsx`                | Reusable files panel implementation: changes tab (git diff tree), all files tab (lazy filesystem browser)                                                        |
-| `WorkspaceArea.tsx`                  | Workspace tab layout host for session, terminal, code, diff, and HTML tabs with draggable panes                                                                  |
+| `WorkspaceArea.tsx`                  | Tab layout host for session/terminal, code, diff, and HTML tabs with draggable panes; despite the legacy name, Tab is the leaf surface                           |
 | `SplitPaneLayout.tsx`                | Resizable layout wrapper for the workspace area and utility rail with draggable resize handles                                                                   |
 | `DiffViewer.tsx`                     | Unified diff renderer with diff2html parsing and Shiki syntax highlighting                                                                                       |
 | `CodeBlock.tsx`                      | Shared Shiki syntax highlighting wrapper component                                                                                                               |
@@ -93,7 +123,7 @@ State is managed via Zustand stores and React hooks. Pure logic modules live und
 
 ### Action Registry (`frontend/src/lib/actions/`)
 
-Typed action registry for the command palette. Actions are pure metadata (`ActionMeta`) defined in `definitions/` files, registered with handler closures in `App.tsx` via `registerGlobal()`. CommandPalette reads commands from the registry via `getAllActions()`.
+Typed action registry for the command palette. Actions are pure metadata (`ActionMeta`) defined in `definitions/` files, registered with handler closures in `App.tsx` via `registerGlobal()`. CommandPalette reads commands from the registry via `getAllActions()`. Labels and descriptions should use Tab/Project/Bench vocabulary unless an action is literally git/repo/worktree-specific.
 
 | Module                     | Role                                                                                                                   |
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
@@ -136,7 +166,7 @@ Typed action registry for the command palette. Actions are pure metadata (`Actio
 - Settings dialog close triggers `refreshAll()` for immediate sidebar update
 - All dialogs are built on `DialogShell.tsx` — use the `fullscreen` prop for the Settings modal and omit it for compact dialogs (AddWorkspace, CustomizeSession, DeleteWorktree). DialogShell uses `popover="manual"` + `showPopover()`/`hidePopover()` to guarantee top-layer stacking above xterm.js canvas elements (z-index alone is insufficient for canvas stacking contexts)
 - Cookie TTL uses human-readable format: `s` (seconds), `m` (minutes), `h` (hours), `d` (days). Default: `24h`
-- **Utility rail + workspace tabs** — `SplitPaneLayout` wraps the session view with `WorkspaceArea` (session/file/diff/html tabs) and `WorkspaceUtilityRail` (right, visible/hidden via the PR top-bar toggle). The rail has a fixed-width icon strip at the far right; the selected utility pane renders immediately to its left, and clicking the active icon clears the selected pane while keeping the icon strip. Utility rail state is persisted per workspace path in the UI store; `openFileTab()`/`closeFileTab()` drive file tabs inside WorkspaceArea.
+- **Utility rail + tabs** — `SplitPaneLayout` wraps the active Tab view with `WorkspaceArea` (session/file/diff/html tabs) and `WorkspaceUtilityRail` (right, visible/hidden via the PR top-bar toggle). The rail has a fixed-width icon strip at the far right; the selected utility pane renders immediately to its left, and clicking the active icon clears the selected pane while keeping the icon strip. Utility rail state is currently persisted with legacy workspace/path keys in the UI store; migration code should preserve those keys while exposing a tab-anchor/state-key adapter. `openFileTab()`/`closeFileTab()` drive file tabs inside WorkspaceArea.
 - **Cross-node terminal tabs (#443)** — `WorkspaceTab` session variant carries an optional `nodeId`. When set, `ws.ts` `connectPtySocket` routes via `/nodes/:nodeId/ws/sessions/:sessionId` (resolved through `parseGlobalSessionId` or `session.nodeId`). `WorkspaceTabBar` renders a per-tab node badge (label + heartbeat dot) sourced from `SummaryContext.findNode`, which `WorkspaceArea` populates from `useQuery(['hub-nodes'], fetchHubNodes)`. The tab-bar `+` button is replaced by `TerminalNodePicker` — a dropdown listing "this host" plus paired nodes; only `online` nodes are selectable. Choosing a node calls `createAgentSession({ type: 'terminal', nodeId })`; the layout reconciler picks the new session up via `sessions[]` → `sessionToWorkspaceTab` (which copies `session.nodeId` onto the tab).
 - Root directory scanning: one level deep for git repos, hidden directories excluded
 

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -30,6 +30,28 @@ Relay IDE can run as a **hub** that tracks multiple **relay-nodes** — personal
 | **Worktree instance** | A node-local git worktree, identified by `(nodeId, worktreePath)`.                                                                                                                                                                                    |
 | **Global session ID** | A node-scoped session identifier produced by `createGlobalSessionId` in `shared/identity.ts`: `{encodeURIComponent(nodeId)}:{encodeURIComponent(localSessionId)}`. No prefix — the node ID and local ID are URL-encoded and joined by a single colon. |
 
+## Six-Layer Vocabulary Mapping (#444)
+
+Federated Relay keeps its precise low-level hub/node/repo/session terms, but maps them into the product IA so docs do not imply `repo = Workspace` or `worktree = universal cwd`. The source vocabulary is **View -> Workspace -> Project -> Instance -> Bench -> Tab**.
+
+| Product term  | Federated meaning                                                               | Low-level term that remains valid                                                                                                                  |
+| ------------- | ------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **View**      | Browser lens over nodes, projects, tabs, workers, or a workspace-scoped subset. | Hub/client filters and future saved views.                                                                                                         |
+| **Workspace** | User grouping/pins across Projects.                                             | Existing workspace/repo-folder APIs are migration compatibility, not the federation identity model.                                                |
+| **Project**   | Canonical “what” being worked on.                                               | `Repo identity` is a repo-kind Project identity derived from git remotes. Node/agent/playbook Projects may not have repo inventory.                |
+| **Instance**  | A Project realized on a node/host.                                              | `Repo instance` `(nodeId, repoPath)` is a git-specific Instance compatibility shape.                                                               |
+| **Bench**     | cwd + env inside an Instance.                                                   | `Worktree instance` `(nodeId, worktreePath)` is a git Bench compatibility shape. Free/non-git remote cwd is also a Bench-like anchor once modeled. |
+| **Tab**       | User-visible terminal/file/diff/agent-chat/preview surface.                     | A hub/node session and PTY stream back a Tab; `globalSessionId` remains internal routing identity.                                                 |
+
+Worker/agent identity is dynamic decoration on Bench/Tab, not a federated tree node. Use node/host labels for where work runs, repo/project labels for what is being worked on, and worker badges for who is active.
+
+### Compatibility boundaries
+
+- `globalSessionId` is an internal stream/routing id. It is useful in API diagnostics and reconnect paths, but users should primarily see Tab, node, cwd, and process status.
+- `repoPath` and `worktreePath` remain compatibility fields while old session creation, repo inventory, and git routes are migrated. They must stay node-scoped; never treat a path alone as global identity.
+- Repo inventory is deliberately git-specific. It can seed repo-kind Projects/Instances, but it is not the full future Project inventory.
+- Remote file browsing remains unavailable until #428 file RPC lands; do not document hub-local filesystem fallback as supported behavior.
+
 ## Reverse WebSocket Model
 
 The steady-state transport is a **reverse WebSocket** opened by the node to the hub. This avoids NAT, firewall, and WSL inbound-port problems.
@@ -255,6 +277,8 @@ Content-Type: application/json
 { "type": "agent", "workspacePath": "/Users/kyle/dev/relay-ide", ... }
 ```
 
+`workspacePath` is a legacy path field in the current API. In the six-layer model it maps toward the cwd for a Bench; keep the field name for compatibility until the session-create contract is migrated.
+
 Preconditions checked by the hub:
 
 1. Node is paired and not revoked
@@ -272,11 +296,11 @@ If any precondition fails, the hub returns a typed error with `retryable` guidan
 | `NODE_UNSUPPORTED`      | Node cannot host tmux-backed sessions | No        |
 | `NODE_OFFLINE`          | Node has no live reverse link         | Yes       |
 
-On success, the hub forwards the request as an RPC (`sessions.create`) over the node's reverse WebSocket, receives the node-local `SessionSummary`, and returns a **node-scoped** session with:
+On success, the hub forwards the request as an RPC (`sessions.create`) over the node's reverse WebSocket, receives the node-local `SessionSummary`, and returns a **node-scoped** session that backs a user-visible Tab with:
 
-- `globalSessionId`: `{encodeURIComponent(nodeId)}:{encodeURIComponent(localSessionId)}`
-- `repoInstanceId`: `{encodeURIComponent(nodeId)}:{encodeURIComponent(repoPath)}` (when applicable)
-- `worktreeInstanceId`: `{encodeURIComponent(nodeId)}:{encodeURIComponent(worktreePath)}` (when applicable)
+- `globalSessionId`: `{encodeURIComponent(nodeId)}:{encodeURIComponent(localSessionId)}` for internal stream/routing identity
+- `repoInstanceId`: `{encodeURIComponent(nodeId)}:{encodeURIComponent(repoPath)}` as a repo-kind Instance compatibility id (when applicable)
+- `worktreeInstanceId`: `{encodeURIComponent(nodeId)}:{encodeURIComponent(worktreePath)}` as a git Bench compatibility id (when applicable)
 
 ### Attaching to a PTY on a node
 
@@ -377,7 +401,7 @@ GET /hub/repo-inventory
 Cookie: token={auth-cookie}
 ```
 
-Response groups repo instances by canonical identity, showing per-node paths, branch counts, worktree counts, and online status.
+Response groups repo instances by canonical git identity, showing per-node paths, branch counts, worktree counts, and online status. In #444 terms this is a repo-kind Project inventory plus git-specific Instance/Bench metadata, not the complete future Project inventory.
 
 ## Bootstrap and Service Modes
 
@@ -494,6 +518,7 @@ These were considered during design but are **not implemented** and should not b
 - **Anonymous worker pools** — Every node requires explicit pairing and trust.
 - **Cross-host tmux session transfer** — Sessions are node-local; re-creating on another node is a cold start.
 - **Real-time workspace state sync** — No conflict-free replicated worktree state.
+- **Full #444 IA migration** — This document maps federation terms to the six-layer vocabulary, but it does not implement Workspace/Project/Instance/Bench CRUD, #473 right-rail migration, #428 file RPC, or a Worker tree node.
 
 ## See Also
 

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -274,10 +274,15 @@ POST /hub/nodes/{nodeId}/sessions
 Cookie: token={auth-cookie}
 Content-Type: application/json
 
-{ "type": "agent", "workspacePath": "/Users/kyle/dev/relay-ide", ... }
+{
+  "type": "agent",
+  "repoPath": "/Users/kyle/dev/relay-ide",
+  "worktreePath": "/Users/kyle/dev/relay-ide/.worktrees/444-vocabulary-docs",
+  "cwd": "/Users/kyle/dev/relay-ide/.worktrees/444-vocabulary-docs"
+}
 ```
 
-`workspacePath` is a legacy path field in the current API. In the six-layer model it maps toward the cwd for a Bench; keep the field name for compatibility until the session-create contract is migrated.
+The current node-side `sessions.create` parser reads `repoPath`, `worktreePath`, and `cwd`; it does not read `workspacePath`. Send `cwd` explicitly for remote repo/worktree tabs. If `cwd` is omitted, the node defaults to its host home directory until the #473 create-tab/modal split lands. In the six-layer model, `repoPath` and `worktreePath` remain compatibility fields while `cwd` maps toward the Bench anchor.
 
 Preconditions checked by the hub:
 


### PR DESCRIPTION
## Summary
- Adds a six-layer vocabulary source-of-truth to `docs/ARCHITECTURE.md`: View, Workspace, Project, Instance, Bench, Tab.
- Updates `docs/FRONTEND.md` with tab-context copy/state rules, legacy field boundaries, and first-wave implementation lanes.
- Updates `docs/federated-relay.md` to map repo identity/instance, worktree instance, and `globalSessionId` to Project/Instance/Bench/Tab compatibility terms.

## Migration boundaries
- Keeps `repo`, `worktree`, `session`, `repoPath`, `worktreePath`, and `globalSessionId` where they describe implemented git/process/routing mechanics.
- Calls out Worker/Agent as Bench/Tab decoration: Project = what, Worker = who.
- Explicit non-goals: no dumb repo-wide rename, no full #473 right-rail migration, no #428 file RPC promise, and no Worker tree node.

## The case against
- This is a docs/spec PR, so it can still get ahead of implementation if future workers treat every noun as already shipped UI/data model.
- The docs still mention legacy `/workspaces`, repo dashboards, and worktree operations because those APIs exist today; that could feel uneven until the compatibility adapters and #473 migration land.
- “Bench” and “Instance” are precise but abstract, so UI copy should still prefer host/cwd labels when that is clearer.

## Verification
- `npm exec -- prettier --check docs/ARCHITECTURE.md docs/FRONTEND.md docs/federated-relay.md`
- `npm run check` (passes with 0 errors; existing lint warnings remain)

Refs #444
