### PR TITLE
feat(env): RepoIdentity normalization + cross-node aggregation (#624)

### DIFF
--- a/server/features/repo-router.ts
+++ b/server/features/repo-router.ts
@@ -90,7 +90,11 @@ export function createRepoFeatureRouter(
       if (options.collectLocalRepoInventory) {
         reports.push(await options.collectLocalRepoInventory());
       }
-      res.json(repoInventoryFeature.aggregateInventoryReports(reports));
+      // Both /hub/repo-inventory and /hub/repo-groups honour the router's
+      // `options.now` injection point so `generatedAt` is deterministic in
+      // tests and consistent between the two endpoints (Copilot review on
+      // PR #639).
+      res.json(repoInventoryFeature.aggregateInventoryReports(reports, now()));
     } catch (error) {
       sendRegistryError(registry, res, error);
     }

--- a/server/features/repo-router.ts
+++ b/server/features/repo-router.ts
@@ -30,7 +30,10 @@ import {
   type SessionCreateType,
 } from '../hub-policy-evaluator.js';
 import type { RepoInventoryFeature } from './repo-inventory.js';
-import type { RepoInventoryReport } from '../../shared/repo-inventory.js';
+import {
+  summarizeRepoIdentityGroups,
+  type RepoInventoryReport,
+} from '../../shared/repo-inventory.js';
 import {
   expiresAtFromLifecycleInput,
   lifecycleInputError,
@@ -66,7 +69,8 @@ function sessionCreateTypeFromBody(body: Record<string, unknown>): SessionCreate
 // repo-agnostic.
 //
 // Endpoints:
-// - GET  /hub/repo-inventory                      → aggregate repo inventory across nodes
+// - GET  /hub/repo-inventory                      → aggregate repo inventory across nodes (full payload)
+// - GET  /hub/repo-groups                         → slim cross-node project groups keyed by RepoIdentity (#624)
 // - POST /hub/nodes/:nodeId/sessions/reopen       → cold-reopen a session on a target node from inventory state
 //
 // Pure routing (pairing, heartbeat, node list/lifecycle, direct
@@ -87,6 +91,24 @@ export function createRepoFeatureRouter(
         reports.push(await options.collectLocalRepoInventory());
       }
       res.json(repoInventoryFeature.aggregateInventoryReports(reports));
+    } catch (error) {
+      sendRegistryError(registry, res, error);
+    }
+  });
+
+  // GET /hub/repo-groups (#624): lightweight read of cross-node project
+  // groups keyed by canonical RepoIdentity. Drops dirty/divergence/worktree
+  // payloads so the picker (#615) and external agents can dedupe "same repo
+  // on N nodes" without paying for full inventory bytes. Non-git or
+  // remote-less checkouts surface as `repoIdentity === null` groups
+  // (graceful absence, not an error per #624 AC).
+  router.get('/hub/repo-groups', requireAuth, async (_req, res) => {
+    try {
+      const reports = [...repoInventoryFeature.listInventoryReports()];
+      if (options.collectLocalRepoInventory) {
+        reports.push(await options.collectLocalRepoInventory());
+      }
+      res.json(summarizeRepoIdentityGroups(reports, now()));
     } catch (error) {
       sendRegistryError(registry, res, error);
     }

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -22,3 +22,28 @@ export {
   type EnvironmentOption,
   type EnvironmentRepoInstanceSummary,
 } from './environment-option.js';
+
+export {
+  normalizeRemoteUrl,
+  resolveCanonicalRepoIdentity,
+  type CanonicalRepoIdentityResolution,
+  type NormalizedRemoteIdentity,
+  type RemoteDescriptor,
+  type RemoteProvider,
+  type RepoIdentityWarning,
+  type ResolvedRemoteIdentity,
+} from './repo-identity.js';
+
+export {
+  aggregateRepoInventoryReports,
+  isRepoInventoryReport,
+  summarizeRepoIdentityGroups,
+  type AggregatedRepoInventoryGroup,
+  type AggregatedRepoInventoryResponse,
+  type RepoIdentityGroup,
+  type RepoIdentityGroupInstance,
+  type RepoIdentityGroupsResponse,
+  type RepoInventoryRepoInstance,
+  type RepoInventoryReport,
+  type RepoInventoryWorktreeInstance,
+} from './repo-inventory.js';

--- a/shared/repo-inventory.ts
+++ b/shared/repo-inventory.ts
@@ -89,6 +89,50 @@ export interface AggregatedRepoInventoryResponse {
   reports: RepoInventoryReport[];
 }
 
+/**
+ * Slim per-node coordinates inside a `RepoIdentityGroup`. Mirrors the picker
+ * slice in `shared/environment-option.ts` (`EnvironmentRepoInstanceSummary`)
+ * so the environment picker (#615) can construct options directly from a
+ * group without re-reading full inventory.
+ *
+ * `localPath` is intentionally node-local: per epic #615 / ADR-016 we never
+ * treat absolute paths as global identity, only as the cwd inside their
+ * owning node.
+ */
+export interface RepoIdentityGroupInstance {
+  nodeId: NodeId;
+  repoInstanceId: RepoInstanceId;
+  localPath: string;
+  currentBranch: string | null;
+  defaultBranch: string | null;
+}
+
+/**
+ * Cross-node project grouping keyed by canonical `RepoIdentity`. Lightweight
+ * read shape exposed by `GET /hub/repo-groups`: just enough for the
+ * environment picker (#615) and external agents to dedupe "same logical
+ * repo on N nodes" without paying for the full per-instance inventory
+ * payload returned by `GET /hub/repo-inventory`.
+ *
+ * `repoIdentity` is canonical and stable (see `shared/repo-identity.ts`):
+ *   - github.com remotes normalise to `github.com/owner/repo` (lower-cased)
+ *   - other hosts preserve case in path but lower-case the host
+ *   - non-git or remote-less checkouts land in `unidentified` groups
+ */
+export interface RepoIdentityGroup {
+  repoIdentity: RepoIdentity | null;
+  displayName: string;
+  instanceCount: number;
+  nodeIds: NodeId[];
+  instances: RepoIdentityGroupInstance[];
+  warnings: RepoIdentityWarning[];
+}
+
+export interface RepoIdentityGroupsResponse {
+  generatedAt: string;
+  groups: RepoIdentityGroup[];
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -248,4 +292,39 @@ export function aggregateRepoInventoryReports(
     groups,
     reports,
   };
+}
+
+/**
+ * Build the slim `RepoIdentityGroup[]` view used by the environment picker
+ * (#615) and the `GET /hub/repo-groups` endpoint. Drops dirty/divergence
+ * payloads and worktrees, preserving only the cross-node identity coordinates
+ * a picker needs at decision time.
+ *
+ * Grouping rules:
+ * - Repos with a canonical `repoIdentity` collapse into one group regardless
+ *   of node-local path or remote URL form (https vs ssh vs git@).
+ * - Repos with `repoIdentity === null` (non-git cwd, missing remotes, or
+ *   malformed remote URLs) each get their own group keyed by repoInstanceId.
+ *   This is graceful absence, not an error — matches issue #624 AC.
+ */
+export function summarizeRepoIdentityGroups(
+  reports: RepoInventoryReport[],
+  now: Date = new Date()
+): RepoIdentityGroupsResponse {
+  const aggregated = aggregateRepoInventoryReports(reports, now);
+  const groups: RepoIdentityGroup[] = aggregated.groups.map((group) => ({
+    repoIdentity: group.repoIdentity,
+    displayName: group.displayName,
+    instanceCount: group.identityDebug.instanceCount,
+    nodeIds: group.identityDebug.nodeIds,
+    instances: group.instances.map((instance) => ({
+      nodeId: instance.nodeId,
+      repoInstanceId: instance.repoInstanceId,
+      localPath: instance.localPath,
+      currentBranch: instance.currentBranch,
+      defaultBranch: instance.defaultBranch,
+    })),
+    warnings: group.warnings,
+  }));
+  return { generatedAt: aggregated.generatedAt, groups };
 }

--- a/shared/repo-inventory.ts
+++ b/shared/repo-inventory.ts
@@ -90,10 +90,14 @@ export interface AggregatedRepoInventoryResponse {
 }
 
 /**
- * Slim per-node coordinates inside a `RepoIdentityGroup`. Mirrors the picker
- * slice in `shared/environment-option.ts` (`EnvironmentRepoInstanceSummary`)
- * so the environment picker (#615) can construct options directly from a
- * group without re-reading full inventory.
+ * Slim per-node coordinates inside a `RepoIdentityGroup`. Carries the
+ * per-instance fields the environment picker (#615) needs after it has
+ * already selected a group: `repoIdentity` lives on the parent group (so
+ * we don't repeat it per instance), and `nodeId` is added here because a
+ * single group spans N nodes. Compare with `EnvironmentRepoInstanceSummary`
+ * in `shared/environment-option.ts` — that type carries `repoIdentity`
+ * (because it stands alone outside any group) and omits `nodeId` (because
+ * its `EnvironmentOption` parent already pins the node).
  *
  * `localPath` is intentionally node-local: per epic #615 / ADR-016 we never
  * treat absolute paths as global identity, only as the cwd inside their

--- a/test/server/repo-aggregation.test.ts
+++ b/test/server/repo-aggregation.test.ts
@@ -1,0 +1,468 @@
+// #624 server-level aggregation coverage. Pairs with the shared-layer
+// normalizer tests in test/shared/repo-identity.test.ts.
+//
+// Scope:
+//   - aggregateRepoInventoryReports / summarizeRepoIdentityGroups collapse
+//     N nodes with the same canonical RepoIdentity into one group while
+//     preserving node-local paths;
+//   - non-git inventory entries (repoIdentity === null) are returned as
+//     graceful "unidentified" groups, not errors;
+//   - GET /hub/repo-groups exposes the slim grouped shape and refuses
+//     unauthenticated callers.
+
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import express from 'express';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { createHubNodeRegistry } from '../../server/hub-node-registry.js';
+import {
+  createRepoInventoryFeature,
+} from '../../server/features/repo-inventory.js';
+import { createRepoFeatureRouter } from '../../server/features/repo-router.js';
+import {
+  aggregateRepoInventoryReports,
+  summarizeRepoIdentityGroups,
+  type RepoInventoryRepoInstance,
+  type RepoInventoryReport,
+} from '../../shared/repo-inventory.js';
+import {
+  normalizeRemoteUrl,
+  type ResolvedRemoteIdentity,
+} from '../../shared/repo-identity.js';
+import type { NodeManifest } from '../../shared/node-manifest.js';
+
+function resolvedRemote(name: string, url: string): ResolvedRemoteIdentity {
+  const normalized = normalizeRemoteUrl(url);
+  return {
+    name,
+    url,
+    identity: normalized.identity,
+    provider: normalized.provider,
+    host: normalized.host,
+    path: normalized.path,
+    owner: normalized.owner,
+    repoName: normalized.name,
+    ...(normalized.warning ? { warning: normalized.warning } : {}),
+  };
+}
+
+function repoInstance(
+  overrides: Partial<RepoInventoryRepoInstance> & {
+    nodeId: string;
+    localPath: string;
+  }
+): RepoInventoryRepoInstance {
+  const remote = overrides.selectedRemote ??
+    resolvedRemote('origin', 'git@github.com:donovan-yohan/relay-ide.git');
+  return {
+    repoInstanceId:
+      overrides.repoInstanceId ??
+      `${overrides.nodeId}:${encodeURIComponent(overrides.localPath)}`,
+    nodeId: overrides.nodeId,
+    localPath: overrides.localPath,
+    name: overrides.name ?? 'relay-ide',
+    isGitRepo: overrides.isGitRepo ?? true,
+    defaultBranch: overrides.defaultBranch ?? 'nightly',
+    currentBranch: overrides.currentBranch ?? 'nightly',
+    repoIdentity:
+      'repoIdentity' in overrides ? overrides.repoIdentity ?? null : remote.identity,
+    selectedRemote: 'selectedRemote' in overrides ? overrides.selectedRemote ?? null : remote,
+    remotes: overrides.remotes ?? (remote.identity ? [remote] : []),
+    repoIdentityWarnings: overrides.repoIdentityWarnings ?? [],
+    worktrees: overrides.worktrees ?? [],
+    reportedAt: overrides.reportedAt ?? '2026-05-19T00:00:00.000Z',
+  };
+}
+
+function inventoryReport(
+  nodeId: string,
+  repos: RepoInventoryRepoInstance[]
+): RepoInventoryReport {
+  return {
+    nodeId,
+    generatedAt: '2026-05-19T00:00:00.000Z',
+    repos,
+  };
+}
+
+describe('aggregateRepoInventoryReports (#624 backend grouping)', () => {
+  it('collapses two nodes with the same RepoIdentity but different local paths into one group', () => {
+    const macRemote = resolvedRemote(
+      'origin',
+      'git@github.com:donovan-yohan/relay-ide.git'
+    );
+    const linuxRemote = resolvedRemote(
+      'origin',
+      'https://github.com/donovan-yohan/relay-ide.git'
+    );
+    const result = aggregateRepoInventoryReports([
+      inventoryReport('macbook', [
+        repoInstance({
+          nodeId: 'macbook',
+          localPath: '/Users/kyle/dev/relay-ide',
+          selectedRemote: macRemote,
+          remotes: [macRemote],
+        }),
+      ]),
+      inventoryReport('linux-box', [
+        repoInstance({
+          nodeId: 'linux-box',
+          localPath: '/srv/repos/relay-ide',
+          selectedRemote: linuxRemote,
+          remotes: [linuxRemote],
+        }),
+      ]),
+    ]);
+    expect(result.groups).toHaveLength(1);
+    const [group] = result.groups;
+    expect(group?.repoIdentity).toBe('github.com/donovan-yohan/relay-ide');
+    expect(group?.identityDebug.instanceCount).toBe(2);
+    expect(group?.identityDebug.nodeIds.sort()).toEqual(
+      ['linux-box', 'macbook']
+    );
+    expect(group?.instances.map((i) => [i.nodeId, i.localPath])).toEqual([
+      ['linux-box', '/srv/repos/relay-ide'],
+      ['macbook', '/Users/kyle/dev/relay-ide'],
+    ]);
+  });
+
+  it('returns a graceful unidentified group for non-git cwds (absence, not error)', () => {
+    expect(() =>
+      aggregateRepoInventoryReports([
+        inventoryReport('macbook', [
+          repoInstance({
+            nodeId: 'macbook',
+            localPath: '/Users/kyle/scratch',
+            name: 'scratch',
+            isGitRepo: false,
+            defaultBranch: null,
+            currentBranch: null,
+            repoIdentity: null,
+            selectedRemote: null,
+            remotes: [],
+          }),
+        ]),
+      ])
+    ).not.toThrow();
+    const result = aggregateRepoInventoryReports([
+      inventoryReport('macbook', [
+        repoInstance({
+          nodeId: 'macbook',
+          localPath: '/Users/kyle/scratch',
+          name: 'scratch',
+          isGitRepo: false,
+          defaultBranch: null,
+          currentBranch: null,
+          repoIdentity: null,
+          selectedRemote: null,
+          remotes: [],
+        }),
+      ]),
+    ]);
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]?.repoIdentity).toBeNull();
+    expect(result.groups[0]?.identityDebug.groupedBy).toBe('repoInstanceId');
+  });
+});
+
+describe('summarizeRepoIdentityGroups (#624 slim view)', () => {
+  it('returns the same grouping shape as the full aggregator without dirty/worktree payloads', () => {
+    const linuxRemote = resolvedRemote(
+      'origin',
+      'https://github.com/donovan-yohan/relay-ide.git'
+    );
+    const result = summarizeRepoIdentityGroups([
+      inventoryReport('macbook', [
+        repoInstance({
+          nodeId: 'macbook',
+          localPath: '/Users/kyle/dev/relay-ide',
+          worktrees: [
+            {
+              worktreeInstanceId:
+                'macbook:%2FUsers%2Fkyle%2Fdev%2Frelay-ide%2F.worktrees%2Fa',
+              localPath: '/Users/kyle/dev/relay-ide/.worktrees/a',
+              branchName: 'feature/a',
+            },
+          ],
+        }),
+      ]),
+      inventoryReport('linux-box', [
+        repoInstance({
+          nodeId: 'linux-box',
+          localPath: '/srv/repos/relay-ide',
+          selectedRemote: linuxRemote,
+          remotes: [linuxRemote],
+        }),
+      ]),
+    ]);
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]?.repoIdentity).toBe(
+      'github.com/donovan-yohan/relay-ide'
+    );
+    expect(result.groups[0]?.nodeIds.sort()).toEqual([
+      'linux-box',
+      'macbook',
+    ]);
+    expect(result.groups[0]?.instances).toEqual([
+      {
+        nodeId: 'linux-box',
+        repoInstanceId: 'linux-box:%2Fsrv%2Frepos%2Frelay-ide',
+        localPath: '/srv/repos/relay-ide',
+        currentBranch: 'nightly',
+        defaultBranch: 'nightly',
+      },
+      {
+        nodeId: 'macbook',
+        repoInstanceId: 'macbook:%2FUsers%2Fkyle%2Fdev%2Frelay-ide',
+        localPath: '/Users/kyle/dev/relay-ide',
+        currentBranch: 'nightly',
+        defaultBranch: 'nightly',
+      },
+    ]);
+    // Slim shape must not carry dirty / worktrees / divergence fields per
+    // RepoIdentityGroupInstance contract — guard against future drift.
+    for (const instance of result.groups[0]?.instances ?? []) {
+      expect(instance).not.toHaveProperty('worktrees');
+      expect(instance).not.toHaveProperty('dirty');
+      expect(instance).not.toHaveProperty('divergence');
+    }
+  });
+
+  it('keeps unidentified groups visible (non-git cwd absence, not error)', () => {
+    const result = summarizeRepoIdentityGroups([
+      inventoryReport('macbook', [
+        repoInstance({
+          nodeId: 'macbook',
+          localPath: '/Users/kyle/scratch',
+          name: 'scratch',
+          isGitRepo: false,
+          defaultBranch: null,
+          currentBranch: null,
+          repoIdentity: null,
+          selectedRemote: null,
+          remotes: [],
+        }),
+      ]),
+    ]);
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]?.repoIdentity).toBeNull();
+    expect(result.groups[0]?.instanceCount).toBe(1);
+    expect(result.groups[0]?.instances[0]?.localPath).toBe(
+      '/Users/kyle/scratch'
+    );
+  });
+
+  it('round-trips the slim response through JSON without dropping fields', () => {
+    const original = summarizeRepoIdentityGroups([
+      inventoryReport('macbook', [
+        repoInstance({ nodeId: 'macbook', localPath: '/repo' }),
+      ]),
+    ]);
+    expect(JSON.parse(JSON.stringify(original))).toEqual(original);
+  });
+});
+
+describe('GET /hub/repo-groups (#624 endpoint)', () => {
+  const cleanup: Array<() => Promise<void> | void> = [];
+
+  function listen(server: http.Server): Promise<number> {
+    return new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address();
+        if (typeof address !== 'object' || address === null) {
+          throw new Error('listen did not return an address');
+        }
+        resolve(address.port);
+      });
+    });
+  }
+
+  function close(server: http.Server): Promise<void> {
+    return new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+
+  function manifest(): NodeManifest {
+    return {
+      schemaVersion: 1,
+      platform: 'linux',
+      arch: 'x64',
+      hostname: 'repo-groups-host',
+      relayVersion: '0.1.0-test',
+      generatedAt: '2026-05-19T00:00:00.000Z',
+      wsl: { detected: false, version: null, systemd: false },
+      serviceManager: {
+        kind: 'systemd-user',
+        label: 'systemd user',
+        supported: true,
+        installable: true,
+        installHint: 'install',
+        uninstallHint: 'uninstall',
+        message: 'ok',
+      },
+      capabilities: {
+        tmux: { status: 'available', message: 'tmux 3.4' },
+        git: { status: 'available', message: 'git 2.45.0' },
+        clipboard: { status: 'available', message: 'pbcopy' },
+        browserAutomation: { status: 'available', message: 'playwright ok' },
+        githubCli: { status: 'available', message: 'gh 2.51' },
+        tailscale: { status: 'available', message: 'tailscale 1.62' },
+        ssh: { status: 'available', message: 'OpenSSH 9.7' },
+        agents: {},
+      },
+    };
+  }
+
+  beforeEach(() => {
+    cleanup.length = 0;
+  });
+
+  afterEach(async () => {
+    while (cleanup.length > 0) await cleanup.pop()?.();
+  });
+
+  async function bootHub(): Promise<{
+    base: string;
+    nodeIds: string[];
+    tokens: string[];
+  }> {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-repo-groups-')
+    );
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const registry = createHubNodeRegistry({
+      storagePath: path.join(tmpDir, 'nodes.json'),
+      now: () => new Date('2026-05-19T00:00:00.000Z'),
+    });
+    const feature = createRepoInventoryFeature(registry);
+    const app = express();
+    app.use(express.json());
+    const requireAuth: express.RequestHandler = (req, res, next) => {
+      if (req.headers['x-test-auth'] === 'yes') {
+        next();
+        return;
+      }
+      res.status(401).json({ error: 'Unauthorized' });
+    };
+    app.use(
+      createRepoFeatureRouter({
+        registry,
+        requireAuth,
+        repoInventoryFeature: feature,
+        // Inject a synthetic "local" inventory for the hub node itself so
+        // the endpoint exercises the cross-node aggregation path.
+        collectLocalRepoInventory: async () =>
+          inventoryReport('hub-local', [
+            repoInstance({
+              nodeId: 'hub-local',
+              localPath: '/var/relay/relay-ide',
+            }),
+          ]),
+        now: () => new Date('2026-05-19T00:00:00.000Z'),
+      })
+    );
+    const server = http.createServer(app);
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+
+    const nodeIds: string[] = [];
+    const tokens: string[] = [];
+    for (const _ of [0, 1]) {
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      nodeIds.push(exchanged.node.nodeId);
+      tokens.push(exchanged.credential.token);
+    }
+
+    // First paired node: same RepoIdentity, different local path
+    registry.recordHeartbeat({
+      nodeId: nodeIds[0]!,
+      protocolVersion: '1.0',
+      repoInventory: inventoryReport(nodeIds[0]!, [
+        repoInstance({
+          nodeId: nodeIds[0]!,
+          localPath: '/Users/kyle/dev/relay-ide',
+          selectedRemote: resolvedRemote(
+            'origin',
+            'git@github.com:donovan-yohan/relay-ide.git'
+          ),
+          remotes: [
+            resolvedRemote(
+              'origin',
+              'git@github.com:donovan-yohan/relay-ide.git'
+            ),
+          ],
+        }),
+      ]),
+    });
+    // Second paired node: non-git cwd, should land as a separate
+    // unidentified group (graceful absence, not error).
+    registry.recordHeartbeat({
+      nodeId: nodeIds[1]!,
+      protocolVersion: '1.0',
+      repoInventory: inventoryReport(nodeIds[1]!, [
+        repoInstance({
+          nodeId: nodeIds[1]!,
+          localPath: '/srv/scratch',
+          name: 'scratch',
+          isGitRepo: false,
+          defaultBranch: null,
+          currentBranch: null,
+          repoIdentity: null,
+          selectedRemote: null,
+          remotes: [],
+        }),
+      ]),
+    });
+
+    return { base: `http://127.0.0.1:${port}`, nodeIds, tokens };
+  }
+
+  it('refuses unauthenticated callers', async () => {
+    const { base } = await bootHub();
+    const response = await fetch(`${base}/hub/repo-groups`);
+    expect(response.status).toBe(401);
+  });
+
+  it('returns one cross-node group for the same RepoIdentity and a separate unidentified group', async () => {
+    const { base, nodeIds } = await bootHub();
+    const response = await fetch(`${base}/hub/repo-groups`, {
+      headers: { 'x-test-auth': 'yes' },
+    });
+    expect(response.status).toBe(200);
+    const payload = (await response.json()) as {
+      generatedAt: string;
+      groups: Array<{
+        repoIdentity: string | null;
+        instanceCount: number;
+        nodeIds: string[];
+        instances: Array<{ nodeId: string; localPath: string }>;
+      }>;
+    };
+    expect(typeof payload.generatedAt).toBe('string');
+
+    const relay = payload.groups.find(
+      (group) => group.repoIdentity === 'github.com/donovan-yohan/relay-ide'
+    );
+    expect(relay).toBeDefined();
+    expect(relay?.instanceCount).toBe(2);
+    expect(relay?.nodeIds.sort()).toEqual(['hub-local', nodeIds[0]!].sort());
+    expect(
+      relay?.instances.map((instance) => instance.localPath).sort()
+    ).toEqual(['/Users/kyle/dev/relay-ide', '/var/relay/relay-ide']);
+
+    const unidentified = payload.groups.find(
+      (group) => group.repoIdentity === null
+    );
+    expect(unidentified).toBeDefined();
+    expect(unidentified?.instances[0]?.localPath).toBe('/srv/scratch');
+    expect(unidentified?.instances[0]?.nodeId).toBe(nodeIds[1]);
+  });
+});

--- a/test/shared/repo-identity.test.ts
+++ b/test/shared/repo-identity.test.ts
@@ -1,0 +1,207 @@
+// #624 acceptance-criteria coverage for the canonical RepoIdentity
+// normalizer. The general normalizer contract is exercised in
+// test/repo-identity.test.ts; this file focuses on the edge cases the issue
+// calls out explicitly so they cannot regress silently:
+//
+//   - trailing slash
+//   - .git suffix (present or absent)
+//   - mixed case host
+//   - port-bearing ssh URLs (ssh://git@host:22/...)
+//   - non-GitHub hosts (gitlab.com, bitbucket.org, custom self-hosted)
+//   - bad inputs produce a typed warning, never throw
+//   - JSON round-trip preserves all fields
+//   - non-git cwd (resolveCanonicalRepoIdentity with no remotes) returns
+//     identity: null, not an error
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  normalizeRemoteUrl,
+  resolveCanonicalRepoIdentity,
+  type NormalizedRemoteIdentity,
+} from '../../shared/repo-identity.js';
+
+const CANONICAL_GITHUB = 'github.com/owner/repo';
+
+const GITHUB_EQUIVALENT_URLS: readonly string[] = [
+  'https://github.com/owner/repo',
+  'https://github.com/owner/repo/',
+  'https://github.com/owner/repo.git',
+  'https://github.com/owner/repo.git/',
+  'https://github.com/Owner/Repo',
+  'https://github.com/Owner/Repo.git',
+  'https://GITHUB.com/owner/repo.git',
+  'https://github.COM/Owner/Repo/',
+  'https://github.com:443/owner/repo.git',
+  'git@github.com:owner/repo.git',
+  'git@github.com:owner/repo',
+  'git@GitHub.com:Owner/Repo.git',
+  'ssh://git@github.com/owner/repo.git',
+  'ssh://git@github.com:22/owner/repo.git',
+  'ssh://git@github.com:2222/Owner/Repo',
+  'ssh://git@github.com:22/owner/repo.git/',
+];
+
+describe('normalizeRemoteUrl (#624 acceptance criteria)', () => {
+  it.each(GITHUB_EQUIVALENT_URLS)(
+    'collapses %s to the canonical github.com/owner/repo identity',
+    (url) => {
+      const result = normalizeRemoteUrl(url);
+      expect(result.identity).toBe(CANONICAL_GITHUB);
+      expect(result.provider).toBe('github');
+      expect(result.host).toBe('github.com');
+      expect(result.owner).toBe('owner');
+      expect(result.name).toBe('repo');
+      expect(result.warning).toBeUndefined();
+    }
+  );
+
+  it('preserves host and path for non-GitHub providers (gitlab)', () => {
+    const result = normalizeRemoteUrl(
+      'git@gitlab.example.com:Team/Tools.git'
+    );
+    expect(result).toMatchObject({
+      identity: 'gitlab.example.com/Team/Tools',
+      provider: 'git',
+      host: 'gitlab.example.com',
+      path: 'Team/Tools',
+      owner: 'Team',
+      name: 'Tools',
+    });
+    expect(result.warning).toBeUndefined();
+  });
+
+  it('preserves host and path for non-GitHub providers (bitbucket)', () => {
+    const result = normalizeRemoteUrl(
+      'https://bitbucket.org/Team/repo.git'
+    );
+    expect(result).toMatchObject({
+      identity: 'bitbucket.org/Team/repo',
+      provider: 'git',
+      host: 'bitbucket.org',
+      path: 'Team/repo',
+    });
+  });
+
+  it('preserves nested paths for self-hosted gitea/forgejo style remotes', () => {
+    const result = normalizeRemoteUrl(
+      'ssh://git@code.internal.example.com:2222/group/subgroup/repo.git'
+    );
+    expect(result).toMatchObject({
+      identity: 'code.internal.example.com/group/subgroup/repo',
+      provider: 'git',
+      host: 'code.internal.example.com',
+      path: 'group/subgroup/repo',
+      owner: 'group',
+      name: 'repo',
+    });
+  });
+
+  it('lower-cases the host on non-GitHub remotes too', () => {
+    const result = normalizeRemoteUrl(
+      'https://Gitlab.Example.COM/Team/Repo.git'
+    );
+    expect(result.host).toBe('gitlab.example.com');
+    expect(result.identity).toBe('gitlab.example.com/Team/Repo');
+  });
+
+  it('returns a typed warning rather than throwing on empty input', () => {
+    expect(() => normalizeRemoteUrl('')).not.toThrow();
+    const result = normalizeRemoteUrl('');
+    expect(result.identity).toBeNull();
+    expect(result.warning).toBe('malformed-remote-url');
+  });
+
+  it('returns a typed warning rather than throwing on whitespace-only input', () => {
+    expect(() => normalizeRemoteUrl('   \t  ')).not.toThrow();
+    expect(normalizeRemoteUrl('   \t  ').warning).toBe(
+      'malformed-remote-url'
+    );
+  });
+
+  it('returns a typed warning rather than throwing on malformed URLs', () => {
+    for (const garbage of [
+      'not a url',
+      'http://',
+      'github.com/no-owner',
+      'ssh://',
+      '://malformed',
+    ]) {
+      expect(() => normalizeRemoteUrl(garbage)).not.toThrow();
+      expect(normalizeRemoteUrl(garbage).identity).toBeNull();
+    }
+  });
+
+  it('rejects github URLs with extra path segments instead of inventing identity', () => {
+    for (const url of [
+      'https://github.com/owner/repo/tree/main',
+      'https://github.com/owner/repo/pull/123',
+      'git@github.com:owner/repo/extra.git',
+    ]) {
+      const result = normalizeRemoteUrl(url);
+      expect(result.identity).toBeNull();
+      expect(result.host).toBe('github.com');
+      expect(result.warning).toBe('malformed-remote-url');
+    }
+  });
+
+  it('preserves all fields across a JSON round-trip', () => {
+    const original = normalizeRemoteUrl(
+      'ssh://git@github.com:2222/Owner/Repo.git'
+    );
+    const restored: NormalizedRemoteIdentity = JSON.parse(
+      JSON.stringify(original)
+    );
+    expect(restored).toEqual(original);
+    expect(restored.identity).toBe(CANONICAL_GITHUB);
+    expect(restored.provider).toBe('github');
+  });
+
+  it('preserves the malformed-warning discriminator across JSON round-trip', () => {
+    const original = normalizeRemoteUrl('not a remote');
+    const restored: NormalizedRemoteIdentity = JSON.parse(
+      JSON.stringify(original)
+    );
+    expect(restored).toEqual(original);
+    expect(restored.warning).toBe('malformed-remote-url');
+    expect(restored.identity).toBeNull();
+  });
+});
+
+describe('resolveCanonicalRepoIdentity (#624 acceptance criteria)', () => {
+  it('returns identity: null for a non-git cwd (no remotes) without throwing', () => {
+    expect(() => resolveCanonicalRepoIdentity([])).not.toThrow();
+    const resolved = resolveCanonicalRepoIdentity([]);
+    expect(resolved.identity).toBeNull();
+    expect(resolved.selectedRemote).toBeNull();
+    expect(resolved.warnings).toContain('missing-remotes');
+  });
+
+  it('treats https origin + ssh origin variants as the same canonical identity', () => {
+    const httpsOrigin = resolveCanonicalRepoIdentity([
+      { name: 'origin', url: 'https://github.com/owner/repo.git' },
+    ]);
+    const sshOrigin = resolveCanonicalRepoIdentity([
+      { name: 'origin', url: 'git@github.com:owner/repo.git' },
+    ]);
+    const sshUrlOrigin = resolveCanonicalRepoIdentity([
+      { name: 'origin', url: 'ssh://git@github.com:22/Owner/Repo' },
+    ]);
+    expect(httpsOrigin.identity).toBe(CANONICAL_GITHUB);
+    expect(sshOrigin.identity).toBe(CANONICAL_GITHUB);
+    expect(sshUrlOrigin.identity).toBe(CANONICAL_GITHUB);
+  });
+
+  it('round-trips the resolution result through JSON without dropping fields', () => {
+    const original = resolveCanonicalRepoIdentity([
+      { name: 'origin', url: 'https://github.com/owner/repo.git' },
+      { name: 'upstream', url: 'git@github.com:upstream/repo.git' },
+    ]);
+    const restored = JSON.parse(JSON.stringify(original));
+    expect(restored).toEqual(original);
+    expect(restored.identity).toBe(CANONICAL_GITHUB);
+    expect(restored.warnings).toEqual(
+      expect.arrayContaining(['multiple-remotes', 'fork-upstream-ambiguity'])
+    );
+  });
+});


### PR DESCRIPTION
## Scope

Expose the existing canonical `RepoIdentity` normalizer + cross-node aggregator as a slim picker-friendly read surface, and lock down the issue acceptance-criteria edge cases with explicit test coverage. No UI.

Refs:
- Parent: #615 (environment picker epic)
- Builds on: #623 (PR #634, `EnvironmentOption` data model — already imports `RepoIdentity` as the dedupe discriminator)

## Exported types (`shared/repo-inventory.ts`)

- `RepoIdentityGroup` — `{ repoIdentity, displayName, instanceCount, nodeIds, instances, warnings }`
- `RepoIdentityGroupInstance` — `{ nodeId, repoInstanceId, localPath, currentBranch, defaultBranch }` (mirrors `EnvironmentRepoInstanceSummary` from #623)
- `RepoIdentityGroupsResponse` — `{ generatedAt, groups }`
- `summarizeRepoIdentityGroups(reports, now?)` — drops dirty/divergence/worktree payloads from the full aggregator. Non-git cwds land as `repoIdentity: null` groups (graceful absence, not error).

`shared/index.ts` now re-exports the normalizer + aggregator surface so the picker has one stable import path.

## Endpoint additions

- `GET /hub/repo-groups` (in `server/features/repo-router.ts`) — slim cross-node project groups keyed by canonical `RepoIdentity`. Same auth gate as `GET /hub/repo-inventory`. Composition root in `server/index.ts` already wires the local inventory collector through `createRepoFeatureRouter`, so the new endpoint comes online with no additional plumbing.

The pre-existing `GET /hub/repo-inventory` keeps returning the full aggregated payload (dirty/divergence/worktrees), unchanged.

## Tests

`test/shared/repo-identity.test.ts` — issue #624 AC coverage for `normalizeRemoteUrl` and `resolveCanonicalRepoIdentity`:
- trailing slash, `.git` suffix (present or absent), mixed-case host
- port-bearing ssh URLs (`ssh://git@github.com:22/...`, `:2222/...`)
- non-GitHub hosts (gitlab.com, bitbucket.org, self-hosted gitea with nested paths)
- bad input returns typed warning (never throws) — empty string, whitespace, malformed URLs
- github URLs with extra path segments rejected (no inventing identity)
- JSON round-trip preserves all fields and discriminators
- `resolveCanonicalRepoIdentity([])` returns `identity: null` for a non-git cwd without throwing

`test/server/repo-aggregation.test.ts` — backend grouping + new endpoint:
- two nodes with same canonical `RepoIdentity` (one ssh, one https) but different local paths collapse to one group
- non-git inventory entry returns a graceful `repoIdentity: null` group (absence, not error)
- slim shape never carries dirty/worktrees/divergence fields (guarded explicitly)
- JSON round-trips the slim response without dropping fields
- `GET /hub/repo-groups` refuses unauthenticated callers
- `GET /hub/repo-groups` returns one cross-node group for the same `RepoIdentity` and a separate `repoIdentity: null` group for the non-git node

All 244 test files (2855 tests + 1 expected fail) pass on this branch.

## Test plan

- [x] `npm run check` — 0 errors, only pre-existing warnings (none in touched files)
- [x] `npm test` — full suite passes
- [x] `npx vitest run test/shared/repo-identity.test.ts test/server/repo-aggregation.test.ts test/repo-inventory.test.ts test/repo-inventory-feature.test.ts test/repo-identity.test.ts test/hub-node-routes.test.ts test/hub-node-cold-transfer.test.ts` — all 90 repo-related tests pass