### PR TITLE
feat(#735): Bench CRUD + envOverrides (node-cwd benches)

### DIFF
--- a/server/features/repo-router.ts
+++ b/server/features/repo-router.ts
@@ -39,6 +39,13 @@ import {
   type IaNodeStatus,
   type IaWorkspaceGroupInput,
 } from './ia-tree.js';
+import { IaStoreError, type IaStore } from '../ia-store.js';
+import {
+  createBenchId,
+  parseBenchId,
+  type BenchId,
+} from '../../shared/bench.js';
+import { parseInstanceId } from '../../shared/project.js';
 import {
   expiresAtFromLifecycleInput,
   lifecycleInputError,
@@ -61,6 +68,15 @@ export interface RepoFeatureRouterOptions {
    * never reaches into config directly. Optional: omit → no grouping.
    */
   listWorkspaceGroups?: () => IaWorkspaceGroupInput[];
+  /**
+   * IA persistence store (#737). Backs the Bench overlay CRUD routes (#735):
+   * user-authored env/label overrides + arbitrary-cwd (non-git) benches on a
+   * node instance. Optional: omit (or pass null) → the overlay routes return
+   * 503 (persistence unavailable), exactly like the boot guard degrades when
+   * the SQLite file fails to open. The DERIVED git-worktree benches in
+   * `GET /hub/ia/tree` do not depend on this store.
+   */
+  iaStore?: IaStore | null;
   now?: () => Date;
 }
 
@@ -72,6 +88,140 @@ function sessionCreateTypeFromBody(body: Record<string, unknown>): SessionCreate
     reasonCode: 'INVALID_SESSION_TYPE',
     field: 'type',
   });
+}
+
+// ── Bench overlay validation (#735) ─────────────────────────────────────────
+// All structural/paranoid: the hub mints a BenchId from caller-supplied
+// instanceId + cwd, so both are validated before they ever reach the store.
+// The hub cannot stat a remote node's filesystem, so cwd validation is
+// path-shape only (absolute, no `..` traversal, no NUL/control chars). It
+// deliberately does NOT require the instance to exist in current inventory:
+// an overlay may target an offline node, and coupling persistence to live
+// presence would silently drop legitimate state.
+
+function validateInstanceId(value: unknown): RelayNodeError | null {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return relayError('INVALID_REQUEST', 'instanceId is required', false, {
+      reasonCode: 'INSTANCE_ID_REQUIRED',
+      field: 'instanceId',
+    });
+  }
+  if (!parseInstanceId(value)) {
+    return relayError('INVALID_REQUEST', 'instanceId is malformed', false, {
+      reasonCode: 'INVALID_INSTANCE_ID',
+      field: 'instanceId',
+    });
+  }
+  return null;
+}
+
+function validateBenchCwd(value: unknown): RelayNodeError | null {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return relayError('INVALID_REQUEST', 'cwd is required', false, {
+      reasonCode: 'CWD_REQUIRED',
+      field: 'cwd',
+    });
+  }
+  // NUL or other control chars never belong in a path; reject before they can
+  // reach SQLite or a downstream node shell.
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(value)) {
+    return relayError('INVALID_REQUEST', 'cwd contains control characters', false, {
+      reasonCode: 'INVALID_CWD',
+      field: 'cwd',
+    });
+  }
+  // Absolute path only (POSIX or Windows). A relative cwd is meaningless once
+  // it leaves the requesting context, and `..` traversal is never trusted.
+  const isPosixAbs = value.startsWith('/');
+  const isWindowsAbs = /^[a-zA-Z]:[\\/]/.test(value);
+  if (!isPosixAbs && !isWindowsAbs) {
+    return relayError('INVALID_REQUEST', 'cwd must be an absolute path', false, {
+      reasonCode: 'CWD_NOT_ABSOLUTE',
+      field: 'cwd',
+    });
+  }
+  const segments = value.split(/[\\/]+/);
+  if (segments.includes('..')) {
+    return relayError('INVALID_REQUEST', 'cwd must not contain ".." traversal', false, {
+      reasonCode: 'CWD_TRAVERSAL',
+      field: 'cwd',
+    });
+  }
+  return null;
+}
+
+type ParseResult<T> = { value: T } | { error: RelayNodeError };
+
+// envOverrides: a plain string→string record. Non-string values are an
+// explicit client error (the store would silently strip them; surfacing a 400
+// keeps the contract honest for FE #740). `undefined` → `{}`.
+function readEnvOverrides(value: unknown): ParseResult<Record<string, string>> {
+  if (value === undefined || value === null) return { value: {} };
+  if (
+    typeof value !== 'object' ||
+    Array.isArray(value)
+  ) {
+    return {
+      error: relayError(
+        'INVALID_REQUEST',
+        'envOverrides must be an object of string values',
+        false,
+        { reasonCode: 'INVALID_ENV_OVERRIDES', field: 'envOverrides' }
+      ),
+    };
+  }
+  const out: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof key !== 'string' || key.length === 0) continue;
+    if (typeof raw !== 'string') {
+      return {
+        error: relayError(
+          'INVALID_REQUEST',
+          `envOverrides.${key} must be a string`,
+          false,
+          { reasonCode: 'INVALID_ENV_OVERRIDE_VALUE', field: `envOverrides.${key}` }
+        ),
+      };
+    }
+    out[key] = raw;
+  }
+  return { value: out };
+}
+
+// label: optional display override. `undefined`/missing → leave unset; `null`
+// → clear (fall back to derived label); a string → use it.
+function readLabel(value: unknown): ParseResult<string | null | undefined> {
+  if (value === undefined) return { value: undefined };
+  if (value === null) return { value: null };
+  if (typeof value !== 'string') {
+    return {
+      error: relayError('INVALID_REQUEST', 'label must be a string or null', false, {
+        reasonCode: 'INVALID_LABEL',
+        field: 'label',
+      }),
+    };
+  }
+  return { value };
+}
+
+// Map an IaStoreError (or anything else) onto a relay error envelope. Store
+// validation rejections become 400; everything else is a 500.
+function sendIaStoreError(res: express.Response, error: unknown): void {
+  if (error instanceof IaStoreError) {
+    sendRelayError(
+      res,
+      relayError('INVALID_REQUEST', error.code, false, { reasonCode: error.code })
+    );
+    return;
+  }
+  sendRelayError(
+    res,
+    relayError(
+      'INTERNAL',
+      error instanceof Error ? error.message : 'bench overlay write failed'
+    )
+  );
 }
 
 // Repo-feature HTTP surface. These routes used to live in
