### PR TITLE
feat: harden node identity lifecycle

### DIFF
--- a/docs/RELAY_NODE_BOOTSTRAP.md
+++ b/docs/RELAY_NODE_BOOTSTRAP.md
@@ -4,7 +4,7 @@ Operator guide for pairing, installing, updating, diagnosing, and unpairing Rela
 
 Relay uses one npm package for both roles. The packaging decision is documented in [Relay Hub/Node Packaging Decision](RELAY_HUB_NODE_PACKAGING.md): operators install `relay-ide` once, run the web server as `relay-ide hub`, and pair or bootstrap nodes with `relay-ide node ...`. Bare `relay-ide` and top-level `install/status/uninstall` remain back-compat hub aliases.
 
-Relay uses SSH and Tailscale SSH only for bootstrap, reachability checks, diagnostics, and emergency fallback. They are not the steady-state hub-node product API. Pairing and heartbeat bootstrap are handled by `relay-ide node pair` / `relay-ide node install`; the persistent steady-state reverse WebSocket `/hub/node-link` is opened by `relay-ide node link --hub <url>` (foreground), which can be wrapped by your platform service manager. Bootstrap commands (`node pair`, `node install`) themselves do not open or maintain `/hub/node-link`.
+Relay uses SSH and Tailscale SSH only for bootstrap, reachability checks, diagnostics, emergency fallback, and optional host-binding evidence. They are not the steady-state hub-node product API and do not authorize browser, CLI, or routed session actions. Pairing and heartbeat bootstrap are handled by `relay-ide node pair` / `relay-ide node install`; the persistent steady-state reverse WebSocket `/hub/node-link` is opened by `relay-ide node link --hub <url>` (foreground), which can be wrapped by your platform service manager. Bootstrap commands (`node pair`, `node install`) themselves do not open or maintain `/hub/node-link`.
 
 > This document is the runbook. For architecture and protocol details, see `docs/federated-relay.md`. For the generic Relay service install/uninstall (non-node), see `docs/references/deployment.md`.
 
@@ -149,7 +149,24 @@ Format:
 
 This file is required for the node to authenticate heartbeats and the reverse WebSocket. Do not copy it between machines.
 
-### 4. Verify the node appears online
+### 4. Node identity lifecycle
+
+The hub now separates stable node identity from credential records. The stable identity anchor is the `nodeId` and pairing timestamps; operator-facing identity metadata such as `displayName` and `hostname` describes that identity and may be refreshed by later heartbeats. The active credential is replaceable bearer material tied to that identity. `GET /nodes` returns both the identity summary and a redacted credential summary (`credentialId`, `issuedAt`, and state), never the live token or token hash.
+
+| State | What it means | Operator action |
+| --- | --- | --- |
+| Paired | A one-time pair token was exchanged, the hub created a node identity, and the node stored `node-credential.json`. | Start or supervise `relay-ide node link --hub <url>` for routed sessions. |
+| Reconnected | The node proves the stored credential on heartbeat or `/hub/node-link` reconnect. | No browser cookie is involved; the node credential alone authenticates the node lane. |
+| Rotating | An operator-triggered or scheduled rotation has issued a next credential. The hub accepts the previous credential and the next credential until the node proves possession with a heartbeat carrying the next `credentialId`. | Deliver the new credential if manual; let online delivery write it over the active link if available. Do not clear a failed/delivered rotation if the node may already have written the next credential. |
+| Rotated/stable | The node proved the next credential. The hub swaps the active credential, invalidates the previous token, updates the ACL peer credential id, and preserves the same node identity. | Continue normal operation. |
+| Revoked | `DELETE /nodes/{nodeId}` marks the identity revoked, kills active links, and permanently rejects its credential. | Remove `node-credential.json` from the node before disposal or re-pairing. The old `nodeId` remains revoked in hub history. |
+| Re-pair required | The credential is missing, malformed, mismatched with hub state, expired, revoked, protocol-incompatible, or otherwise returns `REPAIR_REQUIRED`. | Generate a new pair token and run `relay-ide node pair`/`connect` again. Re-pairing creates a new node identity; it does not resurrect a revoked identity. |
+
+Browser auth is deliberately not part of node reconnect. A browser PIN/cookie can authorize an operator to create a pair token or initiate rotation/revocation through browser routes, but it is never accepted as a node credential. Conversely, `node-credential.json` cannot log in to browser-only routes.
+
+Redaction rule: logs, diagnostics, node summaries, registry snapshots, audit entries, and issue comments may include `nodeId`, `credentialId`, `rotationId`, lifecycle state, and hashed/redacted scope metadata. They must not include pair tokens, raw node credential tokens, token hashes, browser cookies, or secret-bearing command output.
+
+### 5. Verify the node appears online
 
 On the node, hold the steady-state reverse link:
 

