### PR TITLE
hotfix(#427): detectGitRepo classifies ENOENT cwd as not-a-repo, not missing binary

### DIFF
--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -441,25 +441,39 @@ export async function detectGitRepo(
   dirPath: string,
   execAsync: typeof execFileAsync = execFileAsync
 ): Promise<{ isGitRepo: boolean; defaultBranch: string | null }> {
+  // Check path exists before spawning git. ENOENT from spawn fires for BOTH
+  // a missing git binary AND a missing cwd, with no way to tell them apart
+  // from the error fields alone. Validate the cwd up front so any subsequent
+  // ENOENT unambiguously means the binary is missing.
+  try {
+    const stat = await fs.promises.stat(dirPath);
+    if (!stat.isDirectory()) {
+      return { isGitRepo: false, defaultBranch: null };
+    }
+  } catch (statErr: unknown) {
+    const e = statErr as NodeJS.ErrnoException;
+    if (e.code === 'ENOENT') {
+      // Path was removed since it was configured; treat as non-git-repo so
+      // bulk re-validation at startup doesn't crash on stale config entries.
+      return { isGitRepo: false, defaultBranch: null };
+    }
+    if (e.code === 'EACCES') {
+      throw new PathInaccessibleError(dirPath);
+    }
+    const message = statErr instanceof Error ? statErr.message : String(statErr);
+    logger.warn('detectGitRepo: stat failed for', dirPath, message);
+    throw new GitInfraError(message);
+  }
+
   try {
     await execAsync('git', ['rev-parse', '--git-dir'], { cwd: dirPath });
   } catch (err: unknown) {
     const e = err as NodeJS.ErrnoException & { stderr?: string; code?: string | number };
 
-    // ENOENT can mean the git binary is missing OR the cwd path doesn't exist.
-    // Distinguish: if the error message/path references the git binary itself
-    // (spawn error with no stderr), it's a missing binary.
+    // ENOENT after the stat check above means the git binary itself is missing
+    // (the cwd was verified to exist as a directory).
     if (e.code === 'ENOENT') {
-      // A spawn failure for the binary has no stderr; a missing-directory
-      // failure from git has stderr containing "not a git repository" or
-      // similar. If there is no stderr at all, treat it as binary missing.
-      const hasStderr = typeof e.stderr === 'string' && e.stderr.trim().length > 0;
-      if (!hasStderr) {
-        throw new GitBinaryMissingError();
-      }
-      // cwd path does not exist — treat as not-a-git-repo (path existence
-      // validated upstream by validateWorkspacePath; here we return gracefully).
-      return { isGitRepo: false, defaultBranch: null };
+      throw new GitBinaryMissingError();
     }
 
     if (e.code === 'EACCES') {

--- a/test/detect-git-repo.test.ts
+++ b/test/detect-git-repo.test.ts
@@ -1,0 +1,127 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  detectGitRepo,
+  GitBinaryMissingError,
+  PathInaccessibleError,
+} from '../server/workspaces.js';
+
+type ExecLike = (
+  file: string,
+  args: readonly string[],
+  options?: { cwd?: string }
+) => Promise<{ stdout: string; stderr: string }>;
+
+function gitExit128(): NodeJS.ErrnoException & { stderr: string } {
+  const err = new Error(
+    'Command failed: git rev-parse --git-dir\nfatal: not a git repository (or any of the parent directories): .git'
+  ) as NodeJS.ErrnoException & { stderr: string };
+  err.code = 128;
+  err.stderr =
+    'fatal: not a git repository (or any of the parent directories): .git\n';
+  return err;
+}
+
+function spawnEnoent(): NodeJS.ErrnoException & { stderr?: string } {
+  const err = new Error(
+    'spawn git ENOENT'
+  ) as NodeJS.ErrnoException & { stderr?: string };
+  err.code = 'ENOENT';
+  err.syscall = 'spawn git';
+  err.stderr = '';
+  return err;
+}
+
+let tmpDir = '';
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-detect-git-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('detectGitRepo — path-aware ENOENT classification', () => {
+  it('returns { isGitRepo: false } when the path does not exist (no git invoked)', async () => {
+    let gitCalled = false;
+    const exec: ExecLike = async () => {
+      gitCalled = true;
+      return { stdout: '', stderr: '' };
+    };
+    const result = await detectGitRepo(
+      path.join(tmpDir, 'does-not-exist'),
+      exec as never
+    );
+    expect(result).toEqual({ isGitRepo: false, defaultBranch: null });
+    expect(gitCalled).toBe(false);
+  });
+
+  it('returns { isGitRepo: false } when the path is a regular file', async () => {
+    const filePath = path.join(tmpDir, 'a-file');
+    fs.writeFileSync(filePath, 'not a directory');
+    let gitCalled = false;
+    const exec: ExecLike = async () => {
+      gitCalled = true;
+      return { stdout: '', stderr: '' };
+    };
+    const result = await detectGitRepo(filePath, exec as never);
+    expect(result).toEqual({ isGitRepo: false, defaultBranch: null });
+    expect(gitCalled).toBe(false);
+  });
+
+  it('throws GitBinaryMissingError when path exists but git binary is missing', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'real-dir'));
+    const exec: ExecLike = async () => {
+      throw spawnEnoent();
+    };
+    await expect(
+      detectGitRepo(path.join(tmpDir, 'real-dir'), exec as never)
+    ).rejects.toBeInstanceOf(GitBinaryMissingError);
+  });
+
+  it('returns { isGitRepo: false } for git exit 128 on a real directory', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'real-dir'));
+    const exec: ExecLike = async () => {
+      throw gitExit128();
+    };
+    const result = await detectGitRepo(
+      path.join(tmpDir, 'real-dir'),
+      exec as never
+    );
+    expect(result).toEqual({ isGitRepo: false, defaultBranch: null });
+  });
+
+  it('throws PathInaccessibleError when stat fails with EACCES', async () => {
+    // Simulate EACCES on the directory access by passing a path that triggers
+    // a permission-style error via a custom exec; but stat happens first.
+    // We can't easily reproduce a real EACCES portably, so this test focuses
+    // on the fall-through path: a directory that exists where git itself
+    // errors with EACCES (e.g. policy denies execve).
+    fs.mkdirSync(path.join(tmpDir, 'real-dir'));
+    const exec: ExecLike = async () => {
+      const err = new Error('git EACCES') as NodeJS.ErrnoException;
+      err.code = 'EACCES';
+      throw err;
+    };
+    await expect(
+      detectGitRepo(path.join(tmpDir, 'real-dir'), exec as never)
+    ).rejects.toBeInstanceOf(PathInaccessibleError);
+  });
+
+  it('returns { isGitRepo: true } for a real git repository', async () => {
+    const repoDir = path.join(tmpDir, 'real-repo');
+    fs.mkdirSync(repoDir);
+    const exec: ExecLike = async (_file, args, opts) => {
+      expect(args).toEqual(['rev-parse', '--git-dir']);
+      expect(opts?.cwd).toBe(repoDir);
+      return { stdout: '.git\n', stderr: '' };
+    };
+    const result = await detectGitRepo(repoDir, exec as never);
+    expect(result.isGitRepo).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Regression from #635 (Sprint 2 wrap-up). The new `detectGitRepo` infra-error classification threw `GitBinaryMissingError` on `spawn git ENOENT`. ENOENT from `execFile('git', ..., { cwd })` fires for BOTH a missing git binary AND a missing/inaccessible cwd; the error fields don't disambiguate. Old code collapsed everything to `{ isGitRepo: false }` (masked infra errors). New code regressed the stale-config case.

**Observed on `dev.fish-rattlesnake.ts.net`** right after the #635 source-deploy: a stale `/tmp/qa-591-nongit` entry left over from earlier QA caused the hub to crash-loop because `addWorkspacesBulk` re-validates `config.repos` on startup, hit ENOENT on the gone path, threw `GitBinaryMissingError`, and exited.

## Fix

`fs.stat` the cwd up front in `detectGitRepo`:
- Path doesn't exist or isn't a directory → return `{ isGitRepo: false }` immediately, do not spawn git.
- EACCES on stat → `PathInaccessibleError`.
- Stat succeeds → spawn git as before. Any ENOENT after the stat check unambiguously means the binary is missing → `GitBinaryMissingError`. Git exit 128 → `{ isGitRepo: false }`. EACCES from git → `PathInaccessibleError`. Anything else → `GitInfraError`.

## Tests

New `test/detect-git-repo.test.ts` (6 cases):
- non-existent path → `{ isGitRepo: false }`, git NOT invoked
- regular file (not directory) → `{ isGitRepo: false }`, git NOT invoked
- real directory + missing git binary → `GitBinaryMissingError`
- real directory + git exit 128 → `{ isGitRepo: false }`
- EACCES from git → `PathInaccessibleError`
- real git repo (exec returns ok) → `{ isGitRepo: true }`

## Verification

- `npm run build`: clean
- `npm run check`: 0 errors
- `npm test`: 239 files, 2675 passed, 1 expected fail, 0 failed
- Manually unblocked devbox in parallel (config scrubbed + service restart); hub `/health` returns ok.

## Risk

- Adds one `fs.stat` per `detectGitRepo` call. Cheap (microseconds) compared to the git spawn. No behavior change for valid paths.
- Routed-PTY backend untouched.

Refs #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)