### PR TITLE
feat(env): wire env picker into command palette (#630)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -82,6 +82,8 @@ import AddWorkspaceDialog from './components/dialogs/AddWorkspaceDialog.js';
 import type { AddWorkspaceDialogHandle } from './components/dialogs/AddWorkspaceDialog.js';
 import WorkspaceSettingsDialog from './components/dialogs/WorkspaceSettingsDialog.js';
 import type { WorkspaceSettingsDialogHandle } from './components/dialogs/WorkspaceSettingsDialog.js';
+import EnvPickerDialog from './components/dialogs/EnvPickerDialog.js';
+import { reposToEnvironmentOptions } from './lib/repo-to-environment.js';
 import AnalyticsDashboard from './components/AnalyticsDashboard.js';
 import SessionDetail from './components/SessionDetail.js';
 import FullPageDiff from './components/FullPageDiff.js';
@@ -1305,6 +1307,14 @@ export default function App() {
             useUiStore.getState().setActiveRepoPath(null);
           }
         }}
+      />
+      {/* #630: command-palette "start work in environment…" target. Driven by
+          the `env-picker` ActiveModal variant. Options derive from known
+          repos as a stopgap until the full env-inventory feed lands (#615). */}
+      <EnvPickerDialog
+        open={activeModal?.modal === 'env-picker'}
+        options={reposToEnvironmentOptions(repos)}
+        onClose={handleModalClose}
       />
 
       {/* Full-page diff overlay */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -889,6 +889,16 @@ export default function App() {
     (s) => s.recallSessionForWorkspace
   );
 
+  // #630: env picker candidates derived from known repos. Memoized so the
+  // dialog's internal effects (default-selection memo, etc.) don't refire
+  // on unrelated App rerenders. The `generatedAt` is intentionally bound to
+  // the `repos` reference — when repos change we get fresh stamps; when they
+  // don't we keep the same option identities (Gemini PR #646 feedback).
+  const envPickerOptions = useMemo(
+    () => reposToEnvironmentOptions(repos, new Date().toISOString()),
+    [repos]
+  );
+
   // ── Boot store ─────────────────────────────────────────────────────────────
   const bootComplete = useBootStateStore((s) => s.bootComplete);
   const startBoot = useBootStateStore((s) => s.startBoot);
@@ -1310,10 +1320,12 @@ export default function App() {
       />
       {/* #630: command-palette "start work in environment…" target. Driven by
           the `env-picker` ActiveModal variant. Options derive from known
-          repos as a stopgap until the full env-inventory feed lands (#615). */}
+          repos as a stopgap until the full env-inventory feed lands (#615).
+          Memoized on `repos` so the picker's internal effects don't fire on
+          unrelated App rerenders (Gemini PR #646 feedback). */}
       <EnvPickerDialog
         open={activeModal?.modal === 'env-picker'}
-        options={reposToEnvironmentOptions(repos)}
+        options={envPickerOptions}
         onClose={handleModalClose}
       />
 

--- a/frontend/src/components/dialogs/EnvPickerDialog.css
+++ b/frontend/src/components/dialogs/EnvPickerDialog.css
@@ -1,0 +1,85 @@
+/* EnvPickerDialog (#630) — overlay wrapper around <EnvironmentPicker>.
+   Follows the TUI aesthetic from DESIGN.md: lowercase labels, zero
+   border-radius, outline-only chrome, monospace stack inherited from the
+   palette/picker. */
+
+.env-picker-dialog__overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 10vh;
+}
+
+.env-picker-dialog {
+  width: min(640px, 95vw);
+  max-height: 80vh;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.env-picker-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.env-picker-dialog__title {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--text);
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}
+
+.env-picker-dialog__close {
+  background: transparent;
+  border: 0;
+  color: var(--text-muted);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.env-picker-dialog__close:hover,
+.env-picker-dialog__close:focus-visible {
+  color: var(--text);
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.env-picker-dialog__body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px;
+  overflow: hidden;
+}
+
+.env-picker-dialog__block-reason {
+  border: 1px solid var(--warning, #c97f00);
+  background: transparent;
+  color: var(--warning, #c97f00);
+  padding: 6px 10px;
+  font-size: 12px;
+  text-transform: lowercase;
+}
+
+.env-picker-dialog__launching {
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 4px 10px;
+  text-transform: lowercase;
+}

--- a/frontend/src/components/dialogs/EnvPickerDialog.tsx
+++ b/frontend/src/components/dialogs/EnvPickerDialog.tsx
@@ -20,7 +20,7 @@
 // button on the selection's freshness so a stale row cannot be activated
 // without surfacing the typed degraded reason.
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   EnvironmentOption,
   EnvironmentDegradedReason,
@@ -131,17 +131,27 @@ export function EnvPickerDialog({
   const [selectedId, setSelectedId] = useState<string | undefined>(defaultId);
   const [blockReason, setBlockReason] = useState<string | null>(null);
   const [launching, setLaunching] = useState(false);
+  // Re-entry guard. We use a ref (not the `launching` state) because state
+  // updates batch and a fast double-click would race past the `launching`
+  // check before React schedules the re-render. The ref reflects the in-flight
+  // launch synchronously. Per CodeRabbit feedback on PR #646.
+  const launchInFlightRef = useRef(false);
 
   useEffect(() => {
     if (open) {
       setSelectedId(defaultId);
       setBlockReason(null);
       setLaunching(false);
+      launchInFlightRef.current = false;
     }
   }, [open, defaultId]);
 
   const handleSelect = useCallback(
     async (option: EnvironmentOption) => {
+      // Re-entry guard: ignore additional selects while a launch is pending.
+      // Double-clicking a fresh option or hammering Enter would otherwise fire
+      // duplicate create-session POSTs (CodeRabbit PR #646 feedback).
+      if (launchInFlightRef.current) return;
       setSelectedId(option.id);
       // Always re-check freshness at launch time (defense-in-depth against the
       // picker surfacing a stale row).
@@ -153,6 +163,7 @@ export function EnvPickerDialog({
       }
       setBlockReason(null);
       setLaunching(true);
+      launchInFlightRef.current = true;
       try {
         const result = await launch(option, launchOverrides);
         if (result.kind === 'blocked') {
@@ -166,8 +177,19 @@ export function EnvPickerDialog({
         }
         onLaunched?.(result);
         onClose();
+      } catch (error) {
+        // Reject-path safety: if the launch hook throws (network blip,
+        // capability check raised mid-flight, etc.) we MUST surface a typed
+        // user-visible failure instead of silently swallowing the error and
+        // leaving the dialog open with no feedback. Defense-in-depth against
+        // the "never silently switch nodes" invariant — a thrown launch is
+        // morally equivalent to a stale environment from the user's POV.
+        const message =
+          error instanceof Error ? error.message : String(error ?? 'unknown');
+        setBlockReason(`launch failed: ${message.toLowerCase()}`);
       } finally {
         setLaunching(false);
+        launchInFlightRef.current = false;
       }
     },
     [launch, launchOverrides, onClose, onLaunched]

--- a/frontend/src/components/dialogs/EnvPickerDialog.tsx
+++ b/frontend/src/components/dialogs/EnvPickerDialog.tsx
@@ -41,7 +41,14 @@ import './EnvPickerDialog.css';
 
 export interface EnvPickerDialogProps {
   open: boolean;
-  options: readonly EnvironmentOption[];
+  /**
+   * Mutable shape (not `readonly`) because the downstream
+   * `EnvironmentPicker` (#627) takes `EnvironmentOption[]`. We don't mutate
+   * here, but typing the prop as `readonly` would force a cast at the
+   * `<EnvironmentPicker>` boundary (Gemini PR #646 feedback). When #627's
+   * picker is later updated to take `readonly`, this loosens to readonly.
+   */
+  options: EnvironmentOption[];
   /** Last-used environment history, newest-first per `pickDefaultEnvironment`. */
   history?: readonly EnvironmentHistoryEntry[];
   /** Active tab context for the safe-default rule (#628). */
@@ -235,7 +242,7 @@ export function EnvPickerDialog({
         </header>
         <div className="env-picker-dialog__body">
           <EnvironmentPicker
-            options={options as EnvironmentOption[]}
+            options={options}
             onSelect={handleSelect}
             onCancel={handleCancel}
             {...(selectedId !== undefined ? { selectedOptionId: selectedId } : {})}

--- a/frontend/src/components/dialogs/EnvPickerDialog.tsx
+++ b/frontend/src/components/dialogs/EnvPickerDialog.tsx
@@ -1,0 +1,244 @@
+// EnvPickerDialog (#630) — wraps `EnvironmentPicker` with safe-default
+// preselection and launch-on-confirm, surfaced from the command palette
+// action "start work in environment…".
+//
+// Why a separate dialog (not the picker rendered inline):
+//   - The picker (#627) is intentionally pure-presentational: props in,
+//     callbacks out, no I/O. This dialog owns the "what happens after the
+//     user picks an option" decision tree: compute the safe default via
+//     `pickDefaultEnvironment` (#628), block-on-stale with a typed reason
+//     (#615 invariant), and route through the shared `launchEnvironment`
+//     hook so #629's new-session dialog can reuse it without duplicating
+//     launch logic.
+//
+//   - Rendered as an overlay (not native <dialog>) so it composes with the
+//     palette overlay z-stack and is testable under happy-dom, which does
+//     not implement HTMLDialogElement.showModal/close.
+//
+// The "never silently switch nodes" invariant lives here AND in
+// `launchEnvironment` (defense-in-depth): the dialog gates the confirm
+// button on the selection's freshness so a stale row cannot be activated
+// without surfacing the typed degraded reason.
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import type {
+  EnvironmentOption,
+  EnvironmentDegradedReason,
+} from '../../../../shared/environment-option.js';
+import {
+  pickDefaultEnvironment,
+  type ActiveTabContext,
+  type EnvironmentHistoryEntry,
+} from '../../../../shared/safe-defaults.js';
+import { EnvironmentPicker } from '../EnvironmentPicker.js';
+import {
+  canLaunchEnvironment,
+  launchEnvironment,
+  type LaunchEnvironmentOptions,
+  type LaunchEnvironmentResult,
+} from '../../lib/launch-environment.js';
+import './EnvPickerDialog.css';
+
+export interface EnvPickerDialogProps {
+  open: boolean;
+  options: readonly EnvironmentOption[];
+  /** Last-used environment history, newest-first per `pickDefaultEnvironment`. */
+  history?: readonly EnvironmentHistoryEntry[];
+  /** Active tab context for the safe-default rule (#628). */
+  activeTab?: ActiveTabContext | null;
+  /** Launch shape overrides forwarded to `launchEnvironment`. */
+  launchOverrides?: LaunchEnvironmentOptions;
+  onClose: () => void;
+  /**
+   * Called after a successful launch. Receives the launch result so callers
+   * can navigate to the new session / show a toast etc.
+   */
+  onLaunched?: (result: LaunchEnvironmentResult) => void;
+  /**
+   * Injection point for tests. Defaults to the real `launchEnvironment`.
+   */
+  launch?: typeof launchEnvironment;
+}
+
+function describeBlockReason(
+  freshness: EnvironmentOption['freshness'],
+  reasons: EnvironmentDegradedReason[] | undefined
+): string {
+  // Use the FIRST typed reason for a concise headline; the picker row itself
+  // already lists all reasons inline. Keep wording lowercase per DESIGN.md.
+  const head = reasons?.[0];
+  if (head) {
+    switch (head.kind) {
+      case 'node-offline':
+        return 'node offline — launch blocked';
+      case 'node-stale':
+        return 'node stale — launch blocked';
+      case 'capability-missing':
+        return `missing capability ${head.capability} — launch blocked`;
+      case 'repo-missing':
+        return 'repo missing on node — launch blocked';
+      case 'worktree-missing':
+        return 'worktree missing on node — launch blocked';
+      case 'auth-failed':
+        return 'auth failed — launch blocked';
+      case 'other':
+        return `${head.message} — launch blocked`;
+    }
+  }
+  return freshness === 'offline'
+    ? 'node offline — launch blocked'
+    : 'environment stale — launch blocked';
+}
+
+/**
+ * Pick the initial selection id from `pickDefaultEnvironment`. On `error`
+ * (no compatible default), returns `undefined` so the picker shows nothing
+ * pre-selected; the user must still pick before launch.
+ */
+function initialSelectionId(
+  options: readonly EnvironmentOption[],
+  history: readonly EnvironmentHistoryEntry[],
+  activeTab: ActiveTabContext | null
+): string | undefined {
+  const result = pickDefaultEnvironment({
+    activeTab,
+    history,
+    candidates: options,
+  });
+  if (result.kind === 'ok') return result.option.id;
+  return undefined;
+}
+
+export function EnvPickerDialog({
+  open,
+  options,
+  history = [],
+  activeTab = null,
+  launchOverrides,
+  onClose,
+  onLaunched,
+  launch = launchEnvironment,
+}: EnvPickerDialogProps): React.ReactElement | null {
+  // Compute the default selection once per open. We DO NOT recompute on every
+  // render so the user's keyboard navigation isn't reset by upstream prop
+  // jitter.
+  const defaultId = useMemo(
+    () => (open ? initialSelectionId(options, history, activeTab) : undefined),
+    // Recompute only when the dialog opens, not on every render of the parent.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [open]
+  );
+  const [selectedId, setSelectedId] = useState<string | undefined>(defaultId);
+  const [blockReason, setBlockReason] = useState<string | null>(null);
+  const [launching, setLaunching] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setSelectedId(defaultId);
+      setBlockReason(null);
+      setLaunching(false);
+    }
+  }, [open, defaultId]);
+
+  const handleSelect = useCallback(
+    async (option: EnvironmentOption) => {
+      setSelectedId(option.id);
+      // Always re-check freshness at launch time (defense-in-depth against the
+      // picker surfacing a stale row).
+      if (!canLaunchEnvironment(option)) {
+        setBlockReason(
+          describeBlockReason(option.freshness, option.degradedReasons)
+        );
+        return;
+      }
+      setBlockReason(null);
+      setLaunching(true);
+      try {
+        const result = await launch(option, launchOverrides);
+        if (result.kind === 'blocked') {
+          // Should not happen given the canLaunch gate above, but if the
+          // launch hook ever rejects, surface the typed reason instead of
+          // silently closing.
+          setBlockReason(
+            describeBlockReason(option.freshness, option.degradedReasons)
+          );
+          return;
+        }
+        onLaunched?.(result);
+        onClose();
+      } finally {
+        setLaunching(false);
+      }
+    },
+    [launch, launchOverrides, onClose, onLaunched]
+  );
+
+  const handleCancel = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  if (!open) return null;
+
+  const handleBackdropClick = (event: React.MouseEvent) => {
+    if (
+      (event.target as HTMLElement).classList.contains('env-picker-dialog__overlay')
+    ) {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="env-picker-dialog__overlay"
+      role="presentation"
+      onClick={handleBackdropClick}
+      data-testid="env-picker-dialog"
+    >
+      <div
+        className="env-picker-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="start work in environment"
+      >
+        <header className="env-picker-dialog__header">
+          <h2 className="env-picker-dialog__title">start work in environment</h2>
+          <button
+            type="button"
+            className="env-picker-dialog__close"
+            onClick={handleCancel}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </header>
+        <div className="env-picker-dialog__body">
+          <EnvironmentPicker
+            options={options as EnvironmentOption[]}
+            onSelect={handleSelect}
+            onCancel={handleCancel}
+            {...(selectedId !== undefined ? { selectedOptionId: selectedId } : {})}
+          />
+          {blockReason ? (
+            <div
+              className="env-picker-dialog__block-reason"
+              role="alert"
+              data-testid="env-picker-dialog-block-reason"
+            >
+              {blockReason}
+            </div>
+          ) : null}
+          {launching ? (
+            <div
+              className="env-picker-dialog__launching"
+              data-testid="env-picker-dialog-launching"
+            >
+              launching…
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default EnvPickerDialog;

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -15,6 +15,7 @@ import {
   sessionCustomize,
   sessionSwitchToTab,
   sessionRename,
+  sessionStartWorkInEnv,
 } from '../lib/actions/definitions/session.js';
 import { createFrameworkAction } from '../lib/actions/definitions/frameworks.js';
 import { isFrameworkAvailable } from '../components/dialogs/CustomizeSessionDialog.js';
@@ -214,6 +215,14 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
       },
       { ...sessionStartOnRepo, handler: () => handleQuickAgent() },
       { ...sessionStartOnTicket, handler: () => navigateToDashboard() },
+      {
+        // #630: opens the env picker dialog. The dialog itself owns
+        // default-selection + block-on-stale + launch wiring; the action's
+        // only job is to surface the entry point in the palette.
+        ...sessionStartWorkInEnv,
+        handler: () =>
+          useUiStore.getState().setActiveModal({ modal: 'env-picker' }),
+      },
       {
         ...sessionCustomize,
         handler: () => {

--- a/frontend/src/lib/actions/definitions/session.ts
+++ b/frontend/src/lib/actions/definitions/session.ts
@@ -83,6 +83,22 @@ export const sessionRename: ActionMeta = {
   when: (ctx) => !!ctx.sessionId,
 };
 
+// #630: command-palette entry that opens the EnvironmentPicker (#627) and
+// launches against the chosen Node/RepoInstance/Bench via the shared launch
+// hook. Distinct from `sessionNewAgent` / `sessionNewTerminal`: those launch
+// against the active workspace's implicit node, while this one explicitly
+// makes the environment a first-class choice the user makes BEFORE launch.
+// Aliases mirror Wave's "connection picker" vocabulary so users searching for
+// "environment", "node", "where" all find it.
+export const sessionStartWorkInEnv: ActionMeta = {
+  id: 'session.start-work-in-env',
+  label: 'start work in environment…',
+  description: 'pick a node / repo / worktree, then launch',
+  aliases: ['start work', 'environment', 'env', 'node', 'where', 'pick env'],
+  category: 'session',
+  icon: '▸',
+};
+
 export const sessionActions: ActionMeta[] = [
   sessionNewAgent,
   sessionNewTerminal,
@@ -93,4 +109,5 @@ export const sessionActions: ActionMeta[] = [
   sessionCustomize,
   sessionSwitchToTab,
   sessionRename,
+  sessionStartWorkInEnv,
 ];

--- a/frontend/src/lib/launch-environment.ts
+++ b/frontend/src/lib/launch-environment.ts
@@ -1,0 +1,118 @@
+// launchEnvironment (#630 / #629) — small adapter that maps an
+// `EnvironmentOption` (the picker's selection shape) onto the existing
+// `createAgentSession` launch path.
+//
+// Scope:
+//   - Single launch entry point shared by the command-palette picker (#630)
+//     and the new-session/start-work dialog (#629). Both surfaces select an
+//     `EnvironmentOption` via the same `EnvironmentPicker`; both must launch
+//     against the SAME create-session API so we get one audit/telemetry path
+//     and no drift between surfaces. If #629 lands after this PR, it imports
+//     `launchEnvironment` from here instead of duplicating the mapping.
+//
+//   - Enforces the "never silently switch nodes" invariant from #615:
+//     stale/offline options are rejected here with a typed reason before the
+//     launch ever reaches the network. The UI is expected to gate on
+//     `canLaunch(option)` BEFORE calling this, but the runtime guard is
+//     defense-in-depth — a bug in the picker that surfaces a stale option
+//     should not silently launch on a different node.
+//
+// This module is intentionally pure-ish: it calls the existing
+// `createAgentSession` (which talks to the store + API) but does no
+// store-state mutation of its own beyond what `createAgentSession` already
+// performs. Tests can inject a `createSession` override.
+
+import type { EnvironmentOption } from '../../../shared/environment-option.js';
+import type { EnvironmentDegradedReason } from '../../../shared/environment-option.js';
+import {
+  createAgentSession,
+  type CreateAgentSessionOptions,
+  type CreateAgentSessionResult,
+} from './session-utils.js';
+
+/**
+ * Result discriminator returned by {@link launchEnvironment}. Callers that need
+ * the block-on-stale reason for UI display can pattern-match on `kind`.
+ */
+export type LaunchEnvironmentResult =
+  | { kind: 'launched'; result: CreateAgentSessionResult }
+  | { kind: 'blocked'; reason: LaunchBlockedReason };
+
+export type LaunchBlockedReason =
+  | { code: 'stale'; degradedReasons?: EnvironmentDegradedReason[] }
+  | { code: 'offline'; degradedReasons?: EnvironmentDegradedReason[] };
+
+export interface LaunchEnvironmentOptions {
+  /** Override the launch type. Defaults to 'terminal' (a bare shell launch). */
+  type?: 'agent' | 'terminal';
+  /**
+   * Override the agent id (e.g. `'claude'`, `'codex'`). Only relevant when
+   * `type === 'agent'`; the create-session path uses this to pick a framework.
+   */
+  agent?: string;
+}
+
+/**
+ * True iff this option is safe to launch against. The picker's "never silently
+ * switch nodes" invariant means anything not `fresh` is blocked at the launch
+ * boundary, regardless of which surface made the selection.
+ */
+export function canLaunchEnvironment(option: EnvironmentOption): boolean {
+  return option.freshness === 'fresh';
+}
+
+/**
+ * Map an EnvironmentOption to `createAgentSession` options. Visible for
+ * testing so adapters / #629's dialog can reuse the mapping without going
+ * through the launch side-effects.
+ */
+export function environmentToCreateSessionOptions(
+  option: EnvironmentOption,
+  overrides: LaunchEnvironmentOptions = {}
+): CreateAgentSessionOptions {
+  const type = overrides.type ?? 'terminal';
+  const base: CreateAgentSessionOptions = {
+    nodeId: option.node.nodeId,
+    cwd: option.cwd,
+    type,
+  };
+  if (option.repoInstance) {
+    base.repoPath = option.repoInstance.localPath;
+  }
+  if (option.bench) {
+    base.worktreePath = option.bench.localPath;
+  }
+  if (overrides.agent !== undefined) {
+    base.agent = overrides.agent;
+  }
+  return base;
+}
+
+/**
+ * Launch a session against the supplied environment. Refuses to launch
+ * non-fresh options with a typed reason — UI surfaces should pre-check via
+ * {@link canLaunchEnvironment} so this only fails on a programming bug.
+ *
+ * The optional `createSession` override is for tests that want to capture the
+ * mapped options without hitting the real store/network.
+ */
+export async function launchEnvironment(
+  option: EnvironmentOption,
+  overrides: LaunchEnvironmentOptions = {},
+  createSession: (
+    opts: CreateAgentSessionOptions
+  ) => Promise<CreateAgentSessionResult> = createAgentSession
+): Promise<LaunchEnvironmentResult> {
+  if (!canLaunchEnvironment(option)) {
+    const code: LaunchBlockedReason['code'] =
+      option.freshness === 'offline' ? 'offline' : 'stale';
+    const reason: LaunchBlockedReason = option.degradedReasons
+      ? { code, degradedReasons: option.degradedReasons }
+      : { code };
+    return { kind: 'blocked', reason };
+  }
+  const result = await createSession(
+    environmentToCreateSessionOptions(option, overrides)
+  );
+  return { kind: 'launched', result };
+}

--- a/frontend/src/lib/repo-to-environment.ts
+++ b/frontend/src/lib/repo-to-environment.ts
@@ -1,0 +1,113 @@
+// repo-to-environment (#630) — minimal adapter that derives an
+// `EnvironmentOption` list from the locally-known `Repo` projection in the
+// sessions store. This is a stopgap until the full env-inventory backend
+// (epic #615) lands; today the frontend has no separate environment feed,
+// but every known repo is a valid launch target on the local node, and the
+// picker is most useful immediately rather than after the inventory work
+// completes.
+//
+// When the full inventory feed lands, App should pass the inventory-derived
+// option list directly to <EnvPickerDialog> and this module can be deleted
+// (or repurposed as a fallback). Until then, the contract is:
+//
+//   - One option per known Repo on the local node.
+//   - One always-available "free / non-git cwd" option for home directory
+//     launches.
+//   - All options surface as `fresh` for now (the local node is by
+//     definition reachable; node staleness is a remote-node concept this
+//     stopgap does not model).
+//
+// The downstream `launchEnvironment` hook still enforces the
+// "never silently switch nodes" invariant by re-checking freshness at the
+// launch boundary.
+
+import {
+  ENVIRONMENT_OPTION_SCHEMA_VERSION,
+  type EnvironmentOption,
+} from '../../../shared/environment-option.js';
+import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
+import type { Repo } from './types.js';
+
+const HOME_FALLBACK_CWD = '~';
+
+/**
+ * Map a Repo from the sessions store to an EnvironmentOption. Free (non-git)
+ * directories are treated as `cwdMode: 'free'` with no `repoInstance`.
+ */
+export function repoToEnvironmentOption(
+  repo: Repo,
+  generatedAt: string
+): EnvironmentOption {
+  const nodeId = repo.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  const localPath = repo.localPath ?? repo.path;
+  const optionId = `${nodeId}::${repo.repoInstanceId ?? localPath}`;
+  if (!repo.isGitRepo) {
+    return {
+      schemaVersion: ENVIRONMENT_OPTION_SCHEMA_VERSION,
+      id: optionId,
+      node: {
+        nodeId,
+        kind: nodeId === DEFAULT_LOCAL_NODE_ID ? 'local' : 'remote',
+        displayName: nodeId,
+        online: true,
+      },
+      capabilities: ['session:create:terminal'],
+      cwd: localPath,
+      cwdMode: 'free',
+      freshness: 'fresh',
+      generatedAt,
+    };
+  }
+  return {
+    schemaVersion: ENVIRONMENT_OPTION_SCHEMA_VERSION,
+    id: optionId,
+    node: {
+      nodeId,
+      kind: nodeId === DEFAULT_LOCAL_NODE_ID ? 'local' : 'remote',
+      displayName: nodeId,
+      online: true,
+    },
+    capabilities: ['session:create:terminal', 'rpc:git:read'],
+    cwd: localPath,
+    cwdMode: 'repo',
+    freshness: 'fresh',
+    repoInstance: {
+      repoInstanceId: repo.repoInstanceId ?? `${nodeId}:${localPath}`,
+      localPath,
+      repoIdentity: repo.repoIdentity ?? null,
+      name: repo.name,
+      currentBranch: repo.currentBranch,
+      defaultBranch: repo.defaultBranch,
+    },
+    generatedAt,
+  };
+}
+
+/**
+ * Build the candidate list <EnvPickerDialog> consumes: one option per known
+ * repo plus a single "free home" option for non-repo launches.
+ */
+export function reposToEnvironmentOptions(
+  repos: readonly Repo[],
+  generatedAt: string = new Date().toISOString()
+): EnvironmentOption[] {
+  const opts = repos.map((repo) => repoToEnvironmentOption(repo, generatedAt));
+  // Always offer a free / non-git cwd entry so the user can launch into a
+  // bare shell on their home dir without having a Repo registered.
+  opts.push({
+    schemaVersion: ENVIRONMENT_OPTION_SCHEMA_VERSION,
+    id: `${DEFAULT_LOCAL_NODE_ID}::__home__`,
+    node: {
+      nodeId: DEFAULT_LOCAL_NODE_ID,
+      kind: 'local',
+      displayName: DEFAULT_LOCAL_NODE_ID,
+      online: true,
+    },
+    capabilities: ['session:create:terminal'],
+    cwd: HOME_FALLBACK_CWD,
+    cwdMode: 'free',
+    freshness: 'fresh',
+    generatedAt,
+  });
+  return opts;
+}

--- a/frontend/src/lib/repo-to-environment.ts
+++ b/frontend/src/lib/repo-to-environment.ts
@@ -86,10 +86,18 @@ export function repoToEnvironmentOption(
 /**
  * Build the candidate list <EnvPickerDialog> consumes: one option per known
  * repo plus a single "free home" option for non-repo launches.
+ *
+ * `generatedAt` is required (no default `new Date().toISOString()`) so the
+ * function is deterministic. Defaulting to "now" would re-stamp every
+ * EnvironmentOption on every call and break reference equality, defeating
+ * React memoization at every call site. Callers are responsible for picking
+ * a stable timestamp source — typically the upstream inventory snapshot
+ * time — or a once-per-mount `useMemo` if no upstream time exists yet
+ * (per Gemini PR #646 feedback).
  */
 export function reposToEnvironmentOptions(
   repos: readonly Repo[],
-  generatedAt: string = new Date().toISOString()
+  generatedAt: string
 ): EnvironmentOption[] {
   const opts = repos.map((repo) => repoToEnvironmentOption(repo, generatedAt));
   // Always offer a free / non-git cwd entry so the user can launch into a

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -420,6 +420,9 @@ export type AnalyticsView = 'dashboard' | { sessionId: string } | null;
 export type ActiveModal =
   | { modal: 'settings'; scrollToId: string | null }
   | { modal: 'add-repo' }
+  // #630: command-palette entry "start work in environment…" sets this
+  // variant; App renders the EnvPickerDialog which embeds EnvironmentPicker.
+  | { modal: 'env-picker' }
   | null;
 
 // ── State interface ────────────────────────────────────────────────────────

--- a/frontend/src/lib/url-nav.ts
+++ b/frontend/src/lib/url-nav.ts
@@ -18,6 +18,11 @@ export function hashPath(path: string): string {
 export type ModalRoute =
   | { modal: 'settings'; scrollToId: string | null }
   | { modal: 'add-repo' }
+  // #630: env-picker is a transient palette-driven dialog. It is included in
+  // the ModalRoute union so the activeModal store shape stays compatible with
+  // ActiveModal, but it is intentionally NOT persisted to the URL — opening
+  // it via deep link would race the env-inventory feed.
+  | { modal: 'env-picker' }
   | null;
 
 /** Parse `window.location.search` into a ModalRoute. */
@@ -40,6 +45,8 @@ export function buildQuery(modal: ModalRoute): string {
     return modal.scrollToId ? `?settings=${modal.scrollToId}` : '?settings';
   }
   if (modal.modal === 'add-repo') return '?add-repo';
+  // #630: env-picker is in-memory only; no URL representation.
+  if (modal.modal === 'env-picker') return '';
   return '';
 }
 

--- a/test/action-coverage.test.ts
+++ b/test/action-coverage.test.ts
@@ -14,15 +14,16 @@ import { dashboardActions } from '../frontend/src/lib/actions/definitions/dashbo
 import { terminalActions } from '../frontend/src/lib/actions/definitions/terminal.js';
 import { navigationActions } from '../frontend/src/lib/actions/definitions/navigation.js';
 
-// Full allowlist: 59 palettable action IDs (15 Phase 2 + 44 Phase 3)
+// Full allowlist: 60 palettable action IDs (15 Phase 2 + 44 Phase 3 + 1 from #630)
 const ACTION_ALLOWLIST = [
-  // Session (9)
+  // Session (10)
   'session.new-agent',
   'session.new-terminal',
   'session.close-active',
   'session.kill',
   'session.start-on-repo',
   'session.start-on-ticket',
+  'session.start-work-in-env',
   'session.customize',
   'session.switch-to-tab',
   'session.rename',

--- a/test/components/EnvPickerPaletteAction.test.ts
+++ b/test/components/EnvPickerPaletteAction.test.ts
@@ -316,6 +316,76 @@ describe('<EnvPickerDialog /> (palette wiring)', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('guards against re-entry: a second click while launching is a no-op', async () => {
+    // CodeRabbit PR #646 feedback: a fast double-click on a fresh row would
+    // otherwise fire two POST /sessions calls before React rerendered the
+    // `launching` flag. The ref-based guard MUST hold synchronously.
+    const fresh = freshOption({ id: 'opt-double' });
+    let resolveLaunch!: (value: LaunchEnvironmentResult) => void;
+    const launch = vi.fn(
+      () =>
+        new Promise<LaunchEnvironmentResult>((resolve) => {
+          resolveLaunch = resolve;
+        })
+    );
+    const onClose = vi.fn();
+    await render({
+      open: true,
+      options: [fresh],
+      onClose,
+      launch,
+    });
+    const row = container.querySelector(
+      '[data-option-id="opt-double"]'
+    ) as HTMLElement;
+    await act(async () => {
+      row.click();
+      row.click(); // second click while the first launch is in-flight
+      row.click(); // and a third for good measure
+    });
+    expect(launch).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveLaunch({
+        kind: 'launched',
+        result: { session: undefined, error: null },
+      });
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a typed block reason if the launch hook throws', async () => {
+    // CodeRabbit PR #646 feedback: a rejected launch promise must not leave
+    // the dialog in a silently-broken state. The error must be surfaced so
+    // the user can retry / pick a different env.
+    const fresh = freshOption({ id: 'opt-throw' });
+    const launch = vi.fn(async (): Promise<LaunchEnvironmentResult> => {
+      throw new Error('network down');
+    });
+    const onClose = vi.fn();
+    const onLaunched = vi.fn();
+    await render({
+      open: true,
+      options: [fresh],
+      onClose,
+      onLaunched,
+      launch,
+    });
+    const row = container.querySelector(
+      '[data-option-id="opt-throw"]'
+    ) as HTMLElement;
+    await act(async () => {
+      row.click();
+    });
+    expect(launch).toHaveBeenCalledTimes(1);
+    expect(onLaunched).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    const block = container.querySelector(
+      '[data-testid="env-picker-dialog-block-reason"]'
+    );
+    expect(block?.textContent).toMatch(/launch failed/i);
+    expect(block?.textContent).toMatch(/network down/i);
+  });
+
   it('closes when the backdrop is clicked', async () => {
     const onClose = vi.fn();
     await render({

--- a/test/components/EnvPickerPaletteAction.test.ts
+++ b/test/components/EnvPickerPaletteAction.test.ts
@@ -1,0 +1,334 @@
+// @vitest-environment happy-dom
+
+// EnvPickerPaletteAction (#630) — integration coverage for the command
+// palette action that opens the EnvironmentPicker.
+//
+// Scope:
+//   1. The action meta is registered and discoverable in the registry under
+//      the natural search terms ("start work", "environment").
+//   2. EnvPickerDialog computes its initial selection via
+//      `pickDefaultEnvironment` (#628) so palette + new-session dialog share
+//      identical default behavior (#629 reuses the same hook).
+//   3. Selecting a FRESH environment from the dialog fires the launch hook
+//      with typed IDs derived from the EnvironmentOption.
+//   4. Selecting a STALE / OFFLINE environment blocks launch and surfaces
+//      the typed degraded reason — never silently switches nodes (#615
+//      invariant).
+//   5. Escape closes the dialog.
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EnvironmentOption } from '../../shared/environment-option.js';
+import { sessionStartWorkInEnv } from '../../frontend/src/lib/actions/definitions/session.js';
+import {
+  _resetForTesting,
+  getAction,
+  getAllActions,
+  registerGlobal,
+} from '../../frontend/src/lib/actions/registry.js';
+import { EnvPickerDialog } from '../../frontend/src/components/dialogs/EnvPickerDialog.js';
+import type { LaunchEnvironmentResult } from '../../frontend/src/lib/launch-environment.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const GENERATED_AT = '2026-05-19T12:00:00.000Z';
+
+function freshOption(
+  overrides: Partial<EnvironmentOption> = {}
+): EnvironmentOption {
+  return {
+    schemaVersion: 1,
+    id: 'opt-fresh',
+    node: {
+      nodeId: 'local',
+      kind: 'local',
+      displayName: 'this host',
+      online: true,
+    },
+    capabilities: ['session:create:terminal'],
+    cwd: '/Users/dev/repos/relay-ide',
+    cwdMode: 'repo',
+    freshness: 'fresh',
+    repoInstance: {
+      repoInstanceId: 'local:/Users/dev/repos/relay-ide',
+      localPath: '/Users/dev/repos/relay-ide',
+      repoIdentity: 'github.com/donovan-yohan/relay-ide',
+      name: 'relay-ide',
+      currentBranch: 'nightly',
+      defaultBranch: 'master',
+    },
+    generatedAt: GENERATED_AT,
+    ...overrides,
+  };
+}
+
+function staleOption(
+  overrides: Partial<EnvironmentOption> = {}
+): EnvironmentOption {
+  return freshOption({
+    id: 'opt-stale',
+    freshness: 'stale',
+    degradedReasons: [
+      { kind: 'node-stale', lastSeenAt: '2026-05-19T11:00:00.000Z' },
+    ],
+    node: {
+      nodeId: 'mac',
+      kind: 'remote',
+      displayName: 'dev mac',
+      online: true,
+    },
+    ...overrides,
+  });
+}
+
+function offlineOption(
+  overrides: Partial<EnvironmentOption> = {}
+): EnvironmentOption {
+  return freshOption({
+    id: 'opt-offline',
+    freshness: 'offline',
+    degradedReasons: [
+      { kind: 'node-offline', message: 'node offline since 11:30' },
+    ],
+    node: {
+      nodeId: 'offline-host',
+      kind: 'remote',
+      displayName: 'offline-host',
+      online: false,
+    },
+    ...overrides,
+  });
+}
+
+describe('sessionStartWorkInEnv action meta', () => {
+  it('registers and is discoverable by the palette search terms', () => {
+    _resetForTesting();
+    registerGlobal([{ ...sessionStartWorkInEnv, handler: () => {} }]);
+    const registered = getAction('session.start-work-in-env');
+    expect(registered).toBeTruthy();
+    expect(registered?.label).toMatch(/start work in environment/i);
+    // The palette's `buildResults` matches against label, description, and
+    // aliases (lowercased substring). We assert the action would match the
+    // user-facing search terms from the issue acceptance criteria.
+    const matchSearch = (q: string): boolean => {
+      const a = registered!;
+      const needle = q.toLowerCase();
+      return (
+        a.label.toLowerCase().includes(needle) ||
+        a.description?.toLowerCase().includes(needle) ||
+        a.aliases?.some((alias) => alias.toLowerCase().includes(needle)) ===
+          true
+      );
+    };
+    expect(matchSearch('start work')).toBe(true);
+    expect(matchSearch('environment')).toBe(true);
+    expect(matchSearch('env')).toBe(true);
+    expect(matchSearch('node')).toBe(true);
+  });
+
+  it('appears alongside other session-category actions in getAllActions', () => {
+    _resetForTesting();
+    registerGlobal([{ ...sessionStartWorkInEnv, handler: () => {} }]);
+    expect(
+      getAllActions().some((a) => a.id === 'session.start-work-in-env')
+    ).toBe(true);
+  });
+});
+
+describe('<EnvPickerDialog /> (palette wiring)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function render(
+    props: React.ComponentProps<typeof EnvPickerDialog>
+  ) {
+    await act(async () => {
+      root.render(React.createElement(EnvPickerDialog, props));
+    });
+  }
+
+  it('does not render when closed', async () => {
+    await render({
+      open: false,
+      options: [freshOption()],
+      onClose: vi.fn(),
+    });
+    expect(container.querySelector('[data-testid="env-picker-dialog"]')).toBe(
+      null
+    );
+  });
+
+  it('renders the picker when open with default selection from pickDefaultEnvironment', async () => {
+    const a = freshOption({ id: 'a' });
+    const b = freshOption({ id: 'b' });
+    await render({
+      open: true,
+      options: [a, b],
+      // No activeTab → safe-defaults rule 3 picks first-fresh = 'a'.
+      activeTab: null,
+      history: [],
+      onClose: vi.fn(),
+    });
+    const row = container.querySelector(
+      '[data-option-id="a"]'
+    ) as HTMLElement | null;
+    expect(row).toBeTruthy();
+    expect(row?.getAttribute('aria-selected')).toBe('true');
+    const otherRow = container.querySelector(
+      '[data-option-id="b"]'
+    ) as HTMLElement | null;
+    expect(otherRow?.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('respects history when no active tab is present', async () => {
+    const a = freshOption({ id: 'a' });
+    const b = freshOption({ id: 'b' });
+    await render({
+      open: true,
+      options: [a, b],
+      activeTab: null,
+      history: [{ environmentId: 'b', lastUsedAt: GENERATED_AT }],
+      onClose: vi.fn(),
+    });
+    const bRow = container.querySelector(
+      '[data-option-id="b"]'
+    ) as HTMLElement | null;
+    expect(bRow?.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('selecting a fresh option invokes the launch hook with typed env IDs', async () => {
+    const fresh = freshOption({ id: 'opt-launch' });
+    const launch = vi.fn(async (): Promise<LaunchEnvironmentResult> => ({
+      kind: 'launched',
+      result: { session: undefined, error: null },
+    }));
+    const onClose = vi.fn();
+    const onLaunched = vi.fn();
+    await render({
+      open: true,
+      options: [fresh],
+      onClose,
+      onLaunched,
+      launch,
+    });
+    const row = container.querySelector(
+      '[data-option-id="opt-launch"]'
+    ) as HTMLElement;
+    expect(row).toBeTruthy();
+    await act(async () => {
+      row.click();
+    });
+    expect(launch).toHaveBeenCalledTimes(1);
+    const launchArgOption = launch.mock.calls[0]?.[0] as EnvironmentOption;
+    // Typed env identity propagates through the launch call — the contract
+    // child issues / agent tasks rely on (#615 acceptance criterion).
+    expect(launchArgOption.id).toBe('opt-launch');
+    expect(launchArgOption.node.nodeId).toBe('local');
+    expect(launchArgOption.repoInstance?.repoInstanceId).toBe(
+      'local:/Users/dev/repos/relay-ide'
+    );
+    expect(onLaunched).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks launch on a stale option and surfaces the typed reason', async () => {
+    const stale = staleOption({ id: 'opt-stale-block' });
+    const launch = vi.fn(async (): Promise<LaunchEnvironmentResult> => ({
+      kind: 'launched',
+      result: { session: undefined, error: null },
+    }));
+    const onClose = vi.fn();
+    await render({
+      open: true,
+      options: [stale],
+      onClose,
+      launch,
+    });
+    const row = container.querySelector(
+      '[data-option-id="opt-stale-block"]'
+    ) as HTMLElement;
+    await act(async () => {
+      row.click();
+    });
+    // CRITICAL: never silently switch nodes. The launch hook MUST NOT be
+    // called, the dialog MUST stay open, and a typed block reason must be
+    // surfaced for the user.
+    expect(launch).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    const block = container.querySelector(
+      '[data-testid="env-picker-dialog-block-reason"]'
+    );
+    expect(block).toBeTruthy();
+    expect(block?.textContent).toMatch(/stale/i);
+  });
+
+  it('blocks launch on an offline option with the offline reason', async () => {
+    const offline = offlineOption({ id: 'opt-offline-block' });
+    const launch = vi.fn();
+    const onClose = vi.fn();
+    await render({
+      open: true,
+      options: [offline],
+      onClose,
+      launch,
+    });
+    const row = container.querySelector(
+      '[data-option-id="opt-offline-block"]'
+    ) as HTMLElement;
+    await act(async () => {
+      row.click();
+    });
+    expect(launch).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    const block = container.querySelector(
+      '[data-testid="env-picker-dialog-block-reason"]'
+    );
+    expect(block?.textContent).toMatch(/offline/i);
+  });
+
+  it('closes via Escape from the picker', async () => {
+    const onClose = vi.fn();
+    await render({
+      open: true,
+      options: [freshOption()],
+      onClose,
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    await act(async () => {
+      listbox.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+      );
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes when the backdrop is clicked', async () => {
+    const onClose = vi.fn();
+    await render({
+      open: true,
+      options: [freshOption()],
+      onClose,
+    });
+    const overlay = container.querySelector(
+      '[data-testid="env-picker-dialog"]'
+    ) as HTMLElement;
+    await act(async () => {
+      overlay.click();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/components/launch-environment.test.ts
+++ b/test/components/launch-environment.test.ts
@@ -1,0 +1,154 @@
+// launch-environment (#630) — unit tests for the shared launch hook that
+// the palette dialog (#630) and the new-session dialog (#629) both call to
+// turn an `EnvironmentOption` into a `createSession` invocation.
+
+import { describe, expect, it, vi } from 'vitest';
+import type { EnvironmentOption } from '../../shared/environment-option.js';
+import {
+  canLaunchEnvironment,
+  environmentToCreateSessionOptions,
+  launchEnvironment,
+} from '../../frontend/src/lib/launch-environment.js';
+
+const GENERATED_AT = '2026-05-19T12:00:00.000Z';
+
+function freshOption(
+  overrides: Partial<EnvironmentOption> = {}
+): EnvironmentOption {
+  return {
+    schemaVersion: 1,
+    id: 'opt-fresh',
+    node: {
+      nodeId: 'local',
+      kind: 'local',
+      displayName: 'this host',
+      online: true,
+    },
+    capabilities: ['session:create:terminal'],
+    cwd: '/Users/dev/repos/relay-ide',
+    cwdMode: 'repo',
+    freshness: 'fresh',
+    repoInstance: {
+      repoInstanceId: 'local:/Users/dev/repos/relay-ide',
+      localPath: '/Users/dev/repos/relay-ide',
+      repoIdentity: 'github.com/donovan-yohan/relay-ide',
+      name: 'relay-ide',
+      currentBranch: 'nightly',
+      defaultBranch: 'master',
+    },
+    generatedAt: GENERATED_AT,
+    ...overrides,
+  };
+}
+
+describe('canLaunchEnvironment', () => {
+  it('returns true for fresh', () => {
+    expect(canLaunchEnvironment(freshOption({ freshness: 'fresh' }))).toBe(
+      true
+    );
+  });
+  it('returns false for stale', () => {
+    expect(canLaunchEnvironment(freshOption({ freshness: 'stale' }))).toBe(
+      false
+    );
+  });
+  it('returns false for offline', () => {
+    expect(canLaunchEnvironment(freshOption({ freshness: 'offline' }))).toBe(
+      false
+    );
+  });
+});
+
+describe('environmentToCreateSessionOptions', () => {
+  it('maps nodeId, cwd, repoPath from EnvironmentOption', () => {
+    const opts = environmentToCreateSessionOptions(freshOption());
+    expect(opts.nodeId).toBe('local');
+    expect(opts.cwd).toBe('/Users/dev/repos/relay-ide');
+    expect(opts.repoPath).toBe('/Users/dev/repos/relay-ide');
+    // Default type is `terminal` — the palette entry launches a bare shell
+    // unless the dialog overrides it.
+    expect(opts.type).toBe('terminal');
+  });
+
+  it('forwards worktree localPath as worktreePath when bench is present', () => {
+    const opt = freshOption({
+      bench: {
+        worktreeInstanceId: 'local:wt-1',
+        localPath: '/Users/dev/repos/relay-ide/.worktrees/feature',
+        branchName: 'feature/foo',
+      },
+    });
+    const opts = environmentToCreateSessionOptions(opt);
+    expect(opts.worktreePath).toBe(
+      '/Users/dev/repos/relay-ide/.worktrees/feature'
+    );
+  });
+
+  it('omits repoPath for free / non-git launches', () => {
+    const opt = freshOption({
+      cwdMode: 'free',
+      cwd: '/tmp/scratch',
+    });
+    delete (opt as { repoInstance?: unknown }).repoInstance;
+    const opts = environmentToCreateSessionOptions(opt);
+    expect(opts.repoPath).toBeUndefined();
+    expect(opts.cwd).toBe('/tmp/scratch');
+  });
+
+  it('forwards agent + type overrides', () => {
+    const opts = environmentToCreateSessionOptions(freshOption(), {
+      type: 'agent',
+      agent: 'claude',
+    });
+    expect(opts.type).toBe('agent');
+    expect(opts.agent).toBe('claude');
+  });
+});
+
+describe('launchEnvironment', () => {
+  it('calls createSession with mapped options for a fresh environment', async () => {
+    const createSession = vi.fn(async () => ({
+      session: undefined,
+      error: null,
+    }));
+    const result = await launchEnvironment(freshOption(), {}, createSession);
+    expect(result.kind).toBe('launched');
+    expect(createSession).toHaveBeenCalledTimes(1);
+    expect(createSession.mock.calls[0]?.[0]?.nodeId).toBe('local');
+  });
+
+  it('refuses to call createSession for a stale environment (typed block)', async () => {
+    const createSession = vi.fn(async () => ({
+      session: undefined,
+      error: null,
+    }));
+    const stale = freshOption({
+      freshness: 'stale',
+      degradedReasons: [{ kind: 'node-stale', lastSeenAt: GENERATED_AT }],
+    });
+    const result = await launchEnvironment(stale, {}, createSession);
+    expect(result.kind).toBe('blocked');
+    if (result.kind === 'blocked') {
+      expect(result.reason.code).toBe('stale');
+      expect(result.reason.degradedReasons?.[0]?.kind).toBe('node-stale');
+    }
+    expect(createSession).not.toHaveBeenCalled();
+  });
+
+  it('refuses to call createSession for an offline environment', async () => {
+    const createSession = vi.fn(async () => ({
+      session: undefined,
+      error: null,
+    }));
+    const offline = freshOption({
+      freshness: 'offline',
+      degradedReasons: [{ kind: 'node-offline' }],
+    });
+    const result = await launchEnvironment(offline, {}, createSession);
+    expect(result.kind).toBe('blocked');
+    if (result.kind === 'blocked') {
+      expect(result.reason.code).toBe('offline');
+    }
+    expect(createSession).not.toHaveBeenCalled();
+  });
+});

--- a/test/components/repo-to-environment.test.ts
+++ b/test/components/repo-to-environment.test.ts
@@ -1,0 +1,90 @@
+// repo-to-environment (#630) — stopgap adapter that derives the env picker
+// candidate list from the locally-known Repo projection. Verifies the
+// invariants the dialog and downstream launch hook rely on.
+
+import { describe, expect, it } from 'vitest';
+import {
+  repoToEnvironmentOption,
+  reposToEnvironmentOptions,
+} from '../../frontend/src/lib/repo-to-environment.js';
+import type { Repo } from '../../frontend/src/lib/types.js';
+
+const GENERATED_AT = '2026-05-19T12:00:00.000Z';
+
+function gitRepo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    path: '/Users/dev/repos/relay-ide',
+    name: 'relay-ide',
+    isGitRepo: true,
+    defaultBranch: 'master',
+    currentBranch: 'nightly',
+    localPath: '/Users/dev/repos/relay-ide',
+    nodeId: 'local',
+    repoIdentity: 'github.com/donovan-yohan/relay-ide',
+    repoInstanceId: 'local:/Users/dev/repos/relay-ide',
+    ...overrides,
+  };
+}
+
+describe('repoToEnvironmentOption', () => {
+  it('maps a git repo to a repo-cwdMode option with the canonical repoIdentity', () => {
+    const opt = repoToEnvironmentOption(gitRepo(), GENERATED_AT);
+    expect(opt.cwdMode).toBe('repo');
+    expect(opt.repoInstance?.repoIdentity).toBe(
+      'github.com/donovan-yohan/relay-ide'
+    );
+    expect(opt.repoInstance?.localPath).toBe('/Users/dev/repos/relay-ide');
+    expect(opt.freshness).toBe('fresh');
+    expect(opt.node.nodeId).toBe('local');
+  });
+
+  it('maps a non-git directory to a free-cwd option with no repoInstance', () => {
+    const opt = repoToEnvironmentOption(
+      gitRepo({
+        isGitRepo: false,
+        name: 'scratch',
+        path: '/tmp/scratch',
+        localPath: '/tmp/scratch',
+      }),
+      GENERATED_AT
+    );
+    expect(opt.cwdMode).toBe('free');
+    expect(opt.repoInstance).toBeUndefined();
+  });
+
+  it('defaults nodeId to DEFAULT_LOCAL_NODE_ID when missing', () => {
+    const opt = repoToEnvironmentOption(
+      gitRepo({ nodeId: undefined as unknown as Repo['nodeId'] }),
+      GENERATED_AT
+    );
+    expect(opt.node.nodeId).toBe('local');
+  });
+});
+
+describe('reposToEnvironmentOptions', () => {
+  it('produces one option per repo + a trailing free home option', () => {
+    const opts = reposToEnvironmentOptions(
+      [gitRepo()],
+      GENERATED_AT
+    );
+    expect(opts.length).toBe(2);
+    expect(opts[1]?.cwdMode).toBe('free');
+    expect(opts[1]?.cwd).toBe('~');
+  });
+
+  it('produces unique ids per option', () => {
+    const opts = reposToEnvironmentOptions(
+      [
+        gitRepo({ repoInstanceId: 'a' }),
+        gitRepo({
+          repoInstanceId: 'b',
+          path: '/Users/dev/other',
+          localPath: '/Users/dev/other',
+        }),
+      ],
+      GENERATED_AT
+    );
+    const ids = new Set(opts.map((o) => o.id));
+    expect(ids.size).toBe(opts.length);
+  });
+});

--- a/test/components/repo-to-environment.test.ts
+++ b/test/components/repo-to-environment.test.ts
@@ -72,6 +72,17 @@ describe('reposToEnvironmentOptions', () => {
     expect(opts[1]?.cwd).toBe('~');
   });
 
+  it('is deterministic for identical inputs (stable refs for React memoization)', () => {
+    // Gemini PR #646: defaulting `generatedAt` to `new Date().toISOString()`
+    // would re-stamp every option on every call and break memoization at
+    // every call site. The signature now requires the timestamp, and the
+    // resulting `generatedAt` field MUST be identical when the input is.
+    const a = reposToEnvironmentOptions([gitRepo()], GENERATED_AT);
+    const b = reposToEnvironmentOptions([gitRepo()], GENERATED_AT);
+    expect(a).toEqual(b);
+    expect(a.every((opt) => opt.generatedAt === GENERATED_AT)).toBe(true);
+  });
+
   it('produces unique ids per option', () => {
     const opts = reposToEnvironmentOptions(
       [


### PR DESCRIPTION
## Summary

Adds the command-palette action **"start work in environment…"** that opens the environment picker (PR #643) with a safe default from `pickDefaultEnvironment` (PR #642). The dialog enforces the #615 invariant that stale/offline environments **cannot silently switch nodes** — the launch is blocked and the typed degraded reason is surfaced inline.

- New `EnvPickerDialog` (`frontend/src/components/dialogs/EnvPickerDialog.tsx`) wraps the pure presentational `EnvironmentPicker` with default-selection + block-on-stale + launch wiring.
- New `launchEnvironment` (`frontend/src/lib/launch-environment.ts`) is the shared launch adapter that maps an `EnvironmentOption` onto `createAgentSession`. #629's new-session dialog can reuse it as-is.
- `reposToEnvironmentOptions` is a stopgap candidate source built from the local sessions store until the full env-inventory feed lands.
- Palette action `session.start-work-in-env` registered with aliases (`start work`, `environment`, `env`, `node`, `where`, `pick env`).
- `ModalRoute` learns the `env-picker` variant. Intentionally no URL representation — the picker requires the live inventory and cannot be deep-linked safely yet.

Refs:
- Parent epic: #615 (environment picker for node/repo/worktree launch context)
- Wave 1: #639 RepoIdentity aggregation, #640 typed env IDs
- Wave 2: #642 safe defaults, #643 picker UI component

## Acceptance criteria (issue #630)

- [x] Palette action is visible and discoverable
- [x] Action opens the picker
- [x] Launching from the picker creates a session/tab via shared `createAgentSession` path
- [x] Covered by an integration test (`test/components/EnvPickerPaletteAction.test.ts`, 10 cases)

## Test plan

- [x] `npx vitest run test/components/EnvPickerPaletteAction.test.ts` — 10 pass
- [x] `npx vitest run test/components/launch-environment.test.ts test/components/repo-to-environment.test.ts test/shared/safe-defaults.test.ts` — full chain green
- [x] `npm run check` — 0 type errors, 0 new lint errors
- [ ] Manual: open palette, type "start work", confirm picker opens, fresh option launches, stale option shows blocked-with-reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Start Work in Environment" command-palette action to explicitly pick a node, repository, and working directory before launching a session.
  * New environment picker dialog with support for terminal and agent session types.
  * Freshness validation prevents launching in stale or offline environments.

* **Tests**
  * Added integration and unit tests for environment picker and launch functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->