### PR TITLE
feat: add hub node diagnostics CLI

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -14,7 +14,10 @@ import {
   BOOTSTRAP_DIAGNOSTICS,
   redactBootstrapSecrets,
 } from '../shared/bootstrap-diagnostics.js';
-import { RELAY_NODE_LINK_PROTOCOL_VERSION } from '../shared/relay-node-protocol.js';
+import {
+  RELAY_NODE_LINK_PROTOCOL_VERSION,
+  type HubNodeSummary,
+} from '../shared/relay-node-protocol.js';
 import type { NodeManifest } from '../shared/node-manifest.js';
 import type { Config } from '../server/types.js';
 import { createNodeLinkClient } from '../server/node-link-client.js';
@@ -77,6 +80,8 @@ Commands:
     uninstall                         Stop and remove the hub background service
     status                            Show hub service status
     logs [--lines <n>] [--follow]     Print or follow local hub log files
+    nodes [--json]                    List paired nodes with status/capability summary
+    doctor [--json]                   Run bounded hub/node diagnostics
     node-logs <nodeId> [--lines <n>] [--follow]
                                        Print or follow logs from a paired remote node
   install            Back-compat alias for relay-ide hub install
@@ -1420,6 +1425,358 @@ async function printHubLogs(commandArgs: string[]): Promise<void> {
   await printLocalLogs('hub', commandArgs);
 }
 
