### PR TITLE
test: stabilize nightly publish flakes

### DIFF
--- a/server/local-logs.ts
+++ b/server/local-logs.ts
@@ -129,13 +129,18 @@ export function createLocalLogFollower(options: {
   files: string[];
   write: (chunk: string) => void;
   onError?: (error: Error) => void;
+  createReadStream?: typeof fs.createReadStream;
   pollIntervalMs?: number;
 }): LocalLogFollower {
   const followedFiles = new Map<string, FollowedFileState>();
+  const activeReads = new Set<string>();
   const files = Array.from(new Set(options.files));
   const pollIntervalMs = options.pollIntervalMs ?? 500;
+  const createReadStream = options.createReadStream ?? fs.createReadStream;
 
   const pollFile = (file: string): void => {
+    if (activeReads.has(file)) return;
+
     let curr: fs.Stats;
     try {
       curr = fs.statSync(file);
@@ -152,16 +157,33 @@ export function createLocalLogFollower(options: {
       followedFiles.set(file, { offset: curr.size, identity: currentIdentity });
       return;
     }
+
+    activeReads.add(file);
+    const chunks: string[] = [];
     try {
-      followedFiles.set(file, { offset: curr.size, identity: currentIdentity });
-      const stream = fs.createReadStream(file, {
+      const stream = createReadStream(file, {
         start,
         end: curr.size - 1,
         encoding: 'utf8',
       });
-      stream.on('data', (chunk) => options.write(String(chunk)));
-      stream.on('error', (error) => options.onError?.(error));
+      stream.on('data', (chunk) => chunks.push(String(chunk)));
+      stream.on('end', () => {
+        try {
+          const output = chunks.join('');
+          if (output.length > 0) options.write(output);
+          followedFiles.set(file, { offset: curr.size, identity: currentIdentity });
+        } catch (error) {
+          options.onError?.(error instanceof Error ? error : new Error(String(error)));
+        } finally {
+          activeReads.delete(file);
+        }
+      });
+      stream.on('error', (error) => {
+        activeReads.delete(file);
+        options.onError?.(error);
+      });
     } catch (error) {
+      activeReads.delete(file);
       options.onError?.(error instanceof Error ? error : new Error(String(error)));
     }
   };

--- a/server/local-logs.ts
+++ b/server/local-logs.ts
@@ -133,43 +133,51 @@ export function createLocalLogFollower(options: {
 }): LocalLogFollower {
   const followedFiles = new Map<string, FollowedFileState>();
   const files = Array.from(new Set(options.files));
+  const pollIntervalMs = options.pollIntervalMs ?? 500;
+
+  const pollFile = (file: string): void => {
+    let curr: fs.Stats;
+    try {
+      curr = fs.statSync(file);
+    } catch {
+      return;
+    }
+    if (!curr.isFile()) return;
+
+    const previousState = followedFiles.get(file) ?? { offset: 0 };
+    const currentIdentity = fileIdentity(curr);
+    const rotated = !sameFileIdentity(previousState.identity, currentIdentity);
+    const start = rotated || curr.size < previousState.offset ? 0 : previousState.offset;
+    if (curr.size <= start) {
+      followedFiles.set(file, { offset: curr.size, identity: currentIdentity });
+      return;
+    }
+    try {
+      followedFiles.set(file, { offset: curr.size, identity: currentIdentity });
+      const stream = fs.createReadStream(file, {
+        start,
+        end: curr.size - 1,
+        encoding: 'utf8',
+      });
+      stream.on('data', (chunk) => options.write(String(chunk)));
+      stream.on('error', (error) => options.onError?.(error));
+    } catch (error) {
+      options.onError?.(error instanceof Error ? error : new Error(String(error)));
+    }
+  };
+
   for (const file of files) {
     followedFiles.set(file, initialFollowedFileState(file));
-    fs.watchFile(
-      file,
-      { interval: options.pollIntervalMs ?? 500, persistent: true },
-      (curr) => {
-        if (!curr.isFile()) return;
-        const previousState = followedFiles.get(file) ?? { offset: 0 };
-        const currentIdentity = fileIdentity(curr);
-        const rotated = !sameFileIdentity(previousState.identity, currentIdentity);
-        const start = rotated || curr.size < previousState.offset ? 0 : previousState.offset;
-        if (curr.size <= start) {
-          followedFiles.set(file, { offset: curr.size, identity: currentIdentity });
-          return;
-        }
-        try {
-          const stream = fs.createReadStream(file, {
-            start,
-            end: curr.size - 1,
-            encoding: 'utf8',
-          });
-          stream.on('data', (chunk) => options.write(String(chunk)));
-          stream.on('error', (error) => options.onError?.(error));
-          stream.on('end', () => {
-            followedFiles.set(file, { offset: curr.size, identity: currentIdentity });
-          });
-        } catch (error) {
-          options.onError?.(error instanceof Error ? error : new Error(String(error)));
-        }
-      }
-    );
   }
+
+  const pollTimer = setInterval(() => {
+    for (const file of files) pollFile(file);
+  }, pollIntervalMs);
 
   return {
     files,
     close() {
-      for (const file of files) fs.unwatchFile(file);
+      clearInterval(pollTimer);
     },
   };
 }

--- a/test/local-logs.test.ts
+++ b/test/local-logs.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { PassThrough } from 'node:stream';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   createLocalLogFollower,
@@ -163,6 +164,64 @@ describe('local Relay logs', () => {
       fs.appendFileSync(logFile, 'appended\n');
       await waitFor(() => output.includes('appended'));
       expect(output).toBe('appended\n');
+    } finally {
+      follower.close();
+    }
+  });
+
+  it('retries an unread append after an async stream error', async () => {
+    const dir = makeTempDir();
+    const logFile = path.join(dir, 'relay-ide.log');
+    fs.writeFileSync(logFile, 'existing\n');
+    const failingStream = new PassThrough();
+    let failNextRead = true;
+    const createReadStream = ((...args: Parameters<typeof fs.createReadStream>) => {
+      if (failNextRead) {
+        failNextRead = false;
+        queueMicrotask(() => failingStream.destroy(new Error('simulated stream failure')));
+        return failingStream as ReturnType<typeof fs.createReadStream>;
+      }
+      return fs.createReadStream(...args);
+    }) as typeof fs.createReadStream;
+    const errors: Error[] = [];
+    let output = '';
+    const follower = createLocalLogFollower({
+      files: [logFile],
+      pollIntervalMs: 20,
+      createReadStream,
+      write: (chunk) => {
+        output += chunk;
+      },
+      onError: (error) => errors.push(error),
+    });
+
+    try {
+      fs.appendFileSync(logFile, 'after-error\n');
+      await waitFor(() => errors.some((error) => error.message === 'simulated stream failure'));
+      await waitFor(() => output.includes('after-error'));
+      expect(output).toBe('after-error\n');
+    } finally {
+      follower.close();
+    }
+  });
+
+  it('follows a truncated log file from the beginning', async () => {
+    const dir = makeTempDir();
+    const logFile = path.join(dir, 'relay-ide.log');
+    fs.writeFileSync(logFile, 'existing-long-line\n');
+    let output = '';
+    const follower = createLocalLogFollower({
+      files: [logFile],
+      pollIntervalMs: 20,
+      write: (chunk) => {
+        output += chunk;
+      },
+    });
+
+    try {
+      fs.writeFileSync(logFile, 'new\n');
+      await waitFor(() => output.includes('new'));
+      expect(output).toBe('new\n');
     } finally {
       follower.close();
     }

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -61,7 +61,8 @@ function delay(ms: number): Promise<void> {
 }
 
 async function waitForTmuxSession(name: string): Promise<void> {
-  for (let i = 0; i < 20; i++) {
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
     try {
       await execTmux(['has-session', '-t', name]);
       return;
@@ -80,23 +81,32 @@ async function waitForSessionRemoval(id: string): Promise<void> {
   expect(sessions.get(id)).toBeUndefined();
 }
 
-afterEach(() => {
+afterEach(async () => {
   // Kill any remaining sessions created during tests. Some restore tests add
   // sessions directly from disk, so cleanup must inspect the live registry too.
   const ids = new Set([
     ...createdIds,
     ...sessions.list().map((session) => session.id),
   ]);
+  const tmuxSessionNames: string[] = [];
   for (const id of ids) {
     try {
       const session = sessions.get(id);
       if (session) {
+        if (session.mode === 'pty' && session.tmuxSessionName) {
+          tmuxSessionNames.push(session.tmuxSessionName);
+        }
         sessions.kill(id);
       }
     } catch {
       // Already killed or exited, ignore
     }
   }
+  await Promise.all(
+    tmuxSessionNames.map((name) =>
+      execTmux(['kill-session', '-t', name]).catch(() => {})
+    )
+  );
   createdIds.length = 0;
 });
 


### PR DESCRIPTION
## Summary
- replaces the local Relay log follower's `fs.watchFile` callback dependency with explicit polling against tracked file identity/offset state, so rotate-and-recreate writes are detected even when they happen before Node's internal watcher baseline observes the old file
- makes the tmux-heavy `sessions.test.ts` cleanup await targeted `tmux kill-session` calls before the next test starts, and gives tmux session adoption checks a 3s startup window under full-suite process load

Closes #526.

## Why
The #523 post-merge nightly publish run failed twice on full-suite timing flakes before passing on the third attempt:
1. `detachForRestart leaves the tmux session alive for restore adoption` could see no private tmux server after adjacent tmux tests cleaned up asynchronously.
2. `follows a recreated log file from the beginning after rotation` could miss a rapid rotate/recreate because the write happened before `fs.watchFile` reported a change.

Both failures were full-suite timing/isolation behavior, not #492 product UI behavior.

## The case against
- The log follower now owns its polling loop instead of using `fs.watchFile`; this is slightly more manual code and could miss a chunk if `createReadStream` errors after the offset is advanced. Existing behavior already treated follower errors as best-effort via `onError`, and this path only advances after a successful stat showing new bytes.
- Awaiting test cleanup adds a bit of runtime to `sessions.test.ts`. The targeted file still finishes in seconds locally, and the full suite is less likely to inherit an in-flight tmux cleanup.
- The tmux wait increase could hide very slow startup. It is bounded at 3s and still fails with the real `tmux has-session` error, so it should reduce noise without making hangs opaque.

## Verification
- `npm test -- test/sessions.test.ts test/local-logs.test.ts` — 79 passed
- stress: local-log rotation test 10/10 passed
- stress: detachForRestart test 5/5 passed
- `npm run build` — passed
- `npm test` after build — 211 files / 2240 tests passed
- `npm run check` — passed with existing warnings only (0 errors, 44 warnings)
