### PR TITLE
fix: keep routed Active Work live on transient node list failures

### DIFF
--- a/server/hub-session-aggregator.ts
+++ b/server/hub-session-aggregator.ts
@@ -31,9 +31,44 @@ export function isLocallyOwnedSession(session: SessionSummary): boolean {
 
 // Per-node RPC timeout for sessions.list aggregation. Tighter than the
 // 10s HubNodeLinkManager default because GET /sessions is on the
-// browser refresh path and slow nodes must not block the response —
-// we drop them instead of stalling every other tab.
+// browser refresh path and slow nodes must not block the response.
 const PER_NODE_TIMEOUT_MS = 3_000;
+const REMOTE_SESSION_CACHE_TTL_MS = 60_000;
+
+export interface RemoteSessionReadModelCache {
+  get(nodeId: string, nowMs: number, maxAgeMs: number): SessionSummary[] | null;
+  set(nodeId: string, sessions: SessionSummary[], observedAtMs: number): void;
+  clear(nodeId: string): void;
+}
+
+interface CachedRemoteSessions {
+  observedAtMs: number;
+  sessions: SessionSummary[];
+}
+
+export function createRemoteSessionReadModelCache(): RemoteSessionReadModelCache {
+  const entries = new Map<string, CachedRemoteSessions>();
+  return {
+    get(nodeId, nowMs, maxAgeMs) {
+      const cached = entries.get(nodeId);
+      if (!cached) return null;
+      if (nowMs - cached.observedAtMs > maxAgeMs) {
+        entries.delete(nodeId);
+        return null;
+      }
+      return cached.sessions.map((session) => ({ ...session }));
+    },
+    set(nodeId, sessions, observedAtMs) {
+      entries.set(nodeId, {
+        observedAtMs,
+        sessions: sessions.map((session) => ({ ...session })),
+      });
+    },
+    clear(nodeId) {
+      entries.delete(nodeId);
+    },
+  };
+}
 
 export interface AggregateRemoteSessionsDeps {
   registry: HubNodeRegistry;
@@ -41,34 +76,46 @@ export interface AggregateRemoteSessionsDeps {
   logger?: Logger;
   sessionEnvelopes?: InMemorySessionEnvelopeRegistry;
   workContextStore?: WorkContextStore;
+  readModelCache?: RemoteSessionReadModelCache;
   perNodeTimeoutMs?: number;
+  readModelCacheTtlMs?: number;
+  now?: () => number;
 }
 
 /**
  * Fetch and aggregate `sessions.list` results from every online paired
  * node with an active reverse link. Returns a flat array of
  * `SessionSummary` stamped with `nodeId`. Per-node failures (offline,
- * RPC timeout, malformed payload) are logged and dropped from the
- * result; the aggregate never throws.
+ * RPC timeout, malformed payload) are logged; callers that supply a
+ * read-model cache get the last recent successful list for transient
+ * failures, otherwise the failed node is dropped. Typed NODE_OFFLINE
+ * failures are not masked by the cache. The aggregate never throws.
  *
- * Offline / stale / revoked nodes are skipped entirely. Sessions from
- * a node that drops mid-fetch effectively disappear from the next
- * `GET /sessions` cycle, matching how routed PTY sockets close on
- * node-link loss.
+ * Offline / stale / revoked nodes are skipped entirely and their cached
+ * read model is cleared. Successful empty session lists replace the
+ * cache, so ended sessions stop appearing once the owning node can answer
+ * authoritatively.
  */
 export async function aggregateRemoteSessions(
   deps: AggregateRemoteSessionsDeps
 ): Promise<SessionSummary[]> {
   const logger = deps.logger ?? createLogger('hub-session-agg');
   const timeoutMs = deps.perNodeTimeoutMs ?? PER_NODE_TIMEOUT_MS;
+  const cacheTtlMs = deps.readModelCacheTtlMs ?? REMOTE_SESSION_CACHE_TTL_MS;
+  const nowMs = deps.now?.() ?? Date.now();
   const envelopes = deps.sessionEnvelopes ?? sessionEnvelopeRegistry;
 
-  const candidates = deps.registry
-    .listNodes()
-    .filter(
-      (node) =>
-        node.status === 'online' && deps.nodeLinks.hasActiveNode(node.nodeId)
-    );
+  const nodes = deps.registry.listNodes();
+  const candidates = nodes.filter(
+    (node) =>
+      node.status === 'online' && deps.nodeLinks.hasActiveNode(node.nodeId)
+  );
+  if (deps.readModelCache) {
+    const candidateIds = new Set(candidates.map((node) => node.nodeId));
+    for (const node of nodes) {
+      if (!candidateIds.has(node.nodeId)) deps.readModelCache.clear(node.nodeId);
+    }
+  }
 
   if (candidates.length === 0) return [];
 
@@ -90,27 +137,66 @@ export async function aggregateRemoteSessions(
     const result = results[i];
     if (!result) continue;
     if (result.status === 'rejected') {
-      const reason =
-        result.reason instanceof HubNodeLinkError
-          ? `${result.reason.relayNodeError.code}: ${result.reason.relayNodeError.message}`
-          : result.reason instanceof Error
-            ? result.reason.message
-            : String(result.reason ?? 'unknown');
-      logger.warn(
-        `sessions.list failed for node ${candidate.nodeId}: ${reason}`
+      const reason = formatSessionListFailure(result.reason);
+      const cached = getCachedSessionsForFailure(
+        deps,
+        candidate.nodeId,
+        result.reason,
+        nowMs,
+        cacheTtlMs
       );
+      if (cached) {
+        logger.warn(
+          `sessions.list failed for node ${candidate.nodeId}: ${reason}; using cached read model`
+        );
+        aggregated.push(
+          ...cached.map((session) =>
+            withWorkContextMetadata(deps.workContextStore, session)
+          )
+        );
+      } else {
+        logger.warn(
+          `sessions.list failed for node ${candidate.nodeId}: ${reason}`
+        );
+      }
       continue;
     }
+    const scopedSessions: SessionSummary[] = [];
     for (const session of result.value.sessions) {
       const scoped = scopedNodeSession(result.value.nodeId, session);
       const sessionEnvelope = envelopes.upsert(scoped.sessionEnvelope!);
-      aggregated.push(
-        withWorkContextMetadata(deps.workContextStore, { ...scoped, sessionEnvelope })
-      );
+      scopedSessions.push({ ...scoped, sessionEnvelope });
     }
+    deps.readModelCache?.set(candidate.nodeId, scopedSessions, nowMs);
+    aggregated.push(
+      ...scopedSessions.map((session) =>
+        withWorkContextMetadata(deps.workContextStore, session)
+      )
+    );
   }
 
   return aggregated;
+}
+
+function formatSessionListFailure(reason: unknown): string {
+  if (reason instanceof HubNodeLinkError) {
+    return `${reason.relayNodeError.code}: ${reason.relayNodeError.message}`;
+  }
+  if (reason instanceof Error) return reason.message;
+  return String(reason ?? 'unknown');
+}
+
+function getCachedSessionsForFailure(
+  deps: AggregateRemoteSessionsDeps,
+  nodeId: string,
+  reason: unknown,
+  nowMs: number,
+  cacheTtlMs: number
+): SessionSummary[] | null {
+  if (reason instanceof HubNodeLinkError && reason.relayNodeError.code === 'NODE_OFFLINE') {
+    return null;
+  }
+  return deps.readModelCache?.get(nodeId, nowMs, cacheTtlMs) ?? null;
 }
 
 function withWorkContextMetadata(

--- a/server/index.ts
+++ b/server/index.ts
@@ -117,6 +117,7 @@ import { createConfirmationChallengeStore } from './confirmation-challenges.js';
 import { createHubNodeLinkManager } from './hub-node-link.js';
 import {
   aggregateRemoteSessions,
+  createRemoteSessionReadModelCache,
   isLocallyOwnedSession,
 } from './hub-session-aggregator.js';
 import { createRepoInventoryFeature } from './features/repo-inventory.js';
@@ -1120,6 +1121,7 @@ async function main(): Promise<void> {
     inventoryValidator: repoInventoryFeature.validateInventoryPayload,
     ptyInputRecorder: sessions.recordRoutedPtyInput,
   });
+  const remoteSessionReadModelCache = createRemoteSessionReadModelCache();
 
   async function flushHubNodeHeartbeatsBestEffort(
     context: string
@@ -1679,6 +1681,7 @@ async function main(): Promise<void> {
             logger,
             sessionEnvelopes: sessionEnvelopeRegistry,
             workContextStore,
+            readModelCache: remoteSessionReadModelCache,
           }),
         ]);
         return [...localSessions, ...remoteSessions];
@@ -2096,6 +2099,7 @@ async function main(): Promise<void> {
         logger,
         sessionEnvelopes: sessionEnvelopeRegistry,
         workContextStore,
+        readModelCache: remoteSessionReadModelCache,
       }),
     ]);
     const allSessions = [...localSessions, ...remoteSessions];
