### PR TITLE
feat: add Tailscale source diagnostics

### DIFF
--- a/docs/RELAY_NODE_BOOTSTRAP.md
+++ b/docs/RELAY_NODE_BOOTSTRAP.md
@@ -164,9 +164,42 @@ The hub now separates stable node identity from credential records. The stable i
 
 Browser auth is deliberately not part of node reconnect. A browser PIN/cookie can authorize an operator to create a pair token or initiate rotation/revocation through browser routes, but it is never accepted as a node credential. Conversely, `node-credential.json` cannot log in to browser-only routes.
 
-Redaction rule: logs, diagnostics, node summaries, registry snapshots, audit entries, and issue comments may include `nodeId`, `credentialId`, `rotationId`, lifecycle state, and hashed/redacted scope metadata. They must not include pair tokens, raw node credential tokens, token hashes, browser cookies, or secret-bearing command output.
+Redaction rule: logs, diagnostics, node summaries, registry snapshots, audit entries, and issue comments may include `nodeId`, `credentialId`, `rotationId`, lifecycle state, node source diagnostics, and hashed/redacted scope metadata. They must not include pair tokens, raw node credential tokens, token hashes, browser cookies, raw forwarded headers, raw environment values, raw terminal bytes, full path inventories, or secret-bearing command output.
 
-### 5. Verify the node appears online
+### 5. Tailscale/MagicDNS source diagnostics
+
+When a node pairs or authenticates with its node credential, the hub records a redacted source diagnostic for that node credential lane. The signal is used for operator visibility and optional strict enforcement only; it is not a replacement for node credentials, hub ACLs, browser auth, or scoped actor credentials. Normal credential failures still fail normally; source diagnostics only annotate those failures.
+
+Public node summaries and audit rows may expose only:
+
+- `state`
+- `policy` (`audit` or `strict-deny`)
+- `reasonCode`
+- `observedAt`
+- stable `sourceFingerprint` such as `src_<32 hex chars>` when a usable source is present
+- lossy `displayHint` such as `tailscale-ip:100.x.x.x`, `magicdns:ts.net:<suffix>`, `hostname:<suffix>`, or `no tailscale/magicdns signal`
+
+They must not expose raw credentials, pair tokens, bearer headers, browser cookies, raw forwarded headers, raw env values, raw terminal bytes, full path inventories, full hostnames, full MagicDNS names, arbitrary unredacted DNS/host strings, or raw tailnet IPs. Treat `sourceFingerprint` as a stable correlation handle and `displayHint` as a human hint, not as the underlying source tuple.
+
+Diagnostic states:
+
+| State | Operational meaning | Default behavior |
+| --- | --- | --- |
+| `signal-unavailable` | The request did not include a usable Tailscale/MagicDNS source signal. | Allowed and audited. This remains allow/audit even when strict-deny mode is enabled, because lack of signal is not proof of credential replay. |
+| `source-match` | The observed source matches the source bound to the node credential from pairing or a prior valid reconnect. | Allowed and audited. |
+| `source-mismatch` | A usable source signal was observed, but it does not match the credential's expected source. | If the credential otherwise validates, default audit mode allows it and surfaces the mismatch for investigation. With strict-deny mode enabled, this becomes `strict-deny`. |
+| `same-credential-multiple-sources` | The same node credential has been observed from more than one redacted source fingerprint. | If the credential otherwise validates, default audit mode allows it as a high-suspicion warning that usually means a credential was copied or replayed. With strict-deny mode enabled, this becomes `strict-deny`. |
+| `strict-deny` | Strict source enforcement is enabled and a reachable source mismatch was detected. | The node credential auth attempt is rejected with a typed `FORBIDDEN` response carrying redacted `sourceDiagnostics`. |
+
+By default Relay runs source diagnostics in warn/audit mode. To opt in to enforcement for node credential traffic, start the hub with:
+
+```bash
+RELAY_NODE_SOURCE_STRICT_DENY=1 relay-ide hub
+```
+
+Strict source denial is scoped to node credential authentication for heartbeat and `/hub/node-link`. It does not change browser-session routes, scoped actor credentials, pair-token exchange semantics, CLI actor-token behavior, ACL policy, or any future approval UX.
+
+### 6. Verify the node appears online
 
 On the node, hold the steady-state reverse link:
 
@@ -489,8 +522,12 @@ If `RMUX_SDK_DAEMON_BINARY` is set, the probe executes that explicit helper over
 | `NODE_CONNECT_FAILED`         | Node cannot reach hub URL                    | Check DNS, firewall, proxy, TLS                                     |
 | `PROTOCOL_INCOMPATIBLE`       | Hub/node protocol version mismatch           | Update both hub and node to the same Relay version                  |
 | `NODE_STARTED_NO_HEARTBEAT`   | Bootstrap finished but hub sees no heartbeat | Run `relay-ide node status` and `relay-ide node doctor` on the node |
+| `NODE_SOURCE_SIGNAL_UNAVAILABLE` | No usable Tailscale/MagicDNS source signal was available for node credential diagnostics | Check proxy/Tailscale topology if you expected a signal; authentication still proceeds |
+| `NODE_SOURCE_MISMATCH`        | Node credential was presented from a different source fingerprint than expected | Investigate copied credentials or topology changes; strict mode denies this path |
+| `NODE_SOURCE_MULTIPLE_SOURCES` | Same node credential has appeared from multiple source fingerprints | Treat as suspicious credential reuse; rotate/revoke/re-pair if unexpected |
+| `NODE_SOURCE_STRICT_DENY`     | `RELAY_NODE_SOURCE_STRICT_DENY=1` rejected a mismatched reachable source | Re-pair from the intended source or disable strict mode if topology legitimately changed |
 
-All diagnostic output redacts secrets before display. See Token Redaction below.
+All diagnostic output redacts secrets and source material before display. See Token Redaction and Tailscale/MagicDNS source diagnostics above.
 
 ### Credential rejected after revocation
 

--- a/docs/RELAY_NODE_BOOTSTRAP.md
+++ b/docs/RELAY_NODE_BOOTSTRAP.md
@@ -185,11 +185,11 @@ Diagnostic states:
 
 | State | Operational meaning | Default behavior |
 | --- | --- | --- |
-| `signal-unavailable` | The request did not include a usable Tailscale/MagicDNS source signal. | Allowed and audited. This remains allow/audit even when strict-deny mode is enabled, because lack of signal is not proof of credential replay. |
+| `signal-unavailable` | The request did not include a usable socket/Tailscale source signal. Caller-provided source headers are not trusted as authoritative source evidence. | Allowed and audited in default mode. With strict-deny enabled, this is denied when the credential already has a Tailscale/MagicDNS source binding, because an untrusted or missing signal cannot prove the credential is still on the expected source. |
 | `source-match` | The observed source matches the source bound to the node credential from pairing or a prior valid reconnect. | Allowed and audited. |
 | `source-mismatch` | A usable source signal was observed, but it does not match the credential's expected source. | If the credential otherwise validates, default audit mode allows it and surfaces the mismatch for investigation. With strict-deny mode enabled, this becomes `strict-deny`. |
 | `same-credential-multiple-sources` | The same node credential has been observed from more than one redacted source fingerprint. | If the credential otherwise validates, default audit mode allows it as a high-suspicion warning that usually means a credential was copied or replayed. With strict-deny mode enabled, this becomes `strict-deny`. |
-| `strict-deny` | Strict source enforcement is enabled and a reachable source mismatch was detected. | The node credential auth attempt is rejected with a typed `FORBIDDEN` response carrying redacted `sourceDiagnostics`. |
+| `strict-deny` | Strict source enforcement is enabled and the request either mismatched the expected source or lacked trusted source evidence for an already source-bound credential. | The node credential auth attempt is rejected with a typed `FORBIDDEN` response carrying redacted `sourceDiagnostics`. |
 
 By default Relay runs source diagnostics in warn/audit mode. To opt in to enforcement for node credential traffic, start the hub with:
 

--- a/docs/SECURITY_POLICY.md
+++ b/docs/SECURITY_POLICY.md
@@ -58,11 +58,11 @@ State meanings:
 
 | State | Security meaning |
 | --- | --- |
-| `signal-unavailable` | No usable Tailscale/MagicDNS signal was available. This is allowed and audited even under strict mode because it is absence of evidence, not proof of credential movement. |
+| `signal-unavailable` | No usable socket/Tailscale source signal was available. Caller-provided source headers are not trusted as authoritative source evidence. Default policy allows and audits this; strict mode denies it when the credential already has a Tailscale/MagicDNS source binding. |
 | `source-match` | The observed source matches the credential binding. |
 | `source-mismatch` | A usable observed source does not match the credential binding. If the credential otherwise validates, default policy allows and audits it so operators can see topology drift or suspicious reuse. |
 | `same-credential-multiple-sources` | The same credential has appeared from multiple redacted source fingerprints. If the credential otherwise validates, default policy allows it but operators should treat it as suspicious copied/replayed credential evidence unless a topology change explains it. |
-| `strict-deny` | `RELAY_NODE_SOURCE_STRICT_DENY=1` is enabled and a reachable source mismatch was denied. |
+| `strict-deny` | `RELAY_NODE_SOURCE_STRICT_DENY=1` is enabled and a reachable source mismatch or missing trusted source evidence for a source-bound credential was denied. |
 
 Strict mode is an opt-in node-credential control:
 

--- a/docs/SECURITY_POLICY.md
+++ b/docs/SECURITY_POLICY.md
@@ -37,7 +37,40 @@ Browser auth is intentionally non-dependent. Browser PIN/cookie auth can authori
 
 SSH and Tailscale are bootstrap/reachability/binding signals only. They can help deliver install/pair commands, prove that an operator can reach a host, or provide host-binding evidence in diagnostics, but they are not the steady-state Relay application authorization model. Steady-state node authorization comes from the node credential, hub ACL/policy, audit, and revocation.
 
