### PR TITLE
docs: capture dogfood recovery runbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,27 +24,28 @@ Relay Agentic Development Environment — a hub/node web workspace for AI coding
 
 ## Documentation Map
 
-| Category        | Path                               | When to look here                                                           |
-| --------------- | ---------------------------------- | --------------------------------------------------------------------------- |
-| Docs index      | `docs/README.md`                   | Current source-of-truth docs vs historical plans/spikes                     |
-| Architecture    | `docs/ARCHITECTURE.md`             | Module boundaries, data flow, API routes, ADR rules                         |
-| Workbench       | `docs/WORKBENCH_BOUNDARY.md`       | Relay product boundary, #552 nouns, mobile/pair/dogfood acceptance          |
-| Visual Design   | `DESIGN.md`                        | Product framing, TUI aesthetic, colors, spacing, buttons                    |
-| Design          | `docs/DESIGN.md`                   | Backend patterns, auth flow, PTY management, session types                  |
-| Frontend        | `docs/FRONTEND.md`                 | React 19 components, state management (Zustand + TanStack Query)            |
-| Quality         | `docs/QUALITY.md`                  | Test runner, test files, isolation patterns                                 |
-| Review          | `docs/REVIEW_GUIDANCE.md`          | Review agent config, question bank, escape log                              |
-| Deployment      | `docs/references/deployment.md`    | Publishing + branching (nightly/master + tags)                              |
-| Self-hosting    | `docs/SELF_HOSTING.md`             | Build Relay with Relay using isolated dev config/ports/tmux                 |
-| Security policy | `docs/SECURITY_POLICY.md`          | Trust tiers, capability bits, hub ACL defaults, manifest-vs-policy boundary |
-| Hub/node pkg    | `docs/RELAY_HUB_NODE_PACKAGING.md` | Hub vs node command shape, npm package decision, install/update commands    |
-| Node bootstrap  | `docs/RELAY_NODE_BOOTSTRAP.md`     | Pair/install/update/unpair nodes for federated Relay, bootstrap diagnostics |
-| Federated dev   | `docs/FEDERATED_DEV.md`            | Cross-machine dev workflow: synced git checkouts, `dev:node`, version skew  |
-| Federated Relay | `docs/federated-relay.md`          | Hub/node architecture, pairing, routing, ADRs                               |
-| CLI gateway     | `docs/CLI_GATEWAY.md`              | Versioned `relay-ide v1 ... --json` contract for external agent adapters    |
-| Learnings       | `docs/LEARNINGS.md`                | Persistent cross-session learnings                                          |
-| Project skills  | `.chalk/skills/<name>/SKILL.md`    | Repo-local skills (see §Skills)                                             |
-| Work tracking   | GitHub Issues                      | `donovan-yohan/relay-ide` — use `/ticket` or `gh issue`                     |
+| Category         | Path                                  | When to look here                                                           |
+| ---------------- | ------------------------------------- | --------------------------------------------------------------------------- |
+| Docs index       | `docs/README.md`                      | Current source-of-truth docs vs historical plans/spikes                     |
+| Architecture     | `docs/ARCHITECTURE.md`                | Module boundaries, data flow, API routes, ADR rules                         |
+| Workbench        | `docs/WORKBENCH_BOUNDARY.md`          | Relay product boundary, #552 nouns, mobile/pair/dogfood acceptance          |
+| Visual Design    | `DESIGN.md`                           | Product framing, TUI aesthetic, colors, spacing, buttons                    |
+| Design           | `docs/DESIGN.md`                      | Backend patterns, auth flow, PTY management, session types                  |
+| Frontend         | `docs/FRONTEND.md`                    | React 19 components, state management (Zustand + TanStack Query)            |
+| Quality          | `docs/QUALITY.md`                     | Test runner, test files, isolation patterns                                 |
+| Review           | `docs/REVIEW_GUIDANCE.md`             | Review agent config, question bank, escape log                              |
+| Deployment       | `docs/references/deployment.md`       | Publishing + branching (nightly/master + tags)                              |
+| Dogfood recovery | `docs/references/dogfood-recovery.md` | Relay-develops-Relay proof loop, recovery, diagnostics, no-force-merge gate |
+| Self-hosting     | `docs/SELF_HOSTING.md`                | Build Relay with Relay using isolated dev config/ports/tmux                 |
+| Security policy  | `docs/SECURITY_POLICY.md`             | Trust tiers, capability bits, hub ACL defaults, manifest-vs-policy boundary |
+| Hub/node pkg     | `docs/RELAY_HUB_NODE_PACKAGING.md`    | Hub vs node command shape, npm package decision, install/update commands    |
+| Node bootstrap   | `docs/RELAY_NODE_BOOTSTRAP.md`        | Pair/install/update/unpair nodes for federated Relay, bootstrap diagnostics |
+| Federated dev    | `docs/FEDERATED_DEV.md`               | Cross-machine dev workflow: synced git checkouts, `dev:node`, version skew  |
+| Federated Relay  | `docs/federated-relay.md`             | Hub/node architecture, pairing, routing, ADRs                               |
+| CLI gateway      | `docs/CLI_GATEWAY.md`                 | Versioned `relay-ide v1 ... --json` contract for external agent adapters    |
+| Learnings        | `docs/LEARNINGS.md`                   | Persistent cross-session learnings                                          |
+| Project skills   | `.chalk/skills/<name>/SKILL.md`       | Repo-local skills (see §Skills)                                             |
+| Work tracking    | GitHub Issues                         | `donovan-yohan/relay-ide` — use `/ticket` or `gh issue`                     |
 
 ## Product Vocabulary
 

