### PR TITLE
feat: add local hub and node log tail CLI

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -21,6 +21,13 @@ import { createNodeLinkPtyHost } from '../server/node-link-pty-host.js';
 import { createNodeLinkRpcHost } from '../server/node-link-rpc-host.js';
 import { createLocalRelayNode } from '../server/local-node.js';
 import { collectLocalRepoInventory } from '../server/repo-inventory.js';
+import {
+  createLocalLogFollower,
+  parseLogLineCount,
+  readLocalLogSnapshot,
+  resolveLocalLogPlan,
+  type LocalLogRole,
+} from '../server/local-logs.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -46,7 +53,7 @@ Commands:
     install                           Install/start the hub background service
     uninstall                         Stop and remove the hub background service
     status                            Show hub service status
-    logs                              Print platform log commands for the hub service
+    logs [--lines <n>] [--follow]     Print or follow local hub log files
   install            Back-compat alias for relay-ide hub install
   uninstall          Back-compat alias for relay-ide hub uninstall
   status             Back-compat alias for relay-ide hub status
@@ -56,7 +63,7 @@ Commands:
                                        Verify the hash-chained security audit log
   node               Manage relay-node pairing and diagnostics
     status                             Show local node/service status
-    logs                               Print platform log commands
+    logs [--lines <n>] [--follow]      Print or follow local node log files
     doctor --hub <url>                 Check hub reachability and local node capability
     connect --hub <url> --pair-token <token>
                                        Exchange a pair token and send one heartbeat
