### PR TITLE
feat: add node cwd terminal onboarding APIs

### DIFF
--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -77,6 +77,7 @@ import {
   type ConfirmationDecision,
   type ConfirmationFailure,
 } from './confirmation-challenges.js';
+import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
 import type { RelayCliGatewayError } from '../shared/cli-gateway-contract.js';
 import { validateAndSanitizeGatewayCreateInput } from '../shared/cli-gateway-runtime.js';
 
@@ -1377,6 +1378,82 @@ function protocolVersionRelayError(nodeProtocolVersion: string): RelayNodeError 
   );
 }
 
+function nodeTerminalUnsupportedError(
+  nodeId: string,
+  node: HubNodeSummary
+): RelayNodeError | null {
+  if (node.capabilities.core.shell !== 'available') {
+    return relayError(
+      'NODE_UNSUPPORTED',
+      `node ${nodeId} cannot host shell-backed terminal sessions`,
+      false,
+      {
+        reasonCode: 'NODE_TERMINAL_SHELL_UNAVAILABLE',
+        capability: 'shell',
+        status: node.capabilities.core.shell,
+      }
+    );
+  }
+  if (node.capabilities.core.tmux !== 'available') {
+    return relayError(
+      'NODE_UNSUPPORTED',
+      `node ${nodeId} cannot host tmux-backed PTY sessions`,
+      false,
+      {
+        reasonCode: 'NODE_TERMINAL_TMUX_UNAVAILABLE',
+        capability: 'tmux',
+        status: node.capabilities.core.tmux,
+      }
+    );
+  }
+  return null;
+}
+
+function cwdOnboardingRoot(node: HubNodeSummary, cwd: string): string {
+  if (node.platform === 'win32') {
+    const drive = cwd.match(/^[a-zA-Z]:[\\/]/)?.[0]?.slice(0, 2);
+    return drive ? `${drive}\\` : cwd;
+  }
+  return '/';
+}
+
+function nodeCwdOnboardingPayload(input: {
+  node: HubNodeSummary;
+  body: Record<string, unknown>;
+  operation: 'browse' | 'validate';
+}): { request: Record<string, unknown>; cwd: string; path: string } | RelayNodeError {
+  const cwd = stringField(input.body, 'cwd') ?? input.node.homeDir ?? '/';
+  if (cwd.includes('\0')) {
+    return relayError('INVALID_REQUEST', 'cwd must not contain NUL bytes', false, {
+      reasonCode: 'NODE_CWD_INVALID_REQUEST',
+      field: 'cwd',
+    });
+  }
+  const root = cwdOnboardingRoot(input.node, cwd);
+  const pathValue =
+    input.operation === 'validate'
+      ? cwd
+      : (stringField(input.body, 'path') ?? '.');
+  if (pathValue.includes('\0')) {
+    return relayError('INVALID_REQUEST', 'path must not contain NUL bytes', false, {
+      reasonCode: 'NODE_CWD_INVALID_REQUEST',
+      field: 'path',
+    });
+  }
+  const maxEntries = input.body['maxEntries'];
+  return {
+    cwd,
+    path: pathValue,
+    request: {
+      sessionId: 'cwd-onboarding',
+      root,
+      cwd: input.operation === 'validate' ? root : cwd,
+      path: pathValue,
+      ...(input.operation === 'browse' && maxEntries !== undefined ? { maxEntries } : {}),
+    },
+  };
+}
+
 function sessionCreatePolicyScope(
   nodeId: string,
   body: Record<string, unknown>
@@ -2174,6 +2251,89 @@ export function createHubNodeRouter(
     res.json({ session: summary });
   });
 
