### PR TITLE
feat: configurable session durability scrollback cap (#664)

### DIFF
--- a/docs/SESSION_DURABILITY.md
+++ b/docs/SESSION_DURABILITY.md
@@ -98,10 +98,35 @@ The frontend subscribes to the `session-durability-changed` event stream
 and updates the matching session in `useSessionsStore` without refetching
 the full list (`handleDurabilityChanged`).
 
+## Configurable scrollback cap
+
+`resolveSessionDurabilityScrollbackBytes(config, repoPath, workspaceId?)`
+resolves the effective per-session FIFO cap. Precedence, most specific
+first:
+
+1. `Config.repoSettings[repoPath].sessionDurability.scrollbackBytes`
+2. `Config.workspaces[].settings.sessionDurability.scrollbackBytes`
+3. `Config.sessionDurability.scrollbackBytes` (global)
+4. `Config.maxScrollbackPerSessionBytes` (legacy top-level)
+5. fallback to the 256 KB hard default in `pty-handler.ts`
+
+Non-positive values are rejected with a warning; the resolver falls
+through to the next layer. `resolveSessionSettings(...)` exposes the
+result as `ResolvedSessionSettings.scrollbackBytes`; session creation
+paths thread it into `CreateParams.maxScrollbackBytes`, which the PTY
+handler persists on `PtySession.scrollbackCapacityBytes` and surfaces in
+`SessionReplaySnapshot.capacityBytes` (slice 2).
+
+Durability mode (Wave's "standard" vs "durable") is not yet a separable
+knob in Relay — every Relay session is durable by construction because
+tmux + node-pty keep the process alive across attach drops. The config
+schema reserves the `sessionDurability` namespace so a future slice can
+add a mode toggle without breaking the surface.
+
 ## Out of scope (later #614 slices)
 
 - Cross-node/remote replay forwarding.
 - Web-session replay redesign (existing `WebSession.messages` buffer is
   unchanged in slice 2).
-- Per-node/per-connection/per-session durability config knobs (slice 4).
+- Durability mode toggle (standard vs durable).
 - Live process migration. No raw infinite transcript storage.

--- a/server/config.ts
+++ b/server/config.ts
@@ -9,6 +9,7 @@ import type {
   WorkspaceSettings,
   WorktreeMetadata,
 } from './types.js';
+import { createLogger } from './logger.js';
 
 export const DEFAULT_PRESETS: FilterPreset[] = [
   {
@@ -150,6 +151,54 @@ export interface ResolvedSessionSettings {
   continuePolicy: ContinuePolicy;
   useTmux: boolean;
   claudeArgs: string[];
+  /** #614 slice 4: effective per-session scrollback cap, undefined = use pty-handler default. */
+  scrollbackBytes?: number;
+}
+
+const SESSION_DURABILITY_LOG = createLogger('session-durability-config');
+
+/**
+ * Resolve the effective per-session scrollback cap for a (config, workspace,
+ * repo) tuple. Precedence (most specific first):
+ *   1. repo-specific `WorkspaceSettings.sessionDurability.scrollbackBytes`
+ *   2. workspace-level `WorkspaceSettings.sessionDurability.scrollbackBytes`
+ *   3. global `Config.sessionDurability.scrollbackBytes`
+ *   4. legacy `Config.maxScrollbackPerSessionBytes`
+ *   5. undefined — pty-handler applies its own 256 KB default.
+ * Non-positive values are rejected with a warning and fall through.
+ */
+export function resolveSessionDurabilityScrollbackBytes(
+  config: Config,
+  repoPath: string,
+  workspaceId?: string
+): number | undefined {
+  const repoOverride =
+    config.repoSettings?.[repoPath]?.sessionDurability?.scrollbackBytes;
+  const wsOverride = workspaceId
+    ? config.workspaces?.find((w) => w.id === workspaceId)?.settings
+        ?.sessionDurability?.scrollbackBytes
+    : undefined;
+  const globalOverride = config.sessionDurability?.scrollbackBytes;
+  const legacyTopLevel = config.maxScrollbackPerSessionBytes;
+
+  for (const [layer, value] of [
+    ['repo', repoOverride],
+    ['workspace', wsOverride],
+    ['global.sessionDurability', globalOverride],
+    ['legacy.maxScrollbackPerSessionBytes', legacyTopLevel],
+  ] as const) {
+    if (value === undefined) continue;
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+      SESSION_DURABILITY_LOG.warn(
+        'ignoring non-positive scrollbackBytes at layer %s (got %s); falling through',
+        layer,
+        String(value)
+      );
+      continue;
+    }
+    return value;
+  }
+  return undefined;
 }
 
 export interface SessionSettingsOverrides {
@@ -202,11 +251,18 @@ export function resolveSessionSettings(
     return (globalDefaults.defaultFramework ?? 'claude') as AgentType;
   })();
 
+  const scrollbackBytes = resolveSessionDurabilityScrollbackBytes(
+    config,
+    repoPath,
+    workspaceId
+  );
+
   return {
     agent: overrides.agent ?? agentFromLayers,
     yolo: overrides.yolo ?? merged.defaultYolo ?? false,
     continuePolicy: overrides.continuePolicy ?? configPolicy,
     useTmux: true,
+    ...(scrollbackBytes !== undefined ? { scrollbackBytes } : {}),
     claudeArgs: overrides.claudeArgs ?? merged.claudeArgs ?? [],
   };
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -719,6 +719,8 @@ type AgentSessionParams = {
   controlState?: ReturnType<typeof createAgentDrivenInitialControlState>;
   /** Port env var names to inject for this worktree (from repo settings) */
   portVariables?: string[] | undefined;
+  /** #614 slice 4: effective scrollback cap from resolveSessionSettings. */
+  scrollbackBytes?: number | undefined;
 };
 
 type TerminalSessionParams = {
@@ -792,6 +794,9 @@ function createAgentSessionRecord(params: AgentSessionParams): CreateResult {
     }),
     // Pass port env var names for per-worktree port injection
     portVariables: params.portVariables,
+    ...(params.scrollbackBytes !== undefined
+      ? { maxScrollbackBytes: params.scrollbackBytes }
+      : {}),
   });
 
   if (params.worktreePath) {
@@ -1998,6 +2003,9 @@ async function main(): Promise<void> {
           }),
           // Pass port env var names for per-worktree port injection
           portVariables,
+          ...(resolved.scrollbackBytes !== undefined
+            ? { maxScrollbackBytes: resolved.scrollbackBytes }
+            : {}),
         });
       },
       broadcastEvent,
