### PR TITLE
feat: add grant-backed CLI actor credential lifecycle

### DIFF
--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -134,9 +134,9 @@ Local discovery commands (`relay-ide v1 --list --json`, `relay-ide v1 schema --j
 
 ### Mint, use, revoke, and rotate
 
-The current MVP exposes credential lifecycle through hub operator endpoints, not through stable `relay-ide v1` adapter commands. Mint/list/revoke requests require the existing hub operator auth path, or `NO_PIN=1` in local dev. That operator auth authorizes issuing a delegated credential; the resulting actor token is not a browser login, is not a node credential, and does not pair a node.
+The current MVP exposes credential lifecycle through hub operator endpoints, not through stable `relay-ide v1` adapter commands. Browser-authenticated operators may mint/list/revoke with the existing hub operator auth path (`NO_PIN=1` in local dev). #815 also allows an approved one-time operator handshake grant for the same lifecycle without browser-cookie fallback. Grant-backed lifecycle calls must carry a handshake `grantHandle`, exact audience `relay:cli-gateway:v1`, actor type/id, explicit `session:read` capability bits, at least one concrete scope dimension, TTL or expiry, and a correlation id.
 
-Mint a short-lived CLI actor token:
+Mint a short-lived CLI actor token with browser operator auth:
 
 ```bash
 curl -sS -X POST http://127.0.0.1:3456/cli-gateway/actor-credentials \
@@ -151,25 +151,57 @@ curl -sS -X POST http://127.0.0.1:3456/cli-gateway/actor-credentials \
   }'
 ```
 
-The response includes `token` once and a public `credential` record. Store the token in the calling process or a secret manager; do not paste it into issues, logs, screenshots, or test snapshots. Use the returned `credential.id` for list/revoke/audit references.
+Mint the same token family with an approved handshake grant:
 
-List public credential records:
+```bash
+curl -sS -X POST http://127.0.0.1:3456/cli-gateway/actor-credentials \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "grantHandle": "<approved-one-time-handshake-grant>",
+    "audience": "relay:cli-gateway:v1",
+    "actor": { "type": "cli", "id": "relay-cli" },
+    "capabilities": ["session:read"],
+    "ttlMs": 300000,
+    "scope": { "sessionIds": ["<session-id>"] },
+    "correlationId": "cli-actor-grant-mint-1"
+  }'
+```
+
+The response includes `token` once and a public `credential` record. Store the token in the calling process or a secret manager; do not paste it into issues, logs, screenshots, or test snapshots. Use the returned `credential.id` for list/revoke/audit references. Public records include the issuer/grant id and redacted metadata only; raw grant handles and bearer material are never returned.
+
+List public credential records with browser auth or a fresh grant handle:
 
 ```bash
 curl -sS http://127.0.0.1:3456/cli-gateway/actor-credentials \
   -b 'token=<operator-browser-session-cookie>'
+
+curl -sS -X POST http://127.0.0.1:3456/cli-gateway/actor-credentials/list \
+  -H 'Content-Type: application/json' \
+  -d '{"grantHandle":"<approved-one-time-handshake-grant>","audience":"relay:cli-gateway:v1","actor":{"type":"cli","id":"relay-cli"},"capabilities":["session:read"],"scope":{"sessionIds":["<session-id>"]},"correlationId":"cli-actor-grant-list-1"}'
 ```
 
-Revoke by credential id:
+Revoke by credential id with browser auth or a fresh grant handle:
 
 ```bash
 curl -sS -X DELETE http://127.0.0.1:3456/cli-gateway/actor-credentials/<credential-id> \
   -H 'Content-Type: application/json' \
   -b 'token=<operator-browser-session-cookie>' \
