### PR TITLE
feat: add prompt fanout workbench fixture block

### DIFF
--- a/frontend/src/workbench/WorkbenchBlockCreateDialog.tsx
+++ b/frontend/src/workbench/WorkbenchBlockCreateDialog.tsx
@@ -106,6 +106,7 @@ export interface WorkbenchBlockCreateDialogProps {
 const ALL_SUPPORTED_KINDS: WorkbenchBlockDescriptor['kind'][] = [
   'terminal',
   'agent',
+  'prompt-fanout',
   'file',
   'markdown',
   'work-context',

--- a/frontend/src/workbench/block-create-helpers.ts
+++ b/frontend/src/workbench/block-create-helpers.ts
@@ -14,6 +14,7 @@ import type {
   CustomBlockDescriptor,
   FileBlockDescriptor,
   MarkdownBlockDescriptor,
+  PromptFanoutBlockDescriptor,
   TerminalBlockDescriptor,
   WorkbenchBlockDescriptor,
   WorkContextBlockDescriptor,
@@ -84,6 +85,14 @@ export function buildBlockDescriptor(
             displayName: request.title,
           },
         },
+      };
+      return desc;
+    }
+    case 'prompt-fanout': {
+      const desc: PromptFanoutBlockDescriptor = {
+        ...base,
+        kind: 'prompt-fanout',
+        meta: { fixture: 'all-success', dryRunOnly: true },
       };
       return desc;
     }

