### PR TITLE
feat(#765): context/inbox gateway verbs + capability bits

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -461,7 +461,7 @@ function requireGatewaySessionId(
 
 function gatewayUsage(): never {
   logger.error(
-    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions renew|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|files write|work-contexts get|handoffs plan|handoffs create|handoffs status|handoffs cancel|handoffs resume|handoffs launch|artifacts read|supervisor snapshot|supervisor sessions|supervisor send-text|supervisor submit|events subscribe) --json'
+    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions renew|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|files write|work-contexts get|context create|context get|context list|inbox send|inbox list|inbox get|inbox ack|inbox resolve|inbox ignore|handoffs plan|handoffs create|handoffs status|handoffs cancel|handoffs resume|handoffs launch|artifacts read|supervisor snapshot|supervisor sessions|supervisor send-text|supervisor submit|events subscribe) --json'
   );
   process.exit(1);
 }
@@ -1525,6 +1525,113 @@ async function runGatewayWorkContexts(gatewayArgs: string[]): Promise<never> {
   printGatewayEnvelope(gatewayOk('work-contexts.get', result), 0);
 }
 
+async function runGatewayContext(gatewayArgs: string[]): Promise<never> {
+  const subcommand = gatewayArgs[1];
+  const contextArgs = gatewayArgs.slice(2);
+  if (subcommand === 'create') {
+    const input = parseGatewayInputObject('context.create', contextArgs);
+    const result = await gatewayHttpJson({
+      commandName: 'context.create',
+      pathName: '/context',
+      method: 'POST',
+      body: input,
+      capabilities: ['context:write'],
+    });
+    printGatewayEnvelope(gatewayOk('context.create', result), 0);
+  }
+  if (subcommand === 'get') {
+    const id = gatewayArg(contextArgs, '--id') ?? contextArgs[0];
+    if (!id || id.startsWith('--')) gatewayInvalid('context.get', '--id is required');
+    const result = await gatewayHttpJson({
+      commandName: 'context.get',
+      pathName: `/context/${encodeURIComponent(id)}`,
+      capabilities: ['context:read'],
+    });
+    printGatewayEnvelope(gatewayOk('context.get', result), 0);
+  }
+  if (subcommand === 'list') {
+    const query = new URLSearchParams();
+    const nodeId = gatewayArg(contextArgs, '--node-id');
+    const workspaceId = gatewayArg(contextArgs, '--workspace-id');
+    const limit = gatewayArg(contextArgs, '--limit');
+    if (nodeId) query.set('nodeId', nodeId);
+    if (workspaceId) query.set('workspaceId', workspaceId);
+    if (limit) query.set('limit', limit);
+    const suffix = query.toString();
+    const result = await gatewayHttpJson({
+      commandName: 'context.list',
+      pathName: suffix ? `/context?${suffix}` : '/context',
+      capabilities: ['context:read'],
+    });
+    printGatewayEnvelope(gatewayOk('context.list', result), 0);
+  }
+  gatewayInvalid('context.get', 'unknown context command', { args: gatewayArgs });
+}
+
+async function runGatewayInbox(gatewayArgs: string[]): Promise<never> {
+  const subcommand = gatewayArgs[1];
+  const inboxArgs = gatewayArgs.slice(2);
+  if (subcommand === 'send') {
+    const input = parseGatewayInputObject('inbox.send', inboxArgs);
+    const result = await gatewayHttpJson({
+      commandName: 'inbox.send',
+      pathName: '/inbox',
+      method: 'POST',
+      body: input,
+      capabilities: ['inbox:write'],
+    });
+    printGatewayEnvelope(gatewayOk('inbox.send', result), 0);
+  }
+  if (subcommand === 'list') {
+    const query = new URLSearchParams();
+    const targetSessionId = gatewayArg(inboxArgs, '--target-session-id');
+    const targetWorkContextId = gatewayArg(inboxArgs, '--target-work-context-id');
+    const state = gatewayArg(inboxArgs, '--state');
+    const limit = gatewayArg(inboxArgs, '--limit');
+    if (targetSessionId) query.set('targetSessionId', targetSessionId);
+    if (targetWorkContextId) query.set('targetWorkContextId', targetWorkContextId);
+    if (state) query.set('state', state);
+    if (limit) query.set('limit', limit);
+    const suffix = query.toString();
+    const result = await gatewayHttpJson({
+      commandName: 'inbox.list',
+      pathName: suffix ? `/inbox?${suffix}` : '/inbox',
+      capabilities: ['inbox:read'],
+    });
+    printGatewayEnvelope(gatewayOk('inbox.list', result), 0);
+  }
+  if (subcommand === 'get') {
+    const id = gatewayArg(inboxArgs, '--id') ?? inboxArgs[0];
+    if (!id || id.startsWith('--')) gatewayInvalid('inbox.get', '--id is required');
+    const result = await gatewayHttpJson({
+      commandName: 'inbox.get',
+      pathName: `/inbox/${encodeURIComponent(id)}`,
+      capabilities: ['inbox:read'],
+    });
+    printGatewayEnvelope(gatewayOk('inbox.get', result), 0);
+  }
+  if (subcommand === 'ack' || subcommand === 'resolve' || subcommand === 'ignore') {
+    const commandName =
+      subcommand === 'ack'
+        ? 'inbox.ack'
+        : subcommand === 'resolve'
+          ? 'inbox.resolve'
+          : 'inbox.ignore';
+    const id = gatewayArg(inboxArgs, '--id') ?? inboxArgs[0];
+    if (!id || id.startsWith('--')) gatewayInvalid(commandName, '--id is required');
+    const actorId = gatewayArg(inboxArgs, '--actor-id');
+    const result = await gatewayHttpJson({
+      commandName,
+      pathName: `/inbox/${encodeURIComponent(id)}/${subcommand}`,
+      method: 'POST',
+      body: actorId ? { actorId } : {},
+      capabilities: ['inbox:write'],
+    });
+    printGatewayEnvelope(gatewayOk(commandName, result), 0);
+  }
+  gatewayInvalid('inbox.get', 'unknown inbox command', { args: gatewayArgs });
+}
+
 async function runGatewayHandoffs(gatewayArgs: string[]): Promise<never> {
   const subcommand = gatewayArgs[1];
   const handoffArgs = gatewayArgs.slice(2);
@@ -2062,6 +2169,8 @@ async function runGatewayV1(): Promise<never> {
   if (top === 'sessions') return runGatewaySessions(gatewayArgs);
   if (top === 'files') return runGatewayFiles(gatewayArgs);
   if (top === 'work-contexts') return runGatewayWorkContexts(gatewayArgs);
+  if (top === 'context') return runGatewayContext(gatewayArgs);
+  if (top === 'inbox') return runGatewayInbox(gatewayArgs);
   if (top === 'handoffs') return runGatewayHandoffs(gatewayArgs);
   if (top === 'artifacts') return runGatewayArtifacts(gatewayArgs);
   if (top === 'supervisor') return runGatewaySupervisor(gatewayArgs);

--- a/server/features/context-inbox-router.ts
+++ b/server/features/context-inbox-router.ts
@@ -1,0 +1,479 @@
+// #765 / ADR-019: gateway HTTP surface for context packets + session inbox.
+//
+// This router owns the `context.*` / `inbox.*` v1 CLI gateway verbs. It is
+// STRICTLY ref-only and hub-mediated: it never pushes context into a session's
+// raw PTY input. Delivery is PULL — `inbox.list` / `inbox.get` are the only
+// verbs that flip a message `queued → delivered`, as a read side effect.
+//
+// STORE SEAM (parallel lane #758): this router depends only on the narrow
+// `ContextInboxStore` interface declared below — create/get/list packets,
+// send/list/get inbox messages, and a single transition-guarded
+// `updateInboxState`. #758 builds the concrete SQLite-behind-gateway store
+// (mirroring `server/work-contexts.ts`) and the orchestrator wires it into the
+// mount block in `server/index.ts` at integration. Until then this router can
+// be exercised against any in-memory implementation of the interface (see the
+// route-level test).
+//
+// CAPABILITY GATE: the gateway client forwards granted bits in the
+// `x-relay-capabilities` header. Reads require `context:read` / `inbox:read`,
+// writes require `context:write` / `inbox:write`. A missing bit is a 403
+// FORBIDDEN — consistent with `server/cli-gateway-events.ts`. The bits are
+// default-allow (reads) / dev-allow-not-high-risk (writes) per ADR-019 D5, so
+// a headless agent ack loop is never gated behind a confirmation prompt.
+//
+// TERMINAL-STATE GUARD (fugu C2): `inbox.ack` / `inbox.resolve` / `inbox.ignore`
+// call the store's transition-guarded `updateInboxState`; the router never
+// trusts the caller to enforce the lifecycle. Idempotent re-acks succeed; any
+// transition out of a `TERMINAL_INBOX_MESSAGE_STATES` member is rejected as a
+// SESSION_CONFLICT. The same guard is shared with #758's store.
+
+import { Router } from 'express';
+import type { RequestHandler, Request, Response } from 'express';
+
+import type { RelayCliGatewayErrorCode } from '../../shared/cli-gateway-contract.js';
+import type { GlobalSessionId } from '../../shared/identity.js';
+import type { WorkContextId } from '../../shared/work-context.js';
+import {
+  TERMINAL_INBOX_MESSAGE_STATES,
+  type ContextPacket,
+  type ContextPacketBinding,
+  type ContextPacketId,
+  type ContextPacketKind,
+  type SessionInboxMessage,
+  type SessionInboxMessageId,
+  type SessionInboxMessageState,
+} from '../../shared/context-packet.js';
+
+// ---------------------------------------------------------------------------
+// Store seam — implemented by #758, depended on here as an interface.
+// ---------------------------------------------------------------------------
+
+/** Input the router hands the store to mint a packet. */
+export interface CreateContextPacketInput {
+  kind: ContextPacketKind;
+  anchor?: ContextPacket['anchor'];
+  fileRef?: ContextPacket['fileRef'];
+  note?: string;
+  binding?: ContextPacketBinding;
+  createdBy: string;
+}
+
+/** Filter for `listPackets`. All fields optional. */
+export interface ListContextPacketsFilter {
+  nodeId?: string;
+  workspaceId?: string;
+  limit?: number;
+}
+
+/** Input the router hands the store to queue an inbox message. */
+export interface CreateInboxMessageInput {
+  targetSessionId?: GlobalSessionId;
+  targetWorkContextId?: WorkContextId;
+  contextPacketIds: ContextPacketId[];
+  text?: string;
+  createdBy: string;
+}
+
+/** Filter for `listInboxMessages`. At least one target is required by the route. */
+export interface ListInboxMessagesFilter {
+  targetSessionId?: GlobalSessionId;
+  targetWorkContextId?: WorkContextId;
+  state?: SessionInboxMessageState;
+  limit?: number;
+}
+
+/**
+ * Result of a transition-guarded inbox state update. `ok: false` carries a
+ * typed reason so the router can map it to the right gateway error code
+ * WITHOUT re-implementing the lifecycle rules (those live in the store, shared
+ * with #758).
+ */
+export type UpdateInboxStateResult =
+  | { ok: true; message: SessionInboxMessage }
+  | { ok: false; reason: 'not_found' }
+  | {
+      ok: false;
+      reason: 'terminal';
+      currentState: SessionInboxMessageState;
+    }
+  | {
+      ok: false;
+      reason: 'invalid_transition';
+      currentState: SessionInboxMessageState;
+    };
+
+/**
+ * The narrow store contract this router needs. #758 implements it over SQLite.
+ *
+ * `getInboxMessage` / `listInboxMessages` MAY flip `queued → delivered` as a
+ * PULL side effect (the read-as-delivery semantics from ADR-019 D3); that
+ * belongs in the store, not the router, so the projection is consistent across
+ * the future agent `preturn` path.
+ *
+ * `updateInboxState` is the single transition-guarded mutation. The store is
+ * the authority on the lifecycle machine (idempotent re-ack, terminal reject);
+ * the router only forwards the requested target state and maps the result.
+ */
+export interface ContextInboxStore {
+  createPacket(input: CreateContextPacketInput): ContextPacket;
+  getPacket(id: ContextPacketId): ContextPacket | null;
+  listPackets(filter?: ListContextPacketsFilter): ContextPacket[];
+
+  createInboxMessage(input: CreateInboxMessageInput): SessionInboxMessage;
+  listInboxMessages(filter: ListInboxMessagesFilter): SessionInboxMessage[];
+  getInboxMessage(id: SessionInboxMessageId): SessionInboxMessage | null;
+
+  /**
+   * Transition-guarded update. Caller-requested `targetState` is validated by
+   * the store against the `queued → delivered → acknowledged → terminal`
+   * machine; transitions out of a terminal state are refused.
+   */
+  updateInboxState(
+    id: SessionInboxMessageId,
+    targetState: SessionInboxMessageState,
+    actorId?: string
+  ): UpdateInboxStateResult;
+}
+
+export interface ContextInboxRouterDeps {
+  store: ContextInboxStore | null;
+  requireAuth?: RequestHandler;
+}
+
+// ---------------------------------------------------------------------------
+// Capability gate (mirrors server/cli-gateway-events.ts).
+// ---------------------------------------------------------------------------
+
+const CONTEXT_READ = 'context:read';
+const CONTEXT_WRITE = 'context:write';
+const INBOX_READ = 'inbox:read';
+const INBOX_WRITE = 'inbox:write';
+
+function parseCapabilityHeader(value: string | undefined): Set<string> {
+  if (!value) return new Set();
+  return new Set(
+    value
+      .split(/[\s,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+  );
+}
+
+interface GatewayErrorBody {
+  error: {
+    code: RelayCliGatewayErrorCode;
+    message: string;
+    retryable: boolean;
+    details?: Record<string, unknown>;
+  };
+}
+
+function gatewayErrorBody(
+  code: RelayCliGatewayErrorCode,
+  message: string,
+  retryable: boolean,
+  details?: Record<string, unknown>
+): GatewayErrorBody {
+  return { error: { code, message, retryable, ...(details ? { details } : {}) } };
+}
+
+function statusForCode(code: RelayCliGatewayErrorCode): number {
+  switch (code) {
+    case 'UNAUTHORIZED':
+      return 401;
+    case 'FORBIDDEN':
+      return 403;
+    case 'NOT_FOUND':
+      return 404;
+    case 'SESSION_CONFLICT':
+      return 409;
+    case 'SERVER_UNAVAILABLE':
+      return 503;
+    default:
+      return 400;
+  }
+}
+
+function sendGatewayError(
+  res: Response,
+  code: RelayCliGatewayErrorCode,
+  message: string,
+  retryable = false,
+  details?: Record<string, unknown>
+): void {
+  res.status(statusForCode(code)).json(gatewayErrorBody(code, message, retryable, details));
+}
+
+/** Returns true (and sends a 403) when a required capability is missing. */
+function denyMissingCapability(
+  req: Request,
+  res: Response,
+  required: readonly string[]
+): boolean {
+  const provided = parseCapabilityHeader(req.header('x-relay-capabilities'));
+  const missing = required.filter((cap) => !provided.has(cap));
+  if (missing.length === 0) return false;
+  sendGatewayError(res, 'FORBIDDEN', `missing required capability: ${missing[0]}`, false, {
+    capability: missing[0],
+    missingCapabilities: missing,
+  });
+  return true;
+}
+
+function bodyRecord(req: Request): Record<string, unknown> {
+  return typeof req.body === 'object' && req.body !== null && !Array.isArray(req.body)
+    ? (req.body as Record<string, unknown>)
+    : {};
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function readStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+}
+
+const CONTEXT_PACKET_KIND_SET = new Set<ContextPacketKind>([
+  'file-anchor',
+  'file-ref',
+  'diff-ref',
+  'log-ref',
+  'note',
+]);
+
+function readPacketKind(value: unknown): ContextPacketKind | undefined {
+  return typeof value === 'string' && CONTEXT_PACKET_KIND_SET.has(value as ContextPacketKind)
+    ? (value as ContextPacketKind)
+    : undefined;
+}
+
+const INBOX_STATE_SET = new Set<SessionInboxMessageState>([
+  'queued',
+  'delivered',
+  'acknowledged',
+  'resolved',
+  'ignored',
+]);
+
+function readInboxState(value: unknown): SessionInboxMessageState | undefined {
+  return typeof value === 'string' && INBOX_STATE_SET.has(value as SessionInboxMessageState)
+    ? (value as SessionInboxMessageState)
+    : undefined;
+}
+
+function readLimit(value: unknown): number | undefined {
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string' && value.trim()
+        ? Number(value)
+        : undefined;
+  if (parsed === undefined || !Number.isFinite(parsed)) return undefined;
+  return Math.min(Math.max(Math.trunc(parsed), 1), 200);
+}
+
+const TERMINAL_STATE_SET = new Set<SessionInboxMessageState>(TERMINAL_INBOX_MESSAGE_STATES);
+
+/** Map a guarded-update failure onto the right gateway error response. */
+function sendUpdateFailure(
+  res: Response,
+  result: Exclude<UpdateInboxStateResult, { ok: true }>
+): void {
+  if (result.reason === 'not_found') {
+    sendGatewayError(res, 'NOT_FOUND', 'inbox message not found');
+    return;
+  }
+  if (result.reason === 'terminal') {
+    sendGatewayError(
+      res,
+      'SESSION_CONFLICT',
+      `inbox message is in terminal state '${result.currentState}'`,
+      false,
+      { currentState: result.currentState, terminalStates: [...TERMINAL_INBOX_MESSAGE_STATES] }
+    );
+    return;
+  }
+  sendGatewayError(
+    res,
+    'SESSION_CONFLICT',
+    `invalid inbox state transition from '${result.currentState}'`,
+    false,
+    { currentState: result.currentState }
+  );
+}
+
+export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
+  const router = Router();
+  const auth = deps.requireAuth ?? ((_req: Request, _res: Response, next) => next());
+
+  /** Resolve the store or send 503; centralizes the null guard. */
+  function store(res: Response): ContextInboxStore | null {
+    if (!deps.store) {
+      sendGatewayError(res, 'SERVER_UNAVAILABLE', 'context/inbox store is unavailable', true, {
+        reasonCode: 'CONTEXT_STORE_UNAVAILABLE',
+      });
+      return null;
+    }
+    return deps.store;
+  }
+
+  // -- context.create ------------------------------------------------------
+  router.post('/context', auth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+    const s = store(res);
+    if (!s) return;
+    const body = bodyRecord(req);
+    const kind = readPacketKind(body['kind']);
+    if (!kind) {
+      sendGatewayError(res, 'INVALID_ARGUMENT', 'kind is required and must be a known ContextPacketKind', false, {
+        field: 'kind',
+      });
+      return;
+    }
+    const createdBy = readString(body['createdBy']) ?? 'cli-gateway';
+    try {
+      const contextPacket = s.createPacket({
+        kind,
+        ...(body['anchor'] !== undefined ? { anchor: body['anchor'] as ContextPacket['anchor'] } : {}),
+        ...(body['fileRef'] !== undefined ? { fileRef: body['fileRef'] as ContextPacket['fileRef'] } : {}),
+        ...(readString(body['note']) ? { note: body['note'] as string } : {}),
+        ...(body['binding'] !== undefined ? { binding: body['binding'] as ContextPacketBinding } : {}),
+        createdBy,
+      });
+      res.status(201).json({ contextPacket });
+    } catch (err) {
+      sendGatewayError(res, 'INVALID_ARGUMENT', err instanceof Error ? err.message : 'invalid context packet');
+    }
+  });
+
+  // -- context.list --------------------------------------------------------
+  router.get('/context', auth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+    const s = store(res);
+    if (!s) return;
+    const filter: ListContextPacketsFilter = {};
+    const nodeId = readString(req.query['nodeId']);
+    const workspaceId = readString(req.query['workspaceId']);
+    const limit = readLimit(req.query['limit']);
+    if (nodeId) filter.nodeId = nodeId;
+    if (workspaceId) filter.workspaceId = workspaceId;
+    if (limit !== undefined) filter.limit = limit;
+    res.json({ contextPackets: s.listPackets(filter) });
+  });
+
+  // -- context.get ---------------------------------------------------------
+  router.get('/context/:id', auth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
+    const s = store(res);
+    if (!s) return;
+    const contextPacket = s.getPacket(req.params['id'] ?? '');
+    if (!contextPacket) {
+      sendGatewayError(res, 'NOT_FOUND', 'context packet not found');
+      return;
+    }
+    res.json({ contextPacket });
+  });
+
+  // -- inbox.send ----------------------------------------------------------
+  router.post('/inbox', auth, (req, res) => {
+    if (denyMissingCapability(req, res, [INBOX_WRITE])) return;
+    const s = store(res);
+    if (!s) return;
+    const body = bodyRecord(req);
+    const targetSessionId = readString(body['targetSessionId']);
+    const targetWorkContextId = readString(body['targetWorkContextId']);
+    if (!targetSessionId && !targetWorkContextId) {
+      sendGatewayError(res, 'INVALID_ARGUMENT', 'one of targetSessionId or targetWorkContextId is required', false, {
+        field: 'targetSessionId',
+      });
+      return;
+    }
+    const createdBy = readString(body['createdBy']) ?? 'cli-gateway';
+    try {
+      const message = s.createInboxMessage({
+        ...(targetSessionId ? { targetSessionId } : {}),
+        ...(targetWorkContextId ? { targetWorkContextId } : {}),
+        contextPacketIds: readStringArray(body['contextPacketIds']),
+        ...(readString(body['text']) ? { text: body['text'] as string } : {}),
+        createdBy,
+      });
+      res.status(201).json({ message });
+    } catch (err) {
+      sendGatewayError(res, 'INVALID_ARGUMENT', err instanceof Error ? err.message : 'invalid inbox message');
+    }
+  });
+
+  // -- inbox.list ----------------------------------------------------------
+  // PULL delivery: the store flips queued → delivered as a read side effect.
+  router.get('/inbox', auth, (req, res) => {
+    if (denyMissingCapability(req, res, [INBOX_READ])) return;
+    const s = store(res);
+    if (!s) return;
+    const targetSessionId = readString(req.query['targetSessionId']);
+    const targetWorkContextId = readString(req.query['targetWorkContextId']);
+    if (!targetSessionId && !targetWorkContextId) {
+      sendGatewayError(res, 'INVALID_ARGUMENT', 'one of targetSessionId or targetWorkContextId is required', false, {
+        field: 'targetSessionId',
+      });
+      return;
+    }
+    const filter: ListInboxMessagesFilter = {};
+    if (targetSessionId) filter.targetSessionId = targetSessionId;
+    if (targetWorkContextId) filter.targetWorkContextId = targetWorkContextId;
+    const state = readInboxState(req.query['state']);
+    const limit = readLimit(req.query['limit']);
+    if (state) filter.state = state;
+    if (limit !== undefined) filter.limit = limit;
+    res.json({ messages: s.listInboxMessages(filter) });
+  });
+
+  // -- inbox.get -----------------------------------------------------------
+  // PULL delivery: the store flips queued → delivered as a read side effect.
+  router.get('/inbox/:id', auth, (req, res) => {
+    if (denyMissingCapability(req, res, [INBOX_READ])) return;
+    const s = store(res);
+    if (!s) return;
+    const message = s.getInboxMessage(req.params['id'] ?? '');
+    if (!message) {
+      sendGatewayError(res, 'NOT_FOUND', 'inbox message not found');
+      return;
+    }
+    res.json({ message });
+  });
+
+  // -- inbox.ack / inbox.resolve / inbox.ignore ----------------------------
+  // All three go through the store's transition-guarded update; the router
+  // never trusts the caller to enforce the lifecycle (fugu C2).
+  function transitionHandler(targetState: SessionInboxMessageState): RequestHandler {
+    return (req, res) => {
+      if (denyMissingCapability(req, res, [INBOX_WRITE])) return;
+      const s = store(res);
+      if (!s) return;
+      const id = req.params['id'] ?? '';
+      if (!id) {
+        sendGatewayError(res, 'INVALID_ARGUMENT', 'id is required', false, { field: 'id' });
+        return;
+      }
+      const actorId = readString(bodyRecord(req)['actorId']);
+      const result = s.updateInboxState(id, targetState, actorId);
+      if (!result.ok) {
+        sendUpdateFailure(res, result);
+        return;
+      }
+      res.json({ message: result.message });
+    };
+  }
+
+  router.post('/inbox/:id/ack', auth, transitionHandler('acknowledged'));
+  router.post('/inbox/:id/resolve', auth, transitionHandler('resolved'));
+  router.post('/inbox/:id/ignore', auth, transitionHandler('ignored'));
+
+  return router;
+}
+
+/** Exported for the store + tests: is this a terminal inbox state? */
+export function isTerminalInboxState(state: SessionInboxMessageState): boolean {
+  return TERMINAL_STATE_SET.has(state);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -141,6 +141,10 @@ import {
 import { createRepoInventoryFeature } from './features/repo-inventory.js';
 import { createRepoFeatureRouter } from './features/repo-router.js';
 import { createIaWorkspaceRouter } from './features/ia-workspace-router.js';
+import {
+  createContextInboxRouter,
+  type ContextInboxStore,
+} from './features/context-inbox-router.js';
 import { collectLocalRepoInventory } from './repo-inventory.js';
 import type {
   AgentType,
@@ -1690,6 +1694,15 @@ async function main(): Promise<void> {
   // non-destructive). Consumes the `iaStore` handle wired above; degrades to
   // 503 if the store failed to init.
   app.use(createIaWorkspaceRouter({ requireAuth, iaStore }));
+  // #765 / ADR-019: context.* / inbox.* gateway verbs. The concrete
+  // SQLite-behind-gateway store is built in the parallel #758 lane; this lane
+  // mounts the router against the shared `ContextInboxStore` seam. The
+  // orchestrator swaps `null` for #758's store handle at integration; until
+  // then the routes return 503 SERVER_UNAVAILABLE rather than failing boot.
+  const contextInboxStore: ContextInboxStore | null = null;
+  app.use(
+    createContextInboxRouter({ requireAuth: requireCliGatewayAuth, store: contextInboxStore })
+  );
   app.use(
     createCliGatewayEventsRouter(express, {
       cliGatewayAuth: requireCliGatewayAuth,

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -1,5 +1,9 @@
 import { RELAY_NODE_LINK_PROTOCOL_VERSION } from './relay-node-protocol.js';
 import { RELAY_SECURITY_POLICY_VERSION } from './security-policy.js';
+import {
+  CONTEXT_PACKET_KINDS,
+  SESSION_INBOX_MESSAGE_STATES,
+} from './context-packet.js';
 
 export const RELAY_CLI_GATEWAY_MAJOR = 'v1' as const;
 export const RELAY_CLI_GATEWAY_CONTRACT_VERSION = '1.0' as const;
@@ -24,6 +28,15 @@ export type RelayCliGatewayCommand =
   | 'files.read'
   | 'files.write'
   | 'work-contexts.get'
+  | 'context.create'
+  | 'context.get'
+  | 'context.list'
+  | 'inbox.send'
+  | 'inbox.list'
+  | 'inbox.get'
+  | 'inbox.ack'
+  | 'inbox.resolve'
+  | 'inbox.ignore'
   | 'handoffs.plan'
   | 'handoffs.create'
   | 'handoffs.status'
@@ -738,6 +751,173 @@ const workContextGetInputSchema: RelayJsonSchema = {
   properties: { id: stringSchema },
   required: ['id'],
 };
+
+// ---------------------------------------------------------------------------
+// context.* / inbox.* (#765, ADR-019)
+//
+// Ref-only, hub-mediated SQLite-behind-gateway context packets + session inbox.
+// Schemas are intentionally `additionalProperties: true` on the nested envelope
+// objects so the #758 store can evolve the canonical `ContextPacket` /
+// `SessionInboxMessage` blob shapes without a contract bump; the gateway verbs
+// pin only the addressing/lifecycle fields they own. Delivery is PULL: only
+// `inbox.list` / `inbox.get` flip `queued → delivered`.
+// ---------------------------------------------------------------------------
+
+const contextPacketEnvelopeSchema: RelayJsonSchema = {
+  title: 'ContextPacket',
+  type: 'object',
+  additionalProperties: true,
+  properties: {
+    id: stringSchema,
+    kind: { type: 'string', enum: CONTEXT_PACKET_KINDS },
+    note: stringSchema,
+    createdBy: stringSchema,
+    createdAt: { type: 'string', format: 'date-time' },
+  },
+  required: ['id', 'kind', 'createdBy', 'createdAt'],
+};
+
+const inboxMessageEnvelopeSchema: RelayJsonSchema = {
+  title: 'SessionInboxMessage',
+  type: 'object',
+  additionalProperties: true,
+  properties: {
+    id: stringSchema,
+    targetSessionId: stringSchema,
+    targetWorkContextId: stringSchema,
+    contextPacketIds: { type: 'array', items: stringSchema },
+    text: stringSchema,
+    state: { type: 'string', enum: SESSION_INBOX_MESSAGE_STATES },
+    createdBy: stringSchema,
+    createdAt: { type: 'string', format: 'date-time' },
+  },
+  required: ['id', 'contextPacketIds', 'state', 'createdBy', 'createdAt'],
+};
+
+const contextCreateInputSchema: RelayJsonSchema = {
+  title: 'ContextCreateInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    kind: { type: 'string', enum: CONTEXT_PACKET_KINDS },
+    anchor: { type: 'object', additionalProperties: true },
+    fileRef: { type: 'object', additionalProperties: true },
+    note: stringSchema,
+    binding: { type: 'object', additionalProperties: true },
+    createdBy: stringSchema,
+  },
+  required: ['kind'],
+};
+
+const contextGetInputSchema: RelayJsonSchema = {
+  title: 'ContextGetInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: { id: stringSchema },
+  required: ['id'],
+};
+
+const contextListInputSchema: RelayJsonSchema = {
+  title: 'ContextListInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    nodeId: stringSchema,
+    workspaceId: stringSchema,
+    limit: { type: 'number', minimum: 1, maximum: 200 },
+  },
+};
+
+const inboxSendInputSchema: RelayJsonSchema = {
+  title: 'InboxSendInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    targetSessionId: stringSchema,
+    targetWorkContextId: stringSchema,
+    contextPacketIds: { type: 'array', items: stringSchema },
+    text: stringSchema,
+    createdBy: stringSchema,
+  },
+  anyOf: [{ required: ['targetSessionId'] }, { required: ['targetWorkContextId'] }],
+};
+
+const inboxListInputSchema: RelayJsonSchema = {
+  title: 'InboxListInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    targetSessionId: stringSchema,
+    targetWorkContextId: stringSchema,
+    state: { type: 'string', enum: SESSION_INBOX_MESSAGE_STATES },
+    limit: { type: 'number', minimum: 1, maximum: 200 },
+  },
+  anyOf: [{ required: ['targetSessionId'] }, { required: ['targetWorkContextId'] }],
+};
+
+const inboxGetInputSchema: RelayJsonSchema = {
+  title: 'InboxGetInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: { id: stringSchema },
+  required: ['id'],
+};
+
+const inboxTransitionInputSchema: RelayJsonSchema = {
+  title: 'InboxTransitionInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: { id: stringSchema, actorId: stringSchema },
+  required: ['id'],
+};
+
+const contextPacketDataSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { contextPacket: contextPacketEnvelopeSchema },
+  required: ['contextPacket'],
+};
+
+const contextListDataSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { contextPackets: { type: 'array', items: contextPacketEnvelopeSchema } },
+  required: ['contextPackets'],
+};
+
+const inboxMessageDataSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { message: inboxMessageEnvelopeSchema },
+  required: ['message'],
+};
+
+const inboxListDataSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: { messages: { type: 'array', items: inboxMessageEnvelopeSchema } },
+  required: ['messages'],
+};
+
+const contextInboxReadErrorCodes = [
+  'UNAUTHORIZED',
+  'INVALID_ARGUMENT',
+  'NOT_FOUND',
+  'FORBIDDEN',
+  'SERVER_UNAVAILABLE',
+  'UPSTREAM_ERROR',
+] as const satisfies readonly RelayCliGatewayErrorCode[];
+
+const contextInboxWriteErrorCodes = [
+  'UNAUTHORIZED',
+  'INVALID_ARGUMENT',
+  'INVALID_JSON',
+  'NOT_FOUND',
+  'FORBIDDEN',
+  'SESSION_CONFLICT',
+  'SERVER_UNAVAILABLE',
+  'UPSTREAM_ERROR',
+] as const satisfies readonly RelayCliGatewayErrorCode[];
 
 const handoffPlanInputSchema: RelayJsonSchema = {
   title: 'HandoffPlanInput',
@@ -1516,6 +1696,118 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       required: ['workContext'],
     }),
     errorCodes: ['UNAUTHORIZED', 'INVALID_ARGUMENT', 'NOT_FOUND', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+  },
