### PR TITLE
feat: add read-only File RPC foundation

### DIFF
--- a/server/file-rpc.ts
+++ b/server/file-rpc.ts
@@ -418,10 +418,15 @@ async function executeRead(request: FileRpcRequest): Promise<FileRpcReadResponse
   const handle = await fs.open(request.path, 'r');
   try {
     const buffer = Buffer.alloc(Math.min(maxBytes + 1, FILE_RPC_MAX_READ_BYTES + 1));
-    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    let bytesRead = 0;
+    while (bytesRead < buffer.length) {
+      const read = await handle.read(buffer, bytesRead, buffer.length - bytesRead, bytesRead);
+      if (read.bytesRead === 0) break;
+      bytesRead += read.bytesRead;
+    }
     const visibleBytes = Math.min(bytesRead, maxBytes);
     let content = buffer.subarray(0, visibleBytes).toString('utf8');
-    const truncatedBytes = bytesRead > maxBytes || stats.size > maxBytes;
+    const truncatedBytes = bytesRead > maxBytes;
     let truncatedLines = false;
     if (maxLines !== undefined) {
       const lines = content.split('\n');

--- a/server/file-rpc.ts
+++ b/server/file-rpc.ts
@@ -1,0 +1,460 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import type { Stats } from 'node:fs';
+import type {
+  FileRpcDenialReason,
+  FileRpcListResponse,
+  FileRpcOperation,
+  FileRpcReadResponse,
+  FileRpcRequest,
+  FileRpcResponse,
+  FileRpcStat,
+  FileRpcStatResponse,
+} from '../shared/file-rpc.js';
+import {
+  FILE_RPC_DEFAULT_LIST_ENTRIES,
+  FILE_RPC_DEFAULT_READ_BYTES,
+  FILE_RPC_MAX_LIST_ENTRIES,
+  FILE_RPC_MAX_READ_BYTES,
+  FILE_RPC_MAX_READ_LINES,
+} from '../shared/file-rpc.js';
+import type { RelayNodeError } from '../shared/relay-node-protocol.js';
+import type { ScopedSessionSummary } from './session-envelope-registry.js';
+
+interface PathApi {
+  sep: string;
+  basename(path: string): string;
+  isAbsolute(path: string): boolean;
+  join(...paths: string[]): string;
+  normalize(path: string): string;
+  relative(from: string, to: string): string;
+  resolve(...paths: string[]): string;
+}
+
+export interface NormalizedHubFileRpcRequest {
+  request: FileRpcRequest;
+  policyScope: {
+    kind: ScopedSessionSummary['scope']['kind'];
+    nodeId: string;
+    cwd: string;
+    path: string;
+    repoPath?: string;
+    worktreePath?: string | null;
+  };
+}
+
+function fileRpcError(
+  code: RelayNodeError['code'],
+  reasonCode: FileRpcDenialReason,
+  message: string,
+  details: Record<string, unknown> = {}
+): RelayNodeError {
+  return {
+    code,
+    message,
+    retryable: false,
+    details: { reasonCode, ...details },
+  };
+}
+
+function invalidRequest(
+  reasonCode: FileRpcDenialReason,
+  message: string,
+  details: Record<string, unknown> = {}
+): RelayNodeError {
+  return fileRpcError('INVALID_REQUEST', reasonCode, message, details);
+}
+
+function notFound(
+  reasonCode: FileRpcDenialReason,
+  message: string,
+  details: Record<string, unknown> = {}
+): RelayNodeError {
+  return fileRpcError('NOT_FOUND', reasonCode, message, details);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function boundedInteger(
+  value: unknown,
+  fallback: number,
+  max: number,
+  field: string
+): number | RelayNodeError {
+  if (value === undefined || value === null) return fallback;
+  if (!Number.isInteger(value) || typeof value !== 'number' || value <= 0) {
+    return invalidRequest('FILE_RPC_INVALID_REQUEST', `${field} must be a positive integer`, {
+      field,
+    });
+  }
+  return Math.min(value, max);
+}
+
+function optionalBoundedInteger(
+  value: unknown,
+  max: number,
+  field: string
+): number | RelayNodeError | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (!Number.isInteger(value) || typeof value !== 'number' || value <= 0) {
+    return invalidRequest('FILE_RPC_INVALID_REQUEST', `${field} must be a positive integer`, {
+      field,
+    });
+  }
+  return Math.min(value, max);
+}
+
+function pathApiForPlatform(platform?: string): PathApi {
+  return platform === 'win32' ? path.win32 : path.posix;
+}
+
+function hasNul(value: string): boolean {
+  return value.includes('\0');
+}
+
+function normalizeForCompare(value: string, api: PathApi): string {
+  const normalized = api.normalize(value);
+  return api === path.win32 ? normalized.toLowerCase() : normalized;
+}
+
+function pathInside(root: string, target: string, api: PathApi): boolean {
+  const normalizedRoot = normalizeForCompare(root, api);
+  const normalizedTarget = normalizeForCompare(target, api);
+  if (normalizedTarget === normalizedRoot) return true;
+  const relative = api.relative(normalizedRoot, normalizedTarget);
+  return !!relative && !relative.startsWith('..') && !api.isAbsolute(relative);
+}
+
+function resolveRoot(summary: ScopedSessionSummary): string | RelayNodeError {
+  const { scope } = summary;
+  if (scope.kind === 'worktree' && scope.worktreePath) return scope.worktreePath;
+  if (scope.kind === 'repo' && scope.repoPath) return scope.repoPath;
+  if (scope.cwd) return scope.cwd;
+  return invalidRequest(
+    'FILE_RPC_ROOT_UNAVAILABLE',
+    'scoped session does not expose a filesystem root',
+    { sessionId: summary.sessionId, scope: scope.kind }
+  );
+}
+
+export function normalizeHubFileRpcRequest(input: {
+  operation: FileRpcOperation;
+  nodePlatform?: string;
+  nodeId: string;
+  session: ScopedSessionSummary;
+  body: Record<string, unknown>;
+}): { ok: true; value: NormalizedHubFileRpcRequest } | { ok: false; error: RelayNodeError } {
+  const api = pathApiForPlatform(input.nodePlatform);
+  const rootRaw = resolveRoot(input.session);
+  if (typeof rootRaw !== 'string') return { ok: false, error: rootRaw };
+  const bodyPath = input.body['path'];
+  const pathRaw = bodyPath === undefined || bodyPath === null ? '.' : nonEmptyString(bodyPath);
+  if (!pathRaw) {
+    return {
+      ok: false,
+      error: invalidRequest('FILE_RPC_INVALID_REQUEST', 'path must be a non-empty string when set', {
+        field: 'path',
+      }),
+    };
+  }
+  const cwdRaw = nonEmptyString(input.body['cwd']) ?? input.session.scope.cwd ?? rootRaw;
+  if (hasNul(rootRaw) || hasNul(cwdRaw) || hasNul(pathRaw)) {
+    return {
+      ok: false,
+      error: invalidRequest('FILE_RPC_INVALID_REQUEST', 'paths must not contain NUL bytes'),
+    };
+  }
+  const root = api.resolve(rootRaw);
+  const cwd = api.isAbsolute(cwdRaw) ? api.resolve(cwdRaw) : api.resolve(root, cwdRaw);
+  if (!pathInside(root, cwd, api)) {
+    return {
+      ok: false,
+      error: invalidRequest('FILE_RPC_CWD_ESCAPE', 'cwd is outside the scoped filesystem root', {
+        root,
+        cwd,
+      }),
+    };
+  }
+  const target = api.isAbsolute(pathRaw) ? api.resolve(pathRaw) : api.resolve(cwd, pathRaw);
+  if (!pathInside(root, target, api)) {
+    return {
+      ok: false,
+      error: invalidRequest('FILE_RPC_ROOT_ESCAPE', 'path is outside the scoped filesystem root', {
+        root,
+        cwd,
+        path: target,
+      }),
+    };
+  }
+
+  const base = {
+    sessionId: input.session.sessionId,
+    root,
+    cwd,
+    path: target,
+  };
+  let request: FileRpcRequest;
+  if (input.operation === 'list') {
+    const maxEntries = boundedInteger(
+      input.body['maxEntries'],
+      FILE_RPC_DEFAULT_LIST_ENTRIES,
+      FILE_RPC_MAX_LIST_ENTRIES,
+      'maxEntries'
+    );
+    if (typeof maxEntries !== 'number') return { ok: false, error: maxEntries };
+    request = { ...base, maxEntries };
+  } else if (input.operation === 'read') {
+    const maxBytes = boundedInteger(
+      input.body['maxBytes'],
+      FILE_RPC_DEFAULT_READ_BYTES,
+      FILE_RPC_MAX_READ_BYTES,
+      'maxBytes'
+    );
+    if (typeof maxBytes !== 'number') return { ok: false, error: maxBytes };
+    const maxLines = optionalBoundedInteger(
+      input.body['maxLines'],
+      FILE_RPC_MAX_READ_LINES,
+      'maxLines'
+    );
+    if (maxLines && typeof maxLines !== 'number') return { ok: false, error: maxLines };
+    request = { ...base, maxBytes, ...(maxLines ? { maxLines } : {}) };
+  } else {
+    request = base;
+  }
+
+  return {
+    ok: true,
+    value: {
+      request,
+      policyScope: {
+        kind: input.session.scope.kind,
+        nodeId: input.nodeId,
+        cwd,
+        path: target,
+        ...(input.session.scope.repoPath ? { repoPath: input.session.scope.repoPath } : {}),
+        ...(input.session.scope.worktreePath !== undefined
+          ? { worktreePath: input.session.scope.worktreePath }
+          : {}),
+      },
+    },
+  };
+}
+
+function parseFileRpcRequest(raw: unknown): FileRpcRequest | RelayNodeError {
+  const record = asRecord(raw);
+  if (!record) return invalidRequest('FILE_RPC_INVALID_REQUEST', 'file RPC payload must be an object');
+  const sessionId = nonEmptyString(record['sessionId']);
+  const root = nonEmptyString(record['root']);
+  const cwd = nonEmptyString(record['cwd']);
+  const requestPath = nonEmptyString(record['path']);
+  if (!sessionId || !root || !cwd || !requestPath) {
+    return invalidRequest(
+      'FILE_RPC_INVALID_REQUEST',
+      'file RPC payload requires sessionId, root, cwd, and path'
+    );
+  }
+  if (hasNul(sessionId) || hasNul(root) || hasNul(cwd) || hasNul(requestPath)) {
+    return invalidRequest('FILE_RPC_INVALID_REQUEST', 'file RPC payload paths must not contain NUL bytes');
+  }
+  const base = { sessionId, root, cwd, path: requestPath };
+  if (typeof record['maxEntries'] === 'number') {
+    const maxEntries = boundedInteger(
+      record['maxEntries'],
+      FILE_RPC_DEFAULT_LIST_ENTRIES,
+      FILE_RPC_MAX_LIST_ENTRIES,
+      'maxEntries'
+    );
+    if (typeof maxEntries !== 'number') return maxEntries;
+    return { ...base, maxEntries };
+  }
+  if (typeof record['maxBytes'] === 'number') {
+    const maxBytes = boundedInteger(
+      record['maxBytes'],
+      FILE_RPC_DEFAULT_READ_BYTES,
+      FILE_RPC_MAX_READ_BYTES,
+      'maxBytes'
+    );
+    if (typeof maxBytes !== 'number') return maxBytes;
+    const maxLines = optionalBoundedInteger(
+      record['maxLines'],
+      FILE_RPC_MAX_READ_LINES,
+      'maxLines'
+    );
+    if (maxLines && typeof maxLines !== 'number') return maxLines;
+    return { ...base, maxBytes, ...(maxLines ? { maxLines } : {}) };
+  }
+  return base;
+}
+
+function entryType(stats: Stats): FileRpcStat['type'] {
+  if (stats.isDirectory()) return 'directory';
+  if (stats.isFile()) return 'file';
+  if (stats.isSymbolicLink()) return 'symlink';
+  return 'other';
+}
+
+function statPayload(targetPath: string, stats: Stats): FileRpcStat {
+  return {
+    path: targetPath,
+    name: path.basename(targetPath),
+    type: entryType(stats),
+    size: stats.size,
+    mtimeMs: stats.mtimeMs,
+    mode: stats.mode,
+  };
+}
+
+async function realpathOrError(target: string, reasonCode: FileRpcDenialReason): Promise<string | RelayNodeError> {
+  try {
+    return await fs.realpath(target);
+  } catch {
+    if (reasonCode === 'FILE_RPC_ROOT_UNAVAILABLE') {
+      return notFound(reasonCode, 'filesystem root is unavailable', { root: target });
+    }
+    return notFound('FILE_RPC_NOT_FOUND', 'file RPC path was not found', { path: target });
+  }
+}
+
+async function normalizeNodeRequest(raw: unknown): Promise<FileRpcRequest | RelayNodeError> {
+  const parsed = parseFileRpcRequest(raw);
+  if ('code' in parsed) return parsed;
+  const root = path.resolve(parsed.root);
+  const cwd = path.resolve(parsed.cwd);
+  const target = path.resolve(parsed.path);
+  if (!pathInside(root, cwd, path)) {
+    return invalidRequest('FILE_RPC_CWD_ESCAPE', 'cwd is outside the scoped filesystem root', {
+      root,
+      cwd,
+    });
+  }
+  if (!pathInside(root, target, path)) {
+    return invalidRequest('FILE_RPC_ROOT_ESCAPE', 'path is outside the scoped filesystem root', {
+      root,
+      path: target,
+    });
+  }
+  const realRoot = await realpathOrError(root, 'FILE_RPC_ROOT_UNAVAILABLE');
+  if (typeof realRoot !== 'string') return realRoot;
+  const realTarget = await realpathOrError(target, 'FILE_RPC_NOT_FOUND');
+  if (typeof realTarget !== 'string') return realTarget;
+  if (!pathInside(realRoot, realTarget, path)) {
+    return invalidRequest('FILE_RPC_ROOT_ESCAPE', 'resolved path escapes the scoped filesystem root', {
+      root: realRoot,
+      path: realTarget,
+    });
+  }
+  return { ...parsed, root, cwd, path: target };
+}
+
+async function executeList(request: FileRpcRequest): Promise<FileRpcListResponse | RelayNodeError> {
+  const maxEntries = 'maxEntries' in request ? request.maxEntries : FILE_RPC_DEFAULT_LIST_ENTRIES;
+  let stats: Stats;
+  try {
+    stats = await fs.stat(request.path);
+  } catch {
+    return notFound('FILE_RPC_NOT_FOUND', 'directory was not found', { path: request.path });
+  }
+  if (!stats.isDirectory()) {
+    return invalidRequest('FILE_RPC_NOT_DIRECTORY', 'path is not a directory', { path: request.path });
+  }
+  const dirents = (await fs.readdir(request.path, { withFileTypes: true })).sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+  const entries: FileRpcStat[] = [];
+  for (const dirent of dirents.slice(0, maxEntries)) {
+    const entryPath = path.join(request.path, dirent.name);
+    try {
+      entries.push(statPayload(entryPath, await fs.lstat(entryPath)));
+    } catch {
+      // Directory changed between readdir and stat; skip the vanishing entry.
+    }
+  }
+  return {
+    operation: 'list',
+    root: request.root,
+    cwd: request.cwd,
+    path: request.path,
+    entries,
+    truncated: dirents.length > maxEntries,
+    maxEntries,
+  };
+}
+
+async function executeStat(request: FileRpcRequest): Promise<FileRpcStatResponse | RelayNodeError> {
+  try {
+    const stats = await fs.lstat(request.path);
+    return {
+      operation: 'stat',
+      root: request.root,
+      cwd: request.cwd,
+      path: request.path,
+      stat: statPayload(request.path, stats),
+    };
+  } catch {
+    return notFound('FILE_RPC_NOT_FOUND', 'path was not found', { path: request.path });
+  }
+}
+
+async function executeRead(request: FileRpcRequest): Promise<FileRpcReadResponse | RelayNodeError> {
+  const maxBytes = 'maxBytes' in request ? request.maxBytes : FILE_RPC_DEFAULT_READ_BYTES;
+  const maxLines = 'maxLines' in request ? request.maxLines : undefined;
+  let stats: Stats;
+  try {
+    stats = await fs.stat(request.path);
+  } catch {
+    return notFound('FILE_RPC_NOT_FOUND', 'file was not found', { path: request.path });
+  }
+  if (!stats.isFile()) {
+    return invalidRequest('FILE_RPC_NOT_FILE', 'path is not a regular file', { path: request.path });
+  }
+  const handle = await fs.open(request.path, 'r');
+  try {
+    const buffer = Buffer.alloc(Math.min(maxBytes + 1, FILE_RPC_MAX_READ_BYTES + 1));
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    const visibleBytes = Math.min(bytesRead, maxBytes);
+    let content = buffer.subarray(0, visibleBytes).toString('utf8');
+    const truncatedBytes = bytesRead > maxBytes || stats.size > maxBytes;
+    let truncatedLines = false;
+    if (maxLines !== undefined) {
+      const lines = content.split('\n');
+      if (lines.length > maxLines) {
+        content = lines.slice(0, maxLines).join('\n');
+        truncatedLines = true;
+      }
+    }
+    return {
+      operation: 'read',
+      root: request.root,
+      cwd: request.cwd,
+      path: request.path,
+      encoding: 'utf8',
+      content,
+      bytesRead: visibleBytes,
+      truncatedBytes,
+      truncatedLines,
+      maxBytes,
+      ...(maxLines !== undefined ? { maxLines } : {}),
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function executeLocalFileRpc(
+  operation: FileRpcOperation,
+  raw: unknown
+): Promise<FileRpcResponse | RelayNodeError> {
+  const request = await normalizeNodeRequest(raw);
+  if ('code' in request) return request;
+  if (operation === 'list') return await executeList(request);
+  if (operation === 'stat') return await executeStat(request);
+  return await executeRead(request);
+}

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -1,4 +1,6 @@
 import * as express from 'express';
+import { isFileRpcOperation } from '../shared/file-rpc.js';
+import { normalizeHubFileRpcRequest } from './file-rpc.js';
 import type { Request, Response } from 'express';
 import { isNodeManifest, type NodeManifest } from '../shared/node-manifest.js';
 import type {
@@ -55,6 +57,7 @@ import {
   evaluateHubPolicy,
   isSessionCreateType,
   policyDecisionToRelayError,
+  requiredCapabilitiesForRpcIntent,
   revokePolicyAffectedSessions,
   sessionCreateCapability,
 } from './hub-policy-evaluator.js';
@@ -1192,6 +1195,141 @@ export function createHubNodeRouter(
       sendRegistryError(registry, res, error);
     }
   });
+
+  router.post(
+    '/hub/nodes/:nodeId/sessions/:sessionId/files/:operation',
+    requireAuth,
+    async (req, res) => {
+      const { nodeId, sessionId, operation } = req.params;
+      if (!nodeId) {
+        sendRelayError(res, relayError('INVALID_REQUEST', 'nodeId is required'));
+        return;
+      }
+      if (!sessionId) {
+        sendRelayError(res, relayError('INVALID_REQUEST', 'sessionId is required'));
+        return;
+      }
+      if (!isFileRpcOperation(operation)) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'file RPC operation must be list, stat, or read', false, {
+            reasonCode: 'FILE_RPC_INVALID_REQUEST',
+            operation,
+          })
+        );
+        return;
+      }
+      const node = registry
+        .listNodes()
+        .find((candidate) => candidate.nodeId === nodeId);
+      if (!node || node.status === 'revoked') {
+        sendRelayError(res, relayError('NOT_FOUND', 'node is not paired'));
+        return;
+      }
+      if (node.protocolVersion !== RELAY_NODE_LINK_PROTOCOL_VERSION) {
+        const [nodeMajor] = node.protocolVersion.split('.');
+        const [hubMajor] = RELAY_NODE_LINK_PROTOCOL_VERSION.split('.');
+        sendRelayError(
+          res,
+          relayError(
+            nodeMajor === hubMajor ? 'VERSION_SKEW' : 'PROTOCOL_INCOMPATIBLE',
+            `relay-node-link protocol ${node.protocolVersion} must exactly match hub protocol ${RELAY_NODE_LINK_PROTOCOL_VERSION}`
+          )
+        );
+        return;
+      }
+      if (
+        node.status !== 'online' ||
+        !options.nodeLinks?.hasActiveNode(nodeId)
+      ) {
+        sendRelayError(
+          res,
+          relayError(
+            'NODE_OFFLINE',
+            `node ${nodeId} has no live reverse link`,
+            true
+          )
+        );
+        return;
+      }
+
+      const body = bodyRecord(req);
+      const lifecycle = envelopes.validate({ nodeId, sessionId, now: now() });
+      if (!lifecycle.ok) {
+        const denial = lifecycle as Exclude<
+          ReturnType<InMemorySessionEnvelopeRegistry['validate']>,
+          { ok: true }
+        >;
+        auditLifecycleDenial(
+          options.auditSink,
+          denial,
+          nodeId,
+          sessionId,
+          `rpc.fs.${operation}`,
+          body
+        );
+        sendRelayError(res, denial.error);
+        return;
+      }
+
+      const normalized = normalizeHubFileRpcRequest({
+        operation,
+        nodePlatform: node.platform,
+        nodeId,
+        session: lifecycle.summary,
+        body,
+      });
+      if (normalized.ok === false) {
+        sendRelayError(res, normalized.error);
+        return;
+      }
+
+      const action = `rpc.fs.${operation}`;
+      const policyDecision = evaluateHubPolicy({
+        peer: { kind: 'hub' },
+        node,
+        nodeId,
+        intent: { action, target: nodeId },
+        scope: normalized.value.policyScope,
+        requiredCapabilities: requiredCapabilitiesForRpcIntent(action),
+        sessionId,
+        ...(lifecycle.summary.correlationId
+          ? { correlationId: lifecycle.summary.correlationId }
+          : {}),
+        ...(lifecycle.summary.expiresAt !== undefined
+          ? { expiresAt: lifecycle.summary.expiresAt }
+          : {}),
+        ...(lifecycle.summary.revokedAt
+          ? { revokedAt: lifecycle.summary.revokedAt }
+          : {}),
+        params: { ...body, path: normalized.value.request.path },
+        now: now(),
+      });
+      if (
+        sendPolicyDecision(options.auditSink, res, policyDecision, {
+          ...body,
+          path: normalized.value.request.path,
+        })
+      ) {
+        return;
+      }
+
+      try {
+        const payload = await options.nodeLinks.request(
+          nodeId,
+          `fs.${operation}`,
+          normalized.value.request
+        );
+        res.json(payload);
+      } catch (error) {
+        if (error instanceof HubNodeLinkError) {
+          sendRelayError(res, error.relayNodeError);
+          return;
+        }
+        sendRegistryError(registry, res, error);
+      }
+    }
+  );
 
   router.delete(
     '/hub/nodes/:nodeId/sessions/:sessionId',

--- a/server/hub-policy-evaluator.ts
+++ b/server/hub-policy-evaluator.ts
@@ -123,6 +123,8 @@ export function requiredCapabilitiesForRpcIntent(action: string): string[] {
       return ['session:read'];
     case 'rpc.fs.list':
       return ['rpc:fs:list'];
+    case 'rpc.fs.stat':
+      return ['rpc:fs:read'];
     case 'rpc.fs.read':
       return ['rpc:fs:read'];
     case 'rpc.fs.tail':

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -1,5 +1,7 @@
 import * as crypto from 'node:crypto';
 import * as os from 'node:os';
+import { isFileRpcOperation } from '../shared/file-rpc.js';
+import { executeLocalFileRpc } from './file-rpc.js';
 import type { LocalRelayNode } from './local-node.js';
 import type { Logger } from './logger.js';
 import { createLogger } from './logger.js';
@@ -22,7 +24,8 @@ import type { SessionSummary } from './types.js';
 // envelope on the same `requestId`.
 //
 // Wired today: `sessions.create` (#425.7), `sessions.list` (#465),
-// and `sessions.kill` (#478).
+// `sessions.kill` (#478), and read-only File RPC `fs.list` / `fs.stat` /
+// `fs.read` (#505).
 // Other RPC types fall through to an INVALID_REQUEST response so
 // misrouted envelopes don't silently hang the hub-side pending
 // request.
@@ -333,6 +336,26 @@ export function createNodeLinkRpcHost(
     }
   }
 
+  async function handleFileRpc(
+    operation: 'list' | 'stat' | 'read',
+    envelope: RelayNodeEnvelope,
+    ctx: NodeLinkEnvelopeHandlerContext
+  ): Promise<void> {
+    try {
+      const result = await executeLocalFileRpc(operation, envelope.payload);
+      if ('code' in result) {
+        sendErrorEnvelope(ctx, envelope, result);
+        return;
+      }
+      sendResultEnvelope(ctx, envelope, result);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error ?? 'unknown');
+      logger.error(`fs.${operation} failed: ${message}`);
+      sendErrorEnvelope(ctx, envelope, internalError(message));
+    }
+  }
+
   function handle(
     envelope: RelayNodeEnvelope,
     ctx: NodeLinkEnvelopeHandlerContext
@@ -348,6 +371,11 @@ export function createNodeLinkRpcHost(
     }
     if (envelope.type === 'sessions.kill') {
       handleSessionsKill(envelope, ctx);
+      return;
+    }
+    const fsMatch = envelope.type.match(/^fs\.(.+)$/);
+    if (fsMatch && isFileRpcOperation(fsMatch[1])) {
+      void handleFileRpc(fsMatch[1], envelope, ctx);
       return;
     }
     logger.warn(

--- a/shared/file-rpc.ts
+++ b/shared/file-rpc.ts
@@ -1,0 +1,89 @@
+export const FILE_RPC_MAX_LIST_ENTRIES = 500;
+export const FILE_RPC_DEFAULT_LIST_ENTRIES = 100;
+export const FILE_RPC_MAX_READ_BYTES = 64 * 1024;
+export const FILE_RPC_DEFAULT_READ_BYTES = 32 * 1024;
+export const FILE_RPC_MAX_READ_LINES = 2_000;
+
+export type FileRpcOperation = 'list' | 'stat' | 'read';
+
+export const FILE_RPC_OPERATIONS = ['list', 'stat', 'read'] as const satisfies readonly FileRpcOperation[];
+
+export type FileRpcDenialReason =
+  | 'FILE_RPC_INVALID_REQUEST'
+  | 'FILE_RPC_SESSION_REQUIRED'
+  | 'FILE_RPC_ROOT_UNAVAILABLE'
+  | 'FILE_RPC_CWD_ESCAPE'
+  | 'FILE_RPC_ROOT_ESCAPE'
+  | 'FILE_RPC_NOT_FOUND'
+  | 'FILE_RPC_NOT_DIRECTORY'
+  | 'FILE_RPC_NOT_FILE'
+  | 'FILE_RPC_SIZE_LIMIT_EXCEEDED';
+
+export type FileRpcEntryType = 'file' | 'directory' | 'symlink' | 'other';
+
+export interface FileRpcBaseRequest {
+  sessionId: string;
+  root: string;
+  cwd: string;
+  path: string;
+}
+
+export interface FileRpcListRequest extends FileRpcBaseRequest {
+  maxEntries: number;
+}
+
+export type FileRpcStatRequest = FileRpcBaseRequest;
+
+export interface FileRpcReadRequest extends FileRpcBaseRequest {
+  maxBytes: number;
+  maxLines?: number;
+}
+
+export type FileRpcRequest = FileRpcListRequest | FileRpcStatRequest | FileRpcReadRequest;
+
+export interface FileRpcStat {
+  path: string;
+  name: string;
+  type: FileRpcEntryType;
+  size: number;
+  mtimeMs: number;
+  mode: number;
+}
+
+export interface FileRpcListResponse {
+  operation: 'list';
+  root: string;
+  cwd: string;
+  path: string;
+  entries: FileRpcStat[];
+  truncated: boolean;
+  maxEntries: number;
+}
+
+export interface FileRpcStatResponse {
+  operation: 'stat';
+  root: string;
+  cwd: string;
+  path: string;
+  stat: FileRpcStat;
+}
+
+export interface FileRpcReadResponse {
+  operation: 'read';
+  root: string;
+  cwd: string;
+  path: string;
+  encoding: 'utf8';
+  content: string;
+  bytesRead: number;
+  truncatedBytes: boolean;
+  truncatedLines: boolean;
+  maxBytes: number;
+  maxLines?: number;
+}
+
+export type FileRpcResponse = FileRpcListResponse | FileRpcStatResponse | FileRpcReadResponse;
+
+export function isFileRpcOperation(value: unknown): value is FileRpcOperation {
+  return value === 'list' || value === 'stat' || value === 'read';
+}

--- a/test/file-rpc.test.ts
+++ b/test/file-rpc.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import * as fsPromises from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -124,6 +125,63 @@ describe('read-only File RPC foundation', () => {
       truncatedBytes: true,
       truncatedLines: true,
     });
+  });
+
+  it('continues reading after short file-handle reads before reporting truncation', async () => {
+    const root = fixtureRoot();
+    const file = path.join(root, 'short-read.txt');
+    fs.writeFileSync(file, 'abcdefghijklmnopqrstuvwxyz');
+    const probeHandle = await fsPromises.open(file, 'r');
+    const handlePrototype = Object.getPrototypeOf(probeHandle) as {
+      read: (buffer: Buffer, offset: number, length: number, position: number) => Promise<{ bytesRead: number }>;
+    };
+    const realRead = handlePrototype.read;
+    await probeHandle.close();
+    handlePrototype.read = function shortRead(
+      this: unknown,
+      buffer: Buffer,
+      offset: number,
+      length: number,
+      position: number
+    ) {
+      return realRead.call(this, buffer, offset, Math.min(length, 5), position);
+    };
+
+    try {
+      const completeRead = await executeLocalFileRpc('read', {
+        sessionId: 'session_a',
+        root,
+        cwd: root,
+        path: file,
+        maxBytes: 30,
+      });
+
+      expect(completeRead).toMatchObject({
+        operation: 'read',
+        content: 'abcdefghijklmnopqrstuvwxyz',
+        bytesRead: 26,
+        truncatedBytes: false,
+        truncatedLines: false,
+      });
+
+      const truncatedRead = await executeLocalFileRpc('read', {
+        sessionId: 'session_a',
+        root,
+        cwd: root,
+        path: file,
+        maxBytes: 10,
+      });
+
+      expect(truncatedRead).toMatchObject({
+        operation: 'read',
+        content: 'abcdefghij',
+        bytesRead: 10,
+        truncatedBytes: true,
+        truncatedLines: false,
+      });
+    } finally {
+      handlePrototype.read = realRead;
+    }
   });
 
   it('denies realpath symlink escapes from the scoped root', async () => {

--- a/test/file-rpc.test.ts
+++ b/test/file-rpc.test.ts
@@ -1,0 +1,149 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { executeLocalFileRpc, normalizeHubFileRpcRequest } from '../server/file-rpc.js';
+import { createRoutedNodeSessionEnvelope } from '../shared/session-envelope.js';
+import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
+
+const cleanup: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanup.length > 0) cleanup.pop()?.();
+});
+
+function fixtureRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-file-rpc-'));
+  cleanup.push(() => fs.rmSync(root, { recursive: true, force: true }));
+  fs.mkdirSync(path.join(root, 'src'));
+  fs.writeFileSync(path.join(root, 'README.md'), 'line 1\nline 2\nline 3\n');
+  fs.writeFileSync(path.join(root, 'src', 'index.ts'), 'export const value = 1;\n');
+  return root;
+}
+
+function sessionSummary(root: string) {
+  const registry = createSessionEnvelopeRegistry();
+  registry.upsert(
+    createRoutedNodeSessionEnvelope({
+      nodeId: 'node_a',
+      sessionId: 'session_a',
+      cwd: root,
+      repoPath: root,
+      issuedAt: '2026-01-02T03:04:05.000Z',
+    })
+  );
+  const validation = registry.validate({
+    nodeId: 'node_a',
+    sessionId: 'session_a',
+    now: new Date('2026-01-02T03:04:05.000Z'),
+  });
+  if (validation.ok === false) throw new Error(validation.error.message);
+  return validation.summary;
+}
+
+describe('read-only File RPC foundation', () => {
+  it('normalizes hub requests against the scoped cwd/root and clamps payload bounds', () => {
+    const root = fixtureRoot();
+    const normalized = normalizeHubFileRpcRequest({
+      operation: 'read',
+      nodeId: 'node_a',
+      nodePlatform: process.platform,
+      session: sessionSummary(root),
+      body: { path: 'README.md', maxBytes: 999_999, maxLines: 10_000 },
+    });
+
+    expect(normalized).toMatchObject({
+      ok: true,
+      value: {
+        request: {
+          sessionId: 'session_a',
+          root,
+          cwd: root,
+          path: path.join(root, 'README.md'),
+          maxBytes: 65536,
+          maxLines: 2000,
+        },
+      },
+    });
+  });
+
+  it('rejects cwd and path escapes before dispatching to a node', () => {
+    const root = fixtureRoot();
+    expect(
+      normalizeHubFileRpcRequest({
+        operation: 'list',
+        nodeId: 'node_a',
+        nodePlatform: process.platform,
+        session: sessionSummary(root),
+        body: { cwd: '..', path: '.' },
+      })
+    ).toMatchObject({ ok: false, error: { details: { reasonCode: 'FILE_RPC_CWD_ESCAPE' } } });
+
+    expect(
+      normalizeHubFileRpcRequest({
+        operation: 'stat',
+        nodeId: 'node_a',
+        nodePlatform: process.platform,
+        session: sessionSummary(root),
+        body: { path: '../outside' },
+      })
+    ).toMatchObject({ ok: false, error: { details: { reasonCode: 'FILE_RPC_ROOT_ESCAPE' } } });
+  });
+
+  it('executes local list/stat/read with entry and byte/line bounds', async () => {
+    const root = fixtureRoot();
+    const list = await executeLocalFileRpc('list', {
+      sessionId: 'session_a',
+      root,
+      cwd: root,
+      path: root,
+      maxEntries: 1,
+    });
+    expect(list).toMatchObject({ operation: 'list', truncated: true, entries: [{ name: 'README.md' }] });
+
+    const stat = await executeLocalFileRpc('stat', {
+      sessionId: 'session_a',
+      root,
+      cwd: root,
+      path: path.join(root, 'README.md'),
+    });
+    expect(stat).toMatchObject({ operation: 'stat', stat: { name: 'README.md', type: 'file' } });
+
+    const read = await executeLocalFileRpc('read', {
+      sessionId: 'session_a',
+      root,
+      cwd: root,
+      path: path.join(root, 'README.md'),
+      maxBytes: 12,
+      maxLines: 1,
+    });
+    expect(read).toMatchObject({
+      operation: 'read',
+      content: 'line 1',
+      bytesRead: 12,
+      truncatedBytes: true,
+      truncatedLines: true,
+    });
+  });
+
+  it('denies realpath symlink escapes from the scoped root', async () => {
+    const root = fixtureRoot();
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-file-rpc-outside-'));
+    cleanup.push(() => fs.rmSync(outside, { recursive: true, force: true }));
+    fs.writeFileSync(path.join(outside, 'secret.txt'), 'nope');
+    fs.symlinkSync(outside, path.join(root, 'outside-link'));
+
+    const denied = await executeLocalFileRpc('read', {
+      sessionId: 'session_a',
+      root,
+      cwd: root,
+      path: path.join(root, 'outside-link', 'secret.txt'),
+      maxBytes: 64,
+    });
+
+    expect(denied).toMatchObject({
+      code: 'INVALID_REQUEST',
+      details: { reasonCode: 'FILE_RPC_ROOT_ESCAPE' },
+    });
+  });
+});

