### PR TITLE
docs: define Relay workbench boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Relay Agentic Development Environment — a hub/node web workspace for AI coding
 | --------------- | ---------------------------------- | --------------------------------------------------------------------------- |
 | Docs index      | `docs/README.md`                   | Current source-of-truth docs vs historical plans/spikes                     |
 | Architecture    | `docs/ARCHITECTURE.md`             | Module boundaries, data flow, API routes, ADR rules                         |
+| Workbench       | `docs/WORKBENCH_BOUNDARY.md`       | Relay product boundary, #552 nouns, mobile/pair/dogfood acceptance          |
 | Visual Design   | `DESIGN.md`                        | Product framing, TUI aesthetic, colors, spacing, buttons                    |
 | Design          | `docs/DESIGN.md`                   | Backend patterns, auth flow, PTY management, session types                  |
 | Frontend        | `docs/FRONTEND.md`                 | React 19 components, state management (Zustand + TanStack Query)            |
@@ -39,7 +40,7 @@ Relay Agentic Development Environment — a hub/node web workspace for AI coding
 | Hub/node pkg    | `docs/RELAY_HUB_NODE_PACKAGING.md` | Hub vs node command shape, npm package decision, install/update commands    |
 | Node bootstrap  | `docs/RELAY_NODE_BOOTSTRAP.md`     | Pair/install/update/unpair nodes for federated Relay, bootstrap diagnostics |
 | Federated dev   | `docs/FEDERATED_DEV.md`            | Cross-machine dev workflow: synced git checkouts, `dev:node`, version skew  |
-| Federated Relay | `docs/federated-relay.md`           | Hub/node architecture, pairing, routing, ADRs                               |
+| Federated Relay | `docs/federated-relay.md`          | Hub/node architecture, pairing, routing, ADRs                               |
 | CLI gateway     | `docs/CLI_GATEWAY.md`              | Versioned `relay-ide v1 ... --json` contract for external agent adapters    |
 | Learnings       | `docs/LEARNINGS.md`                | Persistent cross-session learnings                                          |
 | Project skills  | `.chalk/skills/<name>/SKILL.md`    | Repo-local skills (see §Skills)                                             |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,6 +7,8 @@ If you want to familiarize yourself with the codebase, you are in the right plac
 
 Relay IDE is a remote web interface for interacting with agent and terminal sessions from any device. A user opens the web UI in a browser, authenticates with a PIN, and gets a terminal connected to a tmux-backed process running either on the hub machine or on a paired Relay node. The hub manages auth, UI, routing, node registry state, reverse node-link RPC, aggregated repo inventory, and local hub-as-node sessions; each node owns its own PTY/session execution and local filesystem/git checkout state.
 
+Product boundary: Relay is a federated workbench/control plane for shared identity, routing, context handoff, bounded inspection/control, and audit trails across existing tools. It is not a replacement for Hermes Agent, GitHub, Kanban, tmux, or native Claude/Codex/OpenCode/Hermes CLIs, and it must not scrape raw Hermes profile databases, provider auth, env, or unbounded transcripts/logs. `docs/WORKBENCH_BOUNDARY.md` is the canonical source for #552 workbench nouns (`WorkContext`, `Actor`, `TaskRef`, `Artifact`, `AuditEvent`, `CapabilityGrant`, etc.) and mobile/pair/dogfood journey acceptance criteria.
+
 Input: browser keystrokes, session management commands, clipboard images.
 Output: terminal rendering via xterm.js, real-time session state updates.
 
