### PR TITLE
docs(#764): ADR-019 — context-packet storage + primitive (decision gate)

### DIFF
--- a/docs/adrs/ADR-019-context-packet-storage-and-primitive.md
+++ b/docs/adrs/ADR-019-context-packet-storage-and-primitive.md
@@ -1,0 +1,270 @@
+# ADR-019: Context-packet storage and primitive
+
+- **Status:** Accepted
+- **Date:** 2026-05-27
+- **Refs:** #764 (decision gate), #757 (epic), #758, #765, #766, #763, #761, #616, #470, #493, #552, ADR-015, ADR-017, ADR-018
+- **Supersedes:** none
+
+> Numbering note: issue #764's body calls this "ADR-018". ADR-018 is already
+> taken (`ADR-018-command-mediated-handoff-supervisor.md`, accepted 2026-05-25).
+> This decision is **ADR-019**; the issue text is a stale label.
+
+## Context
+
+Epic #757 introduces a CLI/API-first primitive for attaching precise context —
+file ranges, diff hunks, terminal ranges, markdown blocks, freeform notes — and
+routing it into running agent sessions or durable WorkContexts. The product
+principle is that the CLI/API contract is the source of truth and the web UI
+(#762) is a thin client over the same verbs; an agent must be able to create,
+inspect, deliver, acknowledge, pin, and resolve context headlessly.
+
+The planning cycle's child issues under-specified two forks. This ADR is the
+decision gate (#764) that ratifies both so the parallel implementation lanes
+build against a fixed contract: **#758** (model + store), **#765** (CLI verbs +
+capability bits), **#766** (anchor resolution).
+
+### Fork 1 — where do context packets + inbox messages live?
+
+Children #758/#759 specified workspace-local `.relay/*.json` / `.jsonl` files.
+Grounding that against the code:
+
+- **No `.relay/` directory exists anywhere in the repo today.** The only
+  durable structured stores are SQLite-behind-gateway: `work-contexts.db` via
+  `server/work-contexts.ts`, and the IA store landed in #748.
+- The WorkContext store already demonstrates the full pattern this feature
+  needs: a `schema_version` table with a guarded migration
+  (`server/work-contexts.ts:310-329`), `create/get/list/update`
+  (lines 418-449), an `update()` that accepts an `artifacts[]` patch
+  (the `WorkContextPatchInput` `Pick`, lines 151-165), and HTTP routes mounted
+  via `createWorkContextRouter` (lines 582-745).
+- "Agents inspect the workspace representation" is already satisfied by a CLI
+  gateway **read verb** returning JSON — the same pull model agents use for
+  `work-contexts.get` (ADR-018 command table). Files do not federate across
+  nodes; the hub does. Delivery addressing is already
+  `GlobalSessionId = nodeId:localSessionId` (`shared/identity.ts:46-51`), not a
+  filesystem path.
+
+### Fork 2 — extend `PromptAttachment` or fork a new `ContextAttachment`?
+
+`shared/prompt-attachment.ts` is an **intentionally open** discriminated union
+(line 22, with `'diff-ref'`/`'log-ref'` reserved in the header comment) and
+already ships the bridge to WorkContext: `promptAttachmentToArtifactRef`
+(lines 136-172), which special-cases on `kind`.
+
+`shared/file-resource-ref.ts` already carries
+`nodeId/path/sha256/mtimeMs/size/repoBinding/capturedAt/intent`. Critically,
+`fileResourceRefEquals` (lines 201-214) **excludes `sha256`/`mtimeMs`/
+`capturedAt` from identity** — identity is location `(nodeId, path, intent,
+maxBytes, repoBinding)`, freshness is the excluded decorations. That is exactly
+the split anchor resolution (#766) needs: identity = "same anchor location",
+freshness = "did the content drift". A forked `ContextAttachment` would
+re-derive ~70% of `PromptAttachment` + `FileResourceRef` (the file pointer,
+the ref-only privacy posture, the artifact bridge, the equality semantics) and
+then have to re-implement the freshness primitive that already exists.
+
+The only genuine delta #757 needs is the **anchor**: a line/byte range + a
+captured quote, which `FileResourceRef` does not carry.
+
+## Decision
+
+### D1 — Storage: SQLite-behind-gateway, no workspace files for MVP
+
+Context packets and session inbox messages are stored in **SQLite behind the
+hub gateway**, reusing the `server/work-contexts.ts` store pattern
+(`schema_version` migration, `create/get/list/update`, HTTP router). The CLI
+gateway read verbs (`context.list` / `inbox.list`, #765) return JSON over the
+same pull model as `work-contexts.get`.
+
+**No `.relay/*.json` workspace files are the write path for MVP.** Files do not
+federate across nodes, the hub does, and delivery is already addressed by
+`GlobalSessionId`. An optional, derived, **read-only**
+`.relay/context/<id>.json` projection MAY be added later as a convenience
+mirror for local tooling — it is explicitly a future, never the source of
+truth, and never the write path. The store is canonical; any projection is
+regenerated from it.
+
+### D2 — Primitive: extend `PromptAttachment`, introduce `AnchorRef` + `ContextPacket`
+
+We **extend** the open `PromptAttachment` union and do **not** fork a parallel
+`ContextAttachment`. Concretely (sketched in `shared/context-packet.ts`):
+
+- **`AnchorRef`** composes a `FileResourceRef` + a range (`LineRange` and/or
+  `ByteRange`) + a bounded captured `quote`. This is the only net-new shape
+  the file primitive needs; everything else (location identity, freshness
+  decorations, repo binding, ref-only privacy) is reused from
+  `FileResourceRef`.
+- **`ContextPacket`** is the durable, **reusable** envelope: stable `id`,
+  `kind`, an `AnchorRef` (anchored kinds) or `fileRef`/`note` (freeform),
+  optional IA/workbench `binding` (workspace/node/repoInstance/worktreeInstance
+  ids), `createdBy`/`createdAt`. It is **lifecycle-independent** — one packet
+  can be delivered to many sessions and pinned to many WorkContexts (#763).
+- The file-range case slots into `PromptAttachment` as a **new sibling kind
+  `'file-anchor'`** (not a `range?` field on the existing `'file-ref'` path),
+  so whole-file and ranged attachments stay distinct identities and
+  `parsePromptAttachment` validates the range only for the new kind. The
+  `promptAttachmentToArtifactRef` bridge extends along its existing `kind`
+  switch for the #763 pin path. No `ContextAttachment` type is introduced.
+
+### D3 — Lifecycle (lives on the inbox message, not the packet)
+
+```
+queued → delivered → acknowledged → (resolved | ignored)
+```
+
+- **`queued`** — created, not yet fetched.
+- **`delivered` (= fetched)** — **PULL only**: the consumer fetched it via
+  `inbox.list` / agent `preturn` (#761). Relay **never pushes** context through
+  `sessions.input` or raw PTY bytes. This is consistent with ADR-018: raw input
+  is a narrow PTY smoke primitive, not a blessed agent-to-agent API.
+- **`acknowledged`** — consumer explicitly acked receipt.
+- **`resolved` / `ignored`** — terminal.
+
+**`stale` is NOT a lifecycle state.** It is **derived** from the referenced
+packet's `AnchorState` at render/resolution time, never stored as a manual
+transition. `AnchorState = 'unchanged' | 'stale' | 'missing'` is computed by
+the #766 resolver from `fileResourceRefEquals` (identity) + sha256/mtime
+comparison (freshness). `'shifted'` (range moved but quote relocatable) is
+**explicitly deferred** — until then a moved range surfaces as `stale`.
+
+### D4 — Environment contract
+
+The shipped env var is **`RELAY_WORK_CONTEXT_ID`**, set by
+`injectRelaySessionEnv` in `server/pty-handler.ts:676-677` (both process env and
+tmux env). #761's proposed `RELAY_WORKCONTEXT_ID` (no underscore between WORK
+and CONTEXT) is **wrong** and must align to the shipped name. Agent context
+`preturn` keys off the session's bound `GlobalSessionId` and, when present,
+`RELAY_WORK_CONTEXT_ID`.
+
+### D5 — Capability bits
+
+Four new bits, added to `RELAY_CAPABILITY_BITS` in `shared/security-policy.ts`:
+
+| Bit | Tier placement |
+| --- | --- |
+| `context:read` | default-allow (add to `LEGACY_DEFAULT_ALLOWED_CAPABILITIES`) |
+| `inbox:read` | default-allow (add to `LEGACY_DEFAULT_ALLOWED_CAPABILITIES`) |
+| `context:write` | dev-allow; **NOT** in `HIGH_RISK_CAPABILITIES` |
+| `inbox:write` | dev-allow; **NOT** in `HIGH_RISK_CAPABILITIES` |
+
+Rationale grounded in the policy module: the trust-tier overlay
+(`applyTrustTierOverlay`, `shared/security-policy.ts:190-217`) silently allows
+any granted bit on `dev`/`sandbox` tiers, and only promotes a bit to
+`requiresConfirmation` on the `prod` tier if it is in
+`HIGH_RISK_CAPABILITY_SET`. Reads (`context:read`/`inbox:read`) go in
+`LEGACY_DEFAULT_ALLOWED_CAPABILITIES` (lines 38-55), so they are silent-allow by
+default like `session:read`/`rpc:fs:read`. Writes are ref-only context inserts —
+no raw payload, no file mutation, no PTY exec — so they do **not** belong in
+`HIGH_RISK_CAPABILITIES` (lines 57-66, which is reserved for
+kill/intervention-send/intervention-submit/fs-write/fs-delete/git-write/pty-exec/
+port-forward). They remain grant-gated (an ungranted bit is `deny`) and a `prod`
+operator can still revoke per-node by editing the ACL, but they are not promoted
+to a confirmation challenge on prod.
+
+## Storage schema
+
+Mirrors the `server/work-contexts.ts` column style (TEXT ids, `*_json` blob for
+the typed envelope, ISO-8601 `created_at`/`updated_at`, `schema_version` table
+with the same guarded migration at lines 310-329). Real DDL lands in #758; this
+is the ratified shape.
+
+```sql
+-- schema_version table identical to work-contexts.db (single-row INTEGER).
+
+CREATE TABLE IF NOT EXISTS context_packets (
+  id           TEXT PRIMARY KEY,         -- cp:<suffix>
+  kind         TEXT NOT NULL,            -- file-anchor | file-ref | diff-ref | log-ref | note
+  packet_json  TEXT NOT NULL,            -- canonical ContextPacket (ref-only; no raw bytes)
+  node_id      TEXT,                     -- denormalized from binding for federation queries
+  workspace_id TEXT,                     -- denormalized from binding
+  created_by   TEXT NOT NULL,
+  created_at   TEXT NOT NULL,
+  updated_at   TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_context_packets_created_at
+  ON context_packets(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_context_packets_node
+  ON context_packets(node_id);
+
+CREATE TABLE IF NOT EXISTS inbox_messages (
+  id                     TEXT PRIMARY KEY,   -- im:<suffix>
+  target_session_id      TEXT,               -- GlobalSessionId (nodeId:localSessionId)
+  target_work_context_id TEXT,               -- WorkContextId (handoff/pin path)
+  message_json           TEXT NOT NULL,      -- canonical SessionInboxMessage
+  state                  TEXT NOT NULL,      -- queued|delivered|acknowledged|resolved|ignored
+  created_by             TEXT NOT NULL,
+  created_at             TEXT NOT NULL,
+  delivered_at           TEXT,
+  acknowledged_at        TEXT,
+  resolved_at            TEXT,
+  updated_at             TEXT NOT NULL,
+  CHECK (target_session_id IS NOT NULL OR target_work_context_id IS NOT NULL)
+);
+CREATE INDEX IF NOT EXISTS idx_inbox_messages_session
+  ON inbox_messages(target_session_id, state);
+CREATE INDEX IF NOT EXISTS idx_inbox_messages_work_context
+  ON inbox_messages(target_work_context_id, state);
+
+-- Many-to-many: a packet is reusable across messages; a message carries many.
+CREATE TABLE IF NOT EXISTS inbox_message_packets (
+  message_id        TEXT NOT NULL,
+  context_packet_id TEXT NOT NULL,
+  ordinal           INTEGER NOT NULL,    -- preserve attachment order
+  PRIMARY KEY (message_id, context_packet_id),
+  FOREIGN KEY (message_id) REFERENCES inbox_messages(id) ON DELETE CASCADE,
+  FOREIGN KEY (context_packet_id) REFERENCES context_packets(id) ON DELETE RESTRICT
+);
+CREATE INDEX IF NOT EXISTS idx_inbox_message_packets_packet
+  ON inbox_message_packets(context_packet_id);
+```
+
+Notes:
+
+- `packet_json` / `message_json` hold the canonical typed envelope (same
+  blob-plus-denormalized-columns approach as `work_contexts.context_json`). No
+  `AnchorState` is stored — it is derived at read time by #766.
+- `ON DELETE RESTRICT` on the join's packet FK enforces packet reuse: a packet
+  referenced by a live message cannot be deleted out from under it.
+- No `stale`/`shifted` columns — staleness is never persisted.
+
+## Consequences
+
+- All three impl lanes share one contract: #758 implements the store +
+  `parse`/`create` against `shared/context-packet.ts`; #765 adds the four
+  capability bits + `context.*`/`inbox.*` CLI verbs to
+  `shared/cli-gateway-contract.ts` and the manifest; #766 implements
+  `resolveAnchorState` on top of `fileResourceRefEquals`.
+- Reusing the WorkContext store pattern means context packets inherit the same
+  ref-only/no-raw-payload privacy discipline and federate through the hub
+  exactly like work contexts and active-work read models.
+- The deferred `.relay/` projection and `'shifted'` anchor state are named
+  non-goals, so follow-on issues do not re-litigate them as gaps.
+- #761 must rename its env var to the shipped `RELAY_WORK_CONTEXT_ID`.
+
+## Alternatives considered
+
+- **`.relay/*.json` / `.jsonl` workspace files (as originally specced in
+  #758/#759).** Rejected for MVP: no `.relay/` exists today, files do not
+  federate across nodes (the hub does), and there is no existing file-watch /
+  reconciliation machinery — adopting it would be net-new infrastructure that
+  contradicts the hub-mediated, `GlobalSessionId`-addressed delivery model.
+  Retained as a deferred read-only projection only.
+- **Fork a parallel `ContextAttachment` union.** Rejected: ~70% overlap with
+  `PromptAttachment` + `FileResourceRef` (file pointer, ref-only privacy,
+  artifact bridge, equality), and it would have to re-implement the
+  anchor-freshness primitive that `fileResourceRefEquals` already provides.
+  Extending the open union is the smaller, lower-risk change.
+- **Thread `range?` onto the existing `PromptAttachmentFileRef`.** Rejected in
+  favor of a sibling `'file-anchor'` kind: keeps whole-file vs ranged
+  attachments as distinct identities, avoids weakening the existing `file-ref`
+  parser, and matches the discriminant-switch extension style of
+  `createPromptAttachment` / `promptAttachmentToArtifactRef`.
+- **Store `AnchorState` (`stale`) as a lifecycle column.** Rejected: staleness
+  is a pure function of current file contents vs the captured ref; persisting
+  it would immediately drift and require invalidation on every file change.
+  Derive at render time instead.
+- **Promote `context:write`/`inbox:write` into `HIGH_RISK_CAPABILITIES`.**
+  Rejected: writes are ref-only metadata inserts with no raw payload, file
+  mutation, or exec; high-risk is reserved for kill/intervention/fs-write/
+  fs-delete/git-write/pty-exec/port-forward. They stay grant-gated but not
+  confirmation-gated on prod.
+```

--- a/shared/context-packet.ts
+++ b/shared/context-packet.ts
@@ -1,0 +1,385 @@
+// #764 / Epic #757: CLI-first anchored context packets + session inbox.
+//
+// TYPE SKETCHES ONLY. This module is the ratified contract from ADR-019
+// (`docs/adrs/ADR-019-context-packet-storage-and-primitive.md`). It defines
+// the shared shapes the parallel implementation lanes build against:
+//   - #758 — model + SQLite-behind-gateway store (the real `create`/`parse`/
+//            store/route logic lands here; the stubs below are signatures only)
+//   - #765 — CLI gateway verbs + capability bits
+//   - #766 — anchor resolution (`resolveAnchorState`)
+//
+// Design rules this file obeys (see ADR-019 §Decision):
+//   1. `ContextPacket` is the durable, REUSABLE envelope. It carries no
+//      lifecycle state — lifecycle lives on `SessionInboxMessage`, so one
+//      packet can be delivered to many sessions/WorkContexts independently.
+//   2. The anchored-file primitive REUSES `FileResourceRef` for location
+//      identity and freshness decorations. `AnchorRef` only adds the delta
+//      #757 needs: a line/byte range + a captured quote snapshot. Anchor
+//      freshness derives from `fileResourceRefEquals` (which excludes
+//      sha256/mtime/capturedAt from identity) — see `resolveAnchorState`.
+//   3. `AnchorState` is DERIVED at render/resolution time, never stored as a
+//      manual lifecycle field. `'shifted'` is explicitly deferred.
+//
+// This module is browser-safe: it imports no `node:*` builtins, mirroring
+// `shared/file-resource-ref.ts` and `shared/prompt-attachment.ts` so the web
+// UI (#762) can consume the same shapes. Id minting therefore takes a
+// caller-supplied opaque suffix (the server owns the randomness), matching the
+// `createWorkspaceId(localId)` convention in `shared/workspace.ts`.
+
+import type {
+  GlobalSessionId,
+  NodeId,
+  RepoInstanceId,
+  WorktreeInstanceId,
+} from './identity.js';
+import type { WorkspaceId } from './workspace.js';
+import type { WorkContextId } from './work-context.js';
+import {
+  fileResourceRefEquals,
+  type FileResourceRef,
+} from './file-resource-ref.js';
+import type { PromptAttachment } from './prompt-attachment.js';
+
+// ---------------------------------------------------------------------------
+// Identifiers
+// ---------------------------------------------------------------------------
+
+/** Stable id for a `ContextPacket`. Format: `cp:<suffix>` (see helper). */
+export type ContextPacketId = string;
+
+/** Stable id for a `SessionInboxMessage`. Format: `im:<suffix>`. */
+export type SessionInboxMessageId = string;
+
+export const CONTEXT_PACKET_ID_PREFIX = 'cp:' as const;
+export const SESSION_INBOX_MESSAGE_ID_PREFIX = 'im:' as const;
+
+// ---------------------------------------------------------------------------
+// Anchor primitive
+// ---------------------------------------------------------------------------
+
+/**
+ * A 1-based, inclusive line range inside a file. `endLine >= startLine`.
+ * Used for human-meaningful selections (the common UI case).
+ */
+export interface LineRange {
+  /** 1-based inclusive first line. */
+  startLine: number;
+  /** 1-based inclusive last line (>= `startLine`). */
+  endLine: number;
+}
+
+/**
+ * A byte range inside a file: `[startByte, endByte)` — start inclusive, end
+ * exclusive, 0-based. Used for binary/exact selections and terminal ranges
+ * where line semantics do not apply. Either or both range kinds may be set;
+ * at least one is required for an anchored packet.
+ */
+export interface ByteRange {
+  /** 0-based inclusive first byte. */
+  startByte: number;
+  /** 0-based exclusive end byte (> `startByte`). */
+  endByte: number;
+}
+
+/**
+ * Resolution state of an anchor against the file's current contents.
+ *
+ *   - `unchanged` — the underlying file resource identity matches (per
+ *     `fileResourceRefEquals`) AND the freshness decorations (sha256/mtime)
+ *     still match what was captured. The anchored range is trustworthy.
+ *   - `stale`     — the file resource still resolves to the same location,
+ *     but its content changed since capture (sha256/mtime drift). The range
+ *     may no longer point at the captured `quote`.
+ *   - `missing`   — the file resource no longer resolves (path/node/binding
+ *     identity mismatch, or the file is gone).
+ *
+ * `'shifted'` (range moved but quote still present at a new offset) is
+ * explicitly DEFERRED — it requires content diffing the resolver (#766) does
+ * not do in MVP. Until then a moved range surfaces as `stale`.
+ *
+ * This state is ALWAYS derived at resolution/render time. It is never a
+ * stored field on `ContextPacket` or `SessionInboxMessage`.
+ */
+export type AnchorState = 'unchanged' | 'stale' | 'missing';
+
+/**
+ * `AnchorRef` composes a `FileResourceRef` (location identity + freshness
+ * decorations) with a range and a bounded captured quote snapshot. It is the
+ * delta #757 needs on top of `FileResourceRef`, which carries nodeId/path/
+ * sha256/mtimeMs/size/repoBinding but no range.
+ *
+ * Identity = the underlying `FileResourceRef` identity (`fileResourceRefEquals`
+ * excludes sha256/mtime/capturedAt) + the range. Freshness = the excluded
+ * decorations, compared by the resolver to compute `AnchorState`.
+ */
+export interface AnchorRef {
+  /** Location handle on a (possibly remote) node. Identity carrier. */
+  ref: FileResourceRef;
+  /** Line range (1-based inclusive). Set for line-oriented selections. */
+  lineRange?: LineRange;
+  /** Byte range (0-based, half-open). Set for exact/binary/terminal ranges. */
+  byteRange?: ByteRange;
+  /**
+   * Snapshot of the selected text at capture time, bounded by
+   * `MAX_ANCHOR_QUOTE_BYTES`. Advisory only — used to render the chip and to
+   * let a future `'shifted'` resolver relocate the range. Never authoritative
+   * for access; the resolver re-reads through the node RPC under capability.
+   */
+  quote?: string;
+}
+
+/** Max captured `AnchorRef.quote` length in bytes. Resolver/store truncate. */
+export const MAX_ANCHOR_QUOTE_BYTES = 4096;
+
+// ---------------------------------------------------------------------------
+// Context packet envelope
+// ---------------------------------------------------------------------------
+
+/**
+ * The kind of context a packet carries. Mirrors (and is a superset of) the
+ * `PromptAttachment` open union surface:
+ *   - `file-anchor`   — an `AnchorRef` (file range + quote). The headline kind.
+ *   - `file-ref`      — a whole-file `FileResourceRef` with no range (bridges
+ *                       directly to an existing `PromptAttachment` kind).
+ *   - `diff-ref` / `log-ref` — reserved; align with the `PromptAttachment`
+ *                       reservations in `shared/prompt-attachment.ts`. Anchor
+ *                       support for these is deferred (#760).
+ *   - `note`          — freeform text only; no anchor (the `note` field holds
+ *                       the body).
+ */
+export type ContextPacketKind =
+  | 'file-anchor'
+  | 'file-ref'
+  | 'diff-ref'
+  | 'log-ref'
+  | 'note';
+
+export const CONTEXT_PACKET_KINDS: readonly ContextPacketKind[] = [
+  'file-anchor',
+  'file-ref',
+  'diff-ref',
+  'log-ref',
+  'note',
+] as const;
+
+/**
+ * Optional binding placing the packet in the six-layer IA tree + workbench
+ * identity. All fields optional: a freeform `note` packet may carry none, an
+ * anchored packet typically carries `nodeId` (it is already on the `AnchorRef`'s
+ * `FileResourceRef`) plus repo/worktree instance ids when known.
+ */
+export interface ContextPacketBinding {
+  workspaceId?: WorkspaceId;
+  nodeId?: NodeId;
+  repoInstanceId?: RepoInstanceId;
+  worktreeInstanceId?: WorktreeInstanceId;
+}
+
+/**
+ * `ContextPacket` is the durable, reusable envelope. It is
+ * LIFECYCLE-INDEPENDENT: the same packet id can be referenced by many
+ * `SessionInboxMessage`s and pinned to many WorkContexts (#763). Delivery and
+ * acknowledgement state never live here.
+ *
+ * Stored ref-only (per ADR-019 + the WorkContext privacy model): the packet
+ * carries pointers + a bounded `quote`/`note`, not raw file bytes.
+ */
+export interface ContextPacket {
+  /** Stable id (`cp:<suffix>`). Caller-owned; server mints the suffix. */
+  id: ContextPacketId;
+  kind: ContextPacketKind;
+  /** Set for `file-anchor`. Omitted for `file-ref`/`note`/reserved kinds. */
+  anchor?: AnchorRef;
+  /** Set for `file-ref`: whole-file pointer with no range. */
+  fileRef?: FileResourceRef;
+  /** Freeform body. Required for `note`; optional annotation otherwise. */
+  note?: string;
+  /** IA/workbench placement. */
+  binding?: ContextPacketBinding;
+  /** Actor id that created the packet (human user id, agent id, etc.). */
+  createdBy: string;
+  /** ISO 8601 UTC mint timestamp. */
+  createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Session inbox message (lifecycle lives here)
+// ---------------------------------------------------------------------------
+
+/**
+ * Lifecycle of an inbox message.
+ *
+ *   queued → delivered → acknowledged → (resolved | ignored)
+ *
+ *   - `queued`       — created, not yet fetched by the target consumer.
+ *   - `delivered`    — the consumer PULLED it (via `inbox.list` / agent
+ *     preturn). Delivery is a PULL: "delivered" == "fetched". Relay never
+ *     pushes packets through `sessions.input`/raw PTY bytes (ADR-019, ADR-018).
+ *   - `acknowledged` — the consumer explicitly acked receipt.
+ *   - `resolved`     — terminal: the context was acted on/addressed.
+ *   - `ignored`      — terminal: the consumer dismissed it.
+ *
+ * NOTE: `stale` is NOT a message lifecycle state. Staleness is a DERIVED
+ * property of each referenced packet's `AnchorState` (see `resolveAnchorState`),
+ * surfaced at render time — never a stored manual transition.
+ */
+export type SessionInboxMessageState =
+  | 'queued'
+  | 'delivered'
+  | 'acknowledged'
+  | 'resolved'
+  | 'ignored';
+
+export const SESSION_INBOX_MESSAGE_STATES: readonly SessionInboxMessageState[] =
+  ['queued', 'delivered', 'acknowledged', 'resolved', 'ignored'] as const;
+
+/** Terminal states — no further transitions allowed. */
+export const TERMINAL_INBOX_MESSAGE_STATES: readonly SessionInboxMessageState[] =
+  ['resolved', 'ignored'] as const;
+
+/**
+ * A message in a session/WorkContext inbox. Targets exactly one of a live
+ * session (`GlobalSessionId = nodeId:localSessionId`) or a durable
+ * `WorkContextId` (for handoff/pinning, #763) — at least one is required.
+ * References packets by id so packet bodies stay reusable + deduped.
+ */
+export interface SessionInboxMessage {
+  /** Stable id (`im:<suffix>`). */
+  id: SessionInboxMessageId;
+  /** Target live session, if addressed to a running session. */
+  targetSessionId?: GlobalSessionId;
+  /** Target WorkContext, if addressed durably (handoff/pin). */
+  targetWorkContextId?: WorkContextId;
+  /** Packets this message carries (by id; bodies live in the packet store). */
+  contextPacketIds: ContextPacketId[];
+  /** Optional human/agent-authored message body. */
+  text?: string;
+  /** Current lifecycle state (see `SessionInboxMessageState`). */
+  state: SessionInboxMessageState;
+  /** Actor id that sent the message. */
+  createdBy: string;
+  /** ISO 8601 UTC timestamps for each observed transition. */
+  createdAt: string;
+  deliveredAt?: string;
+  acknowledgedAt?: string;
+  resolvedAt?: string;
+  ignoredAt?: string;
+}
+
+// ---------------------------------------------------------------------------
+// PromptAttachment bridge
+// ---------------------------------------------------------------------------
+//
+// ADR-019 decision: EXTEND the open `PromptAttachment` union; do NOT fork a
+// parallel `ContextAttachment`. The file-range case slots in as a NEW SIBLING
+// kind `'file-anchor'` rather than threading a `range?` onto the existing
+// `'file-ref'` path, because:
+//   - it keeps `PromptAttachmentFileRef` identity-equality clean (a whole-file
+//     ref and a ranged ref are different attachments, not the same one with an
+//     optional field);
+//   - `parsePromptAttachment` can validate the range up front for the new kind
+//     without weakening the existing `file-ref` parser;
+//   - `promptAttachmentToArtifactRef` already special-cases on `kind`, so a new
+//     kind is the natural extension point for the #763 pin path.
+//
+// The new kind to add to `shared/prompt-attachment.ts` in #758 (sketch):
+//
+//   export interface PromptAttachmentFileAnchor {
+//     kind: 'file-anchor';
+//     anchor: AnchorRef;      // from this module
+//     summary?: string;
+//   }
+//   export type PromptAttachment =
+//     | PromptAttachmentFileRef
+//     | PromptAttachmentFileAnchor;   // ← extend the union here
+//
+// `PROMPT_ATTACHMENT_KINDS`, `CreatePromptAttachmentArgs`, the
+// `createPromptAttachment`/`parsePromptAttachment` switches, and
+// `promptAttachmentToArtifactRef` (kind === 'file-anchor' → ArtifactKind
+// 'file' with `path` + range in the summary) all extend along the existing
+// `kind` discriminant. No `ContextAttachment` type is introduced.
+
+/**
+ * Project a `ContextPacket` onto a `PromptAttachment` for inclusion in an
+ * outgoing prompt. `file-anchor` → the new `'file-anchor'` attachment kind;
+ * `file-ref` → the existing `'file-ref'` kind; `note` → not attachable
+ * (returns null — notes ride the message `text`, not the attachment list).
+ *
+ * Signature only — impl in #758 once the union extension lands.
+ */
+export declare function contextPacketToPromptAttachment(
+  packet: ContextPacket
+): PromptAttachment | null;
+
+// ---------------------------------------------------------------------------
+// Id helpers (signatures + minimal compiling stubs)
+// ---------------------------------------------------------------------------
+
+function hasValue(value: string): boolean {
+  return value.trim().length > 0;
+}
+
+/**
+ * Mint a `ContextPacketId` from a caller-supplied opaque suffix. The server
+ * (#758) supplies the random component (e.g. 8 random bytes hex), mirroring
+ * `createWorkContextId` → `wc:<hex>` and `createWorkspaceId(localId)`. Kept
+ * browser-safe: no `node:crypto` import here.
+ */
+export function createContextPacketId(suffix: string): ContextPacketId {
+  if (!hasValue(suffix)) throw new Error('suffix is required');
+  return `${CONTEXT_PACKET_ID_PREFIX}${encodeURIComponent(suffix)}`;
+}
+
+/** Mint a `SessionInboxMessageId` from a caller-supplied opaque suffix. */
+export function createInboxMessageId(suffix: string): SessionInboxMessageId {
+  if (!hasValue(suffix)) throw new Error('suffix is required');
+  return `${SESSION_INBOX_MESSAGE_ID_PREFIX}${encodeURIComponent(suffix)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Parse / validate (signatures only — real validation in #758)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse an unknown payload into a `ContextPacket`, returning `null` on any
+ * validation failure (mirrors `parseFileResourceRef`/`parsePromptAttachment`).
+ * Impl in #758.
+ */
+export declare function parseContextPacket(payload: unknown): ContextPacket | null;
+
+/** Parse an unknown payload into a `SessionInboxMessage`. Impl in #758. */
+export declare function parseSessionInboxMessage(
+  payload: unknown
+): SessionInboxMessage | null;
+
+// ---------------------------------------------------------------------------
+// Anchor resolution (the #766 primitive — signature only)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an `AnchorRef`'s `AnchorState` against the file's CURRENT contents.
+ *
+ * `captured` is the ref as stored on the packet; `current` is a freshly
+ * minted `FileResourceRef` for the same location (re-stat/re-read via node
+ * RPC under capability). Resolution rule (#766):
+ *   - identity mismatch (`!fileResourceRefEquals`) → `'missing'`
+ *   - identity match + sha256/mtime drift           → `'stale'`
+ *   - identity match + decorations match            → `'unchanged'`
+ *
+ * The reference equality below is the load-bearing reuse from
+ * `file-resource-ref.ts`: identity excludes the freshness decorations, so a
+ * re-minted ref for the same file is "the same anchor location" even though
+ * its sha256/mtime/capturedAt differ — exactly the comparison the resolver
+ * needs. Impl in #766; this stub just documents the contract and keeps the
+ * import live.
+ */
+export function resolveAnchorState(
+  captured: AnchorRef,
+  current: FileResourceRef | null
+): AnchorState {
+  // impl in #766 — sketch only. Real version also compares sha256/mtime to
+  // distinguish 'stale' from 'unchanged'.
+  if (!current) return 'missing';
+  if (!fileResourceRefEquals(captured.ref, current)) return 'missing';
+  return 'unchanged';
+}


### PR DESCRIPTION
Decision gate for Epic #757 (CLI-first anchored context packets + session inbox). Ratifies the two forks the planning cycle under-specified, so impl lanes #758 (model+store), #765 (verbs+caps), #766 (anchor-resolution) build against a fixed contract. No feature code — ADR + compiling type sketches only.

## The two decisions ratified

**D1 — Storage = SQLite-behind-gateway.** Reuse the WorkContext store pattern (`server/work-contexts.ts`: `schema_version` guarded migration, `create/get/list/update` with an `artifacts[]` patch, HTTP router). **No `.relay/*.json` workspace files for MVP** — none exist today, files do not federate across nodes (the hub does), and delivery is addressed by `GlobalSessionId = nodeId:localSessionId`. An optional, derived, read-only `.relay/context/<id>.json` projection is documented as a deferred future, never the write path.

**D2 — Extend `PromptAttachment`; do NOT fork `ContextAttachment`.** The open union (`shared/prompt-attachment.ts`) already reserves `diff-ref`/`log-ref` and bridges to WorkContext via `promptAttachmentToArtifactRef`. `FileResourceRef` already carries nodeId/path/sha256/mtime/size/repoBinding, and `fileResourceRefEquals` excludes sha256/mtime/capturedAt from identity — exactly the anchor-freshness primitive #766 needs. A fork would re-derive ~70% of that. The only delta is the anchor (range + quote), so we add `AnchorRef` + the `ContextPacket` envelope and slot the file-range case in as a new sibling `'file-anchor'` kind on `PromptAttachment`.

## Lifecycle

`queued → delivered(=fetched) → acknowledged → (resolved | ignored)`. Delivery is **PULL** ("delivered" == consumer fetched via `inbox.list`/agent `preturn`); Relay never pushes through `sessions.input`/raw PTY bytes. `stale` is **derived** from `AnchorState` at render time, never a stored manual transition. `'shifted'` deferred. Lifecycle lives on `SessionInboxMessage`; `ContextPacket` is reusable + lifecycle-independent.

## Env + capabilities

- Shipped env var is `RELAY_WORK_CONTEXT_ID` (`server/pty-handler.ts:676-677`). #761's `RELAY_WORKCONTEXT_ID` is wrong and must align.
- New bits: `context:read`/`inbox:read` → default-allow (`LEGACY_DEFAULT_ALLOWED_CAPABILITIES`); `context:write`/`inbox:write` → dev-allow but **NOT** `HIGH_RISK_CAPABILITIES` (ref-only metadata inserts, no raw payload/exec/file-mutation). Grant-gated, but not confirmation-gated on prod per the `applyTrustTierOverlay` rule.

## Schema summary

`context_packets` (id `cp:`, kind, `packet_json` blob + denormalized node/workspace, timestamps), `inbox_messages` (id `im:`, target session/workContext, `message_json`, `state`, transition timestamps, CHECK at-least-one-target), `inbox_message_packets` many-to-many join (packet reuse, `ON DELETE RESTRICT`). Same blob+denormalized-column style as `work_contexts`; no `stale`/`AnchorState` column.

## Deliverables

- `docs/adrs/ADR-019-context-packet-storage-and-primitive.md` (ADR-018 was taken; issue body's "ADR-018" label is stale).
- `shared/context-packet.ts` — type sketches: `AnchorRef`, `AnchorState`, `ContextPacket`, `SessionInboxMessage`, the `PromptAttachment` extension note, and `createContextPacketId`/`createInboxMessageId`/`resolveAnchorState` signatures. Browser-safe (no `node:*`). `npm run check` clean (0 errors; the new file is lint-clean).

Gates #758 / #765 / #766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
