### PR TITLE
feat: durability badge + reconnect-aware controls (#661)

### DIFF
--- a/docs/SESSION_DURABILITY.md
+++ b/docs/SESSION_DURABILITY.md
@@ -80,10 +80,27 @@ The existing WebSocket attach path keeps streaming raw scrollback bytes to
 xterm clients — this REST snapshot is a separate, optional read for status
 cards, agent adapters, and reattach UX that need a typed view.
 
+## Frontend reconnect UX
+
+`frontend/src/lib/session-durability.ts` maps each `SessionDurabilityState`
+to a `{ statusDot, label, severity }` badge consumed by `SessionItem` and
+mobile surfaces. `durabilityDisabledReason(state)` returns a typed string
+when controls should be disabled (`stale-node`, `ended`, `error`) and
+`null` otherwise. `permission-needed` deliberately does NOT disable
+controls — the operator is supposed to answer prompts.
+
+`activeWorkMobileControlState` consults the helper so the existing
+disabled-reason fields on the mobile Active Work card surface the
+durability reason ahead of the older "stale read model" / "${status} node"
+messages.
+
+The frontend subscribes to the `session-durability-changed` event stream
+and updates the matching session in `useSessionsStore` without refetching
+the full list (`handleDurabilityChanged`).
+
 ## Out of scope (later #614 slices)
 
-- Reconnect UX badges (slice 3).
-- Cross-node/remote replay forwarding (slice 3).
+- Cross-node/remote replay forwarding.
 - Web-session replay redesign (existing `WebSession.messages` buffer is
   unchanged in slice 2).
 - Per-node/per-connection/per-session durability config knobs (slice 4).

--- a/frontend/src/components/SessionItem.tsx
+++ b/frontend/src/components/SessionItem.tsx
@@ -1,7 +1,13 @@
 import React, { useMemo } from 'react';
-import type { SessionSummary, WorktreeInfo, RepoInfo, GitStatus } from '../lib/types.js';
+import type {
+  SessionSummary,
+  WorktreeInfo,
+  RepoInfo,
+  GitStatus,
+} from '../lib/types.js';
 import { formatRelativeTime } from '../lib/utils.js';
-import StatusDot from './StatusDot.js';
+import { durabilityToBadge } from '../lib/session-durability.js';
+import StatusDot, { type StatusDotStatus } from './StatusDot.js';
 import CipherText from './CipherText.js';
 import MarqueeText from './MarqueeText.js';
 import './SessionItem.css';
@@ -32,7 +38,10 @@ export type IdleRepoVariant = {
   repo: RepoInfo;
 };
 
-export type ItemVariant = ActiveVariant | InactiveWorktreeVariant | IdleRepoVariant;
+export type ItemVariant =
+  | ActiveVariant
+  | InactiveWorktreeVariant
+  | IdleRepoVariant;
 
 export interface SessionItemProps {
   variant: ItemVariant;
@@ -46,74 +55,128 @@ function deriveDisplayName(variant: ItemVariant): string {
   switch (variant.kind) {
     case 'active': {
       if (variant.session.worktreePath === null) {
-        const wasRenamed = variant.session.displayName && variant.session.displayName !== variant.session.repoName;
+        const wasRenamed =
+          variant.session.displayName &&
+          variant.session.displayName !== variant.session.repoName;
         return wasRenamed ? variant.session.displayName : 'default';
       }
-      return variant.session.displayName || variant.session.repoName || variant.session.id;
+      return (
+        variant.session.displayName ||
+        variant.session.repoName ||
+        variant.session.id
+      );
     }
-    case KIND_INACTIVE_WORKTREE: return variant.worktree.displayName || variant.worktree.name;
-    case 'idle-repo': return 'default';
+    case KIND_INACTIVE_WORKTREE:
+      return variant.worktree.displayName || variant.worktree.name;
+    case 'idle-repo':
+      return 'default';
   }
 }
 
 function deriveBranchName(variant: ItemVariant): string {
   switch (variant.kind) {
-    case 'active': return variant.session.branchName || '';
-    case KIND_INACTIVE_WORKTREE: return variant.worktree.branchName || '';
-    case 'idle-repo': return variant.repo.defaultBranch || '';
+    case 'active':
+      return variant.session.branchName || '';
+    case KIND_INACTIVE_WORKTREE:
+      return variant.worktree.branchName || '';
+    case 'idle-repo':
+      return variant.repo.defaultBranch || '';
   }
 }
 
 function deriveLastActivity(variant: ItemVariant): string {
   switch (variant.kind) {
-    case 'active': return formatRelativeTime(variant.session.lastActivity);
-    case KIND_INACTIVE_WORKTREE: return formatRelativeTime(variant.worktree.lastActivity);
-    case 'idle-repo': return '';
+    case 'active':
+      return formatRelativeTime(variant.session.lastActivity);
+    case KIND_INACTIVE_WORKTREE:
+      return formatRelativeTime(variant.worktree.lastActivity);
+    case 'idle-repo':
+      return '';
   }
 }
 
-function derivePrDisplay(gitStatus: GitStatus | undefined): { icon: string; cls: string } {
+function derivePrDisplay(gitStatus: GitStatus | undefined): {
+  icon: string;
+  cls: string;
+} {
   if (!gitStatus) return { icon: '', cls: '' };
   const icons: Record<string, string> = { open: '○', merged: '⬤', closed: '⊗' };
-  const classes: Record<string, string> = { open: 'pr-icon pr-open', merged: 'pr-icon pr-merged', closed: 'pr-icon pr-closed' };
+  const classes: Record<string, string> = {
+    open: 'pr-icon pr-open',
+    merged: 'pr-icon pr-merged',
+    closed: 'pr-icon pr-closed',
+  };
   const state = gitStatus.prState ?? '';
   return { icon: icons[state] ?? '', cls: classes[state] ?? '' };
 }
 
-export function SessionItem({ variant, gitStatus, isLoading = false, onClick }: SessionItemProps) {
+export function SessionItem({
+  variant,
+  gitStatus,
+  isLoading = false,
+  onClick,
+}: SessionItemProps) {
   const displayName = useMemo(() => deriveDisplayName(variant), [variant]);
   const branchName = useMemo(() => deriveBranchName(variant), [variant]);
   const lastActivity = useMemo(() => deriveLastActivity(variant), [variant]);
-  const { icon: prIcon, cls: prIconClass } = useMemo(() => derivePrDisplay(gitStatus), [gitStatus]);
+  const { icon: prIcon, cls: prIconClass } = useMemo(
+    () => derivePrDisplay(gitStatus),
+    [gitStatus]
+  );
 
   const isSelected = variant.kind === 'active' && variant.isSelected;
   const isActive = variant.kind === 'active';
-  const displayState = isActive ? variant.status : 'disconnected';
+  const legacyDisplayState = isActive ? variant.status : 'disconnected';
+  // Prefer the #614 durability state when the backend supplies it; fall
+  // back to the legacy coarse state for old summaries / inactive items.
+  const activeDurability = isActive ? variant.session.durability : undefined;
+  const dotStatus: StatusDotStatus = activeDurability
+    ? durabilityToBadge(activeDurability).statusDot
+    : (legacyDisplayState as StatusDotStatus);
+  const dotTitle = activeDurability
+    ? durabilityToBadge(activeDurability).label
+    : undefined;
 
-  const liClass = ['session-item', isActive ? 'active-session' : KIND_INACTIVE_WORKTREE, isSelected && 'selected', isLoading && 'loading']
-    .filter(Boolean).join(' ');
+  const liClass = [
+    'session-item',
+    isActive ? 'active-session' : KIND_INACTIVE_WORKTREE,
+    isSelected && 'selected',
+    isLoading && 'loading',
+  ]
+    .filter(Boolean)
+    .join(' ');
 
   return (
     <li className={liClass} onClick={onClick}>
       <div className="session-info">
         <div className="session-row-1">
-          <span className="status-dot-wrap">
-            <StatusDot status={displayState as 'running' | 'idle' | 'attention' | 'disconnected'} size={8} />
+          <span className="status-dot-wrap" title={dotTitle}>
+            <StatusDot status={dotStatus} size={8} />
           </span>
           <span className="session-name">
             <MarqueeText>
-              <span className="session-name-text"><CipherText text={displayName} loading={isLoading} /></span>
+              <span className="session-name-text">
+                <CipherText text={displayName} loading={isLoading} />
+              </span>
             </MarqueeText>
           </span>
         </div>
         <div className="session-row-2">
-          {lastActivity ? <span className="session-time">{lastActivity}</span> : null}
-          {branchName ? <span className="session-branch">{branchName}</span> : null}
+          {lastActivity ? (
+            <span className="session-time">{lastActivity}</span>
+          ) : null}
+          {branchName ? (
+            <span className="session-branch">{branchName}</span>
+          ) : null}
           {prIcon ? <span className={prIconClass}>{prIcon}</span> : null}
           {gitStatus && (gitStatus.additions || gitStatus.deletions) ? (
             <span className="git-diff">
-              {gitStatus.additions ? <span className="diff-add">+{gitStatus.additions}</span> : null}
-              {gitStatus.deletions ? <span className="diff-del">-{gitStatus.deletions}</span> : null}
+              {gitStatus.additions ? (
+                <span className="diff-add">+{gitStatus.additions}</span>
+              ) : null}
+              {gitStatus.deletions ? (
+                <span className="diff-del">-{gitStatus.deletions}</span>
+              ) : null}
             </span>
           ) : null}
         </div>

--- a/frontend/src/hooks/useEventSocket.ts
+++ b/frontend/src/hooks/useEventSocket.ts
@@ -147,9 +147,7 @@ function eventSessionScope(msg: {
 }): SessionEventScope {
   const localSessionId = msg.localSessionId ?? msg.sessionId;
   return {
-    ...(localSessionId
-      ? { sessionId: localSessionId, localSessionId }
-      : {}),
+    ...(localSessionId ? { sessionId: localSessionId, localSessionId } : {}),
     ...(msg.nodeId ? { nodeId: msg.nodeId } : {}),
     ...(msg.globalSessionId ? { globalSessionId: msg.globalSessionId } : {}),
   };
@@ -199,7 +197,9 @@ function applyHubNodeStatusEvent(
         ...(msg.manifest
           ? {
               hostname: msg.manifest.hostname,
-              ...(msg.manifest.homeDir ? { homeDir: msg.manifest.homeDir } : {}),
+              ...(msg.manifest.homeDir
+                ? { homeDir: msg.manifest.homeDir }
+                : {}),
               platform: msg.manifest.platform,
               arch: msg.manifest.arch,
               relayVersion: msg.manifest.relayVersion,
@@ -292,6 +292,19 @@ export function useEventSocket({
             msg.sessionId,
             msg.state,
             msg.permissionType,
+            eventSessionScope(msg)
+          );
+      },
+      'session-durability-changed': (msg) => {
+        // Push the transition into the session store so badges + disabled
+        // controls update without refetching the whole list. The hub
+        // emits one event per real change, so this is a thin handler.
+        queryClient.invalidateQueries({ queryKey: ['active-work'] });
+        useSessionsStore
+          .getState()
+          .handleDurabilityChanged(
+            msg.sessionId,
+            msg.to,
             eventSessionScope(msg)
           );
       },

--- a/frontend/src/lib/active-work-control.ts
+++ b/frontend/src/lib/active-work-control.ts
@@ -6,6 +6,7 @@ import type {
   WorkContextActiveGroup,
   WorkContextSessionSummary,
 } from './types.js';
+import { durabilityDisabledReason } from './session-durability.js';
 
 export interface ActiveWorkMobileControlState {
   attachDisabledReason: string | null;
@@ -70,6 +71,12 @@ function liveControlDisabledReason(
   session?: WorkContextSessionSummary
 ): string | null {
   if (!session) return 'no session selected';
+  // Session-level durability overrides coarse live/node checks: a session
+  // that landed in `stale-node` / `ended` / `error` should disable
+  // controls even if other signals say "online", and the typed reason is
+  // more honest than the legacy `${status} node` message.
+  const durabilityReason = durabilityDisabledReason(session.durability);
+  if (durabilityReason) return durabilityReason;
   if (!session.live) return 'last-known session only';
   if (group.node.status !== 'online') return `${group.node.status} node`;
   if (group.staleReadModel) return 'stale read model';

--- a/frontend/src/lib/session-durability.ts
+++ b/frontend/src/lib/session-durability.ts
@@ -1,0 +1,63 @@
+// Frontend visual mapping for #614 durability states. Keeps the shared
+// `SessionDurabilityState` enum decoupled from React/UI rendering decisions —
+// the enum lives in `shared/session-durability.ts`; this module owns the
+// label/colour mapping consumed by `SessionItem`, mobile cards, and tests.
+
+import type { SessionDurabilityState } from '../../../shared/session-durability.js';
+import type { StatusDotStatus } from '../components/StatusDot.js';
+
+export interface SessionDurabilityBadge {
+  /** Maps to an existing `StatusDot` color token to keep the design system intact. */
+  statusDot: StatusDotStatus;
+  /** Short label, lowercased per DESIGN.md. Display max 16 chars. */
+  label: string;
+  /** Severity ordering for sorting/aria. Lower = more attention. */
+  severity: number;
+}
+
+const BADGES: Record<SessionDurabilityState, SessionDurabilityBadge> = {
+  'permission-needed': {
+    statusDot: 'permission-prompt',
+    label: 'needs permission',
+    severity: 0,
+  },
+  error: { statusDot: 'attention', label: 'error', severity: 1 },
+  'stale-node': { statusDot: 'warning', label: 'stale node', severity: 2 },
+  ended: { statusDot: 'disconnected', label: 'ended', severity: 3 },
+  'awaiting-start': {
+    statusDot: 'initializing',
+    label: 'starting',
+    severity: 4,
+  },
+  'running-detached': { statusDot: 'idle', label: 'detached', severity: 5 },
+  'running-attached': { statusDot: 'running', label: 'live', severity: 6 },
+};
+
+export function durabilityToBadge(
+  state: SessionDurabilityState
+): SessionDurabilityBadge {
+  // Closed enum — TS prevents unknown values at the call site; the lookup
+  // is total. Defensive return only catches accidental string-cast misuse.
+  return BADGES[state] ?? BADGES['running-attached'];
+}
+
+/**
+ * Returns a typed disabled-reason code when a session's durability state
+ * means a live control (input, kill) cannot honestly act on the process.
+ * `null` means controls are allowed; `permission-needed` is intentionally
+ * NOT disabled — the operator is supposed to answer it.
+ */
+export function durabilityDisabledReason(
+  state: SessionDurabilityState | undefined
+): string | null {
+  if (state === 'stale-node') {
+    return 'stale node — controls cannot prove the process is alive';
+  }
+  if (state === 'ended') {
+    return 'session ended — no process to control';
+  }
+  if (state === 'error') {
+    return 'session in error state — controls disabled until recovery';
+  }
+  return null;
+}

--- a/frontend/src/lib/stores/sessions.ts
+++ b/frontend/src/lib/stores/sessions.ts
@@ -37,6 +37,7 @@ import {
   type InterventionRecord,
   type TabControlEvent,
 } from '../../../../shared/control-state.js';
+import type { SessionDurabilityState } from '../../../../shared/session-durability.js';
 
 const NOTIFICATIONS_STORAGE_KEY = 'claude-remote-notifications';
 const ACTIVE_SESSION_KEY = 'claude-remote-active-session';
@@ -257,6 +258,11 @@ export interface SessionsState {
     permissionType?: 'approval' | 'question',
     scope?: SessionEventScope
   ) => void;
+  handleDurabilityChanged: (
+    sessionId: string,
+    durability: SessionDurabilityState,
+    scope?: SessionEventScope
+  ) => void;
   handleUserViewed: (sessionId: string, scope?: SessionEventScope) => void;
   handleTabControlEvent: (event: TabControlEvent) => void;
   setNotificationEnabled: (sessionId: string, enabled: boolean) => void;
@@ -329,7 +335,12 @@ function sessionsShareScopedIdentity(
     return left.nodeId === right.nodeId && left.id === right.id;
   }
 
-  if (left.globalSessionId || right.globalSessionId || left.nodeId || right.nodeId) {
+  if (
+    left.globalSessionId ||
+    right.globalSessionId ||
+    left.nodeId ||
+    right.nodeId
+  ) {
     return false;
   }
 
@@ -363,7 +374,8 @@ function storedSessionIdMatchesSession(
   }
 
   return (
-    session.id === storedId && isLegacyLocalSessionIdUnambiguous(sessions, storedId)
+    session.id === storedId &&
+    isLegacyLocalSessionIdUnambiguous(sessions, storedId)
   );
 }
 
@@ -799,6 +811,20 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
     });
   },
 
+  handleDurabilityChanged: (sessionId, durability, scope) => {
+    set((state) => {
+      let changed = false;
+      const sessions = state.sessions.map((s) => {
+        if (!sessionMatchesEventScope(s, sessionId, scope)) return s;
+        if (s.durability === durability) return s;
+        changed = true;
+        return { ...s, durability };
+      });
+      if (!changed) return state;
+      return { ...state, sessions };
+    });
+  },
+
   handleUserViewed: (sessionId, scope) => {
     set((state) => {
       const viewedSession = resolveSessionByKey(state.sessions, sessionId);
@@ -829,9 +855,12 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
       sessionId: identity.sessionId,
       localSessionId: identity.sessionId,
       ...(identity.nodeId ? { nodeId: identity.nodeId } : {}),
-      ...(identity.globalSessionId ? { globalSessionId: identity.globalSessionId } : {}),
+      ...(identity.globalSessionId
+        ? { globalSessionId: identity.globalSessionId }
+        : {}),
     };
-    const cacheKey = identity.globalSessionId ?? `${identity.nodeId}:${identity.sessionId}`;
+    const cacheKey =
+      identity.globalSessionId ?? `${identity.nodeId}:${identity.sessionId}`;
     set((state) => {
       const sessions = state.sessions.map((session): SessionSummary => {
         if (!sessionMatchesEventScope(session, identity.sessionId, scope)) {
@@ -858,7 +887,10 @@ export const useSessionsStore = create<SessionsState>()((set, get) => ({
       });
       if (event.type !== 'tab.intervention') return { sessions };
       const previous = state.interventionsBySession[cacheKey] ?? [];
-      const next = [event.intervention, ...previous.filter((record) => record.id !== event.intervention.id)].slice(0, 12);
+      const next = [
+        event.intervention,
+        ...previous.filter((record) => record.id !== event.intervention.id),
+      ].slice(0, 12);
       return {
         sessions,
         interventionsBySession: {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -6,6 +6,7 @@ import type {
   WorktreeInstanceId,
 } from '../../../shared/identity.js';
 import type { SessionEnvelope } from '../../../shared/session-envelope.js';
+import type { SessionDurabilityState } from '../../../shared/session-durability.js';
 import type {
   RepoIdentityWarning,
   ResolvedRemoteIdentity,
@@ -179,6 +180,8 @@ export interface SessionSummary {
   worktreeInstanceId?: WorktreeInstanceId;
   useTmux?: boolean | undefined;
   status?: 'active' | 'disconnected' | undefined;
+  /** #614: derived durability state. Optional for legacy summaries. */
+  durability?: SessionDurabilityState | undefined;
   agentState?: AgentState | undefined;
   workspaceId?: string | undefined;
   additionalDirs?: string[] | undefined;
@@ -216,6 +219,7 @@ export interface WorkContextSessionSummary {
   branchName?: string;
   displayName?: string;
   status?: SessionSummary['status'];
+  durability?: SessionSummary['durability'];
   agentState?: SessionSummary['agentState'];
   currentActivity?: SessionSummary['currentActivity'];
   controlMode?: ControlMode;

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -23,6 +23,7 @@ import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
 import type { TabControlEvent } from '../../../shared/control-state.js';
 import type { HubNodeStatus } from '../../../shared/relay-node-protocol.js';
+import type { SessionDurabilityState } from '../../../shared/session-durability.js';
 import type { NodeManifest } from '../../../shared/node-manifest.js';
 
 const logger = createLogger('pty-ws');
@@ -111,7 +112,14 @@ export type EventMessage =
       lastSeenAt: string;
       manifest?: NodeManifest;
     }
-  | { type: 'server-restarting'; reason?: string };
+  | { type: 'server-restarting'; reason?: string }
+  | ({
+      type: 'session-durability-changed';
+      sessionId: string;
+      from: SessionDurabilityState | undefined;
+      to: SessionDurabilityState;
+      at: string;
+    } & SessionScopedEvent);
 
 type EventCallback = (msg: EventMessage) => void;
 type EventOpenCallback = () => void;

--- a/test/session-durability-ui.test.ts
+++ b/test/session-durability-ui.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import {
+  durabilityToBadge,
+  durabilityDisabledReason,
+} from '../frontend/src/lib/session-durability.js';
+import { SESSION_DURABILITY_STATES } from '../shared/session-durability.js';
+import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
+import type {
+  WorkContextActiveGroup,
+  WorkContextSessionSummary,
+} from '../frontend/src/lib/types.js';
+import { activeWorkMobileControlState } from '../frontend/src/lib/active-work-control.js';
+
+const session = (
+  overrides: Partial<WorkContextSessionSummary> = {}
+): WorkContextSessionSummary => ({
+  id: 's1',
+  nodeId: DEFAULT_LOCAL_NODE_ID,
+  tabKind: 'terminal',
+  type: 'agent',
+  mode: 'pty',
+  agent: 'codex',
+  cwd: '/repo/relay-ide',
+  status: 'active',
+  agentState: 'processing',
+  controlMode: 'agent-driven',
+  controlFreshness: 'fresh',
+  relationship: 'primary',
+  associatedAt: '2026-05-17T00:00:00.000Z',
+  live: true,
+  ...overrides,
+});
+
+const onlineGroup = (
+  sessions: WorkContextSessionSummary[]
+): WorkContextActiveGroup => ({
+  id: 'work-1',
+  context: null,
+  node: {
+    nodeId: DEFAULT_LOCAL_NODE_ID,
+    status: 'online',
+    kind: 'local',
+    lastSeenAt: '2026-05-17T00:00:00.000Z',
+  },
+  sessions,
+  staleReadModel: false,
+});
+
+describe('durabilityToBadge', () => {
+  it('returns a typed badge for every closed-enum member', () => {
+    for (const state of SESSION_DURABILITY_STATES) {
+      const badge = durabilityToBadge(state);
+      expect(badge.label.length).toBeGreaterThan(0);
+      expect(badge.statusDot).toBeTruthy();
+      expect(typeof badge.severity).toBe('number');
+    }
+  });
+
+  it('orders permission-needed and error ahead of background states', () => {
+    const permission = durabilityToBadge('permission-needed').severity;
+    const error = durabilityToBadge('error').severity;
+    const live = durabilityToBadge('running-attached').severity;
+    expect(permission).toBeLessThan(error);
+    expect(error).toBeLessThan(live);
+  });
+});
+
+describe('durabilityDisabledReason', () => {
+  it('disables controls for stale-node, ended, and error states', () => {
+    expect(durabilityDisabledReason('stale-node')).toMatch(/stale node/);
+    expect(durabilityDisabledReason('ended')).toMatch(/ended/);
+    expect(durabilityDisabledReason('error')).toMatch(/error/);
+  });
+
+  it('does NOT disable controls for permission-needed', () => {
+    // The operator is supposed to answer permission prompts — disabling
+    // controls would defeat the entire flow.
+    expect(durabilityDisabledReason('permission-needed')).toBeNull();
+  });
+
+  it('does not disable controls for happy-path states', () => {
+    expect(durabilityDisabledReason('running-attached')).toBeNull();
+    expect(durabilityDisabledReason('running-detached')).toBeNull();
+    expect(durabilityDisabledReason('awaiting-start')).toBeNull();
+    expect(durabilityDisabledReason(undefined)).toBeNull();
+  });
+});
+
+describe('useSessionsStore.handleDurabilityChanged', () => {
+  it('updates the matching session and leaves others alone', async () => {
+    const { useSessionsStore } =
+      await import('../frontend/src/lib/stores/sessions.js');
+    const before = useSessionsStore.getState().sessions;
+    useSessionsStore.setState({
+      sessions: [
+        { id: 'a', durability: 'running-attached' } as never,
+        { id: 'b', durability: 'running-attached' } as never,
+      ],
+    });
+    useSessionsStore.getState().handleDurabilityChanged('a', 'stale-node');
+    const after = useSessionsStore.getState().sessions;
+    expect(after.find((s) => s.id === 'a')?.durability).toBe('stale-node');
+    expect(after.find((s) => s.id === 'b')?.durability).toBe(
+      'running-attached'
+    );
+    useSessionsStore.setState({ sessions: before });
+  });
+});
+
+describe('activeWorkMobileControlState respects durability', () => {
+  it('disables live input with a typed reason when durability is stale-node', () => {
+    const s = session({ durability: 'stale-node' });
+    const state = activeWorkMobileControlState(onlineGroup([s]), s);
+    expect(state.smallInputDisabledReason).toMatch(/stale node/);
+    expect(state.attachDisabledReason).toMatch(/stale node/);
+    expect(state.destructiveDisabledReason).toMatch(/stale node/);
+  });
+
+  it('disables live controls when durability is ended even if node is online', () => {
+    const s = session({ durability: 'ended' });
+    const state = activeWorkMobileControlState(onlineGroup([s]), s);
+    expect(state.smallInputDisabledReason).toMatch(/ended/);
+  });
+
+  it('leaves controls enabled for running-attached + online node', () => {
+    const s = session({ durability: 'running-attached' });
+    const state = activeWorkMobileControlState(onlineGroup([s]), s);
+    expect(state.smallInputDisabledReason).toBeNull();
+    expect(state.attachDisabledReason).toBeNull();
+  });
+});


### PR DESCRIPTION
Slice 3 of #614. Frontend now reads `SessionSummary.durability` (slice 1), renders an honest badge, disables controls when the session is `stale-node`/`ended`/`error`, and pushes `session-durability-changed` transitions through the existing event stream into the sessions store without a full refetch.

## Summary
- `frontend/src/lib/session-durability.ts` — `durabilityToBadge` maps each closed-enum state to `{ statusDot, label, severity }`. `durabilityDisabledReason` returns a typed reason for stale-node / ended / error, `null` otherwise. `permission-needed` deliberately does NOT disable controls.
- `SessionItem` renders the durability badge when available; falls back to the legacy coarse colour for old summaries / inactive items.
- `active-work-control.ts` consults `durabilityDisabledReason` before legacy live/node checks so the mobile Active Work card surfaces the honest reason on input/attach/destructive controls.
- `ws.ts` + `useEventSocket` + `useSessionsStore.handleDurabilityChanged` carry the transition end-to-end; handler short-circuits when state is unchanged.
- `SessionSummary.durability?: SessionDurabilityState` added to frontend types + `WorkContextSessionSummary`.
- `docs/SESSION_DURABILITY.md` gets a Frontend reconnect UX section; slice-3 lines removed from out-of-scope.

## Test plan
- [x] 9 new tests: every closed-enum badge, severity ordering, disabled-reason matrix (including the `permission-needed = null` rule), mobile control state with durability override, store reducer happy + miss paths.
- [x] `npm run check` — 0 errors, 79 preexisting warnings.
- [x] `npm run build` — clean.
- [ ] Reviewer: confirm `permission-needed = null` rule is the right call (we want operators to answer prompts; disabling controls would make that impossible).
- [ ] Reviewer: confirm legacy fallback in `SessionItem` is fine for older summaries that may not have \`durability\`.

Closes #661, advances #614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)