+type HubDoctorStatus = 'pass' | 'fail' | 'warn' | 'skip';
+type HubDoctorReason =
+  | 'CONFIG_MISSING'
+  | 'CONFIG_UNREADABLE'
+  | 'CONFIG_INVALID'
+  | 'AUTH_TOKEN_MISSING'
+  | 'HUB_UNREACHABLE'
+  | 'HUB_HTTP_ERROR'
+  | 'UNAUTHORIZED'
+  | 'NODE_REGISTRY_INVALID'
+  | 'NODE_OFFLINE'
+  | 'NODE_STALE'
+  | 'NODE_REVOKED'
+  | 'VERSION_SKEW'
+  | 'PROTOCOL_INCOMPATIBLE'
+  | 'UNSUPPORTED_CAPABILITY'
+  | 'MISSING_LOG_SUPPORT'
+  | 'CHECK_SKIPPED';
+
+interface HubDoctorCheck {
+  name: string;
+  status: HubDoctorStatus;
+  message: string;
+  reason?: HubDoctorReason;
+  details?: Record<string, unknown>;
+}
+
+interface HubNodesPayload {
+  generatedAt: string;
+  hub: { url: string };
+  count: number;
+  nodes: HubNodeSummary[];
+}
+
+function hubCliPort(): string {
+  return getArg('--port') ?? process.env['RELAY_IDE_PORT'] ?? String(DEFAULTS.port);
+}
+
+function hubCliBaseUrl(): string {
+  return `http://127.0.0.1:${hubCliPort()}`;
+}
+
+function redactForCli<T>(value: T): T {
+  return JSON.parse(redactBootstrapSecrets(JSON.stringify(value))) as T;
+}
+
+function hubCliToken(): string {
+  return process.env['RELAY_IDE_BROWSER_TOKEN'] ?? '';
+}
+
+async function hubFetchJson(
+  pathName: string,
+  capabilities: readonly string[] = []
+): Promise<
+  | { ok: true; status: number; body: unknown }
+  | { ok: false; status?: number; reason: HubDoctorReason; message: string; body?: unknown }
+> {
+  const token = hubCliToken();
+  const headers: Record<string, string> = { 'x-relay-cli-gateway': 'v1' };
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  if (capabilities.length) headers['x-relay-capabilities'] = capabilities.join(',');
+  let res: Response;
+  try {
+    res = await fetch(`${hubCliBaseUrl()}${pathName}`, { headers });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      reason: 'HUB_UNREACHABLE',
+      message: `could not connect to Relay hub on port ${hubCliPort()}: ${message}`,
+    };
+  }
+  const text = await res.text();
+  let body: unknown;
+  try {
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    body = { raw: text };
+  }
+  if (res.ok) return { ok: true, status: res.status, body: redactForCli(body) };
+  const upstream = typeof body === 'object' && body !== null ? (body as Record<string, unknown>) : undefined;
+  const reason = normalizeGatewayErrorCode(res.status, upstream) === 'UNAUTHORIZED'
+    ? 'UNAUTHORIZED'
+    : 'HUB_HTTP_ERROR';
+  return {
+    ok: false,
+    status: res.status,
+    reason,
+    message: gatewayErrorMessage(res.status, upstream),
+    body: redactForCli(body),
+  };
+}
+
+function hubConfigCheck(): HubDoctorCheck {
+  const configPath = resolveConfigPath();
+  if (!fs.existsSync(configPath)) {
+    return {
+      name: 'config.read',
+      status: 'fail',
+      reason: 'CONFIG_MISSING',
+      message: `config file is missing: ${configPath}`,
+      details: { configPath },
+    };
+  }
+  try {
+    JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    return {
+      name: 'config.read',
+      status: 'pass',
+      message: `config file is readable: ${configPath}`,
+      details: { configPath },
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return {
+      name: 'config.read',
+      status: 'fail',
+      reason: code ? 'CONFIG_UNREADABLE' : 'CONFIG_INVALID',
+      message: `could not read config ${configPath}: ${error instanceof Error ? error.message : String(error)}`,
+      details: { configPath },
+    };
+  }
+}
+
+function hubAuthCheck(): HubDoctorCheck {
+  if (hubCliToken()) {
+    return {
+      name: 'auth.token',
+      status: 'pass',
+      message: 'RELAY_IDE_BROWSER_TOKEN is set for scoped hub API checks.',
+    };
+  }
+  return {
+    name: 'auth.token',
+    status: 'fail',
+    reason: 'AUTH_TOKEN_MISSING',
+    message: 'RELAY_IDE_BROWSER_TOKEN not set. Run from an authenticated Relay session or set a scoped API token.',
+  };
+}
+
+function nodesFromBody(body: unknown): HubNodeSummary[] | undefined {
+  if (typeof body !== 'object' || body === null) return undefined;
+  const nodes = (body as { nodes?: unknown }).nodes;
+  return Array.isArray(nodes) ? (nodes as HubNodeSummary[]) : undefined;
+}
+
+async function fetchHubNodes(): Promise<
+  | { ok: true; nodes: HubNodeSummary[] }
+  | { ok: false; check: HubDoctorCheck }
+> {
+  const result = await hubFetchJson('/nodes', ['session:read']);
+  if ('reason' in result) {
+    return {
+      ok: false,
+      check: {
+        name: 'nodes.registry',
+        status: 'fail',
+        reason: result.reason,
+        message: result.message,
+        details: { status: result.status, body: result.body },
+      },
+    };
+  }
+  const nodes = nodesFromBody(result.body);
+  if (!nodes) {
+    return {
+      ok: false,
+      check: {
+        name: 'nodes.registry',
+        status: 'fail',
+        reason: 'NODE_REGISTRY_INVALID',
+        message: 'hub /nodes did not return a nodes array',
+      },
+    };
+  }
+  return { ok: true, nodes };
+}
+
+function nodeCapabilityChecks(node: HubNodeSummary): HubDoctorCheck[] {
+  const checks: HubDoctorCheck[] = [];
+  const tmuxStatus = node.capabilities.core.tmux;
+  if (tmuxStatus !== 'available') {
+    checks.push({
+      name: `node.${node.nodeId}.capability.tmux`,
+      status: 'fail',
+      reason: 'UNSUPPORTED_CAPABILITY',
+      message: `${node.displayName} reports tmux capability ${tmuxStatus}; routed terminal sessions require tmux support.`,
+      details: { nodeId: node.nodeId, capability: 'tmux', status: tmuxStatus },
+    });
+  }
+  if (node.version.state !== 'compatible') {
+    checks.push({
+      name: `node.${node.nodeId}.version`,
+      status: 'fail',
+      reason: node.version.state === 'version-skew' ? 'VERSION_SKEW' : 'PROTOCOL_INCOMPATIBLE',
+      message: `${node.displayName} protocol ${node.version.nodeProtocolVersion} does not match hub ${node.version.hubProtocolVersion}.`,
+      details: { nodeId: node.nodeId, version: node.version },
+    });
+  }
+  return checks;
+}
+
+function nodeAvailabilityCheck(node: HubNodeSummary): HubDoctorCheck {
+  if (node.status === 'online') {
+    return {
+      name: `node.${node.nodeId}.availability`,
+      status: 'pass',
+      message: `${node.displayName} is online via ${node.connection.route}.`,
+      details: { nodeId: node.nodeId, lastSeenAt: node.lastSeenAt },
+    };
+  }
+  const reason: HubDoctorReason = node.status === 'stale' ? 'NODE_STALE' : node.status === 'revoked' ? 'NODE_REVOKED' : 'NODE_OFFLINE';
+  return {
+    name: `node.${node.nodeId}.availability`,
+    status: 'fail',
+    reason,
+    message: `${node.displayName} is ${node.status}; last seen ${node.lastSeenAt}.`,
+    details: { nodeId: node.nodeId, status: node.status, lastSeenAt: node.lastSeenAt },
+  };
+}
+
+async function nodeLogSupportCheck(node: HubNodeSummary): Promise<HubDoctorCheck> {
+  if (node.status !== 'online' || node.version.state !== 'compatible') {
+    return {
+      name: `node.${node.nodeId}.logs`,
+      status: 'skip',
+      reason: 'CHECK_SKIPPED',
+      message: `${node.displayName} log support check skipped because the node is not online and protocol-compatible.`,
+      details: { nodeId: node.nodeId, status: node.status, version: node.version.state },
+    };
+  }
+  const result = await hubFetchJson(
+    `/hub/nodes/${encodeURIComponent(node.nodeId)}/logs?lines=0`,
+    ['session:read']
+  );
+  if (!('reason' in result)) {
+    return {
+      name: `node.${node.nodeId}.logs`,
+      status: 'pass',
+      message: `${node.displayName} supports hub node-log snapshots.`,
+      details: { nodeId: node.nodeId },
+    };
+  }
+  return {
+    name: `node.${node.nodeId}.logs`,
+    status: 'fail',
+    reason: result.reason === 'HUB_HTTP_ERROR' ? 'MISSING_LOG_SUPPORT' : result.reason,
+    message: `${node.displayName} node-log check failed: ${result.message}`,
+    details: { nodeId: node.nodeId, status: result.status, body: result.body },
+  };
+}
+
+function boundedNodeRow(value: string | undefined, max = 24): string {
+  const text = value || '-';
+  return text.length > max ? `${text.slice(0, Math.max(1, max - 1))}…` : text;
+}
+
+function formatNodeTable(nodes: HubNodeSummary[]): string[] {
+  if (nodes.length === 0) return ['No paired Relay nodes.'];
+  const rows = nodes.slice(0, 100).map((node) => [
+    node.status,
+    boundedNodeRow(node.nodeId, 20),
+    boundedNodeRow(node.displayName, 24),
+    boundedNodeRow(`${node.hostname} ${node.platform}/${node.arch}`, 30),
+    boundedNodeRow(node.relayVersion, 14),
+    boundedNodeRow(node.version.state, 16),
+    `tmux:${node.capabilities.core.tmux}`,
+    node.lastSeenAt,
+  ]);
+  const header = ['STATUS', 'NODE ID', 'NAME', 'HOST', 'VERSION', 'PROTO', 'CAPS', 'LAST SEEN'];
+  const widths = header.map((heading, index) => Math.max(heading.length, ...rows.map((row) => row[index]?.length ?? 0)));
+  const render = (row: string[]): string => row.map((cell, index) => cell.padEnd(widths[index] ?? 0)).join('  ').trimEnd();
+  const output = [render(header), render(widths.map((width) => '-'.repeat(width))), ...rows.map(render)];
+  if (nodes.length > rows.length) output.push(`… ${nodes.length - rows.length} more nodes omitted from human output; use --json for the full list.`);
+  return output;
+}
+
+async function printHubNodes(commandArgs: string[]): Promise<void> {
+  const jsonOutput = commandArgs.includes('--json');
+  const fetched = await fetchHubNodes();
+  if ('check' in fetched) {
+    if (jsonOutput) console.log(JSON.stringify(redactForCli(fetched.check), null, 2));
+    else logger.error(redactBootstrapSecrets(`${fetched.check.reason}: ${fetched.check.message}`));
+    process.exit(1);
+  }
+  const payload = redactForCli<HubNodesPayload>({
+    generatedAt: new Date().toISOString(),
+    hub: { url: hubCliBaseUrl() },
+    count: fetched.nodes.length,
+    nodes: fetched.nodes,
+  });
+  if (jsonOutput) console.log(JSON.stringify(payload, null, 2));
+  else for (const line of formatNodeTable(payload.nodes)) logger.info(redactBootstrapSecrets(line));
+}
+
+async function runHubDoctor(commandArgs: string[]): Promise<void> {
+  const jsonOutput = commandArgs.includes('--json');
+  const checks: HubDoctorCheck[] = [hubConfigCheck(), hubAuthCheck()];
+  const reachable = await hubFetchJson('/version');
+  const hubReachable = !('reason' in reachable);
+  checks.push(
+    hubReachable
+      ? { name: 'hub.reachable', status: 'pass', message: `hub answered /version at ${hubCliBaseUrl()}.` }
+      : { name: 'hub.reachable', status: 'fail', reason: reachable.reason, message: reachable.message }
+  );
+  let nodes: HubNodeSummary[] = [];
+  if (hubCliToken() && hubReachable) {
+    const fetched = await fetchHubNodes();
+    if (!('check' in fetched)) {
+      nodes = fetched.nodes;
+      checks.push({
+        name: 'nodes.registry',
+        status: 'pass',
+        message: `hub returned ${nodes.length} paired node(s).`,
+        details: { count: nodes.length },
+      });
+      for (const node of nodes) checks.push(nodeAvailabilityCheck(node), ...nodeCapabilityChecks(node));
+      for (const node of nodes) checks.push(await nodeLogSupportCheck(node));
+    } else {
+      checks.push(fetched.check);
+    }
+  } else {
+    checks.push({
+      name: 'nodes.registry',
+      status: 'skip',
+      reason: 'CHECK_SKIPPED',
+      message: 'authenticated node registry checks skipped because hub reachability or auth token failed.',
+    });
+  }
+  const failed = checks.filter((check) => check.status === 'fail');
+  const payload = redactForCli({
+    ok: failed.length === 0,
+    generatedAt: new Date().toISOString(),
+    hub: { url: hubCliBaseUrl(), protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION },
+    checks,
+    nodes,
+  });
+  if (jsonOutput) {
+    console.log(JSON.stringify(payload, null, 2));
+  } else {
+    logger.info(`Hub doctor ${payload.ok ? 'OK' : 'FAILED'} (${failed.length} failure(s))`);
+    for (const check of checks) {
+      const label = check.status.toUpperCase().padEnd(4);
+      const reason = check.reason ? ` ${check.reason}` : '';
+      const line = `[${label}] ${check.name}${reason}: ${check.message}`;
+      if (check.status === 'fail') logger.error(redactBootstrapSecrets(line));
+      else logger.info(redactBootstrapSecrets(line));
+    }
+  }
+  process.exit(payload.ok ? 0 : 1);
+}
+
 async function printRemoteNodeLogs(commandArgs: string[]): Promise<void> {
   const nodeId = commandArgs[0];
   if (!nodeId || nodeId.startsWith('-')) {
@@ -1884,6 +2241,10 @@ if (command === 'hub') {
     runServiceCommand(printHubStatus);
   } else if (subCommand === 'logs') {
     await runAsyncCommand(() => printHubLogs(hubArgs.slice(1)));
+  } else if (subCommand === 'nodes') {
+    await runAsyncCommand(() => printHubNodes(hubArgs.slice(1)));
+  } else if (subCommand === 'doctor') {
+    await runHubDoctor(hubArgs.slice(1));
   } else if (subCommand === 'node-logs') {
     await runAsyncCommand(() => printRemoteNodeLogs(hubArgs.slice(1)));
   } else if (
@@ -1904,7 +2265,7 @@ if (command === 'hub') {
     // an alias preserves bare `relay-ide` while making the runtime role explicit.
   } else {
     logger.error(
-      'Usage: relay-ide hub [install|uninstall|status|logs|node-logs] [--port <port>] [--host <host>] [--config <path>]'
+      'Usage: relay-ide hub [install|uninstall|status|logs|nodes|doctor|node-logs] [--port <port>] [--host <host>] [--config <path>]'
     );
     process.exit(1);
   }

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -1475,6 +1475,12 @@ function hubCliToken(): string {
   return process.env['RELAY_IDE_BROWSER_TOKEN'] ?? '';
 }
 
+const HUB_CLI_FETCH_TIMEOUT_MS = 2500;
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
+}
+
 async function hubFetchJson(
   pathName: string,
   capabilities: readonly string[] = []
@@ -1486,18 +1492,26 @@ async function hubFetchJson(
   const headers: Record<string, string> = { 'x-relay-cli-gateway': 'v1' };
   if (token) headers['Authorization'] = `Bearer ${token}`;
   if (capabilities.length) headers['x-relay-capabilities'] = capabilities.join(',');
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), HUB_CLI_FETCH_TIMEOUT_MS);
   let res: Response;
+  let text: string;
   try {
-    res = await fetch(`${hubCliBaseUrl()}${pathName}`, { headers });
+    res = await fetch(`${hubCliBaseUrl()}${pathName}`, { headers, signal: abortController.signal });
+    text = await res.text();
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    const timeoutMessage = isAbortError(error) || abortController.signal.aborted
+      ? `timed out after ${HUB_CLI_FETCH_TIMEOUT_MS}ms`
+      : message;
     return {
       ok: false,
       reason: 'HUB_UNREACHABLE',
-      message: `could not connect to Relay hub on port ${hubCliPort()}: ${message}`,
+      message: `could not reach Relay hub on port ${hubCliPort()}: ${timeoutMessage}`,
     };
+  } finally {
+    clearTimeout(timeout);
   }
-  const text = await res.text();
   let body: unknown;
   try {
     body = text ? JSON.parse(text) : {};

--- a/docs/RELAY_NODE_BOOTSTRAP.md
+++ b/docs/RELAY_NODE_BOOTSTRAP.md
@@ -251,10 +251,17 @@ Reports the same service manager state, but from the generic `install`/`uninstal
 ### Hub-side node list
 
 ```bash
+# Human table from the hub host
+relay-ide hub nodes
+
+# Machine-readable parity for scripts
+relay-ide hub nodes --json
+
+# Raw API equivalent
 curl https://hub.example.com/nodes -b "token=<auth-cookie>"
 ```
 
-Returns all paired nodes with `online`/`stale`/`offline`/`revoked` status, last seen timestamp, and capability summary.
+Returns all paired nodes with `online`/`stale`/`offline`/`revoked` status, last seen timestamp, protocol/version state, and capability summary. The CLI reads the local hub port/config and requires `RELAY_IDE_BROWSER_TOKEN` for the same scoped hub API access as other CLI-gateway operations.
 
 ## Update
 
@@ -311,6 +318,18 @@ relay-ide uninstall
 > There is no `relay-ide node unpair` CLI command. Unpairing is always hub-driven. The node cannot revoke itself.
 
 ## Troubleshooting
+
+### Diagnose from the hub
+
+```bash
+# Human pass/fail checklist from the hub host
+relay-ide hub doctor
+
+# Machine-readable diagnostics for automation
+relay-ide hub doctor --json
+```
+
+Hub doctor is intentionally cheap and read-only. It checks local config readability, scoped CLI auth token presence, hub `/version` reachability, paired node registry shape, node availability, protocol/version compatibility, required terminal capability (`tmux`), and hub-mediated node-log snapshot support. It reports typed reasons such as `CONFIG_MISSING`, `AUTH_TOKEN_MISSING`, `HUB_UNREACHABLE`, `NODE_OFFLINE`, `NODE_STALE`, `NODE_REVOKED`, `VERSION_SKEW`, `PROTOCOL_INCOMPATIBLE`, `UNSUPPORTED_CAPABILITY`, `MISSING_LOG_SUPPORT`, and `CHECK_SKIPPED`. It does not remediate nodes, mutate files, run arbitrary commands, or prove multi-machine topology.
 
 ### Diagnose from the node
 

--- a/shared/bootstrap-diagnostics.ts
+++ b/shared/bootstrap-diagnostics.ts
@@ -265,5 +265,7 @@ export function redactBootstrapSecrets(value: string): string {
     .replace(/\bnode_[A-Za-z0-9._~+/=-]+\.secret_[A-Za-z0-9._~+/=-]+\b/g, 'node_…redacted.secret_…redacted')
     .replace(/\bsecret_[A-Za-z0-9._~+/=-]+\b/g, 'secret_…redacted')
     .replace(/(Authorization:\s*Bearer\s+)\S+/gi, '$1…redacted')
-    .replace(/(Bearer\s+)\S+/gi, '$1…redacted');
+    .replace(/(Bearer\s+)\S+/gi, '$1…redacted')
+    .replace(/("(?:token|pairToken|pin|password|secret)"\s*:\s*)"[^"]*"/gi, '$1"…redacted"')
+    .replace(/\b(token|pin|password|secret)=([^\s&"',}]+)/gi, '$1=…redacted');
 }

--- a/shared/bootstrap-diagnostics.ts
+++ b/shared/bootstrap-diagnostics.ts
@@ -264,8 +264,8 @@ export function redactBootstrapSecrets(value: string): string {
     .replace(/\bpair_[A-Za-z0-9._~+/=-]+\b/g, 'pair_…redacted')
     .replace(/\bnode_[A-Za-z0-9._~+/=-]+\.secret_[A-Za-z0-9._~+/=-]+\b/g, 'node_…redacted.secret_…redacted')
     .replace(/\bsecret_[A-Za-z0-9._~+/=-]+\b/g, 'secret_…redacted')
-    .replace(/(Authorization:\s*Bearer\s+)\S+/gi, '$1…redacted')
-    .replace(/(Bearer\s+)\S+/gi, '$1…redacted')
+    .replace(/(Authorization:\s*Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, '$1…redacted')
+    .replace(/(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, '$1…redacted')
     .replace(/("(?:token|pairToken|pin|password|secret)"\s*:\s*)"[^"]*"/gi, '$1"…redacted"')
     .replace(/\b(token|pin|password|secret)=([^\s&"',}]+)/gi, '$1=…redacted');
 }

--- a/test/bootstrap-diagnostics.test.ts
+++ b/test/bootstrap-diagnostics.test.ts
@@ -141,6 +141,39 @@ describe('bootstrap command generation and diagnostics', () => {
     expect(redacted).toContain('Bearer …redacted');
   });
 
+  it('keeps JSON string redaction parseable for embedded bearer and named secret values', () => {
+    const raw = JSON.stringify({
+      authHeader: 'Bearer upstream-bearer-secret',
+      nested: {
+        token: 'plain-token-secret',
+        pin: '123456',
+        pairToken: 'pair_json_token',
+        password: 'password-secret',
+        secret: 'secret_should-not-log',
+      },
+    });
+
+    const redacted = redactBootstrapSecrets(raw);
+    const parsed = JSON.parse(redacted) as {
+      authHeader: string;
+      nested: Record<string, string>;
+    };
+
+    expect(parsed.authHeader).toBe('Bearer …redacted');
+    expect(Object.values(parsed.nested)).toEqual([
+      '…redacted',
+      '…redacted',
+      '…redacted',
+      '…redacted',
+      '…redacted',
+    ]);
+    expect(redacted).not.toContain('upstream-bearer-secret');
+    expect(redacted).not.toContain('plain-token-secret');
+    expect(redacted).not.toContain('pair_json_token');
+    expect(redacted).not.toContain('password-secret');
+    expect(redacted).not.toContain('secret_should-not-log');
+  });
+
   it('defines the diagnostics taxonomy required for bootstrap triage', () => {
     expect(BOOTSTRAP_DIAGNOSTICS.map((diagnostic) => diagnostic.code)).toEqual([
       'BOOTSTRAP_UNREACHABLE',

--- a/test/hub-node-packaging.test.ts
+++ b/test/hub-node-packaging.test.ts
@@ -100,6 +100,84 @@ function resetCliLogDir(): void {
   fs.rmSync('/tmp/relay-ide-test-config', { recursive: true, force: true });
 }
 
+function writeHubConfig(pathName = '/tmp/relay-ide-test-config/config.json'): string {
+  fs.mkdirSync(path.dirname(pathName), { recursive: true });
+  fs.writeFileSync(pathName, JSON.stringify({ port: 3456 }));
+  return pathName;
+}
+
+function sampleHubNode(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    nodeId: 'node_alpha',
+    displayName: 'Alpha MacBook',
+    hostname: 'alpha.local',
+    platform: 'darwin',
+    arch: 'arm64',
+    relayVersion: '0.1.0',
+    protocolVersion: '1.0',
+    status: 'online',
+    connection: { route: 'reverse-link', status: 'connected' },
+    trust: { state: 'trusted', level: 'standard' },
+    credentialState: 'active',
+    version: {
+      state: 'compatible',
+      nodeProtocolVersion: '1.0',
+      hubProtocolVersion: '1.0',
+    },
+    capabilities: {
+      totals: { available: 3, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        tmux: 'available',
+        git: 'available',
+        browserAutomation: 'unknown',
+        clipboardImage: 'unknown',
+        ssh: 'unknown',
+        tailscale: 'unknown',
+      },
+      agents: { claude: 'available' },
+      serviceManager: 'launchd',
+      wsl: false,
+      sessionResume: 'tmux',
+    },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    pairedAt: '2026-01-01T00:00:00.000Z',
+    lastSeenAt: '2026-01-01T00:00:10.000Z',
+    credentialId: 'cred_alpha',
+    ...overrides,
+  };
+}
+
+interface FetchFixture {
+  pathName: string;
+  status?: number;
+  body: unknown;
+}
+
+function stubHubFetch(fixtures: FetchFixture[]): string[] {
+  const paths: string[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: URL | RequestInfo) => {
+      const url = new URL(String(input));
+      const fixture = fixtures.find((candidate) => candidate.pathName === `${url.pathname}${url.search}`)
+        ?? fixtures.find((candidate) => candidate.pathName === url.pathname);
+      paths.push(`${url.pathname}${url.search}`);
+      if (!fixture) {
+        return new Response(JSON.stringify({ error: { code: 'NOT_FOUND', message: 'missing fixture' } }), {
+          status: 404,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify(fixture.body), {
+        status: fixture.status ?? 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    })
+  );
+  return paths;
+}
+
 describe('hub/node packaging decision', () => {
   it('keeps hub and node roles in the single relay-ide npm package', () => {
     const packageJson = JSON.parse(readRepoFile('package.json')) as {
@@ -219,6 +297,143 @@ describe('hub/node packaging decision', () => {
     expect(loggerMocks.error).toHaveBeenCalledWith(
       expect.stringContaining('Usage: relay-ide hub')
     );
+  });
+
+  it('prints a useful hub nodes table and keeps --json parity', async () => {
+    resetCliLogDir();
+    const configPath = writeHubConfig();
+    const oldToken = process.env['RELAY_IDE_BROWSER_TOKEN'];
+    process.env['RELAY_IDE_BROWSER_TOKEN'] = 'browser-secret-token';
+    const node = sampleHubNode();
+    const requests = stubHubFetch([{ pathName: '/nodes', body: { nodes: [node] } }]);
+    let stdout = '';
+    const stdoutSpy = vi
+      .spyOn(globalThis.console, 'log')
+      .mockImplementation((message?: unknown) => {
+        stdout += `${String(message ?? '')}\n`;
+      });
+
+    try {
+      const tableResult = await runCli(['hub', 'nodes', '--config', configPath]);
+      expect(tableResult.exitCode).toBe(0);
+      expect(loggerMocks.info).toHaveBeenCalledWith(expect.stringContaining('STATUS'));
+      expect(loggerMocks.info).toHaveBeenCalledWith(expect.stringContaining('node_alpha'));
+      expect(loggerMocks.info).toHaveBeenCalledWith(expect.stringContaining('tmux:available'));
+
+      loggerMocks.info.mockClear();
+      const jsonResult = await runCli(['hub', 'nodes', '--json', '--config', configPath]);
+      expect(jsonResult.exitCode).toBe(0);
+      const payload = JSON.parse(stdout) as { count: number; nodes: Array<Record<string, unknown>> };
+      expect(payload.count).toBe(1);
+      expect(payload.nodes[0]?.['nodeId']).toBe('node_alpha');
+      expect(requests).toEqual(['/nodes', '/nodes']);
+    } finally {
+      stdoutSpy.mockRestore();
+      vi.unstubAllGlobals();
+      resetCliLogDir();
+      if (oldToken === undefined) delete process.env['RELAY_IDE_BROWSER_TOKEN'];
+      else process.env['RELAY_IDE_BROWSER_TOKEN'] = oldToken;
+    }
+  });
+
+  it('reports missing config/auth and hub unreachable as typed hub doctor failures', async () => {
+    resetCliLogDir();
+    const oldToken = process.env['RELAY_IDE_BROWSER_TOKEN'];
+    delete process.env['RELAY_IDE_BROWSER_TOKEN'];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('connection refused token=super-secret');
+      })
+    );
+    let stdout = '';
+    const stdoutSpy = vi
+      .spyOn(globalThis.console, 'log')
+      .mockImplementation((message?: unknown) => {
+        stdout += `${String(message ?? '')}\n`;
+      });
+
+    try {
+      const result = await runCli(['hub', 'doctor', '--json']);
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(stdout) as { ok: boolean; checks: Array<{ reason?: string }> };
+      expect(payload.ok).toBe(false);
+      expect(payload.checks.map((check) => check.reason)).toEqual(
+        expect.arrayContaining(['CONFIG_MISSING', 'AUTH_TOKEN_MISSING', 'HUB_UNREACHABLE', 'CHECK_SKIPPED'])
+      );
+      expect(stdout).not.toContain('super-secret');
+    } finally {
+      stdoutSpy.mockRestore();
+      vi.unstubAllGlobals();
+      resetCliLogDir();
+      if (oldToken === undefined) delete process.env['RELAY_IDE_BROWSER_TOKEN'];
+      else process.env['RELAY_IDE_BROWSER_TOKEN'] = oldToken;
+    }
+  });
+
+  it('reports node availability, version, capability, and log support diagnostics', async () => {
+    resetCliLogDir();
+    const configPath = writeHubConfig();
+    const oldToken = process.env['RELAY_IDE_BROWSER_TOKEN'];
+    process.env['RELAY_IDE_BROWSER_TOKEN'] = 'browser-secret-token';
+    const baseCapabilities = sampleHubNode()['capabilities'] as {
+      core: Record<string, string>;
+    };
+    const nodes = [
+      sampleHubNode({ nodeId: 'node_stale', displayName: 'Stale Node', status: 'stale' }),
+      sampleHubNode({
+        nodeId: 'node_skew',
+        displayName: 'Skew Node',
+        version: {
+          state: 'version-skew',
+          nodeProtocolVersion: '0.9',
+          hubProtocolVersion: '1.0',
+        },
+      }),
+      sampleHubNode({
+        nodeId: 'node_no_tmux',
+        displayName: 'No Tmux Node',
+        capabilities: {
+          ...baseCapabilities,
+          core: { ...baseCapabilities.core, tmux: 'unavailable' },
+        },
+      }),
+      sampleHubNode({ nodeId: 'node_no_logs', displayName: 'No Logs Node' }),
+    ];
+    stubHubFetch([
+      { pathName: '/version', body: { version: '0.1.0' } },
+      { pathName: '/nodes', body: { nodes } },
+      { pathName: '/hub/nodes/node_no_tmux/logs?lines=0', body: { log: { message: 'ok' } } },
+      {
+        pathName: '/hub/nodes/node_no_logs/logs?lines=0',
+        status: 404,
+        body: { error: { code: 'NODE_UNSUPPORTED', message: 'logs.tail missing', token: 'node-secret' } },
+      },
+    ]);
+    let stdout = '';
+    const stdoutSpy = vi
+      .spyOn(globalThis.console, 'log')
+      .mockImplementation((message?: unknown) => {
+        stdout += `${String(message ?? '')}\n`;
+      });
+
+    try {
+      const result = await runCli(['hub', 'doctor', '--json', '--config', configPath]);
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(stdout) as { checks: Array<{ reason?: string }> };
+      const reasons = payload.checks.map((check) => check.reason);
+      expect(reasons).toEqual(
+        expect.arrayContaining(['NODE_STALE', 'VERSION_SKEW', 'UNSUPPORTED_CAPABILITY', 'MISSING_LOG_SUPPORT'])
+      );
+      expect(stdout).not.toContain('browser-secret-token');
+      expect(stdout).not.toContain('node-secret');
+    } finally {
+      stdoutSpy.mockRestore();
+      vi.unstubAllGlobals();
+      resetCliLogDir();
+      if (oldToken === undefined) delete process.env['RELAY_IDE_BROWSER_TOKEN'];
+      else process.env['RELAY_IDE_BROWSER_TOKEN'] = oldToken;
+    }
   });
 
   it('tails local hub logs with --lines without platform log commands', async () => {

--- a/test/hub-node-packaging.test.ts
+++ b/test/hub-node-packaging.test.ts
@@ -395,6 +395,62 @@ describe('hub/node packaging decision', () => {
     }
   });
 
+  it('bounds hub doctor probes that connect but never answer', async () => {
+    resetCliLogDir();
+    const configPath = writeHubConfig();
+    const oldToken = process.env['RELAY_IDE_BROWSER_TOKEN'];
+    delete process.env['RELAY_IDE_BROWSER_TOKEN'];
+    vi.useFakeTimers();
+    const fetchMock = vi.fn((_input: URL | RequestInfo, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        expect(signal).toBeInstanceOf(AbortSignal);
+        signal?.addEventListener(
+          'abort',
+          () => {
+            const error = new Error('abort should not leak token=timeout-secret');
+            error.name = 'AbortError';
+            reject(error);
+          },
+          { once: true }
+        );
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    let stdout = '';
+    const stdoutSpy = vi
+      .spyOn(globalThis.console, 'log')
+      .mockImplementation((message?: unknown) => {
+        stdout += `${String(message ?? '')}\n`;
+      });
+
+    try {
+      const resultPromise = runCli(['hub', 'doctor', '--json', '--config', configPath]);
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+      await vi.advanceTimersByTimeAsync(2500);
+      const result = await resultPromise;
+      expect(result.exitCode).toBe(1);
+      const payload = JSON.parse(stdout) as {
+        ok: boolean;
+        checks: Array<{ name: string; reason?: string; message: string }>;
+      };
+      const reachability = payload.checks.find((check) => check.name === 'hub.reachable');
+      expect(payload.ok).toBe(false);
+      expect(reachability).toMatchObject({
+        reason: 'HUB_UNREACHABLE',
+        message: expect.stringContaining('timed out after 2500ms'),
+      });
+      expect(stdout).not.toContain('timeout-secret');
+    } finally {
+      stdoutSpy.mockRestore();
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+      resetCliLogDir();
+      if (oldToken === undefined) delete process.env['RELAY_IDE_BROWSER_TOKEN'];
+      else process.env['RELAY_IDE_BROWSER_TOKEN'] = oldToken;
+    }
+  });
+
   it('reports node availability, version, capability, and log support diagnostics', async () => {
     resetCliLogDir();
     const configPath = writeHubConfig();

--- a/test/hub-node-packaging.test.ts
+++ b/test/hub-node-packaging.test.ts
@@ -304,7 +304,16 @@ describe('hub/node packaging decision', () => {
     const configPath = writeHubConfig();
     const oldToken = process.env['RELAY_IDE_BROWSER_TOKEN'];
     process.env['RELAY_IDE_BROWSER_TOKEN'] = 'browser-secret-token';
-    const node = sampleHubNode();
+    const node = sampleHubNode({
+      debug: {
+        authHeader: 'Bearer upstream-bearer-secret',
+        token: 'node-token-secret',
+        pin: '123456',
+        pairToken: 'pair_node_secret',
+        password: 'password-secret',
+        secret: 'secret_should-not-log',
+      },
+    });
     const requests = stubHubFetch([{ pathName: '/nodes', body: { nodes: [node] } }]);
     let stdout = '';
     const stdoutSpy = vi
@@ -324,8 +333,23 @@ describe('hub/node packaging decision', () => {
       const jsonResult = await runCli(['hub', 'nodes', '--json', '--config', configPath]);
       expect(jsonResult.exitCode).toBe(0);
       const payload = JSON.parse(stdout) as { count: number; nodes: Array<Record<string, unknown>> };
+      const parsedNode = payload.nodes[0] as { debug?: Record<string, unknown> };
       expect(payload.count).toBe(1);
       expect(payload.nodes[0]?.['nodeId']).toBe('node_alpha');
+      expect(parsedNode.debug).toMatchObject({
+        authHeader: 'Bearer …redacted',
+        token: '…redacted',
+        pin: '…redacted',
+        pairToken: '…redacted',
+        password: '…redacted',
+        secret: '…redacted',
+      });
+      expect(stdout).not.toContain('browser-secret-token');
+      expect(stdout).not.toContain('upstream-bearer-secret');
+      expect(stdout).not.toContain('node-token-secret');
+      expect(stdout).not.toContain('pair_node_secret');
+      expect(stdout).not.toContain('password-secret');
+      expect(stdout).not.toContain('secret_should-not-log');
       expect(requests).toEqual(['/nodes', '/nodes']);
     } finally {
       stdoutSpy.mockRestore();
@@ -407,7 +431,18 @@ describe('hub/node packaging decision', () => {
       {
         pathName: '/hub/nodes/node_no_logs/logs?lines=0',
         status: 404,
-        body: { error: { code: 'NODE_UNSUPPORTED', message: 'logs.tail missing', token: 'node-secret' } },
+        body: {
+          error: {
+            code: 'NODE_UNSUPPORTED',
+            message: 'logs.tail missing',
+            authHeader: 'Bearer upstream-doctor-bearer-secret',
+            token: 'node-secret',
+            pin: '654321',
+            pairToken: 'pair_doctor_secret',
+            password: 'doctor-password-secret',
+            secret: 'secret_doctor_should-not-log',
+          },
+        },
       },
     ]);
     let stdout = '';
@@ -420,13 +455,33 @@ describe('hub/node packaging decision', () => {
     try {
       const result = await runCli(['hub', 'doctor', '--json', '--config', configPath]);
       expect(result.exitCode).toBe(1);
-      const payload = JSON.parse(stdout) as { checks: Array<{ reason?: string }> };
+      const payload = JSON.parse(stdout) as {
+        checks: Array<{
+          reason?: string;
+          details?: { body?: { error?: Record<string, unknown> } };
+        }>;
+      };
       const reasons = payload.checks.map((check) => check.reason);
+      const missingLogError = payload.checks.find(
+        (check) => check.reason === 'MISSING_LOG_SUPPORT'
+      )?.details?.body?.error;
       expect(reasons).toEqual(
         expect.arrayContaining(['NODE_STALE', 'VERSION_SKEW', 'UNSUPPORTED_CAPABILITY', 'MISSING_LOG_SUPPORT'])
       );
+      expect(missingLogError).toMatchObject({
+        authHeader: 'Bearer …redacted',
+        token: '…redacted',
+        pin: '…redacted',
+        pairToken: '…redacted',
+        password: '…redacted',
+        secret: '…redacted',
+      });
       expect(stdout).not.toContain('browser-secret-token');
+      expect(stdout).not.toContain('upstream-doctor-bearer-secret');
       expect(stdout).not.toContain('node-secret');
+      expect(stdout).not.toContain('pair_doctor_secret');
+      expect(stdout).not.toContain('doctor-password-secret');
+      expect(stdout).not.toContain('secret_doctor_should-not-log');
     } finally {
       stdoutSpy.mockRestore();
       vi.unstubAllGlobals();


### PR DESCRIPTION
## Summary
- add `relay-ide hub nodes` with a human table and `--json` parity backed by the existing hub `/nodes` API
- add `relay-ide hub doctor` / `--json` with cheap read-only checks for config, auth token, hub reachability, node registry, availability, protocol/version, tmux capability, and node-log support
- extend CLI redaction for bearer/query/JSON-style secrets and document the shipped hub-side diagnostics commands

## Why
#547 is the closeout slice for #476: operators need a bounded hub-side way to see paired node state and answer "why can't this node work?" without turning this into fleet observability or remote remediation soup.

## The Case Against
This change might be wrong because:
- The hub doctor uses the local CLI token environment (`RELAY_IDE_BROWSER_TOKEN`) and local port/config assumptions. That is intentionally consistent with the existing CLI gateway model, but it means this is not a generic remote SaaS health probe.
- The log-support check is a cheap `lines=0` snapshot through the existing node-log proxy. It proves the route is callable; it does not prove long-running follow streaming quality.
- The diagnostics are intentionally read-only. If an operator expects auto-repair, upgrade, or remote command execution, this PR does not do that on purpose.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Secret leakage in diagnostic bodies | Reuses `redactBootstrapSecrets()` and expands it for bearer tokens, JSON secret fields, and query-style token/pin/password/secret pairs; tests assert redaction. |
| Treating stale/offline/version-skew nodes as actionable without context | Typed reason codes and human messages separate availability, version, capability, and skipped log checks. |
| Scope creep into privileged remediation | Commands only call `/version`, `/nodes`, and node-log snapshot endpoints; docs explicitly call out no mutation/remediation/arbitrary exec/topology proof. |

## Verification
- `npm test -- test/hub-node-packaging.test.ts` (12/12 pass)
- `npm run check` (passes; existing warnings only)
- `npm run build` (passes; existing chunk-size warning)
- `node dist/bin/relay-ide.js hub doctor --json --config /tmp/relay-ide-missing-config.json; test $? -eq 1`

Closes #547
Refs #476