--- a/docs/SECURITY_POLICY.md
+++ b/docs/SECURITY_POLICY.md
@@ -17,7 +17,27 @@ Relay auth is split into lanes. The current route inventory is checked into `ser
 
 The PIN and `token` cookie are therefore browser/UI authentication. They reduce drive-by browser access and support first-load local setup, but they cannot protect Relay from malicious processes already running as the same OS user: those processes can usually read local config, invoke local CLIs, attach to local sockets, or modify the checkout. Relay's federated security model relies on lane separation, node credentials, hub ACLs, capability policy, audit, revocation, and scoped actor credentials for non-browser actors rather than treating the browser PIN as global authorization.
 
-Relay issue `#427` shipped the earlier trust-tier/capability/audit/confirmation backbone. Relay issue `#797` tracks the broader multi-node auth model. Relay issue `#798` wave 1 narrowed that work to route-lane inventory, browser-session terminology, and typed lane denials. Relay issue `#802` adds the scoped actor credential registry MVP; it deliberately does not migrate every CLI gateway command, implement node proof-of-possession, passkeys, TOTP, or new approval UX.
+Relay issue `#427` shipped the earlier trust-tier/capability/audit/confirmation backbone. Relay issue `#797` tracks the broader multi-node auth model. Relay issue `#798` wave 1 narrowed that work to route-lane inventory, browser-session terminology, and typed lane denials. Relay issue `#802` adds the scoped actor credential registry MVP; it deliberately does not migrate every CLI gateway command, implement node proof-of-possession, passkeys, TOTP, or new approval UX. Relay issue `#803` hardens node identity lifecycle semantics by separating stable node identity from replaceable credential records.
+
+## Node identity lifecycle
+
+Node identity is not the same thing as a node credential. The hub registry keeps a stable `nodeId` and identity summary for the node record, while credential records hold replaceable bearer material for heartbeat and `/hub/node-link`. Pairing creates both; reconnect proves the current credential; rotation replaces the credential while preserving the node identity; revocation keeps the identity as revoked and permanently rejects its credential; re-pairing after missing, malformed, mismatched, expired, revoked, or protocol-incompatible credentials creates a new node identity instead of reviving the old one.
+
+The lifecycle states exposed to operators are:
+
+| State | Security meaning |
+| --- | --- |
+| `active` | The node has a valid active credential for heartbeat and `/hub/node-link`. |
+| `rotating` | A next credential exists and is provable, but the old credential remains active until heartbeat proof. |
+| `rotation-failed` | Delivery failed or was marked failed; the previous credential remains active until an operator clears the rotation or retries safely. |
+| `revoked` | The node identity remains in registry history, active links are closed, and the credential is rejected without grace. |
+| re-pair required | Authentication returns typed recovery errors such as `NODE_CREDENTIAL_MISSING`, `NODE_CREDENTIAL_MALFORMED`, `NODE_CREDENTIAL_MISMATCH`, `NODE_CREDENTIAL_EXPIRED`, `NODE_REVOKED`, or `REPAIR_REQUIRED`; the operator must run a fresh pair-token exchange. |
+
+Browser auth is intentionally non-dependent. Browser PIN/cookie auth can authorize operator UI/API routes that mint pair tokens or request rotation/revocation, but it is not accepted by node heartbeat or `/hub/node-link`. Node credentials are likewise not browser, CLI, scoped actor, or human impersonation credentials.
+
+SSH and Tailscale are bootstrap/reachability/binding signals only. They can help deliver install/pair commands, prove that an operator can reach a host, or provide host-binding evidence in diagnostics, but they are not the steady-state Relay application authorization model. Steady-state node authorization comes from the node credential, hub ACL/policy, audit, and revocation.
+
+Node lifecycle audit and diagnostics must stay redacted. It is safe to emit `nodeId`, `credentialId`, `rotationId`, lifecycle state, recovery reason code, and hashed/redacted scope metadata. It is not safe to emit raw pair tokens, raw node credential tokens, token hashes, browser cookies, confirmation tokens, scoped actor bearer material, reverse-link private payloads, full env values, file bytes, or terminal byte streams.
 
 ## Scoped actor credentials
 

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -231,6 +231,8 @@ relay-ide node install \
 
 Both commands exchange the pair token, receive a persistent credential, write `node-credential.json`, and send an initial authenticated heartbeat. `node install` then runs the generic Relay service install path for supported service modes. In the current CLI, neither command opens or maintains the persistent reverse WebSocket; run `relay-ide node link --hub <url>` for steady-state session routing.
 
+SSH and Tailscale are bootstrap and reachability mechanisms here: generated commands may use them to deliver the install/pair step, and future diagnostics may use their host identity as binding evidence, but Relay does not treat SSH or Tailscale login as steady-state application authorization. Once paired, hub-node authorization is carried by the node credential on heartbeat and `/hub/node-link`.
+
 > Bootstrap diagnostics pair credentials and install/start the generic Relay service. The persistent `/hub/node-link` reverse WebSocket is opened by `relay-ide node link --hub <url>` (foreground), which can be wrapped by your platform service manager.
 
 ### Step 3: Credential storage
