### PR TITLE
Implement hub-side handoff launch

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -440,7 +440,7 @@ function requireGatewaySessionId(
 
 function gatewayUsage(): never {
   logger.error(
-    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions renew|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|files write|work-contexts get|handoffs plan|handoffs create|handoffs status|handoffs cancel|handoffs resume|artifacts read|events subscribe) --json'
+    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions renew|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|files write|work-contexts get|handoffs plan|handoffs create|handoffs status|handoffs cancel|handoffs resume|handoffs launch|artifacts read|events subscribe) --json'
   );
   process.exit(1);
 }
@@ -1561,6 +1561,19 @@ async function runGatewayHandoffs(gatewayArgs: string[]): Promise<never> {
       capabilities: ['session:read'],
     });
     printGatewayEnvelope(gatewayOk('handoffs.resume', result), 0);
+  }
+  if (subcommand === 'launch') {
+    const runId = gatewayArg(handoffArgs, '--run-id') ?? handoffArgs[0];
+    if (!runId || runId.startsWith('--')) gatewayInvalid('handoffs.launch', '--run-id is required');
+    const actorId = gatewayArg(handoffArgs, '--actor-id');
+    const result = await gatewayHttpJson({
+      commandName: 'handoffs.launch',
+      pathName: `/handoffs/${encodeURIComponent(runId)}/launch`,
+      method: 'POST',
+      body: actorId ? { actorId } : {},
+      capabilities: ['session:read', 'session:create:agent', 'session:create:terminal', 'pty:exec:arbitrary'],
+    });
+    printGatewayEnvelope(gatewayOk('handoffs.launch', result), 0);
   }
   gatewayInvalid('handoffs.plan', 'unknown handoffs command', { args: gatewayArgs });
 }

--- a/server/handoff-transfer.ts
+++ b/server/handoff-transfer.ts
@@ -139,6 +139,13 @@ function makeConflict(
   return { code, message, nodeId, ...(reasonCode ? { reasonCode } : {}) };
 }
 
