### PR TITLE
ci: stabilize e2e smoke gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,28 +35,58 @@ jobs:
     needs: ci
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: Detect e2e-relevant changes
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune origin "${{ github.base_ref }}"
+          changed_files="$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")"
+
+          if [ -z "$changed_files" ]; then
+            echo "e2e_required=true" >> "$GITHUB_OUTPUT"
+            echo "No changed files detected; running e2e conservatively."
+          elif printf '%s\n' "$changed_files" | grep -Ev '^(docs/|.*\.mdx?$)' >/dev/null; then
+            echo "e2e_required=true" >> "$GITHUB_OUTPUT"
+            echo "E2E-relevant changes detected:"
+            printf '%s\n' "$changed_files"
+          else
+            echo "e2e_required=false" >> "$GITHUB_OUTPUT"
+            echo "Docs/markdown-only changes detected; e2e check will no-op successfully."
+            printf '%s\n' "$changed_files"
+          fi
+
       - uses: actions/setup-node@v4
+        if: steps.changes.outputs.e2e_required == 'true'
         with:
           node-version-file: '.nvmrc'
+          cache: npm
 
       - run: npm ci
+        if: steps.changes.outputs.e2e_required == 'true'
 
       - run: npm run build
+        if: steps.changes.outputs.e2e_required == 'true'
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+      - name: Verify hosted Chrome
+        if: steps.changes.outputs.e2e_required == 'true'
+        run: google-chrome --version
 
       - name: Run e2e smoke tests
+        if: steps.changes.outputs.e2e_required == 'true'
         run: npx playwright test --grep "smoke"
         env:
           CI: true
           NO_PIN: '1'
           RELAY_IDE_PORT: '3456'
+          RELAY_IDE_E2E_SKIP_BUILD: '1'
+          PLAYWRIGHT_CHROME_CHANNEL: chrome
 
       - name: Upload Playwright report
         if: failure()

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -86,6 +86,20 @@ Full suite always runs in CI (`npm test` in `.github/workflows/publish.yml`).
 
 Playwright component tests live in `test/e2e/`. They are excluded from `npm test` via `vitest.config.ts` (`exclude: ['test/e2e/**']`) and run separately.
 
+For local/devbox smoke runs, prefer a system browser instead of Playwright's
+downloaded browser cache. On Debian-based devboxes install Chromium once, then
+point Playwright at it:
+
+```bash
+sudo apt-get update && sudo apt-get install -y chromium
+PLAYWRIGHT_EXECUTABLE_PATH=/usr/bin/chromium npm run test:e2e -- --grep smoke
+```
+
+GitHub-hosted CI uses the preinstalled Chrome channel. Avoid putting
+`npx playwright install --with-deps chromium` in the required smoke gate unless a
+runner image truly lacks a browser; browser provisioning has previously wedged
+after download and blocked unrelated PRs.
+
 ## Mobile Input Testing
 
 The mobile input event-intent pipeline is extracted into `shared/mobile-input-pipeline.ts` and tested via JSON event fixtures.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,12 @@ import { defineConfig, devices } from '@playwright/test';
 
 const port = Number(process.env.PLAYWRIGHT_PORT ?? 3456);
 const baseURL = `http://localhost:${port}`;
