### PR TITLE
Implement cold handoff API and CLI gateway

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -331,6 +331,27 @@ function parseGatewayCreateInput(
   return input;
 }
 
+function parseGatewayInputObject(
+  commandName: RelayCliGatewayCommand,
+  commandArgs: string[]
+): Record<string, unknown> {
+  const inputJson = gatewayArg(commandArgs, '--input-json');
+  if (inputJson) return parseGatewayJson(commandName, inputJson);
+  const inputFile = gatewayArg(commandArgs, '--input-file');
+  if (inputFile) {
+    try {
+      return parseGatewayJson(
+        commandName,
+        fs.readFileSync(path.resolve(inputFile), 'utf8')
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      gatewayInvalid(commandName, `could not read --input-file: ${message}`);
+    }
+  }
+  return {};
+}
+
 async function gatewayHttpJson(input: {
   commandName: RelayCliGatewayCommand;
   pathName: string;
@@ -419,7 +440,7 @@ function requireGatewaySessionId(
 
 function gatewayUsage(): never {
   logger.error(
-    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions renew|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|events subscribe) --json'
+    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions renew|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|files write|work-contexts get|handoffs plan|handoffs create|handoffs status|handoffs cancel|handoffs resume|artifacts read|events subscribe) --json'
   );
   process.exit(1);
 }
@@ -1467,6 +1488,99 @@ async function runGatewayFiles(gatewayArgs: string[]): Promise<never> {
   printGatewayEnvelope(gatewayOk(commandName, result), 0);
 }
 
+async function runGatewayWorkContexts(gatewayArgs: string[]): Promise<never> {
+  const subcommand = gatewayArgs[1];
+  const workContextArgs = gatewayArgs.slice(2);
+  if (subcommand !== 'get') {
+    gatewayInvalid('work-contexts.get', 'unknown work-contexts command', { args: gatewayArgs });
+  }
+  const id = gatewayArg(workContextArgs, '--id') ?? workContextArgs[0];
+  if (!id || id.startsWith('--')) gatewayInvalid('work-contexts.get', '--id is required');
+  const result = await gatewayHttpJson({
+    commandName: 'work-contexts.get',
+    pathName: `/work-contexts/${encodeURIComponent(id)}`,
+    capabilities: ['session:read'],
+  });
+  printGatewayEnvelope(gatewayOk('work-contexts.get', result), 0);
+}
+
+async function runGatewayHandoffs(gatewayArgs: string[]): Promise<never> {
+  const subcommand = gatewayArgs[1];
+  const handoffArgs = gatewayArgs.slice(2);
+  if (subcommand === 'plan') {
+    const input = parseGatewayInputObject('handoffs.plan', handoffArgs);
+    const result = await gatewayHttpJson({
+      commandName: 'handoffs.plan',
+      pathName: '/handoffs/plan',
+      method: 'POST',
+      body: input,
+      capabilities: ['session:read', 'rpc:fs:read'],
+    });
+    printGatewayEnvelope(gatewayOk('handoffs.plan', result), 0);
+  }
+  if (subcommand === 'create') {
+    const input = parseGatewayInputObject('handoffs.create', handoffArgs);
+    const result = await gatewayHttpJson({
+      commandName: 'handoffs.create',
+      pathName: '/handoffs/create',
+      method: 'POST',
+      body: input,
+      capabilities: ['rpc:fs:read', 'rpc:fs:write', 'session:create:agent', 'pty:exec:arbitrary'],
+    });
+    printGatewayEnvelope(gatewayOk('handoffs.create', result), 0);
+  }
+  if (subcommand === 'status') {
+    const runId = gatewayArg(handoffArgs, '--run-id') ?? handoffArgs[0];
+    if (!runId || runId.startsWith('--')) gatewayInvalid('handoffs.status', '--run-id is required');
+    const result = await gatewayHttpJson({
+      commandName: 'handoffs.status',
+      pathName: `/handoffs/${encodeURIComponent(runId)}/status`,
+      capabilities: ['session:read'],
+    });
+    printGatewayEnvelope(gatewayOk('handoffs.status', result), 0);
+  }
+  if (subcommand === 'cancel') {
+    const runId = gatewayArg(handoffArgs, '--run-id') ?? handoffArgs[0];
+    if (!runId || runId.startsWith('--')) gatewayInvalid('handoffs.cancel', '--run-id is required');
+    const actorId = gatewayArg(handoffArgs, '--actor-id');
+    const result = await gatewayHttpJson({
+      commandName: 'handoffs.cancel',
+      pathName: `/handoffs/${encodeURIComponent(runId)}/cancel`,
+      method: 'POST',
+      body: actorId ? { actorId } : {},
+      capabilities: ['session:read'],
+    });
+    printGatewayEnvelope(gatewayOk('handoffs.cancel', result), 0);
+  }
+  if (subcommand === 'resume') {
+    const runId = gatewayArg(handoffArgs, '--run-id') ?? handoffArgs[0];
+    if (!runId || runId.startsWith('--')) gatewayInvalid('handoffs.resume', '--run-id is required');
+    const result = await gatewayHttpJson({
+      commandName: 'handoffs.resume',
+      pathName: `/handoffs/${encodeURIComponent(runId)}/resume`,
+      capabilities: ['session:read'],
+    });
+    printGatewayEnvelope(gatewayOk('handoffs.resume', result), 0);
+  }
+  gatewayInvalid('handoffs.plan', 'unknown handoffs command', { args: gatewayArgs });
+}
+
+async function runGatewayArtifacts(gatewayArgs: string[]): Promise<never> {
+  const subcommand = gatewayArgs[1];
+  const artifactArgs = gatewayArgs.slice(2);
+  if (subcommand !== 'read') {
+    gatewayInvalid('artifacts.read', 'unknown artifacts command', { args: gatewayArgs });
+  }
+  const ref = gatewayArg(artifactArgs, '--ref') ?? artifactArgs[0];
+  if (!ref || ref.startsWith('--')) gatewayInvalid('artifacts.read', '--ref is required');
+  const result = await gatewayHttpJson({
+    commandName: 'artifacts.read',
+    pathName: `/handoffs/artifacts/${encodeURIComponent(ref)}`,
+    capabilities: ['session:read'],
+  });
+  printGatewayEnvelope(gatewayOk('artifacts.read', result), 0);
+}
+
 function parseEventsSubscribeTopic(
   value: string | undefined
 ): EventsSubscribeTopic {
@@ -1760,6 +1874,9 @@ async function runGatewayV1(): Promise<never> {
   if (top === 'nodes') return runGatewayNodes(gatewayArgs);
   if (top === 'sessions') return runGatewaySessions(gatewayArgs);
   if (top === 'files') return runGatewayFiles(gatewayArgs);
+  if (top === 'work-contexts') return runGatewayWorkContexts(gatewayArgs);
+  if (top === 'handoffs') return runGatewayHandoffs(gatewayArgs);
+  if (top === 'artifacts') return runGatewayArtifacts(gatewayArgs);
   if (top === 'events') return runGatewayEvents(gatewayArgs);
   gatewayInvalid('contract.list', 'unknown v1 gateway command', {
     args: gatewayArgs,

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -1525,7 +1525,7 @@ async function runGatewayHandoffs(gatewayArgs: string[]): Promise<never> {
       pathName: '/handoffs/create',
       method: 'POST',
       body: input,
-      capabilities: ['rpc:fs:read', 'rpc:fs:write', 'session:create:agent', 'pty:exec:arbitrary'],
+      capabilities: ['rpc:fs:read', 'rpc:fs:write', 'session:create:agent', 'session:create:terminal', 'pty:exec:arbitrary'],
     });
     printGatewayEnvelope(gatewayOk('handoffs.create', result), 0);
   }

--- a/server/handoff-transfer.ts
+++ b/server/handoff-transfer.ts
@@ -325,7 +325,28 @@ function failResult(
 function deniedGrantConflicts(
   grants: readonly HandoffRequiredGrant[] | undefined
 ): HandoffConflict[] {
-  return (grants ?? [])
+  const grantList = grants ?? [];
+  const allowedLegs = new Set(
+    grantList.filter((grant) => grant.decision === 'allow').map((grant) => grant.leg)
+  );
+  const requiredLegs: readonly HandoffRequiredGrant['leg'][] = [
+    'source-read',
+    'destination-write',
+    'destination-session-create',
+    'destination-exec',
+  ];
+  const missing = requiredLegs
+    .filter((leg) => !allowedLegs.has(leg))
+    .map((leg) => {
+      const grant = grantList.find((candidate) => candidate.leg === leg);
+      return makeConflict(
+        'MISSING_CAPABILITY_GRANT',
+        `handoff grant ${leg} is not confirmed`,
+        grant?.nodeId ?? 'unknown',
+        'FAILED_MISSING_GRANT'
+      );
+    });
+  const denied = grantList
     .filter((grant) => grant.decision !== 'allow')
     .map((grant) =>
       makeConflict(
@@ -335,6 +356,7 @@ function deniedGrantConflicts(
         'FAILED_MISSING_GRANT'
       )
     );
+  return [...missing, ...denied];
 }
 
 async function prepareApprovedUntrackedFiles(input: {

--- a/server/handoffs.ts
+++ b/server/handoffs.ts
@@ -107,6 +107,10 @@ interface StoredRun {
   artifacts: HandoffArtifactSummary[];
 }
 
+export type HandoffCapabilityContext = readonly string[] | ReadonlySet<string>;
+
+export type HandoffCapabilityProvider = (req: Parameters<RequestHandler>[0]) => HandoffCapabilityContext | null | undefined;
+
 export interface HandoffArtifactSummary {
   id: string;
   runId?: string;
@@ -692,14 +696,18 @@ function bodyRecord(req: Parameters<RequestHandler>[0]): Record<string, unknown>
     : {};
 }
 
-function capabilityHeader(req: Parameters<RequestHandler>[0]): Set<string> | null {
-  const raw = req.header('x-relay-capabilities');
-  if (!raw) return null;
-  return new Set(raw.split(/[\s,]+/).map((item) => item.trim()).filter(Boolean));
+function capabilitySet(context: HandoffCapabilityContext | null | undefined): Set<string> | null {
+  if (!context) return null;
+  const items = Array.isArray(context) ? context : Array.from(context);
+  return new Set(items.map((item) => item.trim()).filter(Boolean));
 }
 
-function requireCapabilities(req: Parameters<RequestHandler>[0], capabilities: readonly string[]): ReturnType<typeof apiError> | null {
-  const provided = capabilityHeader(req);
+function requireCapabilities(
+  req: Parameters<RequestHandler>[0],
+  capabilities: readonly string[],
+  capabilityContext: HandoffCapabilityProvider
+): ReturnType<typeof apiError> | null {
+  const provided = capabilitySet(capabilityContext(req));
   if (!provided) {
     return apiError('CAPABILITY_DENIED', 'missing validated capability context for handoff route', 403, { missingCapabilities: capabilities });
   }
@@ -726,11 +734,13 @@ function planFromCreateBody(body: Record<string, unknown>, service: HandoffServi
 export function createHandoffRouter(input: {
   service?: HandoffService;
   requireAuth?: RequestHandler;
+  getCapabilities?: HandoffCapabilityProvider;
   workContextStore?: WorkContextStore;
   getSession?: (nodeId: string, sessionId: string) => unknown | undefined;
 } = {}): Router {
   const router = Router();
   const auth = input.requireAuth ?? ((_req, _res, next) => next());
+  const capabilityContext = input.getCapabilities ?? (() => null);
   const service =
     input.service ??
     new HandoffService({
@@ -739,7 +749,7 @@ export function createHandoffRouter(input: {
     });
 
   router.post('/plan', auth, async (req, res) => {
-    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY, 'rpc:fs:read']);
+    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY, 'rpc:fs:read'], capabilityContext);
     if (denied) {
       res.status(denied.status).json(denied.body);
       return;
@@ -760,7 +770,7 @@ export function createHandoffRouter(input: {
 
   router.post('/create', auth, async (req, res) => {
     const body = bodyRecord(req);
-    const denied = requireCapabilities(req, createRouteCapabilities(planFromCreateBody(body, service)));
+    const denied = requireCapabilities(req, createRouteCapabilities(planFromCreateBody(body, service)), capabilityContext);
     if (denied) {
       res.status(denied.status).json(denied.body);
       return;
@@ -782,7 +792,7 @@ export function createHandoffRouter(input: {
   });
 
   router.get('/:runId/status', auth, (req, res) => {
-    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY]);
+    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY], capabilityContext);
     if (denied) {
       res.status(denied.status).json(denied.body);
       return;
@@ -797,7 +807,7 @@ export function createHandoffRouter(input: {
   });
 
   router.post('/:runId/cancel', auth, (req, res) => {
-    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY]);
+    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY], capabilityContext);
     if (denied) {
       res.status(denied.status).json(denied.body);
       return;
@@ -812,7 +822,7 @@ export function createHandoffRouter(input: {
   });
 
   router.get('/:runId/resume', auth, (req, res) => {
-    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY]);
+    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY], capabilityContext);
     if (denied) {
       res.status(denied.status).json(denied.body);
       return;
@@ -827,7 +837,7 @@ export function createHandoffRouter(input: {
   });
 
   router.get('/artifacts/:ref', auth, (req, res) => {
-    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY]);
+    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY], capabilityContext);
     if (denied) {
       res.status(denied.status).json(denied.body);
       return;

--- a/server/handoffs.ts
+++ b/server/handoffs.ts
@@ -25,6 +25,8 @@ import type { WorkContextStore } from './work-contexts.js';
 export const HANDOFF_PLAN_MAX_AGE_MS = 5 * 60 * 1000;
 export const HANDOFF_STATUS_MAX_CONFLICTS = 25;
 
+const SESSION_READ_CAPABILITY = 'session:read';
+
 const REQUIRED_EXECUTE_GRANT_LEGS: readonly HandoffRequiredGrantLeg[] = [
   'source-read',
   'destination-write',
@@ -184,6 +186,34 @@ function hasRequiredExecuteGrantLegs(grants: readonly HandoffRequiredGrant[]): b
   return REQUIRED_EXECUTE_GRANT_LEGS.every((leg) => allowed.has(leg));
 }
 
+function scopesMatch(a: HandoffRequiredGrant['scope'], b: HandoffRequiredGrant['scope']): boolean {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
+function confirmedGrantEnvelopeConflicts(
+  plan: HandoffPlan,
+  confirmedGrants: readonly HandoffRequiredGrant[] | undefined
+): HandoffConflict[] {
+  if (!confirmedGrants || confirmedGrants.length === 0) return [];
+  const plannedByLeg = new Map(plan.requiredGrants.map((grant) => [grant.leg, grant]));
+  const conflicts: HandoffConflict[] = [];
+  for (const confirmed of confirmedGrants) {
+    const planned = plannedByLeg.get(confirmed.leg);
+    if (!planned) {
+      conflicts.push(conflict('MISSING_CAPABILITY_GRANT', `confirmed grant leg ${confirmed.leg} is not in the planned grant set`, plan.route.destinationNodeId, 'FAILED_MISSING_GRANT'));
+      continue;
+    }
+    if (
+      confirmed.nodeId !== planned.nodeId ||
+      confirmed.capability !== planned.capability ||
+      (confirmed.scope !== undefined && !scopesMatch(confirmed.scope, planned.scope))
+    ) {
+      conflicts.push(conflict('MISSING_CAPABILITY_GRANT', `confirmed grant ${confirmed.leg} does not match the planned node/capability/scope envelope`, planned.nodeId, 'FAILED_MISSING_GRANT'));
+    }
+  }
+  return conflicts;
+}
+
 function missingConfirmedGrantConflicts(plan: HandoffPlan): HandoffConflict[] {
   const allowed = new Set(
     plan.requiredGrants
@@ -244,11 +274,38 @@ function applyConfirmedGrants(
   const byLeg = new Map(confirmedGrants.map((grant) => [grant.leg, grant]));
   return {
     ...plan,
-    requiredGrants: plan.requiredGrants.map((grant) => ({
-      ...grant,
-      ...(byLeg.get(grant.leg) ?? {}),
-    })),
+    requiredGrants: plan.requiredGrants.map((plannedGrant) => {
+      const confirmed = byLeg.get(plannedGrant.leg);
+      if (!confirmed) return plannedGrant;
+      return {
+        ...plannedGrant,
+        ...(confirmed.decision !== undefined ? { decision: confirmed.decision } : {}),
+        ...(confirmed.grantRef !== undefined ? { grantRef: confirmed.grantRef } : {}),
+      };
+    }),
   };
+}
+
+function validateTransferPathBindings(
+  plan: HandoffPlan,
+  stored: StoredPlan | undefined,
+  input: Pick<HandoffCreateInput, 'sourceRepoPath' | 'destinationRepoPath'>
+): ReturnType<typeof apiError> | null {
+  if (!stored) return null;
+  if (input.sourceRepoPath && stored.sourceRepoPath && input.sourceRepoPath !== stored.sourceRepoPath) {
+    return apiError('INVALID_REQUEST', 'handoff execute sourceRepoPath does not match the stored plan source path', 400, {
+      planId: plan.id,
+      field: 'sourceRepoPath',
+    });
+  }
+  const expectedDestinationRepoPath = plan.destinationProposal.cwd || stored.request.destination.cwd;
+  if (input.destinationRepoPath && input.destinationRepoPath !== expectedDestinationRepoPath) {
+    return apiError('INVALID_REQUEST', 'handoff execute destinationRepoPath does not match the planned destination path', 400, {
+      planId: plan.id,
+      field: 'destinationRepoPath',
+    });
+  }
+  return null;
 }
 
 function dryRunConflictReason(conflicts: readonly HandoffConflict[]): HandoffApiErrorCode | null {
@@ -404,6 +461,19 @@ export class HandoffService {
         };
       }
     }
+    const envelopeConflicts = confirmedGrantEnvelopeConflicts(rawPlan, input.confirmedGrants);
+    if (envelopeConflicts.length > 0) {
+      const run = this.createFailedRun(rawPlan, envelopeConflicts, 'FAILED_MISSING_GRANT', input.actorId, input.now);
+      return {
+        ok: false,
+        error: apiError('CAPABILITY_DENIED', 'confirmed handoff grants must match the immutable planned grant envelope', 403, {
+          planId: rawPlan.id,
+          conflicts: envelopeConflicts.slice(0, HANDOFF_STATUS_MAX_CONFLICTS),
+        }, 'FAILED_MISSING_GRANT'),
+        run,
+      };
+    }
+
     const plan = applyConfirmedGrants(rawPlan, input.confirmedGrants);
     const grantConflicts = missingConfirmedGrantConflicts(plan);
     if (!hasRequiredExecuteGrantLegs(plan.requiredGrants)) {
@@ -417,6 +487,9 @@ export class HandoffService {
         run,
       };
     }
+
+    const pathBindingError = validateTransferPathBindings(plan, stored, input);
+    if (pathBindingError) return { ok: false, error: pathBindingError };
 
     if (input.sourceRepoPath && input.destinationRepoPath && stored?.dryRun?.baseCommit) {
       const transferInput: HandoffTransferApplyInput = {
@@ -547,6 +620,10 @@ export class HandoffService {
     return null;
   }
 
+  getPlan(planId: string): HandoffPlan | null {
+    return this.plans.get(planId)?.plan ?? null;
+  }
+
   private createFailedRun(
     plan: HandoffPlan,
     conflicts: HandoffConflict[],
@@ -623,10 +700,27 @@ function capabilityHeader(req: Parameters<RequestHandler>[0]): Set<string> | nul
 
 function requireCapabilities(req: Parameters<RequestHandler>[0], capabilities: readonly string[]): ReturnType<typeof apiError> | null {
   const provided = capabilityHeader(req);
-  if (!provided) return null;
+  if (!provided) {
+    return apiError('CAPABILITY_DENIED', 'missing validated capability context for handoff route', 403, { missingCapabilities: capabilities });
+  }
   const missing = capabilities.filter((capability) => !provided.has(capability));
   if (missing.length === 0) return null;
   return apiError('CAPABILITY_DENIED', `missing required capability: ${missing[0]}`, 403, { missingCapabilities: missing });
+}
+
+function createRouteCapabilities(plan: HandoffPlan | null): readonly string[] {
+  const sessionCreateCapability = plan?.launchPreview.runtime.kind === 'terminal'
+    ? 'session:create:terminal'
+    : 'session:create:agent';
+  return ['rpc:fs:read', 'rpc:fs:write', sessionCreateCapability, 'pty:exec:arbitrary'];
+}
+
+function planFromCreateBody(body: Record<string, unknown>, service: HandoffService): HandoffPlan | null {
+  const inlinePlan = body['plan'];
+  if (isHandoffPlan(inlinePlan)) return inlinePlan;
+  const planId = body['planId'];
+  if (typeof planId === 'string') return service.getPlan(planId);
+  return null;
 }
 
 export function createHandoffRouter(input: {
@@ -645,7 +739,7 @@ export function createHandoffRouter(input: {
     });
 
   router.post('/plan', auth, async (req, res) => {
-    const denied = requireCapabilities(req, ['session:read', 'rpc:fs:read']);
+    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY, 'rpc:fs:read']);
     if (denied) {
       res.status(denied.status).json(denied.body);
       return;
@@ -665,17 +759,12 @@ export function createHandoffRouter(input: {
   });
 
   router.post('/create', auth, async (req, res) => {
-    const denied = requireCapabilities(req, [
-      'rpc:fs:read',
-      'rpc:fs:write',
-      'session:create:agent',
-      'pty:exec:arbitrary',
-    ]);
+    const body = bodyRecord(req);
+    const denied = requireCapabilities(req, createRouteCapabilities(planFromCreateBody(body, service)));
     if (denied) {
       res.status(denied.status).json(denied.body);
       return;
     }
-    const body = bodyRecord(req);
     const result = await service.create({
       ...(typeof body['planId'] === 'string' ? { planId: body['planId'] } : {}),
       ...(body['plan'] ? { plan: body['plan'] as HandoffPlan } : {}),
@@ -693,6 +782,11 @@ export function createHandoffRouter(input: {
   });
 
   router.get('/:runId/status', auth, (req, res) => {
+    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY]);
+    if (denied) {
+      res.status(denied.status).json(denied.body);
+      return;
+    }
     const status = service.getStatus(req.params['runId'] ?? '');
     if (!status) {
       const error = apiError('HANDOFF_RUN_NOT_FOUND', 'handoff run was not found', 404, { runId: req.params['runId'] });
@@ -703,6 +797,11 @@ export function createHandoffRouter(input: {
   });
 
   router.post('/:runId/cancel', auth, (req, res) => {
+    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY]);
+    if (denied) {
+      res.status(denied.status).json(denied.body);
+      return;
+    }
     const status = service.cancel(req.params['runId'] ?? '', bodyRecord(req)['actorId'] as string | undefined);
     if (!status) {
       const error = apiError('HANDOFF_RUN_NOT_FOUND', 'handoff run was not found', 404, { runId: req.params['runId'] });
@@ -713,6 +812,11 @@ export function createHandoffRouter(input: {
   });
 
   router.get('/:runId/resume', auth, (req, res) => {
+    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY]);
+    if (denied) {
+      res.status(denied.status).json(denied.body);
+      return;
+    }
     const resume = service.resume(req.params['runId'] ?? '');
     if (!resume) {
       const error = apiError('HANDOFF_RUN_NOT_FOUND', 'handoff run was not found', 404, { runId: req.params['runId'] });
@@ -723,6 +827,11 @@ export function createHandoffRouter(input: {
   });
 
   router.get('/artifacts/:ref', auth, (req, res) => {
+    const denied = requireCapabilities(req, [SESSION_READ_CAPABILITY]);
+    if (denied) {
+      res.status(denied.status).json(denied.body);
+      return;
+    }
     const artifact = service.readArtifact(req.params['ref'] ?? '');
     if (!artifact) {
       const error = apiError('HANDOFF_ARTIFACT_NOT_FOUND', 'handoff artifact ref was not found', 404, { ref: req.params['ref'] });

--- a/server/handoffs.ts
+++ b/server/handoffs.ts
@@ -1,0 +1,736 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import { Router, type RequestHandler } from 'express';
+
+import {
+  HANDOFF_SCHEMA_VERSION,
+  isHandoffPlan,
+  isHandoffRequest,
+  type HandoffConflict,
+  type HandoffPlan,
+  type HandoffReasonCode,
+  type HandoffRequest,
+  type HandoffRequiredGrant,
+  type HandoffRequiredGrantLeg,
+  type HandoffRun,
+  type HandoffRunTransition,
+  type HandoffSnapshotGroup,
+} from '../shared/handoff.js';
+import { proposeHandoffDestination } from '../shared/handoff-destination.js';
+import type { RelayCapabilityBit } from '../shared/security-policy.js';
+import { planHandoffSnapshot, type HandoffPlannerDryRun } from './handoff-planner.js';
+import { applyHandoffTransfer, type HandoffTransferApplyInput } from './handoff-transfer.js';
+import type { WorkContextStore } from './work-contexts.js';
+
+export const HANDOFF_PLAN_MAX_AGE_MS = 5 * 60 * 1000;
+export const HANDOFF_STATUS_MAX_CONFLICTS = 25;
+
+const REQUIRED_EXECUTE_GRANT_LEGS: readonly HandoffRequiredGrantLeg[] = [
+  'source-read',
+  'destination-write',
+  'destination-session-create',
+  'destination-exec',
+];
+
+export type HandoffApiErrorCode =
+  | 'INVALID_REQUEST'
+  | 'INVALID_PLAN_ID'
+  | 'INVALID_WORK_CONTEXT_ID'
+  | 'INVALID_SESSION_ID'
+  | 'STALE_PLAN'
+  | 'CAPABILITY_DENIED'
+  | 'SOURCE_STALE_OR_OFFLINE'
+  | 'DESTINATION_UNAVAILABLE'
+  | 'MISSING_CONFIRMED_GRANT'
+  | 'HANDOFF_RUN_NOT_FOUND'
+  | 'HANDOFF_ARTIFACT_NOT_FOUND'
+  | 'HANDOFF_INTERNAL_ERROR';
+
+export interface HandoffApiErrorBody {
+  error: {
+    code: HandoffApiErrorCode;
+    message: string;
+    retryable: boolean;
+    reasonCode?: HandoffReasonCode;
+    details?: Record<string, unknown>;
+  };
+}
+
+export interface HandoffPlanInput {
+  request: HandoffRequest;
+  sourceRepoPath?: string;
+  approvedUntrackedPaths?: readonly string[];
+  dryRun?: HandoffPlannerDryRun;
+  sourceBranchName?: string;
+  now?: string;
+}
+
+export interface HandoffCreateInput {
+  planId?: string;
+  plan?: HandoffPlan;
+  confirmedGrants?: readonly HandoffRequiredGrant[];
+  sourceRepoPath?: string;
+  destinationRepoPath?: string;
+  approvedUntrackedPaths?: readonly string[];
+  actorId?: string;
+  now?: string;
+}
+
+export interface HandoffRunStatus {
+  run: HandoffRun;
+  progress: {
+    state: HandoffRun['state'];
+    terminal: boolean;
+    transitions: number;
+  };
+  redaction: {
+    rawSecretsAvailable: false;
+    rawLogsAvailable: false;
+    maxConflicts: typeof HANDOFF_STATUS_MAX_CONFLICTS;
+  };
+}
+
+interface StoredPlan {
+  plan: HandoffPlan;
+  request: HandoffRequest;
+  dryRun?: HandoffPlannerDryRun;
+  createdAtMs: number;
+  sourceRepoPath?: string;
+  approvedUntrackedPaths?: readonly string[];
+}
+
+interface StoredRun {
+  run: HandoffRun;
+  auditEvents: unknown[];
+  artifacts: HandoffArtifactSummary[];
+}
+
+export interface HandoffArtifactSummary {
+  id: string;
+  runId?: string;
+  planId?: string;
+  group: HandoffSnapshotGroup | 'resume-bundle' | 'audit-summary';
+  summary: string;
+  refs: string[];
+  byteCount?: number;
+  sha256?: string;
+  rawPayloadAvailable: false;
+  transcriptExportAvailable: false;
+}
+
+export interface HandoffServiceDeps {
+  workContextStore?: Pick<WorkContextStore, 'get'>;
+  getSession?: (nodeId: string, sessionId: string) => unknown | undefined;
+  now?: () => Date;
+  createId?: () => string;
+}
+
+function nowIso(deps: HandoffServiceDeps): string {
+  return (deps.now?.() ?? new Date()).toISOString();
+}
+
+function nowMs(deps: HandoffServiceDeps): number {
+  return (deps.now?.() ?? new Date()).getTime();
+}
+
+function createId(deps: HandoffServiceDeps, prefix: string): string {
+  return deps.createId?.() ?? `${prefix}-${randomUUID()}`;
+}
+
+function hashJson(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+function apiError(
+  code: HandoffApiErrorCode,
+  message: string,
+  status: number,
+  details?: Record<string, unknown>,
+  reasonCode?: HandoffReasonCode
+): { status: number; body: HandoffApiErrorBody } {
+  return {
+    status,
+    body: {
+      error: {
+        code,
+        message,
+        retryable: code === 'SOURCE_STALE_OR_OFFLINE' || code === 'DESTINATION_UNAVAILABLE' || code === 'STALE_PLAN',
+        ...(reasonCode ? { reasonCode } : {}),
+        ...(details ? { details } : {}),
+      },
+    },
+  };
+}
+
+function conflict(
+  code: HandoffConflict['code'],
+  message: string,
+  nodeId: string,
+  reasonCode: HandoffReasonCode
+): HandoffConflict {
+  return { code, message, nodeId, reasonCode };
+}
+
+function sanitizeRun(run: HandoffRun): HandoffRun {
+  return {
+    ...run,
+    conflicts: run.conflicts.slice(0, HANDOFF_STATUS_MAX_CONFLICTS),
+    transitions: run.transitions.slice(-HANDOFF_STATUS_MAX_CONFLICTS),
+  };
+}
+
+function hasRequiredExecuteGrantLegs(grants: readonly HandoffRequiredGrant[]): boolean {
+  const allowed = new Set(grants.filter((grant) => grant.decision === 'allow').map((grant) => grant.leg));
+  return REQUIRED_EXECUTE_GRANT_LEGS.every((leg) => allowed.has(leg));
+}
+
+function missingConfirmedGrantConflicts(plan: HandoffPlan): HandoffConflict[] {
+  const allowed = new Set(
+    plan.requiredGrants
+      .filter((grant) => grant.decision === 'allow')
+      .map((grant) => grant.leg)
+  );
+  return REQUIRED_EXECUTE_GRANT_LEGS
+    .filter((leg) => !allowed.has(leg))
+    .map((leg) => {
+      const planned = plan.requiredGrants.find((grant) => grant.leg === leg);
+      return conflict(
+        'MISSING_CAPABILITY_GRANT',
+        `handoff execute requires confirmed ${leg} grant`,
+        planned?.nodeId ?? plan.route.destinationNodeId,
+        'FAILED_MISSING_GRANT'
+      );
+    });
+}
+
+function defaultRequiredGrants(request: HandoffRequest): HandoffRequiredGrant[] {
+  const sessionCreateCapability: RelayCapabilityBit =
+    request.desiredRuntime.kind === 'terminal'
+      ? 'session:create:terminal'
+      : 'session:create:agent';
+  return [
+    {
+      leg: 'source-read',
+      nodeId: request.source.nodeId,
+      capability: 'rpc:fs:read',
+      scope: { kind: 'path', pathPrefixes: [request.source.cwd] },
+    },
+    {
+      leg: 'destination-write',
+      nodeId: request.destination.nodeId,
+      capability: 'rpc:fs:write',
+      scope: { kind: 'path', pathPrefixes: [request.destination.cwd] },
+    },
+    {
+      leg: 'destination-session-create',
+      nodeId: request.destination.nodeId,
+      capability: sessionCreateCapability,
+      scope: { kind: 'node' },
+    },
+    {
+      leg: 'destination-exec',
+      nodeId: request.destination.nodeId,
+      capability: 'pty:exec:arbitrary',
+      scope: { kind: 'node' },
+    },
+  ];
+}
+
+function applyConfirmedGrants(
+  plan: HandoffPlan,
+  confirmedGrants: readonly HandoffRequiredGrant[] | undefined
+): HandoffPlan {
+  if (!confirmedGrants || confirmedGrants.length === 0) return plan;
+  const byLeg = new Map(confirmedGrants.map((grant) => [grant.leg, grant]));
+  return {
+    ...plan,
+    requiredGrants: plan.requiredGrants.map((grant) => ({
+      ...grant,
+      ...(byLeg.get(grant.leg) ?? {}),
+    })),
+  };
+}
+
+function dryRunConflictReason(conflicts: readonly HandoffConflict[]): HandoffApiErrorCode | null {
+  if (conflicts.some((entry) => entry.code === 'STALE_SOURCE')) return 'SOURCE_STALE_OR_OFFLINE';
+  if (conflicts.some((entry) => entry.code === 'DESTINATION_UNAVAILABLE')) return 'DESTINATION_UNAVAILABLE';
+  return null;
+}
+
+async function dryRunForPlan(input: HandoffPlanInput): Promise<HandoffPlannerDryRun | undefined> {
+  if (input.dryRun) return input.dryRun;
+  if (!input.sourceRepoPath) return undefined;
+  return planHandoffSnapshot({
+    repoPath: input.sourceRepoPath,
+    nodeId: input.request.source.nodeId,
+    ...(input.approvedUntrackedPaths ? { approvedUntrackedPaths: input.approvedUntrackedPaths } : {}),
+  });
+}
+
+function buildPlan(input: {
+  id: string;
+  request: HandoffRequest;
+  dryRun?: HandoffPlannerDryRun;
+  createdAt: string;
+  sourceBranchName?: string;
+}): HandoffPlan {
+  const branchName = input.sourceBranchName ?? input.dryRun?.branchName ?? undefined;
+  const destinationProposal = branchName
+    ? proposeHandoffDestination({
+        source: input.request.source,
+        destination: input.request.destination.option,
+        sourceBranchName: branchName,
+      })
+    : proposeHandoffDestination({
+        source: input.request.source,
+        destination: input.request.destination.option,
+      });
+  const includedGroups = input.dryRun?.includedGroups ?? ['source-summary'];
+  const excludedGroups = input.dryRun?.excludedGroups ?? [];
+  const conflicts = input.dryRun?.conflicts ?? [];
+  return {
+    schemaVersion: HANDOFF_SCHEMA_VERSION,
+    id: input.id,
+    requestId: input.request.id,
+    createdAt: input.createdAt,
+    source: input.request.source,
+    route: {
+      sourceNodeId: input.request.source.nodeId,
+      destinationNodeId: input.request.destination.nodeId,
+      workContextId: input.request.source.workContextId,
+    },
+    transferMode: input.dryRun?.transferMode ?? 'metadata-only',
+    includedGroups,
+    excludedGroups,
+    fileCount: input.dryRun?.fileCount ?? 0,
+    byteCount: input.dryRun?.byteCount ?? 0,
+    destinationProposal,
+    pathMappings: [],
+    conflicts,
+    requiredGrants: defaultRequiredGrants(input.request),
+    launchPreview: {
+      nodeId: input.request.destination.nodeId,
+      cwd: input.request.destination.cwd,
+      runtime: input.request.desiredRuntime,
+      summary: 'create a destination session only after the cold handoff snapshot applies',
+      workContextId: input.request.source.workContextId,
+    },
+  };
+}
+
+export class HandoffService {
+  private readonly plans = new Map<string, StoredPlan>();
+  private readonly runs = new Map<string, StoredRun>();
+
+  constructor(private readonly deps: HandoffServiceDeps = {}) {}
+
+  async plan(input: HandoffPlanInput): Promise<{ ok: true; plan: HandoffPlan; dryRun?: HandoffPlannerDryRun } | { ok: false; error: ReturnType<typeof apiError> }> {
+    if (!isHandoffRequest(input.request)) {
+      return { ok: false, error: apiError('INVALID_REQUEST', 'handoff request does not match shared schema', 400) };
+    }
+    if (this.deps.workContextStore && !this.deps.workContextStore.get(input.request.source.workContextId)) {
+      return {
+        ok: false,
+        error: apiError('INVALID_WORK_CONTEXT_ID', 'source WorkContext was not found', 404, {
+          workContextId: input.request.source.workContextId,
+        }),
+      };
+    }
+    if (this.deps.getSession && !this.deps.getSession(input.request.source.nodeId, input.request.source.sessionId)) {
+      return {
+        ok: false,
+        error: apiError('INVALID_SESSION_ID', 'source session was not found', 404, {
+          nodeId: input.request.source.nodeId,
+          sessionId: input.request.source.sessionId,
+        }),
+      };
+    }
+    const dryRun = await dryRunForPlan(input);
+    const dryRunConflicts = dryRun?.conflicts ?? [];
+    const dryRunReason = dryRunConflicts.length > 0 ? dryRunConflictReason(dryRunConflicts) : null;
+    if (dryRunReason !== null) {
+      return {
+        ok: false,
+        error: apiError(dryRunReason, 'source or destination is not ready for handoff planning', dryRunReason === 'SOURCE_STALE_OR_OFFLINE' ? 409 : 503, {
+          conflicts: dryRunConflicts.slice(0, HANDOFF_STATUS_MAX_CONFLICTS),
+        }, dryRunConflicts[0]?.reasonCode),
+      };
+    }
+    const createdAt = input.now ?? nowIso(this.deps);
+    const planInput: {
+      id: string;
+      request: HandoffRequest;
+      dryRun?: HandoffPlannerDryRun;
+      createdAt: string;
+      sourceBranchName?: string;
+    } = {
+      id: createId(this.deps, 'handoff-plan'),
+      request: input.request,
+      createdAt,
+    };
+    if (dryRun) planInput.dryRun = dryRun;
+    if (input.sourceBranchName) planInput.sourceBranchName = input.sourceBranchName;
+    const plan = buildPlan(planInput);
+    if (!isHandoffPlan(plan)) {
+      return { ok: false, error: apiError('HANDOFF_INTERNAL_ERROR', 'constructed handoff plan failed shared schema validation', 500) };
+    }
+    this.plans.set(plan.id, {
+      plan,
+      request: input.request,
+      ...(dryRun ? { dryRun } : {}),
+      createdAtMs: Date.parse(createdAt),
+      ...(input.sourceRepoPath ? { sourceRepoPath: input.sourceRepoPath } : {}),
+      ...(input.approvedUntrackedPaths ? { approvedUntrackedPaths: input.approvedUntrackedPaths } : {}),
+    });
+    return { ok: true, plan, ...(dryRun ? { dryRun } : {}) };
+  }
+
+  async create(input: HandoffCreateInput): Promise<{ ok: true; run: HandoffRun; artifacts: HandoffArtifactSummary[] } | { ok: false; error: ReturnType<typeof apiError>; run?: HandoffRun }> {
+    const stored = input.planId ? this.plans.get(input.planId) : undefined;
+    const rawPlan = input.plan ?? stored?.plan;
+    if (!rawPlan || !isHandoffPlan(rawPlan)) {
+      return { ok: false, error: apiError('INVALID_PLAN_ID', 'handoff plan was not found or failed schema validation', 404, { planId: input.planId }) };
+    }
+    if (stored) {
+      const ageMs = nowMs(this.deps) - stored.createdAtMs;
+      if (ageMs > HANDOFF_PLAN_MAX_AGE_MS) {
+        return {
+          ok: false,
+          error: apiError('STALE_PLAN', 'handoff plan is stale; refresh plan before execute', 409, {
+            planId: rawPlan.id,
+            maxAgeMs: HANDOFF_PLAN_MAX_AGE_MS,
+            ageMs,
+          }),
+        };
+      }
+    }
+    const plan = applyConfirmedGrants(rawPlan, input.confirmedGrants);
+    const grantConflicts = missingConfirmedGrantConflicts(plan);
+    if (!hasRequiredExecuteGrantLegs(plan.requiredGrants)) {
+      const run = this.createFailedRun(plan, grantConflicts, 'FAILED_MISSING_GRANT', input.actorId, input.now);
+      return {
+        ok: false,
+        error: apiError('MISSING_CONFIRMED_GRANT', 'handoff execute requires confirmed source-read, destination-write, destination-session-create, and destination-exec grants', 403, {
+          planId: plan.id,
+          missingGrantLegs: grantConflicts.map((entry) => entry.message),
+        }, 'FAILED_MISSING_GRANT'),
+        run,
+      };
+    }
+
+    if (input.sourceRepoPath && input.destinationRepoPath && stored?.dryRun?.baseCommit) {
+      const transferInput: HandoffTransferApplyInput = {
+        requestId: plan.requestId,
+        planId: plan.id,
+        sourceRepoPath: input.sourceRepoPath,
+        destinationRepoPath: input.destinationRepoPath,
+        sourceNodeId: plan.route.sourceNodeId,
+        destinationNodeId: plan.route.destinationNodeId,
+        baseCommit: stored.dryRun.baseCommit,
+        requiredGrants: plan.requiredGrants,
+        expectedDryRun: stored.dryRun,
+      };
+      if (stored.dryRun.branchName) transferInput.branchName = stored.dryRun.branchName;
+      if (input.actorId) transferInput.actorId = input.actorId;
+      const approvedUntrackedPaths = input.approvedUntrackedPaths ?? stored.approvedUntrackedPaths;
+      if (approvedUntrackedPaths) transferInput.approvedUntrackedPaths = approvedUntrackedPaths;
+      const result = await applyHandoffTransfer(transferInput);
+      const artifacts = this.artifactsForRun(result.run.id, plan.id, result.auditEvents);
+      this.runs.set(result.run.id, { run: sanitizeRun(result.run), auditEvents: result.auditEvents, artifacts });
+      if (result.ok) return { ok: true, run: sanitizeRun(result.run), artifacts };
+      return {
+        ok: false,
+        error: apiError('SOURCE_STALE_OR_OFFLINE', 'handoff transfer/apply failed with typed conflicts', 409, {
+          runId: result.run.id,
+          conflicts: result.conflicts.slice(0, HANDOFF_STATUS_MAX_CONFLICTS),
+        }, result.run.reasonCode),
+        run: sanitizeRun(result.run),
+      };
+    }
+
+    const run = this.createFailedRun(
+      plan,
+      [
+        conflict(
+          'DESTINATION_UNAVAILABLE',
+          'handoff execute requires sourceRepoPath and destinationRepoPath for the transfer engine; refusing fake success',
+          plan.route.destinationNodeId,
+          'FAILED_DESTINATION_UNAVAILABLE'
+        ),
+      ],
+      'FAILED_DESTINATION_UNAVAILABLE',
+      input.actorId,
+      input.now
+    );
+    return {
+      ok: false,
+      error: apiError('DESTINATION_UNAVAILABLE', 'transfer/apply engine was not invoked; no fake execute success emitted', 503, { runId: run.id }, 'FAILED_DESTINATION_UNAVAILABLE'),
+      run,
+    };
+  }
+
+  getStatus(runId: string): HandoffRunStatus | null {
+    const stored = this.runs.get(runId);
+    if (!stored) return null;
+    const run = sanitizeRun(stored.run);
+    return {
+      run,
+      progress: {
+        state: run.state,
+        terminal: run.state === 'complete' || run.state === 'failed' || run.state === 'cancelled',
+        transitions: run.transitions.length,
+      },
+      redaction: {
+        rawSecretsAvailable: false,
+        rawLogsAvailable: false,
+        maxConflicts: HANDOFF_STATUS_MAX_CONFLICTS,
+      },
+    };
+  }
+
+  cancel(runId: string, actorId?: string): HandoffRunStatus | null {
+    const stored = this.runs.get(runId);
+    if (!stored) return null;
+    if (stored.run.state === 'complete' || stored.run.state === 'failed' || stored.run.state === 'cancelled') {
+      return this.getStatus(runId);
+    }
+    const at = nowIso(this.deps);
+    const transition: HandoffRunTransition = {
+      from: stored.run.state,
+      to: 'cancelled',
+      at,
+      reasonCode: 'CANCELLED_BY_OPERATOR',
+      ...(actorId ? { actorId } : {}),
+    };
+    stored.run = {
+      ...stored.run,
+      state: 'cancelled',
+      reasonCode: 'CANCELLED_BY_OPERATOR',
+      transitions: [...stored.run.transitions, transition],
+      updatedAt: at,
+      completedAt: at,
+    };
+    return this.getStatus(runId);
+  }
+
+  resume(runId: string): { run: HandoffRun; resume: { summary: string; artifactRefs: string[]; rawTranscriptAvailable: false } } | null {
+    const stored = this.runs.get(runId);
+    if (!stored) return null;
+    return {
+      run: sanitizeRun(stored.run),
+      resume: {
+        summary: `Resume cold handoff ${runId} from state ${stored.run.state}; use artifact refs only, never raw transcript/provider auth.`,
+        artifactRefs: stored.artifacts.map((artifact) => artifact.id),
+        rawTranscriptAvailable: false,
+      },
+    };
+  }
+
+  readArtifact(ref: string): HandoffArtifactSummary | null {
+    for (const run of this.runs.values()) {
+      const artifact = run.artifacts.find((entry) => entry.id === ref);
+      if (artifact) return artifact;
+    }
+    const plan = this.plans.get(ref);
+    if (plan) {
+      return {
+        id: ref,
+        planId: ref,
+        group: 'resume-bundle',
+        summary: `handoff plan ${ref} metadata reference`,
+        refs: [plan.plan.id, plan.plan.requestId],
+        sha256: hashJson(plan.plan),
+        rawPayloadAvailable: false,
+        transcriptExportAvailable: false,
+      };
+    }
+    return null;
+  }
+
+  private createFailedRun(
+    plan: HandoffPlan,
+    conflicts: HandoffConflict[],
+    reasonCode: HandoffReasonCode,
+    actorId?: string,
+    atOverride?: string
+  ): HandoffRun {
+    const at = atOverride ?? nowIso(this.deps);
+    const run: HandoffRun = {
+      schemaVersion: HANDOFF_SCHEMA_VERSION,
+      id: createId(this.deps, 'handoff-run'),
+      requestId: plan.requestId,
+      planId: plan.id,
+      state: 'failed',
+      sourceDisposition: 'handoff-failed',
+      reasonCode,
+      conflicts,
+      transitions: [
+        {
+          from: 'planned',
+          to: 'failed',
+          at,
+          reasonCode,
+          ...(actorId ? { actorId } : {}),
+        },
+      ],
+      createdAt: at,
+      updatedAt: at,
+      completedAt: at,
+    };
+    const artifacts = this.artifactsForRun(run.id, plan.id, []);
+    this.runs.set(run.id, { run, auditEvents: [], artifacts });
+    return sanitizeRun(run);
+  }
+
+  private artifactsForRun(runId: string, planId: string, auditEvents: unknown[]): HandoffArtifactSummary[] {
+    return [
+      {
+        id: `handoff-artifact:${runId}:audit-summary`,
+        runId,
+        planId,
+        group: 'audit-summary',
+        summary: 'bounded audit summary for cold handoff run; raw logs and secrets are not included',
+        refs: auditEvents.slice(0, HANDOFF_STATUS_MAX_CONFLICTS).map((_, idx) => `audit:${idx}`),
+        sha256: hashJson(auditEvents),
+        rawPayloadAvailable: false,
+        transcriptExportAvailable: false,
+      },
+      {
+        id: `handoff-artifact:${runId}:resume-bundle`,
+        runId,
+        planId,
+        group: 'resume-bundle',
+        summary: 'resume bundle reference for destination agent; contains metadata refs only',
+        refs: [runId, planId],
+        rawPayloadAvailable: false,
+        transcriptExportAvailable: false,
+      },
+    ];
+  }
+}
+
+function bodyRecord(req: Parameters<RequestHandler>[0]): Record<string, unknown> {
+  return typeof req.body === 'object' && req.body !== null && !Array.isArray(req.body)
+    ? (req.body as Record<string, unknown>)
+    : {};
+}
+
+function capabilityHeader(req: Parameters<RequestHandler>[0]): Set<string> | null {
+  const raw = req.header('x-relay-capabilities');
+  if (!raw) return null;
+  return new Set(raw.split(/[\s,]+/).map((item) => item.trim()).filter(Boolean));
+}
+
+function requireCapabilities(req: Parameters<RequestHandler>[0], capabilities: readonly string[]): ReturnType<typeof apiError> | null {
+  const provided = capabilityHeader(req);
+  if (!provided) return null;
+  const missing = capabilities.filter((capability) => !provided.has(capability));
+  if (missing.length === 0) return null;
+  return apiError('CAPABILITY_DENIED', `missing required capability: ${missing[0]}`, 403, { missingCapabilities: missing });
+}
+
+export function createHandoffRouter(input: {
+  service?: HandoffService;
+  requireAuth?: RequestHandler;
+  workContextStore?: WorkContextStore;
+  getSession?: (nodeId: string, sessionId: string) => unknown | undefined;
+} = {}): Router {
+  const router = Router();
+  const auth = input.requireAuth ?? ((_req, _res, next) => next());
+  const service =
+    input.service ??
+    new HandoffService({
+      ...(input.workContextStore ? { workContextStore: input.workContextStore } : {}),
+      ...(input.getSession ? { getSession: input.getSession } : {}),
+    });
+
+  router.post('/plan', auth, async (req, res) => {
+    const denied = requireCapabilities(req, ['session:read', 'rpc:fs:read']);
+    if (denied) {
+      res.status(denied.status).json(denied.body);
+      return;
+    }
+    const body = bodyRecord(req);
+    const result = await service.plan({
+      request: body['request'] as HandoffRequest,
+      ...(typeof body['sourceRepoPath'] === 'string' ? { sourceRepoPath: body['sourceRepoPath'] } : {}),
+      ...(Array.isArray(body['approvedUntrackedPaths']) ? { approvedUntrackedPaths: body['approvedUntrackedPaths'] as string[] } : {}),
+      ...(typeof body['sourceBranchName'] === 'string' ? { sourceBranchName: body['sourceBranchName'] } : {}),
+    });
+    if (!result.ok) {
+      res.status(result.error.status).json(result.error.body);
+      return;
+    }
+    res.json({ plan: result.plan, dryRun: result.dryRun, readOnly: true });
+  });
+
+  router.post('/create', auth, async (req, res) => {
+    const denied = requireCapabilities(req, [
+      'rpc:fs:read',
+      'rpc:fs:write',
+      'session:create:agent',
+      'pty:exec:arbitrary',
+    ]);
+    if (denied) {
+      res.status(denied.status).json(denied.body);
+      return;
+    }
+    const body = bodyRecord(req);
+    const result = await service.create({
+      ...(typeof body['planId'] === 'string' ? { planId: body['planId'] } : {}),
+      ...(body['plan'] ? { plan: body['plan'] as HandoffPlan } : {}),
+      ...(Array.isArray(body['confirmedGrants']) ? { confirmedGrants: body['confirmedGrants'] as HandoffRequiredGrant[] } : {}),
+      ...(typeof body['sourceRepoPath'] === 'string' ? { sourceRepoPath: body['sourceRepoPath'] } : {}),
+      ...(typeof body['destinationRepoPath'] === 'string' ? { destinationRepoPath: body['destinationRepoPath'] } : {}),
+      ...(Array.isArray(body['approvedUntrackedPaths']) ? { approvedUntrackedPaths: body['approvedUntrackedPaths'] as string[] } : {}),
+      ...(typeof body['actorId'] === 'string' ? { actorId: body['actorId'] } : {}),
+    });
+    if (!result.ok) {
+      res.status(result.error.status).json({ ...result.error.body, ...(result.run ? { run: result.run } : {}) });
+      return;
+    }
+    res.status(201).json({ run: result.run, artifacts: result.artifacts });
+  });
+
+  router.get('/:runId/status', auth, (req, res) => {
+    const status = service.getStatus(req.params['runId'] ?? '');
+    if (!status) {
+      const error = apiError('HANDOFF_RUN_NOT_FOUND', 'handoff run was not found', 404, { runId: req.params['runId'] });
+      res.status(error.status).json(error.body);
+      return;
+    }
+    res.json(status);
+  });
+
+  router.post('/:runId/cancel', auth, (req, res) => {
+    const status = service.cancel(req.params['runId'] ?? '', bodyRecord(req)['actorId'] as string | undefined);
+    if (!status) {
+      const error = apiError('HANDOFF_RUN_NOT_FOUND', 'handoff run was not found', 404, { runId: req.params['runId'] });
+      res.status(error.status).json(error.body);
+      return;
+    }
+    res.json(status);
+  });
+
+  router.get('/:runId/resume', auth, (req, res) => {
+    const resume = service.resume(req.params['runId'] ?? '');
+    if (!resume) {
+      const error = apiError('HANDOFF_RUN_NOT_FOUND', 'handoff run was not found', 404, { runId: req.params['runId'] });
+      res.status(error.status).json(error.body);
+      return;
+    }
+    res.json(resume);
+  });
+
+  router.get('/artifacts/:ref', auth, (req, res) => {
+    const artifact = service.readArtifact(req.params['ref'] ?? '');
+    if (!artifact) {
+      const error = apiError('HANDOFF_ARTIFACT_NOT_FOUND', 'handoff artifact ref was not found', 404, { ref: req.params['ref'] });
+      res.status(error.status).json(error.body);
+      return;
+    }
+    res.json({ artifact });
+  });
+
+  return router;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -122,7 +122,7 @@ import {
 import { createHubNodeRouter } from './hub-node-router.js';
 import { createCliGatewayEventsRouter } from './cli-gateway-events.js';
 import { createConfirmationChallengeStore } from './confirmation-challenges.js';
-import { createHandoffRouter } from './handoffs.js';
+import { createHandoffRouter, type HandoffCapabilityContext } from './handoffs.js';
 import { createHubNodeLinkManager } from './hub-node-link.js';
 import {
   aggregateRemoteSessions,
@@ -1321,10 +1321,29 @@ async function main(): Promise<void> {
     );
   }
 
+  const HANDOFF_CAPABILITIES_LOCAL = 'relayHandoffCapabilities';
+
   function bearerScopedToken(req: express.Request): string {
     const authHeader = req.header('authorization') ?? '';
     const match = authHeader.match(/^Bearer\s+(.+)$/i);
     return match?.[1]?.trim() ?? '';
+  }
+
+  function handoffCapabilitiesFromRequestHeader(req: express.Request): HandoffCapabilityContext | null {
+    const raw = req.header('x-relay-capabilities');
+    if (!raw) return null;
+    return raw.split(/[\s,]+/).map((item) => item.trim()).filter(Boolean);
+  }
+
+  function bindValidatedHandoffCapabilities(req: express.Request, res: express.Response): void {
+    const capabilities = handoffCapabilitiesFromRequestHeader(req);
+    if (capabilities) res.locals[HANDOFF_CAPABILITIES_LOCAL] = capabilities;
+  }
+
+  function validatedHandoffCapabilities(req: express.Request): HandoffCapabilityContext | null {
+    const value = req.res?.locals[HANDOFF_CAPABILITIES_LOCAL];
+    if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) return null;
+    return value;
   }
 
   function isCliGatewayV1Request(req: express.Request): boolean {
@@ -1377,14 +1396,16 @@ async function main(): Promise<void> {
   };
 
   const requireCliGatewayAuth: express.RequestHandler = (req, res, next) => {
-    if (process.env.NO_PIN === '1' || authenticatedCookieToken(req)) {
+    if (isCliGatewayV1Request(req) && validateScopedToken(bearerScopedToken(req))) {
+      bindValidatedHandoffCapabilities(req, res);
       next();
       return;
     }
-    if (
-      req.header('x-relay-cli-gateway') === 'v1' &&
-      validateScopedToken(bearerScopedToken(req))
-    ) {
+    if (process.env.NO_PIN === '1') {
+      next();
+      return;
+    }
+    if (authenticatedCookieToken(req)) {
       next();
       return;
     }
@@ -1838,6 +1859,7 @@ async function main(): Promise<void> {
     '/handoffs',
     createHandoffRouter({
       requireAuth: requireCliGatewayAuth,
+      getCapabilities: validatedHandoffCapabilities,
       workContextStore,
       getSession: (nodeId, sessionId) => {
         if (nodeId !== 'local') return undefined;

--- a/server/index.ts
+++ b/server/index.ts
@@ -122,6 +122,7 @@ import {
 import { createHubNodeRouter } from './hub-node-router.js';
 import { createCliGatewayEventsRouter } from './cli-gateway-events.js';
 import { createConfirmationChallengeStore } from './confirmation-challenges.js';
+import { createHandoffRouter } from './handoffs.js';
 import { createHubNodeLinkManager } from './hub-node-link.js';
 import {
   aggregateRemoteSessions,
@@ -1833,6 +1834,19 @@ async function main(): Promise<void> {
   app.use('/analytics', requireAuth, createAnalyticsRouter(configDir));
   app.use('/api/analytics', requireAuth, createSessionAnalyticsRouter());
   app.use('/telemetry', requireAuth, createTelemetryRouter());
+  app.use(
+    '/handoffs',
+    createHandoffRouter({
+      requireAuth: requireCliGatewayAuth,
+      workContextStore,
+      getSession: (nodeId, sessionId) => {
+        if (nodeId !== 'local') return undefined;
+        return localRelayNode.sessions
+          .list()
+          .find((session) => session.id === sessionId);
+      },
+    })
+  );
   app.use(
     '/work-contexts',
     createWorkContextRouter({

--- a/server/index.ts
+++ b/server/index.ts
@@ -1321,29 +1321,17 @@ async function main(): Promise<void> {
     );
   }
 
-  const HANDOFF_CAPABILITIES_LOCAL = 'relayHandoffCapabilities';
-
   function bearerScopedToken(req: express.Request): string {
     const authHeader = req.header('authorization') ?? '';
     const match = authHeader.match(/^Bearer\s+(.+)$/i);
     return match?.[1]?.trim() ?? '';
   }
 
-  function handoffCapabilitiesFromRequestHeader(req: express.Request): HandoffCapabilityContext | null {
-    const raw = req.header('x-relay-capabilities');
-    if (!raw) return null;
-    return raw.split(/[\s,]+/).map((item) => item.trim()).filter(Boolean);
-  }
-
-  function bindValidatedHandoffCapabilities(req: express.Request, res: express.Response): void {
-    const capabilities = handoffCapabilitiesFromRequestHeader(req);
-    if (capabilities) res.locals[HANDOFF_CAPABILITIES_LOCAL] = capabilities;
-  }
-
-  function validatedHandoffCapabilities(req: express.Request): HandoffCapabilityContext | null {
-    const value = req.res?.locals[HANDOFF_CAPABILITIES_LOCAL];
-    if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) return null;
-    return value;
+  function validatedHandoffCapabilities(_req: express.Request): HandoffCapabilityContext | null {
+    // Scoped CLI tokens currently prove only bearer possession, not capability grants.
+    // Never promote caller-controlled x-relay-capabilities into a validated handoff
+    // context; until token/policy grants are wired, handoff routes fail closed.
+    return null;
   }
 
   function isCliGatewayV1Request(req: express.Request): boolean {
@@ -1397,7 +1385,6 @@ async function main(): Promise<void> {
 
   const requireCliGatewayAuth: express.RequestHandler = (req, res, next) => {
     if (isCliGatewayV1Request(req) && validateScopedToken(bearerScopedToken(req))) {
-      bindValidatedHandoffCapabilities(req, res);
       next();
       return;
     }

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -23,6 +23,13 @@ export type RelayCliGatewayCommand =
   | 'files.stat'
   | 'files.read'
   | 'files.write'
+  | 'work-contexts.get'
+  | 'handoffs.plan'
+  | 'handoffs.create'
+  | 'handoffs.status'
+  | 'handoffs.cancel'
+  | 'handoffs.resume'
+  | 'artifacts.read'
   | 'events.subscribe';
 
 export type RelayCliGatewayErrorCode =
@@ -719,6 +726,122 @@ const eventsSubscribeInputSchema: RelayJsonSchema = {
   required: ['topic'],
 };
 
+const workContextGetInputSchema: RelayJsonSchema = {
+  title: 'WorkContextGetInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: { id: stringSchema },
+  required: ['id'],
+};
+
+const handoffPlanInputSchema: RelayJsonSchema = {
+  title: 'HandoffPlanInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    request: { type: 'object', additionalProperties: true },
+    sourceRepoPath: stringSchema,
+    approvedUntrackedPaths: { type: 'array', items: stringSchema },
+    sourceBranchName: stringSchema,
+  },
+  required: ['request'],
+};
+
+const handoffCreateInputSchema: RelayJsonSchema = {
+  title: 'HandoffCreateInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    planId: stringSchema,
+    plan: { type: 'object', additionalProperties: true },
+    confirmedGrants: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    sourceRepoPath: stringSchema,
+    destinationRepoPath: stringSchema,
+    approvedUntrackedPaths: { type: 'array', items: stringSchema },
+    actorId: stringSchema,
+  },
+};
+
+const handoffRunIdInputSchema: RelayJsonSchema = {
+  title: 'HandoffRunIdInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: { runId: stringSchema, actorId: stringSchema },
+  required: ['runId'],
+};
+
+const artifactReadInputSchema: RelayJsonSchema = {
+  title: 'ArtifactReadInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: { ref: stringSchema },
+  required: ['ref'],
+};
+
+const handoffPlanOutputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    plan: { type: 'object', additionalProperties: true },
+    dryRun: { type: 'object', additionalProperties: true },
+    readOnly: { const: true },
+  },
+  required: ['plan', 'readOnly'],
+};
+
+const handoffCreateOutputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    run: { type: 'object', additionalProperties: true },
+    artifacts: { type: 'array', items: { type: 'object', additionalProperties: true } },
+  },
+  required: ['run', 'artifacts'],
+};
+
+const handoffStatusOutputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    run: { type: 'object', additionalProperties: true },
+    progress: { type: 'object', additionalProperties: true },
+    redaction: { type: 'object', additionalProperties: true },
+  },
+  required: ['run', 'progress', 'redaction'],
+};
+
+const handoffResumeOutputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    run: { type: 'object', additionalProperties: true },
+    resume: { type: 'object', additionalProperties: true },
+  },
+  required: ['run', 'resume'],
+};
+
+const artifactReadOutputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    artifact: { type: 'object', additionalProperties: true },
+  },
+  required: ['artifact'],
+};
+
+const gatewayHandoffErrorCodes = [
+  'UNAUTHORIZED',
+  'INVALID_ARGUMENT',
+  'INVALID_JSON',
+  'NOT_FOUND',
+  'FORBIDDEN',
+  'SESSION_CONFLICT',
+  'NODE_OFFLINE',
+  'SERVER_UNAVAILABLE',
+  'UPSTREAM_ERROR',
+  'INTERNAL',
+] as const satisfies readonly RelayCliGatewayErrorCode[];
+
 const eventsSubscribeFrameSchema: RelayJsonSchema = {
   title: 'EventsSubscribeFrame',
   type: 'object',
@@ -1205,6 +1328,95 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       'CONFIRMATION_REQUIRED',
       'UPSTREAM_ERROR',
     ],
+  },
+  {
+    name: 'work-contexts.get',
+    cli: ['relay-ide', 'v1', 'work-contexts', 'get', '--id', '<work-context-id>', '--json'],
+    summary: 'Read one WorkContext by stable identity for handoff/self-service agents.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read'],
+    inputSchema: workContextGetInputSchema,
+    outputSchema: okOutput('WorkContextsGetOutput', {
+      type: 'object',
+      additionalProperties: false,
+      properties: { workContext: { type: 'object', additionalProperties: true } },
+      required: ['workContext'],
+    }),
+    errorCodes: ['UNAUTHORIZED', 'INVALID_ARGUMENT', 'NOT_FOUND', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+  },
+  {
+    name: 'handoffs.plan',
+    cli: ['relay-ide', 'v1', 'handoffs', 'plan', '--input-json', '<json>', '--json'],
+    summary: 'Dry-run a cold handoff plan. Read-only; never mutates source or destination.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read', 'rpc:fs:read'],
+    inputSchema: handoffPlanInputSchema,
+    outputSchema: okOutput('HandoffsPlanOutput', handoffPlanOutputSchema),
+    errorCodes: gatewayHandoffErrorCodes,
+  },
+  {
+    name: 'handoffs.create',
+    cli: ['relay-ide', 'v1', 'handoffs', 'create', '--input-json', '<json>', '--json'],
+    summary: 'Execute a confirmed cold handoff through the transfer/apply engine; refuses fake success.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['rpc:fs:read', 'rpc:fs:write', 'session:create:agent', 'pty:exec:arbitrary'],
+    inputSchema: handoffCreateInputSchema,
+    outputSchema: okOutput('HandoffsCreateOutput', handoffCreateOutputSchema),
+    errorCodes: gatewayHandoffErrorCodes,
+  },
+  {
+    name: 'handoffs.status',
+    cli: ['relay-ide', 'v1', 'handoffs', 'status', '--run-id', '<run-id>', '--json'],
+    summary: 'Read bounded/redacted HandoffRun state and progress.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read'],
+    inputSchema: handoffRunIdInputSchema,
+    outputSchema: okOutput('HandoffsStatusOutput', handoffStatusOutputSchema),
+    errorCodes: gatewayHandoffErrorCodes,
+  },
+  {
+    name: 'handoffs.cancel',
+    cli: ['relay-ide', 'v1', 'handoffs', 'cancel', '--run-id', '<run-id>', '--json'],
+    summary: 'Cancel a non-terminal handoff run without applying additional mutations.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read'],
+    inputSchema: handoffRunIdInputSchema,
+    outputSchema: okOutput('HandoffsCancelOutput', handoffStatusOutputSchema),
+    errorCodes: gatewayHandoffErrorCodes,
+  },
+  {
+    name: 'handoffs.resume',
+    cli: ['relay-ide', 'v1', 'handoffs', 'resume', '--run-id', '<run-id>', '--json'],
+    summary: 'Read cold handoff resume bundle refs without raw transcript/provider-auth export.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read'],
+    inputSchema: handoffRunIdInputSchema,
+    outputSchema: okOutput('HandoffsResumeOutput', handoffResumeOutputSchema),
+    errorCodes: gatewayHandoffErrorCodes,
+  },
+  {
+    name: 'artifacts.read',
+    cli: ['relay-ide', 'v1', 'artifacts', 'read', '--ref', '<artifact-ref>', '--json'],
+    summary: 'Read a bounded handoff artifact reference; raw logs/secrets/transcripts are unavailable.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read'],
+    inputSchema: artifactReadInputSchema,
+    outputSchema: okOutput('ArtifactsReadOutput', artifactReadOutputSchema),
+    errorCodes: gatewayHandoffErrorCodes,
   },
   {
     name: 'events.subscribe',

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -760,6 +760,8 @@ const handoffCreateInputSchema: RelayJsonSchema = {
     approvedUntrackedPaths: { type: 'array', items: stringSchema },
     actorId: stringSchema,
   },
+  required: ['confirmedGrants', 'sourceRepoPath', 'destinationRepoPath'],
+  anyOf: [{ required: ['planId'] }, { required: ['plan'] }],
 };
 
 const handoffRunIdInputSchema: RelayJsonSchema = {
@@ -1365,7 +1367,7 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
-    capabilityHints: ['rpc:fs:read', 'rpc:fs:write', 'session:create:agent', 'pty:exec:arbitrary'],
+    capabilityHints: ['rpc:fs:read', 'rpc:fs:write', 'session:create:agent', 'session:create:terminal', 'pty:exec:arbitrary'],
     inputSchema: handoffCreateInputSchema,
     outputSchema: okOutput('HandoffsCreateOutput', handoffCreateOutputSchema),
     errorCodes: gatewayHandoffErrorCodes,

--- a/shared/cli-gateway-runtime.ts
+++ b/shared/cli-gateway-runtime.ts
@@ -507,6 +507,39 @@ function upstreamErrorRecord(upstream: Record<string, unknown> | undefined): Rec
     : upstream;
 }
 
+function normalizeHandoffGatewayErrorCode(
+  code: string | undefined
+): RelayCliGatewayErrorCode | null {
+  switch (code) {
+    case 'SOURCE_STALE_OR_OFFLINE':
+      return 'NODE_OFFLINE';
+    case 'STALE_PLAN':
+      return 'SESSION_CONFLICT';
+    case 'DESTINATION_UNAVAILABLE':
+      return 'SERVER_UNAVAILABLE';
+    case 'MISSING_CONFIRMED_GRANT':
+    case 'CAPABILITY_DENIED':
+      return 'FORBIDDEN';
+    default:
+      return null;
+  }
+}
+
+const gatewayPassthroughErrorCodes = new Set<RelayCliGatewayErrorCode>([
+  'NODE_OFFLINE',
+  'SESSION_EXPIRED',
+  'SESSION_REVOKED',
+  'SESSION_MISMATCH',
+  'SESSION_NON_RENEWABLE',
+  'UNSUPPORTED',
+]);
+
+function isGatewayPassthroughErrorCode(
+  code: string | undefined
+): code is RelayCliGatewayErrorCode {
+  return gatewayPassthroughErrorCodes.has(code as RelayCliGatewayErrorCode);
+}
+
 export function normalizeGatewayErrorCode(
   status: number,
   upstream: Record<string, unknown> | undefined
@@ -515,12 +548,9 @@ export function normalizeGatewayErrorCode(
   const reason = typeof body?.['reasonCode'] === 'string' ? body['reasonCode'] : undefined;
   const code = typeof body?.['code'] === 'string' ? body['code'] : undefined;
   if (code === 'CONFIRMATION_REQUIRED' || reason === 'CONFIRMATION_REQUIRED') return 'CONFIRMATION_REQUIRED';
-  if (code === 'NODE_OFFLINE') return 'NODE_OFFLINE';
-  if (code === 'SESSION_EXPIRED') return 'SESSION_EXPIRED';
-  if (code === 'SESSION_REVOKED') return 'SESSION_REVOKED';
-  if (code === 'SESSION_MISMATCH') return 'SESSION_MISMATCH';
-  if (code === 'SESSION_NON_RENEWABLE') return 'SESSION_NON_RENEWABLE';
-  if (code === 'UNSUPPORTED') return 'UNSUPPORTED';
+  const handoffCode = normalizeHandoffGatewayErrorCode(code);
+  if (handoffCode) return handoffCode;
+  if (isGatewayPassthroughErrorCode(code)) return code;
   if (reason === 'HAND_BACK_ACK_REQUIRED') return 'INTERVENTION_ACK_REQUIRED';
   if (reason === 'STALE_INTERVENTION_ACK') return 'INTERVENTION_ACK_STALE';
   if (reason === 'CONTROL_STATE_STALE') return 'CONTROL_STATE_STALE';

--- a/shared/handoff.ts
+++ b/shared/handoff.ts
@@ -613,8 +613,8 @@ function hasRequiredGrantLegs(grants: HandoffRequiredGrant[]): boolean {
   return (
     legs.has(HANDOFF_GRANT_LEG_SOURCE_READ) &&
     legs.has(HANDOFF_GRANT_LEG_DESTINATION_WRITE) &&
-    (legs.has(HANDOFF_GRANT_LEG_DESTINATION_SESSION_CREATE) ||
-      legs.has(HANDOFF_GRANT_LEG_DESTINATION_EXEC))
+    legs.has(HANDOFF_GRANT_LEG_DESTINATION_SESSION_CREATE) &&
+    legs.has(HANDOFF_GRANT_LEG_DESTINATION_EXEC)
   );
 }
 

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -77,6 +77,13 @@ describe('CLI gateway contract', () => {
       'files.stat',
       'files.read',
       'files.write',
+      'work-contexts.get',
+      'handoffs.plan',
+      'handoffs.create',
+      'handoffs.status',
+      'handoffs.cancel',
+      'handoffs.resume',
+      'artifacts.read',
       'events.subscribe',
     ]);
 
@@ -251,6 +258,13 @@ describe('CLI gateway contract', () => {
       'files.stat',
       'files.read',
       'files.write',
+      'work-contexts.get',
+      'handoffs.plan',
+      'handoffs.create',
+      'handoffs.status',
+      'handoffs.cancel',
+      'handoffs.resume',
+      'artifacts.read',
       'events.subscribe',
     ] as const;
 
@@ -282,6 +296,21 @@ describe('CLI gateway contract', () => {
         error: { code: 'NODE_OFFLINE', retryable: true, details: { path: '/internal' } },
       })
     ).toBe('NODE_OFFLINE');
+    expect(
+      normalizeGatewayErrorCode(409, {
+        error: { code: 'SOURCE_STALE_OR_OFFLINE', retryable: true, reasonCode: 'FAILED_STALE_SOURCE' },
+      })
+    ).toBe('NODE_OFFLINE');
+    expect(
+      normalizeGatewayErrorCode(409, {
+        error: { code: 'STALE_PLAN', retryable: true },
+      })
+    ).toBe('SESSION_CONFLICT');
+    expect(
+      normalizeGatewayErrorCode(403, {
+        error: { code: 'MISSING_CONFIRMED_GRANT', retryable: false },
+      })
+    ).toBe('FORBIDDEN');
     expect(
       gatewayErrorRetryable(404, { error: { code: 'NODE_OFFLINE', retryable: true } })
     ).toBe(true);
@@ -404,6 +433,44 @@ describe('CLI gateway contract', () => {
       },
     });
     expect(write.errorCodes).toEqual(expect.arrayContaining(['NODE_OFFLINE', 'FORBIDDEN', 'CONFIRMATION_REQUIRED']));
+  });
+
+  it('advertises handoff/work-context/artifact gateway commands with cold-handoff safety gates', () => {
+    expect(commandSpec('work-contexts.get')).toMatchObject({
+      capabilityHints: ['session:read'],
+      transport: 'hub-http',
+    });
+
+    const plan = commandSpec('handoffs.plan');
+    expect(plan).toMatchObject({
+      capabilityHints: ['session:read', 'rpc:fs:read'],
+      transport: 'hub-http',
+    });
+    expect(plan.inputSchema).toMatchObject({
+      additionalProperties: false,
+      required: ['request'],
+    });
+    expect(plan.outputSchema).toMatchObject({
+      properties: {
+        data: { properties: { readOnly: { const: true } } },
+      },
+    });
+
+    const create = commandSpec('handoffs.create');
+    expect(create.capabilityHints).toEqual([
+      'rpc:fs:read',
+      'rpc:fs:write',
+      'session:create:agent',
+      'pty:exec:arbitrary',
+    ]);
+    expect(create.summary).toContain('refuses fake success');
+    expect(create.errorCodes).toEqual(
+      expect.arrayContaining(['FORBIDDEN', 'SESSION_CONFLICT', 'SERVER_UNAVAILABLE'])
+    );
+
+    expect(commandSpec('handoffs.status').summary).toContain('bounded/redacted');
+    expect(commandSpec('handoffs.resume').summary).toContain('without raw transcript');
+    expect(commandSpec('artifacts.read').summary).toContain('raw logs/secrets/transcripts are unavailable');
   });
 
   it('encodes sessions.input source exclusivity for schema-generated adapters', () => {

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -461,8 +461,13 @@ describe('CLI gateway contract', () => {
       'rpc:fs:read',
       'rpc:fs:write',
       'session:create:agent',
+      'session:create:terminal',
       'pty:exec:arbitrary',
     ]);
+    expect(create.inputSchema).toMatchObject({
+      required: ['confirmedGrants', 'sourceRepoPath', 'destinationRepoPath'],
+      anyOf: [{ required: ['planId'] }, { required: ['plan'] }],
+    });
     expect(create.summary).toContain('refuses fake success');
     expect(create.errorCodes).toEqual(
       expect.arrayContaining(['FORBIDDEN', 'SESSION_CONFLICT', 'SERVER_UNAVAILABLE'])

--- a/test/handoff-transfer.test.ts
+++ b/test/handoff-transfer.test.ts
@@ -73,6 +73,35 @@ function createIdFactory(): () => string {
   return () => `handoff-test-id-${++id}`;
 }
 
+function allowedGrants(): HandoffRequiredGrant[] {
+  return [
+    {
+      leg: 'source-read',
+      nodeId: SOURCE_NODE,
+      capability: 'rpc:fs:read',
+      decision: 'allow',
+    },
+    {
+      leg: 'destination-write',
+      nodeId: DESTINATION_NODE,
+      capability: 'rpc:fs:write',
+      decision: 'allow',
+    },
+    {
+      leg: 'destination-session-create',
+      nodeId: DESTINATION_NODE,
+      capability: 'session:create:agent',
+      decision: 'allow',
+    },
+    {
+      leg: 'destination-exec',
+      nodeId: DESTINATION_NODE,
+      capability: 'pty:exec:arbitrary',
+      decision: 'allow',
+    },
+  ];
+}
+
 async function applyFixture(input: {
   source: string;
   destination: string;
@@ -98,7 +127,7 @@ async function applyFixture(input: {
     destinationNodeId: DESTINATION_NODE,
     baseCommit: input.baseCommit,
     approvedUntrackedPaths: input.approvedUntrackedPaths,
-    requiredGrants: input.requiredGrants,
+    requiredGrants: input.requiredGrants ?? allowedGrants(),
     expectedDryRun: dryRun,
     maxUntrackedFileBytes: input.maxUntrackedFileBytes,
     exec: input.exec,
@@ -267,6 +296,7 @@ describe('applyHandoffTransfer', () => {
       destinationNodeId: DESTINATION_NODE,
       baseCommit,
       expectedDryRun,
+      requiredGrants: allowedGrants(),
       now: () => '2026-05-21T12:00:00.000Z',
       createId: createIdFactory(),
     });
@@ -299,6 +329,7 @@ describe('applyHandoffTransfer', () => {
       baseCommit,
       approvedUntrackedPaths: ['notes.md'],
       expectedDryRun,
+      requiredGrants: allowedGrants(),
       now: () => '2026-05-21T12:00:00.000Z',
       createId: createIdFactory(),
     });

--- a/test/handoff.test.ts
+++ b/test/handoff.test.ts
@@ -206,6 +206,14 @@ function basePlan(overrides: Partial<HandoffPlan> = {}): HandoffPlan {
         grantRef: 'acl:dest:session',
         scope: { kind: 'node' },
       },
+      {
+        leg: 'destination-exec',
+        nodeId: destinationNodeId,
+        capability: 'pty:exec:arbitrary',
+        decision: 'allow',
+        grantRef: 'acl:dest:exec',
+        scope: { kind: 'node' },
+      },
     ],
     launchPreview: {
       nodeId: destinationNodeId,

--- a/test/handoffs-api.test.ts
+++ b/test/handoffs-api.test.ts
@@ -111,10 +111,13 @@ function confirmedGrants(): HandoffRequiredGrant[] {
   ];
 }
 
-async function startHandoffApi(service: HandoffService): Promise<{ url: string; close: () => Promise<void> }> {
+async function startHandoffApi(
+  service: HandoffService,
+  getCapabilities?: Parameters<typeof createHandoffRouter>[0]['getCapabilities']
+): Promise<{ url: string; close: () => Promise<void> }> {
   const app = express();
   app.use(express.json());
-  app.use('/handoffs', createHandoffRouter({ service }));
+  app.use('/handoffs', createHandoffRouter({ service, ...(getCapabilities ? { getCapabilities } : {}) }));
   return createTestServer(app);
 }
 
@@ -290,39 +293,63 @@ describe('handoff API service', () => {
       expect(denied.status).toBe(403);
       expect((await denied.json()).error.code).toBe('CAPABILITY_DENIED');
 
-      const allowed = await fetch(`${url}/handoffs/${failed.run.id}/status`, {
+      const forgedStatus = await fetch(`${url}/handoffs/${failed.run.id}/status`, {
         headers: { 'x-relay-capabilities': headerFor(['session:read']) },
       });
-      expect(allowed.status).toBe(200);
-      expect((await allowed.json()).redaction).toMatchObject({ rawSecretsAvailable: false });
+      expect(forgedStatus.status).toBe(403);
+      expect((await forgedStatus.json()).error.code).toBe('CAPABILITY_DENIED');
 
-      const artifactDenied = await fetch(`${url}/handoffs/artifacts/handoff-artifact:${failed.run.id}:resume-bundle`);
-      expect(artifactDenied.status).toBe(403);
-
-      const terminalPlan = {
-        ...planned.plan,
-        launchPreview: {
-          ...planned.plan.launchPreview,
-          runtime: { ...planned.plan.launchPreview.runtime, kind: 'terminal' as const },
-        },
-      };
-      const terminalCreateDenied = await fetch(`${url}/handoffs/create`, {
+      const forgedPlan = await fetch(`${url}/handoffs/plan`, {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
-          'x-relay-capabilities': headerFor([
-            'rpc:fs:read',
-            'rpc:fs:write',
-            'session:create:agent',
-            'pty:exec:arbitrary',
-          ]),
+          'x-relay-capabilities': headerFor(['session:read', 'rpc:fs:read']),
         },
+        body: JSON.stringify({ request: request() }),
+      });
+      expect(forgedPlan.status).toBe(403);
+      expect((await forgedPlan.json()).error.code).toBe('CAPABILITY_DENIED');
+
+      const artifactDenied = await fetch(`${url}/handoffs/artifacts/handoff-artifact:${failed.run.id}:resume-bundle`);
+      expect(artifactDenied.status).toBe(403);
+    } finally {
+      await close();
+    }
+
+    const trustedRead = await startHandoffApi(service, () => ['session:read']);
+    try {
+      const allowed = await fetch(`${trustedRead.url}/handoffs/${failed.run.id}/status`, {
+        headers: { 'x-relay-capabilities': headerFor(['not-used']) },
+      });
+      expect(allowed.status).toBe(200);
+      expect((await allowed.json()).redaction).toMatchObject({ rawSecretsAvailable: false });
+    } finally {
+      await trustedRead.close();
+    }
+
+    const terminalPlan = {
+      ...planned.plan,
+      launchPreview: {
+        ...planned.plan.launchPreview,
+        runtime: { ...planned.plan.launchPreview.runtime, kind: 'terminal' as const },
+      },
+    };
+    const trustedCreate = await startHandoffApi(service, () => [
+      'rpc:fs:read',
+      'rpc:fs:write',
+      'session:create:agent',
+      'pty:exec:arbitrary',
+    ]);
+    try {
+      const terminalCreateDenied = await fetch(`${trustedCreate.url}/handoffs/create`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ plan: terminalPlan, confirmedGrants: confirmedGrants() }),
       });
       expect(terminalCreateDenied.status).toBe(403);
       expect((await terminalCreateDenied.json()).error.details.missingCapabilities).toEqual(['session:create:terminal']);
     } finally {
-      await close();
+      await trustedCreate.close();
     }
   });
 });

--- a/test/handoffs-api.test.ts
+++ b/test/handoffs-api.test.ts
@@ -9,8 +9,14 @@ import {
   type HandoffRequiredGrant,
 } from '../shared/handoff.js';
 import { ENVIRONMENT_OPTION_SCHEMA_VERSION } from '../shared/environment-option.js';
-import { HandoffService, HANDOFF_PLAN_MAX_AGE_MS, createHandoffRouter } from '../server/handoffs.js';
+import {
+  HandoffService,
+  HANDOFF_PLAN_MAX_AGE_MS,
+  createHandoffRouter,
+  type HandoffCapabilityProvider,
+} from '../server/handoffs.js';
 import type { HandoffPlannerDryRun } from '../server/handoff-planner.js';
+import { generateScopedToken, validateScopedToken } from '../server/browser-content.js';
 import { createTestServer } from './helpers/test-server.js';
 
 const now = '2026-05-21T10:00:00.000Z';
@@ -113,12 +119,37 @@ function confirmedGrants(): HandoffRequiredGrant[] {
 
 async function startHandoffApi(
   service: HandoffService,
-  getCapabilities?: Parameters<typeof createHandoffRouter>[0]['getCapabilities']
+  getCapabilities?: HandoffCapabilityProvider
 ): Promise<{ url: string; close: () => Promise<void> }> {
   const app = express();
   app.use(express.json());
   app.use('/handoffs', createHandoffRouter({ service, ...(getCapabilities ? { getCapabilities } : {}) }));
   return createTestServer(app);
+}
+
+async function startScopedTokenHandoffApi(
+  service: HandoffService
+): Promise<{ url: string; close: () => Promise<void>; token: string }> {
+  const token = generateScopedToken();
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/handoffs',
+    createHandoffRouter({
+      service,
+      requireAuth: (req, res, next) => {
+        const authHeader = req.header('authorization') ?? '';
+        const bearer = authHeader.match(/^Bearer\s+(.+)$/i)?.[1]?.trim() ?? '';
+        if (!validateScopedToken(bearer)) {
+          res.status(401).json({ error: 'Unauthorized' });
+          return;
+        }
+        next();
+      },
+      getCapabilities: () => null,
+    })
+  );
+  return { ...(await createTestServer(app)), token };
 }
 
 function headerFor(capabilities: readonly string[]): string {
@@ -278,6 +309,63 @@ describe('handoff API service', () => {
       code: 'INVALID_REQUEST',
       details: { field: 'destinationRepoPath' },
     });
+  });
+
+  it('fails closed when a scoped CLI token forges handoff capability headers', async () => {
+    let nextId = 0;
+    const service = new HandoffService({ now: () => new Date(now), createId: () => `id-${++nextId}` });
+    const planned = await service.plan({ request: request(), dryRun: dryRun(), sourceRepoPath: sourceCwd });
+    if (!planned.ok) throw new Error('plan failed unexpectedly');
+    const { url, close, token } = await startScopedTokenHandoffApi(service);
+    const forgedHeaders = {
+      authorization: `Bearer ${token}`,
+      'x-relay-cli-gateway': 'v1',
+      'x-relay-capabilities': headerFor([
+        'session:read',
+        'rpc:fs:read',
+        'rpc:fs:write',
+        'session:create:agent',
+        'pty:exec:arbitrary',
+      ]),
+    };
+
+    try {
+      const forgedPlan = await fetch(`${url}/handoffs/plan`, {
+        method: 'POST',
+        headers: { ...forgedHeaders, 'content-type': 'application/json' },
+        body: JSON.stringify({ request: request(), sourceRepoPath: sourceCwd }),
+      });
+      expect(forgedPlan.status).toBe(403);
+      expect((await forgedPlan.json()).error).toMatchObject({
+        code: 'CAPABILITY_DENIED',
+        details: { missingCapabilities: ['session:read', 'rpc:fs:read'] },
+      });
+
+      const forgedCreate = await fetch(`${url}/handoffs/create`, {
+        method: 'POST',
+        headers: { ...forgedHeaders, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          planId: planned.plan.id,
+          confirmedGrants: confirmedGrants(),
+          sourceRepoPath: sourceCwd,
+          destinationRepoPath: destinationCwd,
+        }),
+      });
+      expect(forgedCreate.status).toBe(403);
+      expect((await forgedCreate.json()).error).toMatchObject({
+        code: 'CAPABILITY_DENIED',
+        details: {
+          missingCapabilities: [
+            'rpc:fs:read',
+            'rpc:fs:write',
+            'session:create:agent',
+            'pty:exec:arbitrary',
+          ],
+        },
+      });
+    } finally {
+      await close();
+    }
   });
 
   it('fails closed when handoff routes have no capability context and gates status/artifact routes', async () => {

--- a/test/handoffs-api.test.ts
+++ b/test/handoffs-api.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_LOCAL_NODE_ID, createRepoInstanceId, createWorktreeInstanceId } from '../shared/identity.js';
+import {
+  HANDOFF_SCHEMA_VERSION,
+  type HandoffConflict,
+  type HandoffRequest,
+  type HandoffRequiredGrant,
+} from '../shared/handoff.js';
+import { ENVIRONMENT_OPTION_SCHEMA_VERSION } from '../shared/environment-option.js';
+import { HandoffService, HANDOFF_PLAN_MAX_AGE_MS } from '../server/handoffs.js';
+import type { HandoffPlannerDryRun } from '../server/handoff-planner.js';
+
+const now = '2026-05-21T10:00:00.000Z';
+const sourceNodeId = DEFAULT_LOCAL_NODE_ID;
+const destinationNodeId = 'devbox-1';
+const workContextId = 'wc:handoff:api-test';
+const sourceCwd = '/repos/relay-ide/.worktrees/feature-a';
+const destinationCwd = '/srv/relay-ide/.worktrees/feature-a';
+
+function request(): HandoffRequest {
+  const repoInstanceId = createRepoInstanceId(destinationNodeId, '/srv/relay-ide');
+  const worktreeInstanceId = createWorktreeInstanceId(destinationNodeId, destinationCwd);
+  return {
+    schemaVersion: HANDOFF_SCHEMA_VERSION,
+    id: 'handoff-request-api-test',
+    requestedAt: now,
+    requestedByActorId: 'kani-backend',
+    source: {
+      nodeId: sourceNodeId,
+      sessionId: 'source-session-1',
+      workContextId,
+      cwd: sourceCwd,
+      disposition: 'left-running',
+      durabilityState: 'running-attached',
+    },
+    destination: {
+      nodeId: destinationNodeId,
+      option: {
+        schemaVersion: ENVIRONMENT_OPTION_SCHEMA_VERSION,
+        id: `env:${destinationNodeId}:${destinationCwd}`,
+        node: {
+          nodeId: destinationNodeId,
+          kind: 'remote',
+          displayName: 'devbox',
+          online: true,
+        },
+        capabilities: [
+          'session:read',
+          'session:create:agent',
+          'rpc:fs:read',
+          'rpc:fs:write',
+          'pty:exec:arbitrary',
+        ],
+        cwd: destinationCwd,
+        cwdMode: 'repo',
+        freshness: 'fresh',
+        repoInstance: {
+          repoInstanceId,
+          localPath: '/srv/relay-ide',
+          repoIdentity: 'github.com/donovan-yohan/relay-ide',
+          name: 'relay-ide',
+          currentBranch: 'feat/691-handoff-api-cli',
+        },
+        bench: {
+          worktreeInstanceId,
+          localPath: destinationCwd,
+          branchName: 'feat/691-handoff-api-cli',
+        },
+        generatedAt: now,
+      },
+      cwd: destinationCwd,
+      repoInstanceId,
+      worktreeInstanceId,
+    },
+    desiredRuntime: {
+      kind: 'agent',
+      providerId: 'hermes',
+      commandSummary: 'resume cold handoff in destination worktree',
+      requiredCapabilities: ['session:create:agent', 'pty:exec:arbitrary'],
+    },
+  };
+}
+
+function dryRun(conflicts: HandoffConflict[] = []): HandoffPlannerDryRun {
+  return {
+    branchName: 'feat/691-handoff-api-cli',
+    baseCommit: 'a'.repeat(40),
+    isClean: false,
+    stagedFiles: [],
+    unstagedFiles: [],
+    untrackedCandidates: [],
+    excludedPaths: [],
+    includedGroups: ['source-summary'],
+    excludedGroups: [],
+    fileCount: 0,
+    byteCount: 0,
+    transferMode: 'metadata-only',
+    conflicts,
+  };
+}
+
+function confirmedGrants(): HandoffRequiredGrant[] {
+  return [
+    { leg: 'source-read', nodeId: sourceNodeId, capability: 'rpc:fs:read', decision: 'allow' },
+    { leg: 'destination-write', nodeId: destinationNodeId, capability: 'rpc:fs:write', decision: 'allow' },
+    { leg: 'destination-session-create', nodeId: destinationNodeId, capability: 'session:create:agent', decision: 'allow' },
+    { leg: 'destination-exec', nodeId: destinationNodeId, capability: 'pty:exec:arbitrary', decision: 'allow' },
+  ];
+}
+
+describe('handoff API service', () => {
+  it('plans read-only handoffs with all required execute grant legs unconfirmed', async () => {
+    const service = new HandoffService({ now: () => new Date(now), createId: () => 'plan-1' });
+
+    const planned = await service.plan({ request: request(), dryRun: dryRun() });
+
+    expect(planned.ok).toBe(true);
+    if (!planned.ok) return;
+    expect(planned.plan.id).toBe('plan-1');
+    expect(planned.plan.transferMode).toBe('metadata-only');
+    expect(planned.plan.requiredGrants.map((grant) => grant.leg)).toEqual([
+      'source-read',
+      'destination-write',
+      'destination-session-create',
+      'destination-exec',
+    ]);
+    expect(planned.plan.requiredGrants.every((grant) => grant.decision === undefined)).toBe(true);
+  });
+
+  it('rejects execute without confirmed source/destination grants and records a failed run', async () => {
+    let nextId = 0;
+    const service = new HandoffService({ now: () => new Date(now), createId: () => `id-${++nextId}` });
+    const planned = await service.plan({ request: request(), dryRun: dryRun() });
+    if (!planned.ok) throw new Error('plan failed unexpectedly');
+
+    const created = await service.create({ planId: planned.plan.id });
+
+    expect(created.ok).toBe(false);
+    if (created.ok) return;
+    expect(created.error.body.error.code).toBe('MISSING_CONFIRMED_GRANT');
+    expect(created.run?.state).toBe('failed');
+    expect(created.run?.conflicts.map((entry) => entry.code)).toContain('MISSING_CAPABILITY_GRANT');
+    const status = service.getStatus(created.run?.id ?? '');
+    expect(status?.redaction).toMatchObject({ rawSecretsAvailable: false, rawLogsAvailable: false });
+  });
+
+  it('refuses fake execute success even with confirmed grants when the transfer engine cannot run', async () => {
+    let nextId = 0;
+    const service = new HandoffService({ now: () => new Date(now), createId: () => `id-${++nextId}` });
+    const planned = await service.plan({ request: request(), dryRun: dryRun() });
+    if (!planned.ok) throw new Error('plan failed unexpectedly');
+
+    const created = await service.create({
+      planId: planned.plan.id,
+      confirmedGrants: confirmedGrants(),
+    });
+
+    expect(created.ok).toBe(false);
+    if (created.ok) return;
+    expect(created.error.body.error.code).toBe('DESTINATION_UNAVAILABLE');
+    expect(created.run?.state).toBe('failed');
+    expect(created.run?.reasonCode).toBe('FAILED_DESTINATION_UNAVAILABLE');
+    const resume = service.resume(created.run?.id ?? '');
+    expect(resume?.resume.rawTranscriptAvailable).toBe(false);
+    const artifact = service.readArtifact(`handoff-artifact:${created.run?.id}:resume-bundle`);
+    expect(artifact).toMatchObject({ rawPayloadAvailable: false, transcriptExportAvailable: false });
+  });
+
+  it('requires stale plans to be refreshed before execute', async () => {
+    let currentMs = Date.parse(now);
+    const service = new HandoffService({
+      now: () => new Date(currentMs),
+      createId: () => 'plan-stale',
+    });
+    const planned = await service.plan({ request: request(), dryRun: dryRun() });
+    if (!planned.ok) throw new Error('plan failed unexpectedly');
+    currentMs += HANDOFF_PLAN_MAX_AGE_MS + 1;
+
+    const created = await service.create({ planId: planned.plan.id, confirmedGrants: confirmedGrants() });
+
+    expect(created.ok).toBe(false);
+    if (created.ok) return;
+    expect(created.error.body.error.code).toBe('STALE_PLAN');
+  });
+
+  it('returns typed source stale/offline failures during planning', async () => {
+    const service = new HandoffService({ now: () => new Date(now), createId: () => 'plan-source-stale' });
+
+    const planned = await service.plan({
+      request: request(),
+      dryRun: dryRun([
+        {
+          code: 'STALE_SOURCE',
+          message: 'source node is offline',
+          nodeId: sourceNodeId,
+          reasonCode: 'FAILED_STALE_SOURCE',
+        },
+      ]),
+    });
+
+    expect(planned.ok).toBe(false);
+    if (planned.ok) return;
+    expect(planned.error.body.error.code).toBe('SOURCE_STALE_OR_OFFLINE');
+    expect(planned.error.body.error.reasonCode).toBe('FAILED_STALE_SOURCE');
+  });
+});

--- a/test/handoffs-api.test.ts
+++ b/test/handoffs-api.test.ts
@@ -1,3 +1,4 @@
+import express from 'express';
 import { describe, expect, it } from 'vitest';
 
 import { DEFAULT_LOCAL_NODE_ID, createRepoInstanceId, createWorktreeInstanceId } from '../shared/identity.js';
@@ -8,8 +9,9 @@ import {
   type HandoffRequiredGrant,
 } from '../shared/handoff.js';
 import { ENVIRONMENT_OPTION_SCHEMA_VERSION } from '../shared/environment-option.js';
-import { HandoffService, HANDOFF_PLAN_MAX_AGE_MS } from '../server/handoffs.js';
+import { HandoffService, HANDOFF_PLAN_MAX_AGE_MS, createHandoffRouter } from '../server/handoffs.js';
 import type { HandoffPlannerDryRun } from '../server/handoff-planner.js';
+import { createTestServer } from './helpers/test-server.js';
 
 const now = '2026-05-21T10:00:00.000Z';
 const sourceNodeId = DEFAULT_LOCAL_NODE_ID;
@@ -109,6 +111,17 @@ function confirmedGrants(): HandoffRequiredGrant[] {
   ];
 }
 
+async function startHandoffApi(service: HandoffService): Promise<{ url: string; close: () => Promise<void> }> {
+  const app = express();
+  app.use(express.json());
+  app.use('/handoffs', createHandoffRouter({ service }));
+  return createTestServer(app);
+}
+
+function headerFor(capabilities: readonly string[]): string {
+  return capabilities.join(',');
+}
+
 describe('handoff API service', () => {
   it('plans read-only handoffs with all required execute grant legs unconfirmed', async () => {
     const service = new HandoffService({ now: () => new Date(now), createId: () => 'plan-1' });
@@ -203,5 +216,113 @@ describe('handoff API service', () => {
     if (planned.ok) return;
     expect(planned.error.body.error.code).toBe('SOURCE_STALE_OR_OFFLINE');
     expect(planned.error.body.error.reasonCode).toBe('FAILED_STALE_SOURCE');
+  });
+
+  it('rejects confirmed grants that try to mutate the planned node/capability/scope envelope', async () => {
+    let nextId = 0;
+    const service = new HandoffService({ now: () => new Date(now), createId: () => `id-${++nextId}` });
+    const planned = await service.plan({ request: request(), dryRun: dryRun() });
+    if (!planned.ok) throw new Error('plan failed unexpectedly');
+
+    const malicious = confirmedGrants().map((grant) =>
+      grant.leg === 'destination-write'
+        ? {
+            ...grant,
+            nodeId: sourceNodeId,
+            capability: 'rpc:fs:read' as const,
+            scope: { kind: 'path' as const, pathPrefixes: [sourceCwd] },
+          }
+        : grant
+    );
+
+    const created = await service.create({ planId: planned.plan.id, confirmedGrants: malicious });
+
+    expect(created.ok).toBe(false);
+    if (created.ok) return;
+    expect(created.error.body.error.code).toBe('CAPABILITY_DENIED');
+    expect(created.run?.state).toBe('failed');
+    expect(created.run?.conflicts[0]?.message).toContain('does not match the planned');
+  });
+
+  it('rejects execute when source/destination paths do not match the stored plan', async () => {
+    let nextId = 0;
+    const service = new HandoffService({ now: () => new Date(now), createId: () => `id-${++nextId}` });
+    const planned = await service.plan({ request: request(), dryRun: dryRun(), sourceRepoPath: sourceCwd });
+    if (!planned.ok) throw new Error('plan failed unexpectedly');
+
+    const sourceMismatch = await service.create({
+      planId: planned.plan.id,
+      confirmedGrants: confirmedGrants(),
+      sourceRepoPath: '/tmp/other-source',
+      destinationRepoPath: destinationCwd,
+    });
+    expect(sourceMismatch.ok).toBe(false);
+    if (sourceMismatch.ok) return;
+    expect(sourceMismatch.error.body.error).toMatchObject({
+      code: 'INVALID_REQUEST',
+      details: { field: 'sourceRepoPath' },
+    });
+
+    const destinationMismatch = await service.create({
+      planId: planned.plan.id,
+      confirmedGrants: confirmedGrants(),
+      sourceRepoPath: sourceCwd,
+      destinationRepoPath: '/tmp/other-destination',
+    });
+    expect(destinationMismatch.ok).toBe(false);
+    if (destinationMismatch.ok) return;
+    expect(destinationMismatch.error.body.error).toMatchObject({
+      code: 'INVALID_REQUEST',
+      details: { field: 'destinationRepoPath' },
+    });
+  });
+
+  it('fails closed when handoff routes have no capability context and gates status/artifact routes', async () => {
+    let nextId = 0;
+    const service = new HandoffService({ now: () => new Date(now), createId: () => `id-${++nextId}` });
+    const planned = await service.plan({ request: request(), dryRun: dryRun() });
+    if (!planned.ok) throw new Error('plan failed unexpectedly');
+    const failed = await service.create({ planId: planned.plan.id });
+    if (failed.ok || !failed.run) throw new Error('expected failed run for status fixture');
+    const { url, close } = await startHandoffApi(service);
+    try {
+      const denied = await fetch(`${url}/handoffs/${failed.run.id}/status`);
+      expect(denied.status).toBe(403);
+      expect((await denied.json()).error.code).toBe('CAPABILITY_DENIED');
+
+      const allowed = await fetch(`${url}/handoffs/${failed.run.id}/status`, {
+        headers: { 'x-relay-capabilities': headerFor(['session:read']) },
+      });
+      expect(allowed.status).toBe(200);
+      expect((await allowed.json()).redaction).toMatchObject({ rawSecretsAvailable: false });
+
+      const artifactDenied = await fetch(`${url}/handoffs/artifacts/handoff-artifact:${failed.run.id}:resume-bundle`);
+      expect(artifactDenied.status).toBe(403);
+
+      const terminalPlan = {
+        ...planned.plan,
+        launchPreview: {
+          ...planned.plan.launchPreview,
+          runtime: { ...planned.plan.launchPreview.runtime, kind: 'terminal' as const },
+        },
+      };
+      const terminalCreateDenied = await fetch(`${url}/handoffs/create`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-relay-capabilities': headerFor([
+            'rpc:fs:read',
+            'rpc:fs:write',
+            'session:create:agent',
+            'pty:exec:arbitrary',
+          ]),
+        },
+        body: JSON.stringify({ plan: terminalPlan, confirmedGrants: confirmedGrants() }),
+      });
+      expect(terminalCreateDenied.status).toBe(403);
+      expect((await terminalCreateDenied.json()).error.details.missingCapabilities).toEqual(['session:create:terminal']);
+    } finally {
+      await close();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add `/handoffs` backend routes and an in-memory handoff service for plan/create/status/cancel/resume/artifact reads
- expose `relay-ide v1` gateway commands for work-context get, handoff plan/create/status/cancel/resume, and artifact read
- tighten handoff execute grant validation so source read, destination write, destination session create, and destination exec must all be confirmed; no fake execute success when the transfer engine cannot run

## Verification
- `npm test -- test/handoff.test.ts test/handoff-transfer.test.ts test/cli-gateway-contract.test.ts test/handoffs-api.test.ts`
- `npm test -- test/cli-gateway-contract.test.ts test/handoffs-api.test.ts`
- `npm run check` (passes; existing warnings only)
- `npm run build`
- CLI smoke: `node dist/bin/relay-ide.js v1 schema --json > /tmp/relay-691-schema.json` then verified new command names in the schema

Closes #691
Refs #683, #685, #688, #689, #690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: added commands for work-context retrieval, handoff lifecycle (plan/create/status/cancel/resume) and artifact read; CLI usage/docs extended.
  * Server: added handoff HTTP API with planning, execution, status, cancel/resume, and artifact endpoints.

* **Improvements**
  * Stricter handoff grant validation and enhanced error normalization.
  * Router enforces capability gating and sanitizes/redacts sensitive run/status/artifact data.

* **Tests**
  * Expanded contract and end-to-end tests covering new commands, security gates, and handoff behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->