### PR TITLE
test(env): e2e coverage — 4 picker scenarios (#632)

### DIFF
--- a/frontend/src/test-env-picker-dialog.tsx
+++ b/frontend/src/test-env-picker-dialog.tsx
@@ -1,0 +1,329 @@
+// E2E fixture for EnvPickerDialog (#632) — exercises the four canonical
+// picker scenarios from epic #615 acceptance criteria:
+//
+//   1. remote node selection
+//   2. local repo selection
+//   3. same-remote-different-path aggregation across nodes
+//   4. non-git cwd launch
+//
+// The fixture renders EnvPickerDialog with a button per scenario. Each
+// scenario supplies its own pre-built EnvironmentOption[]. The launch hook is
+// stubbed to record the launched option's typed IDs (nodeId, repoIdentity,
+// repoInstanceId, cwdMode) into a <output data-testid> sink so the Playwright
+// spec can assert the typed-IDs contract round-trips through the dialog
+// without depending on the real session-create API.
+//
+// Pure presentational — no store, no API, no router.
+
+import React, { useState } from 'react';
+import ReactDOM from 'react-dom/client';
+import type { EnvironmentOption } from '../../shared/environment-option.js';
+import EnvPickerDialog from './components/dialogs/EnvPickerDialog.js';
+import type {
+  LaunchEnvironmentResult,
+  LaunchEnvironmentOptions,
+} from './lib/launch-environment.js';
+import './App.css';
+import './components/EnvironmentPicker.css';
+import './components/dialogs/EnvPickerDialog.css';
+
+const GENERATED_AT = '2026-05-19T12:00:00.000Z';
+
+type ScenarioId = 'remote' | 'local' | 'same-remote' | 'non-git';
+
+// ---------------------------------------------------------------------------
+// Scenario 1: remote-only options. Picker must surface a remote node and a
+// launched session must record the remote nodeId via typed IDs.
+// ---------------------------------------------------------------------------
+const REMOTE_SCENARIO: EnvironmentOption[] = [
+  {
+    schemaVersion: 1,
+    id: 'mac::repo-relay',
+    node: {
+      nodeId: 'mac',
+      kind: 'remote',
+      displayName: 'dev mac',
+      online: true,
+    },
+    capabilities: [
+      'session:create:terminal',
+      'session:create:agent',
+      'rpc:fs:read',
+      'rpc:git:read',
+    ],
+    cwd: '/Users/dev/code/relay-ide',
+    cwdMode: 'repo',
+    freshness: 'fresh',
+    repoInstance: {
+      repoInstanceId: 'mac:/Users/dev/code/relay-ide',
+      localPath: '/Users/dev/code/relay-ide',
+      repoIdentity: 'github.com/donovan-yohan/relay-ide',
+      name: 'relay-ide',
+      currentBranch: 'nightly',
+      defaultBranch: 'master',
+    },
+    generatedAt: GENERATED_AT,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Scenario 2: local repo. Picker groups by RepoIdentity; launch carries the
+// local RepoInstance path.
+// ---------------------------------------------------------------------------
+const LOCAL_SCENARIO: EnvironmentOption[] = [
+  {
+    schemaVersion: 1,
+    id: 'local::repo-relay',
+    node: {
+      nodeId: 'local',
+      kind: 'local',
+      displayName: 'this host',
+      online: true,
+    },
+    capabilities: [
+      'session:create:terminal',
+      'session:create:agent',
+      'rpc:fs:read',
+      'rpc:git:read',
+    ],
+    cwd: '/Users/dev/repos/relay-ide',
+    cwdMode: 'repo',
+    freshness: 'fresh',
+    repoInstance: {
+      repoInstanceId: 'local:/Users/dev/repos/relay-ide',
+      localPath: '/Users/dev/repos/relay-ide',
+      repoIdentity: 'github.com/donovan-yohan/relay-ide',
+      name: 'relay-ide',
+      currentBranch: 'nightly',
+      defaultBranch: 'master',
+    },
+    generatedAt: GENERATED_AT,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Scenario 3: same RepoIdentity on TWO different nodes, with DIFFERENT
+// node-local paths. The picker MUST surface ONE group (aggregated by
+// RepoIdentity) with TWO instances. Selecting each instance MUST launch
+// against the correct node — no silent substitution (#615 invariant).
+// ---------------------------------------------------------------------------
+const SAME_REMOTE_DIFFERENT_PATH_SCENARIO: EnvironmentOption[] = [
+  {
+    schemaVersion: 1,
+    id: 'mac::repo-relay',
+    node: {
+      nodeId: 'mac',
+      kind: 'remote',
+      displayName: 'dev mac',
+      online: true,
+    },
+    capabilities: [
+      'session:create:terminal',
+      'session:create:agent',
+      'rpc:git:read',
+    ],
+    cwd: '/Users/dev/code/relay-ide',
+    cwdMode: 'repo',
+    freshness: 'fresh',
+    repoInstance: {
+      repoInstanceId: 'mac:/Users/dev/code/relay-ide',
+      localPath: '/Users/dev/code/relay-ide',
+      repoIdentity: 'github.com/donovan-yohan/relay-ide',
+      name: 'relay-ide',
+      currentBranch: 'nightly',
+      defaultBranch: 'master',
+    },
+    generatedAt: GENERATED_AT,
+  },
+  {
+    schemaVersion: 1,
+    id: 'linux::repo-relay',
+    node: {
+      nodeId: 'linux',
+      kind: 'remote',
+      displayName: 'linux lab',
+      online: true,
+    },
+    capabilities: [
+      'session:create:terminal',
+      'session:create:agent',
+      'rpc:git:read',
+    ],
+    cwd: '/srv/checkouts/relay-ide',
+    cwdMode: 'repo',
+    freshness: 'fresh',
+    repoInstance: {
+      repoInstanceId: 'linux:/srv/checkouts/relay-ide',
+      localPath: '/srv/checkouts/relay-ide',
+      repoIdentity: 'github.com/donovan-yohan/relay-ide',
+      name: 'relay-ide',
+      currentBranch: 'master',
+      defaultBranch: 'master',
+    },
+    generatedAt: GENERATED_AT,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Scenario 4: non-git cwd. Picker surfaces a free / non-git cwd group;
+// launch succeeds without a repoInstance, and the launched record carries
+// `cwdMode: free`. The non-git option carries no repo-only capabilities
+// (rpc:git:* absent) so repo-only actions never surface.
+// ---------------------------------------------------------------------------
+const NON_GIT_SCENARIO: EnvironmentOption[] = [
+  {
+    schemaVersion: 1,
+    id: 'local::scratch',
+    node: {
+      nodeId: 'local',
+      kind: 'local',
+      displayName: 'this host',
+      online: true,
+    },
+    capabilities: ['session:create:terminal'],
+    cwd: '/tmp/scratch',
+    cwdMode: 'free',
+    freshness: 'fresh',
+    generatedAt: GENERATED_AT,
+  },
+];
+
+const SCENARIOS: Record<ScenarioId, EnvironmentOption[]> = {
+  remote: REMOTE_SCENARIO,
+  local: LOCAL_SCENARIO,
+  'same-remote': SAME_REMOTE_DIFFERENT_PATH_SCENARIO,
+  'non-git': NON_GIT_SCENARIO,
+};
+
+interface LaunchedRecord {
+  optionId: string;
+  nodeId: string;
+  nodeKind: 'local' | 'remote';
+  repoIdentity: string | null;
+  repoInstanceId: string | null;
+  cwd: string;
+  cwdMode: string;
+  overrides: LaunchEnvironmentOptions | undefined;
+}
+
+function recordFromOption(
+  option: EnvironmentOption,
+  overrides: LaunchEnvironmentOptions | undefined
+): LaunchedRecord {
+  return {
+    optionId: option.id,
+    nodeId: option.node.nodeId,
+    nodeKind: option.node.kind,
+    repoIdentity: option.repoInstance?.repoIdentity ?? null,
+    repoInstanceId: option.repoInstance?.repoInstanceId ?? null,
+    cwd: option.cwd,
+    cwdMode: option.cwdMode,
+    overrides,
+  };
+}
+
+function Harness() {
+  const [scenario, setScenario] = useState<ScenarioId | null>(null);
+  const [launched, setLaunched] = useState<LaunchedRecord | null>(null);
+  const [launchedCount, setLaunchedCount] = useState(0);
+
+  const handleOpen = (id: ScenarioId) => {
+    setLaunched(null);
+    setScenario(id);
+  };
+
+  const stubLaunch = async (
+    option: EnvironmentOption,
+    overrides?: LaunchEnvironmentOptions
+  ): Promise<LaunchEnvironmentResult> => {
+    setLaunched(recordFromOption(option, overrides));
+    setLaunchedCount((n) => n + 1);
+    return {
+      kind: 'launched',
+      result: {
+        session: undefined,
+        error: null,
+      },
+    };
+  };
+
+  return (
+    <div style={{ padding: 24, maxWidth: 720 }}>
+      <h2 style={{ fontFamily: 'monospace', color: '#e0e0e0' }}>
+        env picker dialog fixture (#632)
+      </h2>
+      <div
+        style={{
+          display: 'flex',
+          gap: 8,
+          flexWrap: 'wrap',
+          marginBottom: 16,
+        }}
+      >
+        <button
+          type="button"
+          data-testid="open-remote"
+          onClick={() => handleOpen('remote')}
+        >
+          open remote scenario
+        </button>
+        <button
+          type="button"
+          data-testid="open-local"
+          onClick={() => handleOpen('local')}
+        >
+          open local scenario
+        </button>
+        <button
+          type="button"
+          data-testid="open-same-remote"
+          onClick={() => handleOpen('same-remote')}
+        >
+          open same-remote-different-path scenario
+        </button>
+        <button
+          type="button"
+          data-testid="open-non-git"
+          onClick={() => handleOpen('non-git')}
+        >
+          open non-git cwd scenario
+        </button>
+      </div>
+      <EnvPickerDialog
+        open={scenario !== null}
+        options={scenario ? SCENARIOS[scenario] : []}
+        onClose={() => setScenario(null)}
+        launch={stubLaunch}
+      />
+      <output
+        data-testid="launched-payload"
+        style={{
+          display: 'block',
+          marginTop: 16,
+          color: '#888',
+          fontFamily: 'monospace',
+          whiteSpace: 'pre-wrap',
+        }}
+      >
+        {launched ? JSON.stringify(launched) : '(none)'}
+      </output>
+      <output
+        data-testid="launched-count"
+        style={{
+          display: 'block',
+          marginTop: 4,
+          color: '#888',
+          fontFamily: 'monospace',
+        }}
+      >
+        launches: {launchedCount}
+      </output>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('app')!).render(
+  <React.StrictMode>
+    <Harness />
+  </React.StrictMode>
+);

--- a/frontend/test-env-picker-dialog.html
+++ b/frontend/test-env-picker-dialog.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>EnvPickerDialog Test Page</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/src/test-env-picker-dialog.tsx"
+    ></script>
+  </body>
+</html>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -40,6 +40,10 @@ if (includeE2eFixtures) {
     import.meta.dirname,
     'test-environment-picker.html'
   );
+  buildInputs['test-env-picker-dialog'] = resolve(
+    import.meta.dirname,
+    'test-env-picker-dialog.html'
+  );
 }
 
 export default defineConfig({

--- a/test/e2e/components/EnvPickerDialog.spec.ts
+++ b/test/e2e/components/EnvPickerDialog.spec.ts
@@ -1,0 +1,180 @@
+// EnvPickerDialog end-to-end coverage (#632) — drives the dialog through the
+// four canonical scenarios from epic #615's acceptance criteria via the
+// existing Playwright + Vite-fixture harness:
+//
+//   1. remote node selection      — launch carries the remote nodeId
+//   2. local repo selection       — launch carries the local RepoIdentity
+//                                   and local RepoInstance path
+//   3. same-remote-different-path — picker aggregates by RepoIdentity into
+//                                   ONE group with N instances; launching
+//                                   each instance preserves the per-node
+//                                   typed IDs (no silent substitution)
+//   4. non-git cwd                — picker exposes a free / non-git group;
+//                                   launch succeeds with `cwdMode: free`
+//                                   and no repo-only capabilities surface
+//
+// Runtime budget: combined <30s. The fixture is a single page (one Vite
+// build target, one webServer warm-up) and each test does at most two clicks
+// and one assertion read, keeping wall-clock well inside budget.
+
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+interface LaunchedRecord {
+  optionId: string;
+  nodeId: string;
+  nodeKind: 'local' | 'remote';
+  repoIdentity: string | null;
+  repoInstanceId: string | null;
+  cwd: string;
+  cwdMode: string;
+}
+
+async function readLaunched(page: Page): Promise<LaunchedRecord> {
+  const raw = await page.getByTestId('launched-payload').textContent();
+  if (!raw || raw.trim() === '' || raw.trim() === '(none)') {
+    throw new Error('expected a launched payload, got: ' + String(raw));
+  }
+  return JSON.parse(raw) as LaunchedRecord;
+}
+
+function groupLabels(page: Page): Locator {
+  return page.getByTestId('env-picker-group-label');
+}
+
+test.describe('EnvPickerDialog e2e — four picker scenarios (#632)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/test-env-picker-dialog.html');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('1. remote node selection — launch carries the remote nodeId via typed IDs', async ({
+    page,
+  }) => {
+    await page.getByTestId('open-remote').click();
+    const dialog = page.getByTestId('env-picker-dialog');
+    await expect(dialog).toBeVisible();
+
+    // The remote node MUST surface in the picker (display name visible).
+    await expect(page.getByText('dev mac', { exact: false })).toBeVisible();
+
+    const row = dialog.locator('[data-option-id="mac::repo-relay"]');
+    await expect(row).toBeVisible();
+    await row.click();
+
+    // After launch the dialog closes.
+    await expect(dialog).toBeHidden();
+    await expect(page.getByTestId('launched-count')).toHaveText('launches: 1');
+
+    const launched = await readLaunched(page);
+    expect(launched.optionId).toBe('mac::repo-relay');
+    expect(launched.nodeId).toBe('mac');
+    expect(launched.nodeKind).toBe('remote');
+    expect(launched.repoIdentity).toBe('github.com/donovan-yohan/relay-ide');
+    expect(launched.repoInstanceId).toBe('mac:/Users/dev/code/relay-ide');
+    expect(launched.cwdMode).toBe('repo');
+  });
+
+  test('2. local repo selection — launch carries RepoIdentity + local RepoInstance path', async ({
+    page,
+  }) => {
+    await page.getByTestId('open-local').click();
+    const dialog = page.getByTestId('env-picker-dialog');
+    await expect(dialog).toBeVisible();
+
+    // Local repo group surfaces under its name.
+    await expect(groupLabels(dialog)).toHaveText(['relay-ide']);
+
+    const row = dialog.locator('[data-option-id="local::repo-relay"]');
+    await expect(row).toBeVisible();
+    await row.click();
+
+    await expect(dialog).toBeHidden();
+    const launched = await readLaunched(page);
+    expect(launched.optionId).toBe('local::repo-relay');
+    expect(launched.nodeId).toBe('local');
+    expect(launched.nodeKind).toBe('local');
+    expect(launched.repoIdentity).toBe('github.com/donovan-yohan/relay-ide');
+    // RepoInstance present and its localPath matches the launch cwd
+    // (`cwdMode: 'repo'` invariant in shared/environment-option.ts).
+    expect(launched.repoInstanceId).toBe('local:/Users/dev/repos/relay-ide');
+    expect(launched.cwd).toBe('/Users/dev/repos/relay-ide');
+    expect(launched.cwdMode).toBe('repo');
+  });
+
+  test('3. same-remote-different-path — ONE group, N instances, no silent substitution', async ({
+    page,
+  }) => {
+    await page.getByTestId('open-same-remote').click();
+    const dialog = page.getByTestId('env-picker-dialog');
+    await expect(dialog).toBeVisible();
+
+    // CORE INVARIANT (#615): two repo instances with the SAME RepoIdentity on
+    // DIFFERENT nodes/paths MUST aggregate into exactly ONE group.
+    await expect(groupLabels(dialog)).toHaveText(['relay-ide']);
+
+    // Both instances MUST be present as separate rows inside that group.
+    const macRow = dialog.locator('[data-option-id="mac::repo-relay"]');
+    const linuxRow = dialog.locator('[data-option-id="linux::repo-relay"]');
+    await expect(macRow).toBeVisible();
+    await expect(linuxRow).toBeVisible();
+    await expect(dialog.locator('[role="option"]')).toHaveCount(2);
+
+    // Pick the linux instance first.
+    await linuxRow.click();
+    await expect(dialog).toBeHidden();
+
+    let launched = await readLaunched(page);
+    expect(launched.nodeId).toBe('linux');
+    expect(launched.repoInstanceId).toBe('linux:/srv/checkouts/relay-ide');
+    expect(launched.cwd).toBe('/srv/checkouts/relay-ide');
+    expect(launched.repoIdentity).toBe('github.com/donovan-yohan/relay-ide');
+
+    // Re-open and pick the mac instance. The launch MUST land on `mac`, not
+    // silently substitute the previously-launched `linux` or the other
+    // instance under the same RepoIdentity.
+    await page.getByTestId('open-same-remote').click();
+    await expect(dialog).toBeVisible();
+    await dialog.locator('[data-option-id="mac::repo-relay"]').click();
+    await expect(dialog).toBeHidden();
+    await expect(page.getByTestId('launched-count')).toHaveText('launches: 2');
+
+    launched = await readLaunched(page);
+    expect(launched.nodeId).toBe('mac');
+    expect(launched.repoInstanceId).toBe('mac:/Users/dev/code/relay-ide');
+    expect(launched.cwd).toBe('/Users/dev/code/relay-ide');
+    // Same RepoIdentity, but the per-node typed IDs are preserved.
+    expect(launched.repoIdentity).toBe('github.com/donovan-yohan/relay-ide');
+  });
+
+  test('4. non-git cwd — picker shows free group; launch succeeds; no repo-only capabilities surface', async ({
+    page,
+  }) => {
+    await page.getByTestId('open-non-git').click();
+    const dialog = page.getByTestId('env-picker-dialog');
+    await expect(dialog).toBeVisible();
+
+    // The free / non-git cwd group surfaces with the dedicated label from
+    // EnvironmentPicker.groupOptionsByRepoIdentity.
+    await expect(groupLabels(dialog)).toHaveText(['non-git cwd']);
+
+    const row = dialog.locator('[data-option-id="local::scratch"]');
+    await expect(row).toBeVisible();
+
+    // No repo-only capability (`rpc:git:*`) advertised on this option — the
+    // picker must not surface git-only badges for a non-git cwd launch.
+    const capabilities = row.getByTestId('env-picker-capability');
+    await expect(capabilities).toHaveText(['session:create:terminal']);
+
+    await row.click();
+    await expect(dialog).toBeHidden();
+
+    const launched = await readLaunched(page);
+    expect(launched.optionId).toBe('local::scratch');
+    expect(launched.nodeId).toBe('local');
+    expect(launched.cwdMode).toBe('free');
+    // No RepoIdentity / RepoInstance attached — the launch MUST NOT inherit
+    // repo-only IDs from a sibling option (#615 acceptance criterion).
+    expect(launched.repoIdentity).toBeNull();
+    expect(launched.repoInstanceId).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds Playwright end-to-end coverage for `EnvPickerDialog` driving the four canonical picker scenarios from epic #615's acceptance criteria. Closes #632.

- **remote node selection** — picker shows the remote node; launch carries `nodeId: 'mac'` and the remote `RepoInstanceId` via typed IDs.
- **local repo selection** — picker groups by `RepoIdentity`; launch carries `RepoIdentity` + local `RepoInstance.localPath`.
- **same-remote-different-path** — two simulated nodes with the same canonical `RepoIdentity` but different local paths aggregate into ONE group with TWO instances; selecting each launches against the correct node (no silent substitution per the #615 invariant).
- **non-git cwd** — free / non-git cwd group surfaces with the dedicated label; launch succeeds with `cwdMode: 'free'`, no `RepoIdentity`/`RepoInstance` attached, and no repo-only capabilities advertised.

## Harness

Re-uses the existing Playwright + Vite fixture pattern (see `test/e2e/components/CustomizeSessionDialog.spec.ts` + `frontend/src/test-customize-session-dialog.tsx`). Adds:

- `frontend/test-env-picker-dialog.html` — fixture entry.
- `frontend/src/test-env-picker-dialog.tsx` — renders `<EnvPickerDialog>` with per-scenario buttons; stubs `launchEnvironment` so the spec can read the launched option's typed IDs (`nodeId`, `nodeKind`, `repoIdentity`, `repoInstanceId`, `cwd`, `cwdMode`) from a `[data-testid="launched-payload"]` sink — no API calls.
- `frontend/vite.config.ts` — adds the fixture to `buildInputs` under `RELAY_IDE_E2E_FIXTURES=1`.
- `test/e2e/components/EnvPickerDialog.spec.ts` — four test cases, one per scenario.

Combined runtime: ~10s (budget <30s).

## Wave 1–3 chain

- Wave 1: #634, #639, #640, #642
- Wave 2: #643
- Wave 3: #646, #647, #648
- This PR (Wave 3 close-out): #632

## Test plan

- [x] `npm run check` — 0 errors (80 pre-existing warnings).
- [x] `RELAY_IDE_E2E_FIXTURES=1 npm run build` — clean.
- [x] `NO_PIN=1 npx playwright test test/e2e/components/EnvPickerDialog.spec.ts` — 4/4 passing in ~10s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)