### PR TITLE
feat(#444): view-spine MVP — flag + read-only derived tree + lenses + bench tab-anchor

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -987,6 +987,7 @@ export default function App() {
     handleRenameActiveSession,
     handleSelectSession,
     handleQuickAgent,
+    handleViewSpineCreateTab,
     handleQuickTerminal,
     handleOpenSettings,
     handleNewWorktree,
@@ -1278,6 +1279,7 @@ export default function App() {
           onResumeWorktree={handleResumeWorktree}
           onLaunchWorkspaceSession={handleLaunchWorkspaceSession}
           onLaunchRepoSession={handleLaunchRepoSession}
+          onViewSpineCreateTab={handleViewSpineCreateTab}
           onOpenAnalytics={openAnalytics}
         />
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -9,13 +9,13 @@ import {
 } from '../lib/stores/ui.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import type { Repo, WorktreeInfo, PullRequest } from '../lib/types.js';
-import type { NodeId } from '../../../shared/identity.js';
 import { fetchOrgPrs } from '../lib/api.js';
 import WorkspaceGroup from './WorkspaceGroup.js';
 import { HubNodeDashboardPanel } from './HubNodeDashboard.js';
 import RepoItem from './RepoItem.js';
 import { SessionHistoryPanel } from './SessionHistoryPanel.js';
 import { ViewSpineTree } from './ViewSpineTree.js';
+import type { BenchCreatePayload } from '../lib/state/view-tree.js';
 import { TuiButton } from './TuiButton.js';
 import {
   DndContext,
@@ -392,8 +392,10 @@ export interface SidebarProps {
   onResumeWorktree?: (wt: WorktreeInfo) => void;
   onLaunchWorkspaceSession?: (workspaceId: string) => void;
   onLaunchRepoSession?: (repoPath: string) => void;
-  /** #731: create a Tab anchored to a view-spine Bench's (nodeId, cwd). */
-  onViewSpineCreateTab?: (payload: { nodeId: NodeId; cwd: string }) => void;
+  /** #731: create an agent Tab anchored to a view-spine Bench. Payload carries
+   *  the node anchor + the configured repo/worktree context the backend
+   *  validates (`BenchCreatePayload`). */
+  onViewSpineCreateTab?: (payload: BenchCreatePayload) => void;
   onOpenAnalytics: () => void;
 }
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -14,6 +14,7 @@ import WorkspaceGroup from './WorkspaceGroup.js';
 import { HubNodeDashboardPanel } from './HubNodeDashboard.js';
 import RepoItem from './RepoItem.js';
 import { SessionHistoryPanel } from './SessionHistoryPanel.js';
+import { ViewSpineTree } from './ViewSpineTree.js';
 import { TuiButton } from './TuiButton.js';
 import {
   DndContext,
@@ -410,6 +411,7 @@ export function Sidebar({
   const sidebarWidth = useUiStore((s) => s.sidebarWidth);
   const activeRepoPath = useUiStore((s) => s.activeRepoPath);
   const analyticsView = useUiStore((s) => s.analyticsView);
+  const viewSpineEnabled = useUiStore((s) => s.viewSpineEnabled);
   const closeSidebar = useUiStore((s) => s.closeSidebar);
   const toggleSidebarCollapsed = useUiStore((s) => s.toggleSidebarCollapsed);
   const repos = useSessionsStore((s) => s.repos);
@@ -540,6 +542,12 @@ export function Sidebar({
               repoName={historyRepo.name}
               onBack={handleCloseHistory}
             />
+          ) : viewSpineEnabled ? (
+            // #732/#729: flag-gated, read-only, client-derived view-spine tree.
+            // OFF path below is byte-identical to today.
+            <div className="sidebar-workspace-list">
+              <ViewSpineTree />
+            </div>
           ) : (
             <div className="sidebar-workspace-list">
               <HubNodeDashboardPanel />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
 } from '../lib/stores/ui.js';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import type { Repo, WorktreeInfo, PullRequest } from '../lib/types.js';
+import type { NodeId } from '../../../shared/identity.js';
 import { fetchOrgPrs } from '../lib/api.js';
 import WorkspaceGroup from './WorkspaceGroup.js';
 import { HubNodeDashboardPanel } from './HubNodeDashboard.js';
@@ -391,6 +392,8 @@ export interface SidebarProps {
   onResumeWorktree?: (wt: WorktreeInfo) => void;
   onLaunchWorkspaceSession?: (workspaceId: string) => void;
   onLaunchRepoSession?: (repoPath: string) => void;
+  /** #731: create a Tab anchored to a view-spine Bench's (nodeId, cwd). */
+  onViewSpineCreateTab?: (payload: { nodeId: NodeId; cwd: string }) => void;
   onOpenAnalytics: () => void;
 }
 
@@ -404,6 +407,7 @@ export function Sidebar({
   onResumeWorktree,
   onLaunchWorkspaceSession,
   onLaunchRepoSession,
+  onViewSpineCreateTab,
   onOpenAnalytics,
 }: SidebarProps) {
   const sidebarOpen = useUiStore((s) => s.sidebarOpen);
@@ -546,7 +550,7 @@ export function Sidebar({
             // #732/#729: flag-gated, read-only, client-derived view-spine tree.
             // OFF path below is byte-identical to today.
             <div className="sidebar-workspace-list">
-              <ViewSpineTree />
+              <ViewSpineTree onCreateTab={onViewSpineCreateTab} />
             </div>
           ) : (
             <div className="sidebar-workspace-list">

--- a/frontend/src/components/ViewSpineTree.css
+++ b/frontend/src/components/ViewSpineTree.css
@@ -94,3 +94,44 @@
   margin-top: 0;
   flex-shrink: 0;
 }
+
+/* #731 "+ tab" affordance. Reuses the `.add-worktree-row`/`.add-worktree-btn`
+   look (muted, low-opacity, brightens on hover, `creating…` disabled tone) but
+   the rules are scoped under `.view-spine-tree` so they ship even when RepoItem
+   (the original owner of these classes) is not mounted. The row sits indented
+   under its bench's children and keeps a ≥44px touch target. */
+.view-spine-bench .add-worktree-row {
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 2px 8px 2px var(--icon-slot-width);
+  cursor: pointer;
+}
+
+.view-spine-bench .add-worktree-btn {
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  opacity: 0.5;
+  cursor: pointer;
+  transition:
+    opacity 0.1s,
+    color 0.1s;
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+.view-spine-bench .add-worktree-row:hover .add-worktree-btn {
+  opacity: 1;
+  color: var(--text);
+}
+
+.view-spine-bench .add-worktree-row.disabled {
+  pointer-events: none;
+}
+
+.view-spine-bench .add-worktree-row.disabled .add-worktree-btn {
+  opacity: 0.7;
+  color: var(--accent);
+}

--- a/frontend/src/components/ViewSpineTree.css
+++ b/frontend/src/components/ViewSpineTree.css
@@ -5,6 +5,61 @@
 .view-spine-tree {
   display: flex;
   flex-direction: column;
+  min-height: 0;
+}
+
+/* Scroll region under the sticky Views selector; the selector itself does not
+   scroll away. */
+.view-spine-scroll {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+/* ── S2 Views selector (#727) ──────────────────────────────────────────────
+   Reuses the FileTree `.fb__tabs`/`.fb__tab` segmented-control primitive; rule
+   bodies copied here and scope-renamed to `.view-lens` so the source stays
+   untouched. Touch target bumped (min-height:32px; padding:6px 10px) for the
+   sidebar context. Lowercase labels, accent border on active, no ellipsis. */
+.view-lens__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 5px 10px;
+  border-bottom: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+.view-lens__tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 32px;
+  padding: 6px 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 0.58rem;
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  /* Labels never truncate — wrap rather than ellipsize. */
+  white-space: normal;
+  text-align: left;
+}
+.view-lens__tab:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+.view-lens__tab.active {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.view-lens__tab:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
 }
 
 .view-spine-workspace,

--- a/frontend/src/components/ViewSpineTree.css
+++ b/frontend/src/components/ViewSpineTree.css
@@ -1,0 +1,41 @@
+/* #729 view-spine MVP tree. Reuses RepoItem/Sidebar primitives; this file only
+   carries the indent ladder + tiny status-dot alignment tweaks. No new colors,
+   no new animations — all tones come from existing design tokens. */
+
+.view-spine-tree {
+  display: flex;
+  flex-direction: column;
+}
+
+.view-spine-workspace,
+.view-spine-free-lane {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Instance rows sit one indent level below the project header; benches sit one
+   level below their instance. The ladder uses the shared --icon-slot-width so
+   it tracks the rest of the sidebar's alignment. */
+.view-spine-instance > .session-row-primary {
+  padding-left: var(--icon-slot-width);
+}
+
+.view-spine-bench-list {
+  padding-left: var(--icon-slot-width);
+}
+
+/* Bench/instance rows are read-only (no hover affordance for selection), but
+   keep the ≥44px min-height inherited from .session-row for touch targets. */
+.view-spine-instance,
+.view-spine-bench,
+.view-spine-free-row {
+  cursor: default;
+}
+
+/* Align the host status dot with the row's text baseline. The shared
+   .hub-node-status-dot adds a top margin tuned for the dashboard's grid; reset
+   it here so the dot centers within the flex row. */
+.view-spine-tree .hub-node-status-dot {
+  margin-top: 0;
+  flex-shrink: 0;
+}

--- a/frontend/src/components/ViewSpineTree.tsx
+++ b/frontend/src/components/ViewSpineTree.tsx
@@ -2,7 +2,7 @@
 // client-derived view-tree (`lib/state/view-tree.ts`). Reuses EXISTING sidebar
 // primitives only — no new visual chrome, no new animations. Leaves are COUNTS,
 // not interactive rows. Default OFF; only mounted when `viewSpineEnabled`.
-import { useMemo } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { fetchHubNodes } from '../lib/api.js';
@@ -10,8 +10,11 @@ import { deriveColor } from '../lib/colors.js';
 import { MarqueeText } from './MarqueeText.js';
 import { CipherText } from './CipherText.js';
 import {
+  applyLens,
   buildViewTree,
+  DEFAULT_VIEW_LENS,
   type InstanceHostStatus,
+  type ViewLens,
   type ViewTreeBench,
   type ViewTreeFreeEntry,
   type ViewTreeInstance,
@@ -19,6 +22,13 @@ import {
   type ViewTreeNodeStatus,
 } from '../lib/state/view-tree.js';
 import './ViewSpineTree.css';
+
+// Ad-hoc, ephemeral lenses (#727). Order is the visual + arrow-key order.
+const LENSES: ReadonlyArray<{ id: ViewLens; label: string }> = [
+  { id: 'recent', label: 'recent' },
+  { id: 'all', label: 'all sessions' },
+  { id: 'this-host', label: 'this host' },
+];
 
 // CSS only defines tones for online/stale/offline/revoked; updating falls back
 // to the muted default. Map straight through — class is harmless if unstyled.
@@ -148,6 +158,84 @@ function FreeRow({ entry }: { entry: ViewTreeFreeEntry }) {
   );
 }
 
+// Segmented control reusing the FileTree `.fb__tab`/`.fb__tabs` primitive,
+// scope-renamed to `.view-lens` (rule bodies copied into ViewSpineTree.css with
+// a larger touch target). Roving tabindex: only the active tab is focusable;
+// Left/Right move + activate, Enter/Space (re)activate the focused tab.
+function LensSelector({
+  value,
+  onChange,
+}: {
+  value: ViewLens;
+  onChange: (lens: ViewLens) => void;
+}) {
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const activeIndex = LENSES.findIndex((l) => l.id === value);
+
+  function focusTab(index: number) {
+    const clamped = (index + LENSES.length) % LENSES.length;
+    const lens = LENSES[clamped];
+    if (!lens) return;
+    onChange(lens.id);
+    tabRefs.current[clamped]?.focus();
+  }
+
+  function onKeyDown(event: React.KeyboardEvent, index: number) {
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        event.preventDefault();
+        focusTab(index + 1);
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        event.preventDefault();
+        focusTab(index - 1);
+        break;
+      case 'Home':
+        event.preventDefault();
+        focusTab(0);
+        break;
+      case 'End':
+        event.preventDefault();
+        focusTab(LENSES.length - 1);
+        break;
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        onChange(LENSES[index]!.id);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return (
+    <div className="view-lens__tabs" role="tablist" aria-label="views">
+      {LENSES.map((lens, index) => {
+        const selected = lens.id === value;
+        return (
+          <button
+            key={lens.id}
+            ref={(el) => {
+              tabRefs.current[index] = el;
+            }}
+            type="button"
+            className={`view-lens__tab${selected ? ' active' : ''}`}
+            role="tab"
+            aria-selected={selected}
+            tabIndex={index === activeIndex ? 0 : -1}
+            onClick={() => onChange(lens.id)}
+            onKeyDown={(event) => onKeyDown(event, index)}
+          >
+            {lens.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 export function ViewSpineTree() {
   const repos = useSessionsStore((s) => s.repos);
   const worktrees = useSessionsStore((s) => s.worktrees);
@@ -176,7 +264,11 @@ export function ViewSpineTree() {
     [nodes]
   );
 
-  const tree = useMemo(
+  // Ephemeral lens state: in-memory only, default `recent`, lost on reload (no
+  // persistence by design — #727).
+  const [lens, setLens] = useState<ViewLens>(DEFAULT_VIEW_LENS);
+
+  const derived = useMemo(
     () =>
       buildViewTree({
         repos,
@@ -188,19 +280,29 @@ export function ViewSpineTree() {
     [repos, worktrees, sessions, workspaceGroups, nodeStatuses]
   );
 
+  const tree = useMemo(() => applyLens(derived, lens), [derived, lens]);
+
+  // The Views selector is part of the sidebar header chrome: it renders in EVERY
+  // state (loading, empty, content) so switching lenses is always available,
+  // even when the active lens yields zero nodes.
+  const selector = <LensSelector value={lens} onChange={setLens} />;
+
   // Loading: the node join is still resolving and there's nothing derived yet.
   if (isLoading && repos.length === 0 && sessions.length === 0) {
     return (
       <div className="view-spine-tree">
-        <ul className="session-list">
-          <li className="session-row loading">
-            <div className="session-row-primary">
-              <span className="session-name">
-                <CipherText text="deriving view…" loading />
-              </span>
-            </div>
-          </li>
-        </ul>
+        {selector}
+        <div className="view-spine-scroll">
+          <ul className="session-list">
+            <li className="session-row loading">
+              <div className="session-row-primary">
+                <span className="session-name">
+                  <CipherText text="deriving view…" loading />
+                </span>
+              </div>
+            </li>
+          </ul>
+        </div>
       </div>
     );
   }
@@ -213,8 +315,13 @@ export function ViewSpineTree() {
   if (!hasContent) {
     return (
       <div className="view-spine-tree">
-        <div className="sidebar-empty-state">
-          <span>{isError ? 'node status unavailable' : 'nothing to show'}</span>
+        {selector}
+        <div className="view-spine-scroll">
+          <div className="sidebar-empty-state">
+            <span>
+              {isError ? 'node status unavailable' : 'nothing to show'}
+            </span>
+          </div>
         </div>
       </div>
     );
@@ -222,38 +329,41 @@ export function ViewSpineTree() {
 
   return (
     <div className="view-spine-tree">
-      {tree.workspaces.map((ws) =>
-        ws.projects.length > 0 ? (
-          <section key={ws.id} className="view-spine-workspace">
-            <div className="sidebar-ungrouped-label">{ws.name}</div>
-            {ws.projects.map((project) => (
+      {selector}
+      <div className="view-spine-scroll">
+        {tree.workspaces.map((ws) =>
+          ws.projects.length > 0 ? (
+            <section key={ws.id} className="view-spine-workspace">
+              <div className="sidebar-ungrouped-label">{ws.name}</div>
+              {ws.projects.map((project) => (
+                <ProjectRow key={project.id} project={project} />
+              ))}
+            </section>
+          ) : null
+        )}
+
+        {tree.ungroupedProjects.length > 0 ? (
+          <section className="view-spine-workspace">
+            {tree.workspaces.some((ws) => ws.projects.length > 0) ? (
+              <div className="sidebar-ungrouped-label">ungrouped</div>
+            ) : null}
+            {tree.ungroupedProjects.map((project) => (
               <ProjectRow key={project.id} project={project} />
             ))}
           </section>
-        ) : null
-      )}
+        ) : null}
 
-      {tree.ungroupedProjects.length > 0 ? (
-        <section className="view-spine-workspace">
-          {tree.workspaces.some((ws) => ws.projects.length > 0) ? (
-            <div className="sidebar-ungrouped-label">ungrouped</div>
-          ) : null}
-          {tree.ungroupedProjects.map((project) => (
-            <ProjectRow key={project.id} project={project} />
-          ))}
-        </section>
-      ) : null}
-
-      {tree.freeLane.length > 0 ? (
-        <section className="view-spine-free-lane">
-          <div className="sidebar-ungrouped-label">free / remote</div>
-          <ul className="session-list">
-            {tree.freeLane.map((entry) => (
-              <FreeRow key={entry.key} entry={entry} />
-            ))}
-          </ul>
-        </section>
-      ) : null}
+        {tree.freeLane.length > 0 ? (
+          <section className="view-spine-free-lane">
+            <div className="sidebar-ungrouped-label">free / remote</div>
+            <ul className="session-list">
+              {tree.freeLane.map((entry) => (
+                <FreeRow key={entry.key} entry={entry} />
+              ))}
+            </ul>
+          </section>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ViewSpineTree.tsx
+++ b/frontend/src/components/ViewSpineTree.tsx
@@ -2,7 +2,7 @@
 // client-derived view-tree (`lib/state/view-tree.ts`). Reuses EXISTING sidebar
 // primitives only — no new visual chrome, no new animations. Leaves are COUNTS,
 // not interactive rows. Default OFF; only mounted when `viewSpineEnabled`.
-import { useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { fetchHubNodes } from '../lib/api.js';
@@ -11,8 +11,10 @@ import { MarqueeText } from './MarqueeText.js';
 import { CipherText } from './CipherText.js';
 import {
   applyLens,
+  benchCreatePayload,
   buildViewTree,
   DEFAULT_VIEW_LENS,
+  type BenchCreatePayload,
   type InstanceHostStatus,
   type ViewLens,
   type ViewTreeBench,
@@ -22,6 +24,11 @@ import {
   type ViewTreeNodeStatus,
 } from '../lib/state/view-tree.js';
 import './ViewSpineTree.css';
+
+/** Create a Tab anchored to a Bench's (nodeId, cwd). Wired to the EXISTING
+ *  node-aware session-create entrypoint by `App` — NOT a new create flow, and
+ *  NOT the worktree-creation path (`onNewWorktree`). */
+export type ViewSpineCreateTab = (payload: BenchCreatePayload) => void;
 
 // Ad-hoc, ephemeral lenses (#727). Order is the visual + arrow-key order.
 const LENSES: ReadonlyArray<{ id: ViewLens; label: string }> = [
@@ -42,7 +49,31 @@ function CountBadge({ count }: { count: number }) {
   return <span className="session-count-badge">{count}</span>;
 }
 
-function BenchRow({ bench }: { bench: ViewTreeBench }) {
+function BenchRow({
+  instance,
+  bench,
+  onCreateTab,
+}: {
+  instance: ViewTreeInstance;
+  bench: ViewTreeBench;
+  onCreateTab?: ViewSpineCreateTab | undefined;
+}) {
+  // Per-bench in-flight guard so the affordance disables itself (and other
+  // benches stay clickable) while a create is pending. Errors surface through
+  // the existing create path's toast — no bespoke error UI here.
+  const [creating, setCreating] = useState(false);
+  const handleCreate = useCallback(async () => {
+    if (!onCreateTab || creating) return;
+    setCreating(true);
+    try {
+      // Resolve the (nodeId, cwd) anchor with the PURE helper, then hand it to
+      // the existing node-aware create entrypoint. NO env-override inheritance.
+      await onCreateTab(benchCreatePayload(instance, bench));
+    } finally {
+      setCreating(false);
+    }
+  }, [onCreateTab, creating, instance, bench]);
+
   return (
     <li className="session-row inactive state-inactive view-spine-bench">
       <div className="session-row-primary">
@@ -60,11 +91,35 @@ function BenchRow({ bench }: { bench: ViewTreeBench }) {
           </span>
         </div>
       ) : null}
+      {/* #731 "+ tab" anchored to THIS bench's (nodeId, cwd). Reuses the
+          `.add-worktree-row`/`.add-worktree-btn` styling ONLY — it wires to
+          session/tab CREATION, NOT worktree creation (distinct copy `+ tab`). */}
+      {onCreateTab ? (
+        <div
+          className={['add-worktree-row', creating && 'disabled']
+            .filter(Boolean)
+            .join(' ')}
+          data-track="view-spine.new-tab"
+          onClick={() => {
+            void handleCreate();
+          }}
+        >
+          <button className="add-worktree-btn" type="button" tabIndex={-1}>
+            {creating ? 'creating…' : '+ tab'}
+          </button>
+        </div>
+      ) : null}
     </li>
   );
 }
 
-function InstanceRow({ instance }: { instance: ViewTreeInstance }) {
+function InstanceRow({
+  instance,
+  onCreateTab,
+}: {
+  instance: ViewTreeInstance;
+  onCreateTab?: ViewSpineCreateTab | undefined;
+}) {
   return (
     <li className="session-row view-spine-instance">
       <div className="session-row-primary">
@@ -82,7 +137,12 @@ function InstanceRow({ instance }: { instance: ViewTreeInstance }) {
       {instance.benches.length > 0 ? (
         <ul className="session-list view-spine-bench-list">
           {instance.benches.map((bench) => (
-            <BenchRow key={bench.id} bench={bench} />
+            <BenchRow
+              key={bench.id}
+              instance={instance}
+              bench={bench}
+              onCreateTab={onCreateTab}
+            />
           ))}
         </ul>
       ) : null}
@@ -90,7 +150,13 @@ function InstanceRow({ instance }: { instance: ViewTreeInstance }) {
   );
 }
 
-function ProjectRow({ project }: { project: ViewTreeProject }) {
+function ProjectRow({
+  project,
+  onCreateTab,
+}: {
+  project: ViewTreeProject;
+  onCreateTab?: ViewSpineCreateTab | undefined;
+}) {
   const initialColor = useMemo(
     () => deriveColor(project.colorSeed),
     [project.colorSeed]
@@ -128,7 +194,11 @@ function ProjectRow({ project }: { project: ViewTreeProject }) {
       </div>
       <ul className="session-list">
         {project.instances.map((instance) => (
-          <InstanceRow key={instance.id} instance={instance} />
+          <InstanceRow
+            key={instance.id}
+            instance={instance}
+            onCreateTab={onCreateTab}
+          />
         ))}
       </ul>
       <div className="repo-divider" />
@@ -236,7 +306,13 @@ function LensSelector({
   );
 }
 
-export function ViewSpineTree() {
+export function ViewSpineTree({
+  onCreateTab,
+}: {
+  /** #731: create a Tab anchored to a Bench's (nodeId, cwd). Read-only when
+   *  omitted — the "+ tab" affordance only renders when this is provided. */
+  onCreateTab?: ViewSpineCreateTab | undefined;
+} = {}) {
   const repos = useSessionsStore((s) => s.repos);
   const worktrees = useSessionsStore((s) => s.worktrees);
   const sessions = useSessionsStore((s) => s.sessions);
@@ -336,7 +412,11 @@ export function ViewSpineTree() {
             <section key={ws.id} className="view-spine-workspace">
               <div className="sidebar-ungrouped-label">{ws.name}</div>
               {ws.projects.map((project) => (
-                <ProjectRow key={project.id} project={project} />
+                <ProjectRow
+                  key={project.id}
+                  project={project}
+                  onCreateTab={onCreateTab}
+                />
               ))}
             </section>
           ) : null
@@ -348,7 +428,11 @@ export function ViewSpineTree() {
               <div className="sidebar-ungrouped-label">ungrouped</div>
             ) : null}
             {tree.ungroupedProjects.map((project) => (
-              <ProjectRow key={project.id} project={project} />
+              <ProjectRow
+                key={project.id}
+                project={project}
+                onCreateTab={onCreateTab}
+              />
             ))}
           </section>
         ) : null}

--- a/frontend/src/components/ViewSpineTree.tsx
+++ b/frontend/src/components/ViewSpineTree.tsx
@@ -1,10 +1,259 @@
-// #732: view-spine MVP placeholder. Flag-gated (default OFF) sidebar body.
-// The client-derived read-only tree (#729) replaces this stub in the next
-// commit. Kept intentionally minimal so the OFF render path is untouched.
-export function ViewSpineTree() {
+// #729 (Epic #444 view-spine MVP): flag-gated, READ-ONLY render of the
+// client-derived view-tree (`lib/state/view-tree.ts`). Reuses EXISTING sidebar
+// primitives only — no new visual chrome, no new animations. Leaves are COUNTS,
+// not interactive rows. Default OFF; only mounted when `viewSpineEnabled`.
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useSessionsStore } from '../lib/stores/sessions.js';
+import { fetchHubNodes } from '../lib/api.js';
+import { deriveColor } from '../lib/colors.js';
+import { MarqueeText } from './MarqueeText.js';
+import { CipherText } from './CipherText.js';
+import {
+  buildViewTree,
+  type InstanceHostStatus,
+  type ViewTreeBench,
+  type ViewTreeFreeEntry,
+  type ViewTreeInstance,
+  type ViewTreeProject,
+  type ViewTreeNodeStatus,
+} from '../lib/state/view-tree.js';
+import './ViewSpineTree.css';
+
+// CSS only defines tones for online/stale/offline/revoked; updating falls back
+// to the muted default. Map straight through — class is harmless if unstyled.
+function statusDotClass(status: InstanceHostStatus): string {
+  if (!status) return '';
+  return `hub-node-status-dot status-${status}`;
+}
+
+function CountBadge({ count }: { count: number }) {
+  if (count <= 0) return null;
+  return <span className="session-count-badge">{count}</span>;
+}
+
+function BenchRow({ bench }: { bench: ViewTreeBench }) {
   return (
-    <div className="sidebar-empty-state">
-      <span>view-spine (coming soon)</span>
+    <li className="session-row inactive state-inactive view-spine-bench">
+      <div className="session-row-primary">
+        <span className="session-name">
+          <MarqueeText>{bench.label}</MarqueeText>
+        </span>
+        <CountBadge count={bench.tab.count} />
+      </div>
+      {/* `.secondary-branch` is rendered ONLY for git benches. Directory
+          benches omit the element entirely (no branch leakage). */}
+      {bench.isGit && bench.branch ? (
+        <div className="session-row-secondary">
+          <span className="secondary-branch">
+            <MarqueeText>{bench.branch}</MarqueeText>
+          </span>
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function InstanceRow({ instance }: { instance: ViewTreeInstance }) {
+  return (
+    <li className="session-row view-spine-instance">
+      <div className="session-row-primary">
+        {instance.status ? (
+          <span
+            className={statusDotClass(instance.status)}
+            aria-label={`host ${instance.status}`}
+          />
+        ) : null}
+        <span className="session-name">
+          <MarqueeText>{instance.hostLabel}</MarqueeText>
+        </span>
+        <CountBadge count={instance.rootTab.count} />
+      </div>
+      {instance.benches.length > 0 ? (
+        <ul className="session-list view-spine-bench-list">
+          {instance.benches.map((bench) => (
+            <BenchRow key={bench.id} bench={bench} />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+function ProjectRow({ project }: { project: ViewTreeProject }) {
+  const initialColor = useMemo(
+    () => deriveColor(project.colorSeed),
+    [project.colorSeed]
+  );
+  const initial = (project.label.charAt(0) || '?').toUpperCase();
+  // Instance-count badge hidden when ≤1 (single materialization is implicit).
+  const instanceCount = project.instances.length;
+  // A repo/directory project always implies a host; show the rolled-up status
+  // of the first instance as the project-level dot. Omit when no instances.
+  const projectStatus = project.instances[0]?.status ?? null;
+  return (
+    <div className="repo-item view-spine-project">
+      <div className="repo-header">
+        <div className="repo-left">
+          {/* `.initial-block` color ONLY for bound git/dir projects. */}
+          <span className="initial-block" style={{ background: initialColor }}>
+            {initial}
+          </span>
+          <span className="repo-name">
+            <MarqueeText>{project.label}</MarqueeText>
+          </span>
+          {project.kind === 'directory' ? (
+            <span className="repo-kind-chip">dir</span>
+          ) : null}
+          {projectStatus ? (
+            <span
+              className={statusDotClass(projectStatus)}
+              aria-label={`project host ${projectStatus}`}
+            />
+          ) : null}
+          {instanceCount > 1 ? (
+            <span className="session-count-badge">{instanceCount}</span>
+          ) : null}
+        </div>
+      </div>
+      <ul className="session-list">
+        {project.instances.map((instance) => (
+          <InstanceRow key={instance.id} instance={instance} />
+        ))}
+      </ul>
+      <div className="repo-divider" />
+    </div>
+  );
+}
+
+// Reduced-anatomy row: structurally omits `.initial-block` AND
+// `.secondary-branch` JSX so repo-identity/branch leakage is impossible by
+// construction for repoPath-less (free/remote) sessions.
+function FreeRow({ entry }: { entry: ViewTreeFreeEntry }) {
+  return (
+    <li className="session-row view-spine-free-row">
+      <div className="session-row-primary">
+        {entry.status ? (
+          <span
+            className={statusDotClass(entry.status)}
+            aria-label={`host ${entry.status}`}
+          />
+        ) : null}
+        <span className="session-name">
+          <MarqueeText>{entry.label}</MarqueeText>
+        </span>
+        <CountBadge count={entry.tab.count} />
+      </div>
+    </li>
+  );
+}
+
+export function ViewSpineTree() {
+  const repos = useSessionsStore((s) => s.repos);
+  const worktrees = useSessionsStore((s) => s.worktrees);
+  const sessions = useSessionsStore((s) => s.sessions);
+  const workspaceGroups = useSessionsStore((s) => s.workspaceGroups);
+  // Reuse the existing ['hub-nodes'] query (shared TanStack cache, no new
+  // server call) — same key the dashboard/dialogs already populate.
+  const {
+    data: nodes,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['hub-nodes'],
+    queryFn: fetchHubNodes,
+    staleTime: 60_000,
+  });
+
+  const nodeStatuses: ViewTreeNodeStatus[] = useMemo(
+    () =>
+      (nodes ?? []).map((n) => ({
+        nodeId: n.nodeId,
+        ...(n.displayName ? { displayName: n.displayName } : {}),
+        status: n.status,
+        ...(n.lastSeenAt ? { lastSeenAt: n.lastSeenAt } : {}),
+      })),
+    [nodes]
+  );
+
+  const tree = useMemo(
+    () =>
+      buildViewTree({
+        repos,
+        worktrees,
+        sessions,
+        workspaceGroups,
+        nodes: nodeStatuses,
+      }),
+    [repos, worktrees, sessions, workspaceGroups, nodeStatuses]
+  );
+
+  // Loading: the node join is still resolving and there's nothing derived yet.
+  if (isLoading && repos.length === 0 && sessions.length === 0) {
+    return (
+      <div className="view-spine-tree">
+        <ul className="session-list">
+          <li className="session-row loading">
+            <div className="session-row-primary">
+              <span className="session-name">
+                <CipherText text="deriving view…" loading />
+              </span>
+            </div>
+          </li>
+        </ul>
+      </div>
+    );
+  }
+
+  const hasContent =
+    tree.workspaces.some((ws) => ws.projects.length > 0) ||
+    tree.ungroupedProjects.length > 0 ||
+    tree.freeLane.length > 0;
+
+  if (!hasContent) {
+    return (
+      <div className="view-spine-tree">
+        <div className="sidebar-empty-state">
+          <span>{isError ? 'node status unavailable' : 'nothing to show'}</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="view-spine-tree">
+      {tree.workspaces.map((ws) =>
+        ws.projects.length > 0 ? (
+          <section key={ws.id} className="view-spine-workspace">
+            <div className="sidebar-ungrouped-label">{ws.name}</div>
+            {ws.projects.map((project) => (
+              <ProjectRow key={project.id} project={project} />
+            ))}
+          </section>
+        ) : null
+      )}
+
+      {tree.ungroupedProjects.length > 0 ? (
+        <section className="view-spine-workspace">
+          {tree.workspaces.some((ws) => ws.projects.length > 0) ? (
+            <div className="sidebar-ungrouped-label">ungrouped</div>
+          ) : null}
+          {tree.ungroupedProjects.map((project) => (
+            <ProjectRow key={project.id} project={project} />
+          ))}
+        </section>
+      ) : null}
+
+      {tree.freeLane.length > 0 ? (
+        <section className="view-spine-free-lane">
+          <div className="sidebar-ungrouped-label">free / remote</div>
+          <ul className="session-list">
+            {tree.freeLane.map((entry) => (
+              <FreeRow key={entry.key} entry={entry} />
+            ))}
+          </ul>
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/ViewSpineTree.tsx
+++ b/frontend/src/components/ViewSpineTree.tsx
@@ -1,0 +1,12 @@
+// #732: view-spine MVP placeholder. Flag-gated (default OFF) sidebar body.
+// The client-derived read-only tree (#729) replaces this stub in the next
+// commit. Kept intentionally minimal so the OFF render path is untouched.
+export function ViewSpineTree() {
+  return (
+    <div className="sidebar-empty-state">
+      <span>view-spine (coming soon)</span>
+    </div>
+  );
+}
+
+export default ViewSpineTree;

--- a/frontend/src/components/ViewSpineTree.tsx
+++ b/frontend/src/components/ViewSpineTree.tsx
@@ -62,17 +62,25 @@ function BenchRow({
   // benches stay clickable) while a create is pending. Errors surface through
   // the existing create path's toast — no bespoke error UI here.
   const [creating, setCreating] = useState(false);
+  // Resolve the create payload up front. `null` for a non-git/directory bench
+  // (no config.repos anchor → agent session impossible), which withholds the
+  // "+ tab" affordance entirely. Memoized so the render decision and the click
+  // handler agree.
+  const createPayload = useMemo(
+    () => benchCreatePayload(instance, bench),
+    [instance, bench]
+  );
   const handleCreate = useCallback(async () => {
-    if (!onCreateTab || creating) return;
+    if (!onCreateTab || !createPayload || creating) return;
     setCreating(true);
     try {
-      // Resolve the (nodeId, cwd) anchor with the PURE helper, then hand it to
-      // the existing node-aware create entrypoint. NO env-override inheritance.
-      await onCreateTab(benchCreatePayload(instance, bench));
+      // Hand the resolved (nodeId, repoPath, worktreePath, cwd) payload to the
+      // existing node-aware create entrypoint. NO env-override inheritance.
+      await onCreateTab(createPayload);
     } finally {
       setCreating(false);
     }
-  }, [onCreateTab, creating, instance, bench]);
+  }, [onCreateTab, createPayload, creating]);
 
   return (
     <li className="session-row inactive state-inactive view-spine-bench">
@@ -91,10 +99,11 @@ function BenchRow({
           </span>
         </div>
       ) : null}
-      {/* #731 "+ tab" anchored to THIS bench's (nodeId, cwd). Reuses the
-          `.add-worktree-row`/`.add-worktree-btn` styling ONLY — it wires to
-          session/tab CREATION, NOT worktree creation (distinct copy `+ tab`). */}
-      {onCreateTab ? (
+      {/* #731 "+ tab" anchored to THIS bench's (nodeId, repoPath, worktree).
+          Reuses the `.add-worktree-row`/`.add-worktree-btn` styling ONLY — it
+          wires to session/tab CREATION, NOT worktree creation (distinct copy
+          `+ tab`). Withheld for non-git benches (no agent-capable repo anchor). */}
+      {onCreateTab && createPayload ? (
         <div
           className={['add-worktree-row', creating && 'disabled']
             .filter(Boolean)

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -219,12 +219,18 @@ export function useSessionHandlers({
 
   // #731: "+ tab" anchored to a view-spine Bench. Reuses the EXISTING
   // node-aware create entrypoint (`createAgentSession` → `createSession`, the
-  // #473 local/remote/free flow) with ONLY the bench's (nodeId, cwd) anchor —
-  // NO env-override inheritance (deferred to #740 / backend #735). Offline/
-  // remote-unavailable benches fail through the same toast path as every other
-  // create; no bespoke error UI.
+  // #473 local/remote/free flow). The bench resolves to the agent-session repo
+  // context the backend requires (`repoPath` ∈ config.repos, worktree → cwd) —
+  // mirroring the dialog's local-git create. NO env-override inheritance
+  // (deferred to #740 / backend #735). Offline/remote-unavailable benches fail
+  // through the same toast path as every other create; no bespoke error UI.
   const handleViewSpineCreateTab = useCallback(
-    async (payload: { nodeId: NodeId; cwd: string }) => {
+    async (payload: {
+      nodeId: NodeId;
+      repoPath: string;
+      worktreePath: string;
+      cwd: string;
+    }) => {
       const loadingKey = `view-spine-tab:${payload.nodeId}:${payload.cwd}`;
       if (useSessionsStore.getState().isItemLoading(loadingKey)) return;
       useSessionsStore.getState().setLoading(loadingKey);
@@ -234,6 +240,8 @@ export function useSessionHandlers({
         );
         const { session, error } = await createAgentSession({
           nodeId: payload.nodeId,
+          repoPath: payload.repoPath,
+          worktreePath: payload.worktreePath,
           cwd: payload.cwd,
           type: 'agent',
           cols,

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -8,6 +8,7 @@ import { useToastStore } from '../lib/stores/toasts.js';
 import { sendPtyData } from '../lib/ws.js';
 import { estimateTerminalDimensions } from '../lib/utils.js';
 import type { WorktreeInfo, Repo, PullRequest } from '../lib/types.js';
+import type { NodeId } from '../../../shared/identity.js';
 import {
   createWorktree,
   ConflictError,
@@ -215,6 +216,52 @@ export function useSessionHandlers({
       useSessionsStore.getState().clearLoading(loadingKey);
     }
   }, []);
+
+  // #731: "+ tab" anchored to a view-spine Bench. Reuses the EXISTING
+  // node-aware create entrypoint (`createAgentSession` → `createSession`, the
+  // #473 local/remote/free flow) with ONLY the bench's (nodeId, cwd) anchor —
+  // NO env-override inheritance (deferred to #740 / backend #735). Offline/
+  // remote-unavailable benches fail through the same toast path as every other
+  // create; no bespoke error UI.
+  const handleViewSpineCreateTab = useCallback(
+    async (payload: { nodeId: NodeId; cwd: string }) => {
+      const loadingKey = `view-spine-tab:${payload.nodeId}:${payload.cwd}`;
+      if (useSessionsStore.getState().isItemLoading(loadingKey)) return;
+      useSessionsStore.getState().setLoading(loadingKey);
+      try {
+        const { cols, rows } = estimateTerminalDimensions(
+          useUiStore.getState().terminalFontSize
+        );
+        const { session, error } = await createAgentSession({
+          nodeId: payload.nodeId,
+          cwd: payload.cwd,
+          type: 'agent',
+          cols,
+          rows,
+        });
+        if (session?.id && !(error instanceof ConflictError)) {
+          useSessionsStore
+            .getState()
+            .initSessionNotification(
+              session.id,
+              useConfigStore.getState().defaultNotifications
+            );
+        }
+        if (session?.id) useUiStore.getState().closeSidebar();
+        if (error && !(error instanceof ConflictError)) {
+          logger.error('Failed to create view-spine tab:', error);
+          useToastStore
+            .getState()
+            .showToast(
+              error instanceof Error ? error.message : 'failed to create tab'
+            );
+        }
+      } finally {
+        useSessionsStore.getState().clearLoading(loadingKey);
+      }
+    },
+    []
+  );
 
   const handleQuickTerminal = useCallback(async () => {
     const { currentActiveWorkspace, currentWorktreePath } =
@@ -864,6 +911,7 @@ export function useSessionHandlers({
     handleSelectSession,
     handleSelectWorkspace,
     handleQuickAgent,
+    handleViewSpineCreateTab,
     handleQuickTerminal,
     handleCustomize,
     handleOpenSettings,

--- a/frontend/src/lib/state/view-tree.ts
+++ b/frontend/src/lib/state/view-tree.ts
@@ -602,3 +602,30 @@ export function applyLens(tree: ViewTree, lens: ViewLens): ViewTree {
     freeLane: [...tree.freeLane].sort(byRecencyDesc),
   };
 }
+
+// ── S4: "+ tab" anchored to a Bench (#731, reduced) ──────────────────────────
+// PURE resolver of the create payload a "+ tab" affordance hands to the EXISTING
+// session-create entrypoint (`createAgentSession` → `createSession`, the #473
+// local/remote/free flow). A Bench is anchored to a single (nodeId, cwd); the
+// nodeId lives on its owning Instance, the cwd is the bench's path. NO
+// env-override inheritance (deferred to #740 / backend #735) — the payload
+// carries ONLY the anchor, mirroring the remote-node branch of
+// `createSessionFromForm` (cwd-only, node-scoped).
+
+/** The minimal anchor a new Tab needs: which node hosts it and which cwd it
+ *  opens in. Consumed by the existing `createAgentSession({ nodeId, cwd })`
+ *  path — this helper invents NO new create logic. */
+export interface BenchCreatePayload {
+  nodeId: NodeId;
+  cwd: string;
+}
+
+/** Resolve the `(nodeId, cwd)` a "+ tab" on `bench` (owned by `instance`)
+ *  should create against. Pure: no I/O, no React. The nodeId comes from the
+ *  Instance (the host materialization), the cwd is the bench's anchored path. */
+export function benchCreatePayload(
+  instance: Pick<ViewTreeInstance, 'nodeId'>,
+  bench: Pick<ViewTreeBench, 'path'>
+): BenchCreatePayload {
+  return { nodeId: instance.nodeId, cwd: bench.path };
+}

--- a/frontend/src/lib/state/view-tree.ts
+++ b/frontend/src/lib/state/view-tree.ts
@@ -73,6 +73,10 @@ export interface ViewTreeBench {
   isGit: boolean;
   /** Tab count grouped under this bench-equivalent. */
   tab: ViewTreeTab;
+  /** Most-recent session/worktree activity rolled up here (ISO). `null` when no
+   *  recency is known. Drives the `recent` lens; derived during build, NOT a
+   *  new fetch. */
+  lastActivity: string | null;
 }
 
 export interface ViewTreeInstance {
@@ -86,6 +90,9 @@ export interface ViewTreeInstance {
   benches: ViewTreeBench[];
   /** Tab count at the instance root (sessions anchored to the repo, no worktree). */
   rootTab: ViewTreeTab;
+  /** Max activity across this instance's benches + root sessions (ISO), `null`
+   *  when unknown. Rolls up into the project's recency. */
+  lastActivity: string | null;
 }
 
 export type ViewTreeProjectKind = 'repo' | 'directory';
@@ -99,6 +106,9 @@ export interface ViewTreeProject {
   /** Color seed (repo/dir name). `.initial-block` color uses this. */
   colorSeed: string;
   instances: ViewTreeInstance[];
+  /** Max activity across all of this project's instances (ISO), `null` when
+   *  unknown. Drives the `recent` lens ordering of projects. */
+  lastActivity: string | null;
 }
 
 export interface ViewTreeWorkspaceGroup {
@@ -123,6 +133,9 @@ export interface ViewTreeFreeEntry {
   label: string;
   /** Tab count grouped under (nodeId, cwd). */
   tab: ViewTreeTab;
+  /** Most-recent session activity for this free group (ISO), `null` when
+   *  unknown. Drives the `recent` lens ordering of the free lane. */
+  lastActivity: string | null;
 }
 
 export interface ViewTree {
@@ -146,6 +159,18 @@ export interface BuildViewTreeInput {
 function nodeIdOf(value: { nodeId?: NodeId } | undefined): NodeId {
   // Local-mode rows omit nodeId; treat as the default local node.
   return value?.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+}
+
+/** Pick the later of two ISO timestamps. `null` is "no activity known" and
+ *  always loses to a real value. Lexicographic compare is correct for ISO-8601
+ *  with a fixed offset (the summaries use UTC `Z`). */
+function maxActivity(
+  a: string | null | undefined,
+  b: string | null | undefined
+): string | null {
+  if (!a) return b ?? null;
+  if (!b) return a;
+  return a >= b ? a : b;
 }
 
 function basename(path: string): string {
@@ -207,6 +232,8 @@ interface MutableInstance {
   status: InstanceHostStatus;
   benchesByPath: Map<string, ViewTreeBench>;
   rootTabCount: number;
+  /** Rolled-up recency for root sessions (benches carry their own). */
+  rootLastActivity: string | null;
 }
 
 interface MutableProject {
@@ -238,6 +265,7 @@ function ensureInstance(
     status: statusFor(nodeId, nodesById),
     benchesByPath: new Map(),
     rootTabCount: 0,
+    rootLastActivity: null,
   };
   project.instancesByNode.set(nodeId, instance);
   return instance;
@@ -247,12 +275,14 @@ function ensureBench(
   project: MutableProject,
   instance: MutableInstance,
   path: string,
-  branch: string | null
+  branch: string | null,
+  activity: string | null
 ): ViewTreeBench {
   const existing = instance.benchesByPath.get(path);
   if (existing) {
     // Fill in a branch we learn later (e.g. from a session) on a git bench.
     if (existing.isGit && !existing.branch && branch) existing.branch = branch;
+    existing.lastActivity = maxActivity(existing.lastActivity, activity);
     return existing;
   }
   const bench: ViewTreeBench = {
@@ -264,6 +294,7 @@ function ensureBench(
     isGit: project.isGit,
     branch: project.isGit ? (branch ?? null) : null,
     tab: { count: 0 },
+    lastActivity: activity ?? null,
   };
   instance.benchesByPath.set(path, bench);
   return bench;
@@ -321,35 +352,50 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
     const project = projectsById.get(projectId);
     if (!project) continue;
     const instance = ensureInstance(project, nodeIdOf(wt), nodesById);
-    ensureBench(project, instance, wt.path, wt.branchName || null);
+    ensureBench(
+      project,
+      instance,
+      wt.path,
+      wt.branchName || null,
+      wt.lastActivity || null
+    );
   }
 
   // ── Sessions → Tab counts + free lane ─────────────────────────────────────
   const freeByKey = new Map<string, ViewTreeFreeEntry>();
+
+  /** Add a repoPath-less (or orphaned) session to the free lane, rolling up its
+   *  recency. Shared by the two no-anchor branches below. */
+  function addToFreeLane(nodeId: NodeId, cwd: string, activity: string | null) {
+    const key = `${nodeId} ${cwd}`;
+    const existing = freeByKey.get(key);
+    if (existing) {
+      existing.tab.count += 1;
+      existing.lastActivity = maxActivity(existing.lastActivity, activity);
+      return;
+    }
+    const { hostLabel, isLocal } = hostLabelFor(nodeId, nodesById);
+    freeByKey.set(key, {
+      key,
+      nodeId,
+      hostLabel,
+      isLocal,
+      status: statusFor(nodeId, nodesById),
+      cwd,
+      label: basename(cwd),
+      tab: { count: 1 },
+      lastActivity: activity ?? null,
+    });
+  }
+
   for (const session of input.sessions) {
     const nodeId = nodeIdOf(session);
+    const activity = session.lastActivity || null;
 
     // Free/remote no-anchor sessions (no repoPath): SEPARATE top-level lane.
     // Carry NO branch and NO repo identity by construction (leak guard C2).
     if (!session.repoPath) {
-      const cwd = session.worktreePath ?? session.cwd;
-      const key = `${nodeId} ${cwd}`;
-      const existing = freeByKey.get(key);
-      if (existing) {
-        existing.tab.count += 1;
-        continue;
-      }
-      const { hostLabel, isLocal } = hostLabelFor(nodeId, nodesById);
-      freeByKey.set(key, {
-        key,
-        nodeId,
-        hostLabel,
-        isLocal,
-        status: statusFor(nodeId, nodesById),
-        cwd,
-        label: basename(cwd),
-        tab: { count: 1 },
-      });
+      addToFreeLane(nodeId, session.worktreePath ?? session.cwd, activity);
       continue;
     }
 
@@ -359,24 +405,7 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
     if (!projectId) {
       // repoPath set but no matching repo row — treat as free-lane to avoid
       // inventing a project. Still carries no branch/identity.
-      const cwd = session.worktreePath ?? session.cwd;
-      const key = `${nodeId} ${cwd}`;
-      const existing = freeByKey.get(key);
-      if (existing) {
-        existing.tab.count += 1;
-        continue;
-      }
-      const { hostLabel, isLocal } = hostLabelFor(nodeId, nodesById);
-      freeByKey.set(key, {
-        key,
-        nodeId,
-        hostLabel,
-        isLocal,
-        status: statusFor(nodeId, nodesById),
-        cwd,
-        label: basename(cwd),
-        tab: { count: 1 },
-      });
+      addToFreeLane(nodeId, session.worktreePath ?? session.cwd, activity);
       continue;
     }
     const project = projectsById.get(projectId);
@@ -388,11 +417,16 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
         project,
         instance,
         session.worktreePath,
-        session.branchName || null
+        session.branchName || null,
+        activity
       );
       bench.tab.count += 1;
     } else {
       // Anchored at the repo root → instance root tab count.
+      instance.rootLastActivity = maxActivity(
+        instance.rootLastActivity,
+        activity
+      );
       instance.rootTabCount += 1;
     }
   }
@@ -405,17 +439,31 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
         if (a.isLocal !== b.isLocal) return a.isLocal ? -1 : 1;
         return a.hostLabel.localeCompare(b.hostLabel);
       })
-      .map((inst) => ({
-        id: inst.id,
-        nodeId: inst.nodeId,
-        hostLabel: inst.hostLabel,
-        isLocal: inst.isLocal,
-        status: inst.status,
-        rootTab: { count: inst.rootTabCount },
-        benches: [...inst.benchesByPath.values()].sort((a, b) =>
+      .map((inst) => {
+        const benches = [...inst.benchesByPath.values()].sort((a, b) =>
           a.path.localeCompare(b.path)
-        ),
-      }));
+        );
+        // Instance recency = max(root sessions, all bench activity).
+        const lastActivity = benches.reduce<string | null>(
+          (acc, b) => maxActivity(acc, b.lastActivity),
+          inst.rootLastActivity
+        );
+        return {
+          id: inst.id,
+          nodeId: inst.nodeId,
+          hostLabel: inst.hostLabel,
+          isLocal: inst.isLocal,
+          status: inst.status,
+          rootTab: { count: inst.rootTabCount },
+          benches,
+          lastActivity,
+        };
+      });
+    // Project recency = max across all instances.
+    const lastActivity = instances.reduce<string | null>(
+      (acc, inst) => maxActivity(acc, inst.lastActivity),
+      null
+    );
     return {
       id: project.id,
       identity: project.identity,
@@ -423,6 +471,7 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
       label: project.label,
       colorSeed: project.colorSeed,
       instances,
+      lastActivity,
     };
   }
 
@@ -466,4 +515,90 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
   );
 
   return { workspaces, ungroupedProjects, freeLane };
+}
+
+// ── S2: Views lenses (#727) ───────────────────────────────────────────────────
+// Ad-hoc, ephemeral, PURE-FILTER lenses over the already-derived tree. No
+// persistence, no new fetch, no saved Views. `applyLens` is a pure function:
+// (ViewTree, ViewLens) → ViewTree. The default lens is `recent`.
+
+export type ViewLens = 'recent' | 'all' | 'this-host';
+
+export const DEFAULT_VIEW_LENS: ViewLens = 'recent';
+
+/** Descending recency comparator. Items with no known activity (`null`) sort
+ *  last. `Array.prototype.sort` is stable (ES2019+), so equal/`null` recency
+ *  preserves the build's deterministic ordering. */
+function byRecencyDesc(
+  a: { lastActivity: string | null },
+  b: { lastActivity: string | null }
+): number {
+  if (a.lastActivity === b.lastActivity) return 0;
+  if (!a.lastActivity) return 1; // a has no activity → after b
+  if (!b.lastActivity) return -1; // b has no activity → after a
+  // Both ISO strings: later timestamp first.
+  return a.lastActivity < b.lastActivity ? 1 : -1;
+}
+
+/** Recursively sort a project's instances + their benches by recency. Returns a
+ *  new project object (no mutation of the input tree). */
+function sortProjectByRecency(project: ViewTreeProject): ViewTreeProject {
+  const instances = [...project.instances]
+    .map((inst) => ({
+      ...inst,
+      benches: [...inst.benches].sort(byRecencyDesc),
+    }))
+    .sort(byRecencyDesc);
+  return { ...project, instances };
+}
+
+/** Keep only local-node ("this host") instances on a project. Drops the project
+ *  entirely (returns `null`) when no local instance remains. Pure. */
+function localOnlyProject(project: ViewTreeProject): ViewTreeProject | null {
+  const instances = project.instances.filter((inst) => inst.isLocal);
+  if (instances.length === 0) return null;
+  return { ...project, instances };
+}
+
+/**
+ * Apply an ephemeral Views lens to the derived tree. PURE — never mutates the
+ * input, never fetches. Returns a structurally-new `ViewTree`.
+ *
+ * - `all`        → identity (the input tree, unchanged).
+ * - `recent`     → projects/instances/benches/free-lane sorted by most-recent
+ *                  activity first; stable for equal/unknown recency.
+ * - `this-host`  → only local-node instances survive; projects, workspaces, and
+ *                  free entries with nothing local drop out.
+ */
+export function applyLens(tree: ViewTree, lens: ViewLens): ViewTree {
+  if (lens === 'all') return tree;
+
+  if (lens === 'this-host') {
+    const filterProjects = (projects: ViewTreeProject[]): ViewTreeProject[] =>
+      projects
+        .map(localOnlyProject)
+        .filter((p): p is ViewTreeProject => p !== null);
+    return {
+      workspaces: tree.workspaces.map((ws) => ({
+        ...ws,
+        projects: filterProjects(ws.projects),
+      })),
+      ungroupedProjects: filterProjects(tree.ungroupedProjects),
+      freeLane: tree.freeLane.filter((entry) => entry.isLocal),
+    };
+  }
+
+  // lens === 'recent'
+  const sortProjects = (projects: ViewTreeProject[]): ViewTreeProject[] =>
+    [...projects].map(sortProjectByRecency).sort(byRecencyDesc);
+  return {
+    // Workspace groups keep their explicit order, but the projects WITHIN a
+    // group reorder by recency.
+    workspaces: tree.workspaces.map((ws) => ({
+      ...ws,
+      projects: sortProjects(ws.projects),
+    })),
+    ungroupedProjects: sortProjects(tree.ungroupedProjects),
+    freeLane: [...tree.freeLane].sort(byRecencyDesc),
+  };
 }

--- a/frontend/src/lib/state/view-tree.ts
+++ b/frontend/src/lib/state/view-tree.ts
@@ -65,6 +65,11 @@ export interface ViewTreeBench {
   id: BenchId;
   /** Anchored cwd/worktree path. */
   path: string;
+  /** Configured PARENT repo path this bench belongs to — the value the backend
+   *  validates against `config.repos` for an agent session (#731). Mirrors what
+   *  the dialog sends as `environment.repoPath`. `null` for non-git/directory
+   *  benches, which have no agent-capable repo anchor. */
+  repoPath: string | null;
   /** Last path segment, for the `.session-name` label. */
   label: string;
   /** Branch name — present ONLY for git benches; omit element otherwise. */
@@ -275,6 +280,10 @@ function ensureBench(
   project: MutableProject,
   instance: MutableInstance,
   path: string,
+  /** Configured parent repo path this bench was derived from (worktree's
+   *  `repoPath` or session's `repoPath`). Carried so "+ tab" can send the
+   *  agent-session `repoPath` the backend validates (#731). */
+  repoPath: string,
   branch: string | null,
   activity: string | null
 ): ViewTreeBench {
@@ -288,6 +297,10 @@ function ensureBench(
   const bench: ViewTreeBench = {
     id: createBenchId(instance.id, path),
     path,
+    // Only git benches expose an agent-capable repo anchor; directory benches
+    // carry `null` so the "+ tab" affordance is withheld (no config.repos
+    // entry to validate against).
+    repoPath: project.isGit ? repoPath : null,
     label: basename(path),
     // Branch element is rendered ONLY for git projects — omit by construction
     // for directory projects so identity/branch leakage is impossible.
@@ -356,6 +369,7 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
       project,
       instance,
       wt.path,
+      wt.repoPath,
       wt.branchName || null,
       wt.lastActivity || null
     );
@@ -417,6 +431,7 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
         project,
         instance,
         session.worktreePath,
+        session.repoPath,
         session.branchName || null,
         activity
       );
@@ -487,7 +502,10 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
     .map((ws) => {
       const seen = new Set<ProjectId>();
       const projects: ViewTreeProject[] = [];
-      for (const repoPath of ws.repos) {
+      // Legacy/malformed persisted workspaces can omit `repos`. Guard exactly
+      // like the OFF path (`Sidebar.tsx`) so the ON path is equally defensive.
+      const repoPaths = Array.isArray(ws.repos) ? ws.repos : [];
+      for (const repoPath of repoPaths) {
         const projectId = projectIdByRepoPath.get(repoPath);
         if (!projectId) continue;
         if (seen.has(projectId)) continue; // dedup repos sharing a remote
@@ -603,29 +621,50 @@ export function applyLens(tree: ViewTree, lens: ViewLens): ViewTree {
   };
 }
 
-// ── S4: "+ tab" anchored to a Bench (#731, reduced) ──────────────────────────
+// ── S4: "+ tab" anchored to a Bench (#731) ───────────────────────────────────
 // PURE resolver of the create payload a "+ tab" affordance hands to the EXISTING
 // session-create entrypoint (`createAgentSession` → `createSession`, the #473
-// local/remote/free flow). A Bench is anchored to a single (nodeId, cwd); the
-// nodeId lives on its owning Instance, the cwd is the bench's path. NO
-// env-override inheritance (deferred to #740 / backend #735) — the payload
-// carries ONLY the anchor, mirroring the remote-node branch of
-// `createSessionFromForm` (cwd-only, node-scoped).
+// local/remote/free flow). A Bench is anchored to a single (nodeId, worktree);
+// the nodeId lives on its owning Instance. The payload MIRRORS the local-git
+// branch of `createSessionFromForm` (the dialog) so it satisfies the backend
+// `validateSessionCreateRequest` agent contract: `repoPath` MUST be a configured
+// repo (`config.repos`) and the worktree becomes the session cwd
+// (`cwd = worktreePath ?? repoPath`, server/index.ts).
+//
+// NO env-override inheritance (deferred to #740 / backend #735) — the payload
+// carries ONLY the node anchor + the agent-session repo/worktree context the
+// backend requires. No branch, env, agent, yolo, or identity is inherited.
 
-/** The minimal anchor a new Tab needs: which node hosts it and which cwd it
- *  opens in. Consumed by the existing `createAgentSession({ nodeId, cwd })`
- *  path — this helper invents NO new create logic. */
+/** The anchor + repo context a new agent Tab needs. `repoPath` is the configured
+ *  parent repo (validated against `config.repos` by the backend); `worktreePath`
+ *  is the bench's worktree (becomes the session cwd); `cwd` mirrors the worktree
+ *  for callers/consumers that want it explicit. Consumed by the existing
+ *  `createAgentSession({ nodeId, repoPath, worktreePath, cwd })` path — this
+ *  helper invents NO new create logic. */
 export interface BenchCreatePayload {
   nodeId: NodeId;
+  repoPath: string;
+  worktreePath: string;
   cwd: string;
 }
 
-/** Resolve the `(nodeId, cwd)` a "+ tab" on `bench` (owned by `instance`)
- *  should create against. Pure: no I/O, no React. The nodeId comes from the
- *  Instance (the host materialization), the cwd is the bench's anchored path. */
+/** Resolve the agent-session create payload a "+ tab" on `bench` (owned by
+ *  `instance`) should create against. Pure: no I/O, no React.
+ *
+ *  Returns `null` for a NON-git/directory bench (`bench.repoPath === null`):
+ *  there is no `config.repos`-validated repo anchor, so an agent session cannot
+ *  be created and the "+ tab" affordance is withheld. For a git bench the
+ *  payload is `{ nodeId, repoPath, worktreePath, cwd }` — exactly what the
+ *  dialog's local-git create sends. */
 export function benchCreatePayload(
   instance: Pick<ViewTreeInstance, 'nodeId'>,
-  bench: Pick<ViewTreeBench, 'path'>
-): BenchCreatePayload {
-  return { nodeId: instance.nodeId, cwd: bench.path };
+  bench: Pick<ViewTreeBench, 'path' | 'repoPath'>
+): BenchCreatePayload | null {
+  if (!bench.repoPath) return null;
+  return {
+    nodeId: instance.nodeId,
+    repoPath: bench.repoPath,
+    worktreePath: bench.path,
+    cwd: bench.path,
+  };
 }

--- a/frontend/src/lib/state/view-tree.ts
+++ b/frontend/src/lib/state/view-tree.ts
@@ -1,0 +1,469 @@
+// #729 (Epic #444 view-spine MVP, Lane B): client-derived, READ-ONLY tree over
+// data already in the stores. ZERO new persistence, ZERO new server calls — a
+// pure projection of `repos`/`worktrees`/`sessions`/`workspaceGroups` joined
+// with the `/nodes` projection. Sibling of `sidebar-items.ts`; the original is
+// NOT modified. First production use of the `shared/project.ts`,
+// `shared/bench.ts`, `shared/workspace.ts` identity helpers.
+//
+// Layer mapping (View → Workspace → Project → Instance → Bench → Tab):
+//   Repo                → Project   (git: keyed on REMOTE identity; non-git:
+//                                     directory-project fallback keyed on
+//                                     node + path). Same remote across nodes =
+//                                     ONE Project, multiple Instances.
+//   (Project, nodeId)   → Instance  (host label: local = `this host`, remote =
+//                                     node displayName; online/stale join).
+//   WorktreeInfo        → Bench      (createBenchId(instanceId, path)).
+//   SessionSummary[]    → Tab COUNTS grouped under (nodeId, worktreePath ?? cwd).
+//   Workspace {repos[]} → Workspace grouping (repo paths → projects).
+//   repoPath-less sess. → SEPARATE free/remote lane (NOT nested under a repo).
+
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  type NodeId,
+  type RepoIdentity,
+} from '../../../../shared/identity.js';
+import {
+  createDirectoryProjectId,
+  createInstanceId,
+  createProjectId,
+  type InstanceId,
+  type ProjectId,
+  type ProjectIdentity,
+} from '../../../../shared/project.js';
+import { createBenchId, type BenchId } from '../../../../shared/bench.js';
+import {
+  createWorkspaceId,
+  type WorkspaceId,
+} from '../../../../shared/workspace.js';
+import type { HubNodeStatus } from '../../../../shared/relay-node-protocol.js';
+import type {
+  Repo,
+  SessionSummary,
+  Workspace,
+  WorktreeInfo,
+} from '../types.js';
+
+/** Subset of `HubNodeSummary` the projection needs. Keeps the adapter testable
+ *  without constructing a full manifest summary. */
+export interface ViewTreeNodeStatus {
+  nodeId: NodeId;
+  displayName?: string;
+  status: HubNodeStatus;
+  lastSeenAt?: string;
+}
+
+/** Online/stale presence for an Instance's host, joined from `/nodes`.
+ *  `null` when the project-type does not imply a host (and the dot is omitted). */
+export type InstanceHostStatus = HubNodeStatus | null;
+
+export interface ViewTreeTab {
+  /** Count only — leaves are not interactive rows. */
+  count: number;
+}
+
+export interface ViewTreeBench {
+  id: BenchId;
+  /** Anchored cwd/worktree path. */
+  path: string;
+  /** Last path segment, for the `.session-name` label. */
+  label: string;
+  /** Branch name — present ONLY for git benches; omit element otherwise. */
+  branch: string | null;
+  /** Whether this bench's host is a git repo (drives `.secondary-branch`). */
+  isGit: boolean;
+  /** Tab count grouped under this bench-equivalent. */
+  tab: ViewTreeTab;
+}
+
+export interface ViewTreeInstance {
+  id: InstanceId;
+  nodeId: NodeId;
+  /** `this host` for local; node displayName (fallback nodeId) for remote. */
+  hostLabel: string;
+  isLocal: boolean;
+  /** Online/stale presence; null when project-type has no host. */
+  status: InstanceHostStatus;
+  benches: ViewTreeBench[];
+  /** Tab count at the instance root (sessions anchored to the repo, no worktree). */
+  rootTab: ViewTreeTab;
+}
+
+export type ViewTreeProjectKind = 'repo' | 'directory';
+
+export interface ViewTreeProject {
+  id: ProjectId;
+  identity: ProjectIdentity;
+  kind: ViewTreeProjectKind;
+  /** Display label: repo name / directory basename. */
+  label: string;
+  /** Color seed (repo/dir name). `.initial-block` color uses this. */
+  colorSeed: string;
+  instances: ViewTreeInstance[];
+}
+
+export interface ViewTreeWorkspaceGroup {
+  id: WorkspaceId;
+  name: string;
+  order: number;
+  projects: ViewTreeProject[];
+}
+
+/** A repoPath-less session, surfaced in the free/remote lane. Carries NO
+ *  branch and NO repo-identity fields by construction (leak regression C2). */
+export interface ViewTreeFreeEntry {
+  /** Stable key for React, derived from node + cwd. NOT a project/instance id. */
+  key: string;
+  nodeId: NodeId;
+  hostLabel: string;
+  isLocal: boolean;
+  status: InstanceHostStatus;
+  /** Anchored cwd for the free session group. */
+  cwd: string;
+  /** Last cwd segment for the row label. */
+  label: string;
+  /** Tab count grouped under (nodeId, cwd). */
+  tab: ViewTreeTab;
+}
+
+export interface ViewTree {
+  /** Workspace-grouped projects (legacy `Workspace.repos[]`). */
+  workspaces: ViewTreeWorkspaceGroup[];
+  /** Projects not a member of any workspace group. */
+  ungroupedProjects: ViewTreeProject[];
+  /** repoPath-less sessions, separate top-level lane. */
+  freeLane: ViewTreeFreeEntry[];
+}
+
+export interface BuildViewTreeInput {
+  repos: Repo[];
+  worktrees: WorktreeInfo[];
+  sessions: SessionSummary[];
+  workspaceGroups: Workspace[];
+  /** `/nodes` projection (HubNodeSummary[] subset). */
+  nodes: ViewTreeNodeStatus[];
+}
+
+function nodeIdOf(value: { nodeId?: NodeId } | undefined): NodeId {
+  // Local-mode rows omit nodeId; treat as the default local node.
+  return value?.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+}
+
+function basename(path: string): string {
+  const trimmed = path.replace(/\/+$/, '');
+  const seg = trimmed.split('/').pop();
+  return seg && seg.length > 0 ? seg : path;
+}
+
+function projectIdentityFor(repo: Repo): ProjectIdentity {
+  const isGit = repo.isGitRepo && repo.kind !== 'directory';
+  const remote: RepoIdentity | null | undefined = repo.repoIdentity;
+  if (isGit && remote && remote.trim().length > 0) {
+    return { kind: 'repo', remote };
+  }
+  // Null/blank repoIdentity OR non-git → directory-project fallback keyed on
+  // node + path (NOT remote). Guarantees C1(a) determinism.
+  return {
+    kind: 'directory',
+    nodeId: nodeIdOf(repo),
+    localPath: repo.path,
+  };
+}
+
+function projectIdFor(identity: ProjectIdentity): ProjectId {
+  return identity.kind === 'directory'
+    ? createDirectoryProjectId(identity.nodeId, identity.localPath)
+    : createProjectId(identity);
+}
+
+function hostLabelFor(
+  nodeId: NodeId,
+  nodesById: Map<NodeId, ViewTreeNodeStatus>
+): { hostLabel: string; isLocal: boolean } {
+  const isLocal = nodeId === DEFAULT_LOCAL_NODE_ID;
+  if (isLocal) return { hostLabel: 'this host', isLocal: true };
+  const node = nodesById.get(nodeId);
+  const displayName = node?.displayName?.trim();
+  return { hostLabel: displayName || nodeId, isLocal: false };
+}
+
+function statusFor(
+  nodeId: NodeId,
+  nodesById: Map<NodeId, ViewTreeNodeStatus>
+): InstanceHostStatus {
+  const node = nodesById.get(nodeId);
+  if (!node) {
+    // Local host is implicitly online even when absent from `/nodes`. A remote
+    // node we have no status for joins as offline (C1(c)).
+    return nodeId === DEFAULT_LOCAL_NODE_ID ? 'online' : 'offline';
+  }
+  return node.status;
+}
+
+interface MutableInstance {
+  id: InstanceId;
+  nodeId: NodeId;
+  hostLabel: string;
+  isLocal: boolean;
+  status: InstanceHostStatus;
+  benchesByPath: Map<string, ViewTreeBench>;
+  rootTabCount: number;
+}
+
+interface MutableProject {
+  id: ProjectId;
+  identity: ProjectIdentity;
+  kind: ViewTreeProjectKind;
+  label: string;
+  colorSeed: string;
+  isGit: boolean;
+  /** repo paths that map to this project (for workspace-group membership). */
+  repoPaths: Set<string>;
+  instancesByNode: Map<NodeId, MutableInstance>;
+}
+
+function ensureInstance(
+  project: MutableProject,
+  nodeId: NodeId,
+  nodesById: Map<NodeId, ViewTreeNodeStatus>
+): MutableInstance {
+  const existing = project.instancesByNode.get(nodeId);
+  if (existing) return existing;
+  const { hostLabel, isLocal } = hostLabelFor(nodeId, nodesById);
+  const instance: MutableInstance = {
+    id: createInstanceId(project.id, nodeId),
+    nodeId,
+    hostLabel,
+    isLocal,
+    // A repo/directory project always implies a host, so the dot is shown.
+    status: statusFor(nodeId, nodesById),
+    benchesByPath: new Map(),
+    rootTabCount: 0,
+  };
+  project.instancesByNode.set(nodeId, instance);
+  return instance;
+}
+
+function ensureBench(
+  project: MutableProject,
+  instance: MutableInstance,
+  path: string,
+  branch: string | null
+): ViewTreeBench {
+  const existing = instance.benchesByPath.get(path);
+  if (existing) {
+    // Fill in a branch we learn later (e.g. from a session) on a git bench.
+    if (existing.isGit && !existing.branch && branch) existing.branch = branch;
+    return existing;
+  }
+  const bench: ViewTreeBench = {
+    id: createBenchId(instance.id, path),
+    path,
+    label: basename(path),
+    // Branch element is rendered ONLY for git projects — omit by construction
+    // for directory projects so identity/branch leakage is impossible.
+    isGit: project.isGit,
+    branch: project.isGit ? (branch ?? null) : null,
+    tab: { count: 0 },
+  };
+  instance.benchesByPath.set(path, bench);
+  return bench;
+}
+
+/**
+ * Build the read-only view-spine tree. Pure: no I/O, no clock reads, no React.
+ */
+export function buildViewTree(input: BuildViewTreeInput): ViewTree {
+  const nodesById = new Map<NodeId, ViewTreeNodeStatus>(
+    input.nodes.map((n) => [n.nodeId, n])
+  );
+
+  // ── Projects (dedup by ProjectId across nodes) ────────────────────────────
+  const projectsById = new Map<ProjectId, MutableProject>();
+  // Map a repo path → its ProjectId for workspace-group membership + session
+  // anchoring.
+  const projectIdByRepoPath = new Map<string, ProjectId>();
+
+  function ensureProjectForRepo(repo: Repo): MutableProject {
+    const identity = projectIdentityFor(repo);
+    const id = projectIdFor(identity);
+    projectIdByRepoPath.set(repo.path, id);
+    const existing = projectsById.get(id);
+    if (existing) {
+      existing.repoPaths.add(repo.path);
+      return existing;
+    }
+    const isGit = identity.kind === 'repo';
+    const project: MutableProject = {
+      id,
+      identity,
+      kind: isGit ? 'repo' : 'directory',
+      label: repo.name || basename(repo.path),
+      colorSeed: repo.name || basename(repo.path),
+      isGit,
+      repoPaths: new Set([repo.path]),
+      instancesByNode: new Map(),
+    };
+    projectsById.set(id, project);
+    return project;
+  }
+
+  for (const repo of input.repos) {
+    const project = ensureProjectForRepo(repo);
+    // Each repo row materializes one Instance on its node. The repo-root path
+    // is itself a bench-equivalent anchor when sessions live there.
+    ensureInstance(project, nodeIdOf(repo), nodesById);
+  }
+
+  // ── Benches from worktrees ────────────────────────────────────────────────
+  for (const wt of input.worktrees) {
+    const projectId = projectIdByRepoPath.get(wt.repoPath);
+    if (!projectId) continue; // worktree for an unknown repo — skip (no anchor)
+    const project = projectsById.get(projectId);
+    if (!project) continue;
+    const instance = ensureInstance(project, nodeIdOf(wt), nodesById);
+    ensureBench(project, instance, wt.path, wt.branchName || null);
+  }
+
+  // ── Sessions → Tab counts + free lane ─────────────────────────────────────
+  const freeByKey = new Map<string, ViewTreeFreeEntry>();
+  for (const session of input.sessions) {
+    const nodeId = nodeIdOf(session);
+
+    // Free/remote no-anchor sessions (no repoPath): SEPARATE top-level lane.
+    // Carry NO branch and NO repo identity by construction (leak guard C2).
+    if (!session.repoPath) {
+      const cwd = session.worktreePath ?? session.cwd;
+      const key = `${nodeId} ${cwd}`;
+      const existing = freeByKey.get(key);
+      if (existing) {
+        existing.tab.count += 1;
+        continue;
+      }
+      const { hostLabel, isLocal } = hostLabelFor(nodeId, nodesById);
+      freeByKey.set(key, {
+        key,
+        nodeId,
+        hostLabel,
+        isLocal,
+        status: statusFor(nodeId, nodesById),
+        cwd,
+        label: basename(cwd),
+        tab: { count: 1 },
+      });
+      continue;
+    }
+
+    // Anchored session: find its project + instance and bump a tab count under
+    // its bench-equivalent (worktreePath ?? repoPath/cwd).
+    const projectId = projectIdByRepoPath.get(session.repoPath);
+    if (!projectId) {
+      // repoPath set but no matching repo row — treat as free-lane to avoid
+      // inventing a project. Still carries no branch/identity.
+      const cwd = session.worktreePath ?? session.cwd;
+      const key = `${nodeId} ${cwd}`;
+      const existing = freeByKey.get(key);
+      if (existing) {
+        existing.tab.count += 1;
+        continue;
+      }
+      const { hostLabel, isLocal } = hostLabelFor(nodeId, nodesById);
+      freeByKey.set(key, {
+        key,
+        nodeId,
+        hostLabel,
+        isLocal,
+        status: statusFor(nodeId, nodesById),
+        cwd,
+        label: basename(cwd),
+        tab: { count: 1 },
+      });
+      continue;
+    }
+    const project = projectsById.get(projectId);
+    if (!project) continue;
+    const instance = ensureInstance(project, nodeId, nodesById);
+
+    if (session.worktreePath) {
+      const bench = ensureBench(
+        project,
+        instance,
+        session.worktreePath,
+        session.branchName || null
+      );
+      bench.tab.count += 1;
+    } else {
+      // Anchored at the repo root → instance root tab count.
+      instance.rootTabCount += 1;
+    }
+  }
+
+  // ── Finalize: mutable → immutable, stable ordering ────────────────────────
+  function finalizeProject(project: MutableProject): ViewTreeProject {
+    const instances: ViewTreeInstance[] = [...project.instancesByNode.values()]
+      .sort((a, b) => {
+        // Local host first, then by host label for deterministic order.
+        if (a.isLocal !== b.isLocal) return a.isLocal ? -1 : 1;
+        return a.hostLabel.localeCompare(b.hostLabel);
+      })
+      .map((inst) => ({
+        id: inst.id,
+        nodeId: inst.nodeId,
+        hostLabel: inst.hostLabel,
+        isLocal: inst.isLocal,
+        status: inst.status,
+        rootTab: { count: inst.rootTabCount },
+        benches: [...inst.benchesByPath.values()].sort((a, b) =>
+          a.path.localeCompare(b.path)
+        ),
+      }));
+    return {
+      id: project.id,
+      identity: project.identity,
+      kind: project.kind,
+      label: project.label,
+      colorSeed: project.colorSeed,
+      instances,
+    };
+  }
+
+  const finalizedById = new Map<ProjectId, ViewTreeProject>();
+  for (const [id, project] of projectsById) {
+    finalizedById.set(id, finalizeProject(project));
+  }
+
+  // ── Workspace grouping (legacy Workspace.repos[] → projects) ──────────────
+  const groupedProjectIds = new Set<ProjectId>();
+  const workspaces: ViewTreeWorkspaceGroup[] = [...input.workspaceGroups]
+    .sort((a, b) => a.order - b.order)
+    .map((ws) => {
+      const seen = new Set<ProjectId>();
+      const projects: ViewTreeProject[] = [];
+      for (const repoPath of ws.repos) {
+        const projectId = projectIdByRepoPath.get(repoPath);
+        if (!projectId) continue;
+        if (seen.has(projectId)) continue; // dedup repos sharing a remote
+        seen.add(projectId);
+        groupedProjectIds.add(projectId);
+        const finalized = finalizedById.get(projectId);
+        if (finalized) projects.push(finalized);
+      }
+      return {
+        id: createWorkspaceId(ws.id),
+        name: ws.name,
+        order: ws.order,
+        projects,
+      };
+    });
+
+  const ungroupedProjects: ViewTreeProject[] = [];
+  for (const [id, finalized] of finalizedById) {
+    if (!groupedProjectIds.has(id)) ungroupedProjects.push(finalized);
+  }
+  ungroupedProjects.sort((a, b) => a.label.localeCompare(b.label));
+
+  const freeLane = [...freeByKey.values()].sort((a, b) =>
+    a.key.localeCompare(b.key)
+  );
+
+  return { workspaces, ungroupedProjects, freeLane };
+}

--- a/frontend/src/lib/stores/ui.ts
+++ b/frontend/src/lib/stores/ui.ts
@@ -12,6 +12,10 @@ const UTILITY_RAIL_STATE_KEY_PREFIX = 'relay-utility-rail::';
 const DIFF_VIEW_MODE_KEY = 'claude-remote-diff-view-mode';
 const WORD_WRAP_KEY = 'claude-remote-word-wrap';
 const COLLAPSED_WORKSPACES_KEY = 'claude-remote-collapsed-workspaces';
+// #732: view-spine MVP feature flag. Default OFF. When OFF the sidebar render
+// is byte-identical to today; ON swaps in the client-derived read-only tree.
+// Dev-only affordance: set `localStorage.relay-view-spine = '1'` and reload.
+const VIEW_SPINE_KEY = 'relay-view-spine';
 
 export const DEFAULT_SIDEBAR_WIDTH = 240;
 export const MIN_SIDEBAR_WIDTH = 180;
@@ -143,6 +147,11 @@ function loadDiffViewMode(): DiffViewMode {
   const stored = ls(DIFF_VIEW_MODE_KEY);
   if (stored === 'unified' || stored === 'side-by-side') return stored;
   return 'unified';
+}
+
+function loadViewSpineEnabled(): boolean {
+  // Truthy only for the explicit opt-in value so a stale '0'/'false' reads OFF.
+  return ls(VIEW_SPINE_KEY) === '1';
 }
 
 function loadTerminalFontSize(): number {
@@ -498,6 +507,8 @@ export interface UiState {
   analyticsView: AnalyticsView;
   activeModal: ActiveModal;
   collapsedWorkspaces: Set<string>;
+  /** #732: view-spine MVP flag. Default false; backed by localStorage. */
+  viewSpineEnabled: boolean;
   // Actions
   openSidebar: () => void;
   closeSidebar: () => void;
@@ -528,6 +539,8 @@ export interface UiState {
   setActiveModal: (v: ActiveModal) => void;
   toggleWorkspaceCollapse: (path: string) => void;
   isWorkspaceCollapsed: (path: string) => boolean;
+  setViewSpineEnabled: (enabled: boolean) => void;
+  toggleViewSpineEnabled: () => void;
 }
 
 export const useUiStore = create<UiState>()((set, get) => ({
@@ -557,6 +570,7 @@ export const useUiStore = create<UiState>()((set, get) => ({
   activeModal: null,
   lastChangedFiles: [],
   collapsedWorkspaces: loadCollapsedWorkspaces(),
+  viewSpineEnabled: loadViewSpineEnabled(),
 
   openSidebar: () => set({ sidebarOpen: true }),
   closeSidebar: () => set({ sidebarOpen: false }),
@@ -1062,4 +1076,14 @@ export const useUiStore = create<UiState>()((set, get) => ({
   },
 
   isWorkspaceCollapsed: (path) => get().collapsedWorkspaces.has(path),
+
+  setViewSpineEnabled: (enabled) => {
+    if (enabled) lsSave(VIEW_SPINE_KEY, '1');
+    else lsRemove(VIEW_SPINE_KEY);
+    set({ viewSpineEnabled: enabled });
+  },
+
+  toggleViewSpineEnabled: () => {
+    get().setViewSpineEnabled(!get().viewSpineEnabled);
+  },
 }));

--- a/test/view-tree.test.ts
+++ b/test/view-tree.test.ts
@@ -4,6 +4,7 @@ import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
 import { parseInstanceId, parseProjectId } from '../shared/project.js';
 import {
   applyLens,
+  benchCreatePayload,
   buildViewTree,
   DEFAULT_VIEW_LENS,
   type BuildViewTreeInput,
@@ -470,5 +471,82 @@ describe('S2 Views lenses', () => {
     const local = applyLens(tree, 'this-host');
     expect(local.freeLane.map((e) => e.label)).toEqual(['local']);
     expect(local.freeLane[0]!.isLocal).toBe(true);
+  });
+});
+
+// ── S4: "+ tab" create-payload resolver (#731) ────────────────────────────────
+describe('S4 benchCreatePayload', () => {
+  it('anchors a local git bench to its (nodeId, worktree cwd)', () => {
+    const worktree: WorktreeInfo = {
+      name: 'feat-x',
+      path: '/repos/relay/.worktrees/feat-x',
+      repoName: 'relay',
+      repoPath: '/repos/relay',
+      displayName: 'feat-x',
+      lastActivity: '2026-05-27T00:00:00.000Z',
+      branchName: 'feature/x',
+      nodeId: DEFAULT_LOCAL_NODE_ID,
+    };
+    const tree = build({ repos: [repo()], worktrees: [worktree] });
+    const instance = allProjects(tree)[0]!.instances[0]!;
+    const bench = instance.benches[0]!;
+
+    expect(benchCreatePayload(instance, bench)).toEqual({
+      nodeId: DEFAULT_LOCAL_NODE_ID,
+      cwd: '/repos/relay/.worktrees/feat-x',
+    });
+  });
+
+  it('routes a remote bench to its node id (correct cross-node routing)', () => {
+    const remoteRepo = repo({ nodeId: 'macbook' });
+    const worktree: WorktreeInfo = {
+      name: 'feat-y',
+      path: '/repos/relay/.worktrees/feat-y',
+      repoName: 'relay',
+      repoPath: '/repos/relay',
+      displayName: 'feat-y',
+      lastActivity: '2026-05-27T00:00:00.000Z',
+      branchName: 'feature/y',
+      nodeId: 'macbook',
+    };
+    const tree = build({
+      repos: [remoteRepo],
+      worktrees: [worktree],
+      nodes: [node({ nodeId: 'macbook', status: 'online' })],
+    });
+    const instance = allProjects(tree)[0]!.instances.find(
+      (i) => i.nodeId === 'macbook'
+    )!;
+    const bench = instance.benches[0]!;
+
+    // The payload routes to the bench's host node, NOT the local default —
+    // guards against creating the tab on the wrong machine.
+    expect(benchCreatePayload(instance, bench)).toEqual({
+      nodeId: 'macbook',
+      cwd: '/repos/relay/.worktrees/feat-y',
+    });
+  });
+
+  it('carries ONLY the (nodeId, cwd) anchor — no env/branch/identity inherited', () => {
+    const worktree: WorktreeInfo = {
+      name: 'feat-z',
+      path: '/repos/relay/.worktrees/feat-z',
+      repoName: 'relay',
+      repoPath: '/repos/relay',
+      displayName: 'feat-z',
+      lastActivity: '2026-05-27T00:00:00.000Z',
+      branchName: 'feature/z',
+      nodeId: DEFAULT_LOCAL_NODE_ID,
+    };
+    const tree = build({ repos: [repo()], worktrees: [worktree] });
+    const instance = allProjects(tree)[0]!.instances[0]!;
+    const bench = instance.benches[0]!;
+
+    // #740/#735 are deferred: the payload must NOT leak branch, env, or repo
+    // identity into the create call — exactly two keys.
+    expect(Object.keys(benchCreatePayload(instance, bench)).sort()).toEqual([
+      'cwd',
+      'nodeId',
+    ]);
   });
 });

--- a/test/view-tree.test.ts
+++ b/test/view-tree.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest';
 import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
 import { parseInstanceId, parseProjectId } from '../shared/project.js';
 import {
+  applyLens,
   buildViewTree,
+  DEFAULT_VIEW_LENS,
   type BuildViewTreeInput,
   type ViewTreeNodeStatus,
 } from '../frontend/src/lib/state/view-tree.js';
@@ -315,5 +317,158 @@ describe('benches and grouping', () => {
     expect(tree.workspaces).toHaveLength(1);
     expect(tree.workspaces[0]!.projects.map((p) => p.label)).toEqual(['grouped']);
     expect(tree.ungroupedProjects.map((p) => p.label)).toEqual(['loose']);
+  });
+});
+
+// ── S2: Views lenses (#727) ───────────────────────────────────────────────────
+
+describe('S2 Views lenses', () => {
+  // Three distinct git remotes → three ungrouped projects, each with a single
+  // local session whose lastActivity is staggered so recency order is testable.
+  function recencyFixture() {
+    const mk = (name: string, when: string) => ({
+      repo: repo({
+        path: `/repos/${name}`,
+        name,
+        repoIdentity: `github.com/acme/${name}`,
+      }),
+      session: session({
+        id: `s-${name}`,
+        repoPath: `/repos/${name}`,
+        cwd: `/repos/${name}`,
+        lastActivity: when,
+      }),
+    });
+    const alpha = mk('alpha', '2026-05-20T00:00:00.000Z'); // oldest
+    const bravo = mk('bravo', '2026-05-27T12:00:00.000Z'); // newest
+    const charlie = mk('charlie', '2026-05-25T00:00:00.000Z'); // middle
+    return build({
+      repos: [alpha.repo, bravo.repo, charlie.repo],
+      sessions: [alpha.session, bravo.session, charlie.session],
+    });
+  }
+
+  it('default lens is recent', () => {
+    expect(DEFAULT_VIEW_LENS).toBe('recent');
+  });
+
+  it('All lens is identity (same object reference, unchanged)', () => {
+    const tree = recencyFixture();
+    expect(applyLens(tree, 'all')).toBe(tree);
+  });
+
+  it('Recent sorts ungrouped projects by most-recent activity first', () => {
+    const tree = recencyFixture();
+    const recent = applyLens(tree, 'recent');
+    expect(recent.ungroupedProjects.map((p) => p.label)).toEqual([
+      'bravo', // newest
+      'charlie',
+      'alpha', // oldest
+    ]);
+    // Pure: input tree untouched (still alphabetical from the build).
+    expect(tree.ungroupedProjects.map((p) => p.label)).toEqual([
+      'alpha',
+      'bravo',
+      'charlie',
+    ]);
+  });
+
+  it('Recent sorts a project\'s benches by activity, newest first', () => {
+    const old: WorktreeInfo = {
+      name: 'old',
+      path: '/repos/relay/.worktrees/old',
+      repoName: 'relay',
+      repoPath: '/repos/relay',
+      displayName: 'old',
+      lastActivity: '2026-05-20T00:00:00.000Z',
+      branchName: 'feature/old',
+      nodeId: DEFAULT_LOCAL_NODE_ID,
+    };
+    const fresh: WorktreeInfo = {
+      ...old,
+      name: 'fresh',
+      path: '/repos/relay/.worktrees/fresh',
+      displayName: 'fresh',
+      lastActivity: '2026-05-27T00:00:00.000Z',
+      branchName: 'feature/fresh',
+    };
+    const tree = build({ repos: [repo()], worktrees: [old, fresh] });
+    const recent = applyLens(tree, 'recent');
+    const benches = recent.ungroupedProjects[0]!.instances[0]!.benches;
+    expect(benches.map((b) => b.label)).toEqual(['fresh', 'old']);
+  });
+
+  it('Recent is stable for equal/unknown recency (preserves build order)', () => {
+    // Two projects, no sessions → both have null recency; build order is
+    // alphabetical and must be preserved by the stable sort.
+    const tree = build({
+      repos: [
+        repo({ path: '/repos/aaa', name: 'aaa', repoIdentity: 'github.com/acme/aaa' }),
+        repo({ path: '/repos/bbb', name: 'bbb', repoIdentity: 'github.com/acme/bbb' }),
+      ],
+    });
+    const recent = applyLens(tree, 'recent');
+    expect(recent.ungroupedProjects.map((p) => p.label)).toEqual(['aaa', 'bbb']);
+  });
+
+  it('Recent sorts the free lane by activity, newest first', () => {
+    const tree = build({
+      sessions: [
+        session({ id: 'f-old', cwd: '/tmp/old', lastActivity: '2026-05-20T00:00:00.000Z' }),
+        session({ id: 'f-new', cwd: '/tmp/new', lastActivity: '2026-05-27T00:00:00.000Z' }),
+      ],
+    });
+    const recent = applyLens(tree, 'recent');
+    expect(recent.freeLane.map((e) => e.label)).toEqual(['new', 'old']);
+  });
+
+  it('This-host excludes remote instances; drops projects with no local instance', () => {
+    const remote = 'github.com/donovan-yohan/relay-ide';
+    const tree = build({
+      repos: [
+        // Same remote on local + remote node → one project, two instances.
+        repo({ path: '/local/relay', repoIdentity: remote, nodeId: DEFAULT_LOCAL_NODE_ID }),
+        repo({ path: '/remote/relay', repoIdentity: remote, nodeId: 'macbook' }),
+        // Remote-only project → must drop out entirely under this-host.
+        repo({
+          path: '/remote/only',
+          name: 'only',
+          repoIdentity: 'github.com/acme/only',
+          nodeId: 'macbook',
+        }),
+      ],
+      nodes: [node({ nodeId: 'macbook', status: 'online' })],
+    });
+
+    const local = applyLens(tree, 'this-host');
+    const projects = [
+      ...local.workspaces.flatMap((w) => w.projects),
+      ...local.ungroupedProjects,
+    ];
+    // The remote-only project is gone; the shared project survives with only
+    // its local instance.
+    expect(projects.map((p) => p.label).sort()).toEqual(['relay']);
+    const survivor = projects.find((p) => p.label === 'relay')!;
+    expect(survivor.instances).toHaveLength(1);
+    expect(survivor.instances[0]!.isLocal).toBe(true);
+    expect(survivor.instances[0]!.nodeId).toBe(DEFAULT_LOCAL_NODE_ID);
+
+    // Pure: input tree still has both instances on the shared project.
+    const sharedBefore = tree.ungroupedProjects.find((p) => p.label === 'relay')!;
+    expect(sharedBefore.instances).toHaveLength(2);
+  });
+
+  it('This-host filters the free lane to local entries only', () => {
+    const tree = build({
+      sessions: [
+        session({ id: 'local-free', cwd: '/tmp/local', nodeId: DEFAULT_LOCAL_NODE_ID }),
+        session({ id: 'remote-free', cwd: '/tmp/remote', nodeId: 'macbook' }),
+      ],
+      nodes: [node({ nodeId: 'macbook', status: 'online' })],
+    });
+    expect(tree.freeLane).toHaveLength(2);
+    const local = applyLens(tree, 'this-host');
+    expect(local.freeLane.map((e) => e.label)).toEqual(['local']);
+    expect(local.freeLane[0]!.isLocal).toBe(true);
   });
 });

--- a/test/view-tree.test.ts
+++ b/test/view-tree.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
+import { parseInstanceId, parseProjectId } from '../shared/project.js';
+import {
+  buildViewTree,
+  type BuildViewTreeInput,
+  type ViewTreeNodeStatus,
+} from '../frontend/src/lib/state/view-tree.js';
+import type {
+  Repo,
+  SessionSummary,
+  Workspace,
+  WorktreeInfo,
+} from '../frontend/src/lib/types.js';
+
+// ── Builders ────────────────────────────────────────────────────────────────
+
+function repo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    path: '/repos/relay',
+    name: 'relay',
+    isGitRepo: true,
+    defaultBranch: 'main',
+    currentBranch: 'main',
+    repoIdentity: 'github.com/donovan-yohan/relay-ide',
+    nodeId: DEFAULT_LOCAL_NODE_ID,
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 's1',
+    type: 'agent',
+    agent: 'claude',
+    cwd: '/repos/relay',
+    displayName: 'relay',
+    createdAt: '2026-05-27T00:00:00.000Z',
+    lastActivity: '2026-05-27T00:00:00.000Z',
+    idle: true,
+    nodeId: DEFAULT_LOCAL_NODE_ID,
+    ...overrides,
+  };
+}
+
+function node(overrides: Partial<ViewTreeNodeStatus> = {}): ViewTreeNodeStatus {
+  return {
+    nodeId: 'macbook',
+    displayName: 'MacBook',
+    status: 'online',
+    ...overrides,
+  };
+}
+
+function build(partial: Partial<BuildViewTreeInput> = {}) {
+  return buildViewTree({
+    repos: [],
+    worktrees: [],
+    sessions: [],
+    workspaceGroups: [],
+    nodes: [],
+    ...partial,
+  });
+}
+
+function allProjects(tree: ReturnType<typeof buildViewTree>) {
+  return [
+    ...tree.workspaces.flatMap((ws) => ws.projects),
+    ...tree.ungroupedProjects,
+  ];
+}
+
+// ── C1: dedup matrix ──────────────────────────────────────────────────────────
+
+describe('C1 dedup matrix', () => {
+  it('(a) null repoIdentity falls back to a directory project keyed on node+path', () => {
+    const tree = build({
+      repos: [
+        repo({
+          path: '/dirs/scratch',
+          name: 'scratch',
+          isGitRepo: false,
+          kind: 'directory',
+          repoIdentity: null,
+        }),
+      ],
+    });
+    const projects = allProjects(tree);
+    expect(projects).toHaveLength(1);
+    const project = projects[0]!;
+    expect(project.kind).toBe('directory');
+    const identity = parseProjectId(project.id);
+    expect(identity).toEqual({
+      kind: 'directory',
+      nodeId: DEFAULT_LOCAL_NODE_ID,
+      localPath: '/dirs/scratch',
+    });
+    // Directory projects never carry a git remote.
+    expect(project.identity.kind).toBe('directory');
+  });
+
+  it('(a) blank repoIdentity on a git repo also falls back to directory project', () => {
+    const tree = build({
+      repos: [repo({ repoIdentity: '   ' })],
+    });
+    const projects = allProjects(tree);
+    expect(projects).toHaveLength(1);
+    expect(projects[0]!.kind).toBe('directory');
+  });
+
+  it('(b) same repo remote on two nodes = ONE project, TWO instances', () => {
+    const remote = 'github.com/donovan-yohan/relay-ide';
+    const tree = build({
+      repos: [
+        repo({
+          path: '/local/relay',
+          repoIdentity: remote,
+          nodeId: DEFAULT_LOCAL_NODE_ID,
+        }),
+        repo({
+          path: '/remote/relay',
+          repoIdentity: remote,
+          nodeId: 'macbook',
+        }),
+      ],
+      nodes: [node({ nodeId: 'macbook', status: 'online' })],
+    });
+    const projects = allProjects(tree);
+    expect(projects).toHaveLength(1);
+    const project = projects[0]!;
+    expect(project.kind).toBe('repo');
+    expect(project.instances).toHaveLength(2);
+
+    const hosts = project.instances.map((i) => i.nodeId).sort();
+    expect(hosts).toEqual(['macbook', DEFAULT_LOCAL_NODE_ID].sort());
+
+    // Instance ids reference the SAME project id, differ only by host.
+    for (const instance of project.instances) {
+      const parsed = parseInstanceId(instance.id);
+      expect(parsed?.projectId).toBe(project.id);
+    }
+
+    // Local instance labels as `this host`; remote as the node displayName.
+    const local = project.instances.find((i) => i.isLocal)!;
+    const remoteInst = project.instances.find((i) => !i.isLocal)!;
+    expect(local.hostLabel).toBe('this host');
+    expect(remoteInst.hostLabel).toBe('MacBook');
+  });
+
+  it('(c) offline-node join surfaces an offline instance status', () => {
+    const remote = 'github.com/donovan-yohan/relay-ide';
+    const tree = build({
+      repos: [repo({ path: '/remote/relay', repoIdentity: remote, nodeId: 'macbook' })],
+      nodes: [node({ nodeId: 'macbook', status: 'offline' })],
+    });
+    const project = allProjects(tree)[0]!;
+    const instance = project.instances[0]!;
+    expect(instance.nodeId).toBe('macbook');
+    expect(instance.status).toBe('offline');
+  });
+
+  it('(c) stale-node join surfaces a stale instance status', () => {
+    const remote = 'github.com/donovan-yohan/relay-ide';
+    const tree = build({
+      repos: [repo({ path: '/remote/relay', repoIdentity: remote, nodeId: 'macbook' })],
+      nodes: [node({ nodeId: 'macbook', status: 'stale' })],
+    });
+    expect(allProjects(tree)[0]!.instances[0]!.status).toBe('stale');
+  });
+
+  it('(c) a remote node absent from /nodes joins as offline', () => {
+    const remote = 'github.com/donovan-yohan/relay-ide';
+    const tree = build({
+      repos: [repo({ path: '/remote/relay', repoIdentity: remote, nodeId: 'ghost' })],
+      nodes: [],
+    });
+    expect(allProjects(tree)[0]!.instances[0]!.status).toBe('offline');
+  });
+
+  it('local host is online even when absent from /nodes', () => {
+    const tree = build({ repos: [repo()], nodes: [] });
+    expect(allProjects(tree)[0]!.instances[0]!.status).toBe('online');
+  });
+});
+
+// ── C2: free-lane leak regression ─────────────────────────────────────────────
+
+describe('C2 free-lane leak regression', () => {
+  it('a repoPath-less session lands in the free lane with NO branch/repo identity', () => {
+    const tree = build({
+      sessions: [
+        session({
+          id: 'free-1',
+          // No repoPath. A malicious-ish summary still carrying branch/repoName
+          // must NOT leak those into the free entry.
+          branchName: 'feature/should-not-leak',
+          repoName: 'should-not-leak',
+          cwd: '/tmp/scratch',
+        }),
+      ],
+    });
+    expect(allProjects(tree)).toHaveLength(0);
+    expect(tree.freeLane).toHaveLength(1);
+    const entry = tree.freeLane[0]!;
+
+    // Structural guarantee: the free entry shape carries no branch/repo fields.
+    expect(entry).not.toHaveProperty('branch');
+    expect(entry).not.toHaveProperty('branchName');
+    expect(entry).not.toHaveProperty('repoName');
+    expect(entry).not.toHaveProperty('repoIdentity');
+    // And no field VALUE equals the leaked branch/repo strings.
+    const serialized = JSON.stringify(entry);
+    expect(serialized).not.toContain('should-not-leak');
+
+    expect(entry.cwd).toBe('/tmp/scratch');
+    expect(entry.label).toBe('scratch');
+    expect(entry.tab.count).toBe(1);
+  });
+
+  it('multiple free sessions on the same (node, cwd) collapse into one counted entry', () => {
+    const tree = build({
+      sessions: [
+        session({ id: 'a', cwd: '/tmp/work', branchName: 'x' }),
+        session({ id: 'b', cwd: '/tmp/work', branchName: 'y' }),
+      ],
+    });
+    expect(tree.freeLane).toHaveLength(1);
+    expect(tree.freeLane[0]!.tab.count).toBe(2);
+  });
+
+  it('free sessions never appear nested under a repo project', () => {
+    const tree = build({
+      repos: [repo()],
+      sessions: [
+        session({ id: 'anchored', repoPath: '/repos/relay', cwd: '/repos/relay' }),
+        session({ id: 'free', cwd: '/tmp/elsewhere' }),
+      ],
+    });
+    expect(tree.freeLane).toHaveLength(1);
+    expect(tree.freeLane[0]!.cwd).toBe('/tmp/elsewhere');
+    // The anchored session bumps the project instance root tab; the free one
+    // stays in its own lane.
+    const project = allProjects(tree)[0]!;
+    expect(project.instances[0]!.rootTab.count).toBe(1);
+  });
+});
+
+// ── Bench/worktree + workspace grouping coverage ──────────────────────────────
+
+describe('benches and grouping', () => {
+  it('maps worktrees to benches with branch on git projects', () => {
+    const worktree: WorktreeInfo = {
+      name: 'feat-x',
+      path: '/repos/relay/.worktrees/feat-x',
+      repoName: 'relay',
+      repoPath: '/repos/relay',
+      displayName: 'feat-x',
+      lastActivity: '2026-05-27T00:00:00.000Z',
+      branchName: 'feature/x',
+      nodeId: DEFAULT_LOCAL_NODE_ID,
+    };
+    const tree = build({ repos: [repo()], worktrees: [worktree] });
+    const instance = allProjects(tree)[0]!.instances[0]!;
+    expect(instance.benches).toHaveLength(1);
+    const bench = instance.benches[0]!;
+    expect(bench.path).toBe('/repos/relay/.worktrees/feat-x');
+    expect(bench.isGit).toBe(true);
+    expect(bench.branch).toBe('feature/x');
+  });
+
+  it('directory-project benches omit branch entirely', () => {
+    const dir = repo({
+      path: '/dirs/scratch',
+      name: 'scratch',
+      isGitRepo: false,
+      kind: 'directory',
+      repoIdentity: null,
+    });
+    const tree = build({
+      repos: [dir],
+      sessions: [
+        session({
+          id: 'w',
+          repoPath: '/dirs/scratch',
+          worktreePath: '/dirs/scratch/sub',
+          branchName: 'leak',
+          cwd: '/dirs/scratch/sub',
+        }),
+      ],
+    });
+    const bench = allProjects(tree)[0]!.instances[0]!.benches[0]!;
+    expect(bench.isGit).toBe(false);
+    expect(bench.branch).toBeNull();
+  });
+
+  it('places workspace-group repos under their group and leaves others ungrouped', () => {
+    const grouped = repo({
+      path: '/repos/grouped',
+      name: 'grouped',
+      repoIdentity: 'github.com/acme/grouped',
+    });
+    const loose = repo({
+      path: '/repos/loose',
+      name: 'loose',
+      repoIdentity: 'github.com/acme/loose',
+    });
+    const ws: Workspace = {
+      id: 'ws-1',
+      name: 'My Workspace',
+      repos: ['/repos/grouped'],
+      order: 0,
+    };
+    const tree = build({ repos: [grouped, loose], workspaceGroups: [ws] });
+    expect(tree.workspaces).toHaveLength(1);
+    expect(tree.workspaces[0]!.projects.map((p) => p.label)).toEqual(['grouped']);
+    expect(tree.ungroupedProjects.map((p) => p.label)).toEqual(['loose']);
+  });
+});

--- a/test/view-tree.test.ts
+++ b/test/view-tree.test.ts
@@ -270,6 +270,9 @@ describe('benches and grouping', () => {
     expect(bench.path).toBe('/repos/relay/.worktrees/feat-x');
     expect(bench.isGit).toBe(true);
     expect(bench.branch).toBe('feature/x');
+    // #731: a git bench carries its configured PARENT repo path (the worktree's
+    // `repoPath`), which the backend validates against `config.repos`.
+    expect(bench.repoPath).toBe('/repos/relay');
   });
 
   it('directory-project benches omit branch entirely', () => {
@@ -295,6 +298,9 @@ describe('benches and grouping', () => {
     const bench = allProjects(tree)[0]!.instances[0]!.benches[0]!;
     expect(bench.isGit).toBe(false);
     expect(bench.branch).toBeNull();
+    // #731: a non-git/directory bench carries NO repo anchor — there is no
+    // `config.repos`-validated path to start an agent session against.
+    expect(bench.repoPath).toBeNull();
   });
 
   it('places workspace-group repos under their group and leaves others ungrouped', () => {
@@ -476,7 +482,7 @@ describe('S2 Views lenses', () => {
 
 // ── S4: "+ tab" create-payload resolver (#731) ────────────────────────────────
 describe('S4 benchCreatePayload', () => {
-  it('anchors a local git bench to its (nodeId, worktree cwd)', () => {
+  it('builds a local git agent payload (nodeId, repoPath, worktreePath, cwd)', () => {
     const worktree: WorktreeInfo = {
       name: 'feat-x',
       path: '/repos/relay/.worktrees/feat-x',
@@ -491,8 +497,12 @@ describe('S4 benchCreatePayload', () => {
     const instance = allProjects(tree)[0]!.instances[0]!;
     const bench = instance.benches[0]!;
 
+    // Mirrors the dialog's local-git create so the backend agent contract
+    // passes: repoPath is the configured parent repo, the worktree becomes cwd.
     expect(benchCreatePayload(instance, bench)).toEqual({
       nodeId: DEFAULT_LOCAL_NODE_ID,
+      repoPath: '/repos/relay',
+      worktreePath: '/repos/relay/.worktrees/feat-x',
       cwd: '/repos/relay/.worktrees/feat-x',
     });
   });
@@ -523,11 +533,41 @@ describe('S4 benchCreatePayload', () => {
     // guards against creating the tab on the wrong machine.
     expect(benchCreatePayload(instance, bench)).toEqual({
       nodeId: 'macbook',
+      repoPath: '/repos/relay',
+      worktreePath: '/repos/relay/.worktrees/feat-y',
       cwd: '/repos/relay/.worktrees/feat-y',
     });
   });
 
-  it('carries ONLY the (nodeId, cwd) anchor — no env/branch/identity inherited', () => {
+  it('returns null for a non-git/directory bench (no agent-capable anchor)', () => {
+    const dir = repo({
+      path: '/dirs/scratch',
+      name: 'scratch',
+      isGitRepo: false,
+      kind: 'directory',
+      repoIdentity: null,
+    });
+    const tree = build({
+      repos: [dir],
+      sessions: [
+        session({
+          id: 'w',
+          repoPath: '/dirs/scratch',
+          worktreePath: '/dirs/scratch/sub',
+          cwd: '/dirs/scratch/sub',
+        }),
+      ],
+    });
+    const instance = allProjects(tree)[0]!.instances[0]!;
+    const bench = instance.benches[0]!;
+
+    // A directory bench has no `config.repos`-validated repo path → an agent
+    // session is impossible, so the helper withholds a payload (UI hides +tab).
+    expect(bench.repoPath).toBeNull();
+    expect(benchCreatePayload(instance, bench)).toBeNull();
+  });
+
+  it('carries ONLY (nodeId, repoPath, worktreePath, cwd) — no env/branch/identity inherited', () => {
     const worktree: WorktreeInfo = {
       name: 'feat-z',
       path: '/repos/relay/.worktrees/feat-z',
@@ -542,11 +582,43 @@ describe('S4 benchCreatePayload', () => {
     const instance = allProjects(tree)[0]!.instances[0]!;
     const bench = instance.benches[0]!;
 
-    // #740/#735 are deferred: the payload must NOT leak branch, env, or repo
-    // identity into the create call — exactly two keys.
-    expect(Object.keys(benchCreatePayload(instance, bench)).sort()).toEqual([
+    // #740/#735 are deferred: the payload must NOT leak branch, env, agent,
+    // yolo, or repo identity into the create call — exactly these four keys.
+    const payload = benchCreatePayload(instance, bench);
+    expect(payload).not.toBeNull();
+    expect(Object.keys(payload!).sort()).toEqual([
       'cwd',
       'nodeId',
+      'repoPath',
+      'worktreePath',
     ]);
+  });
+});
+
+describe('S4 workspace-group ws.repos guard', () => {
+  it('tolerates a persisted workspace whose `repos` field is missing/non-array', () => {
+    const grouped = repo({
+      path: '/repos/grouped',
+      name: 'grouped',
+      repoIdentity: 'github.com/acme/grouped',
+    });
+    // Legacy/malformed persisted workspace: `repos` omitted. The ON path must
+    // not throw (mirrors the OFF path's `Array.isArray` guard in Sidebar.tsx).
+    const malformed = {
+      id: 'ws-legacy',
+      name: 'Legacy',
+      order: 0,
+    } as unknown as Workspace;
+
+    expect(() =>
+      build({ repos: [grouped], workspaceGroups: [malformed] })
+    ).not.toThrow();
+
+    const tree = build({ repos: [grouped], workspaceGroups: [malformed] });
+    // No repos → the group is present but empty; the repo falls through to the
+    // ungrouped lane rather than crashing the projection.
+    expect(tree.workspaces).toHaveLength(1);
+    expect(tree.workspaces[0]!.projects).toEqual([]);
+    expect(tree.ungroupedProjects.map((p) => p.label)).toEqual(['grouped']);
   });
 });


### PR DESCRIPTION
## Epic #444 — view-spine MVP foundation (read-only, flag-gated)

First user-facing slice of the six-layer IA (View→Workspace→Project→Instance→Bench→Tab). A **read-only, client-derived** sidebar tree rendered over **existing** repo/worktree/session/node data — **zero new persistence, zero new server endpoints**. Behind a feature flag, **default OFF**.

### What shipped
- **S1 (#732 fe-half)** — `view-spine` feature flag (`viewSpineEnabled` in `ui.ts`, localStorage `relay-view-spine`, default OFF) + render swap in `Sidebar.tsx`. **OFF path is byte-identical** to legacy (`sidebar-items.ts` + `sessions.ts` untouched).
- **S3 (#729 read-only)** — new `view-tree.ts` derive adapter + `ViewSpineTree.tsx`. First production use of the `shared/` id helpers. Derives View→Workspace→Project→Instance→Bench→Tab; dedups instances across nodes (keyed on repo remote, dir fallback); joins online/stale from `/nodes`; free/remote no-anchor lane structurally omits identity/branch (no leakage).
- **S2 (#727)** — Views selector + Recent (default) / All sessions / This host lenses (ephemeral, pure filters).
- **S4 (#731 reduced)** — "+ tab" on a git bench creates an agent session anchored to `(nodeId, repoPath, worktreePath)` via the existing #473 create path. No env inheritance. Hidden on non-repo benches.

### Verification
- Gates: `npm run build` ✅ · `npm run check` ✅ (0 errors) · `npm test -- view-tree` ✅ **26/26**.
- QA (browser, agent-browser): flag OFF byte-identical ✅; flag ON tree renders with **zero new endpoints** ✅; lenses filter live ✅; states/keyboard/touch ✅; **"+ tab" → 201, session created with repoPath+worktreePath ✅** (initial 400 fixed in `ee8336d`).
- Review: approved; one guard concern (`ws.repos` Array.isArray) fixed in `ee8336d`. Bot triage clean.
- Not browser-verified (single-node env): remote-node / free-lane behavior + positive tab-count badges — covered by unit tests + structural guarantees; flagged for the federated dogfood pass.

### Preview
`localStorage.setItem('relay-view-spine','1')` + reload. Run a test instance: `RELAY_IDE_PORT=3458 RELAY_IDE_CONFIG=/tmp/relay-test/config.json NO_PIN=1 node dist/bin/relay-ide.js hub`.

### Non-goals (deferred, tracked)
No persistence/CRUD/migration (backend lane #733–#737), no Workspace bar (#728), no Bench creation (#730), no env inherit (#740), no saved Views/pins (#738), no interactive tab leaves (#739). Do not flip the flag ON by default until the backend source-of-truth lands.

Refs #444. Implements MVP scope of #727, #729 (read-only), #731 (reduced), #732 (fe flag half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a hierarchical sidebar view displaying workspaces, projects, and their structure with quick tab creation capabilities
  * Users can toggle between different sidebar organization layouts to find the setup that works best

* **Tests**
  * Added comprehensive test suite validating the view-spine tree logic and filtering behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/741?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->