--- a/docs/FEDERATED_DEV.md
+++ b/docs/FEDERATED_DEV.md
@@ -17,6 +17,12 @@ when local/self-host evidence is enough, when devbox hub proof is required,
 how to restart the Mac node link, and how to clean stale local processes
 without killing the wrong Relay service.
 
+For Relay-develops-Relay closeout and recovery, see the
+[`dogfood and recovery runbook`](./references/dogfood-recovery.md). It covers
+the browser/mobile Active Work proof loop, stuck-session recovery, offline
+nodes, bad `WorkContext` metadata, plugin/event ingestion failures,
+diagnostics capture, and the no-force-merge release gate policy.
+
 ## TL;DR
 
 - One package: `relay-ide`. Hub vs node is a subcommand role, not a separate
@@ -175,6 +181,9 @@ dist-tag.
 - [`references/devbox-hub-deploy.md`](./references/devbox-hub-deploy.md) —
   devbox hub deploy, Mac node-link restart, verification evidence, and safe
   process cleanup.
+- [`references/dogfood-recovery.md`](./references/dogfood-recovery.md) —
+  Relay-develops-Relay proof loop, recovery matrix, diagnostics, and release
+  gate policy.
 - [`RELAY_NODE_BOOTSTRAP.md`](./RELAY_NODE_BOOTSTRAP.md) — pair / install /
   doctor flows for nodes (npm-installed shape).
 - [`RELAY_HUB_NODE_PACKAGING.md`](./RELAY_HUB_NODE_PACKAGING.md) — packaging

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ This index separates current source-of-truth docs from historical plans and spik
 | Review                | `REVIEW_GUIDANCE.md`              | Reviewer prompts, risk areas, escape log                                                |
 | Deployment            | `references/deployment.md`        | Branching, npm channels, publishing flow                                                |
 | Devbox deploy         | `references/devbox-hub-deploy.md` | Shared devbox hub deploy, Mac node-link restart, verification evidence, process hygiene |
+| Dogfood recovery      | `references/dogfood-recovery.md`  | Relay-develops-Relay proof loop, recovery matrix, diagnostics, no-force-merge gate      |
 | Self-hosting          | `SELF_HOSTING.md`                 | Running Relay from inside Relay with isolated config/ports                              |
 | Security policy       | `SECURITY_POLICY.md`              | Trust tiers, capability bits, hub ACL defaults                                          |
 | Hub/node packaging    | `RELAY_HUB_NODE_PACKAGING.md`     | Hub/node command shape and npm packaging decisions                                      |

--- a/docs/WORKBENCH_BOUNDARY.md
+++ b/docs/WORKBENCH_BOUNDARY.md
@@ -117,6 +117,8 @@ A v1 Relay-develops-Relay dogfood is acceptable only when this loop works end-to
 7. The assistant can resume from Relay `WorkContext` after the pair session with a compact summary, artifact refs, and audit refs sufficient to continue or close the task.
 8. Dogfood uses isolated Relay config/ports and has an operator recovery path for stuck sessions, bad node links, broken plugin events, and audit/diagnostics collection.
 
+The operator runbook for proving and recovering this loop is [`references/dogfood-recovery.md`](./references/dogfood-recovery.md). Keep that runbook evidence-based: a local self-host run proves only the isolated local instance, while live dogfood claims require current devbox hub, node registry, WorkContext, browser/mobile Active Work, redaction, and release-gate evidence.
+
 ## Hermes Agent integration boundary
 
 Relay needs a Hermes Agent plugin or integration layer that emits Relay-useful metadata without making Relay scrape raw Hermes profile state.