+  router.post('/hub/nodes/:nodeId/cwd/:operation', requireAuth, async (req, res) => {
+    const { nodeId, operation } = req.params;
+    if (!nodeId) {
+      sendRelayError(res, relayError('INVALID_REQUEST', 'nodeId is required'));
+      return;
+    }
+    if (operation !== 'browse' && operation !== 'validate') {
+      sendRelayError(
+        res,
+        relayError('INVALID_REQUEST', 'cwd operation must be browse or validate')
+      );
+      return;
+    }
+    const node = registry
+      .listNodes()
+      .find((candidate) => candidate.nodeId === nodeId);
+    if (!node || node.status === 'revoked') {
+      sendRelayError(res, relayError('NOT_FOUND', 'node is not paired'));
+      return;
+    }
+    if (node.protocolVersion !== RELAY_NODE_LINK_PROTOCOL_VERSION) {
+      sendRelayError(res, protocolVersionRelayError(node.protocolVersion));
+      return;
+    }
+    const terminalUnsupported = nodeTerminalUnsupportedError(nodeId, node);
+    if (terminalUnsupported) {
+      sendRelayError(res, terminalUnsupported);
+      return;
+    }
+    if (node.status !== 'online' || !options.nodeLinks?.hasActiveNode(nodeId)) {
+      sendRelayError(
+        res,
+        relayError('NODE_OFFLINE', `node ${nodeId} has no live reverse link`, true)
+      );
+      return;
+    }
+
+    const body = bodyRecord(req);
+    const normalized = nodeCwdOnboardingPayload({ node, body, operation });
+    if ('code' in normalized) {
+      sendRelayError(res, normalized);
+      return;
+    }
+    const action = operation === 'browse' ? 'rpc.fs.list' : 'rpc.fs.stat';
+    const nowForPolicy = now();
+    const policyDecision = evaluateHubPolicy({
+      peer: { kind: 'hub' },
+      node,
+      nodeId,
+      intent: { action, target: nodeId },
+      scope: {
+        kind: 'node-cwd',
+        nodeId,
+        cwd: normalized.cwd,
+        path: normalized.path,
+      },
+      requiredCapabilities: requiredCapabilitiesForRpcIntent(action),
+      params: normalized.request,
+      now: nowForPolicy,
+    });
+    if (
+      sendPolicyDecision(options.auditSink, res, policyDecision, normalized.request, {
+        confirmations,
+        req,
+        canonicalParams: normalized.request,
+        now: nowForPolicy,
+      })
+    ) return;
+
+    try {
+      const rpcType = operation === 'browse' ? 'fs.list' : 'fs.stat';
+      const payload = await options.nodeLinks.request(nodeId, rpcType, normalized.request);
+      const responsePayload = isRecord(payload) ? payload : { payload };
+      res.json({ nodeId, cwd: normalized.cwd, ...responsePayload });
+    } catch (error) {
+      if (error instanceof HubNodeLinkError) {
+        sendRelayError(res, error.relayNodeError);
+        return;
+      }
+      sendRegistryError(registry, res, error);
+    }
+  });
+
   router.post('/hub/nodes/:nodeId/sessions', cliGatewayAuth, async (req, res) => {
     const { nodeId } = req.params;
     if (!nodeId) {
@@ -2210,14 +2370,9 @@ export function createHubNodeRouter(
       );
       return;
     }
-    if (node.capabilities.core.tmux !== 'available') {
-      sendRelayError(
-        res,
-        relayError(
-          'NODE_UNSUPPORTED',
-          `node ${nodeId} cannot host tmux-backed PTY sessions`
-        )
-      );
+    const terminalUnsupported = nodeTerminalUnsupportedError(nodeId, node);
+    if (terminalUnsupported) {
+      sendRelayError(res, terminalUnsupported);
       return;
     }
     if (node.status !== 'online' || !options.nodeLinks?.hasActiveNode(nodeId)) {

--- a/shared/security-policy.ts
+++ b/shared/security-policy.ts
@@ -38,6 +38,7 @@ export const LEGACY_DEFAULT_ALLOWED_CAPABILITIES = [
   'session:create:terminal',
   'session:create:agent',
   'session:attach',
+  'session:control:kill',
   'tab:mode:set-agent',
   'rpc:fs:list',
   'rpc:fs:read',

--- a/test/hub-confirmation-routing.test.ts
+++ b/test/hub-confirmation-routing.test.ts
@@ -127,6 +127,7 @@ describe('hub confirmation routing', () => {
       node?: HubNodeSummary;
       workContextStore?: WorkContextStore;
       sessionPayload?: unknown;
+      nodeLinkResponse?: (nodeId: string, type: string, payload: unknown) => unknown | Promise<unknown>;
     } = {}
   ) {
     const nodeLinks = {
@@ -134,6 +135,7 @@ describe('hub confirmation routing', () => {
       hasActiveNode: () => true,
       request: async (nodeId: string, type: string, payload: unknown): Promise<unknown> => {
         nodeLinks.requests.push({ nodeId, type, payload });
+        if (options.nodeLinkResponse) return options.nodeLinkResponse(nodeId, type, payload);
         return options.sessionPayload ?? sessionPayload();
       },
     };
@@ -456,6 +458,152 @@ describe('hub confirmation routing', () => {
       id: 'remote-session-1',
       nodeId: 'node_prod',
       live: true,
+    });
+  });
+
+  it('creates routed terminal sessions from node-local cwd without repo identity or agent capability', async () => {
+    const node = nodeSummary({
+      allowed: ['session:read', 'session:create:terminal'],
+      requiresConfirmation: [],
+    });
+    const payload = sessionPayload();
+    delete payload.session.repoPath;
+    delete payload.session.worktreePath;
+    payload.session.cwd = '/home/relay/scratch';
+    delete payload.session.repoName;
+    delete payload.session.branchName;
+    payload.session.displayName = 'scratch terminal';
+    const { base, nodeLinks } = await startHub({ node, sessionPayload: payload });
+    const body = { cwd: '/home/relay/scratch', type: 'terminal' };
+
+    const response = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+      },
+      body: JSON.stringify(body),
+    });
+
+    expect(response.status).toBe(201);
+    const session = await response.json();
+    expect(session).toMatchObject({
+      id: 'remote-session-1',
+      nodeId: 'node_prod',
+      cwd: '/home/relay/scratch',
+    });
+    expect(session.repoPath).toBeUndefined();
+    expect(session.worktreePath).toBeUndefined();
+    expect(session.repoName).toBeUndefined();
+    expect(session.branchName).toBeUndefined();
+    expect(session.repoInstanceId).toBeUndefined();
+    expect(session.worktreeInstanceId).toBeUndefined();
+    expect(session.sessionEnvelope.scope).toMatchObject({
+      kind: 'node-cwd',
+      nodeId: 'node_prod',
+      cwd: '/home/relay/scratch',
+    });
+    expect(nodeLinks.requests).toHaveLength(1);
+    expect(nodeLinks.requests[0]).toMatchObject({ type: 'sessions.create', payload: body });
+  });
+
+  it('denies routed terminal create when shell is unavailable even if an agent is available', async () => {
+    const node = {
+      ...nodeSummary({
+        allowed: ['session:read', 'session:create:terminal'],
+        requiresConfirmation: [],
+      }),
+      capabilities: {
+        ...nodeSummary().capabilities,
+        core: { ...nodeSummary().capabilities.core, shell: 'unavailable' as const },
+        agents: { claude: 'available' as const },
+      },
+    };
+    const { base, nodeLinks } = await startHub({ node });
+
+    const response = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+      },
+      body: JSON.stringify({ cwd: '/home/relay/scratch', type: 'terminal' }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: {
+        code: 'NODE_UNSUPPORTED',
+        details: { reasonCode: 'NODE_TERMINAL_SHELL_UNAVAILABLE' },
+      },
+    });
+    expect(nodeLinks.requests).toHaveLength(0);
+  });
+
+  it('routes node-local cwd browse and validation through file RPC without repo metadata', async () => {
+    const node = {
+      ...nodeSummary({
+        allowed: ['session:read', 'rpc:fs:list', 'rpc:fs:read'],
+        requiresConfirmation: [],
+      }),
+      homeDir: '/home/relay',
+    };
+    const { base, nodeLinks } = await startHub({
+      node,
+      nodeLinkResponse: (_nodeId, type) =>
+        type === 'fs.list'
+          ? { operation: 'list', entries: [{ name: 'scratch', type: 'directory' }] }
+          : { operation: 'stat', stat: { path: '/home/relay/scratch', type: 'directory' } },
+    });
+
+    const browse = await fetch(`${base}/hub/nodes/node_prod/cwd/browse`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+      },
+      body: JSON.stringify({ cwd: '/home/relay', path: 'scratch' }),
+    });
+    expect(browse.status).toBe(200);
+    expect(await browse.json()).toMatchObject({
+      nodeId: 'node_prod',
+      cwd: '/home/relay',
+      operation: 'list',
+    });
+
+    const validate = await fetch(`${base}/hub/nodes/node_prod/cwd/validate`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+      },
+      body: JSON.stringify({ cwd: '/home/relay/scratch' }),
+    });
+    expect(validate.status).toBe(200);
+    expect(await validate.json()).toMatchObject({
+      nodeId: 'node_prod',
+      cwd: '/home/relay/scratch',
+      operation: 'stat',
+    });
+
+    expect(nodeLinks.requests).toHaveLength(2);
+    expect(nodeLinks.requests[0]).toMatchObject({
+      type: 'fs.list',
+      payload: {
+        sessionId: 'cwd-onboarding',
+        root: '/',
+        cwd: '/home/relay',
+        path: 'scratch',
+      },
+    });
+    expect(nodeLinks.requests[1]).toMatchObject({
+      type: 'fs.stat',
+      payload: {
+        sessionId: 'cwd-onboarding',
+        root: '/',
+        cwd: '/',
+        path: '/home/relay/scratch',
+      },
     });
   });
 

