### PR TITLE
feat(#734): server-side derived IA read API (Project/Instance/Bench)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../../node_modules

--- a/server/features/ia-tree.ts
+++ b/server/features/ia-tree.ts
@@ -1,0 +1,408 @@
+// #734 (BE-2, Epic #444 view-spine): SERVER-SIDE, READ-ONLY derive of the
+// six-layer IA read model — Project (with ProjectIdentity) → Instance → Bench —
+// from the AUTHORITATIVE server-side data: per-node `RepoInventoryReport`s
+// (config.repos + worktree scan) joined with hub node status (online/stale/
+// offline). This mirrors, server-side, the structural part of the CLIENT derive
+// in `frontend/src/lib/state/view-tree.ts` so the frontend can LATER switch from
+// its client-derive to this server source-of-truth.
+//
+// NON-DESTRUCTIVE: pure read/derive. ZERO persistence, ZERO DB writes, ZERO
+// migration, ZERO new tables. No I/O and no clock reads in the pure builder
+// (the route supplies the already-collected reports + node statuses + a clock).
+//
+// Layer mapping (View → Workspace → Project → Instance → Bench → Tab):
+//   RepoInventoryRepoInstance      → Project   (git: keyed on REMOTE identity via
+//                                     createProjectId; null/non-git → directory
+//                                     project keyed on node + localPath). Same
+//                                     remote across nodes = ONE Project, N
+//                                     Instances.
+//   (Project, report.nodeId)       → Instance  (host label: local = `this host`,
+//                                     remote = node displayName; online/stale/
+//                                     offline join from node status).
+//   RepoInventoryWorktreeInstance  → Bench      (createBenchId(instanceId, path);
+//                                     branch only on git instances).
+//   Workspace { repos: string[] }  → Workspace grouping (repo localPath → project).
+//
+// Tab COUNTS are intentionally OUT OF SCOPE here: a `RepoInventoryReport` carries
+// no session data, and cross-node session aggregation is a separate read model
+// (`server/hub-session-aggregator.ts`). The client derive layers tab counts from
+// its own `sessions` store; the server tree exposes the durable repo/worktree
+// structure the frontend can join sessions onto.
+
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  type NodeId,
+  type RepoIdentity,
+} from '../../shared/identity.js';
+import {
+  createDirectoryProjectId,
+  createInstanceId,
+  createProjectId,
+  type InstanceId,
+  type ProjectId,
+  type ProjectIdentity,
+} from '../../shared/project.js';
+import { createBenchId, type BenchId } from '../../shared/bench.js';
+import {
+  createWorkspaceId,
+  type WorkspaceId,
+} from '../../shared/workspace.js';
+import type { HubNodeStatus } from '../../shared/relay-node-protocol.js';
+import type {
+  RepoInventoryReport,
+  RepoInventoryRepoInstance,
+  RepoInventoryWorktreeInstance,
+} from '../../shared/repo-inventory.js';
+
+/** Minimal node-status subset the derive needs, joined from the hub registry's
+ *  `HubNodeSummary[]`. Kept small so the builder is testable without a full
+ *  manifest summary (mirrors `ViewTreeNodeStatus` on the client). */
+export interface IaNodeStatus {
+  nodeId: NodeId;
+  displayName?: string;
+  status: HubNodeStatus;
+  lastSeenAt?: string;
+}
+
+/** Minimal workspace-group subset (legacy `config.workspaces[]`) used only for
+ *  grouping projects by their member repo localPaths. */
+export interface IaWorkspaceGroupInput {
+  id: string;
+  name: string;
+  order: number;
+  /** Configured member repo localPaths. Legacy/malformed entries may omit it. */
+  repos?: string[];
+}
+
+/** Online/stale/offline presence for an Instance's host. A repo/directory
+ *  project always implies a host, so this is never null here (unlike the client
+ *  derive, which carries non-host project kinds). */
+export type IaInstanceHostStatus = HubNodeStatus;
+
+export type IaProjectKind = 'repo' | 'directory';
+
+export interface IaBench {
+  id: BenchId;
+  /** Anchored cwd/worktree path (node-local). */
+  path: string;
+  /** Configured PARENT repo localPath this bench belongs to — the value the
+   *  backend validates against `config.repos` for an agent session. `null` for
+   *  non-git/directory benches (no agent-capable repo anchor). */
+  repoPath: string | null;
+  /** Last path segment, for the display label. */
+  label: string;
+  /** Branch name — present ONLY for git benches; `null` otherwise. */
+  branch: string | null;
+  /** Whether this bench's project is a git repo. */
+  isGit: boolean;
+  /** Most-recent worktree activity rolled up here (ISO), `null` when unknown. */
+  lastActivity: string | null;
+}
+
+export interface IaInstance {
+  id: InstanceId;
+  nodeId: NodeId;
+  /** `this host` for local; node displayName (fallback nodeId) for remote. */
+  hostLabel: string;
+  isLocal: boolean;
+  /** Online/stale/offline presence joined from node status. */
+  status: IaInstanceHostStatus;
+  /** Node-local checkout path that materializes this instance. */
+  localPath: string;
+  benches: IaBench[];
+  /** Max activity across this instance's benches (ISO), `null` when unknown. */
+  lastActivity: string | null;
+}
+
+export interface IaProject {
+  id: ProjectId;
+  identity: ProjectIdentity;
+  kind: IaProjectKind;
+  /** Display label: repo name / directory basename. */
+  label: string;
+  instances: IaInstance[];
+  /** Max activity across all instances (ISO), `null` when unknown. */
+  lastActivity: string | null;
+}
+
+export interface IaWorkspaceGroup {
+  id: WorkspaceId;
+  name: string;
+  order: number;
+  projects: IaProject[];
+}
+
+export interface IaTree {
+  /** Workspace-grouped projects (legacy `config.workspaces[].repos`). */
+  workspaces: IaWorkspaceGroup[];
+  /** Projects not a member of any workspace group. */
+  ungroupedProjects: IaProject[];
+  /** ISO timestamp the tree was derived (route-supplied clock). */
+  generatedAt: string;
+}
+
+export interface BuildIaTreeInput {
+  /** Per-node authoritative inventory reports (config.repos + worktree scan). */
+  reports: RepoInventoryReport[];
+  /** Hub node statuses, joined for online/stale/offline + host labels. */
+  nodes: IaNodeStatus[];
+  /** Optional workspace groups (legacy `config.workspaces`). */
+  workspaceGroups?: IaWorkspaceGroupInput[];
+  /** Derivation timestamp (deterministic in tests). */
+  generatedAt: string;
+}
+
+function basename(value: string): string {
+  const trimmed = value.replace(/\/+$/, '');
+  const seg = trimmed.split('/').pop();
+  return seg && seg.length > 0 ? seg : value;
+}
+
+/** Pick the later of two ISO timestamps. `null` is "no activity known" and
+ *  always loses. Lexicographic compare is correct for fixed-offset ISO-8601. */
+function maxActivity(
+  a: string | null | undefined,
+  b: string | null | undefined
+): string | null {
+  if (!a) return b ?? null;
+  if (!b) return a;
+  return a >= b ? a : b;
+}
+
+/** Repo identity → ProjectIdentity. Git repo with a non-blank remote identity
+ *  becomes a `repo`-kind project keyed on the REMOTE (so the same logical repo
+ *  on N nodes dedups to ONE project). Non-git OR null/blank identity falls back
+ *  to a `directory`-kind project keyed on node + localPath (never the remote),
+ *  guaranteeing determinism + no identity leakage onto non-repo entries. */
+function projectIdentityFor(repo: RepoInventoryRepoInstance): ProjectIdentity {
+  const remote: RepoIdentity | null | undefined = repo.repoIdentity;
+  if (repo.isGitRepo && remote && remote.trim().length > 0) {
+    return { kind: 'repo', remote };
+  }
+  return {
+    kind: 'directory',
+    nodeId: repo.nodeId,
+    localPath: repo.localPath,
+  };
+}
+
+function projectIdFor(identity: ProjectIdentity): ProjectId {
+  return identity.kind === 'directory'
+    ? createDirectoryProjectId(identity.nodeId, identity.localPath)
+    : createProjectId(identity);
+}
+
+function hostLabelFor(
+  nodeId: NodeId,
+  nodesById: Map<NodeId, IaNodeStatus>
+): { hostLabel: string; isLocal: boolean } {
+  if (nodeId === DEFAULT_LOCAL_NODE_ID) {
+    return { hostLabel: 'this host', isLocal: true };
+  }
+  const displayName = nodesById.get(nodeId)?.displayName?.trim();
+  return { hostLabel: displayName || nodeId, isLocal: false };
+}
+
+function statusFor(
+  nodeId: NodeId,
+  nodesById: Map<NodeId, IaNodeStatus>
+): IaInstanceHostStatus {
+  const node = nodesById.get(nodeId);
+  if (!node) {
+    // Local host is implicitly online even when absent from the registry. A
+    // remote node we have no status for joins as offline (degrade cleanly,
+    // never crash) — mirrors the client derive's C1(c) rule.
+    return nodeId === DEFAULT_LOCAL_NODE_ID ? 'online' : 'offline';
+  }
+  return node.status;
+}
+
+interface MutableInstance {
+  id: InstanceId;
+  nodeId: NodeId;
+  hostLabel: string;
+  isLocal: boolean;
+  status: IaInstanceHostStatus;
+  localPath: string;
+  benches: IaBench[];
+}
+
+interface MutableProject {
+  id: ProjectId;
+  identity: ProjectIdentity;
+  kind: IaProjectKind;
+  label: string;
+  isGit: boolean;
+  /** repo localPaths that map to this project (for workspace-group membership). */
+  repoPaths: Set<string>;
+  /** keyed by `${nodeId} ${localPath}` — a checkout instance per node+path. */
+  instancesByKey: Map<string, MutableInstance>;
+}
+
+function benchFor(
+  instanceId: InstanceId,
+  isGit: boolean,
+  repoLocalPath: string,
+  worktree: RepoInventoryWorktreeInstance
+): IaBench {
+  return {
+    id: createBenchId(instanceId, worktree.localPath),
+    path: worktree.localPath,
+    // Only git benches expose a `config.repos`-validated agent anchor; directory
+    // benches carry null so identity/branch leakage is impossible.
+    repoPath: isGit ? repoLocalPath : null,
+    label: basename(worktree.localPath),
+    isGit,
+    branch: isGit ? (worktree.branchName ?? null) : null,
+    lastActivity: worktree.lastActivity ?? null,
+  };
+}
+
+/**
+ * Build the server-side IA read tree. PURE: no I/O, no clock reads, no network.
+ * Reports + node statuses + the clock are supplied by the route.
+ */
+export function buildIaTree(input: BuildIaTreeInput): IaTree {
+  const nodesById = new Map<NodeId, IaNodeStatus>(
+    input.nodes.map((n) => [n.nodeId, n])
+  );
+
+  const projectsById = new Map<ProjectId, MutableProject>();
+  // repo localPath → ProjectId, for workspace-group membership.
+  const projectIdByRepoPath = new Map<string, ProjectId>();
+
+  for (const report of input.reports) {
+    for (const repo of report.repos) {
+      const identity = projectIdentityFor(repo);
+      const projectId = projectIdFor(identity);
+      projectIdByRepoPath.set(repo.localPath, projectId);
+
+      let project = projectsById.get(projectId);
+      if (!project) {
+        const isGit = identity.kind === 'repo';
+        project = {
+          id: projectId,
+          identity,
+          kind: isGit ? 'repo' : 'directory',
+          label: repo.name || basename(repo.localPath),
+          isGit,
+          repoPaths: new Set(),
+          instancesByKey: new Map(),
+        };
+        projectsById.set(projectId, project);
+      }
+      project.repoPaths.add(repo.localPath);
+
+      // One Instance per (node, checkout path). The same remote on two nodes is
+      // ONE project with two instances; two checkouts of the same remote on the
+      // SAME node are two instances (distinct localPaths) under one project.
+      const instanceKey = `${repo.nodeId} ${repo.localPath}`;
+      let instance = project.instancesByKey.get(instanceKey);
+      if (!instance) {
+        const { hostLabel, isLocal } = hostLabelFor(repo.nodeId, nodesById);
+        const instanceId = createInstanceId(project.id, repo.nodeId);
+        instance = {
+          id: instanceId,
+          nodeId: repo.nodeId,
+          hostLabel,
+          isLocal,
+          status: statusFor(repo.nodeId, nodesById),
+          localPath: repo.localPath,
+          benches: [],
+        };
+        project.instancesByKey.set(instanceKey, instance);
+      }
+
+      // Benches from the repo's worktree instances.
+      for (const worktree of repo.worktrees) {
+        instance.benches.push(
+          benchFor(instance.id, project.isGit, repo.localPath, worktree)
+        );
+      }
+    }
+  }
+
+  // ── Finalize: mutable → immutable, stable ordering, recency rollup ──────────
+  function finalizeProject(project: MutableProject): IaProject {
+    const instances: IaInstance[] = [...project.instancesByKey.values()]
+      .sort((a, b) => {
+        // Local host first, then host label, then localPath for determinism.
+        if (a.isLocal !== b.isLocal) return a.isLocal ? -1 : 1;
+        return (
+          a.hostLabel.localeCompare(b.hostLabel) ||
+          a.localPath.localeCompare(b.localPath)
+        );
+      })
+      .map((inst) => {
+        const benches = [...inst.benches].sort((a, b) =>
+          a.path.localeCompare(b.path)
+        );
+        const lastActivity = benches.reduce<string | null>(
+          (acc, bench) => maxActivity(acc, bench.lastActivity),
+          null
+        );
+        return {
+          id: inst.id,
+          nodeId: inst.nodeId,
+          hostLabel: inst.hostLabel,
+          isLocal: inst.isLocal,
+          status: inst.status,
+          localPath: inst.localPath,
+          benches,
+          lastActivity,
+        };
+      });
+    const lastActivity = instances.reduce<string | null>(
+      (acc, inst) => maxActivity(acc, inst.lastActivity),
+      null
+    );
+    return {
+      id: project.id,
+      identity: project.identity,
+      kind: project.kind,
+      label: project.label,
+      instances,
+      lastActivity,
+    };
+  }
+
+  const finalizedById = new Map<ProjectId, IaProject>();
+  for (const [id, project] of projectsById) {
+    finalizedById.set(id, finalizeProject(project));
+  }
+
+  // ── Workspace grouping (legacy config.workspaces[].repos → projects) ────────
+  const groupedProjectIds = new Set<ProjectId>();
+  const workspaces: IaWorkspaceGroup[] = [...(input.workspaceGroups ?? [])]
+    .sort((a, b) => a.order - b.order)
+    .map((ws) => {
+      const seen = new Set<ProjectId>();
+      const projects: IaProject[] = [];
+      // Legacy/malformed persisted workspaces can omit `repos` — guard exactly
+      // like the client derive so we never throw on bad on-disk state.
+      const repoPaths = Array.isArray(ws.repos) ? ws.repos : [];
+      for (const repoPath of repoPaths) {
+        const projectId = projectIdByRepoPath.get(repoPath);
+        if (!projectId) continue;
+        if (seen.has(projectId)) continue; // dedup repos sharing a remote
+        seen.add(projectId);
+        groupedProjectIds.add(projectId);
+        const finalized = finalizedById.get(projectId);
+        if (finalized) projects.push(finalized);
+      }
+      return {
+        id: createWorkspaceId(ws.id),
+        name: ws.name,
+        order: ws.order,
+        projects,
+      };
+    });
+
+  const ungroupedProjects: IaProject[] = [];
+  for (const [id, finalized] of finalizedById) {
+    if (!groupedProjectIds.has(id)) ungroupedProjects.push(finalized);
+  }
+  ungroupedProjects.sort((a, b) => a.label.localeCompare(b.label));
+
+  return { workspaces, ungroupedProjects, generatedAt: input.generatedAt };
+}

