### PR TITLE
feat: proxy remote node logs

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -1437,7 +1437,10 @@ async function printRemoteNodeLogs(commandArgs: string[]): Promise<void> {
   }
   logger.info(`Following remote Relay node logs for ${nodeId}; press Ctrl-C to stop.`);
   const reader = res.body?.getReader();
-  if (!reader) return;
+  if (!reader) {
+    logger.error('Remote log stream is unavailable.');
+    process.exit(1);
+  }
   const decoder = new TextDecoder();
   await new Promise<void>((resolve) => {
     const stop = (): void => {
@@ -1452,9 +1455,13 @@ async function printRemoteNodeLogs(commandArgs: string[]): Promise<void> {
           if (done) break;
           if (value) process.stdout.write(decoder.decode(value, { stream: true }));
         }
+      } catch (error) {
+        logger.error(
+          `Log stream error: ${error instanceof Error ? error.message : String(error)}`
+        );
+      } finally {
         const tail = decoder.decode();
         if (tail) process.stdout.write(tail);
-      } finally {
         process.off('SIGINT', stop);
         process.off('SIGTERM', stop);
         resolve();

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -29,6 +29,7 @@ import {
   resolveLocalLogPlan,
   type LocalLogRole,
 } from '../server/local-logs.js';
+import { parseCliNodeLogLineCount } from '../server/node-logs.js';
 import { createDiagnosticsBundle } from '../server/diagnostics-bundle.js';
 import { writeNodeCredentialFile } from './node-credential-file.js';
 import {
@@ -76,6 +77,8 @@ Commands:
     uninstall                         Stop and remove the hub background service
     status                            Show hub service status
     logs [--lines <n>] [--follow]     Print or follow local hub log files
+    node-logs <nodeId> [--lines <n>] [--follow]
+                                       Print or follow logs from a paired remote node
   install            Back-compat alias for relay-ide hub install
   uninstall          Back-compat alias for relay-ide hub uninstall
   status             Back-compat alias for relay-ide hub status
@@ -1369,6 +1372,98 @@ async function printHubLogs(commandArgs: string[]): Promise<void> {
   await printLocalLogs('hub', commandArgs);
 }
 
+async function printRemoteNodeLogs(commandArgs: string[]): Promise<void> {
+  const nodeId = commandArgs[0];
+  if (!nodeId || nodeId.startsWith('-')) {
+    logger.error('Usage: relay-ide hub node-logs <nodeId> [--lines <n>] [--follow]');
+    process.exit(1);
+  }
+  const token = process.env['RELAY_IDE_BROWSER_TOKEN'] ?? '';
+  if (!token) {
+    logger.error(
+      'RELAY_IDE_BROWSER_TOKEN not set. Run from an authenticated Relay session or set a scoped API token.'
+    );
+    process.exit(1);
+  }
+  let lines: number;
+  try {
+    lines = parseCliNodeLogLineCount(getNodeArg(commandArgs, '--lines'));
+  } catch (error) {
+    logger.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+  const follow = commandArgs.includes('--follow') || commandArgs.includes('-f');
+  const port = getArg('--port') ?? process.env['RELAY_IDE_PORT'] ?? String(DEFAULTS.port);
+  const url = new URL(
+    `/hub/nodes/${encodeURIComponent(nodeId)}/logs`,
+    `http://127.0.0.1:${port}`
+  );
+  url.searchParams.set('lines', String(lines));
+  if (follow) url.searchParams.set('follow', '1');
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'x-relay-cli-gateway': 'v1',
+        'x-relay-capabilities': 'session:read',
+      },
+    });
+  } catch (error) {
+    logger.error(
+      `could not connect to Relay hub on port ${port}: ${error instanceof Error ? error.message : String(error)}`
+    );
+    process.exit(1);
+  }
+  if (!res.ok) {
+    const text = await res.text();
+    try {
+      const body = JSON.parse(text) as Record<string, unknown>;
+      const message = gatewayErrorMessage(res.status, body);
+      logger.error(message);
+    } catch {
+      logger.error(text || `HTTP ${res.status}`);
+    }
+    process.exit(1);
+  }
+  if (!follow) {
+    const body = (await res.json()) as Record<string, unknown>;
+    const log = typeof body['log'] === 'object' && body['log'] !== null ? (body['log'] as Record<string, unknown>) : {};
+    const output = log['output'];
+    const message = log['message'];
+    if (typeof output === 'string' && output) process.stdout.write(output);
+    else if (typeof message === 'string') logger.info(message);
+    return;
+  }
+  logger.info(`Following remote Relay node logs for ${nodeId}; press Ctrl-C to stop.`);
+  const reader = res.body?.getReader();
+  if (!reader) return;
+  const decoder = new TextDecoder();
+  await new Promise<void>((resolve) => {
+    const stop = (): void => {
+      void reader.cancel().finally(resolve);
+    };
+    process.once('SIGINT', stop);
+    process.once('SIGTERM', stop);
+    const pump = async (): Promise<void> => {
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value) process.stdout.write(decoder.decode(value, { stream: true }));
+        }
+        const tail = decoder.decode();
+        if (tail) process.stdout.write(tail);
+      } finally {
+        process.off('SIGINT', stop);
+        process.off('SIGTERM', stop);
+        resolve();
+      }
+    };
+    void pump();
+  });
+}
+
 async function printNodeStatus(): Promise<void> {
   const manifest = await getNodeManifest();
   const st = service.status();
@@ -1549,6 +1644,8 @@ async function runNodeLink(nodeArgs: string[]): Promise<void> {
   const nodeLinkClient: { current?: ReturnType<typeof createNodeLinkClient> } = {};
   const rpcHost = createNodeLinkRpcHost({
     localRelayNode,
+    localLogConfigPath: configPath,
+    localLogDir: service.getServicePaths().logDir,
     rotateCredential: (rotatedCredential) => {
       if (rotatedCredential.nodeId !== credential.nodeId) {
         throw new Error('credential rotation nodeId mismatch');
@@ -1594,6 +1691,7 @@ async function runNodeLink(nodeArgs: string[]): Promise<void> {
       // process exits, while keeping the 5s safety timer above as a
       // hard cap. Default close() leaves tmux sessions alive so a
       // reconnect can resume them.
+      rpcHost.closeAllLogFollowers();
       void Promise.allSettled([
         ptyHost.closeAll('node-link client stopping'),
         client.stop(),
@@ -1731,6 +1829,8 @@ if (command === 'hub') {
     runServiceCommand(printHubStatus);
   } else if (subCommand === 'logs') {
     await runAsyncCommand(() => printHubLogs(hubArgs.slice(1)));
+  } else if (subCommand === 'node-logs') {
+    await runAsyncCommand(() => printRemoteNodeLogs(hubArgs.slice(1)));
   } else if (
     hubArgs.includes('--bg') &&
     (!subCommand || subCommand.startsWith('-'))
@@ -1749,7 +1849,7 @@ if (command === 'hub') {
     // an alias preserves bare `relay-ide` while making the runtime role explicit.
   } else {
     logger.error(
-      'Usage: relay-ide hub [install|uninstall|status|logs] [--port <port>] [--host <host>] [--config <path>]'
+      'Usage: relay-ide hub [install|uninstall|status|logs|node-logs] [--port <port>] [--host <host>] [--config <path>]'
     );
     process.exit(1);
   }

--- a/server/hub-node-link.ts
+++ b/server/hub-node-link.ts
@@ -26,6 +26,27 @@ interface PendingRpc {
   timer: NodeJS.Timeout;
 }
 
+interface PendingStream {
+  nodeId: string;
+  nodeWs: WebSocket;
+  requestId: string;
+  streamId: string;
+  opened: boolean;
+  resolve: (stream: HubNodeLinkStream) => void;
+  reject: (error: HubNodeLinkError) => void;
+  onChunk: (payload: unknown) => void;
+  onError?: (error: RelayNodeError) => void;
+  onEnd?: () => void;
+  timer: NodeJS.Timeout;
+}
+
+export interface HubNodeLinkStream {
+  requestId: string;
+  streamId: string;
+  payload: unknown;
+  close(): void;
+}
+
 interface BrowserPtyStream {
   nodeId: string;
   nodeWs: WebSocket;
@@ -188,6 +209,7 @@ export interface HubNodeLinkManagerOptions {
 export class HubNodeLinkManager {
   private readonly links = new Map<string, WebSocket>();
   private readonly pending = new Map<string, PendingRpc>();
+  private readonly streams = new Map<string, PendingStream>();
   private readonly ptyStreams = new Map<string, BrowserPtyStream>();
   private readonly eventHandlers = new Set<NodeEventHandler>();
   private readonly inventoryValidator?: HubNodeLinkInventoryValidator;
@@ -270,6 +292,82 @@ export class HubNodeLinkManager {
     });
   }
 
+  streamRequest(
+    nodeId: string,
+    type: string,
+    payload: unknown,
+    handlers: {
+      onChunk: (payload: unknown) => void;
+      onError?: (error: RelayNodeError) => void;
+      onEnd?: () => void;
+    }
+  ): Promise<HubNodeLinkStream> {
+    const ws = this.links.get(nodeId);
+    if (!ws || ws.readyState !== ws.OPEN) {
+      throw new HubNodeLinkError(
+        nodeOffline(`node ${nodeId} has no live reverse link`)
+      );
+    }
+    const requestId = crypto.randomUUID();
+    const streamId = crypto.randomUUID();
+    return new Promise<HubNodeLinkStream>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.streams.delete(streamId);
+        reject(
+          new HubNodeLinkError({
+            code: 'NODE_OFFLINE',
+            message: `node ${nodeId} did not start ${type}`,
+            retryable: true,
+          })
+        );
+      }, DEFAULT_RPC_TIMEOUT_MS);
+      timer.unref?.();
+      const pendingStream: PendingStream = {
+        nodeId,
+        nodeWs: ws,
+        requestId,
+        streamId,
+        opened: false,
+        resolve,
+        reject,
+        onChunk: handlers.onChunk,
+        timer,
+      };
+      if (handlers.onError !== undefined) {
+        pendingStream.onError = handlers.onError;
+      }
+      if (handlers.onEnd !== undefined) {
+        pendingStream.onEnd = handlers.onEnd;
+      }
+      this.streams.set(streamId, pendingStream);
+      sendJson(
+        ws,
+        envelope(nodeId, 'rpc', type, {
+          requestId,
+          streamId,
+          payload,
+        })
+      );
+    });
+  }
+
+  private closeStream(streamId: string): void {
+    const stream = this.streams.get(streamId);
+    if (!stream) return;
+    this.streams.delete(streamId);
+    clearTimeout(stream.timer);
+    if (stream.nodeWs.readyState === stream.nodeWs.OPEN) {
+      sendJson(
+        stream.nodeWs,
+        envelope(stream.nodeId, 'rpc', 'logs.tail.cancel', {
+          requestId: stream.requestId,
+          streamId,
+        })
+      );
+    }
+    stream.onEnd?.();
+  }
+
   attachPty(nodeId: string, sessionId: string, browserWs: WebSocket): void {
     const nodeWs = this.links.get(nodeId);
     if (!nodeWs || nodeWs.readyState !== nodeWs.OPEN) {
@@ -343,6 +441,10 @@ export class HubNodeLinkManager {
   }
 
   handleEnvelope(message: RelayNodeEnvelope): boolean {
+    if (message.channel === 'rpc' && message.streamId) {
+      return this.handleStreamEnvelope(message);
+    }
+
     if (message.channel === 'rpc' && message.requestId) {
       const pending = this.pending.get(message.requestId);
       if (pending && pending.nodeId === message.nodeId) {
@@ -369,6 +471,60 @@ export class HubNodeLinkManager {
   onNodeEvent(handler: NodeEventHandler): () => void {
     this.eventHandlers.add(handler);
     return () => this.eventHandlers.delete(handler);
+  }
+
+  private handleStreamEnvelope(message: RelayNodeEnvelope): boolean {
+    const stream = this.streams.get(message.streamId!);
+    if (!stream || stream.nodeId !== message.nodeId) return false;
+    if (message.error) {
+      this.handleStreamError(message.streamId!, stream, message.error);
+      return true;
+    }
+    if (message.type.endsWith('.result')) {
+      this.openStream(stream, message.payload);
+      return true;
+    }
+    if (message.type === 'logs.tail.chunk') {
+      stream.onChunk(message.payload);
+      return true;
+    }
+    if (message.type === 'logs.tail.error') {
+      const error = payloadRecord(message.payload)['error'];
+      if (typeof error === 'object' && error !== null) {
+        stream.onError?.(error as RelayNodeError);
+      }
+      return true;
+    }
+    if (message.type === 'logs.tail.end') {
+      this.closeStream(message.streamId!);
+      return true;
+    }
+    return false;
+  }
+
+  private handleStreamError(
+    streamId: string,
+    stream: PendingStream,
+    error: RelayNodeError
+  ): void {
+    clearTimeout(stream.timer);
+    if (!stream.opened) {
+      this.streams.delete(streamId);
+      stream.reject(new HubNodeLinkError(error));
+      return;
+    }
+    stream.onError?.(error);
+  }
+
+  private openStream(stream: PendingStream, payload: unknown): void {
+    clearTimeout(stream.timer);
+    stream.opened = true;
+    stream.resolve({
+      requestId: stream.requestId,
+      streamId: stream.streamId,
+      payload,
+      close: () => this.closeStream(stream.streamId),
+    });
   }
 
   private handlePtyEnvelope(message: RelayNodeEnvelope): boolean {
@@ -417,6 +573,15 @@ export class HubNodeLinkManager {
       pending.reject(
         new HubNodeLinkError(nodeOffline(`node ${nodeId} link closed`))
       );
+    }
+    for (const [streamId, stream] of Array.from(this.streams)) {
+      if (stream.nodeId !== nodeId || stream.nodeWs !== ws) continue;
+      clearTimeout(stream.timer);
+      this.streams.delete(streamId);
+      const error = nodeOffline(`node ${nodeId} link closed`);
+      if (stream.opened) stream.onError?.(error);
+      else stream.reject(new HubNodeLinkError(error));
+      stream.onEnd?.();
     }
     for (const [streamId, stream] of Array.from(this.ptyStreams)) {
       if (stream.nodeId !== nodeId || stream.nodeWs !== ws) continue;

--- a/server/hub-node-link.ts
+++ b/server/hub-node-link.ts
@@ -31,6 +31,7 @@ interface PendingStream {
   nodeWs: WebSocket;
   requestId: string;
   streamId: string;
+  cancelType: string;
   opened: boolean;
   resolve: (stream: HubNodeLinkStream) => void;
   reject: (error: HubNodeLinkError) => void;
@@ -327,6 +328,7 @@ export class HubNodeLinkManager {
         nodeWs: ws,
         requestId,
         streamId,
+        cancelType: `${type}.cancel`,
         opened: false,
         resolve,
         reject,
@@ -359,7 +361,7 @@ export class HubNodeLinkManager {
     if (stream.nodeWs.readyState === stream.nodeWs.OPEN) {
       sendJson(
         stream.nodeWs,
-        envelope(stream.nodeId, 'rpc', 'logs.tail.cancel', {
+        envelope(stream.nodeId, 'rpc', stream.cancelType, {
           requestId: stream.requestId,
           streamId,
         })

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -1053,6 +1053,15 @@ function relayErrorFromUnknown(error: unknown): RelayNodeError {
   );
 }
 
+function protocolVersionRelayError(nodeProtocolVersion: string): RelayNodeError {
+  const [nodeMajor] = nodeProtocolVersion.split('.');
+  const [hubMajor] = RELAY_NODE_LINK_PROTOCOL_VERSION.split('.');
+  return relayError(
+    nodeMajor === hubMajor ? 'VERSION_SKEW' : 'PROTOCOL_INCOMPATIBLE',
+    `relay-node-link protocol ${nodeProtocolVersion} must exactly match hub protocol ${RELAY_NODE_LINK_PROTOCOL_VERSION}`
+  );
+}
+
 function sessionCreatePolicyScope(
   nodeId: string,
   body: Record<string, unknown>
@@ -1411,10 +1420,6 @@ export function createHubNodeRouter(
       sendRelayError(res, relayError('INVALID_REQUEST', 'nodeId is required'));
       return;
     }
-    if (!options.nodeLinks?.hasActiveNode(nodeId)) {
-      sendRelayError(res, relayError('NODE_OFFLINE', `node ${nodeId} is offline`, true));
-      return;
-    }
     const lines = nodeLogLinesFromQuery(req.query['lines']);
     if (typeof lines !== 'number') {
       sendRelayError(res, lines);
@@ -1422,6 +1427,37 @@ export function createHubNodeRouter(
     }
     const follow = includeFlag(req.query['follow']);
     const requestPayload = { lines, follow };
+    const node = registry
+      .listNodes()
+      .find((candidate) => candidate.nodeId === nodeId);
+    if (!node || node.status === 'revoked') {
+      sendRelayError(res, relayError('NOT_FOUND', 'node is not paired'));
+      return;
+    }
+    if (node.protocolVersion !== RELAY_NODE_LINK_PROTOCOL_VERSION) {
+      sendRelayError(res, protocolVersionRelayError(node.protocolVersion));
+      return;
+    }
+    if (node.status !== 'online' || !options.nodeLinks?.hasActiveNode(nodeId)) {
+      sendRelayError(
+        res,
+        relayError('NODE_OFFLINE', `node ${nodeId} has no live reverse link`, true)
+      );
+      return;
+    }
+    const policyDecision = evaluateHubPolicy({
+      peer: { kind: 'hub' },
+      node,
+      nodeId,
+      intent: { action: 'rpc.fs.tail', target: nodeId },
+      scope: { kind: 'node', nodeId, cwd: '/' },
+      requiredCapabilities: requiredCapabilitiesForRpcIntent('rpc.fs.tail'),
+      params: requestPayload,
+      now: now(),
+    });
+    if (sendPolicyDecision(options.auditSink, res, policyDecision, requestPayload)) {
+      return;
+    }
     if (!follow) {
       try {
         const payload = await options.nodeLinks.request(nodeId, 'logs.tail', requestPayload);
@@ -1448,6 +1484,10 @@ export function createHubNodeRouter(
     };
     req.on('close', close);
     try {
+      res.status(200);
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+      res.setHeader('Cache-Control', 'no-store');
+      res.flushHeaders();
       stream = await options.nodeLinks.streamRequest(nodeId, 'logs.tail', requestPayload, {
         onChunk: (payload) => {
           if (closed || res.destroyed) return;
@@ -1464,13 +1504,24 @@ export function createHubNodeRouter(
           res.end();
         },
       });
-      res.status(200);
-      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
-      res.setHeader('Cache-Control', 'no-store');
+      if (closed || res.destroyed) {
+        stream.close();
+        return;
+      }
       const output = nodeLogOutput(stream.payload);
       if (output) res.write(output);
     } catch (error) {
-      sendRelayError(res, relayErrorFromUnknown(error));
+      if (res.headersSent) {
+        const streamError = relayErrorFromUnknown(error);
+        if (!closed && !res.destroyed) {
+          res.write(`\n[${streamError.code}] ${streamError.message}\n`);
+          res.end();
+        }
+      } else {
+        res.removeHeader('Content-Type');
+        res.removeHeader('Cache-Control');
+        sendRelayError(res, relayErrorFromUnknown(error));
+      }
     }
   });
 

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -81,6 +81,16 @@ import { validateAndSanitizeGatewayCreateInput } from '../shared/cli-gateway-run
 interface HubNodeSessionTransport {
   hasActiveNode(nodeId: string): boolean;
   request(nodeId: string, type: string, payload: unknown): Promise<unknown>;
+  streamRequest?(
+    nodeId: string,
+    type: string,
+    payload: unknown,
+    handlers: {
+      onChunk: (payload: unknown) => void;
+      onError?: (error: RelayNodeError) => void;
+      onEnd?: () => void;
+    }
+  ): Promise<{ payload: unknown; close(): void }>;
 }
 
 export interface RoutedSessionAuditSink {
@@ -1008,6 +1018,41 @@ function includeFlag(value: unknown): boolean {
   return value === '1' || value === 'true' || value === true;
 }
 
+function nodeLogLinesFromQuery(value: unknown): number | RelayNodeError {
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (raw === undefined) return 100;
+  if (typeof raw !== 'string' || !/^\d+$/.test(raw)) {
+    return relayError('INVALID_REQUEST', 'lines must be a non-negative integer');
+  }
+  const lines = Number(raw);
+  if (lines > 2_000) return relayError('INVALID_REQUEST', 'lines must be <= 2000');
+  return lines;
+}
+
+function nodeLogOutput(payload: unknown): string {
+  if (!isRecord(payload)) return '';
+  const output = payload['output'];
+  const message = payload['message'];
+  if (typeof output === 'string' && output.length > 0) return output;
+  if (typeof message === 'string') return `${message}\n`;
+  return '';
+}
+
+function nodeLogChunk(payload: unknown): string {
+  if (!isRecord(payload)) return '';
+  const chunk = payload['chunk'];
+  return typeof chunk === 'string' ? chunk : '';
+}
+
+function relayErrorFromUnknown(error: unknown): RelayNodeError {
+  if (error instanceof HubNodeLinkError) return error.relayNodeError;
+  return relayError(
+    'INTERNAL',
+    error instanceof Error ? error.message : String(error ?? 'unknown'),
+    true
+  );
+}
+
 function sessionCreatePolicyScope(
   nodeId: string,
   body: Record<string, unknown>
@@ -1358,6 +1403,75 @@ export function createHubNodeRouter(
 
   router.get('/nodes', cliGatewayAuth, (_req, res) => {
     res.json({ nodes: registry.listNodes() });
+  });
+
+  router.get('/hub/nodes/:nodeId/logs', cliGatewayAuth, async (req, res) => {
+    const { nodeId } = req.params;
+    if (!nodeId) {
+      sendRelayError(res, relayError('INVALID_REQUEST', 'nodeId is required'));
+      return;
+    }
+    if (!options.nodeLinks?.hasActiveNode(nodeId)) {
+      sendRelayError(res, relayError('NODE_OFFLINE', `node ${nodeId} is offline`, true));
+      return;
+    }
+    const lines = nodeLogLinesFromQuery(req.query['lines']);
+    if (typeof lines !== 'number') {
+      sendRelayError(res, lines);
+      return;
+    }
+    const follow = includeFlag(req.query['follow']);
+    const requestPayload = { lines, follow };
+    if (!follow) {
+      try {
+        const payload = await options.nodeLinks.request(nodeId, 'logs.tail', requestPayload);
+        res.json({ log: payload });
+      } catch (error) {
+        sendRelayError(res, relayErrorFromUnknown(error));
+      }
+      return;
+    }
+    if (!options.nodeLinks.streamRequest) {
+      sendRelayError(
+        res,
+        relayError('NODE_UNSUPPORTED', 'hub node log streaming is not supported by this runtime')
+      );
+      return;
+    }
+
+    let closed = false;
+    let stream: { payload: unknown; close(): void } | undefined;
+    const close = (): void => {
+      if (closed) return;
+      closed = true;
+      stream?.close();
+    };
+    req.on('close', close);
+    try {
+      stream = await options.nodeLinks.streamRequest(nodeId, 'logs.tail', requestPayload, {
+        onChunk: (payload) => {
+          if (closed || res.destroyed) return;
+          const chunk = nodeLogChunk(payload);
+          if (chunk) res.write(chunk);
+        },
+        onError: (error) => {
+          if (closed || res.destroyed) return;
+          res.write(`\n[${error.code}] ${error.message}\n`);
+          res.end();
+        },
+        onEnd: () => {
+          if (closed || res.destroyed) return;
+          res.end();
+        },
+      });
+      res.status(200);
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+      res.setHeader('Cache-Control', 'no-store');
+      const output = nodeLogOutput(stream.payload);
+      if (output) res.write(output);
+    } catch (error) {
+      sendRelayError(res, relayErrorFromUnknown(error));
+    }
   });
 
   router.post('/hub/nodes/:nodeId/credential-rotation', requireAuth, async (req, res) => {

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -3,6 +3,13 @@ import * as os from 'node:os';
 import { isFileRpcOperation } from '../shared/file-rpc.js';
 import { executeLocalFileRpc } from './file-rpc.js';
 import type { LocalRelayNode } from './local-node.js';
+import {
+  createNodeLogFollower,
+  defaultNodeLogRuntime,
+  parseNodeLogTailRequest,
+  readNodeLogTailSnapshot,
+  type NodeLogFollower,
+} from './node-logs.js';
 import type { Logger } from './logger.js';
 import { createLogger } from './logger.js';
 import type { CreateParams } from './sessions.js';
@@ -34,11 +41,14 @@ import type { SessionSummary } from './types.js';
 export interface NodeLinkRpcHostOptions {
   localRelayNode: LocalRelayNode;
   rotateCredential?: (credential: RelayNodeCredential) => Promise<void> | void;
+  localLogConfigPath?: string;
+  localLogDir?: string | null;
   logger?: Logger;
 }
 
 export interface NodeLinkRpcHost {
   handle: NodeLinkChannelHandler;
+  closeAllLogFollowers(): void;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -276,6 +286,21 @@ export function createNodeLinkRpcHost(
 ): NodeLinkRpcHost {
   const logger = options.logger ?? createLogger('node-link-rpc');
   const { localRelayNode } = options;
+  const defaultLogs = defaultNodeLogRuntime();
+  const logConfigPath = options.localLogConfigPath ?? defaultLogs.configPath;
+  const logDir = options.localLogDir ?? defaultLogs.serviceLogDir;
+  const logFollowers = new Map<string, NodeLogFollower>();
+
+  function closeLogFollower(streamId: string): void {
+    const follower = logFollowers.get(streamId);
+    if (!follower) return;
+    logFollowers.delete(streamId);
+    follower.close();
+  }
+
+  function closeAllLogFollowers(): void {
+    for (const streamId of Array.from(logFollowers.keys())) closeLogFollower(streamId);
+  }
 
   async function handleSessionsCreate(
     envelope: RelayNodeEnvelope,
@@ -380,6 +405,68 @@ export function createNodeLinkRpcHost(
     }
   }
 
+  function sendStreamEnvelope(
+    ctx: NodeLinkEnvelopeHandlerContext,
+    envelope: RelayNodeEnvelope,
+    type: string,
+    payload?: unknown
+  ): void {
+    ctx.send(
+      ctx.buildEnvelope('rpc', type, {
+        ...(envelope.requestId ? { requestId: envelope.requestId } : {}),
+        ...(envelope.streamId ? { streamId: envelope.streamId } : {}),
+        ...(payload !== undefined ? { payload } : {}),
+      })
+    );
+  }
+
+  function handleLogsTail(
+    envelope: RelayNodeEnvelope,
+    ctx: NodeLinkEnvelopeHandlerContext
+  ): void {
+    const parsed = parseNodeLogTailRequest(envelope.payload);
+    if ('code' in parsed) {
+      sendErrorEnvelope(ctx, envelope, parsed);
+      return;
+    }
+    const snapshot = readNodeLogTailSnapshot({
+      configPath: logConfigPath,
+      serviceLogDir: logDir,
+      lines: parsed.lines,
+    });
+    if ('code' in snapshot) {
+      sendErrorEnvelope(ctx, envelope, snapshot);
+      return;
+    }
+    sendResultEnvelope(ctx, envelope, snapshot);
+    if (!parsed.follow) return;
+    if (!envelope.streamId) {
+      sendErrorEnvelope(
+        ctx,
+        envelope,
+        invalidRequest('logs.tail follow requires envelope.streamId')
+      );
+      return;
+    }
+    closeLogFollower(envelope.streamId);
+    const follower = createNodeLogFollower({
+      configPath: logConfigPath,
+      serviceLogDir: logDir,
+      write: (chunk) => sendStreamEnvelope(ctx, envelope, 'logs.tail.chunk', { chunk }),
+      onError: (error) => {
+        logger.warn(`logs.tail follow failed: ${error.message}`);
+        sendStreamEnvelope(ctx, envelope, 'logs.tail.error', {
+          error: internalError(error.message),
+        });
+      },
+    });
+    logFollowers.set(envelope.streamId, follower);
+  }
+
+  function handleLogsTailCancel(envelope: RelayNodeEnvelope): void {
+    if (envelope.streamId) closeLogFollower(envelope.streamId);
+  }
+
   async function handleCredentialRotate(
     envelope: RelayNodeEnvelope,
     ctx: NodeLinkEnvelopeHandlerContext
@@ -432,6 +519,14 @@ export function createNodeLinkRpcHost(
       void handleCredentialRotate(envelope, ctx);
       return;
     }
+    if (envelope.type === 'logs.tail') {
+      handleLogsTail(envelope, ctx);
+      return;
+    }
+    if (envelope.type === 'logs.tail.cancel') {
+      handleLogsTailCancel(envelope);
+      return;
+    }
     const fsMatch = envelope.type.match(/^fs\.(.+)$/);
     if (fsMatch && isFileRpcOperation(fsMatch[1])) {
       void handleFileRpc(fsMatch[1], envelope, ctx);
@@ -447,5 +542,5 @@ export function createNodeLinkRpcHost(
     );
   }
 
-  return { handle };
+  return { handle, closeAllLogFollowers };
 }

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -263,6 +263,7 @@ function sendResultEnvelope(
   ctx.send(
     ctx.buildEnvelope('rpc', `${envelope.type}.result`, {
       ...(envelope.requestId ? { requestId: envelope.requestId } : {}),
+      ...(envelope.streamId ? { streamId: envelope.streamId } : {}),
       payload,
     })
   );
@@ -276,6 +277,7 @@ function sendErrorEnvelope(
   ctx.send(
     ctx.buildEnvelope('rpc', `${envelope.type}.error`, {
       ...(envelope.requestId ? { requestId: envelope.requestId } : {}),
+      ...(envelope.streamId ? { streamId: envelope.streamId } : {}),
       error,
     })
   );
@@ -429,6 +431,14 @@ export function createNodeLinkRpcHost(
       sendErrorEnvelope(ctx, envelope, parsed);
       return;
     }
+    if (parsed.follow && !envelope.streamId) {
+      sendErrorEnvelope(
+        ctx,
+        envelope,
+        invalidRequest('logs.tail follow requires envelope.streamId')
+      );
+      return;
+    }
     const snapshot = readNodeLogTailSnapshot({
       configPath: logConfigPath,
       serviceLogDir: logDir,
@@ -440,7 +450,8 @@ export function createNodeLinkRpcHost(
     }
     sendResultEnvelope(ctx, envelope, snapshot);
     if (!parsed.follow) return;
-    if (!envelope.streamId) {
+    const streamId = envelope.streamId;
+    if (!streamId) {
       sendErrorEnvelope(
         ctx,
         envelope,
@@ -448,7 +459,7 @@ export function createNodeLinkRpcHost(
       );
       return;
     }
-    closeLogFollower(envelope.streamId);
+    closeLogFollower(streamId);
     const follower = createNodeLogFollower({
       configPath: logConfigPath,
       serviceLogDir: logDir,
@@ -460,7 +471,7 @@ export function createNodeLinkRpcHost(
         });
       },
     });
-    logFollowers.set(envelope.streamId, follower);
+    logFollowers.set(streamId, follower);
   }
 
   function handleLogsTailCancel(envelope: RelayNodeEnvelope): void {

--- a/server/node-logs.ts
+++ b/server/node-logs.ts
@@ -1,0 +1,139 @@
+import * as service from './service.js';
+import {
+  createLocalLogFollower,
+  parseLogLineCount,
+  readLocalLogSnapshot,
+  resolveLocalLogPlan,
+  type LocalLogFollower,
+  type LocalLogRole,
+} from './local-logs.js';
+import { redactText } from './diagnostics-bundle.js';
+import type { RelayNodeError } from '../shared/relay-node-protocol.js';
+
+export interface NodeLogTailRequest {
+  lines: number;
+  follow: boolean;
+}
+
+export interface NodeLogTailSnapshot {
+  status: 'ok' | 'empty';
+  role: LocalLogRole;
+  logDir: string;
+  files: string[];
+  output: string;
+  message: string;
+  redacted: boolean;
+}
+
+export interface NodeLogFollower {
+  files: string[];
+  close(): void;
+}
+
+const DEFAULT_REMOTE_LOG_LINES = 100;
+const MAX_REMOTE_LOG_LINES = 2_000;
+
+export function parseNodeLogTailRequest(raw: unknown): NodeLogTailRequest | RelayNodeError {
+  const record = typeof raw === 'object' && raw !== null ? (raw as Record<string, unknown>) : {};
+  const rawLines = record['lines'];
+  let lines = DEFAULT_REMOTE_LOG_LINES;
+  if (rawLines !== undefined) {
+    if (typeof rawLines !== 'number' || !Number.isInteger(rawLines) || rawLines < 0) {
+      return invalidRequest('logs.tail payload.lines must be a non-negative integer');
+    }
+    if (rawLines > MAX_REMOTE_LOG_LINES) {
+      return invalidRequest(`logs.tail payload.lines must be <= ${MAX_REMOTE_LOG_LINES}`);
+    }
+    lines = rawLines;
+  }
+  const rawFollow = record['follow'];
+  if (rawFollow !== undefined && typeof rawFollow !== 'boolean') {
+    return invalidRequest('logs.tail payload.follow must be boolean when set');
+  }
+  return { lines, follow: rawFollow === true };
+}
+
+export function parseCliNodeLogLineCount(value: string | undefined): number {
+  const lines = parseLogLineCount(value, DEFAULT_REMOTE_LOG_LINES);
+  if (lines > MAX_REMOTE_LOG_LINES) {
+    throw new Error(`Invalid --lines value: ${value}. Expected <= ${MAX_REMOTE_LOG_LINES}.`);
+  }
+  return lines;
+}
+
+export function readNodeLogTailSnapshot(options: {
+  role?: LocalLogRole;
+  configPath: string;
+  serviceLogDir?: string | null;
+  lines: number;
+}): NodeLogTailSnapshot | RelayNodeError {
+  const role = options.role ?? 'node';
+  const snapshotOptions: {
+    role: LocalLogRole;
+    configPath: string;
+    serviceLogDir?: string | null;
+    lines: number;
+  } = {
+    role,
+    configPath: options.configPath,
+    lines: options.lines,
+  };
+  if (options.serviceLogDir !== undefined) {
+    snapshotOptions.serviceLogDir = options.serviceLogDir;
+  }
+  const snapshot = readLocalLogSnapshot(snapshotOptions);
+  if (snapshot.status === 'missing') {
+    return {
+      code: 'NOT_FOUND',
+      message: snapshot.message,
+      retryable: false,
+      details: { logDir: snapshot.logDir, files: snapshot.files },
+    };
+  }
+  const redactedOutput = redactText(snapshot.output);
+  const redactedMessage = redactText(snapshot.message);
+  return {
+    status: snapshot.status === 'ok' ? 'ok' : 'empty',
+    role,
+    logDir: snapshot.logDir,
+    files: snapshot.files,
+    output: redactedOutput.value,
+    message: redactedMessage.value,
+    redacted:
+      Object.values(redactedOutput.counts).some((count) => count > 0) ||
+      Object.values(redactedMessage.counts).some((count) => count > 0),
+  };
+}
+
+export function createNodeLogFollower(options: {
+  configPath: string;
+  serviceLogDir?: string | null;
+  write: (chunk: string) => void;
+  onError?: (error: Error) => void;
+}): NodeLogFollower {
+  const plan = resolveLocalLogPlan(options.configPath, options.serviceLogDir);
+  const followerOptions: {
+    files: string[];
+    write: (chunk: string) => void;
+    onError?: (error: Error) => void;
+  } = {
+    files: plan.files,
+    write: (chunk) => options.write(redactText(chunk).value),
+  };
+  if (options.onError !== undefined) {
+    followerOptions.onError = options.onError;
+  }
+  const follower: LocalLogFollower = createLocalLogFollower(followerOptions);
+  return follower;
+}
+
+export function defaultNodeLogRuntime(): { configPath: string; serviceLogDir: string | null } {
+  return {
+    configPath: `${service.CONFIG_DIR}/config.json`,
+    serviceLogDir: service.getServicePaths().logDir,
+  };
+}
+
+function invalidRequest(message: string): RelayNodeError {
+  return { code: 'INVALID_REQUEST', message, retryable: false };
+}

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -5,11 +5,11 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import express from 'express';
 import { WebSocket } from 'ws';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createHubNodeRegistry } from '../server/hub-node-registry.js';
 import { createHubNodeRouter } from '../server/hub-node-router.js';
 import { createRepoFeatureRouter } from '../server/features/repo-router.js';
-import { createHubNodeLinkManager } from '../server/hub-node-link.js';
+import { createHubNodeLinkManager, HubNodeLinkError } from '../server/hub-node-link.js';
 import { createRepoInventoryFeature } from '../server/features/repo-inventory.js';
 import { setupWebSocket } from '../server/ws.js';
 import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
@@ -104,6 +104,21 @@ function tmpRegistry(now = () => new Date('2026-01-02T03:04:05.000Z')) {
     now,
   });
   return { tmpDir, registry };
+}
+
+function mutateStoredNode(
+  tmpDir: string,
+  nodeId: string,
+  mutate: (node: Record<string, unknown>) => void
+): void {
+  const storagePath = path.join(tmpDir, 'nodes.json');
+  const state = JSON.parse(fs.readFileSync(storagePath, 'utf8')) as {
+    nodes: Array<Record<string, unknown>>;
+  };
+  const node = state.nodes.find((candidate) => candidate['nodeId'] === nodeId);
+  if (!node) throw new Error(`missing stored node ${nodeId}`);
+  mutate(node);
+  fs.writeFileSync(storagePath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
 }
 
 function repoInventoryReport(
@@ -1529,6 +1544,220 @@ describe('hub node routes and link', () => {
       credentialRotation: { state: 'stable' },
     });
     expect(registry.authenticateCredential(exchanged.credential.token)).toBeNull();
+  });
+
+  it('gates hub node log proxy before RPC and forwards remote log errors/snapshots', async () => {
+    const now = new Date('2026-01-02T03:04:05.000Z');
+    const { tmpDir, registry } = tmpRegistry(() => now);
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const exchanged = registry.exchangePairToken({
+      pairToken: registry.createPairToken({}).pairToken,
+      manifest: manifest(),
+    });
+    const headers = { 'x-test-auth': 'yes' };
+
+    const offlineRequest = vi.fn();
+    const offlineApp = express();
+    offlineApp.use(
+      createHubNodeRouter({
+        registry,
+        nodeLinks: {
+          hasActiveNode: () => false,
+          request: offlineRequest,
+        } as never,
+        requireAuth: (req, res, next) => {
+          if (req.header('x-test-auth') === 'yes') next();
+          else res.status(401).json({ error: 'Unauthorized' });
+        },
+        now: () => now,
+      })
+    );
+    const offlineServer = http.createServer(offlineApp);
+    const offlinePort = await listen(offlineServer);
+    cleanup.push(() => close(offlineServer));
+    const offlineRes = await fetch(
+      `http://127.0.0.1:${offlinePort}/hub/nodes/${encodeURIComponent(exchanged.node.nodeId)}/logs`,
+      { headers }
+    );
+    expect(offlineRes.status).toBe(404);
+    expect(await offlineRes.json()).toMatchObject({
+      error: { code: 'NODE_OFFLINE', retryable: true },
+    });
+    expect(offlineRequest).not.toHaveBeenCalled();
+
+    mutateStoredNode(tmpDir, exchanged.node.nodeId, (node) => {
+      node['protocolVersion'] = '1.1';
+    });
+    const skewRegistry = createHubNodeRegistry({
+      storagePath: path.join(tmpDir, 'nodes.json'),
+      now: () => now,
+    });
+    const skewRequest = vi.fn();
+    const skewApp = express();
+    skewApp.use(
+      createHubNodeRouter({
+        registry: skewRegistry,
+        nodeLinks: { hasActiveNode: () => true, request: skewRequest } as never,
+        requireAuth: (req, res, next) => {
+          if (req.header('x-test-auth') === 'yes') next();
+          else res.status(401).json({ error: 'Unauthorized' });
+        },
+        now: () => now,
+      })
+    );
+    const skewServer = http.createServer(skewApp);
+    const skewPort = await listen(skewServer);
+    cleanup.push(() => close(skewServer));
+    const skewRes = await fetch(
+      `http://127.0.0.1:${skewPort}/hub/nodes/${encodeURIComponent(exchanged.node.nodeId)}/logs`,
+      { headers }
+    );
+    expect(skewRes.status).toBe(400);
+    expect(await skewRes.json()).toMatchObject({
+      error: { code: 'VERSION_SKEW', retryable: false },
+    });
+    expect(skewRequest).not.toHaveBeenCalled();
+
+    mutateStoredNode(tmpDir, exchanged.node.nodeId, (node) => {
+      node['protocolVersion'] = '1.0';
+      const acl = node['acl'] as { grants: { allowed: string[] } };
+      acl.grants.allowed = acl.grants.allowed.filter((bit) => bit !== 'rpc:fs:tail');
+    });
+    const deniedRegistry = createHubNodeRegistry({
+      storagePath: path.join(tmpDir, 'nodes.json'),
+      now: () => now,
+    });
+    const deniedRequest = vi.fn();
+    const deniedApp = express();
+    deniedApp.use(
+      createHubNodeRouter({
+        registry: deniedRegistry,
+        nodeLinks: { hasActiveNode: () => true, request: deniedRequest } as never,
+        requireAuth: (req, res, next) => {
+          if (req.header('x-test-auth') === 'yes') next();
+          else res.status(401).json({ error: 'Unauthorized' });
+        },
+        now: () => now,
+      })
+    );
+    const deniedServer = http.createServer(deniedApp);
+    const deniedPort = await listen(deniedServer);
+    cleanup.push(() => close(deniedServer));
+    const deniedRes = await fetch(
+      `http://127.0.0.1:${deniedPort}/hub/nodes/${encodeURIComponent(exchanged.node.nodeId)}/logs`,
+      { headers }
+    );
+    expect(deniedRes.status).toBe(401);
+    expect(await deniedRes.json()).toMatchObject({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: { reasonCode: 'POLICY_CAPABILITY_DENIED' },
+      },
+    });
+    expect(deniedRequest).not.toHaveBeenCalled();
+
+    mutateStoredNode(tmpDir, exchanged.node.nodeId, (node) => {
+      const acl = node['acl'] as { grants: { allowed: string[] } };
+      acl.grants.allowed.push('rpc:fs:tail');
+    });
+    const routeRegistry = createHubNodeRegistry({
+      storagePath: path.join(tmpDir, 'nodes.json'),
+      now: () => now,
+    });
+    const routeRequest = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new HubNodeLinkError({
+          code: 'NOT_FOUND',
+          message: 'node log file was not found',
+          retryable: false,
+        })
+      )
+      .mockResolvedValueOnce({ status: 'empty', output: '', lines: 0 });
+    const routeApp = express();
+    routeApp.use(
+      createHubNodeRouter({
+        registry: routeRegistry,
+        nodeLinks: { hasActiveNode: () => true, request: routeRequest } as never,
+        requireAuth: (req, res, next) => {
+          if (req.header('x-test-auth') === 'yes') next();
+          else res.status(401).json({ error: 'Unauthorized' });
+        },
+        now: () => now,
+      })
+    );
+    const routeServer = http.createServer(routeApp);
+    const routePort = await listen(routeServer);
+    cleanup.push(() => close(routeServer));
+    const routeBase = `http://127.0.0.1:${routePort}/hub/nodes/${encodeURIComponent(exchanged.node.nodeId)}/logs`;
+
+    const missingLogRes = await fetch(routeBase, { headers });
+    expect(missingLogRes.status).toBe(404);
+    expect(await missingLogRes.json()).toMatchObject({
+      error: { code: 'NOT_FOUND', retryable: false },
+    });
+
+    const emptyLogRes = await fetch(routeBase, { headers });
+    expect(emptyLogRes.status).toBe(200);
+    expect(await emptyLogRes.json()).toMatchObject({
+      log: { status: 'empty', output: '' },
+    });
+    expect(routeRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('sets node log follow headers before stream open and cancels if the client disconnects early', async () => {
+    const now = new Date('2026-01-02T03:04:05.000Z');
+    const { tmpDir, registry } = tmpRegistry(() => now);
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const exchanged = registry.exchangePairToken({
+      pairToken: registry.createPairToken({}).pairToken,
+      manifest: manifest(),
+    });
+    let closeCalled = false;
+    let resolveStream: ((stream: { payload: unknown; close(): void }) => void) | undefined;
+    const nodeLinks = {
+      hasActiveNode: () => true,
+      request: vi.fn(),
+      streamRequest: vi.fn(
+        () =>
+          new Promise<{ payload: unknown; close(): void }>((resolve) => {
+            resolveStream = resolve;
+          })
+      ),
+    };
+    const app = express();
+    app.use(
+      createHubNodeRouter({
+        registry,
+        nodeLinks: nodeLinks as never,
+        requireAuth: (req, res, next) => {
+          if (req.header('x-test-auth') === 'yes') next();
+          else res.status(401).json({ error: 'Unauthorized' });
+        },
+        now: () => now,
+      })
+    );
+    const server = http.createServer(app);
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+
+    const res = await fetch(
+      `http://127.0.0.1:${port}/hub/nodes/${encodeURIComponent(exchanged.node.nodeId)}/logs?follow=1`,
+      { headers: { 'x-test-auth': 'yes' } }
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/plain');
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    await res.body?.cancel();
+
+    expect(resolveStream).toBeDefined();
+    resolveStream?.({
+      payload: { status: 'ok', output: 'initial\n' },
+      close: () => {
+        closeCalled = true;
+      },
+    });
+    await vi.waitFor(() => expect(closeCalled).toBe(true));
   });
 
 });

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -412,9 +412,18 @@ describe('node-link-rpc-host', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-node-log-rpc-'));
     const logDir = path.join(tmp, 'logs');
     fs.mkdirSync(logDir, { recursive: true });
+    const bearerFixture = 'Bearer relay_bearer_token_fixture_123';
+    const githubTokenFixture = 'ghp_1234567890abcdefghijklmnopqrstuvwxyz';
+    const pinFixture = 'PIN=123456';
     fs.writeFileSync(
       path.join(logDir, 'relay-ide.log'),
-      'line one\nAuthorization: Bearer abc.def.secret\nline three\n',
+      [
+        'line one',
+        `Authorization: ${bearerFixture}`,
+        `githubToken=${githubTokenFixture}`,
+        pinFixture,
+        'line five',
+      ].join('\n'),
       'utf8'
     );
     const localRelayNode = fakeLocalNode();
@@ -425,15 +434,67 @@ describe('node-link-rpc-host', () => {
     });
     const { sent, ctx } = context();
 
-    host.handle(envelope('logs.tail', { lines: 2 }), ctx);
+    host.handle(envelope('logs.tail', { lines: 5 }), ctx);
 
     expect(sent).toHaveLength(1);
     expect(sent[0]!.type).toBe('logs.tail.result');
     const payload = sent[0]!.payload as { output: string; status: string };
     expect(payload.status).toBe('ok');
-    expect(payload.output).toContain('line three');
-    expect(payload.output).not.toContain('abc.def.secret');
+    expect(payload.output).toContain('line five');
+    expect(payload.output).not.toContain(bearerFixture);
+    expect(payload.output).not.toContain(githubTokenFixture);
+    expect(payload.output).not.toContain(pinFixture);
     expect(payload.output).toContain('[REDACTED]');
+  });
+
+  it('returns NOT_FOUND and empty snapshots for remote node log edge cases', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-node-log-edge-'));
+    const logDir = path.join(tmp, 'logs');
+    fs.mkdirSync(logDir, { recursive: true });
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({
+      localRelayNode,
+      localLogConfigPath: path.join(tmp, 'config.json'),
+      localLogDir: logDir,
+    });
+    const missing = context();
+
+    host.handle(envelope('logs.tail', { lines: 2 }), missing.ctx);
+
+    expect(missing.sent).toHaveLength(1);
+    expect(missing.sent[0]!.type).toBe('logs.tail.error');
+    expect((missing.sent[0]!.error as RelayNodeError).code).toBe('NOT_FOUND');
+
+    fs.writeFileSync(path.join(logDir, 'relay-ide.log'), '', 'utf8');
+    const empty = context();
+    host.handle(envelope('logs.tail', { lines: 2 }), empty.ctx);
+
+    expect(empty.sent).toHaveLength(1);
+    expect(empty.sent[0]!.type).toBe('logs.tail.result');
+    expect(empty.sent[0]!.payload).toMatchObject({ status: 'empty', output: '' });
+  });
+
+  it('rejects malformed logs.tail follow requests with one error envelope', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-node-log-follow-invalid-'));
+    const logDir = path.join(tmp, 'logs');
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.writeFileSync(path.join(logDir, 'relay-ide.log'), 'initial\n', 'utf8');
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({
+      localRelayNode,
+      localLogConfigPath: path.join(tmp, 'config.json'),
+      localLogDir: logDir,
+    });
+    const { sent, ctx } = context();
+
+    host.handle(envelope('logs.tail', { lines: 1, follow: true }), ctx);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('logs.tail.error');
+    expect(sent.some((entry) => entry.type === 'logs.tail.result')).toBe(false);
+    const err = sent[0]!.error as RelayNodeError;
+    expect(err.code).toBe('INVALID_REQUEST');
+    expect(err.message).toContain('streamId');
   });
 
   it('starts and cancels remote node log followers by streamId', async () => {

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -1,4 +1,6 @@
+import * as fs from 'node:fs';
 import * as os from 'node:os';
+import * as path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { createNodeLinkRpcHost } from '../server/node-link-rpc-host.js';
 import type {
@@ -404,6 +406,67 @@ describe('node-link-rpc-host', () => {
 
     expect(sent).toHaveLength(0);
     expect(localRelayNode.sessions.create).not.toHaveBeenCalled();
+  });
+
+  it('returns redacted bounded remote node log snapshots', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-node-log-rpc-'));
+    const logDir = path.join(tmp, 'logs');
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(logDir, 'relay-ide.log'),
+      'line one\nAuthorization: Bearer abc.def.secret\nline three\n',
+      'utf8'
+    );
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({
+      localRelayNode,
+      localLogConfigPath: path.join(tmp, 'config.json'),
+      localLogDir: logDir,
+    });
+    const { sent, ctx } = context();
+
+    host.handle(envelope('logs.tail', { lines: 2 }), ctx);
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('logs.tail.result');
+    const payload = sent[0]!.payload as { output: string; status: string };
+    expect(payload.status).toBe('ok');
+    expect(payload.output).toContain('line three');
+    expect(payload.output).not.toContain('abc.def.secret');
+    expect(payload.output).toContain('[REDACTED]');
+  });
+
+  it('starts and cancels remote node log followers by streamId', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-node-log-follow-'));
+    const logDir = path.join(tmp, 'logs');
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.writeFileSync(path.join(logDir, 'relay-ide.log'), 'initial\n', 'utf8');
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({
+      localRelayNode,
+      localLogConfigPath: path.join(tmp, 'config.json'),
+      localLogDir: logDir,
+    });
+    const { sent, ctx } = context();
+
+    host.handle(
+      envelope('logs.tail', { lines: 1, follow: true }, { streamId: 'stream-1' }),
+      ctx
+    );
+    expect(sent[0]!.type).toBe('logs.tail.result');
+
+    fs.appendFileSync(path.join(logDir, 'relay-ide.log'), 'Authorization: Bearer abc.def.secret\n', 'utf8');
+    await vi.waitFor(() => {
+      expect(sent.some((entry) => entry.type === 'logs.tail.chunk')).toBe(true);
+    });
+    const chunk = sent.find((entry) => entry.type === 'logs.tail.chunk')!.payload as { chunk: string };
+    expect(chunk.chunk).not.toContain('abc.def.secret');
+
+    host.handle(envelope('logs.tail.cancel', {}, { streamId: 'stream-1' }), ctx);
+    const chunkCount = sent.filter((entry) => entry.type === 'logs.tail.chunk').length;
+    fs.appendFileSync(path.join(logDir, 'relay-ide.log'), 'after cancel\n', 'utf8');
+    await new Promise((resolve) => setTimeout(resolve, 1_100));
+    expect(sent.filter((entry) => entry.type === 'logs.tail.chunk')).toHaveLength(chunkCount);
   });
 });
 


### PR DESCRIPTION
## Summary
- Add a narrow `logs.tail` reverse-channel RPC for paired nodes, using the existing local log reader and redacting chunks before they leave the node.
- Add hub `/hub/nodes/:nodeId/logs` proxy support for bounded snapshots and follow streams with client-disconnect cancellation.
- Add `relay-ide hub node-logs <nodeId> [--lines <n>] [--follow]` for CLI access to remote node logs.

Closes #538
Refs #476, #443

## The Case Against
- This introduces a new streaming shape on top of the existing `rpc` channel rather than a dedicated `logs` channel; if more streaming RPCs appear, this may want a more formal protocol envelope.
- Follow mode currently streams raw text over the authenticated hub HTTP response; it is intentionally CLI-oriented and not a fleet dashboard or persisted log upload path.
- The node resolves only Relay service log candidates (`relay-ide.log`, `stdout.log`, `stderr.log`) via the existing local log helper. That keeps scope tight, but it will not help inspect arbitrary remote files.

## Verification
- `npm test -- test/node-link-rpc-host.test.ts` — 17/17 passed
- `npm run check` — passed with existing warnings
- `npm run build` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added `node-logs <nodeId>` CLI command to retrieve logs from paired remote nodes
* Supports `--lines` and `--follow` options for flexible log retrieval (follow enables real-time streaming)
* New `/hub/nodes/:nodeId/logs` API endpoint for log access with configurable parameters
* Log streaming infrastructure with proper resource management and cleanup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->