### PR TITLE
feat(env): wire env picker into Workbench block create (#631)

### DIFF
--- a/frontend/src/workbench/WorkbenchBlockCreateDialog.tsx
+++ b/frontend/src/workbench/WorkbenchBlockCreateDialog.tsx
@@ -282,7 +282,11 @@ export function WorkbenchBlockCreateDialog({
           </div>
         ) : null}
         <EnvironmentPicker
-          options={[...filteredCandidates]}
+          // `filteredCandidates` is already a fresh array from useMemo above
+          // (or the unmodified `candidates` passthrough); no spread needed.
+          // EnvironmentPicker accepts a mutable `EnvironmentOption[]`, so
+          // we narrow the readonly prop with a cast rather than copying.
+          options={filteredCandidates as EnvironmentOption[]}
           {...(selectedId !== undefined
             ? { selectedOptionId: selectedId }
             : {})}

--- a/frontend/src/workbench/WorkbenchBlockCreateDialog.tsx
+++ b/frontend/src/workbench/WorkbenchBlockCreateDialog.tsx
@@ -1,0 +1,317 @@
+/**
+ * WorkbenchBlockCreateDialog (#631) — block-create entry point that wires the
+ * EnvironmentPicker (#627) and safe-default selection (#628) into Workbench
+ * block creation.
+ *
+ * Scope:
+ *   - Renders the existing `EnvironmentPicker` against the supplied candidate
+ *     option list. Defaults via `pickDefaultEnvironment`; if the default fails
+ *     ("no fresh candidate", "active tab is degraded/missing"), the dialog
+ *     surfaces the typed reason and blocks `create` instead of silently
+ *     substituting a different node. This preserves the #615 acceptance
+ *     criterion that launches never silently jump machines.
+ *   - On confirm, calls `onCreate({ descriptor, environment, picker })` with a
+ *     typed `WorkbenchBlockEnvironmentRef` built from the chosen option. The
+ *     caller (WorkbenchCanvas / hub) owns the actual block-add side effect.
+ *   - Pure presentational + small local state. No API calls, no router hooks,
+ *     no Zustand store subscriptions. Mirrors the existing TUI aesthetic from
+ *     `DESIGN.md` (lowercase, monospace, no emoji, outline-only chrome).
+ *
+ * What this component does NOT do:
+ *   - Persist the block to the layout — that lives in the canvas layer.
+ *   - Create a session — slice 5 / #629's launch hook does that. The dialog
+ *     only chooses the env and emits the typed descriptor.
+ *   - Validate the kind picker against capability-bit requirements at the
+ *     dialog layer; the renderer + BlockHost already gate on capabilities at
+ *     mount time.
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { EnvironmentPicker } from '../components/EnvironmentPicker.js';
+import type { EnvironmentOption } from '../../../shared/environment-option.js';
+import {
+  pickDefaultEnvironment,
+  type ActiveTabContext,
+  type EnvironmentHistoryEntry,
+  type PickDefaultEnvironmentErrorReason,
+} from '../../../shared/safe-defaults.js';
+import type { RelayCapabilityBit } from '../../../shared/security-policy.js';
+import type { WorkbenchBlockDescriptor } from '../../../shared/workbench-block-types.js';
+import {
+  buildBlockEnvironmentRef,
+  type WorkbenchBlockEnvironmentRef,
+} from '../../../shared/workbench-block-environment.js';
+import './workbench-block-create-dialog.css';
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+/**
+ * Args fired by the dialog on confirm. Carries the typed env metadata so the
+ * caller can attach it to a fresh descriptor (or hand it to #629's launch
+ * hook) without ever re-deriving env IDs from prose strings.
+ */
+export interface WorkbenchBlockCreateRequest {
+  /** Title the user entered (lowercase per DESIGN.md). */
+  title: string;
+  /** Block kind chosen in the dialog. */
+  kind: WorkbenchBlockDescriptor['kind'];
+  /** Typed env metadata destined for `descriptor.environment`. */
+  environment: WorkbenchBlockEnvironmentRef;
+  /** Original picker option, retained for adapters that want capability bits etc. */
+  option: EnvironmentOption;
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface WorkbenchBlockCreateDialogProps {
+  /** Picker candidate list, supplied by the caller from the env store. */
+  candidates: readonly EnvironmentOption[];
+  /** Active tab context for safe-default selection. */
+  activeTab?: ActiveTabContext | null;
+  /** Last-used env history, newest-first by caller convention. */
+  history?: readonly EnvironmentHistoryEntry[];
+  /** Capability bits the block kind requires; forwarded to the picker filter. */
+  requiredCapabilities?: readonly RelayCapabilityBit[];
+  /** Fired on confirm. */
+  onCreate: (req: WorkbenchBlockCreateRequest) => void;
+  /** Fired on cancel / escape. */
+  onCancel: () => void;
+  /**
+   * Wall-clock ISO timestamp. Injected so tests can pin createdAt. Defaults
+   * to `new Date().toISOString()` at the call site of buildBlockEnvironmentRef.
+   */
+  nowIso?: () => string;
+  /**
+   * Default block kind to preselect. The dialog leaves the user free to
+   * change it before confirming.
+   */
+  defaultKind?: WorkbenchBlockDescriptor['kind'];
+}
+
+// ---------------------------------------------------------------------------
+// Copy
+// ---------------------------------------------------------------------------
+
+const SUPPORTED_KINDS: WorkbenchBlockDescriptor['kind'][] = [
+  'terminal',
+  'agent',
+  'file',
+  'markdown',
+  'work-context',
+  'artifact',
+  'custom',
+];
+
+function describeDefaultError(
+  reason: PickDefaultEnvironmentErrorReason
+): string {
+  switch (reason) {
+    case 'no-candidates':
+      return 'no environments available — pair a node first';
+    case 'active-tab-missing':
+      return "the active tab's environment is no longer paired — pick a different one";
+    case 'active-tab-degraded':
+      return "the active tab's environment is stale or offline — pick a different one";
+    case 'all-degraded':
+      return 'no fresh environments available — try again once a node comes online';
+    default: {
+      const _exhaustive: never = reason;
+      return String(_exhaustive);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dialog
+// ---------------------------------------------------------------------------
+
+export function WorkbenchBlockCreateDialog({
+  candidates,
+  activeTab = null,
+  history = [],
+  requiredCapabilities,
+  onCreate,
+  onCancel,
+  nowIso,
+  defaultKind = 'terminal',
+}: WorkbenchBlockCreateDialogProps): React.ReactElement {
+  // Default selection. We compute once on first render via lazy initialiser
+  // so navigation by the user (clicking another row) wins over the default.
+  const initial = useMemo(
+    () =>
+      pickDefaultEnvironment({
+        activeTab,
+        history,
+        candidates,
+      }),
+    // Run only on mount — once the user starts navigating the picker, we keep
+    // their choice. If `candidates` changes upstream (e.g. a node goes
+    // online), they can re-open the dialog.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  const initialSelected = initial.kind === 'ok' ? initial.option.id : undefined;
+
+  const [selectedId, setSelectedId] = useState<string | undefined>(
+    initialSelected
+  );
+  const [kind, setKind] =
+    useState<WorkbenchBlockDescriptor['kind']>(defaultKind);
+  const [title, setTitle] = useState('');
+
+  const defaultErrorMessage =
+    initial.kind === 'error' ? describeDefaultError(initial.reason) : null;
+
+  // Filter candidates by required capabilities at the picker layer. Resolves
+  // up-front so the picker never offers an option that fails the block's
+  // capability requirements (which would just hit a DeniedCard later).
+  const filteredCandidates = useMemo(() => {
+    if (!requiredCapabilities || requiredCapabilities.length === 0) {
+      return candidates;
+    }
+    const required = new Set(requiredCapabilities);
+    return candidates.filter((c) => {
+      const advertised = new Set(c.capabilities);
+      for (const bit of required) {
+        if (!advertised.has(bit)) return false;
+      }
+      return true;
+    });
+  }, [candidates, requiredCapabilities]);
+
+  const selectedOption = useMemo(
+    () => filteredCandidates.find((c) => c.id === selectedId),
+    [filteredCandidates, selectedId]
+  );
+
+  const handleSelect = useCallback((opt: EnvironmentOption) => {
+    setSelectedId(opt.id);
+  }, []);
+
+  const canCreate =
+    selectedOption !== undefined &&
+    selectedOption.freshness === 'fresh' &&
+    title.trim().length > 0;
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      if (!selectedOption || !canCreate) return;
+      const createdAt = nowIso ? nowIso() : new Date().toISOString();
+      const env = buildBlockEnvironmentRef({
+        option: selectedOption,
+        createdAt,
+      });
+      onCreate({
+        title: title.trim(),
+        kind,
+        environment: env,
+        option: selectedOption,
+      });
+    },
+    [canCreate, kind, nowIso, onCreate, selectedOption, title]
+  );
+
+  return (
+    <form
+      className="workbench-block-create-dialog"
+      data-testid="workbench-block-create-dialog"
+      onSubmit={handleSubmit}
+      aria-label="create workbench block"
+    >
+      <div className="workbench-block-create-dialog__header">
+        <span className="workbench-block-create-dialog__title">
+          create block
+        </span>
+        <button
+          type="button"
+          className="workbench-block-create-dialog__cancel"
+          onClick={onCancel}
+          aria-label="cancel"
+        >
+          esc
+        </button>
+      </div>
+
+      <label className="workbench-block-create-dialog__field">
+        <span className="workbench-block-create-dialog__label">title</span>
+        <input
+          type="text"
+          className="workbench-block-create-dialog__input"
+          data-testid="workbench-block-create-title"
+          value={title}
+          onChange={(e) => setTitle(e.currentTarget.value)}
+          placeholder="lowercase title"
+          spellCheck={false}
+          autoComplete="off"
+        />
+      </label>
+
+      <label className="workbench-block-create-dialog__field">
+        <span className="workbench-block-create-dialog__label">kind</span>
+        <select
+          className="workbench-block-create-dialog__select"
+          data-testid="workbench-block-create-kind"
+          value={kind}
+          onChange={(e) =>
+            setKind(e.currentTarget.value as WorkbenchBlockDescriptor['kind'])
+          }
+        >
+          {SUPPORTED_KINDS.map((k) => (
+            <option key={k} value={k}>
+              {k}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div className="workbench-block-create-dialog__picker-section">
+        <div className="workbench-block-create-dialog__label">environment</div>
+        {defaultErrorMessage !== null ? (
+          <div
+            className="workbench-block-create-dialog__default-error"
+            role="alert"
+            data-testid="workbench-block-create-default-error"
+          >
+            {defaultErrorMessage}
+          </div>
+        ) : null}
+        <EnvironmentPicker
+          options={[...filteredCandidates]}
+          {...(selectedId !== undefined
+            ? { selectedOptionId: selectedId }
+            : {})}
+          onSelect={handleSelect}
+          onCancel={onCancel}
+          autoFocusSearch={false}
+        />
+      </div>
+
+      <div className="workbench-block-create-dialog__actions">
+        <button
+          type="submit"
+          className="workbench-block-create-dialog__confirm"
+          data-testid="workbench-block-create-confirm"
+          disabled={!canCreate}
+          aria-disabled={!canCreate}
+        >
+          create
+        </button>
+        <button
+          type="button"
+          className="workbench-block-create-dialog__cancel-btn"
+          onClick={onCancel}
+        >
+          cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export default WorkbenchBlockCreateDialog;

--- a/frontend/src/workbench/WorkbenchBlockCreateDialog.tsx
+++ b/frontend/src/workbench/WorkbenchBlockCreateDialog.tsx
@@ -26,7 +26,7 @@
  *     mount time.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { EnvironmentPicker } from '../components/EnvironmentPicker.js';
 import type { EnvironmentOption } from '../../../shared/environment-option.js';
 import {
@@ -139,33 +139,39 @@ export function WorkbenchBlockCreateDialog({
   nowIso,
   defaultKind = 'terminal',
 }: WorkbenchBlockCreateDialogProps): React.ReactElement {
-  // Default selection. We compute once on first render via lazy initialiser
-  // so navigation by the user (clicking another row) wins over the default.
-  const initial = useMemo(
+  // Default-selection result. Recomputed when inputs change so the typed
+  // error message stays accurate as candidates load / nodes come online.
+  const defaultResult = useMemo(
     () =>
       pickDefaultEnvironment({
         activeTab,
         history,
         candidates,
       }),
-    // Run only on mount — once the user starts navigating the picker, we keep
-    // their choice. If `candidates` changes upstream (e.g. a node goes
-    // online), they can re-open the dialog.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [activeTab, history, candidates]
   );
 
-  const initialSelected = initial.kind === 'ok' ? initial.option.id : undefined;
-
   const [selectedId, setSelectedId] = useState<string | undefined>(
-    initialSelected
+    defaultResult.kind === 'ok' ? defaultResult.option.id : undefined
   );
   const [kind, setKind] =
     useState<WorkbenchBlockDescriptor['kind']>(defaultKind);
   const [title, setTitle] = useState('');
 
+  // If we didn't have a selection yet (candidates loaded after mount, or the
+  // active tab's node just turned fresh), apply the first valid default that
+  // becomes available. Explicit user navigation always wins because we only
+  // fire while `selectedId === undefined`.
+  useEffect(() => {
+    if (selectedId === undefined && defaultResult.kind === 'ok') {
+      setSelectedId(defaultResult.option.id);
+    }
+  }, [defaultResult, selectedId]);
+
   const defaultErrorMessage =
-    initial.kind === 'error' ? describeDefaultError(initial.reason) : null;
+    defaultResult.kind === 'error'
+      ? describeDefaultError(defaultResult.reason)
+      : null;
 
   // Filter candidates by required capabilities at the picker layer. Resolves
   // up-front so the picker never offers an option that fails the block's

--- a/frontend/src/workbench/WorkbenchCanvas.tsx
+++ b/frontend/src/workbench/WorkbenchCanvas.tsx
@@ -542,8 +542,14 @@ export function WorkbenchCanvas({
   // ---------------------------------------------------------------------------
 
   const [createOpen, setCreateOpen] = useState(false);
+  // Gate the create button on `!isLoading` so the UI does not invite a click
+  // before the layout has hydrated. The handler also seeds an empty layout
+  // for the no-layout case (defense in depth), but hiding the button during
+  // load matches what the empty-state UI already implies.
   const showCreate =
-    environmentCandidates !== undefined && environmentCandidates.length > 0;
+    !isLoading &&
+    environmentCandidates !== undefined &&
+    environmentCandidates.length > 0;
 
   const handleCreate = useCallback(
     (req: WorkbenchBlockCreateRequest) => {

--- a/frontend/src/workbench/WorkbenchCanvas.tsx
+++ b/frontend/src/workbench/WorkbenchCanvas.tsx
@@ -38,8 +38,18 @@ import type {
   WorkbenchBlockContext,
   WorkbenchBlockDescriptor,
 } from '../../../shared/workbench-block-types.js';
+import type { EnvironmentOption } from '../../../shared/environment-option.js';
+import type {
+  ActiveTabContext,
+  EnvironmentHistoryEntry,
+} from '../../../shared/safe-defaults.js';
 import { fetchWorkbenchLayout, putWorkbenchLayout } from '../lib/api.js';
 import { BlockHost } from './BlockHost.js';
+import {
+  WorkbenchBlockCreateDialog,
+  type WorkbenchBlockCreateRequest,
+} from './WorkbenchBlockCreateDialog.js';
+import { buildBlockDescriptor } from './block-create-helpers.js';
 import './workbench-canvas.css';
 
 // ---------------------------------------------------------------------------
@@ -327,6 +337,20 @@ function CanvasBlock({
 
 export interface WorkbenchCanvasProps {
   workspaceId: string;
+  /**
+   * Environment options the create-block dialog will offer. Supplied by the
+   * caller (env store / picker provider). Empty array disables creation with
+   * a typed default-error inside the dialog.
+   *
+   * Optional for backward compatibility — when omitted, the create button is
+   * hidden so the canvas continues to render existing blocks without the
+   * #631 entry point.
+   */
+  environmentCandidates?: readonly EnvironmentOption[];
+  /** Active tab context for `pickDefaultEnvironment`. */
+  activeTab?: ActiveTabContext | null;
+  /** Last-used env history, newest-first by caller convention. */
+  environmentHistory?: readonly EnvironmentHistoryEntry[];
 }
 
 /**
@@ -348,6 +372,9 @@ export interface WorkbenchCanvasProps {
  */
 export function WorkbenchCanvas({
   workspaceId,
+  environmentCandidates,
+  activeTab = null,
+  environmentHistory = [],
 }: WorkbenchCanvasProps): React.ReactElement {
   const queryClient = useQueryClient();
   const queryKey = workbenchLayoutQueryKey(workspaceId);
@@ -511,13 +538,78 @@ export function WorkbenchCanvas({
   );
 
   // ---------------------------------------------------------------------------
+  // Create block (#631) — open dialog, persist on confirm
+  // ---------------------------------------------------------------------------
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const showCreate =
+    environmentCandidates !== undefined && environmentCandidates.length > 0;
+
+  const handleCreate = useCallback(
+    (req: WorkbenchBlockCreateRequest) => {
+      const descriptor = buildBlockDescriptor({
+        request: req,
+        idFactory: () =>
+          typeof crypto !== 'undefined' && 'randomUUID' in crypto
+            ? crypto.randomUUID()
+            : `block-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      });
+      const placement: WorkbenchBlockPlacement = {
+        descriptor,
+        // Stagger new blocks so consecutive creates don't fully overlap.
+        position: {
+          x: 24 + (((layoutRef.current?.blocks.length ?? 0) * 24) % 240),
+          y: 24 + (((layoutRef.current?.blocks.length ?? 0) * 24) % 240),
+        },
+        size: { width: 480, height: 320 },
+        minimized: false,
+      };
+      applyUpdate((prev) => ({ ...prev, blocks: [...prev.blocks, placement] }));
+      setCreateOpen(false);
+    },
+    [applyUpdate]
+  );
+
+  // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
+
+  const createButton = showCreate ? (
+    <button
+      type="button"
+      className="workbench-canvas__create-btn"
+      onClick={() => setCreateOpen(true)}
+      data-testid="workbench-canvas-create-btn"
+      aria-label="create block"
+    >
+      + create block
+    </button>
+  ) : null;
+
+  const createDialog =
+    showCreate && createOpen ? (
+      <div
+        className="workbench-canvas__create-overlay"
+        data-testid="workbench-canvas-create-overlay"
+        role="dialog"
+        aria-modal="true"
+      >
+        <WorkbenchBlockCreateDialog
+          candidates={environmentCandidates ?? []}
+          activeTab={activeTab}
+          history={environmentHistory}
+          onCreate={handleCreate}
+          onCancel={() => setCreateOpen(false)}
+        />
+      </div>
+    ) : null;
 
   if (isLoading) {
     return (
       <div className="workbench-canvas">
         <div className="workbench-canvas__loading">loading workbench…</div>
+        {createButton}
+        {createDialog}
       </div>
     );
   }
@@ -528,6 +620,8 @@ export function WorkbenchCanvas({
         <div className="workbench-canvas__empty">
           no blocks in this workspace
         </div>
+        {createButton}
+        {createDialog}
       </div>
     );
   }
@@ -556,6 +650,8 @@ export function WorkbenchCanvas({
             onClose={handleClose}
           />
         ))}
+        {createButton}
+        {createDialog}
       </div>
     </DndContext>
   );

--- a/frontend/src/workbench/WorkbenchCanvas.tsx
+++ b/frontend/src/workbench/WorkbenchCanvas.tsx
@@ -554,20 +554,32 @@ export function WorkbenchCanvas({
             ? crypto.randomUUID()
             : `block-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       });
+      const existing = layoutRef.current;
+      const blockCount = existing?.blocks.length ?? 0;
       const placement: WorkbenchBlockPlacement = {
         descriptor,
         // Stagger new blocks so consecutive creates don't fully overlap.
         position: {
-          x: 24 + (((layoutRef.current?.blocks.length ?? 0) * 24) % 240),
-          y: 24 + (((layoutRef.current?.blocks.length ?? 0) * 24) % 240),
+          x: 24 + ((blockCount * 24) % 240),
+          y: 24 + ((blockCount * 24) % 240),
         },
         size: { width: 480, height: 320 },
         minimized: false,
       };
-      applyUpdate((prev) => ({ ...prev, blocks: [...prev.blocks, placement] }));
+      // If no layout has hydrated yet, seed an empty one so the first create
+      // is not silently dropped by `applyUpdate`'s `if (!prev) return`.
+      const next: WorkbenchLayout = existing
+        ? { ...existing, blocks: [...existing.blocks, placement] }
+        : {
+            schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+            workspaceScope: { id: workspaceId },
+            blocks: [placement],
+          };
+      setLayout(next);
+      debouncedPersist(next);
       setCreateOpen(false);
     },
-    [applyUpdate]
+    [debouncedPersist, workspaceId]
   );
 
   // ---------------------------------------------------------------------------

--- a/frontend/src/workbench/block-create-helpers.ts
+++ b/frontend/src/workbench/block-create-helpers.ts
@@ -1,0 +1,166 @@
+/**
+ * Block-create helpers (#631) — translate a `WorkbenchBlockCreateRequest`
+ * (from the picker dialog) into a typed `WorkbenchBlockDescriptor` that the
+ * canvas can persist.
+ *
+ * Lives outside the dialog so the canvas (or any future block-spawn surface:
+ * command palette, agent-authored creates via #629's launch hook) can reuse
+ * the exact same translation. The function is pure and synchronous.
+ */
+
+import type {
+  AgentBlockDescriptor,
+  ArtifactBlockDescriptor,
+  CustomBlockDescriptor,
+  FileBlockDescriptor,
+  MarkdownBlockDescriptor,
+  TerminalBlockDescriptor,
+  WorkbenchBlockDescriptor,
+  WorkContextBlockDescriptor,
+} from '../../../shared/workbench-block-types.js';
+import type { WorkbenchBlockEnvironmentRef } from '../../../shared/workbench-block-environment.js';
+import type { WorkbenchBlockCreateRequest } from './WorkbenchBlockCreateDialog.js';
+
+export interface BuildBlockDescriptorInput {
+  request: WorkbenchBlockCreateRequest;
+  /** Stable id factory — usually `crypto.randomUUID`, but injected for tests. */
+  idFactory: () => string;
+}
+
+/**
+ * Translate a create-dialog request into a typed descriptor.
+ *
+ * Every variant carries the same `environment` envelope so resume/attach can
+ * reconstruct the launch context via `resolveBlockEnvironment`. Per-kind
+ * `meta` shapes get safe defaults that the renderer host can refine:
+ *
+ *  - terminal: sessionRef with `nodeId`/`cwd` from the env; sessionId is
+ *    deliberately left as `pending:<blockId>` so #629's launch hook can swap
+ *    it for the real id once the session is created.
+ *  - agent: actorRef placeholder pending the actor identity resolution that
+ *    #629 / slice 5 owns.
+ *  - markdown: empty content; the user can fill it in inline.
+ *  - file/artifact/work-context/custom: minimal stubs — full wiring lives in
+ *    the respective slices.
+ */
+export function buildBlockDescriptor(
+  input: BuildBlockDescriptorInput
+): WorkbenchBlockDescriptor {
+  const { request, idFactory } = input;
+  const id = idFactory();
+  const base = {
+    id,
+    title: request.title,
+    capabilityRequirements: [] as never[],
+    environment: request.environment,
+  };
+
+  switch (request.kind) {
+    case 'terminal': {
+      const desc: TerminalBlockDescriptor = {
+        ...base,
+        kind: 'terminal',
+        capabilityRequirements: ['session:create:terminal'],
+        meta: {
+          sessionRef: {
+            nodeId: request.environment.nodeId,
+            sessionId: `pending:${id}`,
+            tabKind: 'terminal',
+            cwd: request.environment.cwd,
+          },
+        },
+      };
+      return desc;
+    }
+    case 'agent': {
+      const desc: AgentBlockDescriptor = {
+        ...base,
+        kind: 'agent',
+        capabilityRequirements: ['session:create:agent'],
+        meta: {
+          actorRef: {
+            kind: 'actor',
+            id: `pending:${id}`,
+            displayName: request.title,
+          },
+        },
+      };
+      return desc;
+    }
+    case 'file': {
+      const desc: FileBlockDescriptor = {
+        ...base,
+        kind: 'file',
+        capabilityRequirements: ['rpc:fs:read'],
+        meta: {
+          fileRef: {
+            kind: 'file',
+            id: `rpc:fs:${request.environment.nodeId}:${encodeURIComponent(request.environment.cwd)}`,
+            displayName: request.title,
+          },
+          mode: 'read',
+        },
+      };
+      return desc;
+    }
+    case 'markdown': {
+      const desc: MarkdownBlockDescriptor = {
+        ...base,
+        kind: 'markdown',
+        meta: { content: '' },
+      };
+      return desc;
+    }
+    case 'work-context': {
+      const desc: WorkContextBlockDescriptor = {
+        ...base,
+        kind: 'work-context',
+        meta: { workContextRef: `pending:${id}` },
+      };
+      return desc;
+    }
+    case 'artifact': {
+      const desc: ArtifactBlockDescriptor = {
+        ...base,
+        kind: 'artifact',
+        meta: {
+          artifactRef: {
+            id: `pending:${id}`,
+            kind: 'file',
+            title: request.title,
+            privacy: {
+              classification: 'internal',
+              retention: 'session',
+              rawPayloadStored: false,
+              redaction: { redacted: false, strategy: 'none', classes: [] },
+            },
+          },
+        },
+      };
+      return desc;
+    }
+    case 'custom': {
+      const desc: CustomBlockDescriptor = {
+        ...base,
+        kind: 'custom',
+        meta: { rendererId: 'pending', props: {} },
+      };
+      return desc;
+    }
+    default: {
+      const _exhaustive: never = request.kind;
+      throw new Error(`unhandled block kind: ${String(_exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * Read the typed env metadata off a descriptor, returning `undefined` for
+ * legacy blocks. Convenience wrapper so call sites don't reach into private
+ * shape directly.
+ */
+export function readBlockEnvironment(descriptor: {
+  environment?: WorkbenchBlockEnvironmentRef;
+}): WorkbenchBlockEnvironmentRef | undefined {
+  return descriptor.environment;
+}

--- a/frontend/src/workbench/workbench-block-create-dialog.css
+++ b/frontend/src/workbench/workbench-block-create-dialog.css
@@ -1,0 +1,110 @@
+/* WorkbenchBlockCreateDialog — TUI aesthetic per DESIGN.md.
+   Outline-only chrome, monospace, lowercase, zero border-radius, no emoji. */
+
+.workbench-block-create-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  padding: var(--space-md);
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-base);
+  min-width: 480px;
+  max-width: 720px;
+}
+
+.workbench-block-create-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: var(--space-sm);
+}
+
+.workbench-block-create-dialog__title {
+  font-size: var(--font-size-base);
+  color: var(--text);
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.workbench-block-create-dialog__cancel {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  padding: var(--space-2xs) var(--space-sm);
+  cursor: pointer;
+}
+
+.workbench-block-create-dialog__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.workbench-block-create-dialog__label {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  letter-spacing: 0.05em;
+}
+
+.workbench-block-create-dialog__input,
+.workbench-block-create-dialog__select {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-base);
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: var(--space-2xs) var(--space-sm);
+}
+
+.workbench-block-create-dialog__input:focus,
+.workbench-block-create-dialog__select:focus {
+  outline: none;
+  border-color: var(--text-muted);
+}
+
+.workbench-block-create-dialog__picker-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+}
+
+.workbench-block-create-dialog__default-error {
+  font-size: var(--font-size-xs);
+  color: var(--status-error);
+  border: 1px solid color-mix(in srgb, var(--status-error) 40%, transparent);
+  padding: var(--space-2xs) var(--space-sm);
+}
+
+.workbench-block-create-dialog__actions {
+  display: flex;
+  gap: var(--space-sm);
+  justify-content: flex-end;
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-sm);
+}
+
+.workbench-block-create-dialog__confirm,
+.workbench-block-create-dialog__cancel-btn {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: var(--space-2xs) var(--space-md);
+  cursor: pointer;
+}
+
+.workbench-block-create-dialog__confirm:disabled {
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+
+.workbench-block-create-dialog__confirm:not(:disabled):hover {
+  border-color: var(--text);
+}

--- a/frontend/src/workbench/workbench-canvas.css
+++ b/frontend/src/workbench/workbench-canvas.css
@@ -153,3 +153,33 @@
   font-size: var(--font-size-sm, 0.8125rem);
   color: var(--text-muted);
 }
+
+/* ===== Create-block entry point (#631) ===== */
+
+.workbench-canvas__create-btn {
+  position: absolute;
+  bottom: var(--space-md, 12px);
+  right: var(--space-md, 12px);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs, 0.75rem);
+  color: var(--text);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  padding: var(--space-2xs, 4px) var(--space-sm, 8px);
+  cursor: pointer;
+  z-index: 20;
+}
+
+.workbench-canvas__create-btn:hover {
+  border-color: var(--text);
+}
+
+.workbench-canvas__create-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--bg) 80%, transparent);
+  z-index: 30;
+}

--- a/shared/workbench-block-environment.ts
+++ b/shared/workbench-block-environment.ts
@@ -184,10 +184,7 @@ export function isWorkbenchBlockEnvironmentRef(
   ) {
     return false;
   }
-  if (
-    value.repoInstanceId !== undefined &&
-    !hasString(value.repoInstanceId)
-  ) {
+  if (value.repoInstanceId !== undefined && !hasString(value.repoInstanceId)) {
     return false;
   }
   if (
@@ -205,7 +202,10 @@ export function isWorkbenchBlockEnvironmentRef(
     return false;
   }
   // Invariant: bench implies repoInstance.
-  if (value.worktreeInstanceId !== undefined && value.repoInstanceId === undefined) {
+  if (
+    value.worktreeInstanceId !== undefined &&
+    value.repoInstanceId === undefined
+  ) {
     return false;
   }
   // Invariant: cwdMode 'free' MUST NOT carry a repoInstanceId.
@@ -259,6 +259,8 @@ export type ResolveBlockEnvironmentResult =
  *      the create-time bits → `block-on-launch / capability-shrunk`.
  *   5. Otherwise → `ok`.
  */
+const BLOCK_ON_LAUNCH = 'block-on-launch' as const;
+
 export function resolveBlockEnvironment(
   environment: WorkbenchBlockEnvironmentRef | undefined,
   candidates: readonly EnvironmentOption[]
@@ -268,14 +270,14 @@ export function resolveBlockEnvironment(
   const match = candidates.find((c) => c.id === environment.pickerOptionId);
   if (match === undefined) {
     return {
-      kind: 'block-on-launch',
+      kind: BLOCK_ON_LAUNCH,
       reason: 'option-missing',
       ref: environment,
     };
   }
   if (match.freshness === 'offline') {
     return {
-      kind: 'block-on-launch',
+      kind: BLOCK_ON_LAUNCH,
       reason: 'option-offline',
       ref: environment,
       candidate: match,
@@ -283,7 +285,7 @@ export function resolveBlockEnvironment(
   }
   if (match.freshness === 'stale') {
     return {
-      kind: 'block-on-launch',
+      kind: BLOCK_ON_LAUNCH,
       reason: 'option-stale',
       ref: environment,
       candidate: match,
@@ -295,7 +297,7 @@ export function resolveBlockEnvironment(
   );
   if (!stillSatisfied) {
     return {
-      kind: 'block-on-launch',
+      kind: BLOCK_ON_LAUNCH,
       reason: 'capability-shrunk',
       ref: environment,
       candidate: match,

--- a/shared/workbench-block-environment.ts
+++ b/shared/workbench-block-environment.ts
@@ -149,10 +149,6 @@ function hasString(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0;
 }
 
-function isOptionalString(value: unknown): value is string | undefined {
-  return value === undefined || typeof value === 'string';
-}
-
 function isCwdMode(value: unknown): value is EnvironmentCwdMode {
   return (
     value === 'repo' || value === 'free' || value === 'explicit-outside-repo'
@@ -198,9 +194,9 @@ export function isWorkbenchBlockEnvironmentRef(
   if (!value.capabilities.every(isRelayCapabilityBit)) return false;
   if (!hasString(value.pickerOptionId)) return false;
   if (typeof value.pickerVersion !== 'number') return false;
-  if (!isOptionalString(value.createdAt) || !hasString(value.createdAt)) {
-    return false;
-  }
+  // `createdAt` is required on the interface; check directly for a non-empty
+  // string rather than chaining `isOptionalString` + `hasString`.
+  if (!hasString(value.createdAt)) return false;
   // Invariant: bench implies repoInstance.
   if (
     value.worktreeInstanceId !== undefined &&

--- a/shared/workbench-block-environment.ts
+++ b/shared/workbench-block-environment.ts
@@ -1,0 +1,311 @@
+/**
+ * Workbench block environment metadata (#631, parent epic #615).
+ *
+ * Typed envelope describing the environment a Workbench block was launched in,
+ * persisted alongside the block descriptor so resume/attach can rebuild the
+ * exact launch context per `docs/WORKBENCH_BOUNDARY.md`.
+ *
+ * Why this shape (and not a free-form path string):
+ *   - `WORKBENCH_BOUNDARY.md` requires node-scoped identity. `nodeId +
+ *     repoIdentity + repoInstanceId + worktreeInstanceId` form a stable typed
+ *     handle that survives "same repo, different path on different machines".
+ *   - `cwd` and `cwdMode` distinguish in-repo / non-git / explicit-outside
+ *     launches without inheriting repo-only actions on a non-git tab
+ *     (#615 acceptance criterion).
+ *   - `capabilities` is the snapshot of capability bits the picker advertised
+ *     at create time. Resume can compare against the live env's bits and emit
+ *     `block-on-launch` with a typed reason if the bit set has shrunk.
+ *   - `pickerVersion` records the `EnvironmentOption.schemaVersion` so a
+ *     future widening of the picker schema can detect older blocks.
+ *
+ * Forward / backward compatibility:
+ *   - The block descriptor's `environment` field is OPTIONAL. Legacy blocks
+ *     (saved before #631 landed) deserialise with no environment metadata;
+ *     `isLegacyBlockEnvironment` returns `true` for the missing case so the
+ *     resume path can choose a migration policy explicitly instead of
+ *     silently substituting a different node (the #615 non-goal).
+ *   - Adding new fields here MUST keep round-trip identity for older values.
+ *     `WORKBENCH_BLOCK_ENVIRONMENT_SCHEMA_VERSION` bumps when an existing field
+ *     changes shape; pure additions stay on the current version with optional
+ *     fields.
+ */
+
+import {
+  isEnvironmentOption,
+  type EnvironmentCwdMode,
+  type EnvironmentOption,
+} from './environment-option.js';
+import type {
+  NodeId,
+  RepoIdentity,
+  RepoInstanceId,
+  WorktreeInstanceId,
+} from './identity.js';
+import {
+  isRelayCapabilityBit,
+  type RelayCapabilityBit,
+} from './security-policy.js';
+
+export const WORKBENCH_BLOCK_ENVIRONMENT_SCHEMA_VERSION = 1 as const;
+
+/**
+ * Typed environment metadata stored on a Workbench block descriptor.
+ *
+ * Field semantics:
+ *   - `nodeId`: the Node the block targets. Required; the operator's "where
+ *     does this block live" answer.
+ *   - `repoIdentity`: normalized RepoIdentity (e.g. `github.com/owner/repo`)
+ *     when the launch was repo-anchored. Null/absent for free / non-git cwd.
+ *   - `repoInstanceId`: the node-scoped RepoInstance id from
+ *     `shared/identity.ts#createRepoInstanceId`. Present iff the launch is
+ *     anchored to a real on-disk checkout.
+ *   - `worktreeInstanceId`: the WorktreeInstance id when the launch lives
+ *     inside a git worktree (Bench). Implies `repoInstanceId` is set.
+ *   - `benchId`: alias for `worktreeInstanceId` per the WorkbenchBoundary
+ *     vocabulary. We carry both to keep cross-doc grep clean; the picker
+ *     fills both with the same value, but downstream code may evolve.
+ *   - `cwd`: the absolute cwd on the target node. Stored verbatim — the hub
+ *     resolves it against the node. NEVER used as a global identifier.
+ *   - `cwdMode`: matches `EnvironmentOption.cwdMode` so resume can keep
+ *     repo-only actions off a free / non-git cwd.
+ *   - `capabilities`: capability bits the picker advertised at create time.
+ *   - `pickerOptionId`: stable id of the picker option chosen at create time.
+ *     The picker uses this to detect the original choice on resume.
+ *   - `pickerVersion`: `EnvironmentOption.schemaVersion` at create time.
+ *   - `createdAt`: ISO 8601 timestamp; used for audit and "you picked this on
+ *     <date>" UI copy. Resume does NOT use it for decisions.
+ */
+export interface WorkbenchBlockEnvironmentRef {
+  schemaVersion: typeof WORKBENCH_BLOCK_ENVIRONMENT_SCHEMA_VERSION;
+  nodeId: NodeId;
+  repoIdentity?: RepoIdentity | null;
+  repoInstanceId?: RepoInstanceId;
+  worktreeInstanceId?: WorktreeInstanceId;
+  /** Alias for `worktreeInstanceId` to match WORKBENCH_BOUNDARY.md `Bench` noun. */
+  benchId?: WorktreeInstanceId;
+  cwd: string;
+  cwdMode: EnvironmentCwdMode;
+  capabilities: RelayCapabilityBit[];
+  pickerOptionId: string;
+  pickerVersion: number;
+  createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+export interface BuildBlockEnvironmentInput {
+  /** Picker option the user (or agent default) chose. */
+  option: EnvironmentOption;
+  /** Wall-clock ISO timestamp. Injected for deterministic tests. */
+  createdAt: string;
+}
+
+/**
+ * Build a typed `WorkbenchBlockEnvironmentRef` from a picker option.
+ *
+ * Pure: no I/O, no clock reads (caller supplies `createdAt`). The function
+ * captures only typed IDs and capability bits — never derived path strings
+ * outside what `cwd` already carries. Repeated calls with the same input
+ * produce identical output (round-trip safe).
+ */
+export function buildBlockEnvironmentRef(
+  input: BuildBlockEnvironmentInput
+): WorkbenchBlockEnvironmentRef {
+  const { option, createdAt } = input;
+  const ref: WorkbenchBlockEnvironmentRef = {
+    schemaVersion: WORKBENCH_BLOCK_ENVIRONMENT_SCHEMA_VERSION,
+    nodeId: option.node.nodeId,
+    cwd: option.cwd,
+    cwdMode: option.cwdMode,
+    capabilities: [...option.capabilities],
+    pickerOptionId: option.id,
+    pickerVersion: option.schemaVersion,
+    createdAt,
+  };
+  if (option.repoInstance) {
+    ref.repoInstanceId = option.repoInstance.repoInstanceId;
+    ref.repoIdentity = option.repoInstance.repoIdentity;
+  } else {
+    ref.repoIdentity = null;
+  }
+  if (option.bench) {
+    ref.worktreeInstanceId = option.bench.worktreeInstanceId;
+    ref.benchId = option.bench.worktreeInstanceId;
+  }
+  return ref;
+}
+
+// ---------------------------------------------------------------------------
+// Guards
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === 'string';
+}
+
+function isCwdMode(value: unknown): value is EnvironmentCwdMode {
+  return (
+    value === 'repo' || value === 'free' || value === 'explicit-outside-repo'
+  );
+}
+
+/**
+ * Structural guard for `WorkbenchBlockEnvironmentRef`. Validates the schema
+ * version, required scalars, capability bits (against the closed enum), and
+ * `cwdMode`. Optional fields are checked only when present.
+ *
+ * Used by the layout deserialiser to recognise the typed `environment` field
+ * on a block descriptor without leaving it stranded in the `_unknown` bag.
+ */
+export function isWorkbenchBlockEnvironmentRef(
+  value: unknown
+): value is WorkbenchBlockEnvironmentRef {
+  if (!isRecord(value)) return false;
+  if (value.schemaVersion !== WORKBENCH_BLOCK_ENVIRONMENT_SCHEMA_VERSION) {
+    return false;
+  }
+  if (!hasString(value.nodeId)) return false;
+  if (!hasString(value.cwd)) return false;
+  if (!isCwdMode(value.cwdMode)) return false;
+  if (
+    value.repoIdentity !== undefined &&
+    value.repoIdentity !== null &&
+    typeof value.repoIdentity !== 'string'
+  ) {
+    return false;
+  }
+  if (
+    value.repoInstanceId !== undefined &&
+    !hasString(value.repoInstanceId)
+  ) {
+    return false;
+  }
+  if (
+    value.worktreeInstanceId !== undefined &&
+    !hasString(value.worktreeInstanceId)
+  ) {
+    return false;
+  }
+  if (value.benchId !== undefined && !hasString(value.benchId)) return false;
+  if (!Array.isArray(value.capabilities)) return false;
+  if (!value.capabilities.every(isRelayCapabilityBit)) return false;
+  if (!hasString(value.pickerOptionId)) return false;
+  if (typeof value.pickerVersion !== 'number') return false;
+  if (!isOptionalString(value.createdAt) || !hasString(value.createdAt)) {
+    return false;
+  }
+  // Invariant: bench implies repoInstance.
+  if (value.worktreeInstanceId !== undefined && value.repoInstanceId === undefined) {
+    return false;
+  }
+  // Invariant: cwdMode 'free' MUST NOT carry a repoInstanceId.
+  if (value.cwdMode === 'free' && value.repoInstanceId !== undefined) {
+    return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Resume / launch helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Outcome of resolving a block's stored env metadata against the currently
+ * available picker options.
+ *
+ * Discriminated union — callers MUST handle every variant:
+ *   - `ok`: found the same typed option; launch may proceed.
+ *   - `block-on-launch`: typed env exists but the picker no longer offers the
+ *     matching option fresh. UI must surface the typed reason and refuse to
+ *     silently substitute a different node.
+ *   - `legacy-no-environment`: block predates #631; caller chooses migration
+ *     policy (prompt user, default to active tab, etc.). NEVER silently
+ *     substitutes.
+ */
+export type ResolveBlockEnvironmentResult =
+  | { kind: 'ok'; option: EnvironmentOption }
+  | {
+      kind: 'block-on-launch';
+      reason:
+        | 'option-missing'
+        | 'option-stale'
+        | 'option-offline'
+        | 'capability-shrunk';
+      ref: WorkbenchBlockEnvironmentRef;
+      candidate?: EnvironmentOption;
+    }
+  | { kind: 'legacy-no-environment' };
+
+/**
+ * Resolve the typed env metadata on a block descriptor against the currently
+ * known picker options. Pure; no clock reads; never silently switches nodes.
+ *
+ * Decision order:
+ *   1. `environment` missing → `legacy-no-environment`.
+ *   2. Picker option for `pickerOptionId` not in `candidates`
+ *      → `block-on-launch / option-missing`.
+ *   3. Option present but not `fresh` → `block-on-launch / option-stale | offline`.
+ *   4. Option present, fresh, but advertised capability set no longer covers
+ *      the create-time bits → `block-on-launch / capability-shrunk`.
+ *   5. Otherwise → `ok`.
+ */
+export function resolveBlockEnvironment(
+  environment: WorkbenchBlockEnvironmentRef | undefined,
+  candidates: readonly EnvironmentOption[]
+): ResolveBlockEnvironmentResult {
+  if (environment === undefined) return { kind: 'legacy-no-environment' };
+
+  const match = candidates.find((c) => c.id === environment.pickerOptionId);
+  if (match === undefined) {
+    return {
+      kind: 'block-on-launch',
+      reason: 'option-missing',
+      ref: environment,
+    };
+  }
+  if (match.freshness === 'offline') {
+    return {
+      kind: 'block-on-launch',
+      reason: 'option-offline',
+      ref: environment,
+      candidate: match,
+    };
+  }
+  if (match.freshness === 'stale') {
+    return {
+      kind: 'block-on-launch',
+      reason: 'option-stale',
+      ref: environment,
+      candidate: match,
+    };
+  }
+  const advertised = new Set(match.capabilities);
+  const stillSatisfied = environment.capabilities.every((bit) =>
+    advertised.has(bit)
+  );
+  if (!stillSatisfied) {
+    return {
+      kind: 'block-on-launch',
+      reason: 'capability-shrunk',
+      ref: environment,
+      candidate: match,
+    };
+  }
+  return { kind: 'ok', option: match };
+}
+
+// ---------------------------------------------------------------------------
+// Re-export for callers who want the option guard alongside the ref guard
+// ---------------------------------------------------------------------------
+
+export { isEnvironmentOption };

--- a/shared/workbench-block-types.ts
+++ b/shared/workbench-block-types.ts
@@ -32,6 +32,7 @@ import type {
   WorkContext,
   WorkContextRef,
 } from './work-context.js';
+import type { WorkbenchBlockEnvironmentRef } from './workbench-block-environment.js';
 
 // ---------------------------------------------------------------------------
 // Re-exported re-used types for convenience
@@ -138,6 +139,20 @@ interface WorkbenchBlockDescriptorBase {
    * Typed as `RelayCapabilityBit` (closed enum) to prevent invalid bit strings.
    */
   capabilityRequirements: ReadonlyArray<RelayCapabilityBit>;
+  /**
+   * Typed environment metadata captured at block create time (#631).
+   *
+   * Optional for backward compatibility — blocks persisted before #631 landed
+   * have no `environment` field and the resume path treats them as legacy
+   * (see `resolveBlockEnvironment` in `shared/workbench-block-environment.ts`).
+   * Any new block created through the create dialog MUST set this field; the
+   * picker is the only blessed source.
+   *
+   * Stores typed IDs (nodeId, repoIdentity, repoInstanceId, worktreeInstanceId,
+   * cwd, cwdMode, capabilities). Never free-form path strings beyond `cwd`,
+   * which is node-scoped and resolved by the hub at attach time.
+   */
+  environment?: WorkbenchBlockEnvironmentRef;
 }
 
 /** Renders a PTY-backed terminal session. */

--- a/test/components/WorkbenchBlockEnvPicker.test.ts
+++ b/test/components/WorkbenchBlockEnvPicker.test.ts
@@ -1,0 +1,265 @@
+// @vitest-environment happy-dom
+//
+// WorkbenchBlockCreateDialog tests (#631) — verifies the create-block flow
+// wires EnvironmentPicker + pickDefaultEnvironment per the parent epic
+// #615 acceptance criteria.
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EnvironmentOption } from '../../shared/environment-option.js';
+import { WorkbenchBlockCreateDialog } from '../../frontend/src/workbench/WorkbenchBlockCreateDialog.js';
+import {
+  WORKBENCH_BLOCK_ENVIRONMENT_SCHEMA_VERSION,
+  buildBlockEnvironmentRef,
+} from '../../shared/workbench-block-environment.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const NOW = '2026-05-19T12:00:00.000Z';
+
+function freshOption(
+  overrides: Partial<EnvironmentOption> = {}
+): EnvironmentOption {
+  return {
+    schemaVersion: 1,
+    id: 'opt-relay-nightly',
+    node: {
+      nodeId: 'local',
+      kind: 'local',
+      displayName: 'this host',
+      online: true,
+    },
+    capabilities: ['session:create:terminal', 'rpc:fs:read'],
+    cwd: '/Users/dev/repos/relay-ide',
+    cwdMode: 'repo',
+    freshness: 'fresh',
+    repoInstance: {
+      repoInstanceId: 'local:%2FUsers%2Fdev%2Frepos%2Frelay-ide',
+      localPath: '/Users/dev/repos/relay-ide',
+      repoIdentity: 'github.com/donovan-yohan/relay-ide',
+      name: 'relay-ide',
+      currentBranch: 'nightly',
+      defaultBranch: 'master',
+    },
+    generatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function staleOption(
+  overrides: Partial<EnvironmentOption> = {}
+): EnvironmentOption {
+  return freshOption({
+    id: 'opt-stale',
+    freshness: 'stale',
+    degradedReasons: [
+      { kind: 'node-stale', lastSeenAt: '2026-05-19T11:00:00.000Z' },
+    ],
+    ...overrides,
+  });
+}
+
+function offlineOption(
+  overrides: Partial<EnvironmentOption> = {}
+): EnvironmentOption {
+  return freshOption({
+    id: 'opt-offline',
+    node: { nodeId: 'mac', kind: 'remote', displayName: 'mac', online: false },
+    freshness: 'offline',
+    degradedReasons: [{ kind: 'node-offline' }],
+    ...overrides,
+  });
+}
+
+describe('<WorkbenchBlockCreateDialog />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function render(
+    props: React.ComponentProps<typeof WorkbenchBlockCreateDialog>
+  ) {
+    await act(async () => {
+      root.render(React.createElement(WorkbenchBlockCreateDialog, props));
+    });
+  }
+
+  it('renders the EnvironmentPicker with options', async () => {
+    await render({
+      candidates: [freshOption(), staleOption()],
+      onCreate: vi.fn(),
+      onCancel: vi.fn(),
+    });
+    expect(
+      container.querySelector('[data-testid="env-picker-search"]')
+    ).toBeTruthy();
+    expect(container.querySelectorAll('[role="option"]').length).toBe(2);
+  });
+
+  it('preselects the option chosen by pickDefaultEnvironment (history hit)', async () => {
+    const fresh = freshOption();
+    await render({
+      candidates: [staleOption(), fresh],
+      activeTab: null,
+      history: [{ environmentId: fresh.id, lastUsedAt: NOW }],
+      onCreate: vi.fn(),
+      onCancel: vi.fn(),
+    });
+    const selected = container.querySelector(
+      '[role="option"][aria-selected="true"]'
+    );
+    expect(selected?.getAttribute('data-option-id')).toBe(fresh.id);
+  });
+
+  it('blocks create when no fresh candidate exists and surfaces a typed reason', async () => {
+    const onCreate = vi.fn();
+    await render({
+      candidates: [staleOption(), offlineOption()],
+      onCreate,
+      onCancel: vi.fn(),
+    });
+    const errorBanner = container.querySelector(
+      '[data-testid="workbench-block-create-default-error"]'
+    );
+    expect(errorBanner?.textContent).toContain('no fresh');
+    // Title input + stale selection MUST still not enable create.
+    const titleInput = container.querySelector(
+      '[data-testid="workbench-block-create-title"]'
+    ) as HTMLInputElement;
+    await act(async () => {
+      titleInput.value = 'attempt';
+      titleInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const confirm = container.querySelector(
+      '[data-testid="workbench-block-create-confirm"]'
+    ) as HTMLButtonElement;
+    expect(confirm.disabled).toBe(true);
+  });
+
+  it('never silently switches nodes when the active tab is degraded', async () => {
+    const fresh = freshOption();
+    const stale = staleOption({ id: 'opt-active-stale' });
+    const onCreate = vi.fn();
+    await render({
+      candidates: [stale, fresh],
+      activeTab: { environment: stale },
+      onCreate,
+      onCancel: vi.fn(),
+    });
+    // The default error MUST appear (active tab degraded) and the picker MUST
+    // start with no preselection — the user has to make an explicit choice.
+    const errorBanner = container.querySelector(
+      '[data-testid="workbench-block-create-default-error"]'
+    );
+    expect(errorBanner).toBeTruthy();
+    expect(errorBanner?.textContent).toContain('stale');
+    const selected = container.querySelector(
+      '[role="option"][aria-selected="true"]'
+    );
+    expect(selected).toBeNull();
+  });
+
+  it('emits typed env IDs on confirm — no free-form path strings beyond cwd', async () => {
+    const onCreate = vi.fn();
+    const fresh = freshOption();
+    await render({
+      candidates: [fresh],
+      history: [{ environmentId: fresh.id, lastUsedAt: NOW }],
+      onCreate,
+      onCancel: vi.fn(),
+      nowIso: () => NOW,
+    });
+    const titleInput = container.querySelector(
+      '[data-testid="workbench-block-create-title"]'
+    ) as HTMLInputElement;
+    // React's onChange listens via SyntheticEvent on the native input event.
+    // Use the native setter so React picks the value up reliably under happy-dom.
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      'value'
+    )!.set!;
+    await act(async () => {
+      setter.call(titleInput, 'shell');
+      titleInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const confirmBtn = container.querySelector(
+      '[data-testid="workbench-block-create-confirm"]'
+    ) as HTMLButtonElement;
+    expect(confirmBtn.disabled).toBe(false);
+    await act(async () => {
+      confirmBtn.click();
+    });
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    const req = onCreate.mock.calls[0]?.[0];
+    expect(req.title).toBe('shell');
+    expect(req.kind).toBe('terminal');
+    expect(req.environment.schemaVersion).toBe(
+      WORKBENCH_BLOCK_ENVIRONMENT_SCHEMA_VERSION
+    );
+    expect(req.environment.nodeId).toBe('local');
+    expect(req.environment.repoIdentity).toBe(
+      'github.com/donovan-yohan/relay-ide'
+    );
+    expect(req.environment.repoInstanceId).toBe(
+      'local:%2FUsers%2Fdev%2Frepos%2Frelay-ide'
+    );
+    expect(req.environment.cwd).toBe('/Users/dev/repos/relay-ide');
+    expect(req.environment.pickerOptionId).toBe(fresh.id);
+    // Sanity: the matching helper produces an identical envelope.
+    expect(req.environment).toEqual(
+      buildBlockEnvironmentRef({ option: fresh, createdAt: NOW })
+    );
+  });
+
+  it('filters candidates by required capabilities', async () => {
+    await render({
+      candidates: [
+        freshOption({
+          id: 'opt-no-git',
+          capabilities: ['session:create:terminal'],
+        }),
+        freshOption({
+          id: 'opt-with-git',
+          capabilities: ['session:create:terminal', 'rpc:git:write'],
+        }),
+      ],
+      requiredCapabilities: ['rpc:git:write'],
+      onCreate: vi.fn(),
+      onCancel: vi.fn(),
+    });
+    const rows = container.querySelectorAll('[role="option"]');
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.getAttribute('data-option-id')).toBe('opt-with-git');
+  });
+
+  it('cancels via the cancel button', async () => {
+    const onCancel = vi.fn();
+    await render({
+      candidates: [freshOption()],
+      onCreate: vi.fn(),
+      onCancel,
+    });
+    const buttons = Array.from(
+      container.querySelectorAll('.workbench-block-create-dialog__cancel-btn')
+    ) as HTMLButtonElement[];
+    expect(buttons.length).toBeGreaterThan(0);
+    await act(async () => {
+      buttons[0]!.click();
+    });
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/test/shared/workbench-block-env-roundtrip.test.ts
+++ b/test/shared/workbench-block-env-roundtrip.test.ts
@@ -1,0 +1,464 @@
+/**
+ * Round-trip + resume tests for Workbench block environment metadata (#631).
+ *
+ * Covers (per #631 acceptance):
+ *   1. `buildBlockEnvironmentRef` captures ONLY typed env IDs from a picker
+ *      option — never free-form path strings beyond `cwd`.
+ *   2. `isWorkbenchBlockEnvironmentRef` rejects malformed inputs (bad schema
+ *      version, missing required fields, wrong cwdMode, capability strings
+ *      not in the closed enum, free + repoInstance invariant violation).
+ *   3. JSON.stringify → JSON.parse round-trip preserves every typed ID and
+ *      the picker option id / version. Repo, worktree, and free / non-git
+ *      shapes all survive.
+ *   4. `WorkbenchBlockDescriptor.environment` round-trips through the
+ *      layout serialiser/deserialiser without landing in `_unknown`.
+ *   5. Resume / attach via `resolveBlockEnvironment` returns `ok` when the
+ *      same picker option is fresh, `block-on-launch` with a typed reason
+ *      when the option is stale/offline/missing/capability-shrunk, and
+ *      `legacy-no-environment` when the descriptor predates #631.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { EnvironmentOption } from '../../shared/environment-option.js';
+import {
+  WORKBENCH_BLOCK_ENVIRONMENT_SCHEMA_VERSION,
+  buildBlockEnvironmentRef,
+  isWorkbenchBlockEnvironmentRef,
+  resolveBlockEnvironment,
+  type WorkbenchBlockEnvironmentRef,
+} from '../../shared/workbench-block-environment.js';
+import {
+  WORKBENCH_LAYOUT_SCHEMA_VERSION,
+  deserialiseWorkbenchLayout,
+  serialiseWorkbenchLayout,
+  type WorkbenchLayout,
+  type WorkbenchBlockPlacement,
+} from '../../shared/workbench-layout-types.js';
+
+const CREATED_AT = '2026-05-19T12:00:00.000Z';
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function repoOption(overrides: Partial<EnvironmentOption> = {}): EnvironmentOption {
+  return {
+    schemaVersion: 1,
+    id: 'opt-relay-nightly',
+    node: { nodeId: 'local', kind: 'local', displayName: 'this host', online: true },
+    capabilities: ['session:create:terminal', 'rpc:fs:read', 'rpc:git:read'],
+    cwd: '/Users/dev/repos/relay-ide',
+    cwdMode: 'repo',
+    freshness: 'fresh',
+    repoInstance: {
+      repoInstanceId: 'local:%2FUsers%2Fdev%2Frepos%2Frelay-ide',
+      localPath: '/Users/dev/repos/relay-ide',
+      repoIdentity: 'github.com/donovan-yohan/relay-ide',
+      name: 'relay-ide',
+      currentBranch: 'nightly',
+      defaultBranch: 'master',
+    },
+    generatedAt: CREATED_AT,
+    ...overrides,
+  };
+}
+
+function worktreeOption(): EnvironmentOption {
+  return {
+    ...repoOption(),
+    id: 'opt-relay-631-worktree',
+    cwd: '/Users/dev/repos/relay-ide/.worktrees/631',
+    bench: {
+      worktreeInstanceId:
+        'local:%2FUsers%2Fdev%2Frepos%2Frelay-ide%2F.worktrees%2F631',
+      localPath: '/Users/dev/repos/relay-ide/.worktrees/631',
+      branchName: 'feature/631-workbench-picker',
+      displayName: '631-workbench-picker',
+    },
+  };
+}
+
+function freeOption(): EnvironmentOption {
+  return {
+    schemaVersion: 1,
+    id: 'opt-free-scratch',
+    node: { nodeId: 'local', kind: 'local', online: true },
+    capabilities: ['session:create:terminal'],
+    cwd: '/tmp/scratch',
+    cwdMode: 'free',
+    freshness: 'fresh',
+    generatedAt: CREATED_AT,
+  };
+}
+
+function placementWithEnv(
+  env: WorkbenchBlockEnvironmentRef | undefined,
+  id = 'block-1'
+): WorkbenchBlockPlacement {
+  return {
+    descriptor: {
+      kind: 'terminal',
+      id,
+      title: 'shell',
+      capabilityRequirements: ['session:create:terminal'],
+      meta: {
+        sessionRef: {
+          nodeId: 'local',
+          sessionId: 'sess-1',
+          globalSessionId: 'local:sess-1',
+          tabKind: 'terminal',
+          cwd: env?.cwd ?? '/',
+        },
+      },
+      ...(env !== undefined ? { environment: env } : {}),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test scaffold
+    } as any,
+    position: { x: 0, y: 0 },
+    size: { width: 400, height: 200 },
+    minimized: false,
+  };
+}
+
+function makeLayout(blocks: WorkbenchBlockPlacement[]): WorkbenchLayout {
+  return {
+    schemaVersion: WORKBENCH_LAYOUT_SCHEMA_VERSION,
+    workspaceScope: { id: 'ws:test' },
+    blocks,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildBlockEnvironmentRef — captures only typed IDs
+// ---------------------------------------------------------------------------
+
+describe('buildBlockEnvironmentRef', () => {
+  it('captures nodeId, repoIdentity, repoInstanceId, cwd, cwdMode from a repo option', () => {
+    const env = buildBlockEnvironmentRef({
+      option: repoOption(),
+      createdAt: CREATED_AT,
+    });
+    expect(env.schemaVersion).toBe(WORKBENCH_BLOCK_ENVIRONMENT_SCHEMA_VERSION);
+    expect(env.nodeId).toBe('local');
+    expect(env.repoIdentity).toBe('github.com/donovan-yohan/relay-ide');
+    expect(env.repoInstanceId).toBe(
+      'local:%2FUsers%2Fdev%2Frepos%2Frelay-ide'
+    );
+    expect(env.cwd).toBe('/Users/dev/repos/relay-ide');
+    expect(env.cwdMode).toBe('repo');
+    expect(env.pickerOptionId).toBe('opt-relay-nightly');
+    expect(env.pickerVersion).toBe(1);
+    expect(env.createdAt).toBe(CREATED_AT);
+    expect(env.capabilities).toEqual([
+      'session:create:terminal',
+      'rpc:fs:read',
+      'rpc:git:read',
+    ]);
+  });
+
+  it('captures benchId / worktreeInstanceId when the picker option carries a bench', () => {
+    const env = buildBlockEnvironmentRef({
+      option: worktreeOption(),
+      createdAt: CREATED_AT,
+    });
+    expect(env.worktreeInstanceId).toBe(
+      'local:%2FUsers%2Fdev%2Frepos%2Frelay-ide%2F.worktrees%2F631'
+    );
+    expect(env.benchId).toBe(env.worktreeInstanceId);
+    // benchId implies repoInstanceId is set.
+    expect(env.repoInstanceId).toBeDefined();
+  });
+
+  it('represents a free / non-git cwd with null repoIdentity and no repoInstanceId', () => {
+    const env = buildBlockEnvironmentRef({
+      option: freeOption(),
+      createdAt: CREATED_AT,
+    });
+    expect(env.cwdMode).toBe('free');
+    expect(env.repoIdentity).toBeNull();
+    expect(env.repoInstanceId).toBeUndefined();
+    expect(env.worktreeInstanceId).toBeUndefined();
+    expect(env.benchId).toBeUndefined();
+  });
+
+  it('contains no free-form path string fields beyond cwd', () => {
+    const env = buildBlockEnvironmentRef({
+      option: repoOption(),
+      createdAt: CREATED_AT,
+    });
+    // Allow-list of known string fields; reject any new free-form path bag.
+    // If a future change adds a `localPath` or similar verbatim path it MUST
+    // be a typed ID or it fails this test (regression on the #615 acceptance
+    // criterion that agent tasks specify env by typed IDs not prose paths).
+    const allowedStringKeys = new Set([
+      'nodeId',
+      'repoIdentity',
+      'repoInstanceId',
+      'worktreeInstanceId',
+      'benchId',
+      'cwd',
+      'cwdMode',
+      'pickerOptionId',
+      'createdAt',
+    ]);
+    for (const [key, value] of Object.entries(env)) {
+      if (typeof value === 'string') {
+        expect(allowedStringKeys.has(key)).toBe(true);
+      }
+    }
+  });
+
+  it('does not mutate its input option', () => {
+    const opt = repoOption();
+    const before = JSON.stringify(opt);
+    buildBlockEnvironmentRef({ option: opt, createdAt: CREATED_AT });
+    expect(JSON.stringify(opt)).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isWorkbenchBlockEnvironmentRef — structural guard
+// ---------------------------------------------------------------------------
+
+describe('isWorkbenchBlockEnvironmentRef', () => {
+  it('accepts a valid repo ref', () => {
+    const env = buildBlockEnvironmentRef({
+      option: repoOption(),
+      createdAt: CREATED_AT,
+    });
+    expect(isWorkbenchBlockEnvironmentRef(env)).toBe(true);
+  });
+
+  it('accepts a valid free ref', () => {
+    const env = buildBlockEnvironmentRef({
+      option: freeOption(),
+      createdAt: CREATED_AT,
+    });
+    expect(isWorkbenchBlockEnvironmentRef(env)).toBe(true);
+  });
+
+  it('rejects a wrong schemaVersion', () => {
+    const env = buildBlockEnvironmentRef({
+      option: repoOption(),
+      createdAt: CREATED_AT,
+    });
+    const broken = { ...env, schemaVersion: 99 };
+    expect(isWorkbenchBlockEnvironmentRef(broken)).toBe(false);
+  });
+
+  it('rejects missing nodeId', () => {
+    const env = buildBlockEnvironmentRef({
+      option: repoOption(),
+      createdAt: CREATED_AT,
+    });
+    const broken: Record<string, unknown> = { ...env };
+    delete broken.nodeId;
+    expect(isWorkbenchBlockEnvironmentRef(broken)).toBe(false);
+  });
+
+  it('rejects a capability string that is not in the closed enum', () => {
+    const env = buildBlockEnvironmentRef({
+      option: repoOption(),
+      createdAt: CREATED_AT,
+    });
+    const broken = { ...env, capabilities: ['not:a:real:bit'] };
+    expect(isWorkbenchBlockEnvironmentRef(broken)).toBe(false);
+  });
+
+  it('rejects cwdMode: free combined with a repoInstanceId', () => {
+    const env = buildBlockEnvironmentRef({
+      option: freeOption(),
+      createdAt: CREATED_AT,
+    });
+    const broken = { ...env, repoInstanceId: 'local:%2Ffoo' };
+    expect(isWorkbenchBlockEnvironmentRef(broken)).toBe(false);
+  });
+
+  it('rejects a worktreeInstanceId without a repoInstanceId', () => {
+    const env = buildBlockEnvironmentRef({
+      option: repoOption(),
+      createdAt: CREATED_AT,
+    });
+    const broken: Record<string, unknown> = {
+      ...env,
+      worktreeInstanceId: 'local:%2Fwt',
+    };
+    delete broken.repoInstanceId;
+    expect(isWorkbenchBlockEnvironmentRef(broken)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSON round-trip — typed IDs survive
+// ---------------------------------------------------------------------------
+
+describe('JSON serialize/deserialize round-trip', () => {
+  it('preserves every typed ID for a repo-anchored env', () => {
+    const env = buildBlockEnvironmentRef({
+      option: repoOption(),
+      createdAt: CREATED_AT,
+    });
+    const restored = JSON.parse(JSON.stringify(env));
+    expect(restored).toEqual(env);
+    expect(isWorkbenchBlockEnvironmentRef(restored)).toBe(true);
+  });
+
+  it('preserves bench / worktreeInstanceId on round-trip', () => {
+    const env = buildBlockEnvironmentRef({
+      option: worktreeOption(),
+      createdAt: CREATED_AT,
+    });
+    const restored = JSON.parse(JSON.stringify(env));
+    expect(restored.worktreeInstanceId).toBe(env.worktreeInstanceId);
+    expect(restored.benchId).toBe(env.benchId);
+    expect(restored.repoInstanceId).toBe(env.repoInstanceId);
+  });
+
+  it('preserves the null repoIdentity for a free / non-git env', () => {
+    const env = buildBlockEnvironmentRef({
+      option: freeOption(),
+      createdAt: CREATED_AT,
+    });
+    const restored = JSON.parse(JSON.stringify(env));
+    expect(restored.repoIdentity).toBeNull();
+    expect(restored.repoInstanceId).toBeUndefined();
+    expect(restored.cwdMode).toBe('free');
+  });
+
+  it('survives a layout serialise → deserialise round-trip on the descriptor', () => {
+    const env = buildBlockEnvironmentRef({
+      option: worktreeOption(),
+      createdAt: CREATED_AT,
+    });
+    const layout = makeLayout([placementWithEnv(env, 'block-w')]);
+    const serialised = serialiseWorkbenchLayout(layout);
+    const restored = deserialiseWorkbenchLayout(
+      JSON.parse(JSON.stringify(serialised))
+    );
+    expect(restored).not.toBeNull();
+    const descriptor = restored!.blocks[0]!.descriptor as {
+      environment?: WorkbenchBlockEnvironmentRef;
+    };
+    expect(descriptor.environment).toBeDefined();
+    expect(descriptor.environment).toEqual(env);
+    // The environment MUST be on the descriptor itself, not stashed in _unknown.
+    expect(restored!.blocks[0]!._unknown).toBeUndefined();
+  });
+
+  it('survives the round-trip via the existing _unknown forward-compat path for legacy blocks', () => {
+    const layout = makeLayout([placementWithEnv(undefined, 'block-legacy')]);
+    const serialised = serialiseWorkbenchLayout(layout);
+    const restored = deserialiseWorkbenchLayout(
+      JSON.parse(JSON.stringify(serialised))
+    );
+    expect(restored).not.toBeNull();
+    const descriptor = restored!.blocks[0]!.descriptor as {
+      environment?: WorkbenchBlockEnvironmentRef;
+    };
+    expect(descriptor.environment).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveBlockEnvironment — resume / attach contract
+// ---------------------------------------------------------------------------
+
+describe('resolveBlockEnvironment', () => {
+  it('returns legacy-no-environment when the descriptor has no environment metadata', () => {
+    const result = resolveBlockEnvironment(undefined, [repoOption()]);
+    expect(result.kind).toBe('legacy-no-environment');
+  });
+
+  it('returns ok when the same picker option is fresh', () => {
+    const env = buildBlockEnvironmentRef({
+      option: repoOption(),
+      createdAt: CREATED_AT,
+    });
+    const result = resolveBlockEnvironment(env, [repoOption()]);
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.option.id).toBe(env.pickerOptionId);
+    }
+  });
+
+  it('returns block-on-launch / option-missing when the picker option is no longer offered', () => {
+    const env = buildBlockEnvironmentRef({
+      option: repoOption(),
+      createdAt: CREATED_AT,
+    });
+    // Candidates do not include opt-relay-nightly any more.
+    const other = repoOption({ id: 'opt-relay-master' });
+    const result = resolveBlockEnvironment(env, [other]);
+    expect(result.kind).toBe('block-on-launch');
+    if (result.kind === 'block-on-launch') {
+      expect(result.reason).toBe('option-missing');
+      expect(result.ref).toBe(env);
+    }
+  });
+
+  it('returns block-on-launch / option-stale when the candidate is stale', () => {
+    const env = buildBlockEnvironmentRef({
+      option: repoOption(),
+      createdAt: CREATED_AT,
+    });
+    const stale = repoOption({
+      freshness: 'stale',
+      degradedReasons: [
+        { kind: 'node-stale', lastSeenAt: '2026-05-19T11:00:00.000Z' },
+      ],
+    });
+    const result = resolveBlockEnvironment(env, [stale]);
+    expect(result.kind).toBe('block-on-launch');
+    if (result.kind === 'block-on-launch') {
+      expect(result.reason).toBe('option-stale');
+    }
+  });
+
+  it('returns block-on-launch / option-offline when the candidate is offline', () => {
+    const env = buildBlockEnvironmentRef({
+      option: repoOption(),
+      createdAt: CREATED_AT,
+    });
+    const offline = repoOption({
+      freshness: 'offline',
+      degradedReasons: [{ kind: 'node-offline' }],
+    });
+    const result = resolveBlockEnvironment(env, [offline]);
+    expect(result.kind).toBe('block-on-launch');
+    if (result.kind === 'block-on-launch') {
+      expect(result.reason).toBe('option-offline');
+    }
+  });
+
+  it('returns block-on-launch / capability-shrunk when create-time bits are no longer advertised', () => {
+    const env = buildBlockEnvironmentRef({
+      option: repoOption(),
+      createdAt: CREATED_AT,
+    });
+    // Picker now advertises fewer bits than at create time.
+    const shrunk = repoOption({ capabilities: ['session:create:terminal'] });
+    const result = resolveBlockEnvironment(env, [shrunk]);
+    expect(result.kind).toBe('block-on-launch');
+    if (result.kind === 'block-on-launch') {
+      expect(result.reason).toBe('capability-shrunk');
+    }
+  });
+
+  it('never silently substitutes a different node when the original is unavailable', () => {
+    const env = buildBlockEnvironmentRef({
+      option: repoOption(),
+      createdAt: CREATED_AT,
+    });
+    const fresh = repoOption({
+      id: 'opt-different-node',
+      node: { nodeId: 'mac', kind: 'remote', displayName: 'mac', online: true },
+    });
+    const result = resolveBlockEnvironment(env, [fresh]);
+    // Even with a fresh candidate available, the original picker option is
+    // missing so the contract MUST refuse to silently switch nodes.
+    expect(result.kind).toBe('block-on-launch');
+    if (result.kind === 'block-on-launch') {
+      expect(result.reason).toBe('option-missing');
+    }
+  });
+});

--- a/test/shared/workbench-block-env-roundtrip.test.ts
+++ b/test/shared/workbench-block-env-roundtrip.test.ts
@@ -42,11 +42,18 @@ const CREATED_AT = '2026-05-19T12:00:00.000Z';
 // helpers
 // ---------------------------------------------------------------------------
 
-function repoOption(overrides: Partial<EnvironmentOption> = {}): EnvironmentOption {
+function repoOption(
+  overrides: Partial<EnvironmentOption> = {}
+): EnvironmentOption {
   return {
     schemaVersion: 1,
     id: 'opt-relay-nightly',
-    node: { nodeId: 'local', kind: 'local', displayName: 'this host', online: true },
+    node: {
+      nodeId: 'local',
+      kind: 'local',
+      displayName: 'this host',
+      online: true,
+    },
     capabilities: ['session:create:terminal', 'rpc:fs:read', 'rpc:git:read'],
     cwd: '/Users/dev/repos/relay-ide',
     cwdMode: 'repo',
@@ -112,8 +119,7 @@ function placementWithEnv(
         },
       },
       ...(env !== undefined ? { environment: env } : {}),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test scaffold
-    } as any,
+    } as WorkbenchBlockPlacement['descriptor'],
     position: { x: 0, y: 0 },
     size: { width: 400, height: 200 },
     minimized: false,
@@ -141,9 +147,7 @@ describe('buildBlockEnvironmentRef', () => {
     expect(env.schemaVersion).toBe(WORKBENCH_BLOCK_ENVIRONMENT_SCHEMA_VERSION);
     expect(env.nodeId).toBe('local');
     expect(env.repoIdentity).toBe('github.com/donovan-yohan/relay-ide');
-    expect(env.repoInstanceId).toBe(
-      'local:%2FUsers%2Fdev%2Frepos%2Frelay-ide'
-    );
+    expect(env.repoInstanceId).toBe('local:%2FUsers%2Fdev%2Frepos%2Frelay-ide');
     expect(env.cwd).toBe('/Users/dev/repos/relay-ide');
     expect(env.cwdMode).toBe('repo');
     expect(env.pickerOptionId).toBe('opt-relay-nightly');


### PR DESCRIPTION
## Scope

Wires the `EnvironmentPicker` (#627) + `pickDefaultEnvironment` (#628) into Workbench block creation, persists typed environment IDs on block metadata per `docs/WORKBENCH_BOUNDARY.md`, and round-trips them through resume/attach.

- New `WorkbenchBlockEnvironmentRef` shape in `shared/workbench-block-environment.ts` capturing typed IDs only (`nodeId`, `repoIdentity`, `repoInstanceId`, `worktreeInstanceId` / `benchId`, `cwd`, `cwdMode`, `capabilities`, `pickerOptionId`, `pickerVersion`, `createdAt`). No free-form path strings beyond `cwd` itself.
- New `WorkbenchBlockCreateDialog` renders the picker with safe-default selection. Surfaces typed reasons (`no-candidates`, `active-tab-degraded`, `active-tab-missing`, `all-degraded`) and refuses to silently substitute a different node (`#615` acceptance).
- `buildBlockDescriptor` helper translates the dialog's request into a typed `WorkbenchBlockDescriptor` for every kind (terminal / agent / file / markdown / work-context / artifact / custom), each carrying the same `environment` envelope.
- `WorkbenchCanvas` now optionally accepts `environmentCandidates` / `activeTab` / `environmentHistory` and shows a `+ create block` entry point that opens the dialog. When `environmentCandidates` is omitted the button is hidden (back-compat).
- `resolveBlockEnvironment` returns `ok | block-on-launch (option-missing | option-stale | option-offline | capability-shrunk) | legacy-no-environment` so resume/attach has a typed contract for every shape — explicitly *never* silently switching nodes when the original is unavailable.

## Schema delta

`WorkbenchBlockDescriptorBase` gains an optional `environment?: WorkbenchBlockEnvironmentRef`. Additive, backward-compatible. `WORKBENCH_BLOCK_ENVIRONMENT_SCHEMA_VERSION = 1`; pure additions stay on v1, breaking changes bump.

## Legacy / migration plan

- Blocks persisted before this PR have no `environment` field — `resolveBlockEnvironment` returns `{ kind: 'legacy-no-environment' }` so the caller picks the migration policy explicitly rather than silently substituting (the #615 non-goal).
- The existing `_unknown` forward-compat bag is unchanged. Layout `deserialiseWorkbenchLayout` continues to pass `descriptor` through verbatim, so the new optional field round-trips without any layout schema bump.
- UI follow-up (out of scope for this PR): when the resume path returns `block-on-launch`, render a typed reason and a re-pick affordance instead of mounting the block. The contract is in place; surface is left for #629.

## Refs

#615 (epic) · #623 (EnvironmentOption) · #624 (repo aggregation) · #626 (typed env IDs in CLI gateway) · #627 (picker UI) · #628 (safe defaults) · #637 (block registry).

## Test plan

- [x] `npm run check` — 0 errors (74 pre-existing warnings).
- [x] `npm test test/shared/workbench-block-env-roundtrip.test.ts test/components/WorkbenchBlockEnvPicker.test.ts` — 31/31 pass.
- [x] Round-trip: `buildBlockEnvironmentRef` → JSON.stringify → JSON.parse → `isWorkbenchBlockEnvironmentRef` ✓.
- [x] Layout round-trip: descriptor.environment survives `serialiseWorkbenchLayout` / `deserialiseWorkbenchLayout` and is *not* stranded in `_unknown` ✓.
- [x] Resume contract: `ok` / `option-missing` / `option-stale` / `option-offline` / `capability-shrunk` / `legacy-no-environment` ✓ — and "never silently switches nodes" verified with a separate-node fresh candidate.
- [x] Dialog: picker renders, default-selects from history, blocks create on no-fresh / active-tab-degraded with typed reason, emits typed env IDs on confirm, filters by required capabilities.

Pre-existing failing tests in the suite (`browser-cli`, `cli-gateway-events`, `hermes-session-api`, `server-startup`, `workbench-custom-blocks` 404/409 race) are unrelated and exist on `nightly`. None touch the files in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)