### PR TITLE
feat(#739): interactive tab leaves + attention bubbling

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -552,7 +552,10 @@ export function Sidebar({
             // #732/#729: flag-gated, read-only, client-derived view-spine tree.
             // OFF path below is byte-identical to today.
             <div className="sidebar-workspace-list">
-              <ViewSpineTree onCreateTab={onViewSpineCreateTab} />
+              <ViewSpineTree
+                onCreateTab={onViewSpineCreateTab}
+                onSelectTab={onSelectSession}
+              />
             </div>
           ) : (
             <div className="sidebar-workspace-list">

--- a/frontend/src/components/ViewSpineTree.css
+++ b/frontend/src/components/ViewSpineTree.css
@@ -135,3 +135,55 @@
   opacity: 0.7;
   color: var(--accent);
 }
+
+/* ── #739 interactive Tab leaves + attention bubbling ──────────────────────────
+   Individual Tabs (sessions) render as selectable rows one indent below their
+   Bench (or directly under an Instance for root-anchored tabs / a free entry).
+   Reuses the shared `.session-row` anatomy + `SessionIndicator` glyph + the
+   `.repo-attention-badge` pattern — no new colors or animations. */
+
+/* Leaf list sits one level deeper than the bench list. Bench leaves inherit the
+   bench-list indent and add one more slot; instance/free leaves get their own
+   indent below their parent row. */
+.view-spine-bench .view-spine-tab-leaf-list {
+  padding-left: var(--icon-slot-width);
+}
+.view-spine-instance > .view-spine-tab-leaf-list,
+.view-spine-free-row > .view-spine-tab-leaf-list {
+  padding-left: var(--icon-slot-width);
+}
+
+/* Leaf rows keep the ≥44px touch target from `.session-row`. Non-interactive by
+   default (read-only render); the `.selectable` variant adds the pointer +
+   hover/focus affordances so a tap focuses the tab. */
+.view-spine-tab-leaf {
+  cursor: default;
+  min-height: 44px;
+}
+.view-spine-tab-leaf.selectable {
+  cursor: pointer;
+}
+.view-spine-tab-leaf.selectable:hover {
+  background: var(--surface-hover);
+}
+.view-spine-tab-leaf.selectable:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+}
+
+/* The bench/instance collapse chevron is a real <button>; strip the UA chrome so
+   it matches the borrowed `.collapse-chevron` look. */
+.view-spine-bench .collapse-chevron {
+  border: none;
+  background: transparent;
+  padding: 0;
+}
+.view-spine-bench .collapse-chevron:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+}
+
+/* Bubbled attention badge — keep it from being squeezed in a tight row. */
+.view-spine-tree .repo-attention-badge {
+  flex-shrink: 0;
+}

--- a/frontend/src/components/ViewSpineTree.tsx
+++ b/frontend/src/components/ViewSpineTree.tsx
@@ -9,6 +9,7 @@ import { fetchHubNodes } from '../lib/api.js';
 import { deriveColor } from '../lib/colors.js';
 import { MarqueeText } from './MarqueeText.js';
 import { CipherText } from './CipherText.js';
