### PR TITLE
feat: add generated Hermes CLI gateway smoke

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -734,10 +734,15 @@ function gatewayWsErrorCode(message: string): RelayCliGatewayErrorCode {
   return 'UPSTREAM_ERROR';
 }
 
-function gatewayOpenPtyWebSocket(
+interface GatewayPtyWebSocketHandle {
+  ws: WebSocket;
+  opened: Promise<WebSocket>;
+}
+
+function gatewayCreatePtyWebSocket(
   commandName: RelayCliGatewayCommand,
   target: GatewayPtyTarget
-): Promise<WebSocket> {
+): GatewayPtyWebSocketHandle {
   const token = gatewayRequiredToken(commandName);
   const port = gatewayWsPort();
   const ws = new WebSocket(`ws://127.0.0.1:${port}${target.wsPath}`, {
@@ -746,14 +751,14 @@ function gatewayOpenPtyWebSocket(
       'x-relay-cli-gateway': 'v1',
     },
   });
-  return new Promise((resolve) => {
-    let opened = false;
+  const opened = new Promise<WebSocket>((resolve) => {
+    let isOpen = false;
     ws.once('open', () => {
-      opened = true;
+      isOpen = true;
       resolve(ws);
     });
     ws.once('error', (error) => {
-      if (opened) return;
+      if (isOpen) return;
       const message = error instanceof Error ? error.message : String(error);
       printGatewayEnvelope(
         gatewayError(commandName, {
@@ -769,6 +774,7 @@ function gatewayOpenPtyWebSocket(
       );
     });
   });
+  return { ws, opened };
 }
 
 function gatewayTargetPayload(target: GatewayPtyTarget): Record<string, unknown> {
@@ -799,7 +805,7 @@ async function runGatewaySessionStream(sessionArgs: string[]): Promise<never> {
     300000
   );
   const target = await resolveGatewayPtyTarget(id, 'sessions.stream');
-  const ws = await gatewayOpenPtyWebSocket('sessions.stream', target);
+  const { ws, opened } = gatewayCreatePtyWebSocket('sessions.stream', target);
   let sequence = 0;
   let frames = 0;
   let bytesReceived = 0;
@@ -877,6 +883,7 @@ async function runGatewaySessionStream(sessionArgs: string[]): Promise<never> {
       })
     );
   });
+  await opened;
   await new Promise(() => {});
   process.exit(0);
 }
@@ -903,7 +910,7 @@ async function runGatewaySessionInput(sessionArgs: string[]): Promise<never> {
   const maxBytes =
     gatewayOptionalPositiveInt('sessions.input', sessionArgs, '--max-bytes', 1048576) ?? 65536;
   const target = await resolveGatewayPtyTarget(id, 'sessions.input');
-  const ws = await gatewayOpenPtyWebSocket('sessions.input', target);
+  const { ws, opened } = gatewayCreatePtyWebSocket('sessions.input', target);
   const bytesSent = Buffer.byteLength(input, 'utf8');
   let output = '';
   let bytesReceived = 0;
@@ -990,6 +997,7 @@ async function runGatewaySessionInput(sessionArgs: string[]): Promise<never> {
     fail(`PTY input stream error: ${message}`);
   });
 
+  await opened;
   ws.send(input, (error) => {
     if (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -242,11 +242,13 @@ File commands remain read-only. They must surface unavailable node, missing path
 
 `sessions hand-back` requires the latest intervention event id observed by the caller before restoring agent-driven control. Stale, unknown, disconnected, or unacknowledged intervention state returns typed errors instead of resuming blindly.
 
-## First generated adapter smoke
+## First generated adapter smokes
 
 The first #430 proof intentionally stops at one generated Claude-style tool/function bundle in `shared/cli-gateway-claude-tools.ts`. It reads `shared/cli-gateway-contract.ts` / `relay-ide v1 schema --json` shape and emits Anthropic-compatible tool definitions (`name`, `description`, `input_schema`) for only the hello-world path: `nodes.list`, `sessions.create`, `files.read`, and `sessions.detach`.
 
-The smoke runner is deliberately thin: generated definitions select the stable v1 CLI command, Relay's existing CLI gateway does the hub/node/File RPC work, and `sessions.detach` remains descriptor-only so it does not kill the underlying session. Production Claude/Codex/Hermes packages, streaming attach, subscriptions, write/delete/tail File RPC, arbitrary exec, and private node-link shortcuts remain deferred.
+The Hermes-facing smoke in `shared/cli-gateway-hermes-tools.ts` uses the same contract manifest to emit Hermes tool descriptors (`name`, `description`, `parameters`), MCP descriptors (`name`, `description`, `inputSchema`), and OpenAI-style function descriptors (`type: "function"`, `function.parameters`). Its smoke path adds the now-stable PTY exchange commands: `nodes.list`, `sessions.create`, `files.read`, `sessions.stream`, `sessions.input`, and `sessions.detach`.
+
+Both smoke runners are deliberately thin: generated definitions select stable v1 CLI commands, Relay's existing CLI gateway does the hub/node/File RPC/PTY work, and `sessions.detach` remains descriptor-only so it does not kill the underlying session. Production Claude/Codex/Hermes packages, event subscriptions beyond PTY output, multi-session orchestration, File RPC write/delete/tail, arbitrary exec, stdin-backed adapter streaming, and private node-link shortcuts remain deferred.
 
 ## Deferred work
 

--- a/shared/cli-gateway-hermes-tools.ts
+++ b/shared/cli-gateway-hermes-tools.ts
@@ -1,0 +1,305 @@
+import { execFile } from 'node:child_process';
+import type {
+  RelayCliGatewayCommand,
+  RelayCliGatewayContractManifest,
+  RelayCliGatewayEnvelope,
+  RelayJsonSchema,
+} from './cli-gateway-contract.js';
+import { RELAY_CLI_GATEWAY_CONTRACT } from './cli-gateway-contract.js';
+
+export const CLI_GATEWAY_HERMES_SMOKE_COMMANDS = [
+  'nodes.list',
+  'sessions.create',
+  'files.read',
+  'sessions.stream',
+  'sessions.input',
+  'sessions.detach',
+] as const satisfies readonly RelayCliGatewayCommand[];
+
+export type RelayHermesGatewaySmokeCommand = (typeof CLI_GATEWAY_HERMES_SMOKE_COMMANDS)[number];
+
+export interface RelayHermesGatewayMcpDescriptor {
+  name: string;
+  description: string;
+  inputSchema: RelayJsonSchema;
+}
+
+export interface RelayHermesGatewayFunctionDescriptor {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: RelayJsonSchema;
+  };
+}
+
+export interface RelayHermesGatewayToolDefinition {
+  name: string;
+  description: string;
+  parameters: RelayJsonSchema;
+  mcp: RelayHermesGatewayMcpDescriptor;
+  function: RelayHermesGatewayFunctionDescriptor;
+  relay: {
+    contract: RelayCliGatewayContractManifest['contract'];
+    contractVersion: RelayCliGatewayContractManifest['contractVersion'];
+    command: RelayCliGatewayCommand;
+    cli: readonly string[];
+    transport: string;
+    requiresAuth: boolean;
+    capabilityHints: readonly string[];
+  };
+}
+
+export interface RelayHermesGatewayRunnerOptions {
+  command?: string;
+  commandArgsPrefix?: readonly string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}
+
+type ResolvedRelayHermesGatewayRunnerOptions = Required<
+  Pick<RelayHermesGatewayRunnerOptions, 'command' | 'timeoutMs'>
+> &
+  Omit<RelayHermesGatewayRunnerOptions, 'command' | 'timeoutMs'>;
+
+export type RelayHermesGatewayToolResult = RelayCliGatewayEnvelope | RelayCliGatewayEnvelope[];
+
+export function relayHermesGatewayToolName(command: RelayCliGatewayCommand): string {
+  return `relay_gateway_${command.split('.').join('_')}`;
+}
+
+export function generateRelayHermesGatewayTools(
+  manifest: RelayCliGatewayContractManifest = RELAY_CLI_GATEWAY_CONTRACT,
+  commands: readonly RelayCliGatewayCommand[] = CLI_GATEWAY_HERMES_SMOKE_COMMANDS
+): RelayHermesGatewayToolDefinition[] {
+  return commands.map((command) => {
+    const spec = manifest.commandSchemas.find((entry) => entry.name === command);
+    if (!spec) throw new Error(`CLI gateway manifest is missing ${command}`);
+    const name = relayHermesGatewayToolName(spec.name);
+    const mcp: RelayHermesGatewayMcpDescriptor = {
+      name,
+      description: spec.summary,
+      inputSchema: spec.inputSchema,
+    };
+    const functionDescriptor: RelayHermesGatewayFunctionDescriptor = {
+      type: 'function',
+      function: {
+        name,
+        description: spec.summary,
+        parameters: spec.inputSchema,
+      },
+    };
+    return {
+      name,
+      description: spec.summary,
+      parameters: spec.inputSchema,
+      mcp,
+      function: functionDescriptor,
+      relay: {
+        contract: manifest.contract,
+        contractVersion: manifest.contractVersion,
+        command: spec.name,
+        cli: spec.cli,
+        transport: spec.transport,
+        requiresAuth: spec.requiresAuth,
+        capabilityHints: spec.capabilityHints,
+      },
+    };
+  });
+}
+
+export function generateRelayHermesGatewayMcpDescriptors(
+  manifest: RelayCliGatewayContractManifest = RELAY_CLI_GATEWAY_CONTRACT,
+  commands: readonly RelayCliGatewayCommand[] = CLI_GATEWAY_HERMES_SMOKE_COMMANDS
+): RelayHermesGatewayMcpDescriptor[] {
+  return generateRelayHermesGatewayTools(manifest, commands).map((tool) => tool.mcp);
+}
+
+export function generateRelayHermesGatewayFunctionDescriptors(
+  manifest: RelayCliGatewayContractManifest = RELAY_CLI_GATEWAY_CONTRACT,
+  commands: readonly RelayCliGatewayCommand[] = CLI_GATEWAY_HERMES_SMOKE_COMMANDS
+): RelayHermesGatewayFunctionDescriptor[] {
+  return generateRelayHermesGatewayTools(manifest, commands).map((tool) => tool.function);
+}
+
+export class RelayHermesGatewayToolRunner {
+  private readonly toolsByName: Map<string, RelayHermesGatewayToolDefinition>;
+  private readonly options: ResolvedRelayHermesGatewayRunnerOptions;
+
+  constructor(
+    tools: readonly RelayHermesGatewayToolDefinition[],
+    options: RelayHermesGatewayRunnerOptions = {}
+  ) {
+    this.toolsByName = new Map(tools.map((tool) => [tool.name, tool]));
+    const resolved: ResolvedRelayHermesGatewayRunnerOptions = {
+      command: options.command ?? 'relay-ide',
+      commandArgsPrefix: options.commandArgsPrefix ?? [],
+      timeoutMs: options.timeoutMs ?? 10_000,
+    };
+    if (options.cwd !== undefined) resolved.cwd = options.cwd;
+    if (options.env !== undefined) resolved.env = options.env;
+    this.options = resolved;
+  }
+
+  async callTool(
+    name: string,
+    input: Record<string, unknown> = {}
+  ): Promise<RelayHermesGatewayToolResult> {
+    const tool = this.toolsByName.get(name);
+    if (!tool) throw new Error(`unknown generated Relay Hermes gateway tool: ${name}`);
+    const gatewayArgs = gatewayArgsForGeneratedTool(tool, input);
+    return await execRelayGatewayTool(this.options, gatewayArgs);
+  }
+}
+
+function gatewayArgsForGeneratedTool(
+  tool: RelayHermesGatewayToolDefinition,
+  input: Record<string, unknown>
+): string[] {
+  const cliArgs = tool.relay.cli.slice(1);
+  if (tool.relay.command === 'sessions.create') {
+    return replaceCliPlaceholder(cliArgs, '<json>', JSON.stringify(input));
+  }
+  if (tool.relay.command === 'files.read') {
+    return appendOptionalFlags(replaceGatewayInputPlaceholders(cliArgs, input), input, [
+      ['nodeId', '--node-id'],
+      ['cwd', '--cwd'],
+      ['maxBytes', '--max-bytes'],
+      ['maxLines', '--max-lines'],
+      ['confirmationToken', '--confirmation-token'],
+    ]);
+  }
+  if (tool.relay.command === 'sessions.stream') {
+    return appendOptionalFlags(replaceGatewayInputPlaceholders(cliArgs, input), input, [
+      ['maxEvents', '--max-events'],
+      ['maxBytes', '--max-bytes'],
+      ['idleTimeoutMs', '--idle-timeout-ms'],
+    ]);
+  }
+  if (tool.relay.command === 'sessions.input') {
+    return gatewaySessionInputArgs(input);
+  }
+  return replaceGatewayInputPlaceholders(cliArgs, input);
+}
+
+function gatewaySessionInputArgs(input: Record<string, unknown>): string[] {
+  const id = requiredStringInput(input, ['id', 'sessionId'], '<session-id>');
+  const args = ['v1', 'sessions', 'input', '--id', id];
+  if (typeof input['data'] === 'string') {
+    args.push('--data', input['data']);
+  } else if (typeof input['dataBase64'] === 'string') {
+    args.push('--data-base64', input['dataBase64']);
+  } else if (input['stdin'] === true) {
+    throw new Error('generated Relay Hermes gateway smoke runner does not support stdin input');
+  } else {
+    throw new Error('generated Relay Hermes gateway tool input must include data or dataBase64');
+  }
+  for (const [field, flag] of [
+    ['waitFor', '--wait-for'],
+    ['timeoutMs', '--timeout-ms'],
+    ['maxBytes', '--max-bytes'],
+  ] as const) {
+    const value = input[field];
+    if (value === undefined) continue;
+    if (typeof value !== 'string' && typeof value !== 'number') {
+      throw new Error(`generated Relay CLI tool input ${field} must be a string or number`);
+    }
+    args.push(flag, String(value));
+  }
+  args.push('--json');
+  return args;
+}
+
+function replaceGatewayInputPlaceholders(
+  cliArgs: readonly string[],
+  input: Record<string, unknown>
+): string[] {
+  return cliArgs.map((arg) => {
+    if (arg === '<session-id>') return requiredStringInput(input, ['id', 'sessionId'], arg);
+    if (arg === '<path>') return requiredStringInput(input, ['path'], arg);
+    if (arg === '<text>') return requiredStringInput(input, ['data'], arg);
+    return arg;
+  });
+}
+
+function replaceCliPlaceholder(
+  cliArgs: readonly string[],
+  placeholder: string,
+  value: string
+): string[] {
+  return cliArgs.map((arg) => (arg === placeholder ? value : arg));
+}
+
+function requiredStringInput(
+  input: Record<string, unknown>,
+  keys: readonly string[],
+  placeholder: string
+): string {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  throw new Error(`generated Relay CLI tool input must include ${keys.join(' or ')} for ${placeholder}`);
+}
+
+function appendOptionalFlags(
+  cliArgs: string[],
+  input: Record<string, unknown>,
+  fields: readonly (readonly [string, string])[]
+): string[] {
+  const insertion = cliArgs.lastIndexOf('--json');
+  const args = cliArgs.slice();
+  const flags: string[] = [];
+  for (const [field, flag] of fields) {
+    const value = input[field];
+    if (value === undefined) continue;
+    if (typeof value !== 'string' && typeof value !== 'number') {
+      throw new Error(`generated Relay CLI tool input ${field} must be a string or number`);
+    }
+    flags.push(flag, String(value));
+  }
+  if (insertion === -1 || flags.length === 0) return args.concat(flags);
+  args.splice(insertion, 0, ...flags);
+  return args;
+}
+
+async function execRelayGatewayTool(
+  options: ResolvedRelayHermesGatewayRunnerOptions,
+  gatewayArgs: readonly string[]
+): Promise<RelayHermesGatewayToolResult> {
+  const args = [...(options.commandArgsPrefix ?? []), ...gatewayArgs];
+  const execOptions = {
+    encoding: 'utf8' as const,
+    env: { ...process.env, ...options.env },
+    timeout: options.timeoutMs,
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+  };
+  return await new Promise<RelayHermesGatewayToolResult>((resolve, reject) => {
+    execFile(options.command, args, execOptions, (error, stdout, stderr) => {
+      try {
+        resolve(parseGatewayStdout(stdout));
+      } catch (parseError) {
+        reject(error ?? parseError ?? new Error(stderr || 'Relay CLI gateway tool failed'));
+      }
+    });
+  });
+}
+
+function parseGatewayStdout(stdout: string): RelayHermesGatewayToolResult {
+  const trimmed = stdout.trim();
+  if (!trimmed) throw new Error('Relay CLI gateway tool produced no JSON output');
+  try {
+    return JSON.parse(trimmed) as RelayCliGatewayEnvelope;
+  } catch {
+    /* sessions.stream emits newline-delimited compact envelopes. */
+  }
+  const lines = trimmed.split(/\r?\n/).filter((line) => line.length > 0);
+  const parsed = lines.map((line) => JSON.parse(line) as RelayCliGatewayEnvelope);
+  if (parsed.length === 1) {
+    const first = parsed[0];
+    if (!first) throw new Error('Relay CLI gateway tool produced no JSON output');
+    return first;
+  }
+  return parsed;
+}

--- a/test/cli-gateway-hermes-tools.test.ts
+++ b/test/cli-gateway-hermes-tools.test.ts
@@ -1,0 +1,272 @@
+import { expect, test } from 'vitest';
+import * as http from 'node:http';
+import { WebSocketServer } from 'ws';
+import {
+  CLI_GATEWAY_HERMES_SMOKE_COMMANDS,
+  RelayHermesGatewayToolRunner,
+  generateRelayHermesGatewayFunctionDescriptors,
+  generateRelayHermesGatewayMcpDescriptors,
+  generateRelayHermesGatewayTools,
+} from '../shared/cli-gateway-hermes-tools.js';
+import { RELAY_CLI_GATEWAY_CONTRACT, commandSpec } from '../shared/cli-gateway-contract.js';
+
+type CapturedGatewayRequest = {
+  method: string | undefined;
+  url: string | undefined;
+  authorization: string | undefined;
+  marker: string | string[] | undefined;
+  capabilities: string | string[] | undefined;
+  body?: Record<string, unknown>;
+};
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing server address');
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  server.closeAllConnections?.();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test('generates Hermes tool, MCP, and function descriptors from the v1 contract', () => {
+  const tools = generateRelayHermesGatewayTools(RELAY_CLI_GATEWAY_CONTRACT);
+  expect(tools.map((tool) => tool.relay.command)).toEqual([...CLI_GATEWAY_HERMES_SMOKE_COMMANDS]);
+  expect(tools.map((tool) => tool.name)).toEqual([
+    'relay_gateway_nodes_list',
+    'relay_gateway_sessions_create',
+    'relay_gateway_files_read',
+    'relay_gateway_sessions_stream',
+    'relay_gateway_sessions_input',
+    'relay_gateway_sessions_detach',
+  ]);
+
+  const readTool = tools.find((tool) => tool.relay.command === 'files.read');
+  expect(readTool?.parameters).toBe(commandSpec('files.read').inputSchema);
+  expect(readTool?.mcp.inputSchema).toBe(commandSpec('files.read').inputSchema);
+  expect(readTool?.function.function.parameters).toBe(commandSpec('files.read').inputSchema);
+  expect(readTool?.relay).toMatchObject({
+    contract: 'v1',
+    contractVersion: '1.0',
+    command: 'files.read',
+    requiresAuth: true,
+  });
+
+  const mcpDescriptors = generateRelayHermesGatewayMcpDescriptors(RELAY_CLI_GATEWAY_CONTRACT);
+  const functionDescriptors = generateRelayHermesGatewayFunctionDescriptors(RELAY_CLI_GATEWAY_CONTRACT);
+  expect(mcpDescriptors.map((descriptor) => descriptor.inputSchema)).toEqual(
+    tools.map((tool) => tool.parameters)
+  );
+  expect(functionDescriptors).toEqual(tools.map((tool) => tool.function));
+});
+
+test('generated Hermes CLI gateway tools run the fake hub/node adapter smoke over public v1 commands', async () => {
+  const tools = generateRelayHermesGatewayTools(RELAY_CLI_GATEWAY_CONTRACT);
+  const captured: CapturedGatewayRequest[] = [];
+  const upgrades: Array<{ url?: string; cookie?: string; marker?: string | string[] }> = [];
+  const inputs: string[] = [];
+  let sessionAlive = false;
+  const session = {
+    id: 'remote-session-1',
+    globalSessionId: 'node-a:remote-session-1',
+    nodeId: 'node-a',
+    type: 'terminal',
+    agent: 'shell',
+    mode: 'pty',
+    cwd: '/fixture',
+    displayName: 'fixture terminal',
+    status: 'active',
+  };
+
+  const server = http.createServer((req, res) => {
+    const entry: CapturedGatewayRequest = {
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.authorization,
+      marker: req.headers['x-relay-cli-gateway'],
+      capabilities: req.headers['x-relay-capabilities'],
+    };
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const rawBody = Buffer.concat(chunks).toString('utf8');
+      if (rawBody) entry.body = JSON.parse(rawBody) as Record<string, unknown>;
+      captured.push(entry);
+      res.setHeader('content-type', 'application/json');
+
+      if (req.method === 'GET' && req.url === '/nodes') {
+        res.end(
+          JSON.stringify({
+            nodes: [{ nodeId: 'node-a', status: 'online', availability: 'available' }],
+          })
+        );
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/hub/nodes/node-a/sessions') {
+        sessionAlive = true;
+        res.statusCode = 201;
+        res.end(JSON.stringify(session));
+        return;
+      }
+      if (req.method === 'GET' && req.url === '/sessions/remote-session-1' && sessionAlive) {
+        res.end(JSON.stringify(session));
+        return;
+      }
+      if (
+        req.method === 'POST' &&
+        req.url === '/hub/nodes/node-a/sessions/remote-session-1/files/read'
+      ) {
+        res.end(
+          JSON.stringify({
+            operation: 'read',
+            root: '/fixture',
+            cwd: '/fixture',
+            path: '/fixture/hello.txt',
+            encoding: 'utf8',
+            content: 'hello hermes gateway\n',
+            bytesRead: 21,
+            truncatedBytes: false,
+            truncatedLines: false,
+            maxBytes: entry.body?.['maxBytes'] ?? 32768,
+            maxLines: entry.body?.['maxLines'],
+          })
+        );
+        return;
+      }
+      if (req.method === 'DELETE') sessionAlive = false;
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: { code: 'NOT_FOUND', message: 'not found' } }));
+    });
+  });
+  const wss = new WebSocketServer({ noServer: true });
+  server.on('upgrade', (req, socket, head) => {
+    upgrades.push({
+      url: req.url,
+      cookie: req.headers.cookie,
+      marker: req.headers['x-relay-cli-gateway'],
+    });
+    if (req.url !== '/nodes/node-a/ws/sessions/remote-session-1') {
+      socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      ws.send('stream-marker\n');
+      ws.on('message', (data) => {
+        const text = data.toString();
+        inputs.push(text);
+        ws.send(`echo:${text}`);
+      });
+    });
+  });
+
+  const port = await listen(server);
+  try {
+    const runner = new RelayHermesGatewayToolRunner(tools, {
+      command: process.execPath,
+      commandArgsPrefix: ['dist/bin/relay-ide.js'],
+      env: {
+        ...process.env,
+        RELAY_IDE_PORT: String(port),
+        RELAY_IDE_BROWSER_TOKEN: 'scoped-token',
+      },
+    });
+
+    const nodes = await runner.callTool('relay_gateway_nodes_list');
+    expect(nodes).toMatchObject({ ok: true, command: 'nodes.list' });
+    if (Array.isArray(nodes) || !nodes.ok) throw new Error('expected nodes.list to succeed');
+    expect((nodes.data as { nodes: unknown[] }).nodes).toHaveLength(1);
+
+    const created = await runner.callTool('relay_gateway_sessions_create', {
+      nodeId: 'node-a',
+      cwd: '/fixture',
+      type: 'terminal',
+    });
+    expect(created).toMatchObject({ ok: true, command: 'sessions.create' });
+    if (Array.isArray(created) || !created.ok) throw new Error('expected sessions.create to succeed');
+    expect(created.data).toMatchObject({ id: 'remote-session-1', nodeId: 'node-a' });
+
+    const read = await runner.callTool('relay_gateway_files_read', {
+      sessionId: 'remote-session-1',
+      path: 'hello.txt',
+      maxBytes: 64,
+      maxLines: 2,
+    });
+    expect(read).toMatchObject({ ok: true, command: 'files.read' });
+    if (Array.isArray(read) || !read.ok) throw new Error('expected files.read to succeed');
+    expect(read.data).toMatchObject({ content: 'hello hermes gateway\n', maxBytes: 64, maxLines: 2 });
+
+    const stream = await runner.callTool('relay_gateway_sessions_stream', {
+      id: 'remote-session-1',
+      maxEvents: 1,
+    });
+    if (!Array.isArray(stream)) throw new Error('expected sessions.stream to return NDJSON envelopes');
+    expect(stream[0]).toMatchObject({
+      ok: true,
+      command: 'sessions.stream',
+      data: { event: 'data', data: 'stream-marker\n', nodeId: 'node-a' },
+    });
+    expect(stream.at(-1)).toMatchObject({
+      ok: true,
+      command: 'sessions.stream',
+      data: { event: 'closed', frames: 1, truncated: false },
+    });
+
+    const input = await runner.callTool('relay_gateway_sessions_input', {
+      id: 'remote-session-1',
+      data: 'marker-input\n',
+      waitFor: 'echo:marker-input',
+    });
+    expect(input).toMatchObject({
+      ok: true,
+      command: 'sessions.input',
+      data: { matched: true, nodeId: 'node-a' },
+    });
+    if (Array.isArray(input) || !input.ok) throw new Error('expected sessions.input to succeed');
+    expect((input.data as { output: string }).output).toContain('echo:marker-input\n');
+
+    const detached = await runner.callTool('relay_gateway_sessions_detach', { id: 'remote-session-1' });
+    expect(detached).toMatchObject({ ok: true, command: 'sessions.detach' });
+    if (Array.isArray(detached) || !detached.ok) throw new Error('expected sessions.detach to succeed');
+    expect(detached.data).toMatchObject({ detached: true, killed: false });
+  } finally {
+    wss.close();
+    await close(server);
+  }
+
+  expect(sessionAlive).toBe(true);
+  expect(captured.map((entry) => `${entry.method} ${entry.url}`)).toEqual([
+    'GET /nodes',
+    'POST /hub/nodes/node-a/sessions',
+    'GET /sessions/remote-session-1',
+    'POST /hub/nodes/node-a/sessions/remote-session-1/files/read',
+    'GET /sessions/remote-session-1',
+    'GET /sessions/remote-session-1',
+    'GET /sessions/remote-session-1',
+  ]);
+  expect(captured.some((entry) => entry.method === 'DELETE')).toBe(false);
+  expect(captured.find((entry) => entry.url === '/nodes')).toMatchObject({
+    authorization: 'Bearer scoped-token',
+    marker: 'v1',
+    capabilities: 'session:read',
+  });
+  expect(captured.find((entry) => entry.url?.endsWith('/files/read'))?.body).toMatchObject({
+    path: 'hello.txt',
+    maxBytes: 64,
+    maxLines: 2,
+  });
+  expect(upgrades).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        url: '/nodes/node-a/ws/sessions/remote-session-1',
+        cookie: 'token=scoped-token',
+        marker: 'v1',
+      }),
+    ])
+  );
+  expect(inputs).toContain('marker-input\n');
+});


