### PR TITLE
feat: add generated CLI gateway adapter smoke

### DIFF
--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -212,6 +212,12 @@ File commands remain read-only. They must surface unavailable node, missing path
 
 `sessions hand-back` requires the latest intervention event id observed by the caller before restoring agent-driven control. Stale, unknown, disconnected, or unacknowledged intervention state returns typed errors instead of resuming blindly.
 
+## First generated adapter smoke
+
+The first #430 proof intentionally stops at one generated Claude-style tool/function bundle in `shared/cli-gateway-claude-tools.ts`. It reads `shared/cli-gateway-contract.ts` / `relay-ide v1 schema --json` shape and emits Anthropic-compatible tool definitions (`name`, `description`, `input_schema`) for only the hello-world path: `nodes.list`, `sessions.create`, `files.read`, and `sessions.detach`.
+
+The smoke runner is deliberately thin: generated definitions select the stable v1 CLI command, Relay's existing CLI gateway does the hub/node/File RPC work, and `sessions.detach` remains descriptor-only so it does not kill the underlying session. Production Claude/Codex/Hermes packages, streaming attach, subscriptions, write/delete/tail File RPC, arbitrary exec, and private node-link shortcuts remain deferred.
+
 ## Deferred work
 
 Event subscription, input streaming, attach streaming, File RPC write/delete/tail, destructive operations, and adapter packages are follow-up work. If a future adapter needs a missing primitive, extend this CLI contract first; do not bypass it with `/hub/node-link` or browser WebSocket protocol clients.

