### PR TITLE
feat(#728): Workspace bar (grouping-of-Projects)

### DIFF
--- a/frontend/src/components/ViewSpineTree.tsx
+++ b/frontend/src/components/ViewSpineTree.tsx
@@ -13,6 +13,7 @@ import {
   applyLens,
   benchCreatePayload,
   buildViewTree,
+  groupProjectsByWorkspace,
   DEFAULT_VIEW_LENS,
   type BenchCreatePayload,
   type InstanceHostStatus,
@@ -23,6 +24,8 @@ import {
   type ViewTreeProject,
   type ViewTreeNodeStatus,
 } from '../lib/state/view-tree.js';
+import { useIaWorkspaces } from '../lib/hooks/use-ia-workspaces.js';
+import { WorkspaceBar } from './WorkspaceBar.js';
 import './ViewSpineTree.css';
 
 /** Create a Tab anchored to a Bench's (nodeId, cwd). Wired to the EXISTING
@@ -159,12 +162,58 @@ function InstanceRow({
   );
 }
 
+/** Per-project "move to workspace" control. Lists the persisted workspaces plus
+ *  an "ungrouped" option; selecting one PATCHes membership (#733). Withheld when
+ *  no `assign` handler is supplied (read-only render). */
+export interface ProjectAssignControl {
+  /** Persisted workspace options (id + label), in display order. */
+  options: ReadonlyArray<{ id: string; name: string }>;
+  /** The workspace id currently owning this project, or '' for ungrouped. */
+  currentWorkspaceId: string;
+  /** Move the project to the given workspace id, or '' to ungroup. */
+  onAssign: (workspaceId: string) => void;
+  /** Disable while a workspace mutation is in flight. */
+  busy: boolean;
+}
+
+function ProjectAssignSelect({
+  project,
+  assign,
+}: {
+  project: ViewTreeProject;
+  assign: ProjectAssignControl;
+}) {
+  return (
+    <select
+      className="workspace-bar__assign"
+      value={assign.currentWorkspaceId}
+      disabled={assign.busy}
+      aria-label={`assign ${project.label} to a workspace`}
+      title="move to workspace"
+      onClick={(e) => e.stopPropagation()}
+      onChange={(e) => {
+        e.stopPropagation();
+        assign.onAssign(e.currentTarget.value);
+      }}
+    >
+      <option value="">ungrouped</option>
+      {assign.options.map((opt) => (
+        <option key={opt.id} value={opt.id}>
+          {opt.name}
+        </option>
+      ))}
+    </select>
+  );
+}
+
 function ProjectRow({
   project,
   onCreateTab,
+  assign,
 }: {
   project: ViewTreeProject;
   onCreateTab?: ViewSpineCreateTab | undefined;
+  assign?: ProjectAssignControl | undefined;
 }) {
   const initialColor = useMemo(
     () => deriveColor(project.colorSeed),
@@ -200,6 +249,9 @@ function ProjectRow({
             <span className="session-count-badge">{instanceCount}</span>
           ) : null}
         </div>
+        {assign ? (
+          <ProjectAssignSelect project={project} assign={assign} />
+        ) : null}
       </div>
       <ul className="session-list">
         {project.instances.map((instance) => (
@@ -367,6 +419,94 @@ export function ViewSpineTree({
 
   const tree = useMemo(() => applyLens(derived, lens), [derived, lens]);
 
+  // #728: the persisted six-layer Workspace layer (#733 CRUD). The bar manages
+  // workspace lifecycle; here we OVERLAY persisted membership on the derived
+  // tree. All derived projects (from the legacy workspace groups + the legacy
+  // ungrouped lane) are flattened — preserving the lens-applied order — and
+  // RE-grouped by persisted `projectIds`. Unassigned projects fall back to
+  // ungrouped. NO legacy auto-import: the legacy `workspaceGroups` grouping is
+  // collapsed away for render, never migrated into persisted Workspaces.
+  const { workspaces: persistedWorkspaces, updateMutation } = useIaWorkspaces();
+  const assignBusy = updateMutation.isPending;
+
+  const flatProjects = useMemo(
+    () => [
+      ...tree.workspaces.flatMap((ws) => ws.projects),
+      ...tree.ungroupedProjects,
+    ],
+    [tree]
+  );
+
+  const grouped = useMemo(
+    () => groupProjectsByWorkspace(flatProjects, persistedWorkspaces),
+    [flatProjects, persistedWorkspaces]
+  );
+
+  // The workspace each project currently belongs to (first claimant by order),
+  // so the per-project assign control can show the right selection.
+  const workspaceIdByProject = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const ws of grouped.workspaces) {
+      for (const project of ws.projects) {
+        if (!map.has(project.id)) map.set(project.id, ws.id);
+      }
+    }
+    return map;
+  }, [grouped]);
+
+  const assignOptions = useMemo(
+    () =>
+      [...persistedWorkspaces]
+        .sort((a, b) => a.order - b.order || a.id.localeCompare(b.id))
+        .map((ws) => ({ id: ws.id, name: ws.name })),
+    [persistedWorkspaces]
+  );
+
+  // Move a project into `targetWorkspaceId` (or '' to ungroup). PATCHes the
+  // membership of the source (remove) and target (append) workspaces. The
+  // membership list is replaced wholesale per the #733 contract.
+  const assignProjectTo = useCallback(
+    (projectId: string, targetWorkspaceId: string) => {
+      const currentId = workspaceIdByProject.get(projectId) ?? '';
+      if (currentId === targetWorkspaceId) return;
+      // Remove from the current owner (if any).
+      if (currentId) {
+        const source = persistedWorkspaces.find((w) => w.id === currentId);
+        if (source) {
+          updateMutation.mutate({
+            id: source.id,
+            patch: {
+              projectIds: source.projectIds.filter((id) => id !== projectId),
+            },
+          });
+        }
+      }
+      // Append to the target (if not ungrouping). Guard against dupes.
+      if (targetWorkspaceId) {
+        const target = persistedWorkspaces.find(
+          (w) => w.id === targetWorkspaceId
+        );
+        if (target && !target.projectIds.includes(projectId)) {
+          updateMutation.mutate({
+            id: target.id,
+            patch: { projectIds: [...target.projectIds, projectId] },
+          });
+        }
+      }
+    },
+    [persistedWorkspaces, updateMutation, workspaceIdByProject]
+  );
+
+  const makeAssign = useCallback(
+    (project: ViewTreeProject): ProjectAssignControl => ({
+      options: assignOptions,
+      currentWorkspaceId: workspaceIdByProject.get(project.id) ?? '',
+      onAssign: (workspaceId) => assignProjectTo(project.id, workspaceId),
+      busy: assignBusy,
+    }),
+    [assignOptions, workspaceIdByProject, assignProjectTo, assignBusy]
+  );
+
   // The Views selector is part of the sidebar header chrome: it renders in EVERY
   // state (loading, empty, content) so switching lenses is always available,
   // even when the active lens yields zero nodes.
@@ -377,6 +517,7 @@ export function ViewSpineTree({
     return (
       <div className="view-spine-tree">
         {selector}
+        <WorkspaceBar />
         <div className="view-spine-scroll">
           <ul className="session-list">
             <li className="session-row loading">
@@ -392,15 +533,16 @@ export function ViewSpineTree({
     );
   }
 
-  const hasContent =
-    tree.workspaces.some((ws) => ws.projects.length > 0) ||
-    tree.ungroupedProjects.length > 0 ||
-    tree.freeLane.length > 0;
+  const hasGroupedContent =
+    grouped.workspaces.some((ws) => ws.projects.length > 0) ||
+    grouped.ungroupedProjects.length > 0;
+  const hasContent = hasGroupedContent || tree.freeLane.length > 0;
 
   if (!hasContent) {
     return (
       <div className="view-spine-tree">
         {selector}
+        <WorkspaceBar />
         <div className="view-spine-scroll">
           <div className="sidebar-empty-state">
             <span>
@@ -412,11 +554,16 @@ export function ViewSpineTree({
     );
   }
 
+  const hasPersistedGroups = grouped.workspaces.some(
+    (ws) => ws.projects.length > 0
+  );
+
   return (
     <div className="view-spine-tree">
       {selector}
+      <WorkspaceBar />
       <div className="view-spine-scroll">
-        {tree.workspaces.map((ws) =>
+        {grouped.workspaces.map((ws) =>
           ws.projects.length > 0 ? (
             <section key={ws.id} className="view-spine-workspace">
               <div className="sidebar-ungrouped-label">{ws.name}</div>
@@ -425,22 +572,24 @@ export function ViewSpineTree({
                   key={project.id}
                   project={project}
                   onCreateTab={onCreateTab}
+                  assign={makeAssign(project)}
                 />
               ))}
             </section>
           ) : null
         )}
 
-        {tree.ungroupedProjects.length > 0 ? (
+        {grouped.ungroupedProjects.length > 0 ? (
           <section className="view-spine-workspace">
-            {tree.workspaces.some((ws) => ws.projects.length > 0) ? (
+            {hasPersistedGroups ? (
               <div className="sidebar-ungrouped-label">ungrouped</div>
             ) : null}
-            {tree.ungroupedProjects.map((project) => (
+            {grouped.ungroupedProjects.map((project) => (
               <ProjectRow
                 key={project.id}
                 project={project}
                 onCreateTab={onCreateTab}
+                assign={makeAssign(project)}
               />
             ))}
           </section>

--- a/frontend/src/components/WorkspaceBar.css
+++ b/frontend/src/components/WorkspaceBar.css
@@ -1,0 +1,220 @@
+/* #728 Workspace bar. Reuses existing design tokens (no new colors). Sits at
+   the top of the view-spine sidebar, above the derived tree. Touch targets are
+   kept ≥44px for the icon buttons and ≥36px for rows. */
+
+.workspace-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+
+.workspace-bar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.workspace-bar__title {
+  font-size: 0.58rem;
+  text-transform: lowercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.workspace-bar__hint {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  opacity: 0.8;
+  padding: 4px 2px;
+  line-height: 1.4;
+}
+
+.workspace-bar__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.workspace-bar__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 36px;
+}
+
+.workspace-bar__name {
+  flex: 1 1 auto;
+  text-align: left;
+  background: none;
+  border: 1px solid transparent;
+  color: var(--text);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  padding: 4px 6px;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-bar__name:hover:not(:disabled) {
+  background: var(--surface-hover);
+}
+
+.workspace-bar__name:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.workspace-bar__row-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex: 0 0 auto;
+}
+
+.workspace-bar__icon-btn {
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition:
+    color 0.1s,
+    background 0.1s;
+}
+
+.workspace-bar__icon-btn:hover:not(:disabled) {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+.workspace-bar__icon-btn--danger:hover:not(:disabled) {
+  color: var(--danger, var(--accent));
+}
+
+.workspace-bar__icon-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.workspace-bar__icon-btn:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+}
+
+.workspace-bar__create-row {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+}
+
+.workspace-bar__input {
+  flex: 1 1 auto;
+  min-width: 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--text);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  padding: 6px 8px;
+  min-height: 36px;
+  box-sizing: border-box;
+  outline: none;
+}
+
+.workspace-bar__input:focus {
+  border-color: var(--accent);
+}
+
+.workspace-bar__row-input {
+  flex: 1 1 auto;
+}
+
+.workspace-bar__create-btn {
+  flex: 0 0 auto;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+  padding: 0 10px;
+  min-height: 36px;
+  cursor: pointer;
+  transition:
+    color 0.1s,
+    border-color 0.1s;
+}
+
+.workspace-bar__create-btn:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.workspace-bar__create-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.workspace-bar__error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: var(--font-size-xs);
+  color: var(--danger, var(--accent));
+  padding: 4px 2px;
+}
+
+.workspace-bar__retry {
+  background: none;
+  border: 1px solid currentColor;
+  color: inherit;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs);
+  padding: 2px 8px;
+  cursor: pointer;
+}
+
+.workspace-bar__retry:hover {
+  background: var(--surface-hover);
+}
+
+/* ── Per-project assignment select (rendered in ViewSpineTree ProjectRow) ──── */
+.workspace-bar__assign {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs);
+  padding: 2px 4px;
+  min-height: 28px;
+  cursor: pointer;
+  outline: none;
+  max-width: 120px;
+}
+
+.workspace-bar__assign:focus {
+  border-color: var(--accent);
+}
+
+.workspace-bar__assign:disabled {
+  opacity: 0.5;
+  cursor: default;
+}

--- a/frontend/src/components/WorkspaceBar.tsx
+++ b/frontend/src/components/WorkspaceBar.tsx
@@ -1,0 +1,316 @@
+// #728: Workspace bar — the six-layer **Workspace** layer (a durable,
+// user-authored grouping-of-Projects) over the view-spine sidebar. Flag-gated
+// (only mounted by `ViewSpineTree` when `viewSpineEnabled`). Wires to the #733
+// `/hub/ia/workspaces` CRUD API via `useIaWorkspaces`.
+//
+// Scope (MVP): list persisted Workspaces, CREATE (name), RENAME (inline),
+// REORDER (up/down — lowest-risk vs. DnD, matches no existing drag dep in the
+// sidebar), DELETE. Project assignment lives on the project rows (the parent
+// passes `onAssignProject`); this bar owns workspace lifecycle only.
+//
+// States: empty (no workspaces → neutral copy + create affordance), loading,
+// error (failed mutation → non-destructive inline message, list refetches),
+// in-flight (controls disabled while a mutation is pending). Reuses existing
+// TUI primitives + design tokens — no new visual language.
+import { useState } from 'react';
+
+import type { IaWorkspace } from '../lib/api.js';
+import { useIaWorkspaces } from '../lib/hooks/use-ia-workspaces.js';
+import { createLogger } from '../lib/logger.js';
+import './WorkspaceBar.css';
+
+const logger = createLogger('workspace-bar');
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error && err.message ? err.message : fallback;
+}
+
+function WorkspaceRow({
+  workspace,
+  index,
+  count,
+  busy,
+  onRename,
+  onMoveUp,
+  onMoveDown,
+  onDelete,
+}: {
+  workspace: IaWorkspace;
+  index: number;
+  count: number;
+  busy: boolean;
+  onRename: (name: string) => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onDelete: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(workspace.name);
+
+  function commit() {
+    const trimmed = draft.trim();
+    setEditing(false);
+    if (trimmed.length === 0 || trimmed === workspace.name) {
+      setDraft(workspace.name);
+      return;
+    }
+    onRename(trimmed);
+  }
+
+  return (
+    <li className="workspace-bar__row">
+      {editing ? (
+        <input
+          type="text"
+          className="workspace-bar__input workspace-bar__row-input"
+          value={draft}
+          autoFocus
+          disabled={busy}
+          onChange={(e) => setDraft(e.currentTarget.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              commit();
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              setDraft(workspace.name);
+              setEditing(false);
+            }
+          }}
+          aria-label={`rename workspace ${workspace.name}`}
+        />
+      ) : (
+        <button
+          type="button"
+          className="workspace-bar__name"
+          disabled={busy}
+          onClick={() => {
+            setDraft(workspace.name);
+            setEditing(true);
+          }}
+          title="rename"
+        >
+          {workspace.name}
+        </button>
+      )}
+      <div className="workspace-bar__row-actions">
+        <button
+          type="button"
+          className="workspace-bar__icon-btn"
+          disabled={busy || index === 0}
+          onClick={onMoveUp}
+          aria-label={`move ${workspace.name} up`}
+          title="move up"
+        >
+          ↑
+        </button>
+        <button
+          type="button"
+          className="workspace-bar__icon-btn"
+          disabled={busy || index === count - 1}
+          onClick={onMoveDown}
+          aria-label={`move ${workspace.name} down`}
+          title="move down"
+        >
+          ↓
+        </button>
+        <button
+          type="button"
+          className="workspace-bar__icon-btn workspace-bar__icon-btn--danger"
+          disabled={busy}
+          onClick={onDelete}
+          aria-label={`delete ${workspace.name}`}
+          title="delete workspace"
+        >
+          ×
+        </button>
+      </div>
+    </li>
+  );
+}
+
+export function WorkspaceBar() {
+  const {
+    workspaces,
+    isLoading,
+    isError,
+    refetch,
+    createMutation,
+    updateMutation,
+    deleteMutation,
+  } = useIaWorkspaces();
+  const [newName, setNewName] = useState('');
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // Any pending mutation disables the controls (in-flight guard). Ordered by
+  // `order` asc then id (the API already returns this order, but re-sort defends
+  // against any partial cache).
+  const pending =
+    createMutation.isPending ||
+    updateMutation.isPending ||
+    deleteMutation.isPending;
+  const ordered = [...workspaces].sort(
+    (a, b) => a.order - b.order || a.id.localeCompare(b.id)
+  );
+
+  function clearError() {
+    setActionError(null);
+  }
+
+  function handleCreate() {
+    const name = newName.trim();
+    if (name.length === 0 || pending) return;
+    clearError();
+    createMutation.mutate(
+      { name },
+      {
+        onSuccess: () => setNewName(''),
+        onError: (err) => {
+          logger.warn('create workspace failed', err);
+          setActionError(errorMessage(err, 'could not create workspace'));
+        },
+      }
+    );
+  }
+
+  function handleRename(workspace: IaWorkspace, name: string) {
+    clearError();
+    updateMutation.mutate(
+      { id: workspace.id, patch: { name } },
+      {
+        onError: (err) => {
+          logger.warn('rename workspace failed', err);
+          setActionError(errorMessage(err, 'could not rename workspace'));
+        },
+      }
+    );
+  }
+
+  // Reorder by swapping the `order` of two adjacent workspaces. Two PATCHes;
+  // correctness-first (no optimistic UI). The list invalidates and refetches.
+  function handleSwap(a: IaWorkspace, b: IaWorkspace) {
+    clearError();
+    updateMutation.mutate(
+      { id: a.id, patch: { order: b.order } },
+      {
+        onError: (err) => {
+          logger.warn('reorder workspace failed', err);
+          setActionError(errorMessage(err, 'could not reorder workspace'));
+        },
+      }
+    );
+    updateMutation.mutate(
+      { id: b.id, patch: { order: a.order } },
+      {
+        onError: (err) => {
+          logger.warn('reorder workspace failed', err);
+          setActionError(errorMessage(err, 'could not reorder workspace'));
+        },
+      }
+    );
+  }
+
+  function handleDelete(workspace: IaWorkspace) {
+    clearError();
+    deleteMutation.mutate(workspace.id, {
+      onError: (err) => {
+        logger.warn('delete workspace failed', err);
+        setActionError(errorMessage(err, 'could not delete workspace'));
+      },
+    });
+  }
+
+  return (
+    <section className="workspace-bar" aria-label="workspaces">
+      <div className="workspace-bar__header">
+        <span className="workspace-bar__title">workspaces</span>
+      </div>
+
+      {isLoading ? (
+        <div className="workspace-bar__hint">loading workspaces…</div>
+      ) : ordered.length === 0 ? (
+        <div className="workspace-bar__hint">
+          no workspaces yet — create one to group your projects
+        </div>
+      ) : (
+        <ul className="workspace-bar__list">
+          {ordered.map((ws, index) => (
+            <WorkspaceRow
+              key={ws.id}
+              workspace={ws}
+              index={index}
+              count={ordered.length}
+              busy={pending}
+              onRename={(name) => handleRename(ws, name)}
+              onMoveUp={() => {
+                const prev = ordered[index - 1];
+                if (prev) handleSwap(ws, prev);
+              }}
+              onMoveDown={() => {
+                const next = ordered[index + 1];
+                if (next) handleSwap(ws, next);
+              }}
+              onDelete={() => handleDelete(ws)}
+            />
+          ))}
+        </ul>
+      )}
+
+      <div className="workspace-bar__create-row">
+        <input
+          type="text"
+          className="workspace-bar__input"
+          placeholder="new workspace name"
+          value={newName}
+          disabled={pending}
+          onChange={(e) => setNewName(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              handleCreate();
+            }
+          }}
+          aria-label="new workspace name"
+        />
+        <button
+          type="button"
+          className="workspace-bar__create-btn"
+          disabled={pending || newName.trim().length === 0}
+          onClick={handleCreate}
+        >
+          {createMutation.isPending ? 'adding…' : '+ add'}
+        </button>
+      </div>
+
+      {actionError ? (
+        <div className="workspace-bar__error" role="alert">
+          <span>{actionError}</span>
+          <button
+            type="button"
+            className="workspace-bar__retry"
+            onClick={() => {
+              clearError();
+              void refetch();
+            }}
+          >
+            retry
+          </button>
+        </div>
+      ) : isError ? (
+        <div className="workspace-bar__error" role="alert">
+          <span>could not load workspaces</span>
+          <button
+            type="button"
+            className="workspace-bar__retry"
+            onClick={() => void refetch()}
+          >
+            retry
+          </button>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export default WorkspaceBar;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -517,6 +517,72 @@ export async function fetchActiveWork(): Promise<WorkContextActiveGroup[]> {
   return Array.isArray(data.groups) ? data.groups : [];
 }
 
+// ── #728 IA Workspace bar (consumes the #733 CRUD API) ──────────────────────
+// The six-layer **Workspace** (a durable, user-authored grouping-of-Projects),
+// distinct from the legacy `config.workspaces` repo grouping (`Workspace` in
+// `types.ts`). Shape mirrors `shared/workspace.ts`: `projectIds` is an ordered
+// membership list of ProjectIds, NOT embedded projects. Backed by the IA store
+// (`ia.db`) and mounted at `/hub/ia/workspaces` — STRICTLY non-destructive of
+// any legacy state. Endpoints: GET (list), POST (create), PATCH (partial
+// rename/reorder/membership), DELETE.
+export interface IaWorkspace {
+  id: string;
+  name: string;
+  order: number;
+  projectIds: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+const IA_WORKSPACES_PATH = '/hub/ia/workspaces';
+
+export async function fetchIaWorkspaces(): Promise<IaWorkspace[]> {
+  const data = await json<{ workspaces?: IaWorkspace[] }>(
+    await fetch(IA_WORKSPACES_PATH)
+  );
+  return Array.isArray(data.workspaces) ? data.workspaces : [];
+}
+
+export async function createIaWorkspace(input: {
+  name: string;
+  projectIds?: string[];
+  order?: number;
+}): Promise<IaWorkspace> {
+  const data = await json<{ workspace: IaWorkspace }>(
+    await fetch(IA_WORKSPACES_PATH, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+  );
+  return data.workspace;
+}
+
+export async function updateIaWorkspace(
+  id: string,
+  patch: { name?: string; order?: number; projectIds?: string[] }
+): Promise<IaWorkspace> {
+  const data = await json<{ workspace: IaWorkspace }>(
+    await fetch(`${IA_WORKSPACES_PATH}/${encodeURIComponent(id)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(patch),
+    })
+  );
+  return data.workspace;
+}
+
+export async function deleteIaWorkspace(id: string): Promise<void> {
+  const res = await fetch(
+    `${IA_WORKSPACES_PATH}/${encodeURIComponent(id)}`,
+    { method: 'DELETE' }
+  );
+  // 204 No Content on success; surface a structured error otherwise.
+  if (!res.ok) {
+    throw await httpErrorFromResponse(res, 'Failed to delete workspace');
+  }
+}
+
 function normalizeTelemetryMapEntry(
   mapKey: string,
   raw: Record<string, unknown>

--- a/frontend/src/lib/hooks/use-ia-workspaces.ts
+++ b/frontend/src/lib/hooks/use-ia-workspaces.ts
@@ -1,0 +1,69 @@
+// #728: TanStack Query data layer for the IA Workspace bar. Wraps the #733
+// `/hub/ia/workspaces` CRUD client fns (`api.ts`) in a single `['ia-workspaces']`
+// query plus create/update/delete mutations that invalidate that key on success.
+//
+// Correctness-first: no optimistic cache writes. Each mutation simply
+// invalidates `['ia-workspaces']` so the list refetches authoritative state
+// from the store. Reorder, rename, and project-membership moves all funnel
+// through `updateIaWorkspace` (the API folds them into one PATCH).
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  createIaWorkspace,
+  deleteIaWorkspace,
+  fetchIaWorkspaces,
+  updateIaWorkspace,
+  type IaWorkspace,
+} from '../api.js';
+
+export const IA_WORKSPACES_QUERY_KEY = ['ia-workspaces'] as const;
+
+export function useIaWorkspacesQuery() {
+  return useQuery({
+    queryKey: IA_WORKSPACES_QUERY_KEY,
+    queryFn: fetchIaWorkspaces,
+    staleTime: 30_000,
+  });
+}
+
+/** Bundle of the IA Workspace query + its mutations. The mutations invalidate
+ *  the list on success so the UI re-reads authoritative store state. */
+export function useIaWorkspaces() {
+  const queryClient = useQueryClient();
+  const query = useIaWorkspacesQuery();
+
+  const invalidate = () =>
+    void queryClient.invalidateQueries({ queryKey: IA_WORKSPACES_QUERY_KEY });
+
+  const createMutation = useMutation({
+    mutationFn: (input: {
+      name: string;
+      projectIds?: string[];
+      order?: number;
+    }) => createIaWorkspace(input),
+    onSuccess: invalidate,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (args: {
+      id: string;
+      patch: { name?: string; order?: number; projectIds?: string[] };
+    }) => updateIaWorkspace(args.id, args.patch),
+    onSuccess: invalidate,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteIaWorkspace(id),
+    onSuccess: invalidate,
+  });
+
+  return {
+    workspaces: (query.data ?? []) as IaWorkspace[],
+    isLoading: query.isLoading,
+    isError: query.isError,
+    refetch: query.refetch,
+    createMutation,
+    updateMutation,
+    deleteMutation,
+  };
+}

--- a/frontend/src/lib/state/view-tree.ts
+++ b/frontend/src/lib/state/view-tree.ts
@@ -535,6 +535,90 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
   return { workspaces, ungroupedProjects, freeLane };
 }
 
+// ── #728: persisted Workspace grouping (grouping-of-Projects) ─────────────────
+// PURE projection of the persisted six-layer **Workspace** entities (#733 CRUD,
+// `shared/workspace.ts`) over the already-derived `ViewTreeProject[]`. This is
+// DISTINCT from the legacy `Workspace.repos[]` grouping above (which keys on
+// repo paths): persisted Workspaces carry an ordered `projectIds` membership of
+// ProjectIds (the SAME ids `buildViewTree` mints on `ViewTreeProject.id`).
+//
+// Membership rules (no I/O, no fetch):
+//   - Workspaces render in `order` asc, then id asc (stable, mirrors the store).
+//   - Within a workspace, projects render in the workspace's `projectIds` order;
+//     a projectId that no longer resolves to a derived project is skipped (the
+//     project may have gone offline / been removed — membership is non-binding).
+//   - A project may belong to AT MOST one workspace for render purposes; the
+//     FIRST workspace (by order) claiming it wins, so a stale duplicate id in a
+//     later workspace does not double-render the project.
+//   - Any derived project NOT claimed by a workspace falls back to `ungrouped`,
+//     sorted by label for determinism.
+
+/** A persisted-Workspace grouping of derived projects. Mirrors the shape the
+ *  legacy `ViewTreeWorkspaceGroup` uses so the renderer treats both uniformly. */
+export interface PersistedWorkspaceGroup {
+  id: WorkspaceId;
+  name: string;
+  order: number;
+  projects: ViewTreeProject[];
+}
+
+/** Minimal persisted-Workspace shape this projection needs (matches the #733
+ *  API / `shared/workspace.ts`). Kept structural so callers can pass the API
+ *  client's `IaWorkspace` without an import cycle. */
+export interface PersistedWorkspaceInput {
+  id: WorkspaceId;
+  name: string;
+  order: number;
+  projectIds: string[];
+}
+
+export interface GroupedByWorkspace {
+  workspaces: PersistedWorkspaceGroup[];
+  ungroupedProjects: ViewTreeProject[];
+}
+
+/**
+ * Group derived projects under their persisted Workspace membership. PURE:
+ * never mutates inputs, never fetches. Projects unclaimed by any workspace fall
+ * back to `ungroupedProjects` (sorted by label). See the membership rules above.
+ */
+export function groupProjectsByWorkspace(
+  projects: ViewTreeProject[],
+  persisted: PersistedWorkspaceInput[]
+): GroupedByWorkspace {
+  const projectsById = new Map<ProjectId, ViewTreeProject>(
+    projects.map((p) => [p.id, p])
+  );
+  const claimed = new Set<ProjectId>();
+
+  const workspaces: PersistedWorkspaceGroup[] = [...persisted]
+    .sort((a, b) => (a.order - b.order) || a.id.localeCompare(b.id))
+    .map((ws) => {
+      const seen = new Set<ProjectId>();
+      const grouped: ViewTreeProject[] = [];
+      // `projectIds` can be absent/malformed on a legacy/partial record — guard
+      // exactly like the legacy grouping path does for `repos`.
+      const ids = Array.isArray(ws.projectIds) ? ws.projectIds : [];
+      for (const rawId of ids) {
+        const id = rawId as ProjectId;
+        if (seen.has(id)) continue; // dedup within a workspace
+        const project = projectsById.get(id);
+        if (!project) continue; // membership references an unknown/absent project
+        if (claimed.has(id)) continue; // earlier workspace already owns it
+        seen.add(id);
+        claimed.add(id);
+        grouped.push(project);
+      }
+      return { id: ws.id, name: ws.name, order: ws.order, projects: grouped };
+    });
+
+  const ungroupedProjects = projects
+    .filter((p) => !claimed.has(p.id))
+    .sort((a, b) => a.label.localeCompare(b.label));
+
+  return { workspaces, ungroupedProjects };
+}
+
 // ── S2: Views lenses (#727) ───────────────────────────────────────────────────
 // Ad-hoc, ephemeral, PURE-FILTER lenses over the already-derived tree. No
 // persistence, no new fetch, no saved Views. `applyLens` is a pure function:

--- a/test/view-tree-workspace-grouping.test.ts
+++ b/test/view-tree-workspace-grouping.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  groupProjectsByWorkspace,
+  type PersistedWorkspaceInput,
+  type ViewTreeProject,
+} from '../frontend/src/lib/state/view-tree.js';
+
+// `groupProjectsByWorkspace` only reads `id` + `label` off a project; build a
+// minimal shape (cast through unknown) so the test stays focused on the pure
+// grouping logic, not the full derived-project anatomy.
+function project(id: string, label = id): ViewTreeProject {
+  return {
+    id,
+    label,
+    identity: { kind: 'directory', nodeId: 'local', localPath: `/p/${id}` },
+    kind: 'directory',
+    colorSeed: label,
+    instances: [],
+    lastActivity: null,
+  } as unknown as ViewTreeProject;
+}
+
+function ws(
+  id: string,
+  order: number,
+  projectIds: string[],
+  name = id
+): PersistedWorkspaceInput {
+  return { id, name, order, projectIds };
+}
+
+describe('groupProjectsByWorkspace (#728)', () => {
+  it('returns all projects ungrouped when there are no workspaces', () => {
+    const projects = [project('b'), project('a')];
+    const result = groupProjectsByWorkspace(projects, []);
+    expect(result.workspaces).toEqual([]);
+    // Ungrouped is sorted by label for determinism.
+    expect(result.ungroupedProjects.map((p) => p.id)).toEqual(['a', 'b']);
+  });
+
+  it('groups assigned projects and leaves unassigned ones ungrouped', () => {
+    const projects = [project('a'), project('b'), project('c')];
+    const result = groupProjectsByWorkspace(projects, [ws('w1', 0, ['a', 'c'])]);
+    expect(result.workspaces).toHaveLength(1);
+    expect(result.workspaces[0]!.projects.map((p) => p.id)).toEqual(['a', 'c']);
+    expect(result.ungroupedProjects.map((p) => p.id)).toEqual(['b']);
+  });
+
+  it('renders projects in the membership order, not project order', () => {
+    const projects = [project('a'), project('b'), project('c')];
+    const result = groupProjectsByWorkspace(projects, [
+      ws('w1', 0, ['c', 'a', 'b']),
+    ]);
+    expect(result.workspaces[0]!.projects.map((p) => p.id)).toEqual([
+      'c',
+      'a',
+      'b',
+    ]);
+    expect(result.ungroupedProjects).toEqual([]);
+  });
+
+  it('orders workspaces by order asc then id, regardless of input order', () => {
+    const projects = [project('a'), project('b')];
+    const result = groupProjectsByWorkspace(projects, [
+      ws('later', 5, ['b']),
+      ws('first', 1, ['a']),
+    ]);
+    expect(result.workspaces.map((w) => w.id)).toEqual(['first', 'later']);
+  });
+
+  it('breaks order ties by id ascending', () => {
+    const result = groupProjectsByWorkspace(
+      [project('a'), project('b')],
+      [ws('beta', 0, ['b']), ws('alpha', 0, ['a'])]
+    );
+    expect(result.workspaces.map((w) => w.id)).toEqual(['alpha', 'beta']);
+  });
+
+  it('skips membership ids that do not resolve to a derived project', () => {
+    const projects = [project('a')];
+    const result = groupProjectsByWorkspace(projects, [
+      ws('w1', 0, ['a', 'ghost']),
+    ]);
+    expect(result.workspaces[0]!.projects.map((p) => p.id)).toEqual(['a']);
+    expect(result.ungroupedProjects).toEqual([]);
+  });
+
+  it('claims a project for the FIRST workspace (by order) when duplicated', () => {
+    const projects = [project('a')];
+    const result = groupProjectsByWorkspace(projects, [
+      ws('w2', 1, ['a']),
+      ws('w1', 0, ['a']),
+    ]);
+    // w1 (order 0) wins; w2 renders empty.
+    expect(result.workspaces[0]!.id).toBe('w1');
+    expect(result.workspaces[0]!.projects.map((p) => p.id)).toEqual(['a']);
+    expect(result.workspaces[1]!.id).toBe('w2');
+    expect(result.workspaces[1]!.projects).toEqual([]);
+    expect(result.ungroupedProjects).toEqual([]);
+  });
+
+  it('dedups a repeated project id within a single workspace', () => {
+    const projects = [project('a')];
+    const result = groupProjectsByWorkspace(projects, [
+      ws('w1', 0, ['a', 'a']),
+    ]);
+    expect(result.workspaces[0]!.projects.map((p) => p.id)).toEqual(['a']);
+  });
+
+  it('tolerates a workspace with a missing/non-array projectIds', () => {
+    const projects = [project('a')];
+    const malformed = {
+      id: 'w1',
+      name: 'w1',
+      order: 0,
+    } as unknown as PersistedWorkspaceInput;
+    const result = groupProjectsByWorkspace(projects, [malformed]);
+    expect(result.workspaces[0]!.projects).toEqual([]);
+    expect(result.ungroupedProjects.map((p) => p.id)).toEqual(['a']);
+  });
+
+  it('preserves projects that are not referenced by any workspace', () => {
+    const projects = [project('a'), project('b'), project('c')];
+    const result = groupProjectsByWorkspace(projects, [
+      ws('w1', 0, ['b']),
+      ws('w2', 1, []),
+    ]);
+    expect(result.workspaces[0]!.projects.map((p) => p.id)).toEqual(['b']);
+    expect(result.workspaces[1]!.projects).toEqual([]);
+    expect(result.ungroupedProjects.map((p) => p.id)).toEqual(['a', 'c']);
+  });
+});


### PR DESCRIPTION
## What shipped

Adds the six-layer **Workspace** layer (a durable, user-authored grouping-of-Projects) to the view-spine sidebar, behind the existing `view-spine` flag (**default OFF**). Distinct from the legacy `config.workspaces` repo grouping.

- **`api.ts`** — `IaWorkspace` type + typed client fns: `fetchIaWorkspaces`, `createIaWorkspace`, `updateIaWorkspace`, `deleteIaWorkspace`.
- **`lib/hooks/use-ia-workspaces.ts`** — `['ia-workspaces']` TanStack Query + create/update/delete mutations that invalidate the list on success. Correctness-first (no optimistic cache writes); reorder/rename/membership-move all funnel through the single PATCH.
- **`lib/state/view-tree.ts`** — pure `groupProjectsByWorkspace(projects, persisted)`: overlays persisted `projectIds` membership on derived projects. First-claimant-by-order wins, dedups within a workspace, skips unresolved ids, falls back to `ungrouped` (label-sorted), tolerates malformed `projectIds`. Unit-tested (10 cases).
- **`WorkspaceBar.tsx` / `.css`** — list persisted Workspaces, **create** (name), **rename** (inline edit), **reorder** (up/down — lowest-risk; no DnD dep in the sidebar), **delete**. Reuses existing design tokens; no new visual language.
- **`ViewSpineTree.tsx`** — renders projects grouped under their assigned persisted Workspace with a per-project "move to workspace" `<select>` (PATCHes membership). Legacy `workspaceGroups` grouping is collapsed away for render only — **NOT migrated** into persisted Workspaces (#736 is out of scope).

## API consumed (#733)

`/hub/ia/workspaces`: `GET` (list), `POST {name, projectIds?, order?}` (create), `PATCH /:id {name?, order?, projectIds?}` (rename/reorder/membership), `DELETE /:id`. Membership replaced wholesale per the #733 contract.

## States covered

- **Empty** (no workspaces) → neutral copy + create affordance.
- **Loading** → "loading workspaces…" hint; bar still renders so create is always available.
- **Error** (failed mutation/load) → non-destructive inline message + retry (refetch); never discards data.
- **In-flight** → controls disabled while any mutation is pending.
- Touch targets ≥44px on icon buttons; keyboard support (Enter to create/commit rename, Escape to cancel).

## Tests / gates (Node 24)

- `npm run check` → **0 errors** (pre-existing sonarjs warnings only; none in new files).
- `npm run build` → **clean**.
- `npm test` → **291 files / 3757 tests pass**, including 10 new `groupProjectsByWorkspace` cases.

## Stacking

Stacked on **#737 (#748)** + **#733 (#749)** — merges after both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace management functionality allowing users to create, rename, reorder, and delete workspaces for organizing projects.
  * Added project assignment control enabling users to move individual projects between workspaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/751?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->