### PR TITLE
Handoff transfer/apply engine MVP

### DIFF
--- a/server/handoff-planner.ts
+++ b/server/handoff-planner.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process';
-import { lstatSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { lstatSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { promisify } from 'node:util';
 
@@ -74,6 +75,13 @@ export interface ExcludedPathSummary {
 
 export const MAX_UNTRACKED_FILE_BYTES = 10 * 1024 * 1024;
 export const GIT_DIFF_MAX_BUFFER_BYTES = 50 * 1024 * 1024;
+export const MAX_APPROVED_UNTRACKED_TOTAL_BYTES = GIT_DIFF_MAX_BUFFER_BYTES;
+
+export interface HandoffPayloadFileSummary {
+  path: string;
+  byteCount: number;
+  sha256: string;
+}
 
 export interface HandoffPlannerDryRun {
   branchName: string | null;
@@ -90,6 +98,10 @@ export interface HandoffPlannerDryRun {
   fileCount: number;
   /** Approximate transferable byte count for included tracked patches and approved files. */
   byteCount: number;
+  /** SHA256 of the exact tracked patch payload planned for transfer. */
+  trackedPatchSha256?: string;
+  /** SHA256 summaries for exact approved untracked payloads planned for transfer. */
+  approvedUntrackedFiles?: HandoffPayloadFileSummary[];
   transferMode: HandoffTransferMode;
   conflicts: HandoffConflict[];
 }
@@ -185,6 +197,14 @@ function inspectExistingPath(repoPath: string, relativePath: string) {
   } catch {
     return null;
   }
+}
+
+function hashBuffer(buffer: Buffer | string): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+function comparePaths(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 /**
@@ -296,6 +316,7 @@ export function parseGitStatus(
  * worktree. Non-git repos result in STALE_SOURCE conflicts and empty file
  * sets; non-git mode is not supported and remains a follow-up.
  */
+// eslint-disable-next-line complexity -- linear git/filesystem decision table; safety branches are intentionally explicit.
 export async function planHandoffSnapshot(
   input: HandoffPlannerInput
 ): Promise<HandoffPlannerDryRun> {
@@ -409,8 +430,11 @@ export async function planHandoffSnapshot(
   const stagedFiles = excludeTrackedSymlinks(rawStagedFiles);
   const unstagedFiles = excludeTrackedSymlinks(rawUnstagedFiles);
   let untrackedByteCount = 0;
-  const untrackedCandidates: UntrackedCandidate[] = untrackedPaths.map(
-    (path) => {
+  const approvedUntrackedFiles: HandoffPayloadFileSummary[] = [];
+  const untrackedCandidates: UntrackedCandidate[] = untrackedPaths
+    .slice()
+    .sort(comparePaths)
+    .map((path) => {
       const classification = classifyPath(path);
       if (classification !== null) {
         excludedPaths.push({
@@ -480,14 +504,27 @@ export async function planHandoffSnapshot(
       const included = approvedUntrackedPaths.has(path);
       if (included && stat?.isFile()) {
         untrackedByteCount += stat.size;
+        try {
+          const data = readFileSync(resolve(repoPath, path));
+          approvedUntrackedFiles.push({
+            path,
+            byteCount: data.byteLength,
+            sha256: hashBuffer(data),
+          });
+        } catch {
+          conflicts.push({
+            code: 'STALE_SOURCE',
+            message: `approved untracked file became unreadable while planning: ${path}`,
+            nodeId,
+          });
+        }
       }
       return {
         path,
         included,
         approvalStatus: included ? 'approved' : 'requires-review',
       };
-    }
-  );
+    });
 
   for (const path of ignoredPaths) {
     const classification = classifyPath(path) ?? {
@@ -498,6 +535,14 @@ export async function planHandoffSnapshot(
       path,
       conflictCode: classification.conflictCode,
       reason: classification.reason,
+    });
+  }
+
+  if (untrackedByteCount > MAX_APPROVED_UNTRACKED_TOTAL_BYTES) {
+    conflicts.push({
+      code: 'CACHE_EXCLUDED',
+      message: `approved untracked files exceed ${MAX_APPROVED_UNTRACKED_TOTAL_BYTES} byte aggregate snapshot limit`,
+      nodeId,
     });
   }
 
@@ -521,22 +566,24 @@ export async function planHandoffSnapshot(
   // Estimate size as included tracked patch bytes plus known safe untracked file bytes.
   const safeTrackedPaths = [
     ...new Set([...stagedFiles, ...unstagedFiles].map((file) => file.path)),
-  ];
+  ].sort(comparePaths);
   let byteCount = untrackedByteCount;
+  let trackedPatchSha256: string | undefined;
   if (safeTrackedPaths.length > 0) {
     try {
-      const { stdout } = await run(
-        'git',
-        ['diff', 'HEAD', '--', ...safeTrackedPaths],
-        {
-          cwd: repoPath,
-          timeout: 10000,
-          maxBuffer: GIT_DIFF_MAX_BUFFER_BYTES,
-        }
-      );
+      const { stdout } = await run('git', ['diff', 'HEAD'], {
+        cwd: repoPath,
+        timeout: 10000,
+        maxBuffer: GIT_DIFF_MAX_BUFFER_BYTES,
+      });
       byteCount += Buffer.byteLength(stdout);
+      trackedPatchSha256 = hashBuffer(stdout);
     } catch {
-      // best effort
+      conflicts.push({
+        code: 'STALE_SOURCE',
+        message: 'git diff failed; tracked patch payload could not be planned',
+        nodeId,
+      });
     }
   }
 
@@ -591,6 +638,8 @@ export async function planHandoffSnapshot(
     excludedGroups,
     fileCount,
     byteCount,
+    ...(trackedPatchSha256 ? { trackedPatchSha256 } : {}),
+    ...(approvedUntrackedFiles.length > 0 ? { approvedUntrackedFiles } : {}),
     transferMode,
     conflicts,
   };

--- a/server/handoff-transfer.ts
+++ b/server/handoff-transfer.ts
@@ -5,6 +5,7 @@ import {
   mkdtemp,
   readFile,
   rm,
+  rmdir,
   stat,
   writeFile,
 } from 'node:fs/promises';
@@ -24,6 +25,8 @@ import {
 import type { NodeId } from '../shared/identity.js';
 import {
   isSafePath,
+  GIT_DIFF_MAX_BUFFER_BYTES,
+  MAX_APPROVED_UNTRACKED_TOTAL_BYTES,
   MAX_UNTRACKED_FILE_BYTES,
   planHandoffSnapshot,
   type ExecFileAsyncLike,
@@ -31,7 +34,7 @@ import {
 } from './handoff-planner.js';
 
 const execFileAsync = promisify(execFile);
-const GIT_APPLY_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+const GIT_TRANSFER_MAX_BUFFER_BYTES = GIT_DIFF_MAX_BUFFER_BYTES;
 
 export interface HandoffTransferApplyInput {
   requestId: string;
@@ -115,6 +118,18 @@ function hashBuffer(buffer: Buffer | string): string {
   return createHash('sha256').update(buffer).digest('hex');
 }
 
+function comparePaths(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sortUniquePaths(paths: string[]): string[] {
+  return [...new Set(paths)].sort(comparePaths);
+}
+
 function makeConflict(
   code: HandoffConflict['code'],
   message: string,
@@ -136,6 +151,8 @@ function dryRunFingerprint(dryRun: HandoffPlannerDryRun): string {
     excludedGroups: dryRun.excludedGroups,
     fileCount: dryRun.fileCount,
     byteCount: dryRun.byteCount,
+    trackedPatchSha256: dryRun.trackedPatchSha256,
+    approvedUntrackedFiles: dryRun.approvedUntrackedFiles,
     transferMode: dryRun.transferMode,
   });
 }
@@ -166,6 +183,58 @@ async function pathExists(path: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function missingParentDirs(
+  repoPath: string,
+  destinationPath: string
+): Promise<string[]> {
+  const root = resolve(repoPath);
+  const rootPrefix = root.endsWith('/') ? root : `${root}/`;
+  const dirs: string[] = [];
+  let current = dirname(destinationPath);
+  while (current !== root && current.startsWith(rootPrefix)) {
+    if (!(await pathExists(current))) dirs.push(current);
+    current = dirname(current);
+  }
+  return dirs;
+}
+
+async function rollbackDestinationApply(input: {
+  exec: ExecFileAsyncLike;
+  destinationRepoPath: string;
+  patchPath: string | null;
+  trackedPatchApplied: boolean;
+  writtenUntrackedFiles: PreparedUntrackedFile[];
+  createdDirs: string[];
+}): Promise<string[]> {
+  const errors: string[] = [];
+  for (const file of input.writtenUntrackedFiles.slice().reverse()) {
+    try {
+      await rm(file.destinationPath, { force: true });
+    } catch (error) {
+      errors.push(`remove ${file.path}: ${errorMessage(error)}`);
+    }
+  }
+  if (input.trackedPatchApplied && input.patchPath) {
+    try {
+      await runGit(input.exec, input.destinationRepoPath, [
+        'apply',
+        '--reverse',
+        input.patchPath,
+      ]);
+    } catch (error) {
+      errors.push(`reverse tracked patch: ${errorMessage(error)}`);
+    }
+  }
+  for (const dir of input.createdDirs.slice().reverse()) {
+    try {
+      await rmdir(dir);
+    } catch {
+      // Directory did not exist, was not empty, or predated rollback; leave it.
+    }
+  }
+  return errors;
 }
 
 function safeRepoPath(repoPath: string, relativePath: string): string | null {
@@ -281,9 +350,10 @@ async function prepareApprovedUntrackedFiles(input: {
 > {
   const files: PreparedUntrackedFile[] = [];
   const conflicts: HandoffConflict[] = [];
+  let totalBytes = 0;
   const candidates = input.dryRun.untrackedCandidates
     .filter((candidate) => candidate.included)
-    .sort((a, b) => a.path.localeCompare(b.path));
+    .sort((a, b) => comparePaths(a.path, b.path));
 
   for (const candidate of candidates) {
     const sourcePath = safeRepoPath(input.sourceRepoPath, candidate.path);
@@ -335,7 +405,20 @@ async function prepareApprovedUntrackedFiles(input: {
       continue;
     }
 
-    const data = await readFile(sourcePath);
+    let data: Buffer;
+    try {
+      data = await readFile(sourcePath);
+    } catch (error) {
+      conflicts.push(
+        makeConflict(
+          'STALE_SOURCE',
+          `approved untracked file became unreadable while snapshotting: ${candidate.path}: ${errorMessage(error)}`,
+          input.sourceNodeId,
+          'FAILED_STALE_SOURCE'
+        )
+      );
+      continue;
+    }
     if (data.byteLength !== sourceStat.size) {
       conflicts.push(
         makeConflict(
@@ -343,6 +426,18 @@ async function prepareApprovedUntrackedFiles(input: {
           `approved untracked file changed while snapshotting: ${candidate.path}`,
           input.sourceNodeId,
           'FAILED_STALE_SOURCE'
+        )
+      );
+      continue;
+    }
+    totalBytes += data.byteLength;
+    if (totalBytes > MAX_APPROVED_UNTRACKED_TOTAL_BYTES) {
+      conflicts.push(
+        makeConflict(
+          'CACHE_EXCLUDED',
+          `approved untracked files exceed ${MAX_APPROVED_UNTRACKED_TOTAL_BYTES} byte aggregate transfer limit`,
+          input.sourceNodeId,
+          'FAILED_DESTINATION_CONFLICT'
         )
       );
       continue;
@@ -361,6 +456,7 @@ async function prepareApprovedUntrackedFiles(input: {
   return { ok: true, files };
 }
 
+// eslint-disable-next-line complexity -- transfer/apply is a linear safety decision table with explicit typed failures.
 export async function applyHandoffTransfer(
   input: HandoffTransferApplyInput
 ): Promise<HandoffTransferApplyResult> {
@@ -400,11 +496,31 @@ export async function applyHandoffTransfer(
     nodeId: input.sourceNodeId,
     exec,
   } satisfies Parameters<typeof planHandoffSnapshot>[0];
-  const dryRun = await planHandoffSnapshot(
-    input.approvedUntrackedPaths === undefined
-      ? plannerInput
-      : { ...plannerInput, approvedUntrackedPaths: input.approvedUntrackedPaths }
-  );
+  let dryRun: HandoffPlannerDryRun;
+  try {
+    dryRun = await planHandoffSnapshot(
+      input.approvedUntrackedPaths === undefined
+        ? plannerInput
+        : { ...plannerInput, approvedUntrackedPaths: input.approvedUntrackedPaths }
+    );
+  } catch (error) {
+    return failResult(
+      run,
+      auditEvents,
+      [
+        makeConflict(
+          'STALE_SOURCE',
+          `source snapshot planning failed: ${errorMessage(error)}`,
+          input.sourceNodeId,
+          'FAILED_STALE_SOURCE'
+        ),
+      ],
+      'FAILED_STALE_SOURCE',
+      now,
+      input.actorId,
+      createId
+    );
+  }
   if (dryRun.conflicts.length > 0) {
     return failResult(
       run,
@@ -457,22 +573,54 @@ export async function applyHandoffTransfer(
     }
   }
 
-  const trackedPaths = [
-    ...new Set(
-      [...dryRun.stagedFiles, ...dryRun.unstagedFiles].map((file) => file.path)
-    ),
-  ].sort();
-  const patch =
-    trackedPaths.length > 0
-      ? await runGit(
-          exec,
-          input.sourceRepoPath,
-          ['diff', 'HEAD', '--', ...trackedPaths],
-          { maxBuffer: GIT_APPLY_MAX_BUFFER_BYTES }
-        )
-      : '';
+  const trackedPaths = sortUniquePaths(
+    [...dryRun.stagedFiles, ...dryRun.unstagedFiles].map((file) => file.path)
+  );
+  let patch = '';
+  if (trackedPaths.length > 0) {
+    try {
+      patch = await runGit(exec, input.sourceRepoPath, ['diff', 'HEAD'], {
+        maxBuffer: GIT_TRANSFER_MAX_BUFFER_BYTES,
+      });
+    } catch (error) {
+      return failResult(
+        run,
+        auditEvents,
+        [
+          makeConflict(
+            'STALE_SOURCE',
+            `source tracked patch generation failed: ${errorMessage(error)}`,
+            input.sourceNodeId,
+            'FAILED_STALE_SOURCE'
+          ),
+        ],
+        'FAILED_STALE_SOURCE',
+        now,
+        input.actorId,
+        createId
+      );
+    }
+  }
   const patchBuffer = Buffer.from(patch);
   const patchSha256 = hashBuffer(patchBuffer);
+  if (trackedPaths.length > 0 && dryRun.trackedPatchSha256 !== patchSha256) {
+    return failResult(
+      run,
+      auditEvents,
+      [
+        makeConflict(
+          'STALE_SOURCE',
+          'source tracked patch changed while preparing transfer',
+          input.sourceNodeId,
+          'FAILED_STALE_SOURCE'
+        ),
+      ],
+      'FAILED_STALE_SOURCE',
+      now,
+      input.actorId,
+      createId
+    );
+  }
 
   const untracked = await prepareApprovedUntrackedFiles({
     dryRun,
@@ -488,6 +636,35 @@ export async function applyHandoffTransfer(
       auditEvents,
       untracked.conflicts,
       untracked.conflicts[0]?.reasonCode ?? 'FAILED_DESTINATION_CONFLICT',
+      now,
+      input.actorId,
+      createId
+    );
+  }
+  const plannedUntracked = new Map(
+    (dryRun.approvedUntrackedFiles ?? []).map((file) => [file.path, file])
+  );
+  const untrackedHashMismatch = untracked.files.find((file) => {
+    const planned = plannedUntracked.get(file.path);
+    return (
+      planned === undefined ||
+      planned.byteCount !== file.byteCount ||
+      planned.sha256 !== file.sha256
+    );
+  });
+  if (untrackedHashMismatch) {
+    return failResult(
+      run,
+      auditEvents,
+      [
+        makeConflict(
+          'STALE_SOURCE',
+          `approved untracked file changed after handoff planning: ${untrackedHashMismatch.path}`,
+          input.sourceNodeId,
+          'FAILED_STALE_SOURCE'
+        ),
+      ],
+      'FAILED_STALE_SOURCE',
       now,
       input.actorId,
       createId
@@ -518,9 +695,31 @@ export async function applyHandoffTransfer(
     ],
   });
 
-  const destinationHead = (
-    await runGit(exec, input.destinationRepoPath, ['rev-parse', 'HEAD'])
-  ).trim();
+  let destinationHead: string;
+  try {
+    destinationHead = (
+      await runGit(exec, input.destinationRepoPath, ['rev-parse', 'HEAD'], {
+        maxBuffer: GIT_TRANSFER_MAX_BUFFER_BYTES,
+      })
+    ).trim();
+  } catch (error) {
+    return failResult(
+      run,
+      auditEvents,
+      [
+        makeConflict(
+          'DESTINATION_UNAVAILABLE',
+          `destination HEAD could not be resolved: ${errorMessage(error)}`,
+          input.destinationNodeId,
+          'FAILED_DESTINATION_UNAVAILABLE'
+        ),
+      ],
+      'FAILED_DESTINATION_UNAVAILABLE',
+      now,
+      input.actorId,
+      createId
+    );
+  }
   if (destinationHead !== input.baseCommit) {
     return failResult(
       run,
@@ -540,12 +739,32 @@ export async function applyHandoffTransfer(
     );
   }
 
-  const destinationStatus = await runGit(exec, input.destinationRepoPath, [
-    'status',
-    '--porcelain=v1',
-    '-z',
-    '--untracked-files=all',
-  ]);
+  let destinationStatus: string;
+  try {
+    destinationStatus = await runGit(
+      exec,
+      input.destinationRepoPath,
+      ['status', '--porcelain=v1', '-z', '--untracked-files=all'],
+      { maxBuffer: GIT_TRANSFER_MAX_BUFFER_BYTES }
+    );
+  } catch (error) {
+    return failResult(
+      run,
+      auditEvents,
+      [
+        makeConflict(
+          'DESTINATION_UNAVAILABLE',
+          `destination status could not be resolved: ${errorMessage(error)}`,
+          input.destinationNodeId,
+          'FAILED_DESTINATION_UNAVAILABLE'
+        ),
+      ],
+      'FAILED_DESTINATION_UNAVAILABLE',
+      now,
+      input.actorId,
+      createId
+    );
+  }
   if (destinationStatus.length > 0) {
     return failResult(
       run,
@@ -609,7 +828,7 @@ export async function applyHandoffTransfer(
       [
         makeConflict(
           'DESTINATION_CONFLICT',
-          `tracked patch does not apply cleanly: ${error instanceof Error ? error.message : String(error)}`,
+          `tracked patch does not apply cleanly: ${errorMessage(error)}`,
           input.destinationNodeId,
           'FAILED_DESTINATION_CONFLICT'
         ),
@@ -631,13 +850,23 @@ export async function applyHandoffTransfer(
     createId
   );
 
+  let trackedPatchApplied = false;
+  const writtenUntrackedFiles: PreparedUntrackedFile[] = [];
+  const createdDirs: string[] = [];
   try {
     if (patchPath) {
       await runGit(exec, input.destinationRepoPath, ['apply', patchPath]);
+      trackedPatchApplied = true;
     }
     for (const file of untracked.files) {
+      const missingDirs = await missingParentDirs(
+        input.destinationRepoPath,
+        file.destinationPath
+      );
       await mkdir(dirname(file.destinationPath), { recursive: true });
+      createdDirs.push(...missingDirs);
       await writeFile(file.destinationPath, file.data, { flag: 'wx' });
+      writtenUntrackedFiles.push(file);
       auditEvents.push({
         id: createId(),
         runId: run.id,
@@ -651,13 +880,25 @@ export async function applyHandoffTransfer(
       });
     }
   } catch (error) {
+    const rollbackErrors = await rollbackDestinationApply({
+      exec,
+      destinationRepoPath: input.destinationRepoPath,
+      patchPath,
+      trackedPatchApplied,
+      writtenUntrackedFiles,
+      createdDirs,
+    });
+    const rollbackSuffix =
+      rollbackErrors.length > 0
+        ? `; rollback errors: ${rollbackErrors.join('; ')}`
+        : '';
     return failResult(
       run,
       auditEvents,
       [
         makeConflict(
           'DESTINATION_CONFLICT',
-          `failed while applying handoff snapshot: ${error instanceof Error ? error.message : String(error)}`,
+          `failed while applying handoff snapshot: ${errorMessage(error)}${rollbackSuffix}`,
           input.destinationNodeId,
           'FAILED_DESTINATION_CONFLICT'
         ),

--- a/server/handoff-transfer.ts
+++ b/server/handoff-transfer.ts
@@ -1,0 +1,714 @@
+import { execFile } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { promisify } from 'node:util';
+
+import {
+  HANDOFF_SCHEMA_VERSION,
+  type HandoffConflict,
+  type HandoffReasonCode,
+  type HandoffRequiredGrant,
+  type HandoffRun,
+  type HandoffRunState,
+  type HandoffRunTransition,
+} from '../shared/handoff.js';
+import type { NodeId } from '../shared/identity.js';
+import {
+  isSafePath,
+  MAX_UNTRACKED_FILE_BYTES,
+  planHandoffSnapshot,
+  type ExecFileAsyncLike,
+  type HandoffPlannerDryRun,
+} from './handoff-planner.js';
+
+const execFileAsync = promisify(execFile);
+const GIT_APPLY_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+export interface HandoffTransferApplyInput {
+  requestId: string;
+  planId?: string;
+  snapshotId?: string;
+  sourceRepoPath: string;
+  destinationRepoPath: string;
+  sourceNodeId: NodeId;
+  destinationNodeId: NodeId;
+  baseCommit: string;
+  branchName?: string | null;
+  actorId?: string;
+  approvedUntrackedPaths?: readonly string[];
+  requiredGrants?: readonly HandoffRequiredGrant[];
+  expectedDryRun?: HandoffPlannerDryRun;
+  maxUntrackedFileBytes?: number;
+  exec?: ExecFileAsyncLike;
+  now?: () => string;
+  createId?: () => string;
+}
+
+export interface HandoffTransferAuditEvent {
+  id: string;
+  runId: string;
+  at: string;
+  phase: HandoffRunState;
+  type:
+    | 'handoff-run-transition'
+    | 'handoff-snapshot-captured'
+    | 'handoff-transfer-artifact'
+    | 'handoff-apply-complete'
+    | 'handoff-apply-failed';
+  reasonCode: HandoffReasonCode;
+  byteCount?: number;
+  sha256?: string;
+  refs?: string[];
+  decisions?: string[];
+  conflictCode?: HandoffConflict['code'];
+}
+
+export interface AppliedUntrackedFileSummary {
+  path: string;
+  byteCount: number;
+  sha256: string;
+}
+
+export interface HandoffTransferApplySuccess {
+  ok: true;
+  run: HandoffRun;
+  auditEvents: HandoffTransferAuditEvent[];
+  trackedPatch: {
+    byteCount: number;
+    sha256: string;
+    applied: boolean;
+  };
+  approvedUntrackedFiles: AppliedUntrackedFileSummary[];
+}
+
+export interface HandoffTransferApplyFailure {
+  ok: false;
+  run: HandoffRun;
+  auditEvents: HandoffTransferAuditEvent[];
+  conflicts: HandoffConflict[];
+}
+
+export type HandoffTransferApplyResult =
+  | HandoffTransferApplySuccess
+  | HandoffTransferApplyFailure;
+
+interface PreparedUntrackedFile extends AppliedUntrackedFileSummary {
+  sourcePath: string;
+  destinationPath: string;
+  data: Buffer;
+}
+
+function defaultNow(): string {
+  return new Date().toISOString();
+}
+
+function hashBuffer(buffer: Buffer | string): string {
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+function makeConflict(
+  code: HandoffConflict['code'],
+  message: string,
+  nodeId: NodeId,
+  reasonCode?: HandoffReasonCode
+): HandoffConflict {
+  return { code, message, nodeId, ...(reasonCode ? { reasonCode } : {}) };
+}
+
+function dryRunFingerprint(dryRun: HandoffPlannerDryRun): string {
+  return JSON.stringify({
+    branchName: dryRun.branchName,
+    baseCommit: dryRun.baseCommit,
+    stagedFiles: dryRun.stagedFiles,
+    unstagedFiles: dryRun.unstagedFiles,
+    untrackedCandidates: dryRun.untrackedCandidates,
+    excludedPaths: dryRun.excludedPaths,
+    includedGroups: dryRun.includedGroups,
+    excludedGroups: dryRun.excludedGroups,
+    fileCount: dryRun.fileCount,
+    byteCount: dryRun.byteCount,
+    transferMode: dryRun.transferMode,
+  });
+}
+
+async function runGit(
+  run: ExecFileAsyncLike,
+  cwd: string,
+  args: string[],
+  options: { timeout?: number; maxBuffer?: number } = {}
+): Promise<string> {
+  const execOptions: { cwd: string; timeout?: number; maxBuffer?: number } = {
+    cwd,
+    timeout: options.timeout ?? 10_000,
+  };
+  if (options.maxBuffer !== undefined) {
+    execOptions.maxBuffer = options.maxBuffer;
+  }
+  const { stdout } = await run('git', args, {
+    ...execOptions,
+  });
+  return stdout;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function safeRepoPath(repoPath: string, relativePath: string): string | null {
+  if (!isSafePath(repoPath, relativePath)) return null;
+  const resolved = resolve(repoPath, relativePath);
+  const root = repoPath.endsWith('/') ? repoPath : `${repoPath}/`;
+  if (resolved !== repoPath && !resolved.startsWith(root)) return null;
+  return resolved;
+}
+
+function createRun(input: HandoffTransferApplyInput, now: string): HandoffRun {
+  return {
+    schemaVersion: HANDOFF_SCHEMA_VERSION,
+    id: input.createId?.() ?? `handoff-run-${randomUUID()}`,
+    requestId: input.requestId,
+    ...(input.planId ? { planId: input.planId } : {}),
+    ...(input.snapshotId ? { snapshotId: input.snapshotId } : {}),
+    state: 'planned',
+    sourceDisposition: 'left-running',
+    conflicts: [],
+    transitions: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function transitionRun(
+  run: HandoffRun,
+  to: HandoffRunState,
+  reasonCode: HandoffReasonCode,
+  at: string,
+  actorId: string | undefined,
+  auditEvents: HandoffTransferAuditEvent[],
+  createId: () => string
+): void {
+  const from = run.state;
+  const transition: HandoffRunTransition = {
+    from,
+    to,
+    at,
+    reasonCode,
+    ...(actorId ? { actorId } : {}),
+  };
+  run.transitions.push(transition);
+  run.state = to;
+  run.reasonCode = reasonCode;
+  run.updatedAt = at;
+  if (to === 'complete' || to === 'failed' || to === 'cancelled') {
+    run.completedAt = at;
+  }
+  auditEvents.push({
+    id: createId(),
+    runId: run.id,
+    at,
+    phase: to,
+    type: 'handoff-run-transition',
+    reasonCode,
+  });
+}
+
+function failResult(
+  run: HandoffRun,
+  auditEvents: HandoffTransferAuditEvent[],
+  conflicts: HandoffConflict[],
+  reasonCode: HandoffReasonCode,
+  now: () => string,
+  actorId: string | undefined,
+  createId: () => string
+): HandoffTransferApplyFailure {
+  run.conflicts = conflicts;
+  const at = now();
+  transitionRun(run, 'failed', reasonCode, at, actorId, auditEvents, createId);
+  const failureEvent: HandoffTransferAuditEvent = {
+    id: createId(),
+    runId: run.id,
+    at,
+    phase: 'failed',
+    type: 'handoff-apply-failed',
+    reasonCode,
+  };
+  if (conflicts[0]?.code !== undefined) {
+    failureEvent.conflictCode = conflicts[0].code;
+  }
+  auditEvents.push(failureEvent);
+  return { ok: false, run, auditEvents, conflicts };
+}
+
+function deniedGrantConflicts(
+  grants: readonly HandoffRequiredGrant[] | undefined
+): HandoffConflict[] {
+  return (grants ?? [])
+    .filter((grant) => grant.decision !== 'allow')
+    .map((grant) =>
+      makeConflict(
+        'MISSING_CAPABILITY_GRANT',
+        `handoff grant ${grant.leg} for ${grant.capability} on ${grant.nodeId} is not allowed`,
+        grant.nodeId,
+        'FAILED_MISSING_GRANT'
+      )
+    );
+}
+
+async function prepareApprovedUntrackedFiles(input: {
+  dryRun: HandoffPlannerDryRun;
+  sourceRepoPath: string;
+  destinationRepoPath: string;
+  maxUntrackedFileBytes: number;
+  sourceNodeId: NodeId;
+  destinationNodeId: NodeId;
+}): Promise<
+  | { ok: true; files: PreparedUntrackedFile[] }
+  | { ok: false; conflicts: HandoffConflict[] }
+> {
+  const files: PreparedUntrackedFile[] = [];
+  const conflicts: HandoffConflict[] = [];
+  const candidates = input.dryRun.untrackedCandidates
+    .filter((candidate) => candidate.included)
+    .sort((a, b) => a.path.localeCompare(b.path));
+
+  for (const candidate of candidates) {
+    const sourcePath = safeRepoPath(input.sourceRepoPath, candidate.path);
+    const destinationPath = safeRepoPath(input.destinationRepoPath, candidate.path);
+    if (!sourcePath || !destinationPath) {
+      conflicts.push(
+        makeConflict(
+          'UNSAFE_PATH_MAPPING',
+          `approved untracked path is unsafe: ${candidate.path}`,
+          input.destinationNodeId,
+          'FAILED_UNSAFE_PATH_MAPPING'
+        )
+      );
+      continue;
+    }
+
+    const sourceStat = await stat(sourcePath).catch(() => null);
+    if (!sourceStat?.isFile()) {
+      conflicts.push(
+        makeConflict(
+          'STALE_SOURCE',
+          `approved untracked file disappeared or changed kind: ${candidate.path}`,
+          input.sourceNodeId,
+          'FAILED_STALE_SOURCE'
+        )
+      );
+      continue;
+    }
+    if (sourceStat.size > input.maxUntrackedFileBytes) {
+      conflicts.push(
+        makeConflict(
+          'CACHE_EXCLUDED',
+          `approved untracked file exceeds ${input.maxUntrackedFileBytes} byte transfer limit: ${candidate.path}`,
+          input.sourceNodeId,
+          'FAILED_DESTINATION_CONFLICT'
+        )
+      );
+      continue;
+    }
+    if (await pathExists(destinationPath)) {
+      conflicts.push(
+        makeConflict(
+          'UNTRACKED_COLLISION',
+          `destination path already exists for approved untracked file: ${candidate.path}`,
+          input.destinationNodeId,
+          'FAILED_DESTINATION_CONFLICT'
+        )
+      );
+      continue;
+    }
+
+    const data = await readFile(sourcePath);
+    if (data.byteLength !== sourceStat.size) {
+      conflicts.push(
+        makeConflict(
+          'STALE_SOURCE',
+          `approved untracked file changed while snapshotting: ${candidate.path}`,
+          input.sourceNodeId,
+          'FAILED_STALE_SOURCE'
+        )
+      );
+      continue;
+    }
+    files.push({
+      path: candidate.path,
+      sourcePath,
+      destinationPath,
+      data,
+      byteCount: data.byteLength,
+      sha256: hashBuffer(data),
+    });
+  }
+
+  if (conflicts.length > 0) return { ok: false, conflicts };
+  return { ok: true, files };
+}
+
+export async function applyHandoffTransfer(
+  input: HandoffTransferApplyInput
+): Promise<HandoffTransferApplyResult> {
+  const now = input.now ?? defaultNow;
+  const createId = input.createId ?? (() => `handoff-event-${randomUUID()}`);
+  const run = createRun(input, now());
+  const auditEvents: HandoffTransferAuditEvent[] = [];
+  const exec = input.exec ?? (execFileAsync as ExecFileAsyncLike);
+  const maxUntrackedFileBytes =
+    input.maxUntrackedFileBytes ?? MAX_UNTRACKED_FILE_BYTES;
+
+  const grantConflicts = deniedGrantConflicts(input.requiredGrants);
+  if (grantConflicts.length > 0) {
+    return failResult(
+      run,
+      auditEvents,
+      grantConflicts,
+      'FAILED_MISSING_GRANT',
+      now,
+      input.actorId,
+      createId
+    );
+  }
+
+  transitionRun(
+    run,
+    'snapshotting',
+    'SNAPSHOT_CAPTURED',
+    now(),
+    input.actorId,
+    auditEvents,
+    createId
+  );
+
+  const plannerInput = {
+    repoPath: input.sourceRepoPath,
+    nodeId: input.sourceNodeId,
+    exec,
+  } satisfies Parameters<typeof planHandoffSnapshot>[0];
+  const dryRun = await planHandoffSnapshot(
+    input.approvedUntrackedPaths === undefined
+      ? plannerInput
+      : { ...plannerInput, approvedUntrackedPaths: input.approvedUntrackedPaths }
+  );
+  if (dryRun.conflicts.length > 0) {
+    return failResult(
+      run,
+      auditEvents,
+      dryRun.conflicts,
+      dryRun.conflicts[0]?.reasonCode ?? 'FAILED_STALE_SOURCE',
+      now,
+      input.actorId,
+      createId
+    );
+  }
+  if (dryRun.baseCommit !== input.baseCommit) {
+    return failResult(
+      run,
+      auditEvents,
+      [
+        makeConflict(
+          'STALE_SOURCE',
+          `source HEAD changed from planned base ${input.baseCommit} to ${dryRun.baseCommit ?? 'unknown'}`,
+          input.sourceNodeId,
+          'FAILED_STALE_SOURCE'
+        ),
+      ],
+      'FAILED_STALE_SOURCE',
+      now,
+      input.actorId,
+      createId
+    );
+  }
+  if (input.expectedDryRun) {
+    const expected = dryRunFingerprint(input.expectedDryRun);
+    const actual = dryRunFingerprint(dryRun);
+    if (expected !== actual) {
+      return failResult(
+        run,
+        auditEvents,
+        [
+          makeConflict(
+            'STALE_SOURCE',
+            'source working tree changed after handoff planning',
+            input.sourceNodeId,
+            'FAILED_STALE_SOURCE'
+          ),
+        ],
+        'FAILED_STALE_SOURCE',
+        now,
+        input.actorId,
+        createId
+      );
+    }
+  }
+
+  const trackedPaths = [
+    ...new Set(
+      [...dryRun.stagedFiles, ...dryRun.unstagedFiles].map((file) => file.path)
+    ),
+  ].sort();
+  const patch =
+    trackedPaths.length > 0
+      ? await runGit(
+          exec,
+          input.sourceRepoPath,
+          ['diff', 'HEAD', '--', ...trackedPaths],
+          { maxBuffer: GIT_APPLY_MAX_BUFFER_BYTES }
+        )
+      : '';
+  const patchBuffer = Buffer.from(patch);
+  const patchSha256 = hashBuffer(patchBuffer);
+
+  const untracked = await prepareApprovedUntrackedFiles({
+    dryRun,
+    sourceRepoPath: input.sourceRepoPath,
+    destinationRepoPath: input.destinationRepoPath,
+    maxUntrackedFileBytes,
+    sourceNodeId: input.sourceNodeId,
+    destinationNodeId: input.destinationNodeId,
+  });
+  if (!untracked.ok) {
+    return failResult(
+      run,
+      auditEvents,
+      untracked.conflicts,
+      untracked.conflicts[0]?.reasonCode ?? 'FAILED_DESTINATION_CONFLICT',
+      now,
+      input.actorId,
+      createId
+    );
+  }
+
+  auditEvents.push({
+    id: createId(),
+    runId: run.id,
+    at: now(),
+    phase: 'snapshotting',
+    type: 'handoff-snapshot-captured',
+    reasonCode: 'SNAPSHOT_CAPTURED',
+    byteCount:
+      patchBuffer.byteLength +
+      untracked.files.reduce((sum, file) => sum + file.byteCount, 0),
+    sha256: hashBuffer(
+      `${patchSha256}:${untracked.files.map((file) => file.sha256).join(':')}`
+    ),
+    refs: [
+      `git:${input.baseCommit}`,
+      ...trackedPaths.map((path) => `tracked:${path}`),
+      ...untracked.files.map((file) => `untracked:${file.path}`),
+    ],
+    decisions: [
+      `transferMode:${dryRun.transferMode}`,
+      `approvedUntracked:${untracked.files.length}`,
+    ],
+  });
+
+  const destinationHead = (
+    await runGit(exec, input.destinationRepoPath, ['rev-parse', 'HEAD'])
+  ).trim();
+  if (destinationHead !== input.baseCommit) {
+    return failResult(
+      run,
+      auditEvents,
+      [
+        makeConflict(
+          'BASE_MISMATCH',
+          `destination HEAD ${destinationHead} does not match planned base ${input.baseCommit}`,
+          input.destinationNodeId,
+          'FAILED_BASE_MISMATCH'
+        ),
+      ],
+      'FAILED_BASE_MISMATCH',
+      now,
+      input.actorId,
+      createId
+    );
+  }
+
+  const destinationStatus = await runGit(exec, input.destinationRepoPath, [
+    'status',
+    '--porcelain=v1',
+    '-z',
+    '--untracked-files=all',
+  ]);
+  if (destinationStatus.length > 0) {
+    return failResult(
+      run,
+      auditEvents,
+      [
+        makeConflict(
+          'DESTINATION_DIRTY',
+          'destination worktree must be clean before applying a handoff snapshot',
+          input.destinationNodeId,
+          'FAILED_DESTINATION_CONFLICT'
+        ),
+      ],
+      'FAILED_DESTINATION_CONFLICT',
+      now,
+      input.actorId,
+      createId
+    );
+  }
+
+  transitionRun(
+    run,
+    'transferring',
+    'TRANSFER_STARTED',
+    now(),
+    input.actorId,
+    auditEvents,
+    createId
+  );
+
+  let patchPath: string | null = null;
+  let tempDir: string | null = null;
+  try {
+    if (patchBuffer.byteLength > 0) {
+      tempDir = await mkdtemp(join(tmpdir(), 'relay-handoff-transfer-'));
+      patchPath = join(tempDir, 'tracked.patch');
+      await writeFile(patchPath, patchBuffer);
+      await runGit(exec, input.destinationRepoPath, [
+        'apply',
+        '--check',
+        patchPath,
+      ]);
+      auditEvents.push({
+        id: createId(),
+        runId: run.id,
+        at: now(),
+        phase: 'transferring',
+        type: 'handoff-transfer-artifact',
+        reasonCode: 'TRANSFER_COMPLETED',
+        byteCount: patchBuffer.byteLength,
+        sha256: patchSha256,
+        refs: ['tracked-patch'],
+      });
+    }
+  } catch (error) {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+    return failResult(
+      run,
+      auditEvents,
+      [
+        makeConflict(
+          'DESTINATION_CONFLICT',
+          `tracked patch does not apply cleanly: ${error instanceof Error ? error.message : String(error)}`,
+          input.destinationNodeId,
+          'FAILED_DESTINATION_CONFLICT'
+        ),
+      ],
+      'FAILED_DESTINATION_CONFLICT',
+      now,
+      input.actorId,
+      createId
+    );
+  }
+
+  transitionRun(
+    run,
+    'applying',
+    'APPLY_STARTED',
+    now(),
+    input.actorId,
+    auditEvents,
+    createId
+  );
+
+  try {
+    if (patchPath) {
+      await runGit(exec, input.destinationRepoPath, ['apply', patchPath]);
+    }
+    for (const file of untracked.files) {
+      await mkdir(dirname(file.destinationPath), { recursive: true });
+      await writeFile(file.destinationPath, file.data, { flag: 'wx' });
+      auditEvents.push({
+        id: createId(),
+        runId: run.id,
+        at: now(),
+        phase: 'applying',
+        type: 'handoff-transfer-artifact',
+        reasonCode: 'APPLY_COMPLETED',
+        byteCount: file.byteCount,
+        sha256: file.sha256,
+        refs: [`untracked:${file.path}`],
+      });
+    }
+  } catch (error) {
+    return failResult(
+      run,
+      auditEvents,
+      [
+        makeConflict(
+          'DESTINATION_CONFLICT',
+          `failed while applying handoff snapshot: ${error instanceof Error ? error.message : String(error)}`,
+          input.destinationNodeId,
+          'FAILED_DESTINATION_CONFLICT'
+        ),
+      ],
+      'FAILED_DESTINATION_CONFLICT',
+      now,
+      input.actorId,
+      createId
+    );
+  } finally {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  const completedAt = now();
+  transitionRun(
+    run,
+    'complete',
+    'APPLY_COMPLETED',
+    completedAt,
+    input.actorId,
+    auditEvents,
+    createId
+  );
+  auditEvents.push({
+    id: createId(),
+    runId: run.id,
+    at: completedAt,
+    phase: 'complete',
+    type: 'handoff-apply-complete',
+    reasonCode: 'APPLY_COMPLETED',
+    byteCount:
+      patchBuffer.byteLength +
+      untracked.files.reduce((sum, file) => sum + file.byteCount, 0),
+    sha256: hashBuffer(
+      `${patchSha256}:${untracked.files.map((file) => file.sha256).join(':')}`
+    ),
+  });
+
+  return {
+    ok: true,
+    run,
+    auditEvents,
+    trackedPatch: {
+      byteCount: patchBuffer.byteLength,
+      sha256: patchSha256,
+      applied: patchBuffer.byteLength > 0,
+    },
+    approvedUntrackedFiles: untracked.files.map(
+      ({ path, byteCount, sha256 }) => ({ path, byteCount, sha256 })
+    ),
+  };
+}

--- a/shared/handoff.ts
+++ b/shared/handoff.ts
@@ -335,7 +335,7 @@ const ALLOWED_TRANSITIONS: Record<HandoffRunState, readonly HandoffRunState[]> =
     planned: ['snapshotting', 'failed', 'cancelled'],
     snapshotting: ['transferring', 'failed', 'cancelled'],
     transferring: ['applying', 'failed', 'cancelled'],
-    applying: ['launching', 'failed', 'cancelled'],
+    applying: ['complete', 'launching', 'failed', 'cancelled'],
     launching: ['verifying', 'failed', 'cancelled'],
     verifying: ['complete', 'failed', 'cancelled'],
     complete: [],

--- a/test/handoff-planner.test.ts
+++ b/test/handoff-planner.test.ts
@@ -302,12 +302,7 @@ describe('planHandoffSnapshot — dirty tracked diff', () => {
 
     const diffCall = calls.find((call) => call.args[0] === 'diff');
     expect(diffCall?.file).toBe('git');
-    expect(diffCall?.args).toEqual([
-      'diff',
-      'HEAD',
-      '--',
-      'src/server/git.ts',
-    ]);
+    expect(diffCall?.args).toEqual(['diff', 'HEAD']);
     expect(diffCall?.options).toMatchObject({
       cwd: REPO_PATH,
       timeout: 10000,
@@ -315,7 +310,7 @@ describe('planHandoffSnapshot — dirty tracked diff', () => {
     });
   });
 
-  it('excludes staged symlink patch bytes from mixed tracked byte accounting', async () => {
+  it('accounts for whole tracked patch bytes when excluding staged symlink metadata', async () => {
     const repoPath = mkdtempSync(join(tmpdir(), 'relay-handoff-mixed-symlink-'));
     symlinkSync('/etc/passwd', join(repoPath, 'linked-outside'));
     const calls: ExecCall[] = [];
@@ -348,14 +343,8 @@ describe('planHandoffSnapshot — dirty tracked diff', () => {
     const result = await planHandoffSnapshot({ repoPath, nodeId: NODE_ID, exec });
 
     const diffCall = calls.find((call) => call.args[0] === 'diff');
-    expect(diffCall?.args).toEqual([
-      'diff',
-      'HEAD',
-      '--',
-      'src/server/git.ts',
-    ]);
-    expect(result.byteCount).toBe(Buffer.byteLength(safeDiff));
-    expect(result.byteCount).toBeLessThan(Buffer.byteLength(fullDiff));
+    expect(diffCall?.args).toEqual(['diff', 'HEAD']);
+    expect(result.byteCount).toBe(Buffer.byteLength(fullDiff));
     expect(result.fileCount).toBe(1);
     expect(result.transferMode).toBe('tracked-patch');
     expect(result.includedGroups).toContain('tracked-patch');

--- a/test/handoff-transfer.test.ts
+++ b/test/handoff-transfer.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -13,7 +14,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { isHandoffRun, type HandoffRequiredGrant } from '../shared/handoff.js';
-import { planHandoffSnapshot } from '../server/handoff-planner.js';
+import { planHandoffSnapshot, type ExecFileAsyncLike } from '../server/handoff-planner.js';
 import { applyHandoffTransfer } from '../server/handoff-transfer.js';
 
 const SOURCE_NODE = 'local-node';
@@ -79,11 +80,13 @@ async function applyFixture(input: {
   approvedUntrackedPaths?: readonly string[];
   requiredGrants?: readonly HandoffRequiredGrant[];
   maxUntrackedFileBytes?: number;
+  exec?: ExecFileAsyncLike;
 }) {
   const dryRun = await planHandoffSnapshot({
     repoPath: input.source,
     nodeId: SOURCE_NODE,
     approvedUntrackedPaths: input.approvedUntrackedPaths,
+    exec: input.exec,
   });
   return applyHandoffTransfer({
     requestId: 'handoff-request-test',
@@ -98,6 +101,7 @@ async function applyFixture(input: {
     requiredGrants: input.requiredGrants,
     expectedDryRun: dryRun,
     maxUntrackedFileBytes: input.maxUntrackedFileBytes,
+    exec: input.exec,
     now: () => '2026-05-21T12:00:00.000Z',
     createId: createIdFactory(),
   });
@@ -241,6 +245,128 @@ describe('applyHandoffTransfer', () => {
     expect(readFileSync(join(destination, 'src', 'app.ts'), 'utf8')).toBe(
       beforeTracked
     );
+  });
+
+  it('rejects same-size tracked source changes after planning', async () => {
+    const { source, destination, baseCommit } = makeRepos();
+    writeFileSync(join(source, 'src', 'app.ts'), 'export const value = 2;\n');
+    const expectedDryRun = await planHandoffSnapshot({
+      repoPath: source,
+      nodeId: SOURCE_NODE,
+    });
+    writeFileSync(join(source, 'src', 'app.ts'), 'export const value = 3;\n');
+    const beforeTracked = readFileSync(join(destination, 'src', 'app.ts'), 'utf8');
+
+    const result = await applyHandoffTransfer({
+      requestId: 'handoff-request-test',
+      planId: 'handoff-plan-test',
+      snapshotId: 'handoff-snapshot-test',
+      sourceRepoPath: source,
+      destinationRepoPath: destination,
+      sourceNodeId: SOURCE_NODE,
+      destinationNodeId: DESTINATION_NODE,
+      baseCommit,
+      expectedDryRun,
+      now: () => '2026-05-21T12:00:00.000Z',
+      createId: createIdFactory(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected stale-source failure');
+    expect(result.conflicts[0]).toMatchObject({ code: 'STALE_SOURCE' });
+    expect(readFileSync(join(destination, 'src', 'app.ts'), 'utf8')).toBe(beforeTracked);
+    expect(git(destination, ['status', '--porcelain=v1'])).toBe('');
+  });
+
+  it('rejects same-size approved untracked source changes after planning', async () => {
+    const { source, destination, baseCommit } = makeRepos();
+    writeFileSync(join(source, 'notes.md'), 'aaaa\n');
+    const expectedDryRun = await planHandoffSnapshot({
+      repoPath: source,
+      nodeId: SOURCE_NODE,
+      approvedUntrackedPaths: ['notes.md'],
+    });
+    writeFileSync(join(source, 'notes.md'), 'bbbb\n');
+
+    const result = await applyHandoffTransfer({
+      requestId: 'handoff-request-test',
+      planId: 'handoff-plan-test',
+      snapshotId: 'handoff-snapshot-test',
+      sourceRepoPath: source,
+      destinationRepoPath: destination,
+      sourceNodeId: SOURCE_NODE,
+      destinationNodeId: DESTINATION_NODE,
+      baseCommit,
+      approvedUntrackedPaths: ['notes.md'],
+      expectedDryRun,
+      now: () => '2026-05-21T12:00:00.000Z',
+      createId: createIdFactory(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected stale-source failure');
+    expect(result.conflicts[0]).toMatchObject({ code: 'STALE_SOURCE' });
+    expect(existsSync(join(destination, 'notes.md'))).toBe(false);
+    expect(git(destination, ['status', '--porcelain=v1'])).toBe('');
+  });
+
+  it('rolls back tracked and untracked writes when apply fails after mutation starts', async () => {
+    const { source, destination, baseCommit } = makeRepos();
+    writeFileSync(join(source, 'src', 'app.ts'), 'export const value = 7;\n');
+    writeFileSync(join(source, 'notes.md'), 'source note\n');
+    const beforeTracked = readFileSync(join(destination, 'src', 'app.ts'), 'utf8');
+    let lockedDestination = false;
+    const exec: ExecFileAsyncLike = async (file, args, options) => {
+      const stdout = execFileSync(file, args, {
+        cwd: options.cwd,
+        encoding: 'utf8',
+        maxBuffer: options.maxBuffer,
+        timeout: options.timeout,
+      });
+      if (
+        file === 'git' &&
+        args[0] === 'apply' &&
+        args.length === 2 &&
+        options.cwd === destination
+      ) {
+        chmodSync(destination, 0o555);
+        lockedDestination = true;
+      }
+      return { stdout, stderr: '' };
+    };
+
+    try {
+      const result = await applyFixture({
+        source,
+        destination,
+        baseCommit,
+        approvedUntrackedPaths: ['notes.md'],
+        exec,
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error('expected apply failure');
+      expect(result.conflicts[0]).toMatchObject({ code: 'DESTINATION_CONFLICT' });
+    } finally {
+      if (lockedDestination) chmodSync(destination, 0o755);
+    }
+    expect(readFileSync(join(destination, 'src', 'app.ts'), 'utf8')).toBe(
+      beforeTracked
+    );
+    expect(existsSync(join(destination, 'notes.md'))).toBe(false);
+    expect(git(destination, ['status', '--porcelain=v1'])).toBe('');
+  });
+
+  it('returns a typed failure when the destination is unavailable', async () => {
+    const { source, destination, baseCommit } = makeRepos();
+    writeFileSync(join(source, 'src', 'app.ts'), 'export const value = 8;\n');
+    rmSync(destination, { recursive: true, force: true });
+
+    const result = await applyFixture({ source, destination, baseCommit });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected unavailable destination failure');
+    expect(result.conflicts[0]).toMatchObject({ code: 'DESTINATION_UNAVAILABLE' });
   });
 
   it('rejects denied grants and oversized approved files before destination writes', async () => {

--- a/test/handoff-transfer.test.ts
+++ b/test/handoff-transfer.test.ts
@@ -1,0 +1,281 @@
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { isHandoffRun, type HandoffRequiredGrant } from '../shared/handoff.js';
+import { planHandoffSnapshot } from '../server/handoff-planner.js';
+import { applyHandoffTransfer } from '../server/handoff-transfer.js';
+
+const SOURCE_NODE = 'local-node';
+const DESTINATION_NODE = 'hub-node';
+
+const tempRoots: string[] = [];
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_DATE: '2026-05-21T12:00:00Z',
+      GIT_COMMITTER_DATE: '2026-05-21T12:00:00Z',
+    },
+  });
+}
+
+function gitCommit(cwd: string, message: string): void {
+  git(cwd, [
+    '-c',
+    'user.name=Relay Test',
+    '-c',
+    'user.email=relay@example.test',
+    'commit',
+    '-m',
+    message,
+  ]);
+}
+
+function makeRepos(): { root: string; seed: string; source: string; destination: string; baseCommit: string } {
+  const root = mkdtempSync(join(tmpdir(), 'relay-handoff-transfer-test-'));
+  tempRoots.push(root);
+  const seed = join(root, 'seed');
+  const source = join(root, 'source');
+  const destination = join(root, 'destination');
+
+  mkdirSync(seed, { recursive: true });
+  git(seed, ['init', '-b', 'nightly']);
+  writeFileSync(join(seed, 'README.md'), '# relay fixture\n');
+  mkdirSync(join(seed, 'src'));
+  writeFileSync(join(seed, 'src', 'app.ts'), 'export const value = 1;\n');
+  git(seed, ['add', '.']);
+  gitCommit(seed, 'initial fixture');
+  const baseCommit = git(seed, ['rev-parse', 'HEAD']).trim();
+
+  git(root, ['clone', seed, source]);
+  git(root, ['clone', seed, destination]);
+
+  return { root, seed, source, destination, baseCommit };
+}
+
+function createIdFactory(): () => string {
+  let id = 0;
+  return () => `handoff-test-id-${++id}`;
+}
+
+async function applyFixture(input: {
+  source: string;
+  destination: string;
+  baseCommit: string;
+  approvedUntrackedPaths?: readonly string[];
+  requiredGrants?: readonly HandoffRequiredGrant[];
+  maxUntrackedFileBytes?: number;
+}) {
+  const dryRun = await planHandoffSnapshot({
+    repoPath: input.source,
+    nodeId: SOURCE_NODE,
+    approvedUntrackedPaths: input.approvedUntrackedPaths,
+  });
+  return applyHandoffTransfer({
+    requestId: 'handoff-request-test',
+    planId: 'handoff-plan-test',
+    snapshotId: 'handoff-snapshot-test',
+    sourceRepoPath: input.source,
+    destinationRepoPath: input.destination,
+    sourceNodeId: SOURCE_NODE,
+    destinationNodeId: DESTINATION_NODE,
+    baseCommit: input.baseCommit,
+    approvedUntrackedPaths: input.approvedUntrackedPaths,
+    requiredGrants: input.requiredGrants,
+    expectedDryRun: dryRun,
+    maxUntrackedFileBytes: input.maxUntrackedFileBytes,
+    now: () => '2026-05-21T12:00:00.000Z',
+    createId: createIdFactory(),
+  });
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('applyHandoffTransfer', () => {
+  it('completes a clean git-backed handoff without touching destination files', async () => {
+    const { source, destination, baseCommit } = makeRepos();
+    const before = readFileSync(join(destination, 'src', 'app.ts'), 'utf8');
+
+    const result = await applyFixture({ source, destination, baseCommit });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected success');
+    expect(isHandoffRun(result.run)).toBe(true);
+    expect(result.run.state).toBe('complete');
+    expect(result.run.transitions.map((transition) => transition.to)).toEqual([
+      'snapshotting',
+      'transferring',
+      'applying',
+      'complete',
+    ]);
+    expect(result.trackedPatch.applied).toBe(false);
+    expect(readFileSync(join(destination, 'src', 'app.ts'), 'utf8')).toBe(before);
+    expect(git(destination, ['status', '--porcelain=v1'])).toBe('');
+  });
+
+  it('applies a tracked dirty diff as a patch against the planned base', async () => {
+    const { source, destination, baseCommit } = makeRepos();
+    writeFileSync(join(source, 'src', 'app.ts'), 'export const value = 2;\n');
+
+    const result = await applyFixture({ source, destination, baseCommit });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected success');
+    expect(result.trackedPatch.applied).toBe(true);
+    expect(result.trackedPatch.byteCount).toBeGreaterThan(0);
+    expect(readFileSync(join(destination, 'src', 'app.ts'), 'utf8')).toBe(
+      'export const value = 2;\n'
+    );
+    expect(result.auditEvents.some((event) => event.sha256)).toBe(true);
+  });
+
+  it('copies only explicitly approved untracked files and leaves secrets/caches absent', async () => {
+    const { source, destination, baseCommit } = makeRepos();
+    writeFileSync(join(source, 'notes.md'), 'safe note\n');
+    writeFileSync(join(source, '.env'), 'TOKEN=do-not-copy\n');
+    mkdirSync(join(source, 'node_modules'));
+    writeFileSync(join(source, 'node_modules', 'cache.txt'), 'cache\n');
+
+    const result = await applyFixture({
+      source,
+      destination,
+      baseCommit,
+      approvedUntrackedPaths: ['notes.md', '.env', 'node_modules/cache.txt'],
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected success');
+    expect(result.approvedUntrackedFiles.map((file) => file.path)).toEqual([
+      'notes.md',
+    ]);
+    expect(readFileSync(join(destination, 'notes.md'), 'utf8')).toBe('safe note\n');
+    expect(existsSync(join(destination, '.env'))).toBe(false);
+    expect(existsSync(join(destination, 'node_modules', 'cache.txt'))).toBe(false);
+  });
+
+  it('rejects source base mismatch before touching the destination', async () => {
+    const { source, destination, baseCommit } = makeRepos();
+    writeFileSync(join(source, 'src', 'app.ts'), 'export const value = 3;\n');
+    git(source, ['add', 'src/app.ts']);
+    gitCommit(source, 'advance source');
+    const before = readFileSync(join(destination, 'src', 'app.ts'), 'utf8');
+
+    const result = await applyFixture({ source, destination, baseCommit });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.conflicts[0]).toMatchObject({ code: 'STALE_SOURCE' });
+    expect(readFileSync(join(destination, 'src', 'app.ts'), 'utf8')).toBe(before);
+    expect(git(destination, ['status', '--porcelain=v1'])).toBe('');
+  });
+
+  it('rejects destination base mismatch before applying the source patch', async () => {
+    const { source, destination, baseCommit } = makeRepos();
+    writeFileSync(join(source, 'src', 'app.ts'), 'export const value = 4;\n');
+    writeFileSync(join(destination, 'README.md'), '# destination advanced\n');
+    git(destination, ['add', 'README.md']);
+    gitCommit(destination, 'advance destination');
+    const before = readFileSync(join(destination, 'src', 'app.ts'), 'utf8');
+
+    const result = await applyFixture({ source, destination, baseCommit });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.conflicts[0]).toMatchObject({ code: 'BASE_MISMATCH' });
+    expect(readFileSync(join(destination, 'src', 'app.ts'), 'utf8')).toBe(before);
+  });
+
+  it('rejects destination dirty state before applying a patch', async () => {
+    const { source, destination, baseCommit } = makeRepos();
+    writeFileSync(join(source, 'src', 'app.ts'), 'export const value = 5;\n');
+    writeFileSync(join(destination, 'src', 'app.ts'), 'export const local = 99;\n');
+
+    const result = await applyFixture({ source, destination, baseCommit });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.conflicts[0]).toMatchObject({ code: 'DESTINATION_DIRTY' });
+    expect(readFileSync(join(destination, 'src', 'app.ts'), 'utf8')).toBe(
+      'export const local = 99;\n'
+    );
+  });
+
+  it('rejects untracked collisions before applying any tracked patch', async () => {
+    const { source, destination, baseCommit } = makeRepos();
+    writeFileSync(join(source, 'src', 'app.ts'), 'export const value = 6;\n');
+    writeFileSync(join(source, 'notes.md'), 'source note\n');
+    writeFileSync(join(destination, 'notes.md'), 'destination note\n');
+    const beforeTracked = readFileSync(join(destination, 'src', 'app.ts'), 'utf8');
+
+    const result = await applyFixture({
+      source,
+      destination,
+      baseCommit,
+      approvedUntrackedPaths: ['notes.md'],
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.conflicts[0]).toMatchObject({ code: 'UNTRACKED_COLLISION' });
+    expect(readFileSync(join(destination, 'notes.md'), 'utf8')).toBe(
+      'destination note\n'
+    );
+    expect(readFileSync(join(destination, 'src', 'app.ts'), 'utf8')).toBe(
+      beforeTracked
+    );
+  });
+
+  it('rejects denied grants and oversized approved files before destination writes', async () => {
+    const { source, destination, baseCommit } = makeRepos();
+    const deniedGrant: HandoffRequiredGrant = {
+      leg: 'destination-write',
+      nodeId: DESTINATION_NODE,
+      capability: 'rpc:fs:write',
+      decision: 'deny',
+    };
+
+    const denied = await applyFixture({
+      source,
+      destination,
+      baseCommit,
+      requiredGrants: [deniedGrant],
+    });
+    expect(denied.ok).toBe(false);
+    if (denied.ok) throw new Error('expected denied grant failure');
+    expect(denied.conflicts[0]).toMatchObject({
+      code: 'MISSING_CAPABILITY_GRANT',
+    });
+
+    writeFileSync(join(source, 'big.bin'), 'too-large-for-test');
+    const oversized = await applyFixture({
+      source,
+      destination,
+      baseCommit,
+      approvedUntrackedPaths: ['big.bin'],
+      maxUntrackedFileBytes: 4,
+    });
+    expect(oversized.ok).toBe(false);
+    if (oversized.ok) throw new Error('expected oversized failure');
+    expect(oversized.conflicts[0]).toMatchObject({ code: 'CACHE_EXCLUDED' });
+    expect(existsSync(join(destination, 'big.bin'))).toBe(false);
+    expect(git(destination, ['status', '--porcelain=v1'])).toBe('');
+  });
+});


### PR DESCRIPTION
Closes #690
Refs #683, #679

## Summary
- add a backend handoff transfer/apply engine for confirmed git-backed snapshots
- apply tracked dirty state as a checked git patch and copy only explicitly approved safe untracked files
- enforce source/destination preconditions, denied grants, size/collision checks, and audit/run progress records without raw payloads

## Verification
- npm test -- test/handoff-transfer.test.ts
- npm run check
- npm run build
- npm test -- test/handoff-transfer.test.ts test/handoff.test.ts
- npm test -- test/handoff-planner.test.ts test/handoff-destination.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced handoff transfer functionality enabling code changes to be applied between repositories with validation and conflict detection.
  * Supports both tracked and untracked file transfers with comprehensive safety checks and state management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->