### PR TITLE
feat: terminal stream v2 replay envelope

### DIFF
--- a/docs/SESSION_DURABILITY.md
+++ b/docs/SESSION_DURABILITY.md
@@ -76,9 +76,38 @@ routes). Web-mode sessions and unknown ids return 404
 `SESSION_REPLAY_UNAVAILABLE`; remote/routed sessions are out of scope for
 this slice (see #614 slice 3+).
 
-The existing WebSocket attach path keeps streaming raw scrollback bytes to
-xterm clients — this REST snapshot is a separate, optional read for status
-cards, agent adapters, and reattach UX that need a typed view.
+The existing WebSocket attach path now emits the versioned terminal stream v2
+envelope for local PTY/tmux sessions instead of anonymous raw byte frames. The
+browser remains on xterm.js and the default runtime is unchanged; the envelope
+only makes the transport semantics explicit for future adapters.
+
+## Terminal stream v2 envelope
+
+`shared/session-replay.ts` defines `TerminalStreamEnvelope` with
+`type: "terminal-stream"`, `version: 2`, the session id, a monotonic `seq`, a
+cursor, timestamp, replay flag, and typed payload kinds:
+
+- `metadata` announces the existing `node-pty/tmux` runtime, replay capacity,
+  retained cursor range, last resize, and the `single-active-owner` resize
+  policy.
+- `replay-start` / `replay-end` bracket bounded reconnect replay. Clients pass
+  `cursor=<lastSeenCursor>` on `/ws/:sessionId`; omitted cursor replays from
+  the oldest retained frame.
+- `lag` reports explicit stale/repair behavior: `cursor-too-old` starts replay
+  from the oldest retained cursor, `cursor-too-new` skips replay and resumes
+  live output, and `server-backfill` marks normal bounded backfill from a known
+  cursor.
+- `data` carries xterm bytes plus the retained cursor range. The browser still
+  writes the payload to xterm.js; it also tracks the newest cursor for the next
+  reconnect.
+- `resize` records terminal resize attempts. Active clients are the only resize
+  owners whose dimensions are applied to the PTY; passive mirrors receive the
+  event but do not fight terminal geometry.
+
+This contract is the gate for a later rmux adapter: rmux can map its output,
+lag/backfill, render, and resize-owner signals into Relay's envelope without
+changing browser rendering, permission checks, or the current node-pty/tmux
+runtime.
 
 ## Frontend reconnect UX
 

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -25,6 +25,11 @@ import type { TabControlEvent } from '../../../shared/control-state.js';
 import type { HubNodeStatus } from '../../../shared/relay-node-protocol.js';
 import type { SessionDurabilityState } from '../../../shared/session-durability.js';
 import type { NodeManifest } from '../../../shared/node-manifest.js';
+import {
+  isTerminalStreamEnvelope,
+  type TerminalStreamEnvelope,
+  type TerminalStreamResizeOwner,
+} from '../../../shared/session-replay.js';
 
 const logger = createLogger('pty-ws');
 const wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -318,9 +323,97 @@ interface PtyConnection {
   pauseBufferHead: number;
   /** Total UTF-16 code unit count of live pauseBuffer content. */
   pauseBufferSize: number;
+
+  terminalStreamCursor: number;
+  terminalStreamClientId: string;
+  resizeOwner: TerminalStreamResizeOwner;
 }
 
 const ptyConnections = new Map<string, PtyConnection>();
+
+function createTerminalStreamClientId(): string {
+  return `browser-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+}
+
+function appendTerminalStreamParams(
+  path: string,
+  conn: PtyConnection
+): string {
+  const params = new URLSearchParams({
+    clientId: conn.terminalStreamClientId,
+    resizeOwner: conn.resizeOwner,
+  });
+  if (conn.terminalStreamCursor > 0) {
+    params.set('cursor', String(conn.terminalStreamCursor));
+  }
+  return `${path}?${params.toString()}`;
+}
+
+function enqueuePtyOutput(conn: PtyConnection, data: string): void {
+  // While the terminal tab is inactive, route data to the pause ring buffer
+  // instead of the xterm write queue so we don't paint invisible frames.
+  if (conn.renderPaused) {
+    appendToPauseBuffer(conn, data);
+    return;
+  }
+
+  if (conn.queueSize + data.length > MAX_QUEUE_SIZE) {
+    if (!conn.paused) {
+      logger.warn(
+        'flow-control: queue cap reached (session=%s, queue=%d), dropping data',
+        conn.sessionId,
+        conn.queueSize
+      );
+    }
+    return;
+  }
+
+  conn.writeQueue.push(data);
+  conn.queueSize += data.length;
+  if (conn.paused) {
+    logger.debug(
+      'flow-control: queued %d chars while paused (session=%s, pending=%d, queue=%d)',
+      data.length,
+      conn.sessionId,
+      conn.pendingSize,
+      conn.writeQueue.length
+    );
+  }
+  if (!conn.paused) scheduleFlush(conn);
+}
+
+function handleTerminalStreamEnvelope(
+  conn: PtyConnection,
+  envelope: TerminalStreamEnvelope
+): void {
+  conn.terminalStreamCursor = Math.max(conn.terminalStreamCursor, envelope.cursor);
+  if (envelope.kind === 'data') {
+    enqueuePtyOutput(conn, envelope.payload.data);
+    return;
+  }
+  if (envelope.kind === 'lag') {
+    logger.warn(
+      'terminal-stream lag notice (session=%s, reason=%s, requested=%s, oldest=%d, latest=%d)',
+      conn.sessionId,
+      envelope.payload.reason,
+      String(envelope.payload.requestedCursor),
+      envelope.payload.oldestCursor,
+      envelope.payload.latestCursor
+    );
+  }
+}
+
+function parseTerminalStreamMessage(data: string): TerminalStreamEnvelope | null {
+  if (!data.startsWith('{')) return null;
+  try {
+    const parsed: unknown = JSON.parse(data);
+    return isTerminalStreamEnvelope(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
 
 function isWithinServerRestartGrace(): boolean {
   return serverRestartAuthGraceUntil > Date.now();
@@ -497,7 +590,8 @@ export function connectPtySocket(
   sessionId: string,
   term: Terminal,
   onResize: () => void,
-  onSessionEnd: () => void
+  onSessionEnd: () => void,
+  resizeOwner: TerminalStreamResizeOwner = 'active'
 ): void {
   const { registryKey, localSessionId, nodeId } = resolvePtyTarget(sessionId);
   // Tear down any existing connection for this scoped terminal target.
@@ -544,6 +638,9 @@ export function connectPtySocket(
     pauseBuffer: [],
     pauseBufferHead: 0,
     pauseBufferSize: 0,
+    terminalStreamCursor: 0,
+    terminalStreamClientId: createTerminalStreamClientId(),
+    resizeOwner,
   };
   ptyConnections.set(registryKey, conn);
 
@@ -558,7 +655,7 @@ function openPtySocket(conn: PtyConnection): void {
         '/ws/sessions/' +
         encodeURIComponent(conn.localSessionId)
       : '/ws/' + encodeURIComponent(conn.localSessionId);
-  const url = wsProtocol + '//' + location.host + path;
+  const url = wsProtocol + '//' + location.host + appendTerminalStreamParams(path, conn);
   const socket = new WebSocket(url);
   conn.pendingWs = socket;
 
@@ -577,36 +674,13 @@ function openPtySocket(conn: PtyConnection): void {
     if (conn.pongPending) clearPtyPongTimeout(conn);
     if (str === PONG_MSG) return;
 
-    // While the terminal tab is inactive, route data to the pause ring buffer
-    // instead of the xterm write queue so we don't paint invisible frames.
-    if (conn.renderPaused) {
-      appendToPauseBuffer(conn, str);
+    const envelope = parseTerminalStreamMessage(str);
+    if (envelope) {
+      handleTerminalStreamEnvelope(conn, envelope);
       return;
     }
 
-    if (conn.queueSize + str.length > MAX_QUEUE_SIZE) {
-      if (!conn.paused) {
-        logger.warn(
-          'flow-control: queue cap reached (session=%s, queue=%d), dropping data',
-          conn.sessionId,
-          conn.queueSize
-        );
-      }
-      return;
-    }
-
-    conn.writeQueue.push(str);
-    conn.queueSize += str.length;
-    if (conn.paused) {
-      logger.debug(
-        'flow-control: queued %d chars while paused (session=%s, pending=%d, queue=%d)',
-        str.length,
-        conn.sessionId,
-        conn.pendingSize,
-        conn.writeQueue.length
-      );
-    }
-    if (!conn.paused) scheduleFlush(conn);
+    enqueuePtyOutput(conn, str);
   };
 
   socket.onclose = (event) => {
@@ -832,7 +906,15 @@ export function sendPtyResize(
     return;
   }
   if (conn?.ws && conn.ws.readyState === WebSocket.OPEN) {
-    conn.ws.send(JSON.stringify({ type: 'resize', cols, rows }));
+    conn.ws.send(
+      JSON.stringify({
+        type: 'resize',
+        cols,
+        rows,
+        owner: conn.resizeOwner,
+        clientId: conn.terminalStreamClientId,
+      })
+    );
   }
 }
 
@@ -851,6 +933,7 @@ export function isPtyConnected(sessionId?: string): boolean {
 export function pausePtyFeed(sessionId: string): void {
   const conn = ptyConnections.get(resolvePtyTarget(sessionId).registryKey);
   if (!conn || conn.renderPaused) return;
+  conn.resizeOwner = 'passive';
   conn.renderPaused = true;
   // Cancel any pending flush so we don't paint after pausing.
   if (conn.rafHandle !== null) {
@@ -872,6 +955,7 @@ export function resumePtyFeed(sessionId: string): void {
   const conn = ptyConnections.get(resolvePtyTarget(sessionId).registryKey);
   if (!conn || !conn.renderPaused) return;
   conn.renderPaused = false;
+  conn.resizeOwner = 'active';
 
   // Move all live pauseBuffer chunks into the write queue individually —
   // no join() allocation since flushWriteQueue will join them anyway.

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -36,6 +36,10 @@ import {
   normalizeControlStateSummary,
   type ControlStateSummary,
 } from '../shared/control-state.js';
+import {
+  appendTerminalStreamData,
+  createTerminalStreamState,
+} from '../shared/session-replay.js';
 
 const IDLE_TIMEOUT_MS = 5000;
 /** Default per-session scrollback cap. Overridable via createPtySession options. */
@@ -952,6 +956,12 @@ function buildSessionObject(
     scrollback,
     scrollbackBytesEvicted: 0,
     scrollbackCapacityBytes,
+    terminalStream: createTerminalStreamState({
+      sessionId: id,
+      capacityBytes: scrollbackCapacityBytes,
+      initialChunks: scrollback,
+    }),
+    terminalStreamSubscribers: [],
     idle: false,
     cwd,
     customCommand:
@@ -1246,6 +1256,14 @@ export function createPtySession(
       resetIdleTimer();
       scrollback.push(data);
       scrollbackRef.bytes += data.length;
+      const terminalStreamEnvelope = session.terminalStream
+        ? appendTerminalStreamData(session.terminalStream, data)
+        : null;
+      if (terminalStreamEnvelope) {
+        for (const cb of session.terminalStreamSubscribers ?? []) {
+          cb(terminalStreamEnvelope);
+        }
+      }
       // Trim oldest entries if over limit; track total bytes evicted so
       // `SessionReplaySnapshot.bytesDropped` can report lost history.
       while (

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -64,6 +64,7 @@ import {
 } from '../shared/session-durability.js';
 import {
   DEFAULT_SESSION_REPLAY_CAPACITY_BYTES,
+  dropTerminalStreamPrefixBytes,
   type SessionReplaySnapshot,
 } from '../shared/session-replay.js';
 import {
@@ -166,6 +167,7 @@ function enforceGlobalScrollbackCap(
     // Trim oldest chunks one-by-one until this session's scrollback is clear.
     while (session.scrollback.length > 0 && total > globalScrollbackCapBytes) {
       const chunk = session.scrollback.shift()!;
+      dropTerminalStreamPrefixBytes(session.terminalStream, chunk.length);
       total -= chunk.length;
       freed += chunk.length;
     }

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,5 +1,9 @@
 import type { IPty } from 'node-pty';
 import type {
+  TerminalStreamEnvelope,
+  TerminalStreamState,
+} from '../shared/session-replay.js';
+import type {
   GlobalSessionId,
   LocalSessionId,
   NodeId,
@@ -313,6 +317,10 @@ export interface PtySession extends BaseSession {
    * Stored so `SessionReplaySnapshot.capacityBytes` reflects the actual cap.
    */
   scrollbackCapacityBytes: number;
+  /** Terminal stream v2 state for cursor-based replay and resize ownership. */
+  terminalStream?: TerminalStreamState;
+  /** Live subscribers for terminal stream v2 envelopes. */
+  terminalStreamSubscribers?: Array<(envelope: TerminalStreamEnvelope) => void>;
   useTmux: boolean;
   tmuxSessionName: string;
   onPtyReplacedCallbacks: Array<(newPty: IPty) => void>;

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -69,7 +69,8 @@ function ensureTerminalStreamState(session: Extract<Session, { mode: 'pty' }>) {
       bytesDropped: session.scrollbackBytesEvicted,
     });
   }
-  if (!session.terminalStreamSubscribers) session.terminalStreamSubscribers = [];
+  if (!session.terminalStreamSubscribers)
+    session.terminalStreamSubscribers = [];
   return session.terminalStream;
 }
 
@@ -81,6 +82,12 @@ function parseReplayCursor(raw: string | null): number | null {
 
 function parseResizeOwner(value: unknown): TerminalStreamResizeOwner {
   return value === 'passive' ? 'passive' : 'active';
+}
+
+function parseResizeDimension(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0
+    ? value
+    : null;
 }
 
 interface LocalPtyAttachContext {
@@ -751,7 +758,9 @@ function setupWebSocket(
         clientId:
           parseClientId(requestUrl.searchParams.get('clientId')) ??
           createTerminalStreamClientId(),
-        resizeOwner: parseResizeOwner(requestUrl.searchParams.get('resizeOwner')),
+        resizeOwner: parseResizeOwner(
+          requestUrl.searchParams.get('resizeOwner')
+        ),
       });
       wss.emit('connection', ws, request);
     });
@@ -805,26 +814,38 @@ function setupWebSocket(
         const str = msg.toString();
         try {
           const parsed = JSON.parse(str);
-          if (parsed.type === 'ping') {
-            replyPing(ws);
-            return;
-          }
-          if (parsed.type === 'resize' && parsed.cols && parsed.rows) {
-            const owner = parseResizeOwner(parsed.owner ?? attachContext.resizeOwner);
-            const resizeEnvelope = recordTerminalStreamResize(terminalStream, {
-              cols: parsed.cols,
-              rows: parsed.rows,
-              owner,
-              sourceClientId:
-                parseClientId(parsed.clientId) ?? attachContext.clientId,
-            });
-            if (resizeEnvelope.payload.applied) {
-              sessions.resize(session.id, parsed.cols, parsed.rows);
+          if (parsed && typeof parsed === 'object') {
+            const payload = parsed as Record<string, unknown>;
+            if (payload['type'] === 'ping') {
+              replyPing(ws);
+              return;
             }
-            for (const cb of session.terminalStreamSubscribers ?? []) {
-              cb(resizeEnvelope);
+            if (payload['type'] === 'resize') {
+              const cols = parseResizeDimension(payload['cols']);
+              const rows = parseResizeDimension(payload['rows']);
+              if (cols === null || rows === null) return;
+              const owner = parseResizeOwner(
+                payload['owner'] ?? attachContext.resizeOwner
+              );
+              const resizeEnvelope = recordTerminalStreamResize(
+                terminalStream,
+                {
+                  cols,
+                  rows,
+                  owner,
+                  sourceClientId:
+                    parseClientId(payload['clientId']) ??
+                    attachContext.clientId,
+                }
+              );
+              if (resizeEnvelope.payload.applied) {
+                sessions.resize(session.id, cols, rows);
+              }
+              for (const cb of session.terminalStreamSubscribers ?? []) {
+                cb(resizeEnvelope);
+              }
+              return;
             }
-            return;
           }
         } catch (_) {
           // ignore

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -27,6 +27,13 @@ import {
   createNodeScopedFileEvent,
   createNodeScopedSessionEvent,
 } from '../shared/node-boundary.js';
+import {
+  buildTerminalStreamReplay,
+  createTerminalStreamState,
+  recordTerminalStreamResize,
+  type TerminalStreamEnvelope,
+  type TerminalStreamResizeOwner,
+} from '../shared/session-replay.js';
 
 import {
   sessionEnvelopeRegistry,
@@ -44,6 +51,54 @@ const logger = createLogger('ws');
 
 function replyPing(ws: WebSocket): void {
   if (ws.readyState === ws.OPEN) ws.send('{"type":"pong"}');
+}
+
+function sendTerminalStreamEnvelope(
+  ws: WebSocket,
+  envelope: TerminalStreamEnvelope
+): void {
+  if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(envelope));
+}
+
+function ensureTerminalStreamState(session: Extract<Session, { mode: 'pty' }>) {
+  if (!session.terminalStream) {
+    session.terminalStream = createTerminalStreamState({
+      sessionId: session.id,
+      capacityBytes: session.scrollbackCapacityBytes,
+      initialChunks: session.scrollback,
+      bytesDropped: session.scrollbackBytesEvicted,
+    });
+  }
+  if (!session.terminalStreamSubscribers) session.terminalStreamSubscribers = [];
+  return session.terminalStream;
+}
+
+function parseReplayCursor(raw: string | null): number | null {
+  if (raw === null || raw.trim() === '') return null;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function parseResizeOwner(value: unknown): TerminalStreamResizeOwner {
+  return value === 'passive' ? 'passive' : 'active';
+}
+
+interface LocalPtyAttachContext {
+  replayCursor: number | null;
+  clientId: string;
+  resizeOwner: TerminalStreamResizeOwner;
+}
+
+function parseClientId(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 && trimmed.length <= 128 ? trimmed : null;
+}
+
+function createTerminalStreamClientId(): string {
+  return `client-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
 }
 
 function appendRoutedSessionAudit(
@@ -548,9 +603,8 @@ function setupWebSocket(
   });
 
   server.on('upgrade', (request, socket, head) => {
-    const requestPath = request.url
-      ? new URL(request.url, 'http://relay.local').pathname.replace(/\/$/, '')
-      : '';
+    const requestUrl = new URL(request.url ?? '/', 'http://relay.local');
+    const requestPath = requestUrl.pathname.replace(/\/$/, '');
     if (requestPath === '/hub/node-link') {
       const authenticated = authenticateHubNodeLink(request, hubNodeRegistry);
       if (!authenticated || !hubNodeRegistry) {
@@ -675,7 +729,7 @@ function setupWebSocket(
     }
 
     // PTY channel: /ws/:sessionId
-    const match = request.url && request.url.match(/^\/ws\/([a-f0-9]+)$/);
+    const match = requestPath.match(/^\/ws\/([a-f0-9]+)$/);
     if (!match) {
       socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
       socket.destroy();
@@ -692,34 +746,49 @@ function setupWebSocket(
 
     wss.handleUpgrade(request, socket, head, (ws) => {
       sessionMap.set(ws, session);
+      localPtyAttachContext.set(ws, {
+        replayCursor: parseReplayCursor(requestUrl.searchParams.get('cursor')),
+        clientId:
+          parseClientId(requestUrl.searchParams.get('clientId')) ??
+          createTerminalStreamClientId(),
+        resizeOwner: parseResizeOwner(requestUrl.searchParams.get('resizeOwner')),
+      });
       wss.emit('connection', ws, request);
     });
   });
 
   const sessionMap = new WeakMap<WebSocket, Session>();
+  const localPtyAttachContext = new WeakMap<WebSocket, LocalPtyAttachContext>();
 
   wss.on('connection', (ws: WebSocket, _request: http.IncomingMessage) => {
     const session = sessionMap.get(ws);
     if (!session) return;
 
     if (session.mode === 'pty') {
-      let dataDisposable: { dispose(): void } | null = null;
+      const attachContext = localPtyAttachContext.get(ws) ?? {
+        replayCursor: null,
+        clientId: createTerminalStreamClientId(),
+        resizeOwner: 'active' as const,
+      };
+      const terminalStream = ensureTerminalStreamState(session);
+      const terminalStreamSubscriber = (envelope: TerminalStreamEnvelope) => {
+        sendTerminalStreamEnvelope(ws, envelope);
+      };
+      session.terminalStreamSubscribers?.push(terminalStreamSubscriber);
+
+      for (const envelope of buildTerminalStreamReplay(
+        terminalStream,
+        attachContext.replayCursor
+      )) {
+        sendTerminalStreamEnvelope(ws, envelope);
+      }
+
       let exitDisposable: { dispose(): void } | null = null;
 
       const attachToPty = (ptyProcess: IPty): void => {
-        // Dispose previous handlers
-        dataDisposable?.dispose();
+        // Terminal bytes are emitted through TerminalStreamEnvelope subscribers;
+        // this listener only tracks process exit for the attach handle.
         exitDisposable?.dispose();
-
-        // Replay scrollback
-        for (const chunk of session.scrollback) {
-          if (ws.readyState === ws.OPEN) ws.send(chunk);
-        }
-
-        dataDisposable = ptyProcess.onData((data) => {
-          if (ws.readyState === ws.OPEN) ws.send(data);
-        });
-
         exitDisposable = ptyProcess.onExit(() => {
           if (ws.readyState === ws.OPEN) ws.close(1000);
         });
@@ -741,7 +810,20 @@ function setupWebSocket(
             return;
           }
           if (parsed.type === 'resize' && parsed.cols && parsed.rows) {
-            sessions.resize(session.id, parsed.cols, parsed.rows);
+            const owner = parseResizeOwner(parsed.owner ?? attachContext.resizeOwner);
+            const resizeEnvelope = recordTerminalStreamResize(terminalStream, {
+              cols: parsed.cols,
+              rows: parsed.rows,
+              owner,
+              sourceClientId:
+                parseClientId(parsed.clientId) ?? attachContext.clientId,
+            });
+            if (resizeEnvelope.payload.applied) {
+              sessions.resize(session.id, parsed.cols, parsed.rows);
+            }
+            for (const cb of session.terminalStreamSubscribers ?? []) {
+              cb(resizeEnvelope);
+            }
             return;
           }
         } catch (_) {
@@ -763,8 +845,13 @@ function setupWebSocket(
       });
 
       const cleanup = () => {
-        dataDisposable?.dispose();
         exitDisposable?.dispose();
+        const subscriberIdx = session.terminalStreamSubscribers?.indexOf(
+          terminalStreamSubscriber
+        );
+        if (subscriberIdx !== undefined && subscriberIdx !== -1) {
+          session.terminalStreamSubscribers?.splice(subscriberIdx, 1);
+        }
         const idx = session.onPtyReplacedCallbacks.indexOf(ptyReplacedHandler);
         if (idx !== -1) session.onPtyReplacedCallbacks.splice(idx, 1);
       };

--- a/shared/session-replay.ts
+++ b/shared/session-replay.ts
@@ -177,8 +177,7 @@ export function createTerminalStreamState(input: {
     nextSeq: 0,
     cursor: input.bytesDropped ?? 0,
     oldestCursor: input.bytesDropped ?? 0,
-    capacityBytes:
-      input.capacityBytes ?? DEFAULT_SESSION_REPLAY_CAPACITY_BYTES,
+    capacityBytes: input.capacityBytes ?? DEFAULT_SESSION_REPLAY_CAPACITY_BYTES,
     bytesDropped: input.bytesDropped ?? 0,
     frames: [],
     activeResizeOwnerId: null,
@@ -194,22 +193,32 @@ function nowIso(): string {
   return new Date().toISOString();
 }
 
+function envelopeBase<K extends TerminalStreamPayloadKind>(
+  state: TerminalStreamState,
+  kind: K,
+  cursor: number,
+  replay: boolean,
+  seq: number
+): TerminalStreamEnvelopeBase<K> {
+  return {
+    type: 'terminal-stream',
+    version: TERMINAL_STREAM_PROTOCOL_VERSION,
+    sessionId: state.sessionId,
+    seq,
+    cursor,
+    kind,
+    timestamp: nowIso(),
+    replay,
+  };
+}
+
 function nextEnvelopeBase<K extends TerminalStreamPayloadKind>(
   state: TerminalStreamState,
   kind: K,
   cursor: number,
   replay: boolean
 ): TerminalStreamEnvelopeBase<K> {
-  return {
-    type: 'terminal-stream',
-    version: TERMINAL_STREAM_PROTOCOL_VERSION,
-    sessionId: state.sessionId,
-    seq: state.nextSeq++,
-    cursor,
-    kind,
-    timestamp: nowIso(),
-    replay,
-  };
+  return envelopeBase(state, kind, cursor, replay, state.nextSeq++);
 }
 
 export function appendTerminalStreamData(
@@ -279,16 +288,42 @@ export function terminalStreamMetadata(
 ): TerminalStreamMetadataEnvelope {
   return {
     ...nextEnvelopeBase(state, 'metadata', cursor, replay),
-    payload: {
-      runtime: 'node-pty/tmux',
-      capacityBytes: state.capacityBytes,
-      bytesDropped: state.bytesDropped,
-      oldestCursor: state.oldestCursor,
-      latestCursor: state.cursor,
-      resizePolicy: 'single-active-owner',
-      activeResizeOwnerId: state.activeResizeOwnerId,
-      lastResize: state.lastResize,
-    },
+    payload: terminalStreamMetadataPayload(state),
+  };
+}
+
+function terminalStreamMetadataPayload(
+  state: TerminalStreamState
+): TerminalStreamMetadataPayload {
+  return {
+    runtime: 'node-pty/tmux',
+    capacityBytes: state.capacityBytes,
+    bytesDropped: state.bytesDropped,
+    oldestCursor: state.oldestCursor,
+    latestCursor: state.cursor,
+    resizePolicy: 'single-active-owner',
+    activeResizeOwnerId: state.activeResizeOwnerId,
+    lastResize: state.lastResize,
+  };
+}
+
+function replayEnvelopeBase<K extends TerminalStreamPayloadKind>(
+  state: TerminalStreamState,
+  seq: number,
+  kind: K,
+  cursor: number
+): TerminalStreamEnvelopeBase<K> {
+  return envelopeBase(state, kind, cursor, true, seq);
+}
+
+function replayMetadataEnvelope(
+  state: TerminalStreamState,
+  seq: number,
+  cursor: number
+): TerminalStreamMetadataEnvelope {
+  return {
+    ...replayEnvelopeBase(state, seq, 'metadata', cursor),
+    payload: terminalStreamMetadataPayload(state),
   };
 }
 
@@ -323,6 +358,11 @@ export function buildTerminalStreamReplay(
   requestedCursor: number | null
 ): TerminalStreamEnvelope[] {
   const envelopes: TerminalStreamEnvelope[] = [];
+  let replaySeq = state.nextSeq;
+  const nextReplayBase = <K extends TerminalStreamPayloadKind>(
+    kind: K,
+    cursor: number
+  ) => replayEnvelopeBase(state, replaySeq++, kind, cursor);
   const replayFrom = requestedCursor ?? state.oldestCursor;
   const tooOld = requestedCursor !== null && replayFrom < state.oldestCursor;
   const tooNew = requestedCursor !== null && replayFrom > state.cursor;
@@ -332,13 +372,13 @@ export function buildTerminalStreamReplay(
       ? state.cursor
       : Math.max(state.oldestCursor, replayFrom);
 
-  envelopes.push(terminalStreamMetadata(state, true, startCursor));
+  envelopes.push(replayMetadataEnvelope(state, replaySeq++, startCursor));
   if (tooOld || tooNew) {
     const reason: TerminalStreamLagReason = tooOld
       ? 'cursor-too-old'
       : 'cursor-too-new';
     envelopes.push({
-      ...nextEnvelopeBase(state, 'lag', startCursor, true),
+      ...nextReplayBase('lag', startCursor),
       payload: {
         reason,
         requestedCursor,
@@ -353,20 +393,21 @@ export function buildTerminalStreamReplay(
     });
   } else if (requestedCursor !== null && requestedCursor < state.cursor) {
     envelopes.push({
-      ...nextEnvelopeBase(state, 'lag', startCursor, true),
+      ...nextReplayBase('lag', startCursor),
       payload: {
         reason: 'server-backfill',
         requestedCursor,
         oldestCursor: state.oldestCursor,
         latestCursor: state.cursor,
         bytesDropped: state.bytesDropped,
-        message: 'server is backfilling terminal output from the requested cursor',
+        message:
+          'server is backfilling terminal output from the requested cursor',
       },
     });
   }
 
   envelopes.push({
-    ...nextEnvelopeBase(state, 'replay-start', startCursor, true),
+    ...nextReplayBase('replay-start', startCursor),
     payload: {
       requestedCursor,
       startCursor,
@@ -381,7 +422,7 @@ export function buildTerminalStreamReplay(
       if (frame.payload.range.end <= startCursor) continue;
       if (frame.payload.range.start >= startCursor) {
         envelopes.push({
-          ...nextEnvelopeBase(state, 'data', frame.payload.range.end, true),
+          ...nextReplayBase('data', frame.payload.range.end),
           payload: frame.payload,
         });
         replayedFrames++;
@@ -390,7 +431,7 @@ export function buildTerminalStreamReplay(
       const offset = startCursor - frame.payload.range.start;
       const data = frame.payload.data.slice(offset);
       envelopes.push({
-        ...nextEnvelopeBase(state, 'data', frame.payload.range.end, true),
+        ...nextReplayBase('data', frame.payload.range.end),
         payload: {
           ...frame.payload,
           data,
@@ -403,7 +444,7 @@ export function buildTerminalStreamReplay(
   }
 
   envelopes.push({
-    ...nextEnvelopeBase(state, 'replay-end', state.cursor, true),
+    ...nextReplayBase('replay-end', state.cursor),
     payload: { cursor: state.cursor, replayedFrames },
   });
   return envelopes;

--- a/shared/session-replay.ts
+++ b/shared/session-replay.ts
@@ -33,3 +33,395 @@ export interface SessionReplaySnapshot {
   /** Session id this snapshot belongs to. */
   sessionId: string;
 }
+
+export const TERMINAL_STREAM_PROTOCOL_VERSION = 2 as const;
+
+export type TerminalStreamProtocolVersion =
+  typeof TERMINAL_STREAM_PROTOCOL_VERSION;
+
+export type TerminalStreamPayloadKind =
+  | 'metadata'
+  | 'data'
+  | 'replay-start'
+  | 'replay-end'
+  | 'lag'
+  | 'resize';
+
+export type TerminalStreamResizeOwner = 'active' | 'passive';
+
+export interface TerminalStreamCursorRange {
+  start: number;
+  end: number;
+}
+
+interface TerminalStreamEnvelopeBase<K extends TerminalStreamPayloadKind> {
+  type: 'terminal-stream';
+  version: TerminalStreamProtocolVersion;
+  sessionId: string;
+  /** Monotonic envelope sequence for this session stream. */
+  seq: number;
+  /** Monotonic cursor after this envelope has been applied. */
+  cursor: number;
+  kind: K;
+  timestamp: string;
+  /** True when emitted from bounded replay rather than live PTY output. */
+  replay: boolean;
+}
+
+export interface TerminalStreamMetadataPayload {
+  runtime: 'node-pty/tmux';
+  capacityBytes: number;
+  bytesDropped: number;
+  oldestCursor: number;
+  latestCursor: number;
+  resizePolicy: 'single-active-owner';
+  activeResizeOwnerId: string | null;
+  lastResize: TerminalStreamResizePayload | null;
+}
+
+export interface TerminalStreamDataPayload {
+  encoding: 'utf8';
+  data: string;
+  bytes: number;
+  range: TerminalStreamCursorRange;
+}
+
+export interface TerminalStreamReplayStartPayload {
+  requestedCursor: number | null;
+  startCursor: number;
+  endCursor: number;
+  bounded: true;
+}
+
+export interface TerminalStreamReplayEndPayload {
+  cursor: number;
+  replayedFrames: number;
+}
+
+export type TerminalStreamLagReason =
+  | 'cursor-too-old'
+  | 'cursor-too-new'
+  | 'server-backfill';
+
+export interface TerminalStreamLagPayload {
+  reason: TerminalStreamLagReason;
+  requestedCursor: number | null;
+  oldestCursor: number;
+  latestCursor: number;
+  bytesDropped: number;
+  message: string;
+}
+
+export interface TerminalStreamResizePayload {
+  cols: number;
+  rows: number;
+  owner: TerminalStreamResizeOwner;
+  ownerClientId: string | null;
+  sourceClientId: string;
+  applied: boolean;
+}
+
+export type TerminalStreamMetadataEnvelope =
+  TerminalStreamEnvelopeBase<'metadata'> & {
+    payload: TerminalStreamMetadataPayload;
+  };
+export type TerminalStreamDataEnvelope = TerminalStreamEnvelopeBase<'data'> & {
+  payload: TerminalStreamDataPayload;
+};
+export type TerminalStreamReplayStartEnvelope =
+  TerminalStreamEnvelopeBase<'replay-start'> & {
+    payload: TerminalStreamReplayStartPayload;
+  };
+export type TerminalStreamReplayEndEnvelope =
+  TerminalStreamEnvelopeBase<'replay-end'> & {
+    payload: TerminalStreamReplayEndPayload;
+  };
+export type TerminalStreamLagEnvelope = TerminalStreamEnvelopeBase<'lag'> & {
+  payload: TerminalStreamLagPayload;
+};
+export type TerminalStreamResizeEnvelope =
+  TerminalStreamEnvelopeBase<'resize'> & {
+    payload: TerminalStreamResizePayload;
+  };
+
+export type TerminalStreamEnvelope =
+  | TerminalStreamMetadataEnvelope
+  | TerminalStreamDataEnvelope
+  | TerminalStreamReplayStartEnvelope
+  | TerminalStreamReplayEndEnvelope
+  | TerminalStreamLagEnvelope
+  | TerminalStreamResizeEnvelope;
+
+export interface TerminalStreamState {
+  sessionId: string;
+  nextSeq: number;
+  /** Cursor after the newest byte retained/emitted by this session. */
+  cursor: number;
+  /** Cursor for the oldest retained byte; moves forward on FIFO/global trim. */
+  oldestCursor: number;
+  capacityBytes: number;
+  bytesDropped: number;
+  frames: TerminalStreamDataEnvelope[];
+  activeResizeOwnerId: string | null;
+  lastResize: TerminalStreamResizePayload | null;
+}
+
+export function createTerminalStreamState(input: {
+  sessionId: string;
+  capacityBytes?: number;
+  initialChunks?: string[];
+  bytesDropped?: number;
+}): TerminalStreamState {
+  const state: TerminalStreamState = {
+    sessionId: input.sessionId,
+    nextSeq: 0,
+    cursor: input.bytesDropped ?? 0,
+    oldestCursor: input.bytesDropped ?? 0,
+    capacityBytes:
+      input.capacityBytes ?? DEFAULT_SESSION_REPLAY_CAPACITY_BYTES,
+    bytesDropped: input.bytesDropped ?? 0,
+    frames: [],
+    activeResizeOwnerId: null,
+    lastResize: null,
+  };
+  for (const chunk of input.initialChunks ?? []) {
+    appendTerminalStreamData(state, chunk, true);
+  }
+  return state;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function nextEnvelopeBase<K extends TerminalStreamPayloadKind>(
+  state: TerminalStreamState,
+  kind: K,
+  cursor: number,
+  replay: boolean
+): TerminalStreamEnvelopeBase<K> {
+  return {
+    type: 'terminal-stream',
+    version: TERMINAL_STREAM_PROTOCOL_VERSION,
+    sessionId: state.sessionId,
+    seq: state.nextSeq++,
+    cursor,
+    kind,
+    timestamp: nowIso(),
+    replay,
+  };
+}
+
+export function appendTerminalStreamData(
+  state: TerminalStreamState,
+  data: string,
+  replay = false
+): TerminalStreamDataEnvelope {
+  const start = state.cursor;
+  const end = start + data.length;
+  state.cursor = end;
+  const envelope: TerminalStreamDataEnvelope = {
+    ...nextEnvelopeBase(state, 'data', end, replay),
+    payload: {
+      encoding: 'utf8',
+      data,
+      bytes: data.length,
+      range: { start, end },
+    },
+  };
+  state.frames.push(envelope);
+  trimTerminalStreamToCapacity(state);
+  return envelope;
+}
+
+export function trimTerminalStreamToCapacity(state: TerminalStreamState): void {
+  while (
+    state.cursor - state.oldestCursor > state.capacityBytes &&
+    state.frames.length > 1
+  ) {
+    const evicted = state.frames.shift()!;
+    state.oldestCursor = evicted.payload.range.end;
+    state.bytesDropped = Math.max(state.bytesDropped, state.oldestCursor);
+  }
+}
+
+export function dropTerminalStreamPrefixBytes(
+  state: TerminalStreamState | undefined,
+  bytes: number
+): void {
+  if (!state || bytes <= 0) return;
+  const target = Math.min(state.cursor, state.oldestCursor + bytes);
+  state.oldestCursor = Math.max(state.oldestCursor, target);
+  state.bytesDropped = Math.max(state.bytesDropped, state.oldestCursor);
+  state.frames = state.frames
+    .map((frame) => {
+      if (frame.payload.range.end <= state.oldestCursor) return null;
+      if (frame.payload.range.start >= state.oldestCursor) return frame;
+      const offset = state.oldestCursor - frame.payload.range.start;
+      const data = frame.payload.data.slice(offset);
+      return {
+        ...frame,
+        payload: {
+          ...frame.payload,
+          data,
+          bytes: data.length,
+          range: { start: state.oldestCursor, end: frame.payload.range.end },
+        },
+      };
+    })
+    .filter((frame): frame is TerminalStreamDataEnvelope => frame !== null);
+}
+
+export function terminalStreamMetadata(
+  state: TerminalStreamState,
+  replay = false,
+  cursor = state.cursor
+): TerminalStreamMetadataEnvelope {
+  return {
+    ...nextEnvelopeBase(state, 'metadata', cursor, replay),
+    payload: {
+      runtime: 'node-pty/tmux',
+      capacityBytes: state.capacityBytes,
+      bytesDropped: state.bytesDropped,
+      oldestCursor: state.oldestCursor,
+      latestCursor: state.cursor,
+      resizePolicy: 'single-active-owner',
+      activeResizeOwnerId: state.activeResizeOwnerId,
+      lastResize: state.lastResize,
+    },
+  };
+}
+
+export function recordTerminalStreamResize(
+  state: TerminalStreamState,
+  input: {
+    cols: number;
+    rows: number;
+    owner: TerminalStreamResizeOwner;
+    sourceClientId: string;
+  }
+): TerminalStreamResizeEnvelope {
+  const applied = input.owner === 'active';
+  if (applied) state.activeResizeOwnerId = input.sourceClientId;
+  const payload: TerminalStreamResizePayload = {
+    cols: input.cols,
+    rows: input.rows,
+    owner: input.owner,
+    ownerClientId: state.activeResizeOwnerId,
+    sourceClientId: input.sourceClientId,
+    applied,
+  };
+  state.lastResize = payload;
+  return {
+    ...nextEnvelopeBase(state, 'resize', state.cursor, false),
+    payload,
+  };
+}
+
+export function buildTerminalStreamReplay(
+  state: TerminalStreamState,
+  requestedCursor: number | null
+): TerminalStreamEnvelope[] {
+  const envelopes: TerminalStreamEnvelope[] = [];
+  const replayFrom = requestedCursor ?? state.oldestCursor;
+  const tooOld = requestedCursor !== null && replayFrom < state.oldestCursor;
+  const tooNew = requestedCursor !== null && replayFrom > state.cursor;
+  const startCursor = tooOld
+    ? state.oldestCursor
+    : tooNew
+      ? state.cursor
+      : Math.max(state.oldestCursor, replayFrom);
+
+  envelopes.push(terminalStreamMetadata(state, true, startCursor));
+  if (tooOld || tooNew) {
+    const reason: TerminalStreamLagReason = tooOld
+      ? 'cursor-too-old'
+      : 'cursor-too-new';
+    envelopes.push({
+      ...nextEnvelopeBase(state, 'lag', startCursor, true),
+      payload: {
+        reason,
+        requestedCursor,
+        oldestCursor: state.oldestCursor,
+        latestCursor: state.cursor,
+        bytesDropped: state.bytesDropped,
+        message:
+          reason === 'cursor-too-old'
+            ? 'requested terminal cursor is older than the bounded replay buffer; replay starts at the oldest retained cursor'
+            : 'requested terminal cursor is newer than the server cursor; replay is empty and live output will continue from the current cursor',
+      },
+    });
+  } else if (requestedCursor !== null && requestedCursor < state.cursor) {
+    envelopes.push({
+      ...nextEnvelopeBase(state, 'lag', startCursor, true),
+      payload: {
+        reason: 'server-backfill',
+        requestedCursor,
+        oldestCursor: state.oldestCursor,
+        latestCursor: state.cursor,
+        bytesDropped: state.bytesDropped,
+        message: 'server is backfilling terminal output from the requested cursor',
+      },
+    });
+  }
+
+  envelopes.push({
+    ...nextEnvelopeBase(state, 'replay-start', startCursor, true),
+    payload: {
+      requestedCursor,
+      startCursor,
+      endCursor: state.cursor,
+      bounded: true,
+    },
+  });
+
+  let replayedFrames = 0;
+  if (!tooNew) {
+    for (const frame of state.frames) {
+      if (frame.payload.range.end <= startCursor) continue;
+      if (frame.payload.range.start >= startCursor) {
+        envelopes.push({
+          ...nextEnvelopeBase(state, 'data', frame.payload.range.end, true),
+          payload: frame.payload,
+        });
+        replayedFrames++;
+        continue;
+      }
+      const offset = startCursor - frame.payload.range.start;
+      const data = frame.payload.data.slice(offset);
+      envelopes.push({
+        ...nextEnvelopeBase(state, 'data', frame.payload.range.end, true),
+        payload: {
+          ...frame.payload,
+          data,
+          bytes: data.length,
+          range: { start: startCursor, end: frame.payload.range.end },
+        },
+      });
+      replayedFrames++;
+    }
+  }
+
+  envelopes.push({
+    ...nextEnvelopeBase(state, 'replay-end', state.cursor, true),
+    payload: { cursor: state.cursor, replayedFrames },
+  });
+  return envelopes;
+}
+
+export function isTerminalStreamEnvelope(
+  value: unknown
+): value is TerminalStreamEnvelope {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    record['type'] === 'terminal-stream' &&
+    record['version'] === TERMINAL_STREAM_PROTOCOL_VERSION &&
+    typeof record['sessionId'] === 'string' &&
+    typeof record['seq'] === 'number' &&
+    typeof record['cursor'] === 'number' &&
+    typeof record['kind'] === 'string' &&
+    typeof record['payload'] === 'object' &&
+    record['payload'] !== null
+  );
+}

--- a/test/pty-pause.test.ts
+++ b/test/pty-pause.test.ts
@@ -231,6 +231,39 @@ describe('pausePtyFeed / resumePtyFeed', () => {
     expect(ws.isPtyConnected('sess-a')).toBe(true);
     expect(sockets[0]!.close).not.toHaveBeenCalled();
   });
+
+  it('marks inactive mirrors passive and restores active resize ownership on resume', async () => {
+    const ws = await importWs();
+    const term = fakeTerm();
+    ws.connectPtySocket('sess-a', term, vi.fn(), vi.fn());
+    sockets[0]!.__triggerOpen();
+
+    ws.sendPtyResize('sess-a', 120, 40);
+    expect(JSON.parse(sockets[0]!.send.mock.calls.at(-1)![0])).toMatchObject({
+      type: 'resize',
+      cols: 120,
+      rows: 40,
+      owner: 'active',
+    });
+
+    ws.pausePtyFeed('sess-a');
+    ws.sendPtyResize('sess-a', 80, 24);
+    expect(JSON.parse(sockets[0]!.send.mock.calls.at(-1)![0])).toMatchObject({
+      type: 'resize',
+      cols: 80,
+      rows: 24,
+      owner: 'passive',
+    });
+
+    ws.resumePtyFeed('sess-a');
+    ws.sendPtyResize('sess-a', 132, 43);
+    expect(JSON.parse(sockets[0]!.send.mock.calls.at(-1)![0])).toMatchObject({
+      type: 'resize',
+      cols: 132,
+      rows: 43,
+      owner: 'active',
+    });
+  });
 });
 
 describe('pause ring buffer — 256 KB cap with FIFO eviction', () => {

--- a/test/session-replay.test.ts
+++ b/test/session-replay.test.ts
@@ -4,7 +4,14 @@ import os from 'node:os';
 import path from 'node:path';
 import * as sessions from '../server/sessions.js';
 import type { PtySession } from '../server/types.js';
-import { DEFAULT_SESSION_REPLAY_CAPACITY_BYTES } from '../shared/session-replay.js';
+import {
+  appendTerminalStreamData,
+  buildTerminalStreamReplay,
+  createTerminalStreamState,
+  DEFAULT_SESSION_REPLAY_CAPACITY_BYTES,
+  dropTerminalStreamPrefixBytes,
+  recordTerminalStreamResize,
+} from '../shared/session-replay.js';
 
 const createdIds: string[] = [];
 let tmuxTmpdir: string;
@@ -96,5 +103,103 @@ describe('getReplaySnapshot', () => {
     const snap = sessions.getReplaySnapshot(result.id);
     expect(snap?.bytesDropped).toBe(12_345);
     expect(snap?.truncated).toBe(true);
+  });
+});
+
+describe('terminal stream v2 replay envelopes', () => {
+  it('backfills from a known cursor with monotonic envelope sequence and cursor', () => {
+    const state = createTerminalStreamState({ sessionId: 'sess-replay' });
+    appendTerminalStreamData(state, 'hello');
+    appendTerminalStreamData(state, ' world');
+
+    const replay = buildTerminalStreamReplay(state, 5);
+
+    expect(replay.map((envelope) => envelope.kind)).toEqual([
+      'metadata',
+      'lag',
+      'replay-start',
+      'data',
+      'replay-end',
+    ]);
+    expect(replay[1]?.kind).toBe('lag');
+    if (replay[1]?.kind === 'lag') {
+      expect(replay[1].payload.reason).toBe('server-backfill');
+      expect(replay[1].payload.requestedCursor).toBe(5);
+    }
+    const replayedData = replay.find((envelope) => envelope.kind === 'data');
+    expect(replayedData?.kind).toBe('data');
+    if (replayedData?.kind === 'data') {
+      expect(replayedData.payload.data).toBe(' world');
+      expect(replayedData.payload.range).toEqual({ start: 5, end: 11 });
+    }
+    expect(replay.map((envelope) => envelope.seq)).toEqual([2, 3, 4, 5, 6]);
+    expect(replay.map((envelope) => envelope.cursor)).toEqual([5, 5, 5, 11, 11]);
+  });
+
+  it('marks too-old cursors stale and replays from the oldest retained cursor', () => {
+    const state = createTerminalStreamState({ sessionId: 'sess-stale' });
+    appendTerminalStreamData(state, 'abcdef');
+    dropTerminalStreamPrefixBytes(state, 3);
+
+    const replay = buildTerminalStreamReplay(state, 0);
+    const lag = replay.find((envelope) => envelope.kind === 'lag');
+    const replayStart = replay.find(
+      (envelope) => envelope.kind === 'replay-start'
+    );
+    const replayedData = replay.find((envelope) => envelope.kind === 'data');
+
+    expect(lag?.kind).toBe('lag');
+    if (lag?.kind === 'lag') {
+      expect(lag.payload.reason).toBe('cursor-too-old');
+      expect(lag.payload.oldestCursor).toBe(3);
+      expect(lag.payload.latestCursor).toBe(6);
+    }
+    expect(replayStart?.kind).toBe('replay-start');
+    if (replayStart?.kind === 'replay-start') {
+      expect(replayStart.payload.startCursor).toBe(3);
+      expect(replayStart.payload.endCursor).toBe(6);
+    }
+    expect(replayedData?.kind).toBe('data');
+    if (replayedData?.kind === 'data') {
+      expect(replayedData.payload.data).toBe('def');
+      expect(replayedData.payload.range).toEqual({ start: 3, end: 6 });
+    }
+  });
+});
+
+describe('terminal stream v2 resize ownership', () => {
+  it('applies active resize owner events and records passive mirrors as non-applying', () => {
+    const state = createTerminalStreamState({ sessionId: 'sess-resize' });
+
+    const active = recordTerminalStreamResize(state, {
+      cols: 120,
+      rows: 40,
+      owner: 'active',
+      sourceClientId: 'client-active',
+    });
+    const passive = recordTerminalStreamResize(state, {
+      cols: 80,
+      rows: 24,
+      owner: 'passive',
+      sourceClientId: 'client-passive',
+    });
+
+    expect(active.payload).toMatchObject({
+      cols: 120,
+      rows: 40,
+      owner: 'active',
+      ownerClientId: 'client-active',
+      sourceClientId: 'client-active',
+      applied: true,
+    });
+    expect(passive.payload).toMatchObject({
+      cols: 80,
+      rows: 24,
+      owner: 'passive',
+      ownerClientId: 'client-active',
+      sourceClientId: 'client-passive',
+      applied: false,
+    });
+    expect(state.activeResizeOwnerId).toBe('client-active');
   });
 });

--- a/test/session-replay.test.ts
+++ b/test/session-replay.test.ts
@@ -111,6 +111,7 @@ describe('terminal stream v2 replay envelopes', () => {
     const state = createTerminalStreamState({ sessionId: 'sess-replay' });
     appendTerminalStreamData(state, 'hello');
     appendTerminalStreamData(state, ' world');
+    const beforeReplayNextSeq = state.nextSeq;
 
     const replay = buildTerminalStreamReplay(state, 5);
 
@@ -133,7 +134,13 @@ describe('terminal stream v2 replay envelopes', () => {
       expect(replayedData.payload.range).toEqual({ start: 5, end: 11 });
     }
     expect(replay.map((envelope) => envelope.seq)).toEqual([2, 3, 4, 5, 6]);
-    expect(replay.map((envelope) => envelope.cursor)).toEqual([5, 5, 5, 11, 11]);
+    expect(replay.map((envelope) => envelope.cursor)).toEqual([
+      5, 5, 5, 11, 11,
+    ]);
+    expect(state.nextSeq).toBe(beforeReplayNextSeq);
+
+    const liveAfterReplay = appendTerminalStreamData(state, '!');
+    expect(liveAfterReplay.seq).toBe(beforeReplayNextSeq);
   });
 
   it('marks too-old cursors stale and replays from the oldest retained cursor', () => {

--- a/test/ws-pty-intervention.test.ts
+++ b/test/ws-pty-intervention.test.ts
@@ -9,7 +9,10 @@ import { once } from 'node:events';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { WebSocket } from 'ws';
 import * as sessions from '../server/sessions.js';
-import { closeInterventionLog, initInterventionLog } from '../server/intervention-log.js';
+import {
+  closeInterventionLog,
+  initInterventionLog,
+} from '../server/intervention-log.js';
 import { setupWebSocket } from '../server/ws.js';
 import type { PtySession } from '../server/types.js';
 import type { SecurityAuditEntryInput } from '../shared/security-audit.js';
@@ -34,7 +37,10 @@ async function waitForOpen(ws: WebSocket): Promise<void> {
   ]);
 }
 
-async function waitForInterventionCount(sessionId: string, count: number): Promise<void> {
+async function waitForInterventionCount(
+  sessionId: string,
+  count: number
+): Promise<void> {
   for (let i = 0; i < 50; i++) {
     if (sessions.getInterventions(sessionId).length === count) return;
     await delay(10);
@@ -55,7 +61,10 @@ beforeAll(() => {
 });
 
 afterEach(async () => {
-  const ids = new Set([...createdIds, ...sessions.list().map((session) => session.id)]);
+  const ids = new Set([
+    ...createdIds,
+    ...sessions.list().map((session) => session.id),
+  ]);
   for (const id of Array.from(ids)) {
     try {
       sessions.kill(id);
@@ -88,13 +97,23 @@ afterAll(async () => {
 
 describe('PTY WebSocket intervention control', () => {
   it('records browser PTY input through the control engine without treating ping or resize as input', async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ide-interventions-'));
-    cleanupFns.push(() => fs.rmSync(configDir, { recursive: true, force: true }));
+    const configDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-ide-interventions-')
+    );
+    cleanupFns.push(() =>
+      fs.rmSync(configDir, { recursive: true, force: true })
+    );
     initInterventionLog(configDir);
     sessions.configure({ configDir, interventionDebounceMs: 5 });
 
     const server = http.createServer();
-    const { wss } = setupWebSocket(server, new Set<string>(), null, undefined, true);
+    const { wss } = setupWebSocket(
+      server,
+      new Set<string>(),
+      null,
+      undefined,
+      true
+    );
     cleanupFns.push(() => closeServer(server));
     cleanupFns.push(() => wss.close());
     await new Promise<void>((resolve) => server.listen(0, resolve));
@@ -135,8 +154,20 @@ describe('PTY WebSocket intervention control', () => {
     ws.send(JSON.stringify({ type: 'resize', cols: 101, rows: 33 }));
     await delay(20);
 
+    for (const invalidResize of [
+      { type: 'resize', cols: 0, rows: 33 },
+      { type: 'resize', cols: 101, rows: 0 },
+      { type: 'resize', cols: '101', rows: 33 },
+      { type: 'resize', cols: 101 },
+    ]) {
+      ws.send(JSON.stringify(invalidResize));
+    }
+    await delay(20);
+
     expect(sessions.getInterventions(result.id)).toEqual([]);
-    expect((sessions.get(result.id) as PtySession).controlState?.controlMode).toBe('agent-driven');
+    expect(
+      (sessions.get(result.id) as PtySession).controlState?.controlMode
+    ).toBe('agent-driven');
 
     ws.send('hello from browser\n');
     await waitForInterventionCount(result.id, 1);
@@ -157,12 +188,18 @@ describe('PTY WebSocket intervention control', () => {
   });
 
   it('records remote routed PTY input through the real sessions recorder', async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ide-routed-interventions-'));
-    cleanupFns.push(() => fs.rmSync(configDir, { recursive: true, force: true }));
+    const configDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-ide-routed-interventions-')
+    );
+    cleanupFns.push(() =>
+      fs.rmSync(configDir, { recursive: true, force: true })
+    );
     initInterventionLog(configDir);
     sessions.configure({ configDir, interventionDebounceMs: 5 });
 
-    const events: Array<Parameters<Parameters<typeof sessions.onControlEvent>[0]>[0]> = [];
+    const events: Array<
+      Parameters<Parameters<typeof sessions.onControlEvent>[0]>[0]
+    > = [];
     sessions.onControlEvent((event) => events.push(event));
 
     sessions.recordRoutedPtyInput({
@@ -172,7 +209,9 @@ describe('PTY WebSocket intervention control', () => {
     });
 
     await waitForInterventionCount('remote-session-a', 1);
-    const records = sessions.getInterventions('remote-session-a', { nodeId: 'remote-node-a' });
+    const records = sessions.getInterventions('remote-session-a', {
+      nodeId: 'remote-node-a',
+    });
 
     expect(records).toHaveLength(1);
     expect(records[0]).toMatchObject({
@@ -186,7 +225,10 @@ describe('PTY WebSocket intervention control', () => {
       modeAfter: 'co-driven',
       payloadPreview: 'echo routed\\n',
     });
-    expect(events.map((event) => event.type)).toEqual(['tab.mode-changed', 'tab.intervention']);
+    expect(events.map((event) => event.type)).toEqual([
+      'tab.mode-changed',
+      'tab.intervention',
+    ]);
     expect(events[0]?.identity).toMatchObject({
       nodeId: 'remote-node-a',
       sessionId: 'remote-session-a',
@@ -195,8 +237,12 @@ describe('PTY WebSocket intervention control', () => {
   });
 
   it('still appends control audit entries when a control-event listener throws', async () => {
-    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ide-audit-isolation-'));
-    cleanupFns.push(() => fs.rmSync(configDir, { recursive: true, force: true }));
+    const configDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-ide-audit-isolation-')
+    );
+    cleanupFns.push(() =>
+      fs.rmSync(configDir, { recursive: true, force: true })
+    );
     initInterventionLog(configDir);
     const auditEntries: SecurityAuditEntryInput[] = [];
     sessions.configure({
@@ -204,7 +250,9 @@ describe('PTY WebSocket intervention control', () => {
       interventionDebounceMs: 5,
       securityAuditSink: { append: (entry) => auditEntries.push(entry) },
     });
-    const deliveredEvents: Array<Parameters<Parameters<typeof sessions.onControlEvent>[0]>[0]> = [];
+    const deliveredEvents: Array<
+      Parameters<Parameters<typeof sessions.onControlEvent>[0]>[0]
+    > = [];
     sessions.onControlEvent(() => {
       throw new Error('listener boom');
     });

--- a/test/ws-pty-routing.test.ts
+++ b/test/ws-pty-routing.test.ts
@@ -138,9 +138,12 @@ describe('per-session PTY routing', () => {
     sockets[0]!.__triggerOpen();
     sockets[1]!.__triggerOpen();
     ws.sendPtyResize('sess-a', 80, 24);
-    expect(sockets[0]!.send).toHaveBeenCalledWith(
-      JSON.stringify({ type: 'resize', cols: 80, rows: 24 })
-    );
+    expect(JSON.parse(sockets[0]!.send.mock.calls[0]![0])).toMatchObject({
+      type: 'resize',
+      cols: 80,
+      rows: 24,
+      owner: 'active',
+    });
     expect(sockets[1]!.send).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- adds a shared terminal stream v2 envelope with replay metadata, cursor-based backfill, lag notices, and resize-owner events
- emits the envelope on the existing local node-pty/tmux WebSocket path without adding an rmux runtime
- teaches the browser PTY socket to reconnect with the last cursor and mark paused mirrors as passive resize owners
- documents the contract as the gate for future rmux adapters

Closes #703

## Test Plan
- npm test -- --run test/session-replay.test.ts test/pty-pause.test.ts test/ws-pty-routing.test.ts
- npm run check
- npm run build
- npm test (fails only pre-existing/environmental: test/fs-browse.test.ts expects non-empty os.homedir(); this worker profile home is empty)