### PR TITLE
feat(#760): file-range adapter + stale decoration

### DIFF
--- a/server/anchor-file-fetcher.ts
+++ b/server/anchor-file-fetcher.ts
@@ -43,6 +43,11 @@ import {
   hashAnchorContent,
 } from './anchor-resolution.js';
 import type {
+  FileRangeContentFetcher,
+  FileRangeContentResult,
+  FileRangeContentTarget,
+} from './context-adapters/file-range.js';
+import type {
   FileRpcReadResponse,
   FileRpcStatResponse,
 } from '../shared/file-rpc.js';
@@ -256,5 +261,107 @@ function mapPayload(
     grantedCapability: ANCHOR_RESOLUTION_CAPABILITY,
     ...(typeof response.bytesRead === 'number' ? { size: response.bytesRead } : {}),
     ...(contentSha256 !== undefined ? { contentSha256 } : {}),
+  };
+}
+
+// ── #760: content fetcher (File-RPC-under-capability `read` that RETURNS bytes) ─
+//
+// The #766 `AnchorFileFetcher` above discards the read content (it only keeps
+// the freshness sha for staleness comparison). The #760 file-range adapter
+// needs the actual bounded text slice, so this builds a sibling fetcher that
+// returns the UTF-8 content alongside the same freshness decorations. It reuses
+// the IDENTICAL scope-resolution + policy machinery (`resolveScopedReadRequest`
+// + `evaluateHubPolicy` under `rpc:fs:read`) so the security posture is shared,
+// not re-implemented. C1: `target.path` is passed VERBATIM (no decodeURIComponent).
+
+/** Map an authorized File RPC `read` response onto a `FileRangeContentResult`. */
+function mapContentPayload(payload: unknown): FileRangeContentResult {
+  const record = asRecord(payload);
+  if (!record) {
+    return { found: false, grantedCapability: ANCHOR_RESOLUTION_CAPABILITY };
+  }
+  const response = record as unknown as FileRpcReadResponse;
+  if (typeof response.content !== 'string') {
+    return { found: false, grantedCapability: ANCHOR_RESOLUTION_CAPABILITY };
+  }
+  // The adapter slices line ranges over UTF-8 text; a base64 (binary) read is
+  // not line-sliceable, so decode it to a UTF-8 view for the bounded slice.
+  const text =
+    response.encoding === 'base64'
+      ? Buffer.from(response.content, 'base64').toString('utf8')
+      : response.content;
+  const buffer = Buffer.from(text, 'utf8');
+  // A truncated read cannot yield a trustworthy whole-file hash (mirrors the
+  // staleness fetcher); omit the sha so the resolver falls back to size/mtime.
+  const contentSha256 = response.truncatedBytes ? undefined : hashAnchorContent(buffer);
+  return {
+    found: true,
+    grantedCapability: ANCHOR_RESOLUTION_CAPABILITY,
+    content: text,
+    ...(typeof response.bytesRead === 'number' ? { bytesRead: response.bytesRead, size: response.bytesRead } : {}),
+    ...(contentSha256 !== undefined ? { contentSha256 } : {}),
+    ...(typeof response.truncatedBytes === 'boolean' ? { truncatedBytes: response.truncatedBytes } : {}),
+  };
+}
+
+/**
+ * Build the production `FileRangeContentFetcher` for the #760 adapter. Always a
+ * `read` (the adapter needs bytes). Returns `null` when the node is not live,
+ * no in-scope session exists, or policy denies — mapped by the adapter to
+ * `unavailable`/`missing` (never a confidently-wrong slice; C1).
+ */
+export function createAnchorContentFetcher(
+  deps: AnchorFileFetcherDeps
+): FileRangeContentFetcher {
+  const now = deps.now ?? (() => new Date());
+
+  return async function fetchAnchorContent(
+    target: FileRangeContentTarget
+  ): Promise<FileRangeContentResult | null> {
+    const node = liveNode(deps.registry, deps.nodeLinks, target.nodeId);
+    if (!node) return null;
+
+    const resolved = resolveScopedReadRequest({
+      sessions: deps.sessionEnvelopes.listSummaries(),
+      node,
+      nodeId: target.nodeId,
+      path: target.path, // C1: verbatim.
+      operation: 'read',
+      maxBytes: target.maxBytes,
+    });
+    if (!resolved || !resolved.request.ok) return null;
+
+    const policyScope = resolved.request.value.policyScope;
+    const fileRequest = resolved.request.value.request;
+    const decision = evaluateHubPolicy({
+      peer: { kind: 'hub' },
+      node,
+      nodeId: target.nodeId,
+      intent: { action: 'rpc.fs.read', target: target.nodeId },
+      scope: policyScope,
+      requiredCapabilities: requiredCapabilitiesForRpcIntent('rpc.fs.read'),
+      sessionId: resolved.session.sessionId,
+      ...(resolved.session.correlationId
+        ? { correlationId: resolved.session.correlationId }
+        : {}),
+      ...(resolved.session.expiresAt !== null
+        ? { expiresAt: resolved.session.expiresAt }
+        : {}),
+      ...(resolved.session.revokedAt !== null
+        ? { revokedAt: resolved.session.revokedAt }
+        : {}),
+      params: { ...fileRequest },
+      now: now(),
+    });
+    if (decision.decision !== 'allow') return null;
+
+    let payload: unknown;
+    try {
+      payload = await deps.nodeLinks.request(target.nodeId, 'fs.read', fileRequest);
+    } catch {
+      // A node error (e.g. NOT_FOUND) on an authorized read → file gone.
+      return { found: false, grantedCapability: ANCHOR_RESOLUTION_CAPABILITY };
+    }
+    return mapContentPayload(payload);
   };
 }

