### PR TITLE
feat: audit control-mode interventions

### DIFF
--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -127,9 +127,11 @@ Routed and local session summaries carry a product `controlMode` contract that i
 
 The summary fields are flattened on `SessionSummary`: `activeActors`, optional `activeWorker`, `lastInterventionAt`, `lastInterventionBy`, `lastInterventionEventId`, `controlFreshness` (`fresh`, `stale`, `unknown`), and optional `controlReason`. This lets the hub/client render current control state from session list/create responses without fetching intervention history. Legacy or backfilled sessions normalize to `human-driven` with `unknown` freshness.
 
-Reserved node-link event envelope names for later intervention work are `tab.mode-changed` and `tab.intervention` on the `events` channel. Their identity shape uses `nodeId`, node-local `sessionId`, optional `globalSessionId`, and `cwd`; repo/worktree fields (`repoPath`, `worktreePath`, `repoName`, `branchName`) are optional decoration so local repo tabs, remote node tabs, and free/non-git tabs remain representable.
+`tab.mode-changed` and `tab.intervention` event envelope names are emitted on the `events` channel. Their identity shape uses `nodeId`, node-local `sessionId`, optional `globalSessionId`, and `cwd`; repo/worktree fields (`repoPath`, `worktreePath`, `repoName`, `branchName`) are optional decoration so local repo tabs, remote node tabs, and free/non-git tabs remain representable. #470 owns the product semantics of when control modes change and when interventions are captured; #427 owns the allow/challenge/deny policy and hash-chained audit trail for those events.
 
-#427 boundary: #490 only defines and serializes state. It does not add capability gates, trust tiers, two-token confirmation, security policy evaluation, intervention persistence, or hash-chained audit logging.
+Control/intervention audit correlation is intentionally compact: audit rows carry stable event/session/node identifiers, actor identity hashes, intervention kind/source, mode before/after, payload size/hash/redaction summary, and hashes of the compact scope/params. Raw keystrokes, terminal bytes, file bytes, secrets, and full environment values must stay in the intervention/control source systems and must not be duplicated into the security audit log.
+
+#427 boundary: #490 only defines and serializes state. The #499 correlation slice records compact #470 control/intervention events into the #427 audit surface, but it does not broaden control semantics, add file/git/exec powers, or make intervention history a transcript export.
 
 ### Session control reads and hand-back ack (#493)
 
