### PR TITLE
feat: workbench prompt hooks — layout→agent context + propose-block API (slice 5/5, #625)

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -86,6 +86,7 @@ import { clearCiStatusCache } from './gh.js';
 import { createWorkspaceGroupsRouter } from './workspace-groups.js';
 import { createWorkbenchLayoutRouter } from './workbench-layout.js';
 import { createWorkbenchCustomBlocksRouter } from './workbench-custom-blocks.js';
+import { createWorkbenchProposeBlockRouter } from './workbench-prompt-hooks.js';
 import { createOrgDashboardRouter } from './org-dashboard.js';
 import { createIntegrationGitHubRouter } from './integration-github.js';
 import {
@@ -1743,6 +1744,19 @@ async function main(): Promise<void> {
     '/workbench/custom-blocks',
     requireAuth,
     createWorkbenchCustomBlocksRouter({
+      configPath: CONFIG_PATH,
+      auditSink: securityAuditLog,
+    })
+  );
+
+  // Mount workbench propose-block router (slice 5, #625)
+  // POST /workbench/propose-block — agent proposes any block kind
+  // GET  /workbench/propose-block/proposals — list first-party proposals
+  // POST /workbench/propose-block/proposals/:id/(approve|reject)
+  app.use(
+    '/workbench',
+    requireAuth,
+    createWorkbenchProposeBlockRouter({
       configPath: CONFIG_PATH,
       auditSink: securityAuditLog,
     })

--- a/server/workbench-prompt-hooks.ts
+++ b/server/workbench-prompt-hooks.ts
@@ -1,0 +1,670 @@
+/**
+ * Workbench prompt hooks server module — slice 5 of epic #612.
+ *
+ * Provides two surfaces:
+ *
+ * a) Layout → agent context (read-only)
+ *    Re-exports `summarizeWorkbenchBlocks` from shared/ and wires it to the
+ *    layout store so callers can call `getWorkbenchContextSummary(workspaceId)`
+ *    without directly importing both modules.
+ *
+ * b) Agent → block proposal API
+ *    REST router at `/workbench/propose-block`:
+ *      POST /workbench/propose-block — agent submits a block descriptor.
+ *        - `custom` kind → delegates to POST /workbench/custom-blocks/proposals
+ *          and returns the proposal id + `pending` status.
+ *        - First-party kinds → evaluates capability grants:
+ *            * All requirements satisfied → `auto-approved`, stores in first-party
+ *              proposal store.
+ *            * Requirements unsatisfied → `pending`, stores in first-party store
+ *              for user review.
+ *        - Malformed descriptor → `rejected` at validation, HTTP 422.
+ *
+ *    GET /workbench/propose-block/proposals — list first-party proposals.
+ *    POST /workbench/propose-block/proposals/:id/approve — user approves pending.
+ *    POST /workbench/propose-block/proposals/:id/reject  — user rejects pending.
+ *
+ * Audit envelopes are emitted on:
+ *   - proposal create (any status, including auto-approved)
+ *   - auto-approve decision
+ *   - user approve / reject
+ *
+ * Storage: first-party proposals are stored as a JSON file at
+ * `<configDir>/workbench-prompt-hooks/first-party-proposals.json`.
+ * Custom proposals are delegated to the existing slice-4 store.
+ *
+ * Refs: #625, epic #612.
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+
+import {
+  summarizeWorkbenchBlocks,
+  evaluateBlockProposal,
+} from '../shared/workbench-prompt-hooks.js';
+import type {
+  WorkbenchContextSummary,
+  WorkbenchBlockProposalRequest,
+  WorkbenchBlockProposalResult,
+  FirstPartyBlockProposal,
+} from '../shared/workbench-prompt-hooks.js';
+import type { WorkbenchLayout } from '../shared/workbench-layout-types.js';
+import { readWorkbenchLayout } from './workbench-layout.js';
+import {
+  readAllProposals as readCustomProposals,
+  writeAllProposals as writeCustomProposals,
+  validateProposalInput as validateCustomProposalInput,
+} from './workbench-custom-blocks.js';
+import type { SecurityAuditEntryInput } from '../shared/security-audit.js';
+import { isRelayCapabilityBit } from '../shared/security-policy.js';
+import type { WorkbenchBlockDescriptor } from '../shared/workbench-block-types.js';
+import type { ActorRef } from '../shared/workbench-block-types.js';
+import { createLogger } from './logger.js';
+
+// Re-export the pure summarizer for server consumers
+export { summarizeWorkbenchBlocks } from '../shared/workbench-prompt-hooks.js';
+export type { WorkbenchContextSummary } from '../shared/workbench-prompt-hooks.js';
+
+const logger = createLogger('workbench-prompt-hooks');
+
+// ---------------------------------------------------------------------------
+// Context summary helper (wires layout store + summarizer)
+// ---------------------------------------------------------------------------
+
+/**
+ * Load the persisted layout for a workspace and produce a bounded context
+ * summary safe for inclusion in an agent's turn context or system prompt.
+ *
+ * Returns `null` if no layout is stored yet for the workspace.
+ */
+export function getWorkbenchContextSummary(
+  configPath: string,
+  workspaceId: string
+): WorkbenchContextSummary | null {
+  const layout: WorkbenchLayout | null = readWorkbenchLayout(
+    configPath,
+    workspaceId
+  );
+  if (layout === null) return null;
+  return summarizeWorkbenchBlocks(layout);
+}
+
+// ---------------------------------------------------------------------------
+// Status constants
+// ---------------------------------------------------------------------------
+
+const STATUS_AUTO_APPROVED = 'auto-approved' as const;
+const STATUS_PENDING = 'pending' as const;
+const STATUS_REJECTED = 'rejected' as const;
+
+// ---------------------------------------------------------------------------
+// First-party proposal storage
+// ---------------------------------------------------------------------------
+
+function proposalDir(configPath: string): string {
+  return path.join(path.dirname(configPath), 'workbench-prompt-hooks');
+}
+
+function proposalFilePath(configPath: string): string {
+  return path.join(proposalDir(configPath), 'first-party-proposals.json');
+}
+
+function ensureProposalDir(configPath: string): void {
+  const dir = proposalDir(configPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+/**
+ * Read all first-party proposals from disk.
+ * Returns an empty map on first run or parse error.
+ */
+export function readFirstPartyProposals(
+  configPath: string
+): Map<string, FirstPartyBlockProposal> {
+  const fp = proposalFilePath(configPath);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(fp, 'utf8');
+  } catch {
+    return new Map();
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return new Map();
+    const map = new Map<string, FirstPartyBlockProposal>();
+    for (const entry of parsed) {
+      if (
+        typeof entry === 'object' &&
+        entry !== null &&
+        typeof (entry as Record<string, unknown>)['proposalId'] === 'string'
+      ) {
+        const p = entry as FirstPartyBlockProposal;
+        map.set(p.proposalId, p);
+      }
+    }
+    return map;
+  } catch (err) {
+    logger.warn(
+      'Failed to parse first-party proposals store:',
+      err instanceof Error ? err.message : err
+    );
+    return new Map();
+  }
+}
+
+/**
+ * Persist all first-party proposals to disk.
+ * Writes atomically via a temp file rename.
+ */
+export function writeFirstPartyProposals(
+  configPath: string,
+  proposals: Map<string, FirstPartyBlockProposal>
+): void {
+  ensureProposalDir(configPath);
+  const fp = proposalFilePath(configPath);
+  const data = JSON.stringify([...proposals.values()], null, 2);
+  const tmp = `${fp}.tmp.${Date.now()}`;
+  fs.writeFileSync(tmp, data, 'utf8');
+  fs.renameSync(tmp, fp);
+}
+
+// ---------------------------------------------------------------------------
+// Descriptor validation (first-party kinds)
+// ---------------------------------------------------------------------------
+
+const FIRST_PARTY_KINDS = new Set([
+  'terminal',
+  'agent',
+  'work-context',
+  'file',
+  'artifact',
+  'markdown',
+]);
+
+/**
+ * Validate a first-party block descriptor.
+ * Returns an error string or null.
+ */
+function validateFirstPartyDescriptor(descriptor: unknown): string | null {
+  if (
+    typeof descriptor !== 'object' ||
+    descriptor === null ||
+    Array.isArray(descriptor)
+  ) {
+    return 'descriptor must be a JSON object';
+  }
+  const desc = descriptor as Record<string, unknown>;
+
+  if (
+    typeof desc['kind'] !== 'string' ||
+    !FIRST_PARTY_KINDS.has(desc['kind'])
+  ) {
+    return `descriptor.kind must be one of: ${[...FIRST_PARTY_KINDS].join(', ')}`;
+  }
+  if (typeof desc['id'] !== 'string' || desc['id'].trim() === '') {
+    return 'descriptor.id must be a non-empty string';
+  }
+  if (typeof desc['title'] !== 'string' || desc['title'].trim() === '') {
+    return 'descriptor.title must be a non-empty string';
+  }
+
+  if (Array.isArray(desc['capabilityRequirements'])) {
+    for (const bit of desc['capabilityRequirements']) {
+      if (!isRelayCapabilityBit(bit)) {
+        return `descriptor.capabilityRequirements contains unknown capability bit: ${String(bit)}`;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Validate the top-level request body for POST /propose-block.
+ * Returns an error string or null.
+ */
+function validateProposeBlockBody(body: unknown): string | null {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return 'request body must be a JSON object';
+  }
+  const obj = body as Record<string, unknown>;
+
+  if (typeof obj['actorId'] !== 'string' || obj['actorId'].trim() === '') {
+    return 'actorId must be a non-empty string';
+  }
+
+  if (!Array.isArray(obj['actorGrantedBits'])) {
+    return 'actorGrantedBits must be an array';
+  }
+  for (const bit of obj['actorGrantedBits'] as unknown[]) {
+    if (!isRelayCapabilityBit(bit)) {
+      return `actorGrantedBits contains unknown capability bit: ${String(bit)}`;
+    }
+  }
+
+  const descriptor = obj['descriptor'];
+  if (
+    typeof descriptor !== 'object' ||
+    descriptor === null ||
+    Array.isArray(descriptor)
+  ) {
+    return 'descriptor must be a JSON object';
+  }
+  const desc = descriptor as Record<string, unknown>;
+  if (typeof desc['kind'] !== 'string') {
+    return 'descriptor.kind must be a string';
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Audit helper
+// ---------------------------------------------------------------------------
+
+type AuditSink =
+  | { append(input: SecurityAuditEntryInput): unknown }
+  | undefined;
+
+function emitProposeAudit(
+  auditSink: AuditSink,
+  opts: {
+    proposalId: string;
+    actorId: string;
+    action: string;
+    decision: SecurityAuditEntryInput['decision'];
+    eventType: SecurityAuditEntryInput['eventType'];
+    reasonCode: string;
+  }
+): string | undefined {
+  if (!auditSink) return undefined;
+  const eventId = crypto.randomUUID();
+  try {
+    auditSink.append({
+      eventId,
+      eventType: opts.eventType,
+      decision: opts.decision,
+      reasonCode: opts.reasonCode,
+      peer: { kind: 'user', displayName: opts.actorId },
+      node: {},
+      intent: {
+        action: opts.action,
+        target: `workbench-block-proposal:${opts.proposalId}`,
+      },
+      material: {
+        params: { proposalId: opts.proposalId, actorId: opts.actorId },
+      },
+      refs: {},
+    });
+  } catch (err) {
+    logger.warn(
+      'Failed to emit propose-block audit envelope:',
+      err instanceof Error ? err.message : err
+    );
+  }
+  return eventId;
+}
+
+// ---------------------------------------------------------------------------
+// Router factory
+// ---------------------------------------------------------------------------
+
+export interface WorkbenchProposeBlockRouterDeps {
+  configPath: string;
+  auditSink?: AuditSink;
+}
+
+/**
+ * Creates the Express Router for the propose-block API.
+ *
+ * Routes (relative to mount point `/workbench`):
+ *   POST /propose-block                          — agent proposes a block
+ *   GET  /propose-block/proposals               — list first-party proposals
+ *   POST /propose-block/proposals/:id/approve   — user approves pending
+ *   POST /propose-block/proposals/:id/reject    — user rejects pending
+ *
+ * Custom-kind proposals are delegated to the slice-4 router at
+ * `/workbench/custom-blocks/proposals` — the response from that endpoint
+ * is proxied back with the proposalId and status.
+ *
+ * Auth is applied by the caller (mount with requireAuth middleware).
+ */
+export function createWorkbenchProposeBlockRouter(
+  deps: WorkbenchProposeBlockRouterDeps
+): Router {
+  const { configPath, auditSink } = deps;
+  const router = Router();
+
+  // -------------------------------------------------------------------------
+  // POST /propose-block — agent proposes a block descriptor
+  // -------------------------------------------------------------------------
+  router.post('/propose-block', (req: Request, res: Response) => {
+    const body = req.body as unknown;
+
+    // Top-level validation
+    const topError = validateProposeBlockBody(body);
+    if (topError) {
+      res.status(422).json({ error: topError });
+      return;
+    }
+
+    const obj = body as Record<string, unknown>;
+    const descriptor = obj['descriptor'] as Record<string, unknown>;
+    const kind = descriptor['kind'] as string;
+
+    // -----------------------------------------------------------------------
+    // Custom kind → delegate to slice-4 custom block store
+    // -----------------------------------------------------------------------
+    if (kind === 'custom') {
+      // Validate using slice-4's validator (handles custom-specific fields)
+      const customError = validateCustomProposalInput(body);
+      if (customError) {
+        res.status(422).json({ error: customError });
+        return;
+      }
+
+      // Build a CustomBlockProposal record in the slice-4 store
+      const input = body as {
+        descriptor: WorkbenchBlockDescriptor;
+        rendererSource: unknown;
+        proposedBy: ActorRef;
+      };
+      const proposalId = crypto.randomUUID();
+      const now = new Date().toISOString();
+
+      // Persist in slice-4 store
+      const customProposals = readCustomProposals(configPath);
+      const customProposal = {
+        proposalId,
+        descriptor: input.descriptor,
+        rendererSource: input.rendererSource,
+        proposedBy: input.proposedBy,
+        proposedAt: now,
+        status: 'pending' as const,
+        statusUpdatedAt: now,
+      };
+
+      const auditEventId = emitProposeAudit(auditSink, {
+        proposalId,
+        actorId: input.proposedBy.id,
+        action: 'workbench.block.propose.custom',
+        decision: 'recorded',
+        eventType: 'grant',
+        reasonCode: 'workbench_block_proposed_custom',
+      });
+
+      if (auditEventId) {
+        (
+          customProposal as typeof customProposal & { auditEventId?: string }
+        ).auditEventId = auditEventId;
+      }
+
+      customProposals.set(
+        proposalId,
+        customProposal as Parameters<typeof customProposals.set>[1]
+      );
+
+      try {
+        writeCustomProposals(configPath, customProposals);
+      } catch (err) {
+        logger.error(
+          'Failed to write custom proposal in propose-block:',
+          err instanceof Error ? err.message : err
+        );
+        res.status(500).json({ error: 'failed to persist proposal' });
+        return;
+      }
+
+      const result: WorkbenchBlockProposalResult = {
+        proposalId,
+        status: STATUS_PENDING,
+      };
+      res.status(201).json(result);
+      return;
+    }
+
+    // -----------------------------------------------------------------------
+    // First-party kind → validate + evaluate capability grants
+    // -----------------------------------------------------------------------
+    const descError = validateFirstPartyDescriptor(descriptor);
+    if (descError) {
+      const proposalId = crypto.randomUUID();
+      const result: WorkbenchBlockProposalResult = {
+        proposalId,
+        status: STATUS_REJECTED,
+        rejectionReason: descError,
+      };
+      res.status(422).json(result);
+      return;
+    }
+
+    const request: WorkbenchBlockProposalRequest = {
+      descriptor: descriptor as unknown as WorkbenchBlockDescriptor,
+      actorId: obj['actorId'] as string,
+      actorGrantedBits: obj[
+        'actorGrantedBits'
+      ] as string[] as import('../shared/security-policy.js').RelayCapabilityBit[],
+      ...(typeof obj['actorDisplayName'] === 'string'
+        ? { actorDisplayName: obj['actorDisplayName'] }
+        : {}),
+      ...(typeof obj['workspaceScopeId'] === 'string'
+        ? { workspaceScopeId: obj['workspaceScopeId'] }
+        : {}),
+    };
+
+    const result = evaluateBlockProposal(request, () => crypto.randomUUID());
+
+    // Emit audit on any state
+    const auditAction =
+      result.status === STATUS_AUTO_APPROVED
+        ? 'workbench.block.propose.auto-approved'
+        : result.status === STATUS_REJECTED
+          ? 'workbench.block.propose.rejected'
+          : 'workbench.block.propose.pending';
+    const auditDecision: SecurityAuditEntryInput['decision'] =
+      result.status === STATUS_AUTO_APPROVED
+        ? 'approved'
+        : result.status === STATUS_REJECTED
+          ? 'deny'
+          : 'recorded';
+
+    const auditEventId = emitProposeAudit(auditSink, {
+      proposalId: result.proposalId,
+      actorId: request.actorId,
+      action: auditAction,
+      decision: auditDecision,
+      eventType: result.status === STATUS_AUTO_APPROVED ? 'approval' : 'grant',
+      reasonCode: `workbench_block_${result.status.replace('-', '_')}`,
+    });
+
+    if (result.status === STATUS_REJECTED) {
+      res.status(422).json(result);
+      return;
+    }
+
+    // Persist the first-party proposal
+    const now = new Date().toISOString();
+    const record: FirstPartyBlockProposal = {
+      proposalId: result.proposalId,
+      descriptor: request.descriptor,
+      actorId: request.actorId,
+      ...(request.actorDisplayName
+        ? { actorDisplayName: request.actorDisplayName }
+        : {}),
+      ...(request.workspaceScopeId
+        ? { workspaceScopeId: request.workspaceScopeId }
+        : {}),
+      proposedAt: now,
+      status: result.status,
+      statusUpdatedAt: now,
+      ...(auditEventId ? { auditEventId } : {}),
+    };
+
+    const proposals = readFirstPartyProposals(configPath);
+    proposals.set(record.proposalId, record);
+
+    try {
+      writeFirstPartyProposals(configPath, proposals);
+    } catch (err) {
+      logger.error(
+        'Failed to write first-party proposal:',
+        err instanceof Error ? err.message : err
+      );
+      res.status(500).json({ error: 'failed to persist proposal' });
+      return;
+    }
+
+    res.status(201).json(result);
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /propose-block/proposals — list first-party proposals
+  // -------------------------------------------------------------------------
+  router.get('/propose-block/proposals', (req: Request, res: Response) => {
+    const statusFilter = req.query['status'] as string | undefined;
+    const proposals = readFirstPartyProposals(configPath);
+    let results = [...proposals.values()];
+
+    if (statusFilter) {
+      const validStatuses = [
+        STATUS_PENDING,
+        STATUS_AUTO_APPROVED,
+        STATUS_REJECTED,
+      ];
+      if (
+        !validStatuses.includes(statusFilter as (typeof validStatuses)[number])
+      ) {
+        res.status(400).json({
+          error: `invalid status filter "${statusFilter}". Valid values: ${validStatuses.join(', ')}`,
+        });
+        return;
+      }
+      results = results.filter((p) => p.status === statusFilter);
+    }
+
+    // Sort by proposedAt descending (newest first)
+    results.sort((a, b) => b.proposedAt.localeCompare(a.proposedAt));
+    res.json(results);
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /propose-block/proposals/:id/approve — user approves pending
+  // -------------------------------------------------------------------------
+  router.post(
+    '/propose-block/proposals/:id/approve',
+    (req: Request, res: Response) => {
+      const { id } = req.params as { id: string };
+      const proposals = readFirstPartyProposals(configPath);
+      const proposal = proposals.get(id);
+
+      if (!proposal) {
+        res.status(404).json({ error: 'proposal not found' });
+        return;
+      }
+      if (proposal.status !== STATUS_PENDING) {
+        res.status(409).json({
+          error: 'proposal is not in pending status',
+          status: proposal.status,
+        });
+        return;
+      }
+
+      const now = new Date().toISOString();
+      const auditEventId = emitProposeAudit(auditSink, {
+        proposalId: id,
+        actorId: 'user',
+        action: 'workbench.block.propose.user-approved',
+        decision: 'approved',
+        eventType: 'approval',
+        reasonCode: 'workbench_block_user_approved',
+      });
+
+      const updated: FirstPartyBlockProposal = {
+        ...proposal,
+        status: STATUS_AUTO_APPROVED, // treat user-approved as auto-approved state
+        statusUpdatedAt: now,
+        ...(auditEventId ? { auditEventId } : {}),
+      };
+
+      proposals.set(id, updated);
+
+      try {
+        writeFirstPartyProposals(configPath, proposals);
+      } catch (err) {
+        logger.error(
+          'Failed to write first-party proposals on approve:',
+          err instanceof Error ? err.message : err
+        );
+        res.status(500).json({ error: 'failed to persist approval' });
+        return;
+      }
+
+      res.json(updated);
+    }
+  );
+
+  // -------------------------------------------------------------------------
+  // POST /propose-block/proposals/:id/reject — user rejects pending
+  // -------------------------------------------------------------------------
+  router.post(
+    '/propose-block/proposals/:id/reject',
+    (req: Request, res: Response) => {
+      const { id } = req.params as { id: string };
+      const proposals = readFirstPartyProposals(configPath);
+      const proposal = proposals.get(id);
+
+      if (!proposal) {
+        res.status(404).json({ error: 'proposal not found' });
+        return;
+      }
+      if (proposal.status !== STATUS_PENDING) {
+        res.status(409).json({
+          error: 'proposal is not in pending status',
+          status: proposal.status,
+        });
+        return;
+      }
+
+      const now = new Date().toISOString();
+      const auditEventId = emitProposeAudit(auditSink, {
+        proposalId: id,
+        actorId: 'user',
+        action: 'workbench.block.propose.user-rejected',
+        decision: 'deny',
+        eventType: 'denial',
+        reasonCode: 'workbench_block_user_rejected',
+      });
+
+      const updated: FirstPartyBlockProposal = {
+        ...proposal,
+        status: STATUS_REJECTED,
+        statusUpdatedAt: now,
+        ...(auditEventId ? { auditEventId } : {}),
+      };
+
+      proposals.set(id, updated);
+
+      try {
+        writeFirstPartyProposals(configPath, proposals);
+      } catch (err) {
+        logger.error(
+          'Failed to write first-party proposals on reject:',
+          err instanceof Error ? err.message : err
+        );
+        res.status(500).json({ error: 'failed to persist rejection' });
+        return;
+      }
+
+      res.json(updated);
+    }
+  );
+
+  return router;
+}

--- a/shared/workbench-prompt-hooks.ts
+++ b/shared/workbench-prompt-hooks.ts
@@ -1,0 +1,462 @@
+/**
+ * Workbench prompt hooks — slice 5 of epic #612.
+ *
+ * Two contracts:
+ *
+ * a) Layout → agent context (read-only)
+ *    `summarizeWorkbenchBlocks` converts the current Workbench layout into a
+ *    bounded, safe context summary suitable for inclusion in an agent's system
+ *    prompt or turn context. NO secrets, NO env, NO raw transcripts, NO file
+ *    contents are included.
+ *
+ * b) Agent → block proposal API (typed)
+ *    `WorkbenchBlockProposalRequest` / `WorkbenchBlockProposalResult` describe
+ *    the typed propose-block API surface exposed to agents. First-party kinds
+ *    auto-approve when the actor's capability grants satisfy requirements.
+ *    Custom blocks route through the slice-4 approval flow.
+ *
+ * Size cap (documented):
+ *   - WORKBENCH_CONTEXT_SUMMARY_MAX_BYTES = 4096 bytes
+ *   - WORKBENCH_CONTEXT_SUMMARY_MAX_BLOCKS = 20 blocks
+ *   Summaries that exceed the byte cap are truncated at the last complete block
+ *   entry before the limit. Blocks beyond the block cap are omitted entirely.
+ *   Both caps are enforced independently; whichever triggers first wins.
+ *
+ * Safety invariants:
+ *   - per-block status excerpts are limited to descriptor-level metadata fields.
+ *   - `markdown` blocks emit only `title`; `.meta.content` is never included.
+ *   - `file` blocks emit only the `fileRef.kind` discriminant (`'file'`).
+ *   - `agent` blocks emit only the `actorRef.id` and `actorRef.displayName`.
+ *   - `terminal` blocks emit only the `sessionRef.sessionId`.
+ *   - `custom` blocks emit only `rendererId` and `proposalId` (if present).
+ *   - `work-context` blocks emit only the `workContextRef` id string.
+ *   - `artifact` blocks emit only `artifactRef.kind` and `artifactRef.title`.
+ *
+ * Refs: #625, epic #612.
+ */
+
+import type {
+  WorkbenchBlockDescriptor,
+  WorkbenchBlockKind,
+} from './workbench-block-types.js';
+import type { WorkbenchLayout } from './workbench-layout-types.js';
+import type { WorkspaceScopeRef } from './workbench-layout-types.js';
+import type { RelayCapabilityBit } from './security-policy.js';
+
+// ---------------------------------------------------------------------------
+// Size caps (documented)
+// ---------------------------------------------------------------------------
+
+/** Maximum byte size of the serialized context summary (4 KB). */
+export const WORKBENCH_CONTEXT_SUMMARY_MAX_BYTES = 4096 as const;
+
+/** Maximum number of block entries in a summary. Blocks beyond this are omitted. */
+export const WORKBENCH_CONTEXT_SUMMARY_MAX_BLOCKS = 20 as const;
+
+// ---------------------------------------------------------------------------
+// Per-kind status excerpt shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * Status excerpt for a `terminal` block.
+ * Only the sessionId is safe to surface — never raw PTY bytes.
+ */
+export interface TerminalBlockExcerpt {
+  kind: 'terminal';
+  sessionId: string | undefined;
+}
+
+/**
+ * Status excerpt for an `agent` block.
+ * Only the actorRef id and displayName — never raw transcript bytes.
+ */
+export interface AgentBlockExcerpt {
+  kind: 'agent';
+  actorId: string;
+  actorDisplayName?: string | undefined;
+}
+
+/**
+ * Status excerpt for a `work-context` block.
+ * Only the opaque workContextRef string — never full work context data.
+ */
+export interface WorkContextBlockExcerpt {
+  kind: 'work-context';
+  workContextRef: string;
+}
+
+/**
+ * Status excerpt for a `file` block.
+ * Only the file ref kind discriminant — never a path, never file contents.
+ */
+export interface FileBlockExcerpt {
+  kind: 'file';
+  fileRefKind: 'file';
+  mode?: 'read' | 'diff' | undefined;
+}
+
+/**
+ * Status excerpt for an `artifact` block.
+ * Only the artifact kind and title — never the artifact content or URI.
+ */
+export interface ArtifactBlockExcerpt {
+  kind: 'artifact';
+  artifactKind: string | undefined;
+  artifactTitle: string | undefined;
+}
+
+/**
+ * Status excerpt for a `markdown` block.
+ * Only the block title is emitted — never the raw markdown content.
+ */
+export interface MarkdownBlockExcerpt {
+  kind: 'markdown';
+}
+
+/**
+ * Status excerpt for a `custom` block.
+ * Only the rendererId and proposalId metadata — never raw props or data refs.
+ */
+export interface CustomBlockExcerpt {
+  kind: 'custom';
+  rendererId: string;
+  proposalId?: string | undefined;
+}
+
+/** Discriminated union of all per-kind status excerpts. */
+export type WorkbenchBlockExcerpt =
+  | TerminalBlockExcerpt
+  | AgentBlockExcerpt
+  | WorkContextBlockExcerpt
+  | FileBlockExcerpt
+  | ArtifactBlockExcerpt
+  | MarkdownBlockExcerpt
+  | CustomBlockExcerpt;
+
+// ---------------------------------------------------------------------------
+// WorkbenchBlockSummary — per-block summary entry
+// ---------------------------------------------------------------------------
+
+/**
+ * A single block's summary as presented to the agent context.
+ * Includes only descriptor-level metadata and the bounded per-kind excerpt.
+ */
+export interface WorkbenchBlockSummary {
+  /** Stable block id from the descriptor. */
+  id: string;
+  /** Block kind — used to dispatch on excerpt shape. */
+  kind: WorkbenchBlockKind;
+  /** User-visible title. */
+  title: string;
+  /** Capability requirements the block declares. Safe to expose — no secrets. */
+  capabilityRequirements: readonly RelayCapabilityBit[];
+  /** Per-kind status excerpt (bounded, no secrets, no raw content). */
+  excerpt: WorkbenchBlockExcerpt;
+}
+
+// ---------------------------------------------------------------------------
+// WorkbenchContextSummary — the full summary handed to the agent
+// ---------------------------------------------------------------------------
+
+/**
+ * The bounded context summary handed to an agent at turn start.
+ *
+ * Design notes:
+ *   - `truncated` is true when either the byte cap or block cap triggered.
+ *   - `totalBlocks` reflects the layout count before truncation.
+ *   - `summaryBytes` is the byte length of the serialized `blocks` array.
+ *   - The summary is safe to embed as-is in a system prompt or turn context.
+ */
+export interface WorkbenchContextSummary {
+  /** Workspace scope owning the layout. */
+  workspaceScope: WorkspaceScopeRef;
+  /** Summarized blocks (capped by WORKBENCH_CONTEXT_SUMMARY_MAX_BLOCKS and byte limit). */
+  blocks: readonly WorkbenchBlockSummary[];
+  /** Total number of blocks in the layout before truncation. */
+  totalBlocks: number;
+  /** Whether truncation was applied (byte or block cap). */
+  truncated: boolean;
+  /** Byte length of the serialized `blocks` array (for debugging). */
+  summaryBytes: number;
+}
+
+// ---------------------------------------------------------------------------
+// Per-kind excerpt builders
+// ---------------------------------------------------------------------------
+
+function excerptForDescriptor(
+  descriptor: WorkbenchBlockDescriptor
+): WorkbenchBlockExcerpt {
+  switch (descriptor.kind) {
+    case 'terminal': {
+      const sessionRef = descriptor.meta.sessionRef;
+      return {
+        kind: 'terminal',
+        sessionId: sessionRef?.sessionId,
+      };
+    }
+    case 'agent': {
+      const actorRef = descriptor.meta.actorRef;
+      return {
+        kind: 'agent',
+        actorId: actorRef.id,
+        ...(actorRef.displayName
+          ? { actorDisplayName: actorRef.displayName }
+          : {}),
+      };
+    }
+    case 'work-context': {
+      return {
+        kind: 'work-context',
+        workContextRef: descriptor.meta.workContextRef,
+      };
+    }
+    case 'file': {
+      return {
+        kind: 'file',
+        fileRefKind: 'file',
+        ...(descriptor.meta.mode ? { mode: descriptor.meta.mode } : {}),
+      };
+    }
+    case 'artifact': {
+      const artifactRef = descriptor.meta.artifactRef;
+      return {
+        kind: 'artifact',
+        artifactKind:
+          typeof artifactRef === 'object' && artifactRef !== null
+            ? (artifactRef as { kind?: string }).kind
+            : undefined,
+        artifactTitle:
+          typeof artifactRef === 'object' && artifactRef !== null
+            ? (artifactRef as { title?: string }).title
+            : undefined,
+      };
+    }
+    case 'markdown': {
+      // Never emit .meta.content — title only, via base descriptor field.
+      return { kind: 'markdown' };
+    }
+    case 'custom': {
+      return {
+        kind: 'custom',
+        rendererId: descriptor.meta.rendererId,
+        // proposalId is not stored directly in the descriptor — rendererId IS
+        // the proposalId once approved (per slice-4 design). Surface it here.
+        proposalId: descriptor.meta.rendererId,
+      };
+    }
+  }
+}
+
+function summarizeBlock(
+  descriptor: WorkbenchBlockDescriptor
+): WorkbenchBlockSummary {
+  return {
+    id: descriptor.id,
+    kind: descriptor.kind,
+    title: descriptor.title,
+    capabilityRequirements: descriptor.capabilityRequirements,
+    excerpt: excerptForDescriptor(descriptor),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// summarizeWorkbenchBlocks — main public function
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert the current Workbench layout into a bounded, safe context summary.
+ *
+ * Caps applied (both independent; first-to-trigger wins):
+ *   - WORKBENCH_CONTEXT_SUMMARY_MAX_BLOCKS (20) block entries max.
+ *   - WORKBENCH_CONTEXT_SUMMARY_MAX_BYTES (4096) byte cap on the serialized
+ *     `blocks` array — truncated at the last complete block before the limit.
+ *
+ * Safety guarantees:
+ *   - No secrets, no env, no raw transcripts, no file contents.
+ *   - Only descriptor-level metadata + bounded per-kind excerpts.
+ *
+ * @param layout The current workspace layout (from slice 3 persistence).
+ * @returns WorkbenchContextSummary safe for inclusion in agent context.
+ */
+export function summarizeWorkbenchBlocks(
+  layout: WorkbenchLayout
+): WorkbenchContextSummary {
+  const totalBlocks = layout.blocks.length;
+
+  // Step 1: cap by block count
+  const cappedByCount = layout.blocks.slice(
+    0,
+    WORKBENCH_CONTEXT_SUMMARY_MAX_BLOCKS
+  );
+
+  // Step 2: summarize each block
+  const summaries: WorkbenchBlockSummary[] = cappedByCount.map((placement) =>
+    summarizeBlock(placement.descriptor)
+  );
+
+  // Step 3: cap by byte size — serialize incrementally and stop before limit
+  const finalBlocks: WorkbenchBlockSummary[] = [];
+  let accumulatedJson = '[]';
+  for (const summary of summaries) {
+    const candidate = [...finalBlocks, summary];
+    const candidateJson = JSON.stringify(candidate);
+    const byteLen = Buffer.byteLength(candidateJson, 'utf8');
+    if (byteLen > WORKBENCH_CONTEXT_SUMMARY_MAX_BYTES) {
+      break;
+    }
+    finalBlocks.push(summary);
+    accumulatedJson = candidateJson;
+  }
+
+  const truncated =
+    finalBlocks.length < totalBlocks ||
+    finalBlocks.length < cappedByCount.length;
+
+  return {
+    workspaceScope: layout.workspaceScope,
+    blocks: finalBlocks,
+    totalBlocks,
+    truncated,
+    summaryBytes: Buffer.byteLength(accumulatedJson, 'utf8'),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Agent → block proposal API types
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a `proposeWorkbenchBlock` call.
+ *
+ * Status semantics:
+ *   - `pending`       — proposal stored; user must approve (custom kind, or
+ *                       first-party with unsatisfied capability requirements).
+ *   - `auto-approved` — first-party kind with all requirements satisfied by
+ *                       the actor's granted capability set.
+ *   - `rejected`      — descriptor failed validation (returned synchronously).
+ */
+export interface WorkbenchBlockProposalResult {
+  proposalId: string;
+  status: 'pending' | 'auto-approved' | 'rejected';
+  /** Human-readable reason for rejection (only set when status === 'rejected'). */
+  rejectionReason?: string;
+}
+
+/**
+ * Input to the `proposeWorkbenchBlock` REST endpoint.
+ *
+ * For `custom` kind: routes through slice-4's proposal flow (POST to
+ * `/workbench/custom-blocks/proposals`). Status always `pending`.
+ *
+ * For first-party kinds: auto-approved if all `capabilityRequirements` in the
+ * descriptor are satisfied by `actorGrantedBits`. Otherwise `pending`.
+ */
+export interface WorkbenchBlockProposalRequest {
+  /** The block descriptor the agent wants to create. */
+  descriptor: WorkbenchBlockDescriptor;
+  /** The actor id making the request. */
+  actorId: string;
+  /** Optional display name for the actor. */
+  actorDisplayName?: string;
+  /**
+   * The capability bits currently granted to this actor.
+   * Used to decide auto-approve vs. pending for first-party kinds.
+   */
+  actorGrantedBits: readonly RelayCapabilityBit[];
+  /** Workspace scope to place the block in (optional). */
+  workspaceScopeId?: string;
+}
+
+// ---------------------------------------------------------------------------
+// proposeWorkbenchBlock — pure business logic (no I/O)
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure validation and approval-decision logic for a block proposal.
+ *
+ * Does NOT perform I/O. The caller (server router) is responsible for:
+ *   - Persisting the result (via the custom-blocks store or a first-party store)
+ *   - Emitting audit envelopes
+ *
+ * Auto-approval rules for first-party kinds:
+ *   - All `descriptor.capabilityRequirements` must be present in
+ *     `request.actorGrantedBits`.
+ *   - If all requirements are satisfied → `auto-approved`.
+ *   - If any requirement is missing → `pending` (queued for user approval).
+ *
+ * Custom kind:
+ *   - Always → `pending` (routes to slice-4 approval flow).
+ *
+ * @param request The proposal request from the agent.
+ * @returns WorkbenchBlockProposalResult with proposalId and status.
+ */
+export function evaluateBlockProposal(
+  request: WorkbenchBlockProposalRequest,
+  generateId: () => string
+): WorkbenchBlockProposalResult {
+  const { descriptor, actorGrantedBits } = request;
+
+  // Validate required descriptor fields
+  if (!descriptor.id || !descriptor.title || !descriptor.kind) {
+    return {
+      proposalId: generateId(),
+      status: 'rejected',
+      rejectionReason: 'descriptor must have id, title, and kind',
+    };
+  }
+
+  // Custom kind always routes to slice-4 approval flow
+  if (descriptor.kind === 'custom') {
+    return {
+      proposalId: generateId(),
+      status: 'pending',
+    };
+  }
+
+  // First-party kind: check capability grants
+  const grantedSet = new Set<string>(actorGrantedBits);
+  const unsatisfied = descriptor.capabilityRequirements.filter(
+    (bit) => !grantedSet.has(bit)
+  );
+
+  if (unsatisfied.length > 0) {
+    // Some requirements not met — queue for user approval
+    return {
+      proposalId: generateId(),
+      status: 'pending',
+    };
+  }
+
+  // All requirements satisfied — auto-approve
+  return {
+    proposalId: generateId(),
+    status: 'auto-approved',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Serialized proposal record (for first-party kinds)
+// ---------------------------------------------------------------------------
+
+export type FirstPartyBlockProposalStatus =
+  | 'pending'
+  | 'auto-approved'
+  | 'rejected';
+
+/**
+ * Persisted proposal record for first-party block kinds.
+ * Custom blocks use the slice-4 CustomBlockProposal shape.
+ */
+export interface FirstPartyBlockProposal {
+  proposalId: string;
+  descriptor: WorkbenchBlockDescriptor;
+  actorId: string;
+  actorDisplayName?: string;
+  workspaceScopeId?: string;
+  proposedAt: string;
+  status: FirstPartyBlockProposalStatus;
+  statusUpdatedAt: string;
+  /** Audit event ID for the status-change event. */
+  auditEventId?: string;
+}

--- a/shared/workbench-prompt-hooks.ts
+++ b/shared/workbench-prompt-hooks.ts
@@ -44,6 +44,24 @@ import type { WorkspaceScopeRef } from './workbench-layout-types.js';
 import type { RelayCapabilityBit } from './security-policy.js';
 
 // ---------------------------------------------------------------------------
+// Known block-kind guard (forward-compat helper)
+// ---------------------------------------------------------------------------
+
+const KNOWN_BLOCK_KINDS: ReadonlySet<WorkbenchBlockKind> = new Set([
+  'terminal',
+  'agent',
+  'work-context',
+  'file',
+  'artifact',
+  'markdown',
+  'custom',
+]);
+
+function isKnownBlockKind(kind: string): kind is WorkbenchBlockKind {
+  return KNOWN_BLOCK_KINDS.has(kind as WorkbenchBlockKind);
+}
+
+// ---------------------------------------------------------------------------
 // Size caps (documented)
 // ---------------------------------------------------------------------------
 
@@ -290,9 +308,16 @@ export function summarizeWorkbenchBlocks(
     WORKBENCH_CONTEXT_SUMMARY_MAX_BLOCKS
   );
 
-  // Step 2: summarize each block
-  const summaries: WorkbenchBlockSummary[] = cappedByCount.map((placement) =>
-    summarizeBlock(placement.descriptor)
+  // Step 2: summarize each block. Forward-compat: skip placements whose `kind`
+  // is not in the closed `WorkbenchBlockKind` union (future block kinds the
+  // client doesn't yet recognize). They still round-trip in the layout via the
+  // widened `WorkbenchBlockPlacementDescriptor`, but agent context only includes
+  // recognized kinds for now.
+  const summaries: WorkbenchBlockSummary[] = cappedByCount.flatMap(
+    (placement) => {
+      if (!isKnownBlockKind(placement.descriptor.kind)) return [];
+      return [summarizeBlock(placement.descriptor as WorkbenchBlockDescriptor)];
+    }
   );
 
   // Step 3: cap by byte size — serialize incrementally and stop before limit

--- a/test/workbench-prompt-hooks.test.ts
+++ b/test/workbench-prompt-hooks.test.ts
@@ -903,36 +903,44 @@ describe('workbench-prompt-hooks REST router', () => {
     expect(res.status).toBe(404);
   });
 
-  it('returns 409 when approving non-pending proposal', async () => {
+  it('returns 409 when rejecting a non-pending (auto-approved) proposal', async () => {
     const app = makeApp();
     const createRes = await call(app, 'POST', '/workbench/propose-block', {
       descriptor: {
-        kind: 'markdown',
-        id: 'block-md',
-        title: 'MD',
-        capabilityRequirements: [],
-        meta: { content: '' },
+        kind: 'terminal',
+        id: 'block-t3',
+        title: 'Term 3',
+        capabilityRequirements: ['session:attach'],
+        meta: {
+          sessionRef: {
+            sessionId: 'sid3',
+            nodeId: 'n1',
+            tabKind: 'agent',
+            cwd: '/tmp',
+          },
+        },
       },
       actorId: 'actor-test',
-      actorGrantedBits: [], // auto-approved (no requirements)
+      actorGrantedBits: [], // missing session:attach → pending
     });
-    // Wait — this will auto-approve (no capabilityRequirements), attempt second approve
     const proposalId = (createRes.body as { proposalId: string }).proposalId;
+    expect((createRes.body as { status: string }).status).toBe('pending');
 
-    // Reject it first
-    await call(
+    // Approve it (pending → auto-approved)
+    const approveRes = await call(
+      app,
+      'POST',
+      `/workbench/propose-block/proposals/${proposalId}/approve`
+    );
+    expect(approveRes.status).toBe(200);
+
+    // Now trying to reject an already-approved proposal should return 409
+    const rejectRes = await call(
       app,
       'POST',
       `/workbench/propose-block/proposals/${proposalId}/reject`
     );
-
-    // Now trying to reject again should 409
-    const secondReject = await call(
-      app,
-      'POST',
-      `/workbench/propose-block/proposals/${proposalId}/reject`
-    );
-    expect(secondReject.status).toBe(409);
+    expect(rejectRes.status).toBe(409);
   });
 });
 

--- a/test/workbench-prompt-hooks.test.ts
+++ b/test/workbench-prompt-hooks.test.ts
@@ -1,0 +1,1222 @@
+/**
+ * Tests for Workbench prompt hooks — slice 5 of epic #612, #625.
+ *
+ * Covers:
+ *   1. summarizeWorkbenchBlocks
+ *      - Empty layout → empty summary, no truncation
+ *      - Layout with all 7 block kinds → correct per-kind excerpts
+ *      - Layout exceeding block cap → truncates to MAX_BLOCKS, truncated=true
+ *      - Layout exceeding byte cap → truncates safely, truncated=true
+ *      - No secret/env/transcript leakage (grep output for forbidden patterns)
+ *      - Markdown block never leaks .meta.content
+ *      - File block never leaks a path string
+ *      - Custom block only emits rendererId (proposalId)
+ *
+ *   2. evaluateBlockProposal (pure logic)
+ *      - First-party kind with sufficient grants → auto-approved
+ *      - First-party kind with missing grants → pending
+ *      - Custom kind → always pending (routes to slice-4)
+ *      - Malformed descriptor → rejected at validation
+ *
+ *   3. Server REST router — POST /propose-block
+ *      - First-party with sufficient grants → 201 auto-approved
+ *      - First-party with missing grants → 201 pending
+ *      - Custom kind → 201 pending, stored in slice-4 store
+ *      - Malformed body → 422 rejected
+ *      - GET /propose-block/proposals lists correctly
+ *      - POST /propose-block/proposals/:id/approve transitions pending → approved
+ *      - POST /propose-block/proposals/:id/reject transitions pending → rejected
+ *
+ *   4. Audit envelope emission on each state transition
+ *      - proposal create (auto-approved)
+ *      - proposal create (pending)
+ *      - user approve
+ *      - user reject
+ *
+ *   5. getWorkbenchContextSummary wires layout store + summarizer
+ *      - Returns null when no layout stored
+ *      - Returns a valid summary when a layout is persisted
+ *
+ *   6. server/index.ts mounts the router
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type Mock,
+} from 'vitest';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import express from 'express';
+import type { Express } from 'express';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const projectRoot = join(__dirname, '..');
+
+// ---------------------------------------------------------------------------
+// HTTP test helper (matches workbench-layout.test.ts pattern)
+// ---------------------------------------------------------------------------
+
+function call(
+  app: Express,
+  method: string,
+  url: string,
+  body?: unknown
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app);
+    server.listen(0, () => {
+      const addr = server.address() as { port: number };
+      const port = addr.port;
+      const bodyStr = body !== undefined ? JSON.stringify(body) : undefined;
+      const headers: Record<string, string> = {};
+      if (bodyStr !== undefined) {
+        headers['Content-Type'] = 'application/json';
+        headers['Content-Length'] = String(Buffer.byteLength(bodyStr));
+      }
+      const req = http.request(
+        { host: '127.0.0.1', port, path: url, method, headers },
+        (res) => {
+          let data = '';
+          res.on('data', (chunk: Buffer) => {
+            data += chunk.toString();
+          });
+          res.on('end', () => {
+            server.close();
+            let parsed: unknown = null;
+            if (data.trim()) {
+              try {
+                parsed = JSON.parse(data);
+              } catch {
+                parsed = data;
+              }
+            }
+            resolve({ status: res.statusCode ?? 0, body: parsed });
+          });
+        }
+      );
+      req.on('error', (err: Error) => {
+        server.close();
+        reject(err);
+      });
+      if (bodyStr !== undefined) req.write(bodyStr);
+      req.end();
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Shared imports
+// ---------------------------------------------------------------------------
+
+import {
+  summarizeWorkbenchBlocks,
+  evaluateBlockProposal,
+  WORKBENCH_CONTEXT_SUMMARY_MAX_BYTES,
+  WORKBENCH_CONTEXT_SUMMARY_MAX_BLOCKS,
+} from '../shared/workbench-prompt-hooks.js';
+import type { WorkbenchBlockProposalRequest } from '../shared/workbench-prompt-hooks.js';
+import { WORKBENCH_LAYOUT_SCHEMA_VERSION } from '../shared/workbench-layout-types.js';
+import type {
+  WorkbenchLayout,
+  WorkbenchBlockPlacement,
+} from '../shared/workbench-layout-types.js';
+
+// Server imports
+import {
+  getWorkbenchContextSummary,
+  createWorkbenchProposeBlockRouter,
+} from '../server/workbench-prompt-hooks.js';
+import { writeWorkbenchLayout } from '../server/workbench-layout.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeTerminalPlacement(): WorkbenchBlockPlacement {
+  return {
+    descriptor: {
+      kind: 'terminal',
+      id: 'block-terminal',
+      title: 'Terminal',
+      capabilityRequirements: ['session:attach'],
+      meta: {
+        sessionRef: {
+          sessionId: 'sess-abc',
+          nodeId: 'node-1',
+          tabKind: 'agent',
+          cwd: '/home/user/project',
+        },
+      },
+    },
+    position: { x: 0, y: 0 },
+    size: { width: 400, height: 300 },
+    minimized: false,
+  };
+}
+
+function makeAgentPlacement(): WorkbenchBlockPlacement {
+  return {
+    descriptor: {
+      kind: 'agent',
+      id: 'block-agent',
+      title: 'Claude Agent',
+      capabilityRequirements: ['session:attach', 'tab:mode:set-agent'],
+      meta: {
+        actorRef: {
+          kind: 'actor',
+          id: 'actor-xyz',
+          displayName: 'Claude Code',
+        },
+      },
+    },
+    position: { x: 410, y: 0 },
+    size: { width: 400, height: 300 },
+    minimized: false,
+  };
+}
+
+function makeWorkContextPlacement(): WorkbenchBlockPlacement {
+  return {
+    descriptor: {
+      kind: 'work-context',
+      id: 'block-wc',
+      title: 'Task Context',
+      capabilityRequirements: [],
+      meta: {
+        workContextRef: 'wc:task-123',
+      },
+    },
+    position: { x: 0, y: 310 },
+    size: { width: 400, height: 200 },
+    minimized: false,
+  };
+}
+
+function makeFilePlacement(): WorkbenchBlockPlacement {
+  return {
+    descriptor: {
+      kind: 'file',
+      id: 'block-file',
+      title: 'package.json',
+      capabilityRequirements: ['rpc:fs:read'],
+      meta: {
+        fileRef: {
+          kind: 'file',
+          id: 'rpc:fs:node-1:/home/user/project/package.json',
+          displayName: 'package.json',
+        },
+        mode: 'read',
+      },
+    },
+    position: { x: 410, y: 310 },
+    size: { width: 400, height: 200 },
+    minimized: false,
+  };
+}
+
+function makeArtifactPlacement(): WorkbenchBlockPlacement {
+  return {
+    descriptor: {
+      kind: 'artifact',
+      id: 'block-artifact',
+      title: 'Build Log',
+      capabilityRequirements: [],
+      meta: {
+        artifactRef: {
+          id: 'artifact-build-42',
+          kind: 'log',
+          title: 'Build Log 2026-05-19',
+          uri: 'relay://artifacts/build-42',
+          mediaType: 'text/plain',
+        },
+      },
+    },
+    position: { x: 0, y: 520 },
+    size: { width: 400, height: 200 },
+    minimized: false,
+  };
+}
+
+function makeMarkdownPlacement(): WorkbenchBlockPlacement {
+  return {
+    descriptor: {
+      kind: 'markdown',
+      id: 'block-md',
+      title: 'Design Notes',
+      capabilityRequirements: [],
+      meta: {
+        content:
+          '# SECRET CONTENT\nSECRET_KEY=abc123\nexport TOKEN=ghp_xyz\npassword: hunter2',
+      },
+    },
+    position: { x: 410, y: 520 },
+    size: { width: 400, height: 200 },
+    minimized: false,
+  };
+}
+
+function makeCustomPlacement(): WorkbenchBlockPlacement {
+  return {
+    descriptor: {
+      kind: 'custom',
+      id: 'block-custom',
+      title: 'Status Dashboard',
+      capabilityRequirements: [],
+      meta: {
+        rendererId: 'proposal-id-001',
+        props: {
+          title: 'CI Status',
+          status: 'active',
+        },
+      },
+    },
+    position: { x: 0, y: 730 },
+    size: { width: 820, height: 200 },
+    minimized: false,
+  };
+}
+
+function makeLayout(placements: WorkbenchBlockPlacement[]): WorkbenchLayout {
+  return {
+    schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+    workspaceScope: { id: 'ws:test', displayName: 'Test Workspace' },
+    blocks: placements,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. summarizeWorkbenchBlocks
+// ---------------------------------------------------------------------------
+
+describe('summarizeWorkbenchBlocks', () => {
+  it('returns empty summary for empty layout', () => {
+    const layout = makeLayout([]);
+    const summary = summarizeWorkbenchBlocks(layout);
+    expect(summary.blocks).toHaveLength(0);
+    expect(summary.totalBlocks).toBe(0);
+    expect(summary.truncated).toBe(false);
+    expect(summary.workspaceScope.id).toBe('ws:test');
+  });
+
+  it('summarizes all 7 block kinds correctly', () => {
+    const layout = makeLayout([
+      makeTerminalPlacement(),
+      makeAgentPlacement(),
+      makeWorkContextPlacement(),
+      makeFilePlacement(),
+      makeArtifactPlacement(),
+      makeMarkdownPlacement(),
+      makeCustomPlacement(),
+    ]);
+    const summary = summarizeWorkbenchBlocks(layout);
+    expect(summary.blocks).toHaveLength(7);
+    expect(summary.truncated).toBe(false);
+    expect(summary.totalBlocks).toBe(7);
+
+    const terminal = summary.blocks.find((b) => b.kind === 'terminal');
+    expect(terminal?.excerpt).toMatchObject({
+      kind: 'terminal',
+      sessionId: 'sess-abc',
+    });
+
+    const agent = summary.blocks.find((b) => b.kind === 'agent');
+    expect(agent?.excerpt).toMatchObject({
+      kind: 'agent',
+      actorId: 'actor-xyz',
+      actorDisplayName: 'Claude Code',
+    });
+
+    const wc = summary.blocks.find((b) => b.kind === 'work-context');
+    expect(wc?.excerpt).toMatchObject({
+      kind: 'work-context',
+      workContextRef: 'wc:task-123',
+    });
+
+    const file = summary.blocks.find((b) => b.kind === 'file');
+    expect(file?.excerpt).toMatchObject({
+      kind: 'file',
+      fileRefKind: 'file',
+      mode: 'read',
+    });
+
+    const artifact = summary.blocks.find((b) => b.kind === 'artifact');
+    expect(artifact?.excerpt).toMatchObject({
+      kind: 'artifact',
+      artifactKind: 'log',
+      artifactTitle: 'Build Log 2026-05-19',
+    });
+
+    const md = summary.blocks.find((b) => b.kind === 'markdown');
+    expect(md?.excerpt).toMatchObject({ kind: 'markdown' });
+
+    const custom = summary.blocks.find((b) => b.kind === 'custom');
+    expect(custom?.excerpt).toMatchObject({
+      kind: 'custom',
+      rendererId: 'proposal-id-001',
+    });
+  });
+
+  it('truncates when block count exceeds MAX_BLOCKS', () => {
+    const placements: WorkbenchBlockPlacement[] = [];
+    for (let i = 0; i < WORKBENCH_CONTEXT_SUMMARY_MAX_BLOCKS + 5; i++) {
+      placements.push({
+        descriptor: {
+          kind: 'markdown',
+          id: `block-${i}`,
+          title: `Block ${i}`,
+          capabilityRequirements: [],
+          meta: { content: 'short' },
+        },
+        position: { x: 0, y: i * 100 },
+        size: { width: 200, height: 100 },
+        minimized: false,
+      });
+    }
+    const layout = makeLayout(placements);
+    const summary = summarizeWorkbenchBlocks(layout);
+    expect(summary.blocks).toHaveLength(WORKBENCH_CONTEXT_SUMMARY_MAX_BLOCKS);
+    expect(summary.truncated).toBe(true);
+    expect(summary.totalBlocks).toBe(WORKBENCH_CONTEXT_SUMMARY_MAX_BLOCKS + 5);
+  });
+
+  it('truncates safely when byte cap is exceeded', () => {
+    // Each block gets a long title to push total byte count past 4KB
+    const placements: WorkbenchBlockPlacement[] = [];
+    for (let i = 0; i < 15; i++) {
+      placements.push({
+        descriptor: {
+          kind: 'markdown',
+          id: `block-${i}`,
+          title: 'A'.repeat(300), // 300-char title per block
+          capabilityRequirements: [],
+          meta: { content: 'short' },
+        },
+        position: { x: 0, y: i * 100 },
+        size: { width: 200, height: 100 },
+        minimized: false,
+      });
+    }
+    const layout = makeLayout(placements);
+    const summary = summarizeWorkbenchBlocks(layout);
+    expect(summary.summaryBytes).toBeLessThanOrEqual(
+      WORKBENCH_CONTEXT_SUMMARY_MAX_BYTES
+    );
+    expect(summary.truncated).toBe(true);
+    expect(summary.blocks.length).toBeLessThan(15);
+  });
+
+  it('does not leak markdown .meta.content', () => {
+    const layout = makeLayout([makeMarkdownPlacement()]);
+    const summary = summarizeWorkbenchBlocks(layout);
+    const serialized = JSON.stringify(summary);
+
+    // The dangerous content in makeMarkdownPlacement
+    expect(serialized).not.toContain('SECRET_KEY');
+    expect(serialized).not.toContain('hunter2');
+    expect(serialized).not.toContain('ghp_xyz');
+    // Title ('Design Notes') is allowed
+    expect(serialized).toContain('Design Notes');
+    // .meta.content string is not present
+    expect(serialized).not.toContain('SECRET CONTENT');
+  });
+
+  it('does not leak file path from file block', () => {
+    const layout = makeLayout([makeFilePlacement()]);
+    const summary = summarizeWorkbenchBlocks(layout);
+    const serialized = JSON.stringify(summary);
+
+    // The rpc:fs node-scoped id must not appear in the excerpt (file path)
+    expect(serialized).not.toContain('rpc:fs:node-1:');
+    expect(serialized).not.toContain('/home/user');
+    // fileRefKind 'file' is allowed; mode is allowed
+    expect(serialized).toContain('"fileRefKind":"file"');
+    // Verify the excerpt shape — no fileRef.id or displayName in excerpt
+    const fileBlock = summary.blocks.find((b) => b.kind === 'file');
+    expect(fileBlock?.excerpt).toMatchObject({
+      kind: 'file',
+      fileRefKind: 'file',
+    });
+    expect(JSON.stringify(fileBlock?.excerpt)).not.toContain('rpc:fs:node-1:');
+  });
+
+  it('does not leak terminal PTY bytes or session cwd', () => {
+    const layout = makeLayout([makeTerminalPlacement()]);
+    const summary = summarizeWorkbenchBlocks(layout);
+    const serialized = JSON.stringify(summary);
+
+    // Only sessionId is exposed — not cwd, repoPath, nodeId details beyond sessionId
+    expect(serialized).toContain('sess-abc');
+    // cwd should not appear (it's not in the excerpt shape)
+    expect(serialized).not.toContain('/home/user/project');
+  });
+
+  it('does not expose custom block props or dataRefs', () => {
+    const layout = makeLayout([makeCustomPlacement()]);
+    const summary = summarizeWorkbenchBlocks(layout);
+    const serialized = JSON.stringify(summary);
+
+    // Props should not appear
+    expect(serialized).not.toContain('"active"'); // status prop value
+    // rendererId is allowed
+    expect(serialized).toContain('proposal-id-001');
+  });
+
+  it('includes capabilityRequirements in summary (safe metadata)', () => {
+    const layout = makeLayout([makeTerminalPlacement()]);
+    const summary = summarizeWorkbenchBlocks(layout);
+    const block = summary.blocks[0]!;
+    expect(block.capabilityRequirements).toContain('session:attach');
+  });
+
+  it('sets summaryBytes accurately', () => {
+    const layout = makeLayout([makeMarkdownPlacement()]);
+    const summary = summarizeWorkbenchBlocks(layout);
+    const expected = Buffer.byteLength(JSON.stringify(summary.blocks), 'utf8');
+    expect(summary.summaryBytes).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. evaluateBlockProposal (pure logic)
+// ---------------------------------------------------------------------------
+
+describe('evaluateBlockProposal', () => {
+  const generateId = () => 'test-proposal-id';
+
+  it('auto-approves first-party kind when all grants satisfied', () => {
+    const request: WorkbenchBlockProposalRequest = {
+      descriptor: {
+        kind: 'markdown',
+        id: 'block-1',
+        title: 'Notes',
+        capabilityRequirements: [],
+        meta: { content: 'hello' },
+      },
+      actorId: 'actor-1',
+      actorGrantedBits: ['session:read', 'rpc:fs:read'],
+    };
+    const result = evaluateBlockProposal(request, generateId);
+    expect(result.status).toBe('auto-approved');
+    expect(result.proposalId).toBe('test-proposal-id');
+  });
+
+  it('auto-approves when capabilityRequirements subset of granted bits', () => {
+    const request: WorkbenchBlockProposalRequest = {
+      descriptor: {
+        kind: 'terminal',
+        id: 'block-term',
+        title: 'Term',
+        capabilityRequirements: ['session:attach'],
+        meta: {
+          sessionRef: {
+            sessionId: 'sid',
+            nodeId: 'node-1',
+            tabKind: 'agent',
+            cwd: '/tmp',
+          },
+        },
+      },
+      actorId: 'actor-1',
+      actorGrantedBits: ['session:read', 'session:attach', 'rpc:fs:read'],
+    };
+    const result = evaluateBlockProposal(request, generateId);
+    expect(result.status).toBe('auto-approved');
+  });
+
+  it('returns pending when actor is missing a required capability', () => {
+    const request: WorkbenchBlockProposalRequest = {
+      descriptor: {
+        kind: 'terminal',
+        id: 'block-term',
+        title: 'Term',
+        capabilityRequirements: ['session:attach', 'tab:mode:set-agent'],
+        meta: {
+          sessionRef: {
+            sessionId: 'sid',
+            nodeId: 'node-1',
+            tabKind: 'agent',
+            cwd: '/tmp',
+          },
+        },
+      },
+      actorId: 'actor-1',
+      actorGrantedBits: ['session:attach'], // missing tab:mode:set-agent
+    };
+    const result = evaluateBlockProposal(request, generateId);
+    expect(result.status).toBe('pending');
+  });
+
+  it('custom kind always returns pending regardless of grants', () => {
+    const request: WorkbenchBlockProposalRequest = {
+      descriptor: {
+        kind: 'custom',
+        id: 'block-custom',
+        title: 'Custom',
+        capabilityRequirements: [],
+        meta: { rendererId: 'renderer-1' },
+      },
+      actorId: 'actor-1',
+      actorGrantedBits: [
+        'session:read',
+        'session:attach',
+        'rpc:fs:read',
+        'rpc:fs:write',
+        'pty:exec:arbitrary',
+      ],
+    };
+    const result = evaluateBlockProposal(request, generateId);
+    expect(result.status).toBe('pending');
+  });
+
+  it('rejects malformed descriptor (missing id)', () => {
+    const request: WorkbenchBlockProposalRequest = {
+      descriptor: {
+        kind: 'markdown',
+        id: '', // empty — invalid
+        title: 'Notes',
+        capabilityRequirements: [],
+        meta: { content: 'hello' },
+      },
+      actorId: 'actor-1',
+      actorGrantedBits: [],
+    };
+    const result = evaluateBlockProposal(request, generateId);
+    expect(result.status).toBe('rejected');
+    expect(result.rejectionReason).toBeTruthy();
+  });
+
+  it('rejects malformed descriptor (missing title)', () => {
+    const request: WorkbenchBlockProposalRequest = {
+      descriptor: {
+        kind: 'markdown',
+        id: 'block-1',
+        title: '', // empty — invalid
+        capabilityRequirements: [],
+        meta: { content: 'hello' },
+      },
+      actorId: 'actor-1',
+      actorGrantedBits: [],
+    };
+    const result = evaluateBlockProposal(request, generateId);
+    expect(result.status).toBe('rejected');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Server REST router
+// ---------------------------------------------------------------------------
+
+describe('workbench-prompt-hooks REST router', () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-propose-'));
+    configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, '{}');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeApp(auditSink?: { append: Mock }) {
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/workbench',
+      createWorkbenchProposeBlockRouter({ configPath, auditSink })
+    );
+    return app;
+  }
+
+  // -------------------------------------------------------------------------
+  // 3a. POST /propose-block — first-party with sufficient grants → auto-approved
+  // -------------------------------------------------------------------------
+  it('auto-approves first-party kind with sufficient grants', async () => {
+    const app = makeApp();
+    const res = await call(app, 'POST', '/workbench/propose-block', {
+      descriptor: {
+        kind: 'markdown',
+        id: 'block-1',
+        title: 'Notes',
+        capabilityRequirements: [],
+        meta: { content: 'hello' },
+      },
+      actorId: 'actor-test',
+      actorGrantedBits: ['session:read'],
+    });
+    expect(res.status).toBe(201);
+    const body = res.body as { status: string; proposalId: string };
+    expect(body.status).toBe('auto-approved');
+    expect(typeof body.proposalId).toBe('string');
+  });
+
+  // -------------------------------------------------------------------------
+  // 3b. POST /propose-block — first-party without grants → pending
+  // -------------------------------------------------------------------------
+  it('queues first-party kind pending when grants insufficient', async () => {
+    const app = makeApp();
+    const res = await call(app, 'POST', '/workbench/propose-block', {
+      descriptor: {
+        kind: 'terminal',
+        id: 'block-term',
+        title: 'Term',
+        capabilityRequirements: ['session:attach', 'tab:mode:set-agent'],
+        meta: {
+          sessionRef: {
+            sessionId: 'sid',
+            nodeId: 'n1',
+            tabKind: 'agent',
+            cwd: '/tmp',
+          },
+        },
+      },
+      actorId: 'actor-test',
+      actorGrantedBits: ['session:read'], // missing session:attach, tab:mode:set-agent
+    });
+    expect(res.status).toBe(201);
+    const body = res.body as { status: string };
+    expect(body.status).toBe('pending');
+  });
+
+  // -------------------------------------------------------------------------
+  // 3c. POST /propose-block — custom kind → pending in slice-4 store
+  // -------------------------------------------------------------------------
+  it('routes custom kind to slice-4 store with pending status', async () => {
+    const app = makeApp();
+    const res = await call(app, 'POST', '/workbench/propose-block', {
+      descriptor: {
+        kind: 'custom',
+        id: 'block-custom',
+        title: 'My Custom Block',
+        capabilityRequirements: [],
+        meta: { rendererId: 'renderer-abc' },
+      },
+      rendererSource: {
+        kind: 'template',
+        template: 'status-card',
+        props: { title: 'Status', status: 'active' },
+      },
+      proposedBy: { kind: 'actor', id: 'actor-test' },
+      actorId: 'actor-test',
+      actorGrantedBits: [],
+    });
+    expect(res.status).toBe(201);
+    const body = res.body as { status: string; proposalId: string };
+    expect(body.status).toBe('pending');
+  });
+
+  // -------------------------------------------------------------------------
+  // 3d. Malformed body → 422
+  // -------------------------------------------------------------------------
+  it('rejects malformed body with 422', async () => {
+    const app = makeApp();
+    const res = await call(app, 'POST', '/workbench/propose-block', {
+      // missing actorId
+      descriptor: {
+        kind: 'markdown',
+        id: 'block-1',
+        title: 'Notes',
+        capabilityRequirements: [],
+        meta: { content: '' },
+      },
+      actorGrantedBits: [],
+    });
+    expect(res.status).toBe(422);
+  });
+
+  it('rejects unknown capability bit with 422', async () => {
+    const app = makeApp();
+    const res = await call(app, 'POST', '/workbench/propose-block', {
+      descriptor: {
+        kind: 'markdown',
+        id: 'block-1',
+        title: 'Notes',
+        capabilityRequirements: ['not-a-real-bit'],
+        meta: { content: '' },
+      },
+      actorId: 'actor-1',
+      actorGrantedBits: [],
+    });
+    expect(res.status).toBe(422);
+  });
+
+  // -------------------------------------------------------------------------
+  // 3e. GET /propose-block/proposals — list
+  // -------------------------------------------------------------------------
+  it('lists stored first-party proposals', async () => {
+    const app = makeApp();
+    // Create one
+    await call(app, 'POST', '/workbench/propose-block', {
+      descriptor: {
+        kind: 'markdown',
+        id: 'block-1',
+        title: 'Notes',
+        capabilityRequirements: [],
+        meta: { content: 'hello' },
+      },
+      actorId: 'actor-test',
+      actorGrantedBits: [],
+    });
+
+    const res = await call(app, 'GET', '/workbench/propose-block/proposals');
+    expect(res.status).toBe(200);
+    const body = res.body as unknown[];
+    expect(Array.isArray(body)).toBe(true);
+    expect(body.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('filters proposals by status', async () => {
+    const app = makeApp();
+    await call(app, 'POST', '/workbench/propose-block', {
+      descriptor: {
+        kind: 'terminal',
+        id: 'block-t',
+        title: 'Term',
+        capabilityRequirements: ['session:attach'],
+        meta: {
+          sessionRef: {
+            sessionId: 'sid',
+            nodeId: 'n1',
+            tabKind: 'agent',
+            cwd: '/tmp',
+          },
+        },
+      },
+      actorId: 'actor-test',
+      actorGrantedBits: [], // no grants → pending
+    });
+
+    const pending = await call(
+      app,
+      'GET',
+      '/workbench/propose-block/proposals?status=pending'
+    );
+    expect(pending.status).toBe(200);
+    const body = pending.body as Array<{ status: string }>;
+    expect(body.every((p) => p.status === 'pending')).toBe(true);
+
+    const approved = await call(
+      app,
+      'GET',
+      '/workbench/propose-block/proposals?status=auto-approved'
+    );
+    expect(approved.status).toBe(200);
+  });
+
+  it('rejects invalid status filter', async () => {
+    const app = makeApp();
+    const res = await call(
+      app,
+      'GET',
+      '/workbench/propose-block/proposals?status=INVALID'
+    );
+    expect(res.status).toBe(400);
+  });
+
+  // -------------------------------------------------------------------------
+  // 3f. Approve/reject pending proposal
+  // -------------------------------------------------------------------------
+  it('approves a pending proposal', async () => {
+    const app = makeApp();
+    const createRes = await call(app, 'POST', '/workbench/propose-block', {
+      descriptor: {
+        kind: 'terminal',
+        id: 'block-t',
+        title: 'Term',
+        capabilityRequirements: ['session:attach'],
+        meta: {
+          sessionRef: {
+            sessionId: 'sid',
+            nodeId: 'n1',
+            tabKind: 'agent',
+            cwd: '/tmp',
+          },
+        },
+      },
+      actorId: 'actor-test',
+      actorGrantedBits: [],
+    });
+    const proposalId = (createRes.body as { proposalId: string }).proposalId;
+
+    const approveRes = await call(
+      app,
+      'POST',
+      `/workbench/propose-block/proposals/${proposalId}/approve`
+    );
+    expect(approveRes.status).toBe(200);
+    const approved = approveRes.body as { status: string };
+    expect(approved.status).toBe('auto-approved');
+  });
+
+  it('rejects a pending proposal', async () => {
+    const app = makeApp();
+    const createRes = await call(app, 'POST', '/workbench/propose-block', {
+      descriptor: {
+        kind: 'terminal',
+        id: 'block-t2',
+        title: 'Term 2',
+        capabilityRequirements: ['session:attach'],
+        meta: {
+          sessionRef: {
+            sessionId: 'sid2',
+            nodeId: 'n1',
+            tabKind: 'agent',
+            cwd: '/tmp',
+          },
+        },
+      },
+      actorId: 'actor-test',
+      actorGrantedBits: [],
+    });
+    const proposalId = (createRes.body as { proposalId: string }).proposalId;
+
+    const rejectRes = await call(
+      app,
+      'POST',
+      `/workbench/propose-block/proposals/${proposalId}/reject`
+    );
+    expect(rejectRes.status).toBe(200);
+    const rejected = rejectRes.body as { status: string };
+    expect(rejected.status).toBe('rejected');
+  });
+
+  it('returns 404 when approving unknown proposal', async () => {
+    const app = makeApp();
+    const res = await call(
+      app,
+      'POST',
+      '/workbench/propose-block/proposals/non-existent/approve'
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 when approving non-pending proposal', async () => {
+    const app = makeApp();
+    const createRes = await call(app, 'POST', '/workbench/propose-block', {
+      descriptor: {
+        kind: 'markdown',
+        id: 'block-md',
+        title: 'MD',
+        capabilityRequirements: [],
+        meta: { content: '' },
+      },
+      actorId: 'actor-test',
+      actorGrantedBits: [], // auto-approved (no requirements)
+    });
+    // Wait — this will auto-approve (no capabilityRequirements), attempt second approve
+    const proposalId = (createRes.body as { proposalId: string }).proposalId;
+
+    // Reject it first
+    await call(
+      app,
+      'POST',
+      `/workbench/propose-block/proposals/${proposalId}/reject`
+    );
+
+    // Now trying to reject again should 409
+    const secondReject = await call(
+      app,
+      'POST',
+      `/workbench/propose-block/proposals/${proposalId}/reject`
+    );
+    expect(secondReject.status).toBe(409);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Audit envelope emission
+// ---------------------------------------------------------------------------
+
+describe('audit envelope emission', () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-audit-'));
+    configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, '{}');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('emits audit envelope on auto-approved first-party proposal', async () => {
+    const auditSink = { append: vi.fn() };
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/workbench',
+      createWorkbenchProposeBlockRouter({ configPath, auditSink })
+    );
+
+    await call(app, 'POST', '/workbench/propose-block', {
+      descriptor: {
+        kind: 'markdown',
+        id: 'b1',
+        title: 'MD',
+        capabilityRequirements: [],
+        meta: { content: '' },
+      },
+      actorId: 'actor-1',
+      actorGrantedBits: [],
+    });
+
+    expect(auditSink.append).toHaveBeenCalledOnce();
+    const callArg = auditSink.append.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(callArg?.['decision']).toBe('approved');
+    expect(callArg?.['eventType']).toBe('approval');
+  });
+
+  it('emits audit envelope on pending first-party proposal', async () => {
+    const auditSink = { append: vi.fn() };
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/workbench',
+      createWorkbenchProposeBlockRouter({ configPath, auditSink })
+    );
+
+    await call(app, 'POST', '/workbench/propose-block', {
+      descriptor: {
+        kind: 'terminal',
+        id: 'b2',
+        title: 'Term',
+        capabilityRequirements: ['session:attach'],
+        meta: {
+          sessionRef: {
+            sessionId: 'sid',
+            nodeId: 'n1',
+            tabKind: 'agent',
+            cwd: '/tmp',
+          },
+        },
+      },
+      actorId: 'actor-1',
+      actorGrantedBits: [],
+    });
+
+    expect(auditSink.append).toHaveBeenCalledOnce();
+    const callArg = auditSink.append.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(callArg?.['decision']).toBe('recorded');
+  });
+
+  it('emits audit envelope on user approve', async () => {
+    const auditSink = { append: vi.fn() };
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/workbench',
+      createWorkbenchProposeBlockRouter({ configPath, auditSink })
+    );
+
+    const createRes = await call(app, 'POST', '/workbench/propose-block', {
+      descriptor: {
+        kind: 'terminal',
+        id: 'b3',
+        title: 'Term',
+        capabilityRequirements: ['session:attach'],
+        meta: {
+          sessionRef: {
+            sessionId: 'sid',
+            nodeId: 'n1',
+            tabKind: 'agent',
+            cwd: '/tmp',
+          },
+        },
+      },
+      actorId: 'actor-1',
+      actorGrantedBits: [],
+    });
+    const proposalId = (createRes.body as { proposalId: string }).proposalId;
+    auditSink.append.mockClear();
+
+    await call(
+      app,
+      'POST',
+      `/workbench/propose-block/proposals/${proposalId}/approve`
+    );
+    expect(auditSink.append).toHaveBeenCalledOnce();
+    const callArg = auditSink.append.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(callArg?.['decision']).toBe('approved');
+  });
+
+  it('emits audit envelope on user reject', async () => {
+    const auditSink = { append: vi.fn() };
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/workbench',
+      createWorkbenchProposeBlockRouter({ configPath, auditSink })
+    );
+
+    const createRes = await call(app, 'POST', '/workbench/propose-block', {
+      descriptor: {
+        kind: 'terminal',
+        id: 'b4',
+        title: 'Term',
+        capabilityRequirements: ['session:attach'],
+        meta: {
+          sessionRef: {
+            sessionId: 'sid',
+            nodeId: 'n1',
+            tabKind: 'agent',
+            cwd: '/tmp',
+          },
+        },
+      },
+      actorId: 'actor-1',
+      actorGrantedBits: [],
+    });
+    const proposalId = (createRes.body as { proposalId: string }).proposalId;
+    auditSink.append.mockClear();
+
+    await call(
+      app,
+      'POST',
+      `/workbench/propose-block/proposals/${proposalId}/reject`
+    );
+    expect(auditSink.append).toHaveBeenCalledOnce();
+    const callArg = auditSink.append.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(callArg?.['decision']).toBe('deny');
+  });
+
+  it('emits audit envelope on custom kind proposal create', async () => {
+    const auditSink = { append: vi.fn() };
+    const app = express();
+    app.use(express.json());
+    app.use(
+      '/workbench',
+      createWorkbenchProposeBlockRouter({ configPath, auditSink })
+    );
+
+    await call(app, 'POST', '/workbench/propose-block', {
+      descriptor: {
+        kind: 'custom',
+        id: 'block-custom',
+        title: 'Custom',
+        capabilityRequirements: [],
+        meta: { rendererId: 'renderer-x' },
+      },
+      rendererSource: {
+        kind: 'template',
+        template: 'status-card',
+        props: { title: 'S', status: 'active' },
+      },
+      proposedBy: { kind: 'actor', id: 'actor-1' },
+      actorId: 'actor-1',
+      actorGrantedBits: [],
+    });
+
+    expect(auditSink.append).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. getWorkbenchContextSummary wires layout store + summarizer
+// ---------------------------------------------------------------------------
+
+describe('getWorkbenchContextSummary', () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ctx-'));
+    configPath = path.join(tmpDir, 'config.json');
+    fs.writeFileSync(configPath, '{}');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null when no layout stored', () => {
+    const result = getWorkbenchContextSummary(configPath, 'ws:missing');
+    expect(result).toBeNull();
+  });
+
+  it('returns a valid summary when layout is persisted', () => {
+    const layout = makeLayout([
+      makeMarkdownPlacement(),
+      makeTerminalPlacement(),
+    ]);
+    writeWorkbenchLayout(configPath, 'ws:test', layout);
+
+    const result = getWorkbenchContextSummary(configPath, 'ws:test');
+    expect(result).not.toBeNull();
+    expect(result!.blocks).toHaveLength(2);
+    expect(result!.workspaceScope.id).toBe('ws:test');
+    expect(result!.truncated).toBe(false);
+  });
+
+  it('summary from persisted layout does not leak markdown content', () => {
+    const layout = makeLayout([makeMarkdownPlacement()]);
+    writeWorkbenchLayout(configPath, 'ws:test', layout);
+
+    const result = getWorkbenchContextSummary(configPath, 'ws:test');
+    expect(result).not.toBeNull();
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain('SECRET_KEY');
+    expect(serialized).not.toContain('hunter2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. server/index.ts mounts the router
+// ---------------------------------------------------------------------------
+
+describe('server/index.ts mounts the propose-block router', () => {
+  it('imports createWorkbenchProposeBlockRouter in server/index.ts', () => {
+    const indexSource = readFileSync(
+      join(projectRoot, 'server/index.ts'),
+      'utf8'
+    );
+    expect(indexSource).toContain('createWorkbenchProposeBlockRouter');
+  });
+
+  it('uses the propose-block router under /workbench path', () => {
+    const indexSource = readFileSync(
+      join(projectRoot, 'server/index.ts'),
+      'utf8'
+    );
+    expect(indexSource).toContain("'/workbench'");
+    expect(indexSource).toContain('createWorkbenchProposeBlockRouter');
+  });
+
+  it('server/workbench-prompt-hooks.ts exists', () => {
+    expect(
+      existsSync(join(projectRoot, 'server/workbench-prompt-hooks.ts'))
+    ).toBe(true);
+  });
+
+  it('shared/workbench-prompt-hooks.ts exists', () => {
+    expect(
+      existsSync(join(projectRoot, 'shared/workbench-prompt-hooks.ts'))
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

This is the final slice (5/5) of epic #612 (Workbench blocks). It implements two flows from issue #625.

**Stacked on:** `feat/622-custom-blocks` (PR #644) and `feat/621-block-layout` (PR #641). Will rebase onto nightly after both PRs merge.

### a) Layout → agent context (read-only)

- `summarizeWorkbenchBlocks(layout: WorkbenchLayout): WorkbenchContextSummary` — pure function in `shared/workbench-prompt-hooks.ts`
- `getWorkbenchContextSummary(configPath, workspaceId)` — wires layout store (slice 3) + summarizer; ready to hook into agent turn context

**Size caps (documented in source):**
- `WORKBENCH_CONTEXT_SUMMARY_MAX_BYTES = 4096` — truncates at the last complete block entry before the limit
- `WORKBENCH_CONTEXT_SUMMARY_MAX_BLOCKS = 20` — blocks beyond this are omitted
- Both caps enforced independently; whichever triggers first wins

**What's included in the summary (safe metadata only):**

| Kind | Excerpt fields |
|------|---------------|
| `terminal` | `sessionId` only |
| `agent` | `actorId`, `actorDisplayName` |
| `work-context` | opaque `workContextRef` string |
| `file` | `fileRefKind: 'file'`, `mode` |
| `artifact` | `artifactKind`, `artifactTitle` |
| `markdown` | nothing (title comes from base descriptor) |
| `custom` | `rendererId`, `proposalId` |

**What's blocked (never emitted):** secrets, env vars, raw PTY bytes, raw transcripts, file contents, markdown `.meta.content`, file paths, artifact URIs, custom block `props` or `dataRefs`.

### b) Agent → block proposal API (typed)

New REST router at `/workbench` (mounted in `server/index.ts`):

- `POST /workbench/propose-block` — agent proposes any block descriptor
  - `custom` kind → routes through slice-4 custom-blocks approval store (always `pending`)
  - First-party kinds → auto-approved if all `capabilityRequirements` satisfied by `actorGrantedBits`; otherwise `pending`
  - Malformed descriptor → `rejected` at validation, HTTP 422
- `GET /workbench/propose-block/proposals` — list first-party proposals (filterable by status)
- `POST /workbench/propose-block/proposals/:id/approve` — user approves pending
- `POST /workbench/propose-block/proposals/:id/reject` — user rejects pending

**Auto-approval rules for first-party kinds:** all `descriptor.capabilityRequirements` must be present in `actorGrantedBits`. Vacuously satisfied (empty requirements) → auto-approved.

**Storage:** first-party proposals in `<configDir>/workbench-prompt-hooks/first-party-proposals.json`. Custom proposals delegate to the existing slice-4 store.

**Audit envelopes** emitted on: proposal create + auto-approve + pending + user approve + user reject.

## Acceptance criteria

- [x] Active blocks appear in the agent's context as bounded summaries
- [x] Agent can call a typed propose-block API
- [x] First-party block proposals respect capability grants
- [x] Custom block proposals route through slice-4 approval
- [x] vitest coverage for context summarization (no leakage) + propose-block validation

## Test coverage

`test/workbench-prompt-hooks.test.ts` — 40 tests:
1. `summarizeWorkbenchBlocks` — empty layout, all 7 kinds, block cap truncation, byte cap truncation, no leakage (markdown content, file paths, terminal cwd, custom props)
2. `evaluateBlockProposal` (pure logic) — auto-approved with grants, pending without grants, custom always pending, malformed rejected
3. REST router — all endpoints, error cases (404, 409, 422)
4. Audit envelope emission — create (auto-approved/pending), user approve, user reject
5. `getWorkbenchContextSummary` — null on missing layout, valid summary on persisted layout, no leakage
6. `server/index.ts` mounts the router

## Files changed

- `shared/workbench-prompt-hooks.ts` — new: summarizer types + `summarizeWorkbenchBlocks` + proposal evaluation logic
- `server/workbench-prompt-hooks.ts` — new: `getWorkbenchContextSummary`, first-party proposal store, REST router
- `server/index.ts` — mounts `/workbench` propose-block router
- `test/workbench-prompt-hooks.test.ts` — new: 40 tests

## Notes

- Completes epic #612 (all 5 slices now have PRs)
- The `summarizeWorkbenchBlocks` function is ready to hook into agent turn context assembly (see `buildTicketInitialPrompt` pattern in `server/index.ts` for the injection point)
- This PR does not touch `App.tsx` or the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)