@@ -3319,6 +3327,7 @@ async function main(): Promise<void> {
         claudeFullscreen: freshConfig.claudeFullscreen,
         sessionLane,
         portVariables,
+        scrollbackBytes: resolved.scrollbackBytes,
       });
     } catch (err) {
       sendSessionCreateError(res, err, freshConfig.maxPtySessions);

--- a/server/types.ts
+++ b/server/types.ts
@@ -526,6 +526,20 @@ export interface WorkspaceSettings {
 
   /** Environment variable names that should receive per-worktree allocated ports. */
   portVariables?: string[];
+
+  /**
+   * #614 slice 4: per-repo durability overrides. `scrollbackBytes` sets the
+   * effective per-session FIFO cap when this repo creates a new session.
+   * Falls back to `Config.sessionDurability.scrollbackBytes`, then the
+   * legacy top-level `Config.maxScrollbackPerSessionBytes`, then the
+   * 256 KB hard default.
+   */
+  sessionDurability?: SessionDurabilitySettings;
+}
+
+export interface SessionDurabilitySettings {
+  /** Per-session FIFO cap in bytes. Must be > 0. */
+  scrollbackBytes?: number;
 }
 
 export const MOUNTAIN_NAMES = [
@@ -617,6 +631,12 @@ export interface Config {
    * Config-file-only for this release; no settings UI surface yet.
    */
   maxScrollbackGlobalBytes?: number | undefined;
+  /**
+   * #614 slice 4: global durability defaults. `scrollbackBytes` overrides the
+   * legacy `maxScrollbackPerSessionBytes` knob when both are present and is
+   * itself overridden by per-repo `WorkspaceSettings.sessionDurability`.
+   */
+  sessionDurability?: SessionDurabilitySettings | undefined;
   integrations?:
     | {
         jira?: {
@@ -885,6 +905,8 @@ export interface WorkspaceLevelSettings {
   promptGeneral?: string;
   promptFixConflicts?: string;
   promptStartWork?: string;
+  /** #614 slice 4: per-workspace durability overrides; same shape as WorkspaceSettings. */
+  sessionDurability?: SessionDurabilitySettings;
 }
 
 export interface Workspace {

--- a/server/workspace-groups.ts
+++ b/server/workspace-groups.ts
@@ -168,7 +168,9 @@ export function createWorkspaceGroupsRouter(
     }
     const workspaces = config.workspaces ?? [];
     const sorted = workspaces
-      .map((workspace, index) => normalizeWorkspaceForResponse(workspace, index))
+      .map((workspace, index) =>
+        normalizeWorkspaceForResponse(workspace, index)
+      )
       .sort((a, b) => a.order - b.order);
     res.json(sorted);
   });
@@ -504,6 +506,9 @@ export function createWorkspaceGroupsRouter(
             createParams.additionalDirs = additionalDirs;
           if (safeCols != null) createParams.cols = safeCols;
           if (safeRows != null) createParams.rows = safeRows;
+          if (resolved.scrollbackBytes !== undefined) {
+            createParams.maxScrollbackBytes = resolved.scrollbackBytes;
+          }
 
           const activePtySessions = countActivePtySessions(
             sessionDeps.sessions.list?.() ?? []

--- a/test/session-durability-config.test.ts
+++ b/test/session-durability-config.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveSessionSettings,
+  resolveSessionDurabilityScrollbackBytes,
+} from '../server/config.js';
+import type { Config } from '../server/types.js';
+
+const base: Config = {
+  host: '0.0.0.0',
+  port: 3456,
+  cookieTTL: '24h',
+  repos: [],
+  claudeArgs: [],
+  defaultFramework: 'claude',
+  defaultContinue: true,
+  defaultYolo: false,
+  maxPtySessions: 64,
+  launchInTmux: true,
+  defaultNotifications: true,
+  claudeFullscreen: true,
+};
+
+describe('resolveSessionDurabilityScrollbackBytes precedence', () => {
+  it('returns undefined when nothing is configured', () => {
+    expect(resolveSessionDurabilityScrollbackBytes(base, '/r')).toBeUndefined();
+  });
+
+  it('falls back to the legacy top-level cap when nothing else is set', () => {
+    const config: Config = { ...base, maxScrollbackPerSessionBytes: 64_000 };
+    expect(resolveSessionDurabilityScrollbackBytes(config, '/r')).toBe(64_000);
+  });
+
+  it('prefers Config.sessionDurability over the legacy top-level cap', () => {
+    const config: Config = {
+      ...base,
+      maxScrollbackPerSessionBytes: 64_000,
+      sessionDurability: { scrollbackBytes: 128_000 },
+    };
+    expect(resolveSessionDurabilityScrollbackBytes(config, '/r')).toBe(128_000);
+  });
+
+  it('prefers the workspace override over the global cap', () => {
+    const config: Config = {
+      ...base,
+      sessionDurability: { scrollbackBytes: 100_000 },
+      workspaces: [
+        {
+          id: 'ws-1',
+          name: 'work',
+          repos: ['/r'],
+          order: 0,
+          settings: { sessionDurability: { scrollbackBytes: 200_000 } },
+        },
+      ],
+    };
+    expect(resolveSessionDurabilityScrollbackBytes(config, '/r', 'ws-1')).toBe(
+      200_000
+    );
+  });
+
+  it('prefers the per-repo override over workspace and global', () => {
+    const config: Config = {
+      ...base,
+      sessionDurability: { scrollbackBytes: 100_000 },
+      workspaces: [
+        {
+          id: 'ws-1',
+          name: 'work',
+          repos: ['/r'],
+          order: 0,
+          settings: { sessionDurability: { scrollbackBytes: 200_000 } },
+        },
+      ],
+      repoSettings: {
+        '/r': { sessionDurability: { scrollbackBytes: 300_000 } },
+      },
+    };
+    expect(resolveSessionDurabilityScrollbackBytes(config, '/r', 'ws-1')).toBe(
+      300_000
+    );
+  });
+
+  it('falls through past non-positive values with a warning, not crash', () => {
+    const config: Config = {
+      ...base,
+      sessionDurability: { scrollbackBytes: 500_000 },
+      repoSettings: {
+        '/r': { sessionDurability: { scrollbackBytes: 0 } },
+      },
+    };
+    // Per-repo zero is rejected; resolution falls through to the global.
+    expect(resolveSessionDurabilityScrollbackBytes(config, '/r')).toBe(500_000);
+
+    const negative: Config = {
+      ...base,
+      sessionDurability: { scrollbackBytes: -1 },
+      maxScrollbackPerSessionBytes: 64_000,
+    };
+    expect(resolveSessionDurabilityScrollbackBytes(negative, '/r')).toBe(
+      64_000
+    );
+  });
+});
+
+describe('resolveSessionSettings exposes scrollbackBytes', () => {
+  it('does not include scrollbackBytes when nothing is configured', () => {
+    const settings = resolveSessionSettings(base, '/r', {});
+    expect(settings.scrollbackBytes).toBeUndefined();
+  });
+
+  it('returns the resolved per-repo cap', () => {
+    const config: Config = {
+      ...base,
+      repoSettings: {
+        '/r': { sessionDurability: { scrollbackBytes: 333_000 } },
+      },
+    };
+    const settings = resolveSessionSettings(config, '/r', {});
+    expect(settings.scrollbackBytes).toBe(333_000);
+  });
+});


### PR DESCRIPTION
Slice 4 of #614. The per-session FIFO cap was hard-coded at 256 KB. This slice makes it operator-configurable with a documented precedence chain.

## Summary
- `Config.sessionDurability?: { scrollbackBytes?: number }` (global).
- `WorkspaceSettings.sessionDurability` + `WorkspaceLevelSettings.sessionDurability` for per-repo / per-workspace overrides.
- `resolveSessionDurabilityScrollbackBytes(config, repoPath, workspaceId?)` resolves: repo → workspace → global → legacy top-level → undefined (256 KB default). Non-positive values logged + skipped.
- `resolveSessionSettings` exposes the value as `ResolvedSessionSettings.scrollbackBytes`. `AgentSessionParams` and `workspace-groups` create paths thread it into `CreateParams.maxScrollbackBytes` → `PtySession.scrollbackCapacityBytes` → `SessionReplaySnapshot.capacityBytes`.
- `docs/SESSION_DURABILITY.md` gets a Configurable scrollback cap section and notes that Wave's standard/durable mode is intentionally not a separable knob today.

## Test plan
- [x] 8 new tests covering the full precedence chain, legacy compat, non-positive fall-through, and `resolveSessionSettings` exposure.
- [x] `npm run check` — 0 errors, 79 preexisting warnings.
- [ ] Reviewer: confirm precedence direction (more-specific overrides less-specific).
- [ ] Reviewer: confirm legacy `maxScrollbackPerSessionBytes` stays as the lowest precedence rather than getting deprecated outright.

Closes #664, advances #614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)