### PR TITLE
Expose operator security posture in hub UI

### DIFF
--- a/docs/SECURITY_POLICY.md
+++ b/docs/SECURITY_POLICY.md
@@ -42,6 +42,12 @@ Audit storage is intentionally unbounded in this slice: Relay does not yet enfor
 
 Audit write failure policy is fail-closed for prod trust tier or destructive/high-risk capability scope. Low-tier read-only degradation is allowed only as an explicit visible degraded state; silent audit bypasses are not acceptable.
 
+## Operator visibility
+
+The hub UI surfaces each paired node's trust tier, ACL posture, scope, capability readiness, and high-risk summary from the node summary returned by `/hub/nodes`. Confirmation prompts also show the selected node, trust tier, policy ref, required bits grouped by allow/challenge/deny posture, and keep canonical params behind a details disclosure instead of making raw JSON the only security context.
+
+Audit visibility is intentionally minimal in this slice: the UI advertises the safe CLI verification path (`relay-ide audit verify --db ~/.config/relay-ide/security-audit.db`) rather than inventing a broad audit browser. There is no web audit dashboard, SIEM export, retention policy, or remote attestation claim yet.
+
 ## Hub ACL authority
 
 Hub ACL state is stored with the node registry record. Each ACL can express:

--- a/docs/SECURITY_POLICY.md
+++ b/docs/SECURITY_POLICY.md
@@ -44,7 +44,7 @@ Audit write failure policy is fail-closed for prod trust tier or destructive/hig
 
 ## Operator visibility
 
-The hub UI surfaces each paired node's trust tier, ACL posture, scope, capability readiness, and high-risk summary from the node summary returned by `/hub/nodes`. Confirmation prompts also show the selected node, trust tier, policy ref, required bits grouped by allow/challenge/deny posture, and keep canonical params behind a details disclosure instead of making raw JSON the only security context.
+The hub UI surfaces each paired node's trust tier, ACL allow/challenge/deny capability posture, scope, capability availability, and high-risk summary from the node summary returned by `/hub/nodes`. Confirmation prompts also show the selected node, trust tier, policy ref, required bits grouped by allow/challenge/deny/unknown posture, and keep canonical params behind a details disclosure instead of making raw JSON the only security context.
 
 Audit visibility is intentionally minimal in this slice: the UI advertises the safe CLI verification path (`relay-ide audit verify --db ~/.config/relay-ide/security-audit.db`) rather than inventing a broad audit browser. There is no web audit dashboard, SIEM export, retention policy, or remote attestation claim yet.
 

--- a/frontend/src/components/ConfirmationPrompt.css
+++ b/frontend/src/components/ConfirmationPrompt.css
@@ -14,6 +14,14 @@
   font-family: var(--font-mono);
 }
 
+.confirmation-prompt--danger {
+  border-color: var(--status-error);
+}
+
+.confirmation-prompt--safe {
+  border-color: color-mix(in srgb, var(--status-success) 55%, var(--border));
+}
+
 .confirmation-prompt__header {
   display: flex;
   align-items: flex-start;
@@ -81,18 +89,62 @@
   white-space: nowrap;
 }
 
+.confirmation-prompt__trust.trust-sandbox {
+  color: var(--status-info);
+}
+
+.confirmation-prompt__posture.posture-safe,
+.confirmation-prompt__trust.trust-dev {
+  color: var(--status-success);
+}
+
+.confirmation-prompt__trust.trust-prod,
+.confirmation-prompt__posture.posture-danger {
+  color: var(--status-error);
+}
+
+.confirmation-prompt__posture.posture-warning {
+  color: var(--status-warning);
+}
+
 .confirmation-prompt__bits {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: 6px;
   margin: 10px 0 12px;
 }
 
-.confirmation-prompt__bits span {
+.confirmation-prompt__bit-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.confirmation-prompt__bit-group span {
   padding: 2px 6px;
-  border: 1px solid color-mix(in srgb, var(--status-warning) 50%, transparent);
-  color: var(--status-warning);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
   font-size: var(--font-size-xs);
+}
+
+.confirmation-prompt__bit-group .confirmation-prompt__bit-group-label {
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.confirmation-prompt__bit-group.posture-safe span {
+  border-color: color-mix(in srgb, var(--status-success) 50%, var(--border));
+  color: var(--status-success);
+}
+
+.confirmation-prompt__bit-group.posture-warning span {
+  border-color: color-mix(in srgb, var(--status-warning) 50%, var(--border));
+  color: var(--status-warning);
+}
+
+.confirmation-prompt__bit-group.posture-danger span {
+  border-color: color-mix(in srgb, var(--status-error) 50%, var(--border));
+  color: var(--status-error);
 }
 
 .confirmation-prompt__field {

--- a/frontend/src/components/ConfirmationPrompt.css
+++ b/frontend/src/components/ConfirmationPrompt.css
@@ -18,6 +18,14 @@
   border-color: var(--status-error);
 }
 
+.confirmation-prompt--warning {
+  border-color: var(--status-warning);
+}
+
+.confirmation-prompt--muted {
+  border-color: var(--border);
+}
+
 .confirmation-prompt--safe {
   border-color: color-mix(in srgb, var(--status-success) 55%, var(--border));
 }

--- a/frontend/src/components/ConfirmationPrompt.tsx
+++ b/frontend/src/components/ConfirmationPrompt.tsx
@@ -348,6 +348,14 @@ export const ConfirmationPrompt: React.FC = () => {
             ))}
           </div>
         )}
+        {security.unknownBits.length > 0 && (
+          <div className="confirmation-prompt__bit-group posture-warning">
+            <span className="confirmation-prompt__bit-group-label">unknown</span>
+            {security.unknownBits.map((bit) => (
+              <span key={`unknown-${bit}`}>{bit}</span>
+            ))}
+          </div>
+        )}
       </div>
 
       <label className="confirmation-prompt__field">

