### PR TITLE
test: session durability failure-matrix QA suite (#667)

### DIFF
--- a/docs/SESSION_DURABILITY.md
+++ b/docs/SESSION_DURABILITY.md
@@ -123,6 +123,37 @@ tmux + node-pty keep the process alive across attach drops. The config
 schema reserves the `sessionDurability` namespace so a future slice can
 add a mode toggle without breaking the surface.
 
+## Failure-matrix runbook
+
+The five durability transitions the epic body promised. Automated coverage
+lives in `test/session-durability-failure-matrix.test.ts`; manual
+verification steps below for the failure modes the unit tests cannot fake.
+
+| Scenario                              | Expected durability | Operator-visible signal                                    |
+| ------------------------------------- | ------------------- | ---------------------------------------------------------- |
+| Browser tab closed while session live | `running-detached`  | Tab badge flips to "detached"; reopening reattaches.       |
+| Node link drops mid-session           | `stale-node`        | Badge flips to "stale node"; live input + kill disabled.   |
+| Node reconnects after link drop       | `running-attached`  | Badge returns to "live"; controls re-enabled.              |
+| PTY process exits (clean or crash)    | `ended` (then gone) | Badge briefly shows "ended" then session leaves the list.  |
+| Agent posts an unrecoverable error    | `error`             | Badge shows "error"; controls disabled with typed reason.  |
+| Permission prompt waiting             | `permission-needed` | Badge pulses; controls stay enabled so operator can reply. |
+
+Manual verification steps for failure modes the automated suite cannot
+simulate end-to-end:
+
+- **Laptop sleep / network flap.** Pair a remote node, open a session,
+  put the laptop running the hub or the node to sleep. The hub's node
+  registry will flip to `stale` then `offline` within `staleMs` /
+  `offlineMs`. Durability follows. On wake, the reverse link
+  reconnects and durability returns to `running-attached`.
+- **Hub restart.** Restart the hub while a node session is open. tmux
+  keeps the PTY alive on the node. After hub comes back, the session
+  list shows the session with `running-detached` until the browser
+  attaches; then `running-attached`.
+- **Browser refresh.** Refresh the browser tab. The WS reconnect handler
+  reattaches; durability stays `running-attached` (or briefly flips
+  through `running-detached` if the WS is rebuilt slowly).
+
 ## Out of scope (later #614 slices)
 
 - Cross-node/remote replay forwarding.

--- a/test/session-durability-failure-matrix.test.ts
+++ b/test/session-durability-failure-matrix.test.ts
@@ -1,0 +1,210 @@
+// #614 slice 5: failure-matrix QA suite for session durability. Verifies that
+// every documented durability transition surfaces through `sessions.list()`
+// + the `session-durability-changed` event. Where the real failure mode
+// is hard to fake in a unit test (laptop sleep, network flap), we mutate
+// the session signals the production code paths set anyway.
+
+import { describe, it, afterEach, beforeAll, afterAll, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import * as sessions from '../server/sessions.js';
+import type { PtySession } from '../server/types.js';
+import type { SessionDurabilityState } from '../shared/session-durability.js';
+
+const execFileAsync = promisify(execFile);
+const createdIds: string[] = [];
+let tmuxTmpdir: string;
+let previousTmuxTmpdir: string | undefined;
+
+beforeAll(() => {
+  previousTmuxTmpdir = process.env.TMUX_TMPDIR;
+  tmuxTmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-failure-matrix-'));
+  process.env.TMUX_TMPDIR = tmuxTmpdir;
+});
+
+afterEach(async () => {
+  for (const id of createdIds) {
+    try {
+      sessions.kill(id);
+    } catch {
+      // Already killed
+    }
+  }
+  createdIds.length = 0;
+  sessions.setSessionNodeStatusResolver(null);
+  await Promise.resolve();
+});
+
+afterAll(() => {
+  if (tmuxTmpdir) fs.rmSync(tmuxTmpdir, { recursive: true, force: true });
+  if (previousTmuxTmpdir === undefined) delete process.env.TMUX_TMPDIR;
+  else process.env.TMUX_TMPDIR = previousTmuxTmpdir;
+  void execFileAsync('tmux', ['kill-server'], {
+    env: { ...process.env },
+  }).catch(() => {});
+});
+
+function makeSession(label: string): {
+  id: string;
+  session: PtySession;
+} {
+  const result = sessions.create({
+    repoName: label,
+    repoPath: '/tmp',
+    worktreePath: null,
+    cwd: '/tmp',
+    command: '/bin/echo',
+    args: ['hi'],
+  });
+  createdIds.push(result.id);
+  const session = sessions.get(result.id) as PtySession;
+  expect(session).toBeTruthy();
+  return { id: result.id, session };
+}
+
+function durabilityOf(id: string): SessionDurabilityState | undefined {
+  return sessions.list().find((s) => s.id === id)?.durability;
+}
+
+interface CapturedTransition {
+  sessionId: string;
+  from: SessionDurabilityState | undefined;
+  to: SessionDurabilityState;
+}
+
+function captureTransitions(): {
+  unsubscribe: () => void;
+  events: CapturedTransition[];
+} {
+  const events: CapturedTransition[] = [];
+  const unsubscribe = sessions.onSessionDurabilityChanged((event) => {
+    events.push({
+      sessionId: event.sessionId,
+      from: event.from,
+      to: event.to,
+    });
+  });
+  return { unsubscribe, events };
+}
+
+describe('session durability — failure matrix (#614 slice 5)', () => {
+  it('tab close / socket drop while process alive → running-detached', () => {
+    // Closing a browser tab on the live UI flips `session.status` to
+    // `disconnected` once the WS handler clears its attach. The hub keeps
+    // the process running; durability must surface `running-detached`
+    // instead of pretending the session is still attached.
+    const { id, session } = makeSession('tab-close');
+    expect(durabilityOf(id)).toBe('running-attached');
+
+    const cap = captureTransitions();
+    try {
+      session.status = 'disconnected';
+      expect(durabilityOf(id)).toBe('running-detached');
+      const transitions = cap.events.filter((e) => e.sessionId === id);
+      expect(transitions.at(-1)).toMatchObject({
+        from: 'running-attached',
+        to: 'running-detached',
+      });
+    } finally {
+      cap.unsubscribe();
+    }
+  });
+
+  it('node link drops while running-attached → stale-node, reconnect → running-attached', () => {
+    // Production wires a node-status resolver to `hubNodeRegistry`. The
+    // matrix here flips a fake resolver so the transition fires through
+    // the same `emitDurabilityIfChanged` path the hub uses.
+    const { id, session } = makeSession('node-drop');
+    session.nodeId = 'remote-test' as typeof session.nodeId;
+    expect(durabilityOf(id)).toBe('running-attached');
+
+    const cap = captureTransitions();
+    try {
+      let reported: 'online' | 'offline' | 'stale' | 'revoked' = 'online';
+      sessions.setSessionNodeStatusResolver(() => reported);
+      sessions.refreshDurability([id]);
+      expect(durabilityOf(id)).toBe('running-attached');
+
+      reported = 'offline';
+      sessions.refreshDurability([id]);
+      expect(durabilityOf(id)).toBe('stale-node');
+
+      // Node comes back online — durability should return to running-attached
+      // without any other signal changing on the session.
+      reported = 'online';
+      sessions.refreshDurability([id]);
+      expect(durabilityOf(id)).toBe('running-attached');
+
+      const transitions = cap.events.filter((e) => e.sessionId === id);
+      const toStates = transitions.map((t) => t.to);
+      expect(toStates).toEqual(
+        expect.arrayContaining(['stale-node', 'running-attached'])
+      );
+    } finally {
+      cap.unsubscribe();
+    }
+  });
+
+  it('PTY process exit → ended', () => {
+    // `runExitCleanup` flips `session.cleanedUp = true` before removing
+    // the record from the map. The durability derivation must surface
+    // `ended` so any consumer that snapshots the registry mid-cleanup
+    // (or persists last-known summaries) reports the truth.
+    const { id, session } = makeSession('pty-exit');
+    expect(durabilityOf(id)).toBe('running-attached');
+
+    const cap = captureTransitions();
+    try {
+      session.cleanedUp = true;
+      expect(durabilityOf(id)).toBe('ended');
+      expect(cap.events.at(-1)).toMatchObject({
+        sessionId: id,
+        to: 'ended',
+      });
+    } finally {
+      cap.unsubscribe();
+    }
+  });
+
+  it('agent error transition → error', () => {
+    // Agent adapters set `agentState = 'error'` for unrecoverable failures
+    // (e.g. resume failed for web sessions, parser-detected error frames
+    // for PTY sessions). Durability must surface this ahead of the
+    // attached/detached default.
+    const { id, session } = makeSession('agent-error');
+    expect(durabilityOf(id)).toBe('running-attached');
+
+    const cap = captureTransitions();
+    try {
+      session.agentState = 'error';
+      expect(durabilityOf(id)).toBe('error');
+      expect(cap.events.at(-1)).toMatchObject({
+        sessionId: id,
+        to: 'error',
+      });
+    } finally {
+      cap.unsubscribe();
+    }
+  });
+
+  it('permission prompt → permission-needed without disabling the session', () => {
+    // Permission prompts are durability transitions too — they let the
+    // mobile card light up an approval affordance without touching
+    // attach state. Slice 3 explicitly does NOT disable controls for
+    // this state; this test pins that behaviour.
+    const { id, session } = makeSession('permission');
+    expect(durabilityOf(id)).toBe('running-attached');
+
+    const cap = captureTransitions();
+    try {
+      session.agentState = 'permission-prompt';
+      expect(durabilityOf(id)).toBe('permission-needed');
+      expect(cap.events.at(-1)?.to).toBe('permission-needed');
+    } finally {
+      cap.unsubscribe();
+    }
+  });
+});


### PR DESCRIPTION
Final slice of #614. Pins documented durability transitions in code and adds the manual runbook for failure modes the automated suite cannot fake.

## Summary
- `test/session-durability-failure-matrix.test.ts` — 5 focused scenarios covering tab close → `running-detached`, node link drop + reconnect cycle (`stale-node` ↔ `running-attached`), PTY exit → `ended`, agent error → `error`, permission prompt → `permission-needed` with controls intact.
- Every test asserts both the durability returned by `sessions.list()` and the emitted `session-durability-changed` event.
- `docs/SESSION_DURABILITY.md` gets a Failure-matrix runbook section with the transition table + manual verification steps for laptop sleep / network flap, hub restart, and browser refresh.

## Test plan
- [x] 5 new tests pass.
- [x] `npm run check` — 0 errors, 79 preexisting warnings.
- [ ] Reviewer: confirm the `ended → gone` documentation is accurate — once `runExitCleanup` fires, the session leaves the map, so `ended` is observable mid-cleanup but not durably.

Closes #667, **completes #614**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)