### PR TITLE
feat: add operator handshake grant foundation

### DIFF
--- a/docs/OPERATOR_HANDSHAKE_GRANTS.md
+++ b/docs/OPERATOR_HANDSHAKE_GRANTS.md
@@ -1,0 +1,44 @@
+# Operator handshake grants
+
+Issue #813 adds the foundation for a one-time operator handshake grant. The grant is a short-lived, revocable, auditable approval record for a named actor/device/session/work-context. It is not a browser login, scoped actor credential, pair token, or node credential.
+
+## Ceremony copy contract
+
+Operator approval surfaces should say all of this before approval:
+
+- What is delegated: the exact Relay capability bits, such as `session:read` or `logs:read`.
+- Who receives it: actor type and actor id/display name.
+- Audience: the expected grant audience, currently `relay:operator-handshake:v1`.
+- TTL: the grant expiry timestamp; the default foundation TTL is 10 minutes and the maximum is 30 minutes.
+- Scope: node/session/global-session/work-context/repo/path/task dimensions.
+- Bindings: optional device id hash and session binding.
+- Revoke path: `DELETE /operator/handshake-grants/:grantId` for future API wiring.
+
+Suggested minimal approval copy:
+
+> Approve one-time Relay handshake grant for `<actor>`.
+> Delegates `<capabilities>` to `<actor type>:<actor id>` for audience `<audience>` until `<expiresAt>`. This is a one-time handshake grant, not a browser login, pair token, node credential, or reusable scoped actor token. Revoke it at `DELETE /operator/handshake-grants/<grantId>`.
+
+## Lane separation
+
+The browser session may authorize the approval ceremony, but the returned `relay-ohg-v1.<grant-id>.<secret>` handle is the only grant material for this lane and is consumed once by validation. It must not be accepted as any other credential type.
+
+| Presented material                   | Accepted as handshake grant?                           | Notes                                                               |
+| ------------------------------------ | ------------------------------------------------------ | ------------------------------------------------------------------- |
+| Browser PIN/session cookie           | No                                                     | May authorize ceremony routes only; never reusable automation auth. |
+| `relay-ohg-v1...` handshake grant    | Yes, once, if audience/capability/scope/bindings match | Consumed on successful validation.                                  |
+| `relay-sac-v1...` scoped actor token | No                                                     | Separate scoped actor credential lane.                              |
+| Pair token                           | No                                                     | Node bootstrap only.                                                |
+| Node credential                      | No                                                     | Node heartbeat/link only.                                           |
+
+## Validation failure contract
+
+Validation fails closed with stable typed reasons for malformed grant handles, lane mixing, unknown/wrong audience, not-approved grants, expiry, revocation, replay/reuse, actor/device/session mismatch, missing or wrong scope, unknown requested capability, and insufficient capability.
+
+High-risk capability grants, such as `node:lifecycle:destructive`, require existing #807 approval contract evidence before approval. Without that evidence, approval is denied instead of minting a grant handle.
+
+## Audit and redaction
+
+The foundation records audit events for request, approve, deny, issue, validate, expiry, revoke, and replay. Audit payloads include only safe metadata: grant id/jti, actor summary, issuer hash/display name, audience, capability bits, scope/params hashes, and correlation id.
+
+Raw grant handles, browser cookies, scoped actor tokens, pair tokens, node credentials, bearer headers, and secret-looking strings must not appear in logs, diagnostics, registry snapshots, audit payloads, CLI JSON, or browser JSON.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,28 +4,29 @@ This index separates current source-of-truth docs from historical plans and spik
 
 ## Current source of truth
 
-| Area                  | File                              | Use it for                                                                              |
-| --------------------- | --------------------------------- | --------------------------------------------------------------------------------------- |
-| Top-level agent map   | `../AGENTS.md`                    | Repo conventions, command quick reference, compact docs map                             |
-| User onboarding       | `../README.md`                    | Install, run, CLI, config, hub/node overview                                            |
-| Product/design system | `../DESIGN.md`                    | Product positioning, visual language, spacing/color/button rules                        |
-| Architecture          | `ARCHITECTURE.md`                 | Module boundaries, API routes, data flow, ADR index                                     |
-| Workbench boundary    | `WORKBENCH_BOUNDARY.md`           | Relay-as-control-plane scope, canonical nouns, mobile/dogfood journeys                  |
-| Backend design notes  | `DESIGN.md`                       | Backend patterns, auth/session/PTY behavior                                             |
-| Frontend              | `FRONTEND.md`                     | React components, frontend state, UI entrypoints                                        |
-| Quality               | `QUALITY.md`                      | Test strategy, isolation rules, known gate behavior                                     |
-| Review                | `REVIEW_GUIDANCE.md`              | Reviewer prompts, risk areas, escape log                                                |
-| Deployment            | `references/deployment.md`        | Branching, npm channels, publishing flow                                                |
-| Devbox deploy         | `references/devbox-hub-deploy.md` | Shared devbox hub deploy, Mac node-link restart, verification evidence, process hygiene |
-| Dogfood recovery      | `references/dogfood-recovery.md`  | Relay-develops-Relay proof loop, recovery matrix, diagnostics, no-force-merge gate      |
-| Self-hosting          | `SELF_HOSTING.md`                 | Running Relay from inside Relay with isolated config/ports                              |
-| Security policy       | `SECURITY_POLICY.md`              | Trust tiers, capability bits, hub ACL defaults, exact-operation approval challenges     |
-| rmux helper protocol  | `RMUX_HELPER_PROTOCOL.md`         | Experimental #707 helper JSON/stdin-stdout boundary and prototype gates                 |
-| Hub/node packaging    | `RELAY_HUB_NODE_PACKAGING.md`     | Hub/node command shape and npm packaging decisions                                      |
-| Node bootstrap        | `RELAY_NODE_BOOTSTRAP.md`         | Pair/install/update/unpair flows and diagnostics                                        |
-| Federated dev         | `FEDERATED_DEV.md`                | Multi-machine dev workflow and version-skew handling                                    |
-| Federated Relay       | `federated-relay.md`              | Hub/node architecture, pairing, routing, ADR history                                    |
-| Learnings             | `LEARNINGS.md`                    | Durable repo learnings gathered across sessions                                         |
+| Area                  | File                              | Use it for                                                                                   |
+| --------------------- | --------------------------------- | -------------------------------------------------------------------------------------------- |
+| Top-level agent map   | `../AGENTS.md`                    | Repo conventions, command quick reference, compact docs map                                  |
+| User onboarding       | `../README.md`                    | Install, run, CLI, config, hub/node overview                                                 |
+| Product/design system | `../DESIGN.md`                    | Product positioning, visual language, spacing/color/button rules                             |
+| Architecture          | `ARCHITECTURE.md`                 | Module boundaries, API routes, data flow, ADR index                                          |
+| Workbench boundary    | `WORKBENCH_BOUNDARY.md`           | Relay-as-control-plane scope, canonical nouns, mobile/dogfood journeys                       |
+| Backend design notes  | `DESIGN.md`                       | Backend patterns, auth/session/PTY behavior                                                  |
+| Frontend              | `FRONTEND.md`                     | React components, frontend state, UI entrypoints                                             |
+| Quality               | `QUALITY.md`                      | Test strategy, isolation rules, known gate behavior                                          |
+| Review                | `REVIEW_GUIDANCE.md`              | Reviewer prompts, risk areas, escape log                                                     |
+| Deployment            | `references/deployment.md`        | Branching, npm channels, publishing flow                                                     |
+| Devbox deploy         | `references/devbox-hub-deploy.md` | Shared devbox hub deploy, Mac node-link restart, verification evidence, process hygiene      |
+| Dogfood recovery      | `references/dogfood-recovery.md`  | Relay-develops-Relay proof loop, recovery matrix, diagnostics, no-force-merge gate           |
+| Self-hosting          | `SELF_HOSTING.md`                 | Running Relay from inside Relay with isolated config/ports                                   |
+| Security policy       | `SECURITY_POLICY.md`              | Trust tiers, capability bits, hub ACL defaults, exact-operation approvals, handshake grants  |
+| Handshake grants      | `OPERATOR_HANDSHAKE_GRANTS.md`    | One-time operator grant ceremony copy, lane separation, validation, audit/redaction contract |
+| rmux helper protocol  | `RMUX_HELPER_PROTOCOL.md`         | Experimental #707 helper JSON/stdin-stdout boundary and prototype gates                      |
+| Hub/node packaging    | `RELAY_HUB_NODE_PACKAGING.md`     | Hub/node command shape and npm packaging decisions                                           |
+| Node bootstrap        | `RELAY_NODE_BOOTSTRAP.md`         | Pair/install/update/unpair flows and diagnostics                                             |
+| Federated dev         | `FEDERATED_DEV.md`                | Multi-machine dev workflow and version-skew handling                                         |
+| Federated Relay       | `federated-relay.md`              | Hub/node architecture, pairing, routing, ADR history                                         |
+| Learnings             | `LEARNINGS.md`                    | Durable repo learnings gathered across sessions                                              |
 
 ## Vocabulary baseline
 

