### PR TITLE
feat: add CLI gateway session stream input

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -3,6 +3,7 @@
 import path from 'node:path';
 import fs from 'node:fs';
 import { execFile, execFileSync, spawn } from 'node:child_process';
+import { Buffer } from 'node:buffer';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
 import * as service from '../server/service.js';
@@ -36,6 +37,7 @@ import {
   gatewayOk,
   type RelayCliGatewayCommand,
   type RelayCliGatewayEnvelope,
+  type RelayCliGatewayErrorCode,
 } from '../shared/cli-gateway-contract.js';
 import {
   gatewayCliInvalidArgumentError,
@@ -47,6 +49,7 @@ import {
   validateAndSanitizeGatewayCreateInput,
 } from '../shared/cli-gateway-runtime.js';
 import { isFileRpcOperation, type FileRpcOperation } from '../shared/file-rpc.js';
+import { WebSocket } from 'ws';
 
 const execFileAsync = promisify(execFile);
 
@@ -374,7 +377,7 @@ function requireGatewaySessionId(
 
 function gatewayUsage(): never {
   logger.error(
-    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions attach|sessions detach|sessions interventions|sessions hand-back|files list|files stat|files read) --json'
+    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read) --json'
   );
   process.exit(1);
 }
@@ -653,6 +656,348 @@ async function runGatewaySessionDetach(sessionArgs: string[]): Promise<never> {
   );
 }
 
