### PR TITLE
fix: keep routed active work live after create

### DIFF
--- a/server/hub-session-aggregator.ts
+++ b/server/hub-session-aggregator.ts
@@ -35,6 +35,10 @@ export function isLocallyOwnedSession(session: SessionSummary): boolean {
 // browser refresh path and slow nodes must not block the response.
 const PER_NODE_TIMEOUT_MS = 3_000;
 const REMOTE_SESSION_CACHE_TTL_MS = 60_000;
+// A routed create can return before the owning node's sessions.list read model
+// has caught up. Keep that hub-observed session attachable briefly, but let a
+// later authoritative empty list prune it so ended sessions do not linger.
+const OPTIMISTIC_ROUTED_CREATE_GRACE_MS = 10_000;
 const CACHEABLE_TYPED_SESSION_LIST_FAILURE_CODES = new Set<RelayNodeErrorCode>([
   'NODE_BUSY',
   'INTERNAL',
@@ -51,6 +55,7 @@ export interface RemoteSessionReadModelCache {
 interface CachedRemoteSessions {
   observedAtMs: number;
   sessions: SessionSummary[];
+  optimisticUpsertedAtById: Map<string, number>;
 }
 
 export function createRemoteSessionReadModelCache(): RemoteSessionReadModelCache {
@@ -66,9 +71,28 @@ export function createRemoteSessionReadModelCache(): RemoteSessionReadModelCache
       return cached.sessions.map((session) => ({ ...session }));
     },
     set(nodeId, sessions, observedAtMs) {
+      const cached = entries.get(nodeId);
+      const nextSessions = sessions.map((session) => ({ ...session }));
+      const nextSessionIds = new Set(nextSessions.map((session) => session.id));
+      const optimisticUpsertedAtById = new Map<string, number>();
+      if (cached) {
+        cached.optimisticUpsertedAtById.forEach((upsertedAtMs, sessionId) => {
+          if (nextSessionIds.has(sessionId)) return;
+          if (observedAtMs - upsertedAtMs > OPTIMISTIC_ROUTED_CREATE_GRACE_MS) {
+            return;
+          }
+          const optimisticSession = cached.sessions.find(
+            (session) => session.id === sessionId
+          );
+          if (!optimisticSession) return;
+          nextSessions.push({ ...optimisticSession });
+          optimisticUpsertedAtById.set(sessionId, upsertedAtMs);
+        });
+      }
       entries.set(nodeId, {
         observedAtMs,
-        sessions: sessions.map((session) => ({ ...session })),
+        sessions: nextSessions,
+        optimisticUpsertedAtById,
       });
     },
     upsert(nodeId, session, observedAtMs) {
@@ -85,7 +109,11 @@ export function createRemoteSessionReadModelCache(): RemoteSessionReadModelCache
       } else {
         sessions.push(nextSession);
       }
-      entries.set(nodeId, { observedAtMs, sessions });
+      const optimisticUpsertedAtById = new Map(
+        cached?.optimisticUpsertedAtById ?? []
+      );
+      optimisticUpsertedAtById.set(nextSession.id, observedAtMs);
+      entries.set(nodeId, { observedAtMs, sessions, optimisticUpsertedAtById });
     },
     clear(nodeId) {
       entries.delete(nodeId);
@@ -196,8 +224,10 @@ export async function aggregateRemoteSessions(
       scopedSessions.push({ ...scoped, sessionEnvelope });
     }
     deps.readModelCache?.set(candidate.nodeId, scopedSessions, nowMs);
+    const sessionsForAggregate =
+      deps.readModelCache?.get(candidate.nodeId, nowMs, cacheTtlMs) ?? scopedSessions;
     aggregated.push(
-      ...scopedSessions.map((session) =>
+      ...sessionsForAggregate.map((session) =>
         withWorkContextMetadata(deps.workContextStore, session)
       )
     );

--- a/test/hub-routed-create-readmodel.test.ts
+++ b/test/hub-routed-create-readmodel.test.ts
@@ -223,4 +223,102 @@ describe('routed create remote session read model', () => {
       status: 'active',
     });
   });
+
+  it('keeps a freshly routed WorkContext session live through an immediate empty sessions.list read model', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-routed-create-empty-list-'));
+    const workContextStore: WorkContextStore = createWorkContextStore(
+      path.join(tmp, 'work-contexts.db')
+    );
+    cleanup.push(() => {
+      workContextStore.close();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    });
+    const workContextId = 'github-issue-580-active-work-routed-session';
+    workContextStore.create({ id: workContextId, title: 'Issue #580', source: 'test' });
+
+    const node = nodeSummary();
+    const registry = {
+      listNodes: () => [node],
+      errorBody: (error: unknown) => ({
+        error:
+          error instanceof Error
+            ? ({ code: 'INTERNAL', message: error.message, retryable: false } satisfies RelayNodeError)
+            : ({ code: 'INTERNAL', message: 'unknown error', retryable: false } satisfies RelayNodeError),
+      }),
+      revokeNode: () => node,
+    } as unknown as HubNodeRegistry;
+    const nodeLinks = {
+      hasActiveNode: () => true,
+      request: vi.fn(async (_nodeId: string, type: string) => {
+        if (type === 'sessions.create') {
+          return { session: remoteSession('remote-session-580') };
+        }
+        if (type === 'sessions.list') {
+          return { sessions: [] };
+        }
+        throw new Error(`unexpected ${type}`);
+      }),
+    };
+    const sessionEnvelopes = createSessionEnvelopeRegistry();
+    const readModelCache = createRemoteSessionReadModelCache();
+    const app = express();
+    app.use(express.json());
+    app.use(
+      createHubNodeRouter({
+        registry,
+        nodeLinks,
+        sessionEnvelopes,
+        workContextStore,
+        readModelCache,
+        now: () => NOW,
+        requireAuth: (_req, _res, next) => next(),
+      })
+    );
+    const server = http.createServer(app);
+    cleanup.push(
+      () => new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())))
+    );
+    const base = `http://127.0.0.1:${await listen(server)}`;
+
+    const created = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ repoPath: '/srv/relay-ide', type: 'terminal', workContextId }),
+    });
+    expect(created.status).toBe(201);
+    expect(await created.json()).toMatchObject({
+      id: 'remote-session-580',
+      nodeId: 'node_prod',
+      workContextId,
+    });
+
+    const sessions = await aggregateRemoteSessions({
+      registry,
+      nodeLinks: nodeLinks as unknown as HubNodeLinkManager,
+      workContextStore,
+      sessionEnvelopes,
+      readModelCache,
+      now: () => NOW.getTime() + 100,
+    });
+    const groups = workContextStore.listActiveWork({ sessions, nodes: [node] });
+    const group = groups.find((candidate) => candidate.id === workContextId);
+
+    expect(group).toBeDefined();
+    expect(group).toMatchObject({ staleReadModel: false });
+    expect(group?.sessions[0]).toMatchObject({
+      id: 'remote-session-580',
+      nodeId: 'node_prod',
+      live: true,
+    });
+
+    const afterGrace = await aggregateRemoteSessions({
+      registry,
+      nodeLinks: nodeLinks as unknown as HubNodeLinkManager,
+      workContextStore,
+      sessionEnvelopes,
+      readModelCache,
+      now: () => NOW.getTime() + 11_000,
+    });
+    expect(afterGrace).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- Keeps freshly routed WorkContext sessions visible as live Active Work during the short window before the remote node's `sessions.list` read model catches up.
- Tracks optimistic routed-create cache entries separately and preserves them for a 10s grace period across an immediate authoritative-but-empty list response.
- Adds regression coverage for the #580 browser/mobile stale-read-model failure path, including proof that the optimistic entry is pruned after the grace window.

