### PR TITLE
feat: hub↔node version skew detection, node update command, 503 drain gate (#655)

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -2885,6 +2885,217 @@ async function runNodeInstallBinary(nodeArgs: string[]): Promise<void> {
 }
 
 /**
+ * Notify the hub that this node is entering the `updating` state so the hub
+ * blocks new session-create requests while the binary is being replaced.
+ * Best-effort: if the hub cannot be reached, the update proceeds anyway
+ * (the 503 gate is a hub-side guard; the CLI does not block on hub ack).
+ */
+async function notifyHubNodeUpdating(
+  hubUrl: string,
+  nodeId: string,
+  token: string,
+  starting: boolean
+): Promise<void> {
+  const endpoint = `${hubUrl}/hub/nodes/${encodeURIComponent(nodeId)}/updating`;
+  try {
+    const res = await fetch(endpoint, {
+      method: starting ? 'POST' : 'DELETE',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+    });
+    if (!res.ok) {
+      logger.warn(
+        `hub node-updating signal returned ${res.status}; proceeding with update.`
+      );
+    }
+  } catch (err) {
+    logger.warn(
+      `could not signal hub (${starting ? 'updating-start' : 'updating-complete'}): ${err instanceof Error ? err.message : String(err)}. proceeding with update.`
+    );
+  }
+}
+
+/** Read the update channel from config. Defaults to 'stable'. */
+function resolveUpdateChannel(): 'stable' | 'nightly' {
+  const configPath = resolveConfigPath();
+  if (!fs.existsSync(configPath)) return 'stable';
+  try {
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as {
+      updateChannel?: string;
+    };
+    if (config.updateChannel === 'nightly') return 'nightly';
+  } catch {
+    // ignore
+  }
+  return 'stable';
+}
+
+/** Read the currently installed relay-ide version from package.json. */
+function readInstalledVersion(): string {
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf-8')
+    ) as { version: string };
+    return pkg.version;
+  } catch {
+    return 'unknown';
+  }
+}
+
+/** Query npm for the latest published version of the given dist-tag. */
+async function fetchLatestNpmVersion(tag: string): Promise<string> {
+  try {
+    const result = await execFileAsync('npm', [
+      'view',
+      `relay-ide@${tag}`,
+      'version',
+    ]);
+    const v = result.stdout.trim();
+    if (!v) {
+      logger.error(
+        `NODE_UPDATE_FAILED: npm view returned an empty version for relay-ide@${tag}`
+      );
+      process.exit(1);
+    }
+    return v;
+  } catch (err) {
+    logger.error(
+      `NODE_UPDATE_FAILED: could not fetch latest version from npm: ${execErrorMessage(err, 'npm view failed')}`
+    );
+    process.exit(1);
+  }
+}
+
+/** Restart the managed platform service after a binary update. Best-effort. */
+function restartServiceAfterUpdate(): void {
+  if (!service.isInstalled()) {
+    logger.info(
+      'no managed service detected. restart relay-ide node link manually to connect with the updated binary.'
+    );
+    return;
+  }
+  logger.info('platform service detected — restarting...');
+  try {
+    service.uninstall();
+    service.install({
+      configPath: resolveConfigPath(),
+      port: getArg('--port') ?? String(DEFAULTS.port),
+      host: getArg('--host') ?? DEFAULTS.host,
+    });
+    logger.info('service restarted.');
+  } catch (err) {
+    logger.warn(
+      `service restart failed (update succeeded): ${execErrorMessage(err, 'service restart failed')}. restart the service manually.`
+    );
+  }
+}
+
+/**
+ * Update the relay-ide helper binary on this node.
+ *
+ * `relay-ide node update [--hub <url>]`        — install latest, signal hub, restart service if managed
+ * `relay-ide node update --check [--hub <url>]` — report whether update is available (non-destructive)
+ *
+ * Idempotent: if already at the latest version, prints "already at latest" and exits 0.
+ *
+ * When `--hub <url>` is provided, the node signals the hub with `POST /hub/nodes/:nodeId/updating`
+ * before installing and `DELETE /hub/nodes/:nodeId/updating` after completion, so the hub can
+ * block new session-create requests for the duration of the update (#655, Slice 5 of epic #613).
+ */
+async function runNodeUpdate(nodeArgs: string[]): Promise<void> {
+  const checkOnly = nodeArgs.includes('--check');
+  const hubUrl = getNodeArg(nodeArgs, '--hub');
+  const tag = resolveUpdateChannel() === 'nightly' ? 'nightly' : 'latest';
+  const currentVersion = readInstalledVersion();
+  const latestVersion = await fetchLatestNpmVersion(tag);
+
+  if (checkOnly) {
+    if (currentVersion === latestVersion) {
+      logger.info(
+        `already at latest (${currentVersion} == relay-ide@${tag} ${latestVersion}).`
+      );
+    } else {
+      logger.info(
+        `update available: installed ${currentVersion}, latest relay-ide@${tag} is ${latestVersion}. run 'relay-ide node update' to apply.`
+      );
+    }
+    process.exit(0);
+  }
+
+  if (currentVersion === latestVersion) {
+    logger.info(
+      `already at latest (relay-ide@${tag} ${latestVersion}). nothing to do.`
+    );
+    process.exit(0);
+  }
+
+  // Load credential if hub signaling is requested.
+  let credential: { nodeId: string; token: string } | undefined;
+  if (hubUrl) {
+    try {
+      credential = loadNodeCredential();
+    } catch {
+      logger.warn(
+        'could not load node credential; proceeding without hub signaling.'
+      );
+    }
+  }
+
+  // Signal hub: entering updating state (best-effort).
+  if (hubUrl && credential) {
+    await notifyHubNodeUpdating(
+      hubUrl,
+      credential.nodeId,
+      credential.token,
+      true
+    );
+  }
+
+  logger.info(
+    `updating relay-ide from ${currentVersion} → ${latestVersion} (relay-ide@${tag})...`
+  );
+  try {
+    await execFileAsync('npm', ['install', '-g', `relay-ide@${tag}`], {
+      env: process.env,
+    });
+  } catch (err) {
+    if (hubUrl && credential) {
+      await notifyHubNodeUpdating(
+        hubUrl,
+        credential.nodeId,
+        credential.token,
+        false
+      );
+    }
+    logger.error(
+      `NODE_UPDATE_FAILED: ${execErrorMessage(err, 'npm install -g relay-ide failed')}`
+    );
+    process.exit(1);
+  }
+
+  const installedVersion = readInstalledVersion();
+  logger.info(
+    installedVersion !== 'unknown'
+      ? `relay-ide updated to ${installedVersion}.`
+      : 'relay-ide updated.'
+  );
+
+  // Signal hub: update complete, clear the updating flag.
+  if (hubUrl && credential) {
+    await notifyHubNodeUpdating(
+      hubUrl,
+      credential.nodeId,
+      credential.token,
+      false
+    );
+  }
+
+  restartServiceAfterUpdate();
+}
+
+/**
  * Generate and print a paste-able bash script that installs relay-ide and
  * pairs the node with the given hub on a remote machine reached via SSH.
  *
@@ -3272,6 +3483,12 @@ if (command === 'node') {
     await runNodeLink(nodeArgs);
     process.exit(0);
   }
+  // relay-ide node update [--check]
+  // Update the helper binary on this node (Slice 5, #655).
+  if (subCommand === 'update') {
+    await runNodeUpdate(nodeArgs.slice(1));
+    process.exit(0);
+  }
   // relay-ide node pair --hub <url> --pair-token <token>
   // Productized pair-only command. The existing 'connect' subcommand is kept
   // as a back-compat alias. Both call pairNode() under the hood.
@@ -3349,7 +3566,7 @@ if (command === 'node') {
     }
   }
   logger.error(
-    'Usage: relay-ide node <status|logs|doctor|pair|install|ssh-bootstrap|connect|link>'
+    'Usage: relay-ide node <status|logs|doctor|pair|install|ssh-bootstrap|connect|link|update>'
   );
   process.exit(1);
 }

--- a/docs/RELAY_NODE_BOOTSTRAP.md
+++ b/docs/RELAY_NODE_BOOTSTRAP.md
@@ -26,6 +26,8 @@ Relay uses SSH and Tailscale SSH only for bootstrap, reachability checks, diagno
 | Check node status                | `relay-ide node status`                                                                                  |
 | Read service logs                | `relay-ide node logs`                                                                                    |
 | Diagnose local node health       | `relay-ide node doctor [--hub <url>] [--json]`                                                           |
+| Update node helper binary        | `relay-ide node update [--hub <url>]`                                                                    |
+| Check if update is available     | `relay-ide node update --check [--hub <url>]`                                                            |
 | Update Relay + restart service   | `relay-ide update`                                                                                       |
 | Unpair from hub                  | `DELETE /nodes/{nodeId}` from hub UI/API; then `rm ~/.config/relay-ide/node-credential.json` on the node |
 
@@ -303,21 +305,59 @@ Returns all paired nodes with `online`/`stale`/`offline`/`revoked` status, last 
 
 ## Update
 
-To update the node to the latest Relay version:
+### Node helper update (`relay-ide node update`)
+
+To update the helper binary on a paired node, run this command **on the node machine**:
+
+```bash
+# Install the latest version and restart the managed service if present.
+relay-ide node update
+
+# Optional: notify the hub while updating so it blocks new sessions during drain.
+relay-ide node update --hub https://hub.example.com
+
+# Non-destructive check: reports whether an update is available.
+relay-ide node update --check
+relay-ide node update --check --hub https://hub.example.com
+```
+
+The command:
+
+1. Reads the current `updateChannel` from config (`stable` or `nightly`).
+2. Queries `npm view relay-ide@<tag> version` to get the latest published version.
+3. If already at that version, prints "already at latest" and exits 0 (idempotent).
+4. If `--hub` is provided, signals `POST /hub/nodes/:nodeId/updating` — the hub marks the node as `updating` and returns HTTP 503 + `Retry-After: 60` for any new session-create requests while the update runs. Existing sessions drain naturally.
+5. Runs `npm install -g relay-ide@<tag>`.
+6. If `--hub` is provided, signals `DELETE /hub/nodes/:nodeId/updating` to clear the drain gate.
+7. If a managed platform service is detected, stops and restarts it.
+
+> `relay-ide node update` replaces the binary on the node and restarts the local service. It does **not** re-pair the node; the existing `node-credential.json` and hub registration remain valid.
+
+### Hub-only `relay-ide update`
+
+The top-level `relay-ide update` command updates the hub's own binary. It is not node-aware:
 
 ```bash
 relay-ide update
 ```
 
-This:
+This follows the same npm + service-restart pattern but applies to the machine it is run on, not to any paired nodes.
 
-1. Reads the current `updateChannel` from config (`stable` or `nightly`)
-2. Runs `npm install -g relay-ide@<latest|nightly>`
-3. If a background service is detected, stops it, reinstalls with the new binary, and restarts it
+### Version skew model (#655)
 
-> The `update` command updates the global npm package and restarts the local service. It does **not** re-pair the node; the existing `node-credential.json` remains valid.
+The hub detects helper-binary version skew on every heartbeat and pair exchange. The skew category is exposed in the `helperSkew` field of each node summary (`GET /nodes`) and in the hub node dashboard.
 
-To update a specific node from the hub side, you must SSH or otherwise access the node and run `relay-ide update` there. There is no remote forced-upgrade mechanism.
+| Category           | Condition                                 | Effect                                                                          |
+| ------------------ | ----------------------------------------- | ------------------------------------------------------------------------------- |
+| `compatible`       | Same major, `helperMinor >= hubMinor - 2` | No restriction                                                                  |
+| `minor-skew-warn`  | Same major, minor gap > 0                 | Sessions allowed; update recommended                                            |
+| `major-skew-error` | Different major version                   | New session-create returns **503** + `Retry-After: 60`; existing sessions drain |
+
+The compatibility rule is: **same major version, node helper minor within 2 of hub minor** (or node is ahead). Nodes on a different major are fully blocked until `relay-ide node update` is run.
+
+When a node is being updated (`status: updating`), the hub also returns 503 for new session-create requests on that node. This drain window is temporary; the hub automatically clears it when the node signals completion via `DELETE /hub/nodes/:nodeId/updating`.
+
+To update a specific node from the hub side, you must SSH or otherwise access the node and run `relay-ide node update` there. Auto-update from the hub UI is out of scope.
 
 ## Unpairing (Revocation)
 

--- a/frontend/src/lib/state/node-dashboard.ts
+++ b/frontend/src/lib/state/node-dashboard.ts
@@ -23,12 +23,14 @@ export interface HubNodeDashboardRow {
   hostname: string;
   hostLabel: string;
   status: HubNodeStatus;
-  statusTone: 'online' | 'stale' | 'offline' | 'revoked';
+  statusTone: 'online' | 'stale' | 'offline' | 'revoked' | 'updating';
   routeLabel: string;
   lastSeenLabel: string;
   relayVersion: string;
   protocolVersion: string;
   versionWarning: string | null;
+  /** Helper-binary skew warning, present when helper version diverges from hub. */
+  helperSkewWarning: string | null;
   capabilityHints: HubNodeCapabilityHint[];
   security: NodeSecurityVisibility;
   attachable: boolean;