--- a/server/features/repo-router.ts
+++ b/server/features/repo-router.ts
@@ -35,6 +35,11 @@ import {
   type RepoInventoryReport,
 } from '../../shared/repo-inventory.js';
 import {
+  buildIaTree,
+  type IaNodeStatus,
+  type IaWorkspaceGroupInput,
+} from './ia-tree.js';
+import {
   expiresAtFromLifecycleInput,
   lifecycleInputError,
   sessionEnvelopeRegistry,
@@ -50,6 +55,12 @@ export interface RepoFeatureRouterOptions {
   sessionEnvelopes?: InMemorySessionEnvelopeRegistry;
   confirmations?: ConfirmationChallengeStore;
   auditSink?: RoutedSessionAuditSink;
+  /**
+   * Legacy workspace groups (config.workspaces) used ONLY to group derived
+   * projects in `GET /hub/ia/tree`. Config-agnostic by injection so this router
+   * never reaches into config directly. Optional: omit → no grouping.
+   */
+  listWorkspaceGroups?: () => IaWorkspaceGroupInput[];
   now?: () => Date;
 }
 
@@ -113,6 +124,42 @@ export function createRepoFeatureRouter(
         reports.push(await options.collectLocalRepoInventory());
       }
       res.json(summarizeRepoIdentityGroups(reports, now()));
+    } catch (error) {
+      sendRegistryError(registry, res, error);
+    }
+  });
+
+  // GET /hub/ia/tree (#734): server-side DERIVED six-layer IA read model —
+  // Project (with ProjectIdentity) → Instance → Bench — from the SAME
+  // authoritative cross-node inventory reports `/hub/repo-inventory` uses,
+  // joined with hub node status (online/stale/offline) and optional workspace
+  // grouping. Non-destructive: pure read/derive, no persistence/migration. This
+  // is the server source-of-truth the frontend `view-tree` derive can later
+  // consume instead of deriving client-side.
+  router.get('/hub/ia/tree', requireAuth, async (_req, res) => {
+    try {
+      const reports = [...repoInventoryFeature.listInventoryReports()];
+      if (options.collectLocalRepoInventory) {
+        reports.push(await options.collectLocalRepoInventory());
+      }
+      // Join hub node status for host labels + online/stale/offline. Local node
+      // is implicitly online and may be absent from the registry list — the
+      // builder handles that (degrades cleanly, never crashes).
+      const nodes: IaNodeStatus[] = registry.listNodes().map((node) => ({
+        nodeId: node.nodeId,
+        displayName: node.displayName,
+        status: node.status,
+        lastSeenAt: node.lastSeenAt,
+      }));
+      const tree = buildIaTree({
+        reports,
+        nodes,
+        ...(options.listWorkspaceGroups
+          ? { workspaceGroups: options.listWorkspaceGroups() }
+          : {}),
+        generatedAt: now().toISOString(),
+      });
+      res.json(tree);
     } catch (error) {
       sendRegistryError(registry, res, error);
     }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1606,12 +1606,14 @@ async function main(): Promise<void> {
       // GET /hub/ia/tree. Read-only projection of config.workspaces; the
       // builder tolerates malformed/missing `repos` arrays.
       listWorkspaceGroups: () =>
-        (getConfig().workspaces ?? []).map((ws) => ({
-          id: ws.id,
-          name: ws.name,
-          order: ws.order,
-          ...(Array.isArray(ws.repos) ? { repos: ws.repos } : {}),
-        })),
+        (getConfig().workspaces ?? [])
+          .filter((ws): ws is NonNullable<typeof ws> => ws != null)
+          .map((ws) => ({
+            id: ws.id,
+            name: ws.name,
+            order: typeof ws.order === 'number' ? ws.order : 0,
+            ...(Array.isArray(ws.repos) ? { repos: ws.repos } : {}),
+          })),
       ...(securityAuditLog ? { auditSink: securityAuditLog } : {}),
     })
   );

