### PR TITLE
fix: limit inbox pull delivery

### DIFF
--- a/server/features/context-inbox-store-adapter.ts
+++ b/server/features/context-inbox-store-adapter.ts
@@ -167,10 +167,8 @@ export function createContextInboxStoreAdapter(
           : {}),
         ...(filter.state ? { state: filter.state } : {}),
       });
-      const delivered = messages.map((m) => deliverOnPull(store, m));
-      // Apply `limit` after the flip so the row count is stable regardless of
-      // delivery side effects (the store has no LIMIT clause on this read).
-      return filter.limit !== undefined ? delivered.slice(0, filter.limit) : delivered;
+      const visible = filter.limit !== undefined ? messages.slice(0, filter.limit) : messages;
+      return visible.map((m) => deliverOnPull(store, m));
     },
 
     // PULL delivery: getting a queued message by id flips it to delivered.

--- a/test/context-inbox-router.test.ts
+++ b/test/context-inbox-router.test.ts
@@ -113,10 +113,9 @@ function createFakeStore(): ContextInboxStore & { _markDelivered: boolean } {
         all = all.filter((m) => m.targetWorkContextId === filter.targetWorkContextId);
       }
       if (filter.state) all = all.filter((m) => m.state === filter.state);
-      // PULL delivery side effect.
-      all = all.map((m) => deliverOnPull(m));
       if (filter.limit !== undefined) all = all.slice(0, filter.limit);
-      return all;
+      // PULL delivery side effect applies only to rows returned by the list.
+      return all.map((m) => deliverOnPull(m));
     },
     getInboxMessage(id: string): SessionInboxMessage | null {
       const message = messages.get(id);

--- a/test/context-inbox-store-adapter.test.ts
+++ b/test/context-inbox-store-adapter.test.ts
@@ -94,6 +94,24 @@ describe('context-inbox store adapter — PULL-as-delivery flip', () => {
     expect(store.getInboxMessage(msg.id)?.state).toBe('delivered');
   });
 
+  it('listInboxMessages with a limit flips only returned queued rows', () => {
+    const first = seedMessage(SESSION_A);
+    const second = seedMessage(SESSION_A);
+    const third = seedMessage(SESSION_A);
+
+    const listed = adapter.listInboxMessages({ targetSessionId: SESSION_A, limit: 2 });
+
+    expect(listed).toHaveLength(2);
+    const listedIds = new Set(listed.map((m) => m.id));
+    expect(listed.every((m) => m.state === 'delivered')).toBe(true);
+    for (const message of [first, second, third]) {
+      expect(store.getInboxMessage(message.id)?.state).toBe(
+        listedIds.has(message.id) ? 'delivered' : 'queued'
+      );
+    }
+    expect([first, second, third].filter((m) => !listedIds.has(m.id))).toHaveLength(1);
+  });
+
   it('re-fetching a delivered message is idempotent (no-op, timestamp preserved)', () => {
     const msg = seedMessage();
     const first = adapter.getInboxMessage(msg.id);


### PR DESCRIPTION
## Summary
- Change inbox PULL delivery to slice `listInboxMessages` results before flipping queued rows to delivered.
- Add regression coverage proving `limit=N` delivers only returned message ids and leaves one non-returned queued row untouched.
- Align the router fake store with the same slice-before-delivery behavior.

Closes #778

## Test Plan
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/context-inbox-store-adapter.test.ts test/context-inbox-router.test.ts` (24 tests passed)
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check` (passed; existing eslint warnings only)

## Behavior Evidence
- `adapter.listInboxMessages({ targetSessionId, limit: 2 })` now slices the matching rows first and only calls `deliverOnPull` for those visible rows.
- The new regression test seeds three queued messages, lists with `limit: 2`, asserts exactly two returned messages are delivered, and asserts the one message id outside the returned slice remains queued in the underlying store.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inbox message delivery behavior when applying limits. Only messages returned in the result set are now marked as delivered, while other queued messages remain unaffected.

* **Tests**
  * Added integration test to verify proper message delivery behavior with limits applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->