### PR TITLE
fix(#752,#773): atomic workspace ops + bench dedup/fan-out

### DIFF
--- a/frontend/src/components/BenchCreate.tsx
+++ b/frontend/src/components/BenchCreate.tsx
@@ -4,24 +4,25 @@
 // absolute cwd. Flag-gated by its only mount point (`ViewSpineTree`, which is
 // only rendered when `viewSpineEnabled`).
 //
-// Wired to the #735 `/hub/ia/benches` CRUD API via `useIaBenches`. Renders the
-// PERSISTED bench overlays (so a freshly-created bench appears under its
-// Instance) plus the create form. Scope: CREATE + minimal DELETE; env-override
-// INHERITANCE into tabs is out of scope (#740).
+// Wired to the #735 `/hub/ia/benches` CRUD API via `useIaBenchMutations`. This
+// component owns the CREATE form + the "+ bench" affordance ONLY. The PERSISTED
+// overlay rows are rendered by `InstanceRow` (`ViewSpineTree`) as part of the
+// #773 derived-vs-overlay dedup (one row per cwd), so this component no longer
+// renders a separate overlay list. Scope: CREATE + minimal DELETE (delete is
+// invoked from the merged row); env-override INHERITANCE into tabs is out of
+// scope (#740).
 //
 // C1 (from #735 review): a bench `cwd` is sent and displayed VERBATIM — never
 // `decodeURIComponent`-ed. The raw absolute path the user enters is the path the
 // hub mints the BenchId from.
 //
-// States: empty (no overlays → no list, just the affordance), loading, error
-// (non-destructive inline message + refetch), in-flight (form disabled while a
-// create/delete is pending), validation (cwd rejected client-side mirroring the
-// server). Touch targets ≥44px; full keyboard support (Enter submits, Escape
-// cancels).
+// States: error (non-destructive inline message + refetch), in-flight (form
+// disabled while a create/delete is pending), validation (cwd rejected
+// client-side mirroring the server). Touch targets ≥44px; full keyboard support
+// (Enter submits, Escape cancels).
 import { useMemo, useState } from 'react';
 
-import type { IaBench } from '../lib/api.js';
-import { useIaBenches } from '../lib/hooks/use-ia-benches.js';
+import { useIaBenchMutations } from '../lib/hooks/use-ia-benches.js';
 import {
   benchCwdErrorMessage,
   buildBenchPayload,
@@ -30,7 +31,6 @@ import {
 } from '../lib/state/bench-create.js';
 import type { ViewTreeProject } from '../lib/state/view-tree.js';
 import { createLogger } from '../lib/logger.js';
-import { MarqueeText } from './MarqueeText.js';
 import './BenchCreate.css';
 
 const logger = createLogger('bench-create');
@@ -39,55 +39,7 @@ function errorMessage(err: unknown, fallback: string): string {
   return err instanceof Error && err.message ? err.message : fallback;
 }
 
-/** A persisted overlay row. cwd is shown VERBATIM (C1). Label falls back to the
- *  last cwd segment when the overlay carries no explicit label. */
-function BenchOverlayRow({
-  bench,
-  busy,
-  onDelete,
-}: {
-  bench: IaBench;
-  busy: boolean;
-  onDelete: () => void;
-}) {
-  const fallbackLabel =
-    bench.cwd.replace(/[\\/]+$/, '').split(/[\\/]/).pop() || bench.cwd;
-  const label = bench.label && bench.label.length > 0 ? bench.label : fallbackLabel;
-  const envCount = Object.keys(bench.envOverrides).length;
-  return (
-    <li className="session-row inactive state-inactive view-spine-bench bench-overlay-row">
-      <div className="session-row-primary">
-        <span className="session-name">
-          <MarqueeText>{label}</MarqueeText>
-        </span>
-        {envCount > 0 ? (
-          <span className="bench-overlay-env-badge" title={`${envCount} env override(s)`}>
-            env {envCount}
-          </span>
-        ) : null}
-        <button
-          type="button"
-          className="bench-overlay-delete"
-          disabled={busy}
-          onClick={onDelete}
-          aria-label={`delete bench ${label}`}
-          title="delete bench"
-        >
-          ×
-        </button>
-      </div>
-      {/* cwd shown verbatim — the raw absolute path, never decoded (C1). */}
-      <div className="session-row-secondary">
-        <span className="bench-overlay-cwd">
-          <MarqueeText>{bench.cwd}</MarqueeText>
-        </span>
-      </div>
-    </li>
-  );
-}
-
 interface BenchCreateFormProps {
-  instanceId: string;
   projectKind: ViewTreeProject['kind'];
   defaultCwd: string;
   busy: boolean;
@@ -100,7 +52,6 @@ interface BenchCreateFormProps {
 }
 
 function BenchCreateForm({
-  instanceId: _instanceId,
   projectKind,
   defaultCwd,
   busy,
@@ -272,25 +223,22 @@ export function BenchCreate({
   instanceId,
   projectKind,
   defaultCwd,
+  onRefetch,
 }: {
   instanceId: string;
   projectKind: ViewTreeProject['kind'];
   /** Pre-filled cwd for a repo-instance (the parent repo path); empty for a
    *  node-instance (arbitrary absolute cwd). */
   defaultCwd: string;
+  /** Refetch the (tree-level) bench cache — used to reconcile after a failed
+   *  create. The list itself is owned by `InstanceRow` (#773 single query). */
+  onRefetch: () => void;
 }) {
-  const {
-    benches,
-    isLoading,
-    isError,
-    refetch,
-    createMutation,
-    deleteMutation,
-  } = useIaBenches(instanceId);
+  const { createMutation } = useIaBenchMutations(instanceId);
   const [open, setOpen] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
 
-  const busy = createMutation.isPending || deleteMutation.isPending;
+  const busy = createMutation.isPending;
 
   function clearError() {
     setActionError(null);
@@ -319,36 +267,10 @@ export function BenchCreate({
     });
   }
 
-  function handleDelete(bench: IaBench) {
-    clearError();
-    deleteMutation.mutate(bench.id, {
-      onError: (err) => {
-        logger.warn('delete bench failed', err);
-        setActionError(errorMessage(err, 'could not delete bench'));
-      },
-    });
-  }
-
   return (
     <div className="bench-create">
-      {isLoading ? (
-        <div className="bench-create-hint">loading benches…</div>
-      ) : benches.length > 0 ? (
-        <ul className="session-list view-spine-bench-list bench-overlay-list">
-          {benches.map((bench) => (
-            <BenchOverlayRow
-              key={bench.id}
-              bench={bench}
-              busy={busy}
-              onDelete={() => handleDelete(bench)}
-            />
-          ))}
-        </ul>
-      ) : null}
-
       {open ? (
         <BenchCreateForm
-          instanceId={instanceId}
           projectKind={projectKind}
           defaultCwd={defaultCwd}
           busy={busy}
@@ -383,19 +305,8 @@ export function BenchCreate({
             className="bench-create-retry"
             onClick={() => {
               clearError();
-              void refetch();
+              onRefetch();
             }}
-          >
-            retry
-          </button>
-        </div>
-      ) : isError ? (
-        <div className="bench-create-error" role="alert">
-          <span>could not load benches</span>
-          <button
-            type="button"
-            className="bench-create-retry"
-            onClick={() => void refetch()}
           >
             retry
           </button>

--- a/frontend/src/components/ViewSpineTree.tsx
+++ b/frontend/src/components/ViewSpineTree.tsx
@@ -13,21 +13,35 @@ import {
   applyLens,
   benchCreatePayload,
   buildViewTree,
+  groupBenchOverlaysByInstance,
   groupProjectsByWorkspace,
+  mergeInstanceBenches,
   DEFAULT_VIEW_LENS,
   type BenchCreatePayload,
+  type BenchOverlayInput,
   type InstanceHostStatus,
+  type MergedBench,
   type ViewLens,
-  type ViewTreeBench,
   type ViewTreeFreeEntry,
   type ViewTreeInstance,
   type ViewTreeProject,
   type ViewTreeNodeStatus,
 } from '../lib/state/view-tree.js';
 import { useIaWorkspaces } from '../lib/hooks/use-ia-workspaces.js';
+import {
+  useIaBenchesAll,
+  useIaBenchMutations,
+} from '../lib/hooks/use-ia-benches.js';
 import { WorkspaceBar } from './WorkspaceBar.js';
 import { BenchCreate } from './BenchCreate.js';
+import { createLogger } from '../lib/logger.js';
 import './ViewSpineTree.css';
+
+const logger = createLogger('view-spine-tree');
+
+function benchErrorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error && err.message ? err.message : fallback;
+}
 
 /** Create a Tab anchored to a Bench's (nodeId, cwd). Wired to the EXISTING
  *  node-aware session-create entrypoint by `App` — NOT a new create flow, and
@@ -53,25 +67,37 @@ function CountBadge({ count }: { count: number }) {
   return <span className="session-count-badge">{count}</span>;
 }
 
+// #773: one row per cwd, fusing a derived worktree bench with a persisted
+// overlay sharing that cwd. Renders the union: branch + tab count + "+ tab"
+// (when a derived worktree backs it), env badge + delete (when an overlay backs
+// it), and the verbatim cwd secondary line for overlay-backed rows.
 function BenchRow({
   instance,
-  bench,
+  merged,
+  busy,
   onCreateTab,
+  onDeleteOverlay,
 }: {
   instance: ViewTreeInstance;
-  bench: ViewTreeBench;
+  merged: MergedBench;
+  /** Overlay delete in flight (disables this row's delete affordance). */
+  busy: boolean;
   onCreateTab?: ViewSpineCreateTab | undefined;
+  /** Delete the persisted overlay backing this row. Only invoked when
+   *  `merged.overlayId` is set. */
+  onDeleteOverlay: (overlayId: string) => void;
 }) {
+  const { bench } = merged;
   // Per-bench in-flight guard so the affordance disables itself (and other
   // benches stay clickable) while a create is pending. Errors surface through
   // the existing create path's toast — no bespoke error UI here.
   const [creating, setCreating] = useState(false);
   // Resolve the create payload up front. `null` for a non-git/directory bench
-  // (no config.repos anchor → agent session impossible), which withholds the
-  // "+ tab" affordance entirely. Memoized so the render decision and the click
-  // handler agree.
+  // OR an overlay-only row (no derived worktree → no config.repos anchor), which
+  // withholds the "+ tab" affordance entirely. Memoized so the render decision
+  // and the click handler agree.
   const createPayload = useMemo(
-    () => benchCreatePayload(instance, bench),
+    () => (bench ? benchCreatePayload(instance, bench) : null),
     [instance, bench]
   );
   const handleCreate = useCallback(async () => {
@@ -86,27 +112,72 @@ function BenchRow({
     }
   }, [onCreateTab, createPayload, creating]);
 
+  const envCount = Object.keys(merged.envOverrides).length;
+  const isOverlay = merged.overlayId !== null;
+  const showBranch = bench?.isGit && bench.branch;
+  // The verbatim cwd line is shown for overlay-backed rows (so the user sees the
+  // raw absolute path they entered, C1). A derived-only git row shows its branch
+  // instead (no cwd leak beyond the existing #731 behaviour).
+  const showCwd = isOverlay;
+
   return (
-    <li className="session-row inactive state-inactive view-spine-bench">
+    <li
+      className={[
+        'session-row inactive state-inactive view-spine-bench',
+        isOverlay && 'bench-overlay-row',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
       <div className="session-row-primary">
         <span className="session-name">
-          <MarqueeText>{bench.label}</MarqueeText>
+          <MarqueeText>{merged.label}</MarqueeText>
         </span>
-        <CountBadge count={bench.tab.count} />
+        {bench ? <CountBadge count={bench.tab.count} /> : null}
+        {envCount > 0 ? (
+          <span
+            className="bench-overlay-env-badge"
+            title={`${envCount} env override(s)`}
+          >
+            env {envCount}
+          </span>
+        ) : null}
+        {isOverlay ? (
+          <button
+            type="button"
+            className="bench-overlay-delete"
+            disabled={busy}
+            onClick={() => merged.overlayId && onDeleteOverlay(merged.overlayId)}
+            aria-label={`delete bench ${merged.label}`}
+            title="delete bench"
+          >
+            ×
+          </button>
+        ) : null}
       </div>
       {/* `.secondary-branch` is rendered ONLY for git benches. Directory
           benches omit the element entirely (no branch leakage). */}
-      {bench.isGit && bench.branch ? (
+      {showBranch ? (
         <div className="session-row-secondary">
           <span className="secondary-branch">
-            <MarqueeText>{bench.branch}</MarqueeText>
+            <MarqueeText>{bench!.branch}</MarqueeText>
+          </span>
+        </div>
+      ) : null}
+      {/* cwd shown verbatim for overlay-backed rows — the raw absolute path,
+          never decoded (C1). */}
+      {showCwd ? (
+        <div className="session-row-secondary">
+          <span className="bench-overlay-cwd">
+            <MarqueeText>{merged.cwd}</MarqueeText>
           </span>
         </div>
       ) : null}
       {/* #731 "+ tab" anchored to THIS bench's (nodeId, repoPath, worktree).
           Reuses the `.add-worktree-row`/`.add-worktree-btn` styling ONLY — it
           wires to session/tab CREATION, NOT worktree creation (distinct copy
-          `+ tab`). Withheld for non-git benches (no agent-capable repo anchor). */}
+          `+ tab`). Withheld for non-git/overlay-only benches (no agent-capable
+          repo anchor). */}
       {onCreateTab && createPayload ? (
         <div
           className={['add-worktree-row', creating && 'disabled']
@@ -143,12 +214,44 @@ function defaultBenchCwd(
 function InstanceRow({
   instance,
   projectKind,
+  overlays,
   onCreateTab,
+  onRefetchBenches,
 }: {
   instance: ViewTreeInstance;
   projectKind: ViewTreeProject['kind'];
+  /** Persisted bench overlays for THIS instance, pre-grouped from the single
+   *  tree-level `GET /hub/ia/benches` (#773 — no per-instance fan-out). */
+  overlays: BenchOverlayInput[];
   onCreateTab?: ViewSpineCreateTab | undefined;
+  /** Refetch the tree-level bench cache (reconcile after a failed mutation). */
+  onRefetchBenches: () => void;
 }) {
+  // #773: delete lives here (next to the merged row's delete affordance). The
+  // create flow stays in `BenchCreate`. Both invalidate the shared bench cache.
+  const { deleteMutation } = useIaBenchMutations(instance.id);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  // #773: fuse derived worktree benches with persisted overlays by cwd → one row
+  // per cwd (overlay preferred, derived branch/tab/anchor inherited).
+  const merged = useMemo(
+    () => mergeInstanceBenches(instance.benches, overlays),
+    [instance.benches, overlays]
+  );
+
+  const handleDeleteOverlay = useCallback(
+    (overlayId: string) => {
+      setDeleteError(null);
+      deleteMutation.mutate(overlayId, {
+        onError: (err) => {
+          logger.warn('delete bench failed', err);
+          setDeleteError(benchErrorMessage(err, 'could not delete bench'));
+        },
+      });
+    },
+    [deleteMutation]
+  );
+
   return (
     <li className="session-row view-spine-instance">
       <div className="session-row-primary">
@@ -163,17 +266,34 @@ function InstanceRow({
         </span>
         <CountBadge count={instance.rootTab.count} />
       </div>
-      {instance.benches.length > 0 ? (
+      {merged.length > 0 ? (
         <ul className="session-list view-spine-bench-list">
-          {instance.benches.map((bench) => (
+          {merged.map((row) => (
             <BenchRow
-              key={bench.id}
+              key={row.cwd}
               instance={instance}
-              bench={bench}
+              merged={row}
+              busy={deleteMutation.isPending}
               onCreateTab={onCreateTab}
+              onDeleteOverlay={handleDeleteOverlay}
             />
           ))}
         </ul>
+      ) : null}
+      {deleteError ? (
+        <div className="bench-create-error" role="alert">
+          <span>{deleteError}</span>
+          <button
+            type="button"
+            className="bench-create-retry"
+            onClick={() => {
+              setDeleteError(null);
+              onRefetchBenches();
+            }}
+          >
+            retry
+          </button>
+        </div>
       ) : null}
       {/* #730 "+ bench": persisted bench overlays (cwd + env) for this instance
           plus the create flow. Wired to the #735 `/hub/ia/benches` CRUD API. */}
@@ -181,6 +301,7 @@ function InstanceRow({
         instanceId={instance.id}
         projectKind={projectKind}
         defaultCwd={defaultBenchCwd(instance, projectKind)}
+        onRefetch={onRefetchBenches}
       />
     </li>
   );
@@ -232,11 +353,16 @@ function ProjectAssignSelect({
 
 function ProjectRow({
   project,
+  overlaysByInstance,
   onCreateTab,
+  onRefetchBenches,
   assign,
 }: {
   project: ViewTreeProject;
+  /** Persisted bench overlays grouped by instanceId (#773 single query). */
+  overlaysByInstance: Map<string, BenchOverlayInput[]>;
   onCreateTab?: ViewSpineCreateTab | undefined;
+  onRefetchBenches: () => void;
   assign?: ProjectAssignControl | undefined;
 }) {
   const initialColor = useMemo(
@@ -283,7 +409,9 @@ function ProjectRow({
             key={instance.id}
             instance={instance}
             projectKind={project.kind}
+            overlays={overlaysByInstance.get(instance.id) ?? []}
             onCreateTab={onCreateTab}
+            onRefetchBenches={onRefetchBenches}
           />
         ))}
       </ul>
@@ -444,6 +572,18 @@ export function ViewSpineTree({
 
   const tree = useMemo(() => applyLens(derived, lens), [derived, lens]);
 
+  // #773: ONE unfiltered `GET /hub/ia/benches` for the whole tree (no
+  // per-instance fan-out), grouped by instanceId client-side and passed down to
+  // each `InstanceRow`. Reconcile on a failed bench mutation via `refetch`.
+  const { data: allBenches, refetch: refetchBenches } = useIaBenchesAll();
+  const overlaysByInstance = useMemo(
+    () => groupBenchOverlaysByInstance((allBenches ?? []) as BenchOverlayInput[]),
+    [allBenches]
+  );
+  const onRefetchBenches = useCallback(() => {
+    void refetchBenches();
+  }, [refetchBenches]);
+
   // #728: the persisted six-layer Workspace layer (#733 CRUD). The bar manages
   // workspace lifecycle; here we OVERLAY persisted membership on the derived
   // tree. All derived projects (from the legacy workspace groups + the legacy
@@ -451,8 +591,19 @@ export function ViewSpineTree({
   // RE-grouped by persisted `projectIds`. Unassigned projects fall back to
   // ungrouped. NO legacy auto-import: the legacy `workspaceGroups` grouping is
   // collapsed away for render, never migrated into persisted Workspaces.
-  const { workspaces: persistedWorkspaces, updateMutation } = useIaWorkspaces();
-  const assignBusy = updateMutation.isPending;
+  const {
+    workspaces: persistedWorkspaces,
+    updateMutation,
+    refetch: refetchWorkspaces,
+  } = useIaWorkspaces();
+  // #752: a project-assign sequences TWO PATCHes (remove from source, append to
+  // target). They're not individually optimistic, so guard the whole sequence
+  // with one in-flight flag and reconcile via a single refetch at the end. A
+  // separate flag (not `updateMutation.isPending`) keeps the controls disabled
+  // across BOTH awaited PATCHes, not just whichever is currently in flight.
+  const [assignInFlight, setAssignInFlight] = useState(false);
+  const [assignError, setAssignError] = useState<string | null>(null);
+  const assignBusy = updateMutation.isPending || assignInFlight;
 
   const flatProjects = useMemo(
     () => [
@@ -487,46 +638,71 @@ export function ViewSpineTree({
     [persistedWorkspaces]
   );
 
-  // Move a project into `targetWorkspaceId` (or '' to ungroup). PATCHes the
-  // membership of the source (remove) and target (append) workspaces. The
-  // membership list is replaced wholesale per the #733 contract.
+  // #752: Move a project into `targetWorkspaceId` (or '' to ungroup). This is a
+  // SEQUENCED two-PATCH op: remove the project from its current owner, then
+  // append it to the target. The PATCHes are awaited in order via `mutateAsync`
+  // with a SINGLE guarded refetch at the end — never per-mutation invalidation
+  // (which could refetch between the two PATCHes and flicker, or drop/duplicate
+  // the project mid-sequence). On partial failure we surface a clear error AND
+  // refetch to reconcile, so a moved project never silently desyncs.
   const assignProjectTo = useCallback(
-    (projectId: string, targetWorkspaceId: string) => {
+    async (projectId: string, targetWorkspaceId: string) => {
       const currentId = workspaceIdByProject.get(projectId) ?? '';
       if (currentId === targetWorkspaceId) return;
-      // Remove from the current owner (if any).
-      if (currentId) {
-        const source = persistedWorkspaces.find((w) => w.id === currentId);
-        if (source) {
-          updateMutation.mutate({
-            id: source.id,
-            patch: {
-              projectIds: source.projectIds.filter((id) => id !== projectId),
-            },
-          });
+      if (assignInFlight) return;
+      setAssignError(null);
+      setAssignInFlight(true);
+      try {
+        // Remove from the current owner (if any). The membership list is
+        // replaced wholesale per the #733 contract.
+        if (currentId) {
+          const source = persistedWorkspaces.find((w) => w.id === currentId);
+          if (source) {
+            await updateMutation.mutateAsync({
+              id: source.id,
+              patch: {
+                projectIds: source.projectIds.filter((id) => id !== projectId),
+              },
+            });
+          }
         }
-      }
-      // Append to the target (if not ungrouping). Guard against dupes.
-      if (targetWorkspaceId) {
-        const target = persistedWorkspaces.find(
-          (w) => w.id === targetWorkspaceId
+        // Append to the target (if not ungrouping). Guard against dupes.
+        if (targetWorkspaceId) {
+          const target = persistedWorkspaces.find(
+            (w) => w.id === targetWorkspaceId
+          );
+          if (target && !target.projectIds.includes(projectId)) {
+            await updateMutation.mutateAsync({
+              id: target.id,
+              patch: { projectIds: [...target.projectIds, projectId] },
+            });
+          }
+        }
+      } catch (err) {
+        logger.warn('assign project to workspace failed', err);
+        setAssignError(
+          benchErrorMessage(err, 'could not move project to workspace')
         );
-        if (target && !target.projectIds.includes(projectId)) {
-          updateMutation.mutate({
-            id: target.id,
-            patch: { projectIds: [...target.projectIds, projectId] },
-          });
-        }
+      } finally {
+        // One refetch reconciles whatever landed (full success OR partial).
+        setAssignInFlight(false);
+        void refetchWorkspaces();
       }
     },
-    [persistedWorkspaces, updateMutation, workspaceIdByProject]
+    [
+      persistedWorkspaces,
+      updateMutation,
+      workspaceIdByProject,
+      assignInFlight,
+      refetchWorkspaces,
+    ]
   );
 
   const makeAssign = useCallback(
     (project: ViewTreeProject): ProjectAssignControl => ({
       options: assignOptions,
       currentWorkspaceId: workspaceIdByProject.get(project.id) ?? '',
-      onAssign: (workspaceId) => assignProjectTo(project.id, workspaceId),
+      onAssign: (workspaceId) => void assignProjectTo(project.id, workspaceId),
       busy: assignBusy,
     }),
     [assignOptions, workspaceIdByProject, assignProjectTo, assignBusy]
@@ -588,6 +764,21 @@ export function ViewSpineTree({
       {selector}
       <WorkspaceBar />
       <div className="view-spine-scroll">
+        {assignError ? (
+          <div className="bench-create-error" role="alert">
+            <span>{assignError}</span>
+            <button
+              type="button"
+              className="bench-create-retry"
+              onClick={() => {
+                setAssignError(null);
+                void refetchWorkspaces();
+              }}
+            >
+              retry
+            </button>
+          </div>
+        ) : null}
         {grouped.workspaces.map((ws) =>
           ws.projects.length > 0 ? (
             <section key={ws.id} className="view-spine-workspace">
@@ -596,7 +787,9 @@ export function ViewSpineTree({
                 <ProjectRow
                   key={project.id}
                   project={project}
+                  overlaysByInstance={overlaysByInstance}
                   onCreateTab={onCreateTab}
+                  onRefetchBenches={onRefetchBenches}
                   assign={makeAssign(project)}
                 />
               ))}
@@ -613,7 +806,9 @@ export function ViewSpineTree({
               <ProjectRow
                 key={project.id}
                 project={project}
+                overlaysByInstance={overlaysByInstance}
                 onCreateTab={onCreateTab}
+                onRefetchBenches={onRefetchBenches}
                 assign={makeAssign(project)}
               />
             ))}

--- a/frontend/src/components/WorkspaceBar.css
+++ b/frontend/src/components/WorkspaceBar.css
@@ -204,7 +204,8 @@
   font-family: var(--font-mono, monospace);
   font-size: var(--font-size-xs);
   padding: 2px 4px;
-  min-height: 28px;
+  /* #752: meet the ≥44px touch target the row icon buttons already use. */
+  min-height: 44px;
   cursor: pointer;
   outline: none;
   max-width: 120px;

--- a/frontend/src/components/WorkspaceBar.tsx
+++ b/frontend/src/components/WorkspaceBar.tsx
@@ -136,12 +136,16 @@ export function WorkspaceBar() {
     isLoading,
     isError,
     refetch,
+    invalidate,
     createMutation,
     updateMutation,
     deleteMutation,
   } = useIaWorkspaces();
   const [newName, setNewName] = useState('');
   const [actionError, setActionError] = useState<string | null>(null);
+  // #752: a reorder sequences TWO PATCHes; this flag keeps the controls disabled
+  // across BOTH (not just the one currently in flight) until the single refetch.
+  const [reordering, setReordering] = useState(false);
 
   // Any pending mutation disables the controls (in-flight guard). Ordered by
   // `order` asc then id (the API already returns this order, but re-sort defends
@@ -149,7 +153,8 @@ export function WorkspaceBar() {
   const pending =
     createMutation.isPending ||
     updateMutation.isPending ||
-    deleteMutation.isPending;
+    deleteMutation.isPending ||
+    reordering;
   const ordered = [...workspaces].sort(
     (a, b) => a.order - b.order || a.id.localeCompare(b.id)
   );
@@ -176,9 +181,12 @@ export function WorkspaceBar() {
 
   function handleRename(workspace: IaWorkspace, name: string) {
     clearError();
+    // Single-op update: invalidate explicitly on success (the hook no longer
+    // auto-invalidates `update`, since reorder/assign sequence two PATCHes).
     updateMutation.mutate(
       { id: workspace.id, patch: { name } },
       {
+        onSuccess: invalidate,
         onError: (err) => {
           logger.warn('rename workspace failed', err);
           setActionError(errorMessage(err, 'could not rename workspace'));
@@ -187,28 +195,28 @@ export function WorkspaceBar() {
     );
   }
 
-  // Reorder by swapping the `order` of two adjacent workspaces. Two PATCHes;
-  // correctness-first (no optimistic UI). The list invalidates and refetches.
-  function handleSwap(a: IaWorkspace, b: IaWorkspace) {
+  // #752: Reorder by swapping the `order` of two adjacent workspaces. The two
+  // PATCHes are SEQUENCED via `mutateAsync` (await the first, then the second)
+  // with a SINGLE guarded refetch at the end — never per-mutation invalidation
+  // (which would refetch between the PATCHes and flicker, or surface equal
+  // `order`). On partial failure (PATCH 1 ok, PATCH 2 throws) we surface a clear
+  // error AND refetch to reconcile, so the list never silently desyncs.
+  async function handleSwap(a: IaWorkspace, b: IaWorkspace) {
+    if (pending) return;
     clearError();
-    updateMutation.mutate(
-      { id: a.id, patch: { order: b.order } },
-      {
-        onError: (err) => {
-          logger.warn('reorder workspace failed', err);
-          setActionError(errorMessage(err, 'could not reorder workspace'));
-        },
-      }
-    );
-    updateMutation.mutate(
-      { id: b.id, patch: { order: a.order } },
-      {
-        onError: (err) => {
-          logger.warn('reorder workspace failed', err);
-          setActionError(errorMessage(err, 'could not reorder workspace'));
-        },
-      }
-    );
+    setReordering(true);
+    try {
+      await updateMutation.mutateAsync({ id: a.id, patch: { order: b.order } });
+      await updateMutation.mutateAsync({ id: b.id, patch: { order: a.order } });
+    } catch (err) {
+      logger.warn('reorder workspace failed', err);
+      setActionError(errorMessage(err, 'could not reorder workspace'));
+    } finally {
+      // One refetch reconciles whatever landed (full success OR partial), so the
+      // UI always reflects authoritative store state.
+      setReordering(false);
+      void refetch();
+    }
   }
 
   function handleDelete(workspace: IaWorkspace) {
@@ -245,11 +253,11 @@ export function WorkspaceBar() {
               onRename={(name) => handleRename(ws, name)}
               onMoveUp={() => {
                 const prev = ordered[index - 1];
-                if (prev) handleSwap(ws, prev);
+                if (prev) void handleSwap(ws, prev);
               }}
               onMoveDown={() => {
                 const next = ordered[index + 1];
-                if (next) handleSwap(ws, next);
+                if (next) void handleSwap(ws, next);
               }}
               onDelete={() => handleDelete(ws)}
             />

--- a/frontend/src/lib/hooks/use-ia-benches.ts
+++ b/frontend/src/lib/hooks/use-ia-benches.ts
@@ -1,10 +1,14 @@
 // #730: TanStack Query data layer for Bench overlays (#735 `/hub/ia/benches`).
-// Mirrors `use-ia-workspaces.ts`: a per-instance list query plus create/delete
-// mutations that invalidate that instance's key on success.
+// Mirrors `use-ia-workspaces.ts`: a list query plus create/delete mutations that
+// invalidate the bench cache on success.
 //
-// Correctness-first: no optimistic cache writes. Each mutation invalidates the
-// relevant `['ia-benches', instanceId]` key so the list refetches authoritative
-// state from the store and the new overlay appears under its Instance.
+// #773 fan-out fix: the tree fetches ALL overlays ONCE (`useIaBenchesAll`, an
+// unfiltered `GET /hub/ia/benches`) and groups by instanceId client-side,
+// replacing the previous N per-instance GETs (one per `InstanceRow`). Mutations
+// now invalidate the WHOLE `['ia-benches']` family so both the unfiltered list
+// and any legacy per-instance reader stay coherent.
+//
+// Correctness-first: no optimistic cache writes.
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
@@ -14,10 +18,19 @@ import {
   type IaBench,
 } from '../api.js';
 
+/** Root key for the bench-overlay cache family. Invalidating it refetches both
+ *  the unfiltered list and any per-instance query. */
+export const IA_BENCHES_QUERY_KEY = ['ia-benches'] as const;
+
 /** Query key for an instance's bench overlays. A blank instanceId disables the
- *  query (the hook is always mounted per-instance, but guards anyway). */
+ *  query. Retained for callers that still want a single-instance read. */
 export function iaBenchesQueryKey(instanceId: string) {
   return ['ia-benches', instanceId] as const;
+}
+
+/** Query key for the unfiltered (all-instances) bench-overlay list. */
+export function iaBenchesAllQueryKey() {
+  return ['ia-benches', 'all'] as const;
 }
 
 export function useIaBenchesQuery(instanceId: string) {
@@ -29,16 +42,25 @@ export function useIaBenchesQuery(instanceId: string) {
   });
 }
 
-/** Bundle of one instance's bench-overlay query + its mutations. The mutations
- *  invalidate that instance's list on success so the UI re-reads the store. */
-export function useIaBenches(instanceId: string) {
+/** #773: a SINGLE unfiltered `GET /hub/ia/benches` for the whole tree. The
+ *  caller groups the flat list by `instanceId` (no per-instance fan-out). */
+export function useIaBenchesAll() {
+  return useQuery({
+    queryKey: iaBenchesAllQueryKey(),
+    queryFn: () => fetchIaBenches(),
+    staleTime: 30_000,
+  });
+}
+
+/** Create/delete mutations for bench overlays. Each invalidates the entire
+ *  `['ia-benches']` family so the unfiltered list (and any per-instance reader)
+ *  re-reads authoritative store state. Scoped per-instance so error/in-flight
+ *  state stays local to the owning row. */
+export function useIaBenchMutations(_instanceId: string) {
   const queryClient = useQueryClient();
-  const query = useIaBenchesQuery(instanceId);
 
   const invalidate = () =>
-    void queryClient.invalidateQueries({
-      queryKey: iaBenchesQueryKey(instanceId),
-    });
+    void queryClient.invalidateQueries({ queryKey: IA_BENCHES_QUERY_KEY });
 
   const createMutation = useMutation({
     mutationFn: (input: {
@@ -54,6 +76,17 @@ export function useIaBenches(instanceId: string) {
     mutationFn: (id: string) => deleteIaBench(id),
     onSuccess: invalidate,
   });
+
+  return { createMutation, deleteMutation };
+}
+
+/** Bundle of one instance's bench-overlay query + its mutations. The mutations
+ *  invalidate the bench cache on success so the UI re-reads the store. Retained
+ *  for any caller wanting a self-contained per-instance reader; the tree itself
+ *  now uses `useIaBenchesAll` + `useIaBenchMutations` to avoid query fan-out. */
+export function useIaBenches(instanceId: string) {
+  const query = useIaBenchesQuery(instanceId);
+  const { createMutation, deleteMutation } = useIaBenchMutations(instanceId);
 
   return {
     benches: (query.data ?? []) as IaBench[],

--- a/frontend/src/lib/hooks/use-ia-workspaces.ts
+++ b/frontend/src/lib/hooks/use-ia-workspaces.ts
@@ -1,11 +1,14 @@
 // #728: TanStack Query data layer for the IA Workspace bar. Wraps the #733
 // `/hub/ia/workspaces` CRUD client fns (`api.ts`) in a single `['ia-workspaces']`
-// query plus create/update/delete mutations that invalidate that key on success.
+// query plus create/update/delete mutations.
 //
-// Correctness-first: no optimistic cache writes. Each mutation simply
-// invalidates `['ia-workspaces']` so the list refetches authoritative state
-// from the store. Reorder, rename, and project-membership moves all funnel
-// through `updateIaWorkspace` (the API folds them into one PATCH).
+// Correctness-first: no optimistic cache writes. `create`/`delete` are single
+// ops and invalidate `['ia-workspaces']` on success. `update` (rename, reorder,
+// project-membership) does NOT auto-invalidate (#752): reorder and project-move
+// each fire TWO `update` PATCHes that must be SEQUENCED (mutateAsync) and
+// reconciled with a SINGLE refetch at the end — per-mutation invalidation would
+// refetch between the two PATCHes (flicker) and a partial failure would leave
+// the list inconsistent. Callers own the post-sequence `refetch`/`invalidate`.
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
@@ -44,12 +47,14 @@ export function useIaWorkspaces() {
     onSuccess: invalidate,
   });
 
+  // #752: NO auto-invalidate — sequenced two-PATCH ops (reorder, project move)
+  // reconcile with ONE caller-driven refetch at the end. Single-op callers
+  // (rename) invalidate explicitly.
   const updateMutation = useMutation({
     mutationFn: (args: {
       id: string;
       patch: { name?: string; order?: number; projectIds?: string[] };
     }) => updateIaWorkspace(args.id, args.patch),
-    onSuccess: invalidate,
   });
 
   const deleteMutation = useMutation({
@@ -62,6 +67,9 @@ export function useIaWorkspaces() {
     isLoading: query.isLoading,
     isError: query.isError,
     refetch: query.refetch,
+    /** Mark `['ia-workspaces']` stale + refetch. Callers use this after a
+     *  single-op update or to reconcile a sequenced op. */
+    invalidate,
     createMutation,
     updateMutation,
     deleteMutation,

--- a/frontend/src/lib/state/view-tree.ts
+++ b/frontend/src/lib/state/view-tree.ts
@@ -705,6 +705,138 @@ export function applyLens(tree: ViewTree, lens: ViewLens): ViewTree {
   };
 }
 
+// ── #773: dedup derived benches vs. persisted bench overlays ──────────────────
+// An Instance row renders TWO bench sources: benches DERIVED from worktrees
+// (`ViewTreeBench`, keyed on cwd/worktree path) and #735 PERSISTED overlays
+// (`/hub/ia/benches`, keyed on `cwd`). A worktree bench and an overlay targeting
+// the SAME cwd are the same Bench and must render as ONE row — today they
+// double-count. This pure merge keys BOTH by cwd and, on collision, prefers the
+// overlay (it carries the user's label + env) while inheriting the derived
+// bench's git/branch/tab/recency context.
+//
+// C1: cwd is the dedup key VERBATIM — never `decodeURIComponent`-ed.
+
+/** Minimal persisted bench-overlay shape this merge needs (matches the #735
+ *  `/hub/ia/benches` `IaBench`). Kept structural so callers can pass the API
+ *  client's `IaBench` without an import cycle. */
+export interface BenchOverlayInput {
+  id: string;
+  instanceId: string;
+  cwd: string;
+  label: string | null;
+  envOverrides: Record<string, string>;
+}
+
+/** A merged bench row: a derived bench, a persisted overlay, or both fused at
+ *  the same cwd. Carries the union of fields the renderer needs so it can render
+ *  one row per cwd. `overlayId` is set when an overlay backs this row (delete
+ *  affordance); `bench` is set when a derived worktree backs it ("+ tab" anchor,
+ *  branch, tab count). */
+export interface MergedBench {
+  /** Stable React key + dedup identity. The cwd this bench is anchored to. */
+  cwd: string;
+  /** Display label: overlay label (when set) else the derived/basename label. */
+  label: string;
+  /** Persisted overlay id, when an overlay backs this row (enables delete). */
+  overlayId: string | null;
+  /** Env overrides from the overlay (empty when overlay-less). */
+  envOverrides: Record<string, string>;
+  /** Underlying derived bench, when a worktree backs this row. `null` for an
+   *  overlay-only bench (no worktree → no "+ tab" anchor, no branch). */
+  bench: ViewTreeBench | null;
+}
+
+function overlayFallbackLabel(cwd: string): string {
+  const trimmed = cwd.replace(/[\\/]+$/, '');
+  const seg = trimmed.split(/[\\/]/).pop();
+  return seg && seg.length > 0 ? seg : cwd;
+}
+
+/**
+ * Merge an instance's derived benches with its persisted overlays into ONE row
+ * list keyed by cwd. PURE: never mutates inputs, never fetches.
+ *
+ * Rules:
+ *   - Derived benches whose `path` equals an overlay's `cwd` fuse into a single
+ *     row. The OVERLAY is preferred: its label (when non-empty) + env win, but
+ *     the row keeps the derived `bench` so the renderer still has branch/git,
+ *     tab count, and the "+ tab" anchor.
+ *   - An overlay with no matching derived bench renders overlay-only (`bench:
+ *     null`): no branch, no "+ tab" (no worktree anchor).
+ *   - A derived bench with no overlay renders as before (`overlayId: null`).
+ *   - Order: derived benches keep their incoming (build/lens) order first; then
+ *     overlay-only benches in their incoming order. A fused overlay does NOT
+ *     reorder its derived row.
+ */
+export function mergeInstanceBenches(
+  derived: ViewTreeBench[],
+  overlays: BenchOverlayInput[]
+): MergedBench[] {
+  // Index overlays by cwd (last write wins — the store keys benches uniquely by
+  // (instanceId, cwd), so collisions are not expected, but be deterministic).
+  const overlayByCwd = new Map<string, BenchOverlayInput>();
+  for (const overlay of overlays) overlayByCwd.set(overlay.cwd, overlay);
+
+  const merged: MergedBench[] = [];
+  const fusedCwds = new Set<string>();
+
+  // Derived benches first, fusing any overlay sharing the cwd.
+  for (const bench of derived) {
+    const overlay = overlayByCwd.get(bench.path);
+    if (overlay) {
+      fusedCwds.add(bench.path);
+      const overlayLabel =
+        overlay.label && overlay.label.length > 0 ? overlay.label : null;
+      merged.push({
+        cwd: bench.path,
+        label: overlayLabel ?? bench.label,
+        overlayId: overlay.id,
+        envOverrides: overlay.envOverrides,
+        bench,
+      });
+    } else {
+      merged.push({
+        cwd: bench.path,
+        label: bench.label,
+        overlayId: null,
+        envOverrides: {},
+        bench,
+      });
+    }
+  }
+
+  // Overlay-only benches (no derived worktree at that cwd).
+  for (const overlay of overlays) {
+    if (fusedCwds.has(overlay.cwd)) continue;
+    const overlayLabel =
+      overlay.label && overlay.label.length > 0 ? overlay.label : null;
+    merged.push({
+      cwd: overlay.cwd,
+      label: overlayLabel ?? overlayFallbackLabel(overlay.cwd),
+      overlayId: overlay.id,
+      envOverrides: overlay.envOverrides,
+      bench: null,
+    });
+  }
+
+  return merged;
+}
+
+/** Group a flat list of persisted bench overlays by their `instanceId`, so a
+ *  SINGLE unfiltered `GET /hub/ia/benches` can fan out to per-instance rows
+ *  client-side (replacing N per-instance GETs). PURE. */
+export function groupBenchOverlaysByInstance(
+  overlays: BenchOverlayInput[]
+): Map<string, BenchOverlayInput[]> {
+  const byInstance = new Map<string, BenchOverlayInput[]>();
+  for (const overlay of overlays) {
+    const list = byInstance.get(overlay.instanceId);
+    if (list) list.push(overlay);
+    else byInstance.set(overlay.instanceId, [overlay]);
+  }
+  return byInstance;
+}
+
 // ── S4: "+ tab" anchored to a Bench (#731) ───────────────────────────────────
 // PURE resolver of the create payload a "+ tab" affordance hands to the EXISTING
 // session-create entrypoint (`createAgentSession` → `createSession`, the #473

--- a/test/view-tree-bench-merge.test.ts
+++ b/test/view-tree-bench-merge.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  groupBenchOverlaysByInstance,
+  mergeInstanceBenches,
+  type BenchOverlayInput,
+  type ViewTreeBench,
+} from '../frontend/src/lib/state/view-tree.js';
+
+// Minimal `ViewTreeBench` builder. The merge keys on `path` and reads
+// `label`/`branch`/`isGit`/`tab`, so build a focused shape (cast through unknown
+// for the branded `BenchId`).
+function bench(
+  path: string,
+  opts: Partial<Pick<ViewTreeBench, 'label' | 'branch' | 'isGit'>> = {}
+): ViewTreeBench {
+  const label = opts.label ?? path.split('/').pop() ?? path;
+  return {
+    id: `bench:${path}`,
+    path,
+    repoPath: '/repo',
+    label,
+    branch: opts.branch ?? 'main',
+    isGit: opts.isGit ?? true,
+    tab: { count: 0 },
+    lastActivity: null,
+  } as unknown as ViewTreeBench;
+}
+
+function overlay(
+  cwd: string,
+  opts: Partial<Omit<BenchOverlayInput, 'cwd'>> = {}
+): BenchOverlayInput {
+  return {
+    id: opts.id ?? `ov:${cwd}`,
+    instanceId: opts.instanceId ?? 'inst-1',
+    cwd,
+    label: opts.label ?? null,
+    envOverrides: opts.envOverrides ?? {},
+  };
+}
+
+describe('mergeInstanceBenches (#773 dedup)', () => {
+  it('renders ONE row when an overlay and a derived bench share a cwd', () => {
+    const derived = [bench('/repo/wt-a', { label: 'wt-a', branch: 'feat/x' })];
+    const overlays = [overlay('/repo/wt-a', { id: 'ov-a', label: 'My Bench' })];
+
+    const merged = mergeInstanceBenches(derived, overlays);
+
+    expect(merged).toHaveLength(1);
+    const row = merged[0]!;
+    expect(row.cwd).toBe('/repo/wt-a');
+    // Overlay preferred: its label wins.
+    expect(row.label).toBe('My Bench');
+    expect(row.overlayId).toBe('ov-a');
+    // Derived context inherited: branch + git bench retained for "+ tab".
+    expect(row.bench).not.toBeNull();
+    expect(row.bench!.branch).toBe('feat/x');
+  });
+
+  it('falls back to the derived label when the overlay has no label', () => {
+    const derived = [bench('/repo/wt-a', { label: 'derived-label' })];
+    const overlays = [overlay('/repo/wt-a', { label: null })];
+
+    const merged = mergeInstanceBenches(derived, overlays);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.label).toBe('derived-label');
+    expect(merged[0]!.overlayId).not.toBeNull();
+  });
+
+  it('keeps DISTINCT cwds as separate rows (one derived, one overlay-only)', () => {
+    const derived = [bench('/repo/wt-a', { label: 'wt-a' })];
+    const overlays = [overlay('/repo/wt-b', { id: 'ov-b', label: 'B' })];
+
+    const merged = mergeInstanceBenches(derived, overlays);
+
+    expect(merged).toHaveLength(2);
+    const byCwd = new Map(merged.map((m) => [m.cwd, m]));
+    // Derived-only row: no overlay backing, derived bench present.
+    expect(byCwd.get('/repo/wt-a')!.overlayId).toBeNull();
+    expect(byCwd.get('/repo/wt-a')!.bench).not.toBeNull();
+    // Overlay-only row: overlay id set, no derived worktree (no "+ tab" anchor).
+    expect(byCwd.get('/repo/wt-b')!.overlayId).toBe('ov-b');
+    expect(byCwd.get('/repo/wt-b')!.bench).toBeNull();
+  });
+
+  it('carries the overlay env overrides onto the merged row', () => {
+    const derived = [bench('/repo/wt-a')];
+    const overlays = [
+      overlay('/repo/wt-a', { envOverrides: { FOO: 'bar', BAZ: 'qux' } }),
+    ];
+
+    const merged = mergeInstanceBenches(derived, overlays);
+
+    expect(merged[0]!.envOverrides).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  it('derived-only benches keep empty env + null overlayId', () => {
+    const merged = mergeInstanceBenches([bench('/repo/wt-a')], []);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.overlayId).toBeNull();
+    expect(merged[0]!.envOverrides).toEqual({});
+    expect(merged[0]!.bench).not.toBeNull();
+  });
+
+  it('orders derived rows first, then overlay-only rows, preserving input order', () => {
+    const derived = [bench('/repo/a'), bench('/repo/b')];
+    const overlays = [
+      overlay('/repo/b', { id: 'ov-b' }), // fuses with derived b
+      overlay('/repo/z', { id: 'ov-z' }), // overlay-only
+      overlay('/repo/y', { id: 'ov-y' }), // overlay-only
+    ];
+
+    const merged = mergeInstanceBenches(derived, overlays);
+
+    expect(merged.map((m) => m.cwd)).toEqual([
+      '/repo/a',
+      '/repo/b',
+      '/repo/z',
+      '/repo/y',
+    ]);
+  });
+
+  it('does NOT decode the cwd key (C1: verbatim path)', () => {
+    const encoded = '/repo/wt%20with%20spaces';
+    const derived = [bench(encoded)];
+    const overlays = [overlay(encoded, { id: 'ov-enc', label: 'Encoded' })];
+
+    const merged = mergeInstanceBenches(derived, overlays);
+
+    // Same VERBATIM cwd → fused to one row; the key is never decoded.
+    expect(merged).toHaveLength(1);
+    expect(merged[0]!.cwd).toBe(encoded);
+    expect(merged[0]!.overlayId).toBe('ov-enc');
+  });
+});
+
+describe('groupBenchOverlaysByInstance (#773 fan-out)', () => {
+  it('groups a flat overlay list by instanceId', () => {
+    const overlays = [
+      overlay('/a', { id: '1', instanceId: 'inst-1' }),
+      overlay('/b', { id: '2', instanceId: 'inst-2' }),
+      overlay('/c', { id: '3', instanceId: 'inst-1' }),
+    ];
+
+    const grouped = groupBenchOverlaysByInstance(overlays);
+
+    expect([...grouped.keys()].sort()).toEqual(['inst-1', 'inst-2']);
+    expect(grouped.get('inst-1')!.map((o) => o.id)).toEqual(['1', '3']);
+    expect(grouped.get('inst-2')!.map((o) => o.id)).toEqual(['2']);
+  });
+
+  it('returns an empty map for no overlays', () => {
+    expect(groupBenchOverlaysByInstance([]).size).toBe(0);
+  });
+});


### PR DESCRIPTION
View-spine polish for two #728/#730 fugu follow-ups. Both behind the default-OFF `view-spine` flag — the OFF path is untouched.

## #752 — atomic workspace reorder/assign + touch target
- **Reorder (`WorkspaceBar.handleSwap`)**: the two `order`-swap PATCHes were independent fire-and-forget mutations — a partial failure left both rows on the same `order`, and each mutation invalidated `['ia-workspaces']` so an intermediate refetch could flicker between the PATCHes. Now sequenced via `mutateAsync` (await first, then second) under one `reordering` in-flight flag that disables controls across BOTH PATCHes, with a SINGLE refetch at the end to reconcile full-or-partial outcomes; clear error on failure.
- **Assign (`ViewSpineTree.assignProjectTo`)**: the remove-from-source + append-to-target PATCHes are now sequenced the same way (single `assignInFlight` guard + single end-of-sequence `refetch`); partial failure surfaces an error and refetches to reconcile, so a moved project never silently drops to ungrouped.
- **Hook**: `useIaWorkspaces.updateMutation` no longer auto-invalidates (single-op rename invalidates explicitly); sequenced ops own their single refetch. Exposes `invalidate`.
- **Touch target**: `.workspace-bar__assign` select bumped 28px → 44px.

## #773 — dedup derived vs persisted benches + query fan-out
- **Dedup (pure, `view-tree.ts` `mergeInstanceBenches`)**: derived worktree benches + persisted overlays are keyed by cwd (C1: verbatim, never decoded). A derived bench and an overlay sharing a cwd fuse into ONE `MergedBench` row — overlay preferred (label + env win), derived branch/tab/`+ tab` anchor inherited. Distinct cwds stay separate; overlay-only rows carry no `+ tab`. Unit-tested (`test/view-tree-bench-merge.test.ts`).
- **Fan-out**: each `InstanceRow` previously mounted `useIaBenches(instanceId)` → N GETs. `ViewSpineTree` now issues ONE unfiltered `GET /hub/ia/benches` (`useIaBenchesAll`), groups by instanceId client-side (`groupBenchOverlaysByInstance`), and passes the per-instance slice down. Bench mutations invalidate the whole `['ia-benches']` family.
- **Render split**: `InstanceRow` owns the merged bench list + overlay delete; `BenchCreate` reduced to the create form + `+ bench` affordance (dropped its per-instance list/query and the dead `instanceId` form prop, nit 3).

## States
Loading/empty/error/in-flight preserved. Sequenced ops disable their controls across BOTH PATCHes (not just whichever is in flight). Bench load-error reconciles via refetch; create/delete errors surface inline with retry.

## Gates (Node 24)
- `npm run build` — pass
- `npm run check` — pass (0 errors; pre-existing sonarjs warnings only, none in touched files)
- `npm test` — 304 files / 3946 tests pass; new dedup suite passes

Closes #752, closes #773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)