### PR TITLE
Add high-risk approval hook contract

### DIFF
--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -71,7 +71,7 @@ Error:
 }
 ```
 
-The current error taxonomy is declared in `RELAY_CLI_GATEWAY_CONTRACT.errorEnvelopeSchema`. It includes auth/connectivity errors, typed create/validation errors, file RPC errors (`NOT_FOUND`, `FORBIDDEN`, `NODE_OFFLINE`, `CONFIRMATION_REQUIRED`), control hand-back state errors (`CONTROL_STATE_STALE`, `INTERVENTION_ACK_REQUIRED`, `INTERVENTION_ACK_STALE`, `CONTROL_STATE_UNKNOWN`), and typed supervisor action errors. Multi-target supervisor action denials can also appear inside a successful action envelope as per-target `results[].error` entries; see [Supervisor typed actions and rmux mapping](#supervisor-typed-actions-and-rmux-mapping-704).
+The current error taxonomy is declared in `RELAY_CLI_GATEWAY_CONTRACT.errorEnvelopeSchema`. It includes auth/connectivity errors, typed create/validation errors, file RPC errors (`NOT_FOUND`, `FORBIDDEN`, `NODE_OFFLINE`, `CONFIRMATION_REQUIRED`), control hand-back state errors (`CONTROL_STATE_STALE`, `INTERVENTION_ACK_REQUIRED`, `INTERVENTION_ACK_STALE`, `CONTROL_STATE_UNKNOWN`), and typed supervisor action errors. Multi-target supervisor action denials can also appear inside a successful action envelope as per-target `results[].error` entries; see [Supervisor typed actions and rmux mapping](#supervisor-typed-actions-and-rmux-mapping-704). `CONFIRMATION_REQUIRED` means the agent must pause for a human/operator approval of the exact operation described by the returned challenge; it is not a prompt to ask for a broader grant.
 
 ## Discovery and schemas
 
@@ -289,6 +289,21 @@ Fail-closed examples:
 
 The gateway must never silently downgrade unsupported scoped, privileged, or control-mode requests.
 
+## Exact-operation confirmation challenges (#807)
+
+High-risk routed operations can return a normal error envelope with `error.code: "CONFIRMATION_REQUIRED"` and `error.details.challenge`. The challenge is the pause point: the agent or adapter must stop before executing the operation, show the human/operator enough safe metadata to decide, and wait for an approved token. Do not auto-approve from the same actor/session, and do not treat approval as a reusable capability grant.
+
+The challenge is bound to the original requester, node, session/work context, intent/action/target, capability bits, scope hash, canonical params hash, TTL, and approval target. For File RPC writes, the canonical params include action, path, mode, expected hash, decoded byte count, and SHA-256 of the bytes; raw file bytes and confirmation tokens are not safe to log. For exec-style operations, command and cwd may be shown to the approving human but should not be pasted into durable logs if they contain secret-looking values.
+
+The currently implemented retry shape is:
+
+1. The original command returns `CONFIRMATION_REQUIRED` with a `challengeId`, status, reason code, expiry, required/challenge bits, and contract metadata.
+2. A distinct authenticated human/operator approves or denies through the existing hub confirmation surface (`POST /hub/confirmations/:challengeId/approve`). This MVP does not ship passkey/WebAuthn/TOTP, multi-approver policy, or a broad approval center.
+3. The original requester fetches its one-time token with `POST /hub/confirmations/:challengeId/requester-token`.
+4. The requester retries the same CLI operation with `--confirmation-token <token>` or `confirmationToken` in the request body.
+
+Denial, expiry, requester mismatch, context drift, parameter drift, same-session/self-approval, wrong approval target, audit-write failure, and token reuse fail closed. After any of those outcomes, retrying begins with a new command attempt and a fresh challenge. Reusing the old token or changing parameters under the approved token must be reported as a failed redemption, not retried silently.
+
 ## Session stream and input
 
 `relay-ide v1 sessions stream --id <id> --mode ndjson --json` opens the same authenticated PTY attach path as the browser tab and emits newline-delimited gateway envelopes. Each output chunk is a `sessions.stream` success envelope with `data.event: "data"`, UTF-8 `data.data`, `bytes`, and a monotonic `sequence`. When the CLI detaches or the PTY closes, it emits one final `data.event: "closed"` envelope with `closeCode`, `reason`, `frames`, `bytesReceived`, and `truncated`.
@@ -434,7 +449,7 @@ The CLI first resolves the session through `sessions get` unless `--node-id` is 
 POST /hub/nodes/:nodeId/sessions/:sessionId/files/:operation
 ```
 
-Only these operations are stable in v1:
+Only these file operations are stable in v1:
 
 - `files.list` maps to `fs.list` and requires `session:read` + `rpc:fs:list`.
 - `files.stat` maps to `fs.stat` and requires `session:read` + `rpc:fs:read`.
@@ -501,7 +516,7 @@ Read example:
 }
 ```
 
-File commands remain read-only. They must surface unavailable node, missing path, denied capability, stale/expired session envelope, and confirmation-required states as typed error envelopes. They must not fall back to local filesystem reads when the scoped file RPC route rejects a request.
+File commands must surface unavailable node, missing path, denied capability, stale/expired session envelope, and confirmation-required states as typed error envelopes. They must not fall back to local filesystem reads or writes when the scoped file RPC route rejects a request.
 
 ## Intervention and hand-back boundaries
 
@@ -557,4 +572,4 @@ relay-ide v1 events subscribe --topic sessions --max-events 1 --json
 
 ## Deferred work
 
-Event subscription beyond `events.subscribe` (multi-topic fan-out, cursor/resume, replay), multi-session fan-out, File RPC write/delete/tail, destructive operations, and adapter packages are follow-up work. If a future adapter needs a missing primitive, extend this CLI contract first; do not bypass it with `/hub/node-link` or browser WebSocket protocol clients.
+Event subscription beyond `events.subscribe` (multi-topic fan-out, cursor/resume, replay), multi-session fan-out, File RPC delete/tail, arbitrary exec/destructive operations, stronger approval authentication, and adapter packages are follow-up work. If a future adapter needs a missing primitive, extend this CLI contract first; do not bypass it with `/hub/node-link` or browser WebSocket protocol clients.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ This index separates current source-of-truth docs from historical plans and spik
 | Devbox deploy         | `references/devbox-hub-deploy.md` | Shared devbox hub deploy, Mac node-link restart, verification evidence, process hygiene |
 | Dogfood recovery      | `references/dogfood-recovery.md`  | Relay-develops-Relay proof loop, recovery matrix, diagnostics, no-force-merge gate      |
 | Self-hosting          | `SELF_HOSTING.md`                 | Running Relay from inside Relay with isolated config/ports                              |
-| Security policy       | `SECURITY_POLICY.md`              | Trust tiers, capability bits, hub ACL defaults                                          |
+| Security policy       | `SECURITY_POLICY.md`              | Trust tiers, capability bits, hub ACL defaults, exact-operation approval challenges     |
 | rmux helper protocol  | `RMUX_HELPER_PROTOCOL.md`         | Experimental #707 helper JSON/stdin-stdout boundary and prototype gates                 |
 | Hub/node packaging    | `RELAY_HUB_NODE_PACKAGING.md`     | Hub/node command shape and npm packaging decisions                                      |
 | Node bootstrap        | `RELAY_NODE_BOOTSTRAP.md`         | Pair/install/update/unpair flows and diagnostics                                        |
@@ -57,6 +57,6 @@ These directories are useful evidence, but they are not current product docs by 
 ## Guardrails for future doc edits
 
 - Evidence first: source files, tests, package scripts, and CLI help beat old plans.
-- Do not overclaim planned work as shipped: especially File RPC, `logs.tail`/node-log proxying, #427 evaluator/confirmation/audit/rotation beyond the shipped policy schema/default ACLs, and the complete six-layer UI/data migration.
+- Do not overclaim planned work as shipped: especially File RPC beyond the listed v1 commands, `logs.tail`/node-log proxying, high-risk approval UX/auth strength beyond the exact-operation #807 contract, and the complete six-layer UI/data migration.
 - Keep `AGENTS.md` compact; add details here or in focused docs instead.
 - When a historical plan is still linked from a current doc, label it as historical/proposed unless implementation has been verified.

--- a/docs/RELAY_NODE_BOOTSTRAP.md
+++ b/docs/RELAY_NODE_BOOTSTRAP.md
@@ -153,14 +153,14 @@ This file is required for the node to authenticate heartbeats and the reverse We
 
 The hub now separates stable node identity from credential records. The stable identity anchor is the `nodeId` and pairing timestamps; operator-facing identity metadata such as `displayName` and `hostname` describes that identity and may be refreshed by later heartbeats. The active credential is replaceable bearer material tied to that identity. `GET /nodes` returns both the identity summary and a redacted credential summary (`credentialId`, `issuedAt`, and state), never the live token or token hash.
 
-| State | What it means | Operator action |
-| --- | --- | --- |
-| Paired | A one-time pair token was exchanged, the hub created a node identity, and the node stored `node-credential.json`. | Start or supervise `relay-ide node link --hub <url>` for routed sessions. |
-| Reconnected | The node proves the stored credential on heartbeat or `/hub/node-link` reconnect. | No browser cookie is involved; the node credential alone authenticates the node lane. |
-| Rotating | An operator-triggered or scheduled rotation has issued a next credential. The hub accepts the previous credential and the next credential until the node proves possession with a heartbeat carrying the next `credentialId`. | Deliver the new credential if manual; let online delivery write it over the active link if available. Do not clear a failed/delivered rotation if the node may already have written the next credential. |
-| Rotated/stable | The node proved the next credential. The hub swaps the active credential, invalidates the previous token, updates the ACL peer credential id, and preserves the same node identity. | Continue normal operation. |
-| Revoked | `DELETE /nodes/{nodeId}` marks the identity revoked, kills active links, and permanently rejects its credential. | Remove `node-credential.json` from the node before disposal or re-pairing. The old `nodeId` remains revoked in hub history. |
-| Re-pair required | The credential is missing, malformed, mismatched with hub state, expired, revoked, protocol-incompatible, or otherwise returns `REPAIR_REQUIRED`. | Generate a new pair token and run `relay-ide node pair`/`connect` again. Re-pairing creates a new node identity; it does not resurrect a revoked identity. |
+| State            | What it means                                                                                                                                                                                                                 | Operator action                                                                                                                                                                                          |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Paired           | A one-time pair token was exchanged, the hub created a node identity, and the node stored `node-credential.json`.                                                                                                             | Start or supervise `relay-ide node link --hub <url>` for routed sessions.                                                                                                                                |
+| Reconnected      | The node proves the stored credential on heartbeat or `/hub/node-link` reconnect.                                                                                                                                             | No browser cookie is involved; the node credential alone authenticates the node lane.                                                                                                                    |
+| Rotating         | An operator-triggered or scheduled rotation has issued a next credential. The hub accepts the previous credential and the next credential until the node proves possession with a heartbeat carrying the next `credentialId`. | Deliver the new credential if manual; let online delivery write it over the active link if available. Do not clear a failed/delivered rotation if the node may already have written the next credential. |
+| Rotated/stable   | The node proved the next credential. The hub swaps the active credential, invalidates the previous token, updates the ACL peer credential id, and preserves the same node identity.                                           | Continue normal operation.                                                                                                                                                                               |
+| Revoked          | `DELETE /nodes/{nodeId}` marks the identity revoked, kills active links, and permanently rejects its credential.                                                                                                              | Remove `node-credential.json` from the node before disposal or re-pairing. The old `nodeId` remains revoked in hub history.                                                                              |
+| Re-pair required | The credential is missing, malformed, mismatched with hub state, expired, revoked, protocol-incompatible, or otherwise returns `REPAIR_REQUIRED`.                                                                             | Generate a new pair token and run `relay-ide node pair`/`connect` again. Re-pairing creates a new node identity; it does not resurrect a revoked identity.                                               |
 
 Browser auth is deliberately not part of node reconnect. A browser PIN/cookie can authorize an operator to create a pair token or initiate rotation/revocation through browser routes, but it is never accepted as a node credential. Conversely, `node-credential.json` cannot log in to browser-only routes.
 
@@ -524,7 +524,13 @@ To grant `rpc:fs:write` on a paired node (e.g. for an agent brain that needs to 
 relay-ide hub node acl --node-id <node-id> --grant rpc:fs:write
 ```
 
-Prod-tier nodes additionally require a human-approved confirmation challenge on each write request; dev/sandbox-tier nodes execute immediately once the capability is granted.
+Prod-tier nodes additionally require a human-approved exact-operation confirmation challenge on each high-risk write request; dev/sandbox-tier nodes execute immediately once the capability is granted unless the hub ACL explicitly marks the bit as confirmation-required.
+
+Approval is per operation, not per node and not per agent. When a routed request pauses, the operator should inspect the challenge metadata: action, target node, session/work-context ids, required and challenged bits, policy/ACL refs, expiry, reason code, canonical params hash, and operation-specific params such as path/mode/byte count/content SHA-256 for file writes. The approval token is one-time and must be redeemed by the original requester for the same operation. Deny, expiry, mismatch, wrong requester, wrong approval target, self-approval, audit failure, or token reuse all fail closed; a retry starts with a new command and a fresh challenge.
+
+The safe public fields are node/session/work-context ids, challenge id/status, capability bits, timestamps, reason codes, redacted identity hashes/display names, params hashes, and operation summaries. Do not put raw confirmation tokens, browser cookies, node credentials, actor bearer tokens, pair tokens, raw file bytes, full environment values, or secret-looking command text into tickets, logs, screenshots, or chat handoffs.
+
+The current MVP uses the existing authenticated hub confirmation endpoints and UI path. Passkey/WebAuthn/TOTP, stronger approval auth, broad approval-center UX, and multi-approver policy are future work behind the same exact-operation contract, not part of this runbook slice.
 
 This is a privileged local-user blast radius. Do not pair nodes you do not control.
 
@@ -545,7 +551,7 @@ All CLI output, diagnostics, and bootstrap command generation redact sensitive t
 | `pair_...` tokens                      | `pair_…redacted`                  |
 | `node_...._....secret_...` credentials | `node_…redacted.secret_…redacted` |
 | `secret_...` fragments                 | `secret_…redacted`                |
-| `Authorization: Bearer <token>`        | `Authorization: Bearer …redacted` |
+| `Authorization: Bearer <value>`        | `Authorization: Bearer …redacted` |
 | `Bearer <token>`                       | `Bearer …redacted`                |
 
 The redaction is applied by `redactBootstrapSecrets()` in `shared/bootstrap-diagnostics.ts`.

--- a/docs/SECURITY_POLICY.md
+++ b/docs/SECURITY_POLICY.md
@@ -17,7 +17,7 @@ Relay auth is split into lanes. The current route inventory is checked into `ser
 
 The PIN and `token` cookie are therefore browser/UI authentication. They reduce drive-by browser access and support first-load local setup, but they cannot protect Relay from malicious processes already running as the same OS user: those processes can usually read local config, invoke local CLIs, attach to local sockets, or modify the checkout. Relay's federated security model relies on lane separation, node credentials, hub ACLs, capability policy, audit, revocation, and scoped actor credentials for non-browser actors rather than treating the browser PIN as global authorization.
 
-Relay issue `#427` shipped the earlier trust-tier/capability/audit/confirmation backbone. Relay issue `#797` tracks the broader multi-node auth model. Relay issue `#798` wave 1 narrowed that work to route-lane inventory, browser-session terminology, and typed lane denials. Relay issue `#802` adds the scoped actor credential registry MVP; it deliberately does not migrate every CLI gateway command, implement node proof-of-possession, passkeys, TOTP, or new approval UX. Relay issue `#803` hardens node identity lifecycle semantics by separating stable node identity from replaceable credential records.
+Relay issue `#427` shipped the earlier trust-tier/capability/audit/confirmation backbone. Relay issue `#797` tracks the broader multi-node auth model. Relay issue `#798` wave 1 narrowed that work to route-lane inventory, browser-session terminology, and typed lane denials. Relay issue `#802` adds the scoped actor credential registry MVP; it deliberately does not migrate every CLI gateway command, implement node proof-of-possession, passkeys, TOTP, or new approval UX. Relay issue `#803` hardens node identity lifecycle semantics by separating stable node identity from replaceable credential records. Relay issue `#807` adds the high-risk approval hook contract for exact-operation challenges; it is still not MFA, passkeys/WebAuthn, TOTP, enterprise RBAC, or a broad approval-center UX.
 
 ## Node identity lifecycle
 
@@ -25,13 +25,13 @@ Node identity is not the same thing as a node credential. The hub registry keeps
 
 The lifecycle states exposed to operators are:
 
-| State | Security meaning |
-| --- | --- |
-| `active` | The node has a valid active credential for heartbeat and `/hub/node-link`. |
-| `rotating` | A next credential exists and is provable, but the old credential remains active until heartbeat proof. |
-| `rotation-failed` | Delivery failed or was marked failed; the previous credential remains active until an operator clears the rotation or retries safely. |
-| `revoked` | The node identity remains in registry history, active links are closed, and the credential is rejected without grace. |
-| re-pair required | Authentication returns typed recovery errors such as `NODE_CREDENTIAL_MISSING`, `NODE_CREDENTIAL_MALFORMED`, `NODE_CREDENTIAL_MISMATCH`, `NODE_CREDENTIAL_EXPIRED`, `NODE_REVOKED`, or `REPAIR_REQUIRED`; the operator must run a fresh pair-token exchange. |
+| State             | Security meaning                                                                                                                                                                                                                                             |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `active`          | The node has a valid active credential for heartbeat and `/hub/node-link`.                                                                                                                                                                                   |
+| `rotating`        | A next credential exists and is provable, but the old credential remains active until heartbeat proof.                                                                                                                                                       |
+| `rotation-failed` | Delivery failed or was marked failed; the previous credential remains active until an operator clears the rotation or retries safely.                                                                                                                        |
+| `revoked`         | The node identity remains in registry history, active links are closed, and the credential is rejected without grace.                                                                                                                                        |
+| re-pair required  | Authentication returns typed recovery errors such as `NODE_CREDENTIAL_MISSING`, `NODE_CREDENTIAL_MALFORMED`, `NODE_CREDENTIAL_MISMATCH`, `NODE_CREDENTIAL_EXPIRED`, `NODE_REVOKED`, or `REPAIR_REQUIRED`; the operator must run a fresh pair-token exchange. |
 
 Browser auth is intentionally non-dependent. Browser PIN/cookie auth can authorize operator UI/API routes that mint pair tokens or request rotation/revocation, but it is not accepted by node heartbeat or `/hub/node-link`. Node credentials are likewise not browser, CLI, scoped actor, or human impersonation credentials.
 