--- a/docs/SECURITY_POLICY.md
+++ b/docs/SECURITY_POLICY.md
@@ -17,7 +17,17 @@ Relay auth is split into lanes. The current route inventory is checked into `ser
 
 The PIN and `token` cookie are therefore browser/UI authentication. They reduce drive-by browser access and support first-load local setup, but they cannot protect Relay from malicious processes already running as the same OS user: those processes can usually read local config, invoke local CLIs, attach to local sockets, or modify the checkout. Relay's federated security model relies on lane separation, node credentials, hub ACLs, capability policy, audit, revocation, and scoped actor credentials for non-browser actors rather than treating the browser PIN as global authorization.
 
-Relay issue `#427` shipped the earlier trust-tier/capability/audit/confirmation backbone. Relay issue `#797` tracks the broader multi-node auth model. Relay issue `#798` wave 1 narrowed that work to route-lane inventory, browser-session terminology, and typed lane denials. Relay issue `#802` adds the scoped actor credential registry MVP; it deliberately does not migrate every CLI gateway command, implement node proof-of-possession, passkeys, TOTP, or new approval UX. Relay issue `#803` hardens node identity lifecycle semantics by separating stable node identity from replaceable credential records. Relay issue `#807` adds the high-risk approval hook contract for exact-operation challenges; it is still not MFA, passkeys/WebAuthn, TOTP, enterprise RBAC, or a broad approval-center UX.
+Relay issue `#427` shipped the earlier trust-tier/capability/audit/confirmation backbone. Relay issue `#797` tracks the broader multi-node auth model. Relay issue `#798` wave 1 narrowed that work to route-lane inventory, browser-session terminology, and typed lane denials. Relay issue `#802` adds the scoped actor credential registry MVP; it deliberately does not migrate every CLI gateway command, implement node proof-of-possession, passkeys, TOTP, or new approval UX. Relay issue `#803` hardens node identity lifecycle semantics by separating stable node identity from replaceable credential records. Relay issue `#807` adds the high-risk approval hook contract for exact-operation challenges; it is still not MFA, passkeys/WebAuthn, TOTP, enterprise RBAC, or a broad approval-center UX. Relay issue `#813` adds the one-time operator handshake grant registry/audit foundation: a browser session may authorize the ceremony, but the `relay-ohg-v1` grant handle is a separate one-use lane and never becomes a reusable automation credential.
+
+### Operator handshake grants
+
+One-time operator handshake grants live in `shared/operator-handshake-grants.ts` and are documented in `docs/OPERATOR_HANDSHAKE_GRANTS.md`. They bridge browser-session ceremony authorization to a bounded, one-use `relay-ohg-v1.<grant-id>.<secret>` grant handle for a named actor, audience, capability set, scope, optional device binding, and optional session/work-context binding.
+
+The browser session can authorize the ceremony, but it is not the reusable automation credential. A handshake grant is rejected from browser, scoped actor credential, pair-token, and node-credential lanes; those materials are likewise rejected as lane-mixed when presented as handshake grants. Successful validation consumes the grant, and replay/reuse denies with a typed reason.
+
+Validation fails closed on malformed grant handles, unknown or wrong audience, unapproved grants, expiry, revocation, replay, actor/device/session mismatch, missing or wrong node/session/global-session/work-context/repo/path/task scope, unknown requested capability, and insufficient capability. High-risk capability grants require existing #807 exact-operation approval evidence before approval; otherwise the ceremony denies instead of minting a handle.
+
+Operator copy must name what is delegated, who receives it, the audience, expiry/TTL, scope, device/session binding, and revoke path. Safe audit metadata is limited to grant id/jti, actor summary, issuer hash/display name, audience, capability bits, scope/params hashes, and correlation id. Raw grant handles, browser cookies, scoped actor tokens, pair tokens, node credentials, bearer headers, and secret-looking strings must not appear in logs, diagnostics, snapshots, audit payloads, CLI JSON, or browser JSON.
 
 ## Node identity lifecycle
 
@@ -45,24 +55,24 @@ Relay records Tailscale/MagicDNS source diagnostics for node credential authenti
 
 Public and audit surfaces expose only this redacted shape:
 
-| Field | Meaning |
-| --- | --- |
-| `state` | Diagnostic state: `signal-unavailable`, `source-match`, `source-mismatch`, `same-credential-multiple-sources`, or `strict-deny`. |
-| `policy` | `audit` by default, or `strict-deny` when the hub was started with strict source enforcement. |
-| `reasonCode` | Typed reason such as `NODE_SOURCE_MATCH`, `NODE_SOURCE_MISMATCH`, `NODE_SOURCE_MULTIPLE_SOURCES`, `NODE_SOURCE_SIGNAL_UNAVAILABLE`, or `NODE_SOURCE_STRICT_DENY`. |
-| `observedAt` | Time the credential source was evaluated. |
-| `sourceFingerprint` | Stable `src_<32 hex chars>` correlation handle for the normalized source. Omitted when no usable source exists. |
-| `displayHint` | Lossy operator hint such as `tailscale-ip:100.x.x.x`, `magicdns:ts.net:<suffix>`, `hostname:<suffix>`, or `no tailscale/magicdns signal`. |
+| Field               | Meaning                                                                                                                                                           |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `state`             | Diagnostic state: `signal-unavailable`, `source-match`, `source-mismatch`, `same-credential-multiple-sources`, or `strict-deny`.                                  |
+| `policy`            | `audit` by default, or `strict-deny` when the hub was started with strict source enforcement.                                                                     |
+| `reasonCode`        | Typed reason such as `NODE_SOURCE_MATCH`, `NODE_SOURCE_MISMATCH`, `NODE_SOURCE_MULTIPLE_SOURCES`, `NODE_SOURCE_SIGNAL_UNAVAILABLE`, or `NODE_SOURCE_STRICT_DENY`. |
+| `observedAt`        | Time the credential source was evaluated.                                                                                                                         |
+| `sourceFingerprint` | Stable `src_<32 hex chars>` correlation handle for the normalized source. Omitted when no usable source exists.                                                   |
+| `displayHint`       | Lossy operator hint such as `tailscale-ip:100.x.x.x`, `magicdns:ts.net:<suffix>`, `hostname:<suffix>`, or `no tailscale/magicdns signal`.                         |
 
 State meanings:
 
-| State | Security meaning |
-| --- | --- |
-| `signal-unavailable` | No usable socket/Tailscale source signal was available. Caller-provided source headers are not trusted as authoritative source evidence. Default policy allows and audits this; strict mode denies it when the credential already has a Tailscale/MagicDNS source binding. |
-| `source-match` | The observed source matches the credential binding. |
-| `source-mismatch` | A usable observed source does not match the credential binding. If the credential otherwise validates, default policy allows and audits it so operators can see topology drift or suspicious reuse. |
-| `same-credential-multiple-sources` | The same credential has appeared from multiple redacted source fingerprints. If the credential otherwise validates, default policy allows it but operators should treat it as suspicious copied/replayed credential evidence unless a topology change explains it. |
-| `strict-deny` | `RELAY_NODE_SOURCE_STRICT_DENY=1` is enabled and a reachable source mismatch or missing trusted source evidence for a source-bound credential was denied. |
+| State                              | Security meaning                                                                                                                                                                                                                                                           |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `signal-unavailable`               | No usable socket/Tailscale source signal was available. Caller-provided source headers are not trusted as authoritative source evidence. Default policy allows and audits this; strict mode denies it when the credential already has a Tailscale/MagicDNS source binding. |
+| `source-match`                     | The observed source matches the credential binding.                                                                                                                                                                                                                        |
+| `source-mismatch`                  | A usable observed source does not match the credential binding. If the credential otherwise validates, default policy allows and audits it so operators can see topology drift or suspicious reuse.                                                                        |
+| `same-credential-multiple-sources` | The same credential has appeared from multiple redacted source fingerprints. If the credential otherwise validates, default policy allows it but operators should treat it as suspicious copied/replayed credential evidence unless a topology change explains it.         |
+| `strict-deny`                      | `RELAY_NODE_SOURCE_STRICT_DENY=1` is enabled and a reachable source mismatch or missing trusted source evidence for a source-bound credential was denied.                                                                                                                  |
 
 Strict mode is an opt-in node-credential control:
 

