### PR TITLE
Add handoff dry-run plan surface

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -83,6 +83,7 @@ import type { AddWorkspaceDialogHandle } from './components/dialogs/AddWorkspace
 import WorkspaceSettingsDialog from './components/dialogs/WorkspaceSettingsDialog.js';
 import type { WorkspaceSettingsDialogHandle } from './components/dialogs/WorkspaceSettingsDialog.js';
 import EnvPickerDialog from './components/dialogs/EnvPickerDialog.js';
+import HandoffPlanDialog from './components/dialogs/HandoffPlanDialog.js';
 import { reposToEnvironmentOptions } from './lib/repo-to-environment.js';
 import AnalyticsDashboard from './components/AnalyticsDashboard.js';
 import SessionDetail from './components/SessionDetail.js';
@@ -800,6 +801,11 @@ function TerminalAreaContent({
                     sessionId={activeSessionId}
                     currentActivity={activeSession?.currentActivity ?? null}
                     framework={activeSession?.agent}
+                    onHandoffClick={() =>
+                      useUiStore
+                        .getState()
+                        .setActiveModal({ modal: 'handoff-plan' })
+                    }
                   />
                 )}
 
@@ -1326,6 +1332,10 @@ export default function App() {
       <EnvPickerDialog
         open={activeModal?.modal === 'env-picker'}
         options={envPickerOptions}
+        onClose={handleModalClose}
+      />
+      <HandoffPlanDialog
+        open={activeModal?.modal === 'handoff-plan'}
         onClose={handleModalClose}
       />
 

--- a/frontend/src/components/ActiveWorkSurface.tsx
+++ b/frontend/src/components/ActiveWorkSurface.tsx
@@ -469,6 +469,16 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
           </TuiButton>
           <TuiButton
             size="sm"
+            variant="info"
+            title="open fixture dry-run handoff plan"
+            onClick={() =>
+              useUiStore.getState().setActiveModal({ modal: 'handoff-plan' })
+            }
+          >
+            handoff
+          </TuiButton>
+          <TuiButton
+            size="sm"
             variant="ghost"
             disabled
             title="pause/retry require explicit control capability contracts before mobile can route them"

--- a/frontend/src/components/SessionStatusBar.css
+++ b/frontend/src/components/SessionStatusBar.css
@@ -87,6 +87,22 @@
   text-align: right;
 }
 
