### PR TITLE
feat(#759): session inbox integration + delivery lifecycle

### DIFF
--- a/server/anchor-file-fetcher.ts
+++ b/server/anchor-file-fetcher.ts
@@ -1,0 +1,260 @@
+// #759 / ADR-019 (§D3, fugu C1): production wiring of #766's `AnchorFileFetcher`
+// seam to the hub's session-scoped File RPC path under capability.
+//
+// THE SESSION-SCOPE PROBLEM. #766's fetcher contract is `(nodeId, path, …)` with
+// NO session — but the only blessed way to read a (possibly remote) node's file
+// is `server/file-rpc.ts` → `nodeLinks.request('fs.read'|'fs.stat')`, which is
+// SESSION-SCOPED: the request must name a live scoped session whose filesystem
+// root (worktree/repo/cwd) CONTAINS the target path, and the read is gated by
+// `evaluateHubPolicy(rpc.fs.read)` against that session's scope. A bare
+// `(nodeId, path)` carries neither a session nor a scope.
+//
+// DECISION (smallest correct, reuses the policy/scoping machinery rather than
+// re-implementing it): resolve a scope by SCANNING the live scoped-session
+// registry for a session on `nodeId` whose root contains `path` (via the same
+// `normalizeHubFileRpcRequest` root-containment check the File RPC route uses),
+// then route the read through THAT session's envelope + policy. We do NOT mint a
+// synthetic session and we do NOT fall back to a local `fs.stat` (C1: a local
+// stat on the hub would silently resolve the WRONG filesystem for a federated
+// node). If no live in-scope session exists, or policy denies, the fetcher
+// returns `null` — which #766's `resolveAnchor` maps to `AnchorState='missing'`
+// (an honest "can't resolve right now" rather than a confidently-wrong answer).
+//
+// CAPABILITY GATE. The read runs the SAME `evaluateHubPolicy` +
+// `requiredCapabilitiesForRpcIntent('rpc.fs.read'|'rpc.fs.stat')` check as the
+// File RPC route. Both intents require `rpc:fs:read`, which is exactly
+// `ANCHOR_RESOLUTION_CAPABILITY`; the fetch result echoes that bit as
+// `grantedCapability` so #766's caller can assert the gate fired (C1
+// enforcement). A non-`allow` decision returns `null`.
+
+import { normalizeHubFileRpcRequest } from './file-rpc.js';
+import {
+  evaluateHubPolicy,
+  requiredCapabilitiesForRpcIntent,
+} from './hub-policy-evaluator.js';
+import type { ScopedSessionSummary } from './session-envelope-registry.js';
+import { ANCHOR_RESOLUTION_CAPABILITY } from './anchor-resolution.js';
+import type {
+  AnchorFileFetcher,
+  AnchorFileFetchResult,
+  AnchorFileFetchTarget,
+} from './anchor-resolution.js';
+import {
+  hashAnchorContent,
+} from './anchor-resolution.js';
+import type {
+  FileRpcReadResponse,
+  FileRpcStatResponse,
+} from '../shared/file-rpc.js';
+import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
+import { RELAY_NODE_LINK_PROTOCOL_VERSION } from '../shared/relay-node-protocol.js';
+
+/** Minimal node registry shape the fetcher needs (subset of the hub registry). */
+export interface AnchorFetcherNodeRegistry {
+  listNodes(): HubNodeSummary[];
+}
+
+/** Minimal node-link shape the fetcher needs (subset of the hub link manager). */
+export interface AnchorFetcherNodeLinks {
+  hasActiveNode(nodeId: string): boolean;
+  request(nodeId: string, type: string, payload: unknown): Promise<unknown>;
+}
+
+/** Minimal session-envelope registry shape (subset of the in-memory registry). */
+export interface AnchorFetcherSessionEnvelopes {
+  listSummaries(options?: {
+    now?: Date;
+    includeRevoked?: boolean;
+    includeExpired?: boolean;
+  }): ScopedSessionSummary[];
+}
+
+export interface AnchorFileFetcherDeps {
+  registry: AnchorFetcherNodeRegistry;
+  nodeLinks: AnchorFetcherNodeLinks;
+  sessionEnvelopes: AnchorFetcherSessionEnvelopes;
+  now?: () => Date;
+}
+
+function liveNode(
+  registry: AnchorFetcherNodeRegistry,
+  nodeLinks: AnchorFetcherNodeLinks,
+  nodeId: string
+): HubNodeSummary | null {
+  const node = registry.listNodes().find((n) => n.nodeId === nodeId);
+  if (!node) return null;
+  if (node.status !== 'online') return null;
+  if (node.protocolVersion !== RELAY_NODE_LINK_PROTOCOL_VERSION) return null;
+  if (!nodeLinks.hasActiveNode(nodeId)) return null;
+  return node;
+}
+
+/**
+ * Find a live, active scoped session on `nodeId` whose filesystem root CONTAINS
+ * `path`, and return the normalized File RPC request scoped to it. Reuses
+ * `normalizeHubFileRpcRequest` (the same root-containment + traversal guard the
+ * File RPC route uses) so a path outside every session's root is rejected here
+ * exactly as it would be on the route. Returns `null` when no in-scope live
+ * session exists.
+ */
+function resolveScopedReadRequest(input: {
+  sessions: ScopedSessionSummary[];
+  node: HubNodeSummary;
+  nodeId: string;
+  path: string;
+  operation: 'read' | 'stat';
+  maxBytes?: number;
+}): {
+  session: ScopedSessionSummary;
+  request: ReturnType<typeof normalizeHubFileRpcRequest>;
+} | null {
+  for (const session of input.sessions) {
+    if (session.nodeId !== input.nodeId) continue;
+    if (session.status !== 'active') continue;
+    const normalized = normalizeHubFileRpcRequest({
+      operation: input.operation,
+      nodePlatform: input.node.platform,
+      nodeId: input.nodeId,
+      session,
+      body: {
+        path: input.path,
+        ...(input.operation === 'read' && input.maxBytes !== undefined
+          ? { maxBytes: input.maxBytes }
+          : {}),
+      },
+    });
+    // A session whose root does NOT contain the path fails normalization
+    // (ROOT_ESCAPE / ROOT_UNAVAILABLE) — skip it and try the next session.
+    if (normalized.ok) {
+      return { session, request: normalized };
+    }
+  }
+  return null;
+}
+
+/**
+ * Build the production `AnchorFileFetcher`. Each fetch:
+ *   1. confirms the node is live (online, matching protocol, active reverse link);
+ *   2. resolves a live in-scope scoped session + normalized File RPC request;
+ *   3. runs the SAME hub policy check the File RPC route runs for the read;
+ *   4. issues `nodeLinks.request('fs.read'|'fs.stat', …)` and maps the response.
+ * Any failure short of an authorized response that found the file returns either
+ * `null` (no scope / unauthorized — anchor treated as `missing` by the resolver)
+ * or `{ found: false }` (authorized, node reported the path gone).
+ */
+export function createAnchorFileFetcher(deps: AnchorFileFetcherDeps): AnchorFileFetcher {
+  const now = deps.now ?? (() => new Date());
+
+  return async function fetchAnchorFile(
+    target: AnchorFileFetchTarget
+  ): Promise<AnchorFileFetchResult | null> {
+    const node = liveNode(deps.registry, deps.nodeLinks, target.nodeId);
+    if (!node) return null;
+
+    const operation: 'read' | 'stat' = target.preferRead ? 'read' : 'stat';
+    const resolved = resolveScopedReadRequest({
+      sessions: deps.sessionEnvelopes.listSummaries(),
+      node,
+      nodeId: target.nodeId,
+      path: target.path,
+      operation,
+      ...(target.maxBytes !== undefined ? { maxBytes: target.maxBytes } : {}),
+    });
+    // No live session whose scope contains the path → we have no authorization
+    // context for the read. Treat as unresolvable (C1: never local-stat).
+    if (!resolved || !resolved.request.ok) return null;
+
+    const action = `rpc.fs.${operation}` as 'rpc.fs.read' | 'rpc.fs.stat';
+    const policyScope = resolved.request.value.policyScope;
+    const fileRequest = resolved.request.value.request;
+    const decision = evaluateHubPolicy({
+      peer: { kind: 'hub' },
+      node,
+      nodeId: target.nodeId,
+      intent: { action, target: target.nodeId },
+      scope: policyScope,
+      requiredCapabilities: requiredCapabilitiesForRpcIntent(action),
+      sessionId: resolved.session.sessionId,
+      ...(resolved.session.correlationId
+        ? { correlationId: resolved.session.correlationId }
+        : {}),
+      ...(resolved.session.expiresAt !== null
+        ? { expiresAt: resolved.session.expiresAt }
+        : {}),
+      ...(resolved.session.revokedAt !== null
+        ? { revokedAt: resolved.session.revokedAt }
+        : {}),
+      params: { ...fileRequest },
+      now: now(),
+    });
+    // Anything other than a clean allow (deny / challenge / revoke) is treated
+    // as "not authorized for an unattended anchor resolution" → unresolvable.
+    if (decision.decision !== 'allow') return null;
+
+    let payload: unknown;
+    try {
+      payload = await deps.nodeLinks.request(target.nodeId, `fs.${operation}`, fileRequest);
+    } catch {
+      // A NOT_FOUND from the node means the path is gone (authorized fetch, found
+      // nothing); any other link error means we could not perform the read.
+      // We can't cheaply distinguish here without leaking the error taxonomy, so
+      // we conservatively report "found nothing" only when the node is reachable.
+      // A thrown HubNodeLinkError for NOT_FOUND is the common gone-file case.
+      return { found: false, grantedCapability: ANCHOR_RESOLUTION_CAPABILITY };
+    }
+
+    return mapPayload(operation, payload);
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** Map an authorized File RPC response onto an `AnchorFileFetchResult`. */
+function mapPayload(
+  operation: 'read' | 'stat',
+  payload: unknown
+): AnchorFileFetchResult {
+  const record = asRecord(payload);
+  if (!record) {
+    return { found: false, grantedCapability: ANCHOR_RESOLUTION_CAPABILITY };
+  }
+
+  if (operation === 'stat') {
+    const response = record as unknown as FileRpcStatResponse;
+    const stat = response.stat;
+    // Only a regular file resolves an anchor; a directory/symlink/other at the
+    // path means the anchored file no longer exists there → missing.
+    if (!stat || stat.type !== 'file') {
+      return { found: false, grantedCapability: ANCHOR_RESOLUTION_CAPABILITY };
+    }
+    return {
+      found: true,
+      grantedCapability: ANCHOR_RESOLUTION_CAPABILITY,
+      ...(typeof stat.size === 'number' ? { size: stat.size } : {}),
+      ...(typeof stat.mtimeMs === 'number' ? { mtimeMs: stat.mtimeMs } : {}),
+    };
+  }
+
+  const response = record as unknown as FileRpcReadResponse;
+  if (typeof response.content !== 'string') {
+    return { found: false, grantedCapability: ANCHOR_RESOLUTION_CAPABILITY };
+  }
+  // Hash the CURRENT bytes for an authoritative sha-vs-sha comparison. The read
+  // is bounded by `maxBytes`; a truncated read cannot yield a trustworthy whole-
+  // file hash, so we omit the sha (the pure resolver falls back to size/mtime).
+  const buffer =
+    response.encoding === 'base64'
+      ? Buffer.from(response.content, 'base64')
+      : Buffer.from(response.content, 'utf8');
+  const contentSha256 = response.truncatedBytes ? undefined : hashAnchorContent(buffer);
+  return {
+    found: true,
+    grantedCapability: ANCHOR_RESOLUTION_CAPABILITY,
+    ...(typeof response.bytesRead === 'number' ? { size: response.bytesRead } : {}),
+    ...(contentSha256 !== undefined ? { contentSha256 } : {}),
+  };
+}

--- a/server/anchor-resolution.ts
+++ b/server/anchor-resolution.ts
@@ -199,3 +199,41 @@ export async function resolveAnchor(
 
   return { state: resolveAnchorState(captured, current), current };
 }
+
+// ── Hub-level fetcher registration (#759 integration) ───────────────────────
+//
+// The production `AnchorFileFetcher` (File-RPC-under-capability) is constructed
+// once at hub boot in `server/index.ts` from the live registry/link/envelope
+// handles. Consumers that resolve an anchor's `AnchorState` at read time (the
+// inbox-decoration / #760 adapter follow-up) retrieve it here rather than
+// threading the deps through every call site. Registering it makes the #759
+// wiring a real, retrievable hub dependency, not dead code.
+
+let registeredFetcher: AnchorFileFetcher | null = null;
+
+/** Register the hub's production anchor fetcher (called once at boot). */
+export function registerAnchorFileFetcher(fetcher: AnchorFileFetcher): void {
+  registeredFetcher = fetcher;
+}
+
+/**
+ * Retrieve the registered hub anchor fetcher, or `null` if the hub has not
+ * booted / wired it (e.g. unit tests of an unrelated surface). A `null` fetcher
+ * means anchor resolution is unavailable; callers should treat anchors as
+ * unresolved rather than synthesizing a local read.
+ */
+export function getAnchorFileFetcher(): AnchorFileFetcher | null {
+  return registeredFetcher;
+}
+
+/**
+ * Resolve an anchor using the hub-registered fetcher. Returns `null` when no
+ * fetcher is registered (hub not booted) so the caller can distinguish
+ * "unavailable" from a resolved `missing`.
+ */
+export async function resolveAnchorWithRegisteredFetcher(
+  captured: AnchorRef
+): Promise<ResolveAnchorOutcome | null> {
+  if (!registeredFetcher) return null;
+  return resolveAnchor(captured, registeredFetcher);
+}

--- a/server/context-packets.ts
+++ b/server/context-packets.ts
@@ -154,13 +154,24 @@ export interface InboxMessageListFilter {
   state?: SessionInboxMessageState;
 }
 
+/**
+ * Filter for `listContextPackets`. All clauses are ANDed. `nodeId`/`workspaceId`
+ * match the denormalized federation-query columns (derived from the packet's
+ * binding/anchor/fileRef at write time); `limit` caps the result set.
+ */
+export interface ContextPacketListFilter {
+  nodeId?: string;
+  workspaceId?: string;
+  limit?: number;
+}
+
 export interface ContextPacketStore {
   close(): void;
 
   // ── Context packets ──────────────────────────────────────────────────────
   createContextPacket(input: ContextPacketCreateInput): ContextPacket;
   getContextPacket(id: ContextPacketId): ContextPacket | null;
-  listContextPackets(): ContextPacket[];
+  listContextPackets(filter?: ContextPacketListFilter): ContextPacket[];
   /** Delete a packet. RESTRICTed if any live inbox message references it. */
   deleteContextPacket(id: ContextPacketId): boolean;
 
@@ -209,10 +220,6 @@ export function createContextPacketStore(dbPath: string): ContextPacketStore {
   const selectPacket = db.prepare(
     `SELECT id, kind, packet_json, node_id, workspace_id, created_by, created_at, updated_at
      FROM context_packets WHERE id = ?`
-  );
-  const selectAllPackets = db.prepare(
-    `SELECT id, kind, packet_json, node_id, workspace_id, created_by, created_at, updated_at
-     FROM context_packets ORDER BY created_at DESC, id ASC`
   );
   const insertPacket = db.prepare(
     `INSERT INTO context_packets (
@@ -300,8 +307,31 @@ export function createContextPacketStore(dbPath: string): ContextPacketStore {
 
     getContextPacket: getPacketById,
 
-    listContextPackets() {
-      return (selectAllPackets.all() as ContextPacketRow[])
+    listContextPackets(filter: ContextPacketListFilter = {}) {
+      const clauses: string[] = [];
+      const params: unknown[] = [];
+      if (filter.nodeId !== undefined) {
+        clauses.push('node_id = ?');
+        params.push(filter.nodeId);
+      }
+      if (filter.workspaceId !== undefined) {
+        clauses.push('workspace_id = ?');
+        params.push(filter.workspaceId);
+      }
+      const where = clauses.length ? ` WHERE ${clauses.join(' AND ')}` : '';
+      // LIMIT is bound rather than interpolated; clamp to a positive integer.
+      const limit =
+        filter.limit !== undefined && Number.isFinite(filter.limit)
+          ? Math.max(1, Math.trunc(filter.limit))
+          : undefined;
+      const limitClause = limit !== undefined ? ' LIMIT ?' : '';
+      const stmt = db.prepare(
+        `SELECT id, kind, packet_json, node_id, workspace_id, created_by, created_at, updated_at
+         FROM context_packets${where}
+         ORDER BY created_at DESC, id ASC${limitClause}`
+      );
+      const args = limit !== undefined ? [...params, limit] : params;
+      return (stmt.all(...args) as ContextPacketRow[])
         .map(rowToPacketSafe)
         .filter((p): p is ContextPacket => p !== null);
     },

--- a/server/features/context-inbox-store-adapter.ts
+++ b/server/features/context-inbox-store-adapter.ts
@@ -1,0 +1,203 @@
+// #759 / ADR-019: adapter wiring the #765 gateway router's narrow
+// `ContextInboxStore` seam to the concrete #758 SQLite `ContextPacketStore`.
+//
+// The two interfaces were authored in parallel lanes and don't line up
+// mechanically. This adapter is the integration seam:
+//
+//   1. METHOD RENAMES — the router calls `createPacket/getPacket/listPackets`
+//      and `updateInboxState`; the store exposes
+//      `createContextPacket/getContextPacket/listContextPackets` and
+//      `transitionInboxMessage`. The adapter forwards verbatim.
+//
+//   2. THROW → RESULT UNION — `transitionInboxMessage` THROWS a
+//      `ContextPacketStoreError` (`inbox_message_not_found`,
+//      `inbox_transition_terminal_state`, `inbox_transition_illegal_transition`),
+//      but the router expects a `{ ok: false, reason }` union so it can map to a
+//      gateway error code WITHOUT re-implementing the lifecycle. The adapter
+//      catches and remaps (terminal → `terminal`, illegal → `invalid_transition`,
+//      not-found → `not_found`); any other store error propagates (a real 500).
+//
+//   3. PULL-AS-DELIVERY — #758's `listInboxMessages`/`getInboxMessage` are PURE
+//      reads (they do NOT flip `queued → delivered`). ADR-019 D3 makes a fetch
+//      BY THE TARGET the delivery event. The adapter implements the flip on the
+//      read path by calling the store's transition-guarded
+//      `transitionInboxMessage(id, 'delivered')` for any `queued` row whose
+//      target matches the fetch filter. Idempotent: re-fetching a
+//      `delivered`/`acknowledged`/terminal row is a no-op (the transition guard's
+//      same-state idempotence + forward-only rule make a redundant flip safe, and
+//      we only attempt it for `queued` rows). NEVER pushed via `sessions.input`.
+//
+// The `actorId` the router forwards is currently DROPPED on the floor: #758's
+// `transitionInboxMessage` does not record an actor, and ADR-019's audit of
+// inbox transitions is a follow-up (#499 audit envelopes cover PTY interventions,
+// not inbox lifecycle yet). Recording it is a non-destructive future column add.
+
+import type {
+  ContextPacketStore,
+  ContextPacketStoreError as ContextPacketStoreErrorType,
+} from '../context-packets.js';
+import { ContextPacketStoreError } from '../context-packets.js';
+import type {
+  ContextInboxStore,
+  CreateContextPacketInput,
+  CreateInboxMessageInput,
+  ListContextPacketsFilter,
+  ListInboxMessagesFilter,
+  UpdateInboxStateResult,
+} from './context-inbox-router.js';
+import type {
+  ContextPacket,
+  ContextPacketId,
+  SessionInboxMessage,
+  SessionInboxMessageId,
+  SessionInboxMessageState,
+} from '../../shared/context-packet.js';
+
+function isStoreError(err: unknown): err is ContextPacketStoreErrorType {
+  return err instanceof ContextPacketStoreError;
+}
+
+/**
+ * Map a thrown `ContextPacketStoreError.code` from `transitionInboxMessage` onto
+ * the router's `{ ok: false, reason }` union. Returns `null` for codes that are
+ * NOT lifecycle failures (those should propagate as real errors / 500s).
+ */
+function remapTransitionFailure(
+  err: ContextPacketStoreErrorType,
+  currentState: SessionInboxMessageState | undefined
+): Exclude<UpdateInboxStateResult, { ok: true }> | null {
+  switch (err.code) {
+    case 'inbox_message_not_found':
+      return { ok: false, reason: 'not_found' };
+    case 'inbox_transition_terminal_state':
+      // `currentState` is always available here: the row exists (we read it just
+      // before transitioning), it's the terminal state itself.
+      return {
+        ok: false,
+        reason: 'terminal',
+        currentState: currentState ?? 'resolved',
+      };
+    case 'inbox_transition_illegal_transition':
+      return {
+        ok: false,
+        reason: 'invalid_transition',
+        currentState: currentState ?? 'queued',
+      };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Flip a freshly-read message to `delivered` IF it is `queued` and addressed to
+ * the fetch's target. Returns the (possibly transitioned) message. The flip goes
+ * through the store's transition-guarded `transitionInboxMessage`, so a
+ * concurrent ack/resolve that raced ahead of us cannot be clobbered: a no-longer-
+ * `queued` row is left untouched, and a terminal-state throw is swallowed (the
+ * read still returns the row in its real current state).
+ */
+function deliverOnPull(
+  store: ContextPacketStore,
+  message: SessionInboxMessage
+): SessionInboxMessage {
+  if (message.state !== 'queued') return message;
+  try {
+    return store.transitionInboxMessage(message.id, 'delivered');
+  } catch (err) {
+    // A race (the row moved out of `queued` between our read and the flip) or a
+    // terminal-state guard rejection: the read is still valid, return what we
+    // have. Re-read to reflect the racing writer's state.
+    if (isStoreError(err)) {
+      return store.getInboxMessage(message.id) ?? message;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Build the #765 `ContextInboxStore` over the concrete #758 `ContextPacketStore`.
+ * Pure wiring: no new persistence, no new lifecycle rules — the store remains
+ * the single authority on the transition machine.
+ */
+export function createContextInboxStoreAdapter(
+  store: ContextPacketStore
+): ContextInboxStore {
+  return {
+    createPacket(input: CreateContextPacketInput): ContextPacket {
+      return store.createContextPacket({
+        kind: input.kind,
+        ...(input.anchor !== undefined ? { anchor: input.anchor } : {}),
+        ...(input.fileRef !== undefined ? { fileRef: input.fileRef } : {}),
+        ...(input.note !== undefined ? { note: input.note } : {}),
+        ...(input.binding !== undefined ? { binding: input.binding } : {}),
+        createdBy: input.createdBy,
+      });
+    },
+
+    getPacket(id: ContextPacketId): ContextPacket | null {
+      return store.getContextPacket(id);
+    },
+
+    listPackets(filter?: ListContextPacketsFilter): ContextPacket[] {
+      return store.listContextPackets({
+        ...(filter?.nodeId !== undefined ? { nodeId: filter.nodeId } : {}),
+        ...(filter?.workspaceId !== undefined ? { workspaceId: filter.workspaceId } : {}),
+        ...(filter?.limit !== undefined ? { limit: filter.limit } : {}),
+      });
+    },
+
+    createInboxMessage(input: CreateInboxMessageInput): SessionInboxMessage {
+      return store.createInboxMessage({
+        ...(input.targetSessionId ? { targetSessionId: input.targetSessionId } : {}),
+        ...(input.targetWorkContextId
+          ? { targetWorkContextId: input.targetWorkContextId }
+          : {}),
+        contextPacketIds: input.contextPacketIds,
+        ...(input.text !== undefined ? { text: input.text } : {}),
+        createdBy: input.createdBy,
+      });
+    },
+
+    // PULL delivery: reading a queued message flips it to delivered (ADR-019 D3).
+    listInboxMessages(filter: ListInboxMessagesFilter): SessionInboxMessage[] {
+      const messages = store.listInboxMessages({
+        ...(filter.targetSessionId ? { targetSessionId: filter.targetSessionId } : {}),
+        ...(filter.targetWorkContextId
+          ? { targetWorkContextId: filter.targetWorkContextId }
+          : {}),
+        ...(filter.state ? { state: filter.state } : {}),
+      });
+      const delivered = messages.map((m) => deliverOnPull(store, m));
+      // Apply `limit` after the flip so the row count is stable regardless of
+      // delivery side effects (the store has no LIMIT clause on this read).
+      return filter.limit !== undefined ? delivered.slice(0, filter.limit) : delivered;
+    },
+
+    // PULL delivery: getting a queued message by id flips it to delivered.
+    getInboxMessage(id: SessionInboxMessageId): SessionInboxMessage | null {
+      const message = store.getInboxMessage(id);
+      if (!message) return null;
+      return deliverOnPull(store, message);
+    },
+
+    updateInboxState(
+      id: SessionInboxMessageId,
+      targetState: SessionInboxMessageState,
+      _actorId?: string
+    ): UpdateInboxStateResult {
+      // Read the current state first so a terminal/illegal rejection can report
+      // it without a second round trip after the throw.
+      const before = store.getInboxMessage(id);
+      try {
+        const message = store.transitionInboxMessage(id, targetState);
+        return { ok: true, message };
+      } catch (err) {
+        if (isStoreError(err)) {
+          const mapped = remapTransitionFailure(err, before?.state);
+          if (mapped) return mapped;
+        }
+        throw err;
+      }
+    },
+  };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -145,6 +145,12 @@ import {
   createContextInboxRouter,
   type ContextInboxStore,
 } from './features/context-inbox-router.js';
+import { createContextInboxStoreAdapter } from './features/context-inbox-store-adapter.js';
+import { createAnchorFileFetcher } from './anchor-file-fetcher.js';
+import {
+  registerAnchorFileFetcher,
+  type AnchorFileFetcher,
+} from './anchor-resolution.js';
 import { collectLocalRepoInventory } from './repo-inventory.js';
 import type {
   AgentType,
@@ -1271,6 +1277,17 @@ function buildSessionConfig(
   };
 }
 
+/**
+ * Wrap the #758 `ContextPacketStore` in the #765 router's `ContextInboxStore`
+ * adapter, or `null` when the store failed to init (routes then 503). Extracted
+ * from `main()` to keep that boot function under the cognitive-complexity gate.
+ */
+function deriveContextInboxStore(
+  store: ContextPacketStore | null
+): ContextInboxStore | null {
+  return store ? createContextInboxStoreAdapter(store) : null;
+}
+
 async function main(): Promise<void> {
   // Ignore SIGPIPE: node-pty can propagate pipe breaks causing unexpected session exits.
   // Ignore SIGHUP: keep server alive if controlling terminal disconnects.
@@ -1694,15 +1711,31 @@ async function main(): Promise<void> {
   // non-destructive). Consumes the `iaStore` handle wired above; degrades to
   // 503 if the store failed to init.
   app.use(createIaWorkspaceRouter({ requireAuth, iaStore }));
-  // #765 / ADR-019: context.* / inbox.* gateway verbs. The concrete
-  // SQLite-behind-gateway store is built in the parallel #758 lane; this lane
-  // mounts the router against the shared `ContextInboxStore` seam. The
-  // orchestrator swaps `null` for #758's store handle at integration; until
-  // then the routes return 503 SERVER_UNAVAILABLE rather than failing boot.
-  const contextInboxStore: ContextInboxStore | null = null;
+  // #765 / ADR-019: context.* / inbox.* gateway verbs. #759 wires the router
+  // to the concrete #758 `ContextPacketStore` via the integration adapter
+  // (method renames, throw→result-union remap, PULL-as-delivery flip). When the
+  // #758 store failed to init (`contextPacketStore` is null) the routes degrade
+  // to 503 SERVER_UNAVAILABLE rather than failing boot.
+  const contextInboxStore = deriveContextInboxStore(contextPacketStore);
   app.use(
     createContextInboxRouter({ requireAuth: requireCliGatewayAuth, store: contextInboxStore })
   );
+  // #766/#759: production `AnchorFileFetcher` wired to the session-scoped File
+  // RPC path under `rpc:fs:read`. Resolves an anchor's `current` ref by routing
+  // an `fs.read`/`fs.stat` through a live scoped session on the owning node
+  // whose root contains the path; never local-stats (C1). The anchor
+  // `stale`-derivation consumer (inbox decoration / #760) calls `resolveAnchor`
+  // with this fetcher; built here so it shares the live registry/link/envelope
+  // handles and is exposed for that follow-up wiring.
+  const anchorFileFetcher: AnchorFileFetcher = createAnchorFileFetcher({
+    registry: hubNodeRegistry,
+    nodeLinks: hubNodeLinks,
+    sessionEnvelopes: sessionEnvelopeRegistry,
+  });
+  // Anchor resolution (#766) decorates a packet's `AnchorState` at read time.
+  // The consumer endpoint lands in the #760 adapter lane; until then the fetcher
+  // is registered as the hub's anchor-resolution dependency.
+  registerAnchorFileFetcher(anchorFileFetcher);
   app.use(
     createCliGatewayEventsRouter(express, {
       cliGatewayAuth: requireCliGatewayAuth,

--- a/test/anchor-file-fetcher.test.ts
+++ b/test/anchor-file-fetcher.test.ts
@@ -1,0 +1,271 @@
+// #759: integration tests for the production AnchorFileFetcher.
+// Verifies the fetcher resolves a live in-scope scoped session, runs the
+// session-scoped File RPC under the `rpc:fs:read` policy gate, maps the node
+// response onto an AnchorFileFetchResult, and falls back to "unresolvable"
+// (null) when no session scope or authorization is available — NEVER local-stat.
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createAnchorFileFetcher,
+  type AnchorFetcherNodeLinks,
+  type AnchorFetcherNodeRegistry,
+  type AnchorFetcherSessionEnvelopes,
+} from '../server/anchor-file-fetcher.js';
+import {
+  ANCHOR_RESOLUTION_CAPABILITY,
+  type AnchorFileFetchTarget,
+} from '../server/anchor-resolution.js';
+import type { ScopedSessionSummary } from '../server/session-envelope-registry.js';
+import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
+import { RELAY_NODE_LINK_PROTOCOL_VERSION } from '../shared/relay-node-protocol.js';
+import { RELAY_SECURITY_POLICY_VERSION } from '../shared/security-policy.js';
+
+const NODE_ID = 'node-alpha';
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  while (tmpDirs.length) {
+    fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+function makeRoot(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-anchor-fetch-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+/** A node whose ACL grants `rpc:fs:read` over a `node`-kind scope (matches any). */
+function onlineNode(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
+  return {
+    nodeId: NODE_ID,
+    status: 'online',
+    protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+    credentialState: 'active',
+    platform: process.platform,
+    trust: {
+      state: 'trusted',
+      level: 'full',
+      policy: {
+        policyVersion: RELAY_SECURITY_POLICY_VERSION,
+        ref: 'acl:test',
+        trustTier: 'dev',
+        allowed: ['rpc:fs:read'],
+        requiresConfirmation: [],
+        scope: { kind: 'node' },
+      },
+    },
+    // The remaining HubNodeSummary fields are not read by the fetcher / policy
+    // evaluator for an `rpc.fs.read` allow; cast keeps the fixture small.
+    ...overrides,
+  } as unknown as HubNodeSummary;
+}
+
+function scopedSession(root: string): ScopedSessionSummary {
+  return {
+    sessionId: 'sess-1',
+    globalSessionId: `${NODE_ID}:sess-1`,
+    nodeId: NODE_ID,
+    intent: { kind: 'routed-node-session', description: 'test' },
+    scope: { kind: 'node-cwd', nodeId: NODE_ID, cwd: root },
+    peerIdentity: { kind: 'local-user', id: 'local-dev' },
+    issuedAt: new Date().toISOString(),
+    expiresAt: null,
+    revocable: true,
+    status: 'active',
+    revokedAt: null,
+    revokeReason: null,
+    expired: false,
+    expiresInMs: null,
+  } as ScopedSessionSummary;
+}
+
+function deps(input: {
+  nodes: HubNodeSummary[];
+  sessions: ScopedSessionSummary[];
+  request: AnchorFetcherNodeLinks['request'];
+  hasActiveNode?: boolean;
+}): {
+  registry: AnchorFetcherNodeRegistry;
+  nodeLinks: AnchorFetcherNodeLinks;
+  sessionEnvelopes: AnchorFetcherSessionEnvelopes;
+} {
+  return {
+    registry: { listNodes: () => input.nodes },
+    nodeLinks: {
+      hasActiveNode: () => input.hasActiveNode ?? true,
+      request: input.request,
+    },
+    sessionEnvelopes: { listSummaries: () => input.sessions },
+  };
+}
+
+function target(root: string, file: string, preferRead = false): AnchorFileFetchTarget {
+  return { nodeId: NODE_ID, path: path.join(root, file), preferRead };
+}
+
+describe('createAnchorFileFetcher — happy path (stat)', () => {
+  it('resolves found:true with size+mtime from a stat response', async () => {
+    const root = makeRoot();
+    const request = vi.fn(async (_nodeId, type) => {
+      expect(type).toBe('fs.stat');
+      return {
+        operation: 'stat',
+        stat: { type: 'file', size: 123, mtimeMs: 4567, path: 'x', name: 'x', mode: 0 },
+      };
+    });
+    const fetcher = createAnchorFileFetcher(
+      deps({ nodes: [onlineNode()], sessions: [scopedSession(root)], request })
+    );
+    const result = await fetcher(target(root, 'a.ts', false));
+    expect(result).toEqual({
+      found: true,
+      grantedCapability: ANCHOR_RESOLUTION_CAPABILITY,
+      size: 123,
+      mtimeMs: 4567,
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createAnchorFileFetcher — happy path (read, preferRead)', () => {
+  it('resolves found:true and hashes content for an authoritative sha', async () => {
+    const root = makeRoot();
+    const content = 'export const answer = 42;\n';
+    const expectedSha = crypto.createHash('sha256').update(Buffer.from(content, 'utf8')).digest('hex');
+    const request = vi.fn(async (_nodeId, type) => {
+      expect(type).toBe('fs.read');
+      return {
+        operation: 'read',
+        encoding: 'utf8',
+        content,
+        bytesRead: Buffer.byteLength(content),
+        truncatedBytes: false,
+        truncatedLines: false,
+        maxBytes: 65536,
+      };
+    });
+    const fetcher = createAnchorFileFetcher(
+      deps({ nodes: [onlineNode()], sessions: [scopedSession(root)], request })
+    );
+    const result = await fetcher(target(root, 'a.ts', true));
+    expect(result).toMatchObject({
+      found: true,
+      grantedCapability: ANCHOR_RESOLUTION_CAPABILITY,
+      contentSha256: expectedSha,
+    });
+  });
+
+  it('omits sha when the read was truncated (cannot trust a partial hash)', async () => {
+    const root = makeRoot();
+    const request = vi.fn(async () => ({
+      operation: 'read',
+      encoding: 'utf8',
+      content: 'partial',
+      bytesRead: 7,
+      truncatedBytes: true,
+      truncatedLines: false,
+      maxBytes: 7,
+    }));
+    const fetcher = createAnchorFileFetcher(
+      deps({ nodes: [onlineNode()], sessions: [scopedSession(root)], request })
+    );
+    const result = await fetcher(target(root, 'a.ts', true));
+    expect(result?.found).toBe(true);
+    if (result?.found) expect(result.contentSha256).toBeUndefined();
+  });
+});
+
+describe('createAnchorFileFetcher — missing / not-a-file', () => {
+  it('maps a non-file stat (directory) to found:false', async () => {
+    const root = makeRoot();
+    const request = vi.fn(async () => ({
+      operation: 'stat',
+      stat: { type: 'directory', size: 0, mtimeMs: 1, path: 'd', name: 'd', mode: 0 },
+    }));
+    const fetcher = createAnchorFileFetcher(
+      deps({ nodes: [onlineNode()], sessions: [scopedSession(root)], request })
+    );
+    const result = await fetcher(target(root, 'sub', false));
+    expect(result).toEqual({ found: false, grantedCapability: ANCHOR_RESOLUTION_CAPABILITY });
+  });
+
+  it('maps a NOT_FOUND link error to found:false (authorized fetch, gone file)', async () => {
+    const root = makeRoot();
+    const request = vi.fn(async () => {
+      throw new Error('FILE_RPC_NOT_FOUND');
+    });
+    const fetcher = createAnchorFileFetcher(
+      deps({ nodes: [onlineNode()], sessions: [scopedSession(root)], request })
+    );
+    const result = await fetcher(target(root, 'gone.ts', false));
+    expect(result).toEqual({ found: false, grantedCapability: ANCHOR_RESOLUTION_CAPABILITY });
+  });
+});
+
+describe('createAnchorFileFetcher — unresolvable (null, never local-stat)', () => {
+  it('returns null when no live session scope contains the path', async () => {
+    const root = makeRoot();
+    const request = vi.fn(async () => ({ operation: 'stat', stat: { type: 'file' } }));
+    // Session scoped to a DIFFERENT root → path is outside; no in-scope session.
+    const otherRoot = makeRoot();
+    const fetcher = createAnchorFileFetcher(
+      deps({ nodes: [onlineNode()], sessions: [scopedSession(otherRoot)], request })
+    );
+    const result = await fetcher(target(root, 'a.ts', false));
+    expect(result).toBeNull();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('returns null when there are no live sessions at all', async () => {
+    const root = makeRoot();
+    const request = vi.fn();
+    const fetcher = createAnchorFileFetcher(
+      deps({ nodes: [onlineNode()], sessions: [], request })
+    );
+    expect(await fetcher(target(root, 'a.ts', false))).toBeNull();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the node is offline (no File RPC path)', async () => {
+    const root = makeRoot();
+    const request = vi.fn();
+    const offline = onlineNode({ status: 'offline' as HubNodeSummary['status'] });
+    const fetcher = createAnchorFileFetcher(
+      deps({ nodes: [offline], sessions: [scopedSession(root)], request })
+    );
+    expect(await fetcher(target(root, 'a.ts', false))).toBeNull();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the node ACL does NOT grant rpc:fs:read (capability gate)', async () => {
+    const root = makeRoot();
+    const request = vi.fn();
+    const ungranted = onlineNode({
+      trust: {
+        state: 'trusted',
+        level: 'full',
+        policy: {
+          policyVersion: RELAY_SECURITY_POLICY_VERSION,
+          ref: 'acl:test',
+          trustTier: 'dev',
+          allowed: [], // no rpc:fs:read → policy denies
+          requiresConfirmation: [],
+          scope: { kind: 'node' },
+        },
+      } as unknown as HubNodeSummary['trust'],
+    });
+    const fetcher = createAnchorFileFetcher(
+      deps({ nodes: [ungranted], sessions: [scopedSession(root)], request })
+    );
+    expect(await fetcher(target(root, 'a.ts', false))).toBeNull();
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/test/context-inbox-store-adapter.test.ts
+++ b/test/context-inbox-store-adapter.test.ts
@@ -1,0 +1,172 @@
+// #759: integration tests for the context-inbox store adapter.
+// Exercises the real #758 SQLite store (in-memory) through the #765 router's
+// `ContextInboxStore` seam: method renames, throw→result-union remap, the
+// `listPackets` filter, and the PULL-as-delivery flip (idempotent, terminal-safe).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createContextPacketStore,
+  type ContextPacketStore,
+} from '../server/context-packets.js';
+import { createContextInboxStoreAdapter } from '../server/features/context-inbox-store-adapter.js';
+import type { ContextInboxStore } from '../server/features/context-inbox-router.js';
+import type { GlobalSessionId } from '../shared/identity.js';
+
+vi.mock('../server/logger.js', () => ({
+  createLogger: () => ({
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+const SESSION_A = 'node-a:sess-1' as GlobalSessionId;
+const SESSION_B = 'node-a:sess-2' as GlobalSessionId;
+
+let store: ContextPacketStore;
+let adapter: ContextInboxStore;
+
+beforeEach(() => {
+  store = createContextPacketStore(':memory:');
+  adapter = createContextInboxStoreAdapter(store);
+});
+
+afterEach(() => {
+  store.close();
+});
+
+function seedMessage(target: GlobalSessionId = SESSION_A) {
+  const packet = adapter.createPacket({ kind: 'note', note: 'hi', createdBy: 'agent_1' });
+  return adapter.createInboxMessage({
+    targetSessionId: target,
+    contextPacketIds: [packet.id],
+    text: 'do the thing',
+    createdBy: 'agent_1',
+  });
+}
+
+describe('context-inbox store adapter — method renames + packet filter', () => {
+  it('round-trips createPacket/getPacket/listPackets', () => {
+    const created = adapter.createPacket({ kind: 'note', note: 'remember', createdBy: 'agent_1' });
+    expect(created.id).toMatch(/^cp:/);
+    expect(adapter.getPacket(created.id)?.id).toBe(created.id);
+    expect(adapter.listPackets().map((p) => p.id)).toContain(created.id);
+  });
+
+  it('listPackets filters by nodeId (denormalized binding) and limit', () => {
+    adapter.createPacket({
+      kind: 'note',
+      note: 'on node-a',
+      binding: { nodeId: 'node-a' },
+      createdBy: 'agent_1',
+    });
+    adapter.createPacket({
+      kind: 'note',
+      note: 'on node-b',
+      binding: { nodeId: 'node-b' },
+      createdBy: 'agent_1',
+    });
+    expect(adapter.listPackets({ nodeId: 'node-a' })).toHaveLength(1);
+    expect(adapter.listPackets({ nodeId: 'node-a' })[0]?.binding?.nodeId).toBe('node-a');
+    expect(adapter.listPackets({ limit: 1 })).toHaveLength(1);
+  });
+});
+
+describe('context-inbox store adapter — PULL-as-delivery flip', () => {
+  it('getInboxMessage flips queued → delivered (read side effect)', () => {
+    const msg = seedMessage();
+    expect(msg.state).toBe('queued');
+    const fetched = adapter.getInboxMessage(msg.id);
+    expect(fetched?.state).toBe('delivered');
+    expect(fetched?.deliveredAt).toBeTruthy();
+    // The store now reflects delivered — the flip persisted, not just decorated.
+    expect(store.getInboxMessage(msg.id)?.state).toBe('delivered');
+  });
+
+  it('listInboxMessages flips queued → delivered for the target', () => {
+    const msg = seedMessage();
+    const listed = adapter.listInboxMessages({ targetSessionId: SESSION_A });
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.state).toBe('delivered');
+    expect(store.getInboxMessage(msg.id)?.state).toBe('delivered');
+  });
+
+  it('re-fetching a delivered message is idempotent (no-op, timestamp preserved)', () => {
+    const msg = seedMessage();
+    const first = adapter.getInboxMessage(msg.id);
+    const deliveredAt = first?.deliveredAt;
+    const second = adapter.getInboxMessage(msg.id);
+    expect(second?.state).toBe('delivered');
+    expect(second?.deliveredAt).toBe(deliveredAt);
+  });
+
+  it('does NOT flip an acknowledged or terminal message back to delivered', () => {
+    const msg = seedMessage();
+    adapter.updateInboxState(msg.id, 'acknowledged');
+    expect(adapter.getInboxMessage(msg.id)?.state).toBe('acknowledged');
+    adapter.updateInboxState(msg.id, 'resolved');
+    expect(adapter.getInboxMessage(msg.id)?.state).toBe('resolved');
+    // A read of a terminal message leaves it terminal.
+    expect(adapter.listInboxMessages({ targetSessionId: SESSION_A })[0]?.state).toBe('resolved');
+  });
+
+  it('only flips messages addressed to the fetched target', () => {
+    const a = seedMessage(SESSION_A);
+    const b = seedMessage(SESSION_B);
+    adapter.listInboxMessages({ targetSessionId: SESSION_A });
+    expect(store.getInboxMessage(a.id)?.state).toBe('delivered');
+    expect(store.getInboxMessage(b.id)?.state).toBe('queued');
+  });
+});
+
+describe('context-inbox store adapter — throw → result-union remap', () => {
+  it('updateInboxState returns { ok: true } on a valid forward transition', () => {
+    const msg = seedMessage();
+    const result = adapter.updateInboxState(msg.id, 'acknowledged');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.message.state).toBe('acknowledged');
+  });
+
+  it('remaps not-found throw to { ok: false, reason: "not_found" }', () => {
+    const result = adapter.updateInboxState(
+      'im:does-not-exist' as never,
+      'acknowledged'
+    );
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+
+  it('remaps terminal-state throw to { ok: false, reason: "terminal", currentState }', () => {
+    const msg = seedMessage();
+    adapter.updateInboxState(msg.id, 'resolved');
+    const result = adapter.updateInboxState(msg.id, 'acknowledged');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('terminal');
+      if (result.reason === 'terminal') expect(result.currentState).toBe('resolved');
+    }
+  });
+
+  it('remaps illegal (backward) transition to { ok: false, reason: "invalid_transition" }', () => {
+    const msg = seedMessage();
+    adapter.updateInboxState(msg.id, 'acknowledged');
+    const result = adapter.updateInboxState(msg.id, 'delivered'); // backward
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('invalid_transition');
+      if (result.reason === 'invalid_transition') {
+        expect(result.currentState).toBe('acknowledged');
+      }
+    }
+  });
+
+  it('treats a same-state re-ack as idempotent success', () => {
+    const msg = seedMessage();
+    adapter.updateInboxState(msg.id, 'acknowledged');
+    const result = adapter.updateInboxState(msg.id, 'acknowledged');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.message.state).toBe('acknowledged');
+  });
+});


### PR DESCRIPTION
Wires the three merged-but-disconnected #757 lanes (#758 store, #765 verbs/router, #766 anchor resolution) into a working headless inbox loop, per ADR-019. Closes #759.

## The 4 integration pieces

**1. Store adapter** (`server/features/context-inbox-store-adapter.ts`) — maps the #765 router's `ContextInboxStore` seam onto the concrete #758 `ContextPacketStore`:
- method renames (`createPacket/getPacket/listPackets/updateInboxState` → `createContextPacket/getContextPacket/listContextPackets/transitionInboxMessage`);
- `listPackets` filter wired to a new indexed `listContextPackets({nodeId,workspaceId,limit})` on the #758 store (denormalized `node_id`/`workspace_id` columns);
- **throw → result-union remap**: catches `transitionInboxMessage`'s thrown `ContextPacketStoreError` and maps `inbox_transition_terminal_state → terminal`, `inbox_transition_illegal_transition → invalid_transition`, `inbox_message_not_found → not_found`; any other code propagates as a real error;
- mounted in `server/index.ts` (replacing the `store: null` 503 stub).

**2. PULL-as-delivery flip** — the #758 store reads are pure. The adapter flips a `queued` message to `delivered` on fetch (`inbox.list`/`inbox.get`) by calling the store's transition-guarded `transitionInboxMessage(id, 'delivered')`. Idempotent (re-fetch of `delivered`/`acknowledged`/terminal = no-op, `deliveredAt` preserved), only flips rows addressed to the fetched target, and a racing writer cannot be clobbered (a no-longer-`queued` row is left untouched; a terminal-guard throw is swallowed and the real state re-read). **Never** pushes via `sessions.input`.

**3. Anchor fetcher → File RPC** (`server/anchor-file-fetcher.ts`) — wires #766's `AnchorFileFetcher` to the `nodeLinks`-backed session-scoped File RPC under `rpc:fs:read`.

*Session-scope decision:* the fetcher contract is `(nodeId, path)` with no session, but File RPC is session-scoped. The fetcher **scans the live scoped-session registry** for an `active` session on the owning node whose filesystem root **contains** the path (reusing `normalizeHubFileRpcRequest`'s root-containment + traversal guard), then routes the read through that session's envelope + `evaluateHubPolicy(rpc.fs.read|stat)` and `nodeLinks.request('fs.read'|'fs.stat')`. **Behavior when no live session:** if no in-scope live session exists, the node is offline, or the policy decision is not `allow`, the fetcher returns `null` — which #766's `resolveAnchor` maps to `AnchorState='missing'` (an honest "unresolvable now", not a confidently-wrong answer). It **never** falls back to a local `fs.stat` (C1: a local stat on the hub would silently resolve the wrong filesystem for a federated node). Capability-gated: only an `allow` proceeds, and the result echoes `grantedCapability = rpc:fs:read` so #766's caller asserts the gate fired. Registered as the hub's anchor-resolution dependency (`registerAnchorFileFetcher`) for the inbox `stale`-decoration consumer (#760).

**4. Inbox CLI lifecycle** — confirmed `relay-ide v1 context create/get/list` + `inbox send/list/get/ack/resolve/ignore` reach the real adapter end to end. Lifecycle: `queued → delivered(=fetched) → acknowledged` + terminal `resolved/ignored`; reading ≠ resolving.

## End-to-end CLI smoke (real, isolated hub on :3465, `NO_PIN=1`)

```
1. context create               -> packet cp:24bd… (kind=note)
2. inbox send (node-local:tab-1) -> message im:f929… state=queued packets=[cp:24bd…]
3. inbox list --state queued     -> im:f929…=delivered    # fetch of a queued row delivers it
4. inbox get                     -> state=delivered deliveredAt=…416Z
5. inbox list (no filter)        -> all delivered          # idempotent re-fetch, timestamp held
6. inbox list --state queued     -> messages(0)            # flip persisted; no longer queued
7. inbox ack                     -> state=acknowledged acknowledgedAt=…184Z
8. inbox get                     -> acknowledged (reading != resolving)
9. inbox ack (again)             -> acknowledged           # idempotent re-ack
10. inbox resolve                -> state=resolved resolvedAt=…083Z
11. inbox ack (on resolved)      -> SESSION_CONFLICT "terminal state 'resolved'"   # throw->union remap, over HTTP
12. inbox get (missing id)       -> NOT_FOUND "inbox message not found"
```
`context-packets.db` created + persisting in the isolated config dir. Server cleaned up after.

## Gates (Node 24)

- `npm run build` — clean
- `npm run check` — 0 errors (pre-existing warnings only; refactored `main()` boot back under the cognitive-complexity gate via a `deriveContextInboxStore` helper)
- `npm test` — 300 files / 3899 tests pass (no regression); 21 new tests (`test/context-inbox-store-adapter.test.ts`, `test/anchor-file-fetcher.test.ts`) cover the adapter maps + throw→result remap + PULL-flip idempotence/terminal-safety, and the anchor fetcher wiring + capability gate + null-on-no-scope.

Closes the headless loop; unblocks #761 (preturn proof) + #760 (adapter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)