-Node lifecycle audit and diagnostics must stay redacted. It is safe to emit `nodeId`, `credentialId`, `rotationId`, lifecycle state, recovery reason code, and hashed/redacted scope metadata. It is not safe to emit raw pair tokens, raw node credential tokens, token hashes, browser cookies, confirmation tokens, scoped actor bearer material, reverse-link private payloads, full env values, file bytes, or terminal byte streams.
+Node lifecycle audit and diagnostics must stay redacted. It is safe to emit `nodeId`, `credentialId`, `rotationId`, lifecycle state, recovery reason code, source diagnostic state, `observedAt`, stable `sourceFingerprint`, lossy `displayHint`, and hashed/redacted scope metadata. It is not safe to emit raw pair tokens, raw node credential tokens, token hashes, browser cookies, confirmation tokens, scoped actor bearer material, raw forwarded headers, reverse-link private payloads, full env values, file bytes, terminal byte streams, full path inventories, raw tailnet IPs, full MagicDNS names, full hostnames, or arbitrary unredacted DNS/host strings.
+
+## Node source diagnostics
+
+Relay records Tailscale/MagicDNS source diagnostics for node credential authentication. The feature is diagnostic by default: pairing, heartbeat, and `/hub/node-link` credential checks record whether the observed source matches the credential's expected source, but they do not deny an otherwise valid credential unless strict mode is explicitly enabled. Missing, malformed, expired, revoked, or mismatched credentials still fail normally; source diagnostics only annotate those failures.
+
+Public and audit surfaces expose only this redacted shape:
+
+| Field | Meaning |
+| --- | --- |
+| `state` | Diagnostic state: `signal-unavailable`, `source-match`, `source-mismatch`, `same-credential-multiple-sources`, or `strict-deny`. |
+| `policy` | `audit` by default, or `strict-deny` when the hub was started with strict source enforcement. |
+| `reasonCode` | Typed reason such as `NODE_SOURCE_MATCH`, `NODE_SOURCE_MISMATCH`, `NODE_SOURCE_MULTIPLE_SOURCES`, `NODE_SOURCE_SIGNAL_UNAVAILABLE`, or `NODE_SOURCE_STRICT_DENY`. |
+| `observedAt` | Time the credential source was evaluated. |
+| `sourceFingerprint` | Stable `src_<32 hex chars>` correlation handle for the normalized source. Omitted when no usable source exists. |
+| `displayHint` | Lossy operator hint such as `tailscale-ip:100.x.x.x`, `magicdns:ts.net:<suffix>`, `hostname:<suffix>`, or `no tailscale/magicdns signal`. |
+
+State meanings:
+
+| State | Security meaning |
+| --- | --- |
+| `signal-unavailable` | No usable Tailscale/MagicDNS signal was available. This is allowed and audited even under strict mode because it is absence of evidence, not proof of credential movement. |
+| `source-match` | The observed source matches the credential binding. |
+| `source-mismatch` | A usable observed source does not match the credential binding. If the credential otherwise validates, default policy allows and audits it so operators can see topology drift or suspicious reuse. |
+| `same-credential-multiple-sources` | The same credential has appeared from multiple redacted source fingerprints. If the credential otherwise validates, default policy allows it but operators should treat it as suspicious copied/replayed credential evidence unless a topology change explains it. |
+| `strict-deny` | `RELAY_NODE_SOURCE_STRICT_DENY=1` is enabled and a reachable source mismatch was denied. |
+
+Strict mode is an opt-in node-credential control:
+
+```bash
+RELAY_NODE_SOURCE_STRICT_DENY=1 relay-ide hub
+```
+
+It applies to node heartbeat and `/hub/node-link` credential authentication only. It does not implement Tailnet-only authorization, browser route approval, CLI actor-token migration, ACL redesign, or lifecycle semantics beyond the source check described here.
 
 ## Scoped actor credentials
 

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -303,13 +303,13 @@ Operational states:
 
 | State | Meaning | Enforcement behavior |
 | --- | --- | --- |
-| `signal-unavailable` | No usable Tailscale/MagicDNS source signal was observed. | Allowed and audited in both default and strict mode. |
+| `signal-unavailable` | No usable socket/Tailscale source signal was observed. Caller-provided source headers are not trusted as authoritative source evidence. | Allowed and audited in default mode. In strict mode, denied when the credential already has a Tailscale/MagicDNS source binding. |
 | `source-match` | Observed source matches the credential's expected source. | Allowed and audited. |
 | `source-mismatch` | Observed source differs from the expected source. | If the credential otherwise validates, default mode allows and audits; strict mode rewrites the result to `strict-deny`. |
 | `same-credential-multiple-sources` | The same credential has appeared from more than one redacted source fingerprint. | If the credential otherwise validates, default mode allows and audits as suspicious; strict mode rewrites the result to `strict-deny`. |
-| `strict-deny` | Strict enforcement is enabled and a reachable mismatched source presented the credential. | Authentication fails with `FORBIDDEN` and redacted `sourceDiagnostics` details. |
+| `strict-deny` | Strict enforcement is enabled and the credential was presented from a mismatched source or without trusted source evidence for an already source-bound credential. | Authentication fails with `FORBIDDEN` and redacted `sourceDiagnostics` details. |
 
-Default policy is warn/audit. Operators opt in to enforcement by running the hub with `RELAY_NODE_SOURCE_STRICT_DENY=1`. Strict-deny affects node credential authentication only and intentionally leaves `signal-unavailable` as allow/audit so deployments without usable Tailscale/MagicDNS headers do not fail closed by accident.
+Default policy is warn/audit. Operators opt in to enforcement by running the hub with `RELAY_NODE_SOURCE_STRICT_DENY=1`. Strict-deny affects node credential authentication only. For credentials with an existing Tailscale/MagicDNS binding, missing trusted source evidence is denied rather than letting spoofable header-only evidence stand in for the socket source.
 
 `sourceFingerprint` is stable for correlation but hides the source tuple. `displayHint` may reveal only coarse families such as `tailscale-ip:100.x.x.x`, `magicdns:ts.net:<suffix>`, `hostname:<suffix>`, or `no tailscale/magicdns signal`. Public/audit surfaces must not include raw credentials, tokens, headers, env, terminal bytes, full path inventories, raw forwarded headers, or unredacted arbitrary DNS/host strings.
 