+  {
+    name: 'context.create',
+    cli: ['relay-ide', 'v1', 'context', 'create', '--input-json', '<json>', '--json'],
+    summary: 'Create a ref-only context packet (file-anchor/file-ref/note) in the hub store.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['context:write'],
+    inputSchema: contextCreateInputSchema,
+    outputSchema: okOutput('ContextCreateOutput', contextPacketDataSchema),
+    errorCodes: contextInboxWriteErrorCodes,
+  },
+  {
+    name: 'context.get',
+    cli: ['relay-ide', 'v1', 'context', 'get', '--id', '<context-packet-id>', '--json'],
+    summary: 'Read one context packet by stable id. Ref-only; never returns raw file bytes.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['context:read'],
+    inputSchema: contextGetInputSchema,
+    outputSchema: okOutput('ContextGetOutput', contextPacketDataSchema),
+    errorCodes: contextInboxReadErrorCodes,
+  },
+  {
+    name: 'context.list',
+    cli: ['relay-ide', 'v1', 'context', 'list', '--json'],
+    summary: 'List context packets, optionally filtered by node/workspace binding.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['context:read'],
+    inputSchema: contextListInputSchema,
+    outputSchema: okOutput('ContextListOutput', contextListDataSchema),
+    errorCodes: contextInboxReadErrorCodes,
+  },
+  {
+    name: 'inbox.send',
+    cli: ['relay-ide', 'v1', 'inbox', 'send', '--input-json', '<json>', '--json'],
+    summary:
+      'Queue a session/WorkContext inbox message referencing context packets. Never pushes into sessions.input; delivery is PULL.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['inbox:write'],
+    inputSchema: inboxSendInputSchema,
+    outputSchema: okOutput('InboxSendOutput', inboxMessageDataSchema),
+    errorCodes: contextInboxWriteErrorCodes,
+  },
+  {
+    name: 'inbox.list',
+    cli: ['relay-ide', 'v1', 'inbox', 'list', '--target-session-id', '<global-session-id>', '--json'],
+    summary:
+      'List inbox messages for a session/WorkContext. PULL delivery: queued messages flip to delivered as a side effect of being fetched.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['inbox:read'],
+    inputSchema: inboxListInputSchema,
+    outputSchema: okOutput('InboxListOutput', inboxListDataSchema),
+    errorCodes: contextInboxReadErrorCodes,
+  },
+  {
+    name: 'inbox.get',
+    cli: ['relay-ide', 'v1', 'inbox', 'get', '--id', '<inbox-message-id>', '--json'],
+    summary:
+      'Read one inbox message by id. PULL delivery: a queued message flips to delivered as a side effect of being fetched.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['inbox:read'],
+    inputSchema: inboxGetInputSchema,
+    outputSchema: okOutput('InboxGetOutput', inboxMessageDataSchema),
+    errorCodes: contextInboxReadErrorCodes,
+  },
+  {
+    name: 'inbox.ack',
+    cli: ['relay-ide', 'v1', 'inbox', 'ack', '--id', '<inbox-message-id>', '--json'],
+    summary:
+      'Acknowledge an inbox message (delivered → acknowledged). Idempotent; rejects transitions out of terminal states.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['inbox:write'],
+    inputSchema: inboxTransitionInputSchema,
+    outputSchema: okOutput('InboxAckOutput', inboxMessageDataSchema),
+    errorCodes: contextInboxWriteErrorCodes,
+  },
+  {
+    name: 'inbox.resolve',
+    cli: ['relay-ide', 'v1', 'inbox', 'resolve', '--id', '<inbox-message-id>', '--json'],
+    summary: 'Resolve an inbox message (terminal). Rejects transitions out of an already-terminal state.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['inbox:write'],
+    inputSchema: inboxTransitionInputSchema,
+    outputSchema: okOutput('InboxResolveOutput', inboxMessageDataSchema),
+    errorCodes: contextInboxWriteErrorCodes,
+  },
+  {
+    name: 'inbox.ignore',
+    cli: ['relay-ide', 'v1', 'inbox', 'ignore', '--id', '<inbox-message-id>', '--json'],
+    summary: 'Ignore an inbox message (terminal). Rejects transitions out of an already-terminal state.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['inbox:write'],
+    inputSchema: inboxTransitionInputSchema,
+    outputSchema: okOutput('InboxIgnoreOutput', inboxMessageDataSchema),
+    errorCodes: contextInboxWriteErrorCodes,
   },
   {
     name: 'handoffs.plan',

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -87,6 +87,15 @@ const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
   'files.read': 'read session file',
   'files.write': 'write session file',
   'work-contexts.get': 'work context details',
+  'context.create': 'create context packet',
+  'context.get': 'context packet details',
+  'context.list': 'list context packets',
+  'inbox.send': 'send inbox message',
+  'inbox.list': 'list inbox messages',
+  'inbox.get': 'inbox message details',
+  'inbox.ack': 'acknowledge inbox message',
+  'inbox.resolve': 'resolve inbox message',
+  'inbox.ignore': 'ignore inbox message',
   'handoffs.plan': 'plan cold handoff',
   'handoffs.create': 'create cold handoff',
   'handoffs.status': 'handoff status',
@@ -113,7 +122,12 @@ function sideEffectForGatewayCommand(spec: RelayCliGatewayCommandSpec): RelayCom
     spec.name === 'supervisor.sendText' ||
     spec.name === 'supervisor.submit' ||
     spec.name === 'files.write' ||
-    spec.name === 'handoffs.cancel'
+    spec.name === 'handoffs.cancel' ||
+    spec.name === 'context.create' ||
+    spec.name === 'inbox.send' ||
+    spec.name === 'inbox.ack' ||
+    spec.name === 'inbox.resolve' ||
+    spec.name === 'inbox.ignore'
   ) {
     return 'write';
   }
