### PR TITLE
docs: add devbox hub deploy runbook

### DIFF
--- a/docs/FEDERATED_DEV.md
+++ b/docs/FEDERATED_DEV.md
@@ -11,6 +11,12 @@ documented in [`RELAY_NODE_BOOTSTRAP.md`](./RELAY_NODE_BOOTSTRAP.md) and
 are the production shape. Federated dev uses the same package, different
 source.
 
+For the shared dogfood topology and operator proof loop, see the
+[`devbox hub deploy runbook`](./references/devbox-hub-deploy.md). It covers
+when local/self-host evidence is enough, when devbox hub proof is required,
+how to restart the Mac node link, and how to clean stale local processes
+without killing the wrong Relay service.
+
 ## TL;DR
 
 - One package: `relay-ide`. Hub vs node is a subcommand role, not a separate
@@ -166,6 +172,9 @@ dist-tag.
 
 - [`SELF_HOSTING.md`](./SELF_HOSTING.md) — single-machine self-host (Relay
   inside Relay).
+- [`references/devbox-hub-deploy.md`](./references/devbox-hub-deploy.md) —
+  devbox hub deploy, Mac node-link restart, verification evidence, and safe
+  process cleanup.
 - [`RELAY_NODE_BOOTSTRAP.md`](./RELAY_NODE_BOOTSTRAP.md) — pair / install /
   doctor flows for nodes (npm-installed shape).
 - [`RELAY_HUB_NODE_PACKAGING.md`](./RELAY_HUB_NODE_PACKAGING.md) — packaging

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,25 +4,26 @@ This index separates current source-of-truth docs from historical plans and spik
 
 ## Current source of truth
 
-| Area                  | File                          | Use it for                                                             |
-| --------------------- | ----------------------------- | ---------------------------------------------------------------------- |
-| Top-level agent map   | `../AGENTS.md`                | Repo conventions, command quick reference, compact docs map            |
-| User onboarding       | `../README.md`                | Install, run, CLI, config, hub/node overview                           |
-| Product/design system | `../DESIGN.md`                | Product positioning, visual language, spacing/color/button rules       |
-| Architecture          | `ARCHITECTURE.md`             | Module boundaries, API routes, data flow, ADR index                    |
-| Workbench boundary    | `WORKBENCH_BOUNDARY.md`       | Relay-as-control-plane scope, canonical nouns, mobile/dogfood journeys |
-| Backend design notes  | `DESIGN.md`                   | Backend patterns, auth/session/PTY behavior                            |
-| Frontend              | `FRONTEND.md`                 | React components, frontend state, UI entrypoints                       |
-| Quality               | `QUALITY.md`                  | Test strategy, isolation rules, known gate behavior                    |
-| Review                | `REVIEW_GUIDANCE.md`          | Reviewer prompts, risk areas, escape log                               |
-| Deployment            | `references/deployment.md`    | Branching, npm channels, publishing flow                               |
-| Self-hosting          | `SELF_HOSTING.md`             | Running Relay from inside Relay with isolated config/ports             |
-| Security policy       | `SECURITY_POLICY.md`          | Trust tiers, capability bits, hub ACL defaults                         |
-| Hub/node packaging    | `RELAY_HUB_NODE_PACKAGING.md` | Hub/node command shape and npm packaging decisions                     |
-| Node bootstrap        | `RELAY_NODE_BOOTSTRAP.md`     | Pair/install/update/unpair flows and diagnostics                       |
-| Federated dev         | `FEDERATED_DEV.md`            | Multi-machine dev workflow and version-skew handling                   |
-| Federated Relay       | `federated-relay.md`          | Hub/node architecture, pairing, routing, ADR history                   |
-| Learnings             | `LEARNINGS.md`                | Durable repo learnings gathered across sessions                        |
+| Area                  | File                              | Use it for                                                                              |
+| --------------------- | --------------------------------- | --------------------------------------------------------------------------------------- |
+| Top-level agent map   | `../AGENTS.md`                    | Repo conventions, command quick reference, compact docs map                             |
+| User onboarding       | `../README.md`                    | Install, run, CLI, config, hub/node overview                                            |
+| Product/design system | `../DESIGN.md`                    | Product positioning, visual language, spacing/color/button rules                        |
+| Architecture          | `ARCHITECTURE.md`                 | Module boundaries, API routes, data flow, ADR index                                     |
+| Workbench boundary    | `WORKBENCH_BOUNDARY.md`           | Relay-as-control-plane scope, canonical nouns, mobile/dogfood journeys                  |
+| Backend design notes  | `DESIGN.md`                       | Backend patterns, auth/session/PTY behavior                                             |
+| Frontend              | `FRONTEND.md`                     | React components, frontend state, UI entrypoints                                        |
+| Quality               | `QUALITY.md`                      | Test strategy, isolation rules, known gate behavior                                     |
+| Review                | `REVIEW_GUIDANCE.md`              | Reviewer prompts, risk areas, escape log                                                |
+| Deployment            | `references/deployment.md`        | Branching, npm channels, publishing flow                                                |
+| Devbox deploy         | `references/devbox-hub-deploy.md` | Shared devbox hub deploy, Mac node-link restart, verification evidence, process hygiene |
+| Self-hosting          | `SELF_HOSTING.md`                 | Running Relay from inside Relay with isolated config/ports                              |
+| Security policy       | `SECURITY_POLICY.md`              | Trust tiers, capability bits, hub ACL defaults                                          |
+| Hub/node packaging    | `RELAY_HUB_NODE_PACKAGING.md`     | Hub/node command shape and npm packaging decisions                                      |
+| Node bootstrap        | `RELAY_NODE_BOOTSTRAP.md`         | Pair/install/update/unpair flows and diagnostics                                        |
+| Federated dev         | `FEDERATED_DEV.md`                | Multi-machine dev workflow and version-skew handling                                    |
+| Federated Relay       | `federated-relay.md`              | Hub/node architecture, pairing, routing, ADR history                                    |
+| Learnings             | `LEARNINGS.md`                    | Durable repo learnings gathered across sessions                                         |
 
 ## Vocabulary baseline
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -2,6 +2,11 @@
 
 Use this runbook when developing Relay IDE from inside an already-running Relay IDE instance. The goal is to run the source checkout with isolated config, ports, and tmux sessions so it does not collide with the installed/global daemon that is hosting your work.
 
