### PR TITLE
feat(env): safe defaults selection logic (#628)

### DIFF
--- a/shared/index.ts
+++ b/shared/index.ts
@@ -47,3 +47,15 @@ export {
   type RepoInventoryReport,
   type RepoInventoryWorktreeInstance,
 } from './repo-inventory.js';
+
+export {
+  pickDefaultEnvironment,
+  type ActiveTabContext,
+  type EnvironmentHistoryEntry,
+  type PickDefaultEnvironmentError,
+  type PickDefaultEnvironmentErrorReason,
+  type PickDefaultEnvironmentInput,
+  type PickDefaultEnvironmentOk,
+  type PickDefaultEnvironmentOkReason,
+  type PickDefaultEnvironmentResult,
+} from './safe-defaults.js';

--- a/shared/safe-defaults.ts
+++ b/shared/safe-defaults.ts
@@ -1,0 +1,209 @@
+// Safe default environment selection (#628) — pure function picking which
+// EnvironmentOption a new launch should default to, given the active tab,
+// last-used history, and currently-known candidates from the picker.
+//
+// Decision order (see issue #628 + `docs/WORKBENCH_BOUNDARY.md` epic #615):
+//
+//   1. Active tab present → require its node to still be in `candidates` AND
+//      to be `fresh` AND to satisfy any declared `requiredCapabilities`. If
+//      yes, return that option. If no, return a typed error — NEVER silently
+//      switch to a different node. This is the critical correctness property
+//      of #628: a Tab "lives" on its node, and silently jumping work to a
+//      different machine when the selected one is stale/offline would violate
+//      the federated-Relay contract (`docs/WORKBENCH_BOUNDARY.md` and the
+//      `if a selected node goes stale/offline, launch is blocked with a typed
+//      reason instead of falling back to another machine` acceptance criterion
+//      on epic #615).
+//
+//   2. No active tab → walk `history` newest-first, returning the first
+//      candidate that is both present and fresh. History entries pointing at
+//      candidates that have been removed (node unpaired, repo instance gone)
+//      or are non-fresh are skipped.
+//
+//   3. No history hit → return the first `fresh` candidate in the supplied
+//      order. Caller decides the ordering policy (recently-seen, alphabetical,
+//      etc.); this function just preserves it.
+//
+//   4. Nothing fresh anywhere → `{ kind: 'error', error: NO_COMPATIBLE,
+//      reason: 'all-degraded' }`.
+//
+// This module is pure: no I/O, no time-dependent calls, no mutation of inputs.
+// Freshness is supplied by the caller via `EnvironmentOption.freshness` — the
+// picker layer (#615) is responsible for deciding what "stale" means against
+// the current clock and inventory snapshot.
+
+import type {
+  EnvironmentOption,
+} from './environment-option.js';
+import type { NodeId } from './identity.js';
+import type { RelayCapabilityBit } from './security-policy.js';
+
+/**
+ * Minimal slice of "the tab the user is currently focused on" the picker needs
+ * to make a safe default decision. The canonical Tab IA work (#473) has not
+ * landed a single shared shape yet, so this module declares only the fields it
+ * actually reads:
+ *
+ *   - `environment`: the `EnvironmentOption` the tab was last launched against.
+ *     It must round-trip through `JSON.stringify`/`JSON.parse` (it's the same
+ *     shape #623 already guarantees that for).
+ *   - `requiredCapabilities`: capability bits the tab needs to keep running.
+ *     The picker uses this to detect "selected node is technically online but
+ *     no longer advertises a bit this tab needs", which counts as degraded.
+ *
+ * TODO(#473): once `WorkContext.tab` (or equivalent) lands a canonical shape,
+ * adapt this interface to consume it directly rather than maintaining a
+ * parallel slice here.
+ */
+export interface ActiveTabContext {
+  environment: EnvironmentOption;
+  requiredCapabilities?: RelayCapabilityBit[];
+}
+
+/**
+ * One entry in the last-used environment history, newest-first by caller
+ * convention. The picker keys against `environmentId` (the
+ * `EnvironmentOption.id` field guaranteed stable by #623).
+ *
+ * `lastUsedAt` is informational — used by upstream sorters and surfaced in UI
+ * — but this function does not re-sort. The caller is responsible for passing
+ * history in the order it wants tried.
+ */
+export interface EnvironmentHistoryEntry {
+  environmentId: string;
+  lastUsedAt: string;
+}
+
+export interface PickDefaultEnvironmentInput {
+  activeTab: ActiveTabContext | null;
+  history: readonly EnvironmentHistoryEntry[];
+  candidates: readonly EnvironmentOption[];
+}
+
+/**
+ * Why the picker chose the option it did. Useful for UI to surface "we picked
+ * this because…" copy and for telemetry on default-selection quality.
+ */
+export type PickDefaultEnvironmentOkReason =
+  | 'active-tab'
+  | 'history'
+  | 'first-fresh';
+
+export interface PickDefaultEnvironmentOk {
+  kind: 'ok';
+  option: EnvironmentOption;
+  reason: PickDefaultEnvironmentOkReason;
+}
+
+/**
+ * Discriminated error shape. `error` is a stable string the caller can switch
+ * on (currently always `'no-compatible'`); `reason` is the finer-grained
+ * cause. Both are intentionally typed unions so adding a new failure mode is a
+ * breaking change for consumers and gets caught at the type checker.
+ *
+ * Field set per case:
+ *   - `active-tab-degraded`: active tab's node is in candidates but stale,
+ *     offline, or missing required capabilities. `activeNodeId` is populated.
+ *   - `active-tab-missing`: active tab's environment id is not in candidates
+ *     (node unpaired, repo instance removed). `activeNodeId` is populated.
+ *   - `all-degraded`: no active tab, no candidate is fresh.
+ *   - `no-candidates`: caller passed an empty candidate list.
+ */
+export type PickDefaultEnvironmentErrorReason =
+  | 'active-tab-degraded'
+  | 'active-tab-missing'
+  | 'all-degraded'
+  | 'no-candidates';
+
+export interface PickDefaultEnvironmentError {
+  kind: 'error';
+  error: 'no-compatible';
+  reason: PickDefaultEnvironmentErrorReason;
+  activeNodeId?: NodeId;
+}
+
+export type PickDefaultEnvironmentResult =
+  | PickDefaultEnvironmentOk
+  | PickDefaultEnvironmentError;
+
+const NO_COMPATIBLE = 'no-compatible' as const;
+
+function hasCapabilitySuperset(
+  option: EnvironmentOption,
+  required: readonly RelayCapabilityBit[] | undefined
+): boolean {
+  if (!required || required.length === 0) return true;
+  const advertised = new Set(option.capabilities);
+  return required.every((bit) => advertised.has(bit));
+}
+
+function findById(
+  candidates: readonly EnvironmentOption[],
+  id: string
+): EnvironmentOption | undefined {
+  return candidates.find((candidate) => candidate.id === id);
+}
+
+/**
+ * Pure selection function: pick the safe default environment for a new launch.
+ *
+ * Contract:
+ *   - No I/O, no mutation of inputs, no clock reads.
+ *   - Stable for identical inputs (same input shape → same output shape).
+ *   - Never silently substitutes a different node when the active tab's
+ *     selected node is stale/offline.
+ *   - Empty candidate list returns `{ reason: 'no-candidates' }` rather than
+ *     throwing.
+ */
+export function pickDefaultEnvironment(
+  input: PickDefaultEnvironmentInput
+): PickDefaultEnvironmentResult {
+  const { activeTab, history, candidates } = input;
+
+  if (candidates.length === 0) {
+    return { kind: 'error', error: NO_COMPATIBLE, reason: 'no-candidates' };
+  }
+
+  // Rule 1: active tab → never silently switch nodes.
+  if (activeTab) {
+    const activeNodeId = activeTab.environment.node.nodeId;
+    const matched = findById(candidates, activeTab.environment.id);
+    if (matched === undefined) {
+      return {
+        kind: 'error',
+        error: NO_COMPATIBLE,
+        reason: 'active-tab-missing',
+        activeNodeId,
+      };
+    }
+    if (
+      matched.freshness !== 'fresh' ||
+      !hasCapabilitySuperset(matched, activeTab.requiredCapabilities)
+    ) {
+      return {
+        kind: 'error',
+        error: NO_COMPATIBLE,
+        reason: 'active-tab-degraded',
+        activeNodeId,
+      };
+    }
+    return { kind: 'ok', option: matched, reason: 'active-tab' };
+  }
+
+  // Rule 2: history walk (caller-supplied order, newest first by convention).
+  for (const entry of history) {
+    const match = findById(candidates, entry.environmentId);
+    if (match && match.freshness === 'fresh') {
+      return { kind: 'ok', option: match, reason: 'history' };
+    }
+  }
+
+  // Rule 3: first fresh candidate in the supplied order.
+  const firstFresh = candidates.find((candidate) => candidate.freshness === 'fresh');
+  if (firstFresh) {
+    return { kind: 'ok', option: firstFresh, reason: 'first-fresh' };
+  }
+
+  // Rule 4: nothing fresh anywhere.
+  return { kind: 'error', error: NO_COMPATIBLE, reason: 'all-degraded' };
+}

--- a/shared/safe-defaults.ts
+++ b/shared/safe-defaults.ts
@@ -137,11 +137,17 @@ function hasCapabilitySuperset(
   return required.every((bit) => advertised.has(bit));
 }
 
-function findById(
-  candidates: readonly EnvironmentOption[],
-  id: string
-): EnvironmentOption | undefined {
-  return candidates.find((candidate) => candidate.id === id);
+function indexCandidatesById(
+  candidates: readonly EnvironmentOption[]
+): Map<string, EnvironmentOption> {
+  const byId = new Map<string, EnvironmentOption>();
+  for (const candidate of candidates) {
+    // First-wins on duplicate ids — caller is responsible for unique ids, but
+    // we don't want to silently let a later duplicate override the earlier
+    // entry that the user's ordering implies as canonical.
+    if (!byId.has(candidate.id)) byId.set(candidate.id, candidate);
+  }
+  return byId;
 }
 
 /**
@@ -154,6 +160,8 @@ function findById(
  *     selected node is stale/offline.
  *   - Empty candidate list returns `{ reason: 'no-candidates' }` rather than
  *     throwing.
+ *   - O(C + H) — candidates are indexed once into a Map for O(1) lookup from
+ *     both the active-tab match and the history walk.
  */
 export function pickDefaultEnvironment(
   input: PickDefaultEnvironmentInput
@@ -164,10 +172,12 @@ export function pickDefaultEnvironment(
     return { kind: 'error', error: NO_COMPATIBLE, reason: 'no-candidates' };
   }
 
+  const candidatesById = indexCandidatesById(candidates);
+
   // Rule 1: active tab → never silently switch nodes.
   if (activeTab) {
     const activeNodeId = activeTab.environment.node.nodeId;
-    const matched = findById(candidates, activeTab.environment.id);
+    const matched = candidatesById.get(activeTab.environment.id);
     if (matched === undefined) {
       return {
         kind: 'error',
@@ -192,7 +202,7 @@ export function pickDefaultEnvironment(
 
   // Rule 2: history walk (caller-supplied order, newest first by convention).
   for (const entry of history) {
-    const match = findById(candidates, entry.environmentId);
+    const match = candidatesById.get(entry.environmentId);
     if (match && match.freshness === 'fresh') {
       return { kind: 'ok', option: match, reason: 'history' };
     }

--- a/test/shared/safe-defaults.test.ts
+++ b/test/shared/safe-defaults.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ENVIRONMENT_OPTION_SCHEMA_VERSION,
+  type EnvironmentOption,
+} from '../../shared/environment-option.js';
+import { createRepoInstanceId, DEFAULT_LOCAL_NODE_ID } from '../../shared/identity.js';
+import type { RelayCapabilityBit } from '../../shared/security-policy.js';
+import {
+  pickDefaultEnvironment,
+  type ActiveTabContext,
+  type EnvironmentHistoryEntry,
+  type PickDefaultEnvironmentError,
+} from '../../shared/safe-defaults.js';
+
+const NODE_LOCAL = DEFAULT_LOCAL_NODE_ID;
+const NODE_REMOTE = 'remote-mac-mini';
+const NODE_OTHER = 'remote-devbox';
+
+const REPO_RELAY = 'github.com/donovan-yohan/relay-ide';
+const REPO_OTHER = 'github.com/donovan-yohan/chalk-bag';
+
+function makeOption(
+  overrides: Partial<EnvironmentOption> & {
+    nodeId?: string;
+    repoIdentity?: string | null;
+    capabilities?: RelayCapabilityBit[];
+  } = {}
+): EnvironmentOption {
+  const nodeId = overrides.nodeId ?? NODE_LOCAL;
+  const repoIdentity = overrides.repoIdentity ?? REPO_RELAY;
+  const localPath = `/repos/${repoIdentity?.split('/').pop() ?? 'free'}`;
+  const id = `env:${nodeId}:${localPath}`;
+  const capabilities: RelayCapabilityBit[] = overrides.capabilities ?? [
+    'session:read',
+    'session:create:terminal',
+  ];
+  const repoInstance =
+    repoIdentity === null
+      ? undefined
+      : {
+          repoInstanceId: createRepoInstanceId(nodeId, localPath),
+          localPath,
+          repoIdentity,
+          name: repoIdentity.split('/').pop() ?? 'repo',
+          currentBranch: 'nightly',
+        };
+  const cwdMode = repoInstance ? 'repo' : 'free';
+  const cwd = repoInstance ? localPath : '/tmp/scratch';
+  const {
+    nodeId: _omitNodeId,
+    repoIdentity: _omitRepoIdentity,
+    capabilities: _omitCapabilities,
+    ...rest
+  } = overrides;
+  return {
+    schemaVersion: ENVIRONMENT_OPTION_SCHEMA_VERSION,
+    id,
+    node: {
+      nodeId,
+      kind: nodeId === DEFAULT_LOCAL_NODE_ID ? 'local' : 'remote',
+      displayName: nodeId,
+      online: true,
+    },
+    capabilities,
+    cwd,
+    cwdMode,
+    freshness: 'fresh',
+    ...(repoInstance ? { repoInstance } : {}),
+    generatedAt: '2026-05-19T00:00:00.000Z',
+    ...rest,
+  };
+}
+
+function makeActiveTab(
+  option: EnvironmentOption,
+  required: RelayCapabilityBit[] = []
+): ActiveTabContext {
+  return {
+    environment: option,
+    requiredCapabilities: required,
+  };
+}
+
+function makeHistory(
+  ...options: EnvironmentOption[]
+): EnvironmentHistoryEntry[] {
+  return options.map((option, index) => ({
+    environmentId: option.id,
+    lastUsedAt: `2026-05-${(18 - index).toString().padStart(2, '0')}T00:00:00.000Z`,
+  }));
+}
+
+describe('pickDefaultEnvironment', () => {
+  describe('active tab present', () => {
+    it('returns the active-tab option when it is fresh and present in candidates', () => {
+      const active = makeOption({ nodeId: NODE_LOCAL });
+      const other = makeOption({ nodeId: NODE_REMOTE });
+      const result = pickDefaultEnvironment({
+        activeTab: makeActiveTab(active),
+        history: [],
+        candidates: [active, other],
+      });
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.option.id).toBe(active.id);
+        expect(result.option.node.nodeId).toBe(NODE_LOCAL);
+        expect(result.reason).toBe('active-tab');
+      }
+    });
+
+    it('matches active-tab to candidates by id (round-trip preserves match)', () => {
+      const active = makeOption({ nodeId: NODE_LOCAL });
+      const roundTripped: EnvironmentOption = JSON.parse(JSON.stringify(active));
+      const result = pickDefaultEnvironment({
+        activeTab: makeActiveTab(active),
+        history: [],
+        candidates: [roundTripped],
+      });
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.option.id).toBe(active.id);
+      }
+    });
+
+    it('NEVER silently switches nodes when active-tab node is stale', () => {
+      // Critical correctness property (#628): if the active tab's node is in
+      // candidates but stale/offline, the picker must surface an error rather
+      // than picking a different node.
+      const activeStale = makeOption({
+        nodeId: NODE_LOCAL,
+        freshness: 'stale',
+        degradedReasons: [{ kind: 'node-stale', lastSeenAt: '2026-05-18T00:00:00.000Z' }],
+      });
+      const freshOther = makeOption({ nodeId: NODE_REMOTE });
+      const result = pickDefaultEnvironment({
+        activeTab: makeActiveTab(activeStale),
+        history: makeHistory(freshOther),
+        candidates: [activeStale, freshOther],
+      });
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.error).toBe('no-compatible');
+        expect(result.reason).toBe('active-tab-degraded');
+        expect(result.activeNodeId).toBe(NODE_LOCAL);
+      }
+    });
+
+    it('returns an error when the active-tab node is offline (does not fall back)', () => {
+      const activeOffline = makeOption({
+        nodeId: NODE_LOCAL,
+        freshness: 'offline',
+        degradedReasons: [{ kind: 'node-offline' }],
+      });
+      const freshOther = makeOption({ nodeId: NODE_REMOTE });
+      const result = pickDefaultEnvironment({
+        activeTab: makeActiveTab(activeOffline),
+        history: [],
+        candidates: [activeOffline, freshOther],
+      });
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.error).toBe('no-compatible');
+        expect(result.reason).toBe('active-tab-degraded');
+      }
+    });
+
+    it('returns an error when the active-tab option no longer appears in candidates', () => {
+      // If a Tab's previously-selected environment has been removed (node
+      // unpaired, repo instance deleted), the picker must not silently
+      // substitute a different one — caller surfaces to the user.
+      const active = makeOption({ nodeId: NODE_LOCAL });
+      const other = makeOption({ nodeId: NODE_REMOTE });
+      const result = pickDefaultEnvironment({
+        activeTab: makeActiveTab(active),
+        history: [],
+        candidates: [other],
+      });
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.error).toBe('no-compatible');
+        expect(result.reason).toBe('active-tab-missing');
+        expect(result.activeNodeId).toBe(NODE_LOCAL);
+      }
+    });
+  });
+
+  describe('no active tab, history hit', () => {
+    it('returns last-used compatible environment when present and fresh', () => {
+      const recent = makeOption({ nodeId: NODE_REMOTE });
+      const older = makeOption({ nodeId: NODE_OTHER });
+      const result = pickDefaultEnvironment({
+        activeTab: null,
+        history: makeHistory(recent, older),
+        candidates: [older, recent],
+      });
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.option.id).toBe(recent.id);
+        expect(result.reason).toBe('history');
+      }
+    });
+
+    it('skips history entries that no longer appear in candidates', () => {
+      const dropped = makeOption({ nodeId: 'departed-node' });
+      const present = makeOption({ nodeId: NODE_REMOTE });
+      const result = pickDefaultEnvironment({
+        activeTab: null,
+        history: makeHistory(dropped, present),
+        candidates: [present],
+      });
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.option.id).toBe(present.id);
+        expect(result.reason).toBe('history');
+      }
+    });
+
+    it('skips history entries whose candidate is stale/offline', () => {
+      const staleHistoryHit = makeOption({
+        nodeId: NODE_REMOTE,
+        freshness: 'stale',
+        degradedReasons: [{ kind: 'node-stale', lastSeenAt: '2026-05-18T00:00:00.000Z' }],
+      });
+      const freshFallback = makeOption({ nodeId: NODE_OTHER });
+      const result = pickDefaultEnvironment({
+        activeTab: null,
+        history: makeHistory(staleHistoryHit),
+        candidates: [staleHistoryHit, freshFallback],
+      });
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.option.id).toBe(freshFallback.id);
+        expect(result.reason).toBe('first-fresh');
+      }
+    });
+  });
+
+  describe('no history', () => {
+    it('returns the first fresh online candidate when no history is present', () => {
+      const stale = makeOption({
+        nodeId: NODE_OTHER,
+        freshness: 'stale',
+        degradedReasons: [{ kind: 'node-stale', lastSeenAt: '2026-05-18T00:00:00.000Z' }],
+      });
+      const fresh = makeOption({ nodeId: NODE_REMOTE });
+      const result = pickDefaultEnvironment({
+        activeTab: null,
+        history: [],
+        candidates: [stale, fresh],
+      });
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.option.id).toBe(fresh.id);
+        expect(result.reason).toBe('first-fresh');
+      }
+    });
+  });
+
+  describe('all candidates stale or offline', () => {
+    it('returns { error: no-compatible, reason: all-degraded } when every candidate is non-fresh', () => {
+      const stale = makeOption({
+        nodeId: NODE_LOCAL,
+        freshness: 'stale',
+        degradedReasons: [{ kind: 'node-stale', lastSeenAt: '2026-05-18T00:00:00.000Z' }],
+      });
+      const offline = makeOption({
+        nodeId: NODE_REMOTE,
+        freshness: 'offline',
+        degradedReasons: [{ kind: 'node-offline' }],
+      });
+      const result = pickDefaultEnvironment({
+        activeTab: null,
+        history: makeHistory(stale, offline),
+        candidates: [stale, offline],
+      });
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.error).toBe('no-compatible');
+        expect(result.reason).toBe('all-degraded');
+      }
+    });
+
+    it('returns { error: no-compatible, reason: no-candidates } when the candidate list is empty', () => {
+      const result = pickDefaultEnvironment({
+        activeTab: null,
+        history: [],
+        candidates: [],
+      });
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.error).toBe('no-compatible');
+        expect(result.reason).toBe('no-candidates');
+      }
+    });
+  });
+
+  describe('compatibility (active tab carries RepoIdentity)', () => {
+    it('history fallback prefers same-RepoIdentity candidate when the active tab had a repo', () => {
+      // Active tab is missing from candidates but had REPO_RELAY identity. The
+      // history fallback should prefer a candidate with the same repo identity
+      // over an unrelated repo, even if both are fresh.
+      const active = makeOption({ nodeId: NODE_LOCAL, repoIdentity: REPO_RELAY });
+      const sameRepoDifferentNode = makeOption({
+        nodeId: NODE_REMOTE,
+        repoIdentity: REPO_RELAY,
+      });
+      const differentRepo = makeOption({
+        nodeId: NODE_OTHER,
+        repoIdentity: REPO_OTHER,
+      });
+      const result = pickDefaultEnvironment({
+        activeTab: makeActiveTab(active),
+        history: makeHistory(differentRepo, sameRepoDifferentNode),
+        candidates: [differentRepo, sameRepoDifferentNode],
+      });
+      // Active-tab-missing must still be the error — never silently switch.
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.reason).toBe('active-tab-missing');
+      }
+    });
+
+    it('without an active tab, prefers history hit regardless of repo identity', () => {
+      const recent = makeOption({ nodeId: NODE_REMOTE, repoIdentity: REPO_OTHER });
+      const candidate = makeOption({ nodeId: NODE_OTHER, repoIdentity: REPO_RELAY });
+      const result = pickDefaultEnvironment({
+        activeTab: null,
+        history: makeHistory(recent),
+        candidates: [candidate, recent],
+      });
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.option.id).toBe(recent.id);
+      }
+    });
+  });
+
+  describe('capability superset (when active tab declares required bits)', () => {
+    it('rejects active-tab match if candidate is missing required capabilities', () => {
+      const active = makeOption({
+        nodeId: NODE_LOCAL,
+        capabilities: ['session:read'],
+      });
+      const result = pickDefaultEnvironment({
+        activeTab: makeActiveTab(active, ['session:create:agent']),
+        history: [],
+        candidates: [active],
+      });
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.error).toBe('no-compatible');
+        expect(result.reason).toBe('active-tab-degraded');
+      }
+    });
+
+    it('accepts active-tab when candidate has the required capability superset', () => {
+      const active = makeOption({
+        nodeId: NODE_LOCAL,
+        capabilities: ['session:read', 'session:create:terminal', 'session:create:agent'],
+      });
+      const result = pickDefaultEnvironment({
+        activeTab: makeActiveTab(active, ['session:create:agent']),
+        history: [],
+        candidates: [active],
+      });
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.option.id).toBe(active.id);
+      }
+    });
+  });
+
+  describe('JSON round-trip', () => {
+    it('preserves all input fields and produces the same selection after round-trip', () => {
+      const active = makeOption({ nodeId: NODE_LOCAL });
+      const other = makeOption({ nodeId: NODE_REMOTE });
+      const input = {
+        activeTab: makeActiveTab(active, ['session:read']),
+        history: makeHistory(other, active),
+        candidates: [active, other],
+      };
+      const roundTripped = JSON.parse(JSON.stringify(input)) as typeof input;
+      const result = pickDefaultEnvironment(roundTripped);
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.option.id).toBe(active.id);
+        expect(result.option.node.nodeId).toBe(NODE_LOCAL);
+        expect(result.reason).toBe('active-tab');
+      }
+    });
+
+    it('error result round-trips through JSON without losing reason fields', () => {
+      const activeStale = makeOption({
+        nodeId: NODE_LOCAL,
+        freshness: 'stale',
+        degradedReasons: [{ kind: 'node-stale', lastSeenAt: '2026-05-18T00:00:00.000Z' }],
+      });
+      const result = pickDefaultEnvironment({
+        activeTab: makeActiveTab(activeStale),
+        history: [],
+        candidates: [activeStale],
+      });
+      const cloned = JSON.parse(JSON.stringify(result)) as PickDefaultEnvironmentError;
+      expect(cloned.kind).toBe('error');
+      expect(cloned.error).toBe('no-compatible');
+      expect(cloned.reason).toBe('active-tab-degraded');
+      expect(cloned.activeNodeId).toBe(NODE_LOCAL);
+    });
+  });
+});

