### PR TITLE
feat: add hub confirmation challenge flow

### DIFF
--- a/server/confirmation-challenges.ts
+++ b/server/confirmation-challenges.ts
@@ -154,6 +154,15 @@ export interface ConfirmationChallengeStore {
   listChallenges(): ConfirmationChallengePublicView[];
 }
 
+export class ConfirmationChallengeCapacityError extends Error {
+  readonly code = 'CONFIRMATION_CAPACITY_EXHAUSTED';
+
+  constructor(readonly maxChallenges: number) {
+    super('confirmation challenge capacity exhausted');
+    this.name = 'ConfirmationChallengeCapacityError';
+  }
+}
+
 export function createConfirmationChallengeStore(
   options: ConfirmationChallengeStoreOptions = {}
 ): ConfirmationChallengeStore {
@@ -192,9 +201,16 @@ export function createConfirmationChallengeStore(
     }
     while (challenges.size > maxChallenges) {
       const terminal = Array.from(challenges.values()).find((challenge) => isTerminal(challenge.status));
-      const oldest = terminal ?? challenges.values().next().value;
-      if (!oldest) break;
-      challenges.delete(oldest.challengeId);
+      if (!terminal) break;
+      challenges.delete(terminal.challengeId);
+    }
+  }
+
+  function ensureCapacityForNewChallenge(): void {
+    while (challenges.size >= maxChallenges) {
+      const terminal = Array.from(challenges.values()).find((challenge) => isTerminal(challenge.status));
+      if (!terminal) throw new ConfirmationChallengeCapacityError(maxChallenges);
+      challenges.delete(terminal.challengeId);
     }
   }
 
