### PR TITLE
feat: add CLI gateway file RPC and detach smoke

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -46,6 +46,7 @@ import {
   sanitizedGatewayErrorDetails,
   validateAndSanitizeGatewayCreateInput,
 } from '../shared/cli-gateway-runtime.js';
+import { isFileRpcOperation, type FileRpcOperation } from '../shared/file-rpc.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -76,7 +77,7 @@ Commands:
   uninstall          Back-compat alias for relay-ide hub uninstall
   status             Back-compat alias for relay-ide hub status
   manifest           Print local node capability manifest as JSON
-  v1 ... --json      Versioned CLI gateway JSON contract for nodes/sessions
+  v1 ... --json      Versioned CLI gateway JSON contract for nodes/sessions/files
   diag               Collect local diagnostics
     bundle [--output <dir>] [--lines <n>] [--json]
                                        Write a timestamped redacted diagnostics directory
@@ -373,7 +374,7 @@ function requireGatewaySessionId(
 
 function gatewayUsage(): never {
   logger.error(
-    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions interventions|sessions hand-back) --json'
+    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions attach|sessions detach|sessions interventions|sessions hand-back|files list|files stat|files read) --json'
   );
   process.exit(1);
 }
@@ -425,6 +426,164 @@ async function runGatewaySessionGet(sessionArgs: string[]): Promise<never> {
   printGatewayEnvelope(gatewayOk('sessions.get', session), 0);
 }
 
+
+interface GatewaySessionDescriptor {
+  id?: string;
+  nodeId?: string;
+  globalSessionId?: string;
+}
+
+async function gatewaySessionDescriptor(id: string): Promise<GatewaySessionDescriptor> {
+  const session = await gatewayHttpJson({
+    commandName: 'sessions.get',
+    pathName: `/sessions/${encodeURIComponent(id)}`,
+    capabilities: ['session:read'],
+  });
+  return typeof session === 'object' && session !== null
+    ? (session as GatewaySessionDescriptor)
+    : {};
+}
+
+const gatewayFileStringFields = [
+  'nodeId',
+  'sessionId',
+  'id',
+  'path',
+  'cwd',
+  'confirmationToken',
+] as const;
+
+const gatewayFileAllowedFields = new Set<string>([
+  ...gatewayFileStringFields,
+  'maxEntries',
+  'maxBytes',
+  'maxLines',
+]);
+
+function gatewayFileInputFromArgs(
+  commandName: RelayCliGatewayCommand,
+  fileArgs: string[]
+): Record<string, unknown> {
+  const inputJson = gatewayArg(fileArgs, '--input-json');
+  if (inputJson) return parseGatewayJson(commandName, inputJson);
+  const inputFile = gatewayArg(fileArgs, '--input-file');
+  if (!inputFile) return gatewayFileInputFromFlags(fileArgs);
+  try {
+    return parseGatewayJson(commandName, fs.readFileSync(path.resolve(inputFile), 'utf8'));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    gatewayInvalid(commandName, `could not read --input-file: ${message}`);
+  }
+}
+
+function gatewayFileInputFromFlags(fileArgs: string[]): Record<string, unknown> {
+  const input: Record<string, unknown> = {};
+  const sessionId = gatewayArg(fileArgs, '--session-id') ?? gatewayArg(fileArgs, '--id') ?? fileArgs[0];
+  if (sessionId && !sessionId.startsWith('--')) input['sessionId'] = sessionId;
+  for (const [flag, field] of [
+    ['--node-id', 'nodeId'],
+    ['--path', 'path'],
+    ['--cwd', 'cwd'],
+    ['--confirmation-token', 'confirmationToken'],
+  ] as const) {
+    const value = gatewayArg(fileArgs, flag);
+    if (value) input[field] = value;
+  }
+  return input;
+}
+
+function assertGatewayFileStringFields(
+  commandName: RelayCliGatewayCommand,
+  input: Record<string, unknown>
+): void {
+  for (const field of gatewayFileStringFields) {
+    if (input[field] !== undefined && typeof input[field] !== 'string') {
+      gatewayInvalid(commandName, `${field} must be a string`, { field });
+    }
+  }
+}
+
+function normalizeGatewayFileRequiredFields(
+  commandName: RelayCliGatewayCommand,
+  input: Record<string, unknown>
+): void {
+  if (input['sessionId'] === undefined && typeof input['id'] === 'string') {
+    input['sessionId'] = input['id'];
+  }
+  if (typeof input['sessionId'] !== 'string' || !input['sessionId'].trim()) {
+    gatewayInvalid(commandName, '--session-id is required', { field: 'sessionId' });
+  }
+  if (input['path'] === undefined) input['path'] = '.';
+  if (typeof input['path'] !== 'string' || !input['path'].trim()) {
+    gatewayInvalid(commandName, '--path must be a non-empty string', { field: 'path' });
+  }
+}
+
+function gatewayBoundedNumber(
+  commandName: RelayCliGatewayCommand,
+  field: string,
+  value: unknown,
+  max: number
+): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > max) {
+    gatewayInvalid(commandName, `${field} must be a positive integer <= ${max}`, {
+      field,
+      value,
+      max,
+    });
+  }
+  return parsed;
+}
+
+function applyGatewayFileCaps(
+  operation: FileRpcOperation,
+  commandName: RelayCliGatewayCommand,
+  input: Record<string, unknown>,
+  fileArgs: string[]
+): void {
+  if (operation === 'list') {
+    const value = input['maxEntries'] ?? gatewayArg(fileArgs, '--max-entries');
+    if (value !== undefined) input['maxEntries'] = gatewayBoundedNumber(commandName, 'maxEntries', value, 500);
+  }
+  if (operation !== 'read') return;
+  const caps = [
+    ['maxBytes', '--max-bytes', 65536],
+    ['maxLines', '--max-lines', 2000],
+  ] as const;
+  for (const [field, flag, max] of caps) {
+    const value = input[field] ?? gatewayArg(fileArgs, flag);
+    if (value !== undefined) input[field] = gatewayBoundedNumber(commandName, field, value, max);
+  }
+}
+
+function assertGatewayFileAllowedFields(
+  commandName: RelayCliGatewayCommand,
+  operation: FileRpcOperation,
+  input: Record<string, unknown>
+): void {
+  for (const field of Object.keys(input)) {
+    if (!gatewayFileAllowedFields.has(field)) {
+      gatewayInvalid(commandName, `files.${operation} field is not in the v1 contract: ${field}`, {
+        field,
+      });
+    }
+  }
+}
+
+function parseGatewayFileInput(
+  operation: FileRpcOperation,
+  fileArgs: string[]
+): Record<string, unknown> {
+  const commandName = `files.${operation}` as RelayCliGatewayCommand;
+  const input = gatewayFileInputFromArgs(commandName, fileArgs);
+  assertGatewayFileStringFields(commandName, input);
+  normalizeGatewayFileRequiredFields(commandName, input);
+  applyGatewayFileCaps(operation, commandName, input, fileArgs);
+  assertGatewayFileAllowedFields(commandName, operation, input);
+  return input;
+}
+
 async function runGatewaySessionCreate(sessionArgs: string[]): Promise<never> {
   const input = parseGatewayCreateInput(sessionArgs);
   const validated = validateAndSanitizeGatewayCreateInput(input);
@@ -449,6 +608,46 @@ async function runGatewaySessionCreate(sessionArgs: string[]): Promise<never> {
     ],
   });
   printGatewayEnvelope(gatewayOk('sessions.create', session), 0);
