### PR TITLE
feat: add rmux diagnostic capability probe

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -15,7 +15,11 @@ import {
   RELAY_NODE_LINK_PROTOCOL_VERSION,
   type HubNodeSummary,
 } from '../shared/relay-node-protocol.js';
-import type { NodeManifest } from '../shared/node-manifest.js';
+import type {
+  NodeManifest,
+  RmuxCapabilityProbe,
+  RmuxR0ChecklistItem,
+} from '../shared/node-manifest.js';
 import type { Config, SessionSummary } from '../server/types.js';
 import { createSupervisorSnapshot } from '../server/supervisor-snapshot.js';
 import { createNodeLinkClient } from '../server/node-link-client.js';
@@ -2829,6 +2833,8 @@ interface NodeDoctorResult {
     description: string;
     severity: string;
   }>;
+  rmuxCapability?: RmuxCapabilityProbe;
+  rmuxR0Checklist?: RmuxR0ChecklistItem[];
   hubUrl?: string;
   hubReachable?: boolean;
   hubError?: string;
@@ -2890,6 +2896,22 @@ function collectNodeDoctorReasons(
   return all;
 }
 
+function printRmuxDoctorHuman(rmux: RmuxCapabilityProbe | undefined): void {
+  if (!rmux) return;
+  logger.info(
+    `rmux optional capability: ${rmux.status} | binary: ${rmux.binaryPresent ? 'yes' : 'no'} | helper: ${rmux.helperPresent ? 'yes' : 'no'} | ipc: ${rmux.ipc.kind}`
+  );
+  if (rmux.version) logger.info(`  rmux version: ${rmux.version}`);
+  if (rmux.binaryPath) logger.info(`  rmux binary: ${rmux.binaryPath}`);
+  if (rmux.helperPath && rmux.helperPath !== rmux.binaryPath)
+    logger.info(`  rmux helper: ${rmux.helperPath}`);
+  logger.info(`  rmux probe: ${rmux.message}`);
+  logger.info(`  rmux ipc shape: ${rmux.ipc.shape}`);
+  for (const item of rmux.r0Checklist) {
+    logger.info(`  rmux R0 ${item.status} ${item.id}: ${item.message}`);
+  }
+}
+
 /** Print the human-readable doctor report. */
 function printNodeDoctorHuman(
   manifest: NodeManifest,
@@ -2910,6 +2932,7 @@ function printNodeDoctorHuman(
   logger.info(
     `service installed: ${st.installed ? 'yes' : 'no'} | running: ${st.running ? 'yes' : 'no'}`
   );
+  printRmuxDoctorHuman(manifest.capabilities.rmux);
   for (const caveat of manifest.serviceManager.caveats) {
     logger.info(`  caveat: ${caveat}`);
   }
@@ -2972,6 +2995,12 @@ async function runNodeDoctor(
         message: manifest.serviceManager.message,
       },
       degradedReasons: allDegraded,
+      ...(manifest.capabilities.rmux !== undefined
+        ? {
+            rmuxCapability: manifest.capabilities.rmux,
+            rmuxR0Checklist: manifest.capabilities.rmux.r0Checklist,
+          }
+        : {}),
       ...(hubUrl !== undefined ? { hubUrl } : {}),
       ...(hubCheck.reachable !== undefined
         ? { hubReachable: hubCheck.reachable }

--- a/docs/RELAY_NODE_BOOTSTRAP.md
+++ b/docs/RELAY_NODE_BOOTSTRAP.md
@@ -445,6 +445,12 @@ This prints (human-readable):
 
 Exit code is 0 when `ok` is true (no `warn` or `error` degraded reasons and hub reachable if `--hub` supplied), 1 otherwise.
 
+### Optional rmux capability probe
+
+`relay-ide manifest` and node diagnostics may include an `rmux` capability record when an `rmux` binary or `RMUX_SDK_DAEMON_BINARY` helper override is visible on the node. This is diagnostic-only: Relay does not bundle rmux, install rmux, supervise an rmux daemon, or switch the terminal/session backend to rmux by default.
+
+If `RMUX_SDK_DAEMON_BINARY` is set, the probe executes that explicit helper override rather than silently falling back to a different `rmux` found on `PATH`. A bad override is reported as a non-fatal `probe-failed` capability so bootstrap and doctor output can show the configuration problem without blocking the existing Relay backend.
+
 ### Service logs by platform
 
 | Platform      | Command                                                                        |

--- a/server/node-manifest.ts
+++ b/server/node-manifest.ts
@@ -9,6 +9,7 @@ import { resolveExecutablePath } from './frameworks.js';
 import { detectServiceManager, detectWslInfo } from './service.js';
 import { decorateManifestWithFrameworks } from './features/frameworks.js';
 import { enrichManifest } from './node-manifest-build.js';
+import { probeRmuxCapability } from './rmux-probe.js';
 import type {
   NodeCapabilities,
   NodeCapabilityProbe,
@@ -168,6 +169,7 @@ function getNodeCapabilities(
     // raw shell that dies on detach. #469 will introduce
     // 'canonical-emulator' for server-side terminal state.
     sessionResume: tmux.status === 'available' ? 'tmux' : 'none',
+    rmux: probeRmuxCapability({ env, platform }),
     agents: {},
   };
 }

--- a/server/rmux-probe.ts
+++ b/server/rmux-probe.ts
@@ -209,21 +209,32 @@ function failureMessage(result: SpawnSyncReturns<string>): string {
   return `rmux --version exited with status ${result.status ?? 'unknown'}`;
 }
 
+function isPlatformAbsolutePath(value: string, platform: NodeJS.Platform): boolean {
+  return platform === 'win32' ? path.win32.isAbsolute(value) : path.posix.isAbsolute(value);
+}
+
 function resolveRmuxPaths(
   resolveExecutable: (name: string, env: NodeJS.ProcessEnv) => string | null,
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform
 ): RmuxResolvedPaths {
   const binaryPath = resolveExecutable('rmux', env) ?? undefined;
   const configuredHelper = env[RMUX_BINARY_ENV];
-  const helperPath = configuredHelper
-    ? path.isAbsolute(configuredHelper)
-      ? configuredHelper
-      : (resolveExecutable(configuredHelper, env) ?? undefined)
-    : binaryPath;
+  if (!configuredHelper) {
+    return {
+      binaryPath,
+      helperPath: binaryPath,
+      command: binaryPath,
+    };
+  }
+
+  const helperPath = isPlatformAbsolutePath(configuredHelper, platform)
+    ? configuredHelper
+    : (resolveExecutable(configuredHelper, env) ?? undefined);
   return {
     binaryPath,
     helperPath,
-    command: helperPath ?? binaryPath,
+    command: helperPath ?? configuredHelper,
   };
 }
 
@@ -298,7 +309,7 @@ export function probeRmuxCapability(deps: RmuxProbeDeps = {}): RmuxCapabilityPro
   const resolveExecutable = deps.resolveExecutable ?? resolveExecutablePath;
   const spawn = deps.spawn ?? ((command, args, options) => spawnSync(command, args, options));
   const ipc = endpointFromEnv(env[RMUX_ENDPOINT_ENV], platform) ?? platformDefaultIpcShape(platform);
-  const paths = resolveRmuxPaths(resolveExecutable, env);
+  const paths = resolveRmuxPaths(resolveExecutable, env, platform);
 
   if (!paths.command) return unavailableProbe(platform, arch, ipc);
 

--- a/server/rmux-probe.ts
+++ b/server/rmux-probe.ts
@@ -1,0 +1,318 @@
+import type { SpawnSyncReturns } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveExecutablePath } from './frameworks.js';
+import type {
+  RmuxCapabilityProbe,
+  RmuxIpcShape,
+  RmuxProbeStatus,
+  RmuxR0ChecklistItem,
+} from '../shared/node-manifest.js';
+
+const RMUX_BINARY_ENV = 'RMUX_SDK_DAEMON_BINARY';
+const RMUX_ENDPOINT_ENV = 'RMUX_SDK_ENDPOINT';
+const RMUX_TIMEOUT_ENV = 'RMUX_SDK_TIMEOUT_MS';
+const PINNED_RMUX_SOURCE = 'Helvesec/rmux@a37614c026e18616fa57bc27ae23e1f8241c43fe';
+const DEFAULT_PROBE_TIMEOUT_MS = 1_000;
+const MINIMUM_SUPPORTED_VERSION = { major: 0, minor: 1, patch: 0 };
+
+interface RmuxProbeDeps {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  arch?: string;
+  resolveExecutable?: (command: string, env: NodeJS.ProcessEnv) => string | null;
+  spawn?: (
+    command: string,
+    args: string[],
+    options: {
+      encoding: BufferEncoding;
+      timeout: number;
+      stdio: ['ignore', 'pipe', 'pipe'];
+      env: NodeJS.ProcessEnv;
+    }
+  ) => SpawnSyncReturns<string>;
+}
+
+interface ParsedVersion {
+  raw: string;
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease?: string;
+}
+
+interface RmuxResolvedPaths {
+  binaryPath: string | undefined;
+  helperPath: string | undefined;
+  command: string | undefined;
+}
+
+function optionalStringProperty<K extends string>(
+  key: K,
+  value: string | undefined
+): Partial<Record<K, string>> {
+  return value ? ({ [key]: value } as Record<K, string>) : {};
+}
+
+function parsePositiveTimeout(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.min(Math.floor(parsed), 10_000);
+}
+
+function firstOutputLine(result: SpawnSyncReturns<string>): string | undefined {
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
+  const first = output.split('\n')[0]?.trim();
+  return first || undefined;
+}
+
+function parseRmuxVersion(output: string | undefined): ParsedVersion | undefined {
+  if (!output) return undefined;
+  const match = /(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/.exec(output);
+  if (!match) return undefined;
+  const [, majorRaw, minorRaw, patchRaw, prerelease] = match;
+  if (majorRaw === undefined || minorRaw === undefined || patchRaw === undefined)
+    return undefined;
+  return {
+    raw: match[0],
+    major: Number(majorRaw),
+    minor: Number(minorRaw),
+    patch: Number(patchRaw),
+    ...(prerelease ? { prerelease } : {}),
+  };
+}
+
+function compareVersion(a: ParsedVersion, b: typeof MINIMUM_SUPPORTED_VERSION): number {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
+}
+
+function isAbsoluteUnixPath(value: string): boolean {
+  return value.startsWith('/') && !value.includes('\0');
+}
+
+function endpointFromEnv(
+  endpoint: string | undefined,
+  platform: NodeJS.Platform
+): RmuxIpcShape | undefined {
+  if (!endpoint) return undefined;
+  if (platform === 'win32') {
+    const isPipe = endpoint.startsWith('\\\\.\\pipe\\');
+    return {
+      kind: isPipe ? 'windows-pipe' : 'unknown',
+      source: 'env',
+      endpoint,
+      shape: isPipe
+        ? '\\\\.\\pipe\\rmux-{SID}-il-{integrity}-{label} named pipe override'
+        : 'RMUX_SDK_ENDPOINT override is present but does not match the default Windows pipe prefix.',
+    };
+  }
+  return {
+    kind: isAbsoluteUnixPath(endpoint) ? 'unix-socket' : 'unknown',
+    source: 'env',
+    endpoint,
+    shape: isAbsoluteUnixPath(endpoint)
+      ? 'absolute Unix socket path from RMUX_SDK_ENDPOINT'
+      : 'RMUX_SDK_ENDPOINT override is present but is not an absolute Unix socket path.',
+  };
+}
+
+function platformDefaultIpcShape(platform: NodeJS.Platform): RmuxIpcShape {
+  if (platform === 'win32') {
+    return {
+      kind: 'windows-pipe',
+      source: 'platform-default',
+      shape: '\\\\.\\pipe\\rmux-{SID}-il-{integrity}-{label} per-user named pipe',
+    };
+  }
+  return {
+    kind: 'unix-socket',
+    source: 'platform-default',
+    shape: 'owner-only Unix socket under rmux-$uid runtime directory',
+  };
+}
+
+function buildR0Checklist(input: {
+  status: RmuxProbeStatus;
+  version?: ParsedVersion;
+  ipc: RmuxIpcShape;
+  binaryPath?: string;
+  helperPath?: string;
+}): RmuxR0ChecklistItem[] {
+  const versionPinned = input.version !== undefined && input.status === 'available-experimental';
+  return [
+    {
+      id: 'version-pinning',
+      status: versionPinned ? 'warn' : input.status === 'available-but-unsupported' ? 'fail' : 'unknown',
+      message: versionPinned
+        ? `rmux ${input.version?.raw} detected; Relay has not adopted rmux by default and only records diagnostics against ${PINNED_RMUX_SOURCE}.`
+        : input.status === 'available-but-unsupported'
+          ? 'rmux responded, but its version is below the diagnostic compatibility floor.'
+          : 'rmux version could not be pinned by this diagnostic probe.',
+    },
+    {
+      id: 'crash-restart-behavior',
+      status: input.status === 'available-experimental' ? 'warn' : 'unknown',
+      message:
+        input.status === 'available-experimental'
+          ? 'rmux SDK startup has documented daemon race/restart handling, but Relay does not supervise or depend on it yet.'
+          : 'Crash/restart behavior was not exercised; Relay runtime remains on the existing backend.',
+    },
+    {
+      id: 'socket-ipc-exposure',
+      status: input.ipc.kind === 'unknown' ? 'warn' : 'pass',
+      message: `IPC shape: ${input.ipc.shape}`,
+    },
+    {
+      id: 'permission-boundary',
+      status: input.ipc.kind === 'unknown' ? 'unknown' : 'pass',
+      message:
+        input.ipc.kind === 'windows-pipe'
+          ? 'Expected rmux named pipe remains scoped by Windows per-user pipe ACLs; Relay opens no listener.'
+          : input.ipc.kind === 'unix-socket'
+            ? 'Expected rmux socket remains owner-only; Relay opens no listener.'
+            : 'Permission boundary could not be inferred from the endpoint shape.',
+    },
+    {
+      id: 'packaging-update-path',
+      status: input.binaryPath || input.helperPath ? 'warn' : 'unknown',
+      message:
+        input.binaryPath || input.helperPath
+          ? 'rmux is externally installed; Relay does not bundle, install, or update it by default.'
+          : 'No rmux binary/helper found; Relay packaging remains unchanged.',
+    },
+  ];
+}
+
+function unavailableProbe(platform: NodeJS.Platform, arch: string, ipc: RmuxIpcShape): RmuxCapabilityProbe {
+  return {
+    id: 'rmux',
+    label: 'rmux optional backend probe',
+    status: 'unavailable',
+    binaryPresent: false,
+    helperPresent: false,
+    platform,
+    arch,
+    ipc,
+    message: 'rmux is not installed or not on PATH; optional rmux backend remains disabled.',
+    r0Checklist: buildR0Checklist({ status: 'unavailable', ipc }),
+  };
+}
+
+function failureMessage(result: SpawnSyncReturns<string>): string {
+  if (result.error) return result.error.message;
+  const line = firstOutputLine(result);
+  if (line) return line;
+  return `rmux --version exited with status ${result.status ?? 'unknown'}`;
+}
+
+function resolveRmuxPaths(
+  resolveExecutable: (name: string, env: NodeJS.ProcessEnv) => string | null,
+  env: NodeJS.ProcessEnv
+): RmuxResolvedPaths {
+  const binaryPath = resolveExecutable('rmux', env) ?? undefined;
+  const configuredHelper = env[RMUX_BINARY_ENV];
+  const helperPath = configuredHelper
+    ? path.isAbsolute(configuredHelper)
+      ? configuredHelper
+      : (resolveExecutable(configuredHelper, env) ?? undefined)
+    : binaryPath;
+  return {
+    binaryPath,
+    helperPath,
+    command: helperPath ?? binaryPath,
+  };
+}
+
+function rmuxProbeBase(input: {
+  platform: NodeJS.Platform;
+  arch: string;
+  ipc: RmuxIpcShape;
+  paths: RmuxResolvedPaths;
+}) {
+  return {
+    id: 'rmux' as const,
+    label: 'rmux optional backend probe',
+    binaryPresent: Boolean(input.paths.binaryPath),
+    helperPresent: Boolean(input.paths.helperPath),
+    platform: input.platform,
+    arch: input.arch,
+    ipc: input.ipc,
+    ...optionalStringProperty('binaryPath', input.paths.binaryPath),
+    ...optionalStringProperty('helperPath', input.paths.helperPath),
+  };
+}
+
+function failedRmuxProbe(
+  base: ReturnType<typeof rmuxProbeBase>,
+  result: SpawnSyncReturns<string>
+): RmuxCapabilityProbe {
+  const message = `rmux probe failed non-fatally: ${failureMessage(result)}`;
+  return {
+    ...base,
+    status: 'probe-failed',
+    message,
+    r0Checklist: buildR0Checklist({
+      status: 'probe-failed',
+      ipc: base.ipc,
+      ...optionalStringProperty('binaryPath', base.binaryPath),
+      ...optionalStringProperty('helperPath', base.helperPath),
+    }),
+  };
+}
+
+function availableRmuxProbe(
+  base: ReturnType<typeof rmuxProbeBase>,
+  output: string | undefined
+): RmuxCapabilityProbe {
+  const version = parseRmuxVersion(output);
+  const unsupported = version ? compareVersion(version, MINIMUM_SUPPORTED_VERSION) < 0 : false;
+  const status: RmuxProbeStatus = unsupported
+    ? 'available-but-unsupported'
+    : 'available-experimental';
+  const displayVersion = version?.raw ?? output ?? 'unknown';
+  return {
+    ...base,
+    status,
+    ...optionalStringProperty('version', output),
+    message: unsupported
+      ? `rmux ${displayVersion} is present but below Relay's diagnostic compatibility floor.`
+      : `rmux ${displayVersion} is present as an optional experimental capability; Relay will not use it by default.`,
+    r0Checklist: buildR0Checklist({
+      status,
+      ipc: base.ipc,
+      ...(version ? { version } : {}),
+      ...optionalStringProperty('binaryPath', base.binaryPath),
+      ...optionalStringProperty('helperPath', base.helperPath),
+    }),
+  };
+}
+
+export function probeRmuxCapability(deps: RmuxProbeDeps = {}): RmuxCapabilityProbe {
+  const env = deps.env ?? process.env;
+  const platform = deps.platform ?? process.platform;
+  const arch = deps.arch ?? os.arch();
+  const resolveExecutable = deps.resolveExecutable ?? resolveExecutablePath;
+  const spawn = deps.spawn ?? ((command, args, options) => spawnSync(command, args, options));
+  const ipc = endpointFromEnv(env[RMUX_ENDPOINT_ENV], platform) ?? platformDefaultIpcShape(platform);
+  const paths = resolveRmuxPaths(resolveExecutable, env);
+
+  if (!paths.command) return unavailableProbe(platform, arch, ipc);
+
+  const timeout = parsePositiveTimeout(env[RMUX_TIMEOUT_ENV]) ?? DEFAULT_PROBE_TIMEOUT_MS;
+  const result = spawn(paths.command, ['--version'], {
+    encoding: 'utf8',
+    timeout,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env,
+  });
+  const base = rmuxProbeBase({ platform, arch, ipc, paths });
+
+  if (result.error || result.status !== 0) return failedRmuxProbe(base, result);
+  return availableRmuxProbe(base, firstOutputLine(result));
+}
+
+export { PINNED_RMUX_SOURCE, RMUX_BINARY_ENV, RMUX_ENDPOINT_ENV, RMUX_TIMEOUT_ENV };

--- a/shared/node-manifest.ts
+++ b/shared/node-manifest.ts
@@ -17,6 +17,56 @@ export interface NodeCapabilityProbe {
   authStatus?: NodeAgentAuthStatus;
 }
 
+export type RmuxProbeStatus =
+  | 'unavailable'
+  | 'available-but-unsupported'
+  | 'available-experimental'
+  | 'probe-failed';
+
+export type RmuxIpcKind = 'unix-socket' | 'windows-pipe' | 'unknown';
+
+export interface RmuxIpcShape {
+  kind: RmuxIpcKind;
+  source: 'env' | 'platform-default' | 'unknown';
+  shape: string;
+  endpoint?: string;
+}
+
+export type RmuxR0ChecklistStatus = 'pass' | 'warn' | 'fail' | 'unknown';
+
+export type RmuxR0ChecklistId =
+  | 'version-pinning'
+  | 'crash-restart-behavior'
+  | 'socket-ipc-exposure'
+  | 'permission-boundary'
+  | 'packaging-update-path';
+
+export interface RmuxR0ChecklistItem {
+  id: RmuxR0ChecklistId;
+  status: RmuxR0ChecklistStatus;
+  message: string;
+}
+
+/**
+ * Diagnostic-only rmux probe. This is availability/adoption-gate evidence,
+ * not a runtime backend switch and not a hub capability grant.
+ */
+export interface RmuxCapabilityProbe {
+  id: 'rmux';
+  label: string;
+  status: RmuxProbeStatus;
+  binaryPresent: boolean;
+  helperPresent: boolean;
+  platform: string;
+  arch: string;
+  message: string;
+  binaryPath?: string;
+  helperPath?: string;
+  version?: string;
+  ipc: RmuxIpcShape;
+  r0Checklist: RmuxR0ChecklistItem[];
+}
+
 /**
  * Structured degraded reason emitted in `NodeManifest.degradedReasons`.
  * Consumers can filter by severity and react to specific codes without
@@ -121,6 +171,8 @@ export interface NodeCapabilities {
    * `undefined` as 'none'.
    */
   sessionResume?: NodeSessionResumeKind;
+  /** Optional diagnostic-only rmux probe; absence means pre-rmux-probe node. */
+  rmux?: RmuxCapabilityProbe;
   agents: Record<string, NodeCapabilityProbe>;
 }
 
@@ -279,6 +331,74 @@ function isSessionResumeKind(value: unknown): value is NodeSessionResumeKind {
   return value === 'tmux' || value === 'canonical-emulator' || value === 'none';
 }
 
+function isRmuxProbeStatus(value: unknown): value is RmuxProbeStatus {
+  return (
+    value === 'unavailable' ||
+    value === 'available-but-unsupported' ||
+    value === 'available-experimental' ||
+    value === 'probe-failed'
+  );
+}
+
+function isRmuxIpcKind(value: unknown): value is RmuxIpcKind {
+  return value === 'unix-socket' || value === 'windows-pipe' || value === 'unknown';
+}
+
+function isRmuxIpcShape(value: unknown): value is RmuxIpcShape {
+  if (!isRecord(value)) return false;
+  return (
+    isRmuxIpcKind(value['kind']) &&
+    (value['source'] === 'env' ||
+      value['source'] === 'platform-default' ||
+      value['source'] === 'unknown') &&
+    typeof value['shape'] === 'string' &&
+    isOptionalString(value['endpoint'])
+  );
+}
+
+function isRmuxR0ChecklistId(value: unknown): value is RmuxR0ChecklistId {
+  return (
+    value === 'version-pinning' ||
+    value === 'crash-restart-behavior' ||
+    value === 'socket-ipc-exposure' ||
+    value === 'permission-boundary' ||
+    value === 'packaging-update-path'
+  );
+}
+
+function isRmuxR0ChecklistStatus(value: unknown): value is RmuxR0ChecklistStatus {
+  return value === 'pass' || value === 'warn' || value === 'fail' || value === 'unknown';
+}
+
+function isRmuxR0ChecklistItem(value: unknown): value is RmuxR0ChecklistItem {
+  if (!isRecord(value)) return false;
+  return (
+    isRmuxR0ChecklistId(value['id']) &&
+    isRmuxR0ChecklistStatus(value['status']) &&
+    typeof value['message'] === 'string'
+  );
+}
+
+function isRmuxCapabilityProbe(value: unknown): value is RmuxCapabilityProbe {
+  if (!isRecord(value)) return false;
+  return (
+    value['id'] === 'rmux' &&
+    typeof value['label'] === 'string' &&
+    isRmuxProbeStatus(value['status']) &&
+    typeof value['binaryPresent'] === 'boolean' &&
+    typeof value['helperPresent'] === 'boolean' &&
+    typeof value['platform'] === 'string' &&
+    typeof value['arch'] === 'string' &&
+    typeof value['message'] === 'string' &&
+    isOptionalString(value['binaryPath']) &&
+    isOptionalString(value['helperPath']) &&
+    isOptionalString(value['version']) &&
+    isRmuxIpcShape(value['ipc']) &&
+    Array.isArray(value['r0Checklist']) &&
+    (value['r0Checklist'] as unknown[]).every(isRmuxR0ChecklistItem)
+  );
+}
+
 function isNodeCapabilities(value: unknown): value is NodeCapabilities {
   if (!isRecord(value)) return false;
   for (const key of requiredCapabilityKeys) {
@@ -290,6 +410,9 @@ function isNodeCapabilities(value: unknown): value is NodeCapabilities {
     value['sessionResume'] !== undefined &&
     !isSessionResumeKind(value['sessionResume'])
   ) {
+    return false;
+  }
+  if (value['rmux'] !== undefined && !isRmuxCapabilityProbe(value['rmux'])) {
     return false;
   }
 

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -80,6 +80,31 @@ describe('hub node registry', () => {
           path: '/usr/bin/tmux',
           version: 'tmux 3.4',
         },
+        rmux: {
+          id: 'rmux',
+          label: 'rmux optional backend probe',
+          status: 'available-experimental',
+          binaryPresent: true,
+          helperPresent: true,
+          binaryPath: '/usr/local/bin/rmux',
+          helperPath: '/usr/local/bin/rmux',
+          version: 'rmux 0.1.2',
+          platform: 'darwin',
+          arch: 'arm64',
+          ipc: {
+            kind: 'unix-socket',
+            source: 'platform-default',
+            shape: 'owner-only Unix socket under rmux-$uid runtime directory',
+          },
+          message: 'diagnostic-only rmux capability',
+          r0Checklist: [
+            {
+              id: 'version-pinning',
+              status: 'warn',
+              message: 'diagnostic provenance only',
+            },
+          ],
+        },
       },
     });
     expect(isNodeManifest(validWithOptionalStrings)).toBe(true);
@@ -129,6 +154,77 @@ describe('hub node registry', () => {
             unknown
           >;
           capabilities['agents'] = [];
+        }),
+      ],
+      [
+        'rmux status',
+        malformedManifest((candidate) => {
+          const capabilities = candidate['capabilities'] as Record<
+            string,
+            unknown
+          >;
+          capabilities['rmux'] = {
+            id: 'rmux',
+            label: 'rmux optional backend probe',
+            status: 'production-ready',
+            binaryPresent: false,
+            helperPresent: false,
+            platform: 'linux',
+            arch: 'x64',
+            ipc: {
+              kind: 'unix-socket',
+              source: 'platform-default',
+              shape: 'owner-only Unix socket',
+            },
+            message: 'bad status',
+            r0Checklist: [],
+          };
+        }),
+      ],
+      [
+        'rmux ipc shape',
+        malformedManifest((candidate) => {
+          const capabilities = candidate['capabilities'] as Record<
+            string,
+            unknown
+          >;
+          capabilities['rmux'] = {
+            id: 'rmux',
+            label: 'rmux optional backend probe',
+            status: 'unavailable',
+            binaryPresent: false,
+            helperPresent: false,
+            platform: 'linux',
+            arch: 'x64',
+            ipc: { kind: 'tcp', source: 'network', shape: '127.0.0.1:9999' },
+            message: 'bad ipc',
+            r0Checklist: [],
+          };
+        }),
+      ],
+      [
+        'rmux checklist item',
+        malformedManifest((candidate) => {
+          const capabilities = candidate['capabilities'] as Record<
+            string,
+            unknown
+          >;
+          capabilities['rmux'] = {
+            id: 'rmux',
+            label: 'rmux optional backend probe',
+            status: 'unavailable',
+            binaryPresent: false,
+            helperPresent: false,
+            platform: 'linux',
+            arch: 'x64',
+            ipc: {
+              kind: 'unix-socket',
+              source: 'platform-default',
+              shape: 'owner-only Unix socket',
+            },
+            message: 'bad checklist',
+            r0Checklist: [{ id: 'root-shell', status: 'pass', message: 'nope' }],
+          };
         }),
       ],
       [

--- a/test/node-manifest.test.ts
+++ b/test/node-manifest.test.ts
@@ -42,6 +42,12 @@ describe('node manifest', () => {
           tmux: { status: 'available' },
           git: { status: 'available' },
           githubCli: { status: 'unavailable' },
+          rmux: {
+            status: 'unavailable',
+            binaryPresent: false,
+            helperPresent: false,
+            ipc: { kind: 'unix-socket' },
+          },
         },
       });
       // Core manifest no longer hardcodes a specific framework set.

--- a/test/rmux-probe.test.ts
+++ b/test/rmux-probe.test.ts
@@ -1,0 +1,152 @@
+import type { SpawnSyncReturns } from 'node:child_process';
+import { describe, expect, it } from 'vitest';
+import { probeRmuxCapability } from '../server/rmux-probe.js';
+
+function spawnResult(overrides: Partial<SpawnSyncReturns<string>>): SpawnSyncReturns<string> {
+  return {
+    pid: 123,
+    output: [],
+    stdout: '',
+    stderr: '',
+    status: 0,
+    signal: null,
+    error: undefined,
+    ...overrides,
+  } as SpawnSyncReturns<string>;
+}
+
+describe('probeRmuxCapability', () => {
+  it('reports unavailable when neither rmux nor helper can be resolved', () => {
+    const probe = probeRmuxCapability({
+      env: { PATH: '' },
+      platform: 'linux',
+      arch: 'x64',
+      resolveExecutable: () => null,
+    });
+
+    expect(probe).toMatchObject({
+      id: 'rmux',
+      status: 'unavailable',
+      binaryPresent: false,
+      helperPresent: false,
+      platform: 'linux',
+      arch: 'x64',
+      ipc: {
+        kind: 'unix-socket',
+        source: 'platform-default',
+      },
+    });
+    expect(probe.message).toContain('optional rmux backend remains disabled');
+    expect(probe.r0Checklist.map((item) => item.id)).toEqual([
+      'version-pinning',
+      'crash-restart-behavior',
+      'socket-ipc-exposure',
+      'permission-boundary',
+      'packaging-update-path',
+    ]);
+  });
+
+  it('detects experimental rmux with pinned diagnostic provenance and env IPC shape', () => {
+    const probe = probeRmuxCapability({
+      env: { PATH: '/bin', RMUX_SDK_ENDPOINT: '/tmp/rmux.sock' },
+      platform: 'linux',
+      arch: 'arm64',
+      resolveExecutable: (command) => (command === 'rmux' ? '/bin/rmux' : null),
+      spawn: (command, args) => {
+        expect(command).toBe('/bin/rmux');
+        expect(args).toEqual(['--version']);
+        return spawnResult({ stdout: 'rmux 0.1.2\n' });
+      },
+    });
+
+    expect(probe).toMatchObject({
+      status: 'available-experimental',
+      binaryPresent: true,
+      helperPresent: true,
+      binaryPath: '/bin/rmux',
+      helperPath: '/bin/rmux',
+      version: 'rmux 0.1.2',
+      ipc: {
+        kind: 'unix-socket',
+        source: 'env',
+        endpoint: '/tmp/rmux.sock',
+      },
+    });
+    expect(probe.message).toContain('optional experimental capability');
+    expect(probe.r0Checklist).toContainEqual(
+      expect.objectContaining({
+        id: 'version-pinning',
+        status: 'warn',
+        message: expect.stringContaining('Helvesec/rmux@a37614c026e18616fa57bc27ae23e1f8241c43fe'),
+      })
+    );
+  });
+
+  it('uses RMUX_SDK_DAEMON_BINARY helper override when supplied', () => {
+    const probe = probeRmuxCapability({
+      env: { PATH: '/bin', RMUX_SDK_DAEMON_BINARY: '/opt/rmux-helper' },
+      platform: 'darwin',
+      arch: 'arm64',
+      resolveExecutable: (command) => (command === 'rmux' ? '/bin/rmux' : null),
+      spawn: (command) => {
+        expect(command).toBe('/opt/rmux-helper');
+        return spawnResult({ stdout: 'rmux 0.1.0\n' });
+      },
+    });
+
+    expect(probe).toMatchObject({
+      status: 'available-experimental',
+      binaryPath: '/bin/rmux',
+      helperPath: '/opt/rmux-helper',
+      binaryPresent: true,
+      helperPresent: true,
+    });
+  });
+
+  it('marks old rmux versions as available-but-unsupported', () => {
+    const probe = probeRmuxCapability({
+      env: { PATH: '/bin' },
+      platform: 'linux',
+      resolveExecutable: () => '/bin/rmux',
+      spawn: () => spawnResult({ stdout: 'rmux 0.0.9\n' }),
+    });
+
+    expect(probe.status).toBe('available-but-unsupported');
+    expect(probe.r0Checklist).toContainEqual(
+      expect.objectContaining({ id: 'version-pinning', status: 'fail' })
+    );
+  });
+
+  it('keeps probe execution failures non-fatal', () => {
+    const probe = probeRmuxCapability({
+      env: { PATH: '/bin', RMUX_SDK_ENDPOINT: 'not-a-socket' },
+      platform: 'linux',
+      resolveExecutable: () => '/bin/rmux',
+      spawn: () => spawnResult({ status: 2, stderr: 'bad rmux\n' }),
+    });
+
+    expect(probe).toMatchObject({
+      status: 'probe-failed',
+      ipc: {
+        kind: 'unknown',
+        source: 'env',
+        endpoint: 'not-a-socket',
+      },
+    });
+    expect(probe.message).toContain('bad rmux');
+  });
+
+  it('reports Windows pipe IPC defaults without requiring rmux to exist', () => {
+    const probe = probeRmuxCapability({
+      env: { PATH: '' },
+      platform: 'win32',
+      resolveExecutable: () => null,
+    });
+
+    expect(probe.ipc).toMatchObject({
+      kind: 'windows-pipe',
+      source: 'platform-default',
+    });
+    expect(probe.ipc.shape).toContain('\\\\.\\pipe\\rmux');
+  });
+});

--- a/test/rmux-probe.test.ts
+++ b/test/rmux-probe.test.ts
@@ -103,6 +103,52 @@ describe('probeRmuxCapability', () => {
     });
   });
 