+.status-handoff {
+  min-height: 24px;
+  padding: 2px 8px;
+  color: var(--accent);
+  font: inherit;
+  font-size: var(--font-size-xs);
+  background: transparent;
+  border: 1px solid var(--accent);
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.status-handoff:hover {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
 @media (max-width: 600px) {
   .status-model,
   .status-tokens,
@@ -98,6 +114,10 @@
 
   .status-activity {
     max-width: 48vw;
+  }
+
+  .status-handoff {
+    min-height: 44px;
   }
 }
 

--- a/frontend/src/components/SessionStatusBar.tsx
+++ b/frontend/src/components/SessionStatusBar.tsx
@@ -8,6 +8,7 @@ export interface SessionStatusBarProps {
   sessionId: string | null;
   currentActivity?: CurrentActivity | null;
   framework?: string | null | undefined;
+  onHandoffClick?: () => void;
 }
 
 const BAR_WIDTH = 10;
@@ -92,6 +93,7 @@ export function SessionStatusBar({
   sessionId,
   currentActivity = null,
   framework,
+  onHandoffClick,
 }: SessionStatusBarProps) {
   const keyboardOpen = useUiStore((s) => s.keyboardOpen);
   const { telemetry, accountTelemetry, frameworkLabel } =
@@ -139,6 +141,16 @@ export function SessionStatusBar({
       </div>
 
       <div className="status-right">
+        {onHandoffClick && (
+          <button
+            className="status-handoff"
+            type="button"
+            title="open fixture dry-run handoff plan"
+            onClick={onHandoffClick}
+          >
+            handoff
+          </button>
+        )}
         <span
           className="status-rate-limits status-segment"
           title={

--- a/frontend/src/components/dialogs/HandoffPlanDialog.css
+++ b/frontend/src/components/dialogs/HandoffPlanDialog.css
@@ -1,0 +1,265 @@
+.handoff-plan-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgb(0 0 0 / 72%);
+}
+
+.handoff-plan-dialog {
+  display: grid;
+  grid-template-rows: auto auto auto minmax(0, 1fr) auto;
+  width: min(980px, 100%);
+  max-height: min(860px, calc(100vh - 32px));
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  box-shadow: 0 0 0 1px #000;
+}
+
+.handoff-plan-header,
+.handoff-plan-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.handoff-plan-footer {
+  position: sticky;
+  bottom: 0;
+  min-height: 56px;
+  border-top: 1px solid var(--border);
+  border-bottom: 0;
+  background: var(--surface);
+}
+
+.handoff-plan-footer > div {
+  display: grid;
+  gap: 4px;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.handoff-plan-footer strong {
+  color: var(--status-warning);
+  font-weight: 500;
+}
+
+.handoff-plan-header h2,
+.handoff-plan-section h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  text-transform: lowercase;
+}
+
+.handoff-plan-eyebrow,
+.handoff-plan-copy,
+.handoff-plan-empty {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+}
+
+.handoff-plan-eyebrow {
+  margin-bottom: 4px;
+  font-size: var(--font-size-xs);
+  color: var(--accent);
+}
+
+.handoff-plan-dialog > .handoff-plan-copy {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.handoff-plan-fixtures {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.handoff-plan-fixture {
+  min-height: 44px;
+  padding: 8px 12px;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: var(--font-size-xs);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.handoff-plan-fixture:hover,
+.handoff-plan-fixture[data-active='true'] {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.handoff-plan-body {
+  display: grid;
+  gap: 12px;
+  overflow: auto;
+  padding: 16px;
+}
+
+.handoff-plan-status,
+.handoff-plan-section {
+  border: 1px solid var(--border);
+  border-radius: 0;
+  background: #000;
+}
+
+.handoff-plan-status {
+  display: grid;
+  gap: 4px;
+  padding: 12px;
+  border-left-color: var(--status-info);
+}
+
+.handoff-plan-status span,
+.handoff-plan-kv span,
+.handoff-plan-list span,
+.handoff-plan-paths span {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+}
+
+.handoff-plan-status strong {
+  font-weight: 500;
+}
+
+.handoff-plan-status[data-status='ready'] {
+  border-left-color: var(--status-success);
+}
+
+.handoff-plan-status[data-status='blocked'],
+.handoff-plan-status[data-status='offline'] {
+  border-left-color: var(--status-error);
+}
+
+.handoff-plan-status[data-status='needs-grants'],
+.handoff-plan-status[data-status='stale'] {
+  border-left-color: var(--status-warning);
+}
+
+.handoff-plan-section {
+  display: grid;
+  gap: 12px;
+  padding: 12px;
+}
+
+.handoff-plan-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.handoff-plan-kv {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.handoff-plan-kv strong,
+.handoff-plan-list strong,
+.handoff-plan-paths strong,
+.handoff-plan-paths em {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font-size: var(--font-size-sm);
+  font-style: normal;
+  font-weight: 500;
+}
+
+.handoff-plan-file-groups {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.handoff-plan-file-groups details {
+  border: 1px solid var(--border);
+  border-radius: 0;
+}
+
+.handoff-plan-file-groups summary {
+  min-height: 44px;
+  padding: 12px;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.handoff-plan-file-groups ul,
+.handoff-plan-list,
+.handoff-plan-paths {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.handoff-plan-file-groups ul {
+  padding: 0 12px 12px;
+}
+
+.handoff-plan-list li,
+.handoff-plan-paths li {
+  display: grid;
+  gap: 4px;
+  min-height: 44px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+}
+
+.handoff-plan-list--danger li {
+  border-top-color: color-mix(in srgb, var(--status-error) 45%, var(--border));
+}
+
+.handoff-plan-list--warning li {
+  border-top-color: color-mix(in srgb, var(--status-warning) 45%, var(--border));
+}
+
+@media (max-width: 720px) {
+  .handoff-plan-backdrop {
+    align-items: stretch;
+    padding: 0;
+  }
+
+  .handoff-plan-dialog {
+    width: 100%;
+    max-height: 100vh;
+  }
+
+  .handoff-plan-header,
+  .handoff-plan-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .handoff-plan-grid,
+  .handoff-plan-file-groups {
+    grid-template-columns: 1fr;
+  }
+
+  .handoff-plan-fixture,
+  .handoff-plan-footer button {
+    width: 100%;
+    min-height: 44px;
+  }
+}

--- a/frontend/src/components/dialogs/HandoffPlanDialog.tsx
+++ b/frontend/src/components/dialogs/HandoffPlanDialog.tsx
@@ -1,0 +1,233 @@
+import { useMemo, useState } from 'react';
+import {
+  DEFAULT_HANDOFF_FIXTURE_KEY,
+  HANDOFF_CANONICAL_COPY,
+  HANDOFF_FIXTURE_ORDER,
+  getHandoffPlanFixture,
+  fixtureTransferModeLabel,
+  type HandoffFixtureKey,
+  type HandoffPlanFixture,
+} from '../../lib/handoff-fixtures.js';
+import { TuiButton } from '../TuiButton.js';
+import './HandoffPlanDialog.css';
+
+export interface HandoffPlanDialogProps {
+  open: boolean;
+  onClose: () => void;
+  initialFixture?: HandoffFixtureKey;
+}
+
+function fileSizeLabel(bytes: number): string {
+  if (bytes <= 0) return '0 b';
+  if (bytes < 1024) return `${bytes} b`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} kb`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} mb`;
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="handoff-plan-section">
+      <h3>{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+function KeyValue({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="handoff-plan-kv">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}
+
+function EmptyLine({ text }: { text: string }) {
+  return <p className="handoff-plan-empty">{text}</p>;
+}
+
+function FileGroups({ fixture }: { fixture: HandoffPlanFixture }) {
+  const { plan } = fixture;
+  return (
+    <div className="handoff-plan-file-groups">
+      <details open={plan.includedGroups.length <= 1}>
+        <summary>includes · {plan.includedGroups.length}</summary>
+        {plan.includedGroups.length ? (
+          <ul>
+            {plan.includedGroups.map((group) => (
+              <li key={group}>{group.replaceAll('-', ' ')}</li>
+            ))}
+          </ul>
+        ) : (
+          <EmptyLine text="nothing selected for transfer" />
+        )}
+      </details>
+      <details open={false}>
+        <summary>excludes · {plan.excludedGroups.length}</summary>
+        {plan.excludedGroups.length ? (
+          <ul>
+            {plan.excludedGroups.map((group) => (
+              <li key={group}>{group.replaceAll('-', ' ')}</li>
+            ))}
+          </ul>
+        ) : (
+          <EmptyLine text="no excluded groups" />
+        )}
+      </details>
+    </div>
+  );
+}
+
+export function HandoffPlanDialog({
+  open,
+  onClose,
+  initialFixture = DEFAULT_HANDOFF_FIXTURE_KEY,
+}: HandoffPlanDialogProps) {
+  const [fixtureKey, setFixtureKey] = useState<HandoffFixtureKey>(initialFixture);
+  const fixture = getHandoffPlanFixture(fixtureKey);
+  const plan = fixture.plan;
+  const routeLabel = `${plan.route.sourceNodeId} -> ${plan.route.destinationNodeId}`;
+  const transferSummary = useMemo(
+    () => `${plan.fileCount} files · ${fileSizeLabel(plan.byteCount)} · ${fixtureTransferModeLabel(plan.transferMode)}`,
+    [plan.byteCount, plan.fileCount, plan.transferMode]
+  );
+
+  if (!open) return null;
+
+  return (
+    <div className="handoff-plan-backdrop" role="presentation">
+      <section
+        className="handoff-plan-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="handoff-plan-title"
+      >
+        <header className="handoff-plan-header">
+          <div>
+            <p className="handoff-plan-eyebrow">fixture dry run</p>
+            <h2 id="handoff-plan-title">handoff plan</h2>
+          </div>
+          <TuiButton size="sm" variant="ghost" onClick={onClose}>
+            close
+          </TuiButton>
+        </header>
+
+        <p className="handoff-plan-copy">{HANDOFF_CANONICAL_COPY}</p>
+
+        <div className="handoff-plan-fixtures" aria-label="fixture states">
+          {HANDOFF_FIXTURE_ORDER.map((key) => (
+            <button
+              key={key}
+              type="button"
+              className="handoff-plan-fixture"
+              data-active={key === fixtureKey}
+              onClick={() => setFixtureKey(key)}
+            >
+              {key.replaceAll('-', ' ')}
+            </button>
+          ))}
+        </div>
+
+        <div className="handoff-plan-body">
+          <div className="handoff-plan-status" data-status={fixture.status}>
+            <span>{fixture.status}</span>
+            <strong>{fixture.statusCopy}</strong>
+          </div>
+
+          <Section title="route">
+            <div className="handoff-plan-grid">
+              <KeyValue label="path" value={routeLabel} />
+              <KeyValue label="workcontext" value={plan.route.workContextId} />
+              <KeyValue label="source cwd" value={plan.source.cwd} />
+              <KeyValue label="destination path" value={plan.destinationProposal.cwd} />
+            </div>
+          </Section>
+
+          <Section title="transfer mode">
+            <div className="handoff-plan-grid">
+              <KeyValue label="mode" value={fixtureTransferModeLabel(plan.transferMode)} />
+              <KeyValue label="payload" value={transferSummary} />
+              <KeyValue label="destination action" value={plan.destinationProposal.action ?? 'use cwd'} />
+              <KeyValue label="launch runtime" value={plan.launchPreview.runtime.providerId ?? plan.launchPreview.runtime.kind} />
+            </div>
+          </Section>
+
+          <Section title="includes and excludes">
+            <FileGroups fixture={fixture} />
+            {plan.pathMappings.length ? (
+              <ul className="handoff-plan-paths">
+                {plan.pathMappings.map((mapping) => (
+                  <li key={`${mapping.kind}:${mapping.destination.path}`}>
+                    <span>{mapping.kind}</span>
+                    <strong>{mapping.summary ?? mapping.destination.path}</strong>
+                    <em>{mapping.destination.path}</em>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <EmptyLine text="no files selected; continuation uses metadata only" />
+            )}
+          </Section>
+
+          <Section title="conflicts">
+            {plan.conflicts.length ? (
+              <ul className="handoff-plan-list handoff-plan-list--danger">
+                {plan.conflicts.map((item) => (
+                  <li key={`${item.code}:${item.message}`}>
+                    <span>{item.code.toLowerCase().replaceAll('_', ' ')}</span>
+                    <strong>{item.message}</strong>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <EmptyLine text="no conflicts in this fixture" />
+            )}
+          </Section>
+
+          <Section title="grants">
+            {plan.requiredGrants.length ? (
+              <ul className="handoff-plan-list handoff-plan-list--warning">
+                {plan.requiredGrants.map((grant) => (
+                  <li key={`${grant.leg}:${grant.capability}`}>
+                    <span>{grant.leg.replaceAll('-', ' ')}</span>
+                    <strong>{grant.capability}</strong>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <EmptyLine text="no additional grants requested" />
+            )}
+          </Section>
+
+          <Section title="source session outcome">
+            <p className="handoff-plan-copy">{fixture.sourceSessionOutcome}</p>
+          </Section>
+
+          <Section title="launch summary">
+            <p className="handoff-plan-copy">{plan.launchPreview.summary}</p>
+          </Section>
+
+          <Section title="agent continuation">
+            <div className="handoff-plan-grid">
+              <KeyValue label="mode" value={fixture.agentContinuation.mode.replaceAll('-', ' ')} />
+              <KeyValue label="confidence" value={fixture.agentContinuation.confidence} />
+            </div>
+            <p className="handoff-plan-copy">{fixture.agentContinuation.summary}</p>
+          </Section>
+        </div>
+
+        <footer className="handoff-plan-footer">
+          <div>
+            <span>{transferSummary}</span>
+            <strong>{fixture.confirmDisabledReason}</strong>
+          </div>
+          <TuiButton size="sm" variant="primary" disabled title={fixture.confirmDisabledReason}>
+            {fixture.confirmLabel}
+          </TuiButton>
+        </footer>
+      </section>
+    </div>
+  );
+}
+
+export default HandoffPlanDialog;

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -17,6 +17,7 @@ import {
   sessionRename,
   sessionStartWorkInEnv,
 } from '../lib/actions/definitions/session.js';
+import { sessionHandoffToHub } from '../lib/actions/definitions/handoff.js';
 import { createFrameworkAction } from '../lib/actions/definitions/frameworks.js';
 import { isFrameworkAvailable } from '../components/dialogs/CustomizeSessionDialog.js';
 import {
@@ -226,6 +227,13 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
         ...sessionStartWorkInEnv,
         handler: () =>
           useUiStore.getState().setActiveModal({ modal: 'env-picker' }),
+      },
+      {
+        // #692: fixture-backed dry-run only. Opening this action must never
+        // transfer state or start a hub session until #691 execute wiring lands.
+        ...sessionHandoffToHub,
+        handler: () =>
+          useUiStore.getState().setActiveModal({ modal: 'handoff-plan' }),
       },
       {
         ...sessionCustomize,

--- a/frontend/src/lib/actions/definitions/handoff.ts
+++ b/frontend/src/lib/actions/definitions/handoff.ts
@@ -1,0 +1,14 @@
+import type { ActionMeta } from '../types.js';
+
+export const sessionHandoffToHub: ActionMeta = {
+  id: 'session.handoff-to-hub',
+  label: 'handoff to hub…',
+  description: 'open a fixture dry-run plan; never transfers immediately',
+  aliases: ['handoff', 'move to hub', 'laptop closing', 'continue on hub'],
+  category: 'session',
+  icon: '>',
+  when: (ctx) => !!ctx.sessionId,
+  disabledReason: (ctx) =>
+    ctx.sessionId ? undefined : 'select a session before planning a hub handoff',
+  mobile: { showInSheet: true, label: 'handoff' },
+};

--- a/frontend/src/lib/handoff-fixtures.ts
+++ b/frontend/src/lib/handoff-fixtures.ts
@@ -1,0 +1,304 @@
+import {
+  HANDOFF_SCHEMA_VERSION,
+  type HandoffPlan,
+  type HandoffConflict,
+  type HandoffRequiredGrant,
+  type HandoffSnapshotGroup,
+  type HandoffTransferMode,
+} from '../../../shared/handoff.js';
+export const HANDOFF_CANONICAL_COPY =
+  'handoff restarts or continues this work on the hub with the same workcontext. it transfers selected working state and starts a new hub-side session. it does not migrate the live local process.';
+
+export type HandoffFixtureKey =
+  | 'clean'
+  | 'conflicts'
+  | 'grants-required'
+  | 'stale-source'
+  | 'offline-hub'
+  | 'non-git-snapshot'
+  | 'summary-only-agent-continuation';
+
+export type HandoffSourceSessionOutcome =
+  | 'left running locally'
+  | 'stop can be requested after launch'
+  | 'source is stale; refresh required'
+  | 'summary only; live process remains local';
+
+export interface HandoffAgentContinuationPreview {
+  mode: 'full-workcontext' | 'summary-only' | 'terminal-only';
+  confidence: 'high' | 'medium' | 'low';
+  summary: string;
+}
+
+export interface HandoffPlanFixture {
+  key: HandoffFixtureKey;
+  label: string;
+  status: 'ready' | 'blocked' | 'needs-grants' | 'stale' | 'offline';
+  statusCopy: string;
+  confirmLabel: string;
+  confirmDisabledReason: string;
+  plan: HandoffPlan;
+  sourceSessionOutcome: HandoffSourceSessionOutcome;
+  agentContinuation: HandoffAgentContinuationPreview;
+  collapsedGroups: HandoffSnapshotGroup[];
+}
+
+const NOW = '2026-05-22T03:00:00.000Z';
+const SOURCE_NODE = 'local';
+const HUB_NODE = 'hub';
+const SOURCE_CWD = '/Users/dev/relay-ide/.worktrees/692-handoff-ui-dry-run';
+const DESTINATION_CWD = '/srv/relay/workspaces/relay-ide/692-handoff-ui-dry-run';
+const WORK_CONTEXT_ID = 'wc:issue-692';
+const REQUEST_ID = 'handoff-request:fixture';
+
+function conflict(code: HandoffConflict['code'], message: string): HandoffConflict {
+  return { code, message, nodeId: HUB_NODE };
+}
+
+function grant(leg: HandoffRequiredGrant['leg'], capability: HandoffRequiredGrant['capability']): HandoffRequiredGrant {
+  return {
+    leg,
+    nodeId: leg === 'source-read' ? SOURCE_NODE : HUB_NODE,
+    capability,
+    decision: 'requiresConfirmation',
+    scope: { kind: 'repo', repoIds: ['github.com/donovan-yohan/relay-ide'] },
+  };
+}
+
+function basePlan(overrides: Partial<HandoffPlan> = {}): HandoffPlan {
+  const transferMode = overrides.transferMode ?? 'tracked-patch';
+  return {
+    schemaVersion: HANDOFF_SCHEMA_VERSION,
+    id: 'handoff-plan:clean',
+    requestId: REQUEST_ID,
+    createdAt: NOW,
+    source: {
+      nodeId: SOURCE_NODE,
+      sessionId: 'sess-local-692',
+      globalSessionId: 'local:sess-local-692',
+      workContextId: WORK_CONTEXT_ID,
+      cwd: SOURCE_CWD,
+      disposition: 'left-running',
+      durabilityState: 'running-attached',
+    },
+    route: {
+      sourceNodeId: SOURCE_NODE,
+      destinationNodeId: HUB_NODE,
+      workContextId: WORK_CONTEXT_ID,
+    },
+    transferMode,
+    includedGroups: transferMode === 'metadata-only' ? ['source-summary'] : ['tracked-patch', 'staged-metadata'],
+    excludedGroups: ['excluded-secret', 'excluded-cache'],
+    fileCount: transferMode === 'metadata-only' ? 0 : 12,
+    byteCount: transferMode === 'metadata-only' ? 0 : 18432,
+    destinationProposal: {
+      nodeId: HUB_NODE,
+      cwd: DESTINATION_CWD,
+      repoInstanceId: 'repo-instance:hub:relay-ide',
+      worktreeInstanceId: 'worktree-instance:hub:relay-ide:692',
+      branchName: 'feat/692-handoff-ui-dry-run',
+      action: 'create-worktree',
+      sourceCwd: SOURCE_CWD,
+      sourceNodeId: SOURCE_NODE,
+      summary: 'create a hub worktree from nightly, then apply selected working state',
+    },
+    pathMappings: [
+      {
+        kind: 'patch',
+        source: { nodeId: SOURCE_NODE, path: SOURCE_CWD },
+        destination: { nodeId: HUB_NODE, path: DESTINATION_CWD, mode: 'create' },
+        bytes: 16384,
+        sha256: 'sha256:tracked-fixture',
+        summary: 'tracked patch for frontend handoff dry-run surface',
+      },
+      {
+        kind: 'file',
+        source: { nodeId: SOURCE_NODE, path: `${SOURCE_CWD}/notes/handoff-plan.md` },
+        destination: { nodeId: HUB_NODE, path: `${DESTINATION_CWD}/notes/handoff-plan.md`, mode: 'create' },
+        bytes: 2048,
+        sha256: 'sha256:approved-untracked-fixture',
+        summary: 'operator-approved untracked handoff notes',
+      },
+    ],
+    conflicts: [],
+    requiredGrants: [],
+    launchPreview: {
+      nodeId: HUB_NODE,
+      cwd: DESTINATION_CWD,
+      runtime: {
+        kind: 'agent',
+        providerId: 'claude',
+        commandSummary: 'start a new hub-side agent session from the transferred workcontext',
+        requiredCapabilities: ['session:create:agent', 'rpc:fs:write', 'rpc:git:write'],
+      },
+      summary: 'start a new hub-side claude session with the same workcontext after transfer',
+      workContextId: WORK_CONTEXT_ID,
+    },
+    ...overrides,
+  };
+}
+
+function fixture(
+  key: HandoffFixtureKey,
+  overrides: Partial<HandoffPlanFixture> & { plan?: HandoffPlan }
+): HandoffPlanFixture {
+  return {
+    key,
+    label: key.replaceAll('-', ' '),
+    status: 'ready',
+    statusCopy: 'fixture dry run only; #691 live execute wiring is unavailable',
+    confirmLabel: 'start on hub',
+    confirmDisabledReason: 'live handoff execute is unavailable until #691 lands',
+    plan: overrides.plan ?? basePlan({ id: `handoff-plan:${key}` }),
+    sourceSessionOutcome: 'left running locally',
+    agentContinuation: {
+      mode: 'full-workcontext',
+      confidence: 'high',
+      summary: 'continue with workcontext summary, selected patch state, and task refs',
+    },
+    collapsedGroups: ['tracked-patch', 'approved-untracked'],
+    ...overrides,
+  };
+}
+
+export const HANDOFF_PLAN_FIXTURES: Record<HandoffFixtureKey, HandoffPlanFixture> = {
+  clean: fixture('clean', {
+    statusCopy: 'clean plan; live confirm remains disabled in fixture mode',
+  }),
+  conflicts: fixture('conflicts', {
+    status: 'blocked',
+    statusCopy: 'destination has conflicts; resolve before starting hub session',
+    confirmDisabledReason: 'blocked: destination conflict and untracked collision',
+    plan: basePlan({
+      id: 'handoff-plan:conflicts',
+      conflicts: [
+        conflict('DESTINATION_CONFLICT', 'destination worktree already changed frontend/src/App.tsx'),
+        conflict('UNTRACKED_COLLISION', 'untracked notes/handoff-plan.md already exists on hub'),
+      ],
+    }),
+  }),
+  'grants-required': fixture('grants-required', {
+    status: 'needs-grants',
+    statusCopy: 'additional grants are required before the dry run can execute',
+    confirmDisabledReason: 'blocked: source read and destination write grants required',
+    plan: basePlan({
+      id: 'handoff-plan:grants-required',
+      requiredGrants: [
+        grant('source-read', 'session:read'),
+        grant('destination-write', 'rpc:fs:write'),
+        grant('destination-session-create', 'session:create:agent'),
+      ],
+    }),
+  }),
+  'stale-source': fixture('stale-source', {
+    status: 'stale',
+    statusCopy: 'source read model is stale; refresh local session state first',
+    confirmDisabledReason: 'blocked: source session is stale',
+    sourceSessionOutcome: 'source is stale; refresh required',
+    plan: basePlan({
+      id: 'handoff-plan:stale-source',
+      source: {
+        nodeId: SOURCE_NODE,
+        sessionId: 'sess-local-692',
+        globalSessionId: 'local:sess-local-692',
+        workContextId: WORK_CONTEXT_ID,
+        cwd: SOURCE_CWD,
+        disposition: 'stale-source',
+        durabilityState: 'stale-node',
+      },
+      conflicts: [conflict('STALE_SOURCE', 'source session freshness is older than the latest workcontext event')],
+    }),
+  }),
+  'offline-hub': fixture('offline-hub', {
+    status: 'offline',
+    statusCopy: 'hub node is offline; plan is readable but cannot start',
+    confirmDisabledReason: 'blocked: destination hub is offline',
+    plan: basePlan({
+      id: 'handoff-plan:offline-hub',
+      destinationProposal: {
+        nodeId: HUB_NODE,
+        cwd: DESTINATION_CWD,
+        action: 'create-worktree',
+        sourceCwd: SOURCE_CWD,
+        sourceNodeId: SOURCE_NODE,
+        summary: 'hub inventory is last-known only; wait for node heartbeat',
+      },
+      conflicts: [conflict('DESTINATION_UNAVAILABLE', 'hub node has no fresh heartbeat')],
+    }),
+  }),
+  'non-git-snapshot': fixture('non-git-snapshot', {
+    statusCopy: 'directory snapshot uses approved files and metadata only; no git assumptions',
+    plan: basePlan({
+      id: 'handoff-plan:non-git-snapshot',
+      transferMode: 'approved-untracked-files',
+      includedGroups: ['approved-untracked', 'source-summary'],
+      excludedGroups: ['excluded-secret', 'excluded-cache'],
+      destinationProposal: {
+        nodeId: HUB_NODE,
+        cwd: '/srv/relay/scratch/design-spike',
+        action: 'use-cwd',
+        sourceCwd: '/Users/dev/design-spike',
+        sourceNodeId: SOURCE_NODE,
+        summary: 'copy approved directory files into a hub scratch cwd; no repo badge or git actions',
+      },
+      pathMappings: [
+        {
+          kind: 'directory',
+          source: { nodeId: SOURCE_NODE, path: '/Users/dev/design-spike' },
+          destination: { nodeId: HUB_NODE, path: '/srv/relay/scratch/design-spike', mode: 'create' },
+          bytes: 8192,
+          summary: 'approved non-git snapshot contents',
+        },
+      ],
+    }),
+  }),
+  'summary-only-agent-continuation': fixture('summary-only-agent-continuation', {
+    statusCopy: 'agent continuation is summary-only; no raw transcript or live process migration',
+    sourceSessionOutcome: 'summary only; live process remains local',
+    agentContinuation: {
+      mode: 'summary-only',
+      confidence: 'medium',
+      summary: 'continue from bounded workcontext summary and task refs; raw transcript and provider auth stay local',
+    },
+    plan: basePlan({
+      id: 'handoff-plan:summary-only-agent-continuation',
+      transferMode: 'metadata-only',
+      includedGroups: ['source-summary'],
+      excludedGroups: ['excluded-secret', 'excluded-cache'],
+      fileCount: 0,
+      byteCount: 0,
+      pathMappings: [],
+      launchPreview: {
+        nodeId: HUB_NODE,
+        cwd: DESTINATION_CWD,
+        runtime: {
+          kind: 'agent',
+          providerId: 'hermes',
+          commandSummary: 'start a fresh hub-side agent with workcontext summary only',
+          requiredCapabilities: ['session:create:agent'],
+        },
+        summary: 'start a new hub-side agent from summary only; no raw transcript sync',
+        workContextId: WORK_CONTEXT_ID,
+      },
+    }),
+  }),
+};
+
+export const DEFAULT_HANDOFF_FIXTURE_KEY: HandoffFixtureKey = 'clean';
+export const HANDOFF_FIXTURE_ORDER: HandoffFixtureKey[] = [
+  'clean',
+  'conflicts',
+  'grants-required',
+  'stale-source',
+  'offline-hub',
+  'non-git-snapshot',
+  'summary-only-agent-continuation',
+];
+
+export function getHandoffPlanFixture(key: HandoffFixtureKey = DEFAULT_HANDOFF_FIXTURE_KEY): HandoffPlanFixture {
+  return HANDOFF_PLAN_FIXTURES[key];
+}
+
+export function fixtureTransferModeLabel(mode: HandoffTransferMode): string {
+  return mode.replaceAll('-', ' ');
+}

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -423,6 +423,9 @@ export type ActiveModal =
   // #630: command-palette entry "start work in environment…" sets this
   // variant; App renders the EnvPickerDialog which embeds EnvironmentPicker.
   | { modal: 'env-picker' }
+  // #692: fixture-backed hub handoff dry-run surface. This is intentionally
+  // modal-only until the live #691 execute API is wired.
+  | { modal: 'handoff-plan' }
   | null;
 
 // ── State interface ────────────────────────────────────────────────────────

--- a/frontend/src/lib/url-nav.ts
+++ b/frontend/src/lib/url-nav.ts
@@ -23,6 +23,9 @@ export type ModalRoute =
   // ActiveModal, but it is intentionally NOT persisted to the URL — opening
   // it via deep link would race the env-inventory feed.
   | { modal: 'env-picker' }
+  // #692: handoff dry-run is also transient/in-memory. Deep-linking a fixture
+  // modal would imply live #691 planner availability that does not exist yet.
+  | { modal: 'handoff-plan' }
   | null;
 
 /** Parse `window.location.search` into a ModalRoute. */
@@ -47,6 +50,8 @@ export function buildQuery(modal: ModalRoute): string {
   if (modal.modal === 'add-repo') return '?add-repo';
   // #630: env-picker is in-memory only; no URL representation.
   if (modal.modal === 'env-picker') return '';
+  // #692: handoff dry-run is in-memory only until live planner APIs land.
+  if (modal.modal === 'handoff-plan') return '';
   return '';
 }
 

--- a/test/components/HandoffPlanDialog.test.ts
+++ b/test/components/HandoffPlanDialog.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { sessionHandoffToHub } from '../../frontend/src/lib/actions/definitions/handoff.js';
+import {
+  HANDOFF_CANONICAL_COPY,
+  HANDOFF_FIXTURE_ORDER,
+  getHandoffPlanFixture,
+} from '../../frontend/src/lib/handoff-fixtures.js';
+import { HandoffPlanDialog } from '../../frontend/src/components/dialogs/HandoffPlanDialog.js';
+import {
+  _resetForTesting,
+  getAction,
+  registerGlobal,
+} from '../../frontend/src/lib/actions/registry.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('handoff action meta', () => {
+  it('registers palette aliases without invoking transfer directly', () => {
+    _resetForTesting();
+    const handler = vi.fn();
+    registerGlobal([{ ...sessionHandoffToHub, handler }]);
+
+    const registered = getAction('session.handoff-to-hub');
+    expect(registered).toBeTruthy();
+    expect(registered?.label).toBe('handoff to hub…');
+    for (const alias of [
+      'handoff',
+      'move to hub',
+      'laptop closing',
+      'continue on hub',
+    ]) {
+      expect(registered?.aliases).toContain(alias);
+    }
+    expect(registered?.when?.({ view: 'session', sessionId: 'sess-1' })).toBe(
+      true
+    );
+    expect(registered?.when?.({ view: 'dashboard' })).toBe(false);
+    expect(registered?.disabledReason?.({ view: 'dashboard' })).toMatch(
+      /select a session/
+    );
+
+    registered?.handler({ view: 'session', sessionId: 'sess-1' });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('handoff dry-run fixtures', () => {
+  it('covers all required acceptance states', () => {
+    expect(HANDOFF_FIXTURE_ORDER).toEqual([
+      'clean',
+      'conflicts',
+      'grants-required',
+      'stale-source',
+      'offline-hub',
+      'non-git-snapshot',
+      'summary-only-agent-continuation',
+    ]);
+
+    for (const key of HANDOFF_FIXTURE_ORDER) {
+      const fixture = getHandoffPlanFixture(key);
+      expect(fixture.plan.route.destinationNodeId).toBeTruthy();
+      expect(fixture.plan.destinationProposal.cwd).toBeTruthy();
+      expect(fixture.confirmDisabledReason).toMatch(/#691|blocked|unavailable/);
+    }
+  });
+
+  it('models blocked, grant-required, non-git, and summary-only cases explicitly', () => {
+    expect(getHandoffPlanFixture('clean').plan.conflicts).toHaveLength(0);
+    expect(getHandoffPlanFixture('conflicts').plan.conflicts.length).toBeGreaterThan(0);
+    expect(
+      getHandoffPlanFixture('grants-required').plan.requiredGrants.length
+    ).toBeGreaterThan(0);
+    expect(getHandoffPlanFixture('stale-source').plan.source.disposition).toBe(
+      'stale-source'
+    );
+    expect(
+      getHandoffPlanFixture('offline-hub').plan.conflicts.some(
+        (conflict) => conflict.code === 'DESTINATION_UNAVAILABLE'
+      )
+    ).toBe(true);
+    expect(getHandoffPlanFixture('non-git-snapshot').plan.transferMode).toBe(
+      'approved-untracked-files'
+    );
+    expect(
+      getHandoffPlanFixture('summary-only-agent-continuation').agentContinuation
+        .mode
+    ).toBe('summary-only');
+    expect(
+      getHandoffPlanFixture('summary-only-agent-continuation').plan.pathMappings
+    ).toHaveLength(0);
+  });
+});
+
+describe('<HandoffPlanDialog />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function render(props: React.ComponentProps<typeof HandoffPlanDialog>) {
+    await act(async () => {
+      root.render(React.createElement(HandoffPlanDialog, props));
+    });
+  }
+
+  it('does not render when closed', async () => {
+    await render({ open: false, onClose: vi.fn() });
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('renders canonical copy, required sections, and disabled confirm', async () => {
+    await render({ open: true, onClose: vi.fn(), initialFixture: 'clean' });
+    const text = container.textContent ?? '';
+    expect(text).toContain(HANDOFF_CANONICAL_COPY);
+    for (const section of [
+      'route',
+      'transfer mode',
+      'destination path',
+      'includes and excludes',
+      'conflicts',
+      'grants',
+      'source session outcome',
+      'launch summary',
+      'agent continuation',
+    ]) {
+      expect(text).toContain(section);
+    }
+    const startButton = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'start on hub'
+    );
+    expect(startButton).toBeTruthy();
+    expect(startButton?.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('can switch fixture states without transferring', async () => {
+    const onClose = vi.fn();
+    await render({ open: true, onClose, initialFixture: 'clean' });
+    const conflictButton = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'conflicts'
+    );
+    expect(conflictButton).toBeTruthy();
+    await act(async () => {
+      conflictButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.textContent).toContain('destination has conflicts');
+    expect(container.textContent).toContain('destination conflict');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## summary
- add fixture-backed handoff plan dialog/sheet with clean, conflicts, grants required, stale source, offline hub, non-git snapshot, and summary-only continuation states
- wire command palette/session action aliases plus active session status and active work card entrypoints; all open the plan surface only
- keep `start on hub` disabled with #691 unavailable copy, so this cannot execute a live transfer yet

Refs #692, #683

## verification
- `npm test -- test/components/HandoffPlanDialog.test.ts`
- `npm run check` (passes; existing lint warnings only)
- `npm run build` (passes; existing chunk-size warning)

## browser qa
- not run with an interactive browser in this worker; current environment has terminal/test tooling only, so coverage is component-level happy-dom plus production build.
