### PR TITLE
fix: restrict routed session cache fallback

### DIFF
--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -99,6 +99,7 @@ interface HubNodeSessionTransport {
 
 interface RoutedSessionReadModelCache {
   set(nodeId: string, sessions: SessionSummary[], observedAtMs: number): void;
+  upsert(nodeId: string, session: SessionSummary, observedAtMs: number): void;
 }
 
 export interface RoutedSessionAuditSink {
@@ -2349,7 +2350,7 @@ export function createHubNodeRouter(
         session,
         workContextId
       );
-      options.readModelCache?.set(nodeId, [session], createNow.getTime());
+      options.readModelCache?.upsert(nodeId, session, createNow.getTime());
       res.status(201).json(
         associationError
           ? { ...responseSession, workContextAssociationError: associationError }

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -97,6 +97,10 @@ interface HubNodeSessionTransport {
   ): Promise<{ payload: unknown; close(): void }>;
 }
 
+interface RoutedSessionReadModelCache {
+  set(nodeId: string, sessions: SessionSummary[], observedAtMs: number): void;
+}
+
 export interface RoutedSessionAuditSink {
   append(input: SecurityAuditEntryInput): unknown;
 }
@@ -118,6 +122,7 @@ interface HubNodeRouterOptions {
   confirmations?: ConfirmationChallengeStore;
   auditSink?: RoutedSessionAuditSink;
   workContextStore?: WorkContextStore;
+  readModelCache?: RoutedSessionReadModelCache;
   now?: () => Date;
 }
 
@@ -2344,6 +2349,7 @@ export function createHubNodeRouter(
         session,
         workContextId
       );
+      options.readModelCache?.set(nodeId, [session], createNow.getTime());
       res.status(201).json(
         associationError
           ? { ...responseSession, workContextAssociationError: associationError }

--- a/server/hub-session-aggregator.ts
+++ b/server/hub-session-aggregator.ts
@@ -10,6 +10,7 @@ import {
 import type { SessionSummary } from './types.js';
 import { scopedNodeSession, isSessionSummary } from './hub-node-router.js';
 import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
+import type { RelayNodeErrorCode } from '../shared/relay-node-protocol.js';
 import type { WorkContextStore } from './work-contexts.js';
 
 /**
@@ -34,6 +35,10 @@ export function isLocallyOwnedSession(session: SessionSummary): boolean {
 // browser refresh path and slow nodes must not block the response.
 const PER_NODE_TIMEOUT_MS = 3_000;
 const REMOTE_SESSION_CACHE_TTL_MS = 60_000;
+const CACHEABLE_TYPED_SESSION_LIST_FAILURE_CODES = new Set<RelayNodeErrorCode>([
+  'NODE_BUSY',
+  'INTERNAL',
+]);
 
 export interface RemoteSessionReadModelCache {
   get(nodeId: string, nowMs: number, maxAgeMs: number): SessionSummary[] | null;
@@ -87,9 +92,11 @@ export interface AggregateRemoteSessionsDeps {
  * node with an active reverse link. Returns a flat array of
  * `SessionSummary` stamped with `nodeId`. Per-node failures (offline,
  * RPC timeout, malformed payload) are logged; callers that supply a
- * read-model cache get the last recent successful list for transient
- * failures, otherwise the failed node is dropped. Typed NODE_OFFLINE
- * failures are not masked by the cache. The aggregate never throws.
+ * read-model cache get the last recent successful list for true transient
+ * failures, otherwise the failed node is dropped. Non-cacheable typed
+ * HubNodeLinkError failures such as NODE_OFFLINE, auth/credential errors,
+ * revoked nodes/sessions, version skew, and malformed requests are not masked
+ * by the cache. The aggregate never throws.
  *
  * Offline / stale / revoked nodes are skipped entirely and their cached
  * read model is cleared. Successful empty session lists replace the
@@ -193,10 +200,16 @@ function getCachedSessionsForFailure(
   nowMs: number,
   cacheTtlMs: number
 ): SessionSummary[] | null {
-  if (reason instanceof HubNodeLinkError && reason.relayNodeError.code === 'NODE_OFFLINE') {
+  if (!isCacheableSessionListFailure(reason)) {
     return null;
   }
   return deps.readModelCache?.get(nodeId, nowMs, cacheTtlMs) ?? null;
+}
+
+function isCacheableSessionListFailure(reason: unknown): boolean {
+  if (!(reason instanceof HubNodeLinkError)) return true;
+  const { code, retryable } = reason.relayNodeError;
+  return retryable && CACHEABLE_TYPED_SESSION_LIST_FAILURE_CODES.has(code);
 }
 
 function withWorkContextMetadata(

--- a/server/hub-session-aggregator.ts
+++ b/server/hub-session-aggregator.ts
@@ -43,6 +43,7 @@ const CACHEABLE_TYPED_SESSION_LIST_FAILURE_CODES = new Set<RelayNodeErrorCode>([
 export interface RemoteSessionReadModelCache {
   get(nodeId: string, nowMs: number, maxAgeMs: number): SessionSummary[] | null;
   set(nodeId: string, sessions: SessionSummary[], observedAtMs: number): void;
+  upsert(nodeId: string, session: SessionSummary, observedAtMs: number): void;
   clear(nodeId: string): void;
 }
 
@@ -68,6 +69,22 @@ export function createRemoteSessionReadModelCache(): RemoteSessionReadModelCache
         observedAtMs,
         sessions: sessions.map((session) => ({ ...session })),
       });
+    },
+    upsert(nodeId, session, observedAtMs) {
+      const cached = entries.get(nodeId);
+      const nextSession = { ...session };
+      const sessions = cached
+        ? cached.sessions.map((cachedSession) => ({ ...cachedSession }))
+        : [];
+      const existingIndex = sessions.findIndex(
+        (cachedSession) => cachedSession.id === nextSession.id
+      );
+      if (existingIndex >= 0) {
+        sessions[existingIndex] = nextSession;
+      } else {
+        sessions.push(nextSession);
+      }
+      entries.set(nodeId, { observedAtMs, sessions });
     },
     clear(nodeId) {
       entries.delete(nodeId);

--- a/server/index.ts
+++ b/server/index.ts
@@ -1315,6 +1315,7 @@ async function main(): Promise<void> {
       sessionEnvelopes: sessionEnvelopeRegistry,
       renewLocalSession: localRelayNode.sessions.renew,
       workContextStore,
+      readModelCache: remoteSessionReadModelCache,
       ...(securityAuditLog ? { auditSink: securityAuditLog } : {}),
     })
   );

--- a/test/hub-routed-create-readmodel.test.ts
+++ b/test/hub-routed-create-readmodel.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import express from 'express';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createHubNodeRouter } from '../server/hub-node-router.js';
+import { createHubNodeRouter, scopedNodeSession } from '../server/hub-node-router.js';
 import type { HubNodeLinkManager } from '../server/hub-node-link.js';
 import type { HubNodeRegistry } from '../server/hub-node-registry.js';
 import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
@@ -68,9 +68,12 @@ function nodeSummary(
   };
 }
 
-function remoteSession(): SessionSummary {
+function remoteSession(
+  id = 'remote-session-1',
+  overrides: Partial<SessionSummary> = {}
+): SessionSummary {
   return {
-    id: 'remote-session-1',
+    id,
     type: 'terminal',
     agent: 'claude',
     mode: 'pty',
@@ -79,7 +82,7 @@ function remoteSession(): SessionSummary {
     cwd: '/srv/relay-ide',
     repoName: 'relay-ide',
     branchName: 'nightly',
-    displayName: 'relay-ide terminal',
+    displayName: `${id} terminal`,
     createdAt: NOW.toISOString(),
     lastActivity: NOW.toISOString(),
     idle: false,
@@ -89,6 +92,7 @@ function remoteSession(): SessionSummary {
     status: 'active',
     needsBranchRename: false,
     agentState: 'idle',
+    ...overrides,
   };
 }
 
@@ -104,7 +108,7 @@ describe('routed create remote session read model', () => {
     while (cleanup.length > 0) await cleanup.pop()?.();
   });
 
-  it('keeps a just-created WorkContext session visible through an immediate transient sessions.list failure', async () => {
+  it('merges a just-created WorkContext session into cached remote sessions through an immediate transient sessions.list failure', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-routed-create-readmodel-'));
     const workContextStore: WorkContextStore = createWorkContextStore(
       path.join(tmp, 'work-contexts.db')
@@ -130,7 +134,13 @@ describe('routed create remote session read model', () => {
     const nodeLinks = {
       hasActiveNode: () => true,
       request: vi.fn(async (_nodeId: string, type: string) => {
-        if (type === 'sessions.create') return { session: remoteSession() };
+        if (type === 'sessions.create') {
+          return {
+            session: remoteSession('remote-session-2', {
+              workContextId: 'node-owned-context-must-not-leak',
+            }),
+          };
+        }
         if (type === 'sessions.list') {
           throw new Error('transient sessions.list failure immediately after create');
         }
@@ -139,6 +149,18 @@ describe('routed create remote session read model', () => {
     };
     const sessionEnvelopes = createSessionEnvelopeRegistry();
     const readModelCache = createRemoteSessionReadModelCache();
+    readModelCache.set(
+      node.nodeId,
+      [
+        scopedNodeSession(
+          node.nodeId,
+          remoteSession('remote-session-1', {
+            workContextId: 'node-owned-context-must-not-leak',
+          })
+        ),
+      ],
+      NOW.getTime() - 1_000
+    );
     const app = express();
     app.use(express.json());
     app.use(
@@ -166,7 +188,7 @@ describe('routed create remote session read model', () => {
     expect(created.status).toBe(201);
     const createdSession = (await created.json()) as SessionSummary;
     expect(createdSession).toMatchObject({
-      id: 'remote-session-1',
+      id: 'remote-session-2',
       nodeId: 'node_prod',
       workContextId,
     });
@@ -180,9 +202,22 @@ describe('routed create remote session read model', () => {
       now: () => NOW.getTime() + 100,
     });
 
-    expect(afterTransientFailure).toHaveLength(1);
-    expect(afterTransientFailure[0]).toMatchObject({
+    expect(afterTransientFailure).toHaveLength(2);
+    const sessionsById = new Map(
+      afterTransientFailure.map((session) => [session.id, session])
+    );
+    expect([...sessionsById.keys()].sort()).toEqual([
+      'remote-session-1',
+      'remote-session-2',
+    ]);
+    expect(sessionsById.get('remote-session-1')).toMatchObject({
       id: 'remote-session-1',
+      nodeId: 'node_prod',
+      status: 'active',
+    });
+    expect(sessionsById.get('remote-session-1')?.workContextId).toBeUndefined();
+    expect(sessionsById.get('remote-session-2')).toMatchObject({
+      id: 'remote-session-2',
       nodeId: 'node_prod',
       workContextId,
       status: 'active',

--- a/test/hub-routed-create-readmodel.test.ts
+++ b/test/hub-routed-create-readmodel.test.ts
@@ -1,0 +1,191 @@
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createHubNodeRouter } from '../server/hub-node-router.js';
+import type { HubNodeLinkManager } from '../server/hub-node-link.js';
+import type { HubNodeRegistry } from '../server/hub-node-registry.js';
+import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
+import {
+  aggregateRemoteSessions,
+  createRemoteSessionReadModelCache,
+} from '../server/hub-session-aggregator.js';
+import { createWorkContextStore, type WorkContextStore } from '../server/work-contexts.js';
+import {
+  createLegacyDefaultNodeAcl,
+  summarizeAcl,
+  type RelayCapabilityBit,
+} from '../shared/security-policy.js';
+import type { HubNodeSummary, RelayNodeError } from '../shared/relay-node-protocol.js';
+import type { SessionSummary } from '../server/types.js';
+
+const NOW = new Date('2026-01-02T03:04:05.000Z');
+
+function nodeSummary(
+  allowed: RelayCapabilityBit[] = ['session:read', 'session:create:terminal']
+): HubNodeSummary {
+  const acl = createLegacyDefaultNodeAcl({
+    nodeId: 'node_prod',
+    credentialId: 'cred_prod',
+    trustTier: 'prod',
+    createdAt: NOW.toISOString(),
+  });
+  acl.grants = { allowed, requiresConfirmation: [] };
+  return {
+    nodeId: 'node_prod',
+    displayName: 'prod box',
+    hostname: 'prod.example',
+    platform: 'darwin',
+    arch: 'arm64',
+    relayVersion: '0.1.0-test',
+    protocolVersion: '1.0',
+    status: 'online',
+    connection: { route: 'reverse-link', status: 'connected' },
+    trust: { state: 'active', level: 'prod', tier: 'prod', policy: summarizeAcl(acl) },
+    credentialState: 'active',
+    version: { state: 'compatible', nodeProtocolVersion: '1.0', hubProtocolVersion: '1.0' },
+    capabilities: {
+      totals: { available: 2, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        tmux: 'available',
+        git: 'available',
+        browserAutomation: 'unavailable',
+        clipboardImage: 'unavailable',
+        ssh: 'unavailable',
+        tailscale: 'unavailable',
+      },
+      agents: {},
+      serviceManager: 'launchd',
+      wsl: false,
+    },
+    createdAt: NOW.toISOString(),
+    pairedAt: NOW.toISOString(),
+    lastSeenAt: NOW.toISOString(),
+    credentialId: 'cred_prod',
+  };
+}
+
+function remoteSession(): SessionSummary {
+  return {
+    id: 'remote-session-1',
+    type: 'terminal',
+    agent: 'claude',
+    mode: 'pty',
+    repoPath: '/srv/relay-ide',
+    worktreePath: null,
+    cwd: '/srv/relay-ide',
+    repoName: 'relay-ide',
+    branchName: 'nightly',
+    displayName: 'relay-ide terminal',
+    createdAt: NOW.toISOString(),
+    lastActivity: NOW.toISOString(),
+    idle: false,
+    customCommand: null,
+    useTmux: true,
+    tmuxSessionName: 'relay-ide-remote-session-1',
+    status: 'active',
+    needsBranchRename: false,
+    agentState: 'idle',
+  };
+}
+
+async function listen(server: http.Server): Promise<number> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  return (server.address() as { port: number }).port;
+}
+
+describe('routed create remote session read model', () => {
+  const cleanup: Array<() => void | Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanup.length > 0) await cleanup.pop()?.();
+  });
+
+  it('keeps a just-created WorkContext session visible through an immediate transient sessions.list failure', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-routed-create-readmodel-'));
+    const workContextStore: WorkContextStore = createWorkContextStore(
+      path.join(tmp, 'work-contexts.db')
+    );
+    cleanup.push(() => {
+      workContextStore.close();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    });
+    const workContextId = 'github-issue-574-active-work-live-state';
+    workContextStore.create({ id: workContextId, title: 'Issue #574', source: 'test' });
+
+    const node = nodeSummary();
+    const registry = {
+      listNodes: () => [node],
+      errorBody: (error: unknown) => ({
+        error:
+          error instanceof Error
+            ? ({ code: 'INTERNAL', message: error.message, retryable: false } satisfies RelayNodeError)
+            : ({ code: 'INTERNAL', message: 'unknown error', retryable: false } satisfies RelayNodeError),
+      }),
+      revokeNode: () => node,
+    } as unknown as HubNodeRegistry;
+    const nodeLinks = {
+      hasActiveNode: () => true,
+      request: vi.fn(async (_nodeId: string, type: string) => {
+        if (type === 'sessions.create') return { session: remoteSession() };
+        if (type === 'sessions.list') {
+          throw new Error('transient sessions.list failure immediately after create');
+        }
+        throw new Error(`unexpected ${type}`);
+      }),
+    };
+    const sessionEnvelopes = createSessionEnvelopeRegistry();
+    const readModelCache = createRemoteSessionReadModelCache();
+    const app = express();
+    app.use(express.json());
+    app.use(
+      createHubNodeRouter({
+        registry,
+        nodeLinks,
+        sessionEnvelopes,
+        workContextStore,
+        readModelCache,
+        now: () => NOW,
+        requireAuth: (_req, _res, next) => next(),
+      })
+    );
+    const server = http.createServer(app);
+    cleanup.push(
+      () => new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())))
+    );
+    const base = `http://127.0.0.1:${await listen(server)}`;
+
+    const created = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal', workContextId }),
+    });
+    expect(created.status).toBe(201);
+    const createdSession = (await created.json()) as SessionSummary;
+    expect(createdSession).toMatchObject({
+      id: 'remote-session-1',
+      nodeId: 'node_prod',
+      workContextId,
+    });
+
+    const afterTransientFailure = await aggregateRemoteSessions({
+      registry,
+      nodeLinks: nodeLinks as unknown as HubNodeLinkManager,
+      workContextStore,
+      sessionEnvelopes,
+      readModelCache,
+      now: () => NOW.getTime() + 100,
+    });
+
+    expect(afterTransientFailure).toHaveLength(1);
+    expect(afterTransientFailure[0]).toMatchObject({
+      id: 'remote-session-1',
+      nodeId: 'node_prod',
+      workContextId,
+      status: 'active',
+    });
+  });
+});

--- a/test/hub-session-aggregator.test.ts
+++ b/test/hub-session-aggregator.test.ts
@@ -357,6 +357,42 @@ describe('aggregateRemoteSessions', () => {
     expect(result).toEqual([]);
   });
 
+  it('does not mask non-retryable typed HubNodeLinkError failures with the cached read model', async () => {
+    const readModelCache = createRemoteSessionReadModelCache();
+    let unauthorized = false;
+    const { registry, nodeLinks } = buildDeps({
+      nodes: [summary('node-a')],
+      activeNodeIds: new Set(['node-a']),
+      requestImpl: async (nodeId) => {
+        if (unauthorized) {
+          throw new HubNodeLinkError({
+            code: 'UNAUTHORIZED',
+            message: 'node credential was rejected',
+            retryable: false,
+          });
+        }
+        return { sessions: [localSession('s-live', nodeId)] };
+      },
+    });
+
+    await aggregateRemoteSessions({
+      registry,
+      nodeLinks,
+      readModelCache,
+      now: () => 1_000,
+    });
+    unauthorized = true;
+
+    const result = await aggregateRemoteSessions({
+      registry,
+      nodeLinks,
+      readModelCache,
+      now: () => 2_000,
+    });
+
+    expect(result).toEqual([]);
+  });
+
   it('does not use expired cached remote sessions after a sessions.list failure', async () => {
     const readModelCache = createRemoteSessionReadModelCache();
     let fail = false;


### PR DESCRIPTION
Refs #574.\n\nFollow-up to merged PR #575: restrict the remote sessions read-model cache fallback to cacheable transient sessions.list failures only. Non-retryable typed HubNodeLinkError responses such as UNAUTHORIZED now drop the failed node result instead of returning stale cached live sessions, while the existing NODE_OFFLINE behavior remains intact.\n\nVerification:\n- npm test -- test/hub-session-aggregator.test.ts test/work-context-store.test.ts test/active-work-control.test.ts\n- npm run check\n- npm run build