+  it('fails explicit unresolved helper override instead of falling back to PATH rmux', () => {
+    const probe = probeRmuxCapability({
+      env: { PATH: '/bin', RMUX_SDK_DAEMON_BINARY: 'definitely-not-rmux-helper' },
+      platform: 'linux',
+      arch: 'x64',
+      resolveExecutable: (command) => (command === 'rmux' ? '/bin/rmux' : null),
+      spawn: (command) => {
+        expect(command).toBe('definitely-not-rmux-helper');
+        return spawnResult({
+          status: null,
+          error: new Error('spawn definitely-not-rmux-helper ENOENT'),
+        });
+      },
+    });
+
+    expect(probe).toMatchObject({
+      status: 'probe-failed',
+      binaryPath: '/bin/rmux',
+      binaryPresent: true,
+      helperPresent: false,
+    });
+    expect(probe).not.toHaveProperty('helperPath');
+    expect(probe.message).toContain('definitely-not-rmux-helper');
+  });
+
+  it('resolves absolute helper overrides using the injected platform', () => {
+    const probe = probeRmuxCapability({
+      env: { PATH: 'C:\\Windows\\System32', RMUX_SDK_DAEMON_BINARY: 'C:\\Tools\\rmux-helper.exe' },
+      platform: 'win32',
+      arch: 'x64',
+      resolveExecutable: (command) => (command === 'rmux' ? 'C:\\Tools\\rmux.exe' : null),
+      spawn: (command) => {
+        expect(command).toBe('C:\\Tools\\rmux-helper.exe');
+        return spawnResult({ stdout: 'rmux 0.1.0\n' });
+      },
+    });
+
+    expect(probe).toMatchObject({
+      status: 'available-experimental',
+      binaryPath: 'C:\\Tools\\rmux.exe',
+      helperPath: 'C:\\Tools\\rmux-helper.exe',
+      binaryPresent: true,
+      helperPresent: true,
+    });
+  });
+
   it('marks old rmux versions as available-but-unsupported', () => {
     const probe = probeRmuxCapability({
       env: { PATH: '/bin' },


### PR DESCRIPTION
## Summary
- add optional diagnostic-only rmux capability/provenance probe to node manifests
- validate optional capabilities.rmux while preserving manifests from older nodes that omit it
- surface rmux probe status and R0 checklist in node doctor JSON/human output

## Test Plan
- npm test -- --run test/rmux-probe.test.ts test/node-manifest.test.ts test/hub-node-registry.test.ts
- npm run typecheck:test
- npm run build:server
- npx eslint server/rmux-probe.ts shared/node-manifest.ts server/node-manifest.ts bin/relay-ide.ts test/rmux-probe.test.ts test/node-manifest.test.ts test/hub-node-registry.test.ts (warnings only: existing duplicate-string warnings)
- node dist/bin/relay-ide.js node doctor --json > /tmp/relay-doctor-rmux.json || true
- node dist/bin/relay-ide.js node doctor 2>&1 | grep -E 'rmux optional capability|rmux R0'

Closes #706

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended node diagnostics to include RMUX capability detection, reporting binary availability, version compatibility, and IPC configuration status.

* **Documentation**
  * Added documentation describing the optional RMUX diagnostic probe and how it reports capability data.

* **Tests**
  * Added comprehensive test coverage for RMUX capability probing across various resolution scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->