--- a/shared/cli-gateway-claude-tools.ts
+++ b/shared/cli-gateway-claude-tools.ts
@@ -1,0 +1,197 @@
+import { execFile } from 'node:child_process';
+import type {
+  RelayCliGatewayCommand,
+  RelayCliGatewayContractManifest,
+  RelayCliGatewayEnvelope,
+  RelayJsonSchema,
+} from './cli-gateway-contract.js';
+import { RELAY_CLI_GATEWAY_CONTRACT } from './cli-gateway-contract.js';
+
+export const CLI_GATEWAY_CLAUDE_SMOKE_COMMANDS = [
+  'nodes.list',
+  'sessions.create',
+  'files.read',
+  'sessions.detach',
+] as const satisfies readonly RelayCliGatewayCommand[];
+
+export type RelayClaudeGatewaySmokeCommand = (typeof CLI_GATEWAY_CLAUDE_SMOKE_COMMANDS)[number];
+
+export interface RelayClaudeGatewayToolDefinition {
+  name: string;
+  description: string;
+  input_schema: RelayJsonSchema;
+  relay: {
+    contract: RelayCliGatewayContractManifest['contract'];
+    contractVersion: RelayCliGatewayContractManifest['contractVersion'];
+    command: RelayCliGatewayCommand;
+    cli: readonly string[];
+    transport: string;
+    requiresAuth: boolean;
+    capabilityHints: readonly string[];
+  };
+}
+
+export interface RelayClaudeGatewayRunnerOptions {
+  command?: string;
+  commandArgsPrefix?: readonly string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}
+
+type ResolvedRelayClaudeGatewayRunnerOptions = Required<
+  Pick<RelayClaudeGatewayRunnerOptions, 'command' | 'timeoutMs'>
+> &
+  Omit<RelayClaudeGatewayRunnerOptions, 'command' | 'timeoutMs'>;
+
+export function relayClaudeGatewayToolName(command: RelayCliGatewayCommand): string {
+  return `relay_${command.split('.').join('_')}`;
+}
+
+export function generateRelayClaudeGatewayTools(
+  manifest: RelayCliGatewayContractManifest = RELAY_CLI_GATEWAY_CONTRACT,
+  commands: readonly RelayCliGatewayCommand[] = CLI_GATEWAY_CLAUDE_SMOKE_COMMANDS
+): RelayClaudeGatewayToolDefinition[] {
+  return commands.map((command) => {
+    const spec = manifest.commandSchemas.find((entry) => entry.name === command);
+    if (!spec) throw new Error(`CLI gateway manifest is missing ${command}`);
+    return {
+      name: relayClaudeGatewayToolName(spec.name),
+      description: spec.summary,
+      input_schema: spec.inputSchema,
+      relay: {
+        contract: manifest.contract,
+        contractVersion: manifest.contractVersion,
+        command: spec.name,
+        cli: spec.cli,
+        transport: spec.transport,
+        requiresAuth: spec.requiresAuth,
+        capabilityHints: spec.capabilityHints,
+      },
+    };
+  });
+}
+
+export class RelayClaudeGatewayToolRunner {
+  private readonly toolsByName: Map<string, RelayClaudeGatewayToolDefinition>;
+  private readonly options: ResolvedRelayClaudeGatewayRunnerOptions;
+
+  constructor(
+    tools: readonly RelayClaudeGatewayToolDefinition[],
+    options: RelayClaudeGatewayRunnerOptions = {}
+  ) {
+    this.toolsByName = new Map(tools.map((tool) => [tool.name, tool]));
+    const resolved: ResolvedRelayClaudeGatewayRunnerOptions = {
+      command: options.command ?? 'relay-ide',
+      commandArgsPrefix: options.commandArgsPrefix ?? [],
+      timeoutMs: options.timeoutMs ?? 10_000,
+    };
+    if (options.cwd !== undefined) resolved.cwd = options.cwd;
+    if (options.env !== undefined) resolved.env = options.env;
+    this.options = resolved;
+  }
+
+  async callTool(
+    name: string,
+    input: Record<string, unknown> = {}
+  ): Promise<RelayCliGatewayEnvelope> {
+    const tool = this.toolsByName.get(name);
+    if (!tool) throw new Error(`unknown generated Relay Claude gateway tool: ${name}`);
+    const gatewayArgs = gatewayArgsForGeneratedTool(tool, input);
+    return await execRelayGatewayTool(this.options, gatewayArgs);
+  }
+}
+
+function gatewayArgsForGeneratedTool(
+  tool: RelayClaudeGatewayToolDefinition,
+  input: Record<string, unknown>
+): string[] {
+  const cliArgs = tool.relay.cli.slice(1);
+  if (tool.relay.command === 'sessions.create') {
+    return replaceCliPlaceholder(cliArgs, '<json>', JSON.stringify(input));
+  }
+  if (tool.relay.command === 'files.read') {
+    return appendOptionalFlags(replaceGatewayInputPlaceholders(cliArgs, input), input, [
+      ['nodeId', '--node-id'],
+      ['cwd', '--cwd'],
+      ['maxBytes', '--max-bytes'],
+      ['maxLines', '--max-lines'],
+      ['confirmationToken', '--confirmation-token'],
+    ]);
+  }
+  return replaceGatewayInputPlaceholders(cliArgs, input);
+}
+
+function replaceGatewayInputPlaceholders(
+  cliArgs: readonly string[],
+  input: Record<string, unknown>
+): string[] {
+  return cliArgs.map((arg) => {
+    if (arg === '<session-id>') return requiredStringInput(input, ['id', 'sessionId'], arg);
+    if (arg === '<path>') return requiredStringInput(input, ['path'], arg);
+    return arg;
+  });
+}
+
+function replaceCliPlaceholder(
+  cliArgs: readonly string[],
+  placeholder: string,
+  value: string
+): string[] {
+  return cliArgs.map((arg) => (arg === placeholder ? value : arg));
+}
+
+function requiredStringInput(
+  input: Record<string, unknown>,
+  keys: readonly string[],
+  placeholder: string
+): string {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  throw new Error(`generated Relay CLI tool input must include ${keys.join(' or ')} for ${placeholder}`);
+}
+
+function appendOptionalFlags(
+  cliArgs: string[],
+  input: Record<string, unknown>,
+  fields: readonly (readonly [string, string])[]
+): string[] {
+  const insertion = cliArgs.lastIndexOf('--json');
+  const args = cliArgs.slice();
+  const flags: string[] = [];
+  for (const [field, flag] of fields) {
+    const value = input[field];
+    if (value === undefined) continue;
+    if (typeof value !== 'string' && typeof value !== 'number') {
+      throw new Error(`generated Relay CLI tool input ${field} must be a string or number`);
+    }
+    flags.push(flag, String(value));
+  }
+  if (insertion === -1 || flags.length === 0) return args.concat(flags);
+  args.splice(insertion, 0, ...flags);
+  return args;
+}
+
+async function execRelayGatewayTool(
+  options: ResolvedRelayClaudeGatewayRunnerOptions,
+  gatewayArgs: readonly string[]
+): Promise<RelayCliGatewayEnvelope> {
+  const args = [...(options.commandArgsPrefix ?? []), ...gatewayArgs];
+  const execOptions = {
+    encoding: 'utf8' as const,
+    env: { ...process.env, ...options.env },
+    timeout: options.timeoutMs,
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+  };
+  return await new Promise<RelayCliGatewayEnvelope>((resolve, reject) => {
+    execFile(options.command, args, execOptions, (error, stdout, stderr) => {
+      try {
+        resolve(JSON.parse(stdout) as RelayCliGatewayEnvelope);
+      } catch (parseError) {
+        reject(error ?? parseError ?? new Error(stderr || 'Relay CLI gateway tool failed'));
+      }
+    });
+  });
+}