--- a/test/hub-policy-evaluator.test.ts
+++ b/test/hub-policy-evaluator.test.ts
@@ -168,6 +168,21 @@ describe('hub policy evaluator', () => {
         })
       )
     ).toMatchObject({
+      decision: 'allow',
+      reasonCode: 'POLICY_ALLOWED',
+      grantedBits: ['session:control:kill'],
+    });
+
+    const attachOnlyNode = nodeSummary({ allowed: ['session:read', 'session:attach'] });
+    expect(
+      evaluateHubPolicy(
+        baseInput({
+          node: attachOnlyNode,
+          intent: { action: 'sessions.kill', target: 'node_a' },
+          requiredCapabilities: requiredCapabilitiesForRpcIntent('sessions.kill'),
+        })
+      )
+    ).toMatchObject({
       decision: 'deny',
       reasonCode: 'POLICY_CAPABILITY_DENIED',
       deniedBits: ['session:control:kill'],

--- a/test/security-policy.test.ts
+++ b/test/security-policy.test.ts
@@ -28,7 +28,7 @@ describe('security policy schema', () => {
     });
     expect(resolveAclCapability(acl, 'session:control:kill')).toMatchObject({
       known: true,
-      decision: 'deny',
+      decision: 'allow',
     });
   });
 

--- a/test/stores/node-dashboard.test.ts
+++ b/test/stores/node-dashboard.test.ts
@@ -20,14 +20,18 @@ const createdAt = '2026-01-02T03:00:00.000Z';
 function policy(
   nodeId: string,
   trustTier: RelayTrustTier = 'dev',
-  overrides: Partial<{ allowed: RelayCapabilityBit[]; requiresConfirmation: RelayCapabilityBit[] }> = {}
+  overrides: Partial<{
+    allowed: RelayCapabilityBit[];
+    requiresConfirmation: RelayCapabilityBit[];
+  }> = {}
 ) {
   const acl = createLegacyDefaultNodeAcl({ nodeId, trustTier, createdAt });
   return summarizeAcl({
     ...acl,
     grants: {
       allowed: overrides.allowed ?? acl.grants.allowed,
-      requiresConfirmation: overrides.requiresConfirmation ?? acl.grants.requiresConfirmation,
+      requiresConfirmation:
+        overrides.requiresConfirmation ?? acl.grants.requiresConfirmation,
     },
   });
 }
