### PR TITLE
test: add cross-node PTY smoke harness

### DIFF
--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -16,7 +16,7 @@ Testing patterns and quality standards for Relay IDE.
 
 ```bash
 npm test                                    # Run all unit/integration tests (vitest)
-npm run test:smoke:multi-node              # Hub + two simulated nodes smoke harness
+npm run test:smoke:multi-node              # Canonical hub + two-node PTY smoke harness
 npx vitest run                              # Same as npm test
 npx vitest run test/auth.test.ts            # Run a single test file
 npx vitest run --changed HEAD~1             # Run only tests affected by recent changes

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -445,7 +445,7 @@ A single hub UI can host terminal tabs attached to multiple paired nodes:
 - The PTY socket (`frontend/src/lib/ws.ts`) reads `nodeId` from the session (or parses it from a global session id) and opens `/nodes/{nodeId}/ws/sessions/{localSessionId}` instead of the local `/ws/{sessionId}` route.
 - Tab chrome (`WorkspaceTabBar` + `workspace-summary.ts`) shows a node label + heartbeat dot for cross-node tabs, sourced from `SummaryContext.findNode` which `WorkspaceArea` populates from the `useQuery(['hub-nodes'], fetchHubNodes)` cache (15 s refetch interval).
 
-Reload-resume is implemented as of #467: see [SessionAttachment Boundary](#sessionattachment-boundary). The two-node smoke harness remains a follow-up under sub-issues of #443.
+Reload-resume is implemented as of #467: see [SessionAttachment Boundary](#sessionattachment-boundary). The two-node routed PTY smoke harness is now the canonical integration coverage for concurrent cross-node streams and node-link failure isolation; run it with `npm run test:smoke:multi-node`.
 
 ### SessionAttachment Boundary
 

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -27,6 +27,7 @@ Implemented/current:
 - Reverse link: `/hub/node-link` is implemented by `server/hub-node-link.ts` (hub) and `server/node-link-client.ts` (node). Nodes dial out with `relay-ide node link --hub <url>`.
 - Routed sessions: the hub creates sessions with `POST /hub/nodes/:nodeId/sessions`, kills them with `DELETE /hub/nodes/:nodeId/sessions/:sessionId`, and proxies browser PTY traffic through `/nodes/:nodeId/ws/sessions/:sessionId`.
 - Node-local execution: `server/node-link-pty-host.ts` hosts PTY streams through the `SessionAttachment` boundary; tmux-backed resume ships, raw fallback exists for future gates, and the hub currently requires tmux-capable nodes for routed sessions.
+- Multi-node routed PTY smoke: `test/hub-cross-node-pty.test.ts` is the canonical integration harness for hub + two simulated nodes, concurrent browser PTY streams, sustained byte flow, and one-node reverse-link failure isolation. Run it with `npm run test:smoke:multi-node`.
 - Repo inventory: `server/repo-inventory.ts` reports configured repos/worktrees, dirty/divergence summaries, and canonical repo identity; the hub aggregates it through `GET /hub/repo-inventory`.
 - Local hub-as-node: `server/local-node.ts` scopes existing hub-local sessions and file events as the default local node.
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "sandbox:dev": "node dist/scripts/sandbox-cli.js",
     "agent-browser": "node dist/scripts/agent-browser-cli.js",
     "test": "vitest run",
-    "test:smoke:multi-node": "vitest run test/multi-node-smoke.test.ts",
+    "test:smoke:multi-node": "vitest run test/hub-cross-node-pty.test.ts test/multi-node-smoke.test.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:debug": "playwright test --debug",

--- a/test/hub-cross-node-pty.test.ts
+++ b/test/hub-cross-node-pty.test.ts
@@ -1,0 +1,604 @@
+import * as fs from 'node:fs';
+import http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import express from 'express';
+import { WebSocket } from 'ws';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createHubNodeLinkManager } from '../server/hub-node-link.js';
+import { createHubNodeRegistry } from '../server/hub-node-registry.js';
+import { createHubNodeRouter } from '../server/hub-node-router.js';
+import { createLocalRelayNode } from '../server/local-node.js';
+import { setupWebSocket } from '../server/ws.js';
+import type { SessionSummary } from '../server/types.js';
+import type { NodeManifest } from '../shared/node-manifest.js';
+import {
+  RELAY_NODE_LINK_PROTOCOL,
+  RELAY_NODE_LINK_PROTOCOL_VERSION,
+  type RelayNodeEnvelope,
+} from '../shared/relay-node-protocol.js';
+import { buildManifestWithAgents } from './helpers/manifest-fixtures.js';
+
+const AGENTS = [
+  { id: 'claude', label: 'Claude', status: 'available' as const },
+  { id: 'codex', label: 'Codex', status: 'available' as const },
+];
+const STRESS_DURATION_MS = 2_050;
+const STRESS_CHUNK_BYTES = 512;
+const STRESS_TOTAL_BYTES = 10 * 1024;
+
+type Cleanup = () => Promise<void> | void;
+
+function manifest(hostname: string): NodeManifest {
+  return buildManifestWithAgents({
+    agents: AGENTS,
+    overrides: {
+      platform: 'linux',
+      arch: 'x64',
+      hostname,
+      relayVersion: '0.1.0-smoke',
+      capabilities: {
+        tmux: { id: 'tmux', label: 'tmux', status: 'available', message: 'ok' },
+        git: { id: 'git', label: 'Git', status: 'available', message: 'ok' },
+        clipboard: {
+          id: 'clipboard',
+          label: 'Clipboard',
+          status: 'unknown',
+          message: 'not relevant to PTY smoke',
+        },
+        browserAutomation: {
+          id: 'browserAutomation',
+          label: 'Browser automation',
+          status: 'degraded',
+          message: 'not relevant to PTY smoke',
+        },
+        githubCli: {
+          id: 'githubCli',
+          label: 'GitHub CLI',
+          status: 'available',
+          message: 'ok',
+        },
+        tailscale: {
+          id: 'tailscale',
+          label: 'Tailscale CLI',
+          status: 'unavailable',
+          message: 'not relevant to PTY smoke',
+        },
+        ssh: {
+          id: 'ssh',
+          label: 'SSH client',
+          status: 'available',
+          message: 'ok',
+        },
+        agents: Object.fromEntries(
+          AGENTS.map((agent) => [
+            agent.id,
+            {
+              id: agent.id,
+              label: agent.label,
+              status: agent.status,
+              message: 'ok',
+            },
+          ])
+        ),
+      },
+    },
+  });
+}
+
+function remoteSession(input: {
+  nodeId: string;
+  hostname: string;
+  sessionId: string;
+}): SessionSummary {
+  const repoPath = `/nodes/${input.hostname}/relay-ide`;
+  return {
+    id: input.sessionId,
+    type: 'terminal',
+    agent: 'claude',
+    mode: 'pty',
+    repoPath,
+    worktreePath: null,
+    cwd: repoPath,
+    repoName: 'relay-ide',
+    branchName: 'nightly',
+    displayName: `${input.hostname} terminal`,
+    createdAt: '2026-01-02T03:04:05.000Z',
+    lastActivity: '2026-01-02T03:04:05.000Z',
+    idle: false,
+    customCommand: null,
+    nodeId: input.nodeId,
+    globalSessionId: `${input.nodeId}:${input.sessionId}`,
+    repoInstanceId: `${encodeURIComponent(input.nodeId)}:${encodeURIComponent(repoPath)}`,
+    useTmux: true,
+    tmuxSessionName: `relay-ide-${input.sessionId}`,
+    status: 'active',
+    needsBranchRename: false,
+    agentState: 'idle',
+  };
+}
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string')
+    throw new Error('smoke hub did not bind a TCP port');
+  return address.port;
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function waitForOpen(ws: WebSocket): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) return;
+  await new Promise<void>((resolve, reject) => {
+    ws.once('open', resolve);
+    ws.once('error', reject);
+  });
+}
+
+async function waitForClose(ws: WebSocket): Promise<{ code: number; reason: string }> {
+  if (ws.readyState === WebSocket.CLOSED) return { code: 1005, reason: '' };
+  return await new Promise<{ code: number; reason: string }>((resolve) => {
+    ws.once('close', (code, reason) => resolve({ code, reason: reason.toString() }));
+  });
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function sendNodeEnvelope(
+  ws: WebSocket,
+  nodeId: string,
+  type: string,
+  channel: RelayNodeEnvelope['channel'],
+  extras: Partial<RelayNodeEnvelope> = {}
+): void {
+  ws.send(
+    JSON.stringify({
+      protocol: RELAY_NODE_LINK_PROTOCOL,
+      protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+      nodeId,
+      channel,
+      type,
+      timestamp: new Date().toISOString(),
+      ...extras,
+    })
+  );
+}
+
+class SimulatedNode {
+  readonly messages: RelayNodeEnvelope[] = [];
+  private readonly consumedMessageIndexes = new Set<number>();
+  private readonly waiters: Array<{
+    label: string;
+    predicate: (message: RelayNodeEnvelope) => boolean;
+    resolve: (message: RelayNodeEnvelope) => void;
+    reject: (error: Error) => void;
+    timer: NodeJS.Timeout;
+  }> = [];
+
+  constructor(
+    readonly nodeId: string,
+    readonly token: string,
+    readonly hostname: string,
+    readonly ws: WebSocket
+  ) {
+    ws.on('message', (data) => {
+      const message = JSON.parse(data.toString()) as RelayNodeEnvelope;
+      this.messages.push(message);
+      const messageIndex = this.messages.length - 1;
+      for (const waiter of [...this.waiters]) {
+        if (!waiter.predicate(message)) continue;
+        this.consumedMessageIndexes.add(messageIndex);
+        this.removeWaiter(waiter);
+        waiter.resolve(message);
+        break;
+      }
+    });
+  }
+
+  waitFor(
+    predicate: (message: RelayNodeEnvelope) => boolean,
+    label: string,
+    timeoutMs = 2_000
+  ): Promise<RelayNodeEnvelope> {
+    const existingIndex = this.messages.findIndex(
+      (message, index) => !this.consumedMessageIndexes.has(index) && predicate(message)
+    );
+    if (existingIndex >= 0) {
+      this.consumedMessageIndexes.add(existingIndex);
+      return Promise.resolve(this.messages[existingIndex]!);
+    }
+    return new Promise<RelayNodeEnvelope>((resolve, reject) => {
+      const waiter = {
+        label,
+        predicate,
+        resolve,
+        reject,
+        timer: setTimeout(() => {
+          this.removeWaiter(waiter);
+          reject(new Error(`timed out waiting for ${label}`));
+        }, timeoutMs),
+      };
+      waiter.timer.unref?.();
+      this.waiters.push(waiter);
+    });
+  }
+
+  hello(): Promise<RelayNodeEnvelope> {
+    sendNodeEnvelope(this.ws, this.nodeId, 'control.hello', 'control', {
+      payload: { manifest: manifest(this.hostname) },
+    });
+    return this.waitFor(
+      (message) => message.type === 'control.hello.result',
+      `${this.hostname} control.hello.result`
+    );
+  }
+
+  answerCreate(request: RelayNodeEnvelope, sessionId: string): void {
+    sendNodeEnvelope(this.ws, this.nodeId, 'sessions.create.result', 'rpc', {
+      requestId: request.requestId,
+      payload: {
+        session: {
+          ...remoteSession({ nodeId: this.nodeId, hostname: this.hostname, sessionId }),
+          // Deliberately spoof these; the hub must own routing identity.
+          nodeId: 'spoofed-by-node',
+          globalSessionId: 'spoofed-by-node:session',
+        },
+      },
+    });
+  }
+
+  sendPtyData(streamId: string, data: string): void {
+    sendNodeEnvelope(this.ws, this.nodeId, 'pty.data', 'pty', {
+      streamId,
+      payload: { data },
+    });
+  }
+
+  close(): void {
+    this.ws.close();
+  }
+
+  private removeWaiter(waiter: (typeof this.waiters)[number]): void {
+    const index = this.waiters.indexOf(waiter);
+    if (index >= 0) this.waiters.splice(index, 1);
+    clearTimeout(waiter.timer);
+  }
+}
+
+class BrowserClient {
+  readonly messages: string[] = [];
+  readonly closes: Array<{ code: number; reason: string }> = [];
+  private readonly waiters: Array<{
+    label: string;
+    predicate: (message: string) => boolean;
+    resolve: (message: string) => void;
+    reject: (error: Error) => void;
+    timer: NodeJS.Timeout;
+  }> = [];
+
+  constructor(readonly ws: WebSocket) {
+    ws.on('message', (data) => {
+      const message = data.toString();
+      this.messages.push(message);
+      for (const waiter of [...this.waiters]) {
+        if (!waiter.predicate(message)) continue;
+        this.removeWaiter(waiter);
+        waiter.resolve(message);
+        break;
+      }
+    });
+    ws.on('close', (code, reason) => {
+      this.closes.push({ code, reason: reason.toString() });
+    });
+  }
+
+  waitFor(
+    predicate: (message: string) => boolean,
+    label: string,
+    timeoutMs = 2_000
+  ): Promise<string> {
+    const existing = this.messages.find(predicate);
+    if (existing !== undefined) return Promise.resolve(existing);
+    return new Promise<string>((resolve, reject) => {
+      const waiter = {
+        label,
+        predicate,
+        resolve,
+        reject,
+        timer: setTimeout(() => {
+          this.removeWaiter(waiter);
+          reject(new Error(`timed out waiting for browser message ${label}`));
+        }, timeoutMs),
+      };
+      waiter.timer.unref?.();
+      this.waiters.push(waiter);
+    });
+  }
+
+  send(data: string): void {
+    this.ws.send(data);
+  }
+
+  close(): void {
+    this.ws.close();
+  }
+
+  private removeWaiter(waiter: (typeof this.waiters)[number]): void {
+    const index = this.waiters.indexOf(waiter);
+    if (index >= 0) this.waiters.splice(index, 1);
+    clearTimeout(waiter.timer);
+  }
+}
+
+async function startHub() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-cross-node-pty-'));
+  const registry = createHubNodeRegistry({
+    storagePath: path.join(tmpDir, 'hub', 'nodes.json'),
+    staleMs: 45_000,
+    offlineMs: 90_000,
+    heartbeatPersistDebounceMs: 1,
+  });
+  const nodeLinks = createHubNodeLinkManager();
+  const app = express();
+  app.use(express.json());
+  app.use(
+    createHubNodeRouter({
+      registry,
+      nodeLinks,
+      requireAuth: (req, res, next) => {
+        if (req.header('x-test-auth') === 'yes') next();
+        else res.status(401).json({ error: 'Unauthorized' });
+      },
+    })
+  );
+  const server = http.createServer(app);
+  setupWebSocket(
+    server,
+    new Set(),
+    null,
+    undefined,
+    true,
+    createLocalRelayNode({ nodeId: 'local' }),
+    registry,
+    nodeLinks
+  );
+  const port = await listen(server);
+  return {
+    tmpDir,
+    server,
+    base: `http://127.0.0.1:${port}`,
+    wsBase: `ws://127.0.0.1:${port}`,
+  };
+}
+
+async function pairAndConnectNode(input: {
+  base: string;
+  wsBase: string;
+  hostname: string;
+}): Promise<SimulatedNode> {
+  const pairRes = await fetch(`${input.base}/hub/pair-tokens`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+    body: JSON.stringify({ displayName: input.hostname }),
+  });
+  expect(pairRes.status, `pair-token creation failed for ${input.hostname}`).toBe(201);
+  const pair = (await pairRes.json()) as { pairToken: string };
+
+  const exchangeRes = await fetch(`${input.base}/hub/pairing/exchange`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ pairToken: pair.pairToken, manifest: manifest(input.hostname) }),
+  });
+  expect(exchangeRes.status, `pair exchange failed for ${input.hostname}`).toBe(201);
+  const exchange = (await exchangeRes.json()) as {
+    credential: { token: string; nodeId: string };
+  };
+  const ws = new WebSocket(`${input.wsBase}/hub/node-link`, {
+    headers: { authorization: `Bearer ${exchange.credential.token}` },
+  });
+  await waitForOpen(ws);
+  return new SimulatedNode(
+    exchange.credential.nodeId,
+    exchange.credential.token,
+    input.hostname,
+    ws
+  );
+}
+
+async function createRemoteSession(input: {
+  base: string;
+  node: SimulatedNode;
+  sessionId: string;
+}): Promise<SessionSummary> {
+  const createPromise = fetch(
+    `${input.base}/hub/nodes/${encodeURIComponent(input.node.nodeId)}/sessions`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      body: JSON.stringify({
+        repoPath: `/nodes/${input.node.hostname}/relay-ide`,
+        type: 'terminal',
+      }),
+    }
+  );
+  const createRequest = await input.node.waitFor(
+    (message) => message.channel === 'rpc' && message.type === 'sessions.create',
+    `${input.node.hostname} sessions.create`
+  );
+  input.node.answerCreate(createRequest, input.sessionId);
+  const createRes = await createPromise;
+  expect(createRes.status, `${input.node.hostname} session create failed`).toBe(201);
+  return (await createRes.json()) as SessionSummary;
+}
+
+async function attachBrowser(input: {
+  wsBase: string;
+  node: SimulatedNode;
+  sessionId: string;
+}): Promise<{ browser: BrowserClient; attach: RelayNodeEnvelope }> {
+  const browserWs = new WebSocket(
+    `${input.wsBase}/nodes/${encodeURIComponent(input.node.nodeId)}/ws/sessions/${input.sessionId}`
+  );
+  await waitForOpen(browserWs);
+  const browser = new BrowserClient(browserWs);
+  const attach = await input.node.waitFor(
+    (message) => message.channel === 'pty' && message.type === 'pty.attach',
+    `${input.node.hostname} pty.attach`
+  );
+  expect(attach).toMatchObject({
+    nodeId: input.node.nodeId,
+    payload: { sessionId: input.sessionId },
+  });
+  expect(attach.streamId).toBeTruthy();
+  return { browser, attach };
+}
+
+async function runSustainedEcho(input: {
+  node: SimulatedNode;
+  browser: BrowserClient;
+  streamId: string;
+  marker: string;
+}): Promise<{ bytesFromBrowser: number; bytesToBrowser: number }> {
+  let bytesFromBrowser = 0;
+  let bytesToBrowser = 0;
+  const deadline = Date.now() + STRESS_DURATION_MS;
+  const inputPump = (async () => {
+    while (Date.now() < deadline || bytesFromBrowser < STRESS_TOTAL_BYTES) {
+      const sequence = Math.floor(bytesFromBrowser / STRESS_CHUNK_BYTES);
+      const prefix = `${input.marker}:${sequence}:`;
+      const data = prefix.padEnd(STRESS_CHUNK_BYTES, input.marker[0]);
+      input.browser.send(data);
+      bytesFromBrowser += Buffer.byteLength(data);
+      await delay(100);
+    }
+  })();
+
+  while (bytesToBrowser < STRESS_TOTAL_BYTES) {
+    const ptyInput = await input.node.waitFor(
+      (message) =>
+        message.channel === 'pty' &&
+        message.type === 'pty.input' &&
+        message.streamId === input.streamId,
+      `${input.node.hostname} stress pty.input`,
+      4_000
+    );
+    const data = (ptyInput.payload as { data?: unknown } | undefined)?.data;
+    expect(typeof data).toBe('string');
+    expect(data as string).toContain(input.marker);
+    bytesToBrowser += Buffer.byteLength(data as string);
+    input.node.sendPtyData(input.streamId, data as string);
+  }
+  await inputPump;
+  await input.browser.waitFor(
+    (message) => message.includes(`${input.marker}:0:`),
+    `${input.marker} first echoed chunk`,
+    4_000
+  );
+  return { bytesFromBrowser, bytesToBrowser };
+}
+
+describe('hub cross-node PTY smoke harness', () => {
+  const cleanup: Cleanup[] = [];
+
+  afterEach(async () => {
+    while (cleanup.length > 0) await cleanup.pop()?.();
+  });
+
+  it('routes concurrent two-node PTY streams without cross-talk and isolates one node link failure', async () => {
+    const hub = await startHub();
+    cleanup.push(() => fs.rmSync(hub.tmpDir, { recursive: true, force: true }));
+    cleanup.push(() => closeServer(hub.server));
+
+    const [nodeA, nodeB] = await Promise.all([
+      pairAndConnectNode({ base: hub.base, wsBase: hub.wsBase, hostname: 'smoke-node-a' }),
+      pairAndConnectNode({ base: hub.base, wsBase: hub.wsBase, hostname: 'smoke-node-b' }),
+    ]);
+    cleanup.push(() => nodeA.close());
+    cleanup.push(() => nodeB.close());
+
+    await Promise.all([nodeA.hello(), nodeB.hello()]);
+
+    const [sessionA, sessionB] = await Promise.all([
+      createRemoteSession({ base: hub.base, node: nodeA, sessionId: 'terminal-a' }),
+      createRemoteSession({ base: hub.base, node: nodeB, sessionId: 'terminal-b' }),
+    ]);
+    expect(sessionA).toMatchObject({
+      id: 'terminal-a',
+      nodeId: nodeA.nodeId,
+      globalSessionId: `${nodeA.nodeId}:terminal-a`,
+    });
+    expect(sessionB).toMatchObject({
+      id: 'terminal-b',
+      nodeId: nodeB.nodeId,
+      globalSessionId: `${nodeB.nodeId}:terminal-b`,
+    });
+
+    const [{ browser: browserA, attach: attachA }, { browser: browserB, attach: attachB }] =
+      await Promise.all([
+        attachBrowser({ wsBase: hub.wsBase, node: nodeA, sessionId: 'terminal-a' }),
+        attachBrowser({ wsBase: hub.wsBase, node: nodeB, sessionId: 'terminal-b' }),
+      ]);
+    cleanup.push(() => browserA.close());
+    cleanup.push(() => browserB.close());
+
+    const markerA = 'node-a-marker';
+    const markerB = 'node-b-marker';
+    const firstA = browserA.waitFor(
+      (message) => message.includes(markerA),
+      'node A marker'
+    );
+    const firstB = browserB.waitFor(
+      (message) => message.includes(markerB),
+      'node B marker'
+    );
+    nodeA.sendPtyData(attachA.streamId!, `${markerA}:hello-browser-a`);
+    nodeB.sendPtyData(attachB.streamId!, `${markerB}:hello-browser-b`);
+    await expect(firstA).resolves.toContain(markerA);
+    await expect(firstB).resolves.toContain(markerB);
+    expect(browserA.messages.join('\n')).not.toContain(markerB);
+    expect(browserB.messages.join('\n')).not.toContain(markerA);
+
+    const [stressA, stressB] = await Promise.all([
+      runSustainedEcho({
+        node: nodeA,
+        browser: browserA,
+        streamId: attachA.streamId!,
+        marker: 'AAAA',
+      }),
+      runSustainedEcho({
+        node: nodeB,
+        browser: browserB,
+        streamId: attachB.streamId!,
+        marker: 'BBBB',
+      }),
+    ]);
+    expect(stressA.bytesFromBrowser).toBeGreaterThanOrEqual(STRESS_TOTAL_BYTES);
+    expect(stressA.bytesToBrowser).toBeGreaterThanOrEqual(STRESS_TOTAL_BYTES);
+    expect(stressB.bytesFromBrowser).toBeGreaterThanOrEqual(STRESS_TOTAL_BYTES);
+    expect(stressB.bytesToBrowser).toBeGreaterThanOrEqual(STRESS_TOTAL_BYTES);
+    expect(browserA.messages.join('')).not.toContain('BBBB');
+    expect(browserB.messages.join('')).not.toContain('AAAA');
+
+    const browserBClose = waitForClose(browserB.ws);
+    nodeB.close();
+    await expect(browserBClose).resolves.toMatchObject({
+      code: 1011,
+      reason: 'node link closed',
+    });
+
+    const nodeASurvives = browserA.waitFor(
+      (message) => message.includes('node-a-after-b-disconnect'),
+      'node A survives node B disconnect'
+    );
+    nodeA.sendPtyData(attachA.streamId!, 'node-a-after-b-disconnect');
+    await expect(nodeASurvives).resolves.toBe('node-a-after-b-disconnect');
+    expect(nodeA.ws.readyState).toBe(WebSocket.OPEN);
+  });
+});