@@ -2172,6 +2176,7 @@ async function main(): Promise<void> {
       logger,
       sessionEnvelopes: sessionEnvelopeRegistry,
       workContextStore,
+      readModelCache: remoteSessionReadModelCache,
     });
     const remote = remoteSessions.find(
       (candidate) => candidate.id === id || candidate.globalSessionId === id

--- a/test/hub-session-aggregator.test.ts
+++ b/test/hub-session-aggregator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   aggregateRemoteSessions,
+  createRemoteSessionReadModelCache,
   isLocallyOwnedSession,
 } from '../server/hub-session-aggregator.js';
 import { HubNodeLinkError } from '../server/hub-node-link.js';
@@ -34,7 +35,7 @@ function summary(
     pairedAt: '2026-01-01T00:00:00.000Z',
     lastSeenAt: '2026-01-02T00:00:00.000Z',
     capabilities: undefined as never,
-  } as HubNodeSummary;
+  } as unknown as HubNodeSummary;
 }
 
 function localSession(id: string, nodeId: string): SessionSummary {
@@ -271,6 +272,138 @@ describe('aggregateRemoteSessions', () => {
     const result = await aggregateRemoteSessions({ registry, nodeLinks });
     expect(result).toHaveLength(1);
     expect(result[0]?.nodeId).toBe('node-good');
+  });
+
+  it('falls back to the recent remote session read model when a listed node times out', async () => {
+    const readModelCache = createRemoteSessionReadModelCache();
+    let call = 0;
+    const workContextStore = {
+      findSessionWorkContextIds: vi.fn(() => ['hub-owned-context']),
+    } as unknown as WorkContextStore;
+    const { registry, nodeLinks } = buildDeps({
+      nodes: [summary('node-a')],
+      activeNodeIds: new Set(['node-a']),
+      requestImpl: async (nodeId) => {
+        call += 1;
+        if (call > 1) throw new Error('simulated sessions.list timeout');
+        return { sessions: [localSession('s-live', nodeId)] };
+      },
+    });
+
+    const fresh = await aggregateRemoteSessions({
+      registry,
+      nodeLinks,
+      workContextStore,
+      readModelCache,
+      now: () => 1_000,
+    });
+    expect(fresh[0]).toMatchObject({
+      id: 's-live',
+      nodeId: 'node-a',
+      workContextId: 'hub-owned-context',
+      status: 'active',
+    });
+
+    const fallback = await aggregateRemoteSessions({
+      registry,
+      nodeLinks,
+      workContextStore,
+      readModelCache,
+      now: () => 2_000,
+    });
+
+    expect(fallback).toHaveLength(1);
+    expect(fallback[0]).toMatchObject({
+      id: 's-live',
+      nodeId: 'node-a',
+      workContextId: 'hub-owned-context',
+      status: 'active',
+    });
+  });
+
+  it('does not mask typed NODE_OFFLINE failures with the cached read model', async () => {
+    const readModelCache = createRemoteSessionReadModelCache();
+    let offline = false;
+    const { registry, nodeLinks } = buildDeps({
+      nodes: [summary('node-a')],
+      activeNodeIds: new Set(['node-a']),
+      requestImpl: async (nodeId) => {
+        if (offline) {
+          throw new HubNodeLinkError({
+            code: 'NODE_OFFLINE',
+            message: 'node link is offline',
+            retryable: true,
+          });
+        }
+        return { sessions: [localSession('s-live', nodeId)] };
+      },
+    });
+
+    await aggregateRemoteSessions({
+      registry,
+      nodeLinks,
+      readModelCache,
+      now: () => 1_000,
+    });
+    offline = true;
+
+    const result = await aggregateRemoteSessions({
+      registry,
+      nodeLinks,
+      readModelCache,
+      now: () => 2_000,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('does not use expired cached remote sessions after a sessions.list failure', async () => {
+    const readModelCache = createRemoteSessionReadModelCache();
+    let fail = false;
+    const { registry, nodeLinks } = buildDeps({
+      nodes: [summary('node-a')],
+      activeNodeIds: new Set(['node-a']),
+      requestImpl: async (nodeId) => {
+        if (fail) throw new Error('simulated sessions.list timeout');
+        return { sessions: [localSession('s-live', nodeId)] };
+      },
+    });
+
+    await aggregateRemoteSessions({
+      registry,
+      nodeLinks,
+      readModelCache,
+      now: () => 1_000,
+    });
+    fail = true;
+
+    const expired = await aggregateRemoteSessions({
+      registry,
+      nodeLinks,
+      readModelCache,
+      readModelCacheTtlMs: 500,
+      now: () => 2_000,
+    });
+
+    expect(expired).toEqual([]);
+  });
+
+  it('clears cached remote sessions when the owning node no longer has a live link', async () => {
+    const readModelCache = createRemoteSessionReadModelCache();
+    const activeNodeIds = new Set(['node-a']);
+    const { registry, nodeLinks } = buildDeps({
+      nodes: [summary('node-a')],
+      activeNodeIds,
+      requestImpl: async (nodeId) => ({ sessions: [localSession('s-live', nodeId)] }),
+    });
+
+    await aggregateRemoteSessions({ registry, nodeLinks, readModelCache });
+    activeNodeIds.clear();
+
+    const result = await aggregateRemoteSessions({ registry, nodeLinks, readModelCache });
+
+    expect(result).toEqual([]);
+    expect(readModelCache.get('node-a', Date.now(), 60_000)).toBeNull();
   });
 
   it('treats a malformed payload as an empty list rather than throwing', async () => {


### PR DESCRIPTION
## Summary
- adds a short-lived hub-side read-model cache for remote `sessions.list` aggregation
- reuses the last successful per-node remote session list only when the node is still online and has an active reverse link
- keeps typed `NODE_OFFLINE` failures authoritative instead of masking them with cache fallback
- wires the cache through WorkContext active/list/get session reads so routed Mac-node Active Work sessions do not immediately collapse to `stale read model` / `last-known session only` during transient list failures
- adds regression coverage for fallback, TTL expiry, typed offline preservation, and live-link cache clearing

Closes #574

## Motivation
QA for #562 showed a routed Mac-node terminal created through `POST /hub/nodes/:nodeId/sessions` with an existing `workContextId` initially appeared live in `/work-contexts/active`, then the browser/mobile Active Work surface saw only the stale/last-known row and disabled attach/control. The backend aggregation path treated any transient `sessions.list` miss as an authoritative disappearance, even when the node was still online and linked.

## The Case Against
This deliberately keeps a remote session visible for up to 60 seconds after a non-typed/transient `sessions.list` failure. If the session truly ended while the node is online but unable to answer list RPCs, the UI may show it as live briefly until the TTL expires or the next authoritative empty list arrives. That is still preferable to instantly disabling a freshly observed routed session on one transient read-model miss, but it is a tradeoff.

The mitigation is intentionally narrow: cache is per-node, short TTL, cleared for offline/stale/revoked/no-link nodes, not used for typed `NODE_OFFLINE`, and replaced by successful empty lists. It only stores `SessionSummary` shallow copies, not transcripts, raw credentials, PTY output, or node-local process details.

## Verification
- `npm test -- test/hub-session-aggregator.test.ts test/work-context-store.test.ts test/active-work-control.test.ts` — 3 files / 37 tests passed
- `npm run check` — passed with warnings only
- `npm run build` — passed
- `npm test` — 222 files / 2369 tests passed
