### PR TITLE
feat: add federated active-work surface

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -198,19 +198,21 @@ function useTerminalDerivedState() {
     [activeSessionId, sessions]
   );
 
-  const allWorkspaceSessions = useMemo(
-    () =>
-      activeRepoPath
-        ? sessions
-            .filter((session) => session.repoPath === activeRepoPath)
-            .toSorted(
-              (a, b) =>
-                new Date(a.createdAt).getTime() -
-                new Date(b.createdAt).getTime()
-            )
-        : [],
-    [activeRepoPath, sessions]
-  );
+  const allWorkspaceSessions = useMemo(() => {
+    const scopedSessions = activeRepoPath
+      ? sessions.filter((session) => session.repoPath === activeRepoPath)
+      : activeSession
+        ? sessions.filter(
+            (session) =>
+              session.cwd === activeSession.cwd &&
+              (session.nodeId ?? 'local') === (activeSession.nodeId ?? 'local')
+          )
+        : [];
+    return scopedSessions.toSorted(
+      (a, b) =>
+        new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+    );
+  }, [activeRepoPath, activeSession, sessions]);
 
   const workspaceSessions = useMemo(
     () =>
@@ -223,8 +225,7 @@ function useTerminalDerivedState() {
   const hasActiveSession = useMemo(
     () =>
       !!activeSession &&
-      !!activeRepoPath &&
-      activeSession.repoPath === activeRepoPath,
+      (activeRepoPath ? activeSession.repoPath === activeRepoPath : true),
     [activeSession, activeRepoPath]
   );
 
@@ -247,10 +248,10 @@ function useTerminalDerivedState() {
     'empty' | 'org' | 'dashboard' | 'session' | 'analytics'
   >(() => {
     if (analyticsView !== null) return 'analytics';
+    if (hasActiveSession) return 'session';
     if (!repos.length) return 'empty';
     if (!activeRepoPath) return 'org';
-    if (!hasActiveSession) return 'dashboard';
-    return 'session';
+    return 'dashboard';
   }, [analyticsView, repos.length, activeRepoPath, hasActiveSession]);
 
   return {
@@ -602,7 +603,9 @@ function TerminalAreaContent({
       if (relative !== null) {
         const currentActiveRepoPath = useUiStore.getState().activeRepoPath;
         const currentWorkspace = currentActiveRepoPath
-          ? sessionsState.repos.find((repo) => repo.path === currentActiveRepoPath)
+          ? sessionsState.repos.find(
+              (repo) => repo.path === currentActiveRepoPath
+            )
           : undefined;
         const currentRailContext = deriveUtilityRailContext({
           activeRepoPath: currentActiveRepoPath,
@@ -666,7 +669,10 @@ function TerminalAreaContent({
   }, [saveUtilityRailState, utilityRailResizable, utilityRailStateKey]);
 
   const handleToggleUtilityRail = useCallback(() => {
-    toggleUtilityRailForWorkspace(utilityRailStateKey, toggleUtilityRailVisible);
+    toggleUtilityRailForWorkspace(
+      utilityRailStateKey,
+      toggleUtilityRailVisible
+    );
   }, [toggleUtilityRailVisible, utilityRailStateKey]);
 
   const {
@@ -748,14 +754,16 @@ function TerminalAreaContent({
 
       {viewMode === 'session' && (
         <>
-          <PrTopBar
-            workspacePath={activeRepoPath ?? ''}
-            utilityRailWorkspacePath={utilityRailStateKey}
-            branchName={activeSession?.branchName ?? ''}
-            sessionId={activeSessionId}
-            agentRunning={activeSession?.agentState === 'processing'}
-            onArchive={onArchive}
-          />
+          {activeRepoPath && activeSession?.repoPath === activeRepoPath && (
+            <PrTopBar
+              workspacePath={activeRepoPath}
+              utilityRailWorkspacePath={utilityRailStateKey}
+              branchName={activeSession?.branchName ?? ''}
+              sessionId={activeSessionId}
+              agentRunning={activeSession?.agentState === 'processing'}
+              onArchive={onArchive}
+            />
+          )}
           <SplitPaneLayout
             rightSidebarCollapsed={!utilityRailState.visible}
             rightSidebarWidth={utilityRailWidth}

--- a/frontend/src/components/ActiveWorkSurface.css
+++ b/frontend/src/components/ActiveWorkSurface.css
@@ -1,0 +1,290 @@
+.active-work-surface {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.active-work-surface__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.active-work-surface__header h2 {
+  margin: 0;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-base);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.active-work-surface__header p,
+.active-work-surface__summary,
+.active-work-muted,
+.active-work-disabled-reason {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}
+
+.active-work-surface__header p {
+  margin: 4px 0 0;
+}
+
+.active-work-surface__summary {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  white-space: nowrap;
+}
+
+.active-work-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.active-work-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 12px;
+}
+
+.active-work-card {
+  display: grid;
+  grid-template-columns: 3px minmax(0, 1fr);
+  border: 1px solid var(--border);
+  background: var(--bg);
+  min-width: 0;
+}
+
+.active-work-card__status-strip {
+  background: var(--text-muted);
+}
+
+.active-work-card[data-node-status='online'] .active-work-card__status-strip,
+.active-work-card[data-node-status='online'] .active-work-node__dot {
+  background: var(--status-success);
+}
+
+.active-work-card[data-node-status='stale'] .active-work-card__status-strip,
+.active-work-card[data-node-status='stale'] .active-work-node__dot,
+.active-work-card[data-node-status='unknown'] .active-work-card__status-strip,
+.active-work-card[data-node-status='unknown'] .active-work-node__dot {
+  background: var(--status-warning);
+}
+
+.active-work-card[data-node-status='offline'] .active-work-card__status-strip,
+.active-work-card[data-node-status='offline'] .active-work-node__dot,
+.active-work-card[data-node-status='revoked'] .active-work-card__status-strip,
+.active-work-card[data-node-status='revoked'] .active-work-node__dot {
+  background: var(--status-error);
+}
+
+.active-work-card__main {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  min-width: 0;
+}
+
+.active-work-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
+.active-work-card__header h3 {
+  margin: 2px 0 0;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.active-work-card__eyebrow,
+.active-work-label {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.06em;
+}
+
+.active-work-card__eyebrow {
+  color: var(--accent);
+}
+
+.active-work-node {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.active-work-node__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+
+.active-work-chips,
+.active-work-artifacts,
+.active-work-session__meta,
+.active-work-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.active-work-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 6px;
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  color: var(--accent);
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  text-decoration: none;
+  max-width: 100%;
+}
+
+.active-work-chip--muted,
+.active-work-session__meta span {
+  border-color: var(--border);
+  color: var(--text-muted);
+}
+
+.active-work-chip:hover {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.active-work-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.active-work-grid > div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}
+
+.active-work-grid span:last-child,
+.active-work-session__cwd {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.active-work-sessions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.active-work-session {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  min-width: 0;
+}
+
+.active-work-session__title {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}
+
+.active-work-session__cwd {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}
+
+.active-work-session__meta span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  padding: 0 5px;
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}
+
+.active-work-controls {
+  padding-top: 2px;
+}
+
+.active-work-disabled-reason {
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+}
+
+@media (max-width: 760px) {
+  .active-work-surface__header,
+  .active-work-card__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .active-work-surface__summary,
+  .active-work-node {
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .active-work-list {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .active-work-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .active-work-controls {
+    position: sticky;
+    bottom: 0;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    background: var(--bg);
+    border-top: 1px solid var(--border);
+  }
+
+  .active-work-controls .tui-btn {
+    min-height: 44px;
+  }
+}

--- a/frontend/src/components/ActiveWorkSurface.tsx
+++ b/frontend/src/components/ActiveWorkSurface.tsx
@@ -1,0 +1,444 @@
+import { useMemo, useCallback } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
+import type {
+  WorkContextActiveGroup,
+  WorkContextSessionSummary,
+} from '../lib/types.js';
+import { fetchActiveWork } from '../lib/api.js';
+import { useSessionsStore } from '../lib/stores/sessions.js';
+import { useUiStore } from '../lib/stores/ui.js';
+import { scopedSessionKey } from '../lib/session-keys.js';
+import { TuiButton } from './TuiButton.js';
+import './ActiveWorkSurface.css';
+
+const ACTIVE_WORK_REFETCH_MS = 15_000;
+
+function shortId(id: string): string {
+  if (id.length <= 14) return id;
+  return `${id.slice(0, 6)}…${id.slice(-4)}`;
+}
+
+function dateLabel(value?: string): string {
+  if (!value) return 'unknown freshness';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const diffMs = Date.now() - date.getTime();
+  const abs = Math.abs(diffMs);
+  const suffix = diffMs >= 0 ? 'ago' : 'from now';
+  if (abs < 60_000) return 'just now';
+  if (abs < 3_600_000) return `${Math.round(abs / 60_000)}m ${suffix}`;
+  if (abs < 86_400_000) return `${Math.round(abs / 3_600_000)}h ${suffix}`;
+  return `${Math.round(abs / 86_400_000)}d ${suffix}`;
+}
+
+function taskLabel(group: WorkContextActiveGroup): string {
+  const context = group.context;
+  const firstTask = context?.tasks[0];
+  return (
+    context?.title ??
+    firstTask?.title ??
+    firstTask?.id ??
+    'unassigned active work'
+  );
+}
+
+function taskRefs(
+  group: WorkContextActiveGroup
+): Array<{ id: string; label: string; url?: string }> {
+  return (group.context?.tasks ?? []).map((task) => ({
+    id: task.id,
+    label: task.title ? `${task.id} · ${task.title}` : task.id,
+    ...(task.url ? { url: task.url } : {}),
+  }));
+}
+
+function actorLabels(group: WorkContextActiveGroup): string[] {
+  const seen = new Set<string>();
+  const labels: string[] = [];
+  for (const actor of group.context?.actors ?? []) {
+    const label = actor.displayName ?? actor.providerId ?? actor.id;
+    if (!seen.has(label)) {
+      seen.add(label);
+      labels.push(label);
+    }
+  }
+  for (const session of group.sessions) {
+    for (const actor of session.activeActors ?? []) {
+      const label = actor.displayName ?? actor.id ?? actor.kind;
+      if (!seen.has(label)) {
+        seen.add(label);
+        labels.push(label);
+      }
+    }
+    const worker = session.activeWorker;
+    if (worker) {
+      const label = worker.displayName ?? worker.id ?? worker.kind;
+      if (!seen.has(label)) {
+        seen.add(label);
+        labels.push(label);
+      }
+    }
+  }
+  return labels;
+}
+
+function statusPriority(group: WorkContextActiveGroup): number {
+  const hasPrompt = group.sessions.some(
+    (session) => session.agentState === 'permission-prompt'
+  );
+  if (hasPrompt) return 0;
+  if (group.node.status === 'offline' || group.node.status === 'revoked')
+    return 1;
+  if (group.node.status === 'stale' || group.staleReadModel) return 2;
+  if (group.sessions.some((session) => session.agentState === 'processing'))
+    return 3;
+  if (group.sessions.some((session) => session.live)) return 4;
+  return 5;
+}
+
+function stateLabel(group: WorkContextActiveGroup): string {
+  if (
+    group.sessions.some((session) => session.agentState === 'permission-prompt')
+  )
+    return 'needs approval';
+  if (group.node.status === 'offline' || group.node.status === 'revoked')
+    return 'offline';
+  if (group.node.status === 'stale') return 'stale';
+  if (group.staleReadModel) return 'stale read model';
+  if (group.sessions.some((session) => session.agentState === 'processing'))
+    return 'running';
+  if (group.sessions.some((session) => session.agentState === 'error'))
+    return 'error';
+  if (group.sessions.some((session) => session.live)) return 'live';
+  return 'inactive';
+}
+
+function latestStatus(group: WorkContextActiveGroup): string {
+  const active = group.sessions.find((session) => session.currentActivity);
+  if (active?.currentActivity) {
+    const detail = active.currentActivity.detail
+      ? ` · ${active.currentActivity.detail}`
+      : '';
+    return `${active.currentActivity.tool}${detail}`;
+  }
+  const intervention = group.sessions.find(
+    (session) => session.controlReason || session.lastInterventionAt
+  );
+  if (intervention?.controlReason) return intervention.controlReason;
+  if (intervention?.lastInterventionAt) {
+    const by =
+      intervention.lastInterventionBy?.displayName ??
+      intervention.lastInterventionBy?.id ??
+      'human';
+    return `latest intervention by ${by} · ${dateLabel(intervention.lastInterventionAt)}`;
+  }
+  const artifact = group.context?.artifacts[0];
+  if (artifact?.summary) return artifact.summary;
+  const session = group.sessions[0];
+  if (session?.agentState)
+    return `${session.agent ?? session.type ?? session.tabKind} · ${session.agentState}`;
+  return group.context
+    ? 'context linked, waiting for bounded status'
+    : 'session has no work context yet';
+}
+
+function controlDisabledReason(
+  group: WorkContextActiveGroup,
+  session?: WorkContextSessionSummary
+): string | null {
+  if (!session) return 'no session selected';
+  if (!session.live) return 'last-known session only';
+  if (group.node.status !== 'online') return `${group.node.status} node`;
+  if (group.staleReadModel) return 'stale read model';
+  return null;
+}
+
+function repoBindingLabel(
+  group: WorkContextActiveGroup,
+  session: WorkContextSessionSummary
+): string | null {
+  const repo = session.repoName ?? group.context?.anchors.repo?.ownerRepo;
+  const repoPath = session.repoPath ?? group.context?.anchors.repo?.localPath;
+  if (!repo && !repoPath) return null;
+  const branch = session.branchName ?? group.context?.anchors.repo?.branchName;
+  return [repo ?? repoPath, branch].filter(Boolean).join(' · ');
+}
+
+function sessionMeta(
+  group: WorkContextActiveGroup,
+  session: WorkContextSessionSummary
+): string[] {
+  const meta = [
+    session.tabKind,
+    session.type,
+    session.agent,
+    session.controlMode,
+    session.controlFreshness
+      ? `control ${session.controlFreshness}`
+      : undefined,
+  ].filter(Boolean) as string[];
+  const repo = repoBindingLabel(group, session);
+  if (repo) meta.push(`repo ${repo}`);
+  else meta.push('no repo binding');
+  return meta;
+}
+
+function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
+  const sessions = useSessionsStore((s) => s.sessions);
+  const setActiveSessionId = useSessionsStore((s) => s.setActiveSessionId);
+  const setActiveRepoPath = useUiStore((s) => s.setActiveRepoPath);
+  const primarySession =
+    group.sessions.find((session) => session.live) ?? group.sessions[0];
+  const disabledReason = controlDisabledReason(group, primarySession);
+  const actors = actorLabels(group);
+  const refs = taskRefs(group);
+  const artifacts = group.context?.artifacts ?? [];
+
+  const handleAttach = useCallback(() => {
+    if (!primarySession || disabledReason) return;
+    const live = sessions.find(
+      (session) =>
+        session.id === primarySession.id &&
+        (session.nodeId ?? DEFAULT_LOCAL_NODE_ID) === primarySession.nodeId
+    );
+    const nodeId = primarySession.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+    const isLocal = nodeId === DEFAULT_LOCAL_NODE_ID;
+    setActiveRepoPath(isLocal ? (primarySession.repoPath ?? null) : null);
+    setActiveSessionId(
+      live
+        ? scopedSessionKey(live)
+        : (primarySession.globalSessionId ?? primarySession.id)
+    );
+  }, [
+    disabledReason,
+    primarySession,
+    sessions,
+    setActiveRepoPath,
+    setActiveSessionId,
+  ]);
+
+  return (
+    <article className="active-work-card" data-node-status={group.node.status}>
+      <div className="active-work-card__status-strip" aria-hidden="true" />
+      <div className="active-work-card__main">
+        <div className="active-work-card__header">
+          <div>
+            <div className="active-work-card__eyebrow">{stateLabel(group)}</div>
+            <h3>{taskLabel(group)}</h3>
+          </div>
+          <div className="active-work-node">
+            <span className="active-work-node__dot" />
+            <span>{group.node.displayName ?? group.node.nodeId}</span>
+            <span className="active-work-muted">{group.node.status}</span>
+          </div>
+        </div>
+
+        {refs.length > 0 && (
+          <div className="active-work-chips" aria-label="task references">
+            {refs.map((ref) =>
+              ref.url ? (
+                <a
+                  key={ref.id}
+                  className="active-work-chip"
+                  href={ref.url}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {ref.label}
+                </a>
+              ) : (
+                <span key={ref.id} className="active-work-chip">
+                  {ref.label}
+                </span>
+              )
+            )}
+          </div>
+        )}
+
+        <div className="active-work-grid">
+          <div>
+            <span className="active-work-label">anchor</span>
+            <span>
+              {group.node.kind ?? 'remote'} · {primarySession?.cwd ?? 'no cwd'}
+            </span>
+          </div>
+          <div>
+            <span className="active-work-label">freshness</span>
+            <span>
+              {group.node.lastSeenAt
+                ? `last seen ${dateLabel(group.node.lastSeenAt)}`
+                : group.staleReadModel
+                  ? 'stale read model'
+                  : 'fresh'}
+            </span>
+          </div>
+          <div>
+            <span className="active-work-label">actors</span>
+            <span>
+              {actors.length
+                ? actors.join(' / ')
+                : (primarySession?.agent ?? 'unknown actor')}
+            </span>
+          </div>
+          <div>
+            <span className="active-work-label">latest</span>
+            <span>{latestStatus(group)}</span>
+          </div>
+        </div>
+
+        <div className="active-work-sessions">
+          {group.sessions.map((session) => (
+            <div
+              className="active-work-session"
+              key={`${session.nodeId}:${session.id}`}
+            >
+              <div className="active-work-session__title">
+                <span>{session.displayName ?? shortId(session.id)}</span>
+                <span className="active-work-muted">
+                  {shortId(session.globalSessionId ?? session.id)}
+                </span>
+                {!session.live && (
+                  <span className="active-work-chip active-work-chip--muted">
+                    last known
+                  </span>
+                )}
+              </div>
+              <div className="active-work-session__cwd">{session.cwd}</div>
+              <div className="active-work-session__meta">
+                {sessionMeta(group, session).map((item) => (
+                  <span key={item}>{item}</span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {artifacts.length > 0 && (
+          <div className="active-work-artifacts" aria-label="artifacts">
+            <span className="active-work-label">artifacts</span>
+            {artifacts.slice(0, 4).map((artifact) => {
+              const label = artifact.title ?? artifact.summary ?? artifact.id;
+              return artifact.uri ? (
+                <a
+                  key={artifact.id}
+                  className="active-work-chip"
+                  href={artifact.uri}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {artifact.kind} · {label}
+                </a>
+              ) : (
+                <span key={artifact.id} className="active-work-chip">
+                  {artifact.kind} · {label}
+                </span>
+              );
+            })}
+          </div>
+        )}
+
+        <div className="active-work-controls" aria-label="work controls">
+          <TuiButton
+            size="sm"
+            variant="info"
+            disabled={!!disabledReason}
+            title={disabledReason ?? 'attach to live session'}
+            onClick={handleAttach}
+          >
+            attach
+          </TuiButton>
+          <TuiButton
+            size="sm"
+            variant="ghost"
+            disabled
+            title={disabledReason ?? 'small input is #559 scope'}
+          >
+            small input
+          </TuiButton>
+          <TuiButton
+            size="sm"
+            variant="danger"
+            disabled
+            title={disabledReason ?? 'pause/kill requires capability contract'}
+          >
+            interrupt
+          </TuiButton>
+          {disabledReason && (
+            <span className="active-work-disabled-reason">
+              controls disabled: {disabledReason}
+            </span>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export default function ActiveWorkSurface() {
+  const {
+    data = [],
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: ['active-work'],
+    queryFn: fetchActiveWork,
+    staleTime: 5_000,
+    refetchInterval: ACTIVE_WORK_REFETCH_MS,
+  });
+
+  const groups = useMemo(
+    () => [...data].sort((a, b) => statusPriority(a) - statusPriority(b)),
+    [data]
+  );
+  const attentionCount = groups.filter(
+    (group) => statusPriority(group) <= 2
+  ).length;
+
+  if (isLoading)
+    return <div className="state-message">loading active work...</div>;
+  if (isError) {
+    return (
+      <div className="state-message state-message--error">
+        <span>could not load active work.</span>
+        <TuiButton size="sm" variant="ghost" onClick={() => void refetch()}>
+          retry
+        </TuiButton>
+      </div>
+    );
+  }
+
+  return (
+    <section
+      className="active-work-surface"
+      aria-label="active work across nodes"
+    >
+      <div className="active-work-surface__header">
+        <div>
+          <h2>active work</h2>
+          <p>grouped by workcontext across local and remote nodes</p>
+        </div>
+        <div className="active-work-surface__summary">
+          <span>{groups.length} contexts</span>
+          <span>{attentionCount} stale/needs attention</span>
+        </div>
+      </div>
+      {groups.length === 0 ? (
+        <div className="active-work-empty">
+          <span>no active work yet</span>
+          <span>
+            start from assistant, issue, or desktop relay; this surface will
+            group the resulting workcontext here.
+          </span>
+        </div>
+      ) : (
+        <div className="active-work-list">
+          {groups.map((group) => (
+            <ActiveWorkCard key={group.id} group={group} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/OrgDashboard.tsx
+++ b/frontend/src/components/OrgDashboard.tsx
@@ -15,6 +15,7 @@ import type {
   FilterPreset,
 } from '../lib/types.js';
 import TicketsPanel from './TicketsPanel.js';
+import ActiveWorkSurface from './ActiveWorkSurface.js';
 import { derivePrDotStatus } from '../lib/pr-status.js';
 import { TuiButton } from './TuiButton.js';
 import { PrRow } from './PrRow.js';
@@ -27,7 +28,7 @@ export interface OrgDashboardProps {
   onPrAction: (pr: PullRequest) => void;
 }
 
-type ActiveTab = 'prs' | 'tickets';
+type ActiveTab = 'active-work' | 'prs' | 'tickets';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -396,7 +397,7 @@ export function OrgDashboard({
   onOpenPrSession,
   onPrAction,
 }: OrgDashboardProps) {
-  const [activeTab, setActiveTab] = useState<ActiveTab>('prs');
+  const [activeTab, setActiveTab] = useState<ActiveTab>('active-work');
 
   return (
     <div className="org-dashboard">
@@ -406,12 +407,23 @@ export function OrgDashboard({
       {/* tab-strip uses raw buttons intentionally — underline-indicator navigation, not TuiButton actions */}
       <div className="tab-strip">
         <button
+          className={[
+            'tab-btn',
+            activeTab === 'active-work' ? 'tab-btn--active' : '',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+          onClick={() => setActiveTab('active-work')}
+        >
+          active work
+        </button>
+        <button
           className={['tab-btn', activeTab === 'prs' ? 'tab-btn--active' : '']
             .filter(Boolean)
             .join(' ')}
           onClick={() => setActiveTab('prs')}
         >
-          PRs
+          prs
         </button>
         <button
           className={[
@@ -422,9 +434,10 @@ export function OrgDashboard({
             .join(' ')}
           onClick={() => setActiveTab('tickets')}
         >
-          Tickets
+          tickets
         </button>
       </div>
+      {activeTab === 'active-work' && <ActiveWorkSurface />}
       {activeTab === 'prs' && (
         <PrsTab onOpenPrSession={onOpenPrSession} onPrAction={onPrAction} />
       )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -30,6 +30,7 @@ import type {
   FrameworkInfo,
   BranchDivergenceSummary,
   AggregatedRepoInventoryResponse,
+  WorkContextActiveGroup,
 } from './types.js';
 import type { HubNodeSummary } from '../../../shared/relay-node-protocol.js';
 import {
@@ -38,7 +39,10 @@ import {
   type NodeId,
 } from '../../../shared/identity.js';
 import type { SessionLane } from '../../../shared/session-lane.js';
-import type { ControlActor, InterventionRecord } from '../../../shared/control-state.js';
+import type {
+  ControlActor,
+  InterventionRecord,
+} from '../../../shared/control-state.js';
 import { registerConfirmationRetry } from './confirmation-retries.js';
 
 export class ConflictError extends Error {
@@ -111,7 +115,13 @@ export interface ConfirmationChallenge {
 export class ConfirmationRequiredError extends HttpError {
   challenge: ConfirmationChallenge;
   constructor(error: HttpError, challenge: ConfirmationChallenge) {
-    super(error.status, error.message, error.code, error.retryable, error.details);
+    super(
+      error.status,
+      error.message,
+      error.code,
+      error.retryable,
+      error.details
+    );
     this.name = 'ConfirmationRequiredError';
     this.challenge = challenge;
   }
@@ -175,7 +185,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function isConfirmationChallenge(value: unknown): value is ConfirmationChallenge {
+function isConfirmationChallenge(
+  value: unknown
+): value is ConfirmationChallenge {
   if (!isRecord(value)) return false;
   return (
     typeof value['challengeId'] === 'string' &&
@@ -190,7 +202,9 @@ function isConfirmationChallenge(value: unknown): value is ConfirmationChallenge
   );
 }
 
-function confirmationChallengeFromError(error: HttpError): ConfirmationChallenge | undefined {
+function confirmationChallengeFromError(
+  error: HttpError
+): ConfirmationChallenge | undefined {
   const challenge = error.details?.['challenge'];
   return isConfirmationChallenge(challenge) ? challenge : undefined;
 }
@@ -258,8 +272,12 @@ export async function checkAuthStatus(): Promise<{
   return { hasPIN: data.hasPIN === true, noPin: data.noPin === true };
 }
 
-export async function fetchConfirmationChallenges(): Promise<ConfirmationChallenge[]> {
-  const data = await json<{ challenges?: unknown[] }>(await fetch('/hub/confirmations'));
+export async function fetchConfirmationChallenges(): Promise<
+  ConfirmationChallenge[]
+> {
+  const data = await json<{ challenges?: unknown[] }>(
+    await fetch('/hub/confirmations')
+  );
   return Array.isArray(data.challenges)
     ? data.challenges.filter(isConfirmationChallenge)
     : [];
@@ -282,8 +300,11 @@ export async function approveConfirmationChallenge(
   decision: ConfirmationDecision,
   approverSession?: string
 ): Promise<{ confirmationToken?: string; challenge: ConfirmationChallenge }> {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (approverSession?.trim()) headers['x-auth-session'] = approverSession.trim();
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (approverSession?.trim())
+    headers['x-auth-session'] = approverSession.trim();
   const res = await fetch(
     '/hub/confirmations/' + encodeURIComponent(challengeId) + '/approve',
     {
@@ -292,8 +313,12 @@ export async function approveConfirmationChallenge(
       body: JSON.stringify({ decision }),
     }
   );
-  if (!res.ok) throw await httpErrorFromResponse(res, 'Failed to approve confirmation');
-  const data = await jsonEither<{ confirmationToken?: unknown; challenge?: unknown }>(res);
+  if (!res.ok)
+    throw await httpErrorFromResponse(res, 'Failed to approve confirmation');
+  const data = await jsonEither<{
+    confirmationToken?: unknown;
+    challenge?: unknown;
+  }>(res);
   if (!isConfirmationChallenge(data.challenge)) {
     throw new Error('confirmation approval response was malformed');
   }
@@ -309,15 +334,30 @@ export async function fetchConfirmationRequesterToken(
   challengeId: string
 ): Promise<{ confirmationToken: string; challenge: ConfirmationChallenge }> {
   const res = await fetch(
-    '/hub/confirmations/' + encodeURIComponent(challengeId) + '/requester-token',
+    '/hub/confirmations/' +
+      encodeURIComponent(challengeId) +
+      '/requester-token',
     { method: 'POST' }
   );
-  if (!res.ok) throw await httpErrorFromResponse(res, 'Failed to fetch confirmation token');
-  const data = await jsonEither<{ confirmationToken?: unknown; challenge?: unknown }>(res);
-  if (typeof data.confirmationToken !== 'string' || !isConfirmationChallenge(data.challenge)) {
+  if (!res.ok)
+    throw await httpErrorFromResponse(
+      res,
+      'Failed to fetch confirmation token'
+    );
+  const data = await jsonEither<{
+    confirmationToken?: unknown;
+    challenge?: unknown;
+  }>(res);
+  if (
+    typeof data.confirmationToken !== 'string' ||
+    !isConfirmationChallenge(data.challenge)
+  ) {
     throw new Error('confirmation requester-token response was malformed');
   }
-  return { confirmationToken: data.confirmationToken, challenge: data.challenge };
+  return {
+    confirmationToken: data.confirmationToken,
+    challenge: data.challenge,
+  };
 }
 
 export async function setupPin(pin: string, confirm: string): Promise<void> {
@@ -365,22 +405,40 @@ export async function handBackSessionControl(input: {
   sessionId: string;
   latestSeenInterventionEventId: string;
   actor?: ControlActor;
-}): Promise<{ ok: true; events: unknown[]; ackedHumanInterventions: InterventionRecord[] }> {
-  return json<{ ok: true; events: unknown[]; ackedHumanInterventions: InterventionRecord[] }>(
-    await fetch(`/sessions/${encodeURIComponent(input.sessionId)}/control/hand-back`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        latestSeenInterventionEventId: input.latestSeenInterventionEventId,
-        ...(input.actor ? { actor: input.actor } : {}),
-      }),
-    })
+}): Promise<{
+  ok: true;
+  events: unknown[];
+  ackedHumanInterventions: InterventionRecord[];
+}> {
+  return json<{
+    ok: true;
+    events: unknown[];
+    ackedHumanInterventions: InterventionRecord[];
+  }>(
+    await fetch(
+      `/sessions/${encodeURIComponent(input.sessionId)}/control/hand-back`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          latestSeenInterventionEventId: input.latestSeenInterventionEventId,
+          ...(input.actor ? { actor: input.actor } : {}),
+        }),
+      }
+    )
   );
 }
 
 export async function fetchHubNodes(): Promise<HubNodeSummary[]> {
   const data = await json<{ nodes?: HubNodeSummary[] }>(await fetch('/nodes'));
   return Array.isArray(data.nodes) ? data.nodes : [];
+}
+
+export async function fetchActiveWork(): Promise<WorkContextActiveGroup[]> {
+  const data = await json<{ groups?: WorkContextActiveGroup[] }>(
+    await fetch('/work-contexts/active')
+  );
+  return Array.isArray(data.groups) ? data.groups : [];
 }
 
 function normalizeTelemetryMapEntry(
@@ -815,13 +873,18 @@ async function parseSessionCreateResponse(
   throw error;
 }
 
-export async function createSession(body: CreateSessionBody): Promise<SessionSummary> {
+export async function createSession(
+  body: CreateSessionBody
+): Promise<SessionSummary> {
   const { nodeId, ...sessionBody } = body;
   const sessionPath = sessionCreatePath(nodeId);
-  return parseSessionCreateResponse(await postSessionCreate(sessionPath, sessionBody), {
-    sessionPath,
-    sessionBody,
-  });
+  return parseSessionCreateResponse(
+    await postSessionCreate(sessionPath, sessionBody),
+    {
+      sessionPath,
+      sessionBody,
+    }
+  );
 }
 
 export async function killSession(
@@ -847,7 +910,11 @@ export async function killSession(
           method: 'DELETE',
           headers: { 'x-confirmation-token': confirmationToken },
         });
-        if (!retryRes.ok) throw await httpErrorFromResponse(retryRes, 'Failed to close session');
+        if (!retryRes.ok)
+          throw await httpErrorFromResponse(
+            retryRes,
+            'Failed to close session'
+          );
       },
     });
     throw new ConfirmationRequiredError(error, challenge);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -19,6 +19,11 @@ import type {
   ControlFreshness,
   ControlMode,
 } from '../../../shared/control-state.js';
+import type { HubNodeStatus } from '../../../shared/relay-node-protocol.js';
+import type {
+  WorkContext,
+  WorkContextTabKind,
+} from '../../../shared/work-context.js';
 export type {
   AggregatedRepoInventoryGroup,
   AggregatedRepoInventoryResponse,
@@ -190,6 +195,53 @@ export interface SessionSummary {
   permissionType?: 'approval' | 'question';
   /** Typed intent/scope envelope. New server responses include this; old cached sessions may omit it. */
   sessionEnvelope?: SessionEnvelope | undefined;
+}
+
+export interface WorkContextSessionSummary {
+  id: string;
+  nodeId: NodeId;
+  globalSessionId?: GlobalSessionId;
+  tabKind: WorkContextTabKind;
+  type?: SessionSummary['type'];
+  mode?: SessionSummary['mode'];
+  agent?: SessionSummary['agent'];
+  cwd: string;
+  repoPath?: string;
+  worktreePath?: string | null;
+  repoName?: string;
+  branchName?: string;
+  displayName?: string;
+  status?: SessionSummary['status'];
+  agentState?: SessionSummary['agentState'];
+  currentActivity?: SessionSummary['currentActivity'];
+  controlMode?: ControlMode;
+  activeActors?: ControlActor[];
+  activeWorker?: ControlActor;
+  lastInterventionAt?: string | null;
+  lastInterventionBy?: ControlActor | null;
+  lastInterventionEventId?: string | null;
+  controlFreshness?: ControlFreshness;
+  controlReason?: string;
+  lastActivity?: string;
+  relationship: string;
+  associatedAt: string;
+  live: boolean;
+}
+
+export interface WorkContextNodeState {
+  nodeId: NodeId;
+  status: HubNodeStatus | 'unknown';
+  displayName?: string;
+  lastSeenAt?: string;
+  kind?: 'local' | 'remote';
+}
+
+export interface WorkContextActiveGroup {
+  id: string;
+  context: WorkContext | null;
+  node: WorkContextNodeState;
+  sessions: WorkContextSessionSummary[];
+  staleReadModel: boolean;
 }
 
 export interface WorktreeInfo {

--- a/server/work-contexts.ts
+++ b/server/work-contexts.ts
@@ -7,8 +7,14 @@ import type { RequestHandler } from 'express';
 
 import { createLogger } from './logger.js';
 import type { SessionSummary } from './types.js';
-import { DEFAULT_LOCAL_NODE_ID, createGlobalSessionId } from '../shared/identity.js';
-import type { HubNodeStatus, HubNodeSummary } from '../shared/relay-node-protocol.js';
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  createGlobalSessionId,
+} from '../shared/identity.js';
+import type {
+  HubNodeStatus,
+  HubNodeSummary,
+} from '../shared/relay-node-protocol.js';
 import {
   WORK_CONTEXT_SCHEMA_VERSION,
   createWorkContextPrivacyMetadata,
@@ -164,8 +170,15 @@ export interface WorkContextSessionSummary {
   displayName?: string;
   status?: SessionSummary['status'];
   agentState?: SessionSummary['agentState'];
+  currentActivity?: SessionSummary['currentActivity'];
   controlMode?: SessionSummary['controlMode'];
+  activeActors?: SessionSummary['activeActors'];
+  activeWorker?: SessionSummary['activeWorker'];
+  lastInterventionAt?: SessionSummary['lastInterventionAt'];
+  lastInterventionBy?: SessionSummary['lastInterventionBy'];
+  lastInterventionEventId?: SessionSummary['lastInterventionEventId'];
   controlFreshness?: SessionSummary['controlFreshness'];
+  controlReason?: SessionSummary['controlReason'];
   lastActivity?: string;
   relationship: string;
   associatedAt: string;
@@ -199,8 +212,15 @@ export interface WorkContextStore {
   get(id: WorkContextId): WorkContext | null;
   list(): WorkContext[];
   update(id: WorkContextId, patch: WorkContextPatchInput): WorkContext;
-  linkContexts(sourceId: WorkContextId, targetId: WorkContextId, relationship?: string): WorkContext;
-  associateSession(id: WorkContextId, input: SessionAssociationInput): WorkContext;
+  linkContexts(
+    sourceId: WorkContextId,
+    targetId: WorkContextId,
+    relationship?: string
+  ): WorkContext;
+  associateSession(
+    id: WorkContextId,
+    input: SessionAssociationInput
+  ): WorkContext;
   listActiveWork(input: ListActiveWorkInput): WorkContextActiveGroup[];
 }
 
@@ -220,7 +240,9 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
   db.pragma('journal_mode = WAL');
   db.pragma('synchronous = NORMAL');
   db.pragma('foreign_keys = ON');
-  db.exec('CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)');
+  db.exec(
+    'CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)'
+  );
   const row = db.prepare('SELECT version FROM schema_version').get() as
     | { version: number }
     | undefined;
@@ -232,7 +254,9 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
       if (hadRow) {
         db.prepare('UPDATE schema_version SET version = ?').run(SCHEMA_VERSION);
       } else {
-        db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(SCHEMA_VERSION);
+        db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(
+          SCHEMA_VERSION
+        );
       }
     })();
   }
@@ -295,7 +319,8 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
 
   function mustGet(id: WorkContextId): WorkContext {
     const context = getById(id);
-    if (!context) throw new WorkContextStoreError(404, 'work_context_not_found');
+    if (!context)
+      throw new WorkContextStoreError(404, 'work_context_not_found');
     return context;
   }
 
@@ -342,9 +367,16 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
       return write(updated);
     },
 
-    linkContexts(sourceId: WorkContextId, targetId: WorkContextId, relationship = 'related') {
+    linkContexts(
+      sourceId: WorkContextId,
+      targetId: WorkContextId,
+      relationship = 'related'
+    ) {
       if (sourceId === targetId) {
-        throw new WorkContextStoreError(400, 'work_context_self_link_not_allowed');
+        throw new WorkContextStoreError(
+          400,
+          'work_context_self_link_not_allowed'
+        );
       }
       const source = mustGet(sourceId);
       mustGet(targetId);
@@ -357,7 +389,12 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
       };
       db.transaction(() => {
         write(updated);
-        upsertContextLink.run(sourceId, targetId, relationship, updated.updatedAt);
+        upsertContextLink.run(
+          sourceId,
+          targetId,
+          relationship,
+          updated.updatedAt
+        );
       })();
       return updated;
     },
@@ -373,7 +410,11 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
         throw new WorkContextStoreError(400, 'session_ref_required');
       }
       assertValidSessionRef(sessionRef);
-      const updated = contextWithSessionAnchor(existing, sessionRef, associatedAt);
+      const updated = contextWithSessionAnchor(
+        existing,
+        sessionRef,
+        associatedAt
+      );
       db.transaction(() => {
         write(updated);
         upsertSessionLink.run({
@@ -392,7 +433,12 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
     listActiveWork(input: ListActiveWorkInput) {
       const contexts = this.list();
       const allLinks = selectSessionLinks.all() as SessionLinkRow[];
-      return buildActiveGroups(contexts, allLinks, input.sessions, input.nodes ?? []);
+      return buildActiveGroups(
+        contexts,
+        allLinks,
+        input.sessions,
+        input.nodes ?? []
+      );
     },
   };
 }
@@ -458,7 +504,10 @@ export function createWorkContextRouter(deps: WorkContextRouterDeps): Router {
   });
 
   router.post('/:id/link', auth, (req, res) => {
-    const body = req.body as { targetContextId?: string; relationship?: string };
+    const body = req.body as {
+      targetContextId?: string;
+      relationship?: string;
+    };
     if (!body.targetContextId) {
       res.status(400).json({ error: 'targetContextId is required' });
       return;
@@ -535,8 +584,12 @@ function buildContextFromInput(
     artifacts: input.artifacts ?? [],
     auditRefs: input.auditRefs ?? [],
     capabilityGrants: input.capabilityGrants ?? [],
-    ...(input.relatedContextRefs ? { relatedContextRefs: input.relatedContextRefs } : {}),
-    privacy: input.privacy ?? createWorkContextPrivacyMetadata({ retention: 'project' }),
+    ...(input.relatedContextRefs
+      ? { relatedContextRefs: input.relatedContextRefs }
+      : {}),
+    privacy:
+      input.privacy ??
+      createWorkContextPrivacyMetadata({ retention: 'project' }),
   };
   return context;
 }
@@ -596,7 +649,9 @@ function canonicalizePersistableContext(context: WorkContext): WorkContext {
   return canonical;
 }
 
-function pickWorkContextPatch(patch: WorkContextPatchInput): WorkContextPatchInput {
+function pickWorkContextPatch(
+  patch: WorkContextPatchInput
+): WorkContextPatchInput {
   return {
     ...(patch.title !== undefined ? { title: patch.title } : {}),
     ...(patch.source !== undefined ? { source: patch.source } : {}),
@@ -642,7 +697,9 @@ function pickPrivacy(privacy: WorkContext['privacy']): WorkContext['privacy'] {
       ...(privacy.redaction.hashSha256
         ? { hashSha256: privacy.redaction.hashSha256 }
         : {}),
-      ...(privacy.redaction.preview ? { preview: privacy.redaction.preview } : {}),
+      ...(privacy.redaction.preview
+        ? { preview: privacy.redaction.preview }
+        : {}),
     },
     ...(privacy.policyRefs ? { policyRefs: [...privacy.policyRefs] } : {}),
   };
@@ -692,10 +749,18 @@ function pickAnchors(anchors: WorkContext['anchors']): WorkContext['anchors'] {
         branchName: anchors.worktree.branchName,
       })
     : undefined;
-  return withoutUndefined({ node, session, project, repo, worktree }) as WorkContext['anchors'];
+  return withoutUndefined({
+    node,
+    session,
+    project,
+    repo,
+    worktree,
+  }) as WorkContext['anchors'];
 }
 
-function pickActor(actor: WorkContext['actors'][number]): WorkContext['actors'][number] {
+function pickActor(
+  actor: WorkContext['actors'][number]
+): WorkContext['actors'][number] {
   return {
     kind: actor.kind,
     id: actor.id,
@@ -707,7 +772,9 @@ function pickActor(actor: WorkContext['actors'][number]): WorkContext['actors'][
   };
 }
 
-function pickTask(task: WorkContext['tasks'][number]): WorkContext['tasks'][number] {
+function pickTask(
+  task: WorkContext['tasks'][number]
+): WorkContext['tasks'][number] {
   return {
     kind: task.kind,
     id: task.id,
@@ -747,7 +814,9 @@ function pickAuditRef(
     ...(auditRef.type ? { type: auditRef.type } : {}),
     ...(auditRef.occurredAt ? { occurredAt: auditRef.occurredAt } : {}),
     ...(auditRef.actorId ? { actorId: auditRef.actorId } : {}),
-    ...(auditRef.correlationId ? { correlationId: auditRef.correlationId } : {}),
+    ...(auditRef.correlationId
+      ? { correlationId: auditRef.correlationId }
+      : {}),
     ...(auditRef.chainHash ? { chainHash: auditRef.chainHash } : {}),
     ...(auditRef.logRef ? { logRef: auditRef.logRef } : {}),
     privacy: pickPrivacy(auditRef.privacy),
@@ -771,7 +840,9 @@ function pickCapabilityGrant(
             ...(grant.scope.workspaceIds
               ? { workspaceIds: [...grant.scope.workspaceIds] }
               : {}),
-            ...(grant.scope.repoIds ? { repoIds: [...grant.scope.repoIds] } : {}),
+            ...(grant.scope.repoIds
+              ? { repoIds: [...grant.scope.repoIds] }
+              : {}),
             ...(grant.scope.pathPrefixes
               ? { pathPrefixes: [...grant.scope.pathPrefixes] }
               : {}),
@@ -835,8 +906,10 @@ function contextWithSessionAnchor(
 
 export function sessionSummaryToRef(session: SessionSummary): SessionRef {
   const nodeId = session.nodeId ?? DEFAULT_LOCAL_NODE_ID;
-  const globalSessionId = session.globalSessionId ?? createGlobalSessionId(nodeId, session.id);
-  const tabKind: WorkContextTabKind = session.type === 'terminal' ? 'terminal' : 'agent';
+  const globalSessionId =
+    session.globalSessionId ?? createGlobalSessionId(nodeId, session.id);
+  const tabKind: WorkContextTabKind =
+    session.type === 'terminal' ? 'terminal' : 'agent';
   return {
     nodeId,
     sessionId: session.id,
@@ -847,7 +920,11 @@ export function sessionSummaryToRef(session: SessionSummary): SessionRef {
 }
 
 function sessionRefFromBody(body: SessionRefBody): SessionRef {
-  if (!body.cwd) throw new WorkContextStoreError(400, 'cwd is required for offline session refs');
+  if (!body.cwd)
+    throw new WorkContextStoreError(
+      400,
+      'cwd is required for offline session refs'
+    );
   const nodeId = body.nodeId ?? DEFAULT_LOCAL_NODE_ID;
   return {
     nodeId,
@@ -867,7 +944,10 @@ function findLiveSessionForAssociation(
   return sessions.find((session) => {
     const nodeId = session.nodeId ?? DEFAULT_LOCAL_NODE_ID;
     if (body.nodeId && nodeId !== body.nodeId) return false;
-    return session.id === body.sessionId || session.globalSessionId === body.sessionId;
+    return (
+      session.id === body.sessionId ||
+      session.globalSessionId === body.sessionId
+    );
   });
 }
 
@@ -900,8 +980,11 @@ function buildActiveGroups(
     const groupSessions = contextLinks.map((link) => {
       const key = sessionKey(link.node_id, link.session_id);
       linkedSessionKeys.add(key);
-      const live = sessionsByKey.get(key) ??
-        (link.global_session_id ? sessionsByKey.get(link.global_session_id) : undefined);
+      const live =
+        sessionsByKey.get(key) ??
+        (link.global_session_id
+          ? sessionsByKey.get(link.global_session_id)
+          : undefined);
       return summarizeLinkedSession(link, live);
     });
 
@@ -911,7 +994,8 @@ function buildActiveGroups(
       context,
       node,
       sessions: groupSessions,
-      staleReadModel: node.status !== 'online' || groupSessions.some((s) => !s.live),
+      staleReadModel:
+        node.status !== 'online' || groupSessions.some((s) => !s.live),
     });
   }
 
@@ -932,7 +1016,9 @@ function buildActiveGroups(
   return groups;
 }
 
-function buildSessionLookup(sessions: SessionSummary[]): Map<string, SessionSummary> {
+function buildSessionLookup(
+  sessions: SessionSummary[]
+): Map<string, SessionSummary> {
   const lookup = new Map<string, SessionSummary>();
   for (const session of sessions) {
     const nodeId = session.nodeId ?? DEFAULT_LOCAL_NODE_ID;
@@ -942,7 +1028,9 @@ function buildSessionLookup(sessions: SessionSummary[]): Map<string, SessionSumm
   return lookup;
 }
 
-function groupLinksByContext(links: SessionLinkRow[]): Map<string, SessionLinkRow[]> {
+function groupLinksByContext(
+  links: SessionLinkRow[]
+): Map<string, SessionLinkRow[]> {
   const grouped = new Map<string, SessionLinkRow[]>();
   for (const link of links) {
     const existing = grouped.get(link.work_context_id);
@@ -1008,21 +1096,42 @@ function summarizeLiveSession(
   const summary: WorkContextSessionSummary = {
     id: session.id,
     nodeId,
-    ...(session.globalSessionId ? { globalSessionId: session.globalSessionId } : {}),
+    ...(session.globalSessionId
+      ? { globalSessionId: session.globalSessionId }
+      : {}),
     tabKind: session.type === 'terminal' ? 'terminal' : 'agent',
     type: session.type,
     mode: session.mode,
     agent: session.agent,
     cwd: session.cwd,
     ...(session.repoPath ? { repoPath: session.repoPath } : {}),
-    ...(session.worktreePath !== undefined ? { worktreePath: session.worktreePath } : {}),
+    ...(session.worktreePath !== undefined
+      ? { worktreePath: session.worktreePath }
+      : {}),
     ...(session.repoName ? { repoName: session.repoName } : {}),
     ...(session.branchName ? { branchName: session.branchName } : {}),
     displayName: session.displayName,
     status: session.status,
     agentState: session.agentState,
+    ...(session.currentActivity
+      ? { currentActivity: session.currentActivity }
+      : {}),
     ...(session.controlMode ? { controlMode: session.controlMode } : {}),
-    ...(session.controlFreshness ? { controlFreshness: session.controlFreshness } : {}),
+    ...(session.activeActors ? { activeActors: session.activeActors } : {}),
+    ...(session.activeWorker ? { activeWorker: session.activeWorker } : {}),
+    ...(session.lastInterventionAt !== undefined
+      ? { lastInterventionAt: session.lastInterventionAt }
+      : {}),
+    ...(session.lastInterventionBy !== undefined
+      ? { lastInterventionBy: session.lastInterventionBy }
+      : {}),
+    ...(session.lastInterventionEventId !== undefined
+      ? { lastInterventionEventId: session.lastInterventionEventId }
+      : {}),
+    ...(session.controlFreshness
+      ? { controlFreshness: session.controlFreshness }
+      : {}),
+    ...(session.controlReason ? { controlReason: session.controlReason } : {}),
     lastActivity: session.lastActivity,
     relationship: link.relationship,
     associatedAt: link.associated_at,
@@ -1043,7 +1152,9 @@ function nodeStateForContext(
   nodesById: Map<string, HubNodeSummary>
 ): WorkContextNodeState {
   const nodeId =
-    context.anchors.node?.nodeId ?? sessions[0]?.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+    context.anchors.node?.nodeId ??
+    sessions[0]?.nodeId ??
+    DEFAULT_LOCAL_NODE_ID;
   const state = nodeStateForNodeId(nodeId, nodesById);
   if (context.anchors.node?.displayName || context.anchors.node?.kind) {
     return {
@@ -1072,7 +1183,12 @@ function nodeStateForNodeId(
     };
   }
   if (nodeId === DEFAULT_LOCAL_NODE_ID) {
-    return { nodeId, status: 'online', displayName: 'Local node', kind: 'local' };
+    return {
+      nodeId,
+      status: 'online',
+      displayName: 'Local node',
+      kind: 'local',
+    };
   }
   return { nodeId, status: 'unknown', kind: 'remote' };
 }

--- a/test/work-context-store.test.ts
+++ b/test/work-context-store.test.ts
@@ -14,7 +14,10 @@ import {
 } from '../server/work-contexts.js';
 import type { SessionSummary } from '../server/types.js';
 import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
-import { DEFAULT_LOCAL_NODE_ID, createGlobalSessionId } from '../shared/identity.js';
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  createGlobalSessionId,
+} from '../shared/identity.js';
 import {
   WORK_CONTEXT_SCHEMA_VERSION,
   createWorkContextPrivacyMetadata,
@@ -24,7 +27,9 @@ import {
 const tmpDirs: string[] = [];
 
 function makeStoreHandle(): { store: WorkContextStore; dbPath: string } {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-work-context-test-'));
+  const dir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'relay-work-context-test-')
+  );
   tmpDirs.push(dir);
   const dbPath = path.join(dir, 'work-contexts.db');
   return { store: createWorkContextStore(dbPath), dbPath };
@@ -70,7 +75,8 @@ async function startWorkContextApi(
     const listening = app.listen(0, '127.0.0.1', () => resolve(listening));
   });
   const address = server.address();
-  if (!address || typeof address === 'string') throw new Error('server did not bind tcp');
+  if (!address || typeof address === 'string')
+    throw new Error('server did not bind tcp');
   return {
     baseUrl: `http://127.0.0.1:${address.port}`,
     close: () => new Promise((resolve) => server.close(() => resolve())),
@@ -191,10 +197,22 @@ function fullContext(overrides: Partial<WorkContext> = {}): WorkContext {
 describe('WorkContext store', () => {
   it('exposes create/read/list/update/link/session association through API routes', async () => {
     const store = makeStore();
-    const live = session({ id: 'sess-api-live', cwd: '/tmp/free-live', repoPath: undefined });
-    const api = await startWorkContextApi(store, [live], [
-      node({ nodeId: 'node-offline', status: 'offline', displayName: 'offline node' }),
-    ]);
+    const live = session({
+      id: 'sess-api-live',
+      cwd: '/tmp/free-live',
+      repoPath: undefined,
+    });
+    const api = await startWorkContextApi(
+      store,
+      [live],
+      [
+        node({
+          nodeId: 'node-offline',
+          status: 'offline',
+          displayName: 'offline node',
+        }),
+      ]
+    );
     try {
       const created = await jsonRequest(api.baseUrl, 'POST', '/work-contexts', {
         id: 'wc:api',
@@ -204,28 +222,43 @@ describe('WorkContext store', () => {
       expect(created.body.workContext.id).toBe('wc:api');
 
       const listed = await jsonRequest(api.baseUrl, 'GET', '/work-contexts');
-      expect(listed.body.workContexts.map((context: WorkContext) => context.id)).toContain(
-        'wc:api'
-      );
+      expect(
+        listed.body.workContexts.map((context: WorkContext) => context.id)
+      ).toContain('wc:api');
 
-      const updated = await jsonRequest(api.baseUrl, 'PATCH', '/work-contexts/wc:api', {
-        title: 'Updated API work',
-      });
+      const updated = await jsonRequest(
+        api.baseUrl,
+        'PATCH',
+        '/work-contexts/wc:api',
+        {
+          title: 'Updated API work',
+        }
+      );
       expect(updated.body.workContext.title).toBe('Updated API work');
 
       await jsonRequest(api.baseUrl, 'POST', '/work-contexts', {
         id: 'wc:linked',
         title: 'Linked work',
       });
-      const linked = await jsonRequest(api.baseUrl, 'POST', '/work-contexts/wc:api/link', {
-        targetContextId: 'wc:linked',
-        relationship: 'blocks',
-      });
+      const linked = await jsonRequest(
+        api.baseUrl,
+        'POST',
+        '/work-contexts/wc:api/link',
+        {
+          targetContextId: 'wc:linked',
+          relationship: 'blocks',
+        }
+      );
       expect(linked.body.workContext.relatedContextRefs).toContain('wc:linked');
 
-      const selfLink = await jsonRequest(api.baseUrl, 'POST', '/work-contexts/wc:api/link', {
-        targetContextId: 'wc:api',
-      });
+      const selfLink = await jsonRequest(
+        api.baseUrl,
+        'POST',
+        '/work-contexts/wc:api/link',
+        {
+          targetContextId: 'wc:api',
+        }
+      );
       expect(selfLink.status).toBe(400);
       expect(selfLink.body.error).toBe('work_context_self_link_not_allowed');
 
@@ -250,7 +283,11 @@ describe('WorkContext store', () => {
       );
       expect(offlineAssociation.status).toBe(200);
 
-      const active = await jsonRequest(api.baseUrl, 'GET', '/work-contexts/active');
+      const active = await jsonRequest(
+        api.baseUrl,
+        'GET',
+        '/work-contexts/active'
+      );
       expect(active.status).toBe(200);
       expect(active.body.groups).toEqual(
         expect.arrayContaining([
@@ -262,8 +299,13 @@ describe('WorkContext store', () => {
           expect.objectContaining({
             id: 'wc:linked',
             staleReadModel: true,
-            node: expect.objectContaining({ nodeId: 'node-offline', status: 'offline' }),
-            sessions: [expect.objectContaining({ id: 'sess-offline-api', live: false })],
+            node: expect.objectContaining({
+              nodeId: 'node-offline',
+              status: 'offline',
+            }),
+            sessions: [
+              expect.objectContaining({ id: 'sess-offline-api', live: false }),
+            ],
           }),
         ])
       );
@@ -275,11 +317,17 @@ describe('WorkContext store', () => {
 
   it('matches live session associations by nodeId when supplied', async () => {
     const store = makeStore();
-    const local = session({ id: 'shared-session-id', nodeId: DEFAULT_LOCAL_NODE_ID });
+    const local = session({
+      id: 'shared-session-id',
+      nodeId: DEFAULT_LOCAL_NODE_ID,
+    });
     const remote = session({
       id: 'shared-session-id',
       nodeId: 'node-remote',
-      globalSessionId: createGlobalSessionId('node-remote', 'shared-session-id'),
+      globalSessionId: createGlobalSessionId(
+        'node-remote',
+        'shared-session-id'
+      ),
       cwd: '/remote/cwd',
       displayName: 'Remote collision session',
     });
@@ -352,7 +400,9 @@ describe('WorkContext store', () => {
                 kind: 'transcript-ref',
                 summary: 'bad raw transcript',
                 ref: 'file://redacted-pointer',
-                privacy: createWorkContextPrivacyMetadata({ retention: 'audit' }),
+                privacy: createWorkContextPrivacyMetadata({
+                  retention: 'audit',
+                }),
                 rawTranscript: 'terminal bytes should not be persisted',
               } as WorkContext['artifacts'][number],
             ],
@@ -394,7 +444,9 @@ describe('WorkContext store', () => {
               id: 'artifact:summary',
               kind: 'report',
               summary: 'safe summary',
-              privacy: createWorkContextPrivacyMetadata({ retention: 'project' }),
+              privacy: createWorkContextPrivacyMetadata({
+                retention: 'project',
+              }),
               messages: ['raw terminal transcript can hide here'],
             } as WorkContext['artifacts'][number],
           ],
@@ -403,15 +455,25 @@ describe('WorkContext store', () => {
       });
 
       const reloaded = store.get('wc:canonical') as WorkContext;
-      expect((created as WorkContext & { messages?: unknown }).messages).toBeUndefined();
-      expect((reloaded as WorkContext & { messages?: unknown }).messages).toBeUndefined();
       expect(
-        (reloaded.anchors.node as WorkContext['anchors']['node'] & { messages?: unknown })
-          .messages
+        (created as WorkContext & { messages?: unknown }).messages
       ).toBeUndefined();
       expect(
-        (reloaded.artifacts[0] as WorkContext['artifacts'][number] & { messages?: unknown })
-          .messages
+        (reloaded as WorkContext & { messages?: unknown }).messages
+      ).toBeUndefined();
+      expect(
+        (
+          reloaded.anchors.node as WorkContext['anchors']['node'] & {
+            messages?: unknown;
+          }
+        ).messages
+      ).toBeUndefined();
+      expect(
+        (
+          reloaded.artifacts[0] as WorkContext['artifacts'][number] & {
+            messages?: unknown;
+          }
+        ).messages
       ).toBeUndefined();
     } finally {
       store.close();
@@ -430,86 +492,86 @@ describe('WorkContext store', () => {
       repoName: undefined,
       branchName: undefined,
     });
-    const api = await startWorkContextApi(store, [live], [
-      node({ nodeId: 'node-remote', status: 'online', displayName: 'remote node' }),
-    ]);
+    const api = await startWorkContextApi(
+      store,
+      [live],
+      [
+        node({
+          nodeId: 'node-remote',
+          status: 'online',
+          displayName: 'remote node',
+        }),
+      ]
+    );
     try {
       store.create({ id: 'wc:stale-canonical', title: 'Stale canonical row' });
       store.associateSession('wc:stale-canonical', { session: live });
-      replacePersistedContextJson(
-        dbPath,
-        'wc:stale-canonical',
-        {
-          ...fullContext({
-            id: 'wc:stale-canonical',
-            title: 'Stale canonical row',
-            anchors: {
-              node: {
-                nodeId: 'node-remote',
-                kind: 'remote',
-                displayName: 'remote node',
-                debugPayload: 'hidden node payload must not leave the read path',
-              } as WorkContext['anchors']['node'],
-              session: {
-                nodeId: 'node-remote',
-                sessionId: live.id,
-                globalSessionId: live.globalSessionId,
-                tabKind: 'agent',
-                cwd: live.cwd,
-                debugPayload: 'hidden session payload must not leave the read path',
-              } as WorkContext['anchors']['session'],
-            },
-            artifacts: [
-              {
-                id: 'artifact:stale-summary',
-                kind: 'report',
-                summary: 'safe stale summary',
-                privacy: createWorkContextPrivacyMetadata({ retention: 'project' }),
-                debugPayload: 'hidden artifact payload must not leave the read path',
-              } as WorkContext['artifacts'][number],
-            ],
-          }),
-          debugPayload: 'hidden top-level payload must not leave the read path',
-        } as unknown as Record<string, unknown>
-      );
+      replacePersistedContextJson(dbPath, 'wc:stale-canonical', {
+        ...fullContext({
+          id: 'wc:stale-canonical',
+          title: 'Stale canonical row',
+          anchors: {
+            node: {
+              nodeId: 'node-remote',
+              kind: 'remote',
+              displayName: 'remote node',
+              debugPayload: 'hidden node payload must not leave the read path',
+            } as WorkContext['anchors']['node'],
+            session: {
+              nodeId: 'node-remote',
+              sessionId: live.id,
+              globalSessionId: live.globalSessionId,
+              tabKind: 'agent',
+              cwd: live.cwd,
+              debugPayload:
+                'hidden session payload must not leave the read path',
+            } as WorkContext['anchors']['session'],
+          },
+          artifacts: [
+            {
+              id: 'artifact:stale-summary',
+              kind: 'report',
+              summary: 'safe stale summary',
+              privacy: createWorkContextPrivacyMetadata({
+                retention: 'project',
+              }),
+              debugPayload:
+                'hidden artifact payload must not leave the read path',
+            } as WorkContext['artifacts'][number],
+          ],
+        }),
+        debugPayload: 'hidden top-level payload must not leave the read path',
+      } as unknown as Record<string, unknown>);
 
       store.create({ id: 'wc:raw-stale', title: 'Raw stale row' });
-      replacePersistedContextJson(
-        dbPath,
-        'wc:raw-stale',
-        {
-          ...fullContext({
-            id: 'wc:raw-stale',
-            title: 'Raw stale row',
-            artifacts: [
-              {
-                id: 'artifact:raw-transcript',
-                kind: 'transcript-ref',
-                summary: 'unsafe raw transcript row',
-                privacy: createWorkContextPrivacyMetadata({ retention: 'audit' }),
-                rawTranscript: 'raw transcript secret must not leak',
-              } as WorkContext['artifacts'][number],
-            ],
-          }),
-          hermesProfileState: { token: 'profile payload secret must not leak' },
-        } as unknown as Record<string, unknown>
-      );
+      replacePersistedContextJson(dbPath, 'wc:raw-stale', {
+        ...fullContext({
+          id: 'wc:raw-stale',
+          title: 'Raw stale row',
+          artifacts: [
+            {
+              id: 'artifact:raw-transcript',
+              kind: 'transcript-ref',
+              summary: 'unsafe raw transcript row',
+              privacy: createWorkContextPrivacyMetadata({ retention: 'audit' }),
+              rawTranscript: 'raw transcript secret must not leak',
+            } as WorkContext['artifacts'][number],
+          ],
+        }),
+        hermesProfileState: { token: 'profile payload secret must not leak' },
+      } as unknown as Record<string, unknown>);
 
       store.create({ id: 'wc:raw-flag-stale', title: 'Raw flag stale row' });
-      replacePersistedContextJson(
-        dbPath,
-        'wc:raw-flag-stale',
-        {
-          ...fullContext({
-            id: 'wc:raw-flag-stale',
-            title: 'Raw flag stale row',
-            privacy: {
-              ...createWorkContextPrivacyMetadata({ retention: 'project' }),
-              rawPayloadStored: true,
-            },
-          }),
-        } as unknown as Record<string, unknown>
-      );
+      replacePersistedContextJson(dbPath, 'wc:raw-flag-stale', {
+        ...fullContext({
+          id: 'wc:raw-flag-stale',
+          title: 'Raw flag stale row',
+          privacy: {
+            ...createWorkContextPrivacyMetadata({ retention: 'project' }),
+            rawPayloadStored: true,
+          },
+        }),
+      } as unknown as Record<string, unknown>);
 
       const canonicalGet = await jsonRequest(
         api.baseUrl,
@@ -520,7 +582,11 @@ describe('WorkContext store', () => {
       expect(canonicalGet.body.workContext.id).toBe('wc:stale-canonical');
       expect(JSON.stringify(canonicalGet.body)).not.toContain('hidden');
 
-      const rawGet = await jsonRequest(api.baseUrl, 'GET', '/work-contexts/wc:raw-stale');
+      const rawGet = await jsonRequest(
+        api.baseUrl,
+        'GET',
+        '/work-contexts/wc:raw-stale'
+      );
       expect(rawGet.status).toBe(404);
       const rawFlagGet = await jsonRequest(
         api.baseUrl,
@@ -530,7 +596,9 @@ describe('WorkContext store', () => {
       expect(rawFlagGet.status).toBe(404);
 
       const listed = await jsonRequest(api.baseUrl, 'GET', '/work-contexts');
-      const listedIds = listed.body.workContexts.map((context: WorkContext) => context.id);
+      const listedIds = listed.body.workContexts.map(
+        (context: WorkContext) => context.id
+      );
       const listJson = JSON.stringify(listed.body);
       expect(listedIds).toContain('wc:stale-canonical');
       expect(listedIds).not.toContain('wc:raw-stale');
@@ -539,8 +607,14 @@ describe('WorkContext store', () => {
       expect(listJson).not.toContain('raw transcript secret');
       expect(listJson).not.toContain('profile payload secret');
 
-      const active = await jsonRequest(api.baseUrl, 'GET', '/work-contexts/active');
-      const activeIds = active.body.groups.map((group: { id: string }) => group.id);
+      const active = await jsonRequest(
+        api.baseUrl,
+        'GET',
+        '/work-contexts/active'
+      );
+      const activeIds = active.body.groups.map(
+        (group: { id: string }) => group.id
+      );
       const activeJson = JSON.stringify(active.body);
       expect(active.status).toBe(200);
       expect(activeIds).toContain('wc:stale-canonical');
@@ -563,27 +637,39 @@ describe('WorkContext store', () => {
         id: 'wc:patch-filter',
         title: 'Patch filter',
       });
-      const patched = await jsonRequest(api.baseUrl, 'PATCH', '/work-contexts/wc:patch-filter', {
-        title: 'Patched',
-        messages: ['top-level raw transcript'],
-        artifacts: [
-          {
-            id: 'artifact:patch',
-            kind: 'report',
-            summary: 'safe patch summary',
-            privacy: createWorkContextPrivacyMetadata({ retention: 'project' }),
-            messages: ['nested raw transcript'],
-          },
-        ],
-      });
+      const patched = await jsonRequest(
+        api.baseUrl,
+        'PATCH',
+        '/work-contexts/wc:patch-filter',
+        {
+          title: 'Patched',
+          messages: ['top-level raw transcript'],
+          artifacts: [
+            {
+              id: 'artifact:patch',
+              kind: 'report',
+              summary: 'safe patch summary',
+              privacy: createWorkContextPrivacyMetadata({
+                retention: 'project',
+              }),
+              messages: ['nested raw transcript'],
+            },
+          ],
+        }
+      );
 
       expect(patched.status).toBe(200);
-      const context = patched.body.workContext as WorkContext & { messages?: unknown };
+      const context = patched.body.workContext as WorkContext & {
+        messages?: unknown;
+      };
       expect(context.title).toBe('Patched');
       expect(context.messages).toBeUndefined();
       expect(
-        (context.artifacts[0] as WorkContext['artifacts'][number] & { messages?: unknown })
-          .messages
+        (
+          context.artifacts[0] as WorkContext['artifacts'][number] & {
+            messages?: unknown;
+          }
+        ).messages
       ).toBeUndefined();
     } finally {
       await api.close();
@@ -625,6 +711,12 @@ describe('WorkContext store', () => {
         repoPath: '/Users/agent/project',
         worktreePath: null,
         displayName: 'Remote Agent',
+        currentActivity: { tool: 'npm run build', detail: 'vite compiling' },
+        controlMode: 'co-driven',
+        activeActors: [
+          { kind: 'agent', id: 'ika', displayName: 'ika-frontend' },
+        ],
+        controlFreshness: 'fresh',
       });
       store.associateSession(context.id, { session: remote });
 
@@ -640,6 +732,12 @@ describe('WorkContext store', () => {
       expect(groups[0]?.sessions[0]).toMatchObject({
         id: 'sess-remote',
         live: true,
+        currentActivity: { tool: 'npm run build', detail: 'vite compiling' },
+        controlMode: 'co-driven',
+        activeActors: [
+          { kind: 'agent', id: 'ika', displayName: 'ika-frontend' },
+        ],
+        controlFreshness: 'fresh',
       });
     } finally {
       store.close();
@@ -698,10 +796,16 @@ describe('WorkContext store', () => {
         displayName: 'Free shell',
         agentState: 'idle',
       });
-      const context = store.create({ id: 'wc:free', title: 'Free shell context' });
+      const context = store.create({
+        id: 'wc:free',
+        title: 'Free shell context',
+      });
       store.associateSession(context.id, { session: freeSession });
 
-      const [group] = store.listActiveWork({ sessions: [freeSession], nodes: [] });
+      const [group] = store.listActiveWork({
+        sessions: [freeSession],
+        nodes: [],
+      });
       expect(group?.context?.id).toBe('wc:free');
       expect(group?.sessions[0]).toMatchObject({
         id: 'sess-free',
@@ -711,9 +815,17 @@ describe('WorkContext store', () => {
       });
       expect(group?.sessions[0]?.repoPath).toBeUndefined();
 
-      const unassigned = session({ id: 'sess-unassigned', cwd: '/tmp/unassigned' });
-      const groups = store.listActiveWork({ sessions: [freeSession, unassigned], nodes: [] });
-      expect(groups.some((candidate) => candidate.id.startsWith('unassigned:'))).toBe(true);
+      const unassigned = session({
+        id: 'sess-unassigned',
+        cwd: '/tmp/unassigned',
+      });
+      const groups = store.listActiveWork({
+        sessions: [freeSession, unassigned],
+        nodes: [],
+      });
+      expect(
+        groups.some((candidate) => candidate.id.startsWith('unassigned:'))
+      ).toBe(true);
     } finally {
       store.close();
     }


### PR DESCRIPTION
## Summary
- Adds an Active Work tab to the org dashboard backed by `/work-contexts/active`.
- Renders WorkContext cards with task refs, node status/freshness, actors/control state, session/tab/cwd/kind, artifacts, and bounded latest status.
- Keeps stale/offline last-known sessions visible while disabling live controls, and prevents remote/free sessions from inheriting hub-local repo top bars/actions.

## Motivation
Issue #557 needs a federated surface that answers "what work is active across local and remote nodes?" without pretending every tab is a hub-local repo checkout. This uses the existing WorkContext active-group backend contract and only extends it with bounded live session/control summary fields.

## The Case Against
This change might be wrong because:
- The surface is currently an org-dashboard tab, not a deeper #444 IA workspace/view migration. If the final IA wants Active Work somewhere else, this will need relocation.
- Controls are intentionally conservative. Attach works for live sessions; small-input and interrupt remain disabled placeholders until #559/capability contracts define safe behavior.
- Browser proof uses a static production build plus mocked API fixtures for local/remote/free/offline states because this machine does not have a real paired remote node topology available in the test run.
- The mocked browser run emits expected static-harness console noise for `/ws/events` and unmatched POST/static routes; the assertions and screenshots are still useful for layout/state coverage, not websocket health.

## Risks & Mitigation
| Risk | Mitigation |
| --- | --- |
| Remote/free tabs inherit stale repo UI | `App.tsx` now allows active non-repo sessions to render as sessions while hiding `PrTopBar` unless the active session is bound to the active repo path. |
| Offline sessions look live | WorkContext cards distinguish `live: false`, show `last known`, and disable attach/live controls with a reason. |
| Control/latest status omitted from active groups | Server active summaries now include current activity and control actor/freshness/intervention metadata; tests assert the fields survive the active-group read model. |
| Mobile controls too small | Mobile CSS makes card controls sticky within cards and gives buttons 44px minimum height. |

## Verification
- `npm test -- test/work-context-store.test.ts` — 11/11 passed.
- `npm run check` — passed with existing warning-only lint output.
- `npm run build` — passed.
- Browser fixture smoke against production build: checks passed for local repo context, remote node context, free/non-git context, stale/offline disabled controls, and mobile control height.
  - Desktop screenshot: `/tmp/relay-active-work-desktop.png`
  - Mobile screenshot: `/tmp/relay-active-work-mobile.png`

Closes #557
Refs #552