+interface GatewayPtyTarget {
+  requestedId: string;
+  sessionId: string;
+  nodeId?: string;
+  globalSessionId?: string;
+  wsPath: string;
+}
+
+function gatewayOptionalPositiveInt(
+  commandName: RelayCliGatewayCommand,
+  sessionArgs: string[],
+  flag: string,
+  max: number
+): number | undefined {
+  const raw = gatewayArg(sessionArgs, flag);
+  if (raw === undefined) return undefined;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > max) {
+    gatewayInvalid(commandName, `${flag} must be a positive integer <= ${max}`, {
+      flag,
+      value: raw,
+      max,
+    });
+  }
+  return parsed;
+}
+
+function gatewayRequiredToken(commandName: RelayCliGatewayCommand): string {
+  const token = process.env['RELAY_IDE_BROWSER_TOKEN'] ?? '';
+  if (!token) {
+    printGatewayEnvelope(
+      gatewayError(commandName, {
+        code: 'UNAUTHORIZED',
+        message:
+          'RELAY_IDE_BROWSER_TOKEN not set. Run from an authenticated Relay session or set a scoped API token.',
+        retryable: false,
+      }),
+      1
+    );
+  }
+  return token;
+}
+
+function gatewayWsPort(): string {
+  return getArg('--port') ?? process.env['RELAY_IDE_PORT'] ?? String(DEFAULTS.port);
+}
+
+async function resolveGatewayPtyTarget(
+  id: string,
+  commandName: RelayCliGatewayCommand
+): Promise<GatewayPtyTarget> {
+  const session = await gatewaySessionDescriptor(id, commandName);
+  const sessionId = session.id ?? id;
+  const nodeId = session.nodeId;
+  const globalSessionId = session.globalSessionId;
+  const wsPath = nodeId
+    ? `/nodes/${encodeURIComponent(nodeId)}/ws/sessions/${encodeURIComponent(sessionId)}`
+    : `/ws/${encodeURIComponent(sessionId)}`;
+  return {
+    requestedId: id,
+    sessionId,
+    ...(nodeId ? { nodeId } : {}),
+    ...(globalSessionId ? { globalSessionId } : {}),
+    wsPath,
+  };
+}
+
+function gatewayWsErrorCode(message: string): RelayCliGatewayErrorCode {
+  if (message.includes('Unexpected server response: 401')) return 'UNAUTHORIZED';
+  if (message.includes('Unexpected server response: 403')) return 'FORBIDDEN';
+  if (message.includes('Unexpected server response: 404')) return 'NODE_OFFLINE';
+  if (message.includes('ECONNREFUSED') || message.includes('connect')) return 'SERVER_UNAVAILABLE';
+  return 'UPSTREAM_ERROR';
+}
+
+function gatewayOpenPtyWebSocket(
+  commandName: RelayCliGatewayCommand,
+  target: GatewayPtyTarget
+): Promise<WebSocket> {
+  const token = gatewayRequiredToken(commandName);
+  const port = gatewayWsPort();
+  const ws = new WebSocket(`ws://127.0.0.1:${port}${target.wsPath}`, {
+    headers: {
+      Cookie: `token=${encodeURIComponent(token)}`,
+      'x-relay-cli-gateway': 'v1',
+    },
+  });
+  return new Promise((resolve) => {
+    let opened = false;
+    ws.once('open', () => {
+      opened = true;
+      resolve(ws);
+    });
+    ws.once('error', (error) => {
+      if (opened) return;
+      const message = error instanceof Error ? error.message : String(error);
+      printGatewayEnvelope(
+        gatewayError(commandName, {
+          code: gatewayWsErrorCode(message),
+          message: `could not attach PTY stream: ${message}`,
+          retryable: true,
+          details: {
+            sessionId: target.sessionId,
+            ...(target.nodeId ? { nodeId: target.nodeId } : {}),
+          },
+        }),
+        1
+      );
+    });
+  });
+}
+
+function gatewayTargetPayload(target: GatewayPtyTarget): Record<string, unknown> {
+  return {
+    sessionId: target.sessionId,
+    ...(target.nodeId ? { nodeId: target.nodeId } : {}),
+    ...(target.globalSessionId ? { globalSessionId: target.globalSessionId } : {}),
+  };
+}
+
+function writeGatewayNdjson(envelope: RelayCliGatewayEnvelope): boolean {
+  return process.stdout.write(`${JSON.stringify(envelope)}
+`);
+}
+
+async function runGatewaySessionStream(sessionArgs: string[]): Promise<never> {
+  const id = requireGatewaySessionId('sessions.stream', sessionArgs);
+  const mode = gatewayArg(sessionArgs, '--mode') ?? 'ndjson';
+  if (mode !== 'ndjson') {
+    gatewayInvalid('sessions.stream', '--mode must be ndjson', { field: 'mode', value: mode });
+  }
+  const maxEvents = gatewayOptionalPositiveInt('sessions.stream', sessionArgs, '--max-events', 10000);
+  const maxBytes = gatewayOptionalPositiveInt('sessions.stream', sessionArgs, '--max-bytes', 1048576);
+  const idleTimeoutMs = gatewayOptionalPositiveInt(
+    'sessions.stream',
+    sessionArgs,
+    '--idle-timeout-ms',
+    300000
+  );
+  const target = await resolveGatewayPtyTarget(id, 'sessions.stream');
+  const ws = await gatewayOpenPtyWebSocket('sessions.stream', target);
+  let sequence = 0;
+  let frames = 0;
+  let bytesReceived = 0;
+  let truncated = false;
+  let backpressureClosed = false;
+  let idleTimer: NodeJS.Timeout | undefined;
+
+  const refreshIdleTimer = (): void => {
+    if (!idleTimeoutMs) return;
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => ws.close(1000, 'idle timeout'), idleTimeoutMs);
+    idleTimer.unref?.();
+  };
+  refreshIdleTimer();
+
+  ws.on('message', (data) => {
+    refreshIdleTimer();
+    let text = data.toString('utf8');
+    const rawBytes = Buffer.byteLength(text, 'utf8');
+    if (maxBytes !== undefined && bytesReceived + rawBytes > maxBytes) {
+      const remaining = Math.max(0, maxBytes - bytesReceived);
+      text = Buffer.from(text, 'utf8').subarray(0, remaining).toString('utf8');
+      truncated = true;
+    }
+    const bytes = Buffer.byteLength(text, 'utf8');
+    bytesReceived += bytes;
+    if (bytes > 0) {
+      frames += 1;
+      const ok = writeGatewayNdjson(
+        gatewayOk('sessions.stream', {
+          event: 'data',
+          ...gatewayTargetPayload(target),
+          encoding: 'utf8',
+          data: text,
+          bytes,
+          sequence: sequence++,
+        })
+      );
+      if (!ok) {
+        backpressureClosed = true;
+        ws.close(1013, 'stdout backpressure');
+        return;
+      }
+    }
+    if (truncated || (maxEvents !== undefined && frames >= maxEvents)) {
+      ws.close(1000, truncated ? 'maxBytes reached' : 'maxEvents reached');
+    }
+  });
+
+  ws.once('close', (code, reason) => {
+    if (idleTimer) clearTimeout(idleTimer);
+    writeGatewayNdjson(
+      gatewayOk('sessions.stream', {
+        event: 'closed',
+        ...gatewayTargetPayload(target),
+        closeCode: code,
+        reason: reason.toString('utf8'),
+        frames,
+        bytesReceived,
+        truncated,
+        ...(maxBytes !== undefined ? { maxBytes } : {}),
+        backpressureClosed,
+      })
+    );
+    process.exit(0);
+  });
+  ws.once('error', (error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    writeGatewayNdjson(
+      gatewayError('sessions.stream', {
+        code: gatewayWsErrorCode(message),
+        message: `PTY stream error: ${message}`,
+        retryable: true,
+        details: gatewayTargetPayload(target),
+      })
+    );
+  });
+  await new Promise(() => {});
+  process.exit(0);
+}
+
+function gatewayInputData(sessionArgs: string[]): string {
+  const data = gatewayArg(sessionArgs, '--data');
+  const dataBase64 = gatewayArg(sessionArgs, '--data-base64');
+  if (data !== undefined && dataBase64 !== undefined) {
+    gatewayInvalid('sessions.input', 'use only one of --data or --data-base64');
+  }
+  if (data !== undefined) return data;
+  if (dataBase64 !== undefined) return Buffer.from(dataBase64, 'base64').toString('utf8');
+  if (sessionArgs.includes('--stdin')) return fs.readFileSync(0, 'utf8');
+  gatewayInvalid('sessions.input', 'one of --data, --data-base64, or --stdin is required');
+}
+
+async function runGatewaySessionInput(sessionArgs: string[]): Promise<never> {
+  const id = requireGatewaySessionId('sessions.input', sessionArgs);
+  const input = gatewayInputData(sessionArgs);
+  const waitFor = gatewayArg(sessionArgs, '--wait-for');
+  const timeoutMs =
+    gatewayOptionalPositiveInt('sessions.input', sessionArgs, '--timeout-ms', 300000) ?? 5000;
+  const maxBytes =
+    gatewayOptionalPositiveInt('sessions.input', sessionArgs, '--max-bytes', 1048576) ?? 65536;
+  const target = await resolveGatewayPtyTarget(id, 'sessions.input');
+  const ws = await gatewayOpenPtyWebSocket('sessions.input', target);
+  const bytesSent = Buffer.byteLength(input, 'utf8');
+  let output = '';
+  let bytesReceived = 0;
+  let truncated = false;
+  let settled = false;
+
+  const finish = (matched: boolean): void => {
+    if (settled) return;
+    settled = true;
+    try {
+      ws.close(1000, 'sessions.input complete');
+    } catch {
+      /* already closing */
+    }
+    printGatewayEnvelope(
+      gatewayOk('sessions.input', {
+        sent: true,
+        ...gatewayTargetPayload(target),
+        bytesSent,
+        output,
+        matched,
+        ...(waitFor !== undefined ? { waitFor } : {}),
+        bytesReceived,
+        truncated,
+        maxBytes,
+      }),
+      0
+    );
+  };
+
+  const fail = (message: string): void => {
+    if (settled) return;
+    settled = true;
+    try {
+      ws.close(1011, message);
+    } catch {
+      /* already closing */
+    }
+    printGatewayEnvelope(
+      gatewayError('sessions.input', {
+        code: 'UPSTREAM_ERROR',
+        message,
+        retryable: true,
+        details: {
+          ...gatewayTargetPayload(target),
+          ...(waitFor !== undefined ? { waitFor } : {}),
+          bytesReceived,
+          truncated,
+        },
+      }),
+      1
+    );
+  };
+
+  const timer = waitFor
+    ? setTimeout(() => fail(`timed out waiting for PTY output: ${waitFor}`), timeoutMs)
+    : undefined;
+  timer?.unref?.();
+
+  ws.on('message', (data) => {
+    if (settled) return;
+    const text = data.toString('utf8');
+    const nextBytes = Buffer.byteLength(text, 'utf8');
+    if (bytesReceived + nextBytes > maxBytes) {
+      const remaining = Math.max(0, maxBytes - bytesReceived);
+      output += Buffer.from(text, 'utf8').subarray(0, remaining).toString('utf8');
+      bytesReceived = maxBytes;
+      truncated = true;
+      fail(`PTY output exceeded maxBytes before waitFor matched`);
+      return;
+    }
+    output += text;
+    bytesReceived += nextBytes;
+    if (waitFor && output.includes(waitFor)) finish(true);
+  });
+  ws.once('close', () => {
+    if (settled) return;
+    if (waitFor) fail(`PTY stream closed before waitFor matched: ${waitFor}`);
+    else finish(false);
+  });
+  ws.once('error', (error) => {
+    if (settled) return;
+    const message = error instanceof Error ? error.message : String(error);
+    fail(`PTY input stream error: ${message}`);
+  });
+
+  ws.send(input, (error) => {
+    if (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      fail(`could not send PTY input: ${message}`);
+      return;
+    }
+    if (!waitFor) setTimeout(() => finish(false), 10).unref?.();
+  });
+  await new Promise(() => {});
+  process.exit(0);
+}
+
 async function runGatewaySessionInterventions(sessionArgs: string[]): Promise<never> {
   const id = requireGatewaySessionId('sessions.interventions', sessionArgs);
   const limit = gatewayArg(sessionArgs, '--limit');
@@ -695,6 +1040,8 @@ async function runGatewaySessions(gatewayArgs: string[]): Promise<never> {
   if (sessionSubcommand === 'create') return runGatewaySessionCreate(sessionArgs);
   if (sessionSubcommand === 'attach') return runGatewaySessionAttach(sessionArgs);
   if (sessionSubcommand === 'detach') return runGatewaySessionDetach(sessionArgs);
+  if (sessionSubcommand === 'stream') return runGatewaySessionStream(sessionArgs);
+  if (sessionSubcommand === 'input') return runGatewaySessionInput(sessionArgs);
   if (sessionSubcommand === 'interventions') {
     return runGatewaySessionInterventions(sessionArgs);
   }

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -881,13 +881,14 @@ async function runGatewaySessionStream(sessionArgs: string[]): Promise<never> {
 function gatewayInputData(sessionArgs: string[]): string {
   const data = gatewayArg(sessionArgs, '--data');
   const dataBase64 = gatewayArg(sessionArgs, '--data-base64');
-  if (data !== undefined && dataBase64 !== undefined) {
-    gatewayInvalid('sessions.input', 'use only one of --data or --data-base64');
+  const stdin = sessionArgs.includes('--stdin');
+  const sourceCount = [data !== undefined, dataBase64 !== undefined, stdin].filter(Boolean).length;
+  if (sourceCount !== 1) {
+    gatewayInvalid('sessions.input', 'exactly one of --data, --data-base64, or --stdin is required');
   }
   if (data !== undefined) return data;
   if (dataBase64 !== undefined) return Buffer.from(dataBase64, 'base64').toString('utf8');
-  if (sessionArgs.includes('--stdin')) return fs.readFileSync(0, 'utf8');
-  gatewayInvalid('sessions.input', 'one of --data, --data-base64, or --stdin is required');
+  return fs.readFileSync(0, 'utf8');
 }
 
 async function runGatewaySessionInput(sessionArgs: string[]): Promise<never> {

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -143,7 +143,7 @@ Caps are contract-level and conservative:
 - `--idle-timeout-ms N` detaches after N ms without output.
 - If stdout backpressure is observed, the CLI closes the stream instead of dropping frames; the final envelope reports `backpressureClosed: true`.
 
-`relay-ide v1 sessions input --id <id> --data <text> --json` sends one UTF-8 chunk to the PTY attach path and then detaches the CLI handle. `--data-base64` is available for arbitrary bytes encoded as base64, and `--stdin` reads the chunk from standard input. For smoke tests and adapter handshakes, `--wait-for <text>` keeps the temporary attach open until the observed output contains the marker, then returns a single `sessions.input` envelope with `matched`, `output`, `bytesSent`, and `bytesReceived`.
+`relay-ide v1 sessions input --id <id> --data <text> --json` sends one UTF-8 chunk to the PTY attach path and then detaches the CLI handle. `--data-base64` is available for arbitrary bytes encoded as base64, and `--stdin` reads the chunk from standard input. Exactly one of `--data`, `--data-base64`, or `--stdin` is required; mixed or missing input sources fail with `INVALID_ARGUMENT` before Relay opens the temporary attach socket. For smoke tests and adapter handshakes, `--wait-for <text>` keeps the temporary attach open until the observed output contains the marker, then returns a single `sessions.input` envelope with `matched`, `output`, `bytesSent`, and `bytesReceived`.
 
 Example:
 

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -12,6 +12,8 @@ relay-ide v1 sessions get --id <session-id-or-global-id> --json
 relay-ide v1 sessions create --input-json '{...}' --json
 relay-ide v1 sessions attach --id <session-id-or-global-id> --json
 relay-ide v1 sessions detach --id <session-id-or-global-id> --json
+relay-ide v1 sessions stream --id <session-id-or-global-id> --mode ndjson --json
+relay-ide v1 sessions input --id <session-id-or-global-id> --data 'echo ok\n' --wait-for ok --json
 relay-ide v1 files list --session-id <session-id> --path <path> --json
 relay-ide v1 files stat --session-id <session-id> --path <path> --json
 relay-ide v1 files read --session-id <session-id> --path <path> --max-bytes 32768 --max-lines 2000 --json
@@ -123,6 +125,34 @@ Fail-closed examples:
 
 The gateway must never silently downgrade unsupported scoped, privileged, or control-mode requests.
 
+## Session stream and input
+
+`relay-ide v1 sessions stream --id <id> --mode ndjson --json` opens the same authenticated PTY attach path as the browser tab and emits newline-delimited gateway envelopes. Each output chunk is a `sessions.stream` success envelope with `data.event: "data"`, UTF-8 `data.data`, `bytes`, and a monotonic `sequence`. When the CLI detaches or the PTY closes, it emits one final `data.event: "closed"` envelope with `closeCode`, `reason`, `frames`, `bytesReceived`, and `truncated`.
+
+Useful smoke form:
+
+```bash
+relay-ide v1 sessions stream --id remote-session-1 --max-events 1 --json
+```
+
+Caps are contract-level and conservative:
+
+- `--mode ndjson` is the only stable stream mode in v1.
+- `--max-events N` detaches after N data frames.
+- `--max-bytes N` detaches after at most N UTF-8 bytes; the last frame may be truncated and the final envelope reports `truncated: true`.
+- `--idle-timeout-ms N` detaches after N ms without output.
+- If stdout backpressure is observed, the CLI closes the stream instead of dropping frames; the final envelope reports `backpressureClosed: true`.
+
+`relay-ide v1 sessions input --id <id> --data <text> --json` sends one UTF-8 chunk to the PTY attach path and then detaches the CLI handle. `--data-base64` is available for arbitrary bytes encoded as base64, and `--stdin` reads the chunk from standard input. For smoke tests and adapter handshakes, `--wait-for <text>` keeps the temporary attach open until the observed output contains the marker, then returns a single `sessions.input` envelope with `matched`, `output`, `bytesSent`, and `bytesReceived`.
+
+Example:
+
+```bash
+relay-ide v1 sessions input --id remote-session-1 --data 'printf relay-ok\\n\n' --wait-for relay-ok --json
+```
+
+`stream` and `input` detach only their CLI/WebSocket handle. They do not kill the underlying Relay session or tmux process. Missing sessions, expired envelopes, rejected policy, offline nodes, and closed attach sockets surface as typed gateway error envelopes; adapter authors must not fall back to private `/hub/node-link` messages.
+
 ## Read-only file RPC commands
 
 The `files.*` commands route through the existing scoped #505 File RPC surface:
@@ -214,4 +244,4 @@ File commands remain read-only. They must surface unavailable node, missing path
 
 ## Deferred work
 
-Event subscription, input streaming, attach streaming, File RPC write/delete/tail, destructive operations, and adapter packages are follow-up work. If a future adapter needs a missing primitive, extend this CLI contract first; do not bypass it with `/hub/node-link` or browser WebSocket protocol clients.
+Event subscription beyond PTY output, multi-session fan-out, File RPC write/delete/tail, destructive operations, and adapter packages are follow-up work. If a future adapter needs a missing primitive, extend this CLI contract first; do not bypass it with `/hub/node-link` or browser WebSocket protocol clients.

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -431,20 +431,44 @@ const sessionStreamEventSchema: RelayJsonSchema = {
   required: ['event', 'sessionId'],
 };
 
+const sessionInputCommonProperties = {
+  id: stringSchema,
+  waitFor: stringSchema,
+  timeoutMs: { type: 'number', minimum: 1, maximum: 300000 },
+  maxBytes: { type: 'number', minimum: 1, maximum: 1048576 },
+} satisfies Record<string, RelayJsonSchema>;
+
 const sessionInputInputSchema: RelayJsonSchema = {
   title: 'SessionsInputInput',
   type: 'object',
   additionalProperties: false,
   properties: {
-    id: stringSchema,
+    ...sessionInputCommonProperties,
     data: stringSchema,
     dataBase64: stringSchema,
     stdin: booleanSchema,
-    waitFor: stringSchema,
-    timeoutMs: { type: 'number', minimum: 1, maximum: 300000 },
-    maxBytes: { type: 'number', minimum: 1, maximum: 1048576 },
   },
   required: ['id'],
+  oneOf: [
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: { ...sessionInputCommonProperties, data: stringSchema },
+      required: ['id', 'data'],
+    },
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: { ...sessionInputCommonProperties, dataBase64: stringSchema },
+      required: ['id', 'dataBase64'],
+    },
+    {
+      type: 'object',
+      additionalProperties: false,
+      properties: { ...sessionInputCommonProperties, stdin: { const: true } },
+      required: ['id', 'stdin'],
+    },
+  ],
 };
 
 const sessionInputOutputSchema: RelayJsonSchema = {

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -14,6 +14,8 @@ export type RelayCliGatewayCommand =
   | 'sessions.create'
   | 'sessions.attach'
   | 'sessions.detach'
+  | 'sessions.stream'
+  | 'sessions.input'
   | 'sessions.interventions'
   | 'sessions.handBack'
   | 'files.list'
@@ -391,6 +393,80 @@ const detachOutputSchema: RelayJsonSchema = {
   required: ['detached', 'killed', 'session', 'message'],
 };
 
+const sessionStreamInputSchema: RelayJsonSchema = {
+  title: 'SessionsStreamInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    id: stringSchema,
+    mode: { type: 'string', enum: ['ndjson'], default: 'ndjson' },
+    maxEvents: { type: 'number', minimum: 1, maximum: 10000 },
+    maxBytes: { type: 'number', minimum: 1, maximum: 1048576 },
+    idleTimeoutMs: { type: 'number', minimum: 1, maximum: 300000 },
+  },
+  required: ['id'],
+};
+
+const sessionStreamEventSchema: RelayJsonSchema = {
+  title: 'SessionsStreamEvent',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    event: { type: 'string', enum: ['data', 'closed'] },
+    sessionId: stringSchema,
+    nodeId: stringSchema,
+    globalSessionId: stringSchema,
+    encoding: { const: 'utf8' },
+    data: stringSchema,
+    bytes: { type: 'number', minimum: 0 },
+    sequence: { type: 'number', minimum: 0 },
+    closeCode: { type: 'number' },
+    reason: stringSchema,
+    frames: { type: 'number', minimum: 0 },
+    bytesReceived: { type: 'number', minimum: 0 },
+    truncated: booleanSchema,
+    maxBytes: { type: 'number', minimum: 1 },
+    backpressureClosed: booleanSchema,
+  },
+  required: ['event', 'sessionId'],
+};
+
+const sessionInputInputSchema: RelayJsonSchema = {
+  title: 'SessionsInputInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    id: stringSchema,
+    data: stringSchema,
+    dataBase64: stringSchema,
+    stdin: booleanSchema,
+    waitFor: stringSchema,
+    timeoutMs: { type: 'number', minimum: 1, maximum: 300000 },
+    maxBytes: { type: 'number', minimum: 1, maximum: 1048576 },
+  },
+  required: ['id'],
+};
+
+const sessionInputOutputSchema: RelayJsonSchema = {
+  title: 'SessionsInputOutput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    sent: booleanSchema,
+    sessionId: stringSchema,
+    nodeId: stringSchema,
+    globalSessionId: stringSchema,
+    bytesSent: { type: 'number', minimum: 0 },
+    output: stringSchema,
+    matched: booleanSchema,
+    waitFor: stringSchema,
+    bytesReceived: { type: 'number', minimum: 0 },
+    truncated: booleanSchema,
+    maxBytes: { type: 'number', minimum: 1 },
+  },
+  required: ['sent', 'sessionId', 'bytesSent', 'matched', 'bytesReceived', 'truncated'],
+};
+
 const createSessionInputSchema: RelayJsonSchema = {
   title: 'CreateSessionInput',
   type: 'object',
@@ -646,6 +722,69 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       'INVALID_ARGUMENT',
       'NOT_FOUND',
       'FORBIDDEN',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'sessions.stream',
+    cli: [
+      'relay-ide',
+      'v1',
+      'sessions',
+      'stream',
+      '--id',
+      '<session-id>',
+      '--mode',
+      'ndjson',
+      '--json',
+    ],
+    summary:
+      'Attach to a PTY session and emit UTF-8 output frames as newline-delimited gateway envelopes.',
+    stable: true,
+    transport: 'hub-http-or-node-rpc',
+    requiresAuth: true,
+    capabilityHints: ['session:read', 'session:attach'],
+    inputSchema: sessionStreamInputSchema,
+    outputSchema: okOutput('SessionsStreamEvent', sessionStreamEventSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'NODE_OFFLINE',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'sessions.input',
+    cli: [
+      'relay-ide',
+      'v1',
+      'sessions',
+      'input',
+      '--id',
+      '<session-id>',
+      '--data',
+      '<text>',
+      '--json',
+    ],
+    summary:
+      'Send one UTF-8 input chunk to a PTY session, optionally waiting for observable echoed output.',
+    stable: true,
+    transport: 'hub-http-or-node-rpc',
+    requiresAuth: true,
+    capabilityHints: ['session:read', 'session:attach'],
+    inputSchema: sessionInputInputSchema,
+    outputSchema: okOutput('SessionsInputOutput', sessionInputOutputSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'INVALID_JSON',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'NODE_OFFLINE',
       'SERVER_UNAVAILABLE',
       'UPSTREAM_ERROR',
     ],

--- a/test/browser-cli.test.ts
+++ b/test/browser-cli.test.ts
@@ -564,6 +564,39 @@ test('v1 gateway smoke lists node, creates/attaches, reads files, and detaches w
   ).toMatchObject({ path: 'hello.txt', maxBytes: 64, maxLines: 2 });
 });
 