@@ -162,6 +312,208 @@ export function createRepoFeatureRouter(
       res.json(tree);
     } catch (error) {
       sendRegistryError(registry, res, error);
+    }
+  });
+
+  // ── Bench overlay CRUD (#735) ───────────────────────────────────────────────
+  // The PERSISTED, user-authored overlay layer on top of the DERIVED bench
+  // (`GET /hub/ia/tree`). Carries env overrides + an optional label override
+  // and supports arbitrary-cwd (non-git) benches on a node instance — facts
+  // the inventory-derive cannot know. Backed by the #737 IaStore BenchOverlay
+  // table; non-destructive (own SQLite file, new tables only). When the store
+  // is unavailable these routes 503 rather than crashing (mirrors the boot
+  // guard in server/index.ts).
+  const iaStore = options.iaStore ?? null;
+
+  function requireIaStore(res: express.Response): IaStore | null {
+    if (!iaStore) {
+      res.status(503).json({
+        error: relayError(
+          'INTERNAL',
+          'IA persistence is unavailable',
+          true,
+          { reasonCode: 'IA_STORE_UNAVAILABLE' }
+        ),
+      });
+      return null;
+    }
+    return iaStore;
+  }
+
+  // GET /hub/ia/benches[?instanceId=...] — list bench overlays, optionally
+  // filtered to a single instance. Returns [] (never 404) when none exist.
+  router.get('/hub/ia/benches', requireAuth, async (req, res) => {
+    const store = requireIaStore(res);
+    if (!store) return;
+    try {
+      const rawInstanceId = req.query['instanceId'];
+      const instanceId =
+        typeof rawInstanceId === 'string' && rawInstanceId.length > 0
+          ? rawInstanceId
+          : null;
+      if (instanceId !== null && !parseInstanceId(instanceId)) {
+        sendRelayError(
+          res,
+          relayError('INVALID_REQUEST', 'instanceId is malformed', false, {
+            reasonCode: 'INVALID_INSTANCE_ID',
+            field: 'instanceId',
+          })
+        );
+        return;
+      }
+      const all = store.listBenchOverlays();
+      const benches =
+        instanceId === null
+          ? all
+          : all.filter((b) => b.instanceId === instanceId);
+      res.json({ benches });
+    } catch (error) {
+      sendIaStoreError(res, error);
+    }
+  });
+
+  // POST /hub/ia/benches — create a bench overlay. Mints the BenchId from a
+  // (validated) instanceId + cwd, so an arbitrary node-instance cwd becomes a
+  // first-class Bench. Path validation is structural/paranoid (absolute, no
+  // traversal, no NUL): the hub cannot stat a remote node's filesystem, so it
+  // refuses to mint ids it cannot trust rather than guessing.
+  router.post('/hub/ia/benches', requireAuth, async (req, res) => {
+    const store = requireIaStore(res);
+    if (!store) return;
+    const body = bodyRecord(req);
+    const instanceId = body['instanceId'];
+    const cwd = body['cwd'];
+
+    const instanceErr = validateInstanceId(instanceId);
+    if (instanceErr) {
+      sendRelayError(res, instanceErr);
+      return;
+    }
+    const cwdErr = validateBenchCwd(cwd);
+    if (cwdErr) {
+      sendRelayError(res, cwdErr);
+      return;
+    }
+    const envResult = readEnvOverrides(body['envOverrides']);
+    if ('error' in envResult) {
+      sendRelayError(res, envResult.error);
+      return;
+    }
+    const labelResult = readLabel(body['label']);
+    if ('error' in labelResult) {
+      sendRelayError(res, labelResult.error);
+      return;
+    }
+
+    let id: BenchId;
+    try {
+      // Both inputs are validated to be non-blank strings above; createBenchId
+      // throws only on blank values, which validation already rejects. The
+      // casts are sound because validate*() returned no error.
+      id = createBenchId(instanceId as string, cwd as string);
+    } catch {
+      sendRelayError(
+        res,
+        relayError('INVALID_REQUEST', 'could not derive a bench id')
+      );
+      return;
+    }
+
+    try {
+      const overlay = store.upsertBenchOverlay({
+        id,
+        envOverrides: envResult.value,
+        ...(labelResult.value !== undefined ? { label: labelResult.value } : {}),
+      });
+      res.status(201).json({ bench: overlay });
+    } catch (error) {
+      sendIaStoreError(res, error);
+    }
+  });
+
+  // PUT/PATCH /hub/ia/benches/:id — update label and/or env overrides on an
+  // existing overlay. The id is opaque (URL-encoded BenchId); a missing
+  // overlay is a 404. Omitted fields are left unchanged.
+  async function updateBenchOverlay(
+    req: express.Request,
+    res: express.Response
+  ): Promise<void> {
+    const store = requireIaStore(res);
+    if (!store) return;
+    const id = req.params['id'];
+    if (typeof id !== 'string' || !parseBenchId(id)) {
+      sendRelayError(
+        res,
+        relayError('INVALID_REQUEST', 'bench id is malformed', false, {
+          reasonCode: 'INVALID_BENCH_ID',
+        })
+      );
+      return;
+    }
+    const existing = store.getBenchOverlay(id);
+    if (!existing) {
+      sendRelayError(res, relayError('NOT_FOUND', 'bench overlay not found'));
+      return;
+    }
+    const body = bodyRecord(req);
+    const hasEnv = Object.prototype.hasOwnProperty.call(body, 'envOverrides');
+    const hasLabel = Object.prototype.hasOwnProperty.call(body, 'label');
+
+    let envOverrides = existing.envOverrides;
+    if (hasEnv) {
+      const envResult = readEnvOverrides(body['envOverrides']);
+      if ('error' in envResult) {
+        sendRelayError(res, envResult.error);
+        return;
+      }
+      envOverrides = envResult.value;
+    }
+
+    let label: string | null = existing.label;
+    if (hasLabel) {
+      const labelResult = readLabel(body['label']);
+      if ('error' in labelResult) {
+        sendRelayError(res, labelResult.error);
+        return;
+      }
+      label = labelResult.value ?? null;
+    }
+
+    try {
+      const overlay = store.upsertBenchOverlay({ id, envOverrides, label });
+      res.json({ bench: overlay });
+    } catch (error) {
+      sendIaStoreError(res, error);
+    }
+  }
+  router.put('/hub/ia/benches/:id', requireAuth, updateBenchOverlay);
+  router.patch('/hub/ia/benches/:id', requireAuth, updateBenchOverlay);
+
+  // DELETE /hub/ia/benches/:id — remove an overlay. Idempotent-ish: a missing
+  // overlay is a 404 so callers can distinguish "deleted now" from "never
+  // existed"; the derived git-worktree bench is unaffected either way.
+  router.delete('/hub/ia/benches/:id', requireAuth, async (req, res) => {
+    const store = requireIaStore(res);
+    if (!store) return;
+    const id = req.params['id'];
+    if (typeof id !== 'string' || !parseBenchId(id)) {
+      sendRelayError(
+        res,
+        relayError('INVALID_REQUEST', 'bench id is malformed', false, {
+          reasonCode: 'INVALID_BENCH_ID',
+        })
+      );
+      return;
+    }
+    try {
+      const removed = store.deleteBenchOverlay(id);
+      if (!removed) {
+        sendRelayError(res, relayError('NOT_FOUND', 'bench overlay not found'));
+        return;
+      }
+      res.json({ deleted: true, id });
+    } catch (error) {
+      sendIaStoreError(res, error);
     }
   });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1661,6 +1661,9 @@ async function main(): Promise<void> {
             order: typeof ws.order === 'number' ? ws.order : 0,
             ...(Array.isArray(ws.repos) ? { repos: ws.repos } : {}),
           })),
