### PR TITLE
feat(#675): PromptAttachment shape + agent-chat-v2 typing (#616 slice 3)

### DIFF
--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -528,11 +528,11 @@ Response groups repo instances by canonical git identity, showing per-node paths
 ```ts
 interface FileResourceRef {
   nodeId: NodeId;
-  path: string;                   // absolute, POSIX-normalized
-  capturedAt: string;             // ISO 8601 UTC
+  path: string; // absolute, POSIX-normalized
+  capturedAt: string; // ISO 8601 UTC
   intent: 'read' | 'list' | 'stat' | 'tail';
-  size?: number;                  // mint-time hint
-  sha256?: string;                // mint-time hash (only if `fs.read` ran)
+  size?: number; // mint-time hint
+  sha256?: string; // mint-time hash (only if `fs.read` ran)
   mtimeMs?: number;
   repoBinding?: { repoPath; worktreePath?; branch? };
   maxBytes?: number;
@@ -553,6 +553,24 @@ The `FileBlock` renderer (`frontend/src/workbench/blocks/file.tsx`) now consumes
 4. Error states surface inline lowercase copy: `not authorized` (403/FORBIDDEN), `node offline` (NODE_OFFLINE), `file not found` (404/FILE_RPC_NOT_FOUND), `session required` (missing session context).
 
 Legacy `FileRef` descriptors (those without `capturedAt`/`intent`) render the original placeholder copy with no fetch attempted, preserving backward compatibility.
+
+### PromptAttachment shape (#616 slice 3)
+
+`shared/prompt-attachment.ts` defines `PromptAttachment` — the typed, bounded shape an agent or human attaches to an outgoing prompt. The discriminated union is open for future kinds; the slice-3 shape is:
+
+```ts
+type PromptAttachment = {
+  kind: 'file-ref';
+  ref: FileResourceRef;
+  summary?: string;
+};
+```
+
+The contract is **ref-only by default**. Attachments carry a `FileResourceRef` pointer plus advisory size/hash decorations — never raw bytes. Adapters that want to expand a ref into prompt context must hold the right capability grant (`rpc:fs:read`) and respect the ref's `maxBytes` cap.
+
+`AgentUserMessageItemV2.promptAttachments` and the `agent-send-message-v2` command both carry a typed `PromptAttachment[]` field alongside the legacy untyped `attachments` (which still routes the adapter-local `Attachment` shape — local path + mime — for back-compat). `server/ws.ts` parses incoming `promptAttachments` via `parsePromptAttachmentList`, drops malformed entries, and rejects the message when the array exceeds `MAX_PROMPT_ATTACHMENTS_PER_MESSAGE` (16).
+
+`promptAttachmentToArtifactRef` bridges an attachment into a `WorkContext.ArtifactRef` with `privacy.rawPayloadStored = false` and `redaction.strategy = 'hash'` (when `ref.sha256` is set) or `'summary'`. Per-adapter consumption of `promptAttachments` (Claude/Codex/OpenCode/Hermes) and dispatch-site `WorkContext.artifacts` append land in follow-on #616 slices.
 
 ## Bootstrap and Service Modes
 

--- a/server/protocol-adapter-v2.ts
+++ b/server/protocol-adapter-v2.ts
@@ -10,6 +10,7 @@ import {
   type AgentCapabilitySetV2,
   type AgentPatchV2,
 } from '../shared/agent-chat-protocol-v2.js';
+import type { PromptAttachment } from '../shared/prompt-attachment.js';
 
 export type { AdapterConfig, AdapterStatus, Attachment };
 
@@ -18,7 +19,14 @@ const logger = createLogger('protocol-adapter-v2');
 export interface AgentSendMessageInputV2 {
   turnId: string;
   content: string;
+  /** Legacy adapter-shaped attachments — local path + mime. */
   attachments?: Attachment[];
+  /**
+   * Typed federated attachments routed in via slice 3 of #616. Adapters
+   * that do not yet consume these MUST ignore the field; behavior change
+   * lands per-adapter in a follow-on slice.
+   */
+  promptAttachments?: PromptAttachment[];
   clientMessageId?: string;
 }
 

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -187,7 +187,7 @@ function sendAgentMessageV2(
       ws,
       session.id,
       `prompt attachments exceed cap (${rawPromptAttachments.length} > ${MAX_PROMPT_ATTACHMENTS_PER_MESSAGE})`,
-      null
+      new Error('promptAttachments exceeds allowed maximum')
     );
     return;
   }

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -12,6 +12,10 @@ import { loadConfig } from './config.js';
 import { verifyCookieToken } from './auth.js';
 import { createAgentSessionSnapshotPatch } from './web-session-v2-state.js';
 import type { AgentApprovalDecisionV2 } from '../shared/agent-chat-protocol-v2.js';
+import {
+  MAX_PROMPT_ATTACHMENTS_PER_MESSAGE,
+  parsePromptAttachmentList,
+} from '../shared/prompt-attachment.js';
 import type { LocalRelayNode } from './local-node.js';
 import type { HubNodeRegistry } from './hub-node-registry.js';
 import {
@@ -175,12 +179,34 @@ function sendAgentMessageV2(
   session: Extract<Session, { mode: 'web' }>,
   parsed: Record<string, unknown>
 ): void {
+  const rawPromptAttachments = Array.isArray(parsed['promptAttachments'])
+    ? (parsed['promptAttachments'] as unknown[])
+    : [];
+  if (rawPromptAttachments.length > MAX_PROMPT_ATTACHMENTS_PER_MESSAGE) {
+    sendAgentErrorV2(
+      ws,
+      session.id,
+      `prompt attachments exceed cap (${rawPromptAttachments.length} > ${MAX_PROMPT_ATTACHMENTS_PER_MESSAGE})`,
+      null
+    );
+    return;
+  }
+  const promptAttachments = parsePromptAttachmentList(rawPromptAttachments);
+  if (
+    rawPromptAttachments.length > 0 &&
+    promptAttachments.length !== rawPromptAttachments.length
+  ) {
+    logger.warn(
+      `v2 sendMessage dropped ${rawPromptAttachments.length - promptAttachments.length} malformed prompt attachments`
+    );
+  }
   const input = {
     turnId: String(parsed['turnId'] ?? ''),
     content: String(parsed['content'] ?? ''),
     ...(parsed['attachments'] !== undefined
       ? { attachments: parsed['attachments'] as Attachment[] }
       : {}),
+    ...(promptAttachments.length > 0 ? { promptAttachments } : {}),
     ...(typeof parsed['clientMessageId'] === 'string'
       ? { clientMessageId: parsed['clientMessageId'] }
       : {}),

--- a/shared/agent-chat-protocol-v2.ts
+++ b/shared/agent-chat-protocol-v2.ts
@@ -1,3 +1,5 @@
+import type { PromptAttachment } from './prompt-attachment.js';
+
 export type AgentProviderV2 =
   | 'claude'
   | 'codex'
@@ -147,7 +149,14 @@ export interface AgentUserMessageItemV2 extends AgentItemBaseV2 {
   type: 'userMessage';
   text: string;
   expandedText?: string;
+  /**
+   * Legacy adapter-shaped attachments (local path + mime). New federated
+   * attachments — `FileResourceRef`-backed bounded refs — flow via
+   * `promptAttachments` below. Both fields may coexist during migration.
+   */
   attachments?: Array<Record<string, unknown>>;
+  /** Typed federated attachments. Bounded by default — no raw bytes. */
+  promptAttachments?: PromptAttachment[];
   command?: { name: string; arguments?: string };
 }
 
@@ -453,6 +462,8 @@ export type AgentCommandV2 =
       text: string;
       clientMessageId?: string;
       attachments?: Array<Record<string, unknown>>;
+      /** Typed federated attachments. Bounded by default — no raw bytes. */
+      promptAttachments?: PromptAttachment[];
     }
   | { type: 'agent-interrupt-v2'; sessionId: string; turnId?: string }
   | {

--- a/shared/prompt-attachment.ts
+++ b/shared/prompt-attachment.ts
@@ -1,0 +1,180 @@
+import type { ArtifactId, ArtifactKind, ArtifactRef } from './work-context.js';
+import { createWorkContextPrivacyMetadata } from './work-context.js';
+import {
+  createFileResourceRef,
+  parseFileResourceRef,
+  fileResourceRefSummary,
+  type FileResourceRef,
+} from './file-resource-ref.js';
+
+/**
+ * `PromptAttachment` is the typed shape an agent or human attaches to an
+ * outgoing prompt (or to a `WorkContext`). It is **ref-only by default**:
+ * the attachment carries a pointer + advisory metadata, not raw bytes.
+ *
+ * Consumers (adapters, WorkContext store) may expand a ref into content
+ * only when they hold the right capability grant and the expansion is
+ * size-bounded.
+ *
+ * The discriminated union is intentionally open — `'diff-ref'` and
+ * `'log-ref'` kinds will land in follow-on #616 slices.
+ */
+export type PromptAttachment = PromptAttachmentFileRef;
+
+export interface PromptAttachmentFileRef {
+  kind: 'file-ref';
+  ref: FileResourceRef;
+  /** Optional short human-readable summary for chips/audit rows. */
+  summary?: string;
+}
+
+export const PROMPT_ATTACHMENT_KINDS: readonly PromptAttachment['kind'][] = [
+  'file-ref',
+] as const;
+
+/**
+ * Soft cap on the number of attachments a single prompt may carry. Server
+ * `agent-send-message-v2` handler enforces this; `parsePromptAttachmentList`
+ * truncates beyond this bound rather than dropping the whole list (the
+ * accepted prefix is preferable to silent total loss on a single bad entry).
+ */
+export const MAX_PROMPT_ATTACHMENTS_PER_MESSAGE = 16;
+
+export interface CreatePromptAttachmentFileRefArgs {
+  kind: 'file-ref';
+  ref: FileResourceRef;
+  summary?: string;
+}
+
+export type CreatePromptAttachmentArgs = CreatePromptAttachmentFileRefArgs;
+
+export function createPromptAttachment(
+  args: CreatePromptAttachmentArgs
+): PromptAttachment {
+  if (args.kind !== 'file-ref') {
+    throw new Error(
+      `PromptAttachment.kind must be one of ${PROMPT_ATTACHMENT_KINDS.join('|')}, got: ${String((args as { kind?: unknown }).kind)}`
+    );
+  }
+  if (!args.ref || typeof args.ref !== 'object') {
+    throw new Error('PromptAttachment.ref is required for kind=file-ref');
+  }
+  // Re-mint through `createFileResourceRef` so any caller-built ref is
+  // normalized + validated by the canonical constructor.
+  const normalizedRef = createFileResourceRef({
+    nodeId: args.ref.nodeId,
+    path: args.ref.path,
+    intent: args.ref.intent,
+    ...(args.ref.size !== undefined ? { size: args.ref.size } : {}),
+    ...(args.ref.sha256 !== undefined ? { sha256: args.ref.sha256 } : {}),
+    ...(args.ref.mtimeMs !== undefined ? { mtimeMs: args.ref.mtimeMs } : {}),
+    ...(args.ref.repoBinding ? { repoBinding: args.ref.repoBinding } : {}),
+    ...(args.ref.maxBytes !== undefined ? { maxBytes: args.ref.maxBytes } : {}),
+    ...(args.ref.capturedAt ? { capturedAt: args.ref.capturedAt } : {}),
+  });
+  const out: PromptAttachmentFileRef = {
+    kind: 'file-ref',
+    ref: normalizedRef,
+  };
+  if (typeof args.summary === 'string' && args.summary.length > 0) {
+    out.summary = args.summary;
+  }
+  return out;
+}
+
+/**
+ * Parse an unknown payload into a `PromptAttachment`. Returns `null` on
+ * any validation failure so callers can drop the single bad entry without
+ * tearing down the whole prompt.
+ */
+export function parsePromptAttachment(
+  payload: unknown
+): PromptAttachment | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const p = payload as Record<string, unknown>;
+  if (p['kind'] !== 'file-ref') return null;
+  const ref = parseFileResourceRef(p['ref']);
+  if (!ref) return null;
+  try {
+    return createPromptAttachment({
+      kind: 'file-ref',
+      ref,
+      ...(typeof p['summary'] === 'string' ? { summary: p['summary'] } : {}),
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parse an array of unknown attachment payloads, dropping malformed
+ * entries and truncating at `MAX_PROMPT_ATTACHMENTS_PER_MESSAGE`. Returns
+ * an empty array if `payload` is not an array.
+ */
+export function parsePromptAttachmentList(
+  payload: unknown
+): PromptAttachment[] {
+  if (!Array.isArray(payload)) return [];
+  const out: PromptAttachment[] = [];
+  for (const entry of payload) {
+    if (out.length >= MAX_PROMPT_ATTACHMENTS_PER_MESSAGE) break;
+    const parsed = parsePromptAttachment(entry);
+    if (parsed) out.push(parsed);
+  }
+  return out;
+}
+
+export interface PromptAttachmentToArtifactRefArgs {
+  /** Stable artifact id (caller-owned — typically UUID or content hash). */
+  id: ArtifactId;
+  /** Actor that produced the attachment (human user id, agent id, etc.). */
+  producedByActorId?: string;
+  /** Override `producedAt`; defaults to `new Date().toISOString()`. */
+  producedAt?: string;
+}
+
+/**
+ * Bridge a `PromptAttachment` to a `WorkContext.ArtifactRef`. The produced
+ * ref is bounded by default: `privacy.rawPayloadStored = false`,
+ * `redaction.strategy = 'hash'` when the source ref carries a sha256,
+ * else `'summary'`. Callers that expand content into the work context
+ * (with capability) must construct their own `ArtifactRef` with
+ * `rawPayloadStored: true` — this bridge will not produce that shape.
+ */
+export function promptAttachmentToArtifactRef(
+  attachment: PromptAttachment,
+  args: PromptAttachmentToArtifactRefArgs
+): ArtifactRef {
+  if (attachment.kind !== 'file-ref') {
+    throw new Error(
+      `promptAttachmentToArtifactRef: unsupported kind ${String((attachment as { kind?: unknown }).kind)}`
+    );
+  }
+  const ref = attachment.ref;
+  const kind: ArtifactKind = 'file';
+  const hasHash = typeof ref.sha256 === 'string' && ref.sha256.length === 64;
+  const privacy = createWorkContextPrivacyMetadata({
+    classification: 'internal',
+    retention: 'session',
+    rawPayloadStored: false,
+    redaction: {
+      redacted: false,
+      strategy: hasHash ? 'hash' : 'summary',
+      classes: ['artifact'],
+      ...(typeof ref.size === 'number' ? { byteCount: ref.size } : {}),
+      ...(hasHash ? { hashSha256: ref.sha256 } : {}),
+      ...(attachment.summary ? { preview: attachment.summary } : {}),
+    },
+  });
+  const out: ArtifactRef = {
+    id: args.id,
+    kind,
+    title: attachment.summary ?? fileResourceRefSummary(ref),
+    path: ref.path,
+    producedAt: args.producedAt ?? new Date().toISOString(),
+    privacy,
+  };
+  if (args.producedByActorId) out.producedByActorId = args.producedByActorId;
+  if (attachment.summary) out.summary = attachment.summary;
+  return out;
+}

--- a/shared/prompt-attachment.ts
+++ b/shared/prompt-attachment.ts
@@ -60,18 +60,10 @@ export function createPromptAttachment(
     throw new Error('PromptAttachment.ref is required for kind=file-ref');
   }
   // Re-mint through `createFileResourceRef` so any caller-built ref is
-  // normalized + validated by the canonical constructor.
-  const normalizedRef = createFileResourceRef({
-    nodeId: args.ref.nodeId,
-    path: args.ref.path,
-    intent: args.ref.intent,
-    ...(args.ref.size !== undefined ? { size: args.ref.size } : {}),
-    ...(args.ref.sha256 !== undefined ? { sha256: args.ref.sha256 } : {}),
-    ...(args.ref.mtimeMs !== undefined ? { mtimeMs: args.ref.mtimeMs } : {}),
-    ...(args.ref.repoBinding ? { repoBinding: args.ref.repoBinding } : {}),
-    ...(args.ref.maxBytes !== undefined ? { maxBytes: args.ref.maxBytes } : {}),
-    ...(args.ref.capturedAt ? { capturedAt: args.ref.capturedAt } : {}),
-  });
+  // normalized + validated by the canonical constructor. `FileResourceRef`
+  // is a structural supertype of `CreateFileResourceRefArgs`, so the ref
+  // can be passed through directly.
+  const normalizedRef = createFileResourceRef(args.ref);
   const out: PromptAttachmentFileRef = {
     kind: 'file-ref',
     ref: normalizedRef,

--- a/test/prompt-attachment.test.ts
+++ b/test/prompt-attachment.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFileResourceRef } from '../shared/file-resource-ref.js';
+import {
+  MAX_PROMPT_ATTACHMENTS_PER_MESSAGE,
+  PROMPT_ATTACHMENT_KINDS,
+  createPromptAttachment,
+  parsePromptAttachment,
+  parsePromptAttachmentList,
+  promptAttachmentToArtifactRef,
+  type PromptAttachment,
+} from '../shared/prompt-attachment.js';
+
+function makeRef(
+  overrides: Partial<Parameters<typeof createFileResourceRef>[0]> = {}
+) {
+  return createFileResourceRef({
+    nodeId: 'mac-studio',
+    path: '/Users/d/file.txt',
+    intent: 'read',
+    ...overrides,
+  });
+}
+
+describe('createPromptAttachment', () => {
+  it('mints a file-ref attachment carrying the normalized ref', () => {
+    const ref = makeRef();
+    const att = createPromptAttachment({
+      kind: 'file-ref',
+      ref,
+      summary: 'short',
+    });
+    expect(att.kind).toBe('file-ref');
+    expect(att.ref.nodeId).toBe('mac-studio');
+    expect(att.ref.path).toBe('/Users/d/file.txt');
+    expect(att.summary).toBe('short');
+  });
+
+  it('drops empty summary rather than retaining an empty string', () => {
+    const att = createPromptAttachment({
+      kind: 'file-ref',
+      ref: makeRef(),
+      summary: '',
+    });
+    expect(att.summary).toBeUndefined();
+  });
+
+  it('re-normalizes a caller-provided ref through createFileResourceRef', () => {
+    const ref = makeRef({ path: '/Users/d/file.txt' });
+    // Construct an "un-normalized" ref by hand and ensure the constructor
+    // re-runs validation/normalization.
+    const att = createPromptAttachment({
+      kind: 'file-ref',
+      ref: { ...ref, path: '/Users/d//file.txt' },
+    });
+    expect(att.ref.path).toBe('/Users/d/file.txt');
+  });
+
+  it('rejects unknown kinds', () => {
+    expect(() =>
+      createPromptAttachment({
+        // @ts-expect-error: testing runtime guard
+        kind: 'diff-ref',
+        ref: makeRef(),
+      })
+    ).toThrow(/kind/);
+  });
+
+  it('rejects missing ref', () => {
+    expect(() =>
+      createPromptAttachment({
+        kind: 'file-ref',
+        // @ts-expect-error: testing runtime guard
+        ref: undefined,
+      })
+    ).toThrow(/ref/);
+  });
+
+  it('exposes file-ref in PROMPT_ATTACHMENT_KINDS', () => {
+    expect(PROMPT_ATTACHMENT_KINDS).toContain('file-ref');
+  });
+});
+
+describe('parsePromptAttachment', () => {
+  it('round-trips a valid attachment through JSON', () => {
+    const original = createPromptAttachment({
+      kind: 'file-ref',
+      ref: makeRef({ size: 42, sha256: 'a'.repeat(64) }),
+      summary: 'preview',
+    });
+    const parsed = parsePromptAttachment(JSON.parse(JSON.stringify(original)));
+    expect(parsed).not.toBeNull();
+    expect(parsed?.kind).toBe('file-ref');
+    expect(parsed?.ref.path).toBe('/Users/d/file.txt');
+    expect(parsed?.summary).toBe('preview');
+  });
+
+  it('returns null for non-objects', () => {
+    expect(parsePromptAttachment(null)).toBeNull();
+    expect(parsePromptAttachment('x')).toBeNull();
+    expect(parsePromptAttachment(7)).toBeNull();
+  });
+
+  it('returns null on unknown kind', () => {
+    expect(
+      parsePromptAttachment({ kind: 'diff-ref', ref: makeRef() })
+    ).toBeNull();
+  });
+
+  it('returns null on malformed inner ref', () => {
+    expect(
+      parsePromptAttachment({
+        kind: 'file-ref',
+        ref: { nodeId: 'n', path: '../x', intent: 'read' },
+      })
+    ).toBeNull();
+  });
+});
+
+describe('parsePromptAttachmentList', () => {
+  it('returns [] for non-array payload', () => {
+    expect(parsePromptAttachmentList(null)).toEqual([]);
+    expect(parsePromptAttachmentList('not-array')).toEqual([]);
+    expect(parsePromptAttachmentList({})).toEqual([]);
+  });
+
+  it('drops malformed entries and keeps valid ones', () => {
+    const valid = createPromptAttachment({ kind: 'file-ref', ref: makeRef() });
+    const list = parsePromptAttachmentList([
+      JSON.parse(JSON.stringify(valid)),
+      { kind: 'file-ref', ref: { nodeId: 'n', path: 'bad', intent: 'read' } },
+      null,
+      'string',
+      JSON.parse(JSON.stringify(valid)),
+    ]);
+    expect(list).toHaveLength(2);
+    expect(list.every((a) => a.kind === 'file-ref')).toBe(true);
+  });
+
+  it('truncates at MAX_PROMPT_ATTACHMENTS_PER_MESSAGE', () => {
+    const valid = createPromptAttachment({ kind: 'file-ref', ref: makeRef() });
+    const oversized = Array.from(
+      { length: MAX_PROMPT_ATTACHMENTS_PER_MESSAGE + 5 },
+      () => JSON.parse(JSON.stringify(valid)) as unknown
+    );
+    const list = parsePromptAttachmentList(oversized);
+    expect(list).toHaveLength(MAX_PROMPT_ATTACHMENTS_PER_MESSAGE);
+  });
+});
+
+describe('promptAttachmentToArtifactRef', () => {
+  function makeAtt(
+    overrides: Partial<PromptAttachment & { summary: string }> = {}
+  ) {
+    return createPromptAttachment({
+      kind: 'file-ref',
+      ref: makeRef({ size: 100 }),
+      ...(overrides.summary ? { summary: overrides.summary } : {}),
+    });
+  }
+
+  it('produces a bounded ArtifactRef with rawPayloadStored=false', () => {
+    const ref = promptAttachmentToArtifactRef(makeAtt(), { id: 'art_1' });
+    expect(ref.kind).toBe('file');
+    expect(ref.path).toBe('/Users/d/file.txt');
+    expect(ref.privacy.rawPayloadStored).toBe(false);
+    expect(ref.privacy.redaction.strategy).toBe('summary');
+    expect(ref.privacy.redaction.classes).toContain('artifact');
+    expect(ref.privacy.redaction.byteCount).toBe(100);
+  });
+
+  it("uses 'hash' redaction strategy when the ref carries a sha256", () => {
+    const att = createPromptAttachment({
+      kind: 'file-ref',
+      ref: makeRef({ sha256: 'f'.repeat(64) }),
+    });
+    const ref = promptAttachmentToArtifactRef(att, { id: 'art_2' });
+    expect(ref.privacy.redaction.strategy).toBe('hash');
+    expect(ref.privacy.redaction.hashSha256).toBe('f'.repeat(64));
+  });
+
+  it('falls back to ref summary string when no summary is set', () => {
+    const ref = promptAttachmentToArtifactRef(makeAtt(), { id: 'art_3' });
+    expect(ref.title).toBe('mac-studio:/Users/d/file.txt');
+    expect(ref.summary).toBeUndefined();
+  });
+
+  it('preserves caller-provided summary on the ArtifactRef', () => {
+    const ref = promptAttachmentToArtifactRef(
+      makeAtt({ summary: 'helpful note' }),
+      {
+        id: 'art_4',
+      }
+    );
+    expect(ref.title).toBe('helpful note');
+    expect(ref.summary).toBe('helpful note');
+    expect(ref.privacy.redaction.preview).toBe('helpful note');
+  });
+
+  it('uses caller-provided producedAt when supplied', () => {
+    const ts = '2026-05-20T00:00:00.000Z';
+    const ref = promptAttachmentToArtifactRef(makeAtt(), {
+      id: 'art_5',
+      producedAt: ts,
+      producedByActorId: 'actor_human_1',
+    });
+    expect(ref.producedAt).toBe(ts);
+    expect(ref.producedByActorId).toBe('actor_human_1');
+  });
+});


### PR DESCRIPTION
Closes #675. Sub-issue of epic #616 — slice 3 of 5. Follows #672 (slice 1, `FileResourceRef`) and #674 (slice 2, `FileBlock` renderer).

## Summary

- New `shared/prompt-attachment.ts` defines `PromptAttachment` — a discriminated-union shape (`'file-ref'` only for now, open for `'diff-ref' | 'log-ref'`) that lets agents/humans attach a bounded `FileResourceRef` to an outgoing prompt or `WorkContext`. The contract is **ref-only by default**: no raw bytes, just pointer + advisory size/hash decorations.
- `AgentUserMessageItemV2.promptAttachments` and the `agent-send-message-v2` command both gain a typed `PromptAttachment[]` field, alongside the legacy untyped `attachments` (which still routes adapter-local `Attachment` shape — local path + mime — for back-compat).
- `server/ws.ts` parses incoming `promptAttachments` via `parsePromptAttachmentList`, drops malformed entries, and rejects the message when the array exceeds `MAX_PROMPT_ATTACHMENTS_PER_MESSAGE` (16).
- `promptAttachmentToArtifactRef` bridges into a `WorkContext.ArtifactRef` with `privacy.rawPayloadStored: false` and `redaction.strategy: 'hash'` (when `ref.sha256` is set) or `'summary'` — the bounded-by-default invariant the epic requires.
- Adapter `AgentSendMessageInputV2` forwards the parsed list. Per-adapter consumption (Claude / Codex / OpenCode / Hermes expanding refs into prompt context with capability checks) is a follow-on; this slice ships the contract only.

## What is NOT in this PR

- Composer file-picker UI / drag-drop attach — follow-on.
- Adapter consumption of `promptAttachments` (expanding refs into actual prompt context, with `rpc:fs:read` capability gating) — follow-on.
- `WorkContext.artifacts` server-side append from the dispatch site — bridge ships here, dispatch wiring is follow-on.
- Diff-ref / log-ref kinds — open in the union, not implemented.
- Slice 4 (write/edit preview) and slice 5 (cross-node copy spike).

## Test plan

- [x] `npx vitest run test/prompt-attachment.test.ts` — 18 cases (round-trip parse, malformed payload returns `null`, count cap truncation, bridge bounded invariant including `hash` vs `summary` strategy selection, `producedBy` propagation).
- [x] `npx vitest run test/agent-chat-protocol-v2.test.ts test/agent-chat-v1-compat.test.ts test/mock-v2-adapter.test.ts test/ws-pty-intervention.test.ts test/ws-pty-routing.test.ts test/ws-node-scope.test.ts` — 50 pass / 0 fail (no protocol/adapter regressions).
- [x] `npm run check` — 0 errors (warnings are all pre-existing `sonarjs/no-duplicate-string` noise in unrelated files).
- [x] `npm run build` — clean.
- [ ] Follow-on slice 3.5 will exercise the wired path through an actual adapter; nothing in this PR changes runtime adapter behavior since adapters that don't consume `promptAttachments` ignore the new field.

## Notes for review

- The `parsePromptAttachmentList` truncates beyond the cap rather than rejecting the whole list — server `ws.ts` *does* reject when over the cap (returns a typed v2 error). Two layers, two policies: the parser is permissive (drops noise), the transport handler is strict (rejects abuse).
- I deliberately re-mint the `FileResourceRef` through `createFileResourceRef` inside `createPromptAttachment` so caller-built refs cannot smuggle un-normalized paths past the parser. Costs one alloc; gains canonical normalization.
- `MAX_PROMPT_ATTACHMENTS_PER_MESSAGE = 16` is a soft cap chosen to be generous for human attach flows but tight enough to bound malicious clients. Adjustable later without breaking shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for typed file attachments in agent messages with automatic validation and privacy controls.
  * Implemented message attachment limits (maximum 16 per message) with error handling.
  * Added privacy redaction strategy selection based on attachment metadata (hash or summary-based).

* **Documentation**
  * Updated protocol documentation for attachment shapes and federated attachment behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/676?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->