### PR TITLE
feat: add typed supervisor actions and audit

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -457,7 +457,7 @@ function requireGatewaySessionId(
 
 function gatewayUsage(): never {
   logger.error(
-    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions renew|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|files write|work-contexts get|handoffs plan|handoffs create|handoffs status|handoffs cancel|handoffs resume|handoffs launch|artifacts read|supervisor snapshot|events subscribe) --json'
+    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions renew|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|files write|work-contexts get|handoffs plan|handoffs create|handoffs status|handoffs cancel|handoffs resume|handoffs launch|artifacts read|supervisor snapshot|supervisor sessions|supervisor send-text|supervisor submit|events subscribe) --json'
   );
   process.exit(1);
 }
@@ -1595,13 +1595,74 @@ async function runGatewayHandoffs(gatewayArgs: string[]): Promise<never> {
   gatewayInvalid('handoffs.plan', 'unknown handoffs command', { args: gatewayArgs });
 }
 
-async function runGatewaySupervisor(gatewayArgs: string[]): Promise<never> {
-  const subcommand = gatewayArgs[1];
-  const supervisorArgs = gatewayArgs.slice(2);
-  if (subcommand !== 'snapshot') {
-    gatewayInvalid('supervisor.snapshot', 'unknown supervisor command', { args: gatewayArgs });
+async function runGatewaySupervisorSessions(): Promise<never> {
+  const result = await gatewayHttpJson({
+    commandName: 'supervisor.sessions',
+    pathName: '/supervisor/sessions',
+    capabilities: ['session:read', 'tab:intervention:read'],
+  });
+  printGatewayEnvelope(gatewayOk('supervisor.sessions', result), 0);
+}
+
+function parseGatewaySupervisorActionBody(
+  commandName: 'supervisor.sendText' | 'supervisor.submit',
+  supervisorArgs: string[]
+): Record<string, unknown> {
+  const body = parseGatewayInputObject(commandName, supervisorArgs);
+  const id = gatewayArg(supervisorArgs, '--id') ?? supervisorArgs[0];
+  if (id && !id.startsWith('--') && body['id'] === undefined && body['targetIds'] === undefined) {
+    body['id'] = id;
   }
-  const id = requireGatewaySessionId('supervisor.snapshot', supervisorArgs);
+  const targetIds = gatewayArg(supervisorArgs, '--target-ids');
+  if (targetIds && body['targetIds'] === undefined) {
+    body['targetIds'] = targetIds.split(',').map((entry) => entry.trim()).filter(Boolean);
+  }
+  const text = gatewayArg(supervisorArgs, '--text');
+  if (commandName === 'supervisor.sendText' && text !== undefined && body['text'] === undefined) {
+    body['text'] = text;
+  }
+  return body;
+}
+
+function validateGatewaySupervisorActionBody(
+  commandName: 'supervisor.sendText' | 'supervisor.submit',
+  body: Record<string, unknown>
+): void {
+  if (
+    commandName === 'supervisor.sendText' &&
+    (typeof body['text'] !== 'string' || body['text'].length === 0)
+  ) {
+    gatewayInvalid(commandName, '--text is required for supervisor send-text', { field: 'text' });
+  }
+  if (typeof body['id'] !== 'string' && !Array.isArray(body['targetIds'])) {
+    gatewayInvalid(commandName, '--id or --target-ids is required', { field: 'id' });
+  }
+}
+
+async function runGatewaySupervisorAction(
+  subcommand: string,
+  supervisorArgs: string[]
+): Promise<never> {
+  const commandName = subcommand === 'submit' ? 'supervisor.submit' : 'supervisor.sendText';
+  const body = parseGatewaySupervisorActionBody(commandName, supervisorArgs);
+  validateGatewaySupervisorActionBody(commandName, body);
+  const result = await gatewayHttpJson({
+    commandName,
+    pathName: `/supervisor/actions/${commandName === 'supervisor.submit' ? 'submit' : 'sendText'}`,
+    method: 'POST',
+    body,
+    capabilities:
+      commandName === 'supervisor.submit'
+        ? ['session:attach', 'tab:intervention:submit']
+        : ['session:attach', 'tab:intervention:send-text'],
+  });
+  printGatewayEnvelope(gatewayOk(commandName, result), 0);
+}
+
+function parseGatewaySupervisorSnapshotPolicy(supervisorArgs: string[]): {
+  expectedControlMode?: 'agent-driven' | 'human-driven' | 'co-driven';
+  latestSeenInterventionEventId?: string;
+} {
   const expectedControlMode = gatewayArg(supervisorArgs, '--expected-control-mode');
   const policy: {
     expectedControlMode?: 'agent-driven' | 'human-driven' | 'co-driven';
@@ -1624,10 +1685,12 @@ async function runGatewaySupervisor(gatewayArgs: string[]): Promise<never> {
     supervisorArgs,
     '--latest-seen-intervention-event-id'
   );
-  if (latestSeenInterventionEventId) {
-    policy.latestSeenInterventionEventId = latestSeenInterventionEventId;
-  }
+  if (latestSeenInterventionEventId) policy.latestSeenInterventionEventId = latestSeenInterventionEventId;
+  return policy;
+}
 
+async function runGatewaySupervisorSnapshot(supervisorArgs: string[]): Promise<never> {
+  const id = requireGatewaySessionId('supervisor.snapshot', supervisorArgs);
   const session = await gatewayHttpJson({
     commandName: 'supervisor.snapshot',
     pathName: `/sessions/${encodeURIComponent(id)}`,
@@ -1636,9 +1699,9 @@ async function runGatewaySupervisor(gatewayArgs: string[]): Promise<never> {
   const result = await createSupervisorSnapshot({
     session: session as SessionSummary,
     grantedCapabilities: ['session:read', 'tab:intervention:read'],
-    policy,
+    policy: parseGatewaySupervisorSnapshotPolicy(supervisorArgs),
   });
-  if (!result.ok) {
+  if (result.ok === false) {
     printGatewayEnvelope(
       gatewayError('supervisor.snapshot', {
         code: result.error.code,
@@ -1653,6 +1716,17 @@ async function runGatewaySupervisor(gatewayArgs: string[]): Promise<never> {
     gatewayOk('supervisor.snapshot', { snapshot: result.snapshot, audit: result.audit }),
     0
   );
+}
+
+async function runGatewaySupervisor(gatewayArgs: string[]): Promise<never> {
+  const subcommand = gatewayArgs[1];
+  const supervisorArgs = gatewayArgs.slice(2);
+  if (subcommand === 'sessions') return runGatewaySupervisorSessions();
+  if (subcommand === 'send-text' || subcommand === 'sendText' || subcommand === 'submit') {
+    return runGatewaySupervisorAction(subcommand, supervisorArgs);
+  }
+  if (subcommand === 'snapshot') return runGatewaySupervisorSnapshot(supervisorArgs);
+  gatewayInvalid('supervisor.snapshot', 'unknown supervisor command', { args: gatewayArgs });
 }
 
 async function runGatewayArtifacts(gatewayArgs: string[]): Promise<never> {

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -1634,8 +1634,27 @@ function validateGatewaySupervisorActionBody(
   ) {
     gatewayInvalid(commandName, '--text is required for supervisor send-text', { field: 'text' });
   }
-  if (typeof body['id'] !== 'string' && !Array.isArray(body['targetIds'])) {
-    gatewayInvalid(commandName, '--id or --target-ids is required', { field: 'id' });
+  const id = body['id'];
+  const targetIds = body['targetIds'];
+  const hasId = typeof id === 'string' && id.trim().length > 0;
+  if (targetIds !== undefined && !Array.isArray(targetIds)) {
+    gatewayInvalid(commandName, '--target-ids must be a non-empty list of session ids', {
+      field: 'targetIds',
+    });
+  }
+  const hasTargetIds = Array.isArray(targetIds);
+  if (hasTargetIds) {
+    const validTargetIds =
+      targetIds.length > 0 &&
+      targetIds.every((entry) => typeof entry === 'string' && entry.trim().length > 0);
+    if (!validTargetIds) {
+      gatewayInvalid(commandName, '--target-ids must be a non-empty list of session ids', {
+        field: 'targetIds',
+      });
+    }
+  }
+  if (hasId === hasTargetIds) {
+    gatewayInvalid(commandName, 'exactly one of --id or --target-ids is required', { field: 'id' });
   }
 }
 

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -23,6 +23,7 @@ relay-ide v1 supervisor snapshot --id <session-id-or-global-id> --json
 relay-ide v1 supervisor send-text --id <session-id-or-global-id> --text <literal-text> --json
 relay-ide v1 supervisor send-text --target-ids <session-id-1,session-id-2> --text <literal-text> --json
 relay-ide v1 supervisor submit --id <session-id-or-global-id> --json
+relay-ide v1 supervisor submit --target-ids <session-id-1,session-id-2> --json
 relay-ide v1 events subscribe --topic <sessions|nodes|audit> --json
 ```
 

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -18,7 +18,11 @@ relay-ide v1 files list --session-id <session-id> --path <path> --json
 relay-ide v1 files stat --session-id <session-id> --path <path> --json
 relay-ide v1 files read --session-id <session-id> --path <path> --max-bytes 32768 --max-lines 2000 --json
 relay-ide v1 files write --session-id <session-id> --path <path> --mode <create|overwrite|append> --file <local-path|-> --json
+relay-ide v1 supervisor sessions --json
 relay-ide v1 supervisor snapshot --id <session-id-or-global-id> --json
+relay-ide v1 supervisor send-text --id <session-id-or-global-id> --text <literal-text> --json
+relay-ide v1 supervisor send-text --target-ids <session-id-1,session-id-2> --text <literal-text> --json
+relay-ide v1 supervisor submit --id <session-id-or-global-id> --json
 relay-ide v1 events subscribe --topic <sessions|nodes|audit> --json
 ```
 
@@ -57,7 +61,7 @@ Error:
 }
 ```
 
-The current error taxonomy is declared in `RELAY_CLI_GATEWAY_CONTRACT.errorEnvelopeSchema`. It includes auth/connectivity errors, typed create/validation errors, file RPC errors (`NOT_FOUND`, `FORBIDDEN`, `NODE_OFFLINE`, `CONFIRMATION_REQUIRED`), and control hand-back state errors (`CONTROL_STATE_STALE`, `INTERVENTION_ACK_REQUIRED`, `INTERVENTION_ACK_STALE`, `CONTROL_STATE_UNKNOWN`).
+The current error taxonomy is declared in `RELAY_CLI_GATEWAY_CONTRACT.errorEnvelopeSchema`. It includes auth/connectivity errors, typed create/validation errors, file RPC errors (`NOT_FOUND`, `FORBIDDEN`, `NODE_OFFLINE`, `CONFIRMATION_REQUIRED`), control hand-back state errors (`CONTROL_STATE_STALE`, `INTERVENTION_ACK_REQUIRED`, `INTERVENTION_ACK_STALE`, `CONTROL_STATE_UNKNOWN`), and typed supervisor action errors. Multi-target supervisor action denials can also appear inside a successful action envelope as per-target `results[].error` entries; see [Supervisor typed actions and rmux mapping](#supervisor-typed-actions-and-rmux-mapping-704).
 
 ## Discovery and schemas
 
@@ -218,17 +222,88 @@ Provider-native session state adapters are intentionally internal in this slice.
 
 When promoted to v1, the surface must preserve the same boundary as `AgentHarnessStateAdapter`: detection/list/import/read-state are read-only, snapshots are redacted and bounded, and open/resume returns copyable argv data without executing the provider CLI.
 
-## Supervisor snapshot boundary
+## Supervisor typed actions and rmux mapping (#704)
 
-`relay-ide v1 supervisor snapshot --id <session-id-or-global-id> --json` is the first stable typed supervisor path. It is read-only and command-mediated: callers get a bounded `supervisor.snapshot` envelope containing session identity, control-state summary, provider capability boundary, optional redacted intervention summaries, partial-failure metadata, and an audit summary. It requires `session:read` plus `tab:intervention:read` because a safe supervisor read must include whether human intervention metadata exists; missing either bit returns `FORBIDDEN`.
+The stable supervisor surface is Relay-owned command API, not raw PTY, tmux, or rmux API. The implementation source of truth is `shared/cli-gateway-contract.ts`, with shared response types in `shared/supervisor-actions.ts` and server execution in `server/supervisor-actions.ts`.
 
-The optional `expectedControlMode` and `latestSeenInterventionEventId` inputs are preflight guards for future typed actions. If the target control state is stale/mismatched, Relay returns `CONTROL_STATE_STALE`. If a human intervention exists that the caller has not observed, Relay returns `INTERVENTION_ACK_REQUIRED`. Both are typed denials, not best-effort warnings.
+Commands:
 
-This is deliberately distinct from PTY input and terminal substrates:
+| Command | Purpose | Required capabilities |
+| --- | --- | --- |
+| `relay-ide v1 supervisor sessions --json` | Lists sessions and per-action eligibility. | `session:read`, `tab:intervention:read` |
+| `relay-ide v1 supervisor snapshot --id <session-id-or-global-id> --json` | Reads one redacted supervisor snapshot. | `session:read`, `tab:intervention:read` |
+| `relay-ide v1 supervisor send-text --id <session-id-or-global-id> --text <literal-text> --json` | Sends bounded literal text as a typed intervention. | `session:attach`, `tab:intervention:send-text` |
+| `relay-ide v1 supervisor send-text --target-ids <id-1,id-2> --text <literal-text> --json` | Sends the same bounded literal text to multiple sessions and reports per-target results. | `session:attach`, `tab:intervention:send-text` |
+| `relay-ide v1 supervisor submit --id <session-id-or-global-id> --json` | Sends Enter (`\n`) as a typed intervention. | `session:attach`, `tab:intervention:submit` |
+| `relay-ide v1 supervisor submit --target-ids <id-1,id-2> --json` | Sends Enter to multiple sessions and reports per-target results. | `session:attach`, `tab:intervention:submit` |
 
-- `supervisor.snapshot` never writes to the session, never submits text, never accepts provider permission prompts, and never stores raw prompts, raw transcripts, raw PTY input, or raw provider state in audit.
-- `sessions input` remains the raw PTY input path for narrow smoke/debug use. It is not a typed supervisor action and must not be used as the blessed agent-to-agent command API.
-- rmux/tmux panes may be adapter/runtime substrates, but raw rmux/tmux command execution is not stable Relay API. Add or extend a Relay-owned command first, then let adapters map it to a substrate behind the capability/control/audit checks.
+Inputs:
+
+- `supervisor.sessions` takes no input and returns `{ command: "supervisor.sessions", sessions, count }`. Each session includes `sessionId`, optional `globalSessionId`/`nodeId`, `mode`, `status`, optional `controlMode`/`controlFreshness`, and `actions.sendText` / `actions.submit` eligibility. Ineligible actions carry a `reasonCode` such as `SESSION_DISCONNECTED`, `SESSION_MODE_UNSUPPORTED`, `CONTROL_STATE_STALE`, or `CONTROL_STATE_UNKNOWN`.
+- `supervisor.snapshot` requires `id`. Optional `--expected-control-mode <agent-driven|human-driven|co-driven>` and `--latest-seen-intervention-event-id <event-id>` are preflight guards. Stale or mismatched control state returns `CONTROL_STATE_STALE`; an unacknowledged newer intervention returns `INTERVENTION_ACK_REQUIRED`. The snapshot path is read-only: it never writes to the session, accepts prompts, or stores raw prompt/transcript/PTY/provider state.
+- `supervisor.sendText` requires `text` plus exactly one target shape: `id` or `targetIds`. CLI flags are `--id`, positional `<id>`, or comma-separated `--target-ids`; `--input-json` / `--input-file` may provide the same object shape, including optional `actor` metadata. Text must be non-empty literal text, at most 1000 characters, with no CR/LF, ESC, DEL, or control characters except tab. Use `supervisor.submit` for Enter instead of embedding a newline.
+- `supervisor.submit` requires `id` or `targetIds`, accepts optional `actor` metadata via JSON input, and writes exactly `\n`. It does not accept a text payload.
+
+Successful action envelope shape:
+
+```json
+{
+  "ok": true,
+  "contract": "v1",
+  "contractVersion": "1.0",
+  "command": "supervisor.sendText",
+  "data": {
+    "command": "supervisor.sendText",
+    "action": "sendText",
+    "results": [
+      {
+        "sessionId": "sess-1",
+        "globalSessionId": "local:sess-1",
+        "nodeId": "local",
+        "ok": true,
+        "action": "sendText",
+        "bytesWritten": 5,
+        "interventionEventId": "evt-sess-1",
+        "controlModeBefore": "agent-driven",
+        "controlModeAfter": "co-driven"
+      }
+    ],
+    "counts": { "requested": 1, "succeeded": 1, "denied": 0, "failed": 0, "skipped": 0 },
+    "audit": {
+      "action": "sendText",
+      "targetSessionIds": ["sess-1"],
+      "targetCount": 1,
+      "timestamp": "2026-05-16T00:00:00.000Z",
+      "content": {
+        "rawContentAvailable": false,
+        "hashSha256": "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+        "byteCount": 5,
+        "charCount": 5,
+        "lineCount": 1,
+        "classes": ["literal-text"],
+        "redacted": true
+      },
+      "rawContentStored": false,
+      "partialFailure": false
+    },
+    "redaction": { "rawContentAvailable": false, "rawContentStored": false, "hashesOnly": true }
+  }
+}
+```
+
+Action failure semantics:
+
+- CLI parse/auth/connectivity failures return a normal `ok: false` gateway envelope and the CLI exits nonzero. Examples: malformed `--input-json`, missing `RELAY_IDE_BROWSER_TOKEN`, unreachable hub, missing `--id`/`--target-ids`, or missing `--text` for `send-text`.
+- Once the action request reaches the hub, target-level problems are reported in the successful action envelope under `data.results[].error` with aggregate `data.counts` and `data.audit.partialFailure`. This preserves multi-target partial success instead of failing the whole command on the first bad target.
+- Per-target errors use typed `code`, `reasonCode`, `message`, `retryable`, and optional `details`. Current reason codes include `CAPABILITY_REQUIRED`, `SESSION_NOT_FOUND`, `SESSION_DISCONNECTED`, `CONTROL_STATE_STALE`, `CONTROL_STATE_UNKNOWN`, `SESSION_MODE_UNSUPPORTED`, `TEXT_REQUIRED`, `TEXT_TOO_LARGE`, `TEXT_MUST_BE_LITERAL`, and `UPSTREAM_WRITE_FAILED`.
+- `counts.denied` is for capability denials (`FORBIDDEN`). Other per-target errors increment `counts.failed`. `counts.skipped` is reserved for future fan-out decisions.
+- Audit stores actor summary, target session IDs/count, action type, timestamp, hashes/counts/classes for content, and the aggregate partial-failure flag. Raw supervisor text is not returned or stored by default.
+
+This is deliberately distinct from raw PTY input and terminal substrates:
+
+- `sessions input` remains the raw PTY input path for narrow smoke/debug use. It writes bytes through the temporary attach path, can wait for output markers, and is useful for adapter handshake tests, but it is not the blessed typed agent-to-agent command API.
+- Existing browser/human PTY input remains a different event/API path from supervisor automation interventions.
+- rmux/tmux panes may become backing substrates for Relay sessions, but adapters must not call rmux actions, rmux broadcast, tmux send-keys, or shell commands as stable Relay API. Add or extend a Relay-owned `relay-ide v1 supervisor ... --json` command first, then map that typed command to the substrate behind Relay capability, control-state, and hashes-only audit checks.
 
 ## Read-only file RPC commands
 

--- a/server/control-engine.ts
+++ b/server/control-engine.ts
@@ -230,6 +230,7 @@ function buildRecord(input: {
   modeAfter?: ControlMode;
   options?: ControlEngineOptions;
   acked?: boolean;
+  includePayloadPreview?: boolean;
 }): InterventionRecord {
   const identity = identityForSession(input.session);
   const payload = input.payload ?? '';
@@ -249,7 +250,9 @@ function buildRecord(input: {
     redaction: redacted.redaction,
     modeBefore: input.modeBefore,
     ...(input.modeAfter ? { modeAfter: input.modeAfter } : {}),
-    ...(redacted.payloadPreview ? { payloadPreview: redacted.payloadPreview } : {}),
+    ...(input.includePayloadPreview !== false && redacted.payloadPreview
+      ? { payloadPreview: redacted.payloadPreview }
+      : {}),
   };
   if (input.acked) {
     record.ackedBy = input.actor;
@@ -524,6 +527,7 @@ export function recordSupervisorAction(
     modeAfter,
     options,
     acked: true,
+    includePayloadPreview: false,
   });
   const append = options.append ?? appendIntervention;
   append(record);

--- a/server/control-engine.ts
+++ b/server/control-engine.ts
@@ -25,6 +25,7 @@ import {
 } from './intervention-log.js';
 
 export type ControlModeAction = 'join' | 'take-over' | 'hand-back';
+export type SupervisorInterventionAction = 'sendText' | 'submit';
 
 export interface ControlEngineOptions {
   inputDebounceMs?: number;
@@ -496,6 +497,62 @@ export function applyControlModeAction(
   }
   events.push(emitIntervention(session, actor, modeAfter, record, action, options));
   return events;
+}
+
+export function recordSupervisorAction(
+  session: Session,
+  input: {
+    action: SupervisorInterventionAction;
+    actor: ControlActor;
+    payload: string;
+  },
+  options: ControlEngineOptions = {}
+): TabControlEvent {
+  flushBurstForSession(session, options);
+  const before = normalizeControlStateSummary(session.controlState);
+  const modeAfter: ControlMode = 'co-driven';
+  const record = buildRecord({
+    session,
+    actor: input.actor,
+    source: 'supervisor-action',
+    kind:
+      input.action === 'sendText'
+        ? 'supervisor-send-text'
+        : 'supervisor-submit',
+    payload: input.payload,
+    modeBefore: before.controlMode,
+    modeAfter,
+    options,
+    acked: true,
+  });
+  const append = options.append ?? appendIntervention;
+  append(record);
+  updateControlState({
+    session,
+    controlMode: modeAfter,
+    actor: input.actor,
+    eventId: record.id,
+    occurredAt: record.timestamp,
+    reason: `supervisor ${input.action}`,
+  });
+  if (before.controlMode !== modeAfter) {
+    emitModeChanged(
+      session,
+      input.actor,
+      before.controlMode,
+      modeAfter,
+      `supervisor ${input.action}`,
+      options
+    );
+  }
+  return emitIntervention(
+    session,
+    input.actor,
+    modeAfter,
+    record,
+    `supervisor ${input.action}`,
+    options
+  );
 }
 
 export function acknowledgeHumanInput(

--- a/server/index.ts
+++ b/server/index.ts
@@ -185,13 +185,10 @@ import {
   INTERVENTION_READ_CAPABILITY,
   toInterventionReadResponse,
 } from './session-control-api.js';
-import { executeSupervisorAction } from './supervisor-actions.js';
-import { handleSupervisorSessionsRequest } from './supervisor-route-handlers.js';
 import {
-  supervisorActionRequiredCapabilities,
-  type SupervisorActionError,
-  type SupervisorActionType,
-} from '../shared/supervisor-actions.js';
+  handleSupervisorActionRequest,
+  handleSupervisorSessionsRequest,
+} from './supervisor-route-handlers.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -910,16 +907,23 @@ function createHandoffDestinationLauncher(params: {
   configDir: string;
   getConfig: () => Config;
   watchCwd: (cwd: string) => void;
-}): (input: HandoffDestinationLaunchInput) => Promise<{
-  ok: true;
-  session: ReturnType<typeof localRelayNode.sessions.list>[number];
-  acknowledgedBrief: boolean;
-} | {
-  ok: false;
-  code: 'HUB_UNAVAILABLE' | 'NODE_UNAVAILABLE' | 'LAUNCH_UNSUPPORTED' | 'LAUNCH_FAILED';
-  message: string;
-  details?: Record<string, unknown>;
-}> {
+}): (input: HandoffDestinationLaunchInput) => Promise<
+  | {
+      ok: true;
+      session: ReturnType<typeof localRelayNode.sessions.list>[number];
+      acknowledgedBrief: boolean;
+    }
+  | {
+      ok: false;
+      code:
+        | 'HUB_UNAVAILABLE'
+        | 'NODE_UNAVAILABLE'
+        | 'LAUNCH_UNSUPPORTED'
+        | 'LAUNCH_FAILED';
+      message: string;
+      details?: Record<string, unknown>;
+    }
+> {
   return async (input) => {
     const destination = input.plan.destinationProposal;
     if (destination.nodeId !== 'local') {
@@ -945,7 +949,8 @@ function createHandoffDestinationLauncher(params: {
       return {
         ok: false,
         code: 'LAUNCH_UNSUPPORTED',
-        message: 'destination cwd is not inside a configured Relay repo; refusing path-only launch',
+        message:
+          'destination cwd is not inside a configured Relay repo; refusing path-only launch',
         details: { cwd: destination.cwd },
       };
     }
@@ -979,22 +984,33 @@ function createHandoffDestinationLauncher(params: {
           sessionLane: undefined,
           portVariables,
         });
-        localRelayNode.sessions.write(session.id, terminalBriefCommand(input.handoffBrief));
+        localRelayNode.sessions.write(
+          session.id,
+          terminalBriefCommand(input.handoffBrief)
+        );
         params.watchCwd(session.cwd);
         return { ok: true, session, acknowledgedBrief: true };
       }
 
-      const requestedAgent = input.request.desiredRuntime.providerId as AgentType | undefined;
+      const requestedAgent = input.request.desiredRuntime.providerId as
+        | AgentType
+        | undefined;
       const resolved = resolveSessionSettings(freshConfig, repoPath, {
         agent: requestedAgent,
         continuePolicy: 'never',
       });
-      const availability = validateAgentFrameworkAvailable(freshConfig, resolved.agent);
+      const availability = validateAgentFrameworkAvailable(
+        freshConfig,
+        resolved.agent
+      );
       if (!availability.ok) {
         return {
           ok: false,
           code: 'LAUNCH_UNSUPPORTED',
-          message: availability.body.message ?? availability.body.error ?? 'agent framework is unavailable',
+          message:
+            availability.body.message ??
+            availability.body.error ??
+            'agent framework is unavailable',
           details: availability.body,
         };
       }
@@ -1036,7 +1052,10 @@ function createHandoffDestinationLauncher(params: {
       return {
         ok: false,
         code: 'LAUNCH_FAILED',
-        message: err instanceof Error ? err.message : 'destination session launch failed',
+        message:
+          err instanceof Error
+            ? err.message
+            : 'destination session launch failed',
         details: { cwd, repoPath, configDir: params.configDir },
       };
     }
@@ -1493,7 +1512,9 @@ async function main(): Promise<void> {
     return match?.[1]?.trim() ?? '';
   }
 
-  function validatedHandoffCapabilities(_req: express.Request): HandoffCapabilityContext | null {
+  function validatedHandoffCapabilities(
+    _req: express.Request
+  ): HandoffCapabilityContext | null {
     // Scoped CLI tokens currently prove only bearer possession, not capability grants.
     // Never promote caller-controlled x-relay-capabilities into a validated handoff
     // context; until token/policy grants are wired, handoff routes fail closed.
@@ -1550,7 +1571,10 @@ async function main(): Promise<void> {
   };
 
   const requireCliGatewayAuth: express.RequestHandler = (req, res, next) => {
-    if (isCliGatewayV1Request(req) && validateScopedToken(bearerScopedToken(req))) {
+    if (
+      isCliGatewayV1Request(req) &&
+      validateScopedToken(bearerScopedToken(req))
+    ) {
       next();
       return;
     }
@@ -2639,61 +2663,7 @@ async function main(): Promise<void> {
     '/supervisor/actions/:action',
     requireScopedSessionAuth,
     (req, res) => {
-      const actionParam = req.params['action'];
-      const action: SupervisorActionType | undefined =
-        actionParam === 'sendText' || actionParam === 'submit'
-          ? actionParam
-          : undefined;
-      if (!action) {
-        res.status(400).json({
-          error: {
-            code: 'INVALID_ARGUMENT',
-            reasonCode: 'INVALID_ARGUMENT',
-            message: 'supervisor action must be sendText or submit',
-            retryable: false,
-          },
-        });
-        return;
-      }
-      const body =
-        typeof req.body === 'object' && req.body !== null
-          ? (req.body as Record<string, unknown>)
-          : {};
-      const rawTargetIds = Array.isArray(body['targetIds'])
-        ? body['targetIds']
-        : typeof body['id'] === 'string'
-          ? [body['id']]
-          : [];
-      const targetIds = rawTargetIds.filter(
-        (entry): entry is string => typeof entry === 'string'
-      );
-      const decision = capabilitiesDecisionFromRequest(
-        req,
-        supervisorActionRequiredCapabilities(action)
-      );
-      const deniedByCapability: SupervisorActionError | undefined =
-        decision.decision === 'allow'
-          ? undefined
-          : {
-              code: 'FORBIDDEN',
-              reasonCode: 'CAPABILITY_REQUIRED',
-              message: decision.message ?? `missing required capability: ${decision.capability}`,
-              retryable: false,
-              details: {
-                capability: decision.capability,
-                placeholder: decision.placeholder,
-              },
-            };
-      const actor = actorFromRequestBody(body['actor']);
-      const result = executeSupervisorAction({
-        boundary: localRelayNode.sessions,
-        action,
-        targetIds,
-        text: body['text'],
-        ...(actor === undefined ? {} : { actor }),
-        ...(deniedByCapability === undefined ? {} : { deniedByCapability }),
-      });
-      res.json(result);
+      handleSupervisorActionRequest(req, res, localRelayNode.sessions);
     }
   );
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -185,10 +185,8 @@ import {
   INTERVENTION_READ_CAPABILITY,
   toInterventionReadResponse,
 } from './session-control-api.js';
-import {
-  executeSupervisorAction,
-  listSupervisorSessions,
-} from './supervisor-actions.js';
+import { executeSupervisorAction } from './supervisor-actions.js';
+import { handleSupervisorSessionsRequest } from './supervisor-route-handlers.js';
 import {
   supervisorActionRequiredCapabilities,
   type SupervisorActionError,
@@ -2633,8 +2631,8 @@ async function main(): Promise<void> {
     }
   );
 
-  app.get('/supervisor/sessions', requireScopedSessionAuth, (_req, res) => {
-    res.json(listSupervisorSessions(localRelayNode.sessions.list()));
+  app.get('/supervisor/sessions', requireScopedSessionAuth, (req, res) => {
+    handleSupervisorSessionsRequest(req, res, localRelayNode.sessions);
   });
 
   app.post(

--- a/server/index.ts
+++ b/server/index.ts
@@ -185,6 +185,15 @@ import {
   INTERVENTION_READ_CAPABILITY,
   toInterventionReadResponse,
 } from './session-control-api.js';
+import {
+  executeSupervisorAction,
+  listSupervisorSessions,
+} from './supervisor-actions.js';
+import {
+  supervisorActionRequiredCapabilities,
+  type SupervisorActionError,
+  type SupervisorActionType,
+} from '../shared/supervisor-actions.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -2621,6 +2630,72 @@ async function main(): Promise<void> {
       );
       const records = localRelayNode.sessions.getInterventions(id, { limit });
       res.json(toInterventionReadResponse({ records, limit }));
+    }
+  );
+
+  app.get('/supervisor/sessions', requireScopedSessionAuth, (_req, res) => {
+    res.json(listSupervisorSessions(localRelayNode.sessions.list()));
+  });
+
+  app.post(
+    '/supervisor/actions/:action',
+    requireScopedSessionAuth,
+    (req, res) => {
+      const actionParam = req.params['action'];
+      const action: SupervisorActionType | undefined =
+        actionParam === 'sendText' || actionParam === 'submit'
+          ? actionParam
+          : undefined;
+      if (!action) {
+        res.status(400).json({
+          error: {
+            code: 'INVALID_ARGUMENT',
+            reasonCode: 'INVALID_ARGUMENT',
+            message: 'supervisor action must be sendText or submit',
+            retryable: false,
+          },
+        });
+        return;
+      }
+      const body =
+        typeof req.body === 'object' && req.body !== null
+          ? (req.body as Record<string, unknown>)
+          : {};
+      const rawTargetIds = Array.isArray(body['targetIds'])
+        ? body['targetIds']
+        : typeof body['id'] === 'string'
+          ? [body['id']]
+          : [];
+      const targetIds = rawTargetIds.filter(
+        (entry): entry is string => typeof entry === 'string'
+      );
+      const decision = capabilitiesDecisionFromRequest(
+        req,
+        supervisorActionRequiredCapabilities(action)
+      );
+      const deniedByCapability: SupervisorActionError | undefined =
+        decision.decision === 'allow'
+          ? undefined
+          : {
+              code: 'FORBIDDEN',
+              reasonCode: 'CAPABILITY_REQUIRED',
+              message: decision.message ?? `missing required capability: ${decision.capability}`,
+              retryable: false,
+              details: {
+                capability: decision.capability,
+                placeholder: decision.placeholder,
+              },
+            };
+      const actor = actorFromRequestBody(body['actor']);
+      const result = executeSupervisorAction({
+        boundary: localRelayNode.sessions,
+        action,
+        targetIds,
+        text: body['text'],
+        ...(actor === undefined ? {} : { actor }),
+        ...(deniedByCapability === undefined ? {} : { deniedByCapability }),
+      });
+      res.json(result);
     }
   );
 

--- a/server/local-node.ts
+++ b/server/local-node.ts
@@ -4,11 +4,13 @@ import type { CreateParams } from './sessions.js';
 import type { CreateWebParams } from './web-session-handler.js';
 import type { SessionRenewResult } from './session-envelope-registry.js';
 import type { Session, SessionSummary } from './types.js';
+import type { SupervisorInterventionAction } from './control-engine.js';
 import type { SessionReplaySnapshot } from '../shared/session-replay.js';
 import type {
   InterventionRecord,
   TabControlEvent,
   ControlActor,
+  ControlMode,
 } from '../shared/control-state.js';
 import type { SessionControlError } from './session-control-api.js';
 import {
@@ -39,6 +41,14 @@ export interface NodeSessionBoundary {
     displayName: string
   ): { id: string; displayName: string };
   write(id: string, data: string): void;
+  supervisorWrite(
+    id: string,
+    input: {
+      action: SupervisorInterventionAction;
+      actor: ControlActor;
+      payload: string;
+    }
+  ): { eventId: string; modeBefore?: ControlMode; modeAfter?: ControlMode };
   getInterventions(
     id: string,
     options?: { nodeId?: string; limit?: number }
@@ -86,6 +96,7 @@ const defaultSessionBoundary: NodeSessionBoundary = {
   kill: sessionsModule.kill,
   updateDisplayName: sessionsModule.updateDisplayName,
   write: sessionsModule.write,
+  supervisorWrite: sessionsModule.supervisorWrite,
   getInterventions: sessionsModule.getInterventions,
   getReplaySnapshot: sessionsModule.getReplaySnapshot,
   handBackToAgent: sessionsModule.handBackToAgent,

--- a/server/session-control-api.ts
+++ b/server/session-control-api.ts
@@ -5,17 +5,14 @@ import type {
   ControlMode,
   InterventionRecord,
 } from '../shared/control-state.js';
+import type { RelayCapabilityBit } from '../shared/security-policy.js';
 
 export const CONTROL_READ_CAPABILITY = 'session:read' as const;
 export const INTERVENTION_READ_CAPABILITY = 'tab:intervention:read' as const;
 export const CONTROL_WRITE_CAPABILITY = 'tab:mode:set-agent' as const;
 export const CONTROL_SESSION_CAPABILITY = 'session:attach' as const;
 
-export type SessionControlCapability =
-  | typeof CONTROL_READ_CAPABILITY
-  | typeof INTERVENTION_READ_CAPABILITY
-  | typeof CONTROL_WRITE_CAPABILITY
-  | typeof CONTROL_SESSION_CAPABILITY;
+export type SessionControlCapability = RelayCapabilityBit;
 
 export interface ControlCapabilityDecision {
   decision: 'allow' | 'deny';

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -71,6 +71,7 @@ import {
   normalizeControlStateSummary,
   type ControlStateSummary,
   type ControlActor,
+  type ControlMode,
   type TabControlEvent,
   type InterventionRecord,
 } from '../shared/control-state.js';
@@ -87,7 +88,9 @@ import {
   applyControlModeAction,
   maybeAutoRevertToAgentDriven,
   recordHumanPtyInput,
+  recordSupervisorAction,
   type ControlModeAction,
+  type SupervisorInterventionAction,
 } from './control-engine.js';
 import {
   listInterventions,
@@ -994,6 +997,36 @@ function write(id: string, data: string): void {
   } else {
     logger.warn(`write() called on web session ${id} — no-op`);
   }
+}
+
+function supervisorWrite(
+  id: string,
+  input: {
+    action: SupervisorInterventionAction;
+    actor: ControlActor;
+    payload: string;
+  }
+): { eventId: string; modeBefore?: ControlMode; modeAfter?: ControlMode } {
+  const session = sessions.get(id);
+  if (!session) {
+    throw new Error(`Session not found: ${id}`);
+  }
+  if (session.mode !== 'pty') {
+    throw new Error(`Session ${id} is not a PTY session`);
+  }
+  const event = recordSupervisorAction(session, input, controlEngineOptions());
+  if (event.type !== 'tab.intervention') {
+    throw new Error(`Supervisor action did not produce an intervention event for ${id}`);
+  }
+  session.pty.write(input.payload);
+  session.lastActivity = new Date().toISOString();
+  return {
+    eventId: event.eventId,
+    modeBefore: event.intervention.modeBefore,
+    ...(event.intervention.modeAfter === undefined
+      ? {}
+      : { modeAfter: event.intervention.modeAfter }),
+  };
 }
 
 function createRoutedPtyControlState(
@@ -2249,6 +2282,7 @@ export {
   captureTmuxPane,
   updateDisplayName,
   write,
+  supervisorWrite,
   recordRoutedPtyInput,
   controlAction,
   acknowledgeInterventions,

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -1014,11 +1014,16 @@ function supervisorWrite(
   if (session.mode !== 'pty') {
     throw new Error(`Session ${id} is not a PTY session`);
   }
+  try {
+    session.pty.write(input.payload);
+  } catch (error) {
+    logger.warn(`supervisorWrite() failed to write to PTY session ${id}: ${String(error)}`);
+    throw error;
+  }
   const event = recordSupervisorAction(session, input, controlEngineOptions());
   if (event.type !== 'tab.intervention') {
     throw new Error(`Supervisor action did not produce an intervention event for ${id}`);
   }
-  session.pty.write(input.payload);
   session.lastActivity = new Date().toISOString();
   return {
     eventId: event.eventId,

--- a/server/supervisor-actions.ts
+++ b/server/supervisor-actions.ts
@@ -1,0 +1,304 @@
+import * as crypto from 'node:crypto';
+
+import { normalizeControlStateSummary, type ControlActor, type ControlMode } from '../shared/control-state.js';
+import {
+  supervisorActionCommandId,
+  type SupervisorActionAuditSummary,
+  type SupervisorActionCounts,
+  type SupervisorActionError,
+  type SupervisorActionRedactionMetadata,
+  type SupervisorActionResponse,
+  type SupervisorActionTargetResult,
+  type SupervisorActionType,
+  type SupervisorSessionEligibility,
+  type SupervisorSessionsResponse,
+} from '../shared/supervisor-actions.js';
+import { DEFAULT_LOCAL_NODE_ID, createGlobalSessionId } from '../shared/identity.js';
+import { recordSupervisorAction } from './control-engine.js';
+import type { Session, SessionSummary } from './types.js';
+
+const MAX_SUPERVISOR_TEXT_CHARS = 1000;
+const DEFAULT_SUPERVISOR_ACTOR: ControlActor = {
+  kind: 'agent',
+  id: 'relay-supervisor',
+  displayName: 'Relay supervisor',
+};
+
+export interface SupervisorActionSessionBoundary {
+  list(): SessionSummary[];
+  get(id: string): Session | undefined;
+  supervisorWrite(id: string, input: { action: SupervisorActionType; actor: ControlActor; payload: string }): { eventId: string; modeBefore?: ControlMode; modeAfter?: ControlMode };
+}
+
+function sha256(input: string): string {
+  return crypto.createHash('sha256').update(input).digest('hex');
+}
+
+function actorSummary(actor: ControlActor): SupervisorActionAuditSummary['actor'] {
+  return {
+    kind: actor.kind,
+    ...(actor.id ? { idHash: sha256(actor.id) } : {}),
+    ...(actor.displayName ? { displayName: actor.displayName } : {}),
+    ...(actor.nodeId ? { nodeId: actor.nodeId } : {}),
+    ...(actor.sessionId ? { sessionId: actor.sessionId } : {}),
+  };
+}
+
+function targetIdentity(session: Session | SessionSummary | undefined, requestedId: string) {
+  const nodeId = session?.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  const explicitGlobalSessionId =
+    session && 'globalSessionId' in session ? session.globalSessionId : undefined;
+  return {
+    sessionId: session?.id ?? requestedId,
+    ...(explicitGlobalSessionId
+      ? { globalSessionId: explicitGlobalSessionId }
+      : { globalSessionId: createGlobalSessionId(nodeId, session?.id ?? requestedId) }),
+    nodeId,
+  };
+}
+
+function validationError(
+  validation: { ok: true; text: string } | { ok: false; error: SupervisorActionError }
+): SupervisorActionError | undefined {
+  return 'error' in validation ? validation.error : undefined;
+}
+
+function countLines(input: string): number {
+  if (input.length === 0) return 0;
+  return input.split(/\r\n|\r|\n/).length;
+}
+
+function redactionForPayload(payload: string): SupervisorActionRedactionMetadata {
+  return {
+    rawContentAvailable: false,
+    hashSha256: sha256(payload),
+    byteCount: Buffer.byteLength(payload, 'utf8'),
+    charCount: Array.from(payload).length,
+    lineCount: countLines(payload),
+    classes: payload === '\n' ? ['submit'] : ['literal-text'],
+    redacted: true,
+  };
+}
+
+function error(
+  code: SupervisorActionError['code'],
+  reasonCode: SupervisorActionError['reasonCode'],
+  message: string,
+  retryable: boolean,
+  details?: Record<string, unknown>
+): SupervisorActionError {
+  return { code, reasonCode, message, retryable, ...(details ? { details } : {}) };
+}
+
+function validateLiteralText(text: unknown): { ok: true; text: string } | { ok: false; error: SupervisorActionError } {
+  if (typeof text !== 'string' || text.length === 0) {
+    return {
+      ok: false,
+      error: error('INVALID_ARGUMENT', 'TEXT_REQUIRED', 'sendText requires non-empty literal text', false),
+    };
+  }
+  if (Array.from(text).length > MAX_SUPERVISOR_TEXT_CHARS) {
+    return {
+      ok: false,
+      error: error('INVALID_ARGUMENT', 'TEXT_TOO_LARGE', `sendText is limited to ${MAX_SUPERVISOR_TEXT_CHARS} characters`, false, {
+        maxChars: MAX_SUPERVISOR_TEXT_CHARS,
+      }),
+    };
+  }
+  if (/\r|\n/.test(text) || Array.from(text).some((char) => {
+    const code = char.charCodeAt(0);
+    return code === 0x1b || code === 0x7f || (code < 0x20 && code !== 0x09);
+  })) {
+    return {
+      ok: false,
+      error: error(
+        'INVALID_ARGUMENT',
+        'TEXT_MUST_BE_LITERAL',
+        'sendText accepts literal text only; use supervisor.submit for Enter and do not send control sequences',
+        false
+      ),
+    };
+  }
+  return { ok: true, text };
+}
+
+function targetPreflight(session: Session | undefined, requestedId: string): SupervisorActionError | undefined {
+  if (!session) {
+    return error('NOT_FOUND', 'SESSION_NOT_FOUND', 'session was not found or is not locally writable', false, { sessionId: requestedId });
+  }
+  const control = normalizeControlStateSummary(session.controlState);
+  if (session.status === 'disconnected') {
+    return error('SESSION_CONFLICT', 'SESSION_DISCONNECTED', 'cannot run supervisor action on a disconnected session', false, { sessionId: session.id });
+  }
+  if (session.mode !== 'pty') {
+    return error('SESSION_CONFLICT', 'SESSION_MODE_UNSUPPORTED', 'typed supervisor actions are only supported for PTY sessions', false, { sessionId: session.id, mode: session.mode });
+  }
+  if (control.controlFreshness === 'stale') {
+    return error('CONTROL_STATE_STALE', 'CONTROL_STATE_STALE', 'cannot run supervisor action from stale control state', true, { sessionId: session.id });
+  }
+  if (control.controlFreshness !== 'fresh') {
+    return error('CONTROL_STATE_UNKNOWN', 'CONTROL_STATE_UNKNOWN', 'cannot run supervisor action from unknown control state', true, { sessionId: session.id });
+  }
+  return undefined;
+}
+
+function emptyCounts(requested: number): SupervisorActionCounts {
+  return { requested, succeeded: 0, denied: 0, failed: 0, skipped: 0 };
+}
+
+function tally(results: SupervisorActionTargetResult[]): SupervisorActionCounts {
+  const counts = emptyCounts(results.length);
+  for (const result of results) {
+    if (result.ok) counts.succeeded += 1;
+    else if (result.error?.code === 'FORBIDDEN') counts.denied += 1;
+    else counts.failed += 1;
+  }
+  return counts;
+}
+
+export function listSupervisorSessions(sessions: readonly SessionSummary[]): SupervisorSessionsResponse {
+  return {
+    command: 'supervisor.sessions',
+    sessions: sessions.map((session): SupervisorSessionEligibility => {
+      const common = targetIdentity(session, session.id);
+      const reason =
+        session.status === 'disconnected'
+          ? 'SESSION_DISCONNECTED'
+          : session.mode !== 'pty'
+            ? 'SESSION_MODE_UNSUPPORTED'
+            : session.controlFreshness === 'stale'
+              ? 'CONTROL_STATE_STALE'
+              : session.controlFreshness !== 'fresh'
+                ? 'CONTROL_STATE_UNKNOWN'
+                : undefined;
+      const allowed = reason === undefined;
+      return {
+        ...common,
+        mode: session.mode,
+        status: session.status,
+        ...(session.controlMode === undefined ? {} : { controlMode: session.controlMode }),
+        ...(session.controlFreshness === undefined ? {} : { controlFreshness: session.controlFreshness }),
+        actions: {
+          sendText: { allowed, ...(reason ? { reasonCode: reason } : {}) },
+          submit: { allowed, ...(reason ? { reasonCode: reason } : {}) },
+        },
+      };
+    }),
+    count: sessions.length,
+  };
+}
+
+export function executeSupervisorAction(input: {
+  boundary: SupervisorActionSessionBoundary;
+  action: SupervisorActionType;
+  targetIds: readonly string[];
+  text?: unknown;
+  actor?: ControlActor;
+  now?: Date;
+  deniedByCapability?: SupervisorActionError;
+}): SupervisorActionResponse {
+  const actor = input.actor ?? DEFAULT_SUPERVISOR_ACTOR;
+  const timestamp = (input.now ?? new Date()).toISOString();
+  const validation = input.action === 'sendText'
+    ? validateLiteralText(input.text)
+    : { ok: true as const, text: '\n' };
+  const payload = validation.ok ? validation.text : '';
+  const payloadValidationError = validationError(validation);
+  const results: SupervisorActionTargetResult[] = [];
+
+  const uniqueTargetIds = Array.from(new Set(input.targetIds.filter((id) => id.trim().length > 0)));
+  if (uniqueTargetIds.length === 0) {
+    uniqueTargetIds.push('');
+  }
+
+  for (const id of uniqueTargetIds) {
+    const session = id ? input.boundary.get(id) : undefined;
+    const identity = targetIdentity(session, id);
+    if (input.deniedByCapability) {
+      results.push({ ...identity, ok: false, action: input.action, error: input.deniedByCapability });
+      continue;
+    }
+    if (payloadValidationError) {
+      results.push({ ...identity, ok: false, action: input.action, error: payloadValidationError });
+      continue;
+    }
+    const preflight = targetPreflight(session, id);
+    if (preflight) {
+      results.push({ ...identity, ok: false, action: input.action, error: preflight });
+      continue;
+    }
+    try {
+      const write = input.boundary.supervisorWrite(session!.id, {
+        action: input.action,
+        actor,
+        payload,
+      });
+      const targetResult: SupervisorActionTargetResult = {
+        ...identity,
+        ok: true,
+        action: input.action,
+        bytesWritten: Buffer.byteLength(payload, 'utf8'),
+        interventionEventId: write.eventId,
+        ...(write.modeBefore === undefined ? {} : { controlModeBefore: write.modeBefore }),
+        ...(write.modeAfter === undefined ? {} : { controlModeAfter: write.modeAfter }),
+      };
+      results.push(targetResult);
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : 'failed to write supervisor action';
+      results.push({
+        ...identity,
+        ok: false,
+        action: input.action,
+        error: error('UPSTREAM_ERROR', 'UPSTREAM_WRITE_FAILED', message, true, { sessionId: session!.id }),
+      });
+    }
+  }
+
+  const counts = tally(results);
+  const audit: SupervisorActionAuditSummary = {
+    action: input.action,
+    actor: actorSummary(actor),
+    targetSessionIds: results.map((result) => result.sessionId),
+    targetCount: results.length,
+    timestamp,
+    ...(validation.ok ? { content: redactionForPayload(payload) } : {}),
+    counts,
+    rawContentStored: false,
+    partialFailure: counts.failed > 0 || counts.denied > 0 || counts.skipped > 0,
+  };
+  return {
+    command: supervisorActionCommandId(input.action),
+    action: input.action,
+    results,
+    counts,
+    audit,
+    redaction: {
+      rawContentAvailable: false,
+      rawContentStored: false,
+      hashesOnly: true,
+    },
+  };
+}
+
+export function supervisorWriteSession(
+  session: Session,
+  input: { action: SupervisorActionType; actor: ControlActor; payload: string }
+): { eventId: string; modeBefore?: ControlMode; modeAfter?: ControlMode } {
+  if (session.mode !== 'pty') {
+    throw new Error(`Session ${session.id} is not a PTY session`);
+  }
+  const event = recordSupervisorAction(session, input);
+  if (event.type !== 'tab.intervention') {
+    throw new Error(`Supervisor action did not produce an intervention event for ${session.id}`);
+  }
+  session.pty.write(input.payload);
+  session.lastActivity = new Date().toISOString();
+  const result: { eventId: string; modeBefore?: ControlMode; modeAfter?: ControlMode } = {
+    eventId: event.eventId,
+    modeBefore: event.intervention.modeBefore,
+    ...(event.intervention.modeAfter === undefined
+      ? {}
+      : { modeAfter: event.intervention.modeAfter }),
+  };
+  return result;
+}

--- a/server/supervisor-actions.ts
+++ b/server/supervisor-actions.ts
@@ -14,7 +14,6 @@ import {
   type SupervisorSessionsResponse,
 } from '../shared/supervisor-actions.js';
 import { DEFAULT_LOCAL_NODE_ID, createGlobalSessionId } from '../shared/identity.js';
-import { recordSupervisorAction } from './control-engine.js';
 import type { Session, SessionSummary } from './types.js';
 
 const MAX_SUPERVISOR_TEXT_CHARS = 1000;
@@ -122,10 +121,11 @@ function validateLiteralText(text: unknown): { ok: true; text: string } | { ok: 
   return { ok: true, text };
 }
 
-function targetPreflight(session: Session | undefined, requestedId: string): SupervisorActionError | undefined {
-  if (!session) {
-    return error('NOT_FOUND', 'SESSION_NOT_FOUND', 'session was not found or is not locally writable', false, { sessionId: requestedId });
-  }
+function missingSessionError(requestedId: string): SupervisorActionError {
+  return error('NOT_FOUND', 'SESSION_NOT_FOUND', 'session was not found or is not locally writable', false, { sessionId: requestedId });
+}
+
+function targetPreflight(session: Session): SupervisorActionError | undefined {
   const control = normalizeControlStateSummary(session.controlState);
   if (session.status === 'disconnected') {
     return error('SESSION_CONFLICT', 'SESSION_DISCONNECTED', 'cannot run supervisor action on a disconnected session', false, { sessionId: session.id });
@@ -222,13 +222,17 @@ export function executeSupervisorAction(input: {
       results.push({ ...identity, ok: false, action: input.action, error: payloadValidationError });
       continue;
     }
-    const preflight = targetPreflight(session, id);
+    if (!session) {
+      results.push({ ...identity, ok: false, action: input.action, error: missingSessionError(id) });
+      continue;
+    }
+    const preflight = targetPreflight(session);
     if (preflight) {
       results.push({ ...identity, ok: false, action: input.action, error: preflight });
       continue;
     }
     try {
-      const write = input.boundary.supervisorWrite(session!.id, {
+      const write = input.boundary.supervisorWrite(session.id, {
         action: input.action,
         actor,
         payload,
@@ -249,7 +253,7 @@ export function executeSupervisorAction(input: {
         ...identity,
         ok: false,
         action: input.action,
-        error: error('UPSTREAM_ERROR', 'UPSTREAM_WRITE_FAILED', message, true, { sessionId: session!.id }),
+        error: error('UPSTREAM_ERROR', 'UPSTREAM_WRITE_FAILED', message, true, { sessionId: session.id }),
       });
     }
   }
@@ -278,27 +282,4 @@ export function executeSupervisorAction(input: {
       hashesOnly: true,
     },
   };
-}
-
-export function supervisorWriteSession(
-  session: Session,
-  input: { action: SupervisorActionType; actor: ControlActor; payload: string }
-): { eventId: string; modeBefore?: ControlMode; modeAfter?: ControlMode } {
-  if (session.mode !== 'pty') {
-    throw new Error(`Session ${session.id} is not a PTY session`);
-  }
-  const event = recordSupervisorAction(session, input);
-  if (event.type !== 'tab.intervention') {
-    throw new Error(`Supervisor action did not produce an intervention event for ${session.id}`);
-  }
-  session.pty.write(input.payload);
-  session.lastActivity = new Date().toISOString();
-  const result: { eventId: string; modeBefore?: ControlMode; modeAfter?: ControlMode } = {
-    eventId: event.eventId,
-    modeBefore: event.intervention.modeBefore,
-    ...(event.intervention.modeAfter === undefined
-      ? {}
-      : { modeAfter: event.intervention.modeAfter }),
-  };
-  return result;
 }

--- a/server/supervisor-route-handlers.ts
+++ b/server/supervisor-route-handlers.ts
@@ -1,0 +1,31 @@
+import type { Request, Response } from 'express';
+
+import { SUPERVISOR_READ_REQUIRED_CAPABILITIES } from '../shared/supervisor-actions.js';
+import type { SessionSummary } from './types.js';
+import {
+  capabilitiesDecisionFromRequest,
+  capabilityError,
+  errorStatus as sessionControlErrorStatus,
+} from './session-control-api.js';
+import { listSupervisorSessions } from './supervisor-actions.js';
+
+export interface SupervisorSessionsBoundary {
+  list(): SessionSummary[];
+}
+
+export function handleSupervisorSessionsRequest(
+  req: Request,
+  res: Response,
+  sessions: SupervisorSessionsBoundary
+): void {
+  const decision = capabilitiesDecisionFromRequest(
+    req,
+    SUPERVISOR_READ_REQUIRED_CAPABILITIES
+  );
+  if (decision.decision !== 'allow') {
+    const error = capabilityError(decision);
+    res.status(sessionControlErrorStatus(error)).json({ error });
+    return;
+  }
+  res.json(listSupervisorSessions(sessions.list()));
+}

--- a/server/supervisor-route-handlers.ts
+++ b/server/supervisor-route-handlers.ts
@@ -1,16 +1,172 @@
 import type { Request, Response } from 'express';
 
-import { SUPERVISOR_READ_REQUIRED_CAPABILITIES } from '../shared/supervisor-actions.js';
+import {
+  SUPERVISOR_READ_REQUIRED_CAPABILITIES,
+  supervisorActionRequiredCapabilities,
+  type SupervisorActionError,
+  type SupervisorActionType,
+} from '../shared/supervisor-actions.js';
 import type { SessionSummary } from './types.js';
 import {
+  actorFromRequestBody,
   capabilitiesDecisionFromRequest,
   capabilityError,
   errorStatus as sessionControlErrorStatus,
+  type ControlCapabilityDecision,
 } from './session-control-api.js';
-import { listSupervisorSessions } from './supervisor-actions.js';
+import {
+  executeSupervisorAction,
+  listSupervisorSessions,
+  type SupervisorActionSessionBoundary,
+} from './supervisor-actions.js';
 
 export interface SupervisorSessionsBoundary {
   list(): SessionSummary[];
+}
+
+function supervisorActionError(
+  reasonCode: SupervisorActionError['reasonCode'],
+  message: string,
+  details?: Record<string, unknown>
+): SupervisorActionError {
+  return {
+    code: 'INVALID_ARGUMENT',
+    reasonCode,
+    message,
+    retryable: false,
+    ...(details ? { details } : {}),
+  };
+}
+
+function supervisorActionErrorStatus(error: SupervisorActionError): number {
+  switch (error.code) {
+    case 'FORBIDDEN':
+      return 403;
+    case 'NOT_FOUND':
+      return 404;
+    case 'INVALID_ARGUMENT':
+      return 400;
+    default:
+      return 409;
+  }
+}
+
+function actionFromParam(
+  actionParam: string | undefined
+): SupervisorActionType | undefined {
+  return actionParam === 'sendText' || actionParam === 'submit'
+    ? actionParam
+    : undefined;
+}
+
+function requestBody(req: Request): Record<string, unknown> {
+  return typeof req.body === 'object' && req.body !== null
+    ? (req.body as Record<string, unknown>)
+    : {};
+}
+
+function validateSupervisorActionTargets(
+  body: Record<string, unknown>
+):
+  | { ok: true; targetIds: string[] }
+  | { ok: false; error: SupervisorActionError } {
+  const id = body['id'];
+  const targetIds = body['targetIds'];
+  const hasIdField = id !== undefined;
+  const hasTargetIdsField = targetIds !== undefined;
+
+  if (hasIdField && hasTargetIdsField) {
+    return {
+      ok: false,
+      error: supervisorActionError(
+        'TARGET_SELECTOR_INVALID',
+        'exactly one of id or targetIds is required',
+        { field: 'id' }
+      ),
+    };
+  }
+
+  if (!hasIdField && !hasTargetIdsField) {
+    return {
+      ok: false,
+      error: supervisorActionError(
+        'TARGET_SELECTOR_REQUIRED',
+        'exactly one of id or targetIds is required',
+        { field: 'id' }
+      ),
+    };
+  }
+
+  if (hasIdField) {
+    if (typeof id !== 'string' || id.trim().length === 0) {
+      return {
+        ok: false,
+        error: supervisorActionError(
+          'TARGET_SELECTOR_INVALID',
+          'id must be a non-empty session id',
+          { field: 'id' }
+        ),
+      };
+    }
+    return { ok: true, targetIds: [id.trim()] };
+  }
+
+  if (!Array.isArray(targetIds)) {
+    return {
+      ok: false,
+      error: supervisorActionError(
+        'TARGET_SELECTOR_INVALID',
+        'targetIds must be a non-empty list of session ids',
+        { field: 'targetIds' }
+      ),
+    };
+  }
+
+  if (
+    targetIds.length === 0 ||
+    !targetIds.every(
+      (entry) => typeof entry === 'string' && entry.trim().length > 0
+    )
+  ) {
+    return {
+      ok: false,
+      error: supervisorActionError(
+        'TARGET_SELECTOR_INVALID',
+        'targetIds must be a non-empty list of session ids',
+        { field: 'targetIds' }
+      ),
+    };
+  }
+
+  return { ok: true, targetIds: targetIds.map((entry) => entry.trim()) };
+}
+
+function missingCapabilityEvidenceDecision(
+  capability: ControlCapabilityDecision['capability']
+): ControlCapabilityDecision {
+  return {
+    decision: 'deny',
+    capability,
+    placeholder: true,
+    reasonCode: 'CAPABILITY_REQUIRED',
+    message: 'missing required supervisor action capability evidence',
+  };
+}
+
+function supervisorActionCapabilitiesDecision(
+  req: Request,
+  action: SupervisorActionType
+): ControlCapabilityDecision {
+  const capabilities = supervisorActionRequiredCapabilities(action);
+  const header = req.header('x-relay-capabilities') ?? undefined;
+  if (header === undefined || header.trim().length === 0) {
+    const highRiskCapability =
+      action === 'submit'
+        ? 'tab:intervention:submit'
+        : 'tab:intervention:send-text';
+    return missingCapabilityEvidenceDecision(highRiskCapability);
+  }
+  return capabilitiesDecisionFromRequest(req, capabilities);
 }
 
 export function handleSupervisorSessionsRequest(
@@ -28,4 +184,46 @@ export function handleSupervisorSessionsRequest(
     return;
   }
   res.json(listSupervisorSessions(sessions.list()));
+}
+
+export function handleSupervisorActionRequest(
+  req: Request,
+  res: Response,
+  sessions: SupervisorActionSessionBoundary
+): void {
+  const action = actionFromParam(req.params['action']);
+  if (!action) {
+    const error = supervisorActionError(
+      'TARGET_SELECTOR_INVALID',
+      'supervisor action must be sendText or submit',
+      { field: 'action' }
+    );
+    res.status(supervisorActionErrorStatus(error)).json({ error });
+    return;
+  }
+
+  const body = requestBody(req);
+  const targets = validateSupervisorActionTargets(body);
+  if (targets.ok === false) {
+    const error = targets.error;
+    res.status(supervisorActionErrorStatus(error)).json({ error });
+    return;
+  }
+
+  const decision = supervisorActionCapabilitiesDecision(req, action);
+  if (decision.decision !== 'allow') {
+    const error = capabilityError(decision);
+    res.status(sessionControlErrorStatus(error)).json({ error });
+    return;
+  }
+
+  const actor = actorFromRequestBody(body['actor']);
+  const result = executeSupervisorAction({
+    boundary: sessions,
+    action,
+    targetIds: targets.targetIds,
+    text: body['text'],
+    ...(actor === undefined ? {} : { actor }),
+  });
+  res.json(result);
 }

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -959,28 +959,33 @@ const supervisorSessionsOutputSchema: RelayJsonSchema = {
   required: ['command', 'sessions', 'count'],
 };
 
-const supervisorActionOutputSchema = (command: string): RelayJsonSchema => ({
-  type: 'object',
-  additionalProperties: true,
-  properties: {
-    command: { const: command },
-    action: { type: 'string', enum: ['sendText', 'submit'] },
-    results: { type: 'array', items: { type: 'object', additionalProperties: true } },
-    counts: { type: 'object', additionalProperties: true },
-    audit: { type: 'object', additionalProperties: true },
-    redaction: {
-      type: 'object',
-      additionalProperties: false,
-      properties: {
-        rawContentAvailable: { const: false },
-        rawContentStored: { const: false },
-        hashesOnly: { const: true },
+const supervisorActionOutputSchema = (
+  command: 'supervisor.sendText' | 'supervisor.submit'
+): RelayJsonSchema => {
+  const action = command === 'supervisor.submit' ? 'submit' : 'sendText';
+  return {
+    type: 'object',
+    additionalProperties: true,
+    properties: {
+      command: { const: command },
+      action: { const: action },
+      results: { type: 'array', items: { type: 'object', additionalProperties: true } },
+      counts: { type: 'object', additionalProperties: true },
+      audit: { type: 'object', additionalProperties: true },
+      redaction: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          rawContentAvailable: { const: false },
+          rawContentStored: { const: false },
+          hashesOnly: { const: true },
+        },
+        required: ['rawContentAvailable', 'rawContentStored', 'hashesOnly'],
       },
-      required: ['rawContentAvailable', 'rawContentStored', 'hashesOnly'],
     },
-  },
-  required: ['command', 'action', 'results', 'counts', 'audit', 'redaction'],
-});
+    required: ['command', 'action', 'results', 'counts', 'audit', 'redaction'],
+  };
+};
 
 const gatewayHandoffErrorCodes = [
   'UNAUTHORIZED',

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -32,6 +32,9 @@ export type RelayCliGatewayCommand =
   | 'handoffs.launch'
   | 'artifacts.read'
   | 'supervisor.snapshot'
+  | 'supervisor.sessions'
+  | 'supervisor.sendText'
+  | 'supervisor.submit'
   | 'events.subscribe';
 
 export type RelayCliGatewayErrorCode =
@@ -803,6 +806,39 @@ const supervisorSnapshotInputSchema: RelayJsonSchema = {
   required: ['id'],
 };
 
+const supervisorSessionsInputSchema: RelayJsonSchema = {
+  title: 'SupervisorSessionsInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {},
+};
+
+const supervisorSendTextInputSchema: RelayJsonSchema = {
+  title: 'SupervisorSendTextInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    id: stringSchema,
+    targetIds: { type: 'array', items: stringSchema },
+    text: stringSchema,
+    actor: { type: 'object', additionalProperties: true },
+  },
+  required: ['text'],
+  oneOf: [{ required: ['id'] }, { required: ['targetIds'] }],
+};
+
+const supervisorSubmitInputSchema: RelayJsonSchema = {
+  title: 'SupervisorSubmitInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    id: stringSchema,
+    targetIds: { type: 'array', items: stringSchema },
+    actor: { type: 'object', additionalProperties: true },
+  },
+  oneOf: [{ required: ['id'] }, { required: ['targetIds'] }],
+};
+
 const handoffPlanOutputSchema: RelayJsonSchema = {
   type: 'object',
   additionalProperties: false,
@@ -911,6 +947,40 @@ const supervisorSnapshotOutputSchema: RelayJsonSchema = {
   },
   required: ['snapshot', 'audit'],
 };
+
+const supervisorSessionsOutputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    command: { const: 'supervisor.sessions' },
+    sessions: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    count: { type: 'number', minimum: 0 },
+  },
+  required: ['command', 'sessions', 'count'],
+};
+
+const supervisorActionOutputSchema = (command: string): RelayJsonSchema => ({
+  type: 'object',
+  additionalProperties: true,
+  properties: {
+    command: { const: command },
+    action: { type: 'string', enum: ['sendText', 'submit'] },
+    results: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    counts: { type: 'object', additionalProperties: true },
+    audit: { type: 'object', additionalProperties: true },
+    redaction: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        rawContentAvailable: { const: false },
+        rawContentStored: { const: false },
+        hashesOnly: { const: true },
+      },
+      required: ['rawContentAvailable', 'rawContentStored', 'hashesOnly'],
+    },
+  },
+  required: ['command', 'action', 'results', 'counts', 'audit', 'redaction'],
+});
 
 const gatewayHandoffErrorCodes = [
   'UNAUTHORIZED',
@@ -1540,6 +1610,42 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     capabilityHints: ['session:read', 'tab:intervention:read'],
     inputSchema: supervisorSnapshotInputSchema,
     outputSchema: okOutput('SupervisorSnapshotOutput', supervisorSnapshotOutputSchema),
+    errorCodes: gatewaySupervisorErrorCodes,
+  },
+  {
+    name: 'supervisor.sessions',
+    cli: ['relay-ide', 'v1', 'supervisor', 'sessions', '--json'],
+    summary: 'List sessions eligible for typed supervisor actions with per-action reasons.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:read', 'tab:intervention:read'],
+    inputSchema: supervisorSessionsInputSchema,
+    outputSchema: okOutput('SupervisorSessionsOutput', supervisorSessionsOutputSchema),
+    errorCodes: gatewaySupervisorErrorCodes,
+  },
+  {
+    name: 'supervisor.sendText',
+    cli: ['relay-ide', 'v1', 'supervisor', 'send-text', '--id', '<session-id>', '--text', '<text>', '--json'],
+    summary: 'Send bounded literal text to one or more PTY sessions as a typed supervisor intervention.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:attach', 'tab:intervention:send-text'],
+    inputSchema: supervisorSendTextInputSchema,
+    outputSchema: okOutput('SupervisorSendTextOutput', supervisorActionOutputSchema('supervisor.sendText')),
+    errorCodes: gatewaySupervisorErrorCodes,
+  },
+  {
+    name: 'supervisor.submit',
+    cli: ['relay-ide', 'v1', 'supervisor', 'submit', '--id', '<session-id>', '--json'],
+    summary: 'Submit Enter to one or more PTY sessions as a typed supervisor intervention.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:attach', 'tab:intervention:submit'],
+    inputSchema: supervisorSubmitInputSchema,
+    outputSchema: okOutput('SupervisorSubmitOutput', supervisorActionOutputSchema('supervisor.submit')),
     errorCodes: gatewaySupervisorErrorCodes,
   },
   {

--- a/shared/control-state.ts
+++ b/shared/control-state.ts
@@ -53,11 +53,14 @@ export interface TabModeChangedEvent extends TabControlEventBase {
 
 export type InterventionSource =
   | 'pty-input'
+  | 'supervisor-action'
   | 'mode-action'
   | 'auto-revert';
 
 export type InterventionKind =
   | 'human-input'
+  | 'supervisor-send-text'
+  | 'supervisor-submit'
   | 'join'
   | 'take-over'
   | 'hand-back'

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -95,6 +95,9 @@ const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
   'handoffs.launch': 'launch handoff destination',
   'artifacts.read': 'read handoff artifact',
   'supervisor.snapshot': 'supervisor snapshot',
+  'supervisor.sessions': 'supervisor sessions',
+  'supervisor.sendText': 'supervisor send text',
+  'supervisor.submit': 'supervisor submit',
   'events.subscribe': 'subscribe gateway events',
 };
 
@@ -107,6 +110,8 @@ function sideEffectForGatewayCommand(spec: RelayCliGatewayCommandSpec): RelayCom
     spec.name === 'sessions.detach' ||
     spec.name === 'sessions.input' ||
     spec.name === 'sessions.handBack' ||
+    spec.name === 'supervisor.sendText' ||
+    spec.name === 'supervisor.submit' ||
     spec.name === 'files.write' ||
     spec.name === 'handoffs.cancel'
   ) {
@@ -145,6 +150,9 @@ function controlRequirementsForGatewayCommand(
   if (spec.name === 'supervisor.snapshot') {
     requirements.push('fresh-control-state', 'latest-intervention-ack');
   }
+  if (spec.name === 'supervisor.sendText' || spec.name === 'supervisor.submit') {
+    requirements.push('fresh-control-state');
+  }
   if (spec.name === 'sessions.handBack') requirements.push('latest-intervention-ack');
   return requirements;
 }
@@ -156,7 +164,7 @@ function auditExpectationForGatewayCommand(
     return 'schema-only';
   }
   if (spec.name === 'sessions.stream' || spec.name === 'events.subscribe') return 'stream-redacted';
-  if (spec.name === 'supervisor.snapshot') return 'hashes-only';
+  if (spec.name === 'supervisor.snapshot' || spec.name === 'supervisor.sendText' || spec.name === 'supervisor.submit') return 'hashes-only';
   if (sideEffectForGatewayCommand(spec) === 'read') return 'bounded-redacted';
   return 'action-summary';
 }

--- a/shared/security-audit.ts
+++ b/shared/security-audit.ts
@@ -278,6 +278,14 @@ function controlEventAuditParams(event: TabControlEvent): Record<string, unknown
 }
 
 function controlEventRequiredBits(event: TabControlEvent): RelayCapabilityBit[] {
+  if (event.type === 'tab.intervention') {
+    if (event.intervention.kind === 'supervisor-send-text') {
+      return ['session:attach', 'tab:intervention:send-text'];
+    }
+    if (event.intervention.kind === 'supervisor-submit') {
+      return ['session:attach', 'tab:intervention:submit'];
+    }
+  }
   const modeAfter =
     event.type === 'tab.mode-changed'
       ? event.controlMode

--- a/shared/security-policy.ts
+++ b/shared/security-policy.ts
@@ -10,6 +10,8 @@ export const RELAY_CAPABILITY_BITS = [
   'session:control:kill',
   'tab:mode:set-agent',
   'tab:intervention:read',
+  'tab:intervention:send-text',
+  'tab:intervention:submit',
   'rpc:fs:list',
   'rpc:fs:read',
   'rpc:fs:tail',
@@ -54,6 +56,8 @@ export const LEGACY_DEFAULT_ALLOWED_CAPABILITIES = [
 
 export const HIGH_RISK_CAPABILITIES = [
   'session:control:kill',
+  'tab:intervention:send-text',
+  'tab:intervention:submit',
   'rpc:fs:write',
   'rpc:fs:delete',
   'rpc:git:write',

--- a/shared/supervisor-actions.ts
+++ b/shared/supervisor-actions.ts
@@ -1,0 +1,149 @@
+import type { ControlActor, ControlFreshness, ControlMode } from './control-state.js';
+import type { RelayCapabilityBit } from './security-policy.js';
+
+export const SUPERVISOR_SESSIONS_COMMAND_ID = 'supervisor.sessions' as const;
+export const SUPERVISOR_SEND_TEXT_COMMAND_ID = 'supervisor.sendText' as const;
+export const SUPERVISOR_SUBMIT_COMMAND_ID = 'supervisor.submit' as const;
+
+export const SUPERVISOR_READ_REQUIRED_CAPABILITIES = [
+  'session:read',
+  'tab:intervention:read',
+] as const satisfies readonly RelayCapabilityBit[];
+
+export const SUPERVISOR_SEND_TEXT_REQUIRED_CAPABILITIES = [
+  'session:attach',
+  'tab:intervention:send-text',
+] as const satisfies readonly RelayCapabilityBit[];
+
+export const SUPERVISOR_SUBMIT_REQUIRED_CAPABILITIES = [
+  'session:attach',
+  'tab:intervention:submit',
+] as const satisfies readonly RelayCapabilityBit[];
+
+export type SupervisorActionType = 'sendText' | 'submit';
+
+export type SupervisorActionErrorCode =
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'SESSION_CONFLICT'
+  | 'CONTROL_STATE_STALE'
+  | 'CONTROL_STATE_UNKNOWN'
+  | 'INVALID_ARGUMENT'
+  | 'UPSTREAM_ERROR';
+
+export type SupervisorActionReasonCode =
+  | 'CAPABILITY_REQUIRED'
+  | 'SESSION_NOT_FOUND'
+  | 'SESSION_DISCONNECTED'
+  | 'CONTROL_STATE_STALE'
+  | 'CONTROL_STATE_UNKNOWN'
+  | 'SESSION_MODE_UNSUPPORTED'
+  | 'TEXT_REQUIRED'
+  | 'TEXT_TOO_LARGE'
+  | 'TEXT_MUST_BE_LITERAL'
+  | 'UPSTREAM_WRITE_FAILED';
+
+export interface SupervisorActionError {
+  code: SupervisorActionErrorCode;
+  reasonCode: SupervisorActionReasonCode;
+  message: string;
+  retryable: boolean;
+  details?: Record<string, unknown>;
+}
+
+export interface SupervisorActionRedactionMetadata {
+  rawContentAvailable: false;
+  hashSha256: string;
+  byteCount: number;
+  charCount: number;
+  lineCount: number;
+  classes: string[];
+  redacted: boolean;
+}
+
+export interface SupervisorActionTargetResult {
+  sessionId: string;
+  globalSessionId?: string;
+  nodeId?: string;
+  ok: boolean;
+  action: SupervisorActionType;
+  bytesWritten?: number;
+  interventionEventId?: string;
+  controlModeBefore?: ControlMode;
+  controlModeAfter?: ControlMode;
+  error?: SupervisorActionError;
+}
+
+export interface SupervisorActionCounts {
+  requested: number;
+  succeeded: number;
+  denied: number;
+  failed: number;
+  skipped: number;
+}
+
+export interface SupervisorActionAuditSummary {
+  action: SupervisorActionType;
+  actor: {
+    kind: ControlActor['kind'];
+    idHash?: string;
+    displayName?: string;
+    nodeId?: string;
+    sessionId?: string;
+  };
+  targetSessionIds: string[];
+  targetCount: number;
+  timestamp: string;
+  content?: SupervisorActionRedactionMetadata;
+  counts: SupervisorActionCounts;
+  rawContentStored: false;
+  partialFailure: boolean;
+}
+
+export interface SupervisorActionResponse {
+  command:
+    | typeof SUPERVISOR_SEND_TEXT_COMMAND_ID
+    | typeof SUPERVISOR_SUBMIT_COMMAND_ID;
+  action: SupervisorActionType;
+  results: SupervisorActionTargetResult[];
+  counts: SupervisorActionCounts;
+  audit: SupervisorActionAuditSummary;
+  redaction: {
+    rawContentAvailable: false;
+    rawContentStored: false;
+    hashesOnly: true;
+  };
+}
+
+export interface SupervisorSessionEligibility {
+  sessionId: string;
+  globalSessionId?: string;
+  nodeId?: string;
+  mode?: string;
+  status?: string;
+  controlMode?: ControlMode;
+  controlFreshness?: ControlFreshness;
+  actions: Record<SupervisorActionType, { allowed: boolean; reasonCode?: SupervisorActionReasonCode }>;
+}
+
+export interface SupervisorSessionsResponse {
+  command: typeof SUPERVISOR_SESSIONS_COMMAND_ID;
+  sessions: SupervisorSessionEligibility[];
+  count: number;
+}
+
+export function supervisorActionRequiredCapabilities(
+  action: SupervisorActionType
+): readonly RelayCapabilityBit[] {
+  return action === 'sendText'
+    ? SUPERVISOR_SEND_TEXT_REQUIRED_CAPABILITIES
+    : SUPERVISOR_SUBMIT_REQUIRED_CAPABILITIES;
+}
+
+export function supervisorActionCommandId(
+  action: SupervisorActionType
+): typeof SUPERVISOR_SEND_TEXT_COMMAND_ID | typeof SUPERVISOR_SUBMIT_COMMAND_ID {
+  return action === 'sendText'
+    ? SUPERVISOR_SEND_TEXT_COMMAND_ID
+    : SUPERVISOR_SUBMIT_COMMAND_ID;
+}

--- a/shared/supervisor-actions.ts
+++ b/shared/supervisor-actions.ts
@@ -1,4 +1,8 @@
-import type { ControlActor, ControlFreshness, ControlMode } from './control-state.js';
+import type {
+  ControlActor,
+  ControlFreshness,
+  ControlMode,
+} from './control-state.js';
 import type { RelayCapabilityBit } from './security-policy.js';
 
 export const SUPERVISOR_SESSIONS_COMMAND_ID = 'supervisor.sessions' as const;
@@ -38,6 +42,8 @@ export type SupervisorActionReasonCode =
   | 'CONTROL_STATE_STALE'
   | 'CONTROL_STATE_UNKNOWN'
   | 'SESSION_MODE_UNSUPPORTED'
+  | 'TARGET_SELECTOR_REQUIRED'
+  | 'TARGET_SELECTOR_INVALID'
   | 'TEXT_REQUIRED'
   | 'TEXT_TOO_LARGE'
   | 'TEXT_MUST_BE_LITERAL'
@@ -123,7 +129,10 @@ export interface SupervisorSessionEligibility {
   status?: string;
   controlMode?: ControlMode;
   controlFreshness?: ControlFreshness;
-  actions: Record<SupervisorActionType, { allowed: boolean; reasonCode?: SupervisorActionReasonCode }>;
+  actions: Record<
+    SupervisorActionType,
+    { allowed: boolean; reasonCode?: SupervisorActionReasonCode }
+  >;
 }
 
 export interface SupervisorSessionsResponse {
@@ -142,7 +151,9 @@ export function supervisorActionRequiredCapabilities(
 
 export function supervisorActionCommandId(
   action: SupervisorActionType
-): typeof SUPERVISOR_SEND_TEXT_COMMAND_ID | typeof SUPERVISOR_SUBMIT_COMMAND_ID {
+):
+  | typeof SUPERVISOR_SEND_TEXT_COMMAND_ID
+  | typeof SUPERVISOR_SUBMIT_COMMAND_ID {
   return action === 'sendText'
     ? SUPERVISOR_SEND_TEXT_COMMAND_ID
     : SUPERVISOR_SUBMIT_COMMAND_ID;

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -439,6 +439,9 @@ describe('CLI gateway contract', () => {
       'handoffs.launch',
       'artifacts.read',
       'supervisor.snapshot',
+      'supervisor.sessions',
+      'supervisor.sendText',
+      'supervisor.submit',
       'events.subscribe',
     ] as const;
 

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -92,6 +92,9 @@ describe('CLI gateway contract', () => {
       'handoffs.launch',
       'artifacts.read',
       'supervisor.snapshot',
+      'supervisor.sessions',
+      'supervisor.sendText',
+      'supervisor.submit',
       'events.subscribe',
     ]);
 
@@ -180,6 +183,26 @@ describe('CLI gateway contract', () => {
       sideEffect: 'read',
       requiresConfirmation: false,
       controlRequirements: ['fresh-control-state', 'latest-intervention-ack'],
+      auditRedaction: { expectation: 'hashes-only' },
+      scopeKinds: ['session'],
+    });
+    expect(relayCommandDefinition('supervisor.sessions')).toMatchObject({
+      sideEffect: 'read',
+      requiresConfirmation: false,
+      auditRedaction: { expectation: 'bounded-redacted' },
+      scopeKinds: ['session'],
+    });
+    expect(relayCommandDefinition('supervisor.sendText')).toMatchObject({
+      sideEffect: 'write',
+      requiresConfirmation: false,
+      controlRequirements: ['fresh-control-state'],
+      auditRedaction: { expectation: 'hashes-only' },
+      scopeKinds: ['session'],
+    });
+    expect(relayCommandDefinition('supervisor.submit')).toMatchObject({
+      sideEffect: 'write',
+      requiresConfirmation: false,
+      controlRequirements: ['fresh-control-state'],
       auditRedaction: { expectation: 'hashes-only' },
       scopeKinds: ['session'],
     });

--- a/test/control-engine.test.ts
+++ b/test/control-engine.test.ts
@@ -256,7 +256,11 @@ describe('control transition engine', () => {
       modeAfter: 'co-driven',
       ackedAt: baseNow.toISOString(),
     });
-    expect(records[0]?.payloadPreview).toContain('[redacted:secret-like]');
+    expect(records[0]?.redaction).toMatchObject({
+      redacted: true,
+      classes: ['secret-like'],
+    });
+    expect(records[0]).not.toHaveProperty('payloadPreview');
     expect(JSON.stringify(records[0])).not.toContain('raw-secret-value');
     expect(events.map((entry) => entry.type)).toEqual(['tab.mode-changed', 'tab.intervention']);
     expect(event).toMatchObject({
@@ -435,6 +439,29 @@ describe('persistent intervention log', () => {
   afterEach(() => {
     closeInterventionLog();
     fs.rmSync(configDir, { recursive: true, force: true });
+  });
+
+  it('persists supervisor action records as hashes-only metadata without raw payload previews', () => {
+    const session = makeSession({ id: 'supervisor-plain', nodeId: 'node-a' });
+    const actor: ControlActor = { kind: 'human', id: 'supervisor-1', displayName: 'Supervisor' };
+
+    recordSupervisorAction(session, { action: 'sendText', actor, payload: 'hello' });
+
+    const [record] = listInterventions({ sessionId: 'supervisor-plain', nodeId: 'node-a' });
+    expect(record).toMatchObject({
+      source: 'supervisor-action',
+      kind: 'supervisor-send-text',
+      redaction: {
+        redacted: false,
+        byteCount: 5,
+        charCount: 5,
+        lineCount: 1,
+        classes: ['plain-text'],
+      },
+    });
+    expect(record?.redaction.hashSha256).toHaveLength(64);
+    expect(record).not.toHaveProperty('payloadPreview');
+    expect(JSON.stringify(record)).not.toContain('hello');
   });
 
   it('persists structured records, lists by session/node, and acks human input', () => {

--- a/test/control-engine.test.ts
+++ b/test/control-engine.test.ts
@@ -8,6 +8,7 @@ import {
   clearPendingControlBurstsForTests,
   maybeAutoRevertToAgentDriven,
   recordHumanPtyInput,
+  recordSupervisorAction,
   redactInterventionPayload,
 } from '../server/control-engine.js';
 import {
@@ -231,6 +232,38 @@ describe('control transition engine', () => {
     const control = redactInterventionPayload('\u001b[200~paste\u001b[201~');
     expect(control.payloadPreview).toContain('redacted:control-sequence');
     expect(control.redaction.classes).toContain('control-sequence');
+  });
+
+  it('records typed supervisor actions as co-driven intervention events without exposing raw payloads', () => {
+    const session = makeSession();
+    const records: InterventionRecord[] = [];
+    const events: TabControlEvent[] = [];
+    const actor: ControlActor = { kind: 'human', id: 'supervisor-1', displayName: 'Supervisor' };
+    const options = captureOptions(records, events);
+
+    const event = recordSupervisorAction(session, { action: 'sendText', actor, payload: 'password=raw-secret-value' }, options);
+
+    expect(session.controlState).toMatchObject({
+      controlMode: 'co-driven',
+      lastInterventionEventId: event.eventId,
+      controlReason: 'supervisor sendText',
+    });
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      source: 'supervisor-action',
+      kind: 'supervisor-send-text',
+      modeBefore: 'agent-driven',
+      modeAfter: 'co-driven',
+      ackedAt: baseNow.toISOString(),
+    });
+    expect(records[0]?.payloadPreview).toContain('[redacted:secret-like]');
+    expect(JSON.stringify(records[0])).not.toContain('raw-secret-value');
+    expect(events.map((entry) => entry.type)).toEqual(['tab.mode-changed', 'tab.intervention']);
+    expect(event).toMatchObject({
+      type: 'tab.intervention',
+      controlMode: 'co-driven',
+      intervention: { kind: 'supervisor-send-text' },
+    });
   });
 
   it('creates visible intervention and transition events for join, take-over, and hand-back actions', () => {

--- a/test/security-policy.test.ts
+++ b/test/security-policy.test.ts
@@ -17,6 +17,8 @@ describe('security policy schema', () => {
     });
 
     expect(isRelayCapabilityBit('rpc:fs:read')).toBe(true);
+    expect(isRelayCapabilityBit('tab:intervention:send-text')).toBe(true);
+    expect(isRelayCapabilityBit('tab:intervention:submit')).toBe(true);
     expect(isRelayCapabilityBit('rpc:fs:format-disk')).toBe(false);
     expect(resolveAclCapability(acl, 'rpc:fs:read')).toMatchObject({
       known: true,
@@ -41,7 +43,7 @@ describe('security policy schema', () => {
     const acl: RelayNodeAcl = {
       ...base,
       grants: {
-        allowed: ['session:read', 'session:control:kill', 'rpc:fs:write', 'rpc:git:write'],
+        allowed: ['session:read', 'session:control:kill', 'tab:intervention:send-text', 'tab:intervention:submit', 'rpc:fs:write', 'rpc:git:write'],
         requiresConfirmation: ['rpc:fs:delete'],
       },
     };
@@ -52,6 +54,8 @@ describe('security policy schema', () => {
     expect(overlaid.grants.requiresConfirmation).toEqual(
       expect.arrayContaining([
         'session:control:kill',
+        'tab:intervention:send-text',
+        'tab:intervention:submit',
         'rpc:fs:write',
         'rpc:git:write',
         'rpc:fs:delete',

--- a/test/stores/node-dashboard.test.ts
+++ b/test/stores/node-dashboard.test.ts
@@ -297,12 +297,14 @@ describe('hub node dashboard state', () => {
     // in every tier (denied in sandbox, allowed in dev, denied in prod).
     // #592 added `session:control:kill` following the same tier pattern:
     // allowed in dev, denied in sandbox + prod.
+    // #704 added two typed supervisor action bits; all default node tiers
+    // deny them unless a user grants the scoped supervisor capabilities.
     expect(
       rows.map((row) => [row.security.trustTier, row.security.postureLabel])
     ).toEqual([
-      ['sandbox', 'allow 1 · challenge 0 · deny 16'],
-      ['dev', 'allow 11 · challenge 0 · deny 6'],
-      ['prod', 'allow 1 · challenge 2 · deny 14'],
+      ['sandbox', 'allow 1 · challenge 0 · deny 18'],
+      ['dev', 'allow 11 · challenge 0 · deny 8'],
+      ['prod', 'allow 1 · challenge 2 · deny 16'],
     ]);
     expect(rows[2].security).toMatchObject({
       tone: 'danger',

--- a/test/supervisor-actions.test.ts
+++ b/test/supervisor-actions.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { executeSupervisorAction, listSupervisorSessions } from '../server/supervisor-actions.js';
+import type { Session, SessionSummary } from '../server/types.js';
+
+function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 'sess-1',
+    globalSessionId: 'local:sess-1',
+    nodeId: 'local',
+    type: 'agent',
+    agent: 'codex',
+    mode: 'pty',
+    cwd: '/repo',
+    createdAt: '2026-05-16T00:00:00.000Z',
+    lastActivity: '2026-05-16T00:00:00.000Z',
+    idle: true,
+    status: 'active',
+    controlMode: 'agent-driven',
+    controlFreshness: 'fresh',
+    controlState: {
+      controlMode: 'agent-driven',
+      activeActors: [{ kind: 'agent', id: 'codex' }],
+      activeWorker: { kind: 'agent', id: 'codex' },
+      lastInterventionAt: null,
+      lastInterventionBy: null,
+      lastInterventionEventId: null,
+      controlFreshness: 'fresh',
+    },
+    ...overrides,
+  } as SessionSummary;
+}
+
+function boundary(sessions: Record<string, SessionSummary>, writes: string[] = []) {
+  return {
+    list: () => Object.values(sessions),
+    get: (id: string) => sessions[id] as Session | undefined,
+    supervisorWrite: (id: string, input: { payload: string }) => {
+      writes.push(`${id}:${input.payload}`);
+      return { eventId: `evt-${id}`, modeBefore: 'agent-driven', modeAfter: 'co-driven' };
+    },
+  };
+}
+
+describe('typed supervisor actions', () => {
+  it('lists typed action eligibility without exposing raw terminal state', () => {
+    const response = listSupervisorSessions([
+      session(),
+      session({ id: 'web-1', mode: 'web' }),
+      session({ id: 'stale-1', controlFreshness: 'stale' }),
+    ]);
+
+    expect(response).toMatchObject({ command: 'supervisor.sessions', count: 3 });
+    expect(response.sessions[0]?.actions).toEqual({
+      sendText: { allowed: true },
+      submit: { allowed: true },
+    });
+    expect(response.sessions[1]?.actions.sendText).toMatchObject({
+      allowed: false,
+      reasonCode: 'SESSION_MODE_UNSUPPORTED',
+    });
+    expect(JSON.stringify(response)).not.toContain('scrollback');
+  });
+
+  it('executes bounded sendText and submit through the supervisor boundary with hashes-only audit content', () => {
+    const writes: string[] = [];
+    const sessions = { 'sess-1': session() };
+
+    const sendText = executeSupervisorAction({
+      boundary: boundary(sessions, writes),
+      action: 'sendText',
+      targetIds: ['sess-1'],
+      text: 'hello',
+      now: new Date('2026-05-16T00:00:00.000Z'),
+    });
+    const submit = executeSupervisorAction({
+      boundary: boundary(sessions, writes),
+      action: 'submit',
+      targetIds: ['sess-1'],
+      now: new Date('2026-05-16T00:00:01.000Z'),
+    });
+
+    expect(writes).toEqual(['sess-1:hello', 'sess-1:\n']);
+    expect(sendText).toMatchObject({
+      command: 'supervisor.sendText',
+      action: 'sendText',
+      counts: { requested: 1, succeeded: 1, denied: 0, failed: 0, skipped: 0 },
+      redaction: { rawContentAvailable: false, rawContentStored: false, hashesOnly: true },
+    });
+    expect(submit.command).toBe('supervisor.submit');
+    expect(sendText.audit.content).toMatchObject({
+      rawContentAvailable: false,
+      hashSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      byteCount: 5,
+      charCount: 5,
+      lineCount: 1,
+      redacted: true,
+    });
+    expect(JSON.stringify(sendText)).not.toContain('hello');
+  });
+
+  it('refuses control sequences and stale sessions before writing', () => {
+    const writes: string[] = [];
+    const result = executeSupervisorAction({
+      boundary: boundary({ 'sess-1': session({ controlFreshness: 'stale' }) }, writes),
+      action: 'sendText',
+      targetIds: ['sess-1'],
+      text: '\u001b[200~paste',
+    });
+
+    expect(writes).toEqual([]);
+    expect(result.counts).toMatchObject({ requested: 1, succeeded: 0, failed: 1 });
+    expect(result.results[0]?.error).toMatchObject({
+      code: 'INVALID_ARGUMENT',
+      reasonCode: 'TEXT_MUST_BE_LITERAL',
+    });
+  });
+});

--- a/test/supervisor-actions.test.ts
+++ b/test/supervisor-actions.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { executeSupervisorAction, listSupervisorSessions } from '../server/supervisor-actions.js';
+import {
+  executeSupervisorAction,
+  listSupervisorSessions,
+  type SupervisorActionSessionBoundary,
+} from '../server/supervisor-actions.js';
 import type { Session, SessionSummary } from '../server/types.js';
 
 function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
@@ -30,7 +34,7 @@ function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
   } as SessionSummary;
 }
 
-function boundary(sessions: Record<string, SessionSummary>, writes: string[] = []) {
+function boundary(sessions: Record<string, SessionSummary>, writes: string[] = []): SupervisorActionSessionBoundary {
   return {
     list: () => Object.values(sessions),
     get: (id: string) => sessions[id] as Session | undefined,
@@ -96,6 +100,103 @@ describe('typed supervisor actions', () => {
       redacted: true,
     });
     expect(JSON.stringify(sendText)).not.toContain('hello');
+  });
+
+  it.each(['sendText', 'submit'] as const)(
+    'reports capability-denied %s without writing to targets',
+    (action) => {
+      const writes: string[] = [];
+      const result = executeSupervisorAction({
+        boundary: boundary({ 'sess-1': session() }, writes),
+        action,
+        targetIds: ['sess-1'],
+        text: action === 'sendText' ? 'hello' : undefined,
+        deniedByCapability: {
+          code: 'FORBIDDEN',
+          reasonCode: 'CAPABILITY_REQUIRED',
+          message: 'missing required capability: tab:intervention:send-text',
+          retryable: false,
+          details: { capability: 'tab:intervention:send-text' },
+        },
+      });
+
+      expect(writes).toEqual([]);
+      expect(result.counts).toEqual({
+        requested: 1,
+        succeeded: 0,
+        denied: 1,
+        failed: 0,
+        skipped: 0,
+      });
+      expect(result.audit).toMatchObject({
+        partialFailure: true,
+        rawContentStored: false,
+        counts: { denied: 1 },
+      });
+      expect(result.results[0]?.error).toMatchObject({
+        code: 'FORBIDDEN',
+        reasonCode: 'CAPABILITY_REQUIRED',
+      });
+      expect(result.redaction).toEqual({
+        rawContentAvailable: false,
+        rawContentStored: false,
+        hashesOnly: true,
+      });
+      expect(JSON.stringify(result)).not.toContain('hello');
+    }
+  );
+
+  it('preserves successful target results when another supervisor action target fails upstream', () => {
+    const writes: string[] = [];
+    const sessions = {
+      'sess-1': session({ id: 'sess-1' }),
+      'sess-2': session({ id: 'sess-2' }),
+    };
+    const actionBoundary = boundary(sessions, writes);
+    actionBoundary.supervisorWrite = (id: string, input: { payload: string }) => {
+      if (id === 'sess-2') throw new Error('pty is gone');
+      writes.push(`${id}:${input.payload}`);
+      return { eventId: `evt-${id}`, modeBefore: 'agent-driven', modeAfter: 'co-driven' };
+    };
+
+    const result = executeSupervisorAction({
+      boundary: actionBoundary,
+      action: 'sendText',
+      targetIds: ['sess-1', 'sess-2'],
+      text: 'hello',
+    });
+
+    expect(writes).toEqual(['sess-1:hello']);
+    expect(result.counts).toEqual({
+      requested: 2,
+      succeeded: 1,
+      denied: 0,
+      failed: 1,
+      skipped: 0,
+    });
+    expect(result.audit).toMatchObject({
+      partialFailure: true,
+      rawContentStored: false,
+      content: {
+        rawContentAvailable: false,
+        hashSha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+        byteCount: 5,
+        charCount: 5,
+        redacted: true,
+      },
+    });
+    expect(result.results[0]).toMatchObject({ sessionId: 'sess-1', ok: true });
+    expect(result.results[1]).toMatchObject({
+      sessionId: 'sess-2',
+      ok: false,
+      error: {
+        code: 'UPSTREAM_ERROR',
+        reasonCode: 'UPSTREAM_WRITE_FAILED',
+        message: 'pty is gone',
+        retryable: true,
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain('hello');
   });
 
   it('refuses control sequences and stale sessions before writing', () => {

--- a/test/supervisor-route-handlers.test.ts
+++ b/test/supervisor-route-handlers.test.ts
@@ -1,15 +1,38 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Request, Response } from 'express';
-import { handleSupervisorSessionsRequest } from '../server/supervisor-route-handlers.js';
-import type { SessionSummary } from '../server/types.js';
+import {
+  handleSupervisorActionRequest,
+  handleSupervisorSessionsRequest,
+} from '../server/supervisor-route-handlers.js';
+import type { SupervisorActionSessionBoundary } from '../server/supervisor-actions.js';
+import type { Session, SessionSummary } from '../server/types.js';
 
 function requestWithCapabilities(capabilities: string | undefined): Request {
   return {
-    header: (name: string) => (name.toLowerCase() === 'x-relay-capabilities' ? capabilities : undefined),
+    header: (name: string) =>
+      name.toLowerCase() === 'x-relay-capabilities' ? capabilities : undefined,
   } as unknown as Request;
 }
 
-function jsonResponse(): Response & { status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn> } {
+function supervisorActionRequest(input: {
+  action?: string;
+  body?: Record<string, unknown>;
+  capabilities?: string;
+}): Request {
+  return {
+    params: { action: input.action ?? 'sendText' },
+    body: input.body ?? {},
+    header: (name: string) =>
+      name.toLowerCase() === 'x-relay-capabilities'
+        ? input.capabilities
+        : undefined,
+  } as unknown as Request;
+}
+
+function jsonResponse(): Response & {
+  status: ReturnType<typeof vi.fn>;
+  json: ReturnType<typeof vi.fn>;
+} {
   const response = {
     status: vi.fn(function status(this: Response, _code: number) {
       return this;
@@ -18,7 +41,10 @@ function jsonResponse(): Response & { status: ReturnType<typeof vi.fn>; json: Re
       return this;
     }),
   };
-  return response as unknown as Response & { status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn> };
+  return response as unknown as Response & {
+    status: ReturnType<typeof vi.fn>;
+    json: ReturnType<typeof vi.fn>;
+  };
 }
 
 function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
@@ -36,8 +62,34 @@ function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
     status: 'active',
     controlMode: 'agent-driven',
     controlFreshness: 'fresh',
+    controlState: {
+      controlMode: 'agent-driven',
+      activeActors: [{ kind: 'agent', id: 'codex' }],
+      activeWorker: { kind: 'agent', id: 'codex' },
+      lastInterventionAt: null,
+      lastInterventionBy: null,
+      lastInterventionEventId: null,
+      controlFreshness: 'fresh',
+    },
     ...overrides,
   } as SessionSummary;
+}
+
+function supervisorBoundary(
+  sessions: Record<string, SessionSummary> = { 'sess-1': session() }
+): SupervisorActionSessionBoundary & {
+  supervisorWrite: ReturnType<typeof vi.fn>;
+} {
+  const supervisorWrite = vi.fn((id: string, input: { payload: string }) => ({
+    eventId: `evt-${id}-${input.payload.length}`,
+    modeBefore: 'agent-driven' as const,
+    modeAfter: 'co-driven' as const,
+  }));
+  return {
+    list: () => Object.values(sessions),
+    get: (id: string) => sessions[id] as Session | undefined,
+    supervisorWrite,
+  };
 }
 
 describe('supervisor route handlers', () => {
@@ -57,7 +109,9 @@ describe('supervisor route handlers', () => {
       error: expect.objectContaining({
         code: 'FORBIDDEN',
         reasonCode: 'CAPABILITY_REQUIRED',
-        details: expect.objectContaining({ capability: 'tab:intervention:read' }),
+        details: expect.objectContaining({
+          capability: 'tab:intervention:read',
+        }),
       }),
     });
   });
@@ -75,6 +129,153 @@ describe('supervisor route handlers', () => {
     expect(res.status).not.toHaveBeenCalled();
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ command: 'supervisor.sessions', count: 1 })
+    );
+  });
+
+  it('rejects supervisor action requests with both id and targetIds before writing', () => {
+    const sessions = supervisorBoundary();
+    const res = jsonResponse();
+
+    handleSupervisorActionRequest(
+      supervisorActionRequest({
+        body: { id: 'sess-1', targetIds: ['sess-1'], text: 'hello' },
+        capabilities: 'session:attach,tab:intervention:send-text',
+      }),
+      res,
+      sessions
+    );
+
+    expect(sessions.supervisorWrite).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.objectContaining({
+        code: 'INVALID_ARGUMENT',
+        reasonCode: 'TARGET_SELECTOR_INVALID',
+      }),
+    });
+  });
+
+  it('rejects supervisor action requests with no selector before writing', () => {
+    const sessions = supervisorBoundary();
+    const res = jsonResponse();
+
+    handleSupervisorActionRequest(
+      supervisorActionRequest({
+        body: { text: 'hello' },
+        capabilities: 'session:attach,tab:intervention:send-text',
+      }),
+      res,
+      sessions
+    );
+
+    expect(sessions.supervisorWrite).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.objectContaining({
+        code: 'INVALID_ARGUMENT',
+        reasonCode: 'TARGET_SELECTOR_REQUIRED',
+      }),
+    });
+  });
+
+  it.each([
+    { targetIds: [], label: 'empty' },
+    { targetIds: ['sess-1', ''], label: 'blank string' },
+    { targetIds: ['sess-1', 7], label: 'non-string' },
+    { targetIds: 'sess-1', label: 'non-array' },
+  ])('rejects $label targetIds before writing', ({ targetIds }) => {
+    const sessions = supervisorBoundary();
+    const res = jsonResponse();
+
+    handleSupervisorActionRequest(
+      supervisorActionRequest({
+        body: { targetIds, text: 'hello' },
+        capabilities: 'session:attach,tab:intervention:send-text',
+      }),
+      res,
+      sessions
+    );
+
+    expect(sessions.supervisorWrite).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.objectContaining({
+        code: 'INVALID_ARGUMENT',
+        reasonCode: 'TARGET_SELECTOR_INVALID',
+      }),
+    });
+  });
+
+  it('denies missing supervisor action capability evidence before writing', () => {
+    const sessions = supervisorBoundary();
+    const res = jsonResponse();
+
+    handleSupervisorActionRequest(
+      supervisorActionRequest({ body: { id: 'sess-1', text: 'hello' } }),
+      res,
+      sessions
+    );
+
+    expect(sessions.supervisorWrite).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.objectContaining({
+        code: 'FORBIDDEN',
+        reasonCode: 'CAPABILITY_REQUIRED',
+        details: expect.objectContaining({
+          capability: 'tab:intervention:send-text',
+        }),
+      }),
+    });
+  });
+
+  it('preserves multi-target partial-failure semantics for valid supervisor action requests', () => {
+    const sessions = supervisorBoundary({
+      'sess-1': session({ id: 'sess-1' }),
+      'sess-2': session({ id: 'sess-2' }),
+    });
+    sessions.supervisorWrite.mockImplementation(
+      (id: string, input: { payload: string }) => {
+        if (id === 'sess-2') throw new Error('pty is gone');
+        return {
+          eventId: `evt-${id}-${input.payload.length}`,
+          modeBefore: 'agent-driven' as const,
+          modeAfter: 'co-driven' as const,
+        };
+      }
+    );
+    const res = jsonResponse();
+
+    handleSupervisorActionRequest(
+      supervisorActionRequest({
+        body: { targetIds: ['sess-1', 'sess-2'], text: 'hello' },
+        capabilities: 'session:attach,tab:intervention:send-text',
+      }),
+      res,
+      sessions
+    );
+
+    expect(sessions.supervisorWrite).toHaveBeenCalledTimes(2);
+    expect(sessions.supervisorWrite).toHaveBeenCalledWith(
+      'sess-1',
+      expect.objectContaining({ action: 'sendText', payload: 'hello' })
+    );
+    expect(sessions.supervisorWrite).toHaveBeenCalledWith(
+      'sess-2',
+      expect.objectContaining({ action: 'sendText', payload: 'hello' })
+    );
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'supervisor.sendText',
+        counts: {
+          requested: 2,
+          succeeded: 1,
+          denied: 0,
+          failed: 1,
+          skipped: 0,
+        },
+      })
     );
   });
 });

--- a/test/supervisor-route-handlers.test.ts
+++ b/test/supervisor-route-handlers.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { handleSupervisorSessionsRequest } from '../server/supervisor-route-handlers.js';
+import type { SessionSummary } from '../server/types.js';
+
+function requestWithCapabilities(capabilities: string | undefined): Request {
+  return {
+    header: (name: string) => (name.toLowerCase() === 'x-relay-capabilities' ? capabilities : undefined),
+  } as unknown as Request;
+}
+
+function jsonResponse(): Response & { status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn> } {
+  const response = {
+    status: vi.fn(function status(this: Response, _code: number) {
+      return this;
+    }),
+    json: vi.fn(function json(this: Response, _body: unknown) {
+      return this;
+    }),
+  };
+  return response as unknown as Response & { status: ReturnType<typeof vi.fn>; json: ReturnType<typeof vi.fn> };
+}
+
+function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 'sess-1',
+    globalSessionId: 'local:sess-1',
+    nodeId: 'local',
+    type: 'agent',
+    agent: 'codex',
+    mode: 'pty',
+    cwd: '/repo',
+    createdAt: '2026-05-16T00:00:00.000Z',
+    lastActivity: '2026-05-16T00:00:00.000Z',
+    idle: true,
+    status: 'active',
+    controlMode: 'agent-driven',
+    controlFreshness: 'fresh',
+    ...overrides,
+  } as SessionSummary;
+}
+
+describe('supervisor route handlers', () => {
+  it('requires session:read and tab:intervention:read before listing supervisor sessions', () => {
+    const sessions = { list: vi.fn(() => [session()]) };
+    const res = jsonResponse();
+
+    handleSupervisorSessionsRequest(
+      requestWithCapabilities('session:read'),
+      res,
+      sessions
+    );
+
+    expect(sessions.list).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: expect.objectContaining({
+        code: 'FORBIDDEN',
+        reasonCode: 'CAPABILITY_REQUIRED',
+        details: expect.objectContaining({ capability: 'tab:intervention:read' }),
+      }),
+    });
+  });
+
+  it('lists supervisor sessions when both read capabilities are present', () => {
+    const sessions = { list: vi.fn(() => [session()]) };
+    const res = jsonResponse();
+
+    handleSupervisorSessionsRequest(
+      requestWithCapabilities('session:read,tab:intervention:read'),
+      res,
+      sessions
+    );
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'supervisor.sessions', count: 1 })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Implements Relay-owned typed supervisor actions for selected-session intervention.
- Adds shared/server action contracts, HTTP/CLI gateway plumbing, capability gates, control-engine intervention logging, and hash/redaction-focused audit metadata.
- Keeps raw `sessions.input` distinct from the typed supervisor action surface; no raw tmux/rmux command execution is exposed as the public contract.

## Verification from implementation handoff
- `git diff --check` passed
- `npm run check` passed
- `npm test -- --run test/control-engine.test.ts test/session-control-api.test.ts test/security-policy.test.ts test/security-audit.test.ts test/cli-gateway-contract.test.ts test/supervisor-actions.test.ts` passed: 76 tests
- `npm run build` passed

## Notes
- Opened as draft because the planned docs, QA, review, and ops gates are still queued on the Kanban pipeline.
- Follow-up docs task should update `docs/CLI_GATEWAY.md` and `docs/SECURITY_POLICY.md` on this same branch before final review.

Closes #704


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added supervisor commands to list sessions, send text, and submit actions; new HTTP endpoints for supervisor operations.
  * Supervisor actions record co-driven interventions and redact payloads (hash-only audit metadata), with per-target result reporting and partial-failure semantics.

* **Documentation**
  * Extended CLI gateway docs with supervisor command specs, input/output schemas, and typed supervisor action error semantics.

* **Security**
  * Added two new high-risk capability bits for supervisor interventions and updated capability gating.

* **Tests**
  * Added extensive tests for actions, routing, capability checks, and redaction/audit behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->