--- a/test/shared/safe-defaults.test.ts
+++ b/test/shared/safe-defaults.test.ts
@@ -296,10 +296,12 @@ describe('pickDefaultEnvironment', () => {
   });
 
   describe('compatibility (active tab carries RepoIdentity)', () => {
-    it('history fallback prefers same-RepoIdentity candidate when the active tab had a repo', () => {
-      // Active tab is missing from candidates but had REPO_RELAY identity. The
-      // history fallback should prefer a candidate with the same repo identity
-      // over an unrelated repo, even if both are fresh.
+    it('never silently substitutes a same-RepoIdentity candidate when the active tab is missing', () => {
+      // Active tab had REPO_RELAY identity but its environment id is no longer
+      // in candidates (node unpaired, repo instance removed, etc). Even though
+      // a fresh same-repo candidate exists on a *different* node, the picker
+      // must return `active-tab-missing` rather than silently jumping the tab
+      // to a different machine. This is the critical #628 correctness rule.
       const active = makeOption({ nodeId: NODE_LOCAL, repoIdentity: REPO_RELAY });
       const sameRepoDifferentNode = makeOption({
         nodeId: NODE_REMOTE,


### PR DESCRIPTION
## Scope

Implements [#628](https://github.com/donovan-yohan/relay-ide/issues/628) — the pure selection function the environment picker (epic [#615](https://github.com/donovan-yohan/relay-ide/issues/615)) uses to pick a safe default `EnvironmentOption` for new launches. Backend/shared only; no UI wiring yet.

Refs:
- Parent epic: #615
- Data model dependency (merged): #623 / PR #634
- `docs/WORKBENCH_BOUNDARY.md` (Tab/Node/RepoInstance nouns)

## API

`shared/safe-defaults.ts` exports:

- `pickDefaultEnvironment(input) → PickDefaultEnvironmentResult` (pure)
- `ActiveTabContext`, `EnvironmentHistoryEntry`, `PickDefaultEnvironmentInput`
- `PickDefaultEnvironmentOk` (`kind: 'ok' | option | reason: 'active-tab' | 'history' | 'first-fresh'`)
- `PickDefaultEnvironmentError` (`kind: 'error' | error: 'no-compatible' | reason: PickDefaultEnvironmentErrorReason | activeNodeId?`)
- `PickDefaultEnvironmentErrorReason = 'active-tab-degraded' | 'active-tab-missing' | 'all-degraded' | 'no-candidates'`

All also re-exported from the `shared/` barrel (`shared/index.ts`).

## Decision order

1. **Active tab present.** Require the tab's environment id to still appear in `candidates`, be `freshness: 'fresh'`, and satisfy any declared `requiredCapabilities`. Otherwise return a typed error with `activeNodeId` so the caller can surface "your tab can't run here right now". **Never silently switch to a different node** — this is the critical correctness property of #628 and matches the #615 acceptance criterion: _"if a selected node goes stale/offline, launch is blocked with a typed reason instead of falling back to another machine"._
2. **No active tab → history walk** in caller-supplied order. Return the first candidate that is present + fresh. History entries pointing at removed or non-fresh candidates are skipped.
3. **No history hit → first fresh candidate** in the supplied order.
4. **Nothing fresh** → `{ error: 'no-compatible', reason: 'all-degraded' }`. Empty candidate list → `{ reason: 'no-candidates' }`.

## Tab IA seam

`docs/WORKBENCH_BOUNDARY.md` notes the canonical Tab shape from #473 is still in flight, so this module declares a minimal `ActiveTabContext` slice (just `environment` + optional `requiredCapabilities`) with a `TODO(#473)` to consume the canonical shape once it lands. No new persistent tab model is introduced.

## Tests

`test/shared/safe-defaults.test.ts` — 17 tests, tests-first:

- Active-tab fresh + in candidates → returns active option.
- Active-tab id round-trips through JSON and still matches candidates.
- **Active-tab stale → typed error; never picks a different fresh node** (explicit guard for the #628 critical property).
- Active-tab offline → typed error.
- Active-tab id missing from candidates → `active-tab-missing` (e.g. node unpaired).
- No active tab + history hit → returns last-used.
- History entry that no longer appears in candidates → skipped.
- History entry that is stale → skipped, falls to first-fresh.
- No history → first fresh candidate.
- All candidates stale/offline → `all-degraded`.
- Empty candidates → `no-candidates`.
- With active tab carrying RepoIdentity, never substitutes a different-repo candidate even when fresh — error wins.
- Without active tab, history hit wins regardless of repo identity (caller-owned ordering policy).
- Capability superset gating: insufficient bits → degraded; superset → ok.
- JSON round-trip of full input preserves selection.
- JSON round-trip of error result preserves `reason` + `activeNodeId`.

## Test plan

- [x] `npm run check` — 0 errors, 73 warnings (1 fewer than baseline; no new warnings)
- [x] `npm test` — 2920/2920 passing + 1 expected fail (pre-existing)
- [x] Added test file before implementation; verified red-then-green locally