### PR TITLE
feat: add operator confirmation prompt

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,6 +65,7 @@ import UpdateToast from './components/UpdateToast.js';
 import { showImageToast } from './components/ImageToast.js';
 import ErrorToast from './components/ErrorToast.js';
 import NotificationStack from './components/NotificationStack.js';
+import ConfirmationPrompt from './components/ConfirmationPrompt.js';
 import InstallBanner from './components/InstallBanner.js';
 import CommandPalette from './components/CommandPalette.js';
 import OpenPicker from './components/OpenPicker.js';
@@ -1359,6 +1360,7 @@ export default function App() {
       />
 
       {/* Toasts */}
+      <ConfirmationPrompt />
       <UpdateToast />
       <InstallBanner />
       <ErrorToast />

--- a/frontend/src/components/ConfirmationPrompt.css
+++ b/frontend/src/components/ConfirmationPrompt.css
@@ -1,0 +1,191 @@
+.confirmation-prompt {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  z-index: 1200;
+  width: min(560px, calc(100vw - 32px));
+  max-height: min(78vh, 720px);
+  overflow: auto;
+  padding: 16px;
+  border: 1px solid var(--status-warning);
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 0 0 1px var(--bg), 0 16px 48px rgba(0, 0, 0, 0.72);
+  font-family: var(--font-mono);
+}
+
+.confirmation-prompt__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.confirmation-prompt__header h2 {
+  margin: 2px 0 0;
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  text-transform: lowercase;
+}
+
+.confirmation-prompt__eyebrow {
+  color: var(--status-warning);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.confirmation-prompt__status {
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.confirmation-prompt__status--pending {
+  border-color: var(--status-warning);
+  color: var(--status-warning);
+}
+
+.confirmation-prompt__status--approved {
+  border-color: var(--status-success);
+  color: var(--status-success);
+}
+
+.confirmation-prompt__meta {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 8px 16px;
+  margin: 12px 0;
+}
+
+.confirmation-prompt__meta div {
+  min-width: 0;
+}
+
+.confirmation-prompt__meta dt,
+.confirmation-prompt__field {
+  display: block;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.confirmation-prompt__meta dd {
+  margin: 2px 0 0;
+  overflow: hidden;
+  color: var(--text);
+  font-size: var(--font-size-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.confirmation-prompt__bits {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 10px 0 12px;
+}
+
+.confirmation-prompt__bits span {
+  padding: 2px 6px;
+  border: 1px solid color-mix(in srgb, var(--status-warning) 50%, transparent);
+  color: var(--status-warning);
+  font-size: var(--font-size-xs);
+}
+
+.confirmation-prompt__field {
+  margin: 10px 0;
+}
+
+.confirmation-prompt__field input,
+.confirmation-prompt__field select {
+  display: block;
+  width: 100%;
+  margin-top: 4px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+}
+
+.confirmation-prompt__field input:focus,
+.confirmation-prompt__field select:focus {
+  outline: 1px solid var(--accent);
+  outline-offset: 0;
+}
+
+.confirmation-prompt__params {
+  margin: 12px 0;
+  border: 1px solid var(--border);
+}
+
+.confirmation-prompt__params summary {
+  padding: 8px;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.confirmation-prompt__params pre {
+  max-height: 180px;
+  margin: 0;
+  overflow: auto;
+  padding: 8px;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  font-size: var(--font-size-xs);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.confirmation-prompt__message {
+  margin: 8px 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.confirmation-prompt__message--ok {
+  color: var(--status-success);
+}
+
+.confirmation-prompt__message--error {
+  color: var(--status-error);
+}
+
+.confirmation-prompt__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+@media (max-width: 640px) {
+  .confirmation-prompt {
+    right: 8px;
+    bottom: 8px;
+    width: calc(100vw - 16px);
+    max-height: 70vh;
+    padding: 12px;
+  }
+
+  .confirmation-prompt__meta {
+    grid-template-columns: 1fr;
+  }
+
+  .confirmation-prompt__actions {
+    justify-content: stretch;
+  }
+
+  .confirmation-prompt__actions .tui-btn {
+    flex: 1 1 auto;
+  }
+}

--- a/frontend/src/components/ConfirmationPrompt.tsx
+++ b/frontend/src/components/ConfirmationPrompt.tsx
@@ -1,0 +1,308 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  approveConfirmationChallenge,
+  fetchConfirmationChallenges,
+  type ConfirmationChallenge,
+  type ConfirmationDecision,
+} from '../lib/api.js';
+import {
+  getConfirmationRetry,
+  retryConfirmedOperation,
+  subscribeConfirmationRetries,
+} from '../lib/confirmation-retries.js';
+import { useSessionsStore } from '../lib/stores/sessions.js';
+import TuiButton from './TuiButton.js';
+import './ConfirmationPrompt.css';
+
+const APPROVER_STORAGE_KEY = 'relay-confirmation-approver-session';
+const POLL_INTERVAL_MS = 3_000;
+
+function loadApproverSession(): string {
+  try {
+    return localStorage.getItem(APPROVER_STORAGE_KEY) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function saveApproverSession(value: string): void {
+  try {
+    if (value.trim()) localStorage.setItem(APPROVER_STORAGE_KEY, value.trim());
+    else localStorage.removeItem(APPROVER_STORAGE_KEY);
+  } catch {
+    /* localStorage may be unavailable */
+  }
+}
+
+function formatDate(value: string): string {
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return value;
+  return new Date(timestamp).toLocaleString();
+}
+
+function statusRank(status: ConfirmationChallenge['status']): number {
+  if (status === 'pending') return 0;
+  if (status === 'approved') return 1;
+  return 2;
+}
+
+function challengeLabel(challenge: ConfirmationChallenge): string {
+  const target = challenge.intent.target ? ` -> ${challenge.intent.target}` : '';
+  return `${challenge.intent.action}${target}`;
+}
+
+function detailsFromError(error: unknown): { message: string; reasonCode?: string } {
+  if (error && typeof error === 'object') {
+    const maybe = error as { message?: unknown; details?: Record<string, unknown> };
+    return {
+      message: typeof maybe.message === 'string' ? maybe.message : String(error),
+      ...(typeof maybe.details?.['reasonCode'] === 'string'
+        ? { reasonCode: maybe.details['reasonCode'] }
+        : {}),
+    };
+  }
+  return { message: String(error) };
+}
+
+function shouldTreatDeniedAsHandled(decision: ConfirmationDecision, reasonCode?: string): boolean {
+  return (
+    (decision === 'deny' && reasonCode === 'CONFIRMATION_DENIED') ||
+    (decision === 'deny_revoke' && reasonCode === 'CONFIRMATION_DENIED_REVOKE')
+  );
+}
+
+export const ConfirmationPrompt: React.FC = () => {
+  const [challenges, setChallenges] = useState<ConfirmationChallenge[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [approverSession, setApproverSession] = useState(loadApproverSession);
+  const [loading, setLoading] = useState<ConfirmationDecision | 'retry' | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [, setRetryVersion] = useState(0);
+
+  const refresh = async (): Promise<void> => {
+    const next = await fetchConfirmationChallenges();
+    setChallenges(next);
+    setSelectedId((current) => {
+      if (current && next.some((challenge) => challenge.challengeId === current)) {
+        return current;
+      }
+      return next.find((challenge) => challenge.status === 'pending')?.challengeId ?? next[0]?.challengeId ?? null;
+    });
+  };
+
+  useEffect(() => {
+    let active = true;
+    const tick = async () => {
+      try {
+        const next = await fetchConfirmationChallenges();
+        if (!active) return;
+        setChallenges(next);
+        setSelectedId((current) => {
+          if (current && next.some((challenge) => challenge.challengeId === current)) return current;
+          return next.find((challenge) => challenge.status === 'pending')?.challengeId ?? next[0]?.challengeId ?? null;
+        });
+      } catch (error) {
+        if (active) setErrorMessage(error instanceof Error ? error.message : String(error));
+      }
+    };
+    void tick();
+    const timer = setInterval(() => void tick(), POLL_INTERVAL_MS);
+    return () => {
+      active = false;
+      clearInterval(timer);
+    };
+  }, []);
+
+  useEffect(() => subscribeConfirmationRetries(() => setRetryVersion((value) => value + 1)), []);
+
+  const visibleChallenges = useMemo(
+    () =>
+      challenges
+        .filter((challenge) => challenge.status === 'pending' || challenge.status === 'approved')
+        .toSorted((a, b) => {
+          const rank = statusRank(a.status) - statusRank(b.status);
+          if (rank !== 0) return rank;
+          return Date.parse(b.createdAt) - Date.parse(a.createdAt);
+        }),
+    [challenges]
+  );
+
+  const selected =
+    visibleChallenges.find((challenge) => challenge.challengeId === selectedId) ?? visibleChallenges[0];
+  const retryRegistration = selected ? getConfirmationRetry(selected.challengeId) : undefined;
+
+  if (!selected) return null;
+
+  const handleDecision = async (decision: ConfirmationDecision) => {
+    setLoading(decision);
+    setErrorMessage(null);
+    setStatusMessage(null);
+    saveApproverSession(approverSession);
+    try {
+      const result = await approveConfirmationChallenge(
+        selected.challengeId,
+        decision,
+        approverSession
+      );
+      setChallenges((current) =>
+        current.map((challenge) =>
+          challenge.challengeId === result.challenge.challengeId ? result.challenge : challenge
+        )
+      );
+      if (decision !== 'approve') {
+        setStatusMessage(`challenge ${decision === 'deny' ? 'denied' : 'denied + revoke requested'}`);
+        await refresh();
+        return;
+      }
+      if (!result.confirmationToken) {
+        setStatusMessage('challenge approved, but the hub did not return a token');
+        await refresh();
+        return;
+      }
+      const registration = getConfirmationRetry(result.challenge.challengeId);
+      if (!registration) {
+        setStatusMessage('challenge approved. no local retry is registered in this browser session.');
+        await refresh();
+        return;
+      }
+      if (registration.paramsHash !== result.challenge.canonicalParamsHash) {
+        setErrorMessage('approved token was not retried: local params hash does not match the challenge');
+        await refresh();
+        return;
+      }
+      setLoading('retry');
+      await retryConfirmedOperation(result.challenge, result.confirmationToken);
+      await useSessionsStore.getState().refreshAll();
+      setStatusMessage('approved and retried with the exact original params');
+      await refresh();
+    } catch (error) {
+      const details = detailsFromError(error);
+      if (shouldTreatDeniedAsHandled(decision, details.reasonCode)) {
+        setStatusMessage(decision === 'deny' ? 'challenge denied' : 'challenge denied and revoke requested');
+        await refresh();
+      } else if (details.reasonCode === 'CONFIRMATION_SAME_SESSION') {
+        setErrorMessage(`same-session approval blocked: ${details.message}`);
+        await refresh();
+      } else {
+        setErrorMessage(details.message);
+      }
+    } finally {
+      setLoading(null);
+    }
+  };
+
+  const canonicalJson = JSON.stringify(selected.canonicalParams, null, 2);
+
+  return (
+    <aside className="confirmation-prompt" aria-live="polite" aria-label="confirmation challenge prompt">
+      <div className="confirmation-prompt__header">
+        <div>
+          <div className="confirmation-prompt__eyebrow">operator confirmation</div>
+          <h2>dangerous operation queued</h2>
+        </div>
+        <span className={`confirmation-prompt__status confirmation-prompt__status--${selected.status}`}>
+          {selected.status}
+        </span>
+      </div>
+
+      {visibleChallenges.length > 1 && (
+        <label className="confirmation-prompt__field">
+          challenge
+          <select
+            value={selected.challengeId}
+            onChange={(event) => setSelectedId(event.target.value)}
+          >
+            {visibleChallenges.map((challenge) => (
+              <option key={challenge.challengeId} value={challenge.challengeId}>
+                {challengeLabel(challenge)} [{challenge.status}]
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      <dl className="confirmation-prompt__meta">
+        <div>
+          <dt>node</dt>
+          <dd>{selected.nodeId}</dd>
+        </div>
+        <div>
+          <dt>intent</dt>
+          <dd>{challengeLabel(selected)}</dd>
+        </div>
+        {selected.sessionId && (
+          <div>
+            <dt>session</dt>
+            <dd>{selected.sessionId}</dd>
+          </div>
+        )}
+        <div>
+          <dt>expires</dt>
+          <dd>{formatDate(selected.expiresAt)}</dd>
+        </div>
+        <div>
+          <dt>params hash</dt>
+          <dd title={selected.canonicalParamsHash}>{selected.canonicalParamsHash.slice(0, 18)}…</dd>
+        </div>
+        <div>
+          <dt>retry</dt>
+          <dd>{retryRegistration ? `local: ${retryRegistration.label}` : 'not registered in this browser'}</dd>
+        </div>
+      </dl>
+
+      <div className="confirmation-prompt__bits" aria-label="required capability bits">
+        {[...new Set([...selected.requiredBits, ...selected.challengeBits])].map((bit) => (
+          <span key={bit}>{bit}</span>
+        ))}
+      </div>
+
+      <label className="confirmation-prompt__field">
+        approver session label
+        <input
+          value={approverSession}
+          onChange={(event) => setApproverSession(event.target.value)}
+          placeholder="blank = current session, e.g. operator-1 = distinct"
+        />
+      </label>
+
+      <details className="confirmation-prompt__params" open>
+        <summary>canonical params</summary>
+        <pre>{canonicalJson}</pre>
+      </details>
+
+      {selected.message && <p className="confirmation-prompt__message">{selected.message}</p>}
+      {statusMessage && <p className="confirmation-prompt__message confirmation-prompt__message--ok">{statusMessage}</p>}
+      {errorMessage && <p className="confirmation-prompt__message confirmation-prompt__message--error">{errorMessage}</p>}
+
+      <div className="confirmation-prompt__actions">
+        <TuiButton
+          variant="danger"
+          size="sm"
+          disabled={loading !== null || selected.status !== 'pending'}
+          onClick={() => void handleDecision('deny_revoke')}
+        >
+          deny + revoke
+        </TuiButton>
+        <TuiButton
+          variant="ghost"
+          size="sm"
+          disabled={loading !== null || selected.status !== 'pending'}
+          onClick={() => void handleDecision('deny')}
+        >
+          deny
+        </TuiButton>
+        <TuiButton
+          variant="success"
+          size="sm"
+          disabled={loading !== null || selected.status !== 'pending'}
+          onClick={() => void handleDecision('approve')}
+        >
+          {loading === 'retry' ? 'retrying…' : loading === 'approve' ? 'approving…' : 'approve + retry'}
+        </TuiButton>
+      </div>
+    </aside>
+  );
+};
+
+export default ConfirmationPrompt;

--- a/frontend/src/components/ConfirmationPrompt.tsx
+++ b/frontend/src/components/ConfirmationPrompt.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   approveConfirmationChallenge,
   fetchConfirmationChallenges,
+  fetchConfirmationRequesterToken,
   type ConfirmationChallenge,
   type ConfirmationDecision,
 } from '../lib/api.js';
@@ -78,7 +79,8 @@ export const ConfirmationPrompt: React.FC = () => {
   const [loading, setLoading] = useState<ConfirmationDecision | 'retry' | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [, setRetryVersion] = useState(0);
+  const [retryVersion, setRetryVersion] = useState(0);
+  const autoRetryingIds = useRef<Set<string>>(new Set());
 
   const refresh = async (): Promise<void> => {
     const next = await fetchConfirmationChallenges();
@@ -132,6 +134,45 @@ export const ConfirmationPrompt: React.FC = () => {
     visibleChallenges.find((challenge) => challenge.challengeId === selectedId) ?? visibleChallenges[0];
   const retryRegistration = selected ? getConfirmationRetry(selected.challengeId) : undefined;
 
+  useEffect(() => {
+    const approvedRetry = visibleChallenges.find(
+      (challenge) =>
+        challenge.status === 'approved' &&
+        getConfirmationRetry(challenge.challengeId) &&
+        !autoRetryingIds.current.has(challenge.challengeId)
+    );
+    if (!approvedRetry) return;
+
+    autoRetryingIds.current.add(approvedRetry.challengeId);
+    setLoading('retry');
+    setErrorMessage(null);
+    setStatusMessage('approved challenge received; requesting token for original browser retry');
+
+    void (async () => {
+      try {
+        const result = await fetchConfirmationRequesterToken(approvedRetry.challengeId);
+        const registration = getConfirmationRetry(result.challenge.challengeId);
+        if (!registration) {
+          setStatusMessage('approved challenge has no local retry in this browser session');
+          return;
+        }
+        if (registration.paramsHash !== result.challenge.canonicalParamsHash) {
+          setErrorMessage('approved token was not retried: local params hash does not match the challenge');
+          return;
+        }
+        await retryConfirmedOperation(result.challenge, result.confirmationToken);
+        await useSessionsStore.getState().refreshAll();
+        setStatusMessage('approved by another browser and retried with the exact original params');
+        await refresh();
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : String(error));
+      } finally {
+        autoRetryingIds.current.delete(approvedRetry.challengeId);
+        setLoading(null);
+      }
+    })();
+  }, [visibleChallenges, retryVersion]);
+
   if (!selected) return null;
 
   const handleDecision = async (decision: ConfirmationDecision) => {
@@ -162,7 +203,7 @@ export const ConfirmationPrompt: React.FC = () => {
       }
       const registration = getConfirmationRetry(result.challenge.challengeId);
       if (!registration) {
-        setStatusMessage('challenge approved. no local retry is registered in this browser session.');
+        setStatusMessage('challenge approved. waiting for the requesting browser to pick up the token and retry.');
         await refresh();
         return;
       }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -304,6 +304,21 @@ export async function approveConfirmationChallenge(
   };
 }
 
+export async function fetchConfirmationRequesterToken(
+  challengeId: string
+): Promise<{ confirmationToken: string; challenge: ConfirmationChallenge }> {
+  const res = await fetch(
+    '/hub/confirmations/' + encodeURIComponent(challengeId) + '/requester-token',
+    { method: 'POST' }
+  );
+  if (!res.ok) throw await httpErrorFromResponse(res, 'Failed to fetch confirmation token');
+  const data = await jsonEither<{ confirmationToken?: unknown; challenge?: unknown }>(res);
+  if (typeof data.confirmationToken !== 'string' || !isConfirmationChallenge(data.challenge)) {
+    throw new Error('confirmation requester-token response was malformed');
+  }
+  return { confirmationToken: data.confirmationToken, challenge: data.challenge };
+}
+
 export async function setupPin(pin: string, confirm: string): Promise<void> {
   const res = await fetch('/auth/setup', {
     method: 'POST',

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -38,6 +38,7 @@ import {
   type NodeId,
 } from '../../../shared/identity.js';
 import type { SessionLane } from '../../../shared/session-lane.js';
+import { registerConfirmationRetry } from './confirmation-retries.js';
 
 export class ConflictError extends Error {
   sessionId: string;
@@ -52,17 +53,66 @@ export class HttpError extends Error {
   status: number;
   code: string | undefined;
   retryable: boolean | undefined;
+  details: Record<string, unknown> | undefined;
   constructor(
     status: number,
     message = httpErrorMessage(status),
     code?: string | undefined,
-    retryable?: boolean | undefined
+    retryable?: boolean | undefined,
+    details?: Record<string, unknown> | undefined
   ) {
     super(message);
     this.name = 'HttpError';
     this.status = status;
     this.code = code;
     this.retryable = retryable;
+    this.details = details;
+  }
+}
+
+export interface CanonicalConfirmationParams {
+  action: string;
+  [key: string]: unknown;
+}
+
+export type ConfirmationDecision = 'approve' | 'deny' | 'deny_revoke';
+export type ConfirmationChallengeStatus =
+  | 'pending'
+  | 'approved'
+  | 'denied'
+  | 'revoked'
+  | 'expired'
+  | 'redeemed'
+  | 'invalidated';
+
+export interface ConfirmationChallenge {
+  challengeId: string;
+  status: ConfirmationChallengeStatus;
+  nodeId: string;
+  intent: { action: string; target?: string };
+  requiredBits: string[];
+  challengeBits: string[];
+  sessionId?: string;
+  canonicalParams: CanonicalConfirmationParams;
+  canonicalParamsHash: string;
+  requesterDisplayName?: string;
+  approverDisplayName?: string;
+  createdAt: string;
+  expiresAt: string;
+  approvedAt?: string;
+  tokenExpiresAt?: string;
+  failedRedemptions: number;
+  maxFailedRedemptions: number;
+  reasonCode: string;
+  message: string;
+}
+
+export class ConfirmationRequiredError extends HttpError {
+  challenge: ConfirmationChallenge;
+  constructor(error: HttpError, challenge: ConfirmationChallenge) {
+    super(error.status, error.message, error.code, error.retryable, error.details);
+    this.name = 'ConfirmationRequiredError';
+    this.challenge = challenge;
   }
 }
 
@@ -120,16 +170,42 @@ async function parseErrorBody(
   return (await httpErrorFromResponse(res, fallback)).message;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isConfirmationChallenge(value: unknown): value is ConfirmationChallenge {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value['challengeId'] === 'string' &&
+    typeof value['status'] === 'string' &&
+    typeof value['nodeId'] === 'string' &&
+    isRecord(value['intent']) &&
+    typeof value['canonicalParamsHash'] === 'string' &&
+    isRecord(value['canonicalParams']) &&
+    Array.isArray(value['requiredBits']) &&
+    Array.isArray(value['challengeBits']) &&
+    typeof value['expiresAt'] === 'string'
+  );
+}
+
+function confirmationChallengeFromError(error: HttpError): ConfirmationChallenge | undefined {
+  const challenge = error.details?.['challenge'];
+  return isConfirmationChallenge(challenge) ? challenge : undefined;
+}
+
 async function httpErrorFromResponse(
   res: Response,
   fallback?: string
 ): Promise<HttpError> {
   try {
     const data = (await res.json()) as { error?: unknown; message?: unknown };
-    const structuredError =
-      typeof data.error === 'object' && data.error !== null
-        ? (data.error as Record<string, unknown>)
-        : null;
+    const structuredError = isRecord(data.error) ? data.error : null;
+    const details = isRecord(structuredError?.['details'])
+      ? structuredError['details']
+      : typeof (data as { sessionId?: unknown }).sessionId === 'string'
+        ? { sessionId: (data as { sessionId: string }).sessionId }
+        : undefined;
     const code =
       typeof data.error === 'string'
         ? data.error
@@ -148,7 +224,7 @@ async function httpErrorFromResponse(
           : typeof data.error === 'string'
             ? httpErrorMessage(res.status, data.error)
             : httpErrorMessage(res.status, fallback);
-    return new HttpError(res.status, message, code, retryable);
+    return new HttpError(res.status, message, code, retryable, details);
   } catch {
     return new HttpError(res.status, httpErrorMessage(res.status, fallback));
   }
@@ -179,6 +255,53 @@ export async function checkAuthStatus(): Promise<{
     await fetch('/auth/status')
   );
   return { hasPIN: data.hasPIN === true, noPin: data.noPin === true };
+}
+
+export async function fetchConfirmationChallenges(): Promise<ConfirmationChallenge[]> {
+  const data = await json<{ challenges?: unknown[] }>(await fetch('/hub/confirmations'));
+  return Array.isArray(data.challenges)
+    ? data.challenges.filter(isConfirmationChallenge)
+    : [];
+}
+
+export async function fetchConfirmationChallenge(
+  challengeId: string
+): Promise<ConfirmationChallenge> {
+  const data = await json<{ challenge?: unknown }>(
+    await fetch('/hub/confirmations/' + encodeURIComponent(challengeId))
+  );
+  if (!isConfirmationChallenge(data.challenge)) {
+    throw new Error('confirmation challenge response was malformed');
+  }
+  return data.challenge;
+}
+
+export async function approveConfirmationChallenge(
+  challengeId: string,
+  decision: ConfirmationDecision,
+  approverSession?: string
+): Promise<{ confirmationToken?: string; challenge: ConfirmationChallenge }> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (approverSession?.trim()) headers['x-auth-session'] = approverSession.trim();
+  const res = await fetch(
+    '/hub/confirmations/' + encodeURIComponent(challengeId) + '/approve',
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ decision }),
+    }
+  );
+  if (!res.ok) throw await httpErrorFromResponse(res, 'Failed to approve confirmation');
+  const data = await jsonEither<{ confirmationToken?: unknown; challenge?: unknown }>(res);
+  if (!isConfirmationChallenge(data.challenge)) {
+    throw new Error('confirmation approval response was malformed');
+  }
+  return {
+    ...(typeof data.confirmationToken === 'string'
+      ? { confirmationToken: data.confirmationToken }
+      : {}),
+    challenge: data.challenge,
+  };
 }
 
 export async function setupPin(pin: string, confirm: string): Promise<void> {
@@ -542,7 +665,7 @@ export async function enrichBranches(
   return jsonEither<EnrichBranchesResult>(res);
 }
 
-export async function createSession(body: {
+export interface CreateSessionBody {
   nodeId?: NodeId | undefined;
   repoPath?: string | undefined;
   worktreePath?: string | null | undefined;
@@ -570,27 +693,77 @@ export async function createSession(body: {
     repoPath: string;
     repoName: string;
   };
-}): Promise<SessionSummary> {
-  const { nodeId, ...sessionBody } = body;
-  const sessionPath =
-    nodeId && nodeId !== DEFAULT_LOCAL_NODE_ID
-      ? '/hub/nodes/' + encodeURIComponent(nodeId) + '/sessions'
-      : '/sessions';
-  const res = await fetch(sessionPath, {
+}
+
+function sessionCreatePath(nodeId?: NodeId | undefined): string {
+  return nodeId && nodeId !== DEFAULT_LOCAL_NODE_ID
+    ? '/hub/nodes/' + encodeURIComponent(nodeId) + '/sessions'
+    : '/sessions';
+}
+
+async function postSessionCreate(
+  sessionPath: string,
+  sessionBody: Omit<CreateSessionBody, 'nodeId'>,
+  confirmationToken?: string
+): Promise<Response> {
+  return fetch(sessionPath, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(sessionBody),
+    body: JSON.stringify({
+      ...sessionBody,
+      ...(confirmationToken ? { confirmationToken } : {}),
+    }),
   });
-  if (res.status === 409) {
-    try {
-      const data = await jsonEither<{ sessionId?: string }>(res);
-      throw new ConflictError(data.sessionId ?? '');
-    } catch (e) {
-      if (e instanceof ConflictError) throw e;
-      throw new ConflictError('');
-    }
+}
+
+async function parseSessionCreateResponse(
+  res: Response,
+  retryContext?: {
+    sessionPath: string;
+    sessionBody: Omit<CreateSessionBody, 'nodeId'>;
   }
-  return json<SessionSummary>(res);
+): Promise<SessionSummary> {
+  if (res.ok) return jsonEither<SessionSummary>(res);
+
+  const error = await httpErrorFromResponse(res);
+  const challenge = confirmationChallengeFromError(error);
+  if (error.code === 'CONFIRMATION_REQUIRED' && challenge) {
+    if (retryContext) {
+      registerConfirmationRetry({
+        challenge,
+        label: challenge.intent.action,
+        paramsHash: challenge.canonicalParamsHash,
+        retry: async (confirmationToken) =>
+          parseSessionCreateResponse(
+            await postSessionCreate(
+              retryContext.sessionPath,
+              retryContext.sessionBody,
+              confirmationToken
+            )
+          ),
+      });
+    }
+    throw new ConfirmationRequiredError(error, challenge);
+  }
+
+  if (res.status === 409) {
+    const sessionId =
+      typeof error.details?.['sessionId'] === 'string'
+        ? error.details['sessionId']
+        : '';
+    throw new ConflictError(sessionId);
+  }
+
+  throw error;
+}
+
+export async function createSession(body: CreateSessionBody): Promise<SessionSummary> {
+  const { nodeId, ...sessionBody } = body;
+  const sessionPath = sessionCreatePath(nodeId);
+  return parseSessionCreateResponse(await postSessionCreate(sessionPath, sessionBody), {
+    sessionPath,
+    sessionBody,
+  });
 }
 
 export async function killSession(
@@ -602,8 +775,26 @@ export async function killSession(
       ? `/hub/nodes/${encodeURIComponent(nodeId)}/sessions/${encodeURIComponent(id)}`
       : `/sessions/${encodeURIComponent(id)}`;
   const res = await fetch(sessionPath, { method: 'DELETE' });
-  if (!res.ok)
-    throw await httpErrorFromResponse(res, 'Failed to close session');
+  if (res.ok) return;
+
+  const error = await httpErrorFromResponse(res, 'Failed to close session');
+  const challenge = confirmationChallengeFromError(error);
+  if (error.code === 'CONFIRMATION_REQUIRED' && challenge) {
+    registerConfirmationRetry({
+      challenge,
+      label: challenge.intent.action,
+      paramsHash: challenge.canonicalParamsHash,
+      retry: async (confirmationToken) => {
+        const retryRes = await fetch(sessionPath, {
+          method: 'DELETE',
+          headers: { 'x-confirmation-token': confirmationToken },
+        });
+        if (!retryRes.ok) throw await httpErrorFromResponse(retryRes, 'Failed to close session');
+      },
+    });
+    throw new ConfirmationRequiredError(error, challenge);
+  }
+  throw error;
 }
 
 export async function renameSession(

--- a/frontend/src/lib/confirmation-retries.ts
+++ b/frontend/src/lib/confirmation-retries.ts
@@ -8,43 +8,89 @@ export interface ConfirmationRetryRegistration {
   retry: (confirmationToken: string) => Promise<SessionSummary | unknown>;
 }
 
-const retryRegistrations = new Map<string, ConfirmationRetryRegistration>();
-const listeners = new Set<() => void>();
-
-function emitChange(): void {
-  for (const listener of Array.from(listeners)) listener();
+export interface ConfirmationRetryRegistry {
+  registerConfirmationRetry(registration: ConfirmationRetryRegistration): void;
+  getConfirmationRetry(challengeId: string): ConfirmationRetryRegistration | undefined;
+  clearConfirmationRetry(challengeId: string): void;
+  subscribeConfirmationRetries(listener: () => void): () => void;
+  retryConfirmedOperation(
+    challenge: ConfirmationChallenge,
+    confirmationToken: string
+  ): Promise<SessionSummary | unknown>;
 }
 
+export function createConfirmationRetryRegistry(): ConfirmationRetryRegistry {
+  const retryRegistrations = new Map<string, ConfirmationRetryRegistration>();
+  const listeners = new Set<() => void>();
+
+  function emitChange(): void {
+    for (const listener of Array.from(listeners)) listener();
+  }
+
+  function registerConfirmationRetry(registration: ConfirmationRetryRegistration): void {
+    retryRegistrations.set(registration.challenge.challengeId, registration);
+    emitChange();
+  }
+
+  function getConfirmationRetry(challengeId: string): ConfirmationRetryRegistration | undefined {
+    return retryRegistrations.get(challengeId);
+  }
+
+  function clearConfirmationRetry(challengeId: string): void {
+    if (retryRegistrations.delete(challengeId)) emitChange();
+  }
+
+  function subscribeConfirmationRetries(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  }
+
+  async function retryConfirmedOperation(
+    challenge: ConfirmationChallenge,
+    confirmationToken: string
+  ): Promise<SessionSummary | unknown> {
+    const registration = retryRegistrations.get(challenge.challengeId);
+    if (!registration) {
+      throw new Error('no local retry is registered for this confirmation challenge');
+    }
+    if (registration.paramsHash !== challenge.canonicalParamsHash) {
+      throw new Error('registered retry params no longer match the confirmation challenge hash');
+    }
+    const result = await registration.retry(confirmationToken);
+    clearConfirmationRetry(challenge.challengeId);
+    return result;
+  }
+
+  return {
+    registerConfirmationRetry,
+    getConfirmationRetry,
+    clearConfirmationRetry,
+    subscribeConfirmationRetries,
+    retryConfirmedOperation,
+  };
+}
+
+const defaultConfirmationRetryRegistry = createConfirmationRetryRegistry();
+
 export function registerConfirmationRetry(registration: ConfirmationRetryRegistration): void {
-  retryRegistrations.set(registration.challenge.challengeId, registration);
-  emitChange();
+  defaultConfirmationRetryRegistry.registerConfirmationRetry(registration);
 }
 
 export function getConfirmationRetry(challengeId: string): ConfirmationRetryRegistration | undefined {
-  return retryRegistrations.get(challengeId);
+  return defaultConfirmationRetryRegistry.getConfirmationRetry(challengeId);
 }
 
 export function clearConfirmationRetry(challengeId: string): void {
-  if (retryRegistrations.delete(challengeId)) emitChange();
+  defaultConfirmationRetryRegistry.clearConfirmationRetry(challengeId);
 }
 
 export function subscribeConfirmationRetries(listener: () => void): () => void {
-  listeners.add(listener);
-  return () => listeners.delete(listener);
+  return defaultConfirmationRetryRegistry.subscribeConfirmationRetries(listener);
 }
 
 export async function retryConfirmedOperation(
   challenge: ConfirmationChallenge,
   confirmationToken: string
 ): Promise<SessionSummary | unknown> {
-  const registration = retryRegistrations.get(challenge.challengeId);
-  if (!registration) {
-    throw new Error('no local retry is registered for this confirmation challenge');
-  }
-  if (registration.paramsHash !== challenge.canonicalParamsHash) {
-    throw new Error('registered retry params no longer match the confirmation challenge hash');
-  }
-  const result = await registration.retry(confirmationToken);
-  clearConfirmationRetry(challenge.challengeId);
-  return result;
+  return defaultConfirmationRetryRegistry.retryConfirmedOperation(challenge, confirmationToken);
 }

--- a/frontend/src/lib/confirmation-retries.ts
+++ b/frontend/src/lib/confirmation-retries.ts
@@ -1,0 +1,50 @@
+import type { SessionSummary } from './types.js';
+import type { ConfirmationChallenge } from './api.js';
+
+export interface ConfirmationRetryRegistration {
+  challenge: ConfirmationChallenge;
+  label: string;
+  paramsHash: string;
+  retry: (confirmationToken: string) => Promise<SessionSummary | unknown>;
+}
+
+const retryRegistrations = new Map<string, ConfirmationRetryRegistration>();
+const listeners = new Set<() => void>();
+
+function emitChange(): void {
+  for (const listener of Array.from(listeners)) listener();
+}
+
+export function registerConfirmationRetry(registration: ConfirmationRetryRegistration): void {
+  retryRegistrations.set(registration.challenge.challengeId, registration);
+  emitChange();
+}
+
+export function getConfirmationRetry(challengeId: string): ConfirmationRetryRegistration | undefined {
+  return retryRegistrations.get(challengeId);
+}
+
+export function clearConfirmationRetry(challengeId: string): void {
+  if (retryRegistrations.delete(challengeId)) emitChange();
+}
+
+export function subscribeConfirmationRetries(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export async function retryConfirmedOperation(
+  challenge: ConfirmationChallenge,
+  confirmationToken: string
+): Promise<SessionSummary | unknown> {
+  const registration = retryRegistrations.get(challenge.challengeId);
+  if (!registration) {
+    throw new Error('no local retry is registered for this confirmation challenge');
+  }
+  if (registration.paramsHash !== challenge.canonicalParamsHash) {
+    throw new Error('registered retry params no longer match the confirmation challenge hash');
+  }
+  const result = await registration.retry(confirmationToken);
+  clearConfirmationRetry(challenge.challengeId);
+  return result;
+}

--- a/server/confirmation-challenges.ts
+++ b/server/confirmation-challenges.ts
@@ -166,6 +166,12 @@ export interface ConfirmationChallengeStore {
     requesterAuthSessionHash: string;
     now?: Date;
   }): ConfirmationRequesterTokenResult;
+  invalidateChallenge(input: {
+    challengeId: string;
+    reasonCode: ConfirmationReasonCode;
+    message: string;
+    now?: Date;
+  }): ConfirmationChallenge | undefined;
   getChallenge(challengeId: string): ConfirmationChallenge | undefined;
   listChallenges(): ConfirmationChallengePublicView[];
 }
@@ -417,11 +423,31 @@ export function createConfirmationChallengeStore(
     };
   }
 
+  function invalidateChallenge(input: {
+    challengeId: string;
+    reasonCode: ConfirmationReasonCode;
+    message: string;
+    now?: Date;
+  }): ConfirmationChallenge | undefined {
+    const current = input.now ?? now();
+    const challenge = challenges.get(input.challengeId);
+    if (!challenge) return undefined;
+    challenge.status = 'invalidated';
+    challenge.reasonCode = input.reasonCode;
+    challenge.message = input.message;
+    challenge.approvedAt = current.toISOString();
+    delete challenge.tokenExpiresAt;
+    delete challenge.tokenHash;
+    delete challenge.requesterToken;
+    return challenge;
+  }
+
   return {
     createChallenge,
     approveChallenge,
     redeemToken,
     getRequesterToken,
+    invalidateChallenge,
     getChallenge: (challengeId) => {
       pruneStoredChallenges(now());
       return challenges.get(challengeId);

--- a/server/confirmation-challenges.ts
+++ b/server/confirmation-challenges.ts
@@ -59,6 +59,7 @@ export interface ConfirmationChallenge {
   approvedAt?: string;
   tokenExpiresAt?: string;
   tokenHash?: string;
+  requesterToken?: string;
   redeemedAt?: string;
   failedRedemptions: number;
   maxFailedRedemptions: number;
@@ -117,6 +118,16 @@ export type ConfirmationRedemptionResult =
     }
   | ConfirmationFailure;
 
+export type ConfirmationRequesterTokenResult =
+  | {
+      ok: true;
+      reasonCode: 'CONFIRMATION_APPROVED';
+      message: string;
+      challenge: ConfirmationChallenge;
+      confirmationToken: string;
+    }
+  | ConfirmationFailure;
+
 export interface ConfirmationChallengeStoreOptions {
   now?: () => Date;
   randomId?: () => string;
@@ -150,6 +161,11 @@ export interface ConfirmationChallengeStore {
     canonicalParams: CanonicalConfirmationParams;
     now?: Date;
   }): ConfirmationRedemptionResult;
+  getRequesterToken(input: {
+    challengeId: string;
+    requesterAuthSessionHash: string;
+    now?: Date;
+  }): ConfirmationRequesterTokenResult;
   getChallenge(challengeId: string): ConfirmationChallenge | undefined;
   listChallenges(): ConfirmationChallengePublicView[];
 }
@@ -293,6 +309,7 @@ export function createConfirmationChallengeStore(
     challenge.approvedAt = current.toISOString();
     challenge.tokenExpiresAt = new Date(current.getTime() + tokenTtlMs).toISOString();
     challenge.tokenHash = hashToken(token);
+    challenge.requesterToken = token;
     return {
       ok: true,
       reasonCode: 'CONFIRMATION_APPROVED',
@@ -355,6 +372,7 @@ export function createConfirmationChallengeStore(
     challenge.redeemedAt = current.toISOString();
     challenge.reasonCode = 'CONFIRMATION_APPROVED';
     challenge.message = 'confirmation token redeemed';
+    delete challenge.requesterToken;
     return {
       ok: true,
       reasonCode: 'CONFIRMATION_APPROVED',
@@ -368,10 +386,42 @@ export function createConfirmationChallengeStore(
     };
   }
 
+  function getRequesterToken(input: {
+    challengeId: string;
+    requesterAuthSessionHash: string;
+    now?: Date;
+  }): ConfirmationRequesterTokenResult {
+    const current = input.now ?? now();
+    const challenge = challenges.get(input.challengeId);
+    if (!challenge) return failure('CONFIRMATION_NOT_FOUND', 'confirmation challenge not found');
+    const expiryFailure = expireIfNeeded(challenge, current, true);
+    if (expiryFailure) return expiryFailure;
+    if (challenge.requesterAuthSessionHash !== input.requesterAuthSessionHash) {
+      return failure('CONFIRMATION_REQUESTER_MISMATCH', 'confirmation token can only be picked up by the original requesting auth session', challenge);
+    }
+    if (challenge.status === 'redeemed') {
+      return failure('CONFIRMATION_ALREADY_USED', 'confirmation token was already used', challenge);
+    }
+    if (challenge.status !== 'approved') {
+      return failure('CONFIRMATION_NOT_APPROVED', `confirmation challenge is ${challenge.status}`, challenge);
+    }
+    if (!challenge.requesterToken) {
+      return failure('CONFIRMATION_TOKEN_INVALID', 'confirmation token is no longer available', challenge);
+    }
+    return {
+      ok: true,
+      reasonCode: 'CONFIRMATION_APPROVED',
+      message: 'confirmation token available to original requester',
+      challenge,
+      confirmationToken: challenge.requesterToken,
+    };
+  }
+
   return {
     createChallenge,
     approveChallenge,
     redeemToken,
+    getRequesterToken,
     getChallenge: (challengeId) => {
       pruneStoredChallenges(now());
       return challenges.get(challengeId);
@@ -518,6 +568,7 @@ function expireIfNeeded(
   if (!challengeExpired && !tokenExpired) return null;
   challenge.status = 'expired';
   challenge.reasonCode = 'CONFIRMATION_EXPIRED';
+  delete challenge.requesterToken;
   challenge.message = tokenExpired
     ? 'confirmation token expired'
     : 'confirmation challenge expired';

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -1125,6 +1125,14 @@ export function createHubNodeRouter(
       ? appendConfirmationAudit(options.auditSink, result.audit, result.challenge.decision)
       : null;
     if (auditError) {
+      if (result.ok === true) {
+        confirmations.invalidateChallenge({
+          challengeId: result.challenge.challengeId,
+          reasonCode: 'CONFIRMATION_TOKEN_INVALID',
+          message: 'confirmation approval audit write failed; approval token invalidated',
+          now: now(),
+        });
+      }
       sendRelayError(res, auditError);
       return;
     }

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -1079,6 +1079,32 @@ export function createHubNodeRouter(
     res.json({ challenge: publicChallenge(challenge) });
   });
 
+  router.post('/hub/confirmations/:challengeId/requester-token', requireAuth, (req, res) => {
+    const { challengeId } = req.params;
+    if (!challengeId) {
+      sendRelayError(
+        res,
+        relayError('INVALID_REQUEST', 'confirmation challenge id is required', false, {
+          reasonCode: 'CONFIRMATION_NOT_FOUND',
+        })
+      );
+      return;
+    }
+    const result = confirmations.getRequesterToken({
+      challengeId,
+      requesterAuthSessionHash: authSessionHash(req),
+      now: now(),
+    });
+    if (result.ok === false) {
+      sendRelayError(res, relayErrorForConfirmationFailure(result));
+      return;
+    }
+    res.json({
+      confirmationToken: result.confirmationToken,
+      challenge: publicChallenge(result.challenge),
+    });
+  });
+
   router.post('/hub/confirmations/:challengeId/approve', requireAuth, (req, res) => {
     const { challengeId } = req.params;
     const body = bodyRecord(req);

--- a/test/api-error.test.ts
+++ b/test/api-error.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  ConfirmationRequiredError,
   createSession,
   HttpError,
   killSession,
 } from '../frontend/src/lib/api.js';
+import {
+  clearConfirmationRetry,
+  getConfirmationRetry,
+} from '../frontend/src/lib/confirmation-retries.js';
 
 describe('frontend api errors', () => {
   afterEach(() => {
@@ -108,6 +113,77 @@ describe('frontend api errors', () => {
     });
   });
 
+  it('registers confirmation retries with the exact original session-create params', async () => {
+    const challenge = {
+      challengeId: 'challenge-1',
+      status: 'pending',
+      nodeId: 'node-a',
+      intent: { action: 'sessions.create', target: 'node-a' },
+      requiredBits: ['session:create:terminal'],
+      challengeBits: ['session:create:terminal'],
+      canonicalParams: {
+        action: 'sessions.create',
+        type: 'terminal',
+        cwd: '/home/relay/project',
+      },
+      canonicalParamsHash: 'hash-1',
+      createdAt: '2026-05-16T00:00:00.000Z',
+      expiresAt: '2026-05-16T00:05:00.000Z',
+      failedRedemptions: 0,
+      maxFailedRedemptions: 3,
+      reasonCode: 'CONFIRMATION_REQUIRED',
+      message: 'confirmation required',
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'CONFIRMATION_REQUIRED',
+              message: 'confirmation required',
+              retryable: false,
+              details: { reasonCode: 'CONFIRMATION_REQUIRED', challenge },
+            },
+          }),
+          { status: 409, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'remote-session-1' }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      createSession({
+        nodeId: 'node-a',
+        cwd: '/home/relay/project',
+        type: 'terminal',
+        sessionLane: 'remote-cwd',
+      })
+    ).rejects.toBeInstanceOf(ConfirmationRequiredError);
+
+    const retry = getConfirmationRetry('challenge-1');
+    expect(retry?.paramsHash).toBe('hash-1');
+    await retry?.retry('token-1');
+
+    expect(fetchMock).toHaveBeenLastCalledWith('/hub/nodes/node-a/sessions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        cwd: '/home/relay/project',
+        type: 'terminal',
+        sessionLane: 'remote-cwd',
+        confirmationToken: 'token-1',
+      }),
+    });
+
+    clearConfirmationRetry('challenge-1');
+  });
+
   it('preserves local session lane markers in create payloads', async () => {
     const fetchMock = vi.fn(
       async () =>
@@ -147,6 +223,63 @@ describe('frontend api errors', () => {
       '/hub/nodes/node-a/sessions/remote-session-1',
       { method: 'DELETE' }
     );
+  });
+
+  it('registers remote kill confirmation retries with the token header', async () => {
+    const challenge = {
+      challengeId: 'kill-challenge-1',
+      status: 'pending',
+      nodeId: 'node-a',
+      intent: { action: 'sessions.kill', target: 'node-a' },
+      requiredBits: ['session:attach'],
+      challengeBits: ['session:attach'],
+      sessionId: 'remote-session-1',
+      canonicalParams: { action: 'sessions.kill', method: 'DELETE' },
+      canonicalParamsHash: 'kill-hash-1',
+      createdAt: '2026-05-16T00:00:00.000Z',
+      expiresAt: '2026-05-16T00:05:00.000Z',
+      failedRedemptions: 0,
+      maxFailedRedemptions: 3,
+      reasonCode: 'CONFIRMATION_REQUIRED',
+      message: 'confirmation required',
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'CONFIRMATION_REQUIRED',
+              message: 'confirmation required',
+              retryable: false,
+              details: { reasonCode: 'CONFIRMATION_REQUIRED', challenge },
+            },
+          }),
+          { status: 409, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(killSession('remote-session-1', 'node-a')).rejects.toBeInstanceOf(
+      ConfirmationRequiredError
+    );
+    await getConfirmationRetry('kill-challenge-1')?.retry('kill-token-1');
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/hub/nodes/node-a/sessions/remote-session-1',
+      {
+        method: 'DELETE',
+        headers: { 'x-confirmation-token': 'kill-token-1' },
+      }
+    );
+
+    clearConfirmationRetry('kill-challenge-1');
   });
 
   it('keeps local session delete on the local sessions route', async () => {

--- a/test/api-error.test.ts
+++ b/test/api-error.test.ts
@@ -3,11 +3,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   ConfirmationRequiredError,
   createSession,
+  fetchConfirmationRequesterToken,
   HttpError,
   killSession,
+  type ConfirmationChallenge,
 } from '../frontend/src/lib/api.js';
 import {
   clearConfirmationRetry,
+  createConfirmationRetryRegistry,
   getConfirmationRetry,
 } from '../frontend/src/lib/confirmation-retries.js';
 
@@ -182,6 +185,60 @@ describe('frontend api errors', () => {
     });
 
     clearConfirmationRetry('challenge-1');
+  });
+
+  it('hands approved tokens to the requester registry, not the approver registry', async () => {
+    const requesterRegistry = createConfirmationRetryRegistry();
+    const approverRegistry = createConfirmationRetryRegistry();
+    const approvedChallenge: ConfirmationChallenge = {
+      challengeId: 'challenge-1',
+      status: 'approved',
+      nodeId: 'node-a',
+      intent: { action: 'sessions.create', target: 'node-a' },
+      requiredBits: ['session:create:terminal'],
+      challengeBits: ['session:create:terminal'],
+      canonicalParams: {
+        action: 'sessions.create',
+        type: 'terminal',
+        cwd: '/home/relay/project',
+      },
+      canonicalParamsHash: 'hash-1',
+      createdAt: '2026-05-16T00:00:00.000Z',
+      expiresAt: '2026-05-16T00:05:00.000Z',
+      approvedAt: '2026-05-16T00:01:00.000Z',
+      tokenExpiresAt: '2026-05-16T00:02:00.000Z',
+      failedRedemptions: 0,
+      maxFailedRedemptions: 3,
+      reasonCode: 'CONFIRMATION_APPROVED',
+      message: 'confirmation approved',
+    };
+    const retry = vi.fn(async () => ({ id: 'remote-session-1' }));
+    requesterRegistry.registerConfirmationRetry({
+      challenge: approvedChallenge,
+      label: 'sessions.create',
+      paramsHash: 'hash-1',
+      retry,
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({ confirmationToken: 'requester-token-1', challenge: approvedChallenge }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } }
+          )
+      )
+    );
+
+    expect(approverRegistry.getConfirmationRetry('challenge-1')).toBeUndefined();
+    const pickup = await fetchConfirmationRequesterToken('challenge-1');
+    await requesterRegistry.retryConfirmedOperation(pickup.challenge, pickup.confirmationToken);
+
+    expect(fetch).toHaveBeenCalledWith('/hub/confirmations/challenge-1/requester-token', {
+      method: 'POST',
+    });
+    expect(retry).toHaveBeenCalledWith('requester-token-1');
+    expect(requesterRegistry.getConfirmationRetry('challenge-1')).toBeUndefined();
   });
 
   it('preserves local session lane markers in create payloads', async () => {

--- a/test/confirmation-challenges.test.ts
+++ b/test/confirmation-challenges.test.ts
@@ -128,10 +128,28 @@ describe('confirmation challenge store', () => {
     if (!approved.ok) throw new Error('expected approval');
     expect(approved.confirmationToken).toBe('raw-token');
     expect(approved.challenge.tokenHash).not.toBe('raw-token');
+    expect(approved.challenge.requesterToken).toBe('raw-token');
     expect(approved.challenge.approverAuthSessionHash).toBe('approver-session');
     expect(approved.audit.peer.principalHash).toBe('approver-session');
     expect(approved.audit.peer.principalHash).not.toBe('requester-session');
     expect(approved.audit.peer.displayName).toBe('second browser');
+
+    const approverPickup = store.getRequesterToken({
+      challengeId: challenge.challengeId,
+      requesterAuthSessionHash: 'approver-session',
+      now: NOW,
+    });
+    expect(approverPickup.ok).toBe(false);
+    if (!approverPickup.ok) expect(approverPickup.reasonCode).toBe('CONFIRMATION_REQUESTER_MISMATCH');
+
+    const requesterPickup = store.getRequesterToken({
+      challengeId: challenge.challengeId,
+      requesterAuthSessionHash: 'requester-session',
+      now: NOW,
+    });
+    expect(requesterPickup.ok).toBe(true);
+    if (!requesterPickup.ok) throw new Error('expected requester token pickup');
+    expect(requesterPickup.confirmationToken).toBe('raw-token');
 
     const mismatch = store.redeemToken({
       token: 'raw-token',
@@ -165,6 +183,7 @@ describe('confirmation challenge store', () => {
     if (!redeemed.ok) throw new Error('expected redemption');
     expect(redeemed.audit.peer.principalHash).toBe('requester-session');
     expect(redeemed.audit.peer.principalHash).not.toBe('approver-session');
+    expect(redeemed.challenge.requesterToken).toBeUndefined();
 
     const usedAgain = store.redeemToken({
       token: 'raw-token',

--- a/test/hub-confirmation-routing.test.ts
+++ b/test/hub-confirmation-routing.test.ts
@@ -313,6 +313,37 @@ describe('hub confirmation routing', () => {
       challenge: { challengeId: 'challenge-1', status: 'approved' },
     });
 
+    const wrongRequesterPickup = await fetch(
+      `${base}/hub/confirmations/challenge-1/requester-token`,
+      {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-test-auth': 'yes',
+          'x-auth-session': 'approver-browser',
+        },
+      }
+    );
+    expect(wrongRequesterPickup.status).toBe(401);
+    expect(await wrongRequesterPickup.json()).toMatchObject({
+      error: { details: { reasonCode: 'CONFIRMATION_REQUESTER_MISMATCH' } },
+    });
+
+    const requesterPickup = await fetch(`${base}/hub/confirmations/challenge-1/requester-token`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+      },
+    });
+    expect(requesterPickup.status).toBe(200);
+    const requesterPickupJson = await requesterPickup.json();
+    expect(requesterPickupJson).toMatchObject({
+      confirmationToken: 'raw-confirmation-token',
+      challenge: { challengeId: 'challenge-1', status: 'approved' },
+    });
+
     const tampered = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
       method: 'POST',
       headers: {

--- a/test/hub-confirmation-routing.test.ts
+++ b/test/hub-confirmation-routing.test.ts
@@ -431,6 +431,75 @@ describe('hub confirmation routing', () => {
     expect(nodeLinks.requests).toHaveLength(0);
   });
 
+  it('invalidates an approved requester token when approval audit append fails closed', async () => {
+    const auditEntries: Parameters<RoutedSessionAuditSink['append']>[0][] = [];
+    const { base, nodeLinks } = await startHub({
+      auditSink: {
+        append: (entry) => {
+          if (entry.eventType === 'approval') throw new Error('approval audit sink unavailable');
+          auditEntries.push(entry);
+        },
+      },
+    });
+    const originalBody = { repoPath: '/srv/relay-ide', type: 'terminal' };
+    const response = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+      },
+      body: JSON.stringify(originalBody),
+    });
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      error: { details: { reasonCode: 'CONFIRMATION_REQUIRED' } },
+    });
+
+    const approval = await fetch(`${base}/hub/confirmations/challenge-1/approve`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'approver-browser',
+      },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+    expect(approval.status).toBe(500);
+    expect(await approval.json()).toMatchObject({
+      error: { code: 'INTERNAL', details: { reasonCode: 'POLICY_AUDIT_WRITE_FAILED_CLOSED' } },
+    });
+
+    const requesterPickup = await fetch(`${base}/hub/confirmations/challenge-1/requester-token`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+      },
+    });
+    expect(requesterPickup.status).toBe(401);
+    expect(await requesterPickup.json()).toMatchObject({
+      error: { details: { reasonCode: 'CONFIRMATION_NOT_APPROVED' } },
+    });
+
+    const redeemed = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+      },
+      body: JSON.stringify({ ...originalBody, confirmationToken: 'raw-confirmation-token' }),
+    });
+    expect(redeemed.status).toBe(401);
+    expect(await redeemed.json()).toMatchObject({
+      error: { details: { reasonCode: 'CONFIRMATION_TOKEN_INVALID' } },
+    });
+    expect(nodeLinks.requests).toHaveLength(0);
+    expect(auditEntries.map((entry) => entry.eventType)).toEqual(['challenge']);
+  });
+
   it('requires the same two-token confirmation flow for repo cold reopen sessions.create', async () => {
     const { base, nodeLinks, auditEntries } = await startColdReopenHub();
     const reopenBody = {


### PR DESCRIPTION
## Summary
- Adds a global operator confirmation prompt that polls hub confirmation challenges and shows node, intent, required/challenge bits, canonical params/hash, expiration, requester/approver metadata, and status text.
- Adds approve, deny, and deny+revoke actions, with same-session/self-approval failures displayed inline.
- Registers exact-params retries for confirmed remote session create/delete flows and adds a backend-mediated requester-token pickup route so the original requester browser can redeem the approved single-use token even when approval happens in a separate browser/auth session.

## Motivation
PR #521 adds the backend/API confirmation challenge flow for #497. This stacked PR completes the browser/operator handoff: the approver can approve from a distinct session, while the requester browser that owns the original exact retry receives the token and replays only the registered params.

## The Case Against
This change adds a small backend/API glue endpoint to what started as a frontend prompt PR. That is intentional because the prior design returned the token only to the approver browser, which cannot legally redeem it and does not have the requester retry registry. The endpoint stores the raw token in the in-memory challenge until requester pickup/redeem/expiry, which is less minimal than token-hash-only storage, but the token is still only returned to the original requester auth-session and redemption remains single-use and exact-param-bound.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Replaying the wrong operation after approval | Retry registrations are keyed by challenge ID and verify the returned canonical params hash before replaying. |
| Approver steals/redeems the requester token | `/hub/confirmations/:id/requester-token` requires the original requester auth-session hash; approver pickup returns `CONFIRMATION_REQUESTER_MISMATCH`. |
| Self-approval failure looks like a generic auth error | Structured backend error details are preserved in `HttpError` and surfaced in the prompt. |
| Token placement mismatch | Session create retries append `confirmationToken` to the original body; remote session delete retries send `x-confirmation-token` on the original DELETE path. |
| Prompt UI blocks normal app empty state | Prompt remains fixed in the lower-right with responsive sizing and leaves the baseline empty repo state usable. |

## Verification
- `npm test -- test/api-error.test.ts test/confirmation-challenges.test.ts test/hub-confirmation-routing.test.ts` — 19/19 passed.
- `npm run check` — passed with 44 warnings, 0 errors (existing lint-warning baseline plus current stack).
- `npm run build` — passed; existing Vite chunk-size warnings only.

Closes #497
Stacked on #521.
