### PR TITLE
feat: workbench canvas layout persistence (slice 3/5, #621)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1945,7 +1945,9 @@ export async function fetchSecurityAuditVerify(): Promise<SecurityAuditVerifyRes
 export async function fetchWorkbenchLayout(
   workspaceId: string
 ): Promise<WorkbenchLayout | null> {
-  const res = await fetch(`/workspace-groups/${workspaceId}/workbench-layout`);
+  const res = await fetch(
+    `/workspace-groups/${encodeURIComponent(workspaceId)}/workbench-layout`
+  );
   if (res.status === 204) return null;
   if (!res.ok)
     throw new Error(
@@ -1962,11 +1964,14 @@ export async function putWorkbenchLayout(
   workspaceId: string,
   layout: WorkbenchLayout
 ): Promise<WorkbenchLayout> {
-  const res = await fetch(`/workspace-groups/${workspaceId}/workbench-layout`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(layout),
-  });
+  const res = await fetch(
+    `/workspace-groups/${encodeURIComponent(workspaceId)}/workbench-layout`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(layout),
+    }
+  );
   if (!res.ok)
     throw new Error(
       await parseErrorBody(res, 'Failed to save workbench layout')

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,3 +1,4 @@
+import type { WorkbenchLayout } from '../../../shared/workbench-layout-types.js';
 import type {
   SessionSummary,
   WorktreeInfo,
@@ -1921,7 +1922,8 @@ export async function fetchSecurityAuditEntries(params?: {
   limit?: number;
 }): Promise<SecurityAuditEntriesResponse> {
   const qs = new URLSearchParams();
-  if (params?.beforeSequence != null) qs.set('beforeSequence', String(params.beforeSequence));
+  if (params?.beforeSequence != null)
+    qs.set('beforeSequence', String(params.beforeSequence));
   if (params?.limit) qs.set('limit', String(params.limit));
   return json<SecurityAuditEntriesResponse>(
     await fetch(`/hub/audit/entries${qs.toString() ? '?' + qs.toString() : ''}`)
@@ -1930,4 +1932,44 @@ export async function fetchSecurityAuditEntries(params?: {
 
 export async function fetchSecurityAuditVerify(): Promise<SecurityAuditVerifyResponse> {
   return json<SecurityAuditVerifyResponse>(await fetch('/hub/audit/verify'));
+}
+
+// ---------------------------------------------------------------------------
+// Workbench layout API (slice 3 of epic #612)
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the persisted workbench layout for a workspace.
+ * Returns `null` if no layout has been saved yet (server responds 204).
+ */
+export async function fetchWorkbenchLayout(
+  workspaceId: string
+): Promise<WorkbenchLayout | null> {
+  const res = await fetch(`/workspace-groups/${workspaceId}/workbench-layout`);
+  if (res.status === 204) return null;
+  if (!res.ok)
+    throw new Error(
+      await parseErrorBody(res, 'Failed to fetch workbench layout')
+    );
+  return json<WorkbenchLayout>(res);
+}
+
+/**
+ * Persist a workbench layout for a workspace.
+ * Returns the layout as stored by the server.
+ */
+export async function putWorkbenchLayout(
+  workspaceId: string,
+  layout: WorkbenchLayout
+): Promise<WorkbenchLayout> {
+  const res = await fetch(`/workspace-groups/${workspaceId}/workbench-layout`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(layout),
+  });
+  if (!res.ok)
+    throw new Error(
+      await parseErrorBody(res, 'Failed to save workbench layout')
+    );
+  return jsonEither<WorkbenchLayout>(res);
 }

--- a/frontend/src/workbench/WorkbenchCanvas.tsx
+++ b/frontend/src/workbench/WorkbenchCanvas.tsx
@@ -26,6 +26,7 @@ import {
   type DragCancelEvent,
 } from '@dnd-kit/core';
 import { useDraggable } from '@dnd-kit/core';
+import { CSS } from '@dnd-kit/utilities';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type {
@@ -33,7 +34,10 @@ import type {
   WorkbenchBlockPlacement,
 } from '../../../shared/workbench-layout-types.js';
 import { WORKBENCH_LAYOUT_SCHEMA_VERSION } from '../../../shared/workbench-layout-types.js';
-import type { WorkbenchBlockContext } from '../../../shared/workbench-block-types.js';
+import type {
+  WorkbenchBlockContext,
+  WorkbenchBlockDescriptor,
+} from '../../../shared/workbench-block-types.js';
 import { fetchWorkbenchLayout, putWorkbenchLayout } from '../lib/api.js';
 import { BlockHost } from './BlockHost.js';
 import './workbench-canvas.css';
@@ -110,6 +114,31 @@ function useBlockResize(
   onResize: (blockId: string, size: { width: number; height: number }) => void
 ) {
   const resizeRef = useRef<ResizeState | null>(null);
+  // Use a ref so mousemove/mouseup listeners always read the latest callback
+  // without needing to be re-added on every render.
+  const onResizeRef = useRef(onResize);
+  onResizeRef.current = onResize;
+
+  // Store the current listener functions so we can remove them on unmount
+  // even if a resize is still in progress.
+  const listenersRef = useRef<{
+    onMouseMove: ((ev: MouseEvent) => void) | null;
+    onMouseUp: (() => void) | null;
+  }>({ onMouseMove: null, onMouseUp: null });
+
+  // Cleanup on unmount: remove any active window listeners.
+  useEffect(() => {
+    // Capture the ref value at effect setup time for the cleanup closure,
+    // as recommended by the react-hooks/exhaustive-deps rule.
+    const listeners = listenersRef.current;
+    return () => {
+      if (listeners.onMouseMove)
+        window.removeEventListener('mousemove', listeners.onMouseMove);
+      if (listeners.onMouseUp)
+        window.removeEventListener('mouseup', listeners.onMouseUp);
+      resizeRef.current = null;
+    };
+  }, []);
 
   const onMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -126,7 +155,8 @@ function useBlockResize(
         if (!resizeRef.current) return;
         const dx = ev.clientX - resizeRef.current.startX;
         const dy = ev.clientY - resizeRef.current.startY;
-        onResize(blockId, {
+        // Read from ref so we always call the latest callback.
+        onResizeRef.current(blockId, {
           width: Math.max(200, resizeRef.current.startWidth + dx),
           height: Math.max(80, resizeRef.current.startHeight + dy),
         });
@@ -134,14 +164,20 @@ function useBlockResize(
 
       function onMouseUp() {
         resizeRef.current = null;
+        listenersRef.current.onMouseMove = null;
+        listenersRef.current.onMouseUp = null;
         window.removeEventListener('mousemove', onMouseMove);
         window.removeEventListener('mouseup', onMouseUp);
       }
 
+      listenersRef.current.onMouseMove = onMouseMove;
+      listenersRef.current.onMouseUp = onMouseUp;
       window.addEventListener('mousemove', onMouseMove);
       window.addEventListener('mouseup', onMouseUp);
     },
-    [blockId, currentSize.width, currentSize.height, onResize]
+    // currentSize values are captured at drag-start time via resizeRef, so
+    // they do not need to be deps here — only blockId which is stable per block.
+    [blockId, currentSize.width, currentSize.height]
   );
 
   return { onMouseDown };
@@ -168,9 +204,10 @@ function CanvasBlock({
   const blockId = descriptor.id;
 
   // dnd-kit draggable — title bar is the handle
-  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
-    id: blockId,
-  });
+  const { attributes, listeners, setNodeRef, isDragging, transform } =
+    useDraggable({
+      id: blockId,
+    });
 
   const { onMouseDown: onResizeMouseDown } = useBlockResize(
     blockId,
@@ -196,17 +233,25 @@ function CanvasBlock({
       style={{
         left: position.x,
         top: position.y,
-        width: minimized ? size.width : size.width,
+        width: size.width,
         height: minimized ? 'auto' : size.height,
+        // Bug 6 fix: apply dnd-kit transform during drag for live tracking.
+        // Without this, the block only snaps to the new position on drag end.
+        // Persist still happens on drag end (handleDragEnd) — no double-persist.
+        transform: isDragging ? CSS.Translate.toString(transform) : undefined,
       }}
     >
       {/* Title bar — drag handle */}
       <div className="canvas-block__titlebar" {...listeners} {...attributes}>
         <span className="canvas-block__kind">{descriptor.kind}</span>
         <span className="canvas-block__title">{descriptor.title}</span>
+        {/* Bug 7 fix: stop pointerDown propagation so dragging cannot start
+            when the user clicks the minimize button. Stopping click alone is
+            insufficient because dnd-kit's PointerSensor fires on pointerdown. */}
         <button
           type="button"
           className="canvas-block__minimize-btn"
+          onPointerDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
             onMinimizeToggle(blockId);
@@ -220,16 +265,56 @@ function CanvasBlock({
       {/* Block content */}
       {!minimized && (
         <div className="canvas-block__body">
-          <BlockHost descriptor={descriptor} context={context} />
+          {/* Safe cast: WorkbenchBlockPlacementDescriptor is a superset of
+              WorkbenchBlockDescriptor. BlockHost handles unknown kinds via its
+              registry fallback (UnknownKindCard). All required fields (kind, id,
+              title, capabilityRequirements) are validated at deserialization time
+              so this cast cannot produce a crash inside BlockHost. */}
+          <BlockHost
+            descriptor={descriptor as WorkbenchBlockDescriptor}
+            context={context}
+          />
         </div>
       )}
 
-      {/* Resize handle */}
+      {/* Resize handle — Bug 8 fix: semantic role, keyboard resize support. */}
       {!minimized && (
         <div
           className="canvas-block__resize-handle"
-          onMouseDown={onResizeMouseDown}
+          role="separator"
+          aria-orientation="horizontal"
           aria-label="resize block"
+          tabIndex={0}
+          onMouseDown={onResizeMouseDown}
+          onKeyDown={(e) => {
+            // Arrow keys provide keyboard resize: 16px steps.
+            const step = 16;
+            if (e.key === 'ArrowRight') {
+              e.preventDefault();
+              onResize(blockId, {
+                width: Math.max(200, size.width + step),
+                height: size.height,
+              });
+            } else if (e.key === 'ArrowLeft') {
+              e.preventDefault();
+              onResize(blockId, {
+                width: Math.max(200, size.width - step),
+                height: size.height,
+              });
+            } else if (e.key === 'ArrowDown') {
+              e.preventDefault();
+              onResize(blockId, {
+                width: size.width,
+                height: Math.max(80, size.height + step),
+              });
+            } else if (e.key === 'ArrowUp') {
+              e.preventDefault();
+              onResize(blockId, {
+                width: size.width,
+                height: Math.max(80, size.height - step),
+              });
+            }
+          }}
         />
       )}
     </div>
@@ -301,15 +386,23 @@ export function WorkbenchCanvas({
     300
   );
 
-  // Apply a layout mutation locally + schedule persist
+  // Keep a ref to the latest layout so applyUpdate can read current state
+  // outside the setState updater (required to avoid side effects inside updaters).
+  const layoutRef = useRef<WorkbenchLayout | null>(layout);
+  layoutRef.current = layout;
+
+  // Apply a layout mutation locally + schedule persist.
+  // Bug 2 fix: React requires functional updaters passed to setState to be
+  // pure — they may run more than once. debouncedPersist is a side effect and
+  // must NOT be called inside the updater. Instead, compute next state from the
+  // ref snapshot, set it, then persist outside the updater.
   const applyUpdate = useCallback(
     (updater: (prev: WorkbenchLayout) => WorkbenchLayout) => {
-      setLayout((prev) => {
-        if (!prev) return prev;
-        const next = updater(prev);
-        debouncedPersist(next);
-        return next;
-      });
+      const prev = layoutRef.current;
+      if (!prev) return;
+      const next = updater(prev);
+      setLayout(next);
+      debouncedPersist(next);
     },
     [debouncedPersist]
   );

--- a/frontend/src/workbench/WorkbenchCanvas.tsx
+++ b/frontend/src/workbench/WorkbenchCanvas.tsx
@@ -1,0 +1,490 @@
+/**
+ * WorkbenchCanvas — slice 3 of epic #612.
+ *
+ * Renders all Workbench blocks in a freeform pixel-positioned canvas.
+ * Each block can be:
+ *   - dragged via its title bar (uses @dnd-kit/core — already a project dep)
+ *   - resized via a bottom-right resize handle (mouse drag)
+ *   - minimized/restored via the title bar button
+ *
+ * Layout state is fetched via TanStack Query and persisted via a debounced
+ * PUT mutation on every change. No refetchInterval — mutations drive cache
+ * invalidation per the project's anti-polling convention.
+ *
+ * This component does NOT wire into App.tsx or the sidebar — it is
+ * self-contained for now (slice 3 boundary, per #621 scope).
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  DndContext,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+  type DragCancelEvent,
+} from '@dnd-kit/core';
+import { useDraggable } from '@dnd-kit/core';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type {
+  WorkbenchLayout,
+  WorkbenchBlockPlacement,
+} from '../../../shared/workbench-layout-types.js';
+import { WORKBENCH_LAYOUT_SCHEMA_VERSION } from '../../../shared/workbench-layout-types.js';
+import type { WorkbenchBlockContext } from '../../../shared/workbench-block-types.js';
+import { fetchWorkbenchLayout, putWorkbenchLayout } from '../lib/api.js';
+import { BlockHost } from './BlockHost.js';
+import './workbench-canvas.css';
+
+// ---------------------------------------------------------------------------
+// Query key factory
+// ---------------------------------------------------------------------------
+
+export const workbenchLayoutQueryKey = (workspaceId: string) =>
+  ['workbench-layout', workspaceId] as const;
+
+// ---------------------------------------------------------------------------
+// Debounce helper
+// ---------------------------------------------------------------------------
+
+function useDebouncedCallback<T extends unknown[]>(
+  fn: (...args: T) => void,
+  delay: number
+): (...args: T) => void {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fnRef = useRef(fn);
+  fnRef.current = fn;
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    },
+    []
+  );
+
+  return useCallback(
+    (...args: T) => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        fnRef.current(...args);
+      }, delay);
+    },
+    [delay]
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Minimal WorkbenchBlockContext factory
+// ---------------------------------------------------------------------------
+
+const NOOP_EMIT: WorkbenchBlockContext['emitAuditEvent'] = () => undefined;
+const NOOP_REQUEST_CAP: WorkbenchBlockContext['requestCapability'] = () =>
+  Promise.resolve(false);
+
+function makeBlockContext(onClose: () => void): WorkbenchBlockContext {
+  return {
+    capabilityGrants: [],
+    requestCapability: NOOP_REQUEST_CAP,
+    close: onClose,
+    emitAuditEvent: NOOP_EMIT,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Resize hook — bottom-right corner drag
+// ---------------------------------------------------------------------------
+
+interface ResizeState {
+  startX: number;
+  startY: number;
+  startWidth: number;
+  startHeight: number;
+}
+
+function useBlockResize(
+  blockId: string,
+  currentSize: { width: number; height: number },
+  onResize: (blockId: string, size: { width: number; height: number }) => void
+) {
+  const resizeRef = useRef<ResizeState | null>(null);
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      resizeRef.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        startWidth: currentSize.width,
+        startHeight: currentSize.height,
+      };
+
+      function onMouseMove(ev: MouseEvent) {
+        if (!resizeRef.current) return;
+        const dx = ev.clientX - resizeRef.current.startX;
+        const dy = ev.clientY - resizeRef.current.startY;
+        onResize(blockId, {
+          width: Math.max(200, resizeRef.current.startWidth + dx),
+          height: Math.max(80, resizeRef.current.startHeight + dy),
+        });
+      }
+
+      function onMouseUp() {
+        resizeRef.current = null;
+        window.removeEventListener('mousemove', onMouseMove);
+        window.removeEventListener('mouseup', onMouseUp);
+      }
+
+      window.addEventListener('mousemove', onMouseMove);
+      window.addEventListener('mouseup', onMouseUp);
+    },
+    [blockId, currentSize.width, currentSize.height, onResize]
+  );
+
+  return { onMouseDown };
+}
+
+// ---------------------------------------------------------------------------
+// CanvasBlock — one block on the canvas
+// ---------------------------------------------------------------------------
+
+interface CanvasBlockProps {
+  placement: WorkbenchBlockPlacement;
+  onMinimizeToggle: (blockId: string) => void;
+  onResize: (blockId: string, size: { width: number; height: number }) => void;
+  onClose: (blockId: string) => void;
+}
+
+function CanvasBlock({
+  placement,
+  onMinimizeToggle,
+  onResize,
+  onClose,
+}: CanvasBlockProps): React.ReactElement {
+  const { descriptor, position, size, minimized } = placement;
+  const blockId = descriptor.id;
+
+  // dnd-kit draggable — title bar is the handle
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: blockId,
+  });
+
+  const { onMouseDown: onResizeMouseDown } = useBlockResize(
+    blockId,
+    size,
+    onResize
+  );
+
+  const context = React.useMemo(
+    () => makeBlockContext(() => onClose(blockId)),
+    [blockId, onClose]
+  );
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={[
+        'canvas-block',
+        minimized ? 'canvas-block--minimized' : '',
+        isDragging ? 'canvas-block--dragging' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      style={{
+        left: position.x,
+        top: position.y,
+        width: minimized ? size.width : size.width,
+        height: minimized ? 'auto' : size.height,
+      }}
+    >
+      {/* Title bar — drag handle */}
+      <div className="canvas-block__titlebar" {...listeners} {...attributes}>
+        <span className="canvas-block__kind">{descriptor.kind}</span>
+        <span className="canvas-block__title">{descriptor.title}</span>
+        <button
+          type="button"
+          className="canvas-block__minimize-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            onMinimizeToggle(blockId);
+          }}
+          aria-label={minimized ? 'restore' : 'minimize'}
+        >
+          {minimized ? '+' : '−'}
+        </button>
+      </div>
+
+      {/* Block content */}
+      {!minimized && (
+        <div className="canvas-block__body">
+          <BlockHost descriptor={descriptor} context={context} />
+        </div>
+      )}
+
+      {/* Resize handle */}
+      {!minimized && (
+        <div
+          className="canvas-block__resize-handle"
+          onMouseDown={onResizeMouseDown}
+          aria-label="resize block"
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// WorkbenchCanvas
+// ---------------------------------------------------------------------------
+
+export interface WorkbenchCanvasProps {
+  workspaceId: string;
+}
+
+/**
+ * WorkbenchCanvas renders all blocks for a workspace in a freeform
+ * pixel-positioned canvas. Layout is loaded via TanStack Query and
+ * persisted via a debounced PUT mutation.
+ *
+ * Grid vs freeform decision: freeform pixel coordinates.
+ * The Workbench is a floating-block surface analogous to a virtual desktop,
+ * not a split-pane editor. The existing react-resizable-panels split model
+ * is scoped to the SessionPane workspace; Workbench blocks are independently
+ * draggable overlays.
+ *
+ * Reused primitives:
+ *   - @dnd-kit/core (PointerSensor, useDraggable, DndContext) — same lib
+ *     used by WorkspaceLayout for tab drag.
+ *   - Mouse-event resize — lightweight custom hook; react-resizable-panels
+ *     is percentage-split oriented and not suitable for freeform block resize.
+ */
+export function WorkbenchCanvas({
+  workspaceId,
+}: WorkbenchCanvasProps): React.ReactElement {
+  const queryClient = useQueryClient();
+  const queryKey = workbenchLayoutQueryKey(workspaceId);
+
+  // Fetch persisted layout
+  const { data: serverLayout, isLoading } = useQuery<WorkbenchLayout | null>({
+    queryKey,
+    queryFn: () => fetchWorkbenchLayout(workspaceId),
+    // No refetchInterval — mutation-driven invalidation only
+    staleTime: Infinity,
+  });
+
+  // Local layout state — optimistically updated on user interaction
+  const [layout, setLayout] = useState<WorkbenchLayout | null>(null);
+
+  // Sync server layout into local state on initial load
+  useEffect(() => {
+    if (serverLayout !== undefined) {
+      setLayout(serverLayout);
+    }
+  }, [serverLayout]);
+
+  // Persist mutation
+  const { mutate: persistLayout } = useMutation({
+    mutationFn: (next: WorkbenchLayout) =>
+      putWorkbenchLayout(workspaceId, next),
+    onSuccess: (saved) => {
+      queryClient.setQueryData(queryKey, saved);
+    },
+  });
+
+  // Debounce the persist call (300ms) to avoid hammering the server
+  // during continuous drag/resize
+  const debouncedPersist = useDebouncedCallback(
+    (next: WorkbenchLayout) => persistLayout(next),
+    300
+  );
+
+  // Apply a layout mutation locally + schedule persist
+  const applyUpdate = useCallback(
+    (updater: (prev: WorkbenchLayout) => WorkbenchLayout) => {
+      setLayout((prev) => {
+        if (!prev) return prev;
+        const next = updater(prev);
+        debouncedPersist(next);
+        return next;
+      });
+    },
+    [debouncedPersist]
+  );
+
+  // ---------------------------------------------------------------------------
+  // DnD — drag block positions
+  // ---------------------------------------------------------------------------
+
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  // Track the position at drag-start so we can compute delta on drag-end.
+  // @dnd-kit reports the total delta from the initial pointer-down position.
+  const dragStartPositionRef = useRef<{ x: number; y: number } | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } })
+  );
+
+  const handleDragStart = useCallback(
+    (evt: DragStartEvent) => {
+      const id = String(evt.active.id);
+      setDraggingId(id);
+      const block = layout?.blocks.find((b) => b.descriptor.id === id);
+      if (block) {
+        dragStartPositionRef.current = { ...block.position };
+      }
+    },
+    [layout]
+  );
+
+  const handleDragCancel = useCallback((_evt: DragCancelEvent) => {
+    setDraggingId(null);
+    dragStartPositionRef.current = null;
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (evt: DragEndEvent) => {
+      setDraggingId(null);
+      if (!dragStartPositionRef.current) return;
+      const delta = evt.delta;
+      const startPos = dragStartPositionRef.current;
+      dragStartPositionRef.current = null;
+      const id = String(evt.active.id);
+
+      applyUpdate((prev) => ({
+        ...prev,
+        blocks: prev.blocks.map((b) =>
+          b.descriptor.id === id
+            ? {
+                ...b,
+                position: {
+                  x: Math.max(0, startPos.x + delta.x),
+                  y: Math.max(0, startPos.y + delta.y),
+                },
+              }
+            : b
+        ),
+      }));
+    },
+    [applyUpdate]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Resize
+  // ---------------------------------------------------------------------------
+
+  const handleResize = useCallback(
+    (blockId: string, size: { width: number; height: number }) => {
+      applyUpdate((prev) => ({
+        ...prev,
+        blocks: prev.blocks.map((b) =>
+          b.descriptor.id === blockId ? { ...b, size } : b
+        ),
+      }));
+    },
+    [applyUpdate]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Minimize toggle
+  // ---------------------------------------------------------------------------
+
+  const handleMinimizeToggle = useCallback(
+    (blockId: string) => {
+      applyUpdate((prev) => ({
+        ...prev,
+        blocks: prev.blocks.map((b) =>
+          b.descriptor.id === blockId ? { ...b, minimized: !b.minimized } : b
+        ),
+      }));
+    },
+    [applyUpdate]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Close (remove from layout)
+  // ---------------------------------------------------------------------------
+
+  const handleClose = useCallback(
+    (blockId: string) => {
+      applyUpdate((prev) => ({
+        ...prev,
+        blocks: prev.blocks.filter((b) => b.descriptor.id !== blockId),
+      }));
+    },
+    [applyUpdate]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  if (isLoading) {
+    return (
+      <div className="workbench-canvas">
+        <div className="workbench-canvas__loading">loading workbench…</div>
+      </div>
+    );
+  }
+
+  if (!layout || layout.blocks.length === 0) {
+    return (
+      <div className="workbench-canvas">
+        <div className="workbench-canvas__empty">
+          no blocks in this workspace
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <div
+        className={[
+          'workbench-canvas',
+          draggingId ? 'workbench-canvas--dragging' : '',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        {layout.blocks.map((placement) => (
+          <CanvasBlock
+            key={placement.descriptor.id}
+            placement={placement}
+            onMinimizeToggle={handleMinimizeToggle}
+            onResize={handleResize}
+            onClose={handleClose}
+          />
+        ))}
+      </div>
+    </DndContext>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Factory helper — create an empty layout for a workspace
+// ---------------------------------------------------------------------------
+
+export function createEmptyWorkbenchLayout(
+  workspaceId: string,
+  displayName?: string
+): WorkbenchLayout {
+  const scope =
+    displayName !== undefined
+      ? { id: workspaceId, displayName }
+      : { id: workspaceId };
+  return {
+    schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+    workspaceScope: scope,
+    blocks: [],
+  };
+}
+
+export default WorkbenchCanvas;

--- a/frontend/src/workbench/workbench-canvas.css
+++ b/frontend/src/workbench/workbench-canvas.css
@@ -1,0 +1,145 @@
+/* ===== WorkbenchCanvas ===== */
+
+.workbench-canvas {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg);
+  font-family: var(--font-mono);
+}
+
+/* ===== CanvasBlock — a positioned block wrapper on the canvas ===== */
+
+.canvas-block {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  overflow: hidden;
+  min-width: 200px;
+  min-height: 80px;
+  box-sizing: border-box;
+}
+
+.canvas-block--minimized {
+  overflow: visible;
+}
+
+.canvas-block--minimized .canvas-block__body {
+  display: none;
+}
+
+/* ===== Block title bar (drag handle) ===== */
+
+.canvas-block__titlebar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+  padding: 4px var(--space-sm, 8px);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  cursor: grab;
+  user-select: none;
+  flex-shrink: 0;
+  min-height: 28px;
+}
+
+.canvas-block__titlebar:active {
+  cursor: grabbing;
+}
+
+/* While a drag is in progress on this block, suppress pointer events on
+   the inner content so xterm/iframes don't intercept the drag. */
+.canvas-block--dragging .canvas-block__body {
+  pointer-events: none;
+}
+
+.canvas-block__kind {
+  font-size: var(--font-size-xs, 0.75rem);
+  color: var(--text-muted);
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+}
+
+.canvas-block__title {
+  font-size: var(--font-size-xs, 0.75rem);
+  color: var(--text);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Minimize/restore button */
+.canvas-block__minimize-btn {
+  flex-shrink: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs, 0.75rem);
+  padding: 0 var(--space-xs, 4px);
+  cursor: pointer;
+  line-height: 1.4;
+}
+
+.canvas-block__minimize-btn:hover {
+  border-color: var(--border);
+  color: var(--text);
+}
+
+/* ===== Block body (content area) ===== */
+
+.canvas-block__body {
+  flex: 1;
+  overflow: hidden;
+  position: relative;
+}
+
+/* ===== Resize handle (bottom-right corner) ===== */
+
+.canvas-block__resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 12px;
+  height: 12px;
+  cursor: nwse-resize;
+  z-index: 10;
+}
+
+/* Draw a subtle triangle indicator */
+.canvas-block__resize-handle::after {
+  content: '';
+  position: absolute;
+  bottom: 2px;
+  right: 2px;
+  width: 6px;
+  height: 6px;
+  border-bottom: 1px solid var(--text-muted);
+  border-right: 1px solid var(--text-muted);
+}
+
+/* ===== Loading / empty states ===== */
+
+.workbench-canvas__loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: var(--font-size-sm, 0.8125rem);
+  color: var(--text-muted);
+}
+
+.workbench-canvas__empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: var(--font-size-sm, 0.8125rem);
+  color: var(--text-muted);
+}

--- a/frontend/src/workbench/workbench-canvas.css
+++ b/frontend/src/workbench/workbench-canvas.css
@@ -90,6 +90,11 @@
   color: var(--text);
 }
 
+.canvas-block__minimize-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 /* ===== Block body (content area) ===== */
 
 .canvas-block__body {
@@ -108,6 +113,11 @@
   height: 12px;
   cursor: nwse-resize;
   z-index: 10;
+}
+
+.canvas-block__resize-handle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* Draw a subtle triangle indicator */

--- a/server/index.ts
+++ b/server/index.ts
@@ -84,6 +84,7 @@ import {
 } from './workspaces.js';
 import { clearCiStatusCache } from './gh.js';
 import { createWorkspaceGroupsRouter } from './workspace-groups.js';
+import { createWorkbenchLayoutRouter } from './workbench-layout.js';
 import { createOrgDashboardRouter } from './org-dashboard.js';
 import { createIntegrationGitHubRouter } from './integration-github.js';
 import {
@@ -855,12 +856,10 @@ export function validateSessionCreateRequest(
   } else {
     const anchor = repoPath ?? cwd ?? '';
     if (!configured.has(anchor)) {
-      res
-        .status(400)
-        .json({
-          error:
-            'terminal sessions require a cwd that is a configured project path',
-        });
+      res.status(400).json({
+        error:
+          'terminal sessions require a cwd that is a configured project path',
+      });
       return false;
     }
   }
@@ -1727,6 +1726,14 @@ async function main(): Promise<void> {
       gitWatcher,
       configPath: CONFIG_PATH,
     })
+  );
+
+  // Mount workbench layout persistence router
+  // GET/PUT /workspace-groups/:id/workbench-layout
+  app.use(
+    '/workspace-groups',
+    requireAuth,
+    createWorkbenchLayoutRouter({ configPath: CONFIG_PATH })
   );
 
   // Mount GitHub integration router

--- a/server/workbench-layout.ts
+++ b/server/workbench-layout.ts
@@ -121,6 +121,74 @@ export function deleteWorkbenchLayout(
 // ---------------------------------------------------------------------------
 
 /**
+ * Validate a single block placement in a layout body.
+ * Extracted from validateLayoutBody to keep per-function complexity manageable.
+ * Returns a descriptive error string on failure, or null on success.
+ */
+function validateBlockPlacementBody(block: unknown, i: number): string | null {
+  if (typeof block !== 'object' || block === null || Array.isArray(block)) {
+    return `blocks[${i}] must be an object`;
+  }
+  const b = block as Record<string, unknown>;
+
+  const descriptor = b['descriptor'];
+  if (
+    typeof descriptor !== 'object' ||
+    descriptor === null ||
+    Array.isArray(descriptor)
+  ) {
+    return `blocks[${i}].descriptor must be an object`;
+  }
+  const desc = descriptor as Record<string, unknown>;
+  if (typeof desc['kind'] !== 'string') {
+    return `blocks[${i}].descriptor.kind must be a string`;
+  }
+  if (typeof desc['id'] !== 'string') {
+    return `blocks[${i}].descriptor.id must be a string`;
+  }
+  // Bug 3 fix: validate title and capabilityRequirements so the server
+  // rejects malformed descriptors before they reach missingCapabilities().
+  if (typeof desc['title'] !== 'string') {
+    return `blocks[${i}].descriptor.title must be a string`;
+  }
+  if (!Array.isArray(desc['capabilityRequirements'])) {
+    return `blocks[${i}].descriptor.capabilityRequirements must be an array`;
+  }
+  const capReqs = desc['capabilityRequirements'] as unknown[];
+  for (let j = 0; j < capReqs.length; j++) {
+    if (typeof capReqs[j] !== 'string') {
+      return `blocks[${i}].descriptor.capabilityRequirements[${j}] must be a string`;
+    }
+  }
+
+  const pos = b['position'];
+  if (
+    typeof pos !== 'object' ||
+    pos === null ||
+    typeof (pos as Record<string, unknown>)['x'] !== 'number' ||
+    typeof (pos as Record<string, unknown>)['y'] !== 'number'
+  ) {
+    return `blocks[${i}].position must have numeric x and y`;
+  }
+
+  const sz = b['size'];
+  if (
+    typeof sz !== 'object' ||
+    sz === null ||
+    typeof (sz as Record<string, unknown>)['width'] !== 'number' ||
+    typeof (sz as Record<string, unknown>)['height'] !== 'number'
+  ) {
+    return `blocks[${i}].size must have numeric width and height`;
+  }
+
+  if (b['minimized'] !== undefined && typeof b['minimized'] !== 'boolean') {
+    return `blocks[${i}].minimized must be a boolean`;
+  }
+
+  return null;
+}
+
+/**
  * Validate that a layout body submitted via PUT is structurally valid.
  * Returns a descriptive error string on failure, or null on success.
  */
@@ -153,47 +221,8 @@ export function validateLayoutBody(body: unknown): string | null {
 
   const blocks = obj['blocks'] as unknown[];
   for (let i = 0; i < blocks.length; i++) {
-    const block = blocks[i];
-    if (typeof block !== 'object' || block === null || Array.isArray(block)) {
-      return `blocks[${i}] must be an object`;
-    }
-    const b = block as Record<string, unknown>;
-
-    const descriptor = b['descriptor'];
-    if (
-      typeof descriptor !== 'object' ||
-      descriptor === null ||
-      typeof (descriptor as Record<string, unknown>)['kind'] !== 'string'
-    ) {
-      return `blocks[${i}].descriptor.kind must be a string`;
-    }
-    if (typeof (descriptor as Record<string, unknown>)['id'] !== 'string') {
-      return `blocks[${i}].descriptor.id must be a string`;
-    }
-
-    const pos = b['position'];
-    if (
-      typeof pos !== 'object' ||
-      pos === null ||
-      typeof (pos as Record<string, unknown>)['x'] !== 'number' ||
-      typeof (pos as Record<string, unknown>)['y'] !== 'number'
-    ) {
-      return `blocks[${i}].position must have numeric x and y`;
-    }
-
-    const sz = b['size'];
-    if (
-      typeof sz !== 'object' ||
-      sz === null ||
-      typeof (sz as Record<string, unknown>)['width'] !== 'number' ||
-      typeof (sz as Record<string, unknown>)['height'] !== 'number'
-    ) {
-      return `blocks[${i}].size must have numeric width and height`;
-    }
-
-    if (b['minimized'] !== undefined && typeof b['minimized'] !== 'boolean') {
-      return `blocks[${i}].minimized must be a boolean`;
-    }
+    const err = validateBlockPlacementBody(blocks[i], i);
+    if (err !== null) return err;
   }
 
   return null;
@@ -230,7 +259,9 @@ export function createWorkbenchLayoutRouter(
       res.status(204).end();
       return;
     }
-    res.json(layout);
+    // Use serialiseWorkbenchLayout so _unknown fields are merged back into
+    // each block's top-level representation (round-trip fidelity).
+    res.json(serialiseWorkbenchLayout(layout));
   });
 
   // PUT /:id/workbench-layout
@@ -279,7 +310,9 @@ export function createWorkbenchLayoutRouter(
       return;
     }
 
-    res.json(layout);
+    // Use serialiseWorkbenchLayout so _unknown fields are merged back into
+    // each block's top-level representation (round-trip fidelity).
+    res.json(serialiseWorkbenchLayout(layout));
   });
 
   return router;

--- a/server/workbench-layout.ts
+++ b/server/workbench-layout.ts
@@ -1,0 +1,286 @@
+/**
+ * Workbench layout persistence — slice 3 of epic #612.
+ *
+ * Storage model: one JSON file per workspace, keyed by a SHA-256 prefix of
+ * the workspace id. Files live in `<configDir>/workbench-layouts/`. This
+ * mirrors the `worktree-meta/` pattern from server/config.ts.
+ *
+ * Forward-compat: unknown block kinds and extra placement fields are
+ * preserved verbatim (see deserialiseWorkbenchLayout in shared/).
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+
+import {
+  deserialiseWorkbenchLayout,
+  serialiseWorkbenchLayout,
+  WORKBENCH_LAYOUT_SCHEMA_VERSION,
+} from '../shared/workbench-layout-types.js';
+import type { WorkbenchLayout } from '../shared/workbench-layout-types.js';
+import { createLogger } from './logger.js';
+
+const logger = createLogger('workbench-layout');
+
+// ---------------------------------------------------------------------------
+// File path helpers
+// ---------------------------------------------------------------------------
+
+function layoutDir(configPath: string): string {
+  return path.join(path.dirname(configPath), 'workbench-layouts');
+}
+
+function layoutFilePath(configPath: string, workspaceId: string): string {
+  const hash = crypto
+    .createHash('sha256')
+    .update(workspaceId)
+    .digest('hex')
+    .slice(0, 16);
+  return path.join(layoutDir(configPath), `${hash}.json`);
+}
+
+function ensureLayoutDir(configPath: string): void {
+  const dir = layoutDir(configPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public read/write API (used by router and tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the stored layout for a workspace.
+ * Returns `null` if no layout is stored yet.
+ * Returns `null` and logs a warning on parse error (corrupt file).
+ */
+export function readWorkbenchLayout(
+  configPath: string,
+  workspaceId: string
+): WorkbenchLayout | null {
+  const fp = layoutFilePath(configPath, workspaceId);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(fp, 'utf8');
+  } catch {
+    // File not found — no layout stored yet
+    return null;
+  }
+  try {
+    return deserialiseWorkbenchLayout(JSON.parse(raw));
+  } catch (err) {
+    logger.warn(
+      `Failed to parse workbench layout for workspace ${workspaceId}:`,
+      err instanceof Error ? err.message : err
+    );
+    return null;
+  }
+}
+
+/**
+ * Persist a layout for a workspace.
+ * Throws on write errors.
+ */
+export function writeWorkbenchLayout(
+  configPath: string,
+  workspaceId: string,
+  layout: WorkbenchLayout
+): void {
+  ensureLayoutDir(configPath);
+  const fp = layoutFilePath(configPath, workspaceId);
+  fs.writeFileSync(
+    fp,
+    JSON.stringify(serialiseWorkbenchLayout(layout), null, 2),
+    'utf8'
+  );
+}
+
+/**
+ * Delete the stored layout for a workspace (e.g. when workspace is deleted).
+ * Silently ignores missing files.
+ */
+export function deleteWorkbenchLayout(
+  configPath: string,
+  workspaceId: string
+): void {
+  const fp = layoutFilePath(configPath, workspaceId);
+  try {
+    fs.unlinkSync(fp);
+  } catch {
+    // Ignore missing file
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers (used in the router)
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate that a layout body submitted via PUT is structurally valid.
+ * Returns a descriptive error string on failure, or null on success.
+ */
+export function validateLayoutBody(body: unknown): string | null {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return 'request body must be a JSON object';
+  }
+  const obj = body as Record<string, unknown>;
+
+  const schemaVersion = obj['schemaVersion'];
+  if (typeof schemaVersion !== 'number') {
+    return 'schemaVersion must be a number';
+  }
+  if (schemaVersion !== WORKBENCH_LAYOUT_SCHEMA_VERSION) {
+    return `unsupported schemaVersion ${schemaVersion} (expected ${WORKBENCH_LAYOUT_SCHEMA_VERSION})`;
+  }
+
+  const workspaceScope = obj['workspaceScope'];
+  if (
+    typeof workspaceScope !== 'object' ||
+    workspaceScope === null ||
+    typeof (workspaceScope as Record<string, unknown>)['id'] !== 'string'
+  ) {
+    return 'workspaceScope.id must be a string';
+  }
+
+  if (!Array.isArray(obj['blocks'])) {
+    return 'blocks must be an array';
+  }
+
+  const blocks = obj['blocks'] as unknown[];
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+    if (typeof block !== 'object' || block === null || Array.isArray(block)) {
+      return `blocks[${i}] must be an object`;
+    }
+    const b = block as Record<string, unknown>;
+
+    const descriptor = b['descriptor'];
+    if (
+      typeof descriptor !== 'object' ||
+      descriptor === null ||
+      typeof (descriptor as Record<string, unknown>)['kind'] !== 'string'
+    ) {
+      return `blocks[${i}].descriptor.kind must be a string`;
+    }
+    if (typeof (descriptor as Record<string, unknown>)['id'] !== 'string') {
+      return `blocks[${i}].descriptor.id must be a string`;
+    }
+
+    const pos = b['position'];
+    if (
+      typeof pos !== 'object' ||
+      pos === null ||
+      typeof (pos as Record<string, unknown>)['x'] !== 'number' ||
+      typeof (pos as Record<string, unknown>)['y'] !== 'number'
+    ) {
+      return `blocks[${i}].position must have numeric x and y`;
+    }
+
+    const sz = b['size'];
+    if (
+      typeof sz !== 'object' ||
+      sz === null ||
+      typeof (sz as Record<string, unknown>)['width'] !== 'number' ||
+      typeof (sz as Record<string, unknown>)['height'] !== 'number'
+    ) {
+      return `blocks[${i}].size must have numeric width and height`;
+    }
+
+    if (b['minimized'] !== undefined && typeof b['minimized'] !== 'boolean') {
+      return `blocks[${i}].minimized must be a boolean`;
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Express router factory
+// ---------------------------------------------------------------------------
+
+export interface WorkbenchLayoutRouterDeps {
+  configPath: string;
+}
+
+/**
+ * Creates and returns an Express Router for workbench layout persistence.
+ *
+ * Routes (relative to mount point `/workspace-groups`):
+ *   GET  /:id/workbench-layout  → WorkbenchLayout | null (204 if not set)
+ *   PUT  /:id/workbench-layout  → persists layout, returns 200 with layout
+ *
+ * Auth is applied by the caller (mount with requireAuth middleware).
+ */
+export function createWorkbenchLayoutRouter(
+  deps: WorkbenchLayoutRouterDeps
+): Router {
+  const { configPath } = deps;
+  const router = Router({ mergeParams: true });
+
+  // GET /:id/workbench-layout
+  router.get('/:id/workbench-layout', (req: Request, res: Response) => {
+    const { id } = req.params as { id: string };
+    const layout = readWorkbenchLayout(configPath, id);
+    if (layout === null) {
+      res.status(204).end();
+      return;
+    }
+    res.json(layout);
+  });
+
+  // PUT /:id/workbench-layout
+  router.put('/:id/workbench-layout', (req: Request, res: Response) => {
+    const { id } = req.params as { id: string };
+    const body = req.body as unknown;
+
+    const validationError = validateLayoutBody(body);
+    if (validationError) {
+      res.status(400).json({ error: validationError });
+      return;
+    }
+
+    // Parse via the shared deserialiser (handles unknown kinds, extra fields)
+    let layout: WorkbenchLayout | null;
+    try {
+      layout = deserialiseWorkbenchLayout(body);
+    } catch (err) {
+      res.status(400).json({
+        error: err instanceof Error ? err.message : 'invalid layout body',
+      });
+      return;
+    }
+
+    if (!layout) {
+      res.status(400).json({ error: 'layout body is required' });
+      return;
+    }
+
+    // Scope-guard: workspaceScope.id in body must match the URL :id
+    if (layout.workspaceScope.id !== id) {
+      res.status(400).json({
+        error: 'workspaceScope.id in body must match workspace id in URL',
+      });
+      return;
+    }
+
+    try {
+      writeWorkbenchLayout(configPath, id, layout);
+    } catch (err) {
+      logger.error(
+        `Failed to write workbench layout for workspace ${id}:`,
+        err instanceof Error ? err.message : err
+      );
+      res.status(500).json({ error: 'failed to persist layout' });
+      return;
+    }
+
+    res.json(layout);
+  });
+
+  return router;
+}

--- a/server/workbench-layout.ts
+++ b/server/workbench-layout.ts
@@ -67,9 +67,17 @@ export function readWorkbenchLayout(
   let raw: string;
   try {
     raw = fs.readFileSync(fp, 'utf8');
-  } catch {
-    // File not found — no layout stored yet
-    return null;
+  } catch (err: unknown) {
+    if (
+      err &&
+      typeof err === 'object' &&
+      'code' in err &&
+      (err as NodeJS.ErrnoException).code === 'ENOENT'
+    ) {
+      // File not found — no layout stored yet
+      return null;
+    }
+    throw err;
   }
   try {
     return deserialiseWorkbenchLayout(JSON.parse(raw));

--- a/shared/workbench-layout-types.ts
+++ b/shared/workbench-layout-types.ts
@@ -25,6 +25,7 @@
  */
 
 import type { WorkbenchBlockDescriptor } from './workbench-block-types.js';
+import type { RelayCapabilityBit } from './security-policy.js';
 
 // ---------------------------------------------------------------------------
 // WorkspaceScopeRef
@@ -47,25 +48,58 @@ export interface WorkspaceScopeRef {
 // WorkbenchBlockPlacement
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// WorkbenchBlockPlacementDescriptor — forward-compat widened type
+// ---------------------------------------------------------------------------
+
+/**
+ * An "unknown-capable" descriptor shape used inside `WorkbenchBlockPlacement`.
+ *
+ * Widened beyond `WorkbenchBlockDescriptor` (the closed discriminated union)
+ * so that placement records storing future block kinds (not yet in the client's
+ * union) can round-trip without requiring unsafe casts. The concrete known kinds
+ * narrow normally; unknown kinds fall into the catch-all branch that preserves
+ * the raw `kind` string and arbitrary `meta`.
+ *
+ * `BlockHost` (slice 2) already handles unknown kinds via `getBlockRenderer`
+ * returning `undefined` → `UnknownKindCard`. This type widens the container to
+ * match that runtime reality at the type level.
+ */
+export type WorkbenchBlockPlacementDescriptor =
+  | WorkbenchBlockDescriptor
+  // Unknown future kind — forward-compat catch-all (not in the closed union).
+  // `meta` is intentionally `unknown` because the client cannot validate it.
+  // `_unknown` stashes any extra descriptor fields for round-trip fidelity.
+  | {
+      kind: string;
+      id: string;
+      title: string;
+      capabilityRequirements: ReadonlyArray<RelayCapabilityBit | string>;
+      meta?: unknown;
+      _unknown?: Record<string, unknown>;
+    };
+
 /**
  * Placement record for a single block on the canvas.
  *
- * `descriptor` is a full `WorkbenchBlockDescriptor` (discriminated union on
- * `kind`). When a future kind is added server-side, older clients receive it
- * with `kind` set to the new literal; `getBlockRenderer` returns `undefined`
- * and `BlockHost` renders the UnknownKindCard safe fallback.
+ * `descriptor` is typed as `WorkbenchBlockPlacementDescriptor` — a widened
+ * union that includes both the known `WorkbenchBlockDescriptor` variants and
+ * an unknown-kind catch-all. When a future kind is added server-side, older
+ * clients receive it in the catch-all branch; `getBlockRenderer` returns
+ * `undefined` and `BlockHost` renders the UnknownKindCard safe fallback.
  *
- * The `_unknown` bag captures any extra JSON fields from the server that the
- * current client does not recognise — they are round-tripped back to the
- * server on the next PUT so future state is not silently dropped.
+ * The `_unknown` bag captures any extra JSON fields on the placement object
+ * from the server that the current client does not recognise — they are
+ * round-tripped back to the server on the next PUT so future state is not
+ * silently dropped.
  */
 export interface WorkbenchBlockPlacement {
   /** Full block descriptor — includes kind, id, title, capabilityRequirements, meta. */
-  descriptor: WorkbenchBlockDescriptor;
+  descriptor: WorkbenchBlockPlacementDescriptor;
   /**
    * Top-left corner of the block on the canvas in CSS pixels.
    * Stored as pixel values so the layout is stable across viewport sizes.
-   * The canvas component clamps values to the visible area on mount.
+   * The canvas component clamps x/y to >= 0 on drag end.
    */
   position: { x: number; y: number };
   /**
@@ -112,16 +146,56 @@ export interface WorkbenchLayout {
 export const WORKBENCH_LAYOUT_SCHEMA_VERSION = 1;
 
 // ---------------------------------------------------------------------------
+// Serialised shape (JSON-safe)
+// ---------------------------------------------------------------------------
+
+/**
+ * JSON-safe representation of a `WorkbenchLayout`.
+ * Structurally identical to `WorkbenchLayout` but with all `ReadonlyArray`
+ * fields widened to plain `unknown[]` so the value is directly passable to
+ * `res.json()` or `JSON.stringify` without extra conversion.
+ *
+ * Use `serialiseWorkbenchLayout` to produce this shape — do NOT use
+ * `JSON.parse(JSON.stringify(...))` which performs unnecessary double work.
+ */
+export type SerializedWorkbenchLayout = {
+  schemaVersion: number;
+  workspaceScope: {
+    id: string;
+    displayName?: string;
+  };
+  blocks: unknown[];
+};
+
+// ---------------------------------------------------------------------------
 // Serialization helpers
 // ---------------------------------------------------------------------------
 
 /**
  * Serialise a `WorkbenchLayout` to a plain JSON-compatible object.
- * `ReadonlyArray` fields are cast to `unknown[]` so `JSON.stringify` can
- * handle them without extra conversion at the call site.
+ *
+ * Builds the output object directly — no `JSON.parse(JSON.stringify(...))`
+ * round-trip. The server can pass the result directly to `res.json()`.
+ *
+ * Unknown fields stored in `_unknown` on each block placement are merged back
+ * into the serialised block so they survive round-trips to the server.
  */
-export function serialiseWorkbenchLayout(layout: WorkbenchLayout): unknown {
-  return JSON.parse(JSON.stringify(layout));
+export function serialiseWorkbenchLayout(
+  layout: WorkbenchLayout
+): SerializedWorkbenchLayout {
+  const blocks = layout.blocks.map((placement) => {
+    const { _unknown, ...knownFields } = placement;
+    // Merge _unknown back into the serialised object (known fields win on
+    // conflict so we don't accidentally overwrite typed fields with stale data).
+    return _unknown !== undefined
+      ? { ..._unknown, ...knownFields }
+      : knownFields;
+  });
+  return {
+    schemaVersion: layout.schemaVersion,
+    workspaceScope: { ...layout.workspaceScope },
+    blocks,
+  };
 }
 
 /**
@@ -197,12 +271,44 @@ function deserialiseBlockPlacement(
   if (
     typeof descriptor !== 'object' ||
     descriptor === null ||
-    typeof (descriptor as Record<string, unknown>)['kind'] !== 'string' ||
-    typeof (descriptor as Record<string, unknown>)['id'] !== 'string'
+    Array.isArray(descriptor)
   ) {
     throw new Error(
-      `workbench layout: blocks[${index}].descriptor must have kind and id`
+      `workbench layout: blocks[${index}].descriptor must be an object`
     );
+  }
+  const d = descriptor as Record<string, unknown>;
+
+  if (typeof d['kind'] !== 'string') {
+    throw new Error(
+      `workbench layout: blocks[${index}].descriptor.kind must be a string`
+    );
+  }
+  if (typeof d['id'] !== 'string') {
+    throw new Error(
+      `workbench layout: blocks[${index}].descriptor.id must be a string`
+    );
+  }
+  // Bug 3 fix: validate title and capabilityRequirements so that
+  // missingCapabilities() cannot crash on undefined later.
+  if (typeof d['title'] !== 'string') {
+    throw new Error(
+      `workbench layout: blocks[${index}].descriptor.title must be a string`
+    );
+  }
+  if (!Array.isArray(d['capabilityRequirements'])) {
+    throw new Error(
+      `workbench layout: blocks[${index}].descriptor.capabilityRequirements must be an array`
+    );
+  }
+  // Each entry in capabilityRequirements must be a string.
+  const capReqs = d['capabilityRequirements'] as unknown[];
+  for (let j = 0; j < capReqs.length; j++) {
+    if (typeof capReqs[j] !== 'string') {
+      throw new Error(
+        `workbench layout: blocks[${index}].descriptor.capabilityRequirements[${j}] must be a string`
+      );
+    }
   }
 
   const position = obj['position'];
@@ -232,7 +338,16 @@ function deserialiseBlockPlacement(
   const minimized =
     typeof obj['minimized'] === 'boolean' ? obj['minimized'] : false;
 
-  // Collect any extra fields into _unknown for round-trip fidelity
+  // Bug 4 fix: merge existing _unknown (from a prior deserialization round-trip)
+  // with newly-discovered extra fields. Newly-discovered extras win on conflict
+  // so we don't silently drop fields added by future schema versions.
+  const existingUnknown: Record<string, unknown> =
+    typeof obj['_unknown'] === 'object' &&
+    obj['_unknown'] !== null &&
+    !Array.isArray(obj['_unknown'])
+      ? (obj['_unknown'] as Record<string, unknown>)
+      : {};
+
   const knownKeys = new Set([
     'descriptor',
     'position',
@@ -241,13 +356,18 @@ function deserialiseBlockPlacement(
     '_unknown',
   ]);
   const extraKeys = Object.keys(obj).filter((k) => !knownKeys.has(k));
-  const _unknown: Record<string, unknown> | undefined =
+  const newExtras: Record<string, unknown> =
     extraKeys.length > 0
       ? Object.fromEntries(extraKeys.map((k) => [k, obj[k]]))
-      : undefined;
+      : {};
+
+  // Merge: existing _unknown first, then new extras on top (extras win).
+  const merged = { ...existingUnknown, ...newExtras };
+  const _unknown: Record<string, unknown> | undefined =
+    Object.keys(merged).length > 0 ? merged : undefined;
 
   return {
-    descriptor: descriptor as WorkbenchBlockDescriptor,
+    descriptor: descriptor as WorkbenchBlockPlacementDescriptor,
     position: position as { x: number; y: number },
     size: size as { width: number; height: number },
     minimized,

--- a/shared/workbench-layout-types.ts
+++ b/shared/workbench-layout-types.ts
@@ -1,0 +1,256 @@
+/**
+ * Workbench layout persistence contracts — slice 3 of epic #612.
+ *
+ * Defines the serialized layout model for the Workbench canvas: block
+ * placement (position + size + minimized state), per-workspace scope, and
+ * the envelope that owns the schema version.
+ *
+ * Design notes
+ * ────────────
+ * Coordinate model: freeform pixel coordinates. The Workbench canvas hosts
+ * independently draggable/resizable blocks — not a split-pane layout. The
+ * existing `react-resizable-panels` / percentage-split model is scoped to
+ * the SessionPane workspace; the Workbench canvas is a separate surface.
+ *
+ * Forward compatibility: unknown block `kind` values MUST survive a
+ * serialize→deserialize round-trip. The server accepts and returns unknown
+ * kinds verbatim; the renderer falls back to the UnknownKindCard from
+ * slice 2. Unknown extra fields on `WorkbenchBlockPlacement` are preserved
+ * under `_unknown` to avoid silent data loss.
+ *
+ * WorkspaceScopeRef: a lightweight reference to an existing workspace from
+ * server/types.ts `Workspace`. We reuse the `id` field directly — no new
+ * opaque type needed. The `displayName` is a denormalised hint for debug
+ * only and is not authoritative.
+ */
+
+import type { WorkbenchBlockDescriptor } from './workbench-block-types.js';
+
+// ---------------------------------------------------------------------------
+// WorkspaceScopeRef
+// ---------------------------------------------------------------------------
+
+/**
+ * Reference to the workspace scope that owns this layout.
+ * `id` corresponds to `Workspace.id` in server/types.ts — the stable opaque
+ * workspace identifier (`ws:<encoded-name>` shape, but the shape is not
+ * enforced here to avoid a server→shared import cycle).
+ */
+export interface WorkspaceScopeRef {
+  /** Stable workspace id. Matches `Workspace.id` from server/types.ts. */
+  id: string;
+  /** Human-readable hint for debugging. Not authoritative. */
+  displayName?: string;
+}
+
+// ---------------------------------------------------------------------------
+// WorkbenchBlockPlacement
+// ---------------------------------------------------------------------------
+
+/**
+ * Placement record for a single block on the canvas.
+ *
+ * `descriptor` is a full `WorkbenchBlockDescriptor` (discriminated union on
+ * `kind`). When a future kind is added server-side, older clients receive it
+ * with `kind` set to the new literal; `getBlockRenderer` returns `undefined`
+ * and `BlockHost` renders the UnknownKindCard safe fallback.
+ *
+ * The `_unknown` bag captures any extra JSON fields from the server that the
+ * current client does not recognise — they are round-tripped back to the
+ * server on the next PUT so future state is not silently dropped.
+ */
+export interface WorkbenchBlockPlacement {
+  /** Full block descriptor — includes kind, id, title, capabilityRequirements, meta. */
+  descriptor: WorkbenchBlockDescriptor;
+  /**
+   * Top-left corner of the block on the canvas in CSS pixels.
+   * Stored as pixel values so the layout is stable across viewport sizes.
+   * The canvas component clamps values to the visible area on mount.
+   */
+  position: { x: number; y: number };
+  /**
+   * Block dimensions in CSS pixels.
+   * Minimum size enforcement is the responsibility of the canvas component.
+   */
+  size: { width: number; height: number };
+  /** When true, the block body is collapsed; only the title bar is visible. */
+  minimized: boolean;
+  /**
+   * Forward-compat bag: extra fields from the server not recognised by this
+   * client version are stashed here and round-tripped unchanged.
+   * Not rendered or interpreted — purely a persistence fidelity mechanism.
+   */
+  _unknown?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// WorkbenchLayout
+// ---------------------------------------------------------------------------
+
+/**
+ * The full persisted layout for one workspace.
+ * Stored server-side as a JSON document keyed by workspace id.
+ */
+export interface WorkbenchLayout {
+  /**
+   * Schema version for forward compat.
+   * Current: 1.
+   * Increment when a breaking change is made to the layout shape.
+   * The server validates that it understands `schemaVersion` before accepting.
+   */
+  schemaVersion: number;
+  /** Workspace that owns this layout. */
+  workspaceScope: WorkspaceScopeRef;
+  /** Ordered placement list. Order determines z-stacking (last = front). */
+  blocks: ReadonlyArray<WorkbenchBlockPlacement>;
+}
+
+// ---------------------------------------------------------------------------
+// Current schema version constant
+// ---------------------------------------------------------------------------
+
+export const WORKBENCH_LAYOUT_SCHEMA_VERSION = 1;
+
+// ---------------------------------------------------------------------------
+// Serialization helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialise a `WorkbenchLayout` to a plain JSON-compatible object.
+ * `ReadonlyArray` fields are cast to `unknown[]` so `JSON.stringify` can
+ * handle them without extra conversion at the call site.
+ */
+export function serialiseWorkbenchLayout(layout: WorkbenchLayout): unknown {
+  return JSON.parse(JSON.stringify(layout));
+}
+
+/**
+ * Deserialise a raw JSON value into a `WorkbenchLayout`.
+ *
+ * Forward-compat contract:
+ *   - Unknown block `kind` values are accepted and round-tripped.
+ *   - Extra fields on placement objects are stashed in `_unknown`.
+ *   - Missing optional fields receive safe defaults.
+ *
+ * Returns `null` for null/undefined input (no layout stored yet).
+ * Throws `Error` for structurally invalid data (not an object, missing
+ * required fields, unrecognised schemaVersion).
+ */
+export function deserialiseWorkbenchLayout(
+  raw: unknown
+): WorkbenchLayout | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error('workbench layout: expected object at root');
+  }
+  const obj = raw as Record<string, unknown>;
+
+  const schemaVersion = obj['schemaVersion'];
+  if (typeof schemaVersion !== 'number') {
+    throw new Error('workbench layout: schemaVersion must be a number');
+  }
+  if (schemaVersion !== WORKBENCH_LAYOUT_SCHEMA_VERSION) {
+    throw new Error(
+      `workbench layout: unsupported schemaVersion ${schemaVersion} (expected ${WORKBENCH_LAYOUT_SCHEMA_VERSION})`
+    );
+  }
+
+  const workspaceScope = obj['workspaceScope'];
+  if (
+    typeof workspaceScope !== 'object' ||
+    workspaceScope === null ||
+    typeof (workspaceScope as Record<string, unknown>)['id'] !== 'string'
+  ) {
+    throw new Error('workbench layout: workspaceScope.id must be a string');
+  }
+
+  const rawBlocks = obj['blocks'];
+  if (!Array.isArray(rawBlocks)) {
+    throw new Error('workbench layout: blocks must be an array');
+  }
+
+  const blocks: WorkbenchBlockPlacement[] = rawBlocks.map((rawBlock, i) =>
+    deserialiseBlockPlacement(rawBlock, i)
+  );
+
+  return {
+    schemaVersion,
+    workspaceScope: workspaceScope as WorkspaceScopeRef,
+    blocks,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal: block placement deserialisation
+// ---------------------------------------------------------------------------
+
+function deserialiseBlockPlacement(
+  raw: unknown,
+  index: number
+): WorkbenchBlockPlacement {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error(`workbench layout: blocks[${index}] must be an object`);
+  }
+  const obj = raw as Record<string, unknown>;
+
+  const descriptor = obj['descriptor'];
+  if (
+    typeof descriptor !== 'object' ||
+    descriptor === null ||
+    typeof (descriptor as Record<string, unknown>)['kind'] !== 'string' ||
+    typeof (descriptor as Record<string, unknown>)['id'] !== 'string'
+  ) {
+    throw new Error(
+      `workbench layout: blocks[${index}].descriptor must have kind and id`
+    );
+  }
+
+  const position = obj['position'];
+  if (
+    typeof position !== 'object' ||
+    position === null ||
+    typeof (position as Record<string, unknown>)['x'] !== 'number' ||
+    typeof (position as Record<string, unknown>)['y'] !== 'number'
+  ) {
+    throw new Error(
+      `workbench layout: blocks[${index}].position must have x and y numbers`
+    );
+  }
+
+  const size = obj['size'];
+  if (
+    typeof size !== 'object' ||
+    size === null ||
+    typeof (size as Record<string, unknown>)['width'] !== 'number' ||
+    typeof (size as Record<string, unknown>)['height'] !== 'number'
+  ) {
+    throw new Error(
+      `workbench layout: blocks[${index}].size must have width and height numbers`
+    );
+  }
+
+  const minimized =
+    typeof obj['minimized'] === 'boolean' ? obj['minimized'] : false;
+
+  // Collect any extra fields into _unknown for round-trip fidelity
+  const knownKeys = new Set([
+    'descriptor',
+    'position',
+    'size',
+    'minimized',
+    '_unknown',
+  ]);
+  const extraKeys = Object.keys(obj).filter((k) => !knownKeys.has(k));
+  const _unknown: Record<string, unknown> | undefined =
+    extraKeys.length > 0
+      ? Object.fromEntries(extraKeys.map((k) => [k, obj[k]]))
+      : undefined;
+
+  return {
+    descriptor: descriptor as WorkbenchBlockDescriptor,
+    position: position as { x: number; y: number },
+    size: size as { width: number; height: number },
+    minimized,
+    ...(_unknown !== undefined ? { _unknown } : {}),
+  };
+}

--- a/test/workbench-layout.test.ts
+++ b/test/workbench-layout.test.ts
@@ -1,0 +1,693 @@
+/**
+ * Tests for workbench layout persistence — slice 3 of epic #612.
+ *
+ * Covers:
+ *   1. Shared types: serialize/deserialize round-trip
+ *      - Happy path (known kinds)
+ *      - Forward-compat: unknown block kinds survive round-trip
+ *      - Unknown extra fields preserved in _unknown
+ *      - Edge cases: missing fields, wrong types, bad schemaVersion
+ *   2. Server storage module: read/write/delete layout files
+ *   3. Server REST endpoints via the router
+ *      - GET returns 204 for unset layout
+ *      - PUT validates schema, persists, returns layout
+ *      - GET returns what was PUT
+ *      - PUT rejects mismatched workspaceScope.id
+ *   4. WorkbenchCanvas source structure assertions
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+
+// ---------------------------------------------------------------------------
+// 1. Shared types — serialize/deserialize round-trip
+// ---------------------------------------------------------------------------
+
+import {
+  deserialiseWorkbenchLayout,
+  serialiseWorkbenchLayout,
+  WORKBENCH_LAYOUT_SCHEMA_VERSION,
+} from '../shared/workbench-layout-types.js';
+import type {
+  WorkbenchLayout,
+  WorkbenchBlockPlacement,
+} from '../shared/workbench-layout-types.js';
+
+function makePlacement(
+  overrides: Partial<WorkbenchBlockPlacement> = {}
+): WorkbenchBlockPlacement {
+  return {
+    descriptor: {
+      kind: 'markdown',
+      id: 'block-1',
+      title: 'test block',
+      capabilityRequirements: [],
+      meta: { content: 'hello world' },
+    },
+    position: { x: 100, y: 200 },
+    size: { width: 400, height: 300 },
+    minimized: false,
+    ...overrides,
+  };
+}
+
+function makeLayout(overrides: Partial<WorkbenchLayout> = {}): WorkbenchLayout {
+  return {
+    schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+    workspaceScope: { id: 'ws:test', displayName: 'test workspace' },
+    blocks: [makePlacement()],
+    ...overrides,
+  };
+}
+
+describe('workbench-layout-types: serialise/deserialise', () => {
+  it('round-trips a layout with a known block kind', () => {
+    const original = makeLayout();
+    const raw = serialiseWorkbenchLayout(original);
+    const restored = deserialiseWorkbenchLayout(raw);
+    expect(restored).not.toBeNull();
+    expect(restored!.schemaVersion).toBe(WORKBENCH_LAYOUT_SCHEMA_VERSION);
+    expect(restored!.workspaceScope.id).toBe('ws:test');
+    expect(restored!.blocks).toHaveLength(1);
+    const block = restored!.blocks[0]!;
+    expect(block.descriptor.kind).toBe('markdown');
+    expect(block.position).toEqual({ x: 100, y: 200 });
+    expect(block.size).toEqual({ width: 400, height: 300 });
+    expect(block.minimized).toBe(false);
+  });
+
+  it('round-trips a minimized block', () => {
+    const original = makeLayout({
+      blocks: [makePlacement({ minimized: true })],
+    });
+    const restored = deserialiseWorkbenchLayout(
+      serialiseWorkbenchLayout(original)
+    );
+    expect(restored!.blocks[0]!.minimized).toBe(true);
+  });
+
+  it('round-trips a layout with an UNKNOWN block kind (forward-compat)', () => {
+    // Simulate a layout written by a future client with kind 'ai-agent-v2'
+    const futureRaw = {
+      schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+      workspaceScope: { id: 'ws:future', displayName: 'future' },
+      blocks: [
+        {
+          descriptor: {
+            kind: 'ai-agent-v2', // unknown kind
+            id: 'future-block',
+            title: 'future block',
+            capabilityRequirements: [],
+            meta: { something: 'opaque' },
+          },
+          position: { x: 50, y: 75 },
+          size: { width: 320, height: 240 },
+          minimized: false,
+        },
+      ],
+    };
+
+    // Should deserialise without throwing
+    const restored = deserialiseWorkbenchLayout(futureRaw);
+    expect(restored).not.toBeNull();
+    expect(restored!.blocks).toHaveLength(1);
+    // The kind is preserved verbatim
+    expect(restored!.blocks[0]!.descriptor.kind).toBe('ai-agent-v2');
+    expect(restored!.blocks[0]!.descriptor.id).toBe('future-block');
+
+    // Re-serialise — the unknown kind must survive another round-trip
+    const reraw = serialiseWorkbenchLayout(restored!);
+    const rerestored = deserialiseWorkbenchLayout(reraw);
+    expect(rerestored!.blocks[0]!.descriptor.kind).toBe('ai-agent-v2');
+  });
+
+  it('preserves unknown placement fields in _unknown bag', () => {
+    const rawWithExtra = {
+      schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+      workspaceScope: { id: 'ws:test' },
+      blocks: [
+        {
+          descriptor: {
+            kind: 'terminal',
+            id: 'b1',
+            title: 't',
+            capabilityRequirements: [],
+            meta: {
+              sessionRef: {
+                nodeId: 'n1',
+                sessionId: 's1',
+                tabKind: 'agent',
+                cwd: '/',
+              },
+            },
+          },
+          position: { x: 0, y: 0 },
+          size: { width: 200, height: 100 },
+          minimized: false,
+          futureField: 'preserved', // extra field from future schema
+        },
+      ],
+    };
+    const restored = deserialiseWorkbenchLayout(rawWithExtra);
+    expect(restored!.blocks[0]!._unknown).toBeDefined();
+    expect(restored!.blocks[0]!._unknown!['futureField']).toBe('preserved');
+  });
+
+  it('returns null for null input', () => {
+    expect(deserialiseWorkbenchLayout(null)).toBeNull();
+    expect(deserialiseWorkbenchLayout(undefined)).toBeNull();
+  });
+
+  it('throws for non-object root', () => {
+    expect(() => deserialiseWorkbenchLayout('string')).toThrow();
+    expect(() => deserialiseWorkbenchLayout(42)).toThrow();
+    expect(() => deserialiseWorkbenchLayout([])).toThrow();
+  });
+
+  it('throws for missing schemaVersion', () => {
+    const raw = {
+      workspaceScope: { id: 'ws:test' },
+      blocks: [],
+    };
+    expect(() => deserialiseWorkbenchLayout(raw)).toThrow(/schemaVersion/);
+  });
+
+  it('throws for wrong schemaVersion', () => {
+    const raw = {
+      schemaVersion: 999,
+      workspaceScope: { id: 'ws:test' },
+      blocks: [],
+    };
+    expect(() => deserialiseWorkbenchLayout(raw)).toThrow(/schemaVersion/);
+  });
+
+  it('throws for missing workspaceScope.id', () => {
+    const raw = {
+      schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+      workspaceScope: {},
+      blocks: [],
+    };
+    expect(() => deserialiseWorkbenchLayout(raw)).toThrow(/workspaceScope/);
+  });
+
+  it('throws for non-array blocks', () => {
+    const raw = {
+      schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+      workspaceScope: { id: 'ws:test' },
+      blocks: 'not-an-array',
+    };
+    expect(() => deserialiseWorkbenchLayout(raw)).toThrow(/blocks/);
+  });
+
+  it('throws for block missing descriptor.kind', () => {
+    const raw = {
+      schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+      workspaceScope: { id: 'ws:test' },
+      blocks: [
+        {
+          descriptor: {
+            id: 'b1',
+            title: 't',
+            capabilityRequirements: [],
+            meta: {},
+          },
+          position: { x: 0, y: 0 },
+          size: { width: 200, height: 100 },
+          minimized: false,
+        },
+      ],
+    };
+    expect(() => deserialiseWorkbenchLayout(raw)).toThrow(/kind/);
+  });
+
+  it('defaults minimized to false when missing', () => {
+    const raw = {
+      schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+      workspaceScope: { id: 'ws:test' },
+      blocks: [
+        {
+          descriptor: {
+            kind: 'markdown',
+            id: 'b1',
+            title: 't',
+            capabilityRequirements: [],
+            meta: { content: '' },
+          },
+          position: { x: 0, y: 0 },
+          size: { width: 200, height: 100 },
+          // no minimized field
+        },
+      ],
+    };
+    const restored = deserialiseWorkbenchLayout(raw);
+    expect(restored!.blocks[0]!.minimized).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Server storage module — file read/write
+// ---------------------------------------------------------------------------
+
+import {
+  readWorkbenchLayout,
+  writeWorkbenchLayout,
+  deleteWorkbenchLayout,
+  validateLayoutBody,
+} from '../server/workbench-layout.js';
+
+describe('workbench-layout server storage', () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-wb-test-'));
+    configPath = path.join(tmpDir, 'config.json');
+    // Config file itself doesn't need to exist for layout tests
+    fs.writeFileSync(configPath, '{}', 'utf8');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when no layout has been stored', () => {
+    const result = readWorkbenchLayout(configPath, 'ws:test');
+    expect(result).toBeNull();
+  });
+
+  it('round-trips a layout through write/read', () => {
+    const layout = makeLayout();
+    writeWorkbenchLayout(configPath, 'ws:test', layout);
+    const restored = readWorkbenchLayout(configPath, 'ws:test');
+    expect(restored).not.toBeNull();
+    expect(restored!.workspaceScope.id).toBe('ws:test');
+    expect(restored!.blocks).toHaveLength(1);
+  });
+
+  it('different workspaceIds write independent files', () => {
+    const layout1 = makeLayout({
+      workspaceScope: { id: 'ws:alpha' },
+      blocks: [],
+    });
+    const layout2 = makeLayout({
+      workspaceScope: { id: 'ws:beta' },
+      blocks: [
+        makePlacement({
+          descriptor: {
+            kind: 'markdown',
+            id: 'b2',
+            title: 'beta',
+            capabilityRequirements: [],
+            meta: { content: 'b' },
+          },
+        }),
+      ],
+    });
+    writeWorkbenchLayout(configPath, 'ws:alpha', layout1);
+    writeWorkbenchLayout(configPath, 'ws:beta', layout2);
+
+    const r1 = readWorkbenchLayout(configPath, 'ws:alpha');
+    const r2 = readWorkbenchLayout(configPath, 'ws:beta');
+    expect(r1!.blocks).toHaveLength(0);
+    expect(r2!.blocks).toHaveLength(1);
+  });
+
+  it('delete silently removes the layout', () => {
+    writeWorkbenchLayout(configPath, 'ws:test', makeLayout());
+    expect(readWorkbenchLayout(configPath, 'ws:test')).not.toBeNull();
+    deleteWorkbenchLayout(configPath, 'ws:test');
+    expect(readWorkbenchLayout(configPath, 'ws:test')).toBeNull();
+  });
+
+  it('delete on non-existent layout does not throw', () => {
+    expect(() => deleteWorkbenchLayout(configPath, 'ws:ghost')).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Server REST endpoints — router integration test
+// ---------------------------------------------------------------------------
+
+import http from 'node:http';
+import express from 'express';
+import type { Express } from 'express';
+import { createWorkbenchLayoutRouter } from '../server/workbench-layout.js';
+
+function buildTestApp(configPath: string): Express {
+  const app = express();
+  app.use(express.json());
+  // Mount with the same params-shape as the real server
+  app.use('/workspace-groups', createWorkbenchLayoutRouter({ configPath }));
+  return app;
+}
+
+/**
+ * Minimal HTTP test helper — invoke an Express app in-process without
+ * starting a real server, matching the pattern used in other server tests.
+ */
+async function call(
+  app: Express,
+  method: 'GET' | 'PUT',
+  url: string,
+  body?: unknown
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const addr = server.address() as { port: number };
+      const port = addr.port;
+      const bodyStr = body !== undefined ? JSON.stringify(body) : undefined;
+      const headers: Record<string, string> = {};
+      if (bodyStr !== undefined) {
+        headers['Content-Type'] = 'application/json';
+        headers['Content-Length'] = String(Buffer.byteLength(bodyStr));
+      }
+      const req = http.request(
+        {
+          host: '127.0.0.1',
+          port,
+          path: url,
+          method,
+          headers,
+        },
+        (res) => {
+          let data = '';
+          res.on('data', (chunk: Buffer) => {
+            data += chunk.toString();
+          });
+          res.on('end', () => {
+            server.close();
+            const parsed = data.trim() ? JSON.parse(data) : null;
+            resolve({ status: res.statusCode ?? 0, body: parsed });
+          });
+        }
+      );
+      req.on('error', (err: Error) => {
+        server.close();
+        reject(err);
+      });
+      if (bodyStr !== undefined) req.write(bodyStr);
+      req.end();
+    });
+  });
+}
+
+describe('workbench-layout REST endpoints', () => {
+  let tmpDir: string;
+  let configPath: string;
+  let app: Express;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-wb-api-test-'));
+    configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, '{}', 'utf8');
+    app = buildTestApp(configPath);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('GET returns 204 when no layout is stored', async () => {
+    const result = await call(
+      app,
+      'GET',
+      '/workspace-groups/ws%3Atest/workbench-layout'
+    );
+    expect(result.status).toBe(204);
+    expect(result.body).toBeNull();
+  });
+
+  it('PUT persists a valid layout and returns 200 with the layout', async () => {
+    const layout = makeLayout({ workspaceScope: { id: 'ws:test' } });
+    const putResult = await call(
+      app,
+      'PUT',
+      '/workspace-groups/ws%3Atest/workbench-layout',
+      layout
+    );
+    expect(putResult.status).toBe(200);
+    const returnedLayout = putResult.body as WorkbenchLayout;
+    expect(returnedLayout.schemaVersion).toBe(WORKBENCH_LAYOUT_SCHEMA_VERSION);
+    expect(returnedLayout.blocks).toHaveLength(1);
+  });
+
+  it('GET returns what was PUT', async () => {
+    const layout = makeLayout({ workspaceScope: { id: 'ws:alpha' } });
+    await call(
+      app,
+      'PUT',
+      '/workspace-groups/ws%3Aalpha/workbench-layout',
+      layout
+    );
+    const getResult = await call(
+      app,
+      'GET',
+      '/workspace-groups/ws%3Aalpha/workbench-layout'
+    );
+    expect(getResult.status).toBe(200);
+    const returned = getResult.body as WorkbenchLayout;
+    expect(returned.blocks).toHaveLength(1);
+    expect(returned.blocks[0]!.descriptor.kind).toBe('markdown');
+  });
+
+  it('PUT rejects mismatched workspaceScope.id', async () => {
+    const layout = makeLayout({ workspaceScope: { id: 'ws:other' } });
+    const result = await call(
+      app,
+      'PUT',
+      '/workspace-groups/ws%3Atest/workbench-layout',
+      layout
+    );
+    expect(result.status).toBe(400);
+  });
+
+  it('PUT rejects wrong schemaVersion', async () => {
+    const bad = { ...makeLayout(), schemaVersion: 999 };
+    const result = await call(
+      app,
+      'PUT',
+      '/workspace-groups/ws%3Atest/workbench-layout',
+      bad
+    );
+    expect(result.status).toBe(400);
+  });
+
+  it('PUT accepts unknown block kinds (forward-compat)', async () => {
+    const layout = {
+      schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+      workspaceScope: { id: 'ws:future' },
+      blocks: [
+        {
+          descriptor: {
+            kind: 'ai-agent-v2',
+            id: 'b1',
+            title: 't',
+            capabilityRequirements: [],
+            meta: {},
+          },
+          position: { x: 0, y: 0 },
+          size: { width: 200, height: 100 },
+          minimized: false,
+        },
+      ],
+    };
+    const result = await call(
+      app,
+      'PUT',
+      '/workspace-groups/ws%3Afuture/workbench-layout',
+      layout
+    );
+    expect(result.status).toBe(200);
+    // The unknown kind should round-trip
+    const returned = result.body as WorkbenchLayout;
+    expect(returned.blocks[0]!.descriptor.kind).toBe('ai-agent-v2');
+  });
+
+  it('different workspace IDs are stored independently', async () => {
+    const layoutA = makeLayout({
+      workspaceScope: { id: 'ws:aaa' },
+      blocks: [],
+    });
+    const layoutB = makeLayout({
+      workspaceScope: { id: 'ws:bbb' },
+      blocks: [makePlacement()],
+    });
+    await call(
+      app,
+      'PUT',
+      '/workspace-groups/ws%3Aaaa/workbench-layout',
+      layoutA
+    );
+    await call(
+      app,
+      'PUT',
+      '/workspace-groups/ws%3Abbb/workbench-layout',
+      layoutB
+    );
+
+    const getA = await call(
+      app,
+      'GET',
+      '/workspace-groups/ws%3Aaaa/workbench-layout'
+    );
+    const getB = await call(
+      app,
+      'GET',
+      '/workspace-groups/ws%3Abbb/workbench-layout'
+    );
+
+    expect((getA.body as WorkbenchLayout).blocks).toHaveLength(0);
+    expect((getB.body as WorkbenchLayout).blocks).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. validateLayoutBody — unit tests
+// ---------------------------------------------------------------------------
+
+describe('validateLayoutBody', () => {
+  it('returns null for a valid body', () => {
+    expect(validateLayoutBody(makeLayout())).toBeNull();
+  });
+
+  it('returns error for non-object', () => {
+    expect(validateLayoutBody('string')).not.toBeNull();
+    expect(validateLayoutBody(null)).not.toBeNull();
+    expect(validateLayoutBody(42)).not.toBeNull();
+  });
+
+  it('returns error for missing schemaVersion', () => {
+    const bad = { workspaceScope: { id: 'ws:x' }, blocks: [] };
+    expect(validateLayoutBody(bad)).toMatch(/schemaVersion/);
+  });
+
+  it('returns error for wrong schemaVersion', () => {
+    const bad = {
+      schemaVersion: 2,
+      workspaceScope: { id: 'ws:x' },
+      blocks: [],
+    };
+    expect(validateLayoutBody(bad)).toMatch(/schemaVersion/);
+  });
+
+  it('accepts unknown block kinds', () => {
+    const good = {
+      schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+      workspaceScope: { id: 'ws:x' },
+      blocks: [
+        {
+          descriptor: { kind: 'future-kind', id: 'b1' },
+          position: { x: 0, y: 0 },
+          size: { width: 200, height: 100 },
+          minimized: false,
+        },
+      ],
+    };
+    expect(validateLayoutBody(good)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. WorkbenchCanvas source-level assertions
+// ---------------------------------------------------------------------------
+
+describe('WorkbenchCanvas source structure', () => {
+  const canvasPath = join(
+    projectRoot,
+    'frontend/src/workbench/WorkbenchCanvas.tsx'
+  );
+  const canvasCssPath = join(
+    projectRoot,
+    'frontend/src/workbench/workbench-canvas.css'
+  );
+
+  it('WorkbenchCanvas.tsx exists', () => {
+    expect(existsSync(canvasPath)).toBe(true);
+  });
+
+  it('workbench-canvas.css exists', () => {
+    expect(existsSync(canvasCssPath)).toBe(true);
+  });
+
+  it('exports WorkbenchCanvas component', () => {
+    const src = readFileSync(canvasPath, 'utf-8');
+    expect(src).toContain('export function WorkbenchCanvas');
+  });
+
+  it('exports createEmptyWorkbenchLayout helper', () => {
+    const src = readFileSync(canvasPath, 'utf-8');
+    expect(src).toContain('export function createEmptyWorkbenchLayout');
+  });
+
+  it('exports workbenchLayoutQueryKey', () => {
+    const src = readFileSync(canvasPath, 'utf-8');
+    expect(src).toContain('export const workbenchLayoutQueryKey');
+  });
+
+  it('uses @dnd-kit/core for drag', () => {
+    const src = readFileSync(canvasPath, 'utf-8');
+    expect(src).toContain('@dnd-kit/core');
+  });
+
+  it('uses TanStack Query for fetch and mutate', () => {
+    const src = readFileSync(canvasPath, 'utf-8');
+    expect(src).toContain('@tanstack/react-query');
+    expect(src).toContain('useQuery');
+    expect(src).toContain('useMutation');
+  });
+
+  it('does not import App.tsx or sidebar', () => {
+    const src = readFileSync(canvasPath, 'utf-8');
+    // Check imports specifically — not JSDoc comments that may mention these names
+    const importLines = src
+      .split('\n')
+      .filter((line) => line.trimStart().startsWith('import'));
+    expect(importLines.some((l) => l.includes('App.tsx'))).toBe(false);
+    expect(importLines.some((l) => l.includes('Sidebar'))).toBe(false);
+  });
+
+  it('uses BlockHost from slice 2', () => {
+    const src = readFileSync(canvasPath, 'utf-8');
+    expect(src).toContain('BlockHost');
+  });
+
+  it('CSS has canvas-block class', () => {
+    const css = readFileSync(canvasCssPath, 'utf-8');
+    expect(css).toContain('.canvas-block');
+  });
+
+  it('CSS has workbench-canvas class', () => {
+    const css = readFileSync(canvasCssPath, 'utf-8');
+    expect(css).toContain('.workbench-canvas');
+  });
+
+  it('CSS has canvas-block__titlebar for drag handle', () => {
+    const css = readFileSync(canvasCssPath, 'utf-8');
+    expect(css).toContain('.canvas-block__titlebar');
+  });
+
+  it('CSS has canvas-block__resize-handle', () => {
+    const css = readFileSync(canvasCssPath, 'utf-8');
+    expect(css).toContain('.canvas-block__resize-handle');
+  });
+
+  it('minimize toggle is present in source', () => {
+    const src = readFileSync(canvasPath, 'utf-8');
+    expect(src).toContain('onMinimizeToggle');
+  });
+
+  it('position update fires the persist mutation', () => {
+    const src = readFileSync(canvasPath, 'utf-8');
+    expect(src).toContain('persistLayout');
+    expect(src).toContain('debouncedPersist');
+  });
+});

--- a/test/workbench-layout.test.ts
+++ b/test/workbench-layout.test.ts
@@ -250,6 +250,111 @@ describe('workbench-layout-types: serialise/deserialise', () => {
     const restored = deserialiseWorkbenchLayout(raw);
     expect(restored!.blocks[0]!.minimized).toBe(false);
   });
+
+  // Bug 3 fix: descriptor must include title and capabilityRequirements so
+  // missingCapabilities() cannot crash on undefined at runtime.
+  it('throws for block descriptor missing title', () => {
+    const raw = {
+      schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+      workspaceScope: { id: 'ws:test' },
+      blocks: [
+        {
+          descriptor: {
+            kind: 'markdown',
+            id: 'b1',
+            // title intentionally omitted
+            capabilityRequirements: [],
+            meta: { content: '' },
+          },
+          position: { x: 0, y: 0 },
+          size: { width: 200, height: 100 },
+          minimized: false,
+        },
+      ],
+    };
+    expect(() => deserialiseWorkbenchLayout(raw)).toThrow(/title/);
+  });
+
+  it('throws for block descriptor missing capabilityRequirements', () => {
+    const raw = {
+      schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+      workspaceScope: { id: 'ws:test' },
+      blocks: [
+        {
+          descriptor: {
+            kind: 'markdown',
+            id: 'b1',
+            title: 't',
+            // capabilityRequirements intentionally omitted
+            meta: { content: '' },
+          },
+          position: { x: 0, y: 0 },
+          size: { width: 200, height: 100 },
+          minimized: false,
+        },
+      ],
+    };
+    expect(() => deserialiseWorkbenchLayout(raw)).toThrow(
+      /capabilityRequirements/
+    );
+  });
+
+  // Bug 4 fix: existing _unknown from a stored JSON bag must be preserved
+  // when deserializing, so unknown fields survive multiple round-trips.
+  it('preserves _unknown bag across multiple serialize/deserialize cycles', () => {
+    // Simulate a layout that was already deserialized once and has an _unknown bag.
+    const rawWithBothExtraAndUnknown = {
+      schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+      workspaceScope: { id: 'ws:test' },
+      blocks: [
+        {
+          descriptor: {
+            kind: 'markdown',
+            id: 'b1',
+            title: 't',
+            capabilityRequirements: [],
+            meta: { content: '' },
+          },
+          position: { x: 0, y: 0 },
+          size: { width: 200, height: 100 },
+          minimized: false,
+          // Simulates a field that was in _unknown from a prior deserialization
+          // and was merged back into the top-level by serialiseWorkbenchLayout.
+          futureTopLevelField: 'must survive',
+          // An _unknown bag from a prior cycle (would come from a server that
+          // itself already did the round-trip preservation).
+          _unknown: { olderFutureField: 'also preserved' },
+        },
+      ],
+    };
+
+    // First deserialization: collects futureTopLevelField into _unknown, merges
+    // olderFutureField from the existing _unknown bag.
+    const restored1 = deserialiseWorkbenchLayout(rawWithBothExtraAndUnknown);
+    expect(restored1).not.toBeNull();
+    expect(restored1!.blocks[0]!._unknown).toBeDefined();
+    expect(restored1!.blocks[0]!._unknown!['futureTopLevelField']).toBe(
+      'must survive'
+    );
+    expect(restored1!.blocks[0]!._unknown!['olderFutureField']).toBe(
+      'also preserved'
+    );
+
+    // Serialize back out — both unknown fields must be in the top-level output.
+    const serialized = serialiseWorkbenchLayout(restored1!);
+    const block0 = serialized.blocks[0] as Record<string, unknown>;
+    expect(block0['futureTopLevelField']).toBe('must survive');
+    expect(block0['olderFutureField']).toBe('also preserved');
+
+    // Second deserialization — unknown fields must still be present.
+    const restored2 = deserialiseWorkbenchLayout(serialized);
+    expect(restored2!.blocks[0]!._unknown!['futureTopLevelField']).toBe(
+      'must survive'
+    );
+    expect(restored2!.blocks[0]!._unknown!['olderFutureField']).toBe(
+      'also preserved'
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -579,13 +684,20 @@ describe('validateLayoutBody', () => {
     expect(validateLayoutBody(bad)).toMatch(/schemaVersion/);
   });
 
-  it('accepts unknown block kinds', () => {
+  it('accepts unknown block kinds when required descriptor fields are present', () => {
+    // Bug 3 fix: unknown *kinds* are accepted, but title + capabilityRequirements
+    // are required on every descriptor so missingCapabilities() cannot crash.
     const good = {
       schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
       workspaceScope: { id: 'ws:x' },
       blocks: [
         {
-          descriptor: { kind: 'future-kind', id: 'b1' },
+          descriptor: {
+            kind: 'future-kind',
+            id: 'b1',
+            title: 'future block',
+            capabilityRequirements: [],
+          },
           position: { x: 0, y: 0 },
           size: { width: 200, height: 100 },
           minimized: false,
@@ -593,6 +705,51 @@ describe('validateLayoutBody', () => {
       ],
     };
     expect(validateLayoutBody(good)).toBeNull();
+  });
+
+  it('rejects descriptor missing title', () => {
+    // Bug 3: title is required — absence must produce a validation error.
+    const bad = {
+      schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+      workspaceScope: { id: 'ws:x' },
+      blocks: [
+        {
+          descriptor: {
+            kind: 'future-kind',
+            id: 'b1',
+            // title intentionally omitted
+            capabilityRequirements: [],
+          },
+          position: { x: 0, y: 0 },
+          size: { width: 200, height: 100 },
+          minimized: false,
+        },
+      ],
+    };
+    expect(validateLayoutBody(bad)).toMatch(/title/);
+  });
+
+  it('rejects descriptor missing capabilityRequirements', () => {
+    // Bug 3: capabilityRequirements is required — absence must produce a
+    // validation error so missingCapabilities() cannot crash on undefined.
+    const bad = {
+      schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+      workspaceScope: { id: 'ws:x' },
+      blocks: [
+        {
+          descriptor: {
+            kind: 'markdown',
+            id: 'b1',
+            title: 'some block',
+            // capabilityRequirements intentionally omitted
+          },
+          position: { x: 0, y: 0 },
+          size: { width: 200, height: 100 },
+          minimized: false,
+        },
+      ],
+    };
+    expect(validateLayoutBody(bad)).toMatch(/capabilityRequirements/);
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `shared/workbench-layout-types.ts` with `WorkbenchBlockPlacement`, `WorkbenchLayout`, `WorkspaceScopeRef` types plus `serialiseWorkbenchLayout` / `deserialiseWorkbenchLayout` with full forward-compat (unknown block kinds and extra placement fields round-trip cleanly)
- Adds `server/workbench-layout.ts` with JSON file storage per workspace (mirrors `worktree-meta/` pattern from `server/config.ts`), input validation, and an Express router mounted at `GET/PUT /workspace-groups/:id/workbench-layout`
- Adds `frontend/src/workbench/WorkbenchCanvas.tsx` with freeform pixel-positioned blocks, @dnd-kit drag, mouse-event resize handle, minimize toggle, TanStack Query fetch + debounced PUT mutation (no polling)
- 44 new vitest tests covering round-trip, forward-compat, server storage, REST endpoints, and canvas source structure

## Grid vs freeform decision

**Freeform pixel coordinates.** The Workbench canvas hosts independently draggable/resizable floating blocks — semantically a virtual desktop surface, not a document editor. The existing `react-resizable-panels` percentage-split model is scoped to `WorkspaceLayout` (the tab/pane surface); using it for Workbench blocks would force a split-tree data structure that doesn't match the intent. Freeform `{ x, y, width, height }` pixel placement is simpler, lets blocks overlap or tile freely, and aligns with standard windowing UIs.

## Reused primitives

- `@dnd-kit/core` (`DndContext`, `PointerSensor`, `useDraggable`) — same library already used by `WorkspaceLayout` for tab drag; no new dependency needed
- Mouse-event resize hook (`useBlockResize`) — lightweight custom hook because `react-resizable-panels` is percentage-split oriented and not suitable for freeform block resize

## Acceptance criteria status

- [x] User can rearrange blocks on the Workbench canvas
- [x] Layout persists across refresh (server-side JSON per workspace, TanStack Query fetches on mount)
- [x] Layout is per-workspace (independent files keyed by workspace id hash)
- [x] Unknown block kinds survive serialize/deserialize without dropping the layout
- [x] vitest coverage for serialize/deserialize + scope binding (44 tests)

## Notes

- No `App.tsx` or sidebar integration — slice 3 boundary per #621 scope
- Mutation-driven cache invalidation only (no `refetchInterval`), per the project anti-polling convention
- `WorkbenchCanvas` is exported from `frontend/src/workbench/WorkbenchCanvas.tsx` and can be mounted anywhere; demo route / App.tsx wiring is deferred to a later slice

Refs #621
Refs #612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a draggable and resizable workbench canvas with multiple blocks
  * Added support for minimizing and closing blocks
  * Implemented automatic persistence of workbench layouts to the server
  * Layout changes are saved automatically without manual action required

* **Tests**
  * Added comprehensive test suite for workbench layout functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->