@@ -147,7 +149,7 @@ relay-ide sessions interventions <session-id> [--limit <n>]
 relay-ide sessions hand-back <session-id> --latest-seen-intervention-event-id <event-id>
 ```
 
-Capability checks currently use the #427 placeholder header contract: omitted `x-relay-capabilities` preserves compatibility, while an explicit header must include `session:control:read`, `session:intervention:read`, or `session:control:write` for the respective operation.
+Capability checks currently use the #427 placeholder header contract: omitted `x-relay-capabilities` preserves compatibility, while an explicit header must include `session:read` for session summaries, `tab:intervention:read` plus session visibility for intervention history, or `tab:mode:set-agent` plus the session control bit for any path that restores `agent-driven`. The `tab:mode:set-agent` bit is scoped to the mode transition only; it does not imply file write, git write, arbitrary exec, or any other high-risk capability.
 
 ### Heartbeat and Offline Detection
 

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -59,7 +59,7 @@ import {
   policyDecisionToRelayError,
   requiredCapabilitiesForRpcIntent,
   revokePolicyAffectedSessions,
-  sessionCreateCapability,
+  sessionCreateCapabilities,
 } from './hub-policy-evaluator.js';
 
 interface HubNodeSessionTransport {
@@ -1169,7 +1169,10 @@ export function createHubNodeRouter(
       nodeId,
       intent: { action: 'sessions.create', target: nodeId },
       scope: sessionCreatePolicyScope(nodeId, body),
-      requiredCapabilities: [sessionCreateCapability(sessionType)],
+      requiredCapabilities: sessionCreateCapabilities({
+        sessionType,
+        controlMode: body['controlMode'],
+      }),
       ...(expiresAt !== undefined ? { expiresAt } : {}),
       params: body,
       now: createNow,

--- a/server/hub-policy-evaluator.ts
+++ b/server/hub-policy-evaluator.ts
@@ -111,7 +111,18 @@ export function sessionCreateCapability(sessionType: SessionCreateType): RelayCa
   return sessionType === 'agent' ? 'session:create:agent' : 'session:create:terminal';
 }
 
+export function sessionCreateCapabilities(input: {
+  sessionType: SessionCreateType;
+  controlMode?: unknown;
+}): RelayCapabilityBit[] {
+  const capabilities = [sessionCreateCapability(input.sessionType)];
+  if (input.controlMode === 'agent-driven') capabilities.push('tab:mode:set-agent');
+  return capabilities;
+}
+
 export function requiredCapabilitiesForRpcIntent(action: string): string[] {
+  if (action === 'sessions.interventions.read') return ['session:read', 'tab:intervention:read'];
+  if (action === 'sessions.control.set-agent') return ['session:attach', 'tab:mode:set-agent'];
   switch (action) {
     case 'sessions.create.terminal':
       return ['session:create:terminal'];

--- a/server/index.ts
+++ b/server/index.ts
@@ -151,9 +151,11 @@ import {
 import {
   actorFromRequestBody,
   capabilityDecisionFromRequest,
+  capabilitiesDecisionFromRequest,
   capabilityError,
   clampInterventionLimit,
   CONTROL_READ_CAPABILITY,
+  CONTROL_SESSION_CAPABILITY,
   CONTROL_WRITE_CAPABILITY,
   createAgentDrivenInitialControlState,
   errorStatus as sessionControlErrorStatus,
@@ -1394,6 +1396,9 @@ async function main(): Promise<void> {
   if (startupConfig.control?.coDrivenAutoRevertMs !== undefined) {
     sessionConfig.coDrivenAutoRevertMs = startupConfig.control.coDrivenAutoRevertMs;
   }
+  if (securityAuditLog) {
+    sessionConfig.securityAuditSink = securityAuditLog;
+  }
   sessions.configure(sessionConfig);
 
   // Mount hooks router BEFORE auth middleware — hook callbacks come from localhost Claude Code
@@ -2014,7 +2019,10 @@ async function main(): Promise<void> {
   });
 
   app.get('/sessions/:id/interventions', requireScopedSessionAuth, (req, res) => {
-    const decision = capabilityDecisionFromRequest(req, INTERVENTION_READ_CAPABILITY);
+    const decision = capabilitiesDecisionFromRequest(req, [
+      CONTROL_READ_CAPABILITY,
+      INTERVENTION_READ_CAPABILITY,
+    ]);
     if (decision.decision !== 'allow') {
       const error = capabilityError(decision);
       res.status(sessionControlErrorStatus(error)).json({ error });
@@ -2047,7 +2055,10 @@ async function main(): Promise<void> {
   });
 
   app.post('/sessions/:id/control/hand-back', requireScopedSessionAuth, (req, res) => {
-    const decision = capabilityDecisionFromRequest(req, CONTROL_WRITE_CAPABILITY);
+    const decision = capabilitiesDecisionFromRequest(req, [
+      CONTROL_SESSION_CAPABILITY,
+      CONTROL_WRITE_CAPABILITY,
+    ]);
     if (decision.decision !== 'allow') {
       const error = capabilityError(decision);
       res.status(sessionControlErrorStatus(error)).json({ error });

--- a/server/session-control-api.ts
+++ b/server/session-control-api.ts
@@ -6,14 +6,16 @@ import type {
   InterventionRecord,
 } from '../shared/control-state.js';
 
-export const CONTROL_READ_CAPABILITY = 'session:control:read' as const;
-export const INTERVENTION_READ_CAPABILITY = 'session:intervention:read' as const;
-export const CONTROL_WRITE_CAPABILITY = 'session:control:write' as const;
+export const CONTROL_READ_CAPABILITY = 'session:read' as const;
+export const INTERVENTION_READ_CAPABILITY = 'tab:intervention:read' as const;
+export const CONTROL_WRITE_CAPABILITY = 'tab:mode:set-agent' as const;
+export const CONTROL_SESSION_CAPABILITY = 'session:attach' as const;
 
 export type SessionControlCapability =
   | typeof CONTROL_READ_CAPABILITY
   | typeof INTERVENTION_READ_CAPABILITY
-  | typeof CONTROL_WRITE_CAPABILITY;
+  | typeof CONTROL_WRITE_CAPABILITY
+  | typeof CONTROL_SESSION_CAPABILITY;
 
 export interface ControlCapabilityDecision {
   decision: 'allow' | 'deny';
@@ -103,6 +105,20 @@ export function capabilityDecisionFromRequest(
 ): ControlCapabilityDecision {
   const header = req.header('x-relay-capabilities') ?? undefined;
   return evaluateControlCapabilityPlaceholder(header, capability);
+}
+
+export function capabilitiesDecisionFromRequest(
+  req: Request,
+  capabilities: readonly SessionControlCapability[]
+): ControlCapabilityDecision {
+  const header = req.header('x-relay-capabilities') ?? undefined;
+  let firstAllow: ControlCapabilityDecision | undefined;
+  for (const capability of capabilities) {
+    const decision = evaluateControlCapabilityPlaceholder(header, capability);
+    if (decision.decision !== 'allow') return decision;
+    firstAllow ??= decision;
+  }
+  return firstAllow ?? evaluateControlCapabilityPlaceholder(header, CONTROL_READ_CAPABILITY);
 }
 
 export function errorStatus(error: SessionControlError): number {

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -241,7 +241,13 @@ function onControlEvent(cb: ControlEventCallback): void {
 }
 
 function fireControlEvent(event: TabControlEvent): void {
-  for (const cb of [...controlEventCallbacks]) cb(event);
+  for (const cb of [...controlEventCallbacks]) {
+    try {
+      cb(event);
+    } catch (err) {
+      logger.warn('control event listener failed for event %s: %s', event.eventId, err);
+    }
+  }
 }
 
 function auditControlEvent(event: TabControlEvent): void {

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -84,6 +84,10 @@ import {
   validateAgentHandBackAck,
   type SessionControlError,
 } from './session-control-api.js';
+import {
+  securityAuditEntryForTabControlEvent,
+  type SecurityAuditEntryInput,
+} from '../shared/security-audit.js';
 
 const execFileAsync = promisify(execFile);
 const logger = createLogger('sessions');
@@ -164,6 +168,7 @@ let defaultForceOutputParser: boolean | undefined;
 let defaultConfigDir: string | undefined;
 let defaultInterventionDebounceMs: number | undefined;
 let defaultCoDrivenAutoRevertMs: number | undefined;
+let defaultSecurityAuditSink: { append(input: SecurityAuditEntryInput): unknown } | undefined;
 
 function configure(opts: {
   port?: number;
@@ -171,12 +176,14 @@ function configure(opts: {
   configDir?: string;
   interventionDebounceMs?: number;
   coDrivenAutoRevertMs?: number;
+  securityAuditSink?: { append(input: SecurityAuditEntryInput): unknown };
 }): void {
   defaultPort = opts.port;
   defaultForceOutputParser = opts.forceOutputParser;
   defaultConfigDir = opts.configDir;
   defaultInterventionDebounceMs = opts.interventionDebounceMs;
   defaultCoDrivenAutoRevertMs = opts.coDrivenAutoRevertMs;
+  defaultSecurityAuditSink = opts.securityAuditSink;
 }
 
 function withLocalIdentity<T extends SessionSummary>(
@@ -237,6 +244,20 @@ function fireControlEvent(event: TabControlEvent): void {
   for (const cb of [...controlEventCallbacks]) cb(event);
 }
 
+function auditControlEvent(event: TabControlEvent): void {
+  if (!defaultSecurityAuditSink) return;
+  try {
+    defaultSecurityAuditSink.append(securityAuditEntryForTabControlEvent(event));
+  } catch (err) {
+    logger.warn('security audit append failed for control event %s: %s', event.eventId, err);
+  }
+}
+
+function emitAndAuditControlEvent(event: TabControlEvent): void {
+  fireControlEvent(event);
+  auditControlEvent(event);
+}
+
 function controlEngineOptions() {
   return {
     ...(defaultInterventionDebounceMs !== undefined
@@ -245,7 +266,7 @@ function controlEngineOptions() {
     ...(defaultCoDrivenAutoRevertMs !== undefined
       ? { autoRevertMs: defaultCoDrivenAutoRevertMs }
       : {}),
-    emitEvent: fireControlEvent,
+    emitEvent: emitAndAuditControlEvent,
   };
 }
 

--- a/shared/security-audit.ts
+++ b/shared/security-audit.ts
@@ -1,4 +1,5 @@
 import * as crypto from 'node:crypto';
+import type { ControlActor, TabControlEvent } from './control-state.js';
 import {
   HIGH_RISK_CAPABILITIES,
   RELAY_SECURITY_POLICY_VERSION,
@@ -164,6 +165,124 @@ export function stableStringify(value: unknown): string {
 
 export function hashAuditMaterial(value: unknown): string {
   return sha256Hex(stableStringify(redactAuditValue(value)));
+}
+
+export function securityAuditEntryForTabControlEvent(
+  event: TabControlEvent
+): SecurityAuditEntryInput {
+  return {
+    eventId: event.eventId,
+    timestamp: event.occurredAt,
+    eventType: 'bridge_event',
+    decision: 'recorded',
+    reasonCode:
+      event.type === 'tab.mode-changed'
+        ? 'TAB_CONTROL_MODE_CHANGED'
+        : 'TAB_INTERVENTION_RECORDED',
+    peer: auditPeerFromControlActor(event.actor),
+    node: { nodeId: event.identity.nodeId },
+    sessionId: event.identity.sessionId,
+    intent: {
+      action: event.type,
+      target: event.identity.globalSessionId ?? event.identity.sessionId,
+    },
+    material: {
+      scope: controlEventAuditScope(event),
+      params: controlEventAuditParams(event),
+    },
+    requiredBits: controlEventRequiredBits(event),
+    grantedBits: controlEventRequiredBits(event),
+    deniedBits: [],
+    refs: { policyVersion: RELAY_SECURITY_POLICY_VERSION },
+    correlationId: event.eventId,
+  };
+}
+
+function auditPeerFromControlActor(actor: ControlActor): SecurityAuditPeerIdentity {
+  if (actor.kind === 'human') {
+    return {
+      kind: 'user',
+      ...(actor.nodeId ? { nodeId: actor.nodeId } : {}),
+      ...(actor.displayName ? { displayName: actor.displayName } : {}),
+      ...(actor.id ? { principalHash: sha256Hex(actor.id) } : {}),
+    };
+  }
+  if (actor.kind === 'agent' && actor.nodeId) {
+    return {
+      kind: 'node',
+      nodeId: actor.nodeId,
+      ...(actor.displayName ? { displayName: actor.displayName } : {}),
+      ...(actor.id ? { principalHash: sha256Hex(actor.id) } : {}),
+    };
+  }
+  return {
+    kind: 'system',
+    ...(actor.nodeId ? { nodeId: actor.nodeId } : {}),
+    ...(actor.displayName ? { displayName: actor.displayName } : {}),
+    ...(actor.id ? { principalHash: sha256Hex(actor.id) } : {}),
+  };
+}
+
+function controlEventAuditScope(event: TabControlEvent): Record<string, unknown> {
+  return {
+    nodeId: event.identity.nodeId,
+    sessionId: event.identity.sessionId,
+    globalSessionId: event.identity.globalSessionId ?? null,
+    cwd: event.identity.cwd,
+    repoPath: event.identity.repoPath ?? null,
+    worktreePath: event.identity.worktreePath ?? null,
+  };
+}
+
+function controlActorAuditSummary(actor: ControlActor): Record<string, unknown> {
+  return {
+    kind: actor.kind,
+    idHash: actor.id ? sha256Hex(actor.id) : null,
+    displayName: actor.displayName ?? null,
+    nodeId: actor.nodeId ?? null,
+    sessionId: actor.sessionId ?? null,
+  };
+}
+
+function controlEventAuditParams(event: TabControlEvent): Record<string, unknown> {
+  const base = {
+    sourceEventId: event.eventId,
+    kind: event.type,
+    reason: event.reason ?? null,
+    author: controlActorAuditSummary(event.actor),
+  };
+  if (event.type === 'tab.mode-changed') {
+    return {
+      ...base,
+      modeBefore: event.previousControlMode,
+      modeAfter: event.controlMode,
+    };
+  }
+  return {
+    ...base,
+    interventionId: event.intervention.id,
+    interventionKind: event.intervention.kind,
+    interventionSource: event.intervention.source,
+    payload: {
+      hashSha256: event.intervention.redaction.hashSha256,
+      byteCount: event.intervention.redaction.byteCount,
+      charCount: event.intervention.redaction.charCount,
+      lineCount: event.intervention.redaction.lineCount,
+      classes: event.intervention.redaction.classes,
+      redacted: event.intervention.redaction.redacted,
+    },
+    modeBefore: event.intervention.modeBefore,
+    modeAfter: event.intervention.modeAfter ?? event.controlMode,
+    acked: event.intervention.ackedAt !== undefined,
+  };
+}
+
+function controlEventRequiredBits(event: TabControlEvent): RelayCapabilityBit[] {
+  const modeAfter =
+    event.type === 'tab.mode-changed'
+      ? event.controlMode
+      : event.intervention.modeAfter ?? event.controlMode;
+  return modeAfter === 'agent-driven' ? ['tab:mode:set-agent'] : [];
 }
 
 export function redactAuditValue(value: unknown): unknown {

--- a/shared/security-policy.ts
+++ b/shared/security-policy.ts
@@ -7,6 +7,8 @@ export const RELAY_CAPABILITY_BITS = [
   'session:create:terminal',
   'session:create:agent',
   'session:attach',
+  'tab:mode:set-agent',
+  'tab:intervention:read',
   'rpc:fs:list',
   'rpc:fs:read',
   'rpc:fs:tail',

--- a/test/hub-policy-evaluator.test.ts
+++ b/test/hub-policy-evaluator.test.ts
@@ -6,6 +6,7 @@ import {
   policyDecisionToRelayError,
   requiredCapabilitiesForRpcIntent,
   revokePolicyAffectedSessions,
+  sessionCreateCapabilities,
 } from '../server/hub-policy-evaluator.js';
 import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
 import {
@@ -316,6 +317,23 @@ describe('hub policy evaluator', () => {
     expect(requiredCapabilitiesForRpcIntent('rpc.fs.list')).toEqual(['rpc:fs:list']);
     expect(requiredCapabilitiesForRpcIntent('rpc.fs.stat')).toEqual(['rpc:fs:read']);
     expect(requiredCapabilitiesForRpcIntent('rpc.fs.read')).toEqual(['rpc:fs:read']);
+  });
+
+  it('separates tab intervention/control capabilities from file/git/exec powers', () => {
+    expect(requiredCapabilitiesForRpcIntent('sessions.interventions.read')).toEqual([
+      'session:read',
+      'tab:intervention:read',
+    ]);
+    expect(requiredCapabilitiesForRpcIntent('sessions.control.set-agent')).toEqual([
+      'session:attach',
+      'tab:mode:set-agent',
+    ]);
+    expect(
+      sessionCreateCapabilities({ sessionType: 'agent', controlMode: 'agent-driven' })
+    ).toEqual(['session:create:agent', 'tab:mode:set-agent']);
+    expect(
+      sessionCreateCapabilities({ sessionType: 'terminal', controlMode: 'human-driven' })
+    ).toEqual(['session:create:terminal']);
   });
 
   it('denies File RPC when the node ACL lacks the required read-only capability', () => {

--- a/test/security-audit.test.ts
+++ b/test/security-audit.test.ts
@@ -7,6 +7,7 @@ import {
   classifySecurityAuditWriteFailure,
   hashAuditMaterial,
   redactAuditValue,
+  securityAuditEntryForTabControlEvent,
   SECURITY_AUDIT_EVENT_TYPES,
   type SecurityAuditEntryInput,
 } from '../shared/security-audit.js';
@@ -183,6 +184,95 @@ describe('security audit primitives', () => {
     expect(bytes).not.toContain('raw-pair-token');
     expect(bytes).not.toContain('terminal stream');
     expect(bytes).not.toContain('raw-env-secret');
+  });
+
+  it('correlates tab control events without copying raw intervention payloads', () => {
+    const dbPath = tmpDbPath();
+    const log = new SecurityAuditLog(dbPath);
+    const rawTypedInput = 'deploy --token raw-control-secret';
+    const entry = securityAuditEntryForTabControlEvent({
+      eventId: 'intervention-evt-1',
+      type: 'tab.intervention',
+      occurredAt: '2026-05-16T00:00:00.000Z',
+      identity: {
+        nodeId: 'node-a',
+        sessionId: 'session-a',
+        globalSessionId: 'node-a:session-a',
+        cwd: '/repo',
+      },
+      actor: { kind: 'human', id: 'operator-a', displayName: 'operator' },
+      reason: 'human input',
+      controlMode: 'co-driven',
+      intervention: {
+        id: 'intervention-evt-1',
+        sessionId: 'session-a',
+        tabId: 'node-a:session-a',
+        nodeId: 'node-a',
+        globalSessionId: 'node-a:session-a',
+        cwd: '/repo',
+        timestamp: '2026-05-16T00:00:00.000Z',
+        author: { kind: 'human', id: 'operator-a', displayName: 'operator' },
+        source: 'pty-input',
+        kind: 'human-input',
+        payloadPreview: rawTypedInput,
+        redaction: {
+          redacted: true,
+          byteCount: rawTypedInput.length,
+          charCount: rawTypedInput.length,
+          lineCount: 1,
+          hashSha256: 'abc123',
+          classes: ['secret-like'],
+        },
+        modeBefore: 'agent-driven',
+        modeAfter: 'co-driven',
+      },
+    });
+
+    const persisted = log.append(entry);
+    log.close();
+
+    expect(persisted).toMatchObject({
+      eventId: 'intervention-evt-1',
+      eventType: 'bridge_event',
+      decision: 'recorded',
+      reasonCode: 'TAB_INTERVENTION_RECORDED',
+      node: { nodeId: 'node-a' },
+      sessionId: 'session-a',
+      intent: { action: 'tab.intervention', target: 'node-a:session-a' },
+      correlationId: 'intervention-evt-1',
+      requiredBits: [],
+      grantedBits: [],
+    });
+    expect(entry.material.params).toMatchObject({
+      sourceEventId: 'intervention-evt-1',
+      interventionKind: 'human-input',
+      interventionSource: 'pty-input',
+      payload: { hashSha256: 'abc123', classes: ['secret-like'] },
+      modeBefore: 'agent-driven',
+      modeAfter: 'co-driven',
+    });
+    expect(JSON.stringify(entry)).not.toContain(rawTypedInput);
+    expect(fs.readFileSync(dbPath, 'utf8')).not.toContain(rawTypedInput);
+  });
+
+  it('marks agent-driven mode restore audit entries with only the mode-set capability', () => {
+    const entry = securityAuditEntryForTabControlEvent({
+      eventId: 'mode-evt-1',
+      type: 'tab.mode-changed',
+      occurredAt: '2026-05-16T00:00:01.000Z',
+      identity: { nodeId: 'node-a', sessionId: 'session-a', cwd: '/repo' },
+      actor: { kind: 'agent', id: 'worker-1', nodeId: 'node-a' },
+      reason: 'hand-back',
+      previousControlMode: 'co-driven',
+      controlMode: 'agent-driven',
+    });
+
+    expect(entry.requiredBits).toEqual(['tab:mode:set-agent']);
+    expect(entry.grantedBits).toEqual(['tab:mode:set-agent']);
+    expect(entry.deniedBits).toEqual([]);
+    expect(entry.requiredBits).not.toEqual(
+      expect.arrayContaining(['rpc:fs:write', 'rpc:git:write', 'pty:exec:arbitrary'])
+    );
   });
 
   it('verifies a clean append-only chain', () => {

--- a/test/session-control-api.test.ts
+++ b/test/session-control-api.test.ts
@@ -96,15 +96,23 @@ describe('session control API helpers', () => {
 
   it('surfaces the #427 capability placeholder and rejects explicit missing capabilities', () => {
     expect(
-      evaluateControlCapabilityPlaceholder(undefined, 'session:intervention:read')
-    ).toMatchObject({ decision: 'allow', placeholder: true, capability: 'session:intervention:read' });
+      evaluateControlCapabilityPlaceholder(undefined, 'tab:intervention:read')
+    ).toMatchObject({ decision: 'allow', placeholder: true, capability: 'tab:intervention:read' });
 
     expect(
-      evaluateControlCapabilityPlaceholder('session:read,session:attach', 'session:intervention:read')
+      evaluateControlCapabilityPlaceholder('session:read,session:attach', 'tab:intervention:read')
     ).toMatchObject({
       decision: 'deny',
       reasonCode: 'CAPABILITY_REQUIRED',
-      capability: 'session:intervention:read',
+      capability: 'tab:intervention:read',
+    });
+
+    expect(
+      evaluateControlCapabilityPlaceholder('session:read,tab:intervention:read', 'tab:mode:set-agent')
+    ).toMatchObject({
+      decision: 'deny',
+      reasonCode: 'CAPABILITY_REQUIRED',
+      capability: 'tab:mode:set-agent',
     });
   });
 

--- a/test/ws-pty-intervention.test.ts
+++ b/test/ws-pty-intervention.test.ts
@@ -12,6 +12,7 @@ import * as sessions from '../server/sessions.js';
 import { closeInterventionLog, initInterventionLog } from '../server/intervention-log.js';
 import { setupWebSocket } from '../server/ws.js';
 import type { PtySession } from '../server/types.js';
+import type { SecurityAuditEntryInput } from '../shared/security-audit.js';
 
 const execFileAsync = promisify(execFile);
 const cleanupFns: Array<() => void | Promise<void>> = [];
@@ -191,5 +192,43 @@ describe('PTY WebSocket intervention control', () => {
       sessionId: 'remote-session-a',
       globalSessionId: 'remote-node-a:remote-session-a',
     });
+  });
+
+  it('still appends control audit entries when a control-event listener throws', async () => {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ide-audit-isolation-'));
+    cleanupFns.push(() => fs.rmSync(configDir, { recursive: true, force: true }));
+    initInterventionLog(configDir);
+    const auditEntries: SecurityAuditEntryInput[] = [];
+    sessions.configure({
+      configDir,
+      interventionDebounceMs: 5,
+      securityAuditSink: { append: (entry) => auditEntries.push(entry) },
+    });
+    const deliveredEvents: Array<Parameters<Parameters<typeof sessions.onControlEvent>[0]>[0]> = [];
+    sessions.onControlEvent(() => {
+      throw new Error('listener boom');
+    });
+    sessions.onControlEvent((event) => deliveredEvents.push(event));
+    expect(() =>
+      sessions.recordRoutedPtyInput({
+        nodeId: 'remote-node-a',
+        sessionId: 'remote-session-a-throw',
+        data: 'echo audited\\n',
+      })
+    ).not.toThrow();
+    await waitForInterventionCount('remote-session-a-throw', 1);
+    expect(deliveredEvents.map((event) => event.type)).toEqual([
+      'tab.mode-changed',
+      'tab.intervention',
+    ]);
+    expect(auditEntries).toHaveLength(2);
+    expect(auditEntries.map((entry) => entry.intent.action)).toEqual([
+      'tab.mode-changed',
+      'tab.intervention',
+    ]);
+    expect(auditEntries.map((entry) => entry.eventType)).toEqual([
+      'bridge_event',
+      'bridge_event',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- correlate #470 `tab.mode-changed` / `tab.intervention` events into #427 security audit entries
- add scoped capabilities for `tab:mode:set-agent` and `tab:intervention:read`, including routed session creation/control checks
- document the #470 semantics / #427 policy boundary and add regression coverage for sanitized audit payloads

## The Case Against
- This deliberately uses the existing `bridge_event` audit type rather than introducing a new event type; if reviewers want a more specific audit taxonomy, this should be split before merge.
- The local session API still uses the placeholder `x-relay-capabilities` compatibility contract until #427’s full policy evaluator is applied everywhere. This change tightens explicit headers but preserves omitted-header compatibility.
- Control-event audit write failures are logged and do not block control-mode changes. That keeps current session behavior stable, but means fail-closed semantics for control-event audit persistence remain a later full-policy decision.

## Verification
- `npm test -- test/security-audit.test.ts test/session-control-api.test.ts test/hub-policy-evaluator.test.ts`
- `npm run check` (passes; existing warnings only)
- `npm run build`
- `npm test` (2218/2219 passed; `test/local-logs.test.ts` timed out once in full parallel run, then `npm test -- test/local-logs.test.ts` passed 8/8 on rerun)

Closes #499
Refs #427 #470


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security documentation for session control event emission and authorization boundary definitions.

* **New Features**
  * Added security audit logging for tab control events with correlation tracking.

* **Bug Fixes**
  * Refined authorization requirements for session creation and control operations.

* **Tests**
  * Added test coverage for security audit entries and capability validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->