+function mergeSourceDispositions(
+  current: readonly HandoffRun['sourceDisposition'][],
+  next: readonly HandoffRun['sourceDisposition'][]
+): HandoffRun['sourceDisposition'][] {
+  return Array.from(new Set([...current, ...next]));
+}
+
 function dryRunFingerprint(dryRun: HandoffPlannerDryRun): string {
   return JSON.stringify({
     branchName: dryRun.branchName,
@@ -254,6 +261,7 @@ function createRun(input: HandoffTransferApplyInput, now: string): HandoffRun {
     ...(input.snapshotId ? { snapshotId: input.snapshotId } : {}),
     state: 'planned',
     sourceDisposition: 'left-running',
+    sourceDispositions: ['left-running'],
     conflicts: [],
     transitions: [],
     createdAt: now,
@@ -305,6 +313,12 @@ function failResult(
   createId: () => string
 ): HandoffTransferApplyFailure {
   run.conflicts = conflicts;
+  const previousSourceDispositions = run.sourceDispositions ?? [run.sourceDisposition];
+  run.sourceDisposition = 'handoff-failed';
+  run.sourceDispositions = mergeSourceDispositions(
+    previousSourceDispositions,
+    ['handoff-failed']
+  );
   const at = now();
   transitionRun(run, 'failed', reasonCode, at, actorId, auditEvents, createId);
   const failureEvent: HandoffTransferAuditEvent = {

--- a/server/handoffs.ts
+++ b/server/handoffs.ts
@@ -382,6 +382,40 @@ function artifactRefsForWorkContext(
   }));
 }
 
+function handoffStateArtifactRefsForWorkContext(input: {
+  plan: HandoffPlan;
+  run: HandoffRun;
+  producedAt: string;
+  actorId?: string;
+}): ArtifactRef[] {
+  const privacy = createWorkContextPrivacyMetadata({ classification: 'internal' });
+  const refs: ArtifactRef[] = [
+    {
+      id: `handoff-run:${input.run.id}`,
+      kind: 'report',
+      title: 'HandoffRun',
+      summary: `HandoffRun ${input.run.id} ${input.run.state}/${input.run.reasonCode ?? 'unknown'} for plan ${input.plan.id}`,
+      uri: `handoff-run:${input.run.id}`,
+      ...(input.actorId ? { producedByActorId: input.actorId } : {}),
+      producedAt: input.producedAt,
+      privacy,
+    },
+  ];
+  if (input.run.snapshotId) {
+    refs.push({
+      id: `handoff-snapshot:${input.run.snapshotId}`,
+      kind: 'report',
+      title: 'HandoffSnapshot',
+      summary: `Applied handoff snapshot ${input.run.snapshotId} for run ${input.run.id}`,
+      uri: `handoff-snapshot:${input.run.snapshotId}`,
+      ...(input.actorId ? { producedByActorId: input.actorId } : {}),
+      producedAt: input.producedAt,
+      privacy,
+    });
+  }
+  return refs;
+}
+
 function auditRefsForWorkContext(
   run: HandoffRun,
   actorId?: string
@@ -842,6 +876,14 @@ export class HandoffService {
     });
     if (!launch.ok) {
       const failed = this.failLaunchRun(baseRun, launch, input.actorId);
+      this.recordWorkContextLaunchFailure({
+        plan: input.plan,
+        run: failed.run,
+        artifacts: input.artifacts,
+        launch,
+        ...(input.actorId ? { actorId: input.actorId } : {}),
+        at: failed.run.completedAt ?? failed.run.updatedAt,
+      });
       const status =
         launch.code === 'NODE_UNAVAILABLE' ? 404 :
         launch.code === 'HUB_UNAVAILABLE' ? 503 :
@@ -924,6 +966,50 @@ export class HandoffService {
     };
   }
 
+  private recordWorkContextLaunchFailure(input: {
+    plan: HandoffPlan;
+    run: HandoffRun;
+    artifacts: HandoffArtifactSummary[];
+    launch: {
+      code: 'HUB_UNAVAILABLE' | 'NODE_UNAVAILABLE' | 'LAUNCH_UNSUPPORTED' | 'LAUNCH_FAILED';
+      message: string;
+    };
+    actorId?: string;
+    at: string;
+  }): void {
+    const store = this.deps.workContextStore;
+    if (!store) return;
+    const existing = store.get(input.plan.route.workContextId);
+    if (!existing) return;
+    const artifactRefs = [
+      ...artifactRefsForWorkContext(
+        input.artifacts,
+        input.at,
+        input.actorId
+      ),
+      ...handoffStateArtifactRefsForWorkContext({
+        plan: input.plan,
+        run: input.run,
+        producedAt: input.at,
+        ...(input.actorId ? { actorId: input.actorId } : {}),
+      }),
+    ];
+    const auditRefs = auditRefsForWorkContext(input.run, input.actorId);
+    store.update(input.plan.route.workContextId, {
+      artifacts: dedupeById([...existing.artifacts, ...artifactRefs]),
+      auditRefs: dedupeById([...existing.auditRefs, ...auditRefs]),
+    });
+    const lifecycleEvent: WorkContextLifecycleEventInput = {
+      type: 'handoff.closed',
+      occurredAt: input.at,
+      correlationId: input.run.id,
+      artifacts: artifactRefs,
+      summary: `Destination session launch failed for cold handoff ${input.run.id}: ${input.launch.code}; retry launch is available without rerunning transfer. Source state: ${(input.run.sourceDispositions ?? [input.run.sourceDisposition]).join(', ')}`,
+    };
+    if (input.actorId) lifecycleEvent.actorId = input.actorId;
+    store.recordLifecycleEvent(input.plan.route.workContextId, lifecycleEvent);
+  }
+
   private recordWorkContextLaunch(input: {
     plan: HandoffPlan;
     run: HandoffRun;
@@ -936,11 +1022,19 @@ export class HandoffService {
     if (!store) return;
     const existing = store.get(input.plan.route.workContextId);
     if (!existing) return;
-    const artifactRefs = artifactRefsForWorkContext(
-      input.artifacts,
-      input.at,
-      input.actorId
-    );
+    const artifactRefs = [
+      ...artifactRefsForWorkContext(
+        input.artifacts,
+        input.at,
+        input.actorId
+      ),
+      ...handoffStateArtifactRefsForWorkContext({
+        plan: input.plan,
+        run: input.run,
+        producedAt: input.at,
+        ...(input.actorId ? { actorId: input.actorId } : {}),
+      }),
+    ];
     const auditRefs = auditRefsForWorkContext(input.run, input.actorId);
     store.update(input.plan.route.workContextId, {
       artifacts: dedupeById([...existing.artifacts, ...artifactRefs]),

--- a/server/handoffs.ts
+++ b/server/handoffs.ts
@@ -776,7 +776,7 @@ export class HandoffService {
         });
         this.runs.set(launched.run.id, {
           run: sanitizeRun(launched.run),
-          auditEvents: launched.auditEvents,
+          auditEvents: [...result.auditEvents, ...launched.auditEvents],
           artifacts: launched.artifacts,
         });
         if (launched.ok) {
@@ -894,6 +894,37 @@ export class HandoffService {
         artifacts: input.artifacts,
         auditEvents: failed.auditEvents,
         error: apiError(launch.code, launch.message, status, launch.details, 'FAILED_LAUNCH'),
+      };
+    }
+
+    if (!launch.acknowledgedBrief) {
+      const failed = this.failLaunchRun(baseRun, {
+        code: 'LAUNCH_FAILED',
+        message: 'destination session launched but did not acknowledge the bounded handoff brief',
+        details: {
+          runId: baseRun.id,
+          planId: input.plan.id,
+          sessionId: launch.session.id,
+          nodeId: launch.session.nodeId ?? input.plan.route.destinationNodeId,
+        },
+      }, input.actorId);
+      this.recordWorkContextLaunchFailure({
+        plan: input.plan,
+        run: failed.run,
+        artifacts: input.artifacts,
+        launch: {
+          code: 'LAUNCH_FAILED',
+          message: failed.message,
+        },
+        ...(input.actorId ? { actorId: input.actorId } : {}),
+        at: failed.run.completedAt ?? failed.run.updatedAt,
+      });
+      return {
+        ok: false,
+        run: failed.run,
+        artifacts: input.artifacts,
+        auditEvents: failed.auditEvents,
+        error: apiError('LAUNCH_FAILED', failed.message, 500, failed.details, 'FAILED_LAUNCH'),
       };
     }
 
@@ -1157,7 +1188,7 @@ export class HandoffService {
     });
     this.runs.set(launched.run.id, {
       run: sanitizeRun(launched.run),
-      auditEvents: launched.auditEvents,
+      auditEvents: [...stored.auditEvents, ...launched.auditEvents],
       artifacts: launched.artifacts,
     });
     if (launched.ok) {
@@ -1191,6 +1222,12 @@ export class HandoffService {
     return this.plans.get(planId)?.plan ?? null;
   }
 
+  getPlanForRun(runId: string): HandoffPlan | null {
+    const stored = this.runs.get(runId);
+    if (!stored?.run.planId) return null;
+    return this.getPlan(stored.run.planId);
+  }
+
   private createFailedRun(
     plan: HandoffPlan,
     conflicts: HandoffConflict[],
@@ -1206,7 +1243,7 @@ export class HandoffService {
       planId: plan.id,
       state: 'failed',
       sourceDisposition: 'handoff-failed',
-      sourceDispositions: ['left-running', 'handoff-failed'],
+      sourceDispositions: mergeSourceDispositions([plan.source.disposition], ['handoff-failed']),
       reasonCode,
       conflicts,
       transitions: [
@@ -1285,6 +1322,19 @@ function createRouteCapabilities(plan: HandoffPlan | null): readonly string[] {
     ? 'session:create:terminal'
     : 'session:create:agent';
   return ['rpc:fs:read', 'rpc:fs:write', sessionCreateCapability, 'pty:exec:arbitrary'];
+}
+
+function launchRouteCapabilities(plan: HandoffPlan | null): readonly string[] {
+  if (!plan) return [SESSION_READ_CAPABILITY];
+  const runtimeCapabilities = plan.launchPreview.runtime.requiredCapabilities.length > 0
+    ? plan.launchPreview.runtime.requiredCapabilities
+    : [
+        plan.launchPreview.runtime.kind === 'terminal'
+          ? 'session:create:terminal'
+          : 'session:create:agent',
+        'pty:exec:arbitrary',
+      ];
+  return Array.from(new Set([SESSION_READ_CAPABILITY, ...runtimeCapabilities]));
 }
 
 function planFromCreateBody(body: Record<string, unknown>, service: HandoffService): HandoffPlan | null {
@@ -1405,9 +1455,10 @@ export function createHandoffRouter(input: {
   });
 
   router.post('/:runId/launch', auth, async (req, res) => {
+    const runId = req.params['runId'] ?? '';
     const denied = requireCapabilities(
       req,
-      ['session:read', 'session:create:agent', 'session:create:terminal', 'pty:exec:arbitrary'],
+      launchRouteCapabilities(service.getPlanForRun(runId)),
       capabilityContext
     );
     if (denied) {
@@ -1416,7 +1467,7 @@ export function createHandoffRouter(input: {
     }
     const body = bodyRecord(req);
     const result = await service.retryLaunch(
-      req.params['runId'] ?? '',
+      runId,
       typeof body['actorId'] === 'string' ? body['actorId'] : undefined
     );
     if (!result.ok) {

--- a/server/handoffs.ts
+++ b/server/handoffs.ts
@@ -15,12 +15,23 @@ import {
   type HandoffRun,
   type HandoffRunTransition,
   type HandoffSnapshotGroup,
+  type HandoffSourceDisposition,
 } from '../shared/handoff.js';
 import { proposeHandoffDestination } from '../shared/handoff-destination.js';
+import {
+  createWorkContextPrivacyMetadata,
+  type ArtifactRef,
+  type AuditEventRef,
+} from '../shared/work-context.js';
 import type { RelayCapabilityBit } from '../shared/security-policy.js';
 import { planHandoffSnapshot, type HandoffPlannerDryRun } from './handoff-planner.js';
-import { applyHandoffTransfer, type HandoffTransferApplyInput } from './handoff-transfer.js';
-import type { WorkContextStore } from './work-contexts.js';
+import {
+  applyHandoffTransfer,
+  type HandoffTransferApplyInput,
+  type HandoffTransferApplyResult,
+} from './handoff-transfer.js';
+import type { WorkContextLifecycleEventInput, WorkContextStore } from './work-contexts.js';
+import type { SessionSummary } from './types.js';
 
 export const HANDOFF_PLAN_MAX_AGE_MS = 5 * 60 * 1000;
 export const HANDOFF_STATUS_MAX_CONFLICTS = 25;
@@ -39,10 +50,15 @@ export type HandoffApiErrorCode =
   | 'INVALID_PLAN_ID'
   | 'INVALID_WORK_CONTEXT_ID'
   | 'INVALID_SESSION_ID'
+  | 'INVALID_RUN_STATE'
   | 'STALE_PLAN'
   | 'CAPABILITY_DENIED'
   | 'SOURCE_STALE_OR_OFFLINE'
+  | 'HUB_UNAVAILABLE'
+  | 'NODE_UNAVAILABLE'
   | 'DESTINATION_UNAVAILABLE'
+  | 'LAUNCH_UNSUPPORTED'
+  | 'LAUNCH_FAILED'
   | 'MISSING_CONFIRMED_GRANT'
   | 'HANDOFF_RUN_NOT_FOUND'
   | 'HANDOFF_ARTIFACT_NOT_FOUND'
@@ -124,9 +140,35 @@ export interface HandoffArtifactSummary {
   transcriptExportAvailable: false;
 }
 
+export interface HandoffDestinationLaunchInput {
+  plan: HandoffPlan;
+  request: HandoffRequest;
+  run: HandoffRun;
+  artifacts: HandoffArtifactSummary[];
+  handoffBrief: string;
+}
+
+export type HandoffDestinationLaunchResult =
+  | { ok: true; session: SessionSummary; acknowledgedBrief: boolean }
+  | {
+      ok: false;
+      code: 'HUB_UNAVAILABLE' | 'NODE_UNAVAILABLE' | 'LAUNCH_UNSUPPORTED' | 'LAUNCH_FAILED';
+      message: string;
+      details?: Record<string, unknown>;
+    };
+
 export interface HandoffServiceDeps {
-  workContextStore?: Pick<WorkContextStore, 'get'>;
+  workContextStore?: Pick<
+    WorkContextStore,
+    'get' | 'associateSession' | 'recordLifecycleEvent' | 'update'
+  >;
   getSession?: (nodeId: string, sessionId: string) => unknown | undefined;
+  launchDestinationSession?: (
+    input: HandoffDestinationLaunchInput
+  ) => Promise<HandoffDestinationLaunchResult> | HandoffDestinationLaunchResult;
+  applyTransfer?: (
+    input: HandoffTransferApplyInput
+  ) => Promise<HandoffTransferApplyResult>;
   now?: () => Date;
   createId?: () => string;
 }
@@ -160,7 +202,13 @@ function apiError(
       error: {
         code,
         message,
-        retryable: code === 'SOURCE_STALE_OR_OFFLINE' || code === 'DESTINATION_UNAVAILABLE' || code === 'STALE_PLAN',
+        retryable:
+          code === 'SOURCE_STALE_OR_OFFLINE' ||
+          code === 'DESTINATION_UNAVAILABLE' ||
+          code === 'NODE_UNAVAILABLE' ||
+          code === 'HUB_UNAVAILABLE' ||
+          code === 'LAUNCH_FAILED' ||
+          code === 'STALE_PLAN',
         ...(reasonCode ? { reasonCode } : {}),
         ...(details ? { details } : {}),
       },
@@ -183,6 +231,177 @@ function sanitizeRun(run: HandoffRun): HandoffRun {
     conflicts: run.conflicts.slice(0, HANDOFF_STATUS_MAX_CONFLICTS),
     transitions: run.transitions.slice(-HANDOFF_STATUS_MAX_CONFLICTS),
   };
+}
+
+function mergeSourceDispositions(
+  current: readonly HandoffSourceDisposition[],
+  next: readonly HandoffSourceDisposition[]
+): HandoffSourceDisposition[] {
+  return Array.from(new Set([...current, ...next]));
+}
+
+function transition(
+  run: HandoffRun,
+  to: HandoffRun['state'],
+  reasonCode: HandoffReasonCode,
+  at: string,
+  actorId?: string
+): HandoffRunTransition {
+  const item: HandoffRunTransition = {
+    from: run.state,
+    to,
+    at,
+    reasonCode,
+    ...(actorId ? { actorId } : {}),
+  };
+  run.transitions = [...run.transitions, item];
+  run.state = to;
+  run.reasonCode = reasonCode;
+  run.updatedAt = at;
+  if (to === 'complete' || to === 'failed' || to === 'cancelled') {
+    run.completedAt = at;
+  } else {
+    delete run.completedAt;
+  }
+  return item;
+}
+
+function openRunCopy(
+  run: HandoffRun,
+  patchInput: Omit<Partial<HandoffRun>, 'completedAt'> = {}
+): HandoffRun {
+  const copy: HandoffRun = {
+    schemaVersion: run.schemaVersion,
+    id: run.id,
+    requestId: run.requestId,
+    ...(run.planId ? { planId: run.planId } : {}),
+    ...(run.snapshotId ? { snapshotId: run.snapshotId } : {}),
+    state: run.state,
+    sourceDisposition: run.sourceDisposition,
+    ...(run.sourceDispositions ? { sourceDispositions: run.sourceDispositions } : {}),
+    ...(run.reasonCode ? { reasonCode: run.reasonCode } : {}),
+    conflicts: run.conflicts,
+    transitions: run.transitions,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+  };
+  return { ...copy, ...patchInput };
+}
+
+function rewindApplyComplete(run: HandoffRun): HandoffRun {
+  const transitions = run.transitions.slice();
+  const last = transitions.at(-1);
+  if (
+    run.state === 'complete' &&
+    last?.from === 'applying' &&
+    last.to === 'complete' &&
+    last.reasonCode === 'APPLY_COMPLETED'
+  ) {
+    transitions.pop();
+    return openRunCopy(run, {
+      state: 'applying',
+      reasonCode: 'APPLY_COMPLETED',
+      transitions,
+      updatedAt: transitions.at(-1)?.at ?? run.updatedAt,
+    });
+  }
+  return run;
+}
+
+function sourceDispositionsForAppliedRun(
+  plan: HandoffPlan,
+  run: HandoffRun
+): HandoffSourceDisposition[] {
+  return mergeSourceDispositions(
+    run.sourceDispositions ?? [run.sourceDisposition],
+    [plan.source.disposition]
+  );
+}
+
+function sourceDispositionsForLaunch(
+  plan: HandoffPlan,
+  run: HandoffRun
+): HandoffSourceDisposition[] {
+  return mergeSourceDispositions(
+    sourceDispositionsForAppliedRun(plan, run),
+    ['handed-off']
+  );
+}
+
+function rewindLaunchAttempt(run: HandoffRun): HandoffRun {
+  const launchIndex = run.transitions.findLastIndex(
+    (entry) => entry.to === 'launching'
+  );
+  if (launchIndex < 0) return run;
+  const transitions = run.transitions.slice(0, launchIndex);
+  const sourceDispositions = (run.sourceDispositions ?? [run.sourceDisposition]).filter(
+    (entry) => entry !== 'handoff-failed'
+  );
+  return openRunCopy(run, {
+    state: 'applying',
+    reasonCode: transitions.at(-1)?.reasonCode ?? 'APPLY_COMPLETED',
+    conflicts: run.conflicts.filter((entry) => entry.code !== 'LAUNCH_FAILURE'),
+    transitions,
+    sourceDisposition: sourceDispositions[0] ?? 'left-running',
+    sourceDispositions: sourceDispositions.length ? sourceDispositions : ['left-running'],
+    updatedAt: transitions.at(-1)?.at ?? run.updatedAt,
+  });
+}
+
+function buildHandoffBrief(input: {
+  plan: HandoffPlan;
+  run: HandoffRun;
+  artifacts: HandoffArtifactSummary[];
+}): string {
+  const { plan, run, artifacts } = input;
+  const artifactRefs = artifacts.map((artifact) => artifact.id).join(', ') || 'none';
+  return [
+    `Relay cold handoff ${run.id} is applied for WorkContext ${plan.route.workContextId}.`,
+    `Destination cwd: ${plan.destinationProposal.cwd}. Source session: ${plan.source.nodeId}/${plan.source.sessionId}.`,
+    `Source disposition is not process migration: ${(run.sourceDispositions ?? [run.sourceDisposition]).join(', ')}.`,
+    `Artifact refs: ${artifactRefs}. Raw transcripts, provider auth, env/secrets, Hermes DBs, and broad home-folder mirrors are intentionally unavailable.`,
+    'Before editing: inspect git status and the handoff artifact refs, then continue from this bounded brief only.',
+  ].join('\n');
+}
+
+function artifactRefsForWorkContext(
+  artifacts: readonly HandoffArtifactSummary[],
+  producedAt: string,
+  actorId?: string
+): ArtifactRef[] {
+  const privacy = createWorkContextPrivacyMetadata({ classification: 'internal' });
+  return artifacts.map((artifact) => ({
+    id: artifact.id,
+    kind: artifact.group === 'resume-bundle' ? 'report' : 'log-ref',
+    title: artifact.group,
+    summary: artifact.summary,
+    uri: artifact.id,
+    ...(actorId ? { producedByActorId: actorId } : {}),
+    producedAt,
+    privacy,
+  }));
+}
+
+function auditRefsForWorkContext(
+  run: HandoffRun,
+  actorId?: string
+): AuditEventRef[] {
+  const privacy = createWorkContextPrivacyMetadata({ classification: 'internal' });
+  return run.transitions.map((entry, idx) => ({
+    id: `handoff-audit:${run.id}:${idx}`,
+    eventId: `${run.id}:${idx}`,
+    type: 'handoff-run-transition',
+    occurredAt: entry.at,
+    ...(actorId ? { actorId } : {}),
+    correlationId: run.id,
+    privacy,
+  }));
+}
+
+function dedupeById<T extends { id: string }>(items: readonly T[]): T[] {
+  const byId = new Map<string, T>();
+  for (const item of items) byId.set(item.id, item);
+  return Array.from(byId.values());
 }
 
 function hasRequiredExecuteGrantLegs(grants: readonly HandoffRequiredGrant[]): boolean {
@@ -511,10 +730,35 @@ export class HandoffService {
       if (input.actorId) transferInput.actorId = input.actorId;
       const approvedUntrackedPaths = input.approvedUntrackedPaths ?? stored.approvedUntrackedPaths;
       if (approvedUntrackedPaths) transferInput.approvedUntrackedPaths = approvedUntrackedPaths;
-      const result = await applyHandoffTransfer(transferInput);
+      const result = await (this.deps.applyTransfer ?? applyHandoffTransfer)(transferInput);
       const artifacts = this.artifactsForRun(result.run.id, plan.id, result.auditEvents);
+      if (result.ok) {
+        const launched = await this.launchAppliedRun({
+          plan,
+          request: stored.request,
+          run: result.run,
+          artifacts,
+          ...(input.actorId ? { actorId: input.actorId } : {}),
+        });
+        this.runs.set(launched.run.id, {
+          run: sanitizeRun(launched.run),
+          auditEvents: launched.auditEvents,
+          artifacts: launched.artifacts,
+        });
+        if (launched.ok) {
+          return {
+            ok: true,
+            run: sanitizeRun(launched.run),
+            artifacts: launched.artifacts,
+          };
+        }
+        return {
+          ok: false,
+          error: launched.error,
+          run: sanitizeRun(launched.run),
+        };
+      }
       this.runs.set(result.run.id, { run: sanitizeRun(result.run), auditEvents: result.auditEvents, artifacts });
-      if (result.ok) return { ok: true, run: sanitizeRun(result.run), artifacts };
       return {
         ok: false,
         error: apiError('SOURCE_STALE_OR_OFFLINE', 'handoff transfer/apply failed with typed conflicts', 409, {
@@ -544,6 +788,177 @@ export class HandoffService {
       error: apiError('DESTINATION_UNAVAILABLE', 'transfer/apply engine was not invoked; no fake execute success emitted', 503, { runId: run.id }, 'FAILED_DESTINATION_UNAVAILABLE'),
       run,
     };
+  }
+
+  private async launchAppliedRun(input: {
+    plan: HandoffPlan;
+    request: HandoffRequest;
+    run: HandoffRun;
+    artifacts: HandoffArtifactSummary[];
+    actorId?: string;
+  }): Promise<
+    | { ok: true; run: HandoffRun; artifacts: HandoffArtifactSummary[]; auditEvents: unknown[] }
+    | {
+        ok: false;
+        run: HandoffRun;
+        artifacts: HandoffArtifactSummary[];
+        auditEvents: unknown[];
+        error: ReturnType<typeof apiError>;
+      }
+  > {
+    const launcher = this.deps.launchDestinationSession;
+    const baseRun = rewindApplyComplete(input.run);
+    baseRun.sourceDisposition = input.plan.source.disposition;
+    baseRun.sourceDispositions = sourceDispositionsForAppliedRun(input.plan, baseRun);
+    const startedAt = nowIso(this.deps);
+    transition(baseRun, 'launching', 'LAUNCH_STARTED', startedAt, input.actorId);
+    const handoffBrief = buildHandoffBrief({
+      plan: input.plan,
+      run: baseRun,
+      artifacts: input.artifacts,
+    });
+
+    if (!launcher) {
+      const failed = this.failLaunchRun(baseRun, {
+        code: 'LAUNCH_UNSUPPORTED',
+        message: 'destination launch is not wired for this hub; applied artifacts are preserved for retry',
+        details: { runId: baseRun.id, planId: input.plan.id },
+      }, input.actorId);
+      return {
+        ok: false,
+        run: failed.run,
+        artifacts: input.artifacts,
+        auditEvents: failed.auditEvents,
+        error: apiError('LAUNCH_UNSUPPORTED', failed.message, 501, failed.details, 'FAILED_LAUNCH'),
+      };
+    }
+
+    const launch = await launcher({
+      plan: input.plan,
+      request: input.request,
+      run: baseRun,
+      artifacts: input.artifacts,
+      handoffBrief,
+    });
+    if (!launch.ok) {
+      const failed = this.failLaunchRun(baseRun, launch, input.actorId);
+      const status =
+        launch.code === 'NODE_UNAVAILABLE' ? 404 :
+        launch.code === 'HUB_UNAVAILABLE' ? 503 :
+        launch.code === 'LAUNCH_UNSUPPORTED' ? 501 : 500;
+      return {
+        ok: false,
+        run: failed.run,
+        artifacts: input.artifacts,
+        auditEvents: failed.auditEvents,
+        error: apiError(launch.code, launch.message, status, launch.details, 'FAILED_LAUNCH'),
+      };
+    }
+
+    const verifyingAt = nowIso(this.deps);
+    transition(baseRun, 'verifying', 'LAUNCH_COMPLETED', verifyingAt, input.actorId);
+    const completedAt = nowIso(this.deps);
+    transition(baseRun, 'complete', 'VERIFY_COMPLETED', completedAt, input.actorId);
+    baseRun.sourceDisposition = 'handed-off';
+    baseRun.sourceDispositions = sourceDispositionsForLaunch(input.plan, input.run);
+    this.recordWorkContextLaunch({
+      plan: input.plan,
+      run: baseRun,
+      session: launch.session,
+      artifacts: input.artifacts,
+      ...(input.actorId ? { actorId: input.actorId } : {}),
+      at: completedAt,
+    });
+    return {
+      ok: true,
+      run: baseRun,
+      artifacts: input.artifacts,
+      auditEvents: [],
+    };
+  }
+
+  private failLaunchRun(
+    run: HandoffRun,
+    launch: {
+      code: 'HUB_UNAVAILABLE' | 'NODE_UNAVAILABLE' | 'LAUNCH_UNSUPPORTED' | 'LAUNCH_FAILED';
+      message: string;
+      details?: Record<string, unknown>;
+    },
+    actorId?: string
+  ): {
+    run: HandoffRun;
+    auditEvents: unknown[];
+    message: string;
+    details?: Record<string, unknown>;
+  } {
+    const conflictEntry = conflict(
+      'LAUNCH_FAILURE',
+      launch.message,
+      run.planId ?? 'hub',
+      'FAILED_LAUNCH'
+    );
+    run.sourceDispositions = mergeSourceDispositions(
+      run.sourceDispositions ?? [run.sourceDisposition],
+      ['handoff-failed']
+    );
+    run.conflicts = [...run.conflicts, conflictEntry];
+    run.sourceDisposition = 'handoff-failed';
+    const failedAt = nowIso(this.deps);
+    transition(run, 'failed', 'FAILED_LAUNCH', failedAt, actorId);
+    return {
+      run,
+      auditEvents: [
+        {
+          id: createId(this.deps, 'handoff-launch-event'),
+          runId: run.id,
+          at: failedAt,
+          phase: 'failed',
+          type: 'handoff-launch-failed',
+          reasonCode: 'FAILED_LAUNCH',
+          code: launch.code,
+          message: launch.message,
+        },
+      ],
+      message: launch.message,
+      ...(launch.details ? { details: launch.details } : {}),
+    };
+  }
+
+  private recordWorkContextLaunch(input: {
+    plan: HandoffPlan;
+    run: HandoffRun;
+    session: SessionSummary;
+    artifacts: HandoffArtifactSummary[];
+    actorId?: string;
+    at: string;
+  }): void {
+    const store = this.deps.workContextStore;
+    if (!store) return;
+    const existing = store.get(input.plan.route.workContextId);
+    if (!existing) return;
+    const artifactRefs = artifactRefsForWorkContext(
+      input.artifacts,
+      input.at,
+      input.actorId
+    );
+    const auditRefs = auditRefsForWorkContext(input.run, input.actorId);
+    store.update(input.plan.route.workContextId, {
+      artifacts: dedupeById([...existing.artifacts, ...artifactRefs]),
+      auditRefs: dedupeById([...existing.auditRefs, ...auditRefs]),
+    });
+    store.associateSession(input.plan.route.workContextId, {
+      session: input.session,
+      relationship: 'handoff-destination',
+    });
+    const lifecycleEvent: WorkContextLifecycleEventInput = {
+      type: 'session.started',
+      occurredAt: input.at,
+      correlationId: input.run.id,
+      artifacts: artifactRefs,
+      summary: `Started destination session ${input.session.nodeId ?? input.plan.route.destinationNodeId}/${input.session.id} for cold handoff ${input.run.id}; source state: ${(input.run.sourceDispositions ?? [input.run.sourceDisposition]).join(', ')}`,
+    };
+    if (input.actorId) lifecycleEvent.actorId = input.actorId;
+    store.recordLifecycleEvent(input.plan.route.workContextId, lifecycleEvent);
   }
 
   getStatus(runId: string): HandoffRunStatus | null {
@@ -590,7 +1005,7 @@ export class HandoffService {
     return this.getStatus(runId);
   }
 
-  resume(runId: string): { run: HandoffRun; resume: { summary: string; artifactRefs: string[]; rawTranscriptAvailable: false } } | null {
+  resume(runId: string): { run: HandoffRun; resume: { summary: string; artifactRefs: string[]; rawTranscriptAvailable: false; retryLaunchAvailable: boolean } } | null {
     const stored = this.runs.get(runId);
     if (!stored) return null;
     return {
@@ -599,8 +1014,62 @@ export class HandoffService {
         summary: `Resume cold handoff ${runId} from state ${stored.run.state}; use artifact refs only, never raw transcript/provider auth.`,
         artifactRefs: stored.artifacts.map((artifact) => artifact.id),
         rawTranscriptAvailable: false,
+        retryLaunchAvailable:
+          stored.run.state === 'failed' && stored.run.reasonCode === 'FAILED_LAUNCH',
       },
     };
+  }
+
+  async retryLaunch(runId: string, actorId?: string): Promise<
+    | { ok: true; run: HandoffRun; artifacts: HandoffArtifactSummary[] }
+    | { ok: false; error: ReturnType<typeof apiError>; run?: HandoffRun }
+  > {
+    const stored = this.runs.get(runId);
+    if (!stored) {
+      return {
+        ok: false,
+        error: apiError('HANDOFF_RUN_NOT_FOUND', 'handoff run was not found', 404, { runId }),
+      };
+    }
+    if (!stored.run.planId) {
+      return {
+        ok: false,
+        error: apiError('INVALID_PLAN_ID', 'handoff run has no plan id for launch retry', 404, { runId }),
+        run: sanitizeRun(stored.run),
+      };
+    }
+    const storedPlan = this.plans.get(stored.run.planId);
+    if (!storedPlan) {
+      return {
+        ok: false,
+        error: apiError('INVALID_PLAN_ID', 'handoff plan was not found for launch retry', 404, { runId, planId: stored.run.planId }),
+        run: sanitizeRun(stored.run),
+      };
+    }
+    if (!(stored.run.state === 'failed' && stored.run.reasonCode === 'FAILED_LAUNCH')) {
+      return {
+        ok: false,
+        error: apiError('INVALID_RUN_STATE', 'handoff launch retry is available only after a launch failure', 409, { runId, state: stored.run.state, reasonCode: stored.run.reasonCode }),
+        run: sanitizeRun(stored.run),
+      };
+    }
+    const retryRun = rewindLaunchAttempt(stored.run);
+    const launched = await this.launchAppliedRun({
+      plan: storedPlan.plan,
+      request: storedPlan.request,
+      run: retryRun,
+      artifacts: stored.artifacts,
+      ...(actorId ? { actorId } : {}),
+    });
+    this.runs.set(launched.run.id, {
+      run: sanitizeRun(launched.run),
+      auditEvents: launched.auditEvents,
+      artifacts: launched.artifacts,
+    });
+    if (launched.ok) {
+      return { ok: true, run: sanitizeRun(launched.run), artifacts: launched.artifacts };
+    }
+    return { ok: false, error: launched.error, run: sanitizeRun(launched.run) };
   }
 
   readArtifact(ref: string): HandoffArtifactSummary | null {
@@ -643,6 +1112,7 @@ export class HandoffService {
       planId: plan.id,
       state: 'failed',
       sourceDisposition: 'handoff-failed',
+      sourceDispositions: ['left-running', 'handoff-failed'],
       reasonCode,
       conflicts,
       transitions: [
@@ -737,6 +1207,9 @@ export function createHandoffRouter(input: {
   getCapabilities?: HandoffCapabilityProvider;
   workContextStore?: WorkContextStore;
   getSession?: (nodeId: string, sessionId: string) => unknown | undefined;
+  launchDestinationSession?: (
+    input: HandoffDestinationLaunchInput
+  ) => Promise<HandoffDestinationLaunchResult> | HandoffDestinationLaunchResult;
 } = {}): Router {
   const router = Router();
   const auth = input.requireAuth ?? ((_req, _res, next) => next());
@@ -746,6 +1219,7 @@ export function createHandoffRouter(input: {
     new HandoffService({
       ...(input.workContextStore ? { workContextStore: input.workContextStore } : {}),
       ...(input.getSession ? { getSession: input.getSession } : {}),
+      ...(input.launchDestinationSession ? { launchDestinationSession: input.launchDestinationSession } : {}),
     });
 
   router.post('/plan', auth, async (req, res) => {
@@ -834,6 +1308,31 @@ export function createHandoffRouter(input: {
       return;
     }
     res.json(resume);
+  });
+
+  router.post('/:runId/launch', auth, async (req, res) => {
+    const denied = requireCapabilities(
+      req,
+      ['session:read', 'session:create:agent', 'session:create:terminal', 'pty:exec:arbitrary'],
+      capabilityContext
+    );
+    if (denied) {
+      res.status(denied.status).json(denied.body);
+      return;
+    }
+    const body = bodyRecord(req);
+    const result = await service.retryLaunch(
+      req.params['runId'] ?? '',
+      typeof body['actorId'] === 'string' ? body['actorId'] : undefined
+    );
+    if (!result.ok) {
+      res.status(result.error.status).json({
+        ...result.error.body,
+        ...(result.run ? { run: result.run } : {}),
+      });
+      return;
+    }
+    res.json({ run: result.run, artifacts: result.artifacts });
   });
 
   router.get('/artifacts/:ref', auth, (req, res) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -122,7 +122,11 @@ import {
 import { createHubNodeRouter } from './hub-node-router.js';
 import { createCliGatewayEventsRouter } from './cli-gateway-events.js';
 import { createConfirmationChallengeStore } from './confirmation-challenges.js';
-import { createHandoffRouter, type HandoffCapabilityContext } from './handoffs.js';
+import {
+  createHandoffRouter,
+  type HandoffCapabilityContext,
+  type HandoffDestinationLaunchInput,
+} from './handoffs.js';
 import { createHubNodeLinkManager } from './hub-node-link.js';
 import {
   aggregateRemoteSessions,
@@ -875,6 +879,161 @@ export function validateSessionCreateRequest(
   if (workContextStore.get(workContextId)) return true;
   res.status(404).json({ error: 'work_context_not_found' });
   return false;
+}
+
+function configuredRepoForCwd(config: Config, cwd: string): string | null {
+  const repos = config.repos ?? [];
+  return (
+    repos
+      .filter((repo) => cwd === repo || cwd.startsWith(`${repo}${path.sep}`))
+      .sort((a, b) => b.length - a.length)[0] ?? null
+  );
+}
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function terminalBriefCommand(brief: string): string {
+  return `printf '%s\\n' ${shellSingleQuote(brief)}\n`;
+}
+
+function createHandoffDestinationLauncher(params: {
+  startupConfig: Config;
+  configDir: string;
+  getConfig: () => Config;
+  watchCwd: (cwd: string) => void;
+}): (input: HandoffDestinationLaunchInput) => Promise<{
+  ok: true;
+  session: ReturnType<typeof localRelayNode.sessions.list>[number];
+  acknowledgedBrief: boolean;
+} | {
+  ok: false;
+  code: 'HUB_UNAVAILABLE' | 'NODE_UNAVAILABLE' | 'LAUNCH_UNSUPPORTED' | 'LAUNCH_FAILED';
+  message: string;
+  details?: Record<string, unknown>;
+}> {
+  return async (input) => {
+    const destination = input.plan.destinationProposal;
+    if (destination.nodeId !== 'local') {
+      return {
+        ok: false,
+        code: 'NODE_UNAVAILABLE',
+        message: `destination node ${destination.nodeId} is not attached for hub-side launch`,
+        details: { nodeId: destination.nodeId },
+      };
+    }
+    if (!fs.existsSync(destination.cwd)) {
+      return {
+        ok: false,
+        code: 'NODE_UNAVAILABLE',
+        message: `destination cwd does not exist: ${destination.cwd}`,
+        details: { cwd: destination.cwd },
+      };
+    }
+
+    const freshConfig = params.getConfig();
+    const repoPath = configuredRepoForCwd(freshConfig, destination.cwd);
+    if (!repoPath) {
+      return {
+        ok: false,
+        code: 'LAUNCH_UNSUPPORTED',
+        message: 'destination cwd is not inside a configured Relay repo; refusing path-only launch',
+        details: { cwd: destination.cwd },
+      };
+    }
+
+    const cwd = destination.cwd;
+    const worktreePath = cwd === repoPath ? null : cwd;
+    const repoName = sessionNameFromRepoPath(repoPath);
+    const portVariables = getRepoPortVariables(freshConfig, repoPath);
+    const capacityResponse = buildPtyCapacityResponse(
+      activePtySessionCount(),
+      freshConfig.maxPtySessions
+    );
+    if (capacityResponse) {
+      return {
+        ok: false,
+        code: 'LAUNCH_FAILED',
+        message: capacityResponse.message,
+        details: { ...capacityResponse },
+      };
+    }
+
+    try {
+      if (input.request.desiredRuntime.kind === 'terminal') {
+        const session = createTerminalSessionRecord({
+          repoName,
+          repoPath,
+          worktreePath,
+          cwd,
+          safeCols: undefined,
+          safeRows: undefined,
+          sessionLane: undefined,
+          portVariables,
+        });
+        localRelayNode.sessions.write(session.id, terminalBriefCommand(input.handoffBrief));
+        params.watchCwd(session.cwd);
+        return { ok: true, session, acknowledgedBrief: true };
+      }
+
+      const requestedAgent = input.request.desiredRuntime.providerId as AgentType | undefined;
+      const resolved = resolveSessionSettings(freshConfig, repoPath, {
+        agent: requestedAgent,
+        continuePolicy: 'never',
+      });
+      const availability = validateAgentFrameworkAvailable(freshConfig, resolved.agent);
+      if (!availability.ok) {
+        return {
+          ok: false,
+          code: 'LAUNCH_UNSUPPORTED',
+          message: availability.body.message ?? availability.body.error ?? 'agent framework is unavailable',
+          details: availability.body,
+        };
+      }
+      const args = buildAgentArgs(
+        resolved.agent,
+        resolved.claudeArgs,
+        resolved.yolo,
+        resolved.continuePolicy
+      );
+      const displayName = sessions.nextAgentName();
+      const branchName = destination.branchName ?? '';
+      const session = createAgentSessionRecord({
+        repoName,
+        repoPath,
+        worktreePath,
+        cwd,
+        requestBranchName: branchName,
+        displayName,
+        tmuxDisplayName: branchName ? `${repoName}-${branchName}` : repoName,
+        args,
+        resolvedAgent: resolved.agent,
+        resolvedUseTmux: resolved.useTmux,
+        resolvedYolo: resolved.yolo,
+        resolvedClaudeArgs: resolved.claudeArgs,
+        resolvedContinuePolicy: resolved.continuePolicy,
+        safeCols: undefined,
+        safeRows: undefined,
+        needsBranchRename: false,
+        branchRenamePrompt: '',
+        computedInitialPrompt: input.handoffBrief,
+        claudeFullscreen: params.startupConfig.claudeFullscreen,
+        sessionLane: undefined,
+        portVariables,
+        scrollbackBytes: resolved.scrollbackBytes,
+      });
+      params.watchCwd(session.cwd);
+      return { ok: true, session, acknowledgedBrief: true };
+    } catch (err) {
+      return {
+        ok: false,
+        code: 'LAUNCH_FAILED',
+        message: err instanceof Error ? err.message : 'destination session launch failed',
+        details: { cwd, repoPath, configDir: params.configDir },
+      };
+    }
+  };
 }
 
 function sessionNameFromRepoPath(repoPath: string): string {
@@ -1854,6 +2013,12 @@ async function main(): Promise<void> {
           .list()
           .find((session) => session.id === sessionId);
       },
+      launchDestinationSession: createHandoffDestinationLauncher({
+        startupConfig,
+        configDir,
+        getConfig,
+        watchCwd: (cwd) => gitWatcher.watch(cwd),
+      }),
     })
   );
   app.use(

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -1416,6 +1416,9 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
+    // Static gateway manifests cannot know whether the stored retry target is
+    // agent or terminal; advertise the superset for tool generators while the
+    // hub route enforces the stored plan's runtime-specific create capability.
     capabilityHints: ['session:read', 'session:create:agent', 'session:create:terminal', 'pty:exec:arbitrary'],
     inputSchema: handoffRunIdInputSchema,
     outputSchema: okOutput('HandoffsLaunchOutput', handoffCreateOutputSchema),

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -29,6 +29,7 @@ export type RelayCliGatewayCommand =
   | 'handoffs.status'
   | 'handoffs.cancel'
   | 'handoffs.resume'
+  | 'handoffs.launch'
   | 'artifacts.read'
   | 'events.subscribe';
 
@@ -1406,6 +1407,18 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     capabilityHints: ['session:read'],
     inputSchema: handoffRunIdInputSchema,
     outputSchema: okOutput('HandoffsResumeOutput', handoffResumeOutputSchema),
+    errorCodes: gatewayHandoffErrorCodes,
+  },
+  {
+    name: 'handoffs.launch',
+    cli: ['relay-ide', 'v1', 'handoffs', 'launch', '--run-id', '<run-id>', '--json'],
+    summary: 'Retry hub-side destination session launch for an applied cold handoff after a typed launch failure.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read', 'session:create:agent', 'session:create:terminal', 'pty:exec:arbitrary'],
+    inputSchema: handoffRunIdInputSchema,
+    outputSchema: okOutput('HandoffsLaunchOutput', handoffCreateOutputSchema),
     errorCodes: gatewayHandoffErrorCodes,
   },
   {

--- a/shared/handoff.ts
+++ b/shared/handoff.ts
@@ -285,7 +285,13 @@ export interface HandoffRun {
   planId?: string;
   snapshotId?: string;
   state: HandoffRunState;
+  /**
+   * Compatibility summary of the source process state. New handoff flows should
+   * prefer `sourceDispositions` so `handed-off` can coexist with an honestly
+   * reported live/stale source process state instead of implying migration.
+   */
   sourceDisposition: HandoffSourceDisposition;
+  sourceDispositions?: HandoffSourceDisposition[];
   reasonCode?: HandoffReasonCode;
   conflicts: HandoffConflict[];
   transitions: HandoffRunTransition[];
@@ -776,6 +782,8 @@ export function isHandoffRun(value: unknown): value is HandoffRun {
     isOptionalString(value.snapshotId) &&
     isHandoffRunState(value.state) &&
     isHandoffSourceDisposition(value.sourceDisposition) &&
+    (value.sourceDispositions === undefined ||
+      isEnumArray(value.sourceDispositions, SOURCE_DISPOSITION_SET)) &&
     (value.reasonCode === undefined || isHandoffReasonCode(value.reasonCode)) &&
     Array.isArray(value.conflicts) &&
     value.conflicts.every(isConflict) &&

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -83,6 +83,7 @@ describe('CLI gateway contract', () => {
       'handoffs.status',
       'handoffs.cancel',
       'handoffs.resume',
+      'handoffs.launch',
       'artifacts.read',
       'events.subscribe',
     ]);
@@ -264,6 +265,7 @@ describe('CLI gateway contract', () => {
       'handoffs.status',
       'handoffs.cancel',
       'handoffs.resume',
+      'handoffs.launch',
       'artifacts.read',
       'events.subscribe',
     ] as const;

--- a/test/handoffs-api.test.ts
+++ b/test/handoffs-api.test.ts
@@ -7,6 +7,7 @@ import {
   type HandoffConflict,
   type HandoffRequest,
   type HandoffRequiredGrant,
+  type HandoffRun,
 } from '../shared/handoff.js';
 import { ENVIRONMENT_OPTION_SCHEMA_VERSION } from '../shared/environment-option.js';
 import {
@@ -90,6 +91,19 @@ function request(): HandoffRequest {
   };
 }
 
+function requestWithSourceDisposition(
+  disposition: HandoffRequest['source']['disposition']
+): HandoffRequest {
+  const base = request();
+  return {
+    ...base,
+    source: {
+      ...base.source,
+      disposition,
+    },
+  };
+}
+
 function dryRun(conflicts: HandoffConflict[] = []): HandoffPlannerDryRun {
   return {
     branchName: 'feat/691-handoff-api-cli',
@@ -115,6 +129,29 @@ function confirmedGrants(): HandoffRequiredGrant[] {
     { leg: 'destination-session-create', nodeId: destinationNodeId, capability: 'session:create:agent', decision: 'allow' },
     { leg: 'destination-exec', nodeId: destinationNodeId, capability: 'pty:exec:arbitrary', decision: 'allow' },
   ];
+}
+
+function appliedRun(planId: string, requestId = 'handoff-request-api-test'): HandoffRun {
+  return {
+    schemaVersion: HANDOFF_SCHEMA_VERSION,
+    id: 'run-applied-1',
+    requestId,
+    planId,
+    state: 'complete',
+    sourceDisposition: 'left-running',
+    sourceDispositions: ['left-running'],
+    reasonCode: 'APPLY_COMPLETED',
+    conflicts: [],
+    transitions: [
+      { from: 'planned', to: 'snapshotting', at: now, reasonCode: 'SNAPSHOT_CAPTURED' },
+      { from: 'snapshotting', to: 'transferring', at: now, reasonCode: 'TRANSFER_STARTED' },
+      { from: 'transferring', to: 'applying', at: now, reasonCode: 'APPLY_STARTED' },
+      { from: 'applying', to: 'complete', at: now, reasonCode: 'APPLY_COMPLETED' },
+    ],
+    createdAt: now,
+    updatedAt: now,
+    completedAt: now,
+  };
 }
 
 async function startHandoffApi(
@@ -212,6 +249,192 @@ describe('handoff API service', () => {
     expect(resume?.resume.rawTranscriptAvailable).toBe(false);
     const artifact = service.readArtifact(`handoff-artifact:${created.run?.id}:resume-bundle`);
     expect(artifact).toMatchObject({ rawPayloadAvailable: false, transcriptExportAvailable: false });
+  });
+
+  it('launches a destination session after apply and reports source state without migration claims', async () => {
+    let capturedBrief = '';
+    const service = new HandoffService({
+      now: () => new Date(now),
+      createId: () => 'plan-launch',
+      applyTransfer: async (input) => ({
+        ok: true,
+        run: appliedRun(input.planId ?? 'missing-plan-id', input.requestId),
+        auditEvents: [],
+        trackedPatch: { byteCount: 0, sha256: '0'.repeat(64), applied: false },
+        approvedUntrackedFiles: [],
+      }),
+      launchDestinationSession: async (input) => {
+        capturedBrief = input.handoffBrief;
+        return {
+          ok: true,
+          acknowledgedBrief: true,
+          session: {
+            id: 'dest-session-1',
+            type: 'agent',
+            agent: 'hermes',
+            mode: 'pty',
+            cwd: destinationCwd,
+            repoPath: '/srv/relay-ide',
+            worktreePath: destinationCwd,
+            repoName: 'relay-ide',
+            branchName: 'feat/691-handoff-api-cli',
+            displayName: 'Agent 1',
+            createdAt: now,
+            lastActivity: now,
+            idle: false,
+            customCommand: null,
+            nodeId: destinationNodeId,
+            status: 'active',
+            needsBranchRename: false,
+            agentState: 'idle',
+          } as never,
+        };
+      },
+    });
+    const planned = await service.plan({ request: request(), dryRun: dryRun(), sourceRepoPath: sourceCwd });
+    if (!planned.ok) throw new Error('plan failed unexpectedly');
+
+    const created = await service.create({
+      planId: planned.plan.id,
+      confirmedGrants: confirmedGrants(),
+      sourceRepoPath: sourceCwd,
+      destinationRepoPath: destinationCwd,
+    });
+
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+    expect(created.run.state).toBe('complete');
+    expect(created.run.reasonCode).toBe('VERIFY_COMPLETED');
+    expect(created.run.sourceDisposition).toBe('handed-off');
+    expect(created.run.sourceDispositions).toEqual(['left-running', 'handed-off']);
+    expect(created.run.transitions.map((entry) => entry.to)).toEqual([
+      'snapshotting',
+      'transferring',
+      'applying',
+      'launching',
+      'verifying',
+      'complete',
+    ]);
+    expect(capturedBrief).toContain('is not process migration');
+    expect(capturedBrief).toContain('Raw transcripts, provider auth, env/secrets, Hermes DBs');
+    expect(service.resume(created.run.id)?.resume.retryLaunchAvailable).toBe(false);
+  });
+
+  it('fails with a typed launch error after apply when destination launch is unavailable', async () => {
+    const service = new HandoffService({
+      now: () => new Date(now),
+      createId: () => 'plan-launch-missing',
+      applyTransfer: async (input) => ({
+        ok: true,
+        run: appliedRun(input.planId ?? 'missing-plan-id', input.requestId),
+        auditEvents: [],
+        trackedPatch: { byteCount: 0, sha256: '0'.repeat(64), applied: false },
+        approvedUntrackedFiles: [],
+      }),
+    });
+    const planned = await service.plan({ request: request(), dryRun: dryRun(), sourceRepoPath: sourceCwd });
+    if (!planned.ok) throw new Error('plan failed unexpectedly');
+
+    const created = await service.create({
+      planId: planned.plan.id,
+      confirmedGrants: confirmedGrants(),
+      sourceRepoPath: sourceCwd,
+      destinationRepoPath: destinationCwd,
+    });
+
+    expect(created.ok).toBe(false);
+    if (created.ok) return;
+    expect(created.error.body.error).toMatchObject({
+      code: 'LAUNCH_UNSUPPORTED',
+      reasonCode: 'FAILED_LAUNCH',
+    });
+    expect(created.run?.state).toBe('failed');
+    expect(created.run?.reasonCode).toBe('FAILED_LAUNCH');
+    expect(created.run?.sourceDispositions).toEqual(['left-running', 'handoff-failed']);
+    expect(service.resume(created.run?.id ?? '')?.resume.retryLaunchAvailable).toBe(true);
+  });
+
+  it('preserves stop-requested source state and retries launch without rerunning apply', async () => {
+    let applyCalls = 0;
+    let launchCalls = 0;
+    const service = new HandoffService({
+      now: () => new Date(now),
+      createId: () => 'plan-retry-launch',
+      applyTransfer: async (input) => {
+        applyCalls += 1;
+        return {
+          ok: true,
+          run: appliedRun(input.planId ?? 'missing-plan-id', input.requestId),
+          auditEvents: [],
+          trackedPatch: { byteCount: 0, sha256: '0'.repeat(64), applied: false },
+          approvedUntrackedFiles: [],
+        };
+      },
+      launchDestinationSession: async () => {
+        launchCalls += 1;
+        if (launchCalls === 1) {
+          return {
+            ok: false,
+            code: 'LAUNCH_FAILED',
+            message: 'agent runtime exited before acknowledging brief',
+          };
+        }
+        return {
+          ok: true,
+          acknowledgedBrief: true,
+          session: {
+            id: 'dest-session-retry',
+            type: 'agent',
+            agent: 'hermes',
+            mode: 'pty',
+            cwd: destinationCwd,
+            displayName: 'Agent 2',
+            createdAt: now,
+            lastActivity: now,
+            idle: false,
+            customCommand: null,
+            nodeId: destinationNodeId,
+            status: 'active',
+            needsBranchRename: false,
+            agentState: 'idle',
+          } as never,
+        };
+      },
+    });
+    const planned = await service.plan({
+      request: requestWithSourceDisposition('stop-requested'),
+      dryRun: dryRun(),
+      sourceRepoPath: sourceCwd,
+    });
+    if (!planned.ok) throw new Error('plan failed unexpectedly');
+
+    const failed = await service.create({
+      planId: planned.plan.id,
+      confirmedGrants: confirmedGrants(),
+      sourceRepoPath: sourceCwd,
+      destinationRepoPath: destinationCwd,
+    });
+    expect(failed.ok).toBe(false);
+    if (failed.ok || !failed.run) return;
+    expect(failed.run.reasonCode).toBe('FAILED_LAUNCH');
+    expect(failed.run.sourceDispositions).toEqual([
+      'left-running',
+      'stop-requested',
+      'handoff-failed',
+    ]);
+    expect(service.resume(failed.run.id)?.resume.retryLaunchAvailable).toBe(true);
+
+    const retried = await service.retryLaunch(failed.run.id, 'kani-backend');
+    expect(retried.ok).toBe(true);
+    if (!retried.ok) return;
+    expect(applyCalls).toBe(1);
+    expect(launchCalls).toBe(2);
+    expect(retried.run.state).toBe('complete');
+    expect(retried.run.sourceDispositions).toEqual([
+      'left-running',
+      'stop-requested',
+      'handed-off',
+    ]);
   });
 
   it('requires stale plans to be refreshed before execute', async () => {

--- a/test/handoffs-api.test.ts
+++ b/test/handoffs-api.test.ts
@@ -320,6 +320,84 @@ describe('handoff API service', () => {
     expect(service.resume(created.run.id)?.resume.retryLaunchAvailable).toBe(false);
   });
 
+  it('fails launch verification when the destination does not acknowledge the bounded brief', async () => {
+    const service = new HandoffService({
+      now: () => new Date(now),
+      createId: () => 'plan-launch-unacknowledged',
+      applyTransfer: async (input) => ({
+        ok: true,
+        run: appliedRun(input.planId ?? 'missing-plan-id', input.requestId),
+        auditEvents: [],
+        trackedPatch: { byteCount: 0, sha256: '0'.repeat(64), applied: false },
+        approvedUntrackedFiles: [],
+      }),
+      launchDestinationSession: async () => ({
+        ok: true,
+        acknowledgedBrief: false,
+        session: {
+          id: 'dest-session-unacknowledged',
+          type: 'agent',
+          agent: 'hermes',
+          mode: 'pty',
+          cwd: destinationCwd,
+          displayName: 'Agent unacknowledged',
+          createdAt: now,
+          lastActivity: now,
+          idle: false,
+          customCommand: null,
+          nodeId: destinationNodeId,
+          status: 'active',
+          needsBranchRename: false,
+          agentState: 'idle',
+        } as never,
+      }),
+    });
+    const planned = await service.plan({ request: request(), dryRun: dryRun(), sourceRepoPath: sourceCwd });
+    if (!planned.ok) throw new Error('plan failed unexpectedly');
+
+    const created = await service.create({
+      planId: planned.plan.id,
+      confirmedGrants: confirmedGrants(),
+      sourceRepoPath: sourceCwd,
+      destinationRepoPath: destinationCwd,
+    });
+
+    expect(created.ok).toBe(false);
+    if (created.ok) return;
+    expect(created.error.body.error).toMatchObject({
+      code: 'LAUNCH_FAILED',
+      reasonCode: 'FAILED_LAUNCH',
+    });
+    expect(created.error.body.error.message).toContain('did not acknowledge');
+    expect(created.run?.state).toBe('failed');
+    expect(created.run?.reasonCode).toBe('FAILED_LAUNCH');
+    expect(created.run?.transitions.map((entry) => entry.to)).toEqual([
+      'snapshotting',
+      'transferring',
+      'applying',
+      'launching',
+      'failed',
+    ]);
+    expect(service.resume(created.run?.id ?? '')?.resume.retryLaunchAvailable).toBe(true);
+  });
+
+  it('records the planned source disposition in pre-transfer failed runs', async () => {
+    let nextId = 0;
+    const service = new HandoffService({ now: () => new Date(now), createId: () => `id-${++nextId}` });
+    const planned = await service.plan({
+      request: requestWithSourceDisposition('stop-requested'),
+      dryRun: dryRun(),
+    });
+    if (!planned.ok) throw new Error('plan failed unexpectedly');
+
+    const created = await service.create({ planId: planned.plan.id });
+
+    expect(created.ok).toBe(false);
+    if (created.ok) return;
+    expect(created.run?.sourceDisposition).toBe('handoff-failed');
+    expect(created.run?.sourceDispositions).toEqual(['stop-requested', 'handoff-failed']);
+  });
+
   it('fails with a typed launch error after apply when destination launch is unavailable', async () => {
     const service = new HandoffService({
       now: () => new Date(now),
@@ -435,6 +513,74 @@ describe('handoff API service', () => {
       'stop-requested',
       'handed-off',
     ]);
+  });
+
+  it('gates launch retry with runtime-specific create capabilities', async () => {
+    let launchCalls = 0;
+    const service = new HandoffService({
+      now: () => new Date(now),
+      createId: () => 'plan-route-runtime-launch',
+      applyTransfer: async (input) => ({
+        ok: true,
+        run: appliedRun(input.planId ?? 'missing-plan-id', input.requestId),
+        auditEvents: [],
+        trackedPatch: { byteCount: 0, sha256: '0'.repeat(64), applied: false },
+        approvedUntrackedFiles: [],
+      }),
+      launchDestinationSession: async () => {
+        launchCalls += 1;
+        if (launchCalls === 1) {
+          return {
+            ok: false,
+            code: 'LAUNCH_FAILED',
+            message: 'agent runtime exited before acknowledging brief',
+          };
+        }
+        return {
+          ok: true,
+          acknowledgedBrief: true,
+          session: {
+            id: 'dest-session-route-retry',
+            type: 'agent',
+            agent: 'hermes',
+            mode: 'pty',
+            cwd: destinationCwd,
+            displayName: 'Agent route retry',
+            createdAt: now,
+            lastActivity: now,
+            idle: false,
+            customCommand: null,
+            nodeId: destinationNodeId,
+            status: 'active',
+            needsBranchRename: false,
+            agentState: 'idle',
+          } as never,
+        };
+      },
+    });
+    const planned = await service.plan({ request: request(), dryRun: dryRun(), sourceRepoPath: sourceCwd });
+    if (!planned.ok) throw new Error('plan failed unexpectedly');
+    const failed = await service.create({
+      planId: planned.plan.id,
+      confirmedGrants: confirmedGrants(),
+      sourceRepoPath: sourceCwd,
+      destinationRepoPath: destinationCwd,
+    });
+    expect(failed.ok).toBe(false);
+    if (failed.ok || !failed.run) return;
+
+    const api = await startHandoffApi(service, () => [
+      'session:read',
+      'session:create:agent',
+      'pty:exec:arbitrary',
+    ]);
+    try {
+      const retried = await fetch(`${api.url}/handoffs/${failed.run.id}/launch`, { method: 'POST' });
+      expect(retried.status).toBe(200);
+      expect((await retried.json()).run).toMatchObject({ state: 'complete', reasonCode: 'VERIFY_COMPLETED' });
+    } finally {
+      await api.close();
+    }
   });
 
   it('requires stale plans to be refreshed before execute', async () => {


### PR DESCRIPTION
Closes #693

## Summary
- launch destination terminal/agent sessions after successful cold handoff apply, under the same WorkContext
- record destination session, handoff/resume artifacts, audit refs, verification/failure lifecycle events, and source dispositions without claiming live process migration
- add typed launch failure/retry handling plus `relay-ide v1 handoffs launch --run-id ... --json`

## Verification
- `npm test -- test/handoffs-api.test.ts test/handoff-transfer.test.ts` (24/24 pass)
- `npm run check` (passes; repo has existing lint warnings, no errors)
- `npm run build`
- safe CLI smoke: `node dist/bin/relay-ide.js v1 schema --json` exposes `handoffs.launch`
- safe CLI smoke: `node dist/bin/relay-ide.js v1 handoffs launch --run-id missing --json` returns authenticated-command envelope (`UNAUTHORIZED` without scoped token)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `handoffs launch` subcommand to launch destination sessions with `--run-id` and optional `--actor-id` parameters.
* Added API endpoint to retry destination session launch after handoff completion.

## Improvements
* Enhanced error handling and retry capabilities for launch operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->