### PR TITLE
Wire handoff UI to live API

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1337,6 +1337,8 @@ export default function App() {
       <HandoffPlanDialog
         open={activeModal?.modal === 'handoff-plan'}
         onClose={handleModalClose}
+        mode="live"
+        activeSession={activeSession ?? null}
       />
 
       {/* Full-page diff overlay */}

--- a/frontend/src/components/SessionStatusBar.tsx
+++ b/frontend/src/components/SessionStatusBar.tsx
@@ -145,7 +145,7 @@ export function SessionStatusBar({
           <button
             className="status-handoff"
             type="button"
-            title="open fixture dry-run handoff plan"
+            title="open cold handoff dry-run plan"
             onClick={onHandoffClick}
           >
             handoff

--- a/frontend/src/components/dialogs/HandoffPlanDialog.css
+++ b/frontend/src/components/dialogs/HandoffPlanDialog.css
@@ -147,13 +147,27 @@
 }
 
 .handoff-plan-status[data-status='blocked'],
-.handoff-plan-status[data-status='offline'] {
+.handoff-plan-status[data-status='offline'],
+.handoff-plan-status[data-status='capability-denied'],
+.handoff-plan-status[data-status='hub-unavailable'],
+.handoff-plan-status[data-status='error'] {
   border-left-color: var(--status-error);
 }
 
 .handoff-plan-status[data-status='needs-grants'],
-.handoff-plan-status[data-status='stale'] {
+.handoff-plan-status[data-status='stale'],
+.handoff-plan-status[data-status='source-stale'],
+.handoff-plan-status[data-status='creating'] {
   border-left-color: var(--status-warning);
+}
+
+.handoff-plan-status[data-status='loading'],
+.handoff-plan-status[data-status='empty'] {
+  border-left-color: var(--status-info);
+}
+
+.handoff-plan-status[data-status='created'] {
+  border-left-color: var(--status-success);
 }
 
 .handoff-plan-section {

--- a/frontend/src/components/dialogs/HandoffPlanDialog.tsx
+++ b/frontend/src/components/dialogs/HandoffPlanDialog.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import type { HandoffPlan, HandoffRun } from '../../../../shared/handoff.js';
 import {
   DEFAULT_HANDOFF_FIXTURE_KEY,
   HANDOFF_CANONICAL_COPY,
@@ -8,6 +9,16 @@ import {
   type HandoffFixtureKey,
   type HandoffPlanFixture,
 } from '../../lib/handoff-fixtures.js';
+import {
+  buildHandoffDraft,
+  createHandoffFromPlan,
+  handoffStatusFromError,
+  planHandoff,
+  type HandoffApiErrorView,
+  type HandoffDraft,
+  type HandoffLiveStatus,
+} from '../../lib/handoff-live.js';
+import type { SessionSummary } from '../../lib/types.js';
 import { TuiButton } from '../TuiButton.js';
 import './HandoffPlanDialog.css';
 
@@ -15,6 +26,19 @@ export interface HandoffPlanDialogProps {
   open: boolean;
   onClose: () => void;
   initialFixture?: HandoffFixtureKey;
+  mode?: 'live' | 'fixture';
+  activeSession?: SessionSummary | null;
+}
+
+interface PlanView {
+  plan: HandoffPlan;
+  status: HandoffLiveStatus | HandoffPlanFixture['status'];
+  statusCopy: string;
+  confirmLabel: string;
+  confirmDisabledReason: string | null;
+  sourceSessionOutcome: string;
+  agentContinuation: { mode: string; confidence: string; summary: string };
+  showFixtures: boolean;
 }
 
 function fileSizeLabel(bytes: number): string {
@@ -24,7 +48,11 @@ function fileSizeLabel(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} mb`;
 }
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function statusLabel(status: HandoffLiveStatus | HandoffPlanFixture['status']): string {
+  return status.replaceAll('-', ' ');
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section className="handoff-plan-section">
       <h3>{title}</h3>
@@ -33,7 +61,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   );
 }
 
-function KeyValue({ label, value }: { label: string; value: React.ReactNode }) {
+function KeyValue({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div className="handoff-plan-kv">
       <span>{label}</span>
@@ -46,8 +74,7 @@ function EmptyLine({ text }: { text: string }) {
   return <p className="handoff-plan-empty">{text}</p>;
 }
 
-function FileGroups({ fixture }: { fixture: HandoffPlanFixture }) {
-  const { plan } = fixture;
+function FileGroups({ plan }: { plan: HandoffPlan }) {
   return (
     <div className="handoff-plan-file-groups">
       <details open={plan.includedGroups.length <= 1}>
@@ -78,153 +105,400 @@ function FileGroups({ fixture }: { fixture: HandoffPlanFixture }) {
   );
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function apiErrorMessage(error: HandoffApiErrorView): string {
+  if (error.code === 'CAPABILITY_DENIED') {
+    return 'capability denied: handoff grants are not available to this browser session yet';
+  }
+  if (error.code === 'SOURCE_STALE_OR_OFFLINE') {
+    return 'source is stale or offline; refresh the active WorkContext before retrying';
+  }
+  if (error.code === 'DESTINATION_UNAVAILABLE') {
+    return 'hub unavailable; plan cannot start a destination session yet';
+  }
+  return error.message;
+}
+
+function conflictsFromError(error: HandoffApiErrorView) {
+  const conflicts = error.details?.conflicts;
+  return Array.isArray(conflicts) ? conflicts.filter(isRecord) : [];
+}
+
+function runFromError(error: HandoffApiErrorView): HandoffRun | null {
+  const run = error.details?.run;
+  return isRecord(run) ? (run as unknown as HandoffRun) : null;
+}
+
+function fixtureView(fixture: HandoffPlanFixture): PlanView {
+  return {
+    plan: fixture.plan,
+    status: fixture.status,
+    statusCopy: fixture.statusCopy,
+    confirmLabel: fixture.confirmLabel,
+    confirmDisabledReason: fixture.confirmDisabledReason,
+    sourceSessionOutcome: fixture.sourceSessionOutcome,
+    agentContinuation: fixture.agentContinuation,
+    showFixtures: true,
+  };
+}
+
+function liveView(plan: HandoffPlan, run: HandoffRun | null): PlanView {
+  const hasConflicts = plan.conflicts.length > 0;
+  const needsGrants = plan.requiredGrants.some((grant) => grant.decision !== 'allow');
+  const status: HandoffLiveStatus = run
+    ? 'created'
+    : hasConflicts
+      ? 'blocked'
+      : needsGrants
+        ? 'needs-grants'
+        : 'ready';
+  const confirmDisabledReason = hasConflicts
+    ? 'blocked: resolve plan conflicts before starting a hub-side session'
+    : run
+      ? `run ${run.id} is ${run.state}`
+      : null;
+  return {
+    plan,
+    status,
+    statusCopy: run
+      ? `handoff API returned run ${run.id} (${run.state}); raw logs and transcripts are not exposed`
+      : hasConflicts
+        ? 'live API returned conflicts; cold handoff is review-only until resolved'
+        : needsGrants
+          ? 'live API returned a valid plan; confirm explicitly allows the listed grants for this cold snapshot'
+          : 'live API returned a clean plan; ready to request a hub-side continuation',
+    confirmLabel: run ? 'handoff requested' : 'start on hub',
+    confirmDisabledReason,
+    sourceSessionOutcome: plan.source.disposition.replaceAll('-', ' '),
+    agentContinuation: {
+      mode: plan.launchPreview.runtime.kind,
+      confidence: 'server planned',
+      summary: plan.launchPreview.summary,
+    },
+    showFixtures: false,
+  };
+}
+
+function PlanDetails({ view }: { view: PlanView }) {
+  const plan = view.plan;
+  const routeLabel = `${plan.route.sourceNodeId} -> ${plan.route.destinationNodeId}`;
+  const transferSummary = `${plan.fileCount} files · ${fileSizeLabel(plan.byteCount)} · ${fixtureTransferModeLabel(plan.transferMode)}`;
+  return (
+    <>
+      <div className="handoff-plan-status" data-status={view.status}>
+        <span>{statusLabel(view.status)}</span>
+        <strong>{view.statusCopy}</strong>
+      </div>
+
+      <Section title="route">
+        <div className="handoff-plan-grid">
+          <KeyValue label="path" value={routeLabel} />
+          <KeyValue label="workcontext" value={plan.route.workContextId} />
+          <KeyValue label="source cwd" value={plan.source.cwd} />
+          <KeyValue label="destination path" value={plan.destinationProposal.cwd} />
+        </div>
+      </Section>
+
+      <Section title="transfer mode">
+        <div className="handoff-plan-grid">
+          <KeyValue label="mode" value={fixtureTransferModeLabel(plan.transferMode)} />
+          <KeyValue label="payload" value={transferSummary} />
+          <KeyValue label="destination action" value={plan.destinationProposal.action ?? 'use cwd'} />
+          <KeyValue label="launch runtime" value={plan.launchPreview.runtime.providerId ?? plan.launchPreview.runtime.kind} />
+        </div>
+      </Section>
+
+      <Section title="includes and excludes">
+        <FileGroups plan={plan} />
+        {plan.pathMappings.length ? (
+          <ul className="handoff-plan-paths">
+            {plan.pathMappings.map((mapping) => (
+              <li key={`${mapping.kind}:${mapping.destination.path}`}>
+                <span>{mapping.kind}</span>
+                <strong>{mapping.summary ?? mapping.destination.path}</strong>
+                <em>{mapping.destination.path}</em>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <EmptyLine text="no files selected; continuation uses metadata only" />
+        )}
+      </Section>
+
+      <Section title="conflicts">
+        {plan.conflicts.length ? (
+          <ul className="handoff-plan-list handoff-plan-list--danger">
+            {plan.conflicts.map((item) => (
+              <li key={`${item.code}:${item.message}`}>
+                <span>{item.code.toLowerCase().replaceAll('_', ' ')}</span>
+                <strong>{item.message}</strong>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <EmptyLine text="no conflicts returned by this plan" />
+        )}
+      </Section>
+
+      <Section title="grants">
+        {plan.requiredGrants.length ? (
+          <ul className="handoff-plan-list handoff-plan-list--warning">
+            {plan.requiredGrants.map((grant) => (
+              <li key={`${grant.leg}:${grant.capability}`}>
+                <span>{grant.leg.replaceAll('-', ' ')}</span>
+                <strong>{grant.capability}</strong>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <EmptyLine text="no additional grants requested" />
+        )}
+      </Section>
+
+      <Section title="source session outcome">
+        <p className="handoff-plan-copy">{view.sourceSessionOutcome}</p>
+      </Section>
+
+      <Section title="launch summary">
+        <p className="handoff-plan-copy">{plan.launchPreview.summary}</p>
+      </Section>
+
+      <Section title="agent continuation">
+        <div className="handoff-plan-grid">
+          <KeyValue label="mode" value={view.agentContinuation.mode.replaceAll('-', ' ')} />
+          <KeyValue label="confidence" value={view.agentContinuation.confidence} />
+        </div>
+        <p className="handoff-plan-copy">{view.agentContinuation.summary}</p>
+      </Section>
+    </>
+  );
+}
+
+function useLiveHandoffPlan(open: boolean, enabled: boolean, activeSession: SessionSummary | null) {
+  const [draft, setDraft] = useState<HandoffDraft | null>(null);
+  const [plan, setPlan] = useState<HandoffPlan | null>(null);
+  const [run, setRun] = useState<HandoffRun | null>(null);
+  const [status, setStatus] = useState<HandoffLiveStatus>('idle');
+  const [emptyReason, setEmptyReason] = useState<string | null>(null);
+  const [error, setError] = useState<HandoffApiErrorView | null>(null);
+
+  useEffect(() => {
+    if (!open || !enabled) return;
+    const result = buildHandoffDraft(activeSession);
+    setDraft(result.draft);
+    setPlan(null);
+    setRun(null);
+    setError(null);
+    setEmptyReason(result.emptyReason ?? null);
+    if (!result.draft) {
+      setStatus('empty');
+      return;
+    }
+    let cancelled = false;
+    setStatus('loading');
+    void planHandoff(result.draft)
+      .then((response) => {
+        if (cancelled) return;
+        setPlan(response.plan);
+        setStatus(
+          response.plan.conflicts.length
+            ? 'blocked'
+            : response.plan.requiredGrants.length
+              ? 'needs-grants'
+              : 'ready'
+        );
+      })
+      .catch((caught: HandoffApiErrorView) => {
+        if (cancelled) return;
+        setError(caught);
+        setStatus(handoffStatusFromError(caught));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSession, enabled, open]);
+
+  const confirm = async () => {
+    if (!draft || !plan) return;
+    setStatus('creating');
+    setError(null);
+    try {
+      const response = await createHandoffFromPlan(draft, plan);
+      setRun(response.run);
+      setStatus('created');
+    } catch (caught) {
+      const apiError = caught as HandoffApiErrorView;
+      setError(apiError);
+      setRun(runFromError(apiError));
+      setStatus(handoffStatusFromError(apiError));
+    }
+  };
+
+  return { draft, plan, run, status, emptyReason, error, confirm };
+}
+
+function LiveFallbackBody({
+  status,
+  emptyReason,
+  error,
+}: {
+  status: HandoffLiveStatus;
+  emptyReason: string | null;
+  error: HandoffApiErrorView | null;
+}) {
+  if (status === 'loading') {
+    return (
+      <div className="handoff-plan-status" data-status="loading">
+        <span>loading</span>
+        <strong>requesting live cold handoff dry-run from the server</strong>
+      </div>
+    );
+  }
+  if (status === 'empty') {
+    return (
+      <div className="handoff-plan-status" data-status="empty">
+        <span>empty</span>
+        <strong>{emptyReason ?? 'no active handoff source'}</strong>
+      </div>
+    );
+  }
+  if (!error) return null;
+  const conflicts = conflictsFromError(error);
+  return (
+    <>
+      <div className="handoff-plan-status" data-status={status}>
+        <span>{statusLabel(status)}</span>
+        <strong>{apiErrorMessage(error)}</strong>
+      </div>
+      <Section title="api response">
+        <div className="handoff-plan-grid">
+          <KeyValue label="code" value={error.code} />
+          <KeyValue label="retryable" value={error.retryable ? 'yes' : 'no'} />
+          {error.reasonCode && <KeyValue label="reason" value={error.reasonCode} />}
+          {error.status && <KeyValue label="http" value={error.status} />}
+        </div>
+        {conflicts.length ? (
+          <ul className="handoff-plan-list handoff-plan-list--danger">
+            {conflicts.map((item, index) => (
+              <li key={index}>
+                <span>{String(item.code ?? 'conflict').toLowerCase().replaceAll('_', ' ')}</span>
+                <strong>{String(item.message ?? 'typed handoff conflict')}</strong>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <EmptyLine text="no raw logs, transcripts, provider auth, or secrets are exposed" />
+        )}
+      </Section>
+    </>
+  );
+}
+
+function HandoffFooter({
+  status,
+  transferSummary,
+  confirmDisabledReason,
+  canConfirm,
+  confirmLabel,
+  onConfirm,
+}: {
+  status: HandoffLiveStatus;
+  transferSummary: string;
+  confirmDisabledReason: string;
+  canConfirm: boolean;
+  confirmLabel: string;
+  onConfirm: () => void;
+}) {
+  return (
+    <footer className="handoff-plan-footer">
+      <div>
+        <span>{status === 'creating' ? 'requesting handoff run' : transferSummary}</span>
+        <strong>{canConfirm ? 'ready: explicit grants will be confirmed for this plan only' : confirmDisabledReason}</strong>
+      </div>
+      <TuiButton
+        size="sm"
+        variant="primary"
+        disabled={!canConfirm}
+        title={canConfirm ? 'start hub-side continuation from this cold snapshot' : confirmDisabledReason}
+        onClick={onConfirm}
+      >
+        {status === 'creating' ? 'starting...' : confirmLabel}
+      </TuiButton>
+    </footer>
+  );
+}
+
 export function HandoffPlanDialog({
   open,
   onClose,
   initialFixture = DEFAULT_HANDOFF_FIXTURE_KEY,
+  mode,
+  activeSession = null,
 }: HandoffPlanDialogProps) {
+  const effectiveMode = mode ?? (activeSession ? 'live' : 'fixture');
+  const live = useLiveHandoffPlan(open, effectiveMode === 'live', activeSession);
   const [fixtureKey, setFixtureKey] = useState<HandoffFixtureKey>(initialFixture);
   const fixture = getHandoffPlanFixture(fixtureKey);
-  const plan = fixture.plan;
-  const routeLabel = `${plan.route.sourceNodeId} -> ${plan.route.destinationNodeId}`;
-  const transferSummary = useMemo(
-    () => `${plan.fileCount} files · ${fileSizeLabel(plan.byteCount)} · ${fixtureTransferModeLabel(plan.transferMode)}`,
-    [plan.byteCount, plan.fileCount, plan.transferMode]
-  );
+  const view = useMemo(() => {
+    if (effectiveMode === 'fixture') return fixtureView(fixture);
+    return live.plan ? liveView(live.plan, live.run) : null;
+  }, [effectiveMode, fixture, live.plan, live.run]);
+
+  const transferSummary = view
+    ? `${view.plan.fileCount} files · ${fileSizeLabel(view.plan.byteCount)} · ${fixtureTransferModeLabel(view.plan.transferMode)}`
+    : 'no plan loaded';
+  const confirmDisabledReason =
+    view?.confirmDisabledReason ??
+    live.emptyReason ??
+    (live.error ? apiErrorMessage(live.error) : 'handoff plan unavailable');
+  const canConfirm =
+    effectiveMode === 'live' &&
+    !!live.draft &&
+    !!live.plan &&
+    !!view &&
+    !view.confirmDisabledReason &&
+    live.status !== 'creating';
 
   if (!open) return null;
 
   return (
     <div className="handoff-plan-backdrop" role="presentation">
-      <section
-        className="handoff-plan-dialog"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="handoff-plan-title"
-      >
+      <section className="handoff-plan-dialog" role="dialog" aria-modal="true" aria-labelledby="handoff-plan-title">
         <header className="handoff-plan-header">
           <div>
-            <p className="handoff-plan-eyebrow">fixture dry run</p>
+            <p className="handoff-plan-eyebrow">{effectiveMode === 'live' ? 'live api dry run' : 'fixture dry run'}</p>
             <h2 id="handoff-plan-title">handoff plan</h2>
           </div>
-          <TuiButton size="sm" variant="ghost" onClick={onClose}>
-            close
-          </TuiButton>
+          <TuiButton size="sm" variant="ghost" onClick={onClose}>close</TuiButton>
         </header>
 
         <p className="handoff-plan-copy">{HANDOFF_CANONICAL_COPY}</p>
 
-        <div className="handoff-plan-fixtures" aria-label="fixture states">
-          {HANDOFF_FIXTURE_ORDER.map((key) => (
-            <button
-              key={key}
-              type="button"
-              className="handoff-plan-fixture"
-              data-active={key === fixtureKey}
-              onClick={() => setFixtureKey(key)}
-            >
-              {key.replaceAll('-', ' ')}
-            </button>
-          ))}
-        </div>
+        {view?.showFixtures && (
+          <div className="handoff-plan-fixtures" aria-label="fixture states">
+            {HANDOFF_FIXTURE_ORDER.map((key) => (
+              <button key={key} type="button" className="handoff-plan-fixture" data-active={key === fixtureKey} onClick={() => setFixtureKey(key)}>
+                {key.replaceAll('-', ' ')}
+              </button>
+            ))}
+          </div>
+        )}
 
         <div className="handoff-plan-body">
-          <div className="handoff-plan-status" data-status={fixture.status}>
-            <span>{fixture.status}</span>
-            <strong>{fixture.statusCopy}</strong>
-          </div>
-
-          <Section title="route">
-            <div className="handoff-plan-grid">
-              <KeyValue label="path" value={routeLabel} />
-              <KeyValue label="workcontext" value={plan.route.workContextId} />
-              <KeyValue label="source cwd" value={plan.source.cwd} />
-              <KeyValue label="destination path" value={plan.destinationProposal.cwd} />
-            </div>
-          </Section>
-
-          <Section title="transfer mode">
-            <div className="handoff-plan-grid">
-              <KeyValue label="mode" value={fixtureTransferModeLabel(plan.transferMode)} />
-              <KeyValue label="payload" value={transferSummary} />
-              <KeyValue label="destination action" value={plan.destinationProposal.action ?? 'use cwd'} />
-              <KeyValue label="launch runtime" value={plan.launchPreview.runtime.providerId ?? plan.launchPreview.runtime.kind} />
-            </div>
-          </Section>
-
-          <Section title="includes and excludes">
-            <FileGroups fixture={fixture} />
-            {plan.pathMappings.length ? (
-              <ul className="handoff-plan-paths">
-                {plan.pathMappings.map((mapping) => (
-                  <li key={`${mapping.kind}:${mapping.destination.path}`}>
-                    <span>{mapping.kind}</span>
-                    <strong>{mapping.summary ?? mapping.destination.path}</strong>
-                    <em>{mapping.destination.path}</em>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <EmptyLine text="no files selected; continuation uses metadata only" />
-            )}
-          </Section>
-
-          <Section title="conflicts">
-            {plan.conflicts.length ? (
-              <ul className="handoff-plan-list handoff-plan-list--danger">
-                {plan.conflicts.map((item) => (
-                  <li key={`${item.code}:${item.message}`}>
-                    <span>{item.code.toLowerCase().replaceAll('_', ' ')}</span>
-                    <strong>{item.message}</strong>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <EmptyLine text="no conflicts in this fixture" />
-            )}
-          </Section>
-
-          <Section title="grants">
-            {plan.requiredGrants.length ? (
-              <ul className="handoff-plan-list handoff-plan-list--warning">
-                {plan.requiredGrants.map((grant) => (
-                  <li key={`${grant.leg}:${grant.capability}`}>
-                    <span>{grant.leg.replaceAll('-', ' ')}</span>
-                    <strong>{grant.capability}</strong>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <EmptyLine text="no additional grants requested" />
-            )}
-          </Section>
-
-          <Section title="source session outcome">
-            <p className="handoff-plan-copy">{fixture.sourceSessionOutcome}</p>
-          </Section>
-
-          <Section title="launch summary">
-            <p className="handoff-plan-copy">{plan.launchPreview.summary}</p>
-          </Section>
-
-          <Section title="agent continuation">
-            <div className="handoff-plan-grid">
-              <KeyValue label="mode" value={fixture.agentContinuation.mode.replaceAll('-', ' ')} />
-              <KeyValue label="confidence" value={fixture.agentContinuation.confidence} />
-            </div>
-            <p className="handoff-plan-copy">{fixture.agentContinuation.summary}</p>
-          </Section>
+          {view ? <PlanDetails view={view} /> : <LiveFallbackBody status={live.status} emptyReason={live.emptyReason} error={live.error} />}
         </div>
 
-        <footer className="handoff-plan-footer">
-          <div>
-            <span>{transferSummary}</span>
-            <strong>{fixture.confirmDisabledReason}</strong>
-          </div>
-          <TuiButton size="sm" variant="primary" disabled title={fixture.confirmDisabledReason}>
-            {fixture.confirmLabel}
-          </TuiButton>
-        </footer>
+        <HandoffFooter
+          status={live.status}
+          transferSummary={transferSummary}
+          confirmDisabledReason={confirmDisabledReason}
+          canConfirm={canConfirm}
+          confirmLabel={view?.confirmLabel ?? 'start on hub'}
+          onConfirm={live.confirm}
+        />
       </section>
     </div>
   );

--- a/frontend/src/lib/handoff-live.ts
+++ b/frontend/src/lib/handoff-live.ts
@@ -1,0 +1,286 @@
+import {
+  ENVIRONMENT_OPTION_SCHEMA_VERSION,
+  type EnvironmentOption,
+} from '../../../shared/environment-option.js';
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  createRepoInstanceId,
+  createWorktreeInstanceId,
+} from '../../../shared/identity.js';
+import {
+  HANDOFF_SCHEMA_VERSION,
+  isHandoffPlan,
+  type HandoffPlan,
+  type HandoffRequest,
+  type HandoffRequiredGrant,
+  type HandoffRun,
+} from '../../../shared/handoff.js';
+import type { SessionSummary } from './types.js';
+
+export type HandoffLiveStatus =
+  | 'idle'
+  | 'loading'
+  | 'ready'
+  | 'needs-grants'
+  | 'blocked'
+  | 'empty'
+  | 'capability-denied'
+  | 'source-stale'
+  | 'hub-unavailable'
+  | 'error'
+  | 'creating'
+  | 'created';
+
+export interface HandoffApiErrorView {
+  code: string;
+  message: string;
+  retryable: boolean;
+  reasonCode?: string;
+  details?: Record<string, unknown>;
+  status?: number;
+}
+
+export interface HandoffPlanResponse {
+  plan: HandoffPlan;
+  dryRun?: unknown;
+  readOnly?: boolean;
+}
+
+export interface HandoffCreateResponse {
+  run: HandoffRun;
+  artifacts?: Array<{
+    id: string;
+    group: string;
+    summary: string;
+    refs?: string[];
+    rawPayloadAvailable?: false;
+    transcriptExportAvailable?: false;
+  }>;
+}
+
+export interface HandoffDraft {
+  request: HandoffRequest;
+  sourceRepoPath?: string;
+  destinationRepoPath?: string;
+  sourceBranchName?: string;
+}
+
+export interface HandoffDraftResult {
+  draft: HandoffDraft | null;
+  emptyReason?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function preferredCwd(session: SessionSummary): string {
+  return session.worktreePath ?? session.cwd ?? session.repoPath ?? '';
+}
+
+function destinationCwdFor(sourceCwd: string): string {
+  const clean = sourceCwd.startsWith('/') ? sourceCwd : `/${sourceCwd}`;
+  return `/relay-hub-cold-handoff${clean}`.replaceAll('//', '/');
+}
+
+function destinationOptionFor(session: SessionSummary, generatedAt: string): EnvironmentOption {
+  const destinationNodeId = 'hub';
+  const sourceCwd = preferredCwd(session);
+  const destinationCwd = destinationCwdFor(sourceCwd || session.id);
+  const sourceRepoPath = session.repoPath ?? session.worktreePath ?? null;
+  const repoInstanceId = sourceRepoPath
+    ? createRepoInstanceId(destinationNodeId, sourceRepoPath)
+    : undefined;
+  const worktreeInstanceId = session.worktreePath
+    ? createWorktreeInstanceId(destinationNodeId, destinationCwd)
+    : undefined;
+  return {
+    schemaVersion: ENVIRONMENT_OPTION_SCHEMA_VERSION,
+    id: `handoff:${destinationNodeId}:${destinationCwd}`,
+    node: {
+      nodeId: destinationNodeId,
+      kind: 'remote',
+      displayName: 'hub',
+      online: true,
+    },
+    capabilities: [
+      'session:read',
+      'session:create:agent',
+      'rpc:fs:read',
+      'rpc:fs:write',
+      'pty:exec:arbitrary',
+    ],
+    cwd: destinationCwd,
+    cwdMode: sourceRepoPath ? 'repo' : 'free',
+    freshness: 'fresh',
+    ...(repoInstanceId
+      ? {
+          repoInstance: {
+            repoInstanceId,
+            localPath: sourceRepoPath!,
+            repoIdentity: null,
+            ...(session.repoName ? { name: session.repoName } : {}),
+            currentBranch: session.branchName ?? null,
+          },
+        }
+      : {}),
+    ...(repoInstanceId && worktreeInstanceId
+      ? {
+          bench: {
+            worktreeInstanceId,
+            localPath: destinationCwd,
+            branchName: session.branchName ?? null,
+          },
+        }
+      : {}),
+    generatedAt,
+  };
+}
+
+export function buildHandoffDraft(session: SessionSummary | null | undefined): HandoffDraftResult {
+  if (!session) return { draft: null, emptyReason: 'select an active tab before requesting a cold handoff plan' };
+  const cwd = preferredCwd(session);
+  if (!cwd) return { draft: null, emptyReason: 'active tab has no cwd to snapshot' };
+  if (!session.workContextId) return { draft: null, emptyReason: 'active tab has no WorkContext yet' };
+
+  const requestedAt = new Date().toISOString();
+  const sourceNodeId = session.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  const destination = destinationOptionFor(session, requestedAt);
+  const request: HandoffRequest = {
+    schemaVersion: HANDOFF_SCHEMA_VERSION,
+    id: `handoff-request:${sourceNodeId}:${session.id}:${Date.now()}`,
+    requestedAt,
+    requestedByActorId: 'relay-frontend',
+    source: {
+      nodeId: sourceNodeId,
+      sessionId: session.id,
+      ...(session.globalSessionId ? { globalSessionId: session.globalSessionId } : {}),
+      workContextId: session.workContextId,
+      cwd,
+      disposition: session.durability === 'stale-node' ? 'stale-source' : 'left-running',
+      ...(session.durability ? { durabilityState: session.durability } : {}),
+    },
+    destination: {
+      nodeId: destination.node.nodeId,
+      option: destination,
+      cwd: destination.cwd,
+      ...(destination.repoInstance?.repoInstanceId ? { repoInstanceId: destination.repoInstance.repoInstanceId } : {}),
+      ...(destination.bench?.worktreeInstanceId ? { worktreeInstanceId: destination.bench.worktreeInstanceId } : {}),
+    },
+    desiredRuntime: {
+      kind: session.type === 'terminal' ? 'terminal' : 'agent',
+      ...(session.type === 'agent' ? { providerId: session.agent } : {}),
+      commandSummary: 'start a new hub-side session from the cold handoff snapshot',
+      requiredCapabilities: [
+        session.type === 'terminal' ? 'session:create:terminal' : 'session:create:agent',
+        'pty:exec:arbitrary',
+      ],
+    },
+    reason: 'frontend cold handoff dry-run request',
+  };
+
+  const sourceRepoPath = session.worktreePath ?? session.repoPath ?? undefined;
+  return {
+    draft: {
+      request,
+      ...(sourceRepoPath ? { sourceRepoPath } : {}),
+      ...(session.branchName ? { sourceBranchName: session.branchName } : {}),
+      destinationRepoPath: destination.cwd,
+    },
+  };
+}
+
+async function parseHandoffError(res: Response): Promise<HandoffApiErrorView> {
+  try {
+    const data = await res.json();
+    const error = isRecord(data?.error) ? data.error : null;
+    const code = typeof error?.code === 'string' ? error.code : `HTTP_${res.status}`;
+    return {
+      code,
+      message:
+        typeof error?.message === 'string'
+          ? error.message
+          : typeof data?.error === 'string'
+            ? data.error
+            : `handoff API returned HTTP ${res.status}`,
+      retryable: typeof error?.retryable === 'boolean' ? error.retryable : false,
+      ...(typeof error?.reasonCode === 'string' ? { reasonCode: error.reasonCode } : {}),
+      ...(isRecord(error?.details) ? { details: error.details } : {}),
+      status: res.status,
+    };
+  } catch {
+    return {
+      code: `HTTP_${res.status}`,
+      message: `handoff API returned HTTP ${res.status}`,
+      retryable: false,
+      status: res.status,
+    };
+  }
+}
+
+export async function planHandoff(draft: HandoffDraft): Promise<HandoffPlanResponse> {
+  const res = await fetch('/handoffs/plan', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      request: draft.request,
+      ...(draft.sourceRepoPath ? { sourceRepoPath: draft.sourceRepoPath } : {}),
+      ...(draft.sourceBranchName ? { sourceBranchName: draft.sourceBranchName } : {}),
+    }),
+  });
+  if (!res.ok) throw await parseHandoffError(res);
+  const body = (await res.json()) as HandoffPlanResponse;
+  if (!isHandoffPlan(body.plan)) {
+    throw {
+      code: 'INVALID_PLAN_RESPONSE',
+      message: 'handoff API response did not include a valid plan',
+      retryable: false,
+    } satisfies HandoffApiErrorView;
+  }
+  return body;
+}
+
+export function confirmedGrantsForPlan(plan: HandoffPlan): HandoffRequiredGrant[] {
+  return plan.requiredGrants.map((grant) => ({
+    ...grant,
+    decision: 'allow',
+  }));
+}
+
+export async function createHandoffFromPlan(
+  draft: HandoffDraft,
+  plan: HandoffPlan
+): Promise<HandoffCreateResponse> {
+  const res = await fetch('/handoffs/create', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      planId: plan.id,
+      confirmedGrants: confirmedGrantsForPlan(plan),
+      ...(draft.sourceRepoPath ? { sourceRepoPath: draft.sourceRepoPath } : {}),
+      ...(draft.destinationRepoPath ? { destinationRepoPath: draft.destinationRepoPath } : {}),
+      actorId: 'relay-frontend',
+    }),
+  });
+  if (!res.ok) {
+    const clone = res.clone();
+    const error = await parseHandoffError(res);
+    try {
+      const data = await clone.json();
+      if (isRecord(data?.run)) {
+        (error.details ??= {}).run = data.run;
+      }
+    } catch {
+      // ignore parse fallback; the typed error is enough for UI copy.
+    }
+    throw error;
+  }
+  return (await res.json()) as HandoffCreateResponse;
+}
+
+export function handoffStatusFromError(error: HandoffApiErrorView): HandoffLiveStatus {
+  if (error.code === 'CAPABILITY_DENIED') return 'capability-denied';
+  if (error.code === 'SOURCE_STALE_OR_OFFLINE' || error.code === 'STALE_PLAN') return 'source-stale';
+  if (error.code === 'DESTINATION_UNAVAILABLE') return 'hub-unavailable';
+  return 'error';
+}

--- a/test/components/HandoffPlanDialog.test.ts
+++ b/test/components/HandoffPlanDialog.test.ts
@@ -10,6 +10,7 @@ import {
   HANDOFF_FIXTURE_ORDER,
   getHandoffPlanFixture,
 } from '../../frontend/src/lib/handoff-fixtures.js';
+import type { SessionSummary } from '../../frontend/src/lib/types.js';
 import { HandoffPlanDialog } from '../../frontend/src/components/dialogs/HandoffPlanDialog.js';
 import {
   _resetForTesting,
@@ -111,6 +112,7 @@ describe('<HandoffPlanDialog />', () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    vi.unstubAllGlobals();
   });
 
   async function render(props: React.ComponentProps<typeof HandoffPlanDialog>) {
@@ -119,12 +121,37 @@ describe('<HandoffPlanDialog />', () => {
     });
   }
 
+  async function flushEffects() {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+
+  function activeSession(overrides: Partial<SessionSummary> = {}): SessionSummary {
+    return {
+      id: 'sess-local-692',
+      type: 'agent',
+      agent: 'claude',
+      repoName: 'relay-ide',
+      repoPath: '/Users/dev/relay-ide',
+      worktreePath: '/Users/dev/relay-ide/.worktrees/692-handoff-ui-live-api',
+      cwd: '/Users/dev/relay-ide/.worktrees/692-handoff-ui-live-api',
+      branchName: 'feat/692-handoff-ui-live-api',
+      displayName: 'handoff task',
+      createdAt: '2026-05-22T04:00:00.000Z',
+      lastActivity: '2026-05-22T04:01:00.000Z',
+      idle: false,
+      workContextId: 'wc:issue-692',
+      ...overrides,
+    };
+  }
+
   it('does not render when closed', async () => {
     await render({ open: false, onClose: vi.fn() });
     expect(container.querySelector('[role="dialog"]')).toBeNull();
   });
 
-  it('renders canonical copy, required sections, and disabled confirm', async () => {
+  it('renders canonical copy, required sections, and disabled confirm in fixture mode', async () => {
     await render({ open: true, onClose: vi.fn(), initialFixture: 'clean' });
     const text = container.textContent ?? '';
     expect(text).toContain(HANDOFF_CANONICAL_COPY);
@@ -161,5 +188,155 @@ describe('<HandoffPlanDialog />', () => {
     expect(container.textContent).toContain('destination has conflicts');
     expect(container.textContent).toContain('destination conflict');
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('renders live no-source state without calling the API', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await render({ open: true, onClose: vi.fn(), mode: 'live', activeSession: null });
+    await flushEffects();
+
+    expect(container.textContent).toContain('empty');
+    expect(container.textContent).toContain('select an active tab');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('requests a live plan and enables confirm only for the returned plan', async () => {
+    const fixturePlan = getHandoffPlanFixture('grants-required').plan;
+    const plan = {
+      ...fixturePlan,
+      pathMappings: [],
+      requiredGrants: [
+        { leg: 'source-read', nodeId: 'local', capability: 'rpc:fs:read' },
+        { leg: 'destination-write', nodeId: 'hub', capability: 'rpc:fs:write' },
+        { leg: 'destination-session-create', nodeId: 'hub', capability: 'session:create:agent' },
+        { leg: 'destination-exec', nodeId: 'hub', capability: 'pty:exec:arbitrary' },
+      ],
+    };
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === '/handoffs/plan') {
+        const body = JSON.parse(String(init?.body));
+        expect(body.request.source.workContextId).toBe('wc:issue-692');
+        expect(body.request.source.cwd).toContain('692-handoff-ui-live-api');
+        return new Response(JSON.stringify({ plan, readOnly: true }), { status: 200 });
+      }
+      if (url === '/handoffs/create') {
+        const body = JSON.parse(String(init?.body));
+        expect(body.planId).toBe(plan.id);
+        expect(body.confirmedGrants.every((grant: { decision?: string }) => grant.decision === 'allow')).toBe(true);
+        return new Response(
+          JSON.stringify({
+            run: {
+              schemaVersion: 1,
+              id: 'handoff-run-test',
+              requestId: plan.requestId,
+              planId: plan.id,
+              state: 'failed',
+              sourceDisposition: 'handoff-failed',
+              conflicts: [],
+              transitions: [],
+              createdAt: '2026-05-22T04:00:00.000Z',
+              updatedAt: '2026-05-22T04:00:00.000Z',
+            },
+            artifacts: [],
+          }),
+          { status: 201 }
+        );
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await render({ open: true, onClose: vi.fn(), mode: 'live', activeSession: activeSession() });
+    await flushEffects();
+
+    expect(container.textContent).toContain('live api dry run');
+    expect(container.textContent).toContain('live API returned a valid plan');
+    const startButton = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'start on hub'
+    );
+    expect(startButton?.hasAttribute('disabled')).toBe(false);
+
+    await act(async () => {
+      startButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushEffects();
+    expect(fetchMock).toHaveBeenCalledWith('/handoffs/create', expect.any(Object));
+    expect(container.textContent).toContain('handoff API returned run handoff-run-test');
+  });
+
+  it('maps live API capability denial to a typed blocked state', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 'CAPABILITY_DENIED',
+              message: 'missing validated capability context for handoff route',
+              retryable: false,
+              details: { missingCapabilities: ['session:read'] },
+            },
+          }),
+          { status: 403 }
+        )
+      )
+    );
+
+    await render({ open: true, onClose: vi.fn(), mode: 'live', activeSession: activeSession() });
+    await flushEffects();
+
+    expect(container.textContent).toContain('capability denied');
+    expect(container.textContent).toContain('no raw logs, transcripts, provider auth, or secrets are exposed');
+    const startButton = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'start on hub'
+    );
+    expect(startButton?.hasAttribute('disabled')).toBe(true);
+  });
+
+  it.each([
+    {
+      code: 'SOURCE_STALE_OR_OFFLINE',
+      status: 409,
+      expected: 'source is stale or offline',
+    },
+    {
+      code: 'DESTINATION_UNAVAILABLE',
+      status: 503,
+      expected: 'hub unavailable',
+    },
+  ])('maps live API $code to a typed non-secret error state', async ({ code, status, expected }) => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code,
+              message: `${code} should not expose raw payloads`,
+              retryable: false,
+              details: {
+                conflicts: [
+                  {
+                    code: code === 'DESTINATION_UNAVAILABLE' ? 'DESTINATION_UNAVAILABLE' : 'STALE_SOURCE',
+                    message: 'typed conflict summary only',
+                  },
+                ],
+              },
+            },
+          }),
+          { status }
+        )
+      )
+    );
+
+    await render({ open: true, onClose: vi.fn(), mode: 'live', activeSession: activeSession() });
+    await flushEffects();
+
+    expect(container.textContent).toContain(expected);
+    expect(container.textContent).toContain('typed conflict summary only');
+    expect(container.textContent).not.toContain('SECRET=');
+    expect(container.textContent).not.toContain('raw transcript');
   });
 });


### PR DESCRIPTION
## Summary
- Wire the handoff dialog to the live `/handoffs/plan` and `/handoffs/create` API shape instead of only fixture-backed state.
- Add typed live UI states for loading, empty/no WorkContext, capability denied, source stale, hub unavailable, generic error, valid plan/grants, creating, and created run responses.
- Keep copy scoped to cold snapshot + hub-side continuation and keep fixture/demo paths as tests only; no raw secrets/env/provider data/Hermes DB/raw transcripts are surfaced.

Closes #692
Refs #683, #691

## Verification
- `npm test -- test/components/HandoffPlanDialog.test.ts` (11/11)
- `npm run check` (passes; existing lint warnings only)
- `npm run build`
- Browser smoke via Playwright against built app on `http://127.0.0.1:45692`:
  - `/tmp/relay-handoff-no-workcontext.png`: handoff entrypoint opens live dialog and shows empty/no WorkContext state without calling `/handoffs/plan`.
  - `/tmp/relay-handoff-api-plan.png`: mocked API-backed `/handoffs/plan` returns a valid plan; UI shows grants/review sections and enables `start on hub` only for that returned plan.
  - `/tmp/relay-handoff-capability-denied.png`: mocked API-backed 403 `CAPABILITY_DENIED`; UI shows typed error and no raw logs/transcripts/provider/auth/secrets.
  - Console/network notes: expected mocked-session noise from xterm WebSocket 404 and telemetry/auth 403s in the standalone smoke; handoff network calls were observed as expected (`POST /handoffs/plan` for API-backed states, none for no-WorkContext).