### PR TITLE
feat(cli-gateway): add non-destructive events.subscribe verb (#596)

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -36,9 +36,11 @@ import { parseCliNodeLogLineCount } from '../server/node-logs.js';
 import { createDiagnosticsBundle } from '../server/diagnostics-bundle.js';
 import { writeNodeCredentialFile } from './node-credential-file.js';
 import {
+  EVENTS_SUBSCRIBE_TOPICS,
   RELAY_CLI_GATEWAY_CONTRACT,
   gatewayError,
   gatewayOk,
+  type EventsSubscribeTopic,
   type RelayCliGatewayCommand,
   type RelayCliGatewayEnvelope,
   type RelayCliGatewayErrorCode,
@@ -386,7 +388,7 @@ function requireGatewaySessionId(
 
 function gatewayUsage(): never {
   logger.error(
-    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions renew|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read) --json'
+    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions renew|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|events subscribe) --json'
   );
   process.exit(1);
 }
@@ -1153,6 +1155,252 @@ async function runGatewayFiles(gatewayArgs: string[]): Promise<never> {
   printGatewayEnvelope(gatewayOk(commandName, result), 0);
 }
 
+function parseEventsSubscribeTopic(value: string | undefined): EventsSubscribeTopic {
+  if (!value || !EVENTS_SUBSCRIBE_TOPICS.includes(value as EventsSubscribeTopic)) {
+    printGatewayEnvelope(
+      gatewayError('events.subscribe', {
+        code: 'INVALID_ARGUMENT',
+        message: `--topic must be one of: ${EVENTS_SUBSCRIBE_TOPICS.join(', ')}`,
+        retryable: false,
+        details: {
+          field: 'topic',
+          ...(value !== undefined ? { value } : {}),
+          allowed: [...EVENTS_SUBSCRIBE_TOPICS],
+        },
+      }),
+      1
+    );
+  }
+  return value as EventsSubscribeTopic;
+}
+
+async function runGatewayEventsSubscribe(eventsArgs: string[]): Promise<never> {
+  const topic = parseEventsSubscribeTopic(gatewayArg(eventsArgs, '--topic'));
+  const maxEvents = gatewayOptionalPositiveInt(
+    'events.subscribe',
+    eventsArgs,
+    '--max-events',
+    10000
+  );
+  const idleTimeoutMs = gatewayOptionalPositiveInt(
+    'events.subscribe',
+    eventsArgs,
+    '--idle-timeout-ms',
+    300000
+  );
+
+  const token = gatewayRequiredToken('events.subscribe');
+  const port = gatewayWsPort();
+  const url = `http://127.0.0.1:${port}/events?topic=${encodeURIComponent(topic)}`;
+
+  // Use fetch with an AbortController; stream the body as NDJSON.
+  const controller = new AbortController();
+  const onSignal = (): void => {
+    controller.abort();
+  };
+  process.once('SIGINT', onSignal);
+  process.once('SIGTERM', onSignal);
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'x-relay-cli-gateway': 'v1',
+        'x-relay-capabilities': 'session:read',
+        Accept: 'application/x-ndjson',
+      },
+      signal: controller.signal,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    printGatewayEnvelope(
+      gatewayError('events.subscribe', {
+        code: 'SERVER_UNAVAILABLE',
+        message: `could not connect to Relay hub on port ${port}: ${message}`,
+        retryable: true,
+        details: { topic },
+      }),
+      1
+    );
+  }
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    let body: unknown;
+    try {
+      body = text ? JSON.parse(text) : {};
+    } catch {
+      body = { raw: text };
+    }
+    const upstream =
+      typeof body === 'object' && body !== null ? (body as Record<string, unknown>) : undefined;
+    printGatewayEnvelope(
+      gatewayError('events.subscribe', {
+        code: normalizeGatewayErrorCode(res.status, upstream),
+        message: gatewayErrorMessage(res.status, upstream),
+        retryable: gatewayErrorRetryable(res.status, upstream),
+        details: { ...sanitizedGatewayErrorDetails(res.status, upstream), topic },
+      }),
+      1
+    );
+  }
+
+  const body = res.body;
+  if (!body) {
+    printGatewayEnvelope(
+      gatewayError('events.subscribe', {
+        code: 'UPSTREAM_ERROR',
+        message: 'hub /events response had no body stream',
+        retryable: true,
+        details: { topic },
+      }),
+      1
+    );
+  }
+
+  let frames = 0;
+  let dataFrames = 0;
+  let sequence = 0;
+  let buffer = '';
+  let idleTimer: NodeJS.Timeout | undefined;
+  let settled = false;
+
+  const finalizeOk = (reason: string, closeCode = 1000): void => {
+    if (settled) return;
+    settled = true;
+    if (idleTimer) clearTimeout(idleTimer);
+    process.removeListener('SIGINT', onSignal);
+    process.removeListener('SIGTERM', onSignal);
+    writeGatewayNdjson(
+      gatewayOk('events.subscribe', {
+        event: 'closed',
+        topic,
+        sequence: sequence++,
+        frames,
+        closeCode,
+        reason,
+      })
+    );
+  };
+
+  const refreshIdleTimer = (): void => {
+    if (!idleTimeoutMs) return;
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      try {
+        controller.abort();
+      } catch {
+        /* aborting */
+      }
+      finalizeOk('idle timeout', 1000);
+      process.exit(0);
+    }, idleTimeoutMs);
+    idleTimer.unref?.();
+  };
+  refreshIdleTimer();
+
+  const emitFrame = (line: string): boolean => {
+    if (!line) return true;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      // Ignore malformed lines; hub-side bug would be visible in its own logs.
+      return true;
+    }
+    if (!parsed || typeof parsed !== 'object') return true;
+    const frame = parsed as Record<string, unknown>;
+    const eventType =
+      typeof frame['event'] === 'string' ? (frame['event'] as string) : 'event';
+    const frameTopic =
+      typeof frame['topic'] === 'string' ? (frame['topic'] as string) : topic;
+    const occurredAt =
+      typeof frame['occurredAt'] === 'string' ? (frame['occurredAt'] as string) : undefined;
+    const payload =
+      frame['payload'] && typeof frame['payload'] === 'object'
+        ? (frame['payload'] as Record<string, unknown>)
+        : undefined;
+
+    const envelope: Record<string, unknown> = {
+      event: eventType,
+      topic: frameTopic,
+      sequence: sequence++,
+      ...(occurredAt ? { occurredAt } : {}),
+      ...(payload ? { payload } : {}),
+    };
+
+    const ok = writeGatewayNdjson(gatewayOk('events.subscribe', envelope));
+    refreshIdleTimer();
+    if (!ok) {
+      try {
+        controller.abort();
+      } catch {
+        /* aborting */
+      }
+      finalizeOk('stdout backpressure', 1013);
+      process.exit(0);
+    }
+    if (eventType === 'event') {
+      frames += 1;
+      dataFrames += 1;
+      if (maxEvents !== undefined && dataFrames >= maxEvents) {
+        try {
+          controller.abort();
+        } catch {
+          /* aborting */
+        }
+        finalizeOk('maxEvents reached', 1000);
+        process.exit(0);
+      }
+    }
+    return true;
+  };
+
+  try {
+    const reader = (body as ReadableStream<Uint8Array>).getReader();
+    const decoder = new TextDecoder('utf-8');
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let newlineIdx = buffer.indexOf('\n');
+      while (newlineIdx >= 0) {
+        const line = buffer.slice(0, newlineIdx).trim();
+        buffer = buffer.slice(newlineIdx + 1);
+        emitFrame(line);
+        newlineIdx = buffer.indexOf('\n');
+      }
+    }
+    if (buffer.trim().length > 0) emitFrame(buffer.trim());
+    finalizeOk('hub closed stream', 1000);
+    process.exit(0);
+  } catch (error) {
+    if (controller.signal.aborted) {
+      finalizeOk('aborted', 1000);
+      process.exit(0);
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    printGatewayEnvelope(
+      gatewayError('events.subscribe', {
+        code: 'UPSTREAM_ERROR',
+        message: `events stream error: ${message}`,
+        retryable: true,
+        details: { topic, frames },
+      }),
+      1
+    );
+  }
+}
+
+async function runGatewayEvents(gatewayArgs: string[]): Promise<never> {
+  const subcommand = gatewayArgs[1];
+  if (subcommand === 'subscribe') return runGatewayEventsSubscribe(gatewayArgs.slice(2));
+  gatewayInvalid('events.subscribe', 'unknown events command', { args: gatewayArgs });
+}
+
 async function runGatewayV1(): Promise<never> {
   const gatewayArgs = args.slice(1);
   const json = gatewayArgs.includes('--json');
@@ -1174,6 +1422,7 @@ async function runGatewayV1(): Promise<never> {
   if (top === 'nodes') return runGatewayNodes(gatewayArgs);
   if (top === 'sessions') return runGatewaySessions(gatewayArgs);
   if (top === 'files') return runGatewayFiles(gatewayArgs);
+  if (top === 'events') return runGatewayEvents(gatewayArgs);
   gatewayInvalid('contract.list', 'unknown v1 gateway command', { args: gatewayArgs });
 }
 

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -1203,12 +1203,17 @@ async function runGatewayEventsSubscribe(eventsArgs: string[]): Promise<never> {
 
   let res: Response;
   try {
+    // `audit` topic requires `tab:intervention:read` in addition to
+    // `session:read` (enforced by the hub router). Other topics only need
+    // `session:read`.
+    const capabilities =
+      topic === 'audit' ? 'session:read,tab:intervention:read' : 'session:read';
     res = await fetch(url, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${token}`,
         'x-relay-cli-gateway': 'v1',
-        'x-relay-capabilities': 'session:read',
+        'x-relay-capabilities': capabilities,
         Accept: 'application/x-ndjson',
       },
       signal: controller.signal,
@@ -1374,6 +1379,9 @@ async function runGatewayEventsSubscribe(eventsArgs: string[]): Promise<never> {
         newlineIdx = buffer.indexOf('\n');
       }
     }
+    // Flush any remaining bytes the streaming decoder is holding so a
+    // trailing partial multi-byte char doesn't get dropped.
+    buffer += decoder.decode();
     if (buffer.trim().length > 0) emitFrame(buffer.trim());
     finalizeOk('hub closed stream', 1000);
     process.exit(0);

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -17,6 +17,7 @@ relay-ide v1 sessions input --id <session-id-or-global-id> --data 'echo ok\n' --
 relay-ide v1 files list --session-id <session-id> --path <path> --json
 relay-ide v1 files stat --session-id <session-id> --path <path> --json
 relay-ide v1 files read --session-id <session-id> --path <path> --max-bytes 32768 --max-lines 2000 --json
+relay-ide v1 events subscribe --topic <sessions|nodes|audit> --json
 ```
 
 This contract is for external brain-as-peer adapters (#430). It is intentionally separate from the internal `/hub/node-link` WebSocket protocol. Adapter packages must generate native tool/function definitions from `relay-ide v1 schema --json` or the committed source manifest in `shared/cli-gateway-contract.ts`; do not hand-code Hermes/Claude/Codex-specific schemas.
@@ -252,6 +253,42 @@ The Codex-facing smoke in `shared/cli-gateway-codex-tools.ts` derives the same c
 
 These smoke runners are deliberately thin: generated definitions select stable v1 CLI commands, Relay's existing CLI gateway does the hub/node/File RPC/PTY work, and `sessions.detach` remains descriptor-only so it does not kill the underlying session. Production Claude/Codex/Hermes packages, Codex runtime packaging, event subscriptions beyond PTY output, multi-session orchestration, File RPC write/delete/tail, arbitrary exec, stdin-backed adapter streaming, and private node-link shortcuts remain deferred.
 
+## Events subscription
+
+`relay-ide v1 events subscribe --topic <topic> --json` opens a long-lived authenticated NDJSON stream from the hub and emits one gateway envelope per event frame on stdout. Per ADR-017 and #596, this is intentionally narrow: read-only, capability-gated, no writes, no execs, no raw byte streams, no log tailing (that lives under #476).
+
+Topics:
+
+- `sessions` — session lifecycle (`session.started`, `session.ended`) and `tab.mode-changed` envelopes scoped to the current hub.
+- `nodes` — `node.online`, `node.offline`, `node.revoked` envelopes from the hub node registry (#586/`hub-node-registry`).
+- `audit` — redacted summaries of `tab.mode-changed` and `tab.intervention` envelopes (hash-chained at storage time per #470/#499). Raw intervention payloads, raw keylogs, and full terminal transcripts are never streamed through this gateway.
+
+Each frame is a `events.subscribe` success envelope whose `data` carries:
+
+```json
+{
+  "event": "open" | "event" | "closed",
+  "topic": "sessions" | "nodes" | "audit",
+  "sequence": 0,
+  "occurredAt": "2026-05-19T00:00:00.000Z",
+  "payload": { "type": "session.started", "sessionId": "..." }
+}
+```
+
+The first envelope is always `event: "open"`. The final envelope is always `event: "closed"` with a `frames` count and a `reason`. Caps stay conservative:
+
+- `--max-events N` detaches after N event frames (excluding `open`/`closed`).
+- `--idle-timeout-ms N` detaches after N ms without an event frame.
+- If stdout backpressure is observed, the CLI aborts the upstream stream and emits `closed` with `reason: "stdout backpressure"`.
+
+Capability gating fails closed: `sessions` and `nodes` require `session:read`; `audit` additionally requires `tab:intervention:read`. Unknown topics surface as `INVALID_ARGUMENT` with `details.field: "topic"` before the CLI opens any hub request. Missing or denied capabilities surface as `FORBIDDEN` envelopes. The hub side enforces the same gate; the CLI side enforces the same allowlist. This is the only `events.*` verb in v1 — no `events.publish`, no `events.replay`, no event-bus write surface.
+
+Smoke form:
+
+```bash
+relay-ide v1 events subscribe --topic sessions --max-events 1 --json
+```
+
 ## Deferred work
 
-Event subscription beyond PTY output, multi-session fan-out, File RPC write/delete/tail, destructive operations, and adapter packages are follow-up work. If a future adapter needs a missing primitive, extend this CLI contract first; do not bypass it with `/hub/node-link` or browser WebSocket protocol clients.
+Event subscription beyond `events.subscribe` (multi-topic fan-out, cursor/resume, replay), multi-session fan-out, File RPC write/delete/tail, destructive operations, and adapter packages are follow-up work. If a future adapter needs a missing primitive, extend this CLI contract first; do not bypass it with `/hub/node-link` or browser WebSocket protocol clients.

--- a/server/cli-gateway-events.ts
+++ b/server/cli-gateway-events.ts
@@ -1,0 +1,280 @@
+import type express from 'express';
+import type { Request, Response, RequestHandler } from 'express';
+import {
+  EVENTS_SUBSCRIBE_TOPICS,
+  type EventsSubscribeTopic,
+} from '../shared/cli-gateway-contract.js';
+import type { TabControlEvent } from '../shared/control-state.js';
+import type { HubNodeStatusEvent } from './hub-node-registry.js';
+
+const ALLOWED_TOPICS: readonly EventsSubscribeTopic[] = EVENTS_SUBSCRIBE_TOPICS;
+
+function isAllowedTopic(value: string | undefined): value is EventsSubscribeTopic {
+  return typeof value === 'string' && (ALLOWED_TOPICS as readonly string[]).includes(value);
+}
+
+function parseCapabilityHeader(value: string | undefined): Set<string> {
+  if (!value) return new Set();
+  return new Set(
+    value
+      .split(/[\s,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  );
+}
+
+const REQUIRED_TOPIC_CAPABILITIES: Record<EventsSubscribeTopic, readonly string[]> = {
+  sessions: ['session:read'],
+  nodes: ['session:read'],
+  audit: ['session:read', 'tab:intervention:read'],
+};
+
+export interface CliGatewayEventsHooks {
+  /** Subscribe to session lifecycle (create/end). Return an unsubscribe fn. */
+  onSessionCreate: (
+    cb: (sessionId: string, cwd: string, branchName?: string) => void
+  ) => () => void;
+  onSessionEnd: (
+    cb: (sessionId: string, cwd: string, branchName?: string) => void
+  ) => () => void;
+  /** Subscribe to control-mode and intervention envelopes. Return an unsubscribe fn. */
+  onControlEvent: (cb: (event: TabControlEvent) => void) => () => void;
+  /** Subscribe to hub-managed node link status transitions. Return an unsubscribe fn. */
+  onNodeStatus: (cb: (event: HubNodeStatusEvent) => void) => () => void;
+}
+
+export interface CliGatewayEventsRouterOptions {
+  cliGatewayAuth: RequestHandler;
+  hooks: CliGatewayEventsHooks;
+  /** Optional now() override for deterministic tests. */
+  now?: () => Date;
+}
+
+interface SubscriberHandle {
+  res: Response;
+  topic: EventsSubscribeTopic;
+  unsubscribe: () => void;
+}
+
+function writeNdjson(res: Response, frame: Record<string, unknown>): boolean {
+  return res.write(`${JSON.stringify(frame)}\n`);
+}
+
+/**
+ * Redacted event envelope for the `audit` topic. We surface ids, types, timing,
+ * and actor identity but never raw intervention payloads or raw bytes.
+ * Hash-chained audit storage lives in #470/#499; the streaming surface here is
+ * a non-destructive read view, not a hash-chain replay channel.
+ */
+function redactedAuditPayload(event: TabControlEvent): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    type: event.type,
+    eventId: event.eventId,
+    sessionId: event.identity.sessionId,
+    nodeId: event.identity.nodeId,
+    actor: { kind: event.actor.kind, ...(event.actor.id ? { id: event.actor.id } : {}) },
+  };
+  if (event.type === 'tab.mode-changed') {
+    base['previousControlMode'] = event.previousControlMode;
+    base['controlMode'] = event.controlMode;
+  } else {
+    base['controlMode'] = event.controlMode;
+    base['interventionKind'] = event.intervention.kind;
+    base['source'] = event.intervention.source;
+    // Bounded redaction metadata only; never raw payload bytes.
+    base['redaction'] = {
+      redacted: event.intervention.redaction.redacted,
+      byteCount: event.intervention.redaction.byteCount,
+      charCount: event.intervention.redaction.charCount,
+      lineCount: event.intervention.redaction.lineCount,
+      classes: event.intervention.redaction.classes,
+    };
+  }
+  return base;
+}
+
+function sessionsPayload(
+  kind: 'session.started' | 'session.ended' | 'tab.mode-changed' | 'tab.intervention',
+  data: Record<string, unknown>
+): Record<string, unknown> {
+  return { type: kind, ...data };
+}
+
+function nodePayload(event: HubNodeStatusEvent): Record<string, unknown> {
+  return {
+    type: `node.${event.status}`,
+    nodeId: event.nodeId,
+    status: event.status,
+    lastSeenAt: event.lastSeenAt,
+  };
+}
+
+export function createCliGatewayEventsRouter(
+  expressInstance: typeof express,
+  options: CliGatewayEventsRouterOptions
+): express.Router {
+  const router = expressInstance.Router();
+  const now = options.now ?? (() => new Date());
+
+  router.get('/events', options.cliGatewayAuth, (req: Request, res: Response) => {
+    if (req.header('x-relay-cli-gateway') !== 'v1') {
+      // Reserved for v1 gateway clients; browsers use the WebSocket bus.
+      res.status(400).json({
+        error: {
+          code: 'INVALID_ARGUMENT',
+          message: 'events stream requires x-relay-cli-gateway: v1',
+          retryable: false,
+        },
+      });
+      return;
+    }
+
+    const topicParam = typeof req.query['topic'] === 'string' ? req.query['topic'] : undefined;
+    if (!isAllowedTopic(topicParam)) {
+      res.status(400).json({
+        error: {
+          code: 'INVALID_ARGUMENT',
+          message: `unknown topic; allowed: ${ALLOWED_TOPICS.join(', ')}`,
+          retryable: false,
+          details: {
+            field: 'topic',
+            ...(topicParam !== undefined ? { value: topicParam } : {}),
+            allowed: [...ALLOWED_TOPICS],
+          },
+        },
+      });
+      return;
+    }
+    const topic: EventsSubscribeTopic = topicParam;
+
+    const capabilities = parseCapabilityHeader(req.header('x-relay-capabilities'));
+    const required = REQUIRED_TOPIC_CAPABILITIES[topic];
+    const missing = required.filter((cap) => !capabilities.has(cap));
+    if (missing.length > 0) {
+      res.status(403).json({
+        error: {
+          code: 'FORBIDDEN',
+          message: `missing required capability: ${missing.join(', ')}`,
+          retryable: false,
+          details: { capability: missing[0], topic },
+        },
+      });
+      return;
+    }
+
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/x-ndjson; charset=utf-8');
+    res.setHeader('cache-control', 'no-store');
+    res.setHeader('x-accel-buffering', 'no');
+    res.flushHeaders?.();
+
+    let sequence = 0;
+    writeNdjson(res, {
+      event: 'open',
+      topic,
+      sequence: sequence++,
+      occurredAt: now().toISOString(),
+    });
+
+    const emit = (payload: Record<string, unknown>): void => {
+      const ok = writeNdjson(res, {
+        event: 'event',
+        topic,
+        sequence: sequence++,
+        occurredAt: now().toISOString(),
+        payload,
+      });
+      if (!ok) {
+        // Backpressure — drop subscriber.
+        try {
+          handle.unsubscribe();
+        } catch {
+          /* unsubscribing */
+        }
+        try {
+          res.end();
+        } catch {
+          /* ending */
+        }
+      }
+    };
+
+    const subs: Array<() => void> = [];
+    if (topic === 'sessions') {
+      subs.push(
+        options.hooks.onSessionCreate((sessionId, cwd, branchName) => {
+          emit(
+            sessionsPayload('session.started', {
+              sessionId,
+              cwd,
+              ...(branchName ? { branchName } : {}),
+            })
+          );
+        })
+      );
+      subs.push(
+        options.hooks.onSessionEnd((sessionId, cwd, branchName) => {
+          emit(
+            sessionsPayload('session.ended', {
+              sessionId,
+              cwd,
+              ...(branchName ? { branchName } : {}),
+            })
+          );
+        })
+      );
+      subs.push(
+        options.hooks.onControlEvent((event) => {
+          if (event.type === 'tab.mode-changed') {
+            emit(
+              sessionsPayload('tab.mode-changed', {
+                sessionId: event.identity.sessionId,
+                nodeId: event.identity.nodeId,
+                previousControlMode: event.previousControlMode,
+                controlMode: event.controlMode,
+              })
+            );
+          }
+        })
+      );
+    } else if (topic === 'nodes') {
+      subs.push(
+        options.hooks.onNodeStatus((event) => {
+          emit(nodePayload(event));
+        })
+      );
+    } else if (topic === 'audit') {
+      subs.push(
+        options.hooks.onControlEvent((event) => {
+          emit(redactedAuditPayload(event));
+        })
+      );
+    }
+
+    const handle: SubscriberHandle = {
+      res,
+      topic,
+      unsubscribe: () => {
+        while (subs.length) {
+          const fn = subs.pop();
+          try {
+            fn?.();
+          } catch {
+            /* swallow individual listener cleanup errors */
+          }
+        }
+      },
+    };
+
+    req.on('close', () => {
+      handle.unsubscribe();
+      try {
+        res.end();
+      } catch {
+        /* already ended */
+      }
+    });
+  });
+
+  return router;
+}

--- a/server/cli-gateway-events.ts
+++ b/server/cli-gateway-events.ts
@@ -176,6 +176,22 @@ export function createCliGatewayEventsRouter(
       occurredAt: now().toISOString(),
     });
 
+    // Subscriber bookkeeping is declared before `emit` so the backpressure
+    // path doesn't depend on the `handle` binding (which is initialized
+    // further down). A hook that fires synchronously on registration would
+    // otherwise hit a TDZ ReferenceError.
+    const subs: Array<() => void> = [];
+    const unsubscribeAll = (): void => {
+      while (subs.length) {
+        const fn = subs.pop();
+        try {
+          fn?.();
+        } catch {
+          /* swallow individual listener cleanup errors */
+        }
+      }
+    };
+
     const emit = (payload: Record<string, unknown>): void => {
       const ok = writeNdjson(res, {
         event: 'event',
@@ -187,7 +203,7 @@ export function createCliGatewayEventsRouter(
       if (!ok) {
         // Backpressure — drop subscriber.
         try {
-          handle.unsubscribe();
+          unsubscribeAll();
         } catch {
           /* unsubscribing */
         }
@@ -199,7 +215,6 @@ export function createCliGatewayEventsRouter(
       }
     };
 
-    const subs: Array<() => void> = [];
     if (topic === 'sessions') {
       subs.push(
         options.hooks.onSessionCreate((sessionId, cwd, branchName) => {
@@ -254,16 +269,7 @@ export function createCliGatewayEventsRouter(
     const handle: SubscriberHandle = {
       res,
       topic,
-      unsubscribe: () => {
-        while (subs.length) {
-          const fn = subs.pop();
-          try {
-            fn?.();
-          } catch {
-            /* swallow individual listener cleanup errors */
-          }
-        }
-      },
+      unsubscribe: unsubscribeAll,
     };
 
     req.on('close', () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -117,6 +117,7 @@ import {
   type CredentialRotationScheduler,
 } from './credential-rotation-scheduler.js';
 import { createHubNodeRouter } from './hub-node-router.js';
+import { createCliGatewayEventsRouter } from './cli-gateway-events.js';
 import { createConfirmationChallengeStore } from './confirmation-challenges.js';
 import { createHubNodeLinkManager } from './hub-node-link.js';
 import {
@@ -1379,6 +1380,17 @@ async function main(): Promise<void> {
       confirmations: confirmationChallenges,
       sessionEnvelopes: sessionEnvelopeRegistry,
       ...(securityAuditLog ? { auditSink: securityAuditLog } : {}),
+    })
+  );
+  app.use(
+    createCliGatewayEventsRouter(express, {
+      cliGatewayAuth: requireCliGatewayAuth,
+      hooks: {
+        onSessionCreate: (cb) => sessions.onSessionCreate(cb),
+        onSessionEnd: (cb) => sessions.onSessionEnd(cb),
+        onControlEvent: (cb) => sessions.onControlEvent(cb),
+        onNodeStatus: (cb) => hubNodeRegistry.onNodeStatus(cb),
+      },
     })
   );
 

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -239,8 +239,12 @@ const stateChangeCallbacks: StateChangeCallback[] = [];
 type ControlEventCallback = (event: TabControlEvent) => void;
 const controlEventCallbacks: ControlEventCallback[] = [];
 
-function onControlEvent(cb: ControlEventCallback): void {
+function onControlEvent(cb: ControlEventCallback): () => void {
   controlEventCallbacks.push(cb);
+  return () => {
+    const idx = controlEventCallbacks.indexOf(cb);
+    if (idx >= 0) controlEventCallbacks.splice(idx, 1);
+  };
 }
 
 function fireControlEvent(event: TabControlEvent): void {
@@ -295,8 +299,12 @@ type SessionCreateCallback = (
 ) => void;
 const sessionCreateCallbacks: SessionCreateCallback[] = [];
 
-function onSessionCreate(cb: SessionCreateCallback): void {
+function onSessionCreate(cb: SessionCreateCallback): () => void {
   sessionCreateCallbacks.push(cb);
+  return () => {
+    const idx = sessionCreateCallbacks.indexOf(cb);
+    if (idx >= 0) sessionCreateCallbacks.splice(idx, 1);
+  };
 }
 
 function fireSessionCreate(
@@ -320,8 +328,12 @@ type SessionEndCallback = (
 ) => void;
 const sessionEndCallbacks: SessionEndCallback[] = [];
 
-function onSessionEnd(cb: SessionEndCallback): void {
+function onSessionEnd(cb: SessionEndCallback): () => void {
   sessionEndCallbacks.push(cb);
+  return () => {
+    const idx = sessionEndCallbacks.indexOf(cb);
+    if (idx >= 0) sessionEndCallbacks.splice(idx, 1);
+  };
 }
 
 function fireSessionEnd(

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -1092,7 +1092,12 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
-    capabilityHints: ['session:read'],
+    // Union of capabilities across all topics: `sessions` and `nodes` need
+    // `session:read`; `audit` additionally needs `tab:intervention:read`
+    // (enforced by the hub router on the `audit` topic). Generators that
+    // surface this verb should request the superset so a single tool
+    // definition covers every topic.
+    capabilityHints: ['session:read', 'tab:intervention:read'],
     inputSchema: eventsSubscribeInputSchema,
     outputSchema: okOutput('EventsSubscribeFrame', eventsSubscribeFrameSchema),
     errorCodes: [

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -21,7 +21,8 @@ export type RelayCliGatewayCommand =
   | 'sessions.handBack'
   | 'files.list'
   | 'files.stat'
-  | 'files.read';
+  | 'files.read'
+  | 'events.subscribe';
 
 export type RelayCliGatewayErrorCode =
   | 'UNAUTHORIZED'
@@ -593,6 +594,53 @@ const gatewayErrorSchema: RelayJsonSchema = {
   required: ['ok', 'contract', 'contractVersion', 'command', 'error'],
 };
 
+export const EVENTS_SUBSCRIBE_TOPICS = ['sessions', 'nodes', 'audit'] as const;
+export type EventsSubscribeTopic = (typeof EVENTS_SUBSCRIBE_TOPICS)[number];
+
+const eventsSubscribeInputSchema: RelayJsonSchema = {
+  title: 'EventsSubscribeInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    topic: {
+      type: 'string',
+      enum: EVENTS_SUBSCRIBE_TOPICS,
+      description:
+        'Non-destructive event topic to subscribe to: sessions lifecycle/control, node link status, or redacted audit envelopes.',
+    },
+    maxEvents: {
+      type: 'number',
+      minimum: 1,
+      maximum: 10000,
+      description: 'Detach after N event frames (excluding open/closed envelopes).',
+    },
+    idleTimeoutMs: {
+      type: 'number',
+      minimum: 1,
+      maximum: 300000,
+      description: 'Detach after this many ms without an event frame.',
+    },
+  },
+  required: ['topic'],
+};
+
+const eventsSubscribeFrameSchema: RelayJsonSchema = {
+  title: 'EventsSubscribeFrame',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    event: { type: 'string', enum: ['open', 'event', 'closed'] },
+    topic: { type: 'string', enum: EVENTS_SUBSCRIBE_TOPICS },
+    sequence: { type: 'number', minimum: 0 },
+    occurredAt: { type: 'string', format: 'date-time' },
+    payload: { type: 'object', additionalProperties: true },
+    frames: { type: 'number', minimum: 0 },
+    closeCode: { type: 'number' },
+    reason: { type: 'string' },
+  },
+  required: ['event', 'topic', 'sequence'],
+};
+
 const okOutput = (title: string, data: RelayJsonSchema): RelayJsonSchema => ({
   title,
   type: 'object',
@@ -1025,6 +1073,34 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       'NODE_OFFLINE',
       'SERVER_UNAVAILABLE',
       'CONFIRMATION_REQUIRED',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'events.subscribe',
+    cli: [
+      'relay-ide',
+      'v1',
+      'events',
+      'subscribe',
+      '--topic',
+      '<topic>',
+      '--json',
+    ],
+    summary:
+      'Subscribe to a non-destructive hub event topic and emit newline-delimited gateway envelopes. Read-only.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read'],
+    inputSchema: eventsSubscribeInputSchema,
+    outputSchema: okOutput('EventsSubscribeFrame', eventsSubscribeFrameSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'FORBIDDEN',
+      'NOT_FOUND',
+      'SERVER_UNAVAILABLE',
       'UPSTREAM_ERROR',
     ],
   },

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -76,6 +76,7 @@ describe('CLI gateway contract', () => {
       'files.list',
       'files.stat',
       'files.read',
+      'events.subscribe',
     ]);
 
     for (const spec of RELAY_CLI_GATEWAY_CONTRACT.commandSchemas) {
@@ -248,6 +249,7 @@ describe('CLI gateway contract', () => {
       'files.list',
       'files.stat',
       'files.read',
+      'events.subscribe',
     ] as const;
 
     for (const command of invalidArgumentCommands) {

--- a/test/cli-gateway/events.test.ts
+++ b/test/cli-gateway/events.test.ts
@@ -1,0 +1,452 @@
+import { spawn } from 'node:child_process';
+import * as http from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  RELAY_CLI_GATEWAY_CONTRACT,
+  commandSpec,
+  stableCommandNames,
+  type RelayCliGatewayCommand,
+  type RelayCliGatewayEnvelope,
+} from '../../shared/cli-gateway-contract.js';
+
+const RELAY_BIN = 'dist/bin/relay-ide.js';
+const ALLOWED_TOPICS = ['sessions', 'nodes', 'audit'] as const;
+
+type CapturedRequest = {
+  method: string | undefined;
+  url: string | undefined;
+  authorization: string | undefined;
+  marker: string | string[] | undefined;
+  capabilities: string | string[] | undefined;
+};
+
+interface FakeHub {
+  port: number;
+  captured: CapturedRequest[];
+  close: () => Promise<void>;
+  /** Resolves when at least one /events stream is open and ready to push. */
+  whenSubscribed: () => Promise<http.ServerResponse>;
+  /** Active subscriber response, if any. */
+  activeStream: () => http.ServerResponse | undefined;
+}
+
+interface FakeHubOptions {
+  /** Capability decision: 'allow' (default), 'deny', or 'reject-topic'. */
+  policy?: 'allow' | 'deny' | 'reject-topic';
+}
+
+function ndjsonWrite(res: http.ServerResponse, envelope: unknown): void {
+  res.write(`${JSON.stringify(envelope)}\n`);
+}
+
+async function startFakeHub(options: FakeHubOptions = {}): Promise<FakeHub> {
+  const captured: CapturedRequest[] = [];
+  let activeRes: http.ServerResponse | undefined;
+  let resolveSubscribed: ((res: http.ServerResponse) => void) | undefined;
+  const subscribed = new Promise<http.ServerResponse>((resolve) => {
+    resolveSubscribed = resolve;
+  });
+
+  const server = http.createServer((req, res) => {
+    captured.push({
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.authorization,
+      marker: req.headers['x-relay-cli-gateway'],
+      capabilities: req.headers['x-relay-capabilities'],
+    });
+
+    if (req.method !== 'GET' || !req.url?.startsWith('/events')) {
+      res.statusCode = 404;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ error: { code: 'NOT_FOUND', message: 'not found' } }));
+      return;
+    }
+
+    const url = new URL(req.url, 'http://127.0.0.1');
+    const topic = url.searchParams.get('topic');
+    if (!topic || !ALLOWED_TOPICS.includes(topic as (typeof ALLOWED_TOPICS)[number])) {
+      res.statusCode = 400;
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          error: { code: 'INVALID_ARGUMENT', message: 'unknown topic' },
+        })
+      );
+      return;
+    }
+
+    if (options.policy === 'deny') {
+      res.statusCode = 403;
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          error: {
+            code: 'FORBIDDEN',
+            message: 'missing required capability: session:read',
+            details: { capability: 'session:read' },
+          },
+        })
+      );
+      return;
+    }
+
+    if (options.policy === 'reject-topic') {
+      res.statusCode = 400;
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          error: {
+            code: 'INVALID_ARGUMENT',
+            message: `unsupported topic: ${topic}`,
+            details: { field: 'topic', value: topic },
+          },
+        })
+      );
+      return;
+    }
+
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/x-ndjson; charset=utf-8');
+    res.setHeader('cache-control', 'no-store');
+    activeRes = res;
+    req.on('close', () => {
+      if (activeRes === res) activeRes = undefined;
+    });
+    resolveSubscribed?.(res);
+    resolveSubscribed = undefined;
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as AddressInfo).port;
+
+  return {
+    port,
+    captured,
+    activeStream: () => activeRes,
+    whenSubscribed: () => subscribed,
+    close: async () => {
+      if (activeRes) {
+        try {
+          activeRes.end();
+        } catch {
+          /* already closed */
+        }
+      }
+      server.closeAllConnections?.();
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+
+interface CliResult {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  envelopes: RelayCliGatewayEnvelope[];
+  stderr: string;
+}
+
+function parseEnvelopesFromStdout(buffer: string): RelayCliGatewayEnvelope[] {
+  const envelopes: RelayCliGatewayEnvelope[] = [];
+  const trimmed = buffer.trim();
+  if (trimmed.length === 0) return envelopes;
+
+  // Try line-by-line NDJSON first (used by streaming verbs).
+  let parsedAnyLine = false;
+  for (const line of trimmed.split(/\r?\n/)) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      envelopes.push(JSON.parse(t) as RelayCliGatewayEnvelope);
+      parsedAnyLine = true;
+    } catch {
+      parsedAnyLine = false;
+      break;
+    }
+  }
+  if (parsedAnyLine) return envelopes;
+
+  // Fall back to pretty-printed JSON (used by printGatewayEnvelope error/oneshot).
+  envelopes.length = 0;
+  try {
+    envelopes.push(JSON.parse(trimmed) as RelayCliGatewayEnvelope);
+  } catch {
+    /* malformed — leave empty so the test surfaces it */
+  }
+  return envelopes;
+}
+
+async function runCli(
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  options: { killAfterEnvelopes?: number; timeoutMs?: number } = {}
+): Promise<CliResult> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [RELAY_BIN, ...args], {
+      env: { ...process.env, ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const streamingEnvelopes: RelayCliGatewayEnvelope[] = [];
+    let stdoutBuf = '';
+    let stderrBuf = '';
+    let killed = false;
+    let leftover = '';
+
+    const killTimer = setTimeout(() => {
+      killed = true;
+      child.kill('SIGTERM');
+    }, options.timeoutMs ?? 5000);
+
+    const handleLine = (line: string): void => {
+      if (line.length === 0) return;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        return;
+      }
+      if (
+        !parsed ||
+        typeof parsed !== 'object' ||
+        Array.isArray(parsed) ||
+        !('ok' in (parsed as Record<string, unknown>)) ||
+        !('contract' in (parsed as Record<string, unknown>))
+      ) {
+        return;
+      }
+      streamingEnvelopes.push(parsed as RelayCliGatewayEnvelope);
+      if (
+        options.killAfterEnvelopes !== undefined &&
+        streamingEnvelopes.length >= options.killAfterEnvelopes &&
+        !killed
+      ) {
+        killed = true;
+        child.kill('SIGINT');
+      }
+    };
+    child.stdout?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf8');
+      stdoutBuf += text;
+      leftover += text;
+      let newlineIdx = leftover.indexOf('\n');
+      while (newlineIdx >= 0) {
+        const line = leftover.slice(0, newlineIdx).trim();
+        leftover = leftover.slice(newlineIdx + 1);
+        handleLine(line);
+        newlineIdx = leftover.indexOf('\n');
+      }
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderrBuf += chunk.toString('utf8');
+    });
+    child.on('error', (err) => {
+      clearTimeout(killTimer);
+      reject(err);
+    });
+    child.on('close', (exitCode, signal) => {
+      clearTimeout(killTimer);
+      const envelopes =
+        streamingEnvelopes.length > 0
+          ? streamingEnvelopes
+          : parseEnvelopesFromStdout(stdoutBuf);
+      resolve({ exitCode, signal, envelopes, stderr: stderrBuf });
+    });
+  });
+}
+
+describe('CLI gateway events.subscribe contract', () => {
+  it('advertises events.subscribe in the stable command manifest', () => {
+    expect(stableCommandNames()).toContain('events.subscribe');
+  });
+
+  it('declares non-destructive, capability-gated, NDJSON streaming behavior', () => {
+    const spec = commandSpec('events.subscribe' as RelayCliGatewayCommand);
+    expect(spec.stable).toBe(true);
+    expect(spec.requiresAuth).toBe(true);
+    expect(spec.cli).toContain('subscribe');
+    expect(spec.cli).toContain('--topic');
+    expect(spec.cli).toContain('--json');
+    expect(spec.capabilityHints).toContain('session:read');
+    expect(spec.transport).toBe('hub-http');
+
+    // No destructive ops in the verb's argument surface.
+    expect(JSON.stringify(spec.inputSchema)).not.toContain('exec');
+    expect(JSON.stringify(spec.inputSchema)).not.toContain('write');
+    expect(JSON.stringify(spec.inputSchema)).not.toContain('delete');
+
+    const inputProps = spec.inputSchema.properties ?? {};
+    expect(inputProps['topic']).toBeDefined();
+    expect(inputProps['topic']?.enum).toEqual(expect.arrayContaining(['sessions', 'nodes', 'audit']));
+
+    expect(spec.errorCodes).toEqual(
+      expect.arrayContaining(['UNAUTHORIZED', 'INVALID_ARGUMENT', 'FORBIDDEN'])
+    );
+  });
+
+  it('validates the streaming output envelope shape', () => {
+    const spec = commandSpec('events.subscribe' as RelayCliGatewayCommand);
+    const outputData = spec.outputSchema.properties?.data;
+    expect(outputData).toBeDefined();
+    const dataProps = outputData?.properties ?? {};
+    expect(dataProps['event']).toBeDefined();
+    expect(dataProps['event']?.enum).toEqual(
+      expect.arrayContaining(['open', 'event', 'closed'])
+    );
+    expect(dataProps['topic']).toBeDefined();
+    expect(dataProps['topic']?.enum).toEqual(
+      expect.arrayContaining(['sessions', 'nodes', 'audit'])
+    );
+    expect(dataProps['sequence']).toBeDefined();
+  });
+
+  it('does not register additional destructive verbs on the manifest', () => {
+    // events.subscribe is the only new verb in this slice. No siblings.
+    const eventsCommands = RELAY_CLI_GATEWAY_CONTRACT.commandSchemas.filter((spec) =>
+      spec.name.startsWith('events.')
+    );
+    expect(eventsCommands.map((s) => s.name)).toEqual(['events.subscribe']);
+  });
+});
+
+describe('CLI gateway events.subscribe runtime', () => {
+  let hub: FakeHub | undefined;
+  afterEach(async () => {
+    if (hub) {
+      await hub.close();
+      hub = undefined;
+    }
+  });
+
+  it('streams NDJSON envelopes from the hub for an allowed topic', async () => {
+    hub = await startFakeHub();
+    const port = hub.port;
+
+    const runPromise = runCli(
+      ['v1', 'events', 'subscribe', '--topic', 'sessions', '--max-events', '2', '--json'],
+      {
+        RELAY_IDE_PORT: String(port),
+        RELAY_IDE_BROWSER_TOKEN: 'scoped-token',
+      },
+      { timeoutMs: 5000 }
+    );
+
+    const streamRes = await hub.whenSubscribed();
+    ndjsonWrite(streamRes, { event: 'open', topic: 'sessions', sequence: 0 });
+    ndjsonWrite(streamRes, {
+      event: 'event',
+      topic: 'sessions',
+      sequence: 1,
+      occurredAt: '2026-05-19T00:00:00.000Z',
+      payload: { type: 'session.started', sessionId: 's1' },
+    });
+    ndjsonWrite(streamRes, {
+      event: 'event',
+      topic: 'sessions',
+      sequence: 2,
+      occurredAt: '2026-05-19T00:00:00.100Z',
+      payload: { type: 'session.ended', sessionId: 's1' },
+    });
+
+    const result = await runPromise;
+    expect(result.exitCode).toBe(0);
+    // CLI should emit at least: open frame, 2 event frames, closed frame.
+    const events = result.envelopes.filter(
+      (e) => e.ok === true && e.command === 'events.subscribe'
+    );
+    expect(events.length).toBeGreaterThanOrEqual(3);
+    const openFrame = events.find((e) => (e.ok && (e.data as { event: string }).event) === 'open');
+    expect(openFrame).toBeDefined();
+    const dataFrames = events.filter(
+      (e) => e.ok && (e.data as { event: string }).event === 'event'
+    );
+    expect(dataFrames).toHaveLength(2);
+    const closed = events.find((e) => e.ok && (e.data as { event: string }).event === 'closed');
+    expect(closed).toBeDefined();
+
+    const captured = hub.captured.find((entry) => entry.url?.startsWith('/events'));
+    expect(captured?.authorization).toBe('Bearer scoped-token');
+    expect(captured?.marker).toBe('v1');
+    expect(captured?.capabilities).toContain('session:read');
+    expect(captured?.url).toContain('topic=sessions');
+  });
+
+  it('reports a typed FORBIDDEN error when the hub denies the capability', async () => {
+    hub = await startFakeHub({ policy: 'deny' });
+
+    const result = await runCli(
+      ['v1', 'events', 'subscribe', '--topic', 'sessions', '--json'],
+      {
+        RELAY_IDE_PORT: String(hub.port),
+        RELAY_IDE_BROWSER_TOKEN: 'scoped-token',
+      },
+      { timeoutMs: 5000 }
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    const errorEnvelope = result.envelopes.find((e) => e.ok === false);
+    expect(errorEnvelope).toBeDefined();
+    if (!errorEnvelope || errorEnvelope.ok) throw new Error('expected error envelope');
+    expect(errorEnvelope.command).toBe('events.subscribe');
+    expect(errorEnvelope.error.code).toBe('FORBIDDEN');
+  });
+
+  it('rejects unknown topics locally before opening any hub request', async () => {
+    const result = await runCli(
+      ['v1', 'events', 'subscribe', '--topic', 'pty-bytes', '--json'],
+      {
+        // Use a definitely-unused port; the CLI must fail fast before connecting.
+        RELAY_IDE_PORT: '1',
+        RELAY_IDE_BROWSER_TOKEN: 'scoped-token',
+      },
+      { timeoutMs: 5000 }
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    const errorEnvelope = result.envelopes.find((e) => e.ok === false);
+    if (!errorEnvelope) {
+      throw new Error(
+        `expected error envelope; envelopes=${JSON.stringify(result.envelopes)} stderr=${result.stderr}`
+      );
+    }
+    if (errorEnvelope.ok) throw new Error('expected error envelope');
+    expect(errorEnvelope.command).toBe('events.subscribe');
+    expect(errorEnvelope.error.code).toBe('INVALID_ARGUMENT');
+    const details = errorEnvelope.error.details ?? {};
+    expect(details).toMatchObject({ field: 'topic' });
+  });
+
+  it('closes the stream cleanly when the hub ends the connection', async () => {
+    hub = await startFakeHub();
+
+    const runPromise = runCli(
+      ['v1', 'events', 'subscribe', '--topic', 'nodes', '--json'],
+      {
+        RELAY_IDE_PORT: String(hub.port),
+        RELAY_IDE_BROWSER_TOKEN: 'scoped-token',
+      },
+      { timeoutMs: 5000 }
+    );
+
+    const res = await hub.whenSubscribed();
+    ndjsonWrite(res, { event: 'open', topic: 'nodes', sequence: 0 });
+    ndjsonWrite(res, {
+      event: 'event',
+      topic: 'nodes',
+      sequence: 1,
+      occurredAt: '2026-05-19T00:00:00.000Z',
+      payload: { type: 'node.online', nodeId: 'node-a' },
+    });
+    // Hub closes the stream after one event.
+    res.end();
+
+    const result = await runPromise;
+    expect(result.exitCode).toBe(0);
+    const closed = result.envelopes.find(
+      (e) => e.ok && (e.data as { event: string }).event === 'closed'
+    );
+    expect(closed).toBeDefined();
+  });
+});

--- a/test/cli-gateway/events.test.ts
+++ b/test/cli-gateway/events.test.ts
@@ -449,4 +449,59 @@ describe('CLI gateway events.subscribe runtime', () => {
     );
     expect(closed).toBeDefined();
   });
+
+  it('subscribes to the audit topic with the union of required capabilities', async () => {
+    // PR #608 / Copilot+Gemini regression guard: the `audit` topic needs both
+    // `session:read` and `tab:intervention:read` on the hub side. The CLI
+    // must send both so the hub doesn't return FORBIDDEN, and the redacted
+    // audit payload shape must round-trip cleanly through the gateway envelope.
+    hub = await startFakeHub();
+
+    const runPromise = runCli(
+      ['v1', 'events', 'subscribe', '--topic', 'audit', '--max-events', '1', '--json'],
+      {
+        RELAY_IDE_PORT: String(hub.port),
+        RELAY_IDE_BROWSER_TOKEN: 'scoped-token',
+      },
+      { timeoutMs: 5000 }
+    );
+
+    const streamRes = await hub.whenSubscribed();
+    ndjsonWrite(streamRes, { event: 'open', topic: 'audit', sequence: 0 });
+    ndjsonWrite(streamRes, {
+      event: 'event',
+      topic: 'audit',
+      sequence: 1,
+      occurredAt: '2026-05-19T00:00:00.000Z',
+      payload: {
+        type: 'audit.event',
+        kind: 'tab.mode-changed',
+        sessionId: 's1',
+        // Redaction envelope: raw control bytes are never forwarded.
+        redacted: true,
+      },
+    });
+
+    const result = await runPromise;
+    expect(result.exitCode).toBe(0);
+
+    const captured = hub.captured.find((entry) => entry.url?.startsWith('/events'));
+    expect(captured?.url).toContain('topic=audit');
+    expect(captured?.capabilities).toContain('session:read');
+    expect(captured?.capabilities).toContain('tab:intervention:read');
+
+    const events = result.envelopes.filter(
+      (e) => e.ok === true && e.command === 'events.subscribe'
+    );
+    const dataFrames = events.filter(
+      (e) => e.ok && (e.data as { event: string }).event === 'event'
+    );
+    expect(dataFrames).toHaveLength(1);
+    const frame = dataFrames[0];
+    if (!frame || !frame.ok) throw new Error('expected ok frame');
+    const data = frame.data as { topic: string; payload: { redacted?: boolean; kind?: string } };
+    expect(data.topic).toBe('audit');
+    expect(data.payload.kind).toBe('tab.mode-changed');
+    expect(data.payload.redacted).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Implements #596 — the next narrow step in the #429 CLI gateway epic. Adds `relay-ide v1 events subscribe --topic <sessions|nodes|audit> --json` as a capability-gated, read-only NDJSON event stream. No writes, no execs, no raw byte streams, no log tailing.

- Topics:
  - `sessions` — `session.started` / `session.ended` / `tab.mode-changed`
  - `nodes` — `node.online` / `node.offline` / `node.revoked` from the hub node registry
  - `audit` — redacted `tab.mode-changed` / `tab.intervention` summaries (raw payloads never leave)
- Schema added to `shared/cli-gateway-contract.ts`; `events.subscribe` advertised in `stableCommandNames()`.
- New `server/cli-gateway-events.ts` route mounted on the hub; reuses `requireCliGatewayAuth` + `x-relay-capabilities` boundary.
- `sessions.onSessionCreate` / `onSessionEnd` / `onControlEvent` now return an unsubscribe fn (additive; void-discard callers unaffected).
- `docs/CLI_GATEWAY.md` updated with new verb, envelope shape, caps, and deferred-work pointer (cursor/resume, replay, multi-topic fan-out remain follow-ups).

Per ADR-017 §"Minimum CLI JSON schema changes" item 8, this is the explicit, versioned form of the events channel — adapters must not scrape `/hub/node-link`.

## Test plan

- [x] `npm run check` — 0 errors (pre-existing sonarjs warnings only)
- [x] `npm test` — 2389 pass (one pre-existing flake in `workspace-divergence-api` symlink cleanup; passes in isolation)
- [x] New `test/cli-gateway/events.test.ts` covers:
  - schema shape (`stableCommandNames`, capability hints, non-destructive arg surface, NDJSON envelope shape)
  - end-to-end NDJSON streaming via fake-hub fixture
  - typed `FORBIDDEN` envelope when the hub denies the capability
  - unknown topic rejected with `INVALID_ARGUMENT` before any hub request
  - clean close when hub ends the stream
- [x] Manual smoke: `RELAY_IDE_PORT=1 RELAY_IDE_BROWSER_TOKEN=t relay-ide v1 events subscribe --topic pty-bytes --json` returns `INVALID_ARGUMENT` with `details.field: "topic"` (no hub contact).

Refs #596, #429, ADR-017, #470/#499 (audit hash chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)