### PR TITLE
feat: broadcast hub node status events

### DIFF
--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -160,6 +160,30 @@ Capability checks currently use the #427 placeholder header contract: omitted `x
   - `stale` → `offline` after 90s without heartbeat
 - Heartbeat state is persisted to disk with a 5s debounce (`DEFAULT_HEARTBEAT_PERSIST_DEBOUNCE_MS`).
 
+### Browser node-status events (#466)
+
+The authenticated browser event WebSocket (`/ws/events`) emits node status transitions as compact cache-update envelopes. The browser still uses `GET /nodes` for the initial node snapshot, window-refocus/manual refreshes, and one reconnect resync after the event socket reconnects; `node.status` only replaces interval polling for observed transitions.
+
+```json
+{
+  "type": "node.status",
+  "nodeId": "node_dev_macbook",
+  "status": "online",
+  "lastSeenAt": "2026-05-16T17:42:00.000Z",
+  "manifest": {
+    "schemaVersion": 1,
+    "platform": "darwin",
+    "arch": "arm64",
+    "hostname": "dev-macbook",
+    "relayVersion": "0.1.0",
+    "generatedAt": "2026-05-16T17:42:00.000Z",
+    "capabilities": {}
+  }
+}
+```
+
+`status` is one of `online`, `stale`, `offline`, or `revoked`. `manifest` is optional and is present when the transition came from a fresh node hello/heartbeat; stale/offline/revoked transitions usually include only `nodeId`, `status`, and `lastSeenAt`.
+
 ## Pairing and Credential Lifecycle
 
 ### Step 1: Generate a pair token