-  -d '{"revokedBy":"operator","reason":"rotation","correlationId":"cli-actor-rotate-1"}'
+  -d '{"revokedBy":"operator","reason":"rotation","correlationId":"cli-actor-revoke-1"}'
+
+curl -sS -X POST http://127.0.0.1:3456/cli-gateway/actor-credentials/<credential-id>/revoke \
+  -H 'Content-Type: application/json' \
+  -d '{"grantHandle":"<approved-one-time-handshake-grant>","audience":"relay:cli-gateway:v1","actor":{"type":"cli","id":"relay-cli"},"scope":{"sessionIds":["<session-id>"]},"correlationId":"cli-actor-grant-revoke-1"}'
 ```
 
-Rotation is mint-new-then-revoke-old in this slice. There is no separate rotate endpoint: issue a replacement credential with a new TTL/scope, update the automation to use the new token, then revoke the old credential id. Revocation is in-process and applies to future validations by id/jti; expiry is checked on every validation.
+Rotation is mint-new-then-revoke-old in this slice. The grant-backed rotate endpoint performs that ordering in one request with a fresh grant handle and returns `{ token, credential, revoked }`; browser-authenticated operators can do the same manually by issuing a replacement credential, updating the automation to use the new token, then revoking the old credential id. Revocation is in-process and applies to future validations by id/jti; expiry is checked on every validation.
+
+```bash
+curl -sS -X POST http://127.0.0.1:3456/cli-gateway/actor-credentials/<credential-id>/rotate \
+  -H 'Content-Type: application/json' \
+  -d '{"grantHandle":"<approved-one-time-handshake-grant>","audience":"relay:cli-gateway:v1","actor":{"type":"cli","id":"relay-cli"},"ttlMs":300000,"scope":{"sessionIds":["<session-id>"]},"correlationId":"cli-actor-grant-rotate-1"}'
+```
+
+Grant-backed requests are denied before minting when the handle is revoked, expired, replayed, from a different credential lane, scoped to another actor/session/task, asks for another audience, omits scope/TTL, or requests wildcard/unknown/non-allowlisted capabilities. Denial copy must mention stable reason codes, credential/grant ids, and correlation ids only; redact bearer tokens, grant handles, cookies, node credentials, approval secrets, and raw secret-looking reason strings.
 
 ### Lane separation
 

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -2,8 +2,10 @@ import type { Request, Response } from 'express';
 import {
   HandshakeGrantRegistry,
   type HandshakeGrantActor,
+  type HandshakeGrantScope,
   type HandshakeGrantSessionBinding,
   type HandshakeGrantValidationFailureReason,
+  type HandshakeGrantValidationScope,
 } from '../shared/operator-handshake-grants.js';
 import {
   ScopedActorCredentialRegistry,
@@ -388,15 +390,7 @@ export function rotateCliGatewayActorCredentialWithGrant(
 
 function scopeForValidation(
   scope: ScopedActorCredentialScope | undefined
-): {
-  nodeId?: string;
-  sessionId?: string;
-  globalSessionId?: string;
-  workContextId?: string;
-  repoId?: string;
-  path?: string;
-  taskRef?: string;
-} {
+): HandshakeGrantValidationScope {
   return {
     ...(scope?.nodeIds?.[0] ? { nodeId: scope.nodeIds[0] } : {}),
     ...(scope?.sessionIds?.[0] ? { sessionId: scope.sessionIds[0] } : {}),
@@ -536,15 +530,38 @@ function validateCliGatewayLifecycleGrant(
   request: StrictGrantLifecycleRequest,
   consume: boolean
 ) {
-  const validation = grantRegistry.validate(request.grantHandle, {
+  const validationInput = {
     audience: request.audience,
     requiredCapabilities: request.capabilities,
     actor: request.actor,
     ...(request.deviceId ? { deviceId: request.deviceId } : {}),
     ...(request.sessionBinding ? { sessionBinding: request.sessionBinding } : {}),
     scope: scopeForValidation(request.scope),
-    consume,
+    consume: false,
     correlationId: request.correlationId,
+  };
+  const preflight = grantRegistry.validate(request.grantHandle, validationInput);
+  if (preflight.ok === false) {
+    throw new CliGatewayActorGrantError(
+      preflight.reason,
+      'handshake grant does not authorize the requested CLI actor credential lifecycle operation',
+      preflight.grantId
+    );
+  }
+  const scopeExpansion = validateRequestedScopeAgainstGrant(
+    preflight.grant.scope,
+    request.scope
+  );
+  if (scopeExpansion) {
+    throw new CliGatewayActorGrantError(
+      scopeExpansion,
+      'handshake grant does not authorize the requested CLI actor credential lifecycle operation',
+      preflight.grant.id
+    );
+  }
+  const validation = grantRegistry.validate(request.grantHandle, {
+    ...validationInput,
+    consume,
   });
   if (validation.ok === false) {
     throw new CliGatewayActorGrantError(
@@ -554,6 +571,71 @@ function validateCliGatewayLifecycleGrant(
     );
   }
   return validation.grant;
+}
+
+function validateRequestedScopeAgainstGrant(
+  grantScope: HandshakeGrantScope,
+  requestScope: ScopedActorCredentialScope
+): HandshakeGrantValidationFailureReason | null {
+  const rules: {
+    grantValues: readonly string[] | undefined;
+    requestValues: readonly string[] | undefined;
+    wrongReason: HandshakeGrantValidationFailureReason;
+    matches?: (grantValues: readonly string[], requestedValue: string) => boolean;
+  }[] = [
+    {
+      grantValues: grantScope.nodeIds,
+      requestValues: requestScope.nodeIds,
+      wrongReason: 'wrong_node_scope',
+    },
+    {
+      grantValues: grantScope.sessionIds,
+      requestValues: requestScope.sessionIds,
+      wrongReason: 'wrong_session_scope',
+    },
+    {
+      grantValues: grantScope.globalSessionIds,
+      requestValues: requestScope.globalSessionIds,
+      wrongReason: 'wrong_global_session_scope',
+    },
+    {
+      grantValues: grantScope.workContextIds,
+      requestValues: requestScope.workContextIds,
+      wrongReason: 'wrong_work_context_scope',
+    },
+    {
+      grantValues: grantScope.repoIds,
+      requestValues: requestScope.repoIds,
+      wrongReason: 'wrong_repo_scope',
+    },
+    {
+      grantValues: grantScope.pathPrefixes,
+      requestValues: requestScope.pathPrefixes,
+      wrongReason: 'wrong_path_scope',
+      matches: (prefixes, requestedPath) =>
+        prefixes.some((prefix) => pathMatchesGrantPrefix(requestedPath, prefix)),
+    },
+    {
+      grantValues: grantScope.taskRefs,
+      requestValues: requestScope.taskRefs,
+      wrongReason: 'wrong_task_scope',
+    },
+  ];
+
+  for (const rule of rules) {
+    if (!rule.grantValues?.length || !rule.requestValues?.length) continue;
+    const matches = rule.matches ?? ((values, requested) => values.includes(requested));
+    if (!rule.requestValues.every((value) => matches(rule.grantValues ?? [], value))) {
+      return rule.wrongReason;
+    }
+  }
+  return null;
+}
+
+function pathMatchesGrantPrefix(path: string, prefix: string): boolean {
+  if (path === prefix) return true;
+  const normalizedPrefix = prefix.endsWith('/') ? prefix : `${prefix}/`;
+  return path.startsWith(normalizedPrefix);
 }
 
 function strictActor(value: unknown): HandshakeGrantActor {

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -623,13 +623,29 @@ function validateRequestedScopeAgainstGrant(
   ];
 
   for (const rule of rules) {
-    if (!rule.grantValues?.length || !rule.requestValues?.length) continue;
+    if (!rule.requestValues?.length) continue;
+    const grantValues = rule.grantValues;
+    if (!grantValues?.length) {
+      if (requestOnlyScopeDimensionIsAllowed(rule.wrongReason, rule.requestValues)) continue;
+      return rule.wrongReason;
+    }
     const matches = rule.matches ?? ((values, requested) => values.includes(requested));
-    if (!rule.requestValues.every((value) => matches(rule.grantValues ?? [], value))) {
+    if (!rule.requestValues.every((value) => matches(grantValues, value))) {
       return rule.wrongReason;
     }
   }
   return null;
+}
+
+function requestOnlyScopeDimensionIsAllowed(
+  wrongReason: HandshakeGrantValidationFailureReason,
+  requestValues: readonly string[]
+): boolean {
+  return (
+    wrongReason === 'wrong_task_scope' &&
+    requestValues.length === 1 &&
+    requestValues[0] === CLI_GATEWAY_READ_SCOPE_TASK_REF
+  );
 }
 
 function pathMatchesGrantPrefix(path: string, prefix: string): boolean {

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -1,18 +1,28 @@
 import type { Request, Response } from 'express';
 import {
+  HandshakeGrantRegistry,
+  type HandshakeGrantActor,
+  type HandshakeGrantSessionBinding,
+  type HandshakeGrantValidationFailureReason,
+} from '../shared/operator-handshake-grants.js';
+import {
   ScopedActorCredentialRegistry,
   type ScopedActorCredentialRecord,
   type ScopedActorCredentialScope,
   type ScopedActorCredentialValidationFailureReason,
   type ScopedActorCredentialValidationResult,
 } from '../shared/scoped-actor-credentials.js';
-import type { RelayCapabilityBit } from '../shared/security-policy.js';
+import {
+  isRelayCapabilityBit,
+  type RelayCapabilityBit,
+} from '../shared/security-policy.js';
 
 export const CLI_GATEWAY_ACTOR_AUDIENCE = 'relay:cli-gateway:v1' as const;
 export const CLI_GATEWAY_READ_SCOPE_TASK_REF = 'relay:cli-gateway:v1:read' as const;
 export const CLI_GATEWAY_ACTOR_TOKEN_HEADER = 'x-relay-cli-actor-token' as const;
 export const CLI_GATEWAY_COMMAND_HEADER = 'x-relay-cli-command' as const;
 export const CLI_GATEWAY_CORRELATION_ID_HEADER = 'x-relay-correlation-id' as const;
+export const CLI_GATEWAY_ACTOR_GRANT_CAPABILITIES = ['session:read'] as const;
 export const CLI_GATEWAY_ACTOR_READ_COMMANDS = [
   'nodes.list',
   'sessions.list',
@@ -33,6 +43,38 @@ export interface CliGatewayActorIssueInput {
   expiresAt?: unknown;
   metadata?: unknown;
   correlationId?: unknown;
+}
+
+export interface CliGatewayGrantActorLifecycleInput extends CliGatewayActorIssueInput {
+  grantHandle?: unknown;
+  audience?: unknown;
+  grantActor?: { type?: unknown; id?: unknown; displayName?: unknown };
+  deviceId?: unknown;
+  sessionBinding?: unknown;
+}
+
+export type CliGatewayActorGrantFailureReason =
+  | HandshakeGrantValidationFailureReason
+  | 'grant_handle_required'
+  | 'actor_required'
+  | 'issuer_required'
+  | 'ttl_required'
+  | 'audience_required'
+  | 'audience_expansion'
+  | 'capability_required'
+  | 'capability_expansion'
+  | 'scope_required'
+  | 'credential_not_found';
+
+export class CliGatewayActorGrantError extends Error {
+  constructor(
+    public readonly reason: CliGatewayActorGrantFailureReason,
+    message: string,
+    public readonly grantId?: string
+  ) {
+    super(`${reason.toUpperCase()}: ${message}`);
+    this.name = 'CliGatewayActorGrantError';
+  }
 }
 
 export interface CliGatewayActorValidationInput {
@@ -67,6 +109,10 @@ type RequestWithAuthenticatedCliGatewayActor = Request & {
 
 export function createCliGatewayActorRegistry(): ScopedActorCredentialRegistry {
   return new ScopedActorCredentialRegistry();
+}
+
+export function createCliGatewayHandshakeGrantRegistry(): HandshakeGrantRegistry {
+  return new HandshakeGrantRegistry();
 }
 
 export function attachAuthenticatedCliGatewayActorCredential(
@@ -221,6 +267,121 @@ export function issueCliGatewayActorCredential(
   });
 }
 
+export function issueCliGatewayActorCredentialWithGrant(
+  registry: ScopedActorCredentialRegistry,
+  grantRegistry: HandshakeGrantRegistry,
+  input: CliGatewayGrantActorLifecycleInput
+): { token: string; credential: ScopedActorCredentialRecord } {
+  const request = strictGrantLifecycleRequest(input);
+  const grant = validateCliGatewayLifecycleGrant(grantRegistry, request, true);
+  const issued = registry.issue({
+    actor: request.actor,
+    issuer: {
+      id: grant.id,
+      ...(grant.issuer.displayName ? { displayName: grant.issuer.displayName } : {}),
+    },
+    grantId: grant.id,
+    audience: request.audience,
+    capabilities: request.capabilities,
+    scope: request.scope,
+    ...(request.ttlMs != null ? { ttlMs: request.ttlMs } : {}),
+    ...(request.expiresAt ? { expiresAt: request.expiresAt } : {}),
+    ...(isRecord(input.metadata) ? { metadata: input.metadata } : {}),
+    correlationId: request.correlationId,
+  });
+  return issued;
+}
+
+export function listCliGatewayActorCredentialsWithGrant(
+  registry: ScopedActorCredentialRegistry,
+  grantRegistry: HandshakeGrantRegistry,
+  input: CliGatewayGrantActorLifecycleInput
+): { credentials: ScopedActorCredentialRecord[] } {
+  const request = strictGrantLifecycleRequest(input, { ttlRequired: false });
+  validateCliGatewayLifecycleGrant(grantRegistry, request, true);
+  return { credentials: registry.listCredentials() };
+}
+
+export function revokeCliGatewayActorCredentialWithGrant(
+  registry: ScopedActorCredentialRegistry,
+  grantRegistry: HandshakeGrantRegistry,
+  credentialId: string,
+  input: CliGatewayGrantActorLifecycleInput
+): ScopedActorCredentialRecord {
+  const existing = registry.getCredential(credentialId);
+  if (!existing) {
+    throw new CliGatewayActorGrantError(
+      'credential_not_found',
+      'scoped actor credential not found'
+    );
+  }
+  const request = strictGrantLifecycleRequest(input, {
+    ttlRequired: false,
+    capabilities: existing.capabilities,
+    scope: existing.scope,
+    actor: existing.actor,
+  });
+  const grant = validateCliGatewayLifecycleGrant(grantRegistry, request, true);
+  const credential = registry.revoke(credentialId, {
+    revokedBy: `grant:${grant.id}`,
+    ...(typeof input.metadata === 'object' && input.metadata && 'reason' in input.metadata
+      ? { reason: String((input.metadata as { reason?: unknown }).reason ?? '') }
+      : {}),
+    correlationId: request.correlationId,
+  });
+  if (!credential) {
+    throw new CliGatewayActorGrantError(
+      'credential_not_found',
+      'scoped actor credential not found',
+      grant.id
+    );
+  }
+  return credential;
+}
+
+export function rotateCliGatewayActorCredentialWithGrant(
+  registry: ScopedActorCredentialRegistry,
+  grantRegistry: HandshakeGrantRegistry,
+  credentialId: string,
+  input: CliGatewayGrantActorLifecycleInput
+): { token: string; credential: ScopedActorCredentialRecord; revoked: ScopedActorCredentialRecord } {
+  const existing = registry.getCredential(credentialId);
+  if (!existing) {
+    throw new CliGatewayActorGrantError(
+      'credential_not_found',
+      'scoped actor credential not found'
+    );
+  }
+  const request = strictGrantLifecycleRequest(input, {
+    capabilities: existing.capabilities,
+    scope: existing.scope,
+    actor: existing.actor,
+  });
+  const grant = validateCliGatewayLifecycleGrant(grantRegistry, request, true);
+  const issued = registry.issue({
+    actor: existing.actor,
+    issuer: {
+      id: grant.id,
+      ...(grant.issuer.displayName ? { displayName: grant.issuer.displayName } : {}),
+    },
+    grantId: grant.id,
+    audience: existing.audience,
+    capabilities: existing.capabilities,
+    scope: existing.scope,
+    ...(request.ttlMs != null ? { ttlMs: request.ttlMs } : {}),
+    ...(request.expiresAt ? { expiresAt: request.expiresAt } : {}),
+    ...(isRecord(input.metadata) ? { metadata: input.metadata } : {}),
+    correlationId: request.correlationId,
+  });
+  const revoked = registry.revoke(credentialId, {
+    revokedBy: `grant:${grant.id}`,
+    reason: 'rotated by grant-backed lifecycle',
+    correlationId: request.correlationId,
+  });
+  if (!revoked) throw new Error('credential disappeared during rotation');
+  return { ...issued, revoked };
+}
+
 function scopeForValidation(
   scope: ScopedActorCredentialScope | undefined
 ): {
@@ -244,6 +405,169 @@ function scopeForValidation(
     ...(scope?.repoIds?.[0] ? { repoId: scope.repoIds[0] } : {}),
     ...(scope?.pathPrefixes?.[0] ? { path: scope.pathPrefixes[0] } : {}),
     ...(scope?.taskRefs?.[0] ? { taskRef: scope.taskRefs[0] } : {}),
+  };
+}
+
+type StrictGrantLifecycleRequest = {
+  grantHandle: string;
+  audience: typeof CLI_GATEWAY_ACTOR_AUDIENCE;
+  capabilities: RelayCapabilityBit[];
+  actor: HandshakeGrantActor;
+  grantActor?: HandshakeGrantActor;
+  deviceId?: string;
+  sessionBinding?: HandshakeGrantSessionBinding;
+  scope: ScopedActorCredentialScope;
+  ttlMs?: number;
+  expiresAt?: string;
+  correlationId: string;
+};
+
+function strictGrantLifecycleRequest(
+  input: CliGatewayGrantActorLifecycleInput,
+  options: {
+    ttlRequired?: boolean;
+    capabilities?: readonly RelayCapabilityBit[];
+    scope?: ScopedActorCredentialScope;
+    actor?: HandshakeGrantActor;
+  } = {}
+): StrictGrantLifecycleRequest {
+  if (typeof input.grantHandle !== 'string' || !input.grantHandle.trim()) {
+    throw new CliGatewayActorGrantError(
+      'grant_handle_required',
+      'grant-backed lifecycle requires a handshake grant handle'
+    );
+  }
+  if (input.audience !== CLI_GATEWAY_ACTOR_AUDIENCE) {
+    throw new CliGatewayActorGrantError(
+      typeof input.audience === 'string' ? 'audience_expansion' : 'audience_required',
+      'grant-backed CLI actor credentials require audience relay:cli-gateway:v1'
+    );
+  }
+  const actor = options.actor ?? strictActor(input.actor);
+  const capabilities = options.capabilities
+    ? [...options.capabilities]
+    : strictCliGatewayCapabilities(input.capabilities);
+  const scope = defaultCliGatewayActorScope(options.scope ?? strictScope(input.scope));
+  const ttlRequired = options.ttlRequired ?? true;
+  const ttlMs = typeof input.ttlMs === 'number' ? input.ttlMs : undefined;
+  const expiresAt = typeof input.expiresAt === 'string' ? input.expiresAt : undefined;
+  if (ttlRequired && ttlMs == null && !expiresAt) {
+    throw new CliGatewayActorGrantError(
+      'ttl_required',
+      'grant-backed CLI actor credentials require ttlMs or expiresAt'
+    );
+  }
+  return {
+    grantHandle: input.grantHandle.trim(),
+    audience: CLI_GATEWAY_ACTOR_AUDIENCE,
+    capabilities,
+    actor,
+    ...(input.grantActor ? { grantActor: strictActor(input.grantActor) } : {}),
+    ...(typeof input.deviceId === 'string' ? { deviceId: input.deviceId } : {}),
+    ...(isRecord(input.sessionBinding)
+      ? { sessionBinding: strictSessionBinding(input.sessionBinding) }
+      : {}),
+    scope,
+    ...(ttlMs != null ? { ttlMs } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
+    correlationId:
+      typeof input.correlationId === 'string' && input.correlationId.trim()
+        ? input.correlationId.trim()
+        : `cli-actor-grant-${Date.now()}`,
+  };
+}
+
+function validateCliGatewayLifecycleGrant(
+  grantRegistry: HandshakeGrantRegistry,
+  request: StrictGrantLifecycleRequest,
+  consume: boolean
+) {
+  const validation = grantRegistry.validate(request.grantHandle, {
+    audience: request.audience,
+    requiredCapabilities: request.capabilities,
+    actor: request.actor,
+    ...(request.deviceId ? { deviceId: request.deviceId } : {}),
+    ...(request.sessionBinding ? { sessionBinding: request.sessionBinding } : {}),
+    scope: scopeForValidation(request.scope),
+    consume,
+    correlationId: request.correlationId,
+  });
+  if (validation.ok === false) {
+    throw new CliGatewayActorGrantError(
+      validation.reason,
+      'handshake grant does not authorize the requested CLI actor credential lifecycle operation',
+      validation.grantId
+    );
+  }
+  return validation.grant;
+}
+
+function strictActor(value: unknown): HandshakeGrantActor {
+  if (!isRecord(value) || typeof value.type !== 'string' || typeof value.id !== 'string') {
+    throw new CliGatewayActorGrantError(
+      'actor_required',
+      'grant-backed lifecycle requires actor type and id'
+    );
+  }
+  return {
+    type: value.type,
+    id: value.id,
+    ...(typeof value.displayName === 'string' ? { displayName: value.displayName } : {}),
+  };
+}
+
+function strictCliGatewayCapabilities(value: unknown): RelayCapabilityBit[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new CliGatewayActorGrantError(
+      'capability_required',
+      'grant-backed lifecycle requires explicit capability bits'
+    );
+  }
+  const capabilities = value.filter((entry): entry is string => typeof entry === 'string');
+  if (capabilities.length !== value.length || capabilities.some((capability) => capability === '*')) {
+    throw new CliGatewayActorGrantError(
+      'capability_expansion',
+      'grant-backed CLI actor credentials are limited to the read-only CLI gateway capability allowlist'
+    );
+  }
+  if (capabilities.some((capability) => !isRelayCapabilityBit(capability))) {
+    throw new CliGatewayActorGrantError(
+      'unknown_capability',
+      'grant-backed lifecycle requires known Relay capability bits'
+    );
+  }
+  if (capabilities.some((capability) => capability !== CLI_GATEWAY_ACTOR_GRANT_CAPABILITIES[0])) {
+    throw new CliGatewayActorGrantError(
+      'capability_expansion',
+      'grant-backed CLI actor credentials are limited to the read-only CLI gateway capability allowlist'
+    );
+  }
+  return ['session:read'];
+}
+
+function strictScope(value: unknown): ScopedActorCredentialScope {
+  const scope = coerceScope(value);
+  if (!scope || Object.keys(scope).length === 0) {
+    throw new CliGatewayActorGrantError(
+      'scope_required',
+      'grant-backed lifecycle requires at least one explicit scope dimension'
+    );
+  }
+  return scope;
+}
+
+function strictSessionBinding(value: Record<string, unknown>): HandshakeGrantSessionBinding {
+  return {
+    ...(typeof value['sessionId'] === 'string' ? { sessionId: value['sessionId'] } : {}),
+    ...(typeof value['globalSessionId'] === 'string'
+      ? { globalSessionId: value['globalSessionId'] }
+      : {}),
+    ...(typeof value['workContextId'] === 'string'
+      ? { workContextId: value['workContextId'] }
+      : {}),
+    ...(typeof value['authSessionHash'] === 'string'
+      ? { authSessionHash: value['authSessionHash'] }
+      : {}),
   };
 }
 

--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -299,7 +299,11 @@ export function listCliGatewayActorCredentialsWithGrant(
 ): { credentials: ScopedActorCredentialRecord[] } {
   const request = strictGrantLifecycleRequest(input, { ttlRequired: false });
   validateCliGatewayLifecycleGrant(grantRegistry, request, true);
-  return { credentials: registry.listCredentials() };
+  return {
+    credentials: registry
+      .listCredentials()
+      .filter((credential) => credentialMatchesGrantLifecycleRequest(credential, request)),
+  };
 }
 
 export function revokeCliGatewayActorCredentialWithGrant(
@@ -406,6 +410,56 @@ function scopeForValidation(
     ...(scope?.pathPrefixes?.[0] ? { path: scope.pathPrefixes[0] } : {}),
     ...(scope?.taskRefs?.[0] ? { taskRef: scope.taskRefs[0] } : {}),
   };
+}
+
+function credentialMatchesGrantLifecycleRequest(
+  credential: ScopedActorCredentialRecord,
+  request: StrictGrantLifecycleRequest
+): boolean {
+  return (
+    credential.audience === request.audience &&
+    credential.actor.type === request.actor.type &&
+    credential.actor.id === request.actor.id &&
+    listIsSubset(credential.capabilities, request.capabilities) &&
+    scopeIsAuthorizedByRequest(credential.scope, request.scope)
+  );
+}
+
+function scopeIsAuthorizedByRequest(
+  credentialScope: ScopedActorCredentialScope,
+  requestScope: ScopedActorCredentialScope
+): boolean {
+  return (
+    scopeDimensionIsAuthorized(credentialScope.nodeIds, requestScope.nodeIds) &&
+    scopeDimensionIsAuthorized(credentialScope.sessionIds, requestScope.sessionIds) &&
+    scopeDimensionIsAuthorized(
+      credentialScope.globalSessionIds,
+      requestScope.globalSessionIds
+    ) &&
+    scopeDimensionIsAuthorized(
+      credentialScope.workContextIds,
+      requestScope.workContextIds
+    ) &&
+    scopeDimensionIsAuthorized(credentialScope.repoIds, requestScope.repoIds) &&
+    scopeDimensionIsAuthorized(credentialScope.pathPrefixes, requestScope.pathPrefixes) &&
+    scopeDimensionIsAuthorized(credentialScope.taskRefs, requestScope.taskRefs)
+  );
+}
+
+function scopeDimensionIsAuthorized(
+  credentialValues: readonly string[] | undefined,
+  requestValues: readonly string[] | undefined
+): boolean {
+  if (!credentialValues?.length) return !requestValues?.length;
+  if (!requestValues?.length) return false;
+  return listIsSubset(credentialValues, requestValues);
+}
+
+function listIsSubset(
+  values: readonly string[],
+  allowed: readonly string[]
+): boolean {
+  return values.every((value) => allowed.includes(value));
 }
 
 type StrictGrantLifecycleRequest = {

--- a/server/index.ts
+++ b/server/index.ts
@@ -220,8 +220,13 @@ import {
   cliGatewayActorFailure,
   cliGatewayCorrelationId,
   createCliGatewayActorRegistry,
+  createCliGatewayHandshakeGrantRegistry,
   isCliGatewayActorTokenRequest,
   issueCliGatewayActorCredential,
+  issueCliGatewayActorCredentialWithGrant,
+  listCliGatewayActorCredentialsWithGrant,
+  revokeCliGatewayActorCredentialWithGrant,
+  rotateCliGatewayActorCredentialWithGrant,
   sendCliGatewayActorFailure,
   validateCliGatewayActorCredential,
   type CliGatewayActorIssueInput,
@@ -234,6 +239,7 @@ const execFileAsync = promisify(execFile);
 const logger = createLogger('index');
 const localRelayNode = createLocalRelayNode();
 const cliGatewayActorRegistry = createCliGatewayActorRegistry();
+const cliGatewayHandshakeGrantRegistry = createCliGatewayHandshakeGrantRegistry();
 
 // When run via CLI bin, config lives in ~/.config/relay-ide/
 // When run directly (development), fall back to local config.json
@@ -1831,30 +1837,66 @@ async function main(): Promise<void> {
     };
   };
 
-  app.post('/cli-gateway/actor-credentials', requireAuth, (req, res) => {
+  const actorLifecycleAuth: express.RequestHandler = (req, res, next) => {
+    const body = isRecord(req.body) ? req.body : {};
+    if (typeof body['grantHandle'] === 'string') {
+      next();
+      return;
+    }
+    requireAuth(req, res, next);
+  };
+
+  const actorLifecycleError = (res: express.Response, error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    const reason =
+      error instanceof Error && 'reason' in error && typeof error.reason === 'string'
+        ? error.reason
+        : 'issue_failed';
+    res.status(reason === 'credential_not_found' ? 404 : 400).json({
+      error: {
+        code: `CLI_ACTOR_CREDENTIAL_${reason.toUpperCase()}`,
+        message,
+        retryable: false,
+      },
+    });
+  };
+
+  app.post('/cli-gateway/actor-credentials', actorLifecycleAuth, (req, res) => {
     try {
-      const issued = issueCliGatewayActorCredential(
-        cliGatewayActorRegistry,
-        isRecord(req.body) ? (req.body as CliGatewayActorIssueInput) : {}
-      );
+      const body = isRecord(req.body) ? (req.body as CliGatewayActorIssueInput) : {};
+      const issued =
+        isRecord(req.body) && typeof req.body['grantHandle'] === 'string'
+          ? issueCliGatewayActorCredentialWithGrant(
+              cliGatewayActorRegistry,
+              cliGatewayHandshakeGrantRegistry,
+              req.body
+            )
+          : issueCliGatewayActorCredential(cliGatewayActorRegistry, body);
       res.status(201).json({
         token: issued.token,
         credential: issued.credential,
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      res.status(400).json({
-        error: {
-          code: 'CLI_ACTOR_CREDENTIAL_ISSUE_FAILED',
-          message,
-          retryable: false,
-        },
-      });
+      actorLifecycleError(res, error);
     }
   });
 
   app.get('/cli-gateway/actor-credentials', requireAuth, (_req, res) => {
     res.json({ credentials: cliGatewayActorRegistry.listCredentials() });
+  });
+
+  app.post('/cli-gateway/actor-credentials/list', (req, res) => {
+    try {
+      const body = isRecord(req.body) ? req.body : {};
+      const listed = listCliGatewayActorCredentialsWithGrant(
+        cliGatewayActorRegistry,
+        cliGatewayHandshakeGrantRegistry,
+        body
+      );
+      res.json(listed);
+    } catch (error) {
+      actorLifecycleError(res, error);
+    }
   });
 
   app.delete('/cli-gateway/actor-credentials/:id', requireAuth, (req, res) => {
@@ -1888,6 +1930,58 @@ async function main(): Promise<void> {
       return;
     }
     res.json({ credential });
+  });
+
+  app.post('/cli-gateway/actor-credentials/:id/revoke', (req, res) => {
+    const id = req.params['id'];
+    if (!id) {
+      res.status(400).json({
+        error: {
+          code: 'CLI_ACTOR_CREDENTIAL_ID_REQUIRED',
+          message: 'credential id is required',
+          retryable: false,
+        },
+      });
+      return;
+    }
+    try {
+      const body = isRecord(req.body) ? req.body : {};
+      const credential = revokeCliGatewayActorCredentialWithGrant(
+        cliGatewayActorRegistry,
+        cliGatewayHandshakeGrantRegistry,
+        id,
+        body
+      );
+      res.json({ credential });
+    } catch (error) {
+      actorLifecycleError(res, error);
+    }
+  });
+
+  app.post('/cli-gateway/actor-credentials/:id/rotate', (req, res) => {
+    const id = req.params['id'];
+    if (!id) {
+      res.status(400).json({
+        error: {
+          code: 'CLI_ACTOR_CREDENTIAL_ID_REQUIRED',
+          message: 'credential id is required',
+          retryable: false,
+        },
+      });
+      return;
+    }
+    try {
+      const body = isRecord(req.body) ? req.body : {};
+      const rotated = rotateCliGatewayActorCredentialWithGrant(
+        cliGatewayActorRegistry,
+        cliGatewayHandshakeGrantRegistry,
+        id,
+        body
+      );
+      res.status(201).json(rotated);
+    } catch (error) {
+      actorLifecycleError(res, error);
+    }
   });
 
   const collectLocalInventory = () =>

--- a/shared/operator-handshake-grants.ts
+++ b/shared/operator-handshake-grants.ts
@@ -27,6 +27,7 @@ export type HandshakeGrantActorType =
 
 export const HANDSHAKE_GRANT_AUDIENCES = [
   'relay:operator-handshake:v1',
+  'relay:cli-gateway:v1',
   'relay:registry-test',
 ] as const;
 

--- a/shared/scoped-actor-credentials.ts
+++ b/shared/scoped-actor-credentials.ts
@@ -90,6 +90,7 @@ export interface ScopedActorCredentialRecord {
   id: string;
   actor: ScopedActorCredentialActor & { type: ScopedActorCredentialType };
   issuer: ScopedActorCredentialIssuer;
+  grantId?: string;
   audience: ScopedActorCredentialAudience;
   capabilities: RelayCapabilityBit[];
   scope: ScopedActorCredentialScope;
@@ -99,6 +100,7 @@ export interface ScopedActorCredentialRecord {
   revokedAt?: string | undefined;
   revokedBy?: string | undefined;
   revocationReason?: string | undefined;
+  correlationId: string;
 }
 
 interface InternalScopedActorCredentialRecord extends ScopedActorCredentialRecord {
@@ -109,6 +111,7 @@ export interface IssueScopedActorCredentialInput {
   id?: string;
   actor: ScopedActorCredentialActor;
   issuer: ScopedActorCredentialIssuer;
+  grantId?: string;
   audience: string;
   capabilities: string[];
   scope: ScopedActorCredentialScope;
@@ -254,6 +257,7 @@ export class ScopedActorCredentialRegistry {
           ? { displayName: input.issuer.displayName }
           : {}),
       },
+      ...(input.grantId ? { grantId: input.grantId } : {}),
       audience,
       capabilities,
       scope,
@@ -261,6 +265,7 @@ export class ScopedActorCredentialRegistry {
       issuedAt: issuedAt.toISOString(),
       expiresAt: expiresAt.toISOString(),
       secretHash,
+      correlationId: input.correlationId ?? crypto.randomUUID(),
     };
     this.credentials.set(id, credential);
     this.recordAudit({
@@ -384,7 +389,10 @@ export class ScopedActorCredentialRegistry {
     if (!credential) return null;
     credential.revokedAt = this.now().toISOString();
     credential.revokedBy = input.revokedBy;
-    if (input.reason) credential.revocationReason = input.reason;
+    if (input.reason) {
+      const reason = redactString(input.reason);
+      if (reason) credential.revocationReason = reason;
+    }
     this.recordAudit({
       action: 'revoke',
       decision: 'revoked',
@@ -405,6 +413,11 @@ export class ScopedActorCredentialRegistry {
 
   listCredentials(): ScopedActorCredentialRecord[] {
     return Array.from(this.credentials.values()).map(publicCredential);
+  }
+
+  getCredential(credentialId: string): ScopedActorCredentialRecord | null {
+    const credential = this.credentials.get(credentialId);
+    return credential ? publicCredential(credential) : null;
   }
 
   listAuditEvents(): ScopedActorCredentialAuditEvent[] {
@@ -552,6 +565,7 @@ export function redactScopedActorCredentialForAudit(
     expiresAt: credential.expiresAt,
     ...(credential.revokedAt ? { revokedAt: credential.revokedAt } : {}),
     ...(credential.revokedBy ? { revokedBy: credential.revokedBy } : {}),
+    correlationId: credential.correlationId,
   };
 }
 

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -44,7 +44,7 @@ function approveGrant(
   id: string,
   options: {
     actor?: { type: string; id: string; displayName?: string };
-    scope?: typeof GRANT_SCOPE;
+    scope?: typeof GRANT_SCOPE | Record<string, string[]>;
   } = {}
 ): string {
   const grant = grants.request({
@@ -400,6 +400,96 @@ test('denies grant-backed CLI actor lifecycle expansion and lane-mixing attempts
       expect((error as CliGatewayActorGrantError).reason).toBe(reason);
     }
   }
+});
+
+test('rejects grant-backed lifecycle requests that expand multi-value scope dimensions', () => {
+  const scopedRegistry = registry();
+  const grants = grantRegistry();
+
+  const scopeExpansionCases = [
+    { key: 'nodeIds', allowed: 'node-1', denied: 'node-2', reason: 'wrong_node_scope' },
+    { key: 'sessionIds', allowed: 'session-1', denied: 'session-2', reason: 'wrong_session_scope' },
+    {
+      key: 'globalSessionIds',
+      allowed: 'global-session-1',
+      denied: 'global-session-2',
+      reason: 'wrong_global_session_scope',
+    },
+    {
+      key: 'workContextIds',
+      allowed: 'work-context-1',
+      denied: 'work-context-2',
+      reason: 'wrong_work_context_scope',
+    },
+    { key: 'repoIds', allowed: 'repo-1', denied: 'repo-2', reason: 'wrong_repo_scope' },
+    { key: 'pathPrefixes', allowed: '/allowed', denied: '/blocked', reason: 'wrong_path_scope' },
+    { key: 'taskRefs', allowed: CLI_GATEWAY_READ_SCOPE_TASK_REF, denied: 'task-other', reason: 'wrong_task_scope' },
+  ] as const;
+
+  for (const { key, allowed, denied, reason } of scopeExpansionCases) {
+    const handle = approveGrant(grants, `grant-expand-${key}`, {
+      scope: { [key]: [allowed], taskRefs: [CLI_GATEWAY_READ_SCOPE_TASK_REF] },
+    });
+
+    try {
+      issueCliGatewayActorCredentialWithGrant(scopedRegistry, grants, {
+        ...grantLifecycleInput(handle, `expand-${key}`),
+        scope: { [key]: [allowed, denied] },
+      });
+      throw new Error(`expected ${reason} for ${key}`);
+    } catch (error) {
+      expect(error).toBeInstanceOf(CliGatewayActorGrantError);
+      expect((error as CliGatewayActorGrantError).reason).toBe(reason);
+    }
+  }
+
+  expect(scopedRegistry.listCredentials()).toHaveLength(0);
+});
+
+test('denies mixed allowed and disallowed list scopes before exposing credentials', () => {
+  const scopedRegistry = registry();
+  const grants = grantRegistry();
+  const sessionOne = issueCliGatewayActorCredentialWithGrant(
+    scopedRegistry,
+    grants,
+    grantLifecycleInput(approveGrant(grants, 'grant-list-seed-session-1'), 'list-seed-session-1')
+  );
+  const sessionTwo = issueCliGatewayActorCredentialWithGrant(scopedRegistry, grants, {
+    ...grantLifecycleInput(
+      approveGrant(grants, 'grant-list-seed-session-2', {
+        scope: {
+          sessionIds: ['session-2'],
+          taskRefs: [CLI_GATEWAY_READ_SCOPE_TASK_REF],
+        },
+      }),
+      'list-seed-session-2'
+    ),
+    scope: { sessionIds: ['session-2'] },
+  });
+
+  const mixedHandle = approveGrant(grants, 'grant-list-mixed-session');
+  try {
+    listCliGatewayActorCredentialsWithGrant(scopedRegistry, grants, {
+      ...grantLifecycleInput(mixedHandle, 'list-mixed-session'),
+      scope: { sessionIds: ['session-1', 'session-2'] },
+    });
+    throw new Error('expected wrong_session_scope for mixed list scope');
+  } catch (error) {
+    expect(error).toBeInstanceOf(CliGatewayActorGrantError);
+    expect((error as CliGatewayActorGrantError).reason).toBe('wrong_session_scope');
+  }
+
+  const listed = listCliGatewayActorCredentialsWithGrant(
+    scopedRegistry,
+    grants,
+    grantLifecycleInput(mixedHandle, 'list-mixed-session-retry')
+  );
+  expect(listed.credentials.map((credential) => credential.id)).toEqual([
+    sessionOne.credential.id,
+  ]);
+  expect(listed.credentials.map((credential) => credential.id)).not.toContain(
+    sessionTwo.credential.id
+  );
 });
 
 test('denies revoked grant handles before minting actor credentials', () => {

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -4,11 +4,17 @@ import {
   CLI_GATEWAY_ACTOR_AUDIENCE,
   CLI_GATEWAY_ACTOR_READ_COMMANDS,
   CLI_GATEWAY_READ_SCOPE_TASK_REF,
+  CliGatewayActorGrantError,
   cliGatewayActorFailure,
   classifyCliGatewayCredentialLane,
   issueCliGatewayActorCredential,
+  issueCliGatewayActorCredentialWithGrant,
+  listCliGatewayActorCredentialsWithGrant,
+  revokeCliGatewayActorCredentialWithGrant,
+  rotateCliGatewayActorCredentialWithGrant,
   validateCliGatewayActorCredential,
 } from '../server/cli-gateway-actor-auth.js';
+import { HandshakeGrantRegistry } from '../shared/operator-handshake-grants.js';
 import { ScopedActorCredentialRegistry } from '../shared/scoped-actor-credentials.js';
 
 const NOW = new Date('2026-05-29T00:00:00.000Z');
@@ -18,6 +24,55 @@ function registry(): ScopedActorCredentialRegistry {
     now: () => NOW,
     secretBytes: () => Buffer.from('0123456789abcdef0123456789abcdef'),
   });
+}
+
+function grantRegistry(): HandshakeGrantRegistry {
+  return new HandshakeGrantRegistry({
+    now: () => NOW,
+    secretBytes: () => Buffer.from('abcdef0123456789abcdef0123456789'),
+  });
+}
+
+const GRANT_ACTOR = { type: 'cli', id: 'relay-cli-test' } as const;
+const GRANT_SCOPE = {
+  sessionIds: ['session-1'],
+  taskRefs: [CLI_GATEWAY_READ_SCOPE_TASK_REF],
+};
+
+function approveGrant(
+  grants: HandshakeGrantRegistry,
+  id: string,
+  options: {
+    actor?: { type: string; id: string; displayName?: string };
+    scope?: typeof GRANT_SCOPE;
+  } = {}
+): string {
+  const grant = grants.request({
+    id,
+    actor: options.actor ?? GRANT_ACTOR,
+    issuer: { id: 'browser-operator-test' },
+    audience: CLI_GATEWAY_ACTOR_AUDIENCE,
+    capabilities: ['session:read'],
+    scope: options.scope ?? GRANT_SCOPE,
+    ttlMs: 60_000,
+    correlationId: `${id}-request`,
+  });
+  return grants.approve(grant.id, {
+    approvedBy: { id: 'browser-operator-test' },
+    correlationId: `${id}-approve`,
+  }).handle;
+}
+
+function grantLifecycleInput(handle: string, id: string) {
+  return {
+    grantHandle: handle,
+    audience: CLI_GATEWAY_ACTOR_AUDIENCE,
+    actor: GRANT_ACTOR,
+    capabilities: ['session:read'],
+    scope: { sessionIds: ['session-1'] },
+    ttlMs: 60_000,
+    correlationId: `${id}-lifecycle`,
+  };
 }
 
 function req(input: {
@@ -186,4 +241,173 @@ test('returns stable typed denials without token material', () => {
     correlationId: 'corr-cli-deny',
   });
   expect(JSON.stringify(failure)).not.toContain('relay-sac-v1');
+});
+
+test('mints lists rotates and revokes CLI actor credentials with grant-backed lifecycle handles', () => {
+  const scopedRegistry = registry();
+  const grants = grantRegistry();
+
+  const mintHandle = approveGrant(grants, 'grant-mint');
+  const issued = issueCliGatewayActorCredentialWithGrant(
+    scopedRegistry,
+    grants,
+    grantLifecycleInput(mintHandle, 'mint')
+  );
+  expect(() =>
+    issueCliGatewayActorCredentialWithGrant(
+      scopedRegistry,
+      grants,
+      grantLifecycleInput(mintHandle, 'mint-replay')
+    )
+  ).toThrow(CliGatewayActorGrantError);
+  expect(scopedRegistry.listCredentials()).toHaveLength(1);
+
+  expect(issued.credential).toMatchObject({
+    grantId: 'grant-mint',
+    audience: CLI_GATEWAY_ACTOR_AUDIENCE,
+    capabilities: ['session:read'],
+    scope: {
+      sessionIds: ['session-1'],
+      taskRefs: [CLI_GATEWAY_READ_SCOPE_TASK_REF],
+    },
+    actor: GRANT_ACTOR,
+  });
+  expect(JSON.stringify(issued)).not.toContain('abcdef0123456789abcdef0123456789');
+
+  const validation = validateCliGatewayActorCredential(scopedRegistry, {
+    token: issued.token,
+    capabilities: ['session:read'],
+    scope: { sessionIds: ['session-1'] },
+    correlationId: 'mint-validate',
+  });
+  expect(validation).toMatchObject({ ok: true, grantedBits: ['session:read'] });
+  expect(
+    classifyCliGatewayCredentialLane(
+      req({
+        authorization: `Bearer ${issued.token}`,
+        actorMarker: 'v1',
+        command: 'sessions.list',
+        cookie: 'connect.sid=[REDACTED]',
+      }),
+      'sessions.list'
+    )
+  ).toBe('scoped-actor-credential');
+
+  const listed = listCliGatewayActorCredentialsWithGrant(
+    scopedRegistry,
+    grants,
+    grantLifecycleInput(approveGrant(grants, 'grant-list'), 'list')
+  );
+  expect(listed.credentials.map((credential) => credential.id)).toContain(
+    issued.credential.id
+  );
+
+  const rotated = rotateCliGatewayActorCredentialWithGrant(
+    scopedRegistry,
+    grants,
+    issued.credential.id,
+    grantLifecycleInput(approveGrant(grants, 'grant-rotate'), 'rotate')
+  );
+  expect(rotated.credential.id).not.toBe(issued.credential.id);
+  expect(rotated.credential.grantId).toBe('grant-rotate');
+  expect(rotated.revoked).toMatchObject({
+    id: issued.credential.id,
+    revokedBy: 'grant:grant-rotate',
+  });
+  expect(
+    validateCliGatewayActorCredential(scopedRegistry, {
+      token: issued.token,
+      capabilities: ['session:read'],
+      scope: { sessionIds: ['session-1'] },
+    })
+  ).toMatchObject({ ok: false, reason: 'revoked' });
+  expect(
+    validateCliGatewayActorCredential(scopedRegistry, {
+      token: rotated.token,
+      capabilities: ['session:read'],
+      scope: { sessionIds: ['session-1'] },
+    })
+  ).toMatchObject({ ok: true });
+
+  const revoked = revokeCliGatewayActorCredentialWithGrant(
+    scopedRegistry,
+    grants,
+    rotated.credential.id,
+    {
+      ...grantLifecycleInput(approveGrant(grants, 'grant-revoke'), 'revoke'),
+      metadata: { reason: 'rotating bearer relay-sac-v1.supersecretcredentialmaterial' },
+    }
+  );
+  expect(revoked).toMatchObject({
+    id: rotated.credential.id,
+    revokedBy: 'grant:grant-revoke',
+  });
+  expect(revoked.revocationReason).toContain('[REDACTED]');
+  expect(revoked.revocationReason).not.toContain('supersecretcredentialmaterial');
+});
+
+test('denies grant-backed CLI actor lifecycle expansion and lane-mixing attempts', () => {
+  const scopedRegistry = registry();
+  const grants = grantRegistry();
+  const handle = approveGrant(grants, 'grant-deny');
+
+  expect(() =>
+    issueCliGatewayActorCredentialWithGrant(scopedRegistry, grants, {
+      ...grantLifecycleInput(handle, 'deny'),
+      grantHandle: 'relay-sac-v1.credential-id.secret',
+    })
+  ).toThrow(CliGatewayActorGrantError);
+
+  const denialCases = [
+    [{ audience: 'relay:operator-handshake:v1' }, 'audience_expansion'],
+    [{ capabilities: ['session:create:agent'] }, 'capability_expansion'],
+    [{ capabilities: ['definitely:not-a-capability'] }, 'unknown_capability'],
+    [{ capabilities: ['*'] }, 'capability_expansion'],
+    [{ scope: {} }, 'scope_required'],
+    [{ actor: { type: 'cli', id: 'other-cli' } }, 'actor_mismatch'],
+  ] as const;
+  for (let index = 0; index < denialCases.length; index += 1) {
+    const [override, reason] = denialCases[index];
+    const freshHandle = approveGrant(grants, `grant-deny-${index}-${reason}`);
+    try {
+      issueCliGatewayActorCredentialWithGrant(scopedRegistry, grants, {
+        ...grantLifecycleInput(freshHandle, `deny-${reason}`),
+        ...override,
+      });
+      throw new Error(`expected ${reason} denial`);
+    } catch (error) {
+      expect(error).toBeInstanceOf(CliGatewayActorGrantError);
+      expect((error as CliGatewayActorGrantError).reason).toBe(reason);
+    }
+  }
+});
+
+test('denies revoked grant handles before minting actor credentials', () => {
+  const scopedRegistry = registry();
+  const grants = grantRegistry();
+  const grant = grants.request({
+    id: 'grant-revoked-before-mint',
+    actor: GRANT_ACTOR,
+    issuer: { id: 'browser-operator-test' },
+    audience: CLI_GATEWAY_ACTOR_AUDIENCE,
+    capabilities: ['session:read'],
+    scope: GRANT_SCOPE,
+    ttlMs: 60_000,
+  });
+  const handle = grants.approve(grant.id, {
+    approvedBy: { id: 'browser-operator-test' },
+  }).handle;
+  grants.revoke(grant.id, {
+    revokedBy: { id: 'browser-operator-test' },
+    reason: 'operator cancelled bearer relay-ohg-v1.secretmaterial',
+  });
+
+  expect(() =>
+    issueCliGatewayActorCredentialWithGrant(
+      scopedRegistry,
+      grants,
+      grantLifecycleInput(handle, 'revoked')
+    )
+  ).toThrow(CliGatewayActorGrantError);
+  expect(scopedRegistry.listCredentials()).toHaveLength(0);
 });

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -293,13 +293,33 @@ test('mints lists rotates and revokes CLI actor credentials with grant-backed li
     )
   ).toBe('scoped-actor-credential');
 
+  const otherActor = { type: 'cli', id: 'other-cli' };
+  const otherScope = {
+    sessionIds: ['session-2'],
+    taskRefs: [CLI_GATEWAY_READ_SCOPE_TASK_REF],
+  };
+  const otherIssued = issueCliGatewayActorCredentialWithGrant(scopedRegistry, grants, {
+    ...grantLifecycleInput(
+      approveGrant(grants, 'grant-mint-other', {
+        actor: otherActor,
+        scope: otherScope,
+      }),
+      'mint-other'
+    ),
+    actor: otherActor,
+    scope: otherScope,
+  });
+
   const listed = listCliGatewayActorCredentialsWithGrant(
     scopedRegistry,
     grants,
     grantLifecycleInput(approveGrant(grants, 'grant-list'), 'list')
   );
-  expect(listed.credentials.map((credential) => credential.id)).toContain(
-    issued.credential.id
+  expect(listed.credentials.map((credential) => credential.id)).toEqual([
+    issued.credential.id,
+  ]);
+  expect(listed.credentials.map((credential) => credential.id)).not.toContain(
+    otherIssued.credential.id
   );
 
   const rotated = rotateCliGatewayActorCredentialWithGrant(

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -75,6 +75,19 @@ function grantLifecycleInput(handle: string, id: string) {
   };
 }
 
+function expectGrantError(
+  run: () => unknown,
+  reason: CliGatewayActorGrantError['reason']
+): void {
+  try {
+    run();
+    throw new Error(`expected ${reason} denial`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(CliGatewayActorGrantError);
+    expect((error as CliGatewayActorGrantError).reason).toBe(reason);
+  }
+}
+
 function req(input: {
   method?: string;
   authorization?: string;
@@ -431,19 +444,115 @@ test('rejects grant-backed lifecycle requests that expand multi-value scope dime
       scope: { [key]: [allowed], taskRefs: [CLI_GATEWAY_READ_SCOPE_TASK_REF] },
     });
 
-    try {
-      issueCliGatewayActorCredentialWithGrant(scopedRegistry, grants, {
-        ...grantLifecycleInput(handle, `expand-${key}`),
-        scope: { [key]: [allowed, denied] },
-      });
-      throw new Error(`expected ${reason} for ${key}`);
-    } catch (error) {
-      expect(error).toBeInstanceOf(CliGatewayActorGrantError);
-      expect((error as CliGatewayActorGrantError).reason).toBe(reason);
-    }
+    expectGrantError(
+      () =>
+        issueCliGatewayActorCredentialWithGrant(scopedRegistry, grants, {
+          ...grantLifecycleInput(handle, `expand-${key}`),
+          scope: { [key]: [allowed, denied] },
+        }),
+      reason
+    );
   }
 
   expect(scopedRegistry.listCredentials()).toHaveLength(0);
+});
+
+test('rejects request-only lifecycle scope dimensions absent from the approved grant', () => {
+  const scopedRegistry = registry();
+  const grants = grantRegistry();
+  const requestOnlyNodeScope = {
+    sessionIds: ['session-1'],
+    nodeIds: ['node-evil'],
+  };
+
+  expectGrantError(
+    () =>
+      issueCliGatewayActorCredentialWithGrant(scopedRegistry, grants, {
+        ...grantLifecycleInput(approveGrant(grants, 'grant-mint-request-only-node'), 'mint-request-only-node'),
+        scope: requestOnlyNodeScope,
+      }),
+    'wrong_node_scope'
+  );
+  expect(scopedRegistry.listCredentials()).toHaveLength(0);
+
+  const allowedCredential = issueCliGatewayActorCredentialWithGrant(scopedRegistry, grants, {
+    ...grantLifecycleInput(
+      approveGrant(grants, 'grant-mint-node-bound', {
+        scope: {
+          sessionIds: ['session-1'],
+          nodeIds: ['node-allowed'],
+          taskRefs: [CLI_GATEWAY_READ_SCOPE_TASK_REF],
+        },
+      }),
+      'mint-node-bound'
+    ),
+    scope: { sessionIds: ['session-1'], nodeIds: ['node-allowed'] },
+  });
+
+  expectGrantError(
+    () =>
+      listCliGatewayActorCredentialsWithGrant(scopedRegistry, grants, {
+        ...grantLifecycleInput(approveGrant(grants, 'grant-list-request-only-node'), 'list-request-only-node'),
+        scope: requestOnlyNodeScope,
+      }),
+    'wrong_node_scope'
+  );
+
+  expectGrantError(
+    () =>
+      rotateCliGatewayActorCredentialWithGrant(
+        scopedRegistry,
+        grants,
+        allowedCredential.credential.id,
+        grantLifecycleInput(approveGrant(grants, 'grant-rotate-request-only-node'), 'rotate-request-only-node')
+      ),
+    'wrong_node_scope'
+  );
+
+  expectGrantError(
+    () =>
+      revokeCliGatewayActorCredentialWithGrant(
+        scopedRegistry,
+        grants,
+        allowedCredential.credential.id,
+        grantLifecycleInput(approveGrant(grants, 'grant-revoke-request-only-node'), 'revoke-request-only-node')
+      ),
+    'wrong_node_scope'
+  );
+
+  expect(scopedRegistry.getCredential(allowedCredential.credential.id)).not.toHaveProperty(
+    'revokedAt'
+  );
+});
+
+test('allows only the default CLI gateway taskRef when the grant omits task scope', () => {
+  const scopedRegistry = registry();
+  const grants = grantRegistry();
+
+  const issued = issueCliGatewayActorCredentialWithGrant(scopedRegistry, grants, {
+    ...grantLifecycleInput(
+      approveGrant(grants, 'grant-default-taskref', {
+        scope: { sessionIds: ['session-1'] },
+      }),
+      'default-taskref'
+    ),
+    scope: { sessionIds: ['session-1'] },
+  });
+  expect(issued.credential.scope.taskRefs).toEqual([CLI_GATEWAY_READ_SCOPE_TASK_REF]);
+
+  expectGrantError(
+    () =>
+      issueCliGatewayActorCredentialWithGrant(scopedRegistry, grants, {
+        ...grantLifecycleInput(
+          approveGrant(grants, 'grant-request-only-taskref', {
+            scope: { sessionIds: ['session-1'] },
+          }),
+          'request-only-taskref'
+        ),
+        scope: { sessionIds: ['session-1'], taskRefs: ['relay:other-task'] },
+      }),
+    'wrong_task_scope'
+  );
 });
 
 test('denies mixed allowed and disallowed list scopes before exposing credentials', () => {


### PR DESCRIPTION
## Summary

- add grant-backed scoped actor credential lifecycle wiring for the CLI gateway lane
- mint/list/revoke/rotate scoped actor credentials from bounded one-time operator handshake grants
- preserve lane separation: no browser cookie/PIN, node credential, pair token, or actor token fallback as the grant authority
- document the grant-backed CLI gateway lifecycle and add targeted coverage

Closes #815
Refs #812

## Verification

Worker-reported evidence from branch `feat/815-grant-backed-actor-credentials` at `6a8360f5b1a333914935543ffead88609c17816a`:

- `git diff --check` — pass
- `npm test -- test/cli-gateway-actor-auth.test.ts test/scoped-actor-credentials.test.ts test/operator-handshake-grants.test.ts` — pass, 53/53
- `npm run check` — pass with existing lint warnings only, 112 warnings / 0 errors
- `npm run build` — pass
- server smoke on `127.0.0.1:3467`: minted scoped actor credential; `relay-ide v1 nodes list` accepted `--actor-token` with bogus browser token present; direct HTTP actor lane ignored bogus cookie fallback

## Notes

The handshake grant registry remains in-memory in this slice, matching the current #813 foundation. Grant-backed lifecycle consumes each handle once; if credential issuance fails after successful consumption, the grant is intentionally not reusable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Handshake-grant support for CLI gateway credential lifecycles: issue, list, revoke, and rotate.
  * New POST endpoints for revoke and rotate; rotate issues a new token and returns { token, credential, revoked }.

* **Behavior Changes**
  * Endpoints accept unauthenticated grant-backed requests alongside existing browser auth; lifecycle actions require handshake-backed validation and stable denial codes.
  * Credentials now carry correlation IDs; revocation reasons redact sensitive material.

* **Documentation**
  * CLI docs updated with handshake-backed examples and end-to-end flows.

* **Tests**
  * Expanded grant-backed lifecycle test coverage and denial scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->