### PR TITLE
feat: add hub node security policy schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Relay Agentic Development Environment — a hub/node web workspace for AI coding
 | Review          | `docs/REVIEW_GUIDANCE.md`          | Review agent config, question bank, escape log                              |
 | Deployment      | `docs/references/deployment.md`    | Publishing + branching (nightly/master + tags)                              |
 | Self-hosting    | `docs/SELF_HOSTING.md`             | Build Relay with Relay using isolated dev config/ports/tmux                 |
+| Security policy | `docs/SECURITY_POLICY.md`          | Trust tiers, capability bits, hub ACL defaults, manifest-vs-policy boundary |
 | Hub/node pkg    | `docs/RELAY_HUB_NODE_PACKAGING.md` | Hub vs node command shape, npm package decision, install/update commands    |
 | Node bootstrap  | `docs/RELAY_NODE_BOOTSTRAP.md`     | Pair/install/update/unpair nodes for federated Relay, bootstrap diagnostics |
 | Federated dev   | `docs/FEDERATED_DEV.md`            | Cross-machine dev workflow: synced git checkouts, `dev:node`, version skew  |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,7 +101,7 @@ Keep these names precise where they describe implemented plumbing:
 | `node-manifest.ts`                      | Local node capability manifest: probes platform/arch/hostname/version, WSL, service manager, tmux/git/clipboard/browser/gh/tailscale/ssh, and agent tool availability non-fatally                                                                                  |
 | `local-node.ts`                         | Local node state: identity, manifest, repo inventory, credential storage, and heartbeat sender for the current machine when acting as a node                                                                                                                       |
 | `hub-node-router.ts`                    | Express Router for hub/node REST API: pair tokens, pairing exchange, node heartbeat, node listing, direct session creation routing, node revocation                                                                                                                |
-| `hub-node-registry.ts`                  | Pair-token lifecycle, SHA256-hashed credential storage, timing-safe authentication, heartbeat state tracking, offline/stale/revoked status, registry persistence with debounced writes                                                                             |
+| `hub-node-registry.ts`                  | Pair-token lifecycle, SHA256-hashed credential storage, timing-safe authentication, hub-owned ACL policy/default migration, heartbeat state tracking, offline/stale/revoked status, registry persistence with debounced writes                            |
 | `hub-node-link.ts`                      | Reverse WebSocket link manager: node link registration, RPC request/response, PTY stream proxy between browser and node, node event broadcast, cleanup on disconnect/revocation                                                                                    |
 | `repo-inventory.ts`                     | Local repo inventory collection: workspace scanning, git remote normalization, capability-gated repo identity resolution                                                                                                                                           |
 | `features/repo-inventory.ts`            | Repo inventory feature service: stores node-reported inventory snapshots and aggregates local + remote reports by canonical repo identity                                                                                                                          |
@@ -191,7 +191,7 @@ Planned/deferred, not shipped:
 
 - #428 File RPC (`fs.read`, `fs.list`, `fs.write`, `fs.tail`) remains in spikes/design docs, not source.
 - #476 hub/node log proxy (`logs.tail`, node-log streaming, diagnostic bundles beyond current CLI `node status|logs|doctor`) is not implemented.
-- #427 full trust tiers, two-token confirmation, and audit-log sink are design direction only. Current paired nodes are privileged local users with revocable credentials.
+- #427 trust-tier/capability/ACL schema and legacy defaults are implemented in `shared/security-policy.ts` and `server/hub-node-registry.ts`. Policy evaluator gates, two-token confirmation, credential rotation, and audit-log sink remain deferred.
 - #444 six-layer IA (`View -> Workspace -> Project -> Instance -> Bench -> Tab`) is not the persisted/current backend model.
 
 PTY flow:
