### PR TITLE
feat(#766): anchor-resolution service

### DIFF
--- a/server/anchor-resolution.ts
+++ b/server/anchor-resolution.ts
@@ -1,0 +1,201 @@
+// #766 / Epic #757 (ADR-019): anchor-resolution service.
+//
+// `resolveAnchorState` (the PURE comparison primitive) lives in
+// `shared/context-packet.ts` because it performs no I/O. THIS module is the
+// IMPURE caller: it obtains the `current` `FileResourceRef` for an anchor's
+// location and delegates the comparison to the pure resolver.
+//
+// CORRECTNESS-CRITICAL (ADR-019 §D3, fugu concern C1): the `current` ref MUST
+// be minted by re-reading/re-stat-ing through the node File RPC layer UNDER
+// CAPABILITY (`rpc:fs:read` for read, `rpc:fs:stat` maps to `rpc:fs:read`),
+// NEVER a local `fs.stat`. A federated session's file lives on its OWN node
+// (`GlobalSessionId = nodeId:localSessionId`); a local stat on the hub would
+// silently resolve the wrong filesystem and return a confidently-wrong
+// `AnchorState`. The File RPC path
+// (`server/file-rpc.ts` → `nodeLinks.request('fs.read'|'fs.stat', …)` routed
+// over `/hub/node-link`, gated by `requiredCapabilitiesForRpcIntent` +
+// `evaluateHubPolicy` in `server/hub-node-router.ts`) is the only blessed way
+// to read a (possibly remote) node's file. This module depends on that path
+// through the injected `AnchorFileFetcher` seam so the policy/scoping
+// machinery is reused, not re-implemented, and so the caller stays unit-
+// testable with a mock that asserts the capability requirement.
+
+import * as crypto from 'node:crypto';
+
+import {
+  createFileResourceRef,
+  type FileResourceRef,
+} from '../shared/file-resource-ref.js';
+import type { NodeId } from '../shared/identity.js';
+import {
+  resolveAnchorState,
+  type AnchorRef,
+  type AnchorState,
+} from '../shared/context-packet.js';
+import type { RelayCapabilityBit } from '../shared/security-policy.js';
+
+/**
+ * Capability the anchor resolver requires to fetch the `current` ref. Both the
+ * `read` and `stat` File RPC intents resolve to `rpc:fs:read` (see
+ * `requiredCapabilitiesForRpcIntent` in `server/hub-policy-evaluator.ts`), so a
+ * single bit gates anchor resolution. The injected fetcher MUST be invoked
+ * behind a hub policy check for this bit; the caller asserts the fetcher
+ * acknowledges it (defense in depth, so a mis-wired fetcher that skips the gate
+ * is caught rather than silently resolving without authorization).
+ */
+export const ANCHOR_RESOLUTION_CAPABILITY: RelayCapabilityBit = 'rpc:fs:read';
+
+/**
+ * Result of a File-RPC-under-capability fetch for an anchor's location. The
+ * fetcher re-resolves `(nodeId, path)` on the OWNING node and returns the
+ * freshness decorations needed to mint a `current` `FileResourceRef`:
+ *
+ *   - `found: false`  — the node reported the path no longer resolves (e.g.
+ *     `FILE_RPC_NOT_FOUND`, or the path is no longer a regular file). The
+ *     resolver maps this to `AnchorState='missing'`.
+ *   - `found: true`   — the path resolved. `mtimeMs`/`size` come from the node
+ *     `stat`/`read` response. `contentSha256` is present ONLY when the fetch
+ *     was a `read` and the bytes were hashed (use `hashAnchorContent`); a
+ *     stat-only fetch leaves it `undefined`, which the pure resolver treats as
+ *     the conservative C3 case if the captured ref also lacks sha256.
+ *
+ * `grantedCapability` echoes the capability the fetcher was authorized for; the
+ * caller asserts it matches `ANCHOR_RESOLUTION_CAPABILITY` (C1 enforcement).
+ */
+export type AnchorFileFetchResult =
+  | { found: false; grantedCapability: RelayCapabilityBit }
+  | {
+      found: true;
+      grantedCapability: RelayCapabilityBit;
+      mtimeMs?: number;
+      size?: number;
+      /** sha256 hex of the CURRENT contents, set only on a `read` fetch. */
+      contentSha256?: string;
+    };
+
+/**
+ * The target an anchor resolver hands the fetcher. Carries the location
+ * identity (`nodeId`, `path`) plus the `maxBytes`/`repoBinding` decorations so
+ * the re-minted `current` ref preserves identity equality with the captured
+ * ref (`fileResourceRefEquals` includes `maxBytes`/`repoBinding` in identity).
+ */
+export interface AnchorFileFetchTarget {
+  nodeId: NodeId;
+  path: string;
+  maxBytes?: number;
+  repoBinding?: FileResourceRef['repoBinding'];
+  /**
+   * Whether the captured anchor carries `read`-intent freshness (a sha256). If
+   * it does, the fetcher SHOULD perform a `read` (so the current ref also gets
+   * a sha256 for authoritative comparison); otherwise a `stat` suffices.
+   */
+  preferRead: boolean;
+}
+
+/**
+ * Injected File-RPC-under-capability fetch. Production wires this to the hub
+ * File RPC path (`nodeLinks.request('fs.read' | 'fs.stat', …)` behind
+ * `evaluateHubPolicy`); tests mock it. Returns `null` to signal the fetch
+ * could not be authorized/performed at all (distinct from `found: false`,
+ * which is an authorized fetch that found nothing).
+ */
+export type AnchorFileFetcher = (
+  target: AnchorFileFetchTarget
+) => Promise<AnchorFileFetchResult | null>;
+
+/** Hash file content (utf8 or raw bytes) to a sha256 hex digest. */
+export function hashAnchorContent(content: string | Buffer): string {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+export interface ResolveAnchorOutcome {
+  state: AnchorState;
+  /**
+   * The freshly minted `current` ref, when the file resolved. `null` when the
+   * file is missing or the fetch could not be authorized — mirrors the
+   * `current` argument the pure resolver received.
+   */
+  current: FileResourceRef | null;
+}
+
+/**
+ * Resolve an anchor's `AnchorState` by fetching its CURRENT ref through the
+ * File RPC layer under capability and delegating the comparison to the pure
+ * `resolveAnchorState`.
+ *
+ * Steps:
+ *   1. Derive the fetch target from the captured anchor's ref. `preferRead` is
+ *      driven by whether the captured ref carries a sha256 (so an authoritative
+ *      sha-vs-sha comparison is possible).
+ *   2. Call the injected fetcher (the File-RPC-under-capability seam). If it
+ *      returns `null` (fetch unauthorized/unavailable) the anchor is treated as
+ *      `missing` — we do NOT fall back to a local stat (C1).
+ *   3. Assert the fetcher acknowledged the required capability
+ *      (`ANCHOR_RESOLUTION_CAPABILITY`); a mismatch throws, surfacing a
+ *      mis-wired fetcher rather than resolving without authorization.
+ *   4. Re-mint the `current` `FileResourceRef` from the fetch result, carrying
+ *      forward the location identity (`nodeId`, `path`, `intent`, `maxBytes`,
+ *      `repoBinding`) and the fetched freshness decorations.
+ *   5. Delegate to the pure resolver.
+ *
+ * The captured anchor's `intent` is preserved on the minted `current` ref so
+ * `fileResourceRefEquals` (which compares `intent`) treats the two as the same
+ * location. The resolver re-reads through RPC and never trusts the captured
+ * `quote` for access (it is advisory only — ADR-019).
+ */
+export async function resolveAnchor(
+  captured: AnchorRef,
+  fetcher: AnchorFileFetcher
+): Promise<ResolveAnchorOutcome> {
+  const capturedRef = captured.ref;
+  const preferRead = capturedRef.sha256 !== undefined;
+
+  const target: AnchorFileFetchTarget = {
+    nodeId: capturedRef.nodeId,
+    path: capturedRef.path,
+    preferRead,
+    ...(capturedRef.maxBytes !== undefined ? { maxBytes: capturedRef.maxBytes } : {}),
+    ...(capturedRef.repoBinding ? { repoBinding: capturedRef.repoBinding } : {}),
+  };
+
+  const fetched = await fetcher(target);
+
+  // C1: an unauthorized/unavailable fetch resolves to `missing`. We never fall
+  // back to a local `fs.stat` — the file lives on the owning node.
+  if (fetched === null) {
+    return { state: resolveAnchorState(captured, null), current: null };
+  }
+
+  // C1 enforcement: the fetch MUST have been gated on the read capability.
+  if (fetched.grantedCapability !== ANCHOR_RESOLUTION_CAPABILITY) {
+    throw new Error(
+      `anchor resolution fetch was authorized for "${fetched.grantedCapability}" but requires "${ANCHOR_RESOLUTION_CAPABILITY}"`
+    );
+  }
+
+  if (!fetched.found) {
+    return { state: resolveAnchorState(captured, null), current: null };
+  }
+
+  let current: FileResourceRef;
+  try {
+    current = createFileResourceRef({
+      nodeId: capturedRef.nodeId,
+      path: capturedRef.path,
+      // Preserve the captured ref's intent so identity equality holds. The
+      // freshness decorations below are freshly fetched via RPC.
+      intent: capturedRef.intent,
+      ...(fetched.size !== undefined ? { size: fetched.size } : {}),
+      ...(fetched.contentSha256 !== undefined ? { sha256: fetched.contentSha256 } : {}),
+      ...(fetched.mtimeMs !== undefined ? { mtimeMs: fetched.mtimeMs } : {}),
+      ...(capturedRef.maxBytes !== undefined ? { maxBytes: capturedRef.maxBytes } : {}),
+      ...(capturedRef.repoBinding ? { repoBinding: capturedRef.repoBinding } : {}),
+    });
+  } catch {
+    // A current ref that cannot even be minted (e.g. the node returned a path
+    // that no longer normalizes to the same location) is treated as missing.
+    return { state: resolveAnchorState(captured, null), current: null };
+  }
+
+  return { state: resolveAnchorState(captured, current), current };
+}

--- a/shared/context-packet.ts
+++ b/shared/context-packet.ts
@@ -748,27 +748,67 @@ export const parseInboxMessage = parseSessionInboxMessage;
 /**
  * Resolve an `AnchorRef`'s `AnchorState` against the file's CURRENT contents.
  *
- * `captured` is the ref as stored on the packet; `current` is a freshly
- * minted `FileResourceRef` for the same location (re-stat/re-read via node
- * RPC under capability). Resolution rule (#766):
- *   - identity mismatch (`!fileResourceRefEquals`) → `'missing'`
- *   - identity match + sha256/mtime drift           → `'stale'`
- *   - identity match + decorations match            → `'unchanged'`
+ * PURE comparison primitive (#766). It performs NO I/O: `captured` is the ref
+ * as stored on the packet and `current` is a freshly minted `FileResourceRef`
+ * for the same location, obtained by the IMPURE caller in
+ * `server/anchor-resolution.ts` by re-stat/re-read through the node File RPC
+ * layer UNDER CAPABILITY (`rpc:fs:read`/`rpc:fs:stat`) — never a local
+ * `fs.stat` (a federated session's file lives on its own node).
  *
- * The reference equality below is the load-bearing reuse from
- * `file-resource-ref.ts`: identity excludes the freshness decorations, so a
+ * Resolution rule:
+ *   - `current === null`                              → `'missing'`
+ *   - identity mismatch (`!fileResourceRefEquals`)    → `'missing'`
+ *   - identity match + freshness decorations drift    → `'stale'`
+ *   - identity match + freshness decorations match    → `'unchanged'`
+ *   - identity match + freshness UNKNOWABLE (C3)      → `'stale'` (conservative)
+ *
+ * Freshness comparison precedence (identity already established):
+ *   1. If BOTH refs carry `sha256` → exact content equality: equal =>
+ *      `'unchanged'`, differ => `'stale'`. sha256 is authoritative.
+ *   2. Else if BOTH refs carry `mtimeMs` → mtime equality: equal =>
+ *      `'unchanged'`, differ => `'stale'`. Weaker than sha but still a real
+ *      freshness signal when content hashing was not performed.
+ *   3. Otherwise freshness is UNKNOWABLE. This is the C3 case: the captured
+ *      anchor was minted WITHOUT read-intent freshness (e.g. a `stat`/`list`
+ *      ref with no sha256 and no comparable mtime), so the resolver CANNOT
+ *      prove the range still points at the captured `quote`. We return the
+ *      CONSERVATIVE `'stale'` rather than silently asserting `'unchanged'` —
+ *      an anchored packet should be minted with `read` intent so freshness is
+ *      always comparable; absent that, the consumer is warned the range may
+ *      have drifted.
+ *
+ * Identity (`fileResourceRefEquals`) is the load-bearing reuse from
+ * `file-resource-ref.ts`: it excludes the freshness decorations, so a
  * re-minted ref for the same file is "the same anchor location" even though
  * its sha256/mtime/capturedAt differ — exactly the comparison the resolver
- * needs. Impl in #766; this stub just documents the contract and keeps the
- * import live.
+ * needs.
+ *
+ * `'shifted'` (range moved but quote relocatable elsewhere in the file) is
+ * EXPLICITLY DEFERRED (ADR-019); a moved range surfaces as `'stale'`.
  */
 export function resolveAnchorState(
   captured: AnchorRef,
   current: FileResourceRef | null
 ): AnchorState {
-  // impl in #766 — sketch only. Real version also compares sha256/mtime to
-  // distinguish 'stale' from 'unchanged'.
   if (!current) return 'missing';
   if (!fileResourceRefEquals(captured.ref, current)) return 'missing';
-  return 'unchanged';
+
+  const capturedSha = captured.ref.sha256;
+  const currentSha = current.sha256;
+  // 1. sha256 is authoritative when both sides carry it.
+  if (capturedSha !== undefined && currentSha !== undefined) {
+    return capturedSha === currentSha ? 'unchanged' : 'stale';
+  }
+
+  // 2. Fall back to mtime when both sides carry it.
+  const capturedMtime = captured.ref.mtimeMs;
+  const currentMtime = current.mtimeMs;
+  if (capturedMtime !== undefined && currentMtime !== undefined) {
+    return capturedMtime === currentMtime ? 'unchanged' : 'stale';
+  }
+
+  // 3. C3: freshness is unknowable (captured without read-intent freshness, or
+  // no comparable decoration). Conservatively report 'stale' — never silently
+  // 'unchanged' when we cannot prove the content is unchanged.
+  return 'stale';
 }

--- a/test/anchor-resolution.test.ts
+++ b/test/anchor-resolution.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  resolveAnchorState,
+  type AnchorRef,
+} from '../shared/context-packet.js';
+import {
+  createFileResourceRef,
+  type FileResourceRef,
+} from '../shared/file-resource-ref.js';
+import {
+  ANCHOR_RESOLUTION_CAPABILITY,
+  hashAnchorContent,
+  resolveAnchor,
+  type AnchorFileFetchResult,
+  type AnchorFileFetchTarget,
+  type AnchorFileFetcher,
+} from '../server/anchor-resolution.js';
+
+const NODE = 'node-alpha';
+const PATH = '/repo/src/index.ts';
+const SHA_A = 'a'.repeat(64);
+const SHA_B = 'b'.repeat(64);
+
+function ref(overrides: Partial<FileResourceRef> = {}): FileResourceRef {
+  return createFileResourceRef({
+    nodeId: NODE,
+    path: PATH,
+    intent: 'read',
+    sha256: SHA_A,
+    mtimeMs: 1_000,
+    size: 42,
+    ...overrides,
+  });
+}
+
+function anchor(refOverrides: Partial<FileResourceRef> = {}): AnchorRef {
+  return {
+    ref: ref(refOverrides),
+    lineRange: { startLine: 10, endLine: 20 },
+    quote: 'const answer = 42;',
+  };
+}
+
+describe('resolveAnchorState (pure)', () => {
+  it('returns "unchanged" when sha256 matches', () => {
+    const captured = anchor();
+    const current = ref({ mtimeMs: 9_999 }); // mtime can drift; sha is authoritative
+    expect(resolveAnchorState(captured, current)).toBe('unchanged');
+  });
+
+  it('returns "stale" when sha256 differs (file edited)', () => {
+    const captured = anchor({ sha256: SHA_A });
+    const current = ref({ sha256: SHA_B });
+    expect(resolveAnchorState(captured, current)).toBe('stale');
+  });
+
+  it('returns "missing" when current is null (deleted)', () => {
+    expect(resolveAnchorState(anchor(), null)).toBe('missing');
+  });
+
+  it('returns "missing" when the file moved (path identity mismatch)', () => {
+    const captured = anchor();
+    const current = ref({ path: '/repo/src/renamed.ts', sha256: SHA_A });
+    expect(resolveAnchorState(captured, current)).toBe('missing');
+  });
+
+  it('returns "missing" on node identity mismatch (wrong node)', () => {
+    const captured = anchor();
+    const current = ref({ nodeId: 'node-beta', sha256: SHA_A });
+    expect(resolveAnchorState(captured, current)).toBe('missing');
+  });
+
+  it('returns "missing" on intent identity mismatch', () => {
+    const captured = anchor();
+    const current = ref({ intent: 'stat', sha256: SHA_A });
+    expect(resolveAnchorState(captured, current)).toBe('missing');
+  });
+
+  it('falls back to mtime when neither side carries sha256: equal => unchanged', () => {
+    const captured = anchor({ sha256: undefined, mtimeMs: 1_000 });
+    const current = ref({ sha256: undefined, mtimeMs: 1_000 });
+    expect(resolveAnchorState(captured, current)).toBe('unchanged');
+  });
+
+  it('falls back to mtime when neither side carries sha256: differ => stale', () => {
+    const captured = anchor({ sha256: undefined, mtimeMs: 1_000 });
+    const current = ref({ sha256: undefined, mtimeMs: 2_000 });
+    expect(resolveAnchorState(captured, current)).toBe('stale');
+  });
+
+  // C3: captured without read-intent freshness and no comparable mtime.
+  it('C3: returns conservative "stale" when freshness is unknowable (no sha, no comparable mtime)', () => {
+    const captured = anchor({ sha256: undefined, mtimeMs: undefined });
+    const current = ref({ sha256: undefined, mtimeMs: undefined });
+    expect(resolveAnchorState(captured, current)).toBe('stale');
+  });
+
+  it('C3: returns conservative "stale" when only current has sha256 (captured stat-only)', () => {
+    const captured = anchor({ sha256: undefined, mtimeMs: undefined });
+    const current = ref({ sha256: SHA_A, mtimeMs: undefined });
+    expect(resolveAnchorState(captured, current)).toBe('stale');
+  });
+
+  it('never silently returns "unchanged" when captured freshness is absent', () => {
+    const captured = anchor({ sha256: undefined, mtimeMs: undefined });
+    const current = ref({ sha256: SHA_A, mtimeMs: 1_000 });
+    expect(resolveAnchorState(captured, current)).not.toBe('unchanged');
+  });
+});
+
+describe('hashAnchorContent', () => {
+  it('hashes content deterministically to sha256 hex', () => {
+    const hex = hashAnchorContent('const answer = 42;\n');
+    expect(hex).toMatch(/^[a-f0-9]{64}$/);
+    expect(hex).toBe(hashAnchorContent(Buffer.from('const answer = 42;\n')));
+  });
+});
+
+describe('resolveAnchor (impure caller via File RPC under capability)', () => {
+  function fetcherReturning(
+    result: AnchorFileFetchResult | null
+  ): { fn: AnchorFileFetcher; calls: AnchorFileFetchTarget[] } {
+    const calls: AnchorFileFetchTarget[] = [];
+    const fn = vi.fn(async (target: AnchorFileFetchTarget) => {
+      calls.push(target);
+      return result;
+    });
+    return { fn, calls };
+  }
+
+  it('requires the rpc:fs:read capability', () => {
+    expect(ANCHOR_RESOLUTION_CAPABILITY).toBe('rpc:fs:read');
+  });
+
+  it('routes the fetch through the injected File RPC fetcher with the anchor location', async () => {
+    const captured = anchor();
+    const { fn, calls } = fetcherReturning({
+      found: true,
+      grantedCapability: 'rpc:fs:read',
+      contentSha256: SHA_A,
+      mtimeMs: 1_000,
+      size: 42,
+    });
+    const outcome = await resolveAnchor(captured, fn);
+    expect(outcome.state).toBe('unchanged');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.nodeId).toBe(NODE);
+    expect(calls[0]?.path).toBe(PATH);
+    // captured carries sha256 → prefer a read so current also gets a sha256.
+    expect(calls[0]?.preferRead).toBe(true);
+  });
+
+  it('reports "stale" when the re-read content sha differs', async () => {
+    const captured = anchor({ sha256: SHA_A });
+    const { fn } = fetcherReturning({
+      found: true,
+      grantedCapability: 'rpc:fs:read',
+      contentSha256: SHA_B,
+      mtimeMs: 2_000,
+      size: 50,
+    });
+    const outcome = await resolveAnchor(captured, fn);
+    expect(outcome.state).toBe('stale');
+    expect(outcome.current?.sha256).toBe(SHA_B);
+  });
+
+  it('reports "missing" when the node says the file is gone', async () => {
+    const { fn } = fetcherReturning({ found: false, grantedCapability: 'rpc:fs:read' });
+    const outcome = await resolveAnchor(anchor(), fn);
+    expect(outcome.state).toBe('missing');
+    expect(outcome.current).toBeNull();
+  });
+
+  it('reports "missing" (never local fallback) when the fetch is unauthorized/unavailable', async () => {
+    const { fn } = fetcherReturning(null);
+    const outcome = await resolveAnchor(anchor(), fn);
+    expect(outcome.state).toBe('missing');
+    expect(outcome.current).toBeNull();
+  });
+
+  it('throws if the fetcher was authorized for the wrong capability (C1 defense in depth)', async () => {
+    const { fn } = fetcherReturning({
+      found: true,
+      grantedCapability: 'rpc:fs:list' as never,
+      contentSha256: SHA_A,
+    });
+    await expect(resolveAnchor(anchor(), fn)).rejects.toThrow(/rpc:fs:read/);
+  });
+
+  it('C3 end-to-end: captured stat-only anchor resolves conservatively "stale"', async () => {
+    // Captured with stat intent and no sha256 (freshness not captured).
+    const captured = anchor({ intent: 'stat', sha256: undefined, mtimeMs: undefined });
+    // preferRead should be false because captured has no sha256.
+    const { fn, calls } = fetcherReturning({
+      found: true,
+      grantedCapability: 'rpc:fs:read',
+      mtimeMs: undefined,
+      size: 42,
+    });
+    const outcome = await resolveAnchor(captured, fn);
+    expect(calls[0]?.preferRead).toBe(false);
+    expect(outcome.state).toBe('stale');
+  });
+
+  it('preserves maxBytes/repoBinding identity on the re-minted current ref', async () => {
+    const captured = anchor({
+      maxBytes: 8192,
+      repoBinding: { repoPath: '/repo', worktreePath: '/repo', branch: 'main' },
+    });
+    const { fn } = fetcherReturning({
+      found: true,
+      grantedCapability: 'rpc:fs:read',
+      contentSha256: SHA_A,
+      mtimeMs: 1_000,
+    });
+    const outcome = await resolveAnchor(captured, fn);
+    // Identity (incl. maxBytes/repoBinding) must match → unchanged, not missing.
+    expect(outcome.state).toBe('unchanged');
+    expect(outcome.current?.maxBytes).toBe(8192);
+    expect(outcome.current?.repoBinding?.repoPath).toBe('/repo');
+  });
+});