@@ -90,15 +90,39 @@ Default legacy grants are intentionally boring:
 
 `session:control:kill` is intentionally separate from `session:attach`: attaching or streaming a session is not authority to terminate it. Pause/retry controls are not routed in this slice; when added, they need explicit high-risk control bits instead of reusing attach.
 
-`rpc:fs:write` is now shipped (#428). The node executor writes via atomic rename (write-to-temp + `fs.rename`). Prod-tier nodes gate writes behind the two-token confirmation challenge — the hub returns `CONFIRMATION_REQUIRED` on the first POST; the caller must obtain an approved `confirmationToken` and re-POST with it. The CLI enforces a 1 MiB cap on base64-decoded content before the HTTP call.
+`rpc:fs:write` is now shipped (#428). The node executor writes via atomic rename (write-to-temp + `fs.rename`). Prod-tier nodes gate writes behind the exact-operation confirmation challenge — the hub returns `CONFIRMATION_REQUIRED` on the first POST; the caller must obtain an approved `confirmationToken` and re-POST the same operation with it. The CLI enforces a 1 MiB cap on base64-decoded content before the HTTP call.
 
-The schema exists before the full policy evaluator. Current routed surfaces still have their existing route-level checks; this slice adds the policy authority data model and legacy defaults so later gates have a safe source of truth.
+## Exact-operation high-risk approval hook
+
+The #807 MVP makes approval a one-time authorization for one canonical operation. It is not a blanket trust upgrade, not a new capability grant, and not permission for the actor to perform similar future work. A successful approval is redeemed once; a retry after denial, expiry, mismatch, or reuse starts from a fresh challenge.
+
+The current high-risk classifier requires approval for these implemented families when they appear in the routed policy decision: cross-node session/node control, capability escalation (`node:acl:widen` / grant-style actions), shell or arbitrary PTY exec, file write/delete or boundary-crossing mutation, credential/secret export, node revoke/rotate/re-pair/destroy, destructive session control, and any otherwise-routed capability listed in `HIGH_RISK_CAPABILITIES`. Low-risk read and ref-only context/inbox operations stay silent-allow when policy allows them; unknown operations or unknown capability strings deny instead of prompting.
+
+Challenge binding includes the requester auth-session hash, actor type/id hash, scoped credential id/jti hash when present, node id, session id, work-context id, intent/action/target, required and challenged capability bits, ACL/policy refs, trust tier, scope hash, canonical params hash, TTL, approval target, and a stable `contractHash`. The approval target defaults to a human approval. When a target id or session is present, the approver must match it; scoped/autonomous requesters also require a structured approver identity so they cannot self-approve through the same actor, credential, or session.
+
+Safe metadata for operator lists, prompts, diagnostics, and issue handoffs is limited to challenge id/status, action, node/session/work-context ids, required/challenge bits, risk reason, created/expires/token-expires times, failed-redemption counts, reason code, message, `canonicalParamsHash`, `paramsHash`, `scopeHash`, `contractHash`, redacted identity hashes, and display names. Review prompts may show canonical params such as command/cwd, path/mode, expected hash, byte count, and content SHA-256 so a human can tell what they are approving; do not persist or paste raw params if they contain secret-looking values.
+
+Failure modes are fail-closed:
+
+| Case                                                                                                                  | Behavior                                                                                                  |
+| --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Human denies                                                                                                          | Challenge becomes `denied`/`revoked`; no token is usable.                                                 |
+| Challenge or token expires                                                                                            | Challenge becomes `expired`; the requester must repeat the operation to create a fresh challenge.         |
+| Requester, node, intent, capability set, session, scope, or canonical params drift                                    | Redemption fails with context/parameter mismatch; repeated parameter mismatches invalidate the challenge. |
+| Token is reused                                                                                                       | Redemption fails with `reuse_denied`; approvals are one-time only.                                        |
+| Same browser/auth session, same autonomous actor, same scoped credential, or same requester session attempts approval | Approval is rejected as self-approval.                                                                    |
+| Approval target does not match                                                                                        | Approval is rejected with `approval_target_invalid`.                                                      |
+| Approval audit write fails                                                                                            | The approval token is invalidated; destructive/high-risk flows do not continue without audit.             |
+
+The implemented approval transport is the existing authenticated hub confirmation surface: `GET /hub/confirmations`, `GET /hub/confirmations/:challengeId`, `POST /hub/confirmations/:challengeId/approve`, and requester-only `POST /hub/confirmations/:challengeId/requester-token`. The MVP may use the existing hub/browser confirmation components and mocked flows. Passkey/WebAuthn/TOTP, stronger human auth, multi-approver policy, and broad approval-center workflows are future auth-strength/UX work behind this same contract.
+
+The approval hook is a contract and in-process enforcement path for routed high-risk decisions. It does not by itself add every future high-risk command surface; new routed commands still need explicit policy mapping, audit coverage, and contract tests before adapters expose them.
 
 ## Hash-chained security audit sink
 
 Security audit entries are normalized in `shared/security-audit.ts` and persisted by `server/security-audit-log.ts` into `security-audit.db` under the Relay config directory unless a caller supplies a specific DB path. Each entry includes event id, timestamp, monotonic sequence, schema version, event type, decision, reason code, peer/node identity, trust tier, session id, intent, scope/params hashes, required/granted/denied bits, ACL/policy refs, correlation id, `prevHash`, and `entryHash`.
 
-Event types cover grants, denials, challenges, approvals, expiry, revocation, rotation, failed redemption, same-session approval attempts, and #470 bridge events. Raw bearer tokens, pair tokens, confirmation tokens, full env values, file bytes, and terminal byte streams must be passed through the audit redaction helpers before hashing; the persisted entry stores hashes for scope/params rather than raw payload bytes.
+Event types cover grants, denials, challenges, approvals, expiry, revocation, rotation, failed redemption, same-session approval attempts, and #470 bridge events. Raw bearer tokens, pair tokens, confirmation tokens, full env values, file bytes, and terminal byte streams must be passed through the audit redaction helpers before hashing; the persisted entry stores hashes for scope/params rather than raw payload bytes. Confirmation audit entries carry the same exact-operation context as the challenge, including required/granted/denied bits and correlation id, without storing the redemption token.
 
 Persistence uses a SQLite append-only table with an atomic insert transaction, update/delete rejection triggers, and a singleton tail checkpoint updated on every append. Verify with:
 
@@ -107,7 +131,7 @@ relay-ide audit verify --db ~/.config/relay-ide/security-audit.db
 relay-ide audit verify --db ~/.config/relay-ide/security-audit.db --json
 ```
 
-The verifier replays rows in sequence order and recomputes `prevHash` / `entryHash`, using SQLite row iteration so verification memory stays bounded by the largest row rather than total log size. It reports the exact first break location for gaps, row tamper, insert/reorder attacks, tail truncation relative to the stored checkpoint, and corrupt/partial storage. Hash chaining plus the DB-local checkpoint detects accidental corruption and post-hoc edits against the current DB file, but it is not remote attestation: a compromised hub/root account can still rewrite the whole history, recompute hashes, and rewrite the checkpoint unless future slices add external shipping or trusted timestamping. External SIEM, third-party timestamping, full PTY transcript recording, credential rotation, confirmation registries, and evaluator gates are intentionally outside this slice.
+The verifier replays rows in sequence order and recomputes `prevHash` / `entryHash`, using SQLite row iteration so verification memory stays bounded by the largest row rather than total log size. It reports the exact first break location for gaps, row tamper, insert/reorder attacks, tail truncation relative to the stored checkpoint, and corrupt/partial storage. Hash chaining plus the DB-local checkpoint detects accidental corruption and post-hoc edits against the current DB file, but it is not remote attestation: a compromised hub/root account can still rewrite the whole history, recompute hashes, and rewrite the checkpoint unless future slices add external shipping or trusted timestamping. External SIEM, third-party timestamping, full PTY transcript recording, durable/distributed confirmation registries, and stronger approval auth are intentionally outside this slice.
 
 Audit storage is intentionally unbounded in this slice: Relay does not yet enforce retention, rotation, or a maximum `security-audit.db` size. Operators must provision and monitor the config-directory storage accordingly; manual pruning or rotation will break the contiguous sequence/hash chain unless a future retention design preserves verifier semantics.
 

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -57,8 +57,29 @@ export interface CliGatewayActorFailureEnvelope {
   };
 }
 
+const AUTHENTICATED_CLI_GATEWAY_ACTOR_CREDENTIAL = Symbol(
+  'relay.cliGatewayActorCredential'
+);
+
+type RequestWithAuthenticatedCliGatewayActor = Request & {
+  [AUTHENTICATED_CLI_GATEWAY_ACTOR_CREDENTIAL]?: ScopedActorCredentialRecord;
+};
+
 export function createCliGatewayActorRegistry(): ScopedActorCredentialRegistry {
   return new ScopedActorCredentialRegistry();
+}
+
+export function attachAuthenticatedCliGatewayActorCredential(
+  req: Request,
+  credential: ScopedActorCredentialRecord
+): void {
+  (req as RequestWithAuthenticatedCliGatewayActor)[AUTHENTICATED_CLI_GATEWAY_ACTOR_CREDENTIAL] = credential;
+}
+
+export function authenticatedCliGatewayActorCredential(
+  req: Request
+): ScopedActorCredentialRecord | undefined {
+  return (req as RequestWithAuthenticatedCliGatewayActor)[AUTHENTICATED_CLI_GATEWAY_ACTOR_CREDENTIAL];
 }
 
 export function bearerActorToken(req: Request): string {

--- a/server/confirmation-challenges.ts
+++ b/server/confirmation-challenges.ts
@@ -118,6 +118,12 @@ export type ConfirmationFailure = {
   audit?: SecurityAuditEntryInput;
 };
 
+type AttemptedApproval = {
+  approverAuthSessionHash: string;
+  approverDisplayName?: string;
+  approver?: HighRiskApprovalApproverIdentity;
+};
+
 export type ConfirmationApprovalResult =
   | {
       ok: true;
@@ -334,24 +340,25 @@ export function createConfirmationChallengeStore(
     if (challenge.status !== 'pending') {
       return failure('CONFIRMATION_NOT_APPROVED', `confirmation challenge is ${challenge.status}`, challenge);
     }
-    if (challenge.requesterAuthSessionHash === input.approverAuthSessionHash) {
-      return failChallenge(challenge, 'CONFIRMATION_SAME_SESSION', 'the requesting browser/auth session cannot approve its own challenge', 'same_session_approval_attempt', 'deny');
-    }
     const approver = input.approver;
+    const attemptedApproval = attemptedApprovalFromInput(input);
+    if (challenge.requesterAuthSessionHash === input.approverAuthSessionHash) {
+      return failChallenge(challenge, 'CONFIRMATION_SAME_SESSION', 'the requesting browser/auth session cannot approve its own challenge', 'same_session_approval_attempt', 'deny', undefined, attemptedApproval);
+    }
     if (requiresStructuredApprover(challenge) && !approver) {
-      return failChallenge(challenge, 'CONFIRMATION_APPROVAL_TARGET_INVALID', 'approval requires a distinct human/operator approver identity', 'denial', 'deny', 'approval_target_invalid');
+      return failChallenge(challenge, 'CONFIRMATION_APPROVAL_TARGET_INVALID', 'approval requires a distinct human/operator approver identity', 'denial', 'deny', 'approval_target_invalid', attemptedApproval);
     }
     if (sameHighRiskActor(challenge.requester, approver)) {
-      return failChallenge(challenge, 'CONFIRMATION_SAME_ACTOR', 'the requesting autonomous actor cannot approve its own high-risk challenge', 'same_session_approval_attempt', 'deny', 'approval_target_invalid');
+      return failChallenge(challenge, 'CONFIRMATION_SAME_ACTOR', 'the requesting autonomous actor cannot approve its own high-risk challenge', 'same_session_approval_attempt', 'deny', 'approval_target_invalid', attemptedApproval);
     }
     if (sameHighRiskCredential(challenge.requester, approver)) {
-      return failChallenge(challenge, 'CONFIRMATION_SAME_CREDENTIAL', 'the requesting scoped credential cannot approve its own high-risk challenge', 'same_session_approval_attempt', 'deny', 'approval_target_invalid');
+      return failChallenge(challenge, 'CONFIRMATION_SAME_CREDENTIAL', 'the requesting scoped credential cannot approve its own high-risk challenge', 'same_session_approval_attempt', 'deny', 'approval_target_invalid', attemptedApproval);
     }
     if (sameHighRiskSession(challenge.requester, approver)) {
-      return failChallenge(challenge, 'CONFIRMATION_SAME_SESSION', 'the requesting session cannot approve its own high-risk challenge', 'same_session_approval_attempt', 'deny', 'approval_target_invalid');
+      return failChallenge(challenge, 'CONFIRMATION_SAME_SESSION', 'the requesting session cannot approve its own high-risk challenge', 'same_session_approval_attempt', 'deny', 'approval_target_invalid', attemptedApproval);
     }
     if (approver && !approverSatisfiesTarget(approver, challenge.approvalTarget)) {
-      return failChallenge(challenge, 'CONFIRMATION_APPROVAL_TARGET_INVALID', 'approver does not match the challenge approval target', 'denial', 'deny', 'approval_target_invalid');
+      return failChallenge(challenge, 'CONFIRMATION_APPROVAL_TARGET_INVALID', 'approver does not match the challenge approval target', 'denial', 'deny', 'approval_target_invalid', attemptedApproval);
     }
     if (input.decision === 'deny' || input.decision === 'deny_revoke') {
       const reasonCode = input.decision === 'deny' ? 'CONFIRMATION_DENIED' : 'CONFIRMATION_DENIED_REVOKE';
@@ -718,24 +725,42 @@ function invalidateRedemptionChallenge(
   }));
 }
 
+function attemptedApprovalFromInput(input: {
+  approverAuthSessionHash: string;
+  approverDisplayName?: string;
+  approver?: HighRiskApprovalApproverIdentity;
+}): AttemptedApproval {
+  return {
+    approverAuthSessionHash: input.approverAuthSessionHash,
+    ...(input.approverDisplayName ? { approverDisplayName: input.approverDisplayName } : {}),
+    ...(input.approver ? { approver: input.approver } : {}),
+  };
+}
+
 function failChallenge(
   challenge: ConfirmationChallenge,
   reasonCode: ConfirmationReasonCode,
   message: string,
   eventType: SecurityAuditEntryInput['eventType'],
   decision: SecurityAuditEntryInput['decision'],
-  outcome?: HighRiskApprovalOutcome
+  outcome?: HighRiskApprovalOutcome,
+  attemptedApproval?: {
+    approverAuthSessionHash: string;
+    approverDisplayName?: string;
+    approver?: HighRiskApprovalApproverIdentity;
+  }
 ): ConfirmationFailure {
   challenge.reasonCode = reasonCode;
   challenge.message = message;
   if (outcome) {
     challenge.outcome = outcome;
-    challenge.contract = updatedContract(challenge, outcome);
+    challenge.contract = updatedContract(challenge, outcome, undefined, attemptedApproval?.approver);
   }
   return failure(reasonCode, message, challenge, auditForChallenge(challenge, {
     eventType,
     decision,
     reasonCode,
+    ...(attemptedApproval ? { attemptedApproval } : {}),
   }));
 }
 
@@ -797,6 +822,10 @@ function auditForChallenge(
     decision: SecurityAuditEntryInput['decision'];
     reasonCode: string;
     params?: unknown;
+    attemptedApproval?: {
+      approverAuthSessionHash: string;
+      approverDisplayName?: string;
+    };
   }
 ): SecurityAuditEntryInput {
   const policy = challenge.decision;
@@ -804,7 +833,7 @@ function auditForChallenge(
     eventType: input.eventType,
     decision: input.decision,
     reasonCode: input.reasonCode,
-    peer: auditPeerForChallenge(challenge, input.eventType),
+    peer: auditPeerForChallenge(challenge, input.eventType, input.attemptedApproval),
     node: {
       nodeId: challenge.nodeId,
       ...(policy.trustTier ? { trustTier: policy.trustTier } : {}),
@@ -828,17 +857,29 @@ function auditForChallenge(
 
 function auditPeerForChallenge(
   challenge: ConfirmationChallenge,
-  eventType: SecurityAuditEntryInput['eventType']
+  eventType: SecurityAuditEntryInput['eventType'],
+  attemptedApproval?: {
+    approverAuthSessionHash: string;
+    approverDisplayName?: string;
+  }
 ): SecurityAuditEntryInput['peer'] {
+  const useAttemptedApprover =
+    (eventType === 'same_session_approval_attempt' || eventType === 'denial') &&
+    Boolean(attemptedApproval?.approverAuthSessionHash);
   const useApprover =
+    !useAttemptedApprover &&
     (eventType === 'approval' || eventType === 'denial' || eventType === 'revocation') &&
     Boolean(challenge.approverAuthSessionHash);
-  const principalHash = useApprover
-    ? challenge.approverAuthSessionHash!
-    : challenge.requesterAuthSessionHash;
-  const displayName = useApprover
-    ? challenge.approverDisplayName
-    : challenge.requesterDisplayName;
+  const principalHash = useAttemptedApprover
+    ? attemptedApproval!.approverAuthSessionHash
+    : useApprover
+      ? challenge.approverAuthSessionHash!
+      : challenge.requesterAuthSessionHash;
+  const displayName = useAttemptedApprover
+    ? attemptedApproval?.approverDisplayName
+    : useApprover
+      ? challenge.approverDisplayName
+      : challenge.requesterDisplayName;
   return {
     kind: 'user',
     principalHash,

--- a/server/confirmation-challenges.ts
+++ b/server/confirmation-challenges.ts
@@ -417,7 +417,16 @@ export function createConfirmationChallengeStore(
     if (challenge.status === 'redeemed') {
       challenge.outcome = 'reuse_denied';
       challenge.contract = updatedContract(challenge, 'reuse_denied');
-      return failure('CONFIRMATION_ALREADY_USED', 'confirmation token was already used', challenge);
+      return failure(
+        'CONFIRMATION_ALREADY_USED',
+        'confirmation token was already used',
+        challenge,
+        auditForChallenge(challenge, {
+          eventType: 'failed_redemption',
+          decision: 'failed',
+          reasonCode: 'CONFIRMATION_ALREADY_USED',
+        })
+      );
     }
     if (challenge.status !== 'approved') {
       return failure('CONFIRMATION_NOT_APPROVED', `confirmation challenge is ${challenge.status}`, challenge);
@@ -541,13 +550,18 @@ export function canonicalConfirmationParams(
 ): CanonicalConfirmationParams {
   const record = asRecord(params);
   switch (action) {
-    case 'pty.exec.arbitrary':
+    case 'pty.exec.arbitrary': {
+      const command = stringField(record, 'command');
       return stripUndefined({
         action,
-        command: stringField(record, 'command'),
         cwd: stringField(record, 'cwd'),
+        commandHash: command === undefined ? undefined : sha256Hex(command),
+        commandByteCount: command === undefined ? undefined : Buffer.byteLength(command, 'utf8'),
+        commandCharCount: command?.length,
+        commandClasses: command === undefined ? undefined : commandClasses(command),
         envHash: hashOptional(record?.['env']),
       });
+    }
     case 'rpc.fs.write': {
       const bytes = bytesFromFileWrite(record);
       return stripUndefined({
@@ -865,6 +879,22 @@ function stringField(record: Record<string, unknown> | undefined, key: string): 
 
 function hashOptional(value: unknown): string | undefined {
   return value === undefined ? undefined : sha256Hex(stableStringify(value));
+}
+
+function commandClasses(command: string): string[] {
+  const classes: string[] = [];
+  if (command.includes('\r') || command.includes('\n')) classes.push('multiline');
+  if (/[;&|`$<>()[\]{}*?~!]/.test(command)) classes.push('shell-metacharacters');
+  if (/https?:\/\//i.test(command)) classes.push('url');
+  if (
+    /(?:authorization|bearer|token|secret|password|api[_-]?key|gh[pousr]_|sk-|relay-)/i.test(
+      command
+    )
+  ) {
+    classes.push('secret-looking');
+  }
+  if (/[^\x20-\x7e]/.test(command)) classes.push('non-ascii');
+  return classes;
 }
 
 function bytesFromFileWrite(record: Record<string, unknown> | undefined): Buffer {

--- a/server/confirmation-challenges.ts
+++ b/server/confirmation-challenges.ts
@@ -2,6 +2,17 @@ import * as crypto from 'node:crypto';
 import { sha256Hex, stableStringify, type SecurityAuditEntryInput } from '../shared/security-audit.js';
 import type { RelayCapabilityBit } from '../shared/security-policy.js';
 import type { HubPolicyDecision } from './hub-policy-evaluator.js';
+import {
+  createHighRiskApprovalContract,
+  sameHighRiskActor,
+  sameHighRiskCredential,
+  sameHighRiskSession,
+  type HighRiskApprovalApproverIdentity,
+  type HighRiskApprovalContract,
+  type HighRiskApprovalOutcome,
+  type HighRiskApprovalRequesterIdentity,
+  type HighRiskApprovalTarget,
+} from './high-risk-approvals.js';
 
 export const DEFAULT_CONFIRMATION_CHALLENGE_TTL_MS = 5 * 60 * 1000;
 export const DEFAULT_CONFIRMATION_TOKEN_TTL_MS = 60 * 1000;
@@ -31,7 +42,10 @@ export type ConfirmationReasonCode =
   | 'CONFIRMATION_NOT_APPROVED'
   | 'CONFIRMATION_TOKEN_INVALID'
   | 'CONFIRMATION_REQUESTER_MISMATCH'
-  | 'CONFIRMATION_CONTEXT_MISMATCH';
+  | 'CONFIRMATION_CONTEXT_MISMATCH'
+  | 'CONFIRMATION_SAME_ACTOR'
+  | 'CONFIRMATION_SAME_CREDENTIAL'
+  | 'CONFIRMATION_APPROVAL_TARGET_INVALID';
 
 export interface CanonicalConfirmationParams {
   action: string;
@@ -65,6 +79,11 @@ export interface ConfirmationChallenge {
   maxFailedRedemptions: number;
   reasonCode: ConfirmationReasonCode;
   message: string;
+  outcome: HighRiskApprovalOutcome;
+  requester?: HighRiskApprovalRequesterIdentity;
+  approver?: HighRiskApprovalApproverIdentity;
+  approvalTarget?: HighRiskApprovalTarget;
+  contract: HighRiskApprovalContract;
 }
 
 export interface ConfirmationChallengePublicView {
@@ -87,6 +106,8 @@ export interface ConfirmationChallengePublicView {
   maxFailedRedemptions: number;
   reasonCode: ConfirmationReasonCode;
   message: string;
+  outcome: HighRiskApprovalOutcome;
+  contract: HighRiskApprovalContract;
 }
 
 export type ConfirmationFailure = {
@@ -144,6 +165,8 @@ export interface ConfirmationChallengeStore {
     input: {
       requesterAuthSessionHash: string;
       requesterDisplayName?: string;
+      requester?: HighRiskApprovalRequesterIdentity;
+      approvalTarget?: HighRiskApprovalTarget;
       canonicalParams: CanonicalConfirmationParams;
     }
   ): ConfirmationChallenge;
@@ -151,6 +174,7 @@ export interface ConfirmationChallengeStore {
     challengeId: string;
     approverAuthSessionHash: string;
     approverDisplayName?: string;
+    approver?: HighRiskApprovalApproverIdentity;
     decision: ConfirmationDecision;
     now?: Date;
   }): ConfirmationApprovalResult;
@@ -241,14 +265,24 @@ export function createConfirmationChallengeStore(
     input: {
       requesterAuthSessionHash: string;
       requesterDisplayName?: string;
+      requester?: HighRiskApprovalRequesterIdentity;
+      approvalTarget?: HighRiskApprovalTarget;
       canonicalParams: CanonicalConfirmationParams;
     }
   ): ConfirmationChallenge {
     const createdAt = now();
     pruneStoredChallenges(createdAt);
     ensureCapacityForNewChallenge();
+    const expiresAt = new Date(createdAt.getTime() + challengeTtlMs);
+    const requester = input.requester ?? {
+      kind: 'browser-session' as const,
+      authSessionHash: input.requesterAuthSessionHash,
+      ...(input.requesterDisplayName ? { displayName: input.requesterDisplayName } : {}),
+    };
+    const approvalTarget = input.approvalTarget ?? { kind: 'human' as const };
+    const challengeId = randomId();
     const challenge: ConfirmationChallenge = {
-      challengeId: randomId(),
+      challengeId,
       status: 'pending',
       requesterAuthSessionHash: input.requesterAuthSessionHash,
       ...(input.requesterDisplayName ? { requesterDisplayName: input.requesterDisplayName } : {}),
@@ -262,11 +296,23 @@ export function createConfirmationChallengeStore(
       scopeHash: sha256Hex(stableStringify(decision.scope)),
       decision,
       createdAt: createdAt.toISOString(),
-      expiresAt: new Date(createdAt.getTime() + challengeTtlMs).toISOString(),
+      expiresAt: expiresAt.toISOString(),
       failedRedemptions: 0,
       maxFailedRedemptions,
       reasonCode: 'CONFIRMATION_REQUIRED',
       message: 'confirmation required before Relay routes this operation to the node',
+      outcome: 'challenge_created',
+      requester,
+      approvalTarget,
+      contract: createHighRiskApprovalContract({
+        challengeId,
+        decision,
+        canonicalParams: input.canonicalParams,
+        createdAt,
+        expiresAt,
+        requester,
+        approvalTarget,
+      }),
     };
     challenges.set(challenge.challengeId, challenge);
     return challenge;
@@ -276,6 +322,7 @@ export function createConfirmationChallengeStore(
     challengeId: string;
     approverAuthSessionHash: string;
     approverDisplayName?: string;
+    approver?: HighRiskApprovalApproverIdentity;
     decision: ConfirmationDecision;
     now?: Date;
   }): ConfirmationApprovalResult {
@@ -290,6 +337,22 @@ export function createConfirmationChallengeStore(
     if (challenge.requesterAuthSessionHash === input.approverAuthSessionHash) {
       return failChallenge(challenge, 'CONFIRMATION_SAME_SESSION', 'the requesting browser/auth session cannot approve its own challenge', 'same_session_approval_attempt', 'deny');
     }
+    const approver = input.approver;
+    if (requiresStructuredApprover(challenge) && !approver) {
+      return failChallenge(challenge, 'CONFIRMATION_APPROVAL_TARGET_INVALID', 'approval requires a distinct human/operator approver identity', 'denial', 'deny', 'approval_target_invalid');
+    }
+    if (sameHighRiskActor(challenge.requester, approver)) {
+      return failChallenge(challenge, 'CONFIRMATION_SAME_ACTOR', 'the requesting autonomous actor cannot approve its own high-risk challenge', 'same_session_approval_attempt', 'deny', 'approval_target_invalid');
+    }
+    if (sameHighRiskCredential(challenge.requester, approver)) {
+      return failChallenge(challenge, 'CONFIRMATION_SAME_CREDENTIAL', 'the requesting scoped credential cannot approve its own high-risk challenge', 'same_session_approval_attempt', 'deny', 'approval_target_invalid');
+    }
+    if (sameHighRiskSession(challenge.requester, approver)) {
+      return failChallenge(challenge, 'CONFIRMATION_SAME_SESSION', 'the requesting session cannot approve its own high-risk challenge', 'same_session_approval_attempt', 'deny', 'approval_target_invalid');
+    }
+    if (approver && !approverSatisfiesTarget(approver, challenge.approvalTarget)) {
+      return failChallenge(challenge, 'CONFIRMATION_APPROVAL_TARGET_INVALID', 'approver does not match the challenge approval target', 'denial', 'deny', 'approval_target_invalid');
+    }
     if (input.decision === 'deny' || input.decision === 'deny_revoke') {
       const reasonCode = input.decision === 'deny' ? 'CONFIRMATION_DENIED' : 'CONFIRMATION_DENIED_REVOKE';
       challenge.status = input.decision === 'deny' ? 'denied' : 'revoked';
@@ -298,8 +361,11 @@ export function createConfirmationChallengeStore(
         ? 'confirmation challenge was denied by a distinct authenticated session'
         : 'confirmation challenge was denied and the grant should be revoked';
       challenge.approverAuthSessionHash = input.approverAuthSessionHash;
+      if (approver) challenge.approver = approver;
       if (input.approverDisplayName) challenge.approverDisplayName = input.approverDisplayName;
       challenge.approvedAt = current.toISOString();
+      challenge.outcome = 'denied';
+      challenge.contract = updatedContract(challenge, input.decision === 'deny' ? 'denied' : 'denied', undefined, approver);
       return failure(reasonCode, challenge.message, challenge, auditForChallenge(challenge, {
         eventType: input.decision === 'deny' ? 'denial' : 'revocation',
         decision: input.decision === 'deny' ? 'deny' : 'revoked',
@@ -311,11 +377,14 @@ export function createConfirmationChallengeStore(
     challenge.reasonCode = 'CONFIRMATION_APPROVED';
     challenge.message = 'confirmation challenge approved by a distinct authenticated session';
     challenge.approverAuthSessionHash = input.approverAuthSessionHash;
+    if (approver) challenge.approver = approver;
     if (input.approverDisplayName) challenge.approverDisplayName = input.approverDisplayName;
     challenge.approvedAt = current.toISOString();
     challenge.tokenExpiresAt = new Date(current.getTime() + tokenTtlMs).toISOString();
     challenge.tokenHash = hashToken(token);
     challenge.requesterToken = token;
+    challenge.outcome = 'approved';
+    challenge.contract = updatedContract(challenge, 'approved', token, approver);
     return {
       ok: true,
       reasonCode: 'CONFIRMATION_APPROVED',
@@ -346,6 +415,8 @@ export function createConfirmationChallengeStore(
     const expiryFailure = expireIfNeeded(challenge, current, true);
     if (expiryFailure) return expiryFailure;
     if (challenge.status === 'redeemed') {
+      challenge.outcome = 'reuse_denied';
+      challenge.contract = updatedContract(challenge, 'reuse_denied');
       return failure('CONFIRMATION_ALREADY_USED', 'confirmation token was already used', challenge);
     }
     if (challenge.status !== 'approved') {
@@ -362,6 +433,8 @@ export function createConfirmationChallengeStore(
     }
     if (challenge.canonicalParamsHash !== hashCanonicalParams(input.canonicalParams)) {
       challenge.failedRedemptions += 1;
+      challenge.outcome = 'mismatch_denied';
+      challenge.contract = updatedContract(challenge, 'mismatch_denied');
       if (challenge.failedRedemptions >= challenge.maxFailedRedemptions) {
         challenge.status = 'invalidated';
         challenge.reasonCode = 'CONFIRMATION_PARAM_MISMATCH';
@@ -378,6 +451,8 @@ export function createConfirmationChallengeStore(
     challenge.redeemedAt = current.toISOString();
     challenge.reasonCode = 'CONFIRMATION_APPROVED';
     challenge.message = 'confirmation token redeemed';
+    challenge.outcome = 'redeemed';
+    challenge.contract = updatedContract(challenge, 'redeemed');
     delete challenge.requesterToken;
     return {
       ok: true,
@@ -435,6 +510,10 @@ export function createConfirmationChallengeStore(
     challenge.status = 'invalidated';
     challenge.reasonCode = input.reasonCode;
     challenge.message = input.message;
+    challenge.outcome = input.message.includes('audit write failed')
+      ? 'audit_write_failed'
+      : 'mismatch_denied';
+    challenge.contract = updatedContract(challenge, challenge.outcome);
     challenge.approvedAt = current.toISOString();
     delete challenge.tokenExpiresAt;
     delete challenge.tokenHash;
@@ -553,7 +632,56 @@ export function publicChallenge(
     maxFailedRedemptions: challenge.maxFailedRedemptions,
     reasonCode: challenge.reasonCode,
     message: challenge.message,
+    outcome: challenge.outcome,
+    contract: challenge.contract,
   };
+}
+
+function requiresStructuredApprover(challenge: ConfirmationChallenge): boolean {
+  return challenge.requester?.kind === 'scoped-actor' || Boolean(challenge.requester?.actorId || challenge.requester?.credentialId);
+}
+
+function approverSatisfiesTarget(
+  approver: HighRiskApprovalApproverIdentity,
+  target: HighRiskApprovalTarget | undefined
+): boolean {
+  if (!target) return true;
+  if (target.kind === 'human' || target.kind === 'operator') {
+    if (approver.kind !== 'human') return false;
+    return !target.id || approver.actorId === target.id;
+  }
+  if (target.kind === 'session') {
+    return Boolean(target.sessionId && approver.sessionId === target.sessionId);
+  }
+  return true;
+}
+
+function updatedContract(
+  challenge: ConfirmationChallenge,
+  outcome: HighRiskApprovalOutcome,
+  redemptionNonce?: string,
+  approver?: HighRiskApprovalApproverIdentity
+): HighRiskApprovalContract {
+  return createHighRiskApprovalContract({
+    challengeId: challenge.challengeId,
+    decision: challenge.decision,
+    canonicalParams: challenge.canonicalParams,
+    createdAt: new Date(challenge.createdAt),
+    expiresAt: new Date(challenge.expiresAt),
+    requester: challenge.requester ?? {
+      kind: 'browser-session',
+      authSessionHash: challenge.requesterAuthSessionHash,
+      ...(challenge.requesterDisplayName ? { displayName: challenge.requesterDisplayName } : {}),
+    },
+    ...(challenge.approvalTarget ? { approvalTarget: challenge.approvalTarget } : {}),
+    ...(approver ?? challenge.approver ? { approver: approver ?? challenge.approver } : {}),
+    ...(redemptionNonce
+      ? { redemptionNonce }
+      : challenge.contract.redemptionNonceHash
+        ? { redemptionNonceHash: challenge.contract.redemptionNonceHash }
+        : {}),
+    outcome,
+  });
 }
 
 function failChallenge(
@@ -561,10 +689,15 @@ function failChallenge(
   reasonCode: ConfirmationReasonCode,
   message: string,
   eventType: SecurityAuditEntryInput['eventType'],
-  decision: SecurityAuditEntryInput['decision']
+  decision: SecurityAuditEntryInput['decision'],
+  outcome?: HighRiskApprovalOutcome
 ): ConfirmationFailure {
   challenge.reasonCode = reasonCode;
   challenge.message = message;
+  if (outcome) {
+    challenge.outcome = outcome;
+    challenge.contract = updatedContract(challenge, outcome);
+  }
   return failure(reasonCode, message, challenge, auditForChallenge(challenge, {
     eventType,
     decision,
@@ -595,6 +728,8 @@ function expireIfNeeded(
   if (!challengeExpired && !tokenExpired) return null;
   challenge.status = 'expired';
   challenge.reasonCode = 'CONFIRMATION_EXPIRED';
+  challenge.outcome = 'expired';
+  challenge.contract = updatedContract(challenge, 'expired');
   delete challenge.requesterToken;
   challenge.message = tokenExpired
     ? 'confirmation token expired'

--- a/server/confirmation-challenges.ts
+++ b/server/confirmation-challenges.ts
@@ -429,23 +429,20 @@ export function createConfirmationChallengeStore(
       return failChallenge(challenge, 'CONFIRMATION_SAME_SESSION', 'the approving browser/auth session cannot redeem its own approval', 'same_session_approval_attempt', 'deny');
     }
     if (!challengeContextMatches(challenge, input.decision)) {
-      return failChallenge(challenge, 'CONFIRMATION_CONTEXT_MISMATCH', 'confirmation token does not match this node, intent, capability set, or session', 'failed_redemption', 'failed');
+      return invalidateRedemptionChallenge(
+        challenge,
+        'CONFIRMATION_CONTEXT_MISMATCH',
+        'confirmation token context drift invalidated the approved challenge',
+        input.canonicalParams
+      );
     }
     if (challenge.canonicalParamsHash !== hashCanonicalParams(input.canonicalParams)) {
-      challenge.failedRedemptions += 1;
-      challenge.outcome = 'mismatch_denied';
-      challenge.contract = updatedContract(challenge, 'mismatch_denied');
-      if (challenge.failedRedemptions >= challenge.maxFailedRedemptions) {
-        challenge.status = 'invalidated';
-        challenge.reasonCode = 'CONFIRMATION_PARAM_MISMATCH';
-        challenge.message = 'confirmation token invalidated after too many parameter mismatches';
-      }
-      return failure('CONFIRMATION_PARAM_MISMATCH', 'confirmation token parameters do not match the original challenge', challenge, auditForChallenge(challenge, {
-        eventType: 'failed_redemption',
-        decision: 'failed',
-        reasonCode: 'CONFIRMATION_PARAM_MISMATCH',
-        params: input.canonicalParams,
-      }));
+      return invalidateRedemptionChallenge(
+        challenge,
+        'CONFIRMATION_PARAM_MISMATCH',
+        'confirmation token parameter drift invalidated the approved challenge',
+        input.canonicalParams
+      );
     }
     challenge.status = 'redeemed';
     challenge.redeemedAt = current.toISOString();
@@ -682,6 +679,29 @@ function updatedContract(
         : {}),
     outcome,
   });
+}
+
+function invalidateRedemptionChallenge(
+  challenge: ConfirmationChallenge,
+  reasonCode: ConfirmationReasonCode,
+  message: string,
+  params?: unknown
+): ConfirmationFailure {
+  challenge.failedRedemptions += 1;
+  challenge.status = 'invalidated';
+  challenge.reasonCode = reasonCode;
+  challenge.message = message;
+  challenge.outcome = 'mismatch_denied';
+  challenge.contract = updatedContract(challenge, 'mismatch_denied');
+  delete challenge.tokenExpiresAt;
+  delete challenge.tokenHash;
+  delete challenge.requesterToken;
+  return failure(reasonCode, message, challenge, auditForChallenge(challenge, {
+    eventType: 'failed_redemption',
+    decision: 'failed',
+    reasonCode,
+    ...(params !== undefined ? { params } : {}),
+  }));
 }
 
 function failChallenge(

--- a/server/high-risk-approvals.ts
+++ b/server/high-risk-approvals.ts
@@ -171,6 +171,8 @@ export interface HighRiskApprovalContract {
 export interface CreateHighRiskApprovalContractInput {
   challengeId: string;
   decision: HubPolicyDecision;
+  classificationInput?: HighRiskOperationClassificationInput;
+  classification?: HighRiskOperationClassification;
   canonicalParams: unknown;
   createdAt: Date;
   expiresAt: Date;
@@ -276,13 +278,9 @@ export function classifyHighRiskOperation(
 export function createHighRiskApprovalContract(
   input: CreateHighRiskApprovalContractInput
 ): HighRiskApprovalContract {
-  const classification = classifyHighRiskOperation({
-    action: input.decision.intent.action,
-    targetNodeId: input.decision.nodeId,
-    scopeKind: input.decision.scope.kind,
-    requiredCapabilities: input.decision.requiredBits,
-    ...(input.decision.trustTier ? { trustTier: input.decision.trustTier } : {}),
-  });
+  const classification = input.classification ?? classifyHighRiskOperation(
+    input.classificationInput ?? classificationInputFromDecision(input.decision)
+  );
   const workContextId =
     input.requester.workContextId ?? stringField(input.decision.scope as unknown as Record<string, unknown>, 'workspaceId');
   const redemptionNonceHash = input.redemptionNonce
@@ -327,6 +325,21 @@ export function createHighRiskApprovalContract(
   return {
     ...payload,
     contractHash: sha256Hex(stableStringify(payload)),
+  };
+}
+
+function classificationInputFromDecision(
+  decision: HubPolicyDecision
+): HighRiskOperationClassificationInput {
+  return {
+    action: decision.intent.action,
+    targetNodeId: decision.nodeId,
+    ...(decision.peer.kind === 'node' && decision.peer.nodeId
+      ? { sourceNodeId: decision.peer.nodeId }
+      : {}),
+    scopeKind: decision.scope.kind,
+    requiredCapabilities: decision.requiredBits,
+    ...(decision.trustTier ? { trustTier: decision.trustTier } : {}),
   };
 }
 

--- a/server/high-risk-approvals.ts
+++ b/server/high-risk-approvals.ts
@@ -1,0 +1,524 @@
+import {
+  sha256Hex,
+  stableStringify,
+} from '../shared/security-audit.js';
+import {
+  HIGH_RISK_CAPABILITIES,
+  isRelayCapabilityBit,
+  type RelayCapabilityBit,
+  type RelayTrustTier,
+} from '../shared/security-policy.js';
+import type { HubPolicyDecision } from './hub-policy-evaluator.js';
+
+export const HIGH_RISK_APPROVAL_SCHEMA_VERSION = 1 as const;
+export const HIGH_RISK_APPROVAL_CHALLENGE_KIND =
+  'exact-operation-high-risk-approval' as const;
+
+export const HIGH_RISK_APPROVAL_OUTCOMES = [
+  'challenge_created',
+  'approved',
+  'denied',
+  'expired',
+  'redeemed',
+  'reuse_denied',
+  'mismatch_denied',
+  'approval_target_invalid',
+  'audit_write_failed',
+] as const;
+
+export type HighRiskApprovalOutcome =
+  (typeof HIGH_RISK_APPROVAL_OUTCOMES)[number];
+
+export type HighRiskClassificationDecision =
+  | 'approvalRequired'
+  | 'silentAllowIfPolicyAllows'
+  | 'deny';
+
+export type HighRiskRiskReason =
+  | 'cross-node control high-risk'
+  | 'capability escalation high-risk'
+  | 'shell exec high-risk'
+  | 'file boundary mutation high-risk'
+  | 'credential export high-risk'
+  | 'node lifecycle high-risk'
+  | 'destructive session control high-risk'
+  | 'generic high-risk capability'
+  | 'low_risk_ref_only'
+  | 'low_risk_read'
+  | 'unknown_capability'
+  | 'unknown_operation';
+
+export interface HighRiskOperationClassificationInput {
+  action: string;
+  targetNodeId?: string;
+  sourceNodeId?: string;
+  trustTier?: RelayTrustTier;
+  scopeKind?: string;
+  boundaryCrossing?: boolean;
+  requiredCapabilities: readonly string[];
+}
+
+export interface HighRiskOperationClassification {
+  decision: HighRiskClassificationDecision;
+  riskReason: HighRiskRiskReason;
+  requiredBits: RelayCapabilityBit[];
+  unknownBits: string[];
+}
+
+export type HighRiskApprovalActorKind =
+  | 'browser-session'
+  | 'scoped-actor'
+  | 'human'
+  | 'node'
+  | 'system';
+
+export interface HighRiskApprovalRequesterIdentity {
+  kind: HighRiskApprovalActorKind;
+  authSessionHash: string;
+  actorType?: string;
+  actorId?: string;
+  credentialId?: string;
+  credentialJti?: string;
+  nodeId?: string;
+  sessionId?: string;
+  workContextId?: string;
+  displayName?: string;
+}
+
+export interface HighRiskApprovalApproverIdentity {
+  kind: HighRiskApprovalActorKind;
+  actorType?: string;
+  actorId?: string;
+  credentialId?: string;
+  credentialJti?: string;
+  nodeId?: string;
+  sessionId?: string;
+  workContextId?: string;
+  displayName?: string;
+}
+
+export interface HighRiskApprovalTarget {
+  kind: 'human' | 'operator' | 'session' | 'external';
+  id?: string;
+  sessionId?: string;
+  displayName?: string;
+}
+
+export interface SafeHighRiskApprovalRequesterIdentity {
+  kind: HighRiskApprovalActorKind;
+  authSessionHash: string;
+  actorType?: string;
+  actorIdHash?: string;
+  credentialIdHash?: string;
+  credentialJtiHash?: string;
+  nodeId?: string;
+  sessionId?: string;
+  workContextId?: string;
+  displayName?: string;
+}
+
+export interface SafeHighRiskApprovalApproverIdentity {
+  kind: HighRiskApprovalActorKind;
+  actorType?: string;
+  actorIdHash?: string;
+  credentialIdHash?: string;
+  credentialJtiHash?: string;
+  nodeId?: string;
+  sessionId?: string;
+  workContextId?: string;
+  displayName?: string;
+}
+
+export interface SafeHighRiskApprovalTarget {
+  kind: HighRiskApprovalTarget['kind'];
+  idHash?: string;
+  sessionId?: string;
+  displayName?: string;
+}
+
+export interface HighRiskApprovalContract {
+  schemaVersion: typeof HIGH_RISK_APPROVAL_SCHEMA_VERSION;
+  challengeKind: typeof HIGH_RISK_APPROVAL_CHALLENGE_KIND;
+  challengeId: string;
+  outcome: HighRiskApprovalOutcome;
+  correlationId: string;
+  operation: {
+    action: string;
+    nodeId: string;
+    target?: string;
+    sessionId?: string;
+    workContextId?: string;
+  };
+  risk: Pick<HighRiskOperationClassification, 'decision' | 'riskReason' | 'unknownBits'>;
+  policy: {
+    aclRef?: string;
+    policyVersion?: string;
+    trustTier?: RelayTrustTier;
+    requiredBits: RelayCapabilityBit[];
+    challengeBits: RelayCapabilityBit[];
+    scopeHash: string;
+  };
+  requester: SafeHighRiskApprovalRequesterIdentity;
+  approver?: SafeHighRiskApprovalApproverIdentity;
+  approvalTarget: SafeHighRiskApprovalTarget;
+  paramsHash: string;
+  createdAt: string;
+  expiresAt: string;
+  redemptionNonceHash?: string;
+  contractHash: string;
+}
+
+export interface CreateHighRiskApprovalContractInput {
+  challengeId: string;
+  decision: HubPolicyDecision;
+  canonicalParams: unknown;
+  createdAt: Date;
+  expiresAt: Date;
+  requester: HighRiskApprovalRequesterIdentity;
+  approvalTarget?: HighRiskApprovalTarget;
+  approver?: HighRiskApprovalApproverIdentity;
+  redemptionNonce?: string;
+  redemptionNonceHash?: string;
+  outcome?: HighRiskApprovalOutcome;
+}
+
+const HIGH_RISK_CAPABILITY_SET = new Set<string>(HIGH_RISK_CAPABILITIES);
+const LOW_RISK_READ_ACTIONS = new Set([
+  'sessions.read',
+  'sessions.interventions.read',
+  'rpc.fs.list',
+  'rpc.fs.stat',
+  'rpc.fs.read',
+  'rpc.fs.tail',
+  'rpc.git.read',
+  'logs.tail',
+]);
+const LOW_RISK_REF_ONLY_ACTIONS = new Set([
+  'context.read',
+  'context.write',
+  'inbox.read',
+  'inbox.write',
+]);
+const KNOWN_ACTIONS = new Set([
+  ...Array.from(LOW_RISK_READ_ACTIONS),
+  ...Array.from(LOW_RISK_REF_ONLY_ACTIONS),
+  'sessions.create',
+  'sessions.create.agent',
+  'sessions.create.terminal',
+  'sessions.attach',
+  'sessions.kill',
+  'sessions.control.set-agent',
+  'pty.exec.arbitrary',
+  'preview.port-forward',
+  'rpc.fs.write',
+  'rpc.fs.delete',
+  'rpc.git.write',
+  'nodes.acl.widen',
+  'capabilities.grant',
+  'credentials.export',
+  'secrets.export',
+  'nodes.revoke',
+  'nodes.rotate',
+  'nodes.repair',
+  'nodes.re-pair',
+  'nodes.destroy',
+]);
+
+export function isHighRiskApprovalOutcome(
+  value: unknown
+): value is HighRiskApprovalOutcome {
+  return (
+    typeof value === 'string' &&
+    (HIGH_RISK_APPROVAL_OUTCOMES as readonly string[]).includes(value)
+  );
+}
+
+export function classifyHighRiskOperation(
+  input: HighRiskOperationClassificationInput
+): HighRiskOperationClassification {
+  const required = normalizeRequiredBits(input.requiredCapabilities);
+  if (required.unknownBits.length > 0) {
+    return deny('unknown_capability', required);
+  }
+  if (!KNOWN_ACTIONS.has(input.action)) {
+    return deny('unknown_operation', required);
+  }
+  if (isCrossNodeControl(input)) {
+    return approvalRequired('cross-node control high-risk', required);
+  }
+  if (isCapabilityEscalation(input)) {
+    return approvalRequired('capability escalation high-risk', required);
+  }
+  if (isShellExec(input)) {
+    return approvalRequired('shell exec high-risk', required);
+  }
+  if (isFileBoundaryMutation(input)) {
+    return approvalRequired('file boundary mutation high-risk', required);
+  }
+  if (isCredentialExport(input)) {
+    return approvalRequired('credential export high-risk', required);
+  }
+  if (isNodeLifecycle(input)) {
+    return approvalRequired('node lifecycle high-risk', required);
+  }
+  if (isDestructiveSessionControl(input)) {
+    return approvalRequired('destructive session control high-risk', required);
+  }
+  if (required.requiredBits.some((bit) => HIGH_RISK_CAPABILITY_SET.has(bit))) {
+    return approvalRequired('generic high-risk capability', required);
+  }
+  if (LOW_RISK_REF_ONLY_ACTIONS.has(input.action)) {
+    return silent('low_risk_ref_only', required);
+  }
+  return silent('low_risk_read', required);
+}
+
+export function createHighRiskApprovalContract(
+  input: CreateHighRiskApprovalContractInput
+): HighRiskApprovalContract {
+  const classification = classifyHighRiskOperation({
+    action: input.decision.intent.action,
+    targetNodeId: input.decision.nodeId,
+    scopeKind: input.decision.scope.kind,
+    requiredCapabilities: input.decision.requiredBits,
+    ...(input.decision.trustTier ? { trustTier: input.decision.trustTier } : {}),
+  });
+  const workContextId =
+    input.requester.workContextId ?? stringField(input.decision.scope as unknown as Record<string, unknown>, 'workspaceId');
+  const redemptionNonceHash = input.redemptionNonce
+    ? sha256Hex(`relay-approval-nonce:${input.redemptionNonce}`)
+    : input.redemptionNonceHash;
+  const payload: Omit<HighRiskApprovalContract, 'contractHash'> = {
+    schemaVersion: HIGH_RISK_APPROVAL_SCHEMA_VERSION,
+    challengeKind: HIGH_RISK_APPROVAL_CHALLENGE_KIND,
+    challengeId: input.challengeId,
+    outcome: input.outcome ?? 'challenge_created',
+    correlationId: input.decision.correlationId ?? input.challengeId,
+    operation: {
+      action: input.decision.intent.action,
+      nodeId: input.decision.nodeId,
+      ...(input.decision.intent.target ? { target: input.decision.intent.target } : {}),
+      ...(input.decision.sessionId ? { sessionId: input.decision.sessionId } : {}),
+      ...(workContextId ? { workContextId } : {}),
+    },
+    risk: {
+      decision: classification.decision,
+      riskReason: classification.riskReason,
+      unknownBits: [...classification.unknownBits],
+    },
+    policy: {
+      ...(input.decision.aclRef ? { aclRef: input.decision.aclRef } : {}),
+      ...(input.decision.policyVersion
+        ? { policyVersion: input.decision.policyVersion }
+        : {}),
+      ...(input.decision.trustTier ? { trustTier: input.decision.trustTier } : {}),
+      requiredBits: [...input.decision.requiredBits],
+      challengeBits: [...input.decision.challengeBits],
+      scopeHash: sha256Hex(stableStringify(input.decision.scope)),
+    },
+    requester: safeRequester(input.requester),
+    ...(input.approver ? { approver: safeApprover(input.approver) } : {}),
+    approvalTarget: safeTarget(input.approvalTarget ?? { kind: 'human' }),
+    paramsHash: sha256Hex(stableStringify(input.canonicalParams ?? null)),
+    createdAt: input.createdAt.toISOString(),
+    expiresAt: input.expiresAt.toISOString(),
+    ...(redemptionNonceHash ? { redemptionNonceHash } : {}),
+  };
+  return {
+    ...payload,
+    contractHash: sha256Hex(stableStringify(payload)),
+  };
+}
+
+export function sameHighRiskActor(
+  requester: HighRiskApprovalRequesterIdentity | undefined,
+  approver: HighRiskApprovalApproverIdentity | undefined
+): boolean {
+  if (!requester || !approver) return false;
+  return Boolean(
+    requester.actorId &&
+      approver.actorId &&
+      requester.actorType === approver.actorType &&
+      hashIdentity(requester.actorId) === hashIdentity(approver.actorId)
+  );
+}
+
+export function sameHighRiskCredential(
+  requester: HighRiskApprovalRequesterIdentity | undefined,
+  approver: HighRiskApprovalApproverIdentity | undefined
+): boolean {
+  if (!requester || !approver) return false;
+  return Boolean(
+    requester.credentialId &&
+      approver.credentialId &&
+      hashIdentity(requester.credentialId) === hashIdentity(approver.credentialId)
+  );
+}
+
+export function sameHighRiskSession(
+  requester: HighRiskApprovalRequesterIdentity | undefined,
+  approver: HighRiskApprovalApproverIdentity | undefined
+): boolean {
+  if (!requester || !approver) return false;
+  return Boolean(
+    requester.sessionId &&
+      approver.sessionId &&
+      hashIdentity(requester.sessionId) === hashIdentity(approver.sessionId)
+  );
+}
+
+function normalizeRequiredBits(requiredCapabilities: readonly string[]): {
+  requiredBits: RelayCapabilityBit[];
+  unknownBits: string[];
+} {
+  const requiredBits: RelayCapabilityBit[] = [];
+  const unknownBits: string[] = [];
+  const seen = new Set<string>();
+  for (const bit of requiredCapabilities) {
+    if (seen.has(bit)) continue;
+    seen.add(bit);
+    if (isRelayCapabilityBit(bit)) requiredBits.push(bit);
+    else unknownBits.push(bit);
+  }
+  return { requiredBits, unknownBits };
+}
+
+function deny(
+  riskReason: Extract<HighRiskRiskReason, 'unknown_capability' | 'unknown_operation'>,
+  bits: { requiredBits: RelayCapabilityBit[]; unknownBits: string[] }
+): HighRiskOperationClassification {
+  return { decision: 'deny', riskReason, ...bits };
+}
+
+function silent(
+  riskReason: Extract<HighRiskRiskReason, 'low_risk_ref_only' | 'low_risk_read'>,
+  bits: { requiredBits: RelayCapabilityBit[]; unknownBits: string[] }
+): HighRiskOperationClassification {
+  return { decision: 'silentAllowIfPolicyAllows', riskReason, ...bits };
+}
+
+function approvalRequired(
+  riskReason: Exclude<HighRiskRiskReason, 'low_risk_ref_only' | 'low_risk_read' | 'unknown_capability' | 'unknown_operation'>,
+  bits: { requiredBits: RelayCapabilityBit[]; unknownBits: string[] }
+): HighRiskOperationClassification {
+  return { decision: 'approvalRequired', riskReason, ...bits };
+}
+
+function isCrossNodeControl(input: HighRiskOperationClassificationInput): boolean {
+  return Boolean(
+    input.sourceNodeId &&
+      input.targetNodeId &&
+      input.sourceNodeId !== input.targetNodeId &&
+      (input.action.startsWith('sessions.') || input.action.startsWith('nodes.'))
+  );
+}
+
+function isCapabilityEscalation(input: HighRiskOperationClassificationInput): boolean {
+  return (
+    input.action === 'nodes.acl.widen' ||
+    input.action === 'capabilities.grant' ||
+    input.requiredCapabilities.includes('node:acl:widen')
+  );
+}
+
+function isShellExec(input: HighRiskOperationClassificationInput): boolean {
+  return (
+    input.action === 'pty.exec.arbitrary' ||
+    (input.trustTier === 'prod' && input.requiredCapabilities.includes('pty:exec:arbitrary'))
+  );
+}
+
+function isFileBoundaryMutation(input: HighRiskOperationClassificationInput): boolean {
+  return (
+    input.action === 'rpc.fs.write' ||
+    input.action === 'rpc.fs.delete' ||
+    input.boundaryCrossing === true ||
+    input.requiredCapabilities.includes('rpc:fs:write') ||
+    input.requiredCapabilities.includes('rpc:fs:delete')
+  );
+}
+
+function isCredentialExport(input: HighRiskOperationClassificationInput): boolean {
+  return (
+    input.action === 'credentials.export' ||
+    input.action === 'secrets.export' ||
+    input.requiredCapabilities.includes('credential:export')
+  );
+}
+
+function isNodeLifecycle(input: HighRiskOperationClassificationInput): boolean {
+  return (
+    input.action === 'nodes.revoke' ||
+    input.action === 'nodes.rotate' ||
+    input.action === 'nodes.repair' ||
+    input.action === 'nodes.re-pair' ||
+    input.action === 'nodes.destroy' ||
+    input.requiredCapabilities.includes('node:lifecycle:destructive')
+  );
+}
+
+function isDestructiveSessionControl(input: HighRiskOperationClassificationInput): boolean {
+  return (
+    input.action === 'sessions.kill' ||
+    input.requiredCapabilities.includes('session:control:kill')
+  );
+}
+
+function safeRequester(
+  requester: HighRiskApprovalRequesterIdentity
+): SafeHighRiskApprovalRequesterIdentity {
+  return {
+    kind: requester.kind,
+    authSessionHash: requester.authSessionHash,
+    ...(requester.actorType ? { actorType: requester.actorType } : {}),
+    ...(requester.actorId ? { actorIdHash: hashIdentity(requester.actorId) } : {}),
+    ...(requester.credentialId
+      ? { credentialIdHash: hashIdentity(requester.credentialId) }
+      : {}),
+    ...(requester.credentialJti
+      ? { credentialJtiHash: hashIdentity(requester.credentialJti) }
+      : {}),
+    ...(requester.nodeId ? { nodeId: requester.nodeId } : {}),
+    ...(requester.sessionId ? { sessionId: requester.sessionId } : {}),
+    ...(requester.workContextId ? { workContextId: requester.workContextId } : {}),
+    ...(requester.displayName ? { displayName: requester.displayName } : {}),
+  };
+}
+
+function safeApprover(
+  approver: HighRiskApprovalApproverIdentity
+): SafeHighRiskApprovalApproverIdentity {
+  return {
+    kind: approver.kind,
+    ...(approver.actorType ? { actorType: approver.actorType } : {}),
+    ...(approver.actorId ? { actorIdHash: hashIdentity(approver.actorId) } : {}),
+    ...(approver.credentialId
+      ? { credentialIdHash: hashIdentity(approver.credentialId) }
+      : {}),
+    ...(approver.credentialJti
+      ? { credentialJtiHash: hashIdentity(approver.credentialJti) }
+      : {}),
+    ...(approver.nodeId ? { nodeId: approver.nodeId } : {}),
+    ...(approver.sessionId ? { sessionId: approver.sessionId } : {}),
+    ...(approver.workContextId ? { workContextId: approver.workContextId } : {}),
+    ...(approver.displayName ? { displayName: approver.displayName } : {}),
+  };
+}
+
+function safeTarget(target: HighRiskApprovalTarget): SafeHighRiskApprovalTarget {
+  return {
+    kind: target.kind,
+    ...(target.id ? { idHash: hashIdentity(target.id) } : {}),
+    ...(target.sessionId ? { sessionId: target.sessionId } : {}),
+    ...(target.displayName ? { displayName: target.displayName } : {}),
+  };
+}
+
+function hashIdentity(value: string): string {
+  return sha256Hex(`relay-high-risk-approval:${value}`);
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -83,7 +83,10 @@ import {
 import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
 import type { RelayCliGatewayError } from '../shared/cli-gateway-contract.js';
 import { validateAndSanitizeGatewayCreateInput } from '../shared/cli-gateway-runtime.js';
-import type { CliGatewayActorReadCommand } from './cli-gateway-actor-auth.js';
+import {
+  authenticatedCliGatewayActorCredential,
+  type CliGatewayActorReadCommand,
+} from './cli-gateway-actor-auth.js';
 import type {
   HighRiskApprovalApproverIdentity,
   HighRiskApprovalRequesterIdentity,
@@ -595,39 +598,33 @@ function authSessionLabel(req: Request): string | undefined {
   return req.header('x-auth-session')?.trim() || undefined;
 }
 
-function requestHeader(req: Request, name: string): string | undefined {
-  return req.header(name)?.trim() || undefined;
-}
-
-function bodyString(req: Request, key: string): string | undefined {
-  const value = bodyRecord(req)[key];
-  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+function authenticatedScopedRequesterIdentity(
+  req: Request,
+  requesterAuthSessionHash: string
+): HighRiskApprovalRequesterIdentity | undefined {
+  const credential = authenticatedCliGatewayActorCredential(req);
+  if (!credential) return undefined;
+  return {
+    kind: 'scoped-actor',
+    authSessionHash: requesterAuthSessionHash,
+    actorType: credential.actor.type,
+    actorId: credential.actor.id,
+    credentialId: credential.id,
+    ...(credential.scope.sessionIds?.[0] ? { sessionId: credential.scope.sessionIds[0] } : {}),
+    ...(credential.scope.workContextIds?.[0]
+      ? { workContextId: credential.scope.workContextIds[0] }
+      : {}),
+    ...(credential.actor.displayName ? { displayName: credential.actor.displayName } : {}),
+  };
 }
 
 function routedRequesterIdentity(
   req: Request,
   requesterAuthSessionHash: string
 ): HighRiskApprovalRequesterIdentity {
-  const actorId = requestHeader(req, 'x-relay-actor-id') ?? bodyString(req, 'actorId');
-  const actorType = requestHeader(req, 'x-relay-actor-type') ?? bodyString(req, 'actorType');
-  const credentialId = requestHeader(req, 'x-relay-credential-id') ?? bodyString(req, 'credentialId');
-  const credentialJti = requestHeader(req, 'x-relay-credential-jti') ?? bodyString(req, 'credentialJti');
-  const sessionId = requestHeader(req, 'x-relay-session-id') ?? bodyString(req, 'sessionId');
-  const workContextId = requestHeader(req, 'x-relay-work-context-id') ?? bodyString(req, 'workContextId');
-  const displayName = authSessionLabel(req) ?? requestHeader(req, 'x-relay-actor-display-name');
-  if (actorId || actorType || credentialId || credentialJti || sessionId || workContextId) {
-    return {
-      kind: 'scoped-actor',
-      authSessionHash: requesterAuthSessionHash,
-      ...(actorType ? { actorType } : {}),
-      ...(actorId ? { actorId } : {}),
-      ...(credentialId ? { credentialId } : {}),
-      ...(credentialJti ? { credentialJti } : {}),
-      ...(sessionId ? { sessionId } : {}),
-      ...(workContextId ? { workContextId } : {}),
-      ...(displayName ? { displayName } : {}),
-    };
-  }
+  const scopedRequester = authenticatedScopedRequesterIdentity(req, requesterAuthSessionHash);
+  if (scopedRequester) return scopedRequester;
+  const displayName = authSessionLabel(req);
   return {
     kind: 'browser-session',
     authSessionHash: requesterAuthSessionHash,
@@ -635,26 +632,29 @@ function routedRequesterIdentity(
   };
 }
 
-function routedApproverIdentity(req: Request): HighRiskApprovalApproverIdentity | undefined {
-  const actorId =
-    requestHeader(req, 'x-relay-approver-id') ??
-    requestHeader(req, 'x-relay-actor-id') ??
-    authSessionLabel(req);
-  const actorType = requestHeader(req, 'x-relay-actor-type') ?? 'human';
-  const credentialId = requestHeader(req, 'x-relay-credential-id');
-  const credentialJti = requestHeader(req, 'x-relay-credential-jti');
-  const sessionId = requestHeader(req, 'x-relay-session-id');
-  const workContextId = requestHeader(req, 'x-relay-work-context-id');
-  const displayName = authSessionLabel(req) ?? requestHeader(req, 'x-relay-actor-display-name');
-  if (!actorId && !credentialId && !credentialJti && !sessionId && !workContextId) return undefined;
+function routedApproverIdentity(
+  req: Request,
+  approverAuthSessionHash: string
+): HighRiskApprovalApproverIdentity {
+  const credential = authenticatedCliGatewayActorCredential(req);
+  if (credential) {
+    return {
+      kind: credential.actor.type === 'agent' ? 'scoped-actor' : 'human',
+      actorType: credential.actor.type,
+      actorId: credential.actor.id,
+      credentialId: credential.id,
+      ...(credential.scope.sessionIds?.[0] ? { sessionId: credential.scope.sessionIds[0] } : {}),
+      ...(credential.scope.workContextIds?.[0]
+        ? { workContextId: credential.scope.workContextIds[0] }
+        : {}),
+      ...(credential.actor.displayName ? { displayName: credential.actor.displayName } : {}),
+    };
+  }
+  const displayName = authSessionLabel(req);
   return {
     kind: 'human',
-    ...(actorType ? { actorType } : {}),
-    ...(actorId ? { actorId } : {}),
-    ...(credentialId ? { credentialId } : {}),
-    ...(credentialJti ? { credentialJti } : {}),
-    ...(sessionId ? { sessionId } : {}),
-    ...(workContextId ? { workContextId } : {}),
+    actorType: 'human',
+    actorId: approverAuthSessionHash,
     ...(displayName ? { displayName } : {}),
   };
 }
@@ -735,10 +735,11 @@ function confirmationApprovalInput(
   now: Date
 ) {
   const approverDisplayName = authSessionLabel(req);
-  const approver = routedApproverIdentity(req);
+  const approverAuthSessionHash = authSessionHash(req);
+  const approver = routedApproverIdentity(req, approverAuthSessionHash);
   return {
     challengeId,
-    approverAuthSessionHash: authSessionHash(req),
+    approverAuthSessionHash,
     ...(approverDisplayName ? { approverDisplayName } : {}),
     ...(approver ? { approver } : {}),
     decision,

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -84,6 +84,11 @@ import type { HubNodeSummary } from '../shared/relay-node-protocol.js';
 import type { RelayCliGatewayError } from '../shared/cli-gateway-contract.js';
 import { validateAndSanitizeGatewayCreateInput } from '../shared/cli-gateway-runtime.js';
 import type { CliGatewayActorReadCommand } from './cli-gateway-actor-auth.js';
+import type {
+  HighRiskApprovalApproverIdentity,
+  HighRiskApprovalRequesterIdentity,
+  HighRiskApprovalTarget,
+} from './high-risk-approvals.js';
 
 const FILE_RPC_FOLLOW_STREAM_BUFFER_BYTES = 256 * 1024;
 
@@ -590,6 +595,74 @@ function authSessionLabel(req: Request): string | undefined {
   return req.header('x-auth-session')?.trim() || undefined;
 }
 
+function requestHeader(req: Request, name: string): string | undefined {
+  return req.header(name)?.trim() || undefined;
+}
+
+function bodyString(req: Request, key: string): string | undefined {
+  const value = bodyRecord(req)[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function routedRequesterIdentity(
+  req: Request,
+  requesterAuthSessionHash: string
+): HighRiskApprovalRequesterIdentity {
+  const actorId = requestHeader(req, 'x-relay-actor-id') ?? bodyString(req, 'actorId');
+  const actorType = requestHeader(req, 'x-relay-actor-type') ?? bodyString(req, 'actorType');
+  const credentialId = requestHeader(req, 'x-relay-credential-id') ?? bodyString(req, 'credentialId');
+  const credentialJti = requestHeader(req, 'x-relay-credential-jti') ?? bodyString(req, 'credentialJti');
+  const sessionId = requestHeader(req, 'x-relay-session-id') ?? bodyString(req, 'sessionId');
+  const workContextId = requestHeader(req, 'x-relay-work-context-id') ?? bodyString(req, 'workContextId');
+  const displayName = authSessionLabel(req) ?? requestHeader(req, 'x-relay-actor-display-name');
+  if (actorId || actorType || credentialId || credentialJti || sessionId || workContextId) {
+    return {
+      kind: 'scoped-actor',
+      authSessionHash: requesterAuthSessionHash,
+      ...(actorType ? { actorType } : {}),
+      ...(actorId ? { actorId } : {}),
+      ...(credentialId ? { credentialId } : {}),
+      ...(credentialJti ? { credentialJti } : {}),
+      ...(sessionId ? { sessionId } : {}),
+      ...(workContextId ? { workContextId } : {}),
+      ...(displayName ? { displayName } : {}),
+    };
+  }
+  return {
+    kind: 'browser-session',
+    authSessionHash: requesterAuthSessionHash,
+    ...(displayName ? { displayName } : {}),
+  };
+}
+
+function routedApproverIdentity(req: Request): HighRiskApprovalApproverIdentity | undefined {
+  const actorId =
+    requestHeader(req, 'x-relay-approver-id') ??
+    requestHeader(req, 'x-relay-actor-id') ??
+    authSessionLabel(req);
+  const actorType = requestHeader(req, 'x-relay-actor-type') ?? 'human';
+  const credentialId = requestHeader(req, 'x-relay-credential-id');
+  const credentialJti = requestHeader(req, 'x-relay-credential-jti');
+  const sessionId = requestHeader(req, 'x-relay-session-id');
+  const workContextId = requestHeader(req, 'x-relay-work-context-id');
+  const displayName = authSessionLabel(req) ?? requestHeader(req, 'x-relay-actor-display-name');
+  if (!actorId && !credentialId && !credentialJti && !sessionId && !workContextId) return undefined;
+  return {
+    kind: 'human',
+    ...(actorType ? { actorType } : {}),
+    ...(actorId ? { actorId } : {}),
+    ...(credentialId ? { credentialId } : {}),
+    ...(credentialJti ? { credentialJti } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(workContextId ? { workContextId } : {}),
+    ...(displayName ? { displayName } : {}),
+  };
+}
+
+function routedApprovalTarget(requester: HighRiskApprovalRequesterIdentity): HighRiskApprovalTarget | undefined {
+  return requester.kind === 'scoped-actor' ? { kind: 'human' } : undefined;
+}
+
 function relayErrorForConfirmationFailure(
   failure: ConfirmationFailure
 ): RelayNodeError {
@@ -644,9 +717,13 @@ function confirmationCreateInput(
   canonicalParams: ReturnType<typeof canonicalConfirmationParams>
 ) {
   const requesterDisplayName = authSessionLabel(req);
+  const requester = routedRequesterIdentity(req, requesterAuthSessionHash);
+  const approvalTarget = routedApprovalTarget(requester);
   return {
     requesterAuthSessionHash,
     ...(requesterDisplayName ? { requesterDisplayName } : {}),
+    requester,
+    ...(approvalTarget ? { approvalTarget } : {}),
     canonicalParams,
   };
 }
@@ -658,10 +735,12 @@ function confirmationApprovalInput(
   now: Date
 ) {
   const approverDisplayName = authSessionLabel(req);
+  const approver = routedApproverIdentity(req);
   return {
     challengeId,
     approverAuthSessionHash: authSessionHash(req),
     ...(approverDisplayName ? { approverDisplayName } : {}),
+    ...(approver ? { approver } : {}),
     decision,
     now,
   };

--- a/server/index.ts
+++ b/server/index.ts
@@ -214,6 +214,7 @@ import {
   handleSupervisorSessionsRequest,
 } from './supervisor-route-handlers.js';
 import {
+  attachAuthenticatedCliGatewayActorCredential,
   bearerActorToken,
   classifyCliGatewayCredentialLane,
   cliGatewayActorFailure,
@@ -1747,6 +1748,7 @@ async function main(): Promise<void> {
         );
         return;
       }
+      attachAuthenticatedCliGatewayActorCredential(req, validation.credential);
       next();
     };
   };

--- a/shared/security-policy.ts
+++ b/shared/security-policy.ts
@@ -21,6 +21,9 @@ export const RELAY_CAPABILITY_BITS = [
   'rpc:git:write',
   'pty:exec:arbitrary',
   'preview:port-forward',
+  'node:acl:widen',
+  'credential:export',
+  'node:lifecycle:destructive',
   // #597: dedicated read bit for the `logs.tail` RPC backbone. Separate
   // from `rpc:fs:tail` so operator-only log visibility can be granted
   // without exposing arbitrary file tail to peers. Always redacted via
@@ -82,6 +85,9 @@ export const HIGH_RISK_CAPABILITIES = [
   'rpc:git:write',
   'pty:exec:arbitrary',
   'preview:port-forward',
+  'node:acl:widen',
+  'credential:export',
+  'node:lifecycle:destructive',
 ] as const satisfies readonly RelayCapabilityBit[];
 
 const RELAY_CAPABILITY_SET = new Set<string>(RELAY_CAPABILITY_BITS);

--- a/test/confirmation-challenges.test.ts
+++ b/test/confirmation-challenges.test.ts
@@ -49,7 +49,16 @@ describe('confirmation challenge store', () => {
       command: 'npm test',
     });
     expect(execA).toEqual(execB);
-    expect(execA).toMatchObject({ action: 'pty.exec.arbitrary', command: 'npm test', cwd: '/srv/app' });
+    expect(execA).toMatchObject({
+      action: 'pty.exec.arbitrary',
+      cwd: '/srv/app',
+      commandHash: createHash('sha256').update('npm test').digest('hex'),
+      commandByteCount: Buffer.byteLength('npm test'),
+      commandCharCount: 'npm test'.length,
+      commandClasses: [],
+    });
+    expect(execA).not.toHaveProperty('command');
+    expect(JSON.stringify(execA)).not.toContain('npm test');
     expect(JSON.stringify(execA)).not.toContain('"A":"1"');
     expect(execA).toHaveProperty('envHash');
 

--- a/test/confirmation-challenges.test.ts
+++ b/test/confirmation-challenges.test.ts
@@ -169,24 +169,20 @@ describe('confirmation challenge store', () => {
       expect(mismatch.audit?.peer.principalHash).toBe('requester-session');
     }
 
-    const redeemed = store.redeemToken({
-      token: 'raw-token',
-      requesterAuthSessionHash: 'requester-session',
-      decision: challengeDecision(),
-      canonicalParams: canonicalConfirmationParams('rpc.fs.write', {
-        cwd: '/srv/app',
-        path: 'secrets.txt',
-        content: 'hello',
-      }),
-      now: NOW,
+    expect(mismatch.challenge).toMatchObject({
+      status: 'invalidated',
+      failedRedemptions: 1,
+      outcome: 'mismatch_denied',
     });
-    expect(redeemed.ok).toBe(true);
-    if (!redeemed.ok) throw new Error('expected redemption');
-    expect(redeemed.audit.peer.principalHash).toBe('requester-session');
-    expect(redeemed.audit.peer.principalHash).not.toBe('approver-session');
-    expect(redeemed.challenge.requesterToken).toBeUndefined();
+    expect(mismatch.challenge?.tokenHash).toBeUndefined();
+    expect(mismatch.challenge?.requesterToken).toBeUndefined();
+    expect(store.getChallenge(challenge.challengeId)).toMatchObject({
+      status: 'invalidated',
+    });
+    expect(store.getChallenge(challenge.challengeId)?.tokenHash).toBeUndefined();
+    expect(store.getChallenge(challenge.challengeId)?.requesterToken).toBeUndefined();
 
-    const usedAgain = store.redeemToken({
+    const correctAfterMismatch = store.redeemToken({
       token: 'raw-token',
       requesterAuthSessionHash: 'requester-session',
       decision: challengeDecision(),
@@ -197,11 +193,13 @@ describe('confirmation challenge store', () => {
       }),
       now: NOW,
     });
-    expect(usedAgain.ok).toBe(false);
-    if (!usedAgain.ok) expect(usedAgain.reasonCode).toBe('CONFIRMATION_ALREADY_USED');
+    expect(correctAfterMismatch.ok).toBe(false);
+    if (!correctAfterMismatch.ok) {
+      expect(correctAfterMismatch.reasonCode).toBe('CONFIRMATION_TOKEN_INVALID');
+    }
   });
 
-  it('expires, denies, deny+revokes, and caps failed mismatches with operator-readable reason codes', () => {
+  it('expires, denies, deny+revokes, and invalidates failed mismatches with operator-readable reason codes', () => {
     const store = createConfirmationChallengeStore({
       now: () => NOW,
       randomToken: () => 'raw-token',
@@ -263,17 +261,20 @@ describe('confirmation challenge store', () => {
     });
     expect(approved.ok).toBe(true);
     const wrongParams = canonicalConfirmationParams('rpc.fs.write', { path: '/srv/app/a', content: 'wrong' });
-    for (let i = 0; i < 2; i += 1) {
-      const result = store.redeemToken({
-        token: 'raw-token',
-        requesterAuthSessionHash: 'requester-session',
-        decision: challengeDecision(),
-        canonicalParams: wrongParams,
-        now: NOW,
-      });
-      expect(result).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_PARAM_MISMATCH' });
-    }
-    expect(store.getChallenge(capped.challengeId)?.status).toBe('invalidated');
+    const result = store.redeemToken({
+      token: 'raw-token',
+      requesterAuthSessionHash: 'requester-session',
+      decision: challengeDecision(),
+      canonicalParams: wrongParams,
+      now: NOW,
+    });
+    expect(result).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_PARAM_MISMATCH' });
+    expect(store.getChallenge(capped.challengeId)).toMatchObject({
+      status: 'invalidated',
+      failedRedemptions: 1,
+    });
+    expect(store.getChallenge(capped.challengeId)?.tokenHash).toBeUndefined();
+    expect(store.getChallenge(capped.challengeId)?.requesterToken).toBeUndefined();
   });
 
   it('expires stale list entries and bounds stored terminal challenges', () => {

--- a/test/high-risk-approvals.test.ts
+++ b/test/high-risk-approvals.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyHighRiskOperation,
+  createHighRiskApprovalContract,
+  isHighRiskApprovalOutcome,
+} from '../server/high-risk-approvals.js';
+import {
+  canonicalConfirmationParams,
+  createConfirmationChallengeStore,
+  publicChallenge,
+} from '../server/confirmation-challenges.js';
+import type { HubPolicyDecision } from '../server/hub-policy-evaluator.js';
+
+const NOW = new Date('2026-01-02T03:04:05.000Z');
+
+function challengeDecision(overrides: Partial<HubPolicyDecision> = {}): HubPolicyDecision {
+  return {
+    decision: 'challenge',
+    reasonCode: 'POLICY_CHALLENGE_REQUIRED',
+    message: 'node ACL requires confirmation for this capability',
+    nodeId: 'node_prod',
+    peer: { kind: 'hub' },
+    intent: { action: 'rpc.fs.write', target: 'node_prod' },
+    scope: {
+      kind: 'repo',
+      nodeId: 'node_prod',
+      cwd: '/srv/app',
+      repoPath: '/srv/app',
+      workspaceId: 'workspace-1',
+    },
+    trustTier: 'prod',
+    aclRef: 'acl_prod',
+    policyVersion: '1.0',
+    requiredBits: ['rpc:fs:write'],
+    grantedBits: [],
+    deniedBits: [],
+    challengeBits: ['rpc:fs:write'],
+    unknownBits: [],
+    sessionId: 'session-1',
+    correlationId: 'corr-1',
+    params: canonicalConfirmationParams('rpc.fs.write', {
+      cwd: '/srv/app',
+      path: 'secrets.txt',
+      content: 'hello',
+    }),
+    ...overrides,
+  };
+}
+
+describe('high-risk approval classifier', () => {
+  it.each([
+    ['cross-node control', { action: 'sessions.control.set-agent', sourceNodeId: 'node_a', targetNodeId: 'node_b', requiredCapabilities: ['session:attach', 'tab:mode:set-agent'] }],
+    ['capability escalation / ACL widening', { action: 'nodes.acl.widen', targetNodeId: 'node_prod', requiredCapabilities: ['node:acl:widen'] }],
+    ['shell/exec on high-trust node', { action: 'pty.exec.arbitrary', targetNodeId: 'node_prod', trustTier: 'prod', requiredCapabilities: ['pty:exec:arbitrary'] }],
+    ['file write across boundary', { action: 'rpc.fs.write', targetNodeId: 'node_prod', scopeKind: 'path', boundaryCrossing: true, requiredCapabilities: ['rpc:fs:write'] }],
+    ['credential or secret export', { action: 'credentials.export', targetNodeId: 'node_prod', requiredCapabilities: ['credential:export'] }],
+    ['node revoke/rotate/re-pair/destructive lifecycle', { action: 'nodes.revoke', targetNodeId: 'node_prod', requiredCapabilities: ['node:lifecycle:destructive'] }],
+    ['destructive session control', { action: 'sessions.kill', targetNodeId: 'node_prod', requiredCapabilities: ['session:control:kill'] }],
+  ])('marks %s as approval-required with auditable reason', (_label, input) => {
+    const result = classifyHighRiskOperation(input);
+    expect(result.decision).toBe('approvalRequired');
+    expect(result.riskReason).toMatch(/high-risk|cross-node|capability|exec|file|credential|node lifecycle|session control/i);
+  });
+
+  it('fails closed for unknown operations or capabilities while leaving low-risk read/ref-only flows silent', () => {
+    expect(
+      classifyHighRiskOperation({
+        action: 'mystery.op',
+        targetNodeId: 'node_prod',
+        requiredCapabilities: ['rpc:fs:read'],
+      })
+    ).toMatchObject({ decision: 'deny', riskReason: 'unknown_operation' });
+    expect(
+      classifyHighRiskOperation({
+        action: 'rpc.fs.read',
+        targetNodeId: 'node_prod',
+        requiredCapabilities: ['totally:unknown'],
+      })
+    ).toMatchObject({ decision: 'deny', riskReason: 'unknown_capability' });
+    expect(
+      classifyHighRiskOperation({
+        action: 'context.write',
+        targetNodeId: 'node_prod',
+        requiredCapabilities: ['context:write'],
+      })
+    ).toMatchObject({ decision: 'silentAllowIfPolicyAllows', riskReason: 'low_risk_ref_only' });
+    expect(
+      classifyHighRiskOperation({
+        action: 'rpc.fs.read',
+        targetNodeId: 'node_prod',
+        requiredCapabilities: ['rpc:fs:read'],
+      })
+    ).toMatchObject({ decision: 'silentAllowIfPolicyAllows', riskReason: 'low_risk_read' });
+  });
+});
+
+describe('high-risk approval contract bindings', () => {
+  it('binds schema, operation, risk, policy, requester actor, correlation, target, ttl, params hash, and one-time nonce without raw secrets', () => {
+    const canonicalParams = canonicalConfirmationParams('rpc.fs.write', {
+      cwd: '/srv/app',
+      path: 'secrets.txt',
+      content: 'hello',
+      authorization: 'Bearer relay-super-secret-token',
+    });
+    const decision = challengeDecision({ params: canonicalParams });
+    const contract = createHighRiskApprovalContract({
+      challengeId: 'challenge-1',
+      decision,
+      canonicalParams,
+      createdAt: NOW,
+      expiresAt: new Date(NOW.getTime() + 60_000),
+      requester: {
+        kind: 'scoped-actor',
+        authSessionHash: 'requester-session-hash',
+        actorType: 'agent',
+        actorId: 'agent/raw/id',
+        credentialId: 'cred-raw-id',
+        credentialJti: 'jti-raw-id',
+        sessionId: 'session-1',
+        workContextId: 'work-context-1',
+      },
+      approvalTarget: { kind: 'human', id: 'operator-1' },
+      redemptionNonce: 'raw-confirmation-token',
+    });
+
+    expect(contract).toMatchObject({
+      schemaVersion: 1,
+      challengeKind: 'exact-operation-high-risk-approval',
+      challengeId: 'challenge-1',
+      outcome: 'challenge_created',
+      correlationId: 'corr-1',
+      operation: { action: 'rpc.fs.write', target: 'node_prod', nodeId: 'node_prod' },
+      risk: { decision: 'approvalRequired' },
+      policy: {
+        aclRef: 'acl_prod',
+        policyVersion: '1.0',
+        trustTier: 'prod',
+        requiredBits: ['rpc:fs:write'],
+        challengeBits: ['rpc:fs:write'],
+      },
+      requester: {
+        kind: 'scoped-actor',
+        authSessionHash: 'requester-session-hash',
+        actorType: 'agent',
+        actorIdHash: expect.any(String),
+        credentialIdHash: expect.any(String),
+        credentialJtiHash: expect.any(String),
+        sessionId: 'session-1',
+        workContextId: 'work-context-1',
+      },
+      approvalTarget: { kind: 'human', idHash: expect.any(String) },
+      paramsHash: expect.any(String),
+      redemptionNonceHash: expect.any(String),
+      contractHash: expect.any(String),
+    });
+    const serialized = JSON.stringify(contract);
+    expect(serialized).not.toContain('raw-confirmation-token');
+    expect(serialized).not.toContain('cred-raw-id');
+    expect(serialized).not.toContain('jti-raw-id');
+    expect(serialized).not.toContain('agent/raw/id');
+    expect(serialized).not.toContain('hello');
+    expect(serialized).not.toContain('relay-super-secret-token');
+  });
+
+  it.each([
+    'challenge_created',
+    'approved',
+    'denied',
+    'expired',
+    'redeemed',
+    'reuse_denied',
+    'mismatch_denied',
+    'approval_target_invalid',
+    'audit_write_failed',
+  ])('recognizes typed fail-closed outcome %s', (outcome) => {
+    expect(isHighRiskApprovalOutcome(outcome)).toBe(true);
+  });
+
+  it('rejects same actor, same credential, same session, and missing approver while accepting a distinct human operator', () => {
+    const store = createConfirmationChallengeStore({
+      now: () => NOW,
+      randomId: () => 'challenge-1',
+      randomToken: () => 'raw-confirmation-token',
+    });
+    const challenge = store.createChallenge(challengeDecision(), {
+      requesterAuthSessionHash: 'requester-session-hash',
+      requester: {
+        kind: 'scoped-actor',
+        authSessionHash: 'requester-session-hash',
+        actorType: 'agent',
+        actorId: 'agent-1',
+        credentialId: 'cred-1',
+        sessionId: 'session-1',
+        workContextId: 'work-context-1',
+      },
+      approvalTarget: { kind: 'human', id: 'operator-1' },
+      canonicalParams: canonicalConfirmationParams('rpc.fs.write', { path: '/srv/app/a', content: 'a' }),
+    });
+
+    expect(publicChallenge(challenge)).toMatchObject({
+      contract: expect.objectContaining({
+        challengeKind: 'exact-operation-high-risk-approval',
+        requester: expect.objectContaining({ credentialIdHash: expect.any(String) }),
+        approvalTarget: expect.objectContaining({ kind: 'human' }),
+      }),
+    });
+    expect(JSON.stringify(publicChallenge(challenge))).not.toContain('cred-1');
+
+    const missingApprover = store.approveChallenge({
+      challengeId: challenge.challengeId,
+      approverAuthSessionHash: 'operator-session',
+      decision: 'approve',
+      now: NOW,
+    });
+    expect(missingApprover).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_APPROVAL_TARGET_INVALID' });
+
+    const sameActor = store.approveChallenge({
+      challengeId: challenge.challengeId,
+      approverAuthSessionHash: 'operator-session',
+      approver: { kind: 'scoped-actor', actorType: 'agent', actorId: 'agent-1', credentialId: 'cred-2' },
+      decision: 'approve',
+      now: NOW,
+    });
+    expect(sameActor).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_SAME_ACTOR' });
+
+    const sameCredential = store.approveChallenge({
+      challengeId: challenge.challengeId,
+      approverAuthSessionHash: 'operator-session',
+      approver: { kind: 'human', actorId: 'operator-1', credentialId: 'cred-1' },
+      decision: 'approve',
+      now: NOW,
+    });
+    expect(sameCredential).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_SAME_CREDENTIAL' });
+
+    const sameSession = store.approveChallenge({
+      challengeId: challenge.challengeId,
+      approverAuthSessionHash: 'different-browser',
+      approver: { kind: 'human', actorId: 'operator-1', sessionId: 'session-1' },
+      decision: 'approve',
+      now: NOW,
+    });
+    expect(sameSession).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_SAME_SESSION' });
+
+    const wrongOperator = store.approveChallenge({
+      challengeId: challenge.challengeId,
+      approverAuthSessionHash: 'operator-session',
+      approver: { kind: 'human', actorId: 'operator-2', sessionId: 'operator-session-2' },
+      decision: 'approve',
+      now: NOW,
+    });
+    expect(wrongOperator).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_APPROVAL_TARGET_INVALID' });
+
+    const approved = store.approveChallenge({
+      challengeId: challenge.challengeId,
+      approverAuthSessionHash: 'operator-session',
+      approver: { kind: 'human', actorId: 'operator-1', sessionId: 'operator-session-2' },
+      approverDisplayName: 'operator',
+      decision: 'approve',
+      now: NOW,
+    });
+    expect(approved).toMatchObject({ ok: true, reasonCode: 'CONFIRMATION_APPROVED' });
+    if (!approved.ok) throw new Error('expected approval');
+    expect(approved.challenge.outcome).toBe('approved');
+    expect(approved.challenge.contract.outcome).toBe('approved');
+    const approvedNonceHash = approved.challenge.contract.redemptionNonceHash;
+    expect(approvedNonceHash).toEqual(expect.any(String));
+    expect(JSON.stringify(approved.challenge.contract)).not.toContain('raw-confirmation-token');
+
+    const redeemed = store.redeemToken({
+      token: 'raw-confirmation-token',
+      requesterAuthSessionHash: 'requester-session-hash',
+      decision: challengeDecision(),
+      canonicalParams: canonicalConfirmationParams('rpc.fs.write', { path: '/srv/app/a', content: 'a' }),
+      now: NOW,
+    });
+    expect(redeemed).toMatchObject({ ok: true, reasonCode: 'CONFIRMATION_APPROVED' });
+    if (!redeemed.ok) throw new Error('expected redemption');
+    expect(redeemed.challenge.contract.outcome).toBe('redeemed');
+    expect(redeemed.challenge.contract.redemptionNonceHash).toBe(approvedNonceHash);
+    expect(JSON.stringify(publicChallenge(redeemed.challenge))).not.toContain('raw-confirmation-token');
+  });
+});

--- a/test/high-risk-approvals.test.ts
+++ b/test/high-risk-approvals.test.ts
@@ -279,4 +279,152 @@ describe('high-risk approval contract bindings', () => {
     expect(redeemed.challenge.contract.redemptionNonceHash).toBe(approvedNonceHash);
     expect(JSON.stringify(publicChallenge(redeemed.challenge))).not.toContain('raw-confirmation-token');
   });
+
+  it('exercises deny, expire, redeem, reuse, and fail-closed parameter/context drift invalidation', () => {
+    let current = NOW;
+    let nextId = 0;
+    const store = createConfirmationChallengeStore({
+      now: () => current,
+      randomId: () => `challenge-${++nextId}`,
+      randomToken: () => `raw-token-${nextId}`,
+      challengeTtlMs: 1_000,
+      tokenTtlMs: 1_000,
+    });
+    const canonicalParams = canonicalConfirmationParams('rpc.fs.write', {
+      cwd: '/srv/app',
+      path: 'secrets.txt',
+      content: 'hello',
+    });
+
+    const denied = store.createChallenge(challengeDecision({ params: canonicalParams }), {
+      requesterAuthSessionHash: 'requester-session-hash',
+      canonicalParams,
+    });
+    const deniedResult = store.approveChallenge({
+      challengeId: denied.challengeId,
+      approverAuthSessionHash: 'operator-session',
+      decision: 'deny',
+      now: current,
+    });
+    expect(deniedResult).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_DENIED' });
+    expect(store.getChallenge(denied.challengeId)).toMatchObject({ status: 'denied', outcome: 'denied' });
+
+    const expired = store.createChallenge(challengeDecision({ params: canonicalParams }), {
+      requesterAuthSessionHash: 'requester-session-hash',
+      canonicalParams,
+    });
+    current = new Date(NOW.getTime() + 1_001);
+    expect(
+      store.approveChallenge({
+        challengeId: expired.challengeId,
+        approverAuthSessionHash: 'operator-session',
+        decision: 'approve',
+        now: current,
+      })
+    ).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_EXPIRED' });
+    expect(store.getChallenge(expired.challengeId)).toMatchObject({ status: 'expired', outcome: 'expired' });
+
+    current = NOW;
+    const redeemable = store.createChallenge(challengeDecision({ params: canonicalParams }), {
+      requesterAuthSessionHash: 'requester-session-hash',
+      canonicalParams,
+    });
+    const approved = store.approveChallenge({
+      challengeId: redeemable.challengeId,
+      approverAuthSessionHash: 'operator-session',
+      decision: 'approve',
+      now: current,
+    });
+    expect(approved).toMatchObject({ ok: true, reasonCode: 'CONFIRMATION_APPROVED' });
+    if (!approved.ok) throw new Error('expected approval');
+    const redeemed = store.redeemToken({
+      token: approved.confirmationToken,
+      requesterAuthSessionHash: 'requester-session-hash',
+      decision: challengeDecision({ params: canonicalParams }),
+      canonicalParams,
+      now: current,
+    });
+    expect(redeemed).toMatchObject({ ok: true, reasonCode: 'CONFIRMATION_APPROVED' });
+    const reused = store.redeemToken({
+      token: approved.confirmationToken,
+      requesterAuthSessionHash: 'requester-session-hash',
+      decision: challengeDecision({ params: canonicalParams }),
+      canonicalParams,
+      now: current,
+    });
+    expect(reused).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_ALREADY_USED' });
+
+    const drift = store.createChallenge(challengeDecision({ params: canonicalParams }), {
+      requesterAuthSessionHash: 'requester-session-hash',
+      canonicalParams,
+    });
+    const driftApproved = store.approveChallenge({
+      challengeId: drift.challengeId,
+      approverAuthSessionHash: 'operator-session',
+      decision: 'approve',
+      now: current,
+    });
+    if (!driftApproved.ok) throw new Error('expected drift approval');
+    const driftResult = store.redeemToken({
+      token: driftApproved.confirmationToken,
+      requesterAuthSessionHash: 'requester-session-hash',
+      decision: challengeDecision({ params: canonicalParams }),
+      canonicalParams: canonicalConfirmationParams('rpc.fs.write', {
+        cwd: '/srv/app',
+        path: 'secrets.txt',
+        content: 'tampered',
+      }),
+      now: current,
+    });
+    expect(driftResult).toMatchObject({
+      ok: false,
+      reasonCode: 'CONFIRMATION_PARAM_MISMATCH',
+      challenge: {
+        status: 'invalidated',
+        failedRedemptions: 1,
+        outcome: 'mismatch_denied',
+      },
+    });
+    expect(driftResult.challenge?.tokenHash).toBeUndefined();
+    expect(driftResult.challenge?.requesterToken).toBeUndefined();
+    expect(
+      store.redeemToken({
+        token: driftApproved.confirmationToken,
+        requesterAuthSessionHash: 'requester-session-hash',
+        decision: challengeDecision({ params: canonicalParams }),
+        canonicalParams,
+        now: current,
+      })
+    ).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_TOKEN_INVALID' });
+
+    const contextDrift = store.createChallenge(challengeDecision({ params: canonicalParams }), {
+      requesterAuthSessionHash: 'requester-session-hash',
+      canonicalParams,
+    });
+    const contextApproved = store.approveChallenge({
+      challengeId: contextDrift.challengeId,
+      approverAuthSessionHash: 'operator-session',
+      decision: 'approve',
+      now: current,
+    });
+    if (!contextApproved.ok) throw new Error('expected context approval');
+    const contextResult = store.redeemToken({
+      token: contextApproved.confirmationToken,
+      requesterAuthSessionHash: 'requester-session-hash',
+      decision: challengeDecision({ params: canonicalParams, sessionId: 'session-2' }),
+      canonicalParams,
+      now: current,
+    });
+    expect(contextResult).toMatchObject({
+      ok: false,
+      reasonCode: 'CONFIRMATION_CONTEXT_MISMATCH',
+      challenge: {
+        status: 'invalidated',
+        failedRedemptions: 1,
+        outcome: 'mismatch_denied',
+      },
+    });
+    expect(contextResult.challenge?.tokenHash).toBeUndefined();
+    expect(contextResult.challenge?.requesterToken).toBeUndefined();
+  });
 });

--- a/test/high-risk-approvals.test.ts
+++ b/test/high-risk-approvals.test.ts
@@ -162,6 +162,63 @@ describe('high-risk approval contract bindings', () => {
     expect(serialized).not.toContain('relay-super-secret-token');
   });
 
+  it('summarizes pty exec command text without exposing raw shell text to public challenge or audit material', () => {
+    const command = 'curl -H "Authorization: Bearer relay-...456" https://example.test && echo ghp_12...cdef';
+    const canonicalParams = canonicalConfirmationParams('pty.exec.arbitrary', {
+      cwd: '/srv/app',
+      command,
+      env: { PATH: '/bin', SECRET_TOKEN: 'secret-env-value' },
+    });
+
+    expect(canonicalParams).toMatchObject({
+      action: 'pty.exec.arbitrary',
+      cwd: '/srv/app',
+      commandHash: expect.any(String),
+      commandByteCount: Buffer.byteLength(command, 'utf8'),
+      commandCharCount: command.length,
+      commandClasses: expect.arrayContaining(['secret-looking', 'shell-metacharacters']),
+      envHash: expect.any(String),
+    });
+    expect(canonicalParams).not.toHaveProperty('command');
+
+    const store = createConfirmationChallengeStore({
+      now: () => NOW,
+      randomId: () => 'pty-challenge-1',
+      randomToken: () => 'raw-confirmation-token',
+    });
+    const challenge = store.createChallenge(
+      challengeDecision({
+        intent: { action: 'pty.exec.arbitrary', target: 'node_prod' },
+        requiredBits: ['pty:exec:arbitrary'],
+        challengeBits: ['pty:exec:arbitrary'],
+        params: canonicalParams,
+      }),
+      {
+        requesterAuthSessionHash: 'requester-session-hash',
+        canonicalParams,
+      }
+    );
+    const approved = store.approveChallenge({
+      challengeId: challenge.challengeId,
+      approverAuthSessionHash: 'operator-session',
+      decision: 'approve',
+      now: NOW,
+    });
+    expect(approved.ok).toBe(true);
+    if (!approved.ok) throw new Error('expected approval');
+    const publicJson = JSON.stringify(publicChallenge(challenge));
+    const auditJson = JSON.stringify(approved.audit);
+    for (const forbidden of [
+      'relay-super-secret-token-123456',
+      'ghp_12...cdef',
+      'secret-env-value',
+      command,
+    ]) {
+      expect(publicJson).not.toContain(forbidden);
+      expect(auditJson).not.toContain(forbidden);
+    }
+  });
+
   it.each([
     'challenge_created',
     'approved',
@@ -353,6 +410,12 @@ describe('high-risk approval contract bindings', () => {
       now: current,
     });
     expect(reused).toMatchObject({ ok: false, reasonCode: 'CONFIRMATION_ALREADY_USED' });
+    if (reused.ok) throw new Error('expected reuse denial');
+    expect(reused.audit).toMatchObject({
+      eventType: 'failed_redemption',
+      decision: 'failed',
+      reasonCode: 'CONFIRMATION_ALREADY_USED',
+    });
 
     const drift = store.createChallenge(challengeDecision({ params: canonicalParams }), {
       requesterAuthSessionHash: 'requester-session-hash',

--- a/test/high-risk-approvals.test.ts
+++ b/test/high-risk-approvals.test.ts
@@ -162,6 +162,76 @@ describe('high-risk approval contract bindings', () => {
     expect(serialized).not.toContain('relay-super-secret-token');
   });
 
+  it('serializes cross-node control contract risk from full classifier input, not lossy policy bits', () => {
+    const classificationInput = {
+      action: 'sessions.control.set-agent',
+      sourceNodeId: 'node_a',
+      targetNodeId: 'node_b',
+      requiredCapabilities: ['session:attach', 'tab:mode:set-agent'],
+    } as const;
+    const direct = classifyHighRiskOperation(classificationInput);
+    const decision = challengeDecision({
+      nodeId: 'node_b',
+      peer: { kind: 'node', nodeId: 'node_a' },
+      intent: { action: 'sessions.control.set-agent' },
+      scope: { kind: 'node', nodeId: 'node_b' },
+      requiredBits: ['session:attach', 'tab:mode:set-agent'],
+      challengeBits: ['session:attach'],
+      params: { action: 'sessions.control.set-agent' },
+    });
+
+    const contract = createHighRiskApprovalContract({
+      challengeId: 'challenge-cross-node-control',
+      decision,
+      canonicalParams: { action: 'sessions.control.set-agent' },
+      createdAt: NOW,
+      expiresAt: new Date(NOW.getTime() + 60_000),
+      requester: { kind: 'browser-session', authSessionHash: 'requester-session-hash' },
+    });
+
+    expect(direct).toMatchObject({
+      decision: 'approvalRequired',
+      riskReason: 'cross-node control high-risk',
+    });
+    expect(contract.risk).toMatchObject({
+      decision: direct.decision,
+      riskReason: direct.riskReason,
+    });
+  });
+
+  it('honors a preserved original high-risk classification when building contract risk', () => {
+    const classification = classifyHighRiskOperation({
+      action: 'rpc.fs.read',
+      targetNodeId: 'node_prod',
+      boundaryCrossing: true,
+      requiredCapabilities: ['rpc:fs:read'],
+    });
+    const decision = challengeDecision({
+      intent: { action: 'rpc.fs.read', target: 'node_prod' },
+      requiredBits: ['rpc:fs:read'],
+      challengeBits: ['rpc:fs:read'],
+    });
+
+    const contract = createHighRiskApprovalContract({
+      challengeId: 'challenge-boundary-read',
+      decision,
+      classification,
+      canonicalParams: { action: 'rpc.fs.read', path: '/srv/app/secrets.txt' },
+      createdAt: NOW,
+      expiresAt: new Date(NOW.getTime() + 60_000),
+      requester: { kind: 'browser-session', authSessionHash: 'requester-session-hash' },
+    });
+
+    expect(classification).toMatchObject({
+      decision: 'approvalRequired',
+      riskReason: 'file boundary mutation high-risk',
+    });
+    expect(contract.risk).toMatchObject({
+      decision: 'approvalRequired',
+      riskReason: 'file boundary mutation high-risk',
+    });
+  });
+
   it('summarizes pty exec command text without exposing raw shell text to public challenge or audit material', () => {
     const command = 'curl -H "Authorization: Bearer relay-...456" https://example.test && echo ghp_12...cdef';
     const canonicalParams = canonicalConfirmationParams('pty.exec.arbitrary', {

--- a/test/hub-confirmation-routing.test.ts
+++ b/test/hub-confirmation-routing.test.ts
@@ -5,10 +5,15 @@ import path from 'node:path';
 import express from 'express';
 import { afterEach, describe, expect, it } from 'vitest';
 import { createConfirmationChallengeStore, hashAuthSessionIdentity } from '../server/confirmation-challenges.js';
+import { attachAuthenticatedCliGatewayActorCredential } from '../server/cli-gateway-actor-auth.js';
 import { createRepoFeatureRouter } from '../server/features/repo-router.js';
 import { createHubNodeRouter, type RoutedSessionAuditSink } from '../server/hub-node-router.js';
 import type { HubNodeRegistry } from '../server/hub-node-registry.js';
 import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
+import type {
+  ScopedActorCredentialRecord,
+  ScopedActorCredentialType,
+} from '../shared/scoped-actor-credentials.js';
 import { createRoutedNodeSessionEnvelope } from '../shared/session-envelope.js';
 import { createWorkContextStore, type WorkContextStore } from '../server/work-contexts.js';
 import {
@@ -101,6 +106,38 @@ function sessionPayload() {
   };
 }
 
+function testAuthenticatedActorCredential(req: express.Request): ScopedActorCredentialRecord | undefined {
+  const actorId = req.header('x-test-trusted-actor-id')?.trim();
+  const credentialId = req.header('x-test-trusted-credential-id')?.trim();
+  if (!actorId && !credentialId) return undefined;
+  const actorType = (req.header('x-test-trusted-actor-type')?.trim() || 'agent') as ScopedActorCredentialType;
+  const sessionId = req.header('x-test-trusted-session-id')?.trim();
+  const workContextId = req.header('x-test-trusted-work-context-id')?.trim();
+  const displayName = req.header('x-test-trusted-display-name')?.trim();
+  return {
+    id: credentialId || `cred-${actorId}`,
+    actor: {
+      type: actorType,
+      id: actorId || `actor-${credentialId}`,
+      ...(displayName ? { displayName } : {}),
+    },
+    issuer: { id: 'test-auth' },
+    audience: 'relay:cli-gateway:v1',
+    capabilities: ['session:create:terminal', 'session:read'],
+    scope: {
+      ...(sessionId ? { sessionIds: [sessionId] } : {}),
+      ...(workContextId ? { workContextIds: [workContextId] } : {}),
+    },
+    issuedAt: NOW.toISOString(),
+    expiresAt: new Date(NOW.getTime() + 60_000).toISOString(),
+  };
+}
+
+function attachTestAuthenticatedActor(req: express.Request): void {
+  const credential = testAuthenticatedActorCredential(req);
+  if (credential) attachAuthenticatedCliGatewayActorCredential(req, credential);
+}
+
 async function listen(server: http.Server): Promise<number> {
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
   const address = server.address();
@@ -172,8 +209,10 @@ describe('hub confirmation routing', () => {
         workContextStore: options.workContextStore,
         now: () => NOW,
         requireAuth: (req, res, next) => {
-          if (req.header('x-test-auth') === 'yes') next();
-          else res.status(401).json({ error: 'Unauthorized' });
+          if (req.header('x-test-auth') === 'yes') {
+            attachTestAuthenticatedActor(req);
+            next();
+          } else res.status(401).json({ error: 'Unauthorized' });
         },
       })
     );
@@ -405,17 +444,64 @@ describe('hub confirmation routing', () => {
   });
 
   it('enforces structured requester/approver identity through live confirmation endpoints', async () => {
-    async function createScopedChallenge() {
-      const hub = await startHub();
-      const originalBody = { repoPath: '/srv/relay-ide', type: 'terminal' };
-      const requesterHeaders = {
+    const spoofOnly = await startHub();
+    const spoofOnlyResponse = await fetch(`${spoofOnly.base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: {
         'content-type': 'application/json',
         'x-test-auth': 'yes',
         'x-auth-session': 'requester-browser',
         'x-relay-actor-type': 'agent',
-        'x-relay-actor-id': 'agent-1',
-        'x-relay-credential-id': 'cred-1',
-        'x-relay-session-id': 'autonomous-session-1',
+        'x-relay-actor-id': 'spoofed-agent',
+        'x-relay-credential-id': 'spoofed-credential',
+        'x-relay-session-id': 'spoofed-session',
+      },
+      body: JSON.stringify({
+        repoPath: '/srv/relay-ide',
+        type: 'terminal',
+        actorId: 'spoofed-body-agent',
+        credentialId: 'spoofed-body-credential',
+        sessionId: 'spoofed-body-session',
+      }),
+    });
+    expect(spoofOnlyResponse.status).toBe(409);
+    const spoofOnlyJson = await spoofOnlyResponse.json();
+    expect(spoofOnlyJson).toMatchObject({
+      error: {
+        details: {
+          challenge: {
+            contract: {
+              requester: { kind: 'browser-session' },
+            },
+          },
+        },
+      },
+    });
+    expect(spoofOnlyJson.error.details.challenge.contract.requester.actorIdHash).toBeUndefined();
+    expect(spoofOnlyJson.error.details.challenge.contract.requester.credentialIdHash).toBeUndefined();
+    expect(spoofOnlyJson.error.details.challenge.contract.requester.sessionId).toBeUndefined();
+
+    async function createScopedChallenge() {
+      const hub = await startHub();
+      const originalBody = {
+        repoPath: '/srv/relay-ide',
+        type: 'terminal',
+        actorId: 'spoofed-body-agent',
+        credentialId: 'spoofed-body-credential',
+        sessionId: 'spoofed-body-session',
+      };
+      const requesterHeaders = {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+        'x-test-trusted-actor-type': 'agent',
+        'x-test-trusted-actor-id': 'agent-1',
+        'x-test-trusted-credential-id': 'cred-1',
+        'x-test-trusted-session-id': 'trusted-autonomous-session-1',
+        'x-relay-actor-type': 'agent',
+        'x-relay-actor-id': 'spoofed-agent',
+        'x-relay-credential-id': 'spoofed-credential',
+        'x-relay-session-id': 'spoofed-session',
       };
       const first = await fetch(`${hub.base}/hub/nodes/node_prod/sessions`, {
         method: 'POST',
@@ -434,7 +520,7 @@ describe('hub confirmation routing', () => {
                   actorType: 'agent',
                   actorIdHash: expect.any(String),
                   credentialIdHash: expect.any(String),
-                  sessionId: 'autonomous-session-1',
+                  sessionId: 'trusted-autonomous-session-1',
                 },
                 approvalTarget: { kind: 'human' },
               },
@@ -442,6 +528,7 @@ describe('hub confirmation routing', () => {
           },
         },
       });
+      expect(firstJson.error.details.challenge.contract.requester.sessionId).not.toBe('spoofed-session');
       return { ...hub, originalBody, requesterHeaders };
     }
 
@@ -452,8 +539,9 @@ describe('hub confirmation routing', () => {
         'content-type': 'application/json',
         'x-test-auth': 'yes',
         'x-auth-session': 'operator-browser',
-        'x-relay-actor-type': 'agent',
-        'x-relay-actor-id': 'agent-1',
+        'x-test-trusted-actor-type': 'agent',
+        'x-test-trusted-actor-id': 'agent-1',
+        'x-test-trusted-credential-id': 'other-cred',
       },
       body: JSON.stringify({ decision: 'approve' }),
     });
@@ -461,6 +549,10 @@ describe('hub confirmation routing', () => {
     expect(await sameActorApproval.json()).toMatchObject({
       error: { details: { reasonCode: 'CONFIRMATION_SAME_ACTOR' } },
     });
+    expect(
+      sameActor.auditEntries.find((entry) => entry.eventType === 'same_session_approval_attempt')
+        ?.peer.principalHash
+    ).toBe(hashAuthSessionIdentity('test-header:operator-browser'));
 
     const sameCredential = await createScopedChallenge();
     const sameCredentialApproval = await fetch(`${sameCredential.base}/hub/confirmations/challenge-1/approve`, {
@@ -469,7 +561,9 @@ describe('hub confirmation routing', () => {
         'content-type': 'application/json',
         'x-test-auth': 'yes',
         'x-auth-session': 'operator-browser',
-        'x-relay-credential-id': 'cred-1',
+        'x-test-trusted-actor-type': 'agent',
+        'x-test-trusted-actor-id': 'other-agent',
+        'x-test-trusted-credential-id': 'cred-1',
       },
       body: JSON.stringify({ decision: 'approve' }),
     });
@@ -485,7 +579,10 @@ describe('hub confirmation routing', () => {
         'content-type': 'application/json',
         'x-test-auth': 'yes',
         'x-auth-session': 'operator-browser',
-        'x-relay-session-id': 'autonomous-session-1',
+        'x-test-trusted-actor-type': 'agent',
+        'x-test-trusted-actor-id': 'other-agent',
+        'x-test-trusted-credential-id': 'other-cred',
+        'x-test-trusted-session-id': 'trusted-autonomous-session-1',
       },
       body: JSON.stringify({ decision: 'approve' }),
     });
@@ -494,17 +591,21 @@ describe('hub confirmation routing', () => {
       error: { details: { reasonCode: 'CONFIRMATION_SAME_SESSION' } },
     });
 
-    const missingHuman = await createScopedChallenge();
-    const missingHumanApproval = await fetch(`${missingHuman.base}/hub/confirmations/challenge-1/approve`, {
+    const nonHumanApprover = await createScopedChallenge();
+    const nonHumanApproval = await fetch(`${nonHumanApprover.base}/hub/confirmations/challenge-1/approve`, {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
         'x-test-auth': 'yes',
+        'x-auth-session': 'operator-browser',
+        'x-test-trusted-actor-type': 'agent',
+        'x-test-trusted-actor-id': 'other-agent',
+        'x-test-trusted-credential-id': 'other-cred',
       },
       body: JSON.stringify({ decision: 'approve' }),
     });
-    expect(missingHumanApproval.status).toBe(401);
-    expect(await missingHumanApproval.json()).toMatchObject({
+    expect(nonHumanApproval.status).toBe(401);
+    expect(await nonHumanApproval.json()).toMatchObject({
       error: { details: { reasonCode: 'CONFIRMATION_APPROVAL_TARGET_INVALID' } },
     });
 
@@ -515,6 +616,10 @@ describe('hub confirmation routing', () => {
         'content-type': 'application/json',
         'x-test-auth': 'yes',
         'x-auth-session': 'operator-browser',
+        'x-relay-actor-type': 'agent',
+        'x-relay-actor-id': 'agent-1',
+        'x-relay-credential-id': 'cred-1',
+        'x-relay-session-id': 'trusted-autonomous-session-1',
       },
       body: JSON.stringify({ decision: 'approve' }),
     });

--- a/test/hub-confirmation-routing.test.ts
+++ b/test/hub-confirmation-routing.test.ts
@@ -363,21 +363,6 @@ describe('hub confirmation routing', () => {
       challenge: { challengeId: 'challenge-1', status: 'approved' },
     });
 
-    const tampered = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        'x-test-auth': 'yes',
-        'x-auth-session': 'requester-browser',
-      },
-      body: JSON.stringify({ ...originalBody, method: 'cold-reopen', confirmationToken: 'raw-confirmation-token' }),
-    });
-    expect(tampered.status).toBe(401);
-    expect(await tampered.json()).toMatchObject({
-      error: { details: { reasonCode: 'CONFIRMATION_PARAM_MISMATCH' } },
-    });
-    expect(nodeLinks.requests).toHaveLength(0);
-
     const redeemed = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
       method: 'POST',
       headers: {
@@ -391,6 +376,20 @@ describe('hub confirmation routing', () => {
     expect(await redeemed.json()).toMatchObject({ id: 'remote-session-1', nodeId: 'node_prod' });
     expect(nodeLinks.requests).toHaveLength(1);
     expect(nodeLinks.requests[0]).toMatchObject({ type: 'sessions.create', payload: originalBody });
+
+    const reused = await fetch(`${base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+      },
+      body: JSON.stringify({ ...originalBody, confirmationToken: 'raw-confirmation-token' }),
+    });
+    expect(reused.status).toBe(401);
+    expect(await reused.json()).toMatchObject({
+      error: { details: { reasonCode: 'CONFIRMATION_ALREADY_USED' } },
+    });
     expect(auditEntries.map((entry) => entry.eventType)).toEqual(
       expect.arrayContaining(['challenge', 'same_session_approval_attempt', 'approval', 'failed_redemption', 'grant'])
     );
@@ -403,6 +402,130 @@ describe('hub confirmation routing', () => {
     expect(approvalAudit?.peer.principalHash).not.toBe(requesterHash);
     expect(failedRedemptionAudit?.peer.principalHash).toBe(requesterHash);
     expect(grantAudit?.peer.principalHash).toBe(requesterHash);
+  });
+
+  it('enforces structured requester/approver identity through live confirmation endpoints', async () => {
+    async function createScopedChallenge() {
+      const hub = await startHub();
+      const originalBody = { repoPath: '/srv/relay-ide', type: 'terminal' };
+      const requesterHeaders = {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'requester-browser',
+        'x-relay-actor-type': 'agent',
+        'x-relay-actor-id': 'agent-1',
+        'x-relay-credential-id': 'cred-1',
+        'x-relay-session-id': 'autonomous-session-1',
+      };
+      const first = await fetch(`${hub.base}/hub/nodes/node_prod/sessions`, {
+        method: 'POST',
+        headers: requesterHeaders,
+        body: JSON.stringify(originalBody),
+      });
+      expect(first.status).toBe(409);
+      const firstJson = await first.json();
+      expect(firstJson).toMatchObject({
+        error: {
+          details: {
+            challenge: {
+              contract: {
+                requester: {
+                  kind: 'scoped-actor',
+                  actorType: 'agent',
+                  actorIdHash: expect.any(String),
+                  credentialIdHash: expect.any(String),
+                  sessionId: 'autonomous-session-1',
+                },
+                approvalTarget: { kind: 'human' },
+              },
+            },
+          },
+        },
+      });
+      return { ...hub, originalBody, requesterHeaders };
+    }
+
+    const sameActor = await createScopedChallenge();
+    const sameActorApproval = await fetch(`${sameActor.base}/hub/confirmations/challenge-1/approve`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'operator-browser',
+        'x-relay-actor-type': 'agent',
+        'x-relay-actor-id': 'agent-1',
+      },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+    expect(sameActorApproval.status).toBe(401);
+    expect(await sameActorApproval.json()).toMatchObject({
+      error: { details: { reasonCode: 'CONFIRMATION_SAME_ACTOR' } },
+    });
+
+    const sameCredential = await createScopedChallenge();
+    const sameCredentialApproval = await fetch(`${sameCredential.base}/hub/confirmations/challenge-1/approve`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'operator-browser',
+        'x-relay-credential-id': 'cred-1',
+      },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+    expect(sameCredentialApproval.status).toBe(401);
+    expect(await sameCredentialApproval.json()).toMatchObject({
+      error: { details: { reasonCode: 'CONFIRMATION_SAME_CREDENTIAL' } },
+    });
+
+    const sameSession = await createScopedChallenge();
+    const sameSessionApproval = await fetch(`${sameSession.base}/hub/confirmations/challenge-1/approve`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'operator-browser',
+        'x-relay-session-id': 'autonomous-session-1',
+      },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+    expect(sameSessionApproval.status).toBe(401);
+    expect(await sameSessionApproval.json()).toMatchObject({
+      error: { details: { reasonCode: 'CONFIRMATION_SAME_SESSION' } },
+    });
+
+    const missingHuman = await createScopedChallenge();
+    const missingHumanApproval = await fetch(`${missingHuman.base}/hub/confirmations/challenge-1/approve`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+      },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+    expect(missingHumanApproval.status).toBe(401);
+    expect(await missingHumanApproval.json()).toMatchObject({
+      error: { details: { reasonCode: 'CONFIRMATION_APPROVAL_TARGET_INVALID' } },
+    });
+
+    const distinct = await createScopedChallenge();
+    const distinctApproval = await fetch(`${distinct.base}/hub/confirmations/challenge-1/approve`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-auth': 'yes',
+        'x-auth-session': 'operator-browser',
+      },
+      body: JSON.stringify({ decision: 'approve' }),
+    });
+    expect(distinctApproval.status).toBe(200);
+    const redeemed = await fetch(`${distinct.base}/hub/nodes/node_prod/sessions`, {
+      method: 'POST',
+      headers: distinct.requesterHeaders,
+      body: JSON.stringify({ ...distinct.originalBody, confirmationToken: 'raw-confirmation-token' }),
+    });
+    expect(redeemed.status).toBe(201);
+    expect(distinct.nodeLinks.requests).toHaveLength(1);
   });
 
   it('associates routed session creates with existing WorkContext metadata and Active Work groups', async () => {

--- a/test/stores/node-dashboard.test.ts
+++ b/test/stores/node-dashboard.test.ts
@@ -305,12 +305,15 @@ describe('hub node dashboard state', () => {
     // because it does not grant them — but crucially challenge stays at 2:
     // the writes are NOT high-risk, so prod never promotes them to a
     // confirmation challenge (the headless ack loop is not gated).
+    // #807 added three high-risk approval contract bits (node ACL widening,
+    // credential export, destructive node lifecycle). They are denied in these
+    // fixtures unless explicitly granted/challenged, so challenge remains at 2.
     expect(
       rows.map((row) => [row.security.trustTier, row.security.postureLabel])
     ).toEqual([
-      ['sandbox', 'allow 1 · challenge 0 · deny 22'],
-      ['dev', 'allow 15 · challenge 0 · deny 8'],
-      ['prod', 'allow 1 · challenge 2 · deny 20'],
+      ['sandbox', 'allow 1 · challenge 0 · deny 25'],
+      ['dev', 'allow 15 · challenge 0 · deny 11'],
+      ['prod', 'allow 1 · challenge 2 · deny 23'],
     ]);
     expect(rows[2].security).toMatchObject({
       tone: 'danger',


### PR DESCRIPTION
Closes #807
Refs #797

## Summary
- add exact-operation high-risk approval contract generation with redacted requester/approver/target identities, params hash, nonce hash, and contract hash
- extend confirmation challenges with typed approval outcomes, approval target enforcement, self-approval rejection, drift/reuse outcome tracking, and one-time redemption binding
- add high-risk capability bits for ACL widening, credential export, and destructive node lifecycle, plus classifier/flow/redaction tests

## Verification
- `PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" npm test -- test/high-risk-approvals.test.ts test/confirmation-challenges.test.ts test/stores/node-dashboard.test.ts test/security-audit.test.ts`
- `PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" npm run check`
- `PATH="$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH" npm run build`

## Notes
- Full `npm test` was also attempted. It hit the existing environment-sensitive fs-browse home-directory assumption (`defaults to home directory when no path given`) in this profile-local HOME; the #807-related node dashboard count drift was fixed and covered by the targeted test above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exact-operation approval challenges for high-risk actions with structured requester/approver identities, signed approval contracts, one‑time token redemption, reuse prevention, and fail‑closed mismatch behavior; file-write now gated by this flow with a 1 MiB CLI content cap.

* **Documentation**
  * Clarified v1 File RPC stability, refined CLI gateway confirmation semantics, expanded operator runbooks, token redaction, and security-boundary guidance.

* **Tests**
  * Added comprehensive tests for classification, approval contracts, challenge routing, redemption, and invalidation behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/811?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->