### PR TITLE
feat(#737): IA persistence schema + store (foundation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ analytics.db-wal
 relay-state.db
 relay-state.db-shm
 relay-state.db-wal
+ia.db
+ia.db-shm
+ia.db-wal
 
 # Runtime port allocator state
 port-assignments.json

--- a/server/ia-store.ts
+++ b/server/ia-store.ts
@@ -385,13 +385,24 @@ function normalizeEnvOverrides(
 }
 
 function parseStringArray(json: string): string[] {
-  const parsed = JSON.parse(json) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json) as unknown;
+  } catch {
+    // Corrupt column (only reachable via external DB tampering) — fail soft.
+    return [];
+  }
   if (!Array.isArray(parsed)) return [];
   return parsed.filter((v): v is string => typeof v === 'string');
 }
 
 function parseStringRecord(json: string): Record<string, string> {
-  const parsed = JSON.parse(json) as unknown;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json) as unknown;
+  } catch {
+    return {};
+  }
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
     return {};
   }

--- a/server/ia-store.ts
+++ b/server/ia-store.ts
@@ -1,0 +1,403 @@
+// IA persistence substrate (#737 / BE-5). Stores the genuinely user-authored,
+// non-derivable six-layer IA state: Workspace grouping (id/name/order/
+// projectIds membership) and Bench overlays (envOverrides + label override +
+// non-worktree benches). Project/Instance and git-worktree Bench facts are
+// DERIVED from the cross-node inventory by `GET /hub/ia/tree` and are NOT
+// persisted here.
+//
+// STRICTLY NON-DESTRUCTIVE: this module owns its own SQLite file (`ia.db`) and
+// creates only new tables. It never reads or mutates `config.json`,
+// `config.repos`, `config.workspaces`, or any existing DB/table. Migration of
+// legacy state into these tables is out of scope (#736), explicitly gated.
+//
+// Mirrors the self-contained store pattern of `server/work-contexts.ts`:
+// per-store DB file, a `schema_version` table, a version-gated migration run
+// inside a transaction, and an `init*(configDir)` / `create*(dbPath)` factory
+// split so the store is trivially unit-testable.
+
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import { createLogger } from './logger.js';
+import type { Workspace, WorkspaceId } from '../shared/workspace.js';
+import { parseWorkspaceId } from '../shared/workspace.js';
+import type { BenchId } from '../shared/bench.js';
+import { parseBenchId } from '../shared/bench.js';
+import type { InstanceId } from '../shared/project.js';
+
+const logger = createLogger('ia-store');
+
+const SCHEMA_V1 = `
+CREATE TABLE IF NOT EXISTS ia_workspaces (
+  id           TEXT PRIMARY KEY,
+  name         TEXT NOT NULL,
+  sort_order   REAL NOT NULL,
+  project_ids_json TEXT NOT NULL,
+  created_at   TEXT NOT NULL,
+  updated_at   TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_ia_workspaces_order
+  ON ia_workspaces(sort_order ASC);
+
+CREATE TABLE IF NOT EXISTS ia_bench_overlays (
+  id              TEXT PRIMARY KEY,
+  instance_id     TEXT NOT NULL,
+  cwd             TEXT NOT NULL,
+  label           TEXT,
+  env_overrides_json TEXT NOT NULL,
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_ia_bench_overlays_instance
+  ON ia_bench_overlays(instance_id);
+`;
+
+const MIGRATIONS: Array<{ version: number; sql: string }> = [
+  { version: 1, sql: SCHEMA_V1 },
+];
+
+interface WorkspaceRow {
+  id: string;
+  name: string;
+  sort_order: number;
+  project_ids_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface BenchOverlayRow {
+  id: string;
+  instance_id: string;
+  cwd: string;
+  label: string | null;
+  env_overrides_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Input for upserting a Workspace. `id` must be a `shared/workspace` encoded
+ *  WorkspaceId (`ws:...`). Timestamps are managed by the store. */
+export interface WorkspaceUpsertInput {
+  id: WorkspaceId;
+  name: string;
+  order: number;
+  projectIds: string[];
+}
+
+/** Persisted Bench overlay: the sparse, user-authored layer on top of the
+ *  DERIVED bench. `envOverrides` is the primary reason this exists; `label` is
+ *  an optional display override (null = fall back to the derived label). */
+export interface BenchOverlayUpsertInput {
+  id: BenchId;
+  envOverrides: Record<string, string>;
+  /** Optional label override. `undefined`/`null` means "use derived label". */
+  label?: string | null;
+}
+
+/** Persisted Bench overlay row, shaped for consumers. */
+export interface BenchOverlay {
+  id: BenchId;
+  instanceId: InstanceId;
+  cwd: string;
+  label: string | null;
+  envOverrides: Record<string, string>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IaStore {
+  close(): void;
+
+  // ── Workspace ────────────────────────────────────────────────────────────
+  /** All workspaces, ordered by `order` ascending then id for stability. */
+  listWorkspaces(): Workspace[];
+  getWorkspace(id: WorkspaceId): Workspace | null;
+  /** Insert or update a workspace. Preserves `createdAt` on update. */
+  upsertWorkspace(input: WorkspaceUpsertInput): Workspace;
+  deleteWorkspace(id: WorkspaceId): boolean;
+
+  // ── Bench overlay ──────────────────────────────────────────────────────
+  /** All bench overlays. */
+  listBenchOverlays(): BenchOverlay[];
+  getBenchOverlay(id: BenchId): BenchOverlay | null;
+  /** Insert or update a bench overlay. Preserves `createdAt` on update. */
+  upsertBenchOverlay(input: BenchOverlayUpsertInput): BenchOverlay;
+  deleteBenchOverlay(id: BenchId): boolean;
+}
+
+export class IaStoreError extends Error {
+  readonly code: string;
+  constructor(code: string, message = code) {
+    super(message);
+    this.name = 'IaStoreError';
+    this.code = code;
+  }
+}
+
+/** Boot entry point: opens (and migrates) the IA store DB under `configDir`. */
+export function initIaStore(configDir: string): IaStore {
+  return createIaStore(path.join(configDir, 'ia.db'));
+}
+
+/** Factory taking an explicit DB path. Used directly by unit tests. */
+export function createIaStore(dbPath: string): IaStore {
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+
+  runMigrations(db);
+
+  const selectWorkspace = db.prepare(
+    `SELECT id, name, sort_order, project_ids_json, created_at, updated_at
+     FROM ia_workspaces WHERE id = ?`
+  );
+  const selectAllWorkspaces = db.prepare(
+    `SELECT id, name, sort_order, project_ids_json, created_at, updated_at
+     FROM ia_workspaces ORDER BY sort_order ASC, id ASC`
+  );
+  const upsertWorkspaceStmt = db.prepare(
+    `INSERT INTO ia_workspaces (
+       id, name, sort_order, project_ids_json, created_at, updated_at
+     ) VALUES (@id, @name, @order, @projectIdsJson, @createdAt, @updatedAt)
+     ON CONFLICT(id) DO UPDATE SET
+       name             = excluded.name,
+       sort_order       = excluded.sort_order,
+       project_ids_json = excluded.project_ids_json,
+       updated_at       = excluded.updated_at`
+  );
+  const deleteWorkspaceStmt = db.prepare(
+    'DELETE FROM ia_workspaces WHERE id = ?'
+  );
+
+  const selectBenchOverlay = db.prepare(
+    `SELECT id, instance_id, cwd, label, env_overrides_json, created_at, updated_at
+     FROM ia_bench_overlays WHERE id = ?`
+  );
+  const selectAllBenchOverlays = db.prepare(
+    `SELECT id, instance_id, cwd, label, env_overrides_json, created_at, updated_at
+     FROM ia_bench_overlays ORDER BY id ASC`
+  );
+  const upsertBenchOverlayStmt = db.prepare(
+    `INSERT INTO ia_bench_overlays (
+       id, instance_id, cwd, label, env_overrides_json, created_at, updated_at
+     ) VALUES (
+       @id, @instanceId, @cwd, @label, @envOverridesJson, @createdAt, @updatedAt
+     )
+     ON CONFLICT(id) DO UPDATE SET
+       label              = excluded.label,
+       env_overrides_json = excluded.env_overrides_json,
+       updated_at         = excluded.updated_at`
+  );
+  const deleteBenchOverlayStmt = db.prepare(
+    'DELETE FROM ia_bench_overlays WHERE id = ?'
+  );
+
+  function getWorkspaceById(id: WorkspaceId): Workspace | null {
+    const row = selectWorkspace.get(id) as WorkspaceRow | undefined;
+    return row ? rowToWorkspace(row) : null;
+  }
+
+  function getBenchOverlayById(id: BenchId): BenchOverlay | null {
+    const row = selectBenchOverlay.get(id) as BenchOverlayRow | undefined;
+    return row ? rowToBenchOverlay(row) : null;
+  }
+
+  return {
+    close() {
+      db.close();
+    },
+
+    listWorkspaces() {
+      return (selectAllWorkspaces.all() as WorkspaceRow[])
+        .map(rowToWorkspaceSafe)
+        .filter((ws): ws is Workspace => ws !== null);
+    },
+
+    getWorkspace: getWorkspaceById,
+
+    upsertWorkspace(input: WorkspaceUpsertInput) {
+      if (!parseWorkspaceId(input.id)) {
+        throw new IaStoreError('invalid_workspace_id');
+      }
+      if (typeof input.name !== 'string' || input.name.trim().length === 0) {
+        throw new IaStoreError('workspace_name_required');
+      }
+      if (!Number.isFinite(input.order)) {
+        throw new IaStoreError('workspace_order_invalid');
+      }
+      const projectIds = normalizeProjectIds(input.projectIds);
+      const now = new Date().toISOString();
+      const existing = getWorkspaceById(input.id);
+      const createdAt = existing?.createdAt ?? now;
+      upsertWorkspaceStmt.run({
+        id: input.id,
+        name: input.name,
+        order: input.order,
+        projectIdsJson: JSON.stringify(projectIds),
+        createdAt,
+        updatedAt: now,
+      });
+      const written = getWorkspaceById(input.id);
+      if (!written) throw new IaStoreError('workspace_write_failed');
+      return written;
+    },
+
+    deleteWorkspace(id: WorkspaceId) {
+      const info = deleteWorkspaceStmt.run(id);
+      return info.changes > 0;
+    },
+
+    listBenchOverlays() {
+      return (selectAllBenchOverlays.all() as BenchOverlayRow[])
+        .map(rowToBenchOverlaySafe)
+        .filter((overlay): overlay is BenchOverlay => overlay !== null);
+    },
+
+    getBenchOverlay: getBenchOverlayById,
+
+    upsertBenchOverlay(input: BenchOverlayUpsertInput) {
+      const parsed = parseBenchId(input.id);
+      if (!parsed) {
+        throw new IaStoreError('invalid_bench_id');
+      }
+      const envOverrides = normalizeEnvOverrides(input.envOverrides);
+      const label =
+        input.label === undefined || input.label === null
+          ? null
+          : String(input.label);
+      const now = new Date().toISOString();
+      const existing = getBenchOverlayById(input.id);
+      const createdAt = existing?.createdAt ?? now;
+      upsertBenchOverlayStmt.run({
+        id: input.id,
+        instanceId: parsed.instanceId,
+        cwd: parsed.cwd,
+        label,
+        envOverridesJson: JSON.stringify(envOverrides),
+        createdAt,
+        updatedAt: now,
+      });
+      const written = getBenchOverlayById(input.id);
+      if (!written) throw new IaStoreError('bench_overlay_write_failed');
+      return written;
+    },
+
+    deleteBenchOverlay(id: BenchId) {
+      const info = deleteBenchOverlayStmt.run(id);
+      return info.changes > 0;
+    },
+  };
+}
+
+// ── Migration runner ─────────────────────────────────────────────────────
+// Idempotent: a fresh DB and an already-migrated DB both end at the latest
+// MIGRATIONS version with no error. Safe on an existing DB that has no IA
+// tables (CREATE ... IF NOT EXISTS + version gate). Bump by appending a new
+// {version, sql} entry to MIGRATIONS. Mirrors the runner in work-contexts.ts.
+function runMigrations(db: Database.Database): void {
+  db.exec('CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)');
+  const row = db.prepare('SELECT version FROM schema_version').get() as
+    | { version: number }
+    | undefined;
+  const hadRow = row !== undefined;
+  let currentVersion = row?.version ?? 0;
+
+  for (const migration of MIGRATIONS) {
+    if (migration.version > currentVersion) {
+      const ver = migration.version;
+      db.transaction(() => {
+        db.exec(migration.sql);
+        if (hadRow || currentVersion > 0) {
+          db.prepare('UPDATE schema_version SET version = ?').run(ver);
+        } else {
+          db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(ver);
+        }
+      })();
+      currentVersion = ver;
+    }
+  }
+}
+
+// ── Row mapping ────────────────────────────────────────────────────────────
+
+function rowToWorkspace(row: WorkspaceRow): Workspace {
+  return {
+    id: row.id,
+    name: row.name,
+    order: row.sort_order,
+    projectIds: parseStringArray(row.project_ids_json),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToWorkspaceSafe(row: WorkspaceRow): Workspace | null {
+  try {
+    return rowToWorkspace(row);
+  } catch (err) {
+    logger.warn('failed to map workspace row %s: %s', row.id, err);
+    return null;
+  }
+}
+
+function rowToBenchOverlay(row: BenchOverlayRow): BenchOverlay {
+  return {
+    id: row.id,
+    instanceId: row.instance_id,
+    cwd: row.cwd,
+    label: row.label,
+    envOverrides: parseStringRecord(row.env_overrides_json),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToBenchOverlaySafe(row: BenchOverlayRow): BenchOverlay | null {
+  try {
+    return rowToBenchOverlay(row);
+  } catch (err) {
+    logger.warn('failed to map bench overlay row %s: %s', row.id, err);
+    return null;
+  }
+}
+
+// ── Input normalization ────────────────────────────────────────────────────
+
+function normalizeProjectIds(value: string[] | undefined): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (id): id is string => typeof id === 'string' && id.length > 0
+  );
+}
+
+function normalizeEnvOverrides(
+  value: Record<string, string> | undefined
+): Record<string, string> {
+  if (!value || typeof value !== 'object') return {};
+  const out: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof key !== 'string' || key.length === 0) continue;
+    if (typeof raw !== 'string') continue;
+    out[key] = raw;
+  }
+  return out;
+}
+
+function parseStringArray(json: string): string[] {
+  const parsed = JSON.parse(json) as unknown;
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter((v): v is string => typeof v === 'string');
+}
+
+function parseStringRecord(json: string): Record<string, string> {
+  const parsed = JSON.parse(json) as unknown;
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {};
+  }
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value === 'string') out[key] = value;
+  }
+  return out;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -72,6 +72,7 @@ import {
   initWorkContextStore,
   type WorkContextStore,
 } from './work-contexts.js';
+import { initIaStore, type IaStore } from './ia-store.js';
 import {
   initInterventionLog,
   closeInterventionLog,
@@ -1444,6 +1445,20 @@ async function main(): Promise<void> {
   }
 
   const workContextStore = initWorkContextStore(configDir);
+
+  // IA persistence substrate (#737): Workspace grouping + Bench overlays. Own
+  // SQLite file; new tables only, non-destructive. Routes that consume it
+  // (#733/#735) land in follow-ups. Guarded so a DB error degrades to "no IA
+  // persistence" rather than failing boot.
+  let iaStore: IaStore | null = null;
+  try {
+    iaStore = initIaStore(configDir);
+  } catch (err) {
+    logger.warn(
+      'IA store disabled: failed to initialize:',
+      err instanceof Error ? err.message : err
+    );
+  }
 
   try {
     initInterventionLog(configDir);
@@ -3728,6 +3743,7 @@ async function main(): Promise<void> {
         flushRelayStateWrites();
         closeRelayStateDb();
         workContextStore.close();
+        iaStore?.close();
         closeInterventionLog();
         broadcastEvent('server-restarting');
       }
@@ -3808,6 +3824,7 @@ async function main(): Promise<void> {
     flushRelayStateWrites();
     closeRelayStateDb();
     workContextStore.close();
+    iaStore?.close();
     closeInterventionLog();
     for (const s of localRelayNode.sessions.list()) {
       try {

--- a/test/ia-store.test.ts
+++ b/test/ia-store.test.ts
@@ -302,6 +302,32 @@ describe('ia-store: durability + migration', () => {
     expect(s2.getBenchOverlay(benchId)!.envOverrides).toEqual({ K: 'v' });
   });
 
+  it('fails soft on corrupt JSON columns instead of throwing (external tampering)', () => {
+    const dbPath = path.join(makeDir(), 'ia.db');
+    const wsId = createWorkspaceId('corrupt');
+    const benchId = createBenchId(INSTANCE_ID, '/work/widget/corrupt');
+
+    const s1 = createIaStore(dbPath);
+    s1.upsertWorkspace({ id: wsId, name: 'Corrupt', order: 1, projectIds: ['proj:repo:x'] });
+    s1.upsertBenchOverlay({ id: benchId, envOverrides: { K: 'v' } });
+    s1.close();
+
+    // Simulate out-of-band corruption of the JSON payload columns.
+    const raw = new Database(dbPath);
+    raw.prepare('UPDATE ia_workspaces SET project_ids_json = ? WHERE id = ?').run('{not json', wsId);
+    raw.prepare('UPDATE ia_bench_overlays SET env_overrides_json = ? WHERE id = ?').run('{not json', benchId);
+    raw.close();
+
+    const s2 = createIaStore(dbPath);
+    openStores.push(s2);
+    // Single-row getters must not throw; they degrade to empty collections.
+    expect(s2.getWorkspace(wsId)!.projectIds).toEqual([]);
+    expect(s2.getBenchOverlay(benchId)!.envOverrides).toEqual({});
+    // List paths stay safe too.
+    expect(() => s2.listWorkspaces()).not.toThrow();
+    expect(() => s2.listBenchOverlays()).not.toThrow();
+  });
+
   it('migration is idempotent: re-running createIaStore on existing DB is a no-op', () => {
     const dbPath = path.join(makeDir(), 'ia.db');
     const a = createIaStore(dbPath);

--- a/test/ia-store.test.ts
+++ b/test/ia-store.test.ts
@@ -1,0 +1,400 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createIaStore,
+  IaStoreError,
+  type IaStore,
+} from '../server/ia-store.js';
+import { createWorkspaceId, parseWorkspaceId } from '../shared/workspace.js';
+import { createBenchId, parseBenchId } from '../shared/bench.js';
+import { createInstanceId, createProjectId } from '../shared/project.js';
+
+vi.mock('../server/logger.js', () => ({
+  createLogger: () => ({
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const tmpDirs: string[] = [];
+const openStores: IaStore[] = [];
+
+function makeDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-ia-store-test-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function makeStore(): { store: IaStore; dbPath: string } {
+  const dbPath = path.join(makeDir(), 'ia.db');
+  const store = createIaStore(dbPath);
+  openStores.push(store);
+  return { store, dbPath };
+}
+
+afterEach(() => {
+  while (openStores.length) {
+    try {
+      openStores.pop()!.close();
+    } catch {
+      /* already closed */
+    }
+  }
+  while (tmpDirs.length) {
+    fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+// A realistic instance id for bench overlay tests.
+const INSTANCE_ID = createInstanceId(
+  createProjectId({ kind: 'repo', remote: 'github.com/acme/widget' }),
+  'local'
+);
+
+describe('ia-store: workspace', () => {
+  it('round-trips a workspace: insert -> read', () => {
+    const { store } = makeStore();
+    const id = createWorkspaceId('design-team');
+    const ws = store.upsertWorkspace({
+      id,
+      name: 'Design',
+      order: 1,
+      projectIds: ['proj:repo:a', 'proj:repo:b'],
+    });
+
+    expect(ws.id).toBe(id);
+    expect(ws.name).toBe('Design');
+    expect(ws.order).toBe(1);
+    expect(ws.projectIds).toEqual(['proj:repo:a', 'proj:repo:b']);
+    expect(ws.createdAt).toBeTruthy();
+    expect(ws.updatedAt).toBeTruthy();
+
+    const read = store.getWorkspace(id);
+    expect(read).not.toBeNull();
+    expect(read!.name).toBe('Design');
+    expect(read!.projectIds).toEqual(['proj:repo:a', 'proj:repo:b']);
+
+    // id round-trips through shared parser.
+    expect(parseWorkspaceId(read!.id)).toEqual({ localId: 'design-team' });
+  });
+
+  it('upsert updates in place and preserves createdAt', () => {
+    const { store } = makeStore();
+    const id = createWorkspaceId('eng');
+    const first = store.upsertWorkspace({
+      id,
+      name: 'Engineering',
+      order: 2,
+      projectIds: ['proj:repo:a'],
+    });
+
+    const updated = store.upsertWorkspace({
+      id,
+      name: 'Engineering (renamed)',
+      order: 5,
+      projectIds: ['proj:repo:a', 'proj:repo:c'],
+    });
+
+    expect(updated.name).toBe('Engineering (renamed)');
+    expect(updated.order).toBe(5);
+    expect(updated.projectIds).toEqual(['proj:repo:a', 'proj:repo:c']);
+    expect(updated.createdAt).toBe(first.createdAt);
+
+    expect(store.listWorkspaces()).toHaveLength(1);
+  });
+
+  it('lists workspaces ordered by order ascending', () => {
+    const { store } = makeStore();
+    store.upsertWorkspace({
+      id: createWorkspaceId('c'),
+      name: 'C',
+      order: 3,
+      projectIds: [],
+    });
+    store.upsertWorkspace({
+      id: createWorkspaceId('a'),
+      name: 'A',
+      order: 1,
+      projectIds: [],
+    });
+    store.upsertWorkspace({
+      id: createWorkspaceId('b'),
+      name: 'B',
+      order: 2,
+      projectIds: [],
+    });
+
+    expect(store.listWorkspaces().map((w) => w.name)).toEqual(['A', 'B', 'C']);
+  });
+
+  it('deletes a workspace', () => {
+    const { store } = makeStore();
+    const id = createWorkspaceId('temp');
+    store.upsertWorkspace({ id, name: 'Temp', order: 0, projectIds: [] });
+    expect(store.getWorkspace(id)).not.toBeNull();
+
+    expect(store.deleteWorkspace(id)).toBe(true);
+    expect(store.getWorkspace(id)).toBeNull();
+    expect(store.deleteWorkspace(id)).toBe(false);
+  });
+
+  it('rejects invalid workspace id', () => {
+    const { store } = makeStore();
+    expect(() =>
+      store.upsertWorkspace({
+        id: 'not-a-workspace-id',
+        name: 'x',
+        order: 0,
+        projectIds: [],
+      })
+    ).toThrow(IaStoreError);
+  });
+
+  it('rejects blank name and non-finite order', () => {
+    const { store } = makeStore();
+    const id = createWorkspaceId('x');
+    expect(() =>
+      store.upsertWorkspace({ id, name: '  ', order: 0, projectIds: [] })
+    ).toThrow(/workspace_name_required/);
+    expect(() =>
+      store.upsertWorkspace({
+        id,
+        name: 'ok',
+        order: Number.NaN,
+        projectIds: [],
+      })
+    ).toThrow(/workspace_order_invalid/);
+  });
+
+  it('preserves float order for reorder-without-renumber', () => {
+    const { store } = makeStore();
+    const id = createWorkspaceId('frac');
+    const ws = store.upsertWorkspace({
+      id,
+      name: 'Frac',
+      order: 1.5,
+      projectIds: [],
+    });
+    expect(ws.order).toBe(1.5);
+    expect(store.getWorkspace(id)!.order).toBe(1.5);
+  });
+});
+
+describe('ia-store: bench overlay', () => {
+  it('round-trips a bench overlay: insert -> read', () => {
+    const { store } = makeStore();
+    const id = createBenchId(INSTANCE_ID, '/work/widget/feature-x');
+    const overlay = store.upsertBenchOverlay({
+      id,
+      envOverrides: { NODE_ENV: 'test', PORT: '4000' },
+      label: 'Feature X',
+    });
+
+    expect(overlay.id).toBe(id);
+    expect(overlay.instanceId).toBe(INSTANCE_ID);
+    expect(overlay.cwd).toBe('/work/widget/feature-x');
+    expect(overlay.label).toBe('Feature X');
+    expect(overlay.envOverrides).toEqual({ NODE_ENV: 'test', PORT: '4000' });
+
+    const read = store.getBenchOverlay(id);
+    expect(read).not.toBeNull();
+    expect(read!.envOverrides).toEqual({ NODE_ENV: 'test', PORT: '4000' });
+
+    // BenchId round-trips: instanceId + cwd recovered via shared parser.
+    expect(parseBenchId(read!.id)).toEqual({
+      instanceId: INSTANCE_ID,
+      cwd: '/work/widget/feature-x',
+    });
+  });
+
+  it('label defaults to null when omitted (use derived label)', () => {
+    const { store } = makeStore();
+    const id = createBenchId(INSTANCE_ID, '/work/widget/main');
+    const overlay = store.upsertBenchOverlay({
+      id,
+      envOverrides: {},
+    });
+    expect(overlay.label).toBeNull();
+    expect(overlay.envOverrides).toEqual({});
+  });
+
+  it('upsert updates env overrides + label, preserves createdAt', () => {
+    const { store } = makeStore();
+    const id = createBenchId(INSTANCE_ID, '/work/widget/dev');
+    const first = store.upsertBenchOverlay({
+      id,
+      envOverrides: { A: '1' },
+      label: 'dev',
+    });
+    const updated = store.upsertBenchOverlay({
+      id,
+      envOverrides: { A: '2', B: '3' },
+      label: null,
+    });
+
+    expect(updated.envOverrides).toEqual({ A: '2', B: '3' });
+    expect(updated.label).toBeNull();
+    expect(updated.createdAt).toBe(first.createdAt);
+    expect(store.listBenchOverlays()).toHaveLength(1);
+  });
+
+  it('strips non-string env values on write', () => {
+    const { store } = makeStore();
+    const id = createBenchId(INSTANCE_ID, '/work/widget/dirty');
+    const overlay = store.upsertBenchOverlay({
+      id,
+      envOverrides: {
+        GOOD: 'yes',
+        // intentionally invalid values that must be dropped
+        BAD: 5 as unknown as string,
+        ALSO_BAD: null as unknown as string,
+      },
+    });
+    expect(overlay.envOverrides).toEqual({ GOOD: 'yes' });
+  });
+
+  it('deletes a bench overlay', () => {
+    const { store } = makeStore();
+    const id = createBenchId(INSTANCE_ID, '/work/widget/gone');
+    store.upsertBenchOverlay({ id, envOverrides: { X: '1' } });
+    expect(store.getBenchOverlay(id)).not.toBeNull();
+
+    expect(store.deleteBenchOverlay(id)).toBe(true);
+    expect(store.getBenchOverlay(id)).toBeNull();
+    expect(store.deleteBenchOverlay(id)).toBe(false);
+  });
+
+  it('rejects invalid bench id', () => {
+    const { store } = makeStore();
+    expect(() =>
+      store.upsertBenchOverlay({ id: 'nope', envOverrides: {} })
+    ).toThrow(IaStoreError);
+  });
+});
+
+describe('ia-store: durability + migration', () => {
+  it('persists across re-open of the same DB file', () => {
+    const dbPath = path.join(makeDir(), 'ia.db');
+    const wsId = createWorkspaceId('persist');
+    const benchId = createBenchId(INSTANCE_ID, '/work/widget/persist');
+
+    const s1 = createIaStore(dbPath);
+    s1.upsertWorkspace({
+      id: wsId,
+      name: 'Persist',
+      order: 1,
+      projectIds: ['proj:repo:p'],
+    });
+    s1.upsertBenchOverlay({ id: benchId, envOverrides: { K: 'v' } });
+    s1.close();
+
+    const s2 = createIaStore(dbPath);
+    openStores.push(s2);
+    expect(s2.getWorkspace(wsId)!.projectIds).toEqual(['proj:repo:p']);
+    expect(s2.getBenchOverlay(benchId)!.envOverrides).toEqual({ K: 'v' });
+  });
+
+  it('migration is idempotent: re-running createIaStore on existing DB is a no-op', () => {
+    const dbPath = path.join(makeDir(), 'ia.db');
+    const a = createIaStore(dbPath);
+    a.upsertWorkspace({
+      id: createWorkspaceId('keep'),
+      name: 'Keep',
+      order: 1,
+      projectIds: [],
+    });
+    a.close();
+
+    // Re-open twice more — must not error and must not lose data.
+    const b = createIaStore(dbPath);
+    b.close();
+    const c = createIaStore(dbPath);
+    openStores.push(c);
+    expect(c.listWorkspaces()).toHaveLength(1);
+
+    // schema_version pinned at 1.
+    const db = new Database(dbPath);
+    try {
+      const row = db.prepare('SELECT version FROM schema_version').get() as {
+        version: number;
+      };
+      expect(row.version).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('creates the expected IA tables on a fresh DB', () => {
+    const { store, dbPath } = makeStore();
+    store.close();
+    openStores.pop(); // already closed
+
+    const db = new Database(dbPath);
+    try {
+      const tables = (
+        db
+          .prepare(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+          )
+          .all() as Array<{ name: string }>
+      ).map((r) => r.name);
+      expect(tables).toContain('ia_workspaces');
+      expect(tables).toContain('ia_bench_overlays');
+      expect(tables).toContain('schema_version');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('empty-DB safety: list returns [] before any insert', () => {
+    const { store } = makeStore();
+    expect(store.listWorkspaces()).toEqual([]);
+    expect(store.listBenchOverlays()).toEqual([]);
+    expect(store.getWorkspace(createWorkspaceId('none'))).toBeNull();
+  });
+
+  it('runs cleanly against a pre-existing DB that has no IA tables', () => {
+    // Simulate an existing relay DB with unrelated tables + a schema_version
+    // row. createIaStore must add IA tables without touching the rest.
+    const dbPath = path.join(makeDir(), 'ia.db');
+    const seed = new Database(dbPath);
+    seed.exec(
+      'CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)'
+    );
+    seed
+      .prepare('INSERT INTO schema_version (version) VALUES (?)')
+      .run(0);
+    seed.exec('CREATE TABLE legacy_thing (id TEXT PRIMARY KEY)');
+    seed.prepare('INSERT INTO legacy_thing (id) VALUES (?)').run('keep-me');
+    seed.close();
+
+    const store = createIaStore(dbPath);
+    openStores.push(store);
+    store.upsertWorkspace({
+      id: createWorkspaceId('added'),
+      name: 'Added',
+      order: 1,
+      projectIds: [],
+    });
+    expect(store.listWorkspaces()).toHaveLength(1);
+
+    // Pre-existing unrelated table + row untouched.
+    const db = new Database(dbPath);
+    try {
+      const legacy = db
+        .prepare('SELECT id FROM legacy_thing')
+        .all() as Array<{ id: string }>;
+      expect(legacy).toEqual([{ id: 'keep-me' }]);
+    } finally {
+      db.close();
+    }
+  });
+});


### PR DESCRIPTION
## What

Storage substrate (BE-5, #737) for the six-layer IA nouns the entity-CRUD lanes sit on. **Foundation only** — new tables + a typed store, no REST routes (those are #733 Workspace CRUD / #735 Bench CRUD).

### Tables (`server/ia-store.ts`, own `ia.db` file)
- `ia_workspaces` — `id` (PK, `ws:...`), `name`, `sort_order` (REAL, float for reorder-without-renumber), `project_ids_json`, `created_at`, `updated_at`.
- `ia_bench_overlays` — `id` (PK, `bench:...`), `instance_id`, `cwd` (both decoded from the BenchId for indexing/queries), `label` (nullable; null = use derived label), `env_overrides_json`, `created_at`, `updated_at`.
- `schema_version` — single-row version table.

### Store API
`initIaStore(configDir)` / `createIaStore(dbPath)` factory split (testable). Typed `IaStore`: `listWorkspaces`/`getWorkspace`/`upsertWorkspace`/`deleteWorkspace` and `listBenchOverlays`/`getBenchOverlay`/`upsertBenchOverlay`/`deleteBenchOverlay`, plus `close()`. Reuses `shared/` types + id parsers (`parseWorkspaceId`/`parseBenchId`) — IDs are the `shared/` encoded strings, never re-encoded. Upsert preserves `createdAt`; input is validated/normalized (rejects bad ids/name/order; strips non-string env values).

## Persisted vs derived (+ why)
- **Persisted** = genuinely user-authored, non-derivable: Workspace **grouping** (`projectIds[]` membership — the six-layer model, not the legacy `config.workspaces[].repos` repo-localPath grouping) and Bench **overlays** (`envOverrides` + optional `label`). `GET /hub/ia/tree`'s derived `IaBench` has neither.
- **Derived (NOT persisted)**: Project, Instance, and git-worktree Bench facts — already served by `GET /hub/ia/tree` (#744) from cross-node inventory + node status. No Project/Instance rows are stored.

## Non-destructive guarantee
Strictly additive. The store owns its own SQLite file and creates **only new tables**. It never reads or mutates `config.json`, `config.repos`, `config.workspaces`, or any existing DB/table. **No legacy-data migration** (that's #736, explicitly out of scope and gated). Migration is idempotent (re-run = no-op, version stays at 1) and safe on an existing DB that has no IA tables. Mirrors the established `server/work-contexts.ts` store/migration pattern — no new migration mechanism invented.

## Tests + boot evidence
- `test/ia-store.test.ts` — 18 tests: round-trip per entity (insert→read→update→delete), id round-trip via `shared/` parsers, ordering, float order, input validation, env-value stripping, durability across re-open, idempotent migration (re-run, version pinned at 1), table-existence on fresh DB, empty-DB safety, and clean run against a pre-existing DB with unrelated tables (legacy row untouched).
- Gates (Node24): `npm run build` ✅, `npm run check` ✅ (0 errors), `npm test` ✅ (289 files / 3740 tests, no regression).
- **Real boot verification** (isolated `--config /tmp/kani-737/config.json`, `RELAY_IDE_PORT=3462 NO_PIN=1`, fresh DB): clean boot, `ia.db` created with `ia_workspaces` + `ia_bench_overlays` + `schema_version=1` and the expected columns. Seeded a workspace row, rebooted on the **existing** DB: clean boot, `schema_version` stayed 1 (migration did not re-run), seeded row survived — confirming non-destructive.

## Follow-ups
#733 (Workspace CRUD) and #735 (Bench CRUD) consume this store and add the REST routes. The boot wiring already constructs the store handle (guarded) and closes it on shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)