### PR TITLE
Add context inbox feedback UI

### DIFF
--- a/frontend/dev-server.ts
+++ b/frontend/dev-server.ts
@@ -9,6 +9,8 @@ const DEFAULT_DEV_BACKEND_TARGET = `http://127.0.0.1:${DEV_BACKEND_PORT}`;
 export const backendProxyPaths = [
   '/auth',
   '/sessions',
+  '/context',
+  '/inbox',
   '/repos',
   '/branches',
   '/worktrees',
@@ -43,9 +45,7 @@ type DevEnv = Record<string, string | undefined>;
 function parsePort(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
   const port = Number(value);
-  return Number.isInteger(port) && port > 0 && port <= 65_535
-    ? port
-    : fallback;
+  return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : fallback;
 }
 
 export function buildBackendProxyTarget(env: DevEnv = process.env): string {

--- a/frontend/src/components/FileFeedbackPanel.css
+++ b/frontend/src/components/FileFeedbackPanel.css
@@ -1,0 +1,173 @@
+.file-feedback {
+  border-bottom: 1px solid var(--border, #333);
+  background: var(--bg, #000);
+  padding: 8px 12px;
+  display: grid;
+  gap: 8px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: var(--font-size-xs, 0.75rem);
+  color: var(--text, #e0e0e0);
+}
+
+.file-feedback__head,
+.file-feedback__form,
+.file-feedback__meta,
+.file-feedback__message,
+.file-feedback__message-main,
+.file-feedback__message-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.file-feedback__head {
+  justify-content: space-between;
+}
+
+.file-feedback__eyebrow {
+  color: var(--accent, #d97757);
+  font-size: var(--font-size-xs, 0.75rem);
+}
+
+.file-feedback__copy,
+.file-feedback__empty {
+  color: var(--text-muted, #888);
+}
+
+.file-feedback__form {
+  flex-wrap: wrap;
+}
+
+.file-feedback label {
+  display: grid;
+  gap: 3px;
+  color: var(--text-muted, #888);
+}
+
+.file-feedback select,
+.file-feedback input,
+.file-feedback textarea {
+  background: transparent;
+  color: var(--text, #e0e0e0);
+  border: 1px solid var(--border, #333);
+  border-radius: 0;
+  font: inherit;
+  padding: 5px 7px;
+}
+
+.file-feedback select:focus,
+.file-feedback input:focus,
+.file-feedback textarea:focus {
+  outline: 1px solid var(--accent, #d97757);
+  outline-offset: 0;
+}
+
+.file-feedback input {
+  width: 72px;
+}
+
+.file-feedback__note {
+  flex: 1 1 260px;
+}
+
+.file-feedback__note textarea {
+  min-width: 220px;
+  resize: vertical;
+}
+
+.file-feedback__meta {
+  min-height: 20px;
+  flex-wrap: wrap;
+  color: var(--text-muted, #888);
+}
+
+.file-feedback__error {
+  color: var(--status-error, #f87171);
+}
+
+.file-feedback__messages {
+  display: grid;
+  gap: 4px;
+}
+
+.file-feedback__message {
+  justify-content: space-between;
+  border: 1px solid color-mix(in srgb, var(--border, #333) 70%, transparent);
+  padding: 5px 7px;
+  min-height: 32px;
+}
+
+.file-feedback__message-main {
+  min-width: 0;
+  flex: 1;
+}
+
+.file-feedback__message-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted, #888);
+}
+
+.file-feedback__state,
+.file-feedback__anchor {
+  border: 1px solid currentColor;
+  padding: 1px 5px;
+  flex: 0 0 auto;
+}
+
+.file-feedback__state--queued {
+  color: var(--status-warning, #fbbf24);
+}
+
+.file-feedback__state--delivered,
+.file-feedback__state--acknowledged {
+  color: var(--status-info, #60a5fa);
+}
+
+.file-feedback__state--resolved {
+  color: var(--status-success, #4ade80);
+}
+
+.file-feedback__state--ignored {
+  color: var(--text-muted, #888);
+}
+
+.file-feedback__anchor--unchanged {
+  color: var(--status-success, #4ade80);
+}
+
+.file-feedback__anchor--stale {
+  color: var(--status-warning, #fbbf24);
+}
+
+.file-feedback__anchor--missing {
+  color: var(--status-error, #f87171);
+}
+
+.file-feedback__message-actions button {
+  border: 1px solid var(--border, #333);
+  background: transparent;
+  color: var(--text-muted, #888);
+  border-radius: 0;
+  font: inherit;
+  padding: 2px 6px;
+}
+
+.file-feedback__message-actions button:hover,
+.file-feedback__message-actions button:focus-visible {
+  color: var(--text, #e0e0e0);
+  border-color: var(--accent, #d97757);
+}
+
+@media (max-width: 720px) {
+  .file-feedback__head,
+  .file-feedback__message {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .file-feedback__message-actions {
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/components/FileFeedbackPanel.tsx
+++ b/frontend/src/components/FileFeedbackPanel.tsx
@@ -12,6 +12,10 @@ import {
   updateInboxMessageState,
   type DecoratedInboxMessage,
 } from '../lib/api.js';
+import {
+  initialFeedbackTarget,
+  resolveFeedbackTarget,
+} from '../lib/feedback-target.js';
 import { scopedSessionKey } from '../lib/session-keys.js';
 import TuiButton from './TuiButton.js';
 import './FileFeedbackPanel.css';
@@ -44,19 +48,6 @@ const STATE_LABELS: Record<SessionInboxMessageState, string> = {
 function absoluteFilePath(workspacePath: string, filePath: string): string {
   if (filePath.startsWith('/')) return filePath;
   return `${workspacePath.replace(/\/+$/u, '')}/${filePath.replace(/^\/+/, '')}`;
-}
-
-function initialTarget(
-  sessions: SessionSummary[],
-  preferredTargetSessionId: string | null
-): string {
-  if (preferredTargetSessionId) return preferredTargetSessionId;
-  const firstAgent = sessions.find((session) => session.type === 'agent');
-  return firstAgent
-    ? scopedSessionKey(firstAgent)
-    : sessions[0]
-      ? scopedSessionKey(sessions[0])
-      : '';
 }
 
 function quoteForRange(
@@ -104,7 +95,7 @@ export function FileFeedbackPanel({
   const [endLine, setEndLine] = useState('1');
   const [note, setNote] = useState('');
   const [targetSessionId, setTargetSessionId] = useState(() =>
-    initialTarget(sessions, preferredTargetSessionId)
+    initialFeedbackTarget(sessions, preferredTargetSessionId)
   );
   const [sendState, setSendState] = useState<SendState>({ kind: 'idle' });
   const [inboxLoading, setInboxLoading] = useState(false);
@@ -118,9 +109,14 @@ export function FileFeedbackPanel({
   const isMarkdown = language === 'markdown' || /\.mdx?$/iu.test(filePath);
 
   useEffect(() => {
-    if (targetSessionId) return;
-    setTargetSessionId(initialTarget(sessions, preferredTargetSessionId));
-  }, [preferredTargetSessionId, sessions, targetSessionId]);
+    setTargetSessionId((currentTargetSessionId) =>
+      resolveFeedbackTarget(
+        sessions,
+        preferredTargetSessionId,
+        currentTargetSessionId
+      )
+    );
+  }, [preferredTargetSessionId, sessions]);
 
   useEffect(() => {
     if (selectedLine === null) return;

--- a/frontend/src/components/FileFeedbackPanel.tsx
+++ b/frontend/src/components/FileFeedbackPanel.tsx
@@ -1,0 +1,366 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { DEFAULT_LOCAL_NODE_ID } from '../../../shared/identity.js';
+import type {
+  ContextPacket,
+  SessionInboxMessageState,
+} from '../../../shared/context-packet.js';
+import type { SessionSummary } from '../lib/types.js';
+import {
+  createContextPacket,
+  fetchInboxMessages,
+  sendInboxMessage,
+  updateInboxMessageState,
+  type DecoratedInboxMessage,
+} from '../lib/api.js';
+import { scopedSessionKey } from '../lib/session-keys.js';
+import TuiButton from './TuiButton.js';
+import './FileFeedbackPanel.css';
+
+interface FileFeedbackPanelProps {
+  filePath: string;
+  workspacePath: string;
+  content: string;
+  language: string;
+  sessions: SessionSummary[];
+  preferredTargetSessionId: string | null;
+  selectedLine: number | null;
+  onSelectedLineConsumed: () => void;
+}
+
+type SendState =
+  | { kind: 'idle' }
+  | { kind: 'sending' }
+  | { kind: 'sent'; packet: ContextPacket; message: DecoratedInboxMessage }
+  | { kind: 'error'; message: string };
+
+const STATE_LABELS: Record<SessionInboxMessageState, string> = {
+  queued: 'queued',
+  delivered: 'delivered',
+  acknowledged: 'acknowledged',
+  resolved: 'resolved',
+  ignored: 'ignored',
+};
+
+function absoluteFilePath(workspacePath: string, filePath: string): string {
+  if (filePath.startsWith('/')) return filePath;
+  return `${workspacePath.replace(/\/+$/u, '')}/${filePath.replace(/^\/+/, '')}`;
+}
+
+function initialTarget(
+  sessions: SessionSummary[],
+  preferredTargetSessionId: string | null
+): string {
+  if (preferredTargetSessionId) return preferredTargetSessionId;
+  const firstAgent = sessions.find((session) => session.type === 'agent');
+  return firstAgent
+    ? scopedSessionKey(firstAgent)
+    : sessions[0]
+      ? scopedSessionKey(sessions[0])
+      : '';
+}
+
+function quoteForRange(
+  content: string,
+  startLine: number,
+  endLine: number
+): string {
+  const lines = content.split('\n');
+  return lines.slice(startLine - 1, endLine).join('\n');
+}
+
+function messageError(err: unknown): string {
+  return err instanceof Error ? err.message : 'unknown error';
+}
+
+function stateClass(state: SessionInboxMessageState): string {
+  return `file-feedback__state file-feedback__state--${state}`;
+}
+
+export function FileFeedbackPanel({
+  filePath,
+  workspacePath,
+  content,
+  language,
+  sessions,
+  preferredTargetSessionId,
+  selectedLine,
+  onSelectedLineConsumed,
+}: FileFeedbackPanelProps) {
+  const [startLine, setStartLine] = useState('1');
+  const [endLine, setEndLine] = useState('1');
+  const [note, setNote] = useState('');
+  const [targetSessionId, setTargetSessionId] = useState(() =>
+    initialTarget(sessions, preferredTargetSessionId)
+  );
+  const [sendState, setSendState] = useState<SendState>({ kind: 'idle' });
+  const [inboxLoading, setInboxLoading] = useState(false);
+  const [inboxError, setInboxError] = useState<string | null>(null);
+  const [messages, setMessages] = useState<DecoratedInboxMessage[]>([]);
+
+  const totalLines = useMemo(
+    () => Math.max(content.split('\n').length, 1),
+    [content]
+  );
+  const isMarkdown = language === 'markdown' || /\.mdx?$/iu.test(filePath);
+
+  useEffect(() => {
+    if (targetSessionId) return;
+    setTargetSessionId(initialTarget(sessions, preferredTargetSessionId));
+  }, [preferredTargetSessionId, sessions, targetSessionId]);
+
+  useEffect(() => {
+    if (selectedLine === null) return;
+    const line = String(Math.min(Math.max(selectedLine, 1), totalLines));
+    setStartLine(line);
+    setEndLine(line);
+    onSelectedLineConsumed();
+  }, [onSelectedLineConsumed, selectedLine, totalLines]);
+
+  const range = useMemo(() => {
+    const start = Number.parseInt(startLine, 10);
+    const end = Number.parseInt(endLine, 10);
+    if (!Number.isInteger(start) || !Number.isInteger(end)) return null;
+    if (start < 1 || end < start || end > totalLines) return null;
+    return { startLine: start, endLine: end };
+  }, [endLine, startLine, totalLines]);
+
+  const refreshInbox = useCallback(async () => {
+    if (!targetSessionId) return;
+    setInboxLoading(true);
+    setInboxError(null);
+    try {
+      setMessages(await fetchInboxMessages(targetSessionId, 8));
+    } catch (err) {
+      setInboxError(messageError(err));
+    } finally {
+      setInboxLoading(false);
+    }
+  }, [targetSessionId]);
+
+  useEffect(() => {
+    void refreshInbox();
+  }, [refreshInbox]);
+
+  const handleSend = useCallback(async () => {
+    if (!range || !targetSessionId) return;
+    setSendState({ kind: 'sending' });
+    try {
+      const trimmedNote = note.trim();
+      const packet = await createContextPacket({
+        kind: 'file-anchor',
+        anchor: {
+          ref: {
+            nodeId: DEFAULT_LOCAL_NODE_ID,
+            path: absoluteFilePath(workspacePath, filePath),
+            capturedAt: new Date().toISOString(),
+            intent: 'read',
+            repoBinding: {
+              repoPath: workspacePath,
+              worktreePath: workspacePath,
+            },
+          },
+          lineRange: range,
+          quote: quoteForRange(content, range.startLine, range.endLine),
+        },
+        ...(trimmedNote ? { note: trimmedNote } : {}),
+        binding: { nodeId: DEFAULT_LOCAL_NODE_ID },
+        createdBy: 'relay-web',
+      });
+      const message = await sendInboxMessage({
+        targetSessionId,
+        contextPacketIds: [packet.id],
+        text:
+          trimmedNote || `${filePath}#L${range.startLine}-L${range.endLine}`,
+        createdBy: 'relay-web',
+      });
+      setSendState({ kind: 'sent', packet, message });
+      setMessages((prev) =>
+        [message, ...prev.filter((m) => m.id !== message.id)].slice(0, 8)
+      );
+    } catch (err) {
+      setSendState({ kind: 'error', message: messageError(err) });
+    }
+  }, [content, filePath, note, range, targetSessionId, workspacePath]);
+
+  const transitionMessage = useCallback(
+    async (id: string, action: 'ack' | 'resolve' | 'ignore') => {
+      try {
+        const updated = await updateInboxMessageState(id, action);
+        setMessages((prev) =>
+          prev.map((m) => (m.id === id ? { ...m, ...updated } : m))
+        );
+        setSendState((prev) =>
+          prev.kind === 'sent' && prev.message.id === id
+            ? { ...prev, message: { ...prev.message, ...updated } }
+            : prev
+        );
+      } catch (err) {
+        setInboxError(messageError(err));
+      }
+    },
+    []
+  );
+
+  const canSend = Boolean(
+    range && targetSessionId && sendState.kind !== 'sending'
+  );
+
+  return (
+    <section className="file-feedback" aria-label="file feedback">
+      <div className="file-feedback__head">
+        <div>
+          <div className="file-feedback__eyebrow">
+            {isMarkdown ? 'markdown source feedback' : 'file feedback'}
+          </div>
+          <div className="file-feedback__copy">
+            create a context packet, then queue it through the session inbox
+          </div>
+        </div>
+        <TuiButton
+          variant="ghost"
+          size="sm"
+          onClick={refreshInbox}
+          disabled={!targetSessionId || inboxLoading}
+        >
+          {inboxLoading ? 'refreshing' : 'refresh state'}
+        </TuiButton>
+      </div>
+
+      <div className="file-feedback__form">
+        <label>
+          target
+          <select
+            value={targetSessionId}
+            onChange={(event) => setTargetSessionId(event.target.value)}
+            disabled={sessions.length === 0}
+          >
+            {sessions.length === 0 ? (
+              <option value="">no live sessions</option>
+            ) : (
+              sessions.map((session) => (
+                <option
+                  key={scopedSessionKey(session)}
+                  value={scopedSessionKey(session)}
+                >
+                  {session.displayName || session.id} ·{' '}
+                  {session.agent || session.type}
+                </option>
+              ))
+            )}
+          </select>
+        </label>
+        <label>
+          start
+          <input
+            type="number"
+            min={1}
+            max={totalLines}
+            value={startLine}
+            onChange={(event) => setStartLine(event.target.value)}
+          />
+        </label>
+        <label>
+          end
+          <input
+            type="number"
+            min={1}
+            max={totalLines}
+            value={endLine}
+            onChange={(event) => setEndLine(event.target.value)}
+          />
+        </label>
+        <label className="file-feedback__note">
+          note
+          <textarea
+            value={note}
+            onChange={(event) => setNote(event.target.value)}
+            placeholder="what should the agent review here?"
+            rows={2}
+          />
+        </label>
+        <TuiButton
+          variant="primary"
+          size="sm"
+          onClick={handleSend}
+          disabled={!canSend}
+        >
+          {sendState.kind === 'sending' ? 'sending' : 'send feedback'}
+        </TuiButton>
+      </div>
+
+      <div className="file-feedback__meta" aria-live="polite">
+        {range ? (
+          <span>
+            selected {filePath}#L{range.startLine}
+            {range.endLine === range.startLine ? '' : `-L${range.endLine}`}
+          </span>
+        ) : (
+          <span className="file-feedback__error">
+            range must be within 1-{totalLines}
+          </span>
+        )}
+        {sendState.kind === 'sent' && (
+          <span className={stateClass(sendState.message.state)}>
+            {STATE_LABELS[sendState.message.state]}
+          </span>
+        )}
+        {sendState.kind === 'error' && (
+          <span className="file-feedback__error">{sendState.message}</span>
+        )}
+        {inboxError && (
+          <span className="file-feedback__error">{inboxError}</span>
+        )}
+      </div>
+
+      <div className="file-feedback__messages">
+        {messages.length === 0 ? (
+          <div className="file-feedback__empty">
+            no inbox feedback loaded for this target
+          </div>
+        ) : (
+          messages.map((message) => {
+            const anchorState = message.contextPackets?.find(
+              (packet) => packet.anchorState
+            )?.anchorState;
+            return (
+              <div key={message.id} className="file-feedback__message">
+                <div className="file-feedback__message-main">
+                  <span className={stateClass(message.state)}>
+                    {STATE_LABELS[message.state]}
+                  </span>
+                  {anchorState && (
+                    <span
+                      className={`file-feedback__anchor file-feedback__anchor--${anchorState}`}
+                    >
+                      {anchorState}
+                    </span>
+                  )}
+                  <span className="file-feedback__message-text">
+                    {message.text || message.id}
+                  </span>
+                </div>
+                <div className="file-feedback__message-actions">
+                  <button onClick={() => transitionMessage(message.id, 'ack')}>
+                    ack
+                  </button>
+                  <button
+                    onClick={() => transitionMessage(message.id, 'resolve')}
+                  >
+                    resolve
+                  </button>
+                  <button
+                    onClick={() => transitionMessage(message.id, 'ignore')}
+                  >
+                    ignore
+                  </button>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default FileFeedbackPanel;

--- a/frontend/src/components/FileFeedbackPanel.tsx
+++ b/frontend/src/components/FileFeedbackPanel.tsx
@@ -107,6 +107,16 @@ export function FileFeedbackPanel({
     [content]
   );
   const isMarkdown = language === 'markdown' || /\.mdx?$/iu.test(filePath);
+  const liveTargetSessionId = useMemo(
+    () =>
+      resolveFeedbackTarget(
+        sessions,
+        preferredTargetSessionId,
+        targetSessionId
+      ),
+    [preferredTargetSessionId, sessions, targetSessionId]
+  );
+  const hasLiveTarget = liveTargetSessionId !== '';
 
   useEffect(() => {
     setTargetSessionId((currentTargetSessionId) =>
@@ -135,24 +145,24 @@ export function FileFeedbackPanel({
   }, [endLine, startLine, totalLines]);
 
   const refreshInbox = useCallback(async () => {
-    if (!targetSessionId) return;
+    if (!liveTargetSessionId) return;
     setInboxLoading(true);
     setInboxError(null);
     try {
-      setMessages(await previewInboxMessages(targetSessionId, 8));
+      setMessages(await previewInboxMessages(liveTargetSessionId, 8));
     } catch (err) {
       setInboxError(messageError(err));
     } finally {
       setInboxLoading(false);
     }
-  }, [targetSessionId]);
+  }, [liveTargetSessionId]);
 
   useEffect(() => {
     void refreshInbox();
   }, [refreshInbox]);
 
   const handleSend = useCallback(async () => {
-    if (!range || !targetSessionId) return;
+    if (!range || !liveTargetSessionId) return;
     setSendState({ kind: 'sending' });
     try {
       const trimmedNote = note.trim();
@@ -180,7 +190,7 @@ export function FileFeedbackPanel({
         createdBy: 'relay-web',
       });
       const message = await sendInboxMessage({
-        targetSessionId,
+        targetSessionId: liveTargetSessionId,
         contextPacketIds: [packet.id],
         text:
           trimmedNote || `${filePath}#L${range.startLine}-L${range.endLine}`,
@@ -193,7 +203,7 @@ export function FileFeedbackPanel({
     } catch (err) {
       setSendState({ kind: 'error', message: messageError(err) });
     }
-  }, [content, filePath, note, range, targetSessionId, workspacePath]);
+  }, [content, filePath, liveTargetSessionId, note, range, workspacePath]);
 
   const transitionMessage = useCallback(
     async (id: string, action: 'ack' | 'resolve' | 'ignore') => {
@@ -215,7 +225,7 @@ export function FileFeedbackPanel({
   );
 
   const canSend = Boolean(
-    range && targetSessionId && sendState.kind !== 'sending'
+    range && hasLiveTarget && sendState.kind !== 'sending'
   );
 
   return (
@@ -233,7 +243,7 @@ export function FileFeedbackPanel({
           variant="ghost"
           size="sm"
           onClick={refreshInbox}
-          disabled={!targetSessionId || inboxLoading}
+          disabled={!hasLiveTarget || inboxLoading}
         >
           {inboxLoading ? 'refreshing' : 'refresh state'}
         </TuiButton>
@@ -243,9 +253,9 @@ export function FileFeedbackPanel({
         <label>
           target
           <select
-            value={targetSessionId}
+            value={liveTargetSessionId}
             onChange={(event) => setTargetSessionId(event.target.value)}
-            disabled={sessions.length === 0}
+            disabled={!hasLiveTarget}
           >
             {sessions.length === 0 ? (
               <option value="">no live sessions</option>
@@ -270,6 +280,7 @@ export function FileFeedbackPanel({
             max={totalLines}
             value={startLine}
             onChange={(event) => setStartLine(event.target.value)}
+            disabled={!hasLiveTarget}
           />
         </label>
         <label>
@@ -280,6 +291,7 @@ export function FileFeedbackPanel({
             max={totalLines}
             value={endLine}
             onChange={(event) => setEndLine(event.target.value)}
+            disabled={!hasLiveTarget}
           />
         </label>
         <label className="file-feedback__note">
@@ -289,6 +301,7 @@ export function FileFeedbackPanel({
             onChange={(event) => setNote(event.target.value)}
             placeholder="what should the agent review here?"
             rows={2}
+            disabled={!hasLiveTarget}
           />
         </label>
         <TuiButton

--- a/frontend/src/components/FileFeedbackPanel.tsx
+++ b/frontend/src/components/FileFeedbackPanel.tsx
@@ -7,7 +7,7 @@ import type {
 import type { SessionSummary } from '../lib/types.js';
 import {
   createContextPacket,
-  fetchInboxMessages,
+  previewInboxMessages,
   sendInboxMessage,
   updateInboxMessageState,
   type DecoratedInboxMessage,
@@ -76,6 +76,20 @@ function stateClass(state: SessionInboxMessageState): string {
   return `file-feedback__state file-feedback__state--${state}`;
 }
 
+async function sha256Hex(content: string): Promise<string | null> {
+  const cryptoApi = globalThis.crypto;
+  if (!cryptoApi?.subtle) return null;
+  const bytes = new TextEncoder().encode(content);
+  const digest = await cryptoApi.subtle.digest('SHA-256', bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function utf8Size(content: string): number {
+  return new TextEncoder().encode(content).byteLength;
+}
+
 export function FileFeedbackPanel({
   filePath,
   workspacePath,
@@ -129,7 +143,7 @@ export function FileFeedbackPanel({
     setInboxLoading(true);
     setInboxError(null);
     try {
-      setMessages(await fetchInboxMessages(targetSessionId, 8));
+      setMessages(await previewInboxMessages(targetSessionId, 8));
     } catch (err) {
       setInboxError(messageError(err));
     } finally {
@@ -146,6 +160,7 @@ export function FileFeedbackPanel({
     setSendState({ kind: 'sending' });
     try {
       const trimmedNote = note.trim();
+      const contentSha256 = await sha256Hex(content);
       const packet = await createContextPacket({
         kind: 'file-anchor',
         anchor: {
@@ -154,6 +169,8 @@ export function FileFeedbackPanel({
             path: absoluteFilePath(workspacePath, filePath),
             capturedAt: new Date().toISOString(),
             intent: 'read',
+            size: utf8Size(content),
+            ...(contentSha256 ? { sha256: contentSha256 } : {}),
             repoBinding: {
               repoPath: workspacePath,
               worktreePath: workspacePath,

--- a/frontend/src/components/FileTabContent.tsx
+++ b/frontend/src/components/FileTabContent.tsx
@@ -168,6 +168,7 @@ export interface FileTabContentProps {
 
   hasActiveSession: boolean;
   onInjectReference?: ((reference: string) => void) | undefined;
+  onCodeLineClick?: ((line: number) => void) | undefined;
   onRetry: () => void;
   onCloseTab: () => void;
 
@@ -185,6 +186,7 @@ export interface FileTabContentProps {
 
   summary?: WorkspaceTabSummary | undefined;
   showSummary?: boolean;
+  feedbackPanel?: React.ReactNode;
 }
 
 export function FileTabContent({
@@ -203,12 +205,14 @@ export function FileTabContent({
   wordWrap,
   hasActiveSession,
   onInjectReference,
+  onCodeLineClick,
   onRetry,
   onCloseTab,
   renderDiff,
   renderCode,
   summary,
   showSummary = true,
+  feedbackPanel,
 }: FileTabContentProps) {
   const viewMode: 'html' | 'diff' | 'code' =
     tabType === 'html' ? 'html' : tabType === 'diff' ? 'diff' : 'code';
@@ -223,6 +227,19 @@ export function FileTabContent({
       }
     },
     [filePath, hasActiveSession, onInjectReference]
+  );
+
+  const handleCodeClick = useCallback(
+    (e: React.MouseEvent) => {
+      const target = e.target as HTMLElement;
+      const lineEl = target.closest('.line-number');
+      if (!lineEl) return;
+      const lineNum = parseInt(lineEl.textContent?.trim() ?? '', 10);
+      if (!Number.isNaN(lineNum) && lineNum > 0) {
+        onCodeLineClick?.(lineNum);
+      }
+    },
+    [onCodeLineClick]
   );
 
   const body = (() => {
@@ -291,6 +308,7 @@ export function FileTabContent({
         className={['raw-file', wordWrap ? 'word-wrap' : '']
           .filter(Boolean)
           .join(' ')}
+        onClick={handleCodeClick}
       >
         {renderCode ? (
           renderCode({ code, language: languageFromPath(filePath) })
@@ -304,6 +322,7 @@ export function FileTabContent({
   return (
     <div className="file-tab-content">
       {showSummary && summary && <FileTabSummaryHeader summary={summary} />}
+      {feedbackPanel}
       <div className="file-tab-content__body" role="tabpanel">
         {body}
       </div>

--- a/frontend/src/components/UtilityRailReviewPanel.tsx
+++ b/frontend/src/components/UtilityRailReviewPanel.tsx
@@ -1,23 +1,25 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { ChangedFile } from '../lib/types.js';
 import { fetchChangedFiles, fetchDefaultBranch } from '../lib/api.js';
 import { diffSourceToBase } from '../lib/diff-utils.js';
 import { generateFileSummary } from '../lib/diff-summary.js';
 import { useFileDiff } from '../hooks/useFileDiff.js';
+import { useFileContent } from '../hooks/useFileContent.js';
 import {
   useUiStore,
   type DiffSource,
   type WorkspaceReviewState,
 } from '../lib/stores/ui.js';
+import { useSessionsStore } from '../lib/stores/sessions.js';
 import DiffSourceToggle from './DiffSourceToggle.js';
 import DiffViewer from './DiffViewer.js';
-import { DiffFileSidebar, type DiffFileSidebarHandle } from './DiffFileSidebar.js';
+import {
+  DiffFileSidebar,
+  type DiffFileSidebarHandle,
+} from './DiffFileSidebar.js';
+import FileFeedbackPanel from './FileFeedbackPanel.js';
+import { languageFromPath } from './FileTabContent.js';
 import './WorkspaceUtilityRail.css';
 
 export interface UtilityRailReviewPanelProps {
@@ -90,6 +92,8 @@ export function UtilityRailReviewPanel({
   const sidebarRef = useRef<DiffFileSidebarHandle>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const diffScrollerRef = useRef<HTMLDivElement | null>(null);
+  const sessions = useSessionsStore((s) => s.sessions);
+  const preferredTargetSessionId = useSessionsStore((s) => s.activeSessionId);
 
   const review = reviewState ??
     storeReviewState ?? {
@@ -121,7 +125,13 @@ export function UtilityRailReviewPanel({
     ) {
       setReviewDefaultBranch(workspaceStateKey, branch);
     }
-  }, [defaultBranchQuery.data, review.defaultBranch, setReviewDefaultBranch, workspaceStateKey, workspacePath]);
+  }, [
+    defaultBranchQuery.data,
+    review.defaultBranch,
+    setReviewDefaultBranch,
+    workspaceStateKey,
+    workspacePath,
+  ]);
 
   const filesQuery = useQuery<ChangedFilesResponse>({
     queryKey: changedFilesQueryKey(workspacePath, base),
@@ -147,7 +157,15 @@ export function UtilityRailReviewPanel({
       return;
     }
     setReviewActiveFile(workspaceStateKey, files[0]?.path ?? null);
-  }, [activeFilePath, files, filesQuery.isError, filesQuery.isPending, setReviewActiveFile, workspaceStateKey, workspacePath]);
+  }, [
+    activeFilePath,
+    files,
+    filesQuery.isError,
+    filesQuery.isPending,
+    setReviewActiveFile,
+    workspaceStateKey,
+    workspacePath,
+  ]);
 
   const {
     diff: fileDiff,
@@ -158,6 +176,13 @@ export function UtilityRailReviewPanel({
       workspacePath,
       filePath: activeFilePath ?? '',
       base: base || null,
+    },
+    { enabled: Boolean(activeFilePath) }
+  );
+  const fileContent = useFileContent(
+    {
+      workspacePath,
+      filePath: activeFilePath ?? '',
     },
     { enabled: Boolean(activeFilePath) }
   );
@@ -241,7 +266,9 @@ export function UtilityRailReviewPanel({
         if (onRequestClose) {
           onRequestClose();
         } else {
-          useUiStore.getState().setSelectedUtilityRailTab(workspaceStateKey, null);
+          useUiStore
+            .getState()
+            .setSelectedUtilityRailTab(workspaceStateKey, null);
         }
       }
     },
@@ -315,7 +342,11 @@ export function UtilityRailReviewPanel({
           ) : filesError ? (
             <div className="utility-empty utility-error">
               {filesError}
-              <button type="button" className="utility-panel-btn" onClick={refresh}>
+              <button
+                type="button"
+                className="utility-panel-btn"
+                onClick={refresh}
+              >
                 retry
               </button>
             </div>
@@ -340,24 +371,51 @@ export function UtilityRailReviewPanel({
                     <span className="utility-muted">{summary}</span>
                   ) : null}
                   <span className="utility-muted">
-                    {fileDiffViewMode} · {sourceLabel(review.diffSource, review.defaultBranch)}
+                    {fileDiffViewMode} ·{' '}
+                    {sourceLabel(review.diffSource, review.defaultBranch)}
                   </span>
                 </span>
               </div>
               {diffError ? (
                 <div className="utility-empty utility-error">
                   {diffError}
-                  <button type="button" className="utility-panel-btn" onClick={refresh}>
+                  <button
+                    type="button"
+                    className="utility-panel-btn"
+                    onClick={refresh}
+                  >
                     retry
                   </button>
                 </div>
               ) : (
-                <DiffViewer
-                  diff={fileDiff}
-                  filePath={activeFilePath}
-                  loading={diffLoading}
-                  mode={fileDiffViewMode}
-                />
+                <>
+                  {!fileContent.loading &&
+                    !fileContent.error &&
+                    !fileContent.binary &&
+                    !fileContent.truncated && (
+                      <FileFeedbackPanel
+                        filePath={activeFilePath}
+                        workspacePath={workspacePath}
+                        content={fileContent.content}
+                        language={languageFromPath(activeFilePath)}
+                        sessions={sessions}
+                        preferredTargetSessionId={preferredTargetSessionId}
+                        selectedLine={null}
+                        onSelectedLineConsumed={() => {}}
+                      />
+                    )}
+                  {fileContent.error && (
+                    <div className="utility-empty utility-error">
+                      feedback unavailable: {fileContent.error}
+                    </div>
+                  )}
+                  <DiffViewer
+                    diff={fileDiff}
+                    filePath={activeFilePath}
+                    loading={diffLoading}
+                    mode={fileDiffViewMode}
+                  />
+                </>
               )}
             </>
           ) : filesQuery.isPending ? (
@@ -367,7 +425,10 @@ export function UtilityRailReviewPanel({
           )}
         </div>
       </div>
-      <div className="utility-review-footer" aria-label="review keyboard shortcuts">
+      <div
+        className="utility-review-footer"
+        aria-label="review keyboard shortcuts"
+      >
         <span>j/k or arrows files</span>
         <span>n/p hunks</span>
         <span>esc close pane</span>

--- a/frontend/src/components/WorkspaceArea.tsx
+++ b/frontend/src/components/WorkspaceArea.tsx
@@ -31,7 +31,12 @@ import type { SummaryContext } from '../lib/workspace-summary.js';
 import type { SessionSummary } from '../lib/types.js';
 import { resolveSessionByKey, scopedSessionKey } from '../lib/session-keys.js';
 import { resolveWorkspaceSessionCloseTarget } from '../lib/workspace-session-close.js';
-import { FileTabContent, type FileTabContentProps } from './FileTabContent.js';
+import {
+  FileTabContent,
+  languageFromPath,
+  type FileTabContentProps,
+} from './FileTabContent.js';
+import FileFeedbackPanel from './FileFeedbackPanel.js';
 import { useFileDiff, useInvalidateFileDiff } from '../hooks/useFileDiff.js';
 import { useFileContent } from '../hooks/useFileContent.js';
 import { WorkspaceLayout } from './WorkspaceLayout.js';
@@ -126,6 +131,10 @@ function FileTabContentBridge({
   const openFileTabs = useUiStore((s) => s.openFileTabs);
   const sendToTargetSessionId = useUiStore((s) => s.sendToTargetSessionId);
   const activeSessionId = useSessionsStore((s) => s.activeSessionId);
+  const sessions = useSessionsStore((s) => s.sessions);
+  const [selectedFeedbackLine, setSelectedFeedbackLine] = useState<
+    number | null
+  >(null);
   const hasActiveSession = (sendToTargetSessionId ?? activeSessionId) !== null;
 
   const base = useMemo(
@@ -180,6 +189,20 @@ function FileTabContentBridge({
     closeFileTab(tab.filePath, tab.tabType);
   }, [closeFileTab, tab.filePath, tab.tabType]);
 
+  const feedbackPanel =
+    isCodeMode && !contentLoading && !contentError && !binary && !truncated ? (
+      <FileFeedbackPanel
+        filePath={tab.filePath}
+        workspacePath={workspacePath}
+        content={content ?? ''}
+        language={languageFromPath(tab.filePath)}
+        sessions={sessions}
+        preferredTargetSessionId={sendToTargetSessionId ?? activeSessionId}
+        selectedLine={selectedFeedbackLine}
+        onSelectedLineConsumed={() => setSelectedFeedbackLine(null)}
+      />
+    ) : null;
+
   return (
     <FileTabContent
       filePath={tab.filePath}
@@ -198,10 +221,12 @@ function FileTabContentBridge({
       wordWrap={fileWordWrap}
       hasActiveSession={hasActiveSession}
       onInjectReference={onInjectReference}
+      onCodeLineClick={setSelectedFeedbackLine}
       onRetry={handleRetry}
       onCloseTab={handleCloseTab}
       renderDiff={renderDiff}
       renderCode={renderCode}
+      feedbackPanel={feedbackPanel}
       showSummary={false}
     />
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,15 @@
 import type { WorkbenchLayout } from '../../../shared/workbench-layout-types.js';
 import type {
+  AnchorRef,
+  AnchorState,
+  ContextPacket,
+  ContextPacketBinding,
+  ContextPacketKind,
+  ContextPacketId,
+  SessionInboxMessage,
+  SessionInboxMessageId,
+} from '../../../shared/context-packet.js';
+import type {
   FileRpcListRequest,
   FileRpcListResponse,
   FileRpcReadResponse,
@@ -165,6 +175,93 @@ export interface BrowseResponse {
 async function json<T>(res: Response): Promise<T> {
   if (!res.ok) throw await httpErrorFromResponse(res);
   return res.json() as Promise<T>;
+}
+
+const CONTEXT_INBOX_CAPABILITIES =
+  'context:read,context:write,inbox:read,inbox:write';
+
+function contextInboxHeaders(): HeadersInit {
+  return {
+    'Content-Type': 'application/json',
+    'x-relay-capabilities': CONTEXT_INBOX_CAPABILITIES,
+  };
+}
+
+export type DecoratedContextPacket = ContextPacket & {
+  anchorState?: AnchorState;
+};
+
+export type DecoratedInboxMessage = SessionInboxMessage & {
+  contextPackets?: DecoratedContextPacket[];
+};
+
+export interface CreateContextPacketRequest {
+  kind: ContextPacketKind;
+  anchor?: AnchorRef;
+  note?: string;
+  binding?: ContextPacketBinding;
+  createdBy?: string;
+}
+
+export async function createContextPacket(
+  input: CreateContextPacketRequest
+): Promise<ContextPacket> {
+  const data = await json<{ contextPacket: ContextPacket }>(
+    await fetch('/context', {
+      method: 'POST',
+      headers: contextInboxHeaders(),
+      body: JSON.stringify(input),
+    })
+  );
+  return data.contextPacket;
+}
+
+export interface SendInboxMessageRequest {
+  targetSessionId?: string;
+  targetWorkContextId?: string;
+  contextPacketIds: ContextPacketId[];
+  text?: string;
+  createdBy?: string;
+}
+
+export async function sendInboxMessage(
+  input: SendInboxMessageRequest
+): Promise<DecoratedInboxMessage> {
+  const data = await json<{ message: DecoratedInboxMessage }>(
+    await fetch('/inbox', {
+      method: 'POST',
+      headers: contextInboxHeaders(),
+      body: JSON.stringify(input),
+    })
+  );
+  return data.message;
+}
+
+export async function fetchInboxMessages(
+  targetSessionId: string,
+  limit = 10
+): Promise<DecoratedInboxMessage[]> {
+  const params = new URLSearchParams({ targetSessionId, limit: String(limit) });
+  const data = await json<{ messages?: DecoratedInboxMessage[] }>(
+    await fetch(`/inbox?${params.toString()}`, {
+      headers: { 'x-relay-capabilities': CONTEXT_INBOX_CAPABILITIES },
+    })
+  );
+  return Array.isArray(data.messages) ? data.messages : [];
+}
+
+export async function updateInboxMessageState(
+  id: SessionInboxMessageId,
+  action: 'ack' | 'resolve' | 'ignore'
+): Promise<DecoratedInboxMessage> {
+  const data = await json<{ message: DecoratedInboxMessage }>(
+    await fetch(`/inbox/${encodeURIComponent(id)}/${action}`, {
+      method: 'POST',
+      headers: contextInboxHeaders(),
+      body: JSON.stringify({ actorId: 'relay-web' }),
+    })
+  );
+  return data.message;
 }
 
 async function jsonOrNull<T>(res: Response): Promise<T | null> {
@@ -573,10 +670,9 @@ export async function updateIaWorkspace(
 }
 
 export async function deleteIaWorkspace(id: string): Promise<void> {
-  const res = await fetch(
-    `${IA_WORKSPACES_PATH}/${encodeURIComponent(id)}`,
-    { method: 'DELETE' }
-  );
+  const res = await fetch(`${IA_WORKSPACES_PATH}/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
   // 204 No Content on success; surface a structured error otherwise.
   if (!res.ok) {
     throw await httpErrorFromResponse(res, 'Failed to delete workspace');

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -250,6 +250,19 @@ export async function fetchInboxMessages(
   return Array.isArray(data.messages) ? data.messages : [];
 }
 
+export async function previewInboxMessages(
+  targetSessionId: string,
+  limit = 10
+): Promise<DecoratedInboxMessage[]> {
+  const params = new URLSearchParams({ targetSessionId, limit: String(limit) });
+  const data = await json<{ messages?: DecoratedInboxMessage[] }>(
+    await fetch(`/inbox/preview?${params.toString()}`, {
+      headers: { 'x-relay-capabilities': CONTEXT_INBOX_CAPABILITIES },
+    })
+  );
+  return Array.isArray(data.messages) ? data.messages : [];
+}
+
 export async function updateInboxMessageState(
   id: SessionInboxMessageId,
   action: 'ack' | 'resolve' | 'ignore'

--- a/frontend/src/lib/feedback-target.ts
+++ b/frontend/src/lib/feedback-target.ts
@@ -1,0 +1,31 @@
+import type { SessionSummary } from './types.js';
+import { resolveSessionByKey, scopedSessionKey } from './session-keys.js';
+
+export function initialFeedbackTarget(
+  sessions: SessionSummary[],
+  preferredTargetSessionId: string | null
+): string {
+  const preferredTarget = resolveSessionByKey(
+    sessions,
+    preferredTargetSessionId
+  );
+  if (preferredTarget) return scopedSessionKey(preferredTarget);
+
+  const firstAgent = sessions.find((session) => session.type === 'agent');
+  return firstAgent
+    ? scopedSessionKey(firstAgent)
+    : sessions[0]
+      ? scopedSessionKey(sessions[0])
+      : '';
+}
+
+export function resolveFeedbackTarget(
+  sessions: SessionSummary[],
+  preferredTargetSessionId: string | null,
+  currentTargetSessionId: string
+): string {
+  const currentTarget = resolveSessionByKey(sessions, currentTargetSessionId);
+  return currentTarget
+    ? scopedSessionKey(currentTarget)
+    : initialFeedbackTarget(sessions, preferredTargetSessionId);
+}

--- a/server/anchor-file-fetcher.ts
+++ b/server/anchor-file-fetcher.ts
@@ -27,7 +27,7 @@
 // `grantedCapability` so #766's caller can assert the gate fired (C1
 // enforcement). A non-`allow` decision returns `null`.
 
-import { normalizeHubFileRpcRequest } from './file-rpc.js';
+import { executeLocalFileRpc, normalizeHubFileRpcRequest } from './file-rpc.js';
 import {
   evaluateHubPolicy,
   requiredCapabilitiesForRpcIntent,
@@ -39,9 +39,7 @@ import type {
   AnchorFileFetchResult,
   AnchorFileFetchTarget,
 } from './anchor-resolution.js';
-import {
-  hashAnchorContent,
-} from './anchor-resolution.js';
+import { hashAnchorContent } from './anchor-resolution.js';
 import type {
   FileRangeContentFetcher,
   FileRangeContentResult,
@@ -53,6 +51,8 @@ import type {
 } from '../shared/file-rpc.js';
 import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
 import { RELAY_NODE_LINK_PROTOCOL_VERSION } from '../shared/relay-node-protocol.js';
+import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
+import { RELAY_SECURITY_POLICY_VERSION } from '../shared/security-policy.js';
 
 /** Minimal node registry shape the fetcher needs (subset of the hub registry). */
 export interface AnchorFetcherNodeRegistry {
@@ -81,6 +81,8 @@ export interface AnchorFileFetcherDeps {
   now?: () => Date;
 }
 
+type AnchorFetchTransport = 'local' | 'node-link';
+
 function liveNode(
   registry: AnchorFetcherNodeRegistry,
   nodeLinks: AnchorFetcherNodeLinks,
@@ -92,6 +94,77 @@ function liveNode(
   if (node.protocolVersion !== RELAY_NODE_LINK_PROTOCOL_VERSION) return null;
   if (!nodeLinks.hasActiveNode(nodeId)) return null;
   return node;
+}
+
+function localCompatibilityNode(): HubNodeSummary {
+  const now = new Date().toISOString();
+  return {
+    nodeId: DEFAULT_LOCAL_NODE_ID,
+    displayName: 'Local hub',
+    hostname: 'localhost',
+    platform: process.platform,
+    arch: process.arch,
+    relayVersion: 'local',
+    protocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+    status: 'online',
+    connection: { route: 'local', status: 'online' },
+    trust: {
+      state: 'trusted',
+      level: 'privileged-local-user',
+      tier: 'dev',
+      policy: {
+        policyVersion: RELAY_SECURITY_POLICY_VERSION,
+        ref: 'acl:local-compatibility',
+        trustTier: 'dev',
+        // Anchor resolution is read-only and still scoped to a live local
+        // session root by normalizeHubFileRpcRequest below. This node object is
+        // only for DEFAULT_LOCAL_NODE_ID; remote nodes still require a paired
+        // active reverse link.
+        allowed: ['rpc:fs:read'],
+        requiresConfirmation: [],
+        scope: { kind: 'node' },
+      },
+    },
+    credentialState: 'active',
+    version: {
+      state: 'compatible',
+      nodeProtocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+      hubProtocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,
+    },
+    capabilities: {
+      totals: { available: 0, degraded: 0, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'unknown',
+        tmux: 'unknown',
+        git: 'unknown',
+        browserAutomation: 'unknown',
+        clipboardImage: 'unknown',
+        ssh: 'unknown',
+        tailscale: 'unknown',
+      },
+      agents: {},
+      serviceManager: 'unknown',
+      wsl: false,
+    },
+    fileRpcAvailable: true,
+    degradedReasons: [],
+    createdAt: now,
+    pairedAt: now,
+    lastSeenAt: now,
+    credentialId: 'local-compatibility',
+  };
+}
+
+function resolveNodeTransport(
+  registry: AnchorFetcherNodeRegistry,
+  nodeLinks: AnchorFetcherNodeLinks,
+  nodeId: string
+): { node: HubNodeSummary; transport: AnchorFetchTransport } | null {
+  if (nodeId === DEFAULT_LOCAL_NODE_ID) {
+    return { node: localCompatibilityNode(), transport: 'local' };
+  }
+  const node = liveNode(registry, nodeLinks, nodeId);
+  return node ? { node, transport: 'node-link' } : null;
 }
 
 /**
@@ -147,14 +220,21 @@ function resolveScopedReadRequest(input: {
  * `null` (no scope / unauthorized — anchor treated as `missing` by the resolver)
  * or `{ found: false }` (authorized, node reported the path gone).
  */
-export function createAnchorFileFetcher(deps: AnchorFileFetcherDeps): AnchorFileFetcher {
+export function createAnchorFileFetcher(
+  deps: AnchorFileFetcherDeps
+): AnchorFileFetcher {
   const now = deps.now ?? (() => new Date());
 
   return async function fetchAnchorFile(
     target: AnchorFileFetchTarget
   ): Promise<AnchorFileFetchResult | null> {
-    const node = liveNode(deps.registry, deps.nodeLinks, target.nodeId);
-    if (!node) return null;
+    const nodeTransport = resolveNodeTransport(
+      deps.registry,
+      deps.nodeLinks,
+      target.nodeId
+    );
+    if (!nodeTransport) return null;
+    const { node, transport } = nodeTransport;
 
     const operation: 'read' | 'stat' = target.preferRead ? 'read' : 'stat';
     const resolved = resolveScopedReadRequest({
@@ -198,7 +278,14 @@ export function createAnchorFileFetcher(deps: AnchorFileFetcherDeps): AnchorFile
 
     let payload: unknown;
     try {
-      payload = await deps.nodeLinks.request(target.nodeId, `fs.${operation}`, fileRequest);
+      payload =
+        transport === 'local'
+          ? await executeLocalFileRpc(operation, fileRequest)
+          : await deps.nodeLinks.request(
+              target.nodeId,
+              `fs.${operation}`,
+              fileRequest
+            );
     } catch {
       // A NOT_FOUND from the node means the path is gone (authorized fetch, found
       // nothing); any other link error means we could not perform the read.
@@ -255,11 +342,15 @@ function mapPayload(
     response.encoding === 'base64'
       ? Buffer.from(response.content, 'base64')
       : Buffer.from(response.content, 'utf8');
-  const contentSha256 = response.truncatedBytes ? undefined : hashAnchorContent(buffer);
+  const contentSha256 = response.truncatedBytes
+    ? undefined
+    : hashAnchorContent(buffer);
   return {
     found: true,
     grantedCapability: ANCHOR_RESOLUTION_CAPABILITY,
-    ...(typeof response.bytesRead === 'number' ? { size: response.bytesRead } : {}),
+    ...(typeof response.bytesRead === 'number'
+      ? { size: response.bytesRead }
+      : {}),
     ...(contentSha256 !== undefined ? { contentSha256 } : {}),
   };
 }
@@ -293,14 +384,20 @@ function mapContentPayload(payload: unknown): FileRangeContentResult {
   const buffer = Buffer.from(text, 'utf8');
   // A truncated read cannot yield a trustworthy whole-file hash (mirrors the
   // staleness fetcher); omit the sha so the resolver falls back to size/mtime.
-  const contentSha256 = response.truncatedBytes ? undefined : hashAnchorContent(buffer);
+  const contentSha256 = response.truncatedBytes
+    ? undefined
+    : hashAnchorContent(buffer);
   return {
     found: true,
     grantedCapability: ANCHOR_RESOLUTION_CAPABILITY,
     content: text,
-    ...(typeof response.bytesRead === 'number' ? { bytesRead: response.bytesRead, size: response.bytesRead } : {}),
+    ...(typeof response.bytesRead === 'number'
+      ? { bytesRead: response.bytesRead, size: response.bytesRead }
+      : {}),
     ...(contentSha256 !== undefined ? { contentSha256 } : {}),
-    ...(typeof response.truncatedBytes === 'boolean' ? { truncatedBytes: response.truncatedBytes } : {}),
+    ...(typeof response.truncatedBytes === 'boolean'
+      ? { truncatedBytes: response.truncatedBytes }
+      : {}),
   };
 }
 
@@ -318,8 +415,13 @@ export function createAnchorContentFetcher(
   return async function fetchAnchorContent(
     target: FileRangeContentTarget
   ): Promise<FileRangeContentResult | null> {
-    const node = liveNode(deps.registry, deps.nodeLinks, target.nodeId);
-    if (!node) return null;
+    const nodeTransport = resolveNodeTransport(
+      deps.registry,
+      deps.nodeLinks,
+      target.nodeId
+    );
+    if (!nodeTransport) return null;
+    const { node, transport } = nodeTransport;
 
     const resolved = resolveScopedReadRequest({
       sessions: deps.sessionEnvelopes.listSummaries(),
@@ -357,7 +459,10 @@ export function createAnchorContentFetcher(
 
     let payload: unknown;
     try {
-      payload = await deps.nodeLinks.request(target.nodeId, 'fs.read', fileRequest);
+      payload =
+        transport === 'local'
+          ? await executeLocalFileRpc('read', fileRequest)
+          : await deps.nodeLinks.request(target.nodeId, 'fs.read', fileRequest);
     } catch {
       // A node error (e.g. NOT_FOUND) on an authorized read → file gone.
       return { found: false, grantedCapability: ANCHOR_RESOLUTION_CAPABILITY };

--- a/server/features/context-inbox-router.ts
+++ b/server/features/context-inbox-router.ts
@@ -128,8 +128,14 @@ export interface ContextInboxStore {
   listPackets(filter?: ListContextPacketsFilter): ContextPacket[];
 
   createInboxMessage(input: CreateInboxMessageInput): SessionInboxMessage;
-  listInboxMessages(filter: ListInboxMessagesFilter): SessionInboxMessage[];
-  getInboxMessage(id: SessionInboxMessageId): SessionInboxMessage | null;
+  listInboxMessages(
+    filter: ListInboxMessagesFilter,
+    options?: { markDelivered?: boolean }
+  ): SessionInboxMessage[];
+  getInboxMessage(
+    id: SessionInboxMessageId,
+    options?: { markDelivered?: boolean }
+  ): SessionInboxMessage | null;
 
   /**
    * Transition-guarded update. Caller-requested `targetState` is validated by
@@ -189,7 +195,9 @@ function gatewayErrorBody(
   retryable: boolean,
   details?: Record<string, unknown>
 ): GatewayErrorBody {
-  return { error: { code, message, retryable, ...(details ? { details } : {}) } };
+  return {
+    error: { code, message, retryable, ...(details ? { details } : {}) },
+  };
 }
 
 function statusForCode(code: RelayCliGatewayErrorCode): number {
@@ -216,7 +224,9 @@ function sendGatewayError(
   retryable = false,
   details?: Record<string, unknown>
 ): void {
-  res.status(statusForCode(code)).json(gatewayErrorBody(code, message, retryable, details));
+  res
+    .status(statusForCode(code))
+    .json(gatewayErrorBody(code, message, retryable, details));
 }
 
 /** Returns true (and sends a 403) when a required capability is missing. */
@@ -228,26 +238,38 @@ function denyMissingCapability(
   const provided = parseCapabilityHeader(req.header('x-relay-capabilities'));
   const missing = required.filter((cap) => !provided.has(cap));
   if (missing.length === 0) return false;
-  sendGatewayError(res, 'FORBIDDEN', `missing required capability: ${missing[0]}`, false, {
-    capability: missing[0],
-    missingCapabilities: missing,
-  });
+  sendGatewayError(
+    res,
+    'FORBIDDEN',
+    `missing required capability: ${missing[0]}`,
+    false,
+    {
+      capability: missing[0],
+      missingCapabilities: missing,
+    }
+  );
   return true;
 }
 
 function bodyRecord(req: Request): Record<string, unknown> {
-  return typeof req.body === 'object' && req.body !== null && !Array.isArray(req.body)
+  return typeof req.body === 'object' &&
+    req.body !== null &&
+    !Array.isArray(req.body)
     ? (req.body as Record<string, unknown>)
     : {};
 }
 
 function readString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+  return typeof value === 'string' && value.trim().length > 0
+    ? value
+    : undefined;
 }
 
 function readStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
-  return value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0);
+  return value.filter(
+    (entry): entry is string => typeof entry === 'string' && entry.length > 0
+  );
 }
 
 const CONTEXT_PACKET_KIND_SET = new Set<ContextPacketKind>([
@@ -259,7 +281,8 @@ const CONTEXT_PACKET_KIND_SET = new Set<ContextPacketKind>([
 ]);
 
 function readPacketKind(value: unknown): ContextPacketKind | undefined {
-  return typeof value === 'string' && CONTEXT_PACKET_KIND_SET.has(value as ContextPacketKind)
+  return typeof value === 'string' &&
+    CONTEXT_PACKET_KIND_SET.has(value as ContextPacketKind)
     ? (value as ContextPacketKind)
     : undefined;
 }
@@ -273,7 +296,8 @@ const INBOX_STATE_SET = new Set<SessionInboxMessageState>([
 ]);
 
 function readInboxState(value: unknown): SessionInboxMessageState | undefined {
-  return typeof value === 'string' && INBOX_STATE_SET.has(value as SessionInboxMessageState)
+  return typeof value === 'string' &&
+    INBOX_STATE_SET.has(value as SessionInboxMessageState)
     ? (value as SessionInboxMessageState)
     : undefined;
 }
@@ -330,7 +354,10 @@ function pushStringPathHint(
   } else if (!value.startsWith('/')) {
     hints.push({ field, message: 'must be absolute and start with /' });
   } else if (pathEscapesRoot(value)) {
-    hints.push({ field, message: 'must not escape the filesystem root with .. segments' });
+    hints.push({
+      field,
+      message: 'must not escape the filesystem root with .. segments',
+    });
   }
 }
 
@@ -344,12 +371,21 @@ function pushTimestampAndHashHints(
     rawCapturedAt !== undefined &&
     (typeof rawCapturedAt !== 'string' || !ISO_TIMESTAMP_RE.test(rawCapturedAt))
   ) {
-    hints.push({ field: `${fieldPrefix}.capturedAt`, message: 'must be an ISO 8601 UTC timestamp when set' });
+    hints.push({
+      field: `${fieldPrefix}.capturedAt`,
+      message: 'must be an ISO 8601 UTC timestamp when set',
+    });
   }
 
   const rawSha = payload['sha256'];
-  if (rawSha !== undefined && (typeof rawSha !== 'string' || !SHA256_HEX_RE.test(rawSha))) {
-    hints.push({ field: `${fieldPrefix}.sha256`, message: 'must be 64 hex characters when set' });
+  if (
+    rawSha !== undefined &&
+    (typeof rawSha !== 'string' || !SHA256_HEX_RE.test(rawSha))
+  ) {
+    hints.push({
+      field: `${fieldPrefix}.sha256`,
+      message: 'must be 64 hex characters when set',
+    });
   }
 }
 
@@ -364,16 +400,24 @@ function pushNumericHints(
       value !== undefined &&
       (typeof value !== 'number' || !Number.isFinite(value) || value < 0)
     ) {
-      hints.push({ field: `${fieldPrefix}.${numericField}`, message: 'must be a non-negative finite number when set' });
+      hints.push({
+        field: `${fieldPrefix}.${numericField}`,
+        message: 'must be a non-negative finite number when set',
+      });
     }
   }
 
   const maxBytes = payload['maxBytes'];
   if (
     maxBytes !== undefined &&
-    (typeof maxBytes !== 'number' || !Number.isFinite(maxBytes) || maxBytes <= 0)
+    (typeof maxBytes !== 'number' ||
+      !Number.isFinite(maxBytes) ||
+      maxBytes <= 0)
   ) {
-    hints.push({ field: `${fieldPrefix}.maxBytes`, message: 'must be a positive finite number when set' });
+    hints.push({
+      field: `${fieldPrefix}.maxBytes`,
+      message: 'must be a positive finite number when set',
+    });
   }
 }
 
@@ -385,7 +429,10 @@ function pushRepoBindingHints(
   const repoBinding = payload['repoBinding'];
   if (repoBinding === undefined) return;
   if (!isRecord(repoBinding)) {
-    hints.push({ field: `${fieldPrefix}.repoBinding`, message: 'must be an object when set' });
+    hints.push({
+      field: `${fieldPrefix}.repoBinding`,
+      message: 'must be an object when set',
+    });
     return;
   }
 
@@ -408,7 +455,10 @@ function pushRepoBindingHints(
 
   const branch = repoBinding['branch'];
   if (branch !== undefined && branch !== null && typeof branch !== 'string') {
-    hints.push({ field: `${fieldPrefix}.repoBinding.branch`, message: 'must be a string or null when set' });
+    hints.push({
+      field: `${fieldPrefix}.repoBinding.branch`,
+      message: 'must be a string or null when set',
+    });
   }
 }
 
@@ -427,7 +477,10 @@ function validateFileResourceRefPayload(
   }
 
   if (!isNonEmptyString(payload['nodeId'])) {
-    hints.push({ field: `${fieldPrefix}.nodeId`, message: 'is required and must be a non-empty string' });
+    hints.push({
+      field: `${fieldPrefix}.nodeId`,
+      message: 'is required and must be a non-empty string',
+    });
   }
 
   pushStringPathHint(
@@ -458,17 +511,44 @@ function validateLineRangePayload(
   payload: unknown,
   fieldPrefix: string
 ): FieldValidationHint[] {
-  if (!isRecord(payload)) return [{ field: fieldPrefix, message: 'must be an object with startLine and endLine' }];
+  if (!isRecord(payload))
+    return [
+      {
+        field: fieldPrefix,
+        message: 'must be an object with startLine and endLine',
+      },
+    ];
   const hints: FieldValidationHint[] = [];
   const startLine = payload['startLine'];
   const endLine = payload['endLine'];
-  if (typeof startLine !== 'number' || !Number.isInteger(startLine) || startLine < 1) {
-    hints.push({ field: `${fieldPrefix}.startLine`, message: 'must be an integer >= 1' });
+  if (
+    typeof startLine !== 'number' ||
+    !Number.isInteger(startLine) ||
+    startLine < 1
+  ) {
+    hints.push({
+      field: `${fieldPrefix}.startLine`,
+      message: 'must be an integer >= 1',
+    });
   }
-  if (typeof endLine !== 'number' || !Number.isInteger(endLine) || endLine < 1) {
-    hints.push({ field: `${fieldPrefix}.endLine`, message: 'must be an integer >= 1' });
-  } else if (typeof startLine === 'number' && Number.isInteger(startLine) && endLine < startLine) {
-    hints.push({ field: `${fieldPrefix}.endLine`, message: 'must be >= startLine' });
+  if (
+    typeof endLine !== 'number' ||
+    !Number.isInteger(endLine) ||
+    endLine < 1
+  ) {
+    hints.push({
+      field: `${fieldPrefix}.endLine`,
+      message: 'must be an integer >= 1',
+    });
+  } else if (
+    typeof startLine === 'number' &&
+    Number.isInteger(startLine) &&
+    endLine < startLine
+  ) {
+    hints.push({
+      field: `${fieldPrefix}.endLine`,
+      message: 'must be >= startLine',
+    });
   }
   return hints;
 }
@@ -477,17 +557,44 @@ function validateByteRangePayload(
   payload: unknown,
   fieldPrefix: string
 ): FieldValidationHint[] {
-  if (!isRecord(payload)) return [{ field: fieldPrefix, message: 'must be an object with startByte and endByte' }];
+  if (!isRecord(payload))
+    return [
+      {
+        field: fieldPrefix,
+        message: 'must be an object with startByte and endByte',
+      },
+    ];
   const hints: FieldValidationHint[] = [];
   const startByte = payload['startByte'];
   const endByte = payload['endByte'];
-  if (typeof startByte !== 'number' || !Number.isInteger(startByte) || startByte < 0) {
-    hints.push({ field: `${fieldPrefix}.startByte`, message: 'must be an integer >= 0' });
+  if (
+    typeof startByte !== 'number' ||
+    !Number.isInteger(startByte) ||
+    startByte < 0
+  ) {
+    hints.push({
+      field: `${fieldPrefix}.startByte`,
+      message: 'must be an integer >= 0',
+    });
   }
-  if (typeof endByte !== 'number' || !Number.isInteger(endByte) || endByte < 0) {
-    hints.push({ field: `${fieldPrefix}.endByte`, message: 'must be an integer >= 0' });
-  } else if (typeof startByte === 'number' && Number.isInteger(startByte) && endByte <= startByte) {
-    hints.push({ field: `${fieldPrefix}.endByte`, message: 'must be > startByte' });
+  if (
+    typeof endByte !== 'number' ||
+    !Number.isInteger(endByte) ||
+    endByte < 0
+  ) {
+    hints.push({
+      field: `${fieldPrefix}.endByte`,
+      message: 'must be an integer >= 0',
+    });
+  } else if (
+    typeof startByte === 'number' &&
+    Number.isInteger(startByte) &&
+    endByte <= startByte
+  ) {
+    hints.push({
+      field: `${fieldPrefix}.endByte`,
+      message: 'must be > startByte',
+    });
   }
   return hints;
 }
@@ -495,25 +602,42 @@ function validateByteRangePayload(
 function validateAnchorPayload(payload: unknown): FieldValidationHint[] {
   const hints: FieldValidationHint[] = [];
   if (!isRecord(payload)) {
-    return [{ field: 'anchor', message: 'is required and must be an object for kind=file-anchor' }];
+    return [
+      {
+        field: 'anchor',
+        message: 'is required and must be an object for kind=file-anchor',
+      },
+    ];
   }
   hints.push(...validateFileResourceRefPayload(payload['ref'], 'anchor.ref'));
   const hasLineRange = payload['lineRange'] !== undefined;
   const hasByteRange = payload['byteRange'] !== undefined;
   if (!hasLineRange && !hasByteRange) {
-    hints.push({ field: 'anchor', message: 'must include lineRange or byteRange' });
+    hints.push({
+      field: 'anchor',
+      message: 'must include lineRange or byteRange',
+    });
   }
-  if (hasLineRange) hints.push(...validateLineRangePayload(payload['lineRange'], 'anchor.lineRange'));
-  if (hasByteRange) hints.push(...validateByteRangePayload(payload['byteRange'], 'anchor.byteRange'));
+  if (hasLineRange)
+    hints.push(
+      ...validateLineRangePayload(payload['lineRange'], 'anchor.lineRange')
+    );
+  if (hasByteRange)
+    hints.push(
+      ...validateByteRangePayload(payload['byteRange'], 'anchor.byteRange')
+    );
   if (payload['quote'] !== undefined && typeof payload['quote'] !== 'string') {
     hints.push({ field: 'anchor.quote', message: 'must be a string when set' });
   }
   return hints;
 }
 
-function validateContextBindingPayload(payload: unknown): FieldValidationHint[] {
+function validateContextBindingPayload(
+  payload: unknown
+): FieldValidationHint[] {
   if (payload === undefined) return [];
-  if (!isRecord(payload)) return [{ field: 'binding', message: 'must be an object when set' }];
+  if (!isRecord(payload))
+    return [{ field: 'binding', message: 'must be an object when set' }];
 
   const hints: FieldValidationHint[] = [];
   for (const field of [
@@ -523,7 +647,10 @@ function validateContextBindingPayload(payload: unknown): FieldValidationHint[] 
     'worktreeInstanceId',
   ] as const) {
     if (payload[field] !== undefined && !isNonEmptyString(payload[field])) {
-      hints.push({ field: `binding.${field}`, message: 'must be a non-empty string when set' });
+      hints.push({
+        field: `binding.${field}`,
+        message: 'must be a non-empty string when set',
+      });
     }
   }
   return hints;
@@ -553,7 +680,9 @@ function validateContextCreatePayload(
   }
 }
 
-const TERMINAL_STATE_SET = new Set<SessionInboxMessageState>(TERMINAL_INBOX_MESSAGE_STATES);
+const TERMINAL_STATE_SET = new Set<SessionInboxMessageState>(
+  TERMINAL_INBOX_MESSAGE_STATES
+);
 
 /** Map a guarded-update failure onto the right gateway error response. */
 function sendUpdateFailure(
@@ -570,7 +699,10 @@ function sendUpdateFailure(
       'SESSION_CONFLICT',
       `inbox message is in terminal state '${result.currentState}'`,
       false,
-      { currentState: result.currentState, terminalStates: [...TERMINAL_INBOX_MESSAGE_STATES] }
+      {
+        currentState: result.currentState,
+        terminalStates: [...TERMINAL_INBOX_MESSAGE_STATES],
+      }
     );
     return;
   }
@@ -585,7 +717,8 @@ function sendUpdateFailure(
 
 export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
   const router = Router();
-  const auth = deps.requireAuth ?? ((_req: Request, _res: Response, next) => next());
+  const auth =
+    deps.requireAuth ?? ((_req: Request, _res: Response, next) => next());
   // #760: derived `AnchorState` decoration resolver. Defaults to the hub
   // registry; `resolveAnchorWithRegisteredFetcher` returns `null` when the hub
   // has not wired a fetcher, in which case packets pass through undecorated.
@@ -595,9 +728,15 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
   /** Resolve the store or send 503; centralizes the null guard. */
   function store(res: Response): ContextInboxStore | null {
     if (!deps.store) {
-      sendGatewayError(res, 'SERVER_UNAVAILABLE', 'context/inbox store is unavailable', true, {
-        reasonCode: 'CONTEXT_STORE_UNAVAILABLE',
-      });
+      sendGatewayError(
+        res,
+        'SERVER_UNAVAILABLE',
+        'context/inbox store is unavailable',
+        true,
+        {
+          reasonCode: 'CONTEXT_STORE_UNAVAILABLE',
+        }
+      );
       return null;
     }
     return deps.store;
@@ -629,7 +768,9 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
   async function decorateMessage(
     s: ContextInboxStore,
     message: SessionInboxMessage
-  ): Promise<SessionInboxMessage & { contextPackets?: DecoratedContextPacket[] }> {
+  ): Promise<
+    SessionInboxMessage & { contextPackets?: DecoratedContextPacket[] }
+  > {
     const contextPackets = await decoratedAnchorPacketsFor(s, message);
     return contextPackets.length > 0 ? { ...message, contextPackets } : message;
   }
@@ -642,9 +783,15 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
     const body = bodyRecord(req);
     const kind = readPacketKind(body['kind']);
     if (!kind) {
-      sendGatewayError(res, 'INVALID_ARGUMENT', 'kind is required and must be a known ContextPacketKind', false, {
-        field: 'kind',
-      });
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'kind is required and must be a known ContextPacketKind',
+        false,
+        {
+          field: 'kind',
+        }
+      );
       return;
     }
     const fieldErrors = validateContextCreatePayload(kind, body);
@@ -663,15 +810,25 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
     try {
       const contextPacket = s.createPacket({
         kind,
-        ...(body['anchor'] !== undefined ? { anchor: body['anchor'] as ContextPacket['anchor'] } : {}),
-        ...(body['fileRef'] !== undefined ? { fileRef: body['fileRef'] as ContextPacket['fileRef'] } : {}),
+        ...(body['anchor'] !== undefined
+          ? { anchor: body['anchor'] as ContextPacket['anchor'] }
+          : {}),
+        ...(body['fileRef'] !== undefined
+          ? { fileRef: body['fileRef'] as ContextPacket['fileRef'] }
+          : {}),
         ...(readString(body['note']) ? { note: body['note'] as string } : {}),
-        ...(body['binding'] !== undefined ? { binding: body['binding'] as ContextPacketBinding } : {}),
+        ...(body['binding'] !== undefined
+          ? { binding: body['binding'] as ContextPacketBinding }
+          : {}),
         createdBy,
       });
       res.status(201).json({ contextPacket });
     } catch (err) {
-      sendGatewayError(res, 'INVALID_ARGUMENT', err instanceof Error ? err.message : 'invalid context packet');
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        err instanceof Error ? err.message : 'invalid context packet'
+      );
     }
   });
 
@@ -716,9 +873,15 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
     const targetSessionId = readString(body['targetSessionId']);
     const targetWorkContextId = readString(body['targetWorkContextId']);
     if (!targetSessionId && !targetWorkContextId) {
-      sendGatewayError(res, 'INVALID_ARGUMENT', 'one of targetSessionId or targetWorkContextId is required', false, {
-        field: 'targetSessionId',
-      });
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'one of targetSessionId or targetWorkContextId is required',
+        false,
+        {
+          field: 'targetSessionId',
+        }
+      );
       return;
     }
     const createdBy = readString(body['createdBy']) ?? 'cli-gateway';
@@ -732,7 +895,11 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
       });
       res.status(201).json({ message });
     } catch (err) {
-      sendGatewayError(res, 'INVALID_ARGUMENT', err instanceof Error ? err.message : 'invalid inbox message');
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        err instanceof Error ? err.message : 'invalid inbox message'
+      );
     }
   });
 
@@ -745,9 +912,15 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
     const targetSessionId = readString(req.query['targetSessionId']);
     const targetWorkContextId = readString(req.query['targetWorkContextId']);
     if (!targetSessionId && !targetWorkContextId) {
-      sendGatewayError(res, 'INVALID_ARGUMENT', 'one of targetSessionId or targetWorkContextId is required', false, {
-        field: 'targetSessionId',
-      });
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'one of targetSessionId or targetWorkContextId is required',
+        false,
+        {
+          field: 'targetSessionId',
+        }
+      );
       return;
     }
     const filter: ListInboxMessagesFilter = {};
@@ -760,6 +933,42 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
     // PULL delivery runs first (the store flips queued → delivered), then each
     // message's referenced file-anchor packets are decorated with derived state.
     const messages = s.listInboxMessages(filter);
+    Promise.all(messages.map((m) => decorateMessage(s, m)))
+      .then((decorated) => res.json({ messages: decorated }))
+      .catch(next);
+  });
+
+  // -- inbox.preview -------------------------------------------------------
+  // Sender-side/read-model preview: list and decorate messages WITHOUT the PULL
+  // delivery side effect. This keeps web feedback panels from marking a target
+  // agent's queued inbox rows delivered before the target consumer actually
+  // calls the delivery endpoint above.
+  router.get('/inbox/preview', auth, (req, res, next) => {
+    if (denyMissingCapability(req, res, [INBOX_READ])) return;
+    const s = store(res);
+    if (!s) return;
+    const targetSessionId = readString(req.query['targetSessionId']);
+    const targetWorkContextId = readString(req.query['targetWorkContextId']);
+    if (!targetSessionId && !targetWorkContextId) {
+      sendGatewayError(
+        res,
+        'INVALID_ARGUMENT',
+        'one of targetSessionId or targetWorkContextId is required',
+        false,
+        {
+          field: 'targetSessionId',
+        }
+      );
+      return;
+    }
+    const filter: ListInboxMessagesFilter = {};
+    if (targetSessionId) filter.targetSessionId = targetSessionId;
+    if (targetWorkContextId) filter.targetWorkContextId = targetWorkContextId;
+    const state = readInboxState(req.query['state']);
+    const limit = readLimit(req.query['limit']);
+    if (state) filter.state = state;
+    if (limit !== undefined) filter.limit = limit;
+    const messages = s.listInboxMessages(filter, { markDelivered: false });
     Promise.all(messages.map((m) => decorateMessage(s, m)))
       .then((decorated) => res.json({ messages: decorated }))
       .catch(next);
@@ -785,19 +994,23 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
   // -- inbox.ack / inbox.resolve / inbox.ignore ----------------------------
   // All three go through the store's transition-guarded update; the router
   // never trusts the caller to enforce the lifecycle (fugu C2).
-  function transitionHandler(targetState: SessionInboxMessageState): RequestHandler {
+  function transitionHandler(
+    targetState: SessionInboxMessageState
+  ): RequestHandler {
     return (req, res) => {
       if (denyMissingCapability(req, res, [INBOX_WRITE])) return;
       const s = store(res);
       if (!s) return;
       const id = req.params['id'] ?? '';
       if (!id) {
-        sendGatewayError(res, 'INVALID_ARGUMENT', 'id is required', false, { field: 'id' });
+        sendGatewayError(res, 'INVALID_ARGUMENT', 'id is required', false, {
+          field: 'id',
+        });
         return;
       }
       const actorId = readString(bodyRecord(req)['actorId']);
       const result = s.updateInboxState(id, targetState, actorId);
-      if (!result.ok) {
+      if (result.ok === false) {
         sendUpdateFailure(res, result);
         return;
       }

--- a/server/features/context-inbox-store-adapter.ts
+++ b/server/features/context-inbox-store-adapter.ts
@@ -141,14 +141,18 @@ export function createContextInboxStoreAdapter(
     listPackets(filter?: ListContextPacketsFilter): ContextPacket[] {
       return store.listContextPackets({
         ...(filter?.nodeId !== undefined ? { nodeId: filter.nodeId } : {}),
-        ...(filter?.workspaceId !== undefined ? { workspaceId: filter.workspaceId } : {}),
+        ...(filter?.workspaceId !== undefined
+          ? { workspaceId: filter.workspaceId }
+          : {}),
         ...(filter?.limit !== undefined ? { limit: filter.limit } : {}),
       });
     },
 
     createInboxMessage(input: CreateInboxMessageInput): SessionInboxMessage {
       return store.createInboxMessage({
-        ...(input.targetSessionId ? { targetSessionId: input.targetSessionId } : {}),
+        ...(input.targetSessionId
+          ? { targetSessionId: input.targetSessionId }
+          : {}),
         ...(input.targetWorkContextId
           ? { targetWorkContextId: input.targetWorkContextId }
           : {}),
@@ -158,23 +162,37 @@ export function createContextInboxStoreAdapter(
       });
     },
 
-    // PULL delivery: reading a queued message flips it to delivered (ADR-019 D3).
-    listInboxMessages(filter: ListInboxMessagesFilter): SessionInboxMessage[] {
+    // PULL delivery: reading a queued message flips it to delivered (ADR-019 D3)
+    // unless a sender-side preview explicitly opts out.
+    listInboxMessages(
+      filter: ListInboxMessagesFilter,
+      options: { markDelivered?: boolean } = {}
+    ): SessionInboxMessage[] {
       const messages = store.listInboxMessages({
-        ...(filter.targetSessionId ? { targetSessionId: filter.targetSessionId } : {}),
+        ...(filter.targetSessionId
+          ? { targetSessionId: filter.targetSessionId }
+          : {}),
         ...(filter.targetWorkContextId
           ? { targetWorkContextId: filter.targetWorkContextId }
           : {}),
         ...(filter.state ? { state: filter.state } : {}),
       });
-      const visible = filter.limit !== undefined ? messages.slice(0, filter.limit) : messages;
-      return visible.map((m) => deliverOnPull(store, m));
+      const visible =
+        filter.limit !== undefined ? messages.slice(0, filter.limit) : messages;
+      return options.markDelivered === false
+        ? visible
+        : visible.map((m) => deliverOnPull(store, m));
     },
 
-    // PULL delivery: getting a queued message by id flips it to delivered.
-    getInboxMessage(id: SessionInboxMessageId): SessionInboxMessage | null {
+    // PULL delivery: getting a queued message by id flips it to delivered unless
+    // a sender-side preview explicitly opts out.
+    getInboxMessage(
+      id: SessionInboxMessageId,
+      options: { markDelivered?: boolean } = {}
+    ): SessionInboxMessage | null {
       const message = store.getInboxMessage(id);
       if (!message) return null;
+      if (options.markDelivered === false) return message;
       return deliverOnPull(store, message);
     },
 

--- a/test/anchor-file-fetcher.test.ts
+++ b/test/anchor-file-fetcher.test.ts
@@ -24,6 +24,7 @@ import {
 import type { ScopedSessionSummary } from '../server/session-envelope-registry.js';
 import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
 import { RELAY_NODE_LINK_PROTOCOL_VERSION } from '../shared/relay-node-protocol.js';
+import { DEFAULT_LOCAL_NODE_ID } from '../shared/identity.js';
 import { RELAY_SECURITY_POLICY_VERSION } from '../shared/security-policy.js';
 
 const NODE_ID = 'node-alpha';
@@ -68,13 +69,24 @@ function onlineNode(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
   } as unknown as HubNodeSummary;
 }
 
-function scopedSession(root: string): ScopedSessionSummary {
+function scopedSession(root: string, nodeId = NODE_ID): ScopedSessionSummary {
   return {
     sessionId: 'sess-1',
-    globalSessionId: `${NODE_ID}:sess-1`,
-    nodeId: NODE_ID,
-    intent: { kind: 'routed-node-session', description: 'test' },
-    scope: { kind: 'node-cwd', nodeId: NODE_ID, cwd: root },
+    globalSessionId: `${nodeId}:sess-1`,
+    nodeId,
+    intent: {
+      kind:
+        nodeId === DEFAULT_LOCAL_NODE_ID
+          ? 'local-dev-compatibility'
+          : 'routed-node-session',
+      description: 'test',
+    },
+    scope: {
+      kind:
+        nodeId === DEFAULT_LOCAL_NODE_ID ? 'local-compatibility' : 'node-cwd',
+      nodeId,
+      cwd: root,
+    },
     peerIdentity: { kind: 'local-user', id: 'local-dev' },
     issuedAt: new Date().toISOString(),
     expiresAt: null,
@@ -107,8 +119,13 @@ function deps(input: {
   };
 }
 
-function target(root: string, file: string, preferRead = false): AnchorFileFetchTarget {
-  return { nodeId: NODE_ID, path: path.join(root, file), preferRead };
+function target(
+  root: string,
+  file: string,
+  preferRead = false,
+  nodeId = NODE_ID
+): AnchorFileFetchTarget {
+  return { nodeId, path: path.join(root, file), preferRead };
 }
 
 describe('createAnchorFileFetcher — happy path (stat)', () => {
@@ -118,7 +135,14 @@ describe('createAnchorFileFetcher — happy path (stat)', () => {
       expect(type).toBe('fs.stat');
       return {
         operation: 'stat',
-        stat: { type: 'file', size: 123, mtimeMs: 4567, path: 'x', name: 'x', mode: 0 },
+        stat: {
+          type: 'file',
+          size: 123,
+          mtimeMs: 4567,
+          path: 'x',
+          name: 'x',
+          mode: 0,
+        },
       };
     });
     const fetcher = createAnchorFileFetcher(
@@ -139,7 +163,10 @@ describe('createAnchorFileFetcher — happy path (read, preferRead)', () => {
   it('resolves found:true and hashes content for an authoritative sha', async () => {
     const root = makeRoot();
     const content = 'export const answer = 42;\n';
-    const expectedSha = crypto.createHash('sha256').update(Buffer.from(content, 'utf8')).digest('hex');
+    const expectedSha = crypto
+      .createHash('sha256')
+      .update(Buffer.from(content, 'utf8'))
+      .digest('hex');
     const request = vi.fn(async (_nodeId, type) => {
       expect(type).toBe('fs.read');
       return {
@@ -183,18 +210,78 @@ describe('createAnchorFileFetcher — happy path (read, preferRead)', () => {
   });
 });
 
+describe('createAnchorFileFetcher — local compatibility node', () => {
+  it('resolves an existing DEFAULT_LOCAL_NODE_ID file through local File RPC without a paired node link', async () => {
+    const root = makeRoot();
+    const filePath = path.join(root, 'local.ts');
+    fs.writeFileSync(filePath, 'export const local = true;\n');
+    const request = vi.fn();
+    const fetcher = createAnchorFileFetcher(
+      deps({
+        nodes: [],
+        sessions: [scopedSession(root, DEFAULT_LOCAL_NODE_ID)],
+        request,
+        hasActiveNode: false,
+      })
+    );
+
+    const result = await fetcher(
+      target(root, 'local.ts', false, DEFAULT_LOCAL_NODE_ID)
+    );
+
+    expect(result).toMatchObject({
+      found: true,
+      grantedCapability: ANCHOR_RESOLUTION_CAPABILITY,
+      size: fs.statSync(filePath).size,
+    });
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('does not use the local fallback for non-local nodes without a paired link', async () => {
+    const root = makeRoot();
+    fs.writeFileSync(
+      path.join(root, 'remote-looking.ts'),
+      'exists on the hub only\n'
+    );
+    const request = vi.fn();
+    const fetcher = createAnchorFileFetcher(
+      deps({
+        nodes: [onlineNode()],
+        sessions: [scopedSession(root)],
+        request,
+        hasActiveNode: false,
+      })
+    );
+
+    const result = await fetcher(target(root, 'remote-looking.ts', false));
+
+    expect(result).toBeNull();
+    expect(request).not.toHaveBeenCalled();
+  });
+});
+
 describe('createAnchorFileFetcher — missing / not-a-file', () => {
   it('maps a non-file stat (directory) to found:false', async () => {
     const root = makeRoot();
     const request = vi.fn(async () => ({
       operation: 'stat',
-      stat: { type: 'directory', size: 0, mtimeMs: 1, path: 'd', name: 'd', mode: 0 },
+      stat: {
+        type: 'directory',
+        size: 0,
+        mtimeMs: 1,
+        path: 'd',
+        name: 'd',
+        mode: 0,
+      },
     }));
     const fetcher = createAnchorFileFetcher(
       deps({ nodes: [onlineNode()], sessions: [scopedSession(root)], request })
     );
     const result = await fetcher(target(root, 'sub', false));
-    expect(result).toEqual({ found: false, grantedCapability: ANCHOR_RESOLUTION_CAPABILITY });
+    expect(result).toEqual({
+      found: false,
+      grantedCapability: ANCHOR_RESOLUTION_CAPABILITY,
+    });
   });
 
   it('maps a NOT_FOUND link error to found:false (authorized fetch, gone file)', async () => {
@@ -206,18 +293,28 @@ describe('createAnchorFileFetcher — missing / not-a-file', () => {
       deps({ nodes: [onlineNode()], sessions: [scopedSession(root)], request })
     );
     const result = await fetcher(target(root, 'gone.ts', false));
-    expect(result).toEqual({ found: false, grantedCapability: ANCHOR_RESOLUTION_CAPABILITY });
+    expect(result).toEqual({
+      found: false,
+      grantedCapability: ANCHOR_RESOLUTION_CAPABILITY,
+    });
   });
 });
 
 describe('createAnchorFileFetcher — unresolvable (null, never local-stat)', () => {
   it('returns null when no live session scope contains the path', async () => {
     const root = makeRoot();
-    const request = vi.fn(async () => ({ operation: 'stat', stat: { type: 'file' } }));
+    const request = vi.fn(async () => ({
+      operation: 'stat',
+      stat: { type: 'file' },
+    }));
     // Session scoped to a DIFFERENT root → path is outside; no in-scope session.
     const otherRoot = makeRoot();
     const fetcher = createAnchorFileFetcher(
-      deps({ nodes: [onlineNode()], sessions: [scopedSession(otherRoot)], request })
+      deps({
+        nodes: [onlineNode()],
+        sessions: [scopedSession(otherRoot)],
+        request,
+      })
     );
     const result = await fetcher(target(root, 'a.ts', false));
     expect(result).toBeNull();
@@ -237,7 +334,9 @@ describe('createAnchorFileFetcher — unresolvable (null, never local-stat)', ()
   it('returns null when the node is offline (no File RPC path)', async () => {
     const root = makeRoot();
     const request = vi.fn();
-    const offline = onlineNode({ status: 'offline' as HubNodeSummary['status'] });
+    const offline = onlineNode({
+      status: 'offline' as HubNodeSummary['status'],
+    });
     const fetcher = createAnchorFileFetcher(
       deps({ nodes: [offline], sessions: [scopedSession(root)], request })
     );

--- a/test/components/FileFeedbackPanel.test.ts
+++ b/test/components/FileFeedbackPanel.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import FileFeedbackPanel from '../../frontend/src/components/FileFeedbackPanel.js';
+import type { SessionSummary } from '../../frontend/src/lib/types.js';
+
+const apiMocks = vi.hoisted(() => ({
+  createContextPacket: vi.fn(),
+  previewInboxMessages: vi.fn(),
+  sendInboxMessage: vi.fn(),
+  updateInboxMessageState: vi.fn(),
+}));
+
+vi.mock('../../frontend/src/lib/api.js', () => ({
+  createContextPacket: apiMocks.createContextPacket,
+  previewInboxMessages: apiMocks.previewInboxMessages,
+  sendInboxMessage: apiMocks.sendInboxMessage,
+  updateInboxMessageState: apiMocks.updateInboxMessageState,
+}));
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function session(
+  id: string,
+  type: SessionSummary['type'] = 'agent',
+  overrides: Partial<SessionSummary> = {}
+): SessionSummary {
+  return {
+    id,
+    type,
+    agent: type === 'agent' ? 'claude' : 'shell',
+    cwd: '/repo',
+    displayName: id,
+    createdAt: '2026-05-28T00:00:00.000Z',
+    lastActivity: '2026-05-28T00:00:00.000Z',
+    idle: false,
+    nodeId: 'local',
+    ...overrides,
+  };
+}
+
+type PanelProps = React.ComponentProps<typeof FileFeedbackPanel>;
+
+function props(overrides: Partial<PanelProps> = {}): PanelProps {
+  return {
+    filePath: 'README.md',
+    workspacePath: '/repo',
+    content: 'hello\nworld',
+    language: 'markdown',
+    sessions: [],
+    preferredTargetSessionId: null,
+    selectedLine: null,
+    onSelectedLineConsumed: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('FileFeedbackPanel live target send guard', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    apiMocks.createContextPacket.mockResolvedValue({
+      id: 'cp:test',
+      kind: 'file-anchor',
+      createdAt: '2026-05-28T00:00:00.000Z',
+      createdBy: 'relay-web',
+    });
+    apiMocks.previewInboxMessages.mockResolvedValue([]);
+    apiMocks.sendInboxMessage.mockResolvedValue({
+      id: 'im:test',
+      targetSessionId: 'local:fallback-agent',
+      contextPacketIds: ['cp:test'],
+      state: 'queued',
+      createdAt: '2026-05-28T00:00:00.000Z',
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  function sendButton(): HTMLButtonElement {
+    const button = Array.from(container.querySelectorAll('button')).find(
+      (candidate) => candidate.textContent === 'send feedback'
+    );
+    expect(button).toBeTruthy();
+    return button as HTMLButtonElement;
+  }
+
+  it('disables and refuses a stale selected target when all sessions disappear before passive retargeting', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          FileFeedbackPanel,
+          props({ sessions: [session('removed-agent')] })
+        )
+      );
+    });
+
+    await act(async () => {
+      flushSync(() => {
+        root.render(React.createElement(FileFeedbackPanel, props({ sessions: [] })));
+      });
+
+      expect(sendButton().disabled).toBe(true);
+      sendButton().click();
+    });
+
+    expect(apiMocks.createContextPacket).not.toHaveBeenCalled();
+    expect(apiMocks.sendInboxMessage).not.toHaveBeenCalled();
+  });
+
+  it('uses a live fallback target instead of a removed selected target before passive retargeting runs', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          FileFeedbackPanel,
+          props({ sessions: [session('removed-agent')] })
+        )
+      );
+    });
+
+    await act(async () => {
+      flushSync(() => {
+        root.render(
+          React.createElement(
+            FileFeedbackPanel,
+            props({ sessions: [session('fallback-agent')] })
+          )
+        );
+      });
+
+      sendButton().click();
+    });
+
+    expect(apiMocks.sendInboxMessage).toHaveBeenCalledTimes(1);
+    expect(apiMocks.sendInboxMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ targetSessionId: 'local:fallback-agent' })
+    );
+    expect(apiMocks.sendInboxMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ targetSessionId: 'local:removed-agent' })
+    );
+  });
+});

--- a/test/context-feedback-api.test.ts
+++ b/test/context-feedback-api.test.ts
@@ -3,6 +3,7 @@ import { afterEach, expect, test } from 'vitest';
 import {
   createContextPacket,
   fetchInboxMessages,
+  previewInboxMessages,
   sendInboxMessage,
   updateInboxMessageState,
 } from '../frontend/src/lib/api.js';
@@ -134,5 +135,31 @@ test('context feedback api lists inbox feedback and drives review state transiti
   expect(requests[1]?.url).toBe('/inbox/im%3Aweb-1/resolve');
   expect(JSON.parse(String(requests[1]?.init?.body))).toEqual({
     actorId: 'relay-web',
+  });
+});
+
+test('context feedback api previews inbox feedback through the non-consuming endpoint', async () => {
+  installFetch([
+    {
+      messages: [
+        {
+          id: 'im:web-1',
+          targetSessionId: 'local:session-1',
+          contextPacketIds: ['cp:web-1'],
+          state: 'queued',
+          text: 'please review this range',
+        },
+      ],
+    },
+  ]);
+
+  const messages = await previewInboxMessages('local:session-1', 8);
+
+  expect(messages[0]?.state).toBe('queued');
+  expect(requests[0]?.url).toBe(
+    '/inbox/preview?targetSessionId=local%3Asession-1&limit=8'
+  );
+  expect(requests[0]?.init?.headers).toMatchObject({
+    'x-relay-capabilities': 'context:read,context:write,inbox:read,inbox:write',
   });
 });

--- a/test/context-feedback-api.test.ts
+++ b/test/context-feedback-api.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, expect, test } from 'vitest';
+
+import {
+  createContextPacket,
+  fetchInboxMessages,
+  sendInboxMessage,
+  updateInboxMessageState,
+} from '../frontend/src/lib/api.js';
+
+const originalFetch = globalThis.fetch;
+
+interface CapturedRequest {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+const requests: CapturedRequest[] = [];
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  requests.length = 0;
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function installFetch(responses: unknown[]): void {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    requests.push({ url: String(input), init });
+    const body = responses.shift();
+    if (body === undefined) throw new Error('unexpected fetch');
+    return jsonResponse(body, init?.method === 'POST' ? 201 : 200);
+  }) as typeof globalThis.fetch;
+}
+
+test('context feedback api creates a file anchor and sends it through inbox verbs', async () => {
+  installFetch([
+    {
+      contextPacket: {
+        id: 'cp:web-1',
+        kind: 'file-anchor',
+        createdAt: '2026-05-28T00:00:00.000Z',
+        createdBy: 'relay-web',
+      },
+    },
+    {
+      message: {
+        id: 'im:web-1',
+        targetSessionId: 'local:session-1',
+        contextPacketIds: ['cp:web-1'],
+        state: 'queued',
+        createdAt: '2026-05-28T00:00:01.000Z',
+        createdBy: 'relay-web',
+      },
+    },
+  ]);
+
+  const packet = await createContextPacket({
+    kind: 'file-anchor',
+    anchor: {
+      ref: {
+        nodeId: 'local',
+        path: '/repo/README.md',
+        capturedAt: '2026-05-28T00:00:00.000Z',
+        intent: 'read',
+      },
+      lineRange: { startLine: 1, endLine: 3 },
+      quote: '# relay',
+    },
+    binding: { nodeId: 'local' },
+    createdBy: 'relay-web',
+  });
+  const message = await sendInboxMessage({
+    targetSessionId: 'local:session-1',
+    contextPacketIds: [packet.id],
+    text: 'please review this markdown range',
+    createdBy: 'relay-web',
+  });
+
+  expect(packet.id).toBe('cp:web-1');
+  expect(message.contextPacketIds).toEqual(['cp:web-1']);
+  expect(requests.map((request) => request.url)).toEqual([
+    '/context',
+    '/inbox',
+  ]);
+  expect(requests[0]?.init?.headers).toMatchObject({
+    'Content-Type': 'application/json',
+    'x-relay-capabilities': 'context:read,context:write,inbox:read,inbox:write',
+  });
+  expect(JSON.parse(String(requests[1]?.init?.body))).toMatchObject({
+    targetSessionId: 'local:session-1',
+    contextPacketIds: ['cp:web-1'],
+  });
+});
+
+test('context feedback api lists inbox feedback and drives review state transitions', async () => {
+  installFetch([
+    {
+      messages: [
+        {
+          id: 'im:web-1',
+          targetSessionId: 'local:session-1',
+          contextPacketIds: ['cp:web-1'],
+          state: 'delivered',
+          text: 'please review this range',
+          contextPackets: [
+            { id: 'cp:web-1', kind: 'file-anchor', anchorState: 'unchanged' },
+          ],
+        },
+      ],
+    },
+    {
+      message: {
+        id: 'im:web-1',
+        targetSessionId: 'local:session-1',
+        contextPacketIds: ['cp:web-1'],
+        state: 'resolved',
+      },
+    },
+  ]);
+
+  const messages = await fetchInboxMessages('local:session-1', 8);
+  const resolved = await updateInboxMessageState('im:web-1', 'resolve');
+
+  expect(messages[0]?.contextPackets?.[0]?.anchorState).toBe('unchanged');
+  expect(resolved.state).toBe('resolved');
+  expect(requests[0]?.url).toBe(
+    '/inbox?targetSessionId=local%3Asession-1&limit=8'
+  );
+  expect(requests[1]?.url).toBe('/inbox/im%3Aweb-1/resolve');
+  expect(JSON.parse(String(requests[1]?.init?.body))).toEqual({
+    actorId: 'relay-web',
+  });
+});

--- a/test/context-inbox-router.test.ts
+++ b/test/context-inbox-router.test.ts
@@ -32,10 +32,15 @@ import type { ResolveAnchorOutcome } from '../server/anchor-resolution.js';
 // reject, PULL delivery (list/get flip queued → delivered).
 // ---------------------------------------------------------------------------
 
-const TERMINAL = new Set<SessionInboxMessageState>(TERMINAL_INBOX_MESSAGE_STATES);
+const TERMINAL = new Set<SessionInboxMessageState>(
+  TERMINAL_INBOX_MESSAGE_STATES
+);
 
 // Allowed forward transitions. `delivered` is reached by PULL, not this map.
-const ALLOWED_TRANSITIONS: Record<SessionInboxMessageState, Set<SessionInboxMessageState>> = {
+const ALLOWED_TRANSITIONS: Record<
+  SessionInboxMessageState,
+  Set<SessionInboxMessageState>
+> = {
   queued: new Set(['acknowledged']),
   delivered: new Set(['acknowledged']),
   acknowledged: new Set(['acknowledged', 'resolved', 'ignored']),
@@ -84,8 +89,10 @@ function createFakeStore(): ContextInboxStore & { _markDelivered: boolean } {
     },
     listPackets(filter?: ListContextPacketsFilter): ContextPacket[] {
       let all = [...packets.values()];
-      if (filter?.nodeId) all = all.filter((p) => p.binding?.nodeId === filter.nodeId);
-      if (filter?.workspaceId) all = all.filter((p) => p.binding?.workspaceId === filter.workspaceId);
+      if (filter?.nodeId)
+        all = all.filter((p) => p.binding?.nodeId === filter.nodeId);
+      if (filter?.workspaceId)
+        all = all.filter((p) => p.binding?.workspaceId === filter.workspaceId);
       if (filter?.limit !== undefined) all = all.slice(0, filter.limit);
       return all;
     },
@@ -93,8 +100,12 @@ function createFakeStore(): ContextInboxStore & { _markDelivered: boolean } {
       const id = createInboxMessageId(`test${messageSeq++}`);
       const message: SessionInboxMessage = {
         id,
-        ...(input.targetSessionId ? { targetSessionId: input.targetSessionId } : {}),
-        ...(input.targetWorkContextId ? { targetWorkContextId: input.targetWorkContextId } : {}),
+        ...(input.targetSessionId
+          ? { targetSessionId: input.targetSessionId }
+          : {}),
+        ...(input.targetWorkContextId
+          ? { targetWorkContextId: input.targetWorkContextId }
+          : {}),
         contextPacketIds: input.contextPacketIds,
         ...(input.text !== undefined ? { text: input.text } : {}),
         state: 'queued',
@@ -104,22 +115,33 @@ function createFakeStore(): ContextInboxStore & { _markDelivered: boolean } {
       messages.set(id, message);
       return message;
     },
-    listInboxMessages(filter: ListInboxMessagesFilter): SessionInboxMessage[] {
+    listInboxMessages(
+      filter: ListInboxMessagesFilter,
+      options: { markDelivered?: boolean } = {}
+    ): SessionInboxMessage[] {
       let all = [...messages.values()];
       if (filter.targetSessionId) {
         all = all.filter((m) => m.targetSessionId === filter.targetSessionId);
       }
       if (filter.targetWorkContextId) {
-        all = all.filter((m) => m.targetWorkContextId === filter.targetWorkContextId);
+        all = all.filter(
+          (m) => m.targetWorkContextId === filter.targetWorkContextId
+        );
       }
       if (filter.state) all = all.filter((m) => m.state === filter.state);
       if (filter.limit !== undefined) all = all.slice(0, filter.limit);
       // PULL delivery side effect applies only to rows returned by the list.
-      return all.map((m) => deliverOnPull(m));
+      return options.markDelivered === false
+        ? all
+        : all.map((m) => deliverOnPull(m));
     },
-    getInboxMessage(id: string): SessionInboxMessage | null {
+    getInboxMessage(
+      id: string,
+      options: { markDelivered?: boolean } = {}
+    ): SessionInboxMessage | null {
       const message = messages.get(id);
       if (!message) return null;
+      if (options.markDelivered === false) return message;
       return deliverOnPull(message);
     },
     updateInboxState(
@@ -133,14 +155,24 @@ function createFakeStore(): ContextInboxStore & { _markDelivered: boolean } {
         return { ok: false, reason: 'terminal', currentState: message.state };
       }
       if (!ALLOWED_TRANSITIONS[message.state].has(targetState)) {
-        return { ok: false, reason: 'invalid_transition', currentState: message.state };
+        return {
+          ok: false,
+          reason: 'invalid_transition',
+          currentState: message.state,
+        };
       }
       const updated: SessionInboxMessage = {
         ...message,
         state: targetState,
-        ...(targetState === 'acknowledged' ? { acknowledgedAt: new Date().toISOString() } : {}),
-        ...(targetState === 'resolved' ? { resolvedAt: new Date().toISOString() } : {}),
-        ...(targetState === 'ignored' ? { ignoredAt: new Date().toISOString() } : {}),
+        ...(targetState === 'acknowledged'
+          ? { acknowledgedAt: new Date().toISOString() }
+          : {}),
+        ...(targetState === 'resolved'
+          ? { resolvedAt: new Date().toISOString() }
+          : {}),
+        ...(targetState === 'ignored'
+          ? { ignoredAt: new Date().toISOString() }
+          : {}),
       };
       messages.set(id, updated);
       return { ok: true, message: updated };
@@ -228,7 +260,9 @@ describe('context/inbox gateway router', () => {
     expect(created.body.contextPacket.id).toMatch(/^cp:/);
 
     const id = created.body.contextPacket.id as string;
-    const got = await req('GET', `/context/${encodeURIComponent(id)}`, { caps: 'context:read' });
+    const got = await req('GET', `/context/${encodeURIComponent(id)}`, {
+      caps: 'context:read',
+    });
     expect(got.status).toBe(200);
     expect(got.body.contextPacket.id).toBe(id);
 
@@ -240,51 +274,103 @@ describe('context/inbox gateway router', () => {
   it('inbox.send queues; inbox.list PULL-delivers (queued → delivered)', async () => {
     const sent = await req('POST', '/inbox', {
       caps: 'inbox:write',
-      body: { targetSessionId: 'node1:s1', contextPacketIds: [], text: 'hi', createdBy: 'agent_1' },
+      body: {
+        targetSessionId: 'node1:s1',
+        contextPacketIds: [],
+        text: 'hi',
+        createdBy: 'agent_1',
+      },
     });
     expect(sent.status).toBe(201);
     expect(sent.body.message.state).toBe('queued');
 
-    const listed = await req('GET', '/inbox?targetSessionId=node1:s1', { caps: 'inbox:read' });
+    const listed = await req('GET', '/inbox?targetSessionId=node1:s1', {
+      caps: 'inbox:read',
+    });
     expect(listed.status).toBe(200);
     expect(listed.body.messages).toHaveLength(1);
     // PULL semantics: fetching flips queued → delivered.
     expect(listed.body.messages[0].state).toBe('delivered');
   });
 
+  it('inbox.preview lists without PULL-delivering queued messages', async () => {
+    const sent = await req('POST', '/inbox', {
+      caps: 'inbox:write',
+      body: {
+        targetSessionId: 'node1:s1',
+        contextPacketIds: [],
+        text: 'hi',
+        createdBy: 'agent_1',
+      },
+    });
+    expect(sent.body.message.state).toBe('queued');
+
+    const previewed = await req(
+      'GET',
+      '/inbox/preview?targetSessionId=node1:s1',
+      { caps: 'inbox:read' }
+    );
+    expect(previewed.status).toBe(200);
+    expect(previewed.body.messages).toHaveLength(1);
+    expect(previewed.body.messages[0].state).toBe('queued');
+
+    const listed = await req('GET', '/inbox?targetSessionId=node1:s1', {
+      caps: 'inbox:read',
+    });
+    expect(listed.body.messages[0].state).toBe('delivered');
+  });
+
   it('inbox.ack is idempotent and ack → resolve is terminal-guarded', async () => {
     const sent = await req('POST', '/inbox', {
       caps: 'inbox:write',
-      body: { targetSessionId: 'node1:s2', contextPacketIds: [], createdBy: 'agent_1' },
+      body: {
+        targetSessionId: 'node1:s2',
+        contextPacketIds: [],
+        createdBy: 'agent_1',
+      },
     });
     const id = sent.body.message.id as string;
 
-    const ack1 = await req('POST', `/inbox/${encodeURIComponent(id)}/ack`, { caps: 'inbox:write' });
+    const ack1 = await req('POST', `/inbox/${encodeURIComponent(id)}/ack`, {
+      caps: 'inbox:write',
+    });
     expect(ack1.status).toBe(200);
     expect(ack1.body.message.state).toBe('acknowledged');
 
     // Idempotent re-ack succeeds.
-    const ack2 = await req('POST', `/inbox/${encodeURIComponent(id)}/ack`, { caps: 'inbox:write' });
+    const ack2 = await req('POST', `/inbox/${encodeURIComponent(id)}/ack`, {
+      caps: 'inbox:write',
+    });
     expect(ack2.status).toBe(200);
     expect(ack2.body.message.state).toBe('acknowledged');
 
     // Resolve from acknowledged is allowed → terminal.
-    const resolved = await req('POST', `/inbox/${encodeURIComponent(id)}/resolve`, {
-      caps: 'inbox:write',
-    });
+    const resolved = await req(
+      'POST',
+      `/inbox/${encodeURIComponent(id)}/resolve`,
+      {
+        caps: 'inbox:write',
+      }
+    );
     expect(resolved.status).toBe(200);
     expect(resolved.body.message.state).toBe('resolved');
     expect(isTerminalInboxState(resolved.body.message.state)).toBe(true);
 
     // Any transition out of a terminal state is rejected (SESSION_CONFLICT).
-    const reAck = await req('POST', `/inbox/${encodeURIComponent(id)}/ack`, { caps: 'inbox:write' });
+    const reAck = await req('POST', `/inbox/${encodeURIComponent(id)}/ack`, {
+      caps: 'inbox:write',
+    });
     expect(reAck.status).toBe(409);
     expect(reAck.body.error.code).toBe('SESSION_CONFLICT');
     expect(reAck.body.error.details.currentState).toBe('resolved');
 
-    const reIgnore = await req('POST', `/inbox/${encodeURIComponent(id)}/ignore`, {
-      caps: 'inbox:write',
-    });
+    const reIgnore = await req(
+      'POST',
+      `/inbox/${encodeURIComponent(id)}/ignore`,
+      {
+        caps: 'inbox:write',
+      }
+    );
     expect(reIgnore.status).toBe(409);
     expect(reIgnore.body.error.code).toBe('SESSION_CONFLICT');
   });
@@ -312,7 +398,9 @@ describe('context/inbox gateway router', () => {
     expect(list.body.error.code).toBe('FORBIDDEN');
     expect(list.body.error.details.capability).toBe('context:read');
 
-    const inbox = await req('GET', '/inbox?targetSessionId=node1:s1', { caps: ALL_CAPS.replace('inbox:read', '') });
+    const inbox = await req('GET', '/inbox?targetSessionId=node1:s1', {
+      caps: ALL_CAPS.replace('inbox:read', ''),
+    });
     expect(inbox.status).toBe(403);
     expect(inbox.body.error.details.capability).toBe('inbox:read');
   });
@@ -339,7 +427,9 @@ describe('context/inbox gateway router', () => {
     expect(invalidAnchor.status).toBe(400);
     expect(invalidAnchor.body.error.code).toBe('INVALID_ARGUMENT');
     expect(invalidAnchor.body.error.message).toContain('anchor.ref.nodeId');
-    expect(invalidAnchor.body.error.details.reasonCode).toBe('INVALID_CONTEXT_PACKET');
+    expect(invalidAnchor.body.error.details.reasonCode).toBe(
+      'INVALID_CONTEXT_PACKET'
+    );
     expect(invalidAnchor.body.error.details.fieldErrors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ field: 'anchor.ref.nodeId' }),
@@ -366,7 +456,9 @@ describe('context/inbox gateway router', () => {
     expect(invalidBinding.status).toBe(400);
     expect(invalidBinding.body.error.code).toBe('INVALID_ARGUMENT');
     expect(invalidBinding.body.error.message).toContain('binding.workspaceId');
-    expect(invalidBinding.body.error.details.reasonCode).toBe('INVALID_CONTEXT_PACKET');
+    expect(invalidBinding.body.error.details.reasonCode).toBe(
+      'INVALID_CONTEXT_PACKET'
+    );
     expect(invalidBinding.body.error.details.fieldErrors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ field: 'binding.workspaceId' }),
@@ -387,7 +479,9 @@ describe('context/inbox gateway router', () => {
     });
     expect(nonObjectBinding.status).toBe(400);
     expect(nonObjectBinding.body.error.code).toBe('INVALID_ARGUMENT');
-    expect(nonObjectBinding.body.error.details.reasonCode).toBe('INVALID_CONTEXT_PACKET');
+    expect(nonObjectBinding.body.error.details.reasonCode).toBe(
+      'INVALID_CONTEXT_PACKET'
+    );
     expect(nonObjectBinding.body.error.details.fieldErrors).toEqual([
       expect.objectContaining({ field: 'binding' }),
     ]);
@@ -399,7 +493,9 @@ describe('context/inbox gateway router', () => {
     expect(noTarget.status).toBe(400);
     expect(noTarget.body.error.code).toBe('INVALID_ARGUMENT');
 
-    const missing = await req('GET', '/context/cp:does-not-exist', { caps: 'context:read' });
+    const missing = await req('GET', '/context/cp:does-not-exist', {
+      caps: 'context:read',
+    });
     expect(missing.status).toBe(404);
     expect(missing.body.error.code).toBe('NOT_FOUND');
   });
@@ -416,14 +512,23 @@ describe('context/inbox gateway router without a store', () => {
 
 // #760: derived `AnchorState` decoration wired into the read paths.
 describe('context/inbox gateway router — #760 derived AnchorState decoration', () => {
-  function resolverReturning(state: 'unchanged' | 'stale' | 'missing'): AnchorStateResolver {
-    return async (): Promise<ResolveAnchorOutcome> => ({ state, current: null });
+  function resolverReturning(
+    state: 'unchanged' | 'stale' | 'missing'
+  ): AnchorStateResolver {
+    return async (): Promise<ResolveAnchorOutcome> => ({
+      state,
+      current: null,
+    });
   }
 
   async function createFileAnchor(): Promise<string> {
     const created = await req('POST', '/context', {
       caps: 'context:write',
-      body: { kind: 'file-anchor', anchor: fileAnchorRef(), createdBy: 'agent_1' },
+      body: {
+        kind: 'file-anchor',
+        anchor: fileAnchorRef(),
+        createdBy: 'agent_1',
+      },
     });
     expect(created.status).toBe(201);
     return created.body.contextPacket.id as string;
@@ -434,7 +539,9 @@ describe('context/inbox gateway router — #760 derived AnchorState decoration',
     async (state) => {
       await mount(createFakeStore(), resolverReturning(state));
       const id = await createFileAnchor();
-      const got = await req('GET', `/context/${encodeURIComponent(id)}`, { caps: 'context:read' });
+      const got = await req('GET', `/context/${encodeURIComponent(id)}`, {
+        caps: 'context:read',
+      });
       expect(got.status).toBe(200);
       expect(got.body.contextPacket.kind).toBe('file-anchor');
       // DERIVED at read time, surfaced — never stored.
@@ -449,7 +556,9 @@ describe('context/inbox gateway router — #760 derived AnchorState decoration',
       body: { kind: 'note', note: 'no anchor here', createdBy: 'agent_1' },
     });
     const id = created.body.contextPacket.id as string;
-    const got = await req('GET', `/context/${encodeURIComponent(id)}`, { caps: 'context:read' });
+    const got = await req('GET', `/context/${encodeURIComponent(id)}`, {
+      caps: 'context:read',
+    });
     expect(got.body.contextPacket.anchorState).toBeUndefined();
   });
 
@@ -458,10 +567,16 @@ describe('context/inbox gateway router — #760 derived AnchorState decoration',
     const packetId = await createFileAnchor();
     const sent = await req('POST', '/inbox', {
       caps: 'inbox:write',
-      body: { targetSessionId: 'node1:s9', contextPacketIds: [packetId], createdBy: 'agent_1' },
+      body: {
+        targetSessionId: 'node1:s9',
+        contextPacketIds: [packetId],
+        createdBy: 'agent_1',
+      },
     });
     const msgId = sent.body.message.id as string;
-    const got = await req('GET', `/inbox/${encodeURIComponent(msgId)}`, { caps: 'inbox:read' });
+    const got = await req('GET', `/inbox/${encodeURIComponent(msgId)}`, {
+      caps: 'inbox:read',
+    });
     expect(got.status).toBe(200);
     expect(got.body.message.contextPackets).toHaveLength(1);
     expect(got.body.message.contextPackets[0].anchorState).toBe('unchanged');
@@ -472,13 +587,44 @@ describe('context/inbox gateway router — #760 derived AnchorState decoration',
     const packetId = await createFileAnchor();
     await req('POST', '/inbox', {
       caps: 'inbox:write',
-      body: { targetSessionId: 'node1:s10', contextPacketIds: [packetId], createdBy: 'agent_1' },
+      body: {
+        targetSessionId: 'node1:s10',
+        contextPacketIds: [packetId],
+        createdBy: 'agent_1',
+      },
     });
-    const listed = await req('GET', '/inbox?targetSessionId=node1:s10', { caps: 'inbox:read' });
+    const listed = await req('GET', '/inbox?targetSessionId=node1:s10', {
+      caps: 'inbox:read',
+    });
     expect(listed.status).toBe(200);
     expect(listed.body.messages).toHaveLength(1);
     // PULL delivery still happens alongside decoration.
     expect(listed.body.messages[0].state).toBe('delivered');
-    expect(listed.body.messages[0].contextPackets[0].anchorState).toBe('missing');
+    expect(listed.body.messages[0].contextPackets[0].anchorState).toBe(
+      'missing'
+    );
+  });
+
+  it('inbox.preview decorates referenced packets without PULL-delivering', async () => {
+    await mount(createFakeStore(), resolverReturning('unchanged'));
+    const packetId = await createFileAnchor();
+    await req('POST', '/inbox', {
+      caps: 'inbox:write',
+      body: {
+        targetSessionId: 'node1:s11',
+        contextPacketIds: [packetId],
+        createdBy: 'agent_1',
+      },
+    });
+    const previewed = await req(
+      'GET',
+      '/inbox/preview?targetSessionId=node1:s11',
+      { caps: 'inbox:read' }
+    );
+    expect(previewed.status).toBe(200);
+    expect(previewed.body.messages[0].state).toBe('queued');
+    expect(previewed.body.messages[0].contextPackets[0].anchorState).toBe(
+      'unchanged'
+    );
   });
 });

--- a/test/context-inbox-store-adapter.test.ts
+++ b/test/context-inbox-store-adapter.test.ts
@@ -39,7 +39,11 @@ afterEach(() => {
 });
 
 function seedMessage(target: GlobalSessionId = SESSION_A) {
-  const packet = adapter.createPacket({ kind: 'note', note: 'hi', createdBy: 'agent_1' });
+  const packet = adapter.createPacket({
+    kind: 'note',
+    note: 'hi',
+    createdBy: 'agent_1',
+  });
   return adapter.createInboxMessage({
     targetSessionId: target,
     contextPacketIds: [packet.id],
@@ -50,7 +54,11 @@ function seedMessage(target: GlobalSessionId = SESSION_A) {
 
 describe('context-inbox store adapter — method renames + packet filter', () => {
   it('round-trips createPacket/getPacket/listPackets', () => {
-    const created = adapter.createPacket({ kind: 'note', note: 'remember', createdBy: 'agent_1' });
+    const created = adapter.createPacket({
+      kind: 'note',
+      note: 'remember',
+      createdBy: 'agent_1',
+    });
     expect(created.id).toMatch(/^cp:/);
     expect(adapter.getPacket(created.id)?.id).toBe(created.id);
     expect(adapter.listPackets().map((p) => p.id)).toContain(created.id);
@@ -70,7 +78,9 @@ describe('context-inbox store adapter — method renames + packet filter', () =>
       createdBy: 'agent_1',
     });
     expect(adapter.listPackets({ nodeId: 'node-a' })).toHaveLength(1);
-    expect(adapter.listPackets({ nodeId: 'node-a' })[0]?.binding?.nodeId).toBe('node-a');
+    expect(adapter.listPackets({ nodeId: 'node-a' })[0]?.binding?.nodeId).toBe(
+      'node-a'
+    );
     expect(adapter.listPackets({ limit: 1 })).toHaveLength(1);
   });
 });
@@ -94,12 +104,27 @@ describe('context-inbox store adapter — PULL-as-delivery flip', () => {
     expect(store.getInboxMessage(msg.id)?.state).toBe('delivered');
   });
 
+  it('listInboxMessages can opt out of PULL delivery for sender preview', () => {
+    const msg = seedMessage();
+    const previewed = adapter.listInboxMessages(
+      { targetSessionId: SESSION_A },
+      { markDelivered: false }
+    );
+
+    expect(previewed).toHaveLength(1);
+    expect(previewed[0]?.state).toBe('queued');
+    expect(store.getInboxMessage(msg.id)?.state).toBe('queued');
+  });
+
   it('listInboxMessages with a limit flips only returned queued rows', () => {
     const first = seedMessage(SESSION_A);
     const second = seedMessage(SESSION_A);
     const third = seedMessage(SESSION_A);
 
-    const listed = adapter.listInboxMessages({ targetSessionId: SESSION_A, limit: 2 });
+    const listed = adapter.listInboxMessages({
+      targetSessionId: SESSION_A,
+      limit: 2,
+    });
 
     expect(listed).toHaveLength(2);
     const listedIds = new Set(listed.map((m) => m.id));
@@ -109,7 +134,9 @@ describe('context-inbox store adapter — PULL-as-delivery flip', () => {
         listedIds.has(message.id) ? 'delivered' : 'queued'
       );
     }
-    expect([first, second, third].filter((m) => !listedIds.has(m.id))).toHaveLength(1);
+    expect(
+      [first, second, third].filter((m) => !listedIds.has(m.id))
+    ).toHaveLength(1);
   });
 
   it('re-fetching a delivered message is idempotent (no-op, timestamp preserved)', () => {
@@ -128,7 +155,9 @@ describe('context-inbox store adapter — PULL-as-delivery flip', () => {
     adapter.updateInboxState(msg.id, 'resolved');
     expect(adapter.getInboxMessage(msg.id)?.state).toBe('resolved');
     // A read of a terminal message leaves it terminal.
-    expect(adapter.listInboxMessages({ targetSessionId: SESSION_A })[0]?.state).toBe('resolved');
+    expect(
+      adapter.listInboxMessages({ targetSessionId: SESSION_A })[0]?.state
+    ).toBe('resolved');
   });
 
   it('only flips messages addressed to the fetched target', () => {
@@ -163,7 +192,8 @@ describe('context-inbox store adapter — throw → result-union remap', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.reason).toBe('terminal');
-      if (result.reason === 'terminal') expect(result.currentState).toBe('resolved');
+      if (result.reason === 'terminal')
+        expect(result.currentState).toBe('resolved');
     }
   });
 

--- a/test/feedback-target.test.ts
+++ b/test/feedback-target.test.ts
@@ -1,0 +1,86 @@
+import { expect, test } from 'vitest';
+
+import {
+  initialFeedbackTarget,
+  resolveFeedbackTarget,
+} from '../frontend/src/lib/feedback-target.js';
+import type { SessionSummary } from '../frontend/src/lib/types.js';
+
+function session(
+  id: string,
+  type: SessionSummary['type'],
+  overrides: Partial<SessionSummary> = {}
+): SessionSummary {
+  return {
+    id,
+    type,
+    agent: type === 'agent' ? 'claude' : 'shell',
+    cwd: '/repo',
+    displayName: id,
+    createdAt: '2026-05-28T00:00:00.000Z',
+    lastActivity: '2026-05-28T00:00:00.000Z',
+    idle: false,
+    ...overrides,
+  };
+}
+
+test('feedback target selection honors a live preferred target and normalizes it', () => {
+  const sessions = [
+    session('terminal-a', 'terminal', { nodeId: 'local' }),
+    session('agent-a', 'agent', { nodeId: 'local' }),
+  ];
+
+  expect(initialFeedbackTarget(sessions, 'terminal-a')).toBe(
+    'local:terminal-a'
+  );
+});
+
+test('feedback target selection ignores stale preferred targets and falls back to the first live agent', () => {
+  const sessions = [
+    session('terminal-a', 'terminal', { nodeId: 'local' }),
+    session('agent-a', 'agent', { nodeId: 'remote' }),
+  ];
+
+  expect(initialFeedbackTarget(sessions, 'local:dead-agent')).toBe(
+    'remote:agent-a'
+  );
+});
+
+test('feedback target revalidation preserves a still-live current target', () => {
+  const sessions = [
+    session('agent-a', 'agent', { nodeId: 'local' }),
+    session('agent-b', 'agent', { nodeId: 'remote' }),
+  ];
+
+  expect(
+    resolveFeedbackTarget(sessions, 'local:agent-a', 'remote:agent-b')
+  ).toBe('remote:agent-b');
+});
+
+test('feedback target revalidation retargets to a live preferred target when the current target disappears', () => {
+  const sessions = [
+    session('terminal-a', 'terminal', { nodeId: 'local' }),
+    session('agent-a', 'agent', { nodeId: 'remote' }),
+  ];
+
+  expect(
+    resolveFeedbackTarget(sessions, 'local:terminal-a', 'local:dead-agent')
+  ).toBe('local:terminal-a');
+});
+
+test('feedback target revalidation retargets to the first agent when the current and preferred targets disappear', () => {
+  const sessions = [
+    session('terminal-a', 'terminal', { nodeId: 'local' }),
+    session('agent-a', 'agent', { nodeId: 'remote' }),
+  ];
+
+  expect(
+    resolveFeedbackTarget(sessions, 'local:dead-agent', 'remote:dead-agent')
+  ).toBe('remote:agent-a');
+});
+
+test('feedback target revalidation clears when no live sessions remain', () => {
+  expect(
+    resolveFeedbackTarget([], 'local:dead-agent', 'remote:also-dead')
+  ).toBe('');
+});

--- a/test/vite-dev-proxy.test.ts
+++ b/test/vite-dev-proxy.test.ts
@@ -15,11 +15,13 @@ describe('Vite dev proxy config', () => {
   });
 
   it('builds the backend target from env overrides', () => {
-    expect(buildBackendProxyTarget({ RELAY_IDE_DEV_BACKEND_PORT: '4567' })).toBe(
-      'http://127.0.0.1:4567'
-    );
     expect(
-      buildBackendProxyTarget({ RELAY_IDE_DEV_BACKEND_URL: 'http://localhost:9999' })
+      buildBackendProxyTarget({ RELAY_IDE_DEV_BACKEND_PORT: '4567' })
+    ).toBe('http://127.0.0.1:4567');
+    expect(
+      buildBackendProxyTarget({
+        RELAY_IDE_DEV_BACKEND_URL: 'http://localhost:9999',
+      })
     ).toBe('http://localhost:9999');
   });
 
@@ -33,6 +35,8 @@ describe('Vite dev proxy config', () => {
     expect(proxy['/ws']?.ws).toBe(true);
     expect(backendProxyPaths).toContain('/auth');
     expect(backendProxyPaths).toContain('/sessions');
+    expect(backendProxyPaths).toContain('/context');
+    expect(backendProxyPaths).toContain('/inbox');
     expect(backendProxyPaths).toContain('/branches');
     expect(backendProxyPaths).toContain('/workspaces');
     expect(backendProxyPaths).toContain('/presets');


### PR DESCRIPTION
## Summary
- Adds a file feedback panel for code/markdown tabs and the review workspace diff pane
- Creates file-anchor context packets and sends them through the session inbox with ack/resolve/ignore controls
- Adds typed frontend context/inbox API wrappers plus API coverage for create/send/review flows

## Test Plan
- npm test -- test/context-feedback-api.test.ts
- npm run check
- npm run build
- git push pre-push changed-tests: 44 files / 291 tests passed
- Browser smoke at http://127.0.0.1:3762/?session=local%3Abeecc0d975661559: opened git diff review workspace, sent line feedback to Terminal 1, refreshed inbox state, resolved the delivered message; JS console had no errors (only xterm WebGPU fallback warnings)

## Notes
- Existing lint warnings remain pre-existing repo-wide warnings; no lint errors.


## Issue linkage
Closes #762
Refs #757


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File feedback panel: select file lines, add notes, preview recent anchors, and send feedback to sessions
  * Inbox system: receive, preview, and update message states (queued → delivered, resolve, ignore)
  * File anchors include content hash, metadata, and quoted lines; feedback integrated into file view and workspace UI

* **Chores**
  * Dev server proxy updated to include inbox/context routes and related routing tweaks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->