### PR TITLE
feat(#730): Bench creation flow (cwd + env)

### DIFF
--- a/frontend/src/components/BenchCreate.css
+++ b/frontend/src/components/BenchCreate.css
@@ -1,0 +1,252 @@
+/* #730 Bench creation flow. Reuses existing design tokens (no new colors) and
+   sits under each Instance row in the view-spine tree. Touch targets ≥44px for
+   the create/cancel actions and ≥36px for inputs. */
+
+.bench-create {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 2px 8px 6px 36px;
+}
+
+.bench-create-hint {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+  opacity: 0.8;
+  padding: 2px 0;
+}
+
+/* ── Persisted overlay rows ──────────────────────────────────────────────── */
+.bench-overlay-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bench-overlay-row .session-row-primary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 28px;
+}
+
+.bench-overlay-env-badge {
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  padding: 0 4px;
+  flex: 0 0 auto;
+}
+
+.bench-overlay-cwd {
+  font-size: var(--font-size-xs);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+  opacity: 0.8;
+}
+
+.bench-overlay-delete {
+  min-width: 28px;
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: auto;
+  background: none;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.bench-overlay-delete:hover:not(:disabled) {
+  color: var(--danger, var(--accent));
+  background: var(--surface-hover);
+}
+
+.bench-overlay-delete:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+/* ── Create form ─────────────────────────────────────────────────────────── */
+.bench-create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 0;
+}
+
+.bench-create-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.bench-create-label {
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.bench-create-input {
+  min-width: 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--text);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  padding: 6px 8px;
+  min-height: 36px;
+  box-sizing: border-box;
+  outline: none;
+}
+
+.bench-create-input:focus {
+  border-color: var(--accent);
+}
+
+.bench-create-input[aria-invalid='true'] {
+  border-color: var(--danger, var(--accent));
+}
+
+.bench-create-validation {
+  font-size: var(--font-size-xs);
+  color: var(--danger, var(--accent));
+  padding: 0 2px;
+}
+
+/* ── env override rows ───────────────────────────────────────────────────── */
+.bench-create-env {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.bench-create-env-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.bench-create-env-key {
+  flex: 0 0 38%;
+}
+
+.bench-create-env-value {
+  flex: 1 1 auto;
+}
+
+.bench-create-env-eq {
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+  flex: 0 0 auto;
+}
+
+.bench-create-env-remove {
+  min-width: 32px;
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+
+.bench-create-env-remove:hover:not(:disabled) {
+  color: var(--danger, var(--accent));
+}
+
+.bench-create-env-remove:disabled,
+.bench-create-env-add:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.bench-create-env-add {
+  align-self: flex-start;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  padding: 4px 8px;
+  min-height: 32px;
+  cursor: pointer;
+}
+
+.bench-create-env-add:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* ── actions ─────────────────────────────────────────────────────────────── */
+.bench-create-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.bench-create-submit,
+.bench-create-cancel {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs);
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+  padding: 0 12px;
+  min-height: 44px;
+  cursor: pointer;
+  transition:
+    color 0.1s,
+    border-color 0.1s;
+}
+
+.bench-create-submit:hover:not(:disabled),
+.bench-create-cancel:hover:not(:disabled) {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.bench-create-submit:disabled,
+.bench-create-cancel:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* ── inline error ────────────────────────────────────────────────────────── */
+.bench-create-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: var(--font-size-xs);
+  color: var(--danger, var(--accent));
+  padding: 2px 0;
+}
+
+.bench-create-retry {
+  background: none;
+  border: 1px solid currentColor;
+  color: inherit;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-xs);
+  padding: 2px 8px;
+  cursor: pointer;
+}
+
+.bench-create-retry:hover {
+  background: var(--surface-hover);
+}

