### PR TITLE
security(diag): broaden url-credential redactor to any URL scheme (#604)

### DIFF
--- a/server/diagnostics-bundle.ts
+++ b/server/diagnostics-bundle.ts
@@ -110,7 +110,11 @@ export const DIAGNOSTICS_REDACTION_RULES: readonly DiagnosticsRedactionRule[] = 
   { id: 'bearer-token', description: 'standalone Bearer token values' },
   { id: 'cookie-header', description: 'cookie header values' },
   { id: 'github-token', description: 'GitHub token formats' },
-  { id: 'url-credential', description: 'URL embedded credentials' },
+  {
+    id: 'url-credential',
+    description:
+      'URL embedded credentials (any scheme: http/https/ws/wss/git/ssh/...)',
+  },
   {
     id: 'secret-assignment',
     description:
@@ -606,7 +610,12 @@ export function redactText(value: string): RedactionResult<string> {
   );
   output = replaceAndCount(
     output,
-    /(https?:\/\/)([^/\s:@]+):([^@\s/]+)@/g,
+    // Match any RFC-3986 scheme prefix (http/https/ws/wss/git/ssh/etc.) so
+    // credentials embedded in non-http URLs — notably the wss:// hub URL
+    // logged by node-link-client.ts:411 — get scrubbed too (issue #604).
+    // Case-insensitive; still anchored at the scheme boundary, so JSON-ish
+    // `key:value@host` without `://` does not match.
+    /([a-z][a-z0-9+.-]*:\/\/)([^/\s:@]+):([^@\s/]+)@/gi,
     'url-credential',
     `$1${REDACTED}:${REDACTED}@`,
     counts

--- a/shared/bootstrap-diagnostics.ts
+++ b/shared/bootstrap-diagnostics.ts
@@ -267,5 +267,12 @@ export function redactBootstrapSecrets(value: string): string {
     .replace(/(Authorization:\s*Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, '$1…redacted')
     .replace(/(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, '$1…redacted')
     .replace(/("(?:token|pairToken|pin|password|secret)"\s*:\s*)"[^"]*"/gi, '$1"…redacted"')
-    .replace(/\b(token|pin|password|secret)=([^\s&"',}]+)/gi, '$1=…redacted');
+    .replace(/\b(token|pin|password|secret)=([^\s&"',}]+)/gi, '$1=…redacted')
+    // URL-embedded credentials, any scheme — keeps bootstrap log lines
+    // (which can quote `--hub-url https://user:pass@…` or `wss://…`) in
+    // lockstep with the diag-bundle url-credential rule (#604).
+    .replace(
+      /([a-z][a-z0-9+.-]*:\/\/)([^/\s:@]+):([^@\s/]+)@/gi,
+      '$1…redacted:…redacted@'
+    );
 }

--- a/test/fixtures/redaction/url-credential-ws.txt
+++ b/test/fixtures/redaction/url-credential-ws.txt
@@ -1,0 +1,9 @@
+## meta
+rule: url-credential
+module: diagnostics-bundle
+redactor: redactText
+description: URL embedded credentials on the ws:// node-link variant get scrubbed (issue #604)
+secrets: relayuser,sk_test_FAKE_PASS_bbbbbbbb
+preserves: hub.example.test,connected to,/hub/node-link
+## input
+[node-link] connected to ws://relayuser:sk_test_FAKE_PASS_bbbbbbbb@hub.example.test/hub/node-link

--- a/test/fixtures/redaction/url-credential-wss.txt
+++ b/test/fixtures/redaction/url-credential-wss.txt
@@ -1,0 +1,9 @@
+## meta
+rule: url-credential
+module: diagnostics-bundle
+redactor: redactText
+description: URL embedded credentials on the wss:// node-link variant get scrubbed (issue #604)
+secrets: relayuser,sk_test_FAKE_PASS_aaaaaaaa
+preserves: hub.example.test,connected to,/hub/node-link
+## input
+[node-link] connected to wss://relayuser:sk_test_FAKE_PASS_aaaaaaaa@hub.example.test/hub/node-link

--- a/test/shared/redaction-coverage.test.ts
+++ b/test/shared/redaction-coverage.test.ts
@@ -261,21 +261,27 @@ describe('routed-PTY / node-link log shapes (#587, #588) are covered by redactio
     expect(out).toContain('hub.example.test');
   });
 
-  // Known gap tracked as issue #604: the diag bundle url-credential regex
-  // only matches https?:// URLs, but node-link-client logs the WS variant
-  // (wss://). When that's fixed, this it.fails flips green and forces us
-  // to retire the .fails marker — exactly the regression behavior we want.
-  it.fails(
-    'redacts ws(s) URL-embedded credentials in "connected to <linkUrl>" lines — see issue #604',
-    () => {
-      const raw =
-        "[node-link] connected to wss://relayuser:FAKE_URL_PASS_aaaaaaaa@hub.example.test/hub/node-link";
-      const out = redactText(raw).value;
-      expect(out).not.toContain('FAKE_URL_PASS_aaaaaaaa');
-      expect(out).not.toContain('relayuser');
-      expect(out).toContain('hub.example.test');
-    }
-  );
+  // Issue #604 fixed: the diag bundle url-credential regex now matches any
+  // RFC-3986 scheme prefix (case-insensitive), so the WS variant logged at
+  // node-link-client.ts:411 no longer leaks credentials into shipped bundles.
+  // The `it.fails` marker that previously asserted the leak has been retired.
+  it('redacts ws(s) URL-embedded credentials in "connected to <linkUrl>" lines (covers the ws/wss half of node-link-client.ts:411, issue #604)', () => {
+    const raw =
+      "[node-link] connected to wss://relayuser:FAKE_URL_PASS_aaaaaaaa@hub.example.test/hub/node-link";
+    const out = redactText(raw).value;
+    expect(out).not.toContain('FAKE_URL_PASS_aaaaaaaa');
+    expect(out).not.toContain('relayuser');
+    expect(out).toContain('hub.example.test');
+  });
+
+  it('redacts ws:// URL-embedded credentials too (cleartext websocket variant, issue #604)', () => {
+    const raw =
+      "[node-link] connected to ws://relayuser:FAKE_URL_PASS_bbbbbbbb@hub.example.test/hub/node-link";
+    const out = redactText(raw).value;
+    expect(out).not.toContain('FAKE_URL_PASS_bbbbbbbb');
+    expect(out).not.toContain('relayuser');
+    expect(out).toContain('hub.example.test');
+  });
 
   it('redacts Authorization headers if a node-link RPC error path echoes request headers', () => {
     const raw =


### PR DESCRIPTION
## Summary

Fixes #604 (companion to #598 and #504 / PR #513).

The diagnostics bundle's `url-credential` redaction rule only matched `https?://` URLs, so the node-link client's `connected to wss://user:pass@hub…` log line at `server/node-link-client.ts:411` survived verbatim into shipped diag bundles.

## Changes

- **`server/diagnostics-bundle.ts`** — regex broadened from `/(https?:\/\/)([^/\s:@]+):([^@\s/]+)@/g` to `/([a-z][a-z0-9+.-]*:\/\/)([^/\s:@]+):([^@\s/]+)@/gi`. Matches any RFC-3986 scheme prefix (case-insensitive); still anchored at the scheme boundary so JSON-ish `key:value@host` without `://` does not match. Manifest description updated to reflect any-scheme coverage.
- **`shared/bootstrap-diagnostics.ts`** — appended an equivalent url-credential scrub to `redactBootstrapSecrets` so node-link bootstrap log lines redact uniformly with the diag bundle.
- **`test/fixtures/redaction/url-credential-wss.txt`** + **`url-credential-ws.txt`** — new fixtures covering both websocket variants with obviously fake credentials (`sk_test_FAKE_PASS_*`).
- **`test/shared/redaction-coverage.test.ts`** — retired the `it.fails` marker that previously asserted the leak (lines 268-278 on nightly); replaced with passing ws + wss assertions. Consistency gate (rule ↔ fixture) still passes with the new fixtures pointing at `rule: url-credential`.

## Scope

Redaction-only. No behavior change to the logger, `node-link-client`, or any user-visible code path. Only one `linkUrl` log emission exists in `node-link-client.ts` (line 411); no adjacent leak surfaces found.

## Test plan

- [x] `npm test -- redaction-coverage` — 25/25 pass (4 previously failed without fix)
- [x] `npm run check` — 0 errors
- [x] `npm test` (full) — only pre-existing nightly flakes remain (git-watcher fs race, workbench-custom-blocks 401), unrelated to redaction

Generated with [Claude Code](https://claude.com/claude-code)