### PR TITLE
feat: add read-only provider state adapter foundation

### DIFF
--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -197,6 +197,12 @@ relay-ide v1 sessions input --id remote-session-1 --data 'printf relay-ok\\n\n' 
 
 `stream` and `input` detach only their CLI/WebSocket handle. They do not kill the underlying Relay session or tmux process. Missing sessions, expired envelopes, rejected policy, offline nodes, and closed attach sockets surface as typed gateway error envelopes; adapter authors must not fall back to private `/hub/node-link` messages.
 
+## Provider-native state commands
+
+Provider-native session state adapters are intentionally internal in this slice. `shared/cli-gateway-contract.ts` does not expose stable v1 `providers.*` or `native-sessions.*` commands yet. External adapters must continue to treat missing provider-state verbs as unsupported rather than calling private REST routes or reading provider stores themselves.
+
+When promoted to v1, the surface must preserve the same boundary as `AgentHarnessStateAdapter`: detection/list/import/read-state are read-only, snapshots are redacted and bounded, and open/resume returns copyable argv data without executing the provider CLI.
+
 ## Read-only file RPC commands
 
 The `files.*` commands route through the existing scoped #505 File RPC surface:

--- a/docs/SESSION_DURABILITY.md
+++ b/docs/SESSION_DURABILITY.md
@@ -154,6 +154,17 @@ simulate end-to-end:
   reattaches; durability stays `running-attached` (or briefly flips
   through `running-detached` if the WS is rebuilt slowly).
 
+## Provider-native import boundary
+
+Provider-native session adapters complement durability replay; they do not replace it. Relay may inspect provider-owned state stores such as Claude JSONL files to derive a bounded `AgentSessionV2` read model and safe resume/open argv, but the provider store remains the source of truth for that native CLI.
+
+Rules for this slice:
+
+- provider stores are read-only; Relay must not write `.claude`, `.codex`, `.hermes`, `.opencode`, or equivalent native state paths;
+- imported read models include an audit/divider marker with provider, source kind, import time, and content hash;
+- snapshots expose hashes, sizes, event types, timestamps, and redacted previews, not raw provider rows;
+- resume/open commands are copyable data only and are never executed by the adapter.
+
 ## Out of scope (later #614 slices)
 
 - Cross-node/remote replay forwarding.

--- a/docs/provider-guide.md
+++ b/docs/provider-guide.md
@@ -119,9 +119,31 @@ Approval:
 6. Emit approval item update and live state back to `working`.
 7. Reject all pending resolvers on disconnect/interrupt.
 
-## 8. Testing pattern
+## 8. Provider-native session state adapters
 
-Each provider needs golden trace tests under `test/server/protocol-adapters/<provider>-adapter.test.ts`.
+Provider-native state adapters are separate from live `ProtocolAdapterV2` runtimes. They read provider-owned stores to produce a bounded Relay read model, but they do not control the native CLI and they must not write provider state.
+
+The server-side contract is `AgentHarnessStateAdapter` (`server/harness-state-adapter.ts`) with:
+
+- `detectInstall()` — reports installed/unavailable/unsupported and safe diagnostics.
+- `listNativeSessions(scope?)` — returns provider, native id, source path, cwd/repo/work-context hints when present, timestamps, and redacted preview metadata.
+- `readProviderState(ref)` — returns a hash/size/event-type snapshot with `rawPayloadStored: false`; raw JSONL/database rows are not persisted as Relay artifacts.
+- `importSession(ref)` — normalizes provider state into an `AgentSessionV2` read model plus `AgentPatchV2` snapshot patches. Imports include a `providerExtension` audit/divider marker naming the source provider, source kind, import time, hash, and `readOnly: true`.
+- `resumeCommand(ref)` — returns copyable argv data only. It never executes the command.
+- `capabilities` — explicitly separates transcript import, provider-state read, native resume command generation, live event streaming, approval response, and tool-call exposure.
+
+Read-only-first invariants:
+
+- Do not mutate `.claude`, `.codex`, `.hermes`, `.opencode`, or any other proprietary provider store in this slice.
+- Do not cross-provider migrate context; importing Claude state produces a Claude read model, not a Codex/Hermes/OpenCode session.
+- Redact previews, tool inputs, command metadata, approval payloads, and secret-looking strings before surfacing them through summaries/snapshots.
+- Treat native resume/open as explicit operator/agent intent. Adapter code may generate `['claude', '--resume', '<id>']`; it may not spawn it.
+
+The first implementation is `ClaudeJsonlStateAdapter`, which imports Claude JSONL fixtures and keeps live streaming/approval response disabled.
+
+## 9. Testing pattern
+
+Each provider needs golden trace tests under `test/server/protocol-adapters/<provider>-adapter.test.ts`. Provider-native state adapters use adjacent golden fixture tests under `test/server/provider-state/`.
 
 Minimum cases:
 
@@ -140,7 +162,7 @@ Minimum cases:
 
 Use a deterministic dependency seam for provider transport. Tests should feed native events directly without spawning real CLIs.
 
-## 9. Stacked PR checklist
+## 10. Stacked PR checklist
 
 For each provider:
 
@@ -152,6 +174,6 @@ For each provider:
 6. Run `npm run check`, targeted tests, and `npm run build`.
 7. Push and open a draft PR targeting the previous provider stack.
 
-## 10. Deletion policy
+## 11. Deletion policy
 
 When a provider is fully V2-native, delete replaced V1 code in the same provider stack. If a temporary bridge is used to keep the stack moving, the PR must explicitly label it as temporary and include the deletion target in its body.

--- a/server/harness-state-adapter.ts
+++ b/server/harness-state-adapter.ts
@@ -1,0 +1,30 @@
+import type {
+  AgentHarnessStateCapabilities,
+  NativeSessionImportResult,
+  NativeSessionListScope,
+  NativeSessionProvider,
+  NativeSessionRef,
+  NativeSessionSummary,
+  ProviderInstallStatus,
+  ProviderStateSnapshot,
+} from '../shared/provider-native-session-state.js';
+
+/**
+ * Read-only adapter over provider-owned session stores.
+ *
+ * Implementations may inspect and normalize native provider state, but must not
+ * mutate provider stores or execute native resume/open commands. `resumeCommand`
+ * returns copyable argv data only; callers decide if and when to run it.
+ */
+export interface AgentHarnessStateAdapter {
+  readonly provider: NativeSessionProvider;
+  readonly capabilities: AgentHarnessStateCapabilities;
+
+  detectInstall(): Promise<ProviderInstallStatus>;
+  listNativeSessions(
+    scope?: NativeSessionListScope
+  ): Promise<NativeSessionSummary[]>;
+  importSession(ref: NativeSessionRef): Promise<NativeSessionImportResult>;
+  readProviderState(ref: NativeSessionRef): Promise<ProviderStateSnapshot>;
+  resumeCommand(ref: NativeSessionRef): string[];
+}

