### PR TITLE
fix: prune deleted node session cache

### DIFF
--- a/server/hub-session-aggregator.ts
+++ b/server/hub-session-aggregator.ts
@@ -45,6 +45,7 @@ export interface RemoteSessionReadModelCache {
   set(nodeId: string, sessions: SessionSummary[], observedAtMs: number): void;
   upsert(nodeId: string, session: SessionSummary, observedAtMs: number): void;
   clear(nodeId: string): void;
+  prune(keepNodeIds: ReadonlySet<string>): void;
 }
 
 interface CachedRemoteSessions {
@@ -88,6 +89,11 @@ export function createRemoteSessionReadModelCache(): RemoteSessionReadModelCache
     },
     clear(nodeId) {
       entries.delete(nodeId);
+    },
+    prune(keepNodeIds) {
+      entries.forEach((_cached, nodeId) => {
+        if (!keepNodeIds.has(nodeId)) entries.delete(nodeId);
+      });
     },
   };
 }
@@ -136,9 +142,7 @@ export async function aggregateRemoteSessions(
   );
   if (deps.readModelCache) {
     const candidateIds = new Set(candidates.map((node) => node.nodeId));
-    for (const node of nodes) {
-      if (!candidateIds.has(node.nodeId)) deps.readModelCache.clear(node.nodeId);
-    }
+    deps.readModelCache.prune(candidateIds);
   }
 
   if (candidates.length === 0) return [];

--- a/test/hub-session-aggregator.test.ts
+++ b/test/hub-session-aggregator.test.ts
@@ -442,6 +442,28 @@ describe('aggregateRemoteSessions', () => {
     expect(readModelCache.get('node-a', Date.now(), 60_000)).toBeNull();
   });
 
+  it('prunes cached remote sessions when the owning node is removed from the registry', async () => {
+    const readModelCache = createRemoteSessionReadModelCache();
+    readModelCache.set('node-deleted', [localSession('s-stale', 'node-deleted')], 1_000);
+    const requestImpl = vi.fn(async () => ({ sessions: [] }));
+    const { registry, nodeLinks } = buildDeps({
+      nodes: [],
+      activeNodeIds: new Set(),
+      requestImpl,
+    });
+
+    const result = await aggregateRemoteSessions({
+      registry,
+      nodeLinks,
+      readModelCache,
+      now: () => 2_000,
+    });
+
+    expect(result).toEqual([]);
+    expect(requestImpl).not.toHaveBeenCalled();
+    expect(readModelCache.get('node-deleted', 2_000, 60_000)).toBeNull();
+  });
+
   it('treats a malformed payload as an empty list rather than throwing', async () => {
     const { registry, nodeLinks } = buildDeps({
       nodes: [summary('node-a')],


### PR DESCRIPTION
## Summary
- Add `RemoteSessionReadModelCache.prune(keepNodeIds)` to remove cache entries for nodes no longer present in the hub registry.
- Call prune during remote session aggregation before candidate filtering, while preserving the existing no-live-link/offline cache clearing and typed `NODE_OFFLINE` no-fallback behavior.
- Add regression coverage for a deleted registry node leaving behind a stale cached read model.

## Motivation
PR #575 added a bounded read-model cache for transient remote session list failures. That cache already avoided serving deleted nodes because aggregation only iterates current candidates, but stale entries for removed registry nodes could remain in memory until restart. This is bounded-memory hygiene for #574 follow-up review feedback.

Refs #574.

## The Case Against
This change might be wrong if callers expected the cache to retain entries for nodes removed from the registry and later re-added with the same node id. That would be spooky and probably wrong: registry removal is the ownership boundary, and re-pair/re-add should rebuild authoritative session state from the node rather than resurrect stale hub memory.

## Risks & Mitigation
| Risk | Likelihood | Mitigation |
| --- | --- | --- |
| Accidentally changes transient-fallback behavior for online candidates | Low | Prune keeps all current registry node ids; existing fallback path and `NODE_OFFLINE` handling are unchanged. |
| Missing explicit cleanup for offline/stale/revoked nodes | Low | Existing per-node `clear()` loop remains after prune. |
| Cache mutation while iterating | Low | `Map.forEach` deletes only current stale entries and tests cover the removed-node path. |

## Verification
- `npm test -- test/hub-session-aggregator.test.ts` — 20 passed
- `npm run check` — passed; existing lint warnings only, 0 errors
