### PR TITLE
fix: split session kill control capability

### DIFF
--- a/docs/SECURITY_POLICY.md
+++ b/docs/SECURITY_POLICY.md
@@ -19,7 +19,9 @@ Capability bits are a closed, protocol-versioned enum in `shared/security-policy
 Default legacy grants are intentionally boring:
 
 - allowed: `session:read`, `session:create:terminal`, `session:create:agent`, `session:attach`, `rpc:fs:list`, `rpc:fs:read`, `rpc:fs:tail`, `rpc:git:read`
-- off unless explicitly granted: `rpc:fs:write`, `rpc:fs:delete`, `rpc:git:write`, `pty:exec:arbitrary`, `preview:port-forward`
+- off unless explicitly granted: `session:control:kill`, `rpc:fs:write`, `rpc:fs:delete`, `rpc:git:write`, `pty:exec:arbitrary`, `preview:port-forward`
+
+`session:control:kill` is intentionally separate from `session:attach`: attaching or streaming a session is not authority to terminate it. Pause/retry controls are not routed in this slice; when added, they need explicit high-risk control bits instead of reusing attach.
 
 The schema exists before the full policy evaluator. Current routed surfaces still have their existing route-level checks; this slice adds the policy authority data model and legacy defaults so later gates have a safe source of truth.
 

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -2513,7 +2513,7 @@ export function createHubNodeRouter(
                 : {}),
             }
           : { kind: 'node', nodeId, cwd: '/' },
-        requiredCapabilities: ['session:attach'],
+        requiredCapabilities: ['session:control:kill'],
         sessionId,
         ...(scoped?.correlationId ? { correlationId: scoped.correlationId } : {}),
         ...(scoped?.expiresAt !== undefined ? { expiresAt: scoped.expiresAt } : {}),

--- a/server/hub-policy-evaluator.ts
+++ b/server/hub-policy-evaluator.ts
@@ -123,6 +123,7 @@ export function sessionCreateCapabilities(input: {
 export function requiredCapabilitiesForRpcIntent(action: string): string[] {
   if (action === 'sessions.interventions.read') return ['session:read', 'tab:intervention:read'];
   if (action === 'sessions.control.set-agent') return ['session:attach', 'tab:mode:set-agent'];
+  if (action === 'sessions.kill') return ['session:control:kill'];
   switch (action) {
     case 'sessions.create.terminal':
       return ['session:create:terminal'];

--- a/shared/security-policy.ts
+++ b/shared/security-policy.ts
@@ -7,6 +7,7 @@ export const RELAY_CAPABILITY_BITS = [
   'session:create:terminal',
   'session:create:agent',
   'session:attach',
+  'session:control:kill',
   'tab:mode:set-agent',
   'tab:intervention:read',
   'rpc:fs:list',
@@ -39,6 +40,7 @@ export const LEGACY_DEFAULT_ALLOWED_CAPABILITIES = [
 ] as const satisfies readonly RelayCapabilityBit[];
 
 export const HIGH_RISK_CAPABILITIES = [
+  'session:control:kill',
   'rpc:fs:write',
   'rpc:fs:delete',
   'rpc:git:write',

--- a/test/hub-confirmation-routing.test.ts
+++ b/test/hub-confirmation-routing.test.ts
@@ -6,11 +6,13 @@ import { createRepoFeatureRouter } from '../server/features/repo-router.js';
 import { createHubNodeRouter, type RoutedSessionAuditSink } from '../server/hub-node-router.js';
 import type { HubNodeRegistry } from '../server/hub-node-registry.js';
 import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
+import { createRoutedNodeSessionEnvelope } from '../shared/session-envelope.js';
 import {
   createLegacyDefaultNodeAcl,
   summarizeAcl,
   type RelayCapabilityBit,
   type RelayNodeAcl,
+  type RelayTrustTier,
 } from '../shared/security-policy.js';
 import type { HubNodeSummary, RelayNodeError } from '../shared/relay-node-protocol.js';
 
@@ -19,12 +21,14 @@ const NOW = new Date('2026-01-02T03:04:05.000Z');
 function nodeSummary(input: {
   allowed?: RelayCapabilityBit[];
   requiresConfirmation?: RelayCapabilityBit[];
+  trustTier?: RelayTrustTier;
 } = {}): HubNodeSummary {
+  const trustTier = input.trustTier ?? 'prod';
   const acl: RelayNodeAcl = {
     ...createLegacyDefaultNodeAcl({
       nodeId: 'node_prod',
       credentialId: 'cred_prod',
-      trustTier: 'prod',
+      trustTier,
       createdAt: NOW.toISOString(),
     }),
     grants: {
@@ -42,7 +46,7 @@ function nodeSummary(input: {
     protocolVersion: '1.0',
     status: 'online',
     connection: { route: 'reverse-link', status: 'connected' },
-    trust: { state: 'active', level: 'prod', tier: 'prod', policy: summarizeAcl(acl) },
+    trust: { state: 'active', level: trustTier, tier: trustTier, policy: summarizeAcl(acl) },
     credentialState: 'active',
     version: { state: 'compatible', nodeProtocolVersion: '1.0', hubProtocolVersion: '1.0' },
     capabilities: {
@@ -113,7 +117,9 @@ describe('hub confirmation routing', () => {
     while (cleanup.length > 0) await cleanup.pop()?.();
   });
 
-  async function startHub(options: { auditSink?: RoutedSessionAuditSink } = {}) {
+  async function startHub(
+    options: { auditSink?: RoutedSessionAuditSink; node?: HubNodeSummary } = {}
+  ) {
     const nodeLinks = {
       requests: [] as Array<{ nodeId: string; type: string; payload: unknown }>,
       hasActiveNode: () => true,
@@ -124,6 +130,7 @@ describe('hub confirmation routing', () => {
     };
     const auditEntries: Parameters<RoutedSessionAuditSink['append']>[0][] = [];
     const auditSink = options.auditSink ?? { append: (entry) => auditEntries.push(entry) };
+    const sessionEnvelopes = createSessionEnvelopeRegistry();
     const app = express();
     app.use((req, _res, next) => {
       const cookie = req.header('cookie') ?? '';
@@ -135,16 +142,16 @@ describe('hub confirmation routing', () => {
     app.use(
       createHubNodeRouter({
         registry: {
-          listNodes: () => [nodeSummary()],
+          listNodes: () => [options.node ?? nodeSummary()],
           errorBody: (error: unknown) => ({
             error: error instanceof Error
               ? ({ code: 'INTERNAL', message: error.message, retryable: false } satisfies RelayNodeError)
               : ({ code: 'INTERNAL', message: 'unknown error', retryable: false } satisfies RelayNodeError),
           }),
-          revokeNode: () => nodeSummary(),
+          revokeNode: () => options.node ?? nodeSummary(),
         } as unknown as HubNodeRegistry,
         nodeLinks,
-        sessionEnvelopes: createSessionEnvelopeRegistry(),
+        sessionEnvelopes,
         confirmations: createConfirmationChallengeStore({
           now: () => NOW,
           randomId: () => 'challenge-1',
@@ -161,7 +168,7 @@ describe('hub confirmation routing', () => {
     const server = http.createServer(app);
     const port = await listen(server);
     cleanup.push(() => close(server));
-    return { base: `http://127.0.0.1:${port}`, nodeLinks, auditEntries };
+    return { base: `http://127.0.0.1:${port}`, nodeLinks, auditEntries, sessionEnvelopes };
   }
 
   async function startColdReopenHub() {
@@ -429,6 +436,51 @@ describe('hub confirmation routing', () => {
       error: { code: 'INTERNAL', details: { reasonCode: 'POLICY_AUDIT_WRITE_FAILED_CLOSED' } },
     });
     expect(nodeLinks.requests).toHaveLength(0);
+  });
+
+  it('denies routed session kill when ACL only grants attach', async () => {
+    const { base, nodeLinks, auditEntries, sessionEnvelopes } = await startHub({
+      node: nodeSummary({
+        trustTier: 'dev',
+        allowed: ['session:read', 'session:attach'],
+        requiresConfirmation: [],
+      }),
+    });
+    sessionEnvelopes.upsert(
+      createRoutedNodeSessionEnvelope({
+        nodeId: 'node_prod',
+        sessionId: 'remote-session-1',
+        cwd: '/srv/relay-ide',
+        repoPath: '/srv/relay-ide',
+        issuedAt: NOW.toISOString(),
+      })
+    );
+
+    const response = await fetch(`${base}/hub/nodes/node_prod/sessions/remote-session-1`, {
+      method: 'DELETE',
+      headers: {
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+      },
+    });
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: {
+          reasonCode: 'POLICY_CAPABILITY_DENIED',
+          deniedBits: ['session:control:kill'],
+        },
+      },
+    });
+    expect(nodeLinks.requests).toHaveLength(0);
+    expect(auditEntries.at(-1)).toMatchObject({
+      eventType: 'denial',
+      reasonCode: 'POLICY_CAPABILITY_DENIED',
+      requiredBits: ['session:control:kill'],
+      deniedBits: ['session:control:kill'],
+    });
   });
 
   it('invalidates an approved requester token when approval audit append fails closed', async () => {

--- a/test/hub-node-session-routing.test.ts
+++ b/test/hub-node-session-routing.test.ts
@@ -24,6 +24,7 @@ import {
   createRoutedNodeSessionEnvelope,
 } from '../shared/session-envelope.js';
 import type { SecurityAuditEntryInput } from '../shared/security-audit.js';
+import type { RelayCapabilityBit } from '../shared/security-policy.js';
 
 function manifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
   return {
@@ -225,6 +226,35 @@ function seedRemoteSessionEnvelope(
       issuedAt: '2026-01-02T03:04:05.000Z',
     })
   );
+}
+
+function grantNodeCapabilitiesForTest(
+  registry: ReturnType<typeof createHubNodeRegistry>,
+  nodeId: string,
+  capabilities: RelayCapabilityBit[]
+): void {
+  const state = (registry as unknown as {
+    state: {
+      nodes: Array<{
+        nodeId: string;
+        acl?: {
+          grants: {
+            allowed: RelayCapabilityBit[];
+            requiresConfirmation: RelayCapabilityBit[];
+          };
+          lifecycle: { updatedAt: string };
+        };
+      }>;
+    };
+  }).state;
+  const node = state.nodes.find((candidate) => candidate.nodeId === nodeId);
+  expect(node?.acl).toBeDefined();
+  for (const capability of capabilities) {
+    if (!node!.acl!.grants.allowed.includes(capability)) {
+      node!.acl!.grants.allowed.push(capability);
+    }
+  }
+  node!.acl!.lifecycle.updatedAt = '2026-01-02T03:04:05.000Z';
 }
 
 describe('hub-routed node session create and attach', () => {
@@ -826,8 +856,9 @@ describe('hub-routed node session create and attach', () => {
   });
 
   it('routes remote session delete to the selected connected node', async () => {
-    const { base, wsBase, sessionEnvelopes } = await startHub();
+    const { base, wsBase, sessionEnvelopes, registry } = await startHub();
     const { token, nodeId } = await pairNode(base);
+    grantNodeCapabilitiesForTest(registry, nodeId, ['session:control:kill']);
     seedRemoteSessionEnvelope(sessionEnvelopes, nodeId);
     const nodeWs = new WebSocket(`${wsBase}/hub/node-link`, {
       headers: { authorization: `Bearer ${token}` },

--- a/test/hub-policy-evaluator.test.ts
+++ b/test/hub-policy-evaluator.test.ts
@@ -151,6 +151,29 @@ describe('hub policy evaluator', () => {
     });
   });
 
+  it('maps routed session kill to the explicit high-risk control capability', () => {
+    expect(requiredCapabilitiesForRpcIntent('sessions.kill')).toEqual([
+      'session:control:kill',
+    ]);
+
+    expect(evaluateHubPolicy(baseInput({ requiredCapabilities: ['session:attach'] }))).toMatchObject({
+      decision: 'allow',
+      grantedBits: ['session:attach'],
+    });
+    expect(
+      evaluateHubPolicy(
+        baseInput({
+          intent: { action: 'sessions.kill', target: 'node_a' },
+          requiredCapabilities: requiredCapabilitiesForRpcIntent('sessions.kill'),
+        })
+      )
+    ).toMatchObject({
+      decision: 'deny',
+      reasonCode: 'POLICY_CAPABILITY_DENIED',
+      deniedBits: ['session:control:kill'],
+    });
+  });
+
   it('canonicalizes path ACL comparisons before checking prefixes', () => {
     const node = nodeSummary({
       scope: { kind: 'path', pathPrefixes: ['/srv/allowed'] },

--- a/test/security-policy.test.ts
+++ b/test/security-policy.test.ts
@@ -26,6 +26,10 @@ describe('security policy schema', () => {
       known: false,
       decision: 'deny',
     });
+    expect(resolveAclCapability(acl, 'session:control:kill')).toMatchObject({
+      known: true,
+      decision: 'deny',
+    });
   });
 
   it('moves prod high-risk silent grants to confirmation without granting denied bits', () => {
@@ -37,7 +41,7 @@ describe('security policy schema', () => {
     const acl: RelayNodeAcl = {
       ...base,
       grants: {
-        allowed: ['session:read', 'rpc:fs:write', 'rpc:git:write'],
+        allowed: ['session:read', 'session:control:kill', 'rpc:fs:write', 'rpc:git:write'],
         requiresConfirmation: ['rpc:fs:delete'],
       },
     };
@@ -46,7 +50,12 @@ describe('security policy schema', () => {
 
     expect(overlaid.grants.allowed).toEqual(['session:read']);
     expect(overlaid.grants.requiresConfirmation).toEqual(
-      expect.arrayContaining(['rpc:fs:write', 'rpc:git:write', 'rpc:fs:delete'])
+      expect.arrayContaining([
+        'session:control:kill',
+        'rpc:fs:write',
+        'rpc:git:write',
+        'rpc:fs:delete',
+      ])
     );
     expect(resolveAclCapability(overlaid, 'preview:port-forward')).toMatchObject({
       decision: 'deny',

--- a/test/stores/node-dashboard.test.ts
+++ b/test/stores/node-dashboard.test.ts
@@ -289,9 +289,9 @@ describe('hub node dashboard state', () => {
     );
 
     expect(rows.map((row) => [row.security.trustTier, row.security.postureLabel])).toEqual([
-      ['sandbox', 'allow 1 · challenge 0 · deny 14'],
-      ['dev', 'allow 8 · challenge 0 · deny 7'],
-      ['prod', 'allow 1 · challenge 2 · deny 12'],
+      ['sandbox', 'allow 1 · challenge 0 · deny 15'],
+      ['dev', 'allow 8 · challenge 0 · deny 8'],
+      ['prod', 'allow 1 · challenge 2 · deny 13'],
     ]);
     expect(rows[2].security).toMatchObject({
       tone: 'danger',


### PR DESCRIPTION
## Summary
- Adds `session:control:kill` as a closed, high-risk Relay capability bit that is not included in legacy/default grants.
- Routes `DELETE /hub/nodes/:nodeId/sessions/:sessionId` through `session:control:kill` instead of `session:attach` while preserving envelope lifecycle/offline/session mismatch checks.
- Documents that pause/retry controls are deferred and must get explicit high-risk control bits when routed.

Closes #567
Refs #552 #559 #561

## Motivation
The #561 audit found that a hub credential allowed to attach to a routed session could also terminate it because `sessions.kill` reused `session:attach`. Attach/read authority and destructive process-control authority need separate policy bits. bro this was begging to become a spooky side effect.

## The Case Against
This change might be wrong if existing paired nodes/operators rely on legacy default `session:attach` silently permitting remote kill. That behavior is exactly the bug this PR closes, but it may make old nodes return `UNAUTHORIZED` for routed kill until their ACL is updated to allow or challenge `session:control:kill`.

This PR intentionally does not invent pause/retry bits because those routed controls are not implemented in this slice. If #559 adds pause/retry routes, they should add distinct high-risk bits instead of widening `session:control:kill` into a vague all-control wildcard.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Legacy/default nodes can no longer kill routed sessions with attach-only ACLs | Covered by policy and router tests proving attach alone denies kill. Operators can explicitly allow/challenge `session:control:kill`. |
| Prod/high-risk kill grants silently allow | `session:control:kill` is in `HIGH_RISK_CAPABILITIES`, so prod silent grants move to confirmation. |
| Route regression around stale/offline/session mismatch checks | Only the required policy bit changes inside the existing DELETE route after lifecycle checks; tests cover both attach-only denial and explicitly granted kill routing. |

## Verification
- `npm test -- test/hub-node-session-routing.test.ts test/stores/node-dashboard.test.ts test/security-policy.test.ts test/hub-policy-evaluator.test.ts test/hub-confirmation-routing.test.ts` — 66 passed
- `npm run check` — passed with existing lint warnings
- `npm run build` — passed with existing Vite chunk-size warning