--- a/test/cli-gateway-claude-tools.test.ts
+++ b/test/cli-gateway-claude-tools.test.ts
@@ -1,0 +1,184 @@
+import { expect, test } from 'vitest';
+import * as http from 'node:http';
+import {
+  CLI_GATEWAY_CLAUDE_SMOKE_COMMANDS,
+  RelayClaudeGatewayToolRunner,
+  generateRelayClaudeGatewayTools,
+} from '../shared/cli-gateway-claude-tools.js';
+import { RELAY_CLI_GATEWAY_CONTRACT, commandSpec } from '../shared/cli-gateway-contract.js';
+
+type CapturedGatewayRequest = {
+  method: string | undefined;
+  url: string | undefined;
+  authorization: string | undefined;
+  marker: string | string[] | undefined;
+  capabilities: string | string[] | undefined;
+  body?: Record<string, unknown>;
+};
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing server address');
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  server.closeAllConnections?.();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test('generated Claude-style CLI gateway tools run the first adapter smoke path', async () => {
+  const tools = generateRelayClaudeGatewayTools(RELAY_CLI_GATEWAY_CONTRACT);
+  expect(tools.map((tool) => tool.relay.command)).toEqual([...CLI_GATEWAY_CLAUDE_SMOKE_COMMANDS]);
+  expect(tools.map((tool) => tool.name)).toEqual([
+    'relay_nodes_list',
+    'relay_sessions_create',
+    'relay_files_read',
+    'relay_sessions_detach',
+  ]);
+  expect(tools.find((tool) => tool.relay.command === 'files.read')?.input_schema).toBe(
+    commandSpec('files.read').inputSchema
+  );
+
+  const captured: CapturedGatewayRequest[] = [];
+  let sessionAlive = false;
+  const session = {
+    id: 'remote-session-1',
+    globalSessionId: 'node-a:remote-session-1',
+    nodeId: 'node-a',
+    type: 'terminal',
+    agent: 'shell',
+    mode: 'pty',
+    cwd: '/fixture',
+    displayName: 'fixture terminal',
+    status: 'active',
+  };
+
+  const server = http.createServer((req, res) => {
+    const entry: CapturedGatewayRequest = {
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.authorization,
+      marker: req.headers['x-relay-cli-gateway'],
+      capabilities: req.headers['x-relay-capabilities'],
+    };
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const rawBody = Buffer.concat(chunks).toString('utf8');
+      if (rawBody) entry.body = JSON.parse(rawBody) as Record<string, unknown>;
+      captured.push(entry);
+      res.setHeader('content-type', 'application/json');
+
+      if (req.method === 'GET' && req.url === '/nodes') {
+        res.end(
+          JSON.stringify({
+            nodes: [{ nodeId: 'node-a', status: 'online', availability: 'available' }],
+          })
+        );
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/hub/nodes/node-a/sessions') {
+        sessionAlive = true;
+        res.statusCode = 201;
+        res.end(JSON.stringify(session));
+        return;
+      }
+      if (req.method === 'GET' && req.url === '/sessions/remote-session-1' && sessionAlive) {
+        res.end(JSON.stringify(session));
+        return;
+      }
+      if (
+        req.method === 'POST' &&
+        req.url === '/hub/nodes/node-a/sessions/remote-session-1/files/read'
+      ) {
+        res.end(
+          JSON.stringify({
+            operation: 'read',
+            root: '/fixture',
+            cwd: '/fixture',
+            path: '/fixture/hello.txt',
+            encoding: 'utf8',
+            content: 'hello gateway\n',
+            bytesRead: 14,
+            truncatedBytes: false,
+            truncatedLines: false,
+            maxBytes: entry.body?.['maxBytes'] ?? 32768,
+            maxLines: entry.body?.['maxLines'],
+          })
+        );
+        return;
+      }
+      if (req.method === 'DELETE') sessionAlive = false;
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: { code: 'NOT_FOUND', message: 'not found' } }));
+    });
+  });
+
+  const port = await listen(server);
+  try {
+    const runner = new RelayClaudeGatewayToolRunner(tools, {
+      command: process.execPath,
+      commandArgsPrefix: ['dist/bin/relay-ide.js'],
+      env: {
+        ...process.env,
+        RELAY_IDE_PORT: String(port),
+        RELAY_IDE_BROWSER_TOKEN: 'scoped-token',
+      },
+    });
+
+    const nodes = await runner.callTool('relay_nodes_list');
+    expect(nodes).toMatchObject({ ok: true, command: 'nodes.list' });
+    if (!nodes.ok) throw new Error('expected nodes.list to succeed');
+    expect((nodes.data as { nodes: unknown[] }).nodes).toHaveLength(1);
+
+    const created = await runner.callTool('relay_sessions_create', {
+      nodeId: 'node-a',
+      cwd: '/fixture',
+      type: 'terminal',
+    });
+    expect(created).toMatchObject({ ok: true, command: 'sessions.create' });
+    if (!created.ok) throw new Error('expected sessions.create to succeed');
+    expect(created.data).toMatchObject({ id: 'remote-session-1', nodeId: 'node-a' });
+
+    const read = await runner.callTool('relay_files_read', {
+      sessionId: 'remote-session-1',
+      path: 'hello.txt',
+      maxBytes: 64,
+      maxLines: 2,
+    });
+    expect(read).toMatchObject({ ok: true, command: 'files.read' });
+    if (!read.ok) throw new Error('expected files.read to succeed');
+    expect(read.data).toMatchObject({ content: 'hello gateway\n', maxBytes: 64, maxLines: 2 });
+
+    const detached = await runner.callTool('relay_sessions_detach', { id: 'remote-session-1' });
+    expect(detached).toMatchObject({ ok: true, command: 'sessions.detach' });
+    if (!detached.ok) throw new Error('expected sessions.detach to succeed');
+    expect(detached.data).toMatchObject({ detached: true, killed: false });
+  } finally {
+    await close(server);
+  }
+
+  expect(sessionAlive).toBe(true);
+  expect(captured.map((entry) => `${entry.method} ${entry.url}`)).toEqual([
+    'GET /nodes',
+    'POST /hub/nodes/node-a/sessions',
+    'GET /sessions/remote-session-1',
+    'POST /hub/nodes/node-a/sessions/remote-session-1/files/read',
+    'GET /sessions/remote-session-1',
+  ]);
+  expect(captured.some((entry) => entry.method === 'DELETE')).toBe(false);
+  expect(captured.find((entry) => entry.url === '/nodes')).toMatchObject({
+    authorization: 'Bearer scoped-token',
+    marker: 'v1',
+    capabilities: 'session:read',
+  });
+  expect(captured.find((entry) => entry.url?.endsWith('/files/read'))?.body).toMatchObject({
+    path: 'hello.txt',
+    maxBytes: 64,
+    maxLines: 2,
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a generated Claude-style tool/function artifact for the narrow v1 CLI gateway smoke path.
- Adds a test runner that executes generated tool definitions through the existing `relay-ide v1 ... --json` CLI against a fake hub/node harness.
- Documents this as the first #430 adapter smoke and keeps production adapter packages/deeper verbs deferred.

## Motivation
#430 needs proof that external agent adapters can derive their tool schema from the v1 CLI gateway contract instead of hand-coding provider-specific drift. This PR proves one target format and one hello-world path only.

## The Case Against
This is intentionally not a production Claude/Codex/Hermes adapter package. The runner still shells out to the Relay CLI and only maps the minimal hello-world commands, so a reviewer should reject this if they expected streaming attach, subscriptions, file writes, exec, or packaged provider integrations. The value here is contract-shape proof and drift prevention, not a full adapter split.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Tool schema drifts from the CLI gateway contract | Tool definitions copy `input_schema` from `RELAY_CLI_GATEWAY_CONTRACT` / the v1 manifest, and the test asserts the `files.read` schema is the contract object. |
| Detach accidentally kills sessions | Smoke asserts the generated detach returns `killed: false`, records no DELETE request, and leaves the fake session alive. |
| Scope creep into private node-link or destructive verbs | Generated bundle is limited to `nodes.list`, `sessions.create`, `files.read`, and `sessions.detach`; docs list deferred follow-ups. |

## Verification
- `npm run build:server`
- `npm test -- test/cli-gateway-claude-tools.test.ts test/cli-gateway-contract.test.ts test/browser-cli.test.ts` (17/17 passed)
- `npm run check` (passed; existing lint warnings only)
- `npm run build`

Closes #533
Refs #430, #429, #530


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating and executing Claude-style tools from the CLI Gateway, supporting core operations: nodes.list, sessions.create, files.read, and sessions.detach.

* **Documentation**
  * Added documentation for the proof-of-concept Claude adapter.

* **Tests**
  * Added integration tests for tool generation and execution functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->