### PR TITLE
feat: add Hermes metadata event ingestion spike

### DIFF
--- a/docs/spikes/hermes-metadata-event-ingestion.md
+++ b/docs/spikes/hermes-metadata-event-ingestion.md
@@ -1,0 +1,53 @@
+# Hermes metadata event ingestion spike (#556)
+
+Status: spike handler implemented, route deferred.
+
+## Decision
+
+Relay should accept Hermes Agent integration data only as bounded metadata events. The shared contract lives in `shared/hermes-metadata-events.ts` and is deliberately narrower than a generic payload envelope:
+
+- required identity: `eventId`, `schemaVersion`, timestamp, Hermes source profile/runtime, actor, event kind, and status;
+- work linkage: `workContextId`, task refs, node/session/cwd anchors, optional repo/worktree/project refs;
+- bounded work evidence: child session refs, tool summaries, artifact refs, and audit hints;
+- privacy/retention: every event and artifact carries `WorkContextPrivacyMetadata` with `rawPayloadStored: false` by default.
+
+The spike intentionally does not mount a public ingestion endpoint yet. That keeps the privacy boundary reviewable before adding auth, storage, rate limits, and replay semantics. yeah, shipping a route before proving the filter would be how the cursed sqlite-scraper gremlin gets in.
+
+## Explicitly rejected by the validator
+
+The spike handler rejects events containing raw/secret/transcript-shaped keys anywhere in the object tree, including:
+
+- env and process environment shapes;
+- provider auth, bearer/API token shapes;
+- raw payload/content/log/stdout/stderr/scrollback fields;
+- transcript, conversation, or messages fields;
+- Hermes profile DB path / SQLite DB path fields;
+- events or artifacts with `privacy.rawPayloadStored: true`.
+
+This is intentionally conservative. If a future Hermes plugin needs a raw payload exception, it should be a separate privileged capability with explicit operator policy, not a default metadata ingestion behavior.
+
+## Fixture coverage
+
+Fixtures live under `test/fixtures/hermes-metadata-events/`:
+
+- `session-lifecycle-started.json` proves lifecycle status, task refs, node/cwd/repo/worktree links, artifact refs, and privacy metadata;
+- `tool-summary.json` proves compact tool result metadata;
+- `child-session-linked.json` proves parent/child session linkage;
+- `artifact-recorded.json` proves PR/diagnostic artifact refs without raw evidence blobs.
+
+`test/hermes-metadata-events.test.ts` validates all fixtures and rejects malformed unsafe payloads.
+
+## Next implementation recommendation
+
+Open a follow-up issue to add an authenticated server route, probably `POST /integrations/hermes/events`, that calls `ingestHermesMetadataEventCandidate()` and persists only accepted metadata into the future WorkContext/audit store.
+
+Minimum route requirements before merge:
+
+1. Auth: localhost/plugin token or hub policy grant; never browser PIN cookies alone for agent plugin ingestion.
+2. Storage: append accepted event metadata only; no raw payload/blob table.
+3. Replay/idempotency: de-duplicate by `eventId` plus source profile/runtime/run/session.
+4. Privacy audit: preserve `privacy`, redaction class, retention class, and artifact pointer metadata.
+5. Backpressure: size cap and rate limit before JSON parse can become a footgun.
+6. Tests: keep the current fixture tests and add route tests for accepted event, duplicate event, unauthenticated event, oversized body, raw env, secret key, and transcript-shaped body.
+
+Do not implement raw Hermes DB sync, Hermes memory-provider behavior, provider auth/env capture, or raw transcript export as part of this lane.

--- a/shared/hermes-metadata-events.ts
+++ b/shared/hermes-metadata-events.ts
@@ -234,6 +234,136 @@ const TOP_LEVEL_KEYS = new Set<string>([
   'privacy',
   'audit',
 ]);
