### PR TITLE
feat: add hub policy evaluator

### DIFF
--- a/server/features/repo-router.ts
+++ b/server/features/repo-router.ts
@@ -19,9 +19,11 @@ import {
 } from '../hub-node-router.js';
 import {
   evaluateHubPolicy,
+  isSessionCreateType,
   policyDecisionToRelayError,
   appendPolicyAudit,
   sessionCreateCapability,
+  type SessionCreateType,
 } from '../hub-policy-evaluator.js';
 import type { RepoInventoryFeature } from './repo-inventory.js';
 import type { RepoInventoryReport } from '../../shared/repo-inventory.js';
@@ -41,6 +43,16 @@ export interface RepoFeatureRouterOptions {
   sessionEnvelopes?: InMemorySessionEnvelopeRegistry;
   auditSink?: RoutedSessionAuditSink;
   now?: () => Date;
+}
+
+function sessionCreateTypeFromBody(body: Record<string, unknown>): SessionCreateType | RelayNodeError {
+  const rawSessionType = body['type'];
+  if (rawSessionType === undefined) return 'agent';
+  if (isSessionCreateType(rawSessionType)) return rawSessionType;
+  return relayError('INVALID_REQUEST', 'type must be agent or terminal', false, {
+    reasonCode: 'INVALID_SESSION_TYPE',
+    field: 'type',
+  });
 }
 
 // Repo-feature HTTP surface. These routes used to live in
@@ -160,6 +172,11 @@ export function createRepoFeatureRouter(
         );
         return;
       }
