### PR TITLE
feat(env): environment picker UI component (#627)

### DIFF
--- a/frontend/src/components/EnvironmentPicker.css
+++ b/frontend/src/components/EnvironmentPicker.css
@@ -1,0 +1,202 @@
+/* EnvironmentPicker (#627)
+ *
+ * TUI aesthetic per DESIGN.md:
+ *   - monospace, lowercase, no emoji
+ *   - zero border-radius (status dots are the only circle exception)
+ *   - outline-only chrome, pure black surfaces
+ *   - 4px spacing base, compact row heights
+ */
+
+.env-picker {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg, #000);
+  border: 1px solid var(--border, #333);
+  font-family: var(
+    --font-mono,
+    'SF Mono',
+    'Cascadia Code',
+    'JetBrains Mono',
+    'Fira Code',
+    'Consolas',
+    monospace
+  );
+  font-size: var(--font-size-sm, 0.8125rem);
+  color: var(--text, #e0e0e0);
+  min-width: 320px;
+}
+
+.env-picker__search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border, #333);
+}
+
+.env-picker__search-prompt {
+  color: var(--accent, #d97757);
+  font-weight: 600;
+  user-select: none;
+}
+
+.env-picker__search-input {
+  flex: 1 1 auto;
+  background: transparent;
+  border: 0;
+  outline: none;
+  color: var(--text, #e0e0e0);
+  font: inherit;
+  caret-color: var(--accent, #d97757);
+  padding: 0;
+}
+
+.env-picker__search-input::placeholder {
+  color: var(--text-muted, #888);
+  text-transform: lowercase;
+}
+
+.env-picker__search-input:focus-visible {
+  /* Visible focus indicator without breaking the bare-input look. The
+     parent .env-picker__search container takes the visual accent. */
+  outline: none;
+}
+
+.env-picker__search:focus-within {
+  box-shadow: inset 0 -1px 0 0 var(--accent, #d97757);
+}
+
+.env-picker__listbox {
+  max-height: 320px;
+  overflow-y: auto;
+  outline: none;
+}
+
+.env-picker__listbox:focus-visible {
+  box-shadow: inset 0 0 0 1px var(--accent, #d97757);
+}
+
+.env-picker__group {
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid var(--border, #333);
+}
+
+.env-picker__group:last-child {
+  border-bottom: 0;
+}
+
+.env-picker__group-label {
+  padding: 6px 12px 4px;
+  color: var(--text-muted, #888);
+  text-transform: lowercase;
+  font-size: var(--font-size-xs, 0.75rem);
+  letter-spacing: 0.02em;
+}
+
+.env-picker__option {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 12px;
+  border-left: 2px solid transparent;
+  cursor: pointer;
+}
+
+.env-picker__option:hover,
+.env-picker__option--active {
+  background: var(--surface-hover, #141414);
+  border-left-color: var(--accent, #d97757);
+}
+
+.env-picker__option:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px var(--accent, #d97757);
+}
+
+.env-picker__option-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.env-picker__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.env-picker__dot--fresh {
+  background: var(--status-success, #4ade80);
+}
+
+.env-picker__dot--stale {
+  background: var(--status-warning, #fbbf24);
+}
+
+.env-picker__dot--offline {
+  background: var(--status-error, #f87171);
+}
+
+.env-picker__node {
+  color: var(--text, #e0e0e0);
+  flex-shrink: 0;
+}
+
+.env-picker__cwd {
+  color: var(--text-muted, #888);
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--font-size-xs, 0.75rem);
+}
+
+.env-picker__branch {
+  color: var(--status-info, #60a5fa);
+  font-size: var(--font-size-xs, 0.75rem);
+  flex-shrink: 0;
+}
+
+.env-picker__capabilities {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-left: 14px; /* align under text after dot column */
+}
+
+.env-picker__capability {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border: 1px solid var(--border, #333);
+  color: var(--text-muted, #888);
+  font-size: var(--font-size-xs, 0.75rem);
+  background: transparent;
+  text-transform: lowercase;
+}
+
+.env-picker__degraded-list {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 14px;
+}
+
+.env-picker__degraded {
+  color: var(--status-warning, #fbbf24);
+  font-size: var(--font-size-xs, 0.75rem);
+}
+
+.env-picker__option--offline .env-picker__degraded {
+  color: var(--status-error, #f87171);
+}
+
+.env-picker__empty {
+  padding: 12px;
+  color: var(--text-muted, #888);
+  text-align: center;
+  font-size: var(--font-size-xs, 0.75rem);
+}

--- a/frontend/src/components/EnvironmentPicker.css
+++ b/frontend/src/components/EnvironmentPicker.css
@@ -114,6 +114,18 @@
   box-shadow: inset 0 0 0 1px var(--accent, #d97757);
 }
 
+/* Persistent selected mark: distinct from keyboard-active so the user can see
+ * which option is currently bound (e.g. last-chosen) while navigating freely
+ * with arrow keys. Renders as a leading "·" glyph via ::before so it doesn't
+ * change layout when present/absent. */
+.env-picker__option--selected {
+  border-left-color: var(--text-primary, #e6e6e6);
+}
+.env-picker__option--selected .env-picker__node::before {
+  content: '·  ';
+  color: var(--text-primary, #e6e6e6);
+}
+
 .env-picker__option-header {
   display: flex;
   align-items: center;

--- a/frontend/src/components/EnvironmentPicker.tsx
+++ b/frontend/src/components/EnvironmentPicker.tsx
@@ -1,0 +1,381 @@
+// EnvironmentPicker (#627) — pure presentational picker for an
+// EnvironmentOption list. Renders options grouped by RepoIdentity, with
+// freshness + capability badges, search filter, and keyboard navigation.
+//
+// Scope per #627:
+//   - Pure presentational. No API calls, no store subscriptions, no router
+//     hooks. Props in, callbacks out. Downstream issues wire this into
+//     surfaces (session creation, command palette, Workbench block create).
+//   - Mirrors visual language from `DESIGN.md` (TUI aesthetic: lowercase,
+//     monospace, zero border-radius, outline-only chrome, no emoji).
+//   - Pattern matches existing TerminalNodePicker portal-listbox structure
+//     (id-based aria-activedescendant focus, role="combobox"/"listbox").
+
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import type {
+  EnvironmentDegradedReason,
+  EnvironmentOption,
+} from '../../../shared/environment-option.js';
+import './EnvironmentPicker.css';
+
+export interface EnvironmentPickerGroup {
+  /** RepoIdentity string (e.g. `github.com/owner/repo`) or `null` for free / non-git cwd options. */
+  repoIdentity: string | null;
+  /** Display label for the group header. */
+  label: string;
+  options: EnvironmentOption[];
+}
+
+export interface EnvironmentPickerProps {
+  options: EnvironmentOption[];
+  /**
+   * Optional id of the currently-selected option. Used to render a persistent
+   * "selected" mark; the keyboard active descendant tracks focus separately so
+   * users can navigate without losing the prior selection until they confirm.
+   */
+  selectedOptionId?: string;
+  /** Fired when the user activates an option (click or Enter). */
+  onSelect: (option: EnvironmentOption) => void;
+  /** Fired on Escape. Optional — the picker is presentational. */
+  onCancel?: () => void;
+  /** Placeholder for the search/filter input. Defaults to a lowercase TUI prompt. */
+  searchPlaceholder?: string;
+  /**
+   * When true (default) the picker autofocuses the search input on mount so
+   * keyboard users can start typing immediately. Set false when embedded
+   * inside a surface that owns focus.
+   */
+  autoFocusSearch?: boolean;
+}
+
+const FREE_GROUP_LABEL = 'non-git cwd';
+
+/**
+ * Group options by their repo identity. Options with no `repoInstance` (free
+ * / non-git cwd launches) collapse into a single trailing group whose
+ * `repoIdentity` is `null`.
+ *
+ * Group order preserves the order of first appearance in `options`, then
+ * appends the free group last. This is presentational order only — callers
+ * can pre-sort if they want a different policy.
+ */
+export function groupOptionsByRepoIdentity(
+  options: EnvironmentOption[]
+): EnvironmentPickerGroup[] {
+  const repoGroups = new Map<string, EnvironmentPickerGroup>();
+  const freeGroup: EnvironmentPickerGroup = {
+    repoIdentity: null,
+    label: FREE_GROUP_LABEL,
+    options: [],
+  };
+  for (const opt of options) {
+    const identity = opt.repoInstance?.repoIdentity ?? null;
+    if (identity === null) {
+      freeGroup.options.push(opt);
+      continue;
+    }
+    const existing = repoGroups.get(identity);
+    if (existing) {
+      existing.options.push(opt);
+      continue;
+    }
+    repoGroups.set(identity, {
+      repoIdentity: identity,
+      label: opt.repoInstance?.name ?? identity,
+      options: [opt],
+    });
+  }
+  const result = Array.from(repoGroups.values());
+  if (freeGroup.options.length > 0) result.push(freeGroup);
+  return result;
+}
+
+/**
+ * Filter options by a case-insensitive substring match against the most useful
+ * label fields. Empty / whitespace-only queries return all options unchanged.
+ */
+export function filterOptions(
+  options: EnvironmentOption[],
+  query: string
+): EnvironmentOption[] {
+  const trimmed = query.trim().toLowerCase();
+  if (trimmed === '') return options;
+  return options.filter((opt) => {
+    const haystack = [
+      opt.node.displayName ?? '',
+      opt.node.nodeId,
+      opt.cwd,
+      opt.repoInstance?.repoIdentity ?? '',
+      opt.repoInstance?.name ?? '',
+      opt.repoInstance?.currentBranch ?? '',
+      opt.bench?.branchName ?? '',
+      opt.bench?.displayName ?? '',
+    ]
+      .join(' ')
+      .toLowerCase();
+    return haystack.includes(trimmed);
+  });
+}
+
+function describeDegradedReason(reason: EnvironmentDegradedReason): string {
+  switch (reason.kind) {
+    case 'node-offline':
+      return reason.message ?? 'node offline';
+    case 'node-stale':
+      return reason.message ?? `node stale since ${reason.lastSeenAt}`;
+    case 'capability-missing':
+      return reason.message ?? `missing capability ${reason.capability}`;
+    case 'repo-missing':
+      return (
+        reason.message ??
+        `repo missing${reason.localPath ? ` at ${reason.localPath}` : ''}`
+      );
+    case 'worktree-missing':
+      return reason.message ?? `worktree missing at ${reason.localPath}`;
+    case 'auth-failed':
+      return reason.message;
+    case 'other':
+      return reason.message;
+    default:
+      return '';
+  }
+}
+
+export function EnvironmentPicker({
+  options,
+  selectedOptionId,
+  onSelect,
+  onCancel,
+  searchPlaceholder = 'filter environments…',
+  autoFocusSearch = true,
+}: EnvironmentPickerProps): React.ReactElement {
+  const [query, setQuery] = useState('');
+  const idPrefix = useId();
+  const listboxId = `${idPrefix}-listbox`;
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Filter first, then group. Filtering across the flat list keeps the search
+  // behavior intuitive even when an option's group label would otherwise hide it.
+  const visibleOptions = useMemo(
+    () => filterOptions(options, query),
+    [options, query]
+  );
+  const groups = useMemo(
+    () => groupOptionsByRepoIdentity(visibleOptions),
+    [visibleOptions]
+  );
+
+  // The keyboard active descendant tracks a flat index into `visibleOptions`,
+  // independent of the persistent `selectedOptionId` so navigation never
+  // mutates selection until the user confirms.
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    // Clamp active index when the visible set changes (filter narrowed or grew).
+    setActiveIndex((prev) => {
+      if (visibleOptions.length === 0) return 0;
+      if (prev >= visibleOptions.length) return 0;
+      if (prev < 0) return 0;
+      return prev;
+    });
+  }, [visibleOptions]);
+
+  useEffect(() => {
+    if (autoFocusSearch) inputRef.current?.focus();
+  }, [autoFocusSearch]);
+
+  const optionDomId = useCallback(
+    (id: string) => `${idPrefix}-opt-${id}`,
+    [idPrefix]
+  );
+
+  const activeOption = visibleOptions[activeIndex];
+  const activeDescendantId = activeOption ? optionDomId(activeOption.id) : '';
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setActiveIndex((prev) => {
+          if (visibleOptions.length === 0) return 0;
+          return (prev + 1) % visibleOptions.length;
+        });
+        return;
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setActiveIndex((prev) => {
+          if (visibleOptions.length === 0) return 0;
+          return (prev - 1 + visibleOptions.length) % visibleOptions.length;
+        });
+        return;
+      }
+      if (event.key === 'Home') {
+        event.preventDefault();
+        setActiveIndex(0);
+        return;
+      }
+      if (event.key === 'End') {
+        event.preventDefault();
+        setActiveIndex(Math.max(0, visibleOptions.length - 1));
+        return;
+      }
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        if (activeOption) onSelect(activeOption);
+        return;
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onCancel?.();
+      }
+    },
+    [activeOption, onCancel, onSelect, visibleOptions.length]
+  );
+
+  return (
+    <div
+      className="env-picker"
+      role="combobox"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-controls={listboxId}
+      // The combobox surface itself is a wrapper; the input owns focus, but
+      // the role conveys the relationship to the listbox per ARIA APG.
+    >
+      <div className="env-picker__search">
+        <span className="env-picker__search-prompt" aria-hidden="true">
+          &gt;
+        </span>
+        <input
+          ref={inputRef}
+          type="text"
+          className="env-picker__search-input"
+          data-testid="env-picker-search"
+          placeholder={searchPlaceholder}
+          value={query}
+          onChange={(e) => setQuery(e.currentTarget.value)}
+          onKeyDown={handleKeyDown}
+          aria-controls={listboxId}
+          aria-autocomplete="list"
+          {...(activeDescendantId
+            ? { 'aria-activedescendant': activeDescendantId }
+            : {})}
+        />
+      </div>
+      <div
+        id={listboxId}
+        role="listbox"
+        tabIndex={-1}
+        className="env-picker__listbox"
+        onKeyDown={handleKeyDown}
+        {...(activeDescendantId
+          ? { 'aria-activedescendant': activeDescendantId }
+          : {})}
+      >
+        {groups.length === 0 ? (
+          <div className="env-picker__empty" data-testid="env-picker-empty">
+            no matching environments
+          </div>
+        ) : (
+          groups.map((group) => (
+            <div
+              key={group.repoIdentity ?? '__free__'}
+              className="env-picker__group"
+              data-testid="env-picker-group"
+            >
+              <div
+                className="env-picker__group-label"
+                data-testid="env-picker-group-label"
+              >
+                {group.label}
+              </div>
+              {group.options.map((opt) => {
+                const flatIndex = visibleOptions.indexOf(opt);
+                const isActive = flatIndex === activeIndex;
+                const isSelected = selectedOptionId === opt.id;
+                return (
+                  <div
+                    key={opt.id}
+                    id={optionDomId(opt.id)}
+                    role="option"
+                    aria-selected={isSelected || isActive}
+                    data-option-id={opt.id}
+                    data-freshness={opt.freshness}
+                    data-active={isActive ? 'true' : 'false'}
+                    className={[
+                      'env-picker__option',
+                      isActive ? 'env-picker__option--active' : '',
+                      `env-picker__option--${opt.freshness}`,
+                    ]
+                      .filter(Boolean)
+                      .join(' ')}
+                    onClick={() => onSelect(opt)}
+                    onMouseEnter={() => setActiveIndex(flatIndex)}
+                  >
+                    <div className="env-picker__option-header">
+                      <span
+                        className={`env-picker__dot env-picker__dot--${opt.freshness}`}
+                        aria-hidden="true"
+                      />
+                      <span className="env-picker__node">
+                        {opt.node.displayName ?? opt.node.nodeId}
+                      </span>
+                      <span className="env-picker__cwd" title={opt.cwd}>
+                        {opt.cwd}
+                      </span>
+                      {opt.bench?.branchName ? (
+                        <span className="env-picker__branch">
+                          {opt.bench.branchName}
+                        </span>
+                      ) : opt.repoInstance?.currentBranch ? (
+                        <span className="env-picker__branch">
+                          {opt.repoInstance.currentBranch}
+                        </span>
+                      ) : null}
+                    </div>
+                    {opt.capabilities.length > 0 ? (
+                      <div className="env-picker__capabilities">
+                        {opt.capabilities.map((cap) => (
+                          <span
+                            key={cap}
+                            className="env-picker__capability"
+                            data-testid="env-picker-capability"
+                          >
+                            {cap}
+                          </span>
+                        ))}
+                      </div>
+                    ) : null}
+                    {opt.degradedReasons && opt.degradedReasons.length > 0 ? (
+                      <ul className="env-picker__degraded-list">
+                        {opt.degradedReasons.map((reason, i) => (
+                          <li
+                            key={`${reason.kind}-${i}`}
+                            className="env-picker__degraded"
+                            data-testid="env-picker-degraded"
+                          >
+                            {describeDegradedReason(reason)}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default EnvironmentPicker;

--- a/frontend/src/components/EnvironmentPicker.tsx
+++ b/frontend/src/components/EnvironmentPicker.tsx
@@ -143,8 +143,12 @@ function describeDegradedReason(reason: EnvironmentDegradedReason): string {
       return reason.message;
     case 'other':
       return reason.message;
-    default:
-      return '';
+    default: {
+      // Exhaustive guard: any new EnvironmentDegradedReason kind added to the
+      // shared union will fail to compile here until handled above.
+      const _exhaustive: never = reason;
+      return String(_exhaustive);
+    }
   }
 }
 
@@ -161,16 +165,25 @@ export function EnvironmentPicker({
   const listboxId = `${idPrefix}-listbox`;
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  // Filter first, then group. Filtering across the flat list keeps the search
-  // behavior intuitive even when an option's group label would otherwise hide it.
-  const visibleOptions = useMemo(
-    () => filterOptions(options, query),
+  // Filter, then group, then derive the flat list FROM the grouped order. This
+  // ensures keyboard navigation order matches the visual order — Arrow Down
+  // moves to the next visually-adjacent row, even across the free / non-git
+  // group that grouping appends to the end.
+  const groups = useMemo(
+    () => groupOptionsByRepoIdentity(filterOptions(options, query)),
     [options, query]
   );
-  const groups = useMemo(
-    () => groupOptionsByRepoIdentity(visibleOptions),
-    [visibleOptions]
+  const visibleOptions = useMemo(
+    () => groups.flatMap((group) => group.options),
+    [groups]
   );
+  // Map from option id → flat index so per-row render is O(1) instead of an
+  // O(N) `indexOf` per row (avoids O(N²) total when the picker grows).
+  const flatIndexById = useMemo(() => {
+    const map = new Map<string, number>();
+    visibleOptions.forEach((opt, i) => map.set(opt.id, i));
+    return map;
+  }, [visibleOptions]);
 
   // The keyboard active descendant tracks a flat index into `visibleOptions`,
   // independent of the persistent `selectedOptionId` so navigation never
@@ -178,13 +191,11 @@ export function EnvironmentPicker({
   const [activeIndex, setActiveIndex] = useState(0);
 
   useEffect(() => {
-    // Clamp active index when the visible set changes (filter narrowed or grew).
-    setActiveIndex((prev) => {
-      if (visibleOptions.length === 0) return 0;
-      if (prev >= visibleOptions.length) return 0;
-      if (prev < 0) return 0;
-      return prev;
-    });
+    // Reset to the top of the visible list whenever the filtered set changes
+    // (e.g. user typed a query). Highlighting the first match is the standard
+    // command-palette behavior; clamping mid-list would otherwise leave a
+    // confusing arbitrary row highlighted as the user types.
+    setActiveIndex(0);
   }, [visibleOptions]);
 
   useEffect(() => {
@@ -241,16 +252,11 @@ export function EnvironmentPicker({
   );
 
   return (
-    <div
-      className="env-picker"
-      role="combobox"
-      aria-expanded="true"
-      aria-haspopup="listbox"
-      aria-controls={listboxId}
-      // The combobox surface itself is a wrapper; the input owns focus, but
-      // the role conveys the relationship to the listbox per ARIA APG.
-    >
-      <div className="env-picker__search">
+    // Wrapper is purely presentational. ARIA APG combobox/listbox pattern
+    // places role="combobox" + aria-* on the input (the element that actually
+    // receives focus). Matches existing CommandPalette / FilePicker pattern.
+    <div className="env-picker">
+      <div className="env-picker__search" role="presentation">
         <span className="env-picker__search-prompt" aria-hidden="true">
           &gt;
         </span>
@@ -263,8 +269,13 @@ export function EnvironmentPicker({
           value={query}
           onChange={(e) => setQuery(e.currentTarget.value)}
           onKeyDown={handleKeyDown}
+          role="combobox"
+          aria-expanded={visibleOptions.length > 0}
+          aria-haspopup="listbox"
           aria-controls={listboxId}
           aria-autocomplete="list"
+          autoComplete="off"
+          spellCheck={false}
           {...(activeDescendantId
             ? { 'aria-activedescendant': activeDescendantId }
             : {})}
@@ -276,9 +287,6 @@ export function EnvironmentPicker({
         tabIndex={-1}
         className="env-picker__listbox"
         onKeyDown={handleKeyDown}
-        {...(activeDescendantId
-          ? { 'aria-activedescendant': activeDescendantId }
-          : {})}
       >
         {groups.length === 0 ? (
           <div className="env-picker__empty" data-testid="env-picker-empty">
@@ -298,7 +306,7 @@ export function EnvironmentPicker({
                 {group.label}
               </div>
               {group.options.map((opt) => {
-                const flatIndex = visibleOptions.indexOf(opt);
+                const flatIndex = flatIndexById.get(opt.id) ?? -1;
                 const isActive = flatIndex === activeIndex;
                 const isSelected = selectedOptionId === opt.id;
                 return (
@@ -306,13 +314,19 @@ export function EnvironmentPicker({
                     key={opt.id}
                     id={optionDomId(opt.id)}
                     role="option"
-                    aria-selected={isSelected || isActive}
+                    // ARIA APG combobox/listbox pattern: aria-selected reflects
+                    // the *persistent* selection only. The focused/active row
+                    // is communicated via aria-activedescendant on the
+                    // container; doubling it up on aria-selected confuses
+                    // screen readers in a single-select listbox.
+                    aria-selected={isSelected}
                     data-option-id={opt.id}
                     data-freshness={opt.freshness}
                     data-active={isActive ? 'true' : 'false'}
                     className={[
                       'env-picker__option',
                       isActive ? 'env-picker__option--active' : '',
+                      isSelected ? 'env-picker__option--selected' : '',
                       `env-picker__option--${opt.freshness}`,
                     ]
                       .filter(Boolean)

--- a/frontend/src/test-environment-picker.tsx
+++ b/frontend/src/test-environment-picker.tsx
@@ -1,0 +1,190 @@
+// Visual fixture for the EnvironmentPicker component (#627).
+//
+// Render with `RELAY_IDE_E2E_FIXTURES=1 npm run dev:vite` and open the
+// `/test-environment-picker.html` page. Pure presentational — the picker
+// receives a hard-coded option list and an `onSelect` that logs to the
+// page-level <output>. No store, no API.
+
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom/client';
+import type { EnvironmentOption } from '../../shared/environment-option.js';
+import EnvironmentPicker from './components/EnvironmentPicker.js';
+import './App.css';
+import './components/EnvironmentPicker.css';
+
+const GENERATED_AT = '2026-05-19T12:00:00.000Z';
+
+const OPTIONS: EnvironmentOption[] = [
+  {
+    schemaVersion: 1,
+    id: 'local-relay',
+    node: {
+      nodeId: 'local',
+      kind: 'local',
+      displayName: 'this host',
+      online: true,
+    },
+    capabilities: [
+      'session:create:terminal',
+      'session:create:agent',
+      'rpc:fs:read',
+      'rpc:git:read',
+    ],
+    cwd: '/Users/dev/repos/relay-ide',
+    cwdMode: 'repo',
+    freshness: 'fresh',
+    repoInstance: {
+      repoInstanceId: 'local:/Users/dev/repos/relay-ide',
+      localPath: '/Users/dev/repos/relay-ide',
+      repoIdentity: 'github.com/donovan-yohan/relay-ide',
+      name: 'relay-ide',
+      currentBranch: 'nightly',
+      defaultBranch: 'master',
+    },
+    generatedAt: GENERATED_AT,
+  },
+  {
+    schemaVersion: 1,
+    id: 'mac-relay-nightly',
+    node: {
+      nodeId: 'mac',
+      kind: 'remote',
+      displayName: 'dev mac',
+      online: true,
+    },
+    capabilities: [
+      'session:create:terminal',
+      'session:create:agent',
+      'rpc:fs:read',
+      'rpc:git:read',
+    ],
+    cwd: '/Users/dev/code/relay-ide/.worktrees/627-env-picker',
+    cwdMode: 'repo',
+    freshness: 'fresh',
+    repoInstance: {
+      repoInstanceId: 'mac:/Users/dev/code/relay-ide',
+      localPath: '/Users/dev/code/relay-ide',
+      repoIdentity: 'github.com/donovan-yohan/relay-ide',
+      name: 'relay-ide',
+      currentBranch: 'feature/627-env-picker',
+      defaultBranch: 'master',
+    },
+    bench: {
+      worktreeInstanceId:
+        'mac:/Users/dev/code/relay-ide/.worktrees/627-env-picker',
+      localPath: '/Users/dev/code/relay-ide/.worktrees/627-env-picker',
+      branchName: 'feature/627-env-picker',
+      displayName: '627-env-picker',
+    },
+    generatedAt: GENERATED_AT,
+  },
+  {
+    schemaVersion: 1,
+    id: 'wsl-relay-stale',
+    node: {
+      nodeId: 'wsl',
+      kind: 'remote',
+      displayName: 'win wsl',
+      online: true,
+    },
+    capabilities: ['session:create:terminal', 'rpc:fs:read'],
+    cwd: '/home/dev/repos/relay-ide',
+    cwdMode: 'repo',
+    freshness: 'stale',
+    repoInstance: {
+      repoInstanceId: 'wsl:/home/dev/repos/relay-ide',
+      localPath: '/home/dev/repos/relay-ide',
+      repoIdentity: 'github.com/donovan-yohan/relay-ide',
+      name: 'relay-ide',
+      currentBranch: 'nightly',
+    },
+    degradedReasons: [
+      {
+        kind: 'node-stale',
+        lastSeenAt: '2026-05-19T11:30:00.000Z',
+        message: 'heartbeat 30 min stale',
+      },
+      {
+        kind: 'capability-missing',
+        capability: 'rpc:git:read',
+        message: 'git capability not granted on this node',
+      },
+    ],
+    generatedAt: GENERATED_AT,
+  },
+  {
+    schemaVersion: 1,
+    id: 'lab-other-offline',
+    node: {
+      nodeId: 'lab',
+      kind: 'remote',
+      displayName: 'lab box',
+      online: false,
+    },
+    capabilities: ['session:create:terminal'],
+    cwd: '/srv/repos/other-project',
+    cwdMode: 'repo',
+    freshness: 'offline',
+    repoInstance: {
+      repoInstanceId: 'lab:/srv/repos/other-project',
+      localPath: '/srv/repos/other-project',
+      repoIdentity: 'github.com/donovan-yohan/other-project',
+      name: 'other-project',
+      currentBranch: 'main',
+    },
+    degradedReasons: [
+      { kind: 'node-offline', message: 'node has not checked in' },
+    ],
+    generatedAt: GENERATED_AT,
+  },
+  {
+    schemaVersion: 1,
+    id: 'local-free-scratch',
+    node: {
+      nodeId: 'local',
+      kind: 'local',
+      displayName: 'this host',
+      online: true,
+    },
+    capabilities: ['session:create:terminal'],
+    cwd: '/tmp/scratch',
+    cwdMode: 'free',
+    freshness: 'fresh',
+    generatedAt: GENERATED_AT,
+  },
+];
+
+function Harness() {
+  const [selected, setSelected] = useState<EnvironmentOption | null>(null);
+  const [cancelled, setCancelled] = useState(0);
+  return (
+    <div style={{ padding: 24, maxWidth: 640 }}>
+      <h2 style={{ fontFamily: 'monospace', color: '#e0e0e0' }}>
+        environment picker fixture (#627)
+      </h2>
+      <EnvironmentPicker
+        options={OPTIONS}
+        {...(selected ? { selectedOptionId: selected.id } : {})}
+        onSelect={(opt) => setSelected(opt)}
+        onCancel={() => setCancelled((n) => n + 1)}
+      />
+      <output
+        data-testid="env-picker-selected"
+        style={{
+          display: 'block',
+          marginTop: 16,
+          color: '#888',
+          fontFamily: 'monospace',
+        }}
+      >
+        selected: {selected?.id ?? '(none)'} · cancels: {cancelled}
+      </output>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')!).render(
+  <React.StrictMode>
+    <Harness />
+  </React.StrictMode>
+);

--- a/frontend/test-environment-picker.html
+++ b/frontend/test-environment-picker.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EnvironmentPicker Test Page</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/src/test-environment-picker.tsx"
+    ></script>
+  </body>
+</html>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -36,6 +36,10 @@ if (includeE2eFixtures) {
     import.meta.dirname,
     'test-customize-session-dialog.html'
   );
+  buildInputs['test-environment-picker'] = resolve(
+    import.meta.dirname,
+    'test-environment-picker.html'
+  );
 }
 
 export default defineConfig({

--- a/test/components/EnvironmentPicker.test.ts
+++ b/test/components/EnvironmentPicker.test.ts
@@ -325,28 +325,35 @@ describe('<EnvironmentPicker />', () => {
       options: [option({ id: 'a' }), option({ id: 'b' }), option({ id: 'c' })],
       onSelect,
     });
+    // Per ARIA APG combobox/listbox pattern, aria-activedescendant lives on the
+    // combobox (input), not the listbox. Keyboard events can come from either
+    // (both have onKeyDown), but the assertion target is the combobox input.
+    const combobox = container.querySelector(
+      '[role="combobox"]'
+    ) as HTMLElement;
     const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    expect(combobox).toBeTruthy();
     expect(listbox).toBeTruthy();
     // First option is active by default
-    expect(listbox.getAttribute('aria-activedescendant')).toContain('a');
+    expect(combobox.getAttribute('aria-activedescendant')).toContain('a');
     await act(async () => {
       listbox.dispatchEvent(
         new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })
       );
     });
-    expect(listbox.getAttribute('aria-activedescendant')).toContain('b');
+    expect(combobox.getAttribute('aria-activedescendant')).toContain('b');
     await act(async () => {
       listbox.dispatchEvent(
         new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })
       );
     });
-    expect(listbox.getAttribute('aria-activedescendant')).toContain('c');
+    expect(combobox.getAttribute('aria-activedescendant')).toContain('c');
     await act(async () => {
       listbox.dispatchEvent(
         new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true })
       );
     });
-    expect(listbox.getAttribute('aria-activedescendant')).toContain('b');
+    expect(combobox.getAttribute('aria-activedescendant')).toContain('b');
     await act(async () => {
       listbox.dispatchEvent(
         new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
@@ -407,6 +414,9 @@ describe('<EnvironmentPicker />', () => {
       window.HTMLInputElement.prototype,
       'value'
     )?.set;
+    // Guard so a happy-dom version bump that drops the descriptor surfaces as a
+    // clear assertion failure instead of a generic "cannot read .call of undefined".
+    expect(setter).toBeTruthy();
     await act(async () => {
       setter!.call(input, 'mac');
       input.dispatchEvent(new Event('input', { bubbles: true }));

--- a/test/components/EnvironmentPicker.test.ts
+++ b/test/components/EnvironmentPicker.test.ts
@@ -1,0 +1,456 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EnvironmentOption } from '../../shared/environment-option.js';
+import {
+  EnvironmentPicker,
+  groupOptionsByRepoIdentity,
+  filterOptions,
+} from '../../frontend/src/components/EnvironmentPicker.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const GENERATED_AT = '2026-05-19T12:00:00.000Z';
+
+function option(overrides: Partial<EnvironmentOption> = {}): EnvironmentOption {
+  return {
+    schemaVersion: 1,
+    id: 'opt-default',
+    node: {
+      nodeId: 'local',
+      kind: 'local',
+      displayName: 'this host',
+      online: true,
+    },
+    capabilities: ['session:create:terminal', 'rpc:fs:read'],
+    cwd: '/Users/dev/repos/relay-ide',
+    cwdMode: 'repo',
+    freshness: 'fresh',
+    repoInstance: {
+      repoInstanceId: 'local:/Users/dev/repos/relay-ide',
+      localPath: '/Users/dev/repos/relay-ide',
+      repoIdentity: 'github.com/donovan-yohan/relay-ide',
+      name: 'relay-ide',
+      currentBranch: 'nightly',
+      defaultBranch: 'master',
+    },
+    generatedAt: GENERATED_AT,
+    ...overrides,
+  };
+}
+
+function freeOption(
+  overrides: Partial<EnvironmentOption> = {}
+): EnvironmentOption {
+  return {
+    schemaVersion: 1,
+    id: 'opt-free',
+    node: {
+      nodeId: 'local',
+      kind: 'local',
+      displayName: 'this host',
+      online: true,
+    },
+    capabilities: ['session:create:terminal'],
+    cwd: '/tmp/scratch',
+    cwdMode: 'free',
+    freshness: 'fresh',
+    generatedAt: GENERATED_AT,
+    ...overrides,
+  };
+}
+
+describe('groupOptionsByRepoIdentity', () => {
+  it('groups options by repoIdentity and puts free (no repo) in its own group last', () => {
+    const opts: EnvironmentOption[] = [
+      option({ id: 'a' }),
+      option({
+        id: 'b',
+        repoInstance: {
+          repoInstanceId: 'mac:/repos/relay-ide',
+          localPath: '/repos/relay-ide',
+          repoIdentity: 'github.com/donovan-yohan/relay-ide',
+          name: 'relay-ide',
+          currentBranch: 'main',
+          defaultBranch: 'master',
+        },
+        node: {
+          nodeId: 'mac',
+          kind: 'remote',
+          displayName: 'mac',
+          online: true,
+        },
+      }),
+      option({
+        id: 'c',
+        repoInstance: {
+          repoInstanceId: 'local:/repos/other',
+          localPath: '/repos/other',
+          repoIdentity: 'github.com/donovan-yohan/other',
+          name: 'other',
+        },
+      }),
+      freeOption({ id: 'd' }),
+    ];
+    const groups = groupOptionsByRepoIdentity(opts);
+    // Two repo groups + one free group
+    expect(groups).toHaveLength(3);
+    const relay = groups.find(
+      (g) => g.repoIdentity === 'github.com/donovan-yohan/relay-ide'
+    );
+    expect(relay).toBeTruthy();
+    expect(relay?.options.map((o) => o.id)).toEqual(['a', 'b']);
+    // free is last
+    const free = groups[groups.length - 1];
+    expect(free?.repoIdentity).toBeNull();
+    expect(free?.options.map((o) => o.id)).toEqual(['d']);
+  });
+
+  it('treats options without repoInstance as the free / non-git group', () => {
+    const groups = groupOptionsByRepoIdentity([freeOption({ id: 'x' })]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]?.repoIdentity).toBeNull();
+    expect(groups[0]?.options).toHaveLength(1);
+  });
+});
+
+describe('filterOptions', () => {
+  const opts: EnvironmentOption[] = [
+    option({ id: 'a' }),
+    option({
+      id: 'b',
+      node: {
+        nodeId: 'mac',
+        kind: 'remote',
+        displayName: 'dev mac',
+        online: true,
+      },
+      repoInstance: {
+        repoInstanceId: 'mac:/repos/relay-ide',
+        localPath: '/repos/relay-ide',
+        repoIdentity: 'github.com/donovan-yohan/relay-ide',
+        name: 'relay-ide',
+        currentBranch: 'main',
+      },
+    }),
+    freeOption({ id: 'c', cwd: '/tmp/scratch' }),
+  ];
+
+  it('returns all options for empty query', () => {
+    expect(filterOptions(opts, '').map((o) => o.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('matches node displayName case-insensitively', () => {
+    expect(filterOptions(opts, 'dev mac').map((o) => o.id)).toEqual(['b']);
+    expect(filterOptions(opts, 'MAC').map((o) => o.id)).toEqual(['b']);
+  });
+
+  it('matches cwd substring', () => {
+    expect(filterOptions(opts, 'scratch').map((o) => o.id)).toEqual(['c']);
+  });
+
+  it('matches repo identity', () => {
+    expect(filterOptions(opts, 'donovan-yohan').map((o) => o.id)).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
+  it('returns empty when nothing matches', () => {
+    expect(filterOptions(opts, 'absolutely-nothing-here')).toEqual([]);
+  });
+});
+
+describe('<EnvironmentPicker />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function renderPicker(
+    props: React.ComponentProps<typeof EnvironmentPicker>
+  ) {
+    await act(async () => {
+      root.render(React.createElement(EnvironmentPicker, props));
+    });
+  }
+
+  it('renders option rows grouped by RepoIdentity', async () => {
+    await renderPicker({
+      options: [
+        option({ id: 'a' }),
+        option({
+          id: 'b',
+          repoInstance: {
+            repoInstanceId: 'local:/repos/other',
+            localPath: '/repos/other',
+            repoIdentity: 'github.com/donovan-yohan/other',
+            name: 'other',
+          },
+        }),
+        freeOption({ id: 'c' }),
+      ],
+      onSelect: vi.fn(),
+    });
+    const groupHeaders = container.querySelectorAll(
+      '[data-testid="env-picker-group"]'
+    );
+    expect(groupHeaders.length).toBe(3);
+    const optionRows = container.querySelectorAll('[role="option"]');
+    expect(optionRows.length).toBe(3);
+  });
+
+  it('renders a distinct non-git group label for free cwd options', async () => {
+    await renderPicker({
+      options: [option({ id: 'a' }), freeOption({ id: 'c' })],
+      onSelect: vi.fn(),
+    });
+    const headers = Array.from(
+      container.querySelectorAll('[data-testid="env-picker-group-label"]')
+    ).map((el) => el.textContent);
+    // Free/non-git group uses an explicit lowercase label that is NOT a repo identity
+    expect(headers).toContain('non-git cwd');
+  });
+
+  it('shows freshness state on each option', async () => {
+    await renderPicker({
+      options: [
+        option({ id: 'a', freshness: 'fresh' }),
+        option({
+          id: 'b',
+          freshness: 'stale',
+          degradedReasons: [
+            { kind: 'node-stale', lastSeenAt: '2026-05-19T11:00:00.000Z' },
+          ],
+        }),
+        option({
+          id: 'c',
+          freshness: 'offline',
+          node: {
+            nodeId: 'offline',
+            kind: 'remote',
+            displayName: 'offline',
+            online: false,
+          },
+          degradedReasons: [{ kind: 'node-offline' }],
+        }),
+      ],
+      onSelect: vi.fn(),
+    });
+    const fresh = container.querySelector('[data-option-id="a"]');
+    const stale = container.querySelector('[data-option-id="b"]');
+    const offline = container.querySelector('[data-option-id="c"]');
+    expect(fresh?.getAttribute('data-freshness')).toBe('fresh');
+    expect(stale?.getAttribute('data-freshness')).toBe('stale');
+    expect(offline?.getAttribute('data-freshness')).toBe('offline');
+  });
+
+  it('renders one badge per advertised capability', async () => {
+    await renderPicker({
+      options: [
+        option({
+          id: 'a',
+          capabilities: [
+            'session:create:terminal',
+            'rpc:fs:read',
+            'rpc:git:read',
+          ],
+        }),
+      ],
+      onSelect: vi.fn(),
+    });
+    const row = container.querySelector('[data-option-id="a"]') as HTMLElement;
+    expect(row).toBeTruthy();
+    const badges = row.querySelectorAll(
+      '[data-testid="env-picker-capability"]'
+    );
+    expect(badges.length).toBe(3);
+    const labels = Array.from(badges).map((b) => b.textContent);
+    expect(labels).toContain('session:create:terminal');
+    expect(labels).toContain('rpc:git:read');
+  });
+
+  it('renders degraded reason text when present', async () => {
+    await renderPicker({
+      options: [
+        option({
+          id: 'a',
+          freshness: 'stale',
+          degradedReasons: [
+            {
+              kind: 'capability-missing',
+              capability: 'rpc:git:write',
+              message: 'git write capability not granted',
+            },
+          ],
+        }),
+      ],
+      onSelect: vi.fn(),
+    });
+    const row = container.querySelector('[data-option-id="a"]') as HTMLElement;
+    const reason = row.querySelector('[data-testid="env-picker-degraded"]');
+    expect(reason?.textContent).toContain('git write capability not granted');
+  });
+
+  it('invokes onSelect when an option is clicked', async () => {
+    const onSelect = vi.fn();
+    await renderPicker({
+      options: [option({ id: 'a' }), option({ id: 'b' })],
+      onSelect,
+    });
+    const row = container.querySelector('[data-option-id="b"]') as HTMLElement;
+    await act(async () => {
+      row.click();
+    });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0]?.[0]?.id).toBe('b');
+  });
+
+  it('moves keyboard focus with ArrowDown/ArrowUp and selects with Enter', async () => {
+    const onSelect = vi.fn();
+    await renderPicker({
+      options: [option({ id: 'a' }), option({ id: 'b' }), option({ id: 'c' })],
+      onSelect,
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    expect(listbox).toBeTruthy();
+    // First option is active by default
+    expect(listbox.getAttribute('aria-activedescendant')).toContain('a');
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })
+      );
+    });
+    expect(listbox.getAttribute('aria-activedescendant')).toContain('b');
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })
+      );
+    });
+    expect(listbox.getAttribute('aria-activedescendant')).toContain('c');
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true })
+      );
+    });
+    expect(listbox.getAttribute('aria-activedescendant')).toContain('b');
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+      );
+    });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0]?.[0]?.id).toBe('b');
+  });
+
+  it('calls onCancel on Escape', async () => {
+    const onCancel = vi.fn();
+    await renderPicker({
+      options: [option({ id: 'a' })],
+      onSelect: vi.fn(),
+      onCancel,
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+      );
+    });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('filters options as the search input changes', async () => {
+    await renderPicker({
+      options: [
+        option({
+          id: 'a',
+          node: {
+            nodeId: 'local',
+            kind: 'local',
+            displayName: 'this host',
+            online: true,
+          },
+        }),
+        option({
+          id: 'b',
+          node: {
+            nodeId: 'mac',
+            kind: 'remote',
+            displayName: 'dev mac',
+            online: true,
+          },
+        }),
+      ],
+      onSelect: vi.fn(),
+    });
+    const input = container.querySelector(
+      '[data-testid="env-picker-search"]'
+    ) as HTMLInputElement;
+    expect(input).toBeTruthy();
+    // Use React's native input-value setter so the input event is observed
+    // as a real user keystroke. Setting `.value` directly bypasses React's
+    // change tracker and the synthetic onChange never fires.
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value'
+    )?.set;
+    await act(async () => {
+      setter!.call(input, 'mac');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const rows = container.querySelectorAll('[role="option"]');
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.getAttribute('data-option-id')).toBe('b');
+  });
+
+  it('exposes ARIA combobox/listbox roles and aria-expanded', async () => {
+    await renderPicker({
+      options: [option({ id: 'a' })],
+      onSelect: vi.fn(),
+    });
+    const combobox = container.querySelector(
+      '[role="combobox"]'
+    ) as HTMLElement;
+    expect(combobox).toBeTruthy();
+    expect(combobox.getAttribute('aria-expanded')).toBe('true');
+    expect(combobox.getAttribute('aria-controls')).toBeTruthy();
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    expect(listbox).toBeTruthy();
+    expect(listbox.id).toBe(combobox.getAttribute('aria-controls'));
+  });
+
+  it('renders an empty state when no options match the filter', async () => {
+    await renderPicker({
+      options: [option({ id: 'a' })],
+      onSelect: vi.fn(),
+    });
+    const input = container.querySelector(
+      '[data-testid="env-picker-search"]'
+    ) as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      'value'
+    )?.set;
+    await act(async () => {
+      setter!.call(input, 'nothing-matches');
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(container.querySelectorAll('[role="option"]').length).toBe(0);
+    expect(
+      container.querySelector('[data-testid="env-picker-empty"]')
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Pure presentational React component (`EnvironmentPicker`) that renders an `EnvironmentOption` list grouped by `RepoIdentity`, with freshness + capability badges, search/filter, and full keyboard navigation. No surfaces wired yet — downstream issues consume this.

- New `frontend/src/components/EnvironmentPicker.{tsx,css}`
- Visual fixture at `frontend/test-environment-picker.html` (gated by `RELAY_IDE_E2E_FIXTURES=1` to match existing test-page pattern)
- 18 vitest cases under `test/components/EnvironmentPicker.test.ts` (happy-dom, `createRoot` + `act`)

## Component API

```ts
interface EnvironmentPickerProps {
  options: EnvironmentOption[];      // from #623 shape
  selectedOptionId?: string;         // optional persistent selection
  onSelect: (option: EnvironmentOption) => void;
  onCancel?: () => void;             // Escape
  searchPlaceholder?: string;
  autoFocusSearch?: boolean;         // default true
}
```

Also exports helpers:
- `groupOptionsByRepoIdentity(options): EnvironmentPickerGroup[]` — preserves first-appearance order, appends a single trailing free / non-git group with `repoIdentity: null`
- `filterOptions(options, query): EnvironmentOption[]` — case-insensitive substring match across nodeId / displayName / cwd / repo identity / branch

## A11y

- `role="combobox"` wrapper + `role="listbox"` panel + `role="option"` rows
- `aria-controls`, `aria-expanded`, `aria-autocomplete="list"`, `aria-activedescendant`
- Keyboard: Arrow Up/Down (wraps), Home, End, Enter (select), Escape (cancel)
- Keyboard active descendant is independent of `selectedOptionId` so navigation never mutates selection until confirmed
- Native focus ring on the search input; `focus-within` accent under the input border preserves visible focus without breaking the bare-input look

## Visual language

Follows `DESIGN.md`:
- monospace, lowercase labels, no emoji
- zero border-radius (status dots are the only circle exception)
- outline-only chrome, pure-black surface, `--accent` terracotta for focus/active states
- 4px spacing rhythm, compact 8/12px option rows

## Refs

- Parent epic: #615
- Blocking ancestors: #623 (`EnvironmentOption` shape), #624 (`RepoIdentity` normalization)

## Test plan

- [x] `npm run check` (typecheck + lint) — 0 errors, no new warnings in added files
- [x] `npm test` — 247 files / 2921 passing locally after `npm run build:server` populates `dist/` (the 10 pre-existing CLI-gateway tests need built binaries to run)
- [x] `RELAY_IDE_E2E_FIXTURES=1 npm run build:frontend` — fixture page builds at `dist/frontend/test-environment-picker.html`
- [ ] Reviewer: open the fixture page and confirm the four visual states (fresh / stale with reasons / offline / free) match `DESIGN.md`