@@ -15,6 +17,8 @@ The system has two compilation targets: a TypeScript + ESM backend (Express + no
 ## Six-Layer Vocabulary Contract (#444)
 
 Relay's product information architecture is now described as **View -> Workspace -> Project -> Instance -> Bench -> Tab**. This vocabulary is a source-of-truth for docs and implementation planning; it does not mean every layer must be visible in every UI state. The single-repo golden path should stay compact, while remote, non-repo, and multi-node states expose the layer needed to avoid false repo/worktree assumptions.
+
+The #552 workbench/control-plane nouns in `docs/WORKBENCH_BOUNDARY.md` are compatible with this tree rather than a replacement for it: `WorkContext` is the cross-cutting work envelope, `RepoInstance` maps to a git-specific Instance, `WorktreeInstance` maps to a git-specific Bench, and `Session`/browser Tab remain separate process/surface concepts.
 
 | Layer         | What it answers                                       | Current / compatibility boundary                                                                                                                                                                                       |
 | ------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -101,8 +105,8 @@ Keep these names precise where they describe implemented plumbing:
 | `node-manifest.ts`                      | Local node capability manifest: probes platform/arch/hostname/version, WSL, service manager, tmux/git/clipboard/browser/gh/tailscale/ssh, and agent tool availability non-fatally                                                                                  |
 | `local-node.ts`                         | Local node state: identity, manifest, repo inventory, credential storage, and heartbeat sender for the current machine when acting as a node                                                                                                                       |
 | `hub-node-router.ts`                    | Express Router for hub/node REST API: pair tokens, pairing exchange, node heartbeat, node listing, direct session creation routing, manual/online credential rotation, rotation clear-recovery, node revocation                                                    |
-| `hub-node-registry.ts`                  | Pair-token lifecycle, SHA256-hashed credential storage, timing-safe authentication, hub-owned ACL policy/default migration, heartbeat state tracking, credential rotation proof/audit, offline/stale/revoked status, registry persistence with debounced writes |
-| `security-audit-log.ts`                 | Hash-chained security audit persistence: append-only SQLite table, atomic inserts, verifier for gaps/tamper/corruption, and CLI-facing verification result shape                                                                                       |
+| `hub-node-registry.ts`                  | Pair-token lifecycle, SHA256-hashed credential storage, timing-safe authentication, hub-owned ACL policy/default migration, heartbeat state tracking, credential rotation proof/audit, offline/stale/revoked status, registry persistence with debounced writes    |
+| `security-audit-log.ts`                 | Hash-chained security audit persistence: append-only SQLite table, atomic inserts, verifier for gaps/tamper/corruption, and CLI-facing verification result shape                                                                                                   |
 | `hub-node-link.ts`                      | Reverse WebSocket link manager: node link registration, RPC request/response, PTY stream proxy between browser and node, node event broadcast, cleanup on disconnect/revocation                                                                                    |
 | `repo-inventory.ts`                     | Local repo inventory collection: workspace scanning, git remote normalization, capability-gated repo identity resolution                                                                                                                                           |
 | `features/repo-inventory.ts`            | Repo inventory feature service: stores node-reported inventory snapshots and aggregates local + remote reports by canonical repo identity                                                                                                                          |
@@ -117,7 +121,7 @@ Compiled by both `tsconfig.json` (server build) and `frontend/tsconfig.json` (Vi
 | Module                     | Role                                                                                                                                                 |
 | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `chat-events.ts`           | `ChatEvent` discriminated union and type guards — the wire protocol for web-chat transcripts                                                         |
-| `control-state.ts`         | Product control-state summary and tab intervention event contracts; keeps `controlMode` independent from transport `mode`                             |
+| `control-state.ts`         | Product control-state summary and tab intervention event contracts; keeps `controlMode` independent from transport `mode`                            |
 | `mobile-input-pipeline.ts` | Pure-function event-intent pipeline for mobile virtual keyboard input — consumed by the React `MobileInput` component; unit-tested via JSON fixtures |
 | `node-manifest.ts`         | Shared `NodeManifest` / `NodeCapabilities` schema for platform, service manager, WSL, and tool/agent capability probes                               |
 | `bootstrap-diagnostics.ts` | Relay-node bootstrap command generation, redaction helpers, and diagnostics taxonomy for local/SSH/Tailscale pairing                                 |
@@ -259,7 +263,7 @@ This makes Tab and pane customization (#263) viable without losing process owner
 | `POST`   | `/hub/pair-tokens`                       | Create a short-lived relay-node pair token with redacted-safe SSH/Tailscale/local bootstrap command variants                                        |
 | `POST`   | `/hub/pairing/exchange`                  | Exchange a one-time pair token for a persistent revocable node credential                                                                           |
 | `POST`   | `/hub/node-heartbeat`                    | Authenticated relay-node heartbeat using the persistent node credential                                                                             |
-| `GET`    | `/nodes`                                 | List paired nodes with heartbeat status, reverse-link connection state, manifest capability summary, and hub-owned ACL policy summary                 |
+| `GET`    | `/nodes`                                 | List paired nodes with heartbeat status, reverse-link connection state, manifest capability summary, and hub-owned ACL policy summary               |
 | `GET`    | `/hub/repo-inventory`                    | Aggregate local + node-reported repo inventory by canonical git remote identity                                                                     |
 | `POST`   | `/hub/nodes/:nodeId/sessions`            | Route terminal/agent session creation to an online node over reverse-link RPC; RPC body uses `repoPath`, `worktreePath`, and `cwd`                  |
 | `DELETE` | `/hub/nodes/:nodeId/sessions/:sessionId` | Kill a node-local session through reverse-link RPC                                                                                                  |

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,28 +4,29 @@ This index separates current source-of-truth docs from historical plans and spik
 
 ## Current source of truth
 
-| Area                  | File                          | Use it for                                                       |
-| --------------------- | ----------------------------- | ---------------------------------------------------------------- |
-| Top-level agent map   | `../AGENTS.md`                | Repo conventions, command quick reference, compact docs map      |
-| User onboarding       | `../README.md`                | Install, run, CLI, config, hub/node overview                     |
-| Product/design system | `../DESIGN.md`                | Product positioning, visual language, spacing/color/button rules |
-| Architecture          | `ARCHITECTURE.md`             | Module boundaries, API routes, data flow, ADR index              |
-| Backend design notes  | `DESIGN.md`                   | Backend patterns, auth/session/PTY behavior                      |
-| Frontend              | `FRONTEND.md`                 | React components, frontend state, UI entrypoints                 |
-| Quality               | `QUALITY.md`                  | Test strategy, isolation rules, known gate behavior              |
-| Review                | `REVIEW_GUIDANCE.md`          | Reviewer prompts, risk areas, escape log                         |
-| Deployment            | `references/deployment.md`    | Branching, npm channels, publishing flow                         |
-| Self-hosting          | `SELF_HOSTING.md`             | Running Relay from inside Relay with isolated config/ports       |
-| Security policy       | `SECURITY_POLICY.md`          | Trust tiers, capability bits, hub ACL defaults                   |
-| Hub/node packaging    | `RELAY_HUB_NODE_PACKAGING.md` | Hub/node command shape and npm packaging decisions               |
-| Node bootstrap        | `RELAY_NODE_BOOTSTRAP.md`     | Pair/install/update/unpair flows and diagnostics                 |
-| Federated dev         | `FEDERATED_DEV.md`            | Multi-machine dev workflow and version-skew handling             |
-| Federated Relay       | `federated-relay.md`          | Hub/node architecture, pairing, routing, ADR history             |
-| Learnings             | `LEARNINGS.md`                | Durable repo learnings gathered across sessions                  |
+| Area                  | File                          | Use it for                                                             |
+| --------------------- | ----------------------------- | ---------------------------------------------------------------------- |
+| Top-level agent map   | `../AGENTS.md`                | Repo conventions, command quick reference, compact docs map            |
+| User onboarding       | `../README.md`                | Install, run, CLI, config, hub/node overview                           |
+| Product/design system | `../DESIGN.md`                | Product positioning, visual language, spacing/color/button rules       |
+| Architecture          | `ARCHITECTURE.md`             | Module boundaries, API routes, data flow, ADR index                    |
+| Workbench boundary    | `WORKBENCH_BOUNDARY.md`       | Relay-as-control-plane scope, canonical nouns, mobile/dogfood journeys |
+| Backend design notes  | `DESIGN.md`                   | Backend patterns, auth/session/PTY behavior                            |
+| Frontend              | `FRONTEND.md`                 | React components, frontend state, UI entrypoints                       |
+| Quality               | `QUALITY.md`                  | Test strategy, isolation rules, known gate behavior                    |
+| Review                | `REVIEW_GUIDANCE.md`          | Reviewer prompts, risk areas, escape log                               |
+| Deployment            | `references/deployment.md`    | Branching, npm channels, publishing flow                               |
+| Self-hosting          | `SELF_HOSTING.md`             | Running Relay from inside Relay with isolated config/ports             |
+| Security policy       | `SECURITY_POLICY.md`          | Trust tiers, capability bits, hub ACL defaults                         |
+| Hub/node packaging    | `RELAY_HUB_NODE_PACKAGING.md` | Hub/node command shape and npm packaging decisions                     |
+| Node bootstrap        | `RELAY_NODE_BOOTSTRAP.md`     | Pair/install/update/unpair flows and diagnostics                       |
+| Federated dev         | `FEDERATED_DEV.md`            | Multi-machine dev workflow and version-skew handling                   |
+| Federated Relay       | `federated-relay.md`          | Hub/node architecture, pairing, routing, ADR history                   |
+| Learnings             | `LEARNINGS.md`                | Durable repo learnings gathered across sessions                        |
 
 ## Vocabulary baseline
 
-Use the six-layer IA vocabulary consistently in current docs:
+`WORKBENCH_BOUNDARY.md` is the canonical source for Relay's workbench/control-plane boundary, #552 nouns, and mobile/pair/dogfood journey acceptance criteria. Use the six-layer IA vocabulary consistently in current docs:
 
 1. View — UI mode or surface.
 2. Workspace — grouping/config/pins layer; not a synonym for repo.

--- a/docs/WORKBENCH_BOUNDARY.md
+++ b/docs/WORKBENCH_BOUNDARY.md
@@ -1,0 +1,167 @@
+# Relay workbench boundary
+
+Relay is a federated workbench and control plane for agentic development across online devices. It connects existing tools, sessions, tasks, repos, worktrees, artifacts, and operators into one shared work surface.
+
+Relay is not the runtime, task tracker, source host, or memory system of record. Native agent CLIs, Hermes Agent, GitHub, Kanban, shells, tmux, and node-local filesystems keep owning their domains. Relay's job is shared identity, routing, context handoff, bounded inspection/control, and audit trails.
+
+Status: this document is the product/docs contract for #552/#553. It defines vocabulary and acceptance boundaries for follow-up schema, API, UI, mobile, and dogfood work; it does not claim those follow-up implementations have landed.
+
+## Product thesis
+
+Relay should answer:
+
+> What work is happening across my devices, who or what is doing it, where is it running, what task/repo/worktree/session does it belong to, and what can I safely inspect or control from this device?
+
+The product promise is not "run every agent inside Relay." The promise is: start or observe work anywhere, attach from any device, hand control between assistant/terminal/pair sessions, and keep a bounded audit trail without forcing the operator to reconstruct state from terminals, chats, issue comments, PRs, and logs.
+
+Mobile is a first-class control surface: status, latest bounded output, artifacts, approvals, small input, attach, hand-back, pause/kill/retry where policy allows, and stale/offline state. It is not a full phone IDE.
+
+## Hard boundaries and non-goals
+
+Relay must not:
+
+- replace Hermes Agent, Hermes dashboard, hermes-workspace, GitHub, Kanban, tmux, or native Claude/Codex/OpenCode/Hermes CLIs;
+- scrape, sync, or become a source of truth for raw Hermes profile SQLite DBs, memory stores, provider auth, env, or unbounded transcript/log history;
+- clone GitHub Issues, Kanban, or any future task system as owned storage; those remain external `TaskRef`s linked into `WorkContext`;
+- turn mobile into a worse phone IDE; mobile v1 is status/control/artifact/approval oriented, not bulk editing, broad file navigation, or high-risk write workflows;
+- treat a node capability probe as permission. A node manifest says "can"; hub policy and `CapabilityGrant` say "may";
+- require repo/worktree identity for every surface. Repo/worktree is the golden path, but remote/free/non-git Tabs still need valid `Node`, `cwd`, `kind`, `Session`, and `WorkContext` representation;
+- bundle the broad #444 IA migration, #428 write-capable File RPC, raw transcript export, or universal task database into the #552 workbench spine.
+
+## Canonical nouns
+
+These nouns are the shared language for #552 follow-up work. Future shared schemas should use these names or explicitly map to them.
+
+| Noun               | Definition                                                                                                                                                   | Boundary                                                                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `Node`             | An online/stale/offline execution device exposing local Relay capabilities.                                                                                  | A node is a paired execution host, not a trust grant. Capabilities still require hub policy.                                       |
+| `Actor`            | A human or agent runtime participating in work.                                                                                                              | Actor identity describes who/what acted; it does not imply ownership of the node or task system.                                   |
+| `WorkContext`      | The durable envelope tying task refs, repo/project refs, worktree/cwd/session refs, actors, artifacts, and audit refs together.                              | This is Relay's context spine, not a transcript dump or task database clone.                                                       |
+| `Session`          | A node-owned terminal, agent, web-chat, or process session that can be attached to or summarized.                                                            | Sessions are execution/process handles; a browser Tab may render or attach to one.                                                 |
+| `TaskRef`          | An external task source reference such as a GitHub issue, Kanban row, PR, or future task system item.                                                        | Relay links to task systems; it does not own their canonical state.                                                                |
+| `RepoInstance`     | A repo checkout on a specific node, identified by node-scoped path plus repo identity where available.                                                       | Git-specific Instance compatibility shape; paths are not global IDs.                                                               |
+| `WorktreeInstance` | A git worktree on a specific node, identified by node-scoped worktree path plus related repo metadata where available.                                       | Git-specific Bench compatibility shape; free/non-git cwd must still be representable without it.                                   |
+| `Artifact`         | A bounded external or Relay-produced evidence handle: PR, log, screenshot, diagnostic bundle, summary, recording, test report, etc.                          | Prefer refs, hashes, sizes, and summaries over raw secret-bearing payloads.                                                        |
+| `AuditEvent`       | An append-only event describing important work/context/control/security transitions.                                                                         | Audit rows record compact identifiers, decisions, hashes, and redaction metadata; they are not raw terminal or transcript storage. |
+| `CapabilityGrant`  | A scoped permission allowing an Actor or client to inspect, control, read, write, execute, approve, retry, pause, kill, or attach within a defined boundary. | Grants are separate from node manifests and should be visible enough for operators to understand blast radius.                     |
+
+## Compatibility with the six-layer vocabulary
+
+The #444 information architecture remains: **View -> Workspace -> Project -> Instance -> Bench -> Tab**. The workbench nouns do not rename that tree; they give the federated work/control spine a precise vocabulary.
+
+| Six-layer term | Workbench mapping                                                                                                                                                       |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| View           | A browser/mobile lens over WorkContexts, Nodes, Projects, Sessions, Artifacts, or things needing the operator.                                                          |
+| Workspace      | User grouping/config/pins. It may organize Projects and WorkContexts, but it is not a repo path.                                                                        |
+| Project        | The "what" being worked on. A git repo identity is the common Project kind; agent/playbook/node-target Projects may exist later.                                        |
+| Instance       | Where a Project is realized. `RepoInstance` is the git-specific compatibility shape.                                                                                    |
+| Bench          | The active cwd/environment arrangement inside an Instance. `WorktreeInstance` is the git worktree compatibility shape.                                                  |
+| Tab            | The leaf surface: terminal, agent chat, file, diff, preview, or other attach/render surface. It carries `nodeId`, `cwd`, `kind`, and optional repo/worktree decoration. |
+
+Rules of thumb:
+
+- Use repo/worktree nouns only for git-specific affordances and destructive git operations.
+- Use `WorkContext` when the user-facing question is "what work is this part of?"
+- Use `Session`/`Tab` when the user-facing question is "what process or surface am I attached to?"
+- Use `CapabilityGrant` when the user-facing question is "what is this device/client/actor allowed to do?"
+
+## Canonical user journeys as acceptance criteria
+
+These journeys are acceptance criteria for future workbench/mobile/dogfood implementation. They are not claims about current shipped behavior.
+
+### 1. Phone status/control
+
+As the operator away from the desk, I open Relay on my phone and see active work grouped by `WorkContext`: task, repo/project if any, node, active actor, session/tab, latest bounded status/output, blockers/approvals, and artifacts.
+
+Acceptance criteria:
+
+- phone view prioritizes "what needs me" before raw terminal rendering;
+- raw PTY attach remains available but is not the primary mobile surface;
+- I can approve/deny a pending prompt, send a short text input, pause/kill/retry where policy allows, and open a PR/log/screenshot/diagnostic artifact;
+- destructive controls require an explicit `CapabilityGrant` and visible `AuditEvent`;
+- offline/stale nodes preserve last-known context, show freshness, and disable live controls.
+
+### 2. Tablet/laptop attach
+
+As the operator on a tablet or secondary laptop, I can attach to an existing tab/session without losing the work context.
+
+Acceptance criteria:
+
+- attach is a handle on an existing Relay `Session`, not a hidden new agent runtime;
+- the UI shows node, cwd, kind, active actors/control mode, task refs, artifacts, and hand-back state;
+- I can switch from summary/control view into terminal attach when I need deeper interaction;
+- hand-back requires acknowledgement of latest human intervention where applicable;
+- free/non-git tabs do not inherit stale local repo badges or actions.
+
+### 3. Desktop/devbox handoff
+
+As the operator at a devbox, I can start work from assistant/messaging, have Relay create or associate a `WorkContext`, spawn or attach a Claude/Codex/Hermes pair session in the right node/cwd/worktree, then return control to the assistant with enough context to resume without archaeology.
+
+Acceptance criteria:
+
+- native agent CLIs remain the runtime;
+- Relay records identity, routing, control, artifact, and audit metadata;
+- assistant resume consumes bounded summaries, artifact refs, and audit refs, not raw transcript dumps by default;
+- node/cwd/worktree/session identity is explicit enough that Relay does not route resume work to the wrong local checkout.
+
+## V1 dogfood acceptance loop
+
+A v1 Relay-develops-Relay dogfood is acceptable only when this loop works end-to-end:
+
+1. Assistant/messaging starts or claims a Relay development task and creates or links a `WorkContext` with at least task ref, repo/project ref, intended node/cwd/worktree/bench if known, initiating actor, and requested agent/runtime.
+2. Relay shows that `WorkContext` on desktop and mobile with correct node/session/control state.
+3. The operator opens Relay and starts or attaches a Claude/Codex/Hermes pair session under that same `WorkContext`.
+4. During the pair session, Relay records bounded events: session start/resume/end, actor/control mode changes, approval/intervention summaries, tool/activity summaries, artifacts, and policy/audit decisions.
+5. The operator can inspect latest bounded output/artifacts from phone, send small scoped input or approval, and pause/kill/retry only when capability policy allows.
+6. If the node drops offline, Relay preserves stale read state, shows last-seen timestamps, disables live controls, and does not silently route to the wrong repo/session.
+7. The assistant can resume from Relay `WorkContext` after the pair session with a compact summary, artifact refs, and audit refs sufficient to continue or close the task.
+8. Dogfood uses isolated Relay config/ports and has an operator recovery path for stuck sessions, bad node links, broken plugin events, and audit/diagnostics collection.
+
+## Hermes Agent integration boundary
+
+Relay needs a Hermes Agent plugin or integration layer that emits Relay-useful metadata without making Relay scrape raw Hermes profile state.
+
+Minimum useful event envelope for future schema work:
+
+- event id, schema version, timestamp, source, profile, and stable run/session ids where available;
+- actor identity: human/agent, profile name, runtime (`hermes`, `claude`, `codex`, `opencode`, etc.), and model/provider when non-sensitive;
+- `workContextId` if known, plus task refs such as GitHub issue/PR, Kanban task id, branch/worktree intent;
+- node/cwd/repo/worktree/bench context with node-scoped paths only;
+- session lifecycle: started/resumed/ended/blocked/completed/crashed/timed_out;
+- parent/child session links when Hermes spawns Claude/Codex/Hermes or delegates work;
+- turn/tool summaries: tool name/category, status, compact result/error summary, duration, and artifact refs, without raw secret-bearing inputs by default;
+- control/intervention events: approval requested/approved/denied, clarify/block, hand-back acknowledgement, pause/kill/retry;
+- artifacts: PR URL, issue comment URL, diff/log/diagnostic bundle refs, screenshots, QA evidence refs;
+- redaction/privacy metadata: payload class, raw payload availability false by default, hash/size where needed, retention class.
+
+Non-goals for this integration:
+
+- no raw Hermes DB sync;
+- no Hermes memory provider role;
+- no Hermes dashboard clone;
+- no raw env/provider auth/secrets/unbounded logs;
+- no implicit transcript export into mobile or audit views.
+
+## Follow-up evidence matrix
+
+| Requirement          | Evidence expected before dependent work claims completion                                                      |
+| -------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Product boundary     | Current docs state Relay is a workbench/control plane and list the hard non-goals above.                       |
+| Canonical nouns      | Shared/server/frontend contracts use or explicitly map to the canonical nouns in this document.                |
+| WorkContext schema   | Shared schema includes task refs, actors, node/session, optional repo/bench links, artifacts, and audit refs.  |
+| Hermes metadata      | Fixture events cover task lifecycle, tool summary, child session, artifact, and redaction metadata.            |
+| Federated visibility | Two-node scenario shows online/stale/offline nodes and node-owned sessions without path-only identity.         |
+| Mobile control       | Phone viewport test covers latest status, artifact open, approval/small input, and disabled stale controls.    |
+| Pair handoff         | Dogfood trace covers assistant/messaging -> Relay context -> pair session -> assistant resume.                 |
+| Privacy/audit        | Tests prove default Relay event/audit rows do not contain raw env, tokens, transcript bytes, or provider auth. |
+| Recovery             | Dogfood config is isolated and diagnostics exist for stuck node/session/plugin cases.                          |
+
+## Sources
+
+- GitHub issue #552 body and product/planner comments.
+- GitHub issue #553 acceptance criteria.
+- `docs/ARCHITECTURE.md` for hub/node, six-layer vocabulary, current/deferred implementation state.
+- `docs/federated-relay.md` for node/session routing, stale/offline states, and control/audit boundaries.
+- `docs/CLI_GATEWAY.md` for adapter-facing session descriptors and gateway boundaries.
+- `docs/SECURITY_POLICY.md` for capability grant and audit separation.
+- `DESIGN.md` for mobile-friendly terminal-native product framing and tab-context expectations.

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -2,6 +2,8 @@
 
 Relay IDE can run as a **hub** that tracks multiple **relay-nodes** — personal machines running Relay as execution hosts. From any browser connected to the hub, a user sees which nodes are online, what repositories each node has checked out, and can start terminal/agent sessions on the chosen node. This document describes the architecture, pairing lifecycle, steady-state reverse WebSocket model, session routing, security model, operator runbook, and explicitly out-of-scope items.
 
+Relay's product boundary is broader than terminal routing but narrower than an IDE/runtime clone: Relay is the federated workbench/control plane for shared identity, routing, context handoff, bounded inspection/control, and audit trails. It connects existing agent CLIs, Hermes/Kanban/GitHub refs, tmux sessions, node-local repos/worktrees, and artifacts without replacing those source systems or scraping raw profile/transcript state. See `docs/WORKBENCH_BOUNDARY.md` for the canonical #552 nouns and mobile/pair/dogfood acceptance criteria.
+
 > Terminology is deliberate: `hub` (control plane + UI), `node` (execution host), `client` (browser). A hub is just a `relay-ide` server that has accepted node registrations; a node is just a `relay-ide` install on another host.
 
 ## Overview
@@ -40,15 +42,17 @@ Planned/deferred:
 
 ## Hub/Node/Client Terminology
 
-| Term                  | Definition                                                                                                                                                                                                                                            |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Hub**               | A `relay-ide` server configured to accept node registrations. May also host its own local sessions (the hub can act as its own node).                                                                                                                 |
-| **Node**              | A Relay install on a machine that pairs with a hub and executes sessions locally.                                                                                                                                                                     |
-| **Client UI**         | The React 19 frontend running in a browser connected to the hub.                                                                                                                                                                                      |
-| **Repo identity**     | Canonical repository identity derived from git remotes (e.g. `github.com/donovan-yohan/relay-ide`). Same repo cloned on different nodes shares one identity.                                                                                          |
-| **Repo instance**     | A node-local checkout of a repo, identified by `(nodeId, repoPath)`.                                                                                                                                                                                  |
-| **Worktree instance** | A node-local git worktree, identified by `(nodeId, worktreePath)`.                                                                                                                                                                                    |
-| **Global session ID** | A node-scoped session identifier produced by `createGlobalSessionId` in `shared/identity.ts`: `{encodeURIComponent(nodeId)}:{encodeURIComponent(localSessionId)}`. No prefix — the node ID and local ID are URL-encoded and joined by a single colon. |
+`docs/WORKBENCH_BOUNDARY.md` is the canonical definition point for `Node`, `Actor`, `WorkContext`, `Session`, `TaskRef`, `RepoInstance`, `WorktreeInstance`, `Artifact`, `AuditEvent`, and `CapabilityGrant`. This section maps those workbench nouns onto the existing federated hub/node implementation without redefining them as a different model.
+
+| Term                  | Definition                                                                                                                                                                                                                                            | Workbench mapping                                                          |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **Hub**               | A `relay-ide` server configured to accept node registrations. May also host its own local sessions (the hub can act as its own node).                                                                                                                 | Control-plane host for workbench routing and policy.                       |
+| **Node**              | A Relay install on a machine that pairs with a hub and executes sessions locally.                                                                                                                                                                     | `Node`.                                                                    |
+| **Client UI**         | The React 19 frontend running in a browser connected to the hub.                                                                                                                                                                                      | Device-specific view over WorkContexts, Sessions, Nodes, and Artifacts.    |
+| **Repo identity**     | Canonical repository identity derived from git remotes (e.g. `github.com/donovan-yohan/relay-ide`). Same repo cloned on different nodes shares one identity.                                                                                          | Repo-kind Project identity.                                                |
+| **Repo instance**     | A node-local checkout of a repo, identified by `(nodeId, repoPath)`.                                                                                                                                                                                  | `RepoInstance`; git-specific Instance compatibility shape.                 |
+| **Worktree instance** | A node-local git worktree, identified by `(nodeId, worktreePath)`.                                                                                                                                                                                    | `WorktreeInstance`; git-specific Bench compatibility shape.                |
+| **Global session ID** | A node-scoped session identifier produced by `createGlobalSessionId` in `shared/identity.ts`: `{encodeURIComponent(nodeId)}:{encodeURIComponent(localSessionId)}`. No prefix — the node ID and local ID are URL-encoded and joined by a single colon. | Internal routing identity for a `Session`, not a user-facing work context. |
 
 ## Six-Layer Vocabulary Mapping (#444)
 
@@ -307,8 +311,8 @@ The registry is stored in `<configDir>/hub-node-registry.json` (mode `0600`) wit
 | Comparison                           | `crypto.timingSafeEqual` on hex buffers                           |
 | Pair token lifetime                  | Default 10 minutes; single-use; consumed on exchange              |
 | Registry file                        | Written with `0600` mode; atomic write via temp+rename            |
-| Rotation audit                      | Proof writes `rotation` / `rotated` with credential IDs only     |
-| ACL policy updates                  | Hub policy decisions apply immediately; no rotation wait         |
+| Rotation audit                       | Proof writes `rotation` / `rotated` with credential IDs only      |
+| ACL policy updates                   | Hub policy decisions apply immediately; no rotation wait          |
 | Revocation                           | Immediate; active links are killed; no grace period               |
 
 This table is the implemented security boundary. Control-state fields from #490 are renderable state only; they are not policy decisions and do not imply additional capability gates beyond the hub policy evaluator, trust-tier overrides outside the ACL schema, or raw/control payload duplication into hash-chained audit logging.
@@ -576,11 +580,11 @@ All diagnostics redact secrets (pair tokens, bearer headers, credentials) before
 
 Trust tiers describe blast radius, not vague safety:
 
-| Tier | Blast radius |
-| ---- | ------------ |
-| `sandbox` | Experimental/constrained node. Keep grants narrow. |
-| `dev` | Default legacy private-infra node. Read/session-safe bits are granted by migration; destructive bits stay off. |
-| `prod` | Sensitive node. High-risk allowed bits may be elevated to confirmation-required, never silently widened. |
+| Tier      | Blast radius                                                                                                   |
+| --------- | -------------------------------------------------------------------------------------------------------------- |
+| `sandbox` | Experimental/constrained node. Keep grants narrow.                                                             |
+| `dev`     | Default legacy private-infra node. Read/session-safe bits are granted by migration; destructive bits stay off. |
+| `prod`    | Sensitive node. High-risk allowed bits may be elevated to confirmation-required, never silently widened.       |
 
 The hub owns ACL policy. Node manifests report availability/probe data only — e.g. `git` availability says whether the node can run git, not whether `rpc:git:write` is granted. Legacy paired nodes are migrated to a default `dev` ACL with session/read bits on and file write/delete, git write, arbitrary exec, and preview/port-forward off unless explicitly granted. See `docs/SECURITY_POLICY.md` and `shared/security-policy.ts`.
 
@@ -635,9 +639,14 @@ These were considered during design but are **not implemented** and should not b
 - **Cross-host tmux session transfer** — Sessions are node-local; re-creating on another node is a cold start.
 - **Real-time workspace state sync** — No conflict-free replicated worktree state.
 - **Full #444 IA migration** — This document maps federation terms to the six-layer vocabulary, but it does not implement Workspace/Project/Instance/Bench CRUD, #473 right-rail migration, #428 file RPC, or a Worker tree node.
+- **Raw Hermes state sync** — Relay should receive bounded Hermes plugin/integration metadata; it must not scrape or sync raw Hermes profile DBs, memory stores, provider auth, env, or unbounded transcripts/logs.
+- **Hermes/GitHub/Kanban/native-agent replacement** — Relay links and controls existing systems through scoped refs and adapters; it does not clone their dashboards or become their storage/runtime owner.
+- **Phone IDE** — Mobile control prioritizes status, approvals, small input, artifacts, attach, and safe pause/kill/retry. Bulk editing, broad file navigation, and high-risk write flows are out of scope for the v1 workbench loop.
+- **Capability probe as permission** — Node manifest availability never grants authority by itself; hub policy and scoped capability grants decide whether an action may run.
 
 ## See Also
 
+- `docs/WORKBENCH_BOUNDARY.md` — Product boundary, #552 canonical workbench nouns, and mobile/pair/dogfood acceptance criteria
 - `docs/RELAY_NODE_BOOTSTRAP.md` — Detailed pairing commands, per-platform service setup, and bootstrap diagnostics
 - `docs/ARCHITECTURE.md` — Module boundaries, REST/WebSocket API tables, composition-root invariants
 - `docs/DESIGN.md` — Backend patterns, PTY management, session types, config precedence


### PR DESCRIPTION
## Summary
- Adds `docs/WORKBENCH_BOUNDARY.md` as the source-of-truth boundary for Relay as a federated workbench/control plane.
- Defines the #552 canonical nouns once: `Node`, `Actor`, `WorkContext`, `Session`, `TaskRef`, `RepoInstance`, `WorktreeInstance`, `Artifact`, `AuditEvent`, and `CapabilityGrant`.
- Captures phone status/control, tablet/laptop attach, desktop/devbox handoff, and Relay-develops-Relay dogfood loops as acceptance criteria rather than shipped behavior.
- Cross-references the boundary from `AGENTS.md`, `docs/README.md`, `docs/ARCHITECTURE.md`, and `docs/federated-relay.md` while preserving the #444 six-layer vocabulary.

Closes #553
Refs #552

## The case against
This PR may still be too broad for a docs-only slice: `docs/WORKBENCH_BOUNDARY.md` is intentionally comprehensive so downstream work has a stable fence, but that also means it introduces a lot of future-facing vocabulary before the matching schemas exist. I tried to mitigate that by labeling the document as a product/docs contract and repeatedly saying the journeys are acceptance criteria, not shipped implementation.

The other risk is duplicate terminology drift: `docs/federated-relay.md` already has low-level hub/node terms, so this PR points those terms at the canonical boundary doc instead of making a second full glossary there.

## Verification
- `npm ci`
- `./node_modules/.bin/prettier --check AGENTS.md docs/README.md docs/ARCHITECTURE.md docs/federated-relay.md docs/WORKBENCH_BOUNDARY.md`
- `npm run check` (passes with existing warnings only)
- `npm run build` (passes; existing chunk-size warning)
- `git diff --check`