@@ -93,8 +95,13 @@ function disabledReason(
   if (node.status === 'revoked') return 'not attachable: node was revoked';
   if (node.status === 'offline') return 'not attachable: node is offline';
   if (node.status === 'stale') return 'not attachable: heartbeat is stale';
+  if (node.status === 'updating')
+    return 'not attachable: node is updating — new sessions blocked until update completes';
+  if (node.helperSkew?.category === 'major-skew-error')
+    return `not attachable: ${node.helperSkew.message}${node.helperSkew.remediationHint ? ` — ${node.helperSkew.remediationHint}` : ''}`;
   if (node.trust?.policy?.revokedAt) return 'work disabled: policy revoked';
-  if (node.trust?.policy?.supersededBy) return 'work disabled: policy superseded';
+  if (node.trust?.policy?.supersededBy)
+    return 'work disabled: policy superseded';
 
   const blockers = readinessCapabilities.flatMap((key) => {
     const hint = capabilityHints.find((candidate) => candidate.key === key);
@@ -177,6 +184,11 @@ export function deriveHubNodeDashboardRows(
         ? null
         : `protocol ${node.protocolVersion} != hub ${expectedProtocolVersion}`;
 
+    const helperSkewWarning =
+      node.helperSkew && node.helperSkew.category !== 'compatible'
+        ? node.helperSkew.message
+        : null;
+
     return {
       nodeId: node.nodeId,
       displayName: node.displayName,
@@ -189,6 +201,7 @@ export function deriveHubNodeDashboardRows(
       relayVersion: node.relayVersion,
       protocolVersion: node.protocolVersion,
       versionWarning,
+      helperSkewWarning,
       capabilityHints: hints,
       security,
       attachable: reason === null,
@@ -227,7 +240,9 @@ export function hubNodeDashboardSummary(
   const blockedByCapabilities = rows.filter(
     (row) => !row.attachable && row.disabledReason?.startsWith('work disabled:')
   ).length;
-  const policyUnavailable = rows.filter((row) => row.security.policyRef === null).length;
+  const policyUnavailable = rows.filter(
+    (row) => row.security.policyRef === null
+  ).length;
   const prodHighRisk = rows.filter(
     (row) => row.security.trustTier === 'prod' && row.security.tone === 'danger'
   ).length;

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -12,6 +12,7 @@ import {
   type HubNodeCredentialRotationState,
   type HubNodeCredentialRotationSummary,
   type HubNodeCredentialState,
+  type HubNodeHelperSkewSummary,
   type HubNodeStatus,
   type HubNodeSummary,
   type HubNodeVersionState,
@@ -20,6 +21,7 @@ import {
   type RelayNodeError,
   type RelayNodeErrorCode,
 } from '../shared/relay-node-protocol.js';
+import { classifyHelperSkew } from './node-version-skew.js';
 import {
   RELAY_SECURITY_POLICY_VERSION,
   createLegacyDefaultNodeAcl,
@@ -73,6 +75,8 @@ interface StoredNodeRecord {
   platform: string;
   arch: string;
   relayVersion: string;
+  /** Helper binary version from NodeManifest.helperVersion (#655). Optional for backward compat. */
+  helperVersion?: string;
   protocolVersion: string;
   capabilities: NodeCapabilityManifestSummary;
   acl?: RelayNodeAcl;
@@ -83,6 +87,8 @@ interface StoredNodeRecord {
   lastSeenAt: string;
   linkDisconnectedAt?: string;
   revokedAt?: string;
+  /** Set while `relay-ide node update` is in progress. Cleared when update completes. */
+  updatingAt?: string;
 }
 
 interface RegistryFile {
@@ -142,6 +148,8 @@ export interface HubNodeRegistryOptions {
   offlineMs?: number;
   heartbeatPersistDebounceMs?: number;
   auditSink?: { append(input: SecurityAuditEntryInput): unknown };
+  /** Hub's own package version, used for helper-version skew detection (#655). */
+  hubVersion?: string;
 }
 
 export const DEFAULT_PAIR_TOKEN_TTL_MS = 10 * 60 * 1000;
@@ -401,6 +409,7 @@ function statusForNode(
   offlineMs: number
 ): HubNodeStatus {
   if (node.revokedAt) return 'revoked';
+  if (node.updatingAt) return 'updating';
   if (
     node.linkDisconnectedAt &&
     Date.parse(node.linkDisconnectedAt) >= Date.parse(node.lastSeenAt)
@@ -538,13 +547,32 @@ function assertNoActiveRotation(node: StoredNodeRecord): void {
 
 function publicNode(
   node: StoredNodeRecord,
-  status: HubNodeStatus
+  status: HubNodeStatus,
+  hubVersion?: string
 ): HubNodeSummary {
   const acl = ensureNodeAcl(node);
   const aclSummary = summarizeAcl(acl);
   const rotationSummary = node.credentialRotation
     ? publicRotation(node.credentialRotation)
     : undefined;
+
+  let helperSkew: HubNodeHelperSkewSummary | undefined;
+  if (hubVersion && (node.helperVersion || node.relayVersion)) {
+    const result = classifyHelperSkew(
+      node.helperVersion ?? node.relayVersion,
+      hubVersion
+    );
+    helperSkew = {
+      category: result.category,
+      helperVersion: result.helperVersion,
+      hubVersion: result.hubVersion,
+      message: result.message,
+      ...(result.remediationHint
+        ? { remediationHint: result.remediationHint }
+        : {}),
+    };
+  }
+
   return {
     nodeId: node.nodeId,
     displayName: node.displayName,
@@ -570,6 +598,7 @@ function publicNode(
       nodeProtocolVersion: node.protocolVersion,
       hubProtocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
     },
+    ...(helperSkew ? { helperSkew } : {}),
     capabilities: normalizeCapabilitySummary(node.capabilities),
     createdAt: node.createdAt,
     pairedAt: node.pairedAt,
@@ -587,6 +616,8 @@ function connectionSummary(
     return { route: REVERSE_LINK_ROUTE, status: 'stale heartbeat' };
   if (status === 'offline')
     return { route: REVERSE_LINK_ROUTE, status: 'offline' };
+  if (status === 'updating')
+    return { route: REVERSE_LINK_ROUTE, status: 'updating' };
   return { route: REVERSE_LINK_ROUTE, status: 'revoked' };
 }
 
@@ -605,6 +636,8 @@ export class HubNodeRegistry {
     | undefined;
   private readonly nodeStatusListeners = new Set<NodeStatusListener>();
   private readonly lastNotifiedStatuses = new Map<string, HubNodeStatus>();
+  /** Hub's own package version, forwarded to helperSkew computation. */
+  private readonly hubVersion: string | undefined;
 
   constructor(options: HubNodeRegistryOptions) {
     this.storagePath = options.storagePath;
@@ -616,6 +649,7 @@ export class HubNodeRegistry {
       options.heartbeatPersistDebounceMs ??
       DEFAULT_HEARTBEAT_PERSIST_DEBOUNCE_MS;
     this.auditSink = options.auditSink;
+    this.hubVersion = options.hubVersion;
     this.state = readRegistryFile(options.storagePath);
     const needsAclMigration = registryNeedsAclMigration(this.state);
     for (const node of this.state.nodes) ensureNodeAcl(node);
@@ -709,6 +743,9 @@ export class HubNodeRegistry {
       platform: input.manifest.platform,
       arch: input.manifest.arch,
       relayVersion: input.manifest.relayVersion,
+      ...(input.manifest.helperVersion
+        ? { helperVersion: input.manifest.helperVersion }
+        : {}),
       protocolVersion,
       capabilities: summarizeCapabilities(input.manifest),
       acl: createLegacyDefaultNodeAcl({
@@ -738,7 +775,7 @@ export class HubNodeRegistry {
         token: credential.token,
         issuedAt: timestamp,
       },
-      node: publicNode(node, 'online'),
+      node: publicNode(node, 'online', this.hubVersion),
     };
   }
 
@@ -785,7 +822,8 @@ export class HubNodeRegistry {
       ok: true,
       node: publicNode(
         node,
-        statusForNode(node, this.now(), this.staleMs, this.offlineMs)
+        statusForNode(node, this.now(), this.staleMs, this.offlineMs),
+        this.hubVersion
       ),
       credentialId: matchesRotation
         ? rotation!.nextCredentialId
@@ -823,6 +861,9 @@ export class HubNodeRegistry {
       node.platform = input.manifest.platform;
       node.arch = input.manifest.arch;
       node.relayVersion = input.manifest.relayVersion;
+      if (input.manifest.helperVersion) {
+        node.helperVersion = input.manifest.helperVersion;
+      }
       node.capabilities = summarizeCapabilities(input.manifest);
     }
     if (input.repoInventory !== undefined && input.repoInventory !== null) {
@@ -835,7 +876,7 @@ export class HubNodeRegistry {
       input.manifest,
       previousStatus
     );
-    return publicNode(node, 'online');
+    return publicNode(node, 'online', this.hubVersion);
   }
 
   markNodeLinkDisconnected(nodeId: string): HubNodeSummary {
@@ -844,7 +885,7 @@ export class HubNodeRegistry {
     );
     if (!node)
       throw new HubNodeRegistryError('NOT_FOUND', 'node is not paired');
-    if (node.revokedAt) return publicNode(node, 'revoked');
+    if (node.revokedAt) return publicNode(node, 'revoked', this.hubVersion);
 
     const previousStatus = statusForNode(
       node,
@@ -855,7 +896,7 @@ export class HubNodeRegistry {
     node.linkDisconnectedAt = this.now().toISOString();
     this.persist();
     this.notifyNodeStatusIfChanged(node, 'offline', undefined, previousStatus);
-    return publicNode(node, 'offline');
+    return publicNode(node, 'offline', this.hubVersion);
   }
 
   beginCredentialRotation(nodeId: string): CredentialRotationResult {
@@ -881,7 +922,8 @@ export class HubNodeRegistry {
     return {
       node: publicNode(
         node,
-        statusForNode(node, this.now(), this.staleMs, this.offlineMs)
+        statusForNode(node, this.now(), this.staleMs, this.offlineMs),
+        this.hubVersion
       ),
       credential: {
         protocol: RELAY_NODE_LINK_PROTOCOL,
@@ -909,7 +951,8 @@ export class HubNodeRegistry {
     return {
       node: publicNode(
         node,
-        statusForNode(node, this.now(), this.staleMs, this.offlineMs)
+        statusForNode(node, this.now(), this.staleMs, this.offlineMs),
+        this.hubVersion
       ),
       rotation: publicRotation(rotation)!,
     };
@@ -931,7 +974,8 @@ export class HubNodeRegistry {
     return {
       node: publicNode(
         node,
-        statusForNode(node, this.now(), this.staleMs, this.offlineMs)
+        statusForNode(node, this.now(), this.staleMs, this.offlineMs),
+        this.hubVersion
       ),
       rotation: publicRotation(rotation)!,
     };
@@ -959,7 +1003,8 @@ export class HubNodeRegistry {
     this.persist();
     return publicNode(
       node,
-      statusForNode(node, this.now(), this.staleMs, this.offlineMs)
+      statusForNode(node, this.now(), this.staleMs, this.offlineMs),
+      this.hubVersion
     );
   }
 
@@ -1059,7 +1104,11 @@ export class HubNodeRegistry {
   listNodes(): HubNodeSummary[] {
     const now = this.now();
     return this.state.nodes.map((node) =>
-      publicNode(node, statusForNode(node, now, this.staleMs, this.offlineMs))
+      publicNode(
+        node,
+        statusForNode(node, now, this.staleMs, this.offlineMs),
+        this.hubVersion
+      )
     );
   }
 
@@ -1123,7 +1172,54 @@ export class HubNodeRegistry {
       this.persist();
       this.notifyNodeStatusIfChanged(node, 'revoked');
     }
-    return publicNode(node, 'revoked');
+    return publicNode(node, 'revoked', this.hubVersion);
+  }
+
+  /**
+   * Mark a node as `updating`. While in this state the hub refuses new
+   * session-create requests for the node (returns 503 with Retry-After).
+   * Existing sessions are allowed to drain naturally (#655).
+   */
+  markNodeUpdating(nodeId: string): HubNodeSummary {
+    const node = this.state.nodes.find(
+      (candidate) => candidate.nodeId === nodeId
+    );
+    if (!node)
+      throw new HubNodeRegistryError('NOT_FOUND', 'node is not paired');
+    if (node.revokedAt)
+      throw new HubNodeRegistryError('NODE_REVOKED', 'node was revoked');
+    if (!node.updatingAt) {
+      node.updatingAt = this.now().toISOString();
+      this.persist();
+      this.notifyNodeStatusIfChanged(node, 'updating');
+    }
+    return publicNode(node, 'updating', this.hubVersion);
+  }
+
+  /**
+   * Clear the `updating` flag after a node update completes. The node
+   * transitions back to its normal heartbeat-derived status.
+   */
+  markNodeUpdateComplete(nodeId: string): HubNodeSummary {
+    const node = this.state.nodes.find(
+      (candidate) => candidate.nodeId === nodeId
+    );
+    if (!node)
+      throw new HubNodeRegistryError('NOT_FOUND', 'node is not paired');
+    if (node.revokedAt)
+      throw new HubNodeRegistryError('NODE_REVOKED', 'node was revoked');
+    if (node.updatingAt) {
+      delete node.updatingAt;
+      this.persist();
+    }
+    const status = statusForNode(
+      node,
+      this.now(),
+      this.staleMs,
+      this.offlineMs
+    );
+    this.notifyNodeStatusIfChanged(node, status);
+    return publicNode(node, status, this.hubVersion);
   }
 
   errorBody(error: unknown): { error: RelayNodeError } {

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -111,7 +111,10 @@ export interface RoutedSessionAuditSink {
   listBefore?(
     beforeSequence: number | null,
     limit: number
-  ): { rows: NormalizedSecurityAuditEntry[]; nextBeforeSequence: number | null };
+  ): {
+    rows: NormalizedSecurityAuditEntry[];
+    nextBeforeSequence: number | null;
+  };
   head?(): { latestSequence: number; latestHash: string | null };
   verify?(): SecurityAuditVerificationResult;
 }
@@ -144,7 +147,11 @@ function bearerToken(req: Request): string | null {
 }
 
 function optionalControlActorOk(value: unknown): boolean {
-  return value === undefined || value === null || normalizeControlActor(value) !== undefined;
+  return (
+    value === undefined ||
+    value === null ||
+    normalizeControlActor(value) !== undefined
+  );
 }
 
 function optionalControlStringOk(value: unknown): boolean {
@@ -193,7 +200,8 @@ function controlSummaryFieldsOk(session: Partial<SessionSummary>): boolean {
     optionalControlStringOk(session.lastInterventionEventId) &&
     (session.controlFreshness === undefined ||
       isControlFreshness(session.controlFreshness)) &&
-    (session.controlReason === undefined || typeof session.controlReason === 'string')
+    (session.controlReason === undefined ||
+      typeof session.controlReason === 'string')
   );
 }
 
@@ -251,6 +259,59 @@ export function relayError(
 
 export function sendRelayError(res: Response, error: RelayNodeError): void {
   res.status(errorStatus(error)).json({ error });
+}
+
+/**
+ * Check whether a node is in a state that blocks new session-create:
+ *   - `updating` — binary update in progress, drain in-flight sessions
+ *   - `major-skew-error` — helper major version mismatch, must update first
+ *   - protocol mismatch — node-link protocol != hub protocol
+ *
+ * Returns true and sends the appropriate error response if blocked; returns false if clear.
+ * Extracted to keep the session-create route handler below the complexity limit (#655).
+ */
+export function sendNodeUnavailableForCreate(
+  res: Response,
+  node: import('../shared/relay-node-protocol.js').HubNodeSummary,
+  nodeId: string
+): boolean {
+  if (node.status === 'updating') {
+    res.setHeader('Retry-After', '60');
+    res.status(503).json({
+      error: relayError(
+        'NODE_BUSY',
+        `node ${nodeId} is updating; new sessions blocked while update drains. retry after 60 seconds.`,
+        true,
+        { reasonCode: 'NODE_UPDATING' }
+      ),
+    });
+    return true;
+  }
+  if (node.helperSkew?.category === 'major-skew-error') {
+    res.setHeader('Retry-After', '60');
+    res.status(503).json({
+      error: relayError('NODE_BUSY', node.helperSkew.message, true, {
+        reasonCode: 'NODE_VERSION_SKEW',
+        helperVersion: node.helperSkew.helperVersion,
+        hubVersion: node.helperSkew.hubVersion,
+        remediationHint: node.helperSkew.remediationHint,
+      }),
+    });
+    return true;
+  }
+  if (node.protocolVersion !== RELAY_NODE_LINK_PROTOCOL_VERSION) {
+    const [nodeMajor] = node.protocolVersion.split('.');
+    const [hubMajor] = RELAY_NODE_LINK_PROTOCOL_VERSION.split('.');
+    sendRelayError(
+      res,
+      relayError(
+        nodeMajor === hubMajor ? 'VERSION_SKEW' : 'PROTOCOL_INCOMPATIBLE',
+        `relay-node-link protocol ${node.protocolVersion} must exactly match hub protocol ${RELAY_NODE_LINK_PROTOCOL_VERSION}`
+      )
+    );
+    return true;
+  }
+  return false;
 }
 
 export function isSessionSummary(value: unknown): value is SessionSummary {
@@ -323,7 +384,8 @@ export function scopedNodeSession(
       ...(scoped.worktreePath !== undefined
         ? { worktreePath: scoped.worktreePath }
         : {}),
-      issuedAt: lifecycle.issuedAt ?? existingEnvelope?.issuedAt ?? scoped.createdAt,
+      issuedAt:
+        lifecycle.issuedAt ?? existingEnvelope?.issuedAt ?? scoped.createdAt,
       expiresAt:
         lifecycle.expiresAt !== undefined
           ? lifecycle.expiresAt
@@ -333,12 +395,16 @@ export function scopedNodeSession(
       ...(existingEnvelope?.correlationId
         ? { correlationId: existingEnvelope.correlationId }
         : {}),
-      ...(existingEnvelope?.auditId ? { auditId: existingEnvelope.auditId } : {}),
+      ...(existingEnvelope?.auditId
+        ? { auditId: existingEnvelope.auditId }
+        : {}),
     }),
   };
 }
 
-function routedWorkContextId(body: Record<string, unknown>): string | undefined {
+function routedWorkContextId(
+  body: Record<string, unknown>
+): string | undefined {
   const value = body['workContextId'];
   return typeof value === 'string' && value.trim() ? value.trim() : undefined;
 }
@@ -373,7 +439,9 @@ function associateRoutedWorkContext(
     store.associateSession(workContextId, { session });
     return null;
   } catch (error) {
-    return error instanceof Error ? error.message : 'work_context_association_failed';
+    return error instanceof Error
+      ? error.message
+      : 'work_context_association_failed';
   }
 }
 
@@ -433,7 +501,8 @@ function routedGatewayCreateBodyFromRequest(
   routeNodeId: string
 ): Record<string, unknown> | null {
   const body = req.body as unknown;
-  if (!isCliGatewayV1Request(req)) return paramsWithoutConfirmation(bodyRecord(req));
+  if (!isCliGatewayV1Request(req))
+    return paramsWithoutConfirmation(bodyRecord(req));
   if (!isRecord(body)) {
     sendGatewayCreateValidationError(res, {
       code: 'INVALID_ARGUMENT',
@@ -444,7 +513,8 @@ function routedGatewayCreateBodyFromRequest(
   }
 
   const validationInput = paramsWithoutConfirmation(body);
-  if (validationInput['nodeId'] === undefined) validationInput['nodeId'] = routeNodeId;
+  if (validationInput['nodeId'] === undefined)
+    validationInput['nodeId'] = routeNodeId;
   const validated = validateAndSanitizeGatewayCreateInput(validationInput);
   if (validated.ok === false) {
     sendGatewayCreateValidationError(res, validated.error);
@@ -455,7 +525,11 @@ function routedGatewayCreateBodyFromRequest(
       code: 'INVALID_ARGUMENT',
       message: 'sessions.create nodeId must match route nodeId',
       retryable: false,
-      details: { field: 'nodeId', nodeId: routeNodeId, bodyNodeId: validated.nodeId ?? null },
+      details: {
+        field: 'nodeId',
+        nodeId: routeNodeId,
+        bodyNodeId: validated.nodeId ?? null,
+      },
     });
     return null;
   }
@@ -465,30 +539,40 @@ function routedGatewayCreateBodyFromRequest(
   return routedBody;
 }
 
-function confirmationTokenFromRequest(req: Request, body: Record<string, unknown>): string | undefined {
+function confirmationTokenFromRequest(
+  req: Request,
+  body: Record<string, unknown>
+): string | undefined {
   const bodyToken = body['confirmationToken'];
-  if (typeof bodyToken === 'string' && bodyToken.trim()) return bodyToken.trim();
+  if (typeof bodyToken === 'string' && bodyToken.trim())
+    return bodyToken.trim();
   const headerToken = req.header('x-confirmation-token');
   return headerToken?.trim() || undefined;
 }
 
-export function paramsWithoutConfirmation(body: Record<string, unknown>): Record<string, unknown> {
+export function paramsWithoutConfirmation(
+  body: Record<string, unknown>
+): Record<string, unknown> {
   const cleaned: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(body)) {
-    if (key === 'confirmationToken' || key === 'confirmationChallengeId') continue;
+    if (key === 'confirmationToken' || key === 'confirmationChallengeId')
+      continue;
     cleaned[key] = value;
   }
   return cleaned;
 }
 
 function authSessionHash(req: Request): string {
-  const cookieToken = typeof req.cookies?.token === 'string' ? req.cookies.token : undefined;
+  const cookieToken =
+    typeof req.cookies?.token === 'string' ? req.cookies.token : undefined;
   if (cookieToken) return hashAuthSessionIdentity(`cookie:${cookieToken}`);
   const authHeader = req.header('authorization')?.trim();
   if (authHeader) return hashAuthSessionIdentity(`authorization:${authHeader}`);
   const explicit = req.header('x-auth-session')?.trim();
-  if (explicit && req.header('x-test-auth')) return hashAuthSessionIdentity(`test-header:${explicit}`);
-  if (req.header('x-test-auth')) return hashAuthSessionIdentity(`test:${req.header('x-test-auth')}`);
+  if (explicit && req.header('x-test-auth'))
+    return hashAuthSessionIdentity(`test-header:${explicit}`);
+  if (req.header('x-test-auth'))
+    return hashAuthSessionIdentity(`test:${req.header('x-test-auth')}`);
   return hashAuthSessionIdentity(`remote:${req.ip ?? 'unknown'}`);
 }
 
@@ -497,14 +581,20 @@ function authSessionLabel(req: Request): string | undefined {
   return req.header('x-auth-session')?.trim() || undefined;
 }
 
-function relayErrorForConfirmationFailure(failure: ConfirmationFailure): RelayNodeError {
+function relayErrorForConfirmationFailure(
+  failure: ConfirmationFailure
+): RelayNodeError {
   return relayError(
-    failure.reasonCode === 'CONFIRMATION_REQUIRED' ? 'CONFIRMATION_REQUIRED' : 'UNAUTHORIZED',
+    failure.reasonCode === 'CONFIRMATION_REQUIRED'
+      ? 'CONFIRMATION_REQUIRED'
+      : 'UNAUTHORIZED',
     failure.message,
     false,
     {
       reasonCode: failure.reasonCode,
-      ...(failure.challenge ? { challenge: publicChallenge(failure.challenge) } : {}),
+      ...(failure.challenge
+        ? { challenge: publicChallenge(failure.challenge) }
+        : {}),
     }
   );
 }
@@ -600,7 +690,10 @@ function resolveConfirmationForDecision(input: {
     if (redeemed.ok === true) return { ok: true };
     return { ok: false, error: relayErrorForConfirmationFailure(redeemed) };
   }
-  const decisionWithCanonicalParams = { ...input.decision, params: canonicalParams };
+  const decisionWithCanonicalParams = {
+    ...input.decision,
+    params: canonicalParams,
+  };
   const auditedDecision = appendPolicyAudit(
     input.auditSink,
     decisionWithCanonicalParams,
@@ -613,7 +706,11 @@ function resolveConfirmationForDecision(input: {
   try {
     challenge = input.confirmations.createChallenge(
       decisionWithCanonicalParams,
-      confirmationCreateInput(input.req, requesterAuthSessionHash, canonicalParams)
+      confirmationCreateInput(
+        input.req,
+        requesterAuthSessionHash,
+        canonicalParams
+      )
     );
   } catch (error) {
     if (error instanceof ConfirmationChallengeCapacityError) {
@@ -954,7 +1051,9 @@ export function coldReopenSessionPayload(
   return payload;
 }
 
-function auditPeerForSummary(summary: ScopedSessionSummary | undefined): SecurityAuditEntryInput['peer'] {
+function auditPeerForSummary(
+  summary: ScopedSessionSummary | undefined
+): SecurityAuditEntryInput['peer'] {
   if (summary?.peerIdentity.kind === 'relay-node') {
     return {
       kind: 'node',
@@ -985,55 +1084,69 @@ function appendRoutedSessionAudit(
 
 function appendFsWriteCompletionAudit(
   sink: RoutedSessionAuditSink | undefined,
-  opts: {
-    success: true;
-    peer: SecurityAuditEntryInput['peer'];
-    nodeId: string;
-    sessionId: string;
-    policyScope: unknown;
-    payload: unknown;
-    correlationId?: string;
-  } | {
-    success: false;
-    peer: SecurityAuditEntryInput['peer'];
-    nodeId: string;
-    sessionId: string;
-    policyScope: unknown;
-    errorCode: string;
-    correlationId?: string;
-  }
+  opts:
+    | {
+        success: true;
+        peer: SecurityAuditEntryInput['peer'];
+        nodeId: string;
+        sessionId: string;
+        policyScope: unknown;
+        payload: unknown;
+        correlationId?: string;
+      }
+    | {
+        success: false;
+        peer: SecurityAuditEntryInput['peer'];
+        nodeId: string;
+        sessionId: string;
+        policyScope: unknown;
+        errorCode: string;
+        correlationId?: string;
+      }
 ): void {
-  appendRoutedSessionAudit(sink, opts.success ? {
-    eventType: 'grant',
-    decision: 'allow',
-    reasonCode: 'POLICY_ALLOW',
-    peer: opts.peer,
-    node: { nodeId: opts.nodeId },
-    sessionId: opts.sessionId,
-    intent: { action: 'rpc.fs.write.completed', target: opts.nodeId },
-    material: {
-      scope: opts.policyScope,
-      params: typeof opts.payload === 'object' && opts.payload !== null
-        ? (opts.payload as Record<string, unknown>)
-        : { payload: opts.payload },
-    },
-    ...(opts.correlationId ? { correlationId: opts.correlationId } : {}),
-  } : {
-    eventType: 'denial',
-    decision: 'failed',
-    reasonCode: opts.errorCode,
-    peer: opts.peer,
-    node: { nodeId: opts.nodeId },
-    sessionId: opts.sessionId,
-    intent: { action: 'rpc.fs.write.completed', target: opts.nodeId },
-    material: { scope: opts.policyScope, params: { error: opts.errorCode } },
-    ...(opts.correlationId ? { correlationId: opts.correlationId } : {}),
-  });
+  appendRoutedSessionAudit(
+    sink,
+    opts.success
+      ? {
+          eventType: 'grant',
+          decision: 'allow',
+          reasonCode: 'POLICY_ALLOW',
+          peer: opts.peer,
+          node: { nodeId: opts.nodeId },
+          sessionId: opts.sessionId,
+          intent: { action: 'rpc.fs.write.completed', target: opts.nodeId },
+          material: {
+            scope: opts.policyScope,
+            params:
+              typeof opts.payload === 'object' && opts.payload !== null
+                ? (opts.payload as Record<string, unknown>)
+                : { payload: opts.payload },
+          },
+          ...(opts.correlationId ? { correlationId: opts.correlationId } : {}),
+        }
+      : {
+          eventType: 'denial',
+          decision: 'failed',
+          reasonCode: opts.errorCode,
+          peer: opts.peer,
+          node: { nodeId: opts.nodeId },
+          sessionId: opts.sessionId,
+          intent: { action: 'rpc.fs.write.completed', target: opts.nodeId },
+          material: {
+            scope: opts.policyScope,
+            params: { error: opts.errorCode },
+          },
+          ...(opts.correlationId ? { correlationId: opts.correlationId } : {}),
+        }
+  );
 }
 
 function auditLifecycleDenial(
   sink: RoutedSessionAuditSink | undefined,
-  validation: Exclude<ReturnType<InMemorySessionEnvelopeRegistry['validate']>, { ok: true }>,
+  validation: Exclude<
+    ReturnType<InMemorySessionEnvelopeRegistry['validate']>,
+    { ok: true }
+  >,
   nodeId: string,
   sessionId: string,
   action: string,
@@ -1065,7 +1178,9 @@ function auditLifecycleDenial(
       scope: validation.summary?.scope ?? null,
       params: params ?? validation.error.details ?? null,
     },
-    ...(validation.summary?.correlationId ? { correlationId: validation.summary.correlationId } : {}),
+    ...(validation.summary?.correlationId
+      ? { correlationId: validation.summary.correlationId }
+      : {}),
   });
 }
 
@@ -1134,7 +1249,11 @@ function auditCredentialRotation(
     eventType: input.eventType,
     decision: input.decision,
     reasonCode: input.reasonCode,
-    peer: { kind: 'node', nodeId: input.nodeId, ...(input.credentialId ? { credentialId: input.credentialId } : {}) },
+    peer: {
+      kind: 'node',
+      nodeId: input.nodeId,
+      ...(input.credentialId ? { credentialId: input.credentialId } : {}),
+    },
     node: { nodeId: input.nodeId },
     intent: { action: 'nodes.credential.rotate', target: input.nodeId },
     material: {
@@ -1150,9 +1269,13 @@ function auditCredentialRotation(
   });
 }
 
-function revokedReasonFromBody(body: Record<string, unknown>): string | undefined {
+function revokedReasonFromBody(
+  body: Record<string, unknown>
+): string | undefined {
   const reason = body['reason'];
-  return typeof reason === 'string' && reason.trim() ? reason.trim() : undefined;
+  return typeof reason === 'string' && reason.trim()
+    ? reason.trim()
+    : undefined;
 }
 
 const SESSION_RENEW_IMMUTABLE_FIELDS = [
@@ -1162,8 +1285,12 @@ const SESSION_RENEW_IMMUTABLE_FIELDS = [
   'sessionEnvelope',
 ] as const;
 
-function renewAuthorityError(body: Record<string, unknown>): RelayNodeError | null {
-  const field = SESSION_RENEW_IMMUTABLE_FIELDS.find((key) => body[key] !== undefined);
+function renewAuthorityError(
+  body: Record<string, unknown>
+): RelayNodeError | null {
+  const field = SESSION_RENEW_IMMUTABLE_FIELDS.find(
+    (key) => body[key] !== undefined
+  );
   if (!field) return null;
   return relayError(
     'SESSION_MISMATCH',
@@ -1228,7 +1355,9 @@ function auditLifecycleRenewal(
         renewedExpiresAt: input.summary.expiresAt,
       },
     },
-    ...(input.summary.correlationId ? { correlationId: input.summary.correlationId } : {}),
+    ...(input.summary.correlationId
+      ? { correlationId: input.summary.correlationId }
+      : {}),
   });
 }
 
@@ -1252,7 +1381,10 @@ function auditRenewalImmediateDenial(
     peer: { kind: 'hub' },
     node: { ...(input.nodeId ? { nodeId: input.nodeId } : {}) },
     sessionId: input.sessionId,
-    intent: { action: 'sessions.renew', ...(input.nodeId ? { target: input.nodeId } : {}) },
+    intent: {
+      action: 'sessions.renew',
+      ...(input.nodeId ? { target: input.nodeId } : {}),
+    },
     material: { params: input.params ?? input.error.details ?? null },
   });
 }
@@ -1265,10 +1397,14 @@ function nodeLogLinesFromQuery(value: unknown): number | RelayNodeError {
   const raw = Array.isArray(value) ? value[0] : value;
   if (raw === undefined) return 100;
   if (typeof raw !== 'string' || !/^\d+$/.test(raw)) {
-    return relayError('INVALID_REQUEST', 'lines must be a non-negative integer');
+    return relayError(
+      'INVALID_REQUEST',
+      'lines must be a non-negative integer'
+    );
   }
   const lines = Number(raw);
-  if (lines > 2_000) return relayError('INVALID_REQUEST', 'lines must be <= 2000');
+  if (lines > 2_000)
+    return relayError('INVALID_REQUEST', 'lines must be <= 2000');
   return lines;
 }
 
@@ -1323,7 +1459,10 @@ async function streamFileTailFollow(input: {
   if (!nodeLinks.streamRequest) {
     sendRelayError(
       res,
-      relayError('NODE_UNSUPPORTED', 'file RPC tail follow is not supported by this runtime')
+      relayError(
+        'NODE_UNSUPPORTED',
+        'file RPC tail follow is not supported by this runtime'
+      )
     );
     return;
   }
@@ -1426,7 +1565,9 @@ async function streamFileTailFollow(input: {
   }
 }
 
-function protocolVersionRelayError(nodeProtocolVersion: string): RelayNodeError {
+function protocolVersionRelayError(
+  nodeProtocolVersion: string
+): RelayNodeError {
   const [nodeMajor] = nodeProtocolVersion.split('.');
   const [hubMajor] = RELAY_NODE_LINK_PROTOCOL_VERSION.split('.');
   return relayError(
@@ -1478,13 +1619,20 @@ function nodeCwdOnboardingPayload(input: {
   node: HubNodeSummary;
   body: Record<string, unknown>;
   operation: 'browse' | 'validate';
-}): { request: Record<string, unknown>; cwd: string; path: string } | RelayNodeError {
+}):
+  | { request: Record<string, unknown>; cwd: string; path: string }
+  | RelayNodeError {
   const cwd = stringField(input.body, 'cwd') ?? input.node.homeDir ?? '/';
   if (cwd.includes('\0')) {
-    return relayError('INVALID_REQUEST', 'cwd must not contain NUL bytes', false, {
-      reasonCode: 'NODE_CWD_INVALID_REQUEST',
-      field: 'cwd',
-    });
+    return relayError(
+      'INVALID_REQUEST',
+      'cwd must not contain NUL bytes',
+      false,
+      {
+        reasonCode: 'NODE_CWD_INVALID_REQUEST',
+        field: 'cwd',
+      }
+    );
   }
   const root = cwdOnboardingRoot(input.node, cwd);
   const pathValue =
@@ -1492,10 +1640,15 @@ function nodeCwdOnboardingPayload(input: {
       ? cwd
       : (stringField(input.body, 'path') ?? '.');
   if (pathValue.includes('\0')) {
-    return relayError('INVALID_REQUEST', 'path must not contain NUL bytes', false, {
-      reasonCode: 'NODE_CWD_INVALID_REQUEST',
-      field: 'path',
-    });
+    return relayError(
+      'INVALID_REQUEST',
+      'path must not contain NUL bytes',
+      false,
+      {
+        reasonCode: 'NODE_CWD_INVALID_REQUEST',
+        field: 'path',
+      }
+    );
   }
   const maxEntries = input.body['maxEntries'];
   return {
@@ -1506,7 +1659,9 @@ function nodeCwdOnboardingPayload(input: {
       root,
       cwd: input.operation === 'validate' ? root : cwd,
       path: pathValue,
-      ...(input.operation === 'browse' && maxEntries !== undefined ? { maxEntries } : {}),
+      ...(input.operation === 'browse' && maxEntries !== undefined
+        ? { maxEntries }
+        : {}),
     },
   };
 }
@@ -1662,7 +1817,8 @@ export function createHubNodeRouter(
   const cliGatewayAuth = options.cliGatewayAuth ?? requireAuth;
   const scopedSessionAuth = options.scopedSessionAuth ?? requireAuth;
   const envelopes = options.sessionEnvelopes ?? sessionEnvelopeRegistry;
-  const confirmations = options.confirmations ?? createConfirmationChallengeStore();
+  const confirmations =
+    options.confirmations ?? createConfirmationChallengeStore();
   const now = () => options.now?.() ?? new Date();
   const repoInventoryFeature =
     options.repoInventoryFeature ?? createRepoInventoryFeature(registry);
@@ -1673,7 +1829,9 @@ export function createHubNodeRouter(
 
   router.get('/hub/confirmations/:challengeId', requireAuth, (req, res) => {
     const { challengeId } = req.params;
-    const challenge = challengeId ? confirmations.getChallenge(challengeId) : undefined;
+    const challenge = challengeId
+      ? confirmations.getChallenge(challengeId)
+      : undefined;
     if (!challenge) {
       sendRelayError(
         res,
@@ -1686,72 +1844,95 @@ export function createHubNodeRouter(
     res.json({ challenge: publicChallenge(challenge) });
   });
 
-  router.post('/hub/confirmations/:challengeId/requester-token', requireAuth, (req, res) => {
-    const { challengeId } = req.params;
-    if (!challengeId) {
-      sendRelayError(
-        res,
-        relayError('INVALID_REQUEST', 'confirmation challenge id is required', false, {
-          reasonCode: 'CONFIRMATION_NOT_FOUND',
-        })
-      );
-      return;
-    }
-    const result = confirmations.getRequesterToken({
-      challengeId,
-      requesterAuthSessionHash: authSessionHash(req),
-      now: now(),
-    });
-    if (result.ok === false) {
-      sendRelayError(res, relayErrorForConfirmationFailure(result));
-      return;
-    }
-    res.json({
-      confirmationToken: result.confirmationToken,
-      challenge: publicChallenge(result.challenge),
-    });
-  });
-
-  router.post('/hub/confirmations/:challengeId/approve', requireAuth, (req, res) => {
-    const { challengeId } = req.params;
-    const body = bodyRecord(req);
-    const decision = body['decision'] ?? 'approve';
-    if (!challengeId || !isConfirmationDecision(decision)) {
-      sendRelayError(
-        res,
-        relayError('INVALID_REQUEST', 'decision must be approve, deny, or deny_revoke', false, {
-          reasonCode: 'CONFIRMATION_INVALID_DECISION',
-        })
-      );
-      return;
-    }
-    const result = confirmations.approveChallenge(
-      confirmationApprovalInput(req, challengeId, decision, now())
-    );
-    const auditError = result.challenge
-      ? appendConfirmationAudit(options.auditSink, result.audit, result.challenge.decision)
-      : null;
-    if (auditError) {
-      if (result.ok === true) {
-        confirmations.invalidateChallenge({
-          challengeId: result.challenge.challengeId,
-          reasonCode: 'CONFIRMATION_TOKEN_INVALID',
-          message: 'confirmation approval audit write failed; approval token invalidated',
-          now: now(),
-        });
+  router.post(
+    '/hub/confirmations/:challengeId/requester-token',
+    requireAuth,
+    (req, res) => {
+      const { challengeId } = req.params;
+      if (!challengeId) {
+        sendRelayError(
+          res,
+          relayError(
+            'INVALID_REQUEST',
+            'confirmation challenge id is required',
+            false,
+            {
+              reasonCode: 'CONFIRMATION_NOT_FOUND',
+            }
+          )
+        );
+        return;
       }
-      sendRelayError(res, auditError);
-      return;
+      const result = confirmations.getRequesterToken({
+        challengeId,
+        requesterAuthSessionHash: authSessionHash(req),
+        now: now(),
+      });
+      if (result.ok === false) {
+        sendRelayError(res, relayErrorForConfirmationFailure(result));
+        return;
+      }
+      res.json({
+        confirmationToken: result.confirmationToken,
+        challenge: publicChallenge(result.challenge),
+      });
     }
-    if (result.ok === false) {
-      sendRelayError(res, relayErrorForConfirmationFailure(result));
-      return;
+  );
+
+  router.post(
+    '/hub/confirmations/:challengeId/approve',
+    requireAuth,
+    (req, res) => {
+      const { challengeId } = req.params;
+      const body = bodyRecord(req);
+      const decision = body['decision'] ?? 'approve';
+      if (!challengeId || !isConfirmationDecision(decision)) {
+        sendRelayError(
+          res,
+          relayError(
+            'INVALID_REQUEST',
+            'decision must be approve, deny, or deny_revoke',
+            false,
+            {
+              reasonCode: 'CONFIRMATION_INVALID_DECISION',
+            }
+          )
+        );
+        return;
+      }
+      const result = confirmations.approveChallenge(
+        confirmationApprovalInput(req, challengeId, decision, now())
+      );
+      const auditError = result.challenge
+        ? appendConfirmationAudit(
+            options.auditSink,
+            result.audit,
+            result.challenge.decision
+          )
+        : null;
+      if (auditError) {
+        if (result.ok === true) {
+          confirmations.invalidateChallenge({
+            challengeId: result.challenge.challengeId,
+            reasonCode: 'CONFIRMATION_TOKEN_INVALID',
+            message:
+              'confirmation approval audit write failed; approval token invalidated',
+            now: now(),
+          });
+        }
+        sendRelayError(res, auditError);
+        return;
+      }
+      if (result.ok === false) {
+        sendRelayError(res, relayErrorForConfirmationFailure(result));
+        return;
+      }
+      res.json({
+        confirmationToken: result.confirmationToken,
+        challenge: publicChallenge(result.challenge),
+      });
     }
-    res.json({
-      confirmationToken: result.confirmationToken,
-      challenge: publicChallenge(result.challenge),
-    });
-  });
+  );
 
   router.post('/hub/pair-tokens', requireAuth, (req, res) => {
     const body = bodyRecord(req);
@@ -1899,7 +2080,11 @@ export function createHubNodeRouter(
         peer: redactPeerForBrowser(row.peer),
       }));
       const head = options.auditSink.head();
-      res.json({ entries, nextBeforeSequence: result.nextBeforeSequence, head });
+      res.json({
+        entries,
+        nextBeforeSequence: result.nextBeforeSequence,
+        head,
+      });
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error('[hub-node-router] audit entries read failed', error);
@@ -1949,7 +2134,11 @@ export function createHubNodeRouter(
     if (node.status !== 'online' || !options.nodeLinks?.hasActiveNode(nodeId)) {
       sendRelayError(
         res,
-        relayError('NODE_OFFLINE', `node ${nodeId} has no live reverse link`, true)
+        relayError(
+          'NODE_OFFLINE',
+          `node ${nodeId} has no live reverse link`,
+          true
+        )
       );
       return;
     }
@@ -1967,12 +2156,18 @@ export function createHubNodeRouter(
       params: requestPayload,
       now: now(),
     });
-    if (sendPolicyDecision(options.auditSink, res, policyDecision, requestPayload)) {
+    if (
+      sendPolicyDecision(options.auditSink, res, policyDecision, requestPayload)
+    ) {
       return;
     }
     if (!follow) {
       try {
-        const payload = await options.nodeLinks.request(nodeId, 'logs.tail', requestPayload);
+        const payload = await options.nodeLinks.request(
+          nodeId,
+          'logs.tail',
+          requestPayload
+        );
         res.json({ log: payload });
       } catch (error) {
         sendRelayError(res, relayErrorFromUnknown(error));
@@ -1982,7 +2177,10 @@ export function createHubNodeRouter(
     if (!options.nodeLinks.streamRequest) {
       sendRelayError(
         res,
-        relayError('NODE_UNSUPPORTED', 'hub node log streaming is not supported by this runtime')
+        relayError(
+          'NODE_UNSUPPORTED',
+          'hub node log streaming is not supported by this runtime'
+        )
       );
       return;
     }
@@ -2000,22 +2198,27 @@ export function createHubNodeRouter(
       res.setHeader('Content-Type', 'text/plain; charset=utf-8');
       res.setHeader('Cache-Control', 'no-store');
       res.flushHeaders();
-      stream = await options.nodeLinks.streamRequest(nodeId, 'logs.tail', requestPayload, {
-        onChunk: (payload) => {
-          if (closed || res.destroyed) return;
-          const chunk = nodeLogChunk(payload);
-          if (chunk) res.write(chunk);
-        },
-        onError: (error) => {
-          if (closed || res.destroyed) return;
-          res.write(`\n[${error.code}] ${error.message}\n`);
-          res.end();
-        },
-        onEnd: () => {
-          if (closed || res.destroyed) return;
-          res.end();
-        },
-      });
+      stream = await options.nodeLinks.streamRequest(
+        nodeId,
+        'logs.tail',
+        requestPayload,
+        {
+          onChunk: (payload) => {
+            if (closed || res.destroyed) return;
+            const chunk = nodeLogChunk(payload);
+            if (chunk) res.write(chunk);
+          },
+          onError: (error) => {
+            if (closed || res.destroyed) return;
+            res.write(`\n[${error.code}] ${error.message}\n`);
+            res.end();
+          },
+          onEnd: () => {
+            if (closed || res.destroyed) return;
+            res.end();
+          },
+        }
+      );
       if (closed || res.destroyed) {
         stream.close();
         return;
@@ -2037,106 +2240,119 @@ export function createHubNodeRouter(
     }
   });
 
-  router.post('/hub/nodes/:nodeId/credential-rotation', requireAuth, async (req, res) => {
-    const { nodeId } = req.params;
-    if (!nodeId) {
-      sendRelayError(res, relayError('INVALID_REQUEST', 'nodeId is required'));
-      return;
-    }
-    const body = bodyRecord(req);
-    const delivery = stringField(body, 'delivery') ?? 'online';
-    if (delivery !== 'online' && delivery !== 'manual') {
-      sendRelayError(
-        res,
-        relayError('INVALID_REQUEST', 'delivery must be "online" or "manual"')
-      );
-      return;
-    }
-    try {
-      const started = registry.beginCredentialRotation(nodeId);
-      auditCredentialRotation(options.auditSink, {
-        nodeId,
-        eventType: 'rotation',
-        decision: 'recorded',
-        reasonCode: 'CREDENTIAL_ROTATION_ISSUED',
-        credentialId: started.rotation.previousCredentialId,
-        rotationId: started.rotation.rotationId,
-        params: { delivery },
-      });
-      if (delivery === 'online') {
-        if (!options.nodeLinks?.hasActiveNode(nodeId)) {
-          const failed = registry.failCredentialRotation(
-            nodeId,
-            started.rotation.rotationId,
-            'node is not connected for online credential rotation'
-          );
-          auditCredentialRotation(options.auditSink, {
-            nodeId,
-            eventType: 'rotation',
-            decision: 'failed',
-            reasonCode: 'CREDENTIAL_ROTATION_NODE_OFFLINE',
-            credentialId: started.rotation.previousCredentialId,
-            rotationId: started.rotation.rotationId,
-          });
-          res.status(503).json({
-            error: relayError('NODE_OFFLINE', 'node is not connected', true),
-            node: failed.node,
-            rotation: failed.rotation,
-          });
-          return;
-        }
-        try {
-          await options.nodeLinks.request(nodeId, 'credential.rotate', {
-            credential: started.credential,
-          });
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          const failed = registry.failCredentialRotation(
-            nodeId,
-            started.rotation.rotationId,
-            message
-          );
-          auditCredentialRotation(options.auditSink, {
-            nodeId,
-            eventType: 'rotation',
-            decision: 'failed',
-            reasonCode: 'CREDENTIAL_ROTATION_DELIVERY_FAILED',
-            credentialId: started.rotation.previousCredentialId,
-            rotationId: started.rotation.rotationId,
-            params: { message },
-          });
-          res.status(502).json({
-            error: relayError('NODE_UNSUPPORTED', 'credential rotation delivery failed', true, {
-              reasonCode: 'CREDENTIAL_ROTATION_DELIVERY_FAILED',
-            }),
-            node: failed.node,
-            rotation: failed.rotation,
-          });
-          return;
-        }
-        const delivered = registry.markCredentialRotationDelivered(
-          nodeId,
-          started.rotation.rotationId
+  router.post(
+    '/hub/nodes/:nodeId/credential-rotation',
+    requireAuth,
+    async (req, res) => {
+      const { nodeId } = req.params;
+      if (!nodeId) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'nodeId is required')
         );
+        return;
+      }
+      const body = bodyRecord(req);
+      const delivery = stringField(body, 'delivery') ?? 'online';
+      if (delivery !== 'online' && delivery !== 'manual') {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'delivery must be "online" or "manual"')
+        );
+        return;
+      }
+      try {
+        const started = registry.beginCredentialRotation(nodeId);
         auditCredentialRotation(options.auditSink, {
           nodeId,
           eventType: 'rotation',
           decision: 'recorded',
-          reasonCode: 'CREDENTIAL_ROTATION_DELIVERED',
+          reasonCode: 'CREDENTIAL_ROTATION_ISSUED',
           credentialId: started.rotation.previousCredentialId,
           rotationId: started.rotation.rotationId,
+          params: { delivery },
         });
-        res.status(202).json({
-          node: delivered.node,
-          rotation: delivered.rotation,
-        });
-        return;
+        if (delivery === 'online') {
+          if (!options.nodeLinks?.hasActiveNode(nodeId)) {
+            const failed = registry.failCredentialRotation(
+              nodeId,
+              started.rotation.rotationId,
+              'node is not connected for online credential rotation'
+            );
+            auditCredentialRotation(options.auditSink, {
+              nodeId,
+              eventType: 'rotation',
+              decision: 'failed',
+              reasonCode: 'CREDENTIAL_ROTATION_NODE_OFFLINE',
+              credentialId: started.rotation.previousCredentialId,
+              rotationId: started.rotation.rotationId,
+            });
+            res.status(503).json({
+              error: relayError('NODE_OFFLINE', 'node is not connected', true),
+              node: failed.node,
+              rotation: failed.rotation,
+            });
+            return;
+          }
+          try {
+            await options.nodeLinks.request(nodeId, 'credential.rotate', {
+              credential: started.credential,
+            });
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            const failed = registry.failCredentialRotation(
+              nodeId,
+              started.rotation.rotationId,
+              message
+            );
+            auditCredentialRotation(options.auditSink, {
+              nodeId,
+              eventType: 'rotation',
+              decision: 'failed',
+              reasonCode: 'CREDENTIAL_ROTATION_DELIVERY_FAILED',
+              credentialId: started.rotation.previousCredentialId,
+              rotationId: started.rotation.rotationId,
+              params: { message },
+            });
+            res.status(502).json({
+              error: relayError(
+                'NODE_UNSUPPORTED',
+                'credential rotation delivery failed',
+                true,
+                {
+                  reasonCode: 'CREDENTIAL_ROTATION_DELIVERY_FAILED',
+                }
+              ),
+              node: failed.node,
+              rotation: failed.rotation,
+            });
+            return;
+          }
+          const delivered = registry.markCredentialRotationDelivered(
+            nodeId,
+            started.rotation.rotationId
+          );
+          auditCredentialRotation(options.auditSink, {
+            nodeId,
+            eventType: 'rotation',
+            decision: 'recorded',
+            reasonCode: 'CREDENTIAL_ROTATION_DELIVERED',
+            credentialId: started.rotation.previousCredentialId,
+            rotationId: started.rotation.rotationId,
+          });
+          res.status(202).json({
+            node: delivered.node,
+            rotation: delivered.rotation,
+          });
+          return;
+        }
+        res.status(201).json(started);
+      } catch (error) {
+        sendRegistryError(registry, res, error);
       }
-      res.status(201).json(started);
-    } catch (error) {
-      sendRegistryError(registry, res, error);
     }
-  });
+  );
 
   router.post(
     '/hub/nodes/:nodeId/credential-rotation/clear-failure',
@@ -2144,7 +2360,10 @@ export function createHubNodeRouter(
     (req, res) => {
       const { nodeId } = req.params;
       if (!nodeId) {
-        sendRelayError(res, relayError('INVALID_REQUEST', 'nodeId is required'));
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'nodeId is required')
+        );
         return;
       }
       try {
@@ -2162,6 +2381,39 @@ export function createHubNodeRouter(
     }
   );
 
+  // ── Node update state (Slice 5, #655) ────────────────────────────────────
+  // Marks a node as `updating` so the hub blocks new session-create requests.
+  // Called by `relay-ide node update` at the start of a node binary update.
+  router.post('/hub/nodes/:nodeId/updating', requireAuth, (req, res) => {
+    const { nodeId } = req.params;
+    if (!nodeId) {
+      sendRelayError(res, relayError('INVALID_REQUEST', 'nodeId is required'));
+      return;
+    }
+    try {
+      const node = registry.markNodeUpdating(nodeId);
+      res.json({ node });
+    } catch (error) {
+      sendRegistryError(registry, res, error);
+    }
+  });
+
+  // Clears the `updating` flag after a node update completes.
+  // Called by `relay-ide node update` on success.
+  router.delete('/hub/nodes/:nodeId/updating', requireAuth, (req, res) => {
+    const { nodeId } = req.params;
+    if (!nodeId) {
+      sendRelayError(res, relayError('INVALID_REQUEST', 'nodeId is required'));
+      return;
+    }
+    try {
+      const node = registry.markNodeUpdateComplete(nodeId);
+      res.json({ node });
+    } catch (error) {
+      sendRegistryError(registry, res, error);
+    }
+  });
+
   // Repo-feature endpoints (GET /hub/repo-inventory + POST
   // /hub/nodes/:nodeId/sessions/reopen) used to live here. Per #425.2 /
   // #433 they moved to `server/features/repo-router.ts`. Composition
@@ -2177,51 +2429,123 @@ export function createHubNodeRouter(
     });
   });
 
-  router.post('/hub/scoped-sessions/:sessionId/renew', scopedSessionAuth, (req, res) => {
-    const { sessionId } = req.params;
-    if (!sessionId) {
-      sendRelayError(res, relayError('INVALID_REQUEST', 'sessionId is required'));
-      return;
-    }
-    const body = bodyRecord(req);
-    const queryNodeId =
-      typeof req.query['nodeId'] === 'string' ? req.query['nodeId'] : undefined;
-    const nodeId = stringField(body, 'nodeId') ?? queryNodeId;
-    const renewalNow = now();
+  router.post(
+    '/hub/scoped-sessions/:sessionId/renew',
+    scopedSessionAuth,
+    (req, res) => {
+      const { sessionId } = req.params;
+      if (!sessionId) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'sessionId is required')
+        );
+        return;
+      }
+      const body = bodyRecord(req);
+      const queryNodeId =
+        typeof req.query['nodeId'] === 'string'
+          ? req.query['nodeId']
+          : undefined;
+      const nodeId = stringField(body, 'nodeId') ?? queryNodeId;
+      const renewalNow = now();
 
-    const authorityError = renewAuthorityError(body);
-    if (authorityError) {
-      auditRenewalImmediateDenial(options.auditSink, {
-        error: authorityError,
-        ...(nodeId ? { nodeId } : {}),
-        sessionId,
-        params: body,
-      });
-      sendRelayError(res, authorityError);
-      return;
-    }
+      const authorityError = renewAuthorityError(body);
+      if (authorityError) {
+        auditRenewalImmediateDenial(options.auditSink, {
+          error: authorityError,
+          ...(nodeId ? { nodeId } : {}),
+          sessionId,
+          params: body,
+        });
+        sendRelayError(res, authorityError);
+        return;
+      }
 
-    const expiresAt = renewExpiresAtFromBody(body, renewalNow);
-    if (typeof expiresAt !== 'string') {
-      auditRenewalImmediateDenial(options.auditSink, {
-        error: expiresAt,
-        ...(nodeId ? { nodeId } : {}),
-        sessionId,
-        params: body,
-      });
-      sendRelayError(res, expiresAt);
-      return;
-    }
+      const expiresAt = renewExpiresAtFromBody(body, renewalNow);
+      if (typeof expiresAt !== 'string') {
+        auditRenewalImmediateDenial(options.auditSink, {
+          error: expiresAt,
+          ...(nodeId ? { nodeId } : {}),
+          sessionId,
+          params: body,
+        });
+        sendRelayError(res, expiresAt);
+        return;
+      }
 
-    if (nodeId !== DEFAULT_LOCAL_NODE_ID) {
-      const lifecycle = envelopes.validate({
-        sessionId,
-        ...(nodeId ? { nodeId } : {}),
-        now: renewalNow,
-      });
-      if (lifecycle.ok === false) {
-        const denial = lifecycle as Exclude<
-          ReturnType<InMemorySessionEnvelopeRegistry['validate']>,
+      if (nodeId !== DEFAULT_LOCAL_NODE_ID) {
+        const lifecycle = envelopes.validate({
+          sessionId,
+          ...(nodeId ? { nodeId } : {}),
+          now: renewalNow,
+        });
+        if (lifecycle.ok === false) {
+          const denial = lifecycle as Exclude<
+            ReturnType<InMemorySessionEnvelopeRegistry['validate']>,
+            { ok: true }
+          >;
+          auditLifecycleDenial(
+            options.auditSink,
+            denial,
+            nodeId ?? denial.summary?.nodeId ?? 'unknown',
+            sessionId,
+            'sessions.renew',
+            body
+          );
+          sendRelayError(res, denial.error);
+          return;
+        }
+
+        const policyNode = registry
+          .listNodes()
+          .find((candidate) => candidate.nodeId === lifecycle.summary.nodeId);
+        const policyDecision = evaluateHubPolicy({
+          peer: { kind: 'hub' },
+          node: policyNode ?? null,
+          nodeId: lifecycle.summary.nodeId,
+          intent: {
+            action: 'sessions.renew',
+            target: lifecycle.summary.nodeId,
+          },
+          scope: sessionRenewPolicyScope(lifecycle.summary),
+          requiredCapabilities:
+            requiredCapabilitiesForRpcIntent('sessions.renew'),
+          expiresAt: lifecycle.summary.expiresAt,
+          revokedAt: lifecycle.summary.revokedAt,
+          sessionId: lifecycle.summary.sessionId,
+          ...(lifecycle.summary.correlationId
+            ? { correlationId: lifecycle.summary.correlationId }
+            : {}),
+          params: body,
+          now: renewalNow,
+        });
+        if (
+          sendPolicyDecision(options.auditSink, res, policyDecision, body, {
+            confirmations,
+            req,
+            canonicalParams: body,
+            now: renewalNow,
+          })
+        )
+          return;
+      }
+
+      const renewed =
+        nodeId === DEFAULT_LOCAL_NODE_ID && options.renewLocalSession
+          ? options.renewLocalSession({
+              id: sessionId,
+              expiresAt,
+              now: renewalNow,
+            })
+          : envelopes.renew({
+              sessionId,
+              ...(nodeId ? { nodeId } : {}),
+              expiresAt,
+              now: renewalNow,
+            });
+      if (renewed.ok === false) {
+        const denial = renewed as Exclude<
+          ReturnType<InMemorySessionEnvelopeRegistry['renew']>,
           { ok: true }
         >;
         auditLifecycleDenial(
@@ -2236,395 +2560,416 @@ export function createHubNodeRouter(
         return;
       }
 
-      const policyNode = registry
+      auditLifecycleRenewal(options.auditSink, {
+        previousSummary: renewed.previousSummary,
+        summary: renewed.summary,
+        params: body,
+      });
+      res.json({ session: renewed.summary });
+    }
+  );
+
+  router.post(
+    '/hub/scoped-sessions/:sessionId/revoke',
+    scopedSessionAuth,
+    (req, res) => {
+      const { sessionId } = req.params;
+      if (!sessionId) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'sessionId is required')
+        );
+        return;
+      }
+      const body = bodyRecord(req);
+      const queryNodeId =
+        typeof req.query['nodeId'] === 'string'
+          ? req.query['nodeId']
+          : undefined;
+      const nodeId = stringField(body, 'nodeId') ?? queryNodeId;
+      const revokeReason = revokedReasonFromBody(body);
+      const addressError = revokeAddressError(envelopes, sessionId, nodeId);
+      if (addressError) {
+        sendRelayError(res, addressError);
+        return;
+      }
+      const summary = envelopes.revoke(sessionId, {
+        ...(nodeId ? { nodeId } : {}),
+        ...(revokeReason ? { reason: revokeReason } : {}),
+        now: now(),
+      });
+      if (!summary) {
+        sendRelayError(
+          res,
+          relayError('NOT_FOUND', 'scoped session envelope was not found')
+        );
+        return;
+      }
+      auditLifecycleRevocation(options.auditSink, summary, body);
+      res.json({ session: summary });
+    }
+  );
+
+  router.delete(
+    '/hub/scoped-sessions/:sessionId',
+    scopedSessionAuth,
+    (req, res) => {
+      const { sessionId } = req.params;
+      if (!sessionId) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'sessionId is required')
+        );
+        return;
+      }
+      const nodeId =
+        typeof req.query['nodeId'] === 'string'
+          ? req.query['nodeId']
+          : undefined;
+      const addressError = revokeAddressError(envelopes, sessionId, nodeId);
+      if (addressError) {
+        sendRelayError(res, addressError);
+        return;
+      }
+      const summary = envelopes.revoke(sessionId, {
+        ...(nodeId ? { nodeId } : {}),
+        reason: 'operator-revoked',
+        now: now(),
+      });
+      if (!summary) {
+        sendRelayError(
+          res,
+          relayError('NOT_FOUND', 'scoped session envelope was not found')
+        );
+        return;
+      }
+      auditLifecycleRevocation(options.auditSink, summary, {
+        method: 'DELETE',
+      });
+      res.json({ session: summary });
+    }
+  );
+
+  router.post(
+    '/hub/nodes/:nodeId/cwd/:operation',
+    requireAuth,
+    async (req, res) => {
+      const { nodeId, operation } = req.params;
+      if (!nodeId) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'nodeId is required')
+        );
+        return;
+      }
+      if (operation !== 'browse' && operation !== 'validate') {
+        sendRelayError(
+          res,
+          relayError(
+            'INVALID_REQUEST',
+            'cwd operation must be browse or validate'
+          )
+        );
+        return;
+      }
+      const node = registry
         .listNodes()
-        .find((candidate) => candidate.nodeId === lifecycle.summary.nodeId);
+        .find((candidate) => candidate.nodeId === nodeId);
+      if (!node || node.status === 'revoked') {
+        sendRelayError(res, relayError('NOT_FOUND', 'node is not paired'));
+        return;
+      }
+      if (node.protocolVersion !== RELAY_NODE_LINK_PROTOCOL_VERSION) {
+        sendRelayError(res, protocolVersionRelayError(node.protocolVersion));
+        return;
+      }
+      const terminalUnsupported = nodeTerminalUnsupportedError(nodeId, node);
+      if (terminalUnsupported) {
+        sendRelayError(res, terminalUnsupported);
+        return;
+      }
+      if (
+        node.status !== 'online' ||
+        !options.nodeLinks?.hasActiveNode(nodeId)
+      ) {
+        sendRelayError(
+          res,
+          relayError(
+            'NODE_OFFLINE',
+            `node ${nodeId} has no live reverse link`,
+            true
+          )
+        );
+        return;
+      }
+
+      const body = bodyRecord(req);
+      const normalized = nodeCwdOnboardingPayload({ node, body, operation });
+      if ('code' in normalized) {
+        sendRelayError(res, normalized);
+        return;
+      }
+      const action = operation === 'browse' ? 'rpc.fs.list' : 'rpc.fs.stat';
+      const nowForPolicy = now();
       const policyDecision = evaluateHubPolicy({
         peer: { kind: 'hub' },
-        node: policyNode ?? null,
-        nodeId: lifecycle.summary.nodeId,
-        intent: { action: 'sessions.renew', target: lifecycle.summary.nodeId },
-        scope: sessionRenewPolicyScope(lifecycle.summary),
-        requiredCapabilities: requiredCapabilitiesForRpcIntent('sessions.renew'),
-        expiresAt: lifecycle.summary.expiresAt,
-        revokedAt: lifecycle.summary.revokedAt,
-        sessionId: lifecycle.summary.sessionId,
-        ...(lifecycle.summary.correlationId
-          ? { correlationId: lifecycle.summary.correlationId }
-          : {}),
-        params: body,
-        now: renewalNow,
+        node,
+        nodeId,
+        intent: { action, target: nodeId },
+        scope: {
+          kind: 'node-cwd',
+          nodeId,
+          cwd: normalized.cwd,
+          path: normalized.path,
+        },
+        requiredCapabilities: requiredCapabilitiesForRpcIntent(action),
+        params: normalized.request,
+        now: nowForPolicy,
       });
       if (
-        sendPolicyDecision(options.auditSink, res, policyDecision, body, {
-          confirmations,
-          req,
-          canonicalParams: body,
-          now: renewalNow,
-        })
-      ) return;
-    }
-
-    const renewed =
-      nodeId === DEFAULT_LOCAL_NODE_ID && options.renewLocalSession
-        ? options.renewLocalSession({ id: sessionId, expiresAt, now: renewalNow })
-        : envelopes.renew({
-            sessionId,
-            ...(nodeId ? { nodeId } : {}),
-            expiresAt,
-            now: renewalNow,
-          });
-    if (renewed.ok === false) {
-      const denial = renewed as Exclude<
-        ReturnType<InMemorySessionEnvelopeRegistry['renew']>,
-        { ok: true }
-      >;
-      auditLifecycleDenial(
-        options.auditSink,
-        denial,
-        nodeId ?? denial.summary?.nodeId ?? 'unknown',
-        sessionId,
-        'sessions.renew',
-        body
-      );
-      sendRelayError(res, denial.error);
-      return;
-    }
-
-    auditLifecycleRenewal(options.auditSink, {
-      previousSummary: renewed.previousSummary,
-      summary: renewed.summary,
-      params: body,
-    });
-    res.json({ session: renewed.summary });
-  });
-
-  router.post('/hub/scoped-sessions/:sessionId/revoke', scopedSessionAuth, (req, res) => {
-    const { sessionId } = req.params;
-    if (!sessionId) {
-      sendRelayError(res, relayError('INVALID_REQUEST', 'sessionId is required'));
-      return;
-    }
-    const body = bodyRecord(req);
-    const queryNodeId =
-      typeof req.query['nodeId'] === 'string' ? req.query['nodeId'] : undefined;
-    const nodeId = stringField(body, 'nodeId') ?? queryNodeId;
-    const revokeReason = revokedReasonFromBody(body);
-    const addressError = revokeAddressError(envelopes, sessionId, nodeId);
-    if (addressError) {
-      sendRelayError(res, addressError);
-      return;
-    }
-    const summary = envelopes.revoke(sessionId, {
-      ...(nodeId ? { nodeId } : {}),
-      ...(revokeReason ? { reason: revokeReason } : {}),
-      now: now(),
-    });
-    if (!summary) {
-      sendRelayError(res, relayError('NOT_FOUND', 'scoped session envelope was not found'));
-      return;
-    }
-    auditLifecycleRevocation(options.auditSink, summary, body);
-    res.json({ session: summary });
-  });
-
-  router.delete('/hub/scoped-sessions/:sessionId', scopedSessionAuth, (req, res) => {
-    const { sessionId } = req.params;
-    if (!sessionId) {
-      sendRelayError(res, relayError('INVALID_REQUEST', 'sessionId is required'));
-      return;
-    }
-    const nodeId = typeof req.query['nodeId'] === 'string' ? req.query['nodeId'] : undefined;
-    const addressError = revokeAddressError(envelopes, sessionId, nodeId);
-    if (addressError) {
-      sendRelayError(res, addressError);
-      return;
-    }
-    const summary = envelopes.revoke(sessionId, {
-      ...(nodeId ? { nodeId } : {}),
-      reason: 'operator-revoked',
-      now: now(),
-    });
-    if (!summary) {
-      sendRelayError(res, relayError('NOT_FOUND', 'scoped session envelope was not found'));
-      return;
-    }
-    auditLifecycleRevocation(options.auditSink, summary, { method: 'DELETE' });
-    res.json({ session: summary });
-  });
-
-  router.post('/hub/nodes/:nodeId/cwd/:operation', requireAuth, async (req, res) => {
-    const { nodeId, operation } = req.params;
-    if (!nodeId) {
-      sendRelayError(res, relayError('INVALID_REQUEST', 'nodeId is required'));
-      return;
-    }
-    if (operation !== 'browse' && operation !== 'validate') {
-      sendRelayError(
-        res,
-        relayError('INVALID_REQUEST', 'cwd operation must be browse or validate')
-      );
-      return;
-    }
-    const node = registry
-      .listNodes()
-      .find((candidate) => candidate.nodeId === nodeId);
-    if (!node || node.status === 'revoked') {
-      sendRelayError(res, relayError('NOT_FOUND', 'node is not paired'));
-      return;
-    }
-    if (node.protocolVersion !== RELAY_NODE_LINK_PROTOCOL_VERSION) {
-      sendRelayError(res, protocolVersionRelayError(node.protocolVersion));
-      return;
-    }
-    const terminalUnsupported = nodeTerminalUnsupportedError(nodeId, node);
-    if (terminalUnsupported) {
-      sendRelayError(res, terminalUnsupported);
-      return;
-    }
-    if (node.status !== 'online' || !options.nodeLinks?.hasActiveNode(nodeId)) {
-      sendRelayError(
-        res,
-        relayError('NODE_OFFLINE', `node ${nodeId} has no live reverse link`, true)
-      );
-      return;
-    }
-
-    const body = bodyRecord(req);
-    const normalized = nodeCwdOnboardingPayload({ node, body, operation });
-    if ('code' in normalized) {
-      sendRelayError(res, normalized);
-      return;
-    }
-    const action = operation === 'browse' ? 'rpc.fs.list' : 'rpc.fs.stat';
-    const nowForPolicy = now();
-    const policyDecision = evaluateHubPolicy({
-      peer: { kind: 'hub' },
-      node,
-      nodeId,
-      intent: { action, target: nodeId },
-      scope: {
-        kind: 'node-cwd',
-        nodeId,
-        cwd: normalized.cwd,
-        path: normalized.path,
-      },
-      requiredCapabilities: requiredCapabilitiesForRpcIntent(action),
-      params: normalized.request,
-      now: nowForPolicy,
-    });
-    if (
-      sendPolicyDecision(options.auditSink, res, policyDecision, normalized.request, {
-        confirmations,
-        req,
-        canonicalParams: normalized.request,
-        now: nowForPolicy,
-      })
-    ) return;
-
-    try {
-      const rpcType = operation === 'browse' ? 'fs.list' : 'fs.stat';
-      const payload = await options.nodeLinks.request(nodeId, rpcType, normalized.request);
-      const responsePayload = isRecord(payload) ? payload : { payload };
-      res.json({ nodeId, cwd: normalized.cwd, ...responsePayload });
-    } catch (error) {
-      if (error instanceof HubNodeLinkError) {
-        sendRelayError(res, error.relayNodeError);
-        return;
-      }
-      sendRegistryError(registry, res, error);
-    }
-  });
-
-  router.post('/hub/nodes/:nodeId/sessions', cliGatewayAuth, async (req, res) => {
-    const { nodeId } = req.params;
-    if (!nodeId) {
-      sendRelayError(res, relayError('INVALID_REQUEST', 'nodeId is required'));
-      return;
-    }
-    const routedBody = routedGatewayCreateBodyFromRequest(req, res, nodeId);
-    if (!routedBody) return;
-    const workContextId = routedWorkContextId(routedBody);
-    const workContextError = validateRoutedWorkContext(
-      options.workContextStore,
-      workContextId
-    );
-    if (workContextError) {
-      sendRelayError(res, workContextError);
-      return;
-    }
-    const node = registry
-      .listNodes()
-      .find((candidate) => candidate.nodeId === nodeId);
-    if (!node || node.status === 'revoked') {
-      sendRelayError(res, relayError('NOT_FOUND', 'node is not paired'));
-      return;
-    }
-    if (node.protocolVersion !== RELAY_NODE_LINK_PROTOCOL_VERSION) {
-      const [nodeMajor] = node.protocolVersion.split('.');
-      const [hubMajor] = RELAY_NODE_LINK_PROTOCOL_VERSION.split('.');
-      sendRelayError(
-        res,
-        relayError(
-          nodeMajor === hubMajor ? 'VERSION_SKEW' : 'PROTOCOL_INCOMPATIBLE',
-          `relay-node-link protocol ${node.protocolVersion} must exactly match hub protocol ${RELAY_NODE_LINK_PROTOCOL_VERSION}`
-        )
-      );
-      return;
-    }
-    const terminalUnsupported = nodeTerminalUnsupportedError(nodeId, node);
-    if (terminalUnsupported) {
-      sendRelayError(res, terminalUnsupported);
-      return;
-    }
-    if (node.status !== 'online' || !options.nodeLinks?.hasActiveNode(nodeId)) {
-      sendRelayError(
-        res,
-        relayError(
-          'NODE_OFFLINE',
-          `node ${nodeId} has no live reverse link`,
-          true
-        )
-      );
-      return;
-    }
-
-    const lifecycleError = lifecycleInputError(routedBody);
-    if (lifecycleError) {
-      sendRelayError(
-        res,
-        relayError('INVALID_REQUEST', lifecycleError.message, false, {
-          reasonCode: 'INVALID_LIFECYCLE_INPUT',
-          field: lifecycleError.field,
-        })
-      );
-      return;
-    }
-    const createNow = now();
-    const expiresAt = expiresAtFromLifecycleInput(routedBody, createNow);
-    if (expiresAt !== undefined && expiresAt !== null && Date.parse(expiresAt) <= createNow.getTime()) {
-      const error = relayError(
-        'SESSION_EXPIRED',
-        'routed session envelope is already expired',
-        false,
-        { reasonCode: 'SESSION_EXPIRED', expiresAt }
-      );
-      appendRoutedSessionAudit(options.auditSink, {
-        eventType: 'expiry',
-        decision: 'expired',
-        reasonCode: 'SESSION_EXPIRED',
-        peer: { kind: 'hub' },
-        node: { nodeId },
-        intent: { action: 'sessions.create', target: nodeId },
-        material: { params: routedBody },
-      });
-      sendRelayError(res, error);
-      return;
-    }
-    const requestedEnvelope = isSessionEnvelope(routedBody['sessionEnvelope'])
-      ? routedBody['sessionEnvelope']
-      : null;
-    if (requestedEnvelope && requestedEnvelope.nodeId !== nodeId) {
-      appendRoutedSessionAudit(options.auditSink, {
-        eventType: 'denial',
-        decision: 'deny',
-        reasonCode: 'SESSION_NODE_MISMATCH',
-        peer: { kind: 'hub' },
-        node: { nodeId },
-        sessionId: requestedEnvelope.sessionId,
-        intent: { action: 'sessions.create', target: nodeId },
-        material: {
-          params: {
-            expectedNodeId: requestedEnvelope.nodeId,
-            actualNodeId: nodeId,
-          },
-        },
-        ...(requestedEnvelope.correlationId ? { correlationId: requestedEnvelope.correlationId } : {}),
-      });
-      sendRelayError(
-        res,
-        relayError(
-          'SESSION_MISMATCH',
-          'routed session envelope node does not match the route',
-          false,
+        sendPolicyDecision(
+          options.auditSink,
+          res,
+          policyDecision,
+          normalized.request,
           {
-            reasonCode: 'SESSION_NODE_MISMATCH',
-            expectedNodeId: requestedEnvelope.nodeId,
-            actualNodeId: nodeId,
+            confirmations,
+            req,
+            canonicalParams: normalized.request,
+            now: nowForPolicy,
           }
         )
-      );
-      return;
-    }
-    const rawSessionType = routedBody['type'];
-    if (rawSessionType !== undefined && !isSessionCreateType(rawSessionType)) {
-      sendRelayError(
-        res,
-        relayError('INVALID_REQUEST', 'type must be agent or terminal', false, {
-          reasonCode: 'INVALID_SESSION_TYPE',
-          field: 'type',
-        })
-      );
-      return;
-    }
-    const sessionType = rawSessionType === 'agent' ? 'agent' : 'terminal';
-    const policyDecision = evaluateHubPolicy({
-      peer: { kind: 'hub' },
-      node,
-      nodeId,
-      intent: { action: 'sessions.create', target: nodeId },
-      scope: sessionCreatePolicyScope(nodeId, routedBody),
-      requiredCapabilities: sessionCreateCapabilities({
-        sessionType,
-        controlMode: routedBody['controlMode'],
-      }),
-      ...(expiresAt !== undefined ? { expiresAt } : {}),
-      params: routedBody,
-      now: createNow,
-    });
-    if (
-      sendPolicyDecision(options.auditSink, res, policyDecision, routedBody, {
-        confirmations,
-        req,
-        canonicalParams: routedBody,
-        now: createNow,
-      })
-    ) return;
+      )
+        return;
 
-    try {
-      const payload = await options.nodeLinks.request(
-        nodeId,
-        'sessions.create',
-        routedBody
-      );
-      const session = scopedNodeSession(nodeId, sessionFromPayload(payload), {
-        ...(expiresAt !== undefined ? { expiresAt } : {}),
-      });
-      envelopes.upsert(session.sessionEnvelope!);
-      const associationError = associateRoutedWorkContext(
-        options.workContextStore,
-        workContextId,
-        session
-      );
-      const responseSession = withTrustedWorkContextId(
-        options.workContextStore,
-        session,
-        workContextId
-      );
-      options.readModelCache?.upsert(nodeId, session, createNow.getTime());
-      res.status(201).json(
-        associationError
-          ? { ...responseSession, workContextAssociationError: associationError }
-          : responseSession
-      );
-    } catch (error) {
-      if (error instanceof HubNodeLinkError) {
-        sendRelayError(res, error.relayNodeError);
+      try {
+        const rpcType = operation === 'browse' ? 'fs.list' : 'fs.stat';
+        const payload = await options.nodeLinks.request(
+          nodeId,
+          rpcType,
+          normalized.request
+        );
+        const responsePayload = isRecord(payload) ? payload : { payload };
+        res.json({ nodeId, cwd: normalized.cwd, ...responsePayload });
+      } catch (error) {
+        if (error instanceof HubNodeLinkError) {
+          sendRelayError(res, error.relayNodeError);
+          return;
+        }
+        sendRegistryError(registry, res, error);
+      }
+    }
+  );
+
+  router.post(
+    '/hub/nodes/:nodeId/sessions',
+    cliGatewayAuth,
+    async (req, res) => {
+      const { nodeId } = req.params;
+      if (!nodeId) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'nodeId is required')
+        );
         return;
       }
-      sendRegistryError(registry, res, error);
+      const routedBody = routedGatewayCreateBodyFromRequest(req, res, nodeId);
+      if (!routedBody) return;
+      const workContextId = routedWorkContextId(routedBody);
+      const workContextError = validateRoutedWorkContext(
+        options.workContextStore,
+        workContextId
+      );
+      if (workContextError) {
+        sendRelayError(res, workContextError);
+        return;
+      }
+      const node = registry
+        .listNodes()
+        .find((candidate) => candidate.nodeId === nodeId);
+      if (!node || node.status === 'revoked') {
+        sendRelayError(res, relayError('NOT_FOUND', 'node is not paired'));
+        return;
+      }
+      // 503/400: node updating, helper major-version skew, or protocol mismatch blocks new sessions.
+      if (sendNodeUnavailableForCreate(res, node, nodeId)) return;
+      const terminalUnsupported = nodeTerminalUnsupportedError(nodeId, node);
+      if (terminalUnsupported) {
+        sendRelayError(res, terminalUnsupported);
+        return;
+      }
+      if (
+        node.status !== 'online' ||
+        !options.nodeLinks?.hasActiveNode(nodeId)
+      ) {
+        sendRelayError(
+          res,
+          relayError(
+            'NODE_OFFLINE',
+            `node ${nodeId} has no live reverse link`,
+            true
+          )
+        );
+        return;
+      }
+
+      const lifecycleError = lifecycleInputError(routedBody);
+      if (lifecycleError) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', lifecycleError.message, false, {
+            reasonCode: 'INVALID_LIFECYCLE_INPUT',
+            field: lifecycleError.field,
+          })
+        );
+        return;
+      }
+      const createNow = now();
+      const expiresAt = expiresAtFromLifecycleInput(routedBody, createNow);
+      if (
+        expiresAt !== undefined &&
+        expiresAt !== null &&
+        Date.parse(expiresAt) <= createNow.getTime()
+      ) {
+        const error = relayError(
+          'SESSION_EXPIRED',
+          'routed session envelope is already expired',
+          false,
+          { reasonCode: 'SESSION_EXPIRED', expiresAt }
+        );
+        appendRoutedSessionAudit(options.auditSink, {
+          eventType: 'expiry',
+          decision: 'expired',
+          reasonCode: 'SESSION_EXPIRED',
+          peer: { kind: 'hub' },
+          node: { nodeId },
+          intent: { action: 'sessions.create', target: nodeId },
+          material: { params: routedBody },
+        });
+        sendRelayError(res, error);
+        return;
+      }
+      const requestedEnvelope = isSessionEnvelope(routedBody['sessionEnvelope'])
+        ? routedBody['sessionEnvelope']
+        : null;
+      if (requestedEnvelope && requestedEnvelope.nodeId !== nodeId) {
+        appendRoutedSessionAudit(options.auditSink, {
+          eventType: 'denial',
+          decision: 'deny',
+          reasonCode: 'SESSION_NODE_MISMATCH',
+          peer: { kind: 'hub' },
+          node: { nodeId },
+          sessionId: requestedEnvelope.sessionId,
+          intent: { action: 'sessions.create', target: nodeId },
+          material: {
+            params: {
+              expectedNodeId: requestedEnvelope.nodeId,
+              actualNodeId: nodeId,
+            },
+          },
+          ...(requestedEnvelope.correlationId
+            ? { correlationId: requestedEnvelope.correlationId }
+            : {}),
+        });
+        sendRelayError(
+          res,
+          relayError(
+            'SESSION_MISMATCH',
+            'routed session envelope node does not match the route',
+            false,
+            {
+              reasonCode: 'SESSION_NODE_MISMATCH',
+              expectedNodeId: requestedEnvelope.nodeId,
+              actualNodeId: nodeId,
+            }
+          )
+        );
+        return;
+      }
+      const rawSessionType = routedBody['type'];
+      if (
+        rawSessionType !== undefined &&
+        !isSessionCreateType(rawSessionType)
+      ) {
+        sendRelayError(
+          res,
+          relayError(
+            'INVALID_REQUEST',
+            'type must be agent or terminal',
+            false,
+            {
+              reasonCode: 'INVALID_SESSION_TYPE',
+              field: 'type',
+            }
+          )
+        );
+        return;
+      }
+      const sessionType = rawSessionType === 'agent' ? 'agent' : 'terminal';
+      const policyDecision = evaluateHubPolicy({
+        peer: { kind: 'hub' },
+        node,
+        nodeId,
+        intent: { action: 'sessions.create', target: nodeId },
+        scope: sessionCreatePolicyScope(nodeId, routedBody),
+        requiredCapabilities: sessionCreateCapabilities({
+          sessionType,
+          controlMode: routedBody['controlMode'],
+        }),
+        ...(expiresAt !== undefined ? { expiresAt } : {}),
+        params: routedBody,
+        now: createNow,
+      });
+      if (
+        sendPolicyDecision(options.auditSink, res, policyDecision, routedBody, {
+          confirmations,
+          req,
+          canonicalParams: routedBody,
+          now: createNow,
+        })
+      )
+        return;
+
+      try {
+        const payload = await options.nodeLinks.request(
+          nodeId,
+          'sessions.create',
+          routedBody
+        );
+        const session = scopedNodeSession(nodeId, sessionFromPayload(payload), {
+          ...(expiresAt !== undefined ? { expiresAt } : {}),
+        });
+        envelopes.upsert(session.sessionEnvelope!);
+        const associationError = associateRoutedWorkContext(
+          options.workContextStore,
+          workContextId,
+          session
+        );
+        const responseSession = withTrustedWorkContextId(
+          options.workContextStore,
+          session,
+          workContextId
+        );
+        options.readModelCache?.upsert(nodeId, session, createNow.getTime());
+        res
+          .status(201)
+          .json(
+            associationError
+              ? {
+                  ...responseSession,
+                  workContextAssociationError: associationError,
+                }
+              : responseSession
+          );
+      } catch (error) {
+        if (error instanceof HubNodeLinkError) {
+          sendRelayError(res, error.relayNodeError);
+          return;
+        }
+        sendRegistryError(registry, res, error);
+      }
     }
-  });
+  );
 
   router.post(
     '/hub/nodes/:nodeId/sessions/:sessionId/files/:operation',
@@ -2632,20 +2977,31 @@ export function createHubNodeRouter(
     async (req, res) => {
       const { nodeId, sessionId, operation } = req.params;
       if (!nodeId) {
-        sendRelayError(res, relayError('INVALID_REQUEST', 'nodeId is required'));
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'nodeId is required')
+        );
         return;
       }
       if (!sessionId) {
-        sendRelayError(res, relayError('INVALID_REQUEST', 'sessionId is required'));
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'sessionId is required')
+        );
         return;
       }
       if (!isFileRpcOperation(operation)) {
         sendRelayError(
           res,
-          relayError('INVALID_REQUEST', 'file RPC operation must be list, stat, read, tail, or write', false, {
-            reasonCode: 'FILE_RPC_INVALID_REQUEST',
-            operation,
-          })
+          relayError(
+            'INVALID_REQUEST',
+            'file RPC operation must be list, stat, read, tail, or write',
+            false,
+            {
+              reasonCode: 'FILE_RPC_INVALID_REQUEST',
+              operation,
+            }
+          )
         );
         return;
       }
@@ -2741,12 +3097,18 @@ export function createHubNodeRouter(
         path: normalized.value.request.path,
       };
       if (
-        sendPolicyDecision(options.auditSink, res, policyDecision, canonicalFileParams, {
-          confirmations,
-          req,
-          canonicalParams: canonicalFileParams,
-          now: now(),
-        })
+        sendPolicyDecision(
+          options.auditSink,
+          res,
+          policyDecision,
+          canonicalFileParams,
+          {
+            confirmations,
+            req,
+            canonicalParams: canonicalFileParams,
+            now: now(),
+          }
+        )
       ) {
         return;
       }
@@ -2781,7 +3143,9 @@ export function createHubNodeRouter(
             sessionId,
             policyScope: normalized.value.policyScope,
             payload,
-            ...(lifecycle.summary.correlationId ? { correlationId: lifecycle.summary.correlationId } : {}),
+            ...(lifecycle.summary.correlationId
+              ? { correlationId: lifecycle.summary.correlationId }
+              : {}),
           });
         }
         res.json(payload);
@@ -2794,8 +3158,13 @@ export function createHubNodeRouter(
               nodeId,
               sessionId,
               policyScope: normalized.value.policyScope,
-              errorCode: String(error.relayNodeError.details?.['reasonCode'] ?? error.relayNodeError.code),
-              ...(lifecycle.summary.correlationId ? { correlationId: lifecycle.summary.correlationId } : {}),
+              errorCode: String(
+                error.relayNodeError.details?.['reasonCode'] ??
+                  error.relayNodeError.code
+              ),
+              ...(lifecycle.summary.correlationId
+                ? { correlationId: lifecycle.summary.correlationId }
+                : {}),
             });
           }
           sendRelayError(res, error.relayNodeError);
@@ -2889,7 +3258,9 @@ export function createHubNodeRouter(
               kind: scoped.scope.kind,
               nodeId,
               cwd: scoped.scope.cwd,
-              ...(scoped.scope.repoPath ? { repoPath: scoped.scope.repoPath } : {}),
+              ...(scoped.scope.repoPath
+                ? { repoPath: scoped.scope.repoPath }
+                : {}),
               ...(scoped.scope.worktreePath !== undefined
                 ? { worktreePath: scoped.scope.worktreePath }
                 : {}),
@@ -2897,20 +3268,31 @@ export function createHubNodeRouter(
           : { kind: 'node', nodeId, cwd: '/' },
         requiredCapabilities: ['session:control:kill'],
         sessionId,
-        ...(scoped?.correlationId ? { correlationId: scoped.correlationId } : {}),
-        ...(scoped?.expiresAt !== undefined ? { expiresAt: scoped.expiresAt } : {}),
+        ...(scoped?.correlationId
+          ? { correlationId: scoped.correlationId }
+          : {}),
+        ...(scoped?.expiresAt !== undefined
+          ? { expiresAt: scoped.expiresAt }
+          : {}),
         ...(scoped?.revokedAt ? { revokedAt: scoped.revokedAt } : {}),
         params: killParams,
         now: killNow,
       });
       if (
-        sendPolicyDecision(options.auditSink, res, killPolicyDecision, killParams, {
-          confirmations,
-          req,
-          canonicalParams: killParams,
-          now: killNow,
-        })
-      ) return;
+        sendPolicyDecision(
+          options.auditSink,
+          res,
+          killPolicyDecision,
+          killParams,
+          {
+            confirmations,
+            req,
+            canonicalParams: killParams,
+            now: killNow,
+          }
+        )
+      )
+        return;
 
       try {
         await options.nodeLinks.request(nodeId, 'sessions.kill', {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1016,6 +1016,7 @@ function createAuditedHubNodeRegistry(
 ): ReturnType<typeof createHubNodeRegistry> {
   const options: Parameters<typeof createHubNodeRegistry>[0] = {
     storagePath: path.join(configDir, 'hub-node-registry.json'),
+    hubVersion: getCurrentVersion(),
   };
   if (auditSink) options.auditSink = auditSink;
   return createHubNodeRegistry(options);

--- a/server/node-version-skew.ts
+++ b/server/node-version-skew.ts
@@ -1,0 +1,119 @@
+/**
+ * Hub↔node helper-version skew detection.
+ *
+ * Compatibility policy (ADR-017 / #655):
+ *   - `compatible`         — node helperVersion equals hub version (or falls
+ *                            within the same major and helper minor ≥ hub minor − 2)
+ *   - `minor-skew-warn`    — same major, helper minor in range [hubMinor−2, hubMinor)
+ *                            or > hubMinor (node is ahead); sessions are allowed
+ *   - `major-skew-error`   — different major version; new session-create is blocked
+ *                            (HTTP 503 with Retry-After); existing sessions drain
+ *
+ * The policy is intentionally lenient on minor skew: nodes are commonly one or
+ * two minor versions behind the hub during a rolling fleet update, and their
+ * surface compatibility is governed by the node-link protocol version check
+ * (which already rejects incompatible protocol majors). Helper version skew is
+ * an advisory warning at minor distance and a hard gate only at major distance.
+ */
+
+export type HelperSkewCategory =
+  | 'compatible'
+  | 'minor-skew-warn'
+  | 'major-skew-error';
+
+export interface HelperSkewResult {
+  category: HelperSkewCategory;
+  helperVersion: string;
+  hubVersion: string;
+  /** Human-readable message suitable for UI and logs. */
+  message: string;
+  /** Remediation hint shown when category is not `compatible`. */
+  remediationHint?: string;
+}
+
+function parseMajorMinor(version: string): { major: number; minor: number } {
+  const withoutPre = version.split('-', 1)[0]!;
+  const parts = withoutPre.split('.');
+  return {
+    major: Number(parts[0] ?? '0'),
+    minor: Number(parts[1] ?? '0'),
+  };
+}
+
+/**
+ * Classify the helper version skew between a node and the hub.
+ *
+ * @param helperVersion  The version string from `NodeManifest.helperVersion`
+ *                       (or `relayVersion` for pre-#651 nodes).
+ * @param hubVersion     The hub's own package.json version.
+ */
+export function classifyHelperSkew(
+  helperVersion: string,
+  hubVersion: string
+): HelperSkewResult {
+  if (!helperVersion || helperVersion === 'unknown') {
+    return {
+      category: 'minor-skew-warn',
+      helperVersion,
+      hubVersion,
+      message:
+        'node helper version is unknown; cannot determine compatibility. sessions are allowed.',
+      remediationHint:
+        'run `relay-ide node update` on the node to install the latest version.',
+    };
+  }
+
+  const node = parseMajorMinor(helperVersion);
+  const hub = parseMajorMinor(hubVersion);
+
+  if (node.major !== hub.major) {
+    return {
+      category: 'major-skew-error',
+      helperVersion,
+      hubVersion,
+      message: `node helper v${helperVersion} is a different major version than hub v${hubVersion}; new sessions blocked until node is updated.`,
+      remediationHint: `run \`relay-ide node update\` on the node to install relay-ide v${hubVersion}.`,
+    };
+  }
+
+  // Same major. Accept helper minor within [hubMinor − 2, ∞).
+  // Nodes ahead of the hub (minor > hub.minor) are allowed — hub may be behind.
+  const minorGap = hub.minor - node.minor;
+  if (minorGap <= 0 || minorGap <= 2) {
+    // compatible or close-enough
+    if (helperVersion === hubVersion) {
+      return {
+        category: 'compatible',
+        helperVersion,
+        hubVersion,
+        message: `node helper v${helperVersion} matches hub v${hubVersion}.`,
+      };
+    }
+    if (minorGap === 0 && node.minor === hub.minor) {
+      // same major.minor but pre-release mismatch — treat as compatible
+      return {
+        category: 'compatible',
+        helperVersion,
+        hubVersion,
+        message: `node helper v${helperVersion} is compatible with hub v${hubVersion}.`,
+      };
+    }
+    // minor gap ≤ 2 but not identical — warn
+    return {
+      category: 'minor-skew-warn',
+      helperVersion,
+      hubVersion,
+      message: `node helper v${helperVersion} is slightly behind hub v${hubVersion}; sessions are allowed but an update is recommended.`,
+      remediationHint: `run \`relay-ide node update\` on the node to install relay-ide v${hubVersion}.`,
+    };
+  }
+
+  // minor gap > 2 — still same major, but warn louder
+  return {
+    category: 'minor-skew-warn',
+    helperVersion,
+    hubVersion,
+    message: `node helper v${helperVersion} is ${minorGap} minor versions behind hub v${hubVersion}; sessions are allowed but update is strongly recommended.`,
+    remediationHint: `run \`relay-ide node update\` on the node to install relay-ide v${hubVersion}.`,
+  };
+}

--- a/shared/relay-node-protocol.ts
+++ b/shared/relay-node-protocol.ts
@@ -59,7 +59,12 @@ export interface RelayNodeCredential {
   issuedAt: string;
 }
 
-export type HubNodeStatus = 'online' | 'stale' | 'offline' | 'revoked';
+export type HubNodeStatus =
+  | 'online'
+  | 'stale'
+  | 'offline'
+  | 'revoked'
+  | 'updating';
 export type HubNodeCredentialRotationState =
   | 'issuing'
   | 'delivered'
@@ -85,11 +90,34 @@ export interface HubNodeCredentialRotationSummary {
   failureReason?: string;
 }
 export type HubNodeTrustState = 'active' | 'trusted' | 'paired' | 'revoked';
-export type HubNodeTrustLevel = RelayTrustTier | 'privileged-local-user' | 'standard';
+export type HubNodeTrustLevel =
+  | RelayTrustTier
+  | 'privileged-local-user'
+  | 'standard';
 export type HubNodeVersionState =
   | 'compatible'
   | 'version-skew'
   | 'incompatible';
+
+/**
+ * Hub↔node helper-version (binary) skew categories.
+ * Distinct from the node-link protocol version check:
+ *   - `compatible`       — helperVersion matches hub version or is within 2 minor versions
+ *   - `minor-skew-warn`  — same major, minor gap > 0 but sessions are allowed
+ *   - `major-skew-error` — different major; new session-create blocked (HTTP 503)
+ */
+export type HubNodeHelperSkewCategory =
+  | 'compatible'
+  | 'minor-skew-warn'
+  | 'major-skew-error';
+
+export interface HubNodeHelperSkewSummary {
+  category: HubNodeHelperSkewCategory;
+  helperVersion: string;
+  hubVersion: string;
+  message: string;
+  remediationHint?: string;
+}
 
 export type NodeCapabilityStatus =
   | 'available'
@@ -171,6 +199,8 @@ export interface HubNodeSummary {
     nodeProtocolVersion: string;
     hubProtocolVersion: typeof RELAY_NODE_LINK_PROTOCOL_VERSION;
   };
+  /** Helper-binary version skew summary. Present when the node has reported helperVersion. */
+  helperSkew?: HubNodeHelperSkewSummary;
   capabilities: NodeCapabilityManifestSummary;
   createdAt: string;
   pairedAt: string;

--- a/test/node-version-skew.test.ts
+++ b/test/node-version-skew.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Tests for hub↔node helper-version skew detection (#655, Slice 5 of epic #613).
+ *
+ * Covers:
+ *   - classifyHelperSkew categorization (compatible / minor-skew-warn / major-skew-error)
+ *   - Edge cases: unknown version, node ahead of hub, exact match, pre-release
+ *   - Registry markNodeUpdating / markNodeUpdateComplete state transitions
+ *   - Session-create 503 gate for updating nodes and major-skew nodes
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import express from 'express';
+import http from 'node:http';
+import { describe, expect, it, afterEach } from 'vitest';
+import { classifyHelperSkew } from '../server/node-version-skew.js';
+import { createHubNodeRegistry } from '../server/hub-node-registry.js';
+import { createHubNodeRouter } from '../server/hub-node-router.js';
+import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
+import type { NodeManifest } from '../shared/node-manifest.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeManifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
+  return {
+    schemaVersion: 1,
+    platform: 'linux',
+    arch: 'x64',
+    hostname: 'test-node',
+    relayVersion: '0.1.0-test',
+    helperVersion: '0.1.0-test',
+    protocolVersion: '1.0',
+    generatedAt: new Date().toISOString(),
+    resolvedPaths: {},
+    fileRpc: { available: true, capabilities: [] },
+    degradedReasons: [],
+    wsl: { detected: false, version: null, systemd: false },
+    serviceManager: {
+      kind: 'systemd-user',
+      label: 'systemd user',
+      supported: true,
+      installable: true,
+      installHint: 'install',
+      uninstallHint: 'uninstall',
+      message: 'ok',
+      caveats: [],
+    },
+    capabilities: {
+      tmux: { id: 'tmux', label: 'tmux', status: 'available', message: 'ok' },
+      git: { id: 'git', label: 'Git', status: 'available', message: 'ok' },
+      clipboard: {
+        id: 'clipboard',
+        label: 'Clipboard',
+        status: 'unknown',
+        message: 'unknown',
+      },
+      browserAutomation: {
+        id: 'ba',
+        label: 'Browser',
+        status: 'degraded',
+        message: 'missing',
+      },
+      githubCli: {
+        id: 'gh',
+        label: 'GitHub CLI',
+        status: 'available',
+        message: 'ok',
+      },
+      tailscale: {
+        id: 'ts',
+        label: 'Tailscale',
+        status: 'unavailable',
+        message: 'missing',
+      },
+      ssh: { id: 'ssh', label: 'SSH', status: 'available', message: 'ok' },
+      agents: {},
+    },
+    ...overrides,
+  };
+}
+
+function withTmpRegistry<T>(
+  fn: (registry: ReturnType<typeof createHubNodeRegistry>) => T,
+  hubVersion?: string
+): T {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-skew-test-'));
+  try {
+    return fn(
+      createHubNodeRegistry({
+        storagePath: path.join(tmpDir, 'nodes.json'),
+        now: () => new Date('2026-01-02T03:04:05.000Z'),
+        hubVersion,
+      })
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// classifyHelperSkew: compatibility policy
+// ---------------------------------------------------------------------------
+
+describe('classifyHelperSkew', () => {
+  it('returns compatible when versions match exactly', () => {
+    const result = classifyHelperSkew('0.1.0', '0.1.0');
+    expect(result.category).toBe('compatible');
+  });
+
+  it('returns compatible for same major.minor with different patch', () => {
+    const result = classifyHelperSkew('0.1.3', '0.1.7');
+    // same major.minor → minor gap is 0, still compatible
+    expect(result.category).toBe('compatible');
+  });
+
+  it('returns minor-skew-warn when node is 1 minor behind hub', () => {
+    const result = classifyHelperSkew('0.1.0', '0.2.0');
+    expect(result.category).toBe('minor-skew-warn');
+    expect(result.remediationHint).toBeDefined();
+  });
+
+  it('returns minor-skew-warn when node is 2 minor versions behind hub', () => {
+    const result = classifyHelperSkew('0.1.0', '0.3.0');
+    expect(result.category).toBe('minor-skew-warn');
+  });
+
+  it('returns minor-skew-warn when node is 3+ minor versions behind hub (strongly warns)', () => {
+    const result = classifyHelperSkew('0.1.0', '0.5.0');
+    expect(result.category).toBe('minor-skew-warn');
+    expect(result.message).toMatch(/strongly recommended/);
+  });
+
+  it('returns minor-skew-warn when node is ahead of hub', () => {
+    const result = classifyHelperSkew('0.5.0', '0.4.0');
+    expect(result.category).toBe('minor-skew-warn');
+  });
+
+  it('returns major-skew-error when node major is lower than hub major', () => {
+    const result = classifyHelperSkew('0.1.0', '1.0.0');
+    expect(result.category).toBe('major-skew-error');
+    expect(result.message).toMatch(/new sessions blocked/);
+    expect(result.remediationHint).toBeDefined();
+  });
+
+  it('returns major-skew-error when node major is higher than hub major', () => {
+    const result = classifyHelperSkew('2.0.0', '1.0.0');
+    expect(result.category).toBe('major-skew-error');
+  });
+
+  it('returns minor-skew-warn for unknown helper version', () => {
+    const result = classifyHelperSkew('unknown', '0.1.0');
+    expect(result.category).toBe('minor-skew-warn');
+    expect(result.message).toMatch(/unknown/);
+  });
+
+  it('returns minor-skew-warn for empty helper version', () => {
+    const result = classifyHelperSkew('', '0.1.0');
+    expect(result.category).toBe('minor-skew-warn');
+  });
+
+  it('handles nightly pre-release versions as same major', () => {
+    // pre-release: 0.1.0-nightly.X — major is 0, same as hub 0.2.0
+    const result = classifyHelperSkew('0.1.0-nightly.20260501.1', '0.2.0');
+    expect(result.category).toBe('minor-skew-warn');
+  });
+
+  it('blocks sessions when node is nightly and hub is major-bumped', () => {
+    const result = classifyHelperSkew('0.1.0-nightly.20260501.1', '1.0.0');
+    expect(result.category).toBe('major-skew-error');
+  });
+
+  it('includes helperVersion and hubVersion in result', () => {
+    const result = classifyHelperSkew('0.1.0', '0.2.0');
+    expect(result.helperVersion).toBe('0.1.0');
+    expect(result.hubVersion).toBe('0.2.0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry: markNodeUpdating / markNodeUpdateComplete
+// ---------------------------------------------------------------------------
+
+describe('hub-node-registry updating state', () => {
+  function pairNode(registry: ReturnType<typeof createHubNodeRegistry>) {
+    const { pairToken } = registry.createPairToken({});
+    return registry.exchangePairToken({
+      pairToken,
+      manifest: makeManifest(),
+      protocolVersion: '1.0',
+    });
+  }
+
+  it('marks node as updating and back to normal', () => {
+    withTmpRegistry((registry) => {
+      const { node } = pairNode(registry);
+      const updating = registry.markNodeUpdating(node.nodeId);
+      expect(updating.status).toBe('updating');
+
+      const complete = registry.markNodeUpdateComplete(node.nodeId);
+      // after clearing, node was not heartbeating so may be offline/stale — just not 'updating'
+      expect(complete.status).not.toBe('updating');
+    });
+  });
+
+  it('idempotent: markNodeUpdating twice does not throw', () => {
+    withTmpRegistry((registry) => {
+      const { node } = pairNode(registry);
+      registry.markNodeUpdating(node.nodeId);
+      const second = registry.markNodeUpdating(node.nodeId);
+      expect(second.status).toBe('updating');
+    });
+  });
+
+  it('throws NOT_FOUND for unknown node on markNodeUpdating', () => {
+    withTmpRegistry((registry) => {
+      expect(() => registry.markNodeUpdating('node_nonexistent')).toThrow();
+    });
+  });
+
+  it('throws NOT_FOUND for unknown node on markNodeUpdateComplete', () => {
+    withTmpRegistry((registry) => {
+      expect(() =>
+        registry.markNodeUpdateComplete('node_nonexistent')
+      ).toThrow();
+    });
+  });
+
+  it('listNodes includes updating status', () => {
+    withTmpRegistry((registry) => {
+      const { node } = pairNode(registry);
+      registry.markNodeUpdating(node.nodeId);
+      const nodes = registry.listNodes();
+      const found = nodes.find((n) => n.nodeId === node.nodeId);
+      expect(found?.status).toBe('updating');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registry: helperSkew in publicNode
+// ---------------------------------------------------------------------------
+
+describe('hub-node-registry helperSkew', () => {
+  function pairNode(
+    registry: ReturnType<typeof createHubNodeRegistry>,
+    helperVersion: string
+  ) {
+    const { pairToken } = registry.createPairToken({});
+    return registry.exchangePairToken({
+      pairToken,
+      manifest: makeManifest({ helperVersion, relayVersion: helperVersion }),
+      protocolVersion: '1.0',
+    });
+  }
+
+  it('exposes compatible helperSkew when versions match', () => {
+    withTmpRegistry((registry) => {
+      const { node } = pairNode(registry, '0.1.0');
+      expect(node.helperSkew?.category).toBe('compatible');
+    }, '0.1.0');
+  });
+
+  it('exposes minor-skew-warn when helper is one minor behind', () => {
+    withTmpRegistry((registry) => {
+      const { node } = pairNode(registry, '0.1.0');
+      expect(node.helperSkew?.category).toBe('minor-skew-warn');
+    }, '0.2.0');
+  });
+
+  it('exposes major-skew-error when helper is a different major', () => {
+    withTmpRegistry((registry) => {
+      const { node } = pairNode(registry, '0.1.0');
+      expect(node.helperSkew?.category).toBe('major-skew-error');
+    }, '1.0.0');
+  });
+
+  it('omits helperSkew when no hubVersion configured', () => {
+    withTmpRegistry((registry) => {
+      const { node } = pairNode(registry, '0.1.0');
+      expect(node.helperSkew).toBeUndefined();
+    });
+  });
+
+  it('updates helperSkew after heartbeat with new helperVersion', () => {
+    withTmpRegistry((registry) => {
+      const { node } = pairNode(registry, '0.1.0');
+      const updated = registry.recordHeartbeat({
+        nodeId: node.nodeId,
+        protocolVersion: '1.0',
+        manifest: makeManifest({
+          helperVersion: '0.2.0',
+          relayVersion: '0.2.0',
+        }),
+      });
+      // now within same major, minor gap=0 → compatible
+      expect(updated.helperSkew?.category).toBe('compatible');
+    }, '0.2.0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP: 503 gate for updating and major-skew nodes
+// ---------------------------------------------------------------------------
+
+describe('session-create 503 gate', () => {
+  const servers: http.Server[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      servers.map((s) => new Promise<void>((r) => s.close(() => r())))
+    );
+    servers.length = 0;
+  });
+
+  async function setupServer(hubVersion: string) {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-skew-http-'));
+    const registry = createHubNodeRegistry({
+      storagePath: path.join(tmpDir, 'nodes.json'),
+      now: () => new Date('2026-01-02T03:04:05.000Z'),
+      hubVersion,
+    });
+
+    // Pair a node with the given helper version
+    const { pairToken } = registry.createPairToken({});
+    const { node } = registry.exchangePairToken({
+      pairToken,
+      manifest: makeManifest({ helperVersion: '0.1.0', relayVersion: '0.1.0' }),
+      protocolVersion: '1.0',
+    });
+
+    const app = express();
+    app.use(express.json());
+    const requireAuth: express.RequestHandler = (_req, _res, next) => next();
+    const envelopes = createSessionEnvelopeRegistry();
+    const router = createHubNodeRouter({
+      registry,
+      requireAuth,
+      sessionEnvelopes: envelopes,
+    });
+    app.use(router);
+
+    const server = http.createServer(app);
+    await new Promise<void>((resolve) =>
+      server.listen(0, '127.0.0.1', resolve)
+    );
+    servers.push(server);
+    const address = server.address() as { port: number };
+    const base = `http://127.0.0.1:${address.port}`;
+
+    return { registry, node, base, tmpDir };
+  }
+
+  it('returns 503 with Retry-After when node is in updating state', async () => {
+    const { registry, node, base } = await setupServer('0.1.0');
+    registry.markNodeUpdating(node.nodeId);
+
+    const res = await fetch(`${base}/hub/nodes/${node.nodeId}/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'terminal' }),
+    });
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get('retry-after')).toBe('60');
+    const body = (await res.json()) as {
+      error: { details?: { reasonCode?: string } };
+    };
+    expect(body.error.details?.reasonCode).toBe('NODE_UPDATING');
+  });
+
+  it('returns 503 with Retry-After when node has major-skew-error', async () => {
+    // Hub is v1.0.0, node helper is v0.1.0 → major skew
+    const { node, base } = await setupServer('1.0.0');
+
+    const res = await fetch(`${base}/hub/nodes/${node.nodeId}/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'terminal' }),
+    });
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get('retry-after')).toBe('60');
+    const body = (await res.json()) as {
+      error: { details?: { reasonCode?: string } };
+    };
+    expect(body.error.details?.reasonCode).toBe('NODE_VERSION_SKEW');
+  });
+
+  it('does not block sessions for minor-skew-warn nodes', async () => {
+    // Hub is v0.2.0, node helper is v0.1.0 → minor skew, sessions allowed
+    const { node, base } = await setupServer('0.2.0');
+
+    const res = await fetch(`${base}/hub/nodes/${node.nodeId}/sessions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ type: 'terminal' }),
+    });
+
+    // Should not get 503 from skew; the request will fail for a different
+    // reason (node offline because no live node link) but not from the skew gate.
+    expect(res.status).not.toBe(503);
+  });
+});


### PR DESCRIPTION
## Summary

Slice 5 of 5 for epic #613. Stacked on `feat/653-relayctl` (PR #665) — will rebase onto `nightly` after preceding slices merge. Completes epic #613.

- **Skew detection**: hub classifies node helper-binary versions as `compatible` / `minor-skew-warn` / `major-skew-error` on every pair/heartbeat using `NodeManifest.helperVersion`; exposes `HubNodeSummary.helperSkew`
- **503 gate**: new session-create on a `major-skew-error` or `updating` node returns HTTP 503 + `Retry-After: 60`; extracted into `sendNodeUnavailableForCreate()` to keep the route handler complexity under the ESLint limit
- **`relay-ide node update`**: idempotent binary update via npm, optional hub drain signaling (`--hub`), service restart if managed; `--check` flag for non-destructive version comparison
- **Hub drain state**: `markNodeUpdating` / `markNodeUpdateComplete` on the registry; `POST/DELETE /hub/nodes/:nodeId/updating` REST endpoints; `status: 'updating'` propagated through `listNodes()` and the node dashboard
- **UI annotation**: `HubNodeDashboardRow` gains `helperSkewWarning` field; `disabledReason` blocks attach for `major-skew-error` and `updating` nodes
- **26 new vitest cases**: skew classification, registry state transitions, 503 HTTP gate behavior
- **docs**: `RELAY_NODE_BOOTSTRAP.md` documents skew model, compatibility policy table, `node update` commands, and drain behavior

## Compatibility policy

> **Same major version, node helper minor within 2 of hub minor (or node ahead) → `compatible` or `minor-skew-warn` (sessions allowed). Different major → `major-skew-error` (new sessions blocked).**

| Category | Condition | Sessions |
|---|---|---|
| `compatible` | Exact match or minor gap ≤ 2, same major | allowed |
| `minor-skew-warn` | Same major, minor gap > 0 | allowed, update recommended |
| `major-skew-error` | Different major version | **blocked** (HTTP 503 + Retry-After: 60) |

The rationale: minor skew is normal during rolling fleet updates; the node-link protocol version check already rejects protocol-incompatible connections. Helper binary major version is the only hard gate because that's where breaking changes land.

## 503 gating implementation

`sendNodeUnavailableForCreate(res, node, nodeId)` in `server/hub-node-router.ts` is called from the `POST /hub/nodes/:nodeId/sessions` route before the existing online-check. It:
1. Returns `true` + sends 503 + `Retry-After: 60` if `node.status === 'updating'` (drain gate)
2. Returns `true` + sends 503 + `Retry-After: 60` if `node.helperSkew?.category === 'major-skew-error'` (version gate)
3. Returns `true` + sends 400/409 if protocol version mismatches (moved from inline to helper)
4. Returns `false` (no response sent) otherwise

Existing sessions are not terminated — only new session-create is gated.

## Acceptance criteria status

- [x] Hub detects + categorizes version skew per node (compatible/minor-skew-warn/major-skew-error)
- [x] Hub UI shows skew warnings with remediation hint (`HubNodeDashboardRow.helperSkewWarning`)
- [x] `relay-ide node update` succeeds on a paired node
- [x] Update is idempotent (no-op on same version)
- [x] Major-skew node returns 503 on new session-create
- [x] vitest coverage for skew categorization logic + update command parsing + 503 behavior
- [x] `docs/RELAY_NODE_BOOTSTRAP.md` documents the skew model + update commands

## Caveats / deviations

- `relay-ide node update` runs locally on the node; it does not SSH to the node from the hub. Operator must SSH to the node and run the command there.
- Hub signaling (`--hub` flag) is best-effort: if the hub is unreachable, the update proceeds without drain gating. This is intentional — the update should not be blocked by hub connectivity.
- The `updating` flag persists across hub restarts (stored in the registry file); `markNodeUpdateComplete` must be called to clear it. If the node reconnects without completing the update (e.g. crash during update), the operator can manually clear via `DELETE /hub/nodes/:nodeId/updating`.
- Pre-existing tests that require `dist/` (browser-cli, cli-gateway) are not affected by this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)