--- a/shared/operator-handshake-grants.ts
+++ b/shared/operator-handshake-grants.ts
@@ -1,0 +1,1246 @@
+import * as crypto from 'node:crypto';
+import {
+  hashAuditMaterial,
+  redactAuditValue,
+  sha256Hex,
+  type SecurityAuditDecision,
+  type SecurityAuditEntryInput,
+  type SecurityAuditEventType,
+} from './security-audit.js';
+import {
+  HIGH_RISK_CAPABILITIES,
+  RELAY_SECURITY_POLICY_VERSION,
+  isRelayCapabilityBit,
+  type RelayCapabilityBit,
+} from './security-policy.js';
+
+export const HANDSHAKE_GRANT_TOKEN_PREFIX = 'relay-ohg-v1' as const;
+
+export const HANDSHAKE_GRANT_ACTOR_TYPES = [
+  'agent',
+  'cli',
+  'automation-system',
+] as const;
+
+export type HandshakeGrantActorType =
+  (typeof HANDSHAKE_GRANT_ACTOR_TYPES)[number];
+
+export const HANDSHAKE_GRANT_AUDIENCES = [
+  'relay:operator-handshake:v1',
+  'relay:registry-test',
+] as const;
+
+export type HandshakeGrantAudience = (typeof HANDSHAKE_GRANT_AUDIENCES)[number];
+
+export const DEFAULT_HANDSHAKE_GRANT_TTL_MS = 10 * 60 * 1000;
+export const DEFAULT_HANDSHAKE_GRANT_MAX_TTL_MS = 30 * 60 * 1000;
+
+const HIGH_RISK_CAPABILITY_SET = new Set<RelayCapabilityBit>(
+  HIGH_RISK_CAPABILITIES
+);
+
+export type HandshakeGrantRequestStatus =
+  | 'requested'
+  | 'approved'
+  | 'denied'
+  | 'revoked'
+  | 'expired'
+  | 'consumed';
+
+export type HandshakeGrantValidationFailureReason =
+  | 'malformed_grant'
+  | 'lane_mixing'
+  | 'unknown_audience'
+  | 'wrong_audience'
+  | 'not_approved'
+  | 'expired'
+  | 'revoked'
+  | 'replayed'
+  | 'actor_mismatch'
+  | 'device_mismatch'
+  | 'session_mismatch'
+  | 'missing_scope'
+  | 'wrong_node_scope'
+  | 'wrong_session_scope'
+  | 'wrong_global_session_scope'
+  | 'wrong_work_context_scope'
+  | 'wrong_repo_scope'
+  | 'wrong_path_scope'
+  | 'wrong_task_scope'
+  | 'unknown_capability'
+  | 'insufficient_capability';
+
+export type HandshakeGrantIssueFailureReason =
+  | 'unsupported_actor_type'
+  | 'unknown_audience'
+  | 'unknown_capability'
+  | 'scope_required'
+  | 'expiry_required'
+  | 'expiry_exceeds_max_ttl'
+  | 'duplicate_grant_id'
+  | 'high_risk_approval_required'
+  | 'grant_not_found'
+  | 'grant_not_pending';
+
+export interface HandshakeGrantActor {
+  type: string;
+  id: string;
+  displayName?: string;
+}
+
+export interface HandshakeGrantIssuer {
+  id: string;
+  displayName?: string;
+}
+
+export interface HandshakeGrantDeviceBindingInput {
+  id: string;
+  displayName?: string;
+}
+
+export interface HandshakeGrantSessionBinding {
+  sessionId?: string;
+  globalSessionId?: string;
+  workContextId?: string;
+  authSessionHash?: string;
+}
+
+export interface HandshakeGrantScope {
+  nodeIds?: string[];
+  sessionIds?: string[];
+  globalSessionIds?: string[];
+  workContextIds?: string[];
+  repoIds?: string[];
+  pathPrefixes?: string[];
+  taskRefs?: string[];
+}
+
+export interface HandshakeGrantValidationScope {
+  nodeId?: string;
+  sessionId?: string;
+  globalSessionId?: string;
+  workContextId?: string;
+  repoId?: string;
+  path?: string;
+  taskRef?: string;
+}
+
+export interface HandshakeGrantMetadata {
+  reason?: string;
+  taskRef?: string;
+  refs?: string[];
+}
+
+export interface HandshakeGrantHighRiskApprovalRef {
+  challengeId: string;
+  contractHash: string;
+  approvedAt: string;
+}
+
+export interface HandshakeGrantRecord {
+  id: string;
+  jti: string;
+  status: HandshakeGrantRequestStatus;
+  actor: HandshakeGrantActor & { type: HandshakeGrantActorType };
+  issuer: {
+    idHash: string;
+    displayName?: string;
+  };
+  audience: HandshakeGrantAudience;
+  capabilities: RelayCapabilityBit[];
+  scope: HandshakeGrantScope;
+  device?: {
+    idHash: string;
+    displayName?: string;
+  };
+  sessionBinding?: HandshakeGrantSessionBinding;
+  metadata?: HandshakeGrantMetadata;
+  createdAt: string;
+  expiresAt: string;
+  approvedAt?: string;
+  approvedByHash?: string;
+  deniedAt?: string;
+  deniedByHash?: string;
+  deniedReason?: string;
+  revokedAt?: string;
+  revokedByHash?: string;
+  revocationReason?: string;
+  consumedAt?: string;
+  consumedBy?: string;
+  highRiskApproval?: HandshakeGrantHighRiskApprovalRef;
+  correlationId: string;
+}
+
+interface InternalHandshakeGrantRecord extends HandshakeGrantRecord {
+  handleHash?: string;
+}
+
+export interface RequestHandshakeGrantInput {
+  id?: string;
+  actor: HandshakeGrantActor;
+  issuer: HandshakeGrantIssuer;
+  audience: string;
+  capabilities: string[];
+  scope: HandshakeGrantScope;
+  device?: HandshakeGrantDeviceBindingInput;
+  sessionBinding?: HandshakeGrantSessionBinding;
+  metadata?: HandshakeGrantMetadata;
+  expiresAt?: Date | string;
+  ttlMs?: number;
+  correlationId?: string;
+}
+
+export interface ApproveHandshakeGrantInput {
+  approvedBy: HandshakeGrantIssuer;
+  highRiskApproval?: HandshakeGrantHighRiskApprovalRef;
+  correlationId?: string;
+}
+
+export interface DenyHandshakeGrantInput {
+  deniedBy: HandshakeGrantIssuer;
+  reason?: string;
+  correlationId?: string;
+}
+
+export interface ApprovedHandshakeGrant {
+  handle: string;
+  grant: HandshakeGrantRecord;
+  copy: HandshakeGrantApprovalCopy;
+}
+
+export interface ValidateHandshakeGrantInput {
+  audience: string;
+  requiredCapabilities: string[];
+  actor?: HandshakeGrantActor;
+  deviceId?: string;
+  sessionBinding?: HandshakeGrantSessionBinding;
+  scope?: HandshakeGrantValidationScope;
+  consume?: boolean;
+  correlationId?: string;
+}
+
+export type HandshakeGrantValidationResult =
+  | {
+      ok: true;
+      grant: HandshakeGrantRecord;
+      grantedBits: RelayCapabilityBit[];
+      consumed: boolean;
+    }
+  | {
+      ok: false;
+      reason: HandshakeGrantValidationFailureReason;
+      grantId?: string;
+      deniedBits: string[];
+    };
+
+export interface RevokeHandshakeGrantInput {
+  revokedBy: HandshakeGrantIssuer;
+  reason?: string;
+  correlationId?: string;
+}
+
+export interface HandshakeGrantAuditEvent {
+  action:
+    | 'request'
+    | 'approve'
+    | 'deny'
+    | 'issue'
+    | 'validate'
+    | 'expiry'
+    | 'revoke'
+    | 'replay';
+  decision: SecurityAuditDecision;
+  reasonCode: string;
+  grantId?: string;
+  jti?: string;
+  actor?: HandshakeGrantRecord['actor'];
+  issuer?: HandshakeGrantRecord['issuer'];
+  audience?: HandshakeGrantAudience;
+  scopeHash: string;
+  paramsHash: string;
+  requiredBits: RelayCapabilityBit[];
+  grantedBits: RelayCapabilityBit[];
+  deniedBits: string[];
+  correlationId: string;
+}
+
+export interface CreateHandshakeGrantAuditEntryInput {
+  action: HandshakeGrantAuditEvent['action'];
+  decision: SecurityAuditDecision;
+  reasonCode: string;
+  grant?: HandshakeGrantRecord;
+  requiredCapabilities?: RelayCapabilityBit[];
+  grantedCapabilities?: RelayCapabilityBit[];
+  deniedCapabilities?: RelayCapabilityBit[];
+  correlationId?: string;
+  material?: {
+    scope?: unknown;
+    params?: unknown;
+  };
+}
+
+export interface HandshakeGrantApprovalCopy {
+  title: string;
+  summary: string;
+  details: string[];
+  revokePath: string;
+}
+
+export class HandshakeGrantRegistryError extends Error {
+  constructor(
+    public readonly code: HandshakeGrantIssueFailureReason,
+    message: string
+  ) {
+    super(`${code.toUpperCase()}: ${message}`);
+    this.name = 'HandshakeGrantRegistryError';
+  }
+}
+
+export class HandshakeGrantRegistry {
+  private readonly grants = new Map<string, InternalHandshakeGrantRecord>();
+  private readonly auditEvents: HandshakeGrantAuditEvent[] = [];
+  private readonly maxTtlMs: number;
+  private readonly now: () => Date;
+  private readonly secretBytes: () => Buffer;
+
+  constructor(
+    options: {
+      maxTtlMs?: number;
+      now?: () => Date;
+      secretBytes?: () => Buffer;
+    } = {}
+  ) {
+    this.maxTtlMs = options.maxTtlMs ?? DEFAULT_HANDSHAKE_GRANT_MAX_TTL_MS;
+    this.now = options.now ?? (() => new Date());
+    this.secretBytes = options.secretBytes ?? (() => crypto.randomBytes(32));
+  }
+
+  request(input: RequestHandshakeGrantInput): HandshakeGrantRecord {
+    const actorType = normalizeActorType(input.actor.type);
+    const audience = normalizeAudience(input.audience);
+    const capabilities = normalizeGrantCapabilities(input.capabilities);
+    const scope = normalizeGrantScope(input.scope);
+    const metadata = input.metadata
+      ? normalizeMetadata(input.metadata)
+      : undefined;
+    const createdAt = this.now();
+    const expiresAt = this.resolveExpiry(input, createdAt);
+    const id = input.id ?? crypto.randomUUID();
+    if (this.grants.has(id)) {
+      throw new HandshakeGrantRegistryError(
+        'duplicate_grant_id',
+        `handshake grant ${id} already exists`
+      );
+    }
+
+    const grant: InternalHandshakeGrantRecord = {
+      id,
+      jti: id,
+      status: 'requested',
+      actor: {
+        type: actorType,
+        id: input.actor.id,
+        ...(input.actor.displayName
+          ? { displayName: input.actor.displayName }
+          : {}),
+      },
+      issuer: {
+        idHash: sha256Hex(input.issuer.id),
+        ...(input.issuer.displayName
+          ? { displayName: input.issuer.displayName }
+          : {}),
+      },
+      audience,
+      capabilities,
+      scope,
+      ...(input.device
+        ? {
+            device: {
+              idHash: sha256Hex(input.device.id),
+              ...(input.device.displayName
+                ? { displayName: input.device.displayName }
+                : {}),
+            },
+          }
+        : {}),
+      ...(input.sessionBinding
+        ? { sessionBinding: copySessionBinding(input.sessionBinding) }
+        : {}),
+      ...(metadata ? { metadata } : {}),
+      createdAt: createdAt.toISOString(),
+      expiresAt: expiresAt.toISOString(),
+      correlationId: input.correlationId ?? crypto.randomUUID(),
+    };
+    this.grants.set(id, grant);
+    this.recordAudit({
+      action: 'request',
+      decision: 'requires_confirmation',
+      reasonCode: 'HANDSHAKE_GRANT_REQUESTED',
+      grant,
+      requiredCapabilities: capabilities,
+      ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+      material: auditMaterialForGrant(grant, { operation: 'request' }),
+    });
+    return publicGrant(grant);
+  }
+
+  approve(
+    grantId: string,
+    input: ApproveHandshakeGrantInput
+  ): ApprovedHandshakeGrant {
+    const grant = this.grants.get(grantId);
+    if (!grant) {
+      throw new HandshakeGrantRegistryError(
+        'grant_not_found',
+        `handshake grant ${grantId} was not found`
+      );
+    }
+    if (grant.status !== 'requested') {
+      throw new HandshakeGrantRegistryError(
+        'grant_not_pending',
+        `handshake grant ${grantId} is ${grant.status}`
+      );
+    }
+    if (requiresHighRiskApproval(grant) && !input.highRiskApproval) {
+      grant.status = 'denied';
+      grant.deniedAt = this.now().toISOString();
+      grant.deniedByHash = sha256Hex(input.approvedBy.id);
+      grant.deniedReason =
+        'high-risk capabilities require approval contract evidence';
+      this.recordAudit({
+        action: 'deny',
+        decision: 'deny',
+        reasonCode: 'HANDSHAKE_GRANT_HIGH_RISK_APPROVAL_REQUIRED',
+        grant,
+        deniedCapabilities: grant.capabilities.filter((bit) =>
+          HIGH_RISK_CAPABILITY_SET.has(bit)
+        ),
+        ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+        material: auditMaterialForGrant(grant, { operation: 'approve-denied' }),
+      });
+      throw new HandshakeGrantRegistryError(
+        'high_risk_approval_required',
+        'handshake grants for high-risk capabilities require #807 approval contract evidence'
+      );
+    }
+
+    const secret = this.secretBytes().toString('hex');
+    const handle = `${HANDSHAKE_GRANT_TOKEN_PREFIX}.${grant.id}.${secret}`;
+    grant.handleHash = sha256Hex(secret);
+    grant.status = 'approved';
+    grant.approvedAt = this.now().toISOString();
+    grant.approvedByHash = sha256Hex(input.approvedBy.id);
+    if (input.highRiskApproval) {
+      grant.highRiskApproval = { ...input.highRiskApproval };
+    }
+    this.recordAudit({
+      action: 'approve',
+      decision: 'approved',
+      reasonCode: 'HANDSHAKE_GRANT_APPROVED',
+      grant,
+      grantedCapabilities: grant.capabilities,
+      ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+      material: auditMaterialForGrant(grant, { operation: 'approve' }),
+    });
+    this.recordAudit({
+      action: 'issue',
+      decision: 'allow',
+      reasonCode: 'HANDSHAKE_GRANT_ISSUED',
+      grant,
+      grantedCapabilities: grant.capabilities,
+      ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+      material: auditMaterialForGrant(grant, { operation: 'issue' }),
+    });
+    return {
+      handle,
+      grant: publicGrant(grant),
+      copy: operatorHandshakeGrantApprovalCopy(publicGrant(grant)),
+    };
+  }
+
+  deny(
+    grantId: string,
+    input: DenyHandshakeGrantInput
+  ): HandshakeGrantRecord | null {
+    const grant = this.grants.get(grantId);
+    if (!grant) return null;
+    if (grant.status !== 'requested') return publicGrant(grant);
+    grant.status = 'denied';
+    grant.deniedAt = this.now().toISOString();
+    grant.deniedByHash = sha256Hex(input.deniedBy.id);
+    if (input.reason) {
+      const deniedReason = redactSafeString(input.reason);
+      if (deniedReason) grant.deniedReason = deniedReason;
+    }
+    this.recordAudit({
+      action: 'deny',
+      decision: 'deny',
+      reasonCode: 'HANDSHAKE_GRANT_DENIED',
+      grant,
+      deniedCapabilities: grant.capabilities,
+      ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+      material: auditMaterialForGrant(grant, { operation: 'deny' }),
+    });
+    return publicGrant(grant);
+  }
+
+  validate(
+    handle: string,
+    input: ValidateHandshakeGrantInput
+  ): HandshakeGrantValidationResult {
+    const parsed = parseHandshakeGrantHandle(handle);
+    if (!parsed) {
+      return this.denyValidation(
+        isForeignCredentialLane(handle) ? 'lane_mixing' : 'malformed_grant',
+        undefined,
+        input,
+        []
+      );
+    }
+    const grant = this.grants.get(parsed.id);
+    if (!grant || grant.handleHash !== sha256Hex(parsed.secret)) {
+      return this.denyValidation('malformed_grant', parsed.id, input, []);
+    }
+    if (!isHandshakeGrantAudience(input.audience)) {
+      return this.denyValidation('unknown_audience', grant.id, input, []);
+    }
+    if (grant.audience !== input.audience) {
+      return this.denyValidation('wrong_audience', grant.id, input, []);
+    }
+    if (grant.status === 'requested' || grant.status === 'denied') {
+      return this.denyValidation('not_approved', grant.id, input, []);
+    }
+    if (new Date(grant.expiresAt).getTime() <= this.now().getTime()) {
+      grant.status = 'expired';
+      return this.denyValidation(
+        'expired',
+        grant.id,
+        input,
+        input.requiredCapabilities
+      );
+    }
+    if (grant.revokedAt || grant.status === 'revoked') {
+      return this.denyValidation(
+        'revoked',
+        grant.id,
+        input,
+        input.requiredCapabilities
+      );
+    }
+    if (grant.consumedAt || grant.status === 'consumed') {
+      return this.denyValidation(
+        'replayed',
+        grant.id,
+        input,
+        input.requiredCapabilities
+      );
+    }
+    if (input.actor && !actorMatches(grant.actor, input.actor)) {
+      return this.denyValidation(
+        'actor_mismatch',
+        grant.id,
+        input,
+        input.requiredCapabilities
+      );
+    }
+    if (
+      grant.device &&
+      sha256Hex(input.deviceId ?? '') !== grant.device.idHash
+    ) {
+      return this.denyValidation(
+        'device_mismatch',
+        grant.id,
+        input,
+        input.requiredCapabilities
+      );
+    }
+    if (!sessionBindingMatches(grant.sessionBinding, input.sessionBinding)) {
+      return this.denyValidation(
+        'session_mismatch',
+        grant.id,
+        input,
+        input.requiredCapabilities
+      );
+    }
+
+    const unknownCapability = input.requiredCapabilities.find(
+      (capability) => !isRelayCapabilityBit(capability)
+    );
+    if (unknownCapability) {
+      return this.denyValidation('unknown_capability', grant.id, input, [
+        unknownCapability,
+      ]);
+    }
+    const required = input.requiredCapabilities as RelayCapabilityBit[];
+    const missing = required.filter(
+      (capability) => !grant.capabilities.includes(capability)
+    );
+    if (missing.length > 0) {
+      return this.denyValidation(
+        'insufficient_capability',
+        grant.id,
+        input,
+        missing
+      );
+    }
+    const scopeFailure = validateGrantScope(grant.scope, input.scope);
+    if (scopeFailure) {
+      return this.denyValidation(scopeFailure, grant.id, input, required);
+    }
+
+    const consume = input.consume ?? true;
+    if (consume) {
+      grant.status = 'consumed';
+      grant.consumedAt = this.now().toISOString();
+      grant.consumedBy = input.actor
+        ? `${input.actor.type}:${input.actor.id}`
+        : 'unknown';
+    }
+    this.recordAudit({
+      action: 'validate',
+      decision: 'allow',
+      reasonCode: consume
+        ? 'HANDSHAKE_GRANT_CONSUMED'
+        : 'HANDSHAKE_GRANT_VALIDATED',
+      grant,
+      requiredCapabilities: required,
+      grantedCapabilities: required,
+      ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+      material: auditMaterialForValidation(grant, input),
+    });
+    return {
+      ok: true,
+      grant: publicGrant(grant),
+      grantedBits: required,
+      consumed: consume,
+    };
+  }
+
+  revoke(
+    grantId: string,
+    input: RevokeHandshakeGrantInput
+  ): HandshakeGrantRecord | null {
+    const grant = this.grants.get(grantId);
+    if (!grant) return null;
+    grant.status = 'revoked';
+    grant.revokedAt = this.now().toISOString();
+    grant.revokedByHash = sha256Hex(input.revokedBy.id);
+    if (input.reason) {
+      const revocationReason = redactSafeString(input.reason);
+      if (revocationReason) grant.revocationReason = revocationReason;
+    }
+    this.recordAudit({
+      action: 'revoke',
+      decision: 'revoked',
+      reasonCode: 'HANDSHAKE_GRANT_REVOKED',
+      grant,
+      deniedCapabilities: grant.capabilities,
+      ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+      material: auditMaterialForGrant(grant, { operation: 'revoke' }),
+    });
+    return publicGrant(grant);
+  }
+
+  listGrants(): HandshakeGrantRecord[] {
+    return Array.from(this.grants.values()).map(publicGrant);
+  }
+
+  getGrant(grantId: string): HandshakeGrantRecord | null {
+    const grant = this.grants.get(grantId);
+    return grant ? publicGrant(grant) : null;
+  }
+
+  listAuditEvents(): HandshakeGrantAuditEvent[] {
+    return this.auditEvents.map((event) => ({
+      ...event,
+      ...(event.actor ? { actor: { ...event.actor } } : {}),
+      ...(event.issuer ? { issuer: { ...event.issuer } } : {}),
+      requiredBits: [...event.requiredBits],
+      grantedBits: [...event.grantedBits],
+      deniedBits: [...event.deniedBits],
+    }));
+  }
+
+  private resolveExpiry(
+    input: RequestHandshakeGrantInput,
+    createdAt: Date
+  ): Date {
+    if (!input.expiresAt && input.ttlMs == null) {
+      return new Date(createdAt.getTime() + DEFAULT_HANDSHAKE_GRANT_TTL_MS);
+    }
+    const expiresAt = input.expiresAt
+      ? new Date(input.expiresAt)
+      : new Date(createdAt.getTime() + (input.ttlMs ?? 0));
+    if (!Number.isFinite(expiresAt.getTime())) {
+      throw new HandshakeGrantRegistryError(
+        'expiry_required',
+        'handshake grant expiry must be a valid date'
+      );
+    }
+    if (expiresAt.getTime() - createdAt.getTime() > this.maxTtlMs) {
+      throw new HandshakeGrantRegistryError(
+        'expiry_exceeds_max_ttl',
+        'handshake grant ttl exceeds registry maximum'
+      );
+    }
+    return expiresAt;
+  }
+
+  private denyValidation(
+    reason: HandshakeGrantValidationFailureReason,
+    grantId: string | undefined,
+    input: ValidateHandshakeGrantInput,
+    deniedBits: string[]
+  ): HandshakeGrantValidationResult {
+    const grant = grantId ? this.grants.get(grantId) : undefined;
+    this.recordAudit({
+      action:
+        reason === 'expired'
+          ? 'expiry'
+          : reason === 'revoked'
+            ? 'revoke'
+            : reason === 'replayed'
+              ? 'replay'
+              : 'validate',
+      decision:
+        reason === 'expired'
+          ? 'expired'
+          : reason === 'revoked'
+            ? 'revoked'
+            : 'deny',
+      reasonCode: handshakeGrantReasonCode(reason),
+      ...(grant ? { grant } : {}),
+      deniedCapabilities: knownDeniedCapabilities(deniedBits),
+      ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+      material: grant
+        ? auditMaterialForValidation(grant, input)
+        : {
+            params: {
+              grantId: grantId ?? null,
+              reason,
+              audience: input.audience,
+            },
+          },
+    });
+    return {
+      ok: false,
+      reason,
+      ...(grantId ? { grantId } : {}),
+      deniedBits,
+    };
+  }
+
+  private recordAudit(input: CreateHandshakeGrantAuditEntryInput): void {
+    const grant = input.grant;
+    const materialScope = redactHandshakeGrantValue(
+      input.material?.scope ?? grant?.scope ?? null
+    );
+    const materialParams = redactHandshakeGrantValue(
+      input.material?.params ?? null
+    );
+    this.auditEvents.push({
+      action: input.action,
+      decision: input.decision,
+      reasonCode: input.reasonCode,
+      ...(grant ? { grantId: grant.id, jti: grant.jti } : {}),
+      ...(grant ? { actor: { ...grant.actor } } : {}),
+      ...(grant ? { issuer: { ...grant.issuer } } : {}),
+      ...(grant ? { audience: grant.audience } : {}),
+      scopeHash: hashAuditMaterial(materialScope),
+      paramsHash: hashAuditMaterial(materialParams),
+      requiredBits: [...(input.requiredCapabilities ?? [])],
+      grantedBits: [...(input.grantedCapabilities ?? [])],
+      deniedBits: [...(input.deniedCapabilities ?? [])],
+      correlationId: input.correlationId ?? crypto.randomUUID(),
+    });
+  }
+}
+
+export function isHandshakeGrantActorType(
+  value: unknown
+): value is HandshakeGrantActorType {
+  return (
+    typeof value === 'string' &&
+    (HANDSHAKE_GRANT_ACTOR_TYPES as readonly string[]).includes(value)
+  );
+}
+
+export function isHandshakeGrantAudience(
+  value: unknown
+): value is HandshakeGrantAudience {
+  return (
+    typeof value === 'string' &&
+    (HANDSHAKE_GRANT_AUDIENCES as readonly string[]).includes(value)
+  );
+}
+
+export function redactHandshakeGrantValue(value: unknown): unknown {
+  return redactAuditValue(value);
+}
+
+export function operatorHandshakeGrantApprovalCopy(
+  grant: HandshakeGrantRecord
+): HandshakeGrantApprovalCopy {
+  const scope = describeGrantScope(grant.scope);
+  const device = grant.device?.displayName ?? 'no device binding';
+  const session = describeSessionBinding(grant.sessionBinding);
+  return {
+    title: `Approve one-time Relay handshake grant for ${grant.actor.displayName ?? grant.actor.id}`,
+    summary:
+      `Delegates ${grant.capabilities.join(', ')} to ${grant.actor.type}:${grant.actor.id} ` +
+      `for audience ${grant.audience} until ${grant.expiresAt}. This is a one-time handshake grant, not a browser login, pair token, node credential, or reusable scoped actor token.`,
+    details: [
+      `Actor: ${grant.actor.type}:${grant.actor.id}`,
+      `Audience: ${grant.audience}`,
+      `TTL/expires: ${grant.expiresAt}`,
+      `Scope: ${scope}`,
+      `Device: ${device}`,
+      `Session binding: ${session}`,
+      `Revoke: DELETE /operator/handshake-grants/${grant.id}`,
+    ],
+    revokePath: `/operator/handshake-grants/${grant.id}`,
+  };
+}
+
+export function createHandshakeGrantAuditEntry(
+  input: CreateHandshakeGrantAuditEntryInput
+): SecurityAuditEntryInput {
+  const grant = input.grant;
+  return {
+    eventType: handshakeGrantAuditEventType(input.action, input.decision),
+    decision: input.decision,
+    reasonCode: input.reasonCode,
+    peer: grant
+      ? {
+          kind: 'system',
+          credentialId: grant.id,
+          displayName: grant.actor.displayName ?? grant.actor.type,
+          principalHash: sha256Hex(`${grant.actor.type}:${grant.actor.id}`),
+        }
+      : { kind: 'system' },
+    intent: {
+      action: `operator-handshake-grant.${input.action}`,
+      ...(grant ? { target: grant.id } : {}),
+    },
+    material: {
+      scope: redactHandshakeGrantValue(
+        input.material?.scope ?? grant?.scope ?? null
+      ),
+      params: redactHandshakeGrantValue({
+        grant: grant ? redactHandshakeGrantForAudit(grant) : undefined,
+        ...(typeof input.material?.params === 'object' &&
+        input.material.params !== null
+          ? (input.material.params as Record<string, unknown>)
+          : { params: input.material?.params ?? null }),
+      }),
+    },
+    requiredBits: [...(input.requiredCapabilities ?? [])],
+    grantedBits: [...(input.grantedCapabilities ?? [])],
+    deniedBits: [...(input.deniedCapabilities ?? [])],
+    refs: { policyVersion: RELAY_SECURITY_POLICY_VERSION },
+    correlationId: input.correlationId ?? crypto.randomUUID(),
+  };
+}
+
+export function redactHandshakeGrantForAudit(grant: HandshakeGrantRecord): Omit<
+  HandshakeGrantRecord,
+  'actor' | 'deniedReason' | 'revocationReason'
+> & {
+  actor: Omit<HandshakeGrantRecord['actor'], 'id'> & { idHash: string };
+} {
+  const { id: _actorId, ...actor } = grant.actor;
+  return {
+    ...publicGrant(grant),
+    actor: {
+      ...actor,
+      idHash: sha256Hex(grant.actor.id),
+    },
+  };
+}
+
+function normalizeActorType(value: string): HandshakeGrantActorType {
+  if (isHandshakeGrantActorType(value)) return value;
+  throw new HandshakeGrantRegistryError(
+    'unsupported_actor_type',
+    `unsupported handshake grant actor type: ${value}`
+  );
+}
+
+function normalizeAudience(value: string): HandshakeGrantAudience {
+  if (isHandshakeGrantAudience(value)) return value;
+  throw new HandshakeGrantRegistryError(
+    'unknown_audience',
+    `unknown handshake grant audience: ${value}`
+  );
+}
+
+function normalizeGrantCapabilities(values: string[]): RelayCapabilityBit[] {
+  const normalized: RelayCapabilityBit[] = [];
+  const seen = new Set<RelayCapabilityBit>();
+  for (const value of values) {
+    if (!isRelayCapabilityBit(value)) {
+      throw new HandshakeGrantRegistryError(
+        'unknown_capability',
+        `unknown Relay capability bit: ${value}`
+      );
+    }
+    if (!seen.has(value)) {
+      seen.add(value);
+      normalized.push(value);
+    }
+  }
+  return normalized;
+}
+
+function normalizeGrantScope(scope: HandshakeGrantScope): HandshakeGrantScope {
+  if (!scope || typeof scope !== 'object' || Array.isArray(scope)) {
+    throw new HandshakeGrantRegistryError(
+      'scope_required',
+      'handshake grants require at least one explicit scope dimension'
+    );
+  }
+  const normalized: HandshakeGrantScope = {
+    ...(normalizeStringList(scope.nodeIds).length > 0
+      ? { nodeIds: normalizeStringList(scope.nodeIds) }
+      : {}),
+    ...(normalizeStringList(scope.sessionIds).length > 0
+      ? { sessionIds: normalizeStringList(scope.sessionIds) }
+      : {}),
+    ...(normalizeStringList(scope.globalSessionIds).length > 0
+      ? { globalSessionIds: normalizeStringList(scope.globalSessionIds) }
+      : {}),
+    ...(normalizeStringList(scope.workContextIds).length > 0
+      ? { workContextIds: normalizeStringList(scope.workContextIds) }
+      : {}),
+    ...(normalizeStringList(scope.repoIds).length > 0
+      ? { repoIds: normalizeStringList(scope.repoIds) }
+      : {}),
+    ...(normalizeStringList(scope.pathPrefixes).length > 0
+      ? { pathPrefixes: normalizeStringList(scope.pathPrefixes) }
+      : {}),
+    ...(normalizeStringList(scope.taskRefs).length > 0
+      ? { taskRefs: normalizeStringList(scope.taskRefs) }
+      : {}),
+  };
+  if (Object.keys(normalized).length === 0) {
+    throw new HandshakeGrantRegistryError(
+      'scope_required',
+      'handshake grants require at least one explicit scope dimension'
+    );
+  }
+  return normalized;
+}
+
+type ScopeValidationRule = {
+  values: string[] | undefined;
+  requested: string | undefined;
+  wrongReason: HandshakeGrantValidationFailureReason;
+  matches?: (values: string[], requested: string) => boolean;
+};
+
+function validateGrantScope(
+  grantScope: HandshakeGrantScope,
+  expectedScope: HandshakeGrantValidationScope | undefined
+): HandshakeGrantValidationFailureReason | null {
+  const rules: ScopeValidationRule[] = [
+    {
+      values: grantScope.nodeIds,
+      requested: expectedScope?.nodeId,
+      wrongReason: 'wrong_node_scope',
+    },
+    {
+      values: grantScope.sessionIds,
+      requested: expectedScope?.sessionId,
+      wrongReason: 'wrong_session_scope',
+    },
+    {
+      values: grantScope.globalSessionIds,
+      requested: expectedScope?.globalSessionId,
+      wrongReason: 'wrong_global_session_scope',
+    },
+    {
+      values: grantScope.workContextIds,
+      requested: expectedScope?.workContextId,
+      wrongReason: 'wrong_work_context_scope',
+    },
+    {
+      values: grantScope.repoIds,
+      requested: expectedScope?.repoId,
+      wrongReason: 'wrong_repo_scope',
+    },
+    {
+      values: grantScope.pathPrefixes,
+      requested: expectedScope?.path,
+      wrongReason: 'wrong_path_scope',
+      matches: (prefixes, path) =>
+        prefixes.some((prefix) => pathMatchesGrantPrefix(path, prefix)),
+    },
+    {
+      values: grantScope.taskRefs,
+      requested: expectedScope?.taskRef,
+      wrongReason: 'wrong_task_scope',
+    },
+  ];
+
+  for (const rule of rules) {
+    if (!rule.values || !rule.requested) continue;
+    const matches = rule.matches ?? listIncludesRequestedValue;
+    if (!matches(rule.values, rule.requested)) return rule.wrongReason;
+  }
+
+  return rules.some((rule) => rule.values && !rule.requested)
+    ? 'missing_scope'
+    : null;
+}
+
+function parseHandshakeGrantHandle(
+  handle: unknown
+): { id: string; secret: string } | null {
+  if (typeof handle !== 'string') return null;
+  const parts = handle.split('.');
+  if (parts.length !== 3 || parts[0] !== HANDSHAKE_GRANT_TOKEN_PREFIX) {
+    return null;
+  }
+  const [, id, secret] = parts;
+  if (!id || !secret) return null;
+  return { id, secret };
+}
+
+function isForeignCredentialLane(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim().toLowerCase();
+  return (
+    trimmed.startsWith('bearer ') ||
+    trimmed.startsWith('relay-sac-v1.') ||
+    trimmed.startsWith('relay-pair-') ||
+    trimmed.startsWith('relay-node-') ||
+    trimmed.includes('connect.sid=') ||
+    trimmed.includes('token=')
+  );
+}
+
+function requiresHighRiskApproval(grant: HandshakeGrantRecord): boolean {
+  return grant.capabilities.some((capability) =>
+    HIGH_RISK_CAPABILITY_SET.has(capability)
+  );
+}
+
+function actorMatches(
+  grantActor: HandshakeGrantRecord['actor'],
+  requestedActor: HandshakeGrantActor
+): boolean {
+  return (
+    grantActor.type === requestedActor.type &&
+    grantActor.id === requestedActor.id
+  );
+}
+
+function sessionBindingMatches(
+  grantBinding: HandshakeGrantSessionBinding | undefined,
+  requestedBinding: HandshakeGrantSessionBinding | undefined
+): boolean {
+  if (!grantBinding) return true;
+  return (
+    (!grantBinding.sessionId ||
+      grantBinding.sessionId === requestedBinding?.sessionId) &&
+    (!grantBinding.globalSessionId ||
+      grantBinding.globalSessionId === requestedBinding?.globalSessionId) &&
+    (!grantBinding.workContextId ||
+      grantBinding.workContextId === requestedBinding?.workContextId) &&
+    (!grantBinding.authSessionHash ||
+      grantBinding.authSessionHash === requestedBinding?.authSessionHash)
+  );
+}
+
+function listIncludesRequestedValue(
+  values: string[],
+  requested: string
+): boolean {
+  return values.includes(requested);
+}
+
+function pathMatchesGrantPrefix(path: string, prefix: string): boolean {
+  if (path === prefix) return true;
+  const normalizedPrefix = prefix.endsWith('/') ? prefix : `${prefix}/`;
+  return path.startsWith(normalizedPrefix);
+}
+
+function normalizeStringList(values: string[] | undefined): string[] {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+function normalizeMetadata(
+  metadata: HandshakeGrantMetadata
+): HandshakeGrantMetadata | undefined {
+  const normalized: HandshakeGrantMetadata = {};
+  const reason = redactSafeString(metadata.reason);
+  const taskRef = redactSafeString(metadata.taskRef);
+  const refs = normalizeStringList(metadata.refs).map((ref) =>
+    redactSafeString(ref)
+  );
+  const safeRefs = refs.filter((ref): ref is string => Boolean(ref));
+  if (reason) normalized.reason = reason;
+  if (taskRef) normalized.taskRef = taskRef;
+  if (safeRefs.length > 0) normalized.refs = safeRefs;
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function redactSafeString(value: string | undefined): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const redacted = redactHandshakeGrantValue(value);
+  return typeof redacted === 'string' && redacted.trim()
+    ? redacted.trim()
+    : undefined;
+}
+
+function publicGrant(
+  grant: InternalHandshakeGrantRecord
+): HandshakeGrantRecord {
+  const { handleHash: _handleHash, ...publicRecord } = grant;
+  return {
+    ...publicRecord,
+    actor: { ...publicRecord.actor },
+    issuer: { ...publicRecord.issuer },
+    capabilities: [...publicRecord.capabilities],
+    scope: copyScope(publicRecord.scope),
+    ...(publicRecord.device ? { device: { ...publicRecord.device } } : {}),
+    ...(publicRecord.sessionBinding
+      ? { sessionBinding: copySessionBinding(publicRecord.sessionBinding) }
+      : {}),
+    ...(publicRecord.metadata
+      ? { metadata: copyMetadata(publicRecord.metadata) }
+      : {}),
+    ...(publicRecord.highRiskApproval
+      ? { highRiskApproval: { ...publicRecord.highRiskApproval } }
+      : {}),
+  };
+}
+
+function copyScope(scope: HandshakeGrantScope): HandshakeGrantScope {
+  return {
+    ...(scope.nodeIds ? { nodeIds: [...scope.nodeIds] } : {}),
+    ...(scope.sessionIds ? { sessionIds: [...scope.sessionIds] } : {}),
+    ...(scope.globalSessionIds
+      ? { globalSessionIds: [...scope.globalSessionIds] }
+      : {}),
+    ...(scope.workContextIds
+      ? { workContextIds: [...scope.workContextIds] }
+      : {}),
+    ...(scope.repoIds ? { repoIds: [...scope.repoIds] } : {}),
+    ...(scope.pathPrefixes ? { pathPrefixes: [...scope.pathPrefixes] } : {}),
+    ...(scope.taskRefs ? { taskRefs: [...scope.taskRefs] } : {}),
+  };
+}
+
+function copySessionBinding(
+  binding: HandshakeGrantSessionBinding
+): HandshakeGrantSessionBinding {
+  return {
+    ...(binding.sessionId ? { sessionId: binding.sessionId } : {}),
+    ...(binding.globalSessionId
+      ? { globalSessionId: binding.globalSessionId }
+      : {}),
+    ...(binding.workContextId ? { workContextId: binding.workContextId } : {}),
+    ...(binding.authSessionHash
+      ? { authSessionHash: binding.authSessionHash }
+      : {}),
+  };
+}
+
+function copyMetadata(
+  metadata: HandshakeGrantMetadata
+): HandshakeGrantMetadata {
+  return {
+    ...(metadata.reason ? { reason: metadata.reason } : {}),
+    ...(metadata.taskRef ? { taskRef: metadata.taskRef } : {}),
+    ...(metadata.refs ? { refs: [...metadata.refs] } : {}),
+  };
+}
+
+function knownDeniedCapabilities(values: string[]): RelayCapabilityBit[] {
+  return values.filter(isRelayCapabilityBit);
+}
+
+function handshakeGrantReasonCode(
+  reason: HandshakeGrantValidationFailureReason
+): string {
+  return `HANDSHAKE_GRANT_${reason.toUpperCase()}`;
+}
+
+function auditMaterialForGrant(
+  grant: HandshakeGrantRecord,
+  params: Record<string, unknown>
+): { scope: unknown; params: unknown } {
+  return {
+    scope: {
+      grantScope: grant.scope,
+      device: grant.device ?? null,
+      sessionBinding: grant.sessionBinding ?? null,
+    },
+    params: {
+      ...params,
+      grant: redactHandshakeGrantForAudit(grant),
+    },
+  };
+}
+
+function auditMaterialForValidation(
+  grant: HandshakeGrantRecord,
+  input: ValidateHandshakeGrantInput
+): { scope: unknown; params: unknown } {
+  return {
+    scope: {
+      grantScope: grant.scope,
+      requestedScope: input.scope ?? null,
+      sessionBinding: input.sessionBinding ?? null,
+      devicePresented: Boolean(input.deviceId),
+    },
+    params: {
+      grantId: grant.id,
+      audience: input.audience,
+      actor: input.actor ?? null,
+      requiredCapabilities: input.requiredCapabilities,
+      consume: input.consume ?? true,
+    },
+  };
+}
+
+function handshakeGrantAuditEventType(
+  action: HandshakeGrantAuditEvent['action'],
+  decision: SecurityAuditDecision
+): SecurityAuditEventType {
+  if (action === 'revoke' || decision === 'revoked') return 'revocation';
+  if (action === 'expiry' || decision === 'expired') return 'expiry';
+  if (action === 'replay') return 'failed_redemption';
+  if (action === 'approve' || decision === 'approved') return 'approval';
+  if (decision === 'deny' || decision === 'failed') return 'denial';
+  return 'grant';
+}
+
+function describeGrantScope(scope: HandshakeGrantScope): string {
+  return Object.entries(scope)
+    .map(
+      ([key, values]) =>
+        `${key}=${Array.isArray(values) ? values.join(',') : ''}`
+    )
+    .join('; ');
+}
+
+function describeSessionBinding(
+  binding: HandshakeGrantSessionBinding | undefined
+): string {
+  if (!binding) return 'no session binding';
+  return Object.entries(binding)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('; ');
+}

--- a/shared/operator-handshake-grants.ts
+++ b/shared/operator-handshake-grants.ts
@@ -806,6 +806,10 @@ export function createHandshakeGrantAuditEntry(
   input: CreateHandshakeGrantAuditEntryInput
 ): SecurityAuditEntryInput {
   const grant = input.grant;
+  const inputParams =
+    typeof input.material?.params === 'object' && input.material.params !== null
+      ? (input.material.params as Record<string, unknown>)
+      : { params: input.material?.params ?? null };
   return {
     eventType: handshakeGrantAuditEventType(input.action, input.decision),
     decision: input.decision,
@@ -827,11 +831,8 @@ export function createHandshakeGrantAuditEntry(
         input.material?.scope ?? grant?.scope ?? null
       ),
       params: redactHandshakeGrantValue({
-        grant: grant ? redactHandshakeGrantForAudit(grant) : undefined,
-        ...(typeof input.material?.params === 'object' &&
-        input.material.params !== null
-          ? (input.material.params as Record<string, unknown>)
-          : { params: input.material?.params ?? null }),
+        ...inputParams,
+        ...(grant ? { grant: redactHandshakeGrantForAudit(grant) } : {}),
       }),
     },
     requiredBits: [...(input.requiredCapabilities ?? [])],
@@ -849,8 +850,13 @@ export function redactHandshakeGrantForAudit(grant: HandshakeGrantRecord): Omit<
   actor: Omit<HandshakeGrantRecord['actor'], 'id'> & { idHash: string };
 } {
   const { id: _actorId, ...actor } = grant.actor;
+  const {
+    deniedReason: _deniedReason,
+    revocationReason: _revocationReason,
+    ...publicRecord
+  } = publicGrant(grant);
   return {
-    ...publicGrant(grant),
+    ...publicRecord,
     actor: {
       ...actor,
       idHash: sha256Hex(grant.actor.id),
@@ -1106,7 +1112,12 @@ function redactSafeString(value: string | undefined): string | undefined {
 function publicGrant(
   grant: InternalHandshakeGrantRecord
 ): HandshakeGrantRecord {
-  const { handleHash: _handleHash, ...publicRecord } = grant;
+  const {
+    handleHash: _handleHash,
+    deniedReason: _deniedReason,
+    revocationReason: _revocationReason,
+    ...publicRecord
+  } = grant;
   return {
     ...publicRecord,
     actor: { ...publicRecord.actor },

--- a/shared/security-audit.ts
+++ b/shared/security-audit.ts
@@ -146,7 +146,7 @@ const SENSITIVE_KEY_TERMS = new Set([
   'value',
 ]);
 const SENSITIVE_TEXT_PATTERN =
-  /(bearer\s+[a-z0-9._~+/=-]+|gh[pousr]_[a-z0-9_]+|sk-[a-z0-9_-]+|relay-[a-z0-9._~+/=-]{16,})/gi;
+  /(bearer\s+[a-z0-9._~+/=-]+|connect\.sid=[^\s;]+|\b(?:access_?token|refresh_?token|token)=[^\s&;]+|gh[pousr]_[a-z0-9_]+|sk-[a-z0-9_-]+|relay-[a-z0-9._~+/=-]{16,})/gi;
 const HIGH_RISK_SET = new Set<RelayCapabilityBit>(HIGH_RISK_CAPABILITIES);
 
 export function isSecurityAuditEventType(

--- a/test/operator-handshake-grants.test.ts
+++ b/test/operator-handshake-grants.test.ts
@@ -1,0 +1,406 @@
+import { describe, expect, it } from 'vitest';
+import {
+  HANDSHAKE_GRANT_AUDIENCES,
+  HANDSHAKE_GRANT_ACTOR_TYPES,
+  HandshakeGrantRegistry,
+  HandshakeGrantRegistryError,
+  createHandshakeGrantAuditEntry,
+  operatorHandshakeGrantApprovalCopy,
+  redactHandshakeGrantForAudit,
+  type HandshakeGrantValidationFailureReason,
+} from '../shared/operator-handshake-grants.js';
+
+const NOW = new Date('2026-05-29T00:00:00.000Z');
+const LATER = new Date('2026-05-29T00:05:00.000Z');
+const EXPIRED = new Date('2026-05-28T23:59:59.000Z');
+
+function registry(): HandshakeGrantRegistry {
+  return new HandshakeGrantRegistry({
+    now: () => NOW,
+    secretBytes: () => Buffer.from('0123456789abcdef0123456789abcdef'),
+  });
+}
+
+function requestedGrant(store = registry()) {
+  const grant = store.request({
+    id: 'grant-1',
+    actor: { type: 'agent', id: 'agent-1', displayName: 'Hermes worker' },
+    issuer: { id: 'operator-1', displayName: 'operator' },
+    audience: 'relay:operator-handshake:v1',
+    capabilities: ['session:read', 'logs:read'],
+    scope: {
+      nodeIds: ['node-a'],
+      sessionIds: ['session-a'],
+      globalSessionIds: ['node-a:session-a'],
+      workContextIds: ['work-context-a'],
+      repoIds: ['repo-a'],
+      pathPrefixes: ['/repo-a/src/safe/'],
+      taskRefs: ['issue-813'],
+    },
+    device: { id: 'device-a', displayName: 'work-mac' },
+    sessionBinding: {
+      sessionId: 'session-a',
+      globalSessionId: 'node-a:session-a',
+      workContextId: 'work-context-a',
+      authSessionHash: 'auth-session-hash-a',
+    },
+    metadata: {
+      reason: 'bounded handshake for issue #813',
+      taskRef: 'issue-813',
+      refs: ['github:issue:813'],
+    },
+    expiresAt: LATER,
+    correlationId: 'corr-request-1',
+  });
+  return { store, grant };
+}
+
+function approvedGrant() {
+  const { store, grant } = requestedGrant();
+  const approved = store.approve(grant.id, {
+    approvedBy: { id: 'operator-1', displayName: 'operator' },
+    correlationId: 'corr-approve-1',
+  });
+  return { store, grant: approved.grant, handle: approved.handle };
+}
+
+describe('operator handshake grant registry', () => {
+  it('defines closed actor and audience lanes for the handshake MVP', () => {
+    expect(HANDSHAKE_GRANT_ACTOR_TYPES).toEqual([
+      'agent',
+      'cli',
+      'automation-system',
+    ]);
+    expect(HANDSHAKE_GRANT_AUDIENCES).toEqual(
+      expect.arrayContaining([
+        'relay:operator-handshake:v1',
+        'relay:registry-test',
+      ])
+    );
+  });
+
+  it('requests, approves, and validates a bounded one-time grant without minting a browser or scoped actor token', () => {
+    const { store, grant, handle } = approvedGrant();
+
+    expect(handle).toMatch(/^relay-ohg-v1\.grant-1\.[a-f0-9]+$/);
+    expect(handle).not.toMatch(/^relay-sac-v1\./);
+    expect(grant).toMatchObject({
+      id: 'grant-1',
+      jti: 'grant-1',
+      status: 'approved',
+      actor: { type: 'agent', id: 'agent-1' },
+      issuer: { displayName: 'operator' },
+      audience: 'relay:operator-handshake:v1',
+      capabilities: ['session:read', 'logs:read'],
+      scope: {
+        nodeIds: ['node-a'],
+        sessionIds: ['session-a'],
+        globalSessionIds: ['node-a:session-a'],
+        workContextIds: ['work-context-a'],
+        repoIds: ['repo-a'],
+        pathPrefixes: ['/repo-a/src/safe/'],
+        taskRefs: ['issue-813'],
+      },
+      device: { displayName: 'work-mac' },
+      sessionBinding: {
+        sessionId: 'session-a',
+        globalSessionId: 'node-a:session-a',
+        workContextId: 'work-context-a',
+      },
+      expiresAt: LATER.toISOString(),
+    });
+    expect(JSON.stringify(grant)).not.toContain('operator-1');
+    expect(JSON.stringify(grant)).not.toContain('device-a');
+    expect(JSON.stringify(grant)).not.toContain('handleHash');
+
+    const valid = store.validate(handle, {
+      audience: 'relay:operator-handshake:v1',
+      requiredCapabilities: ['session:read'],
+      actor: { type: 'agent', id: 'agent-1' },
+      deviceId: 'device-a',
+      sessionBinding: {
+        sessionId: 'session-a',
+        globalSessionId: 'node-a:session-a',
+        workContextId: 'work-context-a',
+        authSessionHash: 'auth-session-hash-a',
+      },
+      scope: {
+        nodeId: 'node-a',
+        sessionId: 'session-a',
+        globalSessionId: 'node-a:session-a',
+        workContextId: 'work-context-a',
+        repoId: 'repo-a',
+        path: '/repo-a/src/safe/file.ts',
+        taskRef: 'issue-813',
+      },
+      correlationId: 'corr-validate-1',
+    });
+
+    expect(valid).toMatchObject({ ok: true, consumed: true });
+    expect(store.getGrant(grant.id)).toMatchObject({ status: 'consumed' });
+  });
+
+  it.each([
+    ['wrong_audience', { audience: 'relay:registry-test' }],
+    ['unknown_audience', { audience: 'relay:nope' }],
+    ['actor_mismatch', { actor: { type: 'agent', id: 'agent-2' } }],
+    ['device_mismatch', { deviceId: 'device-b' }],
+    ['session_mismatch', { sessionBinding: { sessionId: 'session-b' } }],
+    ['wrong_node_scope', { scope: { nodeId: 'node-b' } }],
+    ['wrong_session_scope', { scope: { sessionId: 'session-b' } }],
+    [
+      'wrong_global_session_scope',
+      { scope: { globalSessionId: 'node-b:session-b' } },
+    ],
+    [
+      'wrong_work_context_scope',
+      { scope: { workContextId: 'work-context-b' } },
+    ],
+    ['wrong_repo_scope', { scope: { repoId: 'repo-b' } }],
+    ['wrong_path_scope', { scope: { path: '/repo-a/src/secret.ts' } }],
+    ['wrong_task_scope', { scope: { taskRef: 'issue-999' } }],
+    ['missing_scope', { scope: { nodeId: undefined } }],
+    ['unknown_capability', { requiredCapabilities: ['session:teleport'] }],
+    ['insufficient_capability', { requiredCapabilities: ['rpc:fs:write'] }],
+  ] satisfies [
+    HandshakeGrantValidationFailureReason,
+    Record<string, unknown>,
+  ][])('fails closed for %s', (reason, override) => {
+    const { store, handle } = approvedGrant();
+    const validInput = {
+      audience: 'relay:operator-handshake:v1',
+      requiredCapabilities: ['session:read'],
+      actor: { type: 'agent', id: 'agent-1' },
+      deviceId: 'device-a',
+      sessionBinding: {
+        sessionId: 'session-a',
+        globalSessionId: 'node-a:session-a',
+        workContextId: 'work-context-a',
+        authSessionHash: 'auth-session-hash-a',
+      },
+      scope: {
+        nodeId: 'node-a',
+        sessionId: 'session-a',
+        globalSessionId: 'node-a:session-a',
+        workContextId: 'work-context-a',
+        repoId: 'repo-a',
+        path: '/repo-a/src/safe/file.ts',
+        taskRef: 'issue-813',
+      },
+      consume: false,
+    };
+
+    expect(
+      store.validate(handle, { ...validInput, ...override })
+    ).toMatchObject({
+      ok: false,
+      reason,
+    });
+  });
+
+  it('rejects replay after one successful validation consumes the grant', () => {
+    const { store, handle } = approvedGrant();
+    const input = {
+      audience: 'relay:operator-handshake:v1',
+      requiredCapabilities: ['session:read'],
+      actor: { type: 'agent', id: 'agent-1' },
+      deviceId: 'device-a',
+      sessionBinding: {
+        sessionId: 'session-a',
+        globalSessionId: 'node-a:session-a',
+        workContextId: 'work-context-a',
+        authSessionHash: 'auth-session-hash-a',
+      },
+      scope: {
+        nodeId: 'node-a',
+        sessionId: 'session-a',
+        globalSessionId: 'node-a:session-a',
+        workContextId: 'work-context-a',
+        repoId: 'repo-a',
+        path: '/repo-a/src/safe/file.ts',
+        taskRef: 'issue-813',
+      },
+    };
+
+    expect(store.validate(handle, input)).toMatchObject({ ok: true });
+    expect(store.validate(handle, input)).toMatchObject({
+      ok: false,
+      reason: 'replayed',
+    });
+    expect(store.listAuditEvents().map((event) => event.reasonCode)).toContain(
+      'HANDSHAKE_GRANT_REPLAYED'
+    );
+  });
+
+  it('rejects lane-mixed browser, scoped actor, pair-token, and node credentials', () => {
+    const store = registry();
+    for (const foreign of [
+      'Bearer relay-sac-v1.credential.raw-secret',
+      'relay-sac-v1.credential.raw-secret',
+      'relay-pair-token-raw-material',
+      'relay-node-credential-raw-material',
+      'connect.sid=s%3Araw-browser-cookie',
+    ]) {
+      expect(
+        store.validate(foreign, {
+          audience: 'relay:operator-handshake:v1',
+          requiredCapabilities: ['session:read'],
+        })
+      ).toMatchObject({ ok: false, reason: 'lane_mixing' });
+    }
+  });
+
+  it('expires and revokes grants without accepting the handle afterward', () => {
+    const expiredStore = registry();
+    const expiredGrant = expiredStore.request({
+      actor: { type: 'cli', id: 'cli-1' },
+      issuer: { id: 'operator-1' },
+      audience: 'relay:operator-handshake:v1',
+      capabilities: ['session:read'],
+      scope: { nodeIds: ['node-a'] },
+      expiresAt: EXPIRED,
+    });
+    const expired = expiredStore.approve(expiredGrant.id, {
+      approvedBy: { id: 'operator-1' },
+    });
+    expect(
+      expiredStore.validate(expired.handle, {
+        audience: 'relay:operator-handshake:v1',
+        requiredCapabilities: ['session:read'],
+        scope: { nodeId: 'node-a' },
+      })
+    ).toMatchObject({ ok: false, reason: 'expired' });
+
+    const { store, grant, handle } = approvedGrant();
+    store.revoke(grant.id, {
+      revokedBy: { id: 'operator-1' },
+      reason: 'operator request',
+    });
+    expect(
+      store.validate(handle, {
+        audience: 'relay:operator-handshake:v1',
+        requiredCapabilities: ['session:read'],
+        scope: { nodeId: 'node-a' },
+      })
+    ).toMatchObject({ ok: false, reason: 'revoked' });
+  });
+
+  it('requires #807 approval evidence before approving high-risk capability grants', () => {
+    const store = registry();
+    const grant = store.request({
+      actor: { type: 'automation-system', id: 'automation-1' },
+      issuer: { id: 'operator-1' },
+      audience: 'relay:operator-handshake:v1',
+      capabilities: ['node:lifecycle:destructive'],
+      scope: { nodeIds: ['node-a'] },
+      expiresAt: LATER,
+    });
+
+    expect(() =>
+      store.approve(grant.id, { approvedBy: { id: 'operator-1' } })
+    ).toThrow(HandshakeGrantRegistryError);
+    expect(store.getGrant(grant.id)).toMatchObject({ status: 'denied' });
+
+    const approvedStore = registry();
+    const approvedGrant = approvedStore.request({
+      id: 'high-risk-grant-2',
+      actor: { type: 'automation-system', id: 'automation-1' },
+      issuer: { id: 'operator-1' },
+      audience: 'relay:operator-handshake:v1',
+      capabilities: ['node:lifecycle:destructive'],
+      scope: { nodeIds: ['node-a'] },
+      expiresAt: LATER,
+    });
+    expect(
+      approvedStore.approve(approvedGrant.id, {
+        approvedBy: { id: 'operator-1' },
+        highRiskApproval: {
+          challengeId: 'challenge-1',
+          contractHash: 'hash-1',
+          approvedAt: NOW.toISOString(),
+        },
+      }).grant.highRiskApproval
+    ).toMatchObject({ challengeId: 'challenge-1', contractHash: 'hash-1' });
+  });
+
+  it('keeps grant handles, browser cookies, scoped actor tokens, pair tokens, and node credentials out of snapshots/audit payloads', () => {
+    const { store, grant, handle } = approvedGrant();
+    store.validate(handle, {
+      audience: 'relay:operator-handshake:v1',
+      requiredCapabilities: ['session:read'],
+      actor: { type: 'agent', id: 'agent-1' },
+      deviceId: 'device-a',
+      sessionBinding: {
+        sessionId: 'session-a',
+        globalSessionId: 'node-a:session-a',
+        workContextId: 'work-context-a',
+        authSessionHash: 'auth-session-hash-a',
+      },
+      scope: {
+        nodeId: 'node-a',
+        sessionId: 'session-a',
+        globalSessionId: 'node-a:session-a',
+        workContextId: 'work-context-a',
+        repoId: 'repo-a',
+        path: '/repo-a/src/safe/file.ts',
+        taskRef: 'issue-813',
+      },
+    });
+
+    const rawCookie = 'connect.sid=s%3Araw-browser-cookie';
+    const rawScopedActor = 'relay-sac-v1.credential.raw-secret-token-material';
+    const rawPairToken = 'relay-pair-token-raw-material';
+    const rawNodeCredential = 'relay-node-credential-raw-material';
+    const serialized = JSON.stringify({
+      grants: store.listGrants(),
+      auditEvents: store.listAuditEvents(),
+      auditEntry: createHandshakeGrantAuditEntry({
+        action: 'validate',
+        decision: 'deny',
+        reasonCode: 'HANDSHAKE_GRANT_LANE_MIXING',
+        grant,
+        requiredCapabilities: ['session:read'],
+        deniedCapabilities: ['session:read'],
+        material: {
+          scope: {
+            grantHandle: handle,
+            browserCookie: rawCookie,
+            scopedActorToken: rawScopedActor,
+            pairToken: rawPairToken,
+            nodeCredential: rawNodeCredential,
+          },
+          params: {
+            authorization: `Bearer ${handle}`,
+            credential: rawNodeCredential,
+          },
+        },
+      }),
+      redacted: redactHandshakeGrantForAudit(grant),
+    });
+
+    expect(serialized).not.toContain(handle);
+    expect(serialized).not.toContain('raw-browser-cookie');
+    expect(serialized).not.toContain('raw-secret-token-material');
+    expect(serialized).not.toContain(rawPairToken);
+    expect(serialized).not.toContain(rawNodeCredential);
+    expect(serialized).not.toContain('0123456789abcdef');
+    expect(serialized).not.toContain('handleHash');
+  });
+
+  it('renders approval copy with delegation, TTL, actor, audience, scope, and revoke path', () => {
+    const { grant } = requestedGrant();
+    const copy = operatorHandshakeGrantApprovalCopy(grant);
+
+    expect(copy.title).toContain('Approve one-time Relay handshake grant');
+    expect(copy.summary).toContain('session:read');
+    expect(copy.summary).toContain('agent:agent-1');
+    expect(copy.summary).toContain('relay:operator-handshake:v1');
+    expect(copy.summary).toContain(LATER.toISOString());
+    expect(copy.summary).toContain('not a browser login');
+    expect(copy.details.join('\n')).toContain('workContextIds=work-context-a');
+    expect(copy.details.join('\n')).toContain(
+      'Revoke: DELETE /operator/handshake-grants/grant-1'
+    );
+    expect(copy.revokePath).toBe('/operator/handshake-grants/grant-1');
+  });
+});

--- a/test/operator-handshake-grants.test.ts
+++ b/test/operator-handshake-grants.test.ts
@@ -387,6 +387,89 @@ describe('operator handshake grant registry', () => {
     expect(serialized).not.toContain('handleHash');
   });
 
+  it('keeps hostile grant params and lifecycle reasons out of public and audit payloads', () => {
+    const deniedStore = registry();
+    const { grant: pendingGrant } = requestedGrant(deniedStore);
+    const denialReason =
+      'denial raw reason connect.sid=s%3Adeny-cookie token=deny-secret';
+    const deniedGrant = deniedStore.deny(pendingGrant.id, {
+      deniedBy: { id: 'operator-raw-deny-id', displayName: 'operator' },
+      reason: denialReason,
+      correlationId: 'corr-deny-redaction',
+    });
+    if (!deniedGrant) throw new Error('expected denied grant');
+
+    const {
+      store: revokedStore,
+      grant: approvedForRevocation,
+      handle: revokedHandle,
+    } = approvedGrant();
+    const revocationReason =
+      'revocation raw reason connect.sid=s%3Arevoke-cookie token=revoke-secret';
+    const revokedGrant = revokedStore.revoke(approvedForRevocation.id, {
+      revokedBy: { id: 'operator-raw-revoke-id', displayName: 'operator' },
+      reason: revocationReason,
+      correlationId: 'corr-revoke-redaction',
+    });
+    if (!revokedGrant) throw new Error('expected revoked grant');
+
+    const rawCookie = 'connect.sid=s%3Araw-browser-cookie';
+    const tokenOnly = 'token=raw-token-only-secret';
+    const rawHandle = `${revokedHandle}-malicious-copy`;
+    const rawPairToken = 'relay-pair-token-malicious-material';
+    const rawNodeCredential = 'relay-node-credential-malicious-material';
+    const rawActorId = 'malicious-raw-actor-id';
+    const auditEntry = createHandshakeGrantAuditEntry({
+      action: 'validate',
+      decision: 'deny',
+      reasonCode: 'HANDSHAKE_GRANT_MALICIOUS_PARAMS',
+      grant: revokedGrant,
+      material: {
+        scope: {
+          note: `${rawCookie} ${tokenOnly}`,
+          grantHandle: rawHandle,
+        },
+        params: {
+          note: `${rawCookie} ${tokenOnly}`,
+          grant: {
+            actor: { id: rawActorId },
+            deniedReason: denialReason,
+            revocationReason,
+            handle: rawHandle,
+            pairToken: rawPairToken,
+            nodeCredential: rawNodeCredential,
+          },
+        },
+      },
+    });
+
+    const serialized = JSON.stringify({
+      deniedGrant,
+      deniedByIdSurface: deniedStore.listGrants(),
+      deniedLookup: deniedStore.getGrant(pendingGrant.id),
+      deniedAuditEvents: deniedStore.listAuditEvents(),
+      revokedGrant,
+      revokedSurface: revokedStore.listGrants(),
+      revokedLookup: revokedStore.getGrant(approvedForRevocation.id),
+      revokedAuditEvents: revokedStore.listAuditEvents(),
+      auditEntry,
+      redactedDenied: redactHandshakeGrantForAudit(deniedGrant),
+      redactedRevoked: redactHandshakeGrantForAudit(revokedGrant),
+    });
+
+    expect(serialized).not.toContain(denialReason);
+    expect(serialized).not.toContain(revocationReason);
+    expect(serialized).not.toContain('raw reason');
+    expect(serialized).not.toContain('raw-browser-cookie');
+    expect(serialized).not.toContain('raw-token-only-secret');
+    expect(serialized).not.toContain(rawHandle);
+    expect(serialized).not.toContain(rawPairToken);
+    expect(serialized).not.toContain(rawNodeCredential);
+    expect(serialized).not.toContain(rawActorId);
+    expect(serialized).not.toContain('operator-raw-deny-id');
+    expect(serialized).not.toContain('operator-raw-revoke-id');
+  });
+
   it('renders approval copy with delegation, TTL, actor, audience, scope, and revoke path', () => {
     const { grant } = requestedGrant();
     const copy = operatorHandshakeGrantApprovalCopy(grant);


### PR DESCRIPTION
## Summary

- add the `relay-ohg-v1` operator handshake grant foundation for #812
- model grant issuance/validation/revocation/replay denial with actor/audience/capability/scope/device/session binding
- add audit/redaction helpers plus docs/operator copy for the one-time ceremony vs reusable automation credential boundary

Closes #813
Refs #812

## Verification

Worker-reported and branch-verified evidence:

- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/operator-handshake-grants.test.ts` — pass, 23 tests
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/operator-handshake-grants.test.ts test/scoped-actor-credentials.test.ts test/security-audit.test.ts` — pass, 70 tests
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check` — pass with existing warnings only
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run build` — pass

## Notes

This intentionally does **not** implement #814 pair-token minting or #815 scoped actor credential lifecycle. Those should stack after this foundation lands so the auth boundary does not turn into soup.
