### PR TITLE
fix: spawn routed agent runtime commands

### DIFF
--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -111,8 +111,13 @@ function parseSessionCommand(
   record: Record<string, unknown>,
   type: SessionsCreateInput['type']
 ): string | undefined {
-  return asString(record['command']) ??
-    (type === 'terminal' ? defaultTerminalCommand() : undefined);
+  if (type === 'agent') {
+    // Routed native agent sessions must spawn the selected framework command
+    // on the node. Do not let a hub/browser shell fallback sneak through as
+    // `command` while metadata still says `type: agent` / `agent: codex`.
+    return undefined;
+  }
+  return asString(record['command']) ?? defaultTerminalCommand();
 }
 
 function parseInitialControlMode(

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -165,6 +165,38 @@ describe('node-link-rpc-host', () => {
     });
   });
 
+  it('routes native agent creates to the selected runtime instead of a shell fallback', () => {
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const { ctx } = context();
+
+    host.handle(
+      envelope('sessions.create', {
+        type: 'agent',
+        agent: 'codex',
+        cwd: '/Users/ebi/project',
+        command: process.env.SHELL ?? '/bin/sh',
+        displayName: 'Remote Codex worker',
+      }),
+      ctx
+    );
+
+    const createCall = (
+      localRelayNode.sessions.create as ReturnType<typeof vi.fn>
+    ).mock.calls[0]?.[0] as CreateParams;
+    expect(createCall).toMatchObject({
+      type: 'agent',
+      agent: 'codex',
+      cwd: '/Users/ebi/project',
+      controlState: {
+        controlMode: 'agent-driven',
+        controlFreshness: 'fresh',
+        controlReason: 'requested-initial-agent-driven',
+      },
+    });
+    expect(createCall).not.toHaveProperty('command');
+  });
+
   it('turns requested initial agent-driven control mode into fresh control state before dispatch', () => {
     const localRelayNode = fakeLocalNode();
     const host = createNodeLinkRpcHost({ localRelayNode });

--- a/test/pty-handler-multi-agent.test.ts
+++ b/test/pty-handler-multi-agent.test.ts
@@ -207,6 +207,45 @@ describe('PTY multi-agent hook/plugin wiring', () => {
     expect(output).toMatch(/HAS_HOOKS_JSON=true/);
   });
 
+  it('uses the selected agent framework command when no custom command is provided', async () => {
+    const codexStub = path.join(testHome, 'codex-stub.sh');
+    fs.writeFileSync(
+      codexStub,
+      `#!/bin/sh
+printf 'SELECTED_RUNTIME=codex\\n'
+sleep 10
+`,
+      'utf-8'
+    );
+    fs.chmodSync(codexStub, 0o755);
+
+    const result = sessions.create({
+      repoName: 'test-repo',
+      repoPath: '/tmp',
+      worktreePath: null,
+      cwd: '/tmp',
+      agent: 'codex',
+      args: [],
+      tmuxAttach: true,
+      frameworks: {
+        codex: {
+          commandOverride: codexStub,
+          eventSource: 'parser',
+        },
+      },
+    });
+    createdIds.push(result.id);
+
+    const output = await waitForScrollbackContains(
+      result.id,
+      'SELECTED_RUNTIME=codex'
+    );
+    expect(output).toContain('SELECTED_RUNTIME=codex');
+    const session = sessions.get(result.id) as PtySession;
+    expect(session.agent).toBe('codex');
+    expect(session.customCommand).toBeNull();
+  });
+
   it('resolves framework from config.frameworks overrides', () => {
     const result = sessions.create({
       repoName: 'test-repo',


### PR DESCRIPTION
## Summary
- prevent routed `type: agent` node-link creates from carrying a shell `command` into node-local session creation
- preserve routed terminal creates as explicit shell sessions
- add regression coverage for routed agent metadata + native framework command selection

## Motivation
#587 showed remote/native agent sessions with metadata like `type: agent` / `agent: codex` attaching to a default zsh prompt. The node-side RPC adapter was allowed to pass a shell command through for routed creates, so metadata could say “agent” while the PTY actually started a shell. cursed little boundary bug.

## The Case Against
This change intentionally ignores `payload.command` for routed agent creates. If a future remote API wants custom arbitrary commands while still labeling the session as an agent, this PR blocks that path. I think that is the safer invariant: `type: terminal` is the custom/shell path; `type: agent` should mean Relay picks the configured agent framework command for `agent: codex|hermes|claude`.

## Risks & Mitigation
- Risk: terminal sessions lose shell behavior. Mitigated by existing + retained regression test asserting routed terminal creates still get the node shell command.
- Risk: agent args stop working. Mitigated because only `command` is suppressed for agent creates; `args` still flows through to the selected framework runtime.
- Risk: native framework command selection regresses elsewhere. Mitigated by a PTY test that starts a codex framework override with no custom command and proves that selected command ran.

## Verification
- `npm test -- test/node-link-rpc-host.test.ts test/pty-handler-multi-agent.test.ts` — 32/32 passed
- `npm run check` — passed; existing lint warnings only, 0 errors
- `npm run build` — passed; Vite chunk-size warning only

Closes #587
Refs #562
Refs #552


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command fallback behavior for agent-type sessions to prevent unintended terminal command execution
  * Corrected control state initialization for agent-driven session creation

* **New Features**
  * Added support for codex agent framework in multi-agent sessions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->