+}
+
+async function runGatewaySessionAttach(sessionArgs: string[]): Promise<never> {
+  const id = requireGatewaySessionId('sessions.attach', sessionArgs);
+  const session = await gatewayHttpJson({
+    commandName: 'sessions.attach',
+    pathName: `/sessions/${encodeURIComponent(id)}`,
+    capabilities: ['session:read', 'session:attach'],
+  });
+  printGatewayEnvelope(
+    gatewayOk('sessions.attach', {
+      session,
+      attach: {
+        streaming: false,
+        mode: 'descriptor',
+        message:
+          'resolved session descriptor only; v1 attach does not start an adapter runtime or PTY stream',
+      },
+    }),
+    0
+  );
+}
+
+async function runGatewaySessionDetach(sessionArgs: string[]): Promise<never> {
+  const id = requireGatewaySessionId('sessions.detach', sessionArgs);
+  const session = await gatewayHttpJson({
+    commandName: 'sessions.detach',
+    pathName: `/sessions/${encodeURIComponent(id)}`,
+    capabilities: ['session:read', 'session:attach'],
+  });
+  printGatewayEnvelope(
+    gatewayOk('sessions.detach', {
+      detached: true,
+      killed: false,
+      session,
+      message:
+        'detached CLI gateway handle only; underlying Relay session/process was left running',
+    }),
+    0
+  );
 }
 
 async function runGatewaySessionInterventions(sessionArgs: string[]): Promise<never> {
@@ -491,6 +690,8 @@ async function runGatewaySessions(gatewayArgs: string[]): Promise<never> {
   if (sessionSubcommand === 'list') return runGatewaySessionList();
   if (sessionSubcommand === 'get') return runGatewaySessionGet(sessionArgs);
   if (sessionSubcommand === 'create') return runGatewaySessionCreate(sessionArgs);
+  if (sessionSubcommand === 'attach') return runGatewaySessionAttach(sessionArgs);
+  if (sessionSubcommand === 'detach') return runGatewaySessionDetach(sessionArgs);
   if (sessionSubcommand === 'interventions') {
     return runGatewaySessionInterventions(sessionArgs);
   }
@@ -498,6 +699,50 @@ async function runGatewaySessions(gatewayArgs: string[]): Promise<never> {
     return runGatewaySessionHandBack(sessionArgs);
   }
   gatewayInvalid('sessions.list', 'unknown sessions command', { args: gatewayArgs });
+}
+
+
+async function runGatewayFiles(gatewayArgs: string[]): Promise<never> {
+  const operation = gatewayArgs[1];
+  if (!isFileRpcOperation(operation)) {
+    gatewayInvalid('files.list', 'unknown files command', { args: gatewayArgs });
+  }
+  const commandName = `files.${operation}` as RelayCliGatewayCommand;
+  const input = parseGatewayFileInput(operation, gatewayArgs.slice(2));
+  const requestedSessionId = input['sessionId'] as string;
+  let nodeId = typeof input['nodeId'] === 'string' ? input['nodeId'] : undefined;
+  let sessionId = requestedSessionId;
+  if (!nodeId) {
+    const session = await gatewaySessionDescriptor(requestedSessionId);
+    nodeId = session.nodeId;
+    sessionId = session.id ?? requestedSessionId;
+  }
+  if (!nodeId) {
+    printGatewayEnvelope(
+      gatewayError(commandName, {
+        code: 'UNSUPPORTED',
+        message:
+          'files commands require a routed session with nodeId; pass --node-id or use a session descriptor that includes nodeId',
+        retryable: false,
+        details: { field: 'nodeId', sessionId: requestedSessionId },
+      }),
+      1
+    );
+  }
+  const body: Record<string, unknown> = {};
+  for (const field of ['path', 'cwd', 'maxEntries', 'maxBytes', 'maxLines', 'confirmationToken']) {
+    if (input[field] !== undefined) body[field] = input[field];
+  }
+  const result = await gatewayHttpJson({
+    commandName,
+    pathName: `/hub/nodes/${encodeURIComponent(nodeId)}/sessions/${encodeURIComponent(
+      sessionId
+    )}/files/${operation}`,
+    method: 'POST',
+    body,
+    capabilities: ['session:read', operation === 'list' ? 'rpc:fs:list' : 'rpc:fs:read'],
+  });
+  printGatewayEnvelope(gatewayOk(commandName, result), 0);
 }
 
 async function runGatewayV1(): Promise<never> {
@@ -520,6 +765,7 @@ async function runGatewayV1(): Promise<never> {
   if (!json) gatewayUsage();
   if (top === 'nodes') return runGatewayNodes(gatewayArgs);
   if (top === 'sessions') return runGatewaySessions(gatewayArgs);
+  if (top === 'files') return runGatewayFiles(gatewayArgs);
   gatewayInvalid('contract.list', 'unknown v1 gateway command', { args: gatewayArgs });
 }
 

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -433,9 +433,12 @@ interface GatewaySessionDescriptor {
   globalSessionId?: string;
 }
 
-async function gatewaySessionDescriptor(id: string): Promise<GatewaySessionDescriptor> {
+async function gatewaySessionDescriptor(
+  id: string,
+  errorCommandName: RelayCliGatewayCommand = 'sessions.get'
+): Promise<GatewaySessionDescriptor> {
   const session = await gatewayHttpJson({
-    commandName: 'sessions.get',
+    commandName: errorCommandName,
     pathName: `/sessions/${encodeURIComponent(id)}`,
     capabilities: ['session:read'],
   });
@@ -713,7 +716,7 @@ async function runGatewayFiles(gatewayArgs: string[]): Promise<never> {
   let nodeId = typeof input['nodeId'] === 'string' ? input['nodeId'] : undefined;
   let sessionId = requestedSessionId;
   if (!nodeId) {
-    const session = await gatewaySessionDescriptor(requestedSessionId);
+    const session = await gatewaySessionDescriptor(requestedSessionId, commandName);
     nodeId = session.nodeId;
     sessionId = session.id ?? requestedSessionId;
   }

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -10,6 +10,11 @@ relay-ide v1 nodes list --json
 relay-ide v1 sessions list --json
 relay-ide v1 sessions get --id <session-id-or-global-id> --json
 relay-ide v1 sessions create --input-json '{...}' --json
+relay-ide v1 sessions attach --id <session-id-or-global-id> --json
+relay-ide v1 sessions detach --id <session-id-or-global-id> --json
+relay-ide v1 files list --session-id <session-id> --path <path> --json
+relay-ide v1 files stat --session-id <session-id> --path <path> --json
+relay-ide v1 files read --session-id <session-id> --path <path> --max-bytes 32768 --max-lines 2000 --json
 ```
 
 This contract is for external brain-as-peer adapters (#430). It is intentionally separate from the internal `/hub/node-link` WebSocket protocol. Adapter packages must generate native tool/function definitions from `relay-ide v1 schema --json` or the committed source manifest in `shared/cli-gateway-contract.ts`; do not hand-code Hermes/Claude/Codex-specific schemas.
@@ -37,17 +42,17 @@ Error:
   "ok": false,
   "contract": "v1",
   "contractVersion": "1.0",
-  "command": "sessions.create",
+  "command": "files.read",
   "error": {
-    "code": "UNSUPPORTED",
-    "message": "local /sessions creation derives cwd from repoPath/worktreePath; explicit cwd requires routed node creation",
+    "code": "NOT_FOUND",
+    "message": "file was not found",
     "retryable": false,
-    "details": { "field": "cwd" }
+    "details": { "upstreamCode": "NOT_FOUND", "reasonCode": "FILE_RPC_NOT_FOUND" }
   }
 }
 ```
 
-The current error taxonomy is declared in `RELAY_CLI_GATEWAY_CONTRACT.errorEnvelopeSchema`. It includes auth/connectivity errors, typed create/validation errors, and control hand-back state errors (`CONTROL_STATE_STALE`, `INTERVENTION_ACK_REQUIRED`, `INTERVENTION_ACK_STALE`, `CONTROL_STATE_UNKNOWN`).
+The current error taxonomy is declared in `RELAY_CLI_GATEWAY_CONTRACT.errorEnvelopeSchema`. It includes auth/connectivity errors, typed create/validation errors, file RPC errors (`NOT_FOUND`, `FORBIDDEN`, `NODE_OFFLINE`, `CONFIRMATION_REQUIRED`), and control hand-back state errors (`CONTROL_STATE_STALE`, `INTERVENTION_ACK_REQUIRED`, `INTERVENTION_ACK_STALE`, `CONTROL_STATE_UNKNOWN`).
 
 ## Discovery and schemas
 
@@ -68,17 +73,18 @@ The schema is the source of truth for adapter generation. A command missing from
 
 Local discovery commands (`contract.*`, `nodes.manifest`) do not require a hub token.
 
-Hub-backed commands (`nodes.list`, `sessions.*`) use the same local server token path as existing CLI session commands:
+Hub-backed commands (`nodes.list`, `sessions.*`, `files.*`) use the same local server token path as existing CLI session commands:
 
 - `RELAY_IDE_BROWSER_TOKEN` supplies the bearer token.
 - `--port` or `RELAY_IDE_PORT` selects the local hub port; otherwise Relay uses the default port.
 - Gateway requests send capability hints via `x-relay-capabilities` so hub policy can fail closed.
+- Gateway requests send `x-relay-cli-gateway: v1` so the hub can apply the adapter contract boundary.
 
 Missing tokens and rejected hub responses are converted to the gateway error envelope. The CLI still exits nonzero for error envelopes.
 
 ## Session descriptors
 
-`nodes list`, `sessions list`, `sessions get`, and `sessions create` return the existing backend descriptors, wrapped in gateway envelopes. Session descriptors are expected to include the already-available identity and control fields where present:
+`nodes list`, `sessions list`, `sessions get`, `sessions create`, `sessions attach`, and `sessions detach` return existing backend descriptors, wrapped in gateway envelopes. Session descriptors are expected to include the already-available identity and control fields where present:
 
 - `id`, `globalSessionId`, `nodeId`
 - `type`, `agent`, `mode`, `cwd`
@@ -88,7 +94,7 @@ Missing tokens and rejected hub responses are converted to the gateway error env
 
 External brain/agent peer identity is reserved for hub-owned credential/session registry work. v1 currently documents the envelope field but only round-trips `local-user`, `relay-node`, and `unknown` peer identities; routed creates are represented as `relay-node` peers. Adapters must not add impersonation flags such as `--act-as-node` or `--brain`.
 
-## Session create support and fail-closed behavior
+## Session create, attach, and detach
 
 `sessions create` accepts either `--input-json`, `--input-file`, or typed flags. `nodeId` selects routed node creation through `/hub/nodes/:nodeId/sessions`; omitting it uses the current local `/sessions` path.
 
@@ -97,6 +103,12 @@ Supported now:
 - local repo/worktree-backed session creation using `repoPath` and optional `worktreePath`
 - routed node creation with `nodeId`, `cwd`, `type` (defaulting to `agent` when omitted), `mode`, `agent`, lifecycle fields, and optional non-agent `sessionEnvelope` where the existing backend supports them
 - `controlMode=agent-driven` only for routed node creation, where hub/node policy and hand-back state can be checked
+- descriptor-only attach with `sessions attach --id ... --json`
+- safe detach with `sessions detach --id ... --json`; this resolves the session and releases only the CLI gateway handle, leaving the underlying Relay session/process running
+
+`sessions attach` is intentionally descriptor-only in v1. It does not start a Claude/Codex/Hermes adapter runtime and it does not stream PTY data.
+
+`sessions detach` intentionally does not call the session kill route. If the session is already gone, the command returns the normal typed `NOT_FOUND` envelope from `sessions.get`.
 
 Fail-closed examples:
 
@@ -111,6 +123,89 @@ Fail-closed examples:
 
 The gateway must never silently downgrade unsupported scoped, privileged, or control-mode requests.
 
+## Read-only file RPC commands
+
+The `files.*` commands route through the existing scoped #505 File RPC surface:
+
+```bash
+relay-ide v1 files list --session-id remote-session-1 --path . --max-entries 100 --json
+relay-ide v1 files stat --session-id remote-session-1 --path package.json --json
+relay-ide v1 files read --session-id remote-session-1 --path package.json --max-bytes 32768 --max-lines 200 --json
+```
+
+The CLI first resolves the session through `sessions get` unless `--node-id` is supplied. It then calls:
+
+```text
+POST /hub/nodes/:nodeId/sessions/:sessionId/files/:operation
+```
+
+Only these operations are stable in v1:
+
+- `files.list` maps to `fs.list` and requires `session:read` + `rpc:fs:list`.
+- `files.stat` maps to `fs.stat` and requires `session:read` + `rpc:fs:read`.
+- `files.read` maps to `fs.read` and requires `session:read` + `rpc:fs:read`.
+
+Caps are enforced by the existing File RPC layer and reflected in the contract:
+
+- list: default 100 entries, max 500 entries
+- read: default 32 KiB, max 64 KiB
+- read line cap: optional, max 2000 lines
+
+List example:
+
+```json
+{
+  "ok": true,
+  "contract": "v1",
+  "contractVersion": "1.0",
+  "command": "files.list",
+  "data": {
+    "operation": "list",
+    "root": "/repo",
+    "cwd": "/repo",
+    "path": "/repo",
+    "entries": [
+      {
+        "path": "/repo/package.json",
+        "name": "package.json",
+        "type": "file",
+        "size": 4133,
+        "mtimeMs": 1760000000000,
+        "mode": 33188
+      }
+    ],
+    "truncated": false,
+    "maxEntries": 100
+  }
+}
+```
+
+Read example:
+
+```json
+{
+  "ok": true,
+  "contract": "v1",
+  "contractVersion": "1.0",
+  "command": "files.read",
+  "data": {
+    "operation": "read",
+    "root": "/repo",
+    "cwd": "/repo",
+    "path": "/repo/package.json",
+    "encoding": "utf8",
+    "content": "{\n  \"name\": \"relay-ide\"\n}\n",
+    "bytesRead": 28,
+    "truncatedBytes": false,
+    "truncatedLines": false,
+    "maxBytes": 32768,
+    "maxLines": 200
+  }
+}
+```
+
+File commands remain read-only. They must surface unavailable node, missing path, denied capability, stale/expired session envelope, and confirmation-required states as typed error envelopes. They must not fall back to local filesystem reads when the scoped file RPC route rejects a request.
+
 ## Intervention and hand-back boundaries
 
 `sessions interventions` is a bounded metadata read. The v1 contract explicitly marks raw payload and transcript export unavailable. Do not expose human intervention keylogs or full terminal transcripts through this gateway.
@@ -119,4 +214,4 @@ The gateway must never silently downgrade unsupported scoped, privileged, or con
 
 ## Deferred work
 
-Event subscription, attach/input/detach streaming, File RPC expansion, destructive operations, and adapter packages are follow-up work. If a future adapter needs a missing primitive, extend this CLI contract first; do not bypass it with `/hub/node-link` or browser WebSocket protocol clients.
+Event subscription, input streaming, attach streaming, File RPC write/delete/tail, destructive operations, and adapter packages are follow-up work. If a future adapter needs a missing primitive, extend this CLI contract first; do not bypass it with `/hub/node-link` or browser WebSocket protocol clients.

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -12,8 +12,13 @@ export type RelayCliGatewayCommand =
   | 'sessions.list'
   | 'sessions.get'
   | 'sessions.create'
+  | 'sessions.attach'
+  | 'sessions.detach'
   | 'sessions.interventions'
-  | 'sessions.handBack';
+  | 'sessions.handBack'
+  | 'files.list'
+  | 'files.stat'
+  | 'files.read';
 
 export type RelayCliGatewayErrorCode =
   | 'UNAUTHORIZED'
@@ -242,6 +247,150 @@ const sessionDescriptorSchema: RelayJsonSchema = {
   required: ['id', 'type', 'agent', 'mode', 'cwd', 'displayName', 'status'],
 };
 
+
+const fileRpcStatSchema: RelayJsonSchema = {
+  title: 'FileRpcStat',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    path: stringSchema,
+    name: stringSchema,
+    type: { type: 'string', enum: ['file', 'directory', 'symlink', 'other'] },
+    size: { type: 'number', minimum: 0 },
+    mtimeMs: { type: 'number' },
+    mode: { type: 'number' },
+  },
+  required: ['path', 'name', 'type', 'size', 'mtimeMs', 'mode'],
+};
+
+const fileRpcBaseInputSchema: RelayJsonSchema = {
+  title: 'FileRpcGatewayInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    nodeId: stringSchema,
+    sessionId: stringSchema,
+    id: stringSchema,
+    path: stringSchema,
+    cwd: stringSchema,
+    confirmationToken: stringSchema,
+  },
+  required: ['sessionId'],
+};
+
+const fileRpcListInputSchema: RelayJsonSchema = {
+  ...fileRpcBaseInputSchema,
+  title: 'FileRpcListGatewayInput',
+  properties: {
+    ...(fileRpcBaseInputSchema.properties ?? {}),
+    maxEntries: { type: 'number', minimum: 1, maximum: 500 },
+  },
+};
+
+const fileRpcStatInputSchema: RelayJsonSchema = {
+  ...fileRpcBaseInputSchema,
+  title: 'FileRpcStatGatewayInput',
+};
+
+const fileRpcReadInputSchema: RelayJsonSchema = {
+  ...fileRpcBaseInputSchema,
+  title: 'FileRpcReadGatewayInput',
+  properties: {
+    ...(fileRpcBaseInputSchema.properties ?? {}),
+    maxBytes: { type: 'number', minimum: 1, maximum: 65536 },
+    maxLines: { type: 'number', minimum: 1, maximum: 2000 },
+  },
+};
+
+const fileRpcListOutputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    operation: { const: 'list' },
+    root: stringSchema,
+    cwd: stringSchema,
+    path: stringSchema,
+    entries: { type: 'array', items: fileRpcStatSchema },
+    truncated: booleanSchema,
+    maxEntries: { type: 'number' },
+  },
+  required: ['operation', 'root', 'cwd', 'path', 'entries', 'truncated', 'maxEntries'],
+};
+
+const fileRpcStatOutputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    operation: { const: 'stat' },
+    root: stringSchema,
+    cwd: stringSchema,
+    path: stringSchema,
+    stat: fileRpcStatSchema,
+  },
+  required: ['operation', 'root', 'cwd', 'path', 'stat'],
+};
+
+const fileRpcReadOutputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    operation: { const: 'read' },
+    root: stringSchema,
+    cwd: stringSchema,
+    path: stringSchema,
+    encoding: { const: 'utf8' },
+    content: stringSchema,
+    bytesRead: { type: 'number' },
+    truncatedBytes: booleanSchema,
+    truncatedLines: booleanSchema,
+    maxBytes: { type: 'number' },
+    maxLines: { type: 'number' },
+  },
+  required: [
+    'operation',
+    'root',
+    'cwd',
+    'path',
+    'encoding',
+    'content',
+    'bytesRead',
+    'truncatedBytes',
+    'truncatedLines',
+    'maxBytes',
+  ],
+};
+
+const attachOutputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    session: sessionDescriptorSchema,
+    attach: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        streaming: booleanSchema,
+        mode: { const: 'descriptor' },
+        message: stringSchema,
+      },
+      required: ['streaming', 'mode', 'message'],
+    },
+  },
+  required: ['session', 'attach'],
+};
+
+const detachOutputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    detached: booleanSchema,
+    killed: booleanSchema,
+    session: sessionDescriptorSchema,
+    message: stringSchema,
+  },
+  required: ['detached', 'killed', 'session', 'message'],
+};
+
 const createSessionInputSchema: RelayJsonSchema = {
   title: 'CreateSessionInput',
   type: 'object',
@@ -452,6 +601,56 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     ],
   },
   {
+    name: 'sessions.attach',
+    cli: ['relay-ide', 'v1', 'sessions', 'attach', '--id', '<session-id>', '--json'],
+    summary:
+      'Resolve a local or routed session descriptor for adapter attach without starting a streaming adapter runtime.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read', 'session:attach'],
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { id: stringSchema },
+      required: ['id'],
+    },
+    outputSchema: okOutput('SessionsAttachOutput', attachOutputSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'sessions.detach',
+    cli: ['relay-ide', 'v1', 'sessions', 'detach', '--id', '<session-id>', '--json'],
+    summary:
+      'Detach adapter control from a session without killing the underlying remote process.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read', 'session:attach'],
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { id: stringSchema },
+      required: ['id'],
+    },
+    outputSchema: okOutput('SessionsDetachOutput', detachOutputSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
     name: 'sessions.interventions',
     cli: ['relay-ide', 'v1', 'sessions', 'interventions', '--id', '<session-id>', '--json'],
     summary: 'Read bounded, redacted intervention metadata for a local session.',
@@ -518,6 +717,99 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       'INTERVENTION_ACK_STALE',
       'CONTROL_STATE_UNKNOWN',
       'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'files.list',
+    cli: [
+      'relay-ide',
+      'v1',
+      'files',
+      'list',
+      '--session-id',
+      '<session-id>',
+      '--path',
+      '<path>',
+      '--json',
+    ],
+    summary: 'List a directory through scoped read-only File RPC.',
+    stable: true,
+    transport: 'hub-http-or-node-rpc',
+    requiresAuth: true,
+    capabilityHints: ['session:read', 'rpc:fs:list'],
+    inputSchema: fileRpcListInputSchema,
+    outputSchema: okOutput('FilesListOutput', fileRpcListOutputSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'NODE_OFFLINE',
+      'SERVER_UNAVAILABLE',
+      'CONFIRMATION_REQUIRED',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'files.stat',
+    cli: [
+      'relay-ide',
+      'v1',
+      'files',
+      'stat',
+      '--session-id',
+      '<session-id>',
+      '--path',
+      '<path>',
+      '--json',
+    ],
+    summary: 'Stat a path through scoped read-only File RPC.',
+    stable: true,
+    transport: 'hub-http-or-node-rpc',
+    requiresAuth: true,
+    capabilityHints: ['session:read', 'rpc:fs:read'],
+    inputSchema: fileRpcStatInputSchema,
+    outputSchema: okOutput('FilesStatOutput', fileRpcStatOutputSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'NODE_OFFLINE',
+      'SERVER_UNAVAILABLE',
+      'CONFIRMATION_REQUIRED',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'files.read',
+    cli: [
+      'relay-ide',
+      'v1',
+      'files',
+      'read',
+      '--session-id',
+      '<session-id>',
+      '--path',
+      '<path>',
+      '--json',
+    ],
+    summary: 'Read UTF-8 file content through scoped read-only File RPC with byte/line caps.',
+    stable: true,
+    transport: 'hub-http-or-node-rpc',
+    requiresAuth: true,
+    capabilityHints: ['session:read', 'rpc:fs:read'],
+    inputSchema: fileRpcReadInputSchema,
+    outputSchema: okOutput('FilesReadOutput', fileRpcReadOutputSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'NODE_OFFLINE',
+      'SERVER_UNAVAILABLE',
+      'CONFIRMATION_REQUIRED',
       'UPSTREAM_ERROR',
     ],
   },

--- a/test/browser-cli.test.ts
+++ b/test/browser-cli.test.ts
@@ -43,6 +43,27 @@ async function execNode(args: string[], env: NodeJS.ProcessEnv): Promise<string>
   });
 }
 
