### PR TITLE
feat: add CLI gateway contract foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ Relay Agentic Development Environment — a hub/node web workspace for AI coding
 | Hub/node pkg    | `docs/RELAY_HUB_NODE_PACKAGING.md` | Hub vs node command shape, npm package decision, install/update commands    |
 | Node bootstrap  | `docs/RELAY_NODE_BOOTSTRAP.md`     | Pair/install/update/unpair nodes for federated Relay, bootstrap diagnostics |
 | Federated dev   | `docs/FEDERATED_DEV.md`            | Cross-machine dev workflow: synced git checkouts, `dev:node`, version skew  |
-| Federated Relay | `docs/federated-relay.md`          | Hub/node architecture, pairing, routing, ADRs                               |
+| Federated Relay | `docs/federated-relay.md`           | Hub/node architecture, pairing, routing, ADRs                               |
+| CLI gateway     | `docs/CLI_GATEWAY.md`              | Versioned `relay-ide v1 ... --json` contract for external agent adapters    |
 | Learnings       | `docs/LEARNINGS.md`                | Persistent cross-session learnings                                          |
 | Project skills  | `.chalk/skills/<name>/SKILL.md`    | Repo-local skills (see §Skills)                                             |
 | Work tracking   | GitHub Issues                      | `donovan-yohan/relay-ide` — use `/ticket` or `gh issue`                     |

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -30,6 +30,14 @@ import {
 } from '../server/local-logs.js';
 import { createDiagnosticsBundle } from '../server/diagnostics-bundle.js';
 import { writeNodeCredentialFile } from './node-credential-file.js';
+import {
+  RELAY_CLI_GATEWAY_CONTRACT,
+  gatewayError,
+  gatewayOk,
+  type RelayCliGatewayCommand,
+  type RelayCliGatewayEnvelope,
+  type RelayCliGatewayErrorCode,
+} from '../shared/cli-gateway-contract.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -60,6 +68,7 @@ Commands:
   uninstall          Back-compat alias for relay-ide hub uninstall
   status             Back-compat alias for relay-ide hub status
   manifest           Print local node capability manifest as JSON
+  v1 ... --json      Versioned CLI gateway JSON contract for nodes/sessions
   diag               Collect local diagnostics
     bundle [--output <dir>] [--lines <n>] [--json]
                                        Write a timestamped redacted diagnostics directory
@@ -173,6 +182,423 @@ async function runAsyncCommand(fn: () => Promise<void> | void): Promise<never> {
 }
 
 const command = args[0];