## Motivation
QA for #562 showed the API setup path returning `staleReadModel:false` / `live:true`, while the browser/mobile Active Work path immediately saw the same routed Mac session as stale and disabled attach/send/kill as "last-known session only". The hub had observed the routed create, but the next aggregate call trusted an empty remote read model before the node list had caught up.

Fixes #580
Refs #562

## The Case Against
This change deliberately keeps a hub-observed routed-create session alive even if an immediate `sessions.list` response from the node is empty. That could be wrong if the node creates and destroys the session inside the grace window, because Active Work may treat it as attachable briefly.

Why this is bounded:
- the grace window is only 10s, not the normal 60s transient-failure read-model TTL
- typed offline / unauthorized failures are still not masked by the cache fallback
- a later empty list after the grace window prunes the optimistic session
- existing cache pruning for deleted/offline nodes remains in place

## Verification
- `npm test -- test/hub-routed-create-readmodel.test.ts` — 2/2 passed
- `npm test -- test/hub-routed-create-readmodel.test.ts test/hub-session-aggregator.test.ts test/hub-confirmation-routing.test.ts` — 31/31 passed
- `npm run check` — passed, existing lint warnings only
- `npm run build` — passed, existing Vite chunk-size warning only
- `npm test` — 223 files / 2373 tests passed