### PR DESCRIPTION
Implements #766 — the anchor-resolution primitive ratified by ADR-019. **Stacked on #764 (PR #768)**; review/merge that first.

## Resolution semantics

`AnchorState = 'unchanged' | 'stale' | 'missing'`, always **derived** at render/resolution time (never stored).

The pure `resolveAnchorState(captured: AnchorRef, current: FileResourceRef | null)` (in `shared/context-packet.ts`, no I/O):

- `current === null` → `missing`
- identity mismatch (`!fileResourceRefEquals`, i.e. different node/path/intent/maxBytes/repoBinding — covers moved/renamed files and wrong-node) → `missing`
- identity match, then freshness, in precedence order:
  1. both refs carry `sha256` → exact content equality: equal ⇒ `unchanged`, differ ⇒ `stale` (sha is authoritative; mtime drift alone does not flip a sha-equal ref)
  2. both refs carry `mtimeMs` (no sha) → mtime equality
  3. otherwise freshness unknowable → conservative `stale` (see C3)

## C1 — cross-node File RPC under capability

The impure caller `resolveAnchor()` (in `server/anchor-resolution.ts`) obtains `current` by re-minting a `FileResourceRef` for the anchor's `(nodeId, path)` through the **File RPC layer under capability**, never a local `fs.stat`. A federated session's file lives on its own node (`GlobalSessionId = nodeId:localSessionId`), so a hub-local stat would silently resolve the wrong filesystem.

