### PR TITLE
fix: attach routed ptys to live native sessions

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -2059,15 +2059,18 @@ async function runNodeLink(nodeArgs: string[]): Promise<void> {
   } catch {
     config = undefined;
   }
+  const localRelayNode = createLocalRelayNode({ nodeId: credential.nodeId });
   // #467: ask the manifest probe which resume mode this host supports
-  // so the pty host can pick tmux vs raw without re-probing.
+  // so the pty host can pick tmux vs raw without re-probing. The host also
+  // gets the local session boundary so routed browser attaches bind to the
+  // already-created native PTY session instead of spawning a fallback shell.
   const initialManifest = await getNodeManifest();
   const sessionResume = initialManifest.capabilities.sessionResume ?? 'none';
   const ptyHost = createNodeLinkPtyHost({
     nodeId: credential.nodeId,
     sessionResume,
+    localRelayNode,
   });
-  const localRelayNode = createLocalRelayNode({ nodeId: credential.nodeId });
   const nodeLinkClient: { current?: ReturnType<typeof createNodeLinkClient> } = {};
   const rpcHost = createNodeLinkRpcHost({
     localRelayNode,

--- a/server/node-link-pty-host.ts
+++ b/server/node-link-pty-host.ts
@@ -12,6 +12,8 @@ import {
   createTmuxAttachmentFactory,
 } from './session-attachment.js';
 import type { NodeSessionResumeKind } from '../shared/node-manifest.js';
+import type { LocalRelayNode } from './local-node.js';
+import type { PtySession } from './types.js';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
@@ -37,6 +39,7 @@ export interface NodeLinkPtyHostDeps {
   defaultShell?: string;
   defaultCwd?: string;
   defaultEnv?: NodeJS.ProcessEnv;
+  localRelayNode?: LocalRelayNode;
   logger?: Logger;
   inputRecorder?: (input: { sessionId: string; data: string }) => void;
   /**
@@ -134,12 +137,81 @@ function resolveFactory(opts: NodeLinkPtyHostDeps): SessionAttachmentFactory {
   return createRawAttachmentFactory();
 }
 
+function createLiveSessionAttachment(session: PtySession): SessionAttachment {
+  let state: 'attached' | 'closed' = 'attached';
+  let exitEmitted = false;
+  const disposables: Array<{ dispose(): void }> = [];
+  const exitHandlers = new Set<(event: { exitCode: number; signal?: number }) => void>();
+
+  function emitExit(event: { exitCode: number; signal?: number }): void {
+    if (exitEmitted) return;
+    exitEmitted = true;
+    state = 'closed';
+    for (const disposable of disposables.splice(0)) disposable.dispose();
+    for (const handler of Array.from(exitHandlers)) handler(event);
+  }
+
+  const realExit = session.pty.onExit(({ exitCode, signal }) => {
+    const event: { exitCode: number; signal?: number } = {
+      exitCode: exitCode ?? 0,
+    };
+    if (signal !== undefined && signal !== null) event.signal = signal;
+    emitExit(event);
+  });
+  disposables.push(realExit);
+
+  return {
+    sessionId: session.id,
+    mode: 'raw',
+    onData(handler) {
+      if (state === 'closed') return { dispose: () => {} };
+      for (const chunk of session.scrollback) {
+        handler(Buffer.from(chunk, 'utf8'));
+      }
+      const disposable = session.pty.onData((chunk) => {
+        if (state === 'closed') return;
+        handler(Buffer.from(chunk, 'utf8'));
+      });
+      disposables.push(disposable);
+      return {
+        dispose: () => {
+          disposable.dispose();
+          const index = disposables.indexOf(disposable);
+          if (index >= 0) disposables.splice(index, 1);
+        },
+      };
+    },
+    onExit(handler) {
+      exitHandlers.add(handler);
+      return { dispose: () => void exitHandlers.delete(handler) };
+    },
+    write(bytes) {
+      if (state === 'closed') return;
+      session.pty.write(bytes.toString('utf8'));
+    },
+    resize(cols, rows) {
+      if (state === 'closed') return;
+      session.pty.resize(cols, rows);
+    },
+    async close() {
+      // Browser detach must not kill the node-local session that was created
+      // via sessions.create. It only closes this stream and leaves the real
+      // Codex/Claude/etc process running for later reattach.
+      emitExit({ exitCode: 0 });
+    },
+    status() {
+      return state;
+    },
+  };
+}
+
 export function createNodeLinkPtyHost(
   options: NodeLinkPtyHostOptions
 ): NodeLinkPtyHost {
   const logger = options.logger ?? createLogger('node-link-pty');
   const factory = resolveFactory(options);
   const inputRecorder = options.inputRecorder;
+  const localRelayNode = options.localRelayNode;
   const defaultShell = options.defaultShell ?? defaultLoginShell();
   const defaultCwd = options.defaultCwd ?? process.cwd();
   const defaultEnv = options.defaultEnv ?? process.env;
@@ -206,15 +278,19 @@ export function createNodeLinkPtyHost(
 
       let attachment: SessionAttachment;
       try {
-        attachment = await factory.open({
-          sessionId,
-          command,
-          args,
-          cwd,
-          env,
-          cols,
-          rows,
-        });
+        const liveSession = localRelayNode?.sessions.get(sessionId);
+        attachment =
+          liveSession?.mode === 'pty'
+            ? createLiveSessionAttachment(liveSession)
+            : await factory.open({
+                sessionId,
+                command,
+                args,
+                cwd,
+                env,
+                cols,
+                rows,
+              });
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         logger.error(`pty attach failed (${streamId}): ${message}`);

--- a/test/node-link-pty-host.test.ts
+++ b/test/node-link-pty-host.test.ts
@@ -53,6 +53,67 @@ async function waitFor<T>(
   throw new Error('waitFor timed out');
 }
 
+function fakeLivePtySession(id = 'session-a') {
+  const dataHandlers: Array<(data: string) => void> = [];
+  const exitHandlers: Array<
+    (event: { exitCode: number | null; signal?: number }) => void
+  > = [];
+  const writes: string[] = [];
+  const resizes: Array<{ cols: number; rows: number }> = [];
+  const pty = {
+    pid: 123,
+    process: 'codex',
+    handleFlowControl: false,
+    onData(handler: (data: string) => void) {
+      dataHandlers.push(handler);
+      return {
+        dispose: () => {
+          const index = dataHandlers.indexOf(handler);
+          if (index >= 0) dataHandlers.splice(index, 1);
+        },
+      };
+    },
+    onExit(
+      handler: (event: { exitCode: number | null; signal?: number }) => void
+    ) {
+      exitHandlers.push(handler);
+      return {
+        dispose: () => {
+          const index = exitHandlers.indexOf(handler);
+          if (index >= 0) exitHandlers.splice(index, 1);
+        },
+      };
+    },
+    write(data: string) {
+      writes.push(data);
+    },
+    resize(cols: number, rows: number) {
+      resizes.push({ cols, rows });
+    },
+    clear() {},
+    pause() {},
+    resume() {},
+    kill() {},
+    emit(data: string) {
+      for (const handler of dataHandlers.slice()) handler(data);
+    },
+    exit(exitCode = 0) {
+      for (const handler of exitHandlers.slice()) handler({ exitCode });
+    },
+  };
+  return {
+    session: {
+      id,
+      mode: 'pty',
+      pty,
+      scrollback: ['selected runtime: codex\n'],
+    },
+    pty,
+    writes,
+    resizes,
+  };
+}
+
 describe('node link pty host (unit)', () => {
   it('opens attachment on pty.attach, forwards data, closes on detach', async () => {
     const sent: RelayNodeEnvelope[] = [];
@@ -111,6 +172,56 @@ describe('node link pty host (unit)', () => {
     expect(factory.records[0]!.closed).toBe(true);
     const exit = sent.find((e) => e.type === 'pty.exit');
     expect(exit).toBeDefined();
+  });
+
+  it('attaches routed streams to an existing node-local PTY session instead of spawning a shell fallback', async () => {
+    const sent: RelayNodeEnvelope[] = [];
+    const factory: MockAttachmentFactory = createMockAttachmentFactory();
+    const live = fakeLivePtySession('native-codex-session');
+    const host = createNodeLinkPtyHost({
+      nodeId: 'node-1',
+      attachmentFactory: factory,
+      defaultShell: '/bin/zsh',
+      localRelayNode: {
+        sessions: { get: () => live.session },
+      } as never,
+    });
+    const build = envelopeBuilder('node-1');
+    const ctx = {
+      send: (env: RelayNodeEnvelope) => sent.push(env),
+      buildEnvelope: build,
+    };
+
+    host.handle(
+      build('pty', 'pty.attach', {
+        streamId: 's1',
+        payload: { sessionId: 'native-codex-session', cols: 100, rows: 30 },
+      }),
+      ctx
+    );
+
+    const data = await waitFor(() => sent.find((e) => e.type === 'pty.data'));
+    expect(factory.attachments).toHaveLength(0);
+    expect((data.payload as { data: string }).data).toBe(
+      'selected runtime: codex\n'
+    );
+
+    live.pty.emit('codex live output\n');
+    await flush();
+    expect(
+      sent
+        .filter((e) => e.type === 'pty.data')
+        .map((e) => (e.payload as { data: string }).data)
+    ).toContain('codex live output\n');
+
+    host.handle(
+      build('pty', 'pty.input', {
+        streamId: 's1',
+        payload: { data: 'hello codex\n' },
+      }),
+      ctx
+    );
+    expect(live.writes).toEqual(['hello codex\n']);
   });
 
   it('emits pty.exit when the underlying attachment exits', async () => {


### PR DESCRIPTION
## Summary
- Wire the node-link PTY host to the same local session boundary used by routed `sessions.create`.
- When a browser attaches to an existing node-local PTY session, bind the stream to that live PTY and replay its scrollback instead of opening a new tmux/raw fallback shell.
- Keep browser detach as stream-only so the native Codex/Claude process stays alive for later reattach.

Closes #589
Refs #562 #552

## Verification
- `npm test -- test/node-link-pty-host.test.ts test/node-link-rpc-host.test.ts test/pty-handler-multi-agent.test.ts` — 40/40 passed
- `npm run check` — passed with existing warnings only
- `npm run build` — passed with existing Vite chunk-size warning


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching to existing local terminal sessions instead of always creating new ones.

* **Improvements**
  * Enhanced terminal session initialization order and lifecycle management for more efficient reuse.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->