### PR TITLE
feat: add Codex CLI gateway adapter smoke

### DIFF
--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -248,7 +248,9 @@ The first #430 proof intentionally stops at one generated Claude-style tool/func
 
 The Hermes-facing smoke in `shared/cli-gateway-hermes-tools.ts` uses the same contract manifest to emit Hermes tool descriptors (`name`, `description`, `parameters`), MCP descriptors (`name`, `description`, `inputSchema`), and OpenAI-style function descriptors (`type: "function"`, `function.parameters`). Its smoke path adds the now-stable PTY exchange commands: `nodes.list`, `sessions.create`, `files.read`, `sessions.stream`, `sessions.input`, and `sessions.detach`.
 
-Both smoke runners are deliberately thin: generated definitions select stable v1 CLI commands, Relay's existing CLI gateway does the hub/node/File RPC/PTY work, and `sessions.detach` remains descriptor-only so it does not kill the underlying session. Production Claude/Codex/Hermes packages, event subscriptions beyond PTY output, multi-session orchestration, File RPC write/delete/tail, arbitrary exec, stdin-backed adapter streaming, and private node-link shortcuts remain deferred.
+The Codex-facing smoke in `shared/cli-gateway-codex-tools.ts` derives the same command subset from the v1 manifest and emits Codex/OpenAI-compatible function descriptors in both common shapes: Chat Completions-style nested tools (`type: "function"`, `function.parameters`) and Responses-style flat function tools (`type: "function"`, `name`, `parameters`). Its fake hub/node example runs only public `relay-ide v1 ... --json` commands: `nodes.list`, scoped `sessions.create`, read-only `files.read`, bounded `sessions.stream`, `sessions.input`, and descriptor-only `sessions.detach`.
+
+These smoke runners are deliberately thin: generated definitions select stable v1 CLI commands, Relay's existing CLI gateway does the hub/node/File RPC/PTY work, and `sessions.detach` remains descriptor-only so it does not kill the underlying session. Production Claude/Codex/Hermes packages, Codex runtime packaging, event subscriptions beyond PTY output, multi-session orchestration, File RPC write/delete/tail, arbitrary exec, stdin-backed adapter streaming, and private node-link shortcuts remain deferred.
 
 ## Deferred work
 

--- a/shared/cli-gateway-codex-tools.ts
+++ b/shared/cli-gateway-codex-tools.ts
@@ -16,6 +16,12 @@ export const CLI_GATEWAY_CODEX_SMOKE_COMMANDS = [
   'sessions.detach',
 ] as const satisfies readonly RelayCliGatewayCommand[];
 