@@ -124,6 +138,8 @@ function scopeKindsForGatewayCommand(name: RelayCliGatewayCommand): readonly Rel
   if (name.startsWith('nodes.')) return ['node'];
   if (name.startsWith('files.')) return ['session'];
   if (name.startsWith('work-contexts.')) return ['work-context'];
+  if (name.startsWith('context.')) return ['work-context', 'session'];
+  if (name.startsWith('inbox.')) return ['session', 'work-context'];
   if (name.startsWith('handoffs.')) return ['repo', 'worktree', 'work-context', 'session'];
   if (name.startsWith('artifacts.')) return ['work-context'];
   if (name.startsWith('supervisor.')) return ['session'];

--- a/shared/security-policy.ts
+++ b/shared/security-policy.ts
@@ -26,6 +26,15 @@ export const RELAY_CAPABILITY_BITS = [
   // without exposing arbitrary file tail to peers. Always redacted via
   // the diagnostics-bundle pipeline before crossing the wire.
   'logs:read',
+  // #765 / ADR-019: context packets + session inbox (ref-only, hub-mediated).
+  // Reads are default-allow peers of `session:read`; writes are grant-gated
+  // but NOT high-risk (ref-only metadata inserts — no raw payload, no file
+  // mutation, no exec), so they stay silent-allow on dev/sandbox and never
+  // get promoted to a confirmation prompt on prod (would break headless ack).
+  'context:read',
+  'context:write',
+  'inbox:read',
+  'inbox:write',
 ] as const;
 
 export type RelayCapabilityBit = (typeof RELAY_CAPABILITY_BITS)[number];
