### PR TITLE
feat: add session control hand-back API

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -958,6 +958,58 @@ if (command === 'sessions') {
   }
 
   try {
+    if (subCommand === 'get') {
+      const sessionId = sessionArgs[1];
+      if (!sessionId) {
+        logger.error('Usage: relay-ide sessions get <session-id>');
+        process.exit(1);
+      }
+      const data = await scopedSessionRequest(
+        `/sessions/${encodeURIComponent(sessionId)}`
+      );
+      console.log(JSON.stringify(data, null, 2));
+      process.exit(0);
+    }
+
+    if (subCommand === 'interventions') {
+      const sessionId = sessionArgs[1];
+      if (!sessionId) {
+        logger.error('Usage: relay-ide sessions interventions <session-id> [--limit <n>]');
+        process.exit(1);
+      }
+      const limit = getNodeArg(sessionArgs, '--limit');
+      const query = limit ? `?limit=${encodeURIComponent(limit)}` : '';
+      const data = await scopedSessionRequest(
+        `/sessions/${encodeURIComponent(sessionId)}/interventions${query}`
+      );
+      console.log(JSON.stringify(data, null, 2));
+      process.exit(0);
+    }
+
+    if (subCommand === 'hand-back') {
+      const sessionId = sessionArgs[1];
+      const latestSeenInterventionEventId = getNodeArg(
+        sessionArgs,
+        '--latest-seen-intervention-event-id'
+      );
+      if (!sessionId || !latestSeenInterventionEventId) {
+        logger.error(
+          'Usage: relay-ide sessions hand-back <session-id> --latest-seen-intervention-event-id <event-id>'
+        );
+        process.exit(1);
+      }
+      const data = await scopedSessionRequest(
+        `/sessions/${encodeURIComponent(sessionId)}/control/hand-back`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ latestSeenInterventionEventId }),
+        }
+      );
+      console.log(JSON.stringify(data, null, 2));
+      process.exit(0);
+    }
+
     if (subCommand === 'scoped' && sessionArgs[1] === 'list') {
       const includeRevoked = sessionArgs.includes('--include-revoked') ? '1' : '0';
       const includeExpired = sessionArgs.includes('--active-only') ? '0' : '1';
@@ -996,14 +1048,17 @@ if (command === 'sessions') {
     process.exit(1);
   }
 
-  logger.error(`Usage: relay-ide sessions scoped <list|revoke>
+  logger.error(`Usage: relay-ide sessions <command>
 
 Commands:
+  relay-ide sessions get <session-id>
+  relay-ide sessions interventions <session-id> [--limit <n>]
+  relay-ide sessions hand-back <session-id> --latest-seen-intervention-event-id <event-id>
   relay-ide sessions scoped list [--include-revoked] [--active-only]
   relay-ide sessions scoped revoke <session-id> [--node-id <nodeId>] [--reason <reason>]
 
 Environment:
-  RELAY_IDE_BROWSER_TOKEN   Auth token for scoped-session API
+  RELAY_IDE_BROWSER_TOKEN   Auth token for session/scoped-session API
   RELAY_IDE_PORT            Server port (default: 3456)`);
   process.exit(1);
 }

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -131,6 +131,24 @@ Reserved node-link event envelope names for later intervention work are `tab.mod
 
 #427 boundary: #490 only defines and serializes state. It does not add capability gates, trust tiers, two-token confirmation, security policy evaluation, intervention persistence, or hash-chained audit logging.
 
+### Session control reads and hand-back ack (#493)
+
+The scoped session API exposes current control state without requiring raw terminal history export:
+
+- `GET /sessions/:id` returns a local or routed session summary with the flattened control fields above.
+- `GET /sessions/:id/interventions?limit=<n>` returns bounded local-session intervention records plus redaction metadata (`rawPayloadAvailable: false`, `transcriptExportAvailable: false`). It is intentionally not a routed read, keylog, or terminal transcript endpoint.
+- `POST /sessions/:id/control/hand-back` accepts `{ "latestSeenInterventionEventId": "..." }` and only resumes `agent-driven` after the caller acknowledges the latest unacked human intervention id. Missing, old, stale, unknown, disconnected, or already-acked state returns a typed error.
+
+The matching CLI surface is:
+
+```bash
+relay-ide sessions get <session-id>
+relay-ide sessions interventions <session-id> [--limit <n>]
+relay-ide sessions hand-back <session-id> --latest-seen-intervention-event-id <event-id>
+```
+
+Capability checks currently use the #427 placeholder header contract: omitted `x-relay-capabilities` preserves compatibility, while an explicit header must include `session:control:read`, `session:intervention:read`, or `session:control:write` for the respective operation.
+
 ### Heartbeat and Offline Detection
 
 - Default heartbeat is implicit: any `control.hello` or `control.heartbeat` refreshes the node's `lastSeenAt`.

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import http from 'node:http';
 import os from 'node:os';
@@ -147,6 +148,18 @@ import {
   removePortsFromEnvFile,
   upsertPortsInEnvFile,
 } from './port-allocator.js';
+import {
+  actorFromRequestBody,
+  capabilityDecisionFromRequest,
+  capabilityError,
+  clampInterventionLimit,
+  CONTROL_READ_CAPABILITY,
+  CONTROL_WRITE_CAPABILITY,
+  createAgentDrivenInitialControlState,
+  errorStatus as sessionControlErrorStatus,
+  INTERVENTION_READ_CAPABILITY,
+  toInterventionReadResponse,
+} from './session-control-api.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -662,6 +675,7 @@ async function removeWorktreeFromDisk(
 }
 
 type AgentSessionParams = {
+  id?: string;
   repoName: string;
   repoPath: string;
   worktreePath: string | null | undefined;
@@ -682,6 +696,7 @@ type AgentSessionParams = {
   computedInitialPrompt: string | undefined;
   claudeFullscreen: boolean;
   sessionLane: SessionLane | undefined;
+  controlState?: ReturnType<typeof createAgentDrivenInitialControlState>;
   /** Port env var names to inject for this worktree (from repo settings) */
   portVariables?: string[] | undefined;
 };
@@ -722,7 +737,9 @@ function createTerminalSessionRecord(
 
 /** Creates an agent session record and writes worktree metadata if applicable. */
 function createAgentSessionRecord(params: AgentSessionParams): CreateResult {
+  const sessionId = params.id ?? crypto.randomBytes(8).toString('hex');
   const session = localRelayNode.sessions.create({
+    id: sessionId,
     type: 'agent',
     agent: params.resolvedAgent,
     repoName: params.repoName,
@@ -742,6 +759,12 @@ function createAgentSessionRecord(params: AgentSessionParams): CreateResult {
     ...(params.safeCols != null && { cols: params.safeCols }),
     ...(params.safeRows != null && { rows: params.safeRows }),
     ...(params.sessionLane ? { sessionLane: params.sessionLane } : {}),
+    controlState:
+      params.controlState ??
+      createAgentDrivenInitialControlState({
+        workerId: sessionId,
+        displayName: params.displayName,
+      }),
     needsBranchRename: params.needsBranchRename,
     branchRenamePrompt: params.branchRenamePrompt,
     ...(params.computedInitialPrompt != null && {
@@ -1940,6 +1963,114 @@ async function main(): Promise<void> {
       })
     );
     res.json(allSessions);
+  });
+
+  app.get('/sessions/:id', requireScopedSessionAuth, async (req, res) => {
+    const decision = capabilityDecisionFromRequest(req, CONTROL_READ_CAPABILITY);
+    if (decision.decision !== 'allow') {
+      const error = capabilityError(decision);
+      res.status(sessionControlErrorStatus(error)).json({ error });
+      return;
+    }
+    const id = req.params['id'] as string;
+    const local = localRelayNode.sessions.get(id);
+    if (local) {
+      const session = localRelayNode.sessions.list().find((candidate) => candidate.id === id);
+      if (!session) {
+        res.status(404).json({
+          error: {
+            code: 'NOT_FOUND',
+            reasonCode: 'SESSION_NOT_FOUND',
+            message: 'session summary was not found',
+            retryable: false,
+          },
+        });
+        return;
+      }
+      res.json(session);
+      return;
+    }
+    const remoteSessions = await aggregateRemoteSessions({
+      registry: hubNodeRegistry,
+      nodeLinks: hubNodeLinks,
+      logger,
+      sessionEnvelopes: sessionEnvelopeRegistry,
+    });
+    const remote = remoteSessions.find(
+      (candidate) => candidate.id === id || candidate.globalSessionId === id
+    );
+    if (!remote) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          reasonCode: 'SESSION_NOT_FOUND',
+          message: 'session was not found',
+          retryable: false,
+        },
+      });
+      return;
+    }
+    res.json(remote);
+  });
+
+  app.get('/sessions/:id/interventions', requireScopedSessionAuth, (req, res) => {
+    const decision = capabilityDecisionFromRequest(req, INTERVENTION_READ_CAPABILITY);
+    if (decision.decision !== 'allow') {
+      const error = capabilityError(decision);
+      res.status(sessionControlErrorStatus(error)).json({ error });
+      return;
+    }
+    const id = req.params['id'] as string;
+    if (!localRelayNode.sessions.get(id)) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          reasonCode: 'SESSION_NOT_FOUND',
+          message: 'session was not found or is not locally readable',
+          retryable: false,
+        },
+      });
+      return;
+    }
+    const limit = clampInterventionLimit(
+      typeof req.query.limit === 'string' ? req.query.limit : undefined
+    );
+    const records = localRelayNode.sessions.getInterventions(
+      id,
+      { limit }
+    );
+    res.json(
+      toInterventionReadResponse(
+        { records, limit }
+      )
+    );
+  });
+
+  app.post('/sessions/:id/control/hand-back', requireScopedSessionAuth, (req, res) => {
+    const decision = capabilityDecisionFromRequest(req, CONTROL_WRITE_CAPABILITY);
+    if (decision.decision !== 'allow') {
+      const error = capabilityError(decision);
+      res.status(sessionControlErrorStatus(error)).json({ error });
+      return;
+    }
+    const body = typeof req.body === 'object' && req.body !== null ? req.body as Record<string, unknown> : {};
+    const latestSeenInterventionEventId =
+      typeof body['latestSeenInterventionEventId'] === 'string'
+        ? body['latestSeenInterventionEventId']
+        : undefined;
+    const actor = actorFromRequestBody(body['actor']);
+    const result = localRelayNode.sessions.handBackToAgent({
+      id: req.params['id'] as string,
+      ...(latestSeenInterventionEventId === undefined
+        ? {}
+        : { latestSeenInterventionEventId }),
+      ...(actor === undefined ? {} : { actor }),
+    });
+    if (result.ok === false) {
+      res.status(sessionControlErrorStatus(result.error)).json({ error: result.error });
+      return;
+    }
+    res.json({ ok: true, events: result.events, ackedHumanInterventions: result.ackedHumanInterventions });
   });
 
   // GET /repos — scan root dirs for repos

