### PR TITLE
Fix routed terminal active-work liveness

### DIFF
--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -102,6 +102,19 @@ function asNullableString(value: unknown): string | null | undefined {
   return undefined;
 }
 
+function defaultTerminalCommand(): string {
+  if (process.env.SHELL) return process.env.SHELL;
+  return process.platform === 'win32' ? 'powershell.exe' : '/bin/sh';
+}
+
+function parseSessionCommand(
+  record: Record<string, unknown>,
+  type: SessionsCreateInput['type']
+): string | undefined {
+  return asString(record['command']) ??
+    (type === 'terminal' ? defaultTerminalCommand() : undefined);
+}
+
 function parseInitialControlMode(
   record: Record<string, unknown>,
   type: SessionsCreateInput['type']
@@ -183,7 +196,7 @@ function parseSessionsCreateInput(
   // node host's home directory so spawn() never receives undefined.
   const cwd = asString(record['cwd']) ?? os.homedir();
   input.cwd = cwd;
-  const command = asString(record['command']);
+  const command = parseSessionCommand(record, typeRaw);
   if (command !== undefined) input.command = command;
   const args = asStringArray(record['args']);
   if (args !== undefined) input.args = args;

--- a/test/active-work-control.test.ts
+++ b/test/active-work-control.test.ts
@@ -98,7 +98,28 @@ describe('active work mobile control helpers', () => {
       }),
       session({ nodeId: 'remote-a' })
     );
+    expect(routed.attachDisabledReason).toBeNull();
     expect(routed.smallInputDisabledReason).toBeNull();
+
+    const routedHumanTerminal = session({
+      id: 'remote-terminal-584',
+      nodeId: 'mac-node',
+      type: 'terminal',
+      agent: 'claude',
+      controlMode: 'human-driven',
+      agentState: 'idle',
+      cwd: '/Users/ebi/project',
+      globalSessionId: 'mac-node:remote-terminal-584',
+    });
+    const routedHumanTerminalState = activeWorkMobileControlState(
+      group({
+        node: { nodeId: 'mac-node', status: 'online', kind: 'remote' },
+        sessions: [routedHumanTerminal],
+      }),
+      routedHumanTerminal
+    );
+    expect(routedHumanTerminalState.attachDisabledReason).toBeNull();
+    expect(routedHumanTerminalState.smallInputDisabledReason).toBeNull();
   });
 
   it('disables controls for stale/offline read models and reports last-known state reasons', () => {

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -134,6 +134,37 @@ describe('node-link-rpc-host', () => {
     expect(replyPayload.session).not.toHaveProperty('pid');
   });
 
+  it('defaults routed terminal creates to a shell command instead of the agent command', () => {
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { ctx } = context();
+
+    host.handle(
+      envelope('sessions.create', {
+        type: 'terminal',
+        cwd: '/Users/ebi/project',
+        workContextId: 'wc:issue-584',
+      }),
+      ctx
+    );
+
+    const createCall = (
+      localRelayNode.sessions.create as ReturnType<typeof vi.fn>
+    ).mock.calls[0]?.[0] as CreateParams;
+    expect(createCall).toMatchObject({
+      type: 'terminal',
+      cwd: '/Users/ebi/project',
+      command:
+        process.env.SHELL ??
+        (process.platform === 'win32' ? 'powershell.exe' : '/bin/sh'),
+      controlState: {
+        controlMode: 'human-driven',
+        controlFreshness: 'fresh',
+        controlReason: 'routed-session-created',
+      },
+    });
+  });
+
   it('turns requested initial agent-driven control mode into fresh control state before dispatch', () => {
     const localRelayNode = fakeLocalNode();
     const host = createNodeLinkRpcHost({ localRelayNode });


### PR DESCRIPTION
Fixes #584
Refs #562

## Summary
- default node-link routed terminal creates to the node shell when the browser omits an explicit command
- preserve fresh human-driven routed terminal control state so the session stays in the live read model instead of falling back to last-known-only after the spawned PTY immediately exits
- add regression coverage for routed terminal shell dispatch plus Active Work attach/input controls for fresh live human-driven routed terminals

## Tests
- npm test -- test/node-link-rpc-host.test.ts test/hub-routed-create-readmodel.test.ts test/active-work-control.test.ts
- npm test (first run before build failed because dist/bin/relay-ide.js and dist/server/index.js were absent; rerun after npm run build passed: 223 files / 2379 tests)
- npm run check
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Terminal sessions now intelligently default to the user's shell when no explicit command is provided, with platform-specific fallbacks for improved session creation.

* **Tests**
  * Added comprehensive test coverage for terminal session command defaulting and routed session control states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->