+Self-host mode proves local source behavior only. When a change needs proof on
+the shared devbox hub or the `macbook-relay-node` link, use the
+[`devbox hub deploy runbook`](./references/devbox-hub-deploy.md) instead of
+treating a local self-host run as federated evidence.
+
 ## Recommended loop
 
 Start from a real Relay worktree, not the main checkout:

--- a/docs/references/devbox-hub-deploy.md
+++ b/docs/references/devbox-hub-deploy.md
@@ -100,38 +100,37 @@ relay-ide node link --hub <devbox-hub-url>
 
 `relay-ide node link` is the persistent reverse WebSocket used for routed sessions. `relay-ide node connect` and `relay-ide node install` are bootstrap steps; they do not by themselves prove routed sessions are available.
 
-If the node link is supervised by launchd or another wrapper, restart that exact wrapper. On macOS, first inspect the Relay label before touching it:
+If the node link is supervised by launchd or another wrapper, restart that exact wrapper. On macOS, first inspect the Relay label before touching it; prefer `kickstart -k` over a manual stop/start because `KeepAlive` agents can immediately restart between commands:
 
 ```bash
 relay-ide node status
 launchctl print gui/$(id -u)/com.relay-ide
-launchctl stop com.relay-ide
-launchctl start com.relay-ide
+launchctl kickstart -k gui/$(id -u)/com.relay-ide
 relay-ide node logs
 ```
 
 ## Verification checklist
 
-Run the applicable checks and record redacted evidence.
+Run the applicable checks and record redacted evidence. Run service-manager and package-version commands on the host being verified: use SSH for devbox hub service checks, and run Mac launchd/node-link checks on the Mac. Remote HTTP health can be checked from any trusted operator machine. If you run hub CLI checks locally against the devbox instead of over SSH, pass the devbox hub URL through the supported CLI flag/env for that command rather than accidentally querying a local Relay daemon.
 
 ### Hub health and version
 
 ```bash
 DEVBOX_HUB=http://100.77.36.51:3456
 curl -fsS "$DEVBOX_HUB/health"
-relay-ide --version
-relay-ide hub status
-relay-ide hub doctor
+ssh dev 'relay-ide --version'
+ssh dev 'systemctl --user status relay-ide --no-pager'
+ssh dev 'relay-ide hub doctor'
 ```
 
-`/health` is unauthenticated and should return `{"status":"ok"}`. `hub doctor` may require the local scoped CLI/browser token for authenticated hub checks; do not paste that token or any auth-bearing URL.
+`/health` is unauthenticated and should return `{"status":"ok"}`. `hub doctor` may require the scoped CLI/browser token available in the target environment for authenticated hub checks; do not paste that token or any auth-bearing URL.
 
 ### Node registry and protocol state
 
 ```bash
-relay-ide hub nodes
-relay-ide hub nodes --json
-relay-ide hub doctor
+ssh dev 'relay-ide hub nodes'
+ssh dev 'relay-ide hub nodes --json'
+ssh dev 'relay-ide hub doctor'
 ```
 
 Confirm `macbook-relay-node` is online/current and protocol-compatible. If `VERSION_SKEW` or `PROTOCOL_INCOMPATIBLE` appears, update both hub and node to the same source SHA or package channel before debugging higher-level behavior.