@@ -143,6 +150,16 @@ function resolveConfigPath(): string {
 function runServiceCommand(fn: () => void): never {
   try {
     fn();
+  } catch (e) {
+    logger.error((e as Error).message);
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+async function runAsyncCommand(fn: () => Promise<void> | void): Promise<never> {
+  try {
+    await fn();
   } catch (e) {
     logger.error((e as Error).message);
     process.exit(1);
@@ -299,30 +316,49 @@ function getNodeArg(nodeArgs: string[], flag: string): string | undefined {
   return nodeArgs[idx + 1];
 }
 
-function serviceLogHints(kind: string, mode: 'hub' | 'node'): string[] {
-  if (kind === 'launchd') {
-    return ['launchctl print gui/$(id -u)/com.relay-ide'];
+async function printLocalLogs(
+  role: LocalLogRole,
+  commandArgs: string[]
+): Promise<void> {
+  const lines = parseLogLineCount(getNodeArg(commandArgs, '--lines'));
+  const follow = commandArgs.includes('--follow') || commandArgs.includes('-f');
+  const configPath = resolveConfigPath();
+  const serviceLogDir = service.getServicePaths().logDir;
+  const snapshot = readLocalLogSnapshot({
+    role,
+    configPath,
+    serviceLogDir,
+    lines,
+  });
+
+  if (snapshot.output) {
+    process.stdout.write(snapshot.output);
+  } else {
+    logger.info(snapshot.message);
   }
-  if (kind === 'systemd-user' || kind === 'wsl-systemd') {
-    return [
-      'systemctl --user status relay-ide',
-      'journalctl --user -u relay-ide --no-pager -n 100',
-    ];
-  }
-  if (kind === 'systemd-system') {
-    return [
-      'sudo systemctl status relay-ide',
-      'sudo journalctl -u relay-ide --no-pager -n 100',
-    ];
-  }
-  if (mode === 'hub') {
-    return [
-      'manual mode has no Relay-managed service logs; run relay-ide hub in the foreground',
-    ];
-  }
-  return [
-    'manual mode has no Relay-managed service logs; node connect only pairs credentials and exits',
-  ];
+
+  if (!follow) return;
+
+  const plan = resolveLocalLogPlan(configPath, serviceLogDir);
+  logger.info(
+    snapshot.status === 'missing'
+      ? 'Waiting for local Relay log files; press Ctrl-C to stop.'
+      : 'Following local Relay log files; press Ctrl-C to stop.'
+  );
+  const follower = createLocalLogFollower({
+    files: plan.files,
+    write: (chunk) => process.stdout.write(chunk),
+    onError: (error) => logger.error(`Log follow error: ${error.message}`),
+  });
+
+  await new Promise<void>((resolve) => {
+    const stop = (): void => {
+      follower.close();
+      resolve();
+    };
+    process.once('SIGINT', stop);
+    process.once('SIGTERM', stop);
+  });
 }
 
 function printHubStatus(): void {
@@ -343,10 +379,8 @@ function printHubStatus(): void {
   for (const caveat of st.manager.caveats) logger.info(caveat);
 }
 
-function printHubLogs(): void {
-  const st = service.status();
-  logger.info(`Log hints for ${st.manager.label} (${st.manager.kind}):`);
-  for (const hint of serviceLogHints(st.manager.kind, 'hub')) logger.info(hint);
+async function printHubLogs(commandArgs: string[]): Promise<void> {
+  await printLocalLogs('hub', commandArgs);
 }
 
 async function printNodeStatus(): Promise<void> {
@@ -365,13 +399,8 @@ async function printNodeStatus(): Promise<void> {
   for (const caveat of manifest.serviceManager.caveats) logger.info(caveat);
 }
 
-async function printNodeLogs(): Promise<void> {
-  const manifest = await getNodeManifest();
-  logger.info(
-    `Log hints for ${manifest.serviceManager.label} (${manifest.serviceManager.kind}):`
-  );
-  for (const hint of serviceLogHints(manifest.serviceManager.kind, 'node'))
-    logger.info(hint);
+async function printNodeLogs(commandArgs: string[]): Promise<void> {
+  await printLocalLogs('node', commandArgs);
 }
 
 async function runNodeDoctor(hubUrl: string | undefined): Promise<void> {
@@ -697,7 +726,7 @@ if (command === 'hub') {
   } else if (subCommand === 'status') {
     runServiceCommand(printHubStatus);
   } else if (subCommand === 'logs') {
-    runServiceCommand(printHubLogs);
+    await runAsyncCommand(() => printHubLogs(hubArgs.slice(1)));
   } else if (
     hubArgs.includes('--bg') &&
     (!subCommand || subCommand.startsWith('-'))
@@ -730,8 +759,7 @@ if (command === 'node') {
     process.exit(0);
   }
   if (subCommand === 'logs') {
-    await printNodeLogs();
-    process.exit(0);
+    await runAsyncCommand(() => printNodeLogs(nodeArgs.slice(1)));
   }
   if (subCommand === 'doctor') {
     await runNodeDoctor(getNodeArg(nodeArgs, '--hub'));

--- a/server/local-logs.ts
+++ b/server/local-logs.ts
@@ -1,0 +1,224 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const DEFAULT_LOG_LINES = 100;
+const TAIL_CHUNK_SIZE = 64 * 1024;
+
+export type LocalLogRole = 'hub' | 'node';
+
+export interface LocalLogPlan {
+  logDir: string;
+  files: string[];
+}
+
+export interface LocalLogSnapshot {
+  status: 'ok' | 'missing' | 'empty';
+  logDir: string;
+  files: string[];
+  output: string;
+  message: string;
+}
+
+export interface LocalLogFollower {
+  files: string[];
+  close(): void;
+}
+
+export function parseLogLineCount(
+  value: string | undefined,
+  fallback = DEFAULT_LOG_LINES
+): number {
+  if (value === undefined) return fallback;
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`Invalid --lines value: ${value}. Expected a non-negative integer.`);
+  }
+  return Number(value);
+}
+
+export function resolveLocalLogPlan(
+  configPath: string,
+  serviceLogDir?: string | null
+): LocalLogPlan {
+  const configLogDir = path.join(path.dirname(path.resolve(configPath)), 'logs');
+  const logDirs = [configLogDir];
+  if (serviceLogDir) logDirs.push(path.resolve(serviceLogDir));
+  const uniqueDirs = Array.from(new Set(logDirs));
+  const files = uniqueDirs.flatMap((dir) => [
+    path.join(dir, 'relay-ide.log'),
+    path.join(dir, 'stdout.log'),
+    path.join(dir, 'stderr.log'),
+  ]);
+  return { logDir: configLogDir, files: Array.from(new Set(files)) };
+}
+
+export function readLocalLogSnapshot(options: {
+  role: LocalLogRole;
+  configPath: string;
+  serviceLogDir?: string | null;
+  lines?: number;
+}): LocalLogSnapshot {
+  const lines = options.lines ?? DEFAULT_LOG_LINES;
+  const plan = resolveLocalLogPlan(options.configPath, options.serviceLogDir);
+  const readableFiles = plan.files.filter(isReadableFile);
+
+  if (readableFiles.length === 0) {
+    return {
+      status: 'missing',
+      logDir: plan.logDir,
+      files: plan.files,
+      output: '',
+      message: missingLogsMessage(options.role, plan),
+    };
+  }
+
+  const chunks = readableFiles
+    .map((file) => ({ file, text: readLastLines(file, lines) }))
+    .filter((entry) => entry.text.length > 0);
+
+  if (chunks.length === 0) {
+    return {
+      status: 'empty',
+      logDir: plan.logDir,
+      files: readableFiles,
+      output: '',
+      message: emptyLogsMessage(options.role, readableFiles),
+    };
+  }
+
+  const output = chunks
+    .map((entry) => formatLogChunk(entry.file, entry.text, chunks.length > 1))
+    .join('');
+
+  return {
+    status: 'ok',
+    logDir: plan.logDir,
+    files: readableFiles,
+    output,
+    message: '',
+  };
+}
+
+export function createLocalLogFollower(options: {
+  files: string[];
+  write: (chunk: string) => void;
+  onError?: (error: Error) => void;
+  pollIntervalMs?: number;
+}): LocalLogFollower {
+  const offsets = new Map<string, number>();
+  const files = Array.from(new Set(options.files));
+  for (const file of files) {
+    offsets.set(file, initialOffset(file));
+    fs.watchFile(
+      file,
+      { interval: options.pollIntervalMs ?? 500, persistent: true },
+      (curr) => {
+        if (!curr.isFile()) return;
+        const previousOffset = offsets.get(file) ?? 0;
+        const start = curr.size < previousOffset ? 0 : previousOffset;
+        if (curr.size <= start) return;
+        try {
+          const stream = fs.createReadStream(file, {
+            start,
+            end: curr.size - 1,
+            encoding: 'utf8',
+          });
+          stream.on('data', (chunk) => options.write(String(chunk)));
+          stream.on('error', (error) => options.onError?.(error));
+          stream.on('end', () => offsets.set(file, curr.size));
+        } catch (error) {
+          options.onError?.(error instanceof Error ? error : new Error(String(error)));
+        }
+      }
+    );
+  }
+
+  return {
+    files,
+    close() {
+      for (const file of files) fs.unwatchFile(file);
+    },
+  };
+}
+
+function readLastLines(filePath: string, lines: number): string {
+  if (lines === 0) return '';
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const { size } = fs.fstatSync(fd);
+    if (size === 0) return '';
+    const chunks: Buffer[] = [];
+    let position = size;
+    let newlineCount = 0;
+
+    while (position > 0 && newlineCount <= lines) {
+      const length = Math.min(TAIL_CHUNK_SIZE, position);
+      position -= length;
+      const buffer = Buffer.allocUnsafe(length);
+      fs.readSync(fd, buffer, 0, length, position);
+      chunks.unshift(buffer);
+      newlineCount += countNewlines(buffer);
+    }
+
+    return takeLastLines(Buffer.concat(chunks).toString('utf8'), lines);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function takeLastLines(text: string, lines: number): string {
+  const endsWithNewline = text.endsWith('\n');
+  const parts = text.split('\n');
+  if (endsWithNewline) parts.pop();
+  const selected = parts.slice(-lines).join('\n');
+  if (!selected) return '';
+  return selected + (endsWithNewline ? '\n' : '');
+}
+
+function countNewlines(buffer: Buffer): number {
+  let count = 0;
+  for (let index = 0; index < buffer.length; index += 1) {
+    if (buffer[index] === 10) count += 1;
+  }
+  return count;
+}
+
+function isReadableFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function initialOffset(filePath: string): number {
+  try {
+    const stat = fs.statSync(filePath);
+    return stat.isFile() ? stat.size : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function formatLogChunk(file: string, text: string, includeHeader: boolean): string {
+  if (!includeHeader) return text;
+  return `==> ${file} <==\n${text}${text.endsWith('\n') ? '' : '\n'}`;
+}
+
+function missingLogsMessage(role: LocalLogRole, plan: LocalLogPlan): string {
+  const startCommand = role === 'hub' ? 'relay-ide hub' : 'relay-ide node link --hub <url>';
+  return [
+    `No local Relay ${role} log files were found in ${plan.logDir}.`,
+    'Checked:',
+    ...plan.files.map((file) => `  ${file}`),
+    `Start Relay with ${startCommand}, or install/start the Relay-managed service, then try again.`,
+  ].join('\n');
+}
+
+function emptyLogsMessage(role: LocalLogRole, files: string[]): string {
+  return [
+    `Local Relay ${role} log files exist but are empty.`,
+    'Checked:',
+    ...files.map((file) => `  ${file}`),
+    'If Relay was started manually, the useful output may still be in that foreground terminal.',
+  ].join('\n');
+}

--- a/server/local-logs.ts
+++ b/server/local-logs.ts
@@ -24,6 +24,17 @@ export interface LocalLogFollower {
   close(): void;
 }
 
+interface FollowedFileIdentity {
+  dev: number;
+  ino: number;
+  birthtimeMs: number;
+}
+
+interface FollowedFileState {
+  offset: number;
+  identity?: FollowedFileIdentity;
+}
+
 export function parseLogLineCount(
   value: string | undefined,
   fallback = DEFAULT_LOG_LINES
@@ -120,18 +131,23 @@ export function createLocalLogFollower(options: {
   onError?: (error: Error) => void;
   pollIntervalMs?: number;
 }): LocalLogFollower {
-  const offsets = new Map<string, number>();
+  const followedFiles = new Map<string, FollowedFileState>();
   const files = Array.from(new Set(options.files));
   for (const file of files) {
-    offsets.set(file, initialOffset(file));
+    followedFiles.set(file, initialFollowedFileState(file));
     fs.watchFile(
       file,
       { interval: options.pollIntervalMs ?? 500, persistent: true },
       (curr) => {
         if (!curr.isFile()) return;
-        const previousOffset = offsets.get(file) ?? 0;
-        const start = curr.size < previousOffset ? 0 : previousOffset;
-        if (curr.size <= start) return;
+        const previousState = followedFiles.get(file) ?? { offset: 0 };
+        const currentIdentity = fileIdentity(curr);
+        const rotated = !sameFileIdentity(previousState.identity, currentIdentity);
+        const start = rotated || curr.size < previousState.offset ? 0 : previousState.offset;
+        if (curr.size <= start) {
+          followedFiles.set(file, { offset: curr.size, identity: currentIdentity });
+          return;
+        }
         try {
           const stream = fs.createReadStream(file, {
             start,
@@ -140,7 +156,9 @@ export function createLocalLogFollower(options: {
           });
           stream.on('data', (chunk) => options.write(String(chunk)));
           stream.on('error', (error) => options.onError?.(error));
-          stream.on('end', () => offsets.set(file, curr.size));
+          stream.on('end', () => {
+            followedFiles.set(file, { offset: curr.size, identity: currentIdentity });
+          });
         } catch (error) {
           options.onError?.(error instanceof Error ? error : new Error(String(error)));
         }
@@ -218,13 +236,33 @@ function isReadableFile(filePath: string): boolean {
   }
 }
 
-function initialOffset(filePath: string): number {
+function initialFollowedFileState(filePath: string): FollowedFileState {
   try {
     const stat = fs.statSync(filePath);
-    return stat.isFile() ? stat.size : 0;
+    return stat.isFile() ? { offset: stat.size, identity: fileIdentity(stat) } : { offset: 0 };
   } catch {
-    return 0;
+    return { offset: 0 };
   }
+}
+
+function fileIdentity(stat: fs.Stats): FollowedFileIdentity {
+  return {
+    dev: stat.dev,
+    ino: stat.ino,
+    birthtimeMs: stat.birthtimeMs,
+  };
+}
+
+function sameFileIdentity(
+  previous: FollowedFileIdentity | undefined,
+  current: FollowedFileIdentity
+): boolean {
+  return (
+    previous !== undefined &&
+    previous.dev === current.dev &&
+    previous.ino === current.ino &&
+    previous.birthtimeMs === current.birthtimeMs
+  );
 }
 
 function formatLogChunk(file: string, text: string, includeHeader: boolean): string {

--- a/server/local-logs.ts
+++ b/server/local-logs.ts
@@ -71,17 +71,33 @@ export function readLocalLogSnapshot(options: {
     };
   }
 
-  const chunks = readableFiles
-    .map((file) => ({ file, text: readLastLines(file, lines) }))
-    .filter((entry) => entry.text.length > 0);
+  const chunks: Array<{ file: string; text: string }> = [];
+  const readFiles: string[] = [];
+
+  for (const file of readableFiles) {
+    const text = safeReadLastLines(file, lines);
+    if (text === undefined) continue;
+    readFiles.push(file);
+    if (text.length > 0) chunks.push({ file, text });
+  }
+
+  if (readFiles.length === 0) {
+    return {
+      status: 'missing',
+      logDir: plan.logDir,
+      files: plan.files,
+      output: '',
+      message: missingLogsMessage(options.role, plan),
+    };
+  }
 
   if (chunks.length === 0) {
     return {
       status: 'empty',
       logDir: plan.logDir,
-      files: readableFiles,
+      files: readFiles,
       output: '',
-      message: emptyLogsMessage(options.role, readableFiles),
+      message: emptyLogsMessage(options.role, readFiles),
     };
   }
 
@@ -150,18 +166,28 @@ function readLastLines(filePath: string, lines: number): string {
     let position = size;
     let newlineCount = 0;
 
-    while (position > 0 && newlineCount <= lines) {
+    while (position > 0 && newlineCount < lines) {
       const length = Math.min(TAIL_CHUNK_SIZE, position);
       position -= length;
       const buffer = Buffer.allocUnsafe(length);
-      fs.readSync(fd, buffer, 0, length, position);
-      chunks.unshift(buffer);
-      newlineCount += countNewlines(buffer);
+      const bytesRead = fs.readSync(fd, buffer, 0, length, position);
+      if (bytesRead === 0) continue;
+      const chunk = bytesRead === length ? buffer : buffer.subarray(0, bytesRead);
+      chunks.unshift(chunk);
+      newlineCount += countNewlines(chunk);
     }
 
     return takeLastLines(Buffer.concat(chunks).toString('utf8'), lines);
   } finally {
     fs.closeSync(fd);
+  }
+}
+
+function safeReadLastLines(filePath: string, lines: number): string | undefined {
+  try {
+    return readLastLines(filePath, lines);
+  } catch {
+    return undefined;
   }
 }
 
@@ -184,7 +210,9 @@ function countNewlines(buffer: Buffer): number {
 
 function isReadableFile(filePath: string): boolean {
   try {
-    return fs.statSync(filePath).isFile();
+    if (!fs.statSync(filePath).isFile()) return false;
+    fs.accessSync(filePath, fs.constants.R_OK);
+    return true;
   } catch {
     return false;
   }

--- a/test/hub-node-packaging.test.ts
+++ b/test/hub-node-packaging.test.ts
@@ -9,6 +9,11 @@ const repoRoot = path.resolve(__dirname, '..');
 const serviceMocks = vi.hoisted(() => ({
   install: vi.fn(),
   uninstall: vi.fn(),
+  getServicePaths: vi.fn(() => ({
+    servicePath: '/tmp/relay-ide-test-service',
+    logDir: '/tmp/relay-ide-test-config/logs',
+    label: 'relay-ide-test',
+  })),
   status: vi.fn(() => ({
     installed: false,
     running: false,
@@ -32,6 +37,7 @@ vi.mock('../server/service.js', () => ({
   CONFIG_DIR: '/tmp/relay-ide-test-config',
   install: serviceMocks.install,
   uninstall: serviceMocks.uninstall,
+  getServicePaths: serviceMocks.getServicePaths,
   status: serviceMocks.status,
 }));
 
@@ -56,6 +62,7 @@ async function runCli(
   const originalArgv = process.argv;
   serviceMocks.install.mockClear();
   serviceMocks.uninstall.mockClear();
+  serviceMocks.getServicePaths.mockClear();
   serviceMocks.status.mockClear();
   loggerMocks.info.mockClear();
   loggerMocks.error.mockClear();
@@ -87,6 +94,10 @@ async function runCli(
 
 function readRepoFile(relativePath: string): string {
   return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function resetCliLogDir(): void {
+  fs.rmSync('/tmp/relay-ide-test-config', { recursive: true, force: true });
 }
 
 describe('hub/node packaging decision', () => {
@@ -207,6 +218,54 @@ describe('hub/node packaging decision', () => {
     expect(serviceMocks.install).not.toHaveBeenCalled();
     expect(loggerMocks.error).toHaveBeenCalledWith(
       expect.stringContaining('Usage: relay-ide hub')
+    );
+  });
+
+  it('tails local hub logs with --lines without platform log commands', async () => {
+    resetCliLogDir();
+    const logDir = '/tmp/relay-ide-test-config/logs';
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(logDir, 'relay-ide.log'),
+      ['first', 'second', 'third'].join('\n') + '\n'
+    );
+    let stdout = '';
+    const stdoutSpy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        stdout += String(chunk);
+        return true;
+      });
+
+    try {
+      const result = await runCli(['hub', 'logs', '--lines', '2']);
+
+      expect(result.exitCode).toBe(0);
+      expect(stdout).toBe('second\nthird\n');
+      expect(loggerMocks.info).not.toHaveBeenCalledWith(
+        expect.stringContaining('journalctl')
+      );
+      expect(serviceMocks.getServicePaths).toHaveBeenCalled();
+    } finally {
+      stdoutSpy.mockRestore();
+      resetCliLogDir();
+    }
+  });
+
+  it('reports missing local node logs from the CLI without systemd or journalctl', async () => {
+    resetCliLogDir();
+
+    const result = await runCli(['node', 'logs']);
+
+    expect(result.exitCode).toBe(0);
+    expect(loggerMocks.info).toHaveBeenCalledWith(
+      expect.stringContaining('No local Relay node log files were found')
+    );
+    expect(loggerMocks.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('journalctl')
+    );
+    expect(loggerMocks.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('systemctl')
     );
   });
 

--- a/test/local-logs.test.ts
+++ b/test/local-logs.test.ts
@@ -167,4 +167,28 @@ describe('local Relay logs', () => {
       follower.close();
     }
   });
+
+  it('follows a recreated log file from the beginning after rotation', async () => {
+    const dir = makeTempDir();
+    const logFile = path.join(dir, 'relay-ide.log');
+    const rotatedLogFile = path.join(dir, 'relay-ide.log.1');
+    fs.writeFileSync(logFile, 'existing\n');
+    let output = '';
+    const follower = createLocalLogFollower({
+      files: [logFile],
+      pollIntervalMs: 20,
+      write: (chunk) => {
+        output += chunk;
+      },
+    });
+
+    try {
+      fs.renameSync(logFile, rotatedLogFile);
+      fs.writeFileSync(logFile, 'first-new-line\nsecond-new-line\n');
+      await waitFor(() => output.includes('second-new-line'));
+      expect(output).toBe('first-new-line\nsecond-new-line\n');
+    } finally {
+      follower.close();
+    }
+  });
 });

--- a/test/local-logs.test.ts
+++ b/test/local-logs.test.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createLocalLogFollower,
+  parseLogLineCount,
+  readLocalLogSnapshot,
+  resolveLocalLogPlan,
+} from '../server/local-logs.js';
+
+const cleanup: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-local-logs-'));
+  cleanup.push(dir);
+  return dir;
+}
+
+function waitFor(predicate: () => boolean): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const startedAt = Date.now();
+    const timer = setInterval(() => {
+      if (predicate()) {
+        clearInterval(timer);
+        resolve();
+      } else if (Date.now() - startedAt > 1_000) {
+        clearInterval(timer);
+        reject(new Error('timed out waiting for log follower'));
+      }
+    }, 10);
+  });
+}
+
+afterEach(() => {
+  for (const dir of cleanup.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('local Relay logs', () => {
+  it('resolves local log files from the config path first', () => {
+    const dir = makeTempDir();
+    const plan = resolveLocalLogPlan(
+      path.join(dir, 'config.json'),
+      path.join(dir, 'service-logs')
+    );
+
+    expect(plan.logDir).toBe(path.join(dir, 'logs'));
+    expect(plan.files).toEqual([
+      path.join(dir, 'logs', 'relay-ide.log'),
+      path.join(dir, 'logs', 'stdout.log'),
+      path.join(dir, 'logs', 'stderr.log'),
+      path.join(dir, 'service-logs', 'relay-ide.log'),
+      path.join(dir, 'service-logs', 'stdout.log'),
+      path.join(dir, 'service-logs', 'stderr.log'),
+    ]);
+  });
+
+  it('tails the requested number of local log lines', () => {
+    const dir = makeTempDir();
+    const logDir = path.join(dir, 'logs');
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(logDir, 'relay-ide.log'),
+      ['one', 'two', 'three', 'four'].join('\n') + '\n'
+    );
+
+    const snapshot = readLocalLogSnapshot({
+      role: 'hub',
+      configPath: path.join(dir, 'config.json'),
+      lines: 2,
+    });
+
+    expect(snapshot.status).toBe('ok');
+    expect(snapshot.output).toBe('three\nfour\n');
+  });
+
+  it('reports missing local logs without invoking platform log systems', () => {
+    const dir = makeTempDir();
+    const snapshot = readLocalLogSnapshot({
+      role: 'node',
+      configPath: path.join(dir, 'config.json'),
+      lines: 10,
+    });
+
+    expect(snapshot.status).toBe('missing');
+    expect(snapshot.message).toContain('No local Relay node log files were found');
+    expect(snapshot.message).toContain(path.join(dir, 'logs', 'relay-ide.log'));
+    expect(snapshot.message).not.toContain('journalctl');
+    expect(snapshot.message).not.toContain('systemctl');
+  });
+
+  it('reports empty local log files clearly', () => {
+    const dir = makeTempDir();
+    const logDir = path.join(dir, 'logs');
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.writeFileSync(path.join(logDir, 'relay-ide.log'), '');
+
+    const snapshot = readLocalLogSnapshot({
+      role: 'hub',
+      configPath: path.join(dir, 'config.json'),
+      lines: 10,
+    });
+
+    expect(snapshot.status).toBe('empty');
+    expect(snapshot.message).toContain('Local Relay hub log files exist but are empty');
+  });
+
+  it('parses --lines as a non-negative integer', () => {
+    expect(parseLogLineCount(undefined)).toBe(100);
+    expect(parseLogLineCount('0')).toBe(0);
+    expect(parseLogLineCount('25')).toBe(25);
+    expect(() => parseLogLineCount('-1')).toThrow('Invalid --lines value');
+    expect(() => parseLogLineCount('abc')).toThrow('Invalid --lines value');
+  });
+
+  it('follows appended log lines without requiring systemd or journalctl', async () => {
+    const dir = makeTempDir();
+    const logFile = path.join(dir, 'relay-ide.log');
+    fs.writeFileSync(logFile, 'existing\n');
+    let output = '';
+    const follower = createLocalLogFollower({
+      files: [logFile],
+      pollIntervalMs: 20,
+      write: (chunk) => {
+        output += chunk;
+      },
+    });
+
+    try {
+      fs.appendFileSync(logFile, 'appended\n');
+      await waitFor(() => output.includes('appended'));
+      expect(output).toBe('appended\n');
+    } finally {
+      follower.close();
+    }
+  });
+});

--- a/test/local-logs.test.ts
+++ b/test/local-logs.test.ts
@@ -76,6 +76,37 @@ describe('local Relay logs', () => {
     expect(snapshot.output).toBe('three\nfour\n');
   });
 
+  it('skips unreadable local log files while reading other logs', () => {
+    if (process.platform === 'win32' || process.getuid?.() === 0) return;
+
+    const dir = makeTempDir();
+    const logDir = path.join(dir, 'logs');
+    const serviceLogDir = path.join(dir, 'service-logs');
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.mkdirSync(serviceLogDir, { recursive: true });
+    const unreadableLog = path.join(logDir, 'relay-ide.log');
+    fs.writeFileSync(unreadableLog, 'do-not-read\n');
+    fs.chmodSync(unreadableLog, 0o000);
+    fs.writeFileSync(path.join(serviceLogDir, 'stdout.log'), 'service-log\n');
+
+    const snapshot = (() => {
+      try {
+        return readLocalLogSnapshot({
+          role: 'hub',
+          configPath: path.join(dir, 'config.json'),
+          serviceLogDir,
+          lines: 10,
+        });
+      } finally {
+        fs.chmodSync(unreadableLog, 0o600);
+      }
+    })();
+
+    expect(snapshot.status).toBe('ok');
+    expect(snapshot.files).not.toContain(unreadableLog);
+    expect(snapshot.output).toBe('service-log\n');
+  });
+
   it('reports missing local logs without invoking platform log systems', () => {
     const dir = makeTempDir();
     const snapshot = readLocalLogSnapshot({

--- a/test/node-bootstrap-docs.test.ts
+++ b/test/node-bootstrap-docs.test.ts
@@ -11,7 +11,7 @@ function readRepoFile(relativePath: string): string {
 }
 
 describe('relay-node bootstrap docs', () => {
-  it('keeps macOS launchd diagnostics aligned with the service label and CLI log hint', () => {
+  it('keeps macOS launchd diagnostics aligned with local CLI log behavior', () => {
     const cliSource = readRepoFile('bin/relay-ide.ts');
     const docs = readRepoFile('docs/RELAY_NODE_BOOTSTRAP.md');
     const serviceSource = readRepoFile('server/service.ts');
@@ -22,10 +22,8 @@ describe('relay-node bootstrap docs', () => {
     const serviceLabel = serviceLabelMatch![1];
 
     expect(serviceLabel).toBe('com.relay-ide');
-
-    const launchdLogHint = `launchctl print gui/$(id -u)/${serviceLabel}`;
-    expect(cliSource).toContain(launchdLogHint);
-    expect(docs).toContain(launchdLogHint);
+    expect(cliSource).toContain('logs [--lines <n>] [--follow]');
+    expect(cliSource).toContain('readLocalLogSnapshot');
     expect(docs).not.toContain(`${serviceLabel}.node`);
   });
 


### PR DESCRIPTION
Closes #503
Refs #476


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `hub logs` and `node logs` CLI commands to read and display local log files from the filesystem.
  * Added `--lines` option to limit the number of log lines displayed.
  * Added `--follow` flag to stream new log entries in real-time as they are written.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->