+async function execNodeFailure(
+  args: string[],
+  env: NodeJS.ProcessEnv
+): Promise<{ status: number | string | undefined; stdout: string; stderr: string }> {
+  return await new Promise((resolve, reject) => {
+    execFile(
+      'node',
+      args,
+      { encoding: 'utf-8', env, timeout: 10_000 },
+      (error, stdout, stderr) => {
+        if (!error) {
+          reject(new Error(`expected command to fail: node ${args.join(' ')}`));
+          return;
+        }
+        const execError = error as { code?: number | string };
+        resolve({ status: execError.code, stdout, stderr });
+      }
+    );
+  });
+}
+
 function parseEnvelope<T = unknown>(stdout: string): {
   ok: boolean;
   command: string;
@@ -225,6 +246,65 @@ test('v1 gateway commands use scoped bearer auth and the v1 marker header', asyn
   );
 });
 
+test('v1 files.read preserves its command envelope when session lookup fails', async () => {
+  const captured: CapturedGatewayRequest[] = [];
+  const server = http.createServer((req, res) => {
+    captured.push({
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.authorization,
+      marker: req.headers['x-relay-cli-gateway'],
+    });
+    res.setHeader('content-type', 'application/json');
+    if (req.method === 'GET' && req.url === '/sessions/missing') {
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: { code: 'NOT_FOUND', message: 'session not found' } }));
+      return;
+    }
+    res.statusCode = 500;
+    res.end(JSON.stringify({ error: { code: 'INTERNAL', message: 'unexpected route' } }));
+  });
+  const port = await listen(server);
+  try {
+    const env = {
+      ...process.env,
+      RELAY_IDE_PORT: String(port),
+      RELAY_IDE_BROWSER_TOKEN: 'scoped-token',
+      PATH: process.env.PATH,
+    };
+    const failure = await execNodeFailure(
+      [
+        'dist/bin/relay-ide.js',
+        'v1',
+        'files',
+        'read',
+        '--session-id',
+        'missing',
+        '--path',
+        'hello.txt',
+        '--json',
+      ],
+      env
+    );
+    const envelope = JSON.parse(failure.stdout) as {
+      ok: boolean;
+      command: string;
+      error: { code: string; message: string; details?: Record<string, unknown> };
+    };
+    expect(failure.status).not.toBe(0);
+    expect(envelope).toMatchObject({
+      ok: false,
+      command: 'files.read',
+      error: { code: 'NOT_FOUND' },
+    });
+    expect(envelope.error.message).toContain('session not found');
+  } finally {
+    await close(server);
+  }
+
+  expect(captured.map((entry) => `${entry.method} ${entry.url}`)).toEqual(['GET /sessions/missing']);
+});
+
 
 test('v1 gateway smoke lists node, creates/attaches, reads files, and detaches without kill', async () => {
   const captured: CapturedGatewayRequest[] = [];
@@ -300,6 +380,25 @@ test('v1 gateway smoke lists node, creates/attaches, reads files, and detaches w
             ],
             truncated: false,
             maxEntries: entry.body?.['maxEntries'] ?? 100,
+          })
+        );
+        return;
+      }
+      if (
+        req.method === 'POST' &&
+        req.url === '/hub/nodes/node-a/sessions/remote-session-1/files/stat'
+      ) {
+        res.end(
+          JSON.stringify({
+            operation: 'stat',
+            root: '/fixture',
+            cwd: '/fixture',
+            path: '/fixture/hello.txt',
+            name: 'hello.txt',
+            type: 'file',
+            size: 14,
+            mtimeMs: 1,
+            mode: 0o100644,
           })
         );
         return;
@@ -388,6 +487,25 @@ test('v1 gateway smoke lists node, creates/attaches, reads files, and detaches w
     );
     expect(listed.data.entries[0]?.name).toBe('hello.txt');
 
+    const stat = parseEnvelope<{ name: string; type: string; size: number }>(
+      await execNode(
+        [
+          'dist/bin/relay-ide.js',
+          'v1',
+          'files',
+          'stat',
+          '--session-id',
+          'remote-session-1',
+          '--path',
+          'hello.txt',
+          '--json',
+        ],
+        env
+      )
+    );
+    expect(stat).toMatchObject({ ok: true, command: 'files.stat' });
+    expect(stat.data).toMatchObject({ name: 'hello.txt', type: 'file', size: 14 });
+
     const read = parseEnvelope<{ content: string; maxBytes: number; maxLines: number }>(
       await execNode(
         [
@@ -434,6 +552,7 @@ test('v1 gateway smoke lists node, creates/attaches, reads files, and detaches w
       'GET /nodes',
       'POST /hub/nodes/node-a/sessions',
       'POST /hub/nodes/node-a/sessions/remote-session-1/files/list',
+      'POST /hub/nodes/node-a/sessions/remote-session-1/files/stat',
       'POST /hub/nodes/node-a/sessions/remote-session-1/files/read',
       'GET /sessions/remote-session-1',
     ])

--- a/test/browser-cli.test.ts
+++ b/test/browser-cli.test.ts
@@ -29,13 +29,26 @@ async function close(server: http.Server): Promise<void> {
   });
 }
 
-async function execNode(args: string[], env: NodeJS.ProcessEnv): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    execFile('node', args, { encoding: 'utf-8', env, timeout: 10_000 }, (error) => {
-      if (error) reject(error);
-      else resolve();
-    });
+async function execNode(args: string[], env: NodeJS.ProcessEnv): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    execFile(
+      'node',
+      args,
+      { encoding: 'utf-8', env, timeout: 10_000 },
+      (error, stdout) => {
+        if (error) reject(error);
+        else resolve(stdout);
+      }
+    );
   });
