### PR TITLE
Add shared CLI gateway command manifest

### DIFF
--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -73,6 +73,20 @@ The current error taxonomy is declared in `RELAY_CLI_GATEWAY_CONTRACT.errorEnvel
 
 The schema is the source of truth for adapter generation. A command missing from this manifest is not stable adapter API, even if an internal REST/WebSocket route exists.
 
+## Command taxonomy
+
+Relay command metadata is defined in [`shared/relay-command-manifest.ts`](../shared/relay-command-manifest.ts) as a projection of this v1 gateway contract. That module adds product-facing fields on top of each stable gateway command: `id`/`name`, label, description/summary, supported surfaces, input/output schemas, capability hints, side-effect class, confirmation requirement, scope kinds, and the public handler projection.
+
+Current command surfaces are intentionally separate:
+
+| Surface | Meaning | Execution path |
+| --- | --- | --- |
+| UI-only Command Center actions | Browser affordances such as navigation, settings, local palette helpers, and workflow entry points that are not stable agent API. | Frontend action registry only; do not generate agent tools from these. |
+| Stable CLI gateway commands | Versioned `relay-ide v1 ... --json` commands in `RELAY_CLI_GATEWAY_CONTRACT`. | Public CLI JSON gateway; this is the adapter-facing contract. |
+| Agent-callable commands | Gateway commands safe to expose to Claude/Codex/Hermes/MCP/ACP-style adapters through generated schemas. | Generated from the shared command manifest and executed through `relay-ide v1 ... --json`, never private node-link/browser routes. |
+
+The Command Center may search and describe stable gateway commands using the shared manifest before browser execution is wired. Until a `handler.uiAction` or explicit UI execution bridge exists, these entries must stay disabled/degraded in the palette and point operators to the stable CLI argv. Do not mark every internal UI button as agent-callable, and do not add Claude/Codex/Hermes-specific schemas by hand; add or change the Relay-owned command definition first.
+
 ## Auth and hub access
 
 Local discovery commands (`contract.*`, `nodes.manifest`) do not require a hub token.

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -275,7 +275,9 @@ function buildResults(
       });
     for (const a of registryCommands)
       items.push(actionToPaletteCommand(a, actionContext));
-    for (const { action, reason } of degradedCommands)
+    for (const { action, reason } of degradedCommands.filter(
+      (entry) => entry.action.category !== 'gateway'
+    ))
       items.push({
         type: 'command',
         id: `cmd-${action.id}`,

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -89,6 +89,7 @@ import {
   navSwitchToTab,
   navOpenFile,
 } from '../lib/actions/definitions/navigation.js';
+import { cliGatewayCommandActions } from '../lib/actions/definitions/cli-gateway.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import { useConfigStore } from '../lib/stores/config.js';
@@ -557,6 +558,13 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
           // For now a noop — same reasoning as workspaceOpenFileBrowser above.
         },
       },
+
+      // ── Stable CLI gateway projection (#716) ────────────────────────────────
+      // These are searchable Command Center descriptions for the public
+      // relay-ide v1 ... --json contract. They stay disabled until a future
+      // slice wires safe UI execution; agents must keep using the v1 CLI
+      // gateway rather than private node-link/browser routes.
+      ...cliGatewayCommandActions.map((def) => ({ ...def, handler: () => {} })),
 
       // ── Noop placeholders ────────────────────────────────────────────────────
       ...noopActions,

--- a/frontend/src/lib/actions/definitions/cli-gateway.ts
+++ b/frontend/src/lib/actions/definitions/cli-gateway.ts
@@ -1,0 +1,38 @@
+import {
+  RELAY_COMMAND_MANIFEST,
+  type RelayCommandDefinition,
+} from '../../../../../shared/relay-command-manifest.js';
+import type { ActionMeta } from '../types.js';
+
+export type CliGatewayCommandActionMeta = ActionMeta & {
+  relayCommand: RelayCommandDefinition;
+};
+
+export function cliGatewayActionId(command: RelayCommandDefinition): `gateway.${string}` {
+  return `gateway.${command.name}`;
+}
+
+function gatewayDisabledReason(command: RelayCommandDefinition): string {
+  const argv = command.handler.cli?.join(' ') ?? command.name;
+  return `stable cli gateway command; run via ${argv}. Command Center execution is not wired yet.`;
+}
+
+export const cliGatewayCommandActions: CliGatewayCommandActionMeta[] =
+  RELAY_COMMAND_MANIFEST.commands.map((command) => ({
+    id: cliGatewayActionId(command),
+    label: command.label,
+    description: command.description,
+    aliases: [
+      command.name,
+      `relay ${command.name}`,
+      command.handler.cli?.join(' ') ?? command.name,
+      command.sideEffect,
+      ...command.capabilityHints,
+      ...command.scopeKinds,
+    ],
+    category: 'gateway',
+    icon: 'v1',
+    when: () => false,
+    disabledReason: () => gatewayDisabledReason(command),
+    relayCommand: command,
+  }));

--- a/frontend/src/lib/actions/types.ts
+++ b/frontend/src/lib/actions/types.ts
@@ -8,7 +8,8 @@ export type ActionCategory =
   | 'navigation'
   | 'dashboard'
   | 'org'
-  | 'ticket';
+  | 'ticket'
+  | 'gateway';
 
 export type ActionContext = {
   view: 'workspace' | 'session' | 'dashboard' | 'settings' | 'org';

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -1,0 +1,156 @@
+import {
+  RELAY_CLI_GATEWAY_CONTRACT,
+  type RelayCliGatewayCommand,
+  type RelayCliGatewayCommandSpec,
+  type RelayJsonSchema,
+} from './cli-gateway-contract.js';
+import type { RelayCapabilityBit } from './security-policy.js';
+
+export type RelayCommandSurface = 'web' | 'cli' | 'agent';
+export type RelayCommandSideEffect = 'read' | 'write' | 'destructive' | 'stream';
+export type RelayCommandScopeKind = 'node' | 'repo' | 'worktree' | 'work-context' | 'session';
+
+export interface RelayCommandHandler {
+  /** Public CLI argv projection for the stable `relay-ide v1 ... --json` gateway. */
+  cli?: readonly string[];
+  /** Future hub/API execution projection; absent means this manifest does not expose a private route. */
+  api?: { method: string; path: string };
+  /** Existing Command Center action id when execution is wired through the UI registry. */
+  uiAction?: string;
+}
+
+export interface RelayCommandDefinition {
+  /** Stable Relay-owned command id. For gateway commands this is the v1 command name. */
+  id: RelayCliGatewayCommand;
+  /** Alias kept for agent/tool generators that call the command field `name`. */
+  name: RelayCliGatewayCommand;
+  label: string;
+  description: string;
+  summary: string;
+  surfaces: readonly RelayCommandSurface[];
+  inputSchema: RelayJsonSchema;
+  outputSchema: RelayJsonSchema;
+  capabilityHints: readonly RelayCapabilityBit[];
+  sideEffect: RelayCommandSideEffect;
+  requiresConfirmation: boolean;
+  scopeKinds: readonly RelayCommandScopeKind[];
+  handler: RelayCommandHandler;
+  stable: boolean;
+  source: 'cli-gateway-v1';
+}
+
+export interface RelayCommandManifest {
+  schemaVersion: 1;
+  generatedFrom: 'shared/cli-gateway-contract.ts';
+  commands: readonly RelayCommandDefinition[];
+}
+
+const CLI_AGENT_WEB_SURFACES = ['cli', 'agent', 'web'] as const;
+
+const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
+  'contract.list': 'gateway commands list',
+  'contract.schema': 'gateway schema',
+  'nodes.manifest': 'local node manifest',
+  'nodes.list': 'relay nodes list',
+  'sessions.list': 'sessions list',
+  'sessions.get': 'session details',
+  'sessions.create': 'create session',
+  'sessions.renew': 'renew session',
+  'sessions.attach': 'attach session descriptor',
+  'sessions.detach': 'detach session handle',
+  'sessions.stream': 'stream session output',
+  'sessions.input': 'send session input',
+  'sessions.interventions': 'session interventions',
+  'sessions.handBack': 'hand back session control',
+  'files.list': 'list session files',
+  'files.stat': 'stat session file',
+  'files.read': 'read session file',
+  'files.write': 'write session file',
+  'work-contexts.get': 'work context details',
+  'handoffs.plan': 'plan cold handoff',
+  'handoffs.create': 'create cold handoff',
+  'handoffs.status': 'handoff status',
+  'handoffs.cancel': 'cancel handoff',
+  'handoffs.resume': 'handoff resume bundle',
+  'handoffs.launch': 'launch handoff destination',
+  'artifacts.read': 'read handoff artifact',
+  'events.subscribe': 'subscribe gateway events',
+};
+
+function sideEffectForGatewayCommand(spec: RelayCliGatewayCommandSpec): RelayCommandSideEffect {
+  if (spec.name === 'sessions.stream' || spec.name === 'events.subscribe') return 'stream';
+  if (spec.name === 'handoffs.create' || spec.name === 'handoffs.launch') return 'destructive';
+  if (
+    spec.name === 'sessions.create' ||
+    spec.name === 'sessions.renew' ||
+    spec.name === 'sessions.detach' ||
+    spec.name === 'sessions.input' ||
+    spec.name === 'sessions.handBack' ||
+    spec.name === 'files.write' ||
+    spec.name === 'handoffs.cancel'
+  ) {
+    return 'write';
+  }
+  return 'read';
+}
+
+function scopeKindsForGatewayCommand(name: RelayCliGatewayCommand): readonly RelayCommandScopeKind[] {
+  if (name.startsWith('nodes.')) return ['node'];
+  if (name.startsWith('files.')) return ['session'];
+  if (name.startsWith('work-contexts.')) return ['work-context'];
+  if (name.startsWith('handoffs.')) return ['repo', 'worktree', 'work-context', 'session'];
+  if (name.startsWith('artifacts.')) return ['work-context'];
+  if (name.startsWith('events.')) return ['node', 'session'];
+  if (name.startsWith('sessions.')) return ['session'];
+  return [];
+}
+
+function requiresConfirmationForGatewayCommand(spec: RelayCliGatewayCommandSpec): boolean {
+  return (
+    spec.name === 'files.write' ||
+    spec.name === 'handoffs.create' ||
+    spec.name === 'handoffs.launch' ||
+    spec.capabilityHints.includes('pty:exec:arbitrary') ||
+    spec.capabilityHints.includes('rpc:fs:write')
+  );
+}
+
+export function relayCommandDefinitionFromCliGatewaySpec(
+  spec: RelayCliGatewayCommandSpec
+): RelayCommandDefinition {
+  return {
+    id: spec.name,
+    name: spec.name,
+    label: COMMAND_LABELS[spec.name],
+    description: spec.summary,
+    summary: spec.summary,
+    surfaces: CLI_AGENT_WEB_SURFACES,
+    inputSchema: spec.inputSchema,
+    outputSchema: spec.outputSchema,
+    capabilityHints: spec.capabilityHints as readonly RelayCapabilityBit[],
+    sideEffect: sideEffectForGatewayCommand(spec),
+    requiresConfirmation: requiresConfirmationForGatewayCommand(spec),
+    scopeKinds: scopeKindsForGatewayCommand(spec.name),
+    handler: { cli: spec.cli },
+    stable: spec.stable,
+    source: 'cli-gateway-v1',
+  };
+}
+
+export const RELAY_COMMAND_MANIFEST: RelayCommandManifest = {
+  schemaVersion: 1,
+  generatedFrom: 'shared/cli-gateway-contract.ts',
+  commands: RELAY_CLI_GATEWAY_CONTRACT.commandSchemas.map(relayCommandDefinitionFromCliGatewaySpec),
+};
+
+export function relayCommandDefinition(name: RelayCliGatewayCommand): RelayCommandDefinition {
+  const definition = RELAY_COMMAND_MANIFEST.commands.find((entry) => entry.name === name);
+  if (!definition) throw new Error(`unknown Relay command definition: ${name}`);
+  return definition;
+}
+
+export function relayCommandDefinitionsForSurface(
+  surface: RelayCommandSurface
+): RelayCommandDefinition[] {
+  return RELAY_COMMAND_MANIFEST.commands.filter((command) => command.surfaces.includes(surface));
+}

--- a/test/action-coverage.test.ts
+++ b/test/action-coverage.test.ts
@@ -13,6 +13,8 @@ import { sidebarActions } from '../frontend/src/lib/actions/definitions/sidebar.
 import { dashboardActions } from '../frontend/src/lib/actions/definitions/dashboard.js';
 import { terminalActions } from '../frontend/src/lib/actions/definitions/terminal.js';
 import { navigationActions } from '../frontend/src/lib/actions/definitions/navigation.js';
+import { cliGatewayCommandActions } from '../frontend/src/lib/actions/definitions/cli-gateway.js';
+import { stableCommandNames } from '../shared/cli-gateway-contract.js';
 
 // Full allowlist: 60 palettable action IDs (15 Phase 2 + 44 Phase 3 + 1 from #630)
 const ACTION_ALLOWLIST = [
@@ -138,6 +140,26 @@ describe('Action Coverage', () => {
       expect(meta.label).toBeTruthy();
       expect(meta.category).toBeTruthy();
       expect(meta.label).toBe(meta.label.toLowerCase());
+    }
+  });
+
+  it('projects stable CLI gateway commands into disabled Command Center metadata', () => {
+    expect(cliGatewayCommandActions.map((action) => action.relayCommand.name)).toEqual(
+      stableCommandNames()
+    );
+    expect(cliGatewayCommandActions.map((action) => action.id)).toEqual(
+      stableCommandNames().map((name) => `gateway.${name}`)
+    );
+
+    for (const action of cliGatewayCommandActions) {
+      expect(action.category).toBe('gateway');
+      expect(action.label).toBe(action.label.toLowerCase());
+      expect(action.description).toBe(action.relayCommand.summary);
+      expect(action.aliases).toEqual(
+        expect.arrayContaining([action.relayCommand.name, action.relayCommand.sideEffect])
+      );
+      expect(action.when?.({ view: 'workspace' })).toBe(false);
+      expect(action.disabledReason?.({ view: 'workspace' })).toContain('relay-ide v1');
     }
   });
 

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -10,6 +10,12 @@ import {
   type RelayJsonSchema,
 } from '../shared/cli-gateway-contract.js';
 import {
+  RELAY_COMMAND_MANIFEST,
+  relayCommandDefinition,
+  relayCommandDefinitionsForSurface,
+} from '../shared/relay-command-manifest.js';
+import { RELAY_CAPABILITY_BITS } from '../shared/security-policy.js';
+import {
   gatewayCliInvalidArgumentError,
   gatewayCliInvalidJsonError,
   gatewayErrorRetryable,
@@ -95,6 +101,62 @@ describe('CLI gateway contract', () => {
       expect(spec.outputSchema).toBeDefined();
       expect(spec.errorCodes.length).toBeGreaterThan(0);
     }
+  });
+
+  it('projects every stable gateway command into shared Relay command metadata', () => {
+    const stableNames = stableCommandNames();
+    expect(RELAY_COMMAND_MANIFEST).toMatchObject({
+      schemaVersion: 1,
+      generatedFrom: 'shared/cli-gateway-contract.ts',
+    });
+    expect(RELAY_COMMAND_MANIFEST.commands.map((command) => command.name)).toEqual(stableNames);
+    expect(relayCommandDefinitionsForSurface('cli').map((command) => command.name)).toEqual(
+      stableNames
+    );
+    expect(relayCommandDefinitionsForSurface('agent').map((command) => command.name)).toEqual(
+      stableNames
+    );
+    expect(relayCommandDefinitionsForSurface('web').map((command) => command.name)).toEqual(
+      stableNames
+    );
+
+    for (const name of stableNames) {
+      const spec = commandSpec(name);
+      const command = relayCommandDefinition(name);
+      expect(command).toMatchObject({
+        id: name,
+        name,
+        stable: true,
+        source: 'cli-gateway-v1',
+        surfaces: ['cli', 'agent', 'web'],
+      });
+      expect(command.label.length).toBeGreaterThan(0);
+      expect(command.description).toBe(spec.summary);
+      expect(command.summary).toBe(spec.summary);
+      expect(command.inputSchema).toBe(spec.inputSchema);
+      expect(command.outputSchema).toBe(spec.outputSchema);
+      expect(command.capabilityHints).toEqual(spec.capabilityHints);
+      for (const hint of command.capabilityHints) {
+        expect(RELAY_CAPABILITY_BITS).toContain(hint);
+      }
+      expect(command.handler.cli).toEqual(spec.cli);
+      expect(['read', 'write', 'destructive', 'stream']).toContain(command.sideEffect);
+      expect(Array.isArray(command.scopeKinds)).toBe(true);
+    }
+
+    expect(relayCommandDefinition('files.write')).toMatchObject({
+      sideEffect: 'write',
+      requiresConfirmation: true,
+      scopeKinds: ['session'],
+    });
+    expect(relayCommandDefinition('sessions.stream')).toMatchObject({
+      sideEffect: 'stream',
+      requiresConfirmation: false,
+    });
+    expect(relayCommandDefinition('handoffs.create')).toMatchObject({
+      sideEffect: 'destructive',
+      requiresConfirmation: true,
+    });
   });
 
   it('keeps success and error envelopes machine-readable and versioned', () => {


### PR DESCRIPTION
## Summary
- Add a Relay-owned shared command manifest derived from the stable `relay-ide v1 ... --json` CLI gateway contract.
- Project stable gateway commands into Command Center metadata as disabled/degraded `gateway` actions without wiring browser execution.
- Document command taxonomy and add drift coverage across CLI contract, manifest, capability hints, and action registry.

Closes #716

## Verification
- `npm test -- test/cli-gateway-contract.test.ts test/action-coverage.test.ts` — 18 passed
- `npm run check` — passed; existing ESLint warnings only (93 warnings, 0 errors)
- `npm run build` — passed; existing Vite chunk-size warnings
- CLI smoke: `node dist/bin/relay-ide.js v1 schema --json` parsed successfully (`ok=true`, `command=contract.schema`, `commandSchemas=27`, first=`contract.list`)
- Static staged-diff scan: no hardcoded secrets, shell injection, eval/exec, unsafe deserialization, or SQL injection patterns
- Independent pre-commit review: passed; follow-up suggestions addressed

## Notes
- Gateway Command Center projections remain non-executable until a safe UI execution bridge exists.
- Disabled gateway entries are filtered out of the default degraded palette list to avoid flooding the Command Center.