@@ -52,6 +61,16 @@ export const LEGACY_DEFAULT_ALLOWED_CAPABILITIES = [
   // tier overlay (`applyTrustTierOverlay`) leaves it in the silent-allow
   // set; operators can still revoke per-node by editing the ACL.
   'logs:read',
+  // #765 / ADR-019: context/inbox reads are silent-allow peers of
+  // `session:read` (default pull-model inspection). Writes are granted by
+  // default and, because they are NOT in `HIGH_RISK_CAPABILITIES`, stay
+  // silent-allow even on the `prod` tier — so a headless agent's
+  // `inbox.ack`/`resolve`/`ignore` loop is never gated behind a
+  // confirmation prompt. They remain grant-gated (an ACL edit can revoke).
+  'context:read',
+  'context:write',
+  'inbox:read',
+  'inbox:write',
 ] as const satisfies readonly RelayCapabilityBit[];
 
 export const HIGH_RISK_CAPABILITIES = [

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -14,7 +14,13 @@ import {
   relayCommandDefinition,
   relayCommandDefinitionsForSurface,
 } from '../shared/relay-command-manifest.js';
-import { RELAY_CAPABILITY_BITS } from '../shared/security-policy.js';
+import {
+  HIGH_RISK_CAPABILITIES,
+  LEGACY_DEFAULT_ALLOWED_CAPABILITIES,
+  RELAY_CAPABILITY_BITS,
+  createLegacyDefaultNodeAcl,
+  resolveAclCapability,
+} from '../shared/security-policy.js';
 import {
   gatewayCliInvalidArgumentError,
   gatewayCliInvalidJsonError,
@@ -84,6 +90,15 @@ describe('CLI gateway contract', () => {
       'files.read',
       'files.write',
       'work-contexts.get',
+      'context.create',
+      'context.get',
+      'context.list',
+      'inbox.send',
+      'inbox.list',
+      'inbox.get',
+      'inbox.ack',
+      'inbox.resolve',
+      'inbox.ignore',
       'handoffs.plan',
       'handoffs.create',
       'handoffs.status',
@@ -431,6 +446,15 @@ describe('CLI gateway contract', () => {
       'files.read',
       'files.write',
       'work-contexts.get',
+      'context.create',
+      'context.get',
+      'context.list',
+      'inbox.send',
+      'inbox.list',
+      'inbox.get',
+      'inbox.ack',
+      'inbox.resolve',
+      'inbox.ignore',
       'handoffs.plan',
       'handoffs.create',
       'handoffs.status',
@@ -670,6 +694,77 @@ describe('CLI gateway contract', () => {
       expect.arrayContaining(['FORBIDDEN', 'CONTROL_STATE_STALE', 'INTERVENTION_ACK_REQUIRED'])
     );
     expect(supervisor.summary).toContain('never sends raw PTY input');
+  });
+
+  it('advertises context.* / inbox.* verbs with ADR-019 capability + PULL semantics', () => {
+    // Reads are session:read peers; writes use the dedicated context/inbox bits.
+    expect(commandSpec('context.get').capabilityHints).toEqual(['context:read']);
+    expect(commandSpec('context.list').capabilityHints).toEqual(['context:read']);
+    expect(commandSpec('context.create').capabilityHints).toEqual(['context:write']);
+    expect(commandSpec('inbox.list').capabilityHints).toEqual(['inbox:read']);
+    expect(commandSpec('inbox.get').capabilityHints).toEqual(['inbox:read']);
+    expect(commandSpec('inbox.send').capabilityHints).toEqual(['inbox:write']);
+    for (const verb of ['inbox.ack', 'inbox.resolve', 'inbox.ignore'] as const) {
+      expect(commandSpec(verb).capabilityHints).toEqual(['inbox:write']);
+    }
+
+    // PULL delivery is documented on the read verbs; nothing pushes into sessions.input.
+    expect(commandSpec('inbox.list').summary).toContain('PULL delivery');
+    expect(commandSpec('inbox.get').summary).toContain('PULL delivery');
+    expect(commandSpec('inbox.send').summary).toContain('Never pushes into sessions.input');
+
+    // anchored addressing: send/list require a target.
+    expect(commandSpec('inbox.send').inputSchema).toMatchObject({
+      anyOf: [{ required: ['targetSessionId'] }, { required: ['targetWorkContextId'] }],
+    });
+
+    // Manifest side-effects: writes are 'write' (not destructive); reads are 'read'.
+    expect(relayCommandDefinition('context.create').sideEffect).toBe('write');
+    expect(relayCommandDefinition('inbox.ack').sideEffect).toBe('write');
+    expect(relayCommandDefinition('context.get').sideEffect).toBe('read');
+    expect(relayCommandDefinition('inbox.list').sideEffect).toBe('read');
+
+    // CRITICAL (fugu gate): write verbs must NOT require a confirmation
+    // challenge — that would gate a headless agent ack loop. They carry
+    // context/inbox bits, not rpc:fs:write / pty:exec:arbitrary.
+    for (const verb of [
+      'context.create',
+      'inbox.send',
+      'inbox.ack',
+      'inbox.resolve',
+      'inbox.ignore',
+    ] as const) {
+      expect(relayCommandDefinition(verb).requiresConfirmation).toBe(false);
+      expect(relayCommandDefinition(verb).controlRequirements).toEqual([]);
+    }
+  });
+
+  it('places context/inbox capability bits in the correct trust tier (ADR-019 D5)', () => {
+    for (const bit of ['context:read', 'context:write', 'inbox:read', 'inbox:write'] as const) {
+      expect(RELAY_CAPABILITY_BITS).toContain(bit);
+    }
+    // Reads are default-allow peers of session:read.
+    expect(LEGACY_DEFAULT_ALLOWED_CAPABILITIES).toContain('context:read');
+    expect(LEGACY_DEFAULT_ALLOWED_CAPABILITIES).toContain('inbox:read');
+    // Writes are dev-allow (granted by default) but NOT high-risk — so the
+    // prod trust overlay never promotes them to a confirmation prompt.
+    expect(LEGACY_DEFAULT_ALLOWED_CAPABILITIES).toContain('context:write');
+    expect(LEGACY_DEFAULT_ALLOWED_CAPABILITIES).toContain('inbox:write');
+    expect(HIGH_RISK_CAPABILITIES).not.toContain('context:write');
+    expect(HIGH_RISK_CAPABILITIES).not.toContain('inbox:write');
+
+    // On the prod tier the overlay keeps writes silent-allow (not confirmation).
+    const prodAcl = createLegacyDefaultNodeAcl({
+      nodeId: 'node_prod_ctx',
+      createdAt: '2026-05-27T00:00:00.000Z',
+      trustTier: 'prod',
+    });
+    for (const bit of ['context:read', 'context:write', 'inbox:read', 'inbox:write'] as const) {
+      expect(resolveAclCapability(prodAcl, bit)).toMatchObject({
+        known: true,
+        decision: 'allow',
+      });
+    }
   });
 
   it('encodes sessions.input source exclusivity for schema-generated adapters', () => {

--- a/test/context-inbox-router.test.ts
+++ b/test/context-inbox-router.test.ts
@@ -1,0 +1,325 @@
+import express from 'express';
+import type { Server } from 'node:http';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createContextInboxRouter,
+  isTerminalInboxState,
+  type ContextInboxStore,
+  type CreateContextPacketInput,
+  type CreateInboxMessageInput,
+  type ListContextPacketsFilter,
+  type ListInboxMessagesFilter,
+  type UpdateInboxStateResult,
+} from '../server/features/context-inbox-router.js';
+import {
+  TERMINAL_INBOX_MESSAGE_STATES,
+  createContextPacketId,
+  createInboxMessageId,
+  type ContextPacket,
+  type SessionInboxMessage,
+  type SessionInboxMessageState,
+} from '../shared/context-packet.js';
+
+// ---------------------------------------------------------------------------
+// In-memory store implementing the #765 seam (#758 builds the SQLite version).
+// It enforces the SAME transition guard #758 will: idempotent re-ack, terminal
+// reject, PULL delivery (list/get flip queued → delivered).
+// ---------------------------------------------------------------------------
+
+const TERMINAL = new Set<SessionInboxMessageState>(TERMINAL_INBOX_MESSAGE_STATES);
+
+// Allowed forward transitions. `delivered` is reached by PULL, not this map.
+const ALLOWED_TRANSITIONS: Record<SessionInboxMessageState, Set<SessionInboxMessageState>> = {
+  queued: new Set(['acknowledged']),
+  delivered: new Set(['acknowledged']),
+  acknowledged: new Set(['acknowledged', 'resolved', 'ignored']),
+  resolved: new Set(),
+  ignored: new Set(),
+};
+
+function createFakeStore(): ContextInboxStore & { _markDelivered: boolean } {
+  const packets = new Map<string, ContextPacket>();
+  const messages = new Map<string, SessionInboxMessage>();
+  let packetSeq = 0;
+  let messageSeq = 0;
+
+  function deliverOnPull(message: SessionInboxMessage): SessionInboxMessage {
+    if (message.state === 'queued') {
+      const updated: SessionInboxMessage = {
+        ...message,
+        state: 'delivered',
+        deliveredAt: new Date().toISOString(),
+      };
+      messages.set(message.id, updated);
+      return updated;
+    }
+    return message;
+  }
+
+  const store: ContextInboxStore & { _markDelivered: boolean } = {
+    _markDelivered: true,
+    createPacket(input: CreateContextPacketInput): ContextPacket {
+      const id = createContextPacketId(`test${packetSeq++}`);
+      const packet: ContextPacket = {
+        id,
+        kind: input.kind,
+        ...(input.anchor !== undefined ? { anchor: input.anchor } : {}),
+        ...(input.fileRef !== undefined ? { fileRef: input.fileRef } : {}),
+        ...(input.note !== undefined ? { note: input.note } : {}),
+        ...(input.binding !== undefined ? { binding: input.binding } : {}),
+        createdBy: input.createdBy,
+        createdAt: new Date().toISOString(),
+      };
+      packets.set(id, packet);
+      return packet;
+    },
+    getPacket(id: string): ContextPacket | null {
+      return packets.get(id) ?? null;
+    },
+    listPackets(filter?: ListContextPacketsFilter): ContextPacket[] {
+      let all = [...packets.values()];
+      if (filter?.nodeId) all = all.filter((p) => p.binding?.nodeId === filter.nodeId);
+      if (filter?.workspaceId) all = all.filter((p) => p.binding?.workspaceId === filter.workspaceId);
+      if (filter?.limit !== undefined) all = all.slice(0, filter.limit);
+      return all;
+    },
+    createInboxMessage(input: CreateInboxMessageInput): SessionInboxMessage {
+      const id = createInboxMessageId(`test${messageSeq++}`);
+      const message: SessionInboxMessage = {
+        id,
+        ...(input.targetSessionId ? { targetSessionId: input.targetSessionId } : {}),
+        ...(input.targetWorkContextId ? { targetWorkContextId: input.targetWorkContextId } : {}),
+        contextPacketIds: input.contextPacketIds,
+        ...(input.text !== undefined ? { text: input.text } : {}),
+        state: 'queued',
+        createdBy: input.createdBy,
+        createdAt: new Date().toISOString(),
+      };
+      messages.set(id, message);
+      return message;
+    },
+    listInboxMessages(filter: ListInboxMessagesFilter): SessionInboxMessage[] {
+      let all = [...messages.values()];
+      if (filter.targetSessionId) {
+        all = all.filter((m) => m.targetSessionId === filter.targetSessionId);
+      }
+      if (filter.targetWorkContextId) {
+        all = all.filter((m) => m.targetWorkContextId === filter.targetWorkContextId);
+      }
+      if (filter.state) all = all.filter((m) => m.state === filter.state);
+      // PULL delivery side effect.
+      all = all.map((m) => deliverOnPull(m));
+      if (filter.limit !== undefined) all = all.slice(0, filter.limit);
+      return all;
+    },
+    getInboxMessage(id: string): SessionInboxMessage | null {
+      const message = messages.get(id);
+      if (!message) return null;
+      return deliverOnPull(message);
+    },
+    updateInboxState(
+      id: string,
+      targetState: SessionInboxMessageState,
+      _actorId?: string
+    ): UpdateInboxStateResult {
+      const message = messages.get(id);
+      if (!message) return { ok: false, reason: 'not_found' };
+      if (TERMINAL.has(message.state)) {
+        return { ok: false, reason: 'terminal', currentState: message.state };
+      }
+      if (!ALLOWED_TRANSITIONS[message.state].has(targetState)) {
+        return { ok: false, reason: 'invalid_transition', currentState: message.state };
+      }
+      const updated: SessionInboxMessage = {
+        ...message,
+        state: targetState,
+        ...(targetState === 'acknowledged' ? { acknowledgedAt: new Date().toISOString() } : {}),
+        ...(targetState === 'resolved' ? { resolvedAt: new Date().toISOString() } : {}),
+        ...(targetState === 'ignored' ? { ignoredAt: new Date().toISOString() } : {}),
+      };
+      messages.set(id, updated);
+      return { ok: true, message: updated };
+    },
+  };
+  return store;
+}
+
+const ALL_CAPS = 'context:read,context:write,inbox:read,inbox:write';
+
+let server: Server;
+let baseUrl: string;
+
+function mount(store: ContextInboxStore | null): Promise<void> {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    createContextInboxRouter({
+      requireAuth: (_req, _res, next) => next(),
+      store,
+    })
+  );
+  return new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as { port: number };
+      baseUrl = `http://127.0.0.1:${addr.port}`;
+      resolve();
+    });
+  });
+}
+
+async function req(
+  method: string,
+  path: string,
+  opts: { caps?: string; body?: unknown } = {}
+): Promise<{ status: number; body: any }> {
+  const headers: Record<string, string> = {};
+  if (opts.caps !== undefined) headers['x-relay-capabilities'] = opts.caps;
+  if (opts.body !== undefined) headers['content-type'] = 'application/json';
+  const res = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    ...(opts.body !== undefined ? { body: JSON.stringify(opts.body) } : {}),
+  });
+  const text = await res.text();
+  return { status: res.status, body: text ? JSON.parse(text) : {} };
+}
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server?.close(() => resolve()));
+});
+
+describe('context/inbox gateway router', () => {
+  beforeEach(async () => {
+    await mount(createFakeStore());
+  });
+
+  it('round-trips context.create → context.get → context.list', async () => {
+    const created = await req('POST', '/context', {
+      caps: 'context:write',
+      body: { kind: 'note', note: 'remember this', createdBy: 'agent_1' },
+    });
+    expect(created.status).toBe(201);
+    expect(created.body.contextPacket.kind).toBe('note');
+    expect(created.body.contextPacket.id).toMatch(/^cp:/);
+
+    const id = created.body.contextPacket.id as string;
+    const got = await req('GET', `/context/${encodeURIComponent(id)}`, { caps: 'context:read' });
+    expect(got.status).toBe(200);
+    expect(got.body.contextPacket.id).toBe(id);
+
+    const listed = await req('GET', '/context', { caps: 'context:read' });
+    expect(listed.status).toBe(200);
+    expect(listed.body.contextPackets).toHaveLength(1);
+  });
+
+  it('inbox.send queues; inbox.list PULL-delivers (queued → delivered)', async () => {
+    const sent = await req('POST', '/inbox', {
+      caps: 'inbox:write',
+      body: { targetSessionId: 'node1:s1', contextPacketIds: [], text: 'hi', createdBy: 'agent_1' },
+    });
+    expect(sent.status).toBe(201);
+    expect(sent.body.message.state).toBe('queued');
+
+    const listed = await req('GET', '/inbox?targetSessionId=node1:s1', { caps: 'inbox:read' });
+    expect(listed.status).toBe(200);
+    expect(listed.body.messages).toHaveLength(1);
+    // PULL semantics: fetching flips queued → delivered.
+    expect(listed.body.messages[0].state).toBe('delivered');
+  });
+
+  it('inbox.ack is idempotent and ack → resolve is terminal-guarded', async () => {
+    const sent = await req('POST', '/inbox', {
+      caps: 'inbox:write',
+      body: { targetSessionId: 'node1:s2', contextPacketIds: [], createdBy: 'agent_1' },
+    });
+    const id = sent.body.message.id as string;
+
+    const ack1 = await req('POST', `/inbox/${encodeURIComponent(id)}/ack`, { caps: 'inbox:write' });
+    expect(ack1.status).toBe(200);
+    expect(ack1.body.message.state).toBe('acknowledged');
+
+    // Idempotent re-ack succeeds.
+    const ack2 = await req('POST', `/inbox/${encodeURIComponent(id)}/ack`, { caps: 'inbox:write' });
+    expect(ack2.status).toBe(200);
+    expect(ack2.body.message.state).toBe('acknowledged');
+
+    // Resolve from acknowledged is allowed → terminal.
+    const resolved = await req('POST', `/inbox/${encodeURIComponent(id)}/resolve`, {
+      caps: 'inbox:write',
+    });
+    expect(resolved.status).toBe(200);
+    expect(resolved.body.message.state).toBe('resolved');
+    expect(isTerminalInboxState(resolved.body.message.state)).toBe(true);
+
+    // Any transition out of a terminal state is rejected (SESSION_CONFLICT).
+    const reAck = await req('POST', `/inbox/${encodeURIComponent(id)}/ack`, { caps: 'inbox:write' });
+    expect(reAck.status).toBe(409);
+    expect(reAck.body.error.code).toBe('SESSION_CONFLICT');
+    expect(reAck.body.error.details.currentState).toBe('resolved');
+
+    const reIgnore = await req('POST', `/inbox/${encodeURIComponent(id)}/ignore`, {
+      caps: 'inbox:write',
+    });
+    expect(reIgnore.status).toBe(409);
+    expect(reIgnore.body.error.code).toBe('SESSION_CONFLICT');
+  });
+
+  it('denies write verbs lacking the capability bit with 403 FORBIDDEN', async () => {
+    // context:write missing.
+    const create = await req('POST', '/context', {
+      caps: 'context:read',
+      body: { kind: 'note', note: 'x', createdBy: 'agent_1' },
+    });
+    expect(create.status).toBe(403);
+    expect(create.body.error.code).toBe('FORBIDDEN');
+    expect(create.body.error.details.capability).toBe('context:write');
+
+    // inbox:write missing on ack.
+    const ack = await req('POST', '/inbox/im:nope/ack', { caps: 'inbox:read' });
+    expect(ack.status).toBe(403);
+    expect(ack.body.error.code).toBe('FORBIDDEN');
+    expect(ack.body.error.details.capability).toBe('inbox:write');
+  });
+
+  it('denies read verbs lacking the capability bit with 403 FORBIDDEN', async () => {
+    const list = await req('GET', '/context', { caps: '' });
+    expect(list.status).toBe(403);
+    expect(list.body.error.code).toBe('FORBIDDEN');
+    expect(list.body.error.details.capability).toBe('context:read');
+
+    const inbox = await req('GET', '/inbox?targetSessionId=node1:s1', { caps: ALL_CAPS.replace('inbox:read', '') });
+    expect(inbox.status).toBe(403);
+    expect(inbox.body.error.details.capability).toBe('inbox:read');
+  });
+
+  it('validates required addressing / fields', async () => {
+    const noKind = await req('POST', '/context', {
+      caps: 'context:write',
+      body: { note: 'no kind' },
+    });
+    expect(noKind.status).toBe(400);
+    expect(noKind.body.error.code).toBe('INVALID_ARGUMENT');
+
+    const noTarget = await req('POST', '/inbox', {
+      caps: 'inbox:write',
+      body: { contextPacketIds: [], createdBy: 'agent_1' },
+    });
+    expect(noTarget.status).toBe(400);
+    expect(noTarget.body.error.code).toBe('INVALID_ARGUMENT');
+
+    const missing = await req('GET', '/context/cp:does-not-exist', { caps: 'context:read' });
+    expect(missing.status).toBe(404);
+    expect(missing.body.error.code).toBe('NOT_FOUND');
+  });
+});
+
+describe('context/inbox gateway router without a store', () => {
+  it('returns 503 SERVER_UNAVAILABLE when the store seam is unwired', async () => {
+    await mount(null);
+    const res = await req('GET', '/context', { caps: 'context:read' });
+    expect(res.status).toBe(503);
+    expect(res.body.error.code).toBe('SERVER_UNAVAILABLE');
+  });
+});

