### PR TITLE
feat(cli-gateway): typed environment IDs for agent tasks (#626)

### DIFF
--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -134,7 +134,7 @@ Fields:
 
 - `nodeId` (required) — target Relay node id; sourced from `EnvironmentOption.node.nodeId`.
 - `cwd` (required) — absolute cwd on the target node where the session starts.
-- `repoIdentity` (optional) — canonical normalized repo identity (e.g. `github.com/owner/name`), produced by `shared/repo-identity.ts`. Never a free-form `{ host, path }` pair.
+- `repoIdentity` (optional, nullable) — canonical normalized repo identity (e.g. `github.com/owner/name`), produced by `shared/repo-identity.ts`. Never a free-form `{ host, path }` pair. May be `null` when the environment was built from a `RepoInstance` whose remotes did not produce a canonical identity (see `EnvironmentRepoInstanceSummary.repoIdentity` in `shared/environment-option.ts`), so adapters can round-trip the field without losing the "no identity resolved" signal; omit the field entirely otherwise.
 - `repoInstanceId` (optional) — scoped `RepoInstanceId` from `createRepoInstanceId(nodeId, localPath)`.
 - `benchId` (optional) — scoped `WorktreeInstanceId` from `createWorktreeInstanceId(nodeId, localPath)`. Requires `repoIdentity` or `repoInstanceId` (a Bench is anchored to a RepoInstance per `docs/WORKBENCH_BOUNDARY.md`).
 

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -106,9 +106,51 @@ Supported now:
 
 - local repo/worktree-backed session creation using `repoPath` and optional `worktreePath`
 - routed node creation with `nodeId`, `cwd`, `type` (defaulting to `agent` when omitted), `mode`, `agent`, lifecycle fields, and optional non-agent `sessionEnvelope` where the existing backend supports them
+- routed node creation with the typed `environment` object (see [Typed environment IDs](#typed-environment-ids-626) below)
 - `controlMode=agent-driven` only for routed node creation, where hub/node policy and hand-back state can be checked
 - descriptor-only attach with `sessions attach --id ... --json`
 - safe detach with `sessions detach --id ... --json`; this resolves the session and releases only the CLI gateway handle, leaving the underlying Relay session/process running
+
+### Typed environment IDs (#626)
+
+`sessions.create` accepts a typed `environment` object (epic #615) so agent tasks reference where work runs by **typed IDs**, not free-form host/path strings. The shape mirrors `EnvironmentOption` in `shared/environment-option.ts` and uses scoped IDs from `shared/identity.ts` plus the canonical `RepoIdentity` from `shared/repo-identity.ts`.
+
+```json
+{
+  "environment": {
+    "nodeId": "node-a",
+    "repoIdentity": "github.com/donovan-yohan/relay-ide",
+    "repoInstanceId": "node-a:%2FUsers%2Fme%2Fcode%2Frelay-ide",
+    "benchId": "node-a:%2FUsers%2Fme%2Fcode%2Frelay-ide%2F.worktrees%2F626",
+    "cwd": "/Users/me/code/relay-ide/.worktrees/626"
+  },
+  "type": "agent",
+  "mode": "pty",
+  "agent": "claude"
+}
+```
+
+Fields:
+
+- `nodeId` (required) — target Relay node id; sourced from `EnvironmentOption.node.nodeId`.
+- `cwd` (required) — absolute cwd on the target node where the session starts.
+- `repoIdentity` (optional) — canonical normalized repo identity (e.g. `github.com/owner/name`), produced by `shared/repo-identity.ts`. Never a free-form `{ host, path }` pair.
+- `repoInstanceId` (optional) — scoped `RepoInstanceId` from `createRepoInstanceId(nodeId, localPath)`.
+- `benchId` (optional) — scoped `WorktreeInstanceId` from `createWorktreeInstanceId(nodeId, localPath)`. Requires `repoIdentity` or `repoInstanceId` (a Bench is anchored to a RepoInstance per `docs/WORKBENCH_BOUNDARY.md`).
+
+Fail-closed examples specific to the typed shape:
+
+- raw `{ host, path }` on `environment` returns `INVALID_ARGUMENT` with `details.field` under `environment.*` (free-form host/path is exactly what #626 forbids)
+- missing `environment.nodeId` or `environment.cwd` returns `INVALID_ARGUMENT`
+- `environment.benchId` without `repoIdentity` or `repoInstanceId` returns `INVALID_ARGUMENT`
+- mixing `environment` with any legacy flat `nodeId` / `repoPath` / `worktreePath` / `cwd` returns `INVALID_ARGUMENT` — pick one shape per request
+- local `/sessions` gateway creation rejects `environment` (typed `environment` always implies routed creation)
+
+A schema fixture of the typed shape is committed at [`docs/cli-schema/sessions.create.environment.json`](cli-schema/sessions.create.environment.json) for adapter generators that consume the schema out-of-band.
+
+#### Deprecation policy
+
+Legacy flat fields `nodeId`, `repoPath`, `worktreePath`, and `cwd` on `sessions.create` remain accepted in **v1.x** so adapters shipped before #626 do not break. They are documented as deprecated and will be **removed in v2**. Adapters built today should emit the typed `environment` object. Mixing legacy flat fields with `environment` in the same call is rejected with `INVALID_ARGUMENT` to avoid ambiguous routing.
 
 `sessions attach` is intentionally descriptor-only in v1. It does not start a Claude/Codex/Hermes adapter runtime and it does not stream PTY data.
 

--- a/docs/cli-schema/sessions.create.environment.json
+++ b/docs/cli-schema/sessions.create.environment.json
@@ -1,0 +1,51 @@
+{
+  "contract": "v1",
+  "contractVersion": "1.0",
+  "command": "sessions.create",
+  "field": "environment",
+  "description": "Typed environment IDs for agent tasks (#626). Sourced from shared/environment-option.ts (EnvironmentOption.node / .repoInstance / .bench / .cwd) and shared/identity.ts (NodeId / RepoInstanceId / WorktreeInstanceId) and shared/repo-identity.ts (RepoIdentity).",
+  "schema": {
+    "title": "CreateSessionEnvironment",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "nodeId": {
+        "type": "string",
+        "description": "Target Relay node id. From EnvironmentOption.node.nodeId."
+      },
+      "repoIdentity": {
+        "type": [
+          "string",
+          "null"
+        ],
+        "description": "Canonical normalized repo identity (e.g. \"github.com/owner/name\"). Sourced from shared/repo-identity.ts; never a free-form host/path pair."
+      },
+      "repoInstanceId": {
+        "type": "string",
+        "description": "Scoped RepoInstanceId for a node-local checkout (encodes nodeId + local path)."
+      },
+      "benchId": {
+        "type": "string",
+        "description": "Scoped WorktreeInstanceId for a Bench inside the RepoInstance. Requires repoIdentity or repoInstanceId."
+      },
+      "cwd": {
+        "type": "string",
+        "description": "Absolute cwd on the target node where the session starts."
+      }
+    },
+    "required": [
+      "nodeId",
+      "cwd"
+    ]
+  },
+  "deprecation": {
+    "legacyFields": [
+      "nodeId",
+      "repoPath",
+      "worktreePath",
+      "cwd"
+    ],
+    "targetRemoval": "v2",
+    "policy": "Legacy flat fields remain accepted in v1.x. Mixing legacy flat fields with environment is INVALID_ARGUMENT. Raw { host, path } pairs on environment are INVALID_ARGUMENT."
+  }
+}

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -528,17 +528,77 @@ const sessionInputOutputSchema: RelayJsonSchema = {
   required: ['sent', 'sessionId', 'bytesSent', 'matched', 'bytesReceived', 'truncated'],
 };
 
+/**
+ * Typed environment shape for agent task creation (#626, epic #615).
+ *
+ * Adapter-facing alternative to the legacy `repoPath` / `worktreePath` / flat
+ * `nodeId` + `cwd` fields. Uses scoped IDs from `shared/identity.ts` and the
+ * canonical `RepoIdentity` string ("github.com/{owner}/{name}" or
+ * "{host}/{path}") emitted by `shared/repo-identity.ts`. Raw host/path pairs
+ * are intentionally absent: free-form host strings are exactly what #626
+ * forbids on the agent task contract.
+ *
+ * Invariants (enforced in `shared/cli-gateway-runtime.ts`):
+ *   - `nodeId` and `cwd` are required.
+ *   - `benchId` requires either `repoIdentity` or `repoInstanceId` (a Bench is
+ *     anchored to a RepoInstance per `docs/WORKBENCH_BOUNDARY.md`).
+ *   - Mixing `environment` with any of `repoPath` / `worktreePath` / flat
+ *     `cwd` / flat `nodeId` is rejected — callers pick one shape.
+ */
+const createSessionEnvironmentSchema: RelayJsonSchema = {
+  title: 'CreateSessionEnvironment',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    nodeId: {
+      type: 'string',
+      description: 'Target Relay node id. From EnvironmentOption.node.nodeId.',
+    },
+    repoIdentity: {
+      type: ['string', 'null'],
+      description:
+        'Canonical normalized repo identity (e.g. "github.com/owner/name"). ' +
+        'Sourced from shared/repo-identity.ts; never a free-form host/path pair.',
+    },
+    repoInstanceId: {
+      type: 'string',
+      description:
+        'Scoped RepoInstanceId for a node-local checkout (encodes nodeId + local path).',
+    },
+    benchId: {
+      type: 'string',
+      description:
+        'Scoped WorktreeInstanceId for a Bench inside the RepoInstance. Requires repoIdentity or repoInstanceId.',
+    },
+    cwd: {
+      type: 'string',
+      description: 'Absolute cwd on the target node where the session starts.',
+    },
+  },
+  required: ['nodeId', 'cwd'],
+};
+
 const createSessionInputSchema: RelayJsonSchema = {
   title: 'CreateSessionInput',
   type: 'object',
   additionalProperties: false,
   properties: {
     nodeId: {
-      description: 'Optional execution node. Omit for current local /sessions path.',
+      description:
+        'DEPRECATED in v1.x — prefer `environment.nodeId`. Optional execution node; omit for the current local /sessions path. Removed in v2.',
       type: 'string',
     },
-    repoPath: stringSchema,
-    worktreePath: nullableStringSchema,
+    environment: createSessionEnvironmentSchema,
+    repoPath: {
+      ...stringSchema,
+      description:
+        'DEPRECATED in v1.x — prefer `environment.cwd` (with repoIdentity/repoInstanceId for repo-bound launches). Removed in v2.',
+    },
+    worktreePath: {
+      ...nullableStringSchema,
+      description:
+        'DEPRECATED in v1.x — prefer `environment.benchId` + `environment.cwd`. Removed in v2.',
+    },
     cwd: stringSchema,
     type: { type: 'string', enum: ['agent', 'terminal'], default: 'agent' },
     mode: { type: 'string', enum: ['pty', 'web'] },

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -599,7 +599,11 @@ const createSessionInputSchema: RelayJsonSchema = {
       description:
         'DEPRECATED in v1.x — prefer `environment.benchId` + `environment.cwd`. Removed in v2.',
     },
-    cwd: stringSchema,
+    cwd: {
+      ...stringSchema,
+      description:
+        'DEPRECATED in v1.x — prefer `environment.cwd`. Removed in v2.',
+    },
     type: { type: 'string', enum: ['agent', 'terminal'], default: 'agent' },
     mode: { type: 'string', enum: ['pty', 'web'] },
     agent: stringSchema,

--- a/shared/cli-gateway-runtime.ts
+++ b/shared/cli-gateway-runtime.ts
@@ -221,27 +221,33 @@ function validateCreateEnvironment(
   if (
     environment['repoIdentity'] !== undefined &&
     environment['repoIdentity'] !== null &&
-    typeof environment['repoIdentity'] !== 'string'
+    (typeof environment['repoIdentity'] !== 'string' ||
+      environment['repoIdentity'].length === 0)
   ) {
     return invalidCreateInput(
-      'sessions.create environment.repoIdentity must be a string or null',
+      'sessions.create environment.repoIdentity must be a non-empty string or null',
       { field: 'environment.repoIdentity' }
     );
   }
   if (
     environment['repoInstanceId'] !== undefined &&
-    typeof environment['repoInstanceId'] !== 'string'
+    (typeof environment['repoInstanceId'] !== 'string' ||
+      environment['repoInstanceId'].length === 0)
   ) {
     return invalidCreateInput(
-      'sessions.create environment.repoInstanceId must be a string',
+      'sessions.create environment.repoInstanceId must be a non-empty string',
       { field: 'environment.repoInstanceId' }
     );
   }
   if (environment['benchId'] !== undefined) {
-    if (typeof environment['benchId'] !== 'string') {
-      return invalidCreateInput('sessions.create environment.benchId must be a string', {
-        field: 'environment.benchId',
-      });
+    if (
+      typeof environment['benchId'] !== 'string' ||
+      environment['benchId'].length === 0
+    ) {
+      return invalidCreateInput(
+        'sessions.create environment.benchId must be a non-empty string',
+        { field: 'environment.benchId' }
+      );
     }
     const hasTypedRepoBinding =
       typeof environment['repoIdentity'] === 'string' ||

--- a/shared/cli-gateway-runtime.ts
+++ b/shared/cli-gateway-runtime.ts
@@ -22,6 +22,7 @@ export type GatewayCreateValidationResult =
 
 const createSessionAllowedFields = new Set([
   'nodeId',
+  'environment',
   'repoPath',
   'worktreePath',
   'cwd',
@@ -41,6 +42,26 @@ const createSessionAllowedFields = new Set([
   'expiresAt',
   'confirmationToken',
 ]);
+
+/**
+ * Fields on the typed `environment` object accepted by `sessions.create` for
+ * #626. Free-form `host` / `path` strings are intentionally NOT in this set:
+ * the whole point of the typed-environment contract is to keep raw host/path
+ * pairs out of the agent task surface.
+ */
+const createSessionEnvironmentAllowedFields = new Set([
+  'nodeId',
+  'repoIdentity',
+  'repoInstanceId',
+  'benchId',
+  'cwd',
+]);
+
+/**
+ * Legacy flat fields that cannot be combined with the typed `environment`
+ * object. Callers pick one shape per request; mixing produces INVALID_ARGUMENT.
+ */
+const legacyEnvironmentFlatFields = ['nodeId', 'repoPath', 'worktreePath', 'cwd'] as const;
 
 const stringFields = [
   'nodeId',
@@ -146,6 +167,105 @@ function validateNumberField(
       { field, min, ...(max !== undefined ? { max } : {}) }
     );
   }
+  return null;
+}
+
+/**
+ * Validate the typed `environment` object for `sessions.create` (#626).
+ *
+ * Returns a validation failure when:
+ *   - `environment` is not an object;
+ *   - it contains an unknown field (notably `host` / `path`, which #626 forbids
+ *     on the agent task contract);
+ *   - `nodeId` or `cwd` is missing or not a string;
+ *   - `repoIdentity`, `repoInstanceId`, or `benchId` is present but not a string;
+ *   - `benchId` is set without a typed repo binding (`repoIdentity` or
+ *     `repoInstanceId`) — a Bench is always anchored to a RepoInstance.
+ */
+function validateCreateEnvironment(
+  rawInput: Record<string, unknown>
+): GatewayCreateValidationFailure | null {
+  const environment = rawInput['environment'];
+  if (environment === undefined) return null;
+  if (!isRecord(environment)) {
+    return invalidCreateInput('sessions.create environment must be an object', {
+      field: 'environment',
+    });
+  }
+
+  for (const field of Object.keys(environment)) {
+    if (!createSessionEnvironmentAllowedFields.has(field)) {
+      // Specifically catch the #626 anti-pattern: raw host/path identity pairs.
+      return invalidCreateInput(
+        `sessions.create environment field is not in the v1 typed contract: ${field}`,
+        {
+          field: `environment.${field}`,
+          allowed: Array.from(createSessionEnvironmentAllowedFields).sort(),
+        }
+      );
+    }
+  }
+
+  if (typeof environment['nodeId'] !== 'string' || environment['nodeId'].length === 0) {
+    return invalidCreateInput(
+      'sessions.create environment.nodeId is required and must be a non-empty string',
+      { field: 'environment.nodeId' }
+    );
+  }
+  if (typeof environment['cwd'] !== 'string' || environment['cwd'].length === 0) {
+    return invalidCreateInput(
+      'sessions.create environment.cwd is required and must be a non-empty string',
+      { field: 'environment.cwd' }
+    );
+  }
+  if (
+    environment['repoIdentity'] !== undefined &&
+    environment['repoIdentity'] !== null &&
+    typeof environment['repoIdentity'] !== 'string'
+  ) {
+    return invalidCreateInput(
+      'sessions.create environment.repoIdentity must be a string or null',
+      { field: 'environment.repoIdentity' }
+    );
+  }
+  if (
+    environment['repoInstanceId'] !== undefined &&
+    typeof environment['repoInstanceId'] !== 'string'
+  ) {
+    return invalidCreateInput(
+      'sessions.create environment.repoInstanceId must be a string',
+      { field: 'environment.repoInstanceId' }
+    );
+  }
+  if (environment['benchId'] !== undefined) {
+    if (typeof environment['benchId'] !== 'string') {
+      return invalidCreateInput('sessions.create environment.benchId must be a string', {
+        field: 'environment.benchId',
+      });
+    }
+    const hasTypedRepoBinding =
+      typeof environment['repoIdentity'] === 'string' ||
+      typeof environment['repoInstanceId'] === 'string';
+    if (!hasTypedRepoBinding) {
+      return invalidCreateInput(
+        'sessions.create environment.benchId requires environment.repoIdentity or environment.repoInstanceId',
+        { field: 'environment.benchId' }
+      );
+    }
+  }
+
+  // Reject mixing the typed environment with the legacy flat fields. Adapters
+  // pick one shape per call — the typed shape is canonical, the flat fields
+  // remain accepted in v1.x only for callers that have not migrated yet.
+  for (const field of legacyEnvironmentFlatFields) {
+    if (rawInput[field] !== undefined) {
+      return invalidCreateInput(
+        `sessions.create cannot mix legacy ${field} with the typed environment object — pick one shape`,
+        { field, conflictsWith: 'environment' }
+      );
+    }
+  }
+
   return null;
 }
 
@@ -324,12 +444,24 @@ export function validateAndSanitizeGatewayCreateInput(
   if (sanitizedResult.ok === false) return sanitizedResult;
 
   const sanitized = sanitizedResult.input;
+  const environmentError = validateCreateEnvironment(sanitized);
+  if (environmentError) return environmentError;
   const typeError = validateCreateFieldTypes(sanitized);
   if (typeError) return typeError;
   const enumError = validateCreateEnums(sanitized);
   if (enumError) return enumError;
 
-  const nodeId = typeof sanitized['nodeId'] === 'string' ? sanitized['nodeId'] : undefined;
+  // The typed environment supplies an effective nodeId for downstream routing
+  // when present. When `environment` is set, `nodeId` (flat) is forbidden by
+  // validateCreateEnvironment, so this is unambiguous.
+  const environment = isRecord(sanitized['environment']) ? sanitized['environment'] : undefined;
+  const environmentNodeId =
+    environment && typeof environment['nodeId'] === 'string'
+      ? environment['nodeId']
+      : undefined;
+  const flatNodeId = typeof sanitized['nodeId'] === 'string' ? sanitized['nodeId'] : undefined;
+  const nodeId = environmentNodeId ?? flatNodeId;
+
   const envelopeError = validateSessionEnvelopeInput(sanitized['sessionEnvelope'], nodeId);
   if (envelopeError) return envelopeError;
   if (!nodeId) {
@@ -347,6 +479,12 @@ export function validateAndSanitizeLocalGatewayCreateInput(
 ): GatewayCreateValidationResult {
   const validated = validateAndSanitizeGatewayCreateInput(rawInput);
   if (validated.ok === false) return validated;
+  if (validated.input['environment'] !== undefined) {
+    return unsupportedCreateInput(
+      'local /sessions gateway creation cannot accept the typed environment object; use routed node creation through /hub/nodes/:nodeId/sessions',
+      { field: 'environment', supported: ['repoPath', 'worktreePath'] }
+    );
+  }
   if (validated.nodeId) {
     return unsupportedCreateInput(
       'local /sessions gateway creation cannot accept nodeId; use routed node creation through /hub/nodes/:nodeId/sessions',

--- a/test/cli-gateway/typed-env-ids.test.ts
+++ b/test/cli-gateway/typed-env-ids.test.ts
@@ -173,6 +173,41 @@ describe('CLI gateway typed environment IDs (#626)', () => {
       expect(result.error.code).toBe('INVALID_ARGUMENT');
       expect(result.error.details?.['field']).toMatch(/environment\.benchId/);
     });
+
+    it('rejects environment.repoIdentity as empty string (must be non-empty or null)', () => {
+      const result = validateAndSanitizeGatewayCreateInput({
+        environment: { nodeId: NODE_A, cwd: REPO_CWD, repoIdentity: '' },
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok !== false) return;
+      expect(result.error.code).toBe('INVALID_ARGUMENT');
+      expect(result.error.details?.['field']).toMatch(/environment\.repoIdentity/);
+    });
+
+    it('rejects environment.repoInstanceId as empty string', () => {
+      const result = validateAndSanitizeGatewayCreateInput({
+        environment: { nodeId: NODE_A, cwd: REPO_CWD, repoInstanceId: '' },
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok !== false) return;
+      expect(result.error.code).toBe('INVALID_ARGUMENT');
+      expect(result.error.details?.['field']).toMatch(/environment\.repoInstanceId/);
+    });
+
+    it('rejects environment.benchId as empty string', () => {
+      const result = validateAndSanitizeGatewayCreateInput({
+        environment: {
+          nodeId: NODE_A,
+          cwd: BENCH_CWD,
+          repoIdentity: REPO_IDENTITY,
+          benchId: '',
+        },
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok !== false) return;
+      expect(result.error.code).toBe('INVALID_ARGUMENT');
+      expect(result.error.details?.['field']).toMatch(/environment\.benchId/);
+    });
   });
 
   describe('deprecation policy', () => {

--- a/test/cli-gateway/typed-env-ids.test.ts
+++ b/test/cli-gateway/typed-env-ids.test.ts
@@ -105,6 +105,24 @@ describe('CLI gateway typed environment IDs (#626)', () => {
         benchId: BENCH_ID,
       });
     });
+
+    it('accepts environment with repoIdentity: null (no canonical identity resolved)', () => {
+      // Mirrors EnvironmentRepoInstanceSummary.repoIdentity, which is `string | null`
+      // when remotes did not produce a canonical RepoIdentity. Adapters must be able
+      // to round-trip the null signal without dropping the field.
+      const result = validateAndSanitizeGatewayCreateInput({
+        environment: {
+          nodeId: NODE_A,
+          repoIdentity: null,
+          repoInstanceId: REPO_INSTANCE_ID,
+          cwd: REPO_CWD,
+        },
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok !== true) return;
+      const env = result.input['environment'] as Record<string, unknown>;
+      expect(env['repoIdentity']).toBeNull();
+    });
   });
 
   describe('validation — raw host/path rejected', () => {

--- a/test/cli-gateway/typed-env-ids.test.ts
+++ b/test/cli-gateway/typed-env-ids.test.ts
@@ -1,0 +1,240 @@
+// #626: CLI gateway — typed environment IDs for agent tasks.
+//
+// Verifies that `sessions.create` and any other agent-task verbs accept a typed
+// `environment: { nodeId, repoIdentity?, benchId?, cwd }` shape sourced from
+// `shared/environment-option.ts` (EnvironmentOption) and reject raw host/path
+// pairs as INVALID_ARGUMENT.
+//
+// Deprecation policy chosen: existing flat fields (`repoPath`, `worktreePath`,
+// `cwd`, `nodeId`) remain accepted in v1.x as legacy inputs so adapters
+// shipped before #626 do not break. Sending both `environment` and a flat
+// `repoPath`/`worktreePath`/`cwd` is INVALID_ARGUMENT (callers must pick one).
+// The legacy flat fields are documented as deprecated in `docs/CLI_GATEWAY.md`
+// with target removal at the next major (v2). Raw `{ host, path }` (without
+// typed IDs) is rejected.
+
+import { describe, expect, it } from 'vitest';
+import {
+  RELAY_CLI_GATEWAY_CONTRACT,
+  commandSpec,
+} from '../../shared/cli-gateway-contract.js';
+import { validateAndSanitizeGatewayCreateInput } from '../../shared/cli-gateway-runtime.js';
+import {
+  createRepoInstanceId,
+  createWorktreeInstanceId,
+} from '../../shared/identity.js';
+import type { RepoIdentity } from '../../shared/identity.js';
+
+const NODE_A = 'node-a';
+const REPO_IDENTITY: RepoIdentity = 'github.com/donovan-yohan/relay-ide';
+const REPO_INSTANCE_ID = createRepoInstanceId(NODE_A, '/Users/me/code/relay-ide');
+const BENCH_ID = createWorktreeInstanceId(NODE_A, '/Users/me/code/relay-ide/.worktrees/626');
+const REPO_CWD = '/Users/me/code/relay-ide';
+const BENCH_CWD = '/Users/me/code/relay-ide/.worktrees/626';
+
+describe('CLI gateway typed environment IDs (#626)', () => {
+  describe('schema surface', () => {
+    it('declares an environment object on sessions.create with typed IDs', () => {
+      const create = commandSpec('sessions.create');
+      const properties = create.inputSchema.properties ?? {};
+      const environment = properties['environment'];
+      expect(environment).toBeDefined();
+      expect(environment?.type).toBe('object');
+      expect(environment?.additionalProperties).toBe(false);
+      expect(environment?.required).toEqual(expect.arrayContaining(['nodeId', 'cwd']));
+
+      const envProps = environment?.properties ?? {};
+      expect(envProps['nodeId']?.type).toBe('string');
+      expect(envProps['cwd']?.type).toBe('string');
+      expect(envProps['repoIdentity']).toBeDefined();
+      expect(envProps['repoInstanceId']?.type).toBe('string');
+      expect(envProps['benchId']?.type).toBe('string');
+    });
+
+    it('does NOT permit raw host/path identity pairs on the environment object', () => {
+      const env = commandSpec('sessions.create').inputSchema.properties?.['environment'];
+      const envProps = env?.properties ?? {};
+      // Anti-regression: the typed shape must never grow a `host` field
+      // (free-form host/path identity is exactly what #626 outlaws).
+      expect(envProps['host']).toBeUndefined();
+      expect(envProps['path']).toBeUndefined();
+      // additionalProperties:false guards against silent host/path leakage.
+      expect(env?.additionalProperties).toBe(false);
+    });
+
+    it('keeps INVALID_ARGUMENT in the create errorCodes for the new typed shape', () => {
+      const create = commandSpec('sessions.create');
+      expect(create.errorCodes).toContain('INVALID_ARGUMENT');
+    });
+  });
+
+  describe('validation — typed environment accepted', () => {
+    it('accepts a minimal typed environment (nodeId + cwd) without legacy fields', () => {
+      const result = validateAndSanitizeGatewayCreateInput({
+        environment: { nodeId: NODE_A, cwd: REPO_CWD },
+        type: 'agent',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok !== true) return;
+      expect(result.nodeId).toBe(NODE_A);
+      expect(result.input['environment']).toMatchObject({
+        nodeId: NODE_A,
+        cwd: REPO_CWD,
+      });
+      // The typed environment must not be silently rewritten back to the flat fields.
+      expect(result.input['repoPath']).toBeUndefined();
+    });
+
+    it('accepts environment with repoIdentity + repoInstanceId + benchId', () => {
+      const result = validateAndSanitizeGatewayCreateInput({
+        environment: {
+          nodeId: NODE_A,
+          repoIdentity: REPO_IDENTITY,
+          repoInstanceId: REPO_INSTANCE_ID,
+          benchId: BENCH_ID,
+          cwd: BENCH_CWD,
+        },
+        type: 'agent',
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok !== true) return;
+      expect(result.input['environment']).toMatchObject({
+        nodeId: NODE_A,
+        repoIdentity: REPO_IDENTITY,
+        repoInstanceId: REPO_INSTANCE_ID,
+        benchId: BENCH_ID,
+      });
+    });
+  });
+
+  describe('validation — raw host/path rejected', () => {
+    it('rejects a raw { host, path } pair on the environment object', () => {
+      const result = validateAndSanitizeGatewayCreateInput({
+        environment: {
+          host: 'devbox.local',
+          path: '/srv/relay-ide',
+          cwd: '/srv/relay-ide',
+        },
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok !== false) return;
+      expect(result.error.code).toBe('INVALID_ARGUMENT');
+      expect(result.error.details?.['field']).toMatch(/environment/);
+    });
+
+    it('rejects environment missing nodeId (typed identity required)', () => {
+      const result = validateAndSanitizeGatewayCreateInput({
+        environment: { cwd: '/tmp/work' },
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok !== false) return;
+      expect(result.error.code).toBe('INVALID_ARGUMENT');
+      expect(result.error.details?.['field']).toMatch(/environment\.nodeId/);
+    });
+
+    it('rejects environment missing cwd', () => {
+      const result = validateAndSanitizeGatewayCreateInput({
+        environment: { nodeId: NODE_A },
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok !== false) return;
+      expect(result.error.code).toBe('INVALID_ARGUMENT');
+      expect(result.error.details?.['field']).toMatch(/environment\.cwd/);
+    });
+
+    it('rejects benchId without typed repo IDs (typed bench requires typed repo)', () => {
+      const result = validateAndSanitizeGatewayCreateInput({
+        environment: {
+          nodeId: NODE_A,
+          benchId: BENCH_ID,
+          cwd: BENCH_CWD,
+        },
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok !== false) return;
+      expect(result.error.code).toBe('INVALID_ARGUMENT');
+      expect(result.error.details?.['field']).toMatch(/environment\.benchId/);
+    });
+  });
+
+  describe('deprecation policy', () => {
+    it('still accepts legacy flat fields (repoPath, nodeId) for backward compat', () => {
+      const result = validateAndSanitizeGatewayCreateInput({
+        nodeId: NODE_A,
+        repoPath: REPO_CWD,
+      });
+      expect(result.ok).toBe(true);
+      if (result.ok !== true) return;
+      expect(result.nodeId).toBe(NODE_A);
+      expect(result.input['repoPath']).toBe(REPO_CWD);
+    });
+
+    it('rejects mixing typed environment with legacy flat repoPath/cwd', () => {
+      const result = validateAndSanitizeGatewayCreateInput({
+        environment: { nodeId: NODE_A, cwd: REPO_CWD },
+        repoPath: REPO_CWD,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok !== false) return;
+      expect(result.error.code).toBe('INVALID_ARGUMENT');
+      expect(result.error.details?.['field']).toMatch(/environment|repoPath/);
+    });
+
+    it('rejects mixing typed environment with legacy flat nodeId (must be supplied via environment only)', () => {
+      const result = validateAndSanitizeGatewayCreateInput({
+        environment: { nodeId: NODE_A, cwd: REPO_CWD },
+        nodeId: NODE_A,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok !== false) return;
+      expect(result.error.code).toBe('INVALID_ARGUMENT');
+    });
+
+    it('rejects mixing typed environment with legacy worktreePath', () => {
+      const result = validateAndSanitizeGatewayCreateInput({
+        environment: { nodeId: NODE_A, cwd: BENCH_CWD },
+        worktreePath: BENCH_CWD,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok !== false) return;
+      expect(result.error.code).toBe('INVALID_ARGUMENT');
+    });
+  });
+
+  describe('contract manifest schema regression', () => {
+    it('exposes the typed environment shape through the manifest', () => {
+      const found = RELAY_CLI_GATEWAY_CONTRACT.commandSchemas.find(
+        (entry) => entry.name === 'sessions.create'
+      );
+      expect(found).toBeDefined();
+      const envSchema = found?.inputSchema.properties?.['environment'];
+      expect(envSchema).toBeDefined();
+      expect(envSchema?.title).toBe('CreateSessionEnvironment');
+    });
+  });
+
+  describe('back-compat round-trip', () => {
+    it('still validates the pre-#626 routed-create example body', () => {
+      // Existing example from test/cli-gateway-contract.test.ts must continue to pass.
+      const routedDefault = validateAndSanitizeGatewayCreateInput({
+        nodeId: NODE_A,
+        repoPath: '/tmp/repo',
+      });
+      expect(routedDefault.ok).toBe(true);
+      if (routedDefault.ok !== true) return;
+      expect(routedDefault.sessionType).toBe('agent');
+    });
+
+    it('still validates a clean local create body', () => {
+      const clean = validateAndSanitizeGatewayCreateInput({
+        repoPath: '/tmp/repo',
+        worktreePath: null,
+        type: 'terminal',
+        cols: 120,
+      });
+      expect(clean.ok).toBe(true);
+      if (clean.ok !== true) return;
+      expect(clean.sessionType).toBe('terminal');
+    });
+  });
+});


### PR DESCRIPTION
Closes #626. Implements child of epic #615 (environment picker).

## Scope

Extends `shared/cli-gateway-contract.ts` so `sessions.create` accepts a typed `environment: { nodeId, repoIdentity?, repoInstanceId?, benchId?, cwd }` object. Sourced from `EnvironmentOption` in `shared/environment-option.ts` (#623/#634) and the canonical `RepoIdentity` from `shared/repo-identity.ts` + scoped IDs from `shared/identity.ts`.

Backend + schema only. No UI wiring.

## Schema additions

- new `CreateSessionEnvironment` schema (additionalProperties:false) with `nodeId`, `cwd` required and optional `repoIdentity`, `repoInstanceId`, `benchId`.
- raw `host` / `path` fields are intentionally absent and rejected by `additionalProperties:false` (the exact #626 anti-pattern).
- schema fixture committed at `docs/cli-schema/sessions.create.environment.json` for adapter generators.

## Validation (`shared/cli-gateway-runtime.ts`)

- rejects unknown fields under `environment` (notably raw `host`/`path`).
- requires `environment.nodeId` and `environment.cwd`.
- `environment.benchId` requires `environment.repoIdentity` or `environment.repoInstanceId` (a Bench is anchored to a RepoInstance per `docs/WORKBENCH_BOUNDARY.md`).
- mixing `environment` with any legacy flat field (`nodeId`, `repoPath`, `worktreePath`, `cwd`) returns `INVALID_ARGUMENT` — callers pick one shape per request.
- `environment.nodeId` propagates as the effective routing nodeId.
- local `/sessions` gateway creation rejects `environment` (typed `environment` always implies routed creation).

## Deprecation policy

Legacy flat fields (`nodeId`, `repoPath`, `worktreePath`, `cwd`) remain accepted in **v1.x** so adapters shipped before #626 do not break. They are documented as deprecated in `docs/CLI_GATEWAY.md` with target removal at **v2**. The typed `environment` object is the canonical shape new adapters should emit. This matches the prior pattern in the codebase of failing closed on conflicts (e.g. `agent-chat-v1-compat.ts` for ChatEvent legacy bridge) while keeping a hard removal version visible to consumers.

## Tests

`test/cli-gateway/typed-env-ids.test.ts` — 16 cases covering:

- schema surface (typed environment present; no `host`/`path`).
- accept paths (minimal `{nodeId, cwd}`; full `{nodeId, repoIdentity, repoInstanceId, benchId, cwd}`).
- reject paths (raw host/path, missing nodeId, missing cwd, benchId without repo binding).
- deprecation policy (legacy flat still accepted; mixing rejected; conflicting `worktreePath` rejected).
- contract manifest schema regression.
- back-compat round-trip on the existing routed-create and local-create bodies.

`npm run check` and `npm test` (244 files / 2863 tests) are green locally.

## Refs

- Parent epic: #615 (environment picker for node/repo/worktree launch context)
- Data model: #623 / merged in PR #634 (`EnvironmentOption`)
- RepoIdentity: already present in `shared/repo-identity.ts` and `shared/identity.ts`
- ADR-017 (brain-as-peer)
- `docs/CLI_GATEWAY.md`, `docs/WORKBENCH_BOUNDARY.md`

## Test plan

- [ ] CI green on nightly base
- [ ] Copilot + Gemini bot review pass
- [ ] Confirm `docs/cli-schema/sessions.create.environment.json` matches the in-source schema after merge