@@ -208,6 +224,7 @@ export function createConfirmationChallengeStore(
   ): ConfirmationChallenge {
     const createdAt = now();
     pruneStoredChallenges(createdAt);
+    ensureCapacityForNewChallenge();
     const challenge: ConfirmationChallenge = {
       challengeId: randomId(),
       status: 'pending',
@@ -492,6 +509,7 @@ function expireIfNeeded(
   now: Date,
   includeToken = false
 ): ConfirmationFailure | null {
+  if (isTerminalChallengeStatus(challenge.status)) return null;
   const challengeExpired = Date.parse(challenge.expiresAt) <= now.getTime();
   const tokenExpired =
     includeToken && challenge.tokenExpiresAt
@@ -539,7 +557,7 @@ function auditForChallenge(
     eventType: input.eventType,
     decision: input.decision,
     reasonCode: input.reasonCode,
-    peer: { kind: 'user', principalHash: challenge.requesterAuthSessionHash },
+    peer: auditPeerForChallenge(challenge, input.eventType),
     node: {
       nodeId: challenge.nodeId,
       ...(policy.trustTier ? { trustTier: policy.trustTier } : {}),
@@ -559,6 +577,30 @@ function auditForChallenge(
     },
     ...(policy.correlationId ? { correlationId: policy.correlationId } : {}),
   };
+}
+
+function auditPeerForChallenge(
+  challenge: ConfirmationChallenge,
+  eventType: SecurityAuditEntryInput['eventType']
+): SecurityAuditEntryInput['peer'] {
+  const useApprover =
+    (eventType === 'approval' || eventType === 'denial' || eventType === 'revocation') &&
+    Boolean(challenge.approverAuthSessionHash);
+  const principalHash = useApprover
+    ? challenge.approverAuthSessionHash!
+    : challenge.requesterAuthSessionHash;
+  const displayName = useApprover
+    ? challenge.approverDisplayName
+    : challenge.requesterDisplayName;
+  return {
+    kind: 'user',
+    principalHash,
+    ...(displayName ? { displayName } : {}),
+  };
+}
+
+function isTerminalChallengeStatus(status: ConfirmationChallengeStatus): boolean {
+  return status !== 'pending' && status !== 'approved';
 }
 
 function hashCanonicalParams(value: CanonicalConfirmationParams): string {

--- a/server/confirmation-challenges.ts
+++ b/server/confirmation-challenges.ts
@@ -6,6 +6,7 @@ import type { HubPolicyDecision } from './hub-policy-evaluator.js';
 export const DEFAULT_CONFIRMATION_CHALLENGE_TTL_MS = 5 * 60 * 1000;
 export const DEFAULT_CONFIRMATION_TOKEN_TTL_MS = 60 * 1000;
 export const DEFAULT_CONFIRMATION_MAX_FAILED_REDEMPTIONS = 3;
+export const DEFAULT_CONFIRMATION_MAX_CHALLENGES = 1000;
 
 export type ConfirmationDecision = 'approve' | 'deny' | 'deny_revoke';
 export type ConfirmationChallengeStatus =
@@ -123,6 +124,7 @@ export interface ConfirmationChallengeStoreOptions {
   challengeTtlMs?: number;
   tokenTtlMs?: number;
   maxFailedRedemptions?: number;
+  maxChallenges?: number;
 }
 
 export interface ConfirmationChallengeStore {
@@ -160,9 +162,41 @@ export function createConfirmationChallengeStore(
   const tokenTtlMs = options.tokenTtlMs ?? DEFAULT_CONFIRMATION_TOKEN_TTL_MS;
   const maxFailedRedemptions =
     options.maxFailedRedemptions ?? DEFAULT_CONFIRMATION_MAX_FAILED_REDEMPTIONS;
+  const maxChallenges = Math.max(1, options.maxChallenges ?? DEFAULT_CONFIRMATION_MAX_CHALLENGES);
   const now = options.now ?? (() => new Date());
   const randomId = options.randomId ?? randomChallengeId;
   const randomToken = options.randomToken ?? randomConfirmationToken;
+
+  function terminalRetentionMs(): number {
+    return Math.max(challengeTtlMs, tokenTtlMs, 1);
+  }
+
+  function isTerminal(status: ConfirmationChallengeStatus): boolean {
+    return status !== 'pending' && status !== 'approved';
+  }
+
+  function pruneExpired(current: Date): void {
+    for (const challenge of Array.from(challenges.values())) expireIfNeeded(challenge, current, true);
+  }
+
+  function pruneStoredChallenges(current: Date): void {
+    pruneExpired(current);
+    const cutoff = current.getTime() - terminalRetentionMs();
+    for (const [challengeId, challenge] of Array.from(challenges.entries())) {
+      const finishedAt = Date.parse(
+        challenge.redeemedAt ?? challenge.approvedAt ?? challenge.expiresAt
+      );
+      if (isTerminal(challenge.status) && Number.isFinite(finishedAt) && finishedAt < cutoff) {
+        challenges.delete(challengeId);
+      }
+    }
+    while (challenges.size > maxChallenges) {
+      const terminal = Array.from(challenges.values()).find((challenge) => isTerminal(challenge.status));
+      const oldest = terminal ?? challenges.values().next().value;
+      if (!oldest) break;
+      challenges.delete(oldest.challengeId);
+    }
+  }
 
   function createChallenge(
     decision: HubPolicyDecision,
@@ -173,6 +207,7 @@ export function createConfirmationChallengeStore(
     }
   ): ConfirmationChallenge {
     const createdAt = now();
+    pruneStoredChallenges(createdAt);
     const challenge: ConfirmationChallenge = {
       challengeId: randomId(),
       status: 'pending',
@@ -320,8 +355,14 @@ export function createConfirmationChallengeStore(
     createChallenge,
     approveChallenge,
     redeemToken,
-    getChallenge: (challengeId) => challenges.get(challengeId),
-    listChallenges: () => Array.from(challenges.values()).map(publicChallenge),
+    getChallenge: (challengeId) => {
+      pruneStoredChallenges(now());
+      return challenges.get(challengeId);
+    },
+    listChallenges: () => {
+      pruneStoredChallenges(now());
+      return Array.from(challenges.values()).map(publicChallenge);
+    },
   };
 }
 

--- a/server/confirmation-challenges.ts
+++ b/server/confirmation-challenges.ts
@@ -408,7 +408,7 @@ export function canonicalConfirmationParams(
     case 'sessions.kill':
     case 'sessions.create.agent':
     case 'sessions.create.terminal':
-      return canonicalGenericParams(action, record, [
+      return canonicalSessionParams(action, record, [
         'type',
         'cwd',
         'repoPath',
@@ -611,6 +611,21 @@ function canonicalGenericParams(
     if (value !== undefined) result[key] = value;
   }
   return result;
+}
+
+function canonicalSessionParams(
+  action: string,
+  record: Record<string, unknown> | undefined,
+  keys: string[]
+): CanonicalConfirmationParams {
+  return {
+    ...canonicalGenericParams(action, record, keys),
+    // Keep the operator-readable fields above, but bind the approval token to
+    // the full routed session payload so omitted security-relevant fields (for
+    // example command/customCommand/initialPrompt/controlMode/useTmux) cannot be
+    // changed between approval and redemption.
+    paramsHash: sha256Hex(stableStringify(record ?? null)),
+  };
 }
 
 function stripUndefined(input: Record<string, unknown>): CanonicalConfirmationParams {

--- a/server/confirmation-challenges.ts
+++ b/server/confirmation-challenges.ts
@@ -1,0 +1,582 @@
+import * as crypto from 'node:crypto';
+import { sha256Hex, stableStringify, type SecurityAuditEntryInput } from '../shared/security-audit.js';
+import type { RelayCapabilityBit } from '../shared/security-policy.js';
+import type { HubPolicyDecision } from './hub-policy-evaluator.js';
+
+export const DEFAULT_CONFIRMATION_CHALLENGE_TTL_MS = 5 * 60 * 1000;
+export const DEFAULT_CONFIRMATION_TOKEN_TTL_MS = 60 * 1000;
+export const DEFAULT_CONFIRMATION_MAX_FAILED_REDEMPTIONS = 3;
+
+export type ConfirmationDecision = 'approve' | 'deny' | 'deny_revoke';
+export type ConfirmationChallengeStatus =
+  | 'pending'
+  | 'approved'
+  | 'denied'
+  | 'revoked'
+  | 'expired'
+  | 'redeemed'
+  | 'invalidated';
+
+export type ConfirmationReasonCode =
+  | 'CONFIRMATION_REQUIRED'
+  | 'CONFIRMATION_APPROVED'
+  | 'CONFIRMATION_DENIED'
+  | 'CONFIRMATION_DENIED_REVOKE'
+  | 'CONFIRMATION_EXPIRED'
+  | 'CONFIRMATION_ALREADY_USED'
+  | 'CONFIRMATION_SAME_SESSION'
+  | 'CONFIRMATION_PARAM_MISMATCH'
+  | 'CONFIRMATION_NOT_FOUND'
+  | 'CONFIRMATION_NOT_APPROVED'
+  | 'CONFIRMATION_TOKEN_INVALID'
+  | 'CONFIRMATION_REQUESTER_MISMATCH'
+  | 'CONFIRMATION_CONTEXT_MISMATCH';
+
+export interface CanonicalConfirmationParams {
+  action: string;
+  [key: string]: unknown;
+}
+
+export interface ConfirmationChallenge {
+  challengeId: string;
+  status: ConfirmationChallengeStatus;
+  requesterAuthSessionHash: string;
+  requesterDisplayName?: string;
+  approverAuthSessionHash?: string;
+  approverDisplayName?: string;
+  nodeId: string;
+  intent: HubPolicyDecision['intent'];
+  requiredBits: RelayCapabilityBit[];
+  challengeBits: RelayCapabilityBit[];
+  sessionId?: string;
+  canonicalParams: CanonicalConfirmationParams;
+  canonicalParamsHash: string;
+  scopeHash: string;
+  decision: HubPolicyDecision;
+  createdAt: string;
+  expiresAt: string;
+  approvedAt?: string;
+  tokenExpiresAt?: string;
+  tokenHash?: string;
+  redeemedAt?: string;
+  failedRedemptions: number;
+  maxFailedRedemptions: number;
+  reasonCode: ConfirmationReasonCode;
+  message: string;
+}
+
+export interface ConfirmationChallengePublicView {
+  challengeId: string;
+  status: ConfirmationChallengeStatus;
+  nodeId: string;
+  intent: HubPolicyDecision['intent'];
+  requiredBits: RelayCapabilityBit[];
+  challengeBits: RelayCapabilityBit[];
+  sessionId?: string;
+  canonicalParams: CanonicalConfirmationParams;
+  canonicalParamsHash: string;
+  requesterDisplayName?: string;
+  approverDisplayName?: string;
+  createdAt: string;
+  expiresAt: string;
+  approvedAt?: string;
+  tokenExpiresAt?: string;
+  failedRedemptions: number;
+  maxFailedRedemptions: number;
+  reasonCode: ConfirmationReasonCode;
+  message: string;
+}
+
+export type ConfirmationFailure = {
+  ok: false;
+  reasonCode: ConfirmationReasonCode;
+  message: string;
+  challenge?: ConfirmationChallenge;
+  audit?: SecurityAuditEntryInput;
+};
+
+export type ConfirmationApprovalResult =
+  | {
+      ok: true;
+      reasonCode: 'CONFIRMATION_APPROVED';
+      message: string;
+      challenge: ConfirmationChallenge;
+      confirmationToken: string;
+      audit: SecurityAuditEntryInput;
+    }
+  | ConfirmationFailure;
+
+export type ConfirmationRedemptionResult =
+  | {
+      ok: true;
+      reasonCode: 'CONFIRMATION_APPROVED';
+      message: string;
+      challenge: ConfirmationChallenge;
+      audit: SecurityAuditEntryInput;
+    }
+  | ConfirmationFailure;
+
+export interface ConfirmationChallengeStoreOptions {
+  now?: () => Date;
+  randomId?: () => string;
+  randomToken?: () => string;
+  challengeTtlMs?: number;
+  tokenTtlMs?: number;
+  maxFailedRedemptions?: number;
+}
+
+export interface ConfirmationChallengeStore {
+  createChallenge(
+    decision: HubPolicyDecision,
+    input: {
+      requesterAuthSessionHash: string;
+      requesterDisplayName?: string;
+      canonicalParams: CanonicalConfirmationParams;
+    }
+  ): ConfirmationChallenge;
+  approveChallenge(input: {
+    challengeId: string;
+    approverAuthSessionHash: string;
+    approverDisplayName?: string;
+    decision: ConfirmationDecision;
+    now?: Date;
+  }): ConfirmationApprovalResult;
+  redeemToken(input: {
+    token: string;
+    requesterAuthSessionHash: string;
+    decision: HubPolicyDecision;
+    canonicalParams: CanonicalConfirmationParams;
+    now?: Date;
+  }): ConfirmationRedemptionResult;
+  getChallenge(challengeId: string): ConfirmationChallenge | undefined;
+  listChallenges(): ConfirmationChallengePublicView[];
+}
+
+export function createConfirmationChallengeStore(
+  options: ConfirmationChallengeStoreOptions = {}
+): ConfirmationChallengeStore {
+  const challenges = new Map<string, ConfirmationChallenge>();
+  const challengeTtlMs = options.challengeTtlMs ?? DEFAULT_CONFIRMATION_CHALLENGE_TTL_MS;
+  const tokenTtlMs = options.tokenTtlMs ?? DEFAULT_CONFIRMATION_TOKEN_TTL_MS;
+  const maxFailedRedemptions =
+    options.maxFailedRedemptions ?? DEFAULT_CONFIRMATION_MAX_FAILED_REDEMPTIONS;
+  const now = options.now ?? (() => new Date());
+  const randomId = options.randomId ?? randomChallengeId;
+  const randomToken = options.randomToken ?? randomConfirmationToken;
+
+  function createChallenge(
+    decision: HubPolicyDecision,
+    input: {
+      requesterAuthSessionHash: string;
+      requesterDisplayName?: string;
+      canonicalParams: CanonicalConfirmationParams;
+    }
+  ): ConfirmationChallenge {
+    const createdAt = now();
+    const challenge: ConfirmationChallenge = {
+      challengeId: randomId(),
+      status: 'pending',
+      requesterAuthSessionHash: input.requesterAuthSessionHash,
+      ...(input.requesterDisplayName ? { requesterDisplayName: input.requesterDisplayName } : {}),
+      nodeId: decision.nodeId,
+      intent: decision.intent,
+      requiredBits: [...decision.requiredBits],
+      challengeBits: [...decision.challengeBits],
+      ...(decision.sessionId ? { sessionId: decision.sessionId } : {}),
+      canonicalParams: input.canonicalParams,
+      canonicalParamsHash: hashCanonicalParams(input.canonicalParams),
+      scopeHash: sha256Hex(stableStringify(decision.scope)),
+      decision,
+      createdAt: createdAt.toISOString(),
+      expiresAt: new Date(createdAt.getTime() + challengeTtlMs).toISOString(),
+      failedRedemptions: 0,
+      maxFailedRedemptions,
+      reasonCode: 'CONFIRMATION_REQUIRED',
+      message: 'confirmation required before Relay routes this operation to the node',
+    };
+    challenges.set(challenge.challengeId, challenge);
+    return challenge;
+  }
+
+  function approveChallenge(input: {
+    challengeId: string;
+    approverAuthSessionHash: string;
+    approverDisplayName?: string;
+    decision: ConfirmationDecision;
+    now?: Date;
+  }): ConfirmationApprovalResult {
+    const current = input.now ?? now();
+    const challenge = challenges.get(input.challengeId);
+    if (!challenge) return failure('CONFIRMATION_NOT_FOUND', 'confirmation challenge not found');
+    const expiryFailure = expireIfNeeded(challenge, current);
+    if (expiryFailure) return expiryFailure;
+    if (challenge.status !== 'pending') {
+      return failure('CONFIRMATION_NOT_APPROVED', `confirmation challenge is ${challenge.status}`, challenge);
+    }
+    if (challenge.requesterAuthSessionHash === input.approverAuthSessionHash) {
+      return failChallenge(challenge, 'CONFIRMATION_SAME_SESSION', 'the requesting browser/auth session cannot approve its own challenge', 'same_session_approval_attempt', 'deny');
+    }
+    if (input.decision === 'deny' || input.decision === 'deny_revoke') {
+      const reasonCode = input.decision === 'deny' ? 'CONFIRMATION_DENIED' : 'CONFIRMATION_DENIED_REVOKE';
+      challenge.status = input.decision === 'deny' ? 'denied' : 'revoked';
+      challenge.reasonCode = reasonCode;
+      challenge.message = input.decision === 'deny'
+        ? 'confirmation challenge was denied by a distinct authenticated session'
+        : 'confirmation challenge was denied and the grant should be revoked';
+      challenge.approverAuthSessionHash = input.approverAuthSessionHash;
+      if (input.approverDisplayName) challenge.approverDisplayName = input.approverDisplayName;
+      challenge.approvedAt = current.toISOString();
+      return failure(reasonCode, challenge.message, challenge, auditForChallenge(challenge, {
+        eventType: input.decision === 'deny' ? 'denial' : 'revocation',
+        decision: input.decision === 'deny' ? 'deny' : 'revoked',
+        reasonCode,
+      }));
+    }
+    const token = randomToken();
+    challenge.status = 'approved';
+    challenge.reasonCode = 'CONFIRMATION_APPROVED';
+    challenge.message = 'confirmation challenge approved by a distinct authenticated session';
+    challenge.approverAuthSessionHash = input.approverAuthSessionHash;
+    if (input.approverDisplayName) challenge.approverDisplayName = input.approverDisplayName;
+    challenge.approvedAt = current.toISOString();
+    challenge.tokenExpiresAt = new Date(current.getTime() + tokenTtlMs).toISOString();
+    challenge.tokenHash = hashToken(token);
+    return {
+      ok: true,
+      reasonCode: 'CONFIRMATION_APPROVED',
+      message: challenge.message,
+      challenge,
+      confirmationToken: token,
+      audit: auditForChallenge(challenge, {
+        eventType: 'approval',
+        decision: 'approved',
+        reasonCode: 'CONFIRMATION_APPROVED',
+      }),
+    };
+  }
+
+  function redeemToken(input: {
+    token: string;
+    requesterAuthSessionHash: string;
+    decision: HubPolicyDecision;
+    canonicalParams: CanonicalConfirmationParams;
+    now?: Date;
+  }): ConfirmationRedemptionResult {
+    const current = input.now ?? now();
+    const tokenHash = hashToken(input.token);
+    const challenge = Array.from(challenges.values()).find(
+      (candidate) => candidate.tokenHash === tokenHash
+    );
+    if (!challenge) return failure('CONFIRMATION_TOKEN_INVALID', 'confirmation token is invalid');
+    const expiryFailure = expireIfNeeded(challenge, current, true);
+    if (expiryFailure) return expiryFailure;
+    if (challenge.status === 'redeemed') {
+      return failure('CONFIRMATION_ALREADY_USED', 'confirmation token was already used', challenge);
+    }
+    if (challenge.status !== 'approved') {
+      return failure('CONFIRMATION_NOT_APPROVED', `confirmation challenge is ${challenge.status}`, challenge);
+    }
+    if (challenge.requesterAuthSessionHash !== input.requesterAuthSessionHash) {
+      return failChallenge(challenge, 'CONFIRMATION_REQUESTER_MISMATCH', 'confirmation token can only be redeemed by the original requesting auth session', 'failed_redemption', 'failed');
+    }
+    if (challenge.approverAuthSessionHash === input.requesterAuthSessionHash) {
+      return failChallenge(challenge, 'CONFIRMATION_SAME_SESSION', 'the approving browser/auth session cannot redeem its own approval', 'same_session_approval_attempt', 'deny');
+    }
+    if (!challengeContextMatches(challenge, input.decision)) {
+      return failChallenge(challenge, 'CONFIRMATION_CONTEXT_MISMATCH', 'confirmation token does not match this node, intent, capability set, or session', 'failed_redemption', 'failed');
+    }
+    if (challenge.canonicalParamsHash !== hashCanonicalParams(input.canonicalParams)) {
+      challenge.failedRedemptions += 1;
+      if (challenge.failedRedemptions >= challenge.maxFailedRedemptions) {
+        challenge.status = 'invalidated';
+        challenge.reasonCode = 'CONFIRMATION_PARAM_MISMATCH';
+        challenge.message = 'confirmation token invalidated after too many parameter mismatches';
+      }
+      return failure('CONFIRMATION_PARAM_MISMATCH', 'confirmation token parameters do not match the original challenge', challenge, auditForChallenge(challenge, {
+        eventType: 'failed_redemption',
+        decision: 'failed',
+        reasonCode: 'CONFIRMATION_PARAM_MISMATCH',
+        params: input.canonicalParams,
+      }));
+    }
+    challenge.status = 'redeemed';
+    challenge.redeemedAt = current.toISOString();
+    challenge.reasonCode = 'CONFIRMATION_APPROVED';
+    challenge.message = 'confirmation token redeemed';
+    return {
+      ok: true,
+      reasonCode: 'CONFIRMATION_APPROVED',
+      message: challenge.message,
+      challenge,
+      audit: auditForChallenge(challenge, {
+        eventType: 'grant',
+        decision: 'allow',
+        reasonCode: 'CONFIRMATION_APPROVED',
+      }),
+    };
+  }
+
+  return {
+    createChallenge,
+    approveChallenge,
+    redeemToken,
+    getChallenge: (challengeId) => challenges.get(challengeId),
+    listChallenges: () => Array.from(challenges.values()).map(publicChallenge),
+  };
+}
+
+export function canonicalConfirmationParams(
+  action: string,
+  params: unknown
+): CanonicalConfirmationParams {
+  const record = asRecord(params);
+  switch (action) {
+    case 'pty.exec.arbitrary':
+      return stripUndefined({
+        action,
+        command: stringField(record, 'command'),
+        cwd: stringField(record, 'cwd'),
+        envHash: hashOptional(record?.['env']),
+      });
+    case 'rpc.fs.write': {
+      const bytes = bytesFromFileWrite(record);
+      return stripUndefined({
+        action,
+        cwd: stringField(record, 'cwd'),
+        path: stringField(record, 'path'),
+        size: bytes.length,
+        sha256: crypto.createHash('sha256').update(bytes).digest('hex'),
+      });
+    }
+    case 'rpc.fs.delete':
+      return stripUndefined({
+        action,
+        cwd: stringField(record, 'cwd'),
+        path: stringField(record, 'path'),
+        recursive: Boolean(record?.['recursive']),
+      });
+    case 'rpc.git.write':
+      return stripUndefined({
+        action,
+        cwd: stringField(record, 'cwd'),
+        verb: stringField(record, 'verb') ?? stringField(record, 'gitVerb'),
+        refSpec: stringField(record, 'refSpec'),
+        remote: stringField(record, 'remote'),
+      });
+    case 'sessions.create':
+    case 'sessions.kill':
+    case 'sessions.create.agent':
+    case 'sessions.create.terminal':
+      return canonicalGenericParams(action, record, [
+        'type',
+        'cwd',
+        'repoPath',
+        'worktreePath',
+        'sessionId',
+        'method',
+      ]);
+    default:
+      if (action.startsWith('rpc.fs.')) {
+        return canonicalGenericParams(action, record, [
+          'cwd',
+          'path',
+          'root',
+          'maxBytes',
+          'maxLines',
+          'maxEntries',
+          'recursive',
+        ]);
+      }
+      return { action, paramsHash: sha256Hex(stableStringify(params ?? null)) };
+  }
+}
+
+export function hashAuthSessionIdentity(value: string): string {
+  return sha256Hex(`relay-auth-session:${value}`);
+}
+
+export function publicChallenge(
+  challenge: ConfirmationChallenge
+): ConfirmationChallengePublicView {
+  return {
+    challengeId: challenge.challengeId,
+    status: challenge.status,
+    nodeId: challenge.nodeId,
+    intent: challenge.intent,
+    requiredBits: challenge.requiredBits,
+    challengeBits: challenge.challengeBits,
+    ...(challenge.sessionId ? { sessionId: challenge.sessionId } : {}),
+    canonicalParams: challenge.canonicalParams,
+    canonicalParamsHash: challenge.canonicalParamsHash,
+    ...(challenge.requesterDisplayName ? { requesterDisplayName: challenge.requesterDisplayName } : {}),
+    ...(challenge.approverDisplayName ? { approverDisplayName: challenge.approverDisplayName } : {}),
+    createdAt: challenge.createdAt,
+    expiresAt: challenge.expiresAt,
+    ...(challenge.approvedAt ? { approvedAt: challenge.approvedAt } : {}),
+    ...(challenge.tokenExpiresAt ? { tokenExpiresAt: challenge.tokenExpiresAt } : {}),
+    failedRedemptions: challenge.failedRedemptions,
+    maxFailedRedemptions: challenge.maxFailedRedemptions,
+    reasonCode: challenge.reasonCode,
+    message: challenge.message,
+  };
+}
+
+function failChallenge(
+  challenge: ConfirmationChallenge,
+  reasonCode: ConfirmationReasonCode,
+  message: string,
+  eventType: SecurityAuditEntryInput['eventType'],
+  decision: SecurityAuditEntryInput['decision']
+): ConfirmationFailure {
+  challenge.reasonCode = reasonCode;
+  challenge.message = message;
+  return failure(reasonCode, message, challenge, auditForChallenge(challenge, {
+    eventType,
+    decision,
+    reasonCode,
+  }));
+}
+
+function failure(
+  reasonCode: ConfirmationReasonCode,
+  message: string,
+  challenge?: ConfirmationChallenge,
+  audit?: SecurityAuditEntryInput
+): ConfirmationFailure {
+  return { ok: false, reasonCode, message, ...(challenge ? { challenge } : {}), ...(audit ? { audit } : {}) };
+}
+
+function expireIfNeeded(
+  challenge: ConfirmationChallenge,
+  now: Date,
+  includeToken = false
+): ConfirmationFailure | null {
+  const challengeExpired = Date.parse(challenge.expiresAt) <= now.getTime();
+  const tokenExpired =
+    includeToken && challenge.tokenExpiresAt
+      ? Date.parse(challenge.tokenExpiresAt) <= now.getTime()
+      : false;
+  if (!challengeExpired && !tokenExpired) return null;
+  challenge.status = 'expired';
+  challenge.reasonCode = 'CONFIRMATION_EXPIRED';
+  challenge.message = tokenExpired
+    ? 'confirmation token expired'
+    : 'confirmation challenge expired';
+  return failure('CONFIRMATION_EXPIRED', challenge.message, challenge, auditForChallenge(challenge, {
+    eventType: 'expiry',
+    decision: 'expired',
+    reasonCode: 'CONFIRMATION_EXPIRED',
+  }));
+}
+
+function challengeContextMatches(
+  challenge: ConfirmationChallenge,
+  decision: HubPolicyDecision
+): boolean {
+  return (
+    challenge.nodeId === decision.nodeId &&
+    challenge.intent.action === decision.intent.action &&
+    (challenge.intent.target ?? null) === (decision.intent.target ?? null) &&
+    (challenge.sessionId ?? null) === (decision.sessionId ?? null) &&
+    stableStringify(challenge.requiredBits) === stableStringify(decision.requiredBits) &&
+    stableStringify(challenge.challengeBits) === stableStringify(decision.challengeBits) &&
+    challenge.scopeHash === sha256Hex(stableStringify(decision.scope))
+  );
+}
+
+function auditForChallenge(
+  challenge: ConfirmationChallenge,
+  input: {
+    eventType: SecurityAuditEntryInput['eventType'];
+    decision: SecurityAuditEntryInput['decision'];
+    reasonCode: string;
+    params?: unknown;
+  }
+): SecurityAuditEntryInput {
+  const policy = challenge.decision;
+  return {
+    eventType: input.eventType,
+    decision: input.decision,
+    reasonCode: input.reasonCode,
+    peer: { kind: 'user', principalHash: challenge.requesterAuthSessionHash },
+    node: {
+      nodeId: challenge.nodeId,
+      ...(policy.trustTier ? { trustTier: policy.trustTier } : {}),
+    },
+    ...(challenge.sessionId ? { sessionId: challenge.sessionId } : {}),
+    intent: challenge.intent,
+    material: {
+      scope: policy.scope,
+      params: input.params ?? challenge.canonicalParams,
+    },
+    requiredBits: challenge.requiredBits,
+    grantedBits: input.decision === 'allow' || input.decision === 'approved' ? challenge.requiredBits : [],
+    deniedBits: input.decision === 'deny' || input.decision === 'failed' ? challenge.requiredBits : [],
+    refs: {
+      ...(policy.aclRef ? { aclRef: policy.aclRef } : {}),
+      ...(policy.policyVersion ? { policyVersion: policy.policyVersion } : {}),
+    },
+    ...(policy.correlationId ? { correlationId: policy.correlationId } : {}),
+  };
+}
+
+function hashCanonicalParams(value: CanonicalConfirmationParams): string {
+  return sha256Hex(stableStringify(value));
+}
+
+function hashToken(token: string): string {
+  return sha256Hex(`relay-confirmation-token:${token}`);
+}
+
+function randomChallengeId(): string {
+  return `confirm_${crypto.randomBytes(16).toString('hex')}`;
+}
+
+function randomConfirmationToken(): string {
+  return `relay-confirm.${crypto.randomBytes(32).toString('base64url')}`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringField(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = record?.[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function hashOptional(value: unknown): string | undefined {
+  return value === undefined ? undefined : sha256Hex(stableStringify(value));
+}
+
+function bytesFromFileWrite(record: Record<string, unknown> | undefined): Buffer {
+  const content = record?.['content'] ?? record?.['bytes'] ?? record?.['data'];
+  if (Buffer.isBuffer(content)) return content;
+  if (content instanceof Uint8Array) return Buffer.from(content);
+  if (typeof content === 'string') return Buffer.from(content);
+  return Buffer.alloc(0);
+}
+
+function canonicalGenericParams(
+  action: string,
+  record: Record<string, unknown> | undefined,
+  keys: string[]
+): CanonicalConfirmationParams {
+  const result: CanonicalConfirmationParams = { action };
+  for (const key of keys) {
+    const value = record?.[key];
+    if (value !== undefined) result[key] = value;
+  }
+  return result;
+}
+
+function stripUndefined(input: Record<string, unknown>): CanonicalConfirmationParams {
+  const output: CanonicalConfirmationParams = { action: String(input['action']) };
+  for (const [key, value] of Object.entries(input)) {
+    if (key === 'action' || value === undefined) continue;
+    output[key] = value;
+  }
+  return output;
+}

--- a/server/features/repo-router.ts
+++ b/server/features/repo-router.ts
@@ -26,7 +26,7 @@ import {
 import {
   evaluateHubPolicy,
   isSessionCreateType,
-  sessionCreateCapability,
+  sessionCreateCapabilities,
   type SessionCreateType,
 } from '../hub-policy-evaluator.js';
 import type { RepoInventoryFeature } from './repo-inventory.js';
@@ -207,7 +207,10 @@ export function createRepoFeatureRouter(
             repoPath: target.repo.localPath,
             ...(target.worktree ? { worktreePath: target.worktree.localPath } : {}),
           },
-          requiredCapabilities: [sessionCreateCapability(sessionType)],
+          requiredCapabilities: sessionCreateCapabilities({
+            sessionType,
+            controlMode: routedBody['controlMode'],
+          }),
           ...(expiresAt !== undefined ? { expiresAt } : {}),
           params: routedBody,
           now: reopenNow,

--- a/server/features/repo-router.ts
+++ b/server/features/repo-router.ts
@@ -1,4 +1,8 @@
 import * as express from 'express';
+import {
+  createConfirmationChallengeStore,
+  type ConfirmationChallengeStore,
+} from '../confirmation-challenges.js';
 import { type HubNodeRegistry } from '../hub-node-registry.js';
 import {
   RELAY_NODE_LINK_PROTOCOL_VERSION,
@@ -9,9 +13,11 @@ import {
   bodyRecord,
   coldReopenSessionPayload,
   findColdReopenTarget,
+  paramsWithoutConfirmation,
   recordField,
   relayError,
   scopedNodeSession,
+  sendPolicyDecision,
   sendRelayError,
   sendRegistryError,
   sessionFromPayload,
@@ -20,8 +26,6 @@ import {
 import {
   evaluateHubPolicy,
   isSessionCreateType,
-  policyDecisionToRelayError,
-  appendPolicyAudit,
   sessionCreateCapability,
   type SessionCreateType,
 } from '../hub-policy-evaluator.js';
@@ -41,6 +45,7 @@ export interface RepoFeatureRouterOptions {
   collectLocalRepoInventory?: () => Promise<RepoInventoryReport>;
   nodeLinks?: HubNodeLinkManager;
   sessionEnvelopes?: InMemorySessionEnvelopeRegistry;
+  confirmations?: ConfirmationChallengeStore;
   auditSink?: RoutedSessionAuditSink;
   now?: () => Date;
 }
@@ -72,6 +77,7 @@ export function createRepoFeatureRouter(
   const router = express.Router();
   const { registry, requireAuth, repoInventoryFeature } = options;
   const sessionEnvelopes = options.sessionEnvelopes ?? sessionEnvelopeRegistry;
+  const confirmations = options.confirmations ?? createConfirmationChallengeStore();
   const now = () => options.now?.() ?? new Date();
 
   router.get('/hub/repo-inventory', requireAuth, async (_req, res) => {
@@ -143,7 +149,8 @@ export function createRepoFeatureRouter(
       }
 
       const body = bodyRecord(req);
-      const lifecycleError = lifecycleInputError(body);
+      const routedBody = paramsWithoutConfirmation(body);
+      const lifecycleError = lifecycleInputError(routedBody);
       if (lifecycleError) {
         sendRelayError(
           res,
@@ -155,7 +162,7 @@ export function createRepoFeatureRouter(
         return;
       }
       const reopenNow = now();
-      const expiresAt = expiresAtFromLifecycleInput(body, reopenNow);
+      const expiresAt = expiresAtFromLifecycleInput(routedBody, reopenNow);
       if (
         expiresAt !== undefined &&
         expiresAt !== null &&
@@ -172,7 +179,7 @@ export function createRepoFeatureRouter(
         );
         return;
       }
-      const sessionType = sessionCreateTypeFromBody(body);
+      const sessionType = sessionCreateTypeFromBody(routedBody);
       if (typeof sessionType !== 'string') {
         sendRelayError(res, sessionType);
         return;
@@ -202,18 +209,19 @@ export function createRepoFeatureRouter(
           },
           requiredCapabilities: [sessionCreateCapability(sessionType)],
           ...(expiresAt !== undefined ? { expiresAt } : {}),
-          params: body,
+          params: routedBody,
           now: reopenNow,
         });
-        const auditedDecision = appendPolicyAudit(options.auditSink, policyDecision, {
-          params: body,
-        });
-        if (auditedDecision.decision !== 'allow') {
-          sendRelayError(res, policyDecisionToRelayError(auditedDecision));
-          return;
-        }
+        if (
+          sendPolicyDecision(options.auditSink, res, policyDecision, routedBody, {
+            confirmations,
+            req,
+            canonicalParams: routedBody,
+            now: reopenNow,
+          })
+        ) return;
 
-        const sessionPayload = coldReopenSessionPayload(body, target);
+        const sessionPayload = coldReopenSessionPayload(routedBody, target);
         const payload = await options.nodeLinks.request(
           nodeId,
           'sessions.create',

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -66,6 +66,7 @@ import {
   sessionCreateCapabilities,
 } from './hub-policy-evaluator.js';
 import {
+  ConfirmationChallengeCapacityError,
   canonicalConfirmationParams,
   createConfirmationChallengeStore,
   hashAuthSessionIdentity,
@@ -154,6 +155,8 @@ export function errorStatus(error: RelayNodeError): number {
     case 'NOT_FOUND':
     case 'NODE_OFFLINE':
       return 404;
+    case 'NODE_BUSY':
+      return 503;
     default:
       return 500;
   }
@@ -446,10 +449,26 @@ function resolveConfirmationForDecision(input: {
   if (auditedDecision.decision !== 'challenge') {
     return { ok: false, error: policyDecisionToRelayError(auditedDecision) };
   }
-  const challenge = input.confirmations.createChallenge(
-    decisionWithCanonicalParams,
-    confirmationCreateInput(input.req, requesterAuthSessionHash, canonicalParams)
-  );
+  let challenge: ReturnType<ConfirmationChallengeStore['createChallenge']>;
+  try {
+    challenge = input.confirmations.createChallenge(
+      decisionWithCanonicalParams,
+      confirmationCreateInput(input.req, requesterAuthSessionHash, canonicalParams)
+    );
+  } catch (error) {
+    if (error instanceof ConfirmationChallengeCapacityError) {
+      return {
+        ok: false,
+        error: relayError(
+          'NODE_BUSY',
+          'confirmation challenge capacity exhausted; retry after existing challenges resolve',
+          true,
+          { reasonCode: error.code, maxChallenges: error.maxChallenges }
+        ),
+      };
+    }
+    throw error;
+  }
   return {
     ok: false,
     error: relayError('CONFIRMATION_REQUIRED', challenge.message, false, {

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -55,12 +55,22 @@ import {
 import {
   appendPolicyAudit,
   evaluateHubPolicy,
+  type HubPolicyDecision,
   isSessionCreateType,
   policyDecisionToRelayError,
   requiredCapabilitiesForRpcIntent,
   revokePolicyAffectedSessions,
   sessionCreateCapabilities,
 } from './hub-policy-evaluator.js';
+import {
+  canonicalConfirmationParams,
+  createConfirmationChallengeStore,
+  hashAuthSessionIdentity,
+  publicChallenge,
+  type ConfirmationChallengeStore,
+  type ConfirmationDecision,
+  type ConfirmationFailure,
+} from './confirmation-challenges.js';
 
 interface HubNodeSessionTransport {
   hasActiveNode(nodeId: string): boolean;
@@ -79,6 +89,7 @@ interface HubNodeRouterOptions {
   collectLocalRepoInventory?: () => Promise<RepoInventoryReport>;
   nodeLinks?: HubNodeSessionTransport;
   sessionEnvelopes?: InMemorySessionEnvelopeRegistry;
+  confirmations?: ConfirmationChallengeStore;
   auditSink?: RoutedSessionAuditSink;
   now?: () => Date;
 }
@@ -122,6 +133,8 @@ export function errorStatus(error: RelayNodeError): number {
   switch (error.code) {
     case 'UNAUTHORIZED':
       return 401;
+    case 'CONFIRMATION_REQUIRED':
+      return 409;
     case 'TOKEN_EXPIRED':
     case 'TOKEN_ALREADY_USED':
     case 'PROTOCOL_INCOMPATIBLE':
@@ -284,6 +297,130 @@ export function bodyRecord(req: Request): Record<string, unknown> {
   return typeof req.body === 'object' && req.body !== null
     ? (req.body as Record<string, unknown>)
     : {};
+}
+
+function confirmationTokenFromRequest(req: Request, body: Record<string, unknown>): string | undefined {
+  const bodyToken = body['confirmationToken'];
+  if (typeof bodyToken === 'string' && bodyToken.trim()) return bodyToken.trim();
+  const headerToken = req.header('x-confirmation-token');
+  return headerToken?.trim() || undefined;
+}
+
+function paramsWithoutConfirmation(body: Record<string, unknown>): Record<string, unknown> {
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(body)) {
+    if (key === 'confirmationToken' || key === 'confirmationChallengeId') continue;
+    cleaned[key] = value;
+  }
+  return cleaned;
+}
+
+function authSessionHash(req: Request): string {
+  const explicit = req.header('x-auth-session')?.trim();
+  if (explicit) return hashAuthSessionIdentity(`header:${explicit}`);
+  const cookieToken = typeof req.cookies?.token === 'string' ? req.cookies.token : undefined;
+  if (cookieToken) return hashAuthSessionIdentity(`cookie:${cookieToken}`);
+  const authHeader = req.header('authorization')?.trim();
+  if (authHeader) return hashAuthSessionIdentity(`authorization:${authHeader}`);
+  if (req.header('x-test-auth')) return hashAuthSessionIdentity(`test:${req.header('x-test-auth')}`);
+  return hashAuthSessionIdentity(`remote:${req.ip ?? 'unknown'}`);
+}
+
+function authSessionLabel(req: Request): string | undefined {
+  return req.header('x-auth-session')?.trim() || undefined;
+}
+
+function relayErrorForConfirmationFailure(failure: ConfirmationFailure): RelayNodeError {
+  return relayError(
+    failure.reasonCode === 'CONFIRMATION_REQUIRED' ? 'CONFIRMATION_REQUIRED' : 'UNAUTHORIZED',
+    failure.message,
+    false,
+    {
+      reasonCode: failure.reasonCode,
+      ...(failure.challenge ? { challenge: publicChallenge(failure.challenge) } : {}),
+    }
+  );
+}
+
+function appendConfirmationAudit(
+  sink: RoutedSessionAuditSink | undefined,
+  entry: SecurityAuditEntryInput | undefined
+): void {
+  if (entry) appendRoutedSessionAudit(sink, entry);
+}
+
+function confirmationCreateInput(
+  req: Request,
+  requesterAuthSessionHash: string,
+  canonicalParams: ReturnType<typeof canonicalConfirmationParams>
+) {
+  const requesterDisplayName = authSessionLabel(req);
+  return {
+    requesterAuthSessionHash,
+    ...(requesterDisplayName ? { requesterDisplayName } : {}),
+    canonicalParams,
+  };
+}
+
+function confirmationApprovalInput(
+  req: Request,
+  challengeId: string,
+  decision: ConfirmationDecision,
+  now: Date
+) {
+  const approverDisplayName = authSessionLabel(req);
+  return {
+    challengeId,
+    approverAuthSessionHash: authSessionHash(req),
+    ...(approverDisplayName ? { approverDisplayName } : {}),
+    decision,
+    now,
+  };
+}
+
+function resolveConfirmationForDecision(input: {
+  confirmations: ConfirmationChallengeStore;
+  auditSink: RoutedSessionAuditSink | undefined;
+  req: Request;
+  decision: HubPolicyDecision;
+  params: Record<string, unknown>;
+  now: Date;
+}): { ok: true } | { ok: false; error: RelayNodeError } {
+  if (input.decision.decision !== 'challenge') return { ok: true };
+  const canonicalParams = canonicalConfirmationParams(
+    input.decision.intent.action,
+    input.params
+  );
+  const requesterAuthSessionHash = authSessionHash(input.req);
+  const token = confirmationTokenFromRequest(input.req, bodyRecord(input.req));
+  if (token) {
+    const redeemed = input.confirmations.redeemToken({
+      token,
+      requesterAuthSessionHash,
+      decision: { ...input.decision, params: canonicalParams },
+      canonicalParams,
+      now: input.now,
+    });
+    appendConfirmationAudit(input.auditSink, redeemed.audit);
+    if (redeemed.ok === true) return { ok: true };
+    return { ok: false, error: relayErrorForConfirmationFailure(redeemed) };
+  }
+  const challenge = input.confirmations.createChallenge(
+    { ...input.decision, params: canonicalParams },
+    confirmationCreateInput(input.req, requesterAuthSessionHash, canonicalParams)
+  );
+  appendPolicyAudit(input.auditSink, { ...input.decision, params: canonicalParams }, { params: canonicalParams });
+  return {
+    ok: false,
+    error: relayError('CONFIRMATION_REQUIRED', challenge.message, false, {
+      reasonCode: 'CONFIRMATION_REQUIRED',
+      challenge: publicChallenge(challenge),
+    }),
+  };
+}
+
+function isConfirmationDecision(value: unknown): value is ConfirmationDecision {
+  return value === 'approve' || value === 'deny' || value === 'deny_revoke';
 }
 
 export interface ColdReopenWarning {
@@ -669,8 +806,27 @@ function sendPolicyDecision(
   sink: RoutedSessionAuditSink | undefined,
   res: Response,
   decision: ReturnType<typeof evaluateHubPolicy>,
-  params?: unknown
+  params?: unknown,
+  confirmation?: {
+    confirmations: ConfirmationChallengeStore;
+    req: Request;
+    canonicalParams: Record<string, unknown>;
+    now: Date;
+  }
 ): boolean {
+  if (decision.decision === 'challenge' && confirmation) {
+    const resolved = resolveConfirmationForDecision({
+      confirmations: confirmation.confirmations,
+      auditSink: sink,
+      req: confirmation.req,
+      decision,
+      params: confirmation.canonicalParams,
+      now: confirmation.now,
+    });
+    if (resolved.ok === true) return false;
+    sendRelayError(res, resolved.error);
+    return true;
+  }
   const audited = appendPolicyAudit(sink, decision, { params });
   if (audited.decision === 'allow') return false;
   sendRelayError(res, policyDecisionToRelayError(audited));
@@ -840,9 +996,56 @@ export function createHubNodeRouter(
   const { registry, requireAuth } = options;
   const scopedSessionAuth = options.scopedSessionAuth ?? requireAuth;
   const envelopes = options.sessionEnvelopes ?? sessionEnvelopeRegistry;
+  const confirmations = options.confirmations ?? createConfirmationChallengeStore();
   const now = () => options.now?.() ?? new Date();
   const repoInventoryFeature =
     options.repoInventoryFeature ?? createRepoInventoryFeature(registry);
+
+  router.get('/hub/confirmations', requireAuth, (_req, res) => {
+    res.json({ challenges: confirmations.listChallenges() });
+  });
+
+  router.get('/hub/confirmations/:challengeId', requireAuth, (req, res) => {
+    const { challengeId } = req.params;
+    const challenge = challengeId ? confirmations.getChallenge(challengeId) : undefined;
+    if (!challenge) {
+      sendRelayError(
+        res,
+        relayError('NOT_FOUND', 'confirmation challenge not found', false, {
+          reasonCode: 'CONFIRMATION_NOT_FOUND',
+        })
+      );
+      return;
+    }
+    res.json({ challenge: publicChallenge(challenge) });
+  });
+
+  router.post('/hub/confirmations/:challengeId/approve', requireAuth, (req, res) => {
+    const { challengeId } = req.params;
+    const body = bodyRecord(req);
+    const decision = body['decision'] ?? 'approve';
+    if (!challengeId || !isConfirmationDecision(decision)) {
+      sendRelayError(
+        res,
+        relayError('INVALID_REQUEST', 'decision must be approve, deny, or deny_revoke', false, {
+          reasonCode: 'CONFIRMATION_INVALID_DECISION',
+        })
+      );
+      return;
+    }
+    const result = confirmations.approveChallenge(
+      confirmationApprovalInput(req, challengeId, decision, now())
+    );
+    appendConfirmationAudit(options.auditSink, result.audit);
+    if (result.ok === false) {
+      sendRelayError(res, relayErrorForConfirmationFailure(result));
+      return;
+    }
+    res.json({
+      confirmationToken: result.confirmationToken,
+      challenge: publicChallenge(result.challenge),
+    });
+  });
 
   router.post('/hub/pair-tokens', requireAuth, (req, res) => {
     const body = bodyRecord(req);
@@ -1084,7 +1287,8 @@ export function createHubNodeRouter(
     }
 
     const body = bodyRecord(req);
-    const lifecycleError = lifecycleInputError(body);
+    const routedBody = paramsWithoutConfirmation(body);
+    const lifecycleError = lifecycleInputError(routedBody);
     if (lifecycleError) {
       sendRelayError(
         res,
@@ -1096,7 +1300,7 @@ export function createHubNodeRouter(
       return;
     }
     const createNow = now();
-    const expiresAt = expiresAtFromLifecycleInput(body, createNow);
+    const expiresAt = expiresAtFromLifecycleInput(routedBody, createNow);
     if (expiresAt !== undefined && expiresAt !== null && Date.parse(expiresAt) <= createNow.getTime()) {
       const error = relayError(
         'SESSION_EXPIRED',
@@ -1111,13 +1315,13 @@ export function createHubNodeRouter(
         peer: { kind: 'hub' },
         node: { nodeId },
         intent: { action: 'sessions.create', target: nodeId },
-        material: { params: body },
+        material: { params: routedBody },
       });
       sendRelayError(res, error);
       return;
     }
-    const requestedEnvelope = isSessionEnvelope(body['sessionEnvelope'])
-      ? body['sessionEnvelope']
+    const requestedEnvelope = isSessionEnvelope(routedBody['sessionEnvelope'])
+      ? routedBody['sessionEnvelope']
       : null;
     if (requestedEnvelope && requestedEnvelope.nodeId !== nodeId) {
       appendRoutedSessionAudit(options.auditSink, {
@@ -1151,7 +1355,7 @@ export function createHubNodeRouter(
       );
       return;
     }
-    const rawSessionType = body['type'];
+    const rawSessionType = routedBody['type'];
     if (rawSessionType !== undefined && !isSessionCreateType(rawSessionType)) {
       sendRelayError(
         res,
@@ -1168,22 +1372,29 @@ export function createHubNodeRouter(
       node,
       nodeId,
       intent: { action: 'sessions.create', target: nodeId },
-      scope: sessionCreatePolicyScope(nodeId, body),
+      scope: sessionCreatePolicyScope(nodeId, routedBody),
       requiredCapabilities: sessionCreateCapabilities({
         sessionType,
-        controlMode: body['controlMode'],
+        controlMode: routedBody['controlMode'],
       }),
       ...(expiresAt !== undefined ? { expiresAt } : {}),
-      params: body,
+      params: routedBody,
       now: createNow,
     });
-    if (sendPolicyDecision(options.auditSink, res, policyDecision, body)) return;
+    if (
+      sendPolicyDecision(options.auditSink, res, policyDecision, routedBody, {
+        confirmations,
+        req,
+        canonicalParams: routedBody,
+        now: createNow,
+      })
+    ) return;
 
     try {
       const payload = await options.nodeLinks.request(
         nodeId,
         'sessions.create',
-        body
+        routedBody
       );
       const session = scopedNodeSession(nodeId, sessionFromPayload(payload), {
         ...(expiresAt !== undefined ? { expiresAt } : {}),
@@ -1257,6 +1468,7 @@ export function createHubNodeRouter(
       }
 
       const body = bodyRecord(req);
+      const routedBody = paramsWithoutConfirmation(body);
       const lifecycle = envelopes.validate({ nodeId, sessionId, now: now() });
       if (!lifecycle.ok) {
         const denial = lifecycle as Exclude<
@@ -1269,7 +1481,7 @@ export function createHubNodeRouter(
           nodeId,
           sessionId,
           `rpc.fs.${operation}`,
-          body
+          routedBody
         );
         sendRelayError(res, denial.error);
         return;
@@ -1280,7 +1492,7 @@ export function createHubNodeRouter(
         nodePlatform: node.platform,
         nodeId,
         session: lifecycle.summary,
-        body,
+        body: routedBody,
       });
       if (normalized.ok === false) {
         sendRelayError(res, normalized.error);
@@ -1305,13 +1517,19 @@ export function createHubNodeRouter(
         ...(lifecycle.summary.revokedAt
           ? { revokedAt: lifecycle.summary.revokedAt }
           : {}),
-        params: { ...body, path: normalized.value.request.path },
+        params: { ...routedBody, path: normalized.value.request.path },
         now: now(),
       });
+      const canonicalFileParams = {
+        ...routedBody,
+        path: normalized.value.request.path,
+      };
       if (
-        sendPolicyDecision(options.auditSink, res, policyDecision, {
-          ...body,
-          path: normalized.value.request.path,
+        sendPolicyDecision(options.auditSink, res, policyDecision, canonicalFileParams, {
+          confirmations,
+          req,
+          canonicalParams: canonicalFileParams,
+          now: now(),
         })
       ) {
         return;
@@ -1405,6 +1623,8 @@ export function createHubNodeRouter(
         return;
       }
       const scoped = lifecycle.summary;
+      const killNow = now();
+      const killParams = { method: 'DELETE' };
       const killPolicyDecision = evaluateHubPolicy({
         peer: { kind: 'hub' },
         node,
@@ -1426,10 +1646,17 @@ export function createHubNodeRouter(
         ...(scoped?.correlationId ? { correlationId: scoped.correlationId } : {}),
         ...(scoped?.expiresAt !== undefined ? { expiresAt: scoped.expiresAt } : {}),
         ...(scoped?.revokedAt ? { revokedAt: scoped.revokedAt } : {}),
-        params: { method: 'DELETE' },
-        now: now(),
+        params: killParams,
+        now: killNow,
       });
-      if (sendPolicyDecision(options.auditSink, res, killPolicyDecision, { method: 'DELETE' })) return;
+      if (
+        sendPolicyDecision(options.auditSink, res, killPolicyDecision, killParams, {
+          confirmations,
+          req,
+          canonicalParams: killParams,
+          now: killNow,
+        })
+      ) return;
 
       try {
         await options.nodeLinks.request(nodeId, 'sessions.kill', {

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -10,7 +10,10 @@ import type {
   RepoInventoryReport,
   RepoInventoryWorktreeInstance,
 } from '../shared/repo-inventory.js';
-import type { SecurityAuditEntryInput } from '../shared/security-audit.js';
+import {
+  classifySecurityAuditWriteFailure,
+  type SecurityAuditEntryInput,
+} from '../shared/security-audit.js';
 import {
   HubNodeRegistryError,
   type HubNodeRegistry,
@@ -306,7 +309,7 @@ function confirmationTokenFromRequest(req: Request, body: Record<string, unknown
   return headerToken?.trim() || undefined;
 }
 
-function paramsWithoutConfirmation(body: Record<string, unknown>): Record<string, unknown> {
+export function paramsWithoutConfirmation(body: Record<string, unknown>): Record<string, unknown> {
   const cleaned: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(body)) {
     if (key === 'confirmationToken' || key === 'confirmationChallengeId') continue;
@@ -316,17 +319,18 @@ function paramsWithoutConfirmation(body: Record<string, unknown>): Record<string
 }
 
 function authSessionHash(req: Request): string {
-  const explicit = req.header('x-auth-session')?.trim();
-  if (explicit) return hashAuthSessionIdentity(`header:${explicit}`);
   const cookieToken = typeof req.cookies?.token === 'string' ? req.cookies.token : undefined;
   if (cookieToken) return hashAuthSessionIdentity(`cookie:${cookieToken}`);
   const authHeader = req.header('authorization')?.trim();
   if (authHeader) return hashAuthSessionIdentity(`authorization:${authHeader}`);
+  const explicit = req.header('x-auth-session')?.trim();
+  if (explicit && req.header('x-test-auth')) return hashAuthSessionIdentity(`test-header:${explicit}`);
   if (req.header('x-test-auth')) return hashAuthSessionIdentity(`test:${req.header('x-test-auth')}`);
   return hashAuthSessionIdentity(`remote:${req.ip ?? 'unknown'}`);
 }
 
 function authSessionLabel(req: Request): string | undefined {
+  if (!req.header('x-test-auth')) return undefined;
   return req.header('x-auth-session')?.trim() || undefined;
 }
 
@@ -344,9 +348,32 @@ function relayErrorForConfirmationFailure(failure: ConfirmationFailure): RelayNo
 
 function appendConfirmationAudit(
   sink: RoutedSessionAuditSink | undefined,
-  entry: SecurityAuditEntryInput | undefined
-): void {
-  if (entry) appendRoutedSessionAudit(sink, entry);
+  entry: SecurityAuditEntryInput | undefined,
+  decision: HubPolicyDecision
+): RelayNodeError | null {
+  if (!entry || !sink) return null;
+  try {
+    sink.append(entry);
+    return null;
+  } catch {
+    const classification = classifySecurityAuditWriteFailure({
+      ...(decision.trustTier ? { trustTier: decision.trustTier } : {}),
+      requiredBits: decision.requiredBits,
+      decision: entry.decision,
+    });
+    if (classification.mode === 'fail-closed') {
+      return policyDecisionToRelayError({
+        ...decision,
+        decision: 'deny',
+        reasonCode: 'POLICY_AUDIT_WRITE_FAILED_CLOSED',
+        message: classification.visibleMessage,
+        grantedBits: [],
+        deniedBits: decision.requiredBits,
+        challengeBits: [],
+      });
+    }
+    return null;
+  }
 }
 
 function confirmationCreateInput(
@@ -401,15 +428,28 @@ function resolveConfirmationForDecision(input: {
       canonicalParams,
       now: input.now,
     });
-    appendConfirmationAudit(input.auditSink, redeemed.audit);
+    const auditError = appendConfirmationAudit(
+      input.auditSink,
+      redeemed.audit,
+      redeemed.challenge?.decision ?? input.decision
+    );
+    if (auditError) return { ok: false, error: auditError };
     if (redeemed.ok === true) return { ok: true };
     return { ok: false, error: relayErrorForConfirmationFailure(redeemed) };
   }
+  const decisionWithCanonicalParams = { ...input.decision, params: canonicalParams };
+  const auditedDecision = appendPolicyAudit(
+    input.auditSink,
+    decisionWithCanonicalParams,
+    { params: canonicalParams }
+  );
+  if (auditedDecision.decision !== 'challenge') {
+    return { ok: false, error: policyDecisionToRelayError(auditedDecision) };
+  }
   const challenge = input.confirmations.createChallenge(
-    { ...input.decision, params: canonicalParams },
+    decisionWithCanonicalParams,
     confirmationCreateInput(input.req, requesterAuthSessionHash, canonicalParams)
   );
-  appendPolicyAudit(input.auditSink, { ...input.decision, params: canonicalParams }, { params: canonicalParams });
   return {
     ok: false,
     error: relayError('CONFIRMATION_REQUIRED', challenge.message, false, {
@@ -802,7 +842,7 @@ function auditLifecycleDenial(
   });
 }
 
-function sendPolicyDecision(
+export function sendPolicyDecision(
   sink: RoutedSessionAuditSink | undefined,
   res: Response,
   decision: ReturnType<typeof evaluateHubPolicy>,
@@ -1036,7 +1076,13 @@ export function createHubNodeRouter(
     const result = confirmations.approveChallenge(
       confirmationApprovalInput(req, challengeId, decision, now())
     );
-    appendConfirmationAudit(options.auditSink, result.audit);
+    const auditError = result.challenge
+      ? appendConfirmationAudit(options.auditSink, result.audit, result.challenge.decision)
+      : null;
+    if (auditError) {
+      sendRelayError(res, auditError);
+      return;
+    }
     if (result.ok === false) {
       sendRelayError(res, relayErrorForConfirmationFailure(result));
       return;

--- a/server/index.ts
+++ b/server/index.ts
@@ -108,6 +108,7 @@ import {
 import { getNodeManifest } from './node-manifest.js';
 import { createHubNodeRegistry } from './hub-node-registry.js';
 import { createHubNodeRouter } from './hub-node-router.js';
+import { createConfirmationChallengeStore } from './confirmation-challenges.js';
 import { createHubNodeLinkManager } from './hub-node-link.js';
 import {
   aggregateRemoteSessions,
@@ -1166,6 +1167,7 @@ async function main(): Promise<void> {
       config: getConfig(),
       configPath: CONFIG_PATH,
     });
+  const confirmationChallenges = createConfirmationChallengeStore();
   app.use(
     createHubNodeRouter({
       registry: hubNodeRegistry,
@@ -1174,6 +1176,7 @@ async function main(): Promise<void> {
       scopedSessionAuth: requireScopedSessionAuth,
       repoInventoryFeature,
       collectLocalRepoInventory: collectLocalInventory,
+      confirmations: confirmationChallenges,
       sessionEnvelopes: sessionEnvelopeRegistry,
       ...(securityAuditLog ? { auditSink: securityAuditLog } : {}),
     })
@@ -1185,6 +1188,7 @@ async function main(): Promise<void> {
       requireAuth,
       repoInventoryFeature,
       collectLocalRepoInventory: collectLocalInventory,
+      confirmations: confirmationChallenges,
       sessionEnvelopes: sessionEnvelopeRegistry,
       ...(securityAuditLog ? { auditSink: securityAuditLog } : {}),
     })

--- a/shared/relay-node-protocol.ts
+++ b/shared/relay-node-protocol.ts
@@ -10,6 +10,7 @@ export type RelayNodeChannel = 'control' | 'rpc' | 'events' | 'pty' | 'preview';
 
 export type RelayNodeErrorCode =
   | 'UNAUTHORIZED'
+  | 'CONFIRMATION_REQUIRED'
   | 'TOKEN_EXPIRED'
   | 'TOKEN_ALREADY_USED'
   | 'NODE_REVOKED'

--- a/test/confirmation-challenges.test.ts
+++ b/test/confirmation-challenges.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canonicalConfirmationParams,
+  createConfirmationChallengeStore,
+} from '../server/confirmation-challenges.js';
+import type { HubPolicyDecision } from '../server/hub-policy-evaluator.js';
+
+const NOW = new Date('2026-01-02T03:04:05.000Z');
+
+function challengeDecision(overrides: Partial<HubPolicyDecision> = {}): HubPolicyDecision {
+  return {
+    decision: 'challenge',
+    reasonCode: 'POLICY_CHALLENGE_REQUIRED',
+    message: 'node ACL requires confirmation for this capability',
+    nodeId: 'node_prod',
+    peer: { kind: 'hub' },
+    intent: { action: 'rpc.fs.write', target: 'node_prod' },
+    scope: { kind: 'repo', nodeId: 'node_prod', cwd: '/srv/app', repoPath: '/srv/app' },
+    trustTier: 'prod',
+    aclRef: 'acl_prod',
+    policyVersion: '1.0',
+    requiredBits: ['rpc:fs:write'],
+    grantedBits: [],
+    deniedBits: [],
+    challengeBits: ['rpc:fs:write'],
+    unknownBits: [],
+    sessionId: 'session-1',
+    correlationId: 'corr-1',
+    params: canonicalConfirmationParams('rpc.fs.write', {
+      cwd: '/srv/app',
+      path: 'secrets.txt',
+      content: 'hello',
+    }),
+    ...overrides,
+  };
+}
+
+describe('confirmation challenge store', () => {
+  it('canonicalizes dangerous operation params deterministically without raw env or file bytes', () => {
+    const execA = canonicalConfirmationParams('pty.exec.arbitrary', {
+      command: 'npm test',
+      cwd: '/srv/app',
+      env: { B: '2', A: '1' },
+    });
+    const execB = canonicalConfirmationParams('pty.exec.arbitrary', {
+      env: { A: '1', B: '2' },
+      cwd: '/srv/app',
+      command: 'npm test',
+    });
+    expect(execA).toEqual(execB);
+    expect(execA).toMatchObject({ action: 'pty.exec.arbitrary', command: 'npm test', cwd: '/srv/app' });
+    expect(JSON.stringify(execA)).not.toContain('"A":"1"');
+    expect(execA).toHaveProperty('envHash');
+
+    const write = canonicalConfirmationParams('rpc.fs.write', {
+      path: '/srv/app/secrets.txt',
+      content: 'super-secret',
+    });
+    expect(write).toMatchObject({
+      action: 'rpc.fs.write',
+      path: '/srv/app/secrets.txt',
+      size: Buffer.byteLength('super-secret'),
+    });
+    expect(write).toHaveProperty('sha256');
+    expect(JSON.stringify(write)).not.toContain('super-secret');
+
+    expect(canonicalConfirmationParams('rpc.fs.delete', { path: '/tmp/x', recursive: true })).toMatchObject({
+      action: 'rpc.fs.delete',
+      path: '/tmp/x',
+      recursive: true,
+    });
+    expect(canonicalConfirmationParams('rpc.git.write', { verb: 'push', refSpec: 'HEAD:main' })).toMatchObject({
+      action: 'rpc.git.write',
+      verb: 'push',
+      refSpec: 'HEAD:main',
+    });
+  });
+
+  it('requires distinct approval, mints a hashed single-use token, and binds redemption to exact params', () => {
+    const store = createConfirmationChallengeStore({
+      now: () => NOW,
+      randomToken: () => 'raw-token',
+      randomId: () => 'challenge-1',
+    });
+    const challenge = store.createChallenge(challengeDecision(), {
+      requesterAuthSessionHash: 'requester-session',
+      canonicalParams: canonicalConfirmationParams('rpc.fs.write', {
+        cwd: '/srv/app',
+        path: 'secrets.txt',
+        content: 'hello',
+      }),
+    });
+
+    const sameSession = store.approveChallenge({
+      challengeId: challenge.challengeId,
+      approverAuthSessionHash: 'requester-session',
+      decision: 'approve',
+      now: NOW,
+    });
+    expect(sameSession.ok).toBe(false);
+    if (!sameSession.ok) expect(sameSession.reasonCode).toBe('CONFIRMATION_SAME_SESSION');
+
+    const approved = store.approveChallenge({
+      challengeId: challenge.challengeId,
+      approverAuthSessionHash: 'approver-session',
+      approverDisplayName: 'second browser',
+      decision: 'approve',
+      now: NOW,
+    });
+    expect(approved.ok).toBe(true);
+    if (!approved.ok) throw new Error('expected approval');
+    expect(approved.confirmationToken).toBe('raw-token');
+    expect(approved.challenge.tokenHash).not.toBe('raw-token');
+    expect(approved.challenge.approverAuthSessionHash).toBe('approver-session');
+
+    const mismatch = store.redeemToken({
+      token: 'raw-token',
+      requesterAuthSessionHash: 'requester-session',
+      decision: challengeDecision(),
+      canonicalParams: canonicalConfirmationParams('rpc.fs.write', {
+        cwd: '/srv/app',
+        path: 'secrets.txt',
+        content: 'tampered',
+      }),
+      now: NOW,
+    });
+    expect(mismatch.ok).toBe(false);
+    if (!mismatch.ok) expect(mismatch.reasonCode).toBe('CONFIRMATION_PARAM_MISMATCH');
+
+    const redeemed = store.redeemToken({
+      token: 'raw-token',
+      requesterAuthSessionHash: 'requester-session',
+      decision: challengeDecision(),
+      canonicalParams: canonicalConfirmationParams('rpc.fs.write', {
+        cwd: '/srv/app',
+        path: 'secrets.txt',
+        content: 'hello',
+      }),
+      now: NOW,
+    });
+    expect(redeemed.ok).toBe(true);
+
+    const usedAgain = store.redeemToken({
+      token: 'raw-token',
+      requesterAuthSessionHash: 'requester-session',
+      decision: challengeDecision(),
+      canonicalParams: canonicalConfirmationParams('rpc.fs.write', {
+        cwd: '/srv/app',
+        path: 'secrets.txt',
+        content: 'hello',
+      }),
+      now: NOW,
+    });
+    expect(usedAgain.ok).toBe(false);
+    if (!usedAgain.ok) expect(usedAgain.reasonCode).toBe('CONFIRMATION_ALREADY_USED');
+  });
+
+  it('expires, denies, deny+revokes, and caps failed mismatches with operator-readable reason codes', () => {
+    const store = createConfirmationChallengeStore({
+      now: () => NOW,
+      randomToken: () => 'raw-token',
+      randomId: () => 'challenge-1',
+      challengeTtlMs: 1_000,
+      tokenTtlMs: 1_000,
+      maxFailedRedemptions: 2,
+    });
+    const canonicalParams = canonicalConfirmationParams('rpc.fs.write', { path: '/srv/app/a', content: 'a' });
+    const challenge = store.createChallenge(challengeDecision({ params: canonicalParams }), {
+      requesterAuthSessionHash: 'requester-session',
+      canonicalParams,
+    });
+
+    expect(
+      store.approveChallenge({
+        challengeId: challenge.challengeId,
+        approverAuthSessionHash: 'approver-session',
+        decision: 'approve',
+        now: new Date(NOW.getTime() + 1_001),
+      })
+    ).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_EXPIRED' });
+
+    const denied = store.createChallenge(challengeDecision(), {
+      requesterAuthSessionHash: 'requester-session',
+      canonicalParams: challengeDecision().params,
+    });
+    expect(
+      store.approveChallenge({
+        challengeId: denied.challengeId,
+        approverAuthSessionHash: 'approver-session',
+        decision: 'deny',
+        now: NOW,
+      })
+    ).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_DENIED' });
+
+    const revoked = store.createChallenge(challengeDecision(), {
+      requesterAuthSessionHash: 'requester-session',
+      canonicalParams: challengeDecision().params,
+    });
+    expect(
+      store.approveChallenge({
+        challengeId: revoked.challengeId,
+        approverAuthSessionHash: 'approver-session',
+        decision: 'deny_revoke',
+        now: NOW,
+      })
+    ).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_DENIED_REVOKE' });
+
+    const capped = store.createChallenge(challengeDecision(), {
+      requesterAuthSessionHash: 'requester-session',
+      canonicalParams: challengeDecision().params,
+    });
+    const approved = store.approveChallenge({
+      challengeId: capped.challengeId,
+      approverAuthSessionHash: 'approver-session',
+      decision: 'approve',
+      now: NOW,
+    });
+    expect(approved.ok).toBe(true);
+    const wrongParams = canonicalConfirmationParams('rpc.fs.write', { path: '/srv/app/a', content: 'wrong' });
+    for (let i = 0; i < 2; i += 1) {
+      const result = store.redeemToken({
+        token: 'raw-token',
+        requesterAuthSessionHash: 'requester-session',
+        decision: challengeDecision(),
+        canonicalParams: wrongParams,
+        now: NOW,
+      });
+      expect(result).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_PARAM_MISMATCH' });
+    }
+    expect(store.getChallenge(capped.challengeId)?.status).toBe('invalidated');
+  });
+});

--- a/test/confirmation-challenges.test.ts
+++ b/test/confirmation-challenges.test.ts
@@ -181,7 +181,7 @@ describe('confirmation challenge store', () => {
 
     const denied = store.createChallenge(challengeDecision(), {
       requesterAuthSessionHash: 'requester-session',
-      canonicalParams: challengeDecision().params,
+      canonicalParams: challengeDecision().params as ReturnType<typeof canonicalConfirmationParams>,
     });
     expect(
       store.approveChallenge({
@@ -194,7 +194,7 @@ describe('confirmation challenge store', () => {
 
     const revoked = store.createChallenge(challengeDecision(), {
       requesterAuthSessionHash: 'requester-session',
-      canonicalParams: challengeDecision().params,
+      canonicalParams: challengeDecision().params as ReturnType<typeof canonicalConfirmationParams>,
     });
     expect(
       store.approveChallenge({
@@ -207,7 +207,7 @@ describe('confirmation challenge store', () => {
 
     const capped = store.createChallenge(challengeDecision(), {
       requesterAuthSessionHash: 'requester-session',
-      canonicalParams: challengeDecision().params,
+      canonicalParams: challengeDecision().params as ReturnType<typeof canonicalConfirmationParams>,
     });
     const approved = store.approveChallenge({
       challengeId: capped.challengeId,
@@ -229,4 +229,40 @@ describe('confirmation challenge store', () => {
     }
     expect(store.getChallenge(capped.challengeId)?.status).toBe('invalidated');
   });
+
+  it('expires stale list entries and bounds stored terminal challenges', () => {
+    let current = NOW;
+    let nextId = 0;
+    const store = createConfirmationChallengeStore({
+      now: () => current,
+      randomId: () => `challenge-${++nextId}`,
+      randomToken: () => `raw-token-${nextId}`,
+      challengeTtlMs: 1_000,
+      tokenTtlMs: 1_000,
+      maxChallenges: 2,
+    });
+    const params = challengeDecision().params as ReturnType<typeof canonicalConfirmationParams>;
+    const first = store.createChallenge(challengeDecision(), {
+      requesterAuthSessionHash: 'requester-session',
+      canonicalParams: params,
+    });
+    current = new Date(NOW.getTime() + 1_001);
+    expect(store.listChallenges()).toEqual([
+      expect.objectContaining({ challengeId: first.challengeId, status: 'expired' }),
+    ]);
+
+    current = new Date(NOW.getTime() + 2_100);
+    store.createChallenge(challengeDecision(), {
+      requesterAuthSessionHash: 'requester-session',
+      canonicalParams: params,
+    });
+    store.createChallenge(challengeDecision(), {
+      requesterAuthSessionHash: 'requester-session',
+      canonicalParams: params,
+    });
+    const visible = store.listChallenges();
+    expect(visible).toHaveLength(2);
+    expect(visible.map((challenge) => challenge.challengeId)).not.toContain(first.challengeId);
+  });
 });
+

--- a/test/confirmation-challenges.test.ts
+++ b/test/confirmation-challenges.test.ts
@@ -74,6 +74,23 @@ describe('confirmation challenge store', () => {
       verb: 'push',
       refSpec: 'HEAD:main',
     });
+
+    const sessionCreateA = canonicalConfirmationParams('sessions.create', {
+      type: 'terminal',
+      cwd: '/srv/app',
+      command: 'npm test',
+      initialPrompt: 'ship it',
+    });
+    const sessionCreateB = canonicalConfirmationParams('sessions.create', {
+      type: 'terminal',
+      cwd: '/srv/app',
+      command: 'npm run build',
+      initialPrompt: 'ship it',
+    });
+    expect(sessionCreateA).toMatchObject({ action: 'sessions.create', type: 'terminal', cwd: '/srv/app' });
+    expect(sessionCreateA).toHaveProperty('paramsHash');
+    expect(sessionCreateA.paramsHash).not.toBe(sessionCreateB.paramsHash);
+    expect(JSON.stringify(sessionCreateA)).not.toContain('ship it');
   });
 
   it('requires distinct approval, mints a hashed single-use token, and binds redemption to exact params', () => {

--- a/test/confirmation-challenges.test.ts
+++ b/test/confirmation-challenges.test.ts
@@ -129,6 +129,9 @@ describe('confirmation challenge store', () => {
     expect(approved.confirmationToken).toBe('raw-token');
     expect(approved.challenge.tokenHash).not.toBe('raw-token');
     expect(approved.challenge.approverAuthSessionHash).toBe('approver-session');
+    expect(approved.audit.peer.principalHash).toBe('approver-session');
+    expect(approved.audit.peer.principalHash).not.toBe('requester-session');
+    expect(approved.audit.peer.displayName).toBe('second browser');
 
     const mismatch = store.redeemToken({
       token: 'raw-token',
@@ -142,7 +145,10 @@ describe('confirmation challenge store', () => {
       now: NOW,
     });
     expect(mismatch.ok).toBe(false);
-    if (!mismatch.ok) expect(mismatch.reasonCode).toBe('CONFIRMATION_PARAM_MISMATCH');
+    if (!mismatch.ok) {
+      expect(mismatch.reasonCode).toBe('CONFIRMATION_PARAM_MISMATCH');
+      expect(mismatch.audit?.peer.principalHash).toBe('requester-session');
+    }
 
     const redeemed = store.redeemToken({
       token: 'raw-token',
@@ -156,6 +162,9 @@ describe('confirmation challenge store', () => {
       now: NOW,
     });
     expect(redeemed.ok).toBe(true);
+    if (!redeemed.ok) throw new Error('expected redemption');
+    expect(redeemed.audit.peer.principalHash).toBe('requester-session');
+    expect(redeemed.audit.peer.principalHash).not.toBe('approver-session');
 
     const usedAgain = store.redeemToken({
       token: 'raw-token',
@@ -200,27 +209,27 @@ describe('confirmation challenge store', () => {
       requesterAuthSessionHash: 'requester-session',
       canonicalParams: challengeDecision().params as ReturnType<typeof canonicalConfirmationParams>,
     });
-    expect(
-      store.approveChallenge({
-        challengeId: denied.challengeId,
-        approverAuthSessionHash: 'approver-session',
-        decision: 'deny',
-        now: NOW,
-      })
-    ).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_DENIED' });
+    const deniedResult = store.approveChallenge({
+      challengeId: denied.challengeId,
+      approverAuthSessionHash: 'approver-session',
+      decision: 'deny',
+      now: NOW,
+    });
+    expect(deniedResult).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_DENIED' });
+    if (!deniedResult.ok) expect(deniedResult.audit?.peer.principalHash).toBe('approver-session');
 
     const revoked = store.createChallenge(challengeDecision(), {
       requesterAuthSessionHash: 'requester-session',
       canonicalParams: challengeDecision().params as ReturnType<typeof canonicalConfirmationParams>,
     });
-    expect(
-      store.approveChallenge({
-        challengeId: revoked.challengeId,
-        approverAuthSessionHash: 'approver-session',
-        decision: 'deny_revoke',
-        now: NOW,
-      })
-    ).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_DENIED_REVOKE' });
+    const revokedResult = store.approveChallenge({
+      challengeId: revoked.challengeId,
+      approverAuthSessionHash: 'approver-session',
+      decision: 'deny_revoke',
+      now: NOW,
+    });
+    expect(revokedResult).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_DENIED_REVOKE' });
+    if (!revokedResult.ok) expect(revokedResult.audit?.peer.principalHash).toBe('approver-session');
 
     const capped = store.createChallenge(challengeDecision(), {
       requesterAuthSessionHash: 'requester-session',
@@ -280,6 +289,66 @@ describe('confirmation challenge store', () => {
     const visible = store.listChallenges();
     expect(visible).toHaveLength(2);
     expect(visible.map((challenge) => challenge.challengeId)).not.toContain(first.challengeId);
+  });
+
+  it('preserves terminal outcomes after TTL expiry and never evicts live challenges for capacity', () => {
+    let current = NOW;
+    let nextId = 0;
+    const store = createConfirmationChallengeStore({
+      now: () => current,
+      randomId: () => `challenge-${++nextId}`,
+      randomToken: () => `raw-token-${nextId}`,
+      challengeTtlMs: 1_000,
+      tokenTtlMs: 5_000,
+      maxChallenges: 2,
+    });
+    const params = challengeDecision().params as ReturnType<typeof canonicalConfirmationParams>;
+    const first = store.createChallenge(challengeDecision(), {
+      requesterAuthSessionHash: 'requester-session',
+      canonicalParams: params,
+    });
+    const approved = store.approveChallenge({
+      challengeId: first.challengeId,
+      approverAuthSessionHash: 'approver-session',
+      decision: 'approve',
+      now: current,
+    });
+    expect(approved.ok).toBe(true);
+    const second = store.createChallenge(challengeDecision(), {
+      requesterAuthSessionHash: 'requester-session',
+      canonicalParams: params,
+    });
+    expect(() =>
+      store.createChallenge(challengeDecision(), {
+        requesterAuthSessionHash: 'requester-session',
+        canonicalParams: params,
+      })
+    ).toThrow('confirmation challenge capacity exhausted');
+    expect(store.listChallenges().map((challenge) => challenge.challengeId)).toEqual([
+      first.challengeId,
+      second.challengeId,
+    ]);
+
+    if (!approved.ok) throw new Error('expected approval');
+    const redeemed = store.redeemToken({
+      token: approved.confirmationToken,
+      requesterAuthSessionHash: 'requester-session',
+      decision: challengeDecision(),
+      canonicalParams: params,
+      now: current,
+    });
+    expect(redeemed.ok).toBe(true);
+    current = new Date(NOW.getTime() + 1_001);
+    expect(store.getChallenge(first.challengeId)?.status).toBe('redeemed');
+
+    const third = store.createChallenge(challengeDecision(), {
+      requesterAuthSessionHash: 'requester-session',
+      canonicalParams: params,
+    });
+    expect(store.listChallenges().map((challenge) => challenge.challengeId)).toEqual([
+      second.challengeId,
+      third.challengeId,
+    ]);
   });
 });
 

--- a/test/hub-confirmation-routing.test.ts
+++ b/test/hub-confirmation-routing.test.ts
@@ -1,7 +1,7 @@
 import http from 'node:http';
 import express from 'express';
 import { afterEach, describe, expect, it } from 'vitest';
-import { createConfirmationChallengeStore } from '../server/confirmation-challenges.js';
+import { createConfirmationChallengeStore, hashAuthSessionIdentity } from '../server/confirmation-challenges.js';
 import { createRepoFeatureRouter } from '../server/features/repo-router.js';
 import { createHubNodeRouter, type RoutedSessionAuditSink } from '../server/hub-node-router.js';
 import type { HubNodeRegistry } from '../server/hub-node-registry.js';
@@ -344,6 +344,15 @@ describe('hub confirmation routing', () => {
     expect(auditEntries.map((entry) => entry.eventType)).toEqual(
       expect.arrayContaining(['challenge', 'same_session_approval_attempt', 'approval', 'failed_redemption', 'grant'])
     );
+    const requesterHash = hashAuthSessionIdentity('test-header:requester-browser');
+    const approverHash = hashAuthSessionIdentity('test-header:approver-browser');
+    const approvalAudit = auditEntries.find((entry) => entry.eventType === 'approval');
+    const failedRedemptionAudit = auditEntries.find((entry) => entry.eventType === 'failed_redemption');
+    const grantAudit = auditEntries.find((entry) => entry.eventType === 'grant');
+    expect(approvalAudit?.peer.principalHash).toBe(approverHash);
+    expect(approvalAudit?.peer.principalHash).not.toBe(requesterHash);
+    expect(failedRedemptionAudit?.peer.principalHash).toBe(requesterHash);
+    expect(grantAudit?.peer.principalHash).toBe(requesterHash);
   });
 
   it('ignores spoofable x-auth-session when an authenticated cookie is present', async () => {

--- a/test/hub-confirmation-routing.test.ts
+++ b/test/hub-confirmation-routing.test.ts
@@ -2,6 +2,7 @@ import http from 'node:http';
 import express from 'express';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createConfirmationChallengeStore } from '../server/confirmation-challenges.js';
+import { createRepoFeatureRouter } from '../server/features/repo-router.js';
 import { createHubNodeRouter, type RoutedSessionAuditSink } from '../server/hub-node-router.js';
 import type { HubNodeRegistry } from '../server/hub-node-registry.js';
 import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
@@ -112,7 +113,7 @@ describe('hub confirmation routing', () => {
     while (cleanup.length > 0) await cleanup.pop()?.();
   });
 
-  async function startHub() {
+  async function startHub(options: { auditSink?: RoutedSessionAuditSink } = {}) {
     const nodeLinks = {
       requests: [] as Array<{ nodeId: string; type: string; payload: unknown }>,
       hasActiveNode: () => true,
@@ -122,7 +123,14 @@ describe('hub confirmation routing', () => {
       },
     };
     const auditEntries: Parameters<RoutedSessionAuditSink['append']>[0][] = [];
+    const auditSink = options.auditSink ?? { append: (entry) => auditEntries.push(entry) };
     const app = express();
+    app.use((req, _res, next) => {
+      const cookie = req.header('cookie') ?? '';
+      const token = cookie.match(/(?:^|;\s*)token=([^;]+)/)?.[1];
+      if (token) req.cookies = { token };
+      next();
+    });
     app.use(express.json());
     app.use(
       createHubNodeRouter({
@@ -142,12 +150,97 @@ describe('hub confirmation routing', () => {
           randomId: () => 'challenge-1',
           randomToken: () => 'raw-confirmation-token',
         }),
-        auditSink: { append: (entry) => auditEntries.push(entry) },
+        auditSink,
         now: () => NOW,
         requireAuth: (req, res, next) => {
           if (req.header('x-test-auth') === 'yes') next();
           else res.status(401).json({ error: 'Unauthorized' });
         },
+      })
+    );
+    const server = http.createServer(app);
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+    return { base: `http://127.0.0.1:${port}`, nodeLinks, auditEntries };
+  }
+
+  async function startColdReopenHub() {
+    const confirmations = createConfirmationChallengeStore({
+      now: () => NOW,
+      randomId: () => 'challenge-reopen',
+      randomToken: () => 'raw-reopen-token',
+    });
+    const nodeLinks = {
+      requests: [] as Array<{ nodeId: string; type: string; payload: unknown }>,
+      hasActiveNode: () => true,
+      request: async (nodeId: string, type: string, payload: unknown): Promise<unknown> => {
+        nodeLinks.requests.push({ nodeId, type, payload });
+        return sessionPayload();
+      },
+    };
+    const report = {
+      nodeId: 'node_prod',
+      generatedAt: NOW.toISOString(),
+      repos: [
+        {
+          repoInstanceId: 'repo-1',
+          nodeId: 'node_prod',
+          localPath: '/srv/relay-ide',
+          name: 'relay-ide',
+          isGitRepo: true,
+          defaultBranch: 'nightly',
+          currentBranch: 'nightly',
+          repoIdentity: 'github.com/donovan-yohan/relay-ide',
+          selectedRemote: null,
+          remotes: [],
+          repoIdentityWarnings: [],
+          dirty: { stagedCount: 0, unstagedCount: 0, untrackedCount: 0, conflictedCount: 0, files: [], truncated: false },
+          divergence: { upstreamRef: 'origin/nightly', aheadCount: 0, behindCount: 0 },
+          worktrees: [],
+          reportedAt: NOW.toISOString(),
+        },
+      ],
+    };
+    const repoInventoryFeature = {
+      listInventoryReports: () => [report],
+      aggregateInventoryReports: () => ({ nodes: [], repos: [] }),
+      validateInventoryPayload: () => ({ ok: true, payload: report }),
+    };
+    const registry = {
+      listNodes: () => [nodeSummary({ requiresConfirmation: ['session:create:terminal'] })],
+      errorBody: (error: unknown) => ({
+        error: error instanceof Error
+          ? ({ code: 'INTERNAL', message: error.message, retryable: false } satisfies RelayNodeError)
+          : ({ code: 'INTERNAL', message: 'unknown error', retryable: false } satisfies RelayNodeError),
+      }),
+      revokeNode: () => nodeSummary(),
+    } as unknown as HubNodeRegistry;
+    const auditEntries: Parameters<RoutedSessionAuditSink['append']>[0][] = [];
+    const app = express();
+    app.use(express.json());
+    const requireAuth: express.RequestHandler = (req, res, next) => {
+      if (req.header('x-test-auth') === 'yes') next();
+      else res.status(401).json({ error: 'Unauthorized' });
+    };
+    app.use(
+      createHubNodeRouter({
+        registry,
+        nodeLinks,
+        confirmations,
+        requireAuth,
+        auditSink: { append: (entry) => auditEntries.push(entry) },
+        now: () => NOW,
+      })
+    );
+    app.use(
+      createRepoFeatureRouter({
+        registry,
+        nodeLinks: nodeLinks as never,
+        confirmations,
+        requireAuth,
+        repoInventoryFeature: repoInventoryFeature as never,
+        auditSink: { append: (entry) => auditEntries.push(entry) },
+        now: () => NOW,
       })
     );
     const server = http.createServer(app);
@@ -250,6 +343,108 @@ describe('hub confirmation routing', () => {
     expect(nodeLinks.requests[0]).toMatchObject({ type: 'sessions.create', payload: originalBody });
     expect(auditEntries.map((entry) => entry.eventType)).toEqual(
       expect.arrayContaining(['challenge', 'same_session_approval_attempt', 'approval', 'failed_redemption', 'grant'])
+    );
+  });
+
+  it('ignores spoofable x-auth-session when an authenticated cookie is present', async () => {
+    const { base } = await startHub();
+    const headers = {
+      'content-type': 'application/json',
+      'x-test-auth': 'yes',
+      cookie: 'token=trusted-browser-cookie',
+    };
+    const first = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: { ...headers, 'x-auth-session': 'requester-browser' },
+      body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
+    });
+    expect(first.status).toBe(409);
+
+    const spoofedApproval = await fetch(`${base}/hub/confirmations/challenge-1/approve`, {
+      method: 'POST',
+      headers: { ...headers, 'x-auth-session': 'spoofed-approver-browser' },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+    expect(spoofedApproval.status).toBe(401);
+    expect(await spoofedApproval.json()).toMatchObject({
+      error: { code: 'UNAUTHORIZED', details: { reasonCode: 'CONFIRMATION_SAME_SESSION' } },
+    });
+  });
+
+  it('fails closed when confirmation challenge audit append fails for prod/high-risk policy', async () => {
+    const { base, nodeLinks } = await startHub({
+      auditSink: { append: () => { throw new Error('audit sink unavailable'); } },
+    });
+    const response = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+      },
+      body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
+    });
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({
+      error: { code: 'INTERNAL', details: { reasonCode: 'POLICY_AUDIT_WRITE_FAILED_CLOSED' } },
+    });
+    expect(nodeLinks.requests).toHaveLength(0);
+  });
+
+  it('requires the same two-token confirmation flow for repo cold reopen sessions.create', async () => {
+    const { base, nodeLinks, auditEntries } = await startColdReopenHub();
+    const reopenBody = {
+      source: { repoIdentity: 'github.com/donovan-yohan/relay-ide', branchName: 'nightly' },
+      type: 'terminal',
+    };
+    const first = await fetch(`${base}/hub/nodes/node_prod/sessions/reopen`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+      },
+      body: JSON.stringify(reopenBody),
+    });
+    expect(first.status).toBe(409);
+    expect(await first.json()).toMatchObject({
+      error: {
+        details: {
+          reasonCode: 'CONFIRMATION_REQUIRED',
+          challenge: { challengeId: 'challenge-reopen', intent: { action: 'sessions.create' } },
+        },
+      },
+    });
+    expect(nodeLinks.requests).toHaveLength(0);
+
+    const approval = await fetch(`${base}/hub/confirmations/challenge-reopen/approve`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'approver-browser',
+      },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+    expect(approval.status).toBe(200);
+    expect(await approval.json()).toMatchObject({ confirmationToken: 'raw-reopen-token' });
+
+    const redeemed = await fetch(`${base}/hub/nodes/node_prod/sessions/reopen`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+      },
+      body: JSON.stringify({ ...reopenBody, confirmationToken: 'raw-reopen-token' }),
+    });
+    expect(redeemed.status).toBe(201);
+    expect(await redeemed.json()).toMatchObject({ session: { id: 'remote-session-1', nodeId: 'node_prod' } });
+    expect(nodeLinks.requests).toHaveLength(1);
+    expect(nodeLinks.requests[0]).toMatchObject({ type: 'sessions.create' });
+    expect(JSON.stringify(nodeLinks.requests[0]?.payload)).not.toContain('raw-reopen-token');
+    expect(auditEntries.map((entry) => entry.eventType)).toEqual(
+      expect.arrayContaining(['challenge', 'approval', 'grant'])
     );
   });
 });

--- a/test/hub-confirmation-routing.test.ts
+++ b/test/hub-confirmation-routing.test.ts
@@ -1,0 +1,255 @@
+import http from 'node:http';
+import express from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createConfirmationChallengeStore } from '../server/confirmation-challenges.js';
+import { createHubNodeRouter, type RoutedSessionAuditSink } from '../server/hub-node-router.js';
+import type { HubNodeRegistry } from '../server/hub-node-registry.js';
+import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
+import {
+  createLegacyDefaultNodeAcl,
+  summarizeAcl,
+  type RelayCapabilityBit,
+  type RelayNodeAcl,
+} from '../shared/security-policy.js';
+import type { HubNodeSummary, RelayNodeError } from '../shared/relay-node-protocol.js';
+
+const NOW = new Date('2026-01-02T03:04:05.000Z');
+
+function nodeSummary(input: {
+  allowed?: RelayCapabilityBit[];
+  requiresConfirmation?: RelayCapabilityBit[];
+} = {}): HubNodeSummary {
+  const acl: RelayNodeAcl = {
+    ...createLegacyDefaultNodeAcl({
+      nodeId: 'node_prod',
+      credentialId: 'cred_prod',
+      trustTier: 'prod',
+      createdAt: NOW.toISOString(),
+    }),
+    grants: {
+      allowed: input.allowed ?? ['session:read'],
+      requiresConfirmation: input.requiresConfirmation ?? ['session:create:terminal'],
+    },
+  };
+  return {
+    nodeId: 'node_prod',
+    displayName: 'prod box',
+    hostname: 'prod.example',
+    platform: 'linux',
+    arch: 'x64',
+    relayVersion: '0.1.0-test',
+    protocolVersion: '1.0',
+    status: 'online',
+    connection: { route: 'reverse-link', status: 'connected' },
+    trust: { state: 'active', level: 'prod', tier: 'prod', policy: summarizeAcl(acl) },
+    credentialState: 'active',
+    version: { state: 'compatible', nodeProtocolVersion: '1.0', hubProtocolVersion: '1.0' },
+    capabilities: {
+      totals: { available: 2, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        tmux: 'available',
+        git: 'available',
+        browserAutomation: 'unavailable',
+        clipboardImage: 'unavailable',
+        ssh: 'unavailable',
+        tailscale: 'unavailable',
+      },
+      agents: {},
+      serviceManager: 'systemd-user',
+      wsl: false,
+    },
+    createdAt: NOW.toISOString(),
+    pairedAt: NOW.toISOString(),
+    lastSeenAt: NOW.toISOString(),
+    credentialId: 'cred_prod',
+  };
+}
+
+function sessionPayload() {
+  return {
+    session: {
+      id: 'remote-session-1',
+      type: 'terminal',
+      agent: 'claude',
+      mode: 'pty',
+      repoPath: '/srv/relay-ide',
+      worktreePath: null,
+      cwd: '/srv/relay-ide',
+      repoName: 'relay-ide',
+      branchName: 'nightly',
+      displayName: 'relay-ide terminal',
+      createdAt: NOW.toISOString(),
+      lastActivity: NOW.toISOString(),
+      idle: false,
+      customCommand: null,
+      useTmux: true,
+      tmuxSessionName: 'relay-ide-remote-session-1',
+      status: 'active',
+      needsBranchRename: false,
+      agentState: 'idle',
+    },
+  };
+}
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing server address');
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+describe('hub confirmation routing', () => {
+  const cleanup: Array<() => Promise<void> | void> = [];
+
+  afterEach(async () => {
+    while (cleanup.length > 0) await cleanup.pop()?.();
+  });
+
+  async function startHub() {
+    const nodeLinks = {
+      requests: [] as Array<{ nodeId: string; type: string; payload: unknown }>,
+      hasActiveNode: () => true,
+      request: async (nodeId: string, type: string, payload: unknown): Promise<unknown> => {
+        nodeLinks.requests.push({ nodeId, type, payload });
+        return sessionPayload();
+      },
+    };
+    const auditEntries: Parameters<RoutedSessionAuditSink['append']>[0][] = [];
+    const app = express();
+    app.use(express.json());
+    app.use(
+      createHubNodeRouter({
+        registry: {
+          listNodes: () => [nodeSummary()],
+          errorBody: (error: unknown) => ({
+            error: error instanceof Error
+              ? ({ code: 'INTERNAL', message: error.message, retryable: false } satisfies RelayNodeError)
+              : ({ code: 'INTERNAL', message: 'unknown error', retryable: false } satisfies RelayNodeError),
+          }),
+          revokeNode: () => nodeSummary(),
+        } as unknown as HubNodeRegistry,
+        nodeLinks,
+        sessionEnvelopes: createSessionEnvelopeRegistry(),
+        confirmations: createConfirmationChallengeStore({
+          now: () => NOW,
+          randomId: () => 'challenge-1',
+          randomToken: () => 'raw-confirmation-token',
+        }),
+        auditSink: { append: (entry) => auditEntries.push(entry) },
+        now: () => NOW,
+        requireAuth: (req, res, next) => {
+          if (req.header('x-test-auth') === 'yes') next();
+          else res.status(401).json({ error: 'Unauthorized' });
+        },
+      })
+    );
+    const server = http.createServer(app);
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+    return { base: `http://127.0.0.1:${port}`, nodeLinks, auditEntries };
+  }
+
+  it('creates challenge without routing node RPC, then requires distinct approval before exact-token redemption', async () => {
+    const { base, nodeLinks, auditEntries } = await startHub();
+    const originalBody = { repoPath: '/srv/relay-ide', type: 'terminal' };
+    const first = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+      },
+      body: JSON.stringify(originalBody),
+    });
+    const firstJson = await first.json();
+    expect(firstJson).toMatchObject({
+      error: { details: { reasonCode: 'CONFIRMATION_REQUIRED' } },
+    });
+    expect(first.status).toBe(409);
+    expect(nodeLinks.requests).toHaveLength(0);
+    expect(firstJson).toMatchObject({
+      error: {
+        code: 'CONFIRMATION_REQUIRED',
+        details: {
+          reasonCode: 'CONFIRMATION_REQUIRED',
+          challenge: {
+            challengeId: 'challenge-1',
+            nodeId: 'node_prod',
+            intent: { action: 'sessions.create', target: 'node_prod' },
+            requiredBits: ['session:create:terminal'],
+            challengeBits: ['session:create:terminal'],
+          },
+        },
+      },
+    });
+
+    const sameSessionApproval = await fetch(`${base}/hub/confirmations/challenge-1/approve`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+      },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+    expect(sameSessionApproval.status).toBe(401);
+    expect(await sameSessionApproval.json()).toMatchObject({
+      error: { code: 'UNAUTHORIZED', details: { reasonCode: 'CONFIRMATION_SAME_SESSION' } },
+    });
+
+    const approval = await fetch(`${base}/hub/confirmations/challenge-1/approve`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'approver-browser',
+      },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+    expect(approval.status).toBe(200);
+    const approvalJson = await approval.json();
+    expect(approvalJson).toMatchObject({
+      confirmationToken: 'raw-confirmation-token',
+      challenge: { challengeId: 'challenge-1', status: 'approved' },
+    });
+
+    const tampered = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+      },
+      body: JSON.stringify({ ...originalBody, method: 'cold-reopen', confirmationToken: 'raw-confirmation-token' }),
+    });
+    expect(tampered.status).toBe(401);
+    expect(await tampered.json()).toMatchObject({
+      error: { details: { reasonCode: 'CONFIRMATION_PARAM_MISMATCH' } },
+    });
+    expect(nodeLinks.requests).toHaveLength(0);
+
+    const redeemed = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+      },
+      body: JSON.stringify({ ...originalBody, confirmationToken: 'raw-confirmation-token' }),
+    });
+    expect(redeemed.status).toBe(201);
+    expect(await redeemed.json()).toMatchObject({ id: 'remote-session-1', nodeId: 'node_prod' });
+    expect(nodeLinks.requests).toHaveLength(1);
+    expect(nodeLinks.requests[0]).toMatchObject({ type: 'sessions.create', payload: originalBody });
+    expect(auditEntries.map((entry) => entry.eventType)).toEqual(
+      expect.arrayContaining(['challenge', 'same_session_approval_attempt', 'approval', 'failed_redemption', 'grant'])
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a hub-side confirmation challenge/token store for `requiresConfirmation` policy decisions.
- Wires challenge issuance, distinct-session approval, single-use token redemption, and exact canonical-param matching into routed node session/file/kill policy gates.
- Adds confirmation inspection/approval endpoints under `/hub/confirmations` and typed operator-readable failure details.

## Scope
This is intentionally backend/API-only. It uses `Refs #497` rather than `Closes #497` because the browser/operator prompt UI still needs to be implemented before #497 is fully complete.

Frontend follow-up created on the Relay Kanban board: `t_47c10c69` (`#497 frontend/operator prompt for confirmation challenges`).

## The Case Against
This change might be wrong or incomplete because:
- The challenge/token store is in-memory. That is enough for the current hub process and tests, but approvals will not survive a hub restart.
- Auth-session identity is inferred from available request material (`x-auth-session` for tests, cookie token, authorization header, then fallback request metadata). If the production auth layer later exposes a stronger principal/session id, this should switch to that instead of guessing at the edge.
- The UI is not included, so operators cannot yet approve from a polished prompt. API callers can exercise the flow, but full #497 acceptance still needs the frontend follow-up.
- The token is accepted in request body or `x-confirmation-token`; callers need to avoid leaking it in logs.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Confirmation token replay | Tokens are stored hashed and are marked redeemed on first successful redemption. |
| Self-approval | Same auth/browser session is blocked at approval and redemption. |
| Parameter tampering | Redemption recomputes deterministic canonical params and invalidates after capped mismatches. |
| Accidental node RPC before approval | Policy challenge path returns 409 and does not route the RPC until a valid token is redeemed. |

## Verification
- `npm test -- test/confirmation-challenges.test.ts test/hub-confirmation-routing.test.ts` — 4/4 passed.
- `npm run check` — passed (43 existing lint warnings, 0 errors).
- `npm run build` — passed.
- `npm test` — local full run hit one unrelated flaky timeout in `test/local-logs.test.ts`; targeted rerun passed: `npm test -- test/local-logs.test.ts` (8/8).
- `npm test -- test/sessions.test.ts -t "detachForRestart leaves the tmux session alive for restore adoption"` — passed locally after the first GitHub CI attempt hit this unrelated tmux flake.
- GitHub CI — passed on rerun for head `2c002edbc32f7f52e643bb6652953fa8bec63a02`.

Refs #497


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation challenge system for sensitive user actions
  * New endpoints to list, fetch, and approve confirmation challenges
  * Session creation and reopen workflows now include confirmation flows

* **Tests**
  * Added test coverage for confirmation challenges and hub routing integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/521?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->