### PR TITLE
fix routed WorkContext session metadata

### DIFF
--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -193,6 +193,8 @@ export interface SessionSummary {
   dataQuality?: EventSourceType | undefined;
   /** Tracks whether permission-prompt is for approval or question — preserves needs-answer state across refresh */
   permissionType?: 'approval' | 'question';
+  /** WorkContext linked to this session, when the backend can resolve one. */
+  workContextId?: string;
   /** Typed intent/scope envelope. New server responses include this; old cached sessions may omit it. */
   sessionEnvelope?: SessionEnvelope | undefined;
 }

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -2,6 +2,7 @@ import * as express from 'express';
 import { isFileRpcOperation } from '../shared/file-rpc.js';
 import { normalizeHubFileRpcRequest } from './file-rpc.js';
 import type { Request, Response } from 'express';
+import type { WorkContextStore } from './work-contexts.js';
 import { isNodeManifest, type NodeManifest } from '../shared/node-manifest.js';
 import type {
   RepoInventoryDirtySummary,
@@ -116,6 +117,7 @@ interface HubNodeRouterOptions {
   }) => ReturnType<InMemorySessionEnvelopeRegistry['renew']>;
   confirmations?: ConfirmationChallengeStore;
   auditSink?: RoutedSessionAuditSink;
+  workContextStore?: WorkContextStore;
   now?: () => Date;
 }
 
