### PR TITLE
feat(env): EnvironmentOption data model + capability shape (#623)

### DIFF
--- a/shared/environment-option.ts
+++ b/shared/environment-option.ts
@@ -1,0 +1,357 @@
+// EnvironmentOption (#623) — unified shape for an environment a Relay launch
+// can target. Backend + frontend share this so the environment picker (#615),
+// session-create flows, command palette, and agent contracts all agree on what
+// "where work runs" means.
+//
+// An EnvironmentOption combines:
+//   - Node identity + capability bits (from `shared/security-policy.ts`)
+//   - Optional RepoInstance (a repo checkout on that node)
+//   - Optional Bench / WorktreeInstance (a worktree inside that repo instance)
+//   - cwd + cwdMode (repo-relative, free, or explicitly outside the repo)
+//   - Freshness (fresh | stale | offline) + typed degraded reasons
+//
+// This file does NOT redefine Node, RepoInstance, or WorktreeInstance shapes
+// from `shared/work-context.ts` / `shared/repo-inventory.ts`. Those existing
+// types carry inventory state (dirty files, divergence, remotes) the picker
+// doesn't need at decision time, so we pick the minimal slice required for
+// launch context and import the canonical id helpers from `shared/identity.ts`.
+//
+// TODO(#615 follow-ons): once child issues land, prefer importing/re-exporting
+// from a single picker barrel rather than duplicating the slim summary shapes
+// here.
+
+import type {
+  NodeId,
+  RepoInstanceId,
+  WorktreeInstanceId,
+} from './identity.js';
+import {
+  isRelayCapabilityBit,
+  type RelayCapabilityBit,
+} from './security-policy.js';
+
+export const ENVIRONMENT_OPTION_SCHEMA_VERSION = 1 as const;
+
+export const ENVIRONMENT_FRESHNESS_VALUES = [
+  'fresh',
+  'stale',
+  'offline',
+] as const;
+
+export type EnvironmentFreshness = (typeof ENVIRONMENT_FRESHNESS_VALUES)[number];
+
+export const ENVIRONMENT_DEGRADED_REASONS = [
+  'node-offline',
+  'node-stale',
+  'capability-missing',
+  'repo-missing',
+  'worktree-missing',
+  'auth-failed',
+  'other',
+] as const;
+
+export type EnvironmentDegradedReasonKind =
+  (typeof ENVIRONMENT_DEGRADED_REASONS)[number];
+
+export type EnvironmentDegradedReason =
+  | { kind: 'node-offline'; lastSeenAt?: string; message?: string }
+  | { kind: 'node-stale'; lastSeenAt: string; message?: string }
+  | { kind: 'capability-missing'; capability: RelayCapabilityBit; message?: string }
+  | {
+      kind: 'repo-missing';
+      repoIdentity?: string;
+      localPath?: string;
+      message?: string;
+    }
+  | { kind: 'worktree-missing'; localPath: string; message?: string }
+  | { kind: 'auth-failed'; message: string; capability?: RelayCapabilityBit }
+  | { kind: 'other'; message: string; code?: string };
+
+/**
+ * How the cwd relates to the repo instance. The picker uses this to gate
+ * repo-only actions (#615): a "free" launch never inherits repo actions, and
+ * "explicit-outside-repo" is the user opting in to a cwd that intentionally
+ * sits outside the selected repo (e.g. a sibling vendored tree).
+ */
+export type EnvironmentCwdMode = 'repo' | 'free' | 'explicit-outside-repo';
+
+/**
+ * Display node identity for the picker. Mirrors the slim
+ * `WorkContext` `NodeRef` from `shared/work-context.ts` rather than the full
+ * `NodeManifest`, because the picker decides on identity + reachability, not
+ * probe payloads.
+ */
+export interface EnvironmentNodeSummary {
+  nodeId: NodeId;
+  kind: 'local' | 'remote';
+  displayName?: string;
+  online?: boolean;
+}
+
+/**
+ * Minimal RepoInstance slice for the picker. Field names match
+ * `RepoInventoryRepoInstance` from `shared/repo-inventory.ts` so adapter code
+ * can pluck from inventory reports without renaming.
+ */
+export interface EnvironmentRepoInstanceSummary {
+  repoInstanceId: RepoInstanceId;
+  localPath: string;
+  repoIdentity: string | null;
+  name?: string;
+  currentBranch?: string | null;
+  defaultBranch?: string | null;
+}
+
+/**
+ * Minimal Bench / WorktreeInstance slice for the picker. Field names match
+ * `RepoInventoryWorktreeInstance` from `shared/repo-inventory.ts`.
+ */
+export interface EnvironmentBenchSummary {
+  worktreeInstanceId: WorktreeInstanceId;
+  localPath: string;
+  branchName?: string | null;
+  displayName?: string;
+}
+
+export interface EnvironmentOption {
+  schemaVersion: typeof ENVIRONMENT_OPTION_SCHEMA_VERSION;
+  /**
+   * Stable id for this option in picker state. The picker may compose this
+   * from `nodeId + repoInstanceId + worktreeInstanceId`, but the shape here
+   * does not constrain the format beyond "non-empty string".
+   */
+  id: string;
+  node: EnvironmentNodeSummary;
+  /**
+   * Subset of `RELAY_CAPABILITY_BITS` advertised by this environment. The
+   * picker filters launches against required capabilities; agent contracts
+   * declare required bits and the picker hides options that don't satisfy
+   * them.
+   */
+  capabilities: RelayCapabilityBit[];
+  /**
+   * Absolute cwd on the target node where the launched session will start.
+   * If `repoInstance` is present, the invariant in `cwdMode` applies.
+   */
+  cwd: string;
+  cwdMode: EnvironmentCwdMode;
+  freshness: EnvironmentFreshness;
+  /**
+   * Present iff `freshness !== 'fresh'`. Each reason carries discriminator
+   * data the UI can render without re-querying the node.
+   */
+  degradedReasons?: EnvironmentDegradedReason[];
+  repoInstance?: EnvironmentRepoInstanceSummary;
+  /**
+   * Optional Bench / worktree inside the repo instance. Invariant: if `bench`
+   * is set, `repoInstance` MUST also be set (a Bench is always anchored to a
+   * RepoInstance per `docs/WORKBENCH_BOUNDARY.md`).
+   */
+  bench?: EnvironmentBenchSummary;
+  /**
+   * ISO timestamp the picker last refreshed this option. Used by the picker
+   * to compute staleness UI badges.
+   */
+  generatedAt: string;
+}
+
+// --- type guards --------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === 'string';
+}
+
+function isOptionalStringOrNull(value: unknown): value is string | null | undefined {
+  return value === undefined || value === null || typeof value === 'string';
+}
+
+export function isEnvironmentFreshness(
+  value: unknown
+): value is EnvironmentFreshness {
+  return (
+    typeof value === 'string' &&
+    (ENVIRONMENT_FRESHNESS_VALUES as readonly string[]).includes(value)
+  );
+}
+
+export function isEnvironmentDegradedReason(
+  value: unknown
+): value is EnvironmentDegradedReason {
+  if (!isRecord(value)) return false;
+  const kind = value.kind;
+  if (typeof kind !== 'string') return false;
+  switch (kind) {
+    case 'node-offline':
+      return (
+        isOptionalString(value.lastSeenAt) && isOptionalString(value.message)
+      );
+    case 'node-stale':
+      return hasString(value.lastSeenAt) && isOptionalString(value.message);
+    case 'capability-missing':
+      return (
+        isRelayCapabilityBit(value.capability) && isOptionalString(value.message)
+      );
+    case 'repo-missing':
+      return (
+        isOptionalString(value.repoIdentity) &&
+        isOptionalString(value.localPath) &&
+        isOptionalString(value.message)
+      );
+    case 'worktree-missing':
+      return hasString(value.localPath) && isOptionalString(value.message);
+    case 'auth-failed':
+      return (
+        hasString(value.message) &&
+        (value.capability === undefined ||
+          isRelayCapabilityBit(value.capability))
+      );
+    case 'other':
+      return hasString(value.message) && isOptionalString(value.code);
+    default:
+      return false;
+  }
+}
+
+function isEnvironmentNodeSummary(
+  value: unknown
+): value is EnvironmentNodeSummary {
+  if (!isRecord(value)) return false;
+  return (
+    hasString(value.nodeId) &&
+    (value.kind === 'local' || value.kind === 'remote') &&
+    isOptionalString(value.displayName) &&
+    (value.online === undefined || typeof value.online === 'boolean')
+  );
+}
+
+function isEnvironmentRepoInstanceSummary(
+  value: unknown
+): value is EnvironmentRepoInstanceSummary {
+  if (!isRecord(value)) return false;
+  return (
+    hasString(value.repoInstanceId) &&
+    hasString(value.localPath) &&
+    isOptionalStringOrNull(value.repoIdentity) &&
+    isOptionalString(value.name) &&
+    isOptionalStringOrNull(value.currentBranch) &&
+    isOptionalStringOrNull(value.defaultBranch)
+  );
+}
+
+function isEnvironmentBenchSummary(
+  value: unknown
+): value is EnvironmentBenchSummary {
+  if (!isRecord(value)) return false;
+  return (
+    hasString(value.worktreeInstanceId) &&
+    hasString(value.localPath) &&
+    isOptionalStringOrNull(value.branchName) &&
+    isOptionalString(value.displayName)
+  );
+}
+
+function isCwdMode(value: unknown): value is EnvironmentCwdMode {
+  return (
+    value === 'repo' || value === 'free' || value === 'explicit-outside-repo'
+  );
+}
+
+/**
+ * Determines whether `cwd` is inside the given `repoLocalPath`. Treats
+ * path-separator boundaries to avoid `/repos/relay` matching `/repos/relay-ide`.
+ */
+function isCwdInsideRepo(cwd: string, repoLocalPath: string): boolean {
+  if (cwd === repoLocalPath) return true;
+  const withSep = repoLocalPath.endsWith('/')
+    ? repoLocalPath
+    : `${repoLocalPath}/`;
+  return cwd.startsWith(withSep);
+}
+
+export function hasRepoInstance(
+  option: EnvironmentOption
+): option is EnvironmentOption & {
+  repoInstance: EnvironmentRepoInstanceSummary;
+} {
+  return option.repoInstance !== undefined;
+}
+
+export function hasBench(
+  option: EnvironmentOption
+): option is EnvironmentOption & {
+  bench: EnvironmentBenchSummary;
+  repoInstance: EnvironmentRepoInstanceSummary;
+} {
+  return option.bench !== undefined && option.repoInstance !== undefined;
+}
+
+function hasValidScalars(value: Record<string, unknown>): boolean {
+  return (
+    value.schemaVersion === ENVIRONMENT_OPTION_SCHEMA_VERSION &&
+    hasString(value.id) &&
+    isEnvironmentNodeSummary(value.node) &&
+    Array.isArray(value.capabilities) &&
+    value.capabilities.every(isRelayCapabilityBit) &&
+    hasString(value.cwd) &&
+    isCwdMode(value.cwdMode) &&
+    isEnvironmentFreshness(value.freshness) &&
+    hasString(value.generatedAt)
+  );
+}
+
+function hasValidRepoAndBench(value: Record<string, unknown>): boolean {
+  if (
+    value.repoInstance !== undefined &&
+    !isEnvironmentRepoInstanceSummary(value.repoInstance)
+  ) {
+    return false;
+  }
+  if (value.bench === undefined) return true;
+  if (!isEnvironmentBenchSummary(value.bench)) return false;
+  // Invariant: bench implies repoInstance.
+  return value.repoInstance !== undefined;
+}
+
+function hasValidCwdContainment(value: Record<string, unknown>): boolean {
+  const cwd = value.cwd as string;
+  const repoInstance = value.repoInstance as
+    | EnvironmentRepoInstanceSummary
+    | undefined;
+  const bench = value.bench as EnvironmentBenchSummary | undefined;
+  if (value.cwdMode === 'repo') {
+    if (repoInstance === undefined) return false;
+    const insideRepo = isCwdInsideRepo(cwd, repoInstance.localPath);
+    const insideBench =
+      bench !== undefined ? isCwdInsideRepo(cwd, bench.localPath) : false;
+    if (!insideRepo && !insideBench) return false;
+  }
+  if (value.cwdMode === 'free' && repoInstance !== undefined) return false;
+  return true;
+}
+
+function hasValidDegradedReasons(value: Record<string, unknown>): boolean {
+  if (value.degradedReasons === undefined) return true;
+  if (!Array.isArray(value.degradedReasons)) return false;
+  if (value.freshness === 'fresh' && value.degradedReasons.length > 0) {
+    return false;
+  }
+  return value.degradedReasons.every(isEnvironmentDegradedReason);
+}
+
+export function isEnvironmentOption(value: unknown): value is EnvironmentOption {
+  if (!isRecord(value)) return false;
+  return (
+    hasValidScalars(value) &&
+    hasValidRepoAndBench(value) &&
+    hasValidCwdContainment(value) &&
+    hasValidDegradedReasons(value)
+  );
+}

