### PR TITLE
fix: preserve CLI actor grant task scopes

### DIFF
--- a/server/cli-gateway-actor-auth.ts
+++ b/server/cli-gateway-actor-auth.ts
@@ -185,9 +185,13 @@ export function isSupportedCliGatewayActorReadRequest(
 export function defaultCliGatewayActorScope(
   overrides?: ScopedActorCredentialScope
 ): ScopedActorCredentialScope {
+  const taskRefs = uniqueStrings([
+    CLI_GATEWAY_READ_SCOPE_TASK_REF,
+    ...(overrides?.taskRefs ?? []),
+  ]);
   return {
-    taskRefs: [CLI_GATEWAY_READ_SCOPE_TASK_REF],
     ...(overrides ?? {}),
+    taskRefs,
   };
 }
 
@@ -391,6 +395,7 @@ export function rotateCliGatewayActorCredentialWithGrant(
 function scopeForValidation(
   scope: ScopedActorCredentialScope | undefined
 ): HandshakeGrantValidationScope {
+  const taskRef = taskRefForGrantValidation(scope?.taskRefs);
   return {
     ...(scope?.nodeIds?.[0] ? { nodeId: scope.nodeIds[0] } : {}),
     ...(scope?.sessionIds?.[0] ? { sessionId: scope.sessionIds[0] } : {}),
@@ -402,8 +407,16 @@ function scopeForValidation(
       : {}),
     ...(scope?.repoIds?.[0] ? { repoId: scope.repoIds[0] } : {}),
     ...(scope?.pathPrefixes?.[0] ? { path: scope.pathPrefixes[0] } : {}),
-    ...(scope?.taskRefs?.[0] ? { taskRef: scope.taskRefs[0] } : {}),
+    ...(taskRef ? { taskRef } : {}),
   };
+}
+
+function taskRefForGrantValidation(taskRefs: readonly string[] | undefined): string | undefined {
+  if (!taskRefs?.length) return undefined;
+  return (
+    taskRefs.find((taskRef) => taskRef !== CLI_GATEWAY_READ_SCOPE_TASK_REF) ??
+    taskRefs[0]
+  );
 }
 
 function credentialMatchesGrantLifecycleRequest(
@@ -454,6 +467,10 @@ function listIsSubset(
   allowed: readonly string[]
 ): boolean {
   return values.every((value) => allowed.includes(value));
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return Array.from(new Set(values));
 }
 
 type StrictGrantLifecycleRequest = {
@@ -623,18 +640,32 @@ function validateRequestedScopeAgainstGrant(
   ];
 
   for (const rule of rules) {
-    if (!rule.requestValues?.length) continue;
+    const requestValues = requestValuesForGrantScopeRule(rule);
+    if (!requestValues.length) continue;
     const grantValues = rule.grantValues;
     if (!grantValues?.length) {
-      if (requestOnlyScopeDimensionIsAllowed(rule.wrongReason, rule.requestValues)) continue;
+      if (requestOnlyScopeDimensionIsAllowed(rule.wrongReason, requestValues)) continue;
       return rule.wrongReason;
     }
     const matches = rule.matches ?? ((values, requested) => values.includes(requested));
-    if (!rule.requestValues.every((value) => matches(grantValues, value))) {
+    if (!requestValues.every((value) => matches(grantValues, value))) {
       return rule.wrongReason;
     }
   }
   return null;
+}
+
+function requestValuesForGrantScopeRule(rule: {
+  grantValues: readonly string[] | undefined;
+  requestValues: readonly string[] | undefined;
+  wrongReason: HandshakeGrantValidationFailureReason;
+}): readonly string[] {
+  const requestValues = rule.requestValues ?? [];
+  if (rule.wrongReason !== 'wrong_task_scope') return requestValues;
+  return requestValues.filter(
+    (taskRef) =>
+      taskRef !== CLI_GATEWAY_READ_SCOPE_TASK_REF || rule.grantValues?.includes(taskRef)
+  );
 }
 
 function requestOnlyScopeDimensionIsAllowed(

--- a/server/index.ts
+++ b/server/index.ts
@@ -1997,6 +1997,7 @@ async function main(): Promise<void> {
       requireAuth,
       cliGatewayAuth: requireCliGatewayAuth,
       cliGatewayAuthForActorCommand: requireCliGatewayAuthForActorCommand,
+      operatorHandshakeGrants: cliGatewayHandshakeGrantRegistry,
       scopedSessionAuth: requireScopedSessionAuth,
       repoInventoryFeature,
       collectLocalRepoInventory: collectLocalInventory,

--- a/test/cli-gateway-actor-auth.test.ts
+++ b/test/cli-gateway-actor-auth.test.ts
@@ -555,6 +555,32 @@ test('allows only the default CLI gateway taskRef when the grant omits task scop
   );
 });
 
+test('keeps grant-specific task scope while preserving the read gateway marker', () => {
+  const scopedRegistry = registry();
+  const grants = grantRegistry();
+  const dogfoodTaskRef = 'bootstrap-work-mac';
+  const handle = approveGrant(grants, 'grant-dogfood-taskref', {
+    scope: { taskRefs: [dogfoodTaskRef] },
+  });
+
+  const issued = issueCliGatewayActorCredentialWithGrant(scopedRegistry, grants, {
+    ...grantLifecycleInput(handle, 'dogfood-taskref'),
+    scope: { taskRefs: [dogfoodTaskRef] },
+  });
+
+  expect(issued.credential.scope.taskRefs).toEqual([
+    CLI_GATEWAY_READ_SCOPE_TASK_REF,
+    dogfoodTaskRef,
+  ]);
+  expect(
+    validateCliGatewayActorCredential(scopedRegistry, {
+      token: issued.token,
+      capabilities: ['session:read'],
+      correlationId: 'dogfood-nodes-list',
+    })
+  ).toMatchObject({ ok: true, grantedBits: ['session:read'] });
+});
+
 test('denies mixed allowed and disallowed list scopes before exposing credentials', () => {
   const scopedRegistry = registry();
   const grants = grantRegistry();

--- a/test/cli-gateway-actor-route-wiring.test.ts
+++ b/test/cli-gateway-actor-route-wiring.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { expect, test } from 'vitest';
+
+test('live hub shares approved operator handshake grants with CLI actor credential minting', () => {
+  const indexSource = readFileSync(new URL('../server/index.ts', import.meta.url), 'utf8');
+  const hubRouterCall = indexSource.slice(
+    indexSource.indexOf('createHubNodeRouter({'),
+    indexSource.indexOf('createRepoFeatureRouter({')
+  );
+
+  expect(hubRouterCall).toContain(
+    'operatorHandshakeGrants: cliGatewayHandshakeGrantRegistry'
+  );
+});


### PR DESCRIPTION
## Summary
- preserve the mandatory CLI gateway read task marker while retaining task-specific grant refs
- validate handshake grant task scope against the specific task ref instead of the read marker when present
- wire the live hub router to the shared CLI gateway handshake grant registry
- add regression coverage for task-scoped mint/use and live route wiring

## Test Plan
- npm run build
- npm run check (passes with existing warnings)
- npm test -- test/cli-gateway-actor-auth.test.ts test/cli-gateway-actor-route-wiring.test.ts test/hub-node-session-routing.test.ts test/browser-cli.test.ts test/cli-gateway-codex-tools.test.ts test/cli-gateway-hermes-tools.test.ts test/cli-gateway-claude-tools.test.ts
- npm test (4104/4105 pass; unrelated baseline failure: test/fs-browse.test.ts expects visible non-dot entries in profile-local HOME)

Closes #816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved CLI gateway actor credential scope validation with proper deduplication of task references and refined grant validation handling for better reliability.

* **Tests**
  * Added test coverage for grant-specific task scope preservation.
  * Added test verification for operator handshake grant routing configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/donovan-yohan/relay-ide/pull/824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->