### PR TITLE
feat(#761): relayctl agent preturn (headless inbox)

### DIFF
--- a/bin/relayctl.ts
+++ b/bin/relayctl.ts
@@ -13,6 +13,8 @@
  *   status                          — fetch node manifest summary from hub
  *   files read <path> [--cwd <d>]  — read a file via hub file RPC
  *   files list <path> [--cwd <d>]  — list a directory via hub file RPC
+ *   agent preturn [--session <id>] [--format markdown|json]
+ *                                   — read this session's pending inbox (PULL)
  *   logs tail                       — stub (slice 5 will wire #597)
  *
  * exit codes:
@@ -187,6 +189,263 @@ async function cmdFiles(fileArgs: string[]): Promise<void> {
   console.log(JSON.stringify(result, null, 2));
 }
 
+// ── subcommand: agent preturn ────────────────────────────────────────────────
+
+// Minimal shapes mirroring shared/context-packet.ts. relayctl is a tiny
+// standalone shim with no shared-module imports, so we type only the fields we
+// render and treat the rest defensively.
+interface PreturnPacket {
+  id: string;
+  kind: string;
+  note?: string;
+  anchor?: {
+    ref?: { path?: string; nodeId?: string };
+    lineRange?: { startLine: number; endLine: number };
+    byteRange?: { startByte: number; endByte: number };
+    quote?: string;
+  };
+  fileRef?: { path?: string; nodeId?: string };
+  createdBy?: string;
+  createdAt?: string;
+}
+
+interface PreturnMessage {
+  id: string;
+  targetSessionId?: string;
+  targetWorkContextId?: string;
+  contextPacketIds: string[];
+  text?: string;
+  state: string;
+  createdBy?: string;
+  createdAt?: string;
+  deliveredAt?: string;
+}
+
+const PRETURN_CAPABILITIES = 'inbox:read,context:read';
+
+/**
+ * Build the gateway headers a relayctl read uses against the hub. The hub
+ * `requireCliGatewayAuth` middleware accepts the v1 header + a scoped bearer
+ * token (when `RELAY_IDE_BROWSER_TOKEN` is present), or falls through to
+ * NO_PIN/cookie auth (the dev/in-PTY default). The capability header is always
+ * required by the context/inbox router itself, independent of the auth path.
+ */
+function gatewayHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    'x-relay-cli-gateway': 'v1',
+    'x-relay-capabilities': PRETURN_CAPABILITIES,
+  };
+  const token = process.env.RELAY_IDE_BROWSER_TOKEN;
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
+
+/** Parse `--session <id>` / `--format <markdown|json>` from preturn args. */
+function parsePreturnArgs(preturnArgs: string[]): {
+  sessionId: string | undefined;
+  format: 'markdown' | 'json';
+} {
+  let sessionId: string | undefined;
+  let format: 'markdown' | 'json' = 'markdown';
+  for (let i = 0; i < preturnArgs.length; i += 1) {
+    const arg = preturnArgs[i];
+    if (arg === '--session') {
+      sessionId = preturnArgs[i + 1];
+      if (!sessionId) die('--session requires a session id argument');
+      i += 1;
+    } else if (arg === '--format') {
+      const value = preturnArgs[i + 1];
+      if (value !== 'markdown' && value !== 'json') {
+        die(`--format must be 'markdown' or 'json' (got ${value ?? '(none)'})`);
+      }
+      format = value;
+      i += 1;
+    } else {
+      die(
+        `unknown preturn argument: ${arg}. ` +
+          'usage: relayctl agent preturn [--session <id>] [--format markdown|json]'
+      );
+    }
+  }
+  return { sessionId, format };
+}
+
+/** One-line label for a packet's location (anchor range / file ref). */
+function packetLocation(packet: PreturnPacket): string | undefined {
+  const anchor = packet.anchor;
+  if (anchor?.ref?.path) {
+    let label = anchor.ref.path;
+    if (anchor.lineRange) {
+      const { startLine, endLine } = anchor.lineRange;
+      label +=
+        startLine === endLine ? `#L${startLine}` : `#L${startLine}-L${endLine}`;
+    } else if (anchor.byteRange) {
+      label += `@${anchor.byteRange.startByte}-${anchor.byteRange.endByte}`;
+    }
+    return label;
+  }
+  if (packet.fileRef?.path) return packet.fileRef.path;
+  return undefined;
+}
+
+/** Render a single packet as a markdown bullet block. */
+function renderPacketMarkdown(packet: PreturnPacket): string {
+  const lines: string[] = [];
+  const location = packetLocation(packet);
+  lines.push(`  - **${packet.kind}**${location ? ` — \`${location}\`` : ''}`);
+  if (packet.note) lines.push(`    - note: ${packet.note}`);
+  const quote = packet.anchor?.quote;
+  if (quote) {
+    lines.push('    - quote:');
+    lines.push('      ```');
+    for (const q of quote.split('\n')) lines.push(`      ${q}`);
+    lines.push('      ```');
+  }
+  return lines.join('\n');
+}
+
+/** Render the full preturn payload as model-friendly markdown. */
+function renderPreturnMarkdown(
+  sessionId: string,
+  messages: PreturnMessage[],
+  packetsById: Map<string, PreturnPacket>
+): string {
+  const lines: string[] = [];
+  lines.push(`# Relay pending context — session ${sessionId}`);
+  lines.push('');
+  if (messages.length === 0) {
+    lines.push('No pending inbox messages.');
+    return lines.join('\n');
+  }
+  lines.push(
+    `${messages.length} pending message${messages.length === 1 ? '' : 's'}. ` +
+      'Read this context before responding. Rendering does not acknowledge or ' +
+      'resolve a message — use the inbox ack/resolve verbs for that.'
+  );
+  lines.push('');
+  for (const [index, message] of messages.entries()) {
+    lines.push(`## ${index + 1}. ${message.id} (${message.state})`);
+    if (message.createdBy) lines.push(`- from: ${message.createdBy}`);
+    if (message.text) lines.push(`- message: ${message.text}`);
+    if (message.contextPacketIds.length > 0) {
+      lines.push('- context:');
+      for (const packetId of message.contextPacketIds) {
+        const packet = packetsById.get(packetId);
+        if (packet) {
+          lines.push(renderPacketMarkdown(packet));
+        } else {
+          lines.push(`  - (packet ${packetId} unavailable)`);
+        }
+      }
+    }
+    lines.push('');
+  }
+  return lines.join('\n').trimEnd();
+}
+
+/**
+ * `agent preturn` — fetch the pending inbox for the current (or `--session`)
+ * session and render it. Fetching is the PULL step: the hub inbox API flips
+ * each `queued` message to `delivered` as a read side effect. preturn READS
+ * context — it never acks/resolves (that is a separate explicit action).
+ */
+async function cmdAgentPreturn(preturnArgs: string[]): Promise<void> {
+  const { sessionId: overrideSessionId, format } =
+    parsePreturnArgs(preturnArgs);
+
+  const hubUrl = requireEnv('RELAY_HUB_URL');
+  // Allow an explicit `--session` so this works via the gateway outside the
+  // injected PTY env; otherwise fall back to the env-injected session id.
+  const sessionId = overrideSessionId ?? requireEnv('RELAY_SESSION_ID');
+
+  const headers = gatewayHeaders();
+
+  // 1. PULL the inbox for this session. The hub flips queued → delivered here.
+  const inboxEndpoint = `${hubUrl}/inbox?targetSessionId=${encodeURIComponent(sessionId)}`;
+  let inboxRes: Response;
+  try {
+    inboxRes = await fetch(inboxEndpoint, { headers });
+  } catch (err) {
+    die(
+      `failed to reach hub at ${hubUrl}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  if (inboxRes.status === 403) {
+    console.error('relayctl: capability denied: session lacks inbox:read');
+    process.exit(2);
+  }
+  if (!inboxRes.ok) {
+    let detail = '';
+    try {
+      const errBody = (await inboxRes.json()) as {
+        error?: { message?: string } | string;
+      };
+      detail =
+        typeof errBody.error === 'string'
+          ? errBody.error
+          : (errBody.error?.message ?? '');
+    } catch {
+      // ignore parse error
+    }
+    die(
+      `hub returned ${inboxRes.status} ${inboxRes.statusText}${detail ? `: ${detail}` : ''}`
+    );
+  }
+  const inboxBody = (await inboxRes.json()) as { messages?: PreturnMessage[] };
+  const messages = Array.isArray(inboxBody.messages) ? inboxBody.messages : [];
+
+  // 2. Resolve referenced packet bodies (deduped). A missing/denied packet is
+  //    rendered as unavailable rather than tearing down the whole preturn.
+  const packetsById = new Map<string, PreturnPacket>();
+  const uniquePacketIds = new Set<string>();
+  for (const message of messages) {
+    for (const packetId of message.contextPacketIds) uniquePacketIds.add(packetId);
+  }
+  for (const packetId of uniquePacketIds) {
+    const packetEndpoint = `${hubUrl}/context/${encodeURIComponent(packetId)}`;
+    try {
+      const packetRes = await fetch(packetEndpoint, { headers });
+      if (packetRes.ok) {
+        const packetBody = (await packetRes.json()) as {
+          contextPacket?: PreturnPacket;
+        };
+        if (packetBody.contextPacket) {
+          packetsById.set(packetId, packetBody.contextPacket);
+        }
+      }
+    } catch {
+      // Leave unresolved; renderer notes it as unavailable.
+    }
+  }
+
+  // 3. Render.
+  if (format === 'json') {
+    console.log(
+      JSON.stringify(
+        {
+          sessionId,
+          pendingCount: messages.length,
+          messages,
+          contextPackets: [...packetsById.values()],
+        },
+        null,
+        2
+      )
+    );
+    return;
+  }
+  console.log(renderPreturnMarkdown(sessionId, messages, packetsById));
+}
+
+/** Dispatch the `agent` subcommand group. */
+async function cmdAgent(agentArgs: string[]): Promise<void> {
+  const sub = agentArgs[0];
+  if (sub !== 'preturn') {
+    die(`unknown agent subcommand: ${sub ?? '(none)'}. supported: preturn`);
+  }
+  await cmdAgentPreturn(agentArgs.slice(1));
+}
+
 // ── subcommand: logs ───────────────────────────────────────────────────────
 
 function cmdLogs(logsArgs: string[]): void {
@@ -214,6 +473,8 @@ async function main(): Promise<void> {
         '  status                         show node manifest summary',
         '  files read <path> [--cwd <d>]  read a file',
         '  files list <path> [--cwd <d>]  list a directory',
+        '  agent preturn [--session <id>] [--format markdown|json]',
+        '                                 read pending inbox context (PULL)',
         '  logs tail                       (not yet available)',
         '',
         'relayctl is only available inside relay-managed pty sessions.',
@@ -231,6 +492,9 @@ async function main(): Promise<void> {
       break;
     case 'files':
       await cmdFiles(args.slice(1));
+      break;
+    case 'agent':
+      await cmdAgent(args.slice(1));
       break;
     case 'logs':
       cmdLogs(args.slice(1));

--- a/test/relayctl-preturn.test.ts
+++ b/test/relayctl-preturn.test.ts
@@ -1,0 +1,307 @@
+// #761 / ADR-019: `relayctl agent preturn` — the headless inbox read.
+//
+// preturn is the proof that the CLI-first context loop is agent-consumable: an
+// agent inside a Relay PTY runs `relayctl agent preturn`, the hub PULL-delivers
+// its pending inbox (queued → delivered as a read side effect), and the command
+// renders it (markdown default + json). Rendering is NOT acknowledgement.
+//
+// We exercise the SHIPPED `dist/bin/relayctl.js` as a subprocess (mirroring
+// test/browser-cli.test.ts) against a real express server mounting the #765
+// context/inbox router over the same in-memory store seam #765's own route test
+// uses. This keeps the assertion end-to-end: the env contract, the gateway
+// headers relayctl sends, the PULL flip, and both renderers are all real.
+
+import express from 'express';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import type { Server } from 'node:http';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  createContextInboxRouter,
+  type ContextInboxStore,
+  type CreateContextPacketInput,
+  type CreateInboxMessageInput,
+  type ListContextPacketsFilter,
+  type ListInboxMessagesFilter,
+  type UpdateInboxStateResult,
+} from '../server/features/context-inbox-router.js';
+import {
+  TERMINAL_INBOX_MESSAGE_STATES,
+  createContextPacketId,
+  createInboxMessageId,
+  type ContextPacket,
+  type SessionInboxMessage,
+  type SessionInboxMessageState,
+} from '../shared/context-packet.js';
+
+const RELAYCTL_BIN = fileURLToPath(
+  new URL('../dist/bin/relayctl.js', import.meta.url)
+);
+
+const TERMINAL = new Set<SessionInboxMessageState>(TERMINAL_INBOX_MESSAGE_STATES);
+
+// In-memory store implementing the #765 seam with the SAME PULL-delivery side
+// effect (list/get flip queued → delivered) so the headless flip is observable.
+function createFakeStore(): ContextInboxStore & {
+  raw: () => SessionInboxMessage[];
+} {
+  const packets = new Map<string, ContextPacket>();
+  const messages = new Map<string, SessionInboxMessage>();
+  let packetSeq = 0;
+  let messageSeq = 0;
+
+  function deliverOnPull(message: SessionInboxMessage): SessionInboxMessage {
+    if (message.state === 'queued') {
+      const updated: SessionInboxMessage = {
+        ...message,
+        state: 'delivered',
+        deliveredAt: new Date().toISOString(),
+      };
+      messages.set(message.id, updated);
+      return updated;
+    }
+    return message;
+  }
+
+  return {
+    raw: () => [...messages.values()],
+    createPacket(input: CreateContextPacketInput): ContextPacket {
+      const id = createContextPacketId(`pre${packetSeq++}`);
+      const packet: ContextPacket = {
+        id,
+        kind: input.kind,
+        ...(input.anchor !== undefined ? { anchor: input.anchor } : {}),
+        ...(input.fileRef !== undefined ? { fileRef: input.fileRef } : {}),
+        ...(input.note !== undefined ? { note: input.note } : {}),
+        ...(input.binding !== undefined ? { binding: input.binding } : {}),
+        createdBy: input.createdBy,
+        createdAt: new Date().toISOString(),
+      };
+      packets.set(id, packet);
+      return packet;
+    },
+    getPacket(id: string): ContextPacket | null {
+      return packets.get(id) ?? null;
+    },
+    listPackets(filter?: ListContextPacketsFilter): ContextPacket[] {
+      let all = [...packets.values()];
+      if (filter?.limit !== undefined) all = all.slice(0, filter.limit);
+      return all;
+    },
+    createInboxMessage(input: CreateInboxMessageInput): SessionInboxMessage {
+      const id = createInboxMessageId(`pre${messageSeq++}`);
+      const message: SessionInboxMessage = {
+        id,
+        ...(input.targetSessionId ? { targetSessionId: input.targetSessionId } : {}),
+        ...(input.targetWorkContextId
+          ? { targetWorkContextId: input.targetWorkContextId }
+          : {}),
+        contextPacketIds: input.contextPacketIds,
+        ...(input.text !== undefined ? { text: input.text } : {}),
+        state: 'queued',
+        createdBy: input.createdBy,
+        createdAt: new Date().toISOString(),
+      };
+      messages.set(id, message);
+      return message;
+    },
+    listInboxMessages(filter: ListInboxMessagesFilter): SessionInboxMessage[] {
+      let all = [...messages.values()];
+      if (filter.targetSessionId) {
+        all = all.filter((m) => m.targetSessionId === filter.targetSessionId);
+      }
+      if (filter.targetWorkContextId) {
+        all = all.filter(
+          (m) => m.targetWorkContextId === filter.targetWorkContextId
+        );
+      }
+      if (filter.state) all = all.filter((m) => m.state === filter.state);
+      all = all.map((m) => deliverOnPull(m));
+      if (filter.limit !== undefined) all = all.slice(0, filter.limit);
+      return all;
+    },
+    getInboxMessage(id: string): SessionInboxMessage | null {
+      const message = messages.get(id);
+      if (!message) return null;
+      return deliverOnPull(message);
+    },
+    updateInboxState(
+      id: string,
+      targetState: SessionInboxMessageState
+    ): UpdateInboxStateResult {
+      const message = messages.get(id);
+      if (!message) return { ok: false, reason: 'not_found' };
+      if (TERMINAL.has(message.state)) {
+        return { ok: false, reason: 'terminal', currentState: message.state };
+      }
+      const updated: SessionInboxMessage = { ...message, state: targetState };
+      messages.set(id, updated);
+      return { ok: true, message: updated };
+    },
+  };
+}
+
+function runPreturn(
+  preturnArgs: string[],
+  env: NodeJS.ProcessEnv
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    execFile(
+      process.execPath,
+      [RELAYCTL_BIN, 'agent', 'preturn', ...preturnArgs],
+      { encoding: 'utf-8', timeout: 15_000, env },
+      (error, stdout, stderr) => {
+        const code =
+          error && typeof (error as { code?: unknown }).code === 'number'
+            ? (error as { code: number }).code
+            : 0;
+        resolve({ code, stdout, stderr });
+      }
+    );
+  });
+}
+
+let server: Server;
+let baseUrl: string;
+let store: ReturnType<typeof createFakeStore>;
+
+beforeEach(async () => {
+  store = createFakeStore();
+  const app = express();
+  app.use(express.json());
+  app.use(
+    createContextInboxRouter({
+      // Auth is handled upstream by requireCliGatewayAuth in production; the
+      // router itself only enforces the capability header, which relayctl sends.
+      requireAuth: (_req, _res, next) => next(),
+      store,
+    })
+  );
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as { port: number };
+      baseUrl = `http://127.0.0.1:${addr.port}`;
+      resolve();
+    });
+  });
+});
+
+afterEach(async () => {
+  await new Promise<void>((resolve) => server?.close(() => resolve()));
+});
+
+describe('relayctl agent preturn', () => {
+  const SESSION_ID = 'node1:sess-preturn';
+
+  function seedPendingInbox(): { messageId: string } {
+    const packet = store.createPacket({
+      kind: 'note',
+      note: 'check the failing assertion in foo.test.ts',
+      createdBy: 'human_1',
+    });
+    const message = store.createInboxMessage({
+      targetSessionId: SESSION_ID,
+      contextPacketIds: [packet.id],
+      text: 'please look at this before your next turn',
+      createdBy: 'human_1',
+    });
+    return { messageId: message.id };
+  }
+
+  it('renders pending inbox as markdown (default) and PULL-flips queued → delivered', async () => {
+    const { messageId } = seedPendingInbox();
+    expect(store.raw().find((m) => m.id === messageId)?.state).toBe('queued');
+
+    const { code, stdout } = await runPreturn([], {
+      ...process.env,
+      RELAY_HUB_URL: baseUrl,
+      RELAY_SESSION_ID: SESSION_ID,
+    });
+
+    expect(code).toBe(0);
+    expect(stdout).toContain('Relay pending context');
+    expect(stdout).toContain(SESSION_ID);
+    expect(stdout).toContain('1 pending message');
+    expect(stdout).toContain('please look at this before your next turn');
+    expect(stdout).toContain('check the failing assertion in foo.test.ts');
+    // PULL semantics: fetching delivered the message.
+    expect(store.raw().find((m) => m.id === messageId)?.state).toBe('delivered');
+  });
+
+  it('does not ack/resolve — only delivers (rendering != resolution)', async () => {
+    const { messageId } = seedPendingInbox();
+    await runPreturn([], {
+      ...process.env,
+      RELAY_HUB_URL: baseUrl,
+      RELAY_SESSION_ID: SESSION_ID,
+    });
+    // Never advanced past `delivered`.
+    const state = store.raw().find((m) => m.id === messageId)?.state;
+    expect(state).toBe('delivered');
+    expect(state).not.toBe('acknowledged');
+    expect(state).not.toBe('resolved');
+  });
+
+  it('renders machine-readable json with --format json', async () => {
+    seedPendingInbox();
+    const { code, stdout } = await runPreturn(['--format', 'json'], {
+      ...process.env,
+      RELAY_HUB_URL: baseUrl,
+      RELAY_SESSION_ID: SESSION_ID,
+    });
+    expect(code).toBe(0);
+    const parsed = JSON.parse(stdout) as {
+      sessionId: string;
+      pendingCount: number;
+      messages: Array<{ state: string }>;
+      contextPackets: Array<{ kind: string }>;
+    };
+    expect(parsed.sessionId).toBe(SESSION_ID);
+    expect(parsed.pendingCount).toBe(1);
+    expect(parsed.messages[0]?.state).toBe('delivered');
+    expect(parsed.contextPackets[0]?.kind).toBe('note');
+  });
+
+  it('honours --session override outside the env-injected session', async () => {
+    const { messageId } = seedPendingInbox();
+    // No RELAY_SESSION_ID in env — proves the gateway/explicit path.
+    const env = { ...process.env, RELAY_HUB_URL: baseUrl };
+    delete env.RELAY_SESSION_ID;
+    const { code, stdout } = await runPreturn(['--session', SESSION_ID], env);
+    expect(code).toBe(0);
+    expect(stdout).toContain(SESSION_ID);
+    expect(store.raw().find((m) => m.id === messageId)?.state).toBe('delivered');
+  });
+
+  it('renders an empty-inbox message when nothing is pending', async () => {
+    const { code, stdout } = await runPreturn([], {
+      ...process.env,
+      RELAY_HUB_URL: baseUrl,
+      RELAY_SESSION_ID: 'node1:empty',
+    });
+    expect(code).toBe(0);
+    expect(stdout).toContain('No pending inbox messages.');
+  });
+
+  it('fails clean when not running inside a Relay session (no env, no --session)', async () => {
+    const env = { ...process.env };
+    delete env.RELAY_HUB_URL;
+    delete env.RELAY_SESSION_ID;
+    const { code, stderr } = await runPreturn([], env);
+    expect(code).toBe(1);
+    expect(stderr).toContain('not running inside a relay session');
+    expect(stderr).toContain('RELAY_HUB_URL');
+  });
+
+  it('rejects an unknown --format value', async () => {
+    const { code, stderr } = await runPreturn(['--format', 'yaml'], {
+      ...process.env,
+      RELAY_HUB_URL: baseUrl,
+      RELAY_SESSION_ID: SESSION_ID,
+    });
+    expect(code).toBe(1);
+    expect(stderr).toContain("--format must be 'markdown' or 'json'");
+  });
+});


### PR DESCRIPTION
relayctl agent preturn — headless inbox read (the agent proof of the CLI-first loop). fugu-approved + kame QA-verified in the #757 MVP stack; prior PR #776 auto-closed on base-branch deletion — re-targeted to nightly. Closes #761.

🤖 Generated with [Claude Code](https://claude.com/claude-code)