### PR TITLE
feat: add file rpc tail foundation

### DIFF
--- a/server/file-rpc.ts
+++ b/server/file-rpc.ts
@@ -564,11 +564,17 @@ export interface FileRpcFollower {
   close(): void;
 }
 
+function nodeErrorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code)
+    : undefined;
+}
+
 export function createFileRpcFollower(options: {
   request: Pick<FileRpcTailRequest, 'path' | 'maxFollowChunkBytes'>;
   startOffset: number;
   write: (chunk: FileRpcTailChunk) => void;
-  onError?: (error: Error) => void;
+  onError?: (error: RelayNodeError) => void;
   pollIntervalMs?: number;
 }): FileRpcFollower {
   let offset = options.startOffset;
@@ -576,12 +582,26 @@ export function createFileRpcFollower(options: {
   let active = false;
   const pollIntervalMs = options.pollIntervalMs ?? 500;
 
+  const closeWithError = (error: RelayNodeError): void => {
+    if (closed) return;
+    closed = true;
+    clearInterval(timer);
+    options.onError?.(error);
+  };
+
   const poll = async (): Promise<void> => {
     if (closed || active) return;
     active = true;
     try {
       const stats = await fs.stat(options.request.path);
-      if (!stats.isFile()) return;
+      if (!stats.isFile()) {
+        closeWithError(
+          invalidRequest('FILE_RPC_NOT_FILE', 'path is no longer a regular file', {
+            path: options.request.path,
+          })
+        );
+        return;
+      }
       if (stats.size < offset) offset = 0;
       if (stats.size <= offset) return;
       const appendedBytes = stats.size - offset;
@@ -622,9 +642,19 @@ export function createFileRpcFollower(options: {
         await handle.close();
       }
     } catch (error) {
-      options.onError?.(error instanceof Error ? error : new Error(String(error)));
-      closed = true;
-      clearInterval(timer);
+      if (nodeErrorCode(error) === 'ENOENT') {
+        closeWithError(
+          notFound('FILE_RPC_NOT_FOUND', 'followed file was not found', {
+            path: options.request.path,
+          })
+        );
+      } else {
+        closeWithError({
+          code: 'INTERNAL',
+          message: error instanceof Error ? error.message : String(error ?? 'unknown'),
+          retryable: false,
+        });
+      }
     } finally {
       active = false;
     }

--- a/server/file-rpc.ts
+++ b/server/file-rpc.ts
@@ -502,7 +502,7 @@ function tailTextByLines(content: string, maxLines: number | undefined): {
   if (lines.length <= maxLines) return { content, truncatedLines: false };
   const selected = lines.slice(-maxLines).join('\n');
   return {
-    content: selected ? `${selected}${endsWithNewline ? '\n' : ''}` : '',
+    content: `${selected}${endsWithNewline ? '\n' : ''}`,
     truncatedLines: true,
   };
 }

--- a/server/file-rpc.ts
+++ b/server/file-rpc.ts
@@ -10,13 +10,21 @@ import type {
   FileRpcResponse,
   FileRpcStat,
   FileRpcStatResponse,
+  FileRpcTailChunk,
+  FileRpcTailRequest,
+  FileRpcTailResponse,
 } from '../shared/file-rpc.js';
 import {
+  FILE_RPC_DEFAULT_FOLLOW_CHUNK_BYTES,
   FILE_RPC_DEFAULT_LIST_ENTRIES,
   FILE_RPC_DEFAULT_READ_BYTES,
+  FILE_RPC_DEFAULT_TAIL_BYTES,
+  FILE_RPC_MAX_FOLLOW_CHUNK_BYTES,
   FILE_RPC_MAX_LIST_ENTRIES,
   FILE_RPC_MAX_READ_BYTES,
   FILE_RPC_MAX_READ_LINES,
+  FILE_RPC_MAX_TAIL_BYTES,
+  FILE_RPC_MAX_TAIL_LINES,
 } from '../shared/file-rpc.js';
 import type { RelayNodeError } from '../shared/relay-node-protocol.js';
 import type { ScopedSessionSummary } from './session-envelope-registry.js';
@@ -112,6 +120,16 @@ function optionalBoundedInteger(
   return Math.min(value, max);
 }
 
+function optionalBoolean(value: unknown, field: string): boolean | RelayNodeError {
+  if (value === undefined || value === null) return false;
+  if (typeof value !== 'boolean') {
+    return invalidRequest('FILE_RPC_INVALID_REQUEST', `${field} must be boolean when set`, {
+      field,
+    });
+  }
+  return value;
+}
+
 function pathApiForPlatform(platform?: string): PathApi {
   return platform === 'win32' ? path.win32 : path.posix;
 }
@@ -143,6 +161,78 @@ function resolveRoot(summary: ScopedSessionSummary): string | RelayNodeError {
     'scoped session does not expose a filesystem root',
     { sessionId: summary.sessionId, scope: scope.kind }
   );
+}
+
+function buildOperationRequest(
+  operation: FileRpcOperation,
+  base: FileRpcRequest,
+  fields: Record<string, unknown>
+): FileRpcRequest | RelayNodeError {
+  if (operation === 'list') return buildListRequest(base, fields);
+  if (operation === 'read') return buildReadRequest(base, fields);
+  if (operation === 'tail') return buildTailRequest(base, fields);
+  return base;
+}
+
+function buildListRequest(
+  base: FileRpcRequest,
+  fields: Record<string, unknown>
+): FileRpcRequest | RelayNodeError {
+  const maxEntries = boundedInteger(
+    fields['maxEntries'],
+    FILE_RPC_DEFAULT_LIST_ENTRIES,
+    FILE_RPC_MAX_LIST_ENTRIES,
+    'maxEntries'
+  );
+  if (typeof maxEntries !== 'number') return maxEntries;
+  return { ...base, maxEntries };
+}
+
+function buildReadRequest(
+  base: FileRpcRequest,
+  fields: Record<string, unknown>
+): FileRpcRequest | RelayNodeError {
+  const maxBytes = boundedInteger(
+    fields['maxBytes'],
+    FILE_RPC_DEFAULT_READ_BYTES,
+    FILE_RPC_MAX_READ_BYTES,
+    'maxBytes'
+  );
+  if (typeof maxBytes !== 'number') return maxBytes;
+  const maxLines = optionalBoundedInteger(fields['maxLines'], FILE_RPC_MAX_READ_LINES, 'maxLines');
+  if (maxLines !== undefined && typeof maxLines !== 'number') return maxLines;
+  return { ...base, maxBytes, ...(maxLines !== undefined ? { maxLines } : {}) };
+}
+
+function buildTailRequest(
+  base: FileRpcRequest,
+  fields: Record<string, unknown>
+): FileRpcRequest | RelayNodeError {
+  const maxBytes = boundedInteger(
+    fields['maxBytes'],
+    FILE_RPC_DEFAULT_TAIL_BYTES,
+    FILE_RPC_MAX_TAIL_BYTES,
+    'maxBytes'
+  );
+  if (typeof maxBytes !== 'number') return maxBytes;
+  const maxLines = optionalBoundedInteger(fields['maxLines'], FILE_RPC_MAX_TAIL_LINES, 'maxLines');
+  if (maxLines !== undefined && typeof maxLines !== 'number') return maxLines;
+  const follow = optionalBoolean(fields['follow'], 'follow');
+  if (typeof follow !== 'boolean') return follow;
+  const maxFollowChunkBytes = boundedInteger(
+    fields['maxFollowChunkBytes'],
+    FILE_RPC_DEFAULT_FOLLOW_CHUNK_BYTES,
+    FILE_RPC_MAX_FOLLOW_CHUNK_BYTES,
+    'maxFollowChunkBytes'
+  );
+  if (typeof maxFollowChunkBytes !== 'number') return maxFollowChunkBytes;
+  return {
+    ...base,
+    maxBytes,
+    ...(maxLines !== undefined ? { maxLines } : {}),
+    follow,
+    maxFollowChunkBytes,
+  };
 }
 
 export function normalizeHubFileRpcRequest(input: {
@@ -195,40 +285,14 @@ export function normalizeHubFileRpcRequest(input: {
     };
   }
 
-  const base = {
+  const base: FileRpcRequest = {
     sessionId: input.session.sessionId,
     root,
     cwd,
     path: target,
   };
-  let request: FileRpcRequest;
-  if (input.operation === 'list') {
-    const maxEntries = boundedInteger(
-      input.body['maxEntries'],
-      FILE_RPC_DEFAULT_LIST_ENTRIES,
-      FILE_RPC_MAX_LIST_ENTRIES,
-      'maxEntries'
-    );
-    if (typeof maxEntries !== 'number') return { ok: false, error: maxEntries };
-    request = { ...base, maxEntries };
-  } else if (input.operation === 'read') {
-    const maxBytes = boundedInteger(
-      input.body['maxBytes'],
-      FILE_RPC_DEFAULT_READ_BYTES,
-      FILE_RPC_MAX_READ_BYTES,
-      'maxBytes'
-    );
-    if (typeof maxBytes !== 'number') return { ok: false, error: maxBytes };
-    const maxLines = optionalBoundedInteger(
-      input.body['maxLines'],
-      FILE_RPC_MAX_READ_LINES,
-      'maxLines'
-    );
-    if (maxLines && typeof maxLines !== 'number') return { ok: false, error: maxLines };
-    request = { ...base, maxBytes, ...(maxLines ? { maxLines } : {}) };
-  } else {
-    request = base;
-  }
+  const request = buildOperationRequest(input.operation, base, input.body);
+  if ('code' in request) return { ok: false, error: request };
 
   return {
     ok: true,
@@ -248,7 +312,7 @@ export function normalizeHubFileRpcRequest(input: {
   };
 }
 
-function parseFileRpcRequest(raw: unknown): FileRpcRequest | RelayNodeError {
+function parseFileRpcRequest(raw: unknown, operation: FileRpcOperation): FileRpcRequest | RelayNodeError {
   const record = asRecord(raw);
   if (!record) return invalidRequest('FILE_RPC_INVALID_REQUEST', 'file RPC payload must be an object');
   const sessionId = nonEmptyString(record['sessionId']);
@@ -264,34 +328,8 @@ function parseFileRpcRequest(raw: unknown): FileRpcRequest | RelayNodeError {
   if (hasNul(sessionId) || hasNul(root) || hasNul(cwd) || hasNul(requestPath)) {
     return invalidRequest('FILE_RPC_INVALID_REQUEST', 'file RPC payload paths must not contain NUL bytes');
   }
-  const base = { sessionId, root, cwd, path: requestPath };
-  if (typeof record['maxEntries'] === 'number') {
-    const maxEntries = boundedInteger(
-      record['maxEntries'],
-      FILE_RPC_DEFAULT_LIST_ENTRIES,
-      FILE_RPC_MAX_LIST_ENTRIES,
-      'maxEntries'
-    );
-    if (typeof maxEntries !== 'number') return maxEntries;
-    return { ...base, maxEntries };
-  }
-  if (typeof record['maxBytes'] === 'number') {
-    const maxBytes = boundedInteger(
-      record['maxBytes'],
-      FILE_RPC_DEFAULT_READ_BYTES,
-      FILE_RPC_MAX_READ_BYTES,
-      'maxBytes'
-    );
-    if (typeof maxBytes !== 'number') return maxBytes;
-    const maxLines = optionalBoundedInteger(
-      record['maxLines'],
-      FILE_RPC_MAX_READ_LINES,
-      'maxLines'
-    );
-    if (maxLines && typeof maxLines !== 'number') return maxLines;
-    return { ...base, maxBytes, ...(maxLines ? { maxLines } : {}) };
-  }
-  return base;
+  const base: FileRpcRequest = { sessionId, root, cwd, path: requestPath };
+  return buildOperationRequest(operation, base, record);
 }
 
 function entryType(stats: Stats): FileRpcStat['type'] {
@@ -323,8 +361,8 @@ async function realpathOrError(target: string, reasonCode: FileRpcDenialReason):
   }
 }
 
-async function normalizeNodeRequest(raw: unknown): Promise<FileRpcRequest | RelayNodeError> {
-  const parsed = parseFileRpcRequest(raw);
+async function normalizeNodeRequest(raw: unknown, operation: FileRpcOperation): Promise<FileRpcRequest | RelayNodeError> {
+  const parsed = parseFileRpcRequest(raw, operation);
   if ('code' in parsed) return parsed;
   const root = path.resolve(parsed.root);
   const cwd = path.resolve(parsed.cwd);
@@ -453,13 +491,163 @@ async function executeRead(request: FileRpcRequest): Promise<FileRpcReadResponse
   }
 }
 
+function tailTextByLines(content: string, maxLines: number | undefined): {
+  content: string;
+  truncatedLines: boolean;
+} {
+  if (maxLines === undefined) return { content, truncatedLines: false };
+  const endsWithNewline = content.endsWith('\n');
+  const lines = content.split('\n');
+  if (endsWithNewline) lines.pop();
+  if (lines.length <= maxLines) return { content, truncatedLines: false };
+  const selected = lines.slice(-maxLines).join('\n');
+  return {
+    content: selected ? `${selected}${endsWithNewline ? '\n' : ''}` : '',
+    truncatedLines: true,
+  };
+}
+
+function isTailRequest(request: FileRpcRequest): request is FileRpcTailRequest {
+  return 'follow' in request && 'maxFollowChunkBytes' in request;
+}
+
+async function executeTail(request: FileRpcRequest): Promise<FileRpcTailResponse | RelayNodeError> {
+  if (!isTailRequest(request)) {
+    return invalidRequest('FILE_RPC_INVALID_REQUEST', 'tail request requires follow bounds');
+  }
+  let stats: Stats;
+  try {
+    stats = await fs.stat(request.path);
+  } catch {
+    return notFound('FILE_RPC_NOT_FOUND', 'file was not found', { path: request.path });
+  }
+  if (!stats.isFile()) {
+    return invalidRequest('FILE_RPC_NOT_FILE', 'path is not a regular file', { path: request.path });
+  }
+  const bytesToRead = Math.min(request.maxBytes, stats.size);
+  const startOffset = Math.max(0, stats.size - bytesToRead);
+  const handle = await fs.open(request.path, 'r');
+  try {
+    const buffer = Buffer.alloc(bytesToRead);
+    let bytesRead = 0;
+    while (bytesRead < buffer.length) {
+      const read = await handle.read(buffer, bytesRead, buffer.length - bytesRead, startOffset + bytesRead);
+      if (read.bytesRead === 0) break;
+      bytesRead += read.bytesRead;
+    }
+    const visible = buffer.subarray(0, bytesRead);
+    const lineResult = tailTextByLines(visible.toString('utf8'), request.maxLines);
+    return {
+      operation: 'tail',
+      root: request.root,
+      cwd: request.cwd,
+      path: request.path,
+      encoding: 'utf8',
+      content: lineResult.content,
+      bytesRead,
+      startOffset,
+      endOffset: startOffset + bytesRead,
+      fileSize: stats.size,
+      truncatedBytes: startOffset > 0,
+      truncatedLines: lineResult.truncatedLines,
+      follow: request.follow,
+      maxBytes: request.maxBytes,
+      ...(request.maxLines !== undefined ? { maxLines: request.maxLines } : {}),
+      maxFollowChunkBytes: request.maxFollowChunkBytes,
+    };
+  } finally {
+    await handle.close();
+  }
+}
+
+export interface FileRpcFollower {
+  close(): void;
+}
+
+export function createFileRpcFollower(options: {
+  request: Pick<FileRpcTailRequest, 'path' | 'maxFollowChunkBytes'>;
+  startOffset: number;
+  write: (chunk: FileRpcTailChunk) => void;
+  onError?: (error: Error) => void;
+  pollIntervalMs?: number;
+}): FileRpcFollower {
+  let offset = options.startOffset;
+  let closed = false;
+  let active = false;
+  const pollIntervalMs = options.pollIntervalMs ?? 500;
+
+  const poll = async (): Promise<void> => {
+    if (closed || active) return;
+    active = true;
+    try {
+      const stats = await fs.stat(options.request.path);
+      if (!stats.isFile()) return;
+      if (stats.size < offset) offset = 0;
+      if (stats.size <= offset) return;
+      const appendedBytes = stats.size - offset;
+      const skippedBytes = Math.max(0, appendedBytes - options.request.maxFollowChunkBytes);
+      const startOffset = offset + skippedBytes;
+      const bytesToRead = stats.size - startOffset;
+      const handle = await fs.open(options.request.path, 'r');
+      try {
+        const buffer = Buffer.alloc(bytesToRead);
+        let bytesRead = 0;
+        while (bytesRead < buffer.length) {
+          const read = await handle.read(
+            buffer,
+            bytesRead,
+            buffer.length - bytesRead,
+            startOffset + bytesRead
+          );
+          if (read.bytesRead === 0) break;
+          bytesRead += read.bytesRead;
+        }
+        offset = stats.size;
+        if (bytesRead > 0 && !closed) {
+          options.write({
+            operation: 'tail',
+            path: options.request.path,
+            encoding: 'utf8',
+            content: buffer.subarray(0, bytesRead).toString('utf8'),
+            bytesRead,
+            startOffset,
+            endOffset: startOffset + bytesRead,
+            fileSize: stats.size,
+            truncatedBytes: skippedBytes > 0,
+            skippedBytes,
+            maxFollowChunkBytes: options.request.maxFollowChunkBytes,
+          });
+        }
+      } finally {
+        await handle.close();
+      }
+    } catch (error) {
+      options.onError?.(error instanceof Error ? error : new Error(String(error)));
+      closed = true;
+      clearInterval(timer);
+    } finally {
+      active = false;
+    }
+  };
+
+  const timer = setInterval(() => void poll(), pollIntervalMs);
+  timer.unref?.();
+  return {
+    close() {
+      closed = true;
+      clearInterval(timer);
+    },
+  };
+}
+
 export async function executeLocalFileRpc(
   operation: FileRpcOperation,
   raw: unknown
 ): Promise<FileRpcResponse | RelayNodeError> {
-  const request = await normalizeNodeRequest(raw);
+  const request = await normalizeNodeRequest(raw, operation);
   if ('code' in request) return request;
   if (operation === 'list') return await executeList(request);
   if (operation === 'stat') return await executeStat(request);
+  if (operation === 'tail') return await executeTail(request);
   return await executeRead(request);
 }

--- a/server/file-rpc.ts
+++ b/server/file-rpc.ts
@@ -564,23 +564,74 @@ export interface FileRpcFollower {
   close(): void;
 }
 
+const FILE_RPC_FOLLOW_WRITE_TIMEOUT_MS = 5_000;
+
 function nodeErrorCode(error: unknown): string | undefined {
   return typeof error === 'object' && error !== null && 'code' in error
     ? String((error as { code?: unknown }).code)
     : undefined;
 }
 
+function isRelayNodeError(error: unknown): error is RelayNodeError {
+  const record = asRecord(error);
+  return (
+    typeof record?.['code'] === 'string' &&
+    typeof record['message'] === 'string' &&
+    typeof record['retryable'] === 'boolean'
+  );
+}
+
+function followBackpressureError(
+  message: string,
+  details: Record<string, unknown> = {}
+): RelayNodeError {
+  return {
+    code: 'NODE_BUSY',
+    message,
+    retryable: true,
+    details: { reasonCode: 'FILE_RPC_FOLLOW_BACKPRESSURE', ...details },
+  };
+}
+
+async function withFileRpcWriteTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  details: Record<string, unknown>
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            followBackpressureError('file follow writer did not drain before timeout', {
+              timeoutMs,
+              ...details,
+            })
+          );
+        }, timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export function createFileRpcFollower(options: {
   request: Pick<FileRpcTailRequest, 'path' | 'maxFollowChunkBytes'>;
   startOffset: number;
-  write: (chunk: FileRpcTailChunk) => void;
+  write: (chunk: FileRpcTailChunk) => void | Promise<void>;
   onError?: (error: RelayNodeError) => void;
   pollIntervalMs?: number;
+  writeTimeoutMs?: number;
 }): FileRpcFollower {
   let offset = options.startOffset;
   let closed = false;
   let active = false;
   const pollIntervalMs = options.pollIntervalMs ?? 500;
+  const writeTimeoutMs = options.writeTimeoutMs ?? FILE_RPC_FOLLOW_WRITE_TIMEOUT_MS;
 
   const closeWithError = (error: RelayNodeError): void => {
     if (closed) return;
@@ -622,9 +673,8 @@ export function createFileRpcFollower(options: {
           if (read.bytesRead === 0) break;
           bytesRead += read.bytesRead;
         }
-        offset = stats.size;
         if (bytesRead > 0 && !closed) {
-          options.write({
+          const chunk: FileRpcTailChunk = {
             operation: 'tail',
             path: options.request.path,
             encoding: 'utf8',
@@ -636,12 +686,23 @@ export function createFileRpcFollower(options: {
             truncatedBytes: skippedBytes > 0,
             skippedBytes,
             maxFollowChunkBytes: options.request.maxFollowChunkBytes,
+          };
+          await withFileRpcWriteTimeout(Promise.resolve(options.write(chunk)), writeTimeoutMs, {
+            path: options.request.path,
+            startOffset,
+            endOffset: startOffset + bytesRead,
+            bytesRead,
           });
         }
+        offset = stats.size;
       } finally {
         await handle.close();
       }
     } catch (error) {
+      if (isRelayNodeError(error)) {
+        closeWithError(error);
+        return;
+      }
       if (nodeErrorCode(error) === 'ENOENT') {
         closeWithError(
           notFound('FILE_RPC_NOT_FOUND', 'followed file was not found', {

--- a/server/hub-node-link.ts
+++ b/server/hub-node-link.ts
@@ -486,18 +486,18 @@ export class HubNodeLinkManager {
       this.openStream(stream, message.payload);
       return true;
     }
-    if (message.type === 'logs.tail.chunk') {
+    if (message.type === 'logs.tail.chunk' || message.type === 'fs.tail.chunk') {
       stream.onChunk(message.payload);
       return true;
     }
-    if (message.type === 'logs.tail.error') {
+    if (message.type === 'logs.tail.error' || message.type === 'fs.tail.error') {
       const error = payloadRecord(message.payload)['error'];
       if (typeof error === 'object' && error !== null) {
         stream.onError?.(error as RelayNodeError);
       }
       return true;
     }
-    if (message.type === 'logs.tail.end') {
+    if (message.type === 'logs.tail.end' || message.type === 'fs.tail.end') {
       this.closeStream(message.streamId!);
       return true;
     }

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -1153,6 +1153,18 @@ function nodeLogChunk(payload: unknown): string {
   return typeof chunk === 'string' ? chunk : '';
 }
 
+function fileTailOutput(payload: unknown): string {
+  if (!isRecord(payload)) return '';
+  const content = payload['content'];
+  return typeof content === 'string' ? content : '';
+}
+
+function fileTailChunk(payload: unknown): string {
+  if (!isRecord(payload)) return '';
+  const content = payload['content'];
+  return typeof content === 'string' ? content : '';
+}
+
 function relayErrorFromUnknown(error: unknown): RelayNodeError {
   if (error instanceof HubNodeLinkError) return error.relayNodeError;
   return relayError(
@@ -1160,6 +1172,71 @@ function relayErrorFromUnknown(error: unknown): RelayNodeError {
     error instanceof Error ? error.message : String(error ?? 'unknown'),
     true
   );
+}
+
+async function streamFileTailFollow(input: {
+  req: Request;
+  res: Response;
+  nodeLinks: HubNodeSessionTransport;
+  nodeId: string;
+  request: unknown;
+}): Promise<void> {
+  const { req, res, nodeLinks, nodeId, request } = input;
+  if (!nodeLinks.streamRequest) {
+    sendRelayError(
+      res,
+      relayError('NODE_UNSUPPORTED', 'file RPC tail follow is not supported by this runtime')
+    );
+    return;
+  }
+  let closed = false;
+  let stream: { payload: unknown; close(): void } | undefined;
+  const close = (): void => {
+    if (closed) return;
+    closed = true;
+    stream?.close();
+  };
+  req.on('close', close);
+  try {
+    res.status(200);
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-store');
+    res.flushHeaders();
+    stream = await nodeLinks.streamRequest(nodeId, 'fs.tail', request, {
+      onChunk: (payload) => {
+        if (closed || res.destroyed) return;
+        const chunk = fileTailChunk(payload);
+        if (chunk) res.write(chunk);
+      },
+      onError: (error) => {
+        if (closed || res.destroyed) return;
+        res.write(`\n[${error.code}] ${error.message}\n`);
+        res.end();
+      },
+      onEnd: () => {
+        if (closed || res.destroyed) return;
+        res.end();
+      },
+    });
+    if (closed || res.destroyed) {
+      stream.close();
+      return;
+    }
+    const output = fileTailOutput(stream.payload);
+    if (output) res.write(output);
+  } catch (error) {
+    if (res.headersSent) {
+      const streamError = relayErrorFromUnknown(error);
+      if (!closed && !res.destroyed) {
+        res.write(`\n[${streamError.code}] ${streamError.message}\n`);
+        res.end();
+      }
+      return;
+    }
+    res.removeHeader('Content-Type');
+    res.removeHeader('Cache-Control');
+    sendRelayError(res, relayErrorFromUnknown(error));
+  }
 }
 
 function protocolVersionRelayError(nodeProtocolVersion: string): RelayNodeError {
@@ -2151,7 +2228,7 @@ export function createHubNodeRouter(
       if (!isFileRpcOperation(operation)) {
         sendRelayError(
           res,
-          relayError('INVALID_REQUEST', 'file RPC operation must be list, stat, or read', false, {
+          relayError('INVALID_REQUEST', 'file RPC operation must be list, stat, read, or tail', false, {
             reasonCode: 'FILE_RPC_INVALID_REQUEST',
             operation,
           })
@@ -2257,6 +2334,21 @@ export function createHubNodeRouter(
           now: now(),
         })
       ) {
+        return;
+      }
+
+      const follow =
+        operation === 'tail' &&
+        'follow' in normalized.value.request &&
+        normalized.value.request.follow === true;
+      if (follow) {
+        await streamFileTailFollow({
+          req,
+          res,
+          nodeLinks: options.nodeLinks,
+          nodeId,
+          request: normalized.value.request,
+        });
         return;
       }
 

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -79,6 +79,8 @@ import {
 import type { RelayCliGatewayError } from '../shared/cli-gateway-contract.js';
 import { validateAndSanitizeGatewayCreateInput } from '../shared/cli-gateway-runtime.js';
 
+const FILE_RPC_FOLLOW_STREAM_BUFFER_BYTES = 256 * 1024;
+
 interface HubNodeSessionTransport {
   hasActiveNode(nodeId: string): boolean;
   request(nodeId: string, type: string, payload: unknown): Promise<unknown>;
@@ -1165,6 +1167,10 @@ function fileTailChunk(payload: unknown): string {
   return typeof content === 'string' ? content : '';
 }
 
+function relayErrorText(error: RelayNodeError): string {
+  return `\n[${error.code}] ${error.message}\n`;
+}
+
 function relayErrorFromUnknown(error: unknown): RelayNodeError {
   if (error instanceof HubNodeLinkError) return error.relayNodeError;
   return relayError(
@@ -1190,47 +1196,96 @@ async function streamFileTailFollow(input: {
     return;
   }
   let closed = false;
+  let draining = false;
+  let bufferedBytes = 0;
+  const pendingChunks: string[] = [];
   let stream: { payload: unknown; close(): void } | undefined;
   const close = (): void => {
     if (closed) return;
     closed = true;
     stream?.close();
   };
+  const closeWithStreamError = (error: RelayNodeError): void => {
+    if (closed || res.destroyed) return;
+    const output = relayErrorText(error);
+    close();
+    if (!res.destroyed) res.end(output);
+  };
+  const flushBuffered = (): void => {
+    if (closed || res.destroyed || draining) return;
+    while (pendingChunks.length > 0) {
+      const chunk = pendingChunks.shift()!;
+      bufferedBytes -= Buffer.byteLength(chunk);
+      if (!res.write(chunk)) {
+        draining = true;
+        res.once('drain', () => {
+          draining = false;
+          flushBuffered();
+        });
+        return;
+      }
+    }
+  };
+  const writeBounded = (chunk: string): void => {
+    if (!chunk || closed || res.destroyed) return;
+    if (draining || pendingChunks.length > 0) {
+      const chunkBytes = Buffer.byteLength(chunk);
+      bufferedBytes += chunkBytes;
+      pendingChunks.push(chunk);
+      if (bufferedBytes > FILE_RPC_FOLLOW_STREAM_BUFFER_BYTES) {
+        closeWithStreamError(
+          relayError(
+            'NODE_BUSY',
+            'file RPC tail follow output exceeded bounded response buffer; stream closed',
+            true,
+            {
+              reasonCode: 'FILE_RPC_FOLLOW_BACKPRESSURE',
+              maxBufferedBytes: FILE_RPC_FOLLOW_STREAM_BUFFER_BYTES,
+            }
+          )
+        );
+      }
+      return;
+    }
+    if (!res.write(chunk)) {
+      draining = true;
+      res.once('drain', () => {
+        draining = false;
+        flushBuffered();
+      });
+    }
+  };
   req.on('close', close);
   try {
-    res.status(200);
-    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
-    res.setHeader('Cache-Control', 'no-store');
-    res.flushHeaders();
     stream = await nodeLinks.streamRequest(nodeId, 'fs.tail', request, {
       onChunk: (payload) => {
         if (closed || res.destroyed) return;
         const chunk = fileTailChunk(payload);
-        if (chunk) res.write(chunk);
+        writeBounded(chunk);
       },
       onError: (error) => {
         if (closed || res.destroyed) return;
-        res.write(`\n[${error.code}] ${error.message}\n`);
-        res.end();
+        closeWithStreamError(error);
       },
       onEnd: () => {
         if (closed || res.destroyed) return;
         res.end();
       },
     });
+    res.status(200);
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-store');
+    res.flushHeaders();
     if (closed || res.destroyed) {
       stream.close();
       return;
     }
     const output = fileTailOutput(stream.payload);
-    if (output) res.write(output);
+    writeBounded(output);
   } catch (error) {
     if (res.headersSent) {
       const streamError = relayErrorFromUnknown(error);
-      if (!closed && !res.destroyed) {
-        res.write(`\n[${streamError.code}] ${streamError.message}\n`);
-        res.end();
-      }
+      if (!closed && !res.destroyed) closeWithStreamError(streamError);
       return;
     }
     res.removeHeader('Content-Type');

--- a/server/node-link-client.ts
+++ b/server/node-link-client.ts
@@ -16,6 +16,7 @@ export interface NodeLinkCredential {
 
 export interface NodeLinkEnvelopeHandlerContext {
   send: (envelope: RelayNodeEnvelope) => void;
+  sendWithBackpressure?: (envelope: RelayNodeEnvelope) => Promise<void>;
   buildEnvelope: (
     channel: RelayNodeEnvelope['channel'],
     type: string,
@@ -37,6 +38,9 @@ export interface NodeLinkClientDeps {
   initialReconnectDelayMs?: number;
   maxReconnectDelayMs?: number;
   reconnectJitterMs?: number;
+  maxSendBufferedBytes?: number;
+  sendBackpressureTimeoutMs?: number;
+  sendBackpressurePollMs?: number;
   webSocketFactory?: NodeLinkWebSocketFactory;
   setTimeoutFn?: typeof setTimeout;
   clearTimeoutFn?: typeof clearTimeout;
@@ -51,10 +55,11 @@ export interface NodeLinkWebSocketLike {
   on(event: 'message', listener: (data: RawData) => void): void;
   on(event: 'close', listener: (code: number, reason: Buffer) => void): void;
   on(event: 'error', listener: (err: Error) => void): void;
-  send(data: string): void;
+  send(data: string, cb?: (err?: Error) => void): void;
   close(code?: number, reason?: string): void;
   readonly readyState: number;
   readonly OPEN: number;
+  readonly bufferedAmount?: number;
 }
 
 export type NodeLinkWebSocketFactory = (
@@ -81,6 +86,9 @@ const DEFAULTS = {
   initialReconnectDelayMs: 1_000,
   maxReconnectDelayMs: 60_000,
   reconnectJitterMs: 500,
+  maxSendBufferedBytes: 1_048_576,
+  sendBackpressureTimeoutMs: 5_000,
+  sendBackpressurePollMs: 25,
 };
 
 const TERMINAL_ERROR_CODES = new Set<RelayNodeError['code']>([
@@ -115,6 +123,10 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
     deps.maxReconnectDelayMs ?? DEFAULTS.maxReconnectDelayMs;
   const reconnectJitterMs =
     deps.reconnectJitterMs ?? DEFAULTS.reconnectJitterMs;
+  const maxSendBufferedBytes = deps.maxSendBufferedBytes ?? DEFAULTS.maxSendBufferedBytes;
+  const sendBackpressureTimeoutMs =
+    deps.sendBackpressureTimeoutMs ?? DEFAULTS.sendBackpressureTimeoutMs;
+  const sendBackpressurePollMs = deps.sendBackpressurePollMs ?? DEFAULTS.sendBackpressurePollMs;
   const webSocketFactory = deps.webSocketFactory ?? defaultWebSocketFactory;
   const setTimer = deps.setTimeoutFn ?? setTimeout;
   const clearTimer = deps.clearTimeoutFn ?? clearTimeout;
@@ -161,6 +173,79 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
         `send failed: ${error instanceof Error ? error.message : String(error)}`
       );
     }
+  }
+
+  function nodeLinkBackpressureError(
+    message: string,
+    details: Record<string, unknown> = {}
+  ): RelayNodeError {
+    return {
+      code: 'NODE_BUSY',
+      message,
+      retryable: true,
+      details: { reasonCode: 'FILE_RPC_FOLLOW_BACKPRESSURE', ...details },
+    };
+  }
+
+  async function waitForBufferedRoom(socket: NodeLinkWebSocketLike): Promise<void> {
+    const startedAt = Date.now();
+    while ((socket.bufferedAmount ?? 0) > maxSendBufferedBytes) {
+      if (stopped || ws !== socket || socket.readyState !== socket.OPEN) {
+        throw nodeLinkBackpressureError('node link websocket closed before send drained', {
+          bufferedAmount: socket.bufferedAmount ?? 0,
+          maxSendBufferedBytes,
+        });
+      }
+      if (Date.now() - startedAt >= sendBackpressureTimeoutMs) {
+        throw nodeLinkBackpressureError('node link websocket send buffer stayed saturated', {
+          bufferedAmount: socket.bufferedAmount ?? 0,
+          maxSendBufferedBytes,
+          timeoutMs: sendBackpressureTimeoutMs,
+        });
+      }
+      await new Promise<void>((resolve) => {
+        const timer = setTimer(resolve, sendBackpressurePollMs);
+        (timer as unknown as { unref?: () => void }).unref?.();
+      });
+    }
+  }
+
+  async function sendWithBackpressure(payload: RelayNodeEnvelope): Promise<void> {
+    const socket = ws;
+    if (!socket || socket.readyState !== socket.OPEN) {
+      throw nodeLinkBackpressureError('node link websocket is not open');
+    }
+    await waitForBufferedRoom(socket);
+    const data = JSON.stringify(payload);
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const timer = setTimer(() => {
+        if (settled) return;
+        settled = true;
+        reject(
+          nodeLinkBackpressureError('node link websocket send did not drain before timeout', {
+            bufferedAmount: socket.bufferedAmount ?? 0,
+            timeoutMs: sendBackpressureTimeoutMs,
+            bytes: Buffer.byteLength(data),
+          })
+        );
+      }, sendBackpressureTimeoutMs);
+      (timer as unknown as { unref?: () => void }).unref?.();
+      try {
+        socket.send(data, (err?: Error) => {
+          if (settled) return;
+          settled = true;
+          clearTimer(timer);
+          if (err) reject(err);
+          else resolve();
+        });
+      } catch (error) {
+        if (settled) return;
+        settled = true;
+        clearTimer(timer);
+        reject(error);
+      }
+    });
   }
 
   async function buildControlPayload(): Promise<Record<string, unknown>> {
@@ -285,6 +370,7 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
       if (deps.onPtyEnvelope) {
         deps.onPtyEnvelope(env, {
           send,
+          sendWithBackpressure,
           buildEnvelope: envelope,
         });
         return;
@@ -296,6 +382,7 @@ export function createNodeLinkClient(deps: NodeLinkClientDeps): NodeLinkClient {
       if (deps.onRpcEnvelope) {
         deps.onRpcEnvelope(env, {
           send,
+          sendWithBackpressure,
           buildEnvelope: envelope,
         });
         return;

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -1,7 +1,7 @@
 import * as crypto from 'node:crypto';
 import * as os from 'node:os';
-import { isFileRpcOperation } from '../shared/file-rpc.js';
-import { executeLocalFileRpc } from './file-rpc.js';
+import { isFileRpcOperation, type FileRpcTailResponse } from '../shared/file-rpc.js';
+import { createFileRpcFollower, executeLocalFileRpc, type FileRpcFollower } from './file-rpc.js';
 import type { LocalRelayNode } from './local-node.js';
 import {
   createNodeLogFollower,
@@ -292,6 +292,7 @@ export function createNodeLinkRpcHost(
   const logConfigPath = options.localLogConfigPath ?? defaultLogs.configPath;
   const logDir = options.localLogDir ?? defaultLogs.serviceLogDir;
   const logFollowers = new Map<string, NodeLogFollower>();
+  const fileFollowers = new Map<string, FileRpcFollower>();
 
   function closeLogFollower(streamId: string): void {
     const follower = logFollowers.get(streamId);
@@ -300,8 +301,16 @@ export function createNodeLinkRpcHost(
     follower.close();
   }
 
+  function closeFileFollower(streamId: string): void {
+    const follower = fileFollowers.get(streamId);
+    if (!follower) return;
+    fileFollowers.delete(streamId);
+    follower.close();
+  }
+
   function closeAllLogFollowers(): void {
     for (const streamId of Array.from(logFollowers.keys())) closeLogFollower(streamId);
+    for (const streamId of Array.from(fileFollowers.keys())) closeFileFollower(streamId);
   }
 
   async function handleSessionsCreate(
@@ -388,7 +397,7 @@ export function createNodeLinkRpcHost(
   }
 
   async function handleFileRpc(
-    operation: 'list' | 'stat' | 'read',
+    operation: 'list' | 'stat' | 'read' | 'tail',
     envelope: RelayNodeEnvelope,
     ctx: NodeLinkEnvelopeHandlerContext
   ): Promise<void> {
@@ -396,6 +405,36 @@ export function createNodeLinkRpcHost(
       const result = await executeLocalFileRpc(operation, envelope.payload);
       if ('code' in result) {
         sendErrorEnvelope(ctx, envelope, result);
+        return;
+      }
+      if (operation === 'tail' && (result as FileRpcTailResponse).follow) {
+        if (!envelope.streamId) {
+          sendErrorEnvelope(
+            ctx,
+            envelope,
+            invalidRequest('fs.tail follow requires envelope.streamId')
+          );
+          return;
+        }
+        const streamId = envelope.streamId;
+        closeFileFollower(streamId);
+        sendResultEnvelope(ctx, envelope, result);
+        const tailResult = result as FileRpcTailResponse;
+        const follower = createFileRpcFollower({
+          request: {
+            path: tailResult.path,
+            maxFollowChunkBytes: tailResult.maxFollowChunkBytes,
+          },
+          startOffset: tailResult.endOffset,
+          write: (chunk) => sendStreamEnvelope(ctx, envelope, 'fs.tail.chunk', chunk),
+          onError: (error) => {
+            logger.warn(`fs.tail follow failed: ${error.message}`);
+            sendStreamEnvelope(ctx, envelope, 'fs.tail.error', {
+              error: internalError(error.message),
+            });
+          },
+        });
+        fileFollowers.set(streamId, follower);
         return;
       }
       sendResultEnvelope(ctx, envelope, result);
@@ -536,6 +575,10 @@ export function createNodeLinkRpcHost(
     }
     if (envelope.type === 'logs.tail.cancel') {
       handleLogsTailCancel(envelope);
+      return;
+    }
+    if (envelope.type === 'fs.tail.cancel') {
+      if (envelope.streamId) closeFileFollower(envelope.streamId);
       return;
     }
     const fsMatch = envelope.type.match(/^fs\.(.+)$/);

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -426,7 +426,7 @@ export function createNodeLinkRpcHost(
             maxFollowChunkBytes: tailResult.maxFollowChunkBytes,
           },
           startOffset: tailResult.endOffset,
-          write: (chunk) => sendStreamEnvelope(ctx, envelope, 'fs.tail.chunk', chunk),
+          write: (chunk) => sendStreamEnvelopeWithBackpressure(ctx, envelope, 'fs.tail.chunk', chunk),
           onError: (error) => {
             logger.warn(`fs.tail follow failed: ${error.message}`);
             sendStreamEnvelope(ctx, envelope, 'fs.tail.error', {
@@ -460,6 +460,24 @@ export function createNodeLinkRpcHost(
         ...(payload !== undefined ? { payload } : {}),
       })
     );
+  }
+
+  async function sendStreamEnvelopeWithBackpressure(
+    ctx: NodeLinkEnvelopeHandlerContext,
+    envelope: RelayNodeEnvelope,
+    type: string,
+    payload?: unknown
+  ): Promise<void> {
+    const next = ctx.buildEnvelope('rpc', type, {
+      ...(envelope.requestId ? { requestId: envelope.requestId } : {}),
+      ...(envelope.streamId ? { streamId: envelope.streamId } : {}),
+      ...(payload !== undefined ? { payload } : {}),
+    });
+    if (ctx.sendWithBackpressure) {
+      await ctx.sendWithBackpressure(next);
+      return;
+    }
+    ctx.send(next);
   }
 
   function handleLogsTail(

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -430,8 +430,9 @@ export function createNodeLinkRpcHost(
           onError: (error) => {
             logger.warn(`fs.tail follow failed: ${error.message}`);
             sendStreamEnvelope(ctx, envelope, 'fs.tail.error', {
-              error: internalError(error.message),
+              error,
             });
+            closeFileFollower(streamId);
           },
         });
         fileFollowers.set(streamId, follower);

--- a/shared/file-rpc.ts
+++ b/shared/file-rpc.ts
@@ -22,7 +22,8 @@ export type FileRpcDenialReason =
   | 'FILE_RPC_NOT_FOUND'
   | 'FILE_RPC_NOT_DIRECTORY'
   | 'FILE_RPC_NOT_FILE'
-  | 'FILE_RPC_SIZE_LIMIT_EXCEEDED';
+  | 'FILE_RPC_SIZE_LIMIT_EXCEEDED'
+  | 'FILE_RPC_FOLLOW_BACKPRESSURE';
 
 export type FileRpcEntryType = 'file' | 'directory' | 'symlink' | 'other';
 

--- a/shared/file-rpc.ts
+++ b/shared/file-rpc.ts
@@ -3,10 +3,15 @@ export const FILE_RPC_DEFAULT_LIST_ENTRIES = 100;
 export const FILE_RPC_MAX_READ_BYTES = 64 * 1024;
 export const FILE_RPC_DEFAULT_READ_BYTES = 32 * 1024;
 export const FILE_RPC_MAX_READ_LINES = 2_000;
+export const FILE_RPC_MAX_TAIL_BYTES = 64 * 1024;
+export const FILE_RPC_DEFAULT_TAIL_BYTES = 32 * 1024;
+export const FILE_RPC_MAX_TAIL_LINES = 2_000;
+export const FILE_RPC_MAX_FOLLOW_CHUNK_BYTES = 64 * 1024;
+export const FILE_RPC_DEFAULT_FOLLOW_CHUNK_BYTES = 16 * 1024;
 
-export type FileRpcOperation = 'list' | 'stat' | 'read';
+export type FileRpcOperation = 'list' | 'stat' | 'read' | 'tail';
 
-export const FILE_RPC_OPERATIONS = ['list', 'stat', 'read'] as const satisfies readonly FileRpcOperation[];
+export const FILE_RPC_OPERATIONS = ['list', 'stat', 'read', 'tail'] as const satisfies readonly FileRpcOperation[];
 
 export type FileRpcDenialReason =
   | 'FILE_RPC_INVALID_REQUEST'
@@ -39,7 +44,18 @@ export interface FileRpcReadRequest extends FileRpcBaseRequest {
   maxLines?: number;
 }
 
-export type FileRpcRequest = FileRpcListRequest | FileRpcStatRequest | FileRpcReadRequest;
+export interface FileRpcTailRequest extends FileRpcBaseRequest {
+  maxBytes: number;
+  maxLines?: number;
+  follow: boolean;
+  maxFollowChunkBytes: number;
+}
+
+export type FileRpcRequest =
+  | FileRpcListRequest
+  | FileRpcStatRequest
+  | FileRpcReadRequest
+  | FileRpcTailRequest;
 
 export interface FileRpcStat {
   path: string;
@@ -82,8 +98,45 @@ export interface FileRpcReadResponse {
   maxLines?: number;
 }
 
-export type FileRpcResponse = FileRpcListResponse | FileRpcStatResponse | FileRpcReadResponse;
+export interface FileRpcTailResponse {
+  operation: 'tail';
+  root: string;
+  cwd: string;
+  path: string;
+  encoding: 'utf8';
+  content: string;
+  bytesRead: number;
+  startOffset: number;
+  endOffset: number;
+  fileSize: number;
+  truncatedBytes: boolean;
+  truncatedLines: boolean;
+  follow: boolean;
+  maxBytes: number;
+  maxLines?: number;
+  maxFollowChunkBytes: number;
+}
+
+export interface FileRpcTailChunk {
+  operation: 'tail';
+  path: string;
+  encoding: 'utf8';
+  content: string;
+  bytesRead: number;
+  startOffset: number;
+  endOffset: number;
+  fileSize: number;
+  truncatedBytes: boolean;
+  skippedBytes: number;
+  maxFollowChunkBytes: number;
+}
+
+export type FileRpcResponse =
+  | FileRpcListResponse
+  | FileRpcStatResponse
+  | FileRpcReadResponse
+  | FileRpcTailResponse;
 
 export function isFileRpcOperation(value: unknown): value is FileRpcOperation {
-  return value === 'list' || value === 'stat' || value === 'read';
+  return value === 'list' || value === 'stat' || value === 'read' || value === 'tail';
 }

--- a/test/file-rpc.test.ts
+++ b/test/file-rpc.test.ts
@@ -284,6 +284,63 @@ describe('read-only File RPC foundation', () => {
     });
   });
 
+  it('does not poll or enqueue more follow chunks while an async writer is backpressured', async () => {
+    const root = fixtureRoot();
+    const target = path.join(root, 'slow-writer.log');
+    fs.writeFileSync(target, 'initial\n', 'utf8');
+    const writes: unknown[] = [];
+    let releaseWrite: (() => void) | undefined;
+    const follower = createFileRpcFollower({
+      request: { path: target, maxFollowChunkBytes: 64 },
+      startOffset: fs.statSync(target).size,
+      write: (chunk) => {
+        writes.push(chunk);
+        return new Promise<void>((resolve) => {
+          releaseWrite = resolve;
+        });
+      },
+      pollIntervalMs: 10,
+      writeTimeoutMs: 1_000,
+    });
+    cleanup.push(() => follower.close());
+
+    fs.appendFileSync(target, 'first\n', 'utf8');
+    await vi.waitFor(() => expect(writes).toHaveLength(1));
+
+    fs.appendFileSync(target, 'second\n', 'utf8');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(writes).toHaveLength(1);
+
+    releaseWrite?.();
+    await vi.waitFor(() => expect(writes).toHaveLength(2));
+    expect(writes[1]).toMatchObject({ content: 'second\n' });
+  });
+
+  it('closes follow streams with a typed retryable error when writes stay backpressured', async () => {
+    const root = fixtureRoot();
+    const target = path.join(root, 'stuck-writer.log');
+    fs.writeFileSync(target, 'initial\n', 'utf8');
+    const errors: unknown[] = [];
+    const follower = createFileRpcFollower({
+      request: { path: target, maxFollowChunkBytes: 64 },
+      startOffset: fs.statSync(target).size,
+      write: () => new Promise<void>(() => {}),
+      onError: (error) => errors.push(error),
+      pollIntervalMs: 10,
+      writeTimeoutMs: 20,
+    });
+    cleanup.push(() => follower.close());
+
+    fs.appendFileSync(target, 'blocked\n', 'utf8');
+
+    await vi.waitFor(() => expect(errors).toHaveLength(1));
+    expect(errors[0]).toMatchObject({
+      code: 'NODE_BUSY',
+      retryable: true,
+      details: { reasonCode: 'FILE_RPC_FOLLOW_BACKPRESSURE', path: target },
+    });
+  });
+
   it('emits a typed terminal error when a followed file is replaced by a directory', async () => {
     const root = fixtureRoot();
     const target = path.join(root, 'app.log');

--- a/test/file-rpc.test.ts
+++ b/test/file-rpc.test.ts
@@ -184,6 +184,62 @@ describe('read-only File RPC foundation', () => {
     }
   });
 
+  it('executes local tail from the end with byte and line bounds', async () => {
+    const root = fixtureRoot();
+    const logFile = path.join(root, 'app.log');
+    fs.writeFileSync(logFile, 'one\ntwo\nthree\nfour\nfive\n');
+
+    const tail = await executeLocalFileRpc('tail', {
+      sessionId: 'session_a',
+      root,
+      cwd: root,
+      path: logFile,
+      maxBytes: 18,
+      maxLines: 2,
+    });
+
+    expect(tail).toMatchObject({
+      operation: 'tail',
+      content: 'four\nfive\n',
+      bytesRead: 18,
+      truncatedBytes: true,
+      truncatedLines: true,
+      follow: false,
+      maxBytes: 18,
+      maxLines: 2,
+      maxFollowChunkBytes: 16384,
+    });
+    expect('startOffset' in tail && tail.startOffset).toBeGreaterThan(0);
+  });
+
+  it('denies tail for directories and missing files with typed File RPC reasons', async () => {
+    const root = fixtureRoot();
+
+    await expect(
+      executeLocalFileRpc('tail', {
+        sessionId: 'session_a',
+        root,
+        cwd: root,
+        path: path.join(root, 'src'),
+      })
+    ).resolves.toMatchObject({
+      code: 'INVALID_REQUEST',
+      details: { reasonCode: 'FILE_RPC_NOT_FILE' },
+    });
+
+    await expect(
+      executeLocalFileRpc('tail', {
+        sessionId: 'session_a',
+        root,
+        cwd: root,
+        path: path.join(root, 'missing.log'),
+      })
+    ).resolves.toMatchObject({
+      code: 'NOT_FOUND',
+      details: { reasonCode: 'FILE_RPC_NOT_FOUND' },
+    });
+  });
+
   it('denies realpath symlink escapes from the scoped root', async () => {
     const root = fixtureRoot();
     const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-file-rpc-outside-'));

--- a/test/file-rpc.test.ts
+++ b/test/file-rpc.test.ts
@@ -212,6 +212,29 @@ describe('read-only File RPC foundation', () => {
     expect('startOffset' in tail && tail.startOffset).toBeGreaterThan(0);
   });
 
+  it('preserves a trailing empty line when tailing one line from a blank final line', async () => {
+    const root = fixtureRoot();
+    const logFile = path.join(root, 'blank-final-line.log');
+    fs.writeFileSync(logFile, 'one\ntwo\n\n');
+
+    const tail = await executeLocalFileRpc('tail', {
+      sessionId: 'session_a',
+      root,
+      cwd: root,
+      path: logFile,
+      maxBytes: 64,
+      maxLines: 1,
+    });
+
+    expect(tail).toMatchObject({
+      operation: 'tail',
+      content: '\n',
+      truncatedBytes: false,
+      truncatedLines: true,
+      maxLines: 1,
+    });
+  });
+
   it('denies tail for directories and missing files with typed File RPC reasons', async () => {
     const root = fixtureRoot();
 

--- a/test/file-rpc.test.ts
+++ b/test/file-rpc.test.ts
@@ -2,8 +2,8 @@ import * as fs from 'node:fs';
 import * as fsPromises from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
-import { executeLocalFileRpc, normalizeHubFileRpcRequest } from '../server/file-rpc.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createFileRpcFollower, executeLocalFileRpc, normalizeHubFileRpcRequest } from '../server/file-rpc.js';
 import { createRoutedNodeSessionEnvelope } from '../shared/session-envelope.js';
 import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
 
@@ -258,6 +258,30 @@ describe('read-only File RPC foundation', () => {
     expect(denied).toMatchObject({
       code: 'INVALID_REQUEST',
       details: { reasonCode: 'FILE_RPC_ROOT_ESCAPE' },
+    });
+  });
+
+  it('emits a typed terminal error when a followed file is replaced by a directory', async () => {
+    const root = fixtureRoot();
+    const target = path.join(root, 'app.log');
+    fs.writeFileSync(target, 'initial\n', 'utf8');
+    const errors: unknown[] = [];
+    const follower = createFileRpcFollower({
+      request: { path: target, maxFollowChunkBytes: 64 },
+      startOffset: fs.statSync(target).size,
+      write: () => {},
+      onError: (error) => errors.push(error),
+      pollIntervalMs: 10,
+    });
+    cleanup.push(() => follower.close());
+
+    fs.rmSync(target);
+    fs.mkdirSync(target);
+
+    await vi.waitFor(() => expect(errors).toHaveLength(1));
+    expect(errors[0]).toMatchObject({
+      code: 'INVALID_REQUEST',
+      details: { reasonCode: 'FILE_RPC_NOT_FILE', path: target },
     });
   });
 });

--- a/test/hub-node-session-routing.test.ts
+++ b/test/hub-node-session-routing.test.ts
@@ -1346,6 +1346,76 @@ describe('hub-routed node session create and attach', () => {
     expect(await res.json()).toMatchObject({ operation: 'read', content: '# Relay' });
   });
 
+  it('routes read-only File RPC tail requests with scoped root and follow bounds', async () => {
+    const { base, wsBase, sessionEnvelopes } = await startHub();
+    const { token, nodeId } = await pairNode(base);
+    seedRemoteSessionEnvelope(sessionEnvelopes, nodeId);
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const tailPromise = fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions/remote-session-1/files/tail`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({ path: 'logs/app.log', maxBytes: 999_999, maxLines: 1 }),
+      }
+    );
+
+    const request = await nextJson(nodeWs);
+    expect(request).toMatchObject({
+      nodeId,
+      channel: 'rpc',
+      type: 'fs.tail',
+      payload: {
+        sessionId: 'remote-session-1',
+        root: '/srv/relay-ide',
+        cwd: '/srv/relay-ide',
+        path: '/srv/relay-ide/logs/app.log',
+        maxBytes: 65536,
+        maxLines: 1,
+        follow: false,
+        maxFollowChunkBytes: 16384,
+      },
+    });
+    nodeWs.send(
+      JSON.stringify({
+        protocol: request.protocol,
+        protocolVersion: request.protocolVersion,
+        nodeId,
+        channel: 'rpc',
+        type: 'fs.tail.result',
+        requestId: request.requestId,
+        timestamp: new Date().toISOString(),
+        payload: {
+          operation: 'tail',
+          root: '/srv/relay-ide',
+          cwd: '/srv/relay-ide',
+          path: '/srv/relay-ide/logs/app.log',
+          encoding: 'utf8',
+          content: 'last line\n',
+          bytesRead: 10,
+          startOffset: 100,
+          endOffset: 110,
+          fileSize: 110,
+          truncatedBytes: true,
+          truncatedLines: false,
+          follow: false,
+          maxBytes: 65536,
+          maxLines: 1,
+          maxFollowChunkBytes: 16384,
+        },
+      })
+    );
+
+    const res = await tailPromise;
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ operation: 'tail', content: 'last line\n' });
+  });
+
   it('denies File RPC traversal before it reaches the node link', async () => {
     const { base, wsBase, sessionEnvelopes } = await startHub();
     const { token, nodeId } = await pairNode(base);

--- a/test/hub-node-session-routing.test.ts
+++ b/test/hub-node-session-routing.test.ts
@@ -1416,6 +1416,59 @@ describe('hub-routed node session create and attach', () => {
     expect(await res.json()).toMatchObject({ operation: 'tail', content: 'last line\n' });
   });
 
+  it('returns typed JSON errors for initial File RPC tail follow denials before opening text stream', async () => {
+    const { base, wsBase, sessionEnvelopes } = await startHub();
+    const { token, nodeId } = await pairNode(base);
+    seedRemoteSessionEnvelope(sessionEnvelopes, nodeId);
+    const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    cleanup.push(() => nodeWs.close());
+    await waitForOpen(nodeWs);
+
+    const tailPromise = fetch(
+      `${base}/hub/nodes/${encodeURIComponent(nodeId)}/sessions/remote-session-1/files/tail`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({ path: 'logs', follow: true }),
+      }
+    );
+
+    const request = await nextJson(nodeWs);
+    expect(request).toMatchObject({
+      nodeId,
+      channel: 'rpc',
+      type: 'fs.tail',
+      payload: { follow: true, path: '/srv/relay-ide/logs' },
+    });
+    nodeWs.send(
+      JSON.stringify({
+        protocol: request.protocol,
+        protocolVersion: request.protocolVersion,
+        nodeId,
+        channel: 'rpc',
+        type: 'fs.tail.error',
+        requestId: request.requestId,
+        streamId: request.streamId,
+        timestamp: new Date().toISOString(),
+        error: {
+          code: 'INVALID_REQUEST',
+          message: 'path is not a regular file',
+          retryable: false,
+          details: { reasonCode: 'FILE_RPC_NOT_FILE', path: '/srv/relay-ide/logs' },
+        },
+      })
+    );
+
+    const res = await tailPromise;
+    expect(res.status).toBe(400);
+    expect(res.headers.get('content-type')).toContain('application/json');
+    expect(await res.json()).toMatchObject({
+      error: { code: 'INVALID_REQUEST', details: { reasonCode: 'FILE_RPC_NOT_FILE' } },
+    });
+  });
+
   it('denies File RPC traversal before it reaches the node link', async () => {
     const { base, wsBase, sessionEnvelopes } = await startHub();
     const { token, nodeId } = await pairNode(base);

--- a/test/hub-policy-evaluator.test.ts
+++ b/test/hub-policy-evaluator.test.ts
@@ -313,10 +313,11 @@ describe('hub policy evaluator', () => {
     });
   });
 
-  it('maps read-only File RPC intents to read/list capability bits', () => {
+  it('maps read-only File RPC intents to read/list/tail capability bits', () => {
     expect(requiredCapabilitiesForRpcIntent('rpc.fs.list')).toEqual(['rpc:fs:list']);
     expect(requiredCapabilitiesForRpcIntent('rpc.fs.stat')).toEqual(['rpc:fs:read']);
     expect(requiredCapabilitiesForRpcIntent('rpc.fs.read')).toEqual(['rpc:fs:read']);
+    expect(requiredCapabilitiesForRpcIntent('rpc.fs.tail')).toEqual(['rpc:fs:tail']);
   });
 
   it('separates tab intervention/control capabilities from file/git/exec powers', () => {

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -608,6 +608,56 @@ describe('node-link-rpc-host', () => {
     await new Promise((resolve) => setTimeout(resolve, 1_100));
     expect(sent.filter((entry) => entry.type === 'fs.tail.chunk')).toHaveLength(chunkCount);
   });
+
+  it('closes fs.tail followers with a typed retryable error when node-link writes backpressure', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-file-tail-backpressure-'));
+    const target = path.join(tmp, 'app.log');
+    fs.writeFileSync(target, 'initial\n', 'utf8');
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+    const backpressureError: RelayNodeError = {
+      code: 'NODE_BUSY',
+      message: 'node link websocket send buffer stayed saturated',
+      retryable: true,
+      details: { reasonCode: 'FILE_RPC_FOLLOW_BACKPRESSURE' },
+    };
+    const sendWithBackpressure = vi.fn().mockRejectedValue(backpressureError);
+    const backpressureCtx = { ...ctx, sendWithBackpressure };
+
+    host.handle(
+      envelope(
+        'fs.tail',
+        {
+          sessionId: 'sess-1',
+          root: tmp,
+          cwd: tmp,
+          path: target,
+          maxBytes: 64,
+          follow: true,
+          maxFollowChunkBytes: 64,
+        },
+        { streamId: 'file-stream-slow' }
+      ),
+      backpressureCtx
+    );
+
+    await vi.waitFor(() => expect(sent.some((entry) => entry.type === 'fs.tail.result')).toBe(true));
+    fs.appendFileSync(target, 'blocked\n', 'utf8');
+
+    await vi.waitFor(() => expect(sendWithBackpressure).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(sent.some((entry) => entry.type === 'fs.tail.error')).toBe(true));
+    const errorEnvelope = sent.find((entry) => entry.type === 'fs.tail.error')!;
+    expect((errorEnvelope.payload as { error: RelayNodeError }).error).toMatchObject({
+      code: 'NODE_BUSY',
+      retryable: true,
+      details: { reasonCode: 'FILE_RPC_FOLLOW_BACKPRESSURE' },
+    });
+
+    fs.appendFileSync(target, 'after close\n', 'utf8');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(sendWithBackpressure).toHaveBeenCalledTimes(1);
+  });
 });
 
 // Surface unused CreateParams/CreateWebParams type imports so the

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -529,6 +529,85 @@ describe('node-link-rpc-host', () => {
     await new Promise((resolve) => setTimeout(resolve, 1_100));
     expect(sent.filter((entry) => entry.type === 'logs.tail.chunk')).toHaveLength(chunkCount);
   });
+
+  it('rejects malformed fs.tail follow requests with one error envelope', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-file-tail-invalid-'));
+    fs.writeFileSync(path.join(tmp, 'app.log'), 'initial\n', 'utf8');
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(
+      envelope('fs.tail', {
+        sessionId: 'sess-1',
+        root: tmp,
+        cwd: tmp,
+        path: path.join(tmp, 'app.log'),
+        follow: true,
+      }),
+      ctx
+    );
+
+    await vi.waitFor(() => expect(sent).toHaveLength(1));
+    expect(sent[0]!.type).toBe('fs.tail.error');
+    expect(sent.some((entry) => entry.type === 'fs.tail.result')).toBe(false);
+    const err = sent[0]!.error as RelayNodeError;
+    expect(err.code).toBe('INVALID_REQUEST');
+    expect(err.message).toContain('streamId');
+  });
+
+  it('starts and cancels bounded fs.tail followers by streamId', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-file-tail-follow-'));
+    const target = path.join(tmp, 'app.log');
+    fs.writeFileSync(target, 'initial\n', 'utf8');
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(
+      envelope(
+        'fs.tail',
+        {
+          sessionId: 'sess-1',
+          root: tmp,
+          cwd: tmp,
+          path: target,
+          maxBytes: 64,
+          maxLines: 1,
+          follow: true,
+          maxFollowChunkBytes: 8,
+        },
+        { streamId: 'file-stream-1' }
+      ),
+      ctx
+    );
+
+    await vi.waitFor(() => expect(sent.some((entry) => entry.type === 'fs.tail.result')).toBe(true));
+    expect(sent[0]!.payload).toMatchObject({
+      operation: 'tail',
+      content: 'initial\n',
+      follow: true,
+    });
+
+    fs.appendFileSync(target, '123456789abcdef\n', 'utf8');
+    await vi.waitFor(() => {
+      expect(sent.some((entry) => entry.type === 'fs.tail.chunk')).toBe(true);
+    });
+    const chunk = sent.find((entry) => entry.type === 'fs.tail.chunk')!.payload as {
+      content: string;
+      truncatedBytes: boolean;
+      skippedBytes: number;
+    };
+    expect(chunk.content).toBe('9abcdef\n');
+    expect(chunk.truncatedBytes).toBe(true);
+    expect(chunk.skippedBytes).toBeGreaterThan(0);
+
+    host.handle(envelope('fs.tail.cancel', {}, { streamId: 'file-stream-1' }), ctx);
+    const chunkCount = sent.filter((entry) => entry.type === 'fs.tail.chunk').length;
+    fs.appendFileSync(target, 'after cancel\n', 'utf8');
+    await new Promise((resolve) => setTimeout(resolve, 1_100));
+    expect(sent.filter((entry) => entry.type === 'fs.tail.chunk')).toHaveLength(chunkCount);
+  });
 });
 
 // Surface unused CreateParams/CreateWebParams type imports so the


### PR DESCRIPTION
## Summary
- Adds `tail` to the shared File RPC contract with bounded snapshot and follow chunk envelopes.
- Implements local node-side bounded tail reads from the end of regular files, reusing existing scoped root/cwd/path normalization and typed File RPC denials.
- Adds `fs.tail` follow plumbing over node-link streams with bounded append chunks, cancellation, and hub-side streaming proxy support.
- Extends policy/session routing tests so `rpc.fs.tail` uses `rpc:fs:tail` and remote tail requests inherit existing wrong-node/session/protocol/capability gates.

Closes #539
Refs #428, #426, #427

## Motivation
#539 needs a read-only tail/follow foundation for remote node files without opening mutation verbs or shell escape hatches. This keeps the implementation on the existing File RPC/node-link path instead of inventing a parallel file access surface.

## The Case Against
- The HTTP follow response is intentionally narrow text streaming, not a stable CLI gateway command or browser UI. If callers need structured chunk metadata over HTTP, this may need a later versioned endpoint rather than expanding this one.
- Follow uses bounded polling instead of filesystem watchers. That is simpler and avoids wedging on platform watcher behavior, but very bursty append patterns may skip older appended bytes when they exceed `maxFollowChunkBytes`; the chunk reports `skippedBytes`/`truncatedBytes` so callers can detect that.
- Tail content is decoded as UTF-8 after byte slicing from the end of the file, matching existing read semantics but not guaranteeing perfect character-boundary alignment for arbitrary binary/non-UTF8 files.

## Verification
- `npm test -- test/file-rpc.test.ts test/node-link-rpc-host.test.ts test/hub-node-session-routing.test.ts test/hub-policy-evaluator.test.ts` — 69/69 passed
- `npm run check` — passed with existing warning-only lint noise
- `npm run build` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tail operation for file RPC to read file content from the end, with optional follow mode to stream live updates.
  * Implemented bounded buffering with backpressure handling for streaming operations.

* **Tests**
  * Added comprehensive test coverage for tail operations, follow streaming lifecycle, and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->