### PR TITLE
feat(#733): Workspace CRUD (grouping-of-Projects)

### DIFF
--- a/server/features/ia-workspace-router.ts
+++ b/server/features/ia-workspace-router.ts
@@ -1,0 +1,273 @@
+// IA Workspace CRUD HTTP surface (#733 / BE-1). Exposes the six-layer
+// **Workspace** (a durable, user-authored grouping-of-Projects) over REST,
+// backed by the #737 `IaStore` (own `ia.db`, new tables only).
+//
+// STRICTLY NON-DESTRUCTIVE: this router only reads/writes the IA store's
+// `ia_workspaces` table via the injected `IaStore` handle. It never touches
+// `config.workspaces`, `config.repos`, or any legacy state. The legacy
+// `config.workspaces` grouping that feeds `GET /hub/ia/tree` is a separate,
+// read-only concern and is untouched here.
+//
+// Project (Instance / Bench / git-worktree) facts remain DERIVED via
+// `GET /hub/ia/tree` (#734); a Workspace only persists an ORDERED LIST of
+// ProjectIds it groups (membership), not the projects themselves.
+//
+// Endpoints (mounted at `/hub/ia/workspaces`):
+// - GET    /hub/ia/workspaces        → list, ordered by `order` asc then id
+// - POST   /hub/ia/workspaces        → create { name, projectIds?, order? }
+// - PATCH  /hub/ia/workspaces/:id    → partial update (name / order / projectIds)
+// - DELETE /hub/ia/workspaces/:id    → remove
+//
+// Reorder and project-membership-move are folded into PATCH: send `order` to
+// reorder, send the full desired `projectIds` array to set membership (the
+// store replaces the membership list wholesale). This is the minimal correct
+// shape — no dedicated reorder/move endpoints — because the persisted Workspace
+// record is small and fully replaceable.
+
+import * as express from 'express';
+
+import { createLogger } from '../logger.js';
+import { relayError, sendRelayError } from '../hub-node-router.js';
+import type { IaStore } from '../ia-store.js';
+import {
+  createWorkspaceId,
+  parseWorkspaceId,
+  type Workspace,
+} from '../../shared/workspace.js';
+import { randomUUID } from 'node:crypto';
+
+const logger = createLogger('ia-workspace-router');
+
+export interface IaWorkspaceRouterOptions {
+  requireAuth: express.RequestHandler;
+  /**
+   * The #737 IA persistence handle. Optional so the hub degrades gracefully to
+   * "no IA persistence" (503) rather than failing boot if the store could not
+   * initialize — mirrors how `server/index.ts` guards `initIaStore`.
+   */
+  iaStore: IaStore | null;
+}
+
+function bodyRecord(req: express.Request): Record<string, unknown> {
+  return typeof req.body === 'object' && req.body !== null
+    ? (req.body as Record<string, unknown>)
+    : {};
+}
+
+/** Normalize an arbitrary value into a clean string[] of non-empty ids. */
+function readProjectIds(value: unknown): string[] | null {
+  if (value === undefined) return null;
+  if (!Array.isArray(value)) return null;
+  const out: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'string' || entry.length === 0) return null;
+    out.push(entry);
+  }
+  return out;
+}
+
+export function createIaWorkspaceRouter(
+  options: IaWorkspaceRouterOptions
+): express.Router {
+  const router = express.Router();
+  const { requireAuth } = options;
+
+  // Guard: every route needs a live store. Centralized so each handler can
+  // assume a non-null store after this check.
+  function store(res: express.Response): IaStore | null {
+    if (!options.iaStore) {
+      sendRelayError(
+        res,
+        relayError(
+          'NODE_BUSY',
+          'IA persistence store is unavailable',
+          true,
+          { reasonCode: 'IA_STORE_UNAVAILABLE' }
+        )
+      );
+      return null;
+    }
+    return options.iaStore;
+  }
+
+  // GET /hub/ia/workspaces — list all workspaces, ordered by the store
+  // (`order` asc then id asc for stability).
+  router.get('/hub/ia/workspaces', requireAuth, (_req, res) => {
+    const iaStore = store(res);
+    if (!iaStore) return;
+    try {
+      res.json({ workspaces: iaStore.listWorkspaces() });
+    } catch (error) {
+      sendInternal(res, 'list', error);
+    }
+  });
+
+  // POST /hub/ia/workspaces — create. Mints a fresh WorkspaceId. `order`
+  // defaults to (max existing order + 1) so new workspaces append to the bar.
+  router.post('/hub/ia/workspaces', requireAuth, (req, res) => {
+    const iaStore = store(res);
+    if (!iaStore) return;
+    const body = bodyRecord(req);
+
+    const name = body['name'];
+    if (typeof name !== 'string' || name.trim().length === 0) {
+      sendValidation(res, 'name is required', 'name');
+      return;
+    }
+
+    const projectIds = readProjectIds(body['projectIds']);
+    if (body['projectIds'] !== undefined && projectIds === null) {
+      sendValidation(
+        res,
+        'projectIds must be an array of non-empty strings',
+        'projectIds'
+      );
+      return;
+    }
+
+    let order: number;
+    if (body['order'] === undefined) {
+      order = nextOrder(iaStore.listWorkspaces());
+    } else if (typeof body['order'] === 'number' && Number.isFinite(body['order'])) {
+      order = body['order'];
+    } else {
+      sendValidation(res, 'order must be a finite number', 'order');
+      return;
+    }
+
+    try {
+      const created = iaStore.upsertWorkspace({
+        id: createWorkspaceId(randomUUID()),
+        name: name.trim(),
+        order,
+        projectIds: projectIds ?? [],
+      });
+      res.status(201).json({ workspace: created });
+    } catch (error) {
+      sendInternal(res, 'create', error);
+    }
+  });
+
+  // PATCH /hub/ia/workspaces/:id — partial update. Merges provided fields onto
+  // the existing record (rename, reorder, set membership). Absent fields are
+  // preserved. The store upsert preserves `createdAt`.
+  router.patch('/hub/ia/workspaces/:id', requireAuth, (req, res) => {
+    const iaStore = store(res);
+    if (!iaStore) return;
+
+    const id = req.params['id'];
+    if (!id || !parseWorkspaceId(id)) {
+      sendValidation(res, 'invalid workspace id', 'id');
+      return;
+    }
+    const existing = iaStore.getWorkspace(id);
+    if (!existing) {
+      sendRelayError(res, relayError('NOT_FOUND', `workspace ${id} not found`));
+      return;
+    }
+
+    const body = bodyRecord(req);
+
+    let name = existing.name;
+    if (body['name'] !== undefined) {
+      if (typeof body['name'] !== 'string' || body['name'].trim().length === 0) {
+        sendValidation(res, 'name must be a non-empty string', 'name');
+        return;
+      }
+      name = body['name'].trim();
+    }
+
+    let order = existing.order;
+    if (body['order'] !== undefined) {
+      if (typeof body['order'] !== 'number' || !Number.isFinite(body['order'])) {
+        sendValidation(res, 'order must be a finite number', 'order');
+        return;
+      }
+      order = body['order'];
+    }
+
+    let projectIds = existing.projectIds;
+    if (body['projectIds'] !== undefined) {
+      const parsed = readProjectIds(body['projectIds']);
+      if (parsed === null) {
+        sendValidation(
+          res,
+          'projectIds must be an array of non-empty strings',
+          'projectIds'
+        );
+        return;
+      }
+      projectIds = parsed;
+    }
+
+    try {
+      const updated = iaStore.upsertWorkspace({ id, name, order, projectIds });
+      res.json({ workspace: updated });
+    } catch (error) {
+      sendInternal(res, 'update', error);
+    }
+  });
+
+  // DELETE /hub/ia/workspaces/:id — remove. 204 on success, 404 if absent.
+  router.delete('/hub/ia/workspaces/:id', requireAuth, (req, res) => {
+    const iaStore = store(res);
+    if (!iaStore) return;
+
+    const id = req.params['id'];
+    if (!id || !parseWorkspaceId(id)) {
+      sendValidation(res, 'invalid workspace id', 'id');
+      return;
+    }
+    try {
+      const removed = iaStore.deleteWorkspace(id);
+      if (!removed) {
+        sendRelayError(res, relayError('NOT_FOUND', `workspace ${id} not found`));
+        return;
+      }
+      res.status(204).end();
+    } catch (error) {
+      sendInternal(res, 'delete', error);
+    }
+  });
+
+  return router;
+
+  function sendValidation(
+    res: express.Response,
+    message: string,
+    field: string
+  ): void {
+    sendRelayError(
+      res,
+      relayError('INVALID_REQUEST', message, false, {
+        reasonCode: 'INVALID_WORKSPACE_INPUT',
+        field,
+      })
+    );
+  }
+
+  function sendInternal(
+    res: express.Response,
+    op: string,
+    error: unknown
+  ): void {
+    logger.warn('workspace %s failed: %s', op, error);
+    sendRelayError(
+      res,
+      relayError(
+        'INTERNAL',
+        error instanceof Error ? error.message : `workspace ${op} failed`
+      )
+    );
+  }
+}
+
+/** Next append-order: max existing `order` + 1, or 0 for an empty list. */
+function nextOrder(existing: Workspace[]): number {
+  if (existing.length === 0) return 0;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const ws of existing) {
+    if (ws.order > max) max = ws.order;
+  }
+  return Number.isFinite(max) ? max + 1 : 0;
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -136,6 +136,7 @@ import {
 } from './hub-session-aggregator.js';
 import { createRepoInventoryFeature } from './features/repo-inventory.js';
 import { createRepoFeatureRouter } from './features/repo-router.js';