+const SOURCE_KEYS = new Set<string>([
+  'kind',
+  'profile',
+  'runtime',
+  'provider',
+  'model',
+  'runId',
+  'sessionId',
+  'pluginVersion',
+]);
+const ACTOR_KEYS = new Set<string>([
+  'kind',
+  'id',
+  'displayName',
+  'providerId',
+  'nodeId',
+  'sessionId',
+  'profile',
+  'runtime',
+  'model',
+]);
+const WORK_CONTEXT_KEYS = new Set<string>([
+  'workContextId',
+  'taskRefs',
+  'anchors',
+  'relatedContextRefs',
+]);
+const TASK_REF_KEYS = new Set<string>([
+  'kind',
+  'id',
+  'title',
+  'url',
+  'status',
+  'parentRef',
+  'privacy',
+]);
+const ANCHORS_KEYS = new Set<string>([
+  'node',
+  'session',
+  'project',
+  'repo',
+  'worktree',
+]);
+const NODE_ANCHOR_KEYS = new Set<string>([
+  'nodeId',
+  'kind',
+  'displayName',
+  'online',
+]);
+const SESSION_ANCHOR_KEYS = new Set<string>([
+  'nodeId',
+  'sessionId',
+  'globalSessionId',
+  'tabId',
+  'tabKind',
+  'cwd',
+]);
+const PROJECT_ANCHOR_KEYS = new Set<string>([
+  'workspaceId',
+  'projectId',
+  'instanceId',
+  'benchId',
+]);
+const REPO_ANCHOR_KEYS = new Set<string>([
+  'repoIdentity',
+  'repoInstanceId',
+  'ownerRepo',
+  'remoteUrl',
+  'localPath',
+  'branchName',
+]);
+const WORKTREE_ANCHOR_KEYS = new Set<string>([
+  'worktreeInstanceId',
+  'localPath',
+  'branchName',
+]);
+const CHILD_SESSION_KEYS = new Set<string>([
+  'sessionId',
+  'runtime',
+  'profile',
+  'runId',
+  'parentSessionId',
+  'nodeId',
+  'cwd',
+  'status',
+]);
+const TOOL_KEYS = new Set<string>([
+  'name',
+  'category',
+  'status',
+  'durationMs',
+  'summary',
+  'errorSummary',
+  'artifactIds',
+]);
+const ARTIFACT_KEYS = new Set<string>([
+  'id',
+  'kind',
+  'title',
+  'uri',
+  'path',
+  'mediaType',
+  'producedByActorId',
+  'producedAt',
+  'summary',
+  'privacy',
+]);
+const PRIVACY_KEYS = new Set<string>([
+  'classification',
+  'retention',
+  'rawPayloadStored',
+  'redaction',
+  'policyRefs',
+]);
+const REDACTION_KEYS = new Set<string>([
+  'redacted',
+  'strategy',
+  'classes',
+  'byteCount',
+  'charCount',
+  'lineCount',
+  'hashSha256',
+  'preview',
+]);
+const AUDIT_HINT_KEYS = new Set<string>([
+  'correlationId',
+  'emittedByPluginVersion',
+  'retentionExpiresAt',
+  'recommendedNextStep',
+]);
 const FORBIDDEN_RAW_PAYLOAD_KEYS = new Set<string>([
   'apikey',
   'api_key',
@@ -242,10 +372,13 @@ const FORBIDDEN_RAW_PAYLOAD_KEYS = new Set<string>([
   'conversation',
   'environment',
   'env',
+  'hermesprofilepath',
   'hermesdbpath',
   'log',
   'messages',
+  'output',
   'processenv',
+  'profilepath',
   'providerauth',
   'rawcontent',
   'rawlog',
@@ -317,6 +450,128 @@ function hasOnlyTopLevelKeys(value: Record<string, unknown>): boolean {
   return Object.keys(value).every((key) => TOP_LEVEL_KEYS.has(key));
 }
 
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  allowedKeys: ReadonlySet<string>
+): boolean {
+  return Object.keys(value).every((key) => allowedKeys.has(key));
+}
+
+function collectUnknownKeys(
+  value: unknown,
+  allowedKeys: ReadonlySet<string>,
+  path: string
+): string[] {
+  if (!isRecord(value)) return [];
+  return Object.keys(value)
+    .filter((key) => !allowedKeys.has(key))
+    .map((key) => `unknown metadata key: ${path}.${key}`);
+}
+
+function collectPrivacyUnknownKeyErrors(value: unknown, path: string): string[] {
+  if (!isRecord(value)) return [];
+  return [
+    ...collectUnknownKeys(value, PRIVACY_KEYS, path),
+    ...collectUnknownKeys(value.redaction, REDACTION_KEYS, `${path}.redaction`),
+  ];
+}
+
+function collectAnchorUnknownKeyErrors(value: unknown, path: string): string[] {
+  if (!isRecord(value)) return [];
+  return [
+    ...collectUnknownKeys(value, ANCHORS_KEYS, path),
+    ...collectUnknownKeys(value.node, NODE_ANCHOR_KEYS, `${path}.node`),
+    ...collectUnknownKeys(value.session, SESSION_ANCHOR_KEYS, `${path}.session`),
+    ...collectUnknownKeys(value.project, PROJECT_ANCHOR_KEYS, `${path}.project`),
+    ...collectUnknownKeys(value.repo, REPO_ANCHOR_KEYS, `${path}.repo`),
+    ...collectUnknownKeys(value.worktree, WORKTREE_ANCHOR_KEYS, `${path}.worktree`),
+  ];
+}
+
+function collectNestedUnknownKeyErrors(
+  value: Record<string, unknown>
+): string[] {
+  const workContext = isRecord(value.workContext) ? value.workContext : undefined;
+  const errors = [
+    ...collectUnknownKeys(value.source, SOURCE_KEYS, '$.source'),
+    ...collectUnknownKeys(value.actor, ACTOR_KEYS, '$.actor'),
+    ...collectUnknownKeys(value.workContext, WORK_CONTEXT_KEYS, '$.workContext'),
+    ...collectAnchorUnknownKeyErrors(
+      workContext?.anchors,
+      '$.workContext.anchors'
+    ),
+    ...collectUnknownKeys(value.parent, CHILD_SESSION_KEYS, '$.parent'),
+    ...collectUnknownKeys(value.tool, TOOL_KEYS, '$.tool'),
+    ...collectPrivacyUnknownKeyErrors(value.privacy, '$.privacy'),
+    ...collectUnknownKeys(value.audit, AUDIT_HINT_KEYS, '$.audit'),
+  ];
+
+  if (Array.isArray(workContext?.taskRefs)) {
+    workContext.taskRefs.forEach((taskRef, index) => {
+      errors.push(
+        ...collectUnknownKeys(
+          taskRef,
+          TASK_REF_KEYS,
+          `$.workContext.taskRefs[${index}]`
+        )
+      );
+      if (isRecord(taskRef)) {
+        errors.push(
+          ...collectPrivacyUnknownKeyErrors(
+            taskRef.privacy,
+            `$.workContext.taskRefs[${index}].privacy`
+          )
+        );
+      }
+    });
+  }
+
+  if (Array.isArray(value.childSessions)) {
+    value.childSessions.forEach((childSession, index) => {
+      errors.push(
+        ...collectUnknownKeys(
+          childSession,
+          CHILD_SESSION_KEYS,
+          `$.childSessions[${index}]`
+        )
+      );
+    });
+  }
+
+  if (Array.isArray(value.artifacts)) {
+    value.artifacts.forEach((artifact, index) => {
+      errors.push(
+        ...collectUnknownKeys(
+          artifact,
+          ARTIFACT_KEYS,
+          `$.artifacts[${index}]`
+        )
+      );
+      if (isRecord(artifact)) {
+        errors.push(
+          ...collectPrivacyUnknownKeyErrors(
+            artifact.privacy,
+            `$.artifacts[${index}].privacy`
+          )
+        );
+      }
+    });
+  }
+
+  return errors;
+}
+
+function isHermesPrivacyMetadata(
+  value: unknown
+): value is WorkContextPrivacyMetadata {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, PRIVACY_KEYS) &&
+    (!isRecord(value.redaction) || hasOnlyKeys(value.redaction, REDACTION_KEYS)) &&
+    isWorkContextPrivacyMetadata(value)
+  );
+}
+
 function isStringMap(value: unknown): boolean {
   if (value === undefined) return true;
   if (!isRecord(value)) return false;
@@ -326,7 +581,7 @@ function isStringMap(value: unknown): boolean {
 }
 
 function isTaskRef(value: unknown): value is TaskRef {
-  if (!isRecord(value)) return false;
+  if (!isRecord(value) || !hasOnlyKeys(value, TASK_REF_KEYS)) return false;
   return (
     isEnumValue(value.kind, TASK_KINDS) &&
     hasString(value.id) &&
@@ -334,12 +589,12 @@ function isTaskRef(value: unknown): value is TaskRef {
     isOptionalString(value.url) &&
     isOptionalString(value.status) &&
     isOptionalString(value.parentRef) &&
-    (value.privacy === undefined || isWorkContextPrivacyMetadata(value.privacy))
+    (value.privacy === undefined || isHermesPrivacyMetadata(value.privacy))
   );
 }
 
 function isNodeAnchor(value: unknown): boolean {
-  if (!isRecord(value)) return false;
+  if (!isRecord(value) || !hasOnlyKeys(value, NODE_ANCHOR_KEYS)) return false;
   return (
     hasString(value.nodeId) &&
     isEnumValue(value.kind, NODE_KINDS) &&
@@ -349,7 +604,7 @@ function isNodeAnchor(value: unknown): boolean {
 }
 
 function isSessionAnchor(value: unknown): boolean {
-  if (!isRecord(value)) return false;
+  if (!isRecord(value) || !hasOnlyKeys(value, SESSION_ANCHOR_KEYS)) return false;
   return (
     hasString(value.nodeId) &&
     hasString(value.sessionId) &&
@@ -361,18 +616,27 @@ function isSessionAnchor(value: unknown): boolean {
 }
 
 function isWorkContextAnchors(value: unknown): value is WorkContextAnchors {
-  if (!isRecord(value)) return false;
+  if (!isRecord(value) || !hasOnlyKeys(value, ANCHORS_KEYS)) return false;
   return (
     (value.node === undefined || isNodeAnchor(value.node)) &&
     (value.session === undefined || isSessionAnchor(value.session)) &&
-    isStringMap(value.project) &&
-    isStringMap(value.repo) &&
-    isStringMap(value.worktree)
+    (value.project === undefined ||
+      (isRecord(value.project) &&
+        hasOnlyKeys(value.project, PROJECT_ANCHOR_KEYS) &&
+        isStringMap(value.project))) &&
+    (value.repo === undefined ||
+      (isRecord(value.repo) &&
+        hasOnlyKeys(value.repo, REPO_ANCHOR_KEYS) &&
+        isStringMap(value.repo))) &&
+    (value.worktree === undefined ||
+      (isRecord(value.worktree) &&
+        hasOnlyKeys(value.worktree, WORKTREE_ANCHOR_KEYS) &&
+        isStringMap(value.worktree)))
   );
 }
 
 function isArtifactRef(value: unknown): value is ArtifactRef {
-  if (!isRecord(value)) return false;
+  if (!isRecord(value) || !hasOnlyKeys(value, ARTIFACT_KEYS)) return false;
   return (
     hasString(value.id) &&
     isEnumValue(value.kind, ARTIFACT_KINDS) &&
@@ -383,13 +647,13 @@ function isArtifactRef(value: unknown): value is ArtifactRef {
     isOptionalString(value.producedByActorId) &&
     isOptionalString(value.producedAt) &&
     isOptionalString(value.summary) &&
-    isWorkContextPrivacyMetadata(value.privacy) &&
+    isHermesPrivacyMetadata(value.privacy) &&
     value.privacy.rawPayloadStored === false
   );
 }
 
 function isMetadataSource(value: unknown): value is HermesMetadataSource {
-  if (!isRecord(value)) return false;
+  if (!isRecord(value) || !hasOnlyKeys(value, SOURCE_KEYS)) return false;
   return (
     value.kind === 'hermes-agent' &&
     hasString(value.profile) &&
@@ -403,7 +667,7 @@ function isMetadataSource(value: unknown): value is HermesMetadataSource {
 }
 
 function isMetadataActor(value: unknown): value is HermesMetadataActor {
-  if (!isRecord(value)) return false;
+  if (!isRecord(value) || !hasOnlyKeys(value, ACTOR_KEYS)) return false;
   return (
     isEnumValue(value.kind, ACTOR_KINDS) &&
     hasString(value.id) &&
@@ -420,7 +684,7 @@ function isMetadataActor(value: unknown): value is HermesMetadataActor {
 function isWorkContextLink(
   value: unknown
 ): value is HermesMetadataWorkContextLink {
-  if (!isRecord(value)) return false;
+  if (!isRecord(value) || !hasOnlyKeys(value, WORK_CONTEXT_KEYS)) return false;
   return (
     isOptionalString(value.workContextId) &&
     Array.isArray(value.taskRefs) &&
@@ -432,7 +696,7 @@ function isWorkContextLink(
 }
 
 function isChildSession(value: unknown): value is HermesChildSessionRef {
-  if (!isRecord(value)) return false;
+  if (!isRecord(value) || !hasOnlyKeys(value, CHILD_SESSION_KEYS)) return false;
   return (
     hasString(value.sessionId) &&
     isEnumValue(value.runtime, RUNTIMES) &&
@@ -446,7 +710,7 @@ function isChildSession(value: unknown): value is HermesChildSessionRef {
 }
 
 function isToolSummary(value: unknown): value is HermesToolSummary {
-  if (!isRecord(value)) return false;
+  if (!isRecord(value) || !hasOnlyKeys(value, TOOL_KEYS)) return false;
   return (
     hasString(value.name) &&
     isEnumValue(value.category, TOOL_CATEGORIES) &&
@@ -461,7 +725,7 @@ function isToolSummary(value: unknown): value is HermesToolSummary {
 
 function isAuditHint(value: unknown): value is HermesMetadataEventAuditHint {
   if (value === undefined) return true;
-  if (!isRecord(value)) return false;
+  if (!isRecord(value) || !hasOnlyKeys(value, AUDIT_HINT_KEYS)) return false;
   return (
     isOptionalString(value.correlationId) &&
     isOptionalString(value.emittedByPluginVersion) &&
@@ -473,6 +737,7 @@ function isAuditHint(value: unknown): value is HermesMetadataEventAuditHint {
 function collectShapeErrors(value: Record<string, unknown>): string[] {
   const errors: string[] = [];
   if (!hasOnlyTopLevelKeys(value)) errors.push('unknown top-level key');
+  errors.push(...collectNestedUnknownKeyErrors(value));
   if (value.schemaVersion !== HERMES_METADATA_EVENT_SCHEMA_VERSION) {
     errors.push('schemaVersion must be 1');
   }
@@ -504,7 +769,7 @@ function collectShapeErrors(value: Record<string, unknown>): string[] {
     errors.push('artifacts are invalid');
   }
   if (
-    !isWorkContextPrivacyMetadata(value.privacy) ||
+    !isHermesPrivacyMetadata(value.privacy) ||
     value.privacy.rawPayloadStored !== false
   ) {
     errors.push('privacy must be valid and rawPayloadStored=false');

--- a/shared/hermes-metadata-events.ts
+++ b/shared/hermes-metadata-events.ts
@@ -365,10 +365,11 @@ const AUDIT_HINT_KEYS = new Set<string>([
   'recommendedNextStep',
 ]);
 const FORBIDDEN_RAW_PAYLOAD_KEYS = new Set<string>([
+  'accesstoken',
   'apikey',
-  'api_key',
   'authorization',
   'bearer',
+  'clientsecret',
   'conversation',
   'environment',
   'env',
@@ -376,6 +377,7 @@ const FORBIDDEN_RAW_PAYLOAD_KEYS = new Set<string>([
   'hermesdbpath',
   'log',
   'messages',
+  'openaiapikey',
   'output',
   'processenv',
   'profilepath',
@@ -384,10 +386,10 @@ const FORBIDDEN_RAW_PAYLOAD_KEYS = new Set<string>([
   'rawlog',
   'rawpayload',
   'rawtranscript',
-  'refresh_token',
   'refreshtoken',
   'scrollback',
   'secret',
+  'secretkey',
   'secrets',
   'sqlitedbpath',
   'stderr',
@@ -423,7 +425,7 @@ function isIsoTimestamp(value: unknown): value is string {
 }
 
 function normalizedKey(key: string): string {
-  return key.replace(/[-_]/g, '').toLowerCase();
+  return key.replace(/[^a-z0-9]/gi, '').toLowerCase();
 }
 
 function findUnsafePayloadKey(value: unknown, path = '$'): string | undefined {

--- a/shared/hermes-metadata-events.ts
+++ b/shared/hermes-metadata-events.ts
@@ -1,0 +1,580 @@
+import {
+  isWorkContextPrivacyMetadata,
+  type ArtifactRef,
+  type TaskRef,
+  type WorkContextActor,
+  type WorkContextAnchors,
+  type WorkContextPrivacyMetadata,
+} from './work-context.js';
+
+export const HERMES_METADATA_EVENT_SCHEMA_VERSION = 1 as const;
+
+export const HERMES_METADATA_EVENT_INGESTION_RECOMMENDATION =
+  'Keep this as a shared validator/spike handler for #556, then add an authenticated Relay ingestion route that persists only accepted metadata events into the WorkContext/audit store. Do not ingest Hermes profile SQLite, env, provider auth, or raw transcript/log payloads.';
+
+export type HermesMetadataRuntime =
+  | 'hermes'
+  | 'claude'
+  | 'codex'
+  | 'opencode'
+  | 'shell'
+  | 'other';
+
+export type HermesMetadataEventKind =
+  | 'session.lifecycle'
+  | 'task.lifecycle'
+  | 'child-session.linked'
+  | 'tool.summary'
+  | 'artifact.recorded'
+  | 'control.intervention';
+
+export type HermesMetadataEventStatus =
+  | 'started'
+  | 'resumed'
+  | 'ended'
+  | 'claimed'
+  | 'commented'
+  | 'blocked'
+  | 'completed'
+  | 'crashed'
+  | 'timed_out'
+  | 'spawned'
+  | 'succeeded'
+  | 'failed'
+  | 'skipped'
+  | 'requested'
+  | 'approved'
+  | 'denied';
+
+export type HermesToolCategory =
+  | 'terminal'
+  | 'file'
+  | 'web'
+  | 'browser'
+  | 'kanban'
+  | 'git'
+  | 'github'
+  | 'agent'
+  | 'other';
+
+export interface HermesMetadataSource {
+  kind: 'hermes-agent';
+  profile: string;
+  runtime: HermesMetadataRuntime;
+  provider?: string;
+  model?: string;
+  runId?: string;
+  sessionId?: string;
+  pluginVersion?: string;
+}
+
+export interface HermesMetadataActor
+  extends Pick<
+    WorkContextActor,
+    'kind' | 'id' | 'displayName' | 'providerId' | 'nodeId' | 'sessionId'
+  > {
+  profile?: string;
+  runtime?: HermesMetadataRuntime;
+  model?: string;
+}
+
+export interface HermesMetadataWorkContextLink {
+  workContextId?: string;
+  taskRefs: TaskRef[];
+  anchors: WorkContextAnchors;
+  relatedContextRefs?: string[];
+}
+
+export interface HermesChildSessionRef {
+  sessionId: string;
+  runtime: HermesMetadataRuntime;
+  profile?: string;
+  runId?: string;
+  parentSessionId?: string;
+  nodeId?: string;
+  cwd?: string;
+  status?: HermesMetadataEventStatus;
+}
+
+export interface HermesToolSummary {
+  name: string;
+  category: HermesToolCategory;
+  status: 'succeeded' | 'failed' | 'skipped';
+  durationMs?: number;
+  summary?: string;
+  errorSummary?: string;
+  artifactIds?: string[];
+}
+
+export interface HermesMetadataEventAuditHint {
+  correlationId?: string;
+  emittedByPluginVersion?: string;
+  retentionExpiresAt?: string;
+  recommendedNextStep?: string;
+}
+
+export interface HermesMetadataEvent {
+  schemaVersion: typeof HERMES_METADATA_EVENT_SCHEMA_VERSION;
+  eventId: string;
+  timestamp: string;
+  source: HermesMetadataSource;
+  eventKind: HermesMetadataEventKind;
+  status: HermesMetadataEventStatus;
+  workContext: HermesMetadataWorkContextLink;
+  actor: HermesMetadataActor;
+  parent?: HermesChildSessionRef;
+  childSessions?: HermesChildSessionRef[];
+  tool?: HermesToolSummary;
+  artifacts: ArtifactRef[];
+  privacy: WorkContextPrivacyMetadata;
+  audit?: HermesMetadataEventAuditHint;
+}
+
+export interface HermesMetadataIngestionResult {
+  accepted: boolean;
+  event?: HermesMetadataEvent;
+  errors: string[];
+  recommendation: string;
+}
+
+const EVENT_KINDS = new Set<string>([
+  'session.lifecycle',
+  'task.lifecycle',
+  'child-session.linked',
+  'tool.summary',
+  'artifact.recorded',
+  'control.intervention',
+]);
+const STATUSES = new Set<string>([
+  'started',
+  'resumed',
+  'ended',
+  'claimed',
+  'commented',
+  'blocked',
+  'completed',
+  'crashed',
+  'timed_out',
+  'spawned',
+  'succeeded',
+  'failed',
+  'skipped',
+  'requested',
+  'approved',
+  'denied',
+]);
+const RUNTIMES = new Set<string>([
+  'hermes',
+  'claude',
+  'codex',
+  'opencode',
+  'shell',
+  'other',
+]);
+const ACTOR_KINDS = new Set<string>([
+  'human',
+  'agent',
+  'system',
+  'service',
+  'node',
+]);
+const TASK_KINDS = new Set<string>([
+  'github-issue',
+  'github-pr',
+  'kanban-task',
+  'jira-ticket',
+  'linear-issue',
+  'external',
+]);
+const TAB_KINDS = new Set<string>([
+  'agent',
+  'terminal',
+  'file',
+  'diff',
+  'preview',
+  'html',
+  'other',
+]);
+const NODE_KINDS = new Set<string>(['local', 'remote']);
+const ARTIFACT_KINDS = new Set<string>([
+  'file',
+  'diff',
+  'log-ref',
+  'transcript-ref',
+  'screenshot',
+  'report',
+  'command-output-ref',
+  'external',
+]);
+const TOOL_CATEGORIES = new Set<string>([
+  'terminal',
+  'file',
+  'web',
+  'browser',
+  'kanban',
+  'git',
+  'github',
+  'agent',
+  'other',
+]);
+const TOOL_STATUSES = new Set<string>(['succeeded', 'failed', 'skipped']);
+const TOP_LEVEL_KEYS = new Set<string>([
+  'schemaVersion',
+  'eventId',
+  'timestamp',
+  'source',
+  'eventKind',
+  'status',
+  'workContext',
+  'actor',
+  'parent',
+  'childSessions',
+  'tool',
+  'artifacts',
+  'privacy',
+  'audit',
+]);
+const FORBIDDEN_RAW_PAYLOAD_KEYS = new Set<string>([
+  'apikey',
+  'api_key',
+  'authorization',
+  'bearer',
+  'conversation',
+  'environment',
+  'env',
+  'hermesdbpath',
+  'log',
+  'messages',
+  'processenv',
+  'providerauth',
+  'rawcontent',
+  'rawlog',
+  'rawpayload',
+  'rawtranscript',
+  'refresh_token',
+  'refreshtoken',
+  'scrollback',
+  'secret',
+  'secrets',
+  'sqlitedbpath',
+  'stderr',
+  'stdout',
+  'token',
+  'transcript',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === 'string';
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((item) => typeof item === 'string')
+  );
+}
+
+function isEnumValue(value: unknown, values: ReadonlySet<string>): value is string {
+  return typeof value === 'string' && values.has(value);
+}
+
+function isIsoTimestamp(value: unknown): value is string {
+  return hasString(value) && !Number.isNaN(Date.parse(value));
+}
+
+function normalizedKey(key: string): string {
+  return key.replace(/[-_]/g, '').toLowerCase();
+}
+
+function findUnsafePayloadKey(value: unknown, path = '$'): string | undefined {
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const unsafe = findUnsafePayloadKey(value[index], `${path}[${index}]`);
+      if (unsafe) return unsafe;
+    }
+    return undefined;
+  }
+  if (!isRecord(value)) return undefined;
+  for (const [key, nested] of Object.entries(value)) {
+    const normalized = normalizedKey(key);
+    if (FORBIDDEN_RAW_PAYLOAD_KEYS.has(normalized)) {
+      return `${path}.${key}`;
+    }
+    const unsafe = findUnsafePayloadKey(nested, `${path}.${key}`);
+    if (unsafe) return unsafe;
+  }
+  return undefined;
+}
+
+function hasOnlyTopLevelKeys(value: Record<string, unknown>): boolean {
+  return Object.keys(value).every((key) => TOP_LEVEL_KEYS.has(key));
+}
+
+function isStringMap(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (!isRecord(value)) return false;
+  return Object.values(value).every(
+    (item) => item === undefined || typeof item === 'string'
+  );
+}
+
+function isTaskRef(value: unknown): value is TaskRef {
+  if (!isRecord(value)) return false;
+  return (
+    isEnumValue(value.kind, TASK_KINDS) &&
+    hasString(value.id) &&
+    isOptionalString(value.title) &&
+    isOptionalString(value.url) &&
+    isOptionalString(value.status) &&
+    isOptionalString(value.parentRef) &&
+    (value.privacy === undefined || isWorkContextPrivacyMetadata(value.privacy))
+  );
+}
+
+function isNodeAnchor(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    hasString(value.nodeId) &&
+    isEnumValue(value.kind, NODE_KINDS) &&
+    isOptionalString(value.displayName) &&
+    (value.online === undefined || typeof value.online === 'boolean')
+  );
+}
+
+function isSessionAnchor(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  return (
+    hasString(value.nodeId) &&
+    hasString(value.sessionId) &&
+    isOptionalString(value.globalSessionId) &&
+    isOptionalString(value.tabId) &&
+    isEnumValue(value.tabKind, TAB_KINDS) &&
+    hasString(value.cwd)
+  );
+}
+
+function isWorkContextAnchors(value: unknown): value is WorkContextAnchors {
+  if (!isRecord(value)) return false;
+  return (
+    (value.node === undefined || isNodeAnchor(value.node)) &&
+    (value.session === undefined || isSessionAnchor(value.session)) &&
+    isStringMap(value.project) &&
+    isStringMap(value.repo) &&
+    isStringMap(value.worktree)
+  );
+}
+
+function isArtifactRef(value: unknown): value is ArtifactRef {
+  if (!isRecord(value)) return false;
+  return (
+    hasString(value.id) &&
+    isEnumValue(value.kind, ARTIFACT_KINDS) &&
+    isOptionalString(value.title) &&
+    isOptionalString(value.uri) &&
+    isOptionalString(value.path) &&
+    isOptionalString(value.mediaType) &&
+    isOptionalString(value.producedByActorId) &&
+    isOptionalString(value.producedAt) &&
+    isOptionalString(value.summary) &&
+    isWorkContextPrivacyMetadata(value.privacy) &&
+    value.privacy.rawPayloadStored === false
+  );
+}
+
+function isMetadataSource(value: unknown): value is HermesMetadataSource {
+  if (!isRecord(value)) return false;
+  return (
+    value.kind === 'hermes-agent' &&
+    hasString(value.profile) &&
+    isEnumValue(value.runtime, RUNTIMES) &&
+    isOptionalString(value.provider) &&
+    isOptionalString(value.model) &&
+    isOptionalString(value.runId) &&
+    isOptionalString(value.sessionId) &&
+    isOptionalString(value.pluginVersion)
+  );
+}
+
+function isMetadataActor(value: unknown): value is HermesMetadataActor {
+  if (!isRecord(value)) return false;
+  return (
+    isEnumValue(value.kind, ACTOR_KINDS) &&
+    hasString(value.id) &&
+    isOptionalString(value.displayName) &&
+    isOptionalString(value.providerId) &&
+    isOptionalString(value.nodeId) &&
+    isOptionalString(value.sessionId) &&
+    isOptionalString(value.profile) &&
+    (value.runtime === undefined || isEnumValue(value.runtime, RUNTIMES)) &&
+    isOptionalString(value.model)
+  );
+}
+
+function isWorkContextLink(
+  value: unknown
+): value is HermesMetadataWorkContextLink {
+  if (!isRecord(value)) return false;
+  return (
+    isOptionalString(value.workContextId) &&
+    Array.isArray(value.taskRefs) &&
+    value.taskRefs.every(isTaskRef) &&
+    isWorkContextAnchors(value.anchors) &&
+    (value.relatedContextRefs === undefined ||
+      isStringArray(value.relatedContextRefs))
+  );
+}
+
+function isChildSession(value: unknown): value is HermesChildSessionRef {
+  if (!isRecord(value)) return false;
+  return (
+    hasString(value.sessionId) &&
+    isEnumValue(value.runtime, RUNTIMES) &&
+    isOptionalString(value.profile) &&
+    isOptionalString(value.runId) &&
+    isOptionalString(value.parentSessionId) &&
+    isOptionalString(value.nodeId) &&
+    isOptionalString(value.cwd) &&
+    (value.status === undefined || isEnumValue(value.status, STATUSES))
+  );
+}
+
+function isToolSummary(value: unknown): value is HermesToolSummary {
+  if (!isRecord(value)) return false;
+  return (
+    hasString(value.name) &&
+    isEnumValue(value.category, TOOL_CATEGORIES) &&
+    isEnumValue(value.status, TOOL_STATUSES) &&
+    (value.durationMs === undefined ||
+      (typeof value.durationMs === 'number' && value.durationMs >= 0)) &&
+    isOptionalString(value.summary) &&
+    isOptionalString(value.errorSummary) &&
+    (value.artifactIds === undefined || isStringArray(value.artifactIds))
+  );
+}
+
+function isAuditHint(value: unknown): value is HermesMetadataEventAuditHint {
+  if (value === undefined) return true;
+  if (!isRecord(value)) return false;
+  return (
+    isOptionalString(value.correlationId) &&
+    isOptionalString(value.emittedByPluginVersion) &&
+    isOptionalString(value.retentionExpiresAt) &&
+    isOptionalString(value.recommendedNextStep)
+  );
+}
+
+function collectShapeErrors(value: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+  if (!hasOnlyTopLevelKeys(value)) errors.push('unknown top-level key');
+  if (value.schemaVersion !== HERMES_METADATA_EVENT_SCHEMA_VERSION) {
+    errors.push('schemaVersion must be 1');
+  }
+  if (!hasString(value.eventId)) errors.push('eventId is required');
+  if (!isIsoTimestamp(value.timestamp)) errors.push('timestamp must be ISO-like');
+  if (!isMetadataSource(value.source)) errors.push('source is invalid');
+  if (!isEnumValue(value.eventKind, EVENT_KINDS)) {
+    errors.push('eventKind is invalid');
+  }
+  if (!isEnumValue(value.status, STATUSES)) errors.push('status is invalid');
+  if (!isWorkContextLink(value.workContext)) {
+    errors.push('workContext link is invalid');
+  }
+  if (!isMetadataActor(value.actor)) errors.push('actor is invalid');
+  if (value.parent !== undefined && !isChildSession(value.parent)) {
+    errors.push('parent session ref is invalid');
+  }
+  if (
+    value.childSessions !== undefined &&
+    (!Array.isArray(value.childSessions) ||
+      !value.childSessions.every(isChildSession))
+  ) {
+    errors.push('childSessions are invalid');
+  }
+  if (value.tool !== undefined && !isToolSummary(value.tool)) {
+    errors.push('tool summary is invalid');
+  }
+  if (!Array.isArray(value.artifacts) || !value.artifacts.every(isArtifactRef)) {
+    errors.push('artifacts are invalid');
+  }
+  if (
+    !isWorkContextPrivacyMetadata(value.privacy) ||
+    value.privacy.rawPayloadStored !== false
+  ) {
+    errors.push('privacy must be valid and rawPayloadStored=false');
+  }
+  if (!isAuditHint(value.audit)) errors.push('audit hint is invalid');
+  return errors;
+}
+
+function collectEventKindErrors(value: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+  if (value.eventKind === 'tool.summary' && value.tool === undefined) {
+    errors.push('tool.summary events require tool');
+  }
+  if (
+    value.eventKind === 'child-session.linked' &&
+    (!Array.isArray(value.childSessions) || value.childSessions.length === 0)
+  ) {
+    errors.push('child-session.linked events require childSessions');
+  }
+  if (
+    value.eventKind === 'artifact.recorded' &&
+    (!Array.isArray(value.artifacts) || value.artifacts.length === 0)
+  ) {
+    errors.push('artifact.recorded events require artifacts');
+  }
+  if (
+    value.eventKind === 'task.lifecycle' &&
+    (!isRecord(value.workContext) ||
+      !Array.isArray(value.workContext.taskRefs) ||
+      value.workContext.taskRefs.length === 0)
+  ) {
+    errors.push('task.lifecycle events require taskRefs');
+  }
+  return errors;
+}
+
+export function validateHermesMetadataEvent(value: unknown): string[] {
+  if (!isRecord(value)) return ['event must be an object'];
+  const unsafeKeyPath = findUnsafePayloadKey(value);
+  const errors = [
+    ...collectShapeErrors(value),
+    ...collectEventKindErrors(value),
+  ];
+  if (unsafeKeyPath) {
+    errors.push(`raw/secret/transcript-shaped payload key rejected: ${unsafeKeyPath}`);
+  }
+  return errors;
+}
+
+export function isHermesMetadataEvent(
+  value: unknown
+): value is HermesMetadataEvent {
+  return validateHermesMetadataEvent(value).length === 0;
+}
+
+export function ingestHermesMetadataEventCandidate(
+  value: unknown
+): HermesMetadataIngestionResult {
+  const errors = validateHermesMetadataEvent(value);
+  if (errors.length > 0) {
+    return {
+      accepted: false,
+      errors,
+      recommendation: HERMES_METADATA_EVENT_INGESTION_RECOMMENDATION,
+    };
+  }
+  return {
+    accepted: true,
+    event: value as HermesMetadataEvent,
+    errors: [],
+    recommendation: HERMES_METADATA_EVENT_INGESTION_RECOMMENDATION,
+  };
+}

--- a/test/fixtures/hermes-metadata-events/artifact-recorded.json
+++ b/test/fixtures/hermes-metadata-events/artifact-recorded.json
@@ -1,0 +1,84 @@
+{
+  "schemaVersion": 1,
+  "eventId": "hmevt_556_artifact_pr",
+  "timestamp": "2026-05-17T08:05:00.000Z",
+  "source": {
+    "kind": "hermes-agent",
+    "profile": "kani-backend",
+    "runtime": "hermes",
+    "runId": "run_1009",
+    "sessionId": "hermes_session_556"
+  },
+  "eventKind": "artifact.recorded",
+  "status": "completed",
+  "workContext": {
+    "workContextId": "wc:relay-ide:556",
+    "taskRefs": [
+      { "kind": "github-issue", "id": "556", "parentRef": "552", "status": "in-progress" },
+      { "kind": "github-pr", "id": "TBD", "status": "open" },
+      { "kind": "kanban-task", "id": "t_5a0c16a8", "status": "running" }
+    ],
+    "anchors": {
+      "node": { "nodeId": "local", "kind": "local", "online": true },
+      "session": {
+        "nodeId": "local",
+        "sessionId": "hermes_session_556",
+        "tabKind": "agent",
+        "cwd": "/Users/donovanyohan/Documents/Programs/personal/relay-ide/.worktrees/556-hermes-event-ingestion"
+      },
+      "repo": {
+        "ownerRepo": "donovan-yohan/relay-ide",
+        "remoteUrl": "git@github.com:donovan-yohan/relay-ide.git",
+        "branchName": "spike/556-hermes-event-ingestion"
+      },
+      "worktree": {
+        "localPath": "/Users/donovanyohan/Documents/Programs/personal/relay-ide/.worktrees/556-hermes-event-ingestion",
+        "branchName": "spike/556-hermes-event-ingestion"
+      }
+    }
+  },
+  "actor": {
+    "kind": "agent",
+    "id": "kani-backend",
+    "profile": "kani-backend",
+    "runtime": "hermes",
+    "sessionId": "hermes_session_556"
+  },
+  "artifacts": [
+    {
+      "id": "artifact:556-pr",
+      "kind": "external",
+      "title": "Hermes metadata event ingestion spike PR",
+      "uri": "https://github.com/donovan-yohan/relay-ide/pull/TBD",
+      "mediaType": "text/html",
+      "producedByActorId": "kani-backend",
+      "producedAt": "2026-05-17T08:05:00.000Z",
+      "summary": "PR handle only; GitHub remains source of truth.",
+      "privacy": {
+        "classification": "public",
+        "retention": "project",
+        "rawPayloadStored": false,
+        "redaction": { "redacted": false, "strategy": "none", "classes": [] }
+      }
+    },
+    {
+      "id": "artifact:556-diagnostics",
+      "kind": "log-ref",
+      "title": "Build and test diagnostics pointer",
+      "path": ".relay/artifacts/556/verification-summary.txt",
+      "summary": "Pointer to bounded verification summary, not raw command output.",
+      "privacy": {
+        "classification": "internal",
+        "retention": "session",
+        "rawPayloadStored": false,
+        "redaction": { "redacted": true, "strategy": "summary", "classes": ["log", "path"] }
+      }
+    }
+  ],
+  "privacy": {
+    "classification": "internal",
+    "retention": "audit",
+    "rawPayloadStored": false,
+    "redaction": { "redacted": true, "strategy": "summary", "classes": ["artifact", "payload"] }
+  }
+}

--- a/test/fixtures/hermes-metadata-events/child-session-linked.json
+++ b/test/fixtures/hermes-metadata-events/child-session-linked.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": 1,
+  "eventId": "hmevt_556_child_codex",
+  "timestamp": "2026-05-17T08:03:00.000Z",
+  "source": {
+    "kind": "hermes-agent",
+    "profile": "kani-backend",
+    "runtime": "hermes",
+    "runId": "run_1009",
+    "sessionId": "hermes_session_556"
+  },
+  "eventKind": "child-session.linked",
+  "status": "spawned",
+  "workContext": {
+    "workContextId": "wc:relay-ide:556",
+    "taskRefs": [
+      { "kind": "github-issue", "id": "556", "parentRef": "552", "status": "in-progress" },
+      { "kind": "kanban-task", "id": "t_5a0c16a8", "status": "running" }
+    ],
+    "anchors": {
+      "node": { "nodeId": "local", "kind": "local", "online": true },
+      "session": {
+        "nodeId": "local",
+        "sessionId": "hermes_session_556",
+        "tabKind": "agent",
+        "cwd": "/Users/donovanyohan/Documents/Programs/personal/relay-ide/.worktrees/556-hermes-event-ingestion"
+      },
+      "repo": { "ownerRepo": "donovan-yohan/relay-ide" },
+      "worktree": { "branchName": "spike/556-hermes-event-ingestion" }
+    }
+  },
+  "actor": {
+    "kind": "agent",
+    "id": "kani-backend",
+    "profile": "kani-backend",
+    "runtime": "hermes",
+    "sessionId": "hermes_session_556"
+  },
+  "parent": {
+    "sessionId": "hermes_session_556",
+    "runtime": "hermes",
+    "profile": "kani-backend",
+    "runId": "run_1009",
+    "nodeId": "local",
+    "cwd": "/Users/donovanyohan/Documents/Programs/personal/relay-ide/.worktrees/556-hermes-event-ingestion",
+    "status": "started"
+  },
+  "childSessions": [
+    {
+      "sessionId": "codex_child_1",
+      "runtime": "codex",
+      "profile": "kani-backend",
+      "runId": "child_run_1",
+      "parentSessionId": "hermes_session_556",
+      "nodeId": "local",
+      "cwd": "/Users/donovanyohan/Documents/Programs/personal/relay-ide/.worktrees/556-hermes-event-ingestion",
+      "status": "spawned"
+    }
+  ],
+  "artifacts": [],
+  "privacy": {
+    "classification": "internal",
+    "retention": "session",
+    "rawPayloadStored": false,
+    "redaction": { "redacted": true, "strategy": "summary", "classes": ["payload"] }
+  }
+}

--- a/test/fixtures/hermes-metadata-events/session-lifecycle-started.json
+++ b/test/fixtures/hermes-metadata-events/session-lifecycle-started.json
@@ -1,0 +1,111 @@
+{
+  "schemaVersion": 1,
+  "eventId": "hmevt_556_session_started",
+  "timestamp": "2026-05-17T08:00:00.000Z",
+  "source": {
+    "kind": "hermes-agent",
+    "profile": "kani-backend",
+    "runtime": "hermes",
+    "provider": "openai-codex",
+    "model": "gpt-5.5",
+    "runId": "run_1009",
+    "sessionId": "hermes_session_556",
+    "pluginVersion": "spike.1"
+  },
+  "eventKind": "session.lifecycle",
+  "status": "started",
+  "workContext": {
+    "workContextId": "wc:relay-ide:556",
+    "taskRefs": [
+      {
+        "kind": "github-issue",
+        "id": "556",
+        "title": "#552: Hermes metadata event ingestion spike",
+        "url": "https://github.com/donovan-yohan/relay-ide/issues/556",
+        "parentRef": "552",
+        "status": "in-progress"
+      },
+      {
+        "kind": "kanban-task",
+        "id": "t_5a0c16a8",
+        "status": "running"
+      }
+    ],
+    "anchors": {
+      "node": {
+        "nodeId": "local",
+        "kind": "local",
+        "displayName": "Donovan-Yohans-MacBook-Pro",
+        "online": true
+      },
+      "session": {
+        "nodeId": "local",
+        "sessionId": "hermes_session_556",
+        "globalSessionId": "local:hermes_session_556",
+        "tabId": "tab-hermes-556",
+        "tabKind": "agent",
+        "cwd": "/Users/donovanyohan/Documents/Programs/personal/relay-ide/.worktrees/556-hermes-event-ingestion"
+      },
+      "repo": {
+        "ownerRepo": "donovan-yohan/relay-ide",
+        "remoteUrl": "git@github.com:donovan-yohan/relay-ide.git",
+        "localPath": "/Users/donovanyohan/Documents/Programs/personal/relay-ide",
+        "branchName": "spike/556-hermes-event-ingestion"
+      },
+      "worktree": {
+        "localPath": "/Users/donovanyohan/Documents/Programs/personal/relay-ide/.worktrees/556-hermes-event-ingestion",
+        "branchName": "spike/556-hermes-event-ingestion"
+      }
+    }
+  },
+  "actor": {
+    "kind": "agent",
+    "id": "kani-backend",
+    "displayName": "Kani backend",
+    "providerId": "hermes",
+    "profile": "kani-backend",
+    "runtime": "hermes",
+    "model": "gpt-5.5",
+    "nodeId": "local",
+    "sessionId": "hermes_session_556"
+  },
+  "artifacts": [
+    {
+      "id": "artifact:556-spike-notes",
+      "kind": "report",
+      "title": "Spike recommendation note",
+      "path": "docs/spikes/hermes-metadata-event-ingestion.md",
+      "mediaType": "text/markdown",
+      "producedByActorId": "kani-backend",
+      "producedAt": "2026-05-17T08:00:00.000Z",
+      "summary": "Bounded metadata event shape and next implementation recommendation; no raw Hermes DB, env, or transcript content.",
+      "privacy": {
+        "classification": "internal",
+        "retention": "project",
+        "rawPayloadStored": false,
+        "redaction": {
+          "redacted": true,
+          "strategy": "summary",
+          "classes": ["path", "payload"],
+          "preview": "metadata-only artifact ref"
+        }
+      }
+    }
+  ],
+  "privacy": {
+    "classification": "internal",
+    "retention": "audit",
+    "rawPayloadStored": false,
+    "redaction": {
+      "redacted": true,
+      "strategy": "summary",
+      "classes": ["path", "payload"],
+      "preview": "bounded Hermes metadata envelope"
+    }
+  },
+  "audit": {
+    "correlationId": "wc:relay-ide:556",
+    "emittedByPluginVersion": "spike.1",
+    "recommendedNextStep": "Mount an authenticated Relay route that calls the shared validator and persists only accepted metadata summaries."
+  }
+}

--- a/test/fixtures/hermes-metadata-events/tool-summary.json
+++ b/test/fixtures/hermes-metadata-events/tool-summary.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": 1,
+  "eventId": "hmevt_556_tool_summary",
+  "timestamp": "2026-05-17T08:02:00.000Z",
+  "source": {
+    "kind": "hermes-agent",
+    "profile": "kani-backend",
+    "runtime": "hermes",
+    "runId": "run_1009",
+    "sessionId": "hermes_session_556"
+  },
+  "eventKind": "tool.summary",
+  "status": "succeeded",
+  "workContext": {
+    "workContextId": "wc:relay-ide:556",
+    "taskRefs": [
+      { "kind": "kanban-task", "id": "t_5a0c16a8", "status": "running" }
+    ],
+    "anchors": {
+      "node": { "nodeId": "local", "kind": "local", "online": true },
+      "session": {
+        "nodeId": "local",
+        "sessionId": "hermes_session_556",
+        "tabKind": "agent",
+        "cwd": "/Users/donovanyohan/Documents/Programs/personal/relay-ide/.worktrees/556-hermes-event-ingestion"
+      },
+      "repo": {
+        "ownerRepo": "donovan-yohan/relay-ide",
+        "branchName": "spike/556-hermes-event-ingestion"
+      },
+      "worktree": {
+        "localPath": "/Users/donovanyohan/Documents/Programs/personal/relay-ide/.worktrees/556-hermes-event-ingestion",
+        "branchName": "spike/556-hermes-event-ingestion"
+      }
+    }
+  },
+  "actor": {
+    "kind": "agent",
+    "id": "kani-backend",
+    "profile": "kani-backend",
+    "runtime": "hermes",
+    "sessionId": "hermes_session_556"
+  },
+  "tool": {
+    "name": "terminal",
+    "category": "terminal",
+    "status": "succeeded",
+    "durationMs": 1200,
+    "summary": "Ran targeted validation command and captured pass/fail status only.",
+    "artifactIds": ["artifact:556-test-report"]
+  },
+  "artifacts": [
+    {
+      "id": "artifact:556-test-report",
+      "kind": "command-output-ref",
+      "title": "Targeted Hermes metadata tests",
+      "path": "test/hermes-metadata-events.test.ts",
+      "mediaType": "text/plain",
+      "summary": "Test command result pointer; output summary only.",
+      "privacy": {
+        "classification": "internal",
+        "retention": "session",
+        "rawPayloadStored": false,
+        "redaction": { "redacted": true, "strategy": "summary", "classes": ["log"] }
+      }
+    }
+  ],
+  "privacy": {
+    "classification": "internal",
+    "retention": "session",
+    "rawPayloadStored": false,
+    "redaction": { "redacted": true, "strategy": "summary", "classes": ["payload", "log"] }
+  }
+}

--- a/test/hermes-metadata-events.test.ts
+++ b/test/hermes-metadata-events.test.ts
@@ -1,0 +1,171 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import {
+  HERMES_METADATA_EVENT_INGESTION_RECOMMENDATION,
+  ingestHermesMetadataEventCandidate,
+  isHermesMetadataEvent,
+  validateHermesMetadataEvent,
+  type HermesMetadataEvent,
+} from '../shared/hermes-metadata-events.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(__dirname, 'fixtures', 'hermes-metadata-events');
+
+function loadFixture(filename: string): HermesMetadataEvent {
+  return JSON.parse(
+    readFileSync(join(FIXTURES_DIR, filename), 'utf-8')
+  ) as HermesMetadataEvent;
+}
+
+function cloneFixture(fixture: HermesMetadataEvent): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(fixture)) as Record<string, unknown>;
+}
+
+describe('Hermes metadata event ingestion spike contract', () => {
+  const fixtureFiles = readdirSync(FIXTURES_DIR).filter((file) =>
+    file.endsWith('.json')
+  );
+
+  for (const fixtureFile of fixtureFiles) {
+    it(`accepts bounded fixture ${fixtureFile}`, () => {
+      const fixture = loadFixture(fixtureFile);
+      const result = ingestHermesMetadataEventCandidate(fixture);
+
+      expect(result.accepted).toBe(true);
+      expect(result.errors).toEqual([]);
+      expect(result.event?.privacy.rawPayloadStored).toBe(false);
+      expect(result.recommendation).toBe(
+        HERMES_METADATA_EVENT_INGESTION_RECOMMENDATION
+      );
+    });
+  }
+
+  it('captures lifecycle status, task refs, node/cwd/repo/worktree anchors, artifacts, and privacy metadata', () => {
+    const fixture = loadFixture('session-lifecycle-started.json');
+
+    expect(isHermesMetadataEvent(fixture)).toBe(true);
+    expect(fixture.eventKind).toBe('session.lifecycle');
+    expect(fixture.status).toBe('started');
+    expect(fixture.workContext.taskRefs.map((task) => task.kind)).toEqual([
+      'github-issue',
+      'kanban-task',
+    ]);
+    expect(fixture.workContext.anchors.session?.cwd).toContain(
+      '.worktrees/556-hermes-event-ingestion'
+    );
+    expect(fixture.workContext.anchors.repo?.ownerRepo).toBe(
+      'donovan-yohan/relay-ide'
+    );
+    expect(fixture.workContext.anchors.worktree?.branchName).toBe(
+      'spike/556-hermes-event-ingestion'
+    );
+    expect(fixture.artifacts[0]?.privacy.rawPayloadStored).toBe(false);
+    expect(fixture.privacy.redaction.classes).toContain('payload');
+  });
+
+  it('requires tool.summary events to carry compact tool metadata only', () => {
+    const fixture = loadFixture('tool-summary.json');
+    const result = ingestHermesMetadataEventCandidate(fixture);
+
+    expect(result.accepted).toBe(true);
+    expect(result.event?.tool).toMatchObject({
+      name: 'terminal',
+      category: 'terminal',
+      status: 'succeeded',
+    });
+    expect(result.event?.tool?.summary).toContain('pass/fail status only');
+  });
+
+  it('requires child-session.linked events to carry parent/child session refs', () => {
+    const fixture = loadFixture('child-session-linked.json');
+    const withoutChildren = cloneFixture(fixture);
+    delete withoutChildren.childSessions;
+
+    expect(ingestHermesMetadataEventCandidate(fixture).accepted).toBe(true);
+    expect(validateHermesMetadataEvent(withoutChildren)).toContain(
+      'child-session.linked events require childSessions'
+    );
+  });
+
+  it('requires artifact.recorded events to carry artifact refs instead of inline blobs', () => {
+    const fixture = loadFixture('artifact-recorded.json');
+    const withoutArtifacts = cloneFixture(fixture);
+    withoutArtifacts.artifacts = [];
+
+    expect(ingestHermesMetadataEventCandidate(fixture).accepted).toBe(true);
+    expect(validateHermesMetadataEvent(withoutArtifacts)).toContain(
+      'artifact.recorded events require artifacts'
+    );
+  });
+
+  it('rejects raw environment-shaped payloads by default', () => {
+    const fixture = cloneFixture(loadFixture('session-lifecycle-started.json'));
+    fixture.env = { OPENAI_API_KEY: 'sk-nope' };
+
+    const result = ingestHermesMetadataEventCandidate(fixture);
+
+    expect(result.accepted).toBe(false);
+    expect(result.errors.join('\n')).toContain(
+      'raw/secret/transcript-shaped payload key rejected: $.env'
+    );
+  });
+
+  it('rejects secret-shaped payloads nested under otherwise valid metadata', () => {
+    const fixture = cloneFixture(loadFixture('tool-summary.json'));
+    fixture.tool = {
+      ...(fixture.tool as Record<string, unknown>),
+      authorization: 'Bearer nope',
+    };
+
+    const result = ingestHermesMetadataEventCandidate(fixture);
+
+    expect(result.accepted).toBe(false);
+    expect(result.errors.join('\n')).toContain('$.tool.authorization');
+  });
+
+  it('rejects transcript/message-shaped payloads even when an artifact calls itself a ref', () => {
+    const fixture = cloneFixture(loadFixture('artifact-recorded.json'));
+    fixture.artifacts = [
+      ...((fixture.artifacts as unknown[]) ?? []),
+      {
+        id: 'artifact:bad-transcript',
+        kind: 'transcript-ref',
+        summary: 'not enough, this still inlines messages',
+        messages: [{ role: 'user', content: 'full transcript goes here' }],
+        privacy: {
+          classification: 'sensitive',
+          retention: 'audit',
+          rawPayloadStored: false,
+          redaction: {
+            redacted: true,
+            strategy: 'summary',
+            classes: ['transcript'],
+          },
+        },
+      },
+    ];
+
+    const result = ingestHermesMetadataEventCandidate(fixture);
+
+    expect(result.accepted).toBe(false);
+    expect(result.errors.join('\n')).toContain('$.artifacts[2].messages');
+  });
+
+  it('rejects events that explicitly store raw payloads', () => {
+    const fixture = cloneFixture(loadFixture('session-lifecycle-started.json'));
+    fixture.privacy = {
+      ...(fixture.privacy as Record<string, unknown>),
+      rawPayloadStored: true,
+    };
+
+    const result = ingestHermesMetadataEventCandidate(fixture);
+
+    expect(result.accepted).toBe(false);
+    expect(result.errors).toContain(
+      'privacy must be valid and rawPayloadStored=false'
+    );
+  });
+});

--- a/test/hermes-metadata-events.test.ts
+++ b/test/hermes-metadata-events.test.ts
@@ -126,6 +126,67 @@ describe('Hermes metadata event ingestion spike contract', () => {
     expect(result.errors.join('\n')).toContain('$.tool.authorization');
   });
 
+  it('rejects nested profile path and raw output smuggling under allowed metadata objects', () => {
+    const smugglingCases: Array<{
+      name: string;
+      mutate: (fixture: Record<string, unknown>) => void;
+      expectedPath: string;
+    }> = [
+      {
+        name: 'source.profilePath',
+        mutate: (fixture) => {
+          fixture.source = {
+            ...(fixture.source as Record<string, unknown>),
+            profilePath: '/Users/me/.hermes/profiles/ebi/config.yaml',
+          };
+        },
+        expectedPath: '$.source.profilePath',
+      },
+      {
+        name: 'audit.profilePath',
+        mutate: (fixture) => {
+          fixture.audit = {
+            correlationId: 'corr-556-repro',
+            profilePath: '/Users/me/.hermes/profiles/ebi/config.yaml',
+          };
+        },
+        expectedPath: '$.audit.profilePath',
+      },
+      {
+        name: 'audit.hermesProfilePath',
+        mutate: (fixture) => {
+          fixture.audit = {
+            correlationId: 'corr-556-repro',
+            hermesProfilePath: '/Users/me/.hermes/profiles/ebi',
+          };
+        },
+        expectedPath: '$.audit.hermesProfilePath',
+      },
+      {
+        name: 'tool.output',
+        mutate: (fixture) => {
+          fixture.tool = {
+            ...(fixture.tool as Record<string, unknown>),
+            output: 'full command output secret-ish',
+          };
+        },
+        expectedPath: '$.tool.output',
+      },
+    ];
+
+    for (const smugglingCase of smugglingCases) {
+      const fixture = cloneFixture(loadFixture('tool-summary.json'));
+      smugglingCase.mutate(fixture);
+
+      const result = ingestHermesMetadataEventCandidate(fixture);
+
+      expect(result.accepted, smugglingCase.name).toBe(false);
+      expect(result.errors.join('\n'), smugglingCase.name).toContain(
+        smugglingCase.expectedPath
+      );
+    }
+  });
+
   it('rejects transcript/message-shaped payloads even when an artifact calls itself a ref', () => {
     const fixture = cloneFixture(loadFixture('artifact-recorded.json'));
     fixture.artifacts = [

--- a/test/hermes-metadata-events.test.ts
+++ b/test/hermes-metadata-events.test.ts
@@ -187,6 +187,90 @@ describe('Hermes metadata event ingestion spike contract', () => {
     }
   });
 
+  it('rejects normalized credential key variants nested under metadata objects', () => {
+    const credentialKeyCases: Array<{
+      name: string;
+      mutate: (fixture: Record<string, unknown>) => void;
+      expectedPath: string;
+    }> = [
+      {
+        name: 'source.accessToken',
+        mutate: (fixture) => {
+          fixture.source = {
+            ...(fixture.source as Record<string, unknown>),
+            accessToken: 'tok-nope',
+          };
+        },
+        expectedPath: '$.source.accessToken',
+      },
+      {
+        name: 'actor.clientSecret',
+        mutate: (fixture) => {
+          fixture.actor = {
+            ...(fixture.actor as Record<string, unknown>),
+            clientSecret: 'secret-nope',
+          };
+        },
+        expectedPath: '$.actor.clientSecret',
+      },
+      {
+        name: 'tool.access_token',
+        mutate: (fixture) => {
+          fixture.tool = {
+            ...(fixture.tool as Record<string, unknown>),
+            access_token: 'tok-nope',
+          };
+        },
+        expectedPath: '$.tool.access_token',
+      },
+      {
+        name: 'workContext.secret_key',
+        mutate: (fixture) => {
+          fixture.workContext = {
+            ...(fixture.workContext as Record<string, unknown>),
+            secret_key: 'secret-nope',
+          };
+        },
+        expectedPath: '$.workContext.secret_key',
+      },
+      {
+        name: 'workContext.anchors.repo.OPENAI_API_KEY',
+        mutate: (fixture) => {
+          const workContext = fixture.workContext as Record<string, unknown>;
+          const anchors = workContext.anchors as Record<string, unknown>;
+          anchors.repo = {
+            ...(anchors.repo as Record<string, unknown>),
+            OPENAI_API_KEY: 'sk-nope',
+          };
+        },
+        expectedPath: '$.workContext.anchors.repo.OPENAI_API_KEY',
+      },
+      {
+        name: 'artifacts[0].API Key',
+        mutate: (fixture) => {
+          const artifacts = fixture.artifacts as Array<Record<string, unknown>>;
+          artifacts[0] = {
+            ...artifacts[0],
+            'API Key': 'sk-nope',
+          };
+        },
+        expectedPath: '$.artifacts[0].API Key',
+      },
+    ];
+
+    for (const credentialKeyCase of credentialKeyCases) {
+      const fixture = cloneFixture(loadFixture('tool-summary.json'));
+      credentialKeyCase.mutate(fixture);
+
+      const result = ingestHermesMetadataEventCandidate(fixture);
+
+      expect(result.accepted, credentialKeyCase.name).toBe(false);
+      expect(result.errors.join('\n'), credentialKeyCase.name).toContain(
+        credentialKeyCase.expectedPath
+      );
+    }
+  });
+
   it('rejects transcript/message-shaped payloads even when an artifact calls itself a ref', () => {
     const fixture = cloneFixture(loadFixture('artifact-recorded.json'));
     fixture.artifacts = [


### PR DESCRIPTION
## Summary
- Adds a shared Hermes metadata event schema and spike ingestion validator in `shared/hermes-metadata-events.ts`.
- Adds bounded JSON fixtures for lifecycle, tool summary, child session, and artifact events.
- Adds tests proving accepted event shapes and default rejection of raw env/secrets/transcript-shaped payloads.
- Documents the route/storage recommendation in `docs/spikes/hermes-metadata-event-ingestion.md`.

## Motivation
Relay needs Hermes Agent metadata it can safely use for WorkContext/audit views without scraping Hermes profile SQLite, env, provider auth, or raw transcripts. This spike proves the narrow event shape first instead of prematurely mounting a cursed catch-all endpoint.

## The Case Against
This PR might be wrong because:
- It stops at a shared spike handler instead of adding `POST /integrations/hermes/events`, so downstream UI/storage still cannot ingest live plugin events.
- The forbidden-key scan is intentionally conservative. A future plugin may need names like `messages` or `stdout` for a safe summary object, but this validator rejects those keys outright until we design a privileged exception.
- Runtime validation is handwritten rather than generated from JSON Schema/Zod. That keeps dependencies low, but it means future contract evolution needs disciplined tests.
- Fixtures use representative Relay/Hermes identifiers, not live plugin output, because the actual Hermes plugin emission path is not part of this repo slice.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Raw payload sneaks through a nested object | Recursive unsafe-key scan rejects env/auth/raw/transcript/log-shaped keys anywhere in the event tree. |
| Event shape becomes a generic data dump | Top-level keys are bounded, category-specific requirements are enforced, and `rawPayloadStored` must be false. |
| Route design gets implied as shipped | Spike doc explicitly says route is deferred and lists auth/storage/replay/backpressure requirements. |
| WorkContext linkage drifts from #554 | The event shape reuses WorkContext task refs, anchors, artifacts, actor, and privacy metadata types. |

## Verification
- `npm test -- test/hermes-metadata-events.test.ts`
- `npm test -- test/hermes-metadata-events.test.ts test/work-context.test.ts`
- `npm run check` (passes; existing lint warnings only)
- `npm run build`

Closes #556
Refs #552


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Hermes metadata event ingestion system with validation for event identity, work context, artifacts, and privacy metadata.
  * Enforces privacy constraints by rejecting sensitive data patterns and requiring privacy settings compliance.
  * Supports multiple event kinds with specific validation rules for each type.

* **Documentation**
  * Added design specification for the Hermes metadata event ingestion approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->