### PR TITLE
feat: bounded session replay snapshot API (#656)

### DIFF
--- a/docs/SESSION_DURABILITY.md
+++ b/docs/SESSION_DURABILITY.md
@@ -50,9 +50,41 @@ without polling.
 helper only fires when the derived state actually differs, so a steady-state
 session does not emit on every list call.
 
+## Bounded replay snapshot
+
+PTY sessions own a 256 KB FIFO scrollback buffer (`server/pty-handler.ts`).
+Slice 2 formalises this as a typed snapshot consumers can pull on demand:
+
+```ts
+sessions.getReplaySnapshot(sessionId): SessionReplaySnapshot | null
+```
+
+Snapshot fields:
+
+| Field           | Meaning                                        |
+| --------------- | ---------------------------------------------- |
+| `payload`       | Concatenated scrollback string.                |
+| `bytesIncluded` | Resident bytes in `payload`.                   |
+| `bytesDropped`  | Lifetime bytes evicted by the FIFO. Monotonic. |
+| `capacityBytes` | Per-session FIFO cap (currently 256 KB).       |
+| `truncated`     | Convenience flag: `bytesDropped > 0`.          |
+| `capturedAt`    | ISO timestamp of snapshot capture.             |
+| `sessionId`     | Session id this snapshot belongs to.           |
+
+REST endpoint: `GET /sessions/:id/replay` (auth-gated like other session
+routes). Web-mode sessions and unknown ids return 404
+`SESSION_REPLAY_UNAVAILABLE`; remote/routed sessions are out of scope for
+this slice (see #614 slice 3+).
+
+The existing WebSocket attach path keeps streaming raw scrollback bytes to
+xterm clients — this REST snapshot is a separate, optional read for status
+cards, agent adapters, and reattach UX that need a typed view.
+
 ## Out of scope (later #614 slices)
 
 - Reconnect UX badges (slice 3).
-- Bounded replay buffer redesign (slice 2).
+- Cross-node/remote replay forwarding (slice 3).
+- Web-session replay redesign (existing `WebSession.messages` buffer is
+  unchanged in slice 2).
 - Per-node/per-connection/per-session durability config knobs (slice 4).
 - Live process migration. No raw infinite transcript storage.

--- a/server/index.ts
+++ b/server/index.ts
@@ -2365,6 +2365,35 @@ async function main(): Promise<void> {
     res.json(remote);
   });
 
+  app.get('/sessions/:id/replay', requireScopedSessionAuth, (req, res) => {
+    const decision = capabilityDecisionFromRequest(
+      req,
+      CONTROL_READ_CAPABILITY
+    );
+    if (decision.decision !== 'allow') {
+      const error = capabilityError(decision);
+      res.status(sessionControlErrorStatus(error)).json({ error });
+      return;
+    }
+    const id = req.params['id'] as string;
+    const snapshot = localRelayNode.sessions.getReplaySnapshot(id);
+    if (!snapshot) {
+      // Routed/remote replay forwarding is out of scope for #656; the hub
+      // currently only serves replay for sessions owned by the local node.
+      res.status(404).json({
+        error: {
+          code: 'NOT_FOUND',
+          reasonCode: 'SESSION_REPLAY_UNAVAILABLE',
+          message:
+            'session replay is only available for local PTY sessions in this slice',
+          retryable: false,
+        },
+      });
+      return;
+    }
+    res.json(snapshot);
+  });
+
   app.get(
     '/sessions/:id/interventions',
     requireScopedSessionAuth,

--- a/server/local-node.ts
+++ b/server/local-node.ts
@@ -4,7 +4,12 @@ import type { CreateParams } from './sessions.js';
 import type { CreateWebParams } from './web-session-handler.js';
 import type { SessionRenewResult } from './session-envelope-registry.js';
 import type { Session, SessionSummary } from './types.js';
-import type { InterventionRecord, TabControlEvent, ControlActor } from '../shared/control-state.js';
+import type { SessionReplaySnapshot } from '../shared/session-replay.js';
+import type {
+  InterventionRecord,
+  TabControlEvent,
+  ControlActor,
+} from '../shared/control-state.js';
 import type { SessionControlError } from './session-control-api.js';
 import {
   DEFAULT_LOCAL_ENVIRONMENT_ID,
@@ -34,7 +39,11 @@ export interface NodeSessionBoundary {
     displayName: string
   ): { id: string; displayName: string };
   write(id: string, data: string): void;
-  getInterventions(id: string, options?: { nodeId?: string; limit?: number }): InterventionRecord[];
+  getInterventions(
+    id: string,
+    options?: { nodeId?: string; limit?: number }
+  ): InterventionRecord[];
+  getReplaySnapshot(id: string): SessionReplaySnapshot | null;
   handBackToAgent(input: {
     id: string;
     latestSeenInterventionEventId?: string;
@@ -78,6 +87,7 @@ const defaultSessionBoundary: NodeSessionBoundary = {
   updateDisplayName: sessionsModule.updateDisplayName,
   write: sessionsModule.write,
   getInterventions: sessionsModule.getInterventions,
+  getReplaySnapshot: sessionsModule.getReplaySnapshot,
   handBackToAgent: sessionsModule.handBackToAgent,
 };
 

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -825,6 +825,7 @@ function buildSessionObject(
     createdAt,
     lastActivity: createdAt,
     scrollback,
+    scrollbackBytesEvicted: 0,
     idle: false,
     cwd,
     customCommand:
@@ -1108,12 +1109,15 @@ export function createPtySession(
       resetIdleTimer();
       scrollback.push(data);
       scrollbackRef.bytes += data.length;
-      // Trim oldest entries if over limit
+      // Trim oldest entries if over limit; track total bytes evicted so
+      // `SessionReplaySnapshot.bytesDropped` can report lost history.
       while (
         scrollbackRef.bytes > maxScrollbackPerSession &&
         scrollback.length > 1
       ) {
-        scrollbackRef.bytes -= (scrollback.shift() as string).length;
+        const evicted = (scrollback.shift() as string).length;
+        scrollbackRef.bytes -= evicted;
+        session.scrollbackBytesEvicted += evicted;
       }
       // Notify sessions layer so global cap can be enforced.
       // Pass the session id and chunk size so the caller can maintain an

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -785,7 +785,8 @@ function buildSessionObject(
   effectiveEventSource: EventSourceType,
   useTmux: boolean,
   tmuxSessionName: string,
-  createdAt: string
+  createdAt: string,
+  scrollbackCapacityBytes: number
 ): PtySession {
   const {
     id,
@@ -826,6 +827,7 @@ function buildSessionObject(
     lastActivity: createdAt,
     scrollback,
     scrollbackBytesEvicted: 0,
+    scrollbackCapacityBytes,
     idle: false,
     cwd,
     customCommand:
@@ -1061,7 +1063,8 @@ export function createPtySession(
     effectiveEventSource,
     useTmux,
     tmuxSessionName,
-    createdAt
+    createdAt,
+    maxScrollbackPerSession
   );
   sessionsMap.set(id, session);
 

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -762,12 +762,17 @@ function getReplaySnapshot(id: string): SessionReplaySnapshot | null {
   if (!session || session.mode !== 'pty') return null;
   const payload = session.scrollback.join('');
   const bytesDropped = session.scrollbackBytesEvicted;
+  // Prefer the per-session effective cap so the snapshot reports the
+  // actual eviction threshold for that session; fall back to the shared
+  // default only when a legacy/test session record predates the field.
+  const capacityBytes =
+    session.scrollbackCapacityBytes || DEFAULT_SESSION_REPLAY_CAPACITY_BYTES;
   return {
     sessionId: session.id,
     payload,
     bytesIncluded: payload.length,
     bytesDropped,
-    capacityBytes: DEFAULT_SESSION_REPLAY_CAPACITY_BYTES,
+    capacityBytes,
     truncated: bytesDropped > 0,
     capturedAt: new Date().toISOString(),
   };

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -63,6 +63,10 @@ import {
   type SessionDurabilityState,
 } from '../shared/session-durability.js';
 import {
+  DEFAULT_SESSION_REPLAY_CAPACITY_BYTES,
+  type SessionReplaySnapshot,
+} from '../shared/session-replay.js';
+import {
   isControlStateSummary,
   normalizeControlStateSummary,
   type ControlStateSummary,
@@ -751,6 +755,22 @@ function create({
 
 function get(id: string): Session | undefined {
   return sessions.get(id);
+}
+
+function getReplaySnapshot(id: string): SessionReplaySnapshot | null {
+  const session = sessions.get(id);
+  if (!session || session.mode !== 'pty') return null;
+  const payload = session.scrollback.join('');
+  const bytesDropped = session.scrollbackBytesEvicted;
+  return {
+    sessionId: session.id,
+    payload,
+    bytesIncluded: payload.length,
+    bytesDropped,
+    capacityBytes: DEFAULT_SESSION_REPLAY_CAPACITY_BYTES,
+    truncated: bytesDropped > 0,
+    capturedAt: new Date().toISOString(),
+  };
 }
 
 function renew(input: {
@@ -2237,6 +2257,7 @@ export {
   onSessionDurabilityChanged,
   setSessionNodeStatusResolver,
   refreshDurability,
+  getReplaySnapshot,
   nextTerminalName,
   nextAgentName,
   serializeAll,

--- a/server/types.ts
+++ b/server/types.ts
@@ -301,6 +301,12 @@ export interface PtySession extends BaseSession {
   mode: 'pty';
   pty: IPty;
   scrollback: string[];
+  /**
+   * Monotonic total of bytes evicted by the scrollback FIFO over this
+   * session's lifetime. Surfaces in `SessionReplaySnapshot.bytesDropped`
+   * so replay consumers can be honest about history lost to the cap.
+   */
+  scrollbackBytesEvicted: number;
   useTmux: boolean;
   tmuxSessionName: string;
   onPtyReplacedCallbacks: Array<(newPty: IPty) => void>;

--- a/server/types.ts
+++ b/server/types.ts
@@ -307,6 +307,12 @@ export interface PtySession extends BaseSession {
    * so replay consumers can be honest about history lost to the cap.
    */
   scrollbackBytesEvicted: number;
+  /**
+   * Effective per-session FIFO cap in bytes. May differ from the shared
+   * default when a session is created with a custom `maxScrollbackBytes`.
+   * Stored so `SessionReplaySnapshot.capacityBytes` reflects the actual cap.
+   */
+  scrollbackCapacityBytes: number;
   useTmux: boolean;
   tmuxSessionName: string;
   onPtyReplacedCallbacks: Array<(newPty: IPty) => void>;

--- a/shared/session-replay.ts
+++ b/shared/session-replay.ts
@@ -1,0 +1,35 @@
+// Bounded replay snapshot for #614 slice 2. A snapshot is a typed, point-in-time
+// view of a PTY session's scrollback buffer. Consumers (mobile status card,
+// reattach UX, agent adapters) fetch it via REST or pull it directly from
+// `sessions.getReplaySnapshot(id)`.
+
+/**
+ * Default per-session scrollback cap shared between PTY handler and replay
+ * consumers. Keep aligned with `MAX_SCROLLBACK` in `server/pty-handler.ts`
+ * — the constant lives here so frontend / docs can reference one source.
+ */
+export const DEFAULT_SESSION_REPLAY_CAPACITY_BYTES = 256 * 1024;
+
+export interface SessionReplaySnapshot {
+  /**
+   * Bounded replay payload, concatenated from the session's scrollback
+   * buffer. May be empty if the session has not produced output yet.
+   */
+  payload: string;
+  /** Byte length of `payload`. Equal to the FIFO's current resident bytes. */
+  bytesIncluded: number;
+  /**
+   * Total bytes evicted from this session's scrollback over its lifetime.
+   * Strictly increasing; non-zero means earlier output was discarded by the
+   * FIFO cap and is not present in `payload`.
+   */
+  bytesDropped: number;
+  /** Per-session FIFO cap that determined eviction. */
+  capacityBytes: number;
+  /** True iff `bytesDropped > 0`. Convenience flag for consumers. */
+  truncated: boolean;
+  /** ISO timestamp at which this snapshot was captured. */
+  capturedAt: string;
+  /** Session id this snapshot belongs to. */
+  sessionId: string;
+}

--- a/test/session-replay.test.ts
+++ b/test/session-replay.test.ts
@@ -8,8 +8,10 @@ import { DEFAULT_SESSION_REPLAY_CAPACITY_BYTES } from '../shared/session-replay.
 
 const createdIds: string[] = [];
 let tmuxTmpdir: string;
+let previousTmuxTmpdir: string | undefined;
 
 beforeAll(() => {
+  previousTmuxTmpdir = process.env.TMUX_TMPDIR;
   tmuxTmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'replay-tmux-'));
   process.env.TMUX_TMPDIR = tmuxTmpdir;
 });
@@ -27,6 +29,8 @@ afterEach(async () => {
 
 afterAll(() => {
   if (tmuxTmpdir) fs.rmSync(tmuxTmpdir, { recursive: true, force: true });
+  if (previousTmuxTmpdir === undefined) delete process.env.TMUX_TMPDIR;
+  else process.env.TMUX_TMPDIR = previousTmuxTmpdir;
 });
 
 describe('getReplaySnapshot', () => {
@@ -52,6 +56,26 @@ describe('getReplaySnapshot', () => {
     expect(snap?.truncated).toBe(false);
     expect(snap?.capacityBytes).toBe(DEFAULT_SESSION_REPLAY_CAPACITY_BYTES);
     expect(snap?.capturedAt).toMatch(/T.*Z$/);
+  });
+
+  it('reports the per-session effective cap, not the shared default', () => {
+    const result = sessions.create({
+      repoName: 'replay-custom-cap',
+      repoPath: '/tmp',
+      worktreePath: null,
+      cwd: '/tmp',
+      command: '/bin/echo',
+      args: ['hi'],
+    });
+    createdIds.push(result.id);
+    const session = sessions.get(result.id) as PtySession;
+    // Sessions can be created with a non-default cap via
+    // `maxScrollbackBytes`; the snapshot must reflect that effective cap
+    // rather than the shared default, so consumers don't act on stale
+    // metadata.
+    session.scrollbackCapacityBytes = 4096;
+    const snap = sessions.getReplaySnapshot(result.id);
+    expect(snap?.capacityBytes).toBe(4096);
   });
 
   it('reports bytesDropped and truncated=true after the FIFO evicts', () => {

--- a/test/session-replay.test.ts
+++ b/test/session-replay.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, afterEach, beforeAll, afterAll, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as sessions from '../server/sessions.js';
+import type { PtySession } from '../server/types.js';
+import { DEFAULT_SESSION_REPLAY_CAPACITY_BYTES } from '../shared/session-replay.js';
+
+const createdIds: string[] = [];
+let tmuxTmpdir: string;
+
+beforeAll(() => {
+  tmuxTmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'replay-tmux-'));
+  process.env.TMUX_TMPDIR = tmuxTmpdir;
+});
+
+afterEach(async () => {
+  for (const id of createdIds) {
+    try {
+      sessions.kill(id);
+    } catch {
+      // Already killed
+    }
+  }
+  createdIds.length = 0;
+});
+
+afterAll(() => {
+  if (tmuxTmpdir) fs.rmSync(tmuxTmpdir, { recursive: true, force: true });
+});
+
+describe('getReplaySnapshot', () => {
+  it('returns null for unknown session ids', () => {
+    expect(sessions.getReplaySnapshot('does-not-exist')).toBeNull();
+  });
+
+  it('returns a typed snapshot for a PTY session with no output yet', () => {
+    const result = sessions.create({
+      repoName: 'replay-empty',
+      repoPath: '/tmp',
+      worktreePath: null,
+      cwd: '/tmp',
+      command: '/bin/echo',
+      args: ['hi'],
+    });
+    createdIds.push(result.id);
+    const snap = sessions.getReplaySnapshot(result.id);
+    expect(snap).not.toBeNull();
+    expect(snap?.sessionId).toBe(result.id);
+    expect(snap?.bytesIncluded).toBe(snap?.payload.length);
+    expect(snap?.bytesDropped).toBe(0);
+    expect(snap?.truncated).toBe(false);
+    expect(snap?.capacityBytes).toBe(DEFAULT_SESSION_REPLAY_CAPACITY_BYTES);
+    expect(snap?.capturedAt).toMatch(/T.*Z$/);
+  });
+
+  it('reports bytesDropped and truncated=true after the FIFO evicts', () => {
+    const result = sessions.create({
+      repoName: 'replay-trunc',
+      repoPath: '/tmp',
+      worktreePath: null,
+      cwd: '/tmp',
+      command: '/bin/echo',
+      args: ['hi'],
+    });
+    createdIds.push(result.id);
+    const session = sessions.get(result.id) as PtySession;
+    // Simulate the FIFO evicting bytes by mutating the lifetime counter
+    // directly — exercising the snapshot shape without needing to write
+    // 256KB through the real PTY in a unit test.
+    session.scrollbackBytesEvicted = 12_345;
+    const snap = sessions.getReplaySnapshot(result.id);
+    expect(snap?.bytesDropped).toBe(12_345);
+    expect(snap?.truncated).toBe(true);
+  });
+});


### PR DESCRIPTION
Slice 2 of #614. Typed PTY scrollback snapshot + REST accessor + honest history-loss tracking. WS attach untouched.

## Summary
- `shared/session-replay.ts` — `SessionReplaySnapshot` shape and `DEFAULT_SESSION_REPLAY_CAPACITY_BYTES` constant aligned with the PTY handler's 256 KB cap.
- `PtySession.scrollbackBytesEvicted` — monotonic lifetime counter incremented every time the FIFO trims, so consumers can detect lost history.
- `sessions.getReplaySnapshot(sessionId)` — typed accessor for PTY sessions. `null` for web mode or unknown ids.
- REST `GET /sessions/:id/replay` — auth-gated, mirrors `/sessions/:id/interventions`. 404 `SESSION_REPLAY_UNAVAILABLE` for web/remote sessions (cross-node forwarding deferred to slice 3).
- WS attach path unchanged — xterm consumers still get raw bytes; this is a separate typed read for status cards / agent adapters / reattach UX.
- `docs/SESSION_DURABILITY.md` gets a "Bounded replay snapshot" section.

## Test plan
- [x] `vitest run test/session-replay.test.ts` — 3 new tests: null-for-unknown, empty PTY snapshot shape, `bytesDropped`+`truncated` reflection after simulated eviction.
- [x] `vitest run` focused (session-replay + session-durability + sessions) — 91 passed.
- [x] `npm run check` — 0 errors, 80 preexisting warnings.
- [ ] Reviewer: confirm 404 for remote sessions is the right default vs forwarding now.
- [ ] Reviewer: confirm web-mode 404 is fine — `WebSession.messages` is a separate reconnect mechanism with different semantics.

Closes #656, advances #614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session replay snapshots for PTY sessions—retrieve a point-in-time snapshot of session history with metadata on content captured, dropped, and capacity limits.

* **Documentation**
  * Updated documentation to specify the session replay snapshot API and behavior.

* **Tests**
  * Added comprehensive test coverage for session replay functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->