### PR TITLE
feat: add scoped actor CLI gateway credentials

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -373,6 +373,21 @@ function parseGatewayInputObject(
   return {};
 }
 
+const CLI_GATEWAY_ACTOR_TOKEN_COMMANDS = new Set<RelayCliGatewayCommand>([
+  'nodes.list',
+  'sessions.list',
+  'sessions.get',
+  'work-contexts.get',
+]);
+
+function gatewayActorToken(): string {
+  return getArg('--actor-token') ?? process.env['RELAY_IDE_ACTOR_TOKEN'] ?? '';
+}
+
+function gatewayCorrelationId(): string | undefined {
+  return getArg('--correlation-id') ?? process.env['RELAY_IDE_CORRELATION_ID'];
+}
+
 async function gatewayHttpJson(input: {
   commandName: RelayCliGatewayCommand;
   pathName: string;
@@ -380,13 +395,23 @@ async function gatewayHttpJson(input: {
   body?: unknown;
   capabilities?: readonly string[];
 }): Promise<unknown> {
-  const token = process.env['RELAY_IDE_BROWSER_TOKEN'] ?? '';
+  const actorToken = gatewayActorToken();
+  if (actorToken && !CLI_GATEWAY_ACTOR_TOKEN_COMMANDS.has(input.commandName)) {
+    gatewayInvalid(
+      input.commandName,
+      '--actor-token is only supported for read-only CLI gateway commands in this slice',
+      {
+        allowedCommands: Array.from(CLI_GATEWAY_ACTOR_TOKEN_COMMANDS),
+      }
+    );
+  }
+  const token = actorToken || (process.env['RELAY_IDE_BROWSER_TOKEN'] ?? '');
   if (!token) {
     printGatewayEnvelope(
       gatewayError(input.commandName, {
         code: 'UNAUTHORIZED',
         message:
-          'RELAY_IDE_BROWSER_TOKEN not set. Run from an authenticated Relay session or set a scoped API token.',
+          'RELAY_IDE_ACTOR_TOKEN/--actor-token or RELAY_IDE_BROWSER_TOKEN not set. Use a scoped CLI actor credential for the actor lane or run from an authenticated Relay session.',
         retryable: false,
       }),
       1
@@ -399,6 +424,12 @@ async function gatewayHttpJson(input: {
     Authorization: `Bearer ${token}`,
     'x-relay-cli-gateway': 'v1',
   };
+  if (actorToken) {
+    headers['x-relay-cli-actor-token'] = 'v1';
+    headers['x-relay-cli-command'] = input.commandName;
+  }
+  const correlationId = gatewayCorrelationId();
+  if (correlationId) headers['x-relay-correlation-id'] = correlationId;
   if (input.body !== undefined) headers['Content-Type'] = 'application/json';
   if (input.capabilities?.length) {
     headers['x-relay-capabilities'] = input.capabilities.join(',');

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -107,11 +107,12 @@ Local discovery commands (`contract.*`, `nodes.manifest`) do not require a hub t
 
 Hub-backed commands (`nodes.list`, `sessions.*`, `files.*`, `work-contexts.*`, `context.*`, `inbox.*`, `handoffs.*`, `artifacts.*`, `supervisor.*`, and `events.*`) are in the CLI/agent lane, which is distinct from node credentials and the browser-only UI lane:
 
-- Current local/dev callers use `RELAY_IDE_BROWSER_TOKEN` to send the same browser-session bearer token the existing CLI session commands already use.
+- Read-only inventory commands (`nodes.list`, `sessions.list`, `sessions.get`, and `work-contexts.get`) can use scoped actor credentials for the `relay:cli-gateway:v1` audience. Pass them with `--actor-token` or `RELAY_IDE_ACTOR_TOKEN`; the CLI sends the token as bearer auth with `x-relay-cli-actor-token: v1` and `x-relay-cli-command`.
+- Browser-session bearer compatibility remains for other local/dev gateway calls through `RELAY_IDE_BROWSER_TOKEN` while the remaining command slices migrate.
 - `--port` or `RELAY_IDE_PORT` selects the local hub port; otherwise Relay uses the default port.
 - Gateway requests send `x-relay-cli-gateway: v1` so the hub can apply the adapter contract boundary.
 - Gateway requests send capability hints via `x-relay-capabilities` so hub policy can fail closed.
-- #802 defines the scoped actor credential registry and the future `relay:cli-gateway:v1` audience for adapter/agent credentials. This document still describes the pre-migration gateway commands: browser-session compatibility remains for local/dev gateway calls until a later slice wires those commands to scoped actor credentials.
+- #802 defines the scoped actor credential registry. #805 wires the first CLI gateway scoped credential lane for read-only inventory commands without accepting browser cookies or node credentials on that lane.
 - Node credentials are not accepted for CLI gateway calls. `/hub/node-link` and node heartbeat use the `node-credential` lane; adapter authors must not impersonate nodes or call private node-link messages.
 - Token material must stay out of logs, issues, diagnostics, JSON envelopes, and screenshots. Use credential ids, jtis, correlation ids, hashes, and redacted summaries when reporting gateway auth failures or migration evidence.
 

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -18,6 +18,7 @@ relay-ide v1 files list --session-id <session-id> --path <path> --json
 relay-ide v1 files stat --session-id <session-id> --path <path> --json
 relay-ide v1 files read --session-id <session-id> --path <path> --max-bytes 32768 --max-lines 2000 --json
 relay-ide v1 files write --session-id <session-id> --path <path> --mode <create|overwrite|append> --file <local-path|-> --json
+relay-ide v1 work-contexts get --id <work-context-id> --json
 relay-ide v1 context create --input-json '{...}' --json
 relay-ide v1 context get --id <context-packet-id> --json
 relay-ide v1 context list [--work-context-id <work-context-id>] --json
@@ -105,18 +106,103 @@ The Command Center may search and describe stable gateway commands using the sha
 
 Local discovery commands (`contract.*`, `nodes.manifest`) do not require a hub token.
 
-Hub-backed commands (`nodes.list`, `sessions.*`, `files.*`, `work-contexts.*`, `context.*`, `inbox.*`, `handoffs.*`, `artifacts.*`, `supervisor.*`, and `events.*`) are in the CLI/agent lane, which is distinct from node credentials and the browser-only UI lane:
+Hub-backed commands (`nodes.list`, `sessions.*`, `files.*`, `work-contexts.*`, `context.*`, `inbox.*`, `handoffs.*`, `artifacts.*`, `supervisor.*`, and `events.*`) are in the CLI/agent lane, which is distinct from node credentials and the browser-only UI lane. #802 defines the scoped actor credential registry; #805 wires the first CLI gateway scoped credential lane.
 
-- Read-only inventory commands (`nodes.list`, `sessions.list`, `sessions.get`, and `work-contexts.get`) can use scoped actor credentials for the `relay:cli-gateway:v1` audience. Pass them with `--actor-token` or `RELAY_IDE_ACTOR_TOKEN`; the CLI sends the token as bearer auth with `x-relay-cli-actor-token: v1` and `x-relay-cli-command`.
-- Browser-session bearer compatibility remains for other local/dev gateway calls through `RELAY_IDE_BROWSER_TOKEN` while the remaining command slices migrate.
-- `--port` or `RELAY_IDE_PORT` selects the local hub port; otherwise Relay uses the default port.
-- Gateway requests send `x-relay-cli-gateway: v1` so the hub can apply the adapter contract boundary.
-- Gateway requests send capability hints via `x-relay-capabilities` so hub policy can fail closed.
-- #802 defines the scoped actor credential registry. #805 wires the first CLI gateway scoped credential lane for read-only inventory commands without accepting browser cookies or node credentials on that lane.
-- Node credentials are not accepted for CLI gateway calls. `/hub/node-link` and node heartbeat use the `node-credential` lane; adapter authors must not impersonate nodes or call private node-link messages.
-- Token material must stay out of logs, issues, diagnostics, JSON envelopes, and screenshots. Use credential ids, jtis, correlation ids, hashes, and redacted summaries when reporting gateway auth failures or migration evidence.
+### Scoped actor credential MVP (#805)
 
-Missing or rejected gateway auth is converted to the normal JSON error envelope and exits nonzero. The server-side lane challenge includes `lane: "denied"`, accepted lanes (`scoped-actor-credential`, `browser-session`), and non-secret migration metadata where applicable.
+The first scoped actor credential slice supports only this read-only hub-backed set:
+
+| CLI command                                       | Stable command id   | Required capability | Notes                                                                                               |
+| ------------------------------------------------- | ------------------- | ------------------- | --------------------------------------------------------------------------------------------------- |
+| `relay-ide v1 nodes list --json`                  | `nodes.list`        | `session:read`      | Reads summarized hub/node inventory.                                                                |
+| `relay-ide v1 sessions list --json`               | `sessions.list`     | `session:read`      | Reads session descriptors and control summaries.                                                    |
+| `relay-ide v1 sessions get --id <id> --json`      | `sessions.get`      | `session:read`      | Validates the credential against the requested session/global session id when scoped that narrowly. |
+| `relay-ide v1 work-contexts get --id <id> --json` | `work-contexts.get` | `session:read`      | Validates work-context scope when the credential is scoped to a work context.                       |
+
+Pass the credential with `--actor-token` or `RELAY_IDE_ACTOR_TOKEN`; `--actor-token` wins when both are present. `--correlation-id` or `RELAY_IDE_CORRELATION_ID` may be supplied for audit correlation. The CLI sends actor credentials as bearer auth with `x-relay-cli-gateway: v1`, `x-relay-cli-actor-token: v1`, `x-relay-cli-command`, and capability hints in `x-relay-capabilities`.
+
+Examples:
+
+```bash
+relay-ide v1 nodes list --actor-token "$RELAY_IDE_ACTOR_TOKEN" --json
+RELAY_IDE_ACTOR_TOKEN="$token" relay-ide v1 sessions list --json
+relay-ide v1 sessions get --id <session-id-or-global-id> --actor-token "$token" --correlation-id cli-smoke-1 --json
+relay-ide v1 work-contexts get --id <work-context-id> --actor-token "$token" --json
+```
+
+Local discovery commands (`relay-ide v1 --list --json`, `relay-ide v1 schema --json`, and `relay-ide v1 nodes manifest --json`) remain unauthenticated. Browser-session bearer compatibility remains for legacy local/dev gateway invocations through `RELAY_IDE_BROWSER_TOKEN`; that path is separate from the actor-token lane and must not be described as a scoped actor credential. When an invocation presents `--actor-token` or `RELAY_IDE_ACTOR_TOKEN`, the actor-token lane does not fall back to browser cookies/PIN state or node credentials. `--port` or `RELAY_IDE_PORT` selects the local hub port; otherwise Relay uses the default port.
+
+### Mint, use, revoke, and rotate
+
+The current MVP exposes credential lifecycle through hub operator endpoints, not through stable `relay-ide v1` adapter commands. Mint/list/revoke requests require the existing hub operator auth path, or `NO_PIN=1` in local dev. That operator auth authorizes issuing a delegated credential; the resulting actor token is not a browser login, is not a node credential, and does not pair a node.
+
+Mint a short-lived CLI actor token:
+
+```bash
+curl -sS -X POST http://127.0.0.1:3456/cli-gateway/actor-credentials \
+  -H 'Content-Type: application/json' \
+  -b 'token=<operator-browser-session-cookie>' \
+  -d '{
+    "actor": { "type": "cli", "id": "relay-cli" },
+    "issuer": { "id": "operator" },
+    "ttlMs": 300000,
+    "scope": { "taskRefs": ["relay:cli-gateway:v1:read"] },
+    "correlationId": "cli-actor-mint-1"
+  }'
+```
+
+The response includes `token` once and a public `credential` record. Store the token in the calling process or a secret manager; do not paste it into issues, logs, screenshots, or test snapshots. Use the returned `credential.id` for list/revoke/audit references.
+
+List public credential records:
+
+```bash
+curl -sS http://127.0.0.1:3456/cli-gateway/actor-credentials \
+  -b 'token=<operator-browser-session-cookie>'
+```
+
+Revoke by credential id:
+
+```bash
+curl -sS -X DELETE http://127.0.0.1:3456/cli-gateway/actor-credentials/<credential-id> \
+  -H 'Content-Type: application/json' \
+  -b 'token=<operator-browser-session-cookie>' \
+  -d '{"revokedBy":"operator","reason":"rotation","correlationId":"cli-actor-rotate-1"}'
+```
+
+Rotation is mint-new-then-revoke-old in this slice. There is no separate rotate endpoint: issue a replacement credential with a new TTL/scope, update the automation to use the new token, then revoke the old credential id. Revocation is in-process and applies to future validations by id/jti; expiry is checked on every validation.
+
+### Lane separation
+
+| Lane                         | Credential source                                                                                                  | Valid surfaces                                                                                                                        | Must not satisfy                                                                                                                                          | Audit/redaction promise                                                                                                                                   |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Browser cookie / PIN session | Existing browser login/PIN session cookie or local dev no-PIN mode.                                                | Browser UI, operator endpoints such as mint/list/revoke above, and legacy CLI gateway compatibility paths that have not migrated yet. | The scoped actor-token lane, `/hub/node-link`, heartbeat, node pairing/reconnect.                                                                         | Browser cookie/token material is redacted; use safe session/operator metadata only.                                                                       |
+| Node credential              | Node credential material issued through node pairing/lifecycle.                                                    | Node heartbeat and `/hub/node-link`.                                                                                                  | Browser UI auth, CLI actor token, “act as human/agent” auth.                                                                                              | Use node id and credential id/hash; never log raw node token material.                                                                                    |
+| Scoped actor token           | Explicit `--actor-token` / `RELAY_IDE_ACTOR_TOKEN` issued by the scoped actor registry for `relay:cli-gateway:v1`. | The four read-only MVP commands listed above.                                                                                         | Browser routes, node link/heartbeat, writes, control actions, session input/streaming, event streaming, or any command outside the implemented allowlist. | Use actor id/type, issuer, credential id/jti, requested/granted/denied bits, safe scope summary/hash, and correlation id; never emit raw bearer material. |
+
+### Failure examples
+
+Missing or rejected actor credentials use the normal gateway envelope shape (`ok: false`, `contract: "v1"`, command id, stable `error.code`, `retryable: false`) and the CLI exits nonzero. Current server-side lane failures include `lane: "denied"`, `acceptedLanes: ["scoped-actor-credential"]`, and `audience: "relay:cli-gateway:v1"` without token material.
+
+Stable reason codes in this slice include:
+
+| Case                                                    | HTTP / envelope code            | Reason code                                                                                                                                 |
+| ------------------------------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Missing bearer on an actor-marked MVP request           | `UNAUTHORIZED`                  | `CLI_ACTOR_CREDENTIAL_MISSING`                                                                                                              |
+| Browser cookie/PIN supplied to the actor lane           | `UNAUTHORIZED`                  | `CLI_ACTOR_BROWSER_COOKIE_REJECTED`                                                                                                         |
+| Node credential supplied to the actor lane              | `UNAUTHORIZED`                  | `CLI_ACTOR_NODE_CREDENTIAL_REJECTED`                                                                                                        |
+| Actor token used on a command outside the MVP allowlist | `UNAUTHORIZED`                  | `CLI_ACTOR_ROUTE_UNSUPPORTED`                                                                                                               |
+| Unsupported bearer type                                 | `UNAUTHORIZED`                  | `CLI_ACTOR_CREDENTIAL_UNSUPPORTED_TYPE`                                                                                                     |
+| Malformed/unknown token material                        | `UNAUTHORIZED`                  | `CLI_ACTOR_MALFORMED_CREDENTIAL`                                                                                                            |
+| Wrong/unknown audience                                  | `FORBIDDEN` or issue-time `400` | `CLI_ACTOR_WRONG_AUDIENCE` / `CLI_ACTOR_UNKNOWN_AUDIENCE`                                                                                   |
+| Expired or revoked credential                           | `UNAUTHORIZED`                  | `CLI_ACTOR_EXPIRED` / `CLI_ACTOR_REVOKED`                                                                                                   |
+| Missing or wrong scope                                  | `FORBIDDEN`                     | `CLI_ACTOR_MISSING_SCOPE`, `CLI_ACTOR_WRONG_SESSION_SCOPE`, `CLI_ACTOR_WRONG_GLOBAL_SESSION_SCOPE`, or `CLI_ACTOR_WRONG_WORK_CONTEXT_SCOPE` |
+| Unknown or insufficient capability                      | `FORBIDDEN`                     | `CLI_ACTOR_UNKNOWN_CAPABILITY` / `CLI_ACTOR_INSUFFICIENT_CAPABILITY`                                                                        |
+
+Messages and details must not echo `relay-sac-v1...` tokens, bearer headers, browser cookies, node credential material, secret hashes, or raw secret-looking scope/params. Use credential ids, jtis, correlation ids, hashes, and redacted summaries when reporting gateway auth failures or migration evidence.
+
+### Explicit non-goals for the first actor-token PR
+
+This slice does not migrate every v1 command and does not migrate adapter packages broadly. The actor-token lane does not cover `sessions.create`, `sessions.attach`, `sessions.detach`, `sessions.stream`, `sessions.input`, `files.*`, `context.*`, `inbox.*`, `handoffs.*`, `artifacts.*`, `supervisor.*`, `events.subscribe`, write/control/session-input/event-stream surfaces, browser auth replacement, node proof-of-possession, node credential lifecycle, approval UX, MFA/passkeys, enterprise RBAC, or public multi-tenant hosting.
 
 This boundary is part of the #797/#798/#802 split: #427 provided the trust-tier/capability/audit/confirmation backbone, #798 inventories routes and clarifies browser-session vs actor/node credentials, and #802 provides the scoped actor credential lifecycle primitive. Follow-up work may replace local browser-token compatibility with scoped actor credentials, but adapters should treat that as a credential migration, not a reason to reuse node credentials, browser UI cookies, or browser-only private routes.
 

--- a/docs/SECURITY_POLICY.md
+++ b/docs/SECURITY_POLICY.md
@@ -31,6 +31,22 @@ Revocation is in-process and immediate for future validations by credential id/j
 
 Audit helpers record issue, validate allow/deny, revoke, and expiry outcomes with reason codes, actor/issuer/audience metadata, credential id, required/granted/denied bits, correlation id, and hashed/redacted scope/params. Token-looking material is redacted before hashing or emission; raw bearer tokens, secrets, and secret hashes must not appear in logs, issues, diagnostics, registry snapshots, CLI output, browser JSON, or test snapshots.
 
+### CLI gateway actor credential lane
+
+The #805 CLI gateway MVP uses scoped actor credentials for a narrow read-only lane, not as a general login token. Credentials minted for `audience: "relay:cli-gateway:v1"` may be passed only as explicit actor credentials (`--actor-token` or `RELAY_IDE_ACTOR_TOKEN`) to these stable command ids: `nodes.list`, `sessions.list`, `sessions.get`, and `work-contexts.get`. The lane requires `session:read` and applies credential scope checks for requested session/global-session/work-context ids when those scopes are present.
+
+The lifecycle endpoints are hub operator APIs under `/cli-gateway/actor-credentials`: `POST` mints one token plus a public credential record, `GET` lists public records, and `DELETE /cli-gateway/actor-credentials/:id` revokes by credential id. Rotation is intentionally mint-new-then-revoke-old; this slice does not ship a separate rotate endpoint. The operator auth used to call these endpoints authorizes delegation, but the issued actor token is not a browser PIN/cookie, is not "login as Donovan," and does not pair or impersonate a Relay node.
+
+Lane separation is fail-closed:
+
+| Presented credential                          | Accepted here                                                                                                                                              | Rejected from                                                                                                                                             |
+| --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Browser PIN/session cookie                    | Browser UI, operator lifecycle endpoints such as actor credential mint/list/revoke, and legacy CLI gateway compatibility paths that have not migrated yet. | Scoped actor-token lane, node heartbeat, and `/hub/node-link`.                                                                                            |
+| Node credential                               | Node heartbeat and `/hub/node-link`.                                                                                                                       | Browser UI/operator auth and the CLI actor-token lane.                                                                                                    |
+| Scoped actor token for `relay:cli-gateway:v1` | Only the four read-only CLI gateway command ids above.                                                                                                     | Browser auth paths, node auth paths, write/control/session-input/event-stream commands, File RPC, supervisor actions, and commands outside the allowlist. |
+
+Typed CLI actor denials use stable reason codes such as `CLI_ACTOR_CREDENTIAL_MISSING`, `CLI_ACTOR_BROWSER_COOKIE_REJECTED`, `CLI_ACTOR_NODE_CREDENTIAL_REJECTED`, `CLI_ACTOR_ROUTE_UNSUPPORTED`, `CLI_ACTOR_MALFORMED_CREDENTIAL`, `CLI_ACTOR_WRONG_AUDIENCE`, `CLI_ACTOR_EXPIRED`, `CLI_ACTOR_REVOKED`, `CLI_ACTOR_MISSING_SCOPE`, `CLI_ACTOR_WRONG_SESSION_SCOPE`, `CLI_ACTOR_WRONG_GLOBAL_SESSION_SCOPE`, `CLI_ACTOR_WRONG_WORK_CONTEXT_SCOPE`, `CLI_ACTOR_UNKNOWN_CAPABILITY`, and `CLI_ACTOR_INSUFFICIENT_CAPABILITY`. Failure payloads may include safe credential ids, denied bits, the expected audience, and correlation ids, but never raw bearer strings, browser cookies, node credential material, or secret hashes.
+
 Relay issue `#177` remains the first-load/PIN explanation ticket. These docs clarify the security boundary, but closing `#177` should wait until the visible browser first-load copy also explains where the PIN comes from and how to reset it.
 
 ## Trust tiers

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -19,6 +19,8 @@ export const CLI_GATEWAY_ACTOR_READ_COMMANDS = [
   'sessions.get',
   'work-contexts.get',
 ] as const;
+export type CliGatewayActorReadCommand =
+  (typeof CLI_GATEWAY_ACTOR_READ_COMMANDS)[number];
 
 const cliGatewayActorReadCommandSet = new Set<string>(CLI_GATEWAY_ACTOR_READ_COMMANDS);
 
@@ -73,7 +75,10 @@ export function isCliGatewayActorTokenRequest(req: Request): boolean {
   return req.header(CLI_GATEWAY_ACTOR_TOKEN_HEADER) === 'v1';
 }
 
-export function classifyCliGatewayCredentialLane(req: Request):
+export function classifyCliGatewayCredentialLane(
+  req: Request,
+  expectedCommand?: CliGatewayActorReadCommand
+):
   | 'missing'
   | 'scoped-actor-credential'
   | 'browser-cookie-lane'
@@ -86,7 +91,7 @@ export function classifyCliGatewayCredentialLane(req: Request):
     return 'missing';
   }
   if (token.startsWith('relay-sac-v1.')) {
-    return isSupportedCliGatewayActorReadRequest(req)
+    return isSupportedCliGatewayActorReadRequest(req, expectedCommand)
       ? 'scoped-actor-credential'
       : 'unsupported-route';
   }
@@ -96,10 +101,16 @@ export function classifyCliGatewayCredentialLane(req: Request):
   return 'unsupported-type';
 }
 
-export function isSupportedCliGatewayActorReadRequest(req: Request): boolean {
+export function isSupportedCliGatewayActorReadRequest(
+  req: Request,
+  expectedCommand?: CliGatewayActorReadCommand
+): boolean {
   if (req.method !== 'GET') return false;
+  if (!expectedCommand || !cliGatewayActorReadCommandSet.has(expectedCommand)) {
+    return false;
+  }
   const command = req.header(CLI_GATEWAY_COMMAND_HEADER);
-  return typeof command === 'string' && cliGatewayActorReadCommandSet.has(command);
+  return command === expectedCommand;
 }
 
 export function defaultCliGatewayActorScope(

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -1,0 +1,307 @@
+import type { Request, Response } from 'express';
+import {
+  ScopedActorCredentialRegistry,
+  type ScopedActorCredentialRecord,
+  type ScopedActorCredentialScope,
+  type ScopedActorCredentialValidationFailureReason,
+  type ScopedActorCredentialValidationResult,
+} from '../shared/scoped-actor-credentials.js';
+import type { RelayCapabilityBit } from '../shared/security-policy.js';
+
+export const CLI_GATEWAY_ACTOR_AUDIENCE = 'relay:cli-gateway:v1' as const;
+export const CLI_GATEWAY_READ_SCOPE_TASK_REF = 'relay:cli-gateway:v1:read' as const;
+export const CLI_GATEWAY_ACTOR_TOKEN_HEADER = 'x-relay-cli-actor-token' as const;
+export const CLI_GATEWAY_COMMAND_HEADER = 'x-relay-cli-command' as const;
+export const CLI_GATEWAY_CORRELATION_ID_HEADER = 'x-relay-correlation-id' as const;
+export const CLI_GATEWAY_ACTOR_READ_COMMANDS = [
+  'nodes.list',
+  'sessions.list',
+  'sessions.get',
+  'work-contexts.get',
+] as const;
+
+const cliGatewayActorReadCommandSet = new Set<string>(CLI_GATEWAY_ACTOR_READ_COMMANDS);
+
+export interface CliGatewayActorIssueInput {
+  actor?: { type?: unknown; id?: unknown; displayName?: unknown };
+  issuer?: { id?: unknown; displayName?: unknown };
+  capabilities?: unknown;
+  scope?: unknown;
+  ttlMs?: unknown;
+  expiresAt?: unknown;
+  metadata?: unknown;
+  correlationId?: unknown;
+}
+
+export interface CliGatewayActorValidationInput {
+  token: string;
+  capabilities: readonly RelayCapabilityBit[];
+  scope?: ScopedActorCredentialScope;
+  correlationId?: string;
+}
+
+export interface CliGatewayActorFailureEnvelope {
+  error: {
+    code: 'UNAUTHORIZED' | 'FORBIDDEN';
+    reasonCode: string;
+    message: string;
+    retryable: false;
+    lane: 'denied';
+    acceptedLanes: ['scoped-actor-credential'];
+    audience: typeof CLI_GATEWAY_ACTOR_AUDIENCE;
+    credentialId?: string;
+    deniedBits?: string[];
+    correlationId?: string;
+  };
+}
+
+export function createCliGatewayActorRegistry(): ScopedActorCredentialRegistry {
+  return new ScopedActorCredentialRegistry();
+}
+
+export function bearerActorToken(req: Request): string {
+  const authHeader = req.header('authorization') ?? '';
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() ?? '';
+}
+
+export function cliGatewayCorrelationId(req: Request): string | undefined {
+  return req.header(CLI_GATEWAY_CORRELATION_ID_HEADER) ?? undefined;
+}
+
+export function isCliGatewayActorTokenRequest(req: Request): boolean {
+  return req.header(CLI_GATEWAY_ACTOR_TOKEN_HEADER) === 'v1';
+}
+
+export function classifyCliGatewayCredentialLane(req: Request):
+  | 'missing'
+  | 'scoped-actor-credential'
+  | 'browser-cookie-lane'
+  | 'node-credential-lane'
+  | 'unsupported-route'
+  | 'unsupported-type' {
+  const token = bearerActorToken(req);
+  if (!token) {
+    if (req.header('cookie')) return 'browser-cookie-lane';
+    return 'missing';
+  }
+  if (token.startsWith('relay-sac-v1.')) {
+    return isSupportedCliGatewayActorReadRequest(req)
+      ? 'scoped-actor-credential'
+      : 'unsupported-route';
+  }
+  if (req.header('x-relay-node-id') || req.header('x-relay-node-credential')) {
+    return 'node-credential-lane';
+  }
+  return 'unsupported-type';
+}
+
+export function isSupportedCliGatewayActorReadRequest(req: Request): boolean {
+  if (req.method !== 'GET') return false;
+  const command = req.header(CLI_GATEWAY_COMMAND_HEADER);
+  return typeof command === 'string' && cliGatewayActorReadCommandSet.has(command);
+}
+
+export function defaultCliGatewayActorScope(
+  overrides?: ScopedActorCredentialScope
+): ScopedActorCredentialScope {
+  return {
+    taskRefs: [CLI_GATEWAY_READ_SCOPE_TASK_REF],
+    ...(overrides ?? {}),
+  };
+}
+
+export function validateCliGatewayActorCredential(
+  registry: ScopedActorCredentialRegistry,
+  input: CliGatewayActorValidationInput
+): ScopedActorCredentialValidationResult {
+  return registry.validate(input.token, {
+    audience: CLI_GATEWAY_ACTOR_AUDIENCE,
+    requiredCapabilities: [...input.capabilities],
+    scope: {
+      taskRef: CLI_GATEWAY_READ_SCOPE_TASK_REF,
+      ...scopeForValidation(input.scope),
+    },
+    ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+  });
+}
+
+export function sendCliGatewayActorFailure(
+  res: Response,
+  failure: CliGatewayActorFailureEnvelope['error']
+): void {
+  res.status(failure.code === 'FORBIDDEN' ? 403 : 401).json({ error: failure });
+}
+
+export function cliGatewayActorFailure(input: {
+  lane?: ReturnType<typeof classifyCliGatewayCredentialLane>;
+  reason?: ScopedActorCredentialValidationFailureReason;
+  credentialId?: string;
+  deniedBits?: string[];
+  correlationId?: string;
+}): CliGatewayActorFailureEnvelope['error'] {
+  const reason = input.reason;
+  const lane = input.lane;
+  const reasonCode = reason
+    ? cliGatewayActorReasonCode(reason)
+    : lane === 'missing'
+      ? 'CLI_ACTOR_CREDENTIAL_MISSING'
+      : lane === 'browser-cookie-lane'
+        ? 'CLI_ACTOR_BROWSER_COOKIE_REJECTED'
+        : lane === 'node-credential-lane'
+          ? 'CLI_ACTOR_NODE_CREDENTIAL_REJECTED'
+          : lane === 'unsupported-route'
+            ? 'CLI_ACTOR_ROUTE_UNSUPPORTED'
+            : 'CLI_ACTOR_CREDENTIAL_UNSUPPORTED_TYPE';
+  return {
+    code: reason && forbiddenActorReasons.has(reason) ? 'FORBIDDEN' : 'UNAUTHORIZED',
+    reasonCode,
+    message: cliGatewayActorMessage(reasonCode),
+    retryable: false,
+    lane: 'denied',
+    acceptedLanes: ['scoped-actor-credential'],
+    audience: CLI_GATEWAY_ACTOR_AUDIENCE,
+    ...(input.credentialId ? { credentialId: input.credentialId } : {}),
+    ...(input.deniedBits?.length ? { deniedBits: [...input.deniedBits] } : {}),
+    ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+  };
+}
+
+export function issueCliGatewayActorCredential(
+  registry: ScopedActorCredentialRegistry,
+  input: CliGatewayActorIssueInput = {}
+): { token: string; credential: ScopedActorCredentialRecord } {
+  const scope = coerceScope(input.scope);
+  const capabilities = coerceCapabilities(input.capabilities);
+  const ttlMs = typeof input.ttlMs === 'number' ? input.ttlMs : 5 * 60 * 1000;
+  return registry.issue({
+    actor: coerceActor(input.actor),
+    issuer: coerceIssuer(input.issuer),
+    audience: CLI_GATEWAY_ACTOR_AUDIENCE,
+    capabilities,
+    scope: defaultCliGatewayActorScope(scope),
+    ttlMs,
+    ...(typeof input.expiresAt === 'string' ? { expiresAt: input.expiresAt } : {}),
+    ...(isRecord(input.metadata) ? { metadata: input.metadata } : {}),
+    ...(typeof input.correlationId === 'string'
+      ? { correlationId: input.correlationId }
+      : {}),
+  });
+}
+
+function scopeForValidation(
+  scope: ScopedActorCredentialScope | undefined
+): {
+  nodeId?: string;
+  sessionId?: string;
+  globalSessionId?: string;
+  workContextId?: string;
+  repoId?: string;
+  path?: string;
+  taskRef?: string;
+} {
+  return {
+    ...(scope?.nodeIds?.[0] ? { nodeId: scope.nodeIds[0] } : {}),
+    ...(scope?.sessionIds?.[0] ? { sessionId: scope.sessionIds[0] } : {}),
+    ...(scope?.globalSessionIds?.[0]
+      ? { globalSessionId: scope.globalSessionIds[0] }
+      : {}),
+    ...(scope?.workContextIds?.[0]
+      ? { workContextId: scope.workContextIds[0] }
+      : {}),
+    ...(scope?.repoIds?.[0] ? { repoId: scope.repoIds[0] } : {}),
+    ...(scope?.pathPrefixes?.[0] ? { path: scope.pathPrefixes[0] } : {}),
+    ...(scope?.taskRefs?.[0] ? { taskRef: scope.taskRefs[0] } : {}),
+  };
+}
+
+const forbiddenActorReasons = new Set<ScopedActorCredentialValidationFailureReason>([
+  'unsupported_actor_type',
+  'wrong_audience',
+  'unknown_audience',
+  'missing_scope',
+  'wrong_node_scope',
+  'wrong_session_scope',
+  'wrong_global_session_scope',
+  'wrong_work_context_scope',
+  'wrong_repo_scope',
+  'wrong_path_scope',
+  'wrong_task_scope',
+  'unknown_capability',
+  'insufficient_capability',
+]);
+
+function cliGatewayActorReasonCode(
+  reason: ScopedActorCredentialValidationFailureReason
+): string {
+  return `CLI_ACTOR_${reason.toUpperCase()}`;
+}
+
+function cliGatewayActorMessage(reasonCode: string): string {
+  switch (reasonCode) {
+    case 'CLI_ACTOR_CREDENTIAL_MISSING':
+      return 'CLI gateway read commands require --actor-token or RELAY_IDE_ACTOR_TOKEN';
+    case 'CLI_ACTOR_BROWSER_COOKIE_REJECTED':
+      return 'browser cookies are not accepted for the scoped CLI actor lane';
+    case 'CLI_ACTOR_NODE_CREDENTIAL_REJECTED':
+      return 'node credentials are not accepted for the scoped CLI actor lane';
+    case 'CLI_ACTOR_CREDENTIAL_UNSUPPORTED_TYPE':
+      return 'unsupported CLI gateway credential type';
+    case 'CLI_ACTOR_ROUTE_UNSUPPORTED':
+      return 'scoped CLI actor credentials are limited to the read-only CLI gateway smoke surface';
+    default:
+      return `scoped CLI actor credential rejected: ${reasonCode}`;
+  }
+}
+
+function coerceActor(value: unknown): { type: string; id: string; displayName?: string } {
+  const actor = isRecord(value) ? value : {};
+  return {
+    type: typeof actor.type === 'string' ? actor.type : 'cli',
+    id: typeof actor.id === 'string' ? actor.id : 'relay-cli',
+    ...(typeof actor.displayName === 'string'
+      ? { displayName: actor.displayName }
+      : {}),
+  };
+}
+
+function coerceIssuer(value: unknown): { id: string; displayName?: string } {
+  const issuer = isRecord(value) ? value : {};
+  return {
+    id: typeof issuer.id === 'string' ? issuer.id : 'browser-operator',
+    ...(typeof issuer.displayName === 'string'
+      ? { displayName: issuer.displayName }
+      : {}),
+  };
+}
+
+function coerceCapabilities(value: unknown): RelayCapabilityBit[] {
+  if (!Array.isArray(value)) return ['session:read'];
+  const caps = value.filter((cap): cap is RelayCapabilityBit => cap === 'session:read');
+  return caps.length ? caps : ['session:read'];
+}
+
+function coerceScope(value: unknown): ScopedActorCredentialScope | undefined {
+  if (!isRecord(value)) return undefined;
+  const scope: ScopedActorCredentialScope = {};
+  for (const [key, outputKey] of [
+    ['nodeIds', 'nodeIds'],
+    ['sessionIds', 'sessionIds'],
+    ['globalSessionIds', 'globalSessionIds'],
+    ['workContextIds', 'workContextIds'],
+    ['repoIds', 'repoIds'],
+    ['pathPrefixes', 'pathPrefixes'],
+    ['taskRefs', 'taskRefs'],
+  ] as const) {
+    const raw = value[key];
+    if (Array.isArray(raw)) {
+      const strings = raw.filter((entry): entry is string => typeof entry === 'string');
+      if (strings.length) scope[outputKey] = strings;
+    }
+  }
+  return scope;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -83,6 +83,7 @@ import {
 import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
 import type { RelayCliGatewayError } from '../shared/cli-gateway-contract.js';
 import { validateAndSanitizeGatewayCreateInput } from '../shared/cli-gateway-runtime.js';
+import type { CliGatewayActorReadCommand } from './cli-gateway-actor-auth.js';
 
 const FILE_RPC_FOLLOW_STREAM_BUFFER_BYTES = 256 * 1024;
 
@@ -123,6 +124,9 @@ interface HubNodeRouterOptions {
   registry: HubNodeRegistry;
   requireAuth: express.RequestHandler;
   cliGatewayAuth?: express.RequestHandler;
+  cliGatewayAuthForActorCommand?: (
+    command: CliGatewayActorReadCommand
+  ) => express.RequestHandler;
   scopedSessionAuth?: express.RequestHandler;
   repoInventoryFeature?: RepoInventoryFeature;
   collectLocalRepoInventory?: () => Promise<RepoInventoryReport>;
@@ -1815,6 +1819,8 @@ export function createHubNodeRouter(
   const router = express.Router();
   const { registry, requireAuth } = options;
   const cliGatewayAuth = options.cliGatewayAuth ?? requireAuth;
+  const cliGatewayAuthForActorCommand =
+    options.cliGatewayAuthForActorCommand ?? (() => cliGatewayAuth);
   const scopedSessionAuth = options.scopedSessionAuth ?? requireAuth;
   const envelopes = options.sessionEnvelopes ?? sessionEnvelopeRegistry;
   const confirmations =
@@ -2054,7 +2060,7 @@ export function createHubNodeRouter(
     }
   });
 
-  router.get('/nodes', cliGatewayAuth, (_req, res) => {
+  router.get('/nodes', cliGatewayAuthForActorCommand('nodes.list'), (_req, res) => {
     res.json({ nodes: registry.listNodes() });
   });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -224,6 +224,7 @@ import {
   sendCliGatewayActorFailure,
   validateCliGatewayActorCredential,
   type CliGatewayActorIssueInput,
+  type CliGatewayActorReadCommand,
 } from './cli-gateway-actor-auth.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -1699,7 +1700,8 @@ async function main(): Promise<void> {
       sessionIds?: string[];
       globalSessionIds?: string[];
       workContextIds?: string[];
-    }
+    },
+    expectedCommand?: CliGatewayActorReadCommand
   ): express.RequestHandler => {
     return (req, res, next) => {
       if (!isCliGatewayV1Request(req)) {
@@ -1710,7 +1712,7 @@ async function main(): Promise<void> {
         res.status(401).json(auth.cliGatewayOrBrowserAuthRequiredChallenge());
         return;
       }
-      const lane = classifyCliGatewayCredentialLane(req);
+      const lane = classifyCliGatewayCredentialLane(req, expectedCommand);
       const correlationId = cliGatewayCorrelationId(req);
       if (lane !== 'scoped-actor-credential') {
         sendCliGatewayActorFailure(
@@ -1749,12 +1751,26 @@ async function main(): Promise<void> {
     };
   };
 
-  const requireCliGatewayReadAuth: express.RequestHandler = (req, res, next) =>
-    requireCliGatewayActorAuth(['session:read'])(req, res, next);
+  const requireCliGatewayReadAuth = (
+    expectedCommand?: CliGatewayActorReadCommand
+  ): express.RequestHandler =>
+    requireCliGatewayActorAuth(['session:read'], undefined, expectedCommand);
+
+  const requireCliGatewayAuthForActorCommand = (
+    expectedCommand: CliGatewayActorReadCommand
+  ): express.RequestHandler => {
+    return (req, res, next) => {
+      if (isCliGatewayActorTokenRequest(req)) {
+        requireCliGatewayReadAuth(expectedCommand)(req, res, next);
+        return;
+      }
+      requireCliGatewayAuth(req, res, next);
+    };
+  };
 
   const requireCliGatewayAuth: express.RequestHandler = (req, res, next) => {
     if (isCliGatewayActorTokenRequest(req)) {
-      requireCliGatewayReadAuth(req, res, next);
+      requireCliGatewayReadAuth()(req, res, next);
       return;
     }
     if (
@@ -1792,6 +1808,25 @@ async function main(): Promise<void> {
       return;
     }
     res.status(401).json(auth.scopedSessionOrBrowserAuthRequiredChallenge());
+  };
+
+  const requireScopedSessionAuthForActorCommand = (
+    expectedCommand: CliGatewayActorReadCommand
+  ): express.RequestHandler => {
+    return (req, res, next) => {
+      if (isCliGatewayActorTokenRequest(req)) {
+        const id = req.params['id'];
+        requireCliGatewayActorAuth(
+          ['session:read'],
+          {
+            ...(id ? { sessionIds: [id], globalSessionIds: [id] } : {}),
+          },
+          expectedCommand
+        )(req, res, next);
+        return;
+      }
+      requireScopedSessionAuth(req, res, next);
+    };
   };
 
   app.post('/cli-gateway/actor-credentials', requireAuth, (req, res) => {
@@ -1865,6 +1900,7 @@ async function main(): Promise<void> {
       nodeLinks: hubNodeLinks,
       requireAuth,
       cliGatewayAuth: requireCliGatewayAuth,
+      cliGatewayAuthForActorCommand: requireCliGatewayAuthForActorCommand,
       scopedSessionAuth: requireScopedSessionAuth,
       repoInventoryFeature,
       collectLocalRepoInventory: collectLocalInventory,
@@ -2371,9 +2407,13 @@ async function main(): Promise<void> {
       requireReadAuth: (req, res, next) => {
         if (isCliGatewayActorTokenRequest(req)) {
           const id = req.params['id'];
-          requireCliGatewayActorAuth(['session:read'], {
-            ...(id ? { workContextIds: [id] } : {}),
-          })(req, res, next);
+          requireCliGatewayActorAuth(
+            ['session:read'],
+            {
+              ...(id ? { workContextIds: [id] } : {}),
+            },
+            'work-contexts.get'
+          )(req, res, next);
           return;
         }
         if (isCliGatewayV1Request(req)) {
@@ -2804,7 +2844,7 @@ async function main(): Promise<void> {
   // GET /sessions — enrich with live branch from git (rate-limited to avoid spawning git on every poll)
   const branchRefreshCache = new Map<string, number>(); // sessionId -> last refresh timestamp
   const BRANCH_REFRESH_INTERVAL_MS = 10_000;
-  app.get('/sessions', requireCliGatewayAuth, async (_req, res) => {
+  app.get('/sessions', requireCliGatewayAuthForActorCommand('sessions.list'), async (_req, res) => {
     const [localSessions, remoteSessions] = await Promise.all([
       Promise.resolve(
         localRelayNode.sessions
@@ -2863,7 +2903,7 @@ async function main(): Promise<void> {
     res.json(allSessions);
   });
 
-  app.get('/sessions/:id', requireScopedSessionAuth, async (req, res) => {
+  app.get('/sessions/:id', requireScopedSessionAuthForActorCommand('sessions.get'), async (req, res) => {
     const decision = capabilityDecisionFromRequest(
       req,
       CONTROL_READ_CAPABILITY

--- a/server/index.ts
+++ b/server/index.ts
@@ -213,12 +213,25 @@ import {
   handleSupervisorActionRequest,
   handleSupervisorSessionsRequest,
 } from './supervisor-route-handlers.js';
+import {
+  bearerActorToken,
+  classifyCliGatewayCredentialLane,
+  cliGatewayActorFailure,
+  cliGatewayCorrelationId,
+  createCliGatewayActorRegistry,
+  isCliGatewayActorTokenRequest,
+  issueCliGatewayActorCredential,
+  sendCliGatewayActorFailure,
+  validateCliGatewayActorCredential,
+  type CliGatewayActorIssueInput,
+} from './cli-gateway-actor-auth.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const execFileAsync = promisify(execFile);
 const logger = createLogger('index');
 const localRelayNode = createLocalRelayNode();
+const cliGatewayActorRegistry = createCliGatewayActorRegistry();
 
 // When run via CLI bin, config lives in ~/.config/relay-ide/
 // When run directly (development), fall back to local config.json
@@ -1679,7 +1692,71 @@ async function main(): Promise<void> {
     next();
   };
 
+  const requireCliGatewayActorAuth = (
+    capabilities: readonly ['session:read'],
+    scope?: {
+      nodeIds?: string[];
+      sessionIds?: string[];
+      globalSessionIds?: string[];
+      workContextIds?: string[];
+    }
+  ): express.RequestHandler => {
+    return (req, res, next) => {
+      if (!isCliGatewayV1Request(req)) {
+        if (process.env.NO_PIN === '1' || authenticatedBrowserSession(req)) {
+          next();
+          return;
+        }
+        res.status(401).json(auth.cliGatewayOrBrowserAuthRequiredChallenge());
+        return;
+      }
+      const lane = classifyCliGatewayCredentialLane(req);
+      const correlationId = cliGatewayCorrelationId(req);
+      if (lane !== 'scoped-actor-credential') {
+        sendCliGatewayActorFailure(
+          res,
+          cliGatewayActorFailure({
+            lane,
+            ...(correlationId ? { correlationId } : {}),
+          })
+        );
+        return;
+      }
+      const validation = validateCliGatewayActorCredential(
+        cliGatewayActorRegistry,
+        {
+          token: bearerActorToken(req),
+          capabilities,
+          ...(scope ? { scope } : {}),
+          ...(correlationId ? { correlationId } : {}),
+        }
+      );
+      if ('reason' in validation) {
+        sendCliGatewayActorFailure(
+          res,
+          cliGatewayActorFailure({
+            reason: validation.reason,
+            ...(validation.credentialId
+              ? { credentialId: validation.credentialId }
+              : {}),
+            deniedBits: validation.deniedBits,
+            ...(correlationId ? { correlationId } : {}),
+          })
+        );
+        return;
+      }
+      next();
+    };
+  };
+
+  const requireCliGatewayReadAuth: express.RequestHandler = (req, res, next) =>
+    requireCliGatewayActorAuth(['session:read'])(req, res, next);
+
   const requireCliGatewayAuth: express.RequestHandler = (req, res, next) => {
+    if (isCliGatewayActorTokenRequest(req)) {
+      requireCliGatewayReadAuth(req, res, next);
+      return;
+    }
     if (
       isCliGatewayV1Request(req) &&
       validateScopedToken(bearerScopedToken(req))
@@ -1699,6 +1776,13 @@ async function main(): Promise<void> {
   };
 
   const requireScopedSessionAuth: express.RequestHandler = (req, res, next) => {
+    if (isCliGatewayActorTokenRequest(req)) {
+      const id = req.params['id'];
+      requireCliGatewayActorAuth(['session:read'], {
+        ...(id ? { sessionIds: [id], globalSessionIds: [id] } : {}),
+      })(req, res, next);
+      return;
+    }
     if (process.env.NO_PIN === '1' || authenticatedBrowserSession(req)) {
       next();
       return;
@@ -1709,6 +1793,65 @@ async function main(): Promise<void> {
     }
     res.status(401).json(auth.scopedSessionOrBrowserAuthRequiredChallenge());
   };
+
+  app.post('/cli-gateway/actor-credentials', requireAuth, (req, res) => {
+    try {
+      const issued = issueCliGatewayActorCredential(
+        cliGatewayActorRegistry,
+        isRecord(req.body) ? (req.body as CliGatewayActorIssueInput) : {}
+      );
+      res.status(201).json({
+        token: issued.token,
+        credential: issued.credential,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      res.status(400).json({
+        error: {
+          code: 'CLI_ACTOR_CREDENTIAL_ISSUE_FAILED',
+          message,
+          retryable: false,
+        },
+      });
+    }
+  });
+
+  app.get('/cli-gateway/actor-credentials', requireAuth, (_req, res) => {
+    res.json({ credentials: cliGatewayActorRegistry.listCredentials() });
+  });
+
+  app.delete('/cli-gateway/actor-credentials/:id', requireAuth, (req, res) => {
+    const id = req.params['id'];
+    if (!id) {
+      res.status(400).json({
+        error: {
+          code: 'CLI_ACTOR_CREDENTIAL_ID_REQUIRED',
+          message: 'credential id is required',
+          retryable: false,
+        },
+      });
+      return;
+    }
+    const body = isRecord(req.body) ? req.body : {};
+    const credential = cliGatewayActorRegistry.revoke(id, {
+      revokedBy: typeof body['revokedBy'] === 'string' ? body['revokedBy'] : 'browser-operator',
+      ...(typeof body['reason'] === 'string' ? { reason: body['reason'] } : {}),
+      ...(typeof body['correlationId'] === 'string'
+        ? { correlationId: body['correlationId'] }
+        : {}),
+    });
+    if (!credential) {
+      res.status(404).json({
+        error: {
+          code: 'CLI_ACTOR_CREDENTIAL_NOT_FOUND',
+          message: 'credential not found',
+          retryable: false,
+        },
+      });
+      return;
+    }
+    res.json({ credential });
+  });
 
   const collectLocalInventory = () =>
     collectLocalRepoInventory({
@@ -2225,6 +2368,20 @@ async function main(): Promise<void> {
     createWorkContextRouter({
       store: workContextStore,
       requireAuth,
+      requireReadAuth: (req, res, next) => {
+        if (isCliGatewayActorTokenRequest(req)) {
+          const id = req.params['id'];
+          requireCliGatewayActorAuth(['session:read'], {
+            ...(id ? { workContextIds: [id] } : {}),
+          })(req, res, next);
+          return;
+        }
+        if (isCliGatewayV1Request(req)) {
+          requireCliGatewayAuth(req, res, next);
+          return;
+        }
+        requireAuth(req, res, next);
+      },
       getSessions: async () => {
         const [localSessions, remoteSessions] = await Promise.all([
           Promise.resolve(

--- a/server/work-contexts.ts
+++ b/server/work-contexts.ts
@@ -295,6 +295,7 @@ export interface WorkContextStore {
 export interface WorkContextRouterDeps {
   store: WorkContextStore;
   requireAuth?: RequestHandler;
+  requireReadAuth?: RequestHandler;
   getSessions: () => Promise<SessionSummary[]> | SessionSummary[];
   getNodes?: () => HubNodeSummary[];
 }
@@ -590,6 +591,7 @@ export class WorkContextStoreError extends Error {
 export function createWorkContextRouter(deps: WorkContextRouterDeps): Router {
   const router = Router();
   const auth = deps.requireAuth ?? ((_req, _res, next) => next());
+  const readAuth = deps.requireReadAuth ?? auth;
 
   router.get('/', auth, (_req, res) => {
     res.json({ workContexts: deps.store.list() });
@@ -681,7 +683,7 @@ export function createWorkContextRouter(deps: WorkContextRouterDeps): Router {
     }
   });
 
-  router.get('/:id', auth, (req, res) => {
+  router.get('/:id', readAuth, (req, res) => {
     const context = deps.store.get(req.params['id'] ?? '');
     if (!context) {
       res.status(404).json({ error: 'work_context_not_found' });

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -65,7 +65,7 @@ test('issues and validates bounded read-only CLI gateway actor credentials', () 
   expect(validation).toMatchObject({ ok: true, grantedBits: ['session:read'] });
 });
 
-test('classifies only explicit read-only CLI gateway actor requests into the actor lane', () => {
+test('classifies only server-bound read-only CLI gateway actor routes into the actor lane', () => {
   const token = 'relay-sac-v1.credential-id.[REDACTED]';
   expect(CLI_GATEWAY_ACTOR_READ_COMMANDS).toEqual([
     'nodes.list',
@@ -79,9 +79,29 @@ test('classifies only explicit read-only CLI gateway actor requests into the act
         authorization: `Bearer ${token}`,
         actorMarker: 'v1',
         command: 'nodes.list',
-      })
+      }),
+      'nodes.list'
     )
   ).toBe('scoped-actor-credential');
+  expect(
+    classifyCliGatewayCredentialLane(
+      req({
+        authorization: `Bearer ${token}`,
+        actorMarker: 'v1',
+        command: 'nodes.list',
+      })
+    )
+  ).toBe('unsupported-route');
+  expect(
+    classifyCliGatewayCredentialLane(
+      req({
+        authorization: `Bearer ${token}`,
+        actorMarker: 'v1',
+        command: 'nodes.list',
+      }),
+      'sessions.list'
+    )
+  ).toBe('unsupported-route');
   expect(
     classifyCliGatewayCredentialLane(
       req({
@@ -89,11 +109,12 @@ test('classifies only explicit read-only CLI gateway actor requests into the act
         authorization: `Bearer ${token}`,
         actorMarker: 'v1',
         command: 'sessions.create',
-      })
+      }),
+      'sessions.list'
     )
   ).toBe('unsupported-route');
   expect(
-    classifyCliGatewayCredentialLane(req({ authorization: `Bearer ${token}`, actorMarker: 'v1' }))
+    classifyCliGatewayCredentialLane(req({ authorization: `Bearer ${token}`, actorMarker: 'v1' }), 'nodes.list')
   ).toBe('unsupported-route');
   expect(classifyCliGatewayCredentialLane(req({ cookie: 'token=browser' }))).toBe(
     'browser-cookie-lane'
@@ -101,6 +122,52 @@ test('classifies only explicit read-only CLI gateway actor requests into the act
   expect(classifyCliGatewayCredentialLane(req({ authorization: 'Bearer node-secret', nodeId: 'n1' }))).toBe(
     'node-credential-lane'
   );
+});
+
+test('denies spoofed actor command headers on non-MVP route identities', () => {
+  const token = 'relay-sac-v1.credential-id.[REDACTED]';
+  const spoofedRequests = [
+    { route: '/hub/audit/entries', command: 'nodes.list' },
+    { route: '/hub/nodes/node-1/logs', command: 'nodes.list' },
+    { route: '/sessions/session-1/replay', command: 'sessions.get' },
+    { route: '/supervisor/sessions', command: 'sessions.get' },
+  ];
+
+  for (const { route, command } of spoofedRequests) {
+    expect(
+      classifyCliGatewayCredentialLane(
+        req({
+          authorization: `Bearer ${token}`,
+          actorMarker: 'v1',
+          command,
+        })
+      ),
+      route
+    ).toBe('unsupported-route');
+  }
+});
+
+test('allows only the MVP actor command and route identity pairs', () => {
+  const token = 'relay-sac-v1.credential-id.[REDACTED]';
+  const allowed = [
+    { command: 'nodes.list', expected: 'nodes.list' },
+    { command: 'sessions.list', expected: 'sessions.list' },
+    { command: 'sessions.get', expected: 'sessions.get' },
+    { command: 'work-contexts.get', expected: 'work-contexts.get' },
+  ] as const;
+
+  for (const { command, expected } of allowed) {
+    expect(
+      classifyCliGatewayCredentialLane(
+        req({
+          authorization: `Bearer ${token}`,
+          actorMarker: 'v1',
+          command,
+        }),
+        expected
+      )
+    ).toBe('scoped-actor-credential');
+  }
 });
 
 test('returns stable typed denials without token material', () => {

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -1,0 +1,122 @@
+import { expect, test } from 'vitest';
+import type { Request } from 'express';
+import {
+  CLI_GATEWAY_ACTOR_AUDIENCE,
+  CLI_GATEWAY_ACTOR_READ_COMMANDS,
+  CLI_GATEWAY_READ_SCOPE_TASK_REF,
+  cliGatewayActorFailure,
+  classifyCliGatewayCredentialLane,
+  issueCliGatewayActorCredential,
+  validateCliGatewayActorCredential,
+} from '../server/cli-gateway-actor-auth.js';
+import { ScopedActorCredentialRegistry } from '../shared/scoped-actor-credentials.js';
+
+const NOW = new Date('2026-05-29T00:00:00.000Z');
+
+function registry(): ScopedActorCredentialRegistry {
+  return new ScopedActorCredentialRegistry({
+    now: () => NOW,
+    secretBytes: () => Buffer.from('0123456789abcdef0123456789abcdef'),
+  });
+}
+
+function req(input: {
+  method?: string;
+  authorization?: string;
+  actorMarker?: string;
+  command?: string;
+  cookie?: string;
+  nodeId?: string;
+}): Request {
+  const headers = new Map<string, string>();
+  if (input.authorization) headers.set('authorization', input.authorization);
+  if (input.actorMarker) headers.set('x-relay-cli-actor-token', input.actorMarker);
+  if (input.command) headers.set('x-relay-cli-command', input.command);
+  if (input.cookie) headers.set('cookie', input.cookie);
+  if (input.nodeId) headers.set('x-relay-node-id', input.nodeId);
+  return {
+    method: input.method ?? 'GET',
+    header: (name: string) => headers.get(name.toLowerCase()),
+  } as unknown as Request;
+}
+
+test('issues and validates bounded read-only CLI gateway actor credentials', () => {
+  const scopedRegistry = registry();
+  const issued = issueCliGatewayActorCredential(scopedRegistry, {
+    actor: { type: 'cli', id: 'relay-cli-test' },
+    issuer: { id: 'browser-operator-test' },
+    correlationId: 'corr-cli-1',
+  });
+
+  expect(issued.credential).toMatchObject({
+    audience: CLI_GATEWAY_ACTOR_AUDIENCE,
+    capabilities: ['session:read'],
+    scope: { taskRefs: [CLI_GATEWAY_READ_SCOPE_TASK_REF] },
+    actor: { type: 'cli', id: 'relay-cli-test' },
+    issuer: { id: 'browser-operator-test' },
+  });
+  expect(JSON.stringify(issued.credential)).not.toContain(issued.token);
+
+  const validation = validateCliGatewayActorCredential(scopedRegistry, {
+    token: issued.token,
+    capabilities: ['session:read'],
+    correlationId: 'corr-cli-1',
+  });
+  expect(validation).toMatchObject({ ok: true, grantedBits: ['session:read'] });
+});
+
+test('classifies only explicit read-only CLI gateway actor requests into the actor lane', () => {
+  const token = 'relay-sac-v1.credential-id.[REDACTED]';
+  expect(CLI_GATEWAY_ACTOR_READ_COMMANDS).toEqual([
+    'nodes.list',
+    'sessions.list',
+    'sessions.get',
+    'work-contexts.get',
+  ]);
+  expect(
+    classifyCliGatewayCredentialLane(
+      req({
+        authorization: `Bearer ${token}`,
+        actorMarker: 'v1',
+        command: 'nodes.list',
+      })
+    )
+  ).toBe('scoped-actor-credential');
+  expect(
+    classifyCliGatewayCredentialLane(
+      req({
+        method: 'POST',
+        authorization: `Bearer ${token}`,
+        actorMarker: 'v1',
+        command: 'sessions.create',
+      })
+    )
+  ).toBe('unsupported-route');
+  expect(
+    classifyCliGatewayCredentialLane(req({ authorization: `Bearer ${token}`, actorMarker: 'v1' }))
+  ).toBe('unsupported-route');
+  expect(classifyCliGatewayCredentialLane(req({ cookie: 'token=browser' }))).toBe(
+    'browser-cookie-lane'
+  );
+  expect(classifyCliGatewayCredentialLane(req({ authorization: 'Bearer node-secret', nodeId: 'n1' }))).toBe(
+    'node-credential-lane'
+  );
+});
+
+test('returns stable typed denials without token material', () => {
+  const failure = cliGatewayActorFailure({
+    lane: 'unsupported-route',
+    correlationId: 'corr-cli-deny',
+  });
+
+  expect(failure).toMatchObject({
+    code: 'UNAUTHORIZED',
+    reasonCode: 'CLI_ACTOR_ROUTE_UNSUPPORTED',
+    retryable: false,
+    lane: 'denied',
+    acceptedLanes: ['scoped-actor-credential'],
+    audience: CLI_GATEWAY_ACTOR_AUDIENCE,
+    correlationId: 'corr-cli-deny',
+  });
+  expect(JSON.stringify(failure)).not.toContain('relay-sac-v1');
+});

--- a/test/cli-gateway-claude-tools.test.ts
+++ b/test/cli-gateway-claude-tools.test.ts
@@ -12,6 +12,9 @@ type CapturedGatewayRequest = {
   url: string | undefined;
   authorization: string | undefined;
   marker: string | string[] | undefined;
+  actorMarker?: string | string[] | undefined;
+  command?: string | string[] | undefined;
+  correlationId?: string | string[] | undefined;
   capabilities: string | string[] | undefined;
   body?: Record<string, unknown>;
 };
@@ -63,6 +66,9 @@ test('generated Claude-style CLI gateway tools run the first adapter smoke path'
       url: req.url,
       authorization: req.headers.authorization,
       marker: req.headers['x-relay-cli-gateway'],
+      actorMarker: req.headers['x-relay-cli-actor-token'],
+      command: req.headers['x-relay-cli-command'],
+      correlationId: req.headers['x-relay-correlation-id'],
       capabilities: req.headers['x-relay-capabilities'],
     };
     const chunks: Buffer[] = [];
@@ -180,5 +186,57 @@ test('generated Claude-style CLI gateway tools run the first adapter smoke path'
     path: 'hello.txt',
     maxBytes: 64,
     maxLines: 2,
+  });
+});
+
+
+test('read-only CLI gateway calls can use explicit scoped actor token input', async () => {
+  const tools = generateRelayClaudeGatewayTools(RELAY_CLI_GATEWAY_CONTRACT);
+  const captured: CapturedGatewayRequest[] = [];
+  const server = http.createServer((req, res) => {
+    captured.push({
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.authorization,
+      marker: req.headers['x-relay-cli-gateway'],
+      actorMarker: req.headers['x-relay-cli-actor-token'],
+      command: req.headers['x-relay-cli-command'],
+      correlationId: req.headers['x-relay-correlation-id'],
+      capabilities: req.headers['x-relay-capabilities'],
+    });
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ nodes: [{ nodeId: 'node-a', status: 'online' }] }));
+  });
+
+  const port = await listen(server);
+  try {
+    const runner = new RelayClaudeGatewayToolRunner(tools, {
+      command: process.execPath,
+      commandArgsPrefix: ['dist/bin/relay-ide.js'],
+      env: {
+        ...process.env,
+        RELAY_IDE_PORT: String(port),
+        RELAY_IDE_ACTOR_TOKEN: 'relay-sac-v1.test-credential.[REDACTED]',
+        RELAY_IDE_CORRELATION_ID: 'corr-cli-headers',
+        RELAY_IDE_BROWSER_TOKEN: '',
+      },
+    });
+
+    const nodes = await runner.callTool('relay_nodes_list');
+    expect(nodes).toMatchObject({ ok: true, command: 'nodes.list' });
+  } finally {
+    await close(server);
+  }
+
+  expect(captured).toHaveLength(1);
+  expect(captured[0]).toMatchObject({
+    method: 'GET',
+    url: '/nodes',
+    authorization: 'Bearer relay-sac-v1.test-credential.[REDACTED]',
+    marker: 'v1',
+    actorMarker: 'v1',
+    command: 'nodes.list',
+    correlationId: 'corr-cli-headers',
+    capabilities: 'session:read',
   });
 });

--- a/test/hub-node-session-routing.test.ts
+++ b/test/hub-node-session-routing.test.ts
@@ -283,16 +283,40 @@ describe('hub-routed node session create and attach', () => {
       else res.status(401).json({ error: 'Unauthorized' });
     };
     const cliGatewayAuth: express.RequestHandler = (req, res, next) => {
+      if (req.header('x-test-auth') === 'yes') {
+        next();
+        return;
+      }
+      if (req.header('x-relay-cli-actor-token') === 'v1') {
+        res.status(401).json({ error: 'actor command route binding required' });
+        return;
+      }
       if (
-        req.header('x-test-auth') === 'yes' ||
-        (req.header('x-relay-cli-gateway') === 'v1' &&
-          req.header('authorization') === 'Bearer scoped-test-token')
+        req.header('x-relay-cli-gateway') === 'v1' &&
+        req.header('authorization') === 'Bearer scoped-test-token'
       ) {
         next();
         return;
       }
       res.status(401).json({ error: 'Unauthorized' });
     };
+    const cliGatewayAuthForActorCommand =
+      (expectedCommand: string): express.RequestHandler =>
+      (req, res, next) => {
+        if (req.header('x-relay-cli-actor-token') === 'v1') {
+          if (
+            req.header('x-relay-cli-gateway') === 'v1' &&
+            req.header('authorization') === 'Bearer scoped-test-token' &&
+            req.header('x-relay-cli-command') === expectedCommand
+          ) {
+            next();
+            return;
+          }
+          res.status(401).json({ error: 'actor command route binding required' });
+          return;
+        }
+        cliGatewayAuth(req, res, next);
+      };
     app.use(
       createHubNodeRouter({
         registry,
@@ -302,6 +326,7 @@ describe('hub-routed node session create and attach', () => {
         now,
         requireAuth,
         cliGatewayAuth,
+        cliGatewayAuthForActorCommand,
       })
     );
     const server = http.createServer(app);
@@ -353,6 +378,36 @@ describe('hub-routed node session create and attach', () => {
     expect(await createRes.json()).toMatchObject({
       error: { code: 'NODE_OFFLINE', retryable: true },
     });
+  });
+
+  it('binds actor-token nodes.list auth to /nodes instead of caller-spoofed audit or log routes', async () => {
+    const { base } = await startHub();
+    const { nodeId } = await pairNode(base);
+    const actorHeaders = {
+      authorization: 'Bearer scoped-test-token',
+      'x-relay-cli-gateway': 'v1',
+      'x-relay-cli-actor-token': 'v1',
+      'x-relay-cli-command': 'nodes.list',
+    };
+
+    const nodesRes = await fetch(`${base}/nodes`, { headers: actorHeaders });
+    expect(nodesRes.status).toBe(200);
+    expect(await nodesRes.json()).toMatchObject({ nodes: [{ nodeId }] });
+
+    const auditVerifyRes = await fetch(`${base}/hub/audit/verify`, {
+      headers: actorHeaders,
+    });
+    expect(auditVerifyRes.status).toBe(401);
+
+    const auditEntriesRes = await fetch(`${base}/hub/audit/entries`, {
+      headers: actorHeaders,
+    });
+    expect(auditEntriesRes.status).toBe(401);
+
+    const logsRes = await fetch(`${base}/hub/nodes/nope/logs`, {
+      headers: actorHeaders,
+    });
+    expect(logsRes.status).toBe(401);
   });
 
   it('renews routed scoped session expiry without changing authority', async () => {


### PR DESCRIPTION
## Summary
- add a dedicated scoped actor credential lane for read-only CLI gateway commands
- route `nodes.list`, `sessions.list`, `sessions.get`, and `work-contexts.get` through scoped actor auth instead of requiring broad browser/session credentials
- document the `--actor-token` / `RELAY_IDE_ACTOR_TOKEN` flow and add regression coverage for denial classification and generated Claude gateway headers

## Test Plan
- `npm test -- --run test/cli-gateway-actor-auth.test.ts test/cli-gateway-claude-tools.test.ts test/cli-gateway-codex-tools.test.ts test/scoped-actor-credentials.test.ts`
- `npm run typecheck:test`
- `npm run build`
- `npm run check` (passes with existing lint warnings)
- CLI smoke: `node dist/bin/relay-ide.js v1 nodes manifest --json`
- CLI actor-token smoke against a local fake hub verified `authorization: Bearer relay-sac-v1.smoke.[REDACTED]`, `x-relay-cli-actor-token: v1`, `x-relay-cli-command: nodes.list`, and `x-relay-capabilities: session:read`

## Notes
- Full `npm test` has one environment/baseline failure in `test/fs-browse.test.ts` (`os.homedir()` default browse returned an empty directory in this Hermes profile home). `test/components/FileFeedbackPanel.test.ts` failed once in the full run but passed when rerun targeted.

Closes #805
