### PR TITLE
fix: clarify browser auth UI copy

### DIFF
--- a/frontend/src/components/PinGate.tsx
+++ b/frontend/src/components/PinGate.tsx
@@ -18,7 +18,7 @@ interface SetupFormProps {
 function SetupForm({ pinValue, confirmValue, onPinChange, onConfirmChange, onKeyDown, onSubmit }: SetupFormProps) {
   return (
     <>
-      <p>set up a PIN to secure this instance</p>
+      <p>set a browser PIN for this Relay web UI</p>
       <PinInput value={pinValue} onChange={onPinChange} onKeyDown={onKeyDown} placeholder="choose a PIN" autoFocus={true} maxLength={MAX_PIN_LENGTH} />
       <PinInput value={confirmValue} onChange={onConfirmChange} onKeyDown={onKeyDown} placeholder="confirm PIN" maxLength={MAX_PIN_LENGTH} />
       <TuiButton variant="primary" onClick={onSubmit}>set PIN</TuiButton>
@@ -36,11 +36,11 @@ interface UnlockFormProps {
 function UnlockForm({ pinValue, onPinChange, onKeyDown, onSubmit }: UnlockFormProps) {
   return (
     <>
-      <p>enter PIN to continue</p>
+      <p>enter browser PIN to unlock this web session</p>
       <PinInput value={pinValue} onChange={onPinChange} onKeyDown={onKeyDown} placeholder="PIN" autoFocus={true} maxLength={MAX_PIN_LENGTH} />
       <TuiButton variant="primary" onClick={onSubmit}>unlock</TuiButton>
       <p className="hint">
-        forgot your PIN? run <code>relay-ide pin reset</code> on the host machine
+        forgot your PIN? reset browser access with <code>relay-ide pin reset</code> on this host
       </p>
     </>
   );

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -156,6 +156,79 @@ function httpErrorMessage(status: number, fallback?: string): string {
   return fallback ?? `HTTP ${status}`;
 }
 
+const BROWSER_SESSION_AUTH_MESSAGE =
+  'browser session required; enter the browser PIN for this web UI.';
+const SCOPED_ACTOR_AUTH_MESSAGE =
+  'scoped actor credential required; browser PIN auth only unlocks the web UI.';
+const SCOPED_OR_BROWSER_AUTH_MESSAGE =
+  'scoped actor credential or browser session required for this route.';
+const NODE_CREDENTIAL_AUTH_MESSAGE =
+  'node credential required; browser PIN sessions are not accepted by node routes.';
+const PAIR_TOKEN_AUTH_MESSAGE =
+  'pair token required; browser PIN sessions are not accepted by pairing routes.';
+const CAPABILITY_DENIED_AUTH_MESSAGE =
+  'capability denied; this actor or session is missing the required grant.';
+const APPROVAL_REQUIRED_AUTH_MESSAGE =
+  'approval required before this action can continue.';
+const CREDENTIAL_REVOKED_AUTH_MESSAGE =
+  'credential revoked; re-authorize the relevant actor or node.';
+const CREDENTIAL_EXPIRED_AUTH_MESSAGE =
+  'credential expired; re-authenticate the relevant actor or node.';
+
+const AUTH_LANE_ERROR_MESSAGES: Record<string, string> = {
+  'browser-auth-required': BROWSER_SESSION_AUTH_MESSAGE,
+  'browser-session-required': BROWSER_SESSION_AUTH_MESSAGE,
+  browser_auth_required: BROWSER_SESSION_AUTH_MESSAGE,
+  browser_session_required: BROWSER_SESSION_AUTH_MESSAGE,
+  BROWSER_SESSION_REQUIRED: BROWSER_SESSION_AUTH_MESSAGE,
+
+  'actor-credential-required': SCOPED_ACTOR_AUTH_MESSAGE,
+  'scoped-actor-credential-required': SCOPED_ACTOR_AUTH_MESSAGE,
+  actor_credential_required: SCOPED_ACTOR_AUTH_MESSAGE,
+  scoped_actor_credential_required: SCOPED_ACTOR_AUTH_MESSAGE,
+  'scoped-session-or-browser-auth-required': SCOPED_OR_BROWSER_AUTH_MESSAGE,
+  CLI_GATEWAY_OR_BROWSER_AUTH_REQUIRED: SCOPED_OR_BROWSER_AUTH_MESSAGE,
+  SCOPED_SESSION_OR_BROWSER_AUTH_REQUIRED: SCOPED_OR_BROWSER_AUTH_MESSAGE,
+
+  'node-credential-required': NODE_CREDENTIAL_AUTH_MESSAGE,
+  node_credential_required: NODE_CREDENTIAL_AUTH_MESSAGE,
+  NODE_CREDENTIAL_REQUIRED: NODE_CREDENTIAL_AUTH_MESSAGE,
+
+  'pair-token-required': PAIR_TOKEN_AUTH_MESSAGE,
+  pair_token_required: PAIR_TOKEN_AUTH_MESSAGE,
+  PAIR_TOKEN_REQUIRED: PAIR_TOKEN_AUTH_MESSAGE,
+
+  'capability-denied': CAPABILITY_DENIED_AUTH_MESSAGE,
+  capability_denied: CAPABILITY_DENIED_AUTH_MESSAGE,
+  CAPABILITY_DENIED: CAPABILITY_DENIED_AUTH_MESSAGE,
+
+  'approval-required': APPROVAL_REQUIRED_AUTH_MESSAGE,
+  approval_required: APPROVAL_REQUIRED_AUTH_MESSAGE,
+  APPROVAL_REQUIRED: APPROVAL_REQUIRED_AUTH_MESSAGE,
+
+  'credential-revoked': CREDENTIAL_REVOKED_AUTH_MESSAGE,
+  credential_revoked: CREDENTIAL_REVOKED_AUTH_MESSAGE,
+  CREDENTIAL_REVOKED: CREDENTIAL_REVOKED_AUTH_MESSAGE,
+
+  'credential-expired': CREDENTIAL_EXPIRED_AUTH_MESSAGE,
+  credential_expired: CREDENTIAL_EXPIRED_AUTH_MESSAGE,
+  CREDENTIAL_EXPIRED: CREDENTIAL_EXPIRED_AUTH_MESSAGE,
+};
+
+export function authLaneErrorMessage(
+  code: string | undefined,
+  fallback: string
+): string {
+  if (!code) return fallback;
+  const normalized = code.trim();
+  return (
+    AUTH_LANE_ERROR_MESSAGES[normalized] ??
+    AUTH_LANE_ERROR_MESSAGES[normalized.toLowerCase()] ??
+    AUTH_LANE_ERROR_MESSAGES[normalized.toLowerCase().replace(/_/g, '-')] ??
+    fallback
+  );
+}
+
 export interface BrowseEntry {
   name: string;
   path: string;
@@ -350,7 +423,7 @@ async function httpErrorFromResponse(
       typeof structuredError?.['retryable'] === 'boolean'
         ? structuredError['retryable']
         : undefined;
-    const message =
+    const rawMessage =
       typeof data.message === 'string'
         ? data.message
         : typeof structuredError?.['message'] === 'string'
@@ -358,6 +431,7 @@ async function httpErrorFromResponse(
           : typeof data.error === 'string'
             ? httpErrorMessage(res.status, data.error)
             : httpErrorMessage(res.status, fallback);
+    const message = authLaneErrorMessage(code, rawMessage);
     return new HttpError(res.status, message, code, retryable, details);
   } catch {
     return new HttpError(res.status, httpErrorMessage(res.status, fallback));

--- a/test/auth-lane-errors.test.ts
+++ b/test/auth-lane-errors.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { authLaneErrorMessage } from '../frontend/src/lib/api.js';
+
+describe('authLaneErrorMessage', () => {
+  it('maps browser-session denials to browser PIN copy', () => {
+    expect(authLaneErrorMessage('browser-auth-required', 'fallback')).toBe(
+      'browser session required; enter the browser PIN for this web UI.'
+    );
+    expect(authLaneErrorMessage('BROWSER_SESSION_REQUIRED', 'fallback')).toBe(
+      'browser session required; enter the browser PIN for this web UI.'
+    );
+  });
+
+  it('distinguishes actor, node, pair, capability, and approval denials', () => {
+    expect(authLaneErrorMessage('actor-credential-required', 'fallback')).toContain(
+      'scoped actor credential required'
+    );
+    expect(authLaneErrorMessage('NODE_CREDENTIAL_REQUIRED', 'fallback')).toContain(
+      'node credential required'
+    );
+    expect(authLaneErrorMessage('pair-token-required', 'fallback')).toContain(
+      'pair token required'
+    );
+    expect(authLaneErrorMessage('CAPABILITY_DENIED', 'fallback')).toContain(
+      'capability denied'
+    );
+    expect(authLaneErrorMessage('approval-required', 'fallback')).toContain(
+      'approval required'
+    );
+  });
+
+  it('preserves fallback copy for unknown codes', () => {
+    expect(authLaneErrorMessage('unknown-auth-code', 'server supplied message')).toBe(
+      'server supplied message'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Clarifies PIN gate setup/unlock copy as browser-session auth for the Relay web UI instead of implying global instance/fleet/node security.
- Adds frontend auth-lane denial display copy for browser, actor, node, pair-token, capability, approval, revoked, and expired credential codes without importing backend-only types.
- Adds focused coverage for auth-lane error copy normalization.

Refs #798
Related: #799

## Test plan
- `npm test -- test/auth-lane-errors.test.ts` — 3 passed
- `npm run check` — passed with existing lint warnings only
- `npm run build` — passed; Vite emitted existing large chunk warnings
- `git diff --check` — passed
- Browser smoke: `http://127.0.0.1:4567/` with PIN configured showed unlock copy; no console errors. Same URL with no PIN configured showed setup copy; no console errors.