+test('v1 gateway sessions input rejects missing and mixed input sources before attach', async () => {
+  const env = {
+    ...process.env,
+    RELAY_IDE_PORT: '19999',
+    RELAY_IDE_BROWSER_TOKEN: 'scoped-token',
+    PATH: process.env.PATH,
+  };
+
+  for (const args of [
+    ['dist/bin/relay-ide.js', 'v1', 'sessions', 'input', '--id', 'remote-session-1', '--json'],
+    [
+      'dist/bin/relay-ide.js',
+      'v1',
+      'sessions',
+      'input',
+      '--id',
+      'remote-session-1',
+      '--data',
+      'marker-input\n',
+      '--stdin',
+      '--json',
+    ],
+  ]) {
+    const failure = await execNodeFailure(args, env);
+    expect(failure.status).toBe(1);
+    const envelope = JSON.parse(failure.stdout) as { ok: boolean; error: { code: string; message: string } };
+    expect(envelope).toMatchObject({ ok: false, error: { code: 'INVALID_ARGUMENT' } });
+    expect(envelope.error.message).toContain(
+      'exactly one of --data, --data-base64, or --stdin is required'
+    );
+  }
+});
+
 test('v1 gateway session stream and input use routed PTY websocket', async () => {
   const session = {
     id: 'remote-session-1',

--- a/test/browser-cli.test.ts
+++ b/test/browser-cli.test.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { execFile, execFileSync } from 'node:child_process';
 import * as http from 'node:http';
+import { WebSocketServer } from 'ws';
 
 let tmpDir: string;
 
@@ -562,3 +563,131 @@ test('v1 gateway smoke lists node, creates/attaches, reads files, and detaches w
     captured.find((entry) => entry.url?.endsWith('/files/read'))?.body
   ).toMatchObject({ path: 'hello.txt', maxBytes: 64, maxLines: 2 });
 });
+
+test('v1 gateway session stream and input use routed PTY websocket', async () => {
+  const session = {
+    id: 'remote-session-1',
+    globalSessionId: 'node-a:remote-session-1',
+    nodeId: 'node-a',
+    type: 'terminal',
+    agent: 'shell',
+    mode: 'pty',
+    cwd: '/fixture',
+    displayName: 'fixture terminal',
+    status: 'active',
+  };
+  const upgrades: Array<{ url?: string; cookie?: string; marker?: string | string[] }> = [];
+  const inputs: string[] = [];
+  const server = http.createServer((req, res) => {
+    res.setHeader('content-type', 'application/json');
+    if (req.method === 'GET' && req.url === '/sessions/remote-session-1') {
+      res.end(JSON.stringify(session));
+      return;
+    }
+    res.statusCode = 404;
+    res.end(JSON.stringify({ error: { code: 'NOT_FOUND', message: 'not found' } }));
+  });
+  const wss = new WebSocketServer({ noServer: true });
+  server.on('upgrade', (req, socket, head) => {
+    upgrades.push({
+      url: req.url,
+      cookie: req.headers.cookie,
+      marker: req.headers['x-relay-cli-gateway'],
+    });
+    if (req.url !== '/nodes/node-a/ws/sessions/remote-session-1') {
+      socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      ws.send('stream-marker\n');
+      ws.on('message', (data) => {
+        const text = data.toString();
+        inputs.push(text);
+        ws.send(`echo:${text}`);
+      });
+    });
+  });
+  const port = await listen(server);
+  try {
+    const env = {
+      ...process.env,
+      RELAY_IDE_PORT: String(port),
+      RELAY_IDE_BROWSER_TOKEN: 'scoped-token',
+      PATH: process.env.PATH,
+    };
+    const streamStdout = await execNode(
+      [
+        'dist/bin/relay-ide.js',
+        'v1',
+        'sessions',
+        'stream',
+        '--id',
+        'remote-session-1',
+        '--max-events',
+        '1',
+        '--json',
+      ],
+      env
+    );
+    const streamLines = streamStdout
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(streamLines[0]).toMatchObject({
+      ok: true,
+      command: 'sessions.stream',
+      data: { event: 'data', data: 'stream-marker\n', nodeId: 'node-a' },
+    });
+    expect(streamLines.at(-1)).toMatchObject({
+      ok: true,
+      command: 'sessions.stream',
+      data: { event: 'closed', frames: 1, truncated: false },
+    });
+
+    const inputEnvelope = parseEnvelope<{
+      output: string;
+      matched: boolean;
+      bytesSent: number;
+      nodeId: string;
+    }>(
+      await execNode(
+        [
+          'dist/bin/relay-ide.js',
+          'v1',
+          'sessions',
+          'input',
+          '--id',
+          'remote-session-1',
+          '--data',
+          'marker-input\n',
+          '--wait-for',
+          'echo:marker-input',
+          '--json',
+        ],
+        env
+      )
+    );
+    expect(inputEnvelope).toMatchObject({
+      ok: true,
+      command: 'sessions.input',
+      data: { matched: true, nodeId: 'node-a' },
+    });
+    expect(inputEnvelope.data.output).toContain('echo:marker-input\n');
+  } finally {
+    wss.close();
+    await close(server);
+  }
+
+  expect(upgrades).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        url: '/nodes/node-a/ws/sessions/remote-session-1',
+        cookie: 'token=scoped-token',
+        marker: 'v1',
+      }),
+    ])
+  );
+  expect(inputs).toContain('marker-input\n');
+});
+

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -37,6 +37,8 @@ describe('CLI gateway contract', () => {
       'sessions.create',
       'sessions.attach',
       'sessions.detach',
+      'sessions.stream',
+      'sessions.input',
       'sessions.interventions',
       'sessions.handBack',
       'files.list',
@@ -203,6 +205,8 @@ describe('CLI gateway contract', () => {
       'sessions.create',
       'sessions.attach',
       'sessions.detach',
+      'sessions.stream',
+      'sessions.input',
       'sessions.interventions',
       'sessions.handBack',
       'files.list',
@@ -254,7 +258,7 @@ describe('CLI gateway contract', () => {
   });
 
 
-  it('advertises descriptor-only attach/detach and read-only file RPC commands', () => {
+  it('advertises descriptor-only attach/detach, session I/O, and read-only file RPC commands', () => {
     expect(commandSpec('sessions.attach')).toMatchObject({
       capabilityHints: ['session:read', 'session:attach'],
       transport: 'hub-http',
@@ -262,6 +266,21 @@ describe('CLI gateway contract', () => {
     expect(commandSpec('sessions.detach')).toMatchObject({
       capabilityHints: ['session:read', 'session:attach'],
       transport: 'hub-http',
+    });
+
+    const stream = commandSpec('sessions.stream');
+    expect(stream.capabilityHints).toEqual(['session:read', 'session:attach']);
+    expect(stream.outputSchema).toMatchObject({
+      properties: {
+        data: { properties: { event: { enum: ['data', 'closed'] } } },
+      },
+    });
+
+    const input = commandSpec('sessions.input');
+    expect(input.capabilityHints).toEqual(['session:read', 'session:attach']);
+    expect(input.inputSchema).toMatchObject({
+      additionalProperties: false,
+      properties: { maxBytes: { maximum: 1048576 } },
     });
 
     const list = commandSpec('files.list');

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -7,6 +7,7 @@ import {
   gatewayError,
   gatewayOk,
   stableCommandNames,
+  type RelayJsonSchema,
 } from '../shared/cli-gateway-contract.js';
 import {
   gatewayCliInvalidArgumentError,
@@ -17,6 +18,36 @@ import {
   validateAndSanitizeGatewayCreateInput,
   validateAndSanitizeLocalGatewayCreateInput,
 } from '../shared/cli-gateway-runtime.js';
+
+const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+function objectMatchesSchemaKeywords(schema: RelayJsonSchema, value: Record<string, unknown>): boolean {
+  const properties = schema.properties ?? {};
+  const required = schema.required ?? [];
+  if (schema.type === 'object' && (value === null || Array.isArray(value))) return false;
+  if (!required.every((key) => hasOwn(value, key))) return false;
+  if (schema.additionalProperties === false) {
+    for (const key of Object.keys(value)) {
+      if (!hasOwn(properties, key)) return false;
+    }
+  }
+  for (const [key, propertySchema] of Object.entries(properties)) {
+    if (!hasOwn(value, key)) continue;
+    if ('const' in propertySchema && value[key] !== propertySchema.const) return false;
+    if (propertySchema.type === 'string' && typeof value[key] !== 'string') return false;
+    if (propertySchema.type === 'boolean' && typeof value[key] !== 'boolean') return false;
+    if (propertySchema.type === 'number' && typeof value[key] !== 'number') return false;
+  }
+  return true;
+}
+
+function schemaAcceptsSessionInput(value: Record<string, unknown>): boolean {
+  const schema = commandSpec('sessions.input').inputSchema;
+  if (!objectMatchesSchemaKeywords(schema, value)) return false;
+  if (!schema.oneOf) return true;
+  return schema.oneOf.filter((branch) => objectMatchesSchemaKeywords(branch, value)).length === 1;
+}
 
 describe('CLI gateway contract', () => {
   it('exposes a stable versioned command manifest for node/session adapters', () => {
@@ -280,7 +311,13 @@ describe('CLI gateway contract', () => {
     expect(input.capabilityHints).toEqual(['session:read', 'session:attach']);
     expect(input.inputSchema).toMatchObject({
       additionalProperties: false,
+      required: ['id'],
       properties: { maxBytes: { maximum: 1048576 } },
+      oneOf: [
+        { required: ['id', 'data'], properties: { data: { type: 'string' } } },
+        { required: ['id', 'dataBase64'], properties: { dataBase64: { type: 'string' } } },
+        { required: ['id', 'stdin'], properties: { stdin: { const: true } } },
+      ],
     });
 
     const list = commandSpec('files.list');
@@ -311,6 +348,20 @@ describe('CLI gateway contract', () => {
     });
     expect(read.errorCodes).toEqual(expect.arrayContaining(['NODE_OFFLINE', 'NOT_FOUND']));
     expect(commandSpec('files.stat').capabilityHints).toEqual(['session:read', 'rpc:fs:read']);
+  });
+
+  it('encodes sessions.input source exclusivity for schema-generated adapters', () => {
+    expect(schemaAcceptsSessionInput({ id: 's1', data: 'hello', waitFor: 'hello' })).toBe(true);
+    expect(schemaAcceptsSessionInput({ id: 's1', dataBase64: 'aGVsbG8=' })).toBe(true);
+    expect(schemaAcceptsSessionInput({ id: 's1', stdin: true, timeoutMs: 1000 })).toBe(true);
+
+    expect(schemaAcceptsSessionInput({ id: 's1' })).toBe(false);
+    expect(schemaAcceptsSessionInput({ id: 's1', data: 'hello', dataBase64: 'aGVsbG8=' })).toBe(
+      false
+    );
+    expect(schemaAcceptsSessionInput({ id: 's1', data: 'hello', stdin: true })).toBe(false);
+    expect(schemaAcceptsSessionInput({ id: 's1', dataBase64: 'aGVsbG8=', stdin: true })).toBe(false);
+    expect(schemaAcceptsSessionInput({ id: 's1', stdin: false })).toBe(false);
   });
 
   it('does not expose raw intervention payloads as a gateway contract', () => {


### PR DESCRIPTION
## Summary
- Adds stable v1 CLI gateway commands for PTY session output/input: `sessions stream` and `sessions input`.
- Streams PTY output as NDJSON gateway envelopes with caps for max events, max bytes, idle timeout, and stdout-backpressure close behavior.
- Adds one-shot input with `--data`, `--data-base64`, `--stdin`, and `--wait-for` smoke support, plus schema/docs/tests.

## Motivation
This completes the #429 slice needed for external brain/adapters to prove routed PTY session output and input through the public CLI gateway contract instead of private `/hub/node-link` messages.

## The Case Against
- `sessions.stream` currently only stabilizes `--mode ndjson`; raw terminal passthrough remains intentionally out of scope.
- Both stream/input attach through the browser PTY WebSocket path using the scoped Relay browser token as a cookie, so future token/auth refactors must keep CLI gateway WebSocket auth explicit.
- Backpressure is handled by closing the CLI stream rather than buffering unbounded output, which is safer but means high-volume adapters need to reattach/paginate instead of assuming lossless infinite streaming.

## Verification
- `npm test -- test/cli-gateway-contract.test.ts test/browser-cli.test.ts` — 17/17 passed
- `npm run check` — passed (warnings only, existing lint warning profile)
- `npm run build` — passed

Closes #534
Refs #429, #430, #423, #468, #530