--- a/frontend/src/components/ConfirmationPrompt.tsx
+++ b/frontend/src/components/ConfirmationPrompt.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import {
   approveConfirmationChallenge,
   fetchConfirmationChallenges,
   fetchConfirmationRequesterToken,
+  fetchHubNodes,
   type ConfirmationChallenge,
   type ConfirmationDecision,
 } from '../lib/api.js';
@@ -12,6 +14,7 @@ import {
   subscribeConfirmationRetries,
 } from '../lib/confirmation-retries.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
+import { deriveConfirmationSecurityVisibility } from '../lib/state/security-visibility.js';
 import TuiButton from './TuiButton.js';
 import './ConfirmationPrompt.css';
 
@@ -81,6 +84,13 @@ export const ConfirmationPrompt: React.FC = () => {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [retryVersion, setRetryVersion] = useState(0);
   const autoRetryingIds = useRef<Set<string>>(new Set());
+  const { data: nodes } = useQuery({
+    queryKey: ['hub-nodes'],
+    queryFn: fetchHubNodes,
+    staleTime: Infinity,
+    refetchOnWindowFocus: 'always',
+    retry: false,
+  });
 
   const refresh = async (): Promise<void> => {
     const next = await fetchConfirmationChallenges();
@@ -133,6 +143,7 @@ export const ConfirmationPrompt: React.FC = () => {
   const selected =
     visibleChallenges.find((challenge) => challenge.challengeId === selectedId) ?? visibleChallenges[0];
   const retryRegistration = selected ? getConfirmationRetry(selected.challengeId) : undefined;
+  const selectedNode = selected ? nodes?.find((node) => node.nodeId === selected.nodeId) : undefined;
 
   useEffect(() => {
     const approvedRetry = visibleChallenges.find(
@@ -174,6 +185,8 @@ export const ConfirmationPrompt: React.FC = () => {
   }, [visibleChallenges, retryVersion]);
 
   if (!selected) return null;
+
+  const security = deriveConfirmationSecurityVisibility(selected, selectedNode);
 
   const handleDecision = async (decision: ConfirmationDecision) => {
     setLoading(decision);
@@ -236,7 +249,11 @@ export const ConfirmationPrompt: React.FC = () => {
   const canonicalJson = JSON.stringify(selected.canonicalParams, null, 2);
 
   return (
-    <aside className="confirmation-prompt" aria-live="polite" aria-label="confirmation challenge prompt">
+    <aside
+      className={`confirmation-prompt confirmation-prompt--${security.tone}`}
+      aria-live="polite"
+      aria-label="confirmation challenge prompt"
+    >
       <div className="confirmation-prompt__header">
         <div>
           <div className="confirmation-prompt__eyebrow">operator confirmation</div>
@@ -266,7 +283,21 @@ export const ConfirmationPrompt: React.FC = () => {
       <dl className="confirmation-prompt__meta">
         <div>
           <dt>node</dt>
-          <dd>{selected.nodeId}</dd>
+          <dd title={security.nodeLabel}>{security.nodeLabel}</dd>
+        </div>
+        <div>
+          <dt>trust tier</dt>
+          <dd className={`confirmation-prompt__trust trust-${security.trustTier}`}>{security.trustTier}</dd>
+        </div>
+        <div>
+          <dt>policy posture</dt>
+          <dd className={`confirmation-prompt__posture posture-${security.tone}`}>{security.postureLabel}</dd>
+        </div>
+        <div>
+          <dt>policy ref</dt>
+          <dd title={security.policyRef ?? 'policy summary unavailable'}>
+            {security.policyRef ?? 'policy unavailable'}
+          </dd>
         </div>
         <div>
           <dt>intent</dt>
@@ -292,10 +323,31 @@ export const ConfirmationPrompt: React.FC = () => {
         </div>
       </dl>
 
-      <div className="confirmation-prompt__bits" aria-label="required capability bits">
-        {[...new Set([...selected.requiredBits, ...selected.challengeBits])].map((bit) => (
-          <span key={bit}>{bit}</span>
-        ))}
+      <div className="confirmation-prompt__bits" aria-label="capability policy posture">
+        {security.allowedBits.length > 0 && (
+          <div className="confirmation-prompt__bit-group posture-safe">
+            <span className="confirmation-prompt__bit-group-label">allow</span>
+            {security.allowedBits.map((bit) => (
+              <span key={`allow-${bit}`}>{bit}</span>
+            ))}
+          </div>
+        )}
+        {security.challengeBits.length > 0 && (
+          <div className="confirmation-prompt__bit-group posture-warning">
+            <span className="confirmation-prompt__bit-group-label">challenge</span>
+            {security.challengeBits.map((bit) => (
+              <span key={`challenge-${bit}`}>{bit}</span>
+            ))}
+          </div>
+        )}
+        {security.deniedBits.length > 0 && (
+          <div className="confirmation-prompt__bit-group posture-danger">
+            <span className="confirmation-prompt__bit-group-label">deny</span>
+            {security.deniedBits.map((bit) => (
+              <span key={`deny-${bit}`}>{bit}</span>
+            ))}
+          </div>
+        )}
       </div>
 
       <label className="confirmation-prompt__field">

--- a/frontend/src/components/HubNodeDashboard.css
+++ b/frontend/src/components/HubNodeDashboard.css
@@ -44,6 +44,14 @@
   border-color: color-mix(in srgb, var(--status-success) 35%, var(--border));
 }
 
+.hub-node-card.security-danger {
+  border-color: color-mix(in srgb, var(--status-error) 55%, var(--border));
+}
+
+.hub-node-card.security-warning:not(.security-danger) {
+  border-color: color-mix(in srgb, var(--status-warning) 45%, var(--border));
+}
+
 .hub-node-card.status-stale,
 .hub-node-card.status-revoked {
   border-color: color-mix(in srgb, var(--status-warning) 35%, var(--border));
@@ -113,6 +121,31 @@
   text-transform: lowercase;
 }
 
+.hub-node-trust-tier {
+  flex: 0 0 auto;
+  padding: 1px 5px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  line-height: 1.35;
+  text-transform: lowercase;
+}
+
+.hub-node-trust-tier.trust-sandbox {
+  border-color: color-mix(in srgb, var(--status-info) 45%, var(--border));
+  color: var(--status-info);
+}
+
+.hub-node-trust-tier.trust-dev {
+  border-color: color-mix(in srgb, var(--status-success) 40%, var(--border));
+  color: var(--status-success);
+}
+
+.hub-node-trust-tier.trust-prod {
+  border-color: color-mix(in srgb, var(--status-error) 65%, var(--border));
+  color: var(--status-error);
+}
+
 .hub-node-card-meta {
   color: var(--text-muted);
   font-size: var(--font-size-xs);
@@ -152,6 +185,49 @@
   gap: 4px;
   padding-left: var(--icon-slot-width);
   margin-top: 8px;
+}
+
+.hub-node-security {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding-left: var(--icon-slot-width);
+  margin-top: 8px;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  line-height: 1.35;
+}
+
+.hub-node-security-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.hub-node-policy-posture,
+.hub-node-high-risk {
+  color: var(--text);
+}
+
+.hub-node-policy-posture.posture-safe,
+.hub-node-high-risk.posture-safe {
+  color: var(--status-success);
+}
+
+.hub-node-policy-posture.posture-warning,
+.hub-node-high-risk.posture-warning {
+  color: var(--status-warning);
+}
+
+.hub-node-policy-posture.posture-danger,
+.hub-node-high-risk.posture-danger {
+  color: var(--status-error);
+}
+
+.hub-node-security-ref {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hub-node-capability {

--- a/frontend/src/components/HubNodeDashboard.css
+++ b/frontend/src/components/HubNodeDashboard.css
@@ -224,6 +224,11 @@
   color: var(--status-error);
 }
 
+.hub-node-policy-posture.posture-muted,
+.hub-node-high-risk.posture-muted {
+  color: var(--text-muted);
+}
+
 .hub-node-security-ref {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/frontend/src/components/HubNodeDashboard.tsx
+++ b/frontend/src/components/HubNodeDashboard.tsx
@@ -51,6 +51,7 @@ export function HubNodeDashboard({
               'hub-node-card',
               `status-${row.statusTone}`,
               row.attachable ? 'attachable' : 'blocked',
+              `security-${row.security.tone}`,
             ]
               .filter(Boolean)
               .join(' ')}
@@ -63,6 +64,9 @@ export function HubNodeDashboard({
               <div className="hub-node-card-text">
                 <div className="hub-node-card-title-row">
                   <span className="hub-node-card-title">{row.displayName}</span>
+                  <span className={`hub-node-trust-tier trust-${row.security.trustTier}`}>
+                    {row.security.trustTier}
+                  </span>
                   <span className="hub-node-status-label">{row.status}</span>
                 </div>
                 <div className="hub-node-card-meta">{row.hostLabel}</div>
@@ -78,6 +82,26 @@ export function HubNodeDashboard({
             {row.versionWarning && (
               <div className="hub-node-warning">{row.versionWarning}</div>
             )}
+
+            <div className="hub-node-security" aria-label={`${row.displayName} security posture`}>
+              <div className="hub-node-security-row">
+                <span className={`hub-node-policy-posture posture-${row.security.tone}`}>
+                  {row.security.postureLabel}
+                </span>
+                <span>{row.security.scopeLabel}</span>
+              </div>
+              <div className="hub-node-security-row">
+                <span className={`hub-node-high-risk posture-${row.security.tone}`}>
+                  {row.security.highRiskLabel}
+                </span>
+                <span>{row.security.auditLabel}</span>
+              </div>
+              {row.security.policyRef && (
+                <div className="hub-node-security-ref" title={row.security.policyRef}>
+                  policy {row.security.policyRef}
+                </div>
+              )}
+            </div>
 
             <div className="hub-node-capabilities" aria-label={`${row.displayName} capabilities`}>
               {row.capabilityHints.map((hint) => (

--- a/frontend/src/lib/state/node-dashboard.ts
+++ b/frontend/src/lib/state/node-dashboard.ts
@@ -4,6 +4,10 @@ import {
   type HubNodeSummary,
   type NodeCapabilityStatus,
 } from '../../../../shared/relay-node-protocol.js';
+import {
+  deriveNodeSecurityVisibility,
+  type NodeSecurityVisibility,
+} from './security-visibility.js';
 
 type CapabilityTone = NodeCapabilityStatus;
 
@@ -26,6 +30,7 @@ export interface HubNodeDashboardRow {
   protocolVersion: string;
   versionWarning: string | null;
   capabilityHints: HubNodeCapabilityHint[];
+  security: NodeSecurityVisibility;
   attachable: boolean;
   workReadiness: string;
   disabledReason: string | null;
@@ -161,6 +166,7 @@ export function deriveHubNodeDashboardRows(
 
   return nodes.map((node) => {
     const hints = capabilityHints(node);
+    const security = deriveNodeSecurityVisibility(node);
     const reason = disabledReason(node, hints);
     const route = node.connection?.route ?? 'unknown';
     const routeStatus = node.connection?.status ?? node.status;
@@ -182,6 +188,7 @@ export function deriveHubNodeDashboardRows(
       protocolVersion: node.protocolVersion,
       versionWarning,
       capabilityHints: hints,
+      security,
       attachable: reason === null,
       workReadiness: reason === null ? 'ready to work' : 'blocked',
       disabledReason: reason,
@@ -204,6 +211,10 @@ export function hubNodeDashboardSummary(
   const blockedByCapabilities = rows.filter(
     (row) => !row.attachable && row.disabledReason?.startsWith('work disabled:')
   ).length;
+  const policyUnavailable = rows.filter((row) => row.security.policyRef === null).length;
+  const prodHighRisk = rows.filter(
+    (row) => row.security.trustTier === 'prod' && row.security.tone === 'danger'
+  ).length;
 
-  return `${ready}/${rows.length} nodes ready · ${blockedByCapabilities} blocked by capabilities · ${offlineOrStale} offline/stale`;
+  return `${ready}/${rows.length} nodes ready · ${blockedByCapabilities} blocked by capabilities · ${offlineOrStale} offline/stale · ${policyUnavailable} policy unavailable · ${prodHighRisk} prod high-risk`;
 }

--- a/frontend/src/lib/state/node-dashboard.ts
+++ b/frontend/src/lib/state/node-dashboard.ts
@@ -93,6 +93,8 @@ function disabledReason(
   if (node.status === 'revoked') return 'not attachable: node was revoked';
   if (node.status === 'offline') return 'not attachable: node is offline';
   if (node.status === 'stale') return 'not attachable: heartbeat is stale';
+  if (node.trust?.policy?.revokedAt) return 'work disabled: policy revoked';
+  if (node.trust?.policy?.supersededBy) return 'work disabled: policy superseded';
 
   const blockers = readinessCapabilities.flatMap((key) => {
     const hint = capabilityHints.find((candidate) => candidate.key === key);

--- a/frontend/src/lib/state/security-visibility.ts
+++ b/frontend/src/lib/state/security-visibility.ts
@@ -1,0 +1,154 @@
+import type { HubNodeSummary } from '../../../../shared/relay-node-protocol.js';
+import {
+  HIGH_RISK_CAPABILITIES,
+  RELAY_CAPABILITY_BITS,
+  type RelayCapabilityBit,
+  type RelayPolicyScope,
+  type RelayTrustTier,
+} from '../../../../shared/security-policy.js';
+import type { ConfirmationChallenge } from '../api.js';
+
+export type SecurityPostureTone = 'safe' | 'warning' | 'danger' | 'muted';
+
+export interface NodeSecurityVisibility {
+  trustTier: RelayTrustTier | 'unknown';
+  policyRef: string | null;
+  scopeLabel: string;
+  allowedBits: RelayCapabilityBit[];
+  challengeBits: RelayCapabilityBit[];
+  denyBits: RelayCapabilityBit[];
+  postureLabel: string;
+  highRiskLabel: string;
+  tone: SecurityPostureTone;
+  auditLabel: string;
+}
+
+export interface ConfirmationSecurityVisibility {
+  nodeLabel: string;
+  trustTier: RelayTrustTier | 'unknown';
+  policyRef: string | null;
+  postureLabel: string;
+  allowedBits: string[];
+  challengeBits: string[];
+  deniedBits: string[];
+  tone: SecurityPostureTone;
+}
+
+const HIGH_RISK_SET = new Set<string>(HIGH_RISK_CAPABILITIES);
+
+function unique<T extends string>(values: readonly T[]): T[] {
+  return Array.from(new Set(values));
+}
+
+function sortedKnownBits(values: readonly string[] | undefined): RelayCapabilityBit[] {
+  if (!values) return [];
+  const selected = new Set(values);
+  return RELAY_CAPABILITY_BITS.filter((bit) => selected.has(bit));
+}
+
+function trustTierForNode(node: HubNodeSummary): RelayTrustTier | 'unknown' {
+  return node.trust?.tier ?? node.trust?.policy?.trustTier ?? 'unknown';
+}
+
+export function formatPolicyScope(scope: RelayPolicyScope | undefined): string {
+  if (!scope) return 'scope unavailable';
+  if (scope.kind === 'workspace') {
+    const count = scope.workspaceIds?.length ?? 0;
+    return count > 0 ? `workspace scope · ${count} workspace${count === 1 ? '' : 's'}` : 'workspace scope';
+  }
+  if (scope.kind === 'repo') {
+    const count = scope.repoIds?.length ?? 0;
+    return count > 0 ? `repo scope · ${count} repo${count === 1 ? '' : 's'}` : 'repo scope';
+  }
+  if (scope.kind === 'path') {
+    const count = scope.pathPrefixes?.length ?? 0;
+    return count > 0 ? `path scope · ${count} prefix${count === 1 ? '' : 'es'}` : 'path scope';
+  }
+  return 'node scope';
+}
+
+export function deriveNodeSecurityVisibility(node: HubNodeSummary): NodeSecurityVisibility {
+  const trustTier = trustTierForNode(node);
+  const policy = node.trust?.policy;
+  if (!policy) {
+    return {
+      trustTier,
+      policyRef: null,
+      scopeLabel: 'policy unavailable',
+      allowedBits: [],
+      challengeBits: [],
+      denyBits: [],
+      postureLabel: 'policy unavailable · capability grants hidden',
+      highRiskLabel: 'audit: cli only · relay-ide audit verify',
+      tone: trustTier === 'prod' ? 'danger' : 'muted',
+      auditLabel: 'audit visibility: run relay-ide audit verify --db ~/.config/relay-ide/security-audit.db',
+    };
+  }
+
+  const allowedBits = sortedKnownBits(policy.allowed);
+  const challengeBits = sortedKnownBits(policy.requiresConfirmation);
+  const handled = new Set<string>([...allowedBits, ...challengeBits]);
+  const denyBits = RELAY_CAPABILITY_BITS.filter((bit) => !handled.has(bit));
+  const highRiskAllowed = allowedBits.filter((bit) => HIGH_RISK_SET.has(bit));
+  const highRiskChallenged = challengeBits.filter((bit) => HIGH_RISK_SET.has(bit));
+  const highRiskDenied = HIGH_RISK_CAPABILITIES.filter((bit) => denyBits.includes(bit));
+
+  let tone: SecurityPostureTone = 'safe';
+  let highRiskLabel = `${highRiskDenied.length}/${HIGH_RISK_CAPABILITIES.length} high-risk denied`;
+  if (trustTier === 'prod' && highRiskChallenged.length > 0) {
+    tone = 'danger';
+    highRiskLabel = `prod high-risk: ${highRiskChallenged.length} require challenge`;
+  } else if (highRiskAllowed.length > 0) {
+    tone = 'warning';
+    highRiskLabel = `${highRiskAllowed.length} high-risk silently allowed`;
+  } else if (challengeBits.length > 0) {
+    tone = 'warning';
+  }
+
+  return {
+    trustTier,
+    policyRef: policy.ref,
+    scopeLabel: formatPolicyScope(policy.scope),
+    allowedBits,
+    challengeBits,
+    denyBits,
+    postureLabel: `allow ${allowedBits.length} · challenge ${challengeBits.length} · deny ${denyBits.length}`,
+    highRiskLabel,
+    tone,
+    auditLabel: 'audit visibility: cli only · relay-ide audit verify',
+  };
+}
+
+export function deriveConfirmationSecurityVisibility(
+  challenge: ConfirmationChallenge,
+  node?: HubNodeSummary
+): ConfirmationSecurityVisibility {
+  const policy = node?.trust.policy;
+  const trustTier = node ? trustTierForNode(node) : 'unknown';
+  const challengeBits = unique([...challenge.challengeBits]);
+  const requiredBits = unique([...challenge.requiredBits]);
+  const allowedByPolicy = new Set<string>(policy?.allowed ?? []);
+  const challenged = new Set<string>(challengeBits);
+  const allowedBits = requiredBits.filter((bit) => allowedByPolicy.has(bit) && !challenged.has(bit));
+  const deniedBits = policy
+    ? requiredBits.filter((bit) => !allowedByPolicy.has(bit) && !challenged.has(bit))
+    : [];
+  const postureLabel = challengeBits.length > 0
+    ? `challenge required · allow ${allowedBits.length} · challenge ${challengeBits.length} · deny ${deniedBits.length}`
+    : deniedBits.length > 0
+      ? `denied by policy · allow ${allowedBits.length} · deny ${deniedBits.length}`
+      : `allowed by policy · allow ${allowedBits.length}`;
+  const highRiskChallenge = challengeBits.some((bit) => HIGH_RISK_SET.has(bit));
+  const tone: SecurityPostureTone = trustTier === 'prod' || highRiskChallenge ? 'danger' : challengeBits.length > 0 ? 'warning' : 'safe';
+
+  return {
+    nodeLabel: node?.displayName ? `${node.displayName} (${challenge.nodeId})` : challenge.nodeId,
+    trustTier,
+    policyRef: policy?.ref ?? null,
+    postureLabel,
+    allowedBits,
+    challengeBits,
+    deniedBits,
+    tone,
+  };
+}

--- a/frontend/src/lib/state/security-visibility.ts
+++ b/frontend/src/lib/state/security-visibility.ts
@@ -31,6 +31,7 @@ export interface ConfirmationSecurityVisibility {
   allowedBits: string[];
   challengeBits: string[];
   deniedBits: string[];
+  unknownBits: string[];
   tone: SecurityPostureTone;
 }
 
@@ -48,6 +49,13 @@ function sortedKnownBits(values: readonly string[] | undefined): RelayCapability
 
 function trustTierForNode(node: HubNodeSummary): RelayTrustTier | 'unknown' {
   return node.trust?.tier ?? node.trust?.policy?.trustTier ?? 'unknown';
+}
+
+function policyLifecycleDenyLabel(policy: HubNodeSummary['trust']['policy']): string | null {
+  if (!policy) return null;
+  if (policy.revokedAt) return 'policy revoked';
+  if (policy.supersededBy) return 'policy superseded';
+  return null;
 }
 
 export function formatPolicyScope(scope: RelayPolicyScope | undefined): string {
@@ -87,6 +95,21 @@ export function deriveNodeSecurityVisibility(node: HubNodeSummary): NodeSecurity
 
   const allowedBits = sortedKnownBits(policy.allowed);
   const challengeBits = sortedKnownBits(policy.requiresConfirmation);
+  const lifecycleDenyLabel = policyLifecycleDenyLabel(policy);
+  if (lifecycleDenyLabel) {
+    return {
+      trustTier,
+      policyRef: policy.ref,
+      scopeLabel: formatPolicyScope(policy.scope),
+      allowedBits: [],
+      challengeBits: [],
+      denyBits: [...RELAY_CAPABILITY_BITS],
+      postureLabel: `${lifecycleDenyLabel} · deny ${RELAY_CAPABILITY_BITS.length}`,
+      highRiskLabel: `${lifecycleDenyLabel}: backend denies all capabilities`,
+      tone: 'danger',
+      auditLabel: 'audit visibility: cli only · relay-ide audit verify',
+    };
+  }
   const handled = new Set<string>([...allowedBits, ...challengeBits]);
   const denyBits = RELAY_CAPABILITY_BITS.filter((bit) => !handled.has(bit));
   const highRiskAllowed = allowedBits.filter((bit) => HIGH_RISK_SET.has(bit));
@@ -123,23 +146,50 @@ export function deriveConfirmationSecurityVisibility(
   challenge: ConfirmationChallenge,
   node?: HubNodeSummary
 ): ConfirmationSecurityVisibility {
-  const policy = node?.trust.policy;
+  const policy = node?.trust?.policy;
   const trustTier = node ? trustTierForNode(node) : 'unknown';
   const challengeBits = unique([...challenge.challengeBits]);
   const requiredBits = unique([...challenge.requiredBits]);
+  const requiredNonChallengedBits = requiredBits.filter((bit) => !challengeBits.includes(bit));
+  const lifecycleDenyLabel = policyLifecycleDenyLabel(policy);
+  if (lifecycleDenyLabel) {
+    return {
+      nodeLabel: node?.displayName ? `${node.displayName} (${challenge.nodeId})` : challenge.nodeId,
+      trustTier,
+      policyRef: policy?.ref ?? null,
+      postureLabel: `${lifecycleDenyLabel} · deny ${requiredBits.length}`,
+      allowedBits: [],
+      challengeBits: [],
+      deniedBits: requiredBits,
+      unknownBits: [],
+      tone: 'danger',
+    };
+  }
   const allowedByPolicy = new Set<string>(policy?.allowed ?? []);
   const challenged = new Set<string>(challengeBits);
   const allowedBits = requiredBits.filter((bit) => allowedByPolicy.has(bit) && !challenged.has(bit));
   const deniedBits = policy
     ? requiredBits.filter((bit) => !allowedByPolicy.has(bit) && !challenged.has(bit))
     : [];
-  const postureLabel = challengeBits.length > 0
-    ? `challenge required · allow ${allowedBits.length} · challenge ${challengeBits.length} · deny ${deniedBits.length}`
-    : deniedBits.length > 0
-      ? `denied by policy · allow ${allowedBits.length} · deny ${deniedBits.length}`
-      : `allowed by policy · allow ${allowedBits.length}`;
+  const unknownBits = policy ? [] : requiredNonChallengedBits;
+  const postureLabel = !policy
+    ? `policy unavailable · challenge ${challengeBits.length} · unknown ${unknownBits.length}`
+    : challengeBits.length > 0
+      ? `challenge required · allow ${allowedBits.length} · challenge ${challengeBits.length} · deny ${deniedBits.length}`
+      : deniedBits.length > 0
+        ? `denied by policy · allow ${allowedBits.length} · deny ${deniedBits.length}`
+        : `allowed by policy · allow ${allowedBits.length}`;
   const highRiskChallenge = challengeBits.some((bit) => HIGH_RISK_SET.has(bit));
-  const tone: SecurityPostureTone = trustTier === 'prod' || highRiskChallenge ? 'danger' : challengeBits.length > 0 ? 'warning' : 'safe';
+  const highRiskUnknown = unknownBits.some((bit) => HIGH_RISK_SET.has(bit));
+  const tone: SecurityPostureTone = !policy
+    ? highRiskChallenge || highRiskUnknown
+      ? 'danger'
+      : 'warning'
+    : trustTier === 'prod' || highRiskChallenge
+      ? 'danger'
+      : challengeBits.length > 0
+        ? 'warning'
+        : 'safe';
 
   return {
     nodeLabel: node?.displayName ? `${node.displayName} (${challenge.nodeId})` : challenge.nodeId,
@@ -149,6 +199,7 @@ export function deriveConfirmationSecurityVisibility(
     allowedBits,
     challengeBits,
     deniedBits,
+    unknownBits,
     tone,
   };
 }

--- a/test/stores/node-dashboard.test.ts
+++ b/test/stores/node-dashboard.test.ts
@@ -1,11 +1,35 @@
 import { describe, expect, it } from 'vitest';
 import type { HubNodeSummary } from '../../shared/relay-node-protocol.js';
 import {
+  createLegacyDefaultNodeAcl,
+  summarizeAcl,
+  type RelayCapabilityBit,
+  type RelayTrustTier,
+} from '../../shared/security-policy.js';
+import {
   deriveHubNodeDashboardRows,
   hubNodeDashboardSummary,
 } from '../../frontend/src/lib/state/node-dashboard.js';
+import { deriveConfirmationSecurityVisibility } from '../../frontend/src/lib/state/security-visibility.js';
+import type { ConfirmationChallenge } from '../../frontend/src/lib/api.js';
 
 const now = new Date('2026-01-02T03:05:00.000Z');
+const createdAt = '2026-01-02T03:00:00.000Z';
+
+function policy(
+  nodeId: string,
+  trustTier: RelayTrustTier = 'dev',
+  overrides: Partial<{ allowed: RelayCapabilityBit[]; requiresConfirmation: RelayCapabilityBit[] }> = {}
+) {
+  const acl = createLegacyDefaultNodeAcl({ nodeId, trustTier, createdAt });
+  return summarizeAcl({
+    ...acl,
+    grants: {
+      allowed: overrides.allowed ?? acl.grants.allowed,
+      requiresConfirmation: overrides.requiresConfirmation ?? acl.grants.requiresConfirmation,
+    },
+  });
+}
 
 function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
   return {
@@ -33,10 +57,44 @@ function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
       serviceManager: 'launchd',
       wsl: false,
     },
+    trust: {
+      state: 'trusted',
+      level: 'dev',
+      tier: 'dev',
+      policy: policy('node-1'),
+    },
+    credentialState: 'active',
+    version: {
+      state: 'compatible',
+      nodeProtocolVersion: '1.0',
+      hubProtocolVersion: '1.0',
+    },
     createdAt: '2026-01-02T03:00:00.000Z',
     pairedAt: '2026-01-02T03:00:00.000Z',
     lastSeenAt: '2026-01-02T03:04:30.000Z',
     credentialId: 'cred-1',
+    ...overrides,
+  };
+}
+
+function confirmationChallenge(
+  overrides: Partial<ConfirmationChallenge> = {}
+): ConfirmationChallenge {
+  return {
+    challengeId: 'challenge-1',
+    status: 'pending',
+    nodeId: 'node-1',
+    intent: { action: 'rpc.fs.delete', target: '/tmp/nope' },
+    requiredBits: ['session:read', 'rpc:fs:delete'],
+    challengeBits: ['rpc:fs:delete'],
+    canonicalParams: { action: 'rpc.fs.delete', path: '/tmp/nope' },
+    canonicalParamsHash: 'abc123',
+    createdAt,
+    expiresAt: '2026-01-02T03:10:00.000Z',
+    failedRedemptions: 0,
+    maxFailedRedemptions: 3,
+    reasonCode: 'POLICY_CONFIRMATION_REQUIRED',
+    message: 'confirmation required',
     ...overrides,
   };
 }
@@ -186,6 +244,83 @@ describe('hub node dashboard state', () => {
     expect(row.versionWarning).toBe('protocol 1.1 != hub 1.0');
   });
 
+  it('summarizes sandbox, dev, and prod policy posture with prod high-risk challenge distinct', () => {
+    const rows = deriveHubNodeDashboardRows(
+      [
+        node({
+          nodeId: 'sandbox-node',
+          displayName: 'sandbox node',
+          trust: {
+            state: 'trusted',
+            level: 'sandbox',
+            tier: 'sandbox',
+            policy: policy('sandbox-node', 'sandbox', {
+              allowed: ['session:read'],
+              requiresConfirmation: [],
+            }),
+          },
+        }),
+        node({
+          nodeId: 'dev-node',
+          displayName: 'dev node',
+          trust: {
+            state: 'trusted',
+            level: 'dev',
+            tier: 'dev',
+            policy: policy('dev-node', 'dev'),
+          },
+        }),
+        node({
+          nodeId: 'prod-node',
+          displayName: 'prod node',
+          trust: {
+            state: 'trusted',
+            level: 'prod',
+            tier: 'prod',
+            policy: policy('prod-node', 'prod', {
+              allowed: ['session:read'],
+              requiresConfirmation: ['rpc:fs:delete', 'pty:exec:arbitrary'],
+            }),
+          },
+        }),
+      ],
+      { now }
+    );
+
+    expect(rows.map((row) => [row.security.trustTier, row.security.postureLabel])).toEqual([
+      ['sandbox', 'allow 1 · challenge 0 · deny 14'],
+      ['dev', 'allow 8 · challenge 0 · deny 7'],
+      ['prod', 'allow 1 · challenge 2 · deny 12'],
+    ]);
+    expect(rows[2].security).toMatchObject({
+      tone: 'danger',
+      highRiskLabel: 'prod high-risk: 2 require challenge',
+    });
+  });
+
+  it('shows an honest audit cli affordance when policy visibility is unavailable', () => {
+    const [row] = deriveHubNodeDashboardRows(
+      [
+        node({
+          trust: {
+            state: 'paired',
+            level: 'standard',
+            warning: 'legacy pairing without acl summary',
+          },
+        }),
+      ],
+      { now }
+    );
+
+    expect(row.security).toMatchObject({
+      trustTier: 'unknown',
+      policyRef: null,
+      postureLabel: 'policy unavailable · capability grants hidden',
+      highRiskLabel: 'audit: cli only · relay-ide audit verify',
+      auditLabel: 'audit visibility: run relay-ide audit verify --db ~/.config/relay-ide/security-audit.db',
+    });
+  });
+
   it('summarizes which machines can currently do work', () => {
     const summary = hubNodeDashboardSummary(
       [
@@ -203,7 +338,40 @@ describe('hub node dashboard state', () => {
     );
 
     expect(summary).toBe(
-      '1/3 nodes ready · 1 blocked by capabilities · 1 offline/stale'
+      '1/3 nodes ready · 1 blocked by capabilities · 1 offline/stale · 0 policy unavailable · 0 prod high-risk'
     );
+  });
+});
+
+describe('confirmation security visibility state', () => {
+  it('groups allow, challenge, and deny posture from challenge plus node policy', () => {
+    const view = deriveConfirmationSecurityVisibility(
+      confirmationChallenge({
+        requiredBits: ['session:read', 'rpc:fs:delete', 'rpc:git:write'],
+        challengeBits: ['rpc:fs:delete'],
+      }),
+      node({
+        trust: {
+          state: 'trusted',
+          level: 'prod',
+          tier: 'prod',
+          policy: policy('node-1', 'prod', {
+            allowed: ['session:read'],
+            requiresConfirmation: ['rpc:fs:delete'],
+          }),
+        },
+      })
+    );
+
+    expect(view).toMatchObject({
+      nodeLabel: 'dev mac (node-1)',
+      trustTier: 'prod',
+      policyRef: 'acl:node-1:1.0',
+      postureLabel: 'challenge required · allow 1 · challenge 1 · deny 1',
+      allowedBits: ['session:read'],
+      challengeBits: ['rpc:fs:delete'],
+      deniedBits: ['rpc:git:write'],
+      tone: 'danger',
+    });
   });
 });

--- a/test/stores/node-dashboard.test.ts
+++ b/test/stores/node-dashboard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { HubNodeSummary } from '../../shared/relay-node-protocol.js';
 import {
   createLegacyDefaultNodeAcl,
+  RELAY_CAPABILITY_BITS,
   summarizeAcl,
   type RelayCapabilityBit,
   type RelayTrustTier,
@@ -321,6 +322,43 @@ describe('hub node dashboard state', () => {
     });
   });
 
+  it('treats revoked and superseded policy summaries as backend-denied posture', () => {
+    const rows = deriveHubNodeDashboardRows(
+      [
+        node({
+          nodeId: 'revoked-node',
+          trust: {
+            state: 'trusted',
+            level: 'dev',
+            tier: 'dev',
+            policy: { ...policy('revoked-node'), revokedAt: createdAt },
+          },
+        }),
+        node({
+          nodeId: 'superseded-node',
+          trust: {
+            state: 'trusted',
+            level: 'dev',
+            tier: 'dev',
+            policy: { ...policy('superseded-node'), supersededBy: 'acl:superseding:1.0' },
+          },
+        }),
+      ],
+      { now }
+    );
+
+    expect(rows.map((row) => row.disabledReason)).toEqual([
+      'work disabled: policy revoked',
+      'work disabled: policy superseded',
+    ]);
+    expect(rows.map((row) => row.security.postureLabel)).toEqual([
+      `policy revoked · deny ${RELAY_CAPABILITY_BITS.length}`,
+      `policy superseded · deny ${RELAY_CAPABILITY_BITS.length}`,
+    ]);
+    expect(rows.map((row) => row.security.tone)).toEqual(['danger', 'danger']);
+    expect(rows.every((row) => row.security.denyBits.length === RELAY_CAPABILITY_BITS.length)).toBe(true);
+  });
+
   it('summarizes which machines can currently do work', () => {
     const summary = hubNodeDashboardSummary(
       [
@@ -371,6 +409,55 @@ describe('confirmation security visibility state', () => {
       allowedBits: ['session:read'],
       challengeBits: ['rpc:fs:delete'],
       deniedBits: ['rpc:git:write'],
+      unknownBits: [],
+      tone: 'danger',
+    });
+  });
+
+  it('preserves every required bit when the policy summary is unavailable', () => {
+    const view = deriveConfirmationSecurityVisibility(
+      confirmationChallenge({
+        requiredBits: ['session:read', 'rpc:fs:delete', 'rpc:git:write'],
+        challengeBits: ['rpc:fs:delete'],
+      })
+    );
+
+    expect(view).toMatchObject({
+      nodeLabel: 'node-1',
+      trustTier: 'unknown',
+      policyRef: null,
+      postureLabel: 'policy unavailable · challenge 1 · unknown 2',
+      allowedBits: [],
+      challengeBits: ['rpc:fs:delete'],
+      deniedBits: [],
+      unknownBits: ['session:read', 'rpc:git:write'],
+      tone: 'danger',
+    });
+  });
+
+  it('fails closed when a confirmation sees a revoked policy summary', () => {
+    const view = deriveConfirmationSecurityVisibility(
+      confirmationChallenge({
+        requiredBits: ['session:read', 'rpc:fs:delete'],
+        challengeBits: ['rpc:fs:delete'],
+      }),
+      node({
+        trust: {
+          state: 'trusted',
+          level: 'dev',
+          tier: 'dev',
+          policy: { ...policy('node-1'), revokedAt: createdAt },
+        },
+      })
+    );
+
+    expect(view).toMatchObject({
+      policyRef: 'acl:node-1:1.0',
+      postureLabel: 'policy revoked · deny 2',
+      allowedBits: [],
+      challengeBits: [],
+      deniedBits: ['session:read', 'rpc:fs:delete'],
+      unknownBits: [],
       tone: 'danger',
     });
   });


### PR DESCRIPTION
## Summary
- surface trust tier, ACL allow/challenge/deny counts, scope, high-risk posture, and CLI audit verification copy on paired-node cards
- add confirmation prompt security context: node label, trust tier, policy ref, policy posture, and capability bits grouped by allow/challenge/deny before the canonical params JSON
- document the intentionally minimal audit visibility affordance in `docs/SECURITY_POLICY.md`

Closes #543

## The case against
- This intentionally does not add a web audit browser or read audit DB rows. That keeps scope narrow, but operators still have to run `relay-ide audit verify` from a terminal for real audit verification.
- Confirmation prompts infer allow/deny grouping from the node policy summary plus the challenge payload. If a stale/pre-policy node summary is missing, the UI falls back to `unknown` / `policy unavailable` rather than pretending to know the posture.
- The hub node card is denser now. The copy is compact and DESIGN.md-compliant, but QA should check narrow/sidebar width overflow.

## Verification
- `npm test -- test/stores/node-dashboard.test.ts` — 10/10 passed
- `npm run check` — passed with existing warnings only
- `npm run build` — passed; Vite chunk-size warning remains baseline

## Manual QA path
Browser verification was not run in this worker because there is no seeded local hub-node/challenge fixture for sandbox/dev/prod + pending confirmation states without fabricating backend state. QA should verify:
1. hub UI with paired sandbox/dev/prod nodes shows trust tier chips, allow/challenge/deny posture, high-risk prod styling, capability chips, and audit CLI copy
2. confirmation prompt shows node label, trust tier, policy ref, allow/challenge/deny grouped bits, and canonical params still expandable
3. legacy/no-policy node summary shows honest `policy unavailable` and `relay-ide audit verify --db ~/.config/relay-ide/security-audit.db` copy
4. mobile/narrow width keeps chips readable and actions tappable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced confirmation prompts to display security visibility: trust tier, ACL posture, scope, and capability bits grouped by allow/challenge/deny status.
  * Added trust tier badges to hub node cards.
  * Added security posture display to hub node cards with threat-level styling.

* **Documentation**
  * Updated security policy with operator visibility requirements for hub UI features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->