--- a/server/context-adapters/file-range.ts
+++ b/server/context-adapters/file-range.ts
@@ -1,0 +1,424 @@
+// #760 / Epic #757 (ADR-019): file-range context source adapter.
+//
+// TWO RESPONSIBILITIES, both for the `file-anchor` ContextPacket kind only
+// (MVP scope — diff-range / terminal-range / markdown adapters are deferred):
+//
+//   1. EXPANSION — given a `file-anchor` packet, expand its `AnchorRef` (a
+//      `FileResourceRef` location + line/byte range + captured `quote`) into the
+//      referenced CONTENT SLICE for consumption, bounded by the range and a hard
+//      size cap, read through the node File RPC layer UNDER CAPABILITY
+//      (`rpc:fs:read`). `expandFileRange` first resolves the anchor's
+//      `AnchorState` (#766) and REFUSES to serve current-looking content for a
+//      `stale`/`missing` anchor — a drifted range surfaces `stale` and the
+//      ADVISORY captured `quote`, never freshly-read bytes presented as the
+//      anchored selection. This is the load-bearing correctness rule from the
+//      issue: "a stale anchor expansion must surface `stale`, NOT serve
+//      wrong/old content as current."
+//
+//   2. DECORATION — `decoratePacketAnchorState` is the runtime consumer #759
+//      flagged as missing: it derives an anchor packet's `AnchorState` at READ
+//      time (via the #766 resolver registry) and attaches it as a NON-STORED
+//      `anchorState` field so `context.get` / `inbox.get` / `inbox.list` can
+//      surface staleness without ever persisting a lifecycle bit (ADR-019 rule
+//      #3: `AnchorState` is always derived, never stored).
+//
+// C1 (fugu/path security): we NEVER `decodeURIComponent` the stored
+// `AnchorRef.ref.path`. The stored path was validated + normalized at mint time
+// (`createFileResourceRef` → POSIX normalize, no `..`); it is a literal absolute
+// path, not a URL component. The File RPC seam receives it VERBATIM. The hub
+// File RPC route owns root-containment + traversal enforcement (#759 fetcher
+// reuses `normalizeHubFileRpcRequest`); this adapter adds no path rewriting.
+
+import {
+  resolveAnchorState,
+  type AnchorRef,
+  type AnchorState,
+  type ContextPacket,
+} from '../../shared/context-packet.js';
+import {
+  createFileResourceRef,
+  type FileResourceRef,
+} from '../../shared/file-resource-ref.js';
+import type { NodeId } from '../../shared/identity.js';
+import {
+  ANCHOR_RESOLUTION_CAPABILITY,
+  resolveAnchorWithRegisteredFetcher,
+  type ResolveAnchorOutcome,
+} from '../anchor-resolution.js';
+import type { RelayCapabilityBit } from '../../shared/security-policy.js';
+
+// ---------------------------------------------------------------------------
+// Hard bounds for an expanded slice.
+// ---------------------------------------------------------------------------
+
+/**
+ * Hard ceiling on the number of lines a single file-range expansion returns.
+ * A line range wider than this is clamped (and the result flagged
+ * `truncatedLines`) so an enormous selection cannot return an unbounded slice.
+ */
+export const FILE_RANGE_MAX_EXPANDED_LINES = 2_000;
+
+/**
+ * Hard ceiling on the number of UTF-8 bytes a single file-range expansion
+ * returns, independent of the line count. Mirrors the File RPC read ceiling so
+ * a few very long lines cannot blow the budget.
+ */
+export const FILE_RANGE_MAX_EXPANDED_BYTES = 64 * 1024;
+
+const SLICE_ENCODER = new TextEncoder();
+
+// ---------------------------------------------------------------------------
+// Content fetch seam (File-RPC-under-capability `read`).
+// ---------------------------------------------------------------------------
+
+/**
+ * Target a content fetch resolves on the OWNING node. Mirrors the #766
+ * `AnchorFileFetchTarget` location identity, plus the `maxBytes`/`maxLines`
+ * bounds the read must honour. `path` is the stored, already-validated absolute
+ * path — passed VERBATIM (C1: never `decodeURIComponent`'d here).
+ */
+export interface FileRangeContentTarget {
+  nodeId: NodeId;
+  path: string;
+  maxBytes: number;
+  maxLines?: number;
+  repoBinding?: FileResourceRef['repoBinding'];
+}
+
+/**
+ * Result of a File-RPC-under-capability `read` for an anchor's content. Returns
+ * the (bounded) UTF-8 text plus the freshness decorations needed to mint a
+ * `current` `FileResourceRef` for the #766 comparison, so a single read both
+ * expands the slice AND resolves staleness without a second round trip.
+ *
+ *   - `found: false` — node reported the path gone / not a regular file → the
+ *     anchor is `missing`.
+ *   - `found: true`  — `content` is the bounded UTF-8 read; `contentSha256` is
+ *     present only when the read was NOT truncated (a truncated read cannot
+ *     yield a trustworthy whole-file hash — see `anchor-file-fetcher.ts`).
+ *
+ * `grantedCapability` echoes the capability the fetch was authorized for; the
+ * adapter asserts it matches `ANCHOR_RESOLUTION_CAPABILITY` (C1 enforcement,
+ * mirroring `resolveAnchor`).
+ */
+export type FileRangeContentResult =
+  | { found: false; grantedCapability: RelayCapabilityBit }
+  | {
+      found: true;
+      grantedCapability: RelayCapabilityBit;
+      content: string;
+      bytesRead?: number;
+      mtimeMs?: number;
+      size?: number;
+      contentSha256?: string;
+      truncatedBytes?: boolean;
+    };
+
+/**
+ * Injected File-RPC-under-capability content fetch. Production wires this to
+ * the hub File RPC `fs.read` path behind `evaluateHubPolicy` (see
+ * `createAnchorContentFetcher` in `anchor-file-fetcher.ts`); tests mock it.
+ * Returns `null` when the read could not be authorized/performed at all
+ * (distinct from `found: false`).
+ */
+export type FileRangeContentFetcher = (
+  target: FileRangeContentTarget
+) => Promise<FileRangeContentResult | null>;
+
+// ---------------------------------------------------------------------------
+// Expansion result.
+// ---------------------------------------------------------------------------
+
+/**
+ * The outcome of expanding a `file-anchor` packet. `state` is ALWAYS present
+ * (derived). `content` is populated ONLY when `state === 'unchanged'` — a
+ * `stale`/`missing`/unavailable anchor never carries content presented as the
+ * current anchored selection (the issue's correctness rule). For a `stale`
+ * anchor the advisory captured `quote` is echoed under `capturedQuote` so a
+ * consumer can still show what WAS selected, clearly labelled stale.
+ */
+export interface FileRangeExpansion {
+  state: AnchorState | 'unavailable';
+  /** The bounded current slice. Present only when `state === 'unchanged'`. */
+  content?: string;
+  /** True when the slice was clamped by the line/byte cap. */
+  truncated?: boolean;
+  /** The 1-based inclusive line range that was expanded (echoed for the UI). */
+  lineRange?: { startLine: number; endLine: number };
+  /** Advisory captured quote (NEVER current). Echoed for stale/missing anchors. */
+  capturedQuote?: string;
+}
+
+export interface ExpandFileRangeDeps {
+  fetchContent: FileRangeContentFetcher;
+  /**
+   * Resolve the anchor's `AnchorState`. Defaults to the hub-registered #766
+   * resolver; injectable for tests. `null` return ⇒ resolution unavailable.
+   */
+  resolveState?: (anchor: AnchorRef) => Promise<ResolveAnchorOutcome | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Slice helpers (pure).
+// ---------------------------------------------------------------------------
+
+/**
+ * Slice `content` to the anchor's 1-based inclusive line range, clamped to
+ * `FILE_RANGE_MAX_EXPANDED_LINES` lines and `FILE_RANGE_MAX_EXPANDED_BYTES`
+ * bytes. Returns the slice plus whether it was clamped. When no `lineRange` is
+ * set (byte-range-only anchor) the whole bounded read is returned (byte-range
+ * slicing on top of an already-truncated read is deferred — MVP is line-range).
+ */
+export function sliceLineRange(
+  content: string,
+  lineRange: { startLine: number; endLine: number } | undefined
+): { slice: string; truncated: boolean } {
+  if (!lineRange) {
+    return clampBytes(content);
+  }
+  const lines = content.split('\n');
+  // 1-based inclusive → 0-based half-open. Clamp to available lines.
+  const startIdx = Math.max(0, lineRange.startLine - 1);
+  if (startIdx >= lines.length) {
+    // The captured range starts past EOF — nothing to show in-range.
+    return { slice: '', truncated: false };
+  }
+  const requestedCount = lineRange.endLine - lineRange.startLine + 1;
+  const cappedCount = Math.min(requestedCount, FILE_RANGE_MAX_EXPANDED_LINES);
+  const endIdx = Math.min(lines.length, startIdx + cappedCount);
+  const selected = lines.slice(startIdx, endIdx);
+  const truncatedByLineCap = requestedCount > FILE_RANGE_MAX_EXPANDED_LINES;
+  const byteClamped = clampBytes(selected.join('\n'));
+  return {
+    slice: byteClamped.slice,
+    truncated: truncatedByLineCap || byteClamped.truncated,
+  };
+}
+
+/** Clamp a string to `FILE_RANGE_MAX_EXPANDED_BYTES` UTF-8 bytes. */
+function clampBytes(value: string): { slice: string; truncated: boolean } {
+  const encoded = SLICE_ENCODER.encode(value);
+  if (encoded.length <= FILE_RANGE_MAX_EXPANDED_BYTES) {
+    return { slice: value, truncated: false };
+  }
+  const decoder = new TextDecoder();
+  const sliced = decoder.decode(encoded.slice(0, FILE_RANGE_MAX_EXPANDED_BYTES));
+  // Drop a trailing replacement char produced by cutting mid-codepoint.
+  return { slice: sliced.replace(/�+$/u, ''), truncated: true };
+}
+
+/** Build the bounded content target from a captured anchor. */
+function contentTargetFor(anchor: AnchorRef): FileRangeContentTarget {
+  const ref = anchor.ref;
+  // The read is bounded by the anchor's own maxBytes when set, else the hard
+  // expansion ceiling. Either way it never exceeds the File RPC read ceiling.
+  const maxBytes = Math.min(
+    ref.maxBytes ?? FILE_RANGE_MAX_EXPANDED_BYTES,
+    FILE_RANGE_MAX_EXPANDED_BYTES
+  );
+  // A line-range anchor reads enough lines to cover the captured range (clamped
+  // to the hard line ceiling) so the slice is present in the read window.
+  const maxLines = anchor.lineRange
+    ? Math.min(anchor.lineRange.endLine, FILE_RANGE_MAX_EXPANDED_LINES)
+    : undefined;
+  return {
+    nodeId: ref.nodeId,
+    path: ref.path, // C1: verbatim, never decodeURIComponent'd.
+    maxBytes,
+    ...(maxLines !== undefined ? { maxLines } : {}),
+    ...(ref.repoBinding ? { repoBinding: ref.repoBinding } : {}),
+  };
+}
+
+/**
+ * Mint the `current` `FileResourceRef` from a content fetch so the pure #766
+ * resolver can compare it to the captured ref. Preserves the captured ref's
+ * identity carriers (`intent`, `maxBytes`, `repoBinding`) so
+ * `fileResourceRefEquals` treats them as the same location.
+ */
+function currentRefFromContent(
+  captured: AnchorRef,
+  fetched: Extract<FileRangeContentResult, { found: true }>
+): FileResourceRef | null {
+  const ref = captured.ref;
+  try {
+    return createFileResourceRef({
+      nodeId: ref.nodeId,
+      path: ref.path,
+      intent: ref.intent,
+      ...(fetched.size !== undefined ? { size: fetched.size } : {}),
+      ...(fetched.contentSha256 !== undefined ? { sha256: fetched.contentSha256 } : {}),
+      ...(fetched.mtimeMs !== undefined ? { mtimeMs: fetched.mtimeMs } : {}),
+      ...(ref.maxBytes !== undefined ? { maxBytes: ref.maxBytes } : {}),
+      ...(ref.repoBinding ? { repoBinding: ref.repoBinding } : {}),
+    });
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Expansion.
+// ---------------------------------------------------------------------------
+
+/**
+ * Expand a `file-anchor`'s `AnchorRef` into a bounded content slice IF AND ONLY
+ * IF the anchor still resolves `unchanged`. The flow:
+ *
+ *   1. Fetch the bounded current content through the File-RPC-under-capability
+ *      seam (the only blessed read path; C1: never a local stat/read on the hub
+ *      for a federated node's file). A `null` fetch ⇒ `unavailable`; a
+ *      `found:false` fetch ⇒ `missing`.
+ *   2. Assert the fetch acknowledged `ANCHOR_RESOLUTION_CAPABILITY` (C1 defense
+ *      in depth — a mis-wired fetcher that skipped the gate throws).
+ *   3. Mint a `current` ref from the read and derive `AnchorState` via the PURE
+ *      #766 resolver (`resolveState` override may substitute an authoritative
+ *      sha-based resolution; by default we compare the read-derived ref).
+ *   4. ONLY when `unchanged` do we return the sliced content. For `stale` /
+ *      `missing` we return the state + advisory captured `quote` and NO current
+ *      content — never present drifted bytes as the anchored selection.
+ */
+export async function expandFileRange(
+  anchor: AnchorRef,
+  deps: ExpandFileRangeDeps
+): Promise<FileRangeExpansion> {
+  const target = contentTargetFor(anchor);
+  const fetched = await deps.fetchContent(target);
+
+  if (fetched === null) {
+    return baseExpansion(anchor, 'unavailable');
+  }
+  if (fetched.grantedCapability !== ANCHOR_RESOLUTION_CAPABILITY) {
+    throw new Error(
+      `file-range content fetch was authorized for "${fetched.grantedCapability}" but requires "${ANCHOR_RESOLUTION_CAPABILITY}"`
+    );
+  }
+  if (!fetched.found) {
+    return baseExpansion(anchor, 'missing');
+  }
+
+  // Derive state. An injected resolver wins (it may run an authoritative
+  // sha-vs-sha resolution through the registered #766 fetcher); otherwise we
+  // compare the ref minted from this very read.
+  let state: AnchorState;
+  if (deps.resolveState) {
+    const outcome = await deps.resolveState(anchor);
+    if (outcome === null) return baseExpansion(anchor, 'unavailable');
+    state = outcome.state;
+  } else {
+    const current = currentRefFromContent(anchor, fetched);
+    state = resolveAnchorState(anchor, current);
+  }
+
+  if (state !== 'unchanged') {
+    // Stale or missing: surface the state + advisory captured quote, NEVER the
+    // freshly-read bytes presented as the current anchored selection.
+    return baseExpansion(anchor, state);
+  }
+
+  const { slice, truncated } = sliceLineRange(fetched.content, anchor.lineRange);
+  const expansion: FileRangeExpansion = {
+    state: 'unchanged',
+    content: slice,
+    truncated: truncated || fetched.truncatedBytes === true,
+  };
+  if (anchor.lineRange) expansion.lineRange = { ...anchor.lineRange };
+  return expansion;
+}
+
+function baseExpansion(
+  anchor: AnchorRef,
+  state: AnchorState | 'unavailable'
+): FileRangeExpansion {
+  const expansion: FileRangeExpansion = { state };
+  if (anchor.lineRange) expansion.lineRange = { ...anchor.lineRange };
+  if (anchor.quote) expansion.capturedQuote = anchor.quote;
+  return expansion;
+}
+
+// ---------------------------------------------------------------------------
+// Decoration (runtime consumer of #766 — the #759-flagged missing piece).
+// ---------------------------------------------------------------------------
+
+/**
+ * A `ContextPacket` decorated with its DERIVED `AnchorState`. The `anchorState`
+ * field is computed at read time and is NEVER persisted (ADR-019 rule #3). Only
+ * `file-anchor` packets carry it; everything else is the packet unchanged.
+ */
+export type DecoratedContextPacket = ContextPacket & {
+  /** Derived at read time for `file-anchor` packets. Omitted when unresolved. */
+  anchorState?: AnchorState;
+};
+
+/**
+ * Resolver seam for decoration. Defaults to the hub-registered #766 resolver
+ * (`resolveAnchorWithRegisteredFetcher`); injectable for tests. A `null` return
+ * means resolution is unavailable (hub not booted / no in-scope session) — the
+ * packet is then returned UNDECORATED rather than guessing a state.
+ */
+export type AnchorStateResolver = (
+  anchor: AnchorRef
+) => Promise<ResolveAnchorOutcome | null>;
+
+/**
+ * Decorate a single packet with its derived `AnchorState`. Non-`file-anchor`
+ * packets (and `file-anchor` packets whose resolution is unavailable) pass
+ * through unchanged. NEVER mutates the input.
+ */
+export async function decoratePacketAnchorState(
+  packet: ContextPacket,
+  resolve: AnchorStateResolver = resolveAnchorWithRegisteredFetcher
+): Promise<DecoratedContextPacket> {
+  if (packet.kind !== 'file-anchor' || !packet.anchor) return packet;
+  const outcome = await resolve(packet.anchor);
+  if (outcome === null) return packet; // resolution unavailable → undecorated.
+  return { ...packet, anchorState: outcome.state };
+}
+
+/**
+ * Decorate many packets concurrently. Order-preserving. Used by `inbox.list`
+ * where a message references several packets.
+ */
+export async function decoratePacketsAnchorState(
+  packets: readonly ContextPacket[],
+  resolve: AnchorStateResolver = resolveAnchorWithRegisteredFetcher
+): Promise<DecoratedContextPacket[]> {
+  return Promise.all(packets.map((p) => decoratePacketAnchorState(p, resolve)));
+}
+
+// ---------------------------------------------------------------------------
+// Hub-level content-fetcher registration (mirrors the #759 anchor-fetcher
+// registry). The production `FileRangeContentFetcher` is built once at hub boot
+// from the live registry/link/envelope handles and registered here so the
+// `expandFileRange` consumer can retrieve it without threading deps through
+// every call site.
+// ---------------------------------------------------------------------------
+
+let registeredContentFetcher: FileRangeContentFetcher | null = null;
+
+/** Register the hub's production file-range content fetcher (once at boot). */
+export function registerFileRangeContentFetcher(
+  fetcher: FileRangeContentFetcher
+): void {
+  registeredContentFetcher = fetcher;
+}
+
+/** Retrieve the registered content fetcher, or `null` if the hub has not wired it. */
+export function getFileRangeContentFetcher(): FileRangeContentFetcher | null {
+  return registeredContentFetcher;
+}
+
+/**
+ * Expand a `file-anchor` packet using the hub-registered content fetcher and
+ * anchor-state resolver. Returns `null` when no content fetcher is registered
+ * (hub not booted) so the caller can distinguish "unavailable" from a resolved
+ * state. Non-`file-anchor` packets (or anchor packets with no `anchor`) also
+ * return `null` — expansion is file-anchor-only in MVP.
+ */
+export async function expandFileRangePacket(
+  packet: ContextPacket
+): Promise<FileRangeExpansion | null> {
+  if (packet.kind !== 'file-anchor' || !packet.anchor) return null;
+  if (!registeredContentFetcher) return null;
+  return expandFileRange(packet.anchor, { fetchContent: registeredContentFetcher });
+}

--- a/server/features/context-inbox-router.ts
+++ b/server/features/context-inbox-router.ts
@@ -43,6 +43,13 @@ import {
   type SessionInboxMessageId,
   type SessionInboxMessageState,
 } from '../../shared/context-packet.js';
+import {
+  decoratePacketAnchorState,
+  decoratePacketsAnchorState,
+  type AnchorStateResolver,
+  type DecoratedContextPacket,
+} from '../context-adapters/file-range.js';
+import { resolveAnchorWithRegisteredFetcher } from '../anchor-resolution.js';
 
 // ---------------------------------------------------------------------------
 // Store seam — implemented by #758, depended on here as an interface.
@@ -138,6 +145,13 @@ export interface ContextInboxStore {
 export interface ContextInboxRouterDeps {
   store: ContextInboxStore | null;
   requireAuth?: RequestHandler;
+  /**
+   * #760: resolve a `file-anchor` packet's DERIVED `AnchorState` at read time.
+   * Defaults to the hub-registered #766 resolver. A `null` resolution (no
+   * fetcher / no in-scope session) leaves the packet UNDECORATED rather than
+   * guessing. `AnchorState` is never stored — it is computed on every read.
+   */
+  resolveAnchorState?: AnchorStateResolver;
 }
 
 // ---------------------------------------------------------------------------
@@ -307,6 +321,11 @@ function sendUpdateFailure(
 export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
   const router = Router();
   const auth = deps.requireAuth ?? ((_req: Request, _res: Response, next) => next());
+  // #760: derived `AnchorState` decoration resolver. Defaults to the hub
+  // registry; `resolveAnchorWithRegisteredFetcher` returns `null` when the hub
+  // has not wired a fetcher, in which case packets pass through undecorated.
+  const resolveAnchorState: AnchorStateResolver =
+    deps.resolveAnchorState ?? resolveAnchorWithRegisteredFetcher;
 
   /** Resolve the store or send 503; centralizes the null guard. */
   function store(res: Response): ContextInboxStore | null {
@@ -317,6 +336,37 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
       return null;
     }
     return deps.store;
+  }
+
+  /**
+   * #760: collect the decorated `file-anchor` packets a message references, so
+   * `inbox.get`/`inbox.list` can surface each referenced packet's derived
+   * `AnchorState` without the agent issuing a follow-up `context.get`. Only
+   * `file-anchor` packets are decorated; missing/non-anchor packets are skipped.
+   * Returns `[]` when the message references no resolvable file-anchor packets.
+   */
+  async function decoratedAnchorPacketsFor(
+    s: ContextInboxStore,
+    message: SessionInboxMessage
+  ): Promise<DecoratedContextPacket[]> {
+    const anchorPackets: ContextPacket[] = [];
+    for (const id of message.contextPacketIds) {
+      const packet = s.getPacket(id);
+      if (packet && packet.kind === 'file-anchor' && packet.anchor) {
+        anchorPackets.push(packet);
+      }
+    }
+    if (anchorPackets.length === 0) return [];
+    return decoratePacketsAnchorState(anchorPackets, resolveAnchorState);
+  }
+
+  /** Attach decorated referenced packets to a message envelope (additive). */
+  async function decorateMessage(
+    s: ContextInboxStore,
+    message: SessionInboxMessage
+  ): Promise<SessionInboxMessage & { contextPackets?: DecoratedContextPacket[] }> {
+    const contextPackets = await decoratedAnchorPacketsFor(s, message);
+    return contextPackets.length > 0 ? { ...message, contextPackets } : message;
   }
 
   // -- context.create ------------------------------------------------------
@@ -364,7 +414,9 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
   });
 
   // -- context.get ---------------------------------------------------------
-  router.get('/context/:id', auth, (req, res) => {
+  // #760: decorate a returned `file-anchor` packet with its DERIVED, NON-STORED
+  // `AnchorState` (the runtime consumer of #766 flagged as missing by #759).
+  router.get('/context/:id', auth, (req, res, next) => {
     if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
     const s = store(res);
     if (!s) return;
@@ -373,7 +425,9 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
       sendGatewayError(res, 'NOT_FOUND', 'context packet not found');
       return;
     }
-    res.json({ contextPacket });
+    decoratePacketAnchorState(contextPacket, resolveAnchorState)
+      .then((decorated) => res.json({ contextPacket: decorated }))
+      .catch(next);
   });
 
   // -- inbox.send ----------------------------------------------------------
@@ -407,7 +461,7 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
 
   // -- inbox.list ----------------------------------------------------------
   // PULL delivery: the store flips queued → delivered as a read side effect.
-  router.get('/inbox', auth, (req, res) => {
+  router.get('/inbox', auth, (req, res, next) => {
     if (denyMissingCapability(req, res, [INBOX_READ])) return;
     const s = store(res);
     if (!s) return;
@@ -426,12 +480,18 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
     const limit = readLimit(req.query['limit']);
     if (state) filter.state = state;
     if (limit !== undefined) filter.limit = limit;
-    res.json({ messages: s.listInboxMessages(filter) });
+    // PULL delivery runs first (the store flips queued → delivered), then each
+    // message's referenced file-anchor packets are decorated with derived state.
+    const messages = s.listInboxMessages(filter);
+    Promise.all(messages.map((m) => decorateMessage(s, m)))
+      .then((decorated) => res.json({ messages: decorated }))
+      .catch(next);
   });
 
   // -- inbox.get -----------------------------------------------------------
   // PULL delivery: the store flips queued → delivered as a read side effect.
-  router.get('/inbox/:id', auth, (req, res) => {
+  // #760: referenced file-anchor packets are decorated with derived AnchorState.
+  router.get('/inbox/:id', auth, (req, res, next) => {
     if (denyMissingCapability(req, res, [INBOX_READ])) return;
     const s = store(res);
     if (!s) return;
@@ -440,7 +500,9 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
       sendGatewayError(res, 'NOT_FOUND', 'inbox message not found');
       return;
     }
-    res.json({ message });
+    decorateMessage(s, message)
+      .then((decorated) => res.json({ message: decorated }))
+      .catch(next);
   });
 
   // -- inbox.ack / inbox.resolve / inbox.ignore ----------------------------

--- a/server/index.ts
+++ b/server/index.ts
@@ -146,11 +146,18 @@ import {
   type ContextInboxStore,
 } from './features/context-inbox-router.js';
 import { createContextInboxStoreAdapter } from './features/context-inbox-store-adapter.js';
-import { createAnchorFileFetcher } from './anchor-file-fetcher.js';
+import {
+  createAnchorFileFetcher,
+  createAnchorContentFetcher,
+} from './anchor-file-fetcher.js';
 import {
   registerAnchorFileFetcher,
   type AnchorFileFetcher,
 } from './anchor-resolution.js';
+import {
+  registerFileRangeContentFetcher,
+  type FileRangeContentFetcher,
+} from './context-adapters/file-range.js';
 import { collectLocalRepoInventory } from './repo-inventory.js';
 import type {
   AgentType,
@@ -1733,9 +1740,19 @@ async function main(): Promise<void> {
     sessionEnvelopes: sessionEnvelopeRegistry,
   });
   // Anchor resolution (#766) decorates a packet's `AnchorState` at read time.
-  // The consumer endpoint lands in the #760 adapter lane; until then the fetcher
-  // is registered as the hub's anchor-resolution dependency.
+  // The #760 lane wires that decoration into `context.get`/`inbox.*` via the
+  // context-inbox router (it calls `resolveAnchorWithRegisteredFetcher`).
   registerAnchorFileFetcher(anchorFileFetcher);
+  // #760: production `FileRangeContentFetcher` for the file-range adapter's
+  // CONTENT expansion. Reuses the same session-scoped File RPC `read` path under
+  // `rpc:fs:read`; shares the live registry/link/envelope handles. Registered so
+  // `expandFileRangePacket` can read a bounded slice without threading deps.
+  const anchorContentFetcher: FileRangeContentFetcher = createAnchorContentFetcher({
+    registry: hubNodeRegistry,
+    nodeLinks: hubNodeLinks,
+    sessionEnvelopes: sessionEnvelopeRegistry,
+  });
+  registerFileRangeContentFetcher(anchorContentFetcher);
   app.use(
     createCliGatewayEventsRouter(express, {
       cliGatewayAuth: requireCliGatewayAuth,

--- a/test/context-inbox-router.test.ts
+++ b/test/context-inbox-router.test.ts
@@ -17,10 +17,14 @@ import {
   TERMINAL_INBOX_MESSAGE_STATES,
   createContextPacketId,
   createInboxMessageId,
+  type AnchorRef,
   type ContextPacket,
   type SessionInboxMessage,
   type SessionInboxMessageState,
 } from '../shared/context-packet.js';
+import { createFileResourceRef } from '../shared/file-resource-ref.js';
+import type { AnchorStateResolver } from '../server/context-adapters/file-range.js';
+import type { ResolveAnchorOutcome } from '../server/anchor-resolution.js';
 
 // ---------------------------------------------------------------------------
 // In-memory store implementing the #765 seam (#758 builds the SQLite version).
@@ -151,13 +155,19 @@ const ALL_CAPS = 'context:read,context:write,inbox:read,inbox:write';
 let server: Server;
 let baseUrl: string;
 
-function mount(store: ContextInboxStore | null): Promise<void> {
+function mount(
+  store: ContextInboxStore | null,
+  resolveAnchorState?: AnchorStateResolver
+): Promise<void> {
   const app = express();
   app.use(express.json());
   app.use(
     createContextInboxRouter({
       requireAuth: (_req, _res, next) => next(),
       store,
+      // Default to a resolver that never resolves (null) so existing tests stay
+      // undecorated; the #760 decoration tests inject a real resolver.
+      resolveAnchorState: resolveAnchorState ?? (async () => null),
     })
   );
   return new Promise<void>((resolve) => {
@@ -167,6 +177,20 @@ function mount(store: ContextInboxStore | null): Promise<void> {
       resolve();
     });
   });
+}
+
+function fileAnchorRef(): AnchorRef {
+  return {
+    ref: createFileResourceRef({
+      nodeId: 'node1',
+      path: '/repo/src/index.ts',
+      intent: 'read',
+      sha256: 'a'.repeat(64),
+      mtimeMs: 1_000,
+    }),
+    lineRange: { startLine: 10, endLine: 20 },
+    quote: 'const answer = 42;',
+  };
 }
 
 async function req(
@@ -321,5 +345,71 @@ describe('context/inbox gateway router without a store', () => {
     const res = await req('GET', '/context', { caps: 'context:read' });
     expect(res.status).toBe(503);
     expect(res.body.error.code).toBe('SERVER_UNAVAILABLE');
+  });
+});
+
+// #760: derived `AnchorState` decoration wired into the read paths.
+describe('context/inbox gateway router — #760 derived AnchorState decoration', () => {
+  function resolverReturning(state: 'unchanged' | 'stale' | 'missing'): AnchorStateResolver {
+    return async (): Promise<ResolveAnchorOutcome> => ({ state, current: null });
+  }
+
+  async function createFileAnchor(): Promise<string> {
+    const created = await req('POST', '/context', {
+      caps: 'context:write',
+      body: { kind: 'file-anchor', anchor: fileAnchorRef(), createdBy: 'agent_1' },
+    });
+    expect(created.status).toBe(201);
+    return created.body.contextPacket.id as string;
+  }
+
+  it('context.get decorates a file-anchor packet with derived anchorState', async () => {
+    await mount(createFakeStore(), resolverReturning('stale'));
+    const id = await createFileAnchor();
+    const got = await req('GET', `/context/${encodeURIComponent(id)}`, { caps: 'context:read' });
+    expect(got.status).toBe(200);
+    expect(got.body.contextPacket.kind).toBe('file-anchor');
+    // DERIVED at read time, surfaced — never stored.
+    expect(got.body.contextPacket.anchorState).toBe('stale');
+  });
+
+  it('context.get leaves a note packet undecorated', async () => {
+    await mount(createFakeStore(), resolverReturning('unchanged'));
+    const created = await req('POST', '/context', {
+      caps: 'context:write',
+      body: { kind: 'note', note: 'no anchor here', createdBy: 'agent_1' },
+    });
+    const id = created.body.contextPacket.id as string;
+    const got = await req('GET', `/context/${encodeURIComponent(id)}`, { caps: 'context:read' });
+    expect(got.body.contextPacket.anchorState).toBeUndefined();
+  });
+
+  it('inbox.get attaches decorated referenced file-anchor packets', async () => {
+    await mount(createFakeStore(), resolverReturning('unchanged'));
+    const packetId = await createFileAnchor();
+    const sent = await req('POST', '/inbox', {
+      caps: 'inbox:write',
+      body: { targetSessionId: 'node1:s9', contextPacketIds: [packetId], createdBy: 'agent_1' },
+    });
+    const msgId = sent.body.message.id as string;
+    const got = await req('GET', `/inbox/${encodeURIComponent(msgId)}`, { caps: 'inbox:read' });
+    expect(got.status).toBe(200);
+    expect(got.body.message.contextPackets).toHaveLength(1);
+    expect(got.body.message.contextPackets[0].anchorState).toBe('unchanged');
+  });
+
+  it('inbox.list decorates referenced packets and still PULL-delivers', async () => {
+    await mount(createFakeStore(), resolverReturning('missing'));
+    const packetId = await createFileAnchor();
+    await req('POST', '/inbox', {
+      caps: 'inbox:write',
+      body: { targetSessionId: 'node1:s10', contextPacketIds: [packetId], createdBy: 'agent_1' },
+    });
+    const listed = await req('GET', '/inbox?targetSessionId=node1:s10', { caps: 'inbox:read' });
+    expect(listed.status).toBe(200);
+    expect(listed.body.messages).toHaveLength(1);
+    // PULL delivery still happens alongside decoration.
+    expect(listed.body.messages[0].state).toBe('delivered');
+    expect(listed.body.messages[0].contextPackets[0].anchorState).toBe('missing');
   });
 });

--- a/test/file-range-adapter.test.ts
+++ b/test/file-range-adapter.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createContextPacketId,
+  type AnchorRef,
+  type ContextPacket,
+} from '../shared/context-packet.js';
+import { createFileResourceRef } from '../shared/file-resource-ref.js';
+import type { ResolveAnchorOutcome } from '../server/anchor-resolution.js';
+import {
+  FILE_RANGE_MAX_EXPANDED_LINES,
+  decoratePacketAnchorState,
+  decoratePacketsAnchorState,
+  expandFileRange,
+  sliceLineRange,
+  type FileRangeContentFetcher,
+  type FileRangeContentResult,
+  type FileRangeContentTarget,
+} from '../server/context-adapters/file-range.js';
+
+const NODE = 'node-alpha';
+const PATH = '/repo/src/index.ts';
+const SHA_A = 'a'.repeat(64);
+const SHA_B = 'b'.repeat(64);
+
+// 12-line fixture; the anchor selects lines 3..5.
+const FILE_CONTENT = [
+  'line one',
+  'line two',
+  'line three',
+  'line four',
+  'line five',
+  'line six',
+  'line seven',
+  'line eight',
+  'line nine',
+  'line ten',
+  'line eleven',
+  'line twelve',
+].join('\n');
+
+function anchor(overrides: Partial<AnchorRef> = {}): AnchorRef {
+  return {
+    ref: createFileResourceRef({
+      nodeId: NODE,
+      path: PATH,
+      intent: 'read',
+      sha256: SHA_A,
+      mtimeMs: 1_000,
+      size: FILE_CONTENT.length,
+    }),
+    lineRange: { startLine: 3, endLine: 5 },
+    quote: 'line three\nline four\nline five',
+    ...overrides,
+  };
+}
+
+function fileAnchorPacket(a: AnchorRef = anchor()): ContextPacket {
+  return {
+    id: createContextPacketId('test'),
+    kind: 'file-anchor',
+    anchor: a,
+    createdBy: 'agent_1',
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function contentFetcher(
+  result: FileRangeContentResult | null
+): { fn: FileRangeContentFetcher; calls: FileRangeContentTarget[] } {
+  const calls: FileRangeContentTarget[] = [];
+  const fn = vi.fn(async (target: FileRangeContentTarget) => {
+    calls.push(target);
+    return result;
+  });
+  return { fn, calls };
+}
+
+describe('sliceLineRange (pure)', () => {
+  it('extracts the 1-based inclusive line range', () => {
+    const { slice, truncated } = sliceLineRange(FILE_CONTENT, { startLine: 3, endLine: 5 });
+    expect(slice).toBe('line three\nline four\nline five');
+    expect(truncated).toBe(false);
+  });
+
+  it('clamps a single line', () => {
+    const { slice } = sliceLineRange(FILE_CONTENT, { startLine: 1, endLine: 1 });
+    expect(slice).toBe('line one');
+  });
+
+  it('clamps when the range runs past EOF (returns available lines only)', () => {
+    const { slice } = sliceLineRange(FILE_CONTENT, { startLine: 11, endLine: 99 });
+    expect(slice).toBe('line eleven\nline twelve');
+  });
+
+  it('returns empty when the range starts past EOF', () => {
+    const { slice } = sliceLineRange(FILE_CONTENT, { startLine: 50, endLine: 60 });
+    expect(slice).toBe('');
+  });
+
+  it('flags truncation when the requested line count exceeds the hard cap', () => {
+    const huge = Array.from({ length: FILE_RANGE_MAX_EXPANDED_LINES + 50 }, (_, i) => `L${i}`).join('\n');
+    const { slice, truncated } = sliceLineRange(huge, {
+      startLine: 1,
+      endLine: FILE_RANGE_MAX_EXPANDED_LINES + 50,
+    });
+    expect(truncated).toBe(true);
+    expect(slice.split('\n')).toHaveLength(FILE_RANGE_MAX_EXPANDED_LINES);
+  });
+});
+
+describe('expandFileRange', () => {
+  it('expands the correct slice when the anchor is unchanged (sha matches)', async () => {
+    const captured = anchor({ sha256: SHA_A } as Partial<AnchorRef>);
+    const { fn, calls } = contentFetcher({
+      found: true,
+      grantedCapability: 'rpc:fs:read',
+      content: FILE_CONTENT,
+      contentSha256: SHA_A,
+      mtimeMs: 1_000,
+      size: FILE_CONTENT.length,
+    });
+    const result = await expandFileRange(captured, { fetchContent: fn });
+    expect(result.state).toBe('unchanged');
+    expect(result.content).toBe('line three\nline four\nline five');
+    expect(result.lineRange).toEqual({ startLine: 3, endLine: 5 });
+    // C1: the stored path is passed verbatim to the fetcher.
+    expect(calls[0]?.path).toBe(PATH);
+  });
+
+  it('surfaces "stale" and NO current content when the file content drifted', async () => {
+    // Captured sha is SHA_A; the re-read content hashes to SHA_B (file edited).
+    const { fn } = contentFetcher({
+      found: true,
+      grantedCapability: 'rpc:fs:read',
+      content: 'totally different content now',
+      contentSha256: SHA_B,
+      mtimeMs: 2_000,
+      size: 29,
+    });
+    const result = await expandFileRange(anchor(), { fetchContent: fn });
+    expect(result.state).toBe('stale');
+    // CRITICAL: a stale anchor must NOT serve the freshly-read bytes as current.
+    expect(result.content).toBeUndefined();
+    // The advisory captured quote is echoed (clearly NOT current content).
+    expect(result.capturedQuote).toBe('line three\nline four\nline five');
+  });
+
+  it('surfaces "missing" when the node reports the file gone', async () => {
+    const { fn } = contentFetcher({ found: false, grantedCapability: 'rpc:fs:read' });
+    const result = await expandFileRange(anchor(), { fetchContent: fn });
+    expect(result.state).toBe('missing');
+    expect(result.content).toBeUndefined();
+  });
+
+  it('surfaces "unavailable" (never local fallback) when the fetch is unauthorized', async () => {
+    const { fn } = contentFetcher(null);
+    const result = await expandFileRange(anchor(), { fetchContent: fn });
+    expect(result.state).toBe('unavailable');
+    expect(result.content).toBeUndefined();
+  });
+
+  it('throws if the content fetch was authorized for the wrong capability (C1)', async () => {
+    const { fn } = contentFetcher({
+      found: true,
+      grantedCapability: 'rpc:fs:list' as never,
+      content: FILE_CONTENT,
+      contentSha256: SHA_A,
+    });
+    await expect(expandFileRange(anchor(), { fetchContent: fn })).rejects.toThrow(/rpc:fs:read/);
+  });
+
+  it('honors the byte size cap on the read target', async () => {
+    const captured = anchor({
+      ref: createFileResourceRef({
+        nodeId: NODE,
+        path: PATH,
+        intent: 'read',
+        sha256: SHA_A,
+        mtimeMs: 1_000,
+        maxBytes: 4096,
+      }),
+    });
+    const { fn, calls } = contentFetcher({ found: false, grantedCapability: 'rpc:fs:read' });
+    await expandFileRange(captured, { fetchContent: fn });
+    expect(calls[0]?.maxBytes).toBe(4096);
+  });
+
+  it('uses an injected state resolver (authoritative sha resolution) when provided', async () => {
+    const { fn } = contentFetcher({
+      found: true,
+      grantedCapability: 'rpc:fs:read',
+      content: FILE_CONTENT,
+      // No sha on the read (truncated); the injected resolver decides state.
+      mtimeMs: 1_000,
+    });
+    const resolveState = vi.fn(
+      async (): Promise<ResolveAnchorOutcome> => ({ state: 'unchanged', current: null })
+    );
+    const result = await expandFileRange(anchor(), { fetchContent: fn, resolveState });
+    expect(resolveState).toHaveBeenCalledOnce();
+    expect(result.state).toBe('unchanged');
+    expect(result.content).toBe('line three\nline four\nline five');
+  });
+
+  it('treats a null injected-resolver outcome as unavailable', async () => {
+    const { fn } = contentFetcher({
+      found: true,
+      grantedCapability: 'rpc:fs:read',
+      content: FILE_CONTENT,
+      mtimeMs: 1_000,
+    });
+    const resolveState = vi.fn(async (): Promise<ResolveAnchorOutcome | null> => null);
+    const result = await expandFileRange(anchor(), { fetchContent: fn, resolveState });
+    expect(result.state).toBe('unavailable');
+    expect(result.content).toBeUndefined();
+  });
+});
+
+describe('decoratePacketAnchorState (runtime consumer of #766)', () => {
+  it('attaches the derived AnchorState to a file-anchor packet', async () => {
+    const packet = fileAnchorPacket();
+    const resolve = vi.fn(async (): Promise<ResolveAnchorOutcome> => ({ state: 'unchanged', current: null }));
+    const decorated = await decoratePacketAnchorState(packet, resolve);
+    expect(decorated.anchorState).toBe('unchanged');
+    // Does not mutate the input.
+    expect((packet as { anchorState?: unknown }).anchorState).toBeUndefined();
+  });
+
+  it('surfaces "stale" on the decorated packet (derived, never stored)', async () => {
+    const packet = fileAnchorPacket();
+    const resolve = vi.fn(async (): Promise<ResolveAnchorOutcome> => ({ state: 'stale', current: null }));
+    const decorated = await decoratePacketAnchorState(packet, resolve);
+    expect(decorated.anchorState).toBe('stale');
+  });
+
+  it('leaves the packet UNDECORATED when resolution is unavailable (null)', async () => {
+    const packet = fileAnchorPacket();
+    const resolve = vi.fn(async (): Promise<ResolveAnchorOutcome | null> => null);
+    const decorated = await decoratePacketAnchorState(packet, resolve);
+    expect(decorated.anchorState).toBeUndefined();
+  });
+
+  it('passes non-file-anchor packets through unchanged (no resolver call)', async () => {
+    const note: ContextPacket = {
+      id: createContextPacketId('note'),
+      kind: 'note',
+      note: 'remember this',
+      createdBy: 'agent_1',
+      createdAt: new Date().toISOString(),
+    };
+    const resolve = vi.fn(async (): Promise<ResolveAnchorOutcome> => ({ state: 'unchanged', current: null }));
+    const decorated = await decoratePacketAnchorState(note, resolve);
+    expect(decorated).toBe(note);
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('decorates many packets order-preserving', async () => {
+    const a = fileAnchorPacket();
+    const b = fileAnchorPacket();
+    let n = 0;
+    const states: ('unchanged' | 'stale')[] = ['unchanged', 'stale'];
+    const resolve = vi.fn(
+      async (): Promise<ResolveAnchorOutcome> => ({ state: states[n++]!, current: null })
+    );
+    const decorated = await decoratePacketsAnchorState([a, b], resolve);
+    expect(decorated[0]?.anchorState).toBe('unchanged');
+    expect(decorated[1]?.anchorState).toBe('stale');
+  });
+});


### PR DESCRIPTION
## What shipped

The **file-range context source adapter** (MVP = file-range ONLY, per ADR-019 + the #760 scope comment) AND the wiring that makes the derived `stale` decoration a real runtime feature — the consumer of #766 that the #759 lane explicitly flagged as missing ("nothing calls `resolveAnchor` in a request path yet").

### Adapter — `server/context-adapters/file-range.ts`
- `expandFileRange(anchor, deps)` — expands a `file-anchor`'s `AnchorRef` into the referenced **content slice** via File RPC `read` (line-range sliced, size-capped to 64KB / 2000 lines, capability-gated `rpc:fs:read`). It resolves the anchor's `AnchorState` **first** and **refuses to serve current-looking content for a `stale`/`missing` anchor** — it surfaces the state plus the *advisory* captured `quote`, never freshly-read bytes presented as the anchored selection. (The issue's load-bearing correctness rule.)
- `decoratePacketAnchorState` / `decoratePacketsAnchorState` — derive a packet's `AnchorState` at read time and attach it as a **non-stored** `anchorState` field (ADR-019 rule #3: always derived, never persisted).
- `sliceLineRange` — pure 1-based-inclusive line slicing with hard line/byte clamps.

### Content fetcher — `server/anchor-file-fetcher.ts`
- `createAnchorContentFetcher` — a content-**returning** File RPC `read` fetcher that reuses the *identical* session-scope resolution + `evaluateHubPolicy` machinery as the #759 staleness fetcher (no re-implemented security). The #766 fetcher only kept the freshness sha; this returns the bytes the adapter slices.

### Decoration wiring — `server/features/context-inbox-router.ts`
- `context.get`, `inbox.get`, `inbox.list` now decorate file-anchor packets with the resolved `AnchorState`. The resolver defaults to the hub-registered #766 resolver (`resolveAnchorWithRegisteredFetcher`); a `null` resolution (no fetcher / no in-scope session) leaves the packet **undecorated** rather than guessing. `inbox.*` attach decorated referenced packets under `message.contextPackets` (additive; envelope is `additionalProperties: true`, so no contract bump).

### Boot — `server/index.ts`
- Registers the production content fetcher alongside the existing #759 anchor fetcher.

## C1 (security)
The stored `AnchorRef.ref.path` (and cwd) is passed **VERBATIM** to File RPC — never `decodeURIComponent`'d. It is already validated + POSIX-normalized at mint time; the hub File RPC route owns root-containment/traversal enforcement.

## File-range-only scope
diff-range / terminal-range / markdown adapters and the `shifted` anchor state are **deferred** per the issue scope.

## Test evidence
- New `test/file-range-adapter.test.ts` (18 cases): correct slice (line range, clamp past-EOF, byte/line cap); **stale anchor surfaces `stale` not stale-content**; `missing` on gone file; `unavailable` on unauthorized fetch (never local fallback); capability assertion (wrong cap throws); size-cap honored; injected resolver path; decoration derive/undecorated/non-anchor pass-through.
- `test/context-inbox-router.test.ts` extended (4 cases): `context.get`/`inbox.get`/`inbox.list` decoration + note left undecorated + PULL-delivery still fires alongside decoration.
- Gates (Node24): `npm run build` ✅, `npm run check` ✅ (0 errors; new files add 0 warnings), **full `npm test` 301 files / 3921 tests pass**.
- **Live CLI smoke** on isolated hub (`RELAY_IDE_PORT=3466 NO_PIN=1`): `context create` a file-anchor → `context get` returned `"anchorState": "missing"` — proving the full live path (router → `decoratePacketAnchorState` → registered #766 fetcher) honestly reports `missing` for a non-resolvable anchor instead of fabricating content. Cleaned up.

## Stacking
Stacked on **#759 (PR #775)** (`feat/759-inbox-integration`, the inbox integration + anchor fetcher registry). Based on that branch for a clean stacked diff; **retarget to `nightly` once #775 merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)