### PR TITLE
feat: add WorkContext API spine

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -68,6 +68,11 @@ import {
   flushAllPendingWrites as flushRelayStateWrites,
 } from './relay-state-db.js';
 import {
+  createWorkContextRouter,
+  initWorkContextStore,
+  type WorkContextStore,
+} from './work-contexts.js';
+import {
   initInterventionLog,
   closeInterventionLog,
 } from './intervention-log.js';
@@ -122,6 +127,7 @@ import type {
   AutomationSettings,
   Config,
   ContinuePolicy,
+  SessionSummary,
   TicketContext,
   WorkspaceSettings,
 } from './types.js';
@@ -822,6 +828,34 @@ function sendSessionCreateError(
   });
 }
 
+function validateSessionCreateRequest(
+  repoPath: string | undefined,
+  workContextStore: WorkContextStore,
+  workContextId: string | undefined,
+  res: express.Response
+): boolean {
+  if (!repoPath) {
+    res.status(400).json({ error: 'repoPath is required' });
+    return false;
+  }
+  if (!workContextId) return true;
+  if (workContextStore.get(workContextId)) return true;
+  res.status(404).json({ error: 'work_context_not_found' });
+  return false;
+}
+
+function sessionNameFromRepoPath(repoPath: string): string {
+  return repoPath.split('/').filter(Boolean).pop() || 'session';
+}
+
+function associateSessionWithWorkContext(
+  store: WorkContextStore,
+  workContextId: string | undefined,
+  session: SessionSummary
+): void {
+  if (workContextId) store.associateSession(workContextId, { session });
+}
+
 function sessionCreateFailureMessage(err: unknown): string {
   if (!(err instanceof Error)) return 'Failed to create session.';
   // Surface the underlying message so failures (codex spawn, app-server
@@ -1087,6 +1121,8 @@ async function main(): Promise<void> {
       err instanceof Error ? err.message : err
     );
   }
