### PR TITLE
feat: add grant-backed pair-token minting

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -12,6 +12,10 @@ import { createLogger } from '../server/logger.js';
 import { getNodeManifest } from '../server/node-manifest.js';
 import { redactBootstrapSecrets } from '../shared/bootstrap-diagnostics.js';
 import {
+  NODE_PAIR_TOKEN_CREATE_CAPABILITY,
+  NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE,
+} from '../shared/operator-handshake-grants.js';
+import {
   RELAY_NODE_LINK_PROTOCOL_VERSION,
   type HubNodeSummary,
 } from '../shared/relay-node-protocol.js';
@@ -109,6 +113,8 @@ Commands:
     doctor [--hub <url>] [--json]      Diagnose local node health and hub reachability; surfaces all degraded reasons
     pair --hub <url> --pair-token <token>
                                        Exchange a pair token with a hub and send one heartbeat (pair-only, no service)
+    mint-pair-token --hub <url> --operator-grant <handle> [--display-name <name>] [--platform <name>] [--task-ref <ref>] [--json]
+                                       Mint a short-lived node pair token through the scoped operator-grant lane
     install --hub <url> [--service auto|manual|launchd|systemd-user|wsl-systemd|wsl-manual]
                                        Install relay-ide globally via npm and optionally set up the local service (no pairing)
     connect --hub <url> --pair-token <token>
@@ -3686,6 +3692,111 @@ async function runNodeUpdate(nodeArgs: string[]): Promise<void> {
   restartServiceAfterUpdate();
 }
 