+}
+
+function parseEnvelope<T = unknown>(stdout: string): {
+  ok: boolean;
+  command: string;
+  data: T;
+} {
+  return JSON.parse(stdout) as { ok: boolean; command: string; data: T };
 }
 
 beforeEach(() => {
@@ -210,4 +223,223 @@ test('v1 gateway commands use scoped bearer auth and the v1 marker header', asyn
       }),
     ])
   );
+});
+
+
+test('v1 gateway smoke lists node, creates/attaches, reads files, and detaches without kill', async () => {
+  const captured: CapturedGatewayRequest[] = [];
+  const session = {
+    id: 'remote-session-1',
+    globalSessionId: 'node-a:remote-session-1',
+    nodeId: 'node-a',
+    type: 'terminal',
+    agent: 'shell',
+    mode: 'pty',
+    cwd: '/fixture',
+    displayName: 'fixture terminal',
+    status: 'active',
+  };
+  const server = http.createServer((req, res) => {
+    const entry: CapturedGatewayRequest = {
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.authorization,
+      marker: req.headers['x-relay-cli-gateway'],
+    };
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const rawBody = Buffer.concat(chunks).toString('utf8');
+      if (rawBody) entry.body = JSON.parse(rawBody) as Record<string, unknown>;
+      captured.push(entry);
+      res.setHeader('content-type', 'application/json');
+
+      if (req.method === 'GET' && req.url === '/nodes') {
+        res.end(
+          JSON.stringify({
+            nodes: [
+              {
+                nodeId: 'node-a',
+                status: 'online',
+                availability: 'available',
+                cwd: '/fixture',
+              },
+            ],
+          })
+        );
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/hub/nodes/node-a/sessions') {
+        res.statusCode = 201;
+        res.end(JSON.stringify(session));
+        return;
+      }
+      if (req.method === 'GET' && req.url === '/sessions/remote-session-1') {
+        res.end(JSON.stringify(session));
+        return;
+      }
+      if (
+        req.method === 'POST' &&
+        req.url === '/hub/nodes/node-a/sessions/remote-session-1/files/list'
+      ) {
+        res.end(
+          JSON.stringify({
+            operation: 'list',
+            root: '/fixture',
+            cwd: '/fixture',
+            path: '/fixture',
+            entries: [
+              {
+                path: '/fixture/hello.txt',
+                name: 'hello.txt',
+                type: 'file',
+                size: 12,
+                mtimeMs: 1,
+                mode: 0o100644,
+              },
+            ],
+            truncated: false,
+            maxEntries: entry.body?.['maxEntries'] ?? 100,
+          })
+        );
+        return;
+      }
+      if (
+        req.method === 'POST' &&
+        req.url === '/hub/nodes/node-a/sessions/remote-session-1/files/read'
+      ) {
+        res.end(
+          JSON.stringify({
+            operation: 'read',
+            root: '/fixture',
+            cwd: '/fixture',
+            path: '/fixture/hello.txt',
+            encoding: 'utf8',
+            content: 'hello gateway\n',
+            bytesRead: 14,
+            truncatedBytes: false,
+            truncatedLines: false,
+            maxBytes: entry.body?.['maxBytes'] ?? 32768,
+            maxLines: entry.body?.['maxLines'],
+          })
+        );
+        return;
+      }
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: { code: 'NOT_FOUND', message: 'not found' } }));
+    });
+  });
+  const port = await listen(server);
+  try {
+    const env = {
+      ...process.env,
+      RELAY_IDE_PORT: String(port),
+      RELAY_IDE_BROWSER_TOKEN: 'scoped-token',
+      PATH: process.env.PATH,
+    };
+    const nodes = parseEnvelope<{ nodes: unknown[] }>(
+      await execNode(['dist/bin/relay-ide.js', 'v1', 'nodes', 'list', '--json'], env)
+    );
+    expect(nodes).toMatchObject({ ok: true, command: 'nodes.list' });
+    expect(nodes.data.nodes).toHaveLength(1);
+
+    const created = parseEnvelope<typeof session>(
+      await execNode(
+        [
+          'dist/bin/relay-ide.js',
+          'v1',
+          'sessions',
+          'create',
+          '--input-json',
+          '{"nodeId":"node-a","cwd":"/fixture","type":"terminal"}',
+          '--json',
+        ],
+        env
+      )
+    );
+    expect(created).toMatchObject({ ok: true, command: 'sessions.create' });
+    expect(created.data).toMatchObject({ id: 'remote-session-1', nodeId: 'node-a' });
+
+    const attached = parseEnvelope<{ attach: { streaming: boolean }; session: typeof session }>(
+      await execNode(
+        ['dist/bin/relay-ide.js', 'v1', 'sessions', 'attach', '--id', 'remote-session-1', '--json'],
+        env
+      )
+    );
+    expect(attached.data.attach.streaming).toBe(false);
+
+    const listed = parseEnvelope<{ entries: Array<{ name: string }> }>(
+      await execNode(
+        [
+          'dist/bin/relay-ide.js',
+          'v1',
+          'files',
+          'list',
+          '--session-id',
+          'remote-session-1',
+          '--path',
+          '.',
+          '--max-entries',
+          '5',
+          '--json',
+        ],
+        env
+      )
+    );
+    expect(listed.data.entries[0]?.name).toBe('hello.txt');
+
+    const read = parseEnvelope<{ content: string; maxBytes: number; maxLines: number }>(
+      await execNode(
+        [
+          'dist/bin/relay-ide.js',
+          'v1',
+          'files',
+          'read',
+          '--session-id',
+          'remote-session-1',
+          '--path',
+          'hello.txt',
+          '--max-bytes',
+          '64',
+          '--max-lines',
+          '2',
+          '--json',
+        ],
+        env
+      )
+    );
+    expect(read.data).toMatchObject({ content: 'hello gateway\n', maxBytes: 64, maxLines: 2 });
+
+    const detached = parseEnvelope<{ detached: boolean; killed: boolean; session: typeof session }>(
+      await execNode(
+        ['dist/bin/relay-ide.js', 'v1', 'sessions', 'detach', '--id', 'remote-session-1', '--json'],
+        env
+      )
+    );
+    expect(detached.data).toMatchObject({ detached: true, killed: false });
+
+    const stillThere = parseEnvelope<typeof session>(
+      await execNode(
+        ['dist/bin/relay-ide.js', 'v1', 'sessions', 'get', '--id', 'remote-session-1', '--json'],
+        env
+      )
+    );
+    expect(stillThere.data).toMatchObject({ id: 'remote-session-1', status: 'active' });
+  } finally {
+    await close(server);
+  }
+
+  expect(captured.map((entry) => `${entry.method} ${entry.url}`)).toEqual(
+    expect.arrayContaining([
+      'GET /nodes',
+      'POST /hub/nodes/node-a/sessions',
+      'POST /hub/nodes/node-a/sessions/remote-session-1/files/list',
+      'POST /hub/nodes/node-a/sessions/remote-session-1/files/read',
+      'GET /sessions/remote-session-1',
+    ])
+  );
+  expect(captured.some((entry) => entry.method === 'DELETE')).toBe(false);
+  expect(
+    captured.find((entry) => entry.url?.endsWith('/files/read'))?.body
+  ).toMatchObject({ path: 'hello.txt', maxBytes: 64, maxLines: 2 });
 });

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -35,8 +35,13 @@ describe('CLI gateway contract', () => {
       'sessions.list',
       'sessions.get',
       'sessions.create',
+      'sessions.attach',
+      'sessions.detach',
       'sessions.interventions',
       'sessions.handBack',
+      'files.list',
+      'files.stat',
+      'files.read',
     ]);
 
     for (const spec of RELAY_CLI_GATEWAY_CONTRACT.commandSchemas) {
@@ -196,8 +201,13 @@ describe('CLI gateway contract', () => {
       'sessions.list',
       'sessions.get',
       'sessions.create',
+      'sessions.attach',
+      'sessions.detach',
       'sessions.interventions',
       'sessions.handBack',
+      'files.list',
+      'files.stat',
+      'files.read',
     ] as const;
 
     for (const command of invalidArgumentCommands) {
@@ -241,6 +251,47 @@ describe('CLI gateway contract', () => {
         },
       })
     ).toEqual({ status: 500, upstreamCode: 'INTERNAL', field: 'repoPath' });
+  });
+
+
+  it('advertises descriptor-only attach/detach and read-only file RPC commands', () => {
+    expect(commandSpec('sessions.attach')).toMatchObject({
+      capabilityHints: ['session:read', 'session:attach'],
+      transport: 'hub-http',
+    });
+    expect(commandSpec('sessions.detach')).toMatchObject({
+      capabilityHints: ['session:read', 'session:attach'],
+      transport: 'hub-http',
+    });
+
+    const list = commandSpec('files.list');
+    expect(list.capabilityHints).toEqual(['session:read', 'rpc:fs:list']);
+    expect(list.inputSchema).toMatchObject({
+      additionalProperties: false,
+      required: ['sessionId'],
+      properties: { maxEntries: { maximum: 500 } },
+    });
+    expect(list.outputSchema).toMatchObject({
+      properties: {
+        data: {
+          properties: {
+            operation: { const: 'list' },
+            entries: { type: 'array' },
+          },
+        },
+      },
+    });
+
+    const read = commandSpec('files.read');
+    expect(read.capabilityHints).toEqual(['session:read', 'rpc:fs:read']);
+    expect(read.inputSchema).toMatchObject({
+      properties: {
+        maxBytes: { maximum: 65536 },
+        maxLines: { maximum: 2000 },
+      },
+    });
+    expect(read.errorCodes).toEqual(expect.arrayContaining(['NODE_OFFLINE', 'NOT_FOUND']));
+    expect(commandSpec('files.stat').capabilityHints).toEqual(['session:read', 'rpc:fs:read']);
   });
 
   it('does not expose raw intervention payloads as a gateway contract', () => {


### PR DESCRIPTION
## Summary
- Adds v1 CLI gateway `sessions attach` / `sessions detach` descriptor-only commands.
- Adds read-only `files list`, `files stat`, and `files read` commands routed through the existing scoped File RPC endpoint with byte/line/list caps.
- Updates the gateway contract/docs and adds a CLI smoke covering node list → routed session create/attach → fixture file list/read → detach → session still active.

## Motivation
Issue #530 needs a narrow backend slice for adapter-safe discovery, read-only file access, and detach behavior before broader adapter runtime work (#430). This keeps the CLI gateway as the stable boundary instead of letting adapters bypass into browser/node-link internals.

## The Case Against
This change might be wrong because:
- `sessions attach` is descriptor-only, not a real PTY stream attach. That is intentional for this slice, but adapter authors may expect streaming semantics from the word attach.
- `sessions detach` currently releases only the CLI gateway handle by resolving the session and returning `killed: false`; it does not call a backend detach endpoint because the existing delete/kill surfaces are destructive.
- `files.*` requires a routed session `nodeId` from `sessions get` (or explicit `--node-id`). Local-session file reads are fail-closed instead of falling back to host filesystem reads, which is safer but less convenient.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Accidental destructive detach | The implementation only performs `GET /sessions/:id`; tests assert no DELETE request is sent. |
| File reads bypass scoped RPC | `files.*` calls `/hub/nodes/:nodeId/sessions/:sessionId/files/:operation`; no direct filesystem read fallback exists. |
| Contract drift | `shared/cli-gateway-contract.ts`, docs, and contract tests all enumerate the new commands and caps. |
| Over-broad scope | Docs explicitly defer write/delete/tail, event/input/attach streaming, destructive operations, and adapter packages. |

## Verification
- `npm run build:server`
- `npm test -- test/cli-gateway-contract.test.ts test/browser-cli.test.ts` (15/15 passed)
- `npm run check` (passed; existing warnings only)
- `npm run build` (passed; existing Vite chunk-size warning)
- `npm test` (214 files / 2273 tests passed)

Closes #530
Refs #429, #428