+const CODEX_SMOKE_DEFAULT_FILE_PATH = '.';
+const CODEX_SMOKE_DEFAULT_STREAM_MAX_EVENTS = 1;
+const CODEX_SMOKE_DEFAULT_STREAM_MAX_BYTES = 65536;
+const CODEX_SMOKE_DEFAULT_STREAM_IDLE_TIMEOUT_MS = 1000;
+const CODEX_SMOKE_EXEC_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
+
 export type RelayCodexGatewaySmokeCommand = (typeof CLI_GATEWAY_CODEX_SMOKE_COMMANDS)[number];
 
 export interface RelayCodexGatewayMcpDescriptor {
@@ -184,7 +190,8 @@ function gatewayArgsForGeneratedTool(
     return replaceCliPlaceholder(cliArgs, '<json>', JSON.stringify(input));
   }
   if (tool.relay.command === 'files.read') {
-    return appendOptionalFlags(replaceGatewayInputPlaceholders(cliArgs, input), input, [
+    const fileInput = { path: CODEX_SMOKE_DEFAULT_FILE_PATH, ...input };
+    return appendOptionalFlags(replaceGatewayInputPlaceholders(cliArgs, fileInput), fileInput, [
       ['nodeId', '--node-id'],
       ['cwd', '--cwd'],
       ['maxBytes', '--max-bytes'],
@@ -193,7 +200,13 @@ function gatewayArgsForGeneratedTool(
     ]);
   }
   if (tool.relay.command === 'sessions.stream') {
-    return appendOptionalFlags(replaceGatewayInputPlaceholders(cliArgs, input), input, [
+    const streamInput = {
+      maxEvents: CODEX_SMOKE_DEFAULT_STREAM_MAX_EVENTS,
+      maxBytes: CODEX_SMOKE_DEFAULT_STREAM_MAX_BYTES,
+      idleTimeoutMs: CODEX_SMOKE_DEFAULT_STREAM_IDLE_TIMEOUT_MS,
+      ...input,
+    };
+    return appendOptionalFlags(replaceGatewayInputPlaceholders(cliArgs, streamInput), streamInput, [
       ['maxEvents', '--max-events'],
       ['maxBytes', '--max-bytes'],
       ['idleTimeoutMs', '--idle-timeout-ms'],
@@ -294,6 +307,7 @@ async function execRelayGatewayTool(
   const execOptions = {
     encoding: 'utf8' as const,
     env: { ...process.env, ...options.env },
+    maxBuffer: CODEX_SMOKE_EXEC_MAX_BUFFER_BYTES,
     timeout: options.timeoutMs,
     ...(options.cwd ? { cwd: options.cwd } : {}),
   };

--- a/shared/cli-gateway-codex-tools.ts
+++ b/shared/cli-gateway-codex-tools.ts
@@ -1,0 +1,328 @@
+import { execFile } from 'node:child_process';
+import type {
+  RelayCliGatewayCommand,
+  RelayCliGatewayContractManifest,
+  RelayCliGatewayEnvelope,
+  RelayJsonSchema,
+} from './cli-gateway-contract.js';
+import { RELAY_CLI_GATEWAY_CONTRACT } from './cli-gateway-contract.js';
+
+export const CLI_GATEWAY_CODEX_SMOKE_COMMANDS = [
+  'nodes.list',
+  'sessions.create',
+  'files.read',
+  'sessions.stream',
+  'sessions.input',
+  'sessions.detach',
+] as const satisfies readonly RelayCliGatewayCommand[];
+
+export type RelayCodexGatewaySmokeCommand = (typeof CLI_GATEWAY_CODEX_SMOKE_COMMANDS)[number];
+
+export interface RelayCodexGatewayMcpDescriptor {
+  name: string;
+  description: string;
+  inputSchema: RelayJsonSchema;
+}
+
+export interface RelayCodexGatewayFunctionDescriptor {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: RelayJsonSchema;
+  };
+}
+
+export interface RelayCodexGatewayOpenAiToolDescriptor {
+  type: 'function';
+  name: string;
+  description: string;
+  parameters: RelayJsonSchema;
+}
+
+export interface RelayCodexGatewayToolDefinition {
+  name: string;
+  description: string;
+  parameters: RelayJsonSchema;
+  mcp: RelayCodexGatewayMcpDescriptor;
+  function: RelayCodexGatewayFunctionDescriptor;
+  openai: RelayCodexGatewayOpenAiToolDescriptor;
+  relay: {
+    contract: RelayCliGatewayContractManifest['contract'];
+    contractVersion: RelayCliGatewayContractManifest['contractVersion'];
+    command: RelayCliGatewayCommand;
+    cli: readonly string[];
+    transport: string;
+    requiresAuth: boolean;
+    capabilityHints: readonly string[];
+  };
+}
+
+export interface RelayCodexGatewayRunnerOptions {
+  command?: string;
+  commandArgsPrefix?: readonly string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+}
+
+type ResolvedRelayCodexGatewayRunnerOptions = Required<
+  Pick<RelayCodexGatewayRunnerOptions, 'command' | 'timeoutMs'>
+> &
+  Omit<RelayCodexGatewayRunnerOptions, 'command' | 'timeoutMs'>;
+
+export type RelayCodexGatewayToolResult = RelayCliGatewayEnvelope | RelayCliGatewayEnvelope[];
+
+export function relayCodexGatewayToolName(command: RelayCliGatewayCommand): string {
+  return `relay_codex_gateway_${command.split('.').join('_')}`;
+}
+
+export function generateRelayCodexGatewayTools(
+  manifest: RelayCliGatewayContractManifest = RELAY_CLI_GATEWAY_CONTRACT,
+  commands: readonly RelayCliGatewayCommand[] = CLI_GATEWAY_CODEX_SMOKE_COMMANDS
+): RelayCodexGatewayToolDefinition[] {
+  return commands.map((command) => {
+    const spec = manifest.commandSchemas.find((entry) => entry.name === command);
+    if (!spec) throw new Error(`CLI gateway manifest is missing ${command}`);
+    const name = relayCodexGatewayToolName(spec.name);
+    const mcp: RelayCodexGatewayMcpDescriptor = {
+      name,
+      description: spec.summary,
+      inputSchema: spec.inputSchema,
+    };
+    const functionDescriptor: RelayCodexGatewayFunctionDescriptor = {
+      type: 'function',
+      function: {
+        name,
+        description: spec.summary,
+        parameters: spec.inputSchema,
+      },
+    };
+    const openai: RelayCodexGatewayOpenAiToolDescriptor = {
+      type: 'function',
+      name,
+      description: spec.summary,
+      parameters: spec.inputSchema,
+    };
+    return {
+      name,
+      description: spec.summary,
+      parameters: spec.inputSchema,
+      mcp,
+      function: functionDescriptor,
+      openai,
+      relay: {
+        contract: manifest.contract,
+        contractVersion: manifest.contractVersion,
+        command: spec.name,
+        cli: spec.cli,
+        transport: spec.transport,
+        requiresAuth: spec.requiresAuth,
+        capabilityHints: spec.capabilityHints,
+      },
+    };
+  });
+}
+
+export function generateRelayCodexGatewayMcpDescriptors(
+  manifest: RelayCliGatewayContractManifest = RELAY_CLI_GATEWAY_CONTRACT,
+  commands: readonly RelayCliGatewayCommand[] = CLI_GATEWAY_CODEX_SMOKE_COMMANDS
+): RelayCodexGatewayMcpDescriptor[] {
+  return generateRelayCodexGatewayTools(manifest, commands).map((tool) => tool.mcp);
+}
+
+export function generateRelayCodexGatewayFunctionDescriptors(
+  manifest: RelayCliGatewayContractManifest = RELAY_CLI_GATEWAY_CONTRACT,
+  commands: readonly RelayCliGatewayCommand[] = CLI_GATEWAY_CODEX_SMOKE_COMMANDS
+): RelayCodexGatewayFunctionDescriptor[] {
+  return generateRelayCodexGatewayTools(manifest, commands).map((tool) => tool.function);
+}
+
+export function generateRelayCodexGatewayOpenAiToolDescriptors(
+  manifest: RelayCliGatewayContractManifest = RELAY_CLI_GATEWAY_CONTRACT,
+  commands: readonly RelayCliGatewayCommand[] = CLI_GATEWAY_CODEX_SMOKE_COMMANDS
+): RelayCodexGatewayOpenAiToolDescriptor[] {
+  return generateRelayCodexGatewayTools(manifest, commands).map((tool) => tool.openai);
+}
+
+export class RelayCodexGatewayToolRunner {
+  private readonly toolsByName: Map<string, RelayCodexGatewayToolDefinition>;
+  private readonly options: ResolvedRelayCodexGatewayRunnerOptions;
+
+  constructor(
+    tools: readonly RelayCodexGatewayToolDefinition[],
+    options: RelayCodexGatewayRunnerOptions = {}
+  ) {
+    this.toolsByName = new Map(tools.map((tool) => [tool.name, tool]));
+    const resolved: ResolvedRelayCodexGatewayRunnerOptions = {
+      command: options.command ?? 'relay-ide',
+      commandArgsPrefix: options.commandArgsPrefix ?? [],
+      timeoutMs: options.timeoutMs ?? 10_000,
+    };
+    if (options.cwd !== undefined) resolved.cwd = options.cwd;
+    if (options.env !== undefined) resolved.env = options.env;
+    this.options = resolved;
+  }
+
+  async callTool(
+    name: string,
+    input: Record<string, unknown> = {}
+  ): Promise<RelayCodexGatewayToolResult> {
+    const tool = this.toolsByName.get(name);
+    if (!tool) throw new Error(`unknown generated Relay Codex gateway tool: ${name}`);
+    const gatewayArgs = gatewayArgsForGeneratedTool(tool, input);
+    return await execRelayGatewayTool(this.options, gatewayArgs);
+  }
+}
+
+function gatewayArgsForGeneratedTool(
+  tool: RelayCodexGatewayToolDefinition,
+  input: Record<string, unknown>
+): string[] {
+  const cliArgs = tool.relay.cli.slice(1);
+  if (tool.relay.command === 'sessions.create') {
+    return replaceCliPlaceholder(cliArgs, '<json>', JSON.stringify(input));
+  }
+  if (tool.relay.command === 'files.read') {
+    return appendOptionalFlags(replaceGatewayInputPlaceholders(cliArgs, input), input, [
+      ['nodeId', '--node-id'],
+      ['cwd', '--cwd'],
+      ['maxBytes', '--max-bytes'],
+      ['maxLines', '--max-lines'],
+      ['confirmationToken', '--confirmation-token'],
+    ]);
+  }
+  if (tool.relay.command === 'sessions.stream') {
+    return appendOptionalFlags(replaceGatewayInputPlaceholders(cliArgs, input), input, [
+      ['maxEvents', '--max-events'],
+      ['maxBytes', '--max-bytes'],
+      ['idleTimeoutMs', '--idle-timeout-ms'],
+    ]);
+  }
+  if (tool.relay.command === 'sessions.input') {
+    return gatewaySessionInputArgs(input);
+  }
+  return replaceGatewayInputPlaceholders(cliArgs, input);
+}
+
+function gatewaySessionInputArgs(input: Record<string, unknown>): string[] {
+  const id = requiredStringInput(input, ['id', 'sessionId'], '<session-id>');
+  const args = ['v1', 'sessions', 'input', '--id', id];
+  if (typeof input['data'] === 'string') {
+    args.push('--data', input['data']);
+  } else if (typeof input['dataBase64'] === 'string') {
+    args.push('--data-base64', input['dataBase64']);
+  } else if (input['stdin'] === true) {
+    throw new Error('generated Relay Codex gateway smoke runner does not support stdin input');
+  } else {
+    throw new Error('generated Relay Codex gateway tool input must include data or dataBase64');
+  }
+  for (const [field, flag] of [
+    ['waitFor', '--wait-for'],
+    ['timeoutMs', '--timeout-ms'],
+    ['maxBytes', '--max-bytes'],
+  ] as const) {
+    const value = input[field];
+    if (value === undefined) continue;
+    if (typeof value !== 'string' && typeof value !== 'number') {
+      throw new Error(`generated Relay CLI tool input ${field} must be a string or number`);
+    }
+    args.push(flag, String(value));
+  }
+  args.push('--json');
+  return args;
+}
+
+function replaceGatewayInputPlaceholders(
+  cliArgs: readonly string[],
+  input: Record<string, unknown>
+): string[] {
+  return cliArgs.map((arg) => {
+    if (arg === '<session-id>') return requiredStringInput(input, ['id', 'sessionId'], arg);
+    if (arg === '<path>') return requiredStringInput(input, ['path'], arg);
+    if (arg === '<text>') return requiredStringInput(input, ['data'], arg);
+    return arg;
+  });
+}
+
+function replaceCliPlaceholder(
+  cliArgs: readonly string[],
+  placeholder: string,
+  value: string
+): string[] {
+  return cliArgs.map((arg) => (arg === placeholder ? value : arg));
+}
+
+function requiredStringInput(
+  input: Record<string, unknown>,
+  keys: readonly string[],
+  placeholder: string
+): string {
+  for (const key of keys) {
+    const value = input[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  throw new Error(`generated Relay CLI tool input must include ${keys.join(' or ')} for ${placeholder}`);
+}
+
+function appendOptionalFlags(
+  cliArgs: string[],
+  input: Record<string, unknown>,
+  fields: readonly (readonly [string, string])[]
+): string[] {
+  const insertion = cliArgs.lastIndexOf('--json');
+  const args = cliArgs.slice();
+  const flags: string[] = [];
+  for (const [field, flag] of fields) {
+    const value = input[field];
+    if (value === undefined) continue;
+    if (typeof value !== 'string' && typeof value !== 'number') {
+      throw new Error(`generated Relay CLI tool input ${field} must be a string or number`);
+    }
+    flags.push(flag, String(value));
+  }
+  if (insertion === -1 || flags.length === 0) return args.concat(flags);
+  args.splice(insertion, 0, ...flags);
+  return args;
+}
+
+async function execRelayGatewayTool(
+  options: ResolvedRelayCodexGatewayRunnerOptions,
+  gatewayArgs: readonly string[]
+): Promise<RelayCodexGatewayToolResult> {
+  const args = [...(options.commandArgsPrefix ?? []), ...gatewayArgs];
+  const execOptions = {
+    encoding: 'utf8' as const,
+    env: { ...process.env, ...options.env },
+    timeout: options.timeoutMs,
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+  };
+  return await new Promise<RelayCodexGatewayToolResult>((resolve, reject) => {
+    execFile(options.command, args, execOptions, (error, stdout, stderr) => {
+      try {
+        resolve(parseGatewayStdout(stdout));
+      } catch (parseError) {
+        reject(error ?? parseError ?? new Error(stderr || 'Relay CLI gateway tool failed'));
+      }
+    });
+  });
+}
+
+function parseGatewayStdout(stdout: string): RelayCodexGatewayToolResult {
+  const trimmed = stdout.trim();
+  if (!trimmed) throw new Error('Relay CLI gateway tool produced no JSON output');
+  try {
+    return JSON.parse(trimmed) as RelayCliGatewayEnvelope;
+  } catch {
+    /* sessions.stream emits newline-delimited compact envelopes. */
+  }
+  const lines = trimmed.split(/\r?\n/).filter((line) => line.length > 0);
+  const parsed = lines.map((line) => JSON.parse(line) as RelayCliGatewayEnvelope);
+  if (parsed.length === 1) {
+    const first = parsed[0];
+    if (!first) throw new Error('Relay CLI gateway tool produced no JSON output');
+    return first;
+  }
+  return parsed;
+}
+

--- a/test/cli-gateway-codex-tools.test.ts
+++ b/test/cli-gateway-codex-tools.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from 'vitest';
 import * as http from 'node:http';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { WebSocketServer } from 'ws';
 import {
   CLI_GATEWAY_CODEX_SMOKE_COMMANDS,
@@ -139,7 +142,7 @@ test('generated Codex CLI gateway tools run the fake hub/node adapter smoke over
             path: '/fixture/hello.txt',
             encoding: 'utf8',
             content: 'hello codex gateway\n',
-            bytesRead: 21,
+            bytesRead: 20,
             truncatedBytes: false,
             truncatedLines: false,
             maxBytes: entry.body?.['maxBytes'] ?? 32768,
@@ -211,6 +214,15 @@ test('generated Codex CLI gateway tools run the fake hub/node adapter smoke over
     if (Array.isArray(read) || !read.ok) throw new Error('expected files.read to succeed');
     expect(read.data).toMatchObject({ content: 'hello codex gateway\n', maxBytes: 64, maxLines: 2 });
 
+    const defaultPathRead = await runner.callTool('relay_codex_gateway_files_read', {
+      sessionId: 'remote-session-1',
+    });
+    expect(defaultPathRead).toMatchObject({ ok: true, command: 'files.read' });
+    if (Array.isArray(defaultPathRead) || !defaultPathRead.ok) {
+      throw new Error('expected files.read with omitted path to succeed');
+    }
+    expect(defaultPathRead.data).toMatchObject({ content: 'hello codex gateway\n' });
+
     const stream = await runner.callTool('relay_codex_gateway_sessions_stream', {
       id: 'remote-session-1',
       maxEvents: 1,
@@ -225,6 +237,23 @@ test('generated Codex CLI gateway tools run the fake hub/node adapter smoke over
       ok: true,
       command: 'sessions.stream',
       data: { event: 'closed', frames: 1, truncated: false },
+    });
+
+    const defaultBoundedStream = await runner.callTool('relay_codex_gateway_sessions_stream', {
+      id: 'remote-session-1',
+    });
+    if (!Array.isArray(defaultBoundedStream)) {
+      throw new Error('expected default sessions.stream to return NDJSON envelopes');
+    }
+    expect(defaultBoundedStream.at(-1)).toMatchObject({
+      ok: true,
+      command: 'sessions.stream',
+      data: {
+        event: 'closed',
+        frames: 1,
+        truncated: false,
+        maxBytes: 65536,
+      },
     });
 
     const input = await runner.callTool('relay_codex_gateway_sessions_input', {
@@ -258,6 +287,9 @@ test('generated Codex CLI gateway tools run the fake hub/node adapter smoke over
     'GET /sessions/remote-session-1',
     'POST /hub/nodes/node-a/sessions/remote-session-1/files/read',
     'GET /sessions/remote-session-1',
+    'POST /hub/nodes/node-a/sessions/remote-session-1/files/read',
+    'GET /sessions/remote-session-1',
+    'GET /sessions/remote-session-1',
     'GET /sessions/remote-session-1',
     'GET /sessions/remote-session-1',
   ]);
@@ -267,10 +299,16 @@ test('generated Codex CLI gateway tools run the fake hub/node adapter smoke over
     marker: 'v1',
     capabilities: 'session:read',
   });
-  expect(captured.find((entry) => entry.url?.endsWith('/files/read'))?.body).toMatchObject({
+  const readBodies = captured
+    .filter((entry) => entry.url?.endsWith('/files/read'))
+    .map((entry) => entry.body);
+  expect(readBodies[0]).toMatchObject({
     path: 'hello.txt',
     maxBytes: 64,
     maxLines: 2,
+  });
+  expect(readBodies[1]).toMatchObject({
+    path: '.',
   });
   expect(upgrades).toEqual(
     expect.arrayContaining([
@@ -282,5 +320,75 @@ test('generated Codex CLI gateway tools run the fake hub/node adapter smoke over
     ])
   );
   expect(inputs).toContain('marker-input\n');
+});
+
+test('Codex sessions.stream runner has stdout buffer headroom for schema-valid maxBytes', async () => {
+  const tools = generateRelayCodexGatewayTools(RELAY_CLI_GATEWAY_CONTRACT);
+  const largePayload = 'x'.repeat(1024 * 1024);
+  const dataEnvelope = {
+    ok: true,
+    contract: 'v1',
+    contractVersion: '1.0',
+    command: 'sessions.stream',
+    data: {
+      event: 'data',
+      sessionId: 'large-session-1',
+      encoding: 'utf8',
+      data: largePayload,
+      bytes: largePayload.length,
+      sequence: 0,
+    },
+  };
+  const closedEnvelope = {
+    ok: true,
+    contract: 'v1',
+    contractVersion: '1.0',
+    command: 'sessions.stream',
+    data: {
+      event: 'closed',
+      sessionId: 'large-session-1',
+      frames: 1,
+      bytesReceived: largePayload.length,
+      truncated: false,
+      maxBytes: largePayload.length,
+      backpressureClosed: false,
+    },
+  };
+  const tempDir = mkdtempSync(join(tmpdir(), 'relay-codex-buffer-'));
+  const scriptPath = join(tempDir, 'large-stdout.mjs');
+  writeFileSync(
+    scriptPath,
+    `process.stdout.write(${JSON.stringify(`${JSON.stringify(dataEnvelope)}\n${JSON.stringify(closedEnvelope)}\n`)});\n`
+  );
+
+  try {
+    const runner = new RelayCodexGatewayToolRunner(tools, {
+      command: process.execPath,
+      commandArgsPrefix: [scriptPath],
+    });
+
+    const stream = await runner.callTool('relay_codex_gateway_sessions_stream', {
+      id: 'large-session-1',
+      maxBytes: 1024 * 1024,
+    });
+    if (!Array.isArray(stream)) throw new Error('expected sessions.stream to return NDJSON envelopes');
+    expect(stream[0]).toMatchObject({
+      ok: true,
+      command: 'sessions.stream',
+      data: { event: 'data', bytes: largePayload.length },
+    });
+    expect(stream.at(-1)).toMatchObject({
+      ok: true,
+      command: 'sessions.stream',
+      data: {
+        event: 'closed',
+        frames: 1,
+        bytesReceived: largePayload.length,
+        maxBytes: largePayload.length,
+      },
+    });
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
 });
 

--- a/test/cli-gateway-codex-tools.test.ts
+++ b/test/cli-gateway-codex-tools.test.ts
@@ -1,0 +1,286 @@
+import { expect, test } from 'vitest';
+import * as http from 'node:http';
+import { WebSocketServer } from 'ws';
+import {
+  CLI_GATEWAY_CODEX_SMOKE_COMMANDS,
+  RelayCodexGatewayToolRunner,
+  generateRelayCodexGatewayFunctionDescriptors,
+  generateRelayCodexGatewayMcpDescriptors,
+  generateRelayCodexGatewayOpenAiToolDescriptors,
+  generateRelayCodexGatewayTools,
+} from '../shared/cli-gateway-codex-tools.js';
+import { RELAY_CLI_GATEWAY_CONTRACT, commandSpec } from '../shared/cli-gateway-contract.js';
+
+type CapturedGatewayRequest = {
+  method: string | undefined;
+  url: string | undefined;
+  authorization: string | undefined;
+  marker: string | string[] | undefined;
+  capabilities: string | string[] | undefined;
+  body?: Record<string, unknown>;
+};
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing server address');
+  return address.port;
+}
+
+async function close(server: http.Server): Promise<void> {
+  server.closeAllConnections?.();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+test('generates Codex tool, MCP, and function descriptors from the v1 contract', () => {
+  const tools = generateRelayCodexGatewayTools(RELAY_CLI_GATEWAY_CONTRACT);
+  expect(tools.map((tool) => tool.relay.command)).toEqual([...CLI_GATEWAY_CODEX_SMOKE_COMMANDS]);
+  expect(tools.map((tool) => tool.name)).toEqual([
+    'relay_codex_gateway_nodes_list',
+    'relay_codex_gateway_sessions_create',
+    'relay_codex_gateway_files_read',
+    'relay_codex_gateway_sessions_stream',
+    'relay_codex_gateway_sessions_input',
+    'relay_codex_gateway_sessions_detach',
+  ]);
+
+  const readTool = tools.find((tool) => tool.relay.command === 'files.read');
+  expect(readTool?.parameters).toBe(commandSpec('files.read').inputSchema);
+  expect(readTool?.mcp.inputSchema).toBe(commandSpec('files.read').inputSchema);
+  expect(readTool?.function.function.parameters).toBe(commandSpec('files.read').inputSchema);
+  expect(readTool?.openai).toEqual({
+    type: 'function',
+    name: 'relay_codex_gateway_files_read',
+    description: commandSpec('files.read').summary,
+    parameters: commandSpec('files.read').inputSchema,
+  });
+  expect(readTool?.relay).toMatchObject({
+    contract: 'v1',
+    contractVersion: '1.0',
+    command: 'files.read',
+    requiresAuth: true,
+  });
+
+  const mcpDescriptors = generateRelayCodexGatewayMcpDescriptors(RELAY_CLI_GATEWAY_CONTRACT);
+  const functionDescriptors = generateRelayCodexGatewayFunctionDescriptors(RELAY_CLI_GATEWAY_CONTRACT);
+  const openaiToolDescriptors = generateRelayCodexGatewayOpenAiToolDescriptors(
+    RELAY_CLI_GATEWAY_CONTRACT
+  );
+  expect(mcpDescriptors.map((descriptor) => descriptor.inputSchema)).toEqual(
+    tools.map((tool) => tool.parameters)
+  );
+  expect(functionDescriptors).toEqual(tools.map((tool) => tool.function));
+  expect(openaiToolDescriptors).toEqual(tools.map((tool) => tool.openai));
+});
+
+test('generated Codex CLI gateway tools run the fake hub/node adapter smoke over public v1 commands', async () => {
+  const tools = generateRelayCodexGatewayTools(RELAY_CLI_GATEWAY_CONTRACT);
+  const captured: CapturedGatewayRequest[] = [];
+  const upgrades: Array<{ url?: string; cookie?: string; marker?: string | string[] }> = [];
+  const inputs: string[] = [];
+  let sessionAlive = false;
+  const session = {
+    id: 'remote-session-1',
+    globalSessionId: 'node-a:remote-session-1',
+    nodeId: 'node-a',
+    type: 'terminal',
+    agent: 'shell',
+    mode: 'pty',
+    cwd: '/fixture',
+    displayName: 'fixture terminal',
+    status: 'active',
+  };
+
+  const server = http.createServer((req, res) => {
+    const entry: CapturedGatewayRequest = {
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.authorization,
+      marker: req.headers['x-relay-cli-gateway'],
+      capabilities: req.headers['x-relay-capabilities'],
+    };
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const rawBody = Buffer.concat(chunks).toString('utf8');
+      if (rawBody) entry.body = JSON.parse(rawBody) as Record<string, unknown>;
+      captured.push(entry);
+      res.setHeader('content-type', 'application/json');
+
+      if (req.method === 'GET' && req.url === '/nodes') {
+        res.end(
+          JSON.stringify({
+            nodes: [{ nodeId: 'node-a', status: 'online', availability: 'available' }],
+          })
+        );
+        return;
+      }
+      if (req.method === 'POST' && req.url === '/hub/nodes/node-a/sessions') {
+        sessionAlive = true;
+        res.statusCode = 201;
+        res.end(JSON.stringify(session));
+        return;
+      }
+      if (req.method === 'GET' && req.url === '/sessions/remote-session-1' && sessionAlive) {
+        res.end(JSON.stringify(session));
+        return;
+      }
+      if (
+        req.method === 'POST' &&
+        req.url === '/hub/nodes/node-a/sessions/remote-session-1/files/read'
+      ) {
+        res.end(
+          JSON.stringify({
+            operation: 'read',
+            root: '/fixture',
+            cwd: '/fixture',
+            path: '/fixture/hello.txt',
+            encoding: 'utf8',
+            content: 'hello codex gateway\n',
+            bytesRead: 21,
+            truncatedBytes: false,
+            truncatedLines: false,
+            maxBytes: entry.body?.['maxBytes'] ?? 32768,
+            maxLines: entry.body?.['maxLines'],
+          })
+        );
+        return;
+      }
+      if (req.method === 'DELETE') sessionAlive = false;
+      res.statusCode = 404;
+      res.end(JSON.stringify({ error: { code: 'NOT_FOUND', message: 'not found' } }));
+    });
+  });
+  const wss = new WebSocketServer({ noServer: true });
+  server.on('upgrade', (req, socket, head) => {
+    upgrades.push({
+      url: req.url,
+      cookie: req.headers.cookie,
+      marker: req.headers['x-relay-cli-gateway'],
+    });
+    if (req.url !== '/nodes/node-a/ws/sessions/remote-session-1') {
+      socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      ws.send('stream-marker\n');
+      ws.on('message', (data) => {
+        const text = data.toString();
+        inputs.push(text);
+        ws.send(`echo:${text}`);
+      });
+    });
+  });
+
+  const port = await listen(server);
+  try {
+    const runner = new RelayCodexGatewayToolRunner(tools, {
+      command: process.execPath,
+      commandArgsPrefix: ['dist/bin/relay-ide.js'],
+      env: {
+        ...process.env,
+        RELAY_IDE_PORT: String(port),
+        RELAY_IDE_BROWSER_TOKEN: 'scoped-token',
+      },
+    });
+
+    const nodes = await runner.callTool('relay_codex_gateway_nodes_list');
+    expect(nodes).toMatchObject({ ok: true, command: 'nodes.list' });
+    if (Array.isArray(nodes) || !nodes.ok) throw new Error('expected nodes.list to succeed');
+    expect((nodes.data as { nodes: unknown[] }).nodes).toHaveLength(1);
+
+    const created = await runner.callTool('relay_codex_gateway_sessions_create', {
+      nodeId: 'node-a',
+      cwd: '/fixture',
+      type: 'terminal',
+    });
+    expect(created).toMatchObject({ ok: true, command: 'sessions.create' });
+    if (Array.isArray(created) || !created.ok) throw new Error('expected sessions.create to succeed');
+    expect(created.data).toMatchObject({ id: 'remote-session-1', nodeId: 'node-a' });
+
+    const read = await runner.callTool('relay_codex_gateway_files_read', {
+      sessionId: 'remote-session-1',
+      path: 'hello.txt',
+      maxBytes: 64,
+      maxLines: 2,
+    });
+    expect(read).toMatchObject({ ok: true, command: 'files.read' });
+    if (Array.isArray(read) || !read.ok) throw new Error('expected files.read to succeed');
+    expect(read.data).toMatchObject({ content: 'hello codex gateway\n', maxBytes: 64, maxLines: 2 });
+
+    const stream = await runner.callTool('relay_codex_gateway_sessions_stream', {
+      id: 'remote-session-1',
+      maxEvents: 1,
+    });
+    if (!Array.isArray(stream)) throw new Error('expected sessions.stream to return NDJSON envelopes');
+    expect(stream[0]).toMatchObject({
+      ok: true,
+      command: 'sessions.stream',
+      data: { event: 'data', data: 'stream-marker\n', nodeId: 'node-a' },
+    });
+    expect(stream.at(-1)).toMatchObject({
+      ok: true,
+      command: 'sessions.stream',
+      data: { event: 'closed', frames: 1, truncated: false },
+    });
+
+    const input = await runner.callTool('relay_codex_gateway_sessions_input', {
+      id: 'remote-session-1',
+      data: 'marker-input\n',
+      waitFor: 'echo:marker-input',
+    });
+    expect(input).toMatchObject({
+      ok: true,
+      command: 'sessions.input',
+      data: { matched: true, nodeId: 'node-a' },
+    });
+    if (Array.isArray(input) || !input.ok) throw new Error('expected sessions.input to succeed');
+    expect((input.data as { output: string }).output).toContain('echo:marker-input\n');
+
+    const detached = await runner.callTool('relay_codex_gateway_sessions_detach', {
+      id: 'remote-session-1',
+    });
+    expect(detached).toMatchObject({ ok: true, command: 'sessions.detach' });
+    if (Array.isArray(detached) || !detached.ok) throw new Error('expected sessions.detach to succeed');
+    expect(detached.data).toMatchObject({ detached: true, killed: false });
+  } finally {
+    wss.close();
+    await close(server);
+  }
+
+  expect(sessionAlive).toBe(true);
+  expect(captured.map((entry) => `${entry.method} ${entry.url}`)).toEqual([
+    'GET /nodes',
+    'POST /hub/nodes/node-a/sessions',
+    'GET /sessions/remote-session-1',
+    'POST /hub/nodes/node-a/sessions/remote-session-1/files/read',
+    'GET /sessions/remote-session-1',
+    'GET /sessions/remote-session-1',
+    'GET /sessions/remote-session-1',
+  ]);
+  expect(captured.some((entry) => entry.method === 'DELETE')).toBe(false);
+  expect(captured.find((entry) => entry.url === '/nodes')).toMatchObject({
+    authorization: 'Bearer scoped-token',
+    marker: 'v1',
+    capabilities: 'session:read',
+  });
+  expect(captured.find((entry) => entry.url?.endsWith('/files/read'))?.body).toMatchObject({
+    path: 'hello.txt',
+    maxBytes: 64,
+    maxLines: 2,
+  });
+  expect(upgrades).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        url: '/nodes/node-a/ws/sessions/remote-session-1',
+        cookie: 'token=scoped-token',
+        marker: 'v1',
+      }),
+    ])
+  );
+  expect(inputs).toContain('marker-input\n');
+});
+


### PR DESCRIPTION
## Summary
- Add a Codex-facing CLI gateway smoke module generated from the shared `RELAY_CLI_GATEWAY_CONTRACT` manifest.
- Emit Codex/OpenAI-compatible descriptors in both nested Chat Completions-style function shape and flat Responses-style function tool shape.
- Add a fake hub/node smoke that exercises only public `relay-ide v1 ... --json` commands for node discovery, scoped session create, read-only file read, PTY stream/input, and descriptor-only detach.
- Document the Codex smoke and explicitly defer production Codex packaging/runtime work.

## Motivation
This is the #430/#429 Codex proof slice: prove Codex can consume the same versioned CLI gateway contract without hand-maintained schemas or private hub/node shortcuts.

## The Case Against
This is intentionally not a production Codex adapter package. It only proves generated descriptor shape plus a bounded fake hub/node flow through the public CLI. If Codex runtime packaging wants a different exact descriptor envelope, that should be handled in the production package layer while still deriving parameters from `shared/cli-gateway-contract.ts`.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Descriptor drift from the v1 gateway contract | Descriptors are generated from `RELAY_CLI_GATEWAY_CONTRACT`; tests assert representative schemas are object-identical to `commandSpec(...)`. |
| Smoke accidentally uses private WebSocket/node-link shortcuts | Runner shells out to `dist/bin/relay-ide.js v1 ... --json`; the fake server asserts public HTTP/PTY attach paths and no DELETE/kill. |
| Scope creep into destructive/file-write/runtime packaging | Module only includes read-only file read, bounded PTY stream/input, and detach; docs list production Codex packaging/runtime as deferred. |

## Verification
- `npm run build`
- `npm test -- test/cli-gateway-codex-tools.test.ts test/cli-gateway-hermes-tools.test.ts test/cli-gateway-contract.test.ts` — 14 passed
- `npm run check` — passed with existing lint warnings only
- `npm test` — 218 files / 2316 tests passed

Closes #548
Refs #430
Refs #429


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex gateway tool descriptors emitted in multiple formats (MCP and OpenAI-compatible) and a runner to execute CLI gateway commands with argument mapping and validation.

* **Documentation**
  * Updated CLI Gateway docs to describe Codex-facing adapter behavior and the restricted smoke command subset used by the runner.

* **Tests**
  * Added comprehensive tests covering descriptor generation and end-to-end gateway command execution (including streaming and large-payload handling).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->