### PR TITLE
feat: scheduled credential rotation scheduler (#595)

### DIFF
--- a/docs/SECURITY_POLICY.md
+++ b/docs/SECURITY_POLICY.md
@@ -6,11 +6,11 @@ Relay separates node capability discovery from hub-granted policy. A node manife
 
 Trust tiers describe blast radius. They are not marketing labels and they do not imply safety by themselves.
 
-| Tier | Blast radius |
-| ---- | ------------ |
-| `sandbox` | Experimental or constrained node. Route only narrow read/session-safe operations unless an operator grants more. |
-| `dev` | Default legacy/private-infra node. Read/session-safe operations are allowed by default; destructive file/git/exec/preview surfaces stay off unless granted. |
-| `prod` | Production or sensitive node. A prod overlay may make an otherwise-allowed high-risk bit require confirmation, but it must never turn an off bit or confirmation-required bit into silent allow. |
+| Tier      | Blast radius                                                                                                                                                                                     |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `sandbox` | Experimental or constrained node. Route only narrow read/session-safe operations unless an operator grants more.                                                                                 |
+| `dev`     | Default legacy/private-infra node. Read/session-safe operations are allowed by default; destructive file/git/exec/preview surfaces stay off unless granted.                                      |
+| `prod`    | Production or sensitive node. A prod overlay may make an otherwise-allowed high-risk bit require confirmation, but it must never turn an off bit or confirmation-required bit into silent allow. |
 
 ## Capability bits
 
@@ -43,6 +43,14 @@ The verifier replays rows in sequence order and recomputes `prevHash` / `entryHa
 Audit storage is intentionally unbounded in this slice: Relay does not yet enforce retention, rotation, or a maximum `security-audit.db` size. Operators must provision and monitor the config-directory storage accordingly; manual pruning or rotation will break the contiguous sequence/hash chain unless a future retention design preserves verifier semantics.
 
 Audit write failure policy is fail-closed for prod trust tier or destructive/high-risk capability scope. Low-tier read-only degradation is allowed only as an explicit visible degraded state; silent audit bypasses are not acceptable.
+
+## Scheduled credential rotation
+
+Scheduled rotation is opt-in hygiene that reuses the rotation state machine and audit pipeline; it is not a policy enforcement source. When `credentialRotation.intervalMs` is set on the hub config to a positive value, an in-process scheduler scans paired nodes on each tick (default 60s, configurable via `credentialRotation.checkIntervalMs`) and triggers online rotation for every paired, non-revoked, currently-stable node whose active credential has been in use longer than `intervalMs`.
+
+Offline nodes are skipped without throwing and audited with `CREDENTIAL_ROTATION_SCHEDULED_SKIPPED` (`reason: NODE_OFFLINE`). Nodes already mid-rotation are filtered before audit so the scheduler does not collide with operator-initiated rotations. Delivery failures call `failCredentialRotation`, keeping the previous credential active, and audit `CREDENTIAL_ROTATION_SCHEDULED_FAILED`. Successful triggers/deliveries audit `CREDENTIAL_ROTATION_SCHEDULED_TRIGGERED` and `CREDENTIAL_ROTATION_SCHEDULED_DELIVERED`. ACL/policy changes still apply immediately and do not wait for credentials to rotate.
+
+A default cadence is intentionally not shipped; operators opt in by setting `credentialRotation.intervalMs` themselves. The scheduler is process-local: it stops on hub shutdown and does not persist tick state.
 
 ## Operator visibility
 

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -37,7 +37,7 @@ Planned/deferred:
 
 - #428 File RPC (`fs.read`, `fs.list`, `fs.write`, `fs.tail`) is not implemented in source; current mentions live in spikes/design docs.
 - #476 node-log proxy / `logs.tail` / downloadable diagnostic bundles are not implemented. Current CLI diagnostics are `relay-ide node status`, `node logs`, and `node doctor`.
-- #427 policy schema/default ACLs, policy evaluator gates, two-token confirmation, audit sink/verifier, and manual/online credential rotation are implemented. Scheduled/default credential rotation and external audit shipping remain configurable/deferred.
+- #427 policy schema/default ACLs, policy evaluator gates, two-token confirmation, audit sink/verifier, manual/online credential rotation, and an opt-in scheduled credential rotation loop are implemented. External audit shipping and a default rotation cadence in shipped config remain deferred.
 - #444 six-layer IA is product direction, not the persisted backend model in this doc.
 
 ## Hub/Node/Client Terminology
@@ -283,7 +283,9 @@ Cookie: token={auth-cookie}
 
 The clear route is an operator recovery hatch for failed or otherwise non-stable rotations. It preserves the hub's current credential, removes the unproved next credential, and allows another rotation. Do not clear a failed/delivered rotation while the node may already have written the next credential: reconnecting with that next credential can still prove possession until clear explicitly invalidates it.
 
-ACL/policy changes are independent of credential rotation: hub-owned ACL policy is evaluated on each routed decision and applies immediately without waiting for credentials to rotate. Scheduled/default rotation is not currently automatic; callers must invoke the operator route when they want a rotation.
+ACL/policy changes are independent of credential rotation: hub-owned ACL policy is evaluated on each routed decision and applies immediately without waiting for credentials to rotate.
+
+Scheduled rotation is opt-in. When `credentialRotation.intervalMs` is set on the hub config to a positive value, an in-process scheduler scans paired nodes on each tick (default 60s, configurable via `credentialRotation.checkIntervalMs`) and triggers online rotation for every node whose active credential is older than `intervalMs`. The scheduler reuses the same `begin → deliver → prove` state machine and audit pipeline as the operator route. Offline nodes and nodes mid-rotation are skipped without throwing and surface as `CREDENTIAL_ROTATION_SCHEDULED_SKIPPED` audit rows. Delivery failures fail the rotation, leaving the previous credential active, and surface as `CREDENTIAL_ROTATION_SCHEDULED_FAILED`. Successful triggers/deliveries surface as `CREDENTIAL_ROTATION_SCHEDULED_TRIGGERED` and `CREDENTIAL_ROTATION_SCHEDULED_DELIVERED`. ACL evaluation is unchanged: rotation is hygiene, not policy.
 
 ### Revocation
 
@@ -303,17 +305,18 @@ The registry is stored in `<configDir>/hub-node-registry.json` (mode `0600`) wit
 
 ### Security Properties
 
-| Property                             | Implementation                                                    |
-| ------------------------------------ | ----------------------------------------------------------------- |
-| Pair token storage (hub)             | SHA256 hash only; raw token is never stored                       |
-| Node credential storage (hub)        | SHA256 hash only; raw `token` is never stored                     |
-| Node credential storage (node-local) | Raw token in `<configDir>/node-credential.json`; file mode `0600` |
-| Comparison                           | `crypto.timingSafeEqual` on hex buffers                           |
-| Pair token lifetime                  | Default 10 minutes; single-use; consumed on exchange              |
-| Registry file                        | Written with `0600` mode; atomic write via temp+rename            |
-| Rotation audit                       | Proof writes `rotation` / `rotated` with credential IDs only      |
-| ACL policy updates                   | Hub policy decisions apply immediately; no rotation wait          |
-| Revocation                           | Immediate; active links are killed; no grace period               |
+| Property                             | Implementation                                                                           |
+| ------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Pair token storage (hub)             | SHA256 hash only; raw token is never stored                                              |
+| Node credential storage (hub)        | SHA256 hash only; raw `token` is never stored                                            |
+| Node credential storage (node-local) | Raw token in `<configDir>/node-credential.json`; file mode `0600`                        |
+| Comparison                           | `crypto.timingSafeEqual` on hex buffers                                                  |
+| Pair token lifetime                  | Default 10 minutes; single-use; consumed on exchange                                     |
+| Registry file                        | Written with `0600` mode; atomic write via temp+rename                                   |
+| Rotation audit                       | Proof writes `rotation` / `rotated` with credential IDs only                             |
+| Scheduled rotation                   | Opt-in via `credentialRotation.intervalMs`; reuses state machine + audit; off by default |
+| ACL policy updates                   | Hub policy decisions apply immediately; no rotation wait                                 |
+| Revocation                           | Immediate; active links are killed; no grace period                                      |
 
 This table is the implemented security boundary. Control-state fields from #490 are renderable state only; they are not policy decisions and do not imply additional capability gates beyond the hub policy evaluator, trust-tier overrides outside the ACL schema, or raw/control payload duplication into hash-chained audit logging.
 

--- a/server/credential-rotation-scheduler.ts
+++ b/server/credential-rotation-scheduler.ts
@@ -117,13 +117,10 @@ export function createCredentialRotationScheduler(
   ): Promise<void> {
     const { nodeId } = candidate;
     if (!options.nodeLinks.hasActiveNode(nodeId)) {
-      audit(
-        nodeId,
-        'recorded',
-        'CREDENTIAL_ROTATION_SCHEDULED_SKIPPED',
-        { reason: 'NODE_OFFLINE', ageMs: candidate.ageMs },
-        candidate.credentialId
-      );
+      // Offline nodes are intentionally NOT audited every tick: a node that
+      // stays offline would otherwise emit `CREDENTIAL_ROTATION_SCHEDULED_SKIPPED`
+      // once per `checkIntervalMs` indefinitely, flooding the audit log.
+      // The next tick after the node reconnects naturally re-evaluates.
       result.skipped.push({ nodeId, reasonCode: 'NODE_OFFLINE' });
       return;
     }
@@ -187,6 +184,10 @@ export function createCredentialRotationScheduler(
       });
       return;
     }
+    // Audit DELIVERED only after the registry transition succeeds so the
+    // audit log stays consistent with persisted rotation state. A failure
+    // here leaves the rotation in `delivered` -> `issuing` mismatch territory
+    // and we surface that as a failure rather than a misleading success.
     try {
       options.registry.markCredentialRotationDelivered(
         nodeId,
@@ -199,6 +200,21 @@ export function createCredentialRotationScheduler(
         nodeId,
         message
       );
+      audit(
+        nodeId,
+        'failed',
+        'CREDENTIAL_ROTATION_SCHEDULED_FAILED',
+        { message, ageMs: candidate.ageMs, stage: 'mark-delivered' },
+        started.rotation.previousCredentialId,
+        started.rotation.rotationId
+      );
+      result.failed.push({
+        nodeId,
+        reasonCode: 'CREDENTIAL_ROTATION_SCHEDULED_FAILED',
+        message,
+        rotationId: started.rotation.rotationId,
+      });
+      return;
     }
     audit(
       nodeId,

--- a/server/credential-rotation-scheduler.ts
+++ b/server/credential-rotation-scheduler.ts
@@ -1,0 +1,285 @@
+import { createLogger } from './logger.js';
+import type {
+  HubNodeRegistry,
+  ScheduledRotationCandidate,
+} from './hub-node-registry.js';
+import type { HubNodeLinkManager } from './hub-node-link.js';
+import type {
+  SecurityAuditEntryInput,
+  SecurityAuditDecision,
+} from '../shared/security-audit.js';
+
+const logger = createLogger('credential-rotation-scheduler');
+
+const DEFAULT_CHECK_INTERVAL_MS = 60 * 1000;
+const MIN_CHECK_INTERVAL_MS = 1_000;
+
+export type CredentialRotationNodeLinks = Pick<
+  HubNodeLinkManager,
+  'hasActiveNode' | 'request'
+>;
+
+export interface CredentialRotationSchedulerOptions {
+  registry: HubNodeRegistry;
+  nodeLinks: CredentialRotationNodeLinks;
+  auditSink?: { append(input: SecurityAuditEntryInput): unknown } | undefined;
+  intervalMs: number;
+  checkIntervalMs?: number;
+  now?: () => Date;
+}
+
+export interface ScheduledRotationSkip {
+  nodeId: string;
+  reasonCode: string;
+  message?: string;
+}
+
+export interface ScheduledRotationFailure {
+  nodeId: string;
+  reasonCode: string;
+  message: string;
+  rotationId?: string;
+}
+
+export interface ScheduledRotationTickResult {
+  evaluatedAt: string;
+  candidates: number;
+  triggered: Array<{ nodeId: string; rotationId: string }>;
+  skipped: ScheduledRotationSkip[];
+  failed: ScheduledRotationFailure[];
+}
+
+export interface CredentialRotationScheduler {
+  start(): void;
+  stop(): void;
+  runOnce(): Promise<ScheduledRotationTickResult>;
+}
+
+export function createCredentialRotationScheduler(
+  options: CredentialRotationSchedulerOptions
+): CredentialRotationScheduler {
+  if (!Number.isFinite(options.intervalMs) || options.intervalMs <= 0) {
+    throw new Error(
+      'credentialRotationScheduler requires a positive intervalMs'
+    );
+  }
+  const checkIntervalMs = Math.max(
+    options.checkIntervalMs ?? DEFAULT_CHECK_INTERVAL_MS,
+    MIN_CHECK_INTERVAL_MS
+  );
+  const now = options.now ?? (() => new Date());
+
+  let timer: NodeJS.Timeout | null = null;
+  let inFlight: Promise<ScheduledRotationTickResult> | null = null;
+
+  function audit(
+    nodeId: string,
+    decision: SecurityAuditDecision,
+    reasonCode: string,
+    params: Record<string, unknown>,
+    credentialId?: string,
+    rotationId?: string
+  ): void {
+    if (!options.auditSink) return;
+    try {
+      options.auditSink.append({
+        eventType: 'rotation',
+        decision,
+        reasonCode,
+        peer: {
+          kind: 'node',
+          nodeId,
+          ...(credentialId ? { credentialId } : {}),
+        },
+        node: { nodeId },
+        intent: { action: 'nodes.credential.rotate', target: nodeId },
+        material: {
+          params: {
+            trigger: 'scheduled',
+            ...(rotationId ? { rotationId } : {}),
+            ...params,
+          },
+        },
+      });
+    } catch (error) {
+      logger.warn(
+        'scheduled rotation audit append failed for node %s (%s): %s',
+        nodeId,
+        reasonCode,
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+  }
+
+  async function rotateOne(
+    candidate: ScheduledRotationCandidate,
+    result: ScheduledRotationTickResult
+  ): Promise<void> {
+    const { nodeId } = candidate;
+    if (!options.nodeLinks.hasActiveNode(nodeId)) {
+      audit(
+        nodeId,
+        'recorded',
+        'CREDENTIAL_ROTATION_SCHEDULED_SKIPPED',
+        { reason: 'NODE_OFFLINE', ageMs: candidate.ageMs },
+        candidate.credentialId
+      );
+      result.skipped.push({ nodeId, reasonCode: 'NODE_OFFLINE' });
+      return;
+    }
+    let started;
+    try {
+      started = options.registry.beginCredentialRotation(nodeId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const code = extractErrorCode(error) ?? 'BEGIN_FAILED';
+      audit(
+        nodeId,
+        'recorded',
+        'CREDENTIAL_ROTATION_SCHEDULED_SKIPPED',
+        { reason: code, message, ageMs: candidate.ageMs },
+        candidate.credentialId
+      );
+      result.skipped.push({ nodeId, reasonCode: code, message });
+      return;
+    }
+    audit(
+      nodeId,
+      'recorded',
+      'CREDENTIAL_ROTATION_SCHEDULED_TRIGGERED',
+      { ageMs: candidate.ageMs },
+      started.rotation.previousCredentialId,
+      started.rotation.rotationId
+    );
+    result.triggered.push({ nodeId, rotationId: started.rotation.rotationId });
+    try {
+      await options.nodeLinks.request(nodeId, 'credential.rotate', {
+        credential: started.credential,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      try {
+        options.registry.failCredentialRotation(
+          nodeId,
+          started.rotation.rotationId,
+          message
+        );
+      } catch (failError) {
+        logger.warn(
+          'failCredentialRotation threw for node %s after scheduled delivery failure: %s',
+          nodeId,
+          failError instanceof Error ? failError.message : String(failError)
+        );
+      }
+      audit(
+        nodeId,
+        'failed',
+        'CREDENTIAL_ROTATION_SCHEDULED_FAILED',
+        { message, ageMs: candidate.ageMs },
+        started.rotation.previousCredentialId,
+        started.rotation.rotationId
+      );
+      result.failed.push({
+        nodeId,
+        reasonCode: 'CREDENTIAL_ROTATION_SCHEDULED_FAILED',
+        message,
+        rotationId: started.rotation.rotationId,
+      });
+      return;
+    }
+    try {
+      options.registry.markCredentialRotationDelivered(
+        nodeId,
+        started.rotation.rotationId
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(
+        'markCredentialRotationDelivered threw for node %s after scheduled delivery: %s',
+        nodeId,
+        message
+      );
+    }
+    audit(
+      nodeId,
+      'recorded',
+      'CREDENTIAL_ROTATION_SCHEDULED_DELIVERED',
+      { ageMs: candidate.ageMs },
+      started.rotation.previousCredentialId,
+      started.rotation.rotationId
+    );
+  }
+
+  async function tick(): Promise<ScheduledRotationTickResult> {
+    const evaluatedAt = now().toISOString();
+    const candidates = options.registry.listScheduledRotationCandidates(
+      options.intervalMs
+    );
+    const result: ScheduledRotationTickResult = {
+      evaluatedAt,
+      candidates: candidates.length,
+      triggered: [],
+      skipped: [],
+      failed: [],
+    };
+    for (const candidate of candidates) {
+      try {
+        await rotateOne(candidate, result);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(
+          'unexpected scheduled rotation error for node %s: %s',
+          candidate.nodeId,
+          message
+        );
+        result.failed.push({
+          nodeId: candidate.nodeId,
+          reasonCode: 'CREDENTIAL_ROTATION_SCHEDULED_FAILED',
+          message,
+        });
+      }
+    }
+    return result;
+  }
+
+  function runOnce(): Promise<ScheduledRotationTickResult> {
+    if (inFlight) return inFlight;
+    inFlight = tick().finally(() => {
+      inFlight = null;
+    });
+    return inFlight;
+  }
+
+  function start(): void {
+    if (timer) return;
+    timer = setInterval(() => {
+      void runOnce().catch((error) => {
+        logger.error(
+          'scheduled rotation tick threw: %s',
+          error instanceof Error ? error.message : String(error)
+        );
+      });
+    }, checkIntervalMs);
+    timer.unref?.();
+    logger.info(
+      'scheduled credential rotation enabled (intervalMs=%d, checkIntervalMs=%d)',
+      options.intervalMs,
+      checkIntervalMs
+    );
+  }
+
+  function stop(): void {
+    if (!timer) return;
+    clearInterval(timer);
+    timer = null;
+  }
+
+  return { start, stop, runOnce };
+}
+
+function extractErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const maybe = error as { relayNodeError?: { code?: unknown } };
+  const code = maybe.relayNodeError?.code;
+  return typeof code === 'string' ? code : undefined;
+}

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -62,6 +62,11 @@ interface StoredNodeRecord {
   nodeId: string;
   credentialId: string;
   credentialHash: string;
+  // Timestamp of the currently-active credential. Set on pair and updated
+  // when a rotation proves. Optional for backward compatibility with
+  // registry files written before this field existed; consumers fall back
+  // to derived logic when missing.
+  credentialIssuedAt?: string;
   displayName: string;
   hostname: string;
   homeDir?: string;
@@ -463,9 +468,11 @@ function credentialState(node: StoredNodeRecord): HubNodeCredentialState {
 }
 
 function activeCredentialIssuedAt(node: StoredNodeRecord): string {
-  // The active credential was either issued at pair time, or replaced by
-  // the most recently stable rotation. Use whichever is later so a node
-  // that has rotated does not look "old" because of its original pairing.
+  // Prefer the persisted credentialIssuedAt so the value survives in-flight
+  // rotation windows where `credentialRotation` is overwritten before proof.
+  // Fall back to derived logic for legacy records that predate the field
+  // (pair time, or the most recent stable rotation if later).
+  if (node.credentialIssuedAt) return node.credentialIssuedAt;
   const pairedMs = Date.parse(node.pairedAt);
   const rotation = node.credentialRotation;
   if (!rotation || rotation.state !== 'stable' || !rotation.stableAt) {
@@ -713,6 +720,7 @@ export class HubNodeRegistry {
         ),
         createdAt: timestamp,
       }),
+      credentialIssuedAt: timestamp,
       createdAt: timestamp,
       pairedAt: timestamp,
       lastSeenAt: timestamp,
@@ -993,6 +1001,7 @@ export class HubNodeRegistry {
     rotation.provedAt = now;
     node.credentialId = rotation.nextCredentialId;
     node.credentialHash = rotation.nextCredentialHash;
+    node.credentialIssuedAt = now;
     updateAclCredential(node, rotation.nextCredentialId, now);
     delete rotation.nextCredentialHash;
     rotation.state = 'stable';

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -118,6 +118,13 @@ export interface CredentialRotationPublicResult {
   rotation: HubNodeCredentialRotationSummary;
 }
 
+export interface ScheduledRotationCandidate {
+  nodeId: string;
+  credentialId: string;
+  activeCredentialIssuedAt: string;
+  ageMs: number;
+}
+
 export interface InventoryPayloadRecord {
   nodeId: string;
   payload: unknown;
@@ -139,10 +146,15 @@ export const DEFAULT_NODE_HEARTBEAT_TIMEOUTS = {
 } as const;
 export const DEFAULT_HEARTBEAT_PERSIST_DEBOUNCE_MS = 5 * 1000;
 const PRIVILEGED_NODE_WARNING =
-  'A paired Relay node runs with that machine\'s local OS-user blast radius; hub ACL policy grants individual capability bits.';
+  "A paired Relay node runs with that machine's local OS-user blast radius; hub ACL policy grants individual capability bits.";
 
 export type CredentialAuthResult =
-  | { ok: true; node: HubNodeSummary; credentialId: string; rotationId?: string }
+  | {
+      ok: true;
+      node: HubNodeSummary;
+      credentialId: string;
+      rotationId?: string;
+    }
   | { ok: false; error: RelayNodeError };
 
 export interface HubNodeStatusEvent {
@@ -165,7 +177,12 @@ class HubNodeRegistryError extends Error {
   ) {
     super(`${code}: ${message}`);
     this.name = 'HubNodeRegistryError';
-    this.relayNodeError = { code, message, retryable, ...(details ? { details } : {}) };
+    this.relayNodeError = {
+      code,
+      message,
+      retryable,
+      ...(details ? { details } : {}),
+    };
   }
 }
 
@@ -284,7 +301,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function hasOnlyKnownCapabilityBits(value: unknown): boolean {
-  return Array.isArray(value) && value.every((item) => isRelayCapabilityBit(item));
+  return (
+    Array.isArray(value) && value.every((item) => isRelayCapabilityBit(item))
+  );
 }
 
 function nodeNeedsAclMigration(node: StoredNodeRecord): boolean {
@@ -428,30 +447,52 @@ function publicRotation(
     ...(rotation.provedAt ? { provedAt: rotation.provedAt } : {}),
     ...(rotation.stableAt ? { stableAt: rotation.stableAt } : {}),
     ...(rotation.failedAt ? { failedAt: rotation.failedAt } : {}),
-    ...(rotation.failureReason ? { failureReason: rotation.failureReason } : {}),
+    ...(rotation.failureReason
+      ? { failureReason: rotation.failureReason }
+      : {}),
   };
 }
 
 function credentialState(node: StoredNodeRecord): HubNodeCredentialState {
   if (node.revokedAt) return 'revoked';
   if (node.credentialRotation?.state === 'failed') return 'rotation-failed';
-  if (
-    node.credentialRotation &&
-    node.credentialRotation.state !== 'stable'
-  ) {
+  if (node.credentialRotation && node.credentialRotation.state !== 'stable') {
     return 'rotating';
   }
   return 'active';
 }
 
-function provableRotation(node: StoredNodeRecord): StoredCredentialRotation | undefined {
+function activeCredentialIssuedAt(node: StoredNodeRecord): string {
+  // The active credential was either issued at pair time, or replaced by
+  // the most recently stable rotation. Use whichever is later so a node
+  // that has rotated does not look "old" because of its original pairing.
+  const pairedMs = Date.parse(node.pairedAt);
+  const rotation = node.credentialRotation;
+  if (!rotation || rotation.state !== 'stable' || !rotation.stableAt) {
+    return node.pairedAt;
+  }
+  const stableMs = Date.parse(rotation.stableAt);
+  if (!Number.isFinite(stableMs)) return node.pairedAt;
+  if (!Number.isFinite(pairedMs) || stableMs > pairedMs)
+    return rotation.stableAt;
+  return node.pairedAt;
+}
+
+function provableRotation(
+  node: StoredNodeRecord
+): StoredCredentialRotation | undefined {
   const rotation = node.credentialRotation;
   if (!rotation) return undefined;
-  if (rotation.state === 'stable' || !rotation.nextCredentialHash) return undefined;
+  if (rotation.state === 'stable' || !rotation.nextCredentialHash)
+    return undefined;
   return rotation;
 }
 
-function updateAclCredential(node: StoredNodeRecord, credentialId: string, now: string): void {
+function updateAclCredential(
+  node: StoredNodeRecord,
+  credentialId: string,
+  now: string
+): void {
   const acl = ensureNodeAcl(node);
   node.acl = {
     ...acl,
@@ -466,7 +507,11 @@ function updateAclCredential(node: StoredNodeRecord, credentialId: string, now: 
   };
 }
 
-function credentialToken(nodeId: string): { token: string; credentialId: string; hash: string } {
+function credentialToken(nodeId: string): {
+  token: string;
+  credentialId: string;
+  hash: string;
+} {
   const credentialId = randomToken('cred');
   const secret = randomToken('secret');
   const token = `${nodeId}.${secret}`;
@@ -548,7 +593,9 @@ export class HubNodeRegistry {
   private heartbeatPersistTimer: NodeJS.Timeout | null = null;
   private heartbeatPersistDirty = false;
   private heartbeatPersistError: unknown = null;
-  private readonly auditSink: { append(input: SecurityAuditEntryInput): unknown } | undefined;
+  private readonly auditSink:
+    | { append(input: SecurityAuditEntryInput): unknown }
+    | undefined;
   private readonly nodeStatusListeners = new Set<NodeStatusListener>();
   private readonly lastNotifiedStatuses = new Map<string, HubNodeStatus>();
 
@@ -732,7 +779,9 @@ export class HubNodeRegistry {
         node,
         statusForNode(node, this.now(), this.staleMs, this.offlineMs)
       ),
-      credentialId: matchesRotation ? rotation!.nextCredentialId : node.credentialId,
+      credentialId: matchesRotation
+        ? rotation!.nextCredentialId
+        : node.credentialId,
       ...(matchesRotation ? { rotationId: rotation!.rotationId } : {}),
     };
   }
@@ -750,7 +799,12 @@ export class HubNodeRegistry {
     if (input.credentialId) {
       this.proveCredentialRotation(node, input.credentialId, now);
     }
-    const previousStatus = statusForNode(node, this.now(), this.staleMs, this.offlineMs);
+    const previousStatus = statusForNode(
+      node,
+      this.now(),
+      this.staleMs,
+      this.offlineMs
+    );
     node.lastSeenAt = now;
     delete node.linkDisconnectedAt;
     node.protocolVersion = input.protocolVersion;
@@ -767,7 +821,12 @@ export class HubNodeRegistry {
       node.repoInventory = input.repoInventory;
     }
     this.scheduleHeartbeatPersist();
-    this.notifyNodeStatusIfChanged(node, 'online', input.manifest, previousStatus);
+    this.notifyNodeStatusIfChanged(
+      node,
+      'online',
+      input.manifest,
+      previousStatus
+    );
     return publicNode(node, 'online');
   }
 
@@ -792,7 +851,9 @@ export class HubNodeRegistry {
   }
 
   beginCredentialRotation(nodeId: string): CredentialRotationResult {
-    const node = this.state.nodes.find((candidate) => candidate.nodeId === nodeId);
+    const node = this.state.nodes.find(
+      (candidate) => candidate.nodeId === nodeId
+    );
     if (!node)
       throw new HubNodeRegistryError('NOT_FOUND', 'node is not paired');
     if (node.revokedAt)
@@ -810,7 +871,10 @@ export class HubNodeRegistry {
     };
     this.persist();
     return {
-      node: publicNode(node, statusForNode(node, this.now(), this.staleMs, this.offlineMs)),
+      node: publicNode(
+        node,
+        statusForNode(node, this.now(), this.staleMs, this.offlineMs)
+      ),
       credential: {
         protocol: RELAY_NODE_LINK_PROTOCOL,
         protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
@@ -834,7 +898,13 @@ export class HubNodeRegistry {
       rotation.deliveredAt = this.now().toISOString();
       this.persist();
     }
-    return { node: publicNode(node, statusForNode(node, this.now(), this.staleMs, this.offlineMs)), rotation: publicRotation(rotation)! };
+    return {
+      node: publicNode(
+        node,
+        statusForNode(node, this.now(), this.staleMs, this.offlineMs)
+      ),
+      rotation: publicRotation(rotation)!,
+    };
   }
 
   failCredentialRotation(
@@ -850,11 +920,19 @@ export class HubNodeRegistry {
       rotation.failureReason = reason;
       this.persist();
     }
-    return { node: publicNode(node, statusForNode(node, this.now(), this.staleMs, this.offlineMs)), rotation: publicRotation(rotation)! };
+    return {
+      node: publicNode(
+        node,
+        statusForNode(node, this.now(), this.staleMs, this.offlineMs)
+      ),
+      rotation: publicRotation(rotation)!,
+    };
   }
 
   clearCredentialRotationFailure(nodeId: string): HubNodeSummary {
-    const node = this.state.nodes.find((candidate) => candidate.nodeId === nodeId);
+    const node = this.state.nodes.find(
+      (candidate) => candidate.nodeId === nodeId
+    );
     if (!node)
       throw new HubNodeRegistryError('NOT_FOUND', 'node is not paired');
     if (!node.credentialRotation) {
@@ -871,15 +949,29 @@ export class HubNodeRegistry {
     }
     delete node.credentialRotation;
     this.persist();
-    return publicNode(node, statusForNode(node, this.now(), this.staleMs, this.offlineMs));
+    return publicNode(
+      node,
+      statusForNode(node, this.now(), this.staleMs, this.offlineMs)
+    );
   }
 
-  private requireRotationNode(nodeId: string, rotationId: string): StoredNodeRecord {
-    const node = this.state.nodes.find((candidate) => candidate.nodeId === nodeId);
+  private requireRotationNode(
+    nodeId: string,
+    rotationId: string
+  ): StoredNodeRecord {
+    const node = this.state.nodes.find(
+      (candidate) => candidate.nodeId === nodeId
+    );
     if (!node)
       throw new HubNodeRegistryError('NOT_FOUND', 'node is not paired');
-    if (!node.credentialRotation || node.credentialRotation.rotationId !== rotationId) {
-      throw new HubNodeRegistryError('NOT_FOUND', 'credential rotation was not found');
+    if (
+      !node.credentialRotation ||
+      node.credentialRotation.rotationId !== rotationId
+    ) {
+      throw new HubNodeRegistryError(
+        'NOT_FOUND',
+        'credential rotation was not found'
+      );
     }
     return node;
   }
@@ -892,7 +984,10 @@ export class HubNodeRegistry {
     const rotation = provableRotation(node);
     if (!rotation || rotation.nextCredentialId !== credentialId) return;
     if (!rotation.nextCredentialHash) {
-      throw new HubNodeRegistryError('INTERNAL', 'credential rotation is missing proof hash');
+      throw new HubNodeRegistryError(
+        'INTERNAL',
+        'credential rotation is missing proof hash'
+      );
     }
     rotation.state = 'proved';
     rotation.provedAt = now;
@@ -957,6 +1052,31 @@ export class HubNodeRegistry {
     return this.state.nodes.map((node) =>
       publicNode(node, statusForNode(node, now, this.staleMs, this.offlineMs))
     );
+  }
+
+  listScheduledRotationCandidates(
+    intervalMs: number
+  ): ScheduledRotationCandidate[] {
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) return [];
+    const nowMs = this.now().getTime();
+    const candidates: ScheduledRotationCandidate[] = [];
+    for (const node of this.state.nodes) {
+      if (node.revokedAt) continue;
+      const rotation = node.credentialRotation;
+      if (rotation && rotation.state !== 'stable') continue;
+      const issuedAtIso = activeCredentialIssuedAt(node);
+      const issuedAtMs = Date.parse(issuedAtIso);
+      if (!Number.isFinite(issuedAtMs)) continue;
+      const ageMs = nowMs - issuedAtMs;
+      if (ageMs < intervalMs) continue;
+      candidates.push({
+        nodeId: node.nodeId,
+        credentialId: node.credentialId,
+        activeCredentialIssuedAt: issuedAtIso,
+        ageMs,
+      });
+    }
+    return candidates;
   }
 
   refreshNodeStatuses(): HubNodeStatusEvent[] {
@@ -1028,7 +1148,9 @@ export class HubNodeRegistry {
     node: StoredNodeRecord,
     status: HubNodeStatus,
     manifest?: NodeManifest,
-    previousStatus: HubNodeStatus | undefined = this.lastNotifiedStatuses.get(node.nodeId)
+    previousStatus: HubNodeStatus | undefined = this.lastNotifiedStatuses.get(
+      node.nodeId
+    )
   ): HubNodeStatusEvent | null {
     if (previousStatus === status) return null;
     this.lastNotifiedStatuses.set(node.nodeId, status);

--- a/server/index.ts
+++ b/server/index.ts
@@ -112,6 +112,10 @@ import {
 } from './frameworks.js';
 import { getNodeManifest } from './node-manifest.js';
 import { createHubNodeRegistry } from './hub-node-registry.js';
+import {
+  createCredentialRotationScheduler,
+  type CredentialRotationScheduler,
+} from './credential-rotation-scheduler.js';
 import { createHubNodeRouter } from './hub-node-router.js';
 import { createConfirmationChallengeStore } from './confirmation-challenges.js';
 import { createHubNodeLinkManager } from './hub-node-link.js';
@@ -859,8 +863,13 @@ function associateSessionWithWorkContext(
     store.associateSession(workContextId, { session });
     return null;
   } catch (err) {
-    const code = err instanceof Error ? err.message : 'work_context_association_failed';
-    logger.warn('[sessions] failed to associate session with work context %s: %s', workContextId, err);
+    const code =
+      err instanceof Error ? err.message : 'work_context_association_failed';
+    logger.warn(
+      '[sessions] failed to associate session with work context %s: %s',
+      workContextId,
+      err
+    );
     return code || 'work_context_association_failed';
   }
 }
@@ -879,12 +888,16 @@ function sendSessionCreateSuccess(
   associationError: string | null,
   workContextId?: string
 ): void {
-  const responseSession = workContextId ? { ...session, workContextId } : session;
-  res.status(201).json(
-    associationError
-      ? { ...responseSession, workContextAssociationError: associationError }
-      : responseSession
-  );
+  const responseSession = workContextId
+    ? { ...session, workContextId }
+    : session;
+  res
+    .status(201)
+    .json(
+      associationError
+        ? { ...responseSession, workContextAssociationError: associationError }
+        : responseSession
+    );
 }
 
 function sessionCreateFailureMessage(err: unknown): string {
@@ -939,6 +952,34 @@ function initializeRuntimeDirectories(configDir: string): void {
     fs.mkdirSync(path.join(configDir, 'telemetry'), { recursive: true });
   } catch (err) {
     logStartupWarning('Telemetry directory creation failed:', err);
+  }
+}
+
+function startCredentialRotationScheduler(input: {
+  config: Config;
+  registry: ReturnType<typeof createHubNodeRegistry>;
+  nodeLinks: ReturnType<typeof createHubNodeLinkManager>;
+  auditSink: ReturnType<typeof createSecurityAuditLog> | undefined;
+}): CredentialRotationScheduler | null {
+  const cfg = input.config.credentialRotation;
+  const intervalMs = cfg?.intervalMs ?? 0;
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) return null;
+  try {
+    const scheduler = createCredentialRotationScheduler({
+      registry: input.registry,
+      nodeLinks: input.nodeLinks,
+      auditSink: input.auditSink,
+      intervalMs,
+      ...(cfg?.checkIntervalMs ? { checkIntervalMs: cfg.checkIntervalMs } : {}),
+    });
+    scheduler.start();
+    return scheduler;
+  } catch (err) {
+    logger.warn(
+      'Credential rotation scheduler disabled: failed to initialize:',
+      err instanceof Error ? err.message : err
+    );
+    return null;
   }
 }
 
@@ -1122,6 +1163,12 @@ async function main(): Promise<void> {
     ptyInputRecorder: sessions.recordRoutedPtyInput,
   });
   const remoteSessionReadModelCache = createRemoteSessionReadModelCache();
+  const credentialRotationScheduler = startCredentialRotationScheduler({
+    config: startupConfig,
+    registry: hubNodeRegistry,
+    nodeLinks: hubNodeLinks,
+    auditSink: securityAuditLog,
+  });
 
   async function flushHubNodeHeartbeatsBestEffort(
     context: string
@@ -1211,7 +1258,10 @@ async function main(): Promise<void> {
     const token = req.cookies && req.cookies.token;
     if (!token) return false;
     const config = getConfig();
-    return authenticatedTokens.has(token) || auth.verifyCookieToken(token, config.pinHash);
+    return (
+      authenticatedTokens.has(token) ||
+      auth.verifyCookieToken(token, config.pinHash)
+    );
   }
 
   function bearerScopedToken(req: express.Request): string {
@@ -1533,10 +1583,12 @@ async function main(): Promise<void> {
     configDir,
   };
   if (startupConfig.control?.interventionDebounceMs !== undefined) {
-    sessionConfig.interventionDebounceMs = startupConfig.control.interventionDebounceMs;
+    sessionConfig.interventionDebounceMs =
+      startupConfig.control.interventionDebounceMs;
   }
   if (startupConfig.control?.coDrivenAutoRevertMs !== undefined) {
-    sessionConfig.coDrivenAutoRevertMs = startupConfig.control.coDrivenAutoRevertMs;
+    sessionConfig.coDrivenAutoRevertMs =
+      startupConfig.control.coDrivenAutoRevertMs;
   }
   if (securityAuditLog) {
     sessionConfig.securityAuditSink = securityAuditLog;
@@ -1671,10 +1723,11 @@ async function main(): Promise<void> {
       getSessions: async () => {
         const [localSessions, remoteSessions] = await Promise.all([
           Promise.resolve(
-            localRelayNode
-              .sessions
+            localRelayNode.sessions
               .list()
-              .map((session) => withWorkContextMetadata(workContextStore, session))
+              .map((session) =>
+                withWorkContextMetadata(workContextStore, session)
+              )
           ),
           aggregateRemoteSessions({
             registry: hubNodeRegistry,
@@ -2089,8 +2142,7 @@ async function main(): Promise<void> {
   app.get('/sessions', requireCliGatewayAuth, async (_req, res) => {
     const [localSessions, remoteSessions] = await Promise.all([
       Promise.resolve(
-        localRelayNode
-          .sessions
+        localRelayNode.sessions
           .list()
           .map((session) => withWorkContextMetadata(workContextStore, session))
       ),
@@ -2147,7 +2199,10 @@ async function main(): Promise<void> {
   });
 
   app.get('/sessions/:id', requireScopedSessionAuth, async (req, res) => {
-    const decision = capabilityDecisionFromRequest(req, CONTROL_READ_CAPABILITY);
+    const decision = capabilityDecisionFromRequest(
+      req,
+      CONTROL_READ_CAPABILITY
+    );
     if (decision.decision !== 'allow') {
       const error = capabilityError(decision);
       res.status(sessionControlErrorStatus(error)).json({ error });
@@ -2156,7 +2211,9 @@ async function main(): Promise<void> {
     const id = req.params['id'] as string;
     const local = localRelayNode.sessions.get(id);
     if (local) {
-      const session = localRelayNode.sessions.list().find((candidate) => candidate.id === id);
+      const session = localRelayNode.sessions
+        .list()
+        .find((candidate) => candidate.id === id);
       if (!session) {
         res.status(404).json({
           error: {
@@ -2196,74 +2253,87 @@ async function main(): Promise<void> {
     res.json(remote);
   });
 
-  app.get('/sessions/:id/interventions', requireScopedSessionAuth, (req, res) => {
-    const decision = capabilitiesDecisionFromRequest(req, [
-      CONTROL_READ_CAPABILITY,
-      INTERVENTION_READ_CAPABILITY,
-    ]);
-    if (decision.decision !== 'allow') {
-      const error = capabilityError(decision);
-      res.status(sessionControlErrorStatus(error)).json({ error });
-      return;
+  app.get(
+    '/sessions/:id/interventions',
+    requireScopedSessionAuth,
+    (req, res) => {
+      const decision = capabilitiesDecisionFromRequest(req, [
+        CONTROL_READ_CAPABILITY,
+        INTERVENTION_READ_CAPABILITY,
+      ]);
+      if (decision.decision !== 'allow') {
+        const error = capabilityError(decision);
+        res.status(sessionControlErrorStatus(error)).json({ error });
+        return;
+      }
+      const id = req.params['id'] as string;
+      if (!localRelayNode.sessions.get(id)) {
+        res.status(404).json({
+          error: {
+            code: 'NOT_FOUND',
+            reasonCode: 'SESSION_NOT_FOUND',
+            message: 'session was not found or is not locally readable',
+            retryable: false,
+          },
+        });
+        return;
+      }
+      const limit = clampInterventionLimit(
+        typeof req.query.limit === 'string' ? req.query.limit : undefined
+      );
+      const records = localRelayNode.sessions.getInterventions(id, { limit });
+      res.json(toInterventionReadResponse({ records, limit }));
     }
-    const id = req.params['id'] as string;
-    if (!localRelayNode.sessions.get(id)) {
-      res.status(404).json({
-        error: {
-          code: 'NOT_FOUND',
-          reasonCode: 'SESSION_NOT_FOUND',
-          message: 'session was not found or is not locally readable',
-          retryable: false,
-        },
-      });
-      return;
-    }
-    const limit = clampInterventionLimit(
-      typeof req.query.limit === 'string' ? req.query.limit : undefined
-    );
-    const records = localRelayNode.sessions.getInterventions(
-      id,
-      { limit }
-    );
-    res.json(
-      toInterventionReadResponse(
-        { records, limit }
-      )
-    );
-  });
+  );
 
-  app.post('/sessions/:id/control/hand-back', requireScopedSessionAuth, (req, res) => {
-    const decision = capabilitiesDecisionFromRequest(req, [
-      CONTROL_SESSION_CAPABILITY,
-      CONTROL_WRITE_CAPABILITY,
-    ]);
-    if (decision.decision !== 'allow') {
-      const error = capabilityError(decision);
-      res.status(sessionControlErrorStatus(error)).json({ error });
-      return;
+  app.post(
+    '/sessions/:id/control/hand-back',
+    requireScopedSessionAuth,
+    (req, res) => {
+      const decision = capabilitiesDecisionFromRequest(req, [
+        CONTROL_SESSION_CAPABILITY,
+        CONTROL_WRITE_CAPABILITY,
+      ]);
+      if (decision.decision !== 'allow') {
+        const error = capabilityError(decision);
+        res.status(sessionControlErrorStatus(error)).json({ error });
+        return;
+      }
+      const body =
+        typeof req.body === 'object' && req.body !== null
+          ? (req.body as Record<string, unknown>)
+          : {};
+      const latestSeenInterventionEventId =
+        typeof body['latestSeenInterventionEventId'] === 'string'
+          ? body['latestSeenInterventionEventId']
+          : undefined;
+      const actor = actorFromRequestBody(body['actor']);
+      const result = localRelayNode.sessions.handBackToAgent({
+        id: req.params['id'] as string,
+        ...(latestSeenInterventionEventId === undefined
+          ? {}
+          : { latestSeenInterventionEventId }),
+        ...(actor === undefined ? {} : { actor }),
+      });
+      if (result.ok === false) {
+        res
+          .status(sessionControlErrorStatus(result.error))
+          .json({ error: result.error });
+        return;
+      }
+      res.json({
+        ok: true,
+        events: result.events,
+        ackedHumanInterventions: result.ackedHumanInterventions,
+      });
     }
-    const body = typeof req.body === 'object' && req.body !== null ? req.body as Record<string, unknown> : {};
-    const latestSeenInterventionEventId =
-      typeof body['latestSeenInterventionEventId'] === 'string'
-        ? body['latestSeenInterventionEventId']
-        : undefined;
-    const actor = actorFromRequestBody(body['actor']);
-    const result = localRelayNode.sessions.handBackToAgent({
-      id: req.params['id'] as string,
-      ...(latestSeenInterventionEventId === undefined
-        ? {}
-        : { latestSeenInterventionEventId }),
-      ...(actor === undefined ? {} : { actor }),
-    });
-    if (result.ok === false) {
-      res.status(sessionControlErrorStatus(result.error)).json({ error: result.error });
-      return;
-    }
-    res.json({ ok: true, events: result.events, ackedHumanInterventions: result.ackedHumanInterventions });
-  });
+  );
 
   app.post('/sessions/:id/input', requireScopedSessionAuth, (req, res) => {
-    const decision = capabilityDecisionFromRequest(req, CONTROL_SESSION_CAPABILITY);
+    const decision = capabilityDecisionFromRequest(
+      req,
+      CONTROL_SESSION_CAPABILITY
+    );
     if (decision.decision !== 'allow') {
       const error = capabilityError(decision);
       res.status(sessionControlErrorStatus(error)).json({ error });
@@ -2281,7 +2351,9 @@ async function main(): Promise<void> {
       return;
     }
     if (data.length > 1000) {
-      res.status(413).json({ error: 'small input is limited to 1000 characters' });
+      res
+        .status(413)
+        .json({ error: 'small input is limited to 1000 characters' });
       return;
     }
 
@@ -3260,6 +3332,7 @@ async function main(): Promise<void> {
     refWatcher.close();
     gitWatcher.close();
     server.close();
+    credentialRotationScheduler?.stop();
     await flushHubNodeHeartbeatsBestEffort('graceful shutdown');
     // Serialize sessions before detaching the node-pty tmux clients. The tmux
     // sessions themselves must survive so startup can reattach to them.

--- a/server/types.ts
+++ b/server/types.ts
@@ -573,6 +573,7 @@ export interface Config {
     | undefined;
   automations?: AutomationSettings | undefined;
   control?: ControlSettings | undefined;
+  credentialRotation?: CredentialRotationSettings | undefined;
   filterPresets?: FilterPreset[] | undefined;
   github?:
     | {
@@ -597,6 +598,14 @@ export interface AutomationSettings {
 export interface ControlSettings {
   interventionDebounceMs?: number;
   coDrivenAutoRevertMs?: number;
+}
+
+export interface CredentialRotationSettings {
+  // Age threshold for the active credential before the scheduler rotates it.
+  // Omitted or non-positive disables scheduled rotation entirely.
+  intervalMs?: number;
+  // Cadence at which the scheduler scans paired nodes. Defaults to 60_000.
+  checkIntervalMs?: number;
 }
 
 export interface FilterPreset {

--- a/test/credential-rotation-scheduler.test.ts
+++ b/test/credential-rotation-scheduler.test.ts
@@ -162,14 +162,16 @@ describe('credential rotation scheduler', () => {
       ]);
       expect(links.calls).toHaveLength(0);
 
-      const skipped = audits.find(
-        (entry) => entry.reasonCode === 'CREDENTIAL_ROTATION_SCHEDULED_SKIPPED'
+      // Offline-node skips are intentionally silent in the audit log so a
+      // long-offline node does not flood the audit DB once per tick.
+      const offlineAudits = audits.filter(
+        (entry) =>
+          entry.reasonCode === 'CREDENTIAL_ROTATION_SCHEDULED_SKIPPED' &&
+          (entry.material?.params as Record<string, unknown> | undefined)?.[
+            'reason'
+          ] === 'NODE_OFFLINE'
       );
-      expect(skipped).toBeDefined();
-      const params =
-        (skipped?.material?.params as Record<string, unknown> | undefined) ??
-        {};
-      expect(params['reason']).toBe('NODE_OFFLINE');
+      expect(offlineAudits).toHaveLength(0);
     });
   });
 
@@ -239,6 +241,36 @@ describe('credential rotation scheduler', () => {
         .listNodes()
         .find((n) => n.nodeId === exchanged.node.nodeId);
       expect(node?.credentialRotation?.state).toBe('failed');
+    });
+  });
+
+  it('audits failure (not delivered) when markCredentialRotationDelivered throws', async () => {
+    await withHarness(async ({ registry, audits, setNow }) => {
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      const links = fakeNodeLinks(new Set([exchanged.node.nodeId]));
+      vi.spyOn(registry, 'markCredentialRotationDelivered').mockImplementation(
+        () => {
+          throw new Error('persist failed');
+        }
+      );
+      const scheduler = createCredentialRotationScheduler({
+        registry,
+        nodeLinks: links,
+        auditSink: { append: (entry) => audits.push(entry) },
+        intervalMs: 60_000,
+        now: () => new Date(),
+      });
+      setNow(new Date('2026-01-02T00:02:00.000Z'));
+      const result = await scheduler.runOnce();
+      expect(result.failed).toHaveLength(1);
+      const reasonCodes = audits.map((entry) => entry.reasonCode);
+      expect(reasonCodes).toContain('CREDENTIAL_ROTATION_SCHEDULED_FAILED');
+      expect(reasonCodes).not.toContain(
+        'CREDENTIAL_ROTATION_SCHEDULED_DELIVERED'
+      );
     });
   });
 

--- a/test/credential-rotation-scheduler.test.ts
+++ b/test/credential-rotation-scheduler.test.ts
@@ -1,0 +1,279 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createHubNodeRegistry,
+  type HubNodeRegistry,
+} from '../server/hub-node-registry.js';
+import {
+  createCredentialRotationScheduler,
+  type CredentialRotationNodeLinks,
+} from '../server/credential-rotation-scheduler.js';
+import type { SecurityAuditEntryInput } from '../shared/security-audit.js';
+import type { NodeManifest } from '../shared/node-manifest.js';
+import { buildManifestWithAgents } from './helpers/manifest-fixtures.js';
+
+function manifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
+  return buildManifestWithAgents({
+    agents: [{ id: 'claude', label: 'Claude', status: 'available' as const }],
+    overrides,
+  });
+}
+
+interface Harness {
+  registry: HubNodeRegistry;
+  audits: SecurityAuditEntryInput[];
+  setNow: (now: Date) => void;
+}
+
+function withHarness(
+  fn: (harness: Harness) => Promise<void> | void
+): Promise<void> {
+  const tmpDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'relay-credential-rotation-scheduler-')
+  );
+  let currentNow = new Date('2026-01-02T00:00:00.000Z');
+  const audits: SecurityAuditEntryInput[] = [];
+  const registry = createHubNodeRegistry({
+    storagePath: path.join(tmpDir, 'nodes.json'),
+    now: () => currentNow,
+    auditSink: { append: (entry) => audits.push(entry) },
+  });
+  const setNow = (next: Date): void => {
+    currentNow = next;
+    registry.setNowForTest(() => currentNow);
+  };
+  return Promise.resolve(fn({ registry, audits, setNow })).finally(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+}
+
+function fakeNodeLinks(connected: Set<string>): CredentialRotationNodeLinks & {
+  calls: Array<{ nodeId: string; type: string; payload: unknown }>;
+  rejectWith?: Error;
+} {
+  const calls: Array<{ nodeId: string; type: string; payload: unknown }> = [];
+  return {
+    calls,
+    hasActiveNode(nodeId: string) {
+      return connected.has(nodeId);
+    },
+    request(nodeId: string, type: string, payload: unknown) {
+      calls.push({ nodeId, type, payload });
+      if ((this as { rejectWith?: Error }).rejectWith) {
+        return Promise.reject((this as { rejectWith?: Error }).rejectWith);
+      }
+      return Promise.resolve({ ok: true });
+    },
+  } as CredentialRotationNodeLinks & {
+    calls: Array<{ nodeId: string; type: string; payload: unknown }>;
+    rejectWith?: Error;
+  };
+}
+
+describe('credential rotation scheduler', () => {
+  it('refuses to start with a non-positive intervalMs', () => {
+    const noopRegistry = {} as HubNodeRegistry;
+    const noopLinks: CredentialRotationNodeLinks = {
+      hasActiveNode: () => false,
+      request: () => Promise.resolve(undefined),
+    };
+    expect(() =>
+      createCredentialRotationScheduler({
+        registry: noopRegistry,
+        nodeLinks: noopLinks,
+        intervalMs: 0,
+      })
+    ).toThrow(/intervalMs/);
+  });
+
+  it('rotates an aged credential for an online node and audits the decision', async () => {
+    await withHarness(async ({ registry, audits, setNow }) => {
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      const links = fakeNodeLinks(new Set([exchanged.node.nodeId]));
+      const scheduler = createCredentialRotationScheduler({
+        registry,
+        nodeLinks: links,
+        auditSink: { append: (entry) => audits.push(entry) },
+        intervalMs: 60_000,
+        checkIntervalMs: 1_000,
+        now: () => new Date(),
+      });
+
+      // First tick: credential is fresh, nothing should happen.
+      let result = await scheduler.runOnce();
+      expect(result.triggered).toHaveLength(0);
+      expect(result.skipped).toHaveLength(0);
+      expect(links.calls).toHaveLength(0);
+
+      // Age the credential past the interval.
+      setNow(new Date('2026-01-02T00:02:00.000Z'));
+
+      result = await scheduler.runOnce();
+      expect(result.triggered).toHaveLength(1);
+      expect(result.triggered[0]?.nodeId).toBe(exchanged.node.nodeId);
+      expect(links.calls).toEqual([
+        expect.objectContaining({
+          nodeId: exchanged.node.nodeId,
+          type: 'credential.rotate',
+        }),
+      ]);
+
+      const reasonCodes = audits.map((entry) => entry.reasonCode);
+      expect(reasonCodes).toContain('CREDENTIAL_ROTATION_SCHEDULED_TRIGGERED');
+      expect(reasonCodes).toContain('CREDENTIAL_ROTATION_SCHEDULED_DELIVERED');
+
+      const triggered = audits.find(
+        (entry) =>
+          entry.reasonCode === 'CREDENTIAL_ROTATION_SCHEDULED_TRIGGERED'
+      );
+      const params =
+        (triggered?.material?.params as Record<string, unknown> | undefined) ??
+        {};
+      expect(params['trigger']).toBe('scheduled');
+      expect(typeof params['rotationId']).toBe('string');
+    });
+  });
+
+  it('skips offline nodes without throwing or starting a rotation', async () => {
+    await withHarness(async ({ registry, audits, setNow }) => {
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      const links = fakeNodeLinks(new Set()); // no connected nodes
+      const scheduler = createCredentialRotationScheduler({
+        registry,
+        nodeLinks: links,
+        auditSink: { append: (entry) => audits.push(entry) },
+        intervalMs: 60_000,
+        now: () => new Date(),
+      });
+
+      setNow(new Date('2026-01-02T00:02:00.000Z'));
+      const result = await scheduler.runOnce();
+      expect(result.triggered).toHaveLength(0);
+      expect(result.skipped).toEqual([
+        { nodeId: exchanged.node.nodeId, reasonCode: 'NODE_OFFLINE' },
+      ]);
+      expect(links.calls).toHaveLength(0);
+
+      const skipped = audits.find(
+        (entry) => entry.reasonCode === 'CREDENTIAL_ROTATION_SCHEDULED_SKIPPED'
+      );
+      expect(skipped).toBeDefined();
+      const params =
+        (skipped?.material?.params as Record<string, unknown> | undefined) ??
+        {};
+      expect(params['reason']).toBe('NODE_OFFLINE');
+    });
+  });
+
+  it('skips nodes with an in-progress rotation', async () => {
+    await withHarness(async ({ registry, audits, setNow }) => {
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      // Begin a rotation outside the scheduler so the node has an
+      // unresolved rotation when the scheduler ticks.
+      registry.beginCredentialRotation(exchanged.node.nodeId);
+
+      const links = fakeNodeLinks(new Set([exchanged.node.nodeId]));
+      const scheduler = createCredentialRotationScheduler({
+        registry,
+        nodeLinks: links,
+        auditSink: { append: (entry) => audits.push(entry) },
+        intervalMs: 60_000,
+        now: () => new Date(),
+      });
+
+      setNow(new Date('2026-01-02T00:02:00.000Z'));
+      const result = await scheduler.runOnce();
+      // The candidate filter should exclude rotating nodes, so nothing is
+      // triggered and nothing is skipped at the scheduler level.
+      expect(result.candidates).toBe(0);
+      expect(result.triggered).toHaveLength(0);
+      expect(result.skipped).toHaveLength(0);
+      expect(links.calls).toHaveLength(0);
+    });
+  });
+
+  it('marks the rotation failed and audits when delivery rejects', async () => {
+    await withHarness(async ({ registry, audits, setNow }) => {
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      const links = fakeNodeLinks(new Set([exchanged.node.nodeId]));
+      (links as { rejectWith?: Error }).rejectWith = new Error(
+        'delivery timeout'
+      );
+      const scheduler = createCredentialRotationScheduler({
+        registry,
+        nodeLinks: links,
+        auditSink: { append: (entry) => audits.push(entry) },
+        intervalMs: 60_000,
+        now: () => new Date(),
+      });
+
+      setNow(new Date('2026-01-02T00:02:00.000Z'));
+      const result = await scheduler.runOnce();
+      expect(result.failed).toHaveLength(1);
+      expect(result.failed[0]?.reasonCode).toBe(
+        'CREDENTIAL_ROTATION_SCHEDULED_FAILED'
+      );
+
+      const failed = audits.find(
+        (entry) => entry.reasonCode === 'CREDENTIAL_ROTATION_SCHEDULED_FAILED'
+      );
+      expect(failed?.decision).toBe('failed');
+
+      // The registry should reflect the failure so the next tick does not
+      // try to rotate the same node again.
+      const node = registry
+        .listNodes()
+        .find((n) => n.nodeId === exchanged.node.nodeId);
+      expect(node?.credentialRotation?.state).toBe('failed');
+    });
+  });
+
+  it('does not re-enter while a previous tick is still running', async () => {
+    await withHarness(async ({ registry, audits, setNow }) => {
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      const connected = new Set([exchanged.node.nodeId]);
+      let resolveDelivery!: () => void;
+      const requestSpy = vi.fn(() => {
+        return new Promise<unknown>((resolve) => {
+          resolveDelivery = () => resolve({ ok: true });
+        });
+      });
+      const links: CredentialRotationNodeLinks = {
+        hasActiveNode: (nodeId) => connected.has(nodeId),
+        request: requestSpy,
+      };
+      const scheduler = createCredentialRotationScheduler({
+        registry,
+        nodeLinks: links,
+        auditSink: { append: (entry) => audits.push(entry) },
+        intervalMs: 60_000,
+        now: () => new Date(),
+      });
+
+      setNow(new Date('2026-01-02T00:02:00.000Z'));
+      const first = scheduler.runOnce();
+      const second = scheduler.runOnce();
+      expect(first).toBe(second);
+      resolveDelivery();
+      await first;
+      expect(requestSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -848,8 +848,12 @@ describe('hub node registry', () => {
           nextCredentialId: rotation.credential.credentialId,
         },
       });
-      expect(registry.authenticateCredential(exchanged.credential.token)).toBeNull();
-      expect(registry.authenticateCredential(rotation.credential.token)).toMatchObject({
+      expect(
+        registry.authenticateCredential(exchanged.credential.token)
+      ).toBeNull();
+      expect(
+        registry.authenticateCredential(rotation.credential.token)
+      ).toMatchObject({
         credentialId: rotation.credential.credentialId,
         credentialState: 'active',
       });
@@ -863,7 +867,10 @@ describe('hub node registry', () => {
           nodeId: exchanged.node.nodeId,
           credentialId: rotation.credential.credentialId,
         },
-        intent: { action: 'nodes.credential.rotate', target: exchanged.node.nodeId },
+        intent: {
+          action: 'nodes.credential.rotate',
+          target: exchanged.node.nodeId,
+        },
         material: {
           params: {
             rotationId: rotation.rotation.rotationId,
@@ -872,8 +879,12 @@ describe('hub node registry', () => {
           },
         },
       });
-      expect(JSON.stringify(auditEntries)).not.toContain(rotation.credential.token);
-      expect(JSON.stringify(auditEntries)).not.toContain(exchanged.credential.token);
+      expect(JSON.stringify(auditEntries)).not.toContain(
+        rotation.credential.token
+      );
+      expect(JSON.stringify(auditEntries)).not.toContain(
+        exchanged.credential.token
+      );
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -911,14 +922,18 @@ describe('hub node registry', () => {
         registry.beginCredentialRotation(exchanged.node.nodeId)
       ).toThrow(/ROTATION_IN_PROGRESS/);
 
-      const cleared = registry.clearCredentialRotationFailure(exchanged.node.nodeId);
+      const cleared = registry.clearCredentialRotationFailure(
+        exchanged.node.nodeId
+      );
 
       expect(cleared).toMatchObject({
         credentialState: 'active',
         credentialId: exchanged.credential.credentialId,
       });
       expect(cleared.credentialRotation).toBeUndefined();
-      expect(registry.authenticateCredential(rotation.credential.token)).toBeNull();
+      expect(
+        registry.authenticateCredential(rotation.credential.token)
+      ).toBeNull();
       expect(() =>
         registry.beginCredentialRotation(exchanged.node.nodeId)
       ).not.toThrow();
@@ -956,8 +971,12 @@ describe('hub node registry', () => {
           failureReason: 'delivery timeout after node write',
         },
       });
-      expect(registry.authenticateCredential(exchanged.credential.token)).toBeNull();
-      expect(registry.authenticateCredential(rotation.credential.token)).toMatchObject({
+      expect(
+        registry.authenticateCredential(exchanged.credential.token)
+      ).toBeNull();
+      expect(
+        registry.authenticateCredential(rotation.credential.token)
+      ).toMatchObject({
         credentialId: rotation.credential.credentialId,
         credentialState: 'active',
       });
@@ -980,21 +999,152 @@ describe('hub node registry', () => {
         registry.beginCredentialRotation(exchanged.node.nodeId)
       ).toThrow(/ROTATION_IN_PROGRESS/);
 
-      const cleared = registry.clearCredentialRotationFailure(exchanged.node.nodeId);
+      const cleared = registry.clearCredentialRotationFailure(
+        exchanged.node.nodeId
+      );
 
       expect(cleared).toMatchObject({
         credentialState: 'active',
         credentialId: exchanged.credential.credentialId,
       });
       expect(cleared.credentialRotation).toBeUndefined();
-      expect(registry.authenticateCredential(exchanged.credential.token)).toMatchObject({
+      expect(
+        registry.authenticateCredential(exchanged.credential.token)
+      ).toMatchObject({
         credentialId: exchanged.credential.credentialId,
         credentialState: 'active',
       });
-      expect(registry.authenticateCredential(rotation.credential.token)).toBeNull();
+      expect(
+        registry.authenticateCredential(rotation.credential.token)
+      ).toBeNull();
       expect(() =>
         registry.beginCredentialRotation(exchanged.node.nodeId)
       ).not.toThrow();
+    });
+  });
+
+  describe('listScheduledRotationCandidates', () => {
+    it('returns nothing for a non-positive intervalMs', () => {
+      withTmpRegistry((registry) => {
+        const exchanged = registry.exchangePairToken({
+          pairToken: registry.createPairToken({}).pairToken,
+          manifest: manifest(),
+        });
+        expect(registry.listScheduledRotationCandidates(0)).toHaveLength(0);
+        expect(registry.listScheduledRotationCandidates(-1)).toHaveLength(0);
+        expect(exchanged.node.nodeId).toBeTruthy();
+      });
+    });
+
+    it('lists a paired node whose credential is older than the interval', () => {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'relay-hub-node-registry-')
+      );
+      try {
+        let currentNow = new Date('2026-01-02T00:00:00.000Z');
+        const registry = createHubNodeRegistry({
+          storagePath: path.join(tmpDir, 'nodes.json'),
+          now: () => currentNow,
+        });
+        const exchanged = registry.exchangePairToken({
+          pairToken: registry.createPairToken({}).pairToken,
+          manifest: manifest(),
+        });
+        expect(registry.listScheduledRotationCandidates(60_000)).toHaveLength(
+          0
+        );
+        currentNow = new Date('2026-01-02T00:02:00.000Z');
+        registry.setNowForTest(() => currentNow);
+        const candidates = registry.listScheduledRotationCandidates(60_000);
+        expect(candidates).toHaveLength(1);
+        expect(candidates[0]).toMatchObject({
+          nodeId: exchanged.node.nodeId,
+          credentialId: exchanged.credential.credentialId,
+        });
+        expect(candidates[0]!.ageMs).toBeGreaterThanOrEqual(60_000);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('skips revoked nodes and nodes mid-rotation', () => {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'relay-hub-node-registry-')
+      );
+      try {
+        let currentNow = new Date('2026-01-02T00:00:00.000Z');
+        const registry = createHubNodeRegistry({
+          storagePath: path.join(tmpDir, 'nodes.json'),
+          now: () => currentNow,
+        });
+        const stable = registry.exchangePairToken({
+          pairToken: registry.createPairToken({}).pairToken,
+          manifest: manifest(),
+        });
+        const revoked = registry.exchangePairToken({
+          pairToken: registry.createPairToken({}).pairToken,
+          manifest: manifest(),
+        });
+        const rotating = registry.exchangePairToken({
+          pairToken: registry.createPairToken({}).pairToken,
+          manifest: manifest(),
+        });
+        registry.revokeNode(revoked.node.nodeId);
+        registry.beginCredentialRotation(rotating.node.nodeId);
+        currentNow = new Date('2026-01-02T00:02:00.000Z');
+        registry.setNowForTest(() => currentNow);
+        const candidates = registry.listScheduledRotationCandidates(60_000);
+        const ids = candidates.map((c) => c.nodeId);
+        expect(ids).toEqual([stable.node.nodeId]);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('uses the last stable rotation timestamp as the credential age anchor', () => {
+      const tmpDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'relay-hub-node-registry-')
+      );
+      try {
+        let currentNow = new Date('2026-01-02T00:00:00.000Z');
+        const registry = createHubNodeRegistry({
+          storagePath: path.join(tmpDir, 'nodes.json'),
+          now: () => currentNow,
+        });
+        const exchanged = registry.exchangePairToken({
+          pairToken: registry.createPairToken({}).pairToken,
+          manifest: manifest(),
+        });
+        // Age past interval, then rotate to reset the age clock.
+        currentNow = new Date('2026-01-02T00:02:00.000Z');
+        registry.setNowForTest(() => currentNow);
+        const rotation = registry.beginCredentialRotation(
+          exchanged.node.nodeId
+        );
+        registry.markCredentialRotationDelivered(
+          exchanged.node.nodeId,
+          rotation.rotation.rotationId
+        );
+        registry.recordHeartbeat({
+          nodeId: exchanged.node.nodeId,
+          protocolVersion: '1.0',
+          credentialId: rotation.credential.credentialId,
+          manifest: manifest(),
+        });
+        // Immediately after proof, the node should not be a candidate again.
+        expect(registry.listScheduledRotationCandidates(60_000)).toHaveLength(
+          0
+        );
+        // Age past the interval relative to the rotation's stableAt.
+        currentNow = new Date('2026-01-02T00:04:00.000Z');
+        registry.setNowForTest(() => currentNow);
+        const candidates = registry.listScheduledRotationCandidates(60_000);
+        expect(candidates.map((c) => c.nodeId)).toEqual([
+          exchanged.node.nodeId,
+        ]);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary
- Opt-in hub-side scheduler that triggers credential rotation for paired nodes whose active credential is older than a configured age. Reuses the existing `begin → deliver → prove` state machine and audit pipeline.
- New config: `Config.credentialRotation = { intervalMs, checkIntervalMs? }`. Absent or non-positive `intervalMs` keeps the scheduler disabled.
- New audit reason codes: `CREDENTIAL_ROTATION_SCHEDULED_TRIGGERED`, `_DELIVERED`, `_SKIPPED` (with `reason` param), `_FAILED`. All carry `params.trigger = 'scheduled'` so existing rotation rows stay distinguishable.
- Offline nodes audit `SKIPPED reason: NODE_OFFLINE`. Mid-rotation nodes are filtered before audit so the scheduler can't collide with operator-initiated rotations. Delivery failures call `failCredentialRotation` (previous credential stays active).
- Docs: `docs/SECURITY_POLICY.md` gets a scheduled-rotation section; `docs/federated-relay.md` drops the "scheduled rotation not currently automatic" caveat and documents the knob.
- ACL/policy stays independent: rotation is hygiene, not policy. ACL changes still apply immediately.

Closes #595, advances #427.

## Test plan
- [x] `npx vitest run test/credential-rotation-scheduler.test.ts test/hub-node-registry.test.ts` — 26 passed (5 new scheduler tests covering aged-credential trigger + audit, offline-skip, mid-rotation-skip, delivery-failure fail-closed, reentrancy guard; 4 new registry tests covering intervalMs<=0, age threshold, revoked/rotating exclusion, stable-rotation anchoring).
- [x] `npm run check` — 0 errors (warnings preexisting).
- [x] `npm run build` — clean.
- [x] Full suite via `rtk proxy npx vitest run` — 2391 passed, 1 unrelated flake in `test/git-divergence.test.ts` (passes in isolation).
- [ ] Reviewer: confirm there's no path where a paired node's active credential silently changes without the rotation state machine + audit emission.
- [ ] Reviewer: confirm the scheduler is genuinely off by default — verified by default config not setting `credentialRotation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)