### PR TITLE
feat: add mobile active work controls

### DIFF
--- a/frontend/src/components/ActiveWorkSurface.css
+++ b/frontend/src/components/ActiveWorkSurface.css
@@ -248,6 +248,41 @@
   padding-top: 2px;
 }
 
+.active-work-input {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) auto;
+  align-items: end;
+  gap: 6px;
+  min-width: min(100%, 320px);
+  flex: 1 1 320px;
+}
+
+.active-work-input .active-work-label {
+  grid-column: 1 / -1;
+}
+
+.active-work-input input {
+  min-width: 0;
+  min-height: 34px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  padding: 0 8px;
+}
+
+.active-work-input input:focus {
+  outline: 1px solid var(--accent);
+  outline-offset: 0;
+}
+
+.active-work-input input:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 .active-work-disabled-reason {
   min-height: 24px;
   display: inline-flex;
@@ -273,15 +308,30 @@
 
   .active-work-grid {
     grid-template-columns: minmax(0, 1fr);
+    order: 2;
   }
 
   .active-work-controls {
     position: sticky;
     bottom: 0;
+    order: 3;
     padding-top: 8px;
     padding-bottom: 8px;
     background: var(--bg);
     border-top: 1px solid var(--border);
+  }
+
+  .active-work-artifacts {
+    order: 4;
+  }
+
+  .active-work-sessions {
+    order: 5;
+  }
+
+  .active-work-input {
+    grid-template-columns: minmax(0, 1fr);
+    flex-basis: 100%;
   }
 
   .active-work-controls .tui-btn {

--- a/frontend/src/components/ActiveWorkSurface.tsx
+++ b/frontend/src/components/ActiveWorkSurface.tsx
@@ -1,14 +1,19 @@
-import { useMemo, useCallback } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMemo, useCallback, useState, type FormEvent } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
 import type {
   WorkContextActiveGroup,
   WorkContextSessionSummary,
 } from '../lib/types.js';
-import { fetchActiveWork } from '../lib/api.js';
+import { fetchActiveWork, sendSessionInput } from '../lib/api.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import { scopedSessionKey } from '../lib/session-keys.js';
+import {
+  activeWorkAttentionPriority,
+  activeWorkMobileControlState,
+  activeWorkStateLabel,
+} from '../lib/active-work-control.js';
 import { TuiButton } from './TuiButton.js';
 import './ActiveWorkSurface.css';
 
@@ -34,7 +39,7 @@ function dateLabel(value?: string): string {
 
 function taskLabel(group: WorkContextActiveGroup): string {
   const context = group.context;
-  const firstTask = context?.tasks[0];
+  const firstTask = context?.tasks?.[0];
   return (
     context?.title ??
     firstTask?.title ??
@@ -83,38 +88,22 @@ function actorLabels(group: WorkContextActiveGroup): string[] {
   return labels;
 }
 
-function statusPriority(group: WorkContextActiveGroup): number {
-  const hasPrompt = group.sessions.some(
-    (session) => session.agentState === 'permission-prompt'
-  );
-  if (hasPrompt) return 0;
-  if (group.node.status === 'offline' || group.node.status === 'revoked')
-    return 1;
-  if (group.node.status === 'stale' || group.staleReadModel) return 2;
-  if (group.sessions.some((session) => session.agentState === 'processing'))
-    return 3;
-  if (group.sessions.some((session) => session.live)) return 4;
-  return 5;
-}
-
-function stateLabel(group: WorkContextActiveGroup): string {
-  if (
-    group.sessions.some((session) => session.agentState === 'permission-prompt')
-  )
-    return 'needs approval';
-  if (group.node.status === 'offline' || group.node.status === 'revoked')
-    return 'offline';
-  if (group.node.status === 'stale') return 'stale';
-  if (group.staleReadModel) return 'stale read model';
-  if (group.sessions.some((session) => session.agentState === 'processing'))
-    return 'running';
-  if (group.sessions.some((session) => session.agentState === 'error'))
-    return 'error';
-  if (group.sessions.some((session) => session.live)) return 'live';
-  return 'inactive';
-}
-
 function latestStatus(group: WorkContextActiveGroup): string {
+  const prompt = group.sessions.find(
+    (session) =>
+      session.agentState === 'permission-prompt' ||
+      session.agentState === 'waiting-for-input'
+  );
+  if (prompt?.agentState === 'permission-prompt') {
+    return prompt.currentActivity?.detail
+      ? `approval requested · ${prompt.currentActivity.detail}`
+      : 'approval requested';
+  }
+  if (prompt?.agentState === 'waiting-for-input') {
+    return prompt.currentActivity?.detail
+      ? `waiting for input · ${prompt.currentActivity.detail}`
+      : 'waiting for input';
+  }
   const active = group.sessions.find((session) => session.currentActivity);
   if (active?.currentActivity) {
     const detail = active.currentActivity.detail
@@ -133,7 +122,7 @@ function latestStatus(group: WorkContextActiveGroup): string {
       'human';
     return `latest intervention by ${by} · ${dateLabel(intervention.lastInterventionAt)}`;
   }
-  const artifact = group.context?.artifacts[0];
+  const artifact = group.context?.artifacts?.[0];
   if (artifact?.summary) return artifact.summary;
   const session = group.sessions[0];
   if (session?.agentState)
@@ -143,25 +132,14 @@ function latestStatus(group: WorkContextActiveGroup): string {
     : 'session has no work context yet';
 }
 
-function controlDisabledReason(
-  group: WorkContextActiveGroup,
-  session?: WorkContextSessionSummary
-): string | null {
-  if (!session) return 'no session selected';
-  if (!session.live) return 'last-known session only';
-  if (group.node.status !== 'online') return `${group.node.status} node`;
-  if (group.staleReadModel) return 'stale read model';
-  return null;
-}
-
 function repoBindingLabel(
   group: WorkContextActiveGroup,
   session: WorkContextSessionSummary
 ): string | null {
-  const repo = session.repoName ?? group.context?.anchors.repo?.ownerRepo;
-  const repoPath = session.repoPath ?? group.context?.anchors.repo?.localPath;
+  const repo = session.repoName ?? group.context?.anchors?.repo?.ownerRepo;
+  const repoPath = session.repoPath ?? group.context?.anchors?.repo?.localPath;
   if (!repo && !repoPath) return null;
-  const branch = session.branchName ?? group.context?.anchors.repo?.branchName;
+  const branch = session.branchName ?? group.context?.anchors?.repo?.branchName;
   return [repo ?? repoPath, branch].filter(Boolean).join(' · ');
 }
 
@@ -185,18 +163,28 @@ function sessionMeta(
 }
 
 function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
+  const queryClient = useQueryClient();
   const sessions = useSessionsStore((s) => s.sessions);
   const setActiveSessionId = useSessionsStore((s) => s.setActiveSessionId);
   const setActiveRepoPath = useUiStore((s) => s.setActiveRepoPath);
+  const [inputValue, setInputValue] = useState('');
+  const [inputStatus, setInputStatus] = useState<string | null>(null);
   const primarySession =
-    group.sessions.find((session) => session.live) ?? group.sessions[0];
-  const disabledReason = controlDisabledReason(group, primarySession);
+    group.sessions.find(
+      (session) =>
+        session.live &&
+        (session.agentState === 'permission-prompt' ||
+          session.agentState === 'waiting-for-input')
+    ) ??
+    group.sessions.find((session) => session.live) ??
+    group.sessions[0];
+  const controlState = activeWorkMobileControlState(group, primarySession);
   const actors = actorLabels(group);
   const refs = taskRefs(group);
   const artifacts = group.context?.artifacts ?? [];
 
   const handleAttach = useCallback(() => {
-    if (!primarySession || disabledReason) return;
+    if (!primarySession || controlState.attachDisabledReason) return;
     const live = sessions.find(
       (session) =>
         session.id === primarySession.id &&
@@ -211,12 +199,38 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
         : (primarySession.globalSessionId ?? primarySession.id)
     );
   }, [
-    disabledReason,
+    controlState.attachDisabledReason,
     primarySession,
     sessions,
     setActiveRepoPath,
     setActiveSessionId,
   ]);
+
+  const handleSmallInput = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const value = inputValue.trimEnd();
+      if (!primarySession || controlState.smallInputDisabledReason || !value) {
+        return;
+      }
+      setInputStatus('sending...');
+      try {
+        await sendSessionInput(primarySession.id, `${value}\r`);
+        setInputValue('');
+        setInputStatus('sent · recorded as control intervention');
+        void queryClient.invalidateQueries({ queryKey: ['active-work'] });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setInputStatus(`failed: ${message}`);
+      }
+    },
+    [
+      controlState.smallInputDisabledReason,
+      inputValue,
+      primarySession,
+      queryClient,
+    ]
+  );
 
   return (
     <article className="active-work-card" data-node-status={group.node.status}>
@@ -224,7 +238,9 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
       <div className="active-work-card__main">
         <div className="active-work-card__header">
           <div>
-            <div className="active-work-card__eyebrow">{stateLabel(group)}</div>
+            <div className="active-work-card__eyebrow">
+              {activeWorkStateLabel(group)}
+            </div>
             <h3>{taskLabel(group)}</h3>
           </div>
           <div className="active-work-node">
@@ -342,31 +358,72 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
           <TuiButton
             size="sm"
             variant="info"
-            disabled={!!disabledReason}
-            title={disabledReason ?? 'attach to live session'}
+            disabled={!!controlState.attachDisabledReason}
+            title={controlState.attachDisabledReason ?? 'attach to live session'}
             onClick={handleAttach}
           >
             attach
+          </TuiButton>
+          <form className="active-work-input" onSubmit={handleSmallInput}>
+            <label className="active-work-label" htmlFor={`active-work-input-${group.id}`}>
+              {controlState.smallInputLabel}
+            </label>
+            <input
+              id={`active-work-input-${group.id}`}
+              value={inputValue}
+              onChange={(event) => setInputValue(event.target.value)}
+              disabled={!!controlState.smallInputDisabledReason}
+              placeholder={controlState.smallInputPlaceholder}
+              maxLength={1000}
+              aria-describedby={`active-work-input-status-${group.id}`}
+            />
+            <TuiButton
+              size="sm"
+              variant="primary"
+              type="submit"
+              disabled={
+                !!controlState.smallInputDisabledReason ||
+                inputValue.trim().length === 0
+              }
+              title={
+                controlState.smallInputDisabledReason ??
+                'send audited small input to the live PTY session'
+              }
+            >
+              send
+            </TuiButton>
+          </form>
+          <TuiButton
+            size="sm"
+            variant="danger"
+            disabled
+            title={controlState.destructiveDisabledReason}
+          >
+            kill
           </TuiButton>
           <TuiButton
             size="sm"
             variant="ghost"
             disabled
-            title={disabledReason ?? 'small input is #559 scope'}
+            title="pause/retry require explicit control capability contracts before mobile can route them"
           >
-            small input
+            pause/retry
           </TuiButton>
-          <TuiButton
-            size="sm"
-            variant="danger"
-            disabled
-            title={disabledReason ?? 'pause/kill requires capability contract'}
-          >
-            interrupt
-          </TuiButton>
-          {disabledReason && (
+          {(controlState.attachDisabledReason ||
+            controlState.smallInputDisabledReason) && (
             <span className="active-work-disabled-reason">
-              controls disabled: {disabledReason}
+              controls disabled:{' '}
+              {controlState.attachDisabledReason ??
+                controlState.smallInputDisabledReason}
+            </span>
+          )}
+          {inputStatus && (
+            <span
+              id={`active-work-input-status-${group.id}`}
+              className="active-work-disabled-reason"
+              role="status"
+            >
+              {inputStatus}
             </span>
           )}
         </div>
@@ -389,11 +446,14 @@ export default function ActiveWorkSurface() {
   });
 
   const groups = useMemo(
-    () => [...data].sort((a, b) => statusPriority(a) - statusPriority(b)),
+    () =>
+      [...data].sort(
+        (a, b) => activeWorkAttentionPriority(a) - activeWorkAttentionPriority(b)
+      ),
     [data]
   );
   const attentionCount = groups.filter(
-    (group) => statusPriority(group) <= 2
+    (group) => activeWorkAttentionPriority(group) <= 2
   ).length;
 
   if (isLoading)

--- a/frontend/src/components/ActiveWorkSurface.tsx
+++ b/frontend/src/components/ActiveWorkSurface.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useCallback, useState, type FormEvent } from 'react';
+import { useMemo, useCallback, useRef, useState, type FormEvent } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
 import type {
@@ -169,6 +169,8 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
   const setActiveRepoPath = useUiStore((s) => s.setActiveRepoPath);
   const [inputValue, setInputValue] = useState('');
   const [inputStatus, setInputStatus] = useState<string | null>(null);
+  const [isSubmittingInput, setIsSubmittingInput] = useState(false);
+  const isSubmittingInputRef = useRef(false);
   const primarySession =
     group.sessions.find(
       (session) =>
@@ -210,9 +212,16 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
       const value = inputValue.trimEnd();
-      if (!primarySession || controlState.smallInputDisabledReason || !value) {
+      if (
+        !primarySession ||
+        controlState.smallInputDisabledReason ||
+        !value ||
+        isSubmittingInputRef.current
+      ) {
         return;
       }
+      isSubmittingInputRef.current = true;
+      setIsSubmittingInput(true);
       setInputStatus('sending...');
       try {
         await sendSessionInput(primarySession.id, `${value}\r`);
@@ -222,6 +231,9 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         setInputStatus(`failed: ${message}`);
+      } finally {
+        isSubmittingInputRef.current = false;
+        setIsSubmittingInput(false);
       }
     },
     [
@@ -359,13 +371,18 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
             size="sm"
             variant="info"
             disabled={!!controlState.attachDisabledReason}
-            title={controlState.attachDisabledReason ?? 'attach to live session'}
+            title={
+              controlState.attachDisabledReason ?? 'attach to live session'
+            }
             onClick={handleAttach}
           >
             attach
           </TuiButton>
           <form className="active-work-input" onSubmit={handleSmallInput}>
-            <label className="active-work-label" htmlFor={`active-work-input-${group.id}`}>
+            <label
+              className="active-work-label"
+              htmlFor={`active-work-input-${group.id}`}
+            >
               {controlState.smallInputLabel}
             </label>
             <input
@@ -383,7 +400,8 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
               type="submit"
               disabled={
                 !!controlState.smallInputDisabledReason ||
-                inputValue.trim().length === 0
+                inputValue.trim().length === 0 ||
+                isSubmittingInput
               }
               title={
                 controlState.smallInputDisabledReason ??
@@ -448,12 +466,13 @@ export default function ActiveWorkSurface() {
   const groups = useMemo(
     () =>
       [...data].sort(
-        (a, b) => activeWorkAttentionPriority(a) - activeWorkAttentionPriority(b)
+        (a, b) =>
+          activeWorkAttentionPriority(a) - activeWorkAttentionPriority(b)
       ),
     [data]
   );
   const attentionCount = groups.filter(
-    (group) => activeWorkAttentionPriority(group) <= 2
+    (group) => activeWorkAttentionPriority(group) <= 3
   ).length;
 
   if (isLoading)

--- a/frontend/src/lib/active-work-control.ts
+++ b/frontend/src/lib/active-work-control.ts
@@ -1,0 +1,112 @@
+import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
+import type {
+  WorkContextActiveGroup,
+  WorkContextSessionSummary,
+} from './types.js';
+
+export interface ActiveWorkMobileControlState {
+  attachDisabledReason: string | null;
+  smallInputDisabledReason: string | null;
+  destructiveDisabledReason: string;
+  promptKind: 'approval' | 'input' | null;
+  smallInputLabel: string;
+  smallInputPlaceholder: string;
+}
+
+export function activeWorkAttentionPriority(
+  group: WorkContextActiveGroup
+): number {
+  const needsOperator = group.sessions.some(
+    (session) =>
+      session.agentState === 'permission-prompt' ||
+      session.agentState === 'waiting-for-input'
+  );
+  if (needsOperator) return 0;
+  if (group.node.status === 'offline' || group.node.status === 'revoked')
+    return 1;
+  if (group.node.status === 'stale' || group.staleReadModel) return 2;
+  if (group.sessions.some((session) => session.agentState === 'processing'))
+    return 3;
+  if (group.sessions.some((session) => session.live)) return 4;
+  return 5;
+}
+
+export function activeWorkStateLabel(group: WorkContextActiveGroup): string {
+  if (
+    group.sessions.some((session) => session.agentState === 'permission-prompt')
+  )
+    return 'needs approval';
+  if (
+    group.sessions.some((session) => session.agentState === 'waiting-for-input')
+  )
+    return 'needs input';
+  if (group.node.status === 'offline' || group.node.status === 'revoked')
+    return 'offline';
+  if (group.node.status === 'stale') return 'stale';
+  if (group.staleReadModel) return 'stale read model';
+  if (group.sessions.some((session) => session.agentState === 'processing'))
+    return 'running';
+  if (group.sessions.some((session) => session.agentState === 'error'))
+    return 'error';
+  if (group.sessions.some((session) => session.live)) return 'live';
+  return 'inactive';
+}
+
+function liveControlDisabledReason(
+  group: WorkContextActiveGroup,
+  session?: WorkContextSessionSummary
+): string | null {
+  if (!session) return 'no session selected';
+  if (!session.live) return 'last-known session only';
+  if (group.node.status !== 'online') return `${group.node.status} node`;
+  if (group.staleReadModel) return 'stale read model';
+  return null;
+}
+
+function freshControlDisabledReason(
+  session?: WorkContextSessionSummary
+): string | null {
+  if (!session) return 'no session selected';
+  if (session.controlFreshness === 'stale') return 'stale control state';
+  if (session.controlFreshness !== 'fresh') return 'unknown control state';
+  return null;
+}
+
+export function activeWorkMobileControlState(
+  group: WorkContextActiveGroup,
+  session?: WorkContextSessionSummary
+): ActiveWorkMobileControlState {
+  const liveReason = liveControlDisabledReason(group, session);
+  const freshReason = freshControlDisabledReason(session);
+  const isLocal = (session?.nodeId ?? DEFAULT_LOCAL_NODE_ID) === DEFAULT_LOCAL_NODE_ID;
+  const promptKind =
+    session?.agentState === 'permission-prompt'
+      ? 'approval'
+      : session?.agentState === 'waiting-for-input'
+        ? 'input'
+        : null;
+
+  let smallInputDisabledReason = liveReason ?? freshReason;
+  if (!smallInputDisabledReason && !isLocal) {
+    smallInputDisabledReason =
+      'remote small input awaits routed control endpoint';
+  }
+  if (!smallInputDisabledReason && session?.mode === 'web') {
+    smallInputDisabledReason = 'web session input is unsupported here';
+  }
+
+  return {
+    attachDisabledReason: liveReason,
+    smallInputDisabledReason,
+    destructiveDisabledReason:
+      liveReason ??
+      freshReason ??
+      'requires explicit session:control:kill grant; no mobile allow decision is present',
+    promptKind,
+    smallInputLabel: promptKind === 'approval' ? 'reply to approval' : 'send input',
+    smallInputPlaceholder:
+      promptKind === 'approval'
+        ? 'approval reply (example: y, n, or exact prompt text)'
+        : 'short input to send to the session',
+  };
+}

--- a/frontend/src/lib/active-work-control.ts
+++ b/frontend/src/lib/active-work-control.ts
@@ -25,10 +25,12 @@ export function activeWorkAttentionPriority(
   if (group.node.status === 'offline' || group.node.status === 'revoked')
     return 1;
   if (group.node.status === 'stale' || group.staleReadModel) return 2;
-  if (group.sessions.some((session) => session.agentState === 'processing'))
+  if (group.sessions.some((session) => session.agentState === 'error'))
     return 3;
-  if (group.sessions.some((session) => session.live)) return 4;
-  return 5;
+  if (group.sessions.some((session) => session.agentState === 'processing'))
+    return 4;
+  if (group.sessions.some((session) => session.live)) return 5;
+  return 6;
 }
 
 export function activeWorkStateLabel(group: WorkContextActiveGroup): string {
@@ -44,10 +46,10 @@ export function activeWorkStateLabel(group: WorkContextActiveGroup): string {
     return 'offline';
   if (group.node.status === 'stale') return 'stale';
   if (group.staleReadModel) return 'stale read model';
-  if (group.sessions.some((session) => session.agentState === 'processing'))
-    return 'running';
   if (group.sessions.some((session) => session.agentState === 'error'))
     return 'error';
+  if (group.sessions.some((session) => session.agentState === 'processing'))
+    return 'running';
   if (group.sessions.some((session) => session.live)) return 'live';
   return 'inactive';
 }
@@ -78,7 +80,8 @@ export function activeWorkMobileControlState(
 ): ActiveWorkMobileControlState {
   const liveReason = liveControlDisabledReason(group, session);
   const freshReason = freshControlDisabledReason(session);
-  const isLocal = (session?.nodeId ?? DEFAULT_LOCAL_NODE_ID) === DEFAULT_LOCAL_NODE_ID;
+  const isLocal =
+    (session?.nodeId ?? DEFAULT_LOCAL_NODE_ID) === DEFAULT_LOCAL_NODE_ID;
   const promptKind =
     session?.agentState === 'permission-prompt'
       ? 'approval'
@@ -103,7 +106,8 @@ export function activeWorkMobileControlState(
       freshReason ??
       'requires explicit session:control:kill grant; no mobile allow decision is present',
     promptKind,
-    smallInputLabel: promptKind === 'approval' ? 'reply to approval' : 'send input',
+    smallInputLabel:
+      promptKind === 'approval' ? 'reply to approval' : 'send input',
     smallInputPlaceholder:
       promptKind === 'approval'
         ? 'approval reply (example: y, n, or exact prompt text)'

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -429,6 +429,24 @@ export async function handBackSessionControl(input: {
   );
 }
 
+export async function sendSessionInput(
+  sessionId: string,
+  data: string
+): Promise<{ ok: true }> {
+  const res = await fetch(
+    `/sessions/${encodeURIComponent(sessionId)}/input`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ data }),
+    }
+  );
+  if (!res.ok) {
+    throw await httpErrorFromResponse(res, 'Failed to send session input');
+  }
+  return jsonEither<{ ok: true }>(res);
+}
+
 export async function fetchHubNodes(): Promise<HubNodeSummary[]> {
   const data = await json<{ nodes?: HubNodeSummary[] }>(await fetch('/nodes'));
   return Array.isArray(data.nodes) ? data.nodes : [];

--- a/server/index.ts
+++ b/server/index.ts
@@ -2230,6 +2230,107 @@ async function main(): Promise<void> {
     res.json({ ok: true, events: result.events, ackedHumanInterventions: result.ackedHumanInterventions });
   });
 
+  app.post('/sessions/:id/input', requireScopedSessionAuth, (req, res) => {
+    const decision = capabilityDecisionFromRequest(req, CONTROL_SESSION_CAPABILITY);
+    if (decision.decision !== 'allow') {
+      const error = capabilityError(decision);
+      res.status(sessionControlErrorStatus(error)).json({ error });
+      return;
+    }
+
+    const id = req.params['id'] as string;
+    const body =
+      typeof req.body === 'object' && req.body !== null
+        ? (req.body as Record<string, unknown>)
+        : {};
+    const data = body['data'];
+    if (typeof data !== 'string' || data.length === 0) {
+      res.status(400).json({ error: 'data must be a non-empty string' });
+      return;
+    }
+    if (data.length > 1000) {
+      res.status(413).json({ error: 'small input is limited to 1000 characters' });
+      return;
+    }
+
+    const session = localRelayNode.sessions
+      .list()
+      .find((candidate) => candidate.id === id);
+    if (!session) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          reasonCode: 'SESSION_NOT_FOUND',
+          message: 'session was not found or is not locally writable',
+          retryable: false,
+        },
+      });
+      return;
+    }
+    if (session.status === 'disconnected') {
+      res.status(409).json({
+        error: {
+          code: 'SESSION_CONFLICT',
+          reasonCode: 'SESSION_DISCONNECTED',
+          message: 'cannot send input to a disconnected session',
+          retryable: false,
+          details: { sessionId: id },
+        },
+      });
+      return;
+    }
+    if (session.controlFreshness === 'stale') {
+      res.status(409).json({
+        error: {
+          code: 'SESSION_CONFLICT',
+          reasonCode: 'CONTROL_STATE_STALE',
+          message: 'cannot send input from stale control state',
+          retryable: false,
+          details: { sessionId: id },
+        },
+      });
+      return;
+    }
+    if (session.controlFreshness !== 'fresh') {
+      res.status(409).json({
+        error: {
+          code: 'SESSION_CONFLICT',
+          reasonCode: 'CONTROL_STATE_UNKNOWN',
+          message: 'cannot send input from unknown control state',
+          retryable: false,
+          details: { sessionId: id },
+        },
+      });
+      return;
+    }
+    if (session.mode === 'web') {
+      res.status(409).json({
+        error: {
+          code: 'SESSION_CONFLICT',
+          reasonCode: 'CONTROL_STATE_UNKNOWN',
+          message: 'small input is only supported for PTY sessions',
+          retryable: false,
+          details: { sessionId: id },
+        },
+      });
+      return;
+    }
+
+    try {
+      localRelayNode.sessions.write(id, data);
+      res.json({ ok: true });
+    } catch (err) {
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          reasonCode: 'SESSION_NOT_FOUND',
+          message: err instanceof Error ? err.message : 'session was not found',
+          retryable: false,
+        },
+      });
+    }
+  });
+
   // GET /repos — scan root dirs for repos
   app.get('/repos', requireAuth, async (_req, res) => {
     const freshConfig = getConfig();

--- a/test/active-work-control.test.ts
+++ b/test/active-work-control.test.ts
@@ -53,7 +53,11 @@ describe('active work mobile control helpers', () => {
         group({ sessions: [session({ agentState: 'permission-prompt' })] })
       )
     ).toBe(0);
-    expect(activeWorkStateLabel(group({ sessions: [session({ agentState: 'waiting-for-input' })] }))).toBe('needs input');
+    expect(
+      activeWorkStateLabel(
+        group({ sessions: [session({ agentState: 'waiting-for-input' })] })
+      )
+    ).toBe('needs input');
     expect(
       activeWorkAttentionPriority(
         group({
@@ -62,6 +66,18 @@ describe('active work mobile control helpers', () => {
         })
       )
     ).toBe(1);
+  });
+
+  it('surfaces error before processing when a work group has mixed session states', () => {
+    const mixed = group({
+      sessions: [
+        session({ id: 'processing-session', agentState: 'processing' }),
+        session({ id: 'errored-session', agentState: 'error', live: false }),
+      ],
+    });
+
+    expect(activeWorkAttentionPriority(mixed)).toBe(3);
+    expect(activeWorkStateLabel(mixed)).toBe('error');
   });
 
   it('allows audited small input only for fresh live local pty sessions', () => {

--- a/test/active-work-control.test.ts
+++ b/test/active-work-control.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
+import type {
+  WorkContextActiveGroup,
+  WorkContextSessionSummary,
+} from '../frontend/src/lib/types.js';
+import {
+  activeWorkAttentionPriority,
+  activeWorkMobileControlState,
+  activeWorkStateLabel,
+} from '../frontend/src/lib/active-work-control.js';
+
+const session = (
+  overrides: Partial<WorkContextSessionSummary> = {}
+): WorkContextSessionSummary => ({
+  id: 's1',
+  nodeId: DEFAULT_LOCAL_NODE_ID,
+  tabKind: 'terminal',
+  type: 'agent',
+  mode: 'pty',
+  agent: 'codex',
+  cwd: '/repo/relay-ide',
+  status: 'active',
+  agentState: 'processing',
+  controlMode: 'agent-driven',
+  controlFreshness: 'fresh',
+  relationship: 'primary',
+  associatedAt: '2026-05-17T00:00:00.000Z',
+  live: true,
+  ...overrides,
+});
+
+const group = (
+  overrides: Partial<WorkContextActiveGroup> = {}
+): WorkContextActiveGroup => ({
+  id: 'work-1',
+  context: null,
+  node: {
+    nodeId: DEFAULT_LOCAL_NODE_ID,
+    status: 'online',
+    kind: 'local',
+    lastSeenAt: '2026-05-17T00:00:00.000Z',
+  },
+  sessions: [session()],
+  staleReadModel: false,
+  ...overrides,
+});
+
+describe('active work mobile control helpers', () => {
+  it('prioritizes operator prompts before stale/offline/read-only states', () => {
+    expect(
+      activeWorkAttentionPriority(
+        group({ sessions: [session({ agentState: 'permission-prompt' })] })
+      )
+    ).toBe(0);
+    expect(activeWorkStateLabel(group({ sessions: [session({ agentState: 'waiting-for-input' })] }))).toBe('needs input');
+    expect(
+      activeWorkAttentionPriority(
+        group({
+          node: { nodeId: 'remote-a', status: 'offline', kind: 'remote' },
+          sessions: [session({ nodeId: 'remote-a', live: false })],
+        })
+      )
+    ).toBe(1);
+  });
+
+  it('allows audited small input only for fresh live local pty sessions', () => {
+    const state = activeWorkMobileControlState(
+      group({ sessions: [session({ agentState: 'permission-prompt' })] }),
+      session({ agentState: 'permission-prompt' })
+    );
+
+    expect(state.smallInputDisabledReason).toBeNull();
+    expect(state.promptKind).toBe('approval');
+    expect(state.smallInputLabel).toBe('reply to approval');
+  });
+
+  it('disables controls for stale/offline read models and reports last-known state reasons', () => {
+    const stale = activeWorkMobileControlState(
+      group({
+        node: { nodeId: 'remote-a', status: 'stale', kind: 'remote' },
+        sessions: [session({ nodeId: 'remote-a', live: true })],
+      }),
+      session({ nodeId: 'remote-a', live: true })
+    );
+    expect(stale.attachDisabledReason).toBe('stale node');
+    expect(stale.smallInputDisabledReason).toBe('stale node');
+
+    const lastKnown = activeWorkMobileControlState(
+      group({ sessions: [session({ live: false })] }),
+      session({ live: false })
+    );
+    expect(lastKnown.attachDisabledReason).toBe('last-known session only');
+  });
+
+  it('does not enable destructive kill without an explicit mobile allow decision', () => {
+    const state = activeWorkMobileControlState(group(), session());
+    expect(state.destructiveDisabledReason).toContain('session:control:kill');
+  });
+
+  it('does not route remote small input through local-only control paths', () => {
+    const state = activeWorkMobileControlState(
+      group({
+        node: { nodeId: 'remote-a', status: 'online', kind: 'remote' },
+        sessions: [session({ nodeId: 'remote-a' })],
+      }),
+      session({ nodeId: 'remote-a' })
+    );
+    expect(state.smallInputDisabledReason).toBe(
+      'remote small input awaits routed control endpoint'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a phone-first active work control card that prioritizes approval/input prompts, latest bounded status, artifacts, and attach ahead of terminal/session chrome.
- Adds a local-only small input API path (`POST /sessions/:id/input`) guarded by scoped session auth + `session:attach`; it writes through the existing session PTY path so human input is audited by the existing intervention/control machinery.
- Keeps remote, stale, offline, and last-known sessions read-only; pause/retry/kill remain disabled/challenge-only unless future explicit control capability state is available.
- Extracts active-work mobile control derivation into a tested helper and hardens the surface against sparse/nullish work-context payloads.

Closes #559
Refs #552

## The Case Against
- This is deliberately an MVP, not a full mobile control plane: remote small input is still disabled because there is no routed, audited remote input endpoint in this slice.
- Kill is intentionally not enabled from the mobile surface. The backend route now requires `session:control:kill`, but the UI does not yet have a safe explicit allow/challenge decision contract to turn that into a live destructive button.
- Small input is routed through PTY input, so it is appropriate for approval prompts and short terminal replies, not arbitrary structured workflow actions.
- Browser evidence used a temporary mocked active-work harness to force the relevant states; QA should still verify against a real hub/node session when available.

## Verification
- `npm test -- --run test/active-work-control.test.ts test/session-control-api.test.ts` — 23 passed.
- `npm run check` — passed; existing lint warnings only (65 warnings / 0 errors).
- `npm run build` — passed; existing Vite chunk-size warnings.
- Browser/mobile evidence with system Chrome at 390x844 using a temporary active-work harness:
  - approval/needs-me card sorted first and showed latest approval text.
  - small input sent `y\r` and displayed `sent · recorded as control intervention`.
  - stale remote card had attach disabled and visible stale/last-seen copy.
  - artifact link remained openable (`https://example.test/artifact/report`).
  - attach stayed enabled for the fresh local live session.
  - kill buttons stayed disabled with `session:control:kill`/stale-node reasons.
  - console warnings/errors, failed requests, and >=400 responses: none.
  - screenshot: `/tmp/relay-559-mobile-control/phone-active-work-final.png`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to submit small input to active sessions with form validation and error handling.
  * Enhanced active work surface with improved state labels, attention-based prioritization, and refined control states.

* **Tests**
  * Added comprehensive test coverage for active work control helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->