@@ -290,9 +294,13 @@ describe('hub node dashboard state', () => {
 
     // #597 added `logs:read` to the capability bit set; counts shift by 1
     // in every tier (denied in sandbox, allowed in dev, denied in prod).
-    expect(rows.map((row) => [row.security.trustTier, row.security.postureLabel])).toEqual([
+    // #592 added `session:control:kill` following the same tier pattern:
+    // allowed in dev, denied in sandbox + prod.
+    expect(
+      rows.map((row) => [row.security.trustTier, row.security.postureLabel])
+    ).toEqual([
       ['sandbox', 'allow 1 · challenge 0 · deny 16'],
-      ['dev', 'allow 10 · challenge 0 · deny 7'],
+      ['dev', 'allow 11 · challenge 0 · deny 6'],
       ['prod', 'allow 1 · challenge 2 · deny 14'],
     ]);
     expect(rows[2].security).toMatchObject({
@@ -320,7 +328,8 @@ describe('hub node dashboard state', () => {
       policyRef: null,
       postureLabel: 'policy unavailable · capability grants hidden',
       highRiskLabel: 'audit: cli only · relay-ide audit verify',
-      auditLabel: 'audit visibility: run relay-ide audit verify --db ~/.config/relay-ide/security-audit.db',
+      auditLabel:
+        'audit visibility: run relay-ide audit verify --db ~/.config/relay-ide/security-audit.db',
     });
   });
 
@@ -342,7 +351,10 @@ describe('hub node dashboard state', () => {
             state: 'trusted',
             level: 'dev',
             tier: 'dev',
-            policy: { ...policy('superseded-node'), supersededBy: 'acl:superseding:1.0' },
+            policy: {
+              ...policy('superseded-node'),
+              supersededBy: 'acl:superseding:1.0',
+            },
           },
         }),
       ],
@@ -358,7 +370,11 @@ describe('hub node dashboard state', () => {
       `policy superseded · deny ${RELAY_CAPABILITY_BITS.length}`,
     ]);
     expect(rows.map((row) => row.security.tone)).toEqual(['danger', 'danger']);
-    expect(rows.every((row) => row.security.denyBits.length === RELAY_CAPABILITY_BITS.length)).toBe(true);
+    expect(
+      rows.every(
+        (row) => row.security.denyBits.length === RELAY_CAPABILITY_BITS.length
+      )
+    ).toBe(true);
   });
 
   it('summarizes which machines can currently do work', () => {


### PR DESCRIPTION
## Summary
- Adds hub-routed node cwd onboarding endpoints: `POST /hub/nodes/:nodeId/cwd/browse` and `POST /hub/nodes/:nodeId/cwd/validate`, backed by node file RPC.
- Allows routed terminal session creation from a node-local `cwd` without repo/worktree identity and preserves node-cwd session envelope scope.
- Gates terminal creation on shell + tmux availability instead of agent availability.
- Adds `session:control:kill` to the legacy default ACL so newly paired dev nodes can clean up browser-created remote terminal sessions; prod still requires confirmation via the high-risk overlay.

Refs #591

## The Case Against
- This introduces a new cwd onboarding route without a frontend typed client contract yet; the frontend slice still needs to wire UI calls and may want endpoint naming adjusted.
- Cwd validation uses read-only file RPC `fs.stat` with a synthetic onboarding session id and root-scoped validation. That is intentionally narrow, but it is still a new node filesystem access path.
- Existing already-stored ACLs that lack `session:control:kill` may still deny kill until their ACL is updated/repaired; this PR fixes new legacy defaults and keeps explicit attach-only denial behavior covered.

## Verification
- `npm test -- test/hub-policy-evaluator.test.ts test/hub-confirmation-routing.test.ts test/security-policy.test.ts`
- `npm run check` (passes with existing lint warnings)
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to browse and validate working directories directly on nodes without requiring repository metadata
  * Enhanced session management with improved support for session termination operations
  * Strengthened terminal session routing with better node capability validation

* **Bug Fixes**
  * Improved capability validation for terminal operations across different node configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->