The blessed path is `server/file-rpc.ts` → `nodeLinks.request('fs.read' | 'fs.stat', …)` routed over `/hub/node-link`, gated by `requiredCapabilitiesForRpcIntent` + `evaluateHubPolicy` in `server/hub-node-router.ts` (both `fs.read` and `fs.stat` require **`rpc:fs:read`**). The resolver depends on that path through an injected `AnchorFileFetcher` seam so the policy/scoping machinery is reused rather than re-implemented, and so the caller stays unit-testable. The caller **asserts** the fetch was authorized for `rpc:fs:read` (`ANCHOR_RESOLUTION_CAPABILITY`) — a mis-wired fetcher that skips the gate throws instead of silently resolving. An unauthorized/unavailable fetch resolves to `missing`; it never falls back to a local stat.

Note: `executeRead` in `file-rpc.ts` does not return a hash, so the caller hashes the read content itself (`hashAnchorContent`) to mint the `current` sha256 for an authoritative comparison.

## C3 — freshness absent

If the captured anchor's ref has **no `sha256`** (e.g. captured with `stat`/`list`/`tail` intent rather than `read`) and no comparable `mtimeMs`, the resolver cannot prove the range still points at the captured `quote`. Decision: return the conservative **`stale`** — never silently `unchanged` when freshness is unknowable. Anchored packets should be minted with `read` intent so freshness is always comparable; the caller sets `preferRead` from whether the captured ref carries a sha256.

## Deferred

`'shifted'` (range moved but quote relocatable elsewhere in the file) is explicitly deferred per ADR-019; a moved range surfaces as `stale`.

## Files

- `shared/context-packet.ts` — implemented the pure `resolveAnchorState` (was a stub).
- `server/anchor-resolution.ts` (new) — impure caller, `AnchorFileFetcher` seam, capability gate, `hashAnchorContent`.
- `test/anchor-resolution.test.ts` (new) — 20 tests.

## Test evidence

- `npm run build` — green
- `npm run check` — 0 errors (pre-existing warnings only; none in the new files)
- `npm test -- anchor-resolution` — **20 passed**: unchanged (sha match), stale (sha differs), missing (null/moved/wrong-node/intent-mismatch), mtime fallback (both directions), C3 conservative stale (no sha / stat-only / never-silently-unchanged), capability requirement + wrong-capability throw, fetcher routing/preferRead, identity preservation of maxBytes/repoBinding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)