@@ -254,7 +254,7 @@ This makes Tab and pane customization (#263) viable without losing process owner
 | `POST`   | `/hub/pair-tokens`                       | Create a short-lived relay-node pair token with redacted-safe SSH/Tailscale/local bootstrap command variants                                        |
 | `POST`   | `/hub/pairing/exchange`                  | Exchange a one-time pair token for a persistent revocable node credential                                                                           |
 | `POST`   | `/hub/node-heartbeat`                    | Authenticated relay-node heartbeat using the persistent node credential                                                                             |
-| `GET`    | `/nodes`                                 | List paired nodes with heartbeat status, reverse-link connection state, and capability summary                                                      |
+| `GET`    | `/nodes`                                 | List paired nodes with heartbeat status, reverse-link connection state, manifest capability summary, and hub-owned ACL policy summary                 |
 | `GET`    | `/hub/repo-inventory`                    | Aggregate local + node-reported repo inventory by canonical git remote identity                                                                     |
 | `POST`   | `/hub/nodes/:nodeId/sessions`            | Route terminal/agent session creation to an online node over reverse-link RPC; RPC body uses `repoPath`, `worktreePath`, and `cwd`                  |
 | `DELETE` | `/hub/nodes/:nodeId/sessions/:sessionId` | Kill a node-local session through reverse-link RPC                                                                                                  |

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This index separates current source-of-truth docs from historical plans and spik
 | Review                | `REVIEW_GUIDANCE.md`          | Reviewer prompts, risk areas, escape log                         |
 | Deployment            | `references/deployment.md`    | Branching, npm channels, publishing flow                         |
 | Self-hosting          | `SELF_HOSTING.md`             | Running Relay from inside Relay with isolated config/ports       |
+| Security policy       | `SECURITY_POLICY.md`          | Trust tiers, capability bits, hub ACL defaults                   |
 | Hub/node packaging    | `RELAY_HUB_NODE_PACKAGING.md` | Hub/node command shape and npm packaging decisions               |
 | Node bootstrap        | `RELAY_NODE_BOOTSTRAP.md`     | Pair/install/update/unpair flows and diagnostics                 |
 | Federated dev         | `FEDERATED_DEV.md`            | Multi-machine dev workflow and version-skew handling             |
@@ -52,6 +53,6 @@ These directories are useful evidence, but they are not current product docs by 
 ## Guardrails for future doc edits
 
 - Evidence first: source files, tests, package scripts, and CLI help beat old plans.
-- Do not overclaim planned work as shipped: especially File RPC, `logs.tail`/node-log proxying, full trust tiers, and the complete six-layer UI/data migration.
+- Do not overclaim planned work as shipped: especially File RPC, `logs.tail`/node-log proxying, #427 evaluator/confirmation/audit/rotation beyond the shipped policy schema/default ACLs, and the complete six-layer UI/data migration.
 - Keep `AGENTS.md` compact; add details here or in focused docs instead.
 - When a historical plan is still linked from a current doc, label it as historical/proposed unless implementation has been verified.

--- a/docs/RELAY_NODE_BOOTSTRAP.md
+++ b/docs/RELAY_NODE_BOOTSTRAP.md
@@ -360,16 +360,20 @@ If you see `NODE_CREDENTIAL_REJECTED`:
 ### Assumptions
 
 - The hub runs on **private infrastructure**: Tailscale, private mesh, or host-restricted network.
-- There is **no multi-tenant SaaS** model. Every paired node is fully trusted.
-- A paired node acts as the **local OS user** on that machine.
+- There is **no multi-tenant SaaS** model; every node still requires explicit pairing and a revocable credential.
+- A paired node acts as the **local OS user** on that machine. The hub ACL constrains Relay protocol surfaces; it does not sandbox the OS user.
 
-### Trust level
+### Trust tiers and default ACL
 
-| Level                   | Description                                                                                                                                 |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `privileged-local-user` | Default for all paired nodes. The node can execute arbitrary shell commands, access local files, and run agent CLIs as the installing user. |
+| Tier | Blast radius |
+| ---- | ------------ |
+| `sandbox` | Experimental/constrained node. Keep grants narrow. |
+| `dev` | Default legacy private-infra node. Read/session-safe bits are granted by migration; destructive bits stay off. |
+| `prod` | Sensitive node. High-risk allowed bits may require confirmation and must never be silently widened. |
 
-This is a privileged trust boundary. Do not pair nodes you do not fully trust. There is no sandboxing or privilege separation beyond the OS user boundary.
+Legacy paired nodes receive a default `dev` ACL on upgrade. Session/read-safe bits are allowed; file write/delete, git write, arbitrary exec, and preview/port-forward remain off unless explicitly granted. Node manifest capabilities are availability probes only, not grants. See `docs/SECURITY_POLICY.md`.
+
+This is a privileged local-user blast radius. Do not pair nodes you do not control.
 
 ### Transport security
 

--- a/docs/SECURITY_POLICY.md
+++ b/docs/SECURITY_POLICY.md
@@ -1,0 +1,39 @@
+# Relay Security Policy Schema
+
+Relay separates node capability discovery from hub-granted policy. A node manifest says what a node appears able to do right now; the hub ACL says what the hub is willing to route to that node. Manifest data is availability/probe evidence, never a grant.
+
+## Trust tiers
+
+Trust tiers describe blast radius. They are not marketing labels and they do not imply safety by themselves.
+
+| Tier | Blast radius |
+| ---- | ------------ |
+| `sandbox` | Experimental or constrained node. Route only narrow read/session-safe operations unless an operator grants more. |
+| `dev` | Default legacy/private-infra node. Read/session-safe operations are allowed by default; destructive file/git/exec/preview surfaces stay off unless granted. |
+| `prod` | Production or sensitive node. A prod overlay may make an otherwise-allowed high-risk bit require confirmation, but it must never turn an off bit or confirmation-required bit into silent allow. |
+
+## Capability bits
+
+Capability bits are a closed, protocol-versioned enum in `shared/security-policy.ts` (`RELAY_SECURITY_POLICY_VERSION = 1.0`). Unknown strings fail closed: they are dropped during ACL normalization and resolve to `deny` when evaluated.
+
+Default legacy grants are intentionally boring:
+
+- allowed: `session:read`, `session:create:terminal`, `session:create:agent`, `session:attach`, `rpc:fs:list`, `rpc:fs:read`, `rpc:fs:tail`, `rpc:git:read`
+- off unless explicitly granted: `rpc:fs:write`, `rpc:fs:delete`, `rpc:git:write`, `pty:exec:arbitrary`, `preview:port-forward`
+
+The schema exists before the full policy evaluator. Current routed surfaces still have their existing route-level checks; this slice adds the policy authority data model and legacy defaults so later gates have a safe source of truth.
+
+## Hub ACL authority
+
+Hub ACL state is stored with the node registry record. Each ACL can express:
+
+- peer identity: node id, credential id, display name
+- node tier: `sandbox | dev | prod`
+- allowed bits and confirmation-required bits
+- scope: node/workspace/repo/path scope metadata
+- version/ref: schema version, policy version, ACL ref
+- lifecycle metadata: created/updated, revocation, supersession
+
+On upgrade, legacy paired-node records with no ACL are migrated to a default `dev` ACL before `/nodes` summaries or authenticated credential paths return the node. The migration is persisted back to the hub registry file.
+
+Node manifests remain separate. If a node reports `git` as available, that does not grant `rpc:git:write`; if it reports `git` as unavailable, the hub ACL still records whether the policy would allow read/git operations once the capability exists. The policy evaluator must combine both facts later: capability available AND ACL grant.

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -33,7 +33,7 @@ Planned/deferred:
 
 - #428 File RPC (`fs.read`, `fs.list`, `fs.write`, `fs.tail`) is not implemented in source; current mentions live in spikes/design docs.
 - #476 node-log proxy / `logs.tail` / downloadable diagnostic bundles are not implemented. Current CLI diagnostics are `relay-ide node status`, `node logs`, and `node doctor`.
-- #427 full trust tiers, two-token confirmation, and audit-log sink are not implemented. Current security model is explicit pairing + revocable node credential + private-infra trust.
+- #427 policy schema/default ACLs are implemented; policy evaluator gates, two-token confirmation, audit sink, and credential rotation are not implemented.
 - #444 six-layer IA is product direction, not the persisted backend model in this doc.
 
 ## Hub/Node/Client Terminology
@@ -483,14 +483,20 @@ All diagnostics redact secrets (pair tokens, bearer headers, credentials) before
 ### Assumptions
 
 - The hub runs on **private infrastructure**: Tailscale, private mesh, or a host-restricted network.
-- There is **no multi-tenant SaaS** model. Every paired node is fully trusted.
-- A paired node acts as the **local OS user** on that machine. This is a privileged trust boundary.
+- There is **no multi-tenant SaaS** model; every node still requires explicit pairing and a revocable credential.
+- A paired node acts as the **local OS user** on that machine, so the blast radius is the node user's file/process/network access. The hub ACL limits which Relay protocol surfaces are routed; it is not OS sandboxing.
 
-### Trust Levels
+### Trust Tiers and ACL Policy
 
-| Level                   | Description                                                                                                                                 |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `privileged-local-user` | Default for all paired nodes. The node can execute arbitrary shell commands, access local files, and run agent CLIs as the installing user. |
+Trust tiers describe blast radius, not vague safety:
+
+| Tier | Blast radius |
+| ---- | ------------ |
+| `sandbox` | Experimental/constrained node. Keep grants narrow. |
+| `dev` | Default legacy private-infra node. Read/session-safe bits are granted by migration; destructive bits stay off. |
+| `prod` | Sensitive node. High-risk allowed bits may be elevated to confirmation-required, never silently widened. |
+
+The hub owns ACL policy. Node manifests report availability/probe data only — e.g. `git` availability says whether the node can run git, not whether `rpc:git:write` is granted. Legacy paired nodes are migrated to a default `dev` ACL with session/read bits on and file write/delete, git write, arbitrary exec, and preview/port-forward off unless explicitly granted. See `docs/SECURITY_POLICY.md` and `shared/security-policy.ts`.
 
 ### Transport Security
 

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -18,7 +18,10 @@ import {
   type RelayNodeErrorCode,
 } from '../shared/relay-node-protocol.js';
 import {
+  RELAY_SECURITY_POLICY_VERSION,
   createLegacyDefaultNodeAcl,
+  isRelayCapabilityBit,
+  isRelayTrustTier,
   normalizeNodeAcl,
   summarizeAcl,
   type RelayNodeAcl,
@@ -230,8 +233,44 @@ function ensureNodeAcl(node: StoredNodeRecord): RelayNodeAcl {
   return node.acl;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKnownCapabilityBits(value: unknown): boolean {
+  return Array.isArray(value) && value.every((item) => isRelayCapabilityBit(item));
+}
+
+function nodeNeedsAclMigration(node: StoredNodeRecord): boolean {
+  const acl = node.acl as unknown;
+  if (!isRecord(acl)) return true;
+
+  const peer = acl['peer'];
+  const aclNode = acl['node'];
+  const grants = acl['grants'];
+  const lifecycle = acl['lifecycle'];
+
+  if (acl['schemaVersion'] !== 1) return true;
+  if (acl['policyVersion'] !== RELAY_SECURITY_POLICY_VERSION) return true;
+  if (typeof acl['ref'] !== 'string') return true;
+  if (!isRecord(peer) || peer['kind'] !== 'node') return true;
+  if (peer['nodeId'] !== node.nodeId) return true;
+  if (node.credentialId && peer['credentialId'] !== node.credentialId) {
+    return true;
+  }
+  if (!isRecord(aclNode) || aclNode['nodeId'] !== node.nodeId) return true;
+  if (!isRelayTrustTier(aclNode['trustTier'])) return true;
+  if (!isRecord(grants)) return true;
+  if (!hasOnlyKnownCapabilityBits(grants['allowed'])) return true;
+  if (!hasOnlyKnownCapabilityBits(grants['requiresConfirmation'])) return true;
+  if (!isRecord(lifecycle)) return true;
+  if (typeof lifecycle['createdAt'] !== 'string') return true;
+  if (typeof lifecycle['updatedAt'] !== 'string') return true;
+  return false;
+}
+
 function registryNeedsAclMigration(registry: RegistryFile): boolean {
-  return registry.nodes.some((node) => node.acl === undefined);
+  return registry.nodes.some((node) => nodeNeedsAclMigration(node));
 }
 
 function readRegistryFile(storagePath: string): RegistryFile {

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -17,6 +17,12 @@ import {
   type RelayNodeError,
   type RelayNodeErrorCode,
 } from '../shared/relay-node-protocol.js';
+import {
+  createLegacyDefaultNodeAcl,
+  normalizeNodeAcl,
+  summarizeAcl,
+  type RelayNodeAcl,
+} from '../shared/security-policy.js';
 
 const logger = createLogger('hub-node-registry');
 const REVERSE_LINK_ROUTE = 'reverse-link' as const;
@@ -43,6 +49,7 @@ interface StoredNodeRecord {
   relayVersion: string;
   protocolVersion: string;
   capabilities: NodeCapabilityManifestSummary;
+  acl?: RelayNodeAcl;
   repoInventory?: unknown;
   createdAt: string;
   pairedAt: string;
@@ -96,7 +103,7 @@ export const DEFAULT_NODE_HEARTBEAT_TIMEOUTS = {
 } as const;
 export const DEFAULT_HEARTBEAT_PERSIST_DEBOUNCE_MS = 5 * 1000;
 const PRIVILEGED_NODE_WARNING =
-  'A paired Relay node is trusted to act as the local OS user on that machine.';
+  'A paired Relay node runs with that machine\'s local OS-user blast radius; hub ACL policy grants individual capability bits.';
 
 export type CredentialAuthResult =
   | { ok: true; node: HubNodeSummary }
@@ -204,6 +211,29 @@ function nodeDisplayName(
   return trimmed || manifest.hostname;
 }
 
+function fallbackAclInput(node: StoredNodeRecord): {
+  nodeId: string;
+  credentialId?: string;
+  displayName?: string;
+  createdAt: string;
+} {
+  return {
+    nodeId: node.nodeId,
+    credentialId: node.credentialId,
+    displayName: node.displayName,
+    createdAt: node.pairedAt || node.createdAt,
+  };
+}
+
+function ensureNodeAcl(node: StoredNodeRecord): RelayNodeAcl {
+  node.acl = normalizeNodeAcl(node.acl, fallbackAclInput(node));
+  return node.acl;
+}
+
+function registryNeedsAclMigration(registry: RegistryFile): boolean {
+  return registry.nodes.some((node) => node.acl === undefined);
+}
+
 function readRegistryFile(storagePath: string): RegistryFile {
   try {
     const parsed = JSON.parse(
@@ -297,6 +327,8 @@ function publicNode(
   node: StoredNodeRecord,
   status: HubNodeStatus
 ): HubNodeSummary {
+  const acl = ensureNodeAcl(node);
+  const aclSummary = summarizeAcl(acl);
   return {
     nodeId: node.nodeId,
     displayName: node.displayName,
@@ -309,9 +341,11 @@ function publicNode(
     status,
     connection: connectionSummary(status),
     trust: {
-      state: node.revokedAt ? 'revoked' : 'trusted',
-      level: 'privileged-local-user',
+      state: node.revokedAt ? 'revoked' : 'active',
+      level: aclSummary.trustTier,
+      tier: aclSummary.trustTier,
       warning: PRIVILEGED_NODE_WARNING,
+      policy: aclSummary,
     },
     credentialState: node.revokedAt ? 'revoked' : 'active',
     version: {
@@ -361,6 +395,9 @@ export class HubNodeRegistry {
       options.heartbeatPersistDebounceMs ??
       DEFAULT_HEARTBEAT_PERSIST_DEBOUNCE_MS;
     this.state = readRegistryFile(options.storagePath);
+    const needsAclMigration = registryNeedsAclMigration(this.state);
+    for (const node of this.state.nodes) ensureNodeAcl(node);
+    if (needsAclMigration) writeRegistryFile(this.storagePath, this.state);
   }
 
   setNowForTest(now: () => Date): void {
@@ -447,6 +484,15 @@ export class HubNodeRegistry {
       relayVersion: input.manifest.relayVersion,
       protocolVersion,
       capabilities: summarizeCapabilities(input.manifest),
+      acl: createLegacyDefaultNodeAcl({
+        nodeId,
+        credentialId,
+        displayName: nodeDisplayName(
+          input.displayName ?? pairToken.displayName,
+          input.manifest
+        ),
+        createdAt: timestamp,
+      }),
       createdAt: timestamp,
       pairedAt: timestamp,
       lastSeenAt: timestamp,

--- a/shared/relay-node-protocol.ts
+++ b/shared/relay-node-protocol.ts
@@ -1,3 +1,5 @@
+import type { RelayAclSummary, RelayTrustTier } from './security-policy.js';
+
 export const RELAY_NODE_LINK_PROTOCOL = 'relay-node-link' as const;
 export const RELAY_NODE_LINK_PROTOCOL_VERSION = '1.0' as const;
 
@@ -52,8 +54,8 @@ export interface RelayNodeCredential {
 
 export type HubNodeStatus = 'online' | 'stale' | 'offline' | 'revoked';
 export type HubNodeCredentialState = 'active' | 'revoked';
-export type HubNodeTrustState = 'trusted' | 'revoked';
-export type HubNodeTrustLevel = 'privileged-local-user';
+export type HubNodeTrustState = 'active' | 'trusted' | 'paired' | 'revoked';
+export type HubNodeTrustLevel = RelayTrustTier | 'privileged-local-user' | 'standard';
 export type HubNodeVersionState =
   | 'compatible'
   | 'version-skew'
@@ -128,7 +130,9 @@ export interface HubNodeSummary {
   trust: {
     state: HubNodeTrustState;
     level: HubNodeTrustLevel;
-    warning: string;
+    tier?: RelayTrustTier;
+    warning?: string;
+    policy?: RelayAclSummary;
   };
   credentialState: HubNodeCredentialState;
   version: {

--- a/shared/security-policy.ts
+++ b/shared/security-policy.ts
@@ -260,7 +260,6 @@ function normalizeScope(value: unknown): RelayPolicyScope {
   };
 }
 
-// eslint-disable-next-line complexity -- ACL migration normalizes untrusted legacy JSON at the registry boundary.
 export function normalizeNodeAcl(
   value: unknown,
   fallback: {
@@ -318,13 +317,8 @@ export function normalizeNodeAcl(
         : `acl:${fallback.nodeId}:${RELAY_SECURITY_POLICY_VERSION}`,
     peer: {
       kind: 'node',
-      nodeId:
-        typeof peer['nodeId'] === 'string' ? peer['nodeId'] : fallback.nodeId,
-      ...(typeof peer['credentialId'] === 'string'
-        ? { credentialId: peer['credentialId'] }
-        : fallback.credentialId
-          ? { credentialId: fallback.credentialId }
-          : {}),
+      nodeId: fallback.nodeId,
+      ...(fallback.credentialId ? { credentialId: fallback.credentialId } : {}),
       ...(typeof peer['displayName'] === 'string'
         ? { displayName: peer['displayName'] }
         : fallback.displayName
@@ -332,8 +326,7 @@ export function normalizeNodeAcl(
           : {}),
     },
     node: {
-      nodeId:
-        typeof node['nodeId'] === 'string' ? node['nodeId'] : fallback.nodeId,
+      nodeId: fallback.nodeId,
       trustTier,
     },
     grants: {

--- a/shared/security-policy.ts
+++ b/shared/security-policy.ts
@@ -1,0 +1,366 @@
+export const RELAY_SECURITY_POLICY_VERSION = '1.0' as const;
+
+export type RelayTrustTier = 'sandbox' | 'dev' | 'prod';
+
+export const RELAY_CAPABILITY_BITS = [
+  'session:read',
+  'session:create:terminal',
+  'session:create:agent',
+  'session:attach',
+  'rpc:fs:list',
+  'rpc:fs:read',
+  'rpc:fs:tail',
+  'rpc:fs:write',
+  'rpc:fs:delete',
+  'rpc:git:read',
+  'rpc:git:write',
+  'pty:exec:arbitrary',
+  'preview:port-forward',
+] as const;
+
+export type RelayCapabilityBit = (typeof RELAY_CAPABILITY_BITS)[number];
+
+export type RelayCapabilityDecision =
+  | 'allow'
+  | 'requiresConfirmation'
+  | 'deny';
+
+export const LEGACY_DEFAULT_ALLOWED_CAPABILITIES = [
+  'session:read',
+  'session:create:terminal',
+  'session:create:agent',
+  'session:attach',
+  'rpc:fs:list',
+  'rpc:fs:read',
+  'rpc:fs:tail',
+  'rpc:git:read',
+] as const satisfies readonly RelayCapabilityBit[];
+
+export const HIGH_RISK_CAPABILITIES = [
+  'rpc:fs:write',
+  'rpc:fs:delete',
+  'rpc:git:write',
+  'pty:exec:arbitrary',
+  'preview:port-forward',
+] as const satisfies readonly RelayCapabilityBit[];
+
+const RELAY_CAPABILITY_SET = new Set<string>(RELAY_CAPABILITY_BITS);
+const HIGH_RISK_CAPABILITY_SET = new Set<RelayCapabilityBit>(
+  HIGH_RISK_CAPABILITIES
+);
+
+export interface RelayPolicyScope {
+  kind: 'node' | 'workspace' | 'repo' | 'path';
+  workspaceIds?: string[];
+  repoIds?: string[];
+  pathPrefixes?: string[];
+}
+
+export interface RelayAclPeerIdentity {
+  kind: 'node';
+  nodeId: string;
+  credentialId?: string;
+  displayName?: string;
+}
+
+export interface RelayAclGrant {
+  allowed: RelayCapabilityBit[];
+  requiresConfirmation: RelayCapabilityBit[];
+}
+
+export interface RelayAclLifecycle {
+  createdAt: string;
+  updatedAt: string;
+  revokedAt?: string;
+  revokedBy?: string;
+  revocationReason?: string;
+  supersedes?: string;
+  supersededBy?: string;
+}
+
+export interface RelayNodeAcl {
+  schemaVersion: 1;
+  policyVersion: typeof RELAY_SECURITY_POLICY_VERSION;
+  ref: string;
+  peer: RelayAclPeerIdentity;
+  node: {
+    nodeId: string;
+    trustTier: RelayTrustTier;
+  };
+  grants: RelayAclGrant;
+  scope: RelayPolicyScope;
+  lifecycle: RelayAclLifecycle;
+}
+
+export interface RelayAclCapabilityResolution {
+  decision: RelayCapabilityDecision;
+  known: boolean;
+  capability: string;
+}
+
+export interface RelayAclSummary {
+  policyVersion: typeof RELAY_SECURITY_POLICY_VERSION;
+  ref: string;
+  trustTier: RelayTrustTier;
+  allowed: RelayCapabilityBit[];
+  requiresConfirmation: RelayCapabilityBit[];
+  scope: RelayPolicyScope;
+  revokedAt?: string;
+  supersededBy?: string;
+}
+
+export function isRelayTrustTier(value: unknown): value is RelayTrustTier {
+  return value === 'sandbox' || value === 'dev' || value === 'prod';
+}
+
+export function isRelayCapabilityBit(value: unknown): value is RelayCapabilityBit {
+  return typeof value === 'string' && RELAY_CAPABILITY_SET.has(value);
+}
+
+export function normalizeCapabilityBits(values: unknown): RelayCapabilityBit[] {
+  if (!Array.isArray(values)) return [];
+  const normalized: RelayCapabilityBit[] = [];
+  const seen = new Set<RelayCapabilityBit>();
+  for (const value of values) {
+    if (!isRelayCapabilityBit(value) || seen.has(value)) continue;
+    seen.add(value);
+    normalized.push(value);
+  }
+  return normalized;
+}
+
+export function createLegacyDefaultNodeAcl(input: {
+  nodeId: string;
+  credentialId?: string;
+  displayName?: string;
+  trustTier?: RelayTrustTier;
+  createdAt: string;
+  supersedes?: string;
+}): RelayNodeAcl {
+  const trustTier = input.trustTier ?? 'dev';
+  const ref = `acl:${input.nodeId}:${RELAY_SECURITY_POLICY_VERSION}`;
+  return applyTrustTierOverlay({
+    schemaVersion: 1,
+    policyVersion: RELAY_SECURITY_POLICY_VERSION,
+    ref,
+    peer: {
+      kind: 'node',
+      nodeId: input.nodeId,
+      ...(input.credentialId ? { credentialId: input.credentialId } : {}),
+      ...(input.displayName ? { displayName: input.displayName } : {}),
+    },
+    node: {
+      nodeId: input.nodeId,
+      trustTier,
+    },
+    grants: {
+      allowed: [...LEGACY_DEFAULT_ALLOWED_CAPABILITIES],
+      requiresConfirmation: [],
+    },
+    scope: { kind: 'node' },
+    lifecycle: {
+      createdAt: input.createdAt,
+      updatedAt: input.createdAt,
+      ...(input.supersedes ? { supersedes: input.supersedes } : {}),
+    },
+  });
+}
+
+export function applyTrustTierOverlay(acl: RelayNodeAcl): RelayNodeAcl {
+  const allowed = normalizeCapabilityBits(acl.grants.allowed);
+  const requiresConfirmation = normalizeCapabilityBits(
+    acl.grants.requiresConfirmation
+  );
+  const required = new Set<RelayCapabilityBit>(requiresConfirmation);
+  const silentAllowed: RelayCapabilityBit[] = [];
+
+  for (const capability of allowed) {
+    if (required.has(capability)) continue;
+    if (
+      acl.node.trustTier === 'prod' &&
+      HIGH_RISK_CAPABILITY_SET.has(capability)
+    ) {
+      required.add(capability);
+      continue;
+    }
+    silentAllowed.push(capability);
+  }
+
+  return {
+    ...acl,
+    grants: {
+      allowed: silentAllowed,
+      requiresConfirmation: Array.from(required),
+    },
+  };
+}
+
+export function resolveAclCapability(
+  acl: RelayNodeAcl,
+  capability: string
+): RelayAclCapabilityResolution {
+  if (!isRelayCapabilityBit(capability)) {
+    return { decision: 'deny', known: false, capability };
+  }
+  const effectiveAcl = applyTrustTierOverlay(acl);
+  if (effectiveAcl.lifecycle.revokedAt) {
+    return { decision: 'deny', known: true, capability };
+  }
+  if (effectiveAcl.grants.requiresConfirmation.includes(capability)) {
+    return { decision: 'requiresConfirmation', known: true, capability };
+  }
+  if (effectiveAcl.grants.allowed.includes(capability)) {
+    return { decision: 'allow', known: true, capability };
+  }
+  return { decision: 'deny', known: true, capability };
+}
+
+export function summarizeAcl(acl: RelayNodeAcl): RelayAclSummary {
+  const effectiveAcl = applyTrustTierOverlay(acl);
+  return {
+    policyVersion: effectiveAcl.policyVersion,
+    ref: effectiveAcl.ref,
+    trustTier: effectiveAcl.node.trustTier,
+    allowed: [...effectiveAcl.grants.allowed],
+    requiresConfirmation: [...effectiveAcl.grants.requiresConfirmation],
+    scope: effectiveAcl.scope,
+    ...(effectiveAcl.lifecycle.revokedAt
+      ? { revokedAt: effectiveAcl.lifecycle.revokedAt }
+      : {}),
+    ...(effectiveAcl.lifecycle.supersededBy
+      ? { supersededBy: effectiveAcl.lifecycle.supersededBy }
+      : {}),
+  };
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function normalizeScope(value: unknown): RelayPolicyScope {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return { kind: 'node' };
+  }
+  const record = value as Record<string, unknown>;
+  const kind =
+    record['kind'] === 'workspace' ||
+    record['kind'] === 'repo' ||
+    record['kind'] === 'path'
+      ? record['kind']
+      : 'node';
+  return {
+    kind,
+    ...(isStringArray(record['workspaceIds'])
+      ? { workspaceIds: record['workspaceIds'] }
+      : {}),
+    ...(isStringArray(record['repoIds']) ? { repoIds: record['repoIds'] } : {}),
+    ...(isStringArray(record['pathPrefixes'])
+      ? { pathPrefixes: record['pathPrefixes'] }
+      : {}),
+  };
+}
+
+// eslint-disable-next-line complexity -- ACL migration normalizes untrusted legacy JSON at the registry boundary.
+export function normalizeNodeAcl(
+  value: unknown,
+  fallback: {
+    nodeId: string;
+    credentialId?: string;
+    displayName?: string;
+    createdAt: string;
+  }
+): RelayNodeAcl {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return createLegacyDefaultNodeAcl(fallback);
+  }
+  const record = value as Record<string, unknown>;
+  const node =
+    typeof record['node'] === 'object' &&
+    record['node'] !== null &&
+    !Array.isArray(record['node'])
+      ? (record['node'] as Record<string, unknown>)
+      : {};
+  const peer =
+    typeof record['peer'] === 'object' &&
+    record['peer'] !== null &&
+    !Array.isArray(record['peer'])
+      ? (record['peer'] as Record<string, unknown>)
+      : {};
+  const grants =
+    typeof record['grants'] === 'object' &&
+    record['grants'] !== null &&
+    !Array.isArray(record['grants'])
+      ? (record['grants'] as Record<string, unknown>)
+      : {};
+  const lifecycle =
+    typeof record['lifecycle'] === 'object' &&
+    record['lifecycle'] !== null &&
+    !Array.isArray(record['lifecycle'])
+      ? (record['lifecycle'] as Record<string, unknown>)
+      : {};
+
+  const trustTier = isRelayTrustTier(node['trustTier'])
+    ? node['trustTier']
+    : 'dev';
+  const createdAt =
+    typeof lifecycle['createdAt'] === 'string'
+      ? lifecycle['createdAt']
+      : fallback.createdAt;
+  const updatedAt =
+    typeof lifecycle['updatedAt'] === 'string' ? lifecycle['updatedAt'] : createdAt;
+
+  return applyTrustTierOverlay({
+    schemaVersion: 1,
+    policyVersion: RELAY_SECURITY_POLICY_VERSION,
+    ref:
+      typeof record['ref'] === 'string'
+        ? record['ref']
+        : `acl:${fallback.nodeId}:${RELAY_SECURITY_POLICY_VERSION}`,
+    peer: {
+      kind: 'node',
+      nodeId:
+        typeof peer['nodeId'] === 'string' ? peer['nodeId'] : fallback.nodeId,
+      ...(typeof peer['credentialId'] === 'string'
+        ? { credentialId: peer['credentialId'] }
+        : fallback.credentialId
+          ? { credentialId: fallback.credentialId }
+          : {}),
+      ...(typeof peer['displayName'] === 'string'
+        ? { displayName: peer['displayName'] }
+        : fallback.displayName
+          ? { displayName: fallback.displayName }
+          : {}),
+    },
+    node: {
+      nodeId:
+        typeof node['nodeId'] === 'string' ? node['nodeId'] : fallback.nodeId,
+      trustTier,
+    },
+    grants: {
+      allowed: normalizeCapabilityBits(grants['allowed']),
+      requiresConfirmation: normalizeCapabilityBits(
+        grants['requiresConfirmation']
+      ),
+    },
+    scope: normalizeScope(record['scope']),
+    lifecycle: {
+      createdAt,
+      updatedAt,
+      ...(typeof lifecycle['revokedAt'] === 'string'
+        ? { revokedAt: lifecycle['revokedAt'] }
+        : {}),
+      ...(typeof lifecycle['revokedBy'] === 'string'
+        ? { revokedBy: lifecycle['revokedBy'] }
+        : {}),
+      ...(typeof lifecycle['revocationReason'] === 'string'
+        ? { revocationReason: lifecycle['revocationReason'] }
+        : {}),
+      ...(typeof lifecycle['supersedes'] === 'string'
+        ? { supersedes: lifecycle['supersedes'] }
+        : {}),
+      ...(typeof lifecycle['supersededBy'] === 'string'
+        ? { supersededBy: lifecycle['supersededBy'] }
+        : {}),
+    },
+  });
+}

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -197,9 +197,22 @@ describe('hub node registry', () => {
         protocolVersion: '1.0',
         status: 'online',
         trust: {
-          state: 'trusted',
-          level: 'privileged-local-user',
-          warning: expect.stringContaining('local OS user'),
+          state: 'active',
+          level: 'dev',
+          tier: 'dev',
+          warning: expect.stringContaining('blast radius'),
+          policy: {
+            policyVersion: '1.0',
+            trustTier: 'dev',
+            allowed: expect.arrayContaining([
+              'session:create:terminal',
+              'session:create:agent',
+              'session:attach',
+              'rpc:fs:read',
+              'rpc:git:read',
+            ]),
+            requiresConfirmation: [],
+          },
         },
         credentialState: 'active',
         version: {
@@ -225,6 +238,21 @@ describe('hub node registry', () => {
       expect(persisted).not.toContain(exchanged.credential.token);
       expect(persisted).not.toContain(
         exchanged.credential.token.split('.')[1]!
+      );
+      const parsed = JSON.parse(persisted) as {
+        nodes: Array<{ acl?: { grants?: { allowed?: string[] } } }>;
+      };
+      expect(parsed.nodes[0]?.acl?.grants?.allowed).toEqual(
+        expect.arrayContaining(['session:read', 'rpc:fs:read'])
+      );
+      expect(parsed.nodes[0]?.acl?.grants?.allowed).not.toEqual(
+        expect.arrayContaining([
+          'rpc:fs:write',
+          'rpc:fs:delete',
+          'rpc:git:write',
+          'pty:exec:arbitrary',
+          'preview:port-forward',
+        ])
       );
     });
   });
@@ -261,6 +289,123 @@ describe('hub node registry', () => {
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+
+  it('migrates legacy paired nodes to hub-owned default ACL before summaries are returned', () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-hub-node-registry-')
+    );
+    const storagePath = path.join(tmpDir, 'nodes.json');
+    try {
+      fs.writeFileSync(
+        storagePath,
+        JSON.stringify({
+          schemaVersion: 1,
+          pairTokens: [],
+          nodes: [
+            {
+              nodeId: 'node_legacy',
+              credentialId: 'cred_legacy',
+              credentialHash: '0'.repeat(64),
+              displayName: 'Legacy node',
+              hostname: 'legacy-host',
+              platform: 'darwin',
+              arch: 'arm64',
+              relayVersion: '0.1.0',
+              protocolVersion: '1.0',
+              capabilities: {
+                totals: {
+                  available: 0,
+                  degraded: 0,
+                  unavailable: 0,
+                  unknown: 0,
+                },
+                agents: {},
+                serviceManager: 'manual',
+                wsl: false,
+              },
+              createdAt: '2026-01-01T00:00:00.000Z',
+              pairedAt: '2026-01-01T00:00:00.000Z',
+              lastSeenAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        })
+      );
+
+      const registry = createHubNodeRegistry({
+        storagePath,
+        now: () => new Date('2026-01-02T03:04:05.000Z'),
+      });
+      const node = registry.listNodes()[0];
+
+      expect(node?.trust).toMatchObject({
+        state: 'active',
+        level: 'dev',
+        tier: 'dev',
+        policy: {
+          policyVersion: '1.0',
+          ref: 'acl:node_legacy:1.0',
+          trustTier: 'dev',
+          allowed: expect.arrayContaining([
+            'session:read',
+            'session:create:terminal',
+            'rpc:fs:read',
+            'rpc:git:read',
+          ]),
+          requiresConfirmation: [],
+        },
+      });
+      expect(node?.trust.policy.allowed).not.toEqual(
+        expect.arrayContaining([
+          'rpc:fs:write',
+          'rpc:fs:delete',
+          'rpc:git:write',
+          'pty:exec:arbitrary',
+          'preview:port-forward',
+        ])
+      );
+
+      const migrated = JSON.parse(fs.readFileSync(storagePath, 'utf8')) as {
+        nodes: Array<{ acl?: unknown }>;
+      };
+      expect(migrated.nodes[0]?.acl).toBeDefined();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps node manifest availability separate from hub ACL grants', () => {
+    withTmpRegistry((registry) => {
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      registry.recordHeartbeat({
+        nodeId: exchanged.node.nodeId,
+        protocolVersion: '1.0',
+        manifest: manifest({
+          capabilities: {
+            ...manifest().capabilities,
+            git: {
+              id: 'git',
+              label: 'Git',
+              status: 'unavailable',
+              message: 'not installed',
+            },
+          },
+        }),
+      });
+
+      const node = registry.listNodes()[0];
+
+      expect(node?.capabilities.core.git).toBe('unavailable');
+      expect(node?.trust.policy.allowed).toEqual(
+        expect.arrayContaining(['rpc:git:read'])
+      );
+      expect(node?.trust.policy.allowed).not.toEqual(
+        expect.arrayContaining(['rpc:git:write'])
+      );
+    });
   });
 
   it('quarantines corrupt registry JSON and starts with empty replacement state', () => {
@@ -460,8 +605,9 @@ describe('hub node registry', () => {
         credentialState: 'revoked',
         trust: {
           state: 'revoked',
-          level: 'privileged-local-user',
-          warning: expect.stringContaining('local OS user'),
+          level: 'dev',
+          tier: 'dev',
+          warning: expect.stringContaining('blast radius'),
         },
       });
       expect(registry.listNodes()[0]).toMatchObject({

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -245,15 +245,15 @@ describe('hub node registry', () => {
       expect(parsed.nodes[0]?.acl?.grants?.allowed).toEqual(
         expect.arrayContaining(['session:read', 'rpc:fs:read'])
       );
-      expect(parsed.nodes[0]?.acl?.grants?.allowed).not.toEqual(
-        expect.arrayContaining([
-          'rpc:fs:write',
-          'rpc:fs:delete',
-          'rpc:git:write',
-          'pty:exec:arbitrary',
-          'preview:port-forward',
-        ])
-      );
+      for (const forbidden of [
+        'rpc:fs:write',
+        'rpc:fs:delete',
+        'rpc:git:write',
+        'pty:exec:arbitrary',
+        'preview:port-forward',
+      ]) {
+        expect(parsed.nodes[0]?.acl?.grants?.allowed).not.toContain(forbidden);
+      }
     });
   });
 
@@ -328,6 +328,74 @@ describe('hub node registry', () => {
               pairedAt: '2026-01-01T00:00:00.000Z',
               lastSeenAt: '2026-01-01T00:00:00.000Z',
             },
+            {
+              nodeId: 'node_null_acl',
+              credentialId: 'cred_null_acl',
+              credentialHash: '1'.repeat(64),
+              displayName: 'Null ACL node',
+              hostname: 'null-acl-host',
+              platform: 'darwin',
+              arch: 'arm64',
+              relayVersion: '0.1.0',
+              protocolVersion: '1.0',
+              capabilities: {
+                totals: {
+                  available: 0,
+                  degraded: 0,
+                  unavailable: 0,
+                  unknown: 0,
+                },
+                agents: {},
+                serviceManager: 'manual',
+                wsl: false,
+              },
+              acl: null,
+              createdAt: '2026-01-01T00:00:00.000Z',
+              pairedAt: '2026-01-01T00:00:00.000Z',
+              lastSeenAt: '2026-01-01T00:00:00.000Z',
+            },
+            {
+              nodeId: 'node_drifted_acl',
+              credentialId: 'cred_drifted_acl',
+              credentialHash: '2'.repeat(64),
+              displayName: 'Drifted ACL node',
+              hostname: 'drifted-acl-host',
+              platform: 'darwin',
+              arch: 'arm64',
+              relayVersion: '0.1.0',
+              protocolVersion: '1.0',
+              capabilities: {
+                totals: {
+                  available: 0,
+                  degraded: 0,
+                  unavailable: 0,
+                  unknown: 0,
+                },
+                agents: {},
+                serviceManager: 'manual',
+                wsl: false,
+              },
+              acl: {
+                schemaVersion: 1,
+                policyVersion: '1.0',
+                ref: 'acl:other-node:1.0',
+                peer: {
+                  kind: 'node',
+                  nodeId: 'other-node',
+                  credentialId: 'other-credential',
+                },
+                node: { nodeId: 'other-node', trustTier: 'dev' },
+                grants: { allowed: ['session:read'], requiresConfirmation: [] },
+                scope: { kind: 'node' },
+                lifecycle: {
+                  createdAt: '2026-01-01T00:00:00.000Z',
+                  updatedAt: '2026-01-01T00:00:00.000Z',
+                },
+              },
+              createdAt: '2026-01-01T00:00:00.000Z',
+              pairedAt: '2026-01-01T00:00:00.000Z',
+              lastSeenAt: '2026-01-01T00:00:00.000Z',
+            },
           ],
         })
       );
@@ -355,20 +423,34 @@ describe('hub node registry', () => {
           requiresConfirmation: [],
         },
       });
-      expect(node?.trust.policy.allowed).not.toEqual(
-        expect.arrayContaining([
-          'rpc:fs:write',
-          'rpc:fs:delete',
-          'rpc:git:write',
-          'pty:exec:arbitrary',
-          'preview:port-forward',
-        ])
-      );
+      for (const forbidden of [
+        'rpc:fs:write',
+        'rpc:fs:delete',
+        'rpc:git:write',
+        'pty:exec:arbitrary',
+        'preview:port-forward',
+      ]) {
+        expect(node?.trust.policy.allowed).not.toContain(forbidden);
+      }
 
       const migrated = JSON.parse(fs.readFileSync(storagePath, 'utf8')) as {
-        nodes: Array<{ acl?: unknown }>;
+        nodes: Array<{
+          nodeId: string;
+          credentialId: string;
+          acl?: {
+            peer?: { nodeId?: string; credentialId?: string };
+            node?: { nodeId?: string };
+          };
+        }>;
       };
-      expect(migrated.nodes[0]?.acl).toBeDefined();
+      for (const migratedNode of migrated.nodes) {
+        expect(migratedNode.acl).toBeDefined();
+        expect(migratedNode.acl?.peer?.nodeId).toBe(migratedNode.nodeId);
+        expect(migratedNode.acl?.node?.nodeId).toBe(migratedNode.nodeId);
+        expect(migratedNode.acl?.peer?.credentialId).toBe(
+          migratedNode.credentialId
+        );
+      }
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -402,9 +484,7 @@ describe('hub node registry', () => {
       expect(node?.trust.policy.allowed).toEqual(
         expect.arrayContaining(['rpc:git:read'])
       );
-      expect(node?.trust.policy.allowed).not.toEqual(
-        expect.arrayContaining(['rpc:git:write'])
-      );
+      expect(node?.trust.policy.allowed).not.toContain('rpc:git:write');
     });
   });
 

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -408,8 +408,9 @@ describe('hub node routes and link', () => {
     expect(nodesRes.status).toBe(200);
     const nodesBody = await nodesRes.text();
     expect(nodesBody).toContain('0.1.1-test');
-    expect(nodesBody).toContain('privileged-local-user');
-    expect(nodesBody).toContain('local OS user');
+    expect(nodesBody).toContain('"tier":"dev"');
+    expect(nodesBody).toContain('"policyVersion":"1.0"');
+    expect(nodesBody).toContain('blast radius');
     expect(nodesBody).not.toContain(pair.pairToken);
     expect(nodesBody).not.toContain(exchange.credential.token);
 
@@ -423,7 +424,7 @@ describe('hub node routes and link', () => {
         nodeId: exchange.node.nodeId,
         status: 'revoked',
         credentialState: 'revoked',
-        trust: { state: 'revoked', level: 'privileged-local-user' },
+        trust: { state: 'revoked', level: 'dev', tier: 'dev' },
       },
     });
 

--- a/test/security-policy.test.ts
+++ b/test/security-policy.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyTrustTierOverlay,
+  createLegacyDefaultNodeAcl,
+  isRelayCapabilityBit,
+  resolveAclCapability,
+  type RelayNodeAcl,
+} from '../shared/security-policy.js';
+
+describe('security policy schema', () => {
+  it('treats the capability enum as closed and fails unknown bits closed', () => {
+    const acl = createLegacyDefaultNodeAcl({
+      nodeId: 'node_1',
+      credentialId: 'cred_1',
+      createdAt: '2026-01-02T03:04:05.000Z',
+    });
+
+    expect(isRelayCapabilityBit('rpc:fs:read')).toBe(true);
+    expect(isRelayCapabilityBit('rpc:fs:format-disk')).toBe(false);
+    expect(resolveAclCapability(acl, 'rpc:fs:read')).toMatchObject({
+      known: true,
+      decision: 'allow',
+    });
+    expect(resolveAclCapability(acl, 'rpc:fs:format-disk')).toMatchObject({
+      known: false,
+      decision: 'deny',
+    });
+  });
+
+  it('moves prod high-risk silent grants to confirmation without granting denied bits', () => {
+    const base = createLegacyDefaultNodeAcl({
+      nodeId: 'node_prod',
+      createdAt: '2026-01-02T03:04:05.000Z',
+      trustTier: 'prod',
+    });
+    const acl: RelayNodeAcl = {
+      ...base,
+      grants: {
+        allowed: ['session:read', 'rpc:fs:write', 'rpc:git:write'],
+        requiresConfirmation: ['rpc:fs:delete'],
+      },
+    };
+
+    const overlaid = applyTrustTierOverlay(acl);
+
+    expect(overlaid.grants.allowed).toEqual(['session:read']);
+    expect(overlaid.grants.requiresConfirmation).toEqual(
+      expect.arrayContaining(['rpc:fs:write', 'rpc:git:write', 'rpc:fs:delete'])
+    );
+    expect(resolveAclCapability(overlaid, 'preview:port-forward')).toMatchObject({
+      decision: 'deny',
+    });
+  });
+
+  it('normalizes unknown stored bits out of effective ACL decisions', () => {
+    const acl = createLegacyDefaultNodeAcl({
+      nodeId: 'node_dirty',
+      createdAt: '2026-01-02T03:04:05.000Z',
+    }) as RelayNodeAcl & { grants: { allowed: string[]; requiresConfirmation: string[] } };
+    acl.grants.allowed.push('rpc:fs:format-disk');
+    acl.grants.requiresConfirmation.push('session:teleport');
+
+    const overlaid = applyTrustTierOverlay(acl);
+
+    expect(overlaid.grants.allowed).not.toContain('rpc:fs:format-disk');
+    expect(overlaid.grants.requiresConfirmation).not.toContain('session:teleport');
+    expect(resolveAclCapability(acl, 'session:teleport')).toMatchObject({
+      known: false,
+      decision: 'deny',
+    });
+  });
+});

--- a/test/security-policy.test.ts
+++ b/test/security-policy.test.ts
@@ -3,6 +3,7 @@ import {
   applyTrustTierOverlay,
   createLegacyDefaultNodeAcl,
   isRelayCapabilityBit,
+  normalizeNodeAcl,
   resolveAclCapability,
   type RelayNodeAcl,
 } from '../shared/security-policy.js';
@@ -68,5 +69,38 @@ describe('security policy schema', () => {
       known: false,
       decision: 'deny',
     });
+  });
+
+  it('pins normalized ACL identity to the owning registry node fallback', () => {
+    const normalized = normalizeNodeAcl(
+      {
+        schemaVersion: 1,
+        policyVersion: '1.0',
+        ref: 'acl:stored-node:1.0',
+        peer: {
+          kind: 'node',
+          nodeId: 'stored-node',
+          credentialId: 'stored-credential',
+          displayName: 'Stored Node',
+        },
+        node: { nodeId: 'stored-node', trustTier: 'dev' },
+        grants: { allowed: ['session:read'], requiresConfirmation: [] },
+        scope: { kind: 'node' },
+        lifecycle: {
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+      {
+        nodeId: 'trusted-node',
+        credentialId: 'trusted-credential',
+        displayName: 'Trusted Node',
+        createdAt: '2026-01-02T03:04:05.000Z',
+      }
+    );
+
+    expect(normalized.peer.nodeId).toBe('trusted-node');
+    expect(normalized.node.nodeId).toBe('trusted-node');
+    expect(normalized.peer.credentialId).toBe('trusted-credential');
   });
 });


### PR DESCRIPTION
## Summary
- Add `shared/security-policy.ts` with trust tiers, closed protocol-versioned capability bits, default legacy ACL grants, prod overlay behavior, and unknown-bit fail-closed resolution.
- Persist hub-owned ACL policy on paired node registry records, including default ACL creation for new nodes and migration for legacy records before `/nodes` summaries/authenticated paths return them.
- Surface ACL policy summaries separately from manifest capability summaries, and update docs to replace fully-trusted-node wording with tier/capability-gated blast-radius language.

## Scope notes
- This intentionally does not wire the full policy evaluator gates, confirmation-token registry, audit sink, credential rotation, or #470 intervention mechanics.
- Node manifests remain availability/probe data only; hub ACL state is the policy authority.

## Verification
- `npm test -- test/security-policy.test.ts test/hub-node-registry.test.ts test/hub-node-routes.test.ts` — 20/20 passed
- `npm run check` — passed (38 existing lint warnings, 0 errors)
- `npm run build` — passed
- `npm test` — 2113/2114 passed; failed `test/branch-watcher.test.ts > detects second branch change after atomic rename (inode change)` with no files touched in that area, then `npm test -- test/branch-watcher.test.ts` timed out locally. Treating as existing macOS watcher flake/noise for this PR.

Closes #494
Refs #427


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a trust-tier security model (sandbox, dev, prod) replacing the previous "fully trusted" node approach.
  * Added per-node ACL policies with granular capability-based access controls and confirmation requirements.
  * Introduced closed capability model where unknown capabilities are denied by default.

* **Documentation**
  * Added comprehensive security policy documentation defining trust tiers and ACL schema.
  * Updated architecture and node bootstrap documentation to reflect the new trust-tier and ACL framework.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/500)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->