+
+  const workContextStore = initWorkContextStore(configDir);
 
   try {
     initInterventionLog(configDir);
@@ -1593,6 +1629,26 @@ async function main(): Promise<void> {
   app.use('/analytics', requireAuth, createAnalyticsRouter(configDir));
   app.use('/api/analytics', requireAuth, createSessionAnalyticsRouter());
   app.use('/telemetry', requireAuth, createTelemetryRouter());
+  app.use(
+    '/work-contexts',
+    createWorkContextRouter({
+      store: workContextStore,
+      requireAuth,
+      getSessions: async () => {
+        const [localSessions, remoteSessions] = await Promise.all([
+          Promise.resolve(localRelayNode.sessions.list()),
+          aggregateRemoteSessions({
+            registry: hubNodeRegistry,
+            nodeLinks: hubNodeLinks,
+            logger,
+            sessionEnvelopes: sessionEnvelopeRegistry,
+          }),
+        ]);
+        return [...localSessions, ...remoteSessions];
+      },
+      getNodes: () => hubNodeRegistry.listNodes(),
+    })
+  );
 
   // POST /api/frontend-log — relay frontend logs to the server log file
   app.post('/api/frontend-log', requireAuth, (req, res) => {
@@ -2602,6 +2658,7 @@ async function main(): Promise<void> {
       continuePolicy: explicitContinuePolicy,
       sessionLane,
       ticketContext,
+      workContextId,
     } = createBody as {
       repoPath?: string;
       worktreePath?: string | null;
@@ -2621,6 +2678,7 @@ async function main(): Promise<void> {
       continue?: boolean;
       continuePolicy?: ContinuePolicy;
       sessionLane?: SessionLane;
+      workContextId?: string;
       ticketContext?: {
         ticketId: string;
         title: string;
@@ -2632,22 +2690,30 @@ async function main(): Promise<void> {
       };
     };
 
-    if (!repoPath) {
-      res.status(400).json({ error: 'repoPath is required' });
+    if (
+      !validateSessionCreateRequest(
+        repoPath,
+        workContextStore,
+        workContextId,
+        res
+      )
+    ) {
       return;
     }
+
+    const checkedRepoPath = repoPath ?? '';
 
     // Read config once for the lifetime of this request
     const freshConfig = getConfig();
 
     // Validate repoPath is a configured workspace
     const configuredWorkspaces = freshConfig.repos ?? [];
-    if (!configuredWorkspaces.includes(repoPath)) {
+    if (!configuredWorkspaces.includes(checkedRepoPath)) {
       res.status(400).json({ error: 'repoPath is not a configured workspace' });
       return;
     }
 
-    const cwd = worktreePath ?? repoPath;
+    const cwd = worktreePath ?? checkedRepoPath;
 
     // Validate cwd directory exists
     if (!fs.existsSync(cwd)) {
@@ -2658,8 +2724,8 @@ async function main(): Promise<void> {
     const safeCols = clampDimension(cols, 1, 500);
     const safeRows = clampDimension(rows, 1, 200);
 
-    const name = repoPath.split('/').filter(Boolean).pop() || 'session';
-    const portVariables = getRepoPortVariables(freshConfig, repoPath);
+    const name = sessionNameFromRepoPath(checkedRepoPath);
+    const portVariables = getRepoPortVariables(freshConfig, checkedRepoPath);
     const capacityResponse = buildPtyCapacityResponse(
       activePtySessionCount(),
       freshConfig.maxPtySessions
@@ -2672,7 +2738,7 @@ async function main(): Promise<void> {
       try {
         session = createTerminalSessionRecord({
           repoName: name,
-          repoPath,
+          repoPath: checkedRepoPath,
           worktreePath: worktreePath ?? null,
           cwd,
           safeCols,
@@ -2685,6 +2751,7 @@ async function main(): Promise<void> {
         return;
       }
       gitWatcher.watch(session.cwd);
+      associateSessionWithWorkContext(workContextStore, workContextId, session);
       res.status(201).json(session);
       return;
     }
@@ -2697,7 +2764,7 @@ async function main(): Promise<void> {
       newWorktree ?? false
     );
 
-    const resolved = resolveSessionSettings(freshConfig, repoPath, {
+    const resolved = resolveSessionSettings(freshConfig, checkedRepoPath, {
       agent,
       yolo,
       useTmux,
@@ -2732,7 +2799,7 @@ async function main(): Promise<void> {
         const { session } = await localRelayNode.sessions.createWeb({
           agentType: resolvedAgent,
           cwd,
-          repoPath,
+          repoPath: checkedRepoPath,
           repoName: name,
           worktreePath: worktreePath ?? null,
           branchName: requestBranchName ?? '',
@@ -2742,6 +2809,7 @@ async function main(): Promise<void> {
           sessionLane,
         });
         gitWatcher.watch(session.cwd);
+        associateSessionWithWorkContext(workContextStore, workContextId, session);
         res.status(201).json(session);
       } catch (err) {
         sendSessionCreateError(res, err, freshConfig.maxPtySessions);
@@ -2785,7 +2853,7 @@ async function main(): Promise<void> {
     try {
       session = createAgentSessionRecord({
         repoName: name,
-        repoPath,
+        repoPath: checkedRepoPath,
         worktreePath,
         cwd,
         requestBranchName,
@@ -2818,6 +2886,8 @@ async function main(): Promise<void> {
         logger.error('[index] transition on session create failed:', err);
       });
     }
+
+    associateSessionWithWorkContext(workContextStore, workContextId, session);
 
     res.status(201).json(session);
   });
@@ -2954,6 +3024,7 @@ async function main(): Promise<void> {
         serializeAll(configDir, { reason: 'update' });
         flushRelayStateWrites();
         closeRelayStateDb();
+        workContextStore.close();
         closeInterventionLog();
         broadcastEvent('server-restarting');
       }
@@ -3032,6 +3103,7 @@ async function main(): Promise<void> {
     serializeAll(configDir, { reason: restartReason });
     flushRelayStateWrites();
     closeRelayStateDb();
+    workContextStore.close();
     closeInterventionLog();
     for (const s of localRelayNode.sessions.list()) {
       try {

--- a/server/index.ts
+++ b/server/index.ts
@@ -852,8 +852,26 @@ function associateSessionWithWorkContext(
   store: WorkContextStore,
   workContextId: string | undefined,
   session: SessionSummary
+): string | null {
+  if (!workContextId) return null;
+  try {
+    store.associateSession(workContextId, { session });
+    return null;
+  } catch (err) {
+    const code = err instanceof Error ? err.message : 'work_context_association_failed';
+    logger.warn('[sessions] failed to associate session with work context %s: %s', workContextId, err);
+    return code || 'work_context_association_failed';
+  }
+}
+
+function sendSessionCreateSuccess(
+  res: express.Response,
+  session: SessionSummary,
+  associationError: string | null
 ): void {
-  if (workContextId) store.associateSession(workContextId, { session });
+  res.status(201).json(
+    associationError ? { ...session, workContextAssociationError: associationError } : session
+  );
 }
 
 function sessionCreateFailureMessage(err: unknown): string {
@@ -2751,8 +2769,12 @@ async function main(): Promise<void> {
         return;
       }
       gitWatcher.watch(session.cwd);
-      associateSessionWithWorkContext(workContextStore, workContextId, session);
-      res.status(201).json(session);
+      const associationError = associateSessionWithWorkContext(
+        workContextStore,
+        workContextId,
+        session
+      );
+      sendSessionCreateSuccess(res, session, associationError);
       return;
     }
 
@@ -2809,8 +2831,12 @@ async function main(): Promise<void> {
           sessionLane,
         });
         gitWatcher.watch(session.cwd);
-        associateSessionWithWorkContext(workContextStore, workContextId, session);
-        res.status(201).json(session);
+        const associationError = associateSessionWithWorkContext(
+          workContextStore,
+          workContextId,
+          session
+        );
+        sendSessionCreateSuccess(res, session, associationError);
       } catch (err) {
         sendSessionCreateError(res, err, freshConfig.maxPtySessions);
       }
@@ -2887,9 +2913,13 @@ async function main(): Promise<void> {
       });
     }
 
-    associateSessionWithWorkContext(workContextStore, workContextId, session);
+    const associationError = associateSessionWithWorkContext(
+      workContextStore,
+      workContextId,
+      session
+    );
 
-    res.status(201).json(session);
+    sendSessionCreateSuccess(res, session, associationError);
   });
 
   // DELETE /sessions/:id

--- a/server/work-contexts.ts
+++ b/server/work-contexts.ts
@@ -1,0 +1,857 @@
+import * as crypto from 'node:crypto';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { Router } from 'express';
+import type { RequestHandler } from 'express';
+
+import { createLogger } from './logger.js';
+import type { SessionSummary } from './types.js';
+import { DEFAULT_LOCAL_NODE_ID, createGlobalSessionId } from '../shared/identity.js';
+import type { HubNodeStatus, HubNodeSummary } from '../shared/relay-node-protocol.js';
+import {
+  WORK_CONTEXT_SCHEMA_VERSION,
+  createWorkContextPrivacyMetadata,
+  isWorkContext,
+  type NodeRefKind,
+  type SessionRef,
+  type WorkContext,
+  type WorkContextId,
+  type WorkContextTabKind,
+} from '../shared/work-context.js';
+
+const logger = createLogger('work-contexts');
+
+const SCHEMA_VERSION = 1;
+const DEFAULT_SOURCE = 'relay-api';
+const DEFAULT_RELATIONSHIP = 'associated';
+
+const FORBIDDEN_RAW_PAYLOAD_KEYS = new Set([
+  'rawContent',
+  'rawPayload',
+  'rawTranscript',
+  'terminalTranscript',
+  'transcript',
+  'rawLog',
+  'log',
+  'hermesDbPath',
+  'hermesProfileState',
+  'rawHermesProfileState',
+  'providerAuth',
+  'providerToken',
+  'env',
+  'secrets',
+]);
+
+const SESSION_TAB_KINDS = new Set<string>([
+  'agent',
+  'terminal',
+  'file',
+  'diff',
+  'preview',
+  'html',
+  'other',
+]);
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS work_contexts (
+  id           TEXT PRIMARY KEY,
+  title        TEXT,
+  source       TEXT NOT NULL,
+  context_json TEXT NOT NULL,
+  created_at   TEXT NOT NULL,
+  updated_at   TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_work_contexts_updated_at
+  ON work_contexts(updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS work_context_session_links (
+  work_context_id  TEXT NOT NULL,
+  node_id          TEXT NOT NULL,
+  session_id       TEXT NOT NULL,
+  global_session_id TEXT,
+  relationship     TEXT NOT NULL,
+  session_ref_json  TEXT NOT NULL,
+  associated_at     TEXT NOT NULL,
+  PRIMARY KEY (work_context_id, node_id, session_id),
+  FOREIGN KEY (work_context_id) REFERENCES work_contexts(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_work_context_session_links_session
+  ON work_context_session_links(node_id, session_id);
+CREATE INDEX IF NOT EXISTS idx_work_context_session_links_global
+  ON work_context_session_links(global_session_id);
+
+CREATE TABLE IF NOT EXISTS work_context_links (
+  source_context_id TEXT NOT NULL,
+  target_context_id TEXT NOT NULL,
+  relationship      TEXT NOT NULL,
+  linked_at         TEXT NOT NULL,
+  PRIMARY KEY (source_context_id, target_context_id, relationship),
+  FOREIGN KEY (source_context_id) REFERENCES work_contexts(id) ON DELETE CASCADE,
+  FOREIGN KEY (target_context_id) REFERENCES work_contexts(id) ON DELETE CASCADE
+);
+`;
+
+interface WorkContextRow {
+  id: string;
+  title: string | null;
+  source: string;
+  context_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface SessionLinkRow {
+  work_context_id: string;
+  node_id: string;
+  session_id: string;
+  global_session_id: string | null;
+  relationship: string;
+  session_ref_json: string;
+  associated_at: string;
+}
+
+export interface WorkContextCreateInput {
+  context?: WorkContext;
+  id?: string;
+  title?: string;
+  source?: string;
+  anchors?: WorkContext['anchors'];
+  actors?: WorkContext['actors'];
+  tasks?: WorkContext['tasks'];
+  artifacts?: WorkContext['artifacts'];
+  auditRefs?: WorkContext['auditRefs'];
+  capabilityGrants?: WorkContext['capabilityGrants'];
+  relatedContextRefs?: string[];
+  privacy?: WorkContext['privacy'];
+}
+
+export type WorkContextPatchInput = Partial<
+  Pick<
+    WorkContext,
+    | 'title'
+    | 'source'
+    | 'anchors'
+    | 'actors'
+    | 'tasks'
+    | 'artifacts'
+    | 'auditRefs'
+    | 'capabilityGrants'
+    | 'relatedContextRefs'
+    | 'privacy'
+  >
+>;
+
+export interface SessionAssociationInput {
+  session?: SessionSummary;
+  sessionRef?: SessionRef;
+  relationship?: string;
+}
+
+export interface WorkContextSessionSummary {
+  id: string;
+  nodeId: string;
+  globalSessionId?: string;
+  tabKind: WorkContextTabKind;
+  type?: SessionSummary['type'];
+  mode?: SessionSummary['mode'];
+  agent?: SessionSummary['agent'];
+  cwd: string;
+  repoPath?: string;
+  worktreePath?: string | null;
+  repoName?: string;
+  branchName?: string;
+  displayName?: string;
+  status?: SessionSummary['status'];
+  agentState?: SessionSummary['agentState'];
+  controlMode?: SessionSummary['controlMode'];
+  controlFreshness?: SessionSummary['controlFreshness'];
+  lastActivity?: string;
+  relationship: string;
+  associatedAt: string;
+  live: boolean;
+}
+
+export interface WorkContextNodeState {
+  nodeId: string;
+  status: HubNodeStatus | 'unknown';
+  displayName?: string;
+  lastSeenAt?: string;
+  kind?: NodeRefKind;
+}
+
+export interface WorkContextActiveGroup {
+  id: string;
+  context: WorkContext | null;
+  node: WorkContextNodeState;
+  sessions: WorkContextSessionSummary[];
+  staleReadModel: boolean;
+}
+
+export interface ListActiveWorkInput {
+  sessions: SessionSummary[];
+  nodes?: HubNodeSummary[];
+}
+
+export interface WorkContextStore {
+  close(): void;
+  create(input?: WorkContextCreateInput): WorkContext;
+  get(id: WorkContextId): WorkContext | null;
+  list(): WorkContext[];
+  update(id: WorkContextId, patch: WorkContextPatchInput): WorkContext;
+  linkContexts(sourceId: WorkContextId, targetId: WorkContextId, relationship?: string): WorkContext;
+  associateSession(id: WorkContextId, input: SessionAssociationInput): WorkContext;
+  listActiveWork(input: ListActiveWorkInput): WorkContextActiveGroup[];
+}
+
+export interface WorkContextRouterDeps {
+  store: WorkContextStore;
+  requireAuth?: RequestHandler;
+  getSessions: () => Promise<SessionSummary[]> | SessionSummary[];
+  getNodes?: () => HubNodeSummary[];
+}
+
+export function initWorkContextStore(configDir: string): WorkContextStore {
+  return createWorkContextStore(path.join(configDir, 'work-contexts.db'));
+}
+
+export function createWorkContextStore(dbPath: string): WorkContextStore {
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+  db.pragma('foreign_keys = ON');
+  db.exec('CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)');
+  const row = db.prepare('SELECT version FROM schema_version').get() as
+    | { version: number }
+    | undefined;
+  const hadRow = row !== undefined;
+  const currentVersion = row?.version ?? 0;
+  if (currentVersion < SCHEMA_VERSION) {
+    db.transaction(() => {
+      db.exec(SCHEMA_SQL);
+      if (hadRow) {
+        db.prepare('UPDATE schema_version SET version = ?').run(SCHEMA_VERSION);
+      } else {
+        db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(SCHEMA_VERSION);
+      }
+    })();
+  }
+
+  const selectContext = db.prepare(
+    `SELECT id, title, source, context_json, created_at, updated_at
+     FROM work_contexts WHERE id = ?`
+  );
+  const selectAllContexts = db.prepare(
+    `SELECT id, title, source, context_json, created_at, updated_at
+     FROM work_contexts ORDER BY updated_at DESC, created_at DESC`
+  );
+  const upsertContext = db.prepare(
+    `INSERT INTO work_contexts (id, title, source, context_json, created_at, updated_at)
+     VALUES (@id, @title, @source, @contextJson, @createdAt, @updatedAt)
+     ON CONFLICT(id) DO UPDATE SET
+       title = excluded.title,
+       source = excluded.source,
+       context_json = excluded.context_json,
+       updated_at = excluded.updated_at`
+  );
+  const selectSessionLinks = db.prepare(
+    `SELECT work_context_id, node_id, session_id, global_session_id,
+            relationship, session_ref_json, associated_at
+     FROM work_context_session_links
+     ORDER BY associated_at ASC`
+  );
+  const upsertSessionLink = db.prepare(
+    `INSERT INTO work_context_session_links (
+       work_context_id, node_id, session_id, global_session_id,
+       relationship, session_ref_json, associated_at
+     ) VALUES (
+       @workContextId, @nodeId, @sessionId, @globalSessionId,
+       @relationship, @sessionRefJson, @associatedAt
+     )
+     ON CONFLICT(work_context_id, node_id, session_id) DO UPDATE SET
+       global_session_id = excluded.global_session_id,
+       relationship = excluded.relationship,
+       session_ref_json = excluded.session_ref_json,
+       associated_at = excluded.associated_at`
+  );
+  const upsertContextLink = db.prepare(
+    `INSERT OR IGNORE INTO work_context_links (
+       source_context_id, target_context_id, relationship, linked_at
+     ) VALUES (?, ?, ?, ?)`
+  );
+
+  function write(context: WorkContext): WorkContext {
+    assertValidPersistableContext(context);
+    upsertContext.run({
+      id: context.id,
+      title: context.title ?? null,
+      source: context.source,
+      contextJson: JSON.stringify(context),
+      createdAt: context.createdAt,
+      updatedAt: context.updatedAt,
+    });
+    return context;
+  }
+
+  function mustGet(id: WorkContextId): WorkContext {
+    const context = getById(id);
+    if (!context) throw new WorkContextStoreError(404, 'work_context_not_found');
+    return context;
+  }
+
+  function getById(id: WorkContextId): WorkContext | null {
+    const row = selectContext.get(id) as WorkContextRow | undefined;
+    return row ? rowToContext(row) : null;
+  }
+
+  return {
+    close() {
+      db.close();
+    },
+
+    create(input: WorkContextCreateInput = {}) {
+      const now = new Date().toISOString();
+      const context = input.context
+        ? { ...input.context, updatedAt: input.context.updatedAt || now }
+        : buildContextFromInput(input, now);
+      return write(context);
+    },
+
+    get: getById,
+
+    list() {
+      return (selectAllContexts.all() as WorkContextRow[])
+        .map(rowToContext)
+        .filter((context): context is WorkContext => context !== null);
+    },
+
+    update(id: WorkContextId, patch: WorkContextPatchInput) {
+      const existing = mustGet(id);
+      const updated: WorkContext = {
+        ...existing,
+        ...patch,
+        id: existing.id,
+        schemaVersion: existing.schemaVersion,
+        createdAt: existing.createdAt,
+        updatedAt: new Date().toISOString(),
+      };
+      return write(updated);
+    },
+
+    linkContexts(sourceId: WorkContextId, targetId: WorkContextId, relationship = 'related') {
+      const source = mustGet(sourceId);
+      mustGet(targetId);
+      const related = new Set(source.relatedContextRefs ?? []);
+      related.add(targetId);
+      const updated: WorkContext = {
+        ...source,
+        relatedContextRefs: Array.from(related).sort(),
+        updatedAt: new Date().toISOString(),
+      };
+      db.transaction(() => {
+        write(updated);
+        upsertContextLink.run(sourceId, targetId, relationship, updated.updatedAt);
+      })();
+      return updated;
+    },
+
+    associateSession(id: WorkContextId, input: SessionAssociationInput) {
+      const existing = mustGet(id);
+      const associatedAt = new Date().toISOString();
+      const relationship = input.relationship ?? DEFAULT_RELATIONSHIP;
+      const sessionRef = input.session
+        ? sessionSummaryToRef(input.session)
+        : input.sessionRef;
+      if (!sessionRef) {
+        throw new WorkContextStoreError(400, 'session_ref_required');
+      }
+      assertValidSessionRef(sessionRef);
+      const updated = contextWithSessionAnchor(existing, sessionRef, associatedAt);
+      db.transaction(() => {
+        write(updated);
+        upsertSessionLink.run({
+          workContextId: id,
+          nodeId: sessionRef.nodeId,
+          sessionId: sessionRef.sessionId,
+          globalSessionId: sessionRef.globalSessionId ?? null,
+          relationship,
+          sessionRefJson: JSON.stringify(sessionRef),
+          associatedAt,
+        });
+      })();
+      return updated;
+    },
+
+    listActiveWork(input: ListActiveWorkInput) {
+      const contexts = this.list();
+      const allLinks = selectSessionLinks.all() as SessionLinkRow[];
+      return buildActiveGroups(contexts, allLinks, input.sessions, input.nodes ?? []);
+    },
+  };
+}
+
+export class WorkContextStoreError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, code: string, message = code) {
+    super(message);
+    this.name = 'WorkContextStoreError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export function createWorkContextRouter(deps: WorkContextRouterDeps): Router {
+  const router = Router();
+  const auth = deps.requireAuth ?? ((_req, _res, next) => next());
+
+  router.get('/', auth, (_req, res) => {
+    res.json({ workContexts: deps.store.list() });
+  });
+
+  router.post('/', auth, (req, res) => {
+    try {
+      const context = deps.store.create(req.body as WorkContextCreateInput);
+      res.status(201).json({ workContext: context });
+    } catch (err) {
+      sendStoreError(res, err);
+    }
+  });
+
+  router.get('/active', auth, async (_req, res) => {
+    try {
+      const sessions = await deps.getSessions();
+      const nodes = deps.getNodes?.() ?? [];
+      res.json({ groups: deps.store.listActiveWork({ sessions, nodes }) });
+    } catch (err) {
+      sendStoreError(res, err);
+    }
+  });
+
+  router.get('/:id', auth, (req, res) => {
+    const context = deps.store.get(req.params['id'] ?? '');
+    if (!context) {
+      res.status(404).json({ error: 'work_context_not_found' });
+      return;
+    }
+    res.json({ workContext: context });
+  });
+
+  router.patch('/:id', auth, (req, res) => {
+    try {
+      const context = deps.store.update(
+        req.params['id'] ?? '',
+        req.body as WorkContextPatchInput
+      );
+      res.json({ workContext: context });
+    } catch (err) {
+      sendStoreError(res, err);
+    }
+  });
+
+  router.post('/:id/link', auth, (req, res) => {
+    const body = req.body as { targetContextId?: string; relationship?: string };
+    if (!body.targetContextId) {
+      res.status(400).json({ error: 'targetContextId is required' });
+      return;
+    }
+    try {
+      const context = deps.store.linkContexts(
+        req.params['id'] ?? '',
+        body.targetContextId,
+        body.relationship
+      );
+      res.json({ workContext: context });
+    } catch (err) {
+      sendStoreError(res, err);
+    }
+  });
+
+  router.post('/:id/sessions', auth, async (req, res) => {
+    const body = req.body as {
+      sessionId?: string;
+      nodeId?: string;
+      globalSessionId?: string;
+      tabId?: string;
+      tabKind?: WorkContextTabKind;
+      cwd?: string;
+      relationship?: string;
+    };
+    if (!body.sessionId) {
+      res.status(400).json({ error: 'sessionId is required' });
+      return;
+    }
+    const sessions = await deps.getSessions();
+    const liveSession = sessions.find(
+      (session) =>
+        session.id === body.sessionId || session.globalSessionId === body.sessionId
+    );
+    const association: SessionAssociationInput = liveSession
+      ? { session: liveSession }
+      : { sessionRef: sessionRefFromBody(body as SessionRefBody) };
+    if (body.relationship) association.relationship = body.relationship;
+    try {
+      const context = deps.store.associateSession(
+        req.params['id'] ?? '',
+        association
+      );
+      res.json({ workContext: context });
+    } catch (err) {
+      sendStoreError(res, err);
+    }
+  });
+
+  return router;
+}
+
+interface SessionRefBody {
+  sessionId: string;
+  nodeId?: string;
+  globalSessionId?: string;
+  tabId?: string;
+  tabKind?: WorkContextTabKind;
+  cwd?: string;
+}
+
+function buildContextFromInput(
+  input: WorkContextCreateInput,
+  now: string
+): WorkContext {
+  const context: WorkContext = {
+    schemaVersion: WORK_CONTEXT_SCHEMA_VERSION,
+    id: input.id ?? createWorkContextId(),
+    ...(input.title ? { title: input.title } : {}),
+    createdAt: now,
+    updatedAt: now,
+    source: input.source ?? DEFAULT_SOURCE,
+    anchors: input.anchors ?? {},
+    actors: input.actors ?? [],
+    tasks: input.tasks ?? [],
+    artifacts: input.artifacts ?? [],
+    auditRefs: input.auditRefs ?? [],
+    capabilityGrants: input.capabilityGrants ?? [],
+    ...(input.relatedContextRefs ? { relatedContextRefs: input.relatedContextRefs } : {}),
+    privacy: input.privacy ?? createWorkContextPrivacyMetadata({ retention: 'project' }),
+  };
+  return context;
+}
+
+function createWorkContextId(): WorkContextId {
+  return `wc:${crypto.randomBytes(8).toString('hex')}`;
+}
+
+function rowToContext(row: WorkContextRow): WorkContext | null {
+  try {
+    const value = JSON.parse(row.context_json) as unknown;
+    if (!isWorkContext(value)) return null;
+    return value;
+  } catch (err) {
+    logger.warn('failed to parse work context %s: %s', row.id, err);
+    return null;
+  }
+}
+
+function assertValidPersistableContext(context: WorkContext): void {
+  if (!isWorkContext(context)) {
+    throw new WorkContextStoreError(400, 'invalid_work_context');
+  }
+  if (containsForbiddenRawPayloadKey(context)) {
+    throw new WorkContextStoreError(400, 'raw_payload_not_allowed');
+  }
+  if (containsRawPayloadStoredFlag(context)) {
+    throw new WorkContextStoreError(400, 'raw_payload_storage_not_allowed');
+  }
+}
+
+function containsForbiddenRawPayloadKey(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsForbiddenRawPayloadKey);
+  if (!isRecord(value)) return false;
+  for (const [key, child] of Object.entries(value)) {
+    if (FORBIDDEN_RAW_PAYLOAD_KEYS.has(key)) return true;
+    if (containsForbiddenRawPayloadKey(child)) return true;
+  }
+  return false;
+}
+
+function containsRawPayloadStoredFlag(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(containsRawPayloadStoredFlag);
+  if (!isRecord(value)) return false;
+  if (value.rawPayloadStored === true) return true;
+  return Object.values(value).some(containsRawPayloadStoredFlag);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function assertValidSessionRef(ref: SessionRef): void {
+  if (!ref.nodeId || !ref.sessionId || !ref.cwd) {
+    throw new WorkContextStoreError(400, 'invalid_session_ref');
+  }
+  if (!SESSION_TAB_KINDS.has(ref.tabKind)) {
+    throw new WorkContextStoreError(400, 'invalid_session_tab_kind');
+  }
+}
+
+function contextWithSessionAnchor(
+  context: WorkContext,
+  sessionRef: SessionRef,
+  updatedAt: string
+): WorkContext {
+  return {
+    ...context,
+    updatedAt,
+    anchors: {
+      ...context.anchors,
+      node: context.anchors.node ?? {
+        nodeId: sessionRef.nodeId,
+        kind: sessionRef.nodeId === DEFAULT_LOCAL_NODE_ID ? 'local' : 'remote',
+      },
+      session: context.anchors.session ?? sessionRef,
+    },
+  };
+}
+
+export function sessionSummaryToRef(session: SessionSummary): SessionRef {
+  const nodeId = session.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  const globalSessionId = session.globalSessionId ?? createGlobalSessionId(nodeId, session.id);
+  const tabKind: WorkContextTabKind = session.type === 'terminal' ? 'terminal' : 'agent';
+  return {
+    nodeId,
+    sessionId: session.id,
+    globalSessionId,
+    tabKind,
+    cwd: session.cwd,
+  };
+}
+
+function sessionRefFromBody(body: SessionRefBody): SessionRef {
+  if (!body.cwd) throw new WorkContextStoreError(400, 'cwd is required for offline session refs');
+  const nodeId = body.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  return {
+    nodeId,
+    sessionId: body.sessionId,
+    ...(body.globalSessionId ? { globalSessionId: body.globalSessionId } : {}),
+    ...(body.tabId ? { tabId: body.tabId } : {}),
+    tabKind: body.tabKind ?? 'terminal',
+    cwd: body.cwd,
+  };
+}
+
+function buildActiveGroups(
+  contexts: WorkContext[],
+  links: SessionLinkRow[],
+  sessions: SessionSummary[],
+  nodes: HubNodeSummary[]
+): WorkContextActiveGroup[] {
+  const nodesById = new Map(nodes.map((node) => [node.nodeId, node]));
+  const sessionsByKey = buildSessionLookup(sessions);
+  const linkedSessionKeys = new Set<string>();
+  const linksByContext = groupLinksByContext(links);
+  const groups: WorkContextActiveGroup[] = [];
+
+  for (const context of contexts) {
+    const contextLinks = linksByContext.get(context.id) ?? [];
+    const anchorLink = linkFromAnchor(context);
+    if (
+      anchorLink &&
+      !contextLinks.some(
+        (link) =>
+          link.node_id === anchorLink.node_id &&
+          link.session_id === anchorLink.session_id
+      )
+    ) {
+      contextLinks.push(anchorLink);
+    }
+
+    const groupSessions = contextLinks.map((link) => {
+      const key = sessionKey(link.node_id, link.session_id);
+      linkedSessionKeys.add(key);
+      const live = sessionsByKey.get(key) ??
+        (link.global_session_id ? sessionsByKey.get(link.global_session_id) : undefined);
+      return summarizeLinkedSession(link, live);
+    });
+
+    const node = nodeStateForContext(context, groupSessions, nodesById);
+    groups.push({
+      id: context.id,
+      context,
+      node,
+      sessions: groupSessions,
+      staleReadModel: node.status !== 'online' || groupSessions.some((s) => !s.live),
+    });
+  }
+
+  for (const session of sessions) {
+    const nodeId = session.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+    if (linkedSessionKeys.has(sessionKey(nodeId, session.id))) continue;
+    const syntheticLink = sessionLinkFromSession('unassigned', session);
+    const summarized = summarizeLinkedSession(syntheticLink, session);
+    groups.push({
+      id: `unassigned:${nodeId}:${session.id}`,
+      context: null,
+      node: nodeStateForNodeId(nodeId, nodesById),
+      sessions: [summarized],
+      staleReadModel: false,
+    });
+  }
+
+  return groups;
+}
+
+function buildSessionLookup(sessions: SessionSummary[]): Map<string, SessionSummary> {
+  const lookup = new Map<string, SessionSummary>();
+  for (const session of sessions) {
+    const nodeId = session.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+    lookup.set(sessionKey(nodeId, session.id), session);
+    if (session.globalSessionId) lookup.set(session.globalSessionId, session);
+  }
+  return lookup;
+}
+
+function groupLinksByContext(links: SessionLinkRow[]): Map<string, SessionLinkRow[]> {
+  const grouped = new Map<string, SessionLinkRow[]>();
+  for (const link of links) {
+    const existing = grouped.get(link.work_context_id);
+    if (existing) existing.push(link);
+    else grouped.set(link.work_context_id, [link]);
+  }
+  return grouped;
+}
+
+function linkFromAnchor(context: WorkContext): SessionLinkRow | null {
+  const ref = context.anchors.session;
+  if (!ref) return null;
+  return {
+    work_context_id: context.id,
+    node_id: ref.nodeId,
+    session_id: ref.sessionId,
+    global_session_id: ref.globalSessionId ?? null,
+    relationship: 'anchor',
+    session_ref_json: JSON.stringify(ref),
+    associated_at: context.updatedAt,
+  };
+}
+
+function sessionLinkFromSession(
+  workContextId: string,
+  session: SessionSummary
+): SessionLinkRow {
+  const ref = sessionSummaryToRef(session);
+  return {
+    work_context_id: workContextId,
+    node_id: ref.nodeId,
+    session_id: ref.sessionId,
+    global_session_id: ref.globalSessionId ?? null,
+    relationship: DEFAULT_RELATIONSHIP,
+    session_ref_json: JSON.stringify(ref),
+    associated_at: session.createdAt,
+  };
+}
+
+function summarizeLinkedSession(
+  link: SessionLinkRow,
+  liveSession: SessionSummary | undefined
+): WorkContextSessionSummary {
+  const ref = parseSessionRef(link.session_ref_json);
+  if (liveSession) return summarizeLiveSession(link, liveSession);
+  return {
+    id: ref.sessionId,
+    nodeId: ref.nodeId,
+    ...(ref.globalSessionId ? { globalSessionId: ref.globalSessionId } : {}),
+    tabKind: ref.tabKind,
+    cwd: ref.cwd,
+    relationship: link.relationship,
+    associatedAt: link.associated_at,
+    live: false,
+  };
+}
+
+function summarizeLiveSession(
+  link: SessionLinkRow,
+  session: SessionSummary
+): WorkContextSessionSummary {
+  const nodeId = session.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  const summary: WorkContextSessionSummary = {
+    id: session.id,
+    nodeId,
+    ...(session.globalSessionId ? { globalSessionId: session.globalSessionId } : {}),
+    tabKind: session.type === 'terminal' ? 'terminal' : 'agent',
+    type: session.type,
+    mode: session.mode,
+    agent: session.agent,
+    cwd: session.cwd,
+    ...(session.repoPath ? { repoPath: session.repoPath } : {}),
+    ...(session.worktreePath !== undefined ? { worktreePath: session.worktreePath } : {}),
+    ...(session.repoName ? { repoName: session.repoName } : {}),
+    ...(session.branchName ? { branchName: session.branchName } : {}),
+    displayName: session.displayName,
+    status: session.status,
+    agentState: session.agentState,
+    ...(session.controlMode ? { controlMode: session.controlMode } : {}),
+    ...(session.controlFreshness ? { controlFreshness: session.controlFreshness } : {}),
+    lastActivity: session.lastActivity,
+    relationship: link.relationship,
+    associatedAt: link.associated_at,
+    live: true,
+  };
+  return summary;
+}
+
+function parseSessionRef(value: string): SessionRef {
+  const parsed = JSON.parse(value) as SessionRef;
+  assertValidSessionRef(parsed);
+  return parsed;
+}
+
+function nodeStateForContext(
+  context: WorkContext,
+  sessions: WorkContextSessionSummary[],
+  nodesById: Map<string, HubNodeSummary>
+): WorkContextNodeState {
+  const nodeId =
+    context.anchors.node?.nodeId ?? sessions[0]?.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  const state = nodeStateForNodeId(nodeId, nodesById);
+  if (context.anchors.node?.displayName && !state.displayName) {
+    return { ...state, displayName: context.anchors.node.displayName };
+  }
+  if (context.anchors.node?.kind) return { ...state, kind: context.anchors.node.kind };
+  return state;
+}
+
+function nodeStateForNodeId(
+  nodeId: string,
+  nodesById: Map<string, HubNodeSummary>
+): WorkContextNodeState {
+  const node = nodesById.get(nodeId);
+  if (node) {
+    return {
+      nodeId,
+      status: node.status,
+      displayName: node.displayName,
+      lastSeenAt: node.lastSeenAt,
+      kind: nodeId === DEFAULT_LOCAL_NODE_ID ? 'local' : 'remote',
+    };
+  }
+  if (nodeId === DEFAULT_LOCAL_NODE_ID) {
+    return { nodeId, status: 'online', displayName: 'Local node', kind: 'local' };
+  }
+  return { nodeId, status: 'unknown', kind: 'remote' };
+}
+
+function sessionKey(nodeId: string, sessionId: string): string {
+  return `${nodeId}\u0000${sessionId}`;
+}
+
+function sendStoreError(
+  res: { status: (code: number) => { json: (body: unknown) => void } },
+  err: unknown
+): void {
+  if (err instanceof WorkContextStoreError) {
+    res.status(err.status).json({ error: err.code });
+    return;
+  }
+  logger.warn('work-context route failed: %s', err);
+  res.status(500).json({ error: 'work_context_internal_error' });
+}

--- a/server/work-contexts.ts
+++ b/server/work-contexts.ts
@@ -549,9 +549,13 @@ function rowToContext(row: WorkContextRow): WorkContext | null {
   try {
     const value = JSON.parse(row.context_json) as unknown;
     if (!isWorkContext(value)) return null;
-    return value;
+    return canonicalizePersistableContext(value);
   } catch (err) {
-    logger.warn('failed to parse work context %s: %s', row.id, err);
+    if (err instanceof WorkContextStoreError) {
+      logger.warn('dropped unsafe work context %s: %s', row.id, err.code);
+    } else {
+      logger.warn('failed to parse work context %s: %s', row.id, err);
+    }
     return null;
   }
 }

--- a/server/work-contexts.ts
+++ b/server/work-contexts.ts
@@ -281,16 +281,16 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
   );
 
   function write(context: WorkContext): WorkContext {
-    assertValidPersistableContext(context);
+    const persistable = canonicalizePersistableContext(context);
     upsertContext.run({
-      id: context.id,
-      title: context.title ?? null,
-      source: context.source,
-      contextJson: JSON.stringify(context),
-      createdAt: context.createdAt,
-      updatedAt: context.updatedAt,
+      id: persistable.id,
+      title: persistable.title ?? null,
+      source: persistable.source,
+      contextJson: JSON.stringify(persistable),
+      createdAt: persistable.createdAt,
+      updatedAt: persistable.updatedAt,
     });
-    return context;
+    return persistable;
   }
 
   function mustGet(id: WorkContextId): WorkContext {
@@ -312,7 +312,10 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
     create(input: WorkContextCreateInput = {}) {
       const now = new Date().toISOString();
       const context = input.context
-        ? { ...input.context, updatedAt: input.context.updatedAt || now }
+        ? canonicalizePersistableContext({
+            ...input.context,
+            updatedAt: input.context.updatedAt || now,
+          })
         : buildContextFromInput(input, now);
       return write(context);
     },
@@ -327,9 +330,10 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
 
     update(id: WorkContextId, patch: WorkContextPatchInput) {
       const existing = mustGet(id);
+      const allowedPatch = pickWorkContextPatch(patch);
       const updated: WorkContext = {
         ...existing,
-        ...patch,
+        ...allowedPatch,
         id: existing.id,
         schemaVersion: existing.schemaVersion,
         createdAt: existing.createdAt,
@@ -339,6 +343,9 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
     },
 
     linkContexts(sourceId: WorkContextId, targetId: WorkContextId, relationship = 'related') {
+      if (sourceId === targetId) {
+        throw new WorkContextStoreError(400, 'work_context_self_link_not_allowed');
+      }
       const source = mustGet(sourceId);
       mustGet(targetId);
       const related = new Set(source.relatedContextRefs ?? []);
@@ -442,7 +449,7 @@ export function createWorkContextRouter(deps: WorkContextRouterDeps): Router {
     try {
       const context = deps.store.update(
         req.params['id'] ?? '',
-        req.body as WorkContextPatchInput
+        pickWorkContextPatch(req.body as WorkContextPatchInput)
       );
       res.json({ workContext: context });
     } catch (err) {
@@ -483,10 +490,7 @@ export function createWorkContextRouter(deps: WorkContextRouterDeps): Router {
       return;
     }
     const sessions = await deps.getSessions();
-    const liveSession = sessions.find(
-      (session) =>
-        session.id === body.sessionId || session.globalSessionId === body.sessionId
-    );
+    const liveSession = findLiveSessionForAssociation(sessions, body);
     const association: SessionAssociationInput = liveSession
       ? { session: liveSession }
       : { sessionRef: sessionRefFromBody(body as SessionRefBody) };
@@ -564,6 +568,218 @@ function assertValidPersistableContext(context: WorkContext): void {
   }
 }
 
+function canonicalizePersistableContext(context: WorkContext): WorkContext {
+  assertValidPersistableContext(context);
+  const canonical: WorkContext = {
+    schemaVersion: context.schemaVersion,
+    id: context.id,
+    ...(context.title ? { title: context.title } : {}),
+    createdAt: context.createdAt,
+    updatedAt: context.updatedAt,
+    source: context.source,
+    anchors: pickAnchors(context.anchors),
+    actors: context.actors.map(pickActor),
+    tasks: context.tasks.map(pickTask),
+    artifacts: context.artifacts.map(pickArtifact),
+    auditRefs: context.auditRefs.map(pickAuditRef),
+    capabilityGrants: context.capabilityGrants.map(pickCapabilityGrant),
+    ...(context.relatedContextRefs
+      ? { relatedContextRefs: [...context.relatedContextRefs] }
+      : {}),
+    privacy: pickPrivacy(context.privacy),
+  };
+  assertValidPersistableContext(canonical);
+  return canonical;
+}
+
+function pickWorkContextPatch(patch: WorkContextPatchInput): WorkContextPatchInput {
+  return {
+    ...(patch.title !== undefined ? { title: patch.title } : {}),
+    ...(patch.source !== undefined ? { source: patch.source } : {}),
+    ...(patch.anchors !== undefined ? { anchors: patch.anchors } : {}),
+    ...(patch.actors !== undefined ? { actors: patch.actors } : {}),
+    ...(patch.tasks !== undefined ? { tasks: patch.tasks } : {}),
+    ...(patch.artifacts !== undefined ? { artifacts: patch.artifacts } : {}),
+    ...(patch.auditRefs !== undefined ? { auditRefs: patch.auditRefs } : {}),
+    ...(patch.capabilityGrants !== undefined
+      ? { capabilityGrants: patch.capabilityGrants }
+      : {}),
+    ...(patch.relatedContextRefs !== undefined
+      ? { relatedContextRefs: patch.relatedContextRefs }
+      : {}),
+    ...(patch.privacy !== undefined ? { privacy: patch.privacy } : {}),
+  };
+}
+
+function withoutUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, child]) => child !== undefined)
+  ) as T;
+}
+
+function pickPrivacy(privacy: WorkContext['privacy']): WorkContext['privacy'] {
+  return {
+    classification: privacy.classification,
+    retention: privacy.retention,
+    rawPayloadStored: privacy.rawPayloadStored,
+    redaction: {
+      redacted: privacy.redaction.redacted,
+      strategy: privacy.redaction.strategy,
+      classes: [...privacy.redaction.classes],
+      ...(privacy.redaction.byteCount !== undefined
+        ? { byteCount: privacy.redaction.byteCount }
+        : {}),
+      ...(privacy.redaction.charCount !== undefined
+        ? { charCount: privacy.redaction.charCount }
+        : {}),
+      ...(privacy.redaction.lineCount !== undefined
+        ? { lineCount: privacy.redaction.lineCount }
+        : {}),
+      ...(privacy.redaction.hashSha256
+        ? { hashSha256: privacy.redaction.hashSha256 }
+        : {}),
+      ...(privacy.redaction.preview ? { preview: privacy.redaction.preview } : {}),
+    },
+    ...(privacy.policyRefs ? { policyRefs: [...privacy.policyRefs] } : {}),
+  };
+}
+
+function pickAnchors(anchors: WorkContext['anchors']): WorkContext['anchors'] {
+  const node = anchors.node
+    ? withoutUndefined({
+        nodeId: anchors.node.nodeId,
+        kind: anchors.node.kind,
+        displayName: anchors.node.displayName,
+        online: anchors.node.online,
+      })
+    : undefined;
+  const session = anchors.session
+    ? withoutUndefined({
+        nodeId: anchors.session.nodeId,
+        sessionId: anchors.session.sessionId,
+        globalSessionId: anchors.session.globalSessionId,
+        tabId: anchors.session.tabId,
+        tabKind: anchors.session.tabKind,
+        cwd: anchors.session.cwd,
+      })
+    : undefined;
+  const project = anchors.project
+    ? withoutUndefined({
+        workspaceId: anchors.project.workspaceId,
+        projectId: anchors.project.projectId,
+        instanceId: anchors.project.instanceId,
+        benchId: anchors.project.benchId,
+      })
+    : undefined;
+  const repo = anchors.repo
+    ? withoutUndefined({
+        repoIdentity: anchors.repo.repoIdentity,
+        repoInstanceId: anchors.repo.repoInstanceId,
+        ownerRepo: anchors.repo.ownerRepo,
+        remoteUrl: anchors.repo.remoteUrl,
+        localPath: anchors.repo.localPath,
+        branchName: anchors.repo.branchName,
+      })
+    : undefined;
+  const worktree = anchors.worktree
+    ? withoutUndefined({
+        worktreeInstanceId: anchors.worktree.worktreeInstanceId,
+        localPath: anchors.worktree.localPath,
+        branchName: anchors.worktree.branchName,
+      })
+    : undefined;
+  return withoutUndefined({ node, session, project, repo, worktree }) as WorkContext['anchors'];
+}
+
+function pickActor(actor: WorkContext['actors'][number]): WorkContext['actors'][number] {
+  return {
+    kind: actor.kind,
+    id: actor.id,
+    ...(actor.displayName ? { displayName: actor.displayName } : {}),
+    ...(actor.providerId ? { providerId: actor.providerId } : {}),
+    ...(actor.nodeId ? { nodeId: actor.nodeId } : {}),
+    ...(actor.sessionId ? { sessionId: actor.sessionId } : {}),
+    ...(actor.privacy ? { privacy: pickPrivacy(actor.privacy) } : {}),
+  };
+}
+
+function pickTask(task: WorkContext['tasks'][number]): WorkContext['tasks'][number] {
+  return {
+    kind: task.kind,
+    id: task.id,
+    ...(task.title ? { title: task.title } : {}),
+    ...(task.url ? { url: task.url } : {}),
+    ...(task.status ? { status: task.status } : {}),
+    ...(task.parentRef ? { parentRef: task.parentRef } : {}),
+    ...(task.privacy ? { privacy: pickPrivacy(task.privacy) } : {}),
+  };
+}
+
+function pickArtifact(
+  artifact: WorkContext['artifacts'][number]
+): WorkContext['artifacts'][number] {
+  return {
+    id: artifact.id,
+    kind: artifact.kind,
+    ...(artifact.title ? { title: artifact.title } : {}),
+    ...(artifact.uri ? { uri: artifact.uri } : {}),
+    ...(artifact.path ? { path: artifact.path } : {}),
+    ...(artifact.mediaType ? { mediaType: artifact.mediaType } : {}),
+    ...(artifact.producedByActorId
+      ? { producedByActorId: artifact.producedByActorId }
+      : {}),
+    ...(artifact.producedAt ? { producedAt: artifact.producedAt } : {}),
+    ...(artifact.summary ? { summary: artifact.summary } : {}),
+    privacy: pickPrivacy(artifact.privacy),
+  };
+}
+
+function pickAuditRef(
+  auditRef: WorkContext['auditRefs'][number]
+): WorkContext['auditRefs'][number] {
+  return {
+    id: auditRef.id,
+    eventId: auditRef.eventId,
+    ...(auditRef.type ? { type: auditRef.type } : {}),
+    ...(auditRef.occurredAt ? { occurredAt: auditRef.occurredAt } : {}),
+    ...(auditRef.actorId ? { actorId: auditRef.actorId } : {}),
+    ...(auditRef.correlationId ? { correlationId: auditRef.correlationId } : {}),
+    ...(auditRef.chainHash ? { chainHash: auditRef.chainHash } : {}),
+    ...(auditRef.logRef ? { logRef: auditRef.logRef } : {}),
+    privacy: pickPrivacy(auditRef.privacy),
+  };
+}
+
+function pickCapabilityGrant(
+  grant: WorkContext['capabilityGrants'][number]
+): WorkContext['capabilityGrants'][number] {
+  return {
+    id: grant.id,
+    ref: grant.ref,
+    ...(grant.capability ? { capability: grant.capability } : {}),
+    ...(grant.capabilities ? { capabilities: [...grant.capabilities] } : {}),
+    ...(grant.decision ? { decision: grant.decision } : {}),
+    policyClass: grant.policyClass,
+    ...(grant.scope
+      ? {
+          scope: {
+            kind: grant.scope.kind,
+            ...(grant.scope.workspaceIds
+              ? { workspaceIds: [...grant.scope.workspaceIds] }
+              : {}),
+            ...(grant.scope.repoIds ? { repoIds: [...grant.scope.repoIds] } : {}),
+            ...(grant.scope.pathPrefixes
+              ? { pathPrefixes: [...grant.scope.pathPrefixes] }
+              : {}),
+          },
+        }
+      : {}),
+    ...(grant.actorId ? { actorId: grant.actorId } : {}),
+    ...(grant.auditEventId ? { auditEventId: grant.auditEventId } : {}),
+    privacy: pickPrivacy(grant.privacy),
+  };
+}
+
 function containsForbiddenRawPayloadKey(value: unknown): boolean {
   if (Array.isArray(value)) return value.some(containsForbiddenRawPayloadKey);
   if (!isRecord(value)) return false;
@@ -637,6 +853,18 @@ function sessionRefFromBody(body: SessionRefBody): SessionRef {
     tabKind: body.tabKind ?? 'terminal',
     cwd: body.cwd,
   };
+}
+
+function findLiveSessionForAssociation(
+  sessions: SessionSummary[],
+  body: { sessionId?: string; nodeId?: string }
+): SessionSummary | undefined {
+  if (!body.sessionId) return undefined;
+  return sessions.find((session) => {
+    const nodeId = session.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+    if (body.nodeId && nodeId !== body.nodeId) return false;
+    return session.id === body.sessionId || session.globalSessionId === body.sessionId;
+  });
 }
 
 function buildActiveGroups(
@@ -813,10 +1041,15 @@ function nodeStateForContext(
   const nodeId =
     context.anchors.node?.nodeId ?? sessions[0]?.nodeId ?? DEFAULT_LOCAL_NODE_ID;
   const state = nodeStateForNodeId(nodeId, nodesById);
-  if (context.anchors.node?.displayName && !state.displayName) {
-    return { ...state, displayName: context.anchors.node.displayName };
+  if (context.anchors.node?.displayName || context.anchors.node?.kind) {
+    return {
+      ...state,
+      ...(context.anchors.node.displayName
+        ? { displayName: context.anchors.node.displayName }
+        : {}),
+      ...(context.anchors.node.kind ? { kind: context.anchors.node.kind } : {}),
+    };
   }
-  if (context.anchors.node?.kind) return { ...state, kind: context.anchors.node.kind };
   return state;
 }
 

--- a/test/work-context-store.test.ts
+++ b/test/work-context-store.test.ts
@@ -3,6 +3,7 @@ import type { Server } from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
 
+import Database from 'better-sqlite3';
 import express from 'express';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -22,10 +23,31 @@ import {
 
 const tmpDirs: string[] = [];
 
-function makeStore(): WorkContextStore {
+function makeStoreHandle(): { store: WorkContextStore; dbPath: string } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-work-context-test-'));
   tmpDirs.push(dir);
-  return createWorkContextStore(path.join(dir, 'work-contexts.db'));
+  const dbPath = path.join(dir, 'work-contexts.db');
+  return { store: createWorkContextStore(dbPath), dbPath };
+}
+
+function makeStore(): WorkContextStore {
+  return makeStoreHandle().store;
+}
+
+function replacePersistedContextJson(
+  dbPath: string,
+  id: string,
+  context: Record<string, unknown>
+): void {
+  const db = new Database(dbPath);
+  try {
+    db.prepare('UPDATE work_contexts SET context_json = ? WHERE id = ?').run(
+      JSON.stringify(context),
+      id
+    );
+  } finally {
+    db.close();
+  }
 }
 
 async function startWorkContextApi(
@@ -392,6 +414,143 @@ describe('WorkContext store', () => {
           .messages
       ).toBeUndefined();
     } finally {
+      store.close();
+    }
+  });
+
+  it('canonicalizes stale context_json rows on read and drops raw payload rows from API responses', async () => {
+    const { store, dbPath } = makeStoreHandle();
+    const live = session({
+      id: 'sess-stale-row',
+      nodeId: 'node-remote',
+      globalSessionId: createGlobalSessionId('node-remote', 'sess-stale-row'),
+      cwd: '/remote/project',
+      repoPath: undefined,
+      worktreePath: undefined,
+      repoName: undefined,
+      branchName: undefined,
+    });
+    const api = await startWorkContextApi(store, [live], [
+      node({ nodeId: 'node-remote', status: 'online', displayName: 'remote node' }),
+    ]);
+    try {
+      store.create({ id: 'wc:stale-canonical', title: 'Stale canonical row' });
+      store.associateSession('wc:stale-canonical', { session: live });
+      replacePersistedContextJson(
+        dbPath,
+        'wc:stale-canonical',
+        {
+          ...fullContext({
+            id: 'wc:stale-canonical',
+            title: 'Stale canonical row',
+            anchors: {
+              node: {
+                nodeId: 'node-remote',
+                kind: 'remote',
+                displayName: 'remote node',
+                debugPayload: 'hidden node payload must not leave the read path',
+              } as WorkContext['anchors']['node'],
+              session: {
+                nodeId: 'node-remote',
+                sessionId: live.id,
+                globalSessionId: live.globalSessionId,
+                tabKind: 'agent',
+                cwd: live.cwd,
+                debugPayload: 'hidden session payload must not leave the read path',
+              } as WorkContext['anchors']['session'],
+            },
+            artifacts: [
+              {
+                id: 'artifact:stale-summary',
+                kind: 'report',
+                summary: 'safe stale summary',
+                privacy: createWorkContextPrivacyMetadata({ retention: 'project' }),
+                debugPayload: 'hidden artifact payload must not leave the read path',
+              } as WorkContext['artifacts'][number],
+            ],
+          }),
+          debugPayload: 'hidden top-level payload must not leave the read path',
+        } as unknown as Record<string, unknown>
+      );
+
+      store.create({ id: 'wc:raw-stale', title: 'Raw stale row' });
+      replacePersistedContextJson(
+        dbPath,
+        'wc:raw-stale',
+        {
+          ...fullContext({
+            id: 'wc:raw-stale',
+            title: 'Raw stale row',
+            artifacts: [
+              {
+                id: 'artifact:raw-transcript',
+                kind: 'transcript-ref',
+                summary: 'unsafe raw transcript row',
+                privacy: createWorkContextPrivacyMetadata({ retention: 'audit' }),
+                rawTranscript: 'raw transcript secret must not leak',
+              } as WorkContext['artifacts'][number],
+            ],
+          }),
+          hermesProfileState: { token: 'profile payload secret must not leak' },
+        } as unknown as Record<string, unknown>
+      );
+
+      store.create({ id: 'wc:raw-flag-stale', title: 'Raw flag stale row' });
+      replacePersistedContextJson(
+        dbPath,
+        'wc:raw-flag-stale',
+        {
+          ...fullContext({
+            id: 'wc:raw-flag-stale',
+            title: 'Raw flag stale row',
+            privacy: {
+              ...createWorkContextPrivacyMetadata({ retention: 'project' }),
+              rawPayloadStored: true,
+            },
+          }),
+        } as unknown as Record<string, unknown>
+      );
+
+      const canonicalGet = await jsonRequest(
+        api.baseUrl,
+        'GET',
+        '/work-contexts/wc:stale-canonical'
+      );
+      expect(canonicalGet.status).toBe(200);
+      expect(canonicalGet.body.workContext.id).toBe('wc:stale-canonical');
+      expect(JSON.stringify(canonicalGet.body)).not.toContain('hidden');
+
+      const rawGet = await jsonRequest(api.baseUrl, 'GET', '/work-contexts/wc:raw-stale');
+      expect(rawGet.status).toBe(404);
+      const rawFlagGet = await jsonRequest(
+        api.baseUrl,
+        'GET',
+        '/work-contexts/wc:raw-flag-stale'
+      );
+      expect(rawFlagGet.status).toBe(404);
+
+      const listed = await jsonRequest(api.baseUrl, 'GET', '/work-contexts');
+      const listedIds = listed.body.workContexts.map((context: WorkContext) => context.id);
+      const listJson = JSON.stringify(listed.body);
+      expect(listedIds).toContain('wc:stale-canonical');
+      expect(listedIds).not.toContain('wc:raw-stale');
+      expect(listedIds).not.toContain('wc:raw-flag-stale');
+      expect(listJson).not.toContain('hidden');
+      expect(listJson).not.toContain('raw transcript secret');
+      expect(listJson).not.toContain('profile payload secret');
+
+      const active = await jsonRequest(api.baseUrl, 'GET', '/work-contexts/active');
+      const activeIds = active.body.groups.map((group: { id: string }) => group.id);
+      const activeJson = JSON.stringify(active.body);
+      expect(active.status).toBe(200);
+      expect(activeIds).toContain('wc:stale-canonical');
+      expect(activeIds).not.toContain('wc:raw-stale');
+      expect(activeIds).not.toContain('wc:raw-flag-stale');
+      expect(activeJson).not.toContain('hidden');
+      expect(activeJson).not.toContain('raw transcript secret');
+      expect(activeJson).not.toContain('profile payload secret');
+    } finally {
+      await api.close();
       store.close();
     }
   });

--- a/test/work-context-store.test.ts
+++ b/test/work-context-store.test.ts
@@ -1,0 +1,443 @@
+import fs from 'node:fs';
+import type { Server } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+
+import express from 'express';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createWorkContextRouter,
+  createWorkContextStore,
+  type WorkContextStore,
+} from '../server/work-contexts.js';
+import type { SessionSummary } from '../server/types.js';
+import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
+import { DEFAULT_LOCAL_NODE_ID, createGlobalSessionId } from '../shared/identity.js';
+import {
+  WORK_CONTEXT_SCHEMA_VERSION,
+  createWorkContextPrivacyMetadata,
+  type WorkContext,
+} from '../shared/work-context.js';
+
+const tmpDirs: string[] = [];
+
+function makeStore(): WorkContextStore {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-work-context-test-'));
+  tmpDirs.push(dir);
+  return createWorkContextStore(path.join(dir, 'work-contexts.db'));
+}
+
+async function startWorkContextApi(
+  store: WorkContextStore,
+  sessions: SessionSummary[] = [],
+  nodes: HubNodeSummary[] = []
+): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/work-contexts',
+    createWorkContextRouter({
+      store,
+      getSessions: () => sessions,
+      getNodes: () => nodes,
+    })
+  );
+
+  const server = await new Promise<Server>((resolve) => {
+    const listening = app.listen(0, '127.0.0.1', () => resolve(listening));
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind tcp');
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise((resolve) => server.close(() => resolve())),
+  };
+}
+
+async function jsonRequest(
+  baseUrl: string,
+  method: 'GET' | 'POST' | 'PATCH',
+  url: string,
+  body?: object
+): Promise<{ status: number; body: any }> {
+  const response = await fetch(`${baseUrl}${url}`, {
+    method,
+    ...(body
+      ? {
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        }
+      : {}),
+  });
+  return { status: response.status, body: await response.json() };
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  const now = '2026-05-17T08:00:00.000Z';
+  const id = overrides.id ?? 'sess-local';
+  const nodeId = overrides.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  return {
+    id,
+    type: 'agent',
+    agent: 'claude',
+    mode: 'pty',
+    repoPath: '/repo/relay-ide',
+    worktreePath: null,
+    cwd: '/repo/relay-ide',
+    repoName: 'relay-ide',
+    branchName: 'nightly',
+    displayName: 'Agent 1',
+    createdAt: now,
+    lastActivity: now,
+    idle: false,
+    customCommand: null,
+    nodeId,
+    globalSessionId: createGlobalSessionId(nodeId, id),
+    status: 'running',
+    needsBranchRename: false,
+    agentState: 'busy',
+    ...overrides,
+  } as SessionSummary;
+}
+
+function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
+  return {
+    nodeId: 'node-remote',
+    displayName: 'remote mac mini',
+    hostname: 'remote-host',
+    platform: 'darwin',
+    arch: 'arm64',
+    relayVersion: '0.1.0',
+    protocolVersion: '1',
+    status: 'online',
+    connection: { state: 'connected' },
+    trust: { state: 'trusted', level: 'full' },
+    credentialState: 'active',
+    version: {
+      state: 'compatible',
+      nodeProtocolVersion: '1',
+      hubProtocolVersion: 1,
+    },
+    capabilities: {
+      totals: { available: 0, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        tmux: 'available',
+        git: 'available',
+        browserAutomation: 'unknown',
+        clipboardImage: 'unknown',
+        ssh: 'unknown',
+        tailscale: 'unknown',
+      },
+      agents: {},
+    },
+    createdAt: '2026-05-17T07:00:00.000Z',
+    pairedAt: '2026-05-17T07:00:00.000Z',
+    lastSeenAt: '2026-05-17T08:00:00.000Z',
+    credentialId: 'cred-1',
+    ...overrides,
+  } as HubNodeSummary;
+}
+
+function fullContext(overrides: Partial<WorkContext> = {}): WorkContext {
+  const now = '2026-05-17T08:00:00.000Z';
+  return {
+    schemaVersion: WORK_CONTEXT_SCHEMA_VERSION,
+    id: 'wc:test',
+    title: 'test context',
+    createdAt: now,
+    updatedAt: now,
+    source: 'vitest',
+    anchors: {},
+    actors: [],
+    tasks: [],
+    artifacts: [],
+    auditRefs: [],
+    capabilityGrants: [],
+    privacy: createWorkContextPrivacyMetadata({ retention: 'project' }),
+    ...overrides,
+  };
+}
+
+describe('WorkContext store', () => {
+  it('exposes create/read/list/update/link/session association through API routes', async () => {
+    const store = makeStore();
+    const live = session({ id: 'sess-api-live', cwd: '/tmp/free-live', repoPath: undefined });
+    const api = await startWorkContextApi(store, [live], [
+      node({ nodeId: 'node-offline', status: 'offline', displayName: 'offline node' }),
+    ]);
+    try {
+      const created = await jsonRequest(api.baseUrl, 'POST', '/work-contexts', {
+        id: 'wc:api',
+        title: 'API work',
+      });
+      expect(created.status).toBe(201);
+      expect(created.body.workContext.id).toBe('wc:api');
+
+      const listed = await jsonRequest(api.baseUrl, 'GET', '/work-contexts');
+      expect(listed.body.workContexts.map((context: WorkContext) => context.id)).toContain(
+        'wc:api'
+      );
+
+      const updated = await jsonRequest(api.baseUrl, 'PATCH', '/work-contexts/wc:api', {
+        title: 'Updated API work',
+      });
+      expect(updated.body.workContext.title).toBe('Updated API work');
+
+      await jsonRequest(api.baseUrl, 'POST', '/work-contexts', {
+        id: 'wc:linked',
+        title: 'Linked work',
+      });
+      const linked = await jsonRequest(api.baseUrl, 'POST', '/work-contexts/wc:api/link', {
+        targetContextId: 'wc:linked',
+        relationship: 'blocks',
+      });
+      expect(linked.body.workContext.relatedContextRefs).toContain('wc:linked');
+
+      const liveAssociation = await jsonRequest(
+        api.baseUrl,
+        'POST',
+        '/work-contexts/wc:api/sessions',
+        { sessionId: live.id }
+      );
+      expect(liveAssociation.status).toBe(200);
+
+      const offlineAssociation = await jsonRequest(
+        api.baseUrl,
+        'POST',
+        '/work-contexts/wc:linked/sessions',
+        {
+          sessionId: 'sess-offline-api',
+          nodeId: 'node-offline',
+          tabKind: 'agent',
+          cwd: '/remote/offline',
+        }
+      );
+      expect(offlineAssociation.status).toBe(200);
+
+      const active = await jsonRequest(api.baseUrl, 'GET', '/work-contexts/active');
+      expect(active.status).toBe(200);
+      expect(active.body.groups).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: 'wc:api',
+            staleReadModel: false,
+            sessions: [expect.objectContaining({ id: live.id, live: true })],
+          }),
+          expect.objectContaining({
+            id: 'wc:linked',
+            staleReadModel: true,
+            node: expect.objectContaining({ nodeId: 'node-offline', status: 'offline' }),
+            sessions: [expect.objectContaining({ id: 'sess-offline-api', live: false })],
+          }),
+        ])
+      );
+    } finally {
+      await api.close();
+      store.close();
+    }
+  });
+
+  it('persists create/read/list/update/link records using the shared schema', () => {
+    const store = makeStore();
+    try {
+      const created = store.create({ id: 'wc:one', title: 'One' });
+      expect(created.schemaVersion).toBe(WORK_CONTEXT_SCHEMA_VERSION);
+      expect(created.privacy.rawPayloadStored).toBe(false);
+      expect(store.get('wc:one')?.title).toBe('One');
+
+      const updated = store.update('wc:one', {
+        tasks: [
+          {
+            id: 'task:555',
+            kind: 'github-issue',
+            url: 'https://github.com/donovan-yohan/relay-ide/issues/555',
+            title: '#555 WorkContext persistence',
+            privacy: createWorkContextPrivacyMetadata({ retention: 'project' }),
+          },
+        ],
+      });
+      expect(updated.tasks).toHaveLength(1);
+
+      store.create({ id: 'wc:two', title: 'Two' });
+      const linked = store.linkContexts('wc:one', 'wc:two');
+      expect(linked.relatedContextRefs).toContain('wc:two');
+      expect(new Set(store.list().map((context) => context.id))).toEqual(
+        new Set(['wc:one', 'wc:two'])
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it('rejects raw transcripts/log payloads and raw-payload privacy flags', () => {
+    const store = makeStore();
+    try {
+      expect(() =>
+        store.create({
+          context: fullContext({
+            id: 'wc:bad-raw',
+            artifacts: [
+              {
+                id: 'artifact:bad',
+                kind: 'transcript-ref',
+                summary: 'bad raw transcript',
+                ref: 'file://redacted-pointer',
+                privacy: createWorkContextPrivacyMetadata({ retention: 'audit' }),
+                rawTranscript: 'terminal bytes should not be persisted',
+              } as WorkContext['artifacts'][number],
+            ],
+          }),
+        })
+      ).toThrow(/invalid_work_context|raw_payload_not_allowed/);
+      expect(() =>
+        store.create({
+          context: fullContext({
+            id: 'wc:bad-privacy',
+            privacy: {
+              ...createWorkContextPrivacyMetadata({ retention: 'project' }),
+              rawPayloadStored: true,
+            },
+          }),
+        })
+      ).toThrow(/invalid_work_context|raw_payload_storage_not_allowed/);
+    } finally {
+      store.close();
+    }
+  });
+
+  it('groups local sessions by WorkContext without requiring repo-only assumptions', () => {
+    const store = makeStore();
+    try {
+      const context = store.create({ id: 'wc:local', title: 'Local work' });
+      const local = session();
+      store.associateSession(context.id, { session: local });
+
+      const groups = store.listActiveWork({ sessions: [local], nodes: [] });
+      expect(groups).toHaveLength(1);
+      expect(groups[0]?.context?.id).toBe('wc:local');
+      expect(groups[0]?.node.status).toBe('online');
+      expect(groups[0]?.sessions[0]).toMatchObject({
+        id: local.id,
+        nodeId: DEFAULT_LOCAL_NODE_ID,
+        repoPath: '/repo/relay-ide',
+        live: true,
+      });
+    } finally {
+      store.close();
+    }
+  });
+
+  it('groups routed node sessions and reports node state from the hub registry read model', () => {
+    const store = makeStore();
+    try {
+      const context = store.create({ id: 'wc:remote', title: 'Remote work' });
+      const remote = session({
+        id: 'sess-remote',
+        nodeId: 'node-remote',
+        globalSessionId: createGlobalSessionId('node-remote', 'sess-remote'),
+        cwd: '/Users/agent/project',
+        repoPath: '/Users/agent/project',
+        worktreePath: null,
+        displayName: 'Remote Agent',
+      });
+      store.associateSession(context.id, { session: remote });
+
+      const groups = store.listActiveWork({
+        sessions: [remote],
+        nodes: [node({ nodeId: 'node-remote', status: 'online' })],
+      });
+      expect(groups[0]?.node).toMatchObject({
+        nodeId: 'node-remote',
+        status: 'online',
+        displayName: 'remote mac mini',
+      });
+      expect(groups[0]?.sessions[0]).toMatchObject({
+        id: 'sess-remote',
+        live: true,
+      });
+    } finally {
+      store.close();
+    }
+  });
+
+  it('keeps stale/offline node session refs visible when live session aggregation is empty', () => {
+    const store = makeStore();
+    try {
+      const context = store.create({ id: 'wc:offline', title: 'Offline work' });
+      store.associateSession(context.id, {
+        sessionRef: {
+          nodeId: 'node-offline',
+          sessionId: 'sess-old',
+          globalSessionId: createGlobalSessionId('node-offline', 'sess-old'),
+          tabKind: 'agent',
+          cwd: '/remote/worktree',
+        },
+      });
+
+      const groups = store.listActiveWork({
+        sessions: [],
+        nodes: [
+          node({
+            nodeId: 'node-offline',
+            displayName: 'offline node',
+            status: 'offline',
+            lastSeenAt: '2026-05-17T07:00:00.000Z',
+          }),
+        ],
+      });
+      expect(groups[0]?.node.status).toBe('offline');
+      expect(groups[0]?.staleReadModel).toBe(true);
+      expect(groups[0]?.sessions[0]).toMatchObject({
+        id: 'sess-old',
+        live: false,
+        cwd: '/remote/worktree',
+      });
+    } finally {
+      store.close();
+    }
+  });
+
+  it('includes free/non-git sessions in active work associations and unassigned grouping', () => {
+    const store = makeStore();
+    try {
+      const freeSession = session({
+        id: 'sess-free',
+        type: 'terminal',
+        mode: 'pty',
+        repoPath: undefined,
+        worktreePath: undefined,
+        repoName: undefined,
+        branchName: undefined,
+        cwd: '/tmp/free-shell',
+        displayName: 'Free shell',
+        agentState: 'idle',
+      });
+      const context = store.create({ id: 'wc:free', title: 'Free shell context' });
+      store.associateSession(context.id, { session: freeSession });
+
+      const [group] = store.listActiveWork({ sessions: [freeSession], nodes: [] });
+      expect(group?.context?.id).toBe('wc:free');
+      expect(group?.sessions[0]).toMatchObject({
+        id: 'sess-free',
+        tabKind: 'terminal',
+        cwd: '/tmp/free-shell',
+        live: true,
+      });
+      expect(group?.sessions[0]?.repoPath).toBeUndefined();
+
+      const unassigned = session({ id: 'sess-unassigned', cwd: '/tmp/unassigned' });
+      const groups = store.listActiveWork({ sessions: [freeSession, unassigned], nodes: [] });
+      expect(groups.some((candidate) => candidate.id.startsWith('unassigned:'))).toBe(true);
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/test/work-context-store.test.ts
+++ b/test/work-context-store.test.ts
@@ -201,6 +201,12 @@ describe('WorkContext store', () => {
       });
       expect(linked.body.workContext.relatedContextRefs).toContain('wc:linked');
 
+      const selfLink = await jsonRequest(api.baseUrl, 'POST', '/work-contexts/wc:api/link', {
+        targetContextId: 'wc:api',
+      });
+      expect(selfLink.status).toBe(400);
+      expect(selfLink.body.error).toBe('work_context_self_link_not_allowed');
+
       const liveAssociation = await jsonRequest(
         api.baseUrl,
         'POST',
@@ -239,6 +245,40 @@ describe('WorkContext store', () => {
           }),
         ])
       );
+    } finally {
+      await api.close();
+      store.close();
+    }
+  });
+
+  it('matches live session associations by nodeId when supplied', async () => {
+    const store = makeStore();
+    const local = session({ id: 'shared-session-id', nodeId: DEFAULT_LOCAL_NODE_ID });
+    const remote = session({
+      id: 'shared-session-id',
+      nodeId: 'node-remote',
+      globalSessionId: createGlobalSessionId('node-remote', 'shared-session-id'),
+      cwd: '/remote/cwd',
+      displayName: 'Remote collision session',
+    });
+    const api = await startWorkContextApi(store, [local, remote]);
+    try {
+      await jsonRequest(api.baseUrl, 'POST', '/work-contexts', {
+        id: 'wc:node-match',
+        title: 'Node match',
+      });
+      const associated = await jsonRequest(
+        api.baseUrl,
+        'POST',
+        '/work-contexts/wc:node-match/sessions',
+        { sessionId: 'shared-session-id', nodeId: 'node-remote' }
+      );
+
+      expect(associated.status).toBe(200);
+      expect(associated.body.workContext.anchors.session).toMatchObject({
+        nodeId: 'node-remote',
+        cwd: '/remote/cwd',
+      });
     } finally {
       await api.close();
       store.close();
@@ -309,6 +349,85 @@ describe('WorkContext store', () => {
         })
       ).toThrow(/invalid_work_context|raw_payload_storage_not_allowed/);
     } finally {
+      store.close();
+    }
+  });
+
+  it('canonicalizes persisted contexts to the shared WorkContext schema', () => {
+    const store = makeStore();
+    try {
+      const created = store.create({
+        context: fullContext({
+          id: 'wc:canonical',
+          anchors: {
+            node: {
+              nodeId: 'node-remote',
+              kind: 'remote',
+              displayName: 'Remote node',
+              messages: ['hidden node payload'],
+            } as WorkContext['anchors']['node'],
+          },
+          artifacts: [
+            {
+              id: 'artifact:summary',
+              kind: 'report',
+              summary: 'safe summary',
+              privacy: createWorkContextPrivacyMetadata({ retention: 'project' }),
+              messages: ['raw terminal transcript can hide here'],
+            } as WorkContext['artifacts'][number],
+          ],
+          messages: ['raw terminal transcript can hide here'],
+        } as Partial<WorkContext>),
+      });
+
+      const reloaded = store.get('wc:canonical') as WorkContext;
+      expect((created as WorkContext & { messages?: unknown }).messages).toBeUndefined();
+      expect((reloaded as WorkContext & { messages?: unknown }).messages).toBeUndefined();
+      expect(
+        (reloaded.anchors.node as WorkContext['anchors']['node'] & { messages?: unknown })
+          .messages
+      ).toBeUndefined();
+      expect(
+        (reloaded.artifacts[0] as WorkContext['artifacts'][number] & { messages?: unknown })
+          .messages
+      ).toBeUndefined();
+    } finally {
+      store.close();
+    }
+  });
+
+  it('filters PATCH payloads before persistence', async () => {
+    const store = makeStore();
+    const api = await startWorkContextApi(store);
+    try {
+      await jsonRequest(api.baseUrl, 'POST', '/work-contexts', {
+        id: 'wc:patch-filter',
+        title: 'Patch filter',
+      });
+      const patched = await jsonRequest(api.baseUrl, 'PATCH', '/work-contexts/wc:patch-filter', {
+        title: 'Patched',
+        messages: ['top-level raw transcript'],
+        artifacts: [
+          {
+            id: 'artifact:patch',
+            kind: 'report',
+            summary: 'safe patch summary',
+            privacy: createWorkContextPrivacyMetadata({ retention: 'project' }),
+            messages: ['nested raw transcript'],
+          },
+        ],
+      });
+
+      expect(patched.status).toBe(200);
+      const context = patched.body.workContext as WorkContext & { messages?: unknown };
+      expect(context.title).toBe('Patched');
+      expect(context.messages).toBeUndefined();
+      expect(
+        (context.artifacts[0] as WorkContext['artifacts'][number] & { messages?: unknown })
+          .messages
+      ).toBeUndefined();
+    } finally {
+      await api.close();
       store.close();
     }
   });


### PR DESCRIPTION
## Summary
- Add a SQLite-backed WorkContext store and `/work-contexts` API router for create/read/list/update/link/session association.
- Wire the hub server to initialize/close the WorkContext store and expose active work grouped by WorkContext across local and routed node sessions.
- Allow `/sessions` creation to associate new local/web/terminal sessions with an existing WorkContext while preserving legacy session behavior.
- Add coverage for API routes, privacy/raw-payload rejection, local/routed/offline/free-session grouping, and duplicate anchor/link suppression.

Closes #555
Refs #552

## The Case Against
- This is a backend spine only. It intentionally does not add frontend WorkContext UI; consumers still need to adopt `/work-contexts`.
- The store uses its own `work-contexts.db` with schema version 1. Future migrations need to be deliberate; this PR only handles initial creation.
- Session association is intentionally narrow: create-time `workContextId` validates existence, and existing sessions can be associated by live `sessionId`/`globalSessionId` or by explicit offline refs. It does not infer contexts from transcripts or raw Hermes profile state, because that would violate the privacy slice.
- Active-work grouping relies on hub/node read models passed into the router. Offline node visibility is a stale read model, not a live health probe.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Raw terminal/profile data accidentally persisted | Store validation rejects forbidden raw payload keys and any `rawPayloadStored: true` nested flag. Tests cover transcript/log/privacy rejection. |
| Duplicate active sessions from context anchor + association row | Active grouping suppresses duplicate anchor rows when the same node/session is already linked. API test covers this path. |
| Existing session creation breaks | Legacy `/sessions` validation and responses are preserved; `workContextId` is optional and only adds an existence check when present. Full suite passed. |
| Remote/offline sessions disappear | Session refs are persisted independently from live sessions and grouped with hub node state; tests cover routed node and offline stale state. |

## Verification
- `npm test -- test/work-context-store.test.ts` — 7/7 passed
- `npm run check` — passed (64 existing warnings, 0 errors)
- `npm run build` — passed (existing large chunk warnings)
- `npm test` — 220 files / 2334 tests passed
