### PR TITLE
test(redaction): cover every diag bundle pattern + manifest consistency gate (#598)

### DIFF
--- a/test/fixtures/redaction/authorization-header.txt
+++ b/test/fixtures/redaction/authorization-header.txt
@@ -1,0 +1,14 @@
+## meta
+rule: authorization-header
+module: diagnostics-bundle
+redactor: redactText
+description: Any Authorization header value (Basic, Bearer, Token, custom schemes) gets replaced, not just Bearer
+secrets: Basic dXNlcjpGQUtFX1BBU1NfYWFhYWFhYWE=,Token tok_FAKE_VALUE_aaaaaaaaaaaa,Custom-Scheme FAKE_CUSTOM_aaaaaaaaaaaa
+preserves: GET /hub/node-link,host: hub.example.test,User-Agent: relay-ide
+## input
+GET /hub/node-link HTTP/1.1
+host: hub.example.test
+User-Agent: relay-ide
+Authorization: Basic dXNlcjpGQUtFX1BBU1NfYWFhYWFhYWE=
+authorization: Token tok_FAKE_VALUE_aaaaaaaaaaaa
+Authorization: Custom-Scheme FAKE_CUSTOM_aaaaaaaaaaaa

--- a/test/fixtures/redaction/bearer-token.txt
+++ b/test/fixtures/redaction/bearer-token.txt
@@ -1,0 +1,11 @@
+## meta
+rule: bearer-token
+module: diagnostics-bundle
+redactor: redactText
+description: Standalone Bearer tokens (not in an Authorization header line) get scrubbed
+secrets: tok_FAKE_BEARER_VALUE_aaaaaaaaaa
+preserves: connected to wss://hub.example.test/hub/node-link,handshake ok
+## input
+connected to wss://hub.example.test/hub/node-link
+node-link client sent Bearer tok_FAKE_BEARER_VALUE_aaaaaaaaaa for handshake
+handshake ok

--- a/test/fixtures/redaction/bootstrap-bearer-header.txt
+++ b/test/fixtures/redaction/bootstrap-bearer-header.txt
@@ -1,0 +1,12 @@
+## meta
+rule: bootstrap-bearer-header
+module: bootstrap-diagnostics
+redactor: redactBootstrapSecrets
+description: Authorization: Bearer values and standalone Bearer tokens get scrubbed in bootstrap diagnostics text
+secrets: tok_FAKE_BOOTSTRAP_BEARER_aaaaaaaa,tok_FAKE_STANDALONE_BEARER_bbbbbbbb
+preserves: bootstrap response,GET /hub/node-link
+## input
+bootstrap response
+GET /hub/node-link
+Authorization: Bearer tok_FAKE_BOOTSTRAP_BEARER_aaaaaaaa
+fallback header Bearer tok_FAKE_STANDALONE_BEARER_bbbbbbbb logged on retry

--- a/test/fixtures/redaction/bootstrap-json-secret-key.txt
+++ b/test/fixtures/redaction/bootstrap-json-secret-key.txt
@@ -1,0 +1,9 @@
+## meta
+rule: bootstrap-json-secret-key
+module: bootstrap-diagnostics
+redactor: redactBootstrapSecrets
+description: token/pairToken/pin/password/secret JSON keys in serialized bootstrap payloads get scrubbed
+secrets: FAKE_JSON_TOKEN_aaaaaaaa,FAKE_JSON_PAIR_bbbbbbbb,FAKE_JSON_PIN_123456,FAKE_JSON_PASSWORD_cccccccc,FAKE_JSON_SECRET_dddddddd
+preserves: "nodeId":"node-1","hubUrl":"https://hub.example.test"
+## input
+{"nodeId":"node-1","hubUrl":"https://hub.example.test","token":"FAKE_JSON_TOKEN_aaaaaaaa","pairToken":"FAKE_JSON_PAIR_bbbbbbbb","pin":"FAKE_JSON_PIN_123456","password":"FAKE_JSON_PASSWORD_cccccccc","secret":"FAKE_JSON_SECRET_dddddddd"}

--- a/test/fixtures/redaction/bootstrap-node-credential.txt
+++ b/test/fixtures/redaction/bootstrap-node-credential.txt
@@ -1,0 +1,12 @@
+## meta
+rule: bootstrap-node-credential
+module: bootstrap-diagnostics
+redactor: redactBootstrapSecrets
+description: node_<id>.secret_<token> persistent credential shape (#587/#588 routed-PTY) gets scrubbed
+secrets: node_FAKE_NODE_aaaaaaaa.secret_FAKE_SECRET_bbbbbbbb,secret_FAKE_STANDALONE_cccccccc
+preserves: rotating node credential,rotation complete
+## input
+rotating node credential
+old credential: node_FAKE_NODE_aaaaaaaa.secret_FAKE_SECRET_bbbbbbbb
+standalone token observed in error path: secret_FAKE_STANDALONE_cccccccc
+rotation complete

--- a/test/fixtures/redaction/bootstrap-pair-token.txt
+++ b/test/fixtures/redaction/bootstrap-pair-token.txt
@@ -1,0 +1,10 @@
+## meta
+rule: bootstrap-pair-token
+module: bootstrap-diagnostics
+redactor: redactBootstrapSecrets
+description: --pair-token CLI flag and bare pair_ prefixed tokens get scrubbed in routed-PTY / bootstrap command echoes
+secrets: pair_FAKE_TOKEN_VALUE_aaaaaaaaaa,pair_FAKE_SECOND_TOKEN_bbbbbbbb
+preserves: relay-ide node connect,--hub 'https://hub.example.test'
+## input
+relay-ide node connect --hub 'https://hub.example.test' --pair-token 'pair_FAKE_TOKEN_VALUE_aaaaaaaaaa'
+recovered stale pair token pair_FAKE_SECOND_TOKEN_bbbbbbbb during diagnostics

--- a/test/fixtures/redaction/bootstrap-secret-assignment.txt
+++ b/test/fixtures/redaction/bootstrap-secret-assignment.txt
@@ -1,0 +1,9 @@
+## meta
+rule: bootstrap-secret-assignment
+module: bootstrap-diagnostics
+redactor: redactBootstrapSecrets
+description: token=, pin=, password=, secret= assignments in bootstrap text get the value scrubbed
+secrets: FAKE_ASSIGN_TOKEN_aaaaaaaa,FAKE_ASSIGN_PIN_123456,FAKE_ASSIGN_PASSWORD_bbbbbbbb,FAKE_ASSIGN_SECRET_cccccccc
+preserves: relay-ide node install,hub=https://hub.example.test
+## input
+relay-ide node install hub=https://hub.example.test token=FAKE_ASSIGN_TOKEN_aaaaaaaa pin=FAKE_ASSIGN_PIN_123456 password=FAKE_ASSIGN_PASSWORD_bbbbbbbb secret=FAKE_ASSIGN_SECRET_cccccccc

--- a/test/fixtures/redaction/cookie-header.txt
+++ b/test/fixtures/redaction/cookie-header.txt
@@ -1,0 +1,11 @@
+## meta
+rule: cookie-header
+module: diagnostics-bundle
+redactor: redactText
+description: Cookie header values get scrubbed regardless of name
+secrets: relay_sid=FAKE_SESSION_aaaaaaaaaaaa; csrf=FAKE_CSRF_bbbbbbbb
+preserves: GET / HTTP/1.1,host: hub.example.test
+## input
+GET / HTTP/1.1
+host: hub.example.test
+Cookie: relay_sid=FAKE_SESSION_aaaaaaaaaaaa; csrf=FAKE_CSRF_bbbbbbbb

--- a/test/fixtures/redaction/github-token.txt
+++ b/test/fixtures/redaction/github-token.txt
@@ -1,0 +1,11 @@
+## meta
+rule: github-token
+module: diagnostics-bundle
+redactor: redactText
+description: GitHub PAT formats (gh{p,o,u,s,r}_ and github_pat_) get scrubbed even when standalone
+secrets: ghp_FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE1234,github_pat_FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE5678
+preserves: gh auth status,Logged in as @tester
+## input
+gh auth status
+Logged in as @tester with token ghp_FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE1234
+fine-grained token github_pat_FAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE5678 also present

--- a/test/fixtures/redaction/private-key-block.txt
+++ b/test/fixtures/redaction/private-key-block.txt
@@ -1,0 +1,14 @@
+## meta
+rule: private-key-block
+module: diagnostics-bundle
+redactor: redactText
+description: PEM-formatted private key blocks of any algorithm get fully replaced
+secrets: -----BEGIN RSA PRIVATE KEY-----,MIIEogIBAAKCAQEA_FAKE_KEY_DO_NOT_USE_aaaaaaaaaaaaaaaaaaaaaaaaaaaa,-----END RSA PRIVATE KEY-----
+preserves: relay-node boot,credential rotation complete
+## input
+relay-node boot
+-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEA_FAKE_KEY_DO_NOT_USE_aaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+-----END RSA PRIVATE KEY-----
+credential rotation complete

--- a/test/fixtures/redaction/secret-assignment.txt
+++ b/test/fixtures/redaction/secret-assignment.txt
@@ -1,0 +1,15 @@
+## meta
+rule: secret-assignment
+module: diagnostics-bundle
+redactor: redactText
+description: key=value assignments and quoted assignments for sensitive key names get the value scrubbed
+secrets: FAKE_TOKEN_VALUE_aaaaaaaaaaaa,FAKE_PIN_123456,FAKE_QUOTED_SECRET_aaaaaaaaaa,FAKE_SINGLE_QUOTED_aaaaaaaaaa
+preserves: bootstrapping node,RELAY_LOG_LEVEL=debug,startup ok
+## input
+bootstrapping node
+RELAY_LOG_LEVEL=debug
+token=FAKE_TOKEN_VALUE_aaaaaaaaaaaa
+pin=FAKE_PIN_123456
+password="FAKE_QUOTED_SECRET_aaaaaaaaaa"
+api_key='FAKE_SINGLE_QUOTED_aaaaaaaaaa'
+startup ok

--- a/test/fixtures/redaction/sensitive-json-key.json
+++ b/test/fixtures/redaction/sensitive-json-key.json
@@ -1,0 +1,22 @@
+{
+  "rule": "sensitive-json-key",
+  "module": "diagnostics-bundle",
+  "redactor": "redactJson",
+  "description": "JSON object keys matching token/secret/password/pin/cookie/authorization/credential/private-key/access-key/api-key/webhook/hash get fully replaced",
+  "input": {
+    "host": "hub.example.test",
+    "port": 4321,
+    "accessToken": "ghp_FAKE_FAKE_FAKE_FAKE_FAKE_FAKE_FAKE_FAKE",
+    "nested": {
+      "pinHash": "pin_FAKE_VALUE_aaaaaaaaaaaa",
+      "apiKey": "sk_test_FAKE_KEY_aaaaaaaaaaaaaaaa",
+      "label": "safe"
+    }
+  },
+  "secrets": [
+    "ghp_FAKE_FAKE_FAKE_FAKE_FAKE_FAKE_FAKE_FAKE",
+    "pin_FAKE_VALUE_aaaaaaaaaaaa",
+    "sk_test_FAKE_KEY_aaaaaaaaaaaaaaaa"
+  ],
+  "preserves": ["hub.example.test", "safe", "4321"]
+}

--- a/test/fixtures/redaction/url-credential.txt
+++ b/test/fixtures/redaction/url-credential.txt
@@ -1,0 +1,10 @@
+## meta
+rule: url-credential
+module: diagnostics-bundle
+redactor: redactText
+description: Credentials embedded in URLs (http(s)://user:pass@host) get scrubbed
+secrets: relayuser,FAKE_URL_PASSWORD_aaaaaaaaaa
+preserves: hub.example.test,git remote add origin
+## input
+git remote add origin https://relayuser:FAKE_URL_PASSWORD_aaaaaaaaaa@hub.example.test/relay-ide.git
+fetch from https://relayuser:FAKE_URL_PASSWORD_aaaaaaaaaa@hub.example.test/relay-ide.git ok

--- a/test/shared/redaction-coverage.test.ts
+++ b/test/shared/redaction-coverage.test.ts
@@ -78,13 +78,18 @@ function loadFixtures(): Fixture[] {
 }
 
 function parseTxtFixture(file: string, body: string): Fixture {
-  const metaMatch = body.match(/## meta\n([\s\S]*?)\n## input\n([\s\S]*)$/);
+  // CRLF-tolerant: fixtures are checked in with LF endings, but a Windows
+  // checkout (or an editor that converts line endings on save) shouldn't
+  // break the parser. Per Gemini PR #606 feedback.
+  const metaMatch = body.match(
+    /## meta\r?\n([\s\S]*?)\r?\n## input\r?\n([\s\S]*)$/
+  );
   if (!metaMatch) {
     throw new Error(
       `fixture ${file} must have a '## meta' block followed by '## input'`
     );
   }
-  const metaLines = metaMatch[1]!.split('\n');
+  const metaLines = metaMatch[1]!.split(/\r?\n/);
   const meta: Record<string, string> = {};
   for (const line of metaLines) {
     const trimmed = line.trim();
@@ -93,7 +98,7 @@ function parseTxtFixture(file: string, body: string): Fixture {
     if (idx === -1) throw new Error(`fixture ${file} meta line missing colon: ${line}`);
     meta[trimmed.slice(0, idx).trim()] = trimmed.slice(idx + 1).trim();
   }
-  const input = metaMatch[2]!.replace(/\n+$/, '');
+  const input = metaMatch[2]!.replace(/[\r\n]+$/, '');
   return {
     file,
     rule: requireMeta(file, meta, 'rule'),

--- a/test/shared/redaction-coverage.test.ts
+++ b/test/shared/redaction-coverage.test.ts
@@ -1,0 +1,299 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  DIAGNOSTICS_REDACTION_RULES,
+  redactJson,
+  redactText,
+} from '../../server/diagnostics-bundle.js';
+import { redactBootstrapSecrets } from '../../shared/bootstrap-diagnostics.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Manifest <-> fixture consistency gate for the diagnostics bundle redactor.
+//
+// Issue #598 follow-on to PR #513 / #504: ensures every redaction rule shipped
+// by `diagnostics-bundle.ts` has a representative fixture proving it fires,
+// and every fixture maps to a known rule. Adding a rule without a fixture (or
+// removing a fixture without removing the rule) fails this test loudly.
+//
+// Bootstrap-diagnostics fixtures (`module: bootstrap-diagnostics`) cover the
+// `redactBootstrapSecrets` shapes that flow through routed-PTY error paths
+// (#587 / #588) — pair tokens, node credentials, Bearer headers, JSON secret
+// keys, secret assignments. The bootstrap redactor has no exported rule list,
+// so behavioral assertions only on those fixtures.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = path.resolve(__dirname, '..', 'fixtures', 'redaction');
+
+type Module = 'diagnostics-bundle' | 'bootstrap-diagnostics';
+
+interface Fixture {
+  file: string;
+  rule: string;
+  module: Module;
+  redactor: 'redactText' | 'redactJson' | 'redactBootstrapSecrets';
+  description: string;
+  input: string | unknown;
+  inputIsJson: boolean;
+  secrets: string[];
+  preserves: string[];
+}
+
+function loadFixtures(): Fixture[] {
+  const fixtures: Fixture[] = [];
+  const files = fs.readdirSync(FIXTURE_DIR).sort();
+  for (const file of files) {
+    const fullPath = path.join(FIXTURE_DIR, file);
+    if (file.endsWith('.json')) {
+      const raw = JSON.parse(fs.readFileSync(fullPath, 'utf8')) as {
+        rule: string;
+        module: Module;
+        redactor: Fixture['redactor'];
+        description: string;
+        input: unknown;
+        secrets: string[];
+        preserves: string[];
+      };
+      fixtures.push({
+        file,
+        rule: raw.rule,
+        module: raw.module,
+        redactor: raw.redactor,
+        description: raw.description,
+        input: raw.input,
+        inputIsJson: true,
+        secrets: raw.secrets,
+        preserves: raw.preserves,
+      });
+      continue;
+    }
+    if (file.endsWith('.txt')) {
+      fixtures.push(parseTxtFixture(file, fs.readFileSync(fullPath, 'utf8')));
+      continue;
+    }
+  }
+  return fixtures;
+}
+
+function parseTxtFixture(file: string, body: string): Fixture {
+  const metaMatch = body.match(/## meta\n([\s\S]*?)\n## input\n([\s\S]*)$/);
+  if (!metaMatch) {
+    throw new Error(
+      `fixture ${file} must have a '## meta' block followed by '## input'`
+    );
+  }
+  const metaLines = metaMatch[1]!.split('\n');
+  const meta: Record<string, string> = {};
+  for (const line of metaLines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const idx = trimmed.indexOf(':');
+    if (idx === -1) throw new Error(`fixture ${file} meta line missing colon: ${line}`);
+    meta[trimmed.slice(0, idx).trim()] = trimmed.slice(idx + 1).trim();
+  }
+  const input = metaMatch[2]!.replace(/\n+$/, '');
+  return {
+    file,
+    rule: requireMeta(file, meta, 'rule'),
+    module: requireMeta(file, meta, 'module') as Module,
+    redactor: requireMeta(file, meta, 'redactor') as Fixture['redactor'],
+    description: requireMeta(file, meta, 'description'),
+    input,
+    inputIsJson: false,
+    secrets: requireMeta(file, meta, 'secrets')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean),
+    preserves: requireMeta(file, meta, 'preserves')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean),
+  };
+}
+
+function requireMeta(
+  file: string,
+  meta: Record<string, string>,
+  key: string
+): string {
+  const value = meta[key];
+  if (value === undefined || value === '') {
+    throw new Error(`fixture ${file} missing required meta key '${key}'`);
+  }
+  return value;
+}
+
+function applyRedactor(fixture: Fixture): {
+  output: string;
+  counts: Record<string, number>;
+} {
+  if (fixture.redactor === 'redactJson') {
+    const result = redactJson(fixture.input);
+    return { output: JSON.stringify(result.value), counts: result.counts };
+  }
+  const inputText =
+    typeof fixture.input === 'string' ? fixture.input : JSON.stringify(fixture.input);
+  if (fixture.redactor === 'redactText') {
+    const result = redactText(inputText);
+    return { output: result.value, counts: result.counts };
+  }
+  if (fixture.redactor === 'redactBootstrapSecrets') {
+    return { output: redactBootstrapSecrets(inputText), counts: {} };
+  }
+  throw new Error(`fixture ${fixture.file} has unknown redactor ${fixture.redactor}`);
+}
+
+const fixtures = loadFixtures();
+const fixturesByRule = new Map<string, Fixture[]>();
+for (const fixture of fixtures) {
+  const list = fixturesByRule.get(fixture.rule) ?? [];
+  list.push(fixture);
+  fixturesByRule.set(fixture.rule, list);
+}
+
+describe('redaction fixture coverage', () => {
+  it('loads at least one fixture per registered rule', () => {
+    expect(fixtures.length).toBeGreaterThanOrEqual(
+      DIAGNOSTICS_REDACTION_RULES.length
+    );
+  });
+
+  for (const fixture of fixtures) {
+    it(`scrubs ${fixture.rule} secrets while preserving context (${fixture.file})`, () => {
+      const { output, counts } = applyRedactor(fixture);
+      for (const secret of fixture.secrets) {
+        expect(
+          output,
+          `fixture ${fixture.file} leaked secret "${secret}" through ${fixture.redactor}`
+        ).not.toContain(secret);
+      }
+      for (const preserved of fixture.preserves) {
+        expect(
+          output,
+          `fixture ${fixture.file} dropped expected non-secret context "${preserved}"`
+        ).toContain(preserved);
+      }
+      // For the bundle redactor, prove the named rule actually fired (no
+      // silent fallthrough to a different rule).
+      if (fixture.module === 'diagnostics-bundle') {
+        expect(
+          counts[fixture.rule] ?? 0,
+          `fixture ${fixture.file} expected rule '${fixture.rule}' to fire but counts=${JSON.stringify(
+            counts
+          )}`
+        ).toBeGreaterThan(0);
+      }
+    });
+  }
+});
+
+describe('redaction manifest <-> fixture consistency gate', () => {
+  it('every DIAGNOSTICS_REDACTION_RULES entry has at least one fixture', () => {
+    const missing: string[] = [];
+    for (const rule of DIAGNOSTICS_REDACTION_RULES) {
+      const matched = fixturesByRule.get(rule.id) ?? [];
+      const fromBundle = matched.filter((f) => f.module === 'diagnostics-bundle');
+      if (fromBundle.length === 0) missing.push(rule.id);
+    }
+    expect(
+      missing,
+      `missing diagnostics-bundle fixtures for rules: ${missing.join(', ')}. ` +
+        `Add test/fixtures/redaction/<rule>.{txt,json} with module=diagnostics-bundle.`
+    ).toEqual([]);
+  });
+
+  it('every diagnostics-bundle fixture maps to a registered rule', () => {
+    const known = new Set(DIAGNOSTICS_REDACTION_RULES.map((rule) => rule.id));
+    const orphaned: string[] = [];
+    for (const fixture of fixtures) {
+      if (fixture.module !== 'diagnostics-bundle') continue;
+      if (!known.has(fixture.rule)) orphaned.push(`${fixture.file}#${fixture.rule}`);
+    }
+    expect(
+      orphaned,
+      `fixtures reference unknown diagnostics-bundle rules: ${orphaned.join(', ')}. ` +
+        `Either add the rule to DIAGNOSTICS_REDACTION_RULES or remove the fixture.`
+    ).toEqual([]);
+  });
+
+  it('every bootstrap-diagnostics fixture is actually scrubbed by redactBootstrapSecrets', () => {
+    // Bootstrap redactor has no exported rule list, so this is the closest we
+    // can get to a manifest gate: every fixture tagged bootstrap-diagnostics
+    // must round-trip with all declared secrets removed.
+    const leaks: string[] = [];
+    for (const fixture of fixtures) {
+      if (fixture.module !== 'bootstrap-diagnostics') continue;
+      const text =
+        typeof fixture.input === 'string'
+          ? fixture.input
+          : JSON.stringify(fixture.input);
+      const output = redactBootstrapSecrets(text);
+      for (const secret of fixture.secrets) {
+        if (output.includes(secret)) leaks.push(`${fixture.file}:${secret}`);
+      }
+    }
+    expect(
+      leaks,
+      `bootstrap-diagnostics fixtures leaked secrets through redactBootstrapSecrets: ${leaks.join(', ')}`
+    ).toEqual([]);
+  });
+});
+
+describe('routed-PTY / node-link log shapes (#587, #588) are covered by redaction', () => {
+  // Sanity-check the specific log line shapes emitted by node-link-client,
+  // node-link-rpc-host, and node-link-pty-host. If any of these regress to
+  // emit raw secret content and the redactor stops catching it, this test
+  // tells you which log path is now leaking.
+
+  it('redacts http(s) URL-embedded credentials in "connected to <linkUrl>" lines (covers the http/https half of node-link-client.ts:411)', () => {
+    const raw =
+      "[node-link] connected to https://relayuser:FAKE_URL_PASS_aaaaaaaa@hub.example.test/hub/node-link";
+    const out = redactText(raw).value;
+    expect(out).not.toContain('FAKE_URL_PASS_aaaaaaaa');
+    expect(out).not.toContain('relayuser');
+    expect(out).toContain('hub.example.test');
+  });
+
+  // Known gap tracked as issue #604: the diag bundle url-credential regex
+  // only matches https?:// URLs, but node-link-client logs the WS variant
+  // (wss://). When that's fixed, this it.fails flips green and forces us
+  // to retire the .fails marker — exactly the regression behavior we want.
+  it.fails(
+    'redacts ws(s) URL-embedded credentials in "connected to <linkUrl>" lines — see issue #604',
+    () => {
+      const raw =
+        "[node-link] connected to wss://relayuser:FAKE_URL_PASS_aaaaaaaa@hub.example.test/hub/node-link";
+      const out = redactText(raw).value;
+      expect(out).not.toContain('FAKE_URL_PASS_aaaaaaaa');
+      expect(out).not.toContain('relayuser');
+      expect(out).toContain('hub.example.test');
+    }
+  );
+
+  it('redacts Authorization headers if a node-link RPC error path echoes request headers', () => {
+    const raw =
+      "[node-link-rpc] sessions.create failed: upstream rejected Authorization: Bearer tok_FAKE_aaaaaaaa";
+    const out = redactText(raw).value;
+    expect(out).not.toContain('tok_FAKE_aaaaaaaa');
+    expect(out).toContain('sessions.create failed');
+  });
+
+  it('redacts pair tokens echoed in routed-PTY bootstrap diagnostics (#588)', () => {
+    const raw =
+      "[node-link-pty] pty attach failed (stream-1): node connect failed for --pair-token pair_FAKE_PAIR_aaaaaaaa";
+    const out = redactBootstrapSecrets(raw);
+    expect(out).not.toContain('pair_FAKE_PAIR_aaaaaaaa');
+    expect(out).toContain('pty attach failed');
+  });
+
+  it('redacts node credential token shapes echoed in credential.rotate errors', () => {
+    const raw =
+      "[node-link-rpc] credential.rotate failed: persistence rejected node_FAKE_NODE_aaaa.secret_FAKE_TOKEN_bbbb";
+    const out = redactBootstrapSecrets(raw);
+    expect(out).not.toContain('node_FAKE_NODE_aaaa.secret_FAKE_TOKEN_bbbb');
+    expect(out).not.toContain('secret_FAKE_TOKEN_bbbb');
+    expect(out).toContain('credential.rotate failed');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-on to #504 / PR #513 that fixed a non-Bearer Authorization leak in the diagnostics bundle redactor. Per #598:

- Adds one fixture per `DIAGNOSTICS_REDACTION_RULES` entry (8 rules) and per `redactBootstrapSecrets` shape (5 shapes) — 13 fixtures total in `test/fixtures/redaction/`. Every fixture uses clearly-fake placeholder secrets.
- Adds `test/shared/redaction-coverage.test.ts` which:
  - runs each fixture through its declared redactor and asserts the secret disappears + surrounding context survives
  - for bundle fixtures, asserts the named rule actually fires in `counts` (catches silent fallthrough where one rule masks another)
  - **manifest <-> rule consistency gate**: fails loudly if a `DIAGNOSTICS_REDACTION_RULES` entry has no fixture, or a fixture references a removed rule
- Adds routed-PTY / node-link regression tests (#587 / #588) for the specific log line shapes emitted by `node-link-client`, `node-link-rpc-host`, and `node-link-pty-host` on error paths

Tests + fixtures only. No production code changes.

## Real leak found and filed

While writing this I caught one real redaction gap: the diag bundle `url-credential` regex only matches `https?://user:pass@host`, but `node-link-client.ts:411` logs `connected to wss://...` link URLs that carry the same embedded creds. Filed as #604. The test for that case uses `it.fails` so:
- the gap stays visible in test output (1 expected fail)
- the marker has to be retired when #604 lands, which can't be silently skipped

## Test plan

- [x] `npx vitest run test/shared/redaction-coverage.test.ts` → 22 pass, 1 expected fail
- [x] `npx vitest run test/diagnostics-bundle.test.ts test/bootstrap-diagnostics.test.ts test/shared/redaction-coverage.test.ts` → 32 pass + 1 expected fail
- [x] `npm run check` → 0 errors (existing warnings unchanged, none in new file)
- [x] `npm run build && npm test` → 224 files, 2403 pass + 1 expected fail
- [ ] Adding a new rule to `DIAGNOSTICS_REDACTION_RULES` without a fixture fails the gate (verify by removing one fixture and re-running)

## Refs

- Closes #598
- Related: #504, PR #513, #587, #588
- Filed during this work: #604 (ws:// URL credential leak in node-link-client log lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)