### PR TITLE
feat(#740): Tab env-override inheritance from Bench

### DIFF
--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -8,10 +8,10 @@ import { useToastStore } from '../lib/stores/toasts.js';
 import { sendPtyData } from '../lib/ws.js';
 import { estimateTerminalDimensions } from '../lib/utils.js';
 import type { WorktreeInfo, Repo, PullRequest } from '../lib/types.js';
-import type { NodeId } from '../../../shared/identity.js';
 import {
   createWorktree,
   ConflictError,
+  fetchIaBenches,
   fetchWorkspaceSettings,
   fetchWorktreeStatus,
   killSession,
@@ -19,6 +19,7 @@ import {
   renameSession as renameSessionApi,
   launchWorkspaceSession,
 } from '../lib/api.js';
+import type { BenchCreatePayload } from '../lib/state/view-tree.js';
 import {
   derivePrAction,
   buildPrStateInput,
@@ -221,16 +222,15 @@ export function useSessionHandlers({
   // node-aware create entrypoint (`createAgentSession` → `createSession`, the
   // #473 local/remote/free flow). The bench resolves to the agent-session repo
   // context the backend requires (`repoPath` ∈ config.repos, worktree → cwd) —
-  // mirroring the dialog's local-git create. NO env-override inheritance
-  // (deferred to #740 / backend #735). Offline/remote-unavailable benches fail
-  // through the same toast path as every other create; no bespoke error UI.
+  // mirroring the dialog's local-git create. #740: the new Tab also inherits the
+  // anchoring Bench's persisted `envOverrides` overlay (looked up by benchId),
+  // applied additively to the PTY env by the backend (reserved `PATH`/`RELAY_*`
+  // keys are refused). The overlay lookup is best-effort — a fetch failure or
+  // missing overlay just creates with no extra env (unchanged behavior), never
+  // blocking the tab. Offline/remote-unavailable benches fail through the same
+  // toast path as every other create; no bespoke error UI.
   const handleViewSpineCreateTab = useCallback(
-    async (payload: {
-      nodeId: NodeId;
-      repoPath: string;
-      worktreePath: string;
-      cwd: string;
-    }) => {
+    async (payload: BenchCreatePayload) => {
       const loadingKey = `view-spine-tab:${payload.nodeId}:${payload.cwd}`;
       if (useSessionsStore.getState().isItemLoading(loadingKey)) return;
       useSessionsStore.getState().setLoading(loadingKey);
@@ -238,6 +238,21 @@ export function useSessionHandlers({
         const { cols, rows } = estimateTerminalDimensions(
           useUiStore.getState().terminalFontSize
         );
+        // Resolve the anchoring Bench's persisted env overlay (#740). Match by
+        // the deterministic benchId; best-effort so create never blocks on it.
+        let envOverrides: Record<string, string> | undefined;
+        try {
+          const benches = await fetchIaBenches(payload.instanceId);
+          const overlay = benches.find((b) => b.id === payload.benchId);
+          if (overlay && Object.keys(overlay.envOverrides).length > 0) {
+            envOverrides = overlay.envOverrides;
+          }
+        } catch (overlayError) {
+          logger.warn(
+            'view-spine tab: bench env-overlay lookup failed; creating with no inherited env',
+            overlayError
+          );
+        }
         const { session, error } = await createAgentSession({
           nodeId: payload.nodeId,
           repoPath: payload.repoPath,
@@ -246,6 +261,7 @@ export function useSessionHandlers({
           type: 'agent',
           cols,
           rows,
+          ...(envOverrides ? { envOverrides } : {}),
         });
         if (session?.id && !(error instanceof ConflictError)) {
           useSessionsStore

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1155,6 +1155,9 @@ export interface CreateSessionBody {
   newWorktree?: boolean | undefined;
   branchRenamePrompt?: string | undefined;
   sessionLane?: SessionLane | undefined;
+  /** #740: Bench-inherited env overrides applied additively to the PTY env.
+   *  Reserved keys (`PATH`, `RELAY_*`) are refused by the backend. */
+  envOverrides?: Record<string, string> | undefined;
   ticketContext?: {
     ticketId: string;
     title: string;

--- a/frontend/src/lib/session-utils.ts
+++ b/frontend/src/lib/session-utils.ts
@@ -25,6 +25,10 @@ export interface CreateAgentSessionOptions {
   newWorktree?: boolean | undefined;
   branchRenamePrompt?: string | undefined;
   sessionLane?: SessionLane | undefined;
+  /** #740: env overrides inherited from the anchoring Bench, applied additively
+   *  to the spawned PTY env. The backend refuses reserved keys (`PATH`,
+   *  `RELAY_*`). */
+  envOverrides?: Record<string, string> | undefined;
   ticketContext?: {
     ticketId: string;
     title: string;

--- a/frontend/src/lib/state/view-tree.ts
+++ b/frontend/src/lib/state/view-tree.ts
@@ -715,21 +715,28 @@ export function applyLens(tree: ViewTree, lens: ViewLens): ViewTree {
 // repo (`config.repos`) and the worktree becomes the session cwd
 // (`cwd = worktreePath ?? repoPath`, server/index.ts).
 //
-// NO env-override inheritance (deferred to #740 / backend #735) — the payload
-// carries ONLY the node anchor + the agent-session repo/worktree context the
-// backend requires. No branch, env, agent, yolo, or identity is inherited.
+// #740: the payload now also carries the bench's identity (`instanceId` +
+// deterministic `benchId`) so the create handler can look up that Bench's
+// persisted `envOverrides` overlay and inherit them. Branch, agent, yolo, and
+// identity are still NOT inherited — only env overrides.
 
 /** The anchor + repo context a new agent Tab needs. `repoPath` is the configured
  *  parent repo (validated against `config.repos` by the backend); `worktreePath`
  *  is the bench's worktree (becomes the session cwd); `cwd` mirrors the worktree
- *  for callers/consumers that want it explicit. Consumed by the existing
- *  `createAgentSession({ nodeId, repoPath, worktreePath, cwd })` path — this
- *  helper invents NO new create logic. */
+ *  for callers/consumers that want it explicit. `instanceId`/`benchId` identify
+ *  the anchoring Bench so its persisted env overlay can be inherited (#740).
+ *  Consumed by the `handleViewSpineCreateTab` path — this helper invents NO new
+ *  create logic. */
 export interface BenchCreatePayload {
   nodeId: NodeId;
   repoPath: string;
   worktreePath: string;
   cwd: string;
+  /** Owning Instance id — used to scope the bench-overlay env lookup (#740). */
+  instanceId: InstanceId;
+  /** Deterministic BenchId (`createBenchId(instanceId, cwd)`) — matches the
+   *  persisted overlay whose `envOverrides` the new Tab inherits (#740). */
+  benchId: BenchId;
 }
 
 /** Resolve the agent-session create payload a "+ tab" on `bench` (owned by
@@ -741,8 +748,8 @@ export interface BenchCreatePayload {
  *  payload is `{ nodeId, repoPath, worktreePath, cwd }` — exactly what the
  *  dialog's local-git create sends. */
 export function benchCreatePayload(
-  instance: Pick<ViewTreeInstance, 'nodeId'>,
-  bench: Pick<ViewTreeBench, 'path' | 'repoPath'>
+  instance: Pick<ViewTreeInstance, 'id' | 'nodeId'>,
+  bench: Pick<ViewTreeBench, 'id' | 'path' | 'repoPath'>
 ): BenchCreatePayload | null {
   if (!bench.repoPath) return null;
   return {
@@ -750,5 +757,9 @@ export function benchCreatePayload(
     repoPath: bench.repoPath,
     worktreePath: bench.path,
     cwd: bench.path,
+    // #740: identity so the create handler can inherit this Bench's persisted
+    // env overlay. `bench.id` is already `createBenchId(instance.id, bench.path)`.
+    instanceId: instance.id,
+    benchId: bench.id,
   };
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -754,6 +754,8 @@ type AgentSessionParams = {
   portVariables?: string[] | undefined;
   /** #614 slice 4: effective scrollback cap from resolveSessionSettings. */
   scrollbackBytes?: number | undefined;
+  /** #740: anchoring Bench's env overrides, applied additively to the PTY env. */
+  envOverrides?: Record<string, string> | undefined;
 };
 
 type TerminalSessionParams = {
@@ -765,6 +767,8 @@ type TerminalSessionParams = {
   safeRows: number | undefined;
   sessionLane: SessionLane | undefined;
   portVariables?: string[] | undefined;
+  /** #740: anchoring Bench's env overrides, applied additively to the PTY env. */
+  envOverrides?: Record<string, string> | undefined;
 };
 
 function createTerminalSessionRecord(
@@ -787,6 +791,7 @@ function createTerminalSessionRecord(
     ...(params.safeRows != null && { rows: params.safeRows }),
     ...(params.sessionLane ? { sessionLane: params.sessionLane } : {}),
     portVariables: params.portVariables,
+    ...(params.envOverrides ? { envOverrides: params.envOverrides } : {}),
   });
 }
 
@@ -830,6 +835,8 @@ function createAgentSessionRecord(params: AgentSessionParams): CreateResult {
     ...(params.scrollbackBytes !== undefined
       ? { maxScrollbackBytes: params.scrollbackBytes }
       : {}),
+    // #740: anchoring Bench's env overrides, applied additively to the PTY env.
+    ...(params.envOverrides ? { envOverrides: params.envOverrides } : {}),
   });
 
   if (params.worktreePath) {
@@ -907,6 +914,28 @@ export function validateSessionCreateRequest(
   if (workContextStore.get(workContextId)) return true;
   res.status(404).json({ error: 'work_context_not_found' });
   return false;
+}
+
+/**
+ * Sanitize a caller-supplied `envOverrides` map for a session create (#740: a
+ * Tab inherits its anchoring Bench's persisted env overrides). Keeps only
+ * `string -> string` entries with a non-empty key. Non-records and non-string
+ * values are dropped silently — the PTY layer additively applies what survives
+ * and refuses reserved keys (`PATH`, `RELAY_*`) itself, so a malformed map can
+ * never break session identity. Returns `undefined` when nothing usable
+ * remains (no env added = unchanged behavior).
+ */
+function sanitizeSessionEnvOverrides(
+  raw: unknown
+): Record<string, string> | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof key !== 'string' || key.length === 0) continue;
+    if (typeof value !== 'string') continue;
+    out[key] = value;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 function configuredRepoForCwd(config: Config, cwd: string): string | null {
@@ -3473,6 +3502,7 @@ async function main(): Promise<void> {
       sessionLane,
       ticketContext,
       workContextId,
+      envOverrides: rawEnvOverrides,
     } = createBody as {
       repoPath?: string;
       worktreePath?: string | null;
@@ -3493,6 +3523,7 @@ async function main(): Promise<void> {
       continuePolicy?: ContinuePolicy;
       sessionLane?: SessionLane;
       workContextId?: string;
+      envOverrides?: unknown;
       ticketContext?: {
         ticketId: string;
         title: string;
@@ -3506,6 +3537,10 @@ async function main(): Promise<void> {
 
     // Read config once for the lifetime of this request
     const freshConfig = getConfig();
+
+    // #740: Bench-inherited env overrides (sanitized to string->string). The
+    // PTY layer applies these additively and refuses reserved keys.
+    const sessionEnvOverrides = sanitizeSessionEnvOverrides(rawEnvOverrides);
 
     // For terminal sessions where only cwd/worktreePath is set, fall back to that as repoPath
     // Use repoPath if set; for terminal-only sessions the validated anchor was cwd/worktreePath
@@ -3557,6 +3592,7 @@ async function main(): Promise<void> {
           safeRows,
           sessionLane,
           portVariables,
+          envOverrides: sessionEnvOverrides,
         });
       } catch (err) {
         sendSessionCreateError(res, err, freshConfig.maxPtySessions);
@@ -3694,6 +3730,7 @@ async function main(): Promise<void> {
         sessionLane,
         portVariables,
         scrollbackBytes: resolved.scrollbackBytes,
+        envOverrides: sessionEnvOverrides,
       });
     } catch (err) {
       sendSessionCreateError(res, err, freshConfig.maxPtySessions);

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -418,6 +418,15 @@ export type CreatePtyParams = {
   nodeId?: string | undefined;
   /** WorkContext ID to inject as RELAY_WORK_CONTEXT_ID (omitted when not set). */
   workContextId?: string | undefined;
+  /**
+   * Additional env vars layered on top of the base session env (#740: a Tab
+   * inherits its anchoring Bench's persisted `envOverrides`). Applied
+   * ADDITIVELY before Relay-owned identity injection, so Relay's own
+   * `RELAY_*`/`RELAY_HUB_URL` vars and the per-session relayctl PATH shim
+   * always win — caller env can never clobber them. An empty/undefined record
+   * is a no-op (unchanged behavior).
+   */
+  envOverrides?: Record<string, string> | undefined;
   callbacks?:
     | {
         onStateChange?: Array<(sessionId: string, state: AgentState) => void>;
@@ -688,6 +697,53 @@ function injectRelaySessionEnv(
   }
 }
 
+/**
+ * Reserved env keys that bench overrides may NOT set. These are Relay-owned:
+ * `PATH` carries the per-session relayctl shim, and any `RELAY_*` var is part
+ * of the session identity/control contract. A bench override targeting one of
+ * these is dropped (logged once) rather than applied, so a misconfigured bench
+ * can never break session identity or shim discovery.
+ */
+function isReservedEnvKey(key: string): boolean {
+  return key === 'PATH' || key.startsWith('RELAY_');
+}
+
+/**
+ * Layer a Bench's persisted `envOverrides` onto the base PTY env (#740).
+ * Additive: each non-reserved key is set (or overwritten) on both the process
+ * env and the tmux update-environment set. Reserved keys (`PATH`, `RELAY_*`)
+ * are skipped so Relay's own injection always wins. Empty record is a no-op.
+ *
+ * @internal exported as injectBenchEnvOverridesForTest for testing only.
+ */
+function applyBenchEnvOverrides(
+  env: Record<string, string>,
+  tmuxEnv: Record<string, string>,
+  overrides: Record<string, string>
+): void {
+  for (const [key, value] of Object.entries(overrides)) {
+    if (typeof key !== 'string' || key.length === 0) continue;
+    if (typeof value !== 'string') continue;
+    if (isReservedEnvKey(key)) {
+      logger.warn(
+        `Skipping reserved bench env override "${key}" (Relay-owned, not overridable)`
+      );
+      continue;
+    }
+    env[key] = value;
+    tmuxEnv[key] = value;
+  }
+}
+
+/** @internal Exposed for unit tests of bench env-override precedence. */
+export function injectBenchEnvOverridesForTest(
+  env: Record<string, string>,
+  tmuxEnv: Record<string, string>,
+  overrides: Record<string, string>
+): void {
+  applyBenchEnvOverrides(env, tmuxEnv, overrides);
+}
+
 function buildPortInjectionParams(
   repoPath: string | undefined,
   worktreePath: string | null,
@@ -746,7 +802,8 @@ function setupEnvAndHooks(
   paramClaudeFullscreen: boolean | undefined,
   rawArgs: string[],
   portInjectionParams?: PortInjectionParams,
-  relaySessionEnvParams?: RelaySessionEnvParams
+  relaySessionEnvParams?: RelaySessionEnvParams,
+  envOverrides?: Record<string, string> | undefined
 ): HookSetupResult {
   const env = cleanEnv();
   const tmuxEnv: Record<string, string> = {};
@@ -826,8 +883,16 @@ function setupEnvAndHooks(
     injectPortEnvVars(env, tmuxEnv, portInjectionParams);
   }
 
+  // #740: layer the anchoring Bench's persisted env overrides on top of the
+  // base session env. Applied BEFORE Relay identity injection below so the
+  // Relay-owned vars + relayctl PATH shim always win and can never be clobbered
+  // by caller-supplied env.
+  if (envOverrides) {
+    applyBenchEnvOverrides(env, tmuxEnv, envOverrides);
+  }
+
   // Inject Relay-owned session identity env vars. These are set last so they
-  // are never overwritten by hook or port injection above.
+  // are never overwritten by hook, port, or bench-override injection above.
   if (relaySessionEnvParams) {
     injectRelaySessionEnv(env, tmuxEnv, relaySessionEnvParams);
   }
@@ -1098,6 +1163,7 @@ export function createPtySession(
     maxScrollbackBytes: paramMaxScrollbackBytes,
     nodeId: paramNodeId,
     workContextId: paramWorkContextId,
+    envOverrides: paramEnvOverrides,
   } = params;
 
   const maxScrollbackPerSession =
@@ -1142,7 +1208,8 @@ export function createPtySession(
     paramClaudeFullscreen,
     rawArgs,
     portInjectionParams,
-    relaySessionEnvParams
+    relaySessionEnvParams,
+    paramEnvOverrides
   );
 
   const { env, tmuxEnv, hookToken, hooksActive, settingsPath } = hookSetup;

--- a/test/relay-session-env.test.ts
+++ b/test/relay-session-env.test.ts
@@ -21,7 +21,10 @@ import { promisify } from 'node:util';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import * as sessions from '../server/sessions.js';
 import type { PtySession } from '../server/types.js';
-import { injectRelaySessionEnvForTest } from '../server/pty-handler.js';
+import {
+  injectRelaySessionEnvForTest,
+  injectBenchEnvOverridesForTest,
+} from '../server/pty-handler.js';
 
 const execFileAsync = promisify(execFile);
 const createdIds: string[] = [];
@@ -198,6 +201,70 @@ describe('injectRelaySessionEnvForTest — env var injection', () => {
   });
 });
 
+// ── #740: Bench env-override application + precedence ──────────────────────
+
+describe('injectBenchEnvOverridesForTest — bench env inheritance (#740)', () => {
+  it('applies non-reserved overrides to both env and tmuxEnv', () => {
+    const env: Record<string, string> = { PATH: '/usr/bin' };
+    const tmuxEnv: Record<string, string> = { PATH: '/usr/bin' };
+    injectBenchEnvOverridesForTest(env, tmuxEnv, {
+      MY_VAR: 'hello',
+      ANOTHER: '42',
+    });
+    expect(env.MY_VAR).toBe('hello');
+    expect(env.ANOTHER).toBe('42');
+    expect(tmuxEnv.MY_VAR).toBe('hello');
+    expect(tmuxEnv.ANOTHER).toBe('42');
+  });
+
+  it('an empty override record is a no-op (unchanged behavior)', () => {
+    const env: Record<string, string> = { PATH: '/usr/bin', EXISTING: 'x' };
+    const tmuxEnv: Record<string, string> = { PATH: '/usr/bin' };
+    injectBenchEnvOverridesForTest(env, tmuxEnv, {});
+    expect(env).toEqual({ PATH: '/usr/bin', EXISTING: 'x' });
+    expect(tmuxEnv).toEqual({ PATH: '/usr/bin' });
+  });
+
+  it('refuses to clobber PATH (relayctl shim is Relay-owned)', () => {
+    const env: Record<string, string> = { PATH: '/usr/bin' };
+    const tmuxEnv: Record<string, string> = { PATH: '/usr/bin' };
+    injectBenchEnvOverridesForTest(env, tmuxEnv, { PATH: '/evil/bin' });
+    expect(env.PATH).toBe('/usr/bin');
+    expect(tmuxEnv.PATH).toBe('/usr/bin');
+  });
+
+  it('refuses to clobber any RELAY_* var (session identity is Relay-owned)', () => {
+    const env: Record<string, string> = {
+      PATH: '/usr/bin',
+      RELAY_NODE_ID: 'local',
+    };
+    const tmuxEnv: Record<string, string> = { PATH: '/usr/bin' };
+    injectBenchEnvOverridesForTest(env, tmuxEnv, {
+      RELAY_NODE_ID: 'spoofed',
+      RELAY_SESSION_ID: 'spoofed',
+      RELAY_HUB_URL: 'http://evil',
+    });
+    expect(env.RELAY_NODE_ID).toBe('local');
+    expect(env.RELAY_SESSION_ID).toBeUndefined();
+    expect(env.RELAY_HUB_URL).toBeUndefined();
+    expect(tmuxEnv.RELAY_NODE_ID).toBeUndefined();
+  });
+
+  it('drops non-string values and blank keys (paranoid sanitize)', () => {
+    const env: Record<string, string> = { PATH: '/usr/bin' };
+    const tmuxEnv: Record<string, string> = {};
+    injectBenchEnvOverridesForTest(env, tmuxEnv, {
+      GOOD: 'ok',
+      '': 'no-key',
+      // @ts-expect-error intentionally non-string to prove it is dropped
+      BAD: 123,
+    });
+    expect(env.GOOD).toBe('ok');
+    expect(env['']).toBeUndefined();
+    expect(env.BAD).toBeUndefined();
+  });
+});
+
 // ── Non-Relay shells do NOT have RELAY_* vars ──────────────────────────────
 
 describe('env isolation — non-Relay shells are clean', () => {
@@ -302,6 +369,77 @@ describe('sessions.create — RELAY_* env vars reach the spawned PTY', () => {
 
     const scrollback = await waitForScrollbackContains(result.id, 'CTX=');
     expect(scrollback).toContain('CTX=NOTSET');
+  });
+
+  // ── #740: Bench-inherited envOverrides reach the spawned PTY ──────────────
+  it('bench envOverrides appear in the spawned PTY env', async () => {
+    const result = sessions.create({
+      repoName: 'env-bench-test',
+      repoPath: '/tmp',
+      worktreePath: null,
+      cwd: '/tmp',
+      command: process.execPath,
+      args: [
+        '-e',
+        [
+          "console.log('BENCH_VAR=' + (process.env.BENCH_VAR || 'NOTSET'));",
+          'setTimeout(()=>{}, 10000);',
+        ].join(' '),
+      ],
+      tmuxAttach: true,
+      envOverrides: { BENCH_VAR: 'from-bench' },
+    });
+    createdIds.push(result.id);
+
+    const scrollback = await waitForScrollbackContains(result.id, 'BENCH_VAR=');
+    expect(scrollback).toContain('BENCH_VAR=from-bench');
+  });
+
+  it('a bench override cannot clobber RELAY_NODE_ID (Relay identity wins)', async () => {
+    const result = sessions.create({
+      repoName: 'env-bench-precedence',
+      repoPath: '/tmp',
+      worktreePath: null,
+      cwd: '/tmp',
+      command: process.execPath,
+      args: [
+        '-e',
+        [
+          "console.log('NODE=' + (process.env.RELAY_NODE_ID || ''));",
+          'setTimeout(()=>{}, 10000);',
+        ].join(' '),
+      ],
+      tmuxAttach: true,
+      // Adversarial override: must NOT win over Relay's own identity injection.
+      envOverrides: { RELAY_NODE_ID: 'spoofed' },
+    });
+    createdIds.push(result.id);
+
+    const scrollback = await waitForScrollbackContains(result.id, 'NODE=');
+    expect(scrollback).toContain('NODE=local');
+    expect(scrollback).not.toContain('NODE=spoofed');
+  });
+
+  it('no envOverrides → no extra env added (unchanged behavior)', async () => {
+    const result = sessions.create({
+      repoName: 'env-bench-none',
+      repoPath: '/tmp',
+      worktreePath: null,
+      cwd: '/tmp',
+      command: process.execPath,
+      args: [
+        '-e',
+        [
+          "console.log('BENCH_VAR=' + (process.env.BENCH_VAR || 'NOTSET'));",
+          'setTimeout(()=>{}, 10000);',
+        ].join(' '),
+      ],
+      tmuxAttach: true,
+    });
+    createdIds.push(result.id);
+
+    const scrollback = await waitForScrollbackContains(result.id, 'BENCH_VAR=');
+    expect(scrollback).toContain('BENCH_VAR=NOTSET');
   });
 });
 

--- a/test/view-tree.test.ts
+++ b/test/view-tree.test.ts
@@ -499,11 +499,15 @@ describe('S4 benchCreatePayload', () => {
 
     // Mirrors the dialog's local-git create so the backend agent contract
     // passes: repoPath is the configured parent repo, the worktree becomes cwd.
+    // #740: also carries the bench identity (instanceId + deterministic benchId)
+    // so the create handler can inherit this Bench's persisted env overlay.
     expect(benchCreatePayload(instance, bench)).toEqual({
       nodeId: DEFAULT_LOCAL_NODE_ID,
       repoPath: '/repos/relay',
       worktreePath: '/repos/relay/.worktrees/feat-x',
       cwd: '/repos/relay/.worktrees/feat-x',
+      instanceId: instance.id,
+      benchId: bench.id,
     });
   });
 
@@ -536,6 +540,8 @@ describe('S4 benchCreatePayload', () => {
       repoPath: '/repos/relay',
       worktreePath: '/repos/relay/.worktrees/feat-y',
       cwd: '/repos/relay/.worktrees/feat-y',
+      instanceId: instance.id,
+      benchId: bench.id,
     });
   });
 
@@ -567,7 +573,7 @@ describe('S4 benchCreatePayload', () => {
     expect(benchCreatePayload(instance, bench)).toBeNull();
   });
 
-  it('carries ONLY (nodeId, repoPath, worktreePath, cwd) — no env/branch/identity inherited', () => {
+  it('carries anchor + bench identity only — no branch/agent/yolo leaked', () => {
     const worktree: WorktreeInfo = {
       name: 'feat-z',
       path: '/repos/relay/.worktrees/feat-z',
@@ -582,16 +588,24 @@ describe('S4 benchCreatePayload', () => {
     const instance = allProjects(tree)[0]!.instances[0]!;
     const bench = instance.benches[0]!;
 
-    // #740/#735 are deferred: the payload must NOT leak branch, env, agent,
-    // yolo, or repo identity into the create call — exactly these four keys.
+    // #740: the payload carries the repo/worktree anchor plus the bench identity
+    // (instanceId + deterministic benchId) used to inherit the Bench env overlay.
+    // It must NOT leak branch, agent, yolo, or env values directly into the
+    // create call — env inheritance is resolved later, by benchId, at create.
     const payload = benchCreatePayload(instance, bench);
     expect(payload).not.toBeNull();
     expect(Object.keys(payload!).sort()).toEqual([
+      'benchId',
       'cwd',
+      'instanceId',
       'nodeId',
       'repoPath',
       'worktreePath',
     ]);
+    // The benchId is the deterministic id of the anchoring bench, so the
+    // create-time overlay lookup matches exactly one persisted overlay.
+    expect(payload!.benchId).toBe(bench.id);
+    expect(payload!.instanceId).toBe(instance.id);
   });
 });
 


### PR DESCRIPTION
## What

Wires the deferred env-override inheritance from #444/#731: when a Tab is created from a Bench via the view-spine **"+ tab"** flow, it now inherits that Bench's persisted `envOverrides` (the #735 `ia.db` overlay) and applies them to the spawned PTY env.

Previously "+ tab" sent `{nodeId, repoPath, worktreePath, cwd}` with **no env**.

## The wire

**FE (lookup → pass):**
- `handleViewSpineCreateTab` (`frontend/src/hooks/useSessionHandlers.ts`) now resolves the anchoring Bench's overlay via `fetchIaBenches(instanceId)`, matches by the deterministic `benchId`, and threads `envOverrides` into `createAgentSession`.
- `benchCreatePayload` (`frontend/src/lib/state/view-tree.ts`) now also carries `instanceId` + `benchId` (the bench's `id` is already `createBenchId(instanceId, cwd)`), so the create handler can scope the overlay lookup. No new create logic invented.
- `envOverrides` added to `CreateAgentSessionOptions` (`session-utils.ts`) and `CreateSessionBody` (`api.ts`).
- Lookup is **best-effort**: a missing overlay or a failed fetch creates the tab with no extra env (unchanged behavior) — it never blocks tab creation.

**BE (accept → apply):**
- `/sessions` create handler (`server/index.ts`) accepts a `sanitizeSessionEnvOverrides`-cleaned `envOverrides` map (string→string only), threaded through `createAgentSessionRecord`/`createTerminalSessionRecord`.
- `CreatePtyParams.envOverrides` flows through `sessions.create` → `createPtySession` → `setupEnvAndHooks`, where `applyBenchEnvOverrides` layers it onto the PTY + tmux env (`server/pty-handler.ts`).

## Precedence

`base session env < bench overrides < Relay-owned (RELAY_*/PATH)`.

Overrides are applied **after** hook/port injection but **before** Relay identity injection, and `applyBenchEnvOverrides` **refuses reserved keys** (`PATH`, any `RELAY_*`). So the per-session relayctl PATH shim and the `RELAY_NODE_ID/SESSION_ID/HUB_URL/WORK_CONTEXT_ID` identity contract always win — a (mis)configured bench can never clobber them. Additive only.

## Security

- Bench overrides cannot set `PATH` or `RELAY_*` (dropped + logged), so session identity and shim discovery are safe.
- **C1:** the bench `cwd` is never `decodeURIComponent`-ed anywhere in this change.
- Request-body `envOverrides` is sanitized to a string→string record (non-records, arrays, non-string values dropped) before it reaches the PTY layer.
- Scope: local hub-node create path (`/sessions`). Remote/routed-node env forwarding through node-link RPC is out of scope (see Risks).

## Tests

`test/relay-session-env.test.ts` (+8):
- unit `injectBenchEnvOverridesForTest`: applies non-reserved overrides to env+tmuxEnv; empty record is a no-op; refuses `PATH`; refuses any `RELAY_*`; drops non-string/blank-key entries.
- integration via `sessions.create`: bench `envOverrides` reach the spawned PTY; an adversarial `RELAY_NODE_ID` override does NOT win (Relay identity wins); no `envOverrides` → no env added.

`test/view-tree.test.ts`: `benchCreatePayload` now asserts the carried `instanceId`/`benchId`; "no leakage" test confirms branch/agent/yolo are still not inherited.

## Real smoke (isolated config, port 3473, NO_PIN, isolated TMUX_TMPDIR)

1. `POST /hub/ia/benches` with `envOverrides: {MY_BENCH_VAR: "inherited-value", RELAY_NODE_ID: "spoof-attempt"}` → 201.
2. `GET /hub/ia/benches?instanceId=...` (the FE lookup path) → returns the overlay.
3. `POST /sessions` carrying those `envOverrides` → session created.
4. Inspected the live spawned PTY shell's `/proc/<pid>/environ`:
   - `MY_BENCH_VAR=inherited-value` ✅ (override reached the PTY)
   - `RELAY_NODE_ID=local` ✅ (spoof refused — Relay identity won)
   - `PATH=/tmp/relay-ide/<sid>/bin:...` ✅ (relayctl shim intact, first on PATH)
   - `RELAY_SESSION_ID=<sid>` ✅
5. Control session without `envOverrides` → `MY_BENCH_VAR` absent (unchanged behavior). ✅

Cleaned up sessions, hub, tmux, and temp dir afterward.

## Gates (Node 24)

- `npm run build` — ✅
- `npm run check` — ✅ 0 errors (pre-existing warnings only)
- `npm test` — ✅ 303 files / 3945 tests passed

## Risks / notes

- **Remote-node benches:** env forwarding over node-link RPC is not wired here; the local path covers the common case, and offline/remote benches still fail through the existing toast path. Follow-up if needed.
- **Shared FE files:** `view-tree.ts` and `useSessionHandlers.ts` are shared with the view-spine tree lane — conflict-aware (`benchCreatePayload` shape + `BenchCreatePayload` interface changed additively).

Closes #740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)