--- a/frontend/src/components/HubNodeDashboard.tsx
+++ b/frontend/src/components/HubNodeDashboard.tsx
@@ -101,8 +101,8 @@ export function HubNodeDashboardPanel() {
   const { data: nodes } = useQuery({
     queryKey: ['hub-nodes'],
     queryFn: fetchHubNodes,
-    staleTime: 15_000,
-    refetchInterval: 15_000,
+    staleTime: Infinity,
+    refetchOnWindowFocus: 'always',
     retry: false,
   });
 

--- a/frontend/src/components/TerminalNodePicker.tsx
+++ b/frontend/src/components/TerminalNodePicker.tsx
@@ -145,7 +145,8 @@ export function TerminalNodePicker({
     queryKey: ['hub-nodes'],
     queryFn: fetchHubNodes,
     enabled: open,
-    refetchOnWindowFocus: false,
+    staleTime: Infinity,
+    refetchOnWindowFocus: 'always',
   });
 
   const choices = useMemo(() => buildChoices(nodes), [nodes]);

--- a/frontend/src/components/WorkspaceArea.tsx
+++ b/frontend/src/components/WorkspaceArea.tsx
@@ -534,8 +534,8 @@ export function WorkspaceArea({
   const hubNodesQuery = useQuery({
     queryKey: ['hub-nodes'],
     queryFn: fetchHubNodes,
-    refetchInterval: 15_000,
-    refetchOnWindowFocus: false,
+    staleTime: Infinity,
+    refetchOnWindowFocus: 'always',
   });
   const hubNodes = hubNodesQuery.data;
 

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import DialogShell, { type DialogShellHandle } from './DialogShell.js';
 import TuiButton from '../TuiButton.js';
 import TuiCheckbox from '../TuiCheckbox.js';
@@ -887,6 +888,7 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
   function CustomizeSessionDialog({ onSessionCreated }, ref) {
     const shellRef = useRef<DialogShellHandle>(null);
     const openRequestIdRef = useRef(0);
+    const queryClient = useQueryClient();
     const [workspacePath, setWorkspacePath] = useState('');
     const [worktreePath, setWorktreePath] = useState<string | null>(null);
     const [workspaceName, setWorkspaceName] = useState('');
@@ -940,6 +942,16 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
     const selectedRemoteHome = cleanCwd(selectedRemoteNode?.homeDir);
 
     useEffect(() => {
+      return queryClient.getQueryCache().subscribe((event) => {
+        if (event.query.queryKey[0] !== 'hub-nodes') return;
+        const nextNodes = event.query.state.data;
+        if (Array.isArray(nextNodes)) {
+          setNodes(nextNodes as HubNodeSummary[]);
+        }
+      });
+    }, [queryClient]);
+
+    useEffect(() => {
       if (!remoteNodeSelected) {
         setRemoteCwd('');
         return;
@@ -984,6 +996,7 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
           setInventory(inventoryResult.value);
         }
         if (nodesResult.status === 'fulfilled') {
+          queryClient.setQueryData(['hub-nodes'], nodesResult.value);
           setNodes(nodesResult.value);
         }
         const config = useConfigStore.getState();

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import type { QueryClient } from '@tanstack/react-query';
+import { fetchHubNodes } from '../lib/api.js';
 import { connectEventSocket } from '../lib/ws.js';
 import type { EventMessage } from '../lib/ws.js';
 import { useAuthStore } from '../lib/stores/auth.js';
@@ -9,6 +10,10 @@ import { useTelemetryStore } from '../lib/stores/telemetry.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import type { AccountTelemetry, SessionTelemetry } from '../lib/types.js';
 import type { SessionEventScope } from '../../../shared/node-boundary.js';
+import type {
+  HubNodeStatus,
+  HubNodeSummary,
+} from '../../../shared/relay-node-protocol.js';
 
 export interface UseEventSocketParams {
   authAuthenticated: boolean;
@@ -162,6 +167,65 @@ function invalidateReconnectQueries(queryClient: QueryClient): void {
   queryClient.invalidateQueries({ queryKey: ['fileDiff'] });
 }
 
+const HUB_NODE_REVERSE_LINK_ROUTE = 'reverse-link';
+
+function hubNodeConnectionSummary(
+  status: HubNodeStatus
+): HubNodeSummary['connection'] {
+  if (status === 'online') {
+    return { route: HUB_NODE_REVERSE_LINK_ROUTE, status: 'connected' };
+  }
+  if (status === 'stale') {
+    return { route: HUB_NODE_REVERSE_LINK_ROUTE, status: 'stale heartbeat' };
+  }
+  if (status === 'offline') {
+    return { route: HUB_NODE_REVERSE_LINK_ROUTE, status: 'offline' };
+  }
+  return { route: HUB_NODE_REVERSE_LINK_ROUTE, status: 'revoked' };
+}
+
+function applyHubNodeStatusEvent(
+  queryClient: QueryClient,
+  msg: Extract<EventMessage, { type: 'node.status' }>
+): void {
+  let matchedCachedNode = false;
+  queryClient.setQueryData<HubNodeSummary[]>(['hub-nodes'], (nodes) => {
+    if (!nodes) return nodes;
+    return nodes.map((node) => {
+      if (node.nodeId !== msg.nodeId) return node;
+      matchedCachedNode = true;
+      return {
+        ...node,
+        ...(msg.manifest
+          ? {
+              hostname: msg.manifest.hostname,
+              ...(msg.manifest.homeDir ? { homeDir: msg.manifest.homeDir } : {}),
+              platform: msg.manifest.platform,
+              arch: msg.manifest.arch,
+              relayVersion: msg.manifest.relayVersion,
+            }
+          : {}),
+        status: msg.status,
+        connection: hubNodeConnectionSummary(msg.status),
+        lastSeenAt: msg.lastSeenAt,
+      };
+    });
+  });
+  if (!matchedCachedNode) {
+    queryClient.invalidateQueries({ queryKey: ['hub-nodes'] });
+  }
+}
+
+async function resyncHubNodesAfterReconnect(
+  queryClient: QueryClient
+): Promise<void> {
+  try {
+    queryClient.setQueryData(['hub-nodes'], await fetchHubNodes());
+  } catch {
+    queryClient.invalidateQueries({ queryKey: ['hub-nodes'] });
+  }
+}
+
 function forceRefreshRepos(repoPaths: string[], source: 'webhook' | 'manual') {
   for (const repoPath of repoPaths) {
     void useSessionsStore.getState().forceRefresh(repoPath, source);
@@ -193,6 +257,7 @@ export function useEventSocket({
       const sessions = useSessionsStore.getState();
       sessions.setBackendConnectionStatus('connected');
       await sessions.refreshAll();
+      await resyncHubNodesAfterReconnect(queryClient);
       invalidateReconnectQueries(queryClient);
       throttledChangedFilesRefresh();
       void sessions.ensureFreshAll(0);
@@ -310,6 +375,9 @@ export function useEventSocket({
       'tab-control-event': (msg) => {
         useSessionsStore.getState().handleTabControlEvent(msg.event);
         queryClient.invalidateQueries({ queryKey: ['session-interventions'] });
+      },
+      'node.status': (msg) => {
+        applyHubNodeStatusEvent(queryClient, msg);
       },
       'account-telemetry': (msg) => {
         useTelemetryStore

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -22,6 +22,8 @@ import { resolveSessionByKey, resolveSessionKey } from './session-keys.js';
 import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
 import type { TabControlEvent } from '../../../shared/control-state.js';
+import type { HubNodeStatus } from '../../../shared/relay-node-protocol.js';
+import type { NodeManifest } from '../../../shared/node-manifest.js';
 
 const logger = createLogger('pty-ws');
 const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -102,6 +104,13 @@ export type EventMessage =
     }
   | { type: 'browser-tab-opened'; filePath: string; token: string }
   | { type: 'browser-tab-refreshed'; filePath: string }
+  | {
+      type: 'node.status';
+      nodeId: string;
+      status: HubNodeStatus;
+      lastSeenAt: string;
+      manifest?: NodeManifest;
+    }
   | { type: 'server-restarting'; reason?: string };
 
 type EventCallback = (msg: EventMessage) => void;

--- a/server/hub-node-link.ts
+++ b/server/hub-node-link.ts
@@ -442,8 +442,8 @@ export function handleHubNodeLink(
 ): void {
   const authenticatedNodeId = authenticated.node.nodeId;
   nodeLinks?.registerNodeLink(authenticatedNodeId, ws);
-  const unsubscribeRevoked = registry.onNodeRevoked((nodeId) => {
-    if (nodeId !== authenticatedNodeId) return;
+  const unsubscribeStatus = registry.onNodeStatus((event) => {
+    if (event.nodeId !== authenticatedNodeId || event.status !== 'revoked') return;
     sendJson(
       ws,
       errorEnvelope(
@@ -458,7 +458,7 @@ export function handleHubNodeLink(
     );
     ws.close(4003, 'node revoked');
   });
-  const cleanup = () => unsubscribeRevoked();
+  const cleanup = () => unsubscribeStatus();
   ws.on('close', cleanup);
   ws.on('error', cleanup);
 

--- a/server/hub-node-link.ts
+++ b/server/hub-node-link.ts
@@ -218,11 +218,11 @@ export class HubNodeLinkManager {
     const existing = this.links.get(nodeId);
     if (existing && existing !== ws) {
       this.cleanupNodeLinkResources(nodeId, existing);
-      if (existing.readyState === existing.OPEN) {
-        existing.close(1012, 'replaced by newer relay-node link');
-      }
     }
     this.links.set(nodeId, ws);
+    if (existing && existing !== ws && existing.readyState === existing.OPEN) {
+      existing.close(1012, 'replaced by newer relay-node link');
+    }
     const cleanup = () => this.unregisterNodeLink(nodeId, ws);
     ws.once('close', cleanup);
     ws.once('error', cleanup);
@@ -459,8 +459,22 @@ export function handleHubNodeLink(
     ws.close(4003, 'node revoked');
   });
   const cleanup = () => unsubscribeStatus();
+  let disconnected = false;
+  const markDisconnected = () => {
+    if (disconnected) return;
+    disconnected = true;
+    if (nodeLinks?.hasActiveNode(authenticatedNodeId)) return;
+    try {
+      registry.markNodeLinkDisconnected(authenticatedNodeId);
+    } catch {
+      // Authenticated links can race with revoke/unpair lifecycle; close/error
+      // cleanup must never crash the WebSocket upgrade handler.
+    }
+  };
   ws.on('close', cleanup);
   ws.on('error', cleanup);
+  ws.on('close', markDisconnected);
+  ws.on('error', markDisconnected);
 
   ws.on('message', (data) => {
     const parsed = parseEnvelope(data);

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -143,7 +143,15 @@ const PRIVILEGED_NODE_WARNING =
 export type CredentialAuthResult =
   | { ok: true; node: HubNodeSummary; credentialId: string; rotationId?: string }
   | { ok: false; error: RelayNodeError };
-type NodeRevokedListener = (nodeId: string) => void;
+
+export interface HubNodeStatusEvent {
+  nodeId: string;
+  status: HubNodeStatus;
+  lastSeenAt: string;
+  manifest?: NodeManifest;
+}
+
+type NodeStatusListener = (event: HubNodeStatusEvent) => void;
 
 class HubNodeRegistryError extends Error {
   readonly relayNodeError: RelayNodeError;
@@ -534,7 +542,8 @@ export class HubNodeRegistry {
   private heartbeatPersistDirty = false;
   private heartbeatPersistError: unknown = null;
   private readonly auditSink: { append(input: SecurityAuditEntryInput): unknown } | undefined;
-  private readonly nodeRevokedListeners = new Set<NodeRevokedListener>();
+  private readonly nodeStatusListeners = new Set<NodeStatusListener>();
+  private readonly lastNotifiedStatuses = new Map<string, HubNodeStatus>();
 
   constructor(options: HubNodeRegistryOptions) {
     this.storagePath = options.storagePath;
@@ -549,6 +558,7 @@ export class HubNodeRegistry {
     this.state = readRegistryFile(options.storagePath);
     const needsAclMigration = registryNeedsAclMigration(this.state);
     for (const node of this.state.nodes) ensureNodeAcl(node);
+    this.refreshLastNotifiedStatuses();
     if (needsAclMigration) writeRegistryFile(this.storagePath, this.state);
   }
 
@@ -556,11 +566,17 @@ export class HubNodeRegistry {
     this.now = now;
   }
 
-  onNodeRevoked(listener: NodeRevokedListener): () => void {
-    this.nodeRevokedListeners.add(listener);
+  onNodeStatus(listener: NodeStatusListener): () => void {
+    this.nodeStatusListeners.add(listener);
     return () => {
-      this.nodeRevokedListeners.delete(listener);
+      this.nodeStatusListeners.delete(listener);
     };
+  }
+
+  onNodeRevoked(listener: (nodeId: string) => void): () => void {
+    return this.onNodeStatus((event) => {
+      if (event.status === 'revoked') listener(event.nodeId);
+    });
   }
 
   createPairToken(options: {
@@ -650,6 +666,7 @@ export class HubNodeRegistry {
     pairToken.usedAt = timestamp;
     this.state.nodes.push(node);
     this.persist();
+    this.notifyNodeStatusIfChanged(node, 'online', input.manifest);
     return {
       credential: {
         protocol: RELAY_NODE_LINK_PROTOCOL,
@@ -726,6 +743,7 @@ export class HubNodeRegistry {
     if (input.credentialId) {
       this.proveCredentialRotation(node, input.credentialId, now);
     }
+    const previousStatus = statusForNode(node, this.now(), this.staleMs, this.offlineMs);
     node.lastSeenAt = now;
     node.protocolVersion = input.protocolVersion;
     if (input.manifest) {
@@ -741,6 +759,7 @@ export class HubNodeRegistry {
       node.repoInventory = input.repoInventory;
     }
     this.scheduleHeartbeatPersist();
+    this.notifyNodeStatusIfChanged(node, 'online', input.manifest, previousStatus);
     return publicNode(node, 'online');
   }
 
@@ -912,6 +931,17 @@ export class HubNodeRegistry {
     );
   }
 
+  refreshNodeStatuses(): HubNodeStatusEvent[] {
+    const now = this.now();
+    const events: HubNodeStatusEvent[] = [];
+    for (const node of this.state.nodes) {
+      const status = statusForNode(node, now, this.staleMs, this.offlineMs);
+      const event = this.notifyNodeStatusIfChanged(node, status);
+      if (event) events.push(event);
+    }
+    return events;
+  }
+
   listInventoryPayloads(
     options: { includeRevoked?: boolean } = {}
   ): InventoryPayloadRecord[] {
@@ -934,7 +964,7 @@ export class HubNodeRegistry {
     if (!alreadyRevoked) {
       node.revokedAt = this.now().toISOString();
       this.persist();
-      this.notifyNodeRevoked(nodeId);
+      this.notifyNodeStatusIfChanged(node, 'revoked');
     }
     return publicNode(node, 'revoked');
   }
@@ -955,17 +985,42 @@ export class HubNodeRegistry {
     };
   }
 
-  private notifyNodeRevoked(nodeId: string): void {
-    this.nodeRevokedListeners.forEach((listener) => {
+  private refreshLastNotifiedStatuses(): void {
+    const now = this.now();
+    this.lastNotifiedStatuses.clear();
+    for (const node of this.state.nodes) {
+      this.lastNotifiedStatuses.set(
+        node.nodeId,
+        statusForNode(node, now, this.staleMs, this.offlineMs)
+      );
+    }
+  }
+
+  private notifyNodeStatusIfChanged(
+    node: StoredNodeRecord,
+    status: HubNodeStatus,
+    manifest?: NodeManifest,
+    previousStatus: HubNodeStatus | undefined = this.lastNotifiedStatuses.get(node.nodeId)
+  ): HubNodeStatusEvent | null {
+    if (previousStatus === status) return null;
+    this.lastNotifiedStatuses.set(node.nodeId, status);
+    const event: HubNodeStatusEvent = {
+      nodeId: node.nodeId,
+      status,
+      lastSeenAt: node.lastSeenAt,
+      ...(manifest ? { manifest } : {}),
+    };
+    this.nodeStatusListeners.forEach((listener) => {
       try {
-        listener(nodeId);
+        listener(event);
       } catch {
         logger.warn(
-          'hub node revoke listener failed; continuing revoke notifications for node %s',
-          nodeId
+          'hub node status listener failed; continuing status notifications for node %s',
+          node.nodeId
         );
       }
     });
+    return event;
   }
 
   private persist(): void {

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -76,6 +76,7 @@ interface StoredNodeRecord {
   createdAt: string;
   pairedAt: string;
   lastSeenAt: string;
+  linkDisconnectedAt?: string;
   revokedAt?: string;
 }
 
@@ -376,6 +377,12 @@ function statusForNode(
   offlineMs: number
 ): HubNodeStatus {
   if (node.revokedAt) return 'revoked';
+  if (
+    node.linkDisconnectedAt &&
+    Date.parse(node.linkDisconnectedAt) >= Date.parse(node.lastSeenAt)
+  ) {
+    return 'offline';
+  }
   const ageMs = now.getTime() - Date.parse(node.lastSeenAt);
   if (ageMs > offlineMs) return 'offline';
   if (ageMs > staleMs) return 'stale';
@@ -745,6 +752,7 @@ export class HubNodeRegistry {
     }
     const previousStatus = statusForNode(node, this.now(), this.staleMs, this.offlineMs);
     node.lastSeenAt = now;
+    delete node.linkDisconnectedAt;
     node.protocolVersion = input.protocolVersion;
     if (input.manifest) {
       node.hostname = input.manifest.hostname;
@@ -761,6 +769,26 @@ export class HubNodeRegistry {
     this.scheduleHeartbeatPersist();
     this.notifyNodeStatusIfChanged(node, 'online', input.manifest, previousStatus);
     return publicNode(node, 'online');
+  }
+
+  markNodeLinkDisconnected(nodeId: string): HubNodeSummary {
+    const node = this.state.nodes.find(
+      (candidate) => candidate.nodeId === nodeId
+    );
+    if (!node)
+      throw new HubNodeRegistryError('NOT_FOUND', 'node is not paired');
+    if (node.revokedAt) return publicNode(node, 'revoked');
+
+    const previousStatus = statusForNode(
+      node,
+      this.now(),
+      this.staleMs,
+      this.offlineMs
+    );
+    node.linkDisconnectedAt = this.now().toISOString();
+    this.persist();
+    this.notifyNodeStatusIfChanged(node, 'offline', undefined, previousStatus);
+    return publicNode(node, 'offline');
   }
 
   beginCredentialRotation(nodeId: string): CredentialRotationResult {

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -484,6 +484,21 @@ function setupWebSocket(
     broadcastEvent(type, data);
   });
 
+  const unsubscribeNodeStatus = hubNodeRegistry?.onNodeStatus((event) => {
+    broadcastEvent('node.status', { ...event });
+  });
+
+  const nodeStatusRefreshTimer = hubNodeRegistry
+    ? setInterval(() => {
+        hubNodeRegistry.refreshNodeStatuses();
+      }, 5_000)
+    : null;
+  nodeStatusRefreshTimer?.unref?.();
+  server.on('close', () => {
+    unsubscribeNodeStatus?.();
+    if (nodeStatusRefreshTimer) clearInterval(nodeStatusRefreshTimer);
+  });
+
   server.on('upgrade', (request, socket, head) => {
     const requestPath = request.url
       ? new URL(request.url, 'http://relay.local').pathname.replace(/\/$/, '')

--- a/test/customize-session-dialog-open-race.test.ts
+++ b/test/customize-session-dialog-open-race.test.ts
@@ -3,6 +3,7 @@
 import React, { act, createRef } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { FrameworkInfo } from '../frontend/src/lib/types.js';
 import type { CustomizeSessionDialogHandle } from '../frontend/src/components/dialogs/CustomizeSessionDialog.js';
 import type { AggregatedRepoInventoryResponse } from '../shared/repo-inventory.js';
@@ -295,9 +296,18 @@ async function renderAndOpen(
   document.body.appendChild(container);
   root = createRoot(container);
   const ref = createRef<CustomizeSessionDialogHandle>();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
 
   await act(async () => {
-    root!.render(React.createElement(CustomizeSessionDialog, { ref }));
+    root!.render(
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        React.createElement(CustomizeSessionDialog, { ref })
+      )
+    );
   });
   await act(async () => {
     await ref.current!.open(workspace);
@@ -530,9 +540,18 @@ describe('CustomizeSessionDialog open races', () => {
     document.body.appendChild(container);
     root = createRoot(container);
     const ref = createRef<CustomizeSessionDialogHandle>();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
 
     await act(async () => {
-      root!.render(React.createElement(CustomizeSessionDialog, { ref }));
+      root!.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(CustomizeSessionDialog, { ref })
+        )
+      );
     });
 
     let firstOpen!: Promise<void>;

--- a/test/hooks/useEventSocket.test.ts
+++ b/test/hooks/useEventSocket.test.ts
@@ -23,6 +23,10 @@ const wsMock = vi.hoisted(() => ({
   ),
 }));
 
+const apiMock = vi.hoisted(() => ({
+  fetchHubNodes: vi.fn(),
+}));
+
 const storeMock = vi.hoisted(() => ({
   refreshAll: vi.fn(),
   ensureFreshAll: vi.fn(),
@@ -74,6 +78,10 @@ vi.mock('../../frontend/src/lib/ws.js', () => ({
   connectEventSocket: wsMock.connectEventSocket,
 }));
 
+vi.mock('../../frontend/src/lib/api.js', () => ({
+  fetchHubNodes: apiMock.fetchHubNodes,
+}));
+
 vi.mock('../../frontend/src/lib/stores/sessions.js', () => ({
   useSessionsStore: {
     getState: () => storeMock,
@@ -112,9 +120,23 @@ describe('useEventSocket repo-scoped refresh', () => {
     storeMock.backendConnectionStatus = 'connected';
     storeMock.sessions = [];
     storeMock.worktrees = [];
+    apiMock.fetchHubNodes.mockResolvedValue([]);
   });
 
-  function mount(queryClient = { invalidateQueries: vi.fn() } as any): void {
+  function makeQueryClient(cachedNodes?: unknown[]): any {
+    let nodes = cachedNodes;
+    return {
+      invalidateQueries: vi.fn(),
+      setQueryData: vi.fn((_queryKey, updater) => {
+        nodes = typeof updater === 'function' ? updater(nodes) : updater;
+      }),
+      get nodes() {
+        return nodes;
+      },
+    };
+  }
+
+  function mount(queryClient = makeQueryClient()): void {
     useEventSocket({
       authAuthenticated: true,
       queryClient,
@@ -134,11 +156,12 @@ describe('useEventSocket repo-scoped refresh', () => {
     await vi.waitFor(() =>
       expect(storeMock.ensureFreshAll).toHaveBeenCalledWith(0)
     );
+    expect(apiMock.fetchHubNodes).toHaveBeenCalledTimes(1);
     expect(telemetryMock.refreshTelemetry).toHaveBeenCalledTimes(2);
   });
 
   it('refreshes sessions, worktrees, dashboard, and file data after websocket reconnect', async () => {
-    const queryClient = { invalidateQueries: vi.fn() } as any;
+    const queryClient = makeQueryClient();
     const changedFilesRefresh = vi.fn();
     useEventSocket({
       authAuthenticated: true,
@@ -149,7 +172,11 @@ describe('useEventSocket repo-scoped refresh', () => {
 
     wsMock.onOpen?.();
     wsMock.onOpen?.();
-    await vi.waitFor(() => expect(storeMock.refreshAll).toHaveBeenCalled());
+    await vi.waitFor(() =>
+      expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+        queryKey: ['dashboard'],
+      })
+    );
 
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
       queryKey: ['dashboard'],
@@ -158,6 +185,58 @@ describe('useEventSocket repo-scoped refresh', () => {
       queryKey: ['files-list'],
     });
     expect(changedFilesRefresh).toHaveBeenCalled();
+  });
+
+  it('applies node.status events to the hub-nodes query cache without polling', () => {
+    const queryClient = makeQueryClient([
+      {
+        nodeId: 'node-a',
+        displayName: 'build box',
+        hostname: 'old-host',
+        platform: 'darwin',
+        arch: 'arm64',
+        relayVersion: '1.0.0',
+        protocolVersion: '1.0',
+        status: 'online',
+        connection: { route: 'reverse-link', status: 'connected' },
+        trust: { state: 'active', level: 'privileged-local-user' },
+        credentialState: 'active',
+        version: {
+          state: 'compatible',
+          nodeProtocolVersion: '1.0',
+          hubProtocolVersion: '1.0',
+        },
+        capabilities: {
+          totals: { available: 0, degraded: 0, unavailable: 0, unknown: 0 },
+          core: {},
+          agents: {},
+        },
+        createdAt: '2026-01-01T00:00:00.000Z',
+        pairedAt: '2026-01-01T00:00:00.000Z',
+        lastSeenAt: '2026-01-01T00:00:00.000Z',
+        credentialId: 'cred-a',
+      },
+    ]);
+    mount(queryClient);
+
+    wsMock.onMessage?.({
+      type: 'node.status',
+      nodeId: 'node-a',
+      status: 'offline',
+      lastSeenAt: '2026-01-01T00:02:00.000Z',
+    });
+
+    expect(queryClient.nodes).toMatchObject([
+      {
+        nodeId: 'node-a',
+        status: 'offline',
+        connection: { route: 'reverse-link', status: 'offline' },
+        lastSeenAt: '2026-01-01T00:02:00.000Z',
+      },
+    ]);
+    expect(queryClient.invalidateQueries).not.toHaveBeenCalledWith({
+      queryKey: ['hub-nodes'],
+    });
   });
 
   it('marks backend restart state and preserves the active pty session for reconnect', () => {

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -709,7 +709,7 @@ describe('hub node registry', () => {
     });
   });
 
-  it('isolates revoke listener exceptions and continues notifying later listeners', () => {
+  it('isolates status listener exceptions and continues notifying later listeners', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
       withTmpRegistry((registry) => {
@@ -719,11 +719,11 @@ describe('hub node registry', () => {
         });
         const notifiedNodeIds: string[] = [];
 
-        registry.onNodeRevoked(() => {
+        registry.onNodeStatus(() => {
           throw new Error('listener should not leak');
         });
-        registry.onNodeRevoked((nodeId) => {
-          notifiedNodeIds.push(nodeId);
+        registry.onNodeStatus((event) => {
+          if (event.status === 'revoked') notifiedNodeIds.push(event.nodeId);
         });
 
         expect(() => registry.revokeNode(exchanged.node.nodeId)).not.toThrow();
@@ -736,7 +736,7 @@ describe('hub node registry', () => {
         });
         expect(warnSpy).toHaveBeenCalledWith(
           expect.stringContaining(
-            '[hub-node-registry] hub node revoke listener failed; continuing revoke notifications for node %s'
+            '[hub-node-registry] hub node status listener failed; continuing status notifications for node %s'
           ),
           exchanged.node.nodeId
         );

--- a/test/hub-node-status-events.test.ts
+++ b/test/hub-node-status-events.test.ts
@@ -1,0 +1,161 @@
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { once } from 'node:events';
+import { afterEach, describe, expect, it } from 'vitest';
+import { WebSocket } from 'ws';
+import { createHubNodeRegistry } from '../server/hub-node-registry.js';
+import { setupWebSocket } from '../server/ws.js';
+import type { NodeManifest } from '../shared/node-manifest.js';
+import { RELAY_NODE_LINK_PROTOCOL_VERSION } from '../shared/relay-node-protocol.js';
+import { buildManifestWithAgents } from './helpers/manifest-fixtures.js';
+
+const cleanupFns: Array<() => Promise<void> | void> = [];
+
+function manifest(hostname: string): NodeManifest {
+  return buildManifestWithAgents({
+    agents: [{ id: 'claude', label: 'Claude', status: 'available' }],
+    overrides: {
+      hostname,
+      platform: 'linux',
+      arch: 'x64',
+      relayVersion: '0.1.0-test',
+    },
+  });
+}
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('test server did not bind a TCP port');
+  }
+  return address.port;
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function waitForOpen(ws: WebSocket): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) return;
+  await once(ws, 'open');
+}
+
+async function nextNodeStatus(ws: WebSocket): Promise<Record<string, unknown>> {
+  for (;;) {
+    const [raw] = (await once(ws, 'message')) as [Buffer];
+    const payload = JSON.parse(raw.toString()) as Record<string, unknown>;
+    if (payload['type'] === 'node.status') return payload;
+  }
+}
+
+afterEach(async () => {
+  while (cleanupFns.length > 0) await cleanupFns.pop()?.();
+});
+
+describe('hub node status event websocket', () => {
+  it('fans out registry online/stale/offline/revoked transitions to browser event clients', async () => {
+    let currentTime = new Date('2026-01-02T03:04:05.000Z');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-node-status-events-'));
+    cleanupFns.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+    const registry = createHubNodeRegistry({
+      storagePath: path.join(tmpDir, 'hub', 'nodes.json'),
+      now: () => currentTime,
+      staleMs: 45_000,
+      offlineMs: 90_000,
+      heartbeatPersistDebounceMs: 1,
+    });
+    const server = http.createServer();
+    const { wss } = setupWebSocket(
+      server,
+      new Set<string>(),
+      null,
+      undefined,
+      true,
+      undefined,
+      registry
+    );
+    cleanupFns.push(() => wss.close());
+    cleanupFns.push(() => closeServer(server));
+    const port = await listen(server);
+
+    const browser = new WebSocket(`ws://127.0.0.1:${port}/ws/events`);
+    cleanupFns.push(() => browser.close());
+    await waitForOpen(browser);
+
+    const online = nextNodeStatus(browser);
+    const pair = registry.createPairToken({ displayName: 'status-node' });
+    const exchanged = registry.exchangePairToken({
+      pairToken: pair.pairToken,
+      manifest: manifest('status-node'),
+      protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+    });
+    await expect(online).resolves.toMatchObject({
+      type: 'node.status',
+      nodeId: exchanged.node.nodeId,
+      status: 'online',
+      lastSeenAt: '2026-01-02T03:04:05.000Z',
+      manifest: expect.objectContaining({ hostname: 'status-node' }),
+    });
+
+    const stale = nextNodeStatus(browser);
+    currentTime = new Date('2026-01-02T03:04:51.000Z');
+    expect(registry.refreshNodeStatuses()).toEqual([
+      expect.objectContaining({
+        nodeId: exchanged.node.nodeId,
+        status: 'stale',
+        lastSeenAt: '2026-01-02T03:04:05.000Z',
+      }),
+    ]);
+    await expect(stale).resolves.toMatchObject({
+      type: 'node.status',
+      nodeId: exchanged.node.nodeId,
+      status: 'stale',
+      lastSeenAt: '2026-01-02T03:04:05.000Z',
+    });
+
+    const offline = nextNodeStatus(browser);
+    currentTime = new Date('2026-01-02T03:05:36.000Z');
+    expect(registry.refreshNodeStatuses()).toEqual([
+      expect.objectContaining({
+        nodeId: exchanged.node.nodeId,
+        status: 'offline',
+        lastSeenAt: '2026-01-02T03:04:05.000Z',
+      }),
+    ]);
+    await expect(offline).resolves.toMatchObject({
+      type: 'node.status',
+      nodeId: exchanged.node.nodeId,
+      status: 'offline',
+      lastSeenAt: '2026-01-02T03:04:05.000Z',
+    });
+
+    const backOnline = nextNodeStatus(browser);
+    registry.recordHeartbeat({
+      nodeId: exchanged.node.nodeId,
+      protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+      manifest: manifest('status-node-reconnected'),
+    });
+    await expect(backOnline).resolves.toMatchObject({
+      type: 'node.status',
+      nodeId: exchanged.node.nodeId,
+      status: 'online',
+      lastSeenAt: '2026-01-02T03:05:36.000Z',
+      manifest: expect.objectContaining({ hostname: 'status-node-reconnected' }),
+    });
+
+    const revoked = nextNodeStatus(browser);
+    registry.revokeNode(exchanged.node.nodeId);
+    await expect(revoked).resolves.toMatchObject({
+      type: 'node.status',
+      nodeId: exchanged.node.nodeId,
+      status: 'revoked',
+      lastSeenAt: '2026-01-02T03:05:36.000Z',
+    });
+  });
+});

--- a/test/hub-node-status-events.test.ts
+++ b/test/hub-node-status-events.test.ts
@@ -5,10 +5,14 @@ import * as path from 'node:path';
 import { once } from 'node:events';
 import { afterEach, describe, expect, it } from 'vitest';
 import { WebSocket } from 'ws';
+import { createHubNodeLinkManager } from '../server/hub-node-link.js';
 import { createHubNodeRegistry } from '../server/hub-node-registry.js';
 import { setupWebSocket } from '../server/ws.js';
 import type { NodeManifest } from '../shared/node-manifest.js';
-import { RELAY_NODE_LINK_PROTOCOL_VERSION } from '../shared/relay-node-protocol.js';
+import {
+  RELAY_NODE_LINK_PROTOCOL,
+  RELAY_NODE_LINK_PROTOCOL_VERSION,
+} from '../shared/relay-node-protocol.js';
 import { buildManifestWithAgents } from './helpers/manifest-fixtures.js';
 
 const cleanupFns: Array<() => Promise<void> | void> = [];
@@ -50,6 +54,28 @@ async function nextNodeStatus(ws: WebSocket): Promise<Record<string, unknown>> {
     const [raw] = (await once(ws, 'message')) as [Buffer];
     const payload = JSON.parse(raw.toString()) as Record<string, unknown>;
     if (payload['type'] === 'node.status') return payload;
+  }
+}
+
+async function nextJson(ws: WebSocket): Promise<Record<string, unknown>> {
+  const [raw] = (await once(ws, 'message')) as [Buffer];
+  return JSON.parse(raw.toString()) as Record<string, unknown>;
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`timed out after ${ms}ms`)),
+          ms
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 
@@ -157,5 +183,96 @@ describe('hub node status event websocket', () => {
       status: 'revoked',
       lastSeenAt: '2026-01-02T03:05:36.000Z',
     });
+  });
+
+  it('emits offline promptly when a fresh live reverse node-link closes', async () => {
+    const currentTime = new Date('2026-01-02T03:04:05.000Z');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-node-link-offline-'));
+    cleanupFns.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+    const registry = createHubNodeRegistry({
+      storagePath: path.join(tmpDir, 'hub', 'nodes.json'),
+      now: () => currentTime,
+      staleMs: 45_000,
+      offlineMs: 90_000,
+      heartbeatPersistDebounceMs: 1,
+    });
+    const nodeLinks = createHubNodeLinkManager();
+    const server = http.createServer();
+    const { wss } = setupWebSocket(
+      server,
+      new Set<string>(),
+      null,
+      undefined,
+      true,
+      undefined,
+      registry,
+      nodeLinks
+    );
+    cleanupFns.push(() => wss.close());
+    cleanupFns.push(() => closeServer(server));
+    const port = await listen(server);
+
+    const browser = new WebSocket(`ws://127.0.0.1:${port}/ws/events`);
+    cleanupFns.push(() => browser.close());
+    await waitForOpen(browser);
+
+    const online = nextNodeStatus(browser);
+    const pair = registry.createPairToken({ displayName: 'link-close-node' });
+    const exchanged = registry.exchangePairToken({
+      pairToken: pair.pairToken,
+      manifest: manifest('link-close-node'),
+      protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+    });
+    await expect(online).resolves.toMatchObject({
+      type: 'node.status',
+      nodeId: exchanged.node.nodeId,
+      status: 'online',
+      lastSeenAt: '2026-01-02T03:04:05.000Z',
+    });
+
+    const nodeLink = new WebSocket(`ws://127.0.0.1:${port}/hub/node-link`, {
+      headers: { authorization: `Bearer ${exchanged.credential.token}` },
+    });
+    cleanupFns.push(() => nodeLink.close());
+    await waitForOpen(nodeLink);
+    nodeLink.send(
+      JSON.stringify({
+        protocol: RELAY_NODE_LINK_PROTOCOL,
+        protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+        nodeId: exchanged.node.nodeId,
+        channel: 'control',
+        type: 'control.hello',
+        requestId: 'hello-1',
+        timestamp: currentTime.toISOString(),
+        payload: { manifest: manifest('link-close-node') },
+      })
+    );
+    await expect(nextJson(nodeLink)).resolves.toMatchObject({
+      type: 'control.hello.result',
+      requestId: 'hello-1',
+    });
+    expect(registry.listNodes()).toEqual([
+      expect.objectContaining({
+        nodeId: exchanged.node.nodeId,
+        status: 'online',
+      }),
+    ]);
+
+    const offline = withTimeout(nextNodeStatus(browser), 1_000);
+    nodeLink.close();
+    await expect(offline).resolves.toMatchObject({
+      type: 'node.status',
+      nodeId: exchanged.node.nodeId,
+      status: 'offline',
+      lastSeenAt: '2026-01-02T03:04:05.000Z',
+    });
+    expect(registry.listNodes()).toEqual([
+      expect.objectContaining({
+        nodeId: exchanged.node.nodeId,
+        status: 'offline',
+        lastSeenAt: '2026-01-02T03:04:05.000Z',
+      }),
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- Generalizes hub node status transitions into typed `node.status` events over the existing authenticated browser `/ws/events` channel.
- Updates frontend hub-node consumers to stop 15s polling and use `staleTime: Infinity` plus event-driven TanStack Query cache updates.
- Adds browser event reconnect resync by fetching the hub-node snapshot once after reconnect, then reconciling missed transitions.
- Documents the `node.status` envelope in `docs/federated-relay.md`.

## Scope
Closes #466

This keeps `GET /nodes`/hub-node snapshot fetching as the initial load, refocus/manual refresh, and reconnect-resync primitive. It does not add capability-change events, new auth surfaces, or a broader observability event bus.

## Entry points covered
- `HubNodeDashboardPanel`: removed `refetchInterval: 15_000`, uses `staleTime: Infinity`, preserves refocus refresh.
- `WorkspaceArea`: removed `refetchInterval: 15_000`, uses `staleTime: Infinity`, preserves refocus refresh for tab chrome/node picker state.
- `TerminalNodePicker`: aligned the shared hub-node query to the same non-polling/refocus-refresh behavior.
- `CustomizeSessionDialog`: stores its open-time node snapshot in the shared `hub-nodes` cache and subscribes to cache updates so `node.status` events refresh dialog state while open.
- `useEventSocket`: mutates cached hub nodes on `node.status`; invalidates if the node was not cached; fetches a fresh hub-node snapshot after browser event-WS reconnect.

## The Case Against
The frontend cache mutation derives the compact `connection` summary from the pushed status (`online` -> connected, `stale` -> stale heartbeat, etc.) instead of waiting for a full node summary. If the backend later enriches connection details beyond the current summary shape, this helper should move to a shared mapper or the event should include the ready-to-render connection field.

`CustomizeSessionDialog` still fetches a node snapshot when opened because it is an imperative dialog and not a normal query component. The new cache subscription makes it react to event-driven updates after opening, but a future cleanup could convert the dialog fully to `useQuery` if the imperative open API is refactored.

## Verification
- `npm test -- test/hub-node-status-events.test.ts test/hub-node-registry.test.ts test/hub-node-routes.test.ts test/ws-node-scope.test.ts`
- `npm test -- test/multi-node-smoke.test.ts`
- `npm test -- test/hooks/useEventSocket.test.ts test/hub-node-status-events.test.ts test/workspace-area-node-picker.test.ts test/customize-session-dialog-open-race.test.ts`
- `npm run check` (passes; existing warnings only)
- `npm run build`
- Browser/manual screenshot evidence skipped: no visual styling/layout delta; behavior is cache/event plumbing covered by targeted hook/dialog/component tests plus production build.