+function optionalNodeJsonNumber(nodeArgs: string[], flag: string): number | undefined {
+  const value = getNodeArg(nodeArgs, flag);
+  if (!value) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    logger.error(`${flag} must be a positive number`);
+    process.exit(1);
+  }
+  return parsed;
+}
+
+function optionalNodeArgBody(
+  body: Record<string, unknown>,
+  key: string,
+  value: string | undefined
+): void {
+  if (value && value.trim()) body[key] = value.trim();
+}
+
+async function runNodeMintPairToken(nodeArgs: string[]): Promise<void> {
+  const hubUrl = getNodeArg(nodeArgs, '--hub');
+  const operatorGrant =
+    getNodeArg(nodeArgs, '--operator-grant') ??
+    getNodeArg(nodeArgs, '--handshake-grant') ??
+    process.env['RELAY_IDE_OPERATOR_GRANT'];
+  if (!hubUrl || !operatorGrant) {
+    logger.error(
+      'Usage: relay-ide node mint-pair-token --hub <url> --operator-grant <handle> [--display-name <name>] [--platform <name>] [--task-ref <ref>] [--json]'
+    );
+    logger.error(
+      `Requires a previously approved ${NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE} grant with ${NODE_PAIR_TOKEN_CREATE_CAPABILITY}; browser cookies/PIN and node credentials are not accepted for this automation lane.`
+    );
+    process.exit(1);
+  }
+  try {
+    new URL(hubUrl);
+  } catch {
+    logger.error(`invalid --hub url: ${hubUrl}`);
+    process.exit(1);
+  }
+  const actorType = getNodeArg(nodeArgs, '--actor-type') ?? 'cli';
+  const actorId =
+    getNodeArg(nodeArgs, '--actor-id') ??
+    process.env['RELAY_IDE_ACTOR_ID'] ??
+    process.env['USER'] ??
+    'relay-ide-cli';
+  const body: Record<string, unknown> = {};
+  optionalNodeArgBody(body, 'displayName', getNodeArg(nodeArgs, '--display-name'));
+  optionalNodeArgBody(body, 'platform', getNodeArg(nodeArgs, '--platform'));
+  optionalNodeArgBody(body, 'taskRef', getNodeArg(nodeArgs, '--task-ref'));
+  optionalNodeArgBody(body, 'correlationId', getNodeArg(nodeArgs, '--correlation-id'));
+  optionalNodeArgBody(body, 'trustTier', getNodeArg(nodeArgs, '--trust-tier'));
+  const ttlSeconds = optionalNodeJsonNumber(nodeArgs, '--ttl-seconds');
+  if (ttlSeconds !== undefined) body['ttlSeconds'] = ttlSeconds;
+  body['actor'] = {
+    type: actorType,
+    id: actorId,
+    ...(getNodeArg(nodeArgs, '--actor-display-name')
+      ? { displayName: getNodeArg(nodeArgs, '--actor-display-name') }
+      : {}),
+  };
+  const res = await fetch(nodeEndpoint(hubUrl, '/hub/pair-tokens'), {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-relay-operator-grant': operatorGrant,
+      'x-relay-actor-type': actorType,
+      'x-relay-actor-id': actorId,
+      ...(getNodeArg(nodeArgs, '--correlation-id')
+        ? { 'x-relay-correlation-id': getNodeArg(nodeArgs, '--correlation-id')! }
+        : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  const responseText = await res.text();
+  let response: unknown;
+  try {
+    response = responseText ? JSON.parse(responseText) : {};
+  } catch {
+    response = { raw: responseText };
+  }
+  if (!res.ok) {
+    const message =
+      typeof response === 'object' && response !== null
+        ? ((response as { error?: { code?: string; message?: string } }).error?.message ??
+          responseText)
+        : responseText;
+    logger.error(redactBootstrapSecrets(`PAIR_TOKEN_MINT_FAILED: ${message}`));
+    process.exit(1);
+  }
+  if (nodeArgs.includes('--json')) {
+    console.log(redactBootstrapSecrets(JSON.stringify(response, null, 2)));
+    return;
+  }
+  const record = response as { pairToken?: string; tokenId?: string; expiresAt?: string };
+  if (!record.pairToken) {
+    logger.error('PAIR_TOKEN_MINT_FAILED: hub response did not include pairToken');
+    process.exit(1);
+  }
+  console.log(record.pairToken);
+  if (record.expiresAt) {
+    logger.info(`pair token expires at ${record.expiresAt} and is one-time use`);
+  }
+}
+
 /**
  * Generate and print a paste-able bash script that installs relay-ide and
  * pairs the node with the given hub on a remote machine reached via SSH.
@@ -3738,9 +3849,9 @@ async function runNodeSshBootstrap(nodeArgs: string[]): Promise<void> {
   console.log(`# relay-ide ssh bootstrap — generated for ${target}`);
   console.log(`# hub: ${hubUrl}`);
   console.log(`#`);
-  console.log(`# 1. get a pair token from your hub:`);
+  console.log(`# 1. get a pair token from your hub with an approved operator grant:`);
   console.log(
-    `#    curl -X POST ${hubUrl}/hub/pair-tokens -H 'Content-Type: application/json' -b 'token=<browser-session-cookie>' -d '{"displayName":"<name>","ttlSeconds":600}'`
+    `#    relay-ide node mint-pair-token --hub ${hubUrl} --operator-grant <relay-ohg-v1...> --display-name <name> --ttl-seconds 600`
   );
   console.log(`# 2. set PAIR_TOKEN and run the command below:`);
   console.log(`#    PAIR_TOKEN=pair_... ${scriptWithVar}`);
@@ -4083,6 +4194,10 @@ if (command === 'node') {
   // relay-ide node pair --hub <url> --pair-token <token>
   // Productized pair-only command. The existing 'connect' subcommand is kept
   // as a back-compat alias. Both call pairNode() under the hood.
+  if (subCommand === 'mint-pair-token') {
+    await runNodeMintPairToken(nodeArgs);
+    process.exit(0);
+  }
   if (subCommand === 'pair') {
     const pairToken = getNodeArg(nodeArgs, '--pair-token');
     const hubUrl = getNodeArg(nodeArgs, '--hub');
@@ -4091,14 +4206,14 @@ if (command === 'node') {
         'Usage: relay-ide node pair --hub <url> --pair-token <token>'
       );
       logger.error(
-        'Get a pair token from your hub: POST /hub/pair-tokens with {"displayName":"<name>","ttlSeconds":600}'
+        'Get a pair token from your hub with an approved operator grant: relay-ide node mint-pair-token --hub <url> --operator-grant <relay-ohg-v1...>'
       );
       process.exit(1);
     }
     if (!pairToken) {
       logger.info(`to get a pair token from your hub, run:`);
       logger.info(
-        `  curl -X POST ${hubUrl}/hub/pair-tokens -H 'Content-Type: application/json' -b 'token=<browser-session-cookie>' -d '{"displayName":"<name>","ttlSeconds":600}'`
+        `  relay-ide node mint-pair-token --hub ${hubUrl} --operator-grant <relay-ohg-v1...> --display-name <name> --ttl-seconds 600`
       );
       logger.info(
         `then re-run: relay-ide node pair --hub ${hubUrl} --pair-token <token>`
@@ -4157,7 +4272,7 @@ if (command === 'node') {
     }
   }
   logger.error(
-    'Usage: relay-ide node <status|logs|doctor|pair|install|ssh-bootstrap|connect|link|update>'
+    'Usage: relay-ide node <status|logs|doctor|pair|mint-pair-token|install|ssh-bootstrap|connect|link|update>'
   );
   process.exit(1);
 }

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -3737,6 +3737,7 @@ async function runNodeMintPairToken(nodeArgs: string[]): Promise<void> {
     getNodeArg(nodeArgs, '--actor-id') ??
     process.env['RELAY_IDE_ACTOR_ID'] ??
     process.env['USER'] ??
+    process.env['USERNAME'] ??
     'relay-ide-cli';
   const body: Record<string, unknown> = {};
   optionalNodeArgBody(body, 'displayName', getNodeArg(nodeArgs, '--display-name'));

--- a/docs/OPERATOR_HANDSHAKE_GRANTS.md
+++ b/docs/OPERATOR_HANDSHAKE_GRANTS.md
@@ -8,7 +8,7 @@ Operator approval surfaces should say all of this before approval:
 
 - What is delegated: the exact Relay capability bits, such as `session:read` or `logs:read`.
 - Who receives it: actor type and actor id/display name.
-- Audience: the expected grant audience, currently `relay:operator-handshake:v1`.
+- Audience: the expected grant audience, for example `relay:operator-handshake:v1` for generic ceremony handoffs or `relay:node-pair-token:v1` for node pair-token minting.
 - TTL: the grant expiry timestamp; the default foundation TTL is 10 minutes and the maximum is 30 minutes.
 - Scope: node/session/global-session/work-context/repo/path/task dimensions.
 - Bindings: optional device id hash and session binding.
@@ -30,6 +30,18 @@ The browser session may authorize the approval ceremony, but the returned `relay
 | `relay-sac-v1...` scoped actor token | No                                                     | Separate scoped actor credential lane.                              |
 | Pair token                           | No                                                     | Node bootstrap only.                                                |
 | Node credential                      | No                                                     | Node heartbeat/link only.                                           |
+
+## Node pair-token minting grant
+
+The node bootstrap automation lane uses a dedicated audience and capability:
+
+- Audience: `relay:node-pair-token:v1`
+- Capability: `node:pair-token:create`
+- Mint endpoint: `POST /hub/pair-tokens` with `X-Relay-Operator-Grant: <relay-ohg-v1...>` plus safe context in the JSON body (`displayName`, `platform`, `ttlSeconds`, `trustTier`, `capabilityEnvelope`, `taskRef` or session/work-context bindings, actor summary, and correlation id).
+
+The browser/PIN session may authorize creating or approving a grant, and may remain as a human fallback pair-token creation path, but it is not accepted as the automation grant. Scoped actor tokens, node credentials, existing pair tokens, and bearer headers from other lanes fail closed instead of minting node pair tokens.
+
+Successful mint validation consumes the operator grant and creates a separate short-lived pair token. That pair token is still one-time bootstrap material accepted only by `POST /hub/pairing/exchange`; it does not become a browser session, scoped actor credential, node credential, or reusable grant.
 
 ## Validation failure contract
 

--- a/docs/RELAY_NODE_BOOTSTRAP.md
+++ b/docs/RELAY_NODE_BOOTSTRAP.md
@@ -20,6 +20,7 @@ Relay uses SSH and Tailscale SSH only for bootstrap, reachability checks, diagno
 | -------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | Install relay-ide binary on node | `relay-ide node install --hub <url> [--service <mode>]`                                                  |
 | Pair node with hub (pair-only)   | `relay-ide node pair --hub <url> --pair-token <token>`                                                   |
+| Mint pair token from grant       | `relay-ide node mint-pair-token --hub <url> --operator-grant <relay-ohg-v1...> --display-name <name>`     |
 | Pair node (back-compat alias)    | `relay-ide node connect --hub <url> --pair-token <token>`                                                |
 | Generate SSH bootstrap script    | `relay-ide node ssh-bootstrap --target <host> --hub <url>`                                               |
 | Hold reverse node link           | `relay-ide node link --hub <url>`                                                                        |
@@ -56,20 +57,36 @@ Supported `--service` values:
 | `manual`       | Any                  | Binary only; no background service                                |
 | `auto`         | Any                  | Detects platform and chooses the best supported mode              |
 
-### Step 2: Generate a pair token from the hub
+### Step 2: Mint a pair token from the hub
 
-An authenticated hub user creates a short-lived, one-time token:
+Automation should mint a short-lived, one-time token through a previously approved operator handshake grant. The grant must use audience `relay:node-pair-token:v1`, include capability `node:pair-token:create`, and match the safe scope fields supplied with the mint request (for example `taskRef`, session/work-context binding, device id, or actor id). Browser cookies/PIN state, scoped actor tokens, node credentials, and existing pair tokens are not accepted on this automation lane.
+
+```bash
+relay-ide node mint-pair-token \
+  --hub https://hub.example.com \
+  --operator-grant <relay-ohg-v1...> \
+  --display-name dev-macbook \
+  --platform macos \
+  --task-ref bootstrap-work-mac \
+  --ttl-seconds 600
+```
+
+Equivalent API call:
 
 ```bash
 curl -X POST https://hub.example.com/hub/pair-tokens \
   -H "Content-Type: application/json" \
-  -b "token=<browser-session-cookie>" \
-  -d '{"displayName":"dev-macbook","ttlSeconds":600}'
+  -H "X-Relay-Operator-Grant: <relay-ohg-v1...>" \
+  -H "X-Relay-Actor-Type: cli" \
+  -H "X-Relay-Actor-Id: ebi-cli" \
+  -d '{"displayName":"dev-macbook","platform":"macos","taskRef":"bootstrap-work-mac","ttlSeconds":600,"trustTier":"sandbox"}'
 ```
 
-Response includes `pairToken` and suggested bootstrap commands for each supported service mode.
+Response includes `pairToken` and suggested bootstrap commands for each supported service mode. The grant is consumed on successful mint. The pair token remains separate bootstrap material and is accepted only by `POST /hub/pairing/exchange`.
 
-Auth lane boundary: the browser-session cookie only authorizes the operator to create a short-lived pair token from the hub UI/API. The pair token is accepted only by `POST /hub/pairing/exchange`, and the resulting `node-credential.json` is accepted only by node heartbeat and `/hub/node-link`. A browser PIN/cookie is not a node credential, and a node credential does not log in to browser-only routes. Processes already running as the same OS user may still read local Relay state or run local CLIs, so the PIN should be described as browser/UI auth, not as a same-user process boundary.
+Human fallback: an authenticated browser/PIN session may still create a pair token through the hub UI/API for manual operation. Treat that as a separate operator path, not as a reusable automation grant. Do not scrape or borrow browser cookies for Ebi/Hermes/CLI automation.
+
+Auth lane boundary: the operator grant only authorizes minting this one pair token. The pair token is accepted only by `POST /hub/pairing/exchange`, and the resulting `node-credential.json` is accepted only by node heartbeat and `/hub/node-link`. A browser PIN/cookie is not a node credential, and a node credential does not log in to browser-only routes. Processes already running as the same OS user may still read local Relay state or run local CLIs, so the PIN should be described as browser/UI auth, not as a same-user process boundary.
 
 ### Step 3: Pair the node
 

--- a/server/hub-node-registry.ts
+++ b/server/hub-node-registry.ts
@@ -34,12 +34,16 @@ import {
 import { classifyHelperSkew } from './node-version-skew.js';
 import {
   RELAY_SECURITY_POLICY_VERSION,
+  applyTrustTierOverlay,
   createLegacyDefaultNodeAcl,
   isRelayCapabilityBit,
   isRelayTrustTier,
+  normalizeCapabilityBits,
   normalizeNodeAcl,
   summarizeAcl,
+  type RelayCapabilityBit,
   type RelayNodeAcl,
+  type RelayTrustTier,
 } from '../shared/security-policy.js';
 import type {
   SecurityAuditDecision,
@@ -51,10 +55,25 @@ const logger = createLogger('hub-node-registry');
 const REVERSE_LINK_ROUTE = 'reverse-link' as const;
 const UNKNOWN_CAPABILITY_STATUS = 'unknown' as const;
 
+interface StoredPairTokenIssuer {
+  grantId?: string;
+  actorType?: string;
+  actorDisplayName?: string;
+  actorIdHash?: string;
+}
+
 interface StoredPairToken {
   tokenId: string;
   tokenHash: string;
   displayName?: string;
+  platform?: string;
+  trustTier?: RelayTrustTier;
+  allowedCapabilities?: RelayCapabilityBit[];
+  requiresConfirmationCapabilities?: RelayCapabilityBit[];
+  issuer?: StoredPairTokenIssuer;
+  correlationId?: string;
+  mintSourceFingerprint?: string;
+  mintSourceDiagnostics?: RelayNodeSourceDiagnostics;
   createdAt: string;
   expiresAt: string;
   usedAt?: string;
@@ -139,6 +158,18 @@ interface RegistryFile {
   schemaVersion: 1;
   pairTokens: StoredPairToken[];
   nodes: StoredNodeRecord[];
+}
+
+export interface PairTokenMintIssuer {
+  grantId?: string;
+  actorType?: string;
+  actorDisplayName?: string;
+  actorId?: string;
+}
+
+export interface PairTokenCapabilityEnvelope {
+  allowed?: RelayCapabilityBit[];
+  requiresConfirmation?: RelayCapabilityBit[];
 }
 
 export interface PairTokenResponse {
@@ -656,6 +687,42 @@ function updateAclCredential(
   };
 }
 
+
+function createNodeAclForPairToken(input: {
+  pairToken: StoredPairToken;
+  nodeId: string;
+  credentialId: string;
+  displayName: string;
+  createdAt: string;
+}): RelayNodeAcl {
+  const base = createLegacyDefaultNodeAcl({
+    nodeId: input.nodeId,
+    credentialId: input.credentialId,
+    displayName: input.displayName,
+    trustTier: input.pairToken.trustTier ?? 'dev',
+    createdAt: input.createdAt,
+  });
+  const allowed = normalizeCapabilityBits(input.pairToken.allowedCapabilities);
+  const requiresConfirmation = normalizeCapabilityBits(
+    input.pairToken.requiresConfirmationCapabilities
+  );
+  const nodeAllowed = allowed.filter(
+    (capability) => capability !== 'node:pair-token:create'
+  );
+  const nodeRequiresConfirmation = requiresConfirmation.filter(
+    (capability) => capability !== 'node:pair-token:create'
+  );
+  if (nodeAllowed.length === 0 && nodeRequiresConfirmation.length === 0)
+    return base;
+  return applyTrustTierOverlay({
+    ...base,
+    grants: {
+      allowed: nodeAllowed.length > 0 ? nodeAllowed : base.grants.allowed,
+      requiresConfirmation: nodeRequiresConfirmation,
+    },
+  });
+}
+
 function credentialToken(nodeId: string): {
   token: string;
   credentialId: string;
@@ -829,6 +896,12 @@ export class HubNodeRegistry {
   createPairToken(options: {
     displayName?: string;
     ttlMs?: number;
+    platform?: string;
+    trustTier?: RelayTrustTier;
+    capabilityEnvelope?: PairTokenCapabilityEnvelope;
+    issuer?: PairTokenMintIssuer;
+    correlationId?: string;
+    source?: RelayNodeSourceTuple;
   }): PairTokenResponse {
     const createdAt = this.now();
     const expiresAt = new Date(
@@ -836,14 +909,78 @@ export class HubNodeRegistry {
     );
     const pairToken = randomToken('pair');
     const tokenId = randomToken('pt');
-    this.state.pairTokens.push({
+    const tokenHash = sha256(pairToken);
+    const mintSource = sourceTupleWithHostname(options.source, undefined);
+    const mintSourceFingerprint = mintSource
+      ? sourceFingerprint(mintSource, tokenHash)
+      : undefined;
+    const mintSourceDiagnostics = mintSource
+      ? {
+          state: hasTailscaleSourceSignal(mintSource)
+            ? ('source-match' as const)
+            : ('signal-unavailable' as const),
+          policy: 'audit' as const,
+          reasonCode: hasTailscaleSourceSignal(mintSource)
+            ? 'PAIR_TOKEN_MINT_SOURCE_RECORDED'
+            : 'PAIR_TOKEN_MINT_SOURCE_SIGNAL_UNAVAILABLE',
+          observedAt: createdAt.toISOString(),
+          ...(mintSourceFingerprint
+            ? { sourceFingerprint: mintSourceFingerprint }
+            : {}),
+          displayHint: sourceDisplayHint(mintSource, mintSourceFingerprint),
+        }
+      : undefined;
+    const allowedCapabilities = normalizeCapabilityBits(
+      options.capabilityEnvelope?.allowed
+    );
+    const requiresConfirmationCapabilities = normalizeCapabilityBits(
+      options.capabilityEnvelope?.requiresConfirmation
+    );
+    const storedPairToken: StoredPairToken = {
       tokenId,
-      tokenHash: sha256(pairToken),
+      tokenHash,
       ...(options.displayName ? { displayName: options.displayName } : {}),
+      ...(options.platform ? { platform: options.platform } : {}),
+      ...(options.trustTier ? { trustTier: options.trustTier } : {}),
+      ...(allowedCapabilities.length > 0 ? { allowedCapabilities } : {}),
+      ...(requiresConfirmationCapabilities.length > 0
+        ? { requiresConfirmationCapabilities }
+        : {}),
+      ...(options.issuer
+        ? {
+            issuer: {
+              ...(options.issuer.grantId ? { grantId: options.issuer.grantId } : {}),
+              ...(options.issuer.actorType
+                ? { actorType: options.issuer.actorType }
+                : {}),
+              ...(options.issuer.actorDisplayName
+                ? { actorDisplayName: options.issuer.actorDisplayName }
+                : {}),
+              ...(options.issuer.actorId
+                ? { actorIdHash: sha256(options.issuer.actorId) }
+                : {}),
+            },
+          }
+        : {}),
+      ...(options.correlationId ? { correlationId: options.correlationId } : {}),
+      ...(mintSourceFingerprint ? { mintSourceFingerprint } : {}),
+      ...(mintSourceDiagnostics ? { mintSourceDiagnostics } : {}),
       createdAt: createdAt.toISOString(),
       expiresAt: expiresAt.toISOString(),
-    });
+    };
+    this.state.pairTokens.push(storedPairToken);
     this.persist();
+    this.auditPairTokenLifecycle({
+      pairToken: storedPairToken,
+      decision: 'allow',
+      eventType: 'grant',
+      reasonCode: 'PAIR_TOKEN_MINTED',
+      action: 'nodes.pair-token.create',
+      grantedBits: ['node:pair-token:create'],
+      ...(mintSourceDiagnostics
+        ? { sourceDiagnostics: mintSourceDiagnostics }
+        : {}),
+    });
     return {
       tokenId,
       pairToken,
@@ -863,20 +1000,46 @@ export class HubNodeRegistry {
       timingSafeEqualHex(candidate.tokenHash, tokenHash)
     );
     if (!pairToken) {
+      this.auditPairTokenLifecycle({
+        decision: 'deny',
+        eventType: 'denial',
+        reasonCode: 'PAIR_TOKEN_NOT_FOUND',
+        action: 'nodes.pair-token.redeem',
+      });
       throw new HubNodeRegistryError(
         'UNAUTHORIZED',
-        'pair token was not found'
+        'pair token was not found',
+        false,
+        { reasonCode: 'PAIR_TOKEN_NOT_FOUND' }
       );
     }
     if (pairToken.usedAt) {
+      this.auditPairTokenLifecycle({
+        pairToken,
+        decision: 'deny',
+        eventType: 'failed_redemption',
+        reasonCode: 'PAIR_TOKEN_REUSE_DENIED',
+        action: 'nodes.pair-token.redeem',
+      });
       throw new HubNodeRegistryError(
         'TOKEN_ALREADY_USED',
-        'pair token has already been used'
+        'pair token has already been used',
+        false,
+        { reasonCode: 'PAIR_TOKEN_REUSE_DENIED' }
       );
     }
     const now = this.now();
     if (Date.parse(pairToken.expiresAt) <= now.getTime()) {
-      throw new HubNodeRegistryError('TOKEN_EXPIRED', 'pair token expired');
+      this.auditPairTokenLifecycle({
+        pairToken,
+        decision: 'expired',
+        eventType: 'expiry',
+        reasonCode: 'PAIR_TOKEN_EXPIRED',
+        action: 'nodes.pair-token.redeem',
+      });
+      throw new HubNodeRegistryError('TOKEN_EXPIRED', 'pair token expired', false, {
+        reasonCode: 'PAIR_TOKEN_EXPIRED',
+      });
     }
 
     const nodeId = randomToken('node');
@@ -893,6 +1056,37 @@ export class HubNodeRegistry {
     const pairedSourceFingerprint = pairedSource
       ? sourceFingerprint(pairedSource, credential.hash)
       : undefined;
+    const pairTokenRedeemSourceFingerprint = pairedSource
+      ? sourceFingerprint(pairedSource, pairToken.tokenHash)
+      : undefined;
+    if (
+      pairToken.mintSourceFingerprint &&
+      pairTokenRedeemSourceFingerprint &&
+      pairToken.mintSourceFingerprint !== pairTokenRedeemSourceFingerprint
+    ) {
+      this.auditPairTokenLifecycle({
+        pairToken,
+        decision: 'recorded',
+        eventType: 'bridge_event',
+        reasonCode: 'PAIR_TOKEN_SOURCE_MISMATCH_RECORDED',
+        action: 'nodes.pair-token.source-check',
+        sourceDiagnostics: {
+          state: 'source-mismatch',
+          policy: 'audit',
+          reasonCode: 'PAIR_TOKEN_SOURCE_MISMATCH',
+          observedAt: timestamp,
+          sourceFingerprint: pairTokenRedeemSourceFingerprint,
+          displayHint: sourceDisplayHint(pairedSource, pairTokenRedeemSourceFingerprint),
+        },
+      });
+    }
+    const nodeAcl = createNodeAclForPairToken({
+      pairToken,
+      nodeId,
+      credentialId: credential.credentialId,
+      displayName,
+      createdAt: timestamp,
+    });
     const node: StoredNodeRecord = {
       nodeId,
       identity: {
@@ -923,12 +1117,7 @@ export class HubNodeRegistry {
         ? { fileRpcAvailable: input.manifest.fileRpc.available }
         : {}),
       degradedReasons: input.manifest.degradedReasons ?? [],
-      acl: createLegacyDefaultNodeAcl({
-        nodeId,
-        credentialId: credential.credentialId,
-        displayName,
-        createdAt: timestamp,
-      }),
+      acl: nodeAcl,
       credentialIssuedAt: timestamp,
       ...(pairedSource
         ? {
@@ -962,6 +1151,17 @@ export class HubNodeRegistry {
     pairToken.usedAt = timestamp;
     this.state.nodes.push(node);
     this.persist();
+    this.auditPairTokenLifecycle({
+      pairToken,
+      decision: 'allow',
+      eventType: 'grant',
+      reasonCode: 'PAIR_TOKEN_REDEEMED',
+      action: 'nodes.pair-token.redeem',
+      grantedBits: nodeAcl.grants.allowed,
+      ...(node.sourceBinding?.diagnostics
+        ? { sourceDiagnostics: node.sourceBinding.diagnostics }
+        : {}),
+    });
     this.auditNodeCredentialLifecycle({
       node,
       credentialId: credential.credentialId,
@@ -1069,6 +1269,71 @@ export class HubNodeRegistry {
         ...(sourceDiagnostics ? { sourceDiagnostics } : {}),
       },
     };
+  }
+
+  // eslint-disable-next-line complexity -- lifecycle audit payload is intentionally explicit so sensitive pair-token/grant material never gets serialized accidentally.
+  private auditPairTokenLifecycle(input: {
+    pairToken?: StoredPairToken;
+    decision: SecurityAuditDecision;
+    eventType: SecurityAuditEventType;
+    reasonCode: string;
+    action: string;
+    grantedBits?: RelayCapabilityBit[];
+    deniedBits?: RelayCapabilityBit[];
+    sourceDiagnostics?: RelayNodeSourceDiagnostics;
+  }): void {
+    if (!this.auditSink) return;
+    const pairToken = input.pairToken;
+    try {
+      this.auditSink.append({
+        eventType: input.eventType,
+        decision: input.decision,
+        reasonCode: input.reasonCode,
+        peer: {
+          kind: pairToken?.issuer ? 'system' : 'hub',
+          ...(pairToken?.tokenId ? { credentialId: pairToken.tokenId } : {}),
+          ...(pairToken?.issuer?.actorDisplayName
+            ? { displayName: pairToken.issuer.actorDisplayName }
+            : {}),
+          ...(pairToken?.issuer?.actorIdHash
+            ? { principalHash: pairToken.issuer.actorIdHash }
+            : {}),
+        },
+        intent: {
+          action: input.action,
+          ...(pairToken?.tokenId ? { target: pairToken.tokenId } : {}),
+        },
+        material: {
+          params: {
+            reasonCode: input.reasonCode,
+            tokenId: pairToken?.tokenId ?? null,
+            displayName: pairToken?.displayName ?? null,
+            platform: pairToken?.platform ?? null,
+            expiresAt: pairToken?.expiresAt ?? null,
+            trustTier: pairToken?.trustTier ?? null,
+            issuerGrantId: pairToken?.issuer?.grantId ?? null,
+            sourceState: input.sourceDiagnostics?.state ?? null,
+          },
+          scope: {
+            allowedCapabilities: pairToken?.allowedCapabilities ?? [],
+            requiresConfirmationCapabilities:
+              pairToken?.requiresConfirmationCapabilities ?? [],
+          },
+        },
+        grantedBits: input.grantedBits ?? [],
+        deniedBits: input.deniedBits ?? [],
+        refs: { policyVersion: RELAY_SECURITY_POLICY_VERSION },
+        ...(input.sourceDiagnostics
+          ? { sourceDiagnostics: input.sourceDiagnostics }
+          : {}),
+        ...(pairToken?.correlationId
+          ? { correlationId: pairToken.correlationId }
+          : {}),
+      });
+    } catch {
+      // Best-effort pair-token lifecycle visibility only. Never retry or log
+      // raw bootstrap/grant material if the audit sink fails.
+    }
   }
 
   private auditNodeCredentialLifecycle(input: {

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -2034,16 +2034,32 @@ function pairTokenMintScope(
 
 type CapabilityListParseResult =
   | { ok: true; capabilities: RelayCapabilityBit[] }
-  | { ok: false; invalidCapability: string };
+  | {
+      ok: false;
+      reasonCode: string;
+      message: string;
+      invalidCapability?: string;
+    };
 
 function parseCapabilityList(value: unknown): CapabilityListParseResult {
   if (value === undefined) return { ok: true, capabilities: [] };
-  if (!Array.isArray(value)) return { ok: true, capabilities: [] };
+  if (!Array.isArray(value)) {
+    return {
+      ok: false,
+      reasonCode: 'PAIR_TOKEN_CAPABILITY_LIST_INVALID',
+      message: 'pair token capability lists must be arrays',
+    };
+  }
   const capabilities: RelayCapabilityBit[] = [];
   const seen = new Set<RelayCapabilityBit>();
   for (const candidate of value) {
     if (!isRelayCapabilityBit(candidate)) {
-      return { ok: false, invalidCapability: String(candidate) };
+      return {
+        ok: false,
+        reasonCode: 'PAIR_TOKEN_CAPABILITY_UNKNOWN',
+        message: 'unknown pair token capability requested',
+        invalidCapability: String(candidate),
+      };
     }
     if (candidate === NODE_PAIR_TOKEN_CREATE_CAPABILITY) continue;
     if (!seen.has(candidate)) {
@@ -2061,7 +2077,7 @@ function pairTokenCapabilityEnvelopeFromBody(
       ok: true;
       envelope?: { allowed?: RelayCapabilityBit[]; requiresConfirmation?: RelayCapabilityBit[] };
     }
-  | { ok: false; invalidCapability: string } {
+  | { ok: false; reasonCode: string; message: string; invalidCapability?: string } {
   const rawEnvelope = body['capabilityEnvelope'];
   const envelope =
     typeof rawEnvelope === 'object' && rawEnvelope !== null && !Array.isArray(rawEnvelope)
@@ -2391,9 +2407,21 @@ export function createHubNodeRouter(
       );
       return;
     }
-    const device = recordFromBody(body, 'device') as
-      | { id: string; displayName?: string }
-      | undefined;
+    const deviceRecord = recordFromBody(body, 'device');
+    const deviceId = requiredStringFromRecord(deviceRecord, 'id');
+    if (deviceRecord && !deviceId) {
+      sendRelayError(
+        res,
+        relayError('INVALID_REQUEST', 'device.id is required when device is supplied', false, {
+          reasonCode: 'HANDSHAKE_GRANT_DEVICE_INVALID',
+        })
+      );
+      return;
+    }
+    const deviceDisplayName = requiredStringFromRecord(deviceRecord, 'displayName');
+    const device = deviceId
+      ? { id: deviceId, ...(deviceDisplayName ? { displayName: deviceDisplayName } : {}) }
+      : undefined;
     const sessionBinding = pairTokenMintSessionBinding(body);
     const metadata = recordFromBody(body, 'metadata');
     const expiresAt = typeof body['expiresAt'] === 'string' ? body['expiresAt'] : undefined;
@@ -2508,9 +2536,11 @@ export function createHubNodeRouter(
     if (capabilityEnvelope.ok === false) {
       sendRelayError(
         res,
-        relayError('INVALID_REQUEST', 'unknown pair token capability requested', false, {
-          reasonCode: 'PAIR_TOKEN_CAPABILITY_UNKNOWN',
-          capability: capabilityEnvelope.invalidCapability,
+        relayError('INVALID_REQUEST', capabilityEnvelope.message, false, {
+          reasonCode: capabilityEnvelope.reasonCode,
+          ...(capabilityEnvelope.invalidCapability
+            ? { capability: capabilityEnvelope.invalidCapability }
+            : {}),
         })
       );
       return;
@@ -2559,17 +2589,23 @@ export function createHubNodeRouter(
     });
   }
 
-  router.post('/hub/pair-tokens', (req, res, next) => {
+  router.post('/hub/pair-tokens', (req, res) => {
     const body = bodyRecord(req);
     const grantHandle = pairTokenMintGrantHandle(req, body);
     if (!grantHandle) {
-      requireAuth(req, res, (error?: unknown) => {
-        if (error) {
-          next(error);
-          return;
-        }
-        sendMintedPairToken({ req, res, body });
-      });
+      sendRelayError(
+        res,
+        relayError(
+          'UNAUTHORIZED',
+          'operator handshake grant is required to mint pair tokens',
+          false,
+          {
+            reasonCode: 'PAIR_TOKEN_GRANT_REQUIRED',
+            acceptedLanes: ['operator-handshake-grant'],
+            rejectedLanes: ['browser-session', 'node-credential'],
+          }
+        )
+      );
       return;
     }
 

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -21,6 +21,7 @@ import type { SecurityAuditVerificationResult } from './security-audit-log.js';
 import {
   HubNodeRegistryError,
   type HubNodeRegistry,
+  type PairTokenCapabilityEnvelope,
 } from './hub-node-registry.js';
 import {
   RELAY_NODE_LINK_PROTOCOL_VERSION,
@@ -2105,6 +2106,27 @@ function pairTokenCapabilityEnvelopeFromBody(
   };
 }
 
+function pairTokenCapabilityEnvelopeCapabilities(
+  envelope: PairTokenCapabilityEnvelope | undefined
+): RelayCapabilityBit[] {
+  const capabilities = new Set<RelayCapabilityBit>();
+  for (const capability of envelope?.allowed ?? []) capabilities.add(capability);
+  for (const capability of envelope?.requiresConfirmation ?? []) {
+    capabilities.add(capability);
+  }
+  return Array.from(capabilities);
+}
+
+function boundedGrantBackedPairTokenTrustTier(
+  trustTier: RelayTrustTier | undefined
+): RelayTrustTier | undefined {
+  // A pair-token-create grant derives the legacy dev bootstrap posture. The
+  // request may voluntarily narrow that to sandbox, but it cannot promote a
+  // grant-backed mint into a body-chosen prod node unless a future grant schema
+  // carries an explicit trust-tier bound.
+  return trustTier === 'sandbox' ? trustTier : undefined;
+}
+
 function pairTokenTrustTierFromBody(
   body: Record<string, unknown>
 ): { ok: true; trustTier?: RelayTrustTier } | { ok: false; value: string } {
@@ -2516,35 +2538,13 @@ export function createHubNodeRouter(
     req: Request;
     res: Response;
     body: Record<string, unknown>;
+    trustTier?: RelayTrustTier;
+    capabilityEnvelope?: PairTokenCapabilityEnvelope;
     grant?: ReturnType<HandshakeGrantRegistry['getGrant']>;
   }): void {
     const { req, res, body, grant } = input;
     const displayName = stringFromBody(body, 'displayName');
     const ttlMs = pairTtlMs(body);
-    const trustTier = pairTokenTrustTierFromBody(body);
-    if (trustTier.ok === false) {
-      sendRelayError(
-        res,
-        relayError('INVALID_REQUEST', 'trustTier must be sandbox, dev, or prod', false, {
-          reasonCode: 'PAIR_TOKEN_TRUST_TIER_INVALID',
-          trustTier: trustTier.value,
-        })
-      );
-      return;
-    }
-    const capabilityEnvelope = pairTokenCapabilityEnvelopeFromBody(body);
-    if (capabilityEnvelope.ok === false) {
-      sendRelayError(
-        res,
-        relayError('INVALID_REQUEST', capabilityEnvelope.message, false, {
-          reasonCode: capabilityEnvelope.reasonCode,
-          ...(capabilityEnvelope.invalidCapability
-            ? { capability: capabilityEnvelope.invalidCapability }
-            : {}),
-        })
-      );
-      return;
-    }
     const correlationId = pairTokenMintCorrelationId(req, body, grant?.correlationId);
     const source = sourceTupleFromRequest(req);
     const platform = stringFromBody(body, 'platform');
@@ -2552,10 +2552,8 @@ export function createHubNodeRouter(
       ...(displayName ? { displayName } : {}),
       ...(ttlMs !== undefined ? { ttlMs } : {}),
       ...(platform ? { platform } : {}),
-      ...(trustTier.trustTier ? { trustTier: trustTier.trustTier } : {}),
-      ...(capabilityEnvelope.envelope
-        ? { capabilityEnvelope: capabilityEnvelope.envelope }
-        : {}),
+      ...(input.trustTier ? { trustTier: input.trustTier } : {}),
+      ...(input.capabilityEnvelope ? { capabilityEnvelope: input.capabilityEnvelope } : {}),
       ...(grant
         ? {
             issuer: {
@@ -2614,9 +2612,36 @@ export function createHubNodeRouter(
     const deviceId = stringFromBody(body, 'deviceId');
     const sessionBinding = pairTokenMintSessionBinding(body);
     const scope = pairTokenMintScope(body);
+    const trustTier = pairTokenTrustTierFromBody(body);
+    if (trustTier.ok === false) {
+      sendRelayError(
+        res,
+        relayError('INVALID_REQUEST', 'trustTier must be sandbox, dev, or prod', false, {
+          reasonCode: 'PAIR_TOKEN_TRUST_TIER_INVALID',
+          trustTier: trustTier.value,
+        })
+      );
+      return;
+    }
+    const capabilityEnvelope = pairTokenCapabilityEnvelopeFromBody(body);
+    if (capabilityEnvelope.ok === false) {
+      sendRelayError(
+        res,
+        relayError('INVALID_REQUEST', capabilityEnvelope.message, false, {
+          reasonCode: capabilityEnvelope.reasonCode,
+          ...(capabilityEnvelope.invalidCapability
+            ? { capability: capabilityEnvelope.invalidCapability }
+            : {}),
+        })
+      );
+      return;
+    }
     const validation = operatorHandshakeGrants.validate(grantHandle, {
       audience: NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE,
-      requiredCapabilities: [NODE_PAIR_TOKEN_CREATE_CAPABILITY],
+      requiredCapabilities: [
+        NODE_PAIR_TOKEN_CREATE_CAPABILITY,
+        ...pairTokenCapabilityEnvelopeCapabilities(capabilityEnvelope.envelope),
+      ],
       ...(actor ? { actor } : {}),
       ...(deviceId ? { deviceId } : {}),
       ...(sessionBinding ? { sessionBinding } : {}),
@@ -2636,7 +2661,17 @@ export function createHubNodeRouter(
       sendRelayError(res, relayErrorForPairTokenGrantFailure(failure));
       return;
     }
-    sendMintedPairToken({ req, res, body, grant: validation.grant });
+    const boundedTrustTier = boundedGrantBackedPairTokenTrustTier(trustTier.trustTier);
+    sendMintedPairToken({
+      req,
+      res,
+      body,
+      ...(boundedTrustTier ? { trustTier: boundedTrustTier } : {}),
+      ...(capabilityEnvelope.envelope
+        ? { capabilityEnvelope: capabilityEnvelope.envelope }
+        : {}),
+      grant: validation.grant,
+    });
   });
 
   router.post('/hub/pairing/exchange', (req, res) => {

--- a/server/hub-node-router.ts
+++ b/server/hub-node-router.ts
@@ -93,6 +93,24 @@ import type {
   HighRiskApprovalTarget,
 } from './high-risk-approvals.js';
 import { sourceTupleFromRequest } from './node-source-diagnostics.js';
+import {
+  HandshakeGrantRegistryError,
+  HandshakeGrantRegistry,
+  NODE_PAIR_TOKEN_CREATE_CAPABILITY,
+  NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE,
+  type HandshakeGrantActor,
+  type HandshakeGrantScope,
+  type HandshakeGrantSessionBinding,
+  type HandshakeGrantValidationFailureReason,
+  type HandshakeGrantValidationScope,
+} from '../shared/operator-handshake-grants.js';
+import {
+  isRelayCapabilityBit,
+  isRelayTrustTier,
+  normalizeCapabilityBits,
+  type RelayCapabilityBit,
+  type RelayTrustTier,
+} from '../shared/security-policy.js';
 
 const FILE_RPC_FOLLOW_STREAM_BUFFER_BYTES = 256 * 1024;
 
@@ -147,6 +165,7 @@ interface HubNodeRouterOptions {
     now?: Date;
   }) => ReturnType<InMemorySessionEnvelopeRegistry['renew']>;
   confirmations?: ConfirmationChallengeStore;
+  operatorHandshakeGrants?: HandshakeGrantRegistry;
   auditSink?: RoutedSessionAuditSink;
   workContextStore?: WorkContextStore;
   readModelCache?: RoutedSessionReadModelCache;
@@ -1904,6 +1923,323 @@ function hubUrlFromRequest(
   return `${proto}://${host}`;
 }
 
+function pairTokenMintGrantHandle(
+  req: Request,
+  body: Record<string, unknown>
+): string | undefined {
+  const header =
+    req.header('x-relay-operator-grant') ??
+    req.header('x-relay-handshake-grant') ??
+    req.header('x-relay-pair-token-grant');
+  if (header?.trim()) return header.trim();
+  for (const key of ['operatorGrant', 'handshakeGrant', 'grantHandle']) {
+    const value = body[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function pairTokenMintCorrelationId(
+  req: Request,
+  body: Record<string, unknown>,
+  fallback?: string
+): string | undefined {
+  return (
+    stringFromBody(body, 'correlationId') ??
+    req.header('x-relay-correlation-id')?.trim() ??
+    fallback
+  );
+}
+
+function pairTokenMintActor(
+  req: Request,
+  body: Record<string, unknown>
+): HandshakeGrantActor | undefined {
+  const actor = body['actor'];
+  if (typeof actor === 'object' && actor !== null && !Array.isArray(actor)) {
+    const candidate = actor as Record<string, unknown>;
+    if (typeof candidate['type'] === 'string' && typeof candidate['id'] === 'string') {
+      return {
+        type: candidate['type'],
+        id: candidate['id'],
+        ...(typeof candidate['displayName'] === 'string'
+          ? { displayName: candidate['displayName'] }
+          : {}),
+      };
+    }
+  }
+  const actorType = stringFromBody(body, 'actorType') ?? req.header('x-relay-actor-type')?.trim();
+  const actorId = stringFromBody(body, 'actorId') ?? req.header('x-relay-actor-id')?.trim();
+  if (!actorType || !actorId) return undefined;
+  const actorDisplayName =
+    stringFromBody(body, 'actorDisplayName') ??
+    req.header('x-relay-actor-display-name')?.trim();
+  return {
+    type: actorType,
+    id: actorId,
+    ...(actorDisplayName ? { displayName: actorDisplayName } : {}),
+  };
+}
+
+function pairTokenMintSessionBinding(
+  body: Record<string, unknown>
+): HandshakeGrantSessionBinding | undefined {
+  const binding = body['sessionBinding'];
+  const record =
+    typeof binding === 'object' && binding !== null && !Array.isArray(binding)
+      ? (binding as Record<string, unknown>)
+      : body;
+  const normalized: HandshakeGrantSessionBinding = {
+    ...(typeof record['sessionId'] === 'string'
+      ? { sessionId: record['sessionId'] }
+      : {}),
+    ...(typeof record['globalSessionId'] === 'string'
+      ? { globalSessionId: record['globalSessionId'] }
+      : {}),
+    ...(typeof record['workContextId'] === 'string'
+      ? { workContextId: record['workContextId'] }
+      : {}),
+    ...(typeof record['authSessionHash'] === 'string'
+      ? { authSessionHash: record['authSessionHash'] }
+      : {}),
+  };
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function pairTokenMintScope(
+  body: Record<string, unknown>
+): HandshakeGrantValidationScope | undefined {
+  const scope = body['scope'];
+  const record =
+    typeof scope === 'object' && scope !== null && !Array.isArray(scope)
+      ? (scope as Record<string, unknown>)
+      : body;
+  const normalized: HandshakeGrantValidationScope = {
+    ...(typeof record['nodeId'] === 'string' ? { nodeId: record['nodeId'] } : {}),
+    ...(typeof record['sessionId'] === 'string'
+      ? { sessionId: record['sessionId'] }
+      : {}),
+    ...(typeof record['globalSessionId'] === 'string'
+      ? { globalSessionId: record['globalSessionId'] }
+      : {}),
+    ...(typeof record['workContextId'] === 'string'
+      ? { workContextId: record['workContextId'] }
+      : {}),
+    ...(typeof record['repoId'] === 'string' ? { repoId: record['repoId'] } : {}),
+    ...(typeof record['path'] === 'string' ? { path: record['path'] } : {}),
+    ...(typeof record['taskRef'] === 'string' ? { taskRef: record['taskRef'] } : {}),
+  };
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+type CapabilityListParseResult =
+  | { ok: true; capabilities: RelayCapabilityBit[] }
+  | { ok: false; invalidCapability: string };
+
+function parseCapabilityList(value: unknown): CapabilityListParseResult {
+  if (value === undefined) return { ok: true, capabilities: [] };
+  if (!Array.isArray(value)) return { ok: true, capabilities: [] };
+  const capabilities: RelayCapabilityBit[] = [];
+  const seen = new Set<RelayCapabilityBit>();
+  for (const candidate of value) {
+    if (!isRelayCapabilityBit(candidate)) {
+      return { ok: false, invalidCapability: String(candidate) };
+    }
+    if (candidate === NODE_PAIR_TOKEN_CREATE_CAPABILITY) continue;
+    if (!seen.has(candidate)) {
+      seen.add(candidate);
+      capabilities.push(candidate);
+    }
+  }
+  return { ok: true, capabilities };
+}
+
+function pairTokenCapabilityEnvelopeFromBody(
+  body: Record<string, unknown>
+):
+  | {
+      ok: true;
+      envelope?: { allowed?: RelayCapabilityBit[]; requiresConfirmation?: RelayCapabilityBit[] };
+    }
+  | { ok: false; invalidCapability: string } {
+  const rawEnvelope = body['capabilityEnvelope'];
+  const envelope =
+    typeof rawEnvelope === 'object' && rawEnvelope !== null && !Array.isArray(rawEnvelope)
+      ? (rawEnvelope as Record<string, unknown>)
+      : {};
+  const allowed = parseCapabilityList(
+    envelope['allowed'] ?? body['allowedCapabilities'] ?? body['capabilities']
+  );
+  if (!allowed.ok) return allowed;
+  const requiresConfirmation = parseCapabilityList(
+    envelope['requiresConfirmation'] ?? body['requiresConfirmationCapabilities']
+  );
+  if (!requiresConfirmation.ok) return requiresConfirmation;
+  if (allowed.capabilities.length === 0 && requiresConfirmation.capabilities.length === 0) {
+    return { ok: true };
+  }
+  return {
+    ok: true,
+    envelope: {
+      ...(allowed.capabilities.length > 0 ? { allowed: allowed.capabilities } : {}),
+      ...(requiresConfirmation.capabilities.length > 0
+        ? { requiresConfirmation: requiresConfirmation.capabilities }
+        : {}),
+    },
+  };
+}
+
+function pairTokenTrustTierFromBody(
+  body: Record<string, unknown>
+): { ok: true; trustTier?: RelayTrustTier } | { ok: false; value: string } {
+  const value = body['trustTier'];
+  if (value === undefined) return { ok: true };
+  if (isRelayTrustTier(value)) return { ok: true, trustTier: value };
+  return { ok: false, value: String(value) };
+}
+
+function pairTokenGrantReasonCode(
+  reason: HandshakeGrantValidationFailureReason
+): string {
+  return `PAIR_TOKEN_GRANT_${reason.toUpperCase()}`;
+}
+
+function relayErrorForPairTokenGrantFailure(input: {
+  reason: HandshakeGrantValidationFailureReason;
+  grantId?: string;
+  deniedBits: string[];
+}): RelayNodeError {
+  const reasonCode = pairTokenGrantReasonCode(input.reason);
+  const details = {
+    reasonCode,
+    ...(input.grantId ? { grantId: input.grantId } : {}),
+    deniedBits: input.deniedBits,
+  };
+  switch (input.reason) {
+    case 'expired':
+      return relayError('TOKEN_EXPIRED', 'operator handshake grant expired', false, details);
+    case 'replayed':
+      return relayError('TOKEN_ALREADY_USED', 'operator handshake grant was already consumed', false, details);
+    case 'wrong_audience':
+    case 'insufficient_capability':
+    case 'missing_scope':
+    case 'wrong_node_scope':
+    case 'wrong_session_scope':
+    case 'wrong_global_session_scope':
+    case 'wrong_work_context_scope':
+    case 'wrong_repo_scope':
+    case 'wrong_path_scope':
+    case 'wrong_task_scope':
+      return relayError('FORBIDDEN', 'operator handshake grant cannot mint pair tokens for this request', false, details);
+    default:
+      return relayError('UNAUTHORIZED', 'valid operator handshake grant is required to mint a pair token', false, details);
+  }
+}
+
+function appendPairTokenGrantAudit(
+  auditSink: RoutedSessionAuditSink | undefined,
+  input: {
+    reason: HandshakeGrantValidationFailureReason;
+    decision: 'deny' | 'expired';
+    grantId?: string;
+    deniedBits: string[];
+    correlationId?: string;
+  }
+): void {
+  if (!auditSink) return;
+  const deniedBits = normalizeCapabilityBits(input.deniedBits);
+  try {
+    auditSink.append({
+      eventType: input.reason === 'replayed' ? 'failed_redemption' : input.reason === 'expired' ? 'expiry' : 'denial',
+      decision: input.decision,
+      reasonCode: pairTokenGrantReasonCode(input.reason),
+      peer: { kind: 'system', ...(input.grantId ? { credentialId: input.grantId } : {}) },
+      intent: { action: 'nodes.pair-token.create' },
+      material: {
+        params: { reason: input.reason, grantId: input.grantId ?? null },
+        scope: { audience: NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE },
+      },
+      requiredBits: [NODE_PAIR_TOKEN_CREATE_CAPABILITY],
+      deniedBits,
+      refs: { policyVersion: '1.0' },
+      ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+    });
+  } catch {
+    // Denial path only; never leak grant material while trying to report audit failures.
+  }
+}
+
+function recordFromBody(
+  body: Record<string, unknown>,
+  key: string
+): Record<string, unknown> | undefined {
+  const value = body[key];
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function requiredStringFromRecord(
+  record: Record<string, unknown> | undefined,
+  key: string
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function handshakeGrantIssuerFromBody(
+  body: Record<string, unknown>,
+  key: 'issuer' | 'approvedBy' | 'deniedBy' | 'revokedBy',
+  fallbackId: string
+): { id: string; displayName?: string } {
+  const record = recordFromBody(body, key);
+  const id =
+    requiredStringFromRecord(record, 'id') ??
+    (typeof body[key] === 'string' && body[key].trim()
+      ? body[key].trim()
+      : fallbackId);
+  const displayName = requiredStringFromRecord(record, 'displayName');
+  return { id, ...(displayName ? { displayName } : {}) };
+}
+
+function handshakeGrantActorFromBody(
+  body: Record<string, unknown>
+): HandshakeGrantActor | null {
+  const actor = recordFromBody(body, 'actor');
+  const type = requiredStringFromRecord(actor, 'type');
+  const id = requiredStringFromRecord(actor, 'id');
+  if (!type || !id) return null;
+  const displayName = requiredStringFromRecord(actor, 'displayName');
+  return { type, id, ...(displayName ? { displayName } : {}) };
+}
+
+function handshakeGrantCapabilitiesFromBody(
+  body: Record<string, unknown>
+): string[] | null {
+  const value = body['capabilities'];
+  if (!Array.isArray(value)) return null;
+  const capabilities = value.filter(
+    (capability): capability is string =>
+      typeof capability === 'string' && capability.trim().length > 0
+  );
+  return capabilities.length > 0 ? capabilities : null;
+}
+
+function handshakeGrantScopeFromBody(
+  body: Record<string, unknown>
+): HandshakeGrantScope | null {
+  const scope = recordFromBody(body, 'scope');
+  return scope ? (scope as HandshakeGrantScope) : null;
+}
+
+function relayErrorForHandshakeGrantRegistryError(
+  error: HandshakeGrantRegistryError
+): RelayNodeError {
+  return relayError('INVALID_REQUEST', error.message, false, {
+    reasonCode: `HANDSHAKE_GRANT_${error.code.toUpperCase()}`,
+  });
+}
+
 export function createHubNodeRouter(
   options: HubNodeRouterOptions
 ): express.Router {
@@ -1917,6 +2253,8 @@ export function createHubNodeRouter(
   const confirmations =
     options.confirmations ?? createConfirmationChallengeStore();
   const now = () => options.now?.() ?? new Date();
+  const operatorHandshakeGrants =
+    options.operatorHandshakeGrants ?? new HandshakeGrantRegistry({ now });
   const repoInventoryFeature =
     options.repoInventoryFeature ?? createRepoInventoryFeature(registry);
 
@@ -2031,14 +2369,177 @@ export function createHubNodeRouter(
     }
   );
 
-  router.post('/hub/pair-tokens', requireAuth, (req, res) => {
+  router.get('/hub/operator-handshake-grants', requireAuth, (_req, res) => {
+    res.json({ grants: operatorHandshakeGrants.listGrants() });
+  });
+
+  router.post('/hub/operator-handshake-grants', requireAuth, (req, res) => {
     const body = bodyRecord(req);
-    const displayName =
-      typeof body['displayName'] === 'string' ? body['displayName'] : undefined;
+    const actor = handshakeGrantActorFromBody(body);
+    const audience = stringFromBody(body, 'audience');
+    const capabilities = handshakeGrantCapabilitiesFromBody(body);
+    const scope = handshakeGrantScopeFromBody(body);
+    if (!actor || !audience || !capabilities || !scope) {
+      sendRelayError(
+        res,
+        relayError(
+          'INVALID_REQUEST',
+          'actor, audience, capabilities, and scope are required',
+          false,
+          { reasonCode: 'HANDSHAKE_GRANT_REQUEST_INVALID' }
+        )
+      );
+      return;
+    }
+    const device = recordFromBody(body, 'device') as
+      | { id: string; displayName?: string }
+      | undefined;
+    const sessionBinding = pairTokenMintSessionBinding(body);
+    const metadata = recordFromBody(body, 'metadata');
+    const expiresAt = typeof body['expiresAt'] === 'string' ? body['expiresAt'] : undefined;
+    const ttlMs = typeof body['ttlMs'] === 'number' ? body['ttlMs'] : undefined;
+    const correlationId = pairTokenMintCorrelationId(req, body);
+    try {
+      const grant = operatorHandshakeGrants.request({
+        actor,
+        issuer: handshakeGrantIssuerFromBody(body, 'issuer', 'browser-operator'),
+        audience,
+        capabilities,
+        scope,
+        ...(device ? { device } : {}),
+        ...(sessionBinding ? { sessionBinding } : {}),
+        ...(metadata ? { metadata: metadata as never } : {}),
+        ...(expiresAt ? { expiresAt } : {}),
+        ...(ttlMs !== undefined ? { ttlMs } : {}),
+        ...(correlationId ? { correlationId } : {}),
+      });
+      res.status(201).json({ grant });
+    } catch (error) {
+      if (error instanceof HandshakeGrantRegistryError) {
+        sendRelayError(res, relayErrorForHandshakeGrantRegistryError(error));
+        return;
+      }
+      throw error;
+    }
+  });
+
+  router.post('/hub/operator-handshake-grants/:grantId/approve', requireAuth, (req, res) => {
+    const body = bodyRecord(req);
+    const grantId = req.params.grantId;
+    if (!grantId) {
+      sendRelayError(
+        res,
+        relayError('INVALID_REQUEST', 'grant id is required', false, {
+          reasonCode: 'HANDSHAKE_GRANT_ID_REQUIRED',
+        })
+      );
+      return;
+    }
+    const highRiskApproval = recordFromBody(body, 'highRiskApproval');
+    const correlationId = pairTokenMintCorrelationId(req, body);
+    try {
+      const approved = operatorHandshakeGrants.approve(grantId, {
+        approvedBy: handshakeGrantIssuerFromBody(body, 'approvedBy', 'browser-operator'),
+        ...(highRiskApproval ? { highRiskApproval: highRiskApproval as never } : {}),
+        ...(correlationId ? { correlationId } : {}),
+      });
+      res.json(approved);
+    } catch (error) {
+      if (error instanceof HandshakeGrantRegistryError) {
+        sendRelayError(res, relayErrorForHandshakeGrantRegistryError(error));
+        return;
+      }
+      throw error;
+    }
+  });
+
+  router.post('/hub/operator-handshake-grants/:grantId/revoke', requireAuth, (req, res) => {
+    const body = bodyRecord(req);
+    const grantId = req.params.grantId;
+    if (!grantId) {
+      sendRelayError(
+        res,
+        relayError('INVALID_REQUEST', 'grant id is required', false, {
+          reasonCode: 'HANDSHAKE_GRANT_ID_REQUIRED',
+        })
+      );
+      return;
+    }
+    const reason = typeof body['reason'] === 'string' ? body['reason'] : undefined;
+    const correlationId = pairTokenMintCorrelationId(req, body);
+    const grant = operatorHandshakeGrants.revoke(grantId, {
+      revokedBy: handshakeGrantIssuerFromBody(body, 'revokedBy', 'browser-operator'),
+      ...(reason ? { reason } : {}),
+      ...(correlationId ? { correlationId } : {}),
+    });
+    if (!grant) {
+      sendRelayError(
+        res,
+        relayError('NOT_FOUND', 'operator handshake grant not found', false, {
+          reasonCode: 'HANDSHAKE_GRANT_NOT_FOUND',
+        })
+      );
+      return;
+    }
+    res.json({ grant });
+  });
+
+  function sendMintedPairToken(input: {
+    req: Request;
+    res: Response;
+    body: Record<string, unknown>;
+    grant?: ReturnType<HandshakeGrantRegistry['getGrant']>;
+  }): void {
+    const { req, res, body, grant } = input;
+    const displayName = stringFromBody(body, 'displayName');
     const ttlMs = pairTtlMs(body);
+    const trustTier = pairTokenTrustTierFromBody(body);
+    if (trustTier.ok === false) {
+      sendRelayError(
+        res,
+        relayError('INVALID_REQUEST', 'trustTier must be sandbox, dev, or prod', false, {
+          reasonCode: 'PAIR_TOKEN_TRUST_TIER_INVALID',
+          trustTier: trustTier.value,
+        })
+      );
+      return;
+    }
+    const capabilityEnvelope = pairTokenCapabilityEnvelopeFromBody(body);
+    if (capabilityEnvelope.ok === false) {
+      sendRelayError(
+        res,
+        relayError('INVALID_REQUEST', 'unknown pair token capability requested', false, {
+          reasonCode: 'PAIR_TOKEN_CAPABILITY_UNKNOWN',
+          capability: capabilityEnvelope.invalidCapability,
+        })
+      );
+      return;
+    }
+    const correlationId = pairTokenMintCorrelationId(req, body, grant?.correlationId);
+    const source = sourceTupleFromRequest(req);
+    const platform = stringFromBody(body, 'platform');
     const pairToken = registry.createPairToken({
       ...(displayName ? { displayName } : {}),
       ...(ttlMs !== undefined ? { ttlMs } : {}),
+      ...(platform ? { platform } : {}),
+      ...(trustTier.trustTier ? { trustTier: trustTier.trustTier } : {}),
+      ...(capabilityEnvelope.envelope
+        ? { capabilityEnvelope: capabilityEnvelope.envelope }
+        : {}),
+      ...(grant
+        ? {
+            issuer: {
+              grantId: grant.id,
+              actorType: grant.actor.type,
+              ...(grant.actor.displayName
+                ? { actorDisplayName: grant.actor.displayName }
+                : {}),
+              actorId: grant.actor.id,
+            },
+          }
+        : {}),
+      ...(correlationId ? { correlationId } : {}),
+      ...(source ? { source } : {}),
     });
     const hubUrl = hubUrlFromRequest(req, body);
     const sshTarget = stringFromBody(body, 'sshTarget');
@@ -2056,6 +2557,50 @@ export function createHubNodeRouter(
       }),
       diagnostics: BOOTSTRAP_DIAGNOSTICS,
     });
+  }
+
+  router.post('/hub/pair-tokens', (req, res, next) => {
+    const body = bodyRecord(req);
+    const grantHandle = pairTokenMintGrantHandle(req, body);
+    if (!grantHandle) {
+      requireAuth(req, res, (error?: unknown) => {
+        if (error) {
+          next(error);
+          return;
+        }
+        sendMintedPairToken({ req, res, body });
+      });
+      return;
+    }
+
+    const correlationId = pairTokenMintCorrelationId(req, body);
+    const actor = pairTokenMintActor(req, body);
+    const deviceId = stringFromBody(body, 'deviceId');
+    const sessionBinding = pairTokenMintSessionBinding(body);
+    const scope = pairTokenMintScope(body);
+    const validation = operatorHandshakeGrants.validate(grantHandle, {
+      audience: NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE,
+      requiredCapabilities: [NODE_PAIR_TOKEN_CREATE_CAPABILITY],
+      ...(actor ? { actor } : {}),
+      ...(deviceId ? { deviceId } : {}),
+      ...(sessionBinding ? { sessionBinding } : {}),
+      ...(scope ? { scope } : {}),
+      consume: true,
+      ...(correlationId ? { correlationId } : {}),
+    });
+    if (validation.ok === false) {
+      const failure = validation;
+      appendPairTokenGrantAudit(options.auditSink, {
+        reason: failure.reason,
+        decision: failure.reason === 'expired' ? 'expired' : 'deny',
+        ...(failure.grantId ? { grantId: failure.grantId } : {}),
+        deniedBits: failure.deniedBits,
+        ...(correlationId ? { correlationId } : {}),
+      });
+      sendRelayError(res, relayErrorForPairTokenGrantFailure(failure));
+      return;
+    }
+    sendMintedPairToken({ req, res, body, grant: validation.grant });
   });
 
   router.post('/hub/pairing/exchange', (req, res) => {

--- a/shared/bootstrap-diagnostics.ts
+++ b/shared/bootstrap-diagnostics.ts
@@ -260,14 +260,20 @@ export function generateBootstrapCommands(input: BootstrapCommandInput): Bootstr
 
 export function redactBootstrapSecrets(value: string): string {
   return value
+    .replace(
+      /--(?:operator-grant|handshake-grant|actor-token)\s+(?:'[^']*'|"[^"]*"|\S+)/g,
+      (match) => `${match.split(/\s+/, 1)[0]} …redacted`
+    )
     .replace(/--pair-token\s+(?:'[^']*'|"[^"]*"|\S+)/g, '--pair-token pair_…redacted')
+    .replace(/\brelay-ohg-v1\.[A-Za-z0-9._~+/=-]+\.[A-Za-z0-9._~+/=-]+\b/g, 'relay-ohg-v1.…redacted')
+    .replace(/\brelay-sac-v1\.[A-Za-z0-9._~+/=-]+\.[A-Za-z0-9._~+/=-]+\b/g, 'relay-sac-v1.…redacted')
     .replace(/\bpair_[A-Za-z0-9._~+/=-]+\b/g, 'pair_…redacted')
     .replace(/\bnode_[A-Za-z0-9._~+/=-]+\.secret_[A-Za-z0-9._~+/=-]+\b/g, 'node_…redacted.secret_…redacted')
     .replace(/\bsecret_[A-Za-z0-9._~+/=-]+\b/g, 'secret_…redacted')
     .replace(/(Authorization:\s*Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, '$1…redacted')
     .replace(/(Bearer\s+)[A-Za-z0-9._~+/=-]+/gi, '$1…redacted')
-    .replace(/("(?:token|pairToken|pin|password|secret)"\s*:\s*)"[^"]*"/gi, '$1"…redacted"')
-    .replace(/\b(token|pin|password|secret)=([^\s&"',}]+)/gi, '$1=…redacted')
+    .replace(/("(?:token|pairToken|operatorGrant|handshakeGrant|grantHandle|actorToken|pin|password|secret)"\s*:\s*)"[^"]*"/gi, '$1"…redacted"')
+    .replace(/\b(token|pin|password|secret|cookie)=([^\s&"',}]+)/gi, '$1=…redacted')
     // URL-embedded credentials, any scheme — keeps bootstrap log lines
     // (which can quote `--hub-url https://user:pass@…` or `wss://…`) in
     // lockstep with the diag-bundle url-credential rule (#604).

--- a/shared/operator-handshake-grants.ts
+++ b/shared/operator-handshake-grants.ts
@@ -406,7 +406,11 @@ export class HandshakeGrantRegistry {
         `handshake grant ${grantId} is ${grant.status}`
       );
     }
-    if (requiresHighRiskApproval(grant) && !input.highRiskApproval) {
+    const requiresApprovalEvidence = requiresHighRiskApproval(grant);
+    const highRiskApproval = requiresApprovalEvidence
+      ? normalizeHighRiskApprovalEvidence(input.highRiskApproval)
+      : input.highRiskApproval;
+    if (requiresApprovalEvidence && !highRiskApproval) {
       grant.status = 'denied';
       grant.deniedAt = this.now().toISOString();
       grant.deniedByHash = sha256Hex(input.approvedBy.id);
@@ -425,7 +429,7 @@ export class HandshakeGrantRegistry {
       });
       throw new HandshakeGrantRegistryError(
         'high_risk_approval_required',
-        'handshake grants for high-risk capabilities require #807 approval contract evidence'
+        'handshake grants for high-risk capabilities require non-empty #807 approval contract evidence fields'
       );
     }
 
@@ -1037,6 +1041,27 @@ function requiresHighRiskApproval(grant: HandshakeGrantRecord): boolean {
   return grant.capabilities.some((capability) =>
     HIGH_RISK_CAPABILITY_SET.has(capability)
   );
+}
+
+function normalizeHighRiskApprovalEvidence(
+  value: unknown
+): HandshakeGrantHighRiskApprovalRef | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const candidate = value as Record<string, unknown>;
+  const challengeId = candidate.challengeId;
+  const contractHash = candidate.contractHash;
+  const approvedAt = candidate.approvedAt;
+  if (
+    typeof challengeId !== 'string' ||
+    !challengeId.trim() ||
+    typeof contractHash !== 'string' ||
+    !contractHash.trim() ||
+    typeof approvedAt !== 'string' ||
+    !approvedAt.trim()
+  ) {
+    return null;
+  }
+  return { challengeId, contractHash, approvedAt };
 }
 
 function actorMatches(

--- a/shared/operator-handshake-grants.ts
+++ b/shared/operator-handshake-grants.ts
@@ -15,6 +15,10 @@ import {
 } from './security-policy.js';
 
 export const HANDSHAKE_GRANT_TOKEN_PREFIX = 'relay-ohg-v1' as const;
+export const NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE =
+  'relay:node-pair-token:v1' as const;
+export const NODE_PAIR_TOKEN_CREATE_CAPABILITY =
+  'node:pair-token:create' as const;
 
 export const HANDSHAKE_GRANT_ACTOR_TYPES = [
   'agent',
@@ -27,6 +31,7 @@ export type HandshakeGrantActorType =
 
 export const HANDSHAKE_GRANT_AUDIENCES = [
   'relay:operator-handshake:v1',
+  NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE,
   'relay:registry-test',
 ] as const;
 
@@ -1018,6 +1023,9 @@ function isForeignCredentialLane(value: unknown): boolean {
   return (
     trimmed.startsWith('bearer ') ||
     trimmed.startsWith('relay-sac-v1.') ||
+    trimmed.startsWith('pair_') ||
+    trimmed.startsWith('node_') ||
+    trimmed.includes('.secret_') ||
     trimmed.startsWith('relay-pair-') ||
     trimmed.startsWith('relay-node-') ||
     trimmed.includes('connect.sid=') ||

--- a/shared/security-audit.ts
+++ b/shared/security-audit.ts
@@ -146,7 +146,7 @@ const SENSITIVE_KEY_TERMS = new Set([
   'value',
 ]);
 const SENSITIVE_TEXT_PATTERN =
-  /(bearer\s+[a-z0-9._~+/=-]+|connect\.sid=[^\s;]+|\b(?:access_?token|refresh_?token|token)=[^\s&;]+|gh[pousr]_[a-z0-9_]+|sk-[a-z0-9_-]+|relay-[a-z0-9._~+/=-]{16,})/gi;
+  /(bearer\s+[a-z0-9._~+/=-]+|connect\.sid=[^\s;]+|\b(?:access_?token|refresh_?token|token)=[^\s&;]+|gh[pousr]_[a-z0-9_]+|sk-[a-z0-9_-]+|relay-(?:ohg|sac)-v1\.[a-z0-9._~+/=-]+\.[a-z0-9._~+/=-]+|relay-[a-z0-9._~+/=-]{16,}|\bpair_[a-z0-9._~+/=-]+|\bnode_[a-z0-9._~+/=-]+\.secret_[a-z0-9._~+/=-]+)/gi;
 const HIGH_RISK_SET = new Set<RelayCapabilityBit>(HIGH_RISK_CAPABILITIES);
 
 export function isSecurityAuditEventType(

--- a/shared/security-policy.ts
+++ b/shared/security-policy.ts
@@ -24,6 +24,10 @@ export const RELAY_CAPABILITY_BITS = [
   'node:acl:widen',
   'credential:export',
   'node:lifecycle:destructive',
+  // #814: one-time operator handshake grants may mint short-lived node
+  // pair tokens for bootstrap automation. This is not a node ACL default
+  // and is accepted only by the pair-token mint grant lane.
+  'node:pair-token:create',
   // #597: dedicated read bit for the `logs.tail` RPC backbone. Separate
   // from `rpc:fs:tail` so operator-only log visibility can be granted
   // without exposing arbitrary file tail to peers. Always redacted via

--- a/test/fixtures/redaction/bootstrap-operator-grant.txt
+++ b/test/fixtures/redaction/bootstrap-operator-grant.txt
@@ -1,0 +1,11 @@
+## meta
+rule: bootstrap-operator-grant
+module: bootstrap-diagnostics
+redactor: redactBootstrapSecrets
+description: operator handshake grant handles and scoped actor tokens are scrubbed from bootstrap CLI examples and errors
+secrets: relay-ohg-v1.grant_abc123.secret_def456,relay-sac-v1.actor_abc123.secret_def456,pair_FAKE_PAIR_aaaaaaaa,node_FAKE_NODE_aaaaaaaa.secret_FAKE_NODE_SECRET_bbbbbbbb,browser_session_cookie_value
+preserves: relay-ide node mint-pair-token,--hub https://hub.example.test,--operator-grant,grant-backed mint failed
+## input
+relay-ide node mint-pair-token --hub https://hub.example.test --operator-grant relay-ohg-v1.grant_abc123.secret_def456 --actor-token relay-sac-v1.actor_abc123.secret_def456
+{"operatorGrant":"relay-ohg-v1.grant_abc123.secret_def456","actorToken":"relay-sac-v1.actor_abc123.secret_def456","pairToken":"pair_FAKE_PAIR_aaaaaaaa","nodeCredential":"node_FAKE_NODE_aaaaaaaa.secret_FAKE_NODE_SECRET_bbbbbbbb"}
+grant-backed mint failed with cookie=browser_session_cookie_value

--- a/test/helpers/operator-pairing.ts
+++ b/test/helpers/operator-pairing.ts
@@ -1,0 +1,78 @@
+import {
+  NODE_PAIR_TOKEN_CREATE_CAPABILITY,
+  NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE,
+} from '../../shared/operator-handshake-grants.js';
+
+export const TEST_PAIR_TOKEN_TASK_REF = 'test-node-pairing';
+
+export interface MintPairTokenForTestOptions {
+  displayName: string;
+  taskRef?: string;
+  actorId?: string;
+}
+
+async function responseBodyForMessage(response: Response): Promise<string> {
+  try {
+    return JSON.stringify(await response.json());
+  } catch {
+    return await response.text();
+  }
+}
+
+async function expectStatus(
+  response: Response,
+  expectedStatus: number,
+  action: string
+): Promise<void> {
+  if (response.status === expectedStatus) return;
+  throw new Error(
+    `${action} failed: expected ${expectedStatus}, got ${response.status}: ${await responseBodyForMessage(response)}`
+  );
+}
+
+export async function mintPairTokenWithOperatorGrantForTest(
+  base: string,
+  options: MintPairTokenForTestOptions
+): Promise<{ pairToken: string }> {
+  const taskRef = options.taskRef ?? TEST_PAIR_TOKEN_TASK_REF;
+  const actorId = options.actorId ?? 'test-node-pairing-cli';
+
+  const grantRes = await fetch(`${base}/hub/operator-handshake-grants`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+    body: JSON.stringify({
+      actor: { type: 'cli', id: actorId },
+      issuer: { id: 'operator-browser' },
+      audience: NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE,
+      capabilities: [NODE_PAIR_TOKEN_CREATE_CAPABILITY],
+      scope: { taskRefs: [taskRef] },
+      ttlMs: 600_000,
+    }),
+  });
+  await expectStatus(grantRes, 201, 'operator handshake grant request');
+  const grantBody = (await grantRes.json()) as { grant: { id: string } };
+
+  const approveRes = await fetch(
+    `${base}/hub/operator-handshake-grants/${encodeURIComponent(grantBody.grant.id)}/approve`,
+    {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      body: JSON.stringify({ approvedBy: { id: 'operator-browser' } }),
+    }
+  );
+  await expectStatus(approveRes, 200, 'operator handshake grant approval');
+  const approved = (await approveRes.json()) as { handle: string };
+
+  const pairRes = await fetch(`${base}/hub/pair-tokens`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-relay-operator-grant': approved.handle,
+      'x-relay-actor-type': 'cli',
+      'x-relay-actor-id': actorId,
+    },
+    body: JSON.stringify({ displayName: options.displayName, taskRef }),
+  });
+  await expectStatus(pairRes, 201, 'pair-token creation');
+  return (await pairRes.json()) as { pairToken: string };
+}

--- a/test/hub-cross-node-pty.test.ts
+++ b/test/hub-cross-node-pty.test.ts
@@ -19,6 +19,7 @@ import {
   type RelayNodeEnvelope,
 } from '../shared/relay-node-protocol.js';
 import { buildManifestWithAgents } from './helpers/manifest-fixtures.js';
+import { mintPairTokenWithOperatorGrantForTest } from './helpers/operator-pairing.js';
 
 const AGENTS = [
   { id: 'claude', label: 'Claude', status: 'available' as const },
@@ -467,13 +468,9 @@ async function pairAndConnectNode(input: {
   wsBase: string;
   hostname: string;
 }): Promise<SimulatedNode> {
-  const pairRes = await fetch(`${input.base}/hub/pair-tokens`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
-    body: JSON.stringify({ displayName: input.hostname }),
+  const pair = await mintPairTokenWithOperatorGrantForTest(input.base, {
+    displayName: input.hostname,
   });
-  expect(pairRes.status, `pair-token creation failed for ${input.hostname}`).toBe(201);
-  const pair = (await pairRes.json()) as { pairToken: string };
 
   const exchangeRes = await fetch(`${input.base}/hub/pairing/exchange`, {
     method: 'POST',

--- a/test/hub-node-cold-transfer.test.ts
+++ b/test/hub-node-cold-transfer.test.ts
@@ -16,6 +16,7 @@ import type { SessionSummary } from '../server/types.js';
 import type { NodeManifest } from '../shared/node-manifest.js';
 import type { RepoInventoryReport } from '../shared/repo-inventory.js';
 import type { RelayNodeEnvelope } from '../shared/relay-node-protocol.js';
+import { mintPairTokenWithOperatorGrantForTest } from './helpers/operator-pairing.js';
 
 function manifest(): NodeManifest {
   return {
@@ -279,12 +280,9 @@ describe('hub cold transfer / reopen-on-other-node', () => {
   async function pairNode(
     base: string
   ): Promise<{ token: string; nodeId: string }> {
-    const pairRes = await fetch(`${base}/hub/pair-tokens`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+    const pair = await mintPairTokenWithOperatorGrantForTest(base, {
+      displayName: 'Cold Transfer Node',
     });
-    expect(pairRes.status).toBe(201);
-    const pair = (await pairRes.json()) as { pairToken: string };
     const exchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },

--- a/test/hub-node-packaging.test.ts
+++ b/test/hub-node-packaging.test.ts
@@ -633,4 +633,17 @@ describe('hub/node packaging decision', () => {
     expect(validationSource).toContain('Invalid --service');
     expect(validationSource).toContain('process.exit(1)');
   });
+
+  it('uses USERNAME as the Windows CLI actor fallback before relay-ide-cli', () => {
+    const cliSource = readRepoFile('bin/relay-ide.ts');
+    const actorFallbackStart = cliSource.indexOf('const actorId =');
+    const actorFallbackEnd = cliSource.indexOf('const body: Record<string, unknown> = {};', actorFallbackStart);
+    const actorFallbackSource = cliSource.slice(actorFallbackStart, actorFallbackEnd);
+
+    expect(actorFallbackStart).toBeGreaterThanOrEqual(0);
+    expect(actorFallbackEnd).toBeGreaterThan(actorFallbackStart);
+    expect(actorFallbackSource).toMatch(
+      /process\.env\['RELAY_IDE_ACTOR_ID'\][\s\S]*process\.env\['USER'\][\s\S]*process\.env\['USERNAME'\][\s\S]*'relay-ide-cli'/
+    );
+  });
 });

--- a/test/hub-node-production-wiring.test.ts
+++ b/test/hub-node-production-wiring.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { SessionSummary } from '../server/types.js';
 import type { NodeManifest } from '../shared/node-manifest.js';
 import type { RelayNodeEnvelope } from '../shared/relay-node-protocol.js';
+import { mintPairTokenWithOperatorGrantForTest } from './helpers/operator-pairing.js';
 
 function manifest(): NodeManifest {
   return {
@@ -150,13 +151,9 @@ describe('production hub node link wiring', () => {
     const base = `http://127.0.0.1:${port}`;
     const wsBase = `ws://127.0.0.1:${port}`;
 
-    const pairRes = await fetch(`${base}/hub/pair-tokens`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ displayName: 'Remote Node' }),
+    const pair = await mintPairTokenWithOperatorGrantForTest(base, {
+      displayName: 'Remote Node',
     });
-    expect(pairRes.status).toBe(201);
-    const pair = (await pairRes.json()) as { pairToken: string };
 
     const exchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
       method: 'POST',

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -18,6 +18,11 @@ import { setupWebSocket } from '../server/ws.js';
 import { createSessionEnvelopeRegistry } from '../server/session-envelope-registry.js';
 import { SecurityAuditLog } from '../server/security-audit-log.js';
 import * as auth from '../server/auth.js';
+import {
+  HandshakeGrantRegistry,
+  NODE_PAIR_TOKEN_CREATE_CAPABILITY,
+  NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE,
+} from '../shared/operator-handshake-grants.js';
 import type { NodeManifest } from '../shared/node-manifest.js';
 import type { RepoInventoryReport } from '../shared/repo-inventory.js';
 
@@ -563,6 +568,212 @@ describe('hub node routes and link', () => {
       error: { code: 'NODE_REVOKED', retryable: false },
     });
     expect(revokedHeartbeatBody).not.toContain(exchange.credential.token);
+  });
+
+
+  it('mints pair tokens from scoped one-time operator handshake grants only', async () => {
+    const { tmpDir, registry } = tmpRegistry();
+    cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    let now = new Date('2026-01-02T03:04:05.000Z');
+    const operatorHandshakeGrants = new HandshakeGrantRegistry({
+      now: () => now,
+      secretBytes: () => Buffer.from('0123456789abcdef0123456789abcdef'),
+    });
+    const app = express();
+    app.use(express.json());
+    app.use(
+      createHubNodeRouter({
+        registry,
+        operatorHandshakeGrants,
+        requireAuth: (req, res, next) => {
+          if (req.header('x-test-auth') === 'yes') next();
+          else res.status(401).json(auth.browserSessionRequiredChallenge());
+        },
+      })
+    );
+    const server = http.createServer(app);
+    const port = await listen(server);
+    cleanup.push(() => close(server));
+    const base = `http://127.0.0.1:${port}`;
+
+    const grantRequest = await fetch(`${base}/hub/operator-handshake-grants`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      body: JSON.stringify({
+        actor: { type: 'cli', id: 'ebi-cli', displayName: 'Ebi CLI' },
+        issuer: { id: 'operator-browser', displayName: 'Operator' },
+        audience: NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE,
+        capabilities: [NODE_PAIR_TOKEN_CREATE_CAPABILITY],
+        scope: { taskRefs: ['bootstrap-work-mac'] },
+        ttlMs: 600_000,
+        correlationId: 'corr-pair-mint',
+      }),
+    });
+    expect(grantRequest.status).toBe(201);
+    const requested = (await grantRequest.json()) as { grant: { id: string } };
+    const grantApproval = await fetch(
+      `${base}/hub/operator-handshake-grants/${requested.grant.id}/approve`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({ approvedBy: { id: 'operator-browser' } }),
+      }
+    );
+    expect(grantApproval.status).toBe(200);
+    const approved = (await grantApproval.json()) as { handle: string };
+
+    const pairRes = await fetch(`${base}/hub/pair-tokens`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-relay-operator-grant': approved.handle,
+        'x-relay-actor-type': 'cli',
+        'x-relay-actor-id': 'ebi-cli',
+      },
+      body: JSON.stringify({
+        displayName: 'Work Mac',
+        platform: 'macos',
+        taskRef: 'bootstrap-work-mac',
+        trustTier: 'sandbox',
+        ttlSeconds: 300,
+        capabilityEnvelope: {
+          allowed: ['session:read', NODE_PAIR_TOKEN_CREATE_CAPABILITY],
+        },
+      }),
+    });
+    expect(pairRes.status).toBe(201);
+    const pair = (await pairRes.json()) as { pairToken: string };
+    expect(pair.pairToken).toMatch(/^pair_/);
+
+    const replayRes = await fetch(`${base}/hub/pair-tokens`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-relay-operator-grant': approved.handle,
+        'x-relay-actor-type': 'cli',
+        'x-relay-actor-id': 'ebi-cli',
+      },
+      body: JSON.stringify({ taskRef: 'bootstrap-work-mac' }),
+    });
+    expect(replayRes.status).toBe(400);
+    expect(await replayRes.json()).toMatchObject({
+      error: {
+        code: 'TOKEN_ALREADY_USED',
+        details: { reasonCode: 'PAIR_TOKEN_GRANT_REPLAYED' },
+      },
+    });
+
+    const exchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ pairToken: pair.pairToken, manifest: manifest() }),
+    });
+    expect(exchangeRes.status).toBe(201);
+    const node = registry.listNodes()[0]!;
+    expect(node.trust.tier).toBe('sandbox');
+    expect(node.trust.policy?.allowed).toEqual(['session:read']);
+    expect(node.trust.policy?.allowed).not.toContain(
+      NODE_PAIR_TOKEN_CREATE_CAPABILITY
+    );
+
+    const approveGrant = (input: {
+      audience?: string;
+      capabilities?: string[];
+      scope?: { taskRefs?: string[] };
+      ttlMs?: number;
+    } = {}): string => {
+      const grant = operatorHandshakeGrants.request({
+        actor: { type: 'cli', id: 'ebi-cli' },
+        issuer: { id: 'operator-browser' },
+        audience: input.audience ?? NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE,
+        capabilities: input.capabilities ?? [NODE_PAIR_TOKEN_CREATE_CAPABILITY],
+        scope: input.scope ?? { taskRefs: ['bootstrap-work-mac'] },
+        ttlMs: input.ttlMs ?? 600_000,
+      });
+      return operatorHandshakeGrants.approve(grant.id, {
+        approvedBy: { id: 'operator-browser' },
+      }).handle;
+    };
+    const mintWithGrant = async (handle: string, body: Record<string, unknown>) =>
+      await fetch(`${base}/hub/pair-tokens`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-relay-operator-grant': handle,
+          'x-relay-actor-type': 'cli',
+          'x-relay-actor-id': 'ebi-cli',
+        },
+        body: JSON.stringify(body),
+      });
+
+    const missingScopeRes = await mintWithGrant(approveGrant(), {});
+    expect(missingScopeRes.status).toBe(403);
+    expect(await missingScopeRes.json()).toMatchObject({
+      error: { details: { reasonCode: 'PAIR_TOKEN_GRANT_MISSING_SCOPE' } },
+    });
+
+    const wrongAudienceRes = await mintWithGrant(
+      approveGrant({ audience: 'relay:operator-handshake:v1' }),
+      { taskRef: 'bootstrap-work-mac' }
+    );
+    expect(wrongAudienceRes.status).toBe(403);
+    expect(await wrongAudienceRes.json()).toMatchObject({
+      error: { details: { reasonCode: 'PAIR_TOKEN_GRANT_WRONG_AUDIENCE' } },
+    });
+
+    const insufficientCapabilityRes = await mintWithGrant(
+      approveGrant({ capabilities: ['session:read'] }),
+      { taskRef: 'bootstrap-work-mac' }
+    );
+    expect(insufficientCapabilityRes.status).toBe(403);
+    expect(await insufficientCapabilityRes.json()).toMatchObject({
+      error: {
+        details: { reasonCode: 'PAIR_TOKEN_GRANT_INSUFFICIENT_CAPABILITY' },
+      },
+    });
+
+    const wrongScopeRes = await mintWithGrant(
+      approveGrant({ scope: { taskRefs: ['bootstrap-wsl2'] } }),
+      { taskRef: 'bootstrap-work-mac' }
+    );
+    expect(wrongScopeRes.status).toBe(403);
+    expect(await wrongScopeRes.json()).toMatchObject({
+      error: { details: { reasonCode: 'PAIR_TOKEN_GRANT_WRONG_TASK_SCOPE' } },
+    });
+
+    const revoked = approveGrant();
+    const revokedGrantId = revoked.split('.')[1]!;
+    operatorHandshakeGrants.revoke(revokedGrantId, {
+      revokedBy: { id: 'operator-browser' },
+    });
+    const revokedRes = await mintWithGrant(revoked, {
+      taskRef: 'bootstrap-work-mac',
+    });
+    expect(revokedRes.status).toBe(401);
+    expect(await revokedRes.json()).toMatchObject({
+      error: { details: { reasonCode: 'PAIR_TOKEN_GRANT_REVOKED' } },
+    });
+
+    const expired = approveGrant({ ttlMs: 1 });
+    now = new Date('2026-01-02T03:04:06.000Z');
+    const expiredRes = await mintWithGrant(expired, {
+      taskRef: 'bootstrap-work-mac',
+    });
+    expect(expiredRes.status).toBe(400);
+    expect(await expiredRes.json()).toMatchObject({
+      error: {
+        code: 'TOKEN_EXPIRED',
+        details: { reasonCode: 'PAIR_TOKEN_GRANT_EXPIRED' },
+      },
+    });
+
+    const laneMixingRes = await mintWithGrant('pair_fake-token-material', {
+      taskRef: 'bootstrap-work-mac',
+    });
+    expect(laneMixingRes.status).toBe(401);
+    expect(await laneMixingRes.json()).toMatchObject({
+      error: { details: { reasonCode: 'PAIR_TOKEN_GRANT_LANE_MIXING' } },
+    });
   });
 
   it('keeps strict source denial scoped to the node credential lane', async () => {

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -660,7 +660,7 @@ describe('hub node routes and link', () => {
         actor: { type: 'cli', id: 'ebi-cli', displayName: 'Ebi CLI' },
         issuer: { id: 'operator-browser', displayName: 'Operator' },
         audience: NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE,
-        capabilities: [NODE_PAIR_TOKEN_CREATE_CAPABILITY],
+        capabilities: [NODE_PAIR_TOKEN_CREATE_CAPABILITY, 'session:read'],
         scope: { taskRefs: ['bootstrap-work-mac'] },
         ttlMs: 600_000,
         correlationId: 'corr-pair-mint',
@@ -800,6 +800,39 @@ describe('hub node routes and link', () => {
         details: { reasonCode: 'PAIR_TOKEN_GRANT_INSUFFICIENT_CAPABILITY' },
       },
     });
+
+    const bodyControlledAclRes = await mintWithGrant(approveGrant(), {
+      taskRef: 'bootstrap-work-mac',
+      trustTier: 'prod',
+      capabilityEnvelope: {
+        allowed: ['tab:intervention:read'],
+        requiresConfirmation: ['credential:export', 'pty:exec:arbitrary'],
+      },
+    });
+    expect(bodyControlledAclRes.status).toBe(403);
+    expect(await bodyControlledAclRes.json()).toMatchObject({
+      error: {
+        details: { reasonCode: 'PAIR_TOKEN_GRANT_INSUFFICIENT_CAPABILITY' },
+      },
+    });
+
+    const prodOnlyPairRes = await mintWithGrant(approveGrant(), {
+      taskRef: 'bootstrap-work-mac',
+      trustTier: 'prod',
+    });
+    expect(prodOnlyPairRes.status).toBe(201);
+    const prodOnlyPair = (await prodOnlyPairRes.json()) as { pairToken: string };
+    const prodOnlyExchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        pairToken: prodOnlyPair.pairToken,
+        manifest: manifest(),
+      }),
+    });
+    expect(prodOnlyExchangeRes.status).toBe(201);
+    const prodOnlyNode = registry.listNodes()[registry.listNodes().length - 1]!;
+    expect(prodOnlyNode.trust.tier).toBe('dev');
 
     const wrongScopeRes = await mintWithGrant(
       approveGrant({ scope: { taskRefs: ['bootstrap-wsl2'] } }),

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -653,6 +653,46 @@ describe('hub node routes and link', () => {
       },
     });
 
+    const highRiskGrantRequest = await fetch(
+      `${base}/hub/operator-handshake-grants`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({
+          actor: { type: 'cli', id: 'ebi-cli', displayName: 'Ebi CLI' },
+          issuer: { id: 'operator-browser', displayName: 'Operator' },
+          audience: 'relay:operator-handshake:v1',
+          capabilities: ['credential:export'],
+          scope: { nodeIds: ['node-a'] },
+          ttlMs: 600_000,
+        }),
+      }
+    );
+    expect(highRiskGrantRequest.status).toBe(201);
+    const highRiskGrant = (await highRiskGrantRequest.json()) as {
+      grant: { id: string };
+    };
+    const malformedHighRiskApproval = await fetch(
+      `${base}/hub/operator-handshake-grants/${highRiskGrant.grant.id}/approve`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({
+          approvedBy: { id: 'operator-browser' },
+          highRiskApproval: {},
+        }),
+      }
+    );
+    expect(malformedHighRiskApproval.status).toBe(400);
+    expect(await malformedHighRiskApproval.json()).toMatchObject({
+      error: {
+        code: 'INVALID_REQUEST',
+        details: {
+          reasonCode: 'HANDSHAKE_GRANT_HIGH_RISK_APPROVAL_REQUIRED',
+        },
+      },
+    });
+
     const grantRequest = await fetch(`${base}/hub/operator-handshake-grants`, {
       method: 'POST',
       headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },

--- a/test/hub-node-routes.test.ts
+++ b/test/hub-node-routes.test.ts
@@ -253,11 +253,32 @@ describe('hub node routes and link', () => {
   it('protects user-facing pair/list routes while allowing token exchange and bearer heartbeat', async () => {
     const { tmpDir, registry } = tmpRegistry();
     cleanup.push(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+    const operatorHandshakeGrants = new HandshakeGrantRegistry();
+    const approvePairMintGrant = (): string => {
+      const grant = operatorHandshakeGrants.request({
+        actor: { type: 'cli', id: 'route-cli' },
+        issuer: { id: 'operator-browser' },
+        audience: NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE,
+        capabilities: [NODE_PAIR_TOKEN_CREATE_CAPABILITY],
+        scope: { taskRefs: ['route-node'] },
+        ttlMs: 600_000,
+      });
+      return operatorHandshakeGrants.approve(grant.id, {
+        approvedBy: { id: 'operator-browser' },
+      }).handle;
+    };
+    const pairMintHeaders = () => ({
+      'content-type': 'application/json',
+      'x-relay-operator-grant': approvePairMintGrant(),
+      'x-relay-actor-type': 'cli',
+      'x-relay-actor-id': 'route-cli',
+    });
     const app = express();
     app.use(express.json());
     app.use(
       createHubNodeRouter({
         registry,
+        operatorHandshakeGrants,
         requireAuth: (req, res, next) => {
           if (req.header('x-test-auth') === 'yes') next();
           else res.status(401).json(auth.browserSessionRequiredChallenge());
@@ -275,18 +296,29 @@ describe('hub node routes and link', () => {
     expect(deniedPairRes.status).toBe(401);
     expect(await deniedPairRes.json()).toMatchObject({
       error: {
-        code: 'BROWSER_SESSION_REQUIRED',
+        code: 'UNAUTHORIZED',
         retryable: false,
-        lane: 'denied',
-        acceptedLanes: ['browser-session'],
-        migrationTarget: 'scoped-actor-credential',
+        details: { reasonCode: 'PAIR_TOKEN_GRANT_REQUIRED' },
+      },
+    });
+
+    const browserSessionPairRes = await fetch(`${base}/hub/pair-tokens`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+      body: JSON.stringify({ displayName: 'Browser Session Route Node' }),
+    });
+    expect(browserSessionPairRes.status).toBe(401);
+    expect(await browserSessionPairRes.json()).toMatchObject({
+      error: {
+        code: 'UNAUTHORIZED',
+        details: { reasonCode: 'PAIR_TOKEN_GRANT_REQUIRED' },
       },
     });
 
     const pairRes = await fetch(`${base}/hub/pair-tokens`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
-      body: JSON.stringify({ displayName: 'Route Node' }),
+      headers: pairMintHeaders(),
+      body: JSON.stringify({ displayName: 'Route Node', taskRef: 'route-node' }),
     });
     expect(pairRes.status).toBe(201);
     const pair = (await pairRes.json()) as {
@@ -332,8 +364,11 @@ describe('hub node routes and link', () => {
 
     const defaultedModesRes = await fetch(`${base}/hub/pair-tokens`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
-      body: JSON.stringify({ serviceModes: ['bogus', 'also-bogus'] }),
+      headers: pairMintHeaders(),
+      body: JSON.stringify({
+        taskRef: 'route-node',
+        serviceModes: ['bogus', 'also-bogus'],
+      }),
     });
     expect(defaultedModesRes.status).toBe(201);
     const defaultedModes = (await defaultedModesRes.json()) as {
@@ -349,12 +384,11 @@ describe('hub node routes and link', () => {
     const forwardedHostRes = await fetch(`${base}/hub/pair-tokens`, {
       method: 'POST',
       headers: {
-        'content-type': 'application/json',
-        'x-test-auth': 'yes',
+        ...pairMintHeaders(),
         'x-forwarded-proto': 'https',
         'x-forwarded-host': 'relay.example.com',
       },
-      body: JSON.stringify({ displayName: 'Proxy Node' }),
+      body: JSON.stringify({ displayName: 'Proxy Node', taskRef: 'route-node' }),
     });
     expect(forwardedHostRes.status).toBe(201);
     const forwardedHost = (await forwardedHostRes.json()) as { hubUrl: string };
@@ -596,6 +630,29 @@ describe('hub node routes and link', () => {
     cleanup.push(() => close(server));
     const base = `http://127.0.0.1:${port}`;
 
+    const invalidDeviceGrantRequest = await fetch(
+      `${base}/hub/operator-handshake-grants`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
+        body: JSON.stringify({
+          actor: { type: 'cli', id: 'ebi-cli', displayName: 'Ebi CLI' },
+          issuer: { id: 'operator-browser', displayName: 'Operator' },
+          audience: NODE_PAIR_TOKEN_MINT_GRANT_AUDIENCE,
+          capabilities: [NODE_PAIR_TOKEN_CREATE_CAPABILITY],
+          scope: { taskRefs: ['bootstrap-work-mac'] },
+          device: { displayName: 'Missing ID Device' },
+        }),
+      }
+    );
+    expect(invalidDeviceGrantRequest.status).toBe(400);
+    expect(await invalidDeviceGrantRequest.json()).toMatchObject({
+      error: {
+        code: 'INVALID_REQUEST',
+        details: { reasonCode: 'HANDSHAKE_GRANT_DEVICE_INVALID' },
+      },
+    });
+
     const grantRequest = await fetch(`${base}/hub/operator-handshake-grants`, {
       method: 'POST',
       headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
@@ -705,6 +762,18 @@ describe('hub node routes and link', () => {
         },
         body: JSON.stringify(body),
       });
+
+    const invalidCapabilityListRes = await mintWithGrant(approveGrant(), {
+      taskRef: 'bootstrap-work-mac',
+      capabilityEnvelope: { allowed: 'session:read' },
+    });
+    expect(invalidCapabilityListRes.status).toBe(400);
+    expect(await invalidCapabilityListRes.json()).toMatchObject({
+      error: {
+        code: 'INVALID_REQUEST',
+        details: { reasonCode: 'PAIR_TOKEN_CAPABILITY_LIST_INVALID' },
+      },
+    });
 
     const missingScopeRes = await mintWithGrant(approveGrant(), {});
     expect(missingScopeRes.status).toBe(403);

--- a/test/hub-node-session-routing.test.ts
+++ b/test/hub-node-session-routing.test.ts
@@ -25,6 +25,7 @@ import {
 } from '../shared/session-envelope.js';
 import type { SecurityAuditEntryInput } from '../shared/security-audit.js';
 import type { RelayCapabilityBit } from '../shared/security-policy.js';
+import { mintPairTokenWithOperatorGrantForTest } from './helpers/operator-pairing.js';
 
 function manifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
   return {
@@ -162,13 +163,9 @@ async function pairNode(
   token: string;
   nodeId: string;
 }> {
-  const pairRes = await fetch(`${base}/hub/pair-tokens`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
-    body: JSON.stringify({ displayName: 'Remote Node' }),
+  const pair = await mintPairTokenWithOperatorGrantForTest(base, {
+    displayName: 'Remote Node',
   });
-  expect(pairRes.status).toBe(201);
-  const pair = (await pairRes.json()) as { pairToken: string };
 
   const exchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
     method: 'POST',

--- a/test/multi-node-smoke.test.ts
+++ b/test/multi-node-smoke.test.ts
@@ -19,6 +19,7 @@ import {
   type RelayNodeEnvelope,
 } from '../shared/relay-node-protocol.js';
 import { buildManifestWithAgents } from './helpers/manifest-fixtures.js';
+import { mintPairTokenWithOperatorGrantForTest } from './helpers/operator-pairing.js';
 
 const LOCAL_SESSION_ID = 'duplicate-local-session';
 
@@ -302,15 +303,9 @@ async function pairAndConnectNode(
   wsBase: string,
   hostname: string
 ): Promise<SimulatedRelayNode> {
-  const pairRes = await fetch(`${base}/hub/pair-tokens`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
-    body: JSON.stringify({ displayName: hostname }),
+  const pair = await mintPairTokenWithOperatorGrantForTest(base, {
+    displayName: hostname,
   });
-  expect(pairRes.status, `pair-token creation failed for ${hostname}`).toBe(
-    201
-  );
-  const pair = (await pairRes.json()) as { pairToken: string };
 
   const exchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
     method: 'POST',

--- a/test/operator-handshake-grants.test.ts
+++ b/test/operator-handshake-grants.test.ts
@@ -301,6 +301,51 @@ describe('operator handshake grant registry', () => {
     ).toThrow(HandshakeGrantRegistryError);
     expect(store.getGrant(grant.id)).toMatchObject({ status: 'denied' });
 
+    const malformedApprovals: Array<[string, unknown]> = [
+      ['empty', {}],
+      [
+        'missing-approved-at',
+        { challengeId: 'challenge-1', contractHash: 'hash-1' },
+      ],
+      [
+        'blank-challenge-id',
+        {
+          challengeId: '   ',
+          contractHash: 'hash-1',
+          approvedAt: NOW.toISOString(),
+        },
+      ],
+      [
+        'non-string-contract-hash',
+        {
+          challengeId: 'challenge-1',
+          contractHash: 123,
+          approvedAt: NOW.toISOString(),
+        },
+      ],
+    ];
+    for (const [suffix, highRiskApproval] of malformedApprovals) {
+      const malformedStore = registry();
+      const malformedGrant = malformedStore.request({
+        id: `malformed-high-risk-grant-${suffix}`,
+        actor: { type: 'automation-system', id: 'automation-1' },
+        issuer: { id: 'operator-1' },
+        audience: 'relay:operator-handshake:v1',
+        capabilities: ['credential:export'],
+        scope: { nodeIds: ['node-a'] },
+        expiresAt: LATER,
+      });
+      expect(() =>
+        malformedStore.approve(malformedGrant.id, {
+          approvedBy: { id: 'operator-1' },
+          highRiskApproval: highRiskApproval as never,
+        })
+      ).toThrow(HandshakeGrantRegistryError);
+      expect(malformedStore.getGrant(malformedGrant.id)).toMatchObject({
+        status: 'denied',
+      });
+    }
+
     const approvedStore = registry();
     const approvedGrant = approvedStore.request({
       id: 'high-risk-grant-2',

--- a/test/server/hub-fs-write-route.test.ts
+++ b/test/server/hub-fs-write-route.test.ts
@@ -20,6 +20,7 @@ import {
 } from '../../shared/session-envelope.js';
 import type { SecurityAuditEntryInput } from '../../shared/security-audit.js';
 import type { RelayCapabilityBit } from '../../shared/security-policy.js';
+import { mintPairTokenWithOperatorGrantForTest } from '../helpers/operator-pairing.js';
 
 function manifest(overrides: Partial<NodeManifest> = {}): NodeManifest {
   return {
@@ -84,13 +85,9 @@ async function nextJson(ws: WebSocket): Promise<RelayNodeEnvelope> {
 }
 
 async function pairNode(base: string, nodeManifest = manifest()): Promise<{ token: string; nodeId: string }> {
-  const pairRes = await fetch(`${base}/hub/pair-tokens`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json', 'x-test-auth': 'yes' },
-    body: JSON.stringify({ displayName: 'Write Test Node' }),
+  const pair = await mintPairTokenWithOperatorGrantForTest(base, {
+    displayName: 'Write Test Node',
   });
-  expect(pairRes.status).toBe(201);
-  const pair = (await pairRes.json()) as { pairToken: string };
 
   const exchangeRes = await fetch(`${base}/hub/pairing/exchange`, {
     method: 'POST',

--- a/test/stores/node-dashboard.test.ts
+++ b/test/stores/node-dashboard.test.ts
@@ -308,12 +308,14 @@ describe('hub node dashboard state', () => {
     // #807 added three high-risk approval contract bits (node ACL widening,
     // credential export, destructive node lifecycle). They are denied in these
     // fixtures unless explicitly granted/challenged, so challenge remains at 2.
+    // #814 added `node:pair-token:create` for grant-backed node bootstrap; it
+    // is denied by these node policy fixtures unless explicitly delegated.
     expect(
       rows.map((row) => [row.security.trustTier, row.security.postureLabel])
     ).toEqual([
-      ['sandbox', 'allow 1 · challenge 0 · deny 25'],
-      ['dev', 'allow 15 · challenge 0 · deny 11'],
-      ['prod', 'allow 1 · challenge 2 · deny 23'],
+      ['sandbox', 'allow 1 · challenge 0 · deny 26'],
+      ['dev', 'allow 15 · challenge 0 · deny 12'],
+      ['prod', 'allow 1 · challenge 2 · deny 24'],
     ]);
     expect(rows[2].security).toMatchObject({
       tone: 'danger',


### PR DESCRIPTION
## Summary

- add grant-backed pair-token minting for node bootstrap
- enforce handshake/operator grant audience/capability/scope/TTL/actor binding for pair-token creation
- keep browser cookies/PINs, node credentials, scoped actor credentials, and pair tokens out of the operator-grant authority lane
- preserve pair tokens as short-lived one-time bootstrap material with typed audit/deny/reuse paths
- update CLI/help and bootstrap/security docs for the grant-backed flow

Closes #814
Refs #812

## Verification

Worker-reported evidence from branch `feat/814-grant-backed-pair-tokens` at `66350062cb5961c7548c8a0f03a098dd9d49559d`:

- targeted vitest: 5 files, 110/110 passed
- `npm run check` — pass with 113 existing lint warnings
- `npm run build` — pass
- full `npm test` with temp HOME containing a visible dir — 4095/4095 passed
- `git diff --check` — pass
- diff secret scan — no real token/key-looking values; only fake lane-mixing fixture token string

## Notes

An initial full `npm test` under the Hermes profile HOME failed an fs-browse assumption because HOME had no visible non-dot directories; rerun with a temp HOME visible directory passed the full suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI subcommand to mint short-lived node pair tokens via operator grants, with operator/actor identity headers and JSON output option

* **Documentation**
  * Updated node bootstrap and operator-grant docs to document the operator-grant-based pair-token minting workflow and usage

* **Improvements**
  * Stronger diagnostic/audit handling and expanded secret redaction for bootstrap output

* **Tests**
  * Added and updated tests covering grant-scoped minting, replay/revocation, and pairing flows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/823?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->