--- a/server/index.ts
+++ b/server/index.ts
@@ -1602,6 +1602,16 @@ async function main(): Promise<void> {
       collectLocalRepoInventory: collectLocalInventory,
       confirmations: confirmationChallenges,
       sessionEnvelopes: sessionEnvelopeRegistry,
+      // #734: legacy workspace groups feed the optional grouping in
+      // GET /hub/ia/tree. Read-only projection of config.workspaces; the
+      // builder tolerates malformed/missing `repos` arrays.
+      listWorkspaceGroups: () =>
+        (getConfig().workspaces ?? []).map((ws) => ({
+          id: ws.id,
+          name: ws.name,
+          order: ws.order,
+          ...(Array.isArray(ws.repos) ? { repos: ws.repos } : {}),
+        })),
       ...(securityAuditLog ? { auditSink: securityAuditLog } : {}),
     })
   );

--- a/test/ia-tree.test.ts
+++ b/test/ia-tree.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
+import { parseInstanceId, parseProjectId } from '../shared/project.js';
+import type {
+  RepoInventoryReport,
+  RepoInventoryRepoInstance,
+  RepoInventoryWorktreeInstance,
+} from '../shared/repo-inventory.js';
+import {
+  buildIaTree,
+  type BuildIaTreeInput,
+  type IaNodeStatus,
+  type IaProject,
+  type IaTree,
+} from '../server/features/ia-tree.js';
+
+// ── Builders ────────────────────────────────────────────────────────────────
+
+function repoInstance(
+  overrides: Partial<RepoInventoryRepoInstance> = {}
+): RepoInventoryRepoInstance {
+  const nodeId = overrides.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  const localPath = overrides.localPath ?? '/repos/relay';
+  return {
+    repoInstanceId: `${nodeId}:${localPath}`,
+    nodeId,
+    localPath,
+    name: 'relay',
+    isGitRepo: true,
+    defaultBranch: 'main',
+    currentBranch: 'main',
+    repoIdentity: 'github.com/donovan-yohan/relay-ide',
+    selectedRemote: null,
+    remotes: [],
+    repoIdentityWarnings: [],
+    worktrees: [],
+    reportedAt: '2026-05-27T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function worktree(
+  overrides: Partial<RepoInventoryWorktreeInstance> = {}
+): RepoInventoryWorktreeInstance {
+  const localPath = overrides.localPath ?? '/repos/relay/.worktrees/feat-x';
+  return {
+    worktreeInstanceId: `local:${localPath}`,
+    localPath,
+    branchName: 'feature/x',
+    displayName: 'feat-x',
+    lastActivity: '2026-05-27T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function report(
+  nodeId: string,
+  repos: RepoInventoryRepoInstance[]
+): RepoInventoryReport {
+  return { nodeId, generatedAt: '2026-05-27T00:00:00.000Z', repos };
+}
+
+function node(overrides: Partial<IaNodeStatus> = {}): IaNodeStatus {
+  return { nodeId: 'macbook', displayName: 'MacBook', status: 'online', ...overrides };
+}
+
+function build(partial: Partial<BuildIaTreeInput> = {}): IaTree {
+  return buildIaTree({
+    reports: [],
+    nodes: [],
+    generatedAt: '2026-05-27T00:00:00.000Z',
+    ...partial,
+  });
+}
+
+function allProjects(tree: IaTree): IaProject[] {
+  return [...tree.workspaces.flatMap((ws) => ws.projects), ...tree.ungroupedProjects];
+}
+
+// ── C1: dedup matrix ──────────────────────────────────────────────────────────
+
+describe('C1 dedup matrix', () => {
+  it('(a) null repoIdentity → directory project keyed on node+path', () => {
+    const tree = build({
+      reports: [
+        report(DEFAULT_LOCAL_NODE_ID, [
+          repoInstance({
+            localPath: '/dirs/scratch',
+            name: 'scratch',
+            isGitRepo: false,
+            repoIdentity: null,
+          }),
+        ]),
+      ],
+    });
+    const projects = allProjects(tree);
+    expect(projects).toHaveLength(1);
+    const project = projects[0]!;
+    expect(project.kind).toBe('directory');
+    expect(parseProjectId(project.id)).toEqual({
+      kind: 'directory',
+      nodeId: DEFAULT_LOCAL_NODE_ID,
+      localPath: '/dirs/scratch',
+    });
+    expect(project.identity.kind).toBe('directory');
+  });
+
+  it('(a) blank repoIdentity on a git repo also falls back to directory', () => {
+    const tree = build({
+      reports: [report(DEFAULT_LOCAL_NODE_ID, [repoInstance({ repoIdentity: '   ' })])],
+    });
+    const projects = allProjects(tree);
+    expect(projects).toHaveLength(1);
+    expect(projects[0]!.kind).toBe('directory');
+  });
+
+  it('(b) same remote on two nodes = ONE project, TWO instances', () => {
+    const remote = 'github.com/donovan-yohan/relay-ide';
+    const tree = build({
+      reports: [
+        report(DEFAULT_LOCAL_NODE_ID, [
+          repoInstance({ localPath: '/local/relay', repoIdentity: remote }),
+        ]),
+        report('macbook', [
+          repoInstance({
+            nodeId: 'macbook',
+            localPath: '/remote/relay',
+            repoIdentity: remote,
+          }),
+        ]),
+      ],
+      nodes: [node({ nodeId: 'macbook', status: 'online' })],
+    });
+    const projects = allProjects(tree);
+    expect(projects).toHaveLength(1);
+    const project = projects[0]!;
+    expect(project.kind).toBe('repo');
+    expect(project.instances).toHaveLength(2);
+
+    const hosts = project.instances.map((i) => i.nodeId).sort();
+    expect(hosts).toEqual(['macbook', DEFAULT_LOCAL_NODE_ID].sort());
+
+    for (const instance of project.instances) {
+      expect(parseInstanceId(instance.id)?.projectId).toBe(project.id);
+    }
+
+    const local = project.instances.find((i) => i.isLocal)!;
+    const remoteInst = project.instances.find((i) => !i.isLocal)!;
+    expect(local.hostLabel).toBe('this host');
+    expect(remoteInst.hostLabel).toBe('MacBook');
+  });
+
+  it('(c) offline-node join surfaces an offline instance status', () => {
+    const remote = 'github.com/donovan-yohan/relay-ide';
+    const tree = build({
+      reports: [
+        report('macbook', [
+          repoInstance({ nodeId: 'macbook', localPath: '/remote/relay', repoIdentity: remote }),
+        ]),
+      ],
+      nodes: [node({ nodeId: 'macbook', status: 'offline' })],
+    });
+    const instance = allProjects(tree)[0]!.instances[0]!;
+    expect(instance.nodeId).toBe('macbook');
+    expect(instance.status).toBe('offline');
+  });
+
+  it('(c) stale-node join surfaces a stale instance status', () => {
+    const remote = 'github.com/donovan-yohan/relay-ide';
+    const tree = build({
+      reports: [
+        report('macbook', [
+          repoInstance({ nodeId: 'macbook', localPath: '/remote/relay', repoIdentity: remote }),
+        ]),
+      ],
+      nodes: [node({ nodeId: 'macbook', status: 'stale' })],
+    });
+    expect(allProjects(tree)[0]!.instances[0]!.status).toBe('stale');
+  });
+
+  it('(c) a remote node absent from the registry joins as offline', () => {
+    const remote = 'github.com/donovan-yohan/relay-ide';
+    const tree = build({
+      reports: [
+        report('ghost', [
+          repoInstance({ nodeId: 'ghost', localPath: '/remote/relay', repoIdentity: remote }),
+        ]),
+      ],
+      nodes: [],
+    });
+    expect(allProjects(tree)[0]!.instances[0]!.status).toBe('offline');
+  });
+
+  it('local host is online even when absent from the registry', () => {
+    const tree = build({
+      reports: [report(DEFAULT_LOCAL_NODE_ID, [repoInstance()])],
+      nodes: [],
+    });
+    expect(allProjects(tree)[0]!.instances[0]!.status).toBe('online');
+  });
+
+  it('two checkouts of the same remote on the SAME node = one project, two instances', () => {
+    const remote = 'github.com/acme/dup';
+    const tree = build({
+      reports: [
+        report(DEFAULT_LOCAL_NODE_ID, [
+          repoInstance({ localPath: '/a/dup', repoIdentity: remote }),
+          repoInstance({ localPath: '/b/dup', repoIdentity: remote }),
+        ]),
+      ],
+    });
+    const projects = allProjects(tree);
+    expect(projects).toHaveLength(1);
+    expect(projects[0]!.instances).toHaveLength(2);
+    expect(projects[0]!.instances.map((i) => i.localPath).sort()).toEqual([
+      '/a/dup',
+      '/b/dup',
+    ]);
+  });
+});
+
+// ── Identity-leak regression (mirror client C2) ───────────────────────────────
+
+describe('identity-leak regression', () => {
+  it('directory-project benches omit branch entirely and carry no repo anchor', () => {
+    const tree = build({
+      reports: [
+        report(DEFAULT_LOCAL_NODE_ID, [
+          repoInstance({
+            localPath: '/dirs/scratch',
+            name: 'scratch',
+            isGitRepo: false,
+            repoIdentity: null,
+            worktrees: [
+              worktree({ localPath: '/dirs/scratch/sub', branchName: 'leak' }),
+            ],
+          }),
+        ]),
+      ],
+    });
+    const bench = allProjects(tree)[0]!.instances[0]!.benches[0]!;
+    expect(bench.isGit).toBe(false);
+    expect(bench.branch).toBeNull();
+    expect(bench.repoPath).toBeNull();
+    // No leaked branch string anywhere on the directory bench.
+    expect(JSON.stringify(bench)).not.toContain('leak');
+  });
+
+  it('a directory project never carries a repo-kind identity', () => {
+    const tree = build({
+      reports: [
+        report(DEFAULT_LOCAL_NODE_ID, [
+          repoInstance({
+            localPath: '/dirs/x',
+            name: 'x',
+            isGitRepo: false,
+            repoIdentity: null,
+          }),
+        ]),
+      ],
+    });
+    const project = allProjects(tree)[0]!;
+    expect(project.identity.kind).toBe('directory');
+    expect(JSON.stringify(project.identity)).not.toContain('github.com');
+  });
+});
+
+// ── Benches + workspace grouping ──────────────────────────────────────────────
+
+describe('benches and grouping', () => {
+  it('maps worktrees to benches with branch + parent repoPath on git projects', () => {
+    const tree = build({
+      reports: [
+        report(DEFAULT_LOCAL_NODE_ID, [
+          repoInstance({ worktrees: [worktree()] }),
+        ]),
+      ],
+    });
+    const instance = allProjects(tree)[0]!.instances[0]!;
+    expect(instance.benches).toHaveLength(1);
+    const bench = instance.benches[0]!;
+    expect(bench.path).toBe('/repos/relay/.worktrees/feat-x');
+    expect(bench.isGit).toBe(true);
+    expect(bench.branch).toBe('feature/x');
+    expect(bench.repoPath).toBe('/repos/relay');
+    expect(bench.label).toBe('feat-x');
+  });
+
+  it('places workspace-group repos under their group and leaves others ungrouped', () => {
+    const tree = build({
+      reports: [
+        report(DEFAULT_LOCAL_NODE_ID, [
+          repoInstance({
+            localPath: '/repos/grouped',
+            name: 'grouped',
+            repoIdentity: 'github.com/acme/grouped',
+          }),
+          repoInstance({
+            localPath: '/repos/loose',
+            name: 'loose',
+            repoIdentity: 'github.com/acme/loose',
+          }),
+        ]),
+      ],
+      workspaceGroups: [
+        { id: 'ws-1', name: 'My Workspace', order: 0, repos: ['/repos/grouped'] },
+      ],
+    });
+    expect(tree.workspaces).toHaveLength(1);
+    expect(tree.workspaces[0]!.projects.map((p) => p.label)).toEqual(['grouped']);
+    expect(tree.ungroupedProjects.map((p) => p.label)).toEqual(['loose']);
+  });
+
+  it('tolerates a workspace group whose `repos` field is missing/non-array', () => {
+    const malformed = { id: 'ws-legacy', name: 'Legacy', order: 0 } as {
+      id: string;
+      name: string;
+      order: number;
+      repos?: string[];
+    };
+    const tree = build({
+      reports: [
+        report(DEFAULT_LOCAL_NODE_ID, [
+          repoInstance({
+            localPath: '/repos/grouped',
+            name: 'grouped',
+            repoIdentity: 'github.com/acme/grouped',
+          }),
+        ]),
+      ],
+      workspaceGroups: [malformed],
+    });
+    expect(tree.workspaces).toHaveLength(1);
+    expect(tree.workspaces[0]!.projects).toEqual([]);
+    expect(tree.ungroupedProjects.map((p) => p.label)).toEqual(['grouped']);
+  });
+
+  it('rolls up the most-recent worktree activity onto instance + project', () => {
+    const tree = build({
+      reports: [
+        report(DEFAULT_LOCAL_NODE_ID, [
+          repoInstance({
+            worktrees: [
+              worktree({ localPath: '/repos/relay/.worktrees/old', lastActivity: '2026-05-20T00:00:00.000Z' }),
+              worktree({ localPath: '/repos/relay/.worktrees/new', lastActivity: '2026-05-27T00:00:00.000Z' }),
+            ],
+          }),
+        ]),
+      ],
+    });
+    const project = allProjects(tree)[0]!;
+    expect(project.lastActivity).toBe('2026-05-27T00:00:00.000Z');
+    expect(project.instances[0]!.lastActivity).toBe('2026-05-27T00:00:00.000Z');
+  });
+});
+
+describe('determinism + empty', () => {
+  it('returns the supplied generatedAt and empty lanes for no reports', () => {
+    const tree = build({ generatedAt: '2026-01-01T00:00:00.000Z' });
+    expect(tree.generatedAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(tree.workspaces).toEqual([]);
+    expect(tree.ungroupedProjects).toEqual([]);
+  });
+
+  it('sorts ungrouped projects alphabetically by label', () => {
+    const tree = build({
+      reports: [
+        report(DEFAULT_LOCAL_NODE_ID, [
+          repoInstance({ localPath: '/repos/bbb', name: 'bbb', repoIdentity: 'github.com/acme/bbb' }),
+          repoInstance({ localPath: '/repos/aaa', name: 'aaa', repoIdentity: 'github.com/acme/aaa' }),
+        ]),
+      ],
+    });
+    expect(tree.ungroupedProjects.map((p) => p.label)).toEqual(['aaa', 'bbb']);
+  });
+});


### PR DESCRIPTION
## What it serves

`GET /hub/ia/tree` — a server-side, **read-only** derive of the six-layer IA read model: **Project (with `ProjectIdentity`) → Instance → Bench**, with optional **Workspace** grouping. It mirrors, server-side, the structural part of the client derive in `frontend/src/lib/state/view-tree.ts` so the frontend can LATER switch from its client-derive to this server source-of-truth.

Built on the SAME authoritative cross-node data that `GET /hub/repo-inventory` already aggregates — per-node `RepoInventoryReport` (= `config.repos` + worktree scan) from the hub node registry stored payloads + the local node's `collectLocalRepoInventory()` — joined with hub node status from `registry.listNodes()`.

## Derive mapping

| Source (authoritative) | IA layer |
| --- | --- |
| git repo + non-blank `repoIdentity` | **Project** `repo`-kind, keyed on the REMOTE via `createProjectId`. Same remote across N nodes (or N checkouts on one node) = **ONE** Project. |
| non-git OR null/blank `repoIdentity` | **Project** `directory`-kind, keyed on node + localPath via `createDirectoryProjectId`. Never carries a remote. |
| `(Project, report.nodeId, localPath)` | **Instance** (`createInstanceId`). `this host` for local, node `displayName` for remote. `online`/`stale`/`offline` joined from node status. |
| `RepoInventoryWorktreeInstance` | **Bench** (`createBenchId`). `branch` + parent `repoPath` only on git instances; withheld (`null`) on directory benches — no identity/branch leak. |
| `config.workspaces[].repos` | **Workspace** grouping (optional; tolerates missing/non-array `repos`). |

All IDs come from the `shared/` helpers — single source of truth, no re-implemented id encoding.

**Tab counts are intentionally out of scope:** a `RepoInventoryReport` carries no session data, and cross-node session aggregation is a separate read model (`server/hub-session-aggregator.ts`). The tree exposes the durable repo/worktree structure the frontend can join its own sessions onto.

## Endpoint shape

```jsonc
// GET /hub/ia/tree
{
  "workspaces": [
    { "id": "ws:ws-relay", "name": "Relay WS", "order": 0,
      "projects": [ /* IaProject[] */ ] }
  ],
  "ungroupedProjects": [
    { "id": "proj:repo:github.com%2Fowner%2Frepo",
      "identity": { "kind": "repo", "remote": "github.com/owner/repo" },
      "kind": "repo", "label": "relay-ide", "lastActivity": "… |null",
      "instances": [
        { "id": "inst:…", "nodeId": "local", "hostLabel": "this host",
          "isLocal": true, "status": "online",
          "localPath": "/…/relay-ide", "lastActivity": "…|null",
          "benches": [
            { "id": "bench:…", "path": "/…/.worktrees/x", "repoPath": "/…/relay-ide",
              "label": "x", "isGit": true, "branch": "feature/x", "lastActivity": "…|null" }
          ] } ] }
  ],
  "generatedAt": "2026-05-27T10:20:41.375Z"
}
```

## Where it lives (feature layer)

- `server/features/ia-tree.ts` — pure `buildIaTree(...)` derive (no I/O, no clock reads; route supplies reports + node statuses + clock).
- `GET /hub/ia/tree` added to `server/features/repo-router.ts` (`createRepoFeatureRouter`) — the existing repo/IA feature router, NOT the opaque core (ADR-015/016). Behind `requireAuth`, same as its `/hub/repo-inventory` sibling.
- `server/index.ts` injects `listWorkspaceGroups` (a read-only projection of `config.workspaces`) so the router stays config-agnostic.

## Non-destructive guarantee

Pure read/derive over existing state. **No persistence, no DB writes, no migration, no new tables.** No change to any existing route's behavior — only a new GET endpoint and a new pure module + tests.

## Tests + curl evidence

- `test/ia-tree.test.ts` (16 cases) mirrors the client `test/view-tree.test.ts` matrix: dedup across nodes + same-node, null/blank `repoIdentity` → directory fallback, offline/stale/absent-node join, local-implicitly-online, identity-leak guard on directory benches, workspace grouping + malformed-`repos` guard, recency rollup, deterministic ordering.
- Gates (Node 24): `npm run build` PASS, `npm run check` PASS (0 errors), targeted `vitest run` PASS (ia-tree 16 + repo-inventory feature/unit + view-tree = 57 passing, no regression).
- Real API smoke: started the hub on port 3461 with an isolated config (one configured repo + one workspace group), `curl http://127.0.0.1:3461/hub/ia/tree` returned a sane tree — one `repo`-kind Project keyed on the remote, one local `online` Instance, 11 worktrees → git Benches (branch + parent repoPath), and the project correctly grouped under its Workspace (`ungroupedProjects` empty). Sibling `/hub/repo-inventory` derived the same project/instance from the same reports. Server stopped + temp cleaned after.

## Risks

- **Cross-node aggregation correctness**: relies entirely on per-node reports already stored by the registry heartbeat + the local collect — same source as the verified `/hub/repo-inventory`, so dedup/grouping is consistent with existing behavior. Only smoke-tested with a single local node (no live remote node available in this env); offline/stale/absent joins are covered by unit tests, not a live remote.
- **Offline degradation**: a remote node absent from the registry joins as `offline`; local is implicitly `online`. The builder never throws on missing status.
- **`lastActivity`**: rolled up from worktree `lastActivity`; can be empty-string from the scanner (treated as "no activity known" by the `maxActivity` helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)