### PR TITLE
feat(#758): ContextPacket model + SQLite store

### DIFF
--- a/server/context-packets.ts
+++ b/server/context-packets.ts
@@ -1,0 +1,656 @@
+// Context-packet + session-inbox SQLite store (#758, ADR-019).
+//
+// Stores the CLI/API-first anchored-context primitive behind the hub gateway,
+// reusing the self-contained store pattern of `server/work-contexts.ts` and
+// `server/ia-store.ts`: per-store SQLite file, a `schema_version` table with a
+// version-gated migration run inside a transaction, an `init*(configDir)` /
+// `create*(dbPath)` factory split, blob `*_json` columns plus denormalized
+// columns for federation queries, and prepared parameterized statements.
+//
+// STRICTLY NON-DESTRUCTIVE: owns its own DB file (`context-packets.db`) and
+// creates only new tables (`context_packets`, `inbox_messages`,
+// `inbox_message_packets`). It never reads or mutates `config.json` or any
+// existing store/table.
+//
+// Ref-only privacy posture (inherited from the WorkContext store): packets
+// carry pointers + a bounded `quote`/`note`, never raw file bytes. `AnchorState`
+// (`stale`) is DERIVED at read time by #766 and is NEVER stored here.
+
+import * as crypto from 'node:crypto';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import { createLogger } from './logger.js';
+import {
+  createContextPacketId,
+  createInboxMessageId,
+  parseContextPacket,
+  parseSessionInboxMessage,
+  validateInboxTransition,
+  type ContextPacket,
+  type ContextPacketId,
+  type SessionInboxMessage,
+  type SessionInboxMessageId,
+  type SessionInboxMessageState,
+} from '../shared/context-packet.js';
+import type { GlobalSessionId } from '../shared/identity.js';
+import type { WorkContextId } from '../shared/work-context.js';
+
+const logger = createLogger('context-packets');
+
+const SCHEMA_V1 = `
+CREATE TABLE IF NOT EXISTS context_packets (
+  id           TEXT PRIMARY KEY,
+  kind         TEXT NOT NULL,
+  packet_json  TEXT NOT NULL,
+  node_id      TEXT,
+  workspace_id TEXT,
+  created_by   TEXT NOT NULL,
+  created_at   TEXT NOT NULL,
+  updated_at   TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_context_packets_created_at
+  ON context_packets(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_context_packets_node
+  ON context_packets(node_id);
+
+CREATE TABLE IF NOT EXISTS inbox_messages (
+  id                     TEXT PRIMARY KEY,
+  target_session_id      TEXT,
+  target_work_context_id TEXT,
+  message_json           TEXT NOT NULL,
+  state                  TEXT NOT NULL,
+  created_by             TEXT NOT NULL,
+  created_at             TEXT NOT NULL,
+  delivered_at           TEXT,
+  acknowledged_at        TEXT,
+  resolved_at            TEXT,
+  updated_at             TEXT NOT NULL,
+  CHECK (target_session_id IS NOT NULL OR target_work_context_id IS NOT NULL)
+);
+CREATE INDEX IF NOT EXISTS idx_inbox_messages_session
+  ON inbox_messages(target_session_id, state);
+CREATE INDEX IF NOT EXISTS idx_inbox_messages_work_context
+  ON inbox_messages(target_work_context_id, state);
+
+CREATE TABLE IF NOT EXISTS inbox_message_packets (
+  message_id        TEXT NOT NULL,
+  context_packet_id TEXT NOT NULL,
+  ordinal           INTEGER NOT NULL,
+  PRIMARY KEY (message_id, context_packet_id),
+  FOREIGN KEY (message_id) REFERENCES inbox_messages(id) ON DELETE CASCADE,
+  FOREIGN KEY (context_packet_id) REFERENCES context_packets(id) ON DELETE RESTRICT
+);
+CREATE INDEX IF NOT EXISTS idx_inbox_message_packets_packet
+  ON inbox_message_packets(context_packet_id);
+`;
+
+const MIGRATIONS: Array<{ version: number; sql: string }> = [
+  { version: 1, sql: SCHEMA_V1 },
+];
+
+interface ContextPacketRow {
+  id: string;
+  kind: string;
+  packet_json: string;
+  node_id: string | null;
+  workspace_id: string | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface InboxMessageRow {
+  id: string;
+  target_session_id: string | null;
+  target_work_context_id: string | null;
+  message_json: string;
+  state: string;
+  created_by: string;
+  created_at: string;
+  delivered_at: string | null;
+  acknowledged_at: string | null;
+  resolved_at: string | null;
+  updated_at: string;
+}
+
+// ── Public input shapes ──────────────────────────────────────────────────────
+
+/**
+ * Create input for a context packet. The store mints the `id` (server-owned
+ * randomness) and `createdAt` unless `packet` carries a fully-formed envelope.
+ * `createdBy` is required: every packet is attributable.
+ */
+export interface ContextPacketCreateInput {
+  /** A fully-formed packet to persist as-is (validated through `parseContextPacket`). */
+  packet?: ContextPacket;
+  /** Mint a packet from these fields when `packet` is omitted. */
+  kind?: ContextPacket['kind'];
+  anchor?: ContextPacket['anchor'];
+  fileRef?: ContextPacket['fileRef'];
+  note?: ContextPacket['note'];
+  binding?: ContextPacket['binding'];
+  createdBy?: string;
+  /** Override the minted id (must be a `cp:` id); tests/imports only. */
+  id?: ContextPacketId;
+}
+
+/** Create input for an inbox message. Mints `id`, `createdAt`, `state=queued`. */
+export interface InboxMessageCreateInput {
+  message?: SessionInboxMessage;
+  targetSessionId?: GlobalSessionId;
+  targetWorkContextId?: WorkContextId;
+  contextPacketIds?: ContextPacketId[];
+  text?: string;
+  createdBy?: string;
+  id?: SessionInboxMessageId;
+}
+
+/** Filter for `listInboxMessages`. All clauses are ANDed. */
+export interface InboxMessageListFilter {
+  targetSessionId?: GlobalSessionId;
+  targetWorkContextId?: WorkContextId;
+  state?: SessionInboxMessageState;
+}
+
+export interface ContextPacketStore {
+  close(): void;
+
+  // ── Context packets ──────────────────────────────────────────────────────
+  createContextPacket(input: ContextPacketCreateInput): ContextPacket;
+  getContextPacket(id: ContextPacketId): ContextPacket | null;
+  listContextPackets(): ContextPacket[];
+  /** Delete a packet. RESTRICTed if any live inbox message references it. */
+  deleteContextPacket(id: ContextPacketId): boolean;
+
+  // ── Inbox messages ─────────────────────────────────────────────────────────
+  createInboxMessage(input: InboxMessageCreateInput): SessionInboxMessage;
+  getInboxMessage(id: SessionInboxMessageId): SessionInboxMessage | null;
+  listInboxMessages(filter?: InboxMessageListFilter): SessionInboxMessage[];
+  /**
+   * Transition an inbox message to `to`. Idempotent (`from === to` is a no-op
+   * success) and rejects transitions out of terminal states (ADR-019 C2).
+   */
+  transitionInboxMessage(
+    id: SessionInboxMessageId,
+    to: SessionInboxMessageState
+  ): SessionInboxMessage;
+  deleteInboxMessage(id: SessionInboxMessageId): boolean;
+}
+
+export class ContextPacketStoreError extends Error {
+  readonly status: number;
+  readonly code: string;
+  constructor(status: number, code: string, message = code) {
+    super(message);
+    this.name = 'ContextPacketStoreError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+/** Boot entry point: opens (and migrates) the store DB under `configDir`. */
+export function initContextPacketStore(configDir: string): ContextPacketStore {
+  return createContextPacketStore(path.join(configDir, 'context-packets.db'));
+}
+
+/** Factory taking an explicit DB path. Used directly by unit tests. */
+export function createContextPacketStore(dbPath: string): ContextPacketStore {
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+  // FK enforcement is required for the join's ON DELETE CASCADE/RESTRICT.
+  db.pragma('foreign_keys = ON');
+
+  runMigrations(db);
+
+  // ── Context packet statements ──────────────────────────────────────────────
+  const selectPacket = db.prepare(
+    `SELECT id, kind, packet_json, node_id, workspace_id, created_by, created_at, updated_at
+     FROM context_packets WHERE id = ?`
+  );
+  const selectAllPackets = db.prepare(
+    `SELECT id, kind, packet_json, node_id, workspace_id, created_by, created_at, updated_at
+     FROM context_packets ORDER BY created_at DESC, id ASC`
+  );
+  const insertPacket = db.prepare(
+    `INSERT INTO context_packets (
+       id, kind, packet_json, node_id, workspace_id, created_by, created_at, updated_at
+     ) VALUES (
+       @id, @kind, @packetJson, @nodeId, @workspaceId, @createdBy, @createdAt, @updatedAt
+     )`
+  );
+  const deletePacketStmt = db.prepare('DELETE FROM context_packets WHERE id = ?');
+
+  // ── Inbox message statements ───────────────────────────────────────────────
+  const selectMessage = db.prepare(
+    `SELECT id, target_session_id, target_work_context_id, message_json, state,
+            created_by, created_at, delivered_at, acknowledged_at, resolved_at, updated_at
+     FROM inbox_messages WHERE id = ?`
+  );
+  const insertMessage = db.prepare(
+    `INSERT INTO inbox_messages (
+       id, target_session_id, target_work_context_id, message_json, state,
+       created_by, created_at, delivered_at, acknowledged_at, resolved_at, updated_at
+     ) VALUES (
+       @id, @targetSessionId, @targetWorkContextId, @messageJson, @state,
+       @createdBy, @createdAt, @deliveredAt, @acknowledgedAt, @resolvedAt, @updatedAt
+     )`
+  );
+  const updateMessageState = db.prepare(
+    `UPDATE inbox_messages SET
+       message_json    = @messageJson,
+       state           = @state,
+       delivered_at    = @deliveredAt,
+       acknowledged_at = @acknowledgedAt,
+       resolved_at     = @resolvedAt,
+       updated_at      = @updatedAt
+     WHERE id = @id`
+  );
+  const insertMessagePacket = db.prepare(
+    `INSERT INTO inbox_message_packets (message_id, context_packet_id, ordinal)
+     VALUES (?, ?, ?)`
+  );
+  const deleteMessageStmt = db.prepare('DELETE FROM inbox_messages WHERE id = ?');
+
+  function getPacketById(id: ContextPacketId): ContextPacket | null {
+    const row = selectPacket.get(id) as ContextPacketRow | undefined;
+    return row ? rowToPacketSafe(row) : null;
+  }
+
+  function getMessageById(id: SessionInboxMessageId): SessionInboxMessage | null {
+    const row = selectMessage.get(id) as InboxMessageRow | undefined;
+    return row ? rowToMessageSafe(row) : null;
+  }
+
+  function mustGetMessage(id: SessionInboxMessageId): SessionInboxMessage {
+    const message = getMessageById(id);
+    if (!message) {
+      throw new ContextPacketStoreError(404, 'inbox_message_not_found');
+    }
+    return message;
+  }
+
+  return {
+    close() {
+      db.close();
+    },
+
+    createContextPacket(input: ContextPacketCreateInput) {
+      const now = new Date().toISOString();
+      const packet = buildPacketFromInput(input, now);
+      const denorm = denormalizePacket(packet);
+      insertPacket.run({
+        id: packet.id,
+        kind: packet.kind,
+        packetJson: JSON.stringify(packet),
+        nodeId: denorm.nodeId,
+        workspaceId: denorm.workspaceId,
+        createdBy: packet.createdBy,
+        createdAt: packet.createdAt,
+        updatedAt: now,
+      });
+      const written = getPacketById(packet.id);
+      if (!written) {
+        throw new ContextPacketStoreError(500, 'context_packet_write_failed');
+      }
+      return written;
+    },
+
+    getContextPacket: getPacketById,
+
+    listContextPackets() {
+      return (selectAllPackets.all() as ContextPacketRow[])
+        .map(rowToPacketSafe)
+        .filter((p): p is ContextPacket => p !== null);
+    },
+
+    deleteContextPacket(id: ContextPacketId) {
+      try {
+        const info = deletePacketStmt.run(id);
+        return info.changes > 0;
+      } catch (err) {
+        // ON DELETE RESTRICT on the join FK surfaces as a FK constraint error
+        // when a live message still references the packet.
+        if (isForeignKeyConstraintError(err)) {
+          throw new ContextPacketStoreError(
+            409,
+            'context_packet_referenced'
+          );
+        }
+        throw err;
+      }
+    },
+
+    createInboxMessage(input: InboxMessageCreateInput) {
+      const now = new Date().toISOString();
+      const message = buildMessageFromInput(input, now);
+      // Verify every referenced packet exists (the join FK would reject an
+      // orphan insert anyway, but a typed 400 is friendlier than a raw FK error).
+      for (const packetId of message.contextPacketIds) {
+        if (!getPacketById(packetId)) {
+          throw new ContextPacketStoreError(400, 'context_packet_not_found');
+        }
+      }
+      db.transaction(() => {
+        insertMessage.run(messageToRowParams(message, now));
+        message.contextPacketIds.forEach((packetId, ordinal) => {
+          insertMessagePacket.run(message.id, packetId, ordinal);
+        });
+      })();
+      const written = getMessageById(message.id);
+      if (!written) {
+        throw new ContextPacketStoreError(500, 'inbox_message_write_failed');
+      }
+      return written;
+    },
+
+    getInboxMessage: getMessageById,
+
+    listInboxMessages(filter: InboxMessageListFilter = {}) {
+      const clauses: string[] = [];
+      const params: unknown[] = [];
+      if (filter.targetSessionId !== undefined) {
+        clauses.push('target_session_id = ?');
+        params.push(filter.targetSessionId);
+      }
+      if (filter.targetWorkContextId !== undefined) {
+        clauses.push('target_work_context_id = ?');
+        params.push(filter.targetWorkContextId);
+      }
+      if (filter.state !== undefined) {
+        clauses.push('state = ?');
+        params.push(filter.state);
+      }
+      const where = clauses.length ? ` WHERE ${clauses.join(' AND ')}` : '';
+      const stmt = db.prepare(
+        `SELECT id, target_session_id, target_work_context_id, message_json, state,
+                created_by, created_at, delivered_at, acknowledged_at, resolved_at, updated_at
+         FROM inbox_messages${where}
+         ORDER BY created_at ASC, id ASC`
+      );
+      return (stmt.all(...params) as InboxMessageRow[])
+        .map(rowToMessageSafe)
+        .filter((m): m is SessionInboxMessage => m !== null);
+    },
+
+    transitionInboxMessage(
+      id: SessionInboxMessageId,
+      to: SessionInboxMessageState
+    ) {
+      const existing = mustGetMessage(id);
+      const validation = validateInboxTransition(existing.state, to);
+      if (!validation.ok) {
+        // Terminal-state guard + illegal-jump guard (ADR-019 C2).
+        throw new ContextPacketStoreError(
+          409,
+          `inbox_transition_${validation.reason}`
+        );
+      }
+      const now = new Date().toISOString();
+      // Idempotent re-touch (from === to): refresh `updated_at` so a PULL
+      // `inbox.list` re-delivering a row is observable, but DO NOT overwrite the
+      // first-observed transition timestamp.
+      const next = applyTransition(existing, to, now, validation.idempotent);
+      updateMessageState.run({
+        id: next.id,
+        messageJson: JSON.stringify(next),
+        state: next.state,
+        deliveredAt: next.deliveredAt ?? null,
+        acknowledgedAt: next.acknowledgedAt ?? null,
+        resolvedAt: next.resolvedAt ?? null,
+        updatedAt: now,
+      });
+      const written = getMessageById(id);
+      if (!written) {
+        throw new ContextPacketStoreError(500, 'inbox_message_write_failed');
+      }
+      return written;
+    },
+
+    deleteInboxMessage(id: SessionInboxMessageId) {
+      // ON DELETE CASCADE drops the join rows; referenced packets survive.
+      const info = deleteMessageStmt.run(id);
+      return info.changes > 0;
+    },
+  };
+
+  // ── Row → domain mapping (closure-free helpers below use module scope) ──────
+  function rowToPacketSafe(row: ContextPacketRow): ContextPacket | null {
+    let parsedJson: unknown;
+    try {
+      parsedJson = JSON.parse(row.packet_json) as unknown;
+    } catch {
+      // Corrupt column (external tampering) — fail soft.
+      logger.warn('dropped context packet %s: corrupt packet_json', row.id);
+      return null;
+    }
+    const packet = parseContextPacket(parsedJson);
+    if (!packet) {
+      logger.warn('dropped context packet %s: failed validation', row.id);
+      return null;
+    }
+    return packet;
+  }
+
+  function rowToMessageSafe(row: InboxMessageRow): SessionInboxMessage | null {
+    let parsedJson: unknown;
+    try {
+      parsedJson = JSON.parse(row.message_json) as unknown;
+    } catch {
+      logger.warn('dropped inbox message %s: corrupt message_json', row.id);
+      return null;
+    }
+    const message = parseSessionInboxMessage(parsedJson);
+    if (!message) {
+      logger.warn('dropped inbox message %s: failed validation', row.id);
+      return null;
+    }
+    // The denormalized `state` column is the source of truth for transitions;
+    // reconcile the blob to it so a partially-written blob can't drift the
+    // lifecycle (the blob is rewritten on every transition, so this is belt+braces).
+    const stateCol = row.state as SessionInboxMessageState;
+    if (message.state !== stateCol) {
+      return { ...message, state: stateCol };
+    }
+    return message;
+  }
+}
+
+// ── Migration runner ─────────────────────────────────────────────────────────
+// Idempotent: a fresh DB and an already-migrated DB both end at the latest
+// MIGRATIONS version with no error. Safe on an existing DB that already has a
+// `schema_version` row (CREATE ... IF NOT EXISTS + version gate). Mirrors the
+// runner in ia-store.ts / work-contexts.ts. Bump by appending a {version, sql}.
+function runMigrations(db: Database.Database): void {
+  db.exec('CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)');
+  const row = db.prepare('SELECT version FROM schema_version').get() as
+    | { version: number }
+    | undefined;
+  const hadRow = row !== undefined;
+  let currentVersion = row?.version ?? 0;
+
+  for (const migration of MIGRATIONS) {
+    if (migration.version > currentVersion) {
+      const ver = migration.version;
+      db.transaction(() => {
+        db.exec(migration.sql);
+        if (hadRow || currentVersion > 0) {
+          db.prepare('UPDATE schema_version SET version = ?').run(ver);
+        } else {
+          db.prepare('INSERT INTO schema_version (version) VALUES (?)').run(ver);
+        }
+      })();
+      currentVersion = ver;
+    }
+  }
+}
+
+// ── Build / normalize helpers ──────────────────────────────────────────────
+
+function buildPacketFromInput(
+  input: ContextPacketCreateInput,
+  now: string
+): ContextPacket {
+  if (input.packet) {
+    const parsed = parseContextPacket(input.packet);
+    if (!parsed) {
+      throw new ContextPacketStoreError(400, 'invalid_context_packet');
+    }
+    return parsed;
+  }
+  if (!input.kind) {
+    throw new ContextPacketStoreError(400, 'context_packet_kind_required');
+  }
+  if (typeof input.createdBy !== 'string' || input.createdBy.length === 0) {
+    throw new ContextPacketStoreError(400, 'context_packet_created_by_required');
+  }
+  const draft: ContextPacket = {
+    id: input.id ?? mintPacketId(),
+    kind: input.kind,
+    createdBy: input.createdBy,
+    createdAt: now,
+    ...(input.anchor ? { anchor: input.anchor } : {}),
+    ...(input.fileRef ? { fileRef: input.fileRef } : {}),
+    ...(input.note ? { note: input.note } : {}),
+    ...(input.binding ? { binding: input.binding } : {}),
+  };
+  // Validate through the shared parser so kind-specific shape rules
+  // (file-anchor needs anchor, note needs body, etc.) are enforced once.
+  const parsed = parseContextPacket(draft);
+  if (!parsed) {
+    throw new ContextPacketStoreError(400, 'invalid_context_packet');
+  }
+  return parsed;
+}
+
+function buildMessageFromInput(
+  input: InboxMessageCreateInput,
+  now: string
+): SessionInboxMessage {
+  if (input.message) {
+    const parsed = parseSessionInboxMessage(input.message);
+    if (!parsed) {
+      throw new ContextPacketStoreError(400, 'invalid_inbox_message');
+    }
+    return parsed;
+  }
+  if (typeof input.createdBy !== 'string' || input.createdBy.length === 0) {
+    throw new ContextPacketStoreError(400, 'inbox_message_created_by_required');
+  }
+  if (!input.targetSessionId && !input.targetWorkContextId) {
+    throw new ContextPacketStoreError(400, 'inbox_message_target_required');
+  }
+  const draft: SessionInboxMessage = {
+    id: input.id ?? mintMessageId(),
+    contextPacketIds: [...(input.contextPacketIds ?? [])],
+    state: 'queued',
+    createdBy: input.createdBy,
+    createdAt: now,
+    ...(input.targetSessionId ? { targetSessionId: input.targetSessionId } : {}),
+    ...(input.targetWorkContextId
+      ? { targetWorkContextId: input.targetWorkContextId }
+      : {}),
+    ...(input.text ? { text: input.text } : {}),
+  };
+  const parsed = parseSessionInboxMessage(draft);
+  if (!parsed) {
+    throw new ContextPacketStoreError(400, 'invalid_inbox_message');
+  }
+  return parsed;
+}
+
+/**
+ * Apply a validated transition. Sets the first-observed transition timestamp
+ * (idempotent re-touches do not overwrite it). The lifecycle timestamps map:
+ *   delivered → deliveredAt, acknowledged → acknowledgedAt,
+ *   resolved → resolvedAt, ignored → ignoredAt (blob only; no column).
+ */
+function applyTransition(
+  message: SessionInboxMessage,
+  to: SessionInboxMessageState,
+  now: string,
+  idempotent: boolean
+): SessionInboxMessage {
+  if (idempotent) {
+    // No-op success: state unchanged, timestamps preserved.
+    return message;
+  }
+  const next: SessionInboxMessage = { ...message, state: to };
+  switch (to) {
+    case 'delivered':
+      if (!next.deliveredAt) next.deliveredAt = now;
+      break;
+    case 'acknowledged':
+      // A queued→acknowledged skip still records delivery (it was pulled).
+      if (!next.deliveredAt) next.deliveredAt = now;
+      if (!next.acknowledgedAt) next.acknowledgedAt = now;
+      break;
+    case 'resolved':
+      if (!next.resolvedAt) next.resolvedAt = now;
+      break;
+    case 'ignored':
+      if (!next.ignoredAt) next.ignoredAt = now;
+      break;
+    default:
+      break;
+  }
+  return next;
+}
+
+function messageToRowParams(
+  message: SessionInboxMessage,
+  now: string
+): Record<string, string | null> {
+  return {
+    id: message.id,
+    targetSessionId: message.targetSessionId ?? null,
+    targetWorkContextId: message.targetWorkContextId ?? null,
+    messageJson: JSON.stringify(message),
+    state: message.state,
+    createdBy: message.createdBy,
+    createdAt: message.createdAt,
+    deliveredAt: message.deliveredAt ?? null,
+    acknowledgedAt: message.acknowledgedAt ?? null,
+    resolvedAt: message.resolvedAt ?? null,
+    updatedAt: now,
+  };
+}
+
+/**
+ * Pull the federation-query denormalized columns out of a packet's binding +
+ * anchor. `node_id` prefers the binding, falling back to the anchor's
+ * `FileResourceRef.nodeId` (anchored packets always carry a node).
+ */
+function denormalizePacket(packet: ContextPacket): {
+  nodeId: string | null;
+  workspaceId: string | null;
+} {
+  const nodeId =
+    packet.binding?.nodeId ?? packet.anchor?.ref.nodeId ?? packet.fileRef?.nodeId ?? null;
+  const workspaceId = packet.binding?.workspaceId ?? null;
+  return { nodeId, workspaceId };
+}
+
+function mintPacketId(): ContextPacketId {
+  return createContextPacketId(crypto.randomBytes(8).toString('hex'));
+}
+
+function mintMessageId(): SessionInboxMessageId {
+  return createInboxMessageId(crypto.randomBytes(8).toString('hex'));
+}
+
+function isForeignKeyConstraintError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const code = (err as { code?: unknown }).code;
+  // better-sqlite3 surfaces ON DELETE RESTRICT failures with the extended code
+  // SQLITE_CONSTRAINT_TRIGGER (the RESTRICT action runs as a trigger) and FK
+  // violations as SQLITE_CONSTRAINT_FOREIGNKEY; older builds use the base code.
+  return (
+    typeof code === 'string' &&
+    (code === 'SQLITE_CONSTRAINT_FOREIGNKEY' ||
+      code === 'SQLITE_CONSTRAINT_TRIGGER' ||
+      code === 'SQLITE_CONSTRAINT')
+  );
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -74,6 +74,10 @@ import {
 } from './work-contexts.js';
 import { initIaStore, type IaStore } from './ia-store.js';
 import {
+  initContextPacketStore,
+  type ContextPacketStore,
+} from './context-packets.js';
+import {
   initInterventionLog,
   closeInterventionLog,
 } from './intervention-log.js';
@@ -1457,6 +1461,21 @@ async function main(): Promise<void> {
   } catch (err) {
     logger.warn(
       'IA store disabled: failed to initialize:',
+      err instanceof Error ? err.message : err
+    );
+  }
+
+  // Context-packet + session-inbox store (#758, ADR-019). Own SQLite file
+  // (`context-packets.db`); new tables only, non-destructive. CLI verbs/routes
+  // that consume it (#765) and anchor resolution (#766) land in follow-ups.
+  // Guarded so a DB error degrades to "no context-packet persistence" rather
+  // than failing boot.
+  let contextPacketStore: ContextPacketStore | null = null;
+  try {
+    contextPacketStore = initContextPacketStore(configDir);
+  } catch (err) {
+    logger.warn(
+      'Context-packet store disabled: failed to initialize:',
       err instanceof Error ? err.message : err
     );
   }
@@ -3752,6 +3771,7 @@ async function main(): Promise<void> {
         closeRelayStateDb();
         workContextStore.close();
         iaStore?.close();
+        contextPacketStore?.close();
         closeInterventionLog();
         broadcastEvent('server-restarting');
       }
@@ -3833,6 +3853,7 @@ async function main(): Promise<void> {
     closeRelayStateDb();
     workContextStore.close();
     iaStore?.close();
+    contextPacketStore?.close();
     closeInterventionLog();
     for (const s of localRelayNode.sessions.list()) {
       try {

--- a/shared/context-packet.ts
+++ b/shared/context-packet.ts
@@ -36,8 +36,11 @@ import type { WorkspaceId } from './workspace.js';
 import type { WorkContextId } from './work-context.js';
 import {
   fileResourceRefEquals,
+  fileResourceRefSummary,
+  parseFileResourceRef,
   type FileResourceRef,
 } from './file-resource-ref.js';
+import { createPromptAttachment } from './prompt-attachment.js';
 import type { PromptAttachment } from './prompt-attachment.js';
 
 // ---------------------------------------------------------------------------
@@ -130,6 +133,111 @@ export interface AnchorRef {
 
 /** Max captured `AnchorRef.quote` length in bytes. Resolver/store truncate. */
 export const MAX_ANCHOR_QUOTE_BYTES = 4096;
+
+// `quote` is a JS (UTF-16) string but `MAX_ANCHOR_QUOTE_BYTES` is a UTF-8 byte
+// budget. A single emoji is one `.length`-2 string but four UTF-8 bytes, so we
+// must measure and truncate by encoded byte length, never `.length`. Use the
+// platform `TextEncoder` (available in browsers and Node ≥ 11) so this module
+// stays browser-safe (no `node:` import).
+const QUOTE_ENCODER = new TextEncoder();
+const QUOTE_DECODER = new TextDecoder();
+
+/** UTF-8 byte length of a string (not its UTF-16 `.length`). */
+export function utf8ByteLength(value: string): number {
+  return QUOTE_ENCODER.encode(value).length;
+}
+
+/**
+ * Truncate `value` to at most `maxBytes` UTF-8 bytes. Truncation happens on a
+ * byte boundary; a multi-byte code point split by the cut is dropped (the
+ * lenient `TextDecoder` would otherwise emit a replacement char). Returns the
+ * input unchanged when it already fits.
+ */
+export function truncateUtf8(value: string, maxBytes: number): string {
+  const encoded = QUOTE_ENCODER.encode(value);
+  if (encoded.length <= maxBytes) return value;
+  // `fatal: false` (the default) emits U+FFFD for a trailing partial code
+  // point; `ignoreBOM` keeps a leading BOM intact. We then strip any trailing
+  // replacement char produced by cutting mid-codepoint.
+  const sliced = QUOTE_DECODER.decode(encoded.slice(0, maxBytes));
+  return sliced.replace(/�+$/u, '');
+}
+
+function isPositiveInt(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function parseLineRange(payload: unknown): LineRange | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const p = payload as Record<string, unknown>;
+  const startLine = p['startLine'];
+  const endLine = p['endLine'];
+  // 1-based, inclusive, both >= 1, end >= start.
+  if (typeof startLine !== 'number' || !Number.isInteger(startLine)) return null;
+  if (typeof endLine !== 'number' || !Number.isInteger(endLine)) return null;
+  if (startLine < 1 || endLine < startLine) return null;
+  return { startLine, endLine };
+}
+
+function parseByteRange(payload: unknown): ByteRange | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const p = payload as Record<string, unknown>;
+  const startByte = p['startByte'];
+  const endByte = p['endByte'];
+  // 0-based, half-open `[start, end)`, end strictly greater than start.
+  if (!isPositiveInt(startByte)) return null;
+  if (!isPositiveInt(endByte)) return null;
+  if (endByte <= startByte) return null;
+  return { startByte, endByte };
+}
+
+/**
+ * Parse + validate an unknown payload into an `AnchorRef`. Returns `null` on
+ * any validation failure (mirrors `parseFileResourceRef`). Requires a valid
+ * `FileResourceRef` plus at least one of `lineRange`/`byteRange`. The captured
+ * `quote` is truncated to `MAX_ANCHOR_QUOTE_BYTES` UTF-8 bytes (not `.length`).
+ */
+export function parseAnchorRef(payload: unknown): AnchorRef | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const p = payload as Record<string, unknown>;
+  const ref = parseFileResourceRef(p['ref']);
+  if (!ref) return null;
+  const lineRange =
+    p['lineRange'] !== undefined ? parseLineRange(p['lineRange']) : null;
+  if (p['lineRange'] !== undefined && lineRange === null) return null;
+  const byteRange =
+    p['byteRange'] !== undefined ? parseByteRange(p['byteRange']) : null;
+  if (p['byteRange'] !== undefined && byteRange === null) return null;
+  // At least one range kind is required for an anchored packet.
+  if (!lineRange && !byteRange) return null;
+  const anchor: AnchorRef = { ref };
+  if (lineRange) anchor.lineRange = lineRange;
+  if (byteRange) anchor.byteRange = byteRange;
+  if (typeof p['quote'] === 'string') {
+    anchor.quote = truncateUtf8(p['quote'], MAX_ANCHOR_QUOTE_BYTES);
+  }
+  return anchor;
+}
+
+/**
+ * Compact human-readable label for an anchor: the underlying ref summary plus
+ * the range (`#L<start>-L<end>` for line ranges, `@<start>-<end>` for byte
+ * ranges). Used for chips/audit rows and the `PromptAttachment` artifact
+ * bridge.
+ */
+export function anchorRefSummary(anchor: AnchorRef): string {
+  const base = fileResourceRefSummary(anchor.ref);
+  if (anchor.lineRange) {
+    const { startLine, endLine } = anchor.lineRange;
+    return startLine === endLine
+      ? `${base}#L${startLine}`
+      : `${base}#L${startLine}-L${endLine}`;
+  }
+  if (anchor.byteRange) {
+    return `${base}@${anchor.byteRange.startByte}-${anchor.byteRange.endByte}`;
+  }
+  return base;
+}
 
 // ---------------------------------------------------------------------------
 // Context packet envelope
@@ -237,6 +345,71 @@ export const SESSION_INBOX_MESSAGE_STATES: readonly SessionInboxMessageState[] =
 export const TERMINAL_INBOX_MESSAGE_STATES: readonly SessionInboxMessageState[] =
   ['resolved', 'ignored'] as const;
 
+/** True if `state` is terminal (`resolved`/`ignored`). */
+export function isTerminalInboxMessageState(
+  state: SessionInboxMessageState
+): boolean {
+  return (TERMINAL_INBOX_MESSAGE_STATES as readonly string[]).includes(state);
+}
+
+/**
+ * Outcome of validating a requested inbox-message state transition.
+ *   - `ok: true, idempotent: false`  — a real forward transition; apply it.
+ *   - `ok: true, idempotent: true`   — `from === to`; a re-touch (a PULL
+ *     `inbox.list` re-fetching an already-delivered row, an agent
+ *     double-acking). Treat as a no-op success, NOT an error. (ADR-019 C2.)
+ *   - `ok: false`                    — illegal: a transition out of a terminal
+ *     state, or a non-monotonic jump (e.g. `acknowledged` → `delivered`).
+ */
+export type InboxTransitionValidation =
+  | { ok: true; idempotent: boolean }
+  | { ok: false; reason: string };
+
+// Forward-reachable target states from each state. Lifecycle:
+//   queued → delivered → acknowledged → (resolved | ignored)
+// Skips are permitted forward (e.g. queued → acknowledged when an agent acks a
+// message it pulled in the same turn, or queued → resolved/ignored to dismiss
+// without acking). Backward moves are rejected; same-state is idempotent.
+const INBOX_FORWARD_TARGETS: Record<
+  SessionInboxMessageState,
+  readonly SessionInboxMessageState[]
+> = {
+  queued: ['delivered', 'acknowledged', 'resolved', 'ignored'],
+  delivered: ['acknowledged', 'resolved', 'ignored'],
+  acknowledged: ['resolved', 'ignored'],
+  resolved: [],
+  ignored: [],
+};
+
+/**
+ * Validate a requested `from → to` inbox-message state transition. The store
+ * (#758) enforces this on every update and #765 reuses it for the `inbox.*`
+ * write verbs. Implements ADR-019 C2:
+ *   - same-state is idempotent success (PULL re-touch / agent double-fetch);
+ *   - any transition OUT of a terminal state is rejected;
+ *   - only forward-reachable transitions are allowed (no backward moves).
+ */
+export function validateInboxTransition(
+  from: SessionInboxMessageState,
+  to: SessionInboxMessageState
+): InboxTransitionValidation {
+  if (!isInboxMessageState(to)) {
+    return { ok: false, reason: 'invalid_target_state' };
+  }
+  if (from === to) {
+    // Idempotent re-touch. Even when `from` is terminal: re-asserting the same
+    // terminal state is a harmless no-op, not a transition out of it.
+    return { ok: true, idempotent: true };
+  }
+  if (isTerminalInboxMessageState(from)) {
+    return { ok: false, reason: 'terminal_state' };
+  }
+  if (!INBOX_FORWARD_TARGETS[from].includes(to)) {
+    return { ok: false, reason: 'illegal_transition' };
+  }
+  return { ok: true, idempotent: false };
+}
+
 /**
  * A message in a session/WorkContext inbox. Targets exactly one of a live
  * session (`GlobalSessionId = nodeId:localSessionId`) or a durable
@@ -303,13 +476,52 @@ export interface SessionInboxMessage {
  * Project a `ContextPacket` onto a `PromptAttachment` for inclusion in an
  * outgoing prompt. `file-anchor` → the new `'file-anchor'` attachment kind;
  * `file-ref` → the existing `'file-ref'` kind; `note` → not attachable
- * (returns null — notes ride the message `text`, not the attachment list).
+ * (returns `null` — notes ride the message `text`, not the attachment list,
+ * per ADR-019 C4). Reserved kinds (`diff-ref`/`log-ref`) have no
+ * `PromptAttachment` surface yet (#760) and also return `null`.
  *
- * Signature only — impl in #758 once the union extension lands.
+ * Returns `null` (rather than throwing) when the packet lacks the data its
+ * kind requires (e.g. a `file-anchor` packet with no `anchor`), so a single
+ * malformed packet drops out of a prompt instead of tearing it down.
  */
-export declare function contextPacketToPromptAttachment(
+export function contextPacketToPromptAttachment(
   packet: ContextPacket
-): PromptAttachment | null;
+): PromptAttachment | null {
+  switch (packet.kind) {
+    case 'file-anchor': {
+      if (!packet.anchor) return null;
+      try {
+        return createPromptAttachment({
+          kind: 'file-anchor',
+          anchor: packet.anchor,
+          ...(packet.note ? { summary: packet.note } : {}),
+        });
+      } catch {
+        return null;
+      }
+    }
+    case 'file-ref': {
+      if (!packet.fileRef) return null;
+      try {
+        return createPromptAttachment({
+          kind: 'file-ref',
+          ref: packet.fileRef,
+          ...(packet.note ? { summary: packet.note } : {}),
+        });
+      } catch {
+        return null;
+      }
+    }
+    // C4: `note` packets carry no attachable ref — the body rides the inbox
+    // message `text`, never the prompt attachment list. Reserved kinds have no
+    // attachment surface in MVP.
+    case 'note':
+    case 'diff-ref':
+    case 'log-ref':
+    default:
+      return null;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Id helpers (signatures + minimal compiling stubs)
@@ -336,21 +548,198 @@ export function createInboxMessageId(suffix: string): SessionInboxMessageId {
   return `${SESSION_INBOX_MESSAGE_ID_PREFIX}${encodeURIComponent(suffix)}`;
 }
 
+/**
+ * Recover the opaque suffix from a `ContextPacketId`, or `null` if `id` is not
+ * a well-formed `cp:<suffix>` id. Round-trips `createContextPacketId`.
+ */
+export function parseContextPacketId(id: string): { suffix: string } | null {
+  if (typeof id !== 'string' || !id.startsWith(CONTEXT_PACKET_ID_PREFIX)) {
+    return null;
+  }
+  const encoded = id.slice(CONTEXT_PACKET_ID_PREFIX.length);
+  if (encoded.length === 0) return null;
+  try {
+    const suffix = decodeURIComponent(encoded);
+    return hasValue(suffix) ? { suffix } : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Recover the opaque suffix from a `SessionInboxMessageId`, or `null` if `id`
+ * is not a well-formed `im:<suffix>` id. Round-trips `createInboxMessageId`.
+ */
+export function parseInboxMessageId(id: string): { suffix: string } | null {
+  if (typeof id !== 'string' || !id.startsWith(SESSION_INBOX_MESSAGE_ID_PREFIX)) {
+    return null;
+  }
+  const encoded = id.slice(SESSION_INBOX_MESSAGE_ID_PREFIX.length);
+  if (encoded.length === 0) return null;
+  try {
+    const suffix = decodeURIComponent(encoded);
+    return hasValue(suffix) ? { suffix } : null;
+  } catch {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
-// Parse / validate (signatures only — real validation in #758)
+// Parse / validate
 // ---------------------------------------------------------------------------
+
+function isContextPacketKind(value: unknown): value is ContextPacketKind {
+  return (
+    typeof value === 'string' &&
+    (CONTEXT_PACKET_KINDS as readonly string[]).includes(value)
+  );
+}
+
+function isInboxMessageState(
+  value: unknown
+): value is SessionInboxMessageState {
+  return (
+    typeof value === 'string' &&
+    (SESSION_INBOX_MESSAGE_STATES as readonly string[]).includes(value)
+  );
+}
+
+function parseBinding(payload: unknown): ContextPacketBinding | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const p = payload as Record<string, unknown>;
+  const binding: ContextPacketBinding = {};
+  if (typeof p['workspaceId'] === 'string') binding.workspaceId = p['workspaceId'];
+  if (typeof p['nodeId'] === 'string') binding.nodeId = p['nodeId'];
+  if (typeof p['repoInstanceId'] === 'string') {
+    binding.repoInstanceId = p['repoInstanceId'];
+  }
+  if (typeof p['worktreeInstanceId'] === 'string') {
+    binding.worktreeInstanceId = p['worktreeInstanceId'];
+  }
+  return binding;
+}
+
+const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
 
 /**
  * Parse an unknown payload into a `ContextPacket`, returning `null` on any
  * validation failure (mirrors `parseFileResourceRef`/`parsePromptAttachment`).
- * Impl in #758.
+ * Kind-specific shape is enforced:
+ *   - `file-anchor` requires a valid `anchor` (`parseAnchorRef`).
+ *   - `file-ref` requires a valid whole-file `fileRef` (`parseFileResourceRef`).
+ *   - `note` requires a non-empty `note` body.
+ *   - reserved kinds (`diff-ref`/`log-ref`) parse the envelope but carry no
+ *     anchor/ref payload in MVP (#760).
  */
-export declare function parseContextPacket(payload: unknown): ContextPacket | null;
+export function parseContextPacket(payload: unknown): ContextPacket | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const p = payload as Record<string, unknown>;
+  if (typeof p['id'] !== 'string' || !parseContextPacketId(p['id'])) return null;
+  if (!isContextPacketKind(p['kind'])) return null;
+  if (typeof p['createdBy'] !== 'string' || p['createdBy'].length === 0) {
+    return null;
+  }
+  if (typeof p['createdAt'] !== 'string' || !ISO_TIMESTAMP_RE.test(p['createdAt'])) {
+    return null;
+  }
+  const kind = p['kind'];
+  const packet: ContextPacket = {
+    id: p['id'],
+    kind,
+    createdBy: p['createdBy'],
+    createdAt: p['createdAt'],
+  };
 
-/** Parse an unknown payload into a `SessionInboxMessage`. Impl in #758. */
-export declare function parseSessionInboxMessage(
+  if (kind === 'file-anchor') {
+    const anchor = parseAnchorRef(p['anchor']);
+    if (!anchor) return null;
+    packet.anchor = anchor;
+  } else if (kind === 'file-ref') {
+    const fileRef = parseFileResourceRef(p['fileRef']);
+    if (!fileRef) return null;
+    packet.fileRef = fileRef;
+  } else if (kind === 'note') {
+    if (typeof p['note'] !== 'string' || p['note'].trim().length === 0) {
+      return null;
+    }
+  }
+
+  // `note` is the required body for note kind, an optional annotation
+  // otherwise. (Already validated above for `note`.)
+  if (typeof p['note'] === 'string' && p['note'].length > 0) {
+    packet.note = p['note'];
+  }
+  const binding = p['binding'] !== undefined ? parseBinding(p['binding']) : null;
+  if (binding && Object.keys(binding).length > 0) {
+    packet.binding = binding;
+  }
+  return packet;
+}
+
+/**
+ * Parse an unknown payload into a `SessionInboxMessage`, returning `null` on
+ * validation failure. Requires at least one target (`targetSessionId` or
+ * `targetWorkContextId`), a valid lifecycle `state`, well-formed
+ * `contextPacketIds`, and ISO timestamps.
+ */
+export function parseSessionInboxMessage(
   payload: unknown
-): SessionInboxMessage | null;
+): SessionInboxMessage | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const p = payload as Record<string, unknown>;
+  if (typeof p['id'] !== 'string' || !parseInboxMessageId(p['id'])) return null;
+  if (!isInboxMessageState(p['state'])) return null;
+  if (typeof p['createdBy'] !== 'string' || p['createdBy'].length === 0) {
+    return null;
+  }
+  if (typeof p['createdAt'] !== 'string' || !ISO_TIMESTAMP_RE.test(p['createdAt'])) {
+    return null;
+  }
+
+  const targetSessionId =
+    typeof p['targetSessionId'] === 'string' ? p['targetSessionId'] : undefined;
+  const targetWorkContextId =
+    typeof p['targetWorkContextId'] === 'string'
+      ? p['targetWorkContextId']
+      : undefined;
+  // CHECK constraint mirror: at least one target is required.
+  if (!targetSessionId && !targetWorkContextId) return null;
+
+  if (!Array.isArray(p['contextPacketIds'])) return null;
+  const contextPacketIds: ContextPacketId[] = [];
+  for (const raw of p['contextPacketIds']) {
+    if (typeof raw !== 'string' || !parseContextPacketId(raw)) return null;
+    contextPacketIds.push(raw);
+  }
+
+  const message: SessionInboxMessage = {
+    id: p['id'],
+    contextPacketIds,
+    state: p['state'],
+    createdBy: p['createdBy'],
+    createdAt: p['createdAt'],
+  };
+  if (targetSessionId) message.targetSessionId = targetSessionId;
+  if (targetWorkContextId) message.targetWorkContextId = targetWorkContextId;
+  if (typeof p['text'] === 'string' && p['text'].length > 0) {
+    message.text = p['text'];
+  }
+  for (const field of [
+    'deliveredAt',
+    'acknowledgedAt',
+    'resolvedAt',
+    'ignoredAt',
+  ] as const) {
+    const value = p[field];
+    if (typeof value === 'string' && ISO_TIMESTAMP_RE.test(value)) {
+      message[field] = value;
+    }
+  }
+  return message;
+}
+
+/** Alias matching the #758 task naming (`parseInboxMessage`). */
+export const parseInboxMessage = parseSessionInboxMessage;
 
 // ---------------------------------------------------------------------------
 // Anchor resolution (the #766 primitive — signature only)

--- a/shared/prompt-attachment.ts
+++ b/shared/prompt-attachment.ts
@@ -6,6 +6,8 @@ import {
   fileResourceRefSummary,
   type FileResourceRef,
 } from './file-resource-ref.js';
+import type { AnchorRef } from './context-packet.js';
+import { parseAnchorRef, anchorRefSummary } from './context-packet.js';
 
 /**
  * `PromptAttachment` is the typed shape an agent or human attaches to an
@@ -17,9 +19,14 @@ import {
  * size-bounded.
  *
  * The discriminated union is intentionally open — `'diff-ref'` and
- * `'log-ref'` kinds will land in follow-on #616 slices.
+ * `'log-ref'` kinds will land in follow-on #616 slices. ADR-019 (#758) adds
+ * the `'file-anchor'` sibling kind (a `FileResourceRef` + range + captured
+ * quote) for anchored context packets rather than threading a `range?` onto
+ * the existing `'file-ref'` path — see `shared/context-packet.ts`.
  */
-export type PromptAttachment = PromptAttachmentFileRef;
+export type PromptAttachment =
+  | PromptAttachmentFileRef
+  | PromptAttachmentFileAnchor;
 
 export interface PromptAttachmentFileRef {
   kind: 'file-ref';
@@ -28,8 +35,22 @@ export interface PromptAttachmentFileRef {
   summary?: string;
 }
 
+/**
+ * A ranged file attachment: the `AnchorRef` (file pointer + line/byte range +
+ * captured quote) from `shared/context-packet.ts`. Distinct identity from
+ * `file-ref`: a whole-file ref and a ranged ref are different attachments,
+ * not the same one with an optional field (ADR-019 D2).
+ */
+export interface PromptAttachmentFileAnchor {
+  kind: 'file-anchor';
+  anchor: AnchorRef;
+  /** Optional short human-readable summary for chips/audit rows. */
+  summary?: string;
+}
+
 export const PROMPT_ATTACHMENT_KINDS: readonly PromptAttachment['kind'][] = [
   'file-ref',
+  'file-anchor',
 ] as const;
 
 /**
@@ -46,11 +67,35 @@ export interface CreatePromptAttachmentFileRefArgs {
   summary?: string;
 }
 
-export type CreatePromptAttachmentArgs = CreatePromptAttachmentFileRefArgs;
+export interface CreatePromptAttachmentFileAnchorArgs {
+  kind: 'file-anchor';
+  anchor: AnchorRef;
+  summary?: string;
+}
+
+export type CreatePromptAttachmentArgs =
+  | CreatePromptAttachmentFileRefArgs
+  | CreatePromptAttachmentFileAnchorArgs;
 
 export function createPromptAttachment(
   args: CreatePromptAttachmentArgs
 ): PromptAttachment {
+  if (args.kind === 'file-anchor') {
+    // Re-validate through the canonical anchor parser so a caller-built
+    // anchor is normalized (range checked, quote byte-bounded) here too.
+    const anchor = parseAnchorRef(args.anchor);
+    if (!anchor) {
+      throw new Error('PromptAttachment.anchor is invalid for kind=file-anchor');
+    }
+    const out: PromptAttachmentFileAnchor = {
+      kind: 'file-anchor',
+      anchor,
+    };
+    if (typeof args.summary === 'string' && args.summary.length > 0) {
+      out.summary = args.summary;
+    }
+    return out;
+  }
   if (args.kind !== 'file-ref') {
     throw new Error(
       `PromptAttachment.kind must be one of ${PROMPT_ATTACHMENT_KINDS.join('|')}, got: ${String((args as { kind?: unknown }).kind)}`
@@ -84,6 +129,19 @@ export function parsePromptAttachment(
 ): PromptAttachment | null {
   if (!payload || typeof payload !== 'object') return null;
   const p = payload as Record<string, unknown>;
+  if (p['kind'] === 'file-anchor') {
+    const anchor = parseAnchorRef(p['anchor']);
+    if (!anchor) return null;
+    try {
+      return createPromptAttachment({
+        kind: 'file-anchor',
+        anchor,
+        ...(typeof p['summary'] === 'string' ? { summary: p['summary'] } : {}),
+      });
+    } catch {
+      return null;
+    }
+  }
   if (p['kind'] !== 'file-ref') return null;
   const ref = parseFileResourceRef(p['ref']);
   if (!ref) return null;
@@ -137,6 +195,39 @@ export function promptAttachmentToArtifactRef(
   attachment: PromptAttachment,
   args: PromptAttachmentToArtifactRefArgs
 ): ArtifactRef {
+  if (attachment.kind === 'file-anchor') {
+    // Anchored attachment: bridge the underlying FileResourceRef + range to a
+    // bounded `file` artifact. The range rides the summary/title (the #763 pin
+    // path), never expanding the captured quote into a raw payload.
+    const aref = attachment.anchor.ref;
+    const aHasHash =
+      typeof aref.sha256 === 'string' && aref.sha256.length === 64;
+    const aSummary = attachment.summary ?? anchorRefSummary(attachment.anchor);
+    const aPrivacy = createWorkContextPrivacyMetadata({
+      classification: 'internal',
+      retention: 'session',
+      rawPayloadStored: false,
+      redaction: {
+        redacted: false,
+        strategy: aHasHash ? 'hash' : 'summary',
+        classes: ['artifact'],
+        ...(typeof aref.size === 'number' ? { byteCount: aref.size } : {}),
+        ...(aHasHash ? { hashSha256: aref.sha256 } : {}),
+        preview: aSummary,
+      },
+    });
+    const aOut: ArtifactRef = {
+      id: args.id,
+      kind: 'file',
+      title: aSummary,
+      path: aref.path,
+      summary: aSummary,
+      producedAt: args.producedAt ?? new Date().toISOString(),
+      privacy: aPrivacy,
+    };
+    if (args.producedByActorId) aOut.producedByActorId = args.producedByActorId;
+    return aOut;
+  }
   if (attachment.kind !== 'file-ref') {
     throw new Error(
       `promptAttachmentToArtifactRef: unsupported kind ${String((attachment as { kind?: unknown }).kind)}`

--- a/test/context-packets.test.ts
+++ b/test/context-packets.test.ts
@@ -1,0 +1,694 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createContextPacketStore,
+  ContextPacketStoreError,
+  type ContextPacketStore,
+} from '../server/context-packets.js';
+import {
+  createContextPacketId,
+  createInboxMessageId,
+  parseContextPacketId,
+  parseInboxMessageId,
+  parseContextPacket,
+  parseInboxMessage,
+  validateInboxTransition,
+  contextPacketToPromptAttachment,
+  utf8ByteLength,
+  truncateUtf8,
+  MAX_ANCHOR_QUOTE_BYTES,
+  type ContextPacket,
+} from '../shared/context-packet.js';
+import { createFileResourceRef } from '../shared/file-resource-ref.js';
+
+vi.mock('../server/logger.js', () => ({
+  createLogger: () => ({
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const tmpDirs: string[] = [];
+const openStores: ContextPacketStore[] = [];
+
+function makeDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-cp-store-test-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+function makeStore(): { store: ContextPacketStore; dbPath: string } {
+  const dbPath = path.join(makeDir(), 'context-packets.db');
+  const store = createContextPacketStore(dbPath);
+  openStores.push(store);
+  return { store, dbPath };
+}
+
+afterEach(() => {
+  while (openStores.length) {
+    try {
+      openStores.pop()!.close();
+    } catch {
+      /* already closed */
+    }
+  }
+  while (tmpDirs.length) {
+    fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function anchorRefFixture(overridePath = '/work/widget/src/index.ts') {
+  return {
+    ref: createFileResourceRef({
+      nodeId: 'local',
+      path: overridePath,
+      intent: 'read' as const,
+    }),
+    lineRange: { startLine: 10, endLine: 20 },
+    quote: 'const x = 1;',
+  };
+}
+
+// ── Id round-trip ────────────────────────────────────────────────────────────
+
+describe('context-packet: id helpers', () => {
+  it('round-trips a context packet id through create/parse', () => {
+    const id = createContextPacketId('abc123');
+    expect(id).toBe('cp:abc123');
+    expect(parseContextPacketId(id)).toEqual({ suffix: 'abc123' });
+  });
+
+  it('round-trips an inbox message id through create/parse', () => {
+    const id = createInboxMessageId('deadbeef');
+    expect(id).toBe('im:deadbeef');
+    expect(parseInboxMessageId(id)).toEqual({ suffix: 'deadbeef' });
+  });
+
+  it('round-trips suffixes needing url-encoding', () => {
+    const id = createContextPacketId('a:b/c');
+    expect(parseContextPacketId(id)).toEqual({ suffix: 'a:b/c' });
+  });
+
+  it('rejects ids with the wrong prefix or empty suffix', () => {
+    expect(parseContextPacketId('im:abc')).toBeNull();
+    expect(parseContextPacketId('cp:')).toBeNull();
+    expect(parseInboxMessageId('cp:abc')).toBeNull();
+    expect(() => createContextPacketId('   ')).toThrow();
+  });
+});
+
+// ── UTF-8 quote truncation (nit) ─────────────────────────────────────────────
+
+describe('context-packet: utf-8 quote bounding', () => {
+  it('measures by utf-8 bytes, not utf-16 length', () => {
+    // "😀" is .length 2 but 4 utf-8 bytes.
+    expect('😀'.length).toBe(2);
+    expect(utf8ByteLength('😀')).toBe(4);
+  });
+
+  it('truncates by byte length and drops a split multi-byte codepoint', () => {
+    const emojis = '😀😀😀'; // 12 utf-8 bytes, .length 6
+    const truncated = truncateUtf8(emojis, 5); // 1 full emoji (4B) + partial
+    expect(utf8ByteLength(truncated)).toBeLessThanOrEqual(5);
+    // No replacement char left from the split.
+    expect(truncated).not.toContain('�');
+    expect(truncated).toBe('😀');
+  });
+
+  it('parseAnchorRef bounds quote to MAX_ANCHOR_QUOTE_BYTES', () => {
+    const longQuote = 'a'.repeat(MAX_ANCHOR_QUOTE_BYTES + 500);
+    const packet = parseContextPacket({
+      id: createContextPacketId('q'),
+      kind: 'file-anchor',
+      anchor: { ...anchorRefFixture(), quote: longQuote },
+      createdBy: 'tester',
+      createdAt: '2026-05-27T00:00:00.000Z',
+    });
+    expect(packet).not.toBeNull();
+    expect(utf8ByteLength(packet!.anchor!.quote!)).toBeLessThanOrEqual(
+      MAX_ANCHOR_QUOTE_BYTES
+    );
+  });
+});
+
+// ── Context packet round-trip ────────────────────────────────────────────────
+
+describe('context-packet store: packet round-trip', () => {
+  it('creates -> gets -> lists a file-anchor packet', () => {
+    const { store } = makeStore();
+    const created = store.createContextPacket({
+      kind: 'file-anchor',
+      anchor: anchorRefFixture(),
+      createdBy: 'agent:1',
+      binding: { workspaceId: 'ws:team', nodeId: 'local' },
+    });
+    expect(created.id.startsWith('cp:')).toBe(true);
+    expect(created.kind).toBe('file-anchor');
+    expect(created.anchor?.lineRange).toEqual({ startLine: 10, endLine: 20 });
+
+    const read = store.getContextPacket(created.id);
+    expect(read).not.toBeNull();
+    expect(read!.anchor?.ref.path).toBe('/work/widget/src/index.ts');
+
+    expect(store.listContextPackets().map((p) => p.id)).toContain(created.id);
+  });
+
+  it('creates a note packet (no anchor/fileRef)', () => {
+    const { store } = makeStore();
+    const created = store.createContextPacket({
+      kind: 'note',
+      note: 'remember to handle the empty case',
+      createdBy: 'human:donovan',
+    });
+    expect(created.kind).toBe('note');
+    expect(store.getContextPacket(created.id)!.note).toBe(
+      'remember to handle the empty case'
+    );
+  });
+
+  it('rejects a file-anchor packet with no anchor', () => {
+    const { store } = makeStore();
+    expect(() =>
+      store.createContextPacket({ kind: 'file-anchor', createdBy: 'a' })
+    ).toThrow(ContextPacketStoreError);
+  });
+
+  it('rejects a note packet with no body', () => {
+    const { store } = makeStore();
+    expect(() =>
+      store.createContextPacket({ kind: 'note', createdBy: 'a' })
+    ).toThrow(/invalid_context_packet/);
+  });
+
+  it('requires createdBy', () => {
+    const { store } = makeStore();
+    expect(() =>
+      store.createContextPacket({ kind: 'note', note: 'x' })
+    ).toThrow(/created_by_required/);
+  });
+});
+
+// ── Inbox message round-trip ─────────────────────────────────────────────────
+
+describe('context-packet store: inbox message round-trip', () => {
+  it('creates -> gets -> lists an inbox message (queued)', () => {
+    const { store } = makeStore();
+    const packet = store.createContextPacket({
+      kind: 'note',
+      note: 'see this',
+      createdBy: 'agent:1',
+    });
+    const msg = store.createInboxMessage({
+      targetSessionId: 'local:sess-1',
+      contextPacketIds: [packet.id],
+      text: 'context for you',
+      createdBy: 'agent:1',
+    });
+    expect(msg.id.startsWith('im:')).toBe(true);
+    expect(msg.state).toBe('queued');
+    expect(msg.contextPacketIds).toEqual([packet.id]);
+
+    const read = store.getInboxMessage(msg.id);
+    expect(read!.text).toBe('context for you');
+  });
+
+  it('filters by target session and state', () => {
+    const { store } = makeStore();
+    const p = store.createContextPacket({
+      kind: 'note',
+      note: 'n',
+      createdBy: 'a',
+    });
+    const a = store.createInboxMessage({
+      targetSessionId: 'local:s1',
+      contextPacketIds: [p.id],
+      createdBy: 'a',
+    });
+    store.createInboxMessage({
+      targetSessionId: 'local:s2',
+      contextPacketIds: [p.id],
+      createdBy: 'a',
+    });
+    expect(
+      store.listInboxMessages({ targetSessionId: 'local:s1' }).map((m) => m.id)
+    ).toEqual([a.id]);
+    expect(
+      store.listInboxMessages({ targetSessionId: 'local:s1', state: 'delivered' })
+    ).toEqual([]);
+  });
+
+  it('filters by target work context', () => {
+    const { store } = makeStore();
+    const p = store.createContextPacket({
+      kind: 'note',
+      note: 'n',
+      createdBy: 'a',
+    });
+    const m = store.createInboxMessage({
+      targetWorkContextId: 'wc:abc',
+      contextPacketIds: [p.id],
+      createdBy: 'a',
+    });
+    expect(
+      store.listInboxMessages({ targetWorkContextId: 'wc:abc' }).map((x) => x.id)
+    ).toEqual([m.id]);
+  });
+
+  it('requires at least one target', () => {
+    const { store } = makeStore();
+    const p = store.createContextPacket({
+      kind: 'note',
+      note: 'n',
+      createdBy: 'a',
+    });
+    expect(() =>
+      store.createInboxMessage({ contextPacketIds: [p.id], createdBy: 'a' })
+    ).toThrow(/target_required/);
+  });
+
+  it('rejects a message referencing a missing packet', () => {
+    const { store } = makeStore();
+    expect(() =>
+      store.createInboxMessage({
+        targetSessionId: 'local:s1',
+        contextPacketIds: [createContextPacketId('ghost')],
+        createdBy: 'a',
+      })
+    ).toThrow(/context_packet_not_found/);
+  });
+});
+
+// ── M2M join semantics ───────────────────────────────────────────────────────
+
+describe('context-packet store: M2M join + delete semantics', () => {
+  it('one packet referenced by two messages; deleting a message keeps the packet', () => {
+    const { store } = makeStore();
+    const packet = store.createContextPacket({
+      kind: 'note',
+      note: 'shared',
+      createdBy: 'a',
+    });
+    const m1 = store.createInboxMessage({
+      targetSessionId: 'local:s1',
+      contextPacketIds: [packet.id],
+      createdBy: 'a',
+    });
+    const m2 = store.createInboxMessage({
+      targetSessionId: 'local:s2',
+      contextPacketIds: [packet.id],
+      createdBy: 'a',
+    });
+    expect(m1.contextPacketIds).toEqual([packet.id]);
+    expect(m2.contextPacketIds).toEqual([packet.id]);
+
+    // Delete m1: m2 + packet survive.
+    expect(store.deleteInboxMessage(m1.id)).toBe(true);
+    expect(store.getInboxMessage(m1.id)).toBeNull();
+    expect(store.getInboxMessage(m2.id)).not.toBeNull();
+    expect(store.getContextPacket(packet.id)).not.toBeNull();
+  });
+
+  it('deleting a packet still referenced by a live message is RESTRICTed', () => {
+    const { store } = makeStore();
+    const packet = store.createContextPacket({
+      kind: 'note',
+      note: 'pinned',
+      createdBy: 'a',
+    });
+    store.createInboxMessage({
+      targetSessionId: 'local:s1',
+      contextPacketIds: [packet.id],
+      createdBy: 'a',
+    });
+    expect(() => store.deleteContextPacket(packet.id)).toThrow(
+      /context_packet_referenced/
+    );
+    // Still present.
+    expect(store.getContextPacket(packet.id)).not.toBeNull();
+  });
+
+  it('deleting an unreferenced packet succeeds', () => {
+    const { store } = makeStore();
+    const packet = store.createContextPacket({
+      kind: 'note',
+      note: 'lonely',
+      createdBy: 'a',
+    });
+    expect(store.deleteContextPacket(packet.id)).toBe(true);
+    expect(store.getContextPacket(packet.id)).toBeNull();
+    expect(store.deleteContextPacket(packet.id)).toBe(false);
+  });
+
+  it('preserves contextPacketIds order via the ordinal column', () => {
+    const { store } = makeStore();
+    const p1 = store.createContextPacket({
+      kind: 'note',
+      note: '1',
+      createdBy: 'a',
+    });
+    const p2 = store.createContextPacket({
+      kind: 'note',
+      note: '2',
+      createdBy: 'a',
+    });
+    const p3 = store.createContextPacket({
+      kind: 'note',
+      note: '3',
+      createdBy: 'a',
+    });
+    const m = store.createInboxMessage({
+      targetSessionId: 'local:s1',
+      contextPacketIds: [p3.id, p1.id, p2.id],
+      createdBy: 'a',
+    });
+    expect(store.getInboxMessage(m.id)!.contextPacketIds).toEqual([
+      p3.id,
+      p1.id,
+      p2.id,
+    ]);
+  });
+});
+
+// ── State transitions (C2) ───────────────────────────────────────────────────
+
+describe('context-packet store: inbox transitions (ADR-019 C2)', () => {
+  function seedMessage(store: ContextPacketStore) {
+    const p = store.createContextPacket({
+      kind: 'note',
+      note: 'n',
+      createdBy: 'a',
+    });
+    return store.createInboxMessage({
+      targetSessionId: 'local:s1',
+      contextPacketIds: [p.id],
+      createdBy: 'a',
+    });
+  }
+
+  it('queued -> delivered -> acknowledged -> resolved sets timestamps', () => {
+    const { store } = makeStore();
+    const m = seedMessage(store);
+
+    const delivered = store.transitionInboxMessage(m.id, 'delivered');
+    expect(delivered.state).toBe('delivered');
+    expect(delivered.deliveredAt).toBeTruthy();
+
+    const acked = store.transitionInboxMessage(m.id, 'acknowledged');
+    expect(acked.state).toBe('acknowledged');
+    expect(acked.acknowledgedAt).toBeTruthy();
+    // deliveredAt preserved across the ack transition.
+    expect(acked.deliveredAt).toBe(delivered.deliveredAt);
+
+    const resolved = store.transitionInboxMessage(m.id, 'resolved');
+    expect(resolved.state).toBe('resolved');
+    expect(resolved.resolvedAt).toBeTruthy();
+  });
+
+  it('delivered is idempotent: re-touch does not error or move the timestamp', () => {
+    const { store } = makeStore();
+    const m = seedMessage(store);
+    const first = store.transitionInboxMessage(m.id, 'delivered');
+    // PULL inbox.list re-touches the row — must be a no-op success.
+    const second = store.transitionInboxMessage(m.id, 'delivered');
+    expect(second.state).toBe('delivered');
+    expect(second.deliveredAt).toBe(first.deliveredAt);
+  });
+
+  it('acknowledged is idempotent (agent double-fetch / double-ack)', () => {
+    const { store } = makeStore();
+    const m = seedMessage(store);
+    store.transitionInboxMessage(m.id, 'delivered');
+    const first = store.transitionInboxMessage(m.id, 'acknowledged');
+    const second = store.transitionInboxMessage(m.id, 'acknowledged');
+    expect(second.state).toBe('acknowledged');
+    expect(second.acknowledgedAt).toBe(first.acknowledgedAt);
+  });
+
+  it('rejects a transition out of a terminal state (resolved)', () => {
+    const { store } = makeStore();
+    const m = seedMessage(store);
+    store.transitionInboxMessage(m.id, 'resolved');
+    expect(() => store.transitionInboxMessage(m.id, 'delivered')).toThrow(
+      /inbox_transition_terminal_state/
+    );
+    expect(() => store.transitionInboxMessage(m.id, 'acknowledged')).toThrow(
+      /terminal_state/
+    );
+  });
+
+  it('rejects a transition out of a terminal state (ignored)', () => {
+    const { store } = makeStore();
+    const m = seedMessage(store);
+    store.transitionInboxMessage(m.id, 'ignored');
+    expect(() => store.transitionInboxMessage(m.id, 'resolved')).toThrow(
+      /terminal_state/
+    );
+  });
+
+  it('re-asserting the same terminal state is an idempotent no-op (not rejected)', () => {
+    const { store } = makeStore();
+    const m = seedMessage(store);
+    const resolved = store.transitionInboxMessage(m.id, 'resolved');
+    const again = store.transitionInboxMessage(m.id, 'resolved');
+    expect(again.state).toBe('resolved');
+    expect(again.resolvedAt).toBe(resolved.resolvedAt);
+  });
+
+  it('rejects a backward transition (acknowledged -> delivered)', () => {
+    const { store } = makeStore();
+    const m = seedMessage(store);
+    store.transitionInboxMessage(m.id, 'delivered');
+    store.transitionInboxMessage(m.id, 'acknowledged');
+    expect(() => store.transitionInboxMessage(m.id, 'delivered')).toThrow(
+      /illegal_transition/
+    );
+  });
+
+  it('shared validator agrees with the store guard', () => {
+    expect(validateInboxTransition('queued', 'delivered')).toEqual({
+      ok: true,
+      idempotent: false,
+    });
+    expect(validateInboxTransition('delivered', 'delivered')).toEqual({
+      ok: true,
+      idempotent: true,
+    });
+    expect(validateInboxTransition('resolved', 'delivered')).toMatchObject({
+      ok: false,
+      reason: 'terminal_state',
+    });
+    expect(validateInboxTransition('acknowledged', 'queued')).toMatchObject({
+      ok: false,
+    });
+  });
+});
+
+// ── PromptAttachment bridge (C4) ─────────────────────────────────────────────
+
+describe('context-packet: contextPacketToPromptAttachment (C4)', () => {
+  it('file-anchor packet -> file-anchor attachment', () => {
+    const packet: ContextPacket = {
+      id: createContextPacketId('a'),
+      kind: 'file-anchor',
+      anchor: anchorRefFixture(),
+      createdBy: 'a',
+      createdAt: '2026-05-27T00:00:00.000Z',
+    };
+    const att = contextPacketToPromptAttachment(packet);
+    expect(att?.kind).toBe('file-anchor');
+  });
+
+  it('file-ref packet -> file-ref attachment', () => {
+    const packet: ContextPacket = {
+      id: createContextPacketId('b'),
+      kind: 'file-ref',
+      fileRef: createFileResourceRef({
+        nodeId: 'local',
+        path: '/work/widget/README.md',
+        intent: 'read',
+      }),
+      createdBy: 'a',
+      createdAt: '2026-05-27T00:00:00.000Z',
+    };
+    const att = contextPacketToPromptAttachment(packet);
+    expect(att?.kind).toBe('file-ref');
+  });
+
+  it('note packet -> null (rides message text, not the attachment list)', () => {
+    const packet: ContextPacket = {
+      id: createContextPacketId('c'),
+      kind: 'note',
+      note: 'just a note',
+      createdBy: 'a',
+      createdAt: '2026-05-27T00:00:00.000Z',
+    };
+    expect(contextPacketToPromptAttachment(packet)).toBeNull();
+  });
+});
+
+// ── parse round-trips ────────────────────────────────────────────────────────
+
+describe('context-packet: parsers', () => {
+  it('parseContextPacket round-trips a stored packet', () => {
+    const { store } = makeStore();
+    const created = store.createContextPacket({
+      kind: 'file-anchor',
+      anchor: anchorRefFixture(),
+      createdBy: 'agent:1',
+    });
+    const reparsed = parseContextPacket(JSON.parse(JSON.stringify(created)));
+    expect(reparsed).toEqual(created);
+  });
+
+  it('parseInboxMessage round-trips a stored message', () => {
+    const { store } = makeStore();
+    const p = store.createContextPacket({
+      kind: 'note',
+      note: 'n',
+      createdBy: 'a',
+    });
+    const m = store.createInboxMessage({
+      targetSessionId: 'local:s1',
+      contextPacketIds: [p.id],
+      text: 'hi',
+      createdBy: 'a',
+    });
+    const reparsed = parseInboxMessage(JSON.parse(JSON.stringify(m)));
+    expect(reparsed).toEqual(m);
+  });
+
+  it('parseContextPacket rejects bad payloads', () => {
+    expect(parseContextPacket(null)).toBeNull();
+    expect(parseContextPacket({ id: 'cp:x', kind: 'bogus', createdBy: 'a', createdAt: '2026-05-27T00:00:00.000Z' })).toBeNull();
+    expect(parseInboxMessage({ id: 'im:x', state: 'queued', createdBy: 'a', createdAt: '2026-05-27T00:00:00.000Z', contextPacketIds: [] })).toBeNull();
+  });
+});
+
+// ── Durability + migration + fail-soft ───────────────────────────────────────
+
+describe('context-packet store: durability + migration', () => {
+  it('persists across re-open of the same DB file', () => {
+    const dbPath = path.join(makeDir(), 'context-packets.db');
+    const s1 = createContextPacketStore(dbPath);
+    const packet = s1.createContextPacket({
+      kind: 'note',
+      note: 'durable',
+      createdBy: 'a',
+    });
+    const msg = s1.createInboxMessage({
+      targetSessionId: 'local:s1',
+      contextPacketIds: [packet.id],
+      createdBy: 'a',
+    });
+    s1.close();
+
+    const s2 = createContextPacketStore(dbPath);
+    openStores.push(s2);
+    expect(s2.getContextPacket(packet.id)!.note).toBe('durable');
+    expect(s2.getInboxMessage(msg.id)!.contextPacketIds).toEqual([packet.id]);
+  });
+
+  it('migration is idempotent: re-running createContextPacketStore is a no-op', () => {
+    const dbPath = path.join(makeDir(), 'context-packets.db');
+    const a = createContextPacketStore(dbPath);
+    a.createContextPacket({ kind: 'note', note: 'keep', createdBy: 'a' });
+    a.close();
+
+    const b = createContextPacketStore(dbPath);
+    b.close();
+    const c = createContextPacketStore(dbPath);
+    openStores.push(c);
+    expect(c.listContextPackets()).toHaveLength(1);
+
+    const db = new Database(dbPath);
+    try {
+      const row = db.prepare('SELECT version FROM schema_version').get() as {
+        version: number;
+      };
+      expect(row.version).toBe(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('creates the expected tables on a fresh DB', () => {
+    const { store, dbPath } = makeStore();
+    store.close();
+    openStores.pop();
+
+    const db = new Database(dbPath);
+    try {
+      const tables = (
+        db
+          .prepare(
+            "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+          )
+          .all() as Array<{ name: string }>
+      ).map((r) => r.name);
+      expect(tables).toContain('context_packets');
+      expect(tables).toContain('inbox_messages');
+      expect(tables).toContain('inbox_message_packets');
+      expect(tables).toContain('schema_version');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('fails soft on corrupt JSON columns instead of throwing', () => {
+    const dbPath = path.join(makeDir(), 'context-packets.db');
+    const s1 = createContextPacketStore(dbPath);
+    const packet = s1.createContextPacket({
+      kind: 'note',
+      note: 'n',
+      createdBy: 'a',
+    });
+    const msg = s1.createInboxMessage({
+      targetSessionId: 'local:s1',
+      contextPacketIds: [packet.id],
+      createdBy: 'a',
+    });
+    s1.close();
+
+    const raw = new Database(dbPath);
+    raw
+      .prepare('UPDATE context_packets SET packet_json = ? WHERE id = ?')
+      .run('{not json', packet.id);
+    raw
+      .prepare('UPDATE inbox_messages SET message_json = ? WHERE id = ?')
+      .run('{not json', msg.id);
+    raw.close();
+
+    const s2 = createContextPacketStore(dbPath);
+    openStores.push(s2);
+    // Getters degrade to null; list paths drop the bad rows without throwing.
+    expect(s2.getContextPacket(packet.id)).toBeNull();
+    expect(s2.getInboxMessage(msg.id)).toBeNull();
+    expect(() => s2.listContextPackets()).not.toThrow();
+    expect(() => s2.listInboxMessages()).not.toThrow();
+    expect(s2.listContextPackets()).toEqual([]);
+    expect(s2.listInboxMessages()).toEqual([]);
+  });
+
+  it('empty-DB safety: list returns [] before any insert', () => {
+    const { store } = makeStore();
+    expect(store.listContextPackets()).toEqual([]);
+    expect(store.listInboxMessages()).toEqual([]);
+    expect(store.getContextPacket(createContextPacketId('none'))).toBeNull();
+    expect(store.getInboxMessage(createInboxMessageId('none'))).toBeNull();
+  });
+
+  it('transition on a missing message 404s', () => {
+    const { store } = makeStore();
+    expect(() =>
+      store.transitionInboxMessage(createInboxMessageId('ghost'), 'delivered')
+    ).toThrow(/inbox_message_not_found/);
+  });
+});


### PR DESCRIPTION
## What shipped

Implements the **ContextPacket** primitive (ADR-019) and its SQLite-behind-gateway persistence — the model + store lane (#758) of epic #757.

- **`shared/context-packet.ts`** — implemented the sketched stubs:
  - `parseAnchorRef` (validates range + bounds `quote` to `MAX_ANCHOR_QUOTE_BYTES` by **UTF-8 byte length**, not UTF-16 `.length`), `anchorRefSummary`, `utf8ByteLength`/`truncateUtf8`.
  - `parseContextPacket` / `parseSessionInboxMessage` (+ `parseInboxMessage` alias matching the task naming), with kind-specific shape enforcement (file-anchor needs an anchor, note needs a body, etc.).
  - `parseContextPacketId` / `parseInboxMessageId` round-trip helpers for `cp:`/`im:` ids.
  - `contextPacketToPromptAttachment` — `file-anchor`→anchor attachment, `file-ref`→file-ref attachment, **`note`→`null`** (C4: notes ride the message `text`, not the attachment list); reserved kinds → `null`.
  - `validateInboxTransition` + `isTerminalInboxMessageState` — the **C2 transition guard** (see below).
- **`shared/prompt-attachment.ts`** — additively extended the open union with the **`'file-anchor'`** sibling kind across the type, `PROMPT_ATTACHMENT_KINDS`, `create`/`parse`, and `promptAttachmentToArtifactRef`. Existing `file-ref` consumers are unaffected (passthrough / explicit reject paths preserved).
- **`server/context-packets.ts`** (new) — the store, mirroring `server/work-contexts.ts` exactly: guarded `schema_version` migration, `initContextPacketStore(configDir)` / `createContextPacketStore(dbPath)` factory split, blob `*_json` + denormalized columns, prepared parameterized statements, `close()`.
- **`server/index.ts`** — one localized block: guarded `initContextPacketStore` at boot (degrades to "no context-packet persistence", never crashes boot) + `close()` on both shutdown paths (update-restart and `gracefulShutdown`).

## ADR-019 conformance

- **D1** — SQLite behind the gateway, own DB file (`context-packets.db`), no `.relay/*.json` write path.
- **D2** — extends `PromptAttachment` with the `file-anchor` sibling kind; no forked `ContextAttachment`. `AnchorRef` reuses `FileResourceRef` identity/freshness.
- **D3** — lifecycle lives on the inbox message. **`stale` is DERIVED, never stored** — no `AnchorState` column. `resolveAnchorState` left as-is for #766.
- **Schema** — `context_packets`, `inbox_messages` (with the `CHECK (target_session_id IS NOT NULL OR target_work_context_id IS NOT NULL)` constraint), `inbox_message_packets` M2M join with **`ON DELETE CASCADE`** on the message FK and **`ON DELETE RESTRICT`** on the packet FK (`foreign_keys = ON`).

## C2 transition guard

`validateInboxTransition(from, to)` is the shared validator the store enforces and #765 reuses:
- **idempotent re-touch** — `from === to` returns `{ ok: true, idempotent: true }`, a no-op success (PULL `inbox.list` re-touches delivered rows; agents double-fetch/double-ack). First-observed transition timestamps are preserved on re-touch.
- **terminal guard** — any transition *out of* `resolved`/`ignored` is rejected (`terminal_state`). Re-asserting the same terminal state is still an idempotent no-op.
- **forward-only** — backward jumps (e.g. `acknowledged → delivered`) rejected (`illegal_transition`).

## Non-destructive

New tables only, own DB file. No existing store, table, or `config.json` is read or mutated. Index.ts changes are guarded (`try/catch` boot, `?.close()` shutdown).

## Test evidence

`test/context-packets.test.ts` — **41 tests passing**:
- create→get→list round-trip (packet + inbox message); session/work-context filters
- M2M join: one packet referenced by two messages; deleting a message keeps the packet (CASCADE drops join rows only); deleting a referenced packet is RESTRICTed; unreferenced delete succeeds; ordinal order preserved
- idempotent `delivered`/`acknowledged` re-touch; terminal-state transition rejected (resolved + ignored); backward transition rejected; shared validator agrees with store guard
- id round-trip via parsers; `contextPacketToPromptAttachment` C4 (note→null)
- migration idempotent; corrupt-JSON columns fail soft (getters→null, lists→[]); UTF-8 quote bounding

Gates (Node 24): `npm run build` ✓, `npm run check` ✓ (0 errors), `npm test -- context-packets` ✓ (41/41). No regressions in `prompt-attachment` / `file-resource-ref` / `cli-gateway-contract` suites.

## Stacking

Built on **#764 (PR #768, ADR-019 + shared sketches)** which is already merged to `nightly`; this branch is rebased onto `nightly`. Merge after #768. Gateway verbs/capability bits (#765) and `resolveAnchorState`/anchor RPC (#766) are out of scope and owned by their lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)