+      // #735: Bench overlay CRUD (env/label + arbitrary-cwd benches) backed by
+      // the #737 IA store. Null when the store failed to init → routes 503.
+      iaStore,
       ...(securityAuditLog ? { auditSink: securityAuditLog } : {}),
     })
   );

--- a/test/ia-bench-routes.test.ts
+++ b/test/ia-bench-routes.test.ts
@@ -1,0 +1,326 @@
+// #735 (BE-3): integration coverage for the Bench overlay CRUD routes on
+// `createRepoFeatureRouter`. Spins up a real express app + a real (temp-file)
+// IaStore and drives the routes over HTTP with `fetch`, mirroring the
+// router-level test pattern in `test/changed-files-api.test.ts`.
+//
+// The bench routes never touch the node registry or repo-inventory feature, so
+// those collaborators are minimal stubs here; only `requireAuth` (no-op) and
+// the injected `iaStore` matter.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { Server } from 'node:http';
+
+import express from 'express';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createRepoFeatureRouter } from '../server/features/repo-router.js';
+import { createIaStore, type IaStore } from '../server/ia-store.js';
+import { createInstanceId, createProjectId } from '../shared/project.js';
+import { createBenchId, parseBenchId } from '../shared/bench.js';
+
+const INSTANCE_ID = createInstanceId(
+  createProjectId({ kind: 'node', nodeId: 'macbook' }),
+  'macbook'
+);
+const REPO_INSTANCE_ID = createInstanceId(
+  createProjectId({ kind: 'repo', remote: 'github.com/acme/widget' }),
+  'local'
+);
+
+let tmpDir: string;
+let store: IaStore;
+let server: Server;
+let baseUrl: string;
+
+const noopAuth: express.RequestHandler = (_req, _res, next) => next();
+
+beforeAll(async () => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ia-bench-routes-'));
+  store = createIaStore(path.join(tmpDir, 'ia.db'));
+
+  const app = express();
+  app.use(express.json());
+  app.use(
+    createRepoFeatureRouter({
+      // The bench routes don't call these; minimal stubs satisfy the types.
+      registry: {
+        listNodes: () => [],
+        errorBody: (error: unknown) => ({
+          error: {
+            code: 'INTERNAL' as const,
+            message: error instanceof Error ? error.message : 'error',
+            retryable: false,
+          },
+        }),
+      } as never,
+      repoInventoryFeature: {
+        listInventoryReports: () => [],
+        aggregateInventoryReports: () => ({
+          generatedAt: new Date().toISOString(),
+          nodes: [],
+          projectGroups: [],
+        }),
+      } as never,
+      requireAuth: noopAuth,
+      iaStore: store,
+    })
+  );
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', resolve);
+  });
+  const addr = server.address() as { port: number };
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterAll(async () => {
+  server?.close();
+  try {
+    store.close();
+  } catch {
+    /* already closed */
+  }
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+async function post(body: unknown): Promise<Response> {
+  return fetch(`${baseUrl}/hub/ia/benches`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+async function get(query = ''): Promise<Response> {
+  return fetch(`${baseUrl}/hub/ia/benches${query}`);
+}
+
+describe('POST /hub/ia/benches (create)', () => {
+  it('creates an arbitrary-cwd bench on a node instance with envOverrides', async () => {
+    const res = await post({
+      instanceId: INSTANCE_ID,
+      cwd: '/srv/scratch/space',
+      envOverrides: { NODE_ENV: 'test', PORT: '4100' },
+      label: 'Scratch',
+    });
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { bench: Record<string, unknown> };
+    const bench = json.bench;
+    expect(bench['instanceId']).toBe(INSTANCE_ID);
+    expect(bench['cwd']).toBe('/srv/scratch/space');
+    expect(bench['label']).toBe('Scratch');
+    expect(bench['envOverrides']).toEqual({ NODE_ENV: 'test', PORT: '4100' });
+    // Minted id round-trips through the shared parser.
+    expect(parseBenchId(bench['id'] as string)).toEqual({
+      instanceId: INSTANCE_ID,
+      cwd: '/srv/scratch/space',
+    });
+  });
+
+  it('creates a git-worktree-anchored bench overlay (repo instance)', async () => {
+    const res = await post({
+      instanceId: REPO_INSTANCE_ID,
+      cwd: '/repos/widget/.worktrees/feat-x',
+      envOverrides: { FEATURE: 'on' },
+    });
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { bench: Record<string, unknown> };
+    expect(json.bench['label']).toBeNull(); // omitted → derived label
+    expect(json.bench['envOverrides']).toEqual({ FEATURE: 'on' });
+  });
+
+  it('defaults envOverrides to {} when omitted', async () => {
+    const res = await post({
+      instanceId: INSTANCE_ID,
+      cwd: '/srv/no-env',
+    });
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { bench: Record<string, unknown> };
+    expect(json.bench['envOverrides']).toEqual({});
+  });
+
+  it('rejects a malformed instanceId', async () => {
+    const res = await post({ instanceId: 'not-an-instance', cwd: '/ok' });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: { details?: { reasonCode?: string } } };
+    expect(json.error.details?.reasonCode).toBe('INVALID_INSTANCE_ID');
+  });
+
+  it('rejects a relative cwd', async () => {
+    const res = await post({ instanceId: INSTANCE_ID, cwd: 'relative/path' });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: { details?: { reasonCode?: string } } };
+    expect(json.error.details?.reasonCode).toBe('CWD_NOT_ABSOLUTE');
+  });
+
+  it('rejects a cwd containing .. traversal', async () => {
+    const res = await post({ instanceId: INSTANCE_ID, cwd: '/srv/../etc' });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: { details?: { reasonCode?: string } } };
+    expect(json.error.details?.reasonCode).toBe('CWD_TRAVERSAL');
+  });
+
+  it('rejects a cwd containing control characters', async () => {
+    const res = await post({ instanceId: INSTANCE_ID, cwd: '/srv/\x01bad' });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: { details?: { reasonCode?: string } } };
+    expect(json.error.details?.reasonCode).toBe('INVALID_CWD');
+  });
+
+  it('rejects a missing cwd', async () => {
+    const res = await post({ instanceId: INSTANCE_ID });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: { details?: { reasonCode?: string } } };
+    expect(json.error.details?.reasonCode).toBe('CWD_REQUIRED');
+  });
+
+  it('rejects a non-string envOverride value (does not silently strip)', async () => {
+    const res = await post({
+      instanceId: INSTANCE_ID,
+      cwd: '/srv/bad-env',
+      envOverrides: { GOOD: 'yes', BAD: 5 },
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: { details?: { reasonCode?: string } } };
+    expect(json.error.details?.reasonCode).toBe('INVALID_ENV_OVERRIDE_VALUE');
+  });
+});
+
+describe('GET /hub/ia/benches (list + filter)', () => {
+  it('lists all overlays and filters by instanceId', async () => {
+    const all = await (await get()).json();
+    const allBenches = (all as { benches: Array<{ instanceId: string }> }).benches;
+    // Persisted by the create block above: 2 on INSTANCE_ID
+    // (/srv/scratch/space + /srv/no-env) and 1 on REPO_INSTANCE_ID. Rejected
+    // POSTs (bad cwd/env) never persist.
+    expect(allBenches.length).toBeGreaterThanOrEqual(3);
+
+    const filtered = await (
+      await get(`?instanceId=${encodeURIComponent(REPO_INSTANCE_ID)}`)
+    ).json();
+    const filteredBenches = (filtered as { benches: Array<{ instanceId: string }> })
+      .benches;
+    expect(filteredBenches.length).toBe(1);
+    expect(filteredBenches[0]!.instanceId).toBe(REPO_INSTANCE_ID);
+  });
+
+  it('rejects a malformed instanceId filter', async () => {
+    const res = await get('?instanceId=garbage');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns an empty list (not 404) for an instance with no overlays', async () => {
+    const empty = createInstanceId(
+      createProjectId({ kind: 'node', nodeId: 'ghost' }),
+      'ghost'
+    );
+    const res = await get(`?instanceId=${encodeURIComponent(empty)}`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { benches: unknown[] };
+    expect(json.benches).toEqual([]);
+  });
+});
+
+describe('PUT/PATCH /hub/ia/benches/:id (update)', () => {
+  it('round-trips an envOverrides update', async () => {
+    const id = createBenchId(INSTANCE_ID, '/srv/update-me');
+    await post({ instanceId: INSTANCE_ID, cwd: '/srv/update-me', envOverrides: { A: '1' }, label: 'orig' });
+
+    const res = await fetch(`${baseUrl}/hub/ia/benches/${encodeURIComponent(id)}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ envOverrides: { A: '2', B: '3' } }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { bench: Record<string, unknown> };
+    expect(json.bench['envOverrides']).toEqual({ A: '2', B: '3' });
+    // Omitted label is left unchanged.
+    expect(json.bench['label']).toBe('orig');
+  });
+
+  it('PATCH clears the label with null and leaves env unchanged', async () => {
+    const id = createBenchId(INSTANCE_ID, '/srv/patch-me');
+    await post({ instanceId: INSTANCE_ID, cwd: '/srv/patch-me', envOverrides: { K: 'v' }, label: 'set' });
+
+    const res = await fetch(`${baseUrl}/hub/ia/benches/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ label: null }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { bench: Record<string, unknown> };
+    expect(json.bench['label']).toBeNull();
+    expect(json.bench['envOverrides']).toEqual({ K: 'v' });
+  });
+
+  it('404s when updating a non-existent overlay', async () => {
+    const id = createBenchId(INSTANCE_ID, '/srv/never-created');
+    const res = await fetch(`${baseUrl}/hub/ia/benches/${encodeURIComponent(id)}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ label: 'x' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('400s on a malformed bench id', async () => {
+    const res = await fetch(`${baseUrl}/hub/ia/benches/not-a-bench-id`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ label: 'x' }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /hub/ia/benches/:id', () => {
+  it('deletes an overlay then 404s on the second delete', async () => {
+    const id = createBenchId(INSTANCE_ID, '/srv/delete-me');
+    await post({ instanceId: INSTANCE_ID, cwd: '/srv/delete-me', envOverrides: {} });
+
+    const first = await fetch(`${baseUrl}/hub/ia/benches/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    });
+    expect(first.status).toBe(200);
+    const json = (await first.json()) as { deleted: boolean; id: string };
+    expect(json.deleted).toBe(true);
+    expect(json.id).toBe(id);
+
+    const second = await fetch(`${baseUrl}/hub/ia/benches/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    });
+    expect(second.status).toBe(404);
+  });
+});
+
+describe('store-unavailable degradation', () => {
+  it('503s when no iaStore is wired', async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(
+      createRepoFeatureRouter({
+        registry: { listNodes: () => [], errorBody: () => ({ error: { code: 'INTERNAL', message: 'x', retryable: false } }) } as never,
+        repoInventoryFeature: {
+          listInventoryReports: () => [],
+          aggregateInventoryReports: () => ({ generatedAt: '', nodes: [], projectGroups: [] }),
+        } as never,
+        requireAuth: noopAuth,
+        // iaStore intentionally omitted → routes 503.
+      })
+    );
+    const srv = await new Promise<Server>((resolve) => {
+      const s = app.listen(0, '127.0.0.1', () => resolve(s));
+    });
+    try {
+      const addr = srv.address() as { port: number };
+      const res = await fetch(`http://127.0.0.1:${addr.port}/hub/ia/benches`);
+      expect(res.status).toBe(503);
+      const json = (await res.json()) as { error: { details?: { reasonCode?: string } } };
+      expect(json.error.details?.reasonCode).toBe('IA_STORE_UNAVAILABLE');
+    } finally {
+      srv.close();
+    }
+  });
+});


