### PR TITLE
fix(#604): diag bundle url-credential redactor handles ws/wss + any scheme

### DIFF
--- a/server/diagnostics-bundle.ts
+++ b/server/diagnostics-bundle.ts
@@ -606,7 +606,11 @@ export function redactText(value: string): RedactionResult<string> {
   );
   output = replaceAndCount(
     output,
-    /(https?:\/\/)([^/\s:@]+):([^@\s/]+)@/g,
+    // Match URL-embedded credentials for ANY scheme, not just http(s).
+    // node-link-client logs ws://user:pass@host and wss://user:pass@host
+    // after upgrading the configured hub URL; without this generalization
+    // the diag bundle leaked the embedded credential. See issue #604.
+    /([a-z][a-z0-9+.-]*:\/\/)([^/\s:@]+):([^@\s/]+)@/gi,
     'url-credential',
     `$1${REDACTED}:${REDACTED}@`,
     counts

--- a/test/shared/redaction-coverage.test.ts
+++ b/test/shared/redaction-coverage.test.ts
@@ -261,21 +261,34 @@ describe('routed-PTY / node-link log shapes (#587, #588) are covered by redactio
     expect(out).toContain('hub.example.test');
   });
 
-  // Known gap tracked as issue #604: the diag bundle url-credential regex
-  // only matches https?:// URLs, but node-link-client logs the WS variant
-  // (wss://). When that's fixed, this it.fails flips green and forces us
-  // to retire the .fails marker — exactly the regression behavior we want.
-  it.fails(
-    'redacts ws(s) URL-embedded credentials in "connected to <linkUrl>" lines — see issue #604',
-    () => {
-      const raw =
-        "[node-link] connected to wss://relayuser:FAKE_URL_PASS_aaaaaaaa@hub.example.test/hub/node-link";
-      const out = redactText(raw).value;
-      expect(out).not.toContain('FAKE_URL_PASS_aaaaaaaa');
-      expect(out).not.toContain('relayuser');
-      expect(out).toContain('hub.example.test');
-    }
-  );
+  // Closed by #604 fix: url-credential redactor now generalizes across
+  // schemes (http/https/ws/wss/...) so ws-upgraded link URLs are caught.
+  it('redacts ws(s) URL-embedded credentials in "connected to <linkUrl>" lines (closes #604)', () => {
+    const raw =
+      "[node-link] connected to wss://relayuser:FAKE_URL_PASS_aaaaaaaa@hub.example.test/hub/node-link";
+    const out = redactText(raw).value;
+    expect(out).not.toContain('FAKE_URL_PASS_aaaaaaaa');
+    expect(out).not.toContain('relayuser');
+    expect(out).toContain('hub.example.test');
+  });
+
+  it('redacts ws:// URL-embedded credentials (insecure transport variant)', () => {
+    const raw =
+      "[node-link] retrying ws://relayuser:FAKE_URL_PASS_bbbbbbbb@hub.example.test/hub/node-link";
+    const out = redactText(raw).value;
+    expect(out).not.toContain('FAKE_URL_PASS_bbbbbbbb');
+    expect(out).not.toContain('relayuser');
+    expect(out).toContain('hub.example.test');
+  });
+
+  it('redacts URL-embedded credentials behind less-common schemes', () => {
+    const raw =
+      "[adapter] proxy at socks5://relayuser:FAKE_URL_PASS_cccccccc@socks.example.test:1080";
+    const out = redactText(raw).value;
+    expect(out).not.toContain('FAKE_URL_PASS_cccccccc');
+    expect(out).not.toContain('relayuser');
+    expect(out).toContain('socks.example.test');
+  });
 
   it('redacts Authorization headers if a node-link RPC error path echoes request headers', () => {
     const raw =


### PR DESCRIPTION
## Summary

Closes #604. The diag bundle url-credential regex only matched `http(s)://` URLs, so logs from `server/node-link-client.ts:411` of the form `connected to wss://user:pass@hub.example.com/hub/node-link` leaked the embedded credential into the shipped diagnostics bundle.

Found while #598 added coverage in `test/shared/redaction-coverage.test.ts` (it was marked `it.fails` against #604 as a known-gap sentinel).

## Fix

One-line regex broadening from `(https?:\/\/)` to `([a-z][a-z0-9+.-]*:\/\/)` with the `i` flag for case-insensitive scheme matching. Now covers any RFC-3986-style URI scheme:

- `ws://user:pass@host` — pre-fix: leaked
- `wss://user:pass@host` — pre-fix: leaked (the actual node-link path)
- `http(s)://...` — already covered, still covered
- `socks5://...` — also now covered (proxy diag logs)

No other behavior change — host/path preservation, replacement format (`$1<REDACTED>:<REDACTED>@`), counts, and the rule id (`url-credential`) are all unchanged.

## Tests

- Flipped the existing #604 `it.fails` marker in `test/shared/redaction-coverage.test.ts` to a passing `it` assertion. The regression sentinel is now the passing test — any future narrowing of the regex breaks it.
- Added two more scheme cases: `ws://` (insecure variant) and `socks5://` (proxy variant) so the broader scheme coverage is locked in.

`npm run check` 0 errors. `npm test` 3246/3247 passed; the single fail is an unrelated `test/agent-browser.test.ts` playwright timeout. Isolated re-run of `test/workbench-custom-blocks + test/agent-browser` passes 125/125 — confirming the failure is a parallel-test race, not from this PR.

## Test plan

- [ ] Merge to `nightly`.
- [ ] Source-deploy devbox hub. No node restart.
- [ ] Run a diag bundle that exercises the node-link reconnect path with a deliberately-credentialed hub URL (`wss://user:pass@host`); confirm the diag tarball does not contain the cleartext credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)