@@ -207,13 +206,13 @@ Devbox deploy evidence for <PR/issue>:
 
 - Scope: <local/self-host/devbox source/nightly package; hub-only/node-only/protocol>
 - Hub host: dev / 100.77.36.51:3456
-- Hub deploy path: <source SHA + branch OR relay-ide@nightly version>
+- Hub deploy path: <source branch + Git SHA OR relay-ide@nightly version>
 - Hub restart: <command run; status/log result>
 - Hub health: `curl /health` -> <status/body>
-- Hub version: `relay-ide --version` -> <redacted output>
+- Hub version: `relay-ide --version` -> <version and source SHA if available>
 - Hub doctor: <pass/fail summary; include typed failure names only>
 - Node update/restart: <not required OR command run + reason>
-- Node version: <Mac `relay-ide --version` output if checked>
+- Node version: <Mac `relay-ide --version` output, including source SHA if available>
 - Node registry: `macbook-relay-node` <online/stale/offline>, protocol <compatible/skew/incompatible>
 - Routed session proof: <safe command + where it ran; no secrets>
 - Process hygiene: <listeners/tmux checked; stale PID/session killed or none found>

--- a/docs/references/devbox-hub-deploy.md
+++ b/docs/references/devbox-hub-deploy.md
@@ -1,0 +1,228 @@
+# Devbox hub deploy and process hygiene runbook
+
+Use this when a Relay change needs proof on the shared dogfood topology: the devbox hub on `dev` (`100.77.36.51:3456`) with the Mac node `macbook-relay-node` linked back to it. Use placeholders for auth-bearing values in public comments; never paste pair tokens, bearer tokens, cookies, node credentials, or private auth URLs.
+
+This runbook is an operator checklist, not a live-deploy transcript. Only claim a command in an issue or PR comment after you ran it.
+
+## Decision tree
+
+| Need                                                  | Use                                                                                                              | Devbox proof required? |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| Type/lint/unit confidence only                        | Local worktree: `npm run check`, targeted `npm test -- <files>`, `npm run build` when relevant                   | No                     |
+| Local source behavior without touching shared dogfood | `npm run dev:self` from an isolated worktree; open the printed self-host frontend URL                            | No                     |
+| Hub-only dogfood behavior                             | Source deploy/restart on the devbox hub; Mac node can keep running if the node/protocol surface did not change   | Yes                    |
+| Node-only behavior on the Mac                         | Update/restart the Mac `relay-ide node link`; hub can keep running if the hub/protocol surface did not change    | Yes                    |
+| Protocol or shared hub/node envelope change           | Update hub and every affected node from the same source SHA or published package version before testing          | Yes                    |
+| Post-merge package validation                         | Install/update `relay-ide@nightly`, restart the service, then verify package version and routed session behavior | Yes                    |
+
+Prefer the cheapest path that proves the claim. Do not use a local self-host run as evidence that the devbox hub works; it proves only the local isolated instance.
+
+## Source deploy to the devbox hub
+
+Use source mode when testing an unmerged branch or a PR head before `nightly` publishes it.
+
+1. SSH to the devbox and enter the Relay checkout that backs the service:
+
+   ```bash
+   ssh dev
+   cd /path/to/relay-ide
+   git status --short --branch
+   ```
+
+2. Move to the exact branch or SHA under test:
+
+   ```bash
+   git fetch origin
+   git checkout <branch-or-sha>
+   git pull --ff-only origin <branch>   # branch only; skip for detached SHA
+   ```
+
+3. Rebuild and relink the global binary to this checkout:
+
+   ```bash
+   scripts/dev-resync.sh
+   relay-ide --version
+   ```
+
+   `relay-ide --version` should include the source short SHA. If it says only the package version, the global command is still resolving to an npm install instead of the source checkout.
+
+4. Restart the hub service through the platform manager used on that host:
+
+   ```bash
+   relay-ide hub status
+   systemctl --user restart relay-ide
+   relay-ide hub status
+   relay-ide hub logs --lines 80
+   ```
+
+   If the devbox is not using systemd-user, use the manager reported by `relay-ide hub status`. Do not uninstall/reinstall just to restart unless the service file itself is wrong.
+
+## Nightly/package deploy to the devbox hub
+
+Use package mode after the PR has merged to `nightly` and the publish workflow has produced `relay-ide@nightly`.
+
+```bash
+ssh dev
+npm install -g relay-ide@nightly
+relay-ide --version
+relay-ide hub status
+systemctl --user restart relay-ide
+relay-ide hub status
+relay-ide hub logs --lines 80
+```
+
+`relay-ide update` is also valid when the devbox config already has the desired update channel; it updates the global package and restarts a detected service without re-pairing nodes.
+
+## Mac node-link update/restart
+
+Restart the Mac node link when node-side code changed, the protocol version changed, or hub verification reports `macbook-relay-node` as offline, stale, or incompatible. A hub-only UI/routing change does not require a node restart.
+
+For source testing on the Mac node checkout:
+
+```bash
+cd /path/to/relay-ide
+scripts/dev-resync.sh
+relay-ide --version
+relay-ide node status
+relay-ide node doctor --hub <devbox-hub-url>
+relay-ide node link --hub <devbox-hub-url>
+```
+
+For package testing after `nightly` publishes:
+
+```bash
+npm install -g relay-ide@nightly
+relay-ide --version
+relay-ide node status
+relay-ide node doctor --hub <devbox-hub-url>
+relay-ide node link --hub <devbox-hub-url>
+```
+
+`relay-ide node link` is the persistent reverse WebSocket used for routed sessions. `relay-ide node connect` and `relay-ide node install` are bootstrap steps; they do not by themselves prove routed sessions are available.
+
+If the node link is supervised by launchd or another wrapper, restart that exact wrapper. On macOS, first inspect the Relay label before touching it:
+
+```bash
+relay-ide node status
+launchctl print gui/$(id -u)/com.relay-ide
+launchctl stop com.relay-ide
+launchctl start com.relay-ide
+relay-ide node logs
+```
+
+## Verification checklist
+
+Run the applicable checks and record redacted evidence.
+
+### Hub health and version
+
+```bash
+DEVBOX_HUB=http://100.77.36.51:3456
+curl -fsS "$DEVBOX_HUB/health"
+relay-ide --version
+relay-ide hub status
+relay-ide hub doctor
+```
+
+`/health` is unauthenticated and should return `{"status":"ok"}`. `hub doctor` may require the local scoped CLI/browser token for authenticated hub checks; do not paste that token or any auth-bearing URL.
+
+### Node registry and protocol state
+
+```bash
+relay-ide hub nodes
+relay-ide hub nodes --json
+relay-ide hub doctor
+```
+
+Confirm `macbook-relay-node` is online/current and protocol-compatible. If `VERSION_SKEW` or `PROTOCOL_INCOMPATIBLE` appears, update both hub and node to the same source SHA or package channel before debugging higher-level behavior.
+
+### Routed session proof
+
+Use a safe remote terminal/session through the hub UI or CLI path that targets `macbook-relay-node`. The proof should show:
+
+- the session is anchored to `macbook-relay-node`, not the local laptop hub;
+- `pwd` or another harmless command runs on the expected node host;
+- no secrets, private file contents, pair tokens, bearer tokens, or cookies appear in the captured output.
+
+## Process hygiene
+
+Stale local processes can make a devbox test look local-only. Identify before killing. Kill only a specific PID or tmux session after confirming its command, cwd, port, and role.
+
+### Roles to distinguish
+
+| Role                    | Typical signal                                                                                                                             | Safe action                                                                              |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Production/global hub   | `relay-ide hub` or `node dist/server/index.js` on `0.0.0.0:3456`, config under `~/.config/relay-ide/config.json`, tmux prefix `relay-ide-` | Do not kill unless you intend to stop the hosted Relay service                           |
+| Ordinary source dev hub | backend `127.0.0.1:3457`, Vite `127.0.0.1:5173`, config `./config.dev.json`, tmux prefix `relay-dev-`                                      | Stop the owning dev terminal, or kill the verified stale PID                             |
+| Self-host source hub    | allocator ports usually `10000-11999`, config under `~/.config/relay-ide/self-host/`, tmux prefix `relay-self-`                            | Stop the owning self-host terminal, or kill only the verified stale PID/session          |
+| Vite frontend           | `vite --config frontend/vite.config.ts` on the printed frontend port                                                                       | Kill only if it belongs to the stale self-host/dev run                                   |
+| Node link               | `relay-ide node link --hub ...`                                                                                                            | Do not kill during federated proof unless you are intentionally restarting the node link |
+| Test/fixture server     | Playwright/Vitest or sandbox command, often temporary port                                                                                 | Let the test own it unless it is orphaned and verified stale                             |
+
+### Inspect listeners and commands
+
+```bash
+lsof -nP -iTCP:3456 -sTCP:LISTEN
+lsof -nP -iTCP:3457 -sTCP:LISTEN
+lsof -nP -iTCP:5173 -sTCP:LISTEN
+ps -p <pid> -o pid,ppid,lstart,command
+lsof -p <pid> | grep cwd
+```
+
+For self-host ports, use the startup output or `.env` managed block to identify the assigned ports, then inspect those ports with `lsof`.
+
+### Inspect Relay tmux sessions
+
+```bash
+tmux ls | grep '^relay-ide-\|^relay-dev-\|^relay-self-'
+tmux display-message -p -t <session-name> '#S #{session_created_string}'
+```
+
+Kill only the session you have identified:
+
+```bash
+tmux kill-session -t <session-name>
+```
+
+Never use `tmux kill-server` as a cleanup shortcut. It can kill production Relay sessions and active agent work.
+
+### Kill a stale PID safely
+
+```bash
+ps -p <pid> -o pid,ppid,lstart,command
+lsof -p <pid> | grep cwd
+kill <pid>
+sleep 2
+ps -p <pid> -o pid,ppid,command || true
+```
+
+Escalate to `kill -KILL <pid>` only after the normal `SIGTERM` fails and you have rechecked that the PID has not been reused. Avoid `killall node`, broad `pkill -f relay-ide`, and broad process-name cleanup; they are how you murder the wrong fish in the tank.
+
+## Evidence template
+
+Paste a compact version into the PR or issue after deploy. Delete sections you did not run.
+
+```markdown
+Devbox deploy evidence for <PR/issue>:
+
+- Scope: <local/self-host/devbox source/nightly package; hub-only/node-only/protocol>
+- Hub host: dev / 100.77.36.51:3456
+- Hub deploy path: <source SHA + branch OR relay-ide@nightly version>
+- Hub restart: <command run; status/log result>
+- Hub health: `curl /health` -> <status/body>
+- Hub version: `relay-ide --version` -> <redacted output>
+- Hub doctor: <pass/fail summary; include typed failure names only>
+- Node update/restart: <not required OR command run + reason>
+- Node version: <Mac `relay-ide --version` output if checked>
+- Node registry: `macbook-relay-node` <online/stale/offline>, protocol <compatible/skew/incompatible>
+- Routed session proof: <safe command + where it ran; no secrets>
+- Process hygiene: <listeners/tmux checked; stale PID/session killed or none found>
+- Redaction: no pair tokens, bearer tokens, cookies, node credentials, or auth-bearing URLs included
+```
+
+## See also
+
+- [`../FEDERATED_DEV.md`](../FEDERATED_DEV.md) — source dev across hub/node checkouts and protocol skew handling.
+- [`../SELF_HOSTING.md`](../SELF_HOSTING.md) — isolated local self-host mode for testing Relay inside Relay.
+- [`../RELAY_NODE_BOOTSTRAP.md`](../RELAY_NODE_BOOTSTRAP.md) — node pairing, persistent node link, status, logs, and diagnostics.
+- [`deployment.md`](./deployment.md) — branch model, `@nightly` publish flow, and release verification.


