### PR TITLE
feat(#591): node-first onboarding + first-class non-git Projects

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -757,7 +757,7 @@ function TerminalAreaContent({
         <>
           {activeRepoPath &&
             activeSession?.repoPath === activeRepoPath &&
-            activeWorkspace?.kind !== 'directory' && (
+            activeWorkspace?.kind === 'repo' && (
             <PrTopBar
               workspacePath={activeRepoPath}
               utilityRailWorkspacePath={utilityRailStateKey}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -705,14 +705,14 @@ function TerminalAreaContent({
 
       {viewMode === 'empty' && (
         <EmptyState
-          heading="add a repo to get started"
+          heading="add a project to get started"
           description="point to any folder on your machine. git repos get pr tracking and branch management."
-          actionLabel="+ add repo"
+          actionLabel="+ add project"
           onAction={onAddWorkspace}
           hint={
             onboardingHints.showNoReposHint ? (
               <Hint id={HINT_NO_REPOS} variant="inline-text">
-                relay-ide manages claude code sessions across your repos.
+                relay-ide manages agents and terminals across your projects.
               </Hint>
             ) : undefined
           }
@@ -755,7 +755,9 @@ function TerminalAreaContent({
 
       {viewMode === 'session' && (
         <>
-          {activeRepoPath && activeSession?.repoPath === activeRepoPath && (
+          {activeRepoPath &&
+            activeSession?.repoPath === activeRepoPath &&
+            activeWorkspace?.kind !== 'directory' && (
             <PrTopBar
               workspacePath={activeRepoPath}
               utilityRailWorkspacePath={utilityRailStateKey}

--- a/frontend/src/components/ActiveWorkSurface.tsx
+++ b/frontend/src/components/ActiveWorkSurface.tsx
@@ -9,6 +9,7 @@ import {
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
 import type {
+  Repo,
   WorkContextActiveGroup,
   WorkContextSessionSummary,
 } from '../lib/types.js';
@@ -139,12 +140,34 @@ function latestStatus(group: WorkContextActiveGroup): string {
     : 'session has no work context yet';
 }
 
-function repoBindingLabel(
+export function repoKind(
+  session: WorkContextSessionSummary,
+  repos: Repo[]
+): 'repo' | 'directory' | null {
+  if (!session.repoPath) return null;
+  const match = repos.find((r) => r.path === session.repoPath);
+  if (!match) return null;
+  return match.kind ?? (match.isGitRepo ? 'repo' : 'directory');
+}
+
+export function repoBindingLabel(
   group: WorkContextActiveGroup,
-  session: WorkContextSessionSummary
+  session: WorkContextSessionSummary,
+  repos: Repo[]
 ): string | null {
-  const repo = session.repoName ?? group.context?.anchors?.repo?.ownerRepo;
+  const kind = repoKind(session, repos);
   const repoPath = session.repoPath ?? group.context?.anchors?.repo?.localPath;
+
+  if (kind === 'directory') {
+    const nodeLabel =
+      session.nodeId && session.nodeId !== DEFAULT_LOCAL_NODE_ID
+        ? session.nodeId
+        : 'local';
+    const cwd = session.cwd || repoPath || '';
+    return `${nodeLabel} · ${cwd} · directory`;
+  }
+
+  const repo = session.repoName ?? group.context?.anchors?.repo?.ownerRepo;
   if (!repo && !repoPath) return null;
   const branch = session.branchName ?? group.context?.anchors?.repo?.branchName;
   return [repo ?? repoPath, branch].filter(Boolean).join(' · ');
@@ -152,7 +175,8 @@ function repoBindingLabel(
 
 function sessionMeta(
   group: WorkContextActiveGroup,
-  session: WorkContextSessionSummary
+  session: WorkContextSessionSummary,
+  repos: Repo[]
 ): string[] {
   const meta = [
     session.tabKind,
@@ -163,9 +187,16 @@ function sessionMeta(
       ? `control ${session.controlFreshness}`
       : undefined,
   ].filter(Boolean) as string[];
-  const repo = repoBindingLabel(group, session);
-  if (repo) meta.push(`repo ${repo}`);
-  else meta.push('no repo binding');
+  const kind = repoKind(session, repos);
+  const binding = repoBindingLabel(group, session, repos);
+  if (kind === 'directory') {
+    // directory-kind: hide git-only meta (branch, PR chips handled at card level)
+    if (binding) meta.push(binding);
+  } else if (binding) {
+    meta.push(`repo ${binding}`);
+  } else {
+    meta.push('no repo binding');
+  }
   return meta;
 }
 
@@ -174,6 +205,7 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
   const refreshAll = useSessionsStore((s) => s.refreshAll);
   const setActiveSessionId = useSessionsStore((s) => s.setActiveSessionId);
   const setActiveRepoPath = useUiStore((s) => s.setActiveRepoPath);
+  const repos = useSessionsStore((s) => s.repos);
   const [inputValue, setInputValue] = useState('');
   const [inputStatus, setInputStatus] = useState<string | null>(null);
   const [isSubmittingInput, setIsSubmittingInput] = useState(false);
@@ -292,7 +324,19 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
           <div>
             <span className="active-work-label">anchor</span>
             <span>
-              {group.node.kind ?? 'remote'} · {primarySession?.cwd ?? 'no cwd'}
+              {(() => {
+                const nodeLabel = group.node.displayName ?? group.node.nodeId;
+                const cwd = primarySession?.cwd ?? 'no cwd';
+                if (primarySession) {
+                  const kind = repoKind(primarySession, repos);
+                  if (kind === 'directory') {
+                    return `${nodeLabel} · ${cwd} · directory`;
+                  }
+                  const repoLabel = repoBindingLabel(group, primarySession, repos);
+                  if (repoLabel) return `repo ${repoLabel}`;
+                }
+                return `${group.node.kind ?? 'remote'} · ${cwd}`;
+              })()}
             </span>
           </div>
           <div>
@@ -338,7 +382,7 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
               </div>
               <div className="active-work-session__cwd">{session.cwd}</div>
               <div className="active-work-session__meta">
-                {sessionMeta(group, session).map((item) => (
+                {sessionMeta(group, session, repos).map((item) => (
                   <span key={item}>{item}</span>
                 ))}
               </div>

--- a/frontend/src/components/PrTopBar.tsx
+++ b/frontend/src/components/PrTopBar.tsx
@@ -5,7 +5,9 @@ import {
   fetchCiStatusOrNull,
   fetchCurrentBranch,
   renameBranch,
+  HttpError,
 } from '../lib/api.js';
+import { createLogger } from '../lib/logger.js';
 import { sendPtyData } from '../lib/ws.js';
 import {
   derivePrAction,
@@ -28,6 +30,8 @@ import { formatRelativeTime } from '../lib/utils.js';
 import RenameWarningModal from './dialogs/RenameWarningModal.js';
 import Tooltip from './Tooltip.js';
 import './PrTopBar.css';
+
+const logger = createLogger('pr-top-bar');
 
 export interface PrTopBarProps {
   workspacePath: string;
@@ -601,9 +605,17 @@ export function PrTopBar({
   }, [branchName]);
   useEffect(() => {
     if (!branchName && workspacePath) {
-      void fetchCurrentBranch(workspacePath).then((b) => {
-        if (b) setCurrentBranch(b);
-      });
+      void fetchCurrentBranch(workspacePath)
+        .then((b) => {
+          if (b) setCurrentBranch(b);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof HttpError && err.code === 'NOT_GIT') {
+            // expected for non-git workspaces — silently ignore
+            return;
+          }
+          logger.warn('fetchCurrentBranch failed', err);
+        });
     }
   }, [branchName, workspacePath]);
 

--- a/frontend/src/components/RepoDashboard.css
+++ b/frontend/src/components/RepoDashboard.css
@@ -178,6 +178,14 @@
   flex-shrink: 0;
 }
 
+.non-git-error {
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--status-error);
+  margin: 4px 0 0 0;
+  padding: 0;
+}
+
 .skeleton {
   pointer-events: none;
 }

--- a/frontend/src/components/RepoDashboard.tsx
+++ b/frontend/src/components/RepoDashboard.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { fetchDashboard, createSession } from '../lib/api.js';
+import { fetchDashboard } from '../lib/api.js';
+import { createAgentSession } from '../lib/session-utils.js';
 import { sortPrs } from '../lib/pr-utils.js';
 import type {
   PullRequest,
@@ -369,6 +370,8 @@ export function RepoDashboard({
   const [searchQuery, setSearchQuery] = useState('');
   const [activeTab, setActiveTab] = useState<ActiveTab>('overview');
   const [startWorkIssue, setStartWorkIssue] = useState<AnyIssue | null>(null);
+  const [creatingTerminal, setCreatingTerminal] = useState(false);
+  const [terminalError, setTerminalError] = useState<string | null>(null);
   const sortBy = 'age';
   const sortDir: 'asc' | 'desc' = 'desc';
   const { ref: prScrollRef, hasOverflow: prHasOverflow } = useScrollOverflow();
@@ -404,17 +407,32 @@ export function RepoDashboard({
           <div className="cta-row">
             <TuiButton
               variant="primary"
+              disabled={creatingTerminal}
               onClick={() => {
-                void createSession({
+                setTerminalError(null);
+                setCreatingTerminal(true);
+                void createAgentSession({
                   type: 'terminal',
                   repoPath,
                   cwd: repoPath,
+                }).then(({ session, error }) => {
+                  setCreatingTerminal(false);
+                  if (error && !session) {
+                    setTerminalError(
+                      error instanceof Error ? error.message : 'failed to open terminal'
+                    );
+                  } else if (session) {
+                    onSessionCreated?.(session.id);
+                  }
                 });
               }}
             >
-              + open terminal
+              {creatingTerminal ? 'opening...' : '+ open terminal'}
             </TuiButton>
           </div>
+          {terminalError && (
+            <p className="non-git-error">{terminalError}</p>
+          )}
         </div>
       ) : (
         <>

--- a/frontend/src/components/RepoDashboard.tsx
+++ b/frontend/src/components/RepoDashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { fetchDashboard } from '../lib/api.js';
+import { fetchDashboard, createSession } from '../lib/api.js';
 import { sortPrs } from '../lib/pr-utils.js';
 import type {
   PullRequest,
@@ -400,7 +400,21 @@ export function RepoDashboard({
       {hint && <div className="repo-dashboard__hint">{hint}</div>}
       {data && !data.isGitRepo ? (
         <div className="non-git-notice">
-          <span className="non-git-msg">Not a git repository</span>
+          <span className="non-git-msg">not a git repository</span>
+          <div className="cta-row">
+            <TuiButton
+              variant="primary"
+              onClick={() => {
+                void createSession({
+                  type: 'terminal',
+                  repoPath,
+                  cwd: repoPath,
+                });
+              }}
+            >
+              + open terminal
+            </TuiButton>
+          </div>
         </div>
       ) : (
         <>

--- a/frontend/src/components/RepoItem.css
+++ b/frontend/src/components/RepoItem.css
@@ -421,6 +421,19 @@
   color: var(--accent);
 }
 
+.repo-kind-chip {
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  padding: 1px 4px;
+  flex-shrink: 0;
+  line-height: 1.2;
+}
+
 .repo-divider {
   height: 1px;
   background: var(--border);

--- a/frontend/src/components/RepoItem.tsx
+++ b/frontend/src/components/RepoItem.tsx
@@ -614,6 +614,9 @@ export function RepoItem({
           <span className="repo-name">
             <MarqueeText>{repo.name}</MarqueeText>
           </span>
+          {repo.kind === 'directory' || (!repo.isGitRepo && repo.kind == null) ? (
+            <span className="repo-kind-chip">dir</span>
+          ) : null}
           {highestState && attentionCount > 0 ? (
             <span className="repo-attention-badge">
               <SessionIndicator state={highestState} />
@@ -647,7 +650,10 @@ export function RepoItem({
             const rep = sorted[0];
             const isRepoRoot = groupPath === repo.path;
             if (rep) {
-              const matchedPr = findPr(groupSessions[0]?.branchName ?? '');
+              const isDirectory = repo.kind === 'directory' || repo.isGitRepo === false;
+              const matchedPr = isDirectory
+                ? undefined
+                : findPr(groupSessions[0]?.branchName ?? '');
               const isSelected =
                 activeSessionId !== null &&
                 groupSessions.some((s) => sessionKeyMatches(s, activeSessionId));
@@ -775,7 +781,7 @@ export function RepoItem({
           })}
         </ul>
       ) : null}
-      {!collapsed ? (
+      {!collapsed && repo.isGitRepo !== false ? (
         <div
           className={['add-worktree-row', creatingWorktree && 'disabled']
             .filter(Boolean)

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -588,7 +588,7 @@ export function Sidebar({
               )}
               {repos.length === 0 && (
                 <div className="sidebar-empty-state">
-                  <span>no repos</span>
+                  <span>no projects yet</span>
                 </div>
               )}
               {workspaceGroups.length === 0 &&
@@ -606,7 +606,7 @@ export function Sidebar({
               onClick={onAddWorkspace}
               style={{ flex: 1 }}
             >
-              + add repo
+              + add project
             </TuiButton>
             <button
               className={['sidebar-settings-icon-btn', analyticsView !== null && 'active']

--- a/frontend/src/components/TerminalNodePicker.tsx
+++ b/frontend/src/components/TerminalNodePicker.tsx
@@ -12,6 +12,7 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchHubNodes } from '../lib/api.js';
 import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
 import type { HubNodeSummary } from '../../../shared/relay-node-protocol.js';
+import { nodeShellBlockReason } from './dialogs/CustomizeSessionDialog.js';
 import './TerminalNodePicker.css';
 
 export interface TerminalNodePickerProps {
@@ -44,25 +45,13 @@ export interface NodeChoice {
 }
 
 /**
- * Mirrors the hub-side preconditions documented in `docs/federated-relay.md`
- * §Session Routing: a node must be online, version-matched to the hub, and
- * advertise tmux capability. Anything else gets surfaced as a disabled
- * choice with the failing precondition as the tooltip reason — the user
- * never gets to click and then hit a typed error.
- *
- * #467 note: nodes advertising `sessionResume: 'none'` ship a working
- * raw-shell attachment backend, but the hub's `sessions.create`
- * preconditions still require tmux. The picker enforces the same
- * gate (`no tmux`) so users don't get a typed error after clicking.
- * Phase 2 will loosen this once non-resumable nodes have a routing
- * story.
+ * Determines whether a node can accept terminal sessions.
+ * Delegates to nodeShellBlockReason from CustomizeSessionDialog — shell + tmux
+ * availability is the sole gate. Agent availability is NOT checked here
+ * because this picker is terminal-only.
  */
-function nodeBlockReason(node: HubNodeSummary): string | null {
-  if (node.status !== 'online') return node.status;
-  if (node.version.state === 'incompatible') return 'protocol incompatible';
-  if (node.version.state === 'version-skew') return 'version skew';
-  if (node.capabilities.core.tmux !== 'available') return 'no tmux';
-  return null;
+function nodeBlockReasonForTerminal(node: HubNodeSummary): string | null {
+  return nodeShellBlockReason(node);
 }
 
 function isResumable(node: HubNodeSummary): boolean {
@@ -85,7 +74,7 @@ export function buildChoices(nodes: HubNodeSummary[]): NodeChoice[] {
     },
   ];
   for (const node of nodes) {
-    const reason = nodeBlockReason(node);
+    const reason = nodeBlockReasonForTerminal(node);
     choices.push({
       nodeId: node.nodeId,
       label: node.displayName || node.nodeId,

--- a/frontend/src/components/dialogs/AddWorkspaceDialog.css
+++ b/frontend/src/components/dialogs/AddWorkspaceDialog.css
@@ -75,6 +75,21 @@
   margin: 0;
 }
 
+.add-workspace-partial-errors {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.add-workspace-partial-errors-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
 .add-workspace-save-row {
   display: flex;
   align-items: center;

--- a/frontend/src/components/dialogs/AddWorkspaceDialog.css
+++ b/frontend/src/components/dialogs/AddWorkspaceDialog.css
@@ -36,3 +36,56 @@
   font-family: var(--font-mono, monospace);
   margin: 0;
 }
+
+.add-workspace-dialog-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.add-workspace-dialog-label {
+  font-size: var(--font-size-sm, 0.85rem);
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+}
+
+.add-workspace-dialog-select,
+.add-workspace-dialog-input {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--text);
+  font-size: var(--font-size-base);
+  font-family: var(--font-mono);
+  padding: 8px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.add-workspace-dialog-select:disabled,
+.add-workspace-dialog-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.add-workspace-dialog-note {
+  font-size: var(--font-size-xs, 0.75rem);
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+  margin: 0;
+}
+
+.add-workspace-save-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.add-workspace-checkbox {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.add-workspace-save-label {
+  cursor: help;
+}

--- a/frontend/src/components/dialogs/AddWorkspaceDialog.tsx
+++ b/frontend/src/components/dialogs/AddWorkspaceDialog.tsx
@@ -5,6 +5,7 @@ import React, {
   useState,
 } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { createLogger } from '../../lib/logger.js';
 import DialogShell, { type DialogShellHandle } from './DialogShell.js';
 import TuiButton from '../TuiButton.js';
 import FileBrowser, { type FileBrowserHandle } from '../FileBrowser.js';
@@ -37,6 +38,8 @@ interface Props {
 
 const LOCAL_NODE_VALUE = DEFAULT_LOCAL_NODE_ID;
 
+const logger = createLogger('add-workspace-dialog');
+
 const AddWorkspaceDialog = forwardRef<AddWorkspaceDialogHandle, Props>(
   function AddWorkspaceDialog({ onWorkspacesAdded, onClose }, ref) {
     const shellRef = useRef<DialogShellHandle>(null);
@@ -48,6 +51,8 @@ const AddWorkspaceDialog = forwardRef<AddWorkspaceDialogHandle, Props>(
     const [nodes, setNodes] = useState<HubNodeSummary[]>([]);
     const [selectedNodeId, setSelectedNodeId] = useState<string>(LOCAL_NODE_VALUE);
     const [remoteCwd, setRemoteCwd] = useState('');
+    const [fetchNodesError, setFetchNodesError] = useState<string | null>(null);
+    const [partialErrors, setPartialErrors] = useState<{ path: string; error: string }[]>([]);
 
     const isRemote = selectedNodeId !== LOCAL_NODE_VALUE;
     const selectedRemoteNode = isRemote
@@ -62,12 +67,21 @@ const AddWorkspaceDialog = forwardRef<AddWorkspaceDialogHandle, Props>(
         setSubmitting(false);
         setSelectedNodeId(LOCAL_NODE_VALUE);
         setRemoteCwd('');
+        setFetchNodesError(null);
+        setPartialErrors([]);
         fileBrowserRef.current?.reset();
         // Fetch nodes for the host picker
-        void fetchHubNodes().then((result) => {
-          queryClient.setQueryData(['hub-nodes'], result);
-          setNodes(result);
-        });
+        void fetchHubNodes()
+          .then((result) => {
+            queryClient.setQueryData(['hub-nodes'], result);
+            setNodes(result);
+          })
+          .catch((err: unknown) => {
+            logger.warn('fetchHubNodes failed', err);
+            setFetchNodesError(
+              'could not list remote hosts — only this host is available.'
+            );
+          });
         shellRef.current?.open();
       },
       close() {
@@ -88,41 +102,47 @@ const AddWorkspaceDialog = forwardRef<AddWorkspaceDialogHandle, Props>(
       }
     }
 
+    async function handleRemoteSubmit(): Promise<boolean> {
+      const cwd = cleanCwd(remoteCwd);
+      if (!cwd) {
+        setError('cwd is required for remote node sessions');
+        return false;
+      }
+      const { cols, rows } = estimateTerminalDimensions(
+        useUiStore.getState().terminalFontSize
+      );
+      const { session, error: sessionError } = await createAgentSession({
+        nodeId: selectedNodeId,
+        type: 'terminal',
+        mode: 'pty',
+        cwd,
+        sessionLane: 'remote-cwd',
+        cols,
+        rows,
+      });
+      if (sessionError && !session) {
+        setError(
+          sessionError instanceof Error
+            ? sessionError.message
+            : 'Failed to create remote terminal'
+        );
+        return false;
+      }
+      rememberRemoteCwd(selectedNodeId, cwd);
+      shellRef.current?.close();
+      return true;
+    }
+
     async function handleSubmit() {
       setSubmitting(true);
       setError('');
 
       try {
         if (isRemote) {
-          const cwd = cleanCwd(remoteCwd);
-          if (!cwd) {
-            setError('cwd is required for remote node sessions');
+          const ok = await handleRemoteSubmit();
+          if (!ok) {
             setSubmitting(false);
-            return;
           }
-          const { cols, rows } = estimateTerminalDimensions(
-            useUiStore.getState().terminalFontSize
-          );
-          const { session, error: sessionError } = await createAgentSession({
-            nodeId: selectedNodeId,
-            type: 'terminal',
-            mode: 'pty',
-            cwd,
-            sessionLane: 'remote-cwd',
-            cols,
-            rows,
-          });
-          if (sessionError && !session) {
-            setError(
-              sessionError instanceof Error
-                ? sessionError.message
-                : 'Failed to create remote terminal'
-            );
-            setSubmitting(false);
-            return;
-          }
-          rememberRemoteCwd(selectedNodeId, cwd);
-          shellRef.current?.close();
         } else {
           if (selectedPaths.length === 0) {
             setSubmitting(false);
@@ -138,14 +158,31 @@ const AddWorkspaceDialog = forwardRef<AddWorkspaceDialogHandle, Props>(
             return;
           }
 
+          if (result.errors.length > 0 && result.added.length > 0) {
+            // partial success — notify about added paths but keep dialog open
+            // so the user can see and dismiss the failures
+            onWorkspacesAdded(result.added.map((a) => a.path));
+            setPartialErrors(result.errors);
+            setSubmitting(false);
+            return;
+          }
+
           if (result.added.length > 0) {
             onWorkspacesAdded(result.added.map((a) => a.path));
           }
 
           shellRef.current?.close();
         }
-      } catch {
-        setError(isRemote ? 'Failed to create remote terminal.' : 'Failed to add workspaces.');
+      } catch (err) {
+        logger.error(
+          isRemote ? 'failed to create remote terminal' : 'failed to add workspaces',
+          err
+        );
+        setError(
+          isRemote
+            ? `failed to create remote terminal: ${err instanceof Error ? err.message : String(err)}`
+            : `failed to add workspaces: ${err instanceof Error ? err.message : String(err)}`
+        );
       } finally {
         setSubmitting(false);
       }
@@ -212,6 +249,9 @@ const AddWorkspaceDialog = forwardRef<AddWorkspaceDialogHandle, Props>(
                 );
               })}
             </select>
+            {fetchNodesError && (
+              <p className="add-workspace-error-msg">{fetchNodesError}</p>
+            )}
           </div>
 
           {/* Block 2 — Path picker */}
@@ -269,6 +309,20 @@ const AddWorkspaceDialog = forwardRef<AddWorkspaceDialogHandle, Props>(
             </div>
           )}
 
+          {partialErrors.length > 0 && (
+            <div className="add-workspace-partial-errors">
+              <p className="add-workspace-error-msg">
+                some paths could not be added:
+              </p>
+              <ul className="add-workspace-partial-errors-list">
+                {partialErrors.map((e) => (
+                  <li key={e.path} className="add-workspace-error-msg">
+                    {e.path}: {e.error}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
           {error && <p className="add-workspace-error-msg">{error}</p>}
         </div>
       </DialogShell>

--- a/frontend/src/components/dialogs/AddWorkspaceDialog.tsx
+++ b/frontend/src/components/dialogs/AddWorkspaceDialog.tsx
@@ -4,10 +4,25 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import DialogShell, { type DialogShellHandle } from './DialogShell.js';
 import TuiButton from '../TuiButton.js';
 import FileBrowser, { type FileBrowserHandle } from '../FileBrowser.js';
-import { addWorkspacesBulk } from '../../lib/api.js';
+import {
+  addWorkspacesBulk,
+  fetchHubNodes,
+} from '../../lib/api.js';
+import { createAgentSession } from '../../lib/session-utils.js';
+import {
+  cleanCwd,
+  defaultRemoteCwd,
+  rememberRemoteCwd,
+} from '../../lib/remote-node-cwd.js';
+import { nodeShellBlockReason } from './CustomizeSessionDialog.js';
+import type { HubNodeSummary } from '../../../../shared/relay-node-protocol.js';
+import { DEFAULT_LOCAL_NODE_ID } from '../../../../shared/identity.js';
+import { estimateTerminalDimensions } from '../../lib/utils.js';
+import { useUiStore } from '../../lib/stores/ui.js';
 import './AddWorkspaceDialog.css';
 
 export interface AddWorkspaceDialogHandle {
@@ -20,20 +35,39 @@ interface Props {
   onClose?: (() => void) | undefined;
 }
 
+const LOCAL_NODE_VALUE = DEFAULT_LOCAL_NODE_ID;
+
 const AddWorkspaceDialog = forwardRef<AddWorkspaceDialogHandle, Props>(
   function AddWorkspaceDialog({ onWorkspacesAdded, onClose }, ref) {
     const shellRef = useRef<DialogShellHandle>(null);
     const fileBrowserRef = useRef<FileBrowserHandle>(null);
+    const queryClient = useQueryClient();
     const [selectedPaths, setSelectedPaths] = useState<string[]>([]);
     const [error, setError] = useState('');
     const [submitting, setSubmitting] = useState(false);
+    const [nodes, setNodes] = useState<HubNodeSummary[]>([]);
+    const [selectedNodeId, setSelectedNodeId] = useState<string>(LOCAL_NODE_VALUE);
+    const [remoteCwd, setRemoteCwd] = useState('');
+
+    const isRemote = selectedNodeId !== LOCAL_NODE_VALUE;
+    const selectedRemoteNode = isRemote
+      ? (nodes.find((n) => n.nodeId === selectedNodeId) ?? null)
+      : null;
+    const remoteHomeDir = cleanCwd(selectedRemoteNode?.homeDir);
 
     useImperativeHandle(ref, () => ({
       open() {
         setSelectedPaths([]);
         setError('');
         setSubmitting(false);
+        setSelectedNodeId(LOCAL_NODE_VALUE);
+        setRemoteCwd('');
         fileBrowserRef.current?.reset();
+        // Fetch nodes for the host picker
+        void fetchHubNodes().then((result) => {
+          queryClient.setQueryData(['hub-nodes'], result);
+          setNodes(result);
+        });
         shellRef.current?.open();
       },
       close() {
@@ -41,42 +75,88 @@ const AddWorkspaceDialog = forwardRef<AddWorkspaceDialogHandle, Props>(
       },
     }));
 
+    function handleNodeChange(nodeId: string) {
+      setSelectedNodeId(nodeId);
+      setSelectedPaths([]);
+      setError('');
+      if (nodeId !== LOCAL_NODE_VALUE) {
+        const node = nodes.find((n) => n.nodeId === nodeId) ?? null;
+        const home = cleanCwd(node?.homeDir);
+        setRemoteCwd(defaultRemoteCwd(home, nodeId));
+      } else {
+        setRemoteCwd('');
+      }
+    }
+
     async function handleSubmit() {
-      if (selectedPaths.length === 0) return;
       setSubmitting(true);
       setError('');
 
       try {
-        const result = await addWorkspacesBulk(selectedPaths);
-
-        if (result.errors.length > 0 && result.added.length === 0) {
-          setError(
-            result.errors.map((e) => `${e.path}: ${e.error}`).join('; ')
+        if (isRemote) {
+          const cwd = cleanCwd(remoteCwd);
+          if (!cwd) {
+            setError('cwd is required for remote node sessions');
+            setSubmitting(false);
+            return;
+          }
+          const { cols, rows } = estimateTerminalDimensions(
+            useUiStore.getState().terminalFontSize
           );
-          setSubmitting(false);
-          return;
-        }
+          const { session, error: sessionError } = await createAgentSession({
+            nodeId: selectedNodeId,
+            type: 'terminal',
+            mode: 'pty',
+            cwd,
+            sessionLane: 'remote-cwd',
+            cols,
+            rows,
+          });
+          if (sessionError && !session) {
+            setError(
+              sessionError instanceof Error
+                ? sessionError.message
+                : 'Failed to create remote terminal'
+            );
+            setSubmitting(false);
+            return;
+          }
+          rememberRemoteCwd(selectedNodeId, cwd);
+          shellRef.current?.close();
+        } else {
+          if (selectedPaths.length === 0) {
+            setSubmitting(false);
+            return;
+          }
+          const result = await addWorkspacesBulk(selectedPaths);
 
-        if (result.added.length > 0) {
-          onWorkspacesAdded(result.added.map((a) => a.path));
-        }
+          if (result.errors.length > 0 && result.added.length === 0) {
+            setError(
+              result.errors.map((e) => `${e.path}: ${e.error}`).join('; ')
+            );
+            setSubmitting(false);
+            return;
+          }
 
-        if (result.errors.length > 0) {
-          // Partial success — some workspaces failed to add
-        }
+          if (result.added.length > 0) {
+            onWorkspacesAdded(result.added.map((a) => a.path));
+          }
 
-        shellRef.current?.close();
+          shellRef.current?.close();
+        }
       } catch {
-        setError('Failed to add workspaces.');
+        setError(isRemote ? 'Failed to create remote terminal.' : 'Failed to add workspaces.');
       } finally {
         setSubmitting(false);
       }
     }
 
+    const submitDisabled = submitting || (isRemote ? !cleanCwd(remoteCwd) : selectedPaths.length === 0);
+
     const footer = (
       <div className="add-workspace-footer-row">
         <span className="add-workspace-selected-count">
-          {selectedPaths.length > 0 ? `${selectedPaths.length} selected` : ''}
+          {!isRemote && selectedPaths.length > 0 ? `${selectedPaths.length} selected` : ''}
         </span>
         <div className="add-workspace-footer-actions">
           <TuiButton variant="ghost" onClick={() => shellRef.current?.close()}>
@@ -85,11 +165,13 @@ const AddWorkspaceDialog = forwardRef<AddWorkspaceDialogHandle, Props>(
           <TuiButton
             variant="primary"
             onClick={handleSubmit}
-            disabled={selectedPaths.length === 0 || submitting}
+            disabled={submitDisabled}
           >
             {submitting
-              ? 'adding...'
-              : `add repo${selectedPaths.length > 1 ? 's' : ''}`}
+              ? isRemote ? 'connecting...' : 'adding...'
+              : isRemote
+                ? 'open terminal'
+                : `add project${selectedPaths.length > 1 ? 's' : ''}`}
           </TuiButton>
         </div>
       </div>
@@ -99,21 +181,93 @@ const AddWorkspaceDialog = forwardRef<AddWorkspaceDialogHandle, Props>(
       <DialogShell
         ref={shellRef}
         width="520px"
-        title="add repo"
+        title="add project"
         footer={footer}
         onClose={onClose}
       >
         <div className="add-workspace-body-content">
-          <p className="add-workspace-dialog-desc">
-            browse for folders on your machine. git repos get pr tracking and
-            branch management.
-          </p>
+          {/* Block 1 — Host picker */}
+          <div className="add-workspace-dialog-field">
+            <label className="add-workspace-dialog-label" htmlFor="aw-node">
+              host
+            </label>
+            <select
+              id="aw-node"
+              className="add-workspace-dialog-select"
+              value={selectedNodeId}
+              onChange={(e) => handleNodeChange(e.currentTarget.value)}
+            >
+              <option value={LOCAL_NODE_VALUE}>this host</option>
+              {nodes.map((node) => {
+                const reason = nodeShellBlockReason(node);
+                return (
+                  <option
+                    key={node.nodeId}
+                    value={node.nodeId}
+                    disabled={reason !== null}
+                  >
+                    {node.displayName || node.nodeId}
+                    {reason ? ` — ${reason}` : ''}
+                  </option>
+                );
+              })}
+            </select>
+          </div>
 
-          <FileBrowser
-            ref={fileBrowserRef}
-            selectedPaths={selectedPaths}
-            onSelectedPathsChange={setSelectedPaths}
-          />
+          {/* Block 2 — Path picker */}
+          {!isRemote && (
+            <>
+              <p className="add-workspace-dialog-desc">
+                browse for any folder on this machine. git repos get pr tracking +
+                branch management automatically.
+              </p>
+              <FileBrowser
+                ref={fileBrowserRef}
+                selectedPaths={selectedPaths}
+                onSelectedPathsChange={setSelectedPaths}
+              />
+            </>
+          )}
+          {isRemote && (
+            <div className="add-workspace-dialog-field">
+              <label className="add-workspace-dialog-label" htmlFor="aw-remote-cwd">
+                cwd on {selectedRemoteNode?.displayName ?? selectedNodeId}
+              </label>
+              <input
+                id="aw-remote-cwd"
+                type="text"
+                className="add-workspace-dialog-input"
+                placeholder={remoteHomeDir || 'absolute path on remote node'}
+                value={remoteCwd}
+                onChange={(e) => setRemoteCwd(e.currentTarget.value)}
+                autoComplete="off"
+              />
+              <p className="add-workspace-dialog-note">
+                remote files unavailable until file rpc lands
+              </p>
+            </div>
+          )}
+
+          {/* Block 3 — Save as project checkbox (local only; remote never persists) */}
+          {!isRemote && (
+            <div className="add-workspace-save-row">
+              <input
+                id="aw-save"
+                type="checkbox"
+                checked
+                disabled
+                readOnly
+                className="add-workspace-checkbox"
+              />
+              <label
+                htmlFor="aw-save"
+                className="add-workspace-dialog-label add-workspace-save-label"
+                title="non-git directories are saved as projects so they appear in the sidebar"
+              >
+                save as project
+              </label>
+            </div>
+          )}
 
           {error && <p className="add-workspace-error-msg">{error}</p>}
         </div>

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -41,7 +41,7 @@ import './CustomizeSessionDialog.css';
 
 export interface CustomizeSessionDialogHandle {
   open(
-    workspace: { name: string; path: string },
+    workspace: { name: string; path: string; isGitRepo?: boolean },
     worktreePath?: string | null,
     preselectedFramework?: AgentType
   ): Promise<void>;
@@ -146,8 +146,9 @@ export interface EnvironmentPickerInput {
   selectedGroupId: string | null;
   selectedNodeId: NodeId | null;
   selectedCheckoutId: string | null;
-  fallbackWorkspace: { name: string; path: string };
+  fallbackWorkspace: { name: string; path: string; isGitRepo?: boolean };
   fallbackWorktreePath: string | null;
+  sessionType?: 'agent' | 'terminal';
 }
 
 const CHECKOUT_ROOT_PREFIX = 'repo:';
@@ -199,20 +200,23 @@ function syntheticLocalNode(selectedAgent: AgentType): HubNodeSummary {
 }
 
 function fallbackGroupFor(
-  workspace: { name: string; path: string },
+  workspace: { name: string; path: string; isGitRepo?: boolean },
   worktreePath: string | null
 ): AggregatedRepoInventoryGroup {
   const repoInstanceId = `${DEFAULT_LOCAL_NODE_ID}:${encodeURIComponent(workspace.path)}`;
-  const worktrees = worktreePath
-    ? [
-        {
-          worktreeInstanceId: `${DEFAULT_LOCAL_NODE_ID}:${encodeURIComponent(worktreePath)}`,
-          localPath: worktreePath,
-          branchName: null,
-          displayName: worktreePath.split('/').pop() || worktreePath,
-        } satisfies RepoInventoryWorktreeInstance,
-      ]
-    : [];
+  // Only include worktree entries for git repos — non-git directories have no branches
+  const isGit = workspace.isGitRepo !== false;
+  const worktrees =
+    isGit && worktreePath
+      ? [
+          {
+            worktreeInstanceId: `${DEFAULT_LOCAL_NODE_ID}:${encodeURIComponent(worktreePath)}`,
+            localPath: worktreePath,
+            branchName: null,
+            displayName: worktreePath.split('/').pop() || worktreePath,
+          } satisfies RepoInventoryWorktreeInstance,
+        ]
+      : [];
   return {
     groupId: repoInstanceId,
     repoIdentity: null,
@@ -226,7 +230,7 @@ function fallbackGroupFor(
         nodeId: DEFAULT_LOCAL_NODE_ID,
         localPath: workspace.path,
         name: workspace.name,
-        isGitRepo: true,
+        isGitRepo: isGit,
         defaultBranch: null,
         currentBranch: null,
         repoIdentity: null,
@@ -260,9 +264,13 @@ function findGroupForPath(
 }
 
 function labelForRepo(group: AggregatedRepoInventoryGroup): string {
-  return group.repoIdentity
-    ? `${group.displayName} — ${group.repoIdentity}`
-    : `${group.displayName} — unidentified repo`;
+  if (group.repoIdentity) return `${group.displayName} — ${group.repoIdentity}`;
+  // If every instance in the group is a non-git directory, label it accordingly
+  const allNonGit =
+    group.instances.length > 0 &&
+    group.instances.every((inst) => !inst.isGitRepo);
+  if (allNonGit) return `${group.displayName} — non-git directory`;
+  return `${group.displayName} — unidentified repo`;
 }
 
 function capabilityProblem(
@@ -274,9 +282,8 @@ function capabilityProblem(
   return `${name} ${capability}`;
 }
 
-function nodeBlockReason(
-  node: HubNodeSummary | null,
-  selectedAgent: AgentType
+export function nodeShellBlockReason(
+  node: HubNodeSummary | null
 ): string | null {
   if (!node) return 'node availability unknown';
   if (node.status === 'offline') return 'node is offline';
@@ -286,11 +293,28 @@ function nodeBlockReason(
   if (shellProblem) return shellProblem;
   const tmuxProblem = capabilityProblem(node.capabilities.core.tmux, 'tmux');
   if (tmuxProblem) return `${tmuxProblem} on ${node.displayName}`;
+  return null;
+}
+
+export function nodeAgentBlockReason(
+  node: HubNodeSummary | null,
+  agent: AgentType
+): string | null {
+  const shellReason = nodeShellBlockReason(node);
+  if (shellReason) return shellReason;
+  if (!node) return null;
   const agentProblem = capabilityProblem(
-    node.capabilities.agents[selectedAgent],
-    selectedAgent
+    node.capabilities.agents[agent],
+    agent
   );
   return agentProblem ? `${agentProblem} on ${node.displayName}` : null;
+}
+
+function nodeBlockReason(
+  node: HubNodeSummary | null,
+  selectedAgent: AgentType
+): string | null {
+  return nodeAgentBlockReason(node, selectedAgent);
 }
 
 function uniqueInstancesByNode(
@@ -384,14 +408,18 @@ function nodeChoiceIdsFor(
 function nodeChoicesFor(
   selectedGroup: AggregatedRepoInventoryGroup,
   input: EnvironmentPickerInput,
-  nodeById: Map<NodeId, HubNodeSummary>
+  nodeById: Map<NodeId, HubNodeSummary>,
+  sessionType: 'agent' | 'terminal' = 'agent'
 ): EnvironmentChoice[] {
   const seenNodeChoices = new Set<NodeId>();
   return nodeChoiceIdsFor(selectedGroup, input.nodes).flatMap((nodeId) => {
     if (seenNodeChoices.has(nodeId)) return [];
     seenNodeChoices.add(nodeId);
     const node = nodeById.get(nodeId) ?? null;
-    const reason = nodeBlockReason(node, input.selectedAgent);
+    const reason =
+      sessionType === 'terminal'
+        ? nodeShellBlockReason(node)
+        : nodeBlockReason(node, input.selectedAgent);
     return [
       {
         value: nodeId,
@@ -478,10 +506,11 @@ function shouldShowEnvironmentPicker(
 export function buildEnvironmentPickerModel(
   input: EnvironmentPickerInput
 ): EnvironmentPickerModel {
+  const sessionType = input.sessionType ?? 'agent';
   const groups = environmentGroupsFor(input);
   const selectedGroup = selectedEnvironmentGroup(groups, input);
   const nodeById = nodeMapFor(input);
-  const nodeChoices = nodeChoicesFor(selectedGroup, input, nodeById);
+  const nodeChoices = nodeChoicesFor(selectedGroup, input, nodeById, sessionType);
   const selectedNodeChoice = selectedNodeChoiceFor(
     nodeChoices,
     input.selectedNodeId
@@ -518,12 +547,15 @@ export function buildEnvironmentPickerModel(
   };
 }
 
+type DialogSessionType = 'agent' | 'terminal';
+
 interface FormState {
   claudeArgsInput: string;
   selectedAgent: AgentType;
   sessionMode: SessionLaunchMode;
   yoloMode: boolean;
   continueExisting: boolean;
+  dialogSessionType: DialogSessionType;
 }
 
 function defaultForm(): FormState {
@@ -533,7 +565,19 @@ function defaultForm(): FormState {
     sessionMode: 'pty',
     yoloMode: false,
     continueExisting: false,
+    dialogSessionType: 'agent',
   };
+}
+
+export function getSessionModeOptionsForType(
+  frameworks: FrameworkInfo[],
+  selectedAgent: AgentType,
+  dialogSessionType: DialogSessionType
+): SessionModeOption[] {
+  if (dialogSessionType === 'terminal') {
+    return [{ value: 'pty', label: 'shell' }];
+  }
+  return getSessionModeOptions(frameworks, selectedAgent);
 }
 
 async function createSessionFromForm(
@@ -542,14 +586,37 @@ async function createSessionFromForm(
   sessionLane: SessionLane,
   remoteCwd?: string
 ) {
-  const claudeArgs = form.claudeArgsInput.trim().split(/\s+/).filter(Boolean);
   const remoteNodeSelected = environment.nodeId !== DEFAULT_LOCAL_NODE_ID;
-  const sessionMode: SessionLaunchMode = remoteNodeSelected
-    ? 'pty'
-    : form.sessionMode;
   const { cols, rows } = estimateTerminalDimensions(
     useUiStore.getState().terminalFontSize
   );
+
+  if (form.dialogSessionType === 'terminal') {
+    const baseOptions = {
+      nodeId: environment.nodeId,
+      type: 'terminal' as const,
+      mode: 'pty' as const,
+      sessionLane,
+      cols,
+      rows,
+    };
+    if (remoteNodeSelected) {
+      return createAgentSession({
+        ...baseOptions,
+        cwd: cleanCwd(remoteCwd),
+      });
+    }
+    return createAgentSession({
+      ...baseOptions,
+      repoPath: environment.repoPath || undefined,
+      cwd: environment.repoPath || undefined,
+    });
+  }
+
+  const claudeArgs = form.claudeArgsInput.trim().split(/\s+/).filter(Boolean);
+  const sessionMode: SessionLaunchMode = remoteNodeSelected
+    ? 'pty'
+    : form.sessionMode;
   const baseOptions = {
     nodeId: environment.nodeId,
     type: 'agent' as const,
@@ -584,6 +651,7 @@ interface BodyProps {
   onFormChange: (patch: Partial<FormState>) => void;
   onEnvironmentChange: (patch: Partial<EnvironmentSelection>) => void;
   onRemoteCwdChange: (cwd: string) => void;
+  onDialogSessionTypeChange: (t: DialogSessionType) => void;
 }
 
 interface EnvironmentSelection {
@@ -601,6 +669,7 @@ function CustomizeSessionBody({
   onFormChange,
   onEnvironmentChange,
   onRemoteCwdChange,
+  onDialogSessionTypeChange,
 }: BodyProps) {
   const frameworks = useConfigStore((state) => state.frameworks);
   const frameworkOptions =
@@ -622,17 +691,21 @@ function CustomizeSessionBody({
           } satisfies FrameworkInfo,
         ];
 
+  const isTerminal = form.dialogSessionType === 'terminal';
   const remoteNodeSelected =
     environmentModel.selectedNodeId !== DEFAULT_LOCAL_NODE_ID;
-  const modeOptions = remoteNodeSelected
-    ? ([{ value: 'pty', label: 'tui' }] satisfies SessionModeOption[])
-    : getSessionModeOptions(frameworkOptions, form.selectedAgent);
+  const modeOptions = isTerminal
+    ? ([{ value: 'pty', label: 'shell' }] satisfies SessionModeOption[])
+    : remoteNodeSelected
+      ? ([{ value: 'pty', label: 'tui' }] satisfies SessionModeOption[])
+      : getSessionModeOptions(frameworkOptions, form.selectedAgent);
   const selectedFramework = frameworkOptions.find(
     (framework) => framework.id === form.selectedAgent
   );
   const selectedUnavailable =
-    selectedFramework && !isFrameworkAvailable(selectedFramework);
+    !isTerminal && selectedFramework && !isFrameworkAvailable(selectedFramework);
   const selectedWebUnavailable =
+    !isTerminal &&
     selectedFramework &&
     form.sessionMode === 'web' &&
     !isFrameworkWebAvailable(selectedFramework);
@@ -642,6 +715,24 @@ function CustomizeSessionBody({
 
   return (
     <div className="customize-session-body-fields">
+      <div className="customize-session-dialog-field">
+        <label className="customize-session-dialog-label" htmlFor="cs-session-type">
+          mode
+        </label>
+        <select
+          id="cs-session-type"
+          className="customize-session-dialog-select"
+          data-track="dialog.customize-session.session-type"
+          value={form.dialogSessionType}
+          onChange={(e) => {
+            const next = e.currentTarget.value as DialogSessionType;
+            onDialogSessionTypeChange(next);
+          }}
+        >
+          <option value="agent">agent</option>
+          <option value="terminal">terminal</option>
+        </select>
+      </div>
       {workspaceName && (
         <p className="customize-session-workspace-name">— {workspaceName}</p>
       )}
@@ -651,8 +742,8 @@ function CustomizeSessionBody({
           aria-label="environment picker"
         >
           <div className="customize-session-environment-copy">
-            choose repo identity, execution node, then node-local checkout. no
-            live cross-host pty migration or automatic filesystem sync.
+            choose execution node, then directory or git checkout on that node.
+            agents are configured separately below.
           </div>
           {environmentModel.repoChoices.length > 1 && (
             <div className="customize-session-dialog-field">
@@ -660,7 +751,7 @@ function CustomizeSessionBody({
                 className="customize-session-dialog-label"
                 htmlFor="cs-repo"
               >
-                repo identity
+                project
               </label>
               <select
                 id="cs-repo"
@@ -780,9 +871,45 @@ function CustomizeSessionBody({
             )}
         </section>
       )}
+      {!isTerminal && (
+        <AgentOnlyFields
+          form={form}
+          frameworkOptions={frameworkOptions}
+          modeOptions={modeOptions}
+          selectedFramework={selectedFramework}
+          selectedUnavailable={!!selectedUnavailable}
+          selectedWebUnavailable={!!selectedWebUnavailable}
+          onFormChange={onFormChange}
+        />
+      )}
+    </div>
+  );
+}
+
+interface AgentOnlyFieldsProps {
+  form: FormState;
+  frameworkOptions: FrameworkInfo[];
+  modeOptions: SessionModeOption[];
+  selectedFramework: FrameworkInfo | undefined;
+  selectedUnavailable: boolean;
+  selectedWebUnavailable: boolean;
+  onFormChange: (patch: Partial<FormState>) => void;
+}
+
+function AgentOnlyFields({
+  form,
+  frameworkOptions,
+  modeOptions,
+  selectedFramework,
+  selectedUnavailable,
+  selectedWebUnavailable,
+  onFormChange,
+}: AgentOnlyFieldsProps) {
+  return (
+    <>
       <div className="customize-session-dialog-field">
         <label className="customize-session-dialog-label" htmlFor="cs-agent">
-          coding agent
+          agent
         </label>
         <select
           id="cs-agent"
@@ -811,7 +938,7 @@ function CustomizeSessionBody({
             </option>
           ))}
         </select>
-        {selectedUnavailable && (
+        {selectedUnavailable && selectedFramework && (
           <div className="customize-session-field-note">
             {selectedFramework.availability?.reason ??
               `${selectedFramework.displayName} is not installed`}
@@ -844,7 +971,7 @@ function CustomizeSessionBody({
               </option>
             ))}
           </select>
-          {selectedWebUnavailable && (
+          {selectedWebUnavailable && selectedFramework && (
             <div className="customize-session-field-note">
               {selectedFramework.webAvailability?.reason ??
                 `${selectedFramework.displayName} web runtime is not available`}
@@ -880,8 +1007,33 @@ function CustomizeSessionBody({
           autoComplete="off"
         />
       </div>
-    </div>
+    </>
   );
+}
+
+function validateAgentFramework(
+  frameworks: FrameworkInfo[],
+  form: FormState
+): string | null {
+  if (form.dialogSessionType !== 'agent') return null;
+  const selectedFramework = frameworks.find((f) => f.id === form.selectedAgent);
+  if (selectedFramework && !isFrameworkAvailable(selectedFramework)) {
+    return (
+      selectedFramework.availability?.reason ??
+      `${selectedFramework.displayName} is not installed`
+    );
+  }
+  if (
+    selectedFramework &&
+    form.sessionMode === 'web' &&
+    !isFrameworkWebAvailable(selectedFramework)
+  ) {
+    return (
+      selectedFramework.webAvailability?.reason ??
+      `${selectedFramework.displayName} web runtime is not available`
+    );
+  }
+  return null;
 }
 
 const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
@@ -892,6 +1044,7 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
     const [workspacePath, setWorkspacePath] = useState('');
     const [worktreePath, setWorktreePath] = useState<string | null>(null);
     const [workspaceName, setWorkspaceName] = useState('');
+    const [workspaceIsGitRepo, setWorkspaceIsGitRepo] = useState<boolean | undefined>(undefined);
     const [form, setForm] = useState<FormState>(defaultForm());
     const [creating, setCreating] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -916,18 +1069,25 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
           selectedGroupId: environmentSelection.selectedGroupId,
           selectedNodeId: environmentSelection.selectedNodeId,
           selectedCheckoutId: environmentSelection.selectedCheckoutId,
-          fallbackWorkspace: { name: workspaceName, path: workspacePath },
+          fallbackWorkspace: {
+            name: workspaceName,
+            path: workspacePath,
+            ...(workspaceIsGitRepo !== undefined ? { isGitRepo: workspaceIsGitRepo } : {}),
+          },
           fallbackWorktreePath: worktreePath,
+          sessionType: form.dialogSessionType,
         }),
       [
         inventory,
         nodes,
         form.selectedAgent,
+        form.dialogSessionType,
         environmentSelection.selectedGroupId,
         environmentSelection.selectedNodeId,
         environmentSelection.selectedCheckoutId,
         workspaceName,
         workspacePath,
+        workspaceIsGitRepo,
         worktreePath,
       ]
     );
@@ -967,7 +1127,7 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
 
     useImperativeHandle(ref, () => ({
       async open(
-        workspace: { name: string; path: string },
+        workspace: { name: string; path: string; isGitRepo?: boolean },
         nextWorktreePath?: string | null,
         preselectedFramework?: AgentType
       ) {
@@ -985,6 +1145,7 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
         setWorkspacePath(workspace.path);
         setWorktreePath(nextWorktreePath ?? null);
         setWorkspaceName(workspace.name);
+        setWorkspaceIsGitRepo(workspace.isGitRepo);
         const [inventoryResult, nodesResult] = await Promise.allSettled([
           fetchRepoInventory(),
           fetchHubNodes(),
@@ -1013,6 +1174,7 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
           ),
           yoloMode: config.defaultYolo,
           continueExisting: config.defaultContinue,
+          dialogSessionType: 'agent',
         });
         shellRef.current?.open();
       },
@@ -1026,25 +1188,9 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
       rememberCwd = true
     ) {
       if (!workspacePath || creating) return;
-      const selectedFramework = frameworks.find(
-        (framework) => framework.id === form.selectedAgent
-      );
-      if (selectedFramework && !isFrameworkAvailable(selectedFramework)) {
-        setError(
-          selectedFramework.availability?.reason ??
-            `${selectedFramework.displayName} is not installed`
-        );
-        return;
-      }
-      if (
-        selectedFramework &&
-        form.sessionMode === 'web' &&
-        !isFrameworkWebAvailable(selectedFramework)
-      ) {
-        setError(
-          selectedFramework.webAvailability?.reason ??
-            `${selectedFramework.displayName} web runtime is not available`
-        );
+      const frameworkError = validateAgentFramework(frameworks, form);
+      if (frameworkError) {
+        setError(frameworkError);
         return;
       }
       if (environmentModel.selectedNodeReason) {
@@ -1123,13 +1269,14 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
             Boolean(environmentModel.selectedNodeReason) ||
             (remoteNodeSelected && !cleanCwd(remoteCwd)) ||
             creating ||
-            frameworks.some(
-              (framework) =>
-                framework.id === form.selectedAgent &&
-                (!isFrameworkAvailable(framework) ||
-                  (form.sessionMode === 'web' &&
-                    !isFrameworkWebAvailable(framework)))
-            )
+            (form.dialogSessionType === 'agent' &&
+              frameworks.some(
+                (framework) =>
+                  framework.id === form.selectedAgent &&
+                  (!isFrameworkAvailable(framework) ||
+                    (form.sessionMode === 'web' &&
+                      !isFrameworkWebAvailable(framework)))
+              ))
           }
         >
           {creating ? 'Creating...' : 'Start Session'}
@@ -1160,6 +1307,9 @@ const CustomizeSessionDialog = forwardRef<CustomizeSessionDialogHandle, Props>(
             setEnvironmentSelection((selection) => ({ ...selection, ...patch }))
           }
           onRemoteCwdChange={setRemoteCwd}
+          onDialogSessionTypeChange={(t) =>
+            setForm((f) => ({ ...f, dialogSessionType: t }))
+          }
         />
       </DialogShell>
     );

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -289,6 +289,9 @@ export function nodeShellBlockReason(
   if (node.status === 'offline') return 'node is offline';
   if (node.status === 'stale') return 'heartbeat is stale';
   if (node.status === 'revoked') return 'node is revoked';
+  const versionState = node.version?.state;
+  if (versionState === 'incompatible') return 'node protocol is incompatible';
+  if (versionState === 'version-skew') return 'node has version skew';
   const shellProblem = capabilityProblem(node.capabilities.core.shell, 'shell');
   if (shellProblem) return shellProblem;
   const tmuxProblem = capabilityProblem(node.capabilities.core.tmux, 'tmux');

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -727,16 +727,29 @@ export async function fetchDashboard(repoPath: string): Promise<DashboardData> {
     branches: string[];
     activity: ActivityEntry[];
   }
-  const raw = await json<RawDashboard>(
-    await fetch('/workspaces/dashboard?path=' + encodeURIComponent(repoPath))
-  );
-  return {
-    prs: raw.pullRequests?.prs ?? [],
-    activity: raw.activity ?? [],
-    isGitRepo: true,
-    defaultBranch: null,
-    hasGhCli: !raw.pullRequests?.error,
-  };
+  try {
+    const raw = await json<RawDashboard>(
+      await fetch('/workspaces/dashboard?path=' + encodeURIComponent(repoPath))
+    );
+    return {
+      prs: raw.pullRequests?.prs ?? [],
+      activity: raw.activity ?? [],
+      isGitRepo: true,
+      defaultBranch: null,
+      hasGhCli: !raw.pullRequests?.error,
+    };
+  } catch (err) {
+    if (err instanceof HttpError && err.code === 'NOT_GIT') {
+      return {
+        isGitRepo: false,
+        prs: [],
+        activity: [],
+        hasGhCli: false,
+        defaultBranch: null,
+      };
+    }
+    throw err;
+  }
 }
 
 export async function fetchCiStatusOrNull(

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -127,6 +127,8 @@ export interface Repo {
   path: string;
   name: string;
   isGitRepo: boolean;
+  /** Derived from isGitRepo at projection time. 'repo' for git repos, 'directory' for non-git dirs. */
+  kind?: 'repo' | 'directory';
   defaultBranch: string | null;
   currentBranch: string | null;
   /** Node-local checkout path. Kept beside path for backward-compatible local mode consumers. */

--- a/server/index.ts
+++ b/server/index.ts
@@ -834,15 +834,28 @@ function sendSessionCreateError(
   });
 }
 
-function validateSessionCreateRequest(
+export function validateSessionCreateRequest(
   repoPath: string | undefined,
+  cwd: string | undefined,
+  type: 'agent' | 'terminal' | undefined,
+  config: Config,
   workContextStore: WorkContextStore,
   workContextId: string | undefined,
   res: express.Response
 ): boolean {
-  if (!repoPath) {
-    res.status(400).json({ error: 'repoPath is required' });
-    return false;
+  const configured = new Set(config.repos ?? []);
+  const sessionType = type ?? 'agent';
+  if (sessionType === 'agent') {
+    if (!repoPath || !configured.has(repoPath)) {
+      res.status(400).json({ error: 'repoPath is required for agent sessions' });
+      return false;
+    }
+  } else {
+    const anchor = repoPath ?? cwd ?? '';
+    if (!configured.has(anchor)) {
+      res.status(400).json({ error: 'terminal cwd must be a configured project path' });
+      return false;
+    }
   }
   if (!workContextId) return true;
   if (workContextStore.get(workContextId)) return true;
@@ -2939,26 +2952,24 @@ async function main(): Promise<void> {
       };
     };
 
+    // Read config once for the lifetime of this request
+    const freshConfig = getConfig();
+
+    // For terminal sessions where only cwd/worktreePath is set, fall back to that as repoPath
+    // Use repoPath if set; for terminal-only sessions the validated anchor was cwd/worktreePath
+    const checkedRepoPath = repoPath || worktreePath || '';
+
     if (
       !validateSessionCreateRequest(
         repoPath,
+        checkedRepoPath,
+        type,
+        freshConfig,
         workContextStore,
         workContextId,
         res
       )
     ) {
-      return;
-    }
-
-    const checkedRepoPath = repoPath ?? '';
-
-    // Read config once for the lifetime of this request
-    const freshConfig = getConfig();
-
-    // Validate repoPath is a configured workspace
-    const configuredWorkspaces = freshConfig.repos ?? [];
-    if (!configuredWorkspaces.includes(checkedRepoPath)) {
-      res.status(400).json({ error: 'repoPath is not a configured workspace' });
       return;
     }
 
@@ -3086,7 +3097,7 @@ async function main(): Promise<void> {
     if (ticketContext) {
       const ticketErr = validateTicketContext(
         ticketContext,
-        configuredWorkspaces
+        freshConfig.repos ?? []
       );
       if (ticketErr) {
         res.status(400).json({ error: ticketErr });

--- a/server/index.ts
+++ b/server/index.ts
@@ -853,7 +853,7 @@ export function validateSessionCreateRequest(
   } else {
     const anchor = repoPath ?? cwd ?? '';
     if (!configured.has(anchor)) {
-      res.status(400).json({ error: 'terminal cwd must be a configured project path' });
+      res.status(400).json({ error: 'terminal sessions require a cwd that is a configured project path' });
       return false;
     }
   }

--- a/server/types.ts
+++ b/server/types.ts
@@ -795,6 +795,8 @@ export interface Repo {
   path: string;
   name: string;
   isGitRepo: boolean;
+  /** Derived from isGitRepo at projection time. 'repo' for git repos, 'directory' for non-git dirs. */
+  kind?: 'repo' | 'directory';
   defaultBranch: string | null;
   currentBranch: string | null;
   /** Node-local checkout path. Kept beside path for backward-compatible local mode consumers. */

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -61,6 +61,29 @@ import {
 const execFileAsync = promisify(execFile);
 const logger = createLogger('workspaces');
 
+// ── Typed git infrastructure errors ──────────────────────────────────────────
+
+export class GitBinaryMissingError extends Error {
+  constructor() {
+    super('git binary not found');
+    this.name = 'GitBinaryMissingError';
+  }
+}
+
+export class PathInaccessibleError extends Error {
+  constructor(dirPath: string) {
+    super(`path inaccessible: ${dirPath}`);
+    this.name = 'PathInaccessibleError';
+  }
+}
+
+export class GitInfraError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GitInfraError';
+  }
+}
+
 const GIT_SYMBOLIC_REF = 'symbolic-ref';
 const ERR_ON_WORKSPACES_CHANGED = 'onWorkspacesChanged failed:';
 const ERR_PATH_REQUIRED = 'path query parameter is required';
@@ -405,6 +428,14 @@ export async function validateWorkspacePath(rawPath: string): Promise<string> {
 /**
  * Detects whether a directory is the root of a git repository and, if so,
  * what the default branch name is.
+ *
+ * Throws typed errors for infrastructure failures:
+ *   - GitBinaryMissingError  — git binary not found (ENOENT on the binary itself)
+ *   - PathInaccessibleError  — directory cannot be read (EACCES)
+ *   - GitInfraError          — unexpected OS-level failure
+ *
+ * Returns { isGitRepo: false, defaultBranch: null } only for legit
+ * "not a git repository" exits (git exit 128 with the expected stderr).
  */
 export async function detectGitRepo(
   dirPath: string,
@@ -412,8 +443,39 @@ export async function detectGitRepo(
 ): Promise<{ isGitRepo: boolean; defaultBranch: string | null }> {
   try {
     await execAsync('git', ['rev-parse', '--git-dir'], { cwd: dirPath });
-  } catch {
-    return { isGitRepo: false, defaultBranch: null };
+  } catch (err: unknown) {
+    const e = err as NodeJS.ErrnoException & { stderr?: string; code?: string | number };
+
+    // ENOENT can mean the git binary is missing OR the cwd path doesn't exist.
+    // Distinguish: if the error message/path references the git binary itself
+    // (spawn error with no stderr), it's a missing binary.
+    if (e.code === 'ENOENT') {
+      // A spawn failure for the binary has no stderr; a missing-directory
+      // failure from git has stderr containing "not a git repository" or
+      // similar. If there is no stderr at all, treat it as binary missing.
+      const hasStderr = typeof e.stderr === 'string' && e.stderr.trim().length > 0;
+      if (!hasStderr) {
+        throw new GitBinaryMissingError();
+      }
+      // cwd path does not exist — treat as not-a-git-repo (path existence
+      // validated upstream by validateWorkspacePath; here we return gracefully).
+      return { isGitRepo: false, defaultBranch: null };
+    }
+
+    if (e.code === 'EACCES') {
+      throw new PathInaccessibleError(dirPath);
+    }
+
+    // "not a git repository" → git exits with code 128 and writes to stderr.
+    // The spawned-process error has a numeric `code` of 128 (exit status).
+    if (typeof e.code === 'number' && e.code === 128) {
+      return { isGitRepo: false, defaultBranch: null };
+    }
+
+    // For any other non-zero exit or OS error, surface as GitInfraError.
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn('detectGitRepo: unexpected error for', dirPath, message);
+    throw new GitInfraError(message);
   }
 
   // Attempt to determine the default branch from remote HEAD
@@ -512,14 +574,48 @@ function expandTilde(p: string): string {
 
 /**
  * Checks whether a resolved path is a git repository.
- * Returns { ok: true } if it is, or { ok: false, status: 400, body } if not.
- * Call at the top of any route handler that requires a git repo.
+ * Returns { ok: true } if it is.
+ * Returns { ok: false, status, body } for any failure — callers must check
+ * `ok` and forward the status + body to the HTTP response.
+ *
+ * Status mapping:
+ *   400 NOT_GIT            — valid directory, not a git repo
+ *   403 PATH_DENIED        — EACCES on the path
+ *   500 GIT_UNAVAILABLE    — git binary missing
+ *   500 GIT_ERROR          — unexpected infrastructure error
  */
 export async function requireGitRepo(
   resolvedPath: string,
   execAsync: typeof execFileAsync = execFileAsync
-): Promise<{ ok: true } | { ok: false; status: 400; body: { error: string; code: string } }> {
-  const { isGitRepo } = await detectGitRepo(resolvedPath, execAsync);
+): Promise<
+  | { ok: true }
+  | { ok: false; status: 400 | 403 | 500; body: { error: string; code: string; message?: string } }
+> {
+  let isGitRepo: boolean;
+  try {
+    ({ isGitRepo } = await detectGitRepo(resolvedPath, execAsync));
+  } catch (err: unknown) {
+    if (err instanceof GitBinaryMissingError) {
+      return {
+        ok: false,
+        status: 500,
+        body: { error: 'git unavailable', code: 'GIT_UNAVAILABLE' },
+      };
+    }
+    if (err instanceof PathInaccessibleError) {
+      return {
+        ok: false,
+        status: 403,
+        body: { error: 'path inaccessible', code: 'PATH_DENIED' },
+      };
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      status: 500,
+      body: { error: 'git error', code: 'GIT_ERROR', message },
+    };
+  }
   if (!isGitRepo) {
     return {
       ok: false,

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -510,6 +510,26 @@ function expandTilde(p: string): string {
   return p;
 }
 
+/**
+ * Checks whether a resolved path is a git repository.
+ * Returns { ok: true } if it is, or { ok: false, status: 400, body } if not.
+ * Call at the top of any route handler that requires a git repo.
+ */
+export async function requireGitRepo(
+  resolvedPath: string,
+  execAsync: typeof execFileAsync = execFileAsync
+): Promise<{ ok: true } | { ok: false; status: 400; body: { error: string; code: string } }> {
+  const { isGitRepo } = await detectGitRepo(resolvedPath, execAsync);
+  if (!isGitRepo) {
+    return {
+      ok: false,
+      status: 400,
+      body: { error: 'not_git_repo', code: 'NOT_GIT' },
+    };
+  }
+  return { ok: true };
+}
+
 // Router factory
 
 /**
@@ -592,6 +612,7 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
           path: p,
           name,
           isGitRepo,
+          kind: isGitRepo ? ('repo' as const) : ('directory' as const),
           defaultBranch,
           currentBranch,
           ...identityFields,
@@ -679,6 +700,7 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
       path: resolved,
       name: path.basename(resolved),
       isGitRepo,
+      kind: isGitRepo ? 'repo' : 'directory',
       defaultBranch,
       currentBranch,
       ...identityFields,
@@ -822,6 +844,7 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
           path: p,
           name,
           isGitRepo,
+          kind: isGitRepo ? ('repo' as const) : ('directory' as const),
           defaultBranch,
           currentBranch,
           ...identityFields,
@@ -907,6 +930,7 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
         path: resolved,
         name: path.basename(resolved),
         isGitRepo,
+        kind: isGitRepo ? 'repo' : 'directory',
         defaultBranch,
         currentBranch,
         ...identityFields,
@@ -943,6 +967,12 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
 
     if (!repoPath) {
       res.status(400).json({ error: ERR_PATH_REQUIRED });
+      return;
+    }
+
+    const gitCheck = await requireGitRepo(path.resolve(repoPath), exec);
+    if (!gitCheck.ok) {
+      res.status(gitCheck.status).json(gitCheck.body);
       return;
     }
 
@@ -1110,6 +1140,12 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
 
     if (!repoPath) {
       res.status(400).json({ error: ERR_PATH_REQUIRED });
+      return;
+    }
+
+    const gitCheck = await requireGitRepo(path.resolve(repoPath), exec);
+    if (!gitCheck.ok) {
+      res.status(gitCheck.status).json(gitCheck.body);
       return;
     }
 
@@ -1293,6 +1329,12 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
       return;
     }
 
+    const gitCheck = await requireGitRepo(path.resolve(repoPath), exec);
+    if (!gitCheck.ok) {
+      res.status(gitCheck.status).json(gitCheck.body);
+      return;
+    }
+
     const existingBranch =
       typeof req.body?.branch === 'string' ? req.body.branch : undefined;
 
@@ -1359,6 +1401,11 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
       typeof req.query.path === 'string' ? req.query.path : undefined;
     if (!repoPath) {
       res.status(400).json({ error: ERR_PATH_REQUIRED });
+      return;
+    }
+    const gitCheck = await requireGitRepo(path.resolve(repoPath), exec);
+    if (!gitCheck.ok) {
+      res.status(gitCheck.status).json(gitCheck.body);
       return;
     }
     const branch = await getCurrentBranch(path.resolve(repoPath));
@@ -1685,6 +1732,12 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
       return;
     }
 
+    const divergenceGitCheck = await requireGitRepo(resolvedRepo, exec);
+    if (!divergenceGitCheck.ok) {
+      res.status(divergenceGitCheck.status).json(divergenceGitCheck.body);
+      return;
+    }
+
     const base =
       typeof req.query.base === 'string' ? req.query.base : undefined;
     const options = base === undefined ? { exec } : { base, exec };
@@ -1716,6 +1769,12 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
         aggregate: { additions: 0, deletions: 0, fileCount: 0 },
         error: ERR_PATH_NOT_IN_WORKSPACES,
       });
+      return;
+    }
+
+    const changedFilesGitCheck = await requireGitRepo(resolvedRepo, exec);
+    if (!changedFilesGitCheck.ok) {
+      res.status(changedFilesGitCheck.status).json(changedFilesGitCheck.body);
       return;
     }
 
@@ -1831,6 +1890,12 @@ export function createWorkspaceRouter(deps: WorkspaceDeps): Router {
     const resolvedRepo = validateWorkspaceAccess(req.query.path);
     if (!resolvedRepo) {
       res.status(403).json({ diff: '', error: ERR_PATH_NOT_IN_WORKSPACES });
+      return;
+    }
+
+    const fileDiffGitCheck = await requireGitRepo(resolvedRepo, exec);
+    if (!fileDiffGitCheck.ok) {
+      res.status(fileDiffGitCheck.status).json(fileDiffGitCheck.body);
       return;
     }
 

--- a/shared/project.ts
+++ b/shared/project.ts
@@ -80,6 +80,23 @@ export function parseProjectId(id: ProjectId): ProjectIdentity | null {
   const sep = rest.indexOf(':');
   if (sep <= 0 || sep === rest.length - 1) return null;
   const kind = rest.slice(0, sep);
+
+  // directory kind has a two-part payload: <encoded-nodeId>:<encoded-localPath>
+  // Split on the raw (still-encoded) slice to avoid double-decoding either part.
+  if (kind === 'directory') {
+    const raw = rest.slice(sep + 1);
+    const innerSep = raw.indexOf(':');
+    if (innerSep <= 0 || innerSep === raw.length - 1) return null;
+    try {
+      const nodeId = decodeURIComponent(raw.slice(0, innerSep));
+      const localPath = decodeURIComponent(raw.slice(innerSep + 1));
+      if (!hasValue(nodeId) || !hasValue(localPath)) return null;
+      return { kind: 'directory', nodeId, localPath };
+    } catch {
+      return null;
+    }
+  }
+
   let payload: string;
   try {
     payload = decodeURIComponent(rest.slice(sep + 1));
@@ -90,19 +107,6 @@ export function parseProjectId(id: ProjectId): ProjectIdentity | null {
   switch (kind) {
     case 'repo':
       return { kind: 'repo', remote: payload };
-    case 'directory': {
-      // payload for directory is "<nodeId>:<localPath>" (both URI-encoded)
-      const innerSep = payload.indexOf(':');
-      if (innerSep <= 0 || innerSep === payload.length - 1) return null;
-      try {
-        const nodeId = decodeURIComponent(payload.slice(0, innerSep));
-        const localPath = decodeURIComponent(payload.slice(innerSep + 1));
-        if (!hasValue(nodeId) || !hasValue(localPath)) return null;
-        return { kind: 'directory', nodeId, localPath };
-      } catch {
-        return null;
-      }
-    }
     case 'node':
       return { kind: 'node', nodeId: payload };
     case 'agent':

--- a/shared/project.ts
+++ b/shared/project.ts
@@ -9,6 +9,7 @@ export type InstanceId = string;
 
 export type ProjectIdentity =
   | { kind: 'repo'; remote: RepoIdentity }
+  | { kind: 'directory'; nodeId: NodeId; localPath: string } // non-git directory project
   | { kind: 'node'; nodeId: NodeId }
   | { kind: 'agent'; providerId: string }
   | { kind: 'playbook'; playbookId: string };
@@ -48,6 +49,12 @@ function encodeIdentity(identity: ProjectIdentity): string {
       if (!hasValue(identity.remote))
         throw new Error('identity.remote is required');
       return `repo:${encodeURIComponent(identity.remote)}`;
+    case 'directory':
+      if (!hasValue(identity.nodeId))
+        throw new Error('identity.nodeId is required');
+      if (!hasValue(identity.localPath))
+        throw new Error('identity.localPath is required');
+      return `directory:${encodeURIComponent(identity.nodeId)}:${encodeURIComponent(identity.localPath)}`;
     case 'node':
       if (!hasValue(identity.nodeId))
         throw new Error('identity.nodeId is required');
@@ -83,6 +90,19 @@ export function parseProjectId(id: ProjectId): ProjectIdentity | null {
   switch (kind) {
     case 'repo':
       return { kind: 'repo', remote: payload };
+    case 'directory': {
+      // payload for directory is "<nodeId>:<localPath>" (both URI-encoded)
+      const innerSep = payload.indexOf(':');
+      if (innerSep <= 0 || innerSep === payload.length - 1) return null;
+      try {
+        const nodeId = decodeURIComponent(payload.slice(0, innerSep));
+        const localPath = decodeURIComponent(payload.slice(innerSep + 1));
+        if (!hasValue(nodeId) || !hasValue(localPath)) return null;
+        return { kind: 'directory', nodeId, localPath };
+      } catch {
+        return null;
+      }
+    }
     case 'node':
       return { kind: 'node', nodeId: payload };
     case 'agent':
@@ -104,6 +124,10 @@ export function projectIdentityEquals(
       return (
         a.remote === (b as Extract<ProjectIdentity, { kind: 'repo' }>).remote
       );
+    case 'directory': {
+      const bd = b as Extract<ProjectIdentity, { kind: 'directory' }>;
+      return a.nodeId === bd.nodeId && a.localPath === bd.localPath;
+    }
     case 'node':
       return (
         a.nodeId === (b as Extract<ProjectIdentity, { kind: 'node' }>).nodeId
@@ -145,4 +169,27 @@ export function parseInstanceId(
   } catch {
     return null;
   }
+}
+
+/**
+ * Creates a stable ProjectId for a non-git directory project.
+ * Format: proj:directory:<nodeId>:<localPath> (both URI-encoded)
+ */
+export function createDirectoryProjectId(
+  nodeId: NodeId,
+  localPath: string
+): ProjectId {
+  return createProjectId({ kind: 'directory', nodeId, localPath });
+}
+
+/**
+ * Parses a directory-kind ProjectId back to its components, or returns null
+ * if the id is not a valid directory project id.
+ */
+export function parseDirectoryProjectId(
+  id: ProjectId
+): { nodeId: NodeId; localPath: string } | null {
+  const identity = parseProjectId(id);
+  if (!identity || identity.kind !== 'directory') return null;
+  return { nodeId: identity.nodeId, localPath: identity.localPath };
 }

--- a/test/active-work-surface.test.ts
+++ b/test/active-work-surface.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  repoBindingLabel,
+  repoKind,
+} from '../frontend/src/components/ActiveWorkSurface.js';
+import type { Repo, WorkContextActiveGroup, WorkContextSessionSummary } from '../frontend/src/lib/types.js';
+
+function makeSession(
+  overrides: Partial<WorkContextSessionSummary> = {}
+): WorkContextSessionSummary {
+  return {
+    id: 'sess-1',
+    nodeId: 'local',
+    tabKind: 'primary',
+    type: 'terminal',
+    cwd: '/home/user/my-project',
+    repoPath: '/home/user/my-project',
+    relationship: 'primary',
+    associatedAt: '2026-05-12T00:00:00.000Z',
+    live: true,
+    ...overrides,
+  };
+}
+
+function makeGroup(
+  sessions: WorkContextSessionSummary[] = []
+): WorkContextActiveGroup {
+  return {
+    id: 'group-1',
+    context: null,
+    node: {
+      nodeId: 'local',
+      status: 'online',
+      displayName: 'local',
+      kind: 'local',
+    },
+    sessions,
+    staleReadModel: false,
+  };
+}
+
+function makeRepo(path: string, kind: 'repo' | 'directory'): Repo {
+  return {
+    path,
+    name: path.split('/').pop() ?? path,
+    isGitRepo: kind === 'repo',
+    kind,
+    defaultBranch: kind === 'repo' ? 'main' : null,
+    currentBranch: kind === 'repo' ? 'main' : null,
+  };
+}
+
+describe('active-work-surface anchor rendering', () => {
+  it('directory-kind session anchor reads <node> · <cwd> · directory', () => {
+    const session = makeSession({
+      nodeId: 'local',
+      cwd: '/home/user/my-project',
+      repoPath: '/home/user/my-project',
+    });
+    const repos = [makeRepo('/home/user/my-project', 'directory')];
+    const group = makeGroup([session]);
+
+    const kind = repoKind(session, repos);
+    expect(kind).toBe('directory');
+
+    const label = repoBindingLabel(group, session, repos);
+    expect(label).toMatch(/local/);
+    expect(label).toMatch(/\/home\/user\/my-project/);
+    expect(label).toMatch(/directory/);
+  });
+
+  it('repo-kind session anchor includes repo name and branch', () => {
+    const session = makeSession({
+      nodeId: 'local',
+      cwd: '/home/user/relay-ide',
+      repoPath: '/home/user/relay-ide',
+      repoName: 'relay-ide',
+      branchName: 'nightly',
+    });
+    const repos = [makeRepo('/home/user/relay-ide', 'repo')];
+    const group = makeGroup([session]);
+
+    const kind = repoKind(session, repos);
+    expect(kind).toBe('repo');
+
+    const label = repoBindingLabel(group, session, repos);
+    expect(label).toContain('relay-ide');
+    expect(label).toContain('nightly');
+    // should NOT contain 'directory'
+    expect(label).not.toContain('directory');
+  });
+
+  it('session with no matching repo returns null kind', () => {
+    const session = makeSession({ repoPath: '/some/unknown/path' });
+    const repos: Repo[] = [];
+
+    expect(repoKind(session, repos)).toBeNull();
+  });
+
+  it('directory-kind shows remote node name in anchor', () => {
+    const session = makeSession({
+      nodeId: 'remote-server',
+      cwd: '/srv/workspace',
+      repoPath: '/srv/workspace',
+    });
+    const repos = [makeRepo('/srv/workspace', 'directory')];
+    const group = makeGroup([session]);
+
+    const label = repoBindingLabel(group, session, repos);
+    expect(label).toContain('remote-server');
+    expect(label).toContain('/srv/workspace');
+    expect(label).toContain('directory');
+  });
+});

--- a/test/components/TerminalNodePicker.test.ts
+++ b/test/components/TerminalNodePicker.test.ts
@@ -89,9 +89,10 @@ describe('TerminalNodePicker buildChoices', () => {
     expect(choices[1]?.label).toBe('m1');
   });
 
-  it('allows version-skew nodes for terminal sessions (shell+tmux are the only gates)', () => {
-    // nodeShellBlockReason does not check protocol version — a version-skew node
-    // that has shell+tmux available can still host a terminal session.
+  it('blocks version-skew nodes even when shell+tmux are available', () => {
+    // nodeShellBlockReason checks version state before shell+tmux — a version-skew
+    // node is disabled pre-click so the user gets feedback before attempting to
+    // open a session.
     const choices = buildChoices([
       node({
         nodeId: 'skew',
@@ -104,12 +105,14 @@ describe('TerminalNodePicker buildChoices', () => {
       }),
     ]);
     expect(choices[1]).toMatchObject({
-      disabled: false,
+      disabled: true,
+      disabledReason: 'node has version skew',
     });
   });
 
-  it('allows incompatible-version nodes for terminal sessions when shell+tmux are available', () => {
-    // Same reasoning: terminal sessions only require shell+tmux, not version parity.
+  it('blocks incompatible-version nodes even when shell+tmux are available', () => {
+    // Same reasoning: incompatible protocol is infrastructure-level; the hub will
+    // reject a routed session anyway, so we block pre-click.
     const choices = buildChoices([
       node({
         nodeId: 'incompat',
@@ -122,7 +125,8 @@ describe('TerminalNodePicker buildChoices', () => {
       }),
     ]);
     expect(choices[1]).toMatchObject({
-      disabled: false,
+      disabled: true,
+      disabledReason: 'node protocol is incompatible',
     });
   });
 

--- a/test/components/TerminalNodePicker.test.ts
+++ b/test/components/TerminalNodePicker.test.ts
@@ -69,17 +69,18 @@ describe('TerminalNodePicker buildChoices', () => {
       node({ nodeId: 'offline', displayName: 'offline', status: 'offline' }),
       node({ nodeId: 'revoked', displayName: 'revoked', status: 'revoked' }),
     ]);
+    // nodeShellBlockReason returns descriptive messages for non-online states
     expect(choices[1]).toMatchObject({
       disabled: true,
-      disabledReason: 'stale',
+      disabledReason: 'heartbeat is stale',
     });
     expect(choices[2]).toMatchObject({
       disabled: true,
-      disabledReason: 'offline',
+      disabledReason: 'node is offline',
     });
     expect(choices[3]).toMatchObject({
       disabled: true,
-      disabledReason: 'revoked',
+      disabledReason: 'node is revoked',
     });
   });
 
@@ -88,7 +89,9 @@ describe('TerminalNodePicker buildChoices', () => {
     expect(choices[1]?.label).toBe('m1');
   });
 
-  it('disables nodes with version skew even when online', () => {
+  it('allows version-skew nodes for terminal sessions (shell+tmux are the only gates)', () => {
+    // nodeShellBlockReason does not check protocol version — a version-skew node
+    // that has shell+tmux available can still host a terminal session.
     const choices = buildChoices([
       node({
         nodeId: 'skew',
@@ -101,12 +104,12 @@ describe('TerminalNodePicker buildChoices', () => {
       }),
     ]);
     expect(choices[1]).toMatchObject({
-      disabled: true,
-      disabledReason: 'version skew',
+      disabled: false,
     });
   });
 
-  it('disables nodes with incompatible protocol versions', () => {
+  it('allows incompatible-version nodes for terminal sessions when shell+tmux are available', () => {
+    // Same reasoning: terminal sessions only require shell+tmux, not version parity.
     const choices = buildChoices([
       node({
         nodeId: 'incompat',
@@ -119,8 +122,7 @@ describe('TerminalNodePicker buildChoices', () => {
       }),
     ]);
     expect(choices[1]).toMatchObject({
-      disabled: true,
-      disabledReason: 'protocol incompatible',
+      disabled: false,
     });
   });
 
@@ -175,9 +177,27 @@ describe('TerminalNodePicker buildChoices', () => {
         },
       }),
     ]);
+    // nodeShellBlockReason returns "tmux <status> on <displayName>"
     expect(choices[1]).toMatchObject({
       disabled: true,
-      disabledReason: 'no tmux',
+      disabledReason: 'tmux unavailable on thin',
+    });
+  });
+
+  it('hermes unavailable does not block terminal node picker', () => {
+    // Terminal picker uses nodeShellBlockReason (shell+tmux only), not agent availability.
+    const choices = buildChoices([
+      node({
+        nodeId: 'hermes-absent',
+        displayName: 'hermes-absent',
+        capabilities: {
+          ...node().capabilities,
+          agents: {},
+        },
+      }),
+    ]);
+    expect(choices[1]).toMatchObject({
+      disabled: false,
     });
   });
 });

--- a/test/customize-session-dialog.test.ts
+++ b/test/customize-session-dialog.test.ts
@@ -702,6 +702,32 @@ describe('terminal vs agent node eligibility', () => {
     expect(nodeShellBlockReason(offlineNode)).toBe('node is offline');
     expect(nodeAgentBlockReason(offlineNode, 'hermes')).toBe('node is offline');
   });
+
+  it('blocks version-skew node in both terminal and agent mode', () => {
+    const skewNode = remoteNode({
+      version: {
+        state: 'version-skew',
+        nodeProtocolVersion: '1.1',
+        hubProtocolVersion: '1.0',
+      },
+    });
+
+    expect(nodeShellBlockReason(skewNode)).toBe('node has version skew');
+    expect(nodeAgentBlockReason(skewNode, 'hermes')).toBe('node has version skew');
+  });
+
+  it('blocks incompatible node in both terminal and agent mode', () => {
+    const incompatNode = remoteNode({
+      version: {
+        state: 'incompatible',
+        nodeProtocolVersion: '2.0',
+        hubProtocolVersion: '1.0',
+      },
+    });
+
+    expect(nodeShellBlockReason(incompatNode)).toBe('node protocol is incompatible');
+    expect(nodeAgentBlockReason(incompatNode, 'hermes')).toBe('node protocol is incompatible');
+  });
 });
 
 describe('directory-kind workspace support', () => {

--- a/test/customize-session-dialog.test.ts
+++ b/test/customize-session-dialog.test.ts
@@ -4,8 +4,11 @@ import {
   buildEnvironmentPickerModel,
   defaultSessionModeForAgent,
   getSessionModeOptions,
+  getSessionModeOptionsForType,
   isFrameworkAvailable,
   isFrameworkWebAvailable,
+  nodeAgentBlockReason,
+  nodeShellBlockReason,
   selectLaunchAgent,
 } from '../frontend/src/components/dialogs/CustomizeSessionDialog.js';
 import type { FrameworkInfo } from '../frontend/src/lib/types.js';
@@ -583,4 +586,262 @@ describe('CustomizeSessionDialog environment picker model', () => {
       expect(model.resolved.nodeId).toBe('local');
     }
   );
+});
+
+describe('terminal vs agent node eligibility', () => {
+  function remoteNode(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
+    return node({
+      nodeId: 'remote',
+      displayName: 'remote server',
+      capabilities: {
+        ...node().capabilities,
+        agents: {},
+      },
+      ...overrides,
+    });
+  }
+
+  it('nodeAgentBlockReason returns reason for missing agent; nodeShellBlockReason returns null when shell+tmux are available', () => {
+    const hermesMissingNode = remoteNode();
+
+    expect(nodeShellBlockReason(hermesMissingNode)).toBeNull();
+    expect(nodeAgentBlockReason(hermesMissingNode, 'hermes')).toBe(
+      'hermes capability unknown on remote server'
+    );
+  });
+
+  it('buildEnvironmentPickerModel enables node in terminal mode when agent is missing but shell+tmux are available', () => {
+    const hermesMissingNode = remoteNode();
+    const repoInventory = inventory();
+    repoInventory.groups = [
+      {
+        ...repoInventory.groups[0]!,
+        identityDebug: {
+          ...repoInventory.groups[0]!.identityDebug,
+          instanceCount: 2,
+          nodeIds: ['local', 'remote'],
+        },
+        instances: [
+          { ...repoInventory.groups[0]!.instances[1]!, worktrees: [] },
+          {
+            repoInstanceId: 'remote:%2Fsrv%2Frelay-ide',
+            nodeId: 'remote',
+            localPath: '/srv/relay-ide',
+            name: 'relay-ide',
+            isGitRepo: true,
+            defaultBranch: 'nightly',
+            currentBranch: 'nightly',
+            repoIdentity: 'github.com/donovan-yohan/relay-ide',
+            selectedRemote: null,
+            remotes: [],
+            repoIdentityWarnings: [],
+            worktrees: [],
+            reportedAt: '2026-05-12T00:00:00.000Z',
+          },
+        ],
+      },
+    ];
+
+    const agentModel = buildEnvironmentPickerModel({
+      inventory: repoInventory,
+      nodes: [node(), hermesMissingNode],
+      selectedAgent: 'hermes',
+      selectedGroupId: 'github.com/donovan-yohan/relay-ide',
+      selectedNodeId: 'remote',
+      selectedCheckoutId: null,
+      fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
+      fallbackWorktreePath: null,
+      sessionType: 'agent',
+    });
+
+    const terminalModel = buildEnvironmentPickerModel({
+      inventory: repoInventory,
+      nodes: [node(), hermesMissingNode],
+      selectedAgent: 'hermes',
+      selectedGroupId: 'github.com/donovan-yohan/relay-ide',
+      selectedNodeId: 'remote',
+      selectedCheckoutId: null,
+      fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
+      fallbackWorktreePath: null,
+      sessionType: 'terminal',
+    });
+
+    expect(
+      agentModel.nodeChoices.find((c) => c.value === 'remote')
+    ).toMatchObject({ disabled: true, reason: 'hermes capability unknown on remote server' });
+
+    const terminalRemoteChoice = terminalModel.nodeChoices.find(
+      (c) => c.value === 'remote'
+    );
+    expect(terminalRemoteChoice?.disabled).toBeUndefined();
+    expect(terminalRemoteChoice?.reason).toBeUndefined();
+  });
+
+  it('disables node in both modes when tmux is degraded', () => {
+    const tmuxDegradedNode = remoteNode({
+      capabilities: {
+        ...remoteNode().capabilities,
+        core: {
+          ...remoteNode().capabilities.core,
+          tmux: 'degraded',
+        },
+      },
+    });
+
+    expect(nodeShellBlockReason(tmuxDegradedNode)).toBe(
+      'tmux degraded on remote server'
+    );
+    expect(nodeAgentBlockReason(tmuxDegradedNode, 'hermes')).toBe(
+      'tmux degraded on remote server'
+    );
+  });
+
+  it('disables node in both modes when node is offline', () => {
+    const offlineNode = remoteNode({ status: 'offline' });
+
+    expect(nodeShellBlockReason(offlineNode)).toBe('node is offline');
+    expect(nodeAgentBlockReason(offlineNode, 'hermes')).toBe('node is offline');
+  });
+});
+
+describe('directory-kind workspace support', () => {
+  it('fallback group for non-git workspace has isGitRepo: false and no worktrees', () => {
+    const model = buildEnvironmentPickerModel({
+      inventory: null,
+      nodes: [],
+      selectedAgent: 'claude',
+      selectedGroupId: null,
+      selectedNodeId: null,
+      selectedCheckoutId: null,
+      fallbackWorkspace: { name: 'my-project', path: '/home/user/my-project', isGitRepo: false },
+      fallbackWorktreePath: null,
+    });
+
+    expect(model.showPicker).toBe(false);
+    // The group's single instance should reflect isGitRepo: false
+    const groups = model.repoChoices;
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.label).toContain('non-git directory');
+  });
+
+  it('repoChoices labels include "non-git directory" for directory-kind workspace', () => {
+    const model = buildEnvironmentPickerModel({
+      inventory: null,
+      nodes: [],
+      selectedAgent: 'claude',
+      selectedGroupId: null,
+      selectedNodeId: null,
+      selectedCheckoutId: null,
+      fallbackWorkspace: { name: 'scripts', path: '/home/user/scripts', isGitRepo: false },
+      fallbackWorktreePath: null,
+    });
+
+    expect(model.repoChoices[0]?.label).toBe('scripts — non-git directory');
+  });
+
+  it('repoChoices labels show "unidentified repo" for git workspace without identity', () => {
+    const model = buildEnvironmentPickerModel({
+      inventory: null,
+      nodes: [],
+      selectedAgent: 'claude',
+      selectedGroupId: null,
+      selectedNodeId: null,
+      selectedCheckoutId: null,
+      fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide', isGitRepo: true },
+      fallbackWorktreePath: null,
+    });
+
+    expect(model.repoChoices[0]?.label).toBe('relay-ide — unidentified repo');
+  });
+
+  it('synthetic fallback row for git workspace without isGitRepo field defaults to "unidentified repo"', () => {
+    // Backward-compat: callers that don't pass isGitRepo should get old behavior
+    const model = buildEnvironmentPickerModel({
+      inventory: null,
+      nodes: [],
+      selectedAgent: 'claude',
+      selectedGroupId: null,
+      selectedNodeId: null,
+      selectedCheckoutId: null,
+      fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
+      fallbackWorktreePath: null,
+    });
+
+    expect(model.repoChoices[0]?.label).toBe('relay-ide — unidentified repo');
+  });
+});
+
+describe('agent/terminal mode toggle', () => {
+  it('terminal mode forces session mode to pty/shell only', () => {
+    const hermesFrameworks = [framework('hermes')];
+    const options = getSessionModeOptionsForType(hermesFrameworks, 'hermes', 'terminal');
+
+    expect(options).toHaveLength(1);
+    expect(options[0]).toMatchObject({ value: 'pty', label: 'shell' });
+  });
+
+  it('agent mode returns normal session mode options', () => {
+    const hermesFrameworks = [framework('hermes')];
+    const options = getSessionModeOptionsForType(hermesFrameworks, 'hermes', 'agent');
+
+    expect(options.length).toBeGreaterThan(1);
+    expect(options.some((o) => o.value === 'web')).toBe(true);
+  });
+
+  it('terminal mode does not block nodes missing agent capability (buildEnvironmentPickerModel)', () => {
+    const repoInventory = inventory();
+    const noAgentNode = node({
+      nodeId: 'no-agent',
+      displayName: 'no-agent server',
+      capabilities: {
+        ...node().capabilities,
+        agents: {},
+      },
+    });
+    repoInventory.groups = [
+      {
+        ...repoInventory.groups[0]!,
+        identityDebug: {
+          ...repoInventory.groups[0]!.identityDebug,
+          instanceCount: 2,
+          nodeIds: ['local', 'no-agent'],
+        },
+        instances: [
+          { ...repoInventory.groups[0]!.instances[1]!, worktrees: [] },
+          {
+            repoInstanceId: 'no-agent:%2Fsrv%2Frelay-ide',
+            nodeId: 'no-agent',
+            localPath: '/srv/relay-ide',
+            name: 'relay-ide',
+            isGitRepo: true,
+            defaultBranch: 'nightly',
+            currentBranch: 'nightly',
+            repoIdentity: 'github.com/donovan-yohan/relay-ide',
+            selectedRemote: null,
+            remotes: [],
+            repoIdentityWarnings: [],
+            worktrees: [],
+            reportedAt: '2026-05-12T00:00:00.000Z',
+          },
+        ],
+      },
+    ];
+
+    const terminalModel = buildEnvironmentPickerModel({
+      inventory: repoInventory,
+      nodes: [node(), noAgentNode],
+      selectedAgent: 'claude',
+      selectedGroupId: 'github.com/donovan-yohan/relay-ide',
+      selectedNodeId: 'no-agent',
+      selectedCheckoutId: null,
+      fallbackWorkspace: { name: 'relay-ide', path: '/Users/kyle/relay-ide' },
+      fallbackWorktreePath: null,
+      sessionType: 'terminal',
+    });
+
+    const noAgentChoice = terminalModel.nodeChoices.find((c) => c.value === 'no-agent');
+    expect(noAgentChoice).toBeDefined();
+    expect(noAgentChoice?.disabled).toBeUndefined();
+    expect(noAgentChoice?.reason).toBeUndefined();
+  });
 });

--- a/test/sessions-create-validation.test.ts
+++ b/test/sessions-create-validation.test.ts
@@ -152,7 +152,23 @@ describe('validateSessionCreateRequest', () => {
     );
     expect(result).toBe(false);
     expect(res.status).toBe(400);
-    expect(res.body).toMatchObject({ error: expect.stringContaining('configured') });
+    expect(res.body).toMatchObject({ error: 'terminal sessions require a cwd that is a configured project path' });
+  });
+
+  it('returns false with 400 for terminal session with all paths undefined (fail-closed)', () => {
+    const res = makeRes();
+    const result = validateSessionCreateRequest(
+      undefined,
+      undefined,
+      'terminal',
+      config,
+      store,
+      undefined,
+      res.resObj as never
+    );
+    expect(result).toBe(false);
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: 'terminal sessions require a cwd that is a configured project path' });
   });
 
   it('defaults to agent type when type is undefined (requires repoPath)', () => {

--- a/test/sessions-create-validation.test.ts
+++ b/test/sessions-create-validation.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import { validateSessionCreateRequest } from '../server/index.js';
+import type { Config } from '../server/types.js';
+import type { WorkContextStore } from '../server/work-context.js';
+
+// Minimal config stub with the two repos we'll test with
+function makeConfig(repos: string[]): Config {
+  return {
+    host: '0.0.0.0',
+    port: 3000,
+    cookieTTL: '30d',
+    repos,
+    claudeArgs: [],
+    defaultFramework: 'claude',
+    defaultContinue: false,
+    defaultYolo: false,
+    maxPtySessions: 10,
+    launchInTmux: true,
+    defaultNotifications: false,
+    claudeFullscreen: false,
+  };
+}
+
+// Minimal WorkContextStore stub
+function makeStore(): WorkContextStore {
+  const contexts = new Map<string, unknown>();
+  return {
+    get(id: string) {
+      return contexts.get(id);
+    },
+    associateSession() {},
+    findSessionWorkContextIds() { return []; },
+    // @ts-expect-error partial stub
+  } as WorkContextStore;
+}
+
+// Captures res.status(N).json(body) calls
+function makeRes() {
+  let capturedStatus = 200;
+  let capturedBody: unknown = undefined;
+  return {
+    get status() { return capturedStatus; },
+    get body() { return capturedBody; },
+    resObj: {
+      status(code: number) {
+        capturedStatus = code;
+        return {
+          json(body: unknown) {
+            capturedBody = body;
+            return this;
+          },
+        };
+      },
+    },
+  };
+}
+
+describe('validateSessionCreateRequest', () => {
+  const configuredPath = '/configured/repo';
+  const nonGitPath = '/configured/non-git';
+  const unconfiguredPath = '/not/configured';
+
+  const config = makeConfig([configuredPath, nonGitPath]);
+  const store = makeStore();
+
+  it('returns true for agent session with configured repoPath', () => {
+    const res = makeRes();
+    const result = validateSessionCreateRequest(
+      configuredPath,
+      undefined,
+      'agent',
+      config,
+      store,
+      undefined,
+      res.resObj as never
+    );
+    expect(result).toBe(true);
+    expect(res.status).toBe(200); // no error response sent
+  });
+
+  it('returns false with 400 for agent session with no repoPath', () => {
+    const res = makeRes();
+    const result = validateSessionCreateRequest(
+      undefined,
+      undefined,
+      'agent',
+      config,
+      store,
+      undefined,
+      res.resObj as never
+    );
+    expect(result).toBe(false);
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: expect.stringContaining('repoPath') });
+  });
+
+  it('returns false with 400 for agent session with unconfigured repoPath', () => {
+    const res = makeRes();
+    const result = validateSessionCreateRequest(
+      unconfiguredPath,
+      undefined,
+      'agent',
+      config,
+      store,
+      undefined,
+      res.resObj as never
+    );
+    expect(result).toBe(false);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns true for terminal session with configured cwd (no repoPath)', () => {
+    const res = makeRes();
+    const result = validateSessionCreateRequest(
+      undefined,
+      nonGitPath,
+      'terminal',
+      config,
+      store,
+      undefined,
+      res.resObj as never
+    );
+    expect(result).toBe(true);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns true for terminal session with configured repoPath (legacy)', () => {
+    const res = makeRes();
+    const result = validateSessionCreateRequest(
+      configuredPath,
+      configuredPath,
+      'terminal',
+      config,
+      store,
+      undefined,
+      res.resObj as never
+    );
+    expect(result).toBe(true);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns false with 400 for terminal session with unconfigured cwd', () => {
+    const res = makeRes();
+    const result = validateSessionCreateRequest(
+      undefined,
+      unconfiguredPath,
+      'terminal',
+      config,
+      store,
+      undefined,
+      res.resObj as never
+    );
+    expect(result).toBe(false);
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: expect.stringContaining('configured') });
+  });
+
+  it('defaults to agent type when type is undefined (requires repoPath)', () => {
+    const res = makeRes();
+    const result = validateSessionCreateRequest(
+      undefined,
+      nonGitPath,
+      undefined,
+      config,
+      store,
+      undefined,
+      res.resObj as never
+    );
+    expect(result).toBe(false);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns false with 404 when workContextId is set but not found', () => {
+    const res = makeRes();
+    const result = validateSessionCreateRequest(
+      configuredPath,
+      undefined,
+      'agent',
+      config,
+      store,
+      'missing-context-id',
+      res.resObj as never
+    );
+    expect(result).toBe(false);
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ error: 'work_context_not_found' });
+  });
+});

--- a/test/view-spine-identity.test.ts
+++ b/test/view-spine-identity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { createBenchId, parseBenchId } from '../shared/bench.js';
 import {
+  createDirectoryProjectId,
   createInstanceId,
   createProjectId,
   parseInstanceId,
@@ -79,6 +80,61 @@ describe('project id helpers', () => {
     expect(() => createProjectId({ kind: 'playbook', playbookId: '' })).toThrow(
       'identity.playbookId is required'
     );
+  });
+
+  it('round-trips directory identity (simple paths)', () => {
+    const id = createDirectoryProjectId('local-host', '/home/donovan');
+    expect(parseProjectId(id)).toEqual({
+      kind: 'directory',
+      nodeId: 'local-host',
+      localPath: '/home/donovan',
+    });
+  });
+
+  it('round-trips directory identity with colons in nodeId and localPath', () => {
+    const id = createDirectoryProjectId('node:with:colons', '/path/with:colons');
+    expect(parseProjectId(id)).toEqual({
+      kind: 'directory',
+      nodeId: 'node:with:colons',
+      localPath: '/path/with:colons',
+    });
+  });
+
+  it('round-trips directory identity with literal % in localPath', () => {
+    // localPath containing a literal % — encodeURIComponent encodes it to %25,
+    // decoding once must yield the original % back.
+    const id = createDirectoryProjectId('host', '/path/with%20space');
+    expect(parseProjectId(id)).toEqual({
+      kind: 'directory',
+      nodeId: 'host',
+      localPath: '/path/with%20space',
+    });
+  });
+
+  it('round-trips directory identity with literal %2F in localPath', () => {
+    const id = createDirectoryProjectId('host', '/x%2Fy');
+    expect(parseProjectId(id)).toEqual({
+      kind: 'directory',
+      nodeId: 'host',
+      localPath: '/x%2Fy',
+    });
+  });
+
+  it('returns null for malformed directory payload', () => {
+    // Only one segment after the kind tag — no inner colon separator
+    expect(parseProjectId('proj:directory:malformed')).toBeNull();
+  });
+
+  it('directory kind does not parse as node kind and vice versa', () => {
+    const dirId = createDirectoryProjectId('h', '/p');
+    const parsed = parseProjectId(dirId);
+    expect(parsed?.kind).toBe('directory');
+    expect(parsed?.kind).not.toBe('node');
+
+    const nodeId = createProjectId({ kind: 'node', nodeId: 'h' });
+    const parsedNode = parseProjectId(nodeId);
+    expect(parsedNode?.kind).toBe('node');
+    expect(parsedNode?.kind).not.toBe('directory');
   });
 
   it('compares identities by kind+payload', () => {

--- a/test/workspaces-dashboard-cache.test.ts
+++ b/test/workspaces-dashboard-cache.test.ts
@@ -55,6 +55,10 @@ async function fetchDashboard(
 
 function makeDashboardExec(counter: { prListCalls: number }): ExecFn {
   return async (file, args) => {
+    // requireGitRepo uses detectGitRepo which calls git rev-parse --git-dir
+    if (file === 'git' && args[0] === 'rev-parse' && args[1] === '--git-dir') {
+      return { stdout: '.git', stderr: '' };
+    }
     if (file === 'gh' && args[0] === 'api' && args[1] === 'user') {
       return { stdout: 'me\n', stderr: '' };
     }
@@ -124,6 +128,10 @@ describe('/workspaces/dashboard PR cache', () => {
     const prListResolvers: Array<(value: ExecResult) => void> = [];
     let prListCalls = 0;
     const exec: ExecFn = async (file, args) => {
+      // requireGitRepo needs git rev-parse --git-dir to succeed
+      if (file === 'git' && args[0] === 'rev-parse' && args[1] === '--git-dir') {
+        return { stdout: '.git', stderr: '' };
+      }
       if (file === 'gh' && args[0] === 'api' && args[1] === 'user') {
         return { stdout: 'me\n', stderr: '' };
       }

--- a/test/workspaces-routes.test.ts
+++ b/test/workspaces-routes.test.ts
@@ -32,6 +32,14 @@ afterAll(() => {
   if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
+/** Simulate a git exit-128 "not a git repository" error, as node's execFile produces. */
+function makeGitExit128Error(): Error & { code: number; stderr: string } {
+  const err = new Error('not a git repository') as Error & { code: number; stderr: string };
+  err.code = 128;
+  err.stderr = 'fatal: not a git repository (or any of the parent directories): .git';
+  return err;
+}
+
 function makeExec(gitDir: string): ExecFn {
   // Simulates: git rev-parse --git-dir succeeds for gitDir, fails for others
   return async (file: string, args: string[], opts?: { cwd?: string }) => {
@@ -39,19 +47,19 @@ function makeExec(gitDir: string): ExecFn {
       if (opts?.cwd === gitDir) {
         return { stdout: '.git', stderr: '' } as ExecResult;
       }
-      throw new Error('not a git repository');
+      throw makeGitExit128Error();
     }
     if (file === 'git' && args[0] === 'symbolic-ref') {
       if (opts?.cwd === gitDir) {
         return { stdout: 'main\n', stderr: '' } as ExecResult;
       }
-      throw new Error('not a git repository');
+      throw makeGitExit128Error();
     }
     if (file === 'git' && args[0] === 'remote') {
       if (opts?.cwd === gitDir) {
         return { stdout: '', stderr: '' } as ExecResult;
       }
-      throw new Error('not a git repository');
+      throw makeGitExit128Error();
     }
     return { stdout: '', stderr: '' } as ExecResult;
   };
@@ -172,6 +180,57 @@ describe('GET /workspaces/current-branch — NOT_GIT guard', () => {
     try {
       const params = new URLSearchParams({ path: nonGitPath });
       const res = await fetch(`${server.url}/workspaces/current-branch?${params}`);
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe('NOT_GIT');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('GET /workspaces/divergence — NOT_GIT guard', () => {
+  it('returns 400 with code NOT_GIT for a non-git configured path', async () => {
+    const exec = makeExec(gitRepoPath);
+    const app = await makeApp(exec);
+    const server = await createTestServer(app);
+    try {
+      const params = new URLSearchParams({ path: nonGitPath });
+      const res = await fetch(`${server.url}/workspaces/divergence?${params}`);
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe('NOT_GIT');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('GET /workspaces/changed-files — NOT_GIT guard', () => {
+  it('returns 400 with code NOT_GIT for a non-git configured path', async () => {
+    const exec = makeExec(gitRepoPath);
+    const app = await makeApp(exec);
+    const server = await createTestServer(app);
+    try {
+      const params = new URLSearchParams({ path: nonGitPath });
+      const res = await fetch(`${server.url}/workspaces/changed-files?${params}`);
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe('NOT_GIT');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('GET /workspaces/file-diff — NOT_GIT guard', () => {
+  it('returns 400 with code NOT_GIT for a non-git configured path', async () => {
+    const exec = makeExec(gitRepoPath);
+    const app = await makeApp(exec);
+    const server = await createTestServer(app);
+    try {
+      const params = new URLSearchParams({ path: nonGitPath, file: 'README.md' });
+      const res = await fetch(`${server.url}/workspaces/file-diff?${params}`);
       expect(res.status).toBe(400);
       const body = (await res.json()) as { code: string };
       expect(body.code).toBe('NOT_GIT');

--- a/test/workspaces-routes.test.ts
+++ b/test/workspaces-routes.test.ts
@@ -1,0 +1,182 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import express from 'express';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { createWorkspaceRouter, type WorkspaceDeps } from '../server/workspaces.js';
+import { DEFAULTS, saveConfig } from '../server/config.js';
+import { createTestServer } from './helpers/test-server.js';
+
+type ExecFn = NonNullable<WorkspaceDeps['execAsync']>;
+type ExecResult = { stdout: string; stderr: string };
+
+let tmpDir = '';
+let configPath = '';
+let gitRepoPath = '';
+let nonGitPath = '';
+
+beforeEach(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'workspaces-routes-test-'));
+  configPath = path.join(tmpDir, 'config.json');
+  gitRepoPath = path.join(tmpDir, 'git-repo');
+  nonGitPath = path.join(tmpDir, 'non-git');
+  fs.mkdirSync(gitRepoPath, { recursive: true });
+  fs.mkdirSync(nonGitPath, { recursive: true });
+  saveConfig(configPath, { ...DEFAULTS, repos: [gitRepoPath, nonGitPath] });
+});
+
+afterAll(() => {
+  if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeExec(gitDir: string): ExecFn {
+  // Simulates: git rev-parse --git-dir succeeds for gitDir, fails for others
+  return async (file: string, args: string[], opts?: { cwd?: string }) => {
+    if (file === 'git' && args[0] === 'rev-parse' && args[1] === '--git-dir') {
+      if (opts?.cwd === gitDir) {
+        return { stdout: '.git', stderr: '' } as ExecResult;
+      }
+      throw new Error('not a git repository');
+    }
+    if (file === 'git' && args[0] === 'symbolic-ref') {
+      if (opts?.cwd === gitDir) {
+        return { stdout: 'main\n', stderr: '' } as ExecResult;
+      }
+      throw new Error('not a git repository');
+    }
+    if (file === 'git' && args[0] === 'remote') {
+      if (opts?.cwd === gitDir) {
+        return { stdout: '', stderr: '' } as ExecResult;
+      }
+      throw new Error('not a git repository');
+    }
+    return { stdout: '', stderr: '' } as ExecResult;
+  };
+}
+
+async function makeApp(exec: ExecFn) {
+  const app = express();
+  app.use(express.json());
+  app.use('/workspaces', createWorkspaceRouter({ configPath, execAsync: exec }));
+  return app;
+}
+
+describe('GET /workspaces — kind field', () => {
+  it('returns kind: "repo" for a git-initialized path and kind: "directory" for a non-git path', async () => {
+    const exec = makeExec(gitRepoPath);
+    const app = await makeApp(exec);
+    const server = await createTestServer(app);
+    try {
+      const res = await fetch(`${server.url}/workspaces`);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { workspaces: Array<{ path: string; kind?: string; isGitRepo: boolean }> };
+      const git = data.workspaces.find((w) => w.path === gitRepoPath);
+      const dir = data.workspaces.find((w) => w.path === nonGitPath);
+
+      expect(git).toBeDefined();
+      expect(git?.isGitRepo).toBe(true);
+      expect(git?.kind).toBe('repo');
+
+      expect(dir).toBeDefined();
+      expect(dir?.isGitRepo).toBe(false);
+      expect(dir?.kind).toBe('directory');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('GET /workspaces/dashboard — NOT_GIT guard', () => {
+  it('returns 400 with code NOT_GIT for a non-git configured path', async () => {
+    const exec = makeExec(gitRepoPath);
+    const app = await makeApp(exec);
+    const server = await createTestServer(app);
+    try {
+      const params = new URLSearchParams({ path: nonGitPath });
+      const res = await fetch(`${server.url}/workspaces/dashboard?${params}`);
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string; code: string };
+      expect(body.code).toBe('NOT_GIT');
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('does not return 400 for a git-configured path (falls through to auth/data fetch)', async () => {
+    const exec = makeExec(gitRepoPath);
+    const app = await makeApp(exec);
+    const server = await createTestServer(app);
+    try {
+      const params = new URLSearchParams({ path: gitRepoPath });
+      const res = await fetch(`${server.url}/workspaces/dashboard?${params}`);
+      // dashboard will return 200 or some valid response (gh not authenticated etc)
+      // What it must NOT return is 400 with NOT_GIT
+      const body = (await res.json()) as { code?: string };
+      expect(body.code).not.toBe('NOT_GIT');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('POST /workspaces/branch — NOT_GIT guard', () => {
+  it('returns 400 with code NOT_GIT for a non-git path', async () => {
+    const exec = makeExec(gitRepoPath);
+    const app = await makeApp(exec);
+    const server = await createTestServer(app);
+    try {
+      const params = new URLSearchParams({ path: nonGitPath });
+      const res = await fetch(`${server.url}/workspaces/branch?${params}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ branch: 'main' }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe('NOT_GIT');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('POST /workspaces/worktree — NOT_GIT guard', () => {
+  it('returns 400 with code NOT_GIT for a non-git path', async () => {
+    const exec = makeExec(gitRepoPath);
+    const app = await makeApp(exec);
+    const server = await createTestServer(app);
+    try {
+      const params = new URLSearchParams({ path: nonGitPath });
+      const res = await fetch(`${server.url}/workspaces/worktree?${params}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe('NOT_GIT');
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe('GET /workspaces/current-branch — NOT_GIT guard', () => {
+  it('returns 400 with code NOT_GIT for a non-git path', async () => {
+    const exec = makeExec(gitRepoPath);
+    const app = await makeApp(exec);
+    const server = await createTestServer(app);
+    try {
+      const params = new URLSearchParams({ path: nonGitPath });
+      const res = await fetch(`${server.url}/workspaces/current-branch?${params}`);
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe('NOT_GIT');
+    } finally {
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #591. Closes the dogfood gap surfaced on `dev.fish-rattlesnake.ts.net`: the UI was repo-first, plain terminals on remote nodes were gated by the selected agent's availability, and non-git directories had no first-class home in the workspace model. Refs #444, #473.

Two commits:
1. **`e3e49ee3` feat(#591)** — implements the four planned changes (copy refresh, terminal eligibility decoupling, non-git Project entity, node-first add + Active Work tab chrome).
2. **`6672bd15` fixup(#591)** — folds in code-reviewer + silent-failure-hunter findings before review (silent failures, version-skew regression, parser double-decode).

## What changed

- **Copy.** Empty state / Sidebar / AddWorkspaceDialog / CustomizeSessionDialog drop "add repo" / "repo identity" / "coding agent" anchor framing; use project + working-directory + host language.
- **Terminal eligibility.** `nodeBlockReason()` in `CustomizeSessionDialog` split into `nodeShellBlockReason` (status + version + shell + tmux) and `nodeAgentBlockReason` (composes shell, adds agent capability). `buildEnvironmentPickerModel` takes `sessionType: 'agent' | 'terminal'`. Plain terminal node picker no longer disabled by agent availability.
- **Non-git Project entity.** `ProjectIdentity` gains `'directory'` variant; `Repo` gains `kind?: 'repo' | 'directory'`. `GET /workspaces` surfaces the kind; git-only handlers in `server/workspaces.ts` early-return 400 `NOT_GIT` via `requireGitRepo`. `validateSessionCreateRequest` accepts `{ type: 'terminal', cwd }` against any configured project path.
- **Node-first add flow.** AddWorkspaceDialog restructured to host → path → optional save-as-project. Remote paths submit as `POST /hub/nodes/:nodeId/sessions { type: 'terminal', cwd }`. Remote file browse stays explicit "unavailable until file rpc lands" (#428).
- **Agent | terminal toggle** in CustomizeSessionDialog; terminal mode hides agent/continue/yolo, forces `pty`, emits `{ type: 'terminal' }`.
- **Active Work chrome.** Directory-kind anchor reads `<node> · <cwd> · directory`; repo-kind unchanged. PrTopBar gated on `activeWorkspace?.kind === 'repo'`.
- **Fixup pass.**
  - `parseProjectId` directory double-decode fixed; round-trip tests pin colon/percent payloads.
  - `requireGitRepo`/`detectGitRepo` now distinguish infra failures (500 `GIT_UNAVAILABLE`, 403 `PATH_DENIED`) from legit non-git (400 `NOT_GIT`).
  - `RepoDashboard` "+ open terminal" surfaces creating/error state instead of `void`-ing the promise.
  - `fetchDashboard` catches `NOT_GIT` and synthesizes `{ isGitRepo: false, prs: [], ... }` so the non-git dashboard branch is reachable.
  - `AddWorkspaceDialog`: bare-catch captures err.message; `fetchHubNodes` `.catch`; partial-success failures surfaced inline and dialog stays open.
  - `PrTopBar` `.catch` silences expected `NOT_GIT`, logs the rest.
  - `nodeShellBlockReason` version-state branch restored (`incompatible` / `version-skew` block in both terminal and agent modes); tests reverted to pin BLOCKED behavior.
  - `.repo-kind-chip` CSS added (matches TUI tokens).

Routed-PTY backend untouched (`hub-node-router.ts`, `node-link-rpc-host.ts`, `sessions.ts`) — recent #583/#585/#587/#588 risk surface preserved.

## Test plan

Local: `npm run build` clean, `npm run check` 0 errors, `npm test` 2424 passed / 0 failed.

New test coverage:
- `test/customize-session-dialog.test.ts` — terminal vs agent eligibility; agent/terminal mode toggle; version-state block in both modes.
- `test/components/TerminalNodePicker.test.ts` — hermes-unavailable does not block terminal picker; version-skew + incompatible still blocked.
- `test/active-work-surface.test.ts` (new) — directory anchor format vs repo anchor format.
- `test/sessions-create-validation.test.ts` (new) — terminal+cwd accepted; agent+no-repoPath rejected; terminal+unconfigured rejected; all-undefined fails closed.
- `test/workspaces-routes.test.ts` (new) — `GET /workspaces` `kind` decoration; NOT_GIT 400 on `/dashboard`, `/branch`, `/worktree`, `/current-branch`, `/divergence`, `/changed-files`, `/file-diff`.
- `test/view-spine-identity.test.ts` — directory ProjectId round-trip with colons / `%20` / `%2F`; malformed → null; no collision with `node` kind.

## Deploy + dogfood QA (post-merge)

Per `docs/references/devbox-hub-deploy.md`:

- [ ] Merge to `nightly` → `@nightly` publishes.
- [ ] Source-deploy devbox hub (`ssh dev`, `git pull --ff-only origin nightly`, `scripts/dev-resync.sh`, restart service, verify version).
- [ ] No node restart required (no node-link protocol changes; routed-PTY plumbing untouched).
- [ ] `/browse` QA against `http://dev.fish-rattlesnake.ts.net:3456`:
  - Sidebar empty CTA reads `+ add project`.
  - Add-workspace dialog is host-first; `local` / `macbook-relay-node` / `wsl` selectable when online.
  - WSL terminal from `/home/donovan`: `pwd` + `whoami` match.
  - Mac terminal from `/Users/donovanyohan`: `pwd` matches.
  - Hermes selected on agent picker does not disable `wsl` for the terminal picker.
  - `macbook-relay-node` + Codex agent works; `macbook-relay-node` + Claude shows unavailable with precise reason.
  - Non-git directory added on `local` persists across reload; sidebar shows `dir` chip; RepoDashboard shows non-git chrome with `+ open terminal` only.
  - Active Work shows `wsl · /home/donovan · directory` for the terminal and `repo donovan-yohan/relay-ide` for the agent session.
- [ ] Mobile viewport spot-check (Tailscale on phone) — AddWorkspaceDialog host picker + FileBrowser stack stays under 100dvh; flagged by C4 subagent for later confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)