+      const sessionType = sessionCreateTypeFromBody(body);
+      if (typeof sessionType !== 'string') {
+        sendRelayError(res, sessionType);
+        return;
+      }
       try {
         const reports = [...repoInventoryFeature.listInventoryReports()];
         if (options.collectLocalRepoInventory) {
@@ -183,7 +200,7 @@ export function createRepoFeatureRouter(
             repoPath: target.repo.localPath,
             ...(target.worktree ? { worktreePath: target.worktree.localPath } : {}),
           },
-          requiredCapabilities: [sessionCreateCapability(body['type'])],
+          requiredCapabilities: [sessionCreateCapability(sessionType)],
           ...(expiresAt !== undefined ? { expiresAt } : {}),
           params: body,
           now: reopenNow,

--- a/server/features/repo-router.ts
+++ b/server/features/repo-router.ts
@@ -15,7 +15,14 @@ import {
   sendRelayError,
   sendRegistryError,
   sessionFromPayload,
+  type RoutedSessionAuditSink,
 } from '../hub-node-router.js';
+import {
+  evaluateHubPolicy,
+  policyDecisionToRelayError,
+  appendPolicyAudit,
+  sessionCreateCapability,
+} from '../hub-policy-evaluator.js';
 import type { RepoInventoryFeature } from './repo-inventory.js';
 import type { RepoInventoryReport } from '../../shared/repo-inventory.js';
 import {
@@ -32,6 +39,7 @@ export interface RepoFeatureRouterOptions {
   collectLocalRepoInventory?: () => Promise<RepoInventoryReport>;
   nodeLinks?: HubNodeLinkManager;
   sessionEnvelopes?: InMemorySessionEnvelopeRegistry;
+  auditSink?: RoutedSessionAuditSink;
   now?: () => Date;
 }
 
@@ -160,6 +168,31 @@ export function createRepoFeatureRouter(
         const target = findColdReopenTarget(reports, nodeId, body);
         if ('code' in target) {
           sendRelayError(res, target as RelayNodeError);
+          return;
+        }
+
+        const policyDecision = evaluateHubPolicy({
+          peer: { kind: 'hub' },
+          node,
+          nodeId,
+          intent: { action: 'sessions.create', target: nodeId },
+          scope: {
+            kind: target.worktree ? 'worktree' : 'repo',
+            nodeId,
+            cwd: target.worktree?.localPath ?? target.repo.localPath,
+            repoPath: target.repo.localPath,
+            ...(target.worktree ? { worktreePath: target.worktree.localPath } : {}),
+          },
+          requiredCapabilities: [sessionCreateCapability(body['type'])],
+          ...(expiresAt !== undefined ? { expiresAt } : {}),
+          params: body,
+          now: reopenNow,
+        });
+        const auditedDecision = appendPolicyAudit(options.auditSink, policyDecision, {
+          params: body,
+        });
+        if (auditedDecision.decision !== 'allow') {
+          sendRelayError(res, policyDecisionToRelayError(auditedDecision));
           return;
         }
 

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -53,6 +53,7 @@ import {
 import {
   appendPolicyAudit,
   evaluateHubPolicy,
+  isSessionCreateType,
   policyDecisionToRelayError,
   revokePolicyAffectedSessions,
   sessionCreateCapability,
@@ -125,6 +126,7 @@ export function errorStatus(error: RelayNodeError): number {
     case 'NODE_UNSUPPORTED':
     case 'INVALID_REQUEST':
       return 400;
+    case 'UNSUPPORTED_CAPABILITY':
     case 'NODE_REVOKED':
     case 'SESSION_EXPIRED':
     case 'SESSION_REVOKED':
@@ -622,6 +624,44 @@ function appendRoutedSessionAudit(
   }
 }
 
+function auditLifecycleDenial(
+  sink: RoutedSessionAuditSink | undefined,
+  validation: Exclude<ReturnType<InMemorySessionEnvelopeRegistry['validate']>, { ok: true }>,
+  nodeId: string,
+  sessionId: string,
+  action: string,
+  params?: unknown
+): void {
+  const reasonCode =
+    typeof validation.error.details?.['reasonCode'] === 'string'
+      ? validation.error.details['reasonCode']
+      : validation.error.code;
+  appendRoutedSessionAudit(sink, {
+    eventType:
+      validation.error.code === 'SESSION_EXPIRED'
+        ? 'expiry'
+        : validation.error.code === 'SESSION_REVOKED'
+          ? 'revocation'
+          : 'denial',
+    decision:
+      validation.error.code === 'SESSION_EXPIRED'
+        ? 'expired'
+        : validation.error.code === 'SESSION_REVOKED'
+          ? 'revoked'
+          : 'deny',
+    reasonCode,
+    peer: auditPeerForSummary(validation.summary),
+    node: { nodeId },
+    sessionId,
+    intent: { action, target: nodeId },
+    material: {
+      scope: validation.summary?.scope ?? null,
+      params: params ?? validation.error.details ?? null,
+    },
+    ...(validation.summary?.correlationId ? { correlationId: validation.summary.correlationId } : {}),
+  });
+}
+
 function sendPolicyDecision(
   sink: RoutedSessionAuditSink | undefined,
   res: Response,
@@ -1108,7 +1148,18 @@ export function createHubNodeRouter(
       );
       return;
     }
-    const sessionType = body['type'] === 'agent' ? 'agent' : 'terminal';
+    const rawSessionType = body['type'];
+    if (rawSessionType !== undefined && !isSessionCreateType(rawSessionType)) {
+      sendRelayError(
+        res,
+        relayError('INVALID_REQUEST', 'type must be agent or terminal', false, {
+          reasonCode: 'INVALID_SESSION_TYPE',
+          field: 'type',
+        })
+      );
+      return;
+    }
+    const sessionType = rawSessionType === 'agent' ? 'agent' : 'terminal';
     const policyDecision = evaluateHubPolicy({
       peer: { kind: 'hub' },
       node,
@@ -1196,7 +1247,23 @@ export function createHubNodeRouter(
       }
 
       const lifecycle = envelopes.validate({ nodeId, sessionId, now: now() });
-      const scoped = lifecycle.ok ? lifecycle.summary : lifecycle.summary;
+      if (!lifecycle.ok) {
+        const denial = lifecycle as Exclude<
+          ReturnType<InMemorySessionEnvelopeRegistry['validate']>,
+          { ok: true }
+        >;
+        auditLifecycleDenial(
+          options.auditSink,
+          denial,
+          nodeId,
+          sessionId,
+          'sessions.kill',
+          { method: 'DELETE' }
+        );
+        sendRelayError(res, denial.error);
+        return;
+      }
+      const scoped = lifecycle.summary;
       const killPolicyDecision = evaluateHubPolicy({
         peer: { kind: 'hub' },
         node,

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -50,6 +50,13 @@ import {
   type InMemorySessionEnvelopeRegistry,
   type ScopedSessionSummary,
 } from './session-envelope-registry.js';
+import {
+  appendPolicyAudit,
+  evaluateHubPolicy,
+  policyDecisionToRelayError,
+  revokePolicyAffectedSessions,
+  sessionCreateCapability,
+} from './hub-policy-evaluator.js';
 
 interface HubNodeSessionTransport {
   hasActiveNode(nodeId: string): boolean;
@@ -615,6 +622,18 @@ function appendRoutedSessionAudit(
   }
 }
 
+function sendPolicyDecision(
+  sink: RoutedSessionAuditSink | undefined,
+  res: Response,
+  decision: ReturnType<typeof evaluateHubPolicy>,
+  params?: unknown
+): boolean {
+  const audited = appendPolicyAudit(sink, decision, { params });
+  if (audited.decision === 'allow') return false;
+  sendRelayError(res, policyDecisionToRelayError(audited));
+  return true;
+}
+
 function auditLifecycleRevocation(
   sink: RoutedSessionAuditSink | undefined,
   summary: ScopedSessionSummary,
@@ -640,6 +659,27 @@ function revokedReasonFromBody(body: Record<string, unknown>): string | undefine
 
 function includeFlag(value: unknown): boolean {
   return value === '1' || value === 'true' || value === true;
+}
+
+function sessionCreatePolicyScope(
+  nodeId: string,
+  body: Record<string, unknown>
+): Parameters<typeof evaluateHubPolicy>[0]['scope'] {
+  const repoPath = stringField(body, 'repoPath');
+  const worktreePath = stringField(body, 'worktreePath');
+  const cwd = stringField(body, 'cwd') ?? worktreePath ?? repoPath ?? '/';
+  const kind = worktreePath ? 'worktree' : repoPath ? 'repo' : 'node-cwd';
+  return {
+    kind,
+    nodeId,
+    cwd,
+    ...(repoPath ? { repoPath } : {}),
+    ...(body['worktreePath'] === null
+      ? { worktreePath: null }
+      : worktreePath
+        ? { worktreePath }
+        : {}),
+  };
 }
 
 function revokeAddressError(
@@ -1068,6 +1108,19 @@ export function createHubNodeRouter(
       );
       return;
     }
+    const sessionType = body['type'] === 'agent' ? 'agent' : 'terminal';
+    const policyDecision = evaluateHubPolicy({
+      peer: { kind: 'hub' },
+      node,
+      nodeId,
+      intent: { action: 'sessions.create', target: nodeId },
+      scope: sessionCreatePolicyScope(nodeId, body),
+      requiredCapabilities: [sessionCreateCapability(sessionType)],
+      ...(expiresAt !== undefined ? { expiresAt } : {}),
+      params: body,
+      now: createNow,
+    });
+    if (sendPolicyDecision(options.auditSink, res, policyDecision, body)) return;
 
     try {
       const payload = await options.nodeLinks.request(
@@ -1142,6 +1195,34 @@ export function createHubNodeRouter(
         return;
       }
 
+      const lifecycle = envelopes.validate({ nodeId, sessionId, now: now() });
+      const scoped = lifecycle.ok ? lifecycle.summary : lifecycle.summary;
+      const killPolicyDecision = evaluateHubPolicy({
+        peer: { kind: 'hub' },
+        node,
+        nodeId,
+        intent: { action: 'sessions.kill', target: nodeId },
+        scope: scoped
+          ? {
+              kind: scoped.scope.kind,
+              nodeId,
+              cwd: scoped.scope.cwd,
+              ...(scoped.scope.repoPath ? { repoPath: scoped.scope.repoPath } : {}),
+              ...(scoped.scope.worktreePath !== undefined
+                ? { worktreePath: scoped.scope.worktreePath }
+                : {}),
+            }
+          : { kind: 'node', nodeId, cwd: '/' },
+        requiredCapabilities: ['session:attach'],
+        sessionId,
+        ...(scoped?.correlationId ? { correlationId: scoped.correlationId } : {}),
+        ...(scoped?.expiresAt !== undefined ? { expiresAt: scoped.expiresAt } : {}),
+        ...(scoped?.revokedAt ? { revokedAt: scoped.revokedAt } : {}),
+        params: { method: 'DELETE' },
+        now: now(),
+      });
+      if (sendPolicyDecision(options.auditSink, res, killPolicyDecision, { method: 'DELETE' })) return;
+
       try {
         await options.nodeLinks.request(nodeId, 'sessions.kill', {
           id: sessionId,
@@ -1171,7 +1252,25 @@ export function createHubNodeRouter(
       return;
     }
     try {
-      res.json({ node: registry.revokeNode(nodeId) });
+      const node = registry.revokeNode(nodeId);
+      const revokedSessions = revokePolicyAffectedSessions({
+        envelopes,
+        nodeId,
+        node,
+        reason: 'node-revoked',
+        now: now(),
+        auditSink: options.auditSink,
+      });
+      res.json({
+        node,
+        events: revokedSessions.map((session) => ({
+          type: 'SESSION_PERMISSION_REVOKED',
+          nodeId,
+          sessionId: session.sessionId,
+          globalSessionId: session.globalSessionId,
+          reasonCode: 'POLICY_NODE_REVOKED',
+        })),
+      });
     } catch (error) {
       sendRegistryError(registry, res, error);
     }

--- a/server/hub-policy-evaluator.ts
+++ b/server/hub-policy-evaluator.ts
@@ -1,0 +1,517 @@
+import {
+  classifySecurityAuditWriteFailure,
+  type SecurityAuditDecision,
+  type SecurityAuditEntryInput,
+  type SecurityAuditEventType,
+} from '../shared/security-audit.js';
+import {
+  RELAY_SECURITY_POLICY_VERSION,
+  isRelayCapabilityBit,
+  isRelayTrustTier,
+  type RelayAclSummary,
+  type RelayCapabilityBit,
+  type RelayPolicyScope,
+  type RelayTrustTier,
+} from '../shared/security-policy.js';
+import type { HubNodeSummary, RelayNodeError } from '../shared/relay-node-protocol.js';
+import type {
+  InMemorySessionEnvelopeRegistry,
+  ScopedSessionSummary,
+} from './session-envelope-registry.js';
+import type { RoutedSessionAuditSink } from './hub-node-router.js';
+
+export type HubPolicyDecisionKind = 'allow' | 'deny' | 'challenge' | 'revoke';
+
+export type HubPolicyReasonCode =
+  | 'POLICY_ALLOWED'
+  | 'POLICY_CHALLENGE_REQUIRED'
+  | 'POLICY_NODE_NOT_PAIRED'
+  | 'POLICY_NODE_REVOKED'
+  | 'POLICY_NODE_ID_MISMATCH'
+  | 'POLICY_PEER_NODE_MISMATCH'
+  | 'POLICY_SCOPE_NODE_MISMATCH'
+  | 'POLICY_SCOPE_DENIED'
+  | 'POLICY_ACL_MISSING'
+  | 'POLICY_ACL_REVOKED'
+  | 'POLICY_SESSION_EXPIRED'
+  | 'POLICY_SESSION_REVOKED'
+  | 'POLICY_UNKNOWN_CAPABILITY'
+  | 'POLICY_CAPABILITY_DENIED'
+  | 'POLICY_AUDIT_WRITE_FAILED_CLOSED'
+  | 'POLICY_LOCAL_COMPATIBILITY_ALLOWED';
+
+export interface HubPolicyPeerIdentity {
+  kind: 'hub' | 'node' | 'local-user' | 'system';
+  nodeId?: string;
+  credentialId?: string;
+  displayName?: string;
+}
+
+export interface HubPolicyIntent {
+  action: string;
+  target?: string;
+}
+
+export interface HubPolicyScope {
+  kind: 'local-compatibility' | RelayPolicyScope['kind'] | 'node-cwd' | 'worktree';
+  nodeId: string;
+  cwd?: string | undefined;
+  path?: string | undefined;
+  workspaceId?: string | undefined;
+  repoId?: string | undefined;
+  repoPath?: string | undefined;
+  worktreePath?: string | null | undefined;
+}
+
+export interface HubPolicyEvaluationInput {
+  peer: HubPolicyPeerIdentity;
+  node?: HubNodeSummary | null | undefined;
+  nodeId: string;
+  intent: HubPolicyIntent;
+  scope: HubPolicyScope;
+  requiredCapabilities: readonly string[];
+  now?: Date | undefined;
+  expiresAt?: string | null | undefined;
+  revokedAt?: string | null | undefined;
+  sessionId?: string | undefined;
+  correlationId?: string | undefined;
+  params?: unknown;
+}
+
+export interface HubPolicyDecision {
+  decision: HubPolicyDecisionKind;
+  reasonCode: HubPolicyReasonCode;
+  message: string;
+  nodeId: string;
+  peer: HubPolicyPeerIdentity;
+  intent: HubPolicyIntent;
+  scope: HubPolicyScope;
+  trustTier?: RelayTrustTier;
+  aclRef?: string;
+  policyVersion?: string;
+  requiredBits: RelayCapabilityBit[];
+  grantedBits: RelayCapabilityBit[];
+  deniedBits: RelayCapabilityBit[];
+  challengeBits: RelayCapabilityBit[];
+  unknownBits: string[];
+  sessionId?: string;
+  correlationId?: string;
+  params?: unknown;
+}
+
+export function sessionCreateCapability(sessionType: unknown): RelayCapabilityBit {
+  return sessionType === 'agent' ? 'session:create:agent' : 'session:create:terminal';
+}
+
+export function requiredCapabilitiesForRpcIntent(action: string): string[] {
+  switch (action) {
+    case 'sessions.create.terminal':
+      return ['session:create:terminal'];
+    case 'sessions.create.agent':
+      return ['session:create:agent'];
+    case 'sessions.attach':
+      return ['session:attach'];
+    case 'sessions.read':
+      return ['session:read'];
+    case 'rpc.fs.list':
+      return ['rpc:fs:list'];
+    case 'rpc.fs.read':
+      return ['rpc:fs:read'];
+    case 'rpc.fs.tail':
+      return ['rpc:fs:tail'];
+    case 'rpc.fs.write':
+      return ['rpc:fs:write'];
+    case 'rpc.fs.delete':
+      return ['rpc:fs:delete'];
+    case 'rpc.git.read':
+      return ['rpc:git:read'];
+    case 'rpc.git.write':
+      return ['rpc:git:write'];
+    case 'pty.exec.arbitrary':
+      return ['pty:exec:arbitrary'];
+    case 'preview.port-forward':
+      return ['preview:port-forward'];
+    default:
+      return [];
+  }
+}
+
+export function evaluateHubPolicy(input: HubPolicyEvaluationInput): HubPolicyDecision {
+  const required = normalizeRequiredCapabilities(input.requiredCapabilities);
+  const base = baseDecision(input, required.known, required.unknown);
+  if (!input.node) {
+    return deny(base, 'POLICY_NODE_NOT_PAIRED', 'node is not paired');
+  }
+  if (input.node.status === 'revoked' || input.node.credentialState === 'revoked') {
+    return revoke(base, input.node, 'POLICY_NODE_REVOKED', 'node credential was revoked');
+  }
+  if (input.node.nodeId !== input.nodeId) {
+    return deny(
+      withPolicy(base, input.node),
+      'POLICY_NODE_ID_MISMATCH',
+      'policy node does not match requested node'
+    );
+  }
+  if (input.peer.kind === 'node' && input.peer.nodeId !== input.nodeId) {
+    return deny(
+      withPolicy(base, input.node),
+      'POLICY_PEER_NODE_MISMATCH',
+      'node credential cannot act as a different node'
+    );
+  }
+  if (input.scope.nodeId !== input.nodeId) {
+    return deny(
+      withPolicy(base, input.node),
+      'POLICY_SCOPE_NODE_MISMATCH',
+      'requested scope belongs to a different node'
+    );
+  }
+  if (input.revokedAt) {
+    return revoke(
+      withPolicy(base, input.node),
+      input.node,
+      'POLICY_SESSION_REVOKED',
+      'scoped session has been revoked'
+    );
+  }
+  if (isExpired(input.expiresAt, input.now ?? new Date())) {
+    return revoke(
+      withPolicy(base, input.node),
+      input.node,
+      'POLICY_SESSION_EXPIRED',
+      'scoped session has expired'
+    );
+  }
+
+  const policy = input.node.trust.policy;
+  if (!policy) {
+    return deny(
+      withPolicy(base, input.node),
+      'POLICY_ACL_MISSING',
+      'node ACL policy is missing'
+    );
+  }
+  if (policy.revokedAt || policy.supersededBy) {
+    return revoke(
+      withPolicy(base, input.node),
+      input.node,
+      'POLICY_ACL_REVOKED',
+      'node ACL is revoked or superseded'
+    );
+  }
+  if (!scopeMatchesPolicy(policy.scope, input.scope)) {
+    return deny(
+      withPolicy(base, input.node),
+      'POLICY_SCOPE_DENIED',
+      'requested scope is outside the node ACL'
+    );
+  }
+  if (required.unknown.length > 0) {
+    return deny(
+      withPolicy(base, input.node),
+      'POLICY_UNKNOWN_CAPABILITY',
+      'required capability is unknown to this policy version'
+    );
+  }
+
+  const allowed = new Set(policy.allowed);
+  const challenged = new Set(policy.requiresConfirmation);
+  const grantedBits: RelayCapabilityBit[] = [];
+  const challengeBits: RelayCapabilityBit[] = [];
+  const deniedBits: RelayCapabilityBit[] = [];
+  for (const bit of required.known) {
+    if (challenged.has(bit)) challengeBits.push(bit);
+    else if (allowed.has(bit)) grantedBits.push(bit);
+    else deniedBits.push(bit);
+  }
+  const withBits = {
+    ...withPolicy(base, input.node),
+    grantedBits,
+    challengeBits,
+    deniedBits,
+  };
+  if (deniedBits.length > 0) {
+    return deny(
+      withBits,
+      'POLICY_CAPABILITY_DENIED',
+      'node ACL does not grant a required capability'
+    );
+  }
+  if (challengeBits.length > 0) {
+    return {
+      ...withBits,
+      decision: 'challenge',
+      reasonCode: 'POLICY_CHALLENGE_REQUIRED',
+      message: 'node ACL requires confirmation for this capability',
+    };
+  }
+  return {
+    ...withBits,
+    decision: 'allow',
+    reasonCode:
+      input.scope.kind === 'local-compatibility'
+        ? 'POLICY_LOCAL_COMPATIBILITY_ALLOWED'
+        : 'POLICY_ALLOWED',
+    message: 'policy allowed',
+  };
+}
+
+export function policyDecisionToRelayError(decision: HubPolicyDecision): RelayNodeError {
+  const code: RelayNodeError['code'] =
+    decision.decision === 'challenge' ? 'UNSUPPORTED_CAPABILITY' : 'UNAUTHORIZED';
+  return {
+    code,
+    message: decision.message,
+    retryable: false,
+    details: {
+      reasonCode: decision.reasonCode,
+      decision: decision.decision,
+      requiredBits: decision.requiredBits,
+      grantedBits: decision.grantedBits,
+      deniedBits: decision.deniedBits,
+      challengeBits: decision.challengeBits,
+      unknownBits: decision.unknownBits,
+      aclRef: decision.aclRef ?? null,
+      policyVersion: decision.policyVersion ?? null,
+    },
+  };
+}
+
+export function auditEntryForPolicyDecision(
+  decision: HubPolicyDecision,
+  material?: { params?: unknown; scope?: unknown }
+): SecurityAuditEntryInput {
+  return {
+    eventType: auditEventType(decision),
+    decision: auditDecision(decision),
+    reasonCode: decision.reasonCode,
+    peer: auditPeer(decision.peer),
+    node: { nodeId: decision.nodeId, ...(decision.trustTier ? { trustTier: decision.trustTier } : {}) },
+    ...(decision.sessionId ? { sessionId: decision.sessionId } : {}),
+    intent: decision.intent,
+    material: {
+      scope: material?.scope ?? decision.scope,
+      params: material?.params ?? decision.params ?? null,
+    },
+    requiredBits: decision.requiredBits,
+    grantedBits: decision.grantedBits,
+    deniedBits: [...decision.deniedBits, ...knownDeniedUnknowns(decision)],
+    refs: {
+      ...(decision.aclRef ? { aclRef: decision.aclRef } : {}),
+      policyVersion: decision.policyVersion ?? RELAY_SECURITY_POLICY_VERSION,
+    },
+    ...(decision.correlationId ? { correlationId: decision.correlationId } : {}),
+  };
+}
+
+export function appendPolicyAudit(
+  sink: RoutedSessionAuditSink | undefined,
+  decision: HubPolicyDecision,
+  material?: { params?: unknown; scope?: unknown }
+): HubPolicyDecision {
+  if (!sink) return decision;
+  try {
+    sink.append(auditEntryForPolicyDecision(decision, material));
+    return decision;
+  } catch {
+    const classification = classifySecurityAuditWriteFailure({
+      ...(decision.trustTier ? { trustTier: decision.trustTier } : {}),
+      requiredBits: decision.requiredBits,
+      decision: auditDecision(decision),
+    });
+    if (classification.mode === 'fail-closed') {
+      return deny(
+        {
+          ...decision,
+          grantedBits: [],
+          deniedBits: decision.requiredBits,
+          challengeBits: [],
+        },
+        'POLICY_AUDIT_WRITE_FAILED_CLOSED',
+        classification.visibleMessage
+      );
+    }
+    return decision;
+  }
+}
+
+export function revokePolicyAffectedSessions(input: {
+  envelopes: InMemorySessionEnvelopeRegistry;
+  nodeId: string;
+  node?: HubNodeSummary | null;
+  reason?: string;
+  now?: Date;
+  auditSink?: RoutedSessionAuditSink | undefined;
+}): ScopedSessionSummary[] {
+  const now = input.now ?? new Date();
+  const summaries = input.envelopes.revokeForNode(input.nodeId, {
+    reason: input.reason ?? 'policy-revoked',
+    now,
+  });
+  for (const summary of summaries) {
+    const decision = evaluateHubPolicy({
+      peer: { kind: 'system' },
+      node: input.node ?? null,
+      nodeId: input.nodeId,
+      intent: { action: 'sessions.revalidate', target: input.nodeId },
+      scope: {
+        kind: summary.scope.kind,
+        nodeId: summary.nodeId,
+        cwd: summary.scope.cwd,
+        ...(summary.scope.repoPath ? { repoPath: summary.scope.repoPath } : {}),
+        ...(summary.scope.worktreePath !== undefined
+          ? { worktreePath: summary.scope.worktreePath }
+          : {}),
+      },
+      requiredCapabilities: ['session:attach'],
+      revokedAt: summary.revokedAt,
+      expiresAt: summary.expiresAt,
+      sessionId: summary.sessionId,
+      ...(summary.correlationId ? { correlationId: summary.correlationId } : {}),
+      now,
+    });
+    appendPolicyAudit(input.auditSink, {
+      ...decision,
+      decision: 'revoke',
+      reasonCode: 'POLICY_SESSION_REVOKED',
+      message: 'session permission revoked after policy change',
+    });
+  }
+  return summaries;
+}
+
+function normalizeRequiredCapabilities(required: readonly string[]): {
+  known: RelayCapabilityBit[];
+  unknown: string[];
+} {
+  const known: RelayCapabilityBit[] = [];
+  const unknown: string[] = [];
+  const seen = new Set<string>();
+  for (const bit of required) {
+    if (seen.has(bit)) continue;
+    seen.add(bit);
+    if (isRelayCapabilityBit(bit)) known.push(bit);
+    else unknown.push(bit);
+  }
+  return { known, unknown };
+}
+
+function baseDecision(
+  input: HubPolicyEvaluationInput,
+  requiredBits: RelayCapabilityBit[],
+  unknownBits: string[]
+): HubPolicyDecision {
+  return {
+    decision: 'deny',
+    reasonCode: 'POLICY_CAPABILITY_DENIED',
+    message: 'policy denied',
+    nodeId: input.nodeId,
+    peer: input.peer,
+    intent: input.intent,
+    scope: input.scope,
+    requiredBits,
+    grantedBits: [],
+    deniedBits: requiredBits,
+    challengeBits: [],
+    unknownBits,
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+    ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+    ...(input.params !== undefined ? { params: input.params } : {}),
+  };
+}
+
+function withPolicy(decision: HubPolicyDecision, node: HubNodeSummary): HubPolicyDecision {
+  const policy = node.trust.policy;
+  const trustTier = policy?.trustTier ?? node.trust.tier;
+  return {
+    ...decision,
+    ...(isRelayTrustTier(trustTier) ? { trustTier } : {}),
+    ...(policy ? { aclRef: policy.ref, policyVersion: policy.policyVersion } : {}),
+  };
+}
+
+function deny(
+  decision: HubPolicyDecision,
+  reasonCode: HubPolicyReasonCode,
+  message: string
+): HubPolicyDecision {
+  return { ...decision, decision: 'deny', reasonCode, message };
+}
+
+function revoke(
+  decision: HubPolicyDecision,
+  node: HubNodeSummary,
+  reasonCode: HubPolicyReasonCode,
+  message: string
+): HubPolicyDecision {
+  return { ...withPolicy(decision, node), decision: 'revoke', reasonCode, message };
+}
+
+function isExpired(expiresAt: string | null | undefined, now: Date): boolean {
+  if (!expiresAt) return false;
+  const ms = Date.parse(expiresAt);
+  return !Number.isFinite(ms) || ms <= now.getTime();
+}
+
+function scopeMatchesPolicy(policy: RelayPolicyScope, scope: HubPolicyScope): boolean {
+  if (scope.kind === 'local-compatibility') return true;
+  if (policy.kind === 'node') return true;
+  if (policy.kind === 'workspace') {
+    return Boolean(
+      scope.workspaceId && policy.workspaceIds?.includes(scope.workspaceId)
+    );
+  }
+  if (policy.kind === 'repo') {
+    return Boolean(
+      (scope.repoId && policy.repoIds?.includes(scope.repoId)) ||
+        (scope.repoPath && policy.repoIds?.includes(scope.repoPath))
+    );
+  }
+  const requestedPath = scope.path ?? scope.worktreePath ?? scope.repoPath ?? scope.cwd;
+  return Boolean(
+    requestedPath &&
+      policy.pathPrefixes?.some((prefix) => pathWithinPrefix(requestedPath, prefix))
+  );
+}
+
+function pathWithinPrefix(candidate: string, prefix: string): boolean {
+  return candidate === prefix || candidate.startsWith(prefix.endsWith('/') ? prefix : `${prefix}/`);
+}
+
+function auditEventType(decision: HubPolicyDecision): SecurityAuditEventType {
+  if (decision.decision === 'allow') return 'grant';
+  if (decision.decision === 'challenge') return 'challenge';
+  if (decision.decision === 'revoke') return 'revocation';
+  return 'denial';
+}
+
+function auditDecision(decision: HubPolicyDecision): SecurityAuditDecision {
+  if (decision.decision === 'allow') return 'allow';
+  if (decision.decision === 'challenge') return 'requires_confirmation';
+  if (decision.decision === 'revoke') return 'revoked';
+  return 'deny';
+}
+
+function auditPeer(peer: HubPolicyPeerIdentity): SecurityAuditEntryInput['peer'] {
+  if (peer.kind === 'node') {
+    return {
+      kind: 'node',
+      ...(peer.nodeId ? { nodeId: peer.nodeId } : {}),
+      ...(peer.credentialId ? { credentialId: peer.credentialId } : {}),
+      ...(peer.displayName ? { displayName: peer.displayName } : {}),
+    };
+  }
+  if (peer.kind === 'local-user') {
+    return {
+      kind: 'user',
+      ...(peer.displayName ? { displayName: peer.displayName } : {}),
+    };
+  }
+  return { kind: peer.kind };
+}
+
+function knownDeniedUnknowns(decision: HubPolicyDecision): RelayCapabilityBit[] {
+  return decision.unknownBits.filter(isRelayCapabilityBit);
+}
+
+export type { RelayAclSummary };

--- a/server/hub-policy-evaluator.ts
+++ b/server/hub-policy-evaluator.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path';
 import {
   classifySecurityAuditWriteFailure,
   type SecurityAuditDecision,
@@ -29,6 +30,7 @@ export type HubPolicyReasonCode =
   | 'POLICY_NODE_REVOKED'
   | 'POLICY_NODE_ID_MISMATCH'
   | 'POLICY_PEER_NODE_MISMATCH'
+  | 'POLICY_PEER_CREDENTIAL_MISMATCH'
   | 'POLICY_SCOPE_NODE_MISMATCH'
   | 'POLICY_SCOPE_DENIED'
   | 'POLICY_ACL_MISSING'
@@ -99,7 +101,13 @@ export interface HubPolicyDecision {
   params?: unknown;
 }
 
-export function sessionCreateCapability(sessionType: unknown): RelayCapabilityBit {
+export type SessionCreateType = 'agent' | 'terminal';
+
+export function isSessionCreateType(value: unknown): value is SessionCreateType {
+  return value === 'agent' || value === 'terminal';
+}
+
+export function sessionCreateCapability(sessionType: SessionCreateType): RelayCapabilityBit {
   return sessionType === 'agent' ? 'session:create:agent' : 'session:create:terminal';
 }
 
@@ -132,7 +140,7 @@ export function requiredCapabilitiesForRpcIntent(action: string): string[] {
     case 'preview.port-forward':
       return ['preview:port-forward'];
     default:
-      return [];
+      return [`rpc:unknown:${action}`];
   }
 }
 
@@ -157,6 +165,17 @@ export function evaluateHubPolicy(input: HubPolicyEvaluationInput): HubPolicyDec
       withPolicy(base, input.node),
       'POLICY_PEER_NODE_MISMATCH',
       'node credential cannot act as a different node'
+    );
+  }
+  if (
+    input.peer.kind === 'node' &&
+    input.peer.credentialId &&
+    input.peer.credentialId !== input.node.credentialId
+  ) {
+    return deny(
+      withPolicy(base, input.node),
+      'POLICY_PEER_CREDENTIAL_MISMATCH',
+      'node credential does not match the active credential for this node'
     );
   }
   if (input.scope.nodeId !== input.nodeId) {
@@ -257,8 +276,7 @@ export function evaluateHubPolicy(input: HubPolicyEvaluationInput): HubPolicyDec
 }
 
 export function policyDecisionToRelayError(decision: HubPolicyDecision): RelayNodeError {
-  const code: RelayNodeError['code'] =
-    decision.decision === 'challenge' ? 'UNSUPPORTED_CAPABILITY' : 'UNAUTHORIZED';
+  const code: RelayNodeError['code'] = policyDecisionErrorCode(decision);
   return {
     code,
     message: decision.message,
@@ -275,6 +293,26 @@ export function policyDecisionToRelayError(decision: HubPolicyDecision): RelayNo
       policyVersion: decision.policyVersion ?? null,
     },
   };
+}
+
+function policyDecisionErrorCode(decision: HubPolicyDecision): RelayNodeError['code'] {
+  switch (decision.reasonCode) {
+    case 'POLICY_NODE_NOT_PAIRED':
+      return 'NOT_FOUND';
+    case 'POLICY_NODE_REVOKED':
+    case 'POLICY_ACL_REVOKED':
+      return 'NODE_REVOKED';
+    case 'POLICY_SESSION_EXPIRED':
+      return 'SESSION_EXPIRED';
+    case 'POLICY_SESSION_REVOKED':
+      return 'SESSION_REVOKED';
+    case 'POLICY_SCOPE_NODE_MISMATCH':
+      return 'SESSION_MISMATCH';
+    case 'POLICY_AUDIT_WRITE_FAILED_CLOSED':
+      return 'INTERNAL';
+    default:
+      return decision.decision === 'challenge' ? 'UNSUPPORTED_CAPABILITY' : 'UNAUTHORIZED';
+  }
 }
 
 export function auditEntryForPolicyDecision(
@@ -475,7 +513,18 @@ function scopeMatchesPolicy(policy: RelayPolicyScope, scope: HubPolicyScope): bo
 }
 
 function pathWithinPrefix(candidate: string, prefix: string): boolean {
-  return candidate === prefix || candidate.startsWith(prefix.endsWith('/') ? prefix : `${prefix}/`);
+  const candidatePath = canonicalPolicyPath(candidate);
+  const prefixPath = canonicalPolicyPath(prefix);
+  if (!candidatePath || !prefixPath) return false;
+  return candidatePath === prefixPath || candidatePath.startsWith(`${prefixPath}/`);
+}
+
+function canonicalPolicyPath(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.includes('\0')) return null;
+  const normalized = path.posix.normalize(trimmed);
+  if (!path.posix.isAbsolute(normalized)) return null;
+  return normalized;
 }
 
 function auditEventType(decision: HubPolicyDecision): SecurityAuditEventType {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1161,6 +1161,7 @@ async function main(): Promise<void> {
       repoInventoryFeature,
       collectLocalRepoInventory: collectLocalInventory,
       sessionEnvelopes: sessionEnvelopeRegistry,
+      ...(securityAuditLog ? { auditSink: securityAuditLog } : {}),
     })
   );
 

--- a/server/session-envelope-registry.ts
+++ b/server/session-envelope-registry.ts
@@ -188,6 +188,15 @@ export function lifecycleSummary(
   };
 }
 
+function revokeRecord(
+  record: SessionEnvelopeRecord,
+  options: { reason?: string; now?: Date } = {}
+): void {
+  const nowIso = nowDate(options.now).toISOString();
+  record.revokedAt = record.revokedAt ?? nowIso;
+  record.revokeReason = options.reason ?? record.revokeReason ?? 'operator-revoked';
+}
+
 export class InMemorySessionEnvelopeRegistry {
   private readonly records = new Map<string, SessionEnvelopeRecord>();
 
@@ -289,10 +298,23 @@ export class InMemorySessionEnvelopeRegistry {
       ? this.readRecord(sessionIdOrGlobalId, options.nodeId)
       : this.records.get(sessionIdOrGlobalId);
     if (!record) return undefined;
-    const nowIso = nowDate(options.now).toISOString();
-    record.revokedAt = record.revokedAt ?? nowIso;
-    record.revokeReason = options.reason ?? record.revokeReason ?? 'operator-revoked';
+    revokeRecord(record, options);
     return lifecycleSummary(record, nowDate(options.now));
+  }
+
+  revokeForNode(
+    nodeId: string,
+    options: { reason?: string; now?: Date } = {}
+  ): ScopedSessionSummary[] {
+    const revoked: ScopedSessionSummary[] = [];
+    const now = nowDate(options.now);
+    for (const record of Array.from(this.records.values())) {
+      if (record.envelope.nodeId !== nodeId) continue;
+      if (lifecycleState(record, now) !== 'active') continue;
+      revokeRecord(record, { ...options, now });
+      revoked.push(lifecycleSummary(record, now));
+    }
+    return revoked;
   }
 
   validate(context: SessionLifecycleValidationContext): SessionLifecycleValidation {

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -30,6 +30,11 @@ import {
 } from './session-envelope-registry.js';
 import type { SecurityAuditEntryInput } from '../shared/security-audit.js';
 import type { RoutedSessionAuditSink } from './hub-node-router.js';
+import {
+  appendPolicyAudit,
+  evaluateHubPolicy,
+  policyDecisionToRelayError,
+} from './hub-policy-evaluator.js';
 
 const logger = createLogger('ws');
 
@@ -513,6 +518,40 @@ function setupWebSocket(
         socket.write(
           `HTTP/1.1 ${routedSessionStatus(denial.error.code)} ${denial.error.code}\r\n\r\n`
         );
+        socket.destroy();
+        return;
+      }
+      const node = hubNodeRegistry
+        ?.listNodes()
+        .find((candidate) => candidate.nodeId === nodeId);
+      const policyDecision = evaluateHubPolicy({
+        peer: { kind: 'hub' },
+        node,
+        nodeId,
+        intent: { action: 'sessions.attach', target: nodeId },
+        scope: {
+          kind: validation.summary.scope.kind,
+          nodeId,
+          cwd: validation.summary.scope.cwd,
+          ...(validation.summary.scope.repoPath
+            ? { repoPath: validation.summary.scope.repoPath }
+            : {}),
+          ...(validation.summary.scope.worktreePath !== undefined
+            ? { worktreePath: validation.summary.scope.worktreePath }
+            : {}),
+        },
+        requiredCapabilities: ['session:attach'],
+        sessionId,
+        expiresAt: validation.summary.expiresAt,
+        ...(validation.summary.revokedAt ? { revokedAt: validation.summary.revokedAt } : {}),
+        ...(validation.summary.correlationId
+          ? { correlationId: validation.summary.correlationId }
+          : {}),
+      });
+      const auditedDecision = appendPolicyAudit(auditSink, policyDecision);
+      if (auditedDecision.decision !== 'allow') {
+        const error = policyDecisionToRelayError(auditedDecision);
+        socket.write(`HTTP/1.1 ${routedSessionStatus(error.code)} ${error.code}\r\n\r\n`);
         socket.destroy();
         return;
       }

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -67,6 +67,22 @@ function routedSessionStatus(code: string): number {
   return 400;
 }
 
+function routedPolicyStatus(code: string): number {
+  if (code === 'UNAUTHORIZED') return 401;
+  if (code === 'NOT_FOUND') return 404;
+  if (code === 'INTERNAL') return 500;
+  if (
+    code === 'UNSUPPORTED_CAPABILITY' ||
+    code === 'NODE_REVOKED' ||
+    code === 'SESSION_EXPIRED' ||
+    code === 'SESSION_REVOKED' ||
+    code === 'SESSION_MISMATCH'
+  ) {
+    return 403;
+  }
+  return routedSessionStatus(code);
+}
+
 function auditAttachDenial(
   sink: RoutedSessionAuditSink | undefined,
   validation: Exclude<
@@ -551,7 +567,7 @@ function setupWebSocket(
       const auditedDecision = appendPolicyAudit(auditSink, policyDecision);
       if (auditedDecision.decision !== 'allow') {
         const error = policyDecisionToRelayError(auditedDecision);
-        socket.write(`HTTP/1.1 ${routedSessionStatus(error.code)} ${error.code}\r\n\r\n`);
+        socket.write(`HTTP/1.1 ${routedPolicyStatus(error.code)} ${error.code}\r\n\r\n`);
         socket.destroy();
         return;
       }

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -921,6 +921,38 @@ describe('hub node routes and link', () => {
     });
     expect(heartbeat.status).toBe(200);
 
+    const missingKillRes = await fetch(
+      `${base}/hub/nodes/${exchanged.node.nodeId}/sessions/missing-session`,
+      { method: 'DELETE', headers: { 'x-test-auth': 'yes' } }
+    );
+    expect(missingKillRes.status).toBe(404);
+    expect(await missingKillRes.json()).toMatchObject({
+      error: {
+        code: 'NOT_FOUND',
+        details: { reasonCode: 'SESSION_ENVELOPE_NOT_FOUND' },
+      },
+    });
+    expect(auditEntries).toHaveLength(1);
+    expect(auditEntries[0]).toMatchObject({
+      eventType: 'denial',
+      decision: 'deny',
+      reasonCode: 'SESSION_ENVELOPE_NOT_FOUND',
+      intent: { action: 'sessions.kill', target: exchanged.node.nodeId },
+    });
+
+    const invalidTypeRes = await fetch(`${base}/hub/nodes/${exchanged.node.nodeId}/sessions`, {
+      method: 'POST',
+      headers: { 'x-test-auth': 'yes', 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'future-kind', cwd: '/srv/app' }),
+    });
+    expect(invalidTypeRes.status).toBe(400);
+    expect(await invalidTypeRes.json()).toMatchObject({
+      error: {
+        code: 'INVALID_REQUEST',
+        details: { reasonCode: 'INVALID_SESSION_TYPE', field: 'type' },
+      },
+    });
+
     for (const invalidLifecycle of [
       { expiresAt: 'not-a-date' },
       { ttlMs: 0 },
@@ -997,14 +1029,14 @@ describe('hub node routes and link', () => {
       body: JSON.stringify({ nodeId: exchanged.node.nodeId, reason: 'operator-test' }),
     });
     expect(revokeRes.status).toBe(200);
-    expect(auditEntries).toHaveLength(2);
-    expect(auditEntries[0]).toMatchObject({
+    expect(auditEntries).toHaveLength(3);
+    expect(auditEntries[1]).toMatchObject({
       eventType: 'grant',
       decision: 'allow',
       reasonCode: 'POLICY_ALLOWED',
       intent: { action: 'sessions.create', target: exchanged.node.nodeId },
     });
-    expect(auditEntries[1]).toMatchObject({
+    expect(auditEntries[2]).toMatchObject({
       eventType: 'revocation',
       decision: 'revoked',
       reasonCode: 'SESSION_REVOKED',

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -997,8 +997,14 @@ describe('hub node routes and link', () => {
       body: JSON.stringify({ nodeId: exchanged.node.nodeId, reason: 'operator-test' }),
     });
     expect(revokeRes.status).toBe(200);
-    expect(auditEntries).toHaveLength(1);
+    expect(auditEntries).toHaveLength(2);
     expect(auditEntries[0]).toMatchObject({
+      eventType: 'grant',
+      decision: 'allow',
+      reasonCode: 'POLICY_ALLOWED',
+      intent: { action: 'sessions.create', target: exchanged.node.nodeId },
+    });
+    expect(auditEntries[1]).toMatchObject({
       eventType: 'revocation',
       decision: 'revoked',
       reasonCode: 'SESSION_REVOKED',

--- a/test/hub-node-session-routing.test.ts
+++ b/test/hub-node-session-routing.test.ts
@@ -449,8 +449,9 @@ describe('hub-routed node session create and attach', () => {
   });
 
   it('routes remote session delete to the selected connected node', async () => {
-    const { base, wsBase } = await startHub();
+    const { base, wsBase, sessionEnvelopes } = await startHub();
     const { token, nodeId } = await pairNode(base);
+    seedRemoteSessionEnvelope(sessionEnvelopes, nodeId);
     const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
       headers: { authorization: `Bearer ${token}` },
     });

--- a/test/hub-policy-evaluator.test.ts
+++ b/test/hub-policy-evaluator.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendPolicyAudit,
+  auditEntryForPolicyDecision,
+  evaluateHubPolicy,
+  revokePolicyAffectedSessions,
+} from '../server/hub-policy-evaluator.js';
+import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
+import {
+  createLegacyDefaultNodeAcl,
+  summarizeAcl,
+  type RelayCapabilityBit,
+  type RelayNodeAcl,
+  type RelayPolicyScope,
+  type RelayTrustTier,
+} from '../shared/security-policy.js';
+import { createRoutedNodeSessionEnvelope } from '../shared/session-envelope.js';
+import type { SecurityAuditEntryInput } from '../shared/security-audit.js';
+import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
+
+const NOW = new Date('2026-01-02T03:04:05.000Z');
+
+function nodeSummary(input: {
+  nodeId?: string;
+  trustTier?: RelayTrustTier;
+  allowed?: RelayCapabilityBit[];
+  requiresConfirmation?: RelayCapabilityBit[];
+  scope?: RelayPolicyScope;
+  revoked?: boolean;
+} = {}): HubNodeSummary {
+  const nodeId = input.nodeId ?? 'node_a';
+  const acl: RelayNodeAcl = {
+    ...createLegacyDefaultNodeAcl({
+      nodeId,
+      credentialId: `${nodeId}_cred`,
+      createdAt: NOW.toISOString(),
+      trustTier: input.trustTier ?? 'dev',
+    }),
+  };
+  if (input.allowed || input.requiresConfirmation) {
+    acl.grants = {
+      allowed: input.allowed ?? [],
+      requiresConfirmation: input.requiresConfirmation ?? [],
+    };
+  }
+  if (input.scope) acl.scope = input.scope;
+  return {
+    nodeId,
+    displayName: nodeId,
+    hostname: `${nodeId}.example`,
+    platform: 'linux',
+    arch: 'x64',
+    relayVersion: '0.1.0-test',
+    protocolVersion: '1.0',
+    status: input.revoked ? 'revoked' : 'online',
+    connection: { route: 'reverse-link', status: input.revoked ? 'revoked' : 'connected' },
+    trust: {
+      state: input.revoked ? 'revoked' : 'active',
+      level: input.trustTier ?? 'dev',
+      tier: input.trustTier ?? 'dev',
+      policy: summarizeAcl(acl),
+    },
+    credentialState: input.revoked ? 'revoked' : 'active',
+    version: {
+      state: 'compatible',
+      nodeProtocolVersion: '1.0',
+      hubProtocolVersion: '1.0',
+    },
+    capabilities: {
+      totals: { available: 2, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        tmux: 'available',
+        git: 'available',
+        browserAutomation: 'unavailable',
+        clipboardImage: 'unavailable',
+        ssh: 'unavailable',
+        tailscale: 'unavailable',
+      },
+      agents: {},
+      serviceManager: 'systemd-user',
+      wsl: false,
+    },
+    createdAt: NOW.toISOString(),
+    pairedAt: NOW.toISOString(),
+    lastSeenAt: NOW.toISOString(),
+    credentialId: `${nodeId}_cred`,
+  };
+}
+
+function baseInput(overrides: Partial<Parameters<typeof evaluateHubPolicy>[0]> = {}) {
+  const node = nodeSummary();
+  return {
+    peer: { kind: 'hub' as const },
+    node,
+    nodeId: node.nodeId,
+    intent: { action: 'sessions.create', target: node.nodeId },
+    scope: { kind: 'node' as const, nodeId: node.nodeId, cwd: '/srv/relay' },
+    requiredCapabilities: ['session:create:terminal'],
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe('hub policy evaluator', () => {
+  it('allows explicitly granted session capabilities and emits a grant audit entry', () => {
+    const decision = evaluateHubPolicy(baseInput());
+    expect(decision).toMatchObject({
+      decision: 'allow',
+      reasonCode: 'POLICY_ALLOWED',
+      grantedBits: ['session:create:terminal'],
+      deniedBits: [],
+    });
+
+    const audit = auditEntryForPolicyDecision(decision);
+    expect(audit).toMatchObject({
+      eventType: 'grant',
+      decision: 'allow',
+      reasonCode: 'POLICY_ALLOWED',
+      peer: { kind: 'hub' },
+      node: { nodeId: 'node_a', trustTier: 'dev' },
+      requiredBits: ['session:create:terminal'],
+      grantedBits: ['session:create:terminal'],
+      deniedBits: [],
+    });
+  });
+
+  it('fails closed for unknown capability bits before granting known bits', () => {
+    const decision = evaluateHubPolicy(
+      baseInput({ requiredCapabilities: ['session:read', 'rpc:fs:format-disk'] })
+    );
+    expect(decision).toMatchObject({
+      decision: 'deny',
+      reasonCode: 'POLICY_UNKNOWN_CAPABILITY',
+      requiredBits: ['session:read'],
+      unknownBits: ['rpc:fs:format-disk'],
+    });
+  });
+
+  it('returns challenge for prod high-risk capabilities after trust-tier overlay', () => {
+    const node = nodeSummary({
+      trustTier: 'prod',
+      allowed: ['session:read', 'rpc:fs:write'],
+    });
+    const decision = evaluateHubPolicy(
+      baseInput({
+        node,
+        requiredCapabilities: ['rpc:fs:write'],
+        intent: { action: 'rpc.fs.write', target: node.nodeId },
+      })
+    );
+    expect(decision).toMatchObject({
+      decision: 'challenge',
+      reasonCode: 'POLICY_CHALLENGE_REQUIRED',
+      challengeBits: ['rpc:fs:write'],
+    });
+  });
+
+  it('denies scope mismatches and node-originated envelopes acting as another node', () => {
+    expect(
+      evaluateHubPolicy(
+        baseInput({ scope: { kind: 'node', nodeId: 'node_b', cwd: '/srv/relay' } })
+      )
+    ).toMatchObject({ decision: 'deny', reasonCode: 'POLICY_SCOPE_NODE_MISMATCH' });
+
+    expect(
+      evaluateHubPolicy(
+        baseInput({ peer: { kind: 'node', nodeId: 'node_b' } })
+      )
+    ).toMatchObject({ decision: 'deny', reasonCode: 'POLICY_PEER_NODE_MISMATCH' });
+  });
+
+  it('denies expired and revoked session lifecycles', () => {
+    expect(
+      evaluateHubPolicy(
+        baseInput({ expiresAt: '2026-01-02T03:04:04.000Z', sessionId: 's1' })
+      )
+    ).toMatchObject({ decision: 'revoke', reasonCode: 'POLICY_SESSION_EXPIRED' });
+
+    expect(
+      evaluateHubPolicy(
+        baseInput({ revokedAt: '2026-01-02T03:04:04.000Z', sessionId: 's1' })
+      )
+    ).toMatchObject({ decision: 'revoke', reasonCode: 'POLICY_SESSION_REVOKED' });
+  });
+
+  it('keeps multi-node authorization independent', () => {
+    const nodeA = nodeSummary({ nodeId: 'node_a', allowed: ['session:read'] });
+    const nodeB = nodeSummary({ nodeId: 'node_b', allowed: ['session:create:terminal'] });
+
+    expect(
+      evaluateHubPolicy(
+        baseInput({ node: nodeA, nodeId: 'node_a', requiredCapabilities: ['session:create:terminal'] })
+      )
+    ).toMatchObject({ decision: 'deny', reasonCode: 'POLICY_CAPABILITY_DENIED' });
+    expect(
+      evaluateHubPolicy(
+        baseInput({
+          node: nodeB,
+          nodeId: 'node_b',
+          scope: { kind: 'node', nodeId: 'node_b', cwd: '/srv/relay' },
+          requiredCapabilities: ['session:create:terminal'],
+        })
+      )
+    ).toMatchObject({ decision: 'allow' });
+  });
+
+  it('revokes active node sessions and emits typed revocation audit events', () => {
+    const envelopes = createSessionEnvelopeRegistry();
+    envelopes.upsert(
+      createRoutedNodeSessionEnvelope({
+        nodeId: 'node_a',
+        sessionId: 's1',
+        cwd: '/srv/relay',
+        repoPath: '/srv/relay',
+        issuedAt: NOW.toISOString(),
+      })
+    );
+    envelopes.upsert(
+      createRoutedNodeSessionEnvelope({
+        nodeId: 'node_b',
+        sessionId: 's2',
+        cwd: '/srv/other',
+        issuedAt: NOW.toISOString(),
+      })
+    );
+    const auditEntries: SecurityAuditEntryInput[] = [];
+    const revoked = revokePolicyAffectedSessions({
+      envelopes,
+      nodeId: 'node_a',
+      node: nodeSummary({ nodeId: 'node_a', revoked: true }),
+      reason: 'node-revoked',
+      now: NOW,
+      auditSink: { append: (entry) => auditEntries.push(entry) },
+    });
+
+    expect(revoked.map((session) => session.sessionId)).toEqual(['s1']);
+    expect(envelopes.validate({ nodeId: 'node_a', sessionId: 's1', now: NOW })).toMatchObject({
+      ok: false,
+      error: { code: 'SESSION_REVOKED' },
+    });
+    expect(envelopes.validate({ nodeId: 'node_b', sessionId: 's2', now: NOW })).toMatchObject({
+      ok: true,
+    });
+    expect(auditEntries).toHaveLength(1);
+    expect(auditEntries[0]).toMatchObject({
+      eventType: 'revocation',
+      decision: 'revoked',
+      reasonCode: 'POLICY_SESSION_REVOKED',
+      sessionId: 's1',
+      intent: { action: 'sessions.revalidate', target: 'node_a' },
+    });
+  });
+
+  it('fails closed when audit persistence fails for high-risk decisions', () => {
+    const node = nodeSummary({ trustTier: 'prod', allowed: ['rpc:fs:write'] });
+    const decision = evaluateHubPolicy(
+      baseInput({ node, requiredCapabilities: ['rpc:fs:write'] })
+    );
+    const audited = appendPolicyAudit(
+      { append: () => { throw new Error('disk full'); } },
+      decision
+    );
+    expect(audited).toMatchObject({
+      decision: 'deny',
+      reasonCode: 'POLICY_AUDIT_WRITE_FAILED_CLOSED',
+      deniedBits: ['rpc:fs:write'],
+    });
+  });
+});

--- a/test/hub-policy-evaluator.test.ts
+++ b/test/hub-policy-evaluator.test.ts
@@ -3,6 +3,8 @@ import {
   appendPolicyAudit,
   auditEntryForPolicyDecision,
   evaluateHubPolicy,
+  policyDecisionToRelayError,
+  requiredCapabilitiesForRpcIntent,
   revokePolicyAffectedSessions,
 } from '../server/hub-policy-evaluator.js';
 import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
@@ -137,6 +139,58 @@ describe('hub policy evaluator', () => {
     });
   });
 
+  it('maps unknown RPC intents to an unknown capability so callers fail closed', () => {
+    const required = requiredCapabilitiesForRpcIntent('rpc.fs.format-disk');
+    expect(required).toEqual(['rpc:unknown:rpc.fs.format-disk']);
+
+    expect(evaluateHubPolicy(baseInput({ requiredCapabilities: required }))).toMatchObject({
+      decision: 'deny',
+      reasonCode: 'POLICY_UNKNOWN_CAPABILITY',
+      unknownBits: ['rpc:unknown:rpc.fs.format-disk'],
+    });
+  });
+
+  it('canonicalizes path ACL comparisons before checking prefixes', () => {
+    const node = nodeSummary({
+      scope: { kind: 'path', pathPrefixes: ['/srv/allowed'] },
+      allowed: ['session:create:terminal'],
+    });
+
+    expect(
+      evaluateHubPolicy(
+        baseInput({
+          node,
+          scope: { kind: 'node-cwd', nodeId: node.nodeId, cwd: '/srv/allowed/project' },
+        })
+      )
+    ).toMatchObject({ decision: 'allow' });
+
+    expect(
+      evaluateHubPolicy(
+        baseInput({
+          node,
+          scope: { kind: 'node-cwd', nodeId: node.nodeId, cwd: '/srv/allowed/../outside' },
+        })
+      )
+    ).toMatchObject({ decision: 'deny', reasonCode: 'POLICY_SCOPE_DENIED' });
+
+    expect(
+      evaluateHubPolicy(
+        baseInput({
+          node,
+          scope: { kind: 'node-cwd', nodeId: node.nodeId, cwd: '../allowed/project' },
+        })
+      )
+    ).toMatchObject({ decision: 'deny', reasonCode: 'POLICY_SCOPE_DENIED' });
+  });
+
+  it('preserves typed relay errors for policy lifecycle failures', () => {
+    const expired = evaluateHubPolicy(
+      baseInput({ expiresAt: '2026-01-02T03:04:04.000Z', sessionId: 's1' })
+    );
+    expect(policyDecisionToRelayError(expired)).toMatchObject({ code: 'SESSION_EXPIRED' });
+  });
+
   it('returns challenge for prod high-risk capabilities after trust-tier overlay', () => {
     const node = nodeSummary({
       trustTier: 'prod',
@@ -168,6 +222,12 @@ describe('hub policy evaluator', () => {
         baseInput({ peer: { kind: 'node', nodeId: 'node_b' } })
       )
     ).toMatchObject({ decision: 'deny', reasonCode: 'POLICY_PEER_NODE_MISMATCH' });
+
+    expect(
+      evaluateHubPolicy(
+        baseInput({ peer: { kind: 'node', nodeId: 'node_a', credentialId: 'stale_cred' } })
+      )
+    ).toMatchObject({ decision: 'deny', reasonCode: 'POLICY_PEER_CREDENTIAL_MISMATCH' });
   });
 
   it('denies expired and revoked session lifecycles', () => {


### PR DESCRIPTION
## Summary
- Adds a hub-side policy evaluator with typed `allow` / `deny` / `challenge` / `revoke` decisions, normalized audit event conversion, unknown-capability fail-closed behavior, and a minimal RPC/file capability intent mapping for future File RPC integration.
- Gates routed node session creation, cold-reopen session creation, routed session kill, and WebSocket PTY/session attach through the evaluator and audit sink.
- Revokes active scoped sessions on node credential revocation and returns typed `SESSION_PERMISSION_REVOKED` events.
- Adds `revokeForNode` to the session envelope registry and focused coverage for ACL denial, unknown bits, prod overlay challenge behavior, TTL/revocation, node/scope mismatch, multi-node isolation, and audit emission.

## Motivation
#496 is the hub-authoritative policy gate needed before destructive File RPC / gateway work can safely land. The hub now owns the privilege decision shape instead of letting routed sessions and node-originated envelopes drift through ad hoc checks.

## The Case Against
This change is intentionally conservative, but it may still be too narrow:
- It wires the evaluator into the current privileged surfaces Relay already has, but File RPC verbs and two-token approval redemption remain out of scope per the issue lane.
- There is no general ACL mutation API in this slice. The evaluator reads the live node policy summary on every decision, and revocation revalidates active sessions through the new `revokePolicyAffectedSessions` path, but richer ACL update hooks should be reviewed when that API exists.
- `session:attach` is used for routed kill authorization because no separate kill/delete capability bit exists in the current closed policy schema. If we want delete-specific separation later, that should become an explicit policy bit migration.
- WebSocket attach is gated; per-keystroke PTY writes are not separately re-evaluated after attach because the current routed PTY transport is attach-scoped.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Unknown or future capability strings accidentally allowed | Unknown bits fail closed with `POLICY_UNKNOWN_CAPABILITY` and audit denial coverage. |
| Revoked/expired sessions keep working | Evaluator checks `expiresAt` / `revokedAt`; node revocation revokes active envelopes and emits typed events. |
| Node credential acts as another node | Evaluator rejects node peer/node mismatches; tests cover cross-node attempts. |
| Audit persistence failure on high-risk decisions | Uses #495 audit failure classification; high-risk/prod decisions fail closed. |
| Local compatibility becomes a hidden bypass | Local compatibility is represented as an explicit decision reason instead of bypassing the decision/audit shape. |

## Verification
- `npm test -- test/hub-policy-evaluator.test.ts test/hub-node-routes.test.ts test/hub-node-session-routing.test.ts test/session-envelope-registry.test.ts test/security-policy.test.ts test/security-audit.test.ts` — 53/53 pass.
- `npm run check` — pass, with existing lint warnings only.
- `npm run build` — pass.
- `npm test` — 2170/2171 pass; one unrelated `test/local-logs.test.ts` follower timeout on full parallel suite.
- `npm test -- test/local-logs.test.ts` — 8/8 pass on rerun, so treated as baseline/parallel flake.

Closes #496
Refs #427 #426 #428 #429


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented hub policy authorization for session operations (creation, termination, attachment, reopening)
  * Added comprehensive audit logging of all authorization decisions
  * Introduced flexible policy decision framework supporting allow, deny, challenge, and revoke outcomes
  * Integrated capability-based access controls throughout session management workflows

* **Tests**
  * Added extensive test coverage for policy evaluation and authorization scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->