### PR DESCRIPTION
## Summary
- Add `docs/references/devbox-hub-deploy.md`, a checked-in operator runbook for the devbox hub + `macbook-relay-node` dogfood topology.
- Link it from `docs/FEDERATED_DEV.md`, `docs/SELF_HOSTING.md`, and the docs index.
- Cover decision tree, source vs nightly deploy paths, hub/node restart and verification, safe process cleanup, and a copy/paste evidence template.

## The Case Against
- This documents operational commands for a specific dogfood topology, so it can drift if the devbox service manager or node supervision changes.
- The runbook intentionally avoids real secrets and auth-bearing URLs, so operators still need their local auth context for `hub doctor` / node-registry checks.
- I did not perform a live devbox deploy; this is a docs-only runbook based on the existing CLI/docs/code surfaces and issue acceptance criteria.

## Verification
- `npx prettier --write docs/references/devbox-hub-deploy.md docs/FEDERATED_DEV.md docs/SELF_HOSTING.md docs/README.md`
- Markdown link/path sanity script over changed docs: pass
- Secret-like scan over changed docs: pass
- `npm run check` passes with 0 errors / 65 existing warnings

Closes #578


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive deployment runbook documenting workflow and process validation procedures.
  * Updated development and self-hosting guides with deployment procedure references.
  * Clarified distinctions between local testing and shared infrastructure validation requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/579?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->