### PR TITLE
feat: add node cwd terminal flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -704,14 +704,14 @@ function TerminalAreaContent({
 
       {viewMode === 'empty' && (
         <EmptyState
-          heading="add a repo to get started"
-          description="point to any folder on your machine. git repos get pr tracking and branch management."
-          actionLabel="+ add repo"
+          heading="open a working directory"
+          description="start from any project folder. git repos still get pr tracking and branch management when available."
+          actionLabel="open project"
           onAction={onAddWorkspace}
           hint={
             onboardingHints.showNoReposHint ? (
               <Hint id={HINT_NO_REPOS} variant="inline-text">
-                relay-ide manages claude code sessions across your repos.
+                relay-ide opens terminal and agent tabs across your projects.
               </Hint>
             ) : undefined
           }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -606,7 +606,7 @@ export function Sidebar({
               onClick={onAddWorkspace}
               style={{ flex: 1 }}
             >
-              + add repo
+              open project
             </TuiButton>
             <button
               className={['sidebar-settings-icon-btn', analyticsView !== null && 'active']

--- a/frontend/src/components/WorkspaceArea.tsx
+++ b/frontend/src/components/WorkspaceArea.tsx
@@ -291,7 +291,7 @@ function RemoteTerminalCwdDialog({
         onClick={() => onSubmit(homeDir, 'remote-home')}
         disabled={!homeDir || creating}
       >
-        start in home
+        open home terminal
       </TuiButton>
       <TuiButton
         variant="primary"
@@ -299,7 +299,7 @@ function RemoteTerminalCwdDialog({
         onClick={() => onSubmit(cwd, 'remote-cwd')}
         disabled={!cleanCwd(cwd) || creating}
       >
-        {creating ? 'starting...' : 'start terminal'}
+        {creating ? 'opening...' : 'open terminal tab'}
       </TuiButton>
     </div>
   );
@@ -308,7 +308,7 @@ function RemoteTerminalCwdDialog({
     <DialogShell
       ref={shellRef}
       width="460px"
-      title="remote terminal cwd"
+      title="open terminal tab"
       footer={footer}
       onClose={onClose}
     >
@@ -319,26 +319,26 @@ function RemoteTerminalCwdDialog({
           </div>
         )}
         <div className="ws-remote-terminal-copy">
-          choose the node-local directory before creating a terminal on{' '}
+          choose the node-local working directory before creating a terminal on{' '}
           {nodeLabel}.
         </div>
         <div className="ws-remote-terminal-field">
           <label className="ws-remote-terminal-label" htmlFor="ws-remote-cwd">
-            cwd on {nodeLabel}
+            working directory on {nodeLabel}
           </label>
           <input
             id="ws-remote-cwd"
             type="text"
             className="ws-remote-terminal-input"
             data-track="workspace.remote-terminal.cwd"
-            placeholder={homeDir || 'absolute path on remote node'}
+            placeholder={homeDir || 'absolute path on node'}
             value={cwd}
             onChange={(event) => setCwd(event.currentTarget.value)}
             autoComplete="off"
           />
           <div className="ws-remote-terminal-note">
-            remote terminals start directly in this directory. use start in home
-            to skip remembering a cwd.
+            terminal tabs start directly in this directory. use open home
+            terminal to skip remembering a cwd.
           </div>
         </div>
       </div>

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -131,7 +131,10 @@ export interface EnvironmentPickerModel {
   selectedGroupId: string | null;
   selectedNodeId: NodeId;
   selectedCheckoutId: string | null;
+  /** Blocks terminal/session creation on this node. Does not include agent availability. */
   selectedNodeReason: string | null;
+  /** Blocks only agent launch. Plain terminal creation intentionally ignores this. */
+  selectedAgentReason: string | null;
   resolved: {
     nodeId: NodeId;
     repoPath: string;
@@ -274,10 +277,7 @@ function capabilityProblem(
   return `${name} ${capability}`;
 }
 
-function nodeBlockReason(
-  node: HubNodeSummary | null,
-  selectedAgent: AgentType
-): string | null {
+function nodeTerminalBlockReason(node: HubNodeSummary | null): string | null {
   if (!node) return 'node availability unknown';
   if (node.status === 'offline') return 'node is offline';
   if (node.status === 'stale') return 'heartbeat is stale';
@@ -286,6 +286,14 @@ function nodeBlockReason(
   if (shellProblem) return shellProblem;
   const tmuxProblem = capabilityProblem(node.capabilities.core.tmux, 'tmux');
   if (tmuxProblem) return `${tmuxProblem} on ${node.displayName}`;
+  return null;
+}
+
+function nodeAgentBlockReason(
+  node: HubNodeSummary | null,
+  selectedAgent: AgentType
+): string | null {
+  if (!node || nodeTerminalBlockReason(node)) return null;
   const agentProblem = capabilityProblem(
     node.capabilities.agents[selectedAgent],
     selectedAgent
@@ -391,7 +399,7 @@ function nodeChoicesFor(
     if (seenNodeChoices.has(nodeId)) return [];
     seenNodeChoices.add(nodeId);
     const node = nodeById.get(nodeId) ?? null;
-    const reason = nodeBlockReason(node, input.selectedAgent);
+    const reason = nodeTerminalBlockReason(node);
     return [
       {
         value: nodeId,
@@ -488,6 +496,10 @@ export function buildEnvironmentPickerModel(
   );
   const selectedNodeId = selectedNodeChoice?.value ?? DEFAULT_LOCAL_NODE_ID;
   const selectedNodeReason = selectedNodeChoice?.reason ?? null;
+  const selectedAgentReason = nodeAgentBlockReason(
+    nodeById.get(selectedNodeId) ?? null,
+    input.selectedAgent
+  );
   const selectedNodeInstances = selectedGroup.instances.filter(
     (instance) => instance.nodeId === selectedNodeId
   );
@@ -514,6 +526,7 @@ export function buildEnvironmentPickerModel(
     selectedNodeId,
     selectedCheckoutId: selectedCheckout?.value ?? null,
     selectedNodeReason,
+    selectedAgentReason,
     resolved: resolveEnvironment(selectedNodeId, selectedCheckout, input),
   };
 }
@@ -575,6 +588,42 @@ async function createSessionFromForm(
   });
 }
 
+function agentLaunchBlockReason(
+  environmentModel: EnvironmentPickerModel
+): string | null {
+  return environmentModel.selectedNodeReason ?? environmentModel.selectedAgentReason;
+}
+
+async function createTerminalFromEnvironment(
+  environment: EnvironmentPickerModel['resolved'],
+  sessionLane: SessionLane,
+  remoteCwd?: string
+) {
+  const remoteNodeSelected = environment.nodeId !== DEFAULT_LOCAL_NODE_ID;
+  const { cols, rows } = estimateTerminalDimensions(
+    useUiStore.getState().terminalFontSize
+  );
+  if (remoteNodeSelected) {
+    return createAgentSession({
+      nodeId: environment.nodeId,
+      type: 'terminal',
+      cwd: cleanCwd(remoteCwd),
+      sessionLane,
+      cols,
+      rows,
+    });
+  }
+  return createAgentSession({
+    nodeId: environment.nodeId,
+    type: 'terminal',
+    repoPath: environment.repoPath,
+    worktreePath: environment.worktreePath,
+    sessionLane,
+    cols,
+    rows,
+  });
+}
+
 interface BodyProps {
   workspaceName: string;
   form: FormState;
@@ -590,6 +639,65 @@ interface EnvironmentSelection {
   selectedGroupId: string | null;
   selectedNodeId: NodeId | null;
   selectedCheckoutId: string | null;
+}
+
+interface AgentRuntimeFieldProps {
+  form: FormState;
+  environmentModel: EnvironmentPickerModel;
+  frameworkOptions: FrameworkInfo[];
+  selectedFramework: FrameworkInfo | undefined;
+  selectedUnavailable: boolean | undefined;
+  onFormChange: (patch: Partial<FormState>) => void;
+}
+
+function AgentRuntimeField({
+  form,
+  environmentModel,
+  frameworkOptions,
+  selectedFramework,
+  selectedUnavailable,
+  onFormChange,
+}: AgentRuntimeFieldProps) {
+  const note = selectedUnavailable
+    ? (selectedFramework?.availability?.reason ??
+      `${selectedFramework?.displayName ?? form.selectedAgent} is not installed`)
+    : environmentModel.selectedAgentReason;
+
+  return (
+    <div className="customize-session-dialog-field">
+      <label className="customize-session-dialog-label" htmlFor="cs-agent">
+        agent runtime (optional)
+      </label>
+      <select
+        id="cs-agent"
+        className="customize-session-dialog-select"
+        data-track="dialog.customize-session.agent"
+        value={form.selectedAgent}
+        onChange={(e) => {
+          const selectedAgent = e.currentTarget.value as AgentType;
+          onFormChange({
+            selectedAgent,
+            sessionMode: defaultSessionModeForAgent(
+              frameworkOptions,
+              selectedAgent
+            ),
+          });
+        }}
+      >
+        {frameworkOptions.map((framework) => (
+          <option
+            key={framework.id}
+            value={framework.id}
+            disabled={!isFrameworkAvailable(framework)}
+          >
+            {framework.displayName}
+            {!isFrameworkAvailable(framework) ? ' (not installed)' : ''}
+          </option>
+        ))}
+      </select>
+      {note && <div className="customize-session-field-note">{note}</div>}
+    </div>
+  );
 }
 
 function CustomizeSessionBody({
@@ -651,8 +759,9 @@ function CustomizeSessionBody({
           aria-label="environment picker"
         >
           <div className="customize-session-environment-copy">
-            choose repo identity, execution node, then node-local checkout. no
-            live cross-host pty migration or automatic filesystem sync.
+            choose an execution node and working directory first. open a plain
+            terminal tab from any online shell-capable node; agent launch stays
+            optional and uses node-specific agent availability.
           </div>
           {environmentModel.repoChoices.length > 1 && (
             <div className="customize-session-dialog-field">
@@ -660,7 +769,7 @@ function CustomizeSessionBody({
                 className="customize-session-dialog-label"
                 htmlFor="cs-repo"
               >
-                repo identity
+                git project identity
               </label>
               <select
                 id="cs-repo"
@@ -728,20 +837,20 @@ function CustomizeSessionBody({
                 className="customize-session-dialog-label"
                 htmlFor="cs-remote-cwd"
               >
-                cwd on {remoteNodeLabel}
+                working directory on {remoteNodeLabel}
               </label>
               <input
                 id="cs-remote-cwd"
                 type="text"
                 className="customize-session-dialog-input"
                 data-track="dialog.customize-session.remote-cwd"
-                placeholder={remoteHomeDir || 'absolute path on remote node'}
+                placeholder={remoteHomeDir || 'absolute path on node'}
                 value={remoteCwd}
                 onChange={(e) => onRemoteCwdChange(e.currentTarget.value)}
                 autoComplete="off"
               />
               <div className="customize-session-field-note">
-                remote sessions start directly in this node-local directory.
+                terminal tabs start directly in this node-local directory.
               </div>
             </div>
           )}
@@ -752,7 +861,7 @@ function CustomizeSessionBody({
                   className="customize-session-dialog-label"
                   htmlFor="cs-checkout"
                 >
-                  node-local checkout
+                  git checkout / worktree
                 </label>
                 <select
                   id="cs-checkout"
@@ -780,44 +889,14 @@ function CustomizeSessionBody({
             )}
         </section>
       )}
-      <div className="customize-session-dialog-field">
-        <label className="customize-session-dialog-label" htmlFor="cs-agent">
-          coding agent
-        </label>
-        <select
-          id="cs-agent"
-          className="customize-session-dialog-select"
-          data-track="dialog.customize-session.agent"
-          value={form.selectedAgent}
-          onChange={(e) => {
-            const selectedAgent = e.currentTarget.value as AgentType;
-            onFormChange({
-              selectedAgent,
-              sessionMode: defaultSessionModeForAgent(
-                frameworkOptions,
-                selectedAgent
-              ),
-            });
-          }}
-        >
-          {frameworkOptions.map((framework) => (
-            <option
-              key={framework.id}
-              value={framework.id}
-              disabled={!isFrameworkAvailable(framework)}
-            >
-              {framework.displayName}
-              {!isFrameworkAvailable(framework) ? ' (not installed)' : ''}
-            </option>
-          ))}
-        </select>
-        {selectedUnavailable && (
-          <div className="customize-session-field-note">
-            {selectedFramework.availability?.reason ??
-              `${selectedFramework.displayName} is not installed`}
-          </div>
-        )}
-      </div>
+      <AgentRuntimeField
+        form={form}
+        environmentModel={environmentModel}
+        frameworkOptions={frameworkOptions}
+        selectedFramework={selectedFramework}
+        selectedUnavailable={selectedUnavailable}
+        onFormChange={onFormChange}
+      />
       {modeOptions.length > 1 && (
         <div className="customize-session-dialog-field">
           <label className="customize-session-dialog-label" htmlFor="cs-mode">
@@ -1047,8 +1126,9 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
         );
         return;
       }
-      if (environmentModel.selectedNodeReason) {
-        setError(environmentModel.selectedNodeReason);
+      const blockReason = agentLaunchBlockReason(environmentModel);
+      if (blockReason) {
+        setError(blockReason);
         return;
       }
       const cwdForRemote = remoteNodeSelected
@@ -1090,6 +1170,53 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
       }
     }
 
+    async function handleTerminalSubmit(
+      remoteCwdOverride?: string,
+      rememberCwd = true
+    ) {
+      if (!workspacePath || creating) return;
+      if (environmentModel.selectedNodeReason) {
+        setError(environmentModel.selectedNodeReason);
+        return;
+      }
+      const cwdForRemote = remoteNodeSelected
+        ? cleanCwd(remoteCwdOverride ?? remoteCwd)
+        : undefined;
+      if (remoteNodeSelected && !cwdForRemote) {
+        setError('working directory is required for remote terminal tabs');
+        return;
+      }
+      setCreating(true);
+      setError(null);
+      const sessionLane: SessionLane = remoteNodeSelected
+        ? rememberCwd
+          ? 'remote-cwd'
+          : 'remote-home'
+        : 'local-repo';
+      try {
+        const { session, error: submitError } = await createTerminalFromEnvironment(
+          environmentModel.resolved,
+          sessionLane,
+          cwdForRemote
+        );
+        if (submitError && !session) {
+          setError(
+            submitError instanceof Error
+              ? submitError.message
+              : 'Failed to create terminal tab'
+          );
+          return;
+        }
+        if (remoteNodeSelected && cwdForRemote && rememberCwd) {
+          rememberRemoteCwd(environmentModel.selectedNodeId, cwdForRemote);
+        }
+        shellRef.current?.close();
+        if (session?.id) onSessionCreated?.(session.id);
+      } finally {
+        setCreating(false);
+      }
+    }
+
     const footer = (
       <div className="customize-session-footer-row">
         <TuiButton
@@ -1097,13 +1224,13 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
           onClick={() => shellRef.current?.close()}
           disabled={creating}
         >
-          Cancel
+          cancel
         </TuiButton>
         {remoteNodeSelected && (
           <TuiButton
             variant="ghost"
-            data-track="dialog.customize-session.start-in-home"
-            onClick={() => void handleSubmit(selectedRemoteHome, false)}
+            data-track="dialog.customize-session.open-home-terminal"
+            onClick={() => void handleTerminalSubmit(selectedRemoteHome, false)}
             disabled={
               !workspacePath ||
               !selectedRemoteHome ||
@@ -1111,16 +1238,17 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
               creating
             }
           >
-            Start in Home
+            open home terminal
           </TuiButton>
         )}
         <TuiButton
-          variant="primary"
-          data-track="dialog.customize-session.create"
+          variant="ghost"
+          data-track="dialog.customize-session.start-agent"
           onClick={() => void handleSubmit()}
           disabled={
             !workspacePath ||
             Boolean(environmentModel.selectedNodeReason) ||
+            Boolean(environmentModel.selectedAgentReason) ||
             (remoteNodeSelected && !cleanCwd(remoteCwd)) ||
             creating ||
             frameworks.some(
@@ -1132,7 +1260,20 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
             )
           }
         >
-          {creating ? 'Creating...' : 'Start Session'}
+          {creating ? 'starting...' : 'start agent tab'}
+        </TuiButton>
+        <TuiButton
+          variant="primary"
+          data-track="dialog.customize-session.open-terminal"
+          onClick={() => void handleTerminalSubmit()}
+          disabled={
+            !workspacePath ||
+            Boolean(environmentModel.selectedNodeReason) ||
+            (remoteNodeSelected && !cleanCwd(remoteCwd)) ||
+            creating
+          }
+        >
+          {creating ? 'opening...' : 'open terminal tab'}
         </TuiButton>
       </div>
     );
@@ -1141,7 +1282,7 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
       <DialogShell
         ref={shellRef}
         width="480px"
-        title="Customize Session"
+        title="open working directory"
         footer={footer}
       >
         {error && (

--- a/frontend/src/lib/workspace-summary.ts
+++ b/frontend/src/lib/workspace-summary.ts
@@ -110,7 +110,7 @@ function summaryForSessionTab(
     session?.branchName ||
     (isTerminal ? 'terminal' : 'session');
   const dot = sessionDot(session?.agentState, session?.idle);
-  const meta = sessionMeta(session, isTerminal);
+  const meta = sessionMeta(session);
   const nodeBadge = nodeBadgeFor(tab.nodeId ?? session?.nodeId, ctx);
   return {
     icon,
@@ -157,16 +157,16 @@ function sessionDot(state?: AgentState, idle?: boolean): SummaryDot {
   return null;
 }
 
-function sessionMeta(
-  session: SessionSummary | undefined,
-  isTerminal: boolean
-): string | undefined {
+function sessionMeta(session: SessionSummary | undefined): string | undefined {
   if (!session) return undefined;
   const parts: string[] = [];
   if (session.agent) parts.push(session.agent);
-  if (isTerminal && session.cwd) {
+  if (session.cwd) {
     const last = session.cwd.split('/').filter(Boolean).pop();
     if (last) parts.push(last);
+  }
+  if (session.repoName && !parts.includes(session.repoName)) {
+    parts.push(session.repoName);
   }
   if (session.agentState) parts.push(session.agentState);
   return parts.length > 0 ? parts.join(' · ') : undefined;

--- a/frontend/src/test-customize-session-dialog.tsx
+++ b/frontend/src/test-customize-session-dialog.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import React, { useRef, useState } from 'react';
 import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import CustomizeSessionDialog, {
   type CustomizeSessionDialogHandle,
 } from './components/dialogs/CustomizeSessionDialog.js';
@@ -386,6 +387,10 @@ useConfigStore.setState({
   frameworks: [framework('claude'), framework('codex'), framework('hermes')],
 });
 
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+});
+
 function Harness() {
   const dialogRef = useRef<CustomizeSessionDialogHandle>(null);
   const [createdSession, setCreatedSession] = useState('');
@@ -463,6 +468,8 @@ function Harness() {
 
 ReactDOM.createRoot(document.getElementById('app')!).render(
   <React.StrictMode>
-    <Harness />
+    <QueryClientProvider client={queryClient}>
+      <Harness />
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/test/customize-session-dialog-open-race.test.ts
+++ b/test/customize-session-dialog-open-race.test.ts
@@ -344,7 +344,7 @@ describe('CustomizeSessionDialog open races', () => {
     );
 
     await act(async () => {
-      (el.querySelector('[data-track="dialog.customize-session.create"]') as HTMLButtonElement).click();
+      (el.querySelector('[data-track="dialog.customize-session.start-agent"]') as HTMLButtonElement).click();
     });
     await flush();
 
@@ -375,7 +375,7 @@ describe('CustomizeSessionDialog open races', () => {
     await flush();
 
     await act(async () => {
-      (el.querySelector('[data-track="dialog.customize-session.create"]') as HTMLButtonElement).click();
+      (el.querySelector('[data-track="dialog.customize-session.open-terminal"]') as HTMLButtonElement).click();
     });
     await flush();
 
@@ -406,7 +406,7 @@ describe('CustomizeSessionDialog open races', () => {
     await flush();
 
     await act(async () => {
-      (el.querySelector('[data-track="dialog.customize-session.start-in-home"]') as HTMLButtonElement).click();
+      (el.querySelector('[data-track="dialog.customize-session.open-home-terminal"]') as HTMLButtonElement).click();
     });
     await flush();
 
@@ -437,7 +437,7 @@ describe('CustomizeSessionDialog open races', () => {
     expect(cwdInput.value).toBe('/home/relay');
 
     await act(async () => {
-      (el.querySelector('[data-track="dialog.customize-session.create"]') as HTMLButtonElement).click();
+      (el.querySelector('[data-track="dialog.customize-session.open-terminal"]') as HTMLButtonElement).click();
     });
     await flush();
 
@@ -477,7 +477,7 @@ describe('CustomizeSessionDialog open races', () => {
     expect(cwdInput.value).toBe('/home/relay');
 
     await act(async () => {
-      (el.querySelector('[data-track="dialog.customize-session.create"]') as HTMLButtonElement).click();
+      (el.querySelector('[data-track="dialog.customize-session.open-terminal"]') as HTMLButtonElement).click();
     });
     await flush();
 
@@ -491,7 +491,7 @@ describe('CustomizeSessionDialog open races', () => {
     expect(payload).not.toHaveProperty('worktreePath');
   });
 
-  it('disables Start in Home for a blocked selected remote node', async () => {
+  it('disables open home terminal for a blocked selected remote node', async () => {
     const el = await renderAndOpen(
       { name: 'remote-only', path: '/srv/remote-only' },
       remoteOnlyInventory(),
@@ -508,7 +508,7 @@ describe('CustomizeSessionDialog open races', () => {
     await flush();
 
     const startInHome = el.querySelector(
-      '[data-track="dialog.customize-session.start-in-home"]'
+      '[data-track="dialog.customize-session.open-home-terminal"]'
     ) as HTMLButtonElement;
     expect(startInHome.disabled).toBe(true);
 

--- a/test/customize-session-dialog.test.ts
+++ b/test/customize-session-dialog.test.ts
@@ -366,7 +366,7 @@ describe('CustomizeSessionDialog environment picker model', () => {
     expect(model.resolved.nodeId).toBe('local');
   });
 
-  it('disables nodes missing the selected agent capability', () => {
+  it('keeps terminal-capable nodes selectable when the selected agent is unavailable', () => {
     const model = buildEnvironmentPickerModel({
       inventory: inventory(),
       nodes: [
@@ -388,13 +388,12 @@ describe('CustomizeSessionDialog environment picker model', () => {
       fallbackWorktreePath: null,
     });
 
-    expect(
-      model.nodeChoices.find((choice) => choice.value === 'linux')
-    ).toMatchObject({
-      disabled: true,
-      reason: 'claude unavailable on linux lab',
-    });
-    expect(model.resolved.nodeId).toBe('local');
+    const linuxChoice = model.nodeChoices.find((choice) => choice.value === 'linux');
+    expect(linuxChoice?.disabled).toBeUndefined();
+    expect(linuxChoice?.reason).toBeUndefined();
+    expect(model.selectedNodeReason).toBeNull();
+    expect(model.selectedAgentReason).toBe('claude unavailable on linux lab');
+    expect(model.resolved.nodeId).toBe('linux');
   });
 
   it('includes a paired node without repo inventory as a remote target', () => {

--- a/test/e2e/components/CustomizeSessionDialog.spec.ts
+++ b/test/e2e/components/CustomizeSessionDialog.spec.ts
@@ -11,13 +11,13 @@ test.describe('CustomizeSessionDialog', () => {
     await page.getByText('open customize session').click();
     await expect(page.getByRole('dialog')).toBeVisible();
     await expect(
-      page.getByRole('heading', { name: 'Customize Session' })
+      page.getByRole('heading', { name: 'open working directory' })
     ).toBeVisible();
-    await expect(page.getByLabel('repo identity')).toBeVisible();
+    await expect(page.getByLabel('git project identity')).toBeVisible();
     await expect(page.getByLabel('execution node')).toBeVisible();
-    await expect(page.getByLabel('node-local checkout')).toHaveCount(0);
-    await expect(page.getByLabel('cwd on linux lab')).toBeVisible();
-    await expect(page.getByLabel('coding agent')).toBeVisible();
+    await expect(page.getByLabel('git checkout / worktree')).toHaveCount(0);
+    await expect(page.getByLabel('working directory on linux lab')).toBeVisible();
+    await expect(page.getByLabel('agent runtime (optional)')).toBeVisible();
     await expect(page.getByText('continue existing session')).toBeVisible();
     await expect(page.getByText('yolo mode')).toBeVisible();
     await expect(page.getByText('Launch in tmux')).toHaveCount(0);
@@ -27,7 +27,7 @@ test.describe('CustomizeSessionDialog', () => {
     page,
   }) => {
     await page.getByText('open single-node customize session').click();
-    await page.getByRole('button', { name: 'Start Session' }).click();
+    await page.getByRole('button', { name: 'start agent tab' }).click();
 
     await expect(page.getByTestId('created-session')).toHaveText(
       'local-session'
@@ -44,9 +44,9 @@ test.describe('CustomizeSessionDialog', () => {
     page,
   }) => {
     await page.getByText('open local web-capable customize session').click();
-    await expect(page.getByLabel('coding agent')).toHaveValue('hermes');
+    await expect(page.getByLabel('agent runtime (optional)')).toHaveValue('hermes');
     await expect(page.getByLabel('interface')).toHaveValue('web');
-    await page.getByRole('button', { name: 'Start Session' }).click();
+    await page.getByRole('button', { name: 'start agent tab' }).click();
 
     await expect(page.getByTestId('last-create-request')).toContainText(
       '/sessions'
@@ -67,12 +67,12 @@ test.describe('CustomizeSessionDialog', () => {
   }) => {
     await page.getByText('open customize session').click();
     await page.getByLabel('execution node').selectOption('linux');
-    await expect(page.getByLabel('node-local checkout')).toHaveCount(0);
-    await expect(page.getByLabel('cwd on linux lab')).toHaveValue(
+    await expect(page.getByLabel('git checkout / worktree')).toHaveCount(0);
+    await expect(page.getByLabel('working directory on linux lab')).toHaveValue(
       '/home/linux'
     );
-    await page.getByLabel('cwd on linux lab').fill('/srv/manual-cwd');
-    await page.getByRole('button', { name: 'Start Session' }).click();
+    await page.getByLabel('working directory on linux lab').fill('/srv/manual-cwd');
+    await page.getByRole('button', { name: 'open terminal tab' }).click();
 
     await expect(page.getByTestId('created-session')).toHaveText(
       'remote-session'
@@ -96,10 +96,10 @@ test.describe('CustomizeSessionDialog', () => {
   }) => {
     await page.getByText('open web-capable remote customize session').click();
     await page.getByLabel('execution node').selectOption('linux');
-    await expect(page.getByLabel('coding agent')).toHaveValue('hermes');
+    await expect(page.getByLabel('agent runtime (optional)')).toHaveValue('hermes');
     await expect(page.getByLabel('interface')).toHaveCount(0);
-    await page.getByLabel('cwd on linux lab').fill('/srv/hermes-cwd');
-    await page.getByRole('button', { name: 'Start Session' }).click();
+    await page.getByLabel('working directory on linux lab').fill('/srv/hermes-cwd');
+    await page.getByRole('button', { name: 'start agent tab' }).click();
 
     await expect(page.getByTestId('last-create-request')).toContainText(
       '/hub/nodes/linux/sessions'
@@ -123,18 +123,18 @@ test.describe('CustomizeSessionDialog', () => {
   }) => {
     await page.getByText('open customize session').click();
     await page.getByLabel('execution node').selectOption('linux');
-    await page.getByLabel('cwd on linux lab').fill('/opt/remember-me');
-    await page.getByRole('button', { name: 'Start Session' }).click();
+    await page.getByLabel('working directory on linux lab').fill('/opt/remember-me');
+    await page.getByRole('button', { name: 'open terminal tab' }).click();
     await expect(page.getByTestId('last-create-request')).toContainText(
       '"cwd":"/opt/remember-me"'
     );
 
     await page.getByText('open customize session').click();
     await page.getByLabel('execution node').selectOption('linux');
-    await expect(page.getByLabel('cwd on linux lab')).toHaveValue(
+    await expect(page.getByLabel('working directory on linux lab')).toHaveValue(
       '/opt/remember-me'
     );
-    await page.getByRole('button', { name: 'Start in Home' }).click();
+    await page.getByRole('button', { name: 'open home terminal' }).click();
     await expect(page.getByTestId('created-session')).toHaveText(
       'remote-home-session'
     );
@@ -143,7 +143,7 @@ test.describe('CustomizeSessionDialog', () => {
     );
   });
 
-  test('shows disabled reasons for offline and capability-blocked nodes', async ({
+  test('keeps agent-blocked terminal nodes selectable while disabling offline/tmux nodes', async ({
     page,
   }) => {
     await page.getByText('open customize session').click();
@@ -155,10 +155,7 @@ test.describe('CustomizeSessionDialog', () => {
     );
     await expect(
       nodeOptions.filter({ hasText: 'no claude box' })
-    ).toBeDisabled();
-    await expect(
-      nodeOptions.filter({ hasText: 'no claude box' })
-    ).toContainText('claude unavailable on no claude box');
+    ).not.toBeDisabled();
     await expect(nodeOptions.filter({ hasText: 'no tmux box' })).toBeDisabled();
     await expect(nodeOptions.filter({ hasText: 'no tmux box' })).toContainText(
       'tmux unavailable on no tmux box'
@@ -168,10 +165,10 @@ test.describe('CustomizeSessionDialog', () => {
   test('keeps the single-node local path low-friction', async ({ page }) => {
     await page.getByText('open single-node customize session').click();
     await expect(page.getByRole('dialog')).toBeVisible();
-    await expect(page.getByLabel('repo identity')).toHaveCount(0);
+    await expect(page.getByLabel('git project identity')).toHaveCount(0);
     await expect(page.getByLabel('execution node')).toHaveCount(0);
-    await expect(page.getByLabel('node-local checkout')).toHaveCount(0);
-    await expect(page.getByLabel('coding agent')).toBeVisible();
+    await expect(page.getByLabel('git checkout / worktree')).toHaveCount(0);
+    await expect(page.getByLabel('agent runtime (optional)')).toBeVisible();
   });
 
   test('shows the disabled-node reason when the single-node picker is otherwise hidden', async ({
@@ -179,23 +176,26 @@ test.describe('CustomizeSessionDialog', () => {
   }) => {
     await page.getByText('open single disabled-node customize session').click();
     await expect(page.getByRole('dialog')).toBeVisible();
-    await expect(page.getByLabel('repo identity')).toHaveCount(0);
+    await expect(page.getByLabel('git project identity')).toHaveCount(0);
     await expect(page.getByLabel('execution node')).toBeVisible();
     await expect(
       page.getByText('node is offline', { exact: true })
     ).toBeVisible();
-    await expect(page.getByLabel('node-local checkout')).toHaveCount(0);
+    await expect(page.getByLabel('git checkout / worktree')).toHaveCount(0);
     await expect(
-      page.getByRole('button', { name: 'Start Session' })
+      page.getByRole('button', { name: 'start agent tab' })
     ).toBeDisabled();
   });
 
-  test('has Start Session and Cancel buttons', async ({ page }) => {
+  test('has terminal, agent, and cancel buttons', async ({ page }) => {
     await page.getByText('open customize session').click();
     await expect(
-      page.getByRole('button', { name: 'Start Session' })
+      page.getByRole('button', { name: 'start agent tab' })
     ).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'open terminal tab' })
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'cancel' })).toBeVisible();
   });
 
   test('screenshot', async ({ page }) => {

--- a/test/workspace-summary.test.ts
+++ b/test/workspace-summary.test.ts
@@ -146,11 +146,11 @@ describe('summaryForTab — session kind', () => {
     }
   });
 
-  it('builds meta string from agent and state', () => {
+  it('builds meta string from agent, cwd, repo, and state', () => {
     const s = summaryForTab(sessionTab('s1'), {
       findSession: () => session({ agent: 'claude', agentState: 'processing' }),
     });
-    expect(s.meta).toBe('claude · processing');
+    expect(s.meta).toBe('claude · relay-ide · processing');
   });
 
   it('appends cwd basename for terminal sessions', () => {
@@ -159,10 +159,36 @@ describe('summaryForTab — session kind', () => {
         session({
           type: 'terminal',
           agent: 'bash',
+          repoName: null,
           cwd: '/Users/alice/code/relay-ide',
         }),
     });
     expect(s.meta).toContain('relay-ide');
+  });
+
+  it('shows cwd and optional repo identity for active agent work', () => {
+    const s = summaryForTab(sessionTab('s1'), {
+      findSession: () =>
+        session({
+          agent: 'claude',
+          repoName: 'relay-ide',
+          cwd: '/Users/alice/code/relay-ide/frontend',
+        }),
+    });
+    expect(s.meta).toBe('claude · frontend · relay-ide');
+  });
+
+  it('does not duplicate repo identity when cwd already names the repo', () => {
+    const s = summaryForTab(sessionTab('s1', 'terminal'), {
+      findSession: () =>
+        session({
+          type: 'terminal',
+          agent: 'bash',
+          repoName: 'relay-ide',
+          cwd: '/Users/alice/code/relay-ide',
+        }),
+    });
+    expect(s.meta).toBe('bash · relay-ide');
   });
 
   it('returns no meta when session is missing', () => {


### PR DESCRIPTION
## Summary
- Rewords repo-first onboarding and customize-session copy around projects, working directories, and terminal tabs.
- Splits plain terminal launch from agent launch so shell/tmux-capable remote nodes remain selectable even when the selected coding agent is unavailable on that node.
- Adds terminal-specific create flow for remote cwd/home and local repo/worktree terminals, while keeping Git project identity controls scoped to Git-backed selections.
- Surfaces cwd + optional repo identity in active work/tab summaries instead of implying every tab is just the Relay repo.
- Updates component and browser harness coverage for remote cwd terminal, local Git agent, non-git/free remote terminal, and agent-blocked-but-terminal-capable nodes.

## Why
Issue #591 tracks moving the dogfood path away from "add repo first" UX and toward true node/project/bench terminal flow. The backend/API slice is in #592; this PR wires the frontend slice to the existing routed session create contract.

## The Case Against
- This PR intentionally keeps Git repo identity controls when a Git-backed project/worktree is selected. If product wants a more radical IA cutover, this is conservative and still exposes repo vocabulary in Git-specific rows.
- Remote cwd browsing/validation is not added here; users still type cwd in this dialog. That keeps the frontend slice narrow, but a richer browser is still needed for the full #591 experience.
- Runtime remote cwd terminal creation depends on the backend behavior from #592 (`POST /hub/nodes/:nodeId/sessions` with `type: 'terminal'` and `cwd`). If this lands before #592, the UI will be ahead of the runtime capability.
- I changed the test harness to wrap the dialog in `QueryClientProvider`; that fixes the current harness crash and matches app usage, but it is still a harness-only change.

## Verification
- `npm test -- test/customize-session-dialog.test.ts test/customize-session-dialog-open-race.test.ts test/components/TerminalNodePicker.test.ts test/workspace-area-node-picker.test.ts test/workspace-summary.test.ts` — 5 files / 66 tests passed
- `PLAYWRIGHT_PORT=3473 npm run test:e2e -- test/e2e/components/CustomizeSessionDialog.spec.ts` — 11 passed, includes screenshot/mobile-ish 390x844 harness coverage
- `npm run check` — passed with existing lint warnings only (67 warnings, 0 errors)
- `npm run build` — passed; Vite emitted the existing >500 kB chunk warning

Refs #591
Pairs with #592