--- a/test/stores/node-dashboard.test.ts
+++ b/test/stores/node-dashboard.test.ts
@@ -299,12 +299,18 @@ describe('hub node dashboard state', () => {
     // allowed in dev, denied in sandbox + prod.
     // #704 added two typed supervisor action bits; all default node tiers
     // deny them unless a user grants the scoped supervisor capabilities.
+    // #765 / ADR-019 added four context/inbox bits (context/inbox read+write):
+    // dev silent-allows all four (default-allowed grant set), sandbox denies
+    // all four (grants nothing), and the prod fixture below denies all four
+    // because it does not grant them — but crucially challenge stays at 2:
+    // the writes are NOT high-risk, so prod never promotes them to a
+    // confirmation challenge (the headless ack loop is not gated).
     expect(
       rows.map((row) => [row.security.trustTier, row.security.postureLabel])
     ).toEqual([
-      ['sandbox', 'allow 1 · challenge 0 · deny 18'],
-      ['dev', 'allow 11 · challenge 0 · deny 8'],
-      ['prod', 'allow 1 · challenge 2 · deny 16'],
+      ['sandbox', 'allow 1 · challenge 0 · deny 22'],
+      ['dev', 'allow 15 · challenge 0 · deny 8'],
+      ['prod', 'allow 1 · challenge 2 · deny 20'],
     ]);
     expect(rows[2].security).toMatchObject({
       tone: 'danger',


### PR DESCRIPTION
Adds the CLI gateway verbs and capability bits for ADR-019 context packets + session inbox (#765, epic #757). Stacked on #764 (PR #768, ADR-019 + `shared/context-packet.ts`, now squash-merged to nightly).

## Verbs added (`shared/cli-gateway-contract.ts`)
- `context.create` / `context.get` / `context.list`
- `inbox.send` / `inbox.list` / `inbox.get` / `inbox.ack` / `inbox.resolve` / `inbox.ignore`

Each is a `commandSpec` mirroring the `work-contexts.get` shape (name/cli/transport/requiresAuth/capabilityHints/inputSchema/outputSchema/errorCodes). The nested `ContextPacket` / `SessionInboxMessage` envelope schemas are `additionalProperties: true` so the #758 store can evolve the canonical blob without a contract bump; the verbs pin only the addressing/lifecycle fields they own. Projected into `shared/relay-command-manifest.ts` (labels, write/read side-effects, scope kinds).

## Capability-tier placement (`shared/security-policy.ts`) — per ADR-019 D5
- `context:read`, `inbox:read` → `LEGACY_DEFAULT_ALLOWED_CAPABILITIES` (silent-allow peers of `session:read`).
- `context:write`, `inbox:write` → also in `LEGACY_DEFAULT_ALLOWED_CAPABILITIES` (dev-allow), but **NOT** in `HIGH_RISK_CAPABILITIES`.

Why writes are not high-risk: putting them in `HIGH_RISK_CAPABILITIES` would force a confirmation challenge on every agent `inbox.ack` on the `prod` tier (the `applyTrustTierOverlay` promotion), breaking the headless agent loop. Writes are ref-only metadata inserts — no raw payload, no file mutation, no PTY exec — so they stay grant-gated but never confirmation-gated. Verified by the updated `node-dashboard` posture test: prod `challenge` count is unchanged (stays 2) while the 4 new bits land as `deny` on the ungranted prod fixture / `allow` on dev.

## Store-interface seam (wired to #758 at integration)
A parallel lane (#758) builds the SQLite-behind-gateway store. To avoid a merge collision, this lane defines a narrow `ContextInboxStore` interface in the new `server/features/context-inbox-router.ts` and depends only on it:
- `createPacket` / `getPacket` / `listPackets`
- `createInboxMessage` / `listInboxMessages` / `getInboxMessage`
- `updateInboxState(id, targetState, actorId?)` → transition-guarded result union

The orchestrator swaps the `store: null` mount in `server/index.ts` for #758's concrete handle at integration. Until then the routes return `503 SERVER_UNAVAILABLE` rather than failing boot.

## PULL semantics (ADR-019 D3)
Delivery is PULL: only `inbox.list` / `inbox.get` flip `queued → delivered` (a store-side read effect, kept in the store so the future agent `preturn` projection is consistent). Nothing pushes into `sessions.input` / raw PTY bytes.

## fugu C2 — terminal-state guard
`inbox.ack` / `inbox.resolve` / `inbox.ignore` call the store's transition-guarded `updateInboxState`; the router never trusts the caller. Idempotent re-ack succeeds; any transition out of a `TERMINAL_INBOX_MESSAGE_STATES` member is rejected as `409 SESSION_CONFLICT`. Uses `TERMINAL_INBOX_MESSAGE_STATES` from `shared/context-packet.ts`.

## Files touched
- `shared/cli-gateway-contract.ts` — verbs + schemas
- `shared/security-policy.ts` — 4 capability bits + tier placement
- `shared/relay-command-manifest.ts` — labels/side-effects/scope kinds
- `bin/relay-ide.ts` — `runGatewayContext` / `runGatewayInbox` dispatch + usage
- `server/features/context-inbox-router.ts` (NEW) — router + `ContextInboxStore` seam
- `server/index.ts` — one localized mount block
- `test/cli-gateway-contract.test.ts`, `test/context-inbox-router.test.ts`, `test/stores/node-dashboard.test.ts`

## Test evidence
- `npm run build` ✓, `npm run check` ✓ (0 errors)
- Full suite: 293 files, 3775 tests passing
- Contract snapshot includes all 9 new verbs; built CLI `v1 --list --json` emits them end-to-end
- Capability-tier test: reads default-allow, writes prod-allow-not-challenge, writes NOT high-risk
- Route-level test (in-memory store): create→list→ack lifecycle, PULL delivery flip, terminal guard (409), capability denial (403 FORBIDDEN), 503 when store unwired

🤖 Generated with [Claude Code](https://claude.com/claude-code)