--- a/shared/environment-option.ts
+++ b/shared/environment-option.ts
@@ -239,7 +239,7 @@ function isEnvironmentRepoInstanceSummary(
   return (
     hasString(value.repoInstanceId) &&
     hasString(value.localPath) &&
-    isOptionalStringOrNull(value.repoIdentity) &&
+    (typeof value.repoIdentity === 'string' || value.repoIdentity === null) &&
     isOptionalString(value.name) &&
     isOptionalStringOrNull(value.currentBranch) &&
     isOptionalStringOrNull(value.defaultBranch)
@@ -265,15 +265,15 @@ function isCwdMode(value: unknown): value is EnvironmentCwdMode {
 }
 
 /**
- * Determines whether `cwd` is inside the given `repoLocalPath`. Treats
- * path-separator boundaries to avoid `/repos/relay` matching `/repos/relay-ide`.
+ * Determines whether `cwd` is inside the given `repoLocalPath`. Normalises a
+ * trailing slash onto both inputs so `("/foo", "/foo/")` and `("/foo/", "/foo")`
+ * both match, while preserving the path-separator boundary that prevents
+ * `/repos/relay` from matching `/repos/relay-ide`.
  */
 function isCwdInsideRepo(cwd: string, repoLocalPath: string): boolean {
-  if (cwd === repoLocalPath) return true;
-  const withSep = repoLocalPath.endsWith('/')
-    ? repoLocalPath
-    : `${repoLocalPath}/`;
-  return cwd.startsWith(withSep);
+  const r = repoLocalPath.endsWith('/') ? repoLocalPath : `${repoLocalPath}/`;
+  const c = cwd.endsWith('/') ? cwd : `${cwd}/`;
+  return c.startsWith(r);
 }
 
 export function hasRepoInstance(

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,0 +1,24 @@
+// Shared barrel — currently a minimal re-export surface for cross-cutting
+// types added during the #615 environment picker work. Existing modules are
+// still imported by direct file path elsewhere in the codebase; new shared
+// surfaces that span backend + frontend should also re-export from here so
+// the picker has one stable import path.
+
+export {
+  ENVIRONMENT_DEGRADED_REASONS,
+  ENVIRONMENT_FRESHNESS_VALUES,
+  ENVIRONMENT_OPTION_SCHEMA_VERSION,
+  hasBench,
+  hasRepoInstance,
+  isEnvironmentDegradedReason,
+  isEnvironmentFreshness,
+  isEnvironmentOption,
+  type EnvironmentBenchSummary,
+  type EnvironmentCwdMode,
+  type EnvironmentDegradedReason,
+  type EnvironmentDegradedReasonKind,
+  type EnvironmentFreshness,
+  type EnvironmentNodeSummary,
+  type EnvironmentOption,
+  type EnvironmentRepoInstanceSummary,
+} from './environment-option.js';

--- a/test/shared/environment-option.test.ts
+++ b/test/shared/environment-option.test.ts
@@ -135,6 +135,45 @@ describe('environment-option type guards', () => {
     });
     expect(isEnvironmentOption(option)).toBe(true);
   });
+
+  it('accepts cwd containment regardless of trailing-slash differences', () => {
+    // Regression: previous isCwdInsideRepo failed when repoLocalPath had a
+    // trailing slash but cwd did not (PR #634 / Gemini review).
+    const repo = baseRepoInstance('/repos/relay-ide/');
+    const option = baseOption({
+      cwd: '/repos/relay-ide',
+      cwdMode: 'repo',
+      repoInstance: repo,
+    });
+    expect(isEnvironmentOption(option)).toBe(true);
+
+    const optionInverse = baseOption({
+      cwd: '/repos/relay-ide/',
+      cwdMode: 'repo',
+      repoInstance: baseRepoInstance('/repos/relay-ide'),
+    });
+    expect(isEnvironmentOption(optionInverse)).toBe(true);
+  });
+
+  it('rejects sibling path that shares a prefix with repoLocalPath', () => {
+    const option = baseOption({
+      cwd: '/repos/relay-ide-other/src',
+      cwdMode: 'repo',
+      repoInstance: baseRepoInstance('/repos/relay-ide'),
+    });
+    expect(isEnvironmentOption(option)).toBe(false);
+  });
+
+  it('rejects repoInstance missing required repoIdentity field', () => {
+    // Regression: isOptionalStringOrNull previously accepted undefined where
+    // the interface requires string | null (PR #634 / Gemini review).
+    const repo = baseRepoInstance() as Record<string, unknown>;
+    delete repo.repoIdentity;
+    const option = baseOption({
+      repoInstance: repo as unknown as ReturnType<typeof baseRepoInstance>,
+    });
+    expect(isEnvironmentOption(option)).toBe(false);
+  });
 });
 
 describe('environment-option freshness + degraded reasons', () => {

--- a/test/shared/environment-option.test.ts
+++ b/test/shared/environment-option.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createRepoInstanceId,
+  createWorktreeInstanceId,
+  DEFAULT_LOCAL_NODE_ID,
+} from '../../shared/identity.js';
+import { RELAY_CAPABILITY_BITS } from '../../shared/security-policy.js';
+import {
+  ENVIRONMENT_DEGRADED_REASONS,
+  ENVIRONMENT_FRESHNESS_VALUES,
+  ENVIRONMENT_OPTION_SCHEMA_VERSION,
+  hasBench,
+  hasRepoInstance,
+  isEnvironmentDegradedReason,
+  isEnvironmentFreshness,
+  isEnvironmentOption,
+  type EnvironmentDegradedReason,
+  type EnvironmentFreshness,
+  type EnvironmentOption,
+} from '../../shared/environment-option.js';
+
+function baseRepoInstance(localPath = '/repos/relay-ide') {
+  return {
+    repoInstanceId: createRepoInstanceId(DEFAULT_LOCAL_NODE_ID, localPath),
+    localPath,
+    repoIdentity: 'github.com/donovan-yohan/relay-ide',
+    name: 'relay-ide',
+    currentBranch: 'nightly',
+  };
+}
+
+function baseBench(localPath = '/repos/relay-ide/.worktrees/623') {
+  return {
+    worktreeInstanceId: createWorktreeInstanceId(
+      DEFAULT_LOCAL_NODE_ID,
+      localPath
+    ),
+    localPath,
+    branchName: 'feature/623-environment-option',
+  };
+}
+
+function baseNode() {
+  return {
+    nodeId: DEFAULT_LOCAL_NODE_ID,
+    kind: 'local' as const,
+    displayName: 'this-mac',
+    online: true,
+  };
+}
+
+function baseOption(
+  overrides: Partial<EnvironmentOption> = {}
+): EnvironmentOption {
+  return {
+    schemaVersion: ENVIRONMENT_OPTION_SCHEMA_VERSION,
+    id: `env:${DEFAULT_LOCAL_NODE_ID}:/repos/relay-ide`,
+    node: baseNode(),
+    capabilities: ['session:read', 'session:create:terminal'],
+    cwd: '/repos/relay-ide',
+    cwdMode: 'repo',
+    freshness: 'fresh',
+    repoInstance: baseRepoInstance(),
+    generatedAt: '2026-05-19T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('environment-option type guards', () => {
+  it('accepts a minimal free/non-git cwd option (no repo, no bench)', () => {
+    const option = baseOption({
+      cwdMode: 'free',
+      cwd: '/tmp/scratch',
+      repoInstance: undefined,
+      bench: undefined,
+    });
+    expect(isEnvironmentOption(option)).toBe(true);
+    expect(hasRepoInstance(option)).toBe(false);
+    expect(hasBench(option)).toBe(false);
+  });
+
+  it('accepts a repo-backed option with bench', () => {
+    const option = baseOption({ bench: baseBench() });
+    expect(isEnvironmentOption(option)).toBe(true);
+    expect(hasRepoInstance(option)).toBe(true);
+    expect(hasBench(option)).toBe(true);
+  });
+
+  it('rejects non-objects, missing fields, and unknown freshness', () => {
+    expect(isEnvironmentOption(null)).toBe(false);
+    expect(isEnvironmentOption('env')).toBe(false);
+    expect(isEnvironmentOption({})).toBe(false);
+    const bad = baseOption() as unknown as Record<string, unknown>;
+    delete bad.cwd;
+    expect(isEnvironmentOption(bad)).toBe(false);
+    const badFreshness = { ...baseOption(), freshness: 'haunted' };
+    expect(isEnvironmentOption(badFreshness)).toBe(false);
+  });
+
+  it('rejects bench without repoInstance (shape invariant)', () => {
+    const option = baseOption({ bench: baseBench(), repoInstance: undefined });
+    expect(isEnvironmentOption(option)).toBe(false);
+  });
+
+  it('rejects unknown capability bits', () => {
+    const option = baseOption({
+      capabilities: ['session:read', 'session:make:sandwich' as never],
+    });
+    expect(isEnvironmentOption(option)).toBe(false);
+  });
+
+  it('enforces cwd containment when cwdMode is "repo"', () => {
+    const option = baseOption({
+      cwd: '/elsewhere/not-in-repo',
+      cwdMode: 'repo',
+    });
+    expect(isEnvironmentOption(option)).toBe(false);
+  });
+
+  it('allows cwd outside repo when cwdMode is "explicit-outside-repo"', () => {
+    const option = baseOption({
+      cwd: '/elsewhere/explicit',
+      cwdMode: 'explicit-outside-repo',
+    });
+    expect(isEnvironmentOption(option)).toBe(true);
+  });
+
+  it('allows cwd inside a bench worktree', () => {
+    const benchPath = '/repos/relay-ide/.worktrees/623';
+    const option = baseOption({
+      cwd: benchPath,
+      cwdMode: 'repo',
+      bench: baseBench(benchPath),
+    });
+    expect(isEnvironmentOption(option)).toBe(true);
+  });
+});
+
+describe('environment-option freshness + degraded reasons', () => {
+  it('freshness enum is exhaustively fresh/stale/offline', () => {
+    expect(ENVIRONMENT_FRESHNESS_VALUES).toEqual(['fresh', 'stale', 'offline']);
+    for (const value of ENVIRONMENT_FRESHNESS_VALUES) {
+      expect(isEnvironmentFreshness(value)).toBe(true);
+    }
+    expect(isEnvironmentFreshness('haunted')).toBe(false);
+    expect(isEnvironmentFreshness(undefined)).toBe(false);
+  });
+
+  it('typed switch over freshness is exhaustive (compile-time)', () => {
+    function describeFreshness(value: EnvironmentFreshness): string {
+      switch (value) {
+        case 'fresh':
+          return 'fresh';
+        case 'stale':
+          return 'stale';
+        case 'offline':
+          return 'offline';
+        default: {
+          const exhaustive: never = value;
+          return exhaustive;
+        }
+      }
+    }
+    expect(describeFreshness('fresh')).toBe('fresh');
+    expect(describeFreshness('stale')).toBe('stale');
+    expect(describeFreshness('offline')).toBe('offline');
+  });
+
+  it('degraded reason discriminator covers every known variant', () => {
+    const expectedKinds = new Set([
+      'node-offline',
+      'node-stale',
+      'capability-missing',
+      'repo-missing',
+      'worktree-missing',
+      'auth-failed',
+      'other',
+    ]);
+    expect(new Set(ENVIRONMENT_DEGRADED_REASONS)).toEqual(expectedKinds);
+
+    function describeReason(reason: EnvironmentDegradedReason): string {
+      switch (reason.kind) {
+        case 'node-offline':
+          return `offline since ${reason.lastSeenAt ?? 'unknown'}`;
+        case 'node-stale':
+          return `stale since ${reason.lastSeenAt}`;
+        case 'capability-missing':
+          return `missing ${reason.capability}`;
+        case 'repo-missing':
+          return `repo ${reason.repoIdentity ?? reason.localPath} missing`;
+        case 'worktree-missing':
+          return `worktree ${reason.localPath} missing`;
+        case 'auth-failed':
+          return `auth failed: ${reason.message}`;
+        case 'other':
+          return `other: ${reason.message}`;
+        default: {
+          const exhaustive: never = reason;
+          return exhaustive;
+        }
+      }
+    }
+
+    expect(
+      describeReason({ kind: 'capability-missing', capability: 'rpc:git:read' })
+    ).toBe('missing rpc:git:read');
+    expect(
+      describeReason({
+        kind: 'node-offline',
+        lastSeenAt: '2026-05-19T00:00:00.000Z',
+      })
+    ).toContain('offline');
+    expect(
+      describeReason({
+        kind: 'worktree-missing',
+        localPath: '/missing',
+      })
+    ).toContain('worktree');
+  });
+
+  it('isEnvironmentDegradedReason recognizes each kind', () => {
+    expect(
+      isEnvironmentDegradedReason({
+        kind: 'capability-missing',
+        capability: 'session:read',
+      })
+    ).toBe(true);
+    expect(isEnvironmentDegradedReason({ kind: 'unknown' })).toBe(false);
+    expect(isEnvironmentDegradedReason(null)).toBe(false);
+    expect(
+      isEnvironmentDegradedReason({
+        kind: 'capability-missing',
+        capability: 'not-a-bit',
+      })
+    ).toBe(false);
+  });
+
+  it('attaches degradedReasons array on stale/offline options', () => {
+    const option = baseOption({
+      freshness: 'stale',
+      degradedReasons: [
+        { kind: 'node-stale', lastSeenAt: '2026-05-18T00:00:00.000Z' },
+        { kind: 'capability-missing', capability: 'rpc:git:write' },
+      ],
+    });
+    expect(isEnvironmentOption(option)).toBe(true);
+  });
+
+  it('rejects degradedReasons when freshness is fresh', () => {
+    const option = baseOption({
+      freshness: 'fresh',
+      degradedReasons: [{ kind: 'node-stale', lastSeenAt: 'x' }],
+    });
+    expect(isEnvironmentOption(option)).toBe(false);
+  });
+});
+
+describe('environment-option capability bit coverage', () => {
+  it('every known capability bit in security-policy is representable', () => {
+    for (const bit of RELAY_CAPABILITY_BITS) {
+      const option = baseOption({ capabilities: [bit] });
+      expect(isEnvironmentOption(option)).toBe(true);
+    }
+  });
+});
+
+describe('environment-option JSON round trip', () => {
+  it('preserves every field and discriminant through JSON', () => {
+    const option = baseOption({
+      bench: baseBench(),
+      cwd: '/repos/relay-ide/.worktrees/623',
+      freshness: 'stale',
+      degradedReasons: [
+        { kind: 'node-stale', lastSeenAt: '2026-05-18T00:00:00.000Z' },
+        { kind: 'capability-missing', capability: 'rpc:git:write' },
+        { kind: 'auth-failed', message: 'token expired' },
+      ],
+    });
+    const round = JSON.parse(JSON.stringify(option)) as unknown;
+    expect(isEnvironmentOption(round)).toBe(true);
+    expect(round).toEqual(option);
+  });
+
+  it('rejects shape with rogue extra discriminator after round trip', () => {
+    const option = baseOption();
+    const round = JSON.parse(JSON.stringify(option)) as Record<string, unknown>;
+    round.freshness = 'sometimes';
+    expect(isEnvironmentOption(round)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Scope

Adds the `EnvironmentOption` shared type plus supporting enums for the environment picker work in epic #615. Backend-only; no UI wiring. No existing shapes were redefined — `Node`, `RepoInstance`, and `WorktreeInstance` slices use the id helpers from `shared/identity.ts` and the canonical capability bits from `shared/security-policy.ts`.

Refs parent: #615.

## Exported types

From `shared/environment-option.ts` (also re-exported via new `shared/index.ts` barrel):

- `EnvironmentOption`
- `EnvironmentNodeSummary`
- `EnvironmentRepoInstanceSummary`
- `EnvironmentBenchSummary`
- `EnvironmentCwdMode` (`'repo' | 'free' | 'explicit-outside-repo'`)
- `EnvironmentFreshness` (`'fresh' | 'stale' | 'offline'`)
- `EnvironmentDegradedReason` (discriminated union: `node-offline`, `node-stale`, `capability-missing`, `repo-missing`, `worktree-missing`, `auth-failed`, `other`)
- `EnvironmentDegradedReasonKind`
- Constants: `ENVIRONMENT_OPTION_SCHEMA_VERSION`, `ENVIRONMENT_FRESHNESS_VALUES`, `ENVIRONMENT_DEGRADED_REASONS`
- Type guards: `isEnvironmentOption`, `isEnvironmentFreshness`, `isEnvironmentDegradedReason`, `hasRepoInstance`, `hasBench`

## Shape invariants enforced by `isEnvironmentOption`

- `bench` present implies `repoInstance` present (Bench is anchored to a RepoInstance per `docs/WORKBENCH_BOUNDARY.md`).
- `cwdMode === 'repo'` requires `repoInstance` and `cwd` must be inside the repo localPath or an attached bench localPath.
- `cwdMode === 'free'` forbids `repoInstance` (free/non-git cwd never inherits repo actions per epic #615 acceptance criteria).
- `degradedReasons` only allowed when `freshness !== 'fresh'`.
- Every capability bit must be a member of `RELAY_CAPABILITY_BITS`.

## Tests

`test/shared/environment-option.test.ts` — 17 cases:

- Type guards accept free, repo-only, and repo+bench shapes
- Type guards reject missing fields, unknown freshness, bench-without-repo, unknown capabilities, cwd outside repo in `repo` mode
- `explicit-outside-repo` opt-out flag works
- `EnvironmentFreshness` exhaustive switch (TS exhaustiveness via `never`)
- `EnvironmentDegradedReason` exhaustive switch over every variant
- Every bit in `RELAY_CAPABILITY_BITS` is representable
- JSON `stringify`/`parse` round-trip preserves all fields and discriminants
- Rogue discriminator injection rejected post round-trip

## Test plan

- [x] `npm run check` clean (0 errors; pre-existing warnings only)
- [x] `npm test` — 2399/2399 passing
- [x] Tests added before implementation; failing-then-passing confirmed