### PR DESCRIPTION
## What

Exposes **Bench** read + CRUD via REST, backed by the #737 `IaStore` BenchOverlay table. Adds `envOverrides` storage and **node-instance arbitrary-cwd** bench creation (not just git worktrees). Routes live on `createRepoFeatureRouter` (`server/features/repo-router.ts`), wired through the injected `iaStore` handle from `server/index.ts`.

## Endpoints (all `requireAuth`)

| Method | Path | Behavior |
| --- | --- | --- |
| `GET` | `/hub/ia/benches[?instanceId=…]` | List bench overlays; optional filter by `instanceId`. Returns `{ benches: BenchOverlay[] }`, `[]` (never 404) when none. |
| `POST` | `/hub/ia/benches` | Create overlay from `{ instanceId, cwd, envOverrides?, label? }` → mints `createBenchId(instanceId, cwd)`, persists. `201 { bench }`. |
| `PUT` / `PATCH` | `/hub/ia/benches/:id` | Update `label` and/or `envOverrides` (omitted fields unchanged; `label: null` clears to derived). `200 { bench }`. |
| `DELETE` | `/hub/ia/benches/:id` | Remove overlay. `200 { deleted, id }`; missing → 404. |

**Shape** (`BenchOverlay` from `server/ia-store.ts`): `{ id, instanceId, cwd, label: string|null, envOverrides: Record<string,string>, createdAt, updatedAt }`.