--- a/docs/federated-relay.md
+++ b/docs/federated-relay.md
@@ -33,6 +33,7 @@ Implemented/current:
 - Repo inventory: `server/repo-inventory.ts` reports configured repos/worktrees, dirty/divergence summaries, and canonical repo identity; the hub aggregates it through `GET /hub/repo-inventory`.
 - Local hub-as-node: `server/local-node.ts` scopes existing hub-local sessions and file events as the default local node.
 - File RPC (#428, #505, #539, #638): `fs.list`, `fs.stat`, `fs.read`, and `fs.tail` are shipped. `fs.write` is also shipped with the `rpc:fs:write` capability gate, 1 MB cap, atomic-rename semantics on the node executor, and a confirmation gate for prod-tier nodes. See `docs/CLI_GATEWAY.md` for the `files.write` verb shape.
+- Node source diagnostics: node credential auth records redacted Tailscale/MagicDNS source diagnostics on pair/reconnect, exposes only `sourceFingerprint` and lossy `displayHint` on public/audit surfaces, and supports opt-in strict mismatch denial with `RELAY_NODE_SOURCE_STRICT_DENY=1`.
 
 Planned/deferred:
 
@@ -231,7 +232,7 @@ relay-ide node install \
 
 Both commands exchange the pair token, receive a persistent credential, write `node-credential.json`, and send an initial authenticated heartbeat. `node install` then runs the generic Relay service install path for supported service modes. In the current CLI, neither command opens or maintains the persistent reverse WebSocket; run `relay-ide node link --hub <url>` for steady-state session routing.
 
-SSH and Tailscale are bootstrap and reachability mechanisms here: generated commands may use them to deliver the install/pair step, and future diagnostics may use their host identity as binding evidence, but Relay does not treat SSH or Tailscale login as steady-state application authorization. Once paired, hub-node authorization is carried by the node credential on heartbeat and `/hub/node-link`.
+SSH and Tailscale are bootstrap and reachability mechanisms here: generated commands may use them to deliver the install/pair step, and node source diagnostics may record redacted Tailscale/MagicDNS binding evidence for operator visibility. Relay does not treat SSH or Tailscale login as steady-state application authorization. Once paired, hub-node authorization is carried by the node credential on heartbeat and `/hub/node-link`.
 
 > Bootstrap diagnostics pair credentials and install/start the generic Relay service. The persistent `/hub/node-link` reverse WebSocket is opened by `relay-ide node link --hub <url>` (foreground), which can be wrapped by your platform service manager.
 
@@ -279,7 +280,38 @@ The node registry separates node identity from credentials. `HubNodeSummary.iden
 
 Browser sessions are outside this lifecycle. A browser cookie can authorize an operator route that creates a pair token or starts rotation/revocation, but node heartbeat and `/hub/node-link` only accept node credentials. Node credentials are not accepted by browser-only UI routes or scoped actor/CLI routes.
 
-Redaction invariant: public summaries, audit entries, logs, diagnostics, issue comments, and tests may expose ids (`nodeId`, `credentialId`, `rotationId`) and lifecycle state. They must not expose raw pair tokens, raw node credential tokens, token hashes, browser cookies, or private reverse-link payloads.
+Redaction invariant: public summaries, audit entries, logs, diagnostics, issue comments, and tests may expose ids (`nodeId`, `credentialId`, `rotationId`), lifecycle state, source diagnostic state, `reasonCode`, `observedAt`, stable `sourceFingerprint`, and lossy `displayHint`. They must not expose raw pair tokens, raw node credential tokens, token hashes, browser cookies, raw forwarded headers, raw env values, terminal byte streams, full path inventories, private reverse-link payloads, full MagicDNS names, full hostnames, raw tailnet IPs, or arbitrary unredacted DNS/host strings.
+
+### Tailscale/MagicDNS source diagnostics
+
+Node credential authentication records source diagnostics for operator visibility. The binding is attached to the node credential lane only: `POST /hub/pairing/exchange` establishes the initial observed source when available, and later heartbeat or `/hub/node-link` credential checks compare subsequent observed source signals against that binding. Browser sessions, pair-token exchange, scoped actor credentials, ACL policy, and CLI actor-token semantics are separate lanes. Missing, malformed, expired, revoked, or mismatched credentials still fail normally; source diagnostics only annotate those failures.
+
+The public `HubNodeSummary.sourceDiagnostics` shape is deliberately redacted:
+
+```ts
+{
+  state: 'signal-unavailable' | 'source-match' | 'source-mismatch' | 'same-credential-multiple-sources' | 'strict-deny',
+  policy: 'audit' | 'strict-deny',
+  reasonCode: string,
+  observedAt: string,
+  sourceFingerprint?: string, // stable src_<32 hex chars>, not the raw source
+  displayHint?: string        // lossy operator hint, not the raw source
+}
+```
+
+Operational states:
+
+| State | Meaning | Enforcement behavior |
+| --- | --- | --- |
+| `signal-unavailable` | No usable Tailscale/MagicDNS source signal was observed. | Allowed and audited in both default and strict mode. |
+| `source-match` | Observed source matches the credential's expected source. | Allowed and audited. |
+| `source-mismatch` | Observed source differs from the expected source. | If the credential otherwise validates, default mode allows and audits; strict mode rewrites the result to `strict-deny`. |
+| `same-credential-multiple-sources` | The same credential has appeared from more than one redacted source fingerprint. | If the credential otherwise validates, default mode allows and audits as suspicious; strict mode rewrites the result to `strict-deny`. |
+| `strict-deny` | Strict enforcement is enabled and a reachable mismatched source presented the credential. | Authentication fails with `FORBIDDEN` and redacted `sourceDiagnostics` details. |
+
+Default policy is warn/audit. Operators opt in to enforcement by running the hub with `RELAY_NODE_SOURCE_STRICT_DENY=1`. Strict-deny affects node credential authentication only and intentionally leaves `signal-unavailable` as allow/audit so deployments without usable Tailscale/MagicDNS headers do not fail closed by accident.
+
+`sourceFingerprint` is stable for correlation but hides the source tuple. `displayHint` may reveal only coarse families such as `tailscale-ip:100.x.x.x`, `magicdns:ts.net:<suffix>`, `hostname:<suffix>`, or `no tailscale/magicdns signal`. Public/audit surfaces must not include raw credentials, tokens, headers, env, terminal bytes, full path inventories, raw forwarded headers, or unredacted arbitrary DNS/host strings.
 
 ### Credential rotation
 
@@ -645,6 +677,10 @@ The hub returns a diagnostics taxonomy covering the full bootstrap lifecycle:
 | `PAIR_TOKEN_INVALID`            | pair-token        | Malformed, unknown, or already consumed         |
 | `PAIR_TOKEN_EXPIRED`            | pair-token        | Token expired before exchange                   |
 | `NODE_CREDENTIAL_REJECTED`      | node-auth         | Credential was revoked or rejected              |
+| `NODE_SOURCE_SIGNAL_UNAVAILABLE` | node-auth        | No usable Tailscale/MagicDNS source signal      |
+| `NODE_SOURCE_MISMATCH`          | node-auth         | Credential source differs from expected binding |
+| `NODE_SOURCE_MULTIPLE_SOURCES`  | node-auth         | Credential appeared from multiple source fingerprints |
+| `NODE_SOURCE_STRICT_DENY`       | node-auth         | Strict source policy denied a mismatch          |
 | `NODE_CONNECT_FAILED`           | connect-back      | Node cannot reach hub for heartbeat             |
 | `PROTOCOL_INCOMPATIBLE`         | protocol          | Hub/node protocol versions incompatible         |
 | `NODE_STARTED_NO_HEARTBEAT`     | heartbeat         | Bootstrap exited but no heartbeat observed      |
@@ -657,7 +693,7 @@ relay-ide node logs              # Service logs (launchd/systemd)
 relay-ide node doctor --hub URL  # Reachability and capability checks
 ```
 
-All diagnostics redact secrets (pair tokens, bearer headers, credentials) before display.
+All diagnostics redact secrets (pair tokens, bearer headers, credentials) and source material before display; source diagnostics expose only stable `sourceFingerprint` and lossy `displayHint`.
 
 ## WSL Caveats
 

--- a/server/hub-node-link.ts
+++ b/server/hub-node-link.ts
@@ -2,7 +2,7 @@ import * as crypto from 'node:crypto';
 import type * as http from 'node:http';
 import { WebSocket } from 'ws';
 import type { RawData } from 'ws';
-import type { HubNodeRegistry } from './hub-node-registry.js';
+import type { CredentialAuthContext, HubNodeRegistry } from './hub-node-registry.js';
 import { isNodeManifest, type NodeManifest } from '../shared/node-manifest.js';
 import {
   RELAY_NODE_LINK_PROTOCOL,
@@ -17,6 +17,10 @@ interface AuthenticatedNodeLink {
   token: string;
   credentialId: string;
 }
+
+export type HubNodeLinkAuthenticationResult =
+  | { ok: true; authenticated: AuthenticatedNodeLink }
+  | { ok: false; status: number; error?: RelayNodeError };
 
 interface PendingRpc {
   nodeId: string;
@@ -70,15 +74,37 @@ function bearerToken(request: http.IncomingMessage): string | null {
   return match?.[1]?.trim() || null;
 }
 
+function hubNodeLinkAuthStatus(error: RelayNodeError): number {
+  switch (error.code) {
+    case 'FORBIDDEN':
+    case 'NODE_REVOKED':
+    case 'NODE_CREDENTIAL_EXPIRED':
+    case 'REPAIR_REQUIRED':
+      return 403;
+    default:
+      return 401;
+  }
+}
+
 export function authenticateHubNodeLink(
   request: http.IncomingMessage,
-  registry: HubNodeRegistry | undefined
-): AuthenticatedNodeLink | null {
-  if (!registry) return null;
+  registry: HubNodeRegistry | undefined,
+  context: CredentialAuthContext = {}
+): HubNodeLinkAuthenticationResult {
+  if (!registry) return { ok: false, status: 401 };
   const token = bearerToken(request);
-  if (!token) return null;
-  const auth = registry.authenticateCredentialDetailed(token);
-  return auth.ok ? { node: auth.node, token, credentialId: auth.credentialId } : null;
+  if (!token) return { ok: false, status: 401 };
+  const auth = registry.authenticateCredentialDetailed(token, context);
+  if (auth.ok) {
+    return {
+      ok: true,
+      authenticated: { node: auth.node, token, credentialId: auth.credentialId },
+    };
+  }
+  const error = auth.ok === false ? auth.error : undefined;
+  return error
+    ? { ok: false, status: hubNodeLinkAuthStatus(error), error }
+    : { ok: false, status: 401 };
 }
 
 function envelope(

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -21,7 +21,16 @@ import {
   type RelayNodeCredentialRecordSummary,
   type RelayNodeError,
   type RelayNodeErrorCode,
+  type RelayNodeSourceDiagnostics,
 } from '../shared/relay-node-protocol.js';
+import {
+  evaluateRelayNodeSource,
+  hasTailscaleSourceSignal,
+  sourceDisplayHint,
+  sourceFingerprint,
+  sourceTupleWithHostname,
+  type RelayNodeSourceTuple,
+} from './node-source-diagnostics.js';
 import { classifyHelperSkew } from './node-version-skew.js';
 import {
   RELAY_SECURITY_POLICY_VERSION,
@@ -81,6 +90,13 @@ interface StoredActiveCredential {
   revokedAt?: string;
 }
 
+interface StoredNodeSourceBinding {
+  expected?: RelayNodeSourceTuple;
+  lastObserved?: RelayNodeSourceTuple;
+  observedFingerprints?: string[];
+  diagnostics?: RelayNodeSourceDiagnostics;
+}
+
 interface StoredNodeRecord {
   nodeId: string;
   identity?: StoredNodeIdentity;
@@ -109,6 +125,7 @@ interface StoredNodeRecord {
   acl?: RelayNodeAcl;
   repoInventory?: unknown;
   credentialRotation?: StoredCredentialRotation;
+  sourceBinding?: StoredNodeSourceBinding;
   createdAt: string;
   pairedAt: string;
   lastSeenAt: string;
@@ -135,6 +152,7 @@ export interface PairExchangeInput {
   manifest: NodeManifest;
   displayName?: string;
   protocolVersion?: string;
+  source?: RelayNodeSourceTuple;
 }
 
 export interface HeartbeatInput {
@@ -196,6 +214,11 @@ export type CredentialAuthResult =
       rotationId?: string;
     }
   | { ok: false; error: RelayNodeError };
+
+export interface CredentialAuthContext {
+  source?: RelayNodeSourceTuple;
+  strictSourceDeny?: boolean;
+}
 
 export interface HubNodeStatusEvent {
   nodeId: string;
@@ -528,6 +551,51 @@ function ensureSeparatedCredential(node: StoredNodeRecord): StoredActiveCredenti
   return node.activeCredential;
 }
 
+function sourceBindingForNode(node: StoredNodeRecord): StoredNodeSourceBinding {
+  node.sourceBinding ??= {};
+  node.sourceBinding.observedFingerprints ??= [];
+  return node.sourceBinding;
+}
+
+function publicSourceDiagnostics(
+  diagnostics: RelayNodeSourceDiagnostics | undefined
+): RelayNodeSourceDiagnostics | undefined {
+  if (!diagnostics) return undefined;
+  return {
+    state: diagnostics.state,
+    policy: diagnostics.policy,
+    reasonCode: diagnostics.reasonCode,
+    observedAt: diagnostics.observedAt,
+    ...(diagnostics.sourceFingerprint
+      ? { sourceFingerprint: diagnostics.sourceFingerprint }
+      : {}),
+    ...(diagnostics.displayHint ? { displayHint: diagnostics.displayHint } : {}),
+  };
+}
+
+function sourceDiagnosticsForAuthDenied(input: {
+  source?: RelayNodeSourceTuple | undefined;
+  now: string;
+  strictDeny?: boolean | undefined;
+  fingerprintKey?: string | undefined;
+}): RelayNodeSourceDiagnostics {
+  const normalized = sourceTupleWithHostname(input.source, undefined);
+  const hasSignal = hasTailscaleSourceSignal(normalized);
+  const fingerprint = normalized
+    ? sourceFingerprint(normalized, input.fingerprintKey)
+    : undefined;
+  return {
+    state: hasSignal ? 'source-mismatch' : 'signal-unavailable',
+    policy: input.strictDeny ? 'strict-deny' : 'audit',
+    reasonCode: hasSignal
+      ? 'TAILSCALE_REACHABLE_RELAY_AUTH_DENIED'
+      : 'NODE_SOURCE_SIGNAL_UNAVAILABLE',
+    observedAt: input.now,
+    ...(fingerprint ? { sourceFingerprint: fingerprint } : {}),
+    displayHint: sourceDisplayHint(normalized, fingerprint),
+  };
+}
+
 function credentialSummary(node: StoredNodeRecord): RelayNodeCredentialRecordSummary {
   const credential = ensureSeparatedCredential(node);
   const state = credentialState(node);
@@ -622,6 +690,7 @@ function publicNode(
   const rotationSummary = node.credentialRotation
     ? publicRotation(node.credentialRotation)
     : undefined;
+  const sourceDiagnostics = publicSourceDiagnostics(node.sourceBinding?.diagnostics);
 
   let helperSkew: HubNodeHelperSkewSummary | undefined;
   if (hubVersion && (node.helperVersion || node.relayVersion)) {
@@ -676,6 +745,7 @@ function publicNode(
     ...(node.degradedReasons && node.degradedReasons.length > 0
       ? { degradedReasons: node.degradedReasons }
       : {}),
+    ...(sourceDiagnostics ? { sourceDiagnostics } : {}),
     createdAt: node.createdAt,
     pairedAt: node.pairedAt,
     lastSeenAt: node.lastSeenAt,
@@ -816,6 +886,13 @@ export class HubNodeRegistry {
       input.displayName ?? pairToken.displayName,
       input.manifest
     );
+    const pairedSource = sourceTupleWithHostname(
+      input.source,
+      input.manifest.hostname
+    );
+    const pairedSourceFingerprint = pairedSource
+      ? sourceFingerprint(pairedSource, credential.hash)
+      : undefined;
     const node: StoredNodeRecord = {
       nodeId,
       identity: {
@@ -853,6 +930,31 @@ export class HubNodeRegistry {
         createdAt: timestamp,
       }),
       credentialIssuedAt: timestamp,
+      ...(pairedSource
+        ? {
+            sourceBinding: {
+              expected: pairedSource,
+              lastObserved: pairedSource,
+              observedFingerprints: pairedSourceFingerprint
+                ? [pairedSourceFingerprint]
+                : [],
+              diagnostics: {
+                state: hasTailscaleSourceSignal(pairedSource)
+                  ? 'source-match'
+                  : 'signal-unavailable',
+                policy: 'audit',
+                reasonCode: hasTailscaleSourceSignal(pairedSource)
+                  ? 'NODE_SOURCE_MATCH'
+                  : 'NODE_SOURCE_SIGNAL_UNAVAILABLE',
+                observedAt: timestamp,
+                ...(pairedSourceFingerprint
+                  ? { sourceFingerprint: pairedSourceFingerprint }
+                  : {}),
+                displayHint: sourceDisplayHint(pairedSource, pairedSourceFingerprint),
+              },
+            },
+          }
+        : {}),
       createdAt: timestamp,
       pairedAt: timestamp,
       lastSeenAt: timestamp,
@@ -882,18 +984,22 @@ export class HubNodeRegistry {
     };
   }
 
-  authenticateCredential(token: string): HubNodeSummary | null {
-    const result = this.authenticateCredentialDetailed(token);
+  authenticateCredential(token: string, context: CredentialAuthContext = {}): HubNodeSummary | null {
+    const result = this.authenticateCredentialDetailed(token, context);
     return result.ok ? result.node : null;
   }
 
   private parseCredentialToken(
-    token: string
+    token: string,
+    context: CredentialAuthContext = {}
   ):
     | { ok: true; nodeId: string }
     | { ok: false; result: CredentialAuthResult } {
     if (token.length === 0) {
-      return { ok: false, result: this.credentialDenied('NODE_CREDENTIAL_MISSING') };
+      return {
+        ok: false,
+        result: this.credentialDenied('NODE_CREDENTIAL_MISSING', undefined, undefined, context),
+      };
     }
     const firstSeparator = token.indexOf('.');
     if (
@@ -901,11 +1007,17 @@ export class HubNodeRegistry {
       firstSeparator === token.length - 1 ||
       token.indexOf('.', firstSeparator + 1) !== -1
     ) {
-      return { ok: false, result: this.credentialDenied('NODE_CREDENTIAL_MALFORMED') };
+      return {
+        ok: false,
+        result: this.credentialDenied('NODE_CREDENTIAL_MALFORMED', undefined, undefined, context),
+      };
     }
     const nodeId = token.slice(0, firstSeparator);
     if (!nodeId.startsWith('node_')) {
-      return { ok: false, result: this.credentialDenied('NODE_CREDENTIAL_MALFORMED') };
+      return {
+        ok: false,
+        result: this.credentialDenied('NODE_CREDENTIAL_MALFORMED', undefined, undefined, context),
+      };
     }
     return { ok: true, nodeId };
   }
@@ -913,20 +1025,31 @@ export class HubNodeRegistry {
   private credentialDenied(
     code: RelayNodeErrorCode,
     node?: StoredNodeRecord,
-    nodeId?: string
+    nodeId?: string,
+    context: CredentialAuthContext = {}
   ): CredentialAuthResult {
-    const error = this.credentialError(code);
+    const sourceDiagnostics = sourceDiagnosticsForAuthDenied({
+      source: context.source,
+      now: this.now().toISOString(),
+      strictDeny: context.strictSourceDeny,
+      ...(node ? { fingerprintKey: ensureSeparatedCredential(node).tokenHash } : {}),
+    });
+    const error = this.credentialError(code, sourceDiagnostics);
     this.auditNodeCredentialLifecycle({
       ...(node ? { node } : {}),
       ...(nodeId ? { nodeId } : {}),
       decision: code === 'NODE_CREDENTIAL_EXPIRED' ? 'expired' : 'deny',
       eventType: code === 'NODE_CREDENTIAL_EXPIRED' ? 'expiry' : 'denial',
       reasonCode: code,
+      sourceDiagnostics,
     });
     return { ok: false, error };
   }
 
-  private credentialError(code: RelayNodeErrorCode): RelayNodeError {
+  private credentialError(
+    code: RelayNodeErrorCode,
+    sourceDiagnostics?: RelayNodeSourceDiagnostics
+  ): RelayNodeError {
     const messages: Partial<Record<RelayNodeErrorCode, string>> = {
       NODE_CREDENTIAL_MISSING: 'node credential is missing; re-pair this node',
       NODE_CREDENTIAL_MALFORMED:
@@ -941,7 +1064,10 @@ export class HubNodeRegistry {
       code,
       message: messages[code] ?? 'invalid node credential',
       retryable: false,
-      details: { reasonCode: code },
+      details: {
+        reasonCode: code,
+        ...(sourceDiagnostics ? { sourceDiagnostics } : {}),
+      },
     };
   }
 
@@ -953,6 +1079,7 @@ export class HubNodeRegistry {
     eventType: SecurityAuditEventType;
     reasonCode: string;
     action?: string;
+    sourceDiagnostics?: RelayNodeSourceDiagnostics;
   }): void {
     if (!this.auditSink) return;
     const nodeId = input.node?.nodeId ?? input.nodeId;
@@ -975,8 +1102,14 @@ export class HubNodeRegistry {
           params: {
             recoveryReason: input.reasonCode,
             hasCredentialId: Boolean(input.credentialId),
+            ...(input.sourceDiagnostics
+              ? { sourceState: input.sourceDiagnostics.state }
+              : {}),
           },
         },
+        ...(input.sourceDiagnostics
+          ? { sourceDiagnostics: input.sourceDiagnostics }
+          : {}),
       });
     } catch {
       // Best-effort lifecycle visibility only. Authentication remains
@@ -985,9 +1118,43 @@ export class HubNodeRegistry {
     }
   }
 
-  authenticateCredentialDetailed(token: string): CredentialAuthResult {
+  private recordSourceObservation(
+    node: StoredNodeRecord,
+    context: CredentialAuthContext,
+    fingerprintKey: string,
+    now: string
+  ): RelayNodeSourceDiagnostics {
+    const binding = sourceBindingForNode(node);
+    const observed = sourceTupleWithHostname(context.source, node.identity?.hostname ?? node.hostname);
+    if (!binding.expected && observed && hasTailscaleSourceSignal(observed)) {
+      binding.expected = observed;
+    }
+    const evaluation = evaluateRelayNodeSource({
+      expected: binding.expected,
+      observed,
+      observedFingerprints: binding.observedFingerprints,
+      strictDeny: context.strictSourceDeny,
+      fingerprintKey,
+      now,
+    });
+    if (evaluation.normalizedObserved) {
+      binding.lastObserved = evaluation.normalizedObserved;
+    }
+    if (evaluation.observedFingerprint) {
+      const fingerprints = new Set(binding.observedFingerprints ?? []);
+      fingerprints.add(evaluation.observedFingerprint);
+      binding.observedFingerprints = Array.from(fingerprints).slice(-8);
+    }
+    binding.diagnostics = evaluation.diagnostics;
+    return evaluation.diagnostics;
+  }
+
+  authenticateCredentialDetailed(
+    token: string,
+    context: CredentialAuthContext = {}
+  ): CredentialAuthResult {
     const trimmedToken = token.trim();
-    const parsed = this.parseCredentialToken(trimmedToken);
+    const parsed = this.parseCredentialToken(trimmedToken, context);
     if (parsed.ok === false) return parsed.result;
     const { nodeId } = parsed;
     const tokenHash = sha256(trimmedToken);
@@ -1009,20 +1176,51 @@ export class HubNodeRegistry {
         : node.credentialRotation?.state === 'stable'
           ? 'REPAIR_REQUIRED'
           : 'NODE_CREDENTIAL_MISMATCH';
-      return this.credentialDenied(code, node, nodeId);
+      return this.credentialDenied(code, node, nodeId, context);
     }
     if (activeCredential?.expiresAt) {
       const expiresAt = Date.parse(activeCredential.expiresAt);
       if (Number.isFinite(expiresAt) && expiresAt <= this.now().getTime()) {
-        return this.credentialDenied('NODE_CREDENTIAL_EXPIRED', node, nodeId);
+        return this.credentialDenied('NODE_CREDENTIAL_EXPIRED', node, nodeId, context);
       }
     }
     if (node.revokedAt) {
-      return this.credentialDenied('NODE_REVOKED', node, nodeId);
+      return this.credentialDenied('NODE_REVOKED', node, nodeId, context);
     }
     const credentialId = matchesRotation
       ? rotation!.nextCredentialId
       : node.credentialId;
+    const sourceDiagnostics = this.recordSourceObservation(
+      node,
+      context,
+      matchesRotation ? rotation!.nextCredentialHash! : activeCredential!.tokenHash,
+      this.now().toISOString()
+    );
+    if (sourceDiagnostics.state === 'strict-deny') {
+      this.persist();
+      this.auditNodeCredentialLifecycle({
+        node,
+        credentialId,
+        decision: 'deny',
+        eventType: 'denial',
+        reasonCode: sourceDiagnostics.reasonCode,
+        sourceDiagnostics,
+      });
+      return {
+        ok: false,
+        error: {
+          code: 'FORBIDDEN',
+          message:
+            'node credential source does not match the expected Tailscale/MagicDNS binding',
+          retryable: false,
+          details: {
+            reasonCode: sourceDiagnostics.reasonCode,
+            sourceDiagnostics,
+          },
+        },
+      };
+    }
+    this.persist();
     this.auditNodeCredentialLifecycle({
       node,
       credentialId,
@@ -1031,6 +1229,7 @@ export class HubNodeRegistry {
       reasonCode: matchesRotation
         ? 'NODE_CREDENTIAL_ROTATION_RECONNECT_ALLOWED'
         : 'NODE_CREDENTIAL_RECONNECT_ALLOWED',
+      sourceDiagnostics,
     });
     return {
       ok: true,

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -83,6 +83,7 @@ import {
 import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
 import type { RelayCliGatewayError } from '../shared/cli-gateway-contract.js';
 import { validateAndSanitizeGatewayCreateInput } from '../shared/cli-gateway-runtime.js';
+import { sourceTupleFromRequest } from './node-source-diagnostics.js';
 
 const FILE_RPC_FOLLOW_STREAM_BUFFER_BYTES = 256 * 1024;
 
@@ -137,6 +138,9 @@ interface HubNodeRouterOptions {
   auditSink?: RoutedSessionAuditSink;
   workContextStore?: WorkContextStore;
   readModelCache?: RoutedSessionReadModelCache;
+  sourceDiagnostics?: {
+    strictDeny?: boolean;
+  };
   now?: () => Date;
 }
 
@@ -215,6 +219,8 @@ export function errorStatus(error: RelayNodeError): number {
     case 'NODE_CREDENTIAL_MALFORMED':
     case 'NODE_CREDENTIAL_MISMATCH':
       return 401;
+    case 'FORBIDDEN':
+      return 403;
     case 'ROTATION_IN_PROGRESS':
     case 'CONFIRMATION_REQUIRED':
       return 409;
@@ -1989,12 +1995,14 @@ export function createHubNodeRouter(
         typeof body['displayName'] === 'string'
           ? body['displayName']
           : undefined;
+      const source = sourceTupleFromRequest(req);
       res.status(201).json(
         registry.exchangePairToken({
           pairToken,
           manifest,
           ...(displayName ? { displayName } : {}),
           ...(protocolVersion ? { protocolVersion } : {}),
+          ...(source ? { source } : {}),
         })
       );
     } catch (error) {
@@ -2004,9 +2012,16 @@ export function createHubNodeRouter(
 
   router.post('/hub/node-heartbeat', (req, res) => {
     const token = bearerToken(req);
+    const source = sourceTupleFromRequest(req);
+    const authContext = {
+      ...(source ? { source } : {}),
+      ...(options.sourceDiagnostics?.strictDeny
+        ? { strictSourceDeny: true }
+        : {}),
+    };
     const authenticated = token
-      ? registry.authenticateCredentialDetailed(token)
-      : registry.authenticateCredentialDetailed('');
+      ? registry.authenticateCredentialDetailed(token, authContext)
+      : registry.authenticateCredentialDetailed('', authContext);
     if (authenticated.ok === false) {
       const { error } = authenticated;
       res.status(errorStatus(error)).json({ error });

--- a/server/index.ts
+++ b/server/index.ts
@@ -1912,7 +1912,8 @@ async function main(): Promise<void> {
     hubNodeRegistry,
     hubNodeLinks,
     sessionEnvelopeRegistry,
-    securityAuditLog
+    securityAuditLog,
+    { strictDeny: process.env.RELAY_NODE_SOURCE_STRICT_DENY === '1' }
   );
 
   const browserScopedToken = generateScopedToken();

--- a/server/index.ts
+++ b/server/index.ts
@@ -1730,6 +1730,9 @@ async function main(): Promise<void> {
       renewLocalSession: localRelayNode.sessions.renew,
       workContextStore,
       readModelCache: remoteSessionReadModelCache,
+      sourceDiagnostics: {
+        strictDeny: process.env.RELAY_NODE_SOURCE_STRICT_DENY === '1',
+      },
       ...(securityAuditLog ? { auditSink: securityAuditLog } : {}),
     })
   );

--- a/server/node-source-diagnostics.ts
+++ b/server/node-source-diagnostics.ts
@@ -1,4 +1,5 @@
 import * as crypto from 'node:crypto';
+import type * as http from 'node:http';
 import type { Request } from 'express';
 import type {
   RelayNodeSourceDiagnostics,
@@ -41,6 +42,20 @@ function firstHeader(req: Request, names: readonly string[]): string | undefined
   for (const name of names) {
     const value = req.header(name);
     const first = value?.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  return undefined;
+}
+
+function firstIncomingHeader(
+  request: http.IncomingMessage,
+  names: readonly string[]
+): string | undefined {
+  for (const name of names) {
+    const value = request.headers[name.toLowerCase()];
+    const first = (Array.isArray(value) ? value[0] : value)
+      ?.split(',')[0]
+      ?.trim();
     if (first) return first;
   }
   return undefined;
@@ -130,6 +145,23 @@ export function sourceTupleFromRequest(req: Request): RelayNodeSourceTuple | und
   const tailnetIp =
     firstHeader(req, SOURCE_HEADER_NAMES.tailnetIp) ?? normalizeIp(remoteAddress);
   const magicDnsName = firstHeader(req, SOURCE_HEADER_NAMES.magicDnsName);
+  return normalizeRelayNodeSourceTuple({
+    ...(tailnetIp ? { tailnetIp } : {}),
+    ...(magicDnsName ? { magicDnsName } : {}),
+  });
+}
+
+export function sourceTupleFromIncomingMessage(
+  request: http.IncomingMessage
+): RelayNodeSourceTuple | undefined {
+  const remoteAddress = request.socket.remoteAddress;
+  const tailnetIp =
+    firstIncomingHeader(request, SOURCE_HEADER_NAMES.tailnetIp) ??
+    normalizeIp(remoteAddress);
+  const magicDnsName = firstIncomingHeader(
+    request,
+    SOURCE_HEADER_NAMES.magicDnsName
+  );
   return normalizeRelayNodeSourceTuple({
     ...(tailnetIp ? { tailnetIp } : {}),
     ...(magicDnsName ? { magicDnsName } : {}),

--- a/server/node-source-diagnostics.ts
+++ b/server/node-source-diagnostics.ts
@@ -49,7 +49,7 @@ function firstHeader(req: Request, names: readonly string[]): string | undefined
 function normalizeIp(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) return undefined;
-  const withoutIpv6Prefix = trimmed.startsWith('::ffff:')
+  const withoutIpv6Prefix = /^::ffff:/i.test(trimmed)
     ? trimmed.slice('::ffff:'.length)
     : trimmed;
   return isTailscaleIp(withoutIpv6Prefix) ? withoutIpv6Prefix.toLowerCase() : undefined;
@@ -186,19 +186,13 @@ export function sourcesMatch(
   observed: RelayNodeSourceTuple | undefined
 ): boolean {
   if (!expected || !observed) return false;
-  const comparable: (keyof RelayNodeSourceTuple)[] = [
-    'tailnetIp',
-    'magicDnsName',
-    'hostname',
-  ];
-  let sawComparable = false;
+  const comparable: (keyof RelayNodeSourceTuple)[] = ['tailnetIp', 'magicDnsName'];
   for (const key of comparable) {
-    if (expected[key] && observed[key]) {
-      sawComparable = true;
-      if (expected[key] !== observed[key]) return false;
+    if (expected[key] && observed[key] && expected[key] === observed[key]) {
+      return true;
     }
   }
-  return sawComparable;
+  return false;
 }
 
 export function evaluateRelayNodeSource(input: {
@@ -215,11 +209,15 @@ export function evaluateRelayNodeSource(input: {
     ? sourceFingerprint(observed, input.fingerprintKey)
     : undefined;
   if (!hasTailscaleSourceSignal(observed)) {
+    const strictUnavailableDeny =
+      Boolean(input.strictDeny) && hasTailscaleSourceSignal(expected);
     return {
       diagnostics: {
-        state: 'signal-unavailable',
+        state: strictUnavailableDeny ? 'strict-deny' : 'signal-unavailable',
         policy: input.strictDeny ? 'strict-deny' : 'audit',
-        reasonCode: 'NODE_SOURCE_SIGNAL_UNAVAILABLE',
+        reasonCode: strictUnavailableDeny
+          ? 'NODE_SOURCE_STRICT_DENY'
+          : 'NODE_SOURCE_SIGNAL_UNAVAILABLE',
         observedAt: input.now,
         displayHint: sourceDisplayHint(undefined),
       },

--- a/server/node-source-diagnostics.ts
+++ b/server/node-source-diagnostics.ts
@@ -21,44 +21,8 @@ export interface RelayNodeSourceEvaluation {
 
 const MAGICDNS_SUFFIX_PATTERN = /(^|\.)ts\.net$/i;
 const MAGICDNS_LEGACY_SUFFIX_PATTERN = /(^|\.)beta\.tailscale\.net$/i;
-const SOURCE_HEADER_NAMES = {
-  tailnetIp: [
-    'x-relay-node-tailnet-ip',
-    'x-relay-tailnet-ip',
-    'x-tailscale-ip',
-  ],
-  magicDnsName: [
-    'x-relay-node-magicdns-name',
-    'x-relay-magicdns-name',
-    'x-tailscale-magicdns-name',
-  ],
-} as const;
-
 function stableJson(value: unknown): string {
   return JSON.stringify(value, Object.keys(value as Record<string, unknown>).sort());
-}
-
-function firstHeader(req: Request, names: readonly string[]): string | undefined {
-  for (const name of names) {
-    const value = req.header(name);
-    const first = value?.split(',')[0]?.trim();
-    if (first) return first;
-  }
-  return undefined;
-}
-
-function firstIncomingHeader(
-  request: http.IncomingMessage,
-  names: readonly string[]
-): string | undefined {
-  for (const name of names) {
-    const value = request.headers[name.toLowerCase()];
-    const first = (Array.isArray(value) ? value[0] : value)
-      ?.split(',')[0]
-      ?.trim();
-    if (first) return first;
-  }
-  return undefined;
 }
 
 function normalizeIp(value: string | undefined): string | undefined {
@@ -142,29 +106,18 @@ export function sourceTupleWithHostname(
 
 export function sourceTupleFromRequest(req: Request): RelayNodeSourceTuple | undefined {
   const remoteAddress = req.socket.remoteAddress ?? req.ip;
-  const tailnetIp =
-    firstHeader(req, SOURCE_HEADER_NAMES.tailnetIp) ?? normalizeIp(remoteAddress);
-  const magicDnsName = firstHeader(req, SOURCE_HEADER_NAMES.magicDnsName);
+  const tailnetIp = normalizeIp(remoteAddress);
   return normalizeRelayNodeSourceTuple({
     ...(tailnetIp ? { tailnetIp } : {}),
-    ...(magicDnsName ? { magicDnsName } : {}),
   });
 }
 
 export function sourceTupleFromIncomingMessage(
   request: http.IncomingMessage
 ): RelayNodeSourceTuple | undefined {
-  const remoteAddress = request.socket.remoteAddress;
-  const tailnetIp =
-    firstIncomingHeader(request, SOURCE_HEADER_NAMES.tailnetIp) ??
-    normalizeIp(remoteAddress);
-  const magicDnsName = firstIncomingHeader(
-    request,
-    SOURCE_HEADER_NAMES.magicDnsName
-  );
+  const tailnetIp = normalizeIp(request.socket.remoteAddress);
   return normalizeRelayNodeSourceTuple({
     ...(tailnetIp ? { tailnetIp } : {}),
-    ...(magicDnsName ? { magicDnsName } : {}),
   });
 }
 

--- a/server/node-source-diagnostics.ts
+++ b/server/node-source-diagnostics.ts
@@ -1,0 +1,258 @@
+import * as crypto from 'node:crypto';
+import type { Request } from 'express';
+import type {
+  RelayNodeSourceDiagnostics,
+  RelayNodeSourceState,
+} from '../shared/relay-node-protocol.js';
+
+export interface RelayNodeSourceTuple {
+  tailnetIp?: string;
+  magicDnsName?: string;
+  hostname?: string;
+}
+
+export interface RelayNodeSourceEvaluation {
+  diagnostics: RelayNodeSourceDiagnostics;
+  normalizedObserved?: RelayNodeSourceTuple | undefined;
+  observedFingerprint?: string | undefined;
+  matchesExpected: boolean;
+}
+
+const MAGICDNS_SUFFIX_PATTERN = /(^|\.)ts\.net$/i;
+const MAGICDNS_LEGACY_SUFFIX_PATTERN = /(^|\.)beta\.tailscale\.net$/i;
+const SOURCE_HEADER_NAMES = {
+  tailnetIp: [
+    'x-relay-node-tailnet-ip',
+    'x-relay-tailnet-ip',
+    'x-tailscale-ip',
+  ],
+  magicDnsName: [
+    'x-relay-node-magicdns-name',
+    'x-relay-magicdns-name',
+    'x-tailscale-magicdns-name',
+  ],
+} as const;
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value, Object.keys(value as Record<string, unknown>).sort());
+}
+
+function firstHeader(req: Request, names: readonly string[]): string | undefined {
+  for (const name of names) {
+    const value = req.header(name);
+    const first = value?.split(',')[0]?.trim();
+    if (first) return first;
+  }
+  return undefined;
+}
+
+function normalizeIp(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  const withoutIpv6Prefix = trimmed.startsWith('::ffff:')
+    ? trimmed.slice('::ffff:'.length)
+    : trimmed;
+  return isTailscaleIp(withoutIpv6Prefix) ? withoutIpv6Prefix.toLowerCase() : undefined;
+}
+
+function isTailscaleIp(value: string): boolean {
+  const ipv4 = value.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (ipv4) {
+    const octets = ipv4.slice(1).map((part) => Number.parseInt(part, 10));
+    if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+      return false;
+    }
+    return octets[0]! === 100 && octets[1]! >= 64 && octets[1]! <= 127;
+  }
+  return value.toLowerCase().startsWith('fd7a:115c:a1e0:');
+}
+
+function normalizeDnsName(value: string | undefined): string | undefined {
+  const trimmed = value?.trim().replace(/\.$/, '').toLowerCase();
+  if (!trimmed || trimmed.length > 253) return undefined;
+  if (
+    !MAGICDNS_SUFFIX_PATTERN.test(trimmed) &&
+    !MAGICDNS_LEGACY_SUFFIX_PATTERN.test(trimmed)
+  ) {
+    return undefined;
+  }
+  const labels = trimmed.split('.');
+  if (
+    labels.some(
+      (label) =>
+        label.length === 0 ||
+        label.length > 63 ||
+        !/^[a-z0-9-]+$/.test(label) ||
+        label.startsWith('-') ||
+        label.endsWith('-')
+    )
+  ) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function normalizeHostname(value: string | undefined): string | undefined {
+  const trimmed = value?.trim().replace(/\.$/, '').toLowerCase();
+  if (!trimmed || trimmed.length > 253) return undefined;
+  if (!/^[a-z0-9._-]+$/.test(trimmed)) return undefined;
+  return trimmed;
+}
+
+export function normalizeRelayNodeSourceTuple(
+  source: RelayNodeSourceTuple | undefined
+): RelayNodeSourceTuple | undefined {
+  const tailnetIp = normalizeIp(source?.tailnetIp);
+  const magicDnsName = normalizeDnsName(source?.magicDnsName);
+  const hostname = normalizeHostname(source?.hostname);
+  const normalized: RelayNodeSourceTuple = {
+    ...(tailnetIp ? { tailnetIp } : {}),
+    ...(magicDnsName ? { magicDnsName } : {}),
+    ...(hostname ? { hostname } : {}),
+  };
+  return hasTailscaleSourceSignal(normalized) || normalized.hostname
+    ? normalized
+    : undefined;
+}
+
+export function sourceTupleWithHostname(
+  source: RelayNodeSourceTuple | undefined,
+  hostname: string | undefined
+): RelayNodeSourceTuple | undefined {
+  return normalizeRelayNodeSourceTuple({
+    ...(source ?? {}),
+    ...(hostname ? { hostname } : {}),
+  });
+}
+
+export function sourceTupleFromRequest(req: Request): RelayNodeSourceTuple | undefined {
+  const remoteAddress = req.socket.remoteAddress ?? req.ip;
+  const tailnetIp =
+    firstHeader(req, SOURCE_HEADER_NAMES.tailnetIp) ?? normalizeIp(remoteAddress);
+  const magicDnsName = firstHeader(req, SOURCE_HEADER_NAMES.magicDnsName);
+  return normalizeRelayNodeSourceTuple({
+    ...(tailnetIp ? { tailnetIp } : {}),
+    ...(magicDnsName ? { magicDnsName } : {}),
+  });
+}
+
+export function hasTailscaleSourceSignal(
+  source: RelayNodeSourceTuple | undefined
+): boolean {
+  return Boolean(source?.tailnetIp || source?.magicDnsName);
+}
+
+export function sourceFingerprint(
+  source: RelayNodeSourceTuple,
+  fingerprintKey = 'relay-node-source-fingerprint-v1'
+): string {
+  const material = {
+    ...(source.tailnetIp ? { tailnetIp: source.tailnetIp } : {}),
+    ...(source.magicDnsName ? { magicDnsName: source.magicDnsName } : {}),
+    ...(source.hostname ? { hostname: source.hostname } : {}),
+  };
+  return `src_${crypto
+    .createHmac('sha256', fingerprintKey)
+    .update(stableJson(material))
+    .digest('hex')
+    .slice(0, 32)}`;
+}
+
+function lossyIpHint(ip: string): string {
+  if (ip.includes('.')) {
+    const [a] = ip.split('.');
+    return `${a}.x.x.x`;
+  }
+  return `${ip.split(':')[0]}:…`;
+}
+
+function lossyDnsHint(name: string, fingerprint?: string): string {
+  const suffix = name.endsWith('.beta.tailscale.net') ? 'beta.tailscale.net' : 'ts.net';
+  return `${suffix}:${(fingerprint ?? 'src_unknown').slice(-8)}`;
+}
+
+export function sourceDisplayHint(
+  source: RelayNodeSourceTuple | undefined,
+  fingerprint?: string
+): string {
+  if (source?.tailnetIp) return `tailscale-ip:${lossyIpHint(source.tailnetIp)}`;
+  if (source?.magicDnsName) return `magicdns:${lossyDnsHint(source.magicDnsName, fingerprint)}`;
+  if (source?.hostname || fingerprint) return `hostname:${(fingerprint ?? sourceFingerprint(source!)).slice(-8)}`;
+  return 'no tailscale/magicdns signal';
+}
+
+export function sourcesMatch(
+  expected: RelayNodeSourceTuple | undefined,
+  observed: RelayNodeSourceTuple | undefined
+): boolean {
+  if (!expected || !observed) return false;
+  const comparable: (keyof RelayNodeSourceTuple)[] = [
+    'tailnetIp',
+    'magicDnsName',
+    'hostname',
+  ];
+  let sawComparable = false;
+  for (const key of comparable) {
+    if (expected[key] && observed[key]) {
+      sawComparable = true;
+      if (expected[key] !== observed[key]) return false;
+    }
+  }
+  return sawComparable;
+}
+
+export function evaluateRelayNodeSource(input: {
+  expected?: RelayNodeSourceTuple | undefined;
+  observed?: RelayNodeSourceTuple | undefined;
+  observedFingerprints?: string[] | undefined;
+  strictDeny?: boolean | undefined;
+  fingerprintKey?: string | undefined;
+  now: string;
+}): RelayNodeSourceEvaluation {
+  const observed = normalizeRelayNodeSourceTuple(input.observed);
+  const expected = normalizeRelayNodeSourceTuple(input.expected);
+  const observedFingerprint = observed
+    ? sourceFingerprint(observed, input.fingerprintKey)
+    : undefined;
+  if (!hasTailscaleSourceSignal(observed)) {
+    return {
+      diagnostics: {
+        state: 'signal-unavailable',
+        policy: input.strictDeny ? 'strict-deny' : 'audit',
+        reasonCode: 'NODE_SOURCE_SIGNAL_UNAVAILABLE',
+        observedAt: input.now,
+        displayHint: sourceDisplayHint(undefined),
+      },
+      ...(observed ? { normalizedObserved: observed } : {}),
+      ...(observedFingerprint ? { observedFingerprint } : {}),
+      matchesExpected: false,
+    };
+  }
+
+  const unique = new Set(input.observedFingerprints ?? []);
+  if (observedFingerprint) unique.add(observedFingerprint);
+  const matchesExpected = sourcesMatch(expected, observed);
+  let state: RelayNodeSourceState = matchesExpected ? 'source-match' : 'source-mismatch';
+  let reasonCode = matchesExpected ? 'NODE_SOURCE_MATCH' : 'NODE_SOURCE_MISMATCH';
+  if (!matchesExpected && unique.size > 1) {
+    state = 'same-credential-multiple-sources';
+    reasonCode = 'NODE_SOURCE_MULTIPLE_SOURCES';
+  }
+  if (input.strictDeny && !matchesExpected) {
+    state = 'strict-deny';
+    reasonCode = 'NODE_SOURCE_STRICT_DENY';
+  }
+  return {
+    diagnostics: {
+      state,
+      policy: input.strictDeny ? 'strict-deny' : 'audit',
+      reasonCode,
+      observedAt: input.now,
+      ...(observedFingerprint ? { sourceFingerprint: observedFingerprint } : {}),
+      displayHint: sourceDisplayHint(observed, observedFingerprint),
+    },
+    ...(observed ? { normalizedObserved: observed } : {}),
+    ...(observedFingerprint ? { observedFingerprint } : {}),
+    matchesExpected,
+  };
+}

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -1,6 +1,8 @@
 import { WebSocketServer, WebSocket } from 'ws';
 import type { RawData } from 'ws';
 import http from 'node:http';
+import type { Duplex } from 'node:stream';
+import { URL } from 'node:url';
 import type { IPty } from 'node-pty';
 import * as sessions from './sessions.js';
 import { WorktreeWatcher } from './watcher.js';
@@ -46,6 +48,7 @@ import {
   evaluateHubPolicy,
   policyDecisionToRelayError,
 } from './hub-policy-evaluator.js';
+import { sourceTupleFromIncomingMessage } from './node-source-diagnostics.js';
 
 const logger = createLogger('ws');
 
@@ -476,6 +479,10 @@ function parseCookies(
   return cookies;
 }
 
+interface NodeLinkSourceDiagnosticsOptions {
+  strictDeny?: boolean;
+}
+
 function setupWebSocket(
   server: http.Server,
   authenticatedTokens: Set<string>,
@@ -486,13 +493,17 @@ function setupWebSocket(
   hubNodeRegistry?: HubNodeRegistry,
   nodeLinks?: HubNodeLinkManager,
   sessionEnvelopes: InMemorySessionEnvelopeRegistry = sessionEnvelopeRegistry,
-  auditSink?: RoutedSessionAuditSink
+  auditSink?: RoutedSessionAuditSink,
+  sourceDiagnostics?: NodeLinkSourceDiagnosticsOptions
 ): {
   wss: WebSocketServer;
   broadcastEvent: (type: string, data?: Record<string, unknown>) => void;
   broadcastBranchChanged: (cwdPath: string, branchName: string) => void;
 } {
   const wss = new WebSocketServer({ noServer: true });
+  const nodeLinkStrictSourceDeny =
+    sourceDiagnostics?.strictDeny ??
+    process.env.RELAY_NODE_SOURCE_STRICT_DENY === '1';
   const eventClients = new Set<WebSocket>();
 
   function isAuthenticated(cookieHeader: string | undefined): boolean {
@@ -609,19 +620,33 @@ function setupWebSocket(
     if (nodeStatusRefreshTimer) clearInterval(nodeStatusRefreshTimer);
   });
 
+  function handleNodeLinkUpgrade(
+    request: http.IncomingMessage,
+    socket: Duplex,
+    head: Buffer
+  ): boolean {
+    const source = sourceTupleFromIncomingMessage(request);
+    const authenticated = authenticateHubNodeLink(request, hubNodeRegistry, {
+      ...(source ? { source } : {}),
+      ...(nodeLinkStrictSourceDeny ? { strictSourceDeny: true } : {}),
+    });
+    if (authenticated.ok === false || !hubNodeRegistry) {
+      const status = authenticated.ok === false ? authenticated.status : 401;
+      const reason = status === 403 ? 'Forbidden' : 'Unauthorized';
+      socket.write(`HTTP/1.1 ${status} ${reason}\r\n\r\n`);
+      socket.destroy();
+      return true;
+    }
+    wss.handleUpgrade(request, socket, head, (ws) => {
+      handleHubNodeLink(ws, hubNodeRegistry, authenticated.authenticated, nodeLinks);
+    });
+    return true;
+  }
+
   server.on('upgrade', (request, socket, head) => {
     const requestUrl = new URL(request.url ?? '/', 'http://relay.local');
     const requestPath = requestUrl.pathname.replace(/\/$/, '');
-    if (requestPath === '/hub/node-link') {
-      const authenticated = authenticateHubNodeLink(request, hubNodeRegistry);
-      if (!authenticated || !hubNodeRegistry) {
-        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
-        socket.destroy();
-        return;
-      }
-      wss.handleUpgrade(request, socket, head, (ws) => {
-        handleHubNodeLink(ws, hubNodeRegistry, authenticated, nodeLinks);
-      });
+    if (requestPath === '/hub/node-link' && handleNodeLinkUpgrade(request, socket, head)) {
       return;
     }
 

--- a/shared/relay-node-protocol.ts
+++ b/shared/relay-node-protocol.ts
@@ -130,6 +130,22 @@ export type HubNodeVersionState =
   | 'version-skew'
   | 'incompatible';
 
+export type RelayNodeSourceState =
+  | 'signal-unavailable'
+  | 'source-match'
+  | 'source-mismatch'
+  | 'same-credential-multiple-sources'
+  | 'strict-deny';
+
+export interface RelayNodeSourceDiagnostics {
+  state: RelayNodeSourceState;
+  policy: 'audit' | 'strict-deny';
+  reasonCode: string;
+  observedAt: string;
+  sourceFingerprint?: string;
+  displayHint?: string;
+}
+
 /**
  * Hub↔node helper-version (binary) skew categories.
  * Distinct from the node-link protocol version check:
@@ -251,6 +267,12 @@ export interface HubNodeSummary {
    * when the manifest includes `degradedReasons[]`. Empty on healthy nodes.
    */
   degradedReasons?: NodeManifestDegradedReason[];
+  /**
+   * Tailscale/MagicDNS-aware source binding diagnostics. This is intentionally
+   * lossy: public surfaces expose only a stable fingerprint and display hint,
+   * never raw headers, bearer material, DNS names, host inventories, or paths.
+   */
+  sourceDiagnostics?: RelayNodeSourceDiagnostics;
   createdAt: string;
   pairedAt: string;
   lastSeenAt: string;

--- a/shared/security-audit.ts
+++ b/shared/security-audit.ts
@@ -1,5 +1,6 @@
 import * as crypto from 'node:crypto';
 import type { ControlActor, TabControlEvent } from './control-state.js';
+import type { RelayNodeSourceDiagnostics } from './relay-node-protocol.js';
 import {
   HIGH_RISK_CAPABILITIES,
   RELAY_SECURITY_POLICY_VERSION,
@@ -83,6 +84,7 @@ export interface NormalizedSecurityAuditEntry {
   deniedBits: RelayCapabilityBit[];
   aclRef?: string;
   policyVersion?: string;
+  sourceDiagnostics?: RelayNodeSourceDiagnostics;
   correlationId: string;
   prevHash: string | null;
   entryHash: string;
@@ -103,6 +105,7 @@ export interface SecurityAuditEntryInput {
   grantedBits?: RelayCapabilityBit[];
   deniedBits?: RelayCapabilityBit[];
   refs?: SecurityAuditRefs;
+  sourceDiagnostics?: RelayNodeSourceDiagnostics;
   correlationId?: string;
 }
 
@@ -420,6 +423,9 @@ export function normalizeSecurityAuditEntry(
     ...(input.refs?.aclRef ? { aclRef: input.refs.aclRef } : {}),
     ...(input.refs?.policyVersion
       ? { policyVersion: input.refs.policyVersion }
+      : {}),
+    ...(input.sourceDiagnostics
+      ? { sourceDiagnostics: input.sourceDiagnostics }
       : {}),
     correlationId: input.correlationId ?? crypto.randomUUID(),
     prevHash: chain.prevHash,

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -460,12 +460,15 @@ describe('hub node registry', () => {
         exchanged.credential.token,
         { strictSourceDeny: true }
       );
-      expect(strictUnavailable.ok).toBe(true);
-      if (strictUnavailable.ok) {
-        expect(strictUnavailable.node.sourceDiagnostics?.state).toBe(
-          'signal-unavailable'
-        );
-      }
+      const strictUnavailableError =
+        'error' in strictUnavailable ? strictUnavailable.error : undefined;
+      expect(strictUnavailableError).toMatchObject({
+        code: 'FORBIDDEN',
+        details: {
+          reasonCode: 'NODE_SOURCE_STRICT_DENY',
+          sourceDiagnostics: { state: 'strict-deny' },
+        },
+      });
 
       const strictDeny = registry.authenticateCredentialDetailed(
         exchanged.credential.token,

--- a/test/hub-node-registry.test.ts
+++ b/test/hub-node-registry.test.ts
@@ -382,6 +382,136 @@ describe('hub node registry', () => {
     });
   });
 
+  it('tracks Tailscale/MagicDNS source diagnostics without exposing raw source material', () => {
+    const auditEntries: SecurityAuditEntryInput[] = [];
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-hub-node-registry-source-')
+    );
+    try {
+      const registry = createHubNodeRegistry({
+        storagePath: path.join(tmpDir, 'nodes.json'),
+        now: () => new Date('2026-01-02T03:04:05.000Z'),
+        auditSink: { append: (entry) => auditEntries.push(entry) },
+      });
+      const pair = registry.createPairToken({ displayName: 'Dogfood Mac' });
+      const exchanged = registry.exchangePairToken({
+        pairToken: pair.pairToken,
+        manifest: manifest({ hostname: 'donovans-secret-macbook' }),
+        source: {
+          tailnetIp: '100.90.12.34',
+          magicDnsName: 'donovans-secret-macbook.tailnet.ts.net',
+        },
+      });
+
+      expect(exchanged.node.sourceDiagnostics).toMatchObject({
+        state: 'source-match',
+        policy: 'audit',
+        reasonCode: 'NODE_SOURCE_MATCH',
+        sourceFingerprint: expect.stringMatching(/^src_[a-f0-9]{32}$/),
+      });
+      const publicPairDiagnostics = JSON.stringify(
+        exchanged.node.sourceDiagnostics
+      );
+      expect(publicPairDiagnostics).not.toContain('100.90.12.34');
+      expect(publicPairDiagnostics).not.toContain(
+        'donovans-secret-macbook.tailnet.ts.net'
+      );
+      expect(publicPairDiagnostics).not.toContain('donovans-secret-macbook');
+
+      const matched = registry.authenticateCredentialDetailed(
+        exchanged.credential.token,
+        {
+          source: {
+            tailnetIp: '100.90.12.34',
+            magicDnsName: 'donovans-secret-macbook.tailnet.ts.net',
+          },
+        }
+      );
+      expect(matched.ok).toBe(true);
+      if (matched.ok) {
+        expect(matched.node.sourceDiagnostics?.state).toBe('source-match');
+      }
+
+      const unavailable = registry.authenticateCredentialDetailed(
+        exchanged.credential.token,
+        {}
+      );
+      expect(unavailable.ok).toBe(true);
+      if (unavailable.ok) {
+        expect(unavailable.node.sourceDiagnostics).toMatchObject({
+          state: 'signal-unavailable',
+          reasonCode: 'NODE_SOURCE_SIGNAL_UNAVAILABLE',
+        });
+      }
+
+      const mismatch = registry.authenticateCredentialDetailed(
+        exchanged.credential.token,
+        { source: { tailnetIp: '100.91.1.2' } }
+      );
+      expect(mismatch.ok).toBe(true);
+      if (mismatch.ok) {
+        expect(mismatch.node.sourceDiagnostics).toMatchObject({
+          state: 'same-credential-multiple-sources',
+          reasonCode: 'NODE_SOURCE_MULTIPLE_SOURCES',
+        });
+      }
+
+      const strictUnavailable = registry.authenticateCredentialDetailed(
+        exchanged.credential.token,
+        { strictSourceDeny: true }
+      );
+      expect(strictUnavailable.ok).toBe(true);
+      if (strictUnavailable.ok) {
+        expect(strictUnavailable.node.sourceDiagnostics?.state).toBe(
+          'signal-unavailable'
+        );
+      }
+
+      const strictDeny = registry.authenticateCredentialDetailed(
+        exchanged.credential.token,
+        { source: { tailnetIp: '100.92.3.4' }, strictSourceDeny: true }
+      );
+      const strictError = 'error' in strictDeny ? strictDeny.error : undefined;
+      expect(strictError).toMatchObject({
+        code: 'FORBIDDEN',
+        details: {
+          reasonCode: 'NODE_SOURCE_STRICT_DENY',
+          sourceDiagnostics: { state: 'strict-deny' },
+        },
+      });
+
+      const auditJson = JSON.stringify(auditEntries);
+      expect(auditJson).toContain('sourceDiagnostics');
+      expect(auditJson).not.toContain(exchanged.credential.token);
+      expect(auditJson).not.toContain('100.90.12.34');
+      expect(auditJson).not.toContain(
+        'donovans-secret-macbook.tailnet.ts.net'
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('distinguishes Tailscale-reachable Relay auth denial from missing source signal', () => {
+    withTmpRegistry((registry) => {
+      const reachable = registry.authenticateCredentialDetailed('not-a-token', {
+        source: { tailnetIp: '100.80.1.2' },
+      });
+      const unavailable = registry.authenticateCredentialDetailed('not-a-token');
+
+      const reachableError = 'error' in reachable ? reachable.error : undefined;
+      const unavailableError = 'error' in unavailable ? unavailable.error : undefined;
+      expect(reachableError?.details?.['sourceDiagnostics']).toMatchObject({
+        state: 'source-mismatch',
+        reasonCode: 'TAILSCALE_REACHABLE_RELAY_AUTH_DENIED',
+      });
+      expect(unavailableError?.details?.['sourceDiagnostics']).toMatchObject({
+        state: 'signal-unavailable',
+        reasonCode: 'NODE_SOURCE_SIGNAL_UNAVAILABLE',
+      });
+    });
+  });
+
   it('persists paired nodes and authenticates durable node credentials after reload', () => {
     const tmpDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'relay-hub-node-registry-')

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -565,6 +565,77 @@ describe('hub node routes and link', () => {
     expect(revokedHeartbeatBody).not.toContain(exchange.credential.token);
   });
 
+  it('keeps strict source denial scoped to the node credential lane', async () => {
+    const { tmpDir, registry } = tmpRegistry();
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const app = express();
+    app.use(express.json());
+    app.use(
+      createHubNodeRouter({
+        registry,
+        sourceDiagnostics: { strictDeny: true },
+        requireAuth: (req, res, next) => {
+          if (req.header('x-test-auth') === 'yes') next();
+          else res.status(401).json(auth.browserSessionRequiredChallenge());
+        },
+      })
+    );
+    const server = http.createServer(app);
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+    const base = `http://127.0.0.1:${port}`;
+
+    const pairRes = await fetch(`${base}/hub/pair-tokens`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      body: JSON.stringify({ displayName: 'Strict Node' }),
+    });
+    const pair = (await pairRes.json()) as { pairToken: string };
+    const exchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-relay-node-tailnet-ip': '100.90.12.34',
+      },
+      body: JSON.stringify({ pairToken: pair.pairToken, manifest: manifest() }),
+    });
+    expect(exchangeRes.status).toBe(201);
+    const exchanged = (await exchangeRes.json()) as {
+      credential: { token: string; nodeId: string };
+    };
+
+    const deniedHeartbeat = await fetch(`${base}/hub/node-heartbeat`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${exchanged.credential.token}`,
+        'x-relay-node-tailnet-ip': '100.91.1.2',
+      },
+      body: JSON.stringify({
+        nodeId: exchanged.credential.nodeId,
+        protocolVersion: '1.0',
+      }),
+    });
+    expect(deniedHeartbeat.status).toBe(403);
+    expect(await deniedHeartbeat.json()).toMatchObject({
+      error: {
+        code: 'FORBIDDEN',
+        details: { sourceDiagnostics: { state: 'strict-deny' } },
+      },
+    });
+
+    const nodesRes = await fetch(`${base}/nodes`, {
+      headers: { 'x-test-auth': 'yes' },
+    });
+    expect(nodesRes.status).toBe(200);
+    const nodes = (await nodesRes.json()) as {
+      nodes: Array<{ sourceDiagnostics?: { sourceFingerprint?: string } }>;
+    };
+    expect(nodes.nodes[0]?.sourceDiagnostics?.sourceFingerprint).toMatch(
+      /^src_[a-f0-9]{32}$/
+    );
+  });
+
   it('accepts authenticated reverse websocket heartbeats and rejects incompatible protocol envelopes with typed errors', async () => {
     let now = new Date('2026-01-02T03:04:05.000Z');
     const { tmpDir, registry } = tmpRegistry(() => now);

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -636,6 +636,57 @@ describe('hub node routes and link', () => {
     );
   });
 
+  it('denies strict source mismatches on reverse websocket upgrades while allowing matching sources', async () => {
+    const previousStrictDeny = process.env.RELAY_NODE_SOURCE_STRICT_DENY;
+    process.env.RELAY_NODE_SOURCE_STRICT_DENY = '1';
+    cleanup.push(() => {
+      if (previousStrictDeny === undefined) {
+        delete process.env.RELAY_NODE_SOURCE_STRICT_DENY;
+      } else {
+        process.env.RELAY_NODE_SOURCE_STRICT_DENY = previousStrictDeny;
+      }
+    });
+
+    const { tmpDir, registry } = tmpRegistry();
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const exchanged = registry.exchangePairToken({
+      pairToken: registry.createPairToken({}).pairToken,
+      manifest: manifest(),
+      source: { tailnetIp: '100.90.12.34' },
+    });
+
+    const server = http.createServer(express());
+    setupWebSocket(
+      server,
+      new Set(),
+      null,
+      undefined,
+      false,
+      undefined,
+      registry
+    );
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+
+    const mismatchedUpgrade = await rawUpgrade(port, '/hub/node-link', {
+      Authorization: `Bearer ${exchanged.credential.token}`,
+      'x-relay-node-tailnet-ip': '100.91.1.2',
+    });
+    expect(mismatchedUpgrade).toMatch(/^HTTP\/1\.1 403/);
+
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/hub/node-link`, {
+      headers: {
+        authorization: `Bearer ${exchanged.credential.token}`,
+        'x-relay-node-tailnet-ip': '100.90.12.34',
+      },
+    });
+    cleanup.push(() => ws.close());
+    await new Promise<void>((resolve, reject) => {
+      ws.once('open', resolve);
+      ws.once('error', reject);
+    });
+  });
+
   it('accepts authenticated reverse websocket heartbeats and rejects incompatible protocol envelopes with typed errors', async () => {
     let now = new Date('2026-01-02T03:04:05.000Z');
     const { tmpDir, registry } = tmpRegistry(() => now);

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -585,24 +585,11 @@ describe('hub node routes and link', () => {
     cleanup.push(() => close(server));
     const base = `http://127.0.0.1:${port}`;
 
-    const pairRes = await fetch(`${base}/hub/pair-tokens`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
-      body: JSON.stringify({ displayName: 'Strict Node' }),
+    const exchanged = registry.exchangePairToken({
+      pairToken: registry.createPairToken({ displayName: 'Strict Node' }).pairToken,
+      manifest: manifest(),
+      source: { tailnetIp: '100.90.12.34' },
     });
-    const pair = (await pairRes.json()) as { pairToken: string };
-    const exchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        'x-relay-node-tailnet-ip': '100.90.12.34',
-      },
-      body: JSON.stringify({ pairToken: pair.pairToken, manifest: manifest() }),
-    });
-    expect(exchangeRes.status).toBe(201);
-    const exchanged = (await exchangeRes.json()) as {
-      credential: { token: string; nodeId: string };
-    };
 
     const deniedHeartbeat = await fetch(`${base}/hub/node-heartbeat`, {
       method: 'POST',
@@ -629,14 +616,15 @@ describe('hub node routes and link', () => {
     });
     expect(nodesRes.status).toBe(200);
     const nodes = (await nodesRes.json()) as {
-      nodes: Array<{ sourceDiagnostics?: { sourceFingerprint?: string } }>;
+      nodes: Array<{ sourceDiagnostics?: { state?: string; reasonCode?: string } }>;
     };
-    expect(nodes.nodes[0]?.sourceDiagnostics?.sourceFingerprint).toMatch(
-      /^src_[a-f0-9]{32}$/
-    );
+    expect(nodes.nodes[0]?.sourceDiagnostics).toMatchObject({
+      state: 'strict-deny',
+      reasonCode: 'NODE_SOURCE_STRICT_DENY',
+    });
   });
 
-  it('denies strict source mismatches on reverse websocket upgrades while allowing matching sources', async () => {
+  it('denies spoofed source headers on reverse websocket upgrades while allowing unbound credentials', async () => {
     const previousStrictDeny = process.env.RELAY_NODE_SOURCE_STRICT_DENY;
     process.env.RELAY_NODE_SOURCE_STRICT_DENY = '1';
     cleanup.push(() => {
@@ -674,10 +662,13 @@ describe('hub node routes and link', () => {
     });
     expect(mismatchedUpgrade).toMatch(/^HTTP\/1\.1 403/);
 
+    const unboundExchanged = registry.exchangePairToken({
+      pairToken: registry.createPairToken({}).pairToken,
+      manifest: manifest(),
+    });
     const ws = new WebSocket(`ws://127.0.0.1:${port}/hub/node-link`, {
       headers: {
-        authorization: `Bearer ${exchanged.credential.token}`,
-        'x-relay-node-tailnet-ip': '100.90.12.34',
+        authorization: `Bearer ${unboundExchanged.credential.token}`,
       },
     });
     cleanup.push(() => ws.close());

--- a/test/source-diagnostics.test.ts
+++ b/test/source-diagnostics.test.ts
@@ -1,8 +1,37 @@
+import type { IncomingMessage } from 'node:http';
+import type { Request } from 'express';
 import { describe, expect, it } from 'vitest';
 import {
   evaluateRelayNodeSource,
+  sourceTupleFromIncomingMessage,
+  sourceTupleFromRequest,
   sourcesMatch,
 } from '../server/node-source-diagnostics.js';
+
+function fakeExpressRequest(input: {
+  remoteAddress?: string;
+  ip?: string;
+  headers?: Record<string, string>;
+}): Request {
+  const headers = new Map(
+    Object.entries(input.headers ?? {}).map(([key, value]) => [key.toLowerCase(), value])
+  );
+  return {
+    socket: { remoteAddress: input.remoteAddress },
+    ip: input.ip,
+    header: (name: string) => headers.get(name.toLowerCase()),
+  } as unknown as Request;
+}
+
+function fakeIncomingMessage(input: {
+  remoteAddress?: string;
+  headers?: Record<string, string>;
+}): IncomingMessage {
+  return {
+    socket: { remoteAddress: input.remoteAddress },
+    headers: input.headers ?? {},
+  } as unknown as IncomingMessage;
+}
 
 describe('relay node source diagnostics', () => {
   it('strict-denies unavailable source when a Tailscale source is already bound', () => {
@@ -48,5 +77,53 @@ describe('relay node source diagnostics', () => {
     expect(evaluation.matchesExpected).toBe(true);
     expect(evaluation.normalizedObserved).toMatchObject({ tailnetIp: '100.64.0.9' });
     expect(evaluation.diagnostics.state).toBe('source-match');
+  });
+
+  it('ignores caller-controlled source headers on HTTP requests', () => {
+    expect(
+      sourceTupleFromRequest(
+        fakeExpressRequest({
+          remoteAddress: '127.0.0.1',
+          ip: '127.0.0.1',
+          headers: {
+            'x-relay-node-tailnet-ip': '100.64.0.9',
+            'x-relay-node-magicdns-name': 'forged.tailnet.ts.net',
+          },
+        })
+      )
+    ).toBeUndefined();
+
+    expect(
+      sourceTupleFromRequest(
+        fakeExpressRequest({
+          remoteAddress: '100.64.0.10',
+          ip: '100.64.0.10',
+          headers: { 'x-relay-node-tailnet-ip': '100.64.0.9' },
+        })
+      )
+    ).toEqual({ tailnetIp: '100.64.0.10' });
+  });
+
+  it('ignores caller-controlled source headers on websocket upgrade requests', () => {
+    expect(
+      sourceTupleFromIncomingMessage(
+        fakeIncomingMessage({
+          remoteAddress: '127.0.0.1',
+          headers: {
+            'x-relay-node-tailnet-ip': '100.64.0.9',
+            'x-relay-node-magicdns-name': 'forged.tailnet.ts.net',
+          },
+        })
+      )
+    ).toBeUndefined();
+
+    expect(
+      sourceTupleFromIncomingMessage(
+        fakeIncomingMessage({
+          remoteAddress: '100.64.0.10',
+          headers: { 'x-relay-node-tailnet-ip': '100.64.0.9' },
+        })
+      )
+    ).toEqual({ tailnetIp: '100.64.0.10' });
   });
 });

--- a/test/source-diagnostics.test.ts
+++ b/test/source-diagnostics.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateRelayNodeSource,
+  sourcesMatch,
+} from '../server/node-source-diagnostics.js';
+
+describe('relay node source diagnostics', () => {
+  it('strict-denies unavailable source when a Tailscale source is already bound', () => {
+    const evaluation = evaluateRelayNodeSource({
+      expected: { tailnetIp: '100.64.0.9' },
+      observed: undefined,
+      strictDeny: true,
+      now: '2026-01-02T03:04:05.000Z',
+    });
+
+    expect(evaluation.matchesExpected).toBe(false);
+    expect(evaluation.diagnostics).toMatchObject({
+      state: 'strict-deny',
+      policy: 'strict-deny',
+      reasonCode: 'NODE_SOURCE_STRICT_DENY',
+    });
+  });
+
+  it('matches stable Tailscale signals even when hostname display hints change', () => {
+    expect(
+      sourcesMatch(
+        {
+          tailnetIp: '100.64.0.9',
+          magicDnsName: 'old-host.tailnet.ts.net',
+          hostname: 'old-host',
+        },
+        {
+          tailnetIp: '100.64.0.9',
+          magicDnsName: 'new-host.tailnet.ts.net',
+          hostname: 'new-host',
+        }
+      )
+    ).toBe(true);
+  });
+
+  it('normalizes uppercase IPv4-mapped Tailscale addresses', () => {
+    const evaluation = evaluateRelayNodeSource({
+      expected: { tailnetIp: '100.64.0.9' },
+      observed: { tailnetIp: '::FFFF:100.64.0.9' },
+      now: '2026-01-02T03:04:05.000Z',
+    });
+
+    expect(evaluation.matchesExpected).toBe(true);
+    expect(evaluation.normalizedObserved).toMatchObject({ tailnetIp: '100.64.0.9' });
+    expect(evaluation.diagnostics.state).toBe('source-match');
+  });
+});


### PR DESCRIPTION
## Summary
- add Tailscale/MagicDNS source tuple extraction and redacted source diagnostics for node credential auth
- persist expected/observed source binding internally while exposing only sourceFingerprint/displayHint on public and audit surfaces
- add strict opt-in source-deny handling scoped to node heartbeat credential traffic via RELAY_NODE_SOURCE_STRICT_DENY=1

## Tests
- npm run check
- npm test -- test/hub-node-registry.test.ts
- npm test -- test/hub-node-routes.test.ts

Closes #806

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded bootstrapping and security docs with detailed, privacy-preserving node source diagnostics, redaction boundaries, new diagnostic states, and updated troubleshooting guidance.

* **New Features**
  * Added node source diagnostics to surface a lossy fingerprint and display hint for connection origin signals, plus an opt-in strict-deny mode (RELAY_NODE_SOURCE_STRICT_DENY) that can block mismatched sources.

* **Tests**
  * Added coverage for source evaluation, redaction behavior, and strict-deny enforcement scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/810?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->