--- a/test/hub-cross-node-pty.test.ts
+++ b/test/hub-cross-node-pty.test.ts
@@ -11,6 +11,7 @@ import { createHubNodeRouter } from '../server/hub-node-router.js';
 import { createLocalRelayNode } from '../server/local-node.js';
 import { setupWebSocket } from '../server/ws.js';
 import type { SessionSummary } from '../server/types.js';
+import { createGlobalSessionId } from '../shared/identity.js';
 import type { NodeManifest } from '../shared/node-manifest.js';
 import {
   RELAY_NODE_LINK_PROTOCOL,
@@ -108,7 +109,7 @@ function remoteSession(input: {
     idle: false,
     customCommand: null,
     nodeId: input.nodeId,
-    globalSessionId: `${input.nodeId}:${input.sessionId}`,
+    globalSessionId: createGlobalSessionId(input.nodeId, input.sessionId),
     repoInstanceId: `${encodeURIComponent(input.nodeId)}:${encodeURIComponent(repoPath)}`,
     useTmux: true,
     tmuxSessionName: `relay-ide-${input.sessionId}`,
@@ -119,7 +120,23 @@ function remoteSession(input: {
 }
 
 async function listen(server: http.Server): Promise<number> {
-  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  await new Promise<void>((resolve, reject) => {
+    const cleanupListeners = () => {
+      server.off('error', onError);
+      server.off('listening', onListening);
+    };
+    const onError = (error: Error) => {
+      cleanupListeners();
+      reject(error);
+    };
+    const onListening = () => {
+      cleanupListeners();
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(0, '127.0.0.1');
+  });
   const address = server.address();
   if (!address || typeof address === 'string')
     throw new Error('smoke hub did not bind a TCP port');
@@ -200,6 +217,10 @@ class SimulatedNode {
         break;
       }
     });
+    ws.on('close', () => this.rejectWaiters(`${this.hostname} node link closed`));
+    ws.on('error', (error) =>
+      this.rejectWaiters(`${this.hostname} node link error: ${error.message}`)
+    );
   }
 
   waitFor(
@@ -270,6 +291,13 @@ class SimulatedNode {
     if (index >= 0) this.waiters.splice(index, 1);
     clearTimeout(waiter.timer);
   }
+
+  private rejectWaiters(reason: string): void {
+    for (const waiter of [...this.waiters]) {
+      this.removeWaiter(waiter);
+      waiter.reject(new Error(`stopped waiting for ${waiter.label}: ${reason}`));
+    }
+  }
 }
 
 class BrowserClient {
@@ -296,7 +324,13 @@ class BrowserClient {
     });
     ws.on('close', (code, reason) => {
       this.closes.push({ code, reason: reason.toString() });
+      this.rejectWaiters(
+        `browser socket closed (${code}${reason.length ? ` ${reason.toString()}` : ''})`
+      );
     });
+    ws.on('error', (error) =>
+      this.rejectWaiters(`browser socket error: ${error.message}`)
+    );
   }
 
   waitFor(
@@ -322,6 +356,41 @@ class BrowserClient {
     });
   }
 
+  waitForBytes(
+    predicate: (message: string) => boolean,
+    expectedBytes: number,
+    label: string,
+    timeoutMs = 4_000
+  ): Promise<number> {
+    const receivedBytes = () => this.countBytes(predicate);
+    const existingBytes = receivedBytes();
+    if (existingBytes >= expectedBytes) return Promise.resolve(existingBytes);
+
+    return new Promise<number>((resolve, reject) => {
+      const waiter = {
+        label,
+        predicate: () => {
+          const bytes = receivedBytes();
+          if (bytes < expectedBytes) return false;
+          resolve(bytes);
+          return true;
+        },
+        resolve: () => {},
+        reject,
+        timer: setTimeout(() => {
+          this.removeWaiter(waiter);
+          reject(
+            new Error(
+              `timed out waiting for ${expectedBytes} browser bytes for ${label}; received ${receivedBytes()}`
+            )
+          );
+        }, timeoutMs),
+      };
+      waiter.timer.unref?.();
+      this.waiters.push(waiter);
+    });
+  }
+
   send(data: string): void {
     this.ws.send(data);
   }
@@ -334,6 +403,21 @@ class BrowserClient {
     const index = this.waiters.indexOf(waiter);
     if (index >= 0) this.waiters.splice(index, 1);
     clearTimeout(waiter.timer);
+  }
+
+  private countBytes(predicate: (message: string) => boolean): number {
+    return this.messages.reduce(
+      (total, message) =>
+        predicate(message) ? total + Buffer.byteLength(message) : total,
+      0
+    );
+  }
+
+  private rejectWaiters(reason: string): void {
+    for (const waiter of [...this.waiters]) {
+      this.removeWaiter(waiter);
+      waiter.reject(new Error(`stopped waiting for ${waiter.label}: ${reason}`));
+    }
   }
 }
 