--- a/server/local-node.ts
+++ b/server/local-node.ts
@@ -3,6 +3,8 @@ import type { CreateResult } from './sessions.js';
 import type { CreateParams } from './sessions.js';
 import type { CreateWebParams } from './web-session-handler.js';
 import type { Session, SessionSummary } from './types.js';
+import type { InterventionRecord, TabControlEvent, ControlActor } from '../shared/control-state.js';
+import type { SessionControlError } from './session-control-api.js';
 import {
   DEFAULT_LOCAL_ENVIRONMENT_ID,
   createLocalEventAuthority,
@@ -26,6 +28,14 @@ export interface NodeSessionBoundary {
     displayName: string
   ): { id: string; displayName: string };
   write(id: string, data: string): void;
+  getInterventions(id: string, options?: { nodeId?: string; limit?: number }): InterventionRecord[];
+  handBackToAgent(input: {
+    id: string;
+    latestSeenInterventionEventId?: string;
+    actor?: ControlActor;
+  }):
+    | { ok: true; events: TabControlEvent[]; ackedHumanInterventions: number }
+    | { ok: false; error: SessionControlError };
 }
 
 type LocalRelayNodeSessionOverrides = Partial<{
@@ -60,6 +70,8 @@ const defaultSessionBoundary: NodeSessionBoundary = {
   kill: sessionsModule.kill,
   updateDisplayName: sessionsModule.updateDisplayName,
   write: sessionsModule.write,
+  getInterventions: sessionsModule.getInterventions,
+  handBackToAgent: sessionsModule.handBackToAgent,
 };
 
 export function createLocalRelayNode(

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -1,8 +1,10 @@
+import * as crypto from 'node:crypto';
 import * as os from 'node:os';
 import type { LocalRelayNode } from './local-node.js';
 import type { Logger } from './logger.js';
 import { createLogger } from './logger.js';
 import type { CreateParams } from './sessions.js';
+import { createAgentDrivenInitialControlState } from './session-control-api.js';
 import type {
   NodeLinkChannelHandler,
   NodeLinkEnvelopeHandlerContext,
@@ -60,9 +62,30 @@ function asNullableString(value: unknown): string | null | undefined {
   return undefined;
 }
 
+function parseInitialControlMode(
+  record: Record<string, unknown>,
+  type: SessionsCreateInput['type']
+): Pick<SessionsCreateInput, 'controlMode'> | RelayNodeError {
+  const controlMode = asString(record['controlMode']);
+  if (controlMode === undefined) return {};
+  if (controlMode !== 'agent-driven') {
+    return invalidRequest(
+      'sessions.create payload.controlMode must be "agent-driven" when set'
+    );
+  }
+  if (type !== 'agent') {
+    return invalidRequest(
+      'sessions.create payload.controlMode="agent-driven" is only supported for agent sessions'
+    );
+  }
+  return { controlMode };
+}
+
 interface SessionsCreateInput {
+  id?: string;
   type: 'agent' | 'terminal';
   mode?: 'pty' | 'web';
+  controlMode?: 'agent-driven';
   agent?: string;
   repoPath?: string;
   worktreePath?: string | null;
@@ -102,7 +125,12 @@ function parseSessionsCreateInput(
     );
   }
   const input: SessionsCreateInput = { type: typeRaw };
+  const id = asString(record['id']);
+  if (id !== undefined) input.id = id;
   if (modeRaw === 'pty' || modeRaw === 'web') input.mode = modeRaw;
+  const initialControl = parseInitialControlMode(record, typeRaw);
+  if ('code' in initialControl) return initialControl;
+  if (initialControl.controlMode) input.controlMode = initialControl.controlMode;
   const agent = asString(record['agent']);
   if (agent !== undefined) input.agent = agent;
   const repoPath = asString(record['repoPath']);
@@ -240,9 +268,16 @@ export function createNodeLinkRpcHost(
         );
         return;
       }
-      const result = localRelayNode.sessions.create(
-        parsed as unknown as CreateParams
-      );
+      const { controlMode, ...createInput } = parsed;
+      if (controlMode === 'agent-driven') {
+        const sessionId = createInput.id ?? crypto.randomBytes(8).toString('hex');
+        createInput.id = sessionId;
+        (createInput as CreateParams).controlState = createAgentDrivenInitialControlState({
+          workerId: sessionId,
+          ...(createInput.displayName ? { displayName: createInput.displayName } : {}),
+        });
+      }
+      const result = localRelayNode.sessions.create(createInput as CreateParams);
       sendResultEnvelope(ctx, envelope, {
         session: sessionSummaryFromCreateResult(result),
       });

--- a/server/session-control-api.ts
+++ b/server/session-control-api.ts
@@ -1,0 +1,321 @@
+import type { Request } from 'express';
+import type {
+  ControlActor,
+  ControlFreshness,
+  ControlMode,
+  InterventionRecord,
+} from '../shared/control-state.js';
+
+export const CONTROL_READ_CAPABILITY = 'session:control:read' as const;
+export const INTERVENTION_READ_CAPABILITY = 'session:intervention:read' as const;
+export const CONTROL_WRITE_CAPABILITY = 'session:control:write' as const;
+
+export type SessionControlCapability =
+  | typeof CONTROL_READ_CAPABILITY
+  | typeof INTERVENTION_READ_CAPABILITY
+  | typeof CONTROL_WRITE_CAPABILITY;
+
+export interface ControlCapabilityDecision {
+  decision: 'allow' | 'deny';
+  capability: SessionControlCapability;
+  placeholder: boolean;
+  reasonCode?: 'CAPABILITY_REQUIRED';
+  message?: string;
+}
+
+export interface SessionControlError {
+  code: 'INVALID_REQUEST' | 'NOT_FOUND' | 'SESSION_CONFLICT' | 'FORBIDDEN';
+  reasonCode:
+    | 'CAPABILITY_REQUIRED'
+    | 'SESSION_NOT_FOUND'
+    | 'SESSION_DISCONNECTED'
+    | 'CONTROL_STATE_STALE'
+    | 'CONTROL_STATE_UNKNOWN'
+    | 'HAND_BACK_ACK_REQUIRED'
+    | 'STALE_INTERVENTION_ACK'
+    | 'NO_UNACKED_HUMAN_INTERVENTION';
+  message: string;
+  retryable: boolean;
+  details?: Record<string, unknown>;
+}
+
+export interface HandBackSessionSnapshot {
+  id: string;
+  status?: 'active' | 'disconnected';
+  controlMode?: ControlMode;
+  controlFreshness?: ControlFreshness;
+  lastInterventionEventId?: string | null;
+}
+
+export type HandBackValidationResult =
+  | { ok: true }
+  | { ok: false; error: SessionControlError };
+
+export interface InterventionReadResponse {
+  interventions: InterventionRecord[];
+  count: number;
+  limit: number;
+  truncated: boolean;
+  rawPayloadAvailable: false;
+  transcriptExportAvailable: false;
+  redaction: {
+    payload: 'preview-only';
+    metadataIncluded: true;
+  };
+}
+
+const DEFAULT_INTERVENTION_LIMIT = 50;
+const MAX_INTERVENTION_LIMIT = 200;
+
+function parseCapabilityHeader(value: string | undefined): Set<string> | null {
+  if (value === undefined) return null;
+  return new Set(
+    value
+      .split(/[\s,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  );
+}
+
+export function evaluateControlCapabilityPlaceholder(
+  capabilityHeader: string | undefined,
+  capability: SessionControlCapability
+): ControlCapabilityDecision {
+  const explicitCapabilities = parseCapabilityHeader(capabilityHeader);
+  if (!explicitCapabilities) {
+    return { decision: 'allow', capability, placeholder: true };
+  }
+  if (explicitCapabilities.has(capability)) {
+    return { decision: 'allow', capability, placeholder: true };
+  }
+  return {
+    decision: 'deny',
+    capability,
+    placeholder: true,
+    reasonCode: 'CAPABILITY_REQUIRED',
+    message: `missing required capability: ${capability}`,
+  };
+}
+
+export function capabilityDecisionFromRequest(
+  req: Request,
+  capability: SessionControlCapability
+): ControlCapabilityDecision {
+  const header = req.header('x-relay-capabilities') ?? undefined;
+  return evaluateControlCapabilityPlaceholder(header, capability);
+}
+
+export function errorStatus(error: SessionControlError): number {
+  switch (error.reasonCode) {
+    case 'CAPABILITY_REQUIRED':
+      return 403;
+    case 'SESSION_NOT_FOUND':
+      return 404;
+    case 'HAND_BACK_ACK_REQUIRED':
+      return 400;
+    default:
+      return 409;
+  }
+}
+
+export function capabilityError(
+  decision: ControlCapabilityDecision
+): SessionControlError {
+  return {
+    code: 'FORBIDDEN',
+    reasonCode: 'CAPABILITY_REQUIRED',
+    message: decision.message ?? `missing required capability: ${decision.capability}`,
+    retryable: false,
+    details: {
+      capability: decision.capability,
+      placeholder: decision.placeholder,
+    },
+  };
+}
+
+export function clampInterventionLimit(value: unknown): number {
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim()
+        ? Number(value)
+        : DEFAULT_INTERVENTION_LIMIT;
+  if (!Number.isFinite(parsed)) return DEFAULT_INTERVENTION_LIMIT;
+  return Math.min(Math.max(Math.trunc(parsed), 1), MAX_INTERVENTION_LIMIT);
+}
+
+export function toInterventionReadResponse(input: {
+  records: InterventionRecord[];
+  limit?: number;
+}): InterventionReadResponse {
+  const limit = clampInterventionLimit(input.limit);
+  const interventions = input.records.slice(0, limit);
+  return {
+    interventions,
+    count: interventions.length,
+    limit,
+    truncated: input.records.length > interventions.length,
+    rawPayloadAvailable: false,
+    transcriptExportAvailable: false,
+    redaction: {
+      payload: 'preview-only',
+      metadataIncluded: true,
+    },
+  };
+}
+
+function sessionControlError(
+  reasonCode: SessionControlError['reasonCode'],
+  message: string,
+  details?: Record<string, unknown>
+): SessionControlError {
+  const code: SessionControlError['code'] =
+    reasonCode === 'SESSION_NOT_FOUND'
+      ? 'NOT_FOUND'
+      : reasonCode === 'HAND_BACK_ACK_REQUIRED'
+        ? 'INVALID_REQUEST'
+        : 'SESSION_CONFLICT';
+  return {
+    code,
+    reasonCode,
+    message,
+    retryable: false,
+    ...(details ? { details } : {}),
+  };
+}
+
+export function validateAgentHandBackAck(input: {
+  session: HandBackSessionSnapshot | undefined;
+  latestSeenInterventionEventId?: string;
+  unackedHumanInterventions: InterventionRecord[];
+}): HandBackValidationResult {
+  if (!input.session) {
+    return {
+      ok: false,
+      error: sessionControlError('SESSION_NOT_FOUND', 'session was not found'),
+    };
+  }
+
+  if (input.session.status === 'disconnected') {
+    return {
+      ok: false,
+      error: sessionControlError(
+        'SESSION_DISCONNECTED',
+        'cannot hand back control for a disconnected session',
+        { sessionId: input.session.id }
+      ),
+    };
+  }
+
+  if (input.session.controlFreshness === 'stale') {
+    return {
+      ok: false,
+      error: sessionControlError(
+        'CONTROL_STATE_STALE',
+        'cannot hand back control from stale control state',
+        { sessionId: input.session.id }
+      ),
+    };
+  }
+
+  if (input.session.controlFreshness !== 'fresh') {
+    return {
+      ok: false,
+      error: sessionControlError(
+        'CONTROL_STATE_UNKNOWN',
+        'cannot hand back control from unknown control state',
+        { sessionId: input.session.id }
+      ),
+    };
+  }
+
+  const latest = input.session.lastInterventionEventId;
+  if (!input.latestSeenInterventionEventId) {
+    return {
+      ok: false,
+      error: sessionControlError(
+        'HAND_BACK_ACK_REQUIRED',
+        'latestSeenInterventionEventId is required to hand back agent control',
+        { sessionId: input.session.id, latestInterventionEventId: latest ?? null }
+      ),
+    };
+  }
+
+  if (!latest || input.latestSeenInterventionEventId !== latest) {
+    return {
+      ok: false,
+      error: sessionControlError(
+        'STALE_INTERVENTION_ACK',
+        'latestSeenInterventionEventId does not match the latest intervention event',
+        {
+          sessionId: input.session.id,
+          latestInterventionEventId: latest ?? null,
+          latestSeenInterventionEventId: input.latestSeenInterventionEventId,
+        }
+      ),
+    };
+  }
+
+  if (input.unackedHumanInterventions.length === 0) {
+    return {
+      ok: false,
+      error: sessionControlError(
+        'NO_UNACKED_HUMAN_INTERVENTION',
+        'no unacked human intervention is pending for hand-back',
+        { sessionId: input.session.id, latestInterventionEventId: latest }
+      ),
+    };
+  }
+
+  return { ok: true };
+}
+
+export function createAgentDrivenInitialControlState(input: {
+  workerId: string;
+  displayName?: string;
+}): {
+  controlMode: 'agent-driven';
+  activeActors: ControlActor[];
+  activeWorker: ControlActor;
+  lastInterventionAt: null;
+  lastInterventionBy: null;
+  lastInterventionEventId: null;
+  controlFreshness: 'fresh';
+  controlReason: string;
+} {
+  const activeWorker: ControlActor = {
+    kind: 'agent',
+    id: input.workerId,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+  };
+  return {
+    controlMode: 'agent-driven',
+    activeActors: [activeWorker],
+    activeWorker,
+    lastInterventionAt: null,
+    lastInterventionBy: null,
+    lastInterventionEventId: null,
+    controlFreshness: 'fresh',
+    controlReason: 'requested-initial-agent-driven',
+  };
+}
+
+export function actorFromRequestBody(value: unknown): ControlActor | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record['kind'] !== 'agent' &&
+    record['kind'] !== 'human' &&
+    record['kind'] !== 'system'
+  ) {
+    return undefined;
+  }
+  const actor: ControlActor = { kind: record['kind'] };
+  if (typeof record['id'] === 'string') actor.id = record['id'];
+  if (typeof record['displayName'] === 'string') actor.displayName = record['displayName'];
+  if (typeof record['nodeId'] === 'string') actor.nodeId = record['nodeId'];
+  if (typeof record['sessionId'] === 'string') actor.sessionId = record['sessionId'];
+  return actor;
+}

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -76,7 +76,14 @@ import {
   recordHumanPtyInput,
   type ControlModeAction,
 } from './control-engine.js';
-import { listInterventions } from './intervention-log.js';
+import {
+  listInterventions,
+  listUnackedHumanInput,
+} from './intervention-log.js';
+import {
+  validateAgentHandBackAck,
+  type SessionControlError,
+} from './session-control-api.js';
 
 const execFileAsync = promisify(execFile);
 const logger = createLogger('sessions');
@@ -766,6 +773,45 @@ function acknowledgeInterventions(id: string, actor?: ControlActor): number {
     throw new Error(`Session not found: ${id}`);
   }
   return acknowledgeHumanInput(session, actor, controlEngineOptions());
+}
+
+function interventionScopeForSession(session: Session) {
+  const nodeId = session.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  return {
+    sessionId: session.id,
+    nodeId,
+    globalSessionId: createGlobalSessionId(nodeId, session.id),
+  };
+}
+
+function handBackToAgent(input: {
+  id: string;
+  latestSeenInterventionEventId?: string;
+  actor?: ControlActor;
+}):
+  | { ok: true; events: TabControlEvent[]; ackedHumanInterventions: number }
+  | { ok: false; error: SessionControlError } {
+  const session = sessions.get(input.id);
+  const summary = session
+    ? {
+        id: session.id,
+        status: session.status,
+        ...normalizeControlStateSummary(session.controlState),
+      }
+    : undefined;
+  const scope = session ? interventionScopeForSession(session) : { sessionId: input.id };
+  const unackedHumanInterventions = listUnackedHumanInput(scope);
+  const validation = validateAgentHandBackAck({
+    session: summary,
+    ...(input.latestSeenInterventionEventId === undefined
+      ? {}
+      : { latestSeenInterventionEventId: input.latestSeenInterventionEventId }),
+    unackedHumanInterventions,
+  });
+  if (validation.ok === false) return { ok: false, error: validation.error };
+  const ackedHumanInterventions = acknowledgeInterventions(input.id, input.actor);
+  const events = controlAction(input.id, 'hand-back');
+  return { ok: true, events, ackedHumanInterventions };
 }
 
 function maybeAutoRevert(id: string, nodeConnected?: boolean) {
@@ -1815,6 +1861,7 @@ export {
   recordRoutedPtyInput,
   controlAction,
   acknowledgeInterventions,
+  handBackToAgent,
   maybeAutoRevert,
   getInterventions,
   onControlEvent,

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -132,6 +132,71 @@ describe('node-link-rpc-host', () => {
     expect(replyPayload.session).not.toHaveProperty('pid');
   });
 
+  it('turns requested initial agent-driven control mode into fresh control state before dispatch', () => {
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(
+      envelope('sessions.create', {
+        id: 'worker-session-1',
+        type: 'agent',
+        cwd: '/home/user/project',
+        displayName: 'Remote Codex worker',
+        controlMode: 'agent-driven',
+      }),
+      ctx
+    );
+
+    expect(localRelayNode.sessions.create).toHaveBeenCalledTimes(1);
+    const createCall = (
+      localRelayNode.sessions.create as ReturnType<typeof vi.fn>
+    ).mock.calls[0]?.[0] as CreateParams;
+    expect(createCall).toMatchObject({
+      id: 'worker-session-1',
+      type: 'agent',
+      cwd: '/home/user/project',
+      controlState: {
+        controlMode: 'agent-driven',
+        activeActors: [
+          {
+            kind: 'agent',
+            id: 'worker-session-1',
+            displayName: 'Remote Codex worker',
+          },
+        ],
+        activeWorker: {
+          kind: 'agent',
+          id: 'worker-session-1',
+          displayName: 'Remote Codex worker',
+        },
+        controlFreshness: 'fresh',
+        controlReason: 'requested-initial-agent-driven',
+      },
+    });
+    expect(createCall).not.toHaveProperty('controlMode');
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('sessions.create.result');
+  });
+
+  it('rejects requested agent-driven initial control for terminal sessions', () => {
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(
+      envelope('sessions.create', { type: 'terminal', controlMode: 'agent-driven' }),
+      ctx
+    );
+
+    expect(localRelayNode.sessions.create).not.toHaveBeenCalled();
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('sessions.create.error');
+    const err = sent[0]!.error as RelayNodeError;
+    expect(err.code).toBe('INVALID_REQUEST');
+    expect(err.message).toContain('agent sessions');
+  });
+
   it('defaults missing cwd to os.homedir() so routed creates from the picker never spawn with undefined', () => {
     const localRelayNode = fakeLocalNode();
     const host = createNodeLinkRpcHost({ localRelayNode });

--- a/test/session-control-api.test.ts
+++ b/test/session-control-api.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+import type { InterventionRecord } from '../shared/control-state.js';
+import {
+  clampInterventionLimit,
+  createAgentDrivenInitialControlState,
+  evaluateControlCapabilityPlaceholder,
+  toInterventionReadResponse,
+  validateAgentHandBackAck,
+} from '../server/session-control-api.js';
+
+function intervention(id: string, timestamp = `2026-05-16T00:00:0${id.length}.000Z`): InterventionRecord {
+  return {
+    id,
+    sessionId: 'session-1',
+    tabId: 'local:session-1',
+    nodeId: 'local',
+    globalSessionId: 'local:session-1',
+    cwd: '/tmp/work',
+    timestamp,
+    author: { kind: 'human', id: 'local-user', displayName: 'Local user' },
+    source: 'pty-input',
+    kind: 'human-input',
+    payloadPreview: id === 'secret' ? '[redacted:secret-like] bytes=40 sha256=abcdef123456' : `preview-${id}`,
+    redaction: {
+      redacted: id === 'secret',
+      byteCount: 10 + id.length,
+      charCount: id.length,
+      lineCount: 1,
+      hashSha256: `hash-${id}`,
+      classes: id === 'secret' ? ['secret-like'] : ['plain-text'],
+    },
+    modeBefore: 'agent-driven',
+    modeAfter: 'co-driven',
+  };
+}
+
+describe('session control API helpers', () => {
+  it('creates fresh agent-driven control state for new agent sessions', () => {
+    expect(
+      createAgentDrivenInitialControlState({
+        workerId: 'worker-session-1',
+        displayName: 'Ebi backend worker',
+      })
+    ).toEqual({
+      controlMode: 'agent-driven',
+      activeActors: [
+        {
+          kind: 'agent',
+          id: 'worker-session-1',
+          displayName: 'Ebi backend worker',
+        },
+      ],
+      activeWorker: {
+        kind: 'agent',
+        id: 'worker-session-1',
+        displayName: 'Ebi backend worker',
+      },
+      lastInterventionAt: null,
+      lastInterventionBy: null,
+      lastInterventionEventId: null,
+      controlFreshness: 'fresh',
+      controlReason: 'requested-initial-agent-driven',
+    });
+  });
+
+  it('returns bounded intervention history with redaction metadata but no raw payload dump', () => {
+    const response = toInterventionReadResponse({
+      records: [intervention('newest'), intervention('secret'), intervention('oldest')],
+      limit: 2,
+    });
+
+    expect(response.limit).toBe(2);
+    expect(response.count).toBe(2);
+    expect(response.truncated).toBe(true);
+    expect(response.rawPayloadAvailable).toBe(false);
+    expect(response.transcriptExportAvailable).toBe(false);
+    expect(response.interventions.map((record) => record.id)).toEqual(['newest', 'secret']);
+    expect(response.interventions[1]).toMatchObject({
+      payloadPreview: '[redacted:secret-like] bytes=40 sha256=abcdef123456',
+      redaction: { redacted: true, classes: ['secret-like'] },
+    });
+    expect(JSON.stringify(response)).not.toContain('password=');
+  });
+
+  it.each([
+    ['missing', undefined, 50],
+    ['blank', '', 50],
+    ['not-a-number', 'garbage', 50],
+    ['too-small', '0', 1],
+    ['negative', '-10', 1],
+    ['fraction', '3.9', 3],
+    ['too-large', '9999', 200],
+  ])('normalizes %s intervention read limits', (_name, input, expected) => {
+    expect(clampInterventionLimit(input)).toBe(expected);
+  });
+
+  it('surfaces the #427 capability placeholder and rejects explicit missing capabilities', () => {
+    expect(
+      evaluateControlCapabilityPlaceholder(undefined, 'session:intervention:read')
+    ).toMatchObject({ decision: 'allow', placeholder: true, capability: 'session:intervention:read' });
+
+    expect(
+      evaluateControlCapabilityPlaceholder('session:read,session:attach', 'session:intervention:read')
+    ).toMatchObject({
+      decision: 'deny',
+      reasonCode: 'CAPABILITY_REQUIRED',
+      capability: 'session:intervention:read',
+    });
+  });
+
+  it('accepts hand-back only when the caller acknowledges the latest human intervention id', () => {
+    const result = validateAgentHandBackAck({
+      session: {
+        id: 'session-1',
+        status: 'active',
+        controlMode: 'co-driven',
+        controlFreshness: 'fresh',
+        lastInterventionEventId: 'event-2',
+      },
+      latestSeenInterventionEventId: 'event-2',
+      unackedHumanInterventions: [intervention('event-2')],
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it.each([
+    ['missing-event-id', undefined, 'HAND_BACK_ACK_REQUIRED'],
+    ['old-event-id', 'event-1', 'STALE_INTERVENTION_ACK'],
+  ])('rejects hand-back with %s', (_name, latestSeenInterventionEventId, reasonCode) => {
+    const result = validateAgentHandBackAck({
+      session: {
+        id: 'session-1',
+        status: 'active',
+        controlMode: 'co-driven',
+        controlFreshness: 'fresh',
+        lastInterventionEventId: 'event-2',
+      },
+      latestSeenInterventionEventId,
+      unackedHumanInterventions: [intervention('event-2')],
+    });
+
+    expect(result).toMatchObject({ ok: false, error: { reasonCode } });
+  });
+
+  it.each([
+    ['disconnected', { status: 'disconnected', controlFreshness: 'fresh' }, 'SESSION_DISCONNECTED'],
+    ['stale', { status: 'active', controlFreshness: 'stale' }, 'CONTROL_STATE_STALE'],
+    ['unknown', { status: 'active', controlFreshness: 'unknown' }, 'CONTROL_STATE_UNKNOWN'],
+    ['old-session-default', { status: 'active', controlFreshness: undefined }, 'CONTROL_STATE_UNKNOWN'],
+  ])('rejects hand-back for %s sessions with typed errors', (_name, overrides, reasonCode) => {
+    const result = validateAgentHandBackAck({
+      session: {
+        id: 'session-1',
+        status: overrides.status as 'active' | 'disconnected',
+        controlMode: 'co-driven',
+        controlFreshness: overrides.controlFreshness as 'fresh' | 'stale' | 'unknown' | undefined,
+        lastInterventionEventId: 'event-2',
+      },
+      latestSeenInterventionEventId: 'event-2',
+      unackedHumanInterventions: [intervention('event-2')],
+    });
+
+    expect(result).toMatchObject({ ok: false, error: { reasonCode } });
+  });
+
+  it('rejects hand-back when no unacked human intervention is pending', () => {
+    const result = validateAgentHandBackAck({
+      session: {
+        id: 'session-1',
+        status: 'active',
+        controlMode: 'co-driven',
+        controlFreshness: 'fresh',
+        lastInterventionEventId: 'event-2',
+      },
+      latestSeenInterventionEventId: 'event-2',
+      unackedHumanInterventions: [],
+    });
+
+    expect(result).toMatchObject({ ok: false, error: { reasonCode: 'NO_UNACKED_HUMAN_INTERVENTION' } });
+  });
+});


### PR DESCRIPTION
## Summary
- Add scoped session control read helpers and routes for `GET /sessions/:id`, bounded `GET /sessions/:id/interventions`, and `POST /sessions/:id/control/hand-back`.
- Add a typed hand-back ack validator that requires the latest seen human intervention event id and rejects missing, stale, unknown, disconnected, and already-acked states.
- Add CLI commands for control reads/intervention reads/hand-back and document the #493 contract in the federated Relay docs.

## Motivation
External brains need a safe way to inspect who last touched a session before resuming agent control. This exposes the existing #490/#491 control/intervention state through the scoped session surface without exporting raw keylogs or terminal transcripts.

## The Case Against
This change might be wrong because:
- The control capability gate is still a #427 placeholder. Omitted capability headers intentionally preserve compatibility, so this is not a final security policy evaluator.
- Intervention reads are local-session reads only. Remote session summaries can be read through aggregated session state, but remote intervention read/write routing is intentionally not broadened here.
- The hand-back validator keys on the latest recorded intervention event id. If upstream intervention persistence misses a human touch, this API cannot detect that missing record by itself.
- Route coverage is mostly helper/session-level rather than live HTTP + CLI end-to-end. The code compiles into the CLI/server bundle, but QA should still exercise an authenticated running Relay instance before release.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Raw human input leaks through intervention reads | Response exposes existing redacted `payloadPreview`/metadata only and explicitly reports `rawPayloadAvailable: false`, `transcriptExportAvailable: false`. |
| Agent silently resumes after stale human input | Hand-back requires `latestSeenInterventionEventId` to match the session's latest intervention id and requires unacked human interventions. |
| Old sessions break due to missing control fields | Existing normalization remains in session summaries; new initial control state is only applied to newly-created agent sessions through the gateway path. |
| Placeholder capability semantics get mistaken for final auth | Docs and error details mark this as the #427 placeholder contract. |

## Verification
- `npm test -- test/session-control-api.test.ts test/control-engine.test.ts test/ws-pty-intervention.test.ts test/web-session-handler.test.ts test/sessions-web-restore.test.ts` (43 tests passed)
- `npm run check` (passes; 41 existing warnings)
- `npm run build` (passes; existing Vite chunk-size warning)

Closes #493
Refs #470
Refs #429


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI commands to retrieve session details, view session interventions, and acknowledge hand-back operations
  * Added API endpoints for querying and controlling session state

* **Documentation**
  * Added documentation for new session control operations and API endpoints

* **Tests**
  * Added comprehensive test coverage for session control functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->