### PR TITLE
feat: surface tab control state

### DIFF
--- a/frontend/src/components/InterventionStrip.css
+++ b/frontend/src/components/InterventionStrip.css
@@ -1,0 +1,111 @@
+.intervention-strip {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+  min-height: 30px;
+  padding: 4px 8px;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  overflow: hidden;
+}
+
+.intervention-strip__state {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.intervention-strip__detail {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.intervention-strip__events {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 160px;
+  overflow: hidden;
+}
+
+.intervention-strip__event {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 160px;
+  padding: 2px 5px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.intervention-strip__event--human-input,
+.intervention-strip__event--take-over {
+  border-color: color-mix(in srgb, var(--status-info) 45%, transparent);
+  color: var(--status-info);
+}
+
+.intervention-strip__event--hand-back {
+  border-color: color-mix(in srgb, var(--status-success) 45%, transparent);
+  color: var(--status-success);
+}
+
+.intervention-strip__event--auto-revert {
+  border-color: color-mix(in srgb, var(--status-warning) 45%, transparent);
+  color: var(--status-warning);
+}
+
+.intervention-strip__event-time,
+.intervention-strip__event-mode {
+  color: var(--text-muted);
+}
+
+.intervention-strip__empty,
+.intervention-strip__note {
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.intervention-strip__actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.intervention-strip__action {
+  min-height: 24px;
+  padding: 2px 8px;
+  border: 1px solid var(--accent);
+  border-radius: 0;
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  cursor: pointer;
+}
+
+.intervention-strip__action:hover,
+.intervention-strip__action:focus-visible {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  outline: none;
+}
+
+@media (max-width: 760px) {
+  .intervention-strip {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .intervention-strip__events {
+    order: 3;
+    flex-basis: 100%;
+  }
+}

--- a/frontend/src/components/InterventionStrip.tsx
+++ b/frontend/src/components/InterventionStrip.tsx
@@ -1,0 +1,175 @@
+import { useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
+import type { InterventionRecord } from '../../../shared/control-state.js';
+import {
+  canHandBackToAgent,
+  controlBadgeView,
+  interventionLabel,
+  interventionTitle,
+  mergeInterventions,
+} from '../lib/control-display.js';
+import { fetchSessionInterventions, handBackSessionControl } from '../lib/api.js';
+import { useSessionsStore } from '../lib/stores/sessions.js';
+import type { NodeBadge } from '../lib/workspace-summary.js';
+import type { SessionSummary } from '../lib/types.js';
+import TabControlBadge from './TabControlBadge.js';
+import './InterventionStrip.css';
+
+export interface InterventionStripProps {
+  session?: SessionSummary | undefined;
+  nodeBadge?: NodeBadge | undefined;
+}
+
+function isRemoteSession(session: SessionSummary | undefined): boolean {
+  return !!session?.nodeId && session.nodeId !== DEFAULT_LOCAL_NODE_ID;
+}
+
+function shortTime(value: string): string {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value;
+  return new Date(parsed).toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function sessionCacheKey(session: SessionSummary | undefined): string | null {
+  if (!session) return null;
+  return session.globalSessionId ?? `${session.nodeId ?? DEFAULT_LOCAL_NODE_ID}:${session.id}`;
+}
+
+function shouldConfirmHandBack(session: SessionSummary): boolean {
+  if (!session.lastInterventionAt) return false;
+  const touchedAt = Date.parse(session.lastInterventionAt);
+  if (!Number.isFinite(touchedAt)) return true;
+  return Date.now() - touchedAt < 5 * 60_000;
+}
+
+function InterventionItem({ record }: { record: InterventionRecord }) {
+  const label = interventionLabel(record);
+  return (
+    <span
+      className={`intervention-strip__event intervention-strip__event--${record.kind}`}
+      title={interventionTitle(record)}
+    >
+      <span className="intervention-strip__event-time">{shortTime(record.timestamp)}</span>
+      <span className="intervention-strip__event-label">{label}</span>
+      {record.modeAfter && record.modeAfter !== record.modeBefore && (
+        <span className="intervention-strip__event-mode">
+          {record.modeBefore.replace('-driven', '')}→{record.modeAfter.replace('-driven', '')}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export function InterventionStrip({ session, nodeBadge }: InterventionStripProps) {
+  const cacheKey = sessionCacheKey(session);
+  const cachedRecords = useSessionsStore((state) =>
+    cacheKey ? (state.interventionsBySession[cacheKey] ?? []) : []
+  );
+  const refreshAll = useSessionsStore((state) => state.refreshAll);
+  const queryClient = useQueryClient();
+  const remote = isRemoteSession(session);
+  const [actionMessage, setActionMessage] = useState<string | null>(null);
+
+  const interventionsQuery = useQuery({
+    queryKey: [
+      'session-interventions',
+      session?.id ?? null,
+      session?.lastInterventionEventId ?? null,
+    ],
+    queryFn: () => fetchSessionInterventions(session!.id, 12),
+    enabled: !!session && !remote,
+    staleTime: 15_000,
+  });
+
+  const records = useMemo(
+    () =>
+      mergeInterventions(
+        cachedRecords,
+        interventionsQuery.data?.interventions ?? []
+      ).slice(0, 4),
+    [cachedRecords, interventionsQuery.data?.interventions]
+  );
+
+  if (!session) return null;
+
+  const view = controlBadgeView(session, nodeBadge);
+  const canHandBack = canHandBackToAgent(session) && !remote;
+  const detailParts = [
+    `actors ${view.actorSummary}`,
+    `node ${view.nodeSummary}`,
+    `last touch ${view.lastTouchSummary}`,
+  ];
+  if (view.reason) detailParts.push(view.reason);
+
+  const handleHandBack = async () => {
+    if (!session.lastInterventionEventId) return;
+    if (
+      shouldConfirmHandBack(session) &&
+      !window.confirm(
+        'hand control back to the agent after the latest human input?'
+      )
+    ) {
+      return;
+    }
+    setActionMessage('handing back...');
+    try {
+      await handBackSessionControl({
+        sessionId: session.id,
+        latestSeenInterventionEventId: session.lastInterventionEventId,
+        actor: { kind: 'human', id: 'browser-user', displayName: 'browser user' },
+      });
+      setActionMessage('handed back');
+      await queryClient.invalidateQueries({ queryKey: ['session-interventions'] });
+      void refreshAll();
+    } catch (err) {
+      setActionMessage(err instanceof Error ? err.message : 'hand-back failed');
+    }
+  };
+
+  return (
+    <div className="intervention-strip" aria-label="tab control and interventions">
+      <div className="intervention-strip__state">
+        <TabControlBadge session={session} nodeBadge={nodeBadge} />
+        <span className="intervention-strip__detail" title={view.title}>
+          {detailParts.join(' · ')}
+        </span>
+      </div>
+      <div className="intervention-strip__events" aria-label="recent human touch">
+        {interventionsQuery.isLoading && !remote && records.length === 0 ? (
+          <span className="intervention-strip__empty">loading touch events</span>
+        ) : records.length > 0 ? (
+          records.map((record) => <InterventionItem key={record.id} record={record} />)
+        ) : remote ? (
+          <span className="intervention-strip__empty">
+            remote touch history unavailable until node intervention rpc lands
+          </span>
+        ) : (
+          <span className="intervention-strip__empty">no recent human touch</span>
+        )}
+      </div>
+      <div className="intervention-strip__actions">
+        {canHandBack && (
+          <button
+            type="button"
+            className="intervention-strip__action"
+            onClick={handleHandBack}
+          >
+            hand back
+          </button>
+        )}
+        {remote && session.controlFreshness !== 'fresh' && (
+          <span className="intervention-strip__note">controls unavailable while remote state is {session.controlFreshness ?? 'unknown'}</span>
+        )}
+        {actionMessage && (
+          <span className="intervention-strip__note">{actionMessage}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default InterventionStrip;

--- a/frontend/src/components/InterventionStrip.tsx
+++ b/frontend/src/components/InterventionStrip.tsx
@@ -16,6 +16,8 @@ import type { SessionSummary } from '../lib/types.js';
 import TabControlBadge from './TabControlBadge.js';
 import './InterventionStrip.css';
 
+const EMPTY_INTERVENTIONS: InterventionRecord[] = [];
+
 export interface InterventionStripProps {
   session?: SessionSummary | undefined;
   nodeBadge?: NodeBadge | undefined;
@@ -67,7 +69,9 @@ function InterventionItem({ record }: { record: InterventionRecord }) {
 export function InterventionStrip({ session, nodeBadge }: InterventionStripProps) {
   const cacheKey = sessionCacheKey(session);
   const cachedRecords = useSessionsStore((state) =>
-    cacheKey ? (state.interventionsBySession[cacheKey] ?? []) : []
+    cacheKey
+      ? (state.interventionsBySession[cacheKey] ?? EMPTY_INTERVENTIONS)
+      : EMPTY_INTERVENTIONS
   );
   const refreshAll = useSessionsStore((state) => state.refreshAll);
   const queryClient = useQueryClient();

--- a/frontend/src/components/TabControlBadge.css
+++ b/frontend/src/components/TabControlBadge.css
@@ -1,0 +1,48 @@
+.tab-control-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
+  padding: 0 5px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  line-height: 1;
+  text-transform: lowercase;
+  white-space: nowrap;
+}
+
+.tab-control-badge--agent-driven {
+  border-color: color-mix(in srgb, var(--status-success) 50%, transparent);
+  color: var(--status-success);
+}
+
+.tab-control-badge--human-driven {
+  border-color: color-mix(in srgb, var(--status-info) 55%, transparent);
+  color: var(--status-info);
+}
+
+.tab-control-badge--co-driven {
+  border-color: color-mix(in srgb, var(--accent) 60%, transparent);
+  color: var(--accent);
+}
+
+.tab-control-badge--stale {
+  border-color: color-mix(in srgb, var(--status-warning) 55%, transparent);
+  color: var(--status-warning);
+}
+
+.tab-control-badge--unknown {
+  border-color: var(--border);
+  color: var(--text-muted);
+}
+
+.tab-control-badge--compact {
+  min-height: 16px;
+  padding: 0 4px;
+}
+
+.tab-control-badge__label {
+  display: inline-block;
+}

--- a/frontend/src/components/TabControlBadge.tsx
+++ b/frontend/src/components/TabControlBadge.tsx
@@ -1,0 +1,36 @@
+import type { NodeBadge } from '../lib/workspace-summary.js';
+import type { SessionSummary } from '../lib/types.js';
+import { controlBadgeView } from '../lib/control-display.js';
+import './TabControlBadge.css';
+
+export interface TabControlBadgeProps {
+  session?: SessionSummary | undefined;
+  nodeBadge?: NodeBadge | undefined;
+  compact?: boolean;
+}
+
+export function TabControlBadge({
+  session,
+  nodeBadge,
+  compact = false,
+}: TabControlBadgeProps) {
+  const view = controlBadgeView(session, nodeBadge);
+  return (
+    <span
+      className={[
+        'tab-control-badge',
+        `tab-control-badge--${view.mode}`,
+        compact ? 'tab-control-badge--compact' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      title={view.title}
+      aria-label={view.ariaLabel}
+      data-control-mode={view.mode}
+    >
+      <span className="tab-control-badge__label">{view.label}</span>
+    </span>
+  );
+}
+
+export default TabControlBadge;

--- a/frontend/src/components/WorkspacePane.tsx
+++ b/frontend/src/components/WorkspacePane.tsx
@@ -16,16 +16,19 @@ import {
 } from '../lib/workspace-summary.js';
 import { WorkspaceTabBar } from './WorkspaceTabBar.js';
 import { WorkspaceDropOverlay } from './WorkspaceDropOverlay.js';
+import InterventionStrip from './InterventionStrip.js';
 import './WorkspacePane.css';
 
 interface WorkspacePaneSummaryStripProps {
   tab: WorkspaceTab;
   summary: WorkspaceTabSummary;
+  summaryContext: SummaryContext;
 }
 
 function WorkspacePaneSummaryStrip({
   tab,
   summary,
+  summaryContext,
 }: WorkspacePaneSummaryStripProps) {
   if (tab.kind === 'file') {
     const segments = summary.breadcrumb?.segments ?? [];
@@ -79,18 +82,22 @@ function WorkspacePaneSummaryStrip({
       </div>
     );
   }
+  const session = summaryContext.findSession?.(tab.sessionId);
   return (
-    <div className="ws-pane__summary ws-pane__summary--session">
-      <span className="ws-pane__summary-title">{summary.primary}</span>
-      {summary.meta && (
-        <span className="ws-pane__summary-meta">{summary.meta}</span>
-      )}
-      {summary.dot && (
-        <span
-          className={`ws-pane__summary-dot ws-pane__summary-dot--${summary.dot}`}
-        />
-      )}
-    </div>
+    <>
+      <div className="ws-pane__summary ws-pane__summary--session">
+        <span className="ws-pane__summary-title">{summary.primary}</span>
+        {summary.meta && (
+          <span className="ws-pane__summary-meta">{summary.meta}</span>
+        )}
+        {summary.dot && (
+          <span
+            className={`ws-pane__summary-dot ws-pane__summary-dot--${summary.dot}`}
+          />
+        )}
+      </div>
+      <InterventionStrip session={session} nodeBadge={summary.nodeBadge} />
+    </>
   );
 }
 
@@ -155,7 +162,11 @@ function WorkspacePaneImpl({
           : {})}
       />
       {activeTab && activeSummary && (
-        <WorkspacePaneSummaryStrip tab={activeTab} summary={activeSummary} />
+        <WorkspacePaneSummaryStrip
+          tab={activeTab}
+          summary={activeSummary}
+          summaryContext={summaryContext}
+        />
       )}
       <div className="ws-pane__body-wrap">
         <div className="ws-pane__body" ref={bodyRef} role="tabpanel">

--- a/frontend/src/components/WorkspaceTabBar.tsx
+++ b/frontend/src/components/WorkspaceTabBar.tsx
@@ -11,6 +11,7 @@ import {
   type SummaryContext,
   type WorkspaceTabSummary,
 } from '../lib/workspace-summary.js';
+import { TabControlBadge } from './TabControlBadge.js';
 import './WorkspaceTabBar.css';
 
 const ICON_GLYPH: Record<WorkspaceTabSummary['icon'], string> = {
@@ -41,6 +42,7 @@ interface WorkspaceTabItemProps {
   paneId: string;
   isActive: boolean;
   summary: WorkspaceTabSummary;
+  summaryContext: SummaryContext;
   onSelect: () => void;
   onClose: () => void;
 }
@@ -50,6 +52,7 @@ function WorkspaceTabItem({
   paneId,
   isActive,
   summary,
+  summaryContext,
   onSelect,
   onClose,
 }: WorkspaceTabItemProps) {
@@ -67,6 +70,8 @@ function WorkspaceTabItem({
   ]
     .filter(Boolean)
     .join(' ');
+  const session =
+    tab.kind === 'session' ? summaryContext.findSession?.(tab.sessionId) : undefined;
 
   return (
     <div
@@ -94,6 +99,13 @@ function WorkspaceTabItem({
       </span>
       <span className="ws-tab__name">{summary.primary}</span>
       {summary.meta && <span className="ws-tab__meta">{summary.meta}</span>}
+      {tab.kind === 'session' && (
+        <TabControlBadge
+          session={session}
+          nodeBadge={summary.nodeBadge}
+          compact
+        />
+      )}
       {summary.nodeBadge && (
         <span
           className={`ws-tab__node ws-tab__node--${summary.nodeBadge.status}`}
@@ -176,6 +188,7 @@ export function WorkspaceTabBar({
             paneId={pane.id}
             isActive={pane.activeTabId === tabId}
             summary={summary}
+            summaryContext={summaryContext}
             onSelect={() => onSelectTab(tabId)}
             onClose={() => onCloseTab(tabId)}
           />

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -307,6 +307,10 @@ export function useEventSocket({
             eventSessionScope(msg)
           );
       },
+      'tab-control-event': (msg) => {
+        useSessionsStore.getState().handleTabControlEvent(msg.event);
+        queryClient.invalidateQueries({ queryKey: ['session-interventions'] });
+      },
       'account-telemetry': (msg) => {
         useTelemetryStore
           .getState()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -38,6 +38,7 @@ import {
   type NodeId,
 } from '../../../shared/identity.js';
 import type { SessionLane } from '../../../shared/session-lane.js';
+import type { ControlActor, InterventionRecord } from '../../../shared/control-state.js';
 import { registerConfirmationRetry } from './confirmation-retries.js';
 
 export class ConflictError extends Error {
@@ -333,6 +334,48 @@ export async function setupPin(pin: string, confirm: string): Promise<void> {
 
 export async function fetchSessions(): Promise<SessionSummary[]> {
   return json<SessionSummary[]>(await fetch('/sessions'));
+}
+
+export interface InterventionReadResponse {
+  interventions: InterventionRecord[];
+  count: number;
+  limit: number;
+  truncated: boolean;
+  rawPayloadAvailable: false;
+  transcriptExportAvailable: false;
+  redaction: {
+    payload: 'preview-only';
+    metadataIncluded: true;
+  };
+}
+
+export async function fetchSessionInterventions(
+  sessionId: string,
+  limit = 12
+): Promise<InterventionReadResponse> {
+  const query = new URLSearchParams({ limit: String(limit) });
+  return json<InterventionReadResponse>(
+    await fetch(
+      `/sessions/${encodeURIComponent(sessionId)}/interventions?${query.toString()}`
+    )
+  );
+}
+
+export async function handBackSessionControl(input: {
+  sessionId: string;
+  latestSeenInterventionEventId: string;
+  actor?: ControlActor;
+}): Promise<{ ok: true; events: unknown[]; ackedHumanInterventions: InterventionRecord[] }> {
+  return json<{ ok: true; events: unknown[]; ackedHumanInterventions: InterventionRecord[] }>(
+    await fetch(`/sessions/${encodeURIComponent(input.sessionId)}/control/hand-back`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        latestSeenInterventionEventId: input.latestSeenInterventionEventId,
+        ...(input.actor ? { actor: input.actor } : {}),
+      }),
+    })
+  );
 }
 
 export async function fetchHubNodes(): Promise<HubNodeSummary[]> {

--- a/frontend/src/lib/control-display.ts
+++ b/frontend/src/lib/control-display.ts
@@ -1,0 +1,135 @@
+import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
+import type {
+  ControlActor,
+  ControlFreshness,
+  ControlMode,
+  InterventionRecord,
+} from '../../../shared/control-state.js';
+import type { NodeBadge } from './workspace-summary.js';
+import type { SessionSummary } from './types.js';
+
+export type ControlDisplayMode = ControlMode | 'stale' | 'unknown';
+
+export interface ControlBadgeView {
+  mode: ControlDisplayMode;
+  label: 'agent' | 'human' | 'co' | 'stale' | 'unknown';
+  ariaLabel: string;
+  title: string;
+  actorSummary: string;
+  nodeSummary: string;
+  lastTouchSummary: string;
+  reason?: string;
+}
+
+export const CONTROL_BADGE_LABEL: Record<ControlDisplayMode, ControlBadgeView['label']> = {
+  'agent-driven': 'agent',
+  'human-driven': 'human',
+  'co-driven': 'co',
+  stale: 'stale',
+  unknown: 'unknown',
+};
+
+export function actorLabel(actor: ControlActor | null | undefined): string {
+  if (!actor) return 'none';
+  return actor.displayName ?? actor.id ?? actor.kind;
+}
+
+export function actorListLabel(actors: ControlActor[] | undefined): string {
+  if (!actors || actors.length === 0) return 'none';
+  return actors.map(actorLabel).join(', ');
+}
+
+function displayModeFor(
+  mode: ControlMode | undefined,
+  freshness: ControlFreshness | undefined
+): ControlDisplayMode {
+  if (!mode || !freshness) return 'unknown';
+  if (freshness === 'stale') return 'stale';
+  if (freshness === 'unknown') return 'unknown';
+  return mode;
+}
+
+function nodeLabelFor(session: SessionSummary | undefined, nodeBadge?: NodeBadge): string {
+  const nodeId = session?.nodeId;
+  if (!nodeId || nodeId === DEFAULT_LOCAL_NODE_ID) return 'this host';
+  return nodeBadge ? `${nodeBadge.label} (${nodeBadge.status})` : nodeId;
+}
+
+export function formatControlTimestamp(value: string | null | undefined): string {
+  if (!value) return 'none';
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value;
+  return new Date(parsed).toLocaleString();
+}
+
+export function controlBadgeView(
+  session: SessionSummary | undefined,
+  nodeBadge?: NodeBadge
+): ControlBadgeView {
+  const mode = displayModeFor(session?.controlMode, session?.controlFreshness);
+  const label = CONTROL_BADGE_LABEL[mode];
+  const actorSummary = actorListLabel(session?.activeActors);
+  const nodeSummary = nodeLabelFor(session, nodeBadge);
+  const lastTouchSummary = session?.lastInterventionAt
+    ? `${actorLabel(session.lastInterventionBy)} @ ${formatControlTimestamp(session.lastInterventionAt)}`
+    : 'none';
+  const reason = session?.controlReason;
+  const titleParts = [
+    `control: ${label}`,
+    `actors: ${actorSummary}`,
+    `node: ${nodeSummary}`,
+    `freshness: ${session?.controlFreshness ?? 'unknown'}`,
+    `last human touch: ${lastTouchSummary}`,
+  ];
+  if (reason) titleParts.push(`reason: ${reason}`);
+  return {
+    mode,
+    label,
+    ariaLabel: `control mode ${label}`,
+    title: titleParts.join('\n'),
+    actorSummary,
+    nodeSummary,
+    lastTouchSummary,
+    ...(reason ? { reason } : {}),
+  };
+}
+
+export function canHandBackToAgent(session: SessionSummary | undefined): boolean {
+  if (!session) return false;
+  if (session.status === 'disconnected') return false;
+  if (session.controlFreshness !== 'fresh') return false;
+  if (!session.lastInterventionEventId) return false;
+  return session.controlMode === 'human-driven' || session.controlMode === 'co-driven';
+}
+
+export function interventionLabel(record: InterventionRecord): string {
+  if (record.kind === 'human-input') return 'input';
+  if (record.kind === 'take-over') return 'take-over';
+  if (record.kind === 'hand-back') return 'hand-back';
+  if (record.kind === 'auto-revert') return 'auto-revert';
+  return 'join';
+}
+
+export function interventionTitle(record: InterventionRecord): string {
+  const parts = [
+    `${interventionLabel(record)} by ${actorLabel(record.author)}`,
+    `${record.modeBefore}${record.modeAfter ? ` -> ${record.modeAfter}` : ''}`,
+    `at ${formatControlTimestamp(record.timestamp)}`,
+  ];
+  if (record.payloadPreview) parts.push(`preview: ${record.payloadPreview}`);
+  if (record.redaction.redacted) parts.push('payload redacted');
+  return parts.join('\n');
+}
+
+export function mergeInterventions(
+  primary: InterventionRecord[],
+  secondary: InterventionRecord[]
+): InterventionRecord[] {
+  const byId = new Map<string, InterventionRecord>();
+  for (const record of [...primary, ...secondary]) byId.set(record.id, record);
+  return Array.from(byId.values()).sort((a, b) => {
+    const bTime = Date.parse(b.timestamp);
+    const aTime = Date.parse(a.timestamp);
+    return (Number.isFinite(bTime) ? bTime : 0) - (Number.isFinite(aTime) ? aTime : 0);
+  });
+}

--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -31,12 +31,54 @@ import {
   sessionEventMatches,
   type SessionEventScope,
 } from '../../../../shared/node-boundary.js';
-import type { InterventionRecord, TabControlEvent } from '../../../../shared/control-state.js';
+import {
+  normalizeControlActors,
+  type ControlActor,
+  type InterventionRecord,
+  type TabControlEvent,
+} from '../../../../shared/control-state.js';
 
 const NOTIFICATIONS_STORAGE_KEY = 'claude-remote-notifications';
 const ACTIVE_SESSION_KEY = 'claude-remote-active-session';
 const WORKSPACE_SESSIONS_KEY = 'claude-remote-workspace-sessions';
 const logger = createLogger('sessions');
+
+function eventAgentActor(
+  session: SessionSummary,
+  event: TabControlEvent
+): ControlActor | undefined {
+  return (
+    event.activeWorker ??
+    session.activeWorker ??
+    session.activeActors?.find((actor) => actor.kind === 'agent') ??
+    (event.actor.kind === 'agent' ? event.actor : undefined)
+  );
+}
+
+function activeActorsForControlEvent(
+  session: SessionSummary,
+  event: TabControlEvent
+): ControlActor[] {
+  const eventActors = normalizeControlActors(event.activeActors);
+  if (eventActors.length > 0) return eventActors;
+
+  const agent = eventAgentActor(session, event);
+  if (event.controlMode === 'agent-driven') {
+    return normalizeControlActors([agent ?? event.actor]);
+  }
+  if (event.controlMode === 'human-driven') {
+    return normalizeControlActors([event.actor]);
+  }
+  return normalizeControlActors([event.actor, agent].filter(Boolean));
+}
+
+function activeWorkerForControlEvent(
+  session: SessionSummary,
+  event: TabControlEvent
+): ControlActor | undefined {
+  if (event.controlMode === 'human-driven') return undefined;
+  return eventAgentActor(session, event);
+}
 
 const BOOT_FETCH_TIMEOUT_MS = 10_000;
 export const DEFAULT_ENRICHMENT_TTL_MS = 600_000;
@@ -793,13 +835,18 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
         if (!sessionMatchesEventScope(session, identity.sessionId, scope)) {
           return session;
         }
+        const activeActors = activeActorsForControlEvent(session, event);
+        const activeWorker = activeWorkerForControlEvent(session, event);
         const updated: SessionSummary = {
           ...session,
           controlMode: event.controlMode,
-          activeActors: [event.actor],
+          activeActors,
           controlFreshness: 'fresh',
         };
+        if (activeWorker) updated.activeWorker = activeWorker;
+        else delete updated.activeWorker;
         if (event.reason) updated.controlReason = event.reason;
+        else delete updated.controlReason;
         if (event.type === 'tab.intervention') {
           updated.lastInterventionAt = event.intervention.timestamp;
           updated.lastInterventionBy = event.intervention.author;

--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -31,6 +31,7 @@ import {
   sessionEventMatches,
   type SessionEventScope,
 } from '../../../../shared/node-boundary.js';
+import type { InterventionRecord, TabControlEvent } from '../../../../shared/control-state.js';
 
 const NOTIFICATIONS_STORAGE_KEY = 'claude-remote-notifications';
 const ACTIVE_SESSION_KEY = 'claude-remote-active-session';
@@ -169,6 +170,7 @@ export interface SessionsState {
   repoEnrichmentMeta: Record<string, RepoEnrichmentMeta>;
   reconnectingPtySessionIds: Record<string, true>;
   backendConnectionStatus: BackendConnectionStatus;
+  interventionsBySession: Record<string, InterventionRecord[]>;
   // Actions
   setActiveSessionId: (id: string | null) => void;
   rememberSessionForWorkspace: (
@@ -214,6 +216,7 @@ export interface SessionsState {
     scope?: SessionEventScope
   ) => void;
   handleUserViewed: (sessionId: string, scope?: SessionEventScope) => void;
+  handleTabControlEvent: (event: TabControlEvent) => void;
   setNotificationEnabled: (sessionId: string, enabled: boolean) => void;
   initSessionNotification: (sessionId: string, defaultEnabled: boolean) => void;
   getNotificationSessionIds: () => string[];
@@ -354,6 +357,7 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
   repoEnrichmentMeta: {},
   reconnectingPtySessionIds: {},
   backendConnectionStatus: 'connected',
+  interventionsBySession: {},
 
   setActiveSessionId: (id) => {
     const key = id === null ? null : resolveSessionKey(get().sessions, id);
@@ -771,6 +775,47 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
             isUnread: false,
           };
         }),
+      };
+    });
+  },
+
+  handleTabControlEvent: (event) => {
+    const identity = event.identity;
+    const scope: SessionEventScope = {
+      sessionId: identity.sessionId,
+      localSessionId: identity.sessionId,
+      ...(identity.nodeId ? { nodeId: identity.nodeId } : {}),
+      ...(identity.globalSessionId ? { globalSessionId: identity.globalSessionId } : {}),
+    };
+    const cacheKey = identity.globalSessionId ?? `${identity.nodeId}:${identity.sessionId}`;
+    set((state) => {
+      const sessions = state.sessions.map((session): SessionSummary => {
+        if (!sessionMatchesEventScope(session, identity.sessionId, scope)) {
+          return session;
+        }
+        const updated: SessionSummary = {
+          ...session,
+          controlMode: event.controlMode,
+          activeActors: [event.actor],
+          controlFreshness: 'fresh',
+        };
+        if (event.reason) updated.controlReason = event.reason;
+        if (event.type === 'tab.intervention') {
+          updated.lastInterventionAt = event.intervention.timestamp;
+          updated.lastInterventionBy = event.intervention.author;
+          updated.lastInterventionEventId = event.intervention.id;
+        }
+        return updated;
+      });
+      if (event.type !== 'tab.intervention') return { sessions };
+      const previous = state.interventionsBySession[cacheKey] ?? [];
+      const next = [event.intervention, ...previous.filter((record) => record.id !== event.intervention.id)].slice(0, 12);
+      return {
+        sessions,
+        interventionsBySession: {
+          ...state.interventionsBySession,
+          [cacheKey]: next,
+        },
       };
     });
   },

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -21,6 +21,7 @@ import { createLogger } from './logger.js';
 import { resolveSessionByKey, resolveSessionKey } from './session-keys.js';
 import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
+import type { TabControlEvent } from '../../../shared/control-state.js';
 
 const logger = createLogger('pty-ws');
 const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -94,6 +95,7 @@ export type EventMessage =
       sessionId: string;
       data: SessionTelemetry | Record<string, unknown>;
     } & SessionScopedEvent)
+  | { type: 'tab-control-event'; event: TabControlEvent }
   | {
       type: 'account-telemetry';
       data: AccountTelemetry | Record<string, unknown> | null;

--- a/server/control-engine.ts
+++ b/server/control-engine.ts
@@ -257,6 +257,14 @@ function buildRecord(input: {
   return record;
 }
 
+function eventControlStateFields(session: Session): Pick<ControlStateSummary, 'activeActors' | 'activeWorker'> {
+  const summary = normalizeControlStateSummary(session.controlState);
+  return {
+    activeActors: summary.activeActors,
+    ...(summary.activeWorker ? { activeWorker: summary.activeWorker } : {}),
+  };
+}
+
 function updateControlState(input: {
   session: Session;
   controlMode: ControlMode;
@@ -295,6 +303,7 @@ function emitModeChanged(
     occurredAt: nowIso(options),
     identity: identityForSession(session),
     actor,
+    ...eventControlStateFields(session),
     reason,
     previousControlMode,
     controlMode,
@@ -317,6 +326,7 @@ function emitIntervention(
     occurredAt: record.timestamp,
     identity: identityForSession(session),
     actor,
+    ...eventControlStateFields(session),
     reason,
     controlMode,
     intervention: record,

--- a/shared/control-state.ts
+++ b/shared/control-state.ts
@@ -36,7 +36,12 @@ export interface TabControlEventBase {
   type: TabControlEventType;
   occurredAt: string;
   identity: TabControlIdentity;
+  /** Triggering actor for the event; not necessarily the complete active driver list. */
   actor: ControlActor;
+  /** Effective actors after this event is applied. */
+  activeActors?: ControlActor[];
+  /** Effective agent worker after this event is applied, if agent-visible control remains active. */
+  activeWorker?: ControlActor;
   reason?: string;
 }
 

--- a/test/control-display.test.ts
+++ b/test/control-display.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import type { InterventionRecord } from '../shared/control-state.js';
+import type { SessionSummary } from '../frontend/src/lib/types.js';
+import {
+  canHandBackToAgent,
+  controlBadgeView,
+  mergeInterventions,
+} from '../frontend/src/lib/control-display.js';
+
+const session = (overrides: Partial<SessionSummary>): SessionSummary => ({
+  id: 's1',
+  type: 'agent',
+  agent: 'codex',
+  repoName: 'relay-ide',
+  repoPath: '/repo/relay-ide',
+  worktreePath: null,
+  cwd: '/repo/relay-ide',
+  branchName: 'nightly',
+  displayName: 'agent tab',
+  createdAt: '2026-05-16T00:00:00.000Z',
+  lastActivity: '2026-05-16T00:00:00.000Z',
+  idle: false,
+  ...overrides,
+});
+
+const intervention = (overrides: Partial<InterventionRecord>): InterventionRecord => ({
+  id: 'event-1',
+  sessionId: 's1',
+  tabId: 's1',
+  timestamp: '2026-05-16T00:01:00.000Z',
+  author: { kind: 'human', id: 'human-1', displayName: 'Kyle' },
+  source: 'pty-input',
+  kind: 'human-input',
+  redaction: {
+    redacted: true,
+    byteCount: 12,
+    charCount: 12,
+    lineCount: 1,
+    hashSha256: 'abc',
+    classes: ['input'],
+  },
+  modeBefore: 'agent-driven',
+  modeAfter: 'co-driven',
+  ...overrides,
+});
+
+describe('control badge view', () => {
+  it('maps fresh control modes to compact badge labels', () => {
+    expect(
+      controlBadgeView(
+        session({
+          controlMode: 'agent-driven',
+          controlFreshness: 'fresh',
+          activeActors: [{ kind: 'agent', displayName: 'codex' }],
+        })
+      ).label
+    ).toBe('agent');
+    expect(
+      controlBadgeView(
+        session({
+          controlMode: 'human-driven',
+          controlFreshness: 'fresh',
+          activeActors: [{ kind: 'human', displayName: 'Kyle' }],
+        })
+      ).label
+    ).toBe('human');
+    expect(
+      controlBadgeView(
+        session({
+          controlMode: 'co-driven',
+          controlFreshness: 'fresh',
+          activeActors: [
+            { kind: 'agent', displayName: 'codex' },
+            { kind: 'human', displayName: 'Kyle' },
+          ],
+        })
+      ).label
+    ).toBe('co');
+  });
+
+  it('renders stale and unknown as control-state caution, not repo failures', () => {
+    expect(
+      controlBadgeView(
+        session({
+          controlMode: 'agent-driven',
+          controlFreshness: 'stale',
+          activeActors: [{ kind: 'agent', displayName: 'codex' }],
+        })
+      ).mode
+    ).toBe('stale');
+    expect(controlBadgeView(session({})).mode).toBe('unknown');
+  });
+
+  it('keeps remote/free tab details independent of repo binding', () => {
+    const view = controlBadgeView(
+      session({
+        nodeId: 'remote-a',
+        repoPath: undefined,
+        worktreePath: undefined,
+        cwd: '/tmp/free-shell',
+        controlMode: 'co-driven',
+        controlFreshness: 'fresh',
+        activeActors: [{ kind: 'human', displayName: 'browser user' }],
+      }),
+      { label: 'remote box', status: 'online' }
+    );
+    expect(view.nodeSummary).toBe('remote box (online)');
+    expect(view.title).not.toContain('/repo/relay-ide');
+  });
+});
+
+describe('intervention control helpers', () => {
+  it('only enables hand-back when recent human control is acknowledged on fresh local state', () => {
+    expect(
+      canHandBackToAgent(
+        session({
+          controlMode: 'co-driven',
+          controlFreshness: 'fresh',
+          lastInterventionEventId: 'event-1',
+        })
+      )
+    ).toBe(true);
+    expect(
+      canHandBackToAgent(
+        session({
+          controlMode: 'co-driven',
+          controlFreshness: 'stale',
+          lastInterventionEventId: 'event-1',
+        })
+      )
+    ).toBe(false);
+    expect(
+      canHandBackToAgent(
+        session({
+          controlMode: 'agent-driven',
+          controlFreshness: 'fresh',
+          lastInterventionEventId: 'event-1',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('dedupes and sorts interventions newest first', () => {
+    const records = mergeInterventions(
+      [intervention({ id: 'older', timestamp: '2026-05-16T00:01:00.000Z' })],
+      [
+        intervention({ id: 'older', timestamp: '2026-05-16T00:01:00.000Z' }),
+        intervention({ id: 'newer', timestamp: '2026-05-16T00:02:00.000Z' }),
+      ]
+    );
+    expect(records.map((record) => record.id)).toEqual(['newer', 'older']);
+  });
+});

--- a/test/control-engine.test.ts
+++ b/test/control-engine.test.ts
@@ -161,6 +161,14 @@ describe('control transition engine', () => {
       controlReason: 'human input',
     });
     expect(events.map((event) => event.type)).toEqual(['tab.mode-changed', 'tab.intervention']);
+    expect(events[0]).toMatchObject({
+      controlMode: 'co-driven',
+      activeActors: [
+        { kind: 'human', id: 'local-user' },
+        { kind: 'agent', id: 'codex' },
+      ],
+      activeWorker: { kind: 'agent', id: 'codex' },
+    });
   });
 
   it('does not record human-driven or empty PTY input as intervention input', () => {
@@ -241,6 +249,12 @@ describe('control transition engine', () => {
     expect(records.map((record) => record.kind)).toEqual(['join', 'take-over', 'hand-back']);
     expect(events.filter((event) => event.type === 'tab.intervention')).toHaveLength(3);
     expect(events.filter((event) => event.type === 'tab.mode-changed')).toHaveLength(3);
+    expect(events.at(-1)).toMatchObject({
+      controlMode: 'agent-driven',
+      actor: { kind: 'human', id: 'local-user' },
+      activeActors: [{ kind: 'agent', id: 'codex' }],
+      activeWorker: { kind: 'agent', id: 'codex' },
+    });
     expect(records.every((record) => record.ackedAt)).toBe(true);
   });
 

--- a/test/stores/sessions-node-scope.test.ts
+++ b/test/stores/sessions-node-scope.test.ts
@@ -44,6 +44,11 @@ import type {
   SessionSummary,
   SidebarItem,
 } from '../../frontend/src/lib/types.js';
+import type {
+  ControlActor,
+  TabControlEvent,
+  TabModeChangedEvent,
+} from '../../shared/control-state.js';
 import { useSessionsStore } from '../../frontend/src/lib/stores/sessions.js';
 import { useUnreadStore } from '../../frontend/src/lib/stores/unread.js';
 
@@ -74,6 +79,59 @@ const nodeBSession: SessionSummary = {
   nodeId: 'node-b',
   globalSessionId: 'node-b:same-local-id',
 };
+
+const codexActor: ControlActor = {
+  kind: 'agent',
+  id: 'codex',
+  displayName: 'Codex',
+  nodeId: 'node-b',
+  sessionId: 'same-local-id',
+};
+
+const browserActor: ControlActor = {
+  kind: 'human',
+  id: 'browser-user',
+  displayName: 'Browser user',
+  nodeId: 'node-b',
+  sessionId: 'same-local-id',
+};
+
+function tabControlEvent(
+  overrides: Partial<TabModeChangedEvent> & Pick<TabModeChangedEvent, 'controlMode'>
+): TabControlEvent {
+  return {
+    eventId: 'evt-control-1',
+    type: 'tab.mode-changed',
+    occurredAt: '2026-05-11T00:00:01.000Z',
+    identity: {
+      nodeId: 'node-b',
+      sessionId: 'same-local-id',
+      globalSessionId: 'node-b:same-local-id',
+      cwd: '/node-b/relay-ide',
+      repoPath: '/node-b/relay-ide',
+      worktreePath: null,
+      repoName: 'relay-ide',
+      branchName: 'main',
+    },
+    actor: browserActor,
+    previousControlMode: 'agent-driven',
+    ...overrides,
+  };
+}
+
+function controlReadySession(session: SessionSummary): SessionSummary {
+  return {
+    ...session,
+    controlMode: 'agent-driven',
+    activeActors: [codexActor],
+    activeWorker: codexActor,
+    controlFreshness: 'fresh',
+    controlReason: 'boot',
+    lastInterventionAt: null,
+    lastInterventionBy: null,
+    lastInterventionEventId: null,
+  };
+}
 
 function sidebarItem(session: SessionSummary): SidebarItem {
   return {
@@ -110,6 +168,88 @@ describe('sessions store node-scoped events', () => {
       reconnectingPtySessionIds: {},
       backendConnectionStatus: 'connected',
     });
+  });
+
+  it('uses effective pushed actors instead of the triggering actor for co-driven events', () => {
+    useSessionsStore.setState({
+      sessions: [nodeASession, controlReadySession(nodeBSession)],
+    });
+
+    useSessionsStore.getState().handleTabControlEvent(
+      tabControlEvent({
+        controlMode: 'co-driven',
+        activeActors: [browserActor, codexActor],
+        activeWorker: codexActor,
+        reason: 'human input',
+      })
+    );
+
+    const updated = useSessionsStore
+      .getState()
+      .sessions.find((session) => session.globalSessionId === 'node-b:same-local-id');
+    expect(updated).toMatchObject({
+      controlMode: 'co-driven',
+      activeActors: [browserActor, codexActor],
+      activeWorker: codexActor,
+      controlReason: 'human input',
+      controlFreshness: 'fresh',
+    });
+  });
+
+  it('falls back to existing worker identity and clears stale human-only fields on mode events', () => {
+    useSessionsStore.setState({
+      sessions: [nodeASession, controlReadySession(nodeBSession)],
+    });
+
+    useSessionsStore.getState().handleTabControlEvent(
+      tabControlEvent({
+        controlMode: 'human-driven',
+        previousControlMode: 'agent-driven',
+        actor: browserActor,
+        reason: 'take-over',
+      })
+    );
+
+    let updated = useSessionsStore
+      .getState()
+      .sessions.find((session) => session.globalSessionId === 'node-b:same-local-id');
+    expect(updated).toMatchObject({
+      controlMode: 'human-driven',
+      activeActors: [browserActor],
+      controlReason: 'take-over',
+    });
+    expect(updated?.activeWorker).toBeUndefined();
+
+    useSessionsStore.setState({
+      sessions: [
+        nodeASession,
+        {
+          ...controlReadySession(nodeBSession),
+          controlMode: 'co-driven',
+          activeActors: [browserActor, codexActor],
+          activeWorker: codexActor,
+          controlReason: 'human input',
+        },
+      ],
+    });
+
+    useSessionsStore.getState().handleTabControlEvent(
+      tabControlEvent({
+        controlMode: 'agent-driven',
+        previousControlMode: 'co-driven',
+        actor: browserActor,
+      })
+    );
+
+    updated = useSessionsStore
+      .getState()
+      .sessions.find((session) => session.globalSessionId === 'node-b:same-local-id');
+    expect(updated).toMatchObject({
+      controlMode: 'agent-driven',
+      activeActors: [codexActor],
+      activeWorker: codexActor,
+    });
+    expect(updated?.controlReason).toBeUndefined();
   });
 
   it('updates only the matching global session when local ids collide across nodes', () => {

--- a/test/workspace-session-close.test.ts
+++ b/test/workspace-session-close.test.ts
@@ -170,6 +170,7 @@ describe('WorkspaceArea session tab close routing', () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
     });
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -227,5 +228,14 @@ describe('WorkspaceArea session tab close routing', () => {
       '/sessions/remote-session-1',
       expect.anything()
     );
+    const reactStoreErrors = consoleErrorSpy.mock.calls
+      .flat()
+      .filter(
+        (message) =>
+          typeof message === 'string' &&
+          (message.includes('getSnapshot') ||
+            message.includes('Maximum update depth'))
+      );
+    expect(reactStoreErrors).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a compact tab control badge for `agent-driven`, `human-driven`, `co-driven`, `stale`, and `unknown` control states.
- Adds an intervention strip on active session panes with recent human-touch events, mode-transition markers, remote/empty states, and guarded hand-back action.
- Wires pushed `tab-control-event` websocket updates into the sessions store without adding a polling loop.
- Adds typed API helpers for intervention history and hand-back, plus targeted display/helper tests.

Closes #492

## Motivation
#470 added structured tab-control state and intervention events. This PR makes that state visible in the session tab chrome and active session pane without conflating it with repo/worktree identity or node trust/security indicators.

## The Case Against
This change might be wrong because:
- The intervention strip currently shows remote intervention history as unavailable until node intervention RPC lands; remote tabs still get valid control badges and empty-state copy, but not live remote history fetches.
- The hand-back action uses the existing browser user actor and a lightweight `window.confirm` for recent human input. That is intentionally simple for this slice and does not implement #497 confirmation-token UI.
- Browser evidence used a focused visual smoke fixture with the production component CSS/classes to cover local, remote, free/non-git, stale, and confirmation states. It does not prove a full live remote-node topology because this worker does not have a durable remote fixture session.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Repo/worktree data leaks into remote/free tabs | `control-display` tests cover remote/free sessions and verify tooltips do not fall back to stale local repo paths. |
| Control UI gets mistaken for trust/security status | Badge copy uses only driver/actor/freshness language; node status is shown only as context text. |
| Event pushes do not update the UI | `tab-control-event` websocket messages update session summaries and intervention cache; intervention queries are invalidated. |
| Hand-back appears when it cannot work | Hand-back only appears for fresh local `human-driven`/`co-driven` sessions with a latest intervention event. Remote/stale/unknown states render notes/empty states instead. |

## Verification
- `npm test -- test/control-display.test.ts test/workspace-summary.test.ts test/session-control-api.test.ts test/ws-pty-intervention.test.ts` — 47 passed. Expected stderr from listener-throws coverage in `ws-pty-intervention`.
- `npm run check` — passed with existing lint warnings only.
- `npm run build` — passed.
- Browser visual smoke via Playwright/Vite fixture: 4 scenarios rendered (`agent`, `co`, `unknown`, `stale`), no page errors, no failed network requests; local screenshot artifact: `/tmp/relay-control-smoke/control-ui-smoke.png`.

## QA Notes
Verify in a built Relay UI:
1. Local repo session tab shows `agent`/`human`/`co`/`stale`/`unknown` badge states from session summary.
2. Active session pane shows intervention strip below the summary strip.
3. Recent human input shows mode transition markers and enables `hand back` only on fresh local human/co-driven sessions.
4. Remote/free/non-git tabs do not show stale local repo/worktree paths in control tooltips or empty states.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Intervention history strip displaying recent human control events with timestamps and participants
  * Control status badge indicating current session control mode (agent-driven, human-driven, co-driven, etc.)
  * Hand-back action allowing users to return session control to the agent
  * Session control details showing control freshness and optional context
  * Responsive layout optimized for smaller screens

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->