--- a/frontend/src/workbench/block-registry.ts
+++ b/frontend/src/workbench/block-registry.ts
@@ -82,7 +82,7 @@ export function registeredKinds(): ReadonlySet<WorkbenchBlockKind> {
 // ---------------------------------------------------------------------------
 
 /**
- * Register all seven first-party block renderers.
+ * Register all eight first-party block renderers.
  * Call once at application startup (e.g. before rendering the app root).
  * Safe to call multiple times — last writer wins on duplicate registration.
  *
@@ -91,10 +91,20 @@ export function registeredKinds(): ReadonlySet<WorkbenchBlockKind> {
  * server-side type-checking or shared module evaluation.
  */
 export async function initFirstPartyBlocks(): Promise<void> {
-  const [terminal, agent, workContext, file, artifact, markdown, custom] =
+  const [
+    terminal,
+    agent,
+    promptFanout,
+    workContext,
+    file,
+    artifact,
+    markdown,
+    custom,
+  ] =
     await Promise.all([
       import('./blocks/terminal.js'),
       import('./blocks/agent.js'),
+      import('./blocks/prompt-fanout.js'),
       import('./blocks/work-context.js'),
       import('./blocks/file.js'),
       import('./blocks/artifact.js'),
@@ -104,6 +114,7 @@ export async function initFirstPartyBlocks(): Promise<void> {
 
   registerBlockRenderer('terminal', terminal.TerminalBlock);
   registerBlockRenderer('agent', agent.AgentBlock);
+  registerBlockRenderer('prompt-fanout', promptFanout.PromptFanoutBlock);
   registerBlockRenderer('work-context', workContext.WorkContextBlock);
   registerBlockRenderer('file', file.FileBlock);
   registerBlockRenderer('artifact', artifact.ArtifactBlock);

--- a/frontend/src/workbench/blocks/prompt-fanout.css
+++ b/frontend/src/workbench/blocks/prompt-fanout.css
@@ -1,0 +1,220 @@
+/* ===== PromptFanoutBlock ===== */
+
+.block-prompt-fanout {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-sm);
+}
+
+.block-prompt-fanout--loading,
+.block-prompt-fanout--empty {
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.block-prompt-fanout--partial-failure {
+  border-left: 2px solid var(--status-warning);
+}
+
+.block-prompt-fanout--denied {
+  border-left: 2px solid var(--status-error);
+}
+
+.block-prompt-fanout__spinner {
+  color: var(--status-info);
+  font-size: var(--font-size-lg);
+  animation: prompt-fanout-spin 1s linear infinite;
+}
+
+@keyframes prompt-fanout-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.block-prompt-fanout__header,
+.block-prompt-fanout__section,
+.block-prompt-fanout__footer {
+  flex-shrink: 0;
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--border);
+}
+
+.block-prompt-fanout__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.block-prompt-fanout__kind,
+.block-prompt-fanout__label,
+.block-prompt-fanout__detail,
+.block-prompt-fanout__meta-line,
+.block-prompt-fanout__target-meta,
+.block-prompt-fanout__footer {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.block-prompt-fanout__kind,
+.block-prompt-fanout__label {
+  letter-spacing: 0.05em;
+}
+
+.block-prompt-fanout__title,
+.block-prompt-fanout__heading,
+.block-prompt-fanout__prompt-title {
+  color: var(--text);
+  font-size: var(--font-size-base);
+  font-weight: 600;
+}
+
+.block-prompt-fanout__run-state,
+.block-prompt-fanout__status {
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  padding: var(--space-2xs) var(--space-xs);
+  font-size: var(--font-size-xs);
+}
+
+.block-prompt-fanout__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.block-prompt-fanout__section--actions {
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.block-prompt-fanout__meta-line,
+.block-prompt-fanout__footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.block-prompt-fanout__prompt-preview,
+.block-prompt-fanout__target-detail {
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.block-prompt-fanout__dry-run {
+  min-height: 32px;
+  border: 1px solid var(--accent);
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+}
+
+.block-prompt-fanout__dry-run:hover:not(:disabled),
+.block-prompt-fanout__dry-run:focus-visible {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  outline: none;
+}
+
+.block-prompt-fanout__dry-run:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.block-prompt-fanout__notice {
+  color: var(--status-success);
+  font-size: var(--font-size-xs);
+}
+
+.block-prompt-fanout__targets {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.block-prompt-fanout__target {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  padding: var(--space-xs) 0;
+  border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+}
+
+.block-prompt-fanout__target--muted {
+  opacity: 0.65;
+}
+
+.block-prompt-fanout__target-main {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-height: 32px;
+}
+
+.block-prompt-fanout__target-label {
+  color: var(--text);
+}
+
+.block-prompt-fanout__target-runtime {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.block-prompt-fanout__target-meta {
+  display: flex;
+  gap: var(--space-sm);
+}
+
+.block-prompt-fanout__target--succeeded .block-prompt-fanout__status {
+  border-color: var(--status-success);
+  color: var(--status-success);
+}
+
+.block-prompt-fanout__target--running .block-prompt-fanout__status,
+.block-prompt-fanout__target--queued .block-prompt-fanout__status {
+  border-color: var(--status-info);
+  color: var(--status-info);
+}
+
+.block-prompt-fanout__target--failed .block-prompt-fanout__status,
+.block-prompt-fanout__target--denied .block-prompt-fanout__status,
+.block-prompt-fanout__target--timeout .block-prompt-fanout__status {
+  border-color: var(--status-error);
+  color: var(--status-error);
+}
+
+.block-prompt-fanout__target--skipped .block-prompt-fanout__status {
+  border-color: var(--status-warning);
+  color: var(--status-warning);
+}
+
+.block-prompt-fanout__section--errors {
+  color: var(--status-error);
+}
+
+.block-prompt-fanout__error {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  color: var(--status-error);
+  font-size: var(--font-size-xs);
+}
+
+.block-prompt-fanout__footer {
+  margin-top: auto;
+  border-bottom: none;
+}

--- a/frontend/src/workbench/blocks/prompt-fanout.tsx
+++ b/frontend/src/workbench/blocks/prompt-fanout.tsx
@@ -1,0 +1,274 @@
+/**
+ * PromptFanoutBlock — issue #705 mock comparison workbench shell.
+ *
+ * Renders Relay-owned PromptFanoutRun fixtures/schema data only. The dry-run
+ * action emits an audit event for previewability and intentionally never writes
+ * to a terminal, tmux pane, provider process, or rmux runtime.
+ */
+
+import React, { useMemo, useState } from 'react';
+
+import type {
+  PromptFanoutRun,
+  PromptFanoutTarget,
+  PromptFanoutTargetResult,
+} from '../../../../shared/prompt-fanout-run.js';
+import {
+  promptFanoutHasPartialFailure,
+  promptFanoutStatusCounts,
+  selectedPromptFanoutTargets,
+  unselectedPromptFanoutTargets,
+} from '../../../../shared/prompt-fanout-run.js';
+import { getPromptFanoutRunFixture } from '../../../../shared/prompt-fanout-fixtures.js';
+import type { WorkbenchBlockRenderer } from '../../../../shared/workbench-block-types.js';
+
+import './prompt-fanout.css';
+
+type ResultByTarget = Map<string, PromptFanoutTargetResult>;
+
+const STATUS_LABELS: Record<PromptFanoutTargetResult['status'], string> = {
+  queued: 'queued',
+  running: 'running',
+  succeeded: 'success',
+  failed: 'failed',
+  denied: 'denied',
+  timeout: 'timeout',
+  skipped: 'skipped',
+};
+
+function formatDuration(durationMs?: number): string {
+  if (durationMs === undefined) return 'pending';
+  if (durationMs < 1_000) return `${durationMs}ms`;
+  return `${Math.round(durationMs / 100) / 10}s`;
+}
+
+function targetRuntime(target: PromptFanoutTarget): string {
+  return target.actorRef?.runtime ?? target.actorRef?.providerId ?? 'unknown';
+}
+
+function TargetRow({
+  target,
+  result,
+  muted = false,
+}: {
+  target: PromptFanoutTarget;
+  result?: PromptFanoutTargetResult | undefined;
+  muted?: boolean;
+}) {
+  const status = result?.status ?? (target.eligible ? 'queued' : 'skipped');
+  const detail =
+    result?.response?.summary ?? result?.error?.message ?? target.deniedReason;
+
+  return (
+    <div
+      className={[
+        'block-prompt-fanout__target',
+        `block-prompt-fanout__target--${status}`,
+        muted ? 'block-prompt-fanout__target--muted' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div className="block-prompt-fanout__target-main">
+        <span className="block-prompt-fanout__status">
+          {STATUS_LABELS[status]}
+        </span>
+        <span className="block-prompt-fanout__target-label">
+          {target.label}
+        </span>
+        <span className="block-prompt-fanout__target-runtime">
+          {targetRuntime(target)}
+        </span>
+      </div>
+      <div className="block-prompt-fanout__target-meta">
+        <span>{target.nodeLabel ?? target.sessionRef?.nodeId ?? 'node unknown'}</span>
+        <span>{formatDuration(result?.durationMs)}</span>
+      </div>
+      {detail && <div className="block-prompt-fanout__target-detail">{detail}</div>}
+    </div>
+  );
+}
+
+function EmptyState({ run }: { run?: PromptFanoutRun }) {
+  return (
+    <div
+      className="block-prompt-fanout block-prompt-fanout--empty"
+      aria-label="prompt fanout empty state"
+    >
+      <div className="block-prompt-fanout__heading">no eligible targets</div>
+      <div className="block-prompt-fanout__detail">
+        no selected agent sessions are eligible for this dry-run fixture. relay
+        will not broadcast to every session by default.
+      </div>
+      {run && (
+        <div className="block-prompt-fanout__detail">run: {run.id}</div>
+      )}
+    </div>
+  );
+}
+
+export const PromptFanoutBlock: WorkbenchBlockRenderer<'prompt-fanout'> = ({
+  descriptor,
+  context,
+}) => {
+  const [dryRunNotice, setDryRunNotice] = useState<string | null>(null);
+  const meta = descriptor.meta;
+  const run = meta.run ?? getPromptFanoutRunFixture(meta.fixture ?? 'all-success');
+
+  const selectedTargets = useMemo(
+    () => selectedPromptFanoutTargets(run),
+    [run]
+  );
+  const unselectedTargets = useMemo(
+    () => unselectedPromptFanoutTargets(run),
+    [run]
+  );
+  const resultByTarget: ResultByTarget = useMemo(
+    () => new Map(run.results.map((result) => [result.targetId, result])),
+    [run.results]
+  );
+  const counts = useMemo(() => promptFanoutStatusCounts(run), [run]);
+  const partialFailure = promptFanoutHasPartialFailure(run);
+  const loading = meta.loading === true || run.state === 'loading';
+
+  const dryRunDisabled = selectedTargets.length === 0 || loading;
+
+  function handleDryRun() {
+    const selectedTargetIds = selectedTargets.map((target) => target.id);
+    context.emitAuditEvent({
+      type: 'prompt-fanout.dry-run',
+      payload: {
+        runId: run.id,
+        workContextId: run.workContextId,
+        selectedTargetIds,
+        sendsTerminalInput: false,
+      },
+    });
+    setDryRunNotice(
+      `dry-run queued for ${selectedTargetIds.length} selected target${
+        selectedTargetIds.length === 1 ? '' : 's'
+      }; terminal input not sent`
+    );
+  }
+
+  if (loading) {
+    return (
+      <div
+        className="block-prompt-fanout block-prompt-fanout--loading"
+        aria-label="prompt fanout loading state"
+      >
+        <span className="block-prompt-fanout__spinner">&#x280B;</span>
+        <span className="block-prompt-fanout__detail">
+          loading selected target comparison…
+        </span>
+      </div>
+    );
+  }
+
+  if (selectedTargets.length === 0 || run.allTargets.length === 0) {
+    return <EmptyState run={run} />;
+  }
+
+  return (
+    <div
+      className={[
+        'block-prompt-fanout',
+        partialFailure ? 'block-prompt-fanout--partial-failure' : '',
+        run.state === 'denied' ? 'block-prompt-fanout--denied' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      aria-label={`prompt fanout run: ${descriptor.title}`}
+    >
+      <div className="block-prompt-fanout__header">
+        <div>
+          <div className="block-prompt-fanout__kind">prompt fanout</div>
+          <div className="block-prompt-fanout__title">{descriptor.title}</div>
+        </div>
+        <div className="block-prompt-fanout__run-state">{run.state}</div>
+      </div>
+
+      <div className="block-prompt-fanout__section">
+        <div className="block-prompt-fanout__label">prompt</div>
+        <div className="block-prompt-fanout__prompt-title">
+          {run.prompt.title}
+        </div>
+        <div className="block-prompt-fanout__prompt-preview">
+          {run.prompt.bodyPreview}
+        </div>
+        <div className="block-prompt-fanout__meta-line">
+          <span>work context: {run.workContextId}</span>
+          <span>tokens: {run.prompt.tokenEstimate ?? 'n/a'}</span>
+          <span>{run.prompt.dryRun ? 'dry-run only' : 'live disabled'}</span>
+        </div>
+      </div>
+
+      <div className="block-prompt-fanout__section block-prompt-fanout__section--actions">
+        <button
+          type="button"
+          className="block-prompt-fanout__dry-run"
+          onClick={handleDryRun}
+          disabled={dryRunDisabled}
+        >
+          dry-run selected targets
+        </button>
+        <span className="block-prompt-fanout__detail">
+          no broadcast-to-all default; {selectedTargets.length} of{' '}
+          {run.allTargets.length} sessions selected
+        </span>
+        {dryRunNotice && (
+          <span className="block-prompt-fanout__notice">{dryRunNotice}</span>
+        )}
+      </div>
+
+      <div className="block-prompt-fanout__section">
+        <div className="block-prompt-fanout__label">selected targets</div>
+        <div className="block-prompt-fanout__targets">
+          {selectedTargets.map((target) => (
+            <TargetRow
+              key={target.id}
+              target={target}
+              result={resultByTarget.get(target.id)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {unselectedTargets.length > 0 && (
+        <div className="block-prompt-fanout__section">
+          <div className="block-prompt-fanout__label">all sessions not selected</div>
+          <div className="block-prompt-fanout__targets">
+            {unselectedTargets.map((target) => (
+              <TargetRow
+                key={target.id}
+                target={target}
+                result={resultByTarget.get(target.id)}
+                muted
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {(partialFailure || run.errors.length > 0) && (
+        <div className="block-prompt-fanout__section block-prompt-fanout__section--errors">
+          <div className="block-prompt-fanout__label">errors</div>
+          {run.errors.map((error) => (
+            <div key={`${error.code}:${error.message}`} className="block-prompt-fanout__error">
+              <span>{error.code}</span>
+              <span>{error.message}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="block-prompt-fanout__footer">
+        <span>run: {run.id}</span>
+        <span>success: {counts.succeeded}</span>
+        <span>failed: {counts.failed + counts.denied + counts.timeout}</span>
+      </div>
+    </div>
+  );
+};
+
+export default PromptFanoutBlock;

--- a/shared/prompt-fanout-fixtures.ts
+++ b/shared/prompt-fanout-fixtures.ts
@@ -1,0 +1,341 @@
+import {
+  PROMPT_FANOUT_RUN_SCHEMA_VERSION,
+  type PromptFanoutRun,
+  type PromptFanoutTarget,
+  type PromptFanoutTargetResult,
+} from './prompt-fanout-run.js';
+
+export type PromptFanoutFixtureKey =
+  | 'all-success'
+  | 'mixed-success-failure'
+  | 'denied-target'
+  | 'timeout'
+  | 'empty-no-eligible-targets'
+  | 'loading';
+
+const now = '2026-05-21T12:00:00.000Z';
+
+const TARGET_CLAUDE_LOCAL = 'target:claude-local';
+const TARGET_CODEX_NIGHTLY = 'target:codex-nightly';
+const TARGET_HERMES_REVIEW = 'target:hermes-review';
+const TARGET_OPENCODE_MOBILE = 'target:opencode-mobile';
+
+const baseTargets: PromptFanoutTarget[] = [
+  {
+    id: TARGET_CLAUDE_LOCAL,
+    label: 'claude local session',
+    actorRef: {
+      kind: 'actor',
+      id: 'actor:claude-local',
+      displayName: 'claude',
+      runtime: 'claude',
+      providerId: 'claude-code',
+    },
+    sessionRef: {
+      nodeId: 'local-devbox',
+      sessionId: 'sess-claude-001',
+      tabKind: 'agent',
+      cwd: '/workspace/relay-ide',
+    },
+    nodeLabel: 'devbox',
+    selected: true,
+    eligible: true,
+  },
+  {
+    id: TARGET_CODEX_NIGHTLY,
+    label: 'codex nightly worktree',
+    actorRef: {
+      kind: 'actor',
+      id: 'actor:codex-nightly',
+      displayName: 'codex',
+      runtime: 'codex',
+      providerId: 'openai-codex',
+    },
+    sessionRef: {
+      nodeId: 'local-devbox',
+      sessionId: 'sess-codex-002',
+      tabKind: 'agent',
+      cwd: '/workspace/relay-ide/.worktrees/nightly',
+    },
+    nodeLabel: 'devbox',
+    selected: true,
+    eligible: true,
+  },
+  {
+    id: TARGET_HERMES_REVIEW,
+    label: 'hermes review lane',
+    actorRef: {
+      kind: 'actor',
+      id: 'actor:hermes-review',
+      displayName: 'hermes reviewer',
+      runtime: 'hermes',
+      providerId: 'hermes-agent',
+    },
+    sessionRef: {
+      nodeId: 'remote-mac',
+      sessionId: 'sess-hermes-003',
+      tabKind: 'agent',
+      cwd: '/workspace/relay-ide-review',
+    },
+    nodeLabel: 'remote mac',
+    selected: false,
+    eligible: true,
+  },
+  {
+    id: TARGET_OPENCODE_MOBILE,
+    label: 'opencode mobile smoke',
+    actorRef: {
+      kind: 'actor',
+      id: 'actor:opencode-mobile',
+      displayName: 'opencode',
+      runtime: 'opencode',
+      providerId: 'opencode',
+    },
+    sessionRef: {
+      nodeId: 'tablet-node',
+      sessionId: 'sess-opencode-004',
+      tabKind: 'agent',
+      cwd: '/workspace/mobile',
+    },
+    nodeLabel: 'tablet',
+    selected: false,
+    eligible: false,
+    deniedReason: 'node grants do not allow prompt fanout dry-run preview',
+  },
+];
+
+function prompt(title: string, bodyPreview: string) {
+  return {
+    id: `prompt:${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`,
+    title,
+    summary: 'compare implementation plan quality across selected agent sessions',
+    bodyPreview,
+    authorActorId: 'actor:operator',
+    createdAt: now,
+    tokenEstimate: 420,
+    dryRun: true,
+    source: 'fixture' as const,
+  };
+}
+
+function stripUndefined<T extends Record<string, unknown>>(value: T): T {
+  for (const key of Object.keys(value) as Array<keyof T>) {
+    if (value[key] === undefined) {
+      delete value[key];
+    }
+  }
+  return value;
+}
+
+type PromptFanoutTargetResultOverride = Partial<
+  Omit<PromptFanoutTargetResult, 'response' | 'startedAt' | 'completedAt' | 'durationMs'>
+> & {
+  response?: PromptFanoutTargetResult['response'] | undefined;
+  startedAt?: string | undefined;
+  completedAt?: string | undefined;
+  durationMs?: number | undefined;
+};
+
+function result(
+  targetId: string,
+  status: PromptFanoutTargetResult['status'],
+  summary: string,
+  overrides: PromptFanoutTargetResultOverride = {}
+): PromptFanoutTargetResult {
+  const base: PromptFanoutTargetResult = {
+    targetId,
+    status,
+    startedAt: '2026-05-21T12:00:05.000Z',
+    completedAt: '2026-05-21T12:01:30.000Z',
+    durationMs: 85_000,
+  };
+  if (status === 'succeeded') {
+    base.response = {
+      summary,
+      excerpt: summary,
+      normalizedAt: '2026-05-21T12:01:30.000Z',
+      tokenCount: 260,
+    };
+  }
+  return stripUndefined({ ...base, ...overrides }) as PromptFanoutTargetResult;
+}
+
+function makeRun(
+  id: string,
+  state: PromptFanoutRun['state'],
+  allTargets: PromptFanoutTarget[],
+  selectedTargetIds: string[],
+  results: PromptFanoutTargetResult[],
+  errors: PromptFanoutRun['errors'] = []
+): PromptFanoutRun {
+  return stripUndefined({
+    schemaVersion: PROMPT_FANOUT_RUN_SCHEMA_VERSION,
+    id,
+    workContextId: 'wc:issue-705-prompt-fanout',
+    state,
+    prompt: prompt(
+      'implementation comparison',
+      'given the scoped issue, propose the safest workbench-only implementation plan.'
+    ),
+    allTargets,
+    selectedTargetIds,
+    results,
+    errors,
+    createdAt: now,
+    updatedAt: '2026-05-21T12:01:45.000Z',
+    startedAt: '2026-05-21T12:00:05.000Z',
+    completedAt:
+      state === 'running' || state === 'loading' ? undefined : '2026-05-21T12:01:45.000Z',
+  }) as PromptFanoutRun;
+}
+
+export const promptFanoutRunFixtures: Record<
+  PromptFanoutFixtureKey,
+  PromptFanoutRun
+> = {
+  'all-success': makeRun(
+    'pfr:all-success',
+    'completed',
+    baseTargets,
+    [TARGET_CLAUDE_LOCAL, TARGET_CODEX_NIGHTLY],
+    [
+      result(
+        TARGET_CLAUDE_LOCAL,
+        'succeeded',
+        'prefers a schema-first slice with source-level renderer tests and no live sends.'
+      ),
+      result(
+        TARGET_CODEX_NIGHTLY,
+        'succeeded',
+        'recommends fixtures plus a dry-run audit event before any runtime integration.'
+      ),
+    ]
+  ),
+  'mixed-success-failure': makeRun(
+    'pfr:mixed-success-failure',
+    'partial-failure',
+    baseTargets,
+    [TARGET_CLAUDE_LOCAL, TARGET_CODEX_NIGHTLY],
+    [
+      result(
+        TARGET_CLAUDE_LOCAL,
+        'succeeded',
+        'identifies explicit selected targets as the safety boundary.'
+      ),
+      result(TARGET_CODEX_NIGHTLY, 'failed', 'failed', {
+        response: undefined,
+        error: {
+          code: 'MOCK_PROVIDER_ERROR',
+          message: 'fixture provider returned a malformed response summary',
+          retryable: true,
+        },
+      }),
+    ],
+    [
+      {
+        code: 'PARTIAL_FAILURE',
+        message: 'one selected target failed; successful responses remain visible',
+        retryable: true,
+      },
+    ]
+  ),
+  'denied-target': makeRun(
+    'pfr:denied-target',
+    'denied',
+    baseTargets.map((target) =>
+      target.id === TARGET_OPENCODE_MOBILE
+        ? { ...target, selected: true }
+        : target
+    ),
+    [TARGET_CLAUDE_LOCAL, TARGET_OPENCODE_MOBILE],
+    [
+      result(
+        TARGET_CLAUDE_LOCAL,
+        'succeeded',
+        'safe target returned a normal response summary.'
+      ),
+      result(TARGET_OPENCODE_MOBILE, 'denied', 'denied', {
+        response: undefined,
+        error: {
+          code: 'TARGET_DENIED',
+          message: 'capability grant missing for this target',
+          retryable: false,
+        },
+      }),
+    ],
+    [
+      {
+        code: 'TARGET_DENIED',
+        message: 'one selected target was denied by capability policy',
+        retryable: false,
+      },
+    ]
+  ),
+  timeout: makeRun(
+    'pfr:timeout',
+    'timeout',
+    baseTargets,
+    [TARGET_CLAUDE_LOCAL, TARGET_CODEX_NIGHTLY],
+    [
+      result(
+        TARGET_CLAUDE_LOCAL,
+        'succeeded',
+        'completed before the timeout threshold.'
+      ),
+      result(TARGET_CODEX_NIGHTLY, 'timeout', 'timeout', {
+        response: undefined,
+        completedAt: '2026-05-21T12:03:05.000Z',
+        durationMs: 180_000,
+        error: {
+          code: 'TARGET_TIMEOUT',
+          message: 'target did not produce a normalized summary before timeout',
+          retryable: true,
+        },
+      }),
+    ],
+    [
+      {
+        code: 'TARGET_TIMEOUT',
+        message: 'one selected target timed out',
+        retryable: true,
+      },
+    ]
+  ),
+  'empty-no-eligible-targets': makeRun(
+    'pfr:empty-no-eligible-targets',
+    'empty',
+    baseTargets.map((target) => ({
+      ...target,
+      selected: false,
+      eligible: false,
+      deniedReason: 'no eligible dry-run target in this WorkContext fixture',
+    })),
+    [],
+    []
+  ),
+  loading: makeRun(
+    'pfr:loading',
+    'loading',
+    baseTargets,
+    [TARGET_CLAUDE_LOCAL, TARGET_CODEX_NIGHTLY],
+    [
+      result(TARGET_CLAUDE_LOCAL, 'running', 'running', {
+        response: undefined,
+        completedAt: undefined,
+        durationMs: undefined,
+      }),
+      result(TARGET_CODEX_NIGHTLY, 'queued', 'queued', {
+        response: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+        durationMs: undefined,
+      }),
+    ]
+  ),
+};
+
+export function getPromptFanoutRunFixture(
+  key: PromptFanoutFixtureKey = 'all-success'
+): PromptFanoutRun {
+  return promptFanoutRunFixtures[key];
+}

--- a/shared/prompt-fanout-run.ts
+++ b/shared/prompt-fanout-run.ts
@@ -1,0 +1,149 @@
+/**
+ * Prompt fanout run schema — issue #705.
+ *
+ * Relay-owned model for comparing one prompt across an explicit set of
+ * selected agent/session targets. This is a mock/workbench data contract only:
+ * no terminal input, provider chrome parsing, or rmux dependency lives here.
+ */
+
+import type { SessionRef, WorkContextRef } from './work-context.js';
+
+export const PROMPT_FANOUT_RUN_SCHEMA_VERSION = 1;
+
+export type PromptFanoutRunId = string;
+export type PromptFanoutTargetId = string;
+
+export type PromptFanoutRunState =
+  | 'draft'
+  | 'loading'
+  | 'running'
+  | 'completed'
+  | 'partial-failure'
+  | 'denied'
+  | 'timeout'
+  | 'empty';
+
+export type PromptFanoutTargetStatus =
+  | 'queued'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'denied'
+  | 'timeout'
+  | 'skipped';
+
+export interface PromptFanoutActorRef {
+  kind: 'actor';
+  id: string;
+  displayName?: string;
+  runtime?: 'claude' | 'codex' | 'opencode' | 'hermes' | 'custom';
+  providerId?: string;
+}
+
+export interface PromptFanoutTarget {
+  id: PromptFanoutTargetId;
+  label: string;
+  actorRef?: PromptFanoutActorRef;
+  sessionRef?: SessionRef;
+  nodeLabel?: string;
+  selected: boolean;
+  eligible: boolean;
+  deniedReason?: string;
+}
+
+export interface PromptFanoutPromptMetadata {
+  id: string;
+  title: string;
+  summary: string;
+  bodyPreview: string;
+  authorActorId?: string;
+  createdAt: string;
+  tokenEstimate?: number;
+  dryRun: boolean;
+  source: 'manual' | 'fixture' | 'work-context';
+}
+
+export interface PromptFanoutResponseSummary {
+  summary: string;
+  excerpt: string;
+  normalizedAt: string;
+  tokenCount?: number;
+}
+
+export interface PromptFanoutErrorSummary {
+  code: string;
+  message: string;
+  retryable: boolean;
+}
+
+export interface PromptFanoutTargetResult {
+  targetId: PromptFanoutTargetId;
+  status: PromptFanoutTargetStatus;
+  response?: PromptFanoutResponseSummary;
+  error?: PromptFanoutErrorSummary;
+  startedAt?: string;
+  completedAt?: string;
+  durationMs?: number;
+}
+
+export interface PromptFanoutRun {
+  schemaVersion: typeof PROMPT_FANOUT_RUN_SCHEMA_VERSION;
+  id: PromptFanoutRunId;
+  workContextId: WorkContextRef;
+  state: PromptFanoutRunState;
+  prompt: PromptFanoutPromptMetadata;
+  allTargets: ReadonlyArray<PromptFanoutTarget>;
+  selectedTargetIds: ReadonlyArray<PromptFanoutTargetId>;
+  results: ReadonlyArray<PromptFanoutTargetResult>;
+  errors: ReadonlyArray<PromptFanoutErrorSummary>;
+  createdAt: string;
+  updatedAt: string;
+  startedAt?: string;
+  completedAt?: string;
+}
+
+export function selectedPromptFanoutTargets(
+  run: PromptFanoutRun
+): PromptFanoutTarget[] {
+  const selectedIds = new Set(run.selectedTargetIds);
+  return run.allTargets.filter(
+    (target) => target.selected && selectedIds.has(target.id)
+  );
+}
+
+export function unselectedPromptFanoutTargets(
+  run: PromptFanoutRun
+): PromptFanoutTarget[] {
+  const selectedIds = new Set(run.selectedTargetIds);
+  return run.allTargets.filter(
+    (target) => !target.selected || !selectedIds.has(target.id)
+  );
+}
+
+export function promptFanoutHasPartialFailure(run: PromptFanoutRun): boolean {
+  const statuses = run.results.map((result) => result.status);
+  return (
+    statuses.includes('succeeded') &&
+    statuses.some((status) =>
+      ['failed', 'denied', 'timeout', 'skipped'].includes(status)
+    )
+  );
+}
+
+export function promptFanoutStatusCounts(
+  run: PromptFanoutRun
+): Record<PromptFanoutTargetStatus, number> {
+  const counts: Record<PromptFanoutTargetStatus, number> = {
+    queued: 0,
+    running: 0,
+    succeeded: 0,
+    failed: 0,
+    denied: 0,
+    timeout: 0,
+    skipped: 0,
+  };
+  for (const result of run.results) {
+    counts[result.status] += 1;
+  }
+  return counts;
+}

--- a/shared/workbench-block-types.ts
+++ b/shared/workbench-block-types.ts
@@ -34,6 +34,8 @@ import type {
 } from './work-context.js';
 import type { WorkbenchBlockEnvironmentRef } from './workbench-block-environment.js';
 import type { FileResourceRef } from './file-resource-ref.js';
+import type { PromptFanoutFixtureKey } from './prompt-fanout-fixtures.js';
+import type { PromptFanoutRun } from './prompt-fanout-run.js';
 
 // ---------------------------------------------------------------------------
 // Re-exported re-used types for convenience
@@ -128,6 +130,7 @@ export type JsonValue =
 export type WorkbenchBlockKind =
   | 'terminal'
   | 'agent'
+  | 'prompt-fanout'
   | 'work-context'
   | 'file'
   | 'artifact'
@@ -193,6 +196,22 @@ export interface AgentBlockDescriptor extends WorkbenchBlockDescriptorBase {
      * Uses the local `ActorRef` placeholder — see note above.
      */
     actorRef: ActorRef;
+  };
+}
+
+/** Renders a mock PromptFanoutRun comparison across selected targets. */
+export interface PromptFanoutBlockDescriptor
+  extends WorkbenchBlockDescriptorBase {
+  kind: 'prompt-fanout';
+  meta: {
+    /** Inline run payload for mock/API-backed shells. */
+    run?: PromptFanoutRun;
+    /** Fixture key used when no inline run is supplied. */
+    fixture?: PromptFanoutFixtureKey;
+    /** Force the renderer's loading state for testable shell coverage. */
+    loading?: boolean;
+    /** Explicitly marks this block as dry-run only; no terminal send path. */
+    dryRunOnly?: boolean;
   };
 }
 
@@ -287,6 +306,7 @@ export interface CustomBlockDescriptor extends WorkbenchBlockDescriptorBase {
 export type WorkbenchBlockDescriptor =
   | TerminalBlockDescriptor
   | AgentBlockDescriptor
+  | PromptFanoutBlockDescriptor
   | WorkContextBlockDescriptor
   | FileBlockDescriptor
   | ArtifactBlockDescriptor

--- a/shared/workbench-prompt-hooks.ts
+++ b/shared/workbench-prompt-hooks.ts
@@ -29,6 +29,7 @@
  *   - `agent` blocks emit only the `actorRef.id` and `actorRef.displayName`.
  *   - `terminal` blocks emit only the `sessionRef.sessionId`.
  *   - `custom` blocks emit only `rendererId` and `proposalId` (if present).
+ *   - `prompt-fanout` blocks emit run id/state/counts only; never prompt text or responses.
  *   - `work-context` blocks emit only the `workContextRef` id string.
  *   - `artifact` blocks emit only `artifactRef.kind` and `artifactRef.title`.
  *
@@ -47,9 +48,10 @@ import type { RelayCapabilityBit } from './security-policy.js';
 // Known block-kind guard (forward-compat helper)
 // ---------------------------------------------------------------------------
 
-const KNOWN_BLOCK_KINDS: ReadonlySet<WorkbenchBlockKind> = new Set([
+const KNOWN_BLOCK_KINDS: ReadonlySet<WorkbenchBlockKind> = new Set<WorkbenchBlockKind>([
   'terminal',
   'agent',
+  'prompt-fanout',
   'work-context',
   'file',
   'artifact',
@@ -92,6 +94,19 @@ export interface AgentBlockExcerpt {
   kind: 'agent';
   actorId: string;
   actorDisplayName?: string | undefined;
+}
+
+/**
+ * Status excerpt for a `prompt-fanout` block.
+ * Only run identity and counts are safe to surface — never prompt text, raw
+ * responses, errors, target labels, cwd, or provider transcript data.
+ */
+export interface PromptFanoutBlockExcerpt {
+  kind: 'prompt-fanout';
+  runId: string | undefined;
+  state: string | undefined;
+  selectedTargetCount: number | undefined;
+  resultCount: number | undefined;
 }
 
 /**
@@ -145,6 +160,7 @@ export interface CustomBlockExcerpt {
 export type WorkbenchBlockExcerpt =
   | TerminalBlockExcerpt
   | AgentBlockExcerpt
+  | PromptFanoutBlockExcerpt
   | WorkContextBlockExcerpt
   | FileBlockExcerpt
   | ArtifactBlockExcerpt
@@ -221,6 +237,16 @@ function excerptForDescriptor(
         ...(actorRef.displayName
           ? { actorDisplayName: actorRef.displayName }
           : {}),
+      };
+    }
+    case 'prompt-fanout': {
+      const run = descriptor.meta.run;
+      return {
+        kind: 'prompt-fanout',
+        runId: run?.id,
+        state: run?.state,
+        selectedTargetCount: run?.selectedTargetIds.length,
+        resultCount: run?.results.length,
       };
     }
     case 'work-context': {

--- a/test/prompt-fanout-run.test.ts
+++ b/test/prompt-fanout-run.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getPromptFanoutRunFixture,
+  promptFanoutRunFixtures,
+  type PromptFanoutFixtureKey,
+} from '../shared/prompt-fanout-fixtures.js';
+import {
+  PROMPT_FANOUT_RUN_SCHEMA_VERSION,
+  promptFanoutHasPartialFailure,
+  promptFanoutStatusCounts,
+  selectedPromptFanoutTargets,
+  unselectedPromptFanoutTargets,
+  type PromptFanoutRun,
+} from '../shared/prompt-fanout-run.js';
+
+const expectedFixtures: PromptFanoutFixtureKey[] = [
+  'all-success',
+  'mixed-success-failure',
+  'denied-target',
+  'timeout',
+  'empty-no-eligible-targets',
+  'loading',
+];
+
+function assertSchema(run: PromptFanoutRun) {
+  expect(run.schemaVersion).toBe(PROMPT_FANOUT_RUN_SCHEMA_VERSION);
+  expect(run.id).toMatch(/^pfr:/);
+  expect(run.workContextId).toMatch(/^wc:/);
+  expect(run.prompt.id).toMatch(/^prompt:/);
+  expect(run.prompt.dryRun).toBe(true);
+  expect(Array.isArray(run.allTargets)).toBe(true);
+  expect(Array.isArray(run.selectedTargetIds)).toBe(true);
+  expect(Array.isArray(run.results)).toBe(true);
+  expect(Array.isArray(run.errors)).toBe(true);
+  expect(run.createdAt).toBeTruthy();
+  expect(run.updatedAt).toBeTruthy();
+}
+
+describe('PromptFanoutRun fixtures', () => {
+  it('exports every issue #705 acceptance fixture', () => {
+    expect(Object.keys(promptFanoutRunFixtures).sort()).toEqual(
+      [...expectedFixtures].sort()
+    );
+  });
+
+  it('each fixture satisfies the shared run schema shape', () => {
+    for (const key of expectedFixtures) {
+      assertSchema(promptFanoutRunFixtures[key]);
+    }
+  });
+
+  it('all-success fixture has selected targets but not every session selected', () => {
+    const run = getPromptFanoutRunFixture('all-success');
+    const selected = selectedPromptFanoutTargets(run);
+    const unselected = unselectedPromptFanoutTargets(run);
+    expect(selected.length).toBeGreaterThan(0);
+    expect(unselected.length).toBeGreaterThan(0);
+    expect(selected.length).toBeLessThan(run.allTargets.length);
+    expect(run.results.every((result) => result.status === 'succeeded')).toBe(
+      true
+    );
+  });
+
+  it('mixed fixture reports partial failure', () => {
+    const run = getPromptFanoutRunFixture('mixed-success-failure');
+    expect(run.state).toBe('partial-failure');
+    expect(promptFanoutHasPartialFailure(run)).toBe(true);
+    const counts = promptFanoutStatusCounts(run);
+    expect(counts.succeeded).toBe(1);
+    expect(counts.failed).toBe(1);
+  });
+
+  it('denied fixture exposes target and run-level errors', () => {
+    const run = getPromptFanoutRunFixture('denied-target');
+    expect(run.state).toBe('denied');
+    expect(run.errors.some((error) => error.code === 'TARGET_DENIED')).toBe(
+      true
+    );
+    expect(
+      run.results.some((result) => result.status === 'denied' && result.error)
+    ).toBe(true);
+  });
+
+  it('timeout fixture exposes timeout status and retryable error', () => {
+    const run = getPromptFanoutRunFixture('timeout');
+    expect(run.state).toBe('timeout');
+    expect(
+      run.results.some(
+        (result) => result.status === 'timeout' && result.error?.retryable
+      )
+    ).toBe(true);
+  });
+
+  it('empty fixture has no selected targets and no broadcast-to-all default', () => {
+    const run = getPromptFanoutRunFixture('empty-no-eligible-targets');
+    expect(run.state).toBe('empty');
+    expect(selectedPromptFanoutTargets(run)).toHaveLength(0);
+    expect(run.selectedTargetIds).toEqual([]);
+    expect(run.allTargets.every((target) => !target.eligible)).toBe(true);
+  });
+});

--- a/test/workbench-block-registry.test.ts
+++ b/test/workbench-block-registry.test.ts
@@ -53,11 +53,12 @@ describe('block-registry source structure', () => {
     expect(src).toContain('export async function initFirstPartyBlocks');
   });
 
-  it('registers all 7 first-party kinds in initFirstPartyBlocks', () => {
+  it('registers all 8 first-party kinds in initFirstPartyBlocks', () => {
     const src = readFileSync(registryPath, 'utf-8');
     const kinds = [
       'terminal',
       'agent',
+      'prompt-fanout',
       'work-context',
       'file',
       'artifact',

--- a/test/workbench-block-renderers.test.ts
+++ b/test/workbench-block-renderers.test.ts
@@ -172,6 +172,66 @@ describe('work-context renderer', () => {
 });
 
 // ---------------------------------------------------------------------------
+// prompt-fanout renderer
+// ---------------------------------------------------------------------------
+
+describe('prompt-fanout renderer', () => {
+  it('file exists', () => {
+    expect(blockExists('prompt-fanout.tsx')).toBe(true);
+  });
+
+  it('css file exists', () => {
+    expect(blockExists('prompt-fanout.css')).toBe(true);
+  });
+
+  it('exports PromptFanoutBlock', () => {
+    const src = readBlock('prompt-fanout.tsx');
+    expect(src).toContain('export const PromptFanoutBlock');
+  });
+
+  it('is typed as WorkbenchBlockRenderer<"prompt-fanout">', () => {
+    const src = readBlock('prompt-fanout.tsx');
+    expect(src).toContain(`WorkbenchBlockRenderer<'prompt-fanout'>`);
+  });
+
+  it('uses PromptFanoutRun fixtures and schema helpers', () => {
+    const src = readBlock('prompt-fanout.tsx');
+    expect(src).toContain('getPromptFanoutRunFixture');
+    expect(src).toContain('selectedPromptFanoutTargets');
+    expect(src).toContain('unselectedPromptFanoutTargets');
+  });
+
+  it('has visible loading, empty, denied, and partial-failure states', () => {
+    const src = readBlock('prompt-fanout.tsx');
+    expect(src).toContain('block-prompt-fanout--loading');
+    expect(src).toContain('block-prompt-fanout--empty');
+    expect(src).toContain('block-prompt-fanout--denied');
+    expect(src).toContain('block-prompt-fanout--partial-failure');
+  });
+
+  it('distinguishes selected targets from all sessions', () => {
+    const src = readBlock('prompt-fanout.tsx');
+    expect(src).toContain('selected targets');
+    expect(src).toContain('all sessions not selected');
+    expect(src).toContain('no broadcast-to-all default');
+  });
+
+  it('dry-run action emits audit event without terminal input', () => {
+    const src = readBlock('prompt-fanout.tsx');
+    expect(src).toContain('prompt-fanout.dry-run');
+    expect(src).toContain('sendsTerminalInput: false');
+    expect(src).not.toContain('sendInput');
+    expect(src).not.toContain('writeTerminal');
+  });
+
+  it('CSS has block-prompt-fanout classes', () => {
+    const css = readBlock('prompt-fanout.css');
+    expect(css).toContain('.block-prompt-fanout');
+    expect(css).toContain('.block-prompt-fanout__dry-run');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // custom renderer (slice 4 — sandboxed proposal/approval flow)
 // ---------------------------------------------------------------------------
 
@@ -714,13 +774,14 @@ describe('agent renderer', () => {
 });
 
 // ---------------------------------------------------------------------------
-// All 7 renderers: verify they all export their named renderer
+// All 8 renderers: verify they all export their named renderer
 // ---------------------------------------------------------------------------
 
-describe('all 7 renderers exist and export named components', () => {
+describe('all 8 renderers exist and export named components', () => {
   const renderers = [
     { file: 'terminal.tsx', export: 'TerminalBlock' },
     { file: 'agent.tsx', export: 'AgentBlock' },
+    { file: 'prompt-fanout.tsx', export: 'PromptFanoutBlock' },
     { file: 'work-context.tsx', export: 'WorkContextBlock' },
     { file: 'file.tsx', export: 'FileBlock' },
     { file: 'artifact.tsx', export: 'ArtifactBlock' },

--- a/test/workbench-block-types.test.ts
+++ b/test/workbench-block-types.test.ts
@@ -17,6 +17,7 @@ import type {
   FileBlockDescriptor,
   JsonValue,
   MarkdownBlockDescriptor,
+  PromptFanoutBlockDescriptor,
   TerminalBlockDescriptor,
   WorkContextBlockDescriptor,
   WorkbenchBlockDescriptor,
@@ -26,6 +27,7 @@ import type {
 } from '../shared/workbench-block-types.js';
 import type { RelayCapabilityBit } from '../shared/security-policy.js';
 import type { WorkContextRedactionClass } from '../shared/work-context.js';
+import { getPromptFanoutRunFixture } from '../shared/prompt-fanout-fixtures.js';
 
 // ---------------------------------------------------------------------------
 // helpers
@@ -137,10 +139,25 @@ describe('WorkbenchBlockDescriptor discriminated union narrowing', () => {
     }
   });
 
+  it('narrows to PromptFanoutBlockDescriptor on kind === prompt-fanout', () => {
+    const desc: WorkbenchBlockDescriptor = {
+      kind: 'prompt-fanout',
+      id: 'b-3',
+      title: 'Prompt Fanout',
+      capabilityRequirements: [],
+      meta: { fixture: 'all-success', dryRunOnly: true },
+    };
+
+    if (desc.kind === 'prompt-fanout') {
+      assertType<string | undefined>(desc.meta.fixture);
+      assertType<boolean | undefined>(desc.meta.dryRunOnly);
+    }
+  });
+
   it('narrows to WorkContextBlockDescriptor on kind === work-context', () => {
     const desc: WorkbenchBlockDescriptor = {
       kind: 'work-context',
-      id: 'b-3',
+      id: 'b-4',
       title: 'Issue #619',
       capabilityRequirements: [],
       meta: { workContextRef: 'wc:abc-123' },
@@ -291,13 +308,14 @@ describe('WorkbenchBlockKind union', () => {
     const kinds: WorkbenchBlockKind[] = [
       'terminal',
       'agent',
+      'prompt-fanout',
       'work-context',
       'file',
       'artifact',
       'markdown',
       'custom',
     ];
-    expect(kinds).toHaveLength(7);
+    expect(kinds).toHaveLength(8);
   });
 });
 
@@ -332,6 +350,17 @@ describe('WorkbenchBlockDescriptor JSON round-trip', () => {
         actorRef: { kind: 'actor', id: 'actor-001', displayName: 'claude' },
       },
     } satisfies AgentBlockDescriptor,
+    {
+      kind: 'prompt-fanout',
+      id: 'rt-prompt-fanout',
+      title: 'Prompt fanout',
+      capabilityRequirements: [],
+      meta: {
+        fixture: 'all-success',
+        run: getPromptFanoutRunFixture('all-success'),
+        dryRunOnly: true,
+      },
+    } satisfies PromptFanoutBlockDescriptor,
     {
       kind: 'work-context',
       id: 'rt-work-context',
@@ -396,7 +425,7 @@ describe('WorkbenchBlockDescriptor JSON round-trip', () => {
     }
   });
 
-  it('round-trips produce the correct kind for all 7 variants', () => {
+  it('round-trips produce the correct kind for all 8 variants', () => {
     const roundTripped = cases.map((d) => {
       const parsed = JSON.parse(JSON.stringify(d)) as WorkbenchBlockDescriptor;
       return parsed.kind;
@@ -405,6 +434,7 @@ describe('WorkbenchBlockDescriptor JSON round-trip', () => {
     expect(roundTripped).toEqual([
       'terminal',
       'agent',
+      'prompt-fanout',
       'work-context',
       'file',
       'artifact',

--- a/test/workbench-prompt-hooks.test.ts
+++ b/test/workbench-prompt-hooks.test.ts
@@ -4,7 +4,7 @@
  * Covers:
  *   1. summarizeWorkbenchBlocks
  *      - Empty layout → empty summary, no truncation
- *      - Layout with all 7 block kinds → correct per-kind excerpts
+ *      - Layout with all 8 block kinds → correct per-kind excerpts
  *      - Layout exceeding block cap → truncates to MAX_BLOCKS, truncated=true
  *      - Layout exceeding byte cap → truncates safely, truncated=true
  *      - No secret/env/transcript leakage (grep output for forbidden patterns)
@@ -138,6 +138,7 @@ import {
   createWorkbenchProposeBlockRouter,
 } from '../server/workbench-prompt-hooks.js';
 import { writeWorkbenchLayout } from '../server/workbench-layout.js';
+import { getPromptFanoutRunFixture } from '../shared/prompt-fanout-fixtures.js';
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -182,6 +183,25 @@ function makeAgentPlacement(): WorkbenchBlockPlacement {
     },
     position: { x: 410, y: 0 },
     size: { width: 400, height: 300 },
+    minimized: false,
+  };
+}
+
+function makePromptFanoutPlacement(): WorkbenchBlockPlacement {
+  return {
+    descriptor: {
+      kind: 'prompt-fanout',
+      id: 'block-prompt-fanout',
+      title: 'Prompt Fanout',
+      capabilityRequirements: [],
+      meta: {
+        fixture: 'all-success',
+        run: getPromptFanoutRunFixture('all-success'),
+        dryRunOnly: true,
+      },
+    },
+    position: { x: 820, y: 0 },
+    size: { width: 500, height: 300 },
     minimized: false,
   };
 }
@@ -309,10 +329,11 @@ describe('summarizeWorkbenchBlocks', () => {
     expect(summary.workspaceScope.id).toBe('ws:test');
   });
 
-  it('summarizes all 7 block kinds correctly', () => {
+  it('summarizes all 8 block kinds correctly', () => {
     const layout = makeLayout([
       makeTerminalPlacement(),
       makeAgentPlacement(),
+      makePromptFanoutPlacement(),
       makeWorkContextPlacement(),
       makeFilePlacement(),
       makeArtifactPlacement(),
@@ -320,9 +341,9 @@ describe('summarizeWorkbenchBlocks', () => {
       makeCustomPlacement(),
     ]);
     const summary = summarizeWorkbenchBlocks(layout);
-    expect(summary.blocks).toHaveLength(7);
+    expect(summary.blocks).toHaveLength(8);
     expect(summary.truncated).toBe(false);
-    expect(summary.totalBlocks).toBe(7);
+    expect(summary.totalBlocks).toBe(8);
 
     const terminal = summary.blocks.find((b) => b.kind === 'terminal');
     expect(terminal?.excerpt).toMatchObject({
@@ -335,6 +356,17 @@ describe('summarizeWorkbenchBlocks', () => {
       kind: 'agent',
       actorId: 'actor-xyz',
       actorDisplayName: 'Claude Code',
+    });
+
+    const promptFanout = summary.blocks.find(
+      (b) => b.kind === 'prompt-fanout'
+    );
+    expect(promptFanout?.excerpt).toMatchObject({
+      kind: 'prompt-fanout',
+      runId: 'pfr:all-success',
+      state: 'completed',
+      selectedTargetCount: 2,
+      resultCount: 2,
     });
 
     const wc = summary.blocks.find((b) => b.kind === 'work-context');


### PR DESCRIPTION
## Summary
- Adds a shared `PromptFanoutRun` schema and fixtures for all-success, mixed failure, denied, timeout, loading, and empty/no-eligible-target cases.
- Registers a mock-only `prompt-fanout` workbench block with selected-target rendering, unselected session visibility, dry-run placeholder, and visible loading/empty/denied/partial-failure states.
- Extends workbench descriptor creation, registry, prompt-hook excerpts, and source/schema tests for the new block kind.

Closes #705

## Test Plan
- `npm test -- test/prompt-fanout-run.test.ts test/workbench-block-renderers.test.ts test/workbench-block-types.test.ts test/workbench-prompt-hooks.test.ts test/workbench-block-registry.test.ts`
- `npm run check` (passes; existing repo lint warnings remain)
- `npm run build`

## Browser / UI verification
- Tried to open a Vite harness for all prompt-fanout fixture states at `http://127.0.0.1:5178/prompt-fanout-harness.html`; Vite served the page, but the browser tool could not launch Chrome because the environment is missing `libatk-1.0.so.0`.
- The temporary harness file was removed after the attempt; no live terminal-send path was added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prompt-fanout block type to the workbench, enabling users to create and work with fanout runs.
  * Introduced dry-run functionality for testing with selected targets and viewing execution results.
  * Block displays status, timing, and details for each target in a structured view.

* **Tests**
  * Added comprehensive test coverage for prompt-fanout blocks and fixture data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->