### PR TITLE
feat: add assistant-to-pair handoff metadata

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -270,6 +270,7 @@ function parseGatewayCreateInput(sessionArgs: string[]): Record<string, unknown>
     ['--branch-name', 'branchName'],
     ['--initial-prompt', 'initialPrompt'],
     ['--continue-policy', 'continuePolicy'],
+    ['--work-context-id', 'workContextId'],
     ['--control-mode', 'controlMode'],
     ['--confirmation-token', 'confirmationToken'],
     ['--expires-at', 'expiresAt'],

--- a/server/work-contexts.ts
+++ b/server/work-contexts.ts
@@ -13,8 +13,11 @@ import {
   WORK_CONTEXT_SCHEMA_VERSION,
   createWorkContextPrivacyMetadata,
   isWorkContext,
+  type ArtifactRef,
+  type AuditEventRef,
   type NodeRefKind,
   type SessionRef,
+  type TaskRef,
   type WorkContext,
   type WorkContextId,
   type WorkContextTabKind,
@@ -25,6 +28,19 @@ const logger = createLogger('work-contexts');
 const SCHEMA_VERSION = 1;
 const DEFAULT_SOURCE = 'relay-api';
 const DEFAULT_RELATIONSHIP = 'associated';
+const MAX_RESUME_ARTIFACTS = 20;
+const MAX_RESUME_AUDIT_REFS = 50;
+const MAX_RESUME_SESSIONS = 20;
+const LIFECYCLE_EVENT_TYPES = new Set([
+  'handoff.created',
+  'session.associated',
+  'session.started',
+  'session.resumed',
+  'operator.intervened',
+  'artifact.recorded',
+  'summary.recorded',
+  'handoff.closed',
+]);
 
 const FORBIDDEN_RAW_PAYLOAD_KEYS = new Set([
   'rawContent',
@@ -148,6 +164,48 @@ export interface SessionAssociationInput {
   relationship?: string;
 }
 
+export interface WorkContextLifecycleEventInput {
+  eventId?: string;
+  type?: string;
+  actorId?: string;
+  occurredAt?: string;
+  correlationId?: string;
+  logRef?: string;
+  artifacts?: ArtifactRef[];
+  summary?: string;
+}
+
+export interface WorkContextFromTaskRefInput extends WorkContextCreateInput {
+  taskRef?: TaskRef;
+  existingWorkContextId?: string;
+  relationship?: string;
+}
+
+export interface WorkContextResumeSnapshot {
+  workContext: Pick<
+    WorkContext,
+    | 'id'
+    | 'title'
+    | 'source'
+    | 'createdAt'
+    | 'updatedAt'
+    | 'anchors'
+    | 'actors'
+    | 'tasks'
+    | 'relatedContextRefs'
+  >;
+  node: WorkContextNodeState;
+  sessions: WorkContextSessionSummary[];
+  artifacts: ArtifactRef[];
+  auditRefs: AuditEventRef[];
+  privacy: {
+    mode: 'compact-refs';
+    rawPayloadAvailable: false;
+    transcriptExportAvailable: false;
+    rawTranscriptIncluded: false;
+  };
+}
+
 export interface WorkContextSessionSummary {
   id: string;
   nodeId: string;
@@ -201,6 +259,8 @@ export interface WorkContextStore {
   update(id: WorkContextId, patch: WorkContextPatchInput): WorkContext;
   linkContexts(sourceId: WorkContextId, targetId: WorkContextId, relationship?: string): WorkContext;
   associateSession(id: WorkContextId, input: SessionAssociationInput): WorkContext;
+  recordLifecycleEvent(id: WorkContextId, input: WorkContextLifecycleEventInput): WorkContext;
+  getResumeSnapshot(id: WorkContextId, input: ListActiveWorkInput): WorkContextResumeSnapshot;
   listActiveWork(input: ListActiveWorkInput): WorkContextActiveGroup[];
 }
 
@@ -373,7 +433,11 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
         throw new WorkContextStoreError(400, 'session_ref_required');
       }
       assertValidSessionRef(sessionRef);
-      const updated = contextWithSessionAnchor(existing, sessionRef, associatedAt);
+      const updated = contextWithSessionAssociationEvent(
+        contextWithSessionAnchor(existing, sessionRef, associatedAt),
+        sessionRef,
+        associatedAt
+      );
       db.transaction(() => {
         write(updated);
         upsertSessionLink.run({
@@ -387,6 +451,31 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
         });
       })();
       return updated;
+    },
+
+    recordLifecycleEvent(id: WorkContextId, input: WorkContextLifecycleEventInput) {
+      const existing = mustGet(id);
+      const updated = contextWithLifecycleEvent(existing, input, new Date().toISOString());
+      return write(updated);
+    },
+
+    getResumeSnapshot(id: WorkContextId, input: ListActiveWorkInput) {
+      const context = mustGet(id);
+      const groups = buildActiveGroups(
+        [context],
+        selectSessionLinks.all() as SessionLinkRow[],
+        input.sessions,
+        input.nodes ?? []
+      );
+      return resumeSnapshotFromGroup(
+        groups[0] ?? {
+          id: context.id,
+          context,
+          node: nodeStateForNodeId(DEFAULT_LOCAL_NODE_ID, new Map()),
+          sessions: [],
+          staleReadModel: true,
+        }
+      );
     },
 
     listActiveWork(input: ListActiveWorkInput) {
@@ -426,11 +515,71 @@ export function createWorkContextRouter(deps: WorkContextRouterDeps): Router {
     }
   });
 
+  router.post('/from-task-ref', auth, (req, res) => {
+    const input = req.body as WorkContextFromTaskRefInput;
+    if (!input.taskRef) {
+      res.status(400).json({ error: 'taskRef is required' });
+      return;
+    }
+    try {
+      if (input.existingWorkContextId) {
+        const existing = deps.store.get(input.existingWorkContextId);
+        if (!existing) {
+          res.status(404).json({ error: 'work_context_not_found' });
+          return;
+        }
+        const context = deps.store.update(existing.id, {
+          ...pickWorkContextPatch(input),
+          tasks: dedupeById([...existing.tasks, input.taskRef]),
+        });
+        deps.store.recordLifecycleEvent(context.id, {
+          type: 'handoff.created',
+          summary: `Linked task ${input.taskRef.kind}:${input.taskRef.id}`,
+        });
+        res.json({ workContext: deps.store.get(context.id) ?? context });
+        return;
+      }
+      const context = deps.store.create({
+        ...input,
+        tasks: dedupeById([...(input.tasks ?? []), input.taskRef]),
+      });
+      deps.store.recordLifecycleEvent(context.id, {
+        type: 'handoff.created',
+        summary: `Created handoff context for ${input.taskRef.kind}:${input.taskRef.id}`,
+      });
+      res.status(201).json({ workContext: deps.store.get(context.id) ?? context });
+    } catch (err) {
+      sendStoreError(res, err);
+    }
+  });
+
   router.get('/active', auth, async (_req, res) => {
     try {
       const sessions = await deps.getSessions();
       const nodes = deps.getNodes?.() ?? [];
       res.json({ groups: deps.store.listActiveWork({ sessions, nodes }) });
+    } catch (err) {
+      sendStoreError(res, err);
+    }
+  });
+
+  router.get('/:id/resume', auth, async (req, res) => {
+    try {
+      const sessions = await deps.getSessions();
+      const nodes = deps.getNodes?.() ?? [];
+      res.json({ resume: deps.store.getResumeSnapshot(req.params['id'] ?? '', { sessions, nodes }) });
+    } catch (err) {
+      sendStoreError(res, err);
+    }
+  });
+
+  router.post('/:id/events', auth, (req, res) => {
+    try {
+      const context = deps.store.recordLifecycleEvent(
+        req.params['id'] ?? '',
+        req.body as WorkContextLifecycleEventInput
+      );
+      res.status(201).json({ workContext: context });
     } catch (err) {
       sendStoreError(res, err);
     }
@@ -483,6 +632,8 @@ export function createWorkContextRouter(deps: WorkContextRouterDeps): Router {
       tabId?: string;
       tabKind?: WorkContextTabKind;
       cwd?: string;
+      agent?: string;
+      controlMode?: SessionSummary['controlMode'];
       relationship?: string;
     };
     if (!body.sessionId) {
@@ -516,6 +667,8 @@ interface SessionRefBody {
   tabId?: string;
   tabKind?: WorkContextTabKind;
   cwd?: string;
+  agent?: string;
+  controlMode?: SessionSummary['controlMode'];
 }
 
 function buildContextFromInput(
@@ -665,6 +818,8 @@ function pickAnchors(anchors: WorkContext['anchors']): WorkContext['anchors'] {
         tabId: anchors.session.tabId,
         tabKind: anchors.session.tabKind,
         cwd: anchors.session.cwd,
+        agent: anchors.session.agent,
+        controlMode: anchors.session.controlMode,
       })
     : undefined;
   const project = anchors.project
@@ -833,6 +988,108 @@ function contextWithSessionAnchor(
   };
 }
 
+function contextWithSessionAssociationEvent(
+  context: WorkContext,
+  sessionRef: SessionRef,
+  associatedAt: string
+): WorkContext {
+  return contextWithLifecycleEvent(
+    context,
+    {
+      eventId: `session:${sessionRef.nodeId}:${sessionRef.sessionId}:associated`,
+      type: 'session.associated',
+      occurredAt: associatedAt,
+      summary: `Associated ${sessionRef.agent ?? sessionRef.tabKind} session ${sessionRef.sessionId} on ${sessionRef.nodeId}`,
+    },
+    associatedAt
+  );
+}
+
+function contextWithLifecycleEvent(
+  context: WorkContext,
+  input: WorkContextLifecycleEventInput,
+  now: string
+): WorkContext {
+  if (input.type !== undefined && !LIFECYCLE_EVENT_TYPES.has(input.type)) {
+    throw new WorkContextStoreError(400, 'invalid_lifecycle_event_type');
+  }
+  const occurredAt = input.occurredAt ?? now;
+  if (Number.isNaN(Date.parse(occurredAt))) {
+    throw new WorkContextStoreError(400, 'invalid_lifecycle_occurred_at');
+  }
+  const eventId = input.eventId ?? `work-context:${context.id}:${crypto.randomBytes(8).toString('hex')}`;
+  const auditRef: AuditEventRef = {
+    id: `audit-ref:${eventId}`,
+    eventId,
+    ...(input.type ? { type: input.type } : {}),
+    occurredAt,
+    ...(input.actorId ? { actorId: input.actorId } : {}),
+    ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+    ...(input.logRef ? { logRef: input.logRef } : {}),
+    privacy: createWorkContextPrivacyMetadata({
+      classification: 'internal',
+      retention: 'audit',
+      redaction: {
+        redacted: true,
+        strategy: 'summary',
+        classes: ['payload', 'transcript', 'log'],
+      },
+    }),
+  };
+  const artifacts = [...context.artifacts, ...safeLifecycleArtifacts(input, eventId, occurredAt)];
+  const auditRefs = upsertAuditRef(context.auditRefs, auditRef);
+  const updated: WorkContext = {
+    ...context,
+    artifacts: dedupeById(artifacts),
+    auditRefs,
+    updatedAt: now,
+  };
+  return updated;
+}
+
+function safeLifecycleArtifacts(
+  input: WorkContextLifecycleEventInput,
+  eventId: string,
+  occurredAt: string
+): ArtifactRef[] {
+  const artifacts = input.artifacts ?? [];
+  const summaryArtifact: ArtifactRef[] = input.summary
+    ? [
+        {
+          id: `artifact-ref:${eventId}:summary`,
+          kind: 'report',
+          title: 'Lifecycle summary',
+          summary: input.summary,
+          ...(input.actorId ? { producedByActorId: input.actorId } : {}),
+          producedAt: occurredAt,
+          privacy: createWorkContextPrivacyMetadata({
+            classification: 'internal',
+            retention: 'session',
+            redaction: {
+              redacted: true,
+              strategy: 'summary',
+              classes: ['payload', 'transcript', 'log'],
+            },
+          }),
+        },
+      ]
+    : [];
+  return [...artifacts, ...summaryArtifact];
+}
+
+function upsertAuditRef(
+  refs: AuditEventRef[],
+  ref: AuditEventRef
+): AuditEventRef[] {
+  return dedupeById([...refs, ref]);
+}
+
+function dedupeById<T extends { id: string }>(items: T[]): T[] {
+  const byId = new Map<string, T>();
+  for (const item of items) byId.set(item.id, item);
+  return Array.from(byId.values());
+}
+
 export function sessionSummaryToRef(session: SessionSummary): SessionRef {
   const nodeId = session.nodeId ?? DEFAULT_LOCAL_NODE_ID;
   const globalSessionId = session.globalSessionId ?? createGlobalSessionId(nodeId, session.id);
@@ -843,6 +1100,8 @@ export function sessionSummaryToRef(session: SessionSummary): SessionRef {
     globalSessionId,
     tabKind,
     cwd: session.cwd,
+    ...(session.agent ? { agent: session.agent } : {}),
+    ...(session.controlMode ? { controlMode: session.controlMode } : {}),
   };
 }
 
@@ -856,6 +1115,8 @@ function sessionRefFromBody(body: SessionRefBody): SessionRef {
     ...(body.tabId ? { tabId: body.tabId } : {}),
     tabKind: body.tabKind ?? 'terminal',
     cwd: body.cwd,
+    ...(body.agent ? { agent: body.agent } : {}),
+    ...(body.controlMode ? { controlMode: body.controlMode } : {}),
   };
 }
 
@@ -932,6 +1193,34 @@ function buildActiveGroups(
   return groups;
 }
 
+function resumeSnapshotFromGroup(group: WorkContextActiveGroup): WorkContextResumeSnapshot {
+  if (!group.context) throw new WorkContextStoreError(404, 'work_context_not_found');
+  const context = group.context;
+  return {
+    workContext: {
+      id: context.id,
+      ...(context.title ? { title: context.title } : {}),
+      source: context.source,
+      createdAt: context.createdAt,
+      updatedAt: context.updatedAt,
+      anchors: context.anchors,
+      actors: context.actors,
+      tasks: context.tasks,
+      ...(context.relatedContextRefs ? { relatedContextRefs: context.relatedContextRefs } : {}),
+    },
+    node: group.node,
+    sessions: group.sessions.slice(0, MAX_RESUME_SESSIONS),
+    artifacts: context.artifacts.slice(-MAX_RESUME_ARTIFACTS),
+    auditRefs: context.auditRefs.slice(-MAX_RESUME_AUDIT_REFS),
+    privacy: {
+      mode: 'compact-refs',
+      rawPayloadAvailable: false,
+      transcriptExportAvailable: false,
+      rawTranscriptIncluded: false,
+    },
+  };
+}
+
 function buildSessionLookup(sessions: SessionSummary[]): Map<string, SessionSummary> {
   const lookup = new Map<string, SessionSummary>();
   for (const session of sessions) {
@@ -993,7 +1282,9 @@ function summarizeLinkedSession(
     nodeId: ref.nodeId,
     ...(ref.globalSessionId ? { globalSessionId: ref.globalSessionId } : {}),
     tabKind: ref.tabKind,
+    ...(ref.agent ? { agent: ref.agent } : {}),
     cwd: ref.cwd,
+    ...(ref.controlMode ? { controlMode: ref.controlMode } : {}),
     relationship: link.relationship,
     associatedAt: link.associated_at,
     live: false,

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -517,6 +517,7 @@ const createSessionInputSchema: RelayJsonSchema = {
     branchName: stringSchema,
     initialPrompt: stringSchema,
     continuePolicy: { type: 'string', enum: ['always', 'never'] },
+    workContextId: stringSchema,
     controlMode: {
       type: 'string',
       enum: ['agent-driven', 'human-driven'],

--- a/shared/cli-gateway-runtime.ts
+++ b/shared/cli-gateway-runtime.ts
@@ -34,6 +34,7 @@ const createSessionAllowedFields = new Set([
   'branchName',
   'initialPrompt',
   'continuePolicy',
+  'workContextId',
   'controlMode',
   'sessionEnvelope',
   'ttlSeconds',
@@ -48,6 +49,7 @@ const stringFields = [
   'agent',
   'branchName',
   'initialPrompt',
+  'workContextId',
   'expiresAt',
   'confirmationToken',
 ] as const;

--- a/shared/work-context.ts
+++ b/shared/work-context.ts
@@ -14,6 +14,7 @@ import {
   type RelayCapabilityDecision,
   type RelayPolicyScope,
 } from './security-policy.js';
+import type { ControlMode } from './control-state.js';
 
 export const WORK_CONTEXT_SCHEMA_VERSION = 1 as const;
 
@@ -151,6 +152,8 @@ export interface SessionRef {
   tabId?: string;
   tabKind: WorkContextTabKind;
   cwd: string;
+  agent?: string;
+  controlMode?: ControlMode;
 }
 
 export interface RepoRef {
@@ -315,6 +318,11 @@ const CAPABILITY_POLICY_CLASSES = new Set<string>([
   'privileged',
   'unknown',
 ]);
+const CONTROL_MODES = new Set<string>([
+  'agent-driven',
+  'human-driven',
+  'co-driven',
+]);
 const POLICY_SCOPE_KINDS = new Set<string>([
   'node',
   'workspace',
@@ -441,7 +449,9 @@ function isSessionRef(value: unknown): value is SessionRef {
     isOptionalString(value.globalSessionId) &&
     isOptionalString(value.tabId) &&
     isEnumValue(value.tabKind, TAB_KINDS) &&
-    hasString(value.cwd)
+    hasString(value.cwd) &&
+    isOptionalString(value.agent) &&
+    (value.controlMode === undefined || isEnumValue(value.controlMode, CONTROL_MODES))
   );
 }
 

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -132,6 +132,7 @@ describe('CLI gateway contract', () => {
 
     const createProperties = create.inputSchema.properties ?? {};
     expect(createProperties['sessionEnvelope']).toBeDefined();
+    expect(createProperties['workContextId']).toBeDefined();
     expect(JSON.stringify(create.inputSchema)).not.toContain('"kind":{"const":"agent"}');
     expect(JSON.stringify(create.inputSchema)).not.toContain('"adapter"');
   });
@@ -215,6 +216,7 @@ describe('CLI gateway contract', () => {
       worktreePath: null,
       type: 'terminal',
       cols: 120,
+      workContextId: 'wc:handoff',
     });
     expect(clean).toMatchObject({
       ok: true,
@@ -223,6 +225,7 @@ describe('CLI gateway contract', () => {
         worktreePath: null,
         type: 'terminal',
         cols: 120,
+        workContextId: 'wc:handoff',
       },
       sessionType: 'terminal',
     });

--- a/test/work-context-store.test.ts
+++ b/test/work-context-store.test.ts
@@ -307,6 +307,113 @@ describe('WorkContext store', () => {
     }
   });
 
+  it('creates handoff contexts from task refs and exposes compact resume refs', async () => {
+    const store = makeStore();
+    const pairSession = session({
+      id: 'pair-1',
+      nodeId: 'node-remote',
+      globalSessionId: createGlobalSessionId('node-remote', 'pair-1'),
+      agent: 'codex',
+      cwd: '/remote/relay-ide/.worktrees/560-pair-handoff',
+      controlMode: 'co-driven',
+      displayName: 'Pair session',
+    });
+    const api = await startWorkContextApi(store, [pairSession], [node({ nodeId: 'node-remote' })]);
+    try {
+      const created = await jsonRequest(api.baseUrl, 'POST', '/work-contexts/from-task-ref', {
+        id: 'wc:handoff',
+        title: 'Pair handoff',
+        source: 'assistant',
+        taskRef: {
+          kind: 'github-issue',
+          id: '560',
+          title: 'assistant-to-pair-session handoff',
+          url: 'https://github.com/donovan-yohan/relay-ide/issues/560',
+          privacy: createWorkContextPrivacyMetadata({ retention: 'project' }),
+        },
+        actors: [
+          {
+            kind: 'agent',
+            id: 'assistant:kani',
+            displayName: 'Kani backend',
+          },
+        ],
+      });
+      expect(created.status).toBe(201);
+      expect(created.body.workContext.tasks).toHaveLength(1);
+      expect(created.body.workContext.auditRefs).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'handoff.created' })])
+      );
+
+      const associated = await jsonRequest(
+        api.baseUrl,
+        'POST',
+        '/work-contexts/wc:handoff/sessions',
+        { sessionId: 'pair-1', nodeId: 'node-remote' }
+      );
+      expect(associated.status).toBe(200);
+      expect(associated.body.workContext.anchors.session).toMatchObject({
+        nodeId: 'node-remote',
+        sessionId: 'pair-1',
+        agent: 'codex',
+        controlMode: 'co-driven',
+        cwd: '/remote/relay-ide/.worktrees/560-pair-handoff',
+      });
+
+      const event = await jsonRequest(api.baseUrl, 'POST', '/work-contexts/wc:handoff/events', {
+        type: 'summary.recorded',
+        actorId: 'assistant:kani',
+        summary: 'implementation is ready for pair resume; raw transcript omitted',
+        artifacts: [
+          {
+            id: 'artifact:diff-summary',
+            kind: 'report',
+            title: 'Diff summary',
+            summary: 'server/work-contexts.ts adds compact resume refs',
+            privacy: createWorkContextPrivacyMetadata({ retention: 'project' }),
+          },
+        ],
+      });
+      expect(event.status).toBe(201);
+
+      const resume = await jsonRequest(api.baseUrl, 'GET', '/work-contexts/wc:handoff/resume');
+      expect(resume.status).toBe(200);
+      expect(resume.body.resume).toMatchObject({
+        workContext: {
+          id: 'wc:handoff',
+          tasks: [expect.objectContaining({ id: '560', kind: 'github-issue' })],
+        },
+        node: expect.objectContaining({ nodeId: 'node-remote', status: 'online' }),
+        sessions: [
+          expect.objectContaining({
+            id: 'pair-1',
+            nodeId: 'node-remote',
+            agent: 'codex',
+            controlMode: 'co-driven',
+            live: true,
+          }),
+        ],
+        privacy: {
+          mode: 'compact-refs',
+          rawPayloadAvailable: false,
+          transcriptExportAvailable: false,
+          rawTranscriptIncluded: false,
+        },
+      });
+      expect(resume.body.resume.artifacts).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: 'artifact:diff-summary' })])
+      );
+      expect(resume.body.resume.auditRefs).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'session.associated' })])
+      );
+      expect(JSON.stringify(resume.body.resume)).not.toContain('terminalTranscript');
+      expect(JSON.stringify(resume.body.resume)).not.toContain('providerToken');
+    } finally {
+      await api.close();
+      store.close();
+    }
+  });
+
   it('persists create/read/list/update/link records using the shared schema', () => {
     const store = makeStore();
     try {


### PR DESCRIPTION
## Summary
- Adds WorkContext task-ref handoff creation plus bounded lifecycle events and compact resume snapshots.
- Preserves pair-session node/cwd/agent/control-mode metadata when sessions are associated with WorkContexts.
- Allows CLI gateway `sessions.create` to carry `workContextId` so assistant-created context can be linked to local pair sessions.

## Motivation
Issue #560 needs assistant-created task context to become resumable pair-session metadata without replacing Claude/Codex/Hermes CLIs, syncing raw session databases, or exposing provider auth/environment state.

## The Case Against
This change might be wrong because:
- The new `/work-contexts/from-task-ref`, `/:id/events`, and `/:id/resume` REST shape is backend-only and not yet wired into a UI action, so consumers still need to call it directly.
- Lifecycle event types are intentionally bounded; if downstream callers invent new type strings without updating this set, they will get `invalid_lifecycle_event_type` instead of silent schema drift.
- Resume snapshots include compact artifact/audit refs, not raw transcript content. That is the safe default, but any future UX that expects full transcript replay will need an explicit export path.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
| --- | --- | --- |
| Raw transcript/provider payload leakage | Low | Reuses existing WorkContext canonicalization and returns compact refs with `rawTranscriptIncluded: false`. |
| Incorrect pair-session identity across nodes | Medium | Session refs now preserve `nodeId`, global session ID, cwd, agent, and control mode; tests cover remote node association. |
| CLI gateway strips handoff IDs | Low | Contract/runtime/CLI arg parsing now allow `workContextId`; tests cover local gateway sanitization. |

## Verification
- `npm test -- test/work-context-store.test.ts test/cli-gateway-contract.test.ts` — 22/22 passed
- `npm run check` — passed with existing warnings only
- `npm run build` — passed
- `npm test` — 221 files / 2353 tests passed

Closes #560
Refs #552
