### PR TITLE
feat: add typed session envelopes

### DIFF
--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -5,6 +5,7 @@ import type {
   RepoInstanceId,
   WorktreeInstanceId,
 } from '../../../shared/identity.js';
+import type { SessionEnvelope } from '../../../shared/session-envelope.js';
 import type {
   RepoIdentityWarning,
   ResolvedRemoteIdentity,
@@ -187,6 +188,8 @@ export interface SessionSummary {
   dataQuality?: EventSourceType | undefined;
   /** Tracks whether permission-prompt is for approval or question — preserves needs-answer state across refresh */
   permissionType?: 'approval' | 'question';
+  /** Typed intent/scope envelope. New server responses include this; old cached sessions may omit it. */
+  sessionEnvelope?: SessionEnvelope | undefined;
 }
 
 export interface WorktreeInfo {

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -39,9 +39,8 @@ import {
   normalizeControlStateSummary,
 } from '../shared/control-state.js';
 import {
-  ROUTED_NODE_SESSION_INTENT,
+  createRoutedNodeSessionEnvelope,
   isSessionEnvelope,
-  normalizeSessionEnvelope,
 } from '../shared/session-envelope.js';
 import { sessionEnvelopeRegistry } from './session-envelope-registry.js';
 
@@ -181,6 +180,9 @@ export function scopedNodeSession(
   delete scoped.repoInstanceId;
   delete scoped.worktreeInstanceId;
 
+  const existingEnvelope = isSessionEnvelope(scoped.sessionEnvelope)
+    ? scoped.sessionEnvelope
+    : null;
   const globalSessionId = createGlobalSessionId(nodeId, scoped.id);
   const result = {
     ...scoped,
@@ -201,22 +203,24 @@ export function scopedNodeSession(
   };
   return {
     ...result,
-    sessionEnvelope: normalizeSessionEnvelope(
-      scoped.sessionEnvelope,
-      {
-        sessionId: scoped.id,
-        nodeId,
-        globalSessionId,
-        cwd: scoped.cwd,
-        ...(scoped.repoPath ? { repoPath: scoped.repoPath } : {}),
-        ...(scoped.worktreePath !== undefined
-          ? { worktreePath: scoped.worktreePath }
-          : {}),
-        issuedAt: scoped.createdAt,
-        peerIdentity: { kind: 'relay-node', nodeId },
-      },
-      ROUTED_NODE_SESSION_INTENT
-    ),
+    sessionEnvelope: createRoutedNodeSessionEnvelope({
+      sessionId: scoped.id,
+      nodeId,
+      globalSessionId,
+      cwd: scoped.cwd,
+      ...(scoped.repoPath ? { repoPath: scoped.repoPath } : {}),
+      ...(scoped.worktreePath !== undefined
+        ? { worktreePath: scoped.worktreePath }
+        : {}),
+      issuedAt: existingEnvelope?.issuedAt ?? scoped.createdAt,
+      expiresAt: existingEnvelope?.expiresAt ?? null,
+      revocable: existingEnvelope?.revocable ?? true,
+      peerIdentity: { kind: 'relay-node', nodeId },
+      ...(existingEnvelope?.correlationId
+        ? { correlationId: existingEnvelope.correlationId }
+        : {}),
+      ...(existingEnvelope?.auditId ? { auditId: existingEnvelope.auditId } : {}),
+    }),
   };
 }
 

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -38,6 +38,12 @@ import {
   normalizeControlActor,
   normalizeControlStateSummary,
 } from '../shared/control-state.js';
+import {
+  ROUTED_NODE_SESSION_INTENT,
+  isSessionEnvelope,
+  normalizeSessionEnvelope,
+} from '../shared/session-envelope.js';
+import { sessionEnvelopeRegistry } from './session-envelope-registry.js';
 
 interface HubNodeRouterOptions {
   registry: HubNodeRegistry;
@@ -151,6 +157,8 @@ export function isSessionSummary(value: unknown): value is SessionSummary {
     repoNameOk &&
     branchNameOk &&
     controlSummaryFieldsOk(session) &&
+    (session.sessionEnvelope === undefined ||
+      isSessionEnvelope(session.sessionEnvelope)) &&
     typeof session.displayName === 'string' &&
     typeof session.createdAt === 'string' &&
     typeof session.lastActivity === 'string' &&
@@ -173,11 +181,12 @@ export function scopedNodeSession(
   delete scoped.repoInstanceId;
   delete scoped.worktreeInstanceId;
 
-  return {
+  const globalSessionId = createGlobalSessionId(nodeId, scoped.id);
+  const result = {
     ...scoped,
     ...normalizeControlStateSummary(scoped),
     nodeId,
-    globalSessionId: createGlobalSessionId(nodeId, scoped.id),
+    globalSessionId,
     ...(scoped.repoPath
       ? { repoInstanceId: createRepoInstanceId(nodeId, scoped.repoPath) }
       : {}),
@@ -189,6 +198,25 @@ export function scopedNodeSession(
           ),
         }
       : {}),
+  };
+  return {
+    ...result,
+    sessionEnvelope: normalizeSessionEnvelope(
+      scoped.sessionEnvelope,
+      {
+        sessionId: scoped.id,
+        nodeId,
+        globalSessionId,
+        cwd: scoped.cwd,
+        ...(scoped.repoPath ? { repoPath: scoped.repoPath } : {}),
+        ...(scoped.worktreePath !== undefined
+          ? { worktreePath: scoped.worktreePath }
+          : {}),
+        issuedAt: scoped.createdAt,
+        peerIdentity: { kind: 'relay-node', nodeId },
+      },
+      ROUTED_NODE_SESSION_INTENT
+    ),
   };
 }
 
@@ -804,9 +832,9 @@ export function createHubNodeRouter(
         'sessions.create',
         bodyRecord(req)
       );
-      res
-        .status(201)
-        .json(scopedNodeSession(nodeId, sessionFromPayload(payload)));
+      const session = scopedNodeSession(nodeId, sessionFromPayload(payload));
+      sessionEnvelopeRegistry.upsert(session.sessionEnvelope!);
+      res.status(201).json(session);
     } catch (error) {
       if (error instanceof HubNodeLinkError) {
         sendRelayError(res, error.relayNodeError);
@@ -873,6 +901,7 @@ export function createHubNodeRouter(
         await options.nodeLinks.request(nodeId, 'sessions.kill', {
           id: sessionId,
         });
+        sessionEnvelopeRegistry.delete(sessionId, nodeId);
         res.json({ ok: true });
       } catch (error) {
         if (error instanceof HubNodeLinkError) {

--- a/server/session-envelope-registry.ts
+++ b/server/session-envelope-registry.ts
@@ -1,0 +1,65 @@
+import {
+  LOCAL_COMPATIBILITY_SESSION_INTENT,
+  normalizeSessionEnvelope,
+  sessionEnvelopeKey,
+  type SessionEnvelope,
+  type SessionEnvelopeFallback,
+  type SessionIntentKind,
+} from '../shared/session-envelope.js';
+
+export interface SessionEnvelopeCreateInput extends SessionEnvelopeFallback {
+  envelope?: unknown;
+  intentKind?: SessionIntentKind;
+}
+
+export class InMemorySessionEnvelopeRegistry {
+  private readonly envelopes = new Map<string, SessionEnvelope>();
+
+  create(input: SessionEnvelopeCreateInput): SessionEnvelope {
+    const envelope = normalizeSessionEnvelope(
+      input.envelope,
+      input,
+      input.intentKind ?? LOCAL_COMPATIBILITY_SESSION_INTENT
+    );
+    this.envelopes.set(sessionEnvelopeKey(envelope), envelope);
+    return envelope;
+  }
+
+  upsert(envelope: SessionEnvelope): SessionEnvelope {
+    this.envelopes.set(sessionEnvelopeKey(envelope), envelope);
+    return envelope;
+  }
+
+  read(sessionIdOrGlobalId: string, nodeId?: string): SessionEnvelope | undefined {
+    if (nodeId) {
+      return this.envelopes.get(`${encodeURIComponent(nodeId)}:${encodeURIComponent(sessionIdOrGlobalId)}`);
+    }
+    const direct = this.envelopes.get(sessionIdOrGlobalId);
+    if (direct) return direct;
+    return Array.from(this.envelopes.values()).find(
+      (envelope) => envelope.sessionId === sessionIdOrGlobalId
+    );
+  }
+
+  listActive(): SessionEnvelope[] {
+    return Array.from(this.envelopes.values()).sort((a, b) =>
+      b.issuedAt.localeCompare(a.issuedAt)
+    );
+  }
+
+  delete(sessionIdOrGlobalId: string, nodeId?: string): boolean {
+    const found = this.read(sessionIdOrGlobalId, nodeId);
+    if (!found) return false;
+    return this.envelopes.delete(sessionEnvelopeKey(found));
+  }
+
+  clear(): void {
+    this.envelopes.clear();
+  }
+}
+
+export function createSessionEnvelopeRegistry(): InMemorySessionEnvelopeRegistry {
+  return new InMemorySessionEnvelopeRegistry();
+}
+
+export const sessionEnvelopeRegistry = createSessionEnvelopeRegistry();

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -60,6 +60,11 @@ import {
   normalizeControlStateSummary,
   type ControlStateSummary,
 } from '../shared/control-state.js';
+import {
+  LOCAL_COMPATIBILITY_SESSION_INTENT,
+  normalizeSessionEnvelope,
+} from '../shared/session-envelope.js';
+import { sessionEnvelopeRegistry } from './session-envelope-registry.js';
 
 const execFileAsync = promisify(execFile);
 const logger = createLogger('sessions');
@@ -148,12 +153,15 @@ function configure(opts: {
   defaultConfigDir = opts.configDir;
 }
 
-function withLocalIdentity<T extends SessionSummary>(summary: T): T {
+function withLocalIdentity<T extends SessionSummary>(
+  summary: T
+): T & { sessionEnvelope: NonNullable<SessionSummary['sessionEnvelope']> } {
   const nodeId = DEFAULT_LOCAL_NODE_ID;
-  return {
+  const globalSessionId = createGlobalSessionId(nodeId, summary.id);
+  const base = {
     ...summary,
     nodeId,
-    globalSessionId: createGlobalSessionId(nodeId, summary.id),
+    globalSessionId,
     ...(summary.repoPath
       ? { repoInstanceId: createRepoInstanceId(nodeId, summary.repoPath) }
       : {}),
@@ -166,6 +174,24 @@ function withLocalIdentity<T extends SessionSummary>(summary: T): T {
         }
       : {}),
   };
+  return {
+    ...base,
+    sessionEnvelope: normalizeSessionEnvelope(
+      summary.sessionEnvelope,
+      {
+        sessionId: summary.id,
+        nodeId,
+        globalSessionId,
+        cwd: summary.cwd,
+        ...(summary.repoPath ? { repoPath: summary.repoPath } : {}),
+        ...(summary.worktreePath !== undefined
+          ? { worktreePath: summary.worktreePath }
+          : {}),
+        issuedAt: summary.createdAt,
+      },
+      LOCAL_COMPATIBILITY_SESSION_INTENT
+    ),
+  } as T & { sessionEnvelope: NonNullable<SessionSummary['sessionEnvelope']> };
 }
 
 let terminalCounter = 0;
@@ -328,7 +354,10 @@ function create({
       ...ptyParams,
       callbacks: {
         onStateChange: stateChangeCallbacks,
-        onSessionEnd: sessionEndCallbacks,
+        onSessionEnd: [
+          ...sessionEndCallbacks,
+          (sessionId: string) => sessionEnvelopeRegistry.delete(sessionId),
+        ],
         fireBackendStateIfChanged,
       },
     },
@@ -396,10 +425,13 @@ function create({
     };
     stateChangeCallbacks.push(promptHandler);
   }
-  return withLocalIdentity({
+  const summary = withLocalIdentity({
     ...result,
     needsBranchRename: !!ptySession.needsBranchRename,
   });
+  ptySession.sessionEnvelope = summary.sessionEnvelope;
+  sessionEnvelopeRegistry.upsert(summary.sessionEnvelope);
+  return summary;
 }
 
 function get(id: string): Session | undefined {
@@ -407,47 +439,51 @@ function get(id: string): Session | undefined {
 }
 
 function list(): SessionSummary[] {
-  return Array.from(sessions.values())
-    .map(
-      (s): SessionSummary =>
-        withLocalIdentity({
-          id: s.id,
-          type: s.type,
-          agent: s.agent,
-          mode: s.mode,
-          ...(s.repoPath ? { repoPath: s.repoPath } : {}),
-          ...(s.worktreePath !== undefined
-            ? { worktreePath: s.worktreePath }
-            : {}),
-          cwd: s.cwd,
-          ...(s.repoName ? { repoName: s.repoName } : {}),
-          ...(s.branchName !== undefined ? { branchName: s.branchName } : {}),
-          displayName: s.displayName,
-          createdAt: s.createdAt,
-          lastActivity: s.lastActivity,
-          idle: s.idle,
-          customCommand: s.customCommand,
-          status: s.status,
-          needsBranchRename: !!s.needsBranchRename,
-          agentState: s.agentState,
-          currentActivity: s.currentActivity,
-          ...normalizeControlStateSummary(s.controlState),
-          ...(s.mode === 'pty'
-            ? { useTmux: s.useTmux, tmuxSessionName: s.tmuxSessionName }
-            : {}),
-          ...(s.workspaceId ? { workspaceId: s.workspaceId } : {}),
-          ...(s.additionalDirs?.length
-            ? { additionalDirs: s.additionalDirs }
-            : {}),
-          ...(s.mode === 'pty' && s.dataQuality !== undefined
-            ? { dataQuality: s.dataQuality }
-            : {}),
-          ...(s._lastEmittedPermissionType !== undefined
-            ? { permissionType: s._lastEmittedPermissionType }
-            : {}),
-        })
-    )
+  const summaries = Array.from(sessions.values())
+    .map((s): SessionSummary => {
+      const summary = withLocalIdentity({
+        id: s.id,
+        type: s.type,
+        agent: s.agent,
+        mode: s.mode,
+        ...(s.repoPath ? { repoPath: s.repoPath } : {}),
+        ...(s.worktreePath !== undefined
+          ? { worktreePath: s.worktreePath }
+          : {}),
+        cwd: s.cwd,
+        ...(s.repoName ? { repoName: s.repoName } : {}),
+        ...(s.branchName !== undefined ? { branchName: s.branchName } : {}),
+        displayName: s.displayName,
+        createdAt: s.createdAt,
+        lastActivity: s.lastActivity,
+        idle: s.idle,
+        customCommand: s.customCommand,
+        status: s.status,
+        needsBranchRename: !!s.needsBranchRename,
+        agentState: s.agentState,
+        currentActivity: s.currentActivity,
+        ...normalizeControlStateSummary(s.controlState),
+        ...(s.mode === 'pty'
+          ? { useTmux: s.useTmux, tmuxSessionName: s.tmuxSessionName }
+          : {}),
+        ...(s.workspaceId ? { workspaceId: s.workspaceId } : {}),
+        ...(s.additionalDirs?.length
+          ? { additionalDirs: s.additionalDirs }
+          : {}),
+        ...(s.mode === 'pty' && s.dataQuality !== undefined
+          ? { dataQuality: s.dataQuality }
+          : {}),
+        ...(s._lastEmittedPermissionType !== undefined
+          ? { permissionType: s._lastEmittedPermissionType }
+          : {}),
+        ...(s.sessionEnvelope ? { sessionEnvelope: s.sessionEnvelope } : {}),
+      });
+      s.sessionEnvelope = summary.sessionEnvelope;
+      sessionEnvelopeRegistry.upsert(summary.sessionEnvelope);
+      return summary;
+    })
     .sort((a, b) => b.lastActivity.localeCompare(a.lastActivity));
+  return summaries;
 }
 
 function updateDisplayName(
@@ -518,6 +554,7 @@ function kill(id: string): void {
   }
 
   sessions.delete(id);
+  sessionEnvelopeRegistry.delete(id);
 }
 
 function detachForRestart(id: string): void {
@@ -1582,6 +1619,9 @@ async function createWeb(
     sessions,
     fireBackendStateIfChanged
   );
+  if (result.session.sessionEnvelope) {
+    sessionEnvelopeRegistry.upsert(result.session.sessionEnvelope);
+  }
   trackEvent({
     category: 'session',
     action: 'created',

--- a/server/types.ts
+++ b/server/types.ts
@@ -25,6 +25,7 @@ import type {
   ControlMode,
   ControlStateSummary,
 } from '../shared/control-state.js';
+import type { SessionEnvelope } from '../shared/session-envelope.js';
 
 export type AgentState =
   | 'initializing'
@@ -287,6 +288,8 @@ interface BaseSession {
   currentActivity?: { tool: string; detail?: string } | undefined;
   /** Product control state; separate from transport `mode` (`pty` | `web`). */
   controlState?: ControlStateSummary | undefined;
+  /** Typed intent/scope envelope for future revoke/expiry enforcement hooks. */
+  sessionEnvelope?: SessionEnvelope | undefined;
   _lastEmittedBackendState?: BackendDisplayState | undefined;
   _lastEmittedPermissionType?: 'approval' | 'question' | undefined;
   lastAttentionNotifiedAt?: number | undefined;
@@ -421,6 +424,8 @@ export interface SessionSummary {
   dataQuality?: EventSourceType;
   /** Tracks whether permission-prompt is for approval or question — preserves needs-answer state across refresh */
   permissionType?: 'approval' | 'question';
+  /** Typed intent/scope envelope. Present on new responses; legacy callers should normalize when absent. */
+  sessionEnvelope?: SessionEnvelope | undefined;
 }
 
 export interface TelemetryData {

--- a/server/web-session-handler.ts
+++ b/server/web-session-handler.ts
@@ -18,6 +18,7 @@ import {
   normalizeControlStateSummary,
   type ControlStateSummary,
 } from '../shared/control-state.js';
+import { createLocalCompatibilitySessionEnvelope } from '../shared/session-envelope.js';
 
 const logger = createLogger('web-session');
 const MESSAGE_BUFFER_MAX = 1000;
@@ -78,6 +79,7 @@ export async function createWebSession(
   );
   const activeRuntime = adapterV2;
   const hookToken = params.hookToken ?? crypto.randomBytes(16).toString('hex');
+  const createdAt = new Date().toISOString();
   const normalizedControlState = normalizeControlStateSummary(
     params.controlState ?? createLegacyControlStateSummary()
   );
@@ -94,8 +96,8 @@ export async function createWebSession(
     ...(params.repoName ? { repoName: params.repoName } : {}),
     ...(params.repoPath ? { branchName: params.branchName ?? '' } : {}),
     displayName: params.displayName,
-    createdAt: new Date().toISOString(),
-    lastActivity: new Date().toISOString(),
+    createdAt,
+    lastActivity: createdAt,
     idle: true,
     customCommand: null,
     status: 'active',
@@ -132,6 +134,16 @@ export async function createWebSession(
     hookToken,
     hooksActive: true,
     controlState: normalizedControlState,
+    sessionEnvelope: createLocalCompatibilitySessionEnvelope({
+      sessionId: id,
+      nodeId: DEFAULT_LOCAL_NODE_ID,
+      cwd: params.cwd,
+      ...(params.repoPath ? { repoPath: params.repoPath } : {}),
+      ...(params.worktreePath !== undefined
+        ? { worktreePath: params.worktreePath }
+        : {}),
+      issuedAt: createdAt,
+    }),
   };
 
   sessionsMap.set(id, session);

--- a/shared/session-envelope.ts
+++ b/shared/session-envelope.ts
@@ -1,0 +1,259 @@
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  createGlobalSessionId,
+  type GlobalSessionId,
+  type LocalSessionId,
+  type NodeId,
+} from './identity.js';
+
+export const LOCAL_COMPATIBILITY_SESSION_INTENT = 'local-dev-compatibility';
+export const ROUTED_NODE_SESSION_INTENT = 'routed-node-session';
+
+export type SessionIntentKind =
+  | typeof LOCAL_COMPATIBILITY_SESSION_INTENT
+  | typeof ROUTED_NODE_SESSION_INTENT;
+
+export interface SessionIntent {
+  /**
+   * Names why this session exists. This is data for future policy hooks,
+   * not a capability grant by itself.
+   */
+  kind: SessionIntentKind;
+  description: string;
+}
+
+export type SessionScopeKind =
+  | 'local-compatibility'
+  | 'node-cwd'
+  | 'repo'
+  | 'worktree';
+
+export interface SessionScope {
+  /**
+   * Compatibility/default scope is explicit so legacy local flows do not
+   * silently masquerade as an all-powerful authorization bypass.
+   */
+  kind: SessionScopeKind;
+  nodeId: NodeId;
+  cwd: string;
+  repoPath?: string;
+  worktreePath?: string | null;
+}
+
+export type SessionPeerIdentity =
+  | { kind: 'local-user'; id: string; displayName?: string }
+  | { kind: 'relay-node'; nodeId: NodeId; credentialId?: string; displayName?: string }
+  | { kind: 'unknown'; id?: string; displayName?: string };
+
+export interface SessionEnvelope {
+  /** Node-local session id. */
+  sessionId: LocalSessionId;
+  /** Node-scoped session id used by the hub for collision-free routing. */
+  globalSessionId: GlobalSessionId;
+  nodeId: NodeId;
+  intent: SessionIntent;
+  scope: SessionScope;
+  issuedAt: string;
+  expiresAt: string | null;
+  revocable: boolean;
+  peerIdentity: SessionPeerIdentity;
+  correlationId?: string;
+  auditId?: string;
+}
+
+export interface SessionEnvelopeFallback {
+  sessionId: string;
+  nodeId?: NodeId;
+  globalSessionId?: GlobalSessionId;
+  cwd: string;
+  repoPath?: string;
+  worktreePath?: string | null;
+  issuedAt?: string;
+  expiresAt?: string | null;
+  revocable?: boolean;
+  peerIdentity?: SessionPeerIdentity;
+  correlationId?: string;
+  auditId?: string;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function nullableString(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  return stringValue(value);
+}
+
+function isIntent(value: unknown): value is SessionIntent {
+  const candidate = record(value);
+  return (
+    !!candidate &&
+    (candidate['kind'] === LOCAL_COMPATIBILITY_SESSION_INTENT ||
+      candidate['kind'] === ROUTED_NODE_SESSION_INTENT) &&
+    typeof candidate['description'] === 'string'
+  );
+}
+
+function isScope(value: unknown): value is SessionScope {
+  const candidate = record(value);
+  return (
+    !!candidate &&
+    (candidate['kind'] === 'local-compatibility' ||
+      candidate['kind'] === 'node-cwd' ||
+      candidate['kind'] === 'repo' ||
+      candidate['kind'] === 'worktree') &&
+    typeof candidate['nodeId'] === 'string' &&
+    typeof candidate['cwd'] === 'string' &&
+    (candidate['repoPath'] === undefined || typeof candidate['repoPath'] === 'string') &&
+    (candidate['worktreePath'] === undefined ||
+      candidate['worktreePath'] === null ||
+      typeof candidate['worktreePath'] === 'string')
+  );
+}
+
+function isPeerIdentity(value: unknown): value is SessionPeerIdentity {
+  const candidate = record(value);
+  if (!candidate) return false;
+  if (candidate['kind'] === 'local-user') return typeof candidate['id'] === 'string';
+  if (candidate['kind'] === 'relay-node') return typeof candidate['nodeId'] === 'string';
+  return candidate['kind'] === 'unknown';
+}
+
+export function isSessionEnvelope(value: unknown): value is SessionEnvelope {
+  const candidate = record(value);
+  return (
+    !!candidate &&
+    typeof candidate['sessionId'] === 'string' &&
+    typeof candidate['globalSessionId'] === 'string' &&
+    typeof candidate['nodeId'] === 'string' &&
+    isIntent(candidate['intent']) &&
+    isScope(candidate['scope']) &&
+    typeof candidate['issuedAt'] === 'string' &&
+    (candidate['expiresAt'] === null || typeof candidate['expiresAt'] === 'string') &&
+    typeof candidate['revocable'] === 'boolean' &&
+    isPeerIdentity(candidate['peerIdentity']) &&
+    (candidate['correlationId'] === undefined || typeof candidate['correlationId'] === 'string') &&
+    (candidate['auditId'] === undefined || typeof candidate['auditId'] === 'string')
+  );
+}
+
+function compatibilityScope(fallback: SessionEnvelopeFallback): SessionScope {
+  const nodeId = fallback.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  return {
+    kind: 'local-compatibility',
+    nodeId,
+    cwd: fallback.cwd,
+    ...(fallback.repoPath ? { repoPath: fallback.repoPath } : {}),
+    ...(fallback.worktreePath !== undefined
+      ? { worktreePath: fallback.worktreePath }
+      : {}),
+  };
+}
+
+function routedScope(fallback: SessionEnvelopeFallback): SessionScope {
+  const nodeId = fallback.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  const kind: SessionScopeKind = fallback.worktreePath
+    ? 'worktree'
+    : fallback.repoPath
+      ? 'repo'
+      : 'node-cwd';
+  return {
+    kind,
+    nodeId,
+    cwd: fallback.cwd,
+    ...(fallback.repoPath ? { repoPath: fallback.repoPath } : {}),
+    ...(fallback.worktreePath !== undefined
+      ? { worktreePath: fallback.worktreePath }
+      : {}),
+  };
+}
+
+export function createLocalCompatibilitySessionEnvelope(
+  fallback: SessionEnvelopeFallback
+): SessionEnvelope {
+  const nodeId = fallback.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  return {
+    sessionId: fallback.sessionId,
+    globalSessionId:
+      fallback.globalSessionId ?? createGlobalSessionId(nodeId, fallback.sessionId),
+    nodeId,
+    intent: {
+      kind: LOCAL_COMPATIBILITY_SESSION_INTENT,
+      description: 'legacy local/single-node Relay session compatibility',
+    },
+    scope: compatibilityScope(fallback),
+    issuedAt: fallback.issuedAt ?? new Date().toISOString(),
+    expiresAt: fallback.expiresAt ?? null,
+    revocable: fallback.revocable ?? true,
+    peerIdentity: fallback.peerIdentity ?? { kind: 'local-user', id: 'local-dev' },
+    ...(fallback.correlationId ? { correlationId: fallback.correlationId } : {}),
+    ...(fallback.auditId ? { auditId: fallback.auditId } : {}),
+  };
+}
+
+export function createRoutedNodeSessionEnvelope(
+  fallback: SessionEnvelopeFallback
+): SessionEnvelope {
+  const nodeId = fallback.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  return {
+    sessionId: fallback.sessionId,
+    globalSessionId:
+      fallback.globalSessionId ?? createGlobalSessionId(nodeId, fallback.sessionId),
+    nodeId,
+    intent: {
+      kind: ROUTED_NODE_SESSION_INTENT,
+      description: 'hub-routed node session',
+    },
+    scope: routedScope({ ...fallback, nodeId }),
+    issuedAt: fallback.issuedAt ?? new Date().toISOString(),
+    expiresAt: fallback.expiresAt ?? null,
+    revocable: fallback.revocable ?? true,
+    peerIdentity: fallback.peerIdentity ?? { kind: 'relay-node', nodeId },
+    ...(fallback.correlationId ? { correlationId: fallback.correlationId } : {}),
+    ...(fallback.auditId ? { auditId: fallback.auditId } : {}),
+  };
+}
+
+export function normalizeSessionEnvelope(
+  value: unknown,
+  fallback: SessionEnvelopeFallback,
+  intentKind: SessionIntentKind = LOCAL_COMPATIBILITY_SESSION_INTENT
+): SessionEnvelope {
+  if (isSessionEnvelope(value)) {
+    const normalizedNodeId = fallback.nodeId ?? value.nodeId;
+    const normalizedGlobalSessionId =
+      fallback.globalSessionId ?? value.globalSessionId ?? createGlobalSessionId(normalizedNodeId, value.sessionId);
+    return {
+      ...value,
+      nodeId: normalizedNodeId,
+      globalSessionId: normalizedGlobalSessionId,
+      scope: { ...value.scope, nodeId: normalizedNodeId },
+    };
+  }
+  return intentKind === ROUTED_NODE_SESSION_INTENT
+    ? createRoutedNodeSessionEnvelope(fallback)
+    : createLocalCompatibilitySessionEnvelope(fallback);
+}
+
+export function sessionEnvelopeKey(envelope: Pick<SessionEnvelope, 'globalSessionId'>): string {
+  return envelope.globalSessionId;
+}
+
+export function sessionEnvelopeFromUnknown(value: unknown): SessionEnvelope | null {
+  return isSessionEnvelope(value) ? value : null;
+}
+
+export function envelopeStringField(value: unknown): string | undefined {
+  return stringValue(value);
+}
+
+export function envelopeNullableStringField(value: unknown): string | null | undefined {
+  return nullableString(value);
+}

--- a/test/hub-node-session-routing.test.ts
+++ b/test/hub-node-session-routing.test.ts
@@ -18,6 +18,7 @@ import {
   RELAY_NODE_LINK_PROTOCOL_VERSION,
   type RelayNodeEnvelope,
 } from '../shared/relay-node-protocol.js';
+import { createLocalCompatibilitySessionEnvelope } from '../shared/session-envelope.js';
 
 function manifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
   return {
@@ -357,6 +358,69 @@ describe('hub-routed node session create and attach', () => {
       nodeId,
       globalSessionId: `${nodeId}:remote-session-1`,
       mode: 'pty',
+    });
+  });
+
+  it('forces routed-node envelope semantics when the node returns a local compatibility envelope', async () => {
+    const { base, wsBase } = await startHub();
+    const { token, nodeId } = await pairNode(base);
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const createPromise = fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
+      }
+    );
+
+    const request = await nextJson(nodeWs);
+    nodeWs.send(
+      JSON.stringify({
+        protocol: request.protocol,
+        protocolVersion: request.protocolVersion,
+        nodeId,
+        channel: 'rpc',
+        type: 'sessions.create.result',
+        requestId: request.requestId,
+        timestamp: new Date().toISOString(),
+        payload: {
+          session: {
+            ...remoteSession(nodeId),
+            sessionEnvelope: createLocalCompatibilitySessionEnvelope({
+              sessionId: 'remote-session-1',
+              nodeId,
+              cwd: '/srv/relay-ide',
+              repoPath: '/srv/relay-ide',
+              worktreePath: null,
+              issuedAt: '2026-01-02T03:04:05.000Z',
+            }),
+          },
+        },
+      })
+    );
+
+    const res = await createPromise;
+    expect(res.status).toBe(201);
+    const scoped = (await res.json()) as SessionSummary;
+    expect(scoped.sessionEnvelope).toMatchObject({
+      sessionId: 'remote-session-1',
+      nodeId,
+      globalSessionId: `${nodeId}:remote-session-1`,
+      intent: { kind: 'routed-node-session' },
+      peerIdentity: { kind: 'relay-node', nodeId },
+      scope: {
+        kind: 'repo',
+        nodeId,
+        cwd: '/srv/relay-ide',
+        repoPath: '/srv/relay-ide',
+        worktreePath: null,
+      },
     });
   });
 

--- a/test/session-envelope-registry.test.ts
+++ b/test/session-envelope-registry.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LOCAL_COMPATIBILITY_SESSION_INTENT,
+  ROUTED_NODE_SESSION_INTENT,
+} from '../shared/session-envelope.js';
+import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
+
+describe('session envelope registry', () => {
+  it('creates, reads, and lists active local compatibility envelopes', () => {
+    const registry = createSessionEnvelopeRegistry();
+    const envelope = registry.create({
+      sessionId: 'sess-local',
+      nodeId: 'local',
+      globalSessionId: 'local:sess-local',
+      cwd: '/repo',
+      repoPath: '/repo',
+      worktreePath: null,
+      issuedAt: '2026-01-02T03:04:05.000Z',
+    });
+
+    expect(envelope.intent.kind).toBe(LOCAL_COMPATIBILITY_SESSION_INTENT);
+    expect(envelope.scope.kind).toBe('local-compatibility');
+    expect(envelope.revocable).toBe(true);
+    expect(registry.read('local:sess-local')).toEqual(envelope);
+    expect(registry.read('sess-local')).toEqual(envelope);
+    expect(registry.listActive()).toEqual([envelope]);
+  });
+
+  it('normalizes missing legacy metadata into explicit local compatibility envelope', () => {
+    const registry = createSessionEnvelopeRegistry();
+    const envelope = registry.create({
+      envelope: null,
+      sessionId: 'legacy-session',
+      cwd: '/tmp/free',
+      issuedAt: '2026-01-02T03:04:05.000Z',
+    });
+
+    expect(envelope.intent.kind).toBe(LOCAL_COMPATIBILITY_SESSION_INTENT);
+    expect(envelope.scope).toMatchObject({
+      kind: 'local-compatibility',
+      cwd: '/tmp/free',
+    });
+    expect(envelope.expiresAt).toBeNull();
+  });
+
+  it('keeps routed node envelopes distinct from local compatibility', () => {
+    const registry = createSessionEnvelopeRegistry();
+    const envelope = registry.create({
+      sessionId: 'remote-session',
+      nodeId: 'node-a',
+      globalSessionId: 'node-a:remote-session',
+      cwd: '/srv/app',
+      repoPath: '/srv/app',
+      issuedAt: '2026-01-02T03:04:05.000Z',
+      intentKind: ROUTED_NODE_SESSION_INTENT,
+    });
+
+    expect(envelope.intent.kind).toBe(ROUTED_NODE_SESSION_INTENT);
+    expect(envelope.scope.kind).toBe('repo');
+    expect(envelope.peerIdentity).toMatchObject({
+      kind: 'relay-node',
+      nodeId: 'node-a',
+    });
+  });
+});

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -22,6 +22,7 @@ import {
 import { serializeAll, restoreFromDisk } from '../server/sessions.js';
 import { AGENT_CONTINUE_ARGS, AGENT_YOLO_ARGS } from '../server/types.js';
 import type { PtySession } from '../server/types.js';
+import { LOCAL_COMPATIBILITY_SESSION_INTENT } from '../shared/session-envelope.js';
 
 // Track created session IDs so we can clean up after each test
 const createdIds: string[] = [];
@@ -126,10 +127,31 @@ describe('sessions', () => {
     expect(result.pid).toBeTypeOf('number');
     expect(result.createdAt).toBeTruthy();
     expect('pty' in result).toBe(false);
+    expect(result.sessionEnvelope).toMatchObject({
+      sessionId: result.id,
+      globalSessionId: `local:${result.id}`,
+      nodeId: 'local',
+      intent: { kind: LOCAL_COMPATIBILITY_SESSION_INTENT },
+      scope: {
+        kind: 'local-compatibility',
+        nodeId: 'local',
+        cwd: '/tmp',
+        repoPath: '/tmp',
+        worktreePath: null,
+      },
+      revocable: true,
+      peerIdentity: { kind: 'local-user', id: 'local-dev' },
+    });
+    expect(result.sessionEnvelope.expiresAt).toBeNull();
 
     const list = sessions.list();
     expect(list.length).toBe(1);
     expect(list[0]?.id).toBe(result.id);
+    expect(list[0]?.sessionEnvelope).toMatchObject({
+      sessionId: result.id,
+      intent: { kind: LOCAL_COMPATIBILITY_SESSION_INTENT },
+      scope: { kind: 'local-compatibility', cwd: '/tmp' },
+    });
   });
 
   it('does not synthesize repo instance identity without repoPath', () => {


### PR DESCRIPTION
## Summary
- Add shared typed session envelope model for session intent, scope, peer identity, revocability, expiry, and audit/correlation ids.
- Normalize local PTY/web session create/list responses into an explicit `local-dev-compatibility` envelope instead of leaving legacy metadata implicit.
- Add an in-memory hub-side session envelope registry and thread routed node session responses through `routed-node-session` normalization.
- Cover registry behavior and local compatibility normalization in tests.

## The Case Against
This is a typed foundation, not enforcement. The new envelope is intentionally carried through session summaries and registry state, but revoke/expiry policy hooks are not enforced here. If reviewers expect actual authorization decisions, this PR should be rejected as out of scope rather than treated as security enforcement.

## Verification
- `npm test -- test/session-envelope-registry.test.ts test/hub-node-session-routing.test.ts test/sessions.test.ts`
- `npm run check` (passes with existing lint warnings)
- `npm run build` (passes with existing large chunk warning)

Closes #501
Refs #426, #427