+import { SessionIndicator } from './SessionIndicator.js';
 import {
   applyLens,
   benchCreatePayload,
@@ -22,10 +23,12 @@ import {
   type InstanceHostStatus,
   type MergedBench,
   type ViewLens,
+  type ViewTreeAttention,
   type ViewTreeFreeEntry,
   type ViewTreeInstance,
   type ViewTreeProject,
   type ViewTreeNodeStatus,
+  type ViewTreeTabLeaf,
 } from '../lib/state/view-tree.js';
 import { useIaWorkspaces } from '../lib/hooks/use-ia-workspaces.js';
 import {
@@ -48,6 +51,11 @@ function benchErrorMessage(err: unknown, fallback: string): string {
  *  NOT the worktree-creation path (`onNewWorktree`). */
 export type ViewSpineCreateTab = (payload: BenchCreatePayload) => void;
 
+/** #739: focus/select an individual Tab (session). Wired by `App` to the
+ *  EXISTING active-session action (`handleSelectSession`) — NOT a new flow. The
+ *  argument is the scoped session key the legacy sidebar already selects on. */
+export type ViewSpineSelectTab = (selectKey: string) => void;
+
 // Ad-hoc, ephemeral lenses (#727). Order is the visual + arrow-key order.
 const LENSES: ReadonlyArray<{ id: ViewLens; label: string }> = [
   { id: 'recent', label: 'recent' },
@@ -67,15 +75,98 @@ function CountBadge({ count }: { count: number }) {
   return <span className="session-count-badge">{count}</span>;
 }
 
+// #739: bubbled attention badge — reuses the legacy `.repo-attention-badge`
+// anatomy (a `SessionIndicator` glyph + descendant attention count). Rendered on
+// a Bench/Instance/Project when any descendant Tab needs attention; null when
+// none, so non-attention nodes stay visually quiet.
+function AttentionBadge({ attention }: { attention: ViewTreeAttention }) {
+  if (!attention.state || attention.count <= 0) return null;
+  return (
+    <span
+      className="repo-attention-badge"
+      title={`${attention.count} tab(s) need attention`}
+    >
+      <SessionIndicator state={attention.state} />
+      {attention.count}
+    </span>
+  );
+}
+
+// #739: an individual Tab (session) leaf — a selectable row reusing the legacy
+// sidebar session-row anatomy (`SessionIndicator` glyph + name + attention bold
+// + branch). Click selects/focuses that Tab via the EXISTING active-session
+// action. Indented one level below its Bench. Keyboard-accessible (button-like
+// role, Enter/Space activate), touch ≥44px (`.view-spine-tab-leaf` CSS).
+function TabLeafRow({
+  leaf,
+  onSelectTab,
+}: {
+  leaf: ViewTreeTabLeaf;
+  onSelectTab?: ViewSpineSelectTab | undefined;
+}) {
+  const selectable = !!onSelectTab;
+  const activate = () => {
+    if (onSelectTab) onSelectTab(leaf.selectKey);
+  };
+  return (
+    <li
+      className={[
+        'session-row view-spine-tab-leaf',
+        `state-${leaf.state}`,
+        leaf.attention && 'attention',
+        selectable && 'selectable',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      data-track="view-spine.tab.click"
+      role={selectable ? 'button' : undefined}
+      tabIndex={selectable ? 0 : undefined}
+      aria-label={selectable ? `focus tab ${leaf.label}` : undefined}
+      onClick={selectable ? activate : undefined}
+      onKeyDown={
+        selectable
+          ? (event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                activate();
+              }
+            }
+          : undefined
+      }
+    >
+      <div className="session-row-primary">
+        <SessionIndicator state={leaf.state} />
+        <span
+          className={['session-name', leaf.attention && 'bold']
+            .filter(Boolean)
+            .join(' ')}
+        >
+          <MarqueeText>{leaf.label}</MarqueeText>
+        </span>
+      </div>
+      {leaf.branch ? (
+        <div className="session-row-secondary">
+          <span className="secondary-branch">
+            <MarqueeText>{leaf.branch}</MarqueeText>
+          </span>
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
 // #773: one row per cwd, fusing a derived worktree bench with a persisted
 // overlay sharing that cwd. Renders the union: branch + tab count + "+ tab"
 // (when a derived worktree backs it), env badge + delete (when an overlay backs
 // it), and the verbatim cwd secondary line for overlay-backed rows.
+// #739: a Bench with tabs is now expand/collapsible, listing its individual Tabs
+// as selectable leaves; per-tab attention bubbles up via `AttentionBadge`.
 function BenchRow({
   instance,
   merged,
   busy,
   onCreateTab,
+  onSelectTab,
   onDeleteOverlay,
 }: {
   instance: ViewTreeInstance;
@@ -83,11 +174,19 @@ function BenchRow({
   /** Overlay delete in flight (disables this row's delete affordance). */
   busy: boolean;
   onCreateTab?: ViewSpineCreateTab | undefined;
+  /** #739: focus/select an individual Tab leaf. */
+  onSelectTab?: ViewSpineSelectTab | undefined;
   /** Delete the persisted overlay backing this row. Only invoked when
    *  `merged.overlayId` is set. */
   onDeleteOverlay: (overlayId: string) => void;
 }) {
   const { bench } = merged;
+  // #739: the individual Tab leaves under this bench (empty for an overlay-only
+  // row with no derived worktree → no sessions). Default expanded so attention
+  // tabs are visible without an extra click; collapsible to reduce noise.
+  const leaves = bench?.tab.leaves ?? [];
+  const hasLeaves = leaves.length > 0;
+  const [expanded, setExpanded] = useState(true);
   // Per-bench in-flight guard so the affordance disables itself (and other
   // benches stay clickable) while a create is pending. Errors surface through
   // the existing create path's toast — no bespoke error UI here.
@@ -130,10 +229,36 @@ function BenchRow({
         .join(' ')}
     >
       <div className="session-row-primary">
+        {/* #739: collapse/expand toggle — only when this bench has Tab leaves.
+            Keyboard-accessible (real button), stops propagation so it never
+            triggers a row-level action. */}
+        {hasLeaves ? (
+          <button
+            type="button"
+            className={['collapse-chevron', !expanded && 'collapsed']
+              .filter(Boolean)
+              .join(' ')}
+            aria-expanded={expanded}
+            aria-label={
+              expanded
+                ? `collapse tabs for ${merged.label}`
+                : `expand tabs for ${merged.label}`
+            }
+            onClick={(e) => {
+              e.stopPropagation();
+              setExpanded((v) => !v);
+            }}
+          >
+            {expanded ? '⌄' : '›'}
+          </button>
+        ) : null}
         <span className="session-name">
           <MarqueeText>{merged.label}</MarqueeText>
         </span>
         {bench ? <CountBadge count={bench.tab.count} /> : null}
+        {/* #739: attention bubbles up from the bench's tabs (shown when collapsed
+            OR expanded — the badge is the at-a-glance summary). */}
+        {bench ? <AttentionBadge attention={bench.attention} /> : null}
         {envCount > 0 ? (
           <span
             className="bench-overlay-env-badge"
@@ -172,6 +297,20 @@ function BenchRow({
             <MarqueeText>{merged.cwd}</MarqueeText>
           </span>
         </div>
+      ) : null}
+      {/* #739: individual Tab leaves, indented one level below the bench. Each
+          is a selectable row that focuses the session via the existing
+          active-session action. Hidden when collapsed. */}
+      {hasLeaves && expanded ? (
+        <ul className="session-list view-spine-tab-leaf-list">
+          {leaves.map((leaf) => (
+            <TabLeafRow
+              key={leaf.selectKey}
+              leaf={leaf}
+              onSelectTab={onSelectTab}
+            />
+          ))}
+        </ul>
       ) : null}
       {/* #731 "+ tab" anchored to THIS bench's (nodeId, repoPath, worktree).
           Reuses the `.add-worktree-row`/`.add-worktree-btn` styling ONLY — it
@@ -216,6 +355,7 @@ function InstanceRow({
   projectKind,
   overlays,
   onCreateTab,
+  onSelectTab,
   onRefetchBenches,
 }: {
   instance: ViewTreeInstance;
@@ -224,6 +364,8 @@ function InstanceRow({
    *  tree-level `GET /hub/ia/benches` (#773 — no per-instance fan-out). */
   overlays: BenchOverlayInput[];
   onCreateTab?: ViewSpineCreateTab | undefined;
+  /** #739: focus/select an individual Tab leaf. */
+  onSelectTab?: ViewSpineSelectTab | undefined;
   /** Refetch the tree-level bench cache (reconcile after a failed mutation). */
   onRefetchBenches: () => void;
 }) {
@@ -265,7 +407,22 @@ function InstanceRow({
           <MarqueeText>{instance.hostLabel}</MarqueeText>
         </span>
         <CountBadge count={instance.rootTab.count} />
+        {/* #739: attention bubbled up from all of this instance's tabs. */}
+        <AttentionBadge attention={instance.attention} />
       </div>
+      {/* #739: root-anchored Tabs (sessions at the repo root, no worktree) listed
+          as selectable leaves directly under the instance. */}
+      {instance.rootTab.leaves.length > 0 ? (
+        <ul className="session-list view-spine-tab-leaf-list">
+          {instance.rootTab.leaves.map((leaf) => (
+            <TabLeafRow
+              key={leaf.selectKey}
+              leaf={leaf}
+              onSelectTab={onSelectTab}
+            />
+          ))}
+        </ul>
+      ) : null}
       {merged.length > 0 ? (
         <ul className="session-list view-spine-bench-list">
           {merged.map((row) => (
@@ -275,6 +432,7 @@ function InstanceRow({
               merged={row}
               busy={deleteMutation.isPending}
               onCreateTab={onCreateTab}
+              onSelectTab={onSelectTab}
               onDeleteOverlay={handleDeleteOverlay}
             />
           ))}
@@ -355,6 +513,7 @@ function ProjectRow({
   project,
   overlaysByInstance,
   onCreateTab,
+  onSelectTab,
   onRefetchBenches,
   assign,
 }: {
@@ -362,6 +521,8 @@ function ProjectRow({
   /** Persisted bench overlays grouped by instanceId (#773 single query). */
   overlaysByInstance: Map<string, BenchOverlayInput[]>;
   onCreateTab?: ViewSpineCreateTab | undefined;
+  /** #739: focus/select an individual Tab leaf. */
+  onSelectTab?: ViewSpineSelectTab | undefined;
   onRefetchBenches: () => void;
   assign?: ProjectAssignControl | undefined;
 }) {
@@ -398,6 +559,8 @@ function ProjectRow({
           {instanceCount > 1 ? (
             <span className="session-count-badge">{instanceCount}</span>
           ) : null}
+          {/* #739: attention bubbled up from every Tab in this project. */}
+          <AttentionBadge attention={project.attention} />
         </div>
         {assign ? (
           <ProjectAssignSelect project={project} assign={assign} />
@@ -411,6 +574,7 @@ function ProjectRow({
             projectKind={project.kind}
             overlays={overlaysByInstance.get(instance.id) ?? []}
             onCreateTab={onCreateTab}
+            onSelectTab={onSelectTab}
             onRefetchBenches={onRefetchBenches}
           />
         ))}
@@ -422,8 +586,15 @@ function ProjectRow({
 
 // Reduced-anatomy row: structurally omits `.initial-block` AND
 // `.secondary-branch` JSX so repo-identity/branch leakage is impossible by
-// construction for repoPath-less (free/remote) sessions.
-function FreeRow({ entry }: { entry: ViewTreeFreeEntry }) {
+// construction for repoPath-less (free/remote) sessions. #739: its Tab leaves are
+// selectable too (branch-less by construction) and attention bubbles up here.
+function FreeRow({
+  entry,
+  onSelectTab,
+}: {
+  entry: ViewTreeFreeEntry;
+  onSelectTab?: ViewSpineSelectTab | undefined;
+}) {
   return (
     <li className="session-row view-spine-free-row">
       <div className="session-row-primary">
@@ -437,7 +608,19 @@ function FreeRow({ entry }: { entry: ViewTreeFreeEntry }) {
           <MarqueeText>{entry.label}</MarqueeText>
         </span>
         <CountBadge count={entry.tab.count} />
+        <AttentionBadge attention={entry.attention} />
       </div>
+      {entry.tab.leaves.length > 0 ? (
+        <ul className="session-list view-spine-tab-leaf-list">
+          {entry.tab.leaves.map((leaf) => (
+            <TabLeafRow
+              key={leaf.selectKey}
+              leaf={leaf}
+              onSelectTab={onSelectTab}
+            />
+          ))}
+        </ul>
+      ) : null}
     </li>
   );
 }
@@ -522,10 +705,14 @@ function LensSelector({
 
 export function ViewSpineTree({
   onCreateTab,
+  onSelectTab,
 }: {
   /** #731: create a Tab anchored to a Bench's (nodeId, cwd). Read-only when
    *  omitted — the "+ tab" affordance only renders when this is provided. */
   onCreateTab?: ViewSpineCreateTab | undefined;
+  /** #739: focus/select an individual Tab leaf. Leaves render as static rows
+   *  when omitted (read-only); the click action only fires when provided. */
+  onSelectTab?: ViewSpineSelectTab | undefined;
 } = {}) {
   const repos = useSessionsStore((s) => s.repos);
   const worktrees = useSessionsStore((s) => s.worktrees);
@@ -789,6 +976,7 @@ export function ViewSpineTree({
                   project={project}
                   overlaysByInstance={overlaysByInstance}
                   onCreateTab={onCreateTab}
+                  onSelectTab={onSelectTab}
                   onRefetchBenches={onRefetchBenches}
                   assign={makeAssign(project)}
                 />
@@ -808,6 +996,7 @@ export function ViewSpineTree({
                 project={project}
                 overlaysByInstance={overlaysByInstance}
                 onCreateTab={onCreateTab}
+                onSelectTab={onSelectTab}
                 onRefetchBenches={onRefetchBenches}
                 assign={makeAssign(project)}
               />
@@ -820,7 +1009,11 @@ export function ViewSpineTree({
             <div className="sidebar-ungrouped-label">free / remote</div>
             <ul className="session-list">
               {tree.freeLane.map((entry) => (
-                <FreeRow key={entry.key} entry={entry} />
+                <FreeRow
+                  key={entry.key}
+                  entry={entry}
+                  onSelectTab={onSelectTab}
+                />
               ))}
             </ul>
           </section>

--- a/frontend/src/lib/state/view-tree.ts
+++ b/frontend/src/lib/state/view-tree.ts
@@ -13,7 +13,11 @@
 //   (Project, nodeId)   → Instance  (host label: local = `this host`, remote =
 //                                     node displayName; online/stale join).
 //   WorktreeInfo        → Bench      (createBenchId(instanceId, path)).
-//   SessionSummary[]    → Tab COUNTS grouped under (nodeId, worktreePath ?? cwd).
+//   SessionSummary[]    → Tab LEAVES (+ count) grouped under
+//                                     (nodeId, worktreePath ?? cwd). #739 makes
+//                                     the leaf layer interactive: individual Tabs
+//                                     are selectable rows and per-tab attention
+//                                     bubbles up Bench → Instance → Project.
 //   Workspace {repos[]} → Workspace grouping (repo paths → projects).
 //   repoPath-less sess. → SEPARATE free/remote lane (NOT nested under a repo).
 
@@ -42,6 +46,10 @@ import type {
   Workspace,
   WorktreeInfo,
 } from '../types.js';
+import type { DisplayState } from './display-state.js';
+import { isAttentionState } from './display-state.js';
+import { highestPriorityState } from './attention.js';
+import { scopedSessionKey } from '../session-keys.js';
 
 /** Subset of `HubNodeSummary` the projection needs. Keeps the adapter testable
  *  without constructing a full manifest summary. */
@@ -56,9 +64,42 @@ export interface ViewTreeNodeStatus {
  *  `null` when the project-type does not imply a host (and the dot is omitted). */
 export type InstanceHostStatus = HubNodeStatus | null;
 
-export interface ViewTreeTab {
-  /** Count only — leaves are not interactive rows. */
+/** #739: an individual Tab (session) leaf — an interactive, selectable row.
+ *  `selectKey` is the SAME scoped session key the legacy sidebar selects on
+ *  (`scopedSessionKey`), so the leaf click reuses the existing active-session
+ *  action verbatim. `state` is the per-tab lifecycle glyph for `SessionIndicator`,
+ *  derived purely from the `SessionSummary` (no store reconciliation). */
+export interface ViewTreeTabLeaf {
+  /** Stable React key + dedup identity (scoped session key). */
+  selectKey: string;
+  /** Display label: session displayName, else its repo/cwd basename. */
+  label: string;
+  /** Branch this tab runs on, when known (git benches only). */
+  branch: string | null;
+  /** Per-tab lifecycle state for the `SessionIndicator` glyph. */
+  state: DisplayState;
+  /** Whether this tab needs attention (drives the bubble rollup). */
+  attention: boolean;
+  /** Tab activity (ISO), `null` when unknown. */
+  lastActivity: string | null;
+}
+
+/** Per-tab attention rolled up to a node of the tree. `state` is the
+ *  highest-priority attention state among descendant tabs (null = none in an
+ *  attention state); `count` is how many descendant tabs need attention. Mirrors
+ *  the legacy `.repo-attention-badge` anatomy (`SessionIndicator` + count). */
+export interface ViewTreeAttention {
+  /** Highest-priority attention state among descendants, or null when none. */
+  state: DisplayState | null;
+  /** Number of descendant tabs in an attention state. */
   count: number;
+}
+
+export interface ViewTreeTab {
+  /** Count of tabs grouped here (kept for the count badge). */
+  count: number;
+  /** #739: the individual Tabs, as selectable leaves. */
+  leaves: ViewTreeTabLeaf[];
 }
 
 export interface ViewTreeBench {
@@ -76,8 +117,10 @@ export interface ViewTreeBench {
   branch: string | null;
   /** Whether this bench's host is a git repo (drives `.secondary-branch`). */
   isGit: boolean;
-  /** Tab count grouped under this bench-equivalent. */
+  /** Tab count + leaves grouped under this bench-equivalent. */
   tab: ViewTreeTab;
+  /** #739: per-tab attention rolled up to this bench (highest state + count). */
+  attention: ViewTreeAttention;
   /** Most-recent session/worktree activity rolled up here (ISO). `null` when no
    *  recency is known. Drives the `recent` lens; derived during build, NOT a
    *  new fetch. */
@@ -93,8 +136,12 @@ export interface ViewTreeInstance {
   /** Online/stale presence; null when project-type has no host. */
   status: InstanceHostStatus;
   benches: ViewTreeBench[];
-  /** Tab count at the instance root (sessions anchored to the repo, no worktree). */
+  /** Tab count + leaves at the instance root (sessions anchored to the repo, no
+   *  worktree). */
   rootTab: ViewTreeTab;
+  /** #739: per-tab attention rolled up across this instance's benches + root
+   *  tabs (highest state + total count). */
+  attention: ViewTreeAttention;
   /** Max activity across this instance's benches + root sessions (ISO), `null`
    *  when unknown. Rolls up into the project's recency. */
   lastActivity: string | null;
@@ -111,6 +158,9 @@ export interface ViewTreeProject {
   /** Color seed (repo/dir name). `.initial-block` color uses this. */
   colorSeed: string;
   instances: ViewTreeInstance[];
+  /** #739: per-tab attention rolled up across all of this project's instances
+   *  (highest state + total count). Drives the project-level attention badge. */
+  attention: ViewTreeAttention;
   /** Max activity across all of this project's instances (ISO), `null` when
    *  unknown. Drives the `recent` lens ordering of projects. */
   lastActivity: string | null;
@@ -136,8 +186,10 @@ export interface ViewTreeFreeEntry {
   cwd: string;
   /** Last cwd segment for the row label. */
   label: string;
-  /** Tab count grouped under (nodeId, cwd). */
+  /** Tab count + leaves grouped under (nodeId, cwd). */
   tab: ViewTreeTab;
+  /** #739: per-tab attention rolled up for this free group (highest + count). */
+  attention: ViewTreeAttention;
   /** Most-recent session activity for this free group (ISO), `null` when
    *  unknown. Drives the `recent` lens ordering of the free lane. */
   lastActivity: string | null;
@@ -183,6 +235,83 @@ function basename(path: string): string {
   const seg = trimmed.split('/').pop();
   return seg && seg.length > 0 ? seg : path;
 }
+
+// ── #739: per-tab lifecycle state + attention rollup (PURE) ───────────────────
+// A Tab leaf's glyph is derived straight from its `SessionSummary` — NO store
+// reconciliation (the read-only tree owns no seen/unseen memory). This mirrors
+// `sidebar-items.ts#sessionToBackendState` + `initialDisplayState` collapsed into
+// one mapping so an individual session maps to a `SessionIndicator` state. The
+// only divergence from the legacy per-GROUP reconciled state: an idle tab shows
+// `seen-idle` (no unseen memory), so the read-only tree never invents an
+// attention bubble the sidebar wouldn't also raise on its first paint.
+
+/** Map a single session to its `SessionIndicator` lifecycle state, purely. */
+function sessionDisplayState(session: SessionSummary): DisplayState {
+  const { agentState, idle, permissionType, createdAt } = session;
+  if (agentState === 'permission-prompt') {
+    return permissionType === 'question' ? 'needs-answer' : 'permission';
+  }
+  if (agentState === 'error') return 'error';
+  if (agentState === 'processing') return 'running';
+  if (agentState === 'initializing') return 'initializing';
+  // Brand-new sessions without a defined agentState read as initializing (not
+  // running) to avoid flashing an active glyph at 0s — same guard as the sidebar.
+  const isVeryNew = createdAt
+    ? Date.now() - new Date(createdAt).getTime() < 30_000
+    : false;
+  if (!agentState && !idle && isVeryNew) return 'initializing';
+  if (!agentState && !idle) return 'running';
+  // Idle: no unseen memory in the read-only tree → seen-idle (non-attention).
+  return 'seen-idle';
+}
+
+/** Build the interactive Tab leaf for a session. Label/branch presentation
+ *  matches the legacy sidebar (displayName, then cwd basename). */
+function tabLeafFor(
+  session: SessionSummary,
+  isGit: boolean
+): ViewTreeTabLeaf {
+  const state = sessionDisplayState(session);
+  return {
+    selectKey: scopedSessionKey(session),
+    label: session.displayName || basename(session.cwd),
+    // Branch only surfaces for git benches — mirrors the bench-level guard so a
+    // directory/free tab never leaks a branch.
+    branch: isGit ? (session.branchName || null) : null,
+    state,
+    attention: isAttentionState(state),
+    lastActivity: session.lastActivity || null,
+  };
+}
+
+/** Roll a flat list of tab leaves up into an attention summary: highest-priority
+ *  attention state among them + the count of attention tabs. PURE. */
+function rollUpAttention(leaves: ViewTreeTabLeaf[]): ViewTreeAttention {
+  const attentionStates = leaves
+    .filter((leaf) => leaf.attention)
+    .map((leaf) => leaf.state);
+  return {
+    state: highestPriorityState(attentionStates),
+    count: attentionStates.length,
+  };
+}
+
+/** Combine two already-derived attention summaries (child → parent rollup).
+ *  PURE. */
+function mergeAttention(
+  a: ViewTreeAttention,
+  b: ViewTreeAttention
+): ViewTreeAttention {
+  const states = [a.state, b.state].filter(
+    (s): s is DisplayState => s !== null
+  );
+  return {
+    state: highestPriorityState(states),
+    count: a.count + b.count,
+  };
+}
+
+const NO_ATTENTION: ViewTreeAttention = { state: null, count: 0 };
 
 function projectIdentityFor(repo: Repo): ProjectIdentity {
   const isGit = repo.isGitRepo && repo.kind !== 'directory';
@@ -237,6 +366,8 @@ interface MutableInstance {
   status: InstanceHostStatus;
   benchesByPath: Map<string, ViewTreeBench>;
   rootTabCount: number;
+  /** #739: root-anchored Tab leaves (sessions at the repo root, no worktree). */
+  rootLeaves: ViewTreeTabLeaf[];
   /** Rolled-up recency for root sessions (benches carry their own). */
   rootLastActivity: string | null;
 }
@@ -270,6 +401,7 @@ function ensureInstance(
     status: statusFor(nodeId, nodesById),
     benchesByPath: new Map(),
     rootTabCount: 0,
+    rootLeaves: [],
     rootLastActivity: null,
   };
   project.instancesByNode.set(nodeId, instance);
@@ -306,7 +438,9 @@ function ensureBench(
     // for directory projects so identity/branch leakage is impossible.
     isGit: project.isGit,
     branch: project.isGit ? (branch ?? null) : null,
-    tab: { count: 0 },
+    tab: { count: 0, leaves: [] },
+    // Attention is rolled up from the bench's leaves at finalize time.
+    attention: NO_ATTENTION,
     lastActivity: activity ?? null,
   };
   instance.benchesByPath.set(path, bench);
@@ -379,12 +513,21 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
   const freeByKey = new Map<string, ViewTreeFreeEntry>();
 
   /** Add a repoPath-less (or orphaned) session to the free lane, rolling up its
-   *  recency. Shared by the two no-anchor branches below. */
-  function addToFreeLane(nodeId: NodeId, cwd: string, activity: string | null) {
+   *  recency + a (branch-less, identity-less) Tab leaf. Shared by the two
+   *  no-anchor branches below. */
+  function addToFreeLane(
+    nodeId: NodeId,
+    cwd: string,
+    session: SessionSummary
+  ) {
+    const activity = session.lastActivity || null;
     const key = `${nodeId} ${cwd}`;
+    // Free leaves are NON-git by construction → no branch leak (C2).
+    const leaf = tabLeafFor(session, false);
     const existing = freeByKey.get(key);
     if (existing) {
       existing.tab.count += 1;
+      existing.tab.leaves.push(leaf);
       existing.lastActivity = maxActivity(existing.lastActivity, activity);
       return;
     }
@@ -397,7 +540,9 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
       status: statusFor(nodeId, nodesById),
       cwd,
       label: basename(cwd),
-      tab: { count: 1 },
+      tab: { count: 1, leaves: [leaf] },
+      // Rolled up from leaves at finalize time.
+      attention: NO_ATTENTION,
       lastActivity: activity ?? null,
     });
   }
@@ -409,7 +554,7 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
     // Free/remote no-anchor sessions (no repoPath): SEPARATE top-level lane.
     // Carry NO branch and NO repo identity by construction (leak guard C2).
     if (!session.repoPath) {
-      addToFreeLane(nodeId, session.worktreePath ?? session.cwd, activity);
+      addToFreeLane(nodeId, session.worktreePath ?? session.cwd, session);
       continue;
     }
 
@@ -419,7 +564,7 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
     if (!projectId) {
       // repoPath set but no matching repo row — treat as free-lane to avoid
       // inventing a project. Still carries no branch/identity.
-      addToFreeLane(nodeId, session.worktreePath ?? session.cwd, activity);
+      addToFreeLane(nodeId, session.worktreePath ?? session.cwd, session);
       continue;
     }
     const project = projectsById.get(projectId);
@@ -436,13 +581,15 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
         activity
       );
       bench.tab.count += 1;
+      bench.tab.leaves.push(tabLeafFor(session, project.isGit));
     } else {
-      // Anchored at the repo root → instance root tab count.
+      // Anchored at the repo root → instance root tab count + leaf.
       instance.rootLastActivity = maxActivity(
         instance.rootLastActivity,
         activity
       );
       instance.rootTabCount += 1;
+      instance.rootLeaves.push(tabLeafFor(session, project.isGit));
     }
   }
 
@@ -455,13 +602,19 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
         return a.hostLabel.localeCompare(b.hostLabel);
       })
       .map((inst) => {
-        const benches = [...inst.benchesByPath.values()].sort((a, b) =>
-          a.path.localeCompare(b.path)
-        );
+        const benches = [...inst.benchesByPath.values()]
+          .sort((a, b) => a.path.localeCompare(b.path))
+          // #739: roll each bench's leaves up into its attention summary.
+          .map((b) => ({ ...b, attention: rollUpAttention(b.tab.leaves) }));
         // Instance recency = max(root sessions, all bench activity).
         const lastActivity = benches.reduce<string | null>(
           (acc, b) => maxActivity(acc, b.lastActivity),
           inst.rootLastActivity
+        );
+        // #739: instance attention = root tabs ∪ all benches.
+        const attention = benches.reduce<ViewTreeAttention>(
+          (acc, b) => mergeAttention(acc, b.attention),
+          rollUpAttention(inst.rootLeaves)
         );
         return {
           id: inst.id,
@@ -469,8 +622,9 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
           hostLabel: inst.hostLabel,
           isLocal: inst.isLocal,
           status: inst.status,
-          rootTab: { count: inst.rootTabCount },
+          rootTab: { count: inst.rootTabCount, leaves: inst.rootLeaves },
           benches,
+          attention,
           lastActivity,
         };
       });
@@ -479,6 +633,11 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
       (acc, inst) => maxActivity(acc, inst.lastActivity),
       null
     );
+    // #739: project attention = merge across all instances.
+    const attention = instances.reduce<ViewTreeAttention>(
+      (acc, inst) => mergeAttention(acc, inst.attention),
+      NO_ATTENTION
+    );
     return {
       id: project.id,
       identity: project.identity,
@@ -486,6 +645,7 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
       label: project.label,
       colorSeed: project.colorSeed,
       instances,
+      attention,
       lastActivity,
     };
   }
@@ -528,9 +688,10 @@ export function buildViewTree(input: BuildViewTreeInput): ViewTree {
   }
   ungroupedProjects.sort((a, b) => a.label.localeCompare(b.label));
 
-  const freeLane = [...freeByKey.values()].sort((a, b) =>
-    a.key.localeCompare(b.key)
-  );
+  const freeLane = [...freeByKey.values()]
+    // #739: roll each free entry's leaves up into its attention summary.
+    .map((entry) => ({ ...entry, attention: rollUpAttention(entry.tab.leaves) }))
+    .sort((a, b) => a.key.localeCompare(b.key));
 
   return { workspaces, ungroupedProjects, freeLane };
 }

--- a/test/view-tree.test.ts
+++ b/test/view-tree.test.ts
@@ -636,3 +636,193 @@ describe('S4 workspace-group ws.repos guard', () => {
     expect(tree.ungroupedProjects.map((p) => p.label)).toEqual(['grouped']);
   });
 });
+
+// ── #739: interactive Tab leaves + attention bubbling ─────────────────────────
+
+describe('#739 tab leaves', () => {
+  it('lists individual Tabs per bench with a stable select key + label + branch', () => {
+    const tree = build({
+      repos: [repo()],
+      sessions: [
+        session({
+          id: 'a',
+          repoPath: '/repos/relay',
+          worktreePath: '/repos/relay/.worktrees/x',
+          branchName: 'feature/x',
+          displayName: 'agent one',
+          cwd: '/repos/relay/.worktrees/x',
+        }),
+        session({
+          id: 'b',
+          repoPath: '/repos/relay',
+          worktreePath: '/repos/relay/.worktrees/x',
+          branchName: 'feature/x',
+          displayName: 'agent two',
+          cwd: '/repos/relay/.worktrees/x',
+        }),
+      ],
+    });
+    const bench = allProjects(tree)[0]!.instances[0]!.benches[0]!;
+    expect(bench.tab.count).toBe(2);
+    expect(bench.tab.leaves.map((l) => l.label)).toEqual([
+      'agent one',
+      'agent two',
+    ]);
+    // Select key is the scoped session key (node-scoped global id form here).
+    expect(bench.tab.leaves[0]!.selectKey).toContain('a');
+    expect(bench.tab.leaves[0]!.branch).toBe('feature/x');
+  });
+
+  it('root-anchored sessions become instance root tab leaves', () => {
+    const tree = build({
+      repos: [repo()],
+      sessions: [
+        session({
+          id: 'root',
+          repoPath: '/repos/relay',
+          displayName: 'root agent',
+          cwd: '/repos/relay',
+        }),
+      ],
+    });
+    const instance = allProjects(tree)[0]!.instances[0]!;
+    expect(instance.rootTab.count).toBe(1);
+    expect(instance.rootTab.leaves.map((l) => l.label)).toEqual(['root agent']);
+  });
+
+  it('directory/free tab leaves carry NO branch (leak guard)', () => {
+    const tree = build({
+      sessions: [
+        session({
+          id: 'free',
+          cwd: '/tmp/scratch',
+          branchName: 'should-not-leak',
+          displayName: 'scratch session',
+        }),
+      ],
+    });
+    const entry = tree.freeLane[0]!;
+    expect(entry.tab.leaves).toHaveLength(1);
+    expect(entry.tab.leaves[0]!.branch).toBeNull();
+    // No field VALUE leaks the branch string.
+    expect(JSON.stringify(entry.tab.leaves[0])).not.toContain('should-not-leak');
+  });
+});
+
+describe('#739 attention rollup', () => {
+  // A session whose agentState puts it in a given attention/non-attention state.
+  const attn = (id: string, agentState: SessionSummary['agentState'], extra: Partial<SessionSummary> = {}) =>
+    session({
+      id,
+      repoPath: '/repos/relay',
+      worktreePath: `/repos/relay/.worktrees/${id}`,
+      cwd: `/repos/relay/.worktrees/${id}`,
+      agentState,
+      idle: agentState === 'idle',
+      ...extra,
+    });
+
+  it('no-attention case: idle tabs leave bench/instance/project quiet', () => {
+    const tree = build({
+      repos: [repo()],
+      sessions: [attn('a', 'idle'), attn('b', 'idle')],
+    });
+    const project = allProjects(tree)[0]!;
+    const instance = project.instances[0]!;
+    for (const bench of instance.benches) {
+      expect(bench.attention.state).toBeNull();
+      expect(bench.attention.count).toBe(0);
+    }
+    expect(instance.attention.state).toBeNull();
+    expect(instance.attention.count).toBe(0);
+    expect(project.attention.state).toBeNull();
+    expect(project.attention.count).toBe(0);
+  });
+
+  it('bubbles a single attention tab bench → instance → project', () => {
+    const tree = build({
+      repos: [repo()],
+      sessions: [attn('a', 'idle'), attn('b', 'permission-prompt')],
+    });
+    const project = allProjects(tree)[0]!;
+    const instance = project.instances[0]!;
+    const benchB = instance.benches.find((x) =>
+      x.path.endsWith('/b')
+    )!;
+    const benchA = instance.benches.find((x) =>
+      x.path.endsWith('/a')
+    )!;
+    // Only bench b's tab needs attention.
+    expect(benchA.attention.state).toBeNull();
+    expect(benchA.attention.count).toBe(0);
+    expect(benchB.attention.state).toBe('permission');
+    expect(benchB.attention.count).toBe(1);
+    // Instance + project see exactly one attention tab.
+    expect(instance.attention.state).toBe('permission');
+    expect(instance.attention.count).toBe(1);
+    expect(project.attention.state).toBe('permission');
+    expect(project.attention.count).toBe(1);
+  });
+
+  it('picks the HIGHEST-priority attention state and SUMS counts up the tree', () => {
+    const tree = build({
+      repos: [repo()],
+      sessions: [
+        // error (priority 800) on bench a
+        attn('a', 'error'),
+        // permission (priority 1000) on bench b → wins
+        attn('b', 'permission-prompt'),
+        // a second attention tab on bench b → count rolls up to 3 total
+        session({
+          id: 'b2',
+          repoPath: '/repos/relay',
+          worktreePath: '/repos/relay/.worktrees/b',
+          cwd: '/repos/relay/.worktrees/b',
+          agentState: 'error',
+          idle: false,
+        }),
+      ],
+    });
+    const project = allProjects(tree)[0]!;
+    const instance = project.instances[0]!;
+    const benchB = instance.benches.find((x) => x.path.endsWith('/b'))!;
+    // bench b: permission beats error; 2 attention tabs.
+    expect(benchB.attention.state).toBe('permission');
+    expect(benchB.attention.count).toBe(2);
+    // project: highest = permission; total attention tabs = 3 (a + b + b2).
+    expect(project.attention.state).toBe('permission');
+    expect(project.attention.count).toBe(3);
+  });
+
+  it('rolls attention across multiple instances of one project', () => {
+    const tree = build({
+      repos: [repo()],
+      nodes: [node({ nodeId: 'macbook', status: 'online' })],
+      sessions: [
+        // local instance: idle
+        attn('local', 'idle'),
+        // remote instance: needs-answer
+        attn('remote', 'permission-prompt', {
+          nodeId: 'macbook',
+          permissionType: 'question',
+        }),
+      ],
+    });
+    const project = allProjects(tree)[0]!;
+    expect(project.instances.length).toBeGreaterThanOrEqual(2);
+    // needs-answer bubbles to the project even though it's on a remote instance.
+    expect(project.attention.state).toBe('needs-answer');
+    expect(project.attention.count).toBe(1);
+  });
+
+  it('bubbles attention for free-lane tabs', () => {
+    const tree = build({
+      sessions: [
+        session({ id: 'free', cwd: '/tmp/w', agentState: 'permission-prompt', idle: false }),
+      ],
+    });
+    const entry = tree.freeLane[0]!;
+    expect(entry.attention.state).toBe('permission');
+    expect(entry.attention.count).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Follow-up to the #444 view-spine MVP (#729). The MVP rendered Tab leaves as a count badge on the Bench row — the spine tree was read-only and listed no individual sessions. This makes the leaf layer interactive and bubbles per-tab attention up the tree. Behind the existing `view-spine` flag (default OFF); the OFF path is untouched.

### Expand to tabs + select
- Each Bench is now expand/collapsible, listing its individual Tabs (sessions) as selectable rows: `SessionIndicator` lifecycle glyph + session name + branch (git benches only).
- Clicking a Tab focuses/selects it via the **existing** active-session action — `ViewSpineTree` gains an `onSelectTab` prop that `Sidebar` wires to the same `onSelectSession` (`handleSelectSession`) the legacy sidebar uses. The leaf's `selectKey` is `scopedSessionKey(session)`, identical to the legacy selection key. No new select flow.
- Root-anchored Tabs (sessions at the repo root, no worktree) and free/remote Tabs render as selectable leaves too.

### Attention rollup (pure, in `view-tree.ts`)
- Per-tab `DisplayState` is derived purely from each `SessionSummary` (mirrors `sidebar-items.ts` backend-state mapping; idle → `seen-idle` since the read-only tree owns no seen/unseen memory).
- Attention bubbles **bench → instance → project** (and per free entry): a node carries the highest-priority attention state among its descendant tabs + the count of attention tabs, reusing `isAttentionState` + `highestPriorityState`.
- Rendered via `AttentionBadge`, which reuses the legacy `.repo-attention-badge` anatomy (`SessionIndicator` + count). The count badge is kept alongside it.
- Directory/free tab leaves carry **no branch** by construction (leak guard).

## States covered
- Empty bench (no tabs) → no leaf list, no chevron, just the `+ tab` affordance.
- Loading / empty-tree paths unchanged.
- Expand/collapse is a real `<button>` (keyboard-accessible, `aria-expanded`); leaf rows are `role=button` + `tabIndex=0`, Enter/Space activate.
- Touch targets ≥44px; overflow via `MarqueeText`.
- No new colors/animations — all tones from existing design tokens.

## Tests / gates (Node 24)
- `npm run build` ✓
- `npm run check` ✓ (0 errors; pre-existing sonarjs warnings only, none in changed files)
- `npm test` ✓ — 3962 passed (304 files), incl. 9 new pure-logic tests in `test/view-tree.test.ts`: tab-list derivation, root-tab leaves, branch leak guard, and attention rollup (no-attention, single bubble, highest-state/sum-count, multi-instance, free-lane).

## Files
- `frontend/src/lib/state/view-tree.ts` — tab leaves + attention types + pure rollup
- `frontend/src/components/ViewSpineTree.tsx` — interactive leaves, attention badges, `onSelectTab`
- `frontend/src/components/ViewSpineTree.css` — leaf indent + selectable/touch/chevron styles
- `frontend/src/components/Sidebar.tsx` — wire `onSelectTab` → `onSelectSession`
- `test/view-tree.test.ts` — new tests

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Individual session tabs now display as selectable items in the sidebar tree
  * Attention indicators added at the session and project levels

* **Style**
  * Enhanced tab styling with interactive hover, focus, and selection states
  * Added expand/collapse controls for session tab lists
  * Improved keyboard navigation and accessibility for tab selection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->