@@ -444,7 +528,7 @@ async function attachBrowser(input: {
   sessionId: string;
 }): Promise<{ browser: BrowserClient; attach: RelayNodeEnvelope }> {
   const browserWs = new WebSocket(
-    `${input.wsBase}/nodes/${encodeURIComponent(input.node.nodeId)}/ws/sessions/${input.sessionId}`
+    `${input.wsBase}/nodes/${encodeURIComponent(input.node.nodeId)}/ws/sessions/${encodeURIComponent(input.sessionId)}`
   );
   await waitForOpen(browserWs);
   const browser = new BrowserClient(browserWs);
@@ -465,9 +549,13 @@ async function runSustainedEcho(input: {
   browser: BrowserClient;
   streamId: string;
   marker: string;
-}): Promise<{ bytesFromBrowser: number; bytesToBrowser: number }> {
+}): Promise<{
+  bytesFromBrowser: number;
+  bytesObservedByNode: number;
+  bytesToBrowser: number;
+}> {
   let bytesFromBrowser = 0;
-  let bytesToBrowser = 0;
+  let bytesObservedByNode = 0;
   const deadline = Date.now() + STRESS_DURATION_MS;
   const inputPump = (async () => {
     while (Date.now() < deadline || bytesFromBrowser < STRESS_TOTAL_BYTES) {
@@ -480,7 +568,7 @@ async function runSustainedEcho(input: {
     }
   })();
 
-  while (bytesToBrowser < STRESS_TOTAL_BYTES) {
+  while (bytesObservedByNode < STRESS_TOTAL_BYTES) {
     const ptyInput = await input.node.waitFor(
       (message) =>
         message.channel === 'pty' &&
@@ -492,16 +580,17 @@ async function runSustainedEcho(input: {
     const data = (ptyInput.payload as { data?: unknown } | undefined)?.data;
     expect(typeof data).toBe('string');
     expect(data as string).toContain(input.marker);
-    bytesToBrowser += Buffer.byteLength(data as string);
+    bytesObservedByNode += Buffer.byteLength(data as string);
     input.node.sendPtyData(input.streamId, data as string);
   }
-  await inputPump;
-  await input.browser.waitFor(
-    (message) => message.includes(`${input.marker}:0:`),
-    `${input.marker} first echoed chunk`,
+  const bytesToBrowser = await input.browser.waitForBytes(
+    (message) => message.includes(input.marker),
+    STRESS_TOTAL_BYTES,
+    `${input.marker} echoed browser bytes`,
     4_000
   );
-  return { bytesFromBrowser, bytesToBrowser };
+  await inputPump;
+  return { bytesFromBrowser, bytesObservedByNode, bytesToBrowser };
 }
 
 describe('hub cross-node PTY smoke harness', () => {
@@ -532,12 +621,12 @@ describe('hub cross-node PTY smoke harness', () => {
     expect(sessionA).toMatchObject({
       id: 'terminal-a',
       nodeId: nodeA.nodeId,
-      globalSessionId: `${nodeA.nodeId}:terminal-a`,
+      globalSessionId: createGlobalSessionId(nodeA.nodeId, 'terminal-a'),
     });
     expect(sessionB).toMatchObject({
       id: 'terminal-b',
       nodeId: nodeB.nodeId,
-      globalSessionId: `${nodeB.nodeId}:terminal-b`,
+      globalSessionId: createGlobalSessionId(nodeB.nodeId, 'terminal-b'),
     });
 
     const [{ browser: browserA, attach: attachA }, { browser: browserB, attach: attachB }] =
@@ -580,8 +669,10 @@ describe('hub cross-node PTY smoke harness', () => {
       }),
     ]);
     expect(stressA.bytesFromBrowser).toBeGreaterThanOrEqual(STRESS_TOTAL_BYTES);
+    expect(stressA.bytesObservedByNode).toBeGreaterThanOrEqual(STRESS_TOTAL_BYTES);
     expect(stressA.bytesToBrowser).toBeGreaterThanOrEqual(STRESS_TOTAL_BYTES);
     expect(stressB.bytesFromBrowser).toBeGreaterThanOrEqual(STRESS_TOTAL_BYTES);
+    expect(stressB.bytesObservedByNode).toBeGreaterThanOrEqual(STRESS_TOTAL_BYTES);
     expect(stressB.bytesToBrowser).toBeGreaterThanOrEqual(STRESS_TOTAL_BYTES);
     expect(browserA.messages.join('')).not.toContain('BBBB');
     expect(browserB.messages.join('')).not.toContain('AAAA');

--- a/test/hub-cross-node-pty.test.ts
+++ b/test/hub-cross-node-pty.test.ts
@@ -565,9 +565,14 @@ async function runSustainedEcho(input: {
 }> {
   let bytesFromBrowser = 0;
   let bytesObservedByNode = 0;
+  let stopInputPump = false;
   const deadline = Date.now() + STRESS_DURATION_MS;
   const inputPump = (async () => {
-    while (Date.now() < deadline || bytesFromBrowser < STRESS_TOTAL_BYTES) {
+    while (
+      !stopInputPump &&
+      input.browser.ws.readyState === WebSocket.OPEN &&
+      (Date.now() < deadline || bytesFromBrowser < STRESS_TOTAL_BYTES)
+    ) {
       const sequence = Math.floor(bytesFromBrowser / STRESS_CHUNK_BYTES);
       const prefix = `${input.marker}:${sequence}:`;
       const data = prefix.padEnd(STRESS_CHUNK_BYTES, input.marker[0]);
@@ -577,29 +582,87 @@ async function runSustainedEcho(input: {
     }
   })();
 
-  while (bytesObservedByNode < STRESS_TOTAL_BYTES) {
-    const ptyInput = await input.node.waitFor(
-      (message) =>
-        message.channel === 'pty' &&
-        message.type === 'pty.input' &&
-        message.streamId === input.streamId,
-      `${input.node.hostname} stress pty.input`,
+  try {
+    while (bytesObservedByNode < STRESS_TOTAL_BYTES) {
+      const ptyInput = await input.node.waitFor(
+        (message) => {
+          const data = (message.payload as { data?: unknown } | undefined)?.data;
+          return (
+            message.channel === 'pty' &&
+            message.type === 'pty.input' &&
+            message.streamId === input.streamId &&
+            typeof data === 'string' &&
+            data.includes(input.marker)
+          );
+        },
+        `${input.node.hostname} stress pty.input`,
+        4_000
+      );
+      const data = (ptyInput.payload as { data?: unknown } | undefined)?.data;
+      expect(typeof data).toBe('string');
+      expect(data as string).toContain(input.marker);
+      bytesObservedByNode += Buffer.byteLength(data as string);
+      input.node.sendPtyData(input.streamId, data as string);
+    }
+    const bytesToBrowser = await input.browser.waitForBytes(
+      (message) => message.includes(input.marker),
+      STRESS_TOTAL_BYTES,
+      `${input.marker} echoed browser bytes`,
       4_000
     );
-    const data = (ptyInput.payload as { data?: unknown } | undefined)?.data;
-    expect(typeof data).toBe('string');
-    expect(data as string).toContain(input.marker);
-    bytesObservedByNode += Buffer.byteLength(data as string);
-    input.node.sendPtyData(input.streamId, data as string);
+    await inputPump;
+    return { bytesFromBrowser, bytesObservedByNode, bytesToBrowser };
+  } finally {
+    stopInputPump = true;
+    await inputPump.catch(() => {});
   }
-  const bytesToBrowser = await input.browser.waitForBytes(
-    (message) => message.includes(input.marker),
-    STRESS_TOTAL_BYTES,
-    `${input.marker} echoed browser bytes`,
-    4_000
+}
+
+function browserBytes(browser: BrowserClient, marker: string): number {
+  return browser.messages.reduce(
+    (total, message) =>
+      message.includes(marker) ? total + Buffer.byteLength(message) : total,
+    0
   );
-  await inputPump;
-  return { bytesFromBrowser, bytesObservedByNode, bytesToBrowser };
+}
+
+function nodeInputBytes(node: SimulatedNode, streamId: string, marker: string): number {
+  return node.messages.reduce((total, message) => {
+    const data = (message.payload as { data?: unknown } | undefined)?.data;
+    if (
+      message.channel !== 'pty' ||
+      message.type !== 'pty.input' ||
+      message.streamId !== streamId ||
+      typeof data !== 'string' ||
+      !data.includes(marker)
+    ) {
+      return total;
+    }
+    return total + Buffer.byteLength(data);
+  }, 0);
+}
+
+async function waitForNodeInputBytes(input: {
+  node: SimulatedNode;
+  streamId: string;
+  marker: string;
+  expectedBytes: number;
+  label: string;
+  timeoutMs?: number;
+}): Promise<number> {
+  const deadline = Date.now() + (input.timeoutMs ?? 4_000);
+  while (Date.now() < deadline) {
+    const bytes = nodeInputBytes(input.node, input.streamId, input.marker);
+    if (bytes >= input.expectedBytes) return bytes;
+    await delay(25);
+  }
+  throw new Error(
+    `timed out waiting for ${input.expectedBytes} node input bytes for ${input.label}; received ${nodeInputBytes(
+      input.node,
+      input.streamId,
+      input.marker
+    )}`
+  );
 }
 
 describe('hub cross-node PTY smoke harness', () => {
@@ -686,19 +749,65 @@ describe('hub cross-node PTY smoke harness', () => {
     expect(browserA.messages.join('')).not.toContain('BBBB');
     expect(browserB.messages.join('')).not.toContain('AAAA');
 
+    const markerAThroughFailure = 'AAAA-through-node-b-failure';
+    const markerBInterrupted = 'BBBB-interrupted-by-node-link-close';
+    const nodeAThroughFailure = runSustainedEcho({
+      node: nodeA,
+      browser: browserA,
+      streamId: attachA.streamId!,
+      marker: markerAThroughFailure,
+    });
+    const nodeBInterrupted = runSustainedEcho({
+      node: nodeB,
+      browser: browserB,
+      streamId: attachB.streamId!,
+      marker: markerBInterrupted,
+    });
+
+    await Promise.all([
+      waitForNodeInputBytes({
+        node: nodeA,
+        streamId: attachA.streamId!,
+        marker: markerAThroughFailure,
+        expectedBytes: STRESS_CHUNK_BYTES,
+        label: 'node A in-flight before node B disconnect',
+      }),
+      waitForNodeInputBytes({
+        node: nodeB,
+        streamId: attachB.streamId!,
+        marker: markerBInterrupted,
+        expectedBytes: STRESS_CHUNK_BYTES,
+        label: 'node B in-flight before disconnect',
+      }),
+    ]);
+    const nodeABytesBeforeNodeBFailure = await browserA.waitForBytes(
+      (message) => message.includes(markerAThroughFailure),
+      STRESS_CHUNK_BYTES,
+      'node A echoed bytes before node B disconnect'
+    );
+    expect(nodeABytesBeforeNodeBFailure).toBeGreaterThan(0);
+    expect(nodeABytesBeforeNodeBFailure).toBeLessThan(STRESS_TOTAL_BYTES);
+
     const browserBClose = waitForClose(browserB.ws);
     nodeB.close();
     await expect(browserBClose).resolves.toMatchObject({
       code: 1011,
       reason: 'node link closed',
     });
+    await expect(nodeBInterrupted).rejects.toThrow(/node link closed/);
 
-    const nodeASurvives = browserA.waitFor(
-      (message) => message.includes('node-a-after-b-disconnect'),
-      'node A survives node B disconnect'
+    const nodeAAfterNodeBFailure = await nodeAThroughFailure;
+    expect(nodeAAfterNodeBFailure.bytesFromBrowser).toBeGreaterThanOrEqual(STRESS_TOTAL_BYTES);
+    expect(nodeAAfterNodeBFailure.bytesObservedByNode).toBeGreaterThanOrEqual(
+      STRESS_TOTAL_BYTES
     );
-    nodeA.sendPtyData(attachA.streamId!, 'node-a-after-b-disconnect');
-    await expect(nodeASurvives).resolves.toBe('node-a-after-b-disconnect');
+    expect(nodeAAfterNodeBFailure.bytesToBrowser).toBeGreaterThanOrEqual(STRESS_TOTAL_BYTES);
+    expect(browserBytes(browserA, markerAThroughFailure)).toBeGreaterThanOrEqual(
+      STRESS_TOTAL_BYTES
+    );
+    expect(browserA.closes).toHaveLength(0);
+    expect(browserA.messages.join('')).not.toContain(markerBInterrupted);
+    expect(browserB.messages.join('')).not.toContain(markerAThroughFailure);
     expect(nodeA.ws.readyState).toBe(WebSocket.OPEN);
   });
 });

--- a/test/hub-cross-node-pty.test.ts
+++ b/test/hub-cross-node-pty.test.ts
@@ -501,21 +501,30 @@ async function createRemoteSession(input: {
   node: SimulatedNode;
   sessionId: string;
 }): Promise<SessionSummary> {
+  const createController = new AbortController();
   const createPromise = fetch(
     `${input.base}/hub/nodes/${encodeURIComponent(input.node.nodeId)}/sessions`,
     {
       method: 'POST',
       headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      signal: createController.signal,
       body: JSON.stringify({
         repoPath: `/nodes/${input.node.hostname}/relay-ide`,
         type: 'terminal',
       }),
     }
   );
-  const createRequest = await input.node.waitFor(
-    (message) => message.channel === 'rpc' && message.type === 'sessions.create',
-    `${input.node.hostname} sessions.create`
-  );
+  let createRequest: RelayNodeEnvelope;
+  try {
+    createRequest = await input.node.waitFor(
+      (message) => message.channel === 'rpc' && message.type === 'sessions.create',
+      `${input.node.hostname} sessions.create`
+    );
+  } catch (error) {
+    createController.abort();
+    await createPromise.catch(() => undefined);
+    throw error;
+  }
   input.node.answerCreate(createRequest, input.sessionId);
   const createRes = await createPromise;
   expect(createRes.status, `${input.node.hostname} session create failed`).toBe(201);


### PR DESCRIPTION
## Summary
- Adds `test/hub-cross-node-pty.test.ts` as the canonical two-node routed PTY smoke harness.
- Exercises hub pairing, two simultaneous simulated node reverse links, concurrent routed `sessions.create`, two browser PTY WebSocket clients, node-scoped marker echoes, sustained 10KB+ per-link traffic over ~2s, and node-B link failure while node-A survives.
- Updates `npm run test:smoke:multi-node` and federation/quality docs to point at the new harness.

## The Case Against
- This remains a simulated-node integration harness, not real tmux or real remote host coverage. That is deliberate for #468; tmux-specific behavior stays out of scope and belongs behind the `SessionAttachment`/node-link host tests.
- The sustained traffic check uses deterministic WebSocket payloads rather than OS PTY backpressure, so it proves hub/node envelope routing and browser-client isolation, not terminal emulator throughput.
- The file is intentionally verbose because the fake hub/node/browser topology is easier to debug when the harness owns its fixtures locally; shared helpers can be extracted later if more multi-node tests appear.

## Verification
- `npx vitest run test/hub-cross-node-pty.test.ts --reporter=dot` → PASS (1)
- `npm run test:smoke:multi-node -- --reporter=dot` → PASS (2 files, 3 tests)
- `npx vitest run test/hub-node-session-routing.test.ts test/node-link-pty-host.test.ts --reporter=dot` → PASS (28)
- `npm run check` → PASS (0 errors, existing warnings)
- `npm run build` → PASS
- `npm test -- --reporter=dot` → PASS (215 files, 2272 tests) after one bounded retry; first run hit an unrelated `test/branch-watcher.test.ts` `[needs:git-init]` watcher flake, and the targeted file passed immediately.

Closes #468
Refs #443


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified test command descriptions for multi-node smoke testing
  * Added reference to canonical multi-node PTY routing harness in implementation status

* **Tests**
  * Expanded smoke test suite to validate PTY data routing across multiple nodes
  * Updated test script to run additional integration tests for federated relay scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->