## envOverrides + arbitrary-cwd

- `envOverrides` is string→string. **Non-string values are a 400** (`INVALID_ENV_OVERRIDE_VALUE`), not a silent strip, so FE #740 gets an honest contract. Omitted → `{}`.
- A node-instance arbitrary cwd becomes a first-class Bench via the minted `BenchId`; no git worktree required.

## Path validation (paranoid)

The hub cannot stat a remote node's filesystem, so cwd validation is **structural**: must be a non-blank **absolute** path (POSIX or Windows), **no `..` traversal**, **no control chars (0x00–0x1f, 0x7f)**. `instanceId` must parse via `parseInstanceId`. Validation deliberately does **not** require the instance to be present in current inventory (an overlay may target an offline node).

## Non-destructive guarantee

Backed solely by the #737 IA store (its own `ia.db`, new tables only). No `config.json` / legacy-data mutation; existing `POST /worktree` behavior unchanged. Store unavailable → routes return **503** (`IA_STORE_UNAVAILABLE`), mirroring the boot guard.

## Tests + curl evidence

- `test/ia-bench-routes.test.ts`: 18 integration cases over a real express app + temp-file `IaStore` — create (git-worktree-anchored **and** arbitrary node cwd) → list (filter by instance) → update envOverrides → delete; validation rejects bad cwd (relative / `..` / control char / missing) + malformed instanceId + non-string env; empty list; 404s; 503 when store unwired.
- Gates: `npm run build` ✅, `npm run check` ✅ (0 errors), `npm test` ✅ (290 files / 3758 tests).
- **Real hub smoke** (`RELAY_IDE_PORT=3464 NO_PIN=1 --config /tmp/kani-735`):
  - POST → `201`, envOverrides round-trip `{NODE_ENV:test, PORT:9090}`
  - GET list + `?instanceId=` filter → `200`
  - PUT → `200`, env updated to `{NODE_ENV:production, DEBUG:1}`, `label`/`createdAt` preserved, `updatedAt` bumped
  - POST relative cwd → `400 CWD_NOT_ABSOLUTE`
  - DELETE → `200`; subsequent GET → `{"benches":[]}`
  - Confirmed `ia.db` is its own file alongside (not inside) `config.json`.

## Stacking

**Stacked on #737 (PR #748).** Merge after #748 — the diff shows the #737 commit until that lands.

Unblocks #730 (Bench creation) + #740 (env inherit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)