### PR TITLE
Fix routed Active Work live controls

### DIFF
--- a/frontend/src/components/ActiveWorkSurface.tsx
+++ b/frontend/src/components/ActiveWorkSurface.tsx
@@ -1,4 +1,11 @@
-import { useMemo, useCallback, useRef, useState, type FormEvent } from 'react';
+import {
+  useMemo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type FormEvent,
+} from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
 import type {
@@ -8,10 +15,10 @@ import type {
 import { fetchActiveWork, sendSessionInput } from '../lib/api.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
-import { scopedSessionKey } from '../lib/session-keys.js';
 import {
   activeWorkAttentionPriority,
   activeWorkMobileControlState,
+  activeWorkSessionActivationKey,
   activeWorkStateLabel,
 } from '../lib/active-work-control.js';
 import { TuiButton } from './TuiButton.js';
@@ -164,7 +171,7 @@ function sessionMeta(
 
 function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
   const queryClient = useQueryClient();
-  const sessions = useSessionsStore((s) => s.sessions);
+  const refreshAll = useSessionsStore((s) => s.refreshAll);
   const setActiveSessionId = useSessionsStore((s) => s.setActiveSessionId);
   const setActiveRepoPath = useUiStore((s) => s.setActiveRepoPath);
   const [inputValue, setInputValue] = useState('');
@@ -187,23 +194,16 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
 
   const handleAttach = useCallback(() => {
     if (!primarySession || controlState.attachDisabledReason) return;
-    const live = sessions.find(
-      (session) =>
-        session.id === primarySession.id &&
-        (session.nodeId ?? DEFAULT_LOCAL_NODE_ID) === primarySession.nodeId
-    );
+    const activationKey = activeWorkSessionActivationKey(primarySession);
     const nodeId = primarySession.nodeId ?? DEFAULT_LOCAL_NODE_ID;
     const isLocal = nodeId === DEFAULT_LOCAL_NODE_ID;
     setActiveRepoPath(isLocal ? (primarySession.repoPath ?? null) : null);
-    setActiveSessionId(
-      live
-        ? scopedSessionKey(live)
-        : (primarySession.globalSessionId ?? primarySession.id)
-    );
+    setActiveSessionId(activationKey);
+    void refreshAll().then(() => setActiveSessionId(activationKey));
   }, [
     controlState.attachDisabledReason,
     primarySession,
-    sessions,
+    refreshAll,
     setActiveRepoPath,
     setActiveSessionId,
   ]);
@@ -224,7 +224,11 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
       setIsSubmittingInput(true);
       setInputStatus('sending...');
       try {
-        await sendSessionInput(primarySession.id, `${value}\r`);
+        await sendSessionInput(
+          activeWorkSessionActivationKey(primarySession),
+          `${value}\r`,
+          primarySession.nodeId
+        );
         setInputValue('');
         setInputStatus('sent · recorded as control intervention');
         void queryClient.invalidateQueries({ queryKey: ['active-work'] });
@@ -451,6 +455,7 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
 }
 
 export default function ActiveWorkSurface() {
+  const queryClient = useQueryClient();
   const {
     data = [],
     isLoading,
@@ -462,6 +467,16 @@ export default function ActiveWorkSurface() {
     staleTime: 5_000,
     refetchInterval: ACTIVE_WORK_REFETCH_MS,
   });
+
+  useEffect(() => {
+    const invalidateActiveWork = () => {
+      void queryClient.invalidateQueries({ queryKey: ['active-work'] });
+    };
+    window.addEventListener('relay-active-work-changed', invalidateActiveWork);
+    return () => {
+      window.removeEventListener('relay-active-work-changed', invalidateActiveWork);
+    };
+  }, [queryClient]);
 
   const groups = useMemo(
     () =>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -319,12 +319,13 @@ function WorkspaceGroupsList({
   return (
     <>
       {sortedGroups.map((ws) => {
-        const wsRepos = ws.repos
+        const repoPaths = Array.isArray(ws.repos) ? ws.repos : [];
+        const wsRepos = repoPaths
           .map((p: string) => reposByPath.get(p))
           .filter((r): r is Repo => r !== undefined);
         const wsSessions = getSessionsForWorkspaceGroup(ws.id);
         const wsWorktrees = worktrees.filter((wt) =>
-          ws.repos.includes(wt.repoPath)
+          repoPaths.includes(wt.repoPath)
         );
         return (
           <WorkspaceGroup

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -285,6 +285,7 @@ export function useEventSocket({
         useSessionsStore.getState().refreshAll();
       },
       'session-backend-state-changed': (msg) => {
+        queryClient.invalidateQueries({ queryKey: ['active-work'] });
         useSessionsStore
           .getState()
           .handleBackendStateChanged(
@@ -314,6 +315,7 @@ export function useEventSocket({
         if (repoPaths.length > 0) invalidateScopedPrData(repoPaths, 'manual');
       },
       'session-ended': (msg) => {
+        queryClient.invalidateQueries({ queryKey: ['active-work'] });
         const scope = eventSessionScope(msg);
         const repoPaths = resolveRepoPaths([
           msg.cwd ?? '',
@@ -354,6 +356,7 @@ export function useEventSocket({
         }
       },
       'session-activity-changed': (msg) => {
+        queryClient.invalidateQueries({ queryKey: ['active-work'] });
         useSessionsStore
           .getState()
           .handleActivityChanged(
@@ -375,9 +378,11 @@ export function useEventSocket({
       'tab-control-event': (msg) => {
         useSessionsStore.getState().handleTabControlEvent(msg.event);
         queryClient.invalidateQueries({ queryKey: ['session-interventions'] });
+        queryClient.invalidateQueries({ queryKey: ['active-work'] });
       },
       'node.status': (msg) => {
         applyHubNodeStatusEvent(queryClient, msg);
+        queryClient.invalidateQueries({ queryKey: ['active-work'] });
       },
       'account-telemetry': (msg) => {
         useTelemetryStore

--- a/frontend/src/lib/active-work-control.ts
+++ b/frontend/src/lib/active-work-control.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  createGlobalSessionId,
+} from '../../../shared/identity.js';
 import type {
   WorkContextActiveGroup,
   WorkContextSessionSummary,
@@ -11,6 +14,14 @@ export interface ActiveWorkMobileControlState {
   promptKind: 'approval' | 'input' | null;
   smallInputLabel: string;
   smallInputPlaceholder: string;
+}
+
+export function activeWorkSessionActivationKey(
+  session: WorkContextSessionSummary
+): string {
+  const nodeId = session.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  if (nodeId === DEFAULT_LOCAL_NODE_ID) return session.id;
+  return session.globalSessionId ?? createGlobalSessionId(nodeId, session.id);
 }
 
 export function activeWorkAttentionPriority(
@@ -80,8 +91,6 @@ export function activeWorkMobileControlState(
 ): ActiveWorkMobileControlState {
   const liveReason = liveControlDisabledReason(group, session);
   const freshReason = freshControlDisabledReason(session);
-  const isLocal =
-    (session?.nodeId ?? DEFAULT_LOCAL_NODE_ID) === DEFAULT_LOCAL_NODE_ID;
   const promptKind =
     session?.agentState === 'permission-prompt'
       ? 'approval'
@@ -90,10 +99,6 @@ export function activeWorkMobileControlState(
         : null;
 
   let smallInputDisabledReason = liveReason ?? freshReason;
-  if (!smallInputDisabledReason && !isLocal) {
-    smallInputDisabledReason =
-      'remote small input awaits routed control endpoint';
-  }
   if (!smallInputDisabledReason && session?.mode === 'web') {
     smallInputDisabledReason = 'web session input is unsupported here';
   }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -429,10 +429,62 @@ export async function handBackSessionControl(input: {
   );
 }
 
-export async function sendSessionInput(
+function sendRoutedSessionInput(
+  nodeId: NodeId | string,
   sessionId: string,
   data: string
 ): Promise<{ ok: true }> {
+  return new Promise((resolve, reject) => {
+    const parsed = parseGlobalSessionId(sessionId);
+    const localSessionId = parsed?.localSessionId ?? sessionId;
+    const path =
+      '/nodes/' +
+      encodeURIComponent(nodeId) +
+      '/ws/sessions/' +
+      encodeURIComponent(localSessionId);
+    const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const socket = new WebSocket(protocol + '//' + location.host + path);
+    let settled = false;
+    const timeout = window.setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      socket.close();
+      reject(new Error('timed out opening routed session input socket'));
+    }, 5_000);
+
+    socket.onopen = () => {
+      socket.send(data);
+      window.setTimeout(() => socket.close(1000, 'small input sent'), 25);
+      window.clearTimeout(timeout);
+      if (!settled) {
+        settled = true;
+        resolve({ ok: true });
+      }
+    };
+    socket.onerror = () => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeout);
+      reject(new Error('failed to open routed session input socket'));
+    };
+    socket.onclose = () => {
+      if (settled) return;
+      settled = true;
+      window.clearTimeout(timeout);
+      reject(new Error('routed session input socket closed before sending'));
+    };
+  });
+}
+
+export async function sendSessionInput(
+  sessionId: string,
+  data: string,
+  nodeId?: NodeId | string
+): Promise<{ ok: true }> {
+  if (nodeId && nodeId !== DEFAULT_LOCAL_NODE_ID) {
+    return sendRoutedSessionInput(nodeId, sessionId, data);
+  }
+
   const res = await fetch(
     `/sessions/${encodeURIComponent(sessionId)}/input`,
     {
@@ -896,13 +948,21 @@ export async function createSession(
 ): Promise<SessionSummary> {
   const { nodeId, ...sessionBody } = body;
   const sessionPath = sessionCreatePath(nodeId);
-  return parseSessionCreateResponse(
+  const session = await parseSessionCreateResponse(
     await postSessionCreate(sessionPath, sessionBody),
     {
       sessionPath,
       sessionBody,
     }
   );
+  if (typeof window !== 'undefined' && session.workContextId) {
+    window.dispatchEvent(
+      new CustomEvent('relay-active-work-changed', {
+        detail: { workContextId: session.workContextId, sessionId: session.id },
+      })
+    );
+  }
+  return session;
 }
 
 export async function killSession(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1451,8 +1451,22 @@ export async function updateConfigAutoProvision(
 
 // ── Workspace groups ──────────────────────────────────────────────────────────
 
+function normalizeWorkspaceGroup(value: Workspace, index: number): Workspace {
+  const raw = value as Workspace & { repos?: unknown; order?: unknown };
+  return {
+    ...value,
+    repos: Array.isArray(raw.repos)
+      ? raw.repos.filter((repo): repo is string => typeof repo === 'string')
+      : [],
+    order: typeof raw.order === 'number' ? raw.order : index,
+  };
+}
+
 export async function fetchWorkspaceGroups(): Promise<Workspace[]> {
-  return json<Workspace[]>(await fetch('/workspace-groups'));
+  const data = await json<Workspace[]>(await fetch('/workspace-groups'));
+  return Array.isArray(data)
+    ? data.map((workspace, index) => normalizeWorkspaceGroup(workspace, index))
+    : [];
 }
 
 export async function createWorkspaceGroup(data: {

--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -615,7 +615,9 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
     );
     const workspace = workspaceGroups.find((w) => w.id === workspaceId);
     if (!workspace) return directSessions;
-    const repoSet = new Set(workspace.repos);
+    const repoSet = new Set(
+      Array.isArray(workspace.repos) ? workspace.repos : []
+    );
     const repoSessions = sessions.filter(
       (s) => !s.workspaceId && !!s.repoPath && repoSet.has(s.repoPath)
     );

--- a/server/hub-policy-evaluator.ts
+++ b/server/hub-policy-evaluator.ts
@@ -116,7 +116,9 @@ export function sessionCreateCapabilities(input: {
   controlMode?: unknown;
 }): RelayCapabilityBit[] {
   const capabilities = [sessionCreateCapability(input.sessionType)];
-  if (input.controlMode === 'agent-driven') capabilities.push('tab:mode:set-agent');
+  const effectiveControlMode =
+    input.controlMode ?? (input.sessionType === 'agent' ? 'agent-driven' : 'human-driven');
+  if (effectiveControlMode === 'agent-driven') capabilities.push('tab:mode:set-agent');
   return capabilities;
 }
 

--- a/server/hub-policy-evaluator.ts
+++ b/server/hub-policy-evaluator.ts
@@ -103,8 +103,15 @@ export interface HubPolicyDecision {
 
 export type SessionCreateType = 'agent' | 'terminal';
 
+type SessionCreateControlMode = 'agent-driven' | 'human-driven';
+
 export function isSessionCreateType(value: unknown): value is SessionCreateType {
   return value === 'agent' || value === 'terminal';
+}
+
+function normalizeSessionCreateControlMode(value: unknown): SessionCreateControlMode | undefined {
+  if (value === 'agent-driven' || value === 'human-driven') return value;
+  return undefined;
 }
 
 export function sessionCreateCapability(sessionType: SessionCreateType): RelayCapabilityBit {
@@ -117,7 +124,8 @@ export function sessionCreateCapabilities(input: {
 }): RelayCapabilityBit[] {
   const capabilities = [sessionCreateCapability(input.sessionType)];
   const effectiveControlMode =
-    input.controlMode ?? (input.sessionType === 'agent' ? 'agent-driven' : 'human-driven');
+    normalizeSessionCreateControlMode(input.controlMode) ??
+    (input.sessionType === 'agent' ? 'agent-driven' : 'human-driven');
   if (effectiveControlMode === 'agent-driven') capabilities.push('tab:mode:set-agent');
   return capabilities;
 }

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -13,7 +13,10 @@ import {
 import type { Logger } from './logger.js';
 import { createLogger } from './logger.js';
 import type { CreateParams } from './sessions.js';
-import { createAgentDrivenInitialControlState } from './session-control-api.js';
+import {
+  createAgentDrivenInitialControlState,
+  createHumanDrivenInitialControlState,
+} from './session-control-api.js';
 import type {
   NodeLinkChannelHandler,
   NodeLinkEnvelopeHandlerContext,
@@ -332,14 +335,18 @@ export function createNodeLinkRpcHost(
         return;
       }
       const { controlMode, ...createInput } = parsed;
-      if (controlMode === 'agent-driven') {
-        const sessionId = createInput.id ?? crypto.randomBytes(8).toString('hex');
-        createInput.id = sessionId;
-        (createInput as CreateParams).controlState = createAgentDrivenInitialControlState({
-          workerId: sessionId,
-          ...(createInput.displayName ? { displayName: createInput.displayName } : {}),
-        });
-      }
+      const sessionId = createInput.id ?? crypto.randomBytes(8).toString('hex');
+      createInput.id = sessionId;
+      (createInput as CreateParams).controlState =
+        controlMode === 'agent-driven'
+          ? createAgentDrivenInitialControlState({
+              workerId: sessionId,
+              ...(createInput.displayName ? { displayName: createInput.displayName } : {}),
+            })
+          : createHumanDrivenInitialControlState({
+              sessionId,
+              ...(createInput.displayName ? { displayName: createInput.displayName } : {}),
+            });
       const result = localRelayNode.sessions.create(createInput as CreateParams);
       sendResultEnvelope(ctx, envelope, {
         session: sessionSummaryFromCreateResult(result),

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -108,12 +108,12 @@ function parseInitialControlMode(
 ): Pick<SessionsCreateInput, 'controlMode'> | RelayNodeError {
   const controlMode = asString(record['controlMode']);
   if (controlMode === undefined) return {};
-  if (controlMode !== 'agent-driven') {
+  if (controlMode !== 'agent-driven' && controlMode !== 'human-driven') {
     return invalidRequest(
-      'sessions.create payload.controlMode must be "agent-driven" when set'
+      'sessions.create payload.controlMode must be "agent-driven" or "human-driven" when set'
     );
   }
-  if (type !== 'agent') {
+  if (controlMode === 'agent-driven' && type !== 'agent') {
     return invalidRequest(
       'sessions.create payload.controlMode="agent-driven" is only supported for agent sessions'
     );
@@ -125,7 +125,7 @@ interface SessionsCreateInput {
   id?: string;
   type: 'agent' | 'terminal';
   mode?: 'pty' | 'web';
-  controlMode?: 'agent-driven';
+  controlMode?: 'agent-driven' | 'human-driven';
   agent?: string;
   repoPath?: string;
   worktreePath?: string | null;
@@ -337,8 +337,10 @@ export function createNodeLinkRpcHost(
       const { controlMode, ...createInput } = parsed;
       const sessionId = createInput.id ?? crypto.randomBytes(8).toString('hex');
       createInput.id = sessionId;
+      const effectiveControlMode =
+        controlMode ?? (createInput.type === 'agent' ? 'agent-driven' : 'human-driven');
       (createInput as CreateParams).controlState =
-        controlMode === 'agent-driven'
+        effectiveControlMode === 'agent-driven'
           ? createAgentDrivenInitialControlState({
               workerId: sessionId,
               ...(createInput.displayName ? { displayName: createInput.displayName } : {}),

--- a/server/session-control-api.ts
+++ b/server/session-control-api.ts
@@ -316,6 +316,39 @@ export function createAgentDrivenInitialControlState(input: {
   };
 }
 
+export function createHumanDrivenInitialControlState(input: {
+  actorId?: string;
+  displayName?: string;
+  nodeId?: string;
+  sessionId?: string;
+  reason?: string;
+} = {}): {
+  controlMode: 'human-driven';
+  activeActors: ControlActor[];
+  lastInterventionAt: null;
+  lastInterventionBy: null;
+  lastInterventionEventId: null;
+  controlFreshness: 'fresh';
+  controlReason: string;
+} {
+  const activeHuman: ControlActor = {
+    kind: 'human',
+    id: input.actorId ?? 'browser-user',
+    displayName: input.displayName ?? 'Browser user',
+    ...(input.nodeId ? { nodeId: input.nodeId } : {}),
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
+  };
+  return {
+    controlMode: 'human-driven',
+    activeActors: [activeHuman],
+    lastInterventionAt: null,
+    lastInterventionBy: null,
+    lastInterventionEventId: null,
+    controlFreshness: 'fresh',
+    controlReason: input.reason ?? 'routed-session-created',
+  };
+}
+
 export function actorFromRequestBody(value: unknown): ControlActor | undefined {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     return undefined;

--- a/server/workspace-groups.ts
+++ b/server/workspace-groups.ts
@@ -35,6 +35,20 @@ const execFileAsync = promisify(execFile);
 const logger = createLogger('workspace-groups');
 const ERR_FAILED_READ_CONFIG = 'Failed to read config';
 
+function normalizeWorkspaceForResponse(
+  workspace: Workspace,
+  fallbackOrder: number
+): Workspace {
+  const raw = workspace as Workspace & { repos?: unknown; order?: unknown };
+  return {
+    ...workspace,
+    repos: Array.isArray(raw.repos)
+      ? raw.repos.filter((repo): repo is string => typeof repo === 'string')
+      : [],
+    order: typeof raw.order === 'number' ? raw.order : fallbackOrder,
+  };
+}
+
 interface SessionDeps {
   sessions: {
     create: (params: CreateParams) => CreateResult;
@@ -153,7 +167,9 @@ export function createWorkspaceGroupsRouter(
       return;
     }
     const workspaces = config.workspaces ?? [];
-    const sorted = [...workspaces].sort((a, b) => a.order - b.order);
+    const sorted = workspaces
+      .map((workspace, index) => normalizeWorkspaceForResponse(workspace, index))
+      .sort((a, b) => a.order - b.order);
     res.json(sorted);
   });
 

--- a/shared/security-policy.ts
+++ b/shared/security-policy.ts
@@ -33,6 +33,7 @@ export const LEGACY_DEFAULT_ALLOWED_CAPABILITIES = [
   'session:create:terminal',
   'session:create:agent',
   'session:attach',
+  'tab:mode:set-agent',
   'rpc:fs:list',
   'rpc:fs:read',
   'rpc:fs:tail',

--- a/test/active-work-control.test.ts
+++ b/test/active-work-control.test.ts
@@ -7,6 +7,7 @@ import type {
 import {
   activeWorkAttentionPriority,
   activeWorkMobileControlState,
+  activeWorkSessionActivationKey,
   activeWorkStateLabel,
 } from '../frontend/src/lib/active-work-control.js';
 
@@ -80,7 +81,7 @@ describe('active work mobile control helpers', () => {
     expect(activeWorkStateLabel(mixed)).toBe('error');
   });
 
-  it('allows audited small input only for fresh live local pty sessions', () => {
+  it('allows audited small input for fresh live local and routed pty sessions', () => {
     const state = activeWorkMobileControlState(
       group({ sessions: [session({ agentState: 'permission-prompt' })] }),
       session({ agentState: 'permission-prompt' })
@@ -89,6 +90,15 @@ describe('active work mobile control helpers', () => {
     expect(state.smallInputDisabledReason).toBeNull();
     expect(state.promptKind).toBe('approval');
     expect(state.smallInputLabel).toBe('reply to approval');
+
+    const routed = activeWorkMobileControlState(
+      group({
+        node: { nodeId: 'remote-a', status: 'online', kind: 'remote' },
+        sessions: [session({ nodeId: 'remote-a' })],
+      }),
+      session({ nodeId: 'remote-a' })
+    );
+    expect(routed.smallInputDisabledReason).toBeNull();
   });
 
   it('disables controls for stale/offline read models and reports last-known state reasons', () => {
@@ -114,16 +124,33 @@ describe('active work mobile control helpers', () => {
     expect(state.destructiveDisabledReason).toContain('session:control:kill');
   });
 
-  it('does not route remote small input through local-only control paths', () => {
+  it('keeps unknown control state disabled but scopes routed attach/input keys', () => {
     const state = activeWorkMobileControlState(
       group({
         node: { nodeId: 'remote-a', status: 'online', kind: 'remote' },
-        sessions: [session({ nodeId: 'remote-a' })],
+        sessions: [session({ nodeId: 'remote-a', controlFreshness: 'unknown' })],
       }),
-      session({ nodeId: 'remote-a' })
+      session({ nodeId: 'remote-a', controlFreshness: 'unknown' })
     );
-    expect(state.smallInputDisabledReason).toBe(
-      'remote small input awaits routed control endpoint'
-    );
+    expect(state.smallInputDisabledReason).toBe('unknown control state');
+    expect(
+      activeWorkSessionActivationKey(
+        session({ id: 'remote-session-1', nodeId: 'remote-a' })
+      )
+    ).toBe('remote-a:remote-session-1');
+    expect(
+      activeWorkSessionActivationKey(
+        session({
+          id: 'remote-session-1',
+          nodeId: 'remote-a',
+          globalSessionId: 'remote-a:known-global',
+        })
+      )
+    ).toBe('remote-a:known-global');
+    expect(
+      activeWorkSessionActivationKey(
+        session({ id: 'local-session-1', nodeId: DEFAULT_LOCAL_NODE_ID })
+      )
+    ).toBe('local-session-1');
   });
 });

--- a/test/hub-policy-evaluator.test.ts
+++ b/test/hub-policy-evaluator.test.ts
@@ -360,8 +360,16 @@ describe('hub policy evaluator', () => {
       'tab:mode:set-agent',
     ]);
     expect(
+      sessionCreateCapabilities({ sessionType: 'agent', controlMode: 'lol-nope' })
+    ).toEqual(['session:create:agent', 'tab:mode:set-agent']);
+    expect(
       evaluateHubPolicy(
-        baseInput({ requiredCapabilities: sessionCreateCapabilities({ sessionType: 'agent' }) })
+        baseInput({
+          requiredCapabilities: sessionCreateCapabilities({
+            sessionType: 'agent',
+            controlMode: 'lol-nope',
+          }),
+        })
       )
     ).toMatchObject({
       decision: 'allow',

--- a/test/hub-policy-evaluator.test.ts
+++ b/test/hub-policy-evaluator.test.ts
@@ -360,6 +360,14 @@ describe('hub policy evaluator', () => {
       'tab:mode:set-agent',
     ]);
     expect(
+      evaluateHubPolicy(
+        baseInput({ requiredCapabilities: sessionCreateCapabilities({ sessionType: 'agent' }) })
+      )
+    ).toMatchObject({
+      decision: 'allow',
+      grantedBits: ['session:create:agent', 'tab:mode:set-agent'],
+    });
+    expect(
       sessionCreateCapabilities({ sessionType: 'agent', controlMode: 'human-driven' })
     ).toEqual(['session:create:agent']);
     expect(

--- a/test/hub-policy-evaluator.test.ts
+++ b/test/hub-policy-evaluator.test.ts
@@ -355,6 +355,13 @@ describe('hub policy evaluator', () => {
     expect(
       sessionCreateCapabilities({ sessionType: 'agent', controlMode: 'agent-driven' })
     ).toEqual(['session:create:agent', 'tab:mode:set-agent']);
+    expect(sessionCreateCapabilities({ sessionType: 'agent' })).toEqual([
+      'session:create:agent',
+      'tab:mode:set-agent',
+    ]);
+    expect(
+      sessionCreateCapabilities({ sessionType: 'agent', controlMode: 'human-driven' })
+    ).toEqual(['session:create:agent']);
     expect(
       sessionCreateCapabilities({ sessionType: 'terminal', controlMode: 'human-driven' })
     ).toEqual(['session:create:terminal']);

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -181,6 +181,95 @@ describe('node-link-rpc-host', () => {
     expect(sent[0]!.type).toBe('sessions.create.result');
   });
 
+  it('defaults routed agent creates without controlMode to agent-driven control state', () => {
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(
+      envelope('sessions.create', {
+        id: 'worker-session-2',
+        type: 'agent',
+        cwd: '/home/user/project',
+        displayName: 'Remote Codex worker',
+      }),
+      ctx
+    );
+
+    expect(localRelayNode.sessions.create).toHaveBeenCalledTimes(1);
+    const createCall = (
+      localRelayNode.sessions.create as ReturnType<typeof vi.fn>
+    ).mock.calls[0]?.[0] as CreateParams;
+    expect(createCall).toMatchObject({
+      id: 'worker-session-2',
+      type: 'agent',
+      cwd: '/home/user/project',
+      controlState: {
+        controlMode: 'agent-driven',
+        activeActors: [
+          {
+            kind: 'agent',
+            id: 'worker-session-2',
+            displayName: 'Remote Codex worker',
+          },
+        ],
+        activeWorker: {
+          kind: 'agent',
+          id: 'worker-session-2',
+          displayName: 'Remote Codex worker',
+        },
+        controlFreshness: 'fresh',
+        controlReason: 'requested-initial-agent-driven',
+      },
+    });
+    expect(createCall).not.toHaveProperty('controlMode');
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('sessions.create.result');
+  });
+
+  it('keeps explicit human-driven agent creates human-driven before dispatch', () => {
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { sent, ctx } = context();
+
+    host.handle(
+      envelope('sessions.create', {
+        id: 'operator-session-1',
+        type: 'agent',
+        cwd: '/home/user/project',
+        displayName: 'Remote terminal-like agent tab',
+        controlMode: 'human-driven',
+      }),
+      ctx
+    );
+
+    expect(localRelayNode.sessions.create).toHaveBeenCalledTimes(1);
+    const createCall = (
+      localRelayNode.sessions.create as ReturnType<typeof vi.fn>
+    ).mock.calls[0]?.[0] as CreateParams;
+    expect(createCall).toMatchObject({
+      id: 'operator-session-1',
+      type: 'agent',
+      cwd: '/home/user/project',
+      controlState: {
+        controlMode: 'human-driven',
+        activeActors: [
+          {
+            kind: 'human',
+            id: 'browser-user',
+            displayName: 'Remote terminal-like agent tab',
+            sessionId: 'operator-session-1',
+          },
+        ],
+        controlFreshness: 'fresh',
+        controlReason: 'routed-session-created',
+      },
+    });
+    expect(createCall).not.toHaveProperty('controlMode');
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.type).toBe('sessions.create.result');
+  });
+
   it('rejects requested agent-driven initial control for terminal sessions', () => {
     const localRelayNode = fakeLocalNode();
     const host = createNodeLinkRpcHost({ localRelayNode });

--- a/test/session-control-api.test.ts
+++ b/test/session-control-api.test.ts
@@ -3,6 +3,7 @@ import type { InterventionRecord } from '../shared/control-state.js';
 import {
   clampInterventionLimit,
   createAgentDrivenInitialControlState,
+  createHumanDrivenInitialControlState,
   evaluateControlCapabilityPlaceholder,
   toInterventionReadResponse,
   validateAgentHandBackAck,
@@ -60,6 +61,30 @@ describe('session control API helpers', () => {
       lastInterventionEventId: null,
       controlFreshness: 'fresh',
       controlReason: 'requested-initial-agent-driven',
+    });
+  });
+
+  it('creates fresh human-driven control state for routed terminal sessions', () => {
+    expect(
+      createHumanDrivenInitialControlState({
+        sessionId: 'remote-session-1',
+        displayName: 'mac node terminal',
+      })
+    ).toEqual({
+      controlMode: 'human-driven',
+      activeActors: [
+        {
+          kind: 'human',
+          id: 'browser-user',
+          displayName: 'mac node terminal',
+          sessionId: 'remote-session-1',
+        },
+      ],
+      lastInterventionAt: null,
+      lastInterventionBy: null,
+      lastInterventionEventId: null,
+      controlFreshness: 'fresh',
+      controlReason: 'routed-session-created',
     });
   });
 

--- a/test/session-utils.test.ts
+++ b/test/session-utils.test.ts
@@ -178,4 +178,20 @@ describe('createSessionWithoutActivation', () => {
     expect(result).toEqual({ session: undefined, error: createError });
     expect(refreshAll).not.toHaveBeenCalled();
   });
+
+  it('does not throw when legacy workspace groups omit repos', () => {
+    useSessionsStore.setState({
+      sessions: [
+        { ...session('direct'), workspaceId: 'legacy' },
+        { ...session('repo'), workspaceId: undefined },
+      ],
+      workspaceGroups: [{ id: 'legacy', name: 'Legacy', order: 0 } as any],
+    });
+
+    const result = useSessionsStore
+      .getState()
+      .getSessionsForWorkspaceGroup('legacy');
+
+    expect(result.map((s) => s.id)).toEqual(['direct']);
+  });
 });

--- a/test/stores/node-dashboard.test.ts
+++ b/test/stores/node-dashboard.test.ts
@@ -290,7 +290,7 @@ describe('hub node dashboard state', () => {
 
     expect(rows.map((row) => [row.security.trustTier, row.security.postureLabel])).toEqual([
       ['sandbox', 'allow 1 · challenge 0 · deny 15'],
-      ['dev', 'allow 8 · challenge 0 · deny 8'],
+      ['dev', 'allow 9 · challenge 0 · deny 7'],
       ['prod', 'allow 1 · challenge 2 · deny 13'],
     ]);
     expect(rows[2].security).toMatchObject({

--- a/test/workspace-groups.test.ts
+++ b/test/workspace-groups.test.ts
@@ -105,6 +105,22 @@ test('GET returns workspaces sorted by order', async () => {
   expect(body[1].id).toBe('id2');
 });
 
+test('GET normalizes legacy workspaces without repos', async () => {
+  writeConfig({
+    configVersion: 4,
+    repos: ['/a'],
+    workspaces: [
+      { id: 'legacy', name: 'Legacy', order: 0 },
+      { id: 'valid', name: 'Valid', repos: ['/a'], order: 1 },
+    ],
+  });
+  await startServer(configPath);
+  const { status, body } = await req('GET', '/workspace-groups');
+  expect(status).toBe(200);
+  expect(body[0]).toMatchObject({ id: 'legacy', repos: [] });
+  expect(body[1]).toMatchObject({ id: 'valid', repos: ['/a'] });
+});
+
 // ────────────────────────────────────────────────────────────────────────────
 // POST /workspace-groups
 // ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- initialize routed Mac-node terminal sessions with fresh human-driven control state instead of legacy unknown control state
- route Active Work attach/send through scoped remote session ids and the existing routed PTY websocket
- invalidate Active Work on session/control/node events and work-context session creation so already-mounted surfaces refresh
- add regressions for fresh routed controls, unknown control state, scoped activation keys, and fresh human control state

## Verification
- npm test -- --run test/active-work-control.test.ts test/session-control-api.test.ts
- npm test -- --run test/hub-node-session-routing.test.ts test/hub-cross-node-pty.test.ts
- npm run check
- npm run build

Fixes #582
Refs #562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Routed delivery for sending session input to remote nodes (websocket path).
  * Browser dispatch of an active-work change event when sessions are created.

* **Improvements**
  * More reliable mobile attach/send flows and active-work refresh via event listeners and cache invalidation.
  * Better control-mode handling for agent vs. human-driven sessions.
  * Workspace/group responses normalized; defensive handling of missing repo lists.
  * Legacy policy now includes tab-mode capability by default.

* **Tests**
  * Expanded coverage for routed sessions, control-state behavior, workspace normalization, and related hosts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->