### PR TITLE
feat: FileResourceRef shared type (#616 slice 1)

### DIFF
--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -521,6 +521,28 @@ Cookie: token={auth-cookie}
 
 Response groups repo instances by canonical git identity, showing per-node paths, branch counts, worktree counts, and online status. In #444 terms this is a repo-kind Project inventory plus git-specific Instance/Bench metadata, not the complete future Project inventory.
 
+## File Resource Refs (#616 slice 1)
+
+`shared/file-resource-ref.ts` defines `FileResourceRef`, the addressable handle for a file or directory on a paired node. Subsequent #616 slices (preview blocks, agent prompt attachments, write/edit flows) consume refs as their pointer shape:
+
+```ts
+interface FileResourceRef {
+  nodeId: NodeId;
+  path: string;                   // absolute, POSIX-normalized
+  capturedAt: string;             // ISO 8601 UTC
+  intent: 'read' | 'list' | 'stat' | 'tail';
+  size?: number;                  // mint-time hint
+  sha256?: string;                // mint-time hash (only if `fs.read` ran)
+  mtimeMs?: number;
+  repoBinding?: { repoPath; worktreePath?; branch? };
+  maxBytes?: number;
+}
+```
+
+Refs are forward-looking pointers, not capability grants. The hub policy evaluator still enforces actual access at fetch time. The `intent` field signals which `fs.*` verb the ref is meant to invoke so capability checks can be planned up front (`rpc:fs:read` / `rpc:fs:list` / `rpc:fs:stat` / `rpc:fs:tail`).
+
+Helpers `createFileResourceRef`, `parseFileResourceRef`, `fileResourceRefEquals`, and `fileResourceRefSummary` live alongside the type. `createFileResourceRef` rejects relative paths, paths that escape root via `..`, malformed sha256 hex, non-ISO `capturedAt`, and unknown intents.
+
 ## Bootstrap and Service Modes
 
 ### Supported Service Modes

--- a/shared/file-resource-ref.ts
+++ b/shared/file-resource-ref.ts
@@ -1,0 +1,224 @@
+import type { NodeId } from './identity.js';
+
+/**
+ * `FileResourceRef` is the addressable handle for a file/dir/log on a paired
+ * node. Subsequent #616 slices (preview blocks, agent attachments, write/edit
+ * flows) consume these refs as the pointer shape.
+ *
+ * Refs carry freshness/size hints captured at mint time, but consumers MUST
+ * re-stat through `fs.stat` before treating those as authoritative — the file
+ * can change after the ref was minted.
+ *
+ * Refs do NOT carry capability grants; the hub policy evaluator enforces
+ * actual access at fetch time. The `intent` field signals which file RPC
+ * verb the ref is intended to invoke so capability checks can be planned
+ * up front.
+ */
+export interface FileResourceRef {
+  /** Paired node that owns the path. */
+  nodeId: NodeId;
+  /** Absolute path inside the node scope. Normalized via `path.posix.normalize`. */
+  path: string;
+  /** ISO 8601 timestamp at which the ref was minted. */
+  capturedAt: string;
+  /** Intent — which file RPC verb the ref is meant to drive. */
+  intent: FileResourceRefIntent;
+  /** Size in bytes at mint time (optional, advisory). */
+  size?: number;
+  /** sha256 hex of the contents at mint time (optional; only set if `fs.read` ran). */
+  sha256?: string;
+  /** Last-modified time in ms-since-epoch at mint time (optional). */
+  mtimeMs?: number;
+  /** Optional repo/worktree binding so callers can show git context. */
+  repoBinding?: FileResourceRepoBinding;
+  /** Size cap in bytes the ref carries (ignored by `list`/`stat`). */
+  maxBytes?: number;
+}
+
+export type FileResourceRefIntent = 'read' | 'list' | 'stat' | 'tail';
+
+export const FILE_RESOURCE_REF_INTENTS: readonly FileResourceRefIntent[] = [
+  'read',
+  'list',
+  'stat',
+  'tail',
+] as const;
+
+export interface FileResourceRepoBinding {
+  /** Absolute repo root that contains the path. */
+  repoPath: string;
+  /** Absolute worktree path (if the file lives in a non-primary worktree). */
+  worktreePath?: string | null;
+  /** Branch name (best-effort decoration; may be stale). */
+  branch?: string | null;
+}
+
+export interface CreateFileResourceRefArgs {
+  nodeId: NodeId;
+  path: string;
+  intent: FileResourceRefIntent;
+  size?: number;
+  sha256?: string;
+  mtimeMs?: number;
+  repoBinding?: FileResourceRepoBinding;
+  maxBytes?: number;
+  /** Override `capturedAt`; defaults to `new Date().toISOString()`. */
+  capturedAt?: string;
+}
+
+const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+const SHA256_HEX_RE = /^[a-f0-9]{64}$/i;
+
+function normalizePosixPath(input: string): string {
+  if (typeof input !== 'string' || input.length === 0) {
+    throw new Error('FileResourceRef.path must be a non-empty string');
+  }
+  if (!input.startsWith('/')) {
+    throw new Error(`FileResourceRef.path must be absolute, got: ${input}`);
+  }
+  // Inline POSIX normalize so this module stays browser-safe (no `node:path` import).
+  const parts: string[] = [];
+  for (const segment of input.split('/')) {
+    if (segment === '' || segment === '.') continue;
+    if (segment === '..') {
+      if (parts.length === 0) {
+        throw new Error(`FileResourceRef.path escapes root: ${input}`);
+      }
+      parts.pop();
+      continue;
+    }
+    parts.push(segment);
+  }
+  return '/' + parts.join('/');
+}
+
+/**
+ * Mint a `FileResourceRef`. Throws if required fields are missing or
+ * malformed. `path` is normalized via inline POSIX semantics (no `..`
+ * components survive; non-absolute paths are rejected).
+ */
+export function createFileResourceRef(args: CreateFileResourceRefArgs): FileResourceRef {
+  if (typeof args.nodeId !== 'string' || args.nodeId.length === 0) {
+    throw new Error('FileResourceRef.nodeId is required');
+  }
+  if (!FILE_RESOURCE_REF_INTENTS.includes(args.intent)) {
+    throw new Error(
+      `FileResourceRef.intent must be one of ${FILE_RESOURCE_REF_INTENTS.join('|')}, got: ${String(args.intent)}`
+    );
+  }
+  const normalizedPath = normalizePosixPath(args.path);
+  const ref: FileResourceRef = {
+    nodeId: args.nodeId,
+    path: normalizedPath,
+    intent: args.intent,
+    capturedAt: args.capturedAt ?? new Date().toISOString(),
+  };
+  if (typeof args.size === 'number' && Number.isFinite(args.size) && args.size >= 0) {
+    ref.size = args.size;
+  }
+  if (typeof args.sha256 === 'string' && SHA256_HEX_RE.test(args.sha256)) {
+    ref.sha256 = args.sha256.toLowerCase();
+  } else if (args.sha256 !== undefined) {
+    throw new Error('FileResourceRef.sha256 must be 64 hex chars if set');
+  }
+  if (typeof args.mtimeMs === 'number' && Number.isFinite(args.mtimeMs) && args.mtimeMs >= 0) {
+    ref.mtimeMs = args.mtimeMs;
+  }
+  if (args.repoBinding) {
+    ref.repoBinding = sanitizeRepoBinding(args.repoBinding);
+  }
+  if (
+    typeof args.maxBytes === 'number' &&
+    Number.isFinite(args.maxBytes) &&
+    args.maxBytes > 0
+  ) {
+    ref.maxBytes = args.maxBytes;
+  }
+  if (!ISO_TIMESTAMP_RE.test(ref.capturedAt)) {
+    throw new Error(`FileResourceRef.capturedAt must be an ISO 8601 UTC timestamp, got: ${ref.capturedAt}`);
+  }
+  return ref;
+}
+
+function sanitizeRepoBinding(binding: FileResourceRepoBinding): FileResourceRepoBinding {
+  if (typeof binding.repoPath !== 'string' || binding.repoPath.length === 0) {
+    throw new Error('FileResourceRef.repoBinding.repoPath is required');
+  }
+  const out: FileResourceRepoBinding = { repoPath: normalizePosixPath(binding.repoPath) };
+  if (binding.worktreePath != null) {
+    if (typeof binding.worktreePath !== 'string') {
+      throw new Error('FileResourceRef.repoBinding.worktreePath must be a string or null');
+    }
+    out.worktreePath = normalizePosixPath(binding.worktreePath);
+  } else if (binding.worktreePath === null) {
+    out.worktreePath = null;
+  }
+  if (binding.branch != null) {
+    if (typeof binding.branch !== 'string') {
+      throw new Error('FileResourceRef.repoBinding.branch must be a string or null');
+    }
+    out.branch = binding.branch;
+  } else if (binding.branch === null) {
+    out.branch = null;
+  }
+  return out;
+}
+
+/**
+ * Parse + validate an unknown payload into a `FileResourceRef`. Returns
+ * `null` on validation failure rather than throwing — callers typically
+ * surface a typed denial in their own response shape.
+ */
+export function parseFileResourceRef(payload: unknown): FileResourceRef | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const p = payload as Record<string, unknown>;
+  try {
+    const args: CreateFileResourceRefArgs = {
+      nodeId: p['nodeId'] as NodeId,
+      path: p['path'] as string,
+      intent: p['intent'] as FileResourceRefIntent,
+    };
+    if (typeof p['size'] === 'number') args.size = p['size'] as number;
+    if (typeof p['sha256'] === 'string') args.sha256 = p['sha256'] as string;
+    if (typeof p['mtimeMs'] === 'number') args.mtimeMs = p['mtimeMs'] as number;
+    if (p['repoBinding'] && typeof p['repoBinding'] === 'object') {
+      args.repoBinding = p['repoBinding'] as FileResourceRepoBinding;
+    }
+    if (typeof p['maxBytes'] === 'number') args.maxBytes = p['maxBytes'] as number;
+    if (typeof p['capturedAt'] === 'string') args.capturedAt = p['capturedAt'] as string;
+    return createFileResourceRef(args);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Structural equality for refs. Mint-time decorations (`size`, `sha256`,
+ * `mtimeMs`, `capturedAt`) are excluded — the identity is `(nodeId, path,
+ * intent, maxBytes, repoBinding)`. Two refs minted at different times for
+ * the same file with the same intent are considered equal.
+ */
+export function fileResourceRefEquals(a: FileResourceRef, b: FileResourceRef): boolean {
+  if (a.nodeId !== b.nodeId) return false;
+  if (a.path !== b.path) return false;
+  if (a.intent !== b.intent) return false;
+  if ((a.maxBytes ?? null) !== (b.maxBytes ?? null)) return false;
+  const aBinding = a.repoBinding ?? null;
+  const bBinding = b.repoBinding ?? null;
+  if (aBinding === null && bBinding === null) return true;
+  if (aBinding === null || bBinding === null) return false;
+  if (aBinding.repoPath !== bBinding.repoPath) return false;
+  if ((aBinding.worktreePath ?? null) !== (bBinding.worktreePath ?? null)) return false;
+  if ((aBinding.branch ?? null) !== (bBinding.branch ?? null)) return false;
+  return true;
+}
+
+/**
+ * Compact human-readable label suitable for chips, audit rows, or log
+ * lines. Format: `<nodeId>:<path>` plus an optional `(<intent>)` suffix
+ * when the intent is not `read` (the default for most call sites).
+ */
+export function fileResourceRefSummary(ref: FileResourceRef): string {
+  const base = `${ref.nodeId}:${ref.path}`;
+  return ref.intent === 'read' ? base : `${base} (${ref.intent})`;
+}

--- a/test/file-resource-ref.test.ts
+++ b/test/file-resource-ref.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  FILE_RESOURCE_REF_INTENTS,
+  createFileResourceRef,
+  fileResourceRefEquals,
+  fileResourceRefSummary,
+  parseFileResourceRef,
+  type FileResourceRef,
+} from '../shared/file-resource-ref.js';
+
+describe('createFileResourceRef', () => {
+  it('mints a ref with required fields', () => {
+    const ref = createFileResourceRef({
+      nodeId: 'node_abc',
+      path: '/home/user/file.txt',
+      intent: 'read',
+    });
+    expect(ref.nodeId).toBe('node_abc');
+    expect(ref.path).toBe('/home/user/file.txt');
+    expect(ref.intent).toBe('read');
+    expect(typeof ref.capturedAt).toBe('string');
+    expect(ref.capturedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('normalizes paths and strips redundant segments', () => {
+    const ref = createFileResourceRef({
+      nodeId: 'n',
+      path: '/foo//bar/./baz',
+      intent: 'list',
+    });
+    expect(ref.path).toBe('/foo/bar/baz');
+  });
+
+  it('rejects relative paths', () => {
+    expect(() =>
+      createFileResourceRef({ nodeId: 'n', path: 'relative/path', intent: 'read' })
+    ).toThrow(/absolute/);
+  });
+
+  it('rejects paths that escape root via `..`', () => {
+    expect(() =>
+      createFileResourceRef({ nodeId: 'n', path: '/foo/../../etc', intent: 'read' })
+    ).toThrow(/escapes/);
+  });
+
+  it('rejects empty nodeId', () => {
+    expect(() =>
+      createFileResourceRef({
+        nodeId: '' as string,
+        path: '/x',
+        intent: 'read',
+      })
+    ).toThrow(/nodeId/);
+  });
+
+  it('rejects unknown intents', () => {
+    expect(() =>
+      createFileResourceRef({
+        nodeId: 'n',
+        path: '/x',
+        // @ts-expect-error: testing the runtime guard
+        intent: 'write',
+      })
+    ).toThrow(/intent/);
+  });
+
+  it('enforces all four intents are accepted', () => {
+    for (const intent of FILE_RESOURCE_REF_INTENTS) {
+      const ref = createFileResourceRef({ nodeId: 'n', path: '/a', intent });
+      expect(ref.intent).toBe(intent);
+    }
+  });
+
+  it('drops nonsense size / mtime values silently rather than throwing', () => {
+    const ref = createFileResourceRef({
+      nodeId: 'n',
+      path: '/x',
+      intent: 'read',
+      size: -10,
+      mtimeMs: Number.NaN,
+    });
+    expect(ref.size).toBeUndefined();
+    expect(ref.mtimeMs).toBeUndefined();
+  });
+
+  it('rejects malformed sha256 explicitly (vs accepting silently)', () => {
+    expect(() =>
+      createFileResourceRef({
+        nodeId: 'n',
+        path: '/x',
+        intent: 'read',
+        sha256: 'not-a-hex-string',
+      })
+    ).toThrow(/sha256/);
+  });
+
+  it('accepts a valid 64-hex sha256 and lowercases it', () => {
+    const ref = createFileResourceRef({
+      nodeId: 'n',
+      path: '/x',
+      intent: 'read',
+      sha256: 'A'.repeat(64),
+    });
+    expect(ref.sha256).toBe('a'.repeat(64));
+  });
+
+  it('preserves repoBinding (path normalized, branch optional)', () => {
+    const ref = createFileResourceRef({
+      nodeId: 'n',
+      path: '/a/b/c',
+      intent: 'read',
+      repoBinding: {
+        repoPath: '/a',
+        worktreePath: '/a/wt',
+        branch: 'main',
+      },
+    });
+    expect(ref.repoBinding?.repoPath).toBe('/a');
+    expect(ref.repoBinding?.worktreePath).toBe('/a/wt');
+    expect(ref.repoBinding?.branch).toBe('main');
+  });
+
+  it('rejects repoBinding with missing repoPath', () => {
+    expect(() =>
+      createFileResourceRef({
+        nodeId: 'n',
+        path: '/a/b',
+        intent: 'read',
+        // @ts-expect-error: missing repoPath
+        repoBinding: { worktreePath: '/wt' },
+      })
+    ).toThrow(/repoPath/);
+  });
+
+  it('honors an explicit capturedAt override', () => {
+    const ts = '2026-05-20T03:04:05.000Z';
+    const ref = createFileResourceRef({
+      nodeId: 'n',
+      path: '/x',
+      intent: 'read',
+      capturedAt: ts,
+    });
+    expect(ref.capturedAt).toBe(ts);
+  });
+
+  it('rejects a non-ISO capturedAt override', () => {
+    expect(() =>
+      createFileResourceRef({
+        nodeId: 'n',
+        path: '/x',
+        intent: 'read',
+        capturedAt: '2026/05/20 12:00',
+      })
+    ).toThrow(/ISO/);
+  });
+
+  it('drops maxBytes <= 0', () => {
+    const ref = createFileResourceRef({
+      nodeId: 'n',
+      path: '/x',
+      intent: 'read',
+      maxBytes: 0,
+    });
+    expect(ref.maxBytes).toBeUndefined();
+  });
+});
+
+describe('parseFileResourceRef', () => {
+  it('returns null for non-objects', () => {
+    expect(parseFileResourceRef(null)).toBeNull();
+    expect(parseFileResourceRef(undefined)).toBeNull();
+    expect(parseFileResourceRef('a string')).toBeNull();
+    expect(parseFileResourceRef(42)).toBeNull();
+  });
+
+  it('round-trips a valid ref through JSON', () => {
+    const original = createFileResourceRef({
+      nodeId: 'node_xyz',
+      path: '/foo/bar.md',
+      intent: 'read',
+      size: 1234,
+      sha256: 'f'.repeat(64),
+      mtimeMs: 1716200000000,
+      repoBinding: { repoPath: '/foo', branch: 'nightly' },
+      maxBytes: 65536,
+    });
+    const parsed = parseFileResourceRef(JSON.parse(JSON.stringify(original)));
+    expect(parsed).not.toBeNull();
+    expect(parsed?.nodeId).toBe(original.nodeId);
+    expect(parsed?.path).toBe(original.path);
+    expect(parsed?.intent).toBe(original.intent);
+    expect(parsed?.size).toBe(original.size);
+    expect(parsed?.sha256).toBe(original.sha256);
+    expect(parsed?.repoBinding?.repoPath).toBe('/foo');
+    expect(parsed?.repoBinding?.branch).toBe('nightly');
+  });
+
+  it('returns null on malformed payload (bad intent)', () => {
+    expect(parseFileResourceRef({ nodeId: 'n', path: '/x', intent: 'write' })).toBeNull();
+  });
+
+  it('returns null on malformed path', () => {
+    expect(parseFileResourceRef({ nodeId: 'n', path: '../bad', intent: 'read' })).toBeNull();
+  });
+
+  it('returns null on malformed sha256', () => {
+    expect(
+      parseFileResourceRef({ nodeId: 'n', path: '/x', intent: 'read', sha256: 'short' })
+    ).toBeNull();
+  });
+});
+
+describe('fileResourceRefEquals', () => {
+  function make(overrides: Partial<FileResourceRef> = {}): FileResourceRef {
+    return createFileResourceRef({
+      nodeId: 'n',
+      path: '/x',
+      intent: 'read',
+      capturedAt: '2026-05-20T00:00:00.000Z',
+      ...overrides,
+    });
+  }
+
+  it('ignores mint-time decorations (size/sha256/mtime/capturedAt)', () => {
+    const a = make({ size: 10, sha256: 'a'.repeat(64) });
+    const b = make({ size: 999, capturedAt: '2026-05-21T00:00:00.000Z' });
+    expect(fileResourceRefEquals(a, b)).toBe(true);
+  });
+
+  it('differs on intent', () => {
+    expect(fileResourceRefEquals(make({ intent: 'read' }), make({ intent: 'tail' }))).toBe(false);
+  });
+
+  it('differs on repoBinding presence', () => {
+    expect(
+      fileResourceRefEquals(make(), make({ repoBinding: { repoPath: '/x' } }))
+    ).toBe(false);
+  });
+
+  it('differs on repoBinding.branch', () => {
+    expect(
+      fileResourceRefEquals(
+        make({ repoBinding: { repoPath: '/x', branch: 'main' } }),
+        make({ repoBinding: { repoPath: '/x', branch: 'nightly' } })
+      )
+    ).toBe(false);
+  });
+});
+
+describe('fileResourceRefSummary', () => {
+  it('formats with no intent suffix for read', () => {
+    const ref = createFileResourceRef({ nodeId: 'mac', path: '/Users/d', intent: 'read' });
+    expect(fileResourceRefSummary(ref)).toBe('mac:/Users/d');
+  });
+
+  it('adds intent suffix for non-read', () => {
+    const ref = createFileResourceRef({ nodeId: 'mac', path: '/Users/d', intent: 'tail' });
+    expect(fileResourceRefSummary(ref)).toBe('mac:/Users/d (tail)');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #671 (parent epic #616, slice 1 of 5). Defines the shared `FileResourceRef` type that subsequent slices consume — preview blocks (slice 2), agent prompt attachments (slice 3), write/edit preview (slice 4), cross-node copy spike (slice 5).

**Schema-only.** No UI, no fetch path, no capability grant changes.

## What

`shared/file-resource-ref.ts`:
- `FileResourceRef` shape with `nodeId`, POSIX-normalized absolute `path`, ISO `capturedAt`, `intent` (`read`/`list`/`stat`/`tail`), optional `size`/`sha256`/`mtimeMs` mint-time decorations, optional `repoBinding` (`repoPath`/`worktreePath`/`branch`), optional `maxBytes`.
- `createFileResourceRef(args)` — strict mint with validation. Rejects relative paths, root-escape via `..`, malformed 64-hex sha256, non-ISO `capturedAt`, unknown intent, missing `repoBinding.repoPath`. Silently drops non-finite/negative `size`/`mtimeMs` and `maxBytes <= 0` (advisory hints).
- `parseFileResourceRef(unknown)` — zod-style parse. Returns `null` on any malformed field.
- `fileResourceRefEquals(a, b)` — structural equality. Identity is `(nodeId, path, intent, maxBytes, repoBinding)`; mint-time decorations excluded.
- `fileResourceRefSummary(ref)` — compact label `<nodeId>:<path>` with `(<intent>)` suffix for non-read intents.

Module is browser-safe — no `node:path` import; POSIX normalization is inlined.

Refs are forward-looking pointers, **NOT** capability grants. The hub policy evaluator still enforces actual access at fetch time. The `intent` field signals the planned `fs.*` verb so capability checks can be planned up front (`rpc:fs:read` / `rpc:fs:list` / `rpc:fs:stat` / `rpc:fs:tail`).

## Tests

`test/file-resource-ref.test.ts` — 26 cases:
- Happy mint with required fields.
- Path normalization (`/foo//bar/./baz` → `/foo/bar/baz`).
- Reject relative paths.
- Reject root-escape (`/foo/../../etc`).
- Reject empty nodeId.
- Reject unknown intent (e.g. `'write'`).
- Accept all four intents.
- Silently drop negative size / NaN mtime.
- Reject malformed sha256.
- Accept 64-hex sha256 (case-normalized).
- repoBinding round-trip; reject missing `repoPath`.
- Explicit `capturedAt` override; reject non-ISO format.
- Drop `maxBytes <= 0`.
- `parseFileResourceRef` round-trip via JSON; null on bad payload/intent/path/sha256.
- `fileResourceRefEquals` ignores mint decorations; differs on intent/repoBinding/branch.
- `fileResourceRefSummary` formats with/without intent suffix.

`npm run check` 0 errors. `npm test -- file-resource-ref` 26/26.

## Docs

`docs/federated-relay.md` — new "File Resource Refs (#616 slice 1)" subsection under "Repo Identity and Inventory" documenting the shape + the policy-evaluator-still-enforces-access invariant.

## Test plan

- [ ] Merge to `nightly`.
- [ ] No deploy / no node restart required — shared schema only.

Refs #616, closes #671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added File Resource Reference system to address and manage files/directories on paired nodes with validation and path normalization.

* **Documentation**
  * Documented FileResourceRef interface and specifications.

* **Tests**
  * Added comprehensive test coverage for reference creation, parsing, comparison, and formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->