--- a/test/hub-node-session-routing.test.ts
+++ b/test/hub-node-session-routing.test.ts
@@ -277,6 +277,7 @@ describe('hub-routed node session create and attach', () => {
       port,
       nodeLinks,
       sessionEnvelopes,
+      registry,
     };
   }
 
@@ -903,6 +904,119 @@ describe('hub-routed node session create and attach', () => {
       localSessionId: 'remote-session-1',
       globalSessionId: `${nodeId}:remote-session-1`,
       timestamp: '2026-01-02T03:04:05.000Z',
+    });
+  });
+
+  it('routes read-only File RPC requests with scoped root and bounds', async () => {
+    const { base, wsBase, sessionEnvelopes } = await startHub();
+    const { token, nodeId } = await pairNode(base);
+    seedRemoteSessionEnvelope(sessionEnvelopes, nodeId);
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const readPromise = fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions/remote-session-1/files/read`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({ path: 'README.md', maxBytes: 999_999, maxLines: 1 }),
+      }
+    );
+
+    const request = await nextJson(nodeWs);
+    expect(request).toMatchObject({
+      nodeId,
+      channel: 'rpc',
+      type: 'fs.read',
+      payload: {
+        sessionId: 'remote-session-1',
+        root: '/srv/relay-ide',
+        cwd: '/srv/relay-ide',
+        path: '/srv/relay-ide/README.md',
+        maxBytes: 65536,
+        maxLines: 1,
+      },
+    });
+    nodeWs.send(
+      JSON.stringify({
+        protocol: request.protocol,
+        protocolVersion: request.protocolVersion,
+        nodeId,
+        channel: 'rpc',
+        type: 'fs.read.result',
+        requestId: request.requestId,
+        timestamp: new Date().toISOString(),
+        payload: {
+          operation: 'read',
+          root: '/srv/relay-ide',
+          cwd: '/srv/relay-ide',
+          path: '/srv/relay-ide/README.md',
+          encoding: 'utf8',
+          content: '# Relay',
+          bytesRead: 7,
+          truncatedBytes: false,
+          truncatedLines: false,
+          maxBytes: 65536,
+          maxLines: 1,
+        },
+      })
+    );
+
+    const res = await readPromise;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ operation: 'read', content: '# Relay' });
+  });
+
+  it('denies File RPC traversal before it reaches the node link', async () => {
+    const { base, wsBase, sessionEnvelopes } = await startHub();
+    const { token, nodeId } = await pairNode(base);
+    seedRemoteSessionEnvelope(sessionEnvelopes, nodeId);
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const res = await fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions/remote-session-1/files/list`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({ path: '../secret' }),
+      }
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: { code: 'INVALID_REQUEST', details: { reasonCode: 'FILE_RPC_ROOT_ESCAPE' } },
+    });
+    expect(nodeWs.readyState).toBe(WebSocket.OPEN);
+  });
+
+  it('denies File RPC for wrong or missing scoped sessions', async () => {
+    const { base, wsBase } = await startHub();
+    const { token, nodeId } = await pairNode(base);
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const res = await fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions/missing-session/files/stat`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({ path: 'README.md' }),
+      }
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({
+      error: { code: 'NOT_FOUND', details: { reasonCode: 'SESSION_ENVELOPE_NOT_FOUND' } },
     });
   });
 

--- a/test/hub-policy-evaluator.test.ts
+++ b/test/hub-policy-evaluator.test.ts
@@ -312,6 +312,39 @@ describe('hub policy evaluator', () => {
     });
   });
 
+  it('maps read-only File RPC intents to read/list capability bits', () => {
+    expect(requiredCapabilitiesForRpcIntent('rpc.fs.list')).toEqual(['rpc:fs:list']);
+    expect(requiredCapabilitiesForRpcIntent('rpc.fs.stat')).toEqual(['rpc:fs:read']);
+    expect(requiredCapabilitiesForRpcIntent('rpc.fs.read')).toEqual(['rpc:fs:read']);
+  });
+
+  it('denies File RPC when the node ACL lacks the required read-only capability', () => {
+    const node = nodeSummary({ allowed: ['session:read'] });
+    const decision = evaluateHubPolicy(
+      baseInput({
+        node,
+        intent: { action: 'rpc.fs.read', target: node.nodeId },
+        requiredCapabilities: requiredCapabilitiesForRpcIntent('rpc.fs.read'),
+        scope: {
+          kind: 'repo',
+          nodeId: node.nodeId,
+          cwd: '/srv/relay',
+          repoPath: '/srv/relay',
+        },
+        sessionId: 's1',
+      })
+    );
+    expect(decision).toMatchObject({
+      decision: 'deny',
+      reasonCode: 'POLICY_CAPABILITY_DENIED',
+      deniedBits: ['rpc:fs:read'],
+    });
+    expect(policyDecisionToRelayError(decision)).toMatchObject({
+      code: 'UNAUTHORIZED',
+      details: { reasonCode: 'POLICY_CAPABILITY_DENIED', deniedBits: ['rpc:fs:read'] },
+    });
+  });
+
   it('fails closed when audit persistence fails for high-risk decisions', () => {
     const node = nodeSummary({ trustTier: 'prod', allowed: ['rpc:fs:write'] });
     const decision = evaluateHubPolicy(


### PR DESCRIPTION
## Summary
- Adds shared read-only File RPC envelopes for `list`, `stat`, and bounded `read`.
- Adds hub route `POST /hub/nodes/:nodeId/sessions/:sessionId/files/:operation` that validates operation, live node link, scoped session envelope, path/root normalization, and #496 policy capabilities before dispatching over `/hub/node-link`.
- Adds node-link host execution for `fs.list`, `fs.stat`, and `fs.read` with directory entry limits, read byte/line limits, realpath symlink/root escape checks, and typed denial reasons.

Closes #505
Refs #428 #426 #427

## The Case Against
- This introduces the first file-content RPC surface, so the biggest risk is path boundary slop. The route now normalizes hub requests against the #426 scoped session cwd/root before dispatch, and the node rechecks realpaths before reading so symlink escapes fail closed.
- `stat` is mapped to `rpc:fs:read` rather than a new capability bit. That is intentionally conservative for this slice, but reviewers may want a future dedicated stat/list/read split if the product needs finer ACLs.
- The HTTP surface is backend-only; there is no UI migration here. Consumers still need to call the new route explicitly.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Traversal or cwd/root escape | Hub normalization rejects relative escapes; node execution rechecks resolved realpaths. |
| Wrong node/session data leak | Route validates the scoped session envelope for the routed node before policy evaluation or RPC dispatch. |
| Overlarge payloads | Hub clamps list/read limits; node execution enforces list entry, byte, and line bounds. |
| Accidental mutating File RPC expansion | Operation union/guard is only `list | stat | read`; node host only dispatches `fs.list`, `fs.stat`, `fs.read`. |

## Verification
- `npm test -- test/file-rpc.test.ts test/hub-node-session-routing.test.ts test/hub-policy-evaluator.test.ts` — 34/34 passed
- `npm run check` — passed, existing warnings only
- `npm run build` — passed
- `npm test` — 2194/2195 passed; one full-suite `test/local-logs.test.ts` rotation follower timeout reproduced as isolated flake/noise, then `npm test -- test/local-logs.test.ts` passed 8/8

## No mutating File RPC proof
- `shared/file-rpc.ts` defines `FileRpcOperation = 'list' | 'stat' | 'read'` and `FILE_RPC_OPERATIONS = ['list', 'stat', 'read']`.
- `server/node-link-rpc-host.ts` only dispatches valid `fs.list`, `fs.stat`, and `fs.read` operations through `isFileRpcOperation`.
- No `write`, `delete`, `mkdir`, `rename`, or `chmod` File RPC operation was added.