@@ -159,6 +161,7 @@ Non-goals for this integration:
 ## Sources
 
 - GitHub issue #552 body and product/planner comments.
+- GitHub issue #562 dogfood/recovery lane and deployed QA proof.
 - GitHub issue #553 acceptance criteria.
 - `docs/ARCHITECTURE.md` for hub/node, six-layer vocabulary, current/deferred implementation state.
 - `docs/federated-relay.md` for node/session routing, stale/offline states, and control/audit boundaries.

--- a/docs/references/devbox-hub-deploy.md
+++ b/docs/references/devbox-hub-deploy.md
@@ -222,6 +222,7 @@ Devbox deploy evidence for <PR/issue>:
 ## See also
 
 - [`../FEDERATED_DEV.md`](../FEDERATED_DEV.md) — source dev across hub/node checkouts and protocol skew handling.
+- [`dogfood-recovery.md`](./dogfood-recovery.md) — Relay-develops-Relay proof loop, stuck-session/node/work-context/plugin recovery, diagnostics capture, and no-force-merge release gate policy.
 - [`../SELF_HOSTING.md`](../SELF_HOSTING.md) — isolated local self-host mode for testing Relay inside Relay.
 - [`../RELAY_NODE_BOOTSTRAP.md`](../RELAY_NODE_BOOTSTRAP.md) — node pairing, persistent node link, status, logs, and diagnostics.
 - [`deployment.md`](./deployment.md) — branch model, `@nightly` publish flow, and release verification.