+const startCommand =
+  process.env.RELAY_IDE_E2E_SKIP_BUILD === '1'
+    ? 'node dist/server/index.js'
+    : 'npm run start';
+const chromeChannel = process.env.PLAYWRIGHT_CHROME_CHANNEL;
+const executablePath = process.env.PLAYWRIGHT_EXECUTABLE_PATH;
 
 export default defineConfig({
   testDir: './test/e2e',
@@ -15,18 +21,22 @@ export default defineConfig({
     baseURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    video: process.env.CI || executablePath ? 'off' : 'retain-on-failure',
   },
 
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        ...(chromeChannel ? { channel: chromeChannel } : {}),
+        ...(executablePath ? { launchOptions: { executablePath } } : {}),
+      },
     },
   ],
 
   webServer: {
-    command: `RELAY_IDE_E2E_FIXTURES=1 RELAY_IDE_PORT=${port} npm run start`,
+    command: `RELAY_IDE_E2E_FIXTURES=1 RELAY_IDE_PORT=${port} ${startCommand}`,
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120000,

--- a/test/e2e/basic.spec.ts
+++ b/test/e2e/basic.spec.ts
@@ -1,7 +1,17 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 const isExpectedError = (msg: string) => {
   return msg.includes('401 (Unauthorized)') || msg.includes('auth');
+};
+
+const waitForAppReady = async (page: Page) => {
+  if (process.env.NO_PIN === '1') {
+    await expect(page.locator('.main-app')).toBeVisible({ timeout: 10000 });
+  } else {
+    await expect(page.getByRole('button', { name: /set PIN/i })).toBeVisible({
+      timeout: 10000,
+    });
+  }
 };
 
 test.describe('smoke', () => {
@@ -20,6 +30,7 @@ test.describe('smoke', () => {
     await page.goto('/');
 
     await expect(page).toHaveTitle(/relay/i);
+    await waitForAppReady(page);
 
     expect(errors).toHaveLength(0);
   });
@@ -29,11 +40,12 @@ test.describe('smoke', () => {
 
     const setPinButton = page.getByRole('button', { name: /set PIN/i });
 
+    await waitForAppReady(page);
+
     if (process.env.NO_PIN === '1') {
-      await expect(page.locator('.main-app')).toBeVisible({ timeout: 10000 });
       await expect(setPinButton).toHaveCount(0);
     } else {
-      await expect(setPinButton).toBeVisible({ timeout: 10000 });
+      await expect(setPinButton).toBeVisible();
     }
   });
 
@@ -54,10 +66,7 @@ test.describe('smoke', () => {
     });
 
     await page.goto('/');
-
-    await page.waitForLoadState('networkidle');
-
-    await page.waitForTimeout(2000);
+    await waitForAppReady(page);
 
     expect(errors).toHaveLength(0);
   });
@@ -66,8 +75,7 @@ test.describe('smoke', () => {
 test.describe('visual regression', () => {
   test('screenshot comparison', async ({ page }) => {
     await page.goto('/');
-
-    await page.waitForLoadState('networkidle');
+    await waitForAppReady(page);
 
     await expect(page).toHaveScreenshot('homepage.png', {
       maxDiffPixels: 1000,
@@ -79,6 +87,7 @@ test.describe('visual regression', () => {
     await page.setViewportSize({ width: 375, height: 667 });
 
     await page.goto('/');
+    await waitForAppReady(page);
 
     await expect(page).toHaveScreenshot('mobile-homepage.png', {
       maxDiffPixels: 1000,
@@ -90,6 +99,7 @@ test.describe('visual regression', () => {
     await page.setViewportSize({ width: 768, height: 1024 });
 
     await page.goto('/');
+    await waitForAppReady(page);
 
     await expect(page).toHaveScreenshot('tablet-homepage.png', {
       maxDiffPixels: 1000,
@@ -101,6 +111,7 @@ test.describe('visual regression', () => {
     await page.setViewportSize({ width: 1920, height: 1080 });
 
     await page.goto('/');
+    await waitForAppReady(page);
 
     await expect(page).toHaveScreenshot('desktop-homepage.png', {
       maxDiffPixels: 1000,


### PR DESCRIPTION
## Summary
- make required `e2e` check no-op successfully for docs/markdown-only PRs
- stop downloading Playwright Chromium on GitHub-hosted runners; use hosted Chrome via Playwright `channel: chrome`
- add `PLAYWRIGHT_EXECUTABLE_PATH` support so devboxes can use an installed system browser instead of Playwright's browser cache
- add a 15-minute e2e job timeout and npm cache in the e2e job
- avoid rebuilding inside Playwright `webServer` after the e2e job already built dist
- replace smoke-test `networkidle`/fixed waits with explicit app readiness assertions
- document the Debian/devbox Chromium setup in `docs/QUALITY.md`

## Why
The current e2e gate can hang during `npx playwright install --with-deps chromium` after the Chrome download reaches 100%, blocking docs-only PRs even when Relay app code did not change. Using a system browser removes the flaky browser-provisioning step from the required gate and from local devbox smoke runs.

## Verification
- installed Debian Chromium once on the devbox: `/usr/bin/chromium`, `Chromium 148.0.7778.178`
- `python3 - <<'PY' ... yaml.safe_load('.github/workflows/ci.yml') ... PY`
- `npm run check`
- `npm run build`
- `PLAYWRIGHT_CHROME_CHANNEL=chrome npx playwright test --grep "smoke" --list`
- `PLAYWRIGHT_EXECUTABLE_PATH=/usr/bin/chromium PLAYWRIGHT_PORT=4569 RELAY_IDE_PORT=4569 RELAY_IDE_E2E_SKIP_BUILD=1 NO_PIN=1 npm run test:e2e -- --grep smoke --reporter=line --workers=1` → 3 passed
- started built Relay locally on `127.0.0.1:4568` and validated with browser automation:
  - page title: `Relay`
  - `.main-app` present
  - browser console/js errors: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * E2E tests now run conditionally in CI when code changes are detected, skipping unnecessary runs for documentation-only PRs.
  * Added support for using system-installed browsers during testing.

* **Documentation**
  * Added guidance for running local E2E tests with system-installed browsers instead of downloading test dependencies.

* **Tests**
  * Improved test reliability through shared app-readiness helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->