--- a/frontend/src/components/BenchCreate.tsx
+++ b/frontend/src/components/BenchCreate.tsx
@@ -1,0 +1,408 @@
+// #730 (Epic #444 view-spine): Bench-creation flow on an Instance row. A Bench
+// is a cwd + env layered on an Instance; for a repo-instance the cwd defaults to
+// a worktree path under the repo, for a node-instance it is an arbitrary
+// absolute cwd. Flag-gated by its only mount point (`ViewSpineTree`, which is
+// only rendered when `viewSpineEnabled`).
+//
+// Wired to the #735 `/hub/ia/benches` CRUD API via `useIaBenches`. Renders the
+// PERSISTED bench overlays (so a freshly-created bench appears under its
+// Instance) plus the create form. Scope: CREATE + minimal DELETE; env-override
+// INHERITANCE into tabs is out of scope (#740).
+//
+// C1 (from #735 review): a bench `cwd` is sent and displayed VERBATIM — never
+// `decodeURIComponent`-ed. The raw absolute path the user enters is the path the
+// hub mints the BenchId from.
+//
+// States: empty (no overlays → no list, just the affordance), loading, error
+// (non-destructive inline message + refetch), in-flight (form disabled while a
+// create/delete is pending), validation (cwd rejected client-side mirroring the
+// server). Touch targets ≥44px; full keyboard support (Enter submits, Escape
+// cancels).
+import { useMemo, useState } from 'react';
+
+import type { IaBench } from '../lib/api.js';
+import { useIaBenches } from '../lib/hooks/use-ia-benches.js';
+import {
+  benchCwdErrorMessage,
+  buildBenchPayload,
+  validateBenchCwd,
+  type EnvOverrideEntry,
+} from '../lib/state/bench-create.js';
+import type { ViewTreeProject } from '../lib/state/view-tree.js';
+import { createLogger } from '../lib/logger.js';
+import { MarqueeText } from './MarqueeText.js';
+import './BenchCreate.css';
+
+const logger = createLogger('bench-create');
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error && err.message ? err.message : fallback;
+}
+
+/** A persisted overlay row. cwd is shown VERBATIM (C1). Label falls back to the
+ *  last cwd segment when the overlay carries no explicit label. */
+function BenchOverlayRow({
+  bench,
+  busy,
+  onDelete,
+}: {
+  bench: IaBench;
+  busy: boolean;
+  onDelete: () => void;
+}) {
+  const fallbackLabel =
+    bench.cwd.replace(/[\\/]+$/, '').split(/[\\/]/).pop() || bench.cwd;
+  const label = bench.label && bench.label.length > 0 ? bench.label : fallbackLabel;
+  const envCount = Object.keys(bench.envOverrides).length;
+  return (
+    <li className="session-row inactive state-inactive view-spine-bench bench-overlay-row">
+      <div className="session-row-primary">
+        <span className="session-name">
+          <MarqueeText>{label}</MarqueeText>
+        </span>
+        {envCount > 0 ? (
+          <span className="bench-overlay-env-badge" title={`${envCount} env override(s)`}>
+            env {envCount}
+          </span>
+        ) : null}
+        <button
+          type="button"
+          className="bench-overlay-delete"
+          disabled={busy}
+          onClick={onDelete}
+          aria-label={`delete bench ${label}`}
+          title="delete bench"
+        >
+          ×
+        </button>
+      </div>
+      {/* cwd shown verbatim — the raw absolute path, never decoded (C1). */}
+      <div className="session-row-secondary">
+        <span className="bench-overlay-cwd">
+          <MarqueeText>{bench.cwd}</MarqueeText>
+        </span>
+      </div>
+    </li>
+  );
+}
+
+interface BenchCreateFormProps {
+  instanceId: string;
+  projectKind: ViewTreeProject['kind'];
+  defaultCwd: string;
+  busy: boolean;
+  onSubmit: (input: {
+    cwd: string;
+    label: string;
+    envEntries: EnvOverrideEntry[];
+  }) => void;
+  onCancel: () => void;
+}
+
+function BenchCreateForm({
+  instanceId: _instanceId,
+  projectKind,
+  defaultCwd,
+  busy,
+  onSubmit,
+  onCancel,
+}: BenchCreateFormProps) {
+  const [cwd, setCwd] = useState(defaultCwd);
+  const [label, setLabel] = useState('');
+  const [envEntries, setEnvEntries] = useState<EnvOverrideEntry[]>([]);
+  // Validate only AFTER a submit attempt, so the field isn't red on first open.
+  const [touched, setTouched] = useState(false);
+
+  const cwdError = useMemo(() => validateBenchCwd(cwd), [cwd]);
+  const showCwdError = touched && cwdError !== null;
+
+  function updateEnv(index: number, patch: Partial<EnvOverrideEntry>) {
+    setEnvEntries((prev) =>
+      prev.map((e, i) => (i === index ? { ...e, ...patch } : e))
+    );
+  }
+
+  function submit() {
+    setTouched(true);
+    if (busy) return;
+    if (validateBenchCwd(cwd) !== null) return;
+    onSubmit({ cwd, label, envEntries });
+  }
+
+  const cwdPlaceholder =
+    projectKind === 'repo'
+      ? '/abs/path/to/worktree'
+      : '/home/you/project or /tmp/scratch';
+
+  return (
+    <div className="bench-create-form">
+      <label className="bench-create-field">
+        <span className="bench-create-label">cwd</span>
+        <input
+          type="text"
+          className="bench-create-input"
+          value={cwd}
+          placeholder={cwdPlaceholder}
+          disabled={busy}
+          autoFocus
+          spellCheck={false}
+          autoComplete="off"
+          aria-invalid={showCwdError}
+          aria-label="bench cwd (absolute path)"
+          onChange={(e) => setCwd(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              submit();
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              onCancel();
+            }
+          }}
+        />
+      </label>
+      {showCwdError && cwdError ? (
+        <div className="bench-create-validation" role="alert">
+          {benchCwdErrorMessage(cwdError)}
+        </div>
+      ) : null}
+
+      <label className="bench-create-field">
+        <span className="bench-create-label">label</span>
+        <input
+          type="text"
+          className="bench-create-input"
+          value={label}
+          placeholder="optional"
+          disabled={busy}
+          spellCheck={false}
+          autoComplete="off"
+          aria-label="bench label (optional)"
+          onChange={(e) => setLabel(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              submit();
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              onCancel();
+            }
+          }}
+        />
+      </label>
+
+      <div className="bench-create-env">
+        <span className="bench-create-label">env overrides (optional)</span>
+        {envEntries.map((entry, index) => (
+          <div className="bench-create-env-row" key={index}>
+            <input
+              type="text"
+              className="bench-create-input bench-create-env-key"
+              value={entry.key}
+              placeholder="KEY"
+              disabled={busy}
+              spellCheck={false}
+              autoComplete="off"
+              aria-label={`env override key ${index + 1}`}
+              onChange={(e) => updateEnv(index, { key: e.currentTarget.value })}
+            />
+            <span className="bench-create-env-eq">=</span>
+            <input
+              type="text"
+              className="bench-create-input bench-create-env-value"
+              value={entry.value}
+              placeholder="value"
+              disabled={busy}
+              spellCheck={false}
+              autoComplete="off"
+              aria-label={`env override value ${index + 1}`}
+              onChange={(e) =>
+                updateEnv(index, { value: e.currentTarget.value })
+              }
+            />
+            <button
+              type="button"
+              className="bench-create-env-remove"
+              disabled={busy}
+              aria-label={`remove env override ${index + 1}`}
+              title="remove"
+              onClick={() =>
+                setEnvEntries((prev) => prev.filter((_, i) => i !== index))
+              }
+            >
+              ×
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          className="bench-create-env-add"
+          disabled={busy}
+          onClick={() =>
+            setEnvEntries((prev) => [...prev, { key: '', value: '' }])
+          }
+        >
+          + env var
+        </button>
+      </div>
+
+      <div className="bench-create-actions">
+        <button
+          type="button"
+          className="bench-create-submit"
+          disabled={busy}
+          onClick={submit}
+        >
+          {busy ? 'creating…' : 'create bench'}
+        </button>
+        <button
+          type="button"
+          className="bench-create-cancel"
+          disabled={busy}
+          onClick={onCancel}
+        >
+          cancel
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function BenchCreate({
+  instanceId,
+  projectKind,
+  defaultCwd,
+}: {
+  instanceId: string;
+  projectKind: ViewTreeProject['kind'];
+  /** Pre-filled cwd for a repo-instance (the parent repo path); empty for a
+   *  node-instance (arbitrary absolute cwd). */
+  defaultCwd: string;
+}) {
+  const {
+    benches,
+    isLoading,
+    isError,
+    refetch,
+    createMutation,
+    deleteMutation,
+  } = useIaBenches(instanceId);
+  const [open, setOpen] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const busy = createMutation.isPending || deleteMutation.isPending;
+
+  function clearError() {
+    setActionError(null);
+  }
+
+  function handleCreate(input: {
+    cwd: string;
+    label: string;
+    envEntries: EnvOverrideEntry[];
+  }) {
+    clearError();
+    const payload = buildBenchPayload({
+      instanceId,
+      cwd: input.cwd,
+      label: input.label,
+      envEntries: input.envEntries,
+    });
+    createMutation.mutate(payload, {
+      onSuccess: () => {
+        setOpen(false);
+      },
+      onError: (err) => {
+        logger.warn('create bench failed', err);
+        setActionError(errorMessage(err, 'could not create bench'));
+      },
+    });
+  }
+
+  function handleDelete(bench: IaBench) {
+    clearError();
+    deleteMutation.mutate(bench.id, {
+      onError: (err) => {
+        logger.warn('delete bench failed', err);
+        setActionError(errorMessage(err, 'could not delete bench'));
+      },
+    });
+  }
+
+  return (
+    <div className="bench-create">
+      {isLoading ? (
+        <div className="bench-create-hint">loading benches…</div>
+      ) : benches.length > 0 ? (
+        <ul className="session-list view-spine-bench-list bench-overlay-list">
+          {benches.map((bench) => (
+            <BenchOverlayRow
+              key={bench.id}
+              bench={bench}
+              busy={busy}
+              onDelete={() => handleDelete(bench)}
+            />
+          ))}
+        </ul>
+      ) : null}
+
+      {open ? (
+        <BenchCreateForm
+          instanceId={instanceId}
+          projectKind={projectKind}
+          defaultCwd={defaultCwd}
+          busy={busy}
+          onSubmit={handleCreate}
+          onCancel={() => {
+            clearError();
+            setOpen(false);
+          }}
+        />
+      ) : (
+        // Reuses the `.add-worktree-row`/`.add-worktree-btn` affordance styling
+        // (same primitive as the "+ tab" row), distinct copy `+ bench`.
+        <div
+          className="add-worktree-row"
+          data-track="view-spine.new-bench"
+          onClick={() => {
+            clearError();
+            setOpen(true);
+          }}
+        >
+          <button className="add-worktree-btn" type="button" tabIndex={0}>
+            + bench
+          </button>
+        </div>
+      )}
+
+      {actionError ? (
+        <div className="bench-create-error" role="alert">
+          <span>{actionError}</span>
+          <button
+            type="button"
+            className="bench-create-retry"
+            onClick={() => {
+              clearError();
+              void refetch();
+            }}
+          >
+            retry
+          </button>
+        </div>
+      ) : isError ? (
+        <div className="bench-create-error" role="alert">
+          <span>could not load benches</span>
+          <button
+            type="button"
+            className="bench-create-retry"
+            onClick={() => void refetch()}
+          >
+            retry
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default BenchCreate;

--- a/frontend/src/components/ViewSpineTree.tsx
+++ b/frontend/src/components/ViewSpineTree.tsx
@@ -26,6 +26,7 @@ import {
 } from '../lib/state/view-tree.js';
 import { useIaWorkspaces } from '../lib/hooks/use-ia-workspaces.js';
 import { WorkspaceBar } from './WorkspaceBar.js';
+import { BenchCreate } from './BenchCreate.js';
 import './ViewSpineTree.css';
 
 /** Create a Tab anchored to a Bench's (nodeId, cwd). Wired to the EXISTING
@@ -125,11 +126,27 @@ function BenchRow({
   );
 }
 
+/** Default cwd a "+ bench" form pre-fills for this instance:
+ *  - repo-instance: the first git bench's configured parent repo path (a
+ *    worktree path under the repo is the canonical bench cwd), so the user only
+ *    edits the suffix.
+ *  - node-instance: empty (arbitrary absolute cwd — `$HOME`, `/tmp/…`). */
+function defaultBenchCwd(
+  instance: ViewTreeInstance,
+  projectKind: ViewTreeProject['kind']
+): string {
+  if (projectKind !== 'repo') return '';
+  const gitBench = instance.benches.find((b) => b.repoPath);
+  return gitBench?.repoPath ?? '';
+}
+
 function InstanceRow({
   instance,
+  projectKind,
   onCreateTab,
 }: {
   instance: ViewTreeInstance;
+  projectKind: ViewTreeProject['kind'];
   onCreateTab?: ViewSpineCreateTab | undefined;
 }) {
   return (
@@ -158,6 +175,13 @@ function InstanceRow({
           ))}
         </ul>
       ) : null}
+      {/* #730 "+ bench": persisted bench overlays (cwd + env) for this instance
+          plus the create flow. Wired to the #735 `/hub/ia/benches` CRUD API. */}
+      <BenchCreate
+        instanceId={instance.id}
+        projectKind={projectKind}
+        defaultCwd={defaultBenchCwd(instance, projectKind)}
+      />
     </li>
   );
 }
@@ -258,6 +282,7 @@ function ProjectRow({
           <InstanceRow
             key={instance.id}
             instance={instance}
+            projectKind={project.kind}
             onCreateTab={onCreateTab}
           />
         ))}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -583,6 +583,65 @@ export async function deleteIaWorkspace(id: string): Promise<void> {
   }
 }
 
+// ── #735 Bench overlay CRUD (`/hub/ia/benches`) ──────────────────────────────
+// The PERSISTED, user-authored overlay layer (cwd + env + optional label) on
+// top of the DERIVED bench. C1 (from #735 review): a bench `cwd` is sent and
+// displayed VERBATIM — never `decodeURIComponent`-ed — so the raw absolute path
+// the caller chose is the path the hub mints the BenchId from.
+
+/** Persisted bench overlay row, as returned by `/hub/ia/benches`. Mirrors the
+ *  server `BenchOverlay` (ia-store.ts). `label === null` means "use derived". */
+export interface IaBench {
+  id: string;
+  instanceId: string;
+  cwd: string;
+  label: string | null;
+  envOverrides: Record<string, string>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const IA_BENCHES_PATH = '/hub/ia/benches';
+
+/** List bench overlays, optionally filtered to a single instance. Returns []
+ *  (never throws on empty) for an instance with no overlays. */
+export async function fetchIaBenches(instanceId?: string): Promise<IaBench[]> {
+  const url =
+    instanceId && instanceId.length > 0
+      ? `${IA_BENCHES_PATH}?instanceId=${encodeURIComponent(instanceId)}`
+      : IA_BENCHES_PATH;
+  const data = await json<{ benches?: IaBench[] }>(await fetch(url));
+  return Array.isArray(data.benches) ? data.benches : [];
+}
+
+/** Create a bench overlay. `cwd` MUST be the raw absolute path (C1: not
+ *  decoded). The hub mints the BenchId from `instanceId` + `cwd`. */
+export async function createIaBench(input: {
+  instanceId: string;
+  cwd: string;
+  label?: string;
+  envOverrides?: Record<string, string>;
+}): Promise<IaBench> {
+  const data = await json<{ bench: IaBench }>(
+    await fetch(IA_BENCHES_PATH, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    })
+  );
+  return data.bench;
+}
+
+/** Delete a bench overlay by its (opaque) id. */
+export async function deleteIaBench(id: string): Promise<void> {
+  const res = await fetch(`${IA_BENCHES_PATH}/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) {
+    throw await httpErrorFromResponse(res, 'Failed to delete bench');
+  }
+}
+
 function normalizeTelemetryMapEntry(
   mapKey: string,
   raw: Record<string, unknown>

--- a/frontend/src/lib/hooks/use-ia-benches.ts
+++ b/frontend/src/lib/hooks/use-ia-benches.ts
@@ -1,0 +1,66 @@
+// #730: TanStack Query data layer for Bench overlays (#735 `/hub/ia/benches`).
+// Mirrors `use-ia-workspaces.ts`: a per-instance list query plus create/delete
+// mutations that invalidate that instance's key on success.
+//
+// Correctness-first: no optimistic cache writes. Each mutation invalidates the
+// relevant `['ia-benches', instanceId]` key so the list refetches authoritative
+// state from the store and the new overlay appears under its Instance.
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  createIaBench,
+  deleteIaBench,
+  fetchIaBenches,
+  type IaBench,
+} from '../api.js';
+
+/** Query key for an instance's bench overlays. A blank instanceId disables the
+ *  query (the hook is always mounted per-instance, but guards anyway). */
+export function iaBenchesQueryKey(instanceId: string) {
+  return ['ia-benches', instanceId] as const;
+}
+
+export function useIaBenchesQuery(instanceId: string) {
+  return useQuery({
+    queryKey: iaBenchesQueryKey(instanceId),
+    queryFn: () => fetchIaBenches(instanceId),
+    enabled: instanceId.length > 0,
+    staleTime: 30_000,
+  });
+}
+
+/** Bundle of one instance's bench-overlay query + its mutations. The mutations
+ *  invalidate that instance's list on success so the UI re-reads the store. */
+export function useIaBenches(instanceId: string) {
+  const queryClient = useQueryClient();
+  const query = useIaBenchesQuery(instanceId);
+
+  const invalidate = () =>
+    void queryClient.invalidateQueries({
+      queryKey: iaBenchesQueryKey(instanceId),
+    });
+
+  const createMutation = useMutation({
+    mutationFn: (input: {
+      instanceId: string;
+      cwd: string;
+      label?: string;
+      envOverrides?: Record<string, string>;
+    }) => createIaBench(input),
+    onSuccess: invalidate,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteIaBench(id),
+    onSuccess: invalidate,
+  });
+
+  return {
+    benches: (query.data ?? []) as IaBench[],
+    isLoading: query.isLoading,
+    isError: query.isError,
+    refetch: query.refetch,
+    createMutation,
+    deleteMutation,
+  };
+}

--- a/frontend/src/lib/state/bench-create.ts
+++ b/frontend/src/lib/state/bench-create.ts
@@ -1,0 +1,104 @@
+// #730 (Epic #444 view-spine): PURE helpers for the Bench-creation flow wired to
+// the #735 `/hub/ia/benches` CRUD API. A Bench is a cwd + env layered on an
+// Instance; for a repo-instance the cwd defaults to a worktree path under the
+// repo, for a node-instance it is an arbitrary absolute cwd.
+//
+// These helpers carry NO React, NO I/O. They MIRROR the server's structural
+// validation (`validateBenchCwd` in `server/features/repo-router.ts`) so the
+// client rejects bad input before a round-trip:
+//   - cwd must be a non-blank absolute path (POSIX `/…` or Windows `X:\…`)
+//   - no `..` traversal segment
+//   - no NUL / control characters
+//
+// C1 (from #735 review): the cwd is sent VERBATIM. We never `decodeURIComponent`
+// a cwd before sending or displaying it — the raw absolute path is the contract.
+
+/** Why a cwd was rejected. `null` = valid. UI maps these to inline messages. */
+export type BenchCwdError =
+  | 'CWD_REQUIRED'
+  | 'CWD_NOT_ABSOLUTE'
+  | 'CWD_TRAVERSAL'
+  | 'INVALID_CWD';
+
+/** Validate a candidate bench cwd. Returns `null` when valid, else a reason
+ *  code mirroring the server's `validateBenchCwd`. Operates on the RAW string —
+ *  no decoding, no normalization (C1). */
+export function validateBenchCwd(value: string): BenchCwdError | null {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return 'CWD_REQUIRED';
+  }
+  // NUL or other control chars never belong in a path.
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(value)) {
+    return 'INVALID_CWD';
+  }
+  const isPosixAbs = value.startsWith('/');
+  const isWindowsAbs = /^[a-zA-Z]:[\\/]/.test(value);
+  if (!isPosixAbs && !isWindowsAbs) {
+    return 'CWD_NOT_ABSOLUTE';
+  }
+  const segments = value.split(/[\\/]+/);
+  if (segments.includes('..')) {
+    return 'CWD_TRAVERSAL';
+  }
+  return null;
+}
+
+/** Human-readable, lowercase TUI copy for a cwd rejection. */
+export function benchCwdErrorMessage(error: BenchCwdError): string {
+  switch (error) {
+    case 'CWD_REQUIRED':
+      return 'enter an absolute cwd';
+    case 'CWD_NOT_ABSOLUTE':
+      return 'cwd must be an absolute path';
+    case 'CWD_TRAVERSAL':
+      return 'cwd must not contain ".."';
+    case 'INVALID_CWD':
+      return 'cwd contains invalid characters';
+  }
+}
+
+/** A single env override entry as edited in the UI (key=value pair). */
+export interface EnvOverrideEntry {
+  key: string;
+  value: string;
+}
+
+/** The create payload `POST /hub/ia/benches` accepts. `cwd` is the RAW absolute
+ *  path (C1: never decoded). `label`/`envOverrides` are omitted when empty so the
+ *  server falls back to its defaults (derived label, no overrides). */
+export interface CreateBenchPayload {
+  instanceId: string;
+  cwd: string;
+  label?: string;
+  envOverrides?: Record<string, string>;
+}
+
+/** Build the create payload from raw form fields. Trims the cwd of surrounding
+ *  whitespace ONLY (interior bytes are the verbatim path). Drops blank-keyed env
+ *  entries; a later entry with the same key wins (last-write). Omits `label` and
+ *  `envOverrides` entirely when empty so the request stays minimal. PURE. */
+export function buildBenchPayload(input: {
+  instanceId: string;
+  cwd: string;
+  label?: string;
+  envEntries?: ReadonlyArray<EnvOverrideEntry>;
+}): CreateBenchPayload {
+  const cwd = input.cwd.trim();
+  const payload: CreateBenchPayload = {
+    instanceId: input.instanceId,
+    cwd,
+  };
+  const label = input.label?.trim();
+  if (label) payload.label = label;
+
+  const env: Record<string, string> = {};
+  for (const entry of input.envEntries ?? []) {
+    const key = entry.key.trim();
+    if (key.length === 0) continue; // blank keys are dropped (server would too)
+    env[key] = entry.value;
+  }
+  if (Object.keys(env).length > 0) payload.envOverrides = env;
+
+  return payload;
+}

--- a/test/bench-create.test.ts
+++ b/test/bench-create.test.ts
@@ -1,0 +1,132 @@
+// #730: unit tests for the PURE Bench-creation helpers. These MIRROR the
+// server's `validateBenchCwd` (server/features/repo-router.ts) so the client
+// rejects bad input before a round-trip, and verify the create-payload builder
+// drops empty fields + blank env keys.
+import { describe, expect, it } from 'vitest';
+
+import {
+  benchCwdErrorMessage,
+  buildBenchPayload,
+  validateBenchCwd,
+} from '../frontend/src/lib/state/bench-create.js';
+
+describe('validateBenchCwd', () => {
+  it('accepts a POSIX absolute path', () => {
+    expect(validateBenchCwd('/home/user/project')).toBeNull();
+    expect(validateBenchCwd('/tmp/scratch')).toBeNull();
+    expect(validateBenchCwd('/')).toBeNull();
+  });
+
+  it('accepts a Windows absolute path (both slash styles)', () => {
+    expect(validateBenchCwd('C:\\Users\\me\\repo')).toBeNull();
+    expect(validateBenchCwd('D:/projects/app')).toBeNull();
+  });
+
+  it('rejects a blank / whitespace-only cwd', () => {
+    expect(validateBenchCwd('')).toBe('CWD_REQUIRED');
+    expect(validateBenchCwd('   ')).toBe('CWD_REQUIRED');
+  });
+
+  it('rejects a relative path', () => {
+    expect(validateBenchCwd('relative/path')).toBe('CWD_NOT_ABSOLUTE');
+    expect(validateBenchCwd('./here')).toBe('CWD_NOT_ABSOLUTE');
+    expect(validateBenchCwd('~/home')).toBe('CWD_NOT_ABSOLUTE');
+  });
+
+  it('rejects `..` traversal anywhere in the path', () => {
+    expect(validateBenchCwd('/home/../etc')).toBe('CWD_TRAVERSAL');
+    expect(validateBenchCwd('/a/b/..')).toBe('CWD_TRAVERSAL');
+    expect(validateBenchCwd('C:\\a\\..\\b')).toBe('CWD_TRAVERSAL');
+  });
+
+  it('rejects control / NUL characters', () => {
+    expect(validateBenchCwd('/home/\x00/evil')).toBe('INVALID_CWD');
+    expect(validateBenchCwd('/home/\nnewline')).toBe('INVALID_CWD');
+    expect(validateBenchCwd('/home/\x7f')).toBe('INVALID_CWD');
+  });
+
+  it('does NOT reject a single dot segment (only `..` traversal)', () => {
+    // A lone `.` is not a traversal segment; the server treats it the same.
+    expect(validateBenchCwd('/home/.config/app')).toBeNull();
+  });
+
+  it('maps every error code to a non-empty message', () => {
+    for (const code of [
+      'CWD_REQUIRED',
+      'CWD_NOT_ABSOLUTE',
+      'CWD_TRAVERSAL',
+      'INVALID_CWD',
+    ] as const) {
+      expect(benchCwdErrorMessage(code).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('buildBenchPayload', () => {
+  it('trims surrounding whitespace off the cwd but keeps it verbatim', () => {
+    const payload = buildBenchPayload({
+      instanceId: 'inst:proj:node',
+      cwd: '  /home/user/with spaces  ',
+    });
+    // Interior bytes (the space) are preserved — not decoded, not normalized.
+    expect(payload.cwd).toBe('/home/user/with spaces');
+    expect(payload.instanceId).toBe('inst:proj:node');
+  });
+
+  it('omits label when blank, includes it (trimmed) when present', () => {
+    expect(
+      buildBenchPayload({ instanceId: 'i', cwd: '/x', label: '   ' }).label
+    ).toBeUndefined();
+    expect(
+      buildBenchPayload({ instanceId: 'i', cwd: '/x', label: '  feature  ' })
+        .label
+    ).toBe('feature');
+  });
+
+  it('omits envOverrides entirely when there are no usable entries', () => {
+    expect(
+      buildBenchPayload({
+        instanceId: 'i',
+        cwd: '/x',
+        envEntries: [{ key: '   ', value: 'ignored' }],
+      }).envOverrides
+    ).toBeUndefined();
+    expect(
+      buildBenchPayload({ instanceId: 'i', cwd: '/x' }).envOverrides
+    ).toBeUndefined();
+  });
+
+  it('collects env entries, dropping blank keys and keeping empty values', () => {
+    const payload = buildBenchPayload({
+      instanceId: 'i',
+      cwd: '/x',
+      envEntries: [
+        { key: 'FOO', value: 'bar' },
+        { key: '  BAZ  ', value: '' },
+        { key: '', value: 'dropped' },
+      ],
+    });
+    expect(payload.envOverrides).toEqual({ FOO: 'bar', BAZ: '' });
+  });
+
+  it('last-write-wins for a duplicated env key', () => {
+    const payload = buildBenchPayload({
+      instanceId: 'i',
+      cwd: '/x',
+      envEntries: [
+        { key: 'FOO', value: 'first' },
+        { key: 'FOO', value: 'second' },
+      ],
+    });
+    expect(payload.envOverrides).toEqual({ FOO: 'second' });
+  });
+
+  it('does not decode percent-encoded sequences in the cwd (C1)', () => {
+    // A literal "%2e%2e" must NOT become ".." — we send the raw path.
+    const payload = buildBenchPayload({
+      instanceId: 'i',
+      cwd: '/home/%2e%2e/literal',
+    });
+    expect(payload.cwd).toBe('/home/%2e%2e/literal');
+  });
+});


### PR DESCRIPTION
## What shipped

A **Bench creation** flow on each Instance row in the flag-gated `view-spine` sidebar (default OFF), wired to the **#735 Bench CRUD API** (`/hub/ia/benches`).

A Bench = cwd + env layered on an Instance:
- **repo-instance**: cwd pre-fills with the parent repo path (a worktree path under the repo is the canonical bench cwd).
- **node-instance**: arbitrary absolute cwd (`$HOME`, `/tmp/...`).

### Surface
- `+ bench` affordance under each `InstanceRow` (reuses the existing `.add-worktree-row`/`.add-worktree-btn` primitive; distinct copy).
- Inline create form: **cwd** (validated absolute-path text input), optional **label**, optional **env overrides** (key=value pairs, add/remove).
- Persisted bench overlays render under their Instance (with env-count badge + minimal delete), so a freshly-created bench appears immediately.

### API consumed (#735)
- `GET /hub/ia/benches?instanceId=` — list overlays for the instance.
- `POST /hub/ia/benches` — `{ instanceId, cwd, envOverrides?, label? }`; hub mints the BenchId.
- `DELETE /hub/ia/benches/:id` — minimal delete (in scope, trivial).
- Typed client fns (`fetchIaBenches`/`createIaBench`/`deleteIaBench`, `IaBench`) in `frontend/src/lib/api.ts`; TanStack `useIaBenches(instanceId)` hook mirroring #728's `use-ia-workspaces.ts` (per-instance query key, mutations invalidate on success — no optimistic writes).

### C1 security note (#735 review)
The bench `cwd` is sent and displayed **verbatim** — never `decodeURIComponent`-ed. The raw absolute path the user enters is the path the hub mints the BenchId from. A unit test asserts `%2e%2e` is not decoded to `..`.

### Validation
Client-side `validateBenchCwd` mirrors the server's `validateBenchCwd`: non-blank, absolute (POSIX or Windows), no `..` traversal, no NUL/control chars. Rejection blocks submit and shows inline copy.

### States covered
empty (no overlays), loading, error (non-destructive inline + retry/refetch), in-flight (form disabled while create/delete pending), validation (cwd rejected client-side after submit attempt), keyboard (Enter submits / Escape cancels), touch targets ≥44px on create/cancel actions.

### Behind the flag
Only mounted via `ViewSpineTree`, which renders only when `viewSpineEnabled` (default OFF). OFF path is byte-identical to today.

### Out of scope
Env-override inheritance into tabs (#740); bench edit UI; migration/legacy import.

## Test / gate results
- `npm run build` — pass.
- `npm run check` — 0 errors (pre-existing warnings only; none in new files).
- `npm test` — 295 files / 3808 tests pass, incl. 14 new `test/bench-create.test.ts` (cwd validation + payload builder + C1 no-decode).

## Files
- `frontend/src/lib/state/bench-create.ts` (new — pure validation + payload builder)
- `frontend/src/lib/hooks/use-ia-benches.ts` (new — TanStack query/mutations)
- `frontend/src/lib/api.ts` (typed `IaBench` + client fns)
- `frontend/src/components/BenchCreate.tsx` / `.css` (new — UI)
- `frontend/src/components/ViewSpineTree.tsx` (wire `+ bench` into `InstanceRow`)
- `test/bench-create.test.ts` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