--- a/server/provider-state/claude-jsonl-state-adapter.ts
+++ b/server/provider-state/claude-jsonl-state-adapter.ts
@@ -1,0 +1,776 @@
+import { createHash } from 'node:crypto';
+import { constants } from 'node:fs';
+import { access, readdir, readFile, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import * as path from 'node:path';
+import { emptyAgentSessionV2 } from '../../shared/agent-chat-protocol-v2.js';
+import type {
+  AgentItemV2,
+  AgentPatchV2,
+  AgentTurnV2,
+} from '../../shared/agent-chat-protocol-v2.js';
+import type {
+  AgentHarnessStateCapabilities,
+  NativeSessionImportResult,
+  NativeSessionListScope,
+  NativeSessionPreview,
+  NativeSessionRef,
+  NativeSessionSummary,
+  ProviderInstallStatus,
+  ProviderStateSnapshot,
+} from '../../shared/provider-native-session-state.js';
+import type { AgentHarnessStateAdapter } from '../harness-state-adapter.js';
+
+const CLAUDE_STATE_CAPABILITIES: AgentHarnessStateCapabilities = {
+  canImportTranscript: true,
+  canReadProviderState: true,
+  canResumeNative: true,
+  canStreamLiveEvents: false,
+  canRespondToApprovals: false,
+  canExposeToolCalls: true,
+  readOnly: true,
+};
+
+const MAX_LIST_FILES = 500;
+const MAX_SCAN_DEPTH = 6;
+const PREVIEW_LIMIT = 240;
+const TEXT_LIMIT = 32_000;
+
+interface ParsedJsonlLine {
+  lineNumber: number;
+  value: Record<string, unknown>;
+}
+
+interface ClaudeJsonlFile {
+  path: string;
+  bytes: number;
+  hashSha256: string;
+  lines: ParsedJsonlLine[];
+}
+
+interface ClaudeAdapterOptions {
+  stateRoot?: string;
+  now?: () => Date;
+  maxFiles?: number;
+}
+
+export class ClaudeJsonlStateAdapter implements AgentHarnessStateAdapter {
+  readonly provider = 'claude' as const;
+  readonly capabilities = CLAUDE_STATE_CAPABILITIES;
+
+  private readonly stateRoot: string;
+  private readonly now: () => Date;
+  private readonly maxFiles: number;
+
+  constructor(options: ClaudeAdapterOptions = {}) {
+    this.stateRoot = options.stateRoot ?? path.join(homedir(), '.claude');
+    this.now = options.now ?? (() => new Date());
+    this.maxFiles = options.maxFiles ?? MAX_LIST_FILES;
+  }
+
+  async detectInstall(): Promise<ProviderInstallStatus> {
+    const detectedAt = this.nowIso();
+    try {
+      await access(this.stateRoot, constants.R_OK);
+      const files = await findJsonlFiles(this.stateRoot, {
+        maxFiles: 1,
+        maxDepth: MAX_SCAN_DEPTH,
+      });
+      return {
+        provider: this.provider,
+        status: 'installed',
+        detectedAt,
+        stateRoots: [this.stateRoot],
+        diagnostics: files.length > 0
+          ? [
+              {
+                code: 'CLAUDE_STATE_READABLE',
+                message: 'Claude state root is readable.',
+                severity: 'info',
+              },
+            ]
+          : [
+              {
+                code: 'CLAUDE_STATE_EMPTY',
+                message: 'Claude state root is readable but no JSONL sessions were found.',
+                severity: 'warning',
+              },
+            ],
+      };
+    } catch (error) {
+      return {
+        provider: this.provider,
+        status: 'unavailable',
+        detectedAt,
+        stateRoots: [this.stateRoot],
+        diagnostics: [
+          {
+            code: 'CLAUDE_STATE_UNREADABLE',
+            message: safeErrorMessage(error),
+            severity: 'warning',
+          },
+        ],
+      };
+    }
+  }
+
+  async listNativeSessions(
+    scope: NativeSessionListScope = {}
+  ): Promise<NativeSessionSummary[]> {
+    const files = await findJsonlFiles(this.stateRoot, {
+      maxFiles: this.maxFiles,
+      maxDepth: MAX_SCAN_DEPTH,
+    });
+    const summaries: NativeSessionSummary[] = [];
+
+    for (const filePath of files) {
+      const parsed = await readClaudeJsonl(filePath);
+      const summary = summarizeClaudeJsonl(parsed, this.capabilities);
+      if (scope.cwd && summary.cwd !== scope.cwd) continue;
+      if (scope.workContextId && summary.workContextId !== scope.workContextId)
+        continue;
+      summaries.push(summary);
+    }
+
+    return summaries.sort((a, b) => {
+      const aTime = a.updatedAt ?? a.lastMessageAt ?? a.createdAt ?? '';
+      const bTime = b.updatedAt ?? b.lastMessageAt ?? b.createdAt ?? '';
+      return bTime.localeCompare(aTime);
+    });
+  }
+
+  async readProviderState(ref: NativeSessionRef): Promise<ProviderStateSnapshot> {
+    const file = await this.readRef(ref);
+    const summary = summarizeClaudeJsonl(file, this.capabilities);
+    const eventTypes = collectEventTypes(file.lines);
+    const timestamps = collectTimestamps(file.lines);
+
+    return {
+      ref: normalizeRef(ref, summary),
+      capturedAt: this.nowIso(),
+      sourcePath: file.path,
+      summary: {
+        lineCount: file.lines.length,
+        byteCount: file.bytes,
+        hashSha256: file.hashSha256,
+        eventTypes,
+        ...(timestamps.first ? { firstTimestamp: timestamps.first } : {}),
+        ...(timestamps.last ? { lastTimestamp: timestamps.last } : {}),
+        preview: summary.preview,
+      },
+      redaction: {
+        rawPayloadStored: false,
+        strategy: 'preview',
+        classes: ['credential', 'secret', 'payload', 'transcript'],
+      },
+    };
+  }
+
+  async importSession(ref: NativeSessionRef): Promise<NativeSessionImportResult> {
+    const file = await this.readRef(ref);
+    const summary = summarizeClaudeJsonl(file, this.capabilities);
+    const importedAt = this.nowIso();
+    const sessionId = relaySessionId(summary.nativeId, file.hashSha256);
+    const session = emptyAgentSessionV2({
+      id: sessionId,
+      provider: 'claude',
+      cwd: summary.cwd ?? ref.cwd ?? '',
+      capabilities: {
+        text: true,
+        reasoning: true,
+        tools: true,
+        commandExecution: true,
+        fileChanges: false,
+        approvals: false,
+        questions: false,
+        plans: false,
+        resume: true,
+        telemetry: true,
+        streaming: false,
+      },
+      providerSession: providerSession(summary, file),
+      config: {
+        providerOptions: {
+          importedFromNativeProvider: true,
+          importSource: 'claude-jsonl',
+          readOnly: true,
+        },
+      },
+    });
+
+    session.turns = buildTurns(file, sessionId, importedAt);
+
+    const patches: AgentPatchV2[] = [
+      {
+        type: 'agent-session-snapshot-v2',
+        sessionId,
+        timestamp: importedAt,
+        session,
+      },
+    ];
+
+    return {
+      provider: this.provider,
+      nativeId: summary.nativeId,
+      importedAt,
+      sourcePath: file.path,
+      session,
+      patches,
+    };
+  }
+
+  resumeCommand(ref: NativeSessionRef): string[] {
+    return ['claude', '--resume', ref.nativeId];
+  }
+
+  private async readRef(ref: NativeSessionRef): Promise<ClaudeJsonlFile> {
+    if (ref.provider !== this.provider) {
+      throw new Error(`Claude adapter cannot read provider '${ref.provider}'.`);
+    }
+    if (ref.sourcePath) {
+      return readClaudeJsonl(ref.sourcePath);
+    }
+
+    const sessions = await this.listNativeSessions(
+      ref.cwd ? { cwd: ref.cwd } : {}
+    );
+    const found = sessions.find((session) => session.nativeId === ref.nativeId);
+    if (!found) {
+      throw new Error(`Claude native session '${ref.nativeId}' was not found.`);
+    }
+    return readClaudeJsonl(found.sourcePath);
+  }
+
+  private nowIso(): string {
+    return this.now().toISOString();
+  }
+}
+
+async function findJsonlFiles(
+  root: string,
+  opts: { maxFiles: number; maxDepth: number }
+): Promise<string[]> {
+  const found: string[] = [];
+
+  async function walk(dir: string, depth: number): Promise<void> {
+    if (found.length >= opts.maxFiles || depth > opts.maxDepth) return;
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (found.length >= opts.maxFiles) return;
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        await walk(entryPath, depth + 1);
+      } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+        found.push(entryPath);
+      }
+    }
+  }
+
+  await walk(root, 0);
+  return found;
+}
+
+async function readClaudeJsonl(filePath: string): Promise<ClaudeJsonlFile> {
+  const [content, info] = await Promise.all([readFile(filePath, 'utf8'), stat(filePath)]);
+  const hashSha256 = createHash('sha256').update(content).digest('hex');
+  const lines: ParsedJsonlLine[] = [];
+
+  content.split(/\r?\n/).forEach((line, index) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    try {
+      const value = JSON.parse(trimmed) as unknown;
+      if (isRecord(value)) lines.push({ lineNumber: index + 1, value });
+    } catch {
+      // Ignore corrupt lines during read-only listing/import. The snapshot hash
+      // still covers them, and future diagnostics can surface parse errors.
+    }
+  });
+
+  return {
+    path: filePath,
+    bytes: info.size,
+    hashSha256,
+    lines,
+  };
+}
+
+function summarizeClaudeJsonl(
+  file: ClaudeJsonlFile,
+  capabilities: AgentHarnessStateCapabilities
+): NativeSessionSummary {
+  const nativeId = nativeIdFromLines(file.lines) ?? path.basename(file.path, '.jsonl');
+  const cwd = firstStringField(file.lines, ['cwd', 'workspace', 'projectPath']);
+  const workContextId = firstStringField(file.lines, ['workContextId', 'work_context_id']);
+  const repoPath = firstStringField(file.lines, ['repoPath', 'repositoryPath']);
+  const worktreePath = firstStringField(file.lines, ['worktreePath']);
+  const timestamps = collectTimestamps(file.lines);
+  const title = titleFromLines(file.lines);
+  const preview = previewFromLines(file.lines, title ?? path.basename(file.path, '.jsonl'));
+
+  return {
+    provider: 'claude',
+    nativeId,
+    sourcePath: file.path,
+    ...(cwd ? { cwd } : {}),
+    ...(repoPath ? { repoPath } : {}),
+    ...(worktreePath ? { worktreePath } : {}),
+    ...(workContextId ? { workContextId } : {}),
+    ...(timestamps.first ? { createdAt: timestamps.first } : {}),
+    ...(timestamps.last ? { updatedAt: timestamps.last, lastMessageAt: timestamps.last } : {}),
+    ...(title ? { title } : {}),
+    preview,
+    metadata: {
+      lineCount: file.lines.length,
+      byteCount: file.bytes,
+      hashSha256: file.hashSha256,
+      nativeSessionId: nativeId,
+      eventTypes: collectEventTypes(file.lines),
+    },
+    capabilities,
+  };
+}
+
+function buildTurns(
+  file: ClaudeJsonlFile,
+  sessionId: string,
+  importedAt: string
+): AgentTurnV2[] {
+  const turns: AgentTurnV2[] = [
+    {
+      id: 'native-import-audit',
+      status: 'completed',
+      inputMessageId: 'native-import-audit-marker',
+      startedAt: importedAt,
+      completedAt: importedAt,
+      items: [
+        {
+          id: 'native-import-audit-marker',
+          type: 'providerExtension',
+          namespace: 'provider-state-import',
+          status: 'completed',
+          startedAt: importedAt,
+          completedAt: importedAt,
+          payload: {
+            event: 'native-session-imported',
+            sourceProvider: 'claude',
+            importSource: 'claude-jsonl',
+            importedAt,
+            sourcePath: file.path,
+            hashSha256: file.hashSha256,
+            readOnly: true,
+          },
+        },
+      ],
+    },
+  ];
+
+  let activeTurn: AgentTurnV2 | null = null;
+  let assistantSeq = 0;
+  let extensionSeq = 0;
+
+  for (const parsed of file.lines) {
+    const record = parsed.value;
+    const role = messageRole(record);
+    const timestamp = timestampFromRecord(record) ?? importedAt;
+    const blocks = messageBlocks(record);
+
+    if (role === 'user' && isToolResultOnly(blocks)) {
+      const turn = activeTurn ?? createSyntheticTurn(turns, timestamp, importedAt);
+      const text = redactText(blockText(blocks));
+      turn.items.push({
+        id: `native-tool-result-${++extensionSeq}`,
+        type: 'providerExtension',
+        namespace: 'claude',
+        startedAt: timestamp,
+        completedAt: timestamp,
+        status: 'completed',
+        payload: {
+          kind: 'tool_result',
+          lineNumber: parsed.lineNumber,
+          contentPreview: truncate(text, PREVIEW_LIMIT),
+          redacted: true,
+        },
+      });
+      continue;
+    }
+
+    if (role === 'user') {
+      const text = redactText(textFromRecord(record));
+      if (!text) continue;
+      const turnId = `native-turn-${turns.length}`;
+      const itemId = `user-${turnId}`;
+      const providerItemId = stringFromRecord(record, ['uuid', 'id']);
+      const userItem: AgentItemV2 = {
+        id: itemId,
+        type: 'userMessage',
+        text: truncate(text, TEXT_LIMIT),
+        startedAt: timestamp,
+        completedAt: timestamp,
+        status: 'completed',
+        ...(providerItemId ? { providerItemId } : {}),
+      };
+      const turn: AgentTurnV2 = {
+        id: turnId,
+        ...(providerItemId ? { providerTurnId: providerItemId } : {}),
+        status: 'completed',
+        inputMessageId: itemId,
+        startedAt: timestamp,
+        completedAt: timestamp,
+        items: [userItem],
+      };
+      activeTurn = turn;
+      turns.push(turn);
+      continue;
+    }
+
+    if (role === 'assistant') {
+      const turn = activeTurn ?? createSyntheticTurn(turns, timestamp, importedAt);
+      appendAssistantBlocks(turn, blocks, timestamp, ++assistantSeq);
+      turn.completedAt = timestamp;
+      continue;
+    }
+  }
+
+  for (const turn of turns) {
+    turn.status = 'completed';
+    turn.completedAt = turn.completedAt ?? turn.startedAt;
+  }
+
+  // sessionId is passed so future patch-based import helpers can keep stable
+  // IDs without changing this reducer path. Keep the invariant alive, crab tax.
+  void sessionId;
+  return turns;
+}
+
+function appendAssistantBlocks(
+  turn: AgentTurnV2,
+  blocks: Record<string, unknown>[],
+  timestamp: string,
+  seq: number
+): void {
+  const textParts: string[] = [];
+  const reasoningParts: string[] = [];
+  const extraItems: AgentItemV2[] = [];
+
+  for (const block of blocks) {
+    const blockType = stringField(block.type);
+    if (blockType === 'text') {
+      const text = stringField(block.text);
+      if (text) textParts.push(text);
+    } else if (blockType === 'thinking' || blockType === 'reasoning') {
+      const text = stringField(block.thinking ?? block.text ?? block.summary);
+      if (text) reasoningParts.push(text);
+    } else if (blockType === 'tool_use') {
+      extraItems.push(toolUseItem(block, timestamp, seq, extraItems.length));
+    }
+  }
+
+  if (reasoningParts.length > 0) {
+    extraItems.unshift({
+      id: `assistant-reasoning-${seq}`,
+      type: 'reasoning',
+      summary: truncate(redactText(reasoningParts.join('\n')), PREVIEW_LIMIT),
+      visibility: 'summary',
+      startedAt: timestamp,
+      completedAt: timestamp,
+      status: 'completed',
+    });
+  }
+
+  if (textParts.length > 0) {
+    extraItems.push({
+      id: `assistant-message-${seq}`,
+      providerMessageId: `claude-assistant-${seq}`,
+      type: 'assistantMessage',
+      text: truncate(redactText(textParts.join('\n')), TEXT_LIMIT),
+      phase: 'answer',
+      startedAt: timestamp,
+      completedAt: timestamp,
+      status: 'completed',
+    });
+  }
+
+  turn.items.push(...extraItems);
+}
+
+function toolUseItem(
+  block: Record<string, unknown>,
+  timestamp: string,
+  seq: number,
+  index: number
+): AgentItemV2 {
+  const toolName = stringField(block.name, 'tool');
+  const input = redactJsonValue(block.input) as Record<string, unknown>;
+  if (toolName === 'Bash' && typeof input.command === 'string') {
+    return {
+      id: `assistant-command-${seq}-${index}`,
+      providerItemId: stringField(block.id),
+      type: 'commandExecution',
+      command: truncate(input.command, PREVIEW_LIMIT),
+      output: '',
+      exitCode: null,
+      startedAt: timestamp,
+      completedAt: timestamp,
+      status: 'completed',
+      metadata: { sourceProvider: 'claude', readOnlyImport: true },
+      ...(typeof input.cwd === 'string' ? { cwd: input.cwd } : {}),
+    };
+  }
+
+  return {
+    id: `assistant-tool-${seq}-${index}`,
+    providerItemId: stringField(block.id),
+    type: 'dynamicToolCall',
+    namespace: 'claude',
+    tool: toolName,
+    arguments: isRecord(input) ? input : {},
+    startedAt: timestamp,
+    completedAt: timestamp,
+    status: 'completed',
+    metadata: { sourceProvider: 'claude', readOnlyImport: true },
+  };
+}
+
+function createSyntheticTurn(
+  turns: AgentTurnV2[],
+  timestamp: string,
+  importedAt: string
+): AgentTurnV2 {
+  const turnId = `native-turn-${turns.length}`;
+  const itemId = `provider-${turnId}`;
+  const turn: AgentTurnV2 = {
+    id: turnId,
+    status: 'completed',
+    inputMessageId: itemId,
+    startedAt: timestamp,
+    completedAt: timestamp,
+    items: [
+      {
+        id: itemId,
+        type: 'providerExtension',
+        namespace: 'provider-state-import',
+        startedAt: importedAt,
+        completedAt: importedAt,
+        status: 'completed',
+        payload: { event: 'synthetic-turn', reason: 'assistant-without-user' },
+      },
+    ],
+  };
+  turns.push(turn);
+  return turn;
+}
+
+function normalizeRef(
+  ref: NativeSessionRef,
+  summary: NativeSessionSummary
+): NativeSessionRef {
+  return {
+    provider: 'claude',
+    nativeId: summary.nativeId,
+    sourcePath: summary.sourcePath,
+    ...(summary.cwd ? { cwd: summary.cwd } : {}),
+    ...(ref.stateRoot ? { stateRoot: ref.stateRoot } : {}),
+  };
+}
+
+function providerSession(
+  summary: NativeSessionSummary,
+  file: ClaudeJsonlFile
+): Record<string, string> {
+  const providerSession: Record<string, string> = {
+    nativeId: summary.nativeId,
+    sourcePath: file.path,
+    stateKind: 'claude-jsonl',
+    hashSha256: file.hashSha256,
+  };
+  if (summary.cwd) providerSession.cwd = summary.cwd;
+  return providerSession;
+}
+
+function nativeIdFromLines(lines: ParsedJsonlLine[]): string | null {
+  return firstStringField(lines, [
+    'sessionId',
+    'session_id',
+    'conversationId',
+    'conversation_id',
+  ]) ?? null;
+}
+
+function collectTimestamps(lines: ParsedJsonlLine[]): { first?: string; last?: string } {
+  const timestamps = lines
+    .map((line) => timestampFromRecord(line.value))
+    .filter((value): value is string => Boolean(value))
+    .sort();
+  return {
+    ...(timestamps[0] ? { first: timestamps[0] } : {}),
+    ...(timestamps[timestamps.length - 1]
+      ? { last: timestamps[timestamps.length - 1] }
+      : {}),
+  };
+}
+
+function collectEventTypes(lines: ParsedJsonlLine[]): string[] {
+  return [
+    ...new Set(
+      lines
+        .map((line) => stringField(line.value.type) || messageRole(line.value))
+        .filter(Boolean)
+    ),
+  ];
+}
+
+function titleFromLines(lines: ParsedJsonlLine[]): string | undefined {
+  for (const line of lines) {
+    const summary = stringFromRecord(line.value, ['summary', 'title']);
+    if (summary) return truncate(redactText(summary), PREVIEW_LIMIT);
+  }
+  return undefined;
+}
+
+function previewFromLines(lines: ParsedJsonlLine[], fallback: string): NativeSessionPreview {
+  for (const line of lines) {
+    const text = textFromRecord(line.value);
+    if (!text) continue;
+    const redacted = redactText(text);
+    return {
+      text: truncate(redacted, PREVIEW_LIMIT),
+      source: 'transcript',
+      redacted: redacted !== text,
+      charCount: redacted.length,
+    };
+  }
+  return {
+    text: truncate(redactText(fallback), PREVIEW_LIMIT),
+    source: fallback ? 'filename' : 'none',
+    redacted: false,
+    charCount: fallback.length,
+  };
+}
+
+function firstStringField(
+  lines: ParsedJsonlLine[],
+  keys: string[]
+): string | undefined {
+  for (const line of lines) {
+    const value = stringFromRecord(line.value, keys);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function timestampFromRecord(record: Record<string, unknown>): string | undefined {
+  const raw = stringFromRecord(record, ['timestamp', 'createdAt', 'created_at']);
+  if (!raw) return undefined;
+  const date = new Date(raw);
+  return Number.isNaN(date.valueOf()) ? undefined : date.toISOString();
+}
+
+function messageRole(record: Record<string, unknown>): string {
+  const message = objectField(record.message);
+  return stringField(message.role) || stringField(record.role) || stringField(record.type);
+}
+
+function messageBlocks(record: Record<string, unknown>): Record<string, unknown>[] {
+  const message = objectField(record.message);
+  const content = message.content ?? record.content;
+  if (typeof content === 'string') return [{ type: 'text', text: content }];
+  if (!Array.isArray(content)) return [];
+  return content.filter(isRecord);
+}
+
+function textFromRecord(record: Record<string, unknown>): string {
+  return blockText(messageBlocks(record));
+}
+
+function blockText(blocks: Record<string, unknown>[]): string {
+  const parts: string[] = [];
+  for (const block of blocks) {
+    const type = stringField(block.type);
+    if (type === 'text') parts.push(stringField(block.text));
+    if (type === 'tool_result') parts.push(stringField(block.content));
+    if (type === 'thinking') parts.push(stringField(block.thinking));
+  }
+  return parts.filter(Boolean).join('\n');
+}
+
+function isToolResultOnly(blocks: Record<string, unknown>[]): boolean {
+  return blocks.length > 0 && blocks.every((block) => block.type === 'tool_result');
+}
+
+function stringFromRecord(
+  record: Record<string, unknown>,
+  keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const direct = record[key];
+    if (typeof direct === 'string' && direct.trim()) return direct;
+    const nested = objectField(record.message)[key];
+    if (typeof nested === 'string' && nested.trim()) return nested;
+  }
+  return undefined;
+}
+
+function redactJsonValue(value: unknown, depth = 0): unknown {
+  if (depth > 6) return '[redacted-depth]';
+  if (typeof value === 'string') return redactText(value);
+  if (Array.isArray(value)) return value.map((entry) => redactJsonValue(entry, depth + 1));
+  if (!isRecord(value)) return value;
+
+  const out: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (/token|secret|password|api[_-]?key|authorization/i.test(key)) {
+      out[key] = '[redacted]';
+    } else {
+      out[key] = redactJsonValue(entry, depth + 1);
+    }
+  }
+  return out;
+}
+
+function redactText(text: string): string {
+  return text
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, '[redacted-secret]')
+    .replace(/\bgh[pousr]_[A-Za-z0-9_]{8,}\b/g, '[redacted-secret]')
+    .replace(/\b[A-Za-z0-9._%+-]+:[A-Za-z0-9._%+-]+@/g, '[redacted-credential]@')
+    .replace(
+      /\b(api[_-]?key|token|secret|password)\s*[:=]\s*[^\s,;]+/gi,
+      '$1=[redacted]'
+    );
+}
+
+function truncate(text: string, limit: number): string {
+  return text.length > limit ? `${text.slice(0, limit - 1)}…` : text;
+}
+
+function relaySessionId(nativeId: string, hash: string): string {
+  return `native-claude-${slug(nativeId)}-${hash.slice(0, 12)}`;
+}
+
+function slug(value: string): string {
+  const normalized = value.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  return normalized.replace(/^-|-$/g, '').slice(0, 48) || 'session';
+}
+
+function objectField(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function stringField(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value : fallback;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function safeErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/server/provider-state/claude-jsonl-state-adapter.ts
+++ b/server/provider-state/claude-jsonl-state-adapter.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { constants } from 'node:fs';
-import { access, readdir, readFile, stat } from 'node:fs/promises';
+import { access, readdir, readFile, realpath, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 import { emptyAgentSessionV2 } from '../../shared/agent-chat-protocol-v2.js';
@@ -12,6 +12,7 @@ import type {
 import type {
   AgentHarnessStateCapabilities,
   NativeSessionImportResult,
+  NativeSessionImportTruncation,
   NativeSessionListScope,
   NativeSessionPreview,
   NativeSessionRef,
@@ -35,6 +36,7 @@ const MAX_LIST_FILES = 500;
 const MAX_SCAN_DEPTH = 6;
 const PREVIEW_LIMIT = 240;
 const TEXT_LIMIT = 32_000;
+const MAX_IMPORT_TRANSCRIPT_BYTES = 256_000;
 
 interface ParsedJsonlLine {
   lineNumber: number;
@@ -46,6 +48,11 @@ interface ClaudeJsonlFile {
   bytes: number;
   hashSha256: string;
   lines: ParsedJsonlLine[];
+}
+
+interface ImportedTurns {
+  turns: AgentTurnV2[];
+  truncation?: NativeSessionImportTruncation;
 }
 
 interface ClaudeAdapterOptions {
@@ -198,7 +205,15 @@ export class ClaudeJsonlStateAdapter implements AgentHarnessStateAdapter {
       },
     });
 
-    session.turns = buildTurns(file, sessionId, importedAt);
+    const importedTurns = buildTurns(file, sessionId, importedAt);
+    session.turns = importedTurns.turns;
+    if (importedTurns.truncation) {
+      session.config.providerOptions = {
+        ...session.config.providerOptions,
+        importTruncation: importedTurns.truncation,
+      };
+      annotateAuditMarker(session.turns, importedTurns.truncation);
+    }
 
     const patches: AgentPatchV2[] = [
       {
@@ -209,14 +224,16 @@ export class ClaudeJsonlStateAdapter implements AgentHarnessStateAdapter {
       },
     ];
 
-    return {
+    const result: NativeSessionImportResult = {
       provider: this.provider,
       nativeId: summary.nativeId,
       importedAt,
       sourcePath: file.path,
       session,
       patches,
+      ...(importedTurns.truncation ? { importTruncation: importedTurns.truncation } : {}),
     };
+    return result;
   }
 
   resumeCommand(ref: NativeSessionRef): string[] {
@@ -228,7 +245,7 @@ export class ClaudeJsonlStateAdapter implements AgentHarnessStateAdapter {
       throw new Error(`Claude adapter cannot read provider '${ref.provider}'.`);
     }
     if (ref.sourcePath) {
-      return readClaudeJsonl(ref.sourcePath);
+      return readClaudeJsonl(await this.resolveSafeSourcePath(ref.sourcePath));
     }
 
     const sessions = await this.listNativeSessions(
@@ -238,7 +255,29 @@ export class ClaudeJsonlStateAdapter implements AgentHarnessStateAdapter {
     if (!found) {
       throw new Error(`Claude native session '${ref.nativeId}' was not found.`);
     }
-    return readClaudeJsonl(found.sourcePath);
+    return readClaudeJsonl(await this.resolveSafeSourcePath(found.sourcePath));
+  }
+
+  private async resolveSafeSourcePath(sourcePath: string): Promise<string> {
+    const resolvedSourcePath = path.resolve(sourcePath);
+    if (path.extname(resolvedSourcePath) !== '.jsonl') {
+      throw new Error('Claude native session sourcePath must point to a .jsonl file.');
+    }
+
+    const [rootRealPath, sourceRealPath] = await Promise.all([
+      realpath(this.stateRoot),
+      realpath(resolvedSourcePath),
+    ]);
+    if (path.extname(sourceRealPath) !== '.jsonl') {
+      throw new Error('Claude native session sourcePath must resolve to a .jsonl file.');
+    }
+
+    const relative = path.relative(rootRealPath, sourceRealPath);
+    if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error('Claude native session sourcePath must resolve under the configured state root.');
+    }
+
+    return sourceRealPath;
   }
 
   private nowIso(): string {
@@ -342,7 +381,7 @@ function buildTurns(
   file: ClaudeJsonlFile,
   sessionId: string,
   importedAt: string
-): AgentTurnV2[] {
+): ImportedTurns {
   const turns: AgentTurnV2[] = [
     {
       id: 'native-import-audit',
@@ -444,10 +483,56 @@ function buildTurns(
     turn.completedAt = turn.completedAt ?? turn.startedAt;
   }
 
+  const truncation = trimImportedTurns(turns);
+
   // sessionId is passed so future patch-based import helpers can keep stable
   // IDs without changing this reducer path. Keep the invariant alive, crab tax.
   void sessionId;
-  return turns;
+  return truncation ? { turns, truncation } : { turns };
+}
+
+function trimImportedTurns(turns: AgentTurnV2[]): NativeSessionImportTruncation | undefined {
+  let approximateTranscriptBytes = transcriptBytes(turns);
+  if (approximateTranscriptBytes <= MAX_IMPORT_TRANSCRIPT_BYTES) return undefined;
+
+  const originalTurns = turns.length;
+  let droppedTurns = 0;
+  let droppedItems = 0;
+
+  while (approximateTranscriptBytes > MAX_IMPORT_TRANSCRIPT_BYTES && turns.length > 1) {
+    const [removed] = turns.splice(1, 1);
+    if (!removed) break;
+    droppedTurns += 1;
+    droppedItems += removed.items.length;
+    approximateTranscriptBytes = transcriptBytes(turns);
+  }
+
+  return {
+    truncated: true,
+    strategy: 'fifo-oldest-non-audit',
+    maxTranscriptBytes: MAX_IMPORT_TRANSCRIPT_BYTES,
+    approximateTranscriptBytes,
+    originalTurns,
+    retainedTurns: turns.length,
+    droppedTurns,
+    droppedItems,
+  };
+}
+
+function annotateAuditMarker(
+  turns: AgentTurnV2[],
+  truncation: NativeSessionImportTruncation
+): void {
+  const marker = turns[0]?.items[0];
+  if (!marker || marker.type !== 'providerExtension') return;
+  marker.payload = {
+    ...marker.payload,
+    importTruncation: truncation,
+  };
+}
+
+function transcriptBytes(turns: AgentTurnV2[]): number {
+  return Buffer.byteLength(JSON.stringify(turns), 'utf8');
 }
 
 function appendAssistantBlocks(

--- a/server/provider-state/index.ts
+++ b/server/provider-state/index.ts
@@ -1,0 +1,1 @@
+export { ClaudeJsonlStateAdapter } from './claude-jsonl-state-adapter.js';

--- a/shared/provider-native-session-state.ts
+++ b/shared/provider-native-session-state.ts
@@ -109,6 +109,17 @@ export interface ProviderStateSnapshot {
   };
 }
 
+export interface NativeSessionImportTruncation {
+  truncated: true;
+  strategy: 'fifo-oldest-non-audit';
+  maxTranscriptBytes: number;
+  approximateTranscriptBytes: number;
+  originalTurns: number;
+  retainedTurns: number;
+  droppedTurns: number;
+  droppedItems: number;
+}
+
 export interface NativeSessionImportResult {
   provider: NativeSessionProvider;
   nativeId: string;
@@ -116,4 +127,5 @@ export interface NativeSessionImportResult {
   sourcePath: string;
   session: AgentSessionV2;
   patches: AgentPatchV2[];
+  importTruncation?: NativeSessionImportTruncation;
 }

--- a/shared/provider-native-session-state.ts
+++ b/shared/provider-native-session-state.ts
@@ -1,0 +1,119 @@
+import type {
+  AgentPatchV2,
+  AgentProviderV2,
+  AgentSessionV2,
+} from './agent-chat-protocol-v2.js';
+import type { WorkContextId } from './work-context.js';
+
+export type NativeSessionProvider = Extract<
+  AgentProviderV2,
+  'claude' | 'codex' | 'hermes' | 'opencode'
+>;
+
+export type ProviderInstallStatusKind =
+  | 'installed'
+  | 'unavailable'
+  | 'unsupported';
+
+export interface ProviderInstallDiagnostic {
+  code: string;
+  message: string;
+  severity: 'info' | 'warning' | 'error';
+}
+
+export interface ProviderInstallStatus {
+  provider: NativeSessionProvider;
+  status: ProviderInstallStatusKind;
+  detectedAt: string;
+  stateRoots: string[];
+  diagnostics: ProviderInstallDiagnostic[];
+  version?: string;
+}
+
+export interface AgentHarnessStateCapabilities {
+  canImportTranscript: boolean;
+  canReadProviderState: boolean;
+  canResumeNative: boolean;
+  canStreamLiveEvents: boolean;
+  canRespondToApprovals: boolean;
+  canExposeToolCalls: boolean;
+  readOnly: true;
+}
+
+export interface NativeSessionRef {
+  provider: NativeSessionProvider;
+  nativeId: string;
+  sourcePath?: string;
+  stateRoot?: string;
+  cwd?: string;
+}
+
+export interface NativeSessionWorkContextHints {
+  workContextId?: WorkContextId;
+  cwd?: string;
+  repoPath?: string;
+  worktreePath?: string;
+}
+
+export interface NativeSessionListScope extends NativeSessionWorkContextHints {
+  provider?: NativeSessionProvider;
+}
+
+export interface NativeSessionPreview {
+  text: string;
+  source: 'metadata' | 'transcript' | 'filename' | 'none';
+  redacted: boolean;
+  charCount: number;
+}
+
+export interface NativeSessionSummary {
+  provider: NativeSessionProvider;
+  nativeId: string;
+  sourcePath: string;
+  cwd?: string;
+  repoPath?: string;
+  worktreePath?: string;
+  workContextId?: WorkContextId;
+  createdAt?: string;
+  updatedAt?: string;
+  lastMessageAt?: string;
+  title?: string;
+  preview: NativeSessionPreview;
+  metadata: {
+    lineCount?: number;
+    byteCount?: number;
+    hashSha256?: string;
+    nativeSessionId?: string;
+    eventTypes?: string[];
+  };
+  capabilities: AgentHarnessStateCapabilities;
+}
+
+export interface ProviderStateSnapshot {
+  ref: NativeSessionRef;
+  capturedAt: string;
+  sourcePath: string;
+  summary: {
+    lineCount: number;
+    byteCount: number;
+    hashSha256: string;
+    eventTypes: string[];
+    firstTimestamp?: string;
+    lastTimestamp?: string;
+    preview: NativeSessionPreview;
+  };
+  redaction: {
+    rawPayloadStored: false;
+    strategy: 'preview';
+    classes: ('credential' | 'secret' | 'payload' | 'transcript')[];
+  };
+}
+
+export interface NativeSessionImportResult {
+  provider: NativeSessionProvider;
+  nativeId: string;
+  importedAt: string;
+  sourcePath: string;
+  session: AgentSessionV2;
+  patches: AgentPatchV2[];
+}

--- a/test/server/provider-state/claude-jsonl-state-adapter.test.ts
+++ b/test/server/provider-state/claude-jsonl-state-adapter.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -100,6 +100,47 @@ describe('ClaudeJsonlStateAdapter', () => {
     expect(sessions[0]?.preview.text).not.toContain('abc123');
   });
 
+  it('rejects caller-provided source paths outside the configured state root', async () => {
+    const { root } = await writeFixture();
+    const outsideRoot = await mkdtemp(path.join(tmpdir(), 'relay-claude-jsonl-outside-'));
+    const outsidePath = path.join(outsideRoot, 'escape.jsonl');
+    await writeFile(
+      outsidePath,
+      `${JSON.stringify({ type: 'summary', sessionId: 'escape', timestamp: '2026-01-01T00:00:00.000Z' })}\n`
+    );
+    const adapter = new ClaudeJsonlStateAdapter({ stateRoot: root });
+
+    await expect(
+      adapter.readProviderState({
+        provider: 'claude',
+        nativeId: 'escape',
+        sourcePath: path.join(root, '..', path.basename(outsideRoot), 'escape.jsonl'),
+      })
+    ).rejects.toThrow(/state root/i);
+  });
+
+  it('rejects non-jsonl and symlink source paths even when they appear inside the state root', async () => {
+    const { root } = await writeFixture();
+    const nonJsonlPath = path.join(root, 'projects', '-tmp-repo', 'not-json.txt');
+    await writeFile(nonJsonlPath, '{}\n');
+    const outsideRoot = await mkdtemp(path.join(tmpdir(), 'relay-claude-jsonl-symlink-'));
+    const outsidePath = path.join(outsideRoot, 'outside.jsonl');
+    await writeFile(
+      outsidePath,
+      `${JSON.stringify({ type: 'summary', sessionId: 'outside', timestamp: '2026-01-01T00:00:00.000Z' })}\n`
+    );
+    const linkPath = path.join(root, 'projects', '-tmp-repo', 'linked-outside.jsonl');
+    await symlink(outsidePath, linkPath);
+    const adapter = new ClaudeJsonlStateAdapter({ stateRoot: root });
+
+    await expect(
+      adapter.readProviderState({ provider: 'claude', nativeId: 'not-json', sourcePath: nonJsonlPath })
+    ).rejects.toThrow(/jsonl/i);
+    await expect(
+      adapter.readProviderState({ provider: 'claude', nativeId: 'outside', sourcePath: linkPath })
+    ).rejects.toThrow(/state root/i);
+  });
+
   it('imports a Claude JSONL fixture into an AgentSessionV2 read model with an audit marker', async () => {
     const { root, sessionPath } = await writeFixture();
     const adapter = new ClaudeJsonlStateAdapter({
@@ -142,6 +183,51 @@ describe('ClaudeJsonlStateAdapter', () => {
     expect(JSON.stringify(result.session)).not.toContain('ghp_deadbeef12345678');
     expect(result.patches).toHaveLength(1);
     expect(result.patches.every(isAgentPatchV2)).toBe(true);
+  });
+
+  it('trims oversized imports FIFO while preserving the audit marker and reporting truncation', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'relay-claude-jsonl-large-'));
+    const projectDir = path.join(root, 'projects', '-tmp-repo');
+    await mkdir(projectDir, { recursive: true });
+    const sessionPath = path.join(projectDir, 'large-session.jsonl');
+    const lines = [
+      {
+        type: 'summary',
+        summary: 'large import',
+        sessionId: 'large-session',
+        cwd: '/tmp/repo',
+        timestamp: '2026-01-01T00:00:00.000Z',
+      },
+      ...Array.from({ length: 24 }, (_, index) => ({
+        type: 'user',
+        sessionId: 'large-session',
+        uuid: `large-user-${index}`,
+        cwd: '/tmp/repo',
+        timestamp: `2026-01-01T00:${String(index + 1).padStart(2, '0')}:00.000Z`,
+        message: {
+          role: 'user',
+          content: `message-${index}:${'x'.repeat(20_000)}`,
+        },
+      })),
+    ];
+    await writeFile(sessionPath, `${lines.map((line) => JSON.stringify(line)).join('\n')}\n`);
+    const adapter = new ClaudeJsonlStateAdapter({
+      stateRoot: root,
+      now: () => new Date('2026-01-01T00:30:00.000Z'),
+    });
+
+    const result = await adapter.importSession({
+      provider: 'claude',
+      nativeId: 'large-session',
+      sourcePath: sessionPath,
+    });
+
+    expect(result.session.turns[0]?.id).toBe('native-import-audit');
+    expect(result.importTruncation).toMatchObject({ truncated: true, droppedTurns: expect.any(Number) });
+    expect(result.session.config.providerOptions?.importTruncation).toEqual(result.importTruncation);
+    expect(JSON.stringify(result.session)).not.toContain('message-0:');
+    expect(JSON.stringify(result.session)).toContain('message-23:');
+    expect(result.session.turns.length).toBeLessThan(lines.length);
   });
 
   it('returns bounded provider snapshots and copyable resume argv without executing it', async () => {

--- a/test/server/provider-state/claude-jsonl-state-adapter.test.ts
+++ b/test/server/provider-state/claude-jsonl-state-adapter.test.ts
@@ -1,0 +1,179 @@
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { isAgentPatchV2 } from '../../../shared/agent-chat-protocol-v2.js';
+import { ClaudeJsonlStateAdapter } from '../../../server/provider-state/claude-jsonl-state-adapter.js';
+
+async function writeFixture(): Promise<{ root: string; sessionPath: string }> {
+  const root = await mkdtemp(path.join(tmpdir(), 'relay-claude-jsonl-'));
+  const projectDir = path.join(root, 'projects', '-tmp-repo');
+  await mkdir(projectDir, { recursive: true });
+  const sessionPath = path.join(projectDir, 'session-abc.jsonl');
+  const lines = [
+    {
+      type: 'summary',
+      summary: 'Investigate native state import',
+      sessionId: 'session-abc',
+      cwd: '/tmp/repo',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      workContextId: 'wc-1',
+    },
+    {
+      type: 'user',
+      sessionId: 'session-abc',
+      uuid: 'user-1',
+      cwd: '/tmp/repo',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      message: {
+        role: 'user',
+        content: 'please inspect token=abc123 and explain the setup',
+      },
+    },
+    {
+      type: 'assistant',
+      sessionId: 'session-abc',
+      uuid: 'assistant-1',
+      cwd: '/tmp/repo',
+      timestamp: '2026-01-01T00:00:02.000Z',
+      message: {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'need check files' },
+          {
+            type: 'tool_use',
+            id: 'tool-1',
+            name: 'Bash',
+            input: { command: 'npm test', cwd: '/tmp/repo', apiKey: 'sk-1234567890abcdef' },
+          },
+          { type: 'text', text: 'the adapter can read JSONL safely' },
+        ],
+      },
+    },
+    {
+      type: 'user',
+      sessionId: 'session-abc',
+      uuid: 'tool-result-1',
+      cwd: '/tmp/repo',
+      timestamp: '2026-01-01T00:00:03.000Z',
+      message: {
+        role: 'user',
+        content: [{ type: 'tool_result', content: 'stdout contained ghp_deadbeef12345678' }],
+      },
+    },
+  ];
+  await writeFile(sessionPath, `${lines.map((line) => JSON.stringify(line)).join('\n')}\n`);
+  return { root, sessionPath };
+}
+
+describe('ClaudeJsonlStateAdapter', () => {
+  it('detects readable Claude JSONL state and lists redacted native sessions', async () => {
+    const { root, sessionPath } = await writeFixture();
+    const adapter = new ClaudeJsonlStateAdapter({
+      stateRoot: root,
+      now: () => new Date('2026-01-01T00:10:00.000Z'),
+    });
+
+    await expect(adapter.detectInstall()).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'installed',
+      stateRoots: [root],
+    });
+
+    const sessions = await adapter.listNativeSessions({ cwd: '/tmp/repo' });
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      provider: 'claude',
+      nativeId: 'session-abc',
+      sourcePath: sessionPath,
+      cwd: '/tmp/repo',
+      workContextId: 'wc-1',
+      title: 'Investigate native state import',
+      capabilities: {
+        canImportTranscript: true,
+        canReadProviderState: true,
+        canResumeNative: true,
+        readOnly: true,
+      },
+    });
+    expect(sessions[0]?.preview.text).toContain('token=[redacted]');
+    expect(sessions[0]?.preview.text).not.toContain('abc123');
+  });
+
+  it('imports a Claude JSONL fixture into an AgentSessionV2 read model with an audit marker', async () => {
+    const { root, sessionPath } = await writeFixture();
+    const adapter = new ClaudeJsonlStateAdapter({
+      stateRoot: root,
+      now: () => new Date('2026-01-01T00:10:00.000Z'),
+    });
+
+    const result = await adapter.importSession({
+      provider: 'claude',
+      nativeId: 'session-abc',
+      sourcePath: sessionPath,
+    });
+
+    expect(result.provider).toBe('claude');
+    expect(result.session.provider).toBe('claude');
+    expect(result.session.providerSession).toMatchObject({
+      nativeId: 'session-abc',
+      sourcePath: sessionPath,
+      stateKind: 'claude-jsonl',
+    });
+    expect(result.session.turns[0]?.items[0]).toMatchObject({
+      type: 'providerExtension',
+      namespace: 'provider-state-import',
+      payload: {
+        event: 'native-session-imported',
+        sourceProvider: 'claude',
+        readOnly: true,
+      },
+    });
+    expect(result.session.turns[1]?.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'userMessage', text: expect.stringContaining('token=[redacted]') }),
+        expect.objectContaining({ type: 'reasoning', summary: 'need check files' }),
+        expect.objectContaining({ type: 'commandExecution', command: 'npm test' }),
+        expect.objectContaining({ type: 'assistantMessage', text: 'the adapter can read JSONL safely' }),
+        expect.objectContaining({ type: 'providerExtension', namespace: 'claude' }),
+      ])
+    );
+    expect(JSON.stringify(result.session)).not.toContain('sk-1234567890abcdef');
+    expect(JSON.stringify(result.session)).not.toContain('ghp_deadbeef12345678');
+    expect(result.patches).toHaveLength(1);
+    expect(result.patches.every(isAgentPatchV2)).toBe(true);
+  });
+
+  it('returns bounded provider snapshots and copyable resume argv without executing it', async () => {
+    const { root, sessionPath } = await writeFixture();
+    const adapter = new ClaudeJsonlStateAdapter({
+      stateRoot: root,
+      now: () => new Date('2026-01-01T00:10:00.000Z'),
+    });
+
+    const snapshot = await adapter.readProviderState({
+      provider: 'claude',
+      nativeId: 'session-abc',
+      sourcePath: sessionPath,
+    });
+
+    expect(snapshot.redaction).toEqual({
+      rawPayloadStored: false,
+      strategy: 'preview',
+      classes: ['credential', 'secret', 'payload', 'transcript'],
+    });
+    expect(snapshot.summary).toMatchObject({
+      lineCount: 4,
+      byteCount: expect.any(Number),
+      hashSha256: expect.any(String),
+      eventTypes: ['summary', 'user', 'assistant'],
+      firstTimestamp: '2026-01-01T00:00:00.000Z',
+      lastTimestamp: '2026-01-01T00:00:03.000Z',
+    });
+    expect(adapter.resumeCommand({ provider: 'claude', nativeId: 'session-abc' })).toEqual([
+      'claude',
+      '--resume',
+      'session-abc',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- adds shared/server provider-native session state contracts for detect/list/read/import/resume argv and explicit read-only capabilities
- adds a Claude JSONL read-only state adapter that detects/list sessions, returns redacted provider snapshots, imports normalized AgentSessionV2 snapshot patches, and emits copyable resume argv only
- documents provider-store read-only boundaries in provider, durability, and CLI gateway docs

## Test Plan
- npm run check
- npm test -- test/server/protocol-adapters/claude-adapter.test.ts test/server/protocol-adapters/codex-native-adapter.test.ts test/agent-chat-protocol-v2.test.ts test/server/provider-state/claude-jsonl-state-adapter.test.ts
- npm run build

Closes #717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled session import and discovery from provider-owned local state stores
  * Imported sessions include metadata, transcripts, and history with automatic redaction of sensitive data

* **Documentation**
  * Added provider documentation for implementing native session state adapters
  * Updated session durability and CLI gateway contracts with native session handling specifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->