+import { createIaWorkspaceRouter } from './features/ia-workspace-router.js';
 import { collectLocalRepoInventory } from './repo-inventory.js';
 import type {
   AgentType,
@@ -1663,6 +1664,10 @@ async function main(): Promise<void> {
       ...(securityAuditLog ? { auditSink: securityAuditLog } : {}),
     })
   );
+  // #733: Workspace CRUD on the #737 IA store (own `ia.db`, new tables only,
+  // non-destructive). Consumes the `iaStore` handle wired above; degrades to
+  // 503 if the store failed to init.
+  app.use(createIaWorkspaceRouter({ requireAuth, iaStore }));
   app.use(
     createCliGatewayEventsRouter(express, {
       cliGatewayAuth: requireCliGatewayAuth,

--- a/test/ia-workspace-router.test.ts
+++ b/test/ia-workspace-router.test.ts
@@ -1,0 +1,239 @@
+import express from 'express';
+import type { Server } from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createIaWorkspaceRouter } from '../server/features/ia-workspace-router.js';
+import { createIaStore, type IaStore } from '../server/ia-store.js';
+import { parseWorkspaceId, type Workspace } from '../shared/workspace.js';
+
+vi.mock('../server/logger.js', () => ({
+  createLogger: () => ({
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+let tmpDir: string;
+let store: IaStore | null;
+let server: Server;
+let baseUrl: string;
+
+// Pass-through auth so the suite exercises the route logic, not auth itself.
+// A separate test below proves the router actually applies the injected
+// `requireAuth` middleware.
+const passThroughAuth: express.RequestHandler = (_req, _res, next) => next();
+
+function mount(opts: {
+  iaStore: IaStore | null;
+  requireAuth?: express.RequestHandler;
+}): Promise<void> {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    createIaWorkspaceRouter({
+      requireAuth: opts.requireAuth ?? passThroughAuth,
+      iaStore: opts.iaStore,
+    })
+  );
+  return new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as { port: number };
+      baseUrl = `http://127.0.0.1:${addr.port}`;
+      resolve();
+    });
+  });
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ia-workspace-router-'));
+  store = createIaStore(path.join(tmpDir, 'ia.db'));
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server?.close(() => resolve()));
+  try {
+    store?.close();
+  } catch {
+    /* already closed */
+  }
+  store = null;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const WS = '/hub/ia/workspaces';
+
+describe('IA Workspace CRUD router', () => {
+  it('round-trips create → list → patch (rename/reorder/membership) → delete', async () => {
+    await mount({ iaStore: store });
+
+    // empty list to start
+    const empty = await fetch(`${baseUrl}${WS}`);
+    expect(empty.status).toBe(200);
+    expect(await empty.json()).toEqual({ workspaces: [] });
+
+    // create A (no order → appends at 0)
+    const createA = await fetch(`${baseUrl}${WS}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Alpha' }),
+    });
+    expect(createA.status).toBe(201);
+    const { workspace: a } = (await createA.json()) as { workspace: Workspace };
+    expect(parseWorkspaceId(a.id)).not.toBeNull();
+    expect(a).toMatchObject({ name: 'Alpha', order: 0, projectIds: [] });
+    expect(typeof a.createdAt).toBe('string');
+    expect(typeof a.updatedAt).toBe('string');
+
+    // create B with explicit projectIds (no order → appends after A)
+    const createB = await fetch(`${baseUrl}${WS}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Beta', projectIds: ['p1', 'p2'] }),
+    });
+    expect(createB.status).toBe(201);
+    const { workspace: b } = (await createB.json()) as { workspace: Workspace };
+    expect(b).toMatchObject({ name: 'Beta', order: 1, projectIds: ['p1', 'p2'] });
+
+    // list returns both, ordered by order asc
+    const listed = (await (await fetch(`${baseUrl}${WS}`)).json()) as {
+      workspaces: Workspace[];
+    };
+    expect(listed.workspaces.map((w) => w.name)).toEqual(['Alpha', 'Beta']);
+
+    // PATCH A: rename + reorder past B + set membership (move projects)
+    const patchA = await fetch(`${baseUrl}${WS}/${encodeURIComponent(a.id)}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Alpha-2', order: 5, projectIds: ['p2'] }),
+    });
+    expect(patchA.status).toBe(200);
+    const { workspace: a2 } = (await patchA.json()) as { workspace: Workspace };
+    expect(a2).toMatchObject({
+      id: a.id,
+      name: 'Alpha-2',
+      order: 5,
+      projectIds: ['p2'],
+      createdAt: a.createdAt, // preserved across update
+    });
+
+    // reorder reflected in list: Beta(1) now before Alpha-2(5)
+    const reordered = (await (await fetch(`${baseUrl}${WS}`)).json()) as {
+      workspaces: Workspace[];
+    };
+    expect(reordered.workspaces.map((w) => w.name)).toEqual(['Beta', 'Alpha-2']);
+
+    // DELETE B
+    const del = await fetch(`${baseUrl}${WS}/${encodeURIComponent(b.id)}`, {
+      method: 'DELETE',
+    });
+    expect(del.status).toBe(204);
+
+    const after = (await (await fetch(`${baseUrl}${WS}`)).json()) as {
+      workspaces: Workspace[];
+    };
+    expect(after.workspaces.map((w) => w.name)).toEqual(['Alpha-2']);
+  });
+
+  it('PATCH preserves unspecified fields (partial update)', async () => {
+    await mount({ iaStore: store });
+    const created = (await (
+      await fetch(`${baseUrl}${WS}`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Gamma', projectIds: ['p1'], order: 3 }),
+      })
+    ).json()) as { workspace: Workspace };
+
+    // rename only — order + projectIds must survive
+    const patched = (await (
+      await fetch(`${baseUrl}${WS}/${encodeURIComponent(created.workspace.id)}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Gamma-renamed' }),
+      })
+    ).json()) as { workspace: Workspace };
+    expect(patched.workspace).toMatchObject({
+      name: 'Gamma-renamed',
+      order: 3,
+      projectIds: ['p1'],
+    });
+  });
+
+  it('rejects blank name on create (400)', async () => {
+    await mount({ iaStore: store });
+    const res = await fetch(`${baseUrl}${WS}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: '   ' }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string; details?: { field?: string } } };
+    expect(body.error.code).toBe('INVALID_REQUEST');
+    expect(body.error.details?.field).toBe('name');
+  });
+
+  it('rejects bad projectIds and bad order on create (400)', async () => {
+    await mount({ iaStore: store });
+    const badProjects = await fetch(`${baseUrl}${WS}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'X', projectIds: ['ok', ''] }),
+    });
+    expect(badProjects.status).toBe(400);
+    expect((await badProjects.json()).error.details.field).toBe('projectIds');
+
+    const badOrder = await fetch(`${baseUrl}${WS}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'X', order: 'first' }),
+    });
+    expect(badOrder.status).toBe(400);
+    expect((await badOrder.json()).error.details.field).toBe('order');
+  });
+
+  it('PATCH/DELETE on unknown id → 404; bad id → 400', async () => {
+    await mount({ iaStore: store });
+
+    const patchMissing = await fetch(`${baseUrl}${WS}/ws%3Anope`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'x' }),
+    });
+    expect(patchMissing.status).toBe(404);
+    expect((await patchMissing.json()).error.code).toBe('NOT_FOUND');
+
+    const delMissing = await fetch(`${baseUrl}${WS}/ws%3Anope`, {
+      method: 'DELETE',
+    });
+    expect(delMissing.status).toBe(404);
+
+    const badId = await fetch(`${baseUrl}${WS}/not-a-ws-id`, {
+      method: 'DELETE',
+    });
+    expect(badId.status).toBe(400);
+    expect((await badId.json()).error.details.field).toBe('id');
+  });
+
+  it('degrades to 503 when the IA store is unavailable', async () => {
+    await mount({ iaStore: null });
+    const res = await fetch(`${baseUrl}${WS}`);
+    expect(res.status).toBe(503);
+    expect((await res.json()).error.code).toBe('NODE_BUSY');
+  });
+
+  it('applies the injected requireAuth middleware', async () => {
+    const denyAuth: express.RequestHandler = (_req, res) => {
+      res.status(401).json({ error: { code: 'UNAUTHORIZED' } });
+    };
+    await mount({ iaStore: store, requireAuth: denyAuth });
+    const res = await fetch(`${baseUrl}${WS}`);
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## What

Exposes the six-layer **Workspace** (a durable, user-authored grouping-of-Projects) over REST, backed by the #737 `IaStore` (own `ia.db`, new tables only). This unblocks the frontend Workspace bar (#728).

## Endpoints + shapes

Mounted at `/hub/ia/workspaces`, all `requireAuth`-gated. Errors use the existing `relayError`/`sendRelayError` envelope (`{ error: { code, message, retryable, details? } }`).

| Method | Path | Body | Response |
| --- | --- | --- | --- |
| `GET` | `/hub/ia/workspaces` | — | `200 { workspaces: Workspace[] }` (ordered by `order` asc, then id) |
| `POST` | `/hub/ia/workspaces` | `{ name, projectIds?, order? }` | `201 { workspace }` — mints `createWorkspaceId(randomUUID())`; `order` defaults to max+1 (append) |
| `PATCH` | `/hub/ia/workspaces/:id` | `{ name?, order?, projectIds? }` | `200 { workspace }` — partial merge; absent fields preserved; `createdAt` preserved |
| `DELETE` | `/hub/ia/workspaces/:id` | — | `204` (404 if absent) |

`Workspace` shape (`shared/workspace.ts`): `{ id, name, order, projectIds[], createdAt, updatedAt }`.

**Reorder + project-membership-move** fold into `PATCH` — send `order` to reorder, send the full desired `projectIds` array to set membership (the store replaces the membership list wholesale). This is the minimal correct shape: the persisted record is small and fully replaceable, so no dedicated reorder/move endpoints are needed.

**Validation** (`400 INVALID_REQUEST` with `details.field`): blank/missing `name`, non-finite `order`, `projectIds` that isn't an array of non-empty strings, malformed workspace id. Unknown id → `404 NOT_FOUND`.

## Store methods used (#737)

`IaStore.listWorkspaces()`, `getWorkspace(id)`, `upsertWorkspace({ id, name, order, projectIds })`, `deleteWorkspace(id)`. Consumes the **injected** `iaStore` handle wired at boot in `server/index.ts` — no second DB connection. Degrades to `503 NODE_BUSY` if the store failed to init.

## Non-destructive guarantee

Only the IA store's `ia_workspaces` table is read/written. **Never** touches `config.workspaces`, `config.repos`, or any legacy state. The legacy `config.workspaces` grouping that feeds `GET /hub/ia/tree` (#734) is untouched. Project/Instance/Bench facts remain DERIVED via `GET /hub/ia/tree`; a Workspace only persists an ordered list of grouped ProjectIds.

## Backed by #737 / stacking

Stacked on **#737 (PR #748)** — this branch is off `feat/737-ia-persistence-schema`. **Merge after #737.**

## Tests + curl evidence

Gates (Node 24): `npm run build` ✅, `npm run check` ✅ (0 errors; no new warnings in touched files), `npm test` ✅ (290 files, 3747 tests pass — no regression).

New integration test `test/ia-workspace-router.test.ts` (real Express + real `ia.db`): create→list→patch(rename/reorder/membership)→delete round-trip; partial-update field preservation; validation rejects (blank name, bad projectIds, bad order); unknown-id 404 / bad-id 400; store-unavailable 503; injected-`requireAuth` enforcement.

Real API smoke (hub on isolated `--config`, `RELAY_IDE_PORT=3463 NO_PIN=1`):

```
POST {"name":"Alpha","projectIds":["p1"]}
→ 201 {"workspace":{"id":"ws:c15282a1-...","name":"Alpha","order":0,"projectIds":["p1"],...}}
POST {"name":"Beta"} → 201 order:1, projectIds:[]
GET  → [Alpha(0), Beta(1)]
PATCH Alpha {"name":"Alpha-2","order":9,"projectIds":["p2","p3"]}
→ 200 createdAt preserved, updatedAt bumped
GET  → [Beta(1), Alpha-2(9)]   # reorder + membership-move reflected
DELETE Alpha-2 → 204
GET  → [Beta]
POST {"name":"  "}        → 400 field=name
PATCH ws:nope             → 404 NOT_FOUND
DELETE not-a-ws-id        → 400 field=id
```

config.json `workspaces` stayed `[]` — only `ia.db` held the new data (non-destructive confirmed).

## Files touched

- `server/features/ia-workspace-router.ts` (new — the router)
- `test/ia-workspace-router.test.ts` (new — integration tests)
- `server/index.ts` (+5 lines: 1 import, 1 focused mount block) — kept minimal to reduce conflict with the parallel #735 Bench-CRUD lane editing the same boot wiring.

Unblocks #728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)