### PR TITLE
Implement context packet pinning to WorkContexts

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -461,7 +461,7 @@ function requireGatewaySessionId(
 
 function gatewayUsage(): never {
   logger.error(
-    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions renew|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|files write|work-contexts get|context create|context get|context list|inbox send|inbox list|inbox get|inbox ack|inbox resolve|inbox ignore|handoffs plan|handoffs create|handoffs status|handoffs cancel|handoffs resume|handoffs launch|artifacts read|supervisor snapshot|supervisor sessions|supervisor send-text|supervisor submit|events subscribe) --json'
+    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions renew|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|files write|work-contexts get|context create|context get|context list|context pin|context unpin|inbox send|inbox list|inbox get|inbox ack|inbox resolve|inbox ignore|handoffs plan|handoffs create|handoffs status|handoffs cancel|handoffs resume|handoffs launch|artifacts read|supervisor snapshot|supervisor sessions|supervisor send-text|supervisor submit|events subscribe) --json'
   );
   process.exit(1);
 }
@@ -1513,10 +1513,13 @@ async function runGatewayWorkContexts(gatewayArgs: string[]): Promise<never> {
   const subcommand = gatewayArgs[1];
   const workContextArgs = gatewayArgs.slice(2);
   if (subcommand !== 'get') {
-    gatewayInvalid('work-contexts.get', 'unknown work-contexts command', { args: gatewayArgs });
+    gatewayInvalid('work-contexts.get', 'unknown work-contexts command', {
+      args: gatewayArgs,
+    });
   }
   const id = gatewayArg(workContextArgs, '--id') ?? workContextArgs[0];
-  if (!id || id.startsWith('--')) gatewayInvalid('work-contexts.get', '--id is required');
+  if (!id || id.startsWith('--'))
+    gatewayInvalid('work-contexts.get', '--id is required');
   const result = await gatewayHttpJson({
     commandName: 'work-contexts.get',
     pathName: `/work-contexts/${encodeURIComponent(id)}`,
@@ -1541,7 +1544,8 @@ async function runGatewayContext(gatewayArgs: string[]): Promise<never> {
   }
   if (subcommand === 'get') {
     const id = gatewayArg(contextArgs, '--id') ?? contextArgs[0];
-    if (!id || id.startsWith('--')) gatewayInvalid('context.get', '--id is required');
+    if (!id || id.startsWith('--'))
+      gatewayInvalid('context.get', '--id is required');
     const result = await gatewayHttpJson({
       commandName: 'context.get',
       pathName: `/context/${encodeURIComponent(id)}`,
@@ -1553,9 +1557,11 @@ async function runGatewayContext(gatewayArgs: string[]): Promise<never> {
     const query = new URLSearchParams();
     const nodeId = gatewayArg(contextArgs, '--node-id');
     const workspaceId = gatewayArg(contextArgs, '--workspace-id');
+    const workContextId = gatewayArg(contextArgs, '--work-context-id');
     const limit = gatewayArg(contextArgs, '--limit');
     if (nodeId) query.set('nodeId', nodeId);
     if (workspaceId) query.set('workspaceId', workspaceId);
+    if (workContextId) query.set('workContextId', workContextId);
     if (limit) query.set('limit', limit);
     const suffix = query.toString();
     const result = await gatewayHttpJson({
@@ -1565,7 +1571,43 @@ async function runGatewayContext(gatewayArgs: string[]): Promise<never> {
     });
     printGatewayEnvelope(gatewayOk('context.list', result), 0);
   }
-  gatewayInvalid('context.get', 'unknown context command', { args: gatewayArgs });
+  if (subcommand === 'pin' || subcommand === 'unpin') {
+    const commandName: RelayCliGatewayCommand =
+      subcommand === 'pin' ? 'context.pin' : 'context.unpin';
+    const input = parseGatewayInputObject(commandName, contextArgs);
+    const id =
+      gatewayArg(contextArgs, '--id') ??
+      contextArgs[0] ??
+      (typeof input['id'] === 'string' ? input['id'] : undefined);
+    if (!id || id.startsWith('--'))
+      gatewayInvalid(commandName, '--id is required');
+    const workContextId =
+      gatewayArg(contextArgs, '--work-context-id') ??
+      (typeof input['workContextId'] === 'string'
+        ? input['workContextId']
+        : undefined);
+    if (!workContextId) {
+      gatewayInvalid(commandName, '--work-context-id is required', {
+        field: 'workContextId',
+      });
+    }
+    const actorId = gatewayArg(contextArgs, '--actor-id');
+    const createdBy = gatewayArg(contextArgs, '--created-by');
+    const body: Record<string, unknown> = { ...input, workContextId };
+    if (actorId) body['actorId'] = actorId;
+    if (createdBy) body['createdBy'] = createdBy;
+    const result = await gatewayHttpJson({
+      commandName,
+      pathName: `/context/${encodeURIComponent(id)}/${subcommand}`,
+      method: 'POST',
+      body,
+      capabilities: ['context:write'],
+    });
+    printGatewayEnvelope(gatewayOk(commandName, result), 0);
+  }
+  gatewayInvalid('context.get', 'unknown context command', {
+    args: gatewayArgs,
+  });
 }
 
 async function runGatewayInbox(gatewayArgs: string[]): Promise<never> {
@@ -1585,11 +1627,15 @@ async function runGatewayInbox(gatewayArgs: string[]): Promise<never> {
   if (subcommand === 'list') {
     const query = new URLSearchParams();
     const targetSessionId = gatewayArg(inboxArgs, '--target-session-id');
-    const targetWorkContextId = gatewayArg(inboxArgs, '--target-work-context-id');
+    const targetWorkContextId = gatewayArg(
+      inboxArgs,
+      '--target-work-context-id'
+    );
     const state = gatewayArg(inboxArgs, '--state');
     const limit = gatewayArg(inboxArgs, '--limit');
     if (targetSessionId) query.set('targetSessionId', targetSessionId);
-    if (targetWorkContextId) query.set('targetWorkContextId', targetWorkContextId);
+    if (targetWorkContextId)
+      query.set('targetWorkContextId', targetWorkContextId);
     if (state) query.set('state', state);
     if (limit) query.set('limit', limit);
     const suffix = query.toString();
@@ -1602,7 +1648,8 @@ async function runGatewayInbox(gatewayArgs: string[]): Promise<never> {
   }
   if (subcommand === 'get') {
     const id = gatewayArg(inboxArgs, '--id') ?? inboxArgs[0];
-    if (!id || id.startsWith('--')) gatewayInvalid('inbox.get', '--id is required');
+    if (!id || id.startsWith('--'))
+      gatewayInvalid('inbox.get', '--id is required');
     const result = await gatewayHttpJson({
       commandName: 'inbox.get',
       pathName: `/inbox/${encodeURIComponent(id)}`,
@@ -1610,7 +1657,11 @@ async function runGatewayInbox(gatewayArgs: string[]): Promise<never> {
     });
     printGatewayEnvelope(gatewayOk('inbox.get', result), 0);
   }
-  if (subcommand === 'ack' || subcommand === 'resolve' || subcommand === 'ignore') {
+  if (
+    subcommand === 'ack' ||
+    subcommand === 'resolve' ||
+    subcommand === 'ignore'
+  ) {
     const commandName =
       subcommand === 'ack'
         ? 'inbox.ack'
@@ -1618,7 +1669,8 @@ async function runGatewayInbox(gatewayArgs: string[]): Promise<never> {
           ? 'inbox.resolve'
           : 'inbox.ignore';
     const id = gatewayArg(inboxArgs, '--id') ?? inboxArgs[0];
-    if (!id || id.startsWith('--')) gatewayInvalid(commandName, '--id is required');
+    if (!id || id.startsWith('--'))
+      gatewayInvalid(commandName, '--id is required');
     const actorId = gatewayArg(inboxArgs, '--actor-id');
     const result = await gatewayHttpJson({
       commandName,
@@ -1653,13 +1705,20 @@ async function runGatewayHandoffs(gatewayArgs: string[]): Promise<never> {
       pathName: '/handoffs/create',
       method: 'POST',
       body: input,
-      capabilities: ['rpc:fs:read', 'rpc:fs:write', 'session:create:agent', 'session:create:terminal', 'pty:exec:arbitrary'],
+      capabilities: [
+        'rpc:fs:read',
+        'rpc:fs:write',
+        'session:create:agent',
+        'session:create:terminal',
+        'pty:exec:arbitrary',
+      ],
     });
     printGatewayEnvelope(gatewayOk('handoffs.create', result), 0);
   }
   if (subcommand === 'status') {
     const runId = gatewayArg(handoffArgs, '--run-id') ?? handoffArgs[0];
-    if (!runId || runId.startsWith('--')) gatewayInvalid('handoffs.status', '--run-id is required');
+    if (!runId || runId.startsWith('--'))
+      gatewayInvalid('handoffs.status', '--run-id is required');
     const result = await gatewayHttpJson({
       commandName: 'handoffs.status',
       pathName: `/handoffs/${encodeURIComponent(runId)}/status`,
@@ -1669,7 +1728,8 @@ async function runGatewayHandoffs(gatewayArgs: string[]): Promise<never> {
   }
   if (subcommand === 'cancel') {
     const runId = gatewayArg(handoffArgs, '--run-id') ?? handoffArgs[0];
-    if (!runId || runId.startsWith('--')) gatewayInvalid('handoffs.cancel', '--run-id is required');
+    if (!runId || runId.startsWith('--'))
+      gatewayInvalid('handoffs.cancel', '--run-id is required');
     const actorId = gatewayArg(handoffArgs, '--actor-id');
     const result = await gatewayHttpJson({
       commandName: 'handoffs.cancel',
@@ -1682,7 +1742,8 @@ async function runGatewayHandoffs(gatewayArgs: string[]): Promise<never> {
   }
   if (subcommand === 'resume') {
     const runId = gatewayArg(handoffArgs, '--run-id') ?? handoffArgs[0];
-    if (!runId || runId.startsWith('--')) gatewayInvalid('handoffs.resume', '--run-id is required');
+    if (!runId || runId.startsWith('--'))
+      gatewayInvalid('handoffs.resume', '--run-id is required');
     const result = await gatewayHttpJson({
       commandName: 'handoffs.resume',
       pathName: `/handoffs/${encodeURIComponent(runId)}/resume`,
@@ -1692,18 +1753,26 @@ async function runGatewayHandoffs(gatewayArgs: string[]): Promise<never> {
   }
   if (subcommand === 'launch') {
     const runId = gatewayArg(handoffArgs, '--run-id') ?? handoffArgs[0];
-    if (!runId || runId.startsWith('--')) gatewayInvalid('handoffs.launch', '--run-id is required');
+    if (!runId || runId.startsWith('--'))
+      gatewayInvalid('handoffs.launch', '--run-id is required');
     const actorId = gatewayArg(handoffArgs, '--actor-id');
     const result = await gatewayHttpJson({
       commandName: 'handoffs.launch',
       pathName: `/handoffs/${encodeURIComponent(runId)}/launch`,
       method: 'POST',
       body: actorId ? { actorId } : {},
-      capabilities: ['session:read', 'session:create:agent', 'session:create:terminal', 'pty:exec:arbitrary'],
+      capabilities: [
+        'session:read',
+        'session:create:agent',
+        'session:create:terminal',
+        'pty:exec:arbitrary',
+      ],
     });
     printGatewayEnvelope(gatewayOk('handoffs.launch', result), 0);
   }
-  gatewayInvalid('handoffs.plan', 'unknown handoffs command', { args: gatewayArgs });
+  gatewayInvalid('handoffs.plan', 'unknown handoffs command', {
+    args: gatewayArgs,
+  });
 }
 
 async function runGatewaySupervisorSessions(): Promise<never> {
@@ -1721,15 +1790,27 @@ function parseGatewaySupervisorActionBody(
 ): Record<string, unknown> {
   const body = parseGatewayInputObject(commandName, supervisorArgs);
   const id = gatewayArg(supervisorArgs, '--id') ?? supervisorArgs[0];
-  if (id && !id.startsWith('--') && body['id'] === undefined && body['targetIds'] === undefined) {
+  if (
+    id &&
+    !id.startsWith('--') &&
+    body['id'] === undefined &&
+    body['targetIds'] === undefined
+  ) {
     body['id'] = id;
   }
   const targetIds = gatewayArg(supervisorArgs, '--target-ids');
   if (targetIds && body['targetIds'] === undefined) {
-    body['targetIds'] = targetIds.split(',').map((entry) => entry.trim()).filter(Boolean);
+    body['targetIds'] = targetIds
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
   }
   const text = gatewayArg(supervisorArgs, '--text');
-  if (commandName === 'supervisor.sendText' && text !== undefined && body['text'] === undefined) {
+  if (
+    commandName === 'supervisor.sendText' &&
+    text !== undefined &&
+    body['text'] === undefined
+  ) {
     body['text'] = text;
   }
   return body;
@@ -1743,29 +1824,45 @@ function validateGatewaySupervisorActionBody(
     commandName === 'supervisor.sendText' &&
     (typeof body['text'] !== 'string' || body['text'].length === 0)
   ) {
-    gatewayInvalid(commandName, '--text is required for supervisor send-text', { field: 'text' });
+    gatewayInvalid(commandName, '--text is required for supervisor send-text', {
+      field: 'text',
+    });
   }
   const id = body['id'];
   const targetIds = body['targetIds'];
   const hasId = typeof id === 'string' && id.trim().length > 0;
   if (targetIds !== undefined && !Array.isArray(targetIds)) {
-    gatewayInvalid(commandName, '--target-ids must be a non-empty list of session ids', {
-      field: 'targetIds',
-    });
+    gatewayInvalid(
+      commandName,
+      '--target-ids must be a non-empty list of session ids',
+      {
+        field: 'targetIds',
+      }
+    );
   }
   const hasTargetIds = Array.isArray(targetIds);
   if (hasTargetIds) {
     const validTargetIds =
       targetIds.length > 0 &&
-      targetIds.every((entry) => typeof entry === 'string' && entry.trim().length > 0);
+      targetIds.every(
+        (entry) => typeof entry === 'string' && entry.trim().length > 0
+      );
     if (!validTargetIds) {
-      gatewayInvalid(commandName, '--target-ids must be a non-empty list of session ids', {
-        field: 'targetIds',
-      });
+      gatewayInvalid(
+        commandName,
+        '--target-ids must be a non-empty list of session ids',
+        {
+          field: 'targetIds',
+        }
+      );
     }
   }
   if (hasId === hasTargetIds) {
-    gatewayInvalid(commandName, 'exactly one of --id or --target-ids is required', { field: 'id' });
+    gatewayInvalid(
+      commandName,
+      'exactly one of --id or --target-ids is required',
+      { field: 'id' }
+    );
   }
 }
 
@@ -1773,7 +1870,8 @@ async function runGatewaySupervisorAction(
   subcommand: string,
   supervisorArgs: string[]
 ): Promise<never> {
-  const commandName = subcommand === 'submit' ? 'supervisor.submit' : 'supervisor.sendText';
+  const commandName =
+    subcommand === 'submit' ? 'supervisor.submit' : 'supervisor.sendText';
   const body = parseGatewaySupervisorActionBody(commandName, supervisorArgs);
   validateGatewaySupervisorActionBody(commandName, body);
   const result = await gatewayHttpJson({
@@ -1793,7 +1891,10 @@ function parseGatewaySupervisorSnapshotPolicy(supervisorArgs: string[]): {
   expectedControlMode?: 'agent-driven' | 'human-driven' | 'co-driven';
   latestSeenInterventionEventId?: string;
 } {
-  const expectedControlMode = gatewayArg(supervisorArgs, '--expected-control-mode');
+  const expectedControlMode = gatewayArg(
+    supervisorArgs,
+    '--expected-control-mode'
+  );
   const policy: {
     expectedControlMode?: 'agent-driven' | 'human-driven' | 'co-driven';
     latestSeenInterventionEventId?: string;
@@ -1804,10 +1905,14 @@ function parseGatewaySupervisorSnapshotPolicy(supervisorArgs: string[]): {
       expectedControlMode !== 'human-driven' &&
       expectedControlMode !== 'co-driven'
     ) {
-      gatewayInvalid('supervisor.snapshot', '--expected-control-mode is invalid', {
-        field: 'expectedControlMode',
-        value: expectedControlMode,
-      });
+      gatewayInvalid(
+        'supervisor.snapshot',
+        '--expected-control-mode is invalid',
+        {
+          field: 'expectedControlMode',
+          value: expectedControlMode,
+        }
+      );
     }
     policy.expectedControlMode = expectedControlMode;
   }
@@ -1815,11 +1920,14 @@ function parseGatewaySupervisorSnapshotPolicy(supervisorArgs: string[]): {
     supervisorArgs,
     '--latest-seen-intervention-event-id'
   );
-  if (latestSeenInterventionEventId) policy.latestSeenInterventionEventId = latestSeenInterventionEventId;
+  if (latestSeenInterventionEventId)
+    policy.latestSeenInterventionEventId = latestSeenInterventionEventId;
   return policy;
 }
 
-async function runGatewaySupervisorSnapshot(supervisorArgs: string[]): Promise<never> {
+async function runGatewaySupervisorSnapshot(
+  supervisorArgs: string[]
+): Promise<never> {
   const id = requireGatewaySessionId('supervisor.snapshot', supervisorArgs);
   const session = await gatewayHttpJson({
     commandName: 'supervisor.snapshot',
@@ -1843,7 +1951,10 @@ async function runGatewaySupervisorSnapshot(supervisorArgs: string[]): Promise<n
     );
   }
   printGatewayEnvelope(
-    gatewayOk('supervisor.snapshot', { snapshot: result.snapshot, audit: result.audit }),
+    gatewayOk('supervisor.snapshot', {
+      snapshot: result.snapshot,
+      audit: result.audit,
+    }),
     0
   );
 }
@@ -1852,21 +1963,31 @@ async function runGatewaySupervisor(gatewayArgs: string[]): Promise<never> {
   const subcommand = gatewayArgs[1];
   const supervisorArgs = gatewayArgs.slice(2);
   if (subcommand === 'sessions') return runGatewaySupervisorSessions();
-  if (subcommand === 'send-text' || subcommand === 'sendText' || subcommand === 'submit') {
+  if (
+    subcommand === 'send-text' ||
+    subcommand === 'sendText' ||
+    subcommand === 'submit'
+  ) {
     return runGatewaySupervisorAction(subcommand, supervisorArgs);
   }
-  if (subcommand === 'snapshot') return runGatewaySupervisorSnapshot(supervisorArgs);
-  gatewayInvalid('supervisor.snapshot', 'unknown supervisor command', { args: gatewayArgs });
+  if (subcommand === 'snapshot')
+    return runGatewaySupervisorSnapshot(supervisorArgs);
+  gatewayInvalid('supervisor.snapshot', 'unknown supervisor command', {
+    args: gatewayArgs,
+  });
 }
 
 async function runGatewayArtifacts(gatewayArgs: string[]): Promise<never> {
   const subcommand = gatewayArgs[1];
   const artifactArgs = gatewayArgs.slice(2);
   if (subcommand !== 'read') {
-    gatewayInvalid('artifacts.read', 'unknown artifacts command', { args: gatewayArgs });
+    gatewayInvalid('artifacts.read', 'unknown artifacts command', {
+      args: gatewayArgs,
+    });
   }
   const ref = gatewayArg(artifactArgs, '--ref') ?? artifactArgs[0];
-  if (!ref || ref.startsWith('--')) gatewayInvalid('artifacts.read', '--ref is required');
+  if (!ref || ref.startsWith('--'))
+    gatewayInvalid('artifacts.read', '--ref is required');
   const result = await gatewayHttpJson({
     commandName: 'artifacts.read',
     pathName: `/handoffs/artifacts/${encodeURIComponent(ref)}`,

--- a/bin/relayctl.ts
+++ b/bin/relayctl.ts
@@ -303,44 +303,194 @@ function renderPacketMarkdown(packet: PreturnPacket): string {
   }
   return lines.join('\n');
 }
+function renderInboxMessageMarkdown(
+  message: PreturnMessage,
+  index: number,
+  packetsById: Map<string, PreturnPacket>
+): string[] {
+  const lines: string[] = [`## ${index + 1}. ${message.id} (${message.state})`];
+  if (message.createdBy) lines.push(`- from: ${message.createdBy}`);
+  if (message.text) lines.push(`- message: ${message.text}`);
+  if (message.contextPacketIds.length === 0) return [...lines, ''];
+
+  lines.push('- context:');
+  for (const packetId of message.contextPacketIds) {
+    const packet = packetsById.get(packetId);
+    lines.push(
+      packet
+        ? renderPacketMarkdown(packet)
+        : `  - (packet ${packetId} unavailable)`
+    );
+  }
+  lines.push('');
+  return lines;
+}
+
+function renderPinnedContextMarkdown(
+  pinnedContextPackets: PreturnPacket[],
+  workContextId?: string
+): string[] {
+  if (pinnedContextPackets.length === 0) return [];
+  const lines = [
+    `## Pinned WorkContext context${workContextId ? ` — ${workContextId}` : ''}`,
+    `${pinnedContextPackets.length} pinned packet${pinnedContextPackets.length === 1 ? '' : 's'} from the WorkContext artifact pool.`,
+    '',
+  ];
+  for (const packet of pinnedContextPackets) {
+    lines.push(renderPacketMarkdown(packet));
+  }
+  return lines;
+}
 
 /** Render the full preturn payload as model-friendly markdown. */
 function renderPreturnMarkdown(
   sessionId: string,
   messages: PreturnMessage[],
-  packetsById: Map<string, PreturnPacket>
+  packetsById: Map<string, PreturnPacket>,
+  pinnedContextPackets: PreturnPacket[],
+  workContextId?: string
 ): string {
-  const lines: string[] = [];
-  lines.push(`# Relay pending context — session ${sessionId}`);
-  lines.push('');
-  if (messages.length === 0) {
+  const lines: string[] = [
+    `# Relay pending context — session ${sessionId}`,
+    '',
+  ];
+
+  if (messages.length === 0 && pinnedContextPackets.length === 0) {
     lines.push('No pending inbox messages.');
     return lines.join('\n');
   }
-  lines.push(
-    `${messages.length} pending message${messages.length === 1 ? '' : 's'}. ` +
-      'Read this context before responding. Rendering does not acknowledge or ' +
-      'resolve a message — use the inbox ack/resolve verbs for that.'
-  );
-  lines.push('');
-  for (const [index, message] of messages.entries()) {
-    lines.push(`## ${index + 1}. ${message.id} (${message.state})`);
-    if (message.createdBy) lines.push(`- from: ${message.createdBy}`);
-    if (message.text) lines.push(`- message: ${message.text}`);
-    if (message.contextPacketIds.length > 0) {
-      lines.push('- context:');
-      for (const packetId of message.contextPacketIds) {
-        const packet = packetsById.get(packetId);
-        if (packet) {
-          lines.push(renderPacketMarkdown(packet));
-        } else {
-          lines.push(`  - (packet ${packetId} unavailable)`);
-        }
-      }
+
+  if (messages.length > 0) {
+    lines.push(
+      `${messages.length} pending message${messages.length === 1 ? '' : 's'}. ` +
+        'Read this context before responding. Rendering does not acknowledge or ' +
+        'resolve a message — use the inbox ack/resolve verbs for that.',
+      ''
+    );
+    for (const [index, message] of messages.entries()) {
+      lines.push(...renderInboxMessageMarkdown(message, index, packetsById));
     }
-    lines.push('');
+  } else {
+    lines.push('No pending inbox messages.', '');
   }
+
+  lines.push(
+    ...renderPinnedContextMarkdown(pinnedContextPackets, workContextId)
+  );
   return lines.join('\n').trimEnd();
+}
+
+async function responseErrorDetail(res: Response): Promise<string> {
+  try {
+    const errBody = (await res.json()) as {
+      error?: { message?: string } | string;
+    };
+    return typeof errBody.error === 'string'
+      ? errBody.error
+      : (errBody.error?.message ?? '');
+  } catch {
+    return '';
+  }
+}
+
+async function fetchGatewayJson<T>(
+  endpoint: string,
+  headers: Record<string, string>,
+  options: {
+    reachabilityMessage: string;
+    forbiddenMessage: string;
+    failureSuffix?: string;
+  }
+): Promise<T> {
+  let res: Response;
+  try {
+    res = await fetch(endpoint, { headers });
+  } catch (err) {
+    die(
+      `${options.reachabilityMessage}: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  if (res.status === 403) {
+    console.error(options.forbiddenMessage);
+    process.exit(2);
+  }
+  if (!res.ok) {
+    const detail = await responseErrorDetail(res);
+    die(
+      `hub returned ${res.status} ${res.statusText}${options.failureSuffix ?? ''}${detail ? `: ${detail}` : ''}`
+    );
+  }
+  return (await res.json()) as T;
+}
+
+async function fetchInboxMessages(
+  hubUrl: string,
+  headers: Record<string, string>,
+  sessionId: string
+): Promise<PreturnMessage[]> {
+  const inboxBody = await fetchGatewayJson<{ messages?: PreturnMessage[] }>(
+    `${hubUrl}/inbox?targetSessionId=${encodeURIComponent(sessionId)}`,
+    headers,
+    {
+      reachabilityMessage: `failed to reach hub at ${hubUrl}`,
+      forbiddenMessage: 'relayctl: capability denied: session lacks inbox:read',
+    }
+  );
+  return Array.isArray(inboxBody.messages) ? inboxBody.messages : [];
+}
+
+async function fetchPinnedContextPackets(
+  hubUrl: string,
+  headers: Record<string, string>,
+  workContextId?: string
+): Promise<PreturnPacket[]> {
+  if (!workContextId) return [];
+  const pinnedBody = await fetchGatewayJson<{
+    contextPackets?: PreturnPacket[];
+  }>(
+    `${hubUrl}/context?workContextId=${encodeURIComponent(workContextId)}`,
+    headers,
+    {
+      reachabilityMessage: `failed to read WorkContext pinned context from hub at ${hubUrl}`,
+      forbiddenMessage:
+        'relayctl: capability denied: session lacks context:read',
+      failureSuffix: ' while reading WorkContext pinned context',
+    }
+  );
+  return Array.isArray(pinnedBody.contextPackets)
+    ? pinnedBody.contextPackets
+    : [];
+}
+
+function inboxPacketIds(messages: PreturnMessage[]): Set<string> {
+  const uniquePacketIds = new Set<string>();
+  for (const message of messages) {
+    for (const packetId of message.contextPacketIds)
+      uniquePacketIds.add(packetId);
+  }
+  return uniquePacketIds;
+}
+
+async function resolveInboxPackets(
+  hubUrl: string,
+  headers: Record<string, string>,
+  messages: PreturnMessage[],
+  packetsById: Map<string, PreturnPacket>
+): Promise<void> {
+  for (const packetId of inboxPacketIds(messages)) {
+    if (packetsById.has(packetId)) continue;
+    const packetEndpoint = `${hubUrl}/context/${encodeURIComponent(packetId)}`;
+    try {
+      const packetRes = await fetch(packetEndpoint, { headers });
+      const packetBody = packetRes.ok
+        ? ((await packetRes.json()) as { contextPacket?: PreturnPacket })
+        : {};
+      if (packetBody.contextPacket)
+        packetsById.set(packetId, packetBody.contextPacket);
+    } catch {
+      // Leave unresolved; renderer notes it as unavailable.
+    }
+  }
 }
 
 /**
@@ -357,76 +507,39 @@ async function cmdAgentPreturn(preturnArgs: string[]): Promise<void> {
   // Allow an explicit `--session` so this works via the gateway outside the
   // injected PTY env; otherwise fall back to the env-injected session id.
   const sessionId = overrideSessionId ?? requireEnv('RELAY_SESSION_ID');
-
   const headers = gatewayHeaders();
+  const workContextId = RELAY_WORK_CONTEXT_ID;
 
   // 1. PULL the inbox for this session. The hub flips queued → delivered here.
-  const inboxEndpoint = `${hubUrl}/inbox?targetSessionId=${encodeURIComponent(sessionId)}`;
-  let inboxRes: Response;
-  try {
-    inboxRes = await fetch(inboxEndpoint, { headers });
-  } catch (err) {
-    die(
-      `failed to reach hub at ${hubUrl}: ${err instanceof Error ? err.message : String(err)}`
-    );
-  }
-  if (inboxRes.status === 403) {
-    console.error('relayctl: capability denied: session lacks inbox:read');
-    process.exit(2);
-  }
-  if (!inboxRes.ok) {
-    let detail = '';
-    try {
-      const errBody = (await inboxRes.json()) as {
-        error?: { message?: string } | string;
-      };
-      detail =
-        typeof errBody.error === 'string'
-          ? errBody.error
-          : (errBody.error?.message ?? '');
-    } catch {
-      // ignore parse error
-    }
-    die(
-      `hub returned ${inboxRes.status} ${inboxRes.statusText}${detail ? `: ${detail}` : ''}`
-    );
-  }
-  const inboxBody = (await inboxRes.json()) as { messages?: PreturnMessage[] };
-  const messages = Array.isArray(inboxBody.messages) ? inboxBody.messages : [];
+  const messages = await fetchInboxMessages(hubUrl, headers, sessionId);
 
-  // 2. Resolve referenced packet bodies (deduped). A missing/denied packet is
-  //    rendered as unavailable rather than tearing down the whole preturn.
+  // 2. Discover WorkContext-pinned packets. These are source-of-truth refs from
+  //    the WorkContext artifact pool and are agent-facing preturn context even
+  //    when no inbox message targets the current session.
+  const pinnedContextPackets = await fetchPinnedContextPackets(
+    hubUrl,
+    headers,
+    workContextId
+  );
   const packetsById = new Map<string, PreturnPacket>();
-  const uniquePacketIds = new Set<string>();
-  for (const message of messages) {
-    for (const packetId of message.contextPacketIds) uniquePacketIds.add(packetId);
-  }
-  for (const packetId of uniquePacketIds) {
-    const packetEndpoint = `${hubUrl}/context/${encodeURIComponent(packetId)}`;
-    try {
-      const packetRes = await fetch(packetEndpoint, { headers });
-      if (packetRes.ok) {
-        const packetBody = (await packetRes.json()) as {
-          contextPacket?: PreturnPacket;
-        };
-        if (packetBody.contextPacket) {
-          packetsById.set(packetId, packetBody.contextPacket);
-        }
-      }
-    } catch {
-      // Leave unresolved; renderer notes it as unavailable.
-    }
-  }
+  for (const packet of pinnedContextPackets) packetsById.set(packet.id, packet);
 
-  // 3. Render.
+  // 3. Resolve inbox-referenced packet bodies (deduped). A missing/denied packet
+  //    is rendered as unavailable rather than tearing down the whole preturn.
+  await resolveInboxPackets(hubUrl, headers, messages, packetsById);
+
+  // 4. Render.
   if (format === 'json') {
     console.log(
       JSON.stringify(
         {
           sessionId,
+          ...(workContextId ? { workContextId } : {}),
           pendingCount: messages.length,
+          pinnedContextCount: pinnedContextPackets.length,
           messages,
           contextPackets: [...packetsById.values()],
+          pinnedContextPackets,
         },
         null,
         2
@@ -434,7 +547,15 @@ async function cmdAgentPreturn(preturnArgs: string[]): Promise<void> {
     );
     return;
   }
-  console.log(renderPreturnMarkdown(sessionId, messages, packetsById));
+  console.log(
+    renderPreturnMarkdown(
+      sessionId,
+      messages,
+      packetsById,
+      pinnedContextPackets,
+      workContextId
+    )
+  );
 }
 
 /** Dispatch the `agent` subcommand group. */

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -18,6 +18,11 @@ relay-ide v1 files list --session-id <session-id> --path <path> --json
 relay-ide v1 files stat --session-id <session-id> --path <path> --json
 relay-ide v1 files read --session-id <session-id> --path <path> --max-bytes 32768 --max-lines 2000 --json
 relay-ide v1 files write --session-id <session-id> --path <path> --mode <create|overwrite|append> --file <local-path|-> --json
+relay-ide v1 context create --input-json '{...}' --json
+relay-ide v1 context get --id <context-packet-id> --json
+relay-ide v1 context list [--work-context-id <work-context-id>] --json
+relay-ide v1 context pin --id <context-packet-id> --work-context-id <work-context-id> --json
+relay-ide v1 context unpin --id <context-packet-id> --work-context-id <work-context-id> --json
 relay-ide v1 supervisor sessions --json
 relay-ide v1 supervisor snapshot --id <session-id-or-global-id> --json
 relay-ide v1 supervisor send-text --id <session-id-or-global-id> --text <literal-text> --json
@@ -57,7 +62,10 @@ Error:
     "code": "NOT_FOUND",
     "message": "file was not found",
     "retryable": false,
-    "details": { "upstreamCode": "NOT_FOUND", "reasonCode": "FILE_RPC_NOT_FOUND" }
+    "details": {
+      "upstreamCode": "NOT_FOUND",
+      "reasonCode": "FILE_RPC_NOT_FOUND"
+    }
   }
 }
 ```
@@ -77,7 +85,7 @@ The current error taxonomy is declared in `RELAY_CLI_GATEWAY_CONTRACT.errorEnvel
 - capability hints for hub policy checks
 - possible typed error codes
 
-The schema is the source of truth for adapter generation. A command missing from this manifest is not stable adapter API, even if an internal REST/WebSocket route exists.
+The schema is the source of truth for adapter generation. A command missing from this manifest is not stable adapter API, even if an internal REST/WebSocket route exists. WorkContext-pinning commands are exposed here as `context.pin`, `context.unpin`, and `context.list --work-context-id`; agents should discover and call those gateway verbs instead of private HTTP routes.
 
 ## Command taxonomy
 
@@ -85,11 +93,11 @@ Relay command metadata is defined in [`shared/relay-command-manifest.ts`](../sha
 
 Current command surfaces are intentionally separate:
 
-| Surface | Meaning | Execution path |
-| --- | --- | --- |
-| UI-only Command Center actions | Browser affordances such as navigation, settings, local palette helpers, and workflow entry points that are not stable agent API. | Frontend action registry only; do not generate agent tools from these. |
-| Stable CLI gateway commands | Versioned `relay-ide v1 ... --json` commands in `RELAY_CLI_GATEWAY_CONTRACT`. | Public CLI JSON gateway; this is the adapter-facing contract. |
-| Agent-callable commands | Gateway commands safe to expose to Claude/Codex/Hermes/MCP/ACP-style adapters through generated schemas. | Generated from the shared command manifest and executed through `relay-ide v1 ... --json`, never private node-link/browser routes. |
+| Surface                        | Meaning                                                                                                                           | Execution path                                                                                                                     |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| UI-only Command Center actions | Browser affordances such as navigation, settings, local palette helpers, and workflow entry points that are not stable agent API. | Frontend action registry only; do not generate agent tools from these.                                                             |
+| Stable CLI gateway commands    | Versioned `relay-ide v1 ... --json` commands in `RELAY_CLI_GATEWAY_CONTRACT`.                                                     | Public CLI JSON gateway; this is the adapter-facing contract.                                                                      |
+| Agent-callable commands        | Gateway commands safe to expose to Claude/Codex/Hermes/MCP/ACP-style adapters through generated schemas.                          | Generated from the shared command manifest and executed through `relay-ide v1 ... --json`, never private node-link/browser routes. |
 
 The Command Center may search and describe stable gateway commands using the shared manifest before browser execution is wired. The manifest carries the stable command id, CLI projection, side-effect class, capability hints, confirmation/control requirements, scope kinds, and audit redaction expectations. Until a `handler.uiAction` or explicit UI execution bridge exists, these entries must stay disabled/degraded in the palette and point operators to the stable CLI argv. Do not mark every internal UI button as agent-callable, and do not add Claude/Codex/Hermes-specific schemas by hand; add or change the Relay-owned command definition first.
 
@@ -97,7 +105,7 @@ The Command Center may search and describe stable gateway commands using the sha
 
 Local discovery commands (`contract.*`, `nodes.manifest`) do not require a hub token.
 
-Hub-backed commands (`nodes.list`, `sessions.*`, `files.*`, `handoffs.*`, `artifacts.*`, `supervisor.*`, and `events.*`) use the same local server token path as existing CLI session commands:
+Hub-backed commands (`nodes.list`, `sessions.*`, `files.*`, `work-contexts.*`, `context.*`, `inbox.*`, `handoffs.*`, `artifacts.*`, `supervisor.*`, and `events.*`) use the same local server token path as existing CLI session commands:
 
 - `RELAY_IDE_BROWSER_TOKEN` supplies the bearer token.
 - `--port` or `RELAY_IDE_PORT` selects the local hub port; otherwise Relay uses the default port.
@@ -229,14 +237,14 @@ The stable supervisor surface is Relay-owned command API, not raw PTY, tmux, or 
 
 Commands:
 
-| Command | Purpose | Required capabilities |
-| --- | --- | --- |
-| `relay-ide v1 supervisor sessions --json` | Lists sessions and per-action eligibility. | `session:read`, `tab:intervention:read` |
-| `relay-ide v1 supervisor snapshot --id <session-id-or-global-id> --json` | Reads one redacted supervisor snapshot. | `session:read`, `tab:intervention:read` |
-| `relay-ide v1 supervisor send-text --id <session-id-or-global-id> --text <literal-text> --json` | Sends bounded literal text as a typed intervention. | `session:attach`, `tab:intervention:send-text` |
-| `relay-ide v1 supervisor send-text --target-ids <id-1,id-2> --text <literal-text> --json` | Sends the same bounded literal text to multiple sessions and reports per-target results. | `session:attach`, `tab:intervention:send-text` |
-| `relay-ide v1 supervisor submit --id <session-id-or-global-id> --json` | Sends Enter (`\n`) as a typed intervention. | `session:attach`, `tab:intervention:submit` |
-| `relay-ide v1 supervisor submit --target-ids <id-1,id-2> --json` | Sends Enter to multiple sessions and reports per-target results. | `session:attach`, `tab:intervention:submit` |
+| Command                                                                                         | Purpose                                                                                  | Required capabilities                          |
+| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `relay-ide v1 supervisor sessions --json`                                                       | Lists sessions and per-action eligibility.                                               | `session:read`, `tab:intervention:read`        |
+| `relay-ide v1 supervisor snapshot --id <session-id-or-global-id> --json`                        | Reads one redacted supervisor snapshot.                                                  | `session:read`, `tab:intervention:read`        |
+| `relay-ide v1 supervisor send-text --id <session-id-or-global-id> --text <literal-text> --json` | Sends bounded literal text as a typed intervention.                                      | `session:attach`, `tab:intervention:send-text` |
+| `relay-ide v1 supervisor send-text --target-ids <id-1,id-2> --text <literal-text> --json`       | Sends the same bounded literal text to multiple sessions and reports per-target results. | `session:attach`, `tab:intervention:send-text` |
+| `relay-ide v1 supervisor submit --id <session-id-or-global-id> --json`                          | Sends Enter (`\n`) as a typed intervention.                                              | `session:attach`, `tab:intervention:submit`    |
+| `relay-ide v1 supervisor submit --target-ids <id-1,id-2> --json`                                | Sends Enter to multiple sessions and reports per-target results.                         | `session:attach`, `tab:intervention:submit`    |
 
 Inputs:
 
@@ -269,7 +277,13 @@ Successful action envelope shape:
         "controlModeAfter": "co-driven"
       }
     ],
-    "counts": { "requested": 1, "succeeded": 1, "denied": 0, "failed": 0, "skipped": 0 },
+    "counts": {
+      "requested": 1,
+      "succeeded": 1,
+      "denied": 0,
+      "failed": 0,
+      "skipped": 0
+    },
     "audit": {
       "action": "sendText",
       "targetSessionIds": ["sess-1"],
@@ -287,7 +301,11 @@ Successful action envelope shape:
       "rawContentStored": false,
       "partialFailure": false
     },
-    "redaction": { "rawContentAvailable": false, "rawContentStored": false, "hashesOnly": true }
+    "redaction": {
+      "rawContentAvailable": false,
+      "rawContentStored": false,
+      "hashesOnly": true
+    }
   }
 }
 ```

--- a/server/features/context-inbox-router.ts
+++ b/server/features/context-inbox-router.ts
@@ -32,7 +32,12 @@ import type { RequestHandler, Request, Response } from 'express';
 
 import type { RelayCliGatewayErrorCode } from '../../shared/cli-gateway-contract.js';
 import type { GlobalSessionId } from '../../shared/identity.js';
-import type { WorkContextId } from '../../shared/work-context.js';
+import {
+  createWorkContextPrivacyMetadata,
+  type ArtifactRef,
+  type WorkContextId,
+} from '../../shared/work-context.js';
+import type { WorkContextStore } from '../work-contexts.js';
 import {
   TERMINAL_INBOX_MESSAGE_STATES,
   type ContextPacket,
@@ -151,6 +156,7 @@ export interface ContextInboxStore {
 
 export interface ContextInboxRouterDeps {
   store: ContextInboxStore | null;
+  workContextStore?: WorkContextStore;
   requireAuth?: RequestHandler;
   /**
    * #760: resolve a `file-anchor` packet's DERIVED `AnchorState` at read time.
@@ -159,6 +165,61 @@ export interface ContextInboxRouterDeps {
    * guessing. `AnchorState` is never stored — it is computed on every read.
    */
   resolveAnchorState?: AnchorStateResolver;
+}
+
+export const CONTEXT_PACKET_ARTIFACT_URI_PREFIX = 'relay://context-packets/';
+
+function contextPacketArtifactId(id: ContextPacketId): string {
+  return `artifact:context-packet:${id}`;
+}
+
+function contextPacketArtifactUri(id: ContextPacketId): string {
+  return `${CONTEXT_PACKET_ARTIFACT_URI_PREFIX}${encodeURIComponent(id)}`;
+}
+
+function pinnedPacketIdFromArtifact(
+  artifact: ArtifactRef
+): ContextPacketId | null {
+  if (artifact.uri?.startsWith(CONTEXT_PACKET_ARTIFACT_URI_PREFIX)) {
+    try {
+      return decodeURIComponent(
+        artifact.uri.slice(CONTEXT_PACKET_ARTIFACT_URI_PREFIX.length)
+      );
+    } catch {
+      return null;
+    }
+  }
+  const prefix = 'artifact:context-packet:';
+  return artifact.id.startsWith(prefix)
+    ? artifact.id.slice(prefix.length)
+    : null;
+}
+
+function packetPinnedArtifact(
+  packet: ContextPacket,
+  actorId?: string
+): ArtifactRef {
+  return {
+    id: contextPacketArtifactId(packet.id),
+    kind: 'external',
+    title: `Pinned context packet ${packet.id}`,
+    uri: contextPacketArtifactUri(packet.id),
+    producedByActorId: actorId ?? packet.createdBy,
+    producedAt: new Date().toISOString(),
+    summary:
+      packet.note ??
+      `${packet.kind} context packet pinned for WorkContext handoff/review`,
+    privacy: createWorkContextPrivacyMetadata({
+      classification: 'internal',
+      retention: 'project',
+      rawPayloadStored: false,
+      redaction: {
+        redacted: true,
+        strategy: 'summary',
+        classes: ['payload', 'artifact'],
+      },
+    }),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -775,6 +836,57 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
     return contextPackets.length > 0 ? { ...message, contextPackets } : message;
   }
 
+  function workContexts(res: Response): WorkContextStore | null {
+    if (!deps.workContextStore) {
+      sendGatewayError(
+        res,
+        'SERVER_UNAVAILABLE',
+        'WorkContext store is unavailable',
+        true,
+        {
+          reasonCode: 'WORK_CONTEXT_STORE_UNAVAILABLE',
+        }
+      );
+      return null;
+    }
+    return deps.workContextStore;
+  }
+
+  function pinnedArtifactsFor(
+    workContextId: WorkContextId
+  ): ArtifactRef[] | null {
+    const wc = deps.workContextStore?.get(workContextId);
+    if (!wc) return null;
+    return wc.artifacts.filter((artifact) =>
+      pinnedPacketIdFromArtifact(artifact)
+    );
+  }
+
+  async function pinnedContextPacketsFor(
+    s: ContextInboxStore,
+    workContextId: WorkContextId
+  ): Promise<{
+    contextPackets: DecoratedContextPacket[];
+    artifacts: ArtifactRef[];
+  } | null> {
+    const artifacts = pinnedArtifactsFor(workContextId);
+    if (!artifacts) return null;
+    const packets: ContextPacket[] = [];
+    for (const artifact of artifacts) {
+      const packetId = pinnedPacketIdFromArtifact(artifact);
+      if (!packetId) continue;
+      const packet = s.getPacket(packetId);
+      if (packet) packets.push(packet);
+    }
+    return {
+      contextPackets: await decoratePacketsAnchorState(
+        packets,
+        resolveAnchorState
+      ),
+      artifacts,
+    };
+  }
+
   // -- context.create ------------------------------------------------------
   router.post('/context', auth, (req, res) => {
     if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
@@ -832,15 +944,158 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
     }
   });
 
+  // -- context.pin / context.unpin -----------------------------------------
+  // #763: pinning records a WorkContext artifact ref to an existing packet.
+  // The packet body stays in the context-packet store; WorkContext artifacts are
+  // the durable handoff/review pool. Unpin removes only that artifact ref and
+  // writes an audit lifecycle event; it never deletes the packet itself.
+  router.post('/context/:id/pin', auth, async (req, res, next) => {
+    if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+    const s = store(res);
+    const wcStore = workContexts(res);
+    if (!s || !wcStore) return;
+    const packetId = req.params['id'] ?? '';
+    const packet = s.getPacket(packetId);
+    if (!packet) {
+      sendGatewayError(res, 'NOT_FOUND', 'context packet not found');
+      return;
+    }
+    const body = bodyRecord(req);
+    const workContextId = readString(body['workContextId']);
+    if (!workContextId) {
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'workContextId is required',
+        false,
+        { field: 'workContextId' }
+      );
+      return;
+    }
+    const existing = wcStore.get(workContextId);
+    if (!existing) {
+      sendGatewayError(res, 'NOT_FOUND', 'WorkContext not found');
+      return;
+    }
+    const actorId =
+      readString(body['actorId']) ?? readString(body['createdBy']);
+    const artifact = packetPinnedArtifact(packet, actorId);
+    const alreadyPinned = existing.artifacts.some(
+      (item) => item.id === artifact.id || item.uri === artifact.uri
+    );
+    try {
+      let workContext = existing;
+      if (!alreadyPinned) {
+        workContext = wcStore.recordLifecycleEvent(workContextId, {
+          type: 'artifact.recorded',
+          ...(actorId ? { actorId } : {}),
+          artifacts: [artifact],
+          summary: `Pinned context packet ${packet.id} to WorkContext ${workContextId}`,
+        });
+      }
+      const pinned = await pinnedContextPacketsFor(s, workContextId);
+      res.status(alreadyPinned ? 200 : 201).json({
+        workContext,
+        contextPacket: await decoratePacketAnchorState(
+          packet,
+          resolveAnchorState
+        ),
+        pinnedContextPackets: pinned?.contextPackets ?? [],
+        pinnedArtifacts: pinned?.artifacts ?? [],
+        alreadyPinned,
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/context/:id/unpin', auth, (req, res) => {
+    if (denyMissingCapability(req, res, [CONTEXT_WRITE])) return;
+    const s = store(res);
+    const wcStore = workContexts(res);
+    if (!s || !wcStore) return;
+    const packetId = req.params['id'] ?? '';
+    const body = bodyRecord(req);
+    const workContextId = readString(body['workContextId']);
+    if (!workContextId) {
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'workContextId is required',
+        false,
+        { field: 'workContextId' }
+      );
+      return;
+    }
+    const existing = wcStore.get(workContextId);
+    if (!existing) {
+      sendGatewayError(res, 'NOT_FOUND', 'WorkContext not found');
+      return;
+    }
+    const artifactId = contextPacketArtifactId(packetId);
+    const artifactUri = contextPacketArtifactUri(packetId);
+    const nextArtifacts = existing.artifacts.filter(
+      (item) => item.id !== artifactId && item.uri !== artifactUri
+    );
+    const removed = nextArtifacts.length !== existing.artifacts.length;
+    const actorId =
+      readString(body['actorId']) ?? readString(body['createdBy']);
+    const updated = removed
+      ? wcStore.update(workContextId, { artifacts: nextArtifacts })
+      : existing;
+    const workContext = removed
+      ? wcStore.recordLifecycleEvent(workContextId, {
+          type: 'artifact.unpinned',
+          ...(actorId ? { actorId } : {}),
+          summary: `Unpinned context packet ${packetId} from WorkContext ${workContextId}; packet retained for GC until unreferenced`,
+        })
+      : updated;
+    const packet = s.getPacket(packetId);
+    res.json({
+      workContext,
+      ...(packet ? { contextPacket: packet } : {}),
+      removed,
+      lifecycle: {
+        packetDeleted: false,
+        gc: 'packet retained; orphan cleanup must only delete packets with no inbox messages and no WorkContext artifact pins',
+      },
+    });
+  });
+
   // -- context.list --------------------------------------------------------
-  router.get('/context', auth, (req, res) => {
+  router.get('/context', auth, (req, res, next) => {
     if (denyMissingCapability(req, res, [CONTEXT_READ])) return;
     const s = store(res);
     if (!s) return;
+    const workContextId = readString(req.query['workContextId']);
     const filter: ListContextPacketsFilter = {};
     const nodeId = readString(req.query['nodeId']);
     const workspaceId = readString(req.query['workspaceId']);
     const limit = readLimit(req.query['limit']);
+    if (workContextId) {
+      if (!workContexts(res)) return;
+      pinnedContextPacketsFor(s, workContextId)
+        .then((result) => {
+          if (!result) {
+            sendGatewayError(res, 'NOT_FOUND', 'WorkContext not found');
+            return;
+          }
+          let contextPackets = result.contextPackets;
+          if (nodeId)
+            contextPackets = contextPackets.filter(
+              (packet) => packet.binding?.nodeId === nodeId
+            );
+          if (workspaceId)
+            contextPackets = contextPackets.filter(
+              (packet) => packet.binding?.workspaceId === workspaceId
+            );
+          if (limit !== undefined)
+            contextPackets = contextPackets.slice(0, limit);
+          res.json({ contextPackets, pinnedArtifacts: result.artifacts });
+        })
+        .catch(next);
+      return;
+    }
     if (nodeId) filter.nodeId = nodeId;
     if (workspaceId) filter.workspaceId = workspaceId;
     if (limit !== undefined) filter.limit = limit;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1771,7 +1771,11 @@ async function main(): Promise<void> {
   // to 503 SERVER_UNAVAILABLE rather than failing boot.
   const contextInboxStore = deriveContextInboxStore(contextPacketStore);
   app.use(
-    createContextInboxRouter({ requireAuth: requireCliGatewayAuth, store: contextInboxStore })
+    createContextInboxRouter({
+      requireAuth: requireCliGatewayAuth,
+      store: contextInboxStore,
+      workContextStore,
+    })
   );
   // #766/#759: production `AnchorFileFetcher` wired to the session-scoped File
   // RPC path under `rpc:fs:read`. Resolves an anchor's `current` ref by routing
@@ -1793,11 +1797,12 @@ async function main(): Promise<void> {
   // CONTENT expansion. Reuses the same session-scoped File RPC `read` path under
   // `rpc:fs:read`; shares the live registry/link/envelope handles. Registered so
   // `expandFileRangePacket` can read a bounded slice without threading deps.
-  const anchorContentFetcher: FileRangeContentFetcher = createAnchorContentFetcher({
-    registry: hubNodeRegistry,
-    nodeLinks: hubNodeLinks,
-    sessionEnvelopes: sessionEnvelopeRegistry,
-  });
+  const anchorContentFetcher: FileRangeContentFetcher =
+    createAnchorContentFetcher({
+      registry: hubNodeRegistry,
+      nodeLinks: hubNodeLinks,
+      sessionEnvelopes: sessionEnvelopeRegistry,
+    });
   registerFileRangeContentFetcher(anchorContentFetcher);
   app.use(
     createCliGatewayEventsRouter(express, {

--- a/server/work-contexts.ts
+++ b/server/work-contexts.ts
@@ -44,6 +44,7 @@ const LIFECYCLE_EVENT_TYPES = new Set([
   'session.resumed',
   'operator.intervened',
   'artifact.recorded',
+  'artifact.unpinned',
   'summary.recorded',
   'handoff.closed',
 ]);
@@ -511,9 +512,16 @@ export function createWorkContextStore(dbPath: string): WorkContextStore {
       return updated;
     },
 
-    recordLifecycleEvent(id: WorkContextId, input: WorkContextLifecycleEventInput) {
+    recordLifecycleEvent(
+      id: WorkContextId,
+      input: WorkContextLifecycleEventInput
+    ) {
       const existing = mustGet(id);
-      const updated = contextWithLifecycleEvent(existing, input, new Date().toISOString());
+      const updated = contextWithLifecycleEvent(
+        existing,
+        input,
+        new Date().toISOString()
+      );
       return write(updated);
     },
 
@@ -628,7 +636,9 @@ export function createWorkContextRouter(deps: WorkContextRouterDeps): Router {
         type: 'handoff.created',
         summary: `Created handoff context for ${input.taskRef.kind}:${input.taskRef.id}`,
       });
-      res.status(201).json({ workContext: deps.store.get(context.id) ?? context });
+      res
+        .status(201)
+        .json({ workContext: deps.store.get(context.id) ?? context });
     } catch (err) {
       sendStoreError(res, err);
     }
@@ -648,7 +658,12 @@ export function createWorkContextRouter(deps: WorkContextRouterDeps): Router {
     try {
       const sessions = await deps.getSessions();
       const nodes = deps.getNodes?.() ?? [];
-      res.json({ resume: deps.store.getResumeSnapshot(req.params['id'] ?? '', { sessions, nodes }) });
+      res.json({
+        resume: deps.store.getResumeSnapshot(req.params['id'] ?? '', {
+          sessions,
+          nodes,
+        }),
+      });
     } catch (err) {
       sendStoreError(res, err);
     }
@@ -1123,7 +1138,9 @@ function contextWithLifecycleEvent(
   if (Number.isNaN(Date.parse(occurredAt))) {
     throw new WorkContextStoreError(400, 'invalid_lifecycle_occurred_at');
   }
-  const eventId = input.eventId ?? `work-context:${context.id}:${crypto.randomBytes(8).toString('hex')}`;
+  const eventId =
+    input.eventId ??
+    `work-context:${context.id}:${crypto.randomBytes(8).toString('hex')}`;
   const auditRef: AuditEventRef = {
     id: `audit-ref:${eventId}`,
     eventId,
@@ -1142,7 +1159,10 @@ function contextWithLifecycleEvent(
       },
     }),
   };
-  const artifacts = [...context.artifacts, ...safeLifecycleArtifacts(input, eventId, occurredAt)];
+  const artifacts = [
+    ...context.artifacts,
+    ...safeLifecycleArtifacts(input, eventId, occurredAt),
+  ];
   const auditRefs = upsertAuditRef(context.auditRefs, auditRef);
   const updated: WorkContext = {
     ...context,
@@ -1315,7 +1335,8 @@ function buildActiveGroups(
 function resumeSnapshotFromGroup(
   group: WorkContextActiveGroup
 ): WorkContextResumeSnapshot {
-  if (!group.context) throw new WorkContextStoreError(404, 'work_context_not_found');
+  if (!group.context)
+    throw new WorkContextStoreError(404, 'work_context_not_found');
   const context = group.context;
   return {
     workContext: {
@@ -1327,7 +1348,9 @@ function resumeSnapshotFromGroup(
       anchors: context.anchors,
       actors: context.actors,
       tasks: context.tasks,
-      ...(context.relatedContextRefs ? { relatedContextRefs: context.relatedContextRefs } : {}),
+      ...(context.relatedContextRefs
+        ? { relatedContextRefs: context.relatedContextRefs }
+        : {}),
     },
     node: group.node,
     sessions: group.sessions.slice(0, MAX_RESUME_SESSIONS),

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -31,6 +31,8 @@ export type RelayCliGatewayCommand =
   | 'context.create'
   | 'context.get'
   | 'context.list'
+  | 'context.pin'
+  | 'context.unpin'
   | 'inbox.send'
   | 'inbox.list'
   | 'inbox.get'
@@ -222,7 +224,10 @@ const sessionEnvelopeSchema: RelayJsonSchema = {
       type: 'object',
       additionalProperties: false,
       properties: {
-        kind: { type: 'string', enum: ['local-compatibility', 'node-cwd', 'repo', 'worktree'] },
+        kind: {
+          type: 'string',
+          enum: ['local-compatibility', 'node-cwd', 'repo', 'worktree'],
+        },
         nodeId: stringSchema,
         cwd: stringSchema,
         repoPath: stringSchema,
@@ -268,7 +273,10 @@ const sessionDescriptorSchema: RelayJsonSchema = {
     branchName: stringSchema,
     displayName: stringSchema,
     status: { type: 'string', enum: ['active', 'disconnected'] },
-    controlMode: { type: 'string', enum: ['agent-driven', 'human-driven', 'co-driven'] },
+    controlMode: {
+      type: 'string',
+      enum: ['agent-driven', 'human-driven', 'co-driven'],
+    },
     activeActors: { type: 'array', items: controlActorSchema },
     activeWorker: controlActorSchema,
     lastInterventionAt: nullableStringSchema,
@@ -280,7 +288,6 @@ const sessionDescriptorSchema: RelayJsonSchema = {
   },
   required: ['id', 'type', 'agent', 'mode', 'cwd', 'displayName', 'status'],
 };
-
 
 const fileRpcStatSchema: RelayJsonSchema = {
   title: 'FileRpcStat',
@@ -348,7 +355,15 @@ const fileRpcListOutputSchema: RelayJsonSchema = {
     truncated: booleanSchema,
     maxEntries: { type: 'number' },
   },
-  required: ['operation', 'root', 'cwd', 'path', 'entries', 'truncated', 'maxEntries'],
+  required: [
+    'operation',
+    'root',
+    'cwd',
+    'path',
+    'entries',
+    'truncated',
+    'maxEntries',
+  ],
 };
 
 const fileRpcStatOutputSchema: RelayJsonSchema = {
@@ -404,7 +419,11 @@ const fileRpcWriteInputSchema: RelayJsonSchema = {
     expectedHash: stringSchema,
     permissions: { type: 'number', minimum: 0, maximum: 511 },
   },
-  required: [...(fileRpcBaseInputSchema.required ?? []), 'mode', 'contentBase64'],
+  required: [
+    ...(fileRpcBaseInputSchema.required ?? []),
+    'mode',
+    'contentBase64',
+  ],
 };
 
 const fileRpcWriteOutputSchema: RelayJsonSchema = {
@@ -421,7 +440,17 @@ const fileRpcWriteOutputSchema: RelayJsonSchema = {
     newMtime: stringSchema,
     created: booleanSchema,
   },
-  required: ['operation', 'root', 'cwd', 'path', 'mode', 'bytesWritten', 'newHash', 'newMtime', 'created'],
+  required: [
+    'operation',
+    'root',
+    'cwd',
+    'path',
+    'mode',
+    'bytesWritten',
+    'newHash',
+    'newMtime',
+    'created',
+  ],
 };
 
 const attachOutputSchema: RelayJsonSchema = {
@@ -550,7 +579,14 @@ const sessionInputOutputSchema: RelayJsonSchema = {
     truncated: booleanSchema,
     maxBytes: { type: 'number', minimum: 1 },
   },
-  required: ['sent', 'sessionId', 'bytesSent', 'matched', 'bytesReceived', 'truncated'],
+  required: [
+    'sent',
+    'sessionId',
+    'bytesSent',
+    'matched',
+    'bytesReceived',
+    'truncated',
+  ],
 };
 
 /**
@@ -732,7 +768,8 @@ const eventsSubscribeInputSchema: RelayJsonSchema = {
       type: 'number',
       minimum: 1,
       maximum: 10000,
-      description: 'Detach after N event frames (excluding open/closed envelopes).',
+      description:
+        'Detach after N event frames (excluding open/closed envelopes).',
     },
     idleTimeoutMs: {
       type: 'number',
@@ -824,8 +861,22 @@ const contextListInputSchema: RelayJsonSchema = {
   properties: {
     nodeId: stringSchema,
     workspaceId: stringSchema,
+    workContextId: stringSchema,
     limit: { type: 'number', minimum: 1, maximum: 200 },
   },
+};
+
+const contextPinInputSchema: RelayJsonSchema = {
+  title: 'ContextPinInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    id: stringSchema,
+    workContextId: stringSchema,
+    actorId: stringSchema,
+    createdBy: stringSchema,
+  },
+  required: ['id', 'workContextId'],
 };
 
 const inboxSendInputSchema: RelayJsonSchema = {
@@ -839,7 +890,10 @@ const inboxSendInputSchema: RelayJsonSchema = {
     text: stringSchema,
     createdBy: stringSchema,
   },
-  anyOf: [{ required: ['targetSessionId'] }, { required: ['targetWorkContextId'] }],
+  anyOf: [
+    { required: ['targetSessionId'] },
+    { required: ['targetWorkContextId'] },
+  ],
 };
 
 const inboxListInputSchema: RelayJsonSchema = {
@@ -852,7 +906,10 @@ const inboxListInputSchema: RelayJsonSchema = {
     state: { type: 'string', enum: SESSION_INBOX_MESSAGE_STATES },
     limit: { type: 'number', minimum: 1, maximum: 200 },
   },
-  anyOf: [{ required: ['targetSessionId'] }, { required: ['targetWorkContextId'] }],
+  anyOf: [
+    { required: ['targetSessionId'] },
+    { required: ['targetWorkContextId'] },
+  ],
 };
 
 const inboxGetInputSchema: RelayJsonSchema = {
@@ -878,11 +935,59 @@ const contextPacketDataSchema: RelayJsonSchema = {
   required: ['contextPacket'],
 };
 
+const artifactRefEnvelopeSchema: RelayJsonSchema = {
+  title: 'ArtifactRef',
+  type: 'object',
+  additionalProperties: true,
+  properties: {
+    id: stringSchema,
+    kind: stringSchema,
+    title: stringSchema,
+    uri: stringSchema,
+    summary: stringSchema,
+  },
+  required: ['id', 'kind'],
+};
+
 const contextListDataSchema: RelayJsonSchema = {
   type: 'object',
   additionalProperties: false,
-  properties: { contextPackets: { type: 'array', items: contextPacketEnvelopeSchema } },
+  properties: {
+    contextPackets: { type: 'array', items: contextPacketEnvelopeSchema },
+    pinnedArtifacts: { type: 'array', items: artifactRefEnvelopeSchema },
+  },
   required: ['contextPackets'],
+};
+
+const contextPinDataSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    workContext: { type: 'object', additionalProperties: true },
+    contextPacket: contextPacketEnvelopeSchema,
+    pinnedContextPackets: { type: 'array', items: contextPacketEnvelopeSchema },
+    pinnedArtifacts: { type: 'array', items: artifactRefEnvelopeSchema },
+    alreadyPinned: booleanSchema,
+  },
+  required: [
+    'workContext',
+    'contextPacket',
+    'pinnedContextPackets',
+    'pinnedArtifacts',
+    'alreadyPinned',
+  ],
+};
+
+const contextUnpinDataSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    workContext: { type: 'object', additionalProperties: true },
+    contextPacket: contextPacketEnvelopeSchema,
+    removed: booleanSchema,
+    lifecycle: { type: 'object', additionalProperties: true },
+  },
+  required: ['workContext', 'removed', 'lifecycle'],
 };
 
 const inboxMessageDataSchema: RelayJsonSchema = {
@@ -895,7 +1000,9 @@ const inboxMessageDataSchema: RelayJsonSchema = {
 const inboxListDataSchema: RelayJsonSchema = {
   type: 'object',
   additionalProperties: false,
-  properties: { messages: { type: 'array', items: inboxMessageEnvelopeSchema } },
+  properties: {
+    messages: { type: 'array', items: inboxMessageEnvelopeSchema },
+  },
   required: ['messages'],
 };
 
@@ -939,7 +1046,10 @@ const handoffCreateInputSchema: RelayJsonSchema = {
   properties: {
     planId: stringSchema,
     plan: { type: 'object', additionalProperties: true },
-    confirmedGrants: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    confirmedGrants: {
+      type: 'array',
+      items: { type: 'object', additionalProperties: true },
+    },
     sourceRepoPath: stringSchema,
     destinationRepoPath: stringSchema,
     approvedUntrackedPaths: { type: 'array', items: stringSchema },
@@ -1035,7 +1145,10 @@ const handoffCreateOutputSchema: RelayJsonSchema = {
   additionalProperties: false,
   properties: {
     run: { type: 'object', additionalProperties: true },
-    artifacts: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    artifacts: {
+      type: 'array',
+      items: { type: 'object', additionalProperties: true },
+    },
   },
   required: ['run', 'artifacts'],
 };
@@ -1133,7 +1246,10 @@ const supervisorSessionsOutputSchema: RelayJsonSchema = {
   additionalProperties: false,
   properties: {
     command: { const: 'supervisor.sessions' },
-    sessions: { type: 'array', items: { type: 'object', additionalProperties: true } },
+    sessions: {
+      type: 'array',
+      items: { type: 'object', additionalProperties: true },
+    },
     count: { type: 'number', minimum: 0 },
   },
   required: ['command', 'sessions', 'count'],
@@ -1149,7 +1265,10 @@ const supervisorActionOutputSchema = (
     properties: {
       command: { const: command },
       action: { const: action },
-      results: { type: 'array', items: { type: 'object', additionalProperties: true } },
+      results: {
+        type: 'array',
+        items: { type: 'object', additionalProperties: true },
+      },
       counts: { type: 'object', additionalProperties: true },
       audit: { type: 'object', additionalProperties: true },
       redaction: {
@@ -1233,8 +1352,15 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     transport: 'local',
     requiresAuth: false,
     capabilityHints: [],
-    inputSchema: { type: 'object', additionalProperties: false, properties: {} },
-    outputSchema: okOutput('ContractListOutput', { $id: 'RelayCliGatewayContractManifest', type: 'object' }),
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {},
+    },
+    outputSchema: okOutput('ContractListOutput', {
+      $id: 'RelayCliGatewayContractManifest',
+      type: 'object',
+    }),
     errorCodes: ['INVALID_ARGUMENT', 'INTERNAL'],
   },
   {
@@ -1245,8 +1371,15 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     transport: 'local',
     requiresAuth: false,
     capabilityHints: [],
-    inputSchema: { type: 'object', additionalProperties: false, properties: {} },
-    outputSchema: okOutput('ContractSchemaOutput', { $id: 'RelayCliGatewayContractManifest', type: 'object' }),
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {},
+    },
+    outputSchema: okOutput('ContractSchemaOutput', {
+      $id: 'RelayCliGatewayContractManifest',
+      type: 'object',
+    }),
     errorCodes: ['INTERNAL'],
   },
   {
@@ -1257,47 +1390,89 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     transport: 'local',
     requiresAuth: false,
     capabilityHints: [],
-    inputSchema: { type: 'object', additionalProperties: false, properties: {} },
-    outputSchema: okOutput('NodesManifestOutput', { type: 'object', additionalProperties: true }),
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {},
+    },
+    outputSchema: okOutput('NodesManifestOutput', {
+      type: 'object',
+      additionalProperties: true,
+    }),
     errorCodes: ['INTERNAL'],
   },
   {
     name: 'nodes.list',
     cli: ['relay-ide', 'v1', 'nodes', 'list', '--json'],
-    summary: 'List hub-known local/remote relay nodes and summarized capabilities.',
+    summary:
+      'List hub-known local/remote relay nodes and summarized capabilities.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
     capabilityHints: ['session:read'],
-    inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {},
+    },
     outputSchema: okOutput('NodesListOutput', {
       type: 'object',
       additionalProperties: false,
-      properties: { nodes: { type: 'array', items: { type: 'object', additionalProperties: true } } },
+      properties: {
+        nodes: {
+          type: 'array',
+          items: { type: 'object', additionalProperties: true },
+        },
+      },
       required: ['nodes'],
     }),
-    errorCodes: ['UNAUTHORIZED', 'INVALID_ARGUMENT', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
   },
   {
     name: 'sessions.list',
     cli: ['relay-ide', 'v1', 'sessions', 'list', '--json'],
-    summary: 'List active local and routed sessions with identity and control summaries.',
+    summary:
+      'List active local and routed sessions with identity and control summaries.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
     capabilityHints: ['session:read'],
-    inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {},
+    },
     outputSchema: okOutput('SessionsListOutput', {
       type: 'object',
       additionalProperties: false,
-      properties: { sessions: { type: 'array', items: sessionDescriptorSchema } },
+      properties: {
+        sessions: { type: 'array', items: sessionDescriptorSchema },
+      },
       required: ['sessions'],
     }),
-    errorCodes: ['UNAUTHORIZED', 'INVALID_ARGUMENT', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
   },
   {
     name: 'sessions.get',
-    cli: ['relay-ide', 'v1', 'sessions', 'get', '--id', '<session-id>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'sessions',
+      'get',
+      '--id',
+      '<session-id>',
+      '--json',
+    ],
     summary: 'Inspect one session by node-local id or globalSessionId.',
     stable: true,
     transport: 'hub-http',
@@ -1321,12 +1496,25 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'sessions.create',
-    cli: ['relay-ide', 'v1', 'sessions', 'create', '--input-json', '<json>', '--json'],
-    summary: 'Create a local or routed node session and return the created descriptor.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'sessions',
+      'create',
+      '--input-json',
+      '<json>',
+      '--json',
+    ],
+    summary:
+      'Create a local or routed node session and return the created descriptor.',
     stable: true,
     transport: 'hub-http-or-node-rpc',
     requiresAuth: true,
-    capabilityHints: ['session:create:terminal', 'session:create:agent', 'tab:mode:set-agent'],
+    capabilityHints: [
+      'session:create:terminal',
+      'session:create:agent',
+      'tab:mode:set-agent',
+    ],
     inputSchema: createSessionInputSchema,
     outputSchema: okOutput('SessionsCreateOutput', sessionDescriptorSchema),
     errorCodes: [
@@ -1343,8 +1531,19 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'sessions.renew',
-    cli: ['relay-ide', 'v1', 'sessions', 'renew', '--id', '<session-id>', '--ttl-seconds', '<seconds>', '--json'],
-    summary: 'Renew or extend a scoped session expiry without changing its intent, scope, or peer identity.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'sessions',
+      'renew',
+      '--id',
+      '<session-id>',
+      '--ttl-seconds',
+      '<seconds>',
+      '--json',
+    ],
+    summary:
+      'Renew or extend a scoped session expiry without changing its intent, scope, or peer identity.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
@@ -1371,7 +1570,15 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'sessions.attach',
-    cli: ['relay-ide', 'v1', 'sessions', 'attach', '--id', '<session-id>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'sessions',
+      'attach',
+      '--id',
+      '<session-id>',
+      '--json',
+    ],
     summary:
       'Resolve a local or routed session descriptor for adapter attach without starting a streaming adapter runtime.',
     stable: true,
@@ -1396,7 +1603,15 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'sessions.detach',
-    cli: ['relay-ide', 'v1', 'sessions', 'detach', '--id', '<session-id>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'sessions',
+      'detach',
+      '--id',
+      '<session-id>',
+      '--json',
+    ],
     summary:
       'Detach adapter control from a session without killing the underlying remote process.',
     stable: true,
@@ -1484,8 +1699,17 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'sessions.interventions',
-    cli: ['relay-ide', 'v1', 'sessions', 'interventions', '--id', '<session-id>', '--json'],
-    summary: 'Read bounded, redacted intervention metadata for a local session.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'sessions',
+      'interventions',
+      '--id',
+      '<session-id>',
+      '--json',
+    ],
+    summary:
+      'Read bounded, redacted intervention metadata for a local session.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
@@ -1493,7 +1717,10 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     inputSchema: {
       type: 'object',
       additionalProperties: false,
-      properties: { id: stringSchema, limit: { type: 'number', minimum: 1, maximum: 200 } },
+      properties: {
+        id: stringSchema,
+        limit: { type: 'number', minimum: 1, maximum: 200 },
+      },
       required: ['id'],
     },
     outputSchema: okOutput('SessionsInterventionsOutput', {
@@ -1526,7 +1753,8 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       '<event-id>',
       '--json',
     ],
-    summary: 'Acknowledge latest human intervention before restoring agent-driven control.',
+    summary:
+      'Acknowledge latest human intervention before restoring agent-driven control.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
@@ -1534,10 +1762,16 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     inputSchema: {
       type: 'object',
       additionalProperties: false,
-      properties: { id: stringSchema, latestSeenInterventionEventId: stringSchema },
+      properties: {
+        id: stringSchema,
+        latestSeenInterventionEventId: stringSchema,
+      },
       required: ['id', 'latestSeenInterventionEventId'],
     },
-    outputSchema: okOutput('SessionsHandBackOutput', { type: 'object', additionalProperties: true }),
+    outputSchema: okOutput('SessionsHandBackOutput', {
+      type: 'object',
+      additionalProperties: true,
+    }),
     errorCodes: [
       'UNAUTHORIZED',
       'INVALID_ARGUMENT',
@@ -1627,7 +1861,8 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       '<path>',
       '--json',
     ],
-    summary: 'Read UTF-8 file content through scoped read-only File RPC with byte/line caps.',
+    summary:
+      'Read UTF-8 file content through scoped read-only File RPC with byte/line caps.',
     stable: true,
     transport: 'hub-http-or-node-rpc',
     requiresAuth: true,
@@ -1662,7 +1897,8 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       '<local-path|->',
       '--json',
     ],
-    summary: 'Write file content through scoped File RPC with atomic-rename semantics and capability gate.',
+    summary:
+      'Write file content through scoped File RPC with atomic-rename semantics and capability gate.',
     stable: true,
     transport: 'hub-http-or-node-rpc',
     requiresAuth: true,
@@ -1682,8 +1918,17 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'work-contexts.get',
-    cli: ['relay-ide', 'v1', 'work-contexts', 'get', '--id', '<work-context-id>', '--json'],
-    summary: 'Read one WorkContext by stable identity for handoff/self-service agents.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'work-contexts',
+      'get',
+      '--id',
+      '<work-context-id>',
+      '--json',
+    ],
+    summary:
+      'Read one WorkContext by stable identity for handoff/self-service agents.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
@@ -1692,15 +1937,32 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     outputSchema: okOutput('WorkContextsGetOutput', {
       type: 'object',
       additionalProperties: false,
-      properties: { workContext: { type: 'object', additionalProperties: true } },
+      properties: {
+        workContext: { type: 'object', additionalProperties: true },
+      },
       required: ['workContext'],
     }),
-    errorCodes: ['UNAUTHORIZED', 'INVALID_ARGUMENT', 'NOT_FOUND', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'NOT_FOUND',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
   },
   {
     name: 'context.create',
-    cli: ['relay-ide', 'v1', 'context', 'create', '--input-json', '<json>', '--json'],
-    summary: 'Create a ref-only context packet (file-anchor/file-ref/note) in the hub store.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'context',
+      'create',
+      '--input-json',
+      '<json>',
+      '--json',
+    ],
+    summary:
+      'Create a ref-only context packet (file-anchor/file-ref/note) in the hub store.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
@@ -1711,8 +1973,17 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'context.get',
-    cli: ['relay-ide', 'v1', 'context', 'get', '--id', '<context-packet-id>', '--json'],
-    summary: 'Read one context packet by stable id. Ref-only; never returns raw file bytes.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'context',
+      'get',
+      '--id',
+      '<context-packet-id>',
+      '--json',
+    ],
+    summary:
+      'Read one context packet by stable id. Ref-only; never returns raw file bytes.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
@@ -1724,7 +1995,8 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   {
     name: 'context.list',
     cli: ['relay-ide', 'v1', 'context', 'list', '--json'],
-    summary: 'List context packets, optionally filtered by node/workspace binding.',
+    summary:
+      'List context packets, optionally filtered by node/workspace binding or WorkContext artifact pins.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
@@ -1734,8 +2006,62 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     errorCodes: contextInboxReadErrorCodes,
   },
   {
+    name: 'context.pin',
+    cli: [
+      'relay-ide',
+      'v1',
+      'context',
+      'pin',
+      '--id',
+      '<context-packet-id>',
+      '--work-context-id',
+      '<work-context-id>',
+      '--json',
+    ],
+    summary:
+      'Pin an existing context packet to a WorkContext by recording a WorkContext artifact ref; the packet store remains the source of truth.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['context:write'],
+    inputSchema: contextPinInputSchema,
+    outputSchema: okOutput('ContextPinOutput', contextPinDataSchema),
+    errorCodes: contextInboxWriteErrorCodes,
+  },
+  {
+    name: 'context.unpin',
+    cli: [
+      'relay-ide',
+      'v1',
+      'context',
+      'unpin',
+      '--id',
+      '<context-packet-id>',
+      '--work-context-id',
+      '<work-context-id>',
+      '--json',
+    ],
+    summary:
+      'Unpin a context packet from a WorkContext artifact ref without deleting the packet; orphan cleanup/GC semantics remain explicit.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['context:write'],
+    inputSchema: contextPinInputSchema,
+    outputSchema: okOutput('ContextUnpinOutput', contextUnpinDataSchema),
+    errorCodes: contextInboxWriteErrorCodes,
+  },
+  {
     name: 'inbox.send',
-    cli: ['relay-ide', 'v1', 'inbox', 'send', '--input-json', '<json>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'inbox',
+      'send',
+      '--input-json',
+      '<json>',
+      '--json',
+    ],
     summary:
       'Queue a session/WorkContext inbox message referencing context packets. Never pushes into sessions.input; delivery is PULL.',
     stable: true,
@@ -1748,7 +2074,15 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'inbox.list',
-    cli: ['relay-ide', 'v1', 'inbox', 'list', '--target-session-id', '<global-session-id>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'inbox',
+      'list',
+      '--target-session-id',
+      '<global-session-id>',
+      '--json',
+    ],
     summary:
       'List inbox messages for a session/WorkContext. PULL delivery: queued messages flip to delivered as a side effect of being fetched.',
     stable: true,
@@ -1761,7 +2095,15 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'inbox.get',
-    cli: ['relay-ide', 'v1', 'inbox', 'get', '--id', '<inbox-message-id>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'inbox',
+      'get',
+      '--id',
+      '<inbox-message-id>',
+      '--json',
+    ],
     summary:
       'Read one inbox message by id. PULL delivery: a queued message flips to delivered as a side effect of being fetched.',
     stable: true,
@@ -1774,7 +2116,15 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'inbox.ack',
-    cli: ['relay-ide', 'v1', 'inbox', 'ack', '--id', '<inbox-message-id>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'inbox',
+      'ack',
+      '--id',
+      '<inbox-message-id>',
+      '--json',
+    ],
     summary:
       'Acknowledge an inbox message (delivered → acknowledged). Idempotent; rejects transitions out of terminal states.',
     stable: true,
@@ -1787,8 +2137,17 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'inbox.resolve',
-    cli: ['relay-ide', 'v1', 'inbox', 'resolve', '--id', '<inbox-message-id>', '--json'],
-    summary: 'Resolve an inbox message (terminal). Rejects transitions out of an already-terminal state.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'inbox',
+      'resolve',
+      '--id',
+      '<inbox-message-id>',
+      '--json',
+    ],
+    summary:
+      'Resolve an inbox message (terminal). Rejects transitions out of an already-terminal state.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
@@ -1799,8 +2158,17 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'inbox.ignore',
-    cli: ['relay-ide', 'v1', 'inbox', 'ignore', '--id', '<inbox-message-id>', '--json'],
-    summary: 'Ignore an inbox message (terminal). Rejects transitions out of an already-terminal state.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'inbox',
+      'ignore',
+      '--id',
+      '<inbox-message-id>',
+      '--json',
+    ],
+    summary:
+      'Ignore an inbox message (terminal). Rejects transitions out of an already-terminal state.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
@@ -1811,8 +2179,17 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'handoffs.plan',
-    cli: ['relay-ide', 'v1', 'handoffs', 'plan', '--input-json', '<json>', '--json'],
-    summary: 'Dry-run a cold handoff plan. Read-only; never mutates source or destination.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'handoffs',
+      'plan',
+      '--input-json',
+      '<json>',
+      '--json',
+    ],
+    summary:
+      'Dry-run a cold handoff plan. Read-only; never mutates source or destination.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
@@ -1823,19 +2200,42 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'handoffs.create',
-    cli: ['relay-ide', 'v1', 'handoffs', 'create', '--input-json', '<json>', '--json'],
-    summary: 'Execute a confirmed cold handoff through the transfer/apply engine; refuses fake success.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'handoffs',
+      'create',
+      '--input-json',
+      '<json>',
+      '--json',
+    ],
+    summary:
+      'Execute a confirmed cold handoff through the transfer/apply engine; refuses fake success.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
-    capabilityHints: ['rpc:fs:read', 'rpc:fs:write', 'session:create:agent', 'session:create:terminal', 'pty:exec:arbitrary'],
+    capabilityHints: [
+      'rpc:fs:read',
+      'rpc:fs:write',
+      'session:create:agent',
+      'session:create:terminal',
+      'pty:exec:arbitrary',
+    ],
     inputSchema: handoffCreateInputSchema,
     outputSchema: okOutput('HandoffsCreateOutput', handoffCreateOutputSchema),
     errorCodes: gatewayHandoffErrorCodes,
   },
   {
     name: 'handoffs.status',
-    cli: ['relay-ide', 'v1', 'handoffs', 'status', '--run-id', '<run-id>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'handoffs',
+      'status',
+      '--run-id',
+      '<run-id>',
+      '--json',
+    ],
     summary: 'Read bounded/redacted HandoffRun state and progress.',
     stable: true,
     transport: 'hub-http',
@@ -1847,8 +2247,17 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'handoffs.cancel',
-    cli: ['relay-ide', 'v1', 'handoffs', 'cancel', '--run-id', '<run-id>', '--json'],
-    summary: 'Cancel a non-terminal handoff run without applying additional mutations.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'handoffs',
+      'cancel',
+      '--run-id',
+      '<run-id>',
+      '--json',
+    ],
+    summary:
+      'Cancel a non-terminal handoff run without applying additional mutations.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
@@ -1859,8 +2268,17 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'handoffs.resume',
-    cli: ['relay-ide', 'v1', 'handoffs', 'resume', '--run-id', '<run-id>', '--json'],
-    summary: 'Read cold handoff resume bundle refs without raw transcript/provider-auth export.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'handoffs',
+      'resume',
+      '--run-id',
+      '<run-id>',
+      '--json',
+    ],
+    summary:
+      'Read cold handoff resume bundle refs without raw transcript/provider-auth export.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
@@ -1871,23 +2289,46 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'handoffs.launch',
-    cli: ['relay-ide', 'v1', 'handoffs', 'launch', '--run-id', '<run-id>', '--json'],
-    summary: 'Retry hub-side destination session launch for an applied cold handoff after a typed launch failure.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'handoffs',
+      'launch',
+      '--run-id',
+      '<run-id>',
+      '--json',
+    ],
+    summary:
+      'Retry hub-side destination session launch for an applied cold handoff after a typed launch failure.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
     // Static gateway manifests cannot know whether the stored retry target is
     // agent or terminal; advertise the superset for tool generators while the
     // hub route enforces the stored plan's runtime-specific create capability.
-    capabilityHints: ['session:read', 'session:create:agent', 'session:create:terminal', 'pty:exec:arbitrary'],
+    capabilityHints: [
+      'session:read',
+      'session:create:agent',
+      'session:create:terminal',
+      'pty:exec:arbitrary',
+    ],
     inputSchema: handoffRunIdInputSchema,
     outputSchema: okOutput('HandoffsLaunchOutput', handoffCreateOutputSchema),
     errorCodes: gatewayHandoffErrorCodes,
   },
   {
     name: 'artifacts.read',
-    cli: ['relay-ide', 'v1', 'artifacts', 'read', '--ref', '<artifact-ref>', '--json'],
-    summary: 'Read a bounded handoff artifact reference; raw logs/secrets/transcripts are unavailable.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'artifacts',
+      'read',
+      '--ref',
+      '<artifact-ref>',
+      '--json',
+    ],
+    summary:
+      'Read a bounded handoff artifact reference; raw logs/secrets/transcripts are unavailable.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
@@ -1898,7 +2339,15 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'supervisor.snapshot',
-    cli: ['relay-ide', 'v1', 'supervisor', 'snapshot', '--id', '<session-id>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'supervisor',
+      'snapshot',
+      '--id',
+      '<session-id>',
+      '--json',
+    ],
     summary:
       'Read a typed supervisor snapshot for one session with control-mode preflight, intervention ack checks, and redacted audit metadata; never sends raw PTY input.',
     stable: true,
@@ -1906,43 +2355,76 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     requiresAuth: true,
     capabilityHints: ['session:read', 'tab:intervention:read'],
     inputSchema: supervisorSnapshotInputSchema,
-    outputSchema: okOutput('SupervisorSnapshotOutput', supervisorSnapshotOutputSchema),
+    outputSchema: okOutput(
+      'SupervisorSnapshotOutput',
+      supervisorSnapshotOutputSchema
+    ),
     errorCodes: gatewaySupervisorErrorCodes,
   },
   {
     name: 'supervisor.sessions',
     cli: ['relay-ide', 'v1', 'supervisor', 'sessions', '--json'],
-    summary: 'List sessions eligible for typed supervisor actions with per-action reasons.',
+    summary:
+      'List sessions eligible for typed supervisor actions with per-action reasons.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
     capabilityHints: ['session:read', 'tab:intervention:read'],
     inputSchema: supervisorSessionsInputSchema,
-    outputSchema: okOutput('SupervisorSessionsOutput', supervisorSessionsOutputSchema),
+    outputSchema: okOutput(
+      'SupervisorSessionsOutput',
+      supervisorSessionsOutputSchema
+    ),
     errorCodes: gatewaySupervisorErrorCodes,
   },
   {
     name: 'supervisor.sendText',
-    cli: ['relay-ide', 'v1', 'supervisor', 'send-text', '--id', '<session-id>', '--text', '<text>', '--json'],
-    summary: 'Send bounded literal text to one or more PTY sessions as a typed supervisor intervention.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'supervisor',
+      'send-text',
+      '--id',
+      '<session-id>',
+      '--text',
+      '<text>',
+      '--json',
+    ],
+    summary:
+      'Send bounded literal text to one or more PTY sessions as a typed supervisor intervention.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
     capabilityHints: ['session:attach', 'tab:intervention:send-text'],
     inputSchema: supervisorSendTextInputSchema,
-    outputSchema: okOutput('SupervisorSendTextOutput', supervisorActionOutputSchema('supervisor.sendText')),
+    outputSchema: okOutput(
+      'SupervisorSendTextOutput',
+      supervisorActionOutputSchema('supervisor.sendText')
+    ),
     errorCodes: gatewaySupervisorErrorCodes,
   },
   {
     name: 'supervisor.submit',
-    cli: ['relay-ide', 'v1', 'supervisor', 'submit', '--id', '<session-id>', '--json'],
-    summary: 'Submit Enter to one or more PTY sessions as a typed supervisor intervention.',
+    cli: [
+      'relay-ide',
+      'v1',
+      'supervisor',
+      'submit',
+      '--id',
+      '<session-id>',
+      '--json',
+    ],
+    summary:
+      'Submit Enter to one or more PTY sessions as a typed supervisor intervention.',
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
     capabilityHints: ['session:attach', 'tab:intervention:submit'],
     inputSchema: supervisorSubmitInputSchema,
-    outputSchema: okOutput('SupervisorSubmitOutput', supervisorActionOutputSchema('supervisor.submit')),
+    outputSchema: okOutput(
+      'SupervisorSubmitOutput',
+      supervisorActionOutputSchema('supervisor.submit')
+    ),
     errorCodes: gatewaySupervisorErrorCodes,
   },
   {
@@ -2019,8 +2501,12 @@ export function gatewayError(
   };
 }
 
-export function commandSpec(name: RelayCliGatewayCommand): RelayCliGatewayCommandSpec {
-  const spec = RELAY_CLI_GATEWAY_CONTRACT.commandSchemas.find((entry) => entry.name === name);
+export function commandSpec(
+  name: RelayCliGatewayCommand
+): RelayCliGatewayCommandSpec {
+  const spec = RELAY_CLI_GATEWAY_CONTRACT.commandSchemas.find(
+    (entry) => entry.name === name
+  );
   if (!spec) throw new Error(`unknown CLI gateway command spec: ${name}`);
   return spec;
 }

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -7,8 +7,17 @@ import {
 import type { RelayCapabilityBit } from './security-policy.js';
 
 export type RelayCommandSurface = 'web' | 'cli' | 'agent';
-export type RelayCommandSideEffect = 'read' | 'write' | 'destructive' | 'stream';
-export type RelayCommandScopeKind = 'node' | 'repo' | 'worktree' | 'work-context' | 'session';
+export type RelayCommandSideEffect =
+  | 'read'
+  | 'write'
+  | 'destructive'
+  | 'stream';
+export type RelayCommandScopeKind =
+  | 'node'
+  | 'repo'
+  | 'worktree'
+  | 'work-context'
+  | 'session';
 export type RelayCommandControlRequirement =
   | 'fresh-control-state'
   | 'latest-intervention-ack'
@@ -90,6 +99,8 @@ const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
   'context.create': 'create context packet',
   'context.get': 'context packet details',
   'context.list': 'list context packets',
+  'context.pin': 'pin context packet',
+  'context.unpin': 'unpin context packet',
   'inbox.send': 'send inbox message',
   'inbox.list': 'list inbox messages',
   'inbox.get': 'inbox message details',
@@ -110,9 +121,13 @@ const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
   'events.subscribe': 'subscribe gateway events',
 };
 
-function sideEffectForGatewayCommand(spec: RelayCliGatewayCommandSpec): RelayCommandSideEffect {
-  if (spec.name === 'sessions.stream' || spec.name === 'events.subscribe') return 'stream';
-  if (spec.name === 'handoffs.create' || spec.name === 'handoffs.launch') return 'destructive';
+function sideEffectForGatewayCommand(
+  spec: RelayCliGatewayCommandSpec
+): RelayCommandSideEffect {
+  if (spec.name === 'sessions.stream' || spec.name === 'events.subscribe')
+    return 'stream';
+  if (spec.name === 'handoffs.create' || spec.name === 'handoffs.launch')
+    return 'destructive';
   if (
     spec.name === 'sessions.create' ||
     spec.name === 'sessions.renew' ||
@@ -124,6 +139,8 @@ function sideEffectForGatewayCommand(spec: RelayCliGatewayCommandSpec): RelayCom
     spec.name === 'files.write' ||
     spec.name === 'handoffs.cancel' ||
     spec.name === 'context.create' ||
+    spec.name === 'context.pin' ||
+    spec.name === 'context.unpin' ||
     spec.name === 'inbox.send' ||
     spec.name === 'inbox.ack' ||
     spec.name === 'inbox.resolve' ||
@@ -134,13 +151,16 @@ function sideEffectForGatewayCommand(spec: RelayCliGatewayCommandSpec): RelayCom
   return 'read';
 }
 
-function scopeKindsForGatewayCommand(name: RelayCliGatewayCommand): readonly RelayCommandScopeKind[] {
+function scopeKindsForGatewayCommand(
+  name: RelayCliGatewayCommand
+): readonly RelayCommandScopeKind[] {
   if (name.startsWith('nodes.')) return ['node'];
   if (name.startsWith('files.')) return ['session'];
   if (name.startsWith('work-contexts.')) return ['work-context'];
   if (name.startsWith('context.')) return ['work-context', 'session'];
   if (name.startsWith('inbox.')) return ['session', 'work-context'];
-  if (name.startsWith('handoffs.')) return ['repo', 'worktree', 'work-context', 'session'];
+  if (name.startsWith('handoffs.'))
+    return ['repo', 'worktree', 'work-context', 'session'];
   if (name.startsWith('artifacts.')) return ['work-context'];
   if (name.startsWith('supervisor.')) return ['session'];
   if (name.startsWith('events.')) return ['node', 'session'];
@@ -148,7 +168,9 @@ function scopeKindsForGatewayCommand(name: RelayCliGatewayCommand): readonly Rel
   return [];
 }
 
-function requiresConfirmationForGatewayCommand(spec: RelayCliGatewayCommandSpec): boolean {
+function requiresConfirmationForGatewayCommand(
+  spec: RelayCliGatewayCommandSpec
+): boolean {
   return (
     spec.name === 'files.write' ||
     spec.name === 'handoffs.create' ||
@@ -162,25 +184,40 @@ function controlRequirementsForGatewayCommand(
   spec: RelayCliGatewayCommandSpec
 ): readonly RelayCommandControlRequirement[] {
   const requirements: RelayCommandControlRequirement[] = [];
-  if (requiresConfirmationForGatewayCommand(spec)) requirements.push('confirmation-challenge');
+  if (requiresConfirmationForGatewayCommand(spec))
+    requirements.push('confirmation-challenge');
   if (spec.name === 'supervisor.snapshot') {
     requirements.push('fresh-control-state', 'latest-intervention-ack');
   }
-  if (spec.name === 'supervisor.sendText' || spec.name === 'supervisor.submit') {
+  if (
+    spec.name === 'supervisor.sendText' ||
+    spec.name === 'supervisor.submit'
+  ) {
     requirements.push('fresh-control-state');
   }
-  if (spec.name === 'sessions.handBack') requirements.push('latest-intervention-ack');
+  if (spec.name === 'sessions.handBack')
+    requirements.push('latest-intervention-ack');
   return requirements;
 }
 
 function auditExpectationForGatewayCommand(
   spec: RelayCliGatewayCommandSpec
 ): RelayCommandAuditExpectation {
-  if (spec.name === 'contract.list' || spec.name === 'contract.schema' || spec.name === 'nodes.manifest') {
+  if (
+    spec.name === 'contract.list' ||
+    spec.name === 'contract.schema' ||
+    spec.name === 'nodes.manifest'
+  ) {
     return 'schema-only';
   }
-  if (spec.name === 'sessions.stream' || spec.name === 'events.subscribe') return 'stream-redacted';
-  if (spec.name === 'supervisor.snapshot' || spec.name === 'supervisor.sendText' || spec.name === 'supervisor.submit') return 'hashes-only';
+  if (spec.name === 'sessions.stream' || spec.name === 'events.subscribe')
+    return 'stream-redacted';
+  if (
+    spec.name === 'supervisor.snapshot' ||
+    spec.name === 'supervisor.sendText' ||
+    spec.name === 'supervisor.submit'
+  )
+    return 'hashes-only';
   if (sideEffectForGatewayCommand(spec) === 'read') return 'bounded-redacted';
   return 'action-summary';
 }
@@ -224,11 +261,17 @@ export function relayCommandDefinitionFromCliGatewaySpec(
 export const RELAY_COMMAND_MANIFEST: RelayCommandManifest = {
   schemaVersion: 1,
   generatedFrom: 'shared/cli-gateway-contract.ts',
-  commands: RELAY_CLI_GATEWAY_CONTRACT.commandSchemas.map(relayCommandDefinitionFromCliGatewaySpec),
+  commands: RELAY_CLI_GATEWAY_CONTRACT.commandSchemas.map(
+    relayCommandDefinitionFromCliGatewaySpec
+  ),
 };
 
-export function relayCommandDefinition(name: RelayCliGatewayCommand): RelayCommandDefinition {
-  const definition = RELAY_COMMAND_MANIFEST.commands.find((entry) => entry.name === name);
+export function relayCommandDefinition(
+  name: RelayCliGatewayCommand
+): RelayCommandDefinition {
+  const definition = RELAY_COMMAND_MANIFEST.commands.find(
+    (entry) => entry.name === name
+  );
   if (!definition) throw new Error(`unknown Relay command definition: ${name}`);
   return definition;
 }
@@ -236,5 +279,7 @@ export function relayCommandDefinition(name: RelayCliGatewayCommand): RelayComma
 export function relayCommandDefinitionsForSurface(
   surface: RelayCommandSurface
 ): RelayCommandDefinition[] {
-  return RELAY_COMMAND_MANIFEST.commands.filter((command) => command.surfaces.includes(surface));
+  return RELAY_COMMAND_MANIFEST.commands.filter((command) =>
+    command.surfaces.includes(surface)
+  );
 }

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -34,10 +34,14 @@ import {
 const hasOwn = (value: Record<string, unknown>, key: string): boolean =>
   Object.prototype.hasOwnProperty.call(value, key);
 
-function objectMatchesSchemaKeywords(schema: RelayJsonSchema, value: Record<string, unknown>): boolean {
+function objectMatchesSchemaKeywords(
+  schema: RelayJsonSchema,
+  value: Record<string, unknown>
+): boolean {
   const properties = schema.properties ?? {};
   const required = schema.required ?? [];
-  if (schema.type === 'object' && (value === null || Array.isArray(value))) return false;
+  if (schema.type === 'object' && (value === null || Array.isArray(value)))
+    return false;
   if (!required.every((key) => hasOwn(value, key))) return false;
   if (schema.additionalProperties === false) {
     for (const key of Object.keys(value)) {
@@ -46,10 +50,14 @@ function objectMatchesSchemaKeywords(schema: RelayJsonSchema, value: Record<stri
   }
   for (const [key, propertySchema] of Object.entries(properties)) {
     if (!hasOwn(value, key)) continue;
-    if ('const' in propertySchema && value[key] !== propertySchema.const) return false;
-    if (propertySchema.type === 'string' && typeof value[key] !== 'string') return false;
-    if (propertySchema.type === 'boolean' && typeof value[key] !== 'boolean') return false;
-    if (propertySchema.type === 'number' && typeof value[key] !== 'number') return false;
+    if ('const' in propertySchema && value[key] !== propertySchema.const)
+      return false;
+    if (propertySchema.type === 'string' && typeof value[key] !== 'string')
+      return false;
+    if (propertySchema.type === 'boolean' && typeof value[key] !== 'boolean')
+      return false;
+    if (propertySchema.type === 'number' && typeof value[key] !== 'number')
+      return false;
   }
   return true;
 }
@@ -58,7 +66,10 @@ function schemaAcceptsSessionInput(value: Record<string, unknown>): boolean {
   const schema = commandSpec('sessions.input').inputSchema;
   if (!objectMatchesSchemaKeywords(schema, value)) return false;
   if (!schema.oneOf) return true;
-  return schema.oneOf.filter((branch) => objectMatchesSchemaKeywords(branch, value)).length === 1;
+  return (
+    schema.oneOf.filter((branch) => objectMatchesSchemaKeywords(branch, value))
+      .length === 1
+  );
 }
 
 describe('CLI gateway contract', () => {
@@ -93,6 +104,8 @@ describe('CLI gateway contract', () => {
       'context.create',
       'context.get',
       'context.list',
+      'context.pin',
+      'context.unpin',
       'inbox.send',
       'inbox.list',
       'inbox.get',
@@ -128,16 +141,18 @@ describe('CLI gateway contract', () => {
       schemaVersion: 1,
       generatedFrom: 'shared/cli-gateway-contract.ts',
     });
-    expect(RELAY_COMMAND_MANIFEST.commands.map((command) => command.name)).toEqual(stableNames);
-    expect(relayCommandDefinitionsForSurface('cli').map((command) => command.name)).toEqual(
-      stableNames
-    );
-    expect(relayCommandDefinitionsForSurface('agent').map((command) => command.name)).toEqual(
-      stableNames
-    );
-    expect(relayCommandDefinitionsForSurface('web').map((command) => command.name)).toEqual(
-      stableNames
-    );
+    expect(
+      RELAY_COMMAND_MANIFEST.commands.map((command) => command.name)
+    ).toEqual(stableNames);
+    expect(
+      relayCommandDefinitionsForSurface('cli').map((command) => command.name)
+    ).toEqual(stableNames);
+    expect(
+      relayCommandDefinitionsForSurface('agent').map((command) => command.name)
+    ).toEqual(stableNames);
+    expect(
+      relayCommandDefinitionsForSurface('web').map((command) => command.name)
+    ).toEqual(stableNames);
 
     for (const name of stableNames) {
       const spec = commandSpec(name);
@@ -159,7 +174,9 @@ describe('CLI gateway contract', () => {
         expect(RELAY_CAPABILITY_BITS).toContain(hint);
       }
       expect(command.handler.cli).toEqual(spec.cli);
-      expect(['read', 'write', 'destructive', 'stream']).toContain(command.sideEffect);
+      expect(['read', 'write', 'destructive', 'stream']).toContain(
+        command.sideEffect
+      );
       expect(Array.isArray(command.scopeKinds)).toBe(true);
       expect(Array.isArray(command.controlRequirements)).toBe(true);
       expect([
@@ -277,25 +294,36 @@ describe('CLI gateway contract', () => {
     };
     const envelope = gatewayOk('supervisor.snapshot', payload);
 
-    expect(envelope).toMatchObject({ ok: true, command: 'supervisor.snapshot' });
+    expect(envelope).toMatchObject({
+      ok: true,
+      command: 'supervisor.snapshot',
+    });
     expect(envelope.data).toEqual(payload);
     expect(Object.keys(envelope.data).sort()).toEqual(['audit', 'snapshot']);
     expect(hasOwn(envelope.data, 'ok')).toBe(false);
 
     const outputSchema = commandSpec('supervisor.snapshot').outputSchema;
-    expect(objectMatchesSchemaKeywords(outputSchema, envelope as unknown as Record<string, unknown>)).toBe(
-      true
-    );
+    expect(
+      objectMatchesSchemaKeywords(
+        outputSchema,
+        envelope as unknown as Record<string, unknown>
+      )
+    ).toBe(true);
 
     const dataSchema = outputSchema.properties?.data;
-    if (!dataSchema) throw new Error('supervisor.snapshot output schema must define data');
+    if (!dataSchema)
+      throw new Error('supervisor.snapshot output schema must define data');
     expect(objectMatchesSchemaKeywords(dataSchema, envelope.data)).toBe(true);
-    expect(objectMatchesSchemaKeywords(dataSchema, { ok: true, ...payload })).toBe(false);
+    expect(
+      objectMatchesSchemaKeywords(dataSchema, { ok: true, ...payload })
+    ).toBe(false);
 
     const snapshotSchema = dataSchema.properties?.snapshot;
     const auditSchema = dataSchema.properties?.audit;
-    if (!snapshotSchema?.properties?.redaction) throw new Error('snapshot redaction schema required');
-    if (!auditSchema?.properties?.redaction) throw new Error('audit redaction schema required');
+    if (!snapshotSchema?.properties?.redaction)
+      throw new Error('snapshot redaction schema required');
+    if (!auditSchema?.properties?.redaction)
+      throw new Error('audit redaction schema required');
     expect(snapshotSchema.required).toEqual(['command', 'redaction']);
     expect(snapshotSchema.properties.redaction.required).toEqual([
       'rawPtyInputAvailable',
@@ -329,7 +357,9 @@ describe('CLI gateway contract', () => {
     const createProperties = create.inputSchema.properties ?? {};
     expect(createProperties['sessionEnvelope']).toBeDefined();
     expect(createProperties['workContextId']).toBeDefined();
-    expect(JSON.stringify(create.inputSchema)).not.toContain('"kind":{"const":"agent"}');
+    expect(JSON.stringify(create.inputSchema)).not.toContain(
+      '"kind":{"const":"agent"}'
+    );
     expect(JSON.stringify(create.inputSchema)).not.toContain('"adapter"');
   });
 
@@ -355,7 +385,9 @@ describe('CLI gateway contract', () => {
 
     const localEnvelope = validateAndSanitizeGatewayCreateInput({
       repoPath: '/tmp/repo',
-      sessionEnvelope: { peerIdentity: { kind: 'relay-node', nodeId: 'node-a' } },
+      sessionEnvelope: {
+        peerIdentity: { kind: 'relay-node', nodeId: 'node-a' },
+      },
     });
     expect(localEnvelope).toMatchObject({
       ok: false,
@@ -365,7 +397,9 @@ describe('CLI gateway contract', () => {
     const agentPeer = validateAndSanitizeGatewayCreateInput({
       nodeId: 'node-a',
       repoPath: '/tmp/repo',
-      sessionEnvelope: { peerIdentity: { kind: 'agent', id: 'brain', adapter: 'kbrain' } },
+      sessionEnvelope: {
+        peerIdentity: { kind: 'agent', id: 'brain', adapter: 'kbrain' },
+      },
     });
     expect(agentPeer).toMatchObject({
       ok: false,
@@ -379,7 +413,8 @@ describe('CLI gateway contract', () => {
       nodeId: 'node-a',
       repoPath: '/tmp/repo',
     });
-    if (routedDefault.ok !== true) throw new Error('expected routed create input to validate');
+    if (routedDefault.ok !== true)
+      throw new Error('expected routed create input to validate');
     expect(routedDefault.sessionType).toBe('agent');
     expect(routedDefault.input).toMatchObject({
       nodeId: 'node-a',
@@ -449,6 +484,8 @@ describe('CLI gateway contract', () => {
       'context.create',
       'context.get',
       'context.list',
+      'context.pin',
+      'context.unpin',
       'inbox.send',
       'inbox.list',
       'inbox.get',
@@ -472,7 +509,10 @@ describe('CLI gateway contract', () => {
     for (const command of invalidArgumentCommands) {
       const emitted = gatewayError(
         command,
-        gatewayCliInvalidArgumentError(command, 'invalid gateway command arguments')
+        gatewayCliInvalidArgumentError(
+          command,
+          'invalid gateway command arguments'
+        )
       );
       expect(emitted.error.code).toBe('INVALID_ARGUMENT');
       expect(commandSpec(command).errorCodes).toContain(emitted.error.code);
@@ -480,10 +520,15 @@ describe('CLI gateway contract', () => {
 
     const invalidJson = gatewayError(
       'sessions.create',
-      gatewayCliInvalidJsonError('sessions.create', 'Unexpected end of JSON input')
+      gatewayCliInvalidJsonError(
+        'sessions.create',
+        'Unexpected end of JSON input'
+      )
     );
     expect(invalidJson.error.code).toBe('INVALID_JSON');
-    expect(commandSpec('sessions.create').errorCodes).toContain(invalidJson.error.code);
+    expect(commandSpec('sessions.create').errorCodes).toContain(
+      invalidJson.error.code
+    );
   });
 
   it('normalizes routed errors without exposing raw upstream bodies', () => {
@@ -494,12 +539,20 @@ describe('CLI gateway contract', () => {
     ).toBe('CONFIRMATION_REQUIRED');
     expect(
       normalizeGatewayErrorCode(404, {
-        error: { code: 'NODE_OFFLINE', retryable: true, details: { path: '/internal' } },
+        error: {
+          code: 'NODE_OFFLINE',
+          retryable: true,
+          details: { path: '/internal' },
+        },
       })
     ).toBe('NODE_OFFLINE');
     expect(
       normalizeGatewayErrorCode(409, {
-        error: { code: 'SOURCE_STALE_OR_OFFLINE', retryable: true, reasonCode: 'FAILED_STALE_SOURCE' },
+        error: {
+          code: 'SOURCE_STALE_OR_OFFLINE',
+          retryable: true,
+          reasonCode: 'FAILED_STALE_SOURCE',
+        },
       })
     ).toBe('NODE_OFFLINE');
     expect(
@@ -513,7 +566,9 @@ describe('CLI gateway contract', () => {
       })
     ).toBe('FORBIDDEN');
     expect(
-      gatewayErrorRetryable(404, { error: { code: 'NODE_OFFLINE', retryable: true } })
+      gatewayErrorRetryable(404, {
+        error: { code: 'NODE_OFFLINE', retryable: true },
+      })
     ).toBe(true);
     expect(
       sanitizedGatewayErrorDetails(500, {
@@ -526,7 +581,6 @@ describe('CLI gateway contract', () => {
       })
     ).toEqual({ status: 500, upstreamCode: 'INTERNAL', field: 'repoPath' });
   });
-
 
   it('advertises descriptor-only attach/detach, session renewal, session I/O, and read-only file RPC commands', () => {
     const renew = commandSpec('sessions.renew');
@@ -576,7 +630,10 @@ describe('CLI gateway contract', () => {
       properties: { maxBytes: { maximum: 1048576 } },
       oneOf: [
         { required: ['id', 'data'], properties: { data: { type: 'string' } } },
-        { required: ['id', 'dataBase64'], properties: { dataBase64: { type: 'string' } } },
+        {
+          required: ['id', 'dataBase64'],
+          properties: { dataBase64: { type: 'string' } },
+        },
         { required: ['id', 'stdin'], properties: { stdin: { const: true } } },
       ],
     });
@@ -607,8 +664,13 @@ describe('CLI gateway contract', () => {
         maxLines: { maximum: 2000 },
       },
     });
-    expect(read.errorCodes).toEqual(expect.arrayContaining(['NODE_OFFLINE', 'NOT_FOUND']));
-    expect(commandSpec('files.stat').capabilityHints).toEqual(['session:read', 'rpc:fs:read']);
+    expect(read.errorCodes).toEqual(
+      expect.arrayContaining(['NODE_OFFLINE', 'NOT_FOUND'])
+    );
+    expect(commandSpec('files.stat').capabilityHints).toEqual([
+      'session:read',
+      'rpc:fs:read',
+    ]);
 
     const write = commandSpec('files.write');
     expect(write.capabilityHints).toEqual(['session:read', 'rpc:fs:write']);
@@ -633,7 +695,13 @@ describe('CLI gateway contract', () => {
         },
       },
     });
-    expect(write.errorCodes).toEqual(expect.arrayContaining(['NODE_OFFLINE', 'FORBIDDEN', 'CONFIRMATION_REQUIRED']));
+    expect(write.errorCodes).toEqual(
+      expect.arrayContaining([
+        'NODE_OFFLINE',
+        'FORBIDDEN',
+        'CONFIRMATION_REQUIRED',
+      ])
+    );
   });
 
   it('advertises handoff/work-context/artifact gateway commands with cold-handoff safety gates', () => {
@@ -671,12 +739,22 @@ describe('CLI gateway contract', () => {
     });
     expect(create.summary).toContain('refuses fake success');
     expect(create.errorCodes).toEqual(
-      expect.arrayContaining(['FORBIDDEN', 'SESSION_CONFLICT', 'SERVER_UNAVAILABLE'])
+      expect.arrayContaining([
+        'FORBIDDEN',
+        'SESSION_CONFLICT',
+        'SERVER_UNAVAILABLE',
+      ])
     );
 
-    expect(commandSpec('handoffs.status').summary).toContain('bounded/redacted');
-    expect(commandSpec('handoffs.resume').summary).toContain('without raw transcript');
-    expect(commandSpec('artifacts.read').summary).toContain('raw logs/secrets/transcripts are unavailable');
+    expect(commandSpec('handoffs.status').summary).toContain(
+      'bounded/redacted'
+    );
+    expect(commandSpec('handoffs.resume').summary).toContain(
+      'without raw transcript'
+    );
+    expect(commandSpec('artifacts.read').summary).toContain(
+      'raw logs/secrets/transcripts are unavailable'
+    );
 
     const supervisor = commandSpec('supervisor.snapshot');
     expect(supervisor).toMatchObject({
@@ -687,39 +765,82 @@ describe('CLI gateway contract', () => {
       additionalProperties: false,
       required: ['id'],
       properties: {
-        expectedControlMode: { enum: ['agent-driven', 'human-driven', 'co-driven'] },
+        expectedControlMode: {
+          enum: ['agent-driven', 'human-driven', 'co-driven'],
+        },
       },
     });
     expect(supervisor.errorCodes).toEqual(
-      expect.arrayContaining(['FORBIDDEN', 'CONTROL_STATE_STALE', 'INTERVENTION_ACK_REQUIRED'])
+      expect.arrayContaining([
+        'FORBIDDEN',
+        'CONTROL_STATE_STALE',
+        'INTERVENTION_ACK_REQUIRED',
+      ])
     );
     expect(supervisor.summary).toContain('never sends raw PTY input');
   });
 
   it('advertises context.* / inbox.* verbs with ADR-019 capability + PULL semantics', () => {
     // Reads are session:read peers; writes use the dedicated context/inbox bits.
-    expect(commandSpec('context.get').capabilityHints).toEqual(['context:read']);
-    expect(commandSpec('context.list').capabilityHints).toEqual(['context:read']);
-    expect(commandSpec('context.create').capabilityHints).toEqual(['context:write']);
+    expect(commandSpec('context.get').capabilityHints).toEqual([
+      'context:read',
+    ]);
+    expect(commandSpec('context.list').capabilityHints).toEqual([
+      'context:read',
+    ]);
+    expect(commandSpec('context.create').capabilityHints).toEqual([
+      'context:write',
+    ]);
+    expect(commandSpec('context.pin').capabilityHints).toEqual([
+      'context:write',
+    ]);
+    expect(commandSpec('context.unpin').capabilityHints).toEqual([
+      'context:write',
+    ]);
     expect(commandSpec('inbox.list').capabilityHints).toEqual(['inbox:read']);
     expect(commandSpec('inbox.get').capabilityHints).toEqual(['inbox:read']);
     expect(commandSpec('inbox.send').capabilityHints).toEqual(['inbox:write']);
-    for (const verb of ['inbox.ack', 'inbox.resolve', 'inbox.ignore'] as const) {
+    for (const verb of [
+      'inbox.ack',
+      'inbox.resolve',
+      'inbox.ignore',
+    ] as const) {
       expect(commandSpec(verb).capabilityHints).toEqual(['inbox:write']);
     }
 
     // PULL delivery is documented on the read verbs; nothing pushes into sessions.input.
     expect(commandSpec('inbox.list').summary).toContain('PULL delivery');
     expect(commandSpec('inbox.get').summary).toContain('PULL delivery');
-    expect(commandSpec('inbox.send').summary).toContain('Never pushes into sessions.input');
+    expect(commandSpec('inbox.send').summary).toContain(
+      'Never pushes into sessions.input'
+    );
+    expect(commandSpec('context.pin').summary).toContain(
+      'WorkContext artifact ref'
+    );
+    expect(commandSpec('context.unpin').summary).toContain(
+      'without deleting the packet'
+    );
+    expect(commandSpec('context.list').inputSchema).toMatchObject({
+      properties: { workContextId: { type: 'string' } },
+    });
+    for (const verb of ['context.pin', 'context.unpin'] as const) {
+      expect(commandSpec(verb).inputSchema).toMatchObject({
+        required: ['id', 'workContextId'],
+      });
+    }
 
     // anchored addressing: send/list require a target.
     expect(commandSpec('inbox.send').inputSchema).toMatchObject({
-      anyOf: [{ required: ['targetSessionId'] }, { required: ['targetWorkContextId'] }],
+      anyOf: [
+        { required: ['targetSessionId'] },
+        { required: ['targetWorkContextId'] },
+      ],
     });
 
     // Manifest side-effects: writes are 'write' (not destructive); reads are 'read'.
     expect(relayCommandDefinition('context.create').sideEffect).toBe('write');
+    expect(relayCommandDefinition('context.pin').sideEffect).toBe('write');
+    expect(relayCommandDefinition('context.unpin').sideEffect).toBe('write');
     expect(relayCommandDefinition('inbox.ack').sideEffect).toBe('write');
     expect(relayCommandDefinition('context.get').sideEffect).toBe('read');
     expect(relayCommandDefinition('inbox.list').sideEffect).toBe('read');
@@ -729,6 +850,8 @@ describe('CLI gateway contract', () => {
     // context/inbox bits, not rpc:fs:write / pty:exec:arbitrary.
     for (const verb of [
       'context.create',
+      'context.pin',
+      'context.unpin',
       'inbox.send',
       'inbox.ack',
       'inbox.resolve',
@@ -740,7 +863,12 @@ describe('CLI gateway contract', () => {
   });
 
   it('places context/inbox capability bits in the correct trust tier (ADR-019 D5)', () => {
-    for (const bit of ['context:read', 'context:write', 'inbox:read', 'inbox:write'] as const) {
+    for (const bit of [
+      'context:read',
+      'context:write',
+      'inbox:read',
+      'inbox:write',
+    ] as const) {
       expect(RELAY_CAPABILITY_BITS).toContain(bit);
     }
     // Reads are default-allow peers of session:read.
@@ -759,7 +887,12 @@ describe('CLI gateway contract', () => {
       createdAt: '2026-05-27T00:00:00.000Z',
       trustTier: 'prod',
     });
-    for (const bit of ['context:read', 'context:write', 'inbox:read', 'inbox:write'] as const) {
+    for (const bit of [
+      'context:read',
+      'context:write',
+      'inbox:read',
+      'inbox:write',
+    ] as const) {
       expect(resolveAclCapability(prodAcl, bit)).toMatchObject({
         known: true,
         decision: 'allow',
@@ -768,16 +901,34 @@ describe('CLI gateway contract', () => {
   });
 
   it('encodes sessions.input source exclusivity for schema-generated adapters', () => {
-    expect(schemaAcceptsSessionInput({ id: 's1', data: 'hello', waitFor: 'hello' })).toBe(true);
-    expect(schemaAcceptsSessionInput({ id: 's1', dataBase64: 'aGVsbG8=' })).toBe(true);
-    expect(schemaAcceptsSessionInput({ id: 's1', stdin: true, timeoutMs: 1000 })).toBe(true);
+    expect(
+      schemaAcceptsSessionInput({ id: 's1', data: 'hello', waitFor: 'hello' })
+    ).toBe(true);
+    expect(
+      schemaAcceptsSessionInput({ id: 's1', dataBase64: 'aGVsbG8=' })
+    ).toBe(true);
+    expect(
+      schemaAcceptsSessionInput({ id: 's1', stdin: true, timeoutMs: 1000 })
+    ).toBe(true);
 
     expect(schemaAcceptsSessionInput({ id: 's1' })).toBe(false);
-    expect(schemaAcceptsSessionInput({ id: 's1', data: 'hello', dataBase64: 'aGVsbG8=' })).toBe(
-      false
-    );
-    expect(schemaAcceptsSessionInput({ id: 's1', data: 'hello', stdin: true })).toBe(false);
-    expect(schemaAcceptsSessionInput({ id: 's1', dataBase64: 'aGVsbG8=', stdin: true })).toBe(false);
+    expect(
+      schemaAcceptsSessionInput({
+        id: 's1',
+        data: 'hello',
+        dataBase64: 'aGVsbG8=',
+      })
+    ).toBe(false);
+    expect(
+      schemaAcceptsSessionInput({ id: 's1', data: 'hello', stdin: true })
+    ).toBe(false);
+    expect(
+      schemaAcceptsSessionInput({
+        id: 's1',
+        dataBase64: 'aGVsbG8=',
+        stdin: true,
+      })
+    ).toBe(false);
     expect(schemaAcceptsSessionInput({ id: 's1', stdin: false })).toBe(false);
   });
 

--- a/test/context-inbox-router.test.ts
+++ b/test/context-inbox-router.test.ts
@@ -25,6 +25,18 @@ import {
 import { createFileResourceRef } from '../shared/file-resource-ref.js';
 import type { AnchorStateResolver } from '../server/context-adapters/file-range.js';
 import type { ResolveAnchorOutcome } from '../server/anchor-resolution.js';
+import type {
+  WorkContextStore,
+  WorkContextLifecycleEventInput,
+  WorkContextPatchInput,
+} from '../server/work-contexts.js';
+import {
+  WORK_CONTEXT_SCHEMA_VERSION,
+  createWorkContextPrivacyMetadata,
+  type AuditEventRef,
+  type WorkContext,
+  type WorkContextId,
+} from '../shared/work-context.js';
 
 // ---------------------------------------------------------------------------
 // In-memory store implementing the #765 seam (#758 builds the SQLite version).
@@ -181,6 +193,92 @@ function createFakeStore(): ContextInboxStore & { _markDelivered: boolean } {
   return store;
 }
 
+function createFakeWorkContext(id: WorkContextId): WorkContext {
+  const now = new Date().toISOString();
+  return {
+    schemaVersion: WORK_CONTEXT_SCHEMA_VERSION,
+    id,
+    title: 'Pinned context test',
+    createdAt: now,
+    updatedAt: now,
+    source: 'test',
+    anchors: {},
+    actors: [],
+    tasks: [],
+    artifacts: [],
+    auditRefs: [],
+    capabilityGrants: [],
+    privacy: createWorkContextPrivacyMetadata(),
+  };
+}
+
+function createFakeWorkContextStore(
+  ...contexts: WorkContext[]
+): WorkContextStore {
+  const byId = new Map<WorkContextId, WorkContext>(
+    contexts.map((ctx) => [ctx.id, ctx])
+  );
+  function replace(
+    id: WorkContextId,
+    patch: WorkContextPatchInput
+  ): WorkContext {
+    const existing = byId.get(id);
+    if (!existing) throw new Error(`missing WorkContext ${id}`);
+    const updated = {
+      ...existing,
+      ...patch,
+      updatedAt: new Date().toISOString(),
+    };
+    byId.set(id, updated);
+    return updated;
+  }
+  return {
+    close: () => undefined,
+    create: () => {
+      throw new Error('not implemented');
+    },
+    get: (id: WorkContextId) => byId.get(id) ?? null,
+    list: () => [...byId.values()],
+    update: replace,
+    linkContexts: () => {
+      throw new Error('not implemented');
+    },
+    associateSession: () => {
+      throw new Error('not implemented');
+    },
+    recordLifecycleEvent: (
+      id: WorkContextId,
+      input: WorkContextLifecycleEventInput
+    ) => {
+      const existing = byId.get(id);
+      if (!existing) throw new Error(`missing WorkContext ${id}`);
+      const event: AuditEventRef = {
+        id: `audit:${input.type ?? 'event'}:${existing.auditRefs.length}`,
+        eventId: input.eventId ?? `evt:${existing.auditRefs.length}`,
+        ...(input.type ? { type: input.type } : {}),
+        ...(input.actorId ? { actorId: input.actorId } : {}),
+        ...(input.occurredAt ? { occurredAt: input.occurredAt } : {}),
+        privacy: createWorkContextPrivacyMetadata(),
+      };
+      const updated = {
+        ...existing,
+        artifacts: input.artifacts
+          ? [...existing.artifacts, ...input.artifacts]
+          : existing.artifacts,
+        auditRefs: [...existing.auditRefs, event],
+        updatedAt: new Date().toISOString(),
+      };
+      byId.set(id, updated);
+      return updated;
+    },
+    getResumeSnapshot: () => {
+      throw new Error('not implemented');
+    },
+    listActiveWork: () => [],
+    findSessionWorkContextIds: () => [],
+  };
+}
+
 const ALL_CAPS = 'context:read,context:write,inbox:read,inbox:write';
 
 let server: Server;
@@ -188,7 +286,8 @@ let baseUrl: string;
 
 function mount(
   store: ContextInboxStore | null,
-  resolveAnchorState?: AnchorStateResolver
+  resolveAnchorState?: AnchorStateResolver,
+  workContextStore?: WorkContextStore
 ): Promise<void> {
   const app = express();
   app.use(express.json());
@@ -196,6 +295,7 @@ function mount(
     createContextInboxRouter({
       requireAuth: (_req, _res, next) => next(),
       store,
+      workContextStore,
       // Default to a resolver that never resolves (null) so existing tests stay
       // undecorated; the #760 decoration tests inject a real resolver.
       resolveAnchorState: resolveAnchorState ?? (async () => null),
@@ -247,7 +347,11 @@ afterEach(async () => {
 
 describe('context/inbox gateway router', () => {
   beforeEach(async () => {
-    await mount(createFakeStore());
+    await mount(
+      createFakeStore(),
+      undefined,
+      createFakeWorkContextStore(createFakeWorkContext('wc:test'))
+    );
   });
 
   it('round-trips context.create → context.get → context.list', async () => {
@@ -269,6 +373,81 @@ describe('context/inbox gateway router', () => {
     const listed = await req('GET', '/context', { caps: 'context:read' });
     expect(listed.status).toBe(200);
     expect(listed.body.contextPackets).toHaveLength(1);
+  });
+
+  it('pins packets into a WorkContext, lists pinned packets by scope, and unpins without deleting the packet', async () => {
+    const created = await req('POST', '/context', {
+      caps: 'context:write',
+      body: {
+        kind: 'note',
+        note: 'review this during handoff',
+        createdBy: 'agent_1',
+        binding: { nodeId: 'node1', workspaceId: 'workspace-a' },
+      },
+    });
+    expect(created.status).toBe(201);
+    const id = created.body.contextPacket.id as string;
+
+    const pinned = await req('POST', `/context/${encodeURIComponent(id)}/pin`, {
+      caps: 'context:write',
+      body: { workContextId: 'wc:test', actorId: 'agent_1' },
+    });
+    expect(pinned.status).toBe(201);
+    expect(pinned.body.contextPacket.id).toBe(id);
+    expect(pinned.body.alreadyPinned).toBe(false);
+    expect(pinned.body.pinnedContextPackets).toHaveLength(1);
+    expect(pinned.body.pinnedArtifacts[0].uri).toBe(
+      `relay://context-packets/${encodeURIComponent(id)}`
+    );
+    expect(pinned.body.workContext.auditRefs[0].type).toBe('artifact.recorded');
+
+    const idempotent = await req(
+      'POST',
+      `/context/${encodeURIComponent(id)}/pin`,
+      {
+        caps: 'context:write',
+        body: { workContextId: 'wc:test', actorId: 'agent_1' },
+      }
+    );
+    expect(idempotent.status).toBe(200);
+    expect(idempotent.body.alreadyPinned).toBe(true);
+    expect(idempotent.body.pinnedContextPackets).toHaveLength(1);
+
+    const listed = await req(
+      'GET',
+      '/context?workContextId=wc%3Atest&nodeId=node1',
+      { caps: 'context:read' }
+    );
+    expect(listed.status).toBe(200);
+    expect(listed.body.contextPackets).toHaveLength(1);
+    expect(listed.body.contextPackets[0].id).toBe(id);
+    expect(listed.body.pinnedArtifacts).toHaveLength(1);
+
+    const unpinned = await req(
+      'POST',
+      `/context/${encodeURIComponent(id)}/unpin`,
+      {
+        caps: 'context:write',
+        body: { workContextId: 'wc:test', actorId: 'agent_1' },
+      }
+    );
+    expect(unpinned.status).toBe(200);
+    expect(unpinned.body.removed).toBe(true);
+    expect(unpinned.body.lifecycle.packetDeleted).toBe(false);
+    expect(unpinned.body.workContext.auditRefs.at(-1).type).toBe(
+      'artifact.unpinned'
+    );
+
+    const listedAfter = await req('GET', '/context?workContextId=wc%3Atest', {
+      caps: 'context:read',
+    });
+    expect(listedAfter.status).toBe(200);
+    expect(listedAfter.body.contextPackets).toHaveLength(0);
+    const retained = await req('GET', `/context/${encodeURIComponent(id)}`, {
+      caps: 'context:read',
+    });
+    expect(retained.status).toBe(200);
+    expect(retained.body.contextPacket.id).toBe(id);
   });
 
   it('inbox.send queues; inbox.list PULL-delivers (queued → delivered)', async () => {

--- a/test/relayctl-preturn.test.ts
+++ b/test/relayctl-preturn.test.ts
@@ -18,6 +18,13 @@ import type { Server } from 'node:http';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import type { WorkContextStore } from '../server/work-contexts.js';
+import {
+  WORK_CONTEXT_SCHEMA_VERSION,
+  createWorkContextPrivacyMetadata,
+  type ArtifactRef,
+  type WorkContext,
+} from '../shared/work-context.js';
 import {
   createContextInboxRouter,
   type ContextInboxStore,
@@ -40,7 +47,97 @@ const RELAYCTL_BIN = fileURLToPath(
   new URL('../dist/bin/relayctl.js', import.meta.url)
 );
 
-const TERMINAL = new Set<SessionInboxMessageState>(TERMINAL_INBOX_MESSAGE_STATES);
+const TERMINAL = new Set<SessionInboxMessageState>(
+  TERMINAL_INBOX_MESSAGE_STATES
+);
+
+const WORK_CONTEXT_ID = 'wc:preturn:test';
+
+function testPrivacy() {
+  return createWorkContextPrivacyMetadata({
+    classification: 'internal',
+    retention: 'project',
+    rawPayloadStored: false,
+  });
+}
+
+function createFakeWorkContext(
+  id: string,
+  artifacts: ArtifactRef[] = []
+): WorkContext {
+  const now = new Date().toISOString();
+  return {
+    schemaVersion: WORK_CONTEXT_SCHEMA_VERSION,
+    id,
+    title: id,
+    source: 'test',
+    createdAt: now,
+    updatedAt: now,
+    anchors: {},
+    actors: [],
+    tasks: [],
+    artifacts,
+    auditRefs: [],
+    capabilityGrants: [],
+    privacy: testPrivacy(),
+  };
+}
+
+function createPinnedPacketArtifact(packetId: string): ArtifactRef {
+  return {
+    id: `artifact:context-packet:${packetId}`,
+    kind: 'external',
+    title: `Pinned context packet ${packetId}`,
+    uri: `relay://context-packets/${encodeURIComponent(packetId)}`,
+    privacy: testPrivacy(),
+  };
+}
+
+function createFakeWorkContextStore(initial: WorkContext[]): WorkContextStore {
+  const contexts = new Map(initial.map((context) => [context.id, context]));
+  const required = () => {
+    throw new Error('not implemented for relayctl preturn test');
+  };
+  return {
+    close: () => {},
+    create: (input = {}) => {
+      const context =
+        input.context ??
+        createFakeWorkContext(input.id ?? `wc:${contexts.size}`);
+      contexts.set(context.id, context);
+      return context;
+    },
+    get: (id) => contexts.get(id) ?? null,
+    list: () => [...contexts.values()],
+    update: (id, patchInput) => {
+      const existing = contexts.get(id);
+      if (!existing) throw new Error('WorkContext not found');
+      const updated = {
+        ...existing,
+        ...patchInput,
+        updatedAt: new Date().toISOString(),
+      };
+      contexts.set(id, updated);
+      return updated;
+    },
+    linkContexts: required,
+    associateSession: required,
+    recordLifecycleEvent: (id, input) => {
+      const existing = contexts.get(id);
+      if (!existing) throw new Error('WorkContext not found');
+      const updated = {
+        ...existing,
+        artifacts: [...existing.artifacts, ...(input.artifacts ?? [])],
+        updatedAt: new Date().toISOString(),
+      };
+      contexts.set(id, updated);
+      return updated;
+    },
+    getResumeSnapshot: required,
+    listActiveWork: required,
+    findSessionWorkContextIds: () => [],
+  };
+}
 
 // In-memory store implementing the #765 seam with the SAME PULL-delivery side
 // effect (list/get flip queued → delivered) so the headless flip is observable.
@@ -94,7 +191,9 @@ function createFakeStore(): ContextInboxStore & {
       const id = createInboxMessageId(`pre${messageSeq++}`);
       const message: SessionInboxMessage = {
         id,
-        ...(input.targetSessionId ? { targetSessionId: input.targetSessionId } : {}),
+        ...(input.targetSessionId
+          ? { targetSessionId: input.targetSessionId }
+          : {}),
         ...(input.targetWorkContextId
           ? { targetWorkContextId: input.targetWorkContextId }
           : {}),
@@ -166,9 +265,13 @@ function runPreturn(
 let server: Server;
 let baseUrl: string;
 let store: ReturnType<typeof createFakeStore>;
+let workContextStore: WorkContextStore;
 
 beforeEach(async () => {
   store = createFakeStore();
+  workContextStore = createFakeWorkContextStore([
+    createFakeWorkContext(WORK_CONTEXT_ID),
+  ]);
   const app = express();
   app.use(express.json());
   app.use(
@@ -177,6 +280,7 @@ beforeEach(async () => {
       // router itself only enforces the capability header, which relayctl sends.
       requireAuth: (_req, _res, next) => next(),
       store,
+      workContextStore,
     })
   );
   await new Promise<void>((resolve) => {
@@ -227,7 +331,9 @@ describe('relayctl agent preturn', () => {
     expect(stdout).toContain('please look at this before your next turn');
     expect(stdout).toContain('check the failing assertion in foo.test.ts');
     // PULL semantics: fetching delivered the message.
-    expect(store.raw().find((m) => m.id === messageId)?.state).toBe('delivered');
+    expect(store.raw().find((m) => m.id === messageId)?.state).toBe(
+      'delivered'
+    );
   });
 
   it('does not ack/resolve — only delivers (rendering != resolution)', async () => {
@@ -255,13 +361,78 @@ describe('relayctl agent preturn', () => {
     const parsed = JSON.parse(stdout) as {
       sessionId: string;
       pendingCount: number;
+      pinnedContextCount: number;
       messages: Array<{ state: string }>;
       contextPackets: Array<{ kind: string }>;
+      pinnedContextPackets: Array<{ kind: string }>;
     };
     expect(parsed.sessionId).toBe(SESSION_ID);
     expect(parsed.pendingCount).toBe(1);
+    expect(parsed.pinnedContextCount).toBe(0);
     expect(parsed.messages[0]?.state).toBe('delivered');
     expect(parsed.contextPackets[0]?.kind).toBe('note');
+    expect(parsed.pinnedContextPackets).toEqual([]);
+  });
+
+  it('renders WorkContext-pinned packets in preturn markdown even with no inbox message', async () => {
+    const packet = store.createPacket({
+      kind: 'note',
+      note: 'review the durable WorkContext pin before answering',
+      createdBy: 'reviewer_1',
+    });
+    workContextStore.update(WORK_CONTEXT_ID, {
+      artifacts: [createPinnedPacketArtifact(packet.id)],
+    });
+
+    const { code, stdout } = await runPreturn([], {
+      ...process.env,
+      RELAY_HUB_URL: baseUrl,
+      RELAY_SESSION_ID: SESSION_ID,
+      RELAY_WORK_CONTEXT_ID: WORK_CONTEXT_ID,
+    });
+
+    expect(code).toBe(0);
+    expect(stdout).toContain('No pending inbox messages.');
+    expect(stdout).toContain('Pinned WorkContext context');
+    expect(stdout).toContain(WORK_CONTEXT_ID);
+    expect(stdout).toContain(
+      'review the durable WorkContext pin before answering'
+    );
+  });
+
+  it('includes WorkContext-pinned packets in preturn json', async () => {
+    const packet = store.createPacket({
+      kind: 'note',
+      note: 'json pinned packet',
+      createdBy: 'reviewer_1',
+    });
+    workContextStore.update(WORK_CONTEXT_ID, {
+      artifacts: [createPinnedPacketArtifact(packet.id)],
+    });
+
+    const { code, stdout } = await runPreturn(['--format', 'json'], {
+      ...process.env,
+      RELAY_HUB_URL: baseUrl,
+      RELAY_SESSION_ID: SESSION_ID,
+      RELAY_WORK_CONTEXT_ID: WORK_CONTEXT_ID,
+    });
+
+    expect(code).toBe(0);
+    const parsed = JSON.parse(stdout) as {
+      workContextId?: string;
+      pendingCount: number;
+      pinnedContextCount: number;
+      pinnedContextPackets: Array<{ id: string; note?: string }>;
+      contextPackets: Array<{ id: string }>;
+    };
+    expect(parsed.workContextId).toBe(WORK_CONTEXT_ID);
+    expect(parsed.pendingCount).toBe(0);
+    expect(parsed.pinnedContextCount).toBe(1);
+    expect(parsed.pinnedContextPackets[0]?.id).toBe(packet.id);
+    expect(parsed.pinnedContextPackets[0]?.note).toBe('json pinned packet');
+    expect(
+      parsed.contextPackets.some((candidate) => candidate.id === packet.id)
+    ).toBe(true);
   });
 
   it('honours --session override outside the env-injected session', async () => {
@@ -272,7 +443,9 @@ describe('relayctl agent preturn', () => {
     const { code, stdout } = await runPreturn(['--session', SESSION_ID], env);
     expect(code).toBe(0);
     expect(stdout).toContain(SESSION_ID);
-    expect(store.raw().find((m) => m.id === messageId)?.state).toBe('delivered');
+    expect(store.raw().find((m) => m.id === messageId)?.state).toBe(
+      'delivered'
+    );
   });
 
   it('renders an empty-inbox message when nothing is pending', async () => {


### PR DESCRIPTION
Closes #763

## Summary
- add context packet pin/unpin gateway routes backed by WorkContext artifacts and lifecycle audit events
- expose WorkContext-scoped context packet listing via existing `/context?workContextId=...` path
- wire the production context-inbox router to the WorkContext store and cover pin/list/unpin retention behavior in router tests

## Verification
- npm test -- --run test/context-inbox-router.test.ts test/work-context-store.test.ts test/work-context.test.ts
- npm run check
- git push changed-test hook: 67/67 passed (emitted existing sessions-create-validation stderr about .worktrees/package.json, suite still passed)

Note: local Node 24 helper path from the skill was missing on this devbox; commands ran with the available node v22.22.3 and passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pin context packets to work contexts and surface pinned items in listings and preturn outputs.
  * CLI: add `context pin` / `context unpin` commands and support pin/unpin via gateway.

* **Improvements**
  * Better context/inbox filtering by work-context scope and clearer validation/error detail in responses.
  * Enhanced lifecycle handling so pinned artifacts are reflected correctly in reads.

* **Documentation**
  * Updated CLI gateway docs and examples to document new context verbs.

* **Tests**
  * Expanded tests and E2E coverage for pinning, listing, rendering, and error shapes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/794?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->