### PR TITLE
feat: add rich FileBlock previews

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,6 +4,7 @@ import type {
   FileRpcListResponse,
   FileRpcReadResponse,
   FileRpcStatResponse,
+  FileRpcTailResponse,
   FileRpcWriteResponse,
 } from '../../../shared/file-rpc.js';
 import type {
@@ -750,6 +751,7 @@ export interface NodeFsReadArgs {
   path: string;
   maxBytes?: number;
   rangeStart?: number;
+  encoding?: 'utf8' | 'base64';
 }
 
 export async function fetchNodeFsRead(
@@ -759,7 +761,38 @@ export async function fetchNodeFsRead(
   const body: Record<string, unknown> = { path: args.path };
   if (args.maxBytes !== undefined) body.maxBytes = args.maxBytes;
   if (args.rangeStart !== undefined) body.rangeStart = args.rangeStart;
+  if (args.encoding !== undefined) body.encoding = args.encoding;
   return json<FileRpcReadResponse>(
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  );
+}
+
+export interface NodeFsTailArgs {
+  nodeId: string;
+  sessionId: string;
+  path: string;
+  maxBytes?: number;
+  maxLines?: number;
+  follow?: boolean;
+  maxFollowChunkBytes?: number;
+}
+
+export async function fetchNodeFsTail(
+  args: NodeFsTailArgs
+): Promise<FileRpcTailResponse> {
+  const url = `/hub/nodes/${encodeURIComponent(args.nodeId)}/sessions/${encodeURIComponent(args.sessionId)}/files/tail`;
+  const body: Record<string, unknown> = { path: args.path };
+  if (args.maxBytes !== undefined) body.maxBytes = args.maxBytes;
+  if (args.maxLines !== undefined) body.maxLines = args.maxLines;
+  if (args.follow !== undefined) body.follow = args.follow;
+  if (args.maxFollowChunkBytes !== undefined) {
+    body.maxFollowChunkBytes = args.maxFollowChunkBytes;
+  }
+  return json<FileRpcTailResponse>(
     await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/workbench/blocks/file.css
+++ b/frontend/src/workbench/blocks/file.css
@@ -111,6 +111,96 @@
   border-top: 1px solid var(--border);
 }
 
+.block-file__metadata {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs) var(--space-sm);
+  padding-top: var(--space-2xs);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+}
+
+.block-file__metadata span {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.block-file__directory,
+.block-file__tail,
+.block-file__image,
+.block-file__unsupported {
+  padding: var(--space-md);
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+}
+
+.block-file__directory-list {
+  display: flex;
+  flex-direction: column;
+  margin-top: var(--space-sm);
+  border-top: 1px solid var(--border);
+}
+
+.block-file__directory-entry {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: var(--space-sm);
+  padding: var(--space-xs) 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.block-file__directory-entry-name {
+  overflow: hidden;
+  color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.block-file__directory-meta,
+.block-file__tail-meta,
+.block-file__image-meta {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.block-file__tail {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  padding: 0;
+}
+
+.block-file__tail-meta {
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--border);
+}
+
+.block-file__image {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.block-file__image-img {
+  min-height: 0;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  align-self: flex-start;
+  border: 1px solid var(--border);
+}
+
+.block-file__unsupported {
+  border-top: 1px solid var(--border);
+}
+
 .block-file__error {
   padding: var(--space-md);
   font-size: var(--font-size-xs);

--- a/frontend/src/workbench/blocks/file.tsx
+++ b/frontend/src/workbench/blocks/file.tsx
@@ -7,19 +7,6 @@
  *
  * Capability gating: BlockHost enforces 'rpc:fs:read' via
  * descriptor.capabilityRequirements before this component mounts.
- *
- * State branches:
- *   - legacy FileRef → placeholder (no fetch)
- *   - missing sessionId → "session required" empty state
- *   - stat loading → loading copy
- *   - stat error → inline error copy
- *   - binary extension → "binary content" fallback with size + path
- *   - size > FILE_RPC_MAX_READ_BYTES → "too large" fallback with size + cap
- *   - read loading → loading copy
- *   - read error → inline error copy
- *   - success → decoded text in monospace <pre>
- *
- * Deferred: markdown, PDF, image, diff rendering.
  */
 
 import React from 'react';
@@ -28,14 +15,21 @@ import { createPatch } from 'diff';
 
 import type { WorkbenchBlockRenderer } from '../../../../shared/workbench-block-types.js';
 import { isFileResourceRef } from '../../../../shared/workbench-block-types.js';
-import { FILE_RPC_MAX_READ_BYTES } from '../../../../shared/file-rpc.js';
+import {
+  FILE_RPC_DEFAULT_LIST_ENTRIES,
+  FILE_RPC_MAX_READ_BYTES,
+  FILE_RPC_MAX_TAIL_BYTES,
+  FILE_RPC_MAX_TAIL_LINES,
+} from '../../../../shared/file-rpc.js';
 import { grantedBits } from '../../../../shared/workbench-capability-utils.js';
 import {
-  fetchNodeFsStat,
+  fetchNodeFsList,
   fetchNodeFsRead,
+  fetchNodeFsStat,
+  fetchNodeFsTail,
   fetchNodeFsWrite,
-  type NodeFsStatArgs,
   type NodeFsReadArgs,
+  type NodeFsStatArgs,
   HttpError,
 } from '../../lib/api.js';
 import { DiffViewer } from '../../components/DiffViewer.js';
@@ -48,6 +42,8 @@ const BINARY_EXTENSIONS = new Set([
   'jpg',
   'jpeg',
   'gif',
+  'webp',
+  'svg',
   'pdf',
   'zip',
   'gz',
@@ -64,6 +60,15 @@ const BINARY_EXTENSIONS = new Set([
   'mov',
 ]);
 
+const IMAGE_MIME_BY_EXTENSION: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml',
+};
+
 type FileBlockMode = 'read' | 'edit' | 'diff';
 
 const FILE_RPC_WRITE_HASH_MISMATCH_CODE = 'FILE_RPC_WRITE_HASH_MISMATCH';
@@ -71,17 +76,38 @@ const FILE_RPC_INVALID_REQUEST_CODE = 'INVALID_REQUEST';
 const FILE_RPC_EXPECTED_HASH_MISMATCH_REASON_CODE =
   'FILE_RPC_EXPECTED_HASH_MISMATCH';
 
-function isBinaryPath(path: string): boolean {
+function extension(path: string): string {
   const dot = path.lastIndexOf('.');
-  if (dot === -1) return false;
-  const ext = path.slice(dot + 1).toLowerCase();
-  return BINARY_EXTENSIONS.has(ext);
+  return dot === -1 ? '' : path.slice(dot + 1).toLowerCase();
+}
+
+function isImagePath(path: string): boolean {
+  return extension(path) in IMAGE_MIME_BY_EXTENSION;
+}
+
+function imageMimeForPath(path: string): string | undefined {
+  return IMAGE_MIME_BY_EXTENSION[extension(path)];
+}
+
+function isPdfPath(path: string): boolean {
+  return extension(path) === 'pdf';
+}
+
+function isBinaryPath(path: string): boolean {
+  return BINARY_EXTENSIONS.has(extension(path));
 }
 
 function formatBytes(n: number): string {
   if (n < 1024) return `${n} b`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} kb`;
   return `${(n / (1024 * 1024)).toFixed(1)} mb`;
+}
+
+function formatFreshness(mtimeMs?: number, capturedAt?: string): string {
+  if (typeof mtimeMs === 'number' && Number.isFinite(mtimeMs)) {
+    return new Date(mtimeMs).toISOString();
+  }
+  return capturedAt ?? 'unknown';
 }
 
 function isWriteHashMismatchError(err: unknown): boolean {
@@ -155,9 +181,6 @@ export const FileBlock: WorkbenchBlockRenderer<'file'> = ({
     );
   }
 
-  // ---------------------------------------------------------------------------
-  // FileResourceRef path — delegate to the inner component that can use hooks
-  // ---------------------------------------------------------------------------
   return (
     <FileBlockContent
       descriptor={descriptor}
@@ -182,6 +205,7 @@ function FileBlockContent({
 }) {
   const { nodeId, path } = fileRef;
   const sessionId = context.session?.sessionId;
+  const readGranted = grantedBits(context).has('rpc:fs:read');
 
   const headerNode = (
     <div className="block-file__header">
@@ -190,6 +214,15 @@ function FileBlockContent({
       <div className="block-file__ref">{path}</div>
     </div>
   );
+  const advisoryMetadataNode = (
+    <FileBlockMetadata
+      fileRef={fileRef}
+      nodeId={nodeId}
+      sizeBytes={fileRef.size}
+      freshness={formatFreshness(fileRef.mtimeMs, fileRef.capturedAt)}
+      readGranted={readGranted}
+    />
+  );
 
   // No session → short-circuit
   if (!sessionId) {
@@ -197,7 +230,8 @@ function FileBlockContent({
       <div className="block-file" aria-label={`file: ${descriptor.title}`}>
         {headerNode}
         <div className="block-file__body">
-          <div className="block-file__error">
+          {advisoryMetadataNode}
+          <div className="block-file__error block-file__error--session">
             session required to fetch file
           </div>
         </div>
@@ -208,6 +242,7 @@ function FileBlockContent({
   return (
     <FileBlockFetcher
       descriptor={descriptor}
+      fileRef={fileRef}
       nodeId={nodeId}
       sessionId={sessionId}
       path={path}
@@ -218,9 +253,46 @@ function FileBlockContent({
   );
 }
 
+function FileBlockMetadata({
+  fileRef,
+  nodeId,
+  sizeBytes,
+  freshness,
+  readGranted,
+}: {
+  fileRef: import('../../../../shared/file-resource-ref.js').FileResourceRef;
+  nodeId: string;
+  sizeBytes?: number | undefined;
+  freshness: string;
+  readGranted: boolean;
+}) {
+  const binding = fileRef.repoBinding;
+  return (
+    <div className="block-file__metadata" aria-label="file metadata">
+      <span>node: {nodeId}</span>
+      <span>path: {fileRef.path}</span>
+      <span>size: {sizeBytes !== undefined ? formatBytes(sizeBytes) : 'unknown'}</span>
+      <span>fresh: {freshness}</span>
+      <span>intent: {fileRef.intent}</span>
+      <span>grant: {readGranted ? 'read granted' : 'read denied'}</span>
+      <span>repo: {binding?.repoPath ?? 'non-git cwd'}</span>
+      <span>worktree: {binding?.worktreePath ?? 'none'}</span>
+    </div>
+  );
+}
+
+function FileBlockPlaceholder({ label }: { label: string }) {
+  return (
+    <div className="block-file__placeholder">
+      <div className="block-file__placeholder-detail">{label}</div>
+    </div>
+  );
+}
+
 /** Innermost component — calls hooks unconditionally. */
 function FileBlockFetcher({
   descriptor,
+  fileRef,
   nodeId,
   sessionId,
   path,
@@ -229,6 +301,7 @@ function FileBlockFetcher({
   context,
 }: {
   descriptor: import('../../../../shared/workbench-block-types.js').FileBlockDescriptor;
+  fileRef: import('../../../../shared/file-resource-ref.js').FileResourceRef;
   nodeId: string;
   sessionId: string;
   path: string;
@@ -244,12 +317,73 @@ function FileBlockFetcher({
     refetchOnWindowFocus: true,
   });
 
-  const sizeBytes = statQuery.data?.stat.size;
+  const stat = statQuery.data?.stat;
+  const sizeBytes = stat?.size ?? fileRef.size;
+  const statFreshness = formatFreshness(stat?.mtimeMs, fileRef.capturedAt);
+  const directory = stat?.type === 'directory';
+  const imageMime = imageMimeForPath(path);
+  const image = isImagePath(path);
+  const pdf = isPdfPath(path);
   const binary = isBinaryPath(path);
   const tooLarge =
-    !binary && sizeBytes !== undefined && sizeBytes > FILE_RPC_MAX_READ_BYTES;
-  // Only fetch content when stat succeeded, file is not binary, and within cap
-  const enableRead = statQuery.isSuccess && !binary && !tooLarge;
+    !directory && !binary && sizeBytes !== undefined && sizeBytes > FILE_RPC_MAX_READ_BYTES;
+  const imageTooLarge =
+    image && sizeBytes !== undefined && sizeBytes > FILE_RPC_MAX_READ_BYTES;
+  const tailMode = fileRef.intent === 'tail';
+  const enableRead =
+    statQuery.isSuccess &&
+    !directory &&
+    !tailMode &&
+    !image &&
+    !pdf &&
+    !binary &&
+    !tooLarge;
+
+  const listQuery = useQuery({
+    queryKey: ['fs.list', nodeId, sessionId, path],
+    queryFn: () =>
+      fetchNodeFsList({
+        nodeId,
+        sessionId,
+        cwd: statQuery.data?.cwd ?? path,
+        path,
+        maxEntries: FILE_RPC_DEFAULT_LIST_ENTRIES,
+      }),
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+    enabled: statQuery.isSuccess && stat !== undefined && stat.type === 'directory',
+  });
+
+  const tailQuery = useQuery({
+    queryKey: ['fs.tail', nodeId, sessionId, path],
+    queryFn: () =>
+      fetchNodeFsTail({
+        nodeId,
+        sessionId,
+        path,
+        maxBytes: FILE_RPC_MAX_TAIL_BYTES,
+        maxLines: FILE_RPC_MAX_TAIL_LINES,
+        follow: false,
+      }),
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+    enabled: statQuery.isSuccess && !directory && tailMode,
+  });
+
+  const imageQuery = useQuery({
+    queryKey: ['fs.read', nodeId, sessionId, path, 'base64'],
+    queryFn: () =>
+      fetchNodeFsRead({
+        nodeId,
+        sessionId,
+        path,
+        maxBytes: FILE_RPC_MAX_READ_BYTES,
+        encoding: 'base64',
+      }),
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+    enabled: statQuery.isSuccess && image && !imageTooLarge && !directory,
+  });
 
   const readArgs: NodeFsReadArgs = {
     nodeId,
@@ -265,25 +399,97 @@ function FileBlockFetcher({
     enabled: enableRead,
   });
 
-  function body() {
-    // stat error
-    if (statQuery.isError) {
-      return (
-        <div className="block-file__error">{errorMessage(statQuery.error)}</div>
-      );
-    }
+  const metadataNode = (
+    <FileBlockMetadata
+      fileRef={fileRef}
+      nodeId={nodeId}
+      sizeBytes={sizeBytes}
+      freshness={statFreshness}
+      readGranted={grantedBits(context).has('rpc:fs:read')}
+    />
+  );
 
-    // binary
-    if (binary) {
+  function renderDirectoryPreview() {
+    if (listQuery.isLoading) {
+      return <FileBlockPlaceholder label="loading directory…" />;
+    }
+    if (listQuery.isError) {
+      return <div className="block-file__error">{errorMessage(listQuery.error)}</div>;
+    }
+    const entries = listQuery.data?.entries ?? [];
+    if (entries.length === 0) {
       return (
-        <div className="block-file__binary">
-          binary content · {path}
-          {sizeBytes !== undefined ? ` · ${formatBytes(sizeBytes)}` : ''}
+        <div className="block-file__directory block-file__directory--empty">
+          empty directory · cap {FILE_RPC_DEFAULT_LIST_ENTRIES} entries
         </div>
       );
     }
+    return (
+      <div className="block-file__directory">
+        <div className="block-file__directory-meta">
+          {entries.length} entries
+          {listQuery.data?.truncated ? ` · truncated at ${listQuery.data.maxEntries}` : ''}
+        </div>
+        <div className="block-file__directory-list" role="list">
+          {entries.map((entry) => (
+            <div className="block-file__directory-entry" role="listitem" key={entry.path}>
+              <span className="block-file__directory-entry-name">{entry.name}</span>
+              <span>{entry.type}</span>
+              <span>{formatBytes(entry.size)}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
 
-    // too large
+  function renderTailPreview() {
+    if (tailQuery.isLoading) return <FileBlockPlaceholder label="loading tail…" />;
+    if (tailQuery.isError) {
+      return <div className="block-file__error">{errorMessage(tailQuery.error)}</div>;
+    }
+    if (!tailQuery.data) return <FileBlockPlaceholder label="tail preview" />;
+    return (
+      <div className="block-file__tail">
+        <div className="block-file__tail-meta">
+          latest {formatBytes(tailQuery.data.bytesRead)} · cap{' '}
+          {formatBytes(tailQuery.data.maxBytes)} · offset {tailQuery.data.startOffset}-
+          {tailQuery.data.endOffset}
+          {tailQuery.data.truncatedBytes || tailQuery.data.truncatedLines
+            ? ' · truncated'
+            : ''}
+        </div>
+        <pre className="block-file__content">{tailQuery.data.content}</pre>
+      </div>
+    );
+  }
+
+  function renderImagePreview() {
+    if (imageTooLarge && sizeBytes !== undefined) {
+      return (
+        <div className="block-file__too-large">
+          {`image too large to preview · ${formatBytes(sizeBytes)} · cap ${formatBytes(FILE_RPC_MAX_READ_BYTES)}`}
+        </div>
+      );
+    }
+    if (imageQuery.isLoading) return <FileBlockPlaceholder label="loading image…" />;
+    if (imageQuery.isError) {
+      return <div className="block-file__error">{errorMessage(imageQuery.error)}</div>;
+    }
+    if (!imageQuery.data || !imageMime) return <FileBlockPlaceholder label="image preview" />;
+    const src = `data:${imageMime};base64,${imageQuery.data.content}`;
+    return (
+      <div className="block-file__image">
+        <img className="block-file__image-img" src={src} alt={path} />
+        <div className="block-file__image-meta">
+          {imageMime} · {formatBytes(imageQuery.data.bytesRead)}
+          {imageQuery.data.truncatedBytes ? ' · truncated' : ''}
+        </div>
+      </div>
+    );
+  }
+
+  function renderReadPreview() {
     if (tooLarge && sizeBytes !== undefined) {
       return (
         <div className="block-file__too-large">
@@ -291,58 +497,65 @@ function FileBlockFetcher({
         </div>
       );
     }
-
-    // read loading / error
-    if (statQuery.isLoading || (!statQuery.isError && readQuery.isLoading)) {
-      return (
-        <div className="block-file__placeholder">
-          <div className="block-file__placeholder-detail">loading…</div>
-        </div>
-      );
-    }
-
+    if (readQuery.isLoading) return <FileBlockPlaceholder label="loading…" />;
     if (readQuery.isError) {
+      return <div className="block-file__error">{errorMessage(readQuery.error)}</div>;
+    }
+    if (!readQuery.data) {
+      return <FileBlockPlaceholder label={mode === 'diff' ? 'diff view' : 'file view'} />;
+    }
+    const text = readQuery.data.content;
+    if (mode === 'edit') {
       return (
-        <div className="block-file__error">{errorMessage(readQuery.error)}</div>
+        <FileBlockEditor
+          nodeId={nodeId}
+          sessionId={sessionId}
+          path={path}
+          initialContent={text}
+          context={context}
+          onSaved={() => {
+            void readQuery.refetch();
+            void statQuery.refetch();
+          }}
+        />
       );
     }
+    return <pre className="block-file__content">{text}</pre>;
+  }
 
-    // success
-    if (readQuery.data) {
-      // FileRpcReadResponse.content is a UTF-8 string (encoding: 'utf8').
-      const text = readQuery.data.content;
-      if (mode === 'edit') {
-        return (
-          <FileBlockEditor
-            nodeId={nodeId}
-            sessionId={sessionId}
-            path={path}
-            initialContent={text}
-            context={context}
-            onSaved={() => {
-              void readQuery.refetch();
-              void statQuery.refetch();
-            }}
-          />
-        );
-      }
-      return <pre className="block-file__content">{text}</pre>;
+  function body() {
+    if (statQuery.isError) {
+      return <div className="block-file__error">{errorMessage(statQuery.error)}</div>;
     }
-
-    // initial / idle
-    return (
-      <div className="block-file__placeholder">
-        <div className="block-file__placeholder-detail">
-          {mode === 'diff' ? 'diff view' : 'file view'}
+    if (statQuery.isLoading) return <FileBlockPlaceholder label="loading…" />;
+    if (directory) return renderDirectoryPreview();
+    if (tailMode) return renderTailPreview();
+    if (image) return renderImagePreview();
+    if (pdf) {
+      return (
+        <div className="block-file__unsupported block-file__unsupported--pdf">
+          pdf preview unavailable · metadata only · open/download from file browser
         </div>
-      </div>
-    );
+      );
+    }
+    if (binary) {
+      return (
+        <div className="block-file__binary block-file__unsupported">
+          unsupported preview · binary content · open/download from file browser · {path}
+          {sizeBytes !== undefined ? ` · ${formatBytes(sizeBytes)}` : ''}
+        </div>
+      );
+    }
+    return renderReadPreview();
   }
 
   return (
     <div className="block-file" aria-label={`file: ${descriptor.title}`}>
       {headerNode}
-      <div className="block-file__body">{body()}</div>
+      <div className="block-file__body">
+        {metadataNode}
+        {body()}
+      </div>
     </div>
   );
 }

--- a/frontend/src/workbench/blocks/file.tsx
+++ b/frontend/src/workbench/blocks/file.tsx
@@ -105,7 +105,8 @@ function formatBytes(n: number): string {
 
 function formatFreshness(mtimeMs?: number, capturedAt?: string): string {
   if (typeof mtimeMs === 'number' && Number.isFinite(mtimeMs)) {
-    return new Date(mtimeMs).toISOString();
+    const date = new Date(mtimeMs);
+    if (Number.isFinite(date.getTime())) return date.toISOString();
   }
   return capturedAt ?? 'unknown';
 }

--- a/server/file-rpc.ts
+++ b/server/file-rpc.ts
@@ -209,7 +209,24 @@ function buildReadRequest(
   if (typeof maxBytes !== 'number') return maxBytes;
   const maxLines = optionalBoundedInteger(fields['maxLines'], FILE_RPC_MAX_READ_LINES, 'maxLines');
   if (maxLines !== undefined && typeof maxLines !== 'number') return maxLines;
-  return { ...base, maxBytes, ...(maxLines !== undefined ? { maxLines } : {}) };
+  const encodingRaw = fields['encoding'];
+  if (
+    encodingRaw !== undefined &&
+    encodingRaw !== null &&
+    encodingRaw !== 'utf8' &&
+    encodingRaw !== 'base64'
+  ) {
+    return invalidRequest('FILE_RPC_INVALID_REQUEST', 'encoding must be "utf8" or "base64"', {
+      field: 'encoding',
+    });
+  }
+  const encoding = encodingRaw === 'base64' ? 'base64' : 'utf8';
+  return {
+    ...base,
+    maxBytes,
+    ...(maxLines !== undefined ? { maxLines } : {}),
+    ...(encoding !== 'utf8' ? { encoding } : {}),
+  };
 }
 
 function buildTailRequest(
@@ -562,10 +579,12 @@ async function executeRead(request: FileRpcRequest): Promise<FileRpcReadResponse
       bytesRead += read.bytesRead;
     }
     const visibleBytes = Math.min(bytesRead, maxBytes);
-    let content = buffer.subarray(0, visibleBytes).toString('utf8');
+    const visibleBuffer = buffer.subarray(0, visibleBytes);
+    const encoding = 'encoding' in request && request.encoding === 'base64' ? 'base64' : 'utf8';
+    let content = encoding === 'base64' ? visibleBuffer.toString('base64') : visibleBuffer.toString('utf8');
     const truncatedBytes = bytesRead > maxBytes;
     let truncatedLines = false;
-    if (maxLines !== undefined) {
+    if (encoding === 'utf8' && maxLines !== undefined) {
       const lines = content.split('\n');
       if (lines.length > maxLines) {
         content = lines.slice(0, maxLines).join('\n');
@@ -577,7 +596,7 @@ async function executeRead(request: FileRpcRequest): Promise<FileRpcReadResponse
       root: request.root,
       cwd: request.cwd,
       path: request.path,
-      encoding: 'utf8',
+      encoding,
       content,
       bytesRead: visibleBytes,
       truncatedBytes,

--- a/shared/file-rpc.ts
+++ b/shared/file-rpc.ts
@@ -54,6 +54,8 @@ export type FileRpcStatRequest = FileRpcBaseRequest;
 export interface FileRpcReadRequest extends FileRpcBaseRequest {
   maxBytes: number;
   maxLines?: number;
+  /** UTF-8 text by default; base64 is used for bounded binary/image previews. */
+  encoding?: 'utf8' | 'base64';
 }
 
 export interface FileRpcTailRequest extends FileRpcBaseRequest {
@@ -113,7 +115,7 @@ export interface FileRpcReadResponse {
   root: string;
   cwd: string;
   path: string;
-  encoding: 'utf8';
+  encoding: 'utf8' | 'base64';
   content: string;
   bytesRead: number;
   truncatedBytes: boolean;

--- a/test/file-block-editor-reseed.test.ts
+++ b/test/file-block-editor-reseed.test.ts
@@ -253,3 +253,106 @@ describe('FileBlock edit reload reseed', () => {
     });
   });
 });
+
+describe('FileBlock freshness fallback', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  function readDescriptor(): FileBlockDescriptor {
+    return {
+      kind: 'file',
+      id: 'file-block-freshness-fallback',
+      title: 'current.txt',
+      capabilityRequirements: ['rpc:fs:read'],
+      meta: {
+        mode: 'read',
+        fileRef: {
+          nodeId: 'node-a',
+          path: filePath,
+          capturedAt: '2026-01-01T00:00:00Z',
+          intent: 'read',
+        },
+      },
+    };
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal('crypto', webcrypto);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith('/files/stat')) {
+          return jsonResponse({
+            operation: 'stat',
+            root: '/',
+            cwd: '/tmp',
+            path: filePath,
+            stat: {
+              path: filePath,
+              name: 'current.txt',
+              type: 'file',
+              size: 'hello world'.length,
+              mtimeMs: 1e20,
+              mode: 0o644,
+            },
+          });
+        }
+        if (url.endsWith('/files/read')) {
+          return jsonResponse({
+            operation: 'read',
+            root: '/',
+            cwd: '/tmp',
+            path: filePath,
+            encoding: 'utf8',
+            content: 'hello world',
+            bytesRead: 'hello world'.length,
+            truncatedBytes: false,
+            truncatedLines: false,
+            maxBytes: 65536,
+          });
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      })
+    );
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    queryClient.clear();
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it('falls back to capturedAt for finite out-of-range mtimeMs', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(FileBlock, {
+            descriptor: readDescriptor(),
+            context: blockContext(),
+          })
+        )
+      );
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('hello world');
+      expect(container.textContent).toContain('fresh: 2026-01-01T00:00:00Z');
+      expect(container.textContent).not.toContain('Invalid Date');
+    });
+  });
+});

--- a/test/file-rpc.test.ts
+++ b/test/file-rpc.test.ts
@@ -129,6 +129,51 @@ describe('read-only File RPC foundation', () => {
     });
   });
 
+  it('executes local base64 reads for bounded binary previews', async () => {
+    const root = fixtureRoot();
+    const imageFile = path.join(root, 'tiny.png');
+    const imageBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+    fs.writeFileSync(imageFile, imageBytes);
+
+    const read = await executeLocalFileRpc('read', {
+      sessionId: 'session_a',
+      root,
+      cwd: root,
+      path: imageFile,
+      maxBytes: 4,
+      maxLines: 1,
+      encoding: 'base64',
+    });
+
+    expect(read).toMatchObject({
+      operation: 'read',
+      encoding: 'base64',
+      content: imageBytes.subarray(0, 4).toString('base64'),
+      bytesRead: 4,
+      truncatedBytes: true,
+      truncatedLines: false,
+      maxBytes: 4,
+      maxLines: 1,
+    });
+  });
+
+  it('rejects unsupported read encodings before filesystem access', async () => {
+    const root = fixtureRoot();
+
+    const read = await executeLocalFileRpc('read', {
+      sessionId: 'session_a',
+      root,
+      cwd: root,
+      path: path.join(root, 'README.md'),
+      encoding: 'hex',
+    });
+
+    expect(read).toMatchObject({
+      code: 'INVALID_REQUEST',
+      details: { reasonCode: 'FILE_RPC_INVALID_REQUEST', field: 'encoding' },
+    });
+  });
+
   it('continues reading after short file-handle reads before reporting truncation', async () => {
     const root = fixtureRoot();
     const file = path.join(root, 'short-read.txt');

--- a/test/workbench-block-renderers.test.ts
+++ b/test/workbench-block-renderers.test.ts
@@ -27,9 +27,14 @@ import type { FileResourceRef } from '../shared/file-resource-ref.js';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = join(__dirname, '..');
 const blocksDir = join(projectRoot, 'frontend/src/workbench/blocks');
+const frontendLibDir = join(projectRoot, 'frontend/src/lib');
 
 function readBlock(name: string) {
   return readFileSync(join(blocksDir, name), 'utf-8');
+}
+
+function readFrontendLib(name: string) {
+  return readFileSync(join(frontendLibDir, name), 'utf-8');
 }
 
 function blockExists(name: string) {
@@ -486,6 +491,61 @@ describe('file renderer', () => {
     const src = readBlock('file.tsx');
     expect(src).toContain('sessionId');
     expect(src).toContain('session required');
+  });
+
+  it('renders bounded directory previews through fs.list', () => {
+    const src = readBlock('file.tsx');
+    expect(src).toContain('fetchNodeFsList');
+    expect(src).toContain("'fs.list'");
+    expect(src).toContain('FILE_RPC_DEFAULT_LIST_ENTRIES');
+    expect(src).toContain("stat.type === 'directory'");
+    expect(src).toContain('block-file__directory');
+    expect(src).toContain('empty directory');
+    expect(src).toContain('entries.map');
+  });
+
+  it('uses a bounded tail helper for log previews', () => {
+    const src = readBlock('file.tsx');
+    const api = readFrontendLib('api.ts');
+    expect(src).toContain('fetchNodeFsTail');
+    expect(src).toContain("fileRef.intent === 'tail'");
+    expect(src).toContain("'fs.tail'");
+    expect(src).toContain('FILE_RPC_MAX_TAIL_BYTES');
+    expect(src).toContain('FILE_RPC_MAX_TAIL_LINES');
+    expect(src).toContain('block-file__tail-meta');
+    expect(api).toContain('export async function fetchNodeFsTail');
+    expect(api).toContain('/files/tail');
+  });
+
+  it('renders common image previews from bounded base64 reads', () => {
+    const src = readBlock('file.tsx');
+    expect(src).toContain('IMAGE_MIME_BY_EXTENSION');
+    expect(src).toContain("encoding: 'base64'");
+    expect(src).toContain('data:${imageMime};base64');
+    expect(src).toContain('block-file__image');
+    expect(src).toContain('block-file__image-img');
+    expect(src).toContain('image too large to preview');
+  });
+
+  it('renders PDF and unsupported fallbacks without parsing bytes', () => {
+    const src = readBlock('file.tsx');
+    expect(src).toContain('isPdfPath');
+    expect(src).toContain('pdf preview unavailable');
+    expect(src).toContain('unsupported preview');
+    expect(src).toContain('open/download from file browser');
+    expect(src).toContain('block-file__unsupported');
+  });
+
+  it('renders a metadata row with identity, freshness, binding, and grant state', () => {
+    const src = readBlock('file.tsx');
+    expect(src).toContain('block-file__metadata');
+    expect(src).toContain('node:');
+    expect(src).toContain('intent:');
+    expect(src).toContain('fresh:');
+    expect(src).toContain('grant:');
+    expect(src).toContain('repo:');
+    expect(src).toContain('worktree:');
+    expect(src).toContain('non-git cwd');
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add rich FileBlock preview routing for directories, tail/log refs, common image refs, PDF/unsupported fallbacks, and consistent metadata/grant/freshness display
- add frontend file RPC tail helper and bounded base64 read support for image preview payloads
- extend local file RPC read handling to validate optional encoding and return bounded base64 content for binary/image previews
- cover FileBlock preview behavior plus base64 read contract in focused tests

Closes #682

## Test Plan
- npm test -- --run test/file-rpc.test.ts test/workbench-block-renderers.test.ts
- npm run check

## Notes
- Browser/manual visual QA not run in this worker; use a session containing FileResourceRef blocks for text, directory, tail, image, PDF, missing/offline/denied, too-large, and non-git cwd states.