### PR DESCRIPTION
## Summary
- Adds generated Hermes-facing descriptors for the v1 CLI gateway smoke path: Hermes tool schema, MCP descriptors, and OpenAI-style function descriptors all sourced from `RELAY_CLI_GATEWAY_CONTRACT`.
- Adds a thin generated-tool runner that shells through public `relay-ide v1 ... --json` commands only, including the stable PTY `sessions.stream` / `sessions.input` exchange.
- Adds a fake hub/node smoke test covering nodes list, routed session create, read-only file read, PTY stream/input, descriptor-only detach, and no DELETE/kill fallback.
- Documents the Hermes smoke boundary and deferred production packaging/private-protocol work.

## Motivation
#544 is the next #430 adapter proof after the Claude-style generated bundle and CLI session I/O slices. This proves Hermes can consume the existing v1 gateway contract without a hand-maintained parallel schema or private `/hub/node-link` shortcut.

## The Case Against
This is intentionally still not a production Hermes adapter package. The runner is a smoke/example wrapper around the Relay CLI, not an orchestration layer, and it only maps the narrow adapter-proof command set. It also throws for `stdin: true` inputs in the smoke runner even though the contract exposes `--stdin`; the descriptor remains generated from the real contract, but production stdin streaming is deferred rather than faked here. A reviewer should reject this if they expected arbitrary exec, file mutation, subscriptions, multi-session lifecycle, or packaged Hermes integration.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Descriptor drift from v1 CLI gateway | Tests assert descriptor parameters/inputSchema/function parameters are the exact contract schema object from `commandSpec('files.read')`, and generation fails if a requested command is missing from the manifest. |
| Smoke accidentally bypasses public gateway | Runner builds argv from `spec.cli` and invokes `dist/bin/relay-ide.js v1 ... --json`; the fake harness asserts the public HTTP and PTY WebSocket paths reached by the CLI, not private node-link calls from the test. |
| Detach kills the underlying session | Smoke asserts no DELETE request occurs and the fake session remains alive after `sessions.detach`. |
| PTY I/O support regresses | Smoke covers `sessions.stream --max-events 1` and `sessions.input --wait-for` through the routed PTY WebSocket path. |

## Verification
- `npm run build:server`
- `npm test -- test/cli-gateway-hermes-tools.test.ts test/cli-gateway-claude-tools.test.ts test/cli-gateway-contract.test.ts test/browser-cli.test.ts` (22/22 passed)
- `npm run check` (passed; existing warnings only)
- `npm run build`
- `npm test -- test/cli-gateway-hermes-tools.test.ts` (2/2 passed after final build)

Closes #544
Refs #430, #429