@@ -261,6 +263,23 @@ relay-ide node link --hub https://hub.example.com
 ```
 
 `node link` reads `node-credential.json`, opens the reverse WebSocket to `/hub/node-link`, sends `control.hello` with manifest + repo inventory, and then emits a `control.heartbeat` every 20s. The hub reports the node `online` while the link is up. The client reconnects with jittered exponential backoff (1s → 60s cap) on transient close, and exits permanently on `NODE_REVOKED`, `UNAUTHORIZED`, or `PROTOCOL_INCOMPATIBLE`. Routed PTY is handled end-to-end: hub `attachPty` → `pty.attach` over the reverse link → node-side `node-pty` spawn → `pty.data` / `pty.input` / `pty.resize` / `pty.detach` round-trip. Node-side RPC method handlers (manifest refresh, repo listing) and file/git RPC remain follow-ups.
+
+### Node identity and credential states
+
+The node registry separates node identity from credentials. `HubNodeSummary.identity` carries the stable `nodeId`, creation/pairing timestamps, and operator-facing name/host metadata that can be refreshed by later heartbeats. `HubNodeSummary.credential` carries the active credential record (`credentialId`, `issuedAt`, state, and optional `rotationId`). Token material is never returned in summaries.
+
+| Lifecycle state | Protocol behavior | Public state |
+| --- | --- | --- |
+| Pair | `POST /hub/pairing/exchange` consumes a one-time pair token and creates a node identity plus the first active credential. | `identity.nodeId` is new; `credential.state` is `active`; status is based on heartbeat freshness. |
+| Reconnect | Heartbeat or `/hub/node-link` presents the node credential. The hub hashes the presented token, checks it with timing-safe comparison against the active credential or a provable rotation credential, and rejects missing/malformed/mismatch/expired/revoked credentials with typed errors. | Same node identity; status moves `online` while the link/heartbeat is fresh. Audit rows use `NODE_CREDENTIAL_RECONNECT_ALLOWED` or a redacted recovery reason. |
+| Rotate | `POST /hub/nodes/:nodeId/credential-rotation` issues a next credential through manual operator delivery or online `credential.rotate`. The previous credential remains valid until the next credential proves possession. | `credential.state` is `rotating` with `credential.rotationId`; `credentialRotation.state` is `issuing`, `delivered`, or `failed`. |
+| Prove/stabilize | A heartbeat carrying the next `credentialId` proves rotation. The hub swaps active credential hashes, updates the ACL peer credential id, deletes the unproved next-token hash, and marks the rotation stable. | Same `identity.nodeId`; `credential.state` returns to `active`; audit emits a redacted `CREDENTIAL_ROTATION_PROVED` rotation event. |
+| Revoke | `DELETE /nodes/:nodeId` marks the registry record revoked, closes active links with `NODE_REVOKED`, and rejects later credential auth. | Same node identity remains visible as `revoked`; `credential.state` is `revoked`; no grace period. |
+| Re-pair | A missing/malformed/mismatched/expired/revoked/protocol-incompatible credential yields a recovery error such as `NODE_CREDENTIAL_MISSING`, `NODE_CREDENTIAL_MALFORMED`, `NODE_CREDENTIAL_MISMATCH`, `NODE_CREDENTIAL_EXPIRED`, `NODE_REVOKED`, or `REPAIR_REQUIRED`. The recovery path is a fresh pair token exchange. | Re-pairing creates a new node identity; it does not re-enable the revoked or mismatched `nodeId`. |
+
+Browser sessions are outside this lifecycle. A browser cookie can authorize an operator route that creates a pair token or starts rotation/revocation, but node heartbeat and `/hub/node-link` only accept node credentials. Node credentials are not accepted by browser-only UI routes or scoped actor/CLI routes.
+
+Redaction invariant: public summaries, audit entries, logs, diagnostics, issue comments, and tests may expose ids (`nodeId`, `credentialId`, `rotationId`) and lifecycle state. They must not expose raw pair tokens, raw node credential tokens, token hashes, browser cookies, or private reverse-link payloads.
 
 ### Credential rotation
 

--- a/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
+++ b/frontend/src/components/dialogs/CustomizeSessionDialog.tsx
@@ -172,6 +172,13 @@ const PICKER_FALLBACK_GENERATED_AT = '1970-01-01T00:00:00.000Z';
 function syntheticLocalNode(selectedAgent: AgentType): HubNodeSummary {
   return {
     nodeId: DEFAULT_LOCAL_NODE_ID,
+    identity: {
+      nodeId: DEFAULT_LOCAL_NODE_ID,
+      displayName: 'local',
+      hostname: 'local',
+      createdAt: '',
+      pairedAt: '',
+    },
     displayName: 'local',
     hostname: 'local',
     platform: 'local',
@@ -186,6 +193,11 @@ function syntheticLocalNode(selectedAgent: AgentType): HubNodeSummary {
       warning: '',
     },
     credentialState: 'active',
+    credential: {
+      credentialId: 'local',
+      issuedAt: '',
+      state: 'active',
+    },
     version: {
       state: 'compatible',
       nodeProtocolVersion: 'local',

--- a/frontend/src/lib/environment-options.ts
+++ b/frontend/src/lib/environment-options.ts
@@ -177,6 +177,13 @@ function baseCapabilitiesFor(
 function syntheticLocalNode(): HubNodeSummary {
   return {
     nodeId: DEFAULT_LOCAL_NODE_ID,
+    identity: {
+      nodeId: DEFAULT_LOCAL_NODE_ID,
+      displayName: 'local',
+      hostname: 'local',
+      createdAt: '',
+      pairedAt: '',
+    },
     displayName: 'local',
     hostname: 'local',
     platform: 'local',
@@ -187,6 +194,11 @@ function syntheticLocalNode(): HubNodeSummary {
     connection: { route: 'local', status: 'connected' },
     trust: { state: 'trusted', level: 'privileged-local-user', warning: '' },
     credentialState: 'active',
+    credential: {
+      credentialId: 'local',
+      issuedAt: '',
+      state: 'active',
+    },
     version: {
       state: 'compatible',
       nodeProtocolVersion: 'local',

--- a/frontend/src/test-customize-session-dialog.tsx
+++ b/frontend/src/test-customize-session-dialog.tsx
@@ -41,6 +41,13 @@ function framework(id: string): FrameworkInfo {
 function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
   return {
     nodeId: 'local',
+    identity: {
+      nodeId: 'local',
+      displayName: 'local mac',
+      hostname: 'local.local',
+      createdAt: '2026-05-12T00:00:00.000Z',
+      pairedAt: '2026-05-12T00:00:00.000Z',
+    },
     displayName: 'local mac',
     hostname: 'local.local',
     homeDir: '/Users/kyle',
@@ -56,6 +63,11 @@ function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
       warning: 'test node is trusted',
     },
     credentialState: 'active',
+    credential: {
+      credentialId: 'cred-local',
+      issuedAt: '2026-05-12T00:00:00.000Z',
+      state: 'active',
+    },
     version: {
       state: 'compatible',
       nodeProtocolVersion: '1.0',

--- a/server/anchor-file-fetcher.ts
+++ b/server/anchor-file-fetcher.ts
@@ -100,6 +100,13 @@ function localCompatibilityNode(): HubNodeSummary {
   const now = new Date().toISOString();
   return {
     nodeId: DEFAULT_LOCAL_NODE_ID,
+    identity: {
+      nodeId: DEFAULT_LOCAL_NODE_ID,
+      displayName: 'Local hub',
+      hostname: 'localhost',
+      createdAt: now,
+      pairedAt: now,
+    },
     displayName: 'Local hub',
     hostname: 'localhost',
     platform: process.platform,
@@ -126,6 +133,11 @@ function localCompatibilityNode(): HubNodeSummary {
       },
     },
     credentialState: 'active',
+    credential: {
+      credentialId: 'local-compatibility',
+      issuedAt: now,
+      state: 'active',
+    },
     version: {
       state: 'compatible',
       nodeProtocolVersion: RELAY_NODE_LINK_PROTOCOL_VERSION,

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -18,6 +18,7 @@ import {
   type HubNodeVersionState,
   type NodeCapabilityManifestSummary,
   type RelayNodeCredential,
+  type RelayNodeCredentialRecordSummary,
   type RelayNodeError,
   type RelayNodeErrorCode,
 } from '../shared/relay-node-protocol.js';
@@ -31,7 +32,11 @@ import {
   summarizeAcl,
   type RelayNodeAcl,
 } from '../shared/security-policy.js';
-import type { SecurityAuditEntryInput } from '../shared/security-audit.js';
+import type {
+  SecurityAuditDecision,
+  SecurityAuditEntryInput,
+  SecurityAuditEventType,
+} from '../shared/security-audit.js';
 
 const logger = createLogger('hub-node-registry');
 const REVERSE_LINK_ROUTE = 'reverse-link' as const;
@@ -60,8 +65,26 @@ interface StoredCredentialRotation {
   failureReason?: string;
 }
 
+interface StoredNodeIdentity {
+  nodeId: string;
+  displayName: string;
+  hostname: string;
+  createdAt: string;
+  pairedAt: string;
+}
+
+interface StoredActiveCredential {
+  credentialId: string;
+  tokenHash: string;
+  issuedAt: string;
+  expiresAt?: string;
+  revokedAt?: string;
+}
+
 interface StoredNodeRecord {
   nodeId: string;
+  identity?: StoredNodeIdentity;
+  activeCredential?: StoredActiveCredential;
   credentialId: string;
   credentialHash: string;
   // Timestamp of the currently-active credential. Set on pair and updated
@@ -355,6 +378,10 @@ function registryNeedsAclMigration(registry: RegistryFile): boolean {
   return registry.nodes.some((node) => nodeNeedsAclMigration(node));
 }
 
+function registryNeedsIdentityMigration(registry: RegistryFile): boolean {
+  return registry.nodes.some((node) => !node.identity || !node.activeCredential);
+}
+
 function readRegistryFile(storagePath: string): RegistryFile {
   try {
     const parsed = JSON.parse(
@@ -480,6 +507,40 @@ function credentialState(node: StoredNodeRecord): HubNodeCredentialState {
   return 'active';
 }
 
+function ensureSeparatedIdentity(node: StoredNodeRecord): StoredNodeIdentity {
+  node.identity ??= {
+    nodeId: node.nodeId,
+    displayName: node.displayName,
+    hostname: node.hostname,
+    createdAt: node.createdAt,
+    pairedAt: node.pairedAt,
+  };
+  return node.identity;
+}
+
+function ensureSeparatedCredential(node: StoredNodeRecord): StoredActiveCredential {
+  node.activeCredential ??= {
+    credentialId: node.credentialId,
+    tokenHash: node.credentialHash,
+    issuedAt: activeCredentialIssuedAt(node),
+    ...(node.revokedAt ? { revokedAt: node.revokedAt } : {}),
+  };
+  return node.activeCredential;
+}
+
+function credentialSummary(node: StoredNodeRecord): RelayNodeCredentialRecordSummary {
+  const credential = ensureSeparatedCredential(node);
+  const state = credentialState(node);
+  return {
+    credentialId: credential.credentialId,
+    issuedAt: credential.issuedAt,
+    state,
+    ...(node.credentialRotation && state === 'rotating'
+      ? { rotationId: node.credentialRotation.rotationId }
+      : {}),
+  };
+}
+
 function activeCredentialIssuedAt(node: StoredNodeRecord): string {
   // Prefer the persisted credentialIssuedAt so the value survives in-flight
   // rotation windows where `credentialRotation` is overwritten before proof.
@@ -555,6 +616,8 @@ function publicNode(
   hubVersion?: string
 ): HubNodeSummary {
   const acl = ensureNodeAcl(node);
+  const identity = ensureSeparatedIdentity(node);
+  const credential = credentialSummary(node);
   const aclSummary = summarizeAcl(acl);
   const rotationSummary = node.credentialRotation
     ? publicRotation(node.credentialRotation)
@@ -579,6 +642,7 @@ function publicNode(
 
   return {
     nodeId: node.nodeId,
+    identity,
     displayName: node.displayName,
     hostname: node.hostname,
     ...(node.homeDir ? { homeDir: node.homeDir } : {}),
@@ -596,7 +660,8 @@ function publicNode(
       warning: PRIVILEGED_NODE_WARNING,
       policy: aclSummary,
     },
-    credentialState: credentialState(node),
+    credentialState: credential.state,
+    credential,
     ...(rotationSummary ? { credentialRotation: rotationSummary } : {}),
     version: {
       state: versionState(node.protocolVersion),
@@ -663,9 +728,15 @@ export class HubNodeRegistry {
     this.hubVersion = options.hubVersion;
     this.state = readRegistryFile(options.storagePath);
     const needsAclMigration = registryNeedsAclMigration(this.state);
-    for (const node of this.state.nodes) ensureNodeAcl(node);
+    const needsIdentityMigration = registryNeedsIdentityMigration(this.state);
+    for (const node of this.state.nodes) {
+      ensureNodeAcl(node);
+      ensureSeparatedIdentity(node);
+      ensureSeparatedCredential(node);
+    }
     this.refreshLastNotifiedStatuses();
-    if (needsAclMigration) writeRegistryFile(this.storagePath, this.state);
+    if (needsAclMigration || needsIdentityMigration)
+      writeRegistryFile(this.storagePath, this.state);
   }
 
   setNowForTest(now: () => Date): void {
@@ -741,14 +812,27 @@ export class HubNodeRegistry {
     const nodeId = randomToken('node');
     const credential = credentialToken(nodeId);
     const timestamp = now.toISOString();
+    const displayName = nodeDisplayName(
+      input.displayName ?? pairToken.displayName,
+      input.manifest
+    );
     const node: StoredNodeRecord = {
       nodeId,
+      identity: {
+        nodeId,
+        displayName,
+        hostname: input.manifest.hostname,
+        createdAt: timestamp,
+        pairedAt: timestamp,
+      },
+      activeCredential: {
+        credentialId: credential.credentialId,
+        tokenHash: credential.hash,
+        issuedAt: timestamp,
+      },
       credentialId: credential.credentialId,
       credentialHash: credential.hash,
-      displayName: nodeDisplayName(
-        input.displayName ?? pairToken.displayName,
-        input.manifest
-      ),
+      displayName,
       hostname: input.manifest.hostname,
       ...(input.manifest.homeDir ? { homeDir: input.manifest.homeDir } : {}),
       platform: input.manifest.platform,
@@ -765,10 +849,7 @@ export class HubNodeRegistry {
       acl: createLegacyDefaultNodeAcl({
         nodeId,
         credentialId: credential.credentialId,
-        displayName: nodeDisplayName(
-          input.displayName ?? pairToken.displayName,
-          input.manifest
-        ),
+        displayName,
         createdAt: timestamp,
       }),
       credentialIssuedAt: timestamp,
@@ -779,6 +860,14 @@ export class HubNodeRegistry {
     pairToken.usedAt = timestamp;
     this.state.nodes.push(node);
     this.persist();
+    this.auditNodeCredentialLifecycle({
+      node,
+      credentialId: credential.credentialId,
+      decision: 'allow',
+      eventType: 'grant',
+      reasonCode: 'NODE_PAIR_ALLOWED',
+      action: 'nodes.pair',
+    });
     this.notifyNodeStatusIfChanged(node, 'online', input.manifest);
     return {
       credential: {
@@ -798,40 +887,151 @@ export class HubNodeRegistry {
     return result.ok ? result.node : null;
   }
 
+  private parseCredentialToken(
+    token: string
+  ):
+    | { ok: true; nodeId: string }
+    | { ok: false; result: CredentialAuthResult } {
+    if (token.length === 0) {
+      return { ok: false, result: this.credentialDenied('NODE_CREDENTIAL_MISSING') };
+    }
+    const firstSeparator = token.indexOf('.');
+    if (
+      firstSeparator <= 0 ||
+      firstSeparator === token.length - 1 ||
+      token.indexOf('.', firstSeparator + 1) !== -1
+    ) {
+      return { ok: false, result: this.credentialDenied('NODE_CREDENTIAL_MALFORMED') };
+    }
+    const nodeId = token.slice(0, firstSeparator);
+    if (!nodeId.startsWith('node_')) {
+      return { ok: false, result: this.credentialDenied('NODE_CREDENTIAL_MALFORMED') };
+    }
+    return { ok: true, nodeId };
+  }
+
+  private credentialDenied(
+    code: RelayNodeErrorCode,
+    node?: StoredNodeRecord,
+    nodeId?: string
+  ): CredentialAuthResult {
+    const error = this.credentialError(code);
+    this.auditNodeCredentialLifecycle({
+      ...(node ? { node } : {}),
+      ...(nodeId ? { nodeId } : {}),
+      decision: code === 'NODE_CREDENTIAL_EXPIRED' ? 'expired' : 'deny',
+      eventType: code === 'NODE_CREDENTIAL_EXPIRED' ? 'expiry' : 'denial',
+      reasonCode: code,
+    });
+    return { ok: false, error };
+  }
+
+  private credentialError(code: RelayNodeErrorCode): RelayNodeError {
+    const messages: Partial<Record<RelayNodeErrorCode, string>> = {
+      NODE_CREDENTIAL_MISSING: 'node credential is missing; re-pair this node',
+      NODE_CREDENTIAL_MALFORMED:
+        'node credential is malformed; re-pair this node',
+      NODE_CREDENTIAL_MISMATCH:
+        'node credential does not match the stable node identity',
+      NODE_CREDENTIAL_EXPIRED: 'node credential expired; rotate or re-pair',
+      NODE_REVOKED: 'node credential was revoked',
+      REPAIR_REQUIRED: 'node credential no longer matches hub state; re-pair required',
+    };
+    return {
+      code,
+      message: messages[code] ?? 'invalid node credential',
+      retryable: false,
+      details: { reasonCode: code },
+    };
+  }
+
+  private auditNodeCredentialLifecycle(input: {
+    node?: StoredNodeRecord;
+    nodeId?: string;
+    credentialId?: string;
+    decision: SecurityAuditDecision;
+    eventType: SecurityAuditEventType;
+    reasonCode: string;
+    action?: string;
+  }): void {
+    if (!this.auditSink) return;
+    const nodeId = input.node?.nodeId ?? input.nodeId;
+    try {
+      this.auditSink.append({
+        eventType: input.eventType,
+        decision: input.decision,
+        reasonCode: input.reasonCode,
+        peer: {
+          kind: 'node',
+          ...(nodeId ? { nodeId } : {}),
+          ...(input.credentialId ? { credentialId: input.credentialId } : {}),
+        },
+        node: { ...(nodeId ? { nodeId } : {}) },
+        intent: {
+          action: input.action ?? 'nodes.credential.authenticate',
+          ...(nodeId ? { target: nodeId } : {}),
+        },
+        material: {
+          params: {
+            recoveryReason: input.reasonCode,
+            hasCredentialId: Boolean(input.credentialId),
+          },
+        },
+      });
+    } catch {
+      // Best-effort lifecycle visibility only. Authentication remains
+      // fail-closed/allow-closed on the credential decision itself; audit
+      // failures must not cause raw bearer material to be retried or logged.
+    }
+  }
+
   authenticateCredentialDetailed(token: string): CredentialAuthResult {
-    const tokenHash = sha256(token);
-    const [nodeId] = token.split('.', 1);
+    const trimmedToken = token.trim();
+    const parsed = this.parseCredentialToken(trimmedToken);
+    if (parsed.ok === false) return parsed.result;
+    const { nodeId } = parsed;
+    const tokenHash = sha256(trimmedToken);
     const node = this.state.nodes.find(
       (candidate) => candidate.nodeId === nodeId
     );
     const rotation = node ? provableRotation(node) : undefined;
-    const matchesActive = node
-      ? timingSafeEqualHex(node.credentialHash, tokenHash)
+    const activeCredential = node ? ensureSeparatedCredential(node) : undefined;
+    const matchesActive = activeCredential
+      ? timingSafeEqualHex(activeCredential.tokenHash, tokenHash)
       : false;
     const matchesRotation =
       node &&
       rotation?.nextCredentialHash &&
       timingSafeEqualHex(rotation.nextCredentialHash, tokenHash);
     if (!node || (!matchesActive && !matchesRotation)) {
-      return {
-        ok: false,
-        error: {
-          code: 'UNAUTHORIZED',
-          message: 'invalid node credential',
-          retryable: false,
-        },
-      };
+      const code: RelayNodeErrorCode = !node
+        ? 'REPAIR_REQUIRED'
+        : node.credentialRotation?.state === 'stable'
+          ? 'REPAIR_REQUIRED'
+          : 'NODE_CREDENTIAL_MISMATCH';
+      return this.credentialDenied(code, node, nodeId);
+    }
+    if (activeCredential?.expiresAt) {
+      const expiresAt = Date.parse(activeCredential.expiresAt);
+      if (Number.isFinite(expiresAt) && expiresAt <= this.now().getTime()) {
+        return this.credentialDenied('NODE_CREDENTIAL_EXPIRED', node, nodeId);
+      }
     }
     if (node.revokedAt) {
-      return {
-        ok: false,
-        error: {
-          code: 'NODE_REVOKED',
-          message: 'node credential was revoked',
-          retryable: false,
-        },
-      };
+      return this.credentialDenied('NODE_REVOKED', node, nodeId);
     }
+    const credentialId = matchesRotation
+      ? rotation!.nextCredentialId
+      : node.credentialId;
+    this.auditNodeCredentialLifecycle({
+      node,
+      credentialId,
+      decision: 'allow',
+      eventType: 'grant',
+      reasonCode: matchesRotation
+        ? 'NODE_CREDENTIAL_ROTATION_RECONNECT_ALLOWED'
+        : 'NODE_CREDENTIAL_RECONNECT_ALLOWED',
+    });
     return {
       ok: true,
       node: publicNode(
@@ -839,9 +1039,7 @@ export class HubNodeRegistry {
         statusForNode(node, this.now(), this.staleMs, this.offlineMs),
         this.hubVersion
       ),
-      credentialId: matchesRotation
-        ? rotation!.nextCredentialId
-        : node.credentialId,
+      credentialId,
       ...(matchesRotation ? { rotationId: rotation!.rotationId } : {}),
     };
   }
@@ -870,6 +1068,8 @@ export class HubNodeRegistry {
     node.protocolVersion = input.protocolVersion;
     if (input.manifest) {
       node.hostname = input.manifest.hostname;
+      const identity = ensureSeparatedIdentity(node);
+      node.identity = { ...identity, hostname: input.manifest.hostname };
       if (input.manifest.homeDir) node.homeDir = input.manifest.homeDir;
       else delete node.homeDir;
       node.platform = input.manifest.platform;
@@ -1067,6 +1267,11 @@ export class HubNodeRegistry {
     node.credentialHash = rotation.nextCredentialHash;
     node.credentialIssuedAt = now;
     updateAclCredential(node, rotation.nextCredentialId, now);
+    node.activeCredential = {
+      credentialId: rotation.nextCredentialId,
+      tokenHash: rotation.nextCredentialHash,
+      issuedAt: now,
+    };
     delete rotation.nextCredentialHash;
     rotation.state = 'stable';
     rotation.stableAt = now;
@@ -1188,7 +1393,19 @@ export class HubNodeRegistry {
     const alreadyRevoked = Boolean(node.revokedAt);
     if (!alreadyRevoked) {
       node.revokedAt = this.now().toISOString();
+      node.activeCredential = {
+        ...ensureSeparatedCredential(node),
+        revokedAt: node.revokedAt,
+      };
       this.persist();
+      this.auditNodeCredentialLifecycle({
+        node,
+        credentialId: node.credentialId,
+        decision: 'revoked',
+        eventType: 'revocation',
+        reasonCode: 'NODE_CREDENTIAL_REVOKED',
+        action: 'nodes.revoke',
+      });
       this.notifyNodeStatusIfChanged(node, 'revoked');
     }
     return publicNode(node, 'revoked', this.hubVersion);

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -211,6 +211,9 @@ function controlSummaryFieldsOk(session: Partial<SessionSummary>): boolean {
 export function errorStatus(error: RelayNodeError): number {
   switch (error.code) {
     case 'UNAUTHORIZED':
+    case 'NODE_CREDENTIAL_MISSING':
+    case 'NODE_CREDENTIAL_MALFORMED':
+    case 'NODE_CREDENTIAL_MISMATCH':
       return 401;
     case 'ROTATION_IN_PROGRESS':
     case 'CONFIRMATION_REQUIRED':
@@ -224,6 +227,8 @@ export function errorStatus(error: RelayNodeError): number {
       return 400;
     case 'UNSUPPORTED_CAPABILITY':
     case 'NODE_REVOKED':
+    case 'NODE_CREDENTIAL_EXPIRED':
+    case 'REPAIR_REQUIRED':
     case 'SESSION_EXPIRED':
     case 'SESSION_REVOKED':
     case 'SESSION_MISMATCH':
@@ -2001,16 +2006,7 @@ export function createHubNodeRouter(
     const token = bearerToken(req);
     const authenticated = token
       ? registry.authenticateCredentialDetailed(token)
-      : null;
-    if (!authenticated) {
-      const error = {
-        code: 'UNAUTHORIZED' as const,
-        message: 'invalid node credential',
-        retryable: false,
-      };
-      res.status(errorStatus(error)).json({ error });
-      return;
-    }
+      : registry.authenticateCredentialDetailed('');
     if (authenticated.ok === false) {
       const { error } = authenticated;
       res.status(errorStatus(error)).json({ error });

--- a/shared/relay-node-protocol.ts
+++ b/shared/relay-node-protocol.ts
@@ -13,6 +13,11 @@ export type RelayNodeErrorCode =
   | 'UNAUTHORIZED'
   | 'FORBIDDEN'
   | 'CONFIRMATION_REQUIRED'
+  | 'NODE_CREDENTIAL_MISSING'
+  | 'NODE_CREDENTIAL_MALFORMED'
+  | 'NODE_CREDENTIAL_MISMATCH'
+  | 'NODE_CREDENTIAL_EXPIRED'
+  | 'REPAIR_REQUIRED'
   | 'TOKEN_EXPIRED'
   | 'TOKEN_ALREADY_USED'
   | 'NODE_REVOKED'
@@ -58,6 +63,31 @@ export interface RelayNodeCredential {
   credentialId: string;
   token: string;
   issuedAt: string;
+}
+
+export type RelayNodeCredentialRecoveryReason =
+  | 'NODE_CREDENTIAL_MISSING'
+  | 'NODE_CREDENTIAL_MALFORMED'
+  | 'NODE_CREDENTIAL_MISMATCH'
+  | 'NODE_CREDENTIAL_EXPIRED'
+  | 'NODE_REVOKED'
+  | 'VERSION_SKEW'
+  | 'PROTOCOL_INCOMPATIBLE'
+  | 'REPAIR_REQUIRED';
+
+export interface RelayNodeIdentitySummary {
+  nodeId: string;
+  displayName: string;
+  hostname: string;
+  createdAt: string;
+  pairedAt: string;
+}
+
+export interface RelayNodeCredentialRecordSummary {
+  credentialId: string;
+  issuedAt: string;
+  state: HubNodeCredentialState;
+  rotationId?: string;
 }
 
 export type HubNodeStatus =
@@ -177,6 +207,7 @@ export interface NodeCapabilityManifestSummary {
 
 export interface HubNodeSummary {
   nodeId: string;
+  identity: RelayNodeIdentitySummary;
   displayName: string;
   hostname: string;
   homeDir?: string;
@@ -199,6 +230,7 @@ export interface HubNodeSummary {
     policy?: RelayAclSummary;
   };
   credentialState: HubNodeCredentialState;
+  credential: RelayNodeCredentialRecordSummary;
   credentialRotation?: HubNodeCredentialRotationSummary;
   version: {
     state: HubNodeVersionState;

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -286,6 +286,16 @@ describe('hub node registry', () => {
         new RegExp(`^${exchanged.node.nodeId}\\.`)
       );
       expect(exchanged.node).toMatchObject({
+        identity: {
+          nodeId: exchanged.node.nodeId,
+          displayName: 'Dev Mac',
+          pairedAt: '2026-01-02T03:04:05.000Z',
+        },
+        credential: {
+          credentialId: exchanged.credential.credentialId,
+          issuedAt: '2026-01-02T03:04:05.000Z',
+          state: 'active',
+        },
         displayName: 'Dev Mac',
         hostname: 'test-host',
         homeDir: '/Users/dev',
@@ -337,8 +347,26 @@ describe('hub node registry', () => {
         exchanged.credential.token.split('.')[1]!
       );
       const parsed = JSON.parse(persisted) as {
-        nodes: Array<{ acl?: { grants?: { allowed?: string[] } } }>;
+        nodes: Array<{
+          identity?: { nodeId?: string; displayName?: string; pairedAt?: string };
+          activeCredential?: {
+            credentialId?: string;
+            tokenHash?: string;
+            issuedAt?: string;
+          };
+          acl?: { grants?: { allowed?: string[] } };
+        }>;
       };
+      expect(parsed.nodes[0]?.identity).toMatchObject({
+        nodeId: exchanged.node.nodeId,
+        displayName: 'Dev Mac',
+        pairedAt: '2026-01-02T03:04:05.000Z',
+      });
+      expect(parsed.nodes[0]?.activeCredential).toMatchObject({
+        credentialId: exchanged.credential.credentialId,
+        tokenHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        issuedAt: '2026-01-02T03:04:05.000Z',
+      });
       expect(parsed.nodes[0]?.acl?.grants?.allowed).toEqual(
         expect.arrayContaining(['session:read', 'rpc:fs:read'])
       );
@@ -876,6 +904,111 @@ describe('hub node registry', () => {
     });
   });
 
+  it('classifies node credential recovery failures without leaking credential material', () => {
+    const auditEntries: SecurityAuditEntryInput[] = [];
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-hub-node-registry-')
+    );
+    try {
+      const registry = createHubNodeRegistry({
+        storagePath: path.join(tmpDir, 'nodes.json'),
+        now: () => new Date('2026-01-02T03:04:05.000Z'),
+        auditSink: { append: (entry) => auditEntries.push(entry) },
+      });
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+
+      expect(registry.authenticateCredentialDetailed('')).toMatchObject({
+        ok: false,
+        error: {
+          code: 'NODE_CREDENTIAL_MISSING',
+          details: { reasonCode: 'NODE_CREDENTIAL_MISSING' },
+        },
+      });
+      expect(
+        registry.authenticateCredentialDetailed('not-a-relay-node-token')
+      ).toMatchObject({
+        ok: false,
+        error: {
+          code: 'NODE_CREDENTIAL_MALFORMED',
+          details: { reasonCode: 'NODE_CREDENTIAL_MALFORMED' },
+        },
+      });
+      expect(
+        registry.authenticateCredentialDetailed(`${exchanged.node.nodeId}.wrong-secret`)
+      ).toMatchObject({
+        ok: false,
+        error: {
+          code: 'NODE_CREDENTIAL_MISMATCH',
+          details: { reasonCode: 'NODE_CREDENTIAL_MISMATCH' },
+        },
+      });
+
+      registry.revokeNode(exchanged.node.nodeId);
+      expect(
+        registry.authenticateCredentialDetailed(exchanged.credential.token)
+      ).toMatchObject({
+        ok: false,
+        error: {
+          code: 'NODE_REVOKED',
+          details: { reasonCode: 'NODE_REVOKED' },
+        },
+      });
+
+      const serializedAudit = JSON.stringify(auditEntries);
+      expect(serializedAudit).toContain('NODE_CREDENTIAL_MISSING');
+      expect(serializedAudit).toContain('NODE_CREDENTIAL_MALFORMED');
+      expect(serializedAudit).toContain('NODE_CREDENTIAL_MISMATCH');
+      expect(serializedAudit).toContain('NODE_REVOKED');
+      expect(serializedAudit).not.toContain(exchanged.credential.token);
+      expect(serializedAudit).not.toContain(exchanged.credential.token.split('.')[1]!);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps stable node identity while rotating credential records', () => {
+    withTmpRegistry((registry) => {
+      const exchanged = registry.exchangePairToken({
+        pairToken: registry.createPairToken({}).pairToken,
+        manifest: manifest(),
+      });
+      const rotation = registry.beginCredentialRotation(exchanged.node.nodeId);
+      const beforeProof = registry.listNodes()[0];
+
+      expect(rotation.node.identity).toMatchObject(exchanged.node.identity);
+      expect(rotation.node.credential).toMatchObject({
+        credentialId: exchanged.credential.credentialId,
+        state: 'rotating',
+      });
+      expect(beforeProof?.identity).toMatchObject(exchanged.node.identity);
+
+      const proved = registry.recordHeartbeat({
+        nodeId: exchanged.node.nodeId,
+        protocolVersion: '1.0',
+        credentialId: rotation.credential.credentialId,
+        manifest: manifest(),
+      });
+
+      expect(proved.identity).toMatchObject(exchanged.node.identity);
+      expect(proved.credential).toMatchObject({
+        credentialId: rotation.credential.credentialId,
+        state: 'active',
+      });
+      expect(
+        registry.authenticateCredentialDetailed(exchanged.credential.token)
+      ).toMatchObject({
+        ok: false,
+        error: {
+          code: 'REPAIR_REQUIRED',
+          details: { reasonCode: 'REPAIR_REQUIRED' },
+        },
+      });
+    });
+  });
+
   it('rotates node credentials without invalidating the previous token until proof', () => {
     const auditEntries: SecurityAuditEntryInput[] = [];
     const tmpDir = fs.mkdtempSync(
@@ -953,8 +1086,11 @@ describe('hub node registry', () => {
         credentialId: rotation.credential.credentialId,
         credentialState: 'active',
       });
-      expect(auditEntries).toHaveLength(1);
-      expect(auditEntries[0]).toMatchObject({
+      const rotationAuditEntries = auditEntries.filter(
+        (entry) => entry.reasonCode === 'CREDENTIAL_ROTATION_PROVED'
+      );
+      expect(rotationAuditEntries).toHaveLength(1);
+      expect(rotationAuditEntries[0]).toMatchObject({
         eventType: 'rotation',
         decision: 'rotated',
         reasonCode: 'CREDENTIAL_ROTATION_PROVED',

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -438,7 +438,10 @@ describe('hub node routes and link', () => {
     );
     expect(browserSessionOnlyHeartbeatRes.status).toBe(401);
     expect(await browserSessionOnlyHeartbeatRes.json()).toMatchObject({
-      error: { code: 'UNAUTHORIZED', message: 'invalid node credential' },
+      error: {
+        code: 'NODE_CREDENTIAL_MISSING',
+        details: { reasonCode: 'NODE_CREDENTIAL_MISSING' },
+      },
     });
 
     const pairTokenAsNodeCredentialRes = await fetch(
@@ -457,7 +460,10 @@ describe('hub node routes and link', () => {
     );
     expect(pairTokenAsNodeCredentialRes.status).toBe(401);
     expect(await pairTokenAsNodeCredentialRes.json()).toMatchObject({
-      error: { code: 'UNAUTHORIZED', message: 'invalid node credential' },
+      error: {
+        code: 'NODE_CREDENTIAL_MALFORMED',
+        details: { reasonCode: 'NODE_CREDENTIAL_MALFORMED' },
+      },
     });
 
     const malformedHeartbeatRes = await fetch(`${base}/hub/node-heartbeat`, {


### PR DESCRIPTION
## Summary
- separates stable node identity from credential records in node summaries and persisted registry normalization
- hardens node credential auth into typed missing/malformed/mismatch/revoked/expired/re-pair-required recovery errors
- preserves node identity across credential rotation, updates active credential records on proof/revoke, and emits redacted lifecycle audit entries
- updates local compatibility/frontend synthetic node summaries for the new identity/credential contract
- documents the pair/reconnect/rotate/revoke/re-pair lifecycle, browser auth boundary, redaction rules, and SSH/Tailscale bootstrap role

## Test Plan
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/hub-node-registry.test.ts test/hub-node-routes.test.ts test/customize-session-dialog.test.ts` (79 passed)
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check` (pass; existing lint warnings only)
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run build` (pass)
- `git diff --check` (pass)
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test` (4028/4029 passed; baseline/environment failure in `test/fs-browse.test.ts` default home-directory assertion because returned entries were empty)

Closes #803