--- a/docs/references/dogfood-recovery.md
+++ b/docs/references/dogfood-recovery.md
@@ -1,0 +1,109 @@
+# Dogfood and recovery runbook
+
+Use this when Relay is used to develop Relay through the shared dogfood topology: devbox hub on `dev` / `100.77.36.51:3456`, a paired Mac node such as `macbook-relay-node`, and browser/mobile Active Work proof.
+
+This runbook is deliberately narrow. Relay is the federated workbench and control plane: identity, routing, `WorkContext` handoff, bounded inspection/control, and audit/evidence. It is not a replacement for Hermes Agent, Hermes dashboard, hermes-workspace, GitHub, Kanban, tmux, or native Claude/Codex/OpenCode/Hermes CLIs.
+
+Do not paste pair tokens, bearer tokens, cookies, node credentials, private auth URLs, raw env, or unbounded terminal/transcript output into issues, PRs, logs, or screenshots.
+
+## What counts as dogfood proof
+
+A Relay-developing-Relay closeout needs current evidence for all of these, not just a local self-host run:
+
+1. Package/deploy state: the hub package/source SHA, service status, `/health`, and served frontend version match the build under test.
+2. Node state: the target node is online/current in the hub registry, protocol-compatible, and running the matching package/source SHA when node-side behavior changed.
+3. Work context: the routed session is created with a `workContextId`, and the session plus `/work-contexts/active` preserve task/repo/node/cwd/session metadata without raw secrets.
+4. Browser/mobile Active Work: desktop and mobile show the fresh routed session as live/fresh, attach opens the session surface, and small scoped input reaches the routed PTY.
+5. Offline/stale behavior: an offline node returns a typed failure such as `NODE_OFFLINE`; stale/last-known sessions stay visible but live controls are disabled.
+6. Privacy/audit: captured evidence uses ids, statuses, summaries, screenshots, and artifact paths; it does not include auth material or raw transcript dumps.
+7. Release gate: no force/admin merge of unknown checks. A release gate must use current green checks plus latest-head QA/review/bot evidence, and only one release gate should own the final merge/deploy step at a time.
+
+For #562, the passing deployed proof was against `relay-ide@0.1.0-nightly.20260518.457`: devbox hub healthy/current, `macbook-relay-node` online/current, mobile Active Work attach opened the routed session surface, and small-input `pwd` send succeeded. Keep future claims tied to the then-current version/SHA instead of reusing that proof for new code.
+
+## First response checklist
+
+Before fixing anything, preserve enough state to avoid guessing:
+
+```bash
+relay-ide --version
+relay-ide hub status
+relay-ide hub logs --lines 80
+relay-ide hub doctor
+relay-ide hub nodes --json
+relay-ide node status
+relay-ide node logs
+relay-ide node doctor --hub <devbox-hub-url>
+relay-ide diag bundle --lines 120 --json
+```
+
+Run hub commands on the hub host and node commands on the node host unless the command explicitly supports a remote hub URL. If authenticated CLI/browser context is required, use scoped local files or environment supplied by the operator, but never print the credential.
+
+Also capture the UI/API state that proves the symptom:
+
+- global session id: `<nodeId>:<sessionId>`;
+- `workContextId` and task refs;
+- node id, node label, cwd, repo/worktree if any;
+- `/sessions/:globalSessionId` summary when available;
+- `/work-contexts/active` summary when available;
+- desktop/mobile screenshots for Active Work and the attached session surface;
+- console/network summary: warning/error count, failed request count, and any typed error code.
+
+## Recovery matrix
+
+| Symptom                        | Diagnose                                                                                                                                                                                                                                                                        | Recover                                                                                                                                                                                                                  | Do not                                                                                                                                                       |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Stuck routed session           | Confirm `globalSessionId`, `nodeId`, cwd, `status`, `controlMode`, `controlFreshness`, and whether the node is online. Try a harmless attach/send only if the card is live/fresh and policy allows input.                                                                       | If live and controllable, use the UI or scoped API to send a minimal command such as `pwd` or to stop the exact session. If only local cleanup is needed, inspect the exact PID/tmux session first.                      | Do not use `tmux kill-server`, `killall node`, broad `pkill -f relay-ide`, or kill a session whose node/cwd/task identity you have not verified.             |
+| Node offline/stale             | Check hub registry, node logs, `node status`, `node doctor`, package versions, and protocol compatibility. The expected routed-create failure for an offline node is typed, retryable `NODE_OFFLINE`.                                                                           | Restart the exact node-link supervisor only after confirming the label/service. On macOS, inspect the actual launchd label first; the #562 dogfood node used `com.relay-ide-node-link`. Then recheck registry freshness. | Do not treat a successful local `relay-ide node status` as proof that the hub has a live reverse link. Do not route work to a different local node silently. |
+| Bad `WorkContext` metadata     | Compare the create payload, session descriptor, `/sessions/:globalSessionId`, and `/work-contexts/active`. Look for null/absent `workContextId`, wrong task refs, stale `nodeId`, wrong cwd, or stale-read-model downgrades.                                                    | File a focused blocker with the create payload shape, sanitized API summaries, screenshots, and exact version/SHA. Re-run QA only after the fix is merged, published/deployed, and the hub/node versions are refreshed.  | Do not call the dogfood loop live on API-only control if browser/mobile Active Work cannot attach/send. Do not patch evidence by hand in comments.           |
+| Plugin/event ingestion failure | First confirm the integration is actually in scope for the build under test. Relay should ingest bounded metadata events, not scrape Hermes profile DBs or raw transcripts. Capture event schema version, source, task/session refs, validator error code, and redaction class. | Retry only with a bounded sanitized payload. If the plugin or ingestion endpoint is not shipped in the target build, mark the plugin proof as not applicable or blocked rather than inventing behavior.                  | Do not sync raw Hermes SQLite DBs, provider auth, env, or full transcript/log payloads into Relay to make a test pass.                                       |
+| Diagnostics capture needed     | Use hub/node status, logs, doctor output, sanitized API summaries, screenshots, and artifact paths. Keep raw logs local when they may contain secrets; quote only the typed error and last relevant non-secret lines.                                                           | Attach artifact paths or issue/PR links, plus version/SHA and timestamps. Prefer summaries with ids and hashes over payload dumps.                                                                                       | Do not paste tokens, cookies, private auth URLs, raw env, or full PTY transcripts.                                                                           |
+| Release gate uncertainty       | Check PR base/head, issue linkage, current checks, latest-head QA/review/bot triage, and whether the dogfood environment was actually updated after publish.                                                                                                                    | Block the gate with the exact missing proof or rerun the relevant gate on the latest head/deployed version.                                                                                                              | Do not force/admin merge failed, pending, skipped, or unknown checks. Do not reuse stale QA/review after the head SHA or deployed version changed.           |
+
+## Safe process cleanup
+
+Process cleanup is part of recovery, but only after identity is clear. Distinguish these before stopping anything:
+
+- production/global hub: `relay-ide hub` or compiled server on the configured production port, production config, `relay-ide-` tmux prefix;
+- ordinary source dev: `npm run dev`, local dev config, `relay-dev-` prefix;
+- self-host source dev: allocator ports, self-host config, `relay-self-` prefix;
+- node link: `relay-ide node link --hub ...`, usually supervised by launchd/systemd/manual shell;
+- test/fixture server: Playwright/Vitest-owned temporary process.
+
+Prefer exact inspection and exact termination:
+
+```bash
+lsof -nP -iTCP:<port> -sTCP:LISTEN
+ps -p <pid> -o pid,ppid,lstart,command
+lsof -p <pid> | grep cwd
+tmux ls | grep '^relay-ide-\|^relay-dev-\|^relay-self-'
+tmux display-message -p -t <session-name> '#S #{session_created_string}'
+```
+
+Then kill only the intended PID or session. Escalate from `kill` to `kill -KILL` only after rechecking the PID was not reused.
+
+## Evidence comment template
+
+```markdown
+Dogfood/recovery evidence for <issue/PR>:
+
+- Scope: <source/nightly package; hub-only/node-only/protocol; local/self-host/devbox>
+- Hub: <host/url>, version/SHA <...>, service <active/restarted>, `/health` <result>
+- Frontend: served assets/version <...>
+- Node: <node label/id>, version/SHA <...>, registry state <online/stale/offline>, protocol <...>
+- WorkContext: <id>, task refs <...>, cwd <...>, global session <nodeId:sessionId>
+- Active Work desktop/mobile: <live/fresh attach/send result OR typed stale/offline disabled state>
+- Routed proof: <harmless command/result marker, no secrets>
+- Offline/stale proof: <typed error or disabled-control state>
+- Diagnostics/artifacts: <paths or URLs to sanitized summaries/screenshots/log excerpts>
+- Redaction: no pair tokens, bearer tokens, cookies, auth URLs, raw env, or unbounded transcripts included
+- Gate policy: latest-head/deployed evidence used; no force/admin merge of unknown checks
+```
+
+## Sources
+
+- Issue #562 dogfood lane and passing QA evidence after PR #585 / `0.1.0-nightly.20260518.457`.
+- Issue #552 product boundary and dogfood acceptance criteria.
+- `docs/WORKBENCH_BOUNDARY.md` for Relay's control-plane boundary and canonical nouns.
+- `docs/references/devbox-hub-deploy.md` for shared devbox hub deploy and process hygiene.
+- `docs/SELF_HOSTING.md` for isolated local self-host mode.
+- `docs/FEDERATED_DEV.md` and `docs/RELAY_NODE_BOOTSTRAP.md` for hub/node version skew, node status, logs, and doctor flows.