+
+function printGatewayEnvelope(
+  envelope: RelayCliGatewayEnvelope,
+  exitCode: number
+): never {
+  console.log(JSON.stringify(envelope, null, 2));
+  process.exit(exitCode);
+}
+
+function gatewayInvalid(
+  commandName: RelayCliGatewayCommand,
+  message: string,
+  details?: Record<string, unknown>
+): never {
+  printGatewayEnvelope(
+    gatewayError(commandName, {
+      code: 'INVALID_ARGUMENT',
+      message,
+      retryable: false,
+      ...(details ? { details } : {}),
+    }),
+    1
+  );
+}
+
+function gatewayArg(commandArgs: string[], flag: string): string | undefined {
+  const idx = commandArgs.indexOf(flag);
+  if (idx === -1 || idx + 1 >= commandArgs.length) return undefined;
+  const value = commandArgs[idx + 1];
+  return value && !value.startsWith('--') ? value : undefined;
+}
+
+function parseGatewayJson(
+  commandName: RelayCliGatewayCommand,
+  raw: string
+): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    gatewayInvalid(commandName, 'input JSON must be an object');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    printGatewayEnvelope(
+      gatewayError(commandName, {
+        code: 'INVALID_JSON',
+        message: `invalid input JSON: ${message}`,
+        retryable: false,
+      }),
+      1
+    );
+  }
+}
+
+function parseGatewayCreateInput(sessionArgs: string[]): Record<string, unknown> {
+  const inputJson = gatewayArg(sessionArgs, '--input-json');
+  if (inputJson) return parseGatewayJson('sessions.create', inputJson);
+  const inputFile = gatewayArg(sessionArgs, '--input-file');
+  if (inputFile) {
+    try {
+      return parseGatewayJson(
+        'sessions.create',
+        fs.readFileSync(path.resolve(inputFile), 'utf8')
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      gatewayInvalid('sessions.create', `could not read --input-file: ${message}`);
+    }
+  }
+
+  const input: Record<string, unknown> = {};
+  for (const [flag, key] of [
+    ['--node-id', 'nodeId'],
+    ['--repo-path', 'repoPath'],
+    ['--worktree-path', 'worktreePath'],
+    ['--cwd', 'cwd'],
+    ['--type', 'type'],
+    ['--mode', 'mode'],
+    ['--agent', 'agent'],
+    ['--branch-name', 'branchName'],
+    ['--initial-prompt', 'initialPrompt'],
+    ['--continue-policy', 'continuePolicy'],
+    ['--control-mode', 'controlMode'],
+    ['--confirmation-token', 'confirmationToken'],
+    ['--expires-at', 'expiresAt'],
+  ] as const) {
+    const value = gatewayArg(sessionArgs, flag);
+    if (value !== undefined) input[key] = value;
+  }
+  for (const [flag, key] of [
+    ['--cols', 'cols'],
+    ['--rows', 'rows'],
+    ['--ttl-seconds', 'ttlSeconds'],
+  ] as const) {
+    const value = gatewayArg(sessionArgs, flag);
+    if (value !== undefined) {
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) {
+        gatewayInvalid('sessions.create', `${flag} must be numeric`, { flag, value });
+      }
+      input[key] = numeric;
+    }
+  }
+  if (sessionArgs.includes('--yolo')) input['yolo'] = true;
+  const envelopeRaw = gatewayArg(sessionArgs, '--session-envelope-json');
+  if (envelopeRaw) {
+    input['sessionEnvelope'] = parseGatewayJson('sessions.create', envelopeRaw);
+  }
+  return input;
+}
+
+function normalizeGatewayErrorCode(
+  status: number,
+  upstream: Record<string, unknown> | undefined
+): RelayCliGatewayErrorCode {
+  const error = upstream?.['error'];
+  const body =
+    typeof error === 'object' && error !== null
+      ? (error as Record<string, unknown>)
+      : upstream;
+  const reason = typeof body?.['reasonCode'] === 'string' ? body['reasonCode'] : undefined;
+  const code = typeof body?.['code'] === 'string' ? body['code'] : undefined;
+  if (reason === 'HAND_BACK_ACK_REQUIRED') return 'INTERVENTION_ACK_REQUIRED';
+  if (reason === 'STALE_INTERVENTION_ACK') return 'INTERVENTION_ACK_STALE';
+  if (reason === 'CONTROL_STATE_STALE') return 'CONTROL_STATE_STALE';
+  if (reason === 'CONTROL_STATE_UNKNOWN') return 'CONTROL_STATE_UNKNOWN';
+  if (code === 'UNAUTHORIZED' || status === 401) return 'UNAUTHORIZED';
+  if (code === 'NODE_UNSUPPORTED') return 'UNSUPPORTED';
+  if (code === 'NOT_FOUND' || status === 404) return 'NOT_FOUND';
+  if (code === 'FORBIDDEN' || status === 403) return 'FORBIDDEN';
+  if (status === 400 || code === 'INVALID_REQUEST') return 'INVALID_ARGUMENT';
+  if (status === 409 || code === 'SESSION_CONFLICT') return 'SESSION_CONFLICT';
+  if (status === 503) return 'SERVER_UNAVAILABLE';
+  return 'UPSTREAM_ERROR';
+}
+
+async function gatewayHttpJson(input: {
+  commandName: RelayCliGatewayCommand;
+  pathName: string;
+  method?: string;
+  body?: unknown;
+  capabilities?: readonly string[];
+}): Promise<unknown> {
+  const token = process.env['RELAY_IDE_BROWSER_TOKEN'] ?? '';
+  if (!token) {
+    printGatewayEnvelope(
+      gatewayError(input.commandName, {
+        code: 'UNAUTHORIZED',
+        message:
+          'RELAY_IDE_BROWSER_TOKEN not set. Run from an authenticated Relay session or set a scoped API token.',
+        retryable: false,
+      }),
+      1
+    );
+  }
+
+  const port = getArg('--port') ?? process.env['RELAY_IDE_PORT'] ?? String(DEFAULTS.port);
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+  if (input.body !== undefined) headers['Content-Type'] = 'application/json';
+  if (input.capabilities?.length) {
+    headers['x-relay-capabilities'] = input.capabilities.join(',');
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`http://127.0.0.1:${port}${input.pathName}`, {
+      method: input.method ?? 'GET',
+      headers,
+      ...(input.body !== undefined ? { body: JSON.stringify(input.body) } : {}),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    printGatewayEnvelope(
+      gatewayError(input.commandName, {
+        code: 'SERVER_UNAVAILABLE',
+        message: `could not connect to Relay hub on port ${port}: ${message}`,
+        retryable: true,
+      }),
+      1
+    );
+  }
+
+  const text = await res.text();
+  let body: unknown;
+  try {
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    body = { raw: text };
+  }
+  if (!res.ok) {
+    const upstream =
+      typeof body === 'object' && body !== null
+        ? (body as Record<string, unknown>)
+        : undefined;
+    const upstreamError = upstream?.['error'];
+    const errorRecord =
+      typeof upstreamError === 'object' && upstreamError !== null
+        ? (upstreamError as Record<string, unknown>)
+        : upstream;
+    const message =
+      typeof errorRecord?.['message'] === 'string'
+        ? errorRecord['message']
+        : `Relay hub returned HTTP ${res.status}`;
+    printGatewayEnvelope(
+      gatewayError(input.commandName, {
+        code: normalizeGatewayErrorCode(res.status, upstream),
+        message,
+        retryable: res.status === 503 || res.status >= 500,
+        details: { status: res.status, upstream: body },
+      }),
+      1
+    );
+  }
+  return body;
+}
+
+function printGatewayUnsupported(
+  commandName: RelayCliGatewayCommand,
+  message: string,
+  details: Record<string, unknown>
+): never {
+  printGatewayEnvelope(
+    gatewayError(commandName, {
+      code: 'UNSUPPORTED',
+      message,
+      retryable: false,
+      details,
+    }),
+    1
+  );
+}
+
+function requireGatewaySessionId(
+  commandName: RelayCliGatewayCommand,
+  sessionArgs: string[]
+): string {
+  const id = gatewayArg(sessionArgs, '--id') ?? sessionArgs[0];
+  if (!id || id.startsWith('--')) gatewayInvalid(commandName, '--id is required');
+  return id;
+}
+
+function gatewayUsage(): never {
+  logger.error(
+    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions interventions|sessions hand-back) --json'
+  );
+  process.exit(1);
+}
+
+function loadGatewayManifestConfig(): Pick<Config, 'frameworks'> | undefined {
+  const configPath = resolveConfigPath();
+  if (!fs.existsSync(configPath)) return undefined;
+  try {
+    return loadConfig(configPath);
+  } catch {
+    return undefined;
+  }
+}
+
+async function runGatewayNodes(gatewayArgs: string[]): Promise<never> {
+  const nodeSubcommand = gatewayArgs[1];
+  if (nodeSubcommand === 'manifest') {
+    const config = loadGatewayManifestConfig();
+    const manifest = await getNodeManifest(config ? { config } : {});
+    printGatewayEnvelope(gatewayOk('nodes.manifest', manifest), 0);
+  }
+  if (nodeSubcommand === 'list') {
+    const data = await gatewayHttpJson({
+      commandName: 'nodes.list',
+      pathName: '/nodes',
+      capabilities: ['session:read'],
+    });
+    printGatewayEnvelope(gatewayOk('nodes.list', data), 0);
+  }
+  gatewayInvalid('nodes.list', 'unknown nodes command', { args: gatewayArgs });
+}
+
+async function runGatewaySessionList(): Promise<never> {
+  const sessions = await gatewayHttpJson({
+    commandName: 'sessions.list',
+    pathName: '/sessions',
+    capabilities: ['session:read'],
+  });
+  printGatewayEnvelope(gatewayOk('sessions.list', { sessions }), 0);
+}
+
+async function runGatewaySessionGet(sessionArgs: string[]): Promise<never> {
+  const id = requireGatewaySessionId('sessions.get', sessionArgs);
+  const session = await gatewayHttpJson({
+    commandName: 'sessions.get',
+    pathName: `/sessions/${encodeURIComponent(id)}`,
+    capabilities: ['session:read'],
+  });
+  printGatewayEnvelope(gatewayOk('sessions.get', session), 0);
+}
+
+function validateGatewayCreateInput(input: Record<string, unknown>, nodeId: string | undefined): void {
+  if (input['controlMode'] === 'agent-driven' && !nodeId) {
+    printGatewayUnsupported(
+      'sessions.create',
+      'local /sessions creation does not yet policy-gate initial controlMode=agent-driven; use routed node creation or omit controlMode',
+      { field: 'controlMode', supported: ['human-driven', undefined] }
+    );
+  }
+  if (!nodeId && typeof input['cwd'] === 'string') {
+    printGatewayUnsupported(
+      'sessions.create',
+      'local /sessions creation derives cwd from repoPath/worktreePath; explicit cwd requires routed node creation',
+      { field: 'cwd', supported: ['repoPath', 'worktreePath'] }
+    );
+  }
+  if (!nodeId && typeof input['repoPath'] !== 'string') {
+    gatewayInvalid('sessions.create', 'local session creation requires repoPath');
+  }
+}
+
+async function runGatewaySessionCreate(sessionArgs: string[]): Promise<never> {
+  const input = parseGatewayCreateInput(sessionArgs);
+  const nodeId = typeof input['nodeId'] === 'string' ? input['nodeId'] : undefined;
+  validateGatewayCreateInput(input, nodeId);
+  const body = { ...input };
+  delete body['nodeId'];
+  const session = await gatewayHttpJson({
+    commandName: 'sessions.create',
+    pathName: nodeId
+      ? `/hub/nodes/${encodeURIComponent(nodeId)}/sessions`
+      : '/sessions',
+    method: 'POST',
+    body,
+    capabilities: [
+      input['type'] === 'terminal'
+        ? 'session:create:terminal'
+        : 'session:create:agent',
+      ...(input['controlMode'] === 'agent-driven' ? ['tab:mode:set-agent'] : []),
+    ],
+  });
+  printGatewayEnvelope(gatewayOk('sessions.create', session), 0);
+}
+
+async function runGatewaySessionInterventions(sessionArgs: string[]): Promise<never> {
+  const id = requireGatewaySessionId('sessions.interventions', sessionArgs);
+  const limit = gatewayArg(sessionArgs, '--limit');
+  const query = limit ? `?limit=${encodeURIComponent(limit)}` : '';
+  const data = await gatewayHttpJson({
+    commandName: 'sessions.interventions',
+    pathName: `/sessions/${encodeURIComponent(id)}/interventions${query}`,
+    capabilities: ['session:read', 'tab:intervention:read'],
+  });
+  printGatewayEnvelope(gatewayOk('sessions.interventions', data), 0);
+}
+
+async function runGatewaySessionHandBack(sessionArgs: string[]): Promise<never> {
+  const id = requireGatewaySessionId('sessions.handBack', sessionArgs);
+  const latestSeenInterventionEventId = gatewayArg(
+    sessionArgs,
+    '--latest-seen-intervention-event-id'
+  );
+  if (!latestSeenInterventionEventId) {
+    gatewayInvalid(
+      'sessions.handBack',
+      '--latest-seen-intervention-event-id is required'
+    );
+  }
+  const data = await gatewayHttpJson({
+    commandName: 'sessions.handBack',
+    pathName: `/sessions/${encodeURIComponent(id)}/control/hand-back`,
+    method: 'POST',
+    body: { latestSeenInterventionEventId },
+    capabilities: ['session:attach', 'tab:mode:set-agent'],
+  });
+  printGatewayEnvelope(gatewayOk('sessions.handBack', data), 0);
+}
+
+async function runGatewaySessions(gatewayArgs: string[]): Promise<never> {
+  const sessionSubcommand = gatewayArgs[1];
+  const sessionArgs = gatewayArgs.slice(2);
+  if (sessionSubcommand === 'list') return runGatewaySessionList();
+  if (sessionSubcommand === 'get') return runGatewaySessionGet(sessionArgs);
+  if (sessionSubcommand === 'create') return runGatewaySessionCreate(sessionArgs);
+  if (sessionSubcommand === 'interventions') {
+    return runGatewaySessionInterventions(sessionArgs);
+  }
+  if (sessionSubcommand === 'hand-back') {
+    return runGatewaySessionHandBack(sessionArgs);
+  }
+  gatewayInvalid('sessions.list', 'unknown sessions command', { args: gatewayArgs });
+}
+
+async function runGatewayV1(): Promise<never> {
+  const gatewayArgs = args.slice(1);
+  const json = gatewayArgs.includes('--json');
+  const top = gatewayArgs[0];
+
+  if ((top === '--list' || top === 'list') && json) {
+    printGatewayEnvelope(
+      gatewayOk('contract.list', {
+        commands: RELAY_CLI_GATEWAY_CONTRACT.commandSchemas,
+        errorEnvelopeSchema: RELAY_CLI_GATEWAY_CONTRACT.errorEnvelopeSchema,
+      }),
+      0
+    );
+  }
+  if (top === 'schema' && json) {
+    printGatewayEnvelope(gatewayOk('contract.schema', RELAY_CLI_GATEWAY_CONTRACT), 0);
+  }
+  if (!json) gatewayUsage();
+  if (top === 'nodes') return runGatewayNodes(gatewayArgs);
+  if (top === 'sessions') return runGatewaySessions(gatewayArgs);
+  gatewayInvalid('contract.list', 'unknown v1 gateway command', { args: gatewayArgs });
+}
+
+if (command === 'v1') {
+  await runGatewayV1();
+}
+
 if (command === 'dev') {
   await import('../scripts/dev.js');
   await new Promise(() => {});

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -38,6 +38,8 @@ import {
   type RelayCliGatewayEnvelope,
 } from '../shared/cli-gateway-contract.js';
 import {
+  gatewayCliInvalidArgumentError,
+  gatewayCliInvalidJsonError,
   gatewayErrorMessage,
   gatewayErrorRetryable,
   normalizeGatewayErrorCode,
@@ -202,15 +204,7 @@ function gatewayInvalid(
   message: string,
   details?: Record<string, unknown>
 ): never {
-  printGatewayEnvelope(
-    gatewayError(commandName, {
-      code: 'INVALID_ARGUMENT',
-      message,
-      retryable: false,
-      ...(details ? { details } : {}),
-    }),
-    1
-  );
+  printGatewayEnvelope(gatewayError(commandName, gatewayCliInvalidArgumentError(commandName, message, details)), 1);
 }
 
 function gatewayArg(commandArgs: string[], flag: string): string | undefined {
@@ -232,14 +226,7 @@ function parseGatewayJson(
     gatewayInvalid(commandName, 'input JSON must be an object');
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    printGatewayEnvelope(
-      gatewayError(commandName, {
-        code: 'INVALID_JSON',
-        message: `invalid input JSON: ${message}`,
-        retryable: false,
-      }),
-      1
-    );
+    printGatewayEnvelope(gatewayError(commandName, gatewayCliInvalidJsonError(commandName, message)), 1);
   }
 }
 

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -36,8 +36,14 @@ import {
   gatewayOk,
   type RelayCliGatewayCommand,
   type RelayCliGatewayEnvelope,
-  type RelayCliGatewayErrorCode,
 } from '../shared/cli-gateway-contract.js';
+import {
+  gatewayErrorMessage,
+  gatewayErrorRetryable,
+  normalizeGatewayErrorCode,
+  sanitizedGatewayErrorDetails,
+  validateAndSanitizeGatewayCreateInput,
+} from '../shared/cli-gateway-runtime.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -294,31 +300,6 @@ function parseGatewayCreateInput(sessionArgs: string[]): Record<string, unknown>
   return input;
 }
 
-function normalizeGatewayErrorCode(
-  status: number,
-  upstream: Record<string, unknown> | undefined
-): RelayCliGatewayErrorCode {
-  const error = upstream?.['error'];
-  const body =
-    typeof error === 'object' && error !== null
-      ? (error as Record<string, unknown>)
-      : upstream;
-  const reason = typeof body?.['reasonCode'] === 'string' ? body['reasonCode'] : undefined;
-  const code = typeof body?.['code'] === 'string' ? body['code'] : undefined;
-  if (reason === 'HAND_BACK_ACK_REQUIRED') return 'INTERVENTION_ACK_REQUIRED';
-  if (reason === 'STALE_INTERVENTION_ACK') return 'INTERVENTION_ACK_STALE';
-  if (reason === 'CONTROL_STATE_STALE') return 'CONTROL_STATE_STALE';
-  if (reason === 'CONTROL_STATE_UNKNOWN') return 'CONTROL_STATE_UNKNOWN';
-  if (code === 'UNAUTHORIZED' || status === 401) return 'UNAUTHORIZED';
-  if (code === 'NODE_UNSUPPORTED') return 'UNSUPPORTED';
-  if (code === 'NOT_FOUND' || status === 404) return 'NOT_FOUND';
-  if (code === 'FORBIDDEN' || status === 403) return 'FORBIDDEN';
-  if (status === 400 || code === 'INVALID_REQUEST') return 'INVALID_ARGUMENT';
-  if (status === 409 || code === 'SESSION_CONFLICT') return 'SESSION_CONFLICT';
-  if (status === 503) return 'SERVER_UNAVAILABLE';
-  return 'UPSTREAM_ERROR';
-}
-
 async function gatewayHttpJson(input: {
   commandName: RelayCliGatewayCommand;
   pathName: string;
@@ -342,6 +323,7 @@ async function gatewayHttpJson(input: {
   const port = getArg('--port') ?? process.env['RELAY_IDE_PORT'] ?? String(DEFAULTS.port);
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
+    'x-relay-cli-gateway': 'v1',
   };
   if (input.body !== undefined) headers['Content-Type'] = 'application/json';
   if (input.capabilities?.length) {
@@ -379,42 +361,18 @@ async function gatewayHttpJson(input: {
       typeof body === 'object' && body !== null
         ? (body as Record<string, unknown>)
         : undefined;
-    const upstreamError = upstream?.['error'];
-    const errorRecord =
-      typeof upstreamError === 'object' && upstreamError !== null
-        ? (upstreamError as Record<string, unknown>)
-        : upstream;
-    const message =
-      typeof errorRecord?.['message'] === 'string'
-        ? errorRecord['message']
-        : `Relay hub returned HTTP ${res.status}`;
+    const message = gatewayErrorMessage(res.status, upstream);
     printGatewayEnvelope(
       gatewayError(input.commandName, {
         code: normalizeGatewayErrorCode(res.status, upstream),
         message,
-        retryable: res.status === 503 || res.status >= 500,
-        details: { status: res.status, upstream: body },
+        retryable: gatewayErrorRetryable(res.status, upstream),
+        details: sanitizedGatewayErrorDetails(res.status, upstream),
       }),
       1
     );
   }
   return body;
-}
-
-function printGatewayUnsupported(
-  commandName: RelayCliGatewayCommand,
-  message: string,
-  details: Record<string, unknown>
-): never {
-  printGatewayEnvelope(
-    gatewayError(commandName, {
-      code: 'UNSUPPORTED',
-      message,
-      retryable: false,
-      details,
-    }),
-    1
-  );
 }
 
 function requireGatewaySessionId(
@@ -480,31 +438,14 @@ async function runGatewaySessionGet(sessionArgs: string[]): Promise<never> {
   printGatewayEnvelope(gatewayOk('sessions.get', session), 0);
 }
 
-function validateGatewayCreateInput(input: Record<string, unknown>, nodeId: string | undefined): void {
-  if (input['controlMode'] === 'agent-driven' && !nodeId) {
-    printGatewayUnsupported(
-      'sessions.create',
-      'local /sessions creation does not yet policy-gate initial controlMode=agent-driven; use routed node creation or omit controlMode',
-      { field: 'controlMode', supported: ['human-driven', undefined] }
-    );
-  }
-  if (!nodeId && typeof input['cwd'] === 'string') {
-    printGatewayUnsupported(
-      'sessions.create',
-      'local /sessions creation derives cwd from repoPath/worktreePath; explicit cwd requires routed node creation',
-      { field: 'cwd', supported: ['repoPath', 'worktreePath'] }
-    );
-  }
-  if (!nodeId && typeof input['repoPath'] !== 'string') {
-    gatewayInvalid('sessions.create', 'local session creation requires repoPath');
-  }
-}
-
 async function runGatewaySessionCreate(sessionArgs: string[]): Promise<never> {
   const input = parseGatewayCreateInput(sessionArgs);
-  const nodeId = typeof input['nodeId'] === 'string' ? input['nodeId'] : undefined;
-  validateGatewayCreateInput(input, nodeId);
-  const body = { ...input };
+  const validated = validateAndSanitizeGatewayCreateInput(input);
+  if (validated.ok === false) {
+    printGatewayEnvelope(gatewayError('sessions.create', validated.error), 1);
+  }
+  const nodeId = validated.nodeId;
+  const body = { ...validated.input };
   delete body['nodeId'];
   const session = await gatewayHttpJson({
     commandName: 'sessions.create',
@@ -514,10 +455,10 @@ async function runGatewaySessionCreate(sessionArgs: string[]): Promise<never> {
     method: 'POST',
     body,
     capabilities: [
-      input['type'] === 'terminal'
+      validated.sessionType === 'terminal'
         ? 'session:create:terminal'
         : 'session:create:agent',
-      ...(input['controlMode'] === 'agent-driven' ? ['tab:mode:set-agent'] : []),
+      ...(validated.input['controlMode'] === 'agent-driven' ? ['tab:mode:set-agent'] : []),
     ],
   });
   printGatewayEnvelope(gatewayOk('sessions.create', session), 0);

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -86,7 +86,7 @@ Missing tokens and rejected hub responses are converted to the gateway error env
 - `sessionEnvelope` with #426 intent/scope/lifecycle/peer identity
 - #470/#493 control summary fields such as `controlMode`, `activeActors`, `activeWorker`, `lastInterventionAt`, `lastInterventionBy`, `lastInterventionEventId`, `controlFreshness`, and `controlReason`
 
-External brain identity is represented by `sessionEnvelope.peerIdentity.kind: "agent"` with `id`, `adapter`, and optional display/credential metadata. Adapters must not add impersonation flags such as `--act-as-node` or `--brain`; the hub credential/session registry owns peer identity.
+External brain/agent peer identity is reserved for hub-owned credential/session registry work. v1 currently documents the envelope field but only round-trips `local-user`, `relay-node`, and `unknown` peer identities; routed creates are represented as `relay-node` peers. Adapters must not add impersonation flags such as `--act-as-node` or `--brain`.
 
 ## Session create support and fail-closed behavior
 
@@ -95,13 +95,16 @@ External brain identity is represented by `sessionEnvelope.peerIdentity.kind: "a
 Supported now:
 
 - local repo/worktree-backed session creation using `repoPath` and optional `worktreePath`
-- routed node creation with `nodeId`, `cwd`, `type`, `mode`, `agent`, lifecycle fields, and optional `sessionEnvelope` where the existing backend supports them
+- routed node creation with `nodeId`, `cwd`, `type` (defaulting to `agent` when omitted), `mode`, `agent`, lifecycle fields, and optional non-agent `sessionEnvelope` where the existing backend supports them
 - `controlMode=agent-driven` only for routed node creation, where hub/node policy and hand-back state can be checked
 
 Fail-closed examples:
 
 - local create without `repoPath` returns `INVALID_ARGUMENT`
+- unknown `sessions create` input fields return `INVALID_ARGUMENT` before any backend forwarding
 - local create with explicit `cwd` returns `UNSUPPORTED` because the local endpoint derives `cwd` from `repoPath`/`worktreePath`
+- local scoped/lifecycle/peer fields (`sessionEnvelope`, `ttlSeconds`, `expiresAt`, `confirmationToken`) return `UNSUPPORTED` until implemented locally
+- `sessionEnvelope.peerIdentity.kind: "agent"` returns `UNSUPPORTED` until hub-owned agent peer identity is implemented
 - local `controlMode=agent-driven` returns `UNSUPPORTED` until local create has the same policy gate as routed creation
 - malformed JSON returns `INVALID_JSON`
 - unknown flags/commands return `INVALID_ARGUMENT`

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -1,0 +1,119 @@
+# CLI Gateway JSON Contract
+
+Relay exposes the adapter-facing gateway through an explicit major-version CLI surface:
+
+```bash
+relay-ide v1 --list --json
+relay-ide v1 schema --json
+relay-ide v1 nodes manifest --json
+relay-ide v1 nodes list --json
+relay-ide v1 sessions list --json
+relay-ide v1 sessions get --id <session-id-or-global-id> --json
+relay-ide v1 sessions create --input-json '{...}' --json
+```
+
+This contract is for external brain-as-peer adapters (#430). It is intentionally separate from the internal `/hub/node-link` WebSocket protocol. Adapter packages must generate native tool/function definitions from `relay-ide v1 schema --json` or the committed source manifest in `shared/cli-gateway-contract.ts`; do not hand-code Hermes/Claude/Codex-specific schemas.
+
+## Envelope
+
+Every gateway command returns one JSON envelope on stdout. Human-readable CLI behavior outside `v1 ... --json` is unchanged.
+
+Success:
+
+```json
+{
+  "ok": true,
+  "contract": "v1",
+  "contractVersion": "1.0",
+  "command": "sessions.list",
+  "data": {}
+}
+```
+
+Error:
+
+```json
+{
+  "ok": false,
+  "contract": "v1",
+  "contractVersion": "1.0",
+  "command": "sessions.create",
+  "error": {
+    "code": "UNSUPPORTED",
+    "message": "local /sessions creation derives cwd from repoPath/worktreePath; explicit cwd requires routed node creation",
+    "retryable": false,
+    "details": { "field": "cwd" }
+  }
+}
+```
+
+The current error taxonomy is declared in `RELAY_CLI_GATEWAY_CONTRACT.errorEnvelopeSchema`. It includes auth/connectivity errors, typed create/validation errors, and control hand-back state errors (`CONTROL_STATE_STALE`, `INTERVENTION_ACK_REQUIRED`, `INTERVENTION_ACK_STALE`, `CONTROL_STATE_UNKNOWN`).
+
+## Discovery and schemas
+
+`relay-ide v1 --list --json` returns command specs and the common error-envelope schema.
+
+`relay-ide v1 schema --json` returns the complete contract manifest:
+
+- `contract` / `contractVersion`
+- node-link and security-policy versions used by this build
+- command CLI argv shapes
+- per-command input and output schemas
+- capability hints for hub policy checks
+- possible typed error codes
+
+The schema is the source of truth for adapter generation. A command missing from this manifest is not stable adapter API, even if an internal REST/WebSocket route exists.
+
+## Auth and hub access
+
+Local discovery commands (`contract.*`, `nodes.manifest`) do not require a hub token.
+
+Hub-backed commands (`nodes.list`, `sessions.*`) use the same local server token path as existing CLI session commands:
+
+- `RELAY_IDE_BROWSER_TOKEN` supplies the bearer token.
+- `--port` or `RELAY_IDE_PORT` selects the local hub port; otherwise Relay uses the default port.
+- Gateway requests send capability hints via `x-relay-capabilities` so hub policy can fail closed.
+
+Missing tokens and rejected hub responses are converted to the gateway error envelope. The CLI still exits nonzero for error envelopes.
+
+## Session descriptors
+
+`nodes list`, `sessions list`, `sessions get`, and `sessions create` return the existing backend descriptors, wrapped in gateway envelopes. Session descriptors are expected to include the already-available identity and control fields where present:
+
+- `id`, `globalSessionId`, `nodeId`
+- `type`, `agent`, `mode`, `cwd`
+- optional `repoPath` / `worktreePath` as context, not identity
+- `sessionEnvelope` with #426 intent/scope/lifecycle/peer identity
+- #470/#493 control summary fields such as `controlMode`, `activeActors`, `activeWorker`, `lastInterventionAt`, `lastInterventionBy`, `lastInterventionEventId`, `controlFreshness`, and `controlReason`
+
+External brain identity is represented by `sessionEnvelope.peerIdentity.kind: "agent"` with `id`, `adapter`, and optional display/credential metadata. Adapters must not add impersonation flags such as `--act-as-node` or `--brain`; the hub credential/session registry owns peer identity.
+
+## Session create support and fail-closed behavior
+
+`sessions create` accepts either `--input-json`, `--input-file`, or typed flags. `nodeId` selects routed node creation through `/hub/nodes/:nodeId/sessions`; omitting it uses the current local `/sessions` path.
+
+Supported now:
+
+- local repo/worktree-backed session creation using `repoPath` and optional `worktreePath`
+- routed node creation with `nodeId`, `cwd`, `type`, `mode`, `agent`, lifecycle fields, and optional `sessionEnvelope` where the existing backend supports them
+- `controlMode=agent-driven` only for routed node creation, where hub/node policy and hand-back state can be checked
+
+Fail-closed examples:
+
+- local create without `repoPath` returns `INVALID_ARGUMENT`
+- local create with explicit `cwd` returns `UNSUPPORTED` because the local endpoint derives `cwd` from `repoPath`/`worktreePath`
+- local `controlMode=agent-driven` returns `UNSUPPORTED` until local create has the same policy gate as routed creation
+- malformed JSON returns `INVALID_JSON`
+- unknown flags/commands return `INVALID_ARGUMENT`
+
+The gateway must never silently downgrade unsupported scoped, privileged, or control-mode requests.
+
+## Intervention and hand-back boundaries
+
+`sessions interventions` is a bounded metadata read. The v1 contract explicitly marks raw payload and transcript export unavailable. Do not expose human intervention keylogs or full terminal transcripts through this gateway.
+
+`sessions hand-back` requires the latest intervention event id observed by the caller before restoring agent-driven control. Stale, unknown, disconnected, or unacknowledged intervention state returns typed errors instead of resuming blindly.
+
+## Deferred work
+
+Event subscription, attach/input/detach streaming, File RPC expansion, destructive operations, and adapter packages are follow-up work. If a future adapter needs a missing primitive, extend this CLI contract first; do not bypass it with `/hub/node-link` or browser WebSocket protocol clients.

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -75,6 +75,8 @@ import {
   type ConfirmationDecision,
   type ConfirmationFailure,
 } from './confirmation-challenges.js';
+import type { RelayCliGatewayError } from '../shared/cli-gateway-contract.js';
+import { validateAndSanitizeGatewayCreateInput } from '../shared/cli-gateway-runtime.js';
 
 interface HubNodeSessionTransport {
   hasActiveNode(nodeId: string): boolean;
@@ -305,6 +307,59 @@ export function bodyRecord(req: Request): Record<string, unknown> {
   return typeof req.body === 'object' && req.body !== null
     ? (req.body as Record<string, unknown>)
     : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isCliGatewayV1Request(req: Request): boolean {
+  return req.header('x-relay-cli-gateway') === 'v1';
+}
+
+function sendGatewayCreateValidationError(
+  res: Response,
+  error: RelayCliGatewayError
+): void {
+  res.status(400).json({ error });
+}
+
+function routedGatewayCreateBodyFromRequest(
+  req: Request,
+  res: Response,
+  routeNodeId: string
+): Record<string, unknown> | null {
+  const body = req.body as unknown;
+  if (!isCliGatewayV1Request(req)) return paramsWithoutConfirmation(bodyRecord(req));
+  if (!isRecord(body)) {
+    sendGatewayCreateValidationError(res, {
+      code: 'INVALID_ARGUMENT',
+      message: 'sessions.create input JSON must be an object',
+      retryable: false,
+    });
+    return null;
+  }
+
+  const validationInput = paramsWithoutConfirmation(body);
+  if (validationInput['nodeId'] === undefined) validationInput['nodeId'] = routeNodeId;
+  const validated = validateAndSanitizeGatewayCreateInput(validationInput);
+  if (validated.ok === false) {
+    sendGatewayCreateValidationError(res, validated.error);
+    return null;
+  }
+  if (validated.nodeId !== routeNodeId) {
+    sendGatewayCreateValidationError(res, {
+      code: 'INVALID_ARGUMENT',
+      message: 'sessions.create nodeId must match route nodeId',
+      retryable: false,
+      details: { field: 'nodeId', nodeId: routeNodeId, bodyNodeId: validated.nodeId ?? null },
+    });
+    return null;
+  }
+
+  const routedBody = { ...validated.input };
+  delete routedBody['nodeId'];
+  return routedBody;
 }
 
 function confirmationTokenFromRequest(req: Request, body: Record<string, unknown>): string | undefined {
@@ -1505,6 +1560,8 @@ export function createHubNodeRouter(
       sendRelayError(res, relayError('INVALID_REQUEST', 'nodeId is required'));
       return;
     }
+    const routedBody = routedGatewayCreateBodyFromRequest(req, res, nodeId);
+    if (!routedBody) return;
     const node = registry
       .listNodes()
       .find((candidate) => candidate.nodeId === nodeId);
@@ -1546,8 +1603,6 @@ export function createHubNodeRouter(
       return;
     }
 
-    const body = bodyRecord(req);
-    const routedBody = paramsWithoutConfirmation(body);
     const lifecycleError = lifecycleInputError(routedBody);
     if (lifecycleError) {
       sendRelayError(

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -88,6 +88,7 @@ export interface RoutedSessionAuditSink {
 interface HubNodeRouterOptions {
   registry: HubNodeRegistry;
   requireAuth: express.RequestHandler;
+  cliGatewayAuth?: express.RequestHandler;
   scopedSessionAuth?: express.RequestHandler;
   repoInventoryFeature?: RepoInventoryFeature;
   collectLocalRepoInventory?: () => Promise<RepoInventoryReport>;
@@ -1086,6 +1087,7 @@ export function createHubNodeRouter(
 ): express.Router {
   const router = express.Router();
   const { registry, requireAuth } = options;
+  const cliGatewayAuth = options.cliGatewayAuth ?? requireAuth;
   const scopedSessionAuth = options.scopedSessionAuth ?? requireAuth;
   const envelopes = options.sessionEnvelopes ?? sessionEnvelopeRegistry;
   const confirmations = options.confirmations ?? createConfirmationChallengeStore();
@@ -1299,7 +1301,7 @@ export function createHubNodeRouter(
     }
   });
 
-  router.get('/nodes', requireAuth, (_req, res) => {
+  router.get('/nodes', cliGatewayAuth, (_req, res) => {
     res.json({ nodes: registry.listNodes() });
   });
 
@@ -1497,7 +1499,7 @@ export function createHubNodeRouter(
     res.json({ session: summary });
   });
 
-  router.post('/hub/nodes/:nodeId/sessions', requireAuth, async (req, res) => {
+  router.post('/hub/nodes/:nodeId/sessions', cliGatewayAuth, async (req, res) => {
     const { nodeId } = req.params;
     if (!nodeId) {
       sendRelayError(res, relayError('INVALID_REQUEST', 'nodeId is required'));

--- a/server/index.ts
+++ b/server/index.ts
@@ -1162,6 +1162,21 @@ async function main(): Promise<void> {
     next();
   };
 
+  const requireCliGatewayAuth: express.RequestHandler = (req, res, next) => {
+    if (process.env.NO_PIN === '1' || authenticatedCookieToken(req)) {
+      next();
+      return;
+    }
+    if (
+      req.header('x-relay-cli-gateway') === 'v1' &&
+      validateScopedToken(bearerScopedToken(req))
+    ) {
+      next();
+      return;
+    }
+    res.status(401).json({ error: 'Unauthorized' });
+  };
+
   const requireScopedSessionAuth: express.RequestHandler = (req, res, next) => {
     if (process.env.NO_PIN === '1' || authenticatedCookieToken(req)) {
       next();
@@ -1185,6 +1200,7 @@ async function main(): Promise<void> {
       registry: hubNodeRegistry,
       nodeLinks: hubNodeLinks,
       requireAuth,
+      cliGatewayAuth: requireCliGatewayAuth,
       scopedSessionAuth: requireScopedSessionAuth,
       repoInventoryFeature,
       collectLocalRepoInventory: collectLocalInventory,
@@ -1933,7 +1949,7 @@ async function main(): Promise<void> {
   // GET /sessions — enrich with live branch from git (rate-limited to avoid spawning git on every poll)
   const branchRefreshCache = new Map<string, number>(); // sessionId -> last refresh timestamp
   const BRANCH_REFRESH_INTERVAL_MS = 10_000;
-  app.get('/sessions', requireAuth, async (_req, res) => {
+  app.get('/sessions', requireCliGatewayAuth, async (_req, res) => {
     const [localSessions, remoteSessions] = await Promise.all([
       Promise.resolve(localRelayNode.sessions.list()),
       aggregateRemoteSessions({
@@ -2523,7 +2539,7 @@ async function main(): Promise<void> {
   });
 
   // POST /sessions — unified endpoint for agent and terminal sessions
-  app.post('/sessions', requireAuth, async (req, res) => {
+  app.post('/sessions', requireCliGatewayAuth, async (req, res) => {
     const {
       repoPath,
       worktreePath,

--- a/server/index.ts
+++ b/server/index.ts
@@ -126,6 +126,8 @@ import type {
   WorkspaceSettings,
 } from './types.js';
 import type { SessionLane } from '../shared/session-lane.js';
+import type { RelayCliGatewayError } from '../shared/cli-gateway-contract.js';
+import { validateAndSanitizeLocalGatewayCreateInput } from '../shared/cli-gateway-runtime.js';
 import { resolveFramework } from './types.js';
 import { semverLessThan, clampDimension } from './utils.js';
 import {
@@ -1148,6 +1150,43 @@ async function main(): Promise<void> {
     const authHeader = req.header('authorization') ?? '';
     const match = authHeader.match(/^Bearer\s+(.+)$/i);
     return match?.[1]?.trim() ?? '';
+  }
+
+  function isCliGatewayV1Request(req: express.Request): boolean {
+    return req.header('x-relay-cli-gateway') === 'v1';
+  }
+
+  function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+
+  function sendGatewayCreateValidationError(
+    res: express.Response,
+    error: RelayCliGatewayError
+  ): void {
+    res.status(400).json({ error });
+  }
+
+  function sessionCreateBodyFromRequest(
+    req: express.Request,
+    res: express.Response
+  ): Record<string, unknown> | null {
+    const body = req.body as unknown;
+    if (!isCliGatewayV1Request(req)) return isRecord(body) ? body : {};
+    if (!isRecord(body)) {
+      sendGatewayCreateValidationError(res, {
+        code: 'INVALID_ARGUMENT',
+        message: 'sessions.create input JSON must be an object',
+        retryable: false,
+      });
+      return null;
+    }
+    const validated = validateAndSanitizeLocalGatewayCreateInput(body);
+    if (validated.ok === false) {
+      sendGatewayCreateValidationError(res, validated.error);
+      return null;
+    }
+    return validated.input;
   }
 
   const requireAuth: express.RequestHandler = (req, res, next) => {
@@ -2540,6 +2579,8 @@ async function main(): Promise<void> {
 
   // POST /sessions — unified endpoint for agent and terminal sessions
   app.post('/sessions', requireCliGatewayAuth, async (req, res) => {
+    const createBody = sessionCreateBodyFromRequest(req, res);
+    if (!createBody) return;
     const {
       repoPath,
       worktreePath,
@@ -2560,7 +2601,7 @@ async function main(): Promise<void> {
       continuePolicy: explicitContinuePolicy,
       sessionLane,
       ticketContext,
-    } = req.body as {
+    } = createBody as {
       repoPath?: string;
       worktreePath?: string | null;
       type?: 'agent' | 'terminal';

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -1,0 +1,563 @@
+import { RELAY_NODE_LINK_PROTOCOL_VERSION } from './relay-node-protocol.js';
+import { RELAY_SECURITY_POLICY_VERSION } from './security-policy.js';
+
+export const RELAY_CLI_GATEWAY_MAJOR = 'v1' as const;
+export const RELAY_CLI_GATEWAY_CONTRACT_VERSION = '1.0' as const;
+
+export type RelayCliGatewayCommand =
+  | 'contract.list'
+  | 'contract.schema'
+  | 'nodes.manifest'
+  | 'nodes.list'
+  | 'sessions.list'
+  | 'sessions.get'
+  | 'sessions.create'
+  | 'sessions.interventions'
+  | 'sessions.handBack';
+
+export type RelayCliGatewayErrorCode =
+  | 'UNAUTHORIZED'
+  | 'SERVER_UNAVAILABLE'
+  | 'INVALID_ARGUMENT'
+  | 'INVALID_JSON'
+  | 'UNSUPPORTED'
+  | 'NOT_FOUND'
+  | 'FORBIDDEN'
+  | 'SESSION_CONFLICT'
+  | 'CONTROL_STATE_STALE'
+  | 'INTERVENTION_ACK_REQUIRED'
+  | 'INTERVENTION_ACK_STALE'
+  | 'CONTROL_STATE_UNKNOWN'
+  | 'UPSTREAM_ERROR'
+  | 'INTERNAL';
+
+export interface RelayCliGatewayError {
+  code: RelayCliGatewayErrorCode;
+  message: string;
+  retryable: boolean;
+  details?: Record<string, unknown>;
+}
+
+export interface RelayCliGatewayOkEnvelope<T = unknown> {
+  ok: true;
+  contract: typeof RELAY_CLI_GATEWAY_MAJOR;
+  contractVersion: typeof RELAY_CLI_GATEWAY_CONTRACT_VERSION;
+  command: RelayCliGatewayCommand;
+  data: T;
+}
+
+export interface RelayCliGatewayErrorEnvelope {
+  ok: false;
+  contract: typeof RELAY_CLI_GATEWAY_MAJOR;
+  contractVersion: typeof RELAY_CLI_GATEWAY_CONTRACT_VERSION;
+  command: RelayCliGatewayCommand;
+  error: RelayCliGatewayError;
+}
+
+export type RelayCliGatewayEnvelope<T = unknown> =
+  | RelayCliGatewayOkEnvelope<T>
+  | RelayCliGatewayErrorEnvelope;
+
+export interface RelayJsonSchema {
+  $schema?: string;
+  $id?: string;
+  title?: string;
+  description?: string;
+  type?: string | readonly string[];
+  enum?: readonly string[];
+  const?: unknown;
+  properties?: Record<string, RelayJsonSchema>;
+  required?: readonly string[];
+  additionalProperties?: boolean;
+  items?: RelayJsonSchema;
+  anyOf?: readonly RelayJsonSchema[];
+  oneOf?: readonly RelayJsonSchema[];
+  format?: string;
+  minimum?: number;
+  maximum?: number;
+  default?: unknown;
+}
+
+export interface RelayCliGatewayCommandSpec {
+  name: RelayCliGatewayCommand;
+  cli: readonly string[];
+  summary: string;
+  stable: boolean;
+  transport: 'local' | 'hub-http' | 'hub-http-or-node-rpc';
+  requiresAuth: boolean;
+  capabilityHints: readonly string[];
+  inputSchema: RelayJsonSchema;
+  outputSchema: RelayJsonSchema;
+  errorCodes: readonly RelayCliGatewayErrorCode[];
+  unsupported?: string;
+}
+
+export interface RelayCliGatewayContractManifest {
+  schemaVersion: 1;
+  contract: typeof RELAY_CLI_GATEWAY_MAJOR;
+  contractVersion: typeof RELAY_CLI_GATEWAY_CONTRACT_VERSION;
+  generatedFrom: 'shared/cli-gateway-contract.ts';
+  protocolVersions: {
+    nodeLink: typeof RELAY_NODE_LINK_PROTOCOL_VERSION;
+    securityPolicy: typeof RELAY_SECURITY_POLICY_VERSION;
+  };
+  errorEnvelopeSchema: RelayJsonSchema;
+  commandSchemas: readonly RelayCliGatewayCommandSpec[];
+}
+
+const stringSchema = { type: 'string' } as const;
+const nullableStringSchema = { type: ['string', 'null'] } as const;
+const booleanSchema = { type: 'boolean' } as const;
+
+const controlActorSchema: RelayJsonSchema = {
+  title: 'ControlActor',
+  type: 'object',
+  additionalProperties: true,
+  properties: {
+    kind: { type: 'string', enum: ['agent', 'human', 'system'] },
+    id: stringSchema,
+    displayName: stringSchema,
+    nodeId: stringSchema,
+    sessionId: stringSchema,
+  },
+  required: ['kind'],
+};
+
+const sessionPeerIdentitySchema: RelayJsonSchema = {
+  title: 'SessionPeerIdentity',
+  oneOf: [
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        kind: { const: 'local-user' },
+        id: stringSchema,
+        displayName: stringSchema,
+      },
+      required: ['kind', 'id'],
+    },
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        kind: { const: 'relay-node' },
+        nodeId: stringSchema,
+        credentialId: stringSchema,
+        displayName: stringSchema,
+      },
+      required: ['kind', 'nodeId'],
+    },
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        kind: { const: 'agent' },
+        id: stringSchema,
+        adapter: stringSchema,
+        displayName: stringSchema,
+        credentialId: stringSchema,
+      },
+      required: ['kind', 'id', 'adapter'],
+    },
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        kind: { const: 'unknown' },
+        id: stringSchema,
+        displayName: stringSchema,
+      },
+      required: ['kind'],
+    },
+  ],
+};
+
+const sessionEnvelopeSchema: RelayJsonSchema = {
+  title: 'SessionEnvelope',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    sessionId: stringSchema,
+    globalSessionId: stringSchema,
+    nodeId: stringSchema,
+    intent: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        kind: stringSchema,
+        description: stringSchema,
+      },
+      required: ['kind', 'description'],
+    },
+    scope: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        kind: { type: 'string', enum: ['local-compatibility', 'node-cwd', 'repo', 'worktree'] },
+        nodeId: stringSchema,
+        cwd: stringSchema,
+        repoPath: stringSchema,
+        worktreePath: nullableStringSchema,
+      },
+      required: ['kind', 'nodeId', 'cwd'],
+    },
+    issuedAt: { type: 'string', format: 'date-time' },
+    expiresAt: { type: ['string', 'null'], format: 'date-time' },
+    revocable: booleanSchema,
+    peerIdentity: sessionPeerIdentitySchema,
+    correlationId: stringSchema,
+    auditId: stringSchema,
+  },
+  required: [
+    'sessionId',
+    'globalSessionId',
+    'nodeId',
+    'intent',
+    'scope',
+    'issuedAt',
+    'expiresAt',
+    'revocable',
+    'peerIdentity',
+  ],
+};
+
+const sessionDescriptorSchema: RelayJsonSchema = {
+  title: 'RelaySessionDescriptor',
+  type: 'object',
+  additionalProperties: true,
+  properties: {
+    id: stringSchema,
+    type: { type: 'string', enum: ['agent', 'terminal'] },
+    agent: stringSchema,
+    mode: { type: 'string', enum: ['pty', 'web'] },
+    nodeId: stringSchema,
+    globalSessionId: stringSchema,
+    cwd: stringSchema,
+    repoPath: stringSchema,
+    worktreePath: nullableStringSchema,
+    repoName: stringSchema,
+    branchName: stringSchema,
+    displayName: stringSchema,
+    status: { type: 'string', enum: ['active', 'disconnected'] },
+    controlMode: { type: 'string', enum: ['agent-driven', 'human-driven', 'co-driven'] },
+    activeActors: { type: 'array', items: controlActorSchema },
+    activeWorker: controlActorSchema,
+    lastInterventionAt: nullableStringSchema,
+    lastInterventionBy: { oneOf: [controlActorSchema, { type: 'null' }] },
+    lastInterventionEventId: nullableStringSchema,
+    controlFreshness: { type: 'string', enum: ['fresh', 'stale', 'unknown'] },
+    controlReason: stringSchema,
+    sessionEnvelope: sessionEnvelopeSchema,
+  },
+  required: ['id', 'type', 'agent', 'mode', 'cwd', 'displayName', 'status'],
+};
+
+const createSessionInputSchema: RelayJsonSchema = {
+  title: 'CreateSessionInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    nodeId: {
+      description: 'Optional execution node. Omit for current local /sessions path.',
+      type: 'string',
+    },
+    repoPath: stringSchema,
+    worktreePath: nullableStringSchema,
+    cwd: stringSchema,
+    type: { type: 'string', enum: ['agent', 'terminal'], default: 'agent' },
+    mode: { type: 'string', enum: ['pty', 'web'] },
+    agent: stringSchema,
+    yolo: booleanSchema,
+    cols: { type: 'number', minimum: 1, maximum: 500 },
+    rows: { type: 'number', minimum: 1, maximum: 200 },
+    branchName: stringSchema,
+    initialPrompt: stringSchema,
+    continuePolicy: { type: 'string', enum: ['always', 'never'] },
+    controlMode: {
+      type: 'string',
+      enum: ['agent-driven', 'human-driven'],
+      description:
+        'Only routed node session creation currently policy-checks controlMode. Local create rejects agent-driven as unsupported until hub policy support lands.',
+    },
+    sessionEnvelope: sessionEnvelopeSchema,
+    ttlSeconds: { type: 'number', minimum: 1 },
+    expiresAt: { type: 'string', format: 'date-time' },
+    confirmationToken: stringSchema,
+  },
+};
+
+const gatewayErrorSchema: RelayJsonSchema = {
+  title: 'RelayCliGatewayErrorEnvelope',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    ok: { const: false },
+    contract: { const: RELAY_CLI_GATEWAY_MAJOR },
+    contractVersion: { const: RELAY_CLI_GATEWAY_CONTRACT_VERSION },
+    command: stringSchema,
+    error: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        code: {
+          type: 'string',
+          enum: [
+            'UNAUTHORIZED',
+            'SERVER_UNAVAILABLE',
+            'INVALID_ARGUMENT',
+            'INVALID_JSON',
+            'UNSUPPORTED',
+            'NOT_FOUND',
+            'FORBIDDEN',
+            'SESSION_CONFLICT',
+            'CONTROL_STATE_STALE',
+            'INTERVENTION_ACK_REQUIRED',
+            'INTERVENTION_ACK_STALE',
+            'CONTROL_STATE_UNKNOWN',
+            'UPSTREAM_ERROR',
+            'INTERNAL',
+          ],
+        },
+        message: stringSchema,
+        retryable: booleanSchema,
+        details: { type: 'object', additionalProperties: true },
+      },
+      required: ['code', 'message', 'retryable'],
+    },
+  },
+  required: ['ok', 'contract', 'contractVersion', 'command', 'error'],
+};
+
+const okOutput = (title: string, data: RelayJsonSchema): RelayJsonSchema => ({
+  title,
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    ok: { const: true },
+    contract: { const: RELAY_CLI_GATEWAY_MAJOR },
+    contractVersion: { const: RELAY_CLI_GATEWAY_CONTRACT_VERSION },
+    command: stringSchema,
+    data,
+  },
+  required: ['ok', 'contract', 'contractVersion', 'command', 'data'],
+});
+
+const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
+  {
+    name: 'contract.list',
+    cli: ['relay-ide', 'v1', '--list', '--json'],
+    summary: 'List versioned gateway commands and machine-readable schemas.',
+    stable: true,
+    transport: 'local',
+    requiresAuth: false,
+    capabilityHints: [],
+    inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+    outputSchema: okOutput('ContractListOutput', { $id: 'RelayCliGatewayContractManifest', type: 'object' }),
+    errorCodes: ['INTERNAL'],
+  },
+  {
+    name: 'contract.schema',
+    cli: ['relay-ide', 'v1', 'schema', '--json'],
+    summary: 'Emit the complete v1 CLI gateway contract manifest.',
+    stable: true,
+    transport: 'local',
+    requiresAuth: false,
+    capabilityHints: [],
+    inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+    outputSchema: okOutput('ContractSchemaOutput', { $id: 'RelayCliGatewayContractManifest', type: 'object' }),
+    errorCodes: ['INTERNAL'],
+  },
+  {
+    name: 'nodes.manifest',
+    cli: ['relay-ide', 'v1', 'nodes', 'manifest', '--json'],
+    summary: 'Return this host local node capability manifest.',
+    stable: true,
+    transport: 'local',
+    requiresAuth: false,
+    capabilityHints: [],
+    inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+    outputSchema: okOutput('NodesManifestOutput', { type: 'object', additionalProperties: true }),
+    errorCodes: ['INTERNAL'],
+  },
+  {
+    name: 'nodes.list',
+    cli: ['relay-ide', 'v1', 'nodes', 'list', '--json'],
+    summary: 'List hub-known local/remote relay nodes and summarized capabilities.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read'],
+    inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+    outputSchema: okOutput('NodesListOutput', {
+      type: 'object',
+      additionalProperties: false,
+      properties: { nodes: { type: 'array', items: { type: 'object', additionalProperties: true } } },
+      required: ['nodes'],
+    }),
+    errorCodes: ['UNAUTHORIZED', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+  },
+  {
+    name: 'sessions.list',
+    cli: ['relay-ide', 'v1', 'sessions', 'list', '--json'],
+    summary: 'List active local and routed sessions with identity and control summaries.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read'],
+    inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+    outputSchema: okOutput('SessionsListOutput', {
+      type: 'object',
+      additionalProperties: false,
+      properties: { sessions: { type: 'array', items: sessionDescriptorSchema } },
+      required: ['sessions'],
+    }),
+    errorCodes: ['UNAUTHORIZED', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+  },
+  {
+    name: 'sessions.get',
+    cli: ['relay-ide', 'v1', 'sessions', 'get', '--id', '<session-id>', '--json'],
+    summary: 'Inspect one session by node-local id or globalSessionId.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read'],
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { id: stringSchema },
+      required: ['id'],
+    },
+    outputSchema: okOutput('SessionsGetOutput', sessionDescriptorSchema),
+    errorCodes: ['UNAUTHORIZED', 'NOT_FOUND', 'FORBIDDEN', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+  },
+  {
+    name: 'sessions.create',
+    cli: ['relay-ide', 'v1', 'sessions', 'create', '--input-json', '<json>', '--json'],
+    summary: 'Create a local or routed node session and return the created descriptor.',
+    stable: true,
+    transport: 'hub-http-or-node-rpc',
+    requiresAuth: true,
+    capabilityHints: ['session:create:terminal', 'session:create:agent', 'tab:mode:set-agent'],
+    inputSchema: createSessionInputSchema,
+    outputSchema: okOutput('SessionsCreateOutput', sessionDescriptorSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'FORBIDDEN',
+      'INVALID_ARGUMENT',
+      'UNSUPPORTED',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'sessions.interventions',
+    cli: ['relay-ide', 'v1', 'sessions', 'interventions', '--id', '<session-id>', '--json'],
+    summary: 'Read bounded, redacted intervention metadata for a local session.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read', 'tab:intervention:read'],
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { id: stringSchema, limit: { type: 'number', minimum: 1, maximum: 200 } },
+      required: ['id'],
+    },
+    outputSchema: okOutput('SessionsInterventionsOutput', {
+      type: 'object',
+      additionalProperties: true,
+      properties: {
+        rawPayloadAvailable: { const: false },
+        transcriptExportAvailable: { const: false },
+      },
+    }),
+    errorCodes: ['UNAUTHORIZED', 'NOT_FOUND', 'FORBIDDEN', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+  },
+  {
+    name: 'sessions.handBack',
+    cli: [
+      'relay-ide',
+      'v1',
+      'sessions',
+      'hand-back',
+      '--id',
+      '<session-id>',
+      '--latest-seen-intervention-event-id',
+      '<event-id>',
+      '--json',
+    ],
+    summary: 'Acknowledge latest human intervention before restoring agent-driven control.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:attach', 'tab:mode:set-agent'],
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { id: stringSchema, latestSeenInterventionEventId: stringSchema },
+      required: ['id', 'latestSeenInterventionEventId'],
+    },
+    outputSchema: okOutput('SessionsHandBackOutput', { type: 'object', additionalProperties: true }),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'SESSION_CONFLICT',
+      'CONTROL_STATE_STALE',
+      'INTERVENTION_ACK_REQUIRED',
+      'INTERVENTION_ACK_STALE',
+      'CONTROL_STATE_UNKNOWN',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
+  },
+];
+
+export const RELAY_CLI_GATEWAY_CONTRACT: RelayCliGatewayContractManifest = {
+  schemaVersion: 1,
+  contract: RELAY_CLI_GATEWAY_MAJOR,
+  contractVersion: RELAY_CLI_GATEWAY_CONTRACT_VERSION,
+  generatedFrom: 'shared/cli-gateway-contract.ts',
+  protocolVersions: {
+    nodeLink: RELAY_NODE_LINK_PROTOCOL_VERSION,
+    securityPolicy: RELAY_SECURITY_POLICY_VERSION,
+  },
+  errorEnvelopeSchema: gatewayErrorSchema,
+  commandSchemas: commandSpecs,
+};
+
+export function gatewayOk<T>(
+  command: RelayCliGatewayCommand,
+  data: T
+): RelayCliGatewayOkEnvelope<T> {
+  return {
+    ok: true,
+    contract: RELAY_CLI_GATEWAY_MAJOR,
+    contractVersion: RELAY_CLI_GATEWAY_CONTRACT_VERSION,
+    command,
+    data,
+  };
+}
+
+export function gatewayError(
+  command: RelayCliGatewayCommand,
+  error: RelayCliGatewayError
+): RelayCliGatewayErrorEnvelope {
+  return {
+    ok: false,
+    contract: RELAY_CLI_GATEWAY_MAJOR,
+    contractVersion: RELAY_CLI_GATEWAY_CONTRACT_VERSION,
+    command,
+    error,
+  };
+}
+
+export function commandSpec(name: RelayCliGatewayCommand): RelayCliGatewayCommandSpec {
+  const spec = RELAY_CLI_GATEWAY_CONTRACT.commandSchemas.find((entry) => entry.name === name);
+  if (!spec) throw new Error(`unknown CLI gateway command spec: ${name}`);
+  return spec;
+}
+
+export function stableCommandNames(): RelayCliGatewayCommand[] {
+  return RELAY_CLI_GATEWAY_CONTRACT.commandSchemas.map((entry) => entry.name);
+}

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -345,7 +345,7 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     capabilityHints: [],
     inputSchema: { type: 'object', additionalProperties: false, properties: {} },
     outputSchema: okOutput('ContractListOutput', { $id: 'RelayCliGatewayContractManifest', type: 'object' }),
-    errorCodes: ['INTERNAL'],
+    errorCodes: ['INVALID_ARGUMENT', 'INTERNAL'],
   },
   {
     name: 'contract.schema',
@@ -386,7 +386,7 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       properties: { nodes: { type: 'array', items: { type: 'object', additionalProperties: true } } },
       required: ['nodes'],
     }),
-    errorCodes: ['UNAUTHORIZED', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+    errorCodes: ['UNAUTHORIZED', 'INVALID_ARGUMENT', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
   },
   {
     name: 'sessions.list',
@@ -403,7 +403,7 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       properties: { sessions: { type: 'array', items: sessionDescriptorSchema } },
       required: ['sessions'],
     }),
-    errorCodes: ['UNAUTHORIZED', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+    errorCodes: ['UNAUTHORIZED', 'INVALID_ARGUMENT', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
   },
   {
     name: 'sessions.get',
@@ -420,7 +420,14 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       required: ['id'],
     },
     outputSchema: okOutput('SessionsGetOutput', sessionDescriptorSchema),
-    errorCodes: ['UNAUTHORIZED', 'NOT_FOUND', 'FORBIDDEN', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
   },
   {
     name: 'sessions.create',
@@ -436,6 +443,7 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       'UNAUTHORIZED',
       'FORBIDDEN',
       'INVALID_ARGUMENT',
+      'INVALID_JSON',
       'UNSUPPORTED',
       'SERVER_UNAVAILABLE',
       'CONFIRMATION_REQUIRED',
@@ -465,7 +473,14 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
         transcriptExportAvailable: { const: false },
       },
     }),
-    errorCodes: ['UNAUTHORIZED', 'NOT_FOUND', 'FORBIDDEN', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
   },
   {
     name: 'sessions.handBack',
@@ -494,6 +509,7 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     outputSchema: okOutput('SessionsHandBackOutput', { type: 'object', additionalProperties: true }),
     errorCodes: [
       'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
       'NOT_FOUND',
       'FORBIDDEN',
       'SESSION_CONFLICT',

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -24,6 +24,8 @@ export type RelayCliGatewayErrorCode =
   | 'NOT_FOUND'
   | 'FORBIDDEN'
   | 'SESSION_CONFLICT'
+  | 'CONFIRMATION_REQUIRED'
+  | 'NODE_OFFLINE'
   | 'CONTROL_STATE_STALE'
   | 'INTERVENTION_ACK_REQUIRED'
   | 'INTERVENTION_ACK_STALE'
@@ -146,18 +148,6 @@ const sessionPeerIdentitySchema: RelayJsonSchema = {
         displayName: stringSchema,
       },
       required: ['kind', 'nodeId'],
-    },
-    {
-      type: 'object',
-      additionalProperties: false,
-      properties: {
-        kind: { const: 'agent' },
-        id: stringSchema,
-        adapter: stringSchema,
-        displayName: stringSchema,
-        credentialId: stringSchema,
-      },
-      required: ['kind', 'id', 'adapter'],
     },
     {
       type: 'object',
@@ -310,6 +300,8 @@ const gatewayErrorSchema: RelayJsonSchema = {
             'NOT_FOUND',
             'FORBIDDEN',
             'SESSION_CONFLICT',
+            'CONFIRMATION_REQUIRED',
+            'NODE_OFFLINE',
             'CONTROL_STATE_STALE',
             'INTERVENTION_ACK_REQUIRED',
             'INTERVENTION_ACK_STALE',
@@ -446,6 +438,8 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       'INVALID_ARGUMENT',
       'UNSUPPORTED',
       'SERVER_UNAVAILABLE',
+      'CONFIRMATION_REQUIRED',
+      'NODE_OFFLINE',
       'UPSTREAM_ERROR',
     ],
   },

--- a/shared/cli-gateway-runtime.ts
+++ b/shared/cli-gateway-runtime.ts
@@ -1,4 +1,5 @@
 import type {
+  RelayCliGatewayCommand,
   RelayCliGatewayError,
   RelayCliGatewayErrorCode,
 } from './cli-gateway-contract.js';
@@ -90,6 +91,30 @@ function unsupportedCreateInput(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function gatewayCliInvalidArgumentError(
+  _commandName: RelayCliGatewayCommand,
+  message: string,
+  details?: Record<string, unknown>
+): RelayCliGatewayError {
+  return {
+    code: 'INVALID_ARGUMENT',
+    message,
+    retryable: false,
+    ...(details ? { details } : {}),
+  };
+}
+
+export function gatewayCliInvalidJsonError(
+  _commandName: RelayCliGatewayCommand,
+  message: string
+): RelayCliGatewayError {
+  return {
+    code: 'INVALID_JSON',
+    message: `invalid input JSON: ${message}`,
+    retryable: false,
+  };
 }
 
 function validateStringField(
@@ -313,6 +338,20 @@ export function validateAndSanitizeGatewayCreateInput(
   const sessionType = sanitized['type'] === 'terminal' ? 'terminal' : 'agent';
   sanitized['type'] = sessionType;
   return { ok: true, input: sanitized, ...(nodeId ? { nodeId } : {}), sessionType };
+}
+
+export function validateAndSanitizeLocalGatewayCreateInput(
+  rawInput: Record<string, unknown>
+): GatewayCreateValidationResult {
+  const validated = validateAndSanitizeGatewayCreateInput(rawInput);
+  if (validated.ok === false) return validated;
+  if (validated.nodeId) {
+    return unsupportedCreateInput(
+      'local /sessions gateway creation cannot accept nodeId; use routed node creation through /hub/nodes/:nodeId/sessions',
+      { field: 'nodeId', supported: ['repoPath', 'worktreePath'] }
+    );
+  }
+  return validated;
 }
 
 function upstreamErrorRecord(upstream: Record<string, unknown> | undefined): Record<string, unknown> | undefined {

--- a/shared/cli-gateway-runtime.ts
+++ b/shared/cli-gateway-runtime.ts
@@ -1,0 +1,397 @@
+import type {
+  RelayCliGatewayError,
+  RelayCliGatewayErrorCode,
+} from './cli-gateway-contract.js';
+
+export interface GatewayCreateValidationOk {
+  ok: true;
+  input: Record<string, unknown>;
+  nodeId?: string;
+  sessionType: 'agent' | 'terminal';
+}
+
+export interface GatewayCreateValidationFailure {
+  ok: false;
+  error: RelayCliGatewayError;
+}
+
+export type GatewayCreateValidationResult =
+  | GatewayCreateValidationOk
+  | GatewayCreateValidationFailure;
+
+const createSessionAllowedFields = new Set([
+  'nodeId',
+  'repoPath',
+  'worktreePath',
+  'cwd',
+  'type',
+  'mode',
+  'agent',
+  'yolo',
+  'cols',
+  'rows',
+  'branchName',
+  'initialPrompt',
+  'continuePolicy',
+  'controlMode',
+  'sessionEnvelope',
+  'ttlSeconds',
+  'expiresAt',
+  'confirmationToken',
+]);
+
+const stringFields = [
+  'nodeId',
+  'repoPath',
+  'cwd',
+  'agent',
+  'branchName',
+  'initialPrompt',
+  'expiresAt',
+  'confirmationToken',
+] as const;
+
+const localUnsupportedFields = [
+  'sessionEnvelope',
+  'ttlSeconds',
+  'expiresAt',
+  'confirmationToken',
+] as const;
+
+function createValidationError(
+  code: RelayCliGatewayErrorCode,
+  message: string,
+  details?: Record<string, unknown>
+): GatewayCreateValidationFailure {
+  return {
+    ok: false,
+    error: {
+      code,
+      message,
+      retryable: false,
+      ...(details ? { details } : {}),
+    },
+  };
+}
+
+function invalidCreateInput(
+  message: string,
+  details?: Record<string, unknown>
+): GatewayCreateValidationFailure {
+  return createValidationError('INVALID_ARGUMENT', message, details);
+}
+
+function unsupportedCreateInput(
+  message: string,
+  details: Record<string, unknown>
+): GatewayCreateValidationFailure {
+  return createValidationError('UNSUPPORTED', message, details);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validateStringField(
+  input: Record<string, unknown>,
+  field: string
+): GatewayCreateValidationFailure | null {
+  if (input[field] === undefined) return null;
+  if (typeof input[field] !== 'string') {
+    return invalidCreateInput(`sessions.create ${field} must be a string`, { field });
+  }
+  return null;
+}
+
+function validateNumberField(
+  input: Record<string, unknown>,
+  field: 'cols' | 'rows' | 'ttlSeconds',
+  min: number,
+  max?: number
+): GatewayCreateValidationFailure | null {
+  if (input[field] === undefined) return null;
+  if (typeof input[field] !== 'number' || !Number.isFinite(input[field])) {
+    return invalidCreateInput(`sessions.create ${field} must be a finite number`, { field });
+  }
+  if (input[field] < min || (max !== undefined && input[field] > max)) {
+    return invalidCreateInput(
+      `sessions.create ${field} must be between ${min} and ${max ?? 'infinity'}`,
+      { field, min, ...(max !== undefined ? { max } : {}) }
+    );
+  }
+  return null;
+}
+
+function validateSessionEnvelopeInput(
+  envelope: unknown,
+  nodeId: string | undefined
+): GatewayCreateValidationFailure | null {
+  if (envelope === undefined) return null;
+  if (!isRecord(envelope)) {
+    return invalidCreateInput('sessions.create sessionEnvelope must be an object', {
+      field: 'sessionEnvelope',
+    });
+  }
+  const envelopeNodeId = envelope['nodeId'];
+  if (envelopeNodeId !== undefined && typeof envelopeNodeId !== 'string') {
+    return invalidCreateInput('sessions.create sessionEnvelope.nodeId must be a string', {
+      field: 'sessionEnvelope.nodeId',
+    });
+  }
+  if (nodeId && typeof envelopeNodeId === 'string' && envelopeNodeId !== nodeId) {
+    return invalidCreateInput('sessions.create sessionEnvelope.nodeId must match nodeId', {
+      field: 'sessionEnvelope.nodeId',
+      nodeId,
+      envelopeNodeId,
+    });
+  }
+  const peerIdentity = envelope['peerIdentity'];
+  if (peerIdentity !== undefined) {
+    if (!isRecord(peerIdentity)) {
+      return invalidCreateInput(
+        'sessions.create sessionEnvelope.peerIdentity must be an object',
+        { field: 'sessionEnvelope.peerIdentity' }
+      );
+    }
+    const kind = peerIdentity['kind'];
+    if (kind !== 'relay-node') {
+      return unsupportedCreateInput(
+        'sessions.create does not yet accept adapter-owned agent peer identity; routed creates are represented as relay-node peers until hub credential/session registry ownership lands',
+        {
+          field: 'sessionEnvelope.peerIdentity.kind',
+          unsupported: kind ?? null,
+          supported: ['relay-node'],
+        }
+      );
+    }
+    const peerNodeId = peerIdentity['nodeId'];
+    if (peerNodeId !== undefined && typeof peerNodeId !== 'string') {
+      return invalidCreateInput(
+        'sessions.create sessionEnvelope.peerIdentity.nodeId must be a string',
+        { field: 'sessionEnvelope.peerIdentity.nodeId' }
+      );
+    }
+    if (nodeId && typeof peerNodeId === 'string' && peerNodeId !== nodeId) {
+      return invalidCreateInput(
+        'sessions.create sessionEnvelope.peerIdentity.nodeId must match nodeId',
+        { field: 'sessionEnvelope.peerIdentity.nodeId', nodeId, peerNodeId }
+      );
+    }
+  }
+  return null;
+}
+
+function sanitizedCreateInput(
+  rawInput: Record<string, unknown>
+): GatewayCreateValidationFailure | { ok: true; input: Record<string, unknown> } {
+  const sanitized: Record<string, unknown> = {};
+  for (const [field, value] of Object.entries(rawInput)) {
+    if (!createSessionAllowedFields.has(field)) {
+      return invalidCreateInput(`sessions.create field is not in the v1 contract: ${field}`, {
+        field,
+      });
+    }
+    sanitized[field] = value;
+  }
+  return { ok: true, input: sanitized };
+}
+
+function validateCreateFieldTypes(
+  input: Record<string, unknown>
+): GatewayCreateValidationFailure | null {
+  for (const field of stringFields) {
+    const error = validateStringField(input, field);
+    if (error) return error;
+  }
+  if (
+    input['worktreePath'] !== undefined &&
+    input['worktreePath'] !== null &&
+    typeof input['worktreePath'] !== 'string'
+  ) {
+    return invalidCreateInput('sessions.create worktreePath must be a string or null', {
+      field: 'worktreePath',
+    });
+  }
+  if (input['yolo'] !== undefined && typeof input['yolo'] !== 'boolean') {
+    return invalidCreateInput('sessions.create yolo must be a boolean', { field: 'yolo' });
+  }
+  for (const [field, min, max] of [
+    ['cols', 1, 500],
+    ['rows', 1, 200],
+    ['ttlSeconds', 1, undefined],
+  ] as const) {
+    const error = validateNumberField(input, field, min, max);
+    if (error) return error;
+  }
+  return null;
+}
+
+function validateCreateEnums(
+  input: Record<string, unknown>
+): GatewayCreateValidationFailure | null {
+  if (input['type'] !== undefined && input['type'] !== 'agent' && input['type'] !== 'terminal') {
+    return invalidCreateInput('sessions.create type must be agent or terminal', { field: 'type' });
+  }
+  if (input['mode'] !== undefined && input['mode'] !== 'pty' && input['mode'] !== 'web') {
+    return invalidCreateInput('sessions.create mode must be pty or web', { field: 'mode' });
+  }
+  if (
+    input['continuePolicy'] !== undefined &&
+    input['continuePolicy'] !== 'always' &&
+    input['continuePolicy'] !== 'never'
+  ) {
+    return invalidCreateInput('sessions.create continuePolicy must be always or never', {
+      field: 'continuePolicy',
+    });
+  }
+  if (
+    input['controlMode'] !== undefined &&
+    input['controlMode'] !== 'agent-driven' &&
+    input['controlMode'] !== 'human-driven'
+  ) {
+    return invalidCreateInput('sessions.create controlMode must be agent-driven or human-driven', {
+      field: 'controlMode',
+    });
+  }
+  if (input['expiresAt'] !== undefined && Number.isNaN(Date.parse(input['expiresAt'] as string))) {
+    return invalidCreateInput('sessions.create expiresAt must be an ISO date-time string', {
+      field: 'expiresAt',
+    });
+  }
+  return null;
+}
+
+function validateLocalCreateSupport(
+  input: Record<string, unknown>
+): GatewayCreateValidationFailure | null {
+  for (const field of localUnsupportedFields) {
+    if (input[field] !== undefined) {
+      return unsupportedCreateInput(
+        `local sessions.create does not support ${field}; use routed node creation or omit the field`,
+        { field, supportedLocalFields: ['repoPath', 'worktreePath', 'type', 'mode', 'agent'] }
+      );
+    }
+  }
+  if (typeof input['cwd'] === 'string') {
+    return unsupportedCreateInput(
+      'local /sessions creation derives cwd from repoPath/worktreePath; explicit cwd requires routed node creation',
+      { field: 'cwd', supported: ['repoPath', 'worktreePath'] }
+    );
+  }
+  if (input['controlMode'] === 'agent-driven') {
+    return unsupportedCreateInput(
+      'local /sessions creation does not yet policy-gate initial controlMode=agent-driven; use routed node creation or omit controlMode',
+      { field: 'controlMode', supported: ['human-driven', undefined] }
+    );
+  }
+  if (typeof input['repoPath'] !== 'string') {
+    return invalidCreateInput('local session creation requires repoPath', { field: 'repoPath' });
+  }
+  return null;
+}
+
+export function validateAndSanitizeGatewayCreateInput(
+  rawInput: Record<string, unknown>
+): GatewayCreateValidationResult {
+  const sanitizedResult = sanitizedCreateInput(rawInput);
+  if (sanitizedResult.ok === false) return sanitizedResult;
+
+  const sanitized = sanitizedResult.input;
+  const typeError = validateCreateFieldTypes(sanitized);
+  if (typeError) return typeError;
+  const enumError = validateCreateEnums(sanitized);
+  if (enumError) return enumError;
+
+  const nodeId = typeof sanitized['nodeId'] === 'string' ? sanitized['nodeId'] : undefined;
+  const envelopeError = validateSessionEnvelopeInput(sanitized['sessionEnvelope'], nodeId);
+  if (envelopeError) return envelopeError;
+  if (!nodeId) {
+    const localError = validateLocalCreateSupport(sanitized);
+    if (localError) return localError;
+  }
+
+  const sessionType = sanitized['type'] === 'terminal' ? 'terminal' : 'agent';
+  sanitized['type'] = sessionType;
+  return { ok: true, input: sanitized, ...(nodeId ? { nodeId } : {}), sessionType };
+}
+
+function upstreamErrorRecord(upstream: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  const error = upstream?.['error'];
+  return typeof error === 'object' && error !== null
+    ? (error as Record<string, unknown>)
+    : upstream;
+}
+
+export function normalizeGatewayErrorCode(
+  status: number,
+  upstream: Record<string, unknown> | undefined
+): RelayCliGatewayErrorCode {
+  const body = upstreamErrorRecord(upstream);
+  const reason = typeof body?.['reasonCode'] === 'string' ? body['reasonCode'] : undefined;
+  const code = typeof body?.['code'] === 'string' ? body['code'] : undefined;
+  if (code === 'CONFIRMATION_REQUIRED' || reason === 'CONFIRMATION_REQUIRED') return 'CONFIRMATION_REQUIRED';
+  if (code === 'NODE_OFFLINE') return 'NODE_OFFLINE';
+  if (code === 'UNSUPPORTED') return 'UNSUPPORTED';
+  if (reason === 'HAND_BACK_ACK_REQUIRED') return 'INTERVENTION_ACK_REQUIRED';
+  if (reason === 'STALE_INTERVENTION_ACK') return 'INTERVENTION_ACK_STALE';
+  if (reason === 'CONTROL_STATE_STALE') return 'CONTROL_STATE_STALE';
+  if (reason === 'CONTROL_STATE_UNKNOWN') return 'CONTROL_STATE_UNKNOWN';
+  if (code === 'UNAUTHORIZED' || status === 401) return 'UNAUTHORIZED';
+  if (code === 'NODE_UNSUPPORTED') return 'UNSUPPORTED';
+  if (code === 'NOT_FOUND' || status === 404) return 'NOT_FOUND';
+  if (code === 'FORBIDDEN' || status === 403) return 'FORBIDDEN';
+  if (status === 400 || code === 'INVALID_REQUEST' || code === 'INVALID_ARGUMENT') return 'INVALID_ARGUMENT';
+  if (status === 409 || code === 'SESSION_CONFLICT') return 'SESSION_CONFLICT';
+  if (status === 503) return 'SERVER_UNAVAILABLE';
+  return 'UPSTREAM_ERROR';
+}
+
+export function gatewayErrorRetryable(
+  status: number,
+  upstream: Record<string, unknown> | undefined
+): boolean {
+  const body = upstreamErrorRecord(upstream);
+  if (typeof body?.['retryable'] === 'boolean') return body['retryable'];
+  return status === 503 || status >= 500;
+}
+
+export function gatewayErrorMessage(
+  status: number,
+  upstream: Record<string, unknown> | undefined
+): string {
+  const body = upstreamErrorRecord(upstream);
+  return typeof body?.['message'] === 'string'
+    ? body['message']
+    : `Relay hub returned HTTP ${status}`;
+}
+
+function redactedChallenge(value: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(value)) return undefined;
+  const result: Record<string, unknown> = {};
+  for (const key of ['id', 'challengeId', 'expiresAt', 'requiredBits', 'requiredCapabilities']) {
+    const entry = value[key];
+    if (entry !== undefined) result[key] = entry;
+  }
+  return Object.keys(result).length ? result : { present: true };
+}
+
+export function sanitizedGatewayErrorDetails(
+  status: number,
+  upstream: Record<string, unknown> | undefined
+): Record<string, unknown> {
+  const body = upstreamErrorRecord(upstream);
+  const details: Record<string, unknown> = { status };
+  const code = body?.['code'];
+  const reasonCode = body?.['reasonCode'];
+  if (typeof code === 'string') details['upstreamCode'] = code;
+  if (typeof reasonCode === 'string') details['reasonCode'] = reasonCode;
+
+  const upstreamDetails = isRecord(body?.['details']) ? body['details'] : undefined;
+  const field = isRecord(upstreamDetails) ? upstreamDetails['field'] : body?.['field'];
+  if (typeof field === 'string') details['field'] = field;
+  const challenge = redactedChallenge(
+    isRecord(upstreamDetails) ? upstreamDetails['challenge'] : body?.['challenge']
+  );
+  if (challenge) details['challenge'] = challenge;
+  return details;
+}

--- a/shared/session-envelope.ts
+++ b/shared/session-envelope.ts
@@ -43,6 +43,13 @@ export interface SessionScope {
 export type SessionPeerIdentity =
   | { kind: 'local-user'; id: string; displayName?: string }
   | { kind: 'relay-node'; nodeId: NodeId; credentialId?: string; displayName?: string }
+  | {
+      kind: 'agent';
+      id: string;
+      adapter: string;
+      displayName?: string;
+      credentialId?: string;
+    }
   | { kind: 'unknown'; id?: string; displayName?: string };
 
 export interface SessionEnvelope {
@@ -123,6 +130,9 @@ function isPeerIdentity(value: unknown): value is SessionPeerIdentity {
   if (!candidate) return false;
   if (candidate['kind'] === 'local-user') return typeof candidate['id'] === 'string';
   if (candidate['kind'] === 'relay-node') return typeof candidate['nodeId'] === 'string';
+  if (candidate['kind'] === 'agent') {
+    return typeof candidate['id'] === 'string' && typeof candidate['adapter'] === 'string';
+  }
   return candidate['kind'] === 'unknown';
 }
 

--- a/test/browser-cli.test.ts
+++ b/test/browser-cli.test.ts
@@ -2,9 +2,41 @@ import { test, beforeEach, afterEach, expect } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { execFileSync } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
+import * as http from 'node:http';
 
 let tmpDir: string;
+
+type CapturedGatewayRequest = {
+  method: string | undefined;
+  url: string | undefined;
+  authorization: string | undefined;
+  marker: string | string[] | undefined;
+  body?: Record<string, unknown>;
+};
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing server address');
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  server.closeAllConnections?.();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function execNode(args: string[], env: NodeJS.ProcessEnv): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    execFile('node', args, { encoding: 'utf-8', env, timeout: 10_000 }, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browser-cli-test-'));
@@ -96,4 +128,86 @@ test('browser command fails when token not set', () => {
     expect(e.status).not.toBe(0);
     expect(e.stderr ?? '').toContain('RELAY_IDE_BROWSER_TOKEN');
   }
+});
+
+test('v1 gateway commands use scoped bearer auth and the v1 marker header', async () => {
+  const captured: CapturedGatewayRequest[] = [];
+  const server = http.createServer((req, res) => {
+    const entry: CapturedGatewayRequest = {
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.authorization,
+      marker: req.headers['x-relay-cli-gateway'],
+    };
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const rawBody = Buffer.concat(chunks).toString('utf8');
+      if (rawBody) entry.body = JSON.parse(rawBody) as Record<string, unknown>;
+      captured.push(entry);
+      res.setHeader('content-type', 'application/json');
+      if (req.method === 'GET' && req.url === '/sessions') {
+        res.end(JSON.stringify([]));
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/sessions') {
+        res.end(
+          JSON.stringify({
+            id: 'local-created',
+            type: entry.body?.['type'] ?? 'agent',
+            agent: 'claude',
+            mode: 'pty',
+            cwd: entry.body?.['repoPath'] ?? '/tmp/repo',
+            displayName: 'created',
+            status: 'active',
+          })
+        );
+        return;
+      }
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: 'not found' }));
+    });
+  });
+  const port = await listen(server);
+  try {
+    const env = {
+      ...process.env,
+      RELAY_IDE_PORT: String(port),
+      RELAY_IDE_BROWSER_TOKEN: 'scoped-token',
+      PATH: process.env.PATH,
+    };
+    await execNode(['dist/bin/relay-ide.js', 'v1', 'sessions', 'list', '--json'], env);
+    await execNode(
+      [
+        'dist/bin/relay-ide.js',
+        'v1',
+        'sessions',
+        'create',
+        '--input-json',
+        '{"repoPath":"/tmp/repo"}',
+        '--json',
+      ],
+      env
+    );
+  } finally {
+    await close(server);
+  }
+
+  expect(captured).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        method: 'GET',
+        url: '/sessions',
+        authorization: 'Bearer scoped-token',
+        marker: 'v1',
+      }),
+      expect.objectContaining({
+        method: 'POST',
+        url: '/sessions',
+        authorization: 'Bearer scoped-token',
+        marker: 'v1',
+        body: expect.objectContaining({ repoPath: '/tmp/repo', type: 'agent' }),
+      }),
+    ])
+  );
 });

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RELAY_CLI_GATEWAY_CONTRACT,
+  RELAY_CLI_GATEWAY_CONTRACT_VERSION,
+  RELAY_CLI_GATEWAY_MAJOR,
+  commandSpec,
+  gatewayError,
+  gatewayOk,
+  stableCommandNames,
+} from '../shared/cli-gateway-contract.js';
+
+describe('CLI gateway contract', () => {
+  it('exposes a stable versioned command manifest for node/session adapters', () => {
+    expect(RELAY_CLI_GATEWAY_CONTRACT).toMatchObject({
+      schemaVersion: 1,
+      contract: 'v1',
+      contractVersion: '1.0',
+      generatedFrom: 'shared/cli-gateway-contract.ts',
+    });
+
+    expect(stableCommandNames()).toEqual([
+      'contract.list',
+      'contract.schema',
+      'nodes.manifest',
+      'nodes.list',
+      'sessions.list',
+      'sessions.get',
+      'sessions.create',
+      'sessions.interventions',
+      'sessions.handBack',
+    ]);
+
+    for (const spec of RELAY_CLI_GATEWAY_CONTRACT.commandSchemas) {
+      expect(spec.stable).toBe(true);
+      expect(spec.cli).toContain('--json');
+      expect(spec.inputSchema).toBeDefined();
+      expect(spec.outputSchema).toBeDefined();
+      expect(spec.errorCodes.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps success and error envelopes machine-readable and versioned', () => {
+    expect(gatewayOk('nodes.list', { nodes: [] })).toEqual({
+      ok: true,
+      contract: RELAY_CLI_GATEWAY_MAJOR,
+      contractVersion: RELAY_CLI_GATEWAY_CONTRACT_VERSION,
+      command: 'nodes.list',
+      data: { nodes: [] },
+    });
+
+    expect(
+      gatewayError('sessions.create', {
+        code: 'UNSUPPORTED',
+        message: 'local create cannot safely honor cwd',
+        retryable: false,
+        details: { field: 'cwd' },
+      })
+    ).toEqual({
+      ok: false,
+      contract: RELAY_CLI_GATEWAY_MAJOR,
+      contractVersion: RELAY_CLI_GATEWAY_CONTRACT_VERSION,
+      command: 'sessions.create',
+      error: {
+        code: 'UNSUPPORTED',
+        message: 'local create cannot safely honor cwd',
+        retryable: false,
+        details: { field: 'cwd' },
+      },
+    });
+  });
+
+  it('fails closed in the create schema and models brain-as-peer identity explicitly', () => {
+    const create = commandSpec('sessions.create');
+    expect(create.inputSchema).toMatchObject({
+      type: 'object',
+      additionalProperties: false,
+    });
+    expect(create.errorCodes).toContain('UNSUPPORTED');
+    expect(create.capabilityHints).toEqual([
+      'session:create:terminal',
+      'session:create:agent',
+      'tab:mode:set-agent',
+    ]);
+
+    const createProperties = create.inputSchema.properties ?? {};
+    expect(createProperties['sessionEnvelope']).toBeDefined();
+    expect(JSON.stringify(create.inputSchema)).toContain('"kind":{"const":"agent"}');
+    expect(JSON.stringify(create.inputSchema)).toContain('"adapter"');
+  });
+
+  it('does not expose raw intervention payloads as a gateway contract', () => {
+    const interventions = commandSpec('sessions.interventions');
+    expect(interventions.outputSchema).toMatchObject({
+      properties: {
+        data: {
+          properties: {
+            rawPayloadAvailable: { const: false },
+            transcriptExportAvailable: { const: false },
+          },
+        },
+      },
+    });
+  });
+});

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -8,6 +8,12 @@ import {
   gatewayOk,
   stableCommandNames,
 } from '../shared/cli-gateway-contract.js';
+import {
+  gatewayErrorRetryable,
+  normalizeGatewayErrorCode,
+  sanitizedGatewayErrorDetails,
+  validateAndSanitizeGatewayCreateInput,
+} from '../shared/cli-gateway-runtime.js';
 
 describe('CLI gateway contract', () => {
   it('exposes a stable versioned command manifest for node/session adapters', () => {
@@ -69,7 +75,7 @@ describe('CLI gateway contract', () => {
     });
   });
 
-  it('fails closed in the create schema and models brain-as-peer identity explicitly', () => {
+  it('fails closed in the create schema and does not advertise unimplemented agent peer round-trips', () => {
     const create = commandSpec('sessions.create');
     expect(create.inputSchema).toMatchObject({
       type: 'object',
@@ -84,8 +90,89 @@ describe('CLI gateway contract', () => {
 
     const createProperties = create.inputSchema.properties ?? {};
     expect(createProperties['sessionEnvelope']).toBeDefined();
-    expect(JSON.stringify(create.inputSchema)).toContain('"kind":{"const":"agent"}');
-    expect(JSON.stringify(create.inputSchema)).toContain('"adapter"');
+    expect(JSON.stringify(create.inputSchema)).not.toContain('"kind":{"const":"agent"}');
+    expect(JSON.stringify(create.inputSchema)).not.toContain('"adapter"');
+  });
+
+  it('validates and sanitizes sessions.create input before forwarding', () => {
+    const hidden = validateAndSanitizeGatewayCreateInput({
+      repoPath: '/tmp/repo',
+      type: 'agent',
+      claudeArgs: ['--dangerously-skip-permissions'],
+    });
+    expect(hidden).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_ARGUMENT', details: { field: 'claudeArgs' } },
+    });
+
+    const localLifecycle = validateAndSanitizeGatewayCreateInput({
+      repoPath: '/tmp/repo',
+      ttlSeconds: 60,
+    });
+    expect(localLifecycle).toMatchObject({
+      ok: false,
+      error: { code: 'UNSUPPORTED', details: { field: 'ttlSeconds' } },
+    });
+
+    const localEnvelope = validateAndSanitizeGatewayCreateInput({
+      repoPath: '/tmp/repo',
+      sessionEnvelope: { peerIdentity: { kind: 'relay-node', nodeId: 'node-a' } },
+    });
+    expect(localEnvelope).toMatchObject({
+      ok: false,
+      error: { code: 'UNSUPPORTED', details: { field: 'sessionEnvelope' } },
+    });
+
+    const agentPeer = validateAndSanitizeGatewayCreateInput({
+      nodeId: 'node-a',
+      repoPath: '/tmp/repo',
+      sessionEnvelope: { peerIdentity: { kind: 'agent', id: 'brain', adapter: 'kbrain' } },
+    });
+    expect(agentPeer).toMatchObject({
+      ok: false,
+      error: {
+        code: 'UNSUPPORTED',
+        details: { field: 'sessionEnvelope.peerIdentity.kind' },
+      },
+    });
+
+    const routedDefault = validateAndSanitizeGatewayCreateInput({
+      nodeId: 'node-a',
+      repoPath: '/tmp/repo',
+    });
+    if (routedDefault.ok !== true) throw new Error('expected routed create input to validate');
+    expect(routedDefault.sessionType).toBe('agent');
+    expect(routedDefault.input).toMatchObject({
+      nodeId: 'node-a',
+      repoPath: '/tmp/repo',
+      type: 'agent',
+    });
+  });
+
+  it('normalizes routed errors without exposing raw upstream bodies', () => {
+    expect(
+      normalizeGatewayErrorCode(409, {
+        error: { code: 'CONFIRMATION_REQUIRED', retryable: true },
+      })
+    ).toBe('CONFIRMATION_REQUIRED');
+    expect(
+      normalizeGatewayErrorCode(404, {
+        error: { code: 'NODE_OFFLINE', retryable: true, details: { path: '/internal' } },
+      })
+    ).toBe('NODE_OFFLINE');
+    expect(
+      gatewayErrorRetryable(404, { error: { code: 'NODE_OFFLINE', retryable: true } })
+    ).toBe(true);
+    expect(
+      sanitizedGatewayErrorDetails(500, {
+        error: {
+          code: 'INTERNAL',
+          message: 'boom',
+          details: { path: '/secret/internal', field: 'repoPath' },
+          stack: 'nope',
+        },
+      })
+    ).toEqual({ status: 500, upstreamCode: 'INTERNAL', field: 'repoPath' });
   });
 
   it('does not expose raw intervention payloads as a gateway contract', () => {

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -9,10 +9,13 @@ import {
   stableCommandNames,
 } from '../shared/cli-gateway-contract.js';
 import {
+  gatewayCliInvalidArgumentError,
+  gatewayCliInvalidJsonError,
   gatewayErrorRetryable,
   normalizeGatewayErrorCode,
   sanitizedGatewayErrorDetails,
   validateAndSanitizeGatewayCreateInput,
+  validateAndSanitizeLocalGatewayCreateInput,
 } from '../shared/cli-gateway-runtime.js';
 
 describe('CLI gateway contract', () => {
@@ -147,6 +150,71 @@ describe('CLI gateway contract', () => {
       repoPath: '/tmp/repo',
       type: 'agent',
     });
+  });
+
+  it('applies the v1 create contract to direct local /sessions gateway bodies', () => {
+    const hidden = validateAndSanitizeLocalGatewayCreateInput({
+      repoPath: '/tmp/repo',
+      claudeArgs: ['--dangerously-skip-permissions'],
+    });
+    expect(hidden).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_ARGUMENT', details: { field: 'claudeArgs' } },
+    });
+
+    const routedOnly = validateAndSanitizeLocalGatewayCreateInput({
+      nodeId: 'node-a',
+      repoPath: '/tmp/repo',
+    });
+    expect(routedOnly).toMatchObject({
+      ok: false,
+      error: { code: 'UNSUPPORTED', details: { field: 'nodeId' } },
+    });
+
+    const clean = validateAndSanitizeLocalGatewayCreateInput({
+      repoPath: '/tmp/repo',
+      worktreePath: null,
+      type: 'terminal',
+      cols: 120,
+    });
+    expect(clean).toMatchObject({
+      ok: true,
+      input: {
+        repoPath: '/tmp/repo',
+        worktreePath: null,
+        type: 'terminal',
+        cols: 120,
+      },
+      sessionType: 'terminal',
+    });
+  });
+
+  it('advertises CLI argument and JSON parse errors emitted by gateway commands', () => {
+    const invalidArgumentCommands = [
+      'contract.list',
+      'nodes.list',
+      'sessions.list',
+      'sessions.get',
+      'sessions.create',
+      'sessions.interventions',
+      'sessions.handBack',
+    ] as const;
+
+    for (const command of invalidArgumentCommands) {
+      const emitted = gatewayError(
+        command,
+        gatewayCliInvalidArgumentError(command, 'invalid gateway command arguments')
+      );
+      expect(emitted.error.code).toBe('INVALID_ARGUMENT');
+      expect(commandSpec(command).errorCodes).toContain(emitted.error.code);
+    }
+
+    const invalidJson = gatewayError(
+      'sessions.create',
+      gatewayCliInvalidJsonError('sessions.create', 'Unexpected end of JSON input')
+    );
+    expect(invalidJson.error.code).toBe('INVALID_JSON');
+    expect(commandSpec('sessions.create').errorCodes).toContain(invalidJson.error.code);
   });
 
   it('normalizes routed errors without exposing raw upstream bodies', () => {

--- a/test/hub-node-session-routing.test.ts
+++ b/test/hub-node-session-routing.test.ts
@@ -246,15 +246,28 @@ describe('hub-routed node session create and attach', () => {
     const sessionEnvelopes = createSessionEnvelopeRegistry();
     const app = express();
     app.use(express.json());
+    const requireAuth: express.RequestHandler = (req, res, next) => {
+      if (req.header('x-test-auth') === 'yes') next();
+      else res.status(401).json({ error: 'Unauthorized' });
+    };
+    const cliGatewayAuth: express.RequestHandler = (req, res, next) => {
+      if (
+        req.header('x-test-auth') === 'yes' ||
+        (req.header('x-relay-cli-gateway') === 'v1' &&
+          req.header('authorization') === 'Bearer scoped-test-token')
+      ) {
+        next();
+        return;
+      }
+      res.status(401).json({ error: 'Unauthorized' });
+    };
     app.use(
       createHubNodeRouter({
         registry,
         nodeLinks,
         sessionEnvelopes,
-        requireAuth: (req, res, next) => {
-          if (req.header('x-test-auth') === 'yes') next();
-          else res.status(401).json({ error: 'Unauthorized' });
-        },
+        requireAuth,
+        cliGatewayAuth,
       })
     );
     const server = http.createServer(app);
@@ -280,6 +293,32 @@ describe('hub-routed node session create and attach', () => {
       registry,
     };
   }
+
+  it('lets v1 CLI gateway scoped bearer auth read nodes and create routed sessions without cookies', async () => {
+    const { base } = await startHub();
+    const { nodeId } = await pairNode(base);
+    const cliHeaders = {
+      authorization: 'Bearer scoped-test-token',
+      'x-relay-cli-gateway': 'v1',
+    };
+
+    const nodesRes = await fetch(`${base}/nodes`, { headers: cliHeaders });
+    expect(nodesRes.status).toBe(200);
+    expect(await nodesRes.json()).toMatchObject({ nodes: [{ nodeId }] });
+
+    const createRes = await fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`,
+      {
+        method: 'POST',
+        headers: { ...cliHeaders, 'content-type': 'application/json' },
+        body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
+      }
+    );
+    expect(createRes.status).toBe(404);
+    expect(await createRes.json()).toMatchObject({
+      error: { code: 'NODE_OFFLINE', retryable: true },
+    });
+  });
 
   it('returns NODE_OFFLINE when a selected node has no live reverse link', async () => {
     const { base } = await startHub();

--- a/test/hub-node-session-routing.test.ts
+++ b/test/hub-node-session-routing.test.ts
@@ -320,6 +320,120 @@ describe('hub-routed node session create and attach', () => {
     });
   });
 
+  it('rejects hidden v1 create fields before node-link routing', async () => {
+    const { base } = await startHub();
+    const { nodeId } = await pairNode(base);
+
+    const res = await fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer scoped-test-token',
+          'x-relay-cli-gateway': 'v1',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          repoPath: '/srv/relay-ide',
+          type: 'terminal',
+          command: 'hidden-non-contract-field',
+        }),
+      }
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: {
+        code: 'INVALID_ARGUMENT',
+        details: { field: 'command' },
+      },
+    });
+  });
+
+  it('defaults routed v1 creates to agent and forwards only sanitized fields', async () => {
+    const { base, wsBase } = await startHub();
+    const { token, nodeId } = await pairNode(base);
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const createPromise = fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer scoped-test-token',
+          'x-relay-cli-gateway': 'v1',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ repoPath: '/srv/relay-ide' }),
+      }
+    );
+
+    const request = await nextJson(nodeWs);
+    expect(request).toMatchObject({
+      nodeId,
+      channel: 'rpc',
+      type: 'sessions.create',
+      payload: { repoPath: '/srv/relay-ide', type: 'agent' },
+    });
+    expect(request.payload as Record<string, unknown>).not.toHaveProperty('nodeId');
+    nodeWs.send(
+      JSON.stringify({
+        protocol: request.protocol,
+        protocolVersion: request.protocolVersion,
+        nodeId,
+        channel: 'rpc',
+        type: 'sessions.create.result',
+        requestId: request.requestId,
+        timestamp: new Date().toISOString(),
+        payload: {
+          session: {
+            ...remoteSession(nodeId),
+            type: 'agent',
+            displayName: 'relay-ide agent',
+          },
+        },
+      })
+    );
+
+    const res = await createPromise;
+    expect(res.status).toBe(201);
+    expect(await res.json()).toMatchObject({ type: 'agent', nodeId });
+  });
+
+  it('rejects routed v1 create bodies with a conflicting nodeId', async () => {
+    const { base } = await startHub();
+    const { nodeId } = await pairNode(base);
+
+    const res = await fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions`,
+      {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer scoped-test-token',
+          'x-relay-cli-gateway': 'v1',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          nodeId: 'other-node',
+          repoPath: '/srv/relay-ide',
+          type: 'terminal',
+        }),
+      }
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: {
+        code: 'INVALID_ARGUMENT',
+        details: { field: 'nodeId', nodeId, bodyNodeId: 'other-node' },
+      },
+    });
+  });
+
   it('returns NODE_OFFLINE when a selected node has no live reverse link', async () => {
     const { base } = await startHub();
     const { nodeId } = await pairNode(base);

--- a/test/session-envelope-registry.test.ts
+++ b/test/session-envelope-registry.test.ts
@@ -67,6 +67,47 @@ describe('session envelope registry', () => {
     });
   });
 
+  it('accepts explicit agent peer identities for future brain-as-peer adapters', () => {
+    const registry = createSessionEnvelopeRegistry();
+    const envelope = registry.create({
+      envelope: {
+        sessionId: 'agent-peer-session',
+        globalSessionId: 'node-a:agent-peer-session',
+        nodeId: 'node-a',
+        intent: {
+          kind: ROUTED_NODE_SESSION_INTENT,
+          description: 'adapter-owned routed node session',
+        },
+        scope: {
+          kind: 'node-cwd',
+          nodeId: 'node-a',
+          cwd: '/srv/app',
+        },
+        issuedAt: '2026-01-02T03:04:05.000Z',
+        expiresAt: null,
+        revocable: true,
+        peerIdentity: {
+          kind: 'agent',
+          id: 'brain-1',
+          adapter: 'example-adapter',
+          displayName: 'Example Brain',
+        },
+      },
+      sessionId: 'agent-peer-session',
+      nodeId: 'node-a',
+      cwd: '/srv/app',
+      issuedAt: '2026-01-02T03:04:05.000Z',
+      intentKind: ROUTED_NODE_SESSION_INTENT,
+    });
+
+    expect(envelope.peerIdentity).toEqual({
+      kind: 'agent',
+      id: 'brain-1',
+      adapter: 'example-adapter',
+      displayName: 'Example Brain',
+    });
+  });
+
   it('validates allowed, expired, revoked, and mismatched routed envelopes', () => {
     const registry = createSessionEnvelopeRegistry();
     const issuedAt = '2026-01-02T03:04:05.000Z';


### PR DESCRIPTION
## Summary
- Adds a versioned `relay-ide v1 ... --json` CLI gateway surface for contract discovery, local node manifest, hub node/session listing, session inspection, session create, intervention metadata reads, and hand-back.
- Adds `shared/cli-gateway-contract.ts` as the adapter-generation source of truth with command schemas, stable envelopes, error taxonomy, and fail-closed unsupported semantics.
- Extends #426 session peer identity with explicit `kind: "agent"` support for brain-as-peer adapters.
- Documents the v1 CLI gateway contract in `docs/CLI_GATEWAY.md` and links it from `AGENTS.md`.

Closes #524

## Motivation
#430 adapters need a stable machine-readable contract instead of hand-coded Claude/Codex/Hermes schemas or direct coupling to `/hub/node-link`. This keeps external brains as hub-level peers of Relay sessions while leaving the internal node-link WebSocket free to evolve.

## The Case Against
This PR might be wrong because:
- The CLI gateway implementation currently lives inside `bin/relay-ide.ts`, which is already a large CLI entrypoint. I extracted helper functions to satisfy complexity gates, but a future slice may still want a dedicated module once more verbs land.
- Several verbs (`sessions.interventions`, `sessions.hand-back`) are contract/CLI routed now, but depend on backend routes/policy existing and returning meaningful typed upstream errors. If those routes are incomplete in a deployment, callers get typed gateway failures rather than working behavior.
- The JSON Schema is intentionally hand-authored TypeScript objects, not generated from runtime validators. That is acceptable for the foundation but means reviewers should watch future edits for schema/runtime drift.
- `sessions.create` exposes only the safe subset currently supported by local/routed backend paths. Adapters needing attach/input/event streaming still need follow-up CLI contract work instead of bypassing the gateway.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Adapter contract drift | Committed `shared/cli-gateway-contract.ts` plus stability tests for command names, envelopes, schema shape, and intervention redaction fields. |
| Silent privilege downgrade | Local unsupported `cwd` and `controlMode=agent-driven` requests fail closed with typed `UNSUPPORTED` envelopes. |
| Human CLI regression | Gateway dispatch is only under explicit `v1 ... --json`; existing human-readable command paths are left intact. |
| Raw human intervention leakage | Contract docs/tests mark raw payload and transcript export unavailable for intervention reads. |

## Verification
- `npm test -- test/cli-gateway-contract.test.ts test/session-envelope-registry.test.ts` — 12/12 passing
- `npm run check` — passing with existing warnings only
- `npm run build` — passing
- Built CLI smoke: `node dist/bin/relay-ide.js v1 schema --json` produced `contract.schema:9`
- Built CLI smoke: `node dist/bin/relay-ide.js v1 sessions create --input-json '{"cwd":"/tmp"}' --json` exited 1 with `sessions.create:UNSUPPORTED`

## Notes
- No Claude/Codex/Hermes adapter implementation is included.
- No `/hub/node-link` WebSocket protocol rewrite, event bus, File RPC, destructive op expansion, or #444 IA migration is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced CLI gateway v1 command exposing node and session operations over HTTP with JSON contracts for programmatic access.
  * Added support for agent peer identity in session envelopes.

* **Documentation**
  * Added CLI gateway contract specification and documentation reference.

* **Tests**
  * Added comprehensive test coverage for CLI gateway functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/527?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->