### PR TITLE
feat: session durability state model + transition emission (#617)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,33 +24,34 @@ Relay Agentic Development Environment — a hub/node web workspace for AI coding
 
 ## Documentation Map
 
-| Category         | Path                                   | When to look here                                                                              |
-| ---------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| Docs index       | `docs/README.md`                       | Current source-of-truth docs vs historical plans/spikes                                        |
-| Architecture     | `docs/ARCHITECTURE.md`                 | Module boundaries, data flow, API routes, ADR rules                                            |
-| Workbench        | `docs/WORKBENCH_BOUNDARY.md`           | Relay product boundary, #552 nouns, mobile/pair/dogfood acceptance                             |
-| Visual Design    | `DESIGN.md`                            | Product framing, TUI aesthetic, colors, spacing, buttons                                       |
-| Design           | `docs/DESIGN.md`                       | Backend patterns, auth flow, PTY management, session types                                     |
-| Frontend         | `docs/FRONTEND.md`                     | React 19 components, state management (Zustand + TanStack Query)                               |
-| Quality          | `docs/QUALITY.md`                      | Test runner, test files, isolation patterns                                                    |
-| Review           | `docs/REVIEW_GUIDANCE.md`              | Review agent config, question bank, escape log                                                 |
-| Deployment       | `docs/references/deployment.md`        | Publishing + branching (nightly/master + tags)                                                 |
-| Devbox deploy    | `docs/references/devbox-hub-deploy.md` | Shared devbox hub deploy, Mac node-link restart, verification evidence, process hygiene        |
-| Dogfood recovery | `docs/references/dogfood-recovery.md`  | Relay-develops-Relay proof loop, recovery, diagnostics, no-force-merge gate                    |
-| Self-hosting     | `docs/SELF_HOSTING.md`                 | Build Relay with Relay using isolated dev config/ports/tmux                                    |
-| Security policy  | `docs/SECURITY_POLICY.md`              | Trust tiers, capability bits, hub ACL defaults, manifest-vs-policy boundary                    |
-| Hub/node pkg     | `docs/RELAY_HUB_NODE_PACKAGING.md`     | Hub vs node command shape, npm package decision, install/update commands                       |
-| Node bootstrap   | `docs/RELAY_NODE_BOOTSTRAP.md`         | Pair/install/update/unpair nodes for federated Relay, bootstrap diagnostics                    |
-| WSL2 nodes       | `docs/WSL2_RELAY_NODE_SUPPORT.md`      | Windows/WSL2 node bootstrap, service mode, known limits                                        |
-| Federated dev    | `docs/FEDERATED_DEV.md`                | Cross-machine dev workflow: synced git checkouts, `dev:node`, version skew                     |
-| Federated Relay  | `docs/federated-relay.md`              | Hub/node architecture, pairing, routing, ADRs                                                  |
-| CLI gateway      | `docs/CLI_GATEWAY.md`                  | Versioned `relay-ide v1 ... --json` contract for external agent adapters                       |
-| Web chat         | `docs/WEB_CHAT.md`                     | Experimental adapter-shaped web chat surface for agent CLIs (status, scope, limits)            |
-| Provider guide   | `docs/provider-guide.md`               | Authoring/configuring agent framework providers (Claude/Codex/OpenCode/Hermes/custom)          |
-| ADRs             | `docs/adrs/`                           | Accepted ADRs (latest: ADR-015 core primitives, ADR-016 node isolation, ADR-017 brain-as-peer) |
-| Learnings        | `docs/LEARNINGS.md`                    | Persistent cross-session learnings                                                             |
-| Project skills   | `.chalk/skills/<name>/SKILL.md`        | Repo-local skills (see §Skills)                                                                |
-| Work tracking    | GitHub Issues                          | `donovan-yohan/relay-ide` — use `/ticket` or `gh issue`                                        |
+| Category           | Path                                   | When to look here                                                                              |
+| ------------------ | -------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Docs index         | `docs/README.md`                       | Current source-of-truth docs vs historical plans/spikes                                        |
+| Architecture       | `docs/ARCHITECTURE.md`                 | Module boundaries, data flow, API routes, ADR rules                                            |
+| Workbench          | `docs/WORKBENCH_BOUNDARY.md`           | Relay product boundary, #552 nouns, mobile/pair/dogfood acceptance                             |
+| Visual Design      | `DESIGN.md`                            | Product framing, TUI aesthetic, colors, spacing, buttons                                       |
+| Design             | `docs/DESIGN.md`                       | Backend patterns, auth flow, PTY management, session types                                     |
+| Frontend           | `docs/FRONTEND.md`                     | React 19 components, state management (Zustand + TanStack Query)                               |
+| Quality            | `docs/QUALITY.md`                      | Test runner, test files, isolation patterns                                                    |
+| Review             | `docs/REVIEW_GUIDANCE.md`              | Review agent config, question bank, escape log                                                 |
+| Deployment         | `docs/references/deployment.md`        | Publishing + branching (nightly/master + tags)                                                 |
+| Devbox deploy      | `docs/references/devbox-hub-deploy.md` | Shared devbox hub deploy, Mac node-link restart, verification evidence, process hygiene        |
+| Dogfood recovery   | `docs/references/dogfood-recovery.md`  | Relay-develops-Relay proof loop, recovery, diagnostics, no-force-merge gate                    |
+| Self-hosting       | `docs/SELF_HOSTING.md`                 | Build Relay with Relay using isolated dev config/ports/tmux                                    |
+| Security policy    | `docs/SECURITY_POLICY.md`              | Trust tiers, capability bits, hub ACL defaults, manifest-vs-policy boundary                    |
+| Session durability | `docs/SESSION_DURABILITY.md`           | Process-owner vs attach-handle, derived durability state machine, transition emission          |
+| Hub/node pkg       | `docs/RELAY_HUB_NODE_PACKAGING.md`     | Hub vs node command shape, npm package decision, install/update commands                       |
+| Node bootstrap     | `docs/RELAY_NODE_BOOTSTRAP.md`         | Pair/install/update/unpair nodes for federated Relay, bootstrap diagnostics                    |
+| WSL2 nodes         | `docs/WSL2_RELAY_NODE_SUPPORT.md`      | Windows/WSL2 node bootstrap, service mode, known limits                                        |
+| Federated dev      | `docs/FEDERATED_DEV.md`                | Cross-machine dev workflow: synced git checkouts, `dev:node`, version skew                     |
+| Federated Relay    | `docs/federated-relay.md`              | Hub/node architecture, pairing, routing, ADRs                                                  |
+| CLI gateway        | `docs/CLI_GATEWAY.md`                  | Versioned `relay-ide v1 ... --json` contract for external agent adapters                       |
+| Web chat           | `docs/WEB_CHAT.md`                     | Experimental adapter-shaped web chat surface for agent CLIs (status, scope, limits)            |
+| Provider guide     | `docs/provider-guide.md`               | Authoring/configuring agent framework providers (Claude/Codex/OpenCode/Hermes/custom)          |
+| ADRs               | `docs/adrs/`                           | Accepted ADRs (latest: ADR-015 core primitives, ADR-016 node isolation, ADR-017 brain-as-peer) |
+| Learnings          | `docs/LEARNINGS.md`                    | Persistent cross-session learnings                                                             |
+| Project skills     | `.chalk/skills/<name>/SKILL.md`        | Repo-local skills (see §Skills)                                                                |
+| Work tracking      | GitHub Issues                          | `donovan-yohan/relay-ide` — use `/ticket` or `gh issue`                                        |
 
 ## Product Vocabulary
 

--- a/docs/SESSION_DURABILITY.md
+++ b/docs/SESSION_DURABILITY.md
@@ -1,0 +1,58 @@
+# Session Durability
+
+Tracks #614. This document explains the Relay session's process-ownership model
+and the derived durability state machine added in the first epic slice.
+
+## Process owner vs attach handle
+
+A Relay session is owned by a node (PTY/tmux process or attached web runtime).
+Browser tabs and hub sockets are **attach handles**, not process owners.
+Closing a tab does not kill a session; killing a session requires an explicit
+`kill` call that goes through the registry. Agents and operators should treat
+"detach" as cheap and "kill" as load-bearing.
+
+This boundary makes durable sessions feel reliable when a laptop sleeps, a
+browser tab closes, a phone attaches later, or a node link flaps.
+
+## Derived durability state
+
+`shared/session-durability.ts` exposes a closed enum:
+
+| State               | When                                                                       |
+| ------------------- | -------------------------------------------------------------------------- |
+| `running-attached`  | Process alive, hub/node link healthy, at least one attach handle.          |
+| `running-detached`  | Process alive, no live attach handle (or coarse `status` reports so).      |
+| `awaiting-start`    | Session created but has not produced output yet (`initializing` + `idle`). |
+| `stale-node`        | Hub cannot prove the owning node is healthy (`stale`/`offline`/`revoked`). |
+| `ended`             | PTY process was reaped and cleanup ran; nothing to reattach to.            |
+| `error`             | Agent state reports an error condition.                                    |
+| `permission-needed` | Interactive prompt waiting for an operator.                                |
+
+Derivation lives in `deriveSessionDurability(input)`. It is a pure function;
+priority order is documented in the source. `stale-node` is checked first
+because hub-side node link health overrides any cached local process signal:
+we cannot prove a process is still alive on an unreachable node.
+
+The existing `SessionSummary.status: 'active' | 'disconnected'` is unchanged
+for backward compatibility. New consumers reasoning about reattach safety
+should prefer `summary.durability`.
+
+## Transition emission
+
+`sessions.onSessionDurabilityChanged(cb)` registers a listener that fires
+whenever a session's derived durability differs from the last value emitted
+for that session. Each event carries `{ sessionId, from, to, at }`. `ws.ts`
+subscribes and broadcasts `session-durability-changed` over the existing
+event stream so frontend/CLI gateway consumers can observe transitions
+without polling.
+
+`sessions.list()` calls the change-detection helper on every iteration; the
+helper only fires when the derived state actually differs, so a steady-state
+session does not emit on every list call.
+
+## Out of scope (later #614 slices)
+
+- Reconnect UX badges (slice 3).
+- Bounded replay buffer redesign (slice 2).
+- Per-node/per-connection/per-session durability config knobs (slice 4).
+- Live process migration. No raw infinite transcript storage.

--- a/server/index.ts
+++ b/server/index.ts
@@ -847,13 +847,20 @@ export function validateSessionCreateRequest(
   const sessionType = type ?? 'agent';
   if (sessionType === 'agent') {
     if (!repoPath || !configured.has(repoPath)) {
-      res.status(400).json({ error: 'repoPath is required for agent sessions' });
+      res
+        .status(400)
+        .json({ error: 'repoPath is required for agent sessions' });
       return false;
     }
   } else {
     const anchor = repoPath ?? cwd ?? '';
     if (!configured.has(anchor)) {
-      res.status(400).json({ error: 'terminal sessions require a cwd that is a configured project path' });
+      res
+        .status(400)
+        .json({
+          error:
+            'terminal sessions require a cwd that is a configured project path',
+        });
       return false;
     }
   }
@@ -1628,6 +1635,33 @@ async function main(): Promise<void> {
   rebuildRefWatcher();
   sessions.onSessionCreate(() => rebuildRefWatcher());
   sessions.onSessionEnd(() => rebuildRefWatcher());
+
+  // Wire session durability (#614) to hub-side node link health:
+  //   resolver maps a session's owning nodeId to the hub's view of that
+  //   node's connection state, so derivation can surface `stale-node`
+  //   without bothering local-only sessions.
+  sessions.setSessionNodeStatusResolver((nodeId) => {
+    if (!nodeId || nodeId === 'local') return null;
+    const node = hubNodeRegistry
+      .listNodes()
+      .find((candidate) => candidate.nodeId === nodeId);
+    if (!node) return null;
+    const status = node.status;
+    if (
+      status === 'online' ||
+      status === 'stale' ||
+      status === 'offline' ||
+      status === 'revoked'
+    ) {
+      return status;
+    }
+    return null;
+  });
+  hubNodeRegistry.onNodeStatus(() => {
+    // Node status changed — re-derive every session so attach-safety
+    // consumers see `stale-node` transitions without waiting on `list()`.
+    sessions.refreshDurability();
+  });
 
   // Configure session defaults for hooks injection (startup-only — changing these requires restart)
   sessions.configure(

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -58,6 +58,10 @@ import { buildSessionEvent } from './session-attribution.js';
 import { createLogger } from './logger.js';
 import type { SessionLane } from '../shared/session-lane.js';
 import {
+  deriveSessionDurability,
+  type SessionDurabilityState,
+} from '../shared/session-durability.js';
+import {
   isControlStateSummary,
   normalizeControlStateSummary,
   type ControlStateSummary,
@@ -457,6 +461,48 @@ export function fireStateChange(sessionId: string, state: AgentState): void {
   for (const cb of [...stateChangeCallbacks]) cb(sessionId, state);
 }
 
+type DurabilityChangeCallback = (event: {
+  sessionId: string;
+  from: SessionDurabilityState | undefined;
+  to: SessionDurabilityState;
+  at: string;
+}) => void;
+const durabilityChangeCallbacks: DurabilityChangeCallback[] = [];
+
+function onSessionDurabilityChanged(cb: DurabilityChangeCallback): () => void {
+  durabilityChangeCallbacks.push(cb);
+  return () => {
+    const idx = durabilityChangeCallbacks.indexOf(cb);
+    if (idx >= 0) durabilityChangeCallbacks.splice(idx, 1);
+  };
+}
+
+function emitDurabilityIfChanged(session: Session): SessionDurabilityState {
+  const next = deriveSessionDurability({
+    status: session.status,
+    agentState: session.agentState,
+    idle: session.idle,
+    ...(session.mode === 'pty' && session.cleanedUp ? { cleanedUp: true } : {}),
+  });
+  const previous = session._lastEmittedDurability;
+  if (previous === next) return next;
+  session._lastEmittedDurability = next;
+  const event = {
+    sessionId: session.id,
+    from: previous,
+    to: next,
+    at: new Date().toISOString(),
+  };
+  for (const cb of [...durabilityChangeCallbacks]) {
+    try {
+      cb(event);
+    } catch (err) {
+      logger.error('durabilityChange callback error:', err);
+    }
+  }
+  return next;
+}
+
 export function computeBackendState(session: {
   agentState: AgentState;
   idle: boolean;
@@ -683,6 +729,7 @@ function renew(input: {
 function list(): SessionSummary[] {
   const summaries = Array.from(sessions.values())
     .map((s): SessionSummary => {
+      const durability = emitDurabilityIfChanged(s);
       const summary = withLocalIdentity({
         id: s.id,
         type: s.type,
@@ -701,6 +748,7 @@ function list(): SessionSummary[] {
         idle: s.idle,
         customCommand: s.customCommand,
         status: s.status,
+        durability,
         needsBranchRename: !!s.needsBranchRename,
         agentState: s.agentState,
         currentActivity: s.currentActivity,
@@ -2134,6 +2182,7 @@ export {
   onStateChange,
   onSessionCreate,
   onSessionEnd,
+  onSessionDurabilityChanged,
   nextTerminalName,
   nextAgentName,
   serializeAll,

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -59,6 +59,7 @@ import { createLogger } from './logger.js';
 import type { SessionLane } from '../shared/session-lane.js';
 import {
   deriveSessionDurability,
+  type SessionDurabilityNodeStatus,
   type SessionDurabilityState,
 } from '../shared/session-durability.js';
 import {
@@ -459,6 +460,11 @@ function fireSessionEnd(
 
 export function fireStateChange(sessionId: string, state: AgentState): void {
   for (const cb of [...stateChangeCallbacks]) cb(sessionId, state);
+  // Push durability transitions through the live state-change channel so
+  // event-stream consumers see `permission-needed` / `error` / etc. without
+  // waiting for the next `list()` poll.
+  const session = sessions.get(sessionId);
+  if (session) emitDurabilityIfChanged(session);
 }
 
 type DurabilityChangeCallback = (event: {
@@ -477,11 +483,39 @@ function onSessionDurabilityChanged(cb: DurabilityChangeCallback): () => void {
   };
 }
 
+// Resolver for hub-side node link health. Composition root wires this to
+// `hubNodeRegistry`; defaults to `null` so unit tests and the local-only
+// path do not need to think about it. Returning `null` means "no hub-side
+// opinion" and trusts local signals.
+type SessionNodeStatusResolver = (
+  nodeId: string | undefined
+) => SessionDurabilityNodeStatus;
+let nodeStatusResolver: SessionNodeStatusResolver = () => null;
+
+function setSessionNodeStatusResolver(
+  resolver: SessionNodeStatusResolver | null
+): void {
+  nodeStatusResolver = resolver ?? (() => null);
+}
+
+function resolveNodeStatus(session: Session): SessionDurabilityNodeStatus {
+  try {
+    return nodeStatusResolver(session.nodeId ?? undefined);
+  } catch (err) {
+    logger.warn(
+      'session node status resolver threw; treating as no-opinion: %s',
+      err instanceof Error ? err.message : String(err)
+    );
+    return null;
+  }
+}
+
 function emitDurabilityIfChanged(session: Session): SessionDurabilityState {
   const next = deriveSessionDurability({
     status: session.status,
     agentState: session.agentState,
     idle: session.idle,
+    nodeStatus: resolveNodeStatus(session),
     ...(session.mode === 'pty' && session.cleanedUp ? { cleanedUp: true } : {}),
   });
   const previous = session._lastEmittedDurability;
@@ -501,6 +535,19 @@ function emitDurabilityIfChanged(session: Session): SessionDurabilityState {
     }
   }
   return next;
+}
+
+/**
+ * Re-derive durability for the named sessions (or every session when no
+ * filter is given) and emit transitions. Use this when a non-agent signal
+ * changes — e.g. node link goes stale, attach socket count crosses zero.
+ */
+function refreshDurability(sessionIds?: Iterable<string>): void {
+  const ids = sessionIds ? Array.from(sessionIds) : Array.from(sessions.keys());
+  for (const id of ids) {
+    const session = sessions.get(id);
+    if (session) emitDurabilityIfChanged(session);
+  }
 }
 
 export function computeBackendState(session: {
@@ -557,6 +604,11 @@ export function fireBackendStateIfChanged(session: Session): void {
       logger.error('backendStateChange callback error:', err);
     }
   }
+  // Backend state + status are the only inputs to durability that can flip
+  // outside the `fireStateChange` path (e.g. the resume-failure setter
+  // mutates `status` + `agentState` directly). Re-derive here so consumers
+  // see the transition over the event stream immediately.
+  emitDurabilityIfChanged(session);
 }
 
 function create({
@@ -2183,6 +2235,8 @@ export {
   onSessionCreate,
   onSessionEnd,
   onSessionDurabilityChanged,
+  setSessionNodeStatusResolver,
+  refreshDurability,
   nextTerminalName,
   nextAgentName,
   serializeAll,

--- a/server/types.ts
+++ b/server/types.ts
@@ -26,6 +26,7 @@ import type {
   ControlStateSummary,
 } from '../shared/control-state.js';
 import type { SessionEnvelope } from '../shared/session-envelope.js';
+import type { SessionDurabilityState } from '../shared/session-durability.js';
 
 export type AgentState =
   | 'initializing'
@@ -292,6 +293,7 @@ interface BaseSession {
   sessionEnvelope?: SessionEnvelope | undefined;
   _lastEmittedBackendState?: BackendDisplayState | undefined;
   _lastEmittedPermissionType?: 'approval' | 'question' | undefined;
+  _lastEmittedDurability?: SessionDurabilityState | undefined;
   lastAttentionNotifiedAt?: number | undefined;
 }
 
@@ -406,6 +408,12 @@ export interface SessionSummary {
   /** PTY sessions only */
   tmuxSessionName?: string;
   status: SessionStatus;
+  /**
+   * Derived durability state (#614). Coarse `status` stays for backward
+   * compatibility; consumers reasoning about reattach/process ownership
+   * should prefer `durability`.
+   */
+  durability?: SessionDurabilityState;
   needsBranchRename: boolean;
   agentState: AgentState;
   currentActivity?: { tool: string; detail?: string } | undefined;

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -800,6 +800,15 @@ function setupWebSocket(
     broadcastEvent('session-ended', { sessionId, cwd, branchName });
   });
 
+  sessions.onSessionDurabilityChanged((event) => {
+    broadcastEvent('session-durability-changed', {
+      sessionId: event.sessionId,
+      from: event.from,
+      to: event.to,
+      at: event.at,
+    });
+  });
+
   return { wss, broadcastEvent, broadcastBranchChanged };
 }
 

--- a/shared/session-durability.ts
+++ b/shared/session-durability.ts
@@ -1,0 +1,108 @@
+// Session durability state for #614. The Relay session is process-owned by a
+// node (PTY/tmux); browser/hub sockets are attach handles, not process owners.
+// `SessionDurabilityState` is a derived, closed enum surfaced on session
+// summaries so consumers can reason about reattach safety without poking at
+// internal handles.
+
+// Mirror the two existing typing dimensions without importing from
+// `server/types.ts`, so this module stays in the shared layer and is
+// consumable by frontend code without leaking server-only types.
+// Kept narrow on purpose: the durability derivation only reads a small
+// subset of agent-state values.
+export type SessionDurabilityStatus = 'active' | 'disconnected';
+export type SessionDurabilityAgentState =
+  | 'initializing'
+  | 'waiting-for-input'
+  | 'processing'
+  | 'permission-prompt'
+  | 'error'
+  | 'idle';
+
+export const SESSION_DURABILITY_STATES = [
+  'running-attached',
+  'running-detached',
+  'awaiting-start',
+  'stale-node',
+  'ended',
+  'error',
+  'permission-needed',
+] as const;
+
+export type SessionDurabilityState = (typeof SESSION_DURABILITY_STATES)[number];
+
+export function isSessionDurabilityState(
+  value: unknown
+): value is SessionDurabilityState {
+  return (
+    typeof value === 'string' &&
+    (SESSION_DURABILITY_STATES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Node-link health hint from the perspective of the hub. `null` means the
+ * caller does not have a hub-side opinion (e.g. a node is reporting its own
+ * sessions) and the derivation should trust local signals instead.
+ */
+export type SessionDurabilityNodeStatus =
+  | 'online'
+  | 'stale'
+  | 'offline'
+  | 'revoked'
+  | null;
+
+export interface SessionDurabilityInput {
+  /** Coarse two-state field already on every session summary. */
+  status: SessionDurabilityStatus;
+  /** Agent state machine; carries permission-prompt + error signals. */
+  agentState: SessionDurabilityAgentState;
+  /** True when the session is not actively producing/consuming. */
+  idle: boolean;
+  /** PTY sessions only — process was reaped and cleanup ran. */
+  cleanedUp?: boolean;
+  /** Hub-side view of the node link, when available. */
+  nodeStatus?: SessionDurabilityNodeStatus;
+  /** True when the session has at least one live attach handle. */
+  hasLiveAttach?: boolean;
+}
+
+/**
+ * Derive a `SessionDurabilityState` from current Relay signals. Pure function;
+ * callers handle persistence and transition emission. Closed enum: any input
+ * combination resolves to exactly one of the seven states.
+ *
+ * Priority order, top down:
+ *   1. `stale-node` — hub reports the owning node link is unhealthy. The
+ *      session may still be running locally but we cannot prove it from here.
+ *   2. `ended` — process was reaped (PTY `cleanedUp`) and there is nothing to
+ *      reattach to.
+ *   3. `error` — agent state reports an error; honored even when `status` is
+ *      still `'active'` because the error signal is more specific.
+ *   4. `permission-needed` — interactive prompt waiting for an operator.
+ *   5. `awaiting-start` — session created but has not produced output yet.
+ *   6. `running-detached` — process alive but no live attach handle.
+ *   7. `running-attached` — default for an active, attached session.
+ */
+export function deriveSessionDurability(
+  input: SessionDurabilityInput
+): SessionDurabilityState {
+  if (
+    input.nodeStatus === 'stale' ||
+    input.nodeStatus === 'offline' ||
+    input.nodeStatus === 'revoked'
+  ) {
+    return 'stale-node';
+  }
+  if (input.cleanedUp) return 'ended';
+  if (input.agentState === 'error') return 'error';
+  if (input.agentState === 'permission-prompt') return 'permission-needed';
+  if (input.agentState === 'initializing' && input.idle)
+    return 'awaiting-start';
+  if (input.status === 'disconnected') return 'running-detached';
+  // The slice 1 scope does not track per-session attach handles centrally.
+  // When a caller knows attach state explicitly (e.g. a PTY with no open
+  // browser socket), it can pass `hasLiveAttach: false` to surface
+  // `running-detached`; otherwise we trust the coarse `status` field.
+  if (input.hasLiveAttach === false) return 'running-detached';
+  return 'running-attached';
+}

--- a/test/session-durability.test.ts
+++ b/test/session-durability.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SESSION_DURABILITY_STATES,
+  deriveSessionDurability,
+  isSessionDurabilityState,
+} from '../shared/session-durability.js';
+
+describe('deriveSessionDurability', () => {
+  it('maps an active attached session to running-attached', () => {
+    expect(
+      deriveSessionDurability({
+        status: 'active',
+        agentState: 'processing',
+        idle: false,
+      })
+    ).toBe('running-attached');
+  });
+
+  it('maps disconnected to running-detached', () => {
+    expect(
+      deriveSessionDurability({
+        status: 'disconnected',
+        agentState: 'processing',
+        idle: false,
+      })
+    ).toBe('running-detached');
+  });
+
+  it('maps an active session with explicit hasLiveAttach=false to running-detached', () => {
+    expect(
+      deriveSessionDurability({
+        status: 'active',
+        agentState: 'processing',
+        idle: false,
+        hasLiveAttach: false,
+      })
+    ).toBe('running-detached');
+  });
+
+  it('maps initializing+idle to awaiting-start', () => {
+    expect(
+      deriveSessionDurability({
+        status: 'active',
+        agentState: 'initializing',
+        idle: true,
+      })
+    ).toBe('awaiting-start');
+  });
+
+  it('promotes initializing to running-attached once output is flowing', () => {
+    // `idle: false` means the session has already produced or is consuming
+    // input — the awaiting-start branch only applies while idle.
+    expect(
+      deriveSessionDurability({
+        status: 'active',
+        agentState: 'initializing',
+        idle: false,
+      })
+    ).toBe('running-attached');
+  });
+
+  it('maps permission-prompt to permission-needed regardless of status', () => {
+    expect(
+      deriveSessionDurability({
+        status: 'active',
+        agentState: 'permission-prompt',
+        idle: false,
+      })
+    ).toBe('permission-needed');
+    expect(
+      deriveSessionDurability({
+        status: 'disconnected',
+        agentState: 'permission-prompt',
+        idle: true,
+      })
+    ).toBe('permission-needed');
+  });
+
+  it('maps agentState=error to error', () => {
+    expect(
+      deriveSessionDurability({
+        status: 'active',
+        agentState: 'error',
+        idle: true,
+      })
+    ).toBe('error');
+  });
+
+  it('maps PTY cleanedUp to ended', () => {
+    expect(
+      deriveSessionDurability({
+        status: 'disconnected',
+        agentState: 'idle',
+        idle: true,
+        cleanedUp: true,
+      })
+    ).toBe('ended');
+  });
+
+  it('prefers stale-node when the hub reports the node is unhealthy', () => {
+    // Even an `active` session must surface as stale when the hub cannot
+    // prove the node is alive; the local last-known process state is not
+    // authority for reattach safety.
+    for (const status of ['stale', 'offline', 'revoked'] as const) {
+      expect(
+        deriveSessionDurability({
+          status: 'active',
+          agentState: 'processing',
+          idle: false,
+          nodeStatus: status,
+        })
+      ).toBe('stale-node');
+    }
+  });
+
+  it('does not downgrade to stale-node when nodeStatus is online or null', () => {
+    expect(
+      deriveSessionDurability({
+        status: 'active',
+        agentState: 'processing',
+        idle: false,
+        nodeStatus: 'online',
+      })
+    ).toBe('running-attached');
+    expect(
+      deriveSessionDurability({
+        status: 'active',
+        agentState: 'processing',
+        idle: false,
+        nodeStatus: null,
+      })
+    ).toBe('running-attached');
+  });
+
+  it('prioritises stale-node above ended', () => {
+    // A node we cannot reach should not be reported as `ended` from cached
+    // cleanup state — that would lie about reattach impossibility when the
+    // process may actually still be alive on the node.
+    expect(
+      deriveSessionDurability({
+        status: 'disconnected',
+        agentState: 'idle',
+        idle: true,
+        cleanedUp: true,
+        nodeStatus: 'offline',
+      })
+    ).toBe('stale-node');
+  });
+
+  it('every output is a member of the closed enum', () => {
+    const samples = [
+      deriveSessionDurability({
+        status: 'active',
+        agentState: 'processing',
+        idle: false,
+      }),
+      deriveSessionDurability({
+        status: 'disconnected',
+        agentState: 'idle',
+        idle: true,
+      }),
+      deriveSessionDurability({
+        status: 'active',
+        agentState: 'error',
+        idle: true,
+      }),
+    ];
+    for (const value of samples) {
+      expect(isSessionDurabilityState(value)).toBe(true);
+    }
+  });
+
+  it('isSessionDurabilityState rejects unknown values', () => {
+    expect(isSessionDurabilityState('running')).toBe(false);
+    expect(isSessionDurabilityState(undefined)).toBe(false);
+    expect(isSessionDurabilityState(42)).toBe(false);
+  });
+
+  it('exposes the canonical state list for consumers', () => {
+    expect(SESSION_DURABILITY_STATES).toEqual([
+      'running-attached',
+      'running-detached',
+      'awaiting-start',
+      'stale-node',
+      'ended',
+      'error',
+      'permission-needed',
+    ]);
+  });
+});

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -192,6 +192,64 @@ describe('sessions', () => {
     expect(listed).not.toHaveProperty('branchName');
   });
 
+  it('list populates durability and emits a transition event on change', () => {
+    const transitions: Array<{
+      sessionId: string;
+      from: string | undefined;
+      to: string;
+    }> = [];
+    const unsubscribe = sessions.onSessionDurabilityChanged((event) => {
+      transitions.push({
+        sessionId: event.sessionId,
+        from: event.from,
+        to: event.to,
+      });
+    });
+    try {
+      const result = sessions.create({
+        repoName: 'durability-repo',
+        repoPath: '/tmp',
+        worktreePath: null,
+        cwd: '/tmp',
+        command: '/bin/echo',
+        args: ['hi'],
+      });
+      createdIds.push(result.id);
+
+      // First list() call must populate `durability` and emit the
+      // initial transition (undefined -> running-attached).
+      let summary = sessions.list().find((session) => session.id === result.id);
+      expect(summary?.durability).toBe('running-attached');
+      const initial = transitions.filter((t) => t.sessionId === result.id);
+      expect(initial).toHaveLength(1);
+      expect(initial[0]).toMatchObject({
+        from: undefined,
+        to: 'running-attached',
+      });
+
+      // No change between calls: emit must not refire.
+      sessions.list();
+      expect(transitions.filter((t) => t.sessionId === result.id)).toHaveLength(
+        1
+      );
+
+      // Flip the underlying session to `disconnected` and recompute.
+      const session = sessions.get(result.id);
+      expect(session).toBeTruthy();
+      session!.status = 'disconnected';
+      summary = sessions.list().find((entry) => entry.id === result.id);
+      expect(summary?.durability).toBe('running-detached');
+      const after = transitions.filter((t) => t.sessionId === result.id);
+      expect(after).toHaveLength(2);
+      expect(after[1]).toMatchObject({
+        from: 'running-attached',
+        to: 'running-detached',
+      });
+    } finally {
+      unsubscribe();
+    }
+  });
+
   it('get returns session by id', () => {
     const result = sessions.create({
       repoName: 'test-repo',

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -250,6 +250,81 @@ describe('sessions', () => {
     }
   });
 
+  it('emits durability transitions pushed from fireStateChange without list()', () => {
+    const transitions: Array<{ from: string | undefined; to: string }> = [];
+    const unsubscribe = sessions.onSessionDurabilityChanged((event) => {
+      transitions.push({ from: event.from, to: event.to });
+    });
+    try {
+      const result = sessions.create({
+        repoName: 'durability-push',
+        repoPath: '/tmp',
+        worktreePath: null,
+        cwd: '/tmp',
+        command: '/bin/echo',
+        args: ['hi'],
+      });
+      createdIds.push(result.id);
+
+      // Initial list() warms `_lastEmittedDurability` so subsequent state
+      // changes have a baseline to compare against.
+      sessions.list();
+      const baselineCount = transitions.length;
+
+      const session = sessions.get(result.id);
+      expect(session).toBeTruthy();
+      session!.agentState = 'permission-prompt';
+      sessions.fireStateChange(result.id, 'permission-prompt');
+
+      // No list() call between the state change and now — the event must
+      // have fired directly from fireStateChange.
+      expect(transitions.length).toBeGreaterThan(baselineCount);
+      expect(transitions[transitions.length - 1]).toMatchObject({
+        to: 'permission-needed',
+      });
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it('surfaces stale-node when the hub reports the owning node is offline', () => {
+    const transitions: Array<{ to: string }> = [];
+    const unsubscribe = sessions.onSessionDurabilityChanged((event) => {
+      transitions.push({ to: event.to });
+    });
+    try {
+      const result = sessions.create({
+        repoName: 'durability-stale',
+        repoPath: '/tmp',
+        worktreePath: null,
+        cwd: '/tmp',
+        command: '/bin/echo',
+        args: ['hi'],
+      });
+      createdIds.push(result.id);
+
+      // Treat this session as belonging to a remote node so the resolver
+      // is consulted. Without a resolver, the field is null and the
+      // session resolves to `running-attached`.
+      const session = sessions.get(result.id);
+      session!.nodeId = 'remote-test' as typeof session.nodeId;
+
+      let reportedStatus: 'online' | 'offline' = 'online';
+      sessions.setSessionNodeStatusResolver(() => reportedStatus);
+      try {
+        sessions.list(); // emits running-attached
+        reportedStatus = 'offline';
+        sessions.refreshDurability([result.id]);
+        const last = transitions[transitions.length - 1];
+        expect(last?.to).toBe('stale-node');
+      } finally {
+        sessions.setSessionNodeStatusResolver(null);
+      }
+    } finally {
+      unsubscribe();
+    }
+  });
+
   it('get returns session by id', () => {
     const result = sessions.create({
       repoName: 'test-repo',


### PR DESCRIPTION
First slice of #614 — closed-enum `SessionDurabilityState` derived from existing session/agent/node-link signals, surfaced on `SessionSummary`, and emitted on transition. No UI surface, no replay redesign, no config knobs.

## Summary
- `shared/session-durability.ts` — seven-state enum (`running-attached | running-detached | awaiting-start | stale-node | ended | error | permission-needed`) + pure `deriveSessionDurability(input)`. Priority order documented at the helper; `stale-node` overrides cached local signals because we cannot prove a remote process is alive on an unreachable node.
- `SessionSummary.durability` added as an additive field. Existing `status: 'active' | 'disconnected'` is unchanged for backward compat.
- `sessions.onSessionDurabilityChanged(cb)` callback registry; fires only on actual per-session transitions. `sessions.list()` recomputes + emits as a side effect, cached on `_lastEmittedDurability`.
- `ws.ts` subscribes and broadcasts `session-durability-changed` over the existing event stream.
- `docs/SESSION_DURABILITY.md` — process-owner vs attach-handle model + state table. Added to `AGENTS.md` docs map.

## Test plan
- [x] `vitest run test/session-durability.test.ts` — 14 unit tests, every derive branch + priority order + closed-enum guard.
- [x] `vitest run test/sessions.test.ts` — new integration test that creates a session, asserts initial `running-attached`, flips status, asserts `running-detached`, verifies single transition event per change.
- [x] `npm run check` — 0 errors, 71 preexisting warnings.
- [x] `npm run build` — clean.
- [x] Full suite via `rtk proxy npx vitest run` — 2602 passed, 1 expected fail.
- [ ] Reviewer: confirm `stale-node` priority is correct (overrides `ended` because we cannot prove the local cleanup signal on an unreachable node).
- [ ] Reviewer: confirm additive field strategy — keeping `status: 'active' | 'disconnected'` instead of deprecating it.

Closes #617, advances #614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now include a durability state indicator (such as running, awaiting-start, ended, error, or stale) to help understand reattachment safety and session stability.
  * Real-time session durability change notifications allow clients to respond to status transitions.

* **Documentation**
  * New documentation on session durability model, reattachment behavior, and process ownership concepts.
  * Updated documentation formatting for improved readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/618?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->