### PR DESCRIPTION
## Summary

- add `docs/references/dogfood-recovery.md` for the #562 Relay-develops-Relay proof loop
- link it from the docs index, AGENTS map, workbench boundary, federated dev, and devbox deploy runbook
- capture recovery guidance for stuck sessions, node offline/stale state, bad WorkContext metadata, plugin/event ingestion failures, diagnostics capture, and no-force-merge release gates

## Why

#562 now has deployed QA proof on current dogfood bits after PR #585 / `relay-ide@0.1.0-nightly.20260518.457`. The durable part belongs in docs: what counts as live dogfood proof, how to recover safely, and what evidence is required before future gates can claim Relay-develops-Relay is live.

Refs #562
Refs #552

## The case against

- This is a docs-only runbook based on one verified dogfood topology. If the devbox host, Mac node label, CLI commands, or plugin/event ingestion shape changes, the runbook will need a follow-up update.
- The Hermes/plugin ingestion section intentionally does not claim production plugin ingestion is shipped; it tells operators to mark that proof blocked/not applicable rather than inventing behavior.
- `AGENTS.md` was formatted by Prettier while adding the docs-map row, so that file has table-alignment churn in addition to the new link.

## Verification

- `git diff --check`
- `../../node_modules/.bin/prettier --check AGENTS.md docs/README.md docs/WORKBENCH_BOUNDARY.md docs/FEDERATED_DEV.md docs/references/devbox-hub-deploy.md docs/references/dogfood-recovery.md`
- `PATH=/Users/donovanyohan/Documents/Programs/personal/relay-ide/node_modules/.bin:$PATH npm run check` (passes with 67 existing warnings, 0 errors)

## Sources

- #562 passing deployed QA evidence after PR #585 / `.457`
- #552 workbench boundary and dogfood acceptance criteria
- existing docs: `WORKBENCH_BOUNDARY.md`, `references/devbox-hub-deploy.md`, `SELF_HOSTING.md`, `FEDERATED_DEV.md`, `RELAY_NODE_BOOTSTRAP.md`