@@ -223,6 +225,8 @@ export function isSessionSummary(value: unknown): value is SessionSummary {
     session.branchName === undefined || typeof session.branchName === 'string';
   const repoNameOk =
     session.repoName === undefined || typeof session.repoName === 'string';
+  const workContextIdOk =
+    session.workContextId === undefined || typeof session.workContextId === 'string';
   return (
     typeof session.id === 'string' &&
     (session.type === 'agent' || session.type === 'terminal') &&
@@ -232,6 +236,7 @@ export function isSessionSummary(value: unknown): value is SessionSummary {
     typeof session.cwd === 'string' &&
     repoNameOk &&
     branchNameOk &&
+    workContextIdOk &&
     controlSummaryFieldsOk(session) &&
     (session.sessionEnvelope === undefined ||
       isSessionEnvelope(session.sessionEnvelope)) &&
@@ -303,6 +308,52 @@ export function scopedNodeSession(
       ...(existingEnvelope?.auditId ? { auditId: existingEnvelope.auditId } : {}),
     }),
   };
+}
+
+function routedWorkContextId(body: Record<string, unknown>): string | undefined {
+  const value = body['workContextId'];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function validateRoutedWorkContext(
+  store: WorkContextStore | undefined,
+  workContextId: string | undefined
+): RelayNodeError | null {
+  if (!workContextId) return null;
+  if (!store) {
+    return relayError(
+      'NODE_UNSUPPORTED',
+      'workContextId is not supported by this hub runtime',
+      false,
+      { reasonCode: 'WORK_CONTEXT_UNSUPPORTED', workContextId }
+    );
+  }
+  if (store.get(workContextId)) return null;
+  return relayError('NOT_FOUND', 'work context was not found', false, {
+    reasonCode: 'WORK_CONTEXT_NOT_FOUND',
+    workContextId,
+  });
+}
+
+function associateRoutedWorkContext(
+  store: WorkContextStore | undefined,
+  workContextId: string | undefined,
+  session: SessionSummary
+): string | null {
+  if (!workContextId || !store) return null;
+  try {
+    store.associateSession(workContextId, { session });
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error.message : 'work_context_association_failed';
+  }
+}
+
+function withWorkContextId(
+  session: SessionSummary,
+  workContextId: string | undefined
+): SessionSummary {
+  return workContextId ? { ...session, workContextId } : session;
 }
 
 export function sessionFromPayload(payload: unknown): SessionSummary {
@@ -2104,6 +2155,15 @@ export function createHubNodeRouter(
     }
     const routedBody = routedGatewayCreateBodyFromRequest(req, res, nodeId);
     if (!routedBody) return;
+    const workContextId = routedWorkContextId(routedBody);
+    const workContextError = validateRoutedWorkContext(
+      options.workContextStore,
+      workContextId
+    );
+    if (workContextError) {
+      sendRelayError(res, workContextError);
+      return;
+    }
     const node = registry
       .listNodes()
       .find((candidate) => candidate.nodeId === nodeId);
@@ -2257,7 +2317,17 @@ export function createHubNodeRouter(
         ...(expiresAt !== undefined ? { expiresAt } : {}),
       });
       envelopes.upsert(session.sessionEnvelope!);
-      res.status(201).json(session);
+      const associationError = associateRoutedWorkContext(
+        options.workContextStore,
+        workContextId,
+        session
+      );
+      const responseSession = withWorkContextId(session, workContextId);
+      res.status(201).json(
+        associationError
+          ? { ...responseSession, workContextAssociationError: associationError }
+          : responseSession
+      );
     } catch (error) {
       if (error instanceof HubNodeLinkError) {
         sendRelayError(res, error.relayNodeError);

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -135,6 +135,34 @@ function optionalControlStringOk(value: unknown): boolean {
   return value === undefined || value === null || typeof value === 'string';
 }
 
+function optionalStringFieldOk(value: unknown): boolean {
+  return value === undefined || typeof value === 'string';
+}
+
+function optionalNullableStringFieldOk(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === 'string';
+}
+
+function sessionAssociationFieldsOk(session: Partial<SessionSummary>): boolean {
+  // repo/worktree/branch/work-context bindings are optional: a non-repo
+  // routed session (e.g. raw shell on a paired node) carries no repo
+  // binding. Validate them only when present.
+  return (
+    optionalStringFieldOk(session.repoPath) &&
+    optionalNullableStringFieldOk(session.worktreePath) &&
+    optionalStringFieldOk(session.repoName) &&
+    optionalStringFieldOk(session.branchName) &&
+    optionalStringFieldOk(session.workContextId)
+  );
+}
+
+function sessionEnvelopeOk(session: Partial<SessionSummary>): boolean {
+  return (
+    session.sessionEnvelope === undefined ||
+    isSessionEnvelope(session.sessionEnvelope)
+  );
+}
+
 function controlSummaryFieldsOk(session: Partial<SessionSummary>): boolean {
   const activeActorsOk =
     session.activeActors === undefined ||
@@ -212,34 +240,14 @@ export function sendRelayError(res: Response, error: RelayNodeError): void {
 export function isSessionSummary(value: unknown): value is SessionSummary {
   if (typeof value !== 'object' || value === null) return false;
   const session = value as Partial<SessionSummary>;
-  // repoPath / worktreePath / branchName are optional: a non-repo
-  // routed session (e.g. raw shell on a paired node) carries no repo
-  // binding. Validate them only when present.
-  const repoPathOk =
-    session.repoPath === undefined || typeof session.repoPath === 'string';
-  const worktreePathOk =
-    session.worktreePath === undefined ||
-    session.worktreePath === null ||
-    typeof session.worktreePath === 'string';
-  const branchNameOk =
-    session.branchName === undefined || typeof session.branchName === 'string';
-  const repoNameOk =
-    session.repoName === undefined || typeof session.repoName === 'string';
-  const workContextIdOk =
-    session.workContextId === undefined || typeof session.workContextId === 'string';
   return (
     typeof session.id === 'string' &&
     (session.type === 'agent' || session.type === 'terminal') &&
     (session.mode === 'pty' || session.mode === 'web') &&
-    repoPathOk &&
-    worktreePathOk &&
+    sessionAssociationFieldsOk(session) &&
     typeof session.cwd === 'string' &&
-    repoNameOk &&
-    branchNameOk &&
-    workContextIdOk &&
     controlSummaryFieldsOk(session) &&
-    (session.sessionEnvelope === undefined ||
-      isSessionEnvelope(session.sessionEnvelope)) &&
+    sessionEnvelopeOk(session) &&
     typeof session.displayName === 'string' &&
     typeof session.createdAt === 'string' &&
     typeof session.lastActivity === 'string' &&

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -270,6 +270,10 @@ export function scopedNodeSession(
   delete scoped.globalSessionId;
   delete scoped.repoInstanceId;
   delete scoped.worktreeInstanceId;
+  // WorkContext identity is hub-owned metadata. A paired node can report
+  // arbitrary session fields, but the hub must only surface a WorkContext id
+  // after validating the routed create request or resolving a stored link.
+  delete scoped.workContextId;
 
   const existingEnvelope = isSessionEnvelope(scoped.sessionEnvelope)
     ? scoped.sessionEnvelope
@@ -357,11 +361,16 @@ function associateRoutedWorkContext(
   }
 }
 
-function withWorkContextId(
+function withTrustedWorkContextId(
+  store: WorkContextStore | undefined,
   session: SessionSummary,
   workContextId: string | undefined
 ): SessionSummary {
-  return workContextId ? { ...session, workContextId } : session;
+  const trustedWorkContextId =
+    workContextId ?? store?.findSessionWorkContextIds(session)[0];
+  return trustedWorkContextId
+    ? { ...session, workContextId: trustedWorkContextId }
+    : session;
 }
 
 export function sessionFromPayload(payload: unknown): SessionSummary {
@@ -2330,7 +2339,11 @@ export function createHubNodeRouter(
         workContextId,
         session
       );
-      const responseSession = withWorkContextId(session, workContextId);
+      const responseSession = withTrustedWorkContextId(
+        options.workContextStore,
+        session,
+        workContextId
+      );
       res.status(201).json(
         associationError
           ? { ...responseSession, workContextAssociationError: associationError }

--- a/server/hub-session-aggregator.ts
+++ b/server/hub-session-aggregator.ts
@@ -117,8 +117,10 @@ function withWorkContextMetadata(
   store: WorkContextStore | undefined,
   session: SessionSummary
 ): SessionSummary {
-  const workContextId = store?.findSessionWorkContextIds(session)[0];
-  return workContextId ? { ...session, workContextId } : session;
+  const trustedSession = { ...session };
+  delete trustedSession.workContextId;
+  const workContextId = store?.findSessionWorkContextIds(trustedSession)[0];
+  return workContextId ? { ...trustedSession, workContextId } : trustedSession;
 }
 
 async function requestSessionsWithTimeout(

--- a/server/hub-session-aggregator.ts
+++ b/server/hub-session-aggregator.ts
@@ -10,6 +10,7 @@ import {
 import type { SessionSummary } from './types.js';
 import { scopedNodeSession, isSessionSummary } from './hub-node-router.js';
 import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
+import type { WorkContextStore } from './work-contexts.js';
 
 /**
  * Returns true when a session is owned by this hub host (local node).
@@ -39,6 +40,7 @@ export interface AggregateRemoteSessionsDeps {
   nodeLinks: HubNodeLinkManager;
   logger?: Logger;
   sessionEnvelopes?: InMemorySessionEnvelopeRegistry;
+  workContextStore?: WorkContextStore;
   perNodeTimeoutMs?: number;
 }
 
@@ -102,11 +104,21 @@ export async function aggregateRemoteSessions(
     for (const session of result.value.sessions) {
       const scoped = scopedNodeSession(result.value.nodeId, session);
       const sessionEnvelope = envelopes.upsert(scoped.sessionEnvelope!);
-      aggregated.push({ ...scoped, sessionEnvelope });
+      aggregated.push(
+        withWorkContextMetadata(deps.workContextStore, { ...scoped, sessionEnvelope })
+      );
     }
   }
 
   return aggregated;
+}
+
+function withWorkContextMetadata(
+  store: WorkContextStore | undefined,
+  session: SessionSummary
+): SessionSummary {
+  const workContextId = store?.findSessionWorkContextIds(session)[0];
+  return workContextId ? { ...session, workContextId } : session;
 }
 
 async function requestSessionsWithTimeout(

--- a/server/index.ts
+++ b/server/index.ts
@@ -864,13 +864,25 @@ function associateSessionWithWorkContext(
   }
 }
 
+function withWorkContextMetadata(
+  store: WorkContextStore,
+  session: SessionSummary
+): SessionSummary {
+  const workContextId = store.findSessionWorkContextIds(session)[0];
+  return workContextId ? { ...session, workContextId } : session;
+}
+
 function sendSessionCreateSuccess(
   res: express.Response,
   session: SessionSummary,
-  associationError: string | null
+  associationError: string | null,
+  workContextId?: string
 ): void {
+  const responseSession = workContextId ? { ...session, workContextId } : session;
   res.status(201).json(
-    associationError ? { ...session, workContextAssociationError: associationError } : session
+    associationError
+      ? { ...responseSession, workContextAssociationError: associationError }
+      : responseSession
   );
 }
 
@@ -1300,6 +1312,7 @@ async function main(): Promise<void> {
       confirmations: confirmationChallenges,
       sessionEnvelopes: sessionEnvelopeRegistry,
       renewLocalSession: localRelayNode.sessions.renew,
+      workContextStore,
       ...(securityAuditLog ? { auditSink: securityAuditLog } : {}),
     })
   );
@@ -1654,12 +1667,18 @@ async function main(): Promise<void> {
       requireAuth,
       getSessions: async () => {
         const [localSessions, remoteSessions] = await Promise.all([
-          Promise.resolve(localRelayNode.sessions.list()),
+          Promise.resolve(
+            localRelayNode
+              .sessions
+              .list()
+              .map((session) => withWorkContextMetadata(workContextStore, session))
+          ),
           aggregateRemoteSessions({
             registry: hubNodeRegistry,
             nodeLinks: hubNodeLinks,
             logger,
             sessionEnvelopes: sessionEnvelopeRegistry,
+            workContextStore,
           }),
         ]);
         return [...localSessions, ...remoteSessions];
@@ -2065,12 +2084,18 @@ async function main(): Promise<void> {
   const BRANCH_REFRESH_INTERVAL_MS = 10_000;
   app.get('/sessions', requireCliGatewayAuth, async (_req, res) => {
     const [localSessions, remoteSessions] = await Promise.all([
-      Promise.resolve(localRelayNode.sessions.list()),
+      Promise.resolve(
+        localRelayNode
+          .sessions
+          .list()
+          .map((session) => withWorkContextMetadata(workContextStore, session))
+      ),
       aggregateRemoteSessions({
         registry: hubNodeRegistry,
         nodeLinks: hubNodeLinks,
         logger,
         sessionEnvelopes: sessionEnvelopeRegistry,
+        workContextStore,
       }),
     ]);
     const allSessions = [...localSessions, ...remoteSessions];
@@ -2138,7 +2163,7 @@ async function main(): Promise<void> {
         });
         return;
       }
-      res.json(session);
+      res.json(withWorkContextMetadata(workContextStore, session));
       return;
     }
     const remoteSessions = await aggregateRemoteSessions({
@@ -2146,6 +2171,7 @@ async function main(): Promise<void> {
       nodeLinks: hubNodeLinks,
       logger,
       sessionEnvelopes: sessionEnvelopeRegistry,
+      workContextStore,
     });
     const remote = remoteSessions.find(
       (candidate) => candidate.id === id || candidate.globalSessionId === id
@@ -2875,7 +2901,7 @@ async function main(): Promise<void> {
         workContextId,
         session
       );
-      sendSessionCreateSuccess(res, session, associationError);
+      sendSessionCreateSuccess(res, session, associationError, workContextId);
       return;
     }
 
@@ -2937,7 +2963,7 @@ async function main(): Promise<void> {
           workContextId,
           session
         );
-        sendSessionCreateSuccess(res, session, associationError);
+        sendSessionCreateSuccess(res, session, associationError, workContextId);
       } catch (err) {
         sendSessionCreateError(res, err, freshConfig.maxPtySessions);
       }
@@ -3020,7 +3046,7 @@ async function main(): Promise<void> {
       session
     );
 
-    sendSessionCreateSuccess(res, session, associationError);
+    sendSessionCreateSuccess(res, session, associationError, workContextId);
   });
 
   // DELETE /sessions/:id

--- a/server/types.ts
+++ b/server/types.ts
@@ -424,6 +424,8 @@ export interface SessionSummary {
   dataQuality?: EventSourceType;
   /** Tracks whether permission-prompt is for approval or question — preserves needs-answer state across refresh */
   permissionType?: 'approval' | 'question';
+  /** WorkContext linked to this session, when the create/list surface can resolve one. */
+  workContextId?: string;
   /** Typed intent/scope envelope. Present on new responses; legacy callers should normalize when absent. */
   sessionEnvelope?: SessionEnvelope | undefined;
 }

--- a/server/work-contexts.ts
+++ b/server/work-contexts.ts
@@ -288,6 +288,7 @@ export interface WorkContextStore {
     input: ListActiveWorkInput
   ): WorkContextResumeSnapshot;
   listActiveWork(input: ListActiveWorkInput): WorkContextActiveGroup[];
+  findSessionWorkContextIds(session: SessionSummary): WorkContextId[];
 }
 
 export interface WorkContextRouterDeps {
@@ -530,6 +531,20 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
         input.sessions,
         input.nodes ?? []
       );
+    },
+
+    findSessionWorkContextIds(session: SessionSummary) {
+      const ref = sessionSummaryToRef(session);
+      const allLinks = selectSessionLinks.all() as SessionLinkRow[];
+      const ids = new Set<WorkContextId>();
+      for (const link of allLinks) {
+        const sameLocalId =
+          link.node_id === ref.nodeId && link.session_id === ref.sessionId;
+        const sameGlobalId =
+          ref.globalSessionId && link.global_session_id === ref.globalSessionId;
+        if (sameLocalId || sameGlobalId) ids.add(link.work_context_id);
+      }
+      return Array.from(ids);
     },
   };
 }

--- a/server/work-contexts.ts
+++ b/server/work-contexts.ts
@@ -351,6 +351,20 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
      FROM work_context_session_links
      ORDER BY associated_at ASC`
   );
+  const selectSessionLinksBySession = db.prepare(
+    `SELECT work_context_id, node_id, session_id, global_session_id,
+            relationship, session_ref_json, associated_at
+     FROM work_context_session_links
+     WHERE node_id = ? AND session_id = ?
+     ORDER BY associated_at ASC`
+  );
+  const selectSessionLinksByGlobal = db.prepare(
+    `SELECT work_context_id, node_id, session_id, global_session_id,
+            relationship, session_ref_json, associated_at
+     FROM work_context_session_links
+     WHERE global_session_id = ?
+     ORDER BY associated_at ASC`
+  );
   const upsertSessionLink = db.prepare(
     `INSERT INTO work_context_session_links (
        work_context_id, node_id, session_id, global_session_id,
@@ -535,15 +549,19 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
 
     findSessionWorkContextIds(session: SessionSummary) {
       const ref = sessionSummaryToRef(session);
-      const allLinks = selectSessionLinks.all() as SessionLinkRow[];
+      const rows = [
+        ...(selectSessionLinksBySession.all(
+          ref.nodeId,
+          ref.sessionId
+        ) as SessionLinkRow[]),
+        ...(ref.globalSessionId
+          ? (selectSessionLinksByGlobal.all(
+              ref.globalSessionId
+            ) as SessionLinkRow[])
+          : []),
+      ].sort((a, b) => a.associated_at.localeCompare(b.associated_at));
       const ids = new Set<WorkContextId>();
-      for (const link of allLinks) {
-        const sameLocalId =
-          link.node_id === ref.nodeId && link.session_id === ref.sessionId;
-        const sameGlobalId =
-          ref.globalSessionId && link.global_session_id === ref.globalSessionId;
-        if (sameLocalId || sameGlobalId) ids.add(link.work_context_id);
-      }
+      for (const link of rows) ids.add(link.work_context_id);
       return Array.from(ids);
     },
   };

--- a/test/hub-confirmation-routing.test.ts
+++ b/test/hub-confirmation-routing.test.ts
@@ -1,4 +1,7 @@
 import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import express from 'express';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createConfirmationChallengeStore, hashAuthSessionIdentity } from '../server/confirmation-challenges.js';
@@ -7,6 +10,7 @@ import { createHubNodeRouter, type RoutedSessionAuditSink } from '../server/hub-
 import type { HubNodeRegistry } from '../server/hub-node-registry.js';
 import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
 import { createRoutedNodeSessionEnvelope } from '../shared/session-envelope.js';
+import { createWorkContextStore, type WorkContextStore } from '../server/work-contexts.js';
 import {
   createLegacyDefaultNodeAcl,
   summarizeAcl,
@@ -118,7 +122,11 @@ describe('hub confirmation routing', () => {
   });
 
   async function startHub(
-    options: { auditSink?: RoutedSessionAuditSink; node?: HubNodeSummary } = {}
+    options: {
+      auditSink?: RoutedSessionAuditSink;
+      node?: HubNodeSummary;
+      workContextStore?: WorkContextStore;
+    } = {}
   ) {
     const nodeLinks = {
       requests: [] as Array<{ nodeId: string; type: string; payload: unknown }>,
@@ -158,6 +166,7 @@ describe('hub confirmation routing', () => {
           randomToken: () => 'raw-confirmation-token',
         }),
         auditSink,
+        workContextStore: options.workContextStore,
         now: () => NOW,
         requireAuth: (req, res, next) => {
           if (req.header('x-test-auth') === 'yes') next();
@@ -391,6 +400,62 @@ describe('hub confirmation routing', () => {
     expect(approvalAudit?.peer.principalHash).not.toBe(requesterHash);
     expect(failedRedemptionAudit?.peer.principalHash).toBe(requesterHash);
     expect(grantAudit?.peer.principalHash).toBe(requesterHash);
+  });
+
+  it('associates routed session creates with existing WorkContext metadata and Active Work groups', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-work-context-test-'));
+    const workContextStore = createWorkContextStore(path.join(tmp, 'work-contexts.db'));
+    cleanup.push(() => {
+      workContextStore.close();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    });
+    const workContextId = 'github-issue-572-safe-relay-development';
+    workContextStore.create({
+      id: workContextId,
+      title: 'Issue #572 dogfood routed session',
+      source: 'test',
+    });
+    const node = nodeSummary({
+      allowed: ['session:read', 'session:create:terminal'],
+      requiresConfirmation: [],
+    });
+    const { base, nodeLinks } = await startHub({ workContextStore, node });
+
+    const body = {
+      repoPath: '/srv/relay-ide',
+      type: 'terminal',
+      workContextId,
+    };
+    const response = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+      },
+      body: JSON.stringify(body),
+    });
+
+    expect(response.status).toBe(201);
+    const session = await response.json();
+    expect(session).toMatchObject({
+      id: 'remote-session-1',
+      nodeId: 'node_prod',
+      workContextId,
+    });
+    expect(nodeLinks.requests[0]).toMatchObject({
+      type: 'sessions.create',
+      payload: body,
+    });
+    expect(workContextStore.findSessionWorkContextIds(session)).toEqual([workContextId]);
+
+    const groups = workContextStore.listActiveWork({ sessions: [session], nodes: [node] });
+    const group = groups.find((candidate) => candidate.id === workContextId);
+    expect(group).toBeDefined();
+    expect(group?.sessions[0]).toMatchObject({
+      id: 'remote-session-1',
+      nodeId: 'node_prod',
+      live: true,
+    });
   });
 
   it('ignores spoofable x-auth-session when an authenticated cookie is present', async () => {

--- a/test/hub-confirmation-routing.test.ts
+++ b/test/hub-confirmation-routing.test.ts
@@ -126,6 +126,7 @@ describe('hub confirmation routing', () => {
       auditSink?: RoutedSessionAuditSink;
       node?: HubNodeSummary;
       workContextStore?: WorkContextStore;
+      sessionPayload?: unknown;
     } = {}
   ) {
     const nodeLinks = {
@@ -133,7 +134,7 @@ describe('hub confirmation routing', () => {
       hasActiveNode: () => true,
       request: async (nodeId: string, type: string, payload: unknown): Promise<unknown> => {
         nodeLinks.requests.push({ nodeId, type, payload });
-        return sessionPayload();
+        return options.sessionPayload ?? sessionPayload();
       },
     };
     const auditEntries: Parameters<RoutedSessionAuditSink['append']>[0][] = [];
@@ -456,6 +457,32 @@ describe('hub confirmation routing', () => {
       nodeId: 'node_prod',
       live: true,
     });
+  });
+
+  it('strips unvalidated node-provided WorkContext ids from routed session creates', async () => {
+    const spoofedWorkContextId = 'node-owned-untrusted-context';
+    const payload = sessionPayload();
+    (payload.session as typeof payload.session & { workContextId?: string }).workContextId =
+      spoofedWorkContextId;
+    const node = nodeSummary({
+      allowed: ['session:read', 'session:create:terminal'],
+      requiresConfirmation: [],
+    });
+    const { base } = await startHub({ node, sessionPayload: payload });
+
+    const response = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+      },
+      body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal' }),
+    });
+
+    expect(response.status).toBe(201);
+    const session = await response.json();
+    expect(session).toMatchObject({ id: 'remote-session-1', nodeId: 'node_prod' });
+    expect(session.workContextId).toBeUndefined();
   });
 
   it('ignores spoofable x-auth-session when an authenticated cookie is present', async () => {

--- a/test/hub-session-aggregator.test.ts
+++ b/test/hub-session-aggregator.test.ts
@@ -11,6 +11,7 @@ import type { HubNodeLinkManager } from '../server/hub-node-link.js';
 import type { HubNodeRegistry } from '../server/hub-node-registry.js';
 import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
 import type { SessionSummary } from '../server/types.js';
+import type { WorkContextStore } from '../server/work-contexts.js';
 
 function summary(
   nodeId: string,
@@ -134,6 +135,56 @@ describe('aggregateRemoteSessions', () => {
     for (const session of result) {
       expect(session.globalSessionId).toMatch(/^node-(a|b):(s1|s2)$/);
     }
+  });
+
+  it('strips node-provided WorkContext ids from remote session aggregation without a hub link', async () => {
+    const { registry, nodeLinks } = buildDeps({
+      nodes: [summary('node-a')],
+      activeNodeIds: new Set(['node-a']),
+      requestImpl: async (nodeId) => ({
+        sessions: [
+          {
+            ...localSession('s-untrusted', nodeId),
+            workContextId: 'node-owned-context',
+          },
+        ],
+      }),
+    });
+
+    const result = await aggregateRemoteSessions({ registry, nodeLinks });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.workContextId).toBeUndefined();
+  });
+
+  it('hydrates remote session WorkContext ids only from the hub store', async () => {
+    const workContextStore = {
+      findSessionWorkContextIds: vi.fn(() => ['hub-owned-context']),
+    } as unknown as WorkContextStore;
+    const { registry, nodeLinks } = buildDeps({
+      nodes: [summary('node-a')],
+      activeNodeIds: new Set(['node-a']),
+      requestImpl: async (nodeId) => ({
+        sessions: [
+          {
+            ...localSession('s-linked', nodeId),
+            workContextId: 'node-owned-context',
+          },
+        ],
+      }),
+    });
+
+    const result = await aggregateRemoteSessions({
+      registry,
+      nodeLinks,
+      workContextStore,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.workContextId).toBe('hub-owned-context');
+    expect(workContextStore.findSessionWorkContextIds).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 's-linked', nodeId: 'node-a' })
+    );
   });
 
   it('registers listed remote session envelopes for later routed attach validation', async () => {


### PR DESCRIPTION
## Summary
- preserve and return `workContextId` on routed session creates when the hub can resolve the WorkContext
- persist routed session-to-WorkContext links so Active Work can group remote node sessions
- enrich local/remote session list/get surfaces with resolved WorkContext metadata
- add a regression test covering routed create response metadata plus Active Work grouping

## Why
Issue #572 reports that dogfood routed terminal create accepts `workContextId`, but the create/get descriptors do not surface it and Active Work stays empty even though PTY/file RPC work. The metadata was getting dropped at the hub boundary: routed node session create did not validate/associate WorkContext state, and remote session aggregation did not rehydrate links from the WorkContext store.

## The Case Against
- This stores the WorkContext/session association on the hub after the remote node creates the session. If the association write fails, the session still exists remotely and the response carries `workContextAssociationError`; callers may need to surface that partial-success state.
- The routed create path now rejects unknown WorkContext IDs before contacting the node. That is safer than silently creating an ungrouped session, but any client relying on stale WorkContext IDs will now get a clear error.
- Remote session list/get can only report WorkContext metadata that the hub has persisted; sessions created by an older hub without association data remain unassigned unless linked later.

## Verification
- `npm test -- test/hub-confirmation-routing.test.ts` (7/7 passed)
- `npm test -- test/work-context.test.ts test/work-context-store.test.ts` (17/17 passed)
- `npm run build:server` (passed)
- `git diff --check` (passed)
- `npm run lint` attempted locally, but the rtk/npm wrapper exited 2 with empty captured output (`ESLint output (JSON parse failed: EOF while parsing a value at line 1 column 0)`); server build and targeted Vitest suites passed.

Closes #572
Refs #562 #552


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Work context association: Sessions can now be linked to work contexts. Session creation endpoints support specifying a work context, and all session lists and detail views display associated work context information when available. The system automatically enriches both local and remote sessions with work context metadata for unified context awareness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->