### PR TITLE
fix: show full degraded node reasons

### DIFF
--- a/frontend/src/components/HubNodeDashboard.css
+++ b/frontend/src/components/HubNodeDashboard.css
@@ -303,7 +303,7 @@
 
 .hub-node-degraded-reason {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: minmax(0, auto) minmax(12ch, 1fr) auto;
   gap: 6px;
   align-items: baseline;
   border: 1px solid var(--border);
@@ -314,14 +314,14 @@
 .hub-node-degraded-code {
   color: var(--text);
   font-weight: 600;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .hub-node-degraded-desc {
   color: var(--text-muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .hub-node-degraded-severity {

--- a/frontend/src/components/HubNodeDashboard.tsx
+++ b/frontend/src/components/HubNodeDashboard.tsx
@@ -51,23 +51,27 @@ function DegradedReasonsExpander({
       </button>
       {open && (
         <ul className="hub-node-degraded-list" role="list">
-          {reasons.map((reason) => (
-            <li
-              key={reason.code}
-              className={[
-                'hub-node-degraded-reason',
-                severityClass(reason.severity),
-              ].join(' ')}
-            >
-              <span className="hub-node-degraded-code">{reason.code}</span>
-              <span className="hub-node-degraded-desc">
-                {reason.description}
-              </span>
-              <span className="hub-node-degraded-severity">
-                {reason.severity}
-              </span>
-            </li>
-          ))}
+          {reasons.map((reason) => {
+            const fullReason = `${reason.code}: ${reason.description} (${reason.severity})`;
+            return (
+              <li
+                key={reason.code}
+                className={[
+                  'hub-node-degraded-reason',
+                  severityClass(reason.severity),
+                ].join(' ')}
+                title={fullReason}
+              >
+                <span className="hub-node-degraded-code">{reason.code}</span>
+                <span className="hub-node-degraded-desc">
+                  {reason.description}
+                </span>
+                <span className="hub-node-degraded-severity">
+                  {reason.severity}
+                </span>
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/server/protocol-adapters/hermes-adapter.ts
+++ b/server/protocol-adapters/hermes-adapter.ts
@@ -84,7 +84,9 @@ function stripYamlInlineComment(value: string): string {
     } else if (char === '"' && quote !== 'single') {
       quote = quote === 'double' ? null : 'double';
     } else if (char === '#' && quote === null) {
-      return value.slice(0, i).trim();
+      if (i === 0 || /\s/.test(value[i - 1] ?? '')) {
+        return value.slice(0, i).trim();
+      }
     }
   }
   return value.trim();
@@ -131,12 +133,6 @@ function readSimpleYamlScalars(filePath: string): Map<string, string> {
   return values;
 }
 
-function truthyConfig(value: string | null): boolean {
-  return value
-    ? ['true', '1', 'yes', 'on'].includes(value.toLowerCase())
-    : false;
-}
-
 function firstConfigValue(
   values: Map<string, string>,
   prefixes: string[],
@@ -151,9 +147,30 @@ function firstConfigValue(
   return null;
 }
 
+function configBoolean(value: string | null): boolean | null {
+  if (value == null) return null;
+  const normalized = value.toLowerCase();
+  if (['true', '1', 'yes', 'on'].includes(normalized)) return true;
+  if (['false', '0', 'no', 'off'].includes(normalized)) return false;
+  return null;
+}
+
+function firstConfigBoolean(
+  values: Map<string, string>,
+  prefixes: string[],
+  keys: string[]
+): boolean | null {
+  for (const prefix of prefixes) {
+    const value = configBoolean(firstConfigValue(values, [prefix], keys));
+    if (value !== null) return value;
+  }
+  return null;
+}
+
 interface HermesConfigApiServerSettings {
   endpoint: string | null;
   apiKey: string | null;
+  disabled: boolean;
 }
 
 function readHermesConfigApiServerFile(
@@ -166,11 +183,10 @@ function readHermesConfigApiServerFile(
     'gateway.platforms.api_server',
     'gateway.api_server',
   ];
-  const enabled = prefixes.some((prefix) =>
-    truthyConfig(
-      firstConfigValue(values, [prefix], ['enabled', 'extra.enabled'])
-    )
-  );
+  const enabled = firstConfigBoolean(values, prefixes, [
+    'enabled',
+    'extra.enabled',
+  ]);
   const host = firstConfigValue(values, prefixes, ['host', 'extra.host']);
   const port = firstConfigValue(values, prefixes, ['port', 'extra.port']);
   const apiKey = firstConfigValue(values, prefixes, [
@@ -181,14 +197,17 @@ function readHermesConfigApiServerFile(
     'token',
   ]);
 
-  const endpoint =
-    enabled || host || port
+  const disabled = enabled === false;
+  const endpoint = disabled
+    ? null
+    : enabled === true || host || port
       ? `http://${host ?? '127.0.0.1'}:${port ?? '8642'}`
       : null;
 
   return {
     endpoint,
-    apiKey,
+    apiKey: disabled ? null : apiKey,
+    disabled,
   };
 }
 
@@ -196,12 +215,22 @@ function readHermesConfigApiServer(): HermesConfigApiServerSettings {
   const merged: HermesConfigApiServerSettings = {
     endpoint: null,
     apiKey: null,
+    disabled: false,
   };
   for (const home of candidateHermesHomes()) {
     const settings = readHermesConfigApiServerFile(
       path.join(home, 'config.yaml')
     );
-    if (settings.endpoint) merged.endpoint = settings.endpoint;
+    if (settings.disabled) {
+      merged.endpoint = null;
+      merged.apiKey = null;
+      merged.disabled = true;
+      continue;
+    }
+    if (settings.endpoint) {
+      merged.endpoint = settings.endpoint;
+      merged.disabled = false;
+    }
     if (settings.apiKey) merged.apiKey = settings.apiKey;
   }
   return merged;
@@ -211,26 +240,32 @@ function addCandidate(candidates: string[], value: string | null): void {
   if (value && !candidates.includes(value)) candidates.push(value);
 }
 
+function addHomeWithActiveProfile(
+  candidates: string[],
+  home: string | null
+): void {
+  if (!home) return;
+  addCandidate(candidates, home);
+  try {
+    const activeProfile = fs
+      .readFileSync(path.join(home, 'active_profile'), 'utf8')
+      .trim();
+    if (activeProfile) {
+      addCandidate(candidates, path.join(home, 'profiles', activeProfile));
+    }
+  } catch {
+    // No active profile marker for this home.
+  }
+}
+
 function candidateHermesHomes(): string[] {
   const home = os.homedir();
   const root = path.join(home, '.hermes');
   const candidates: string[] = [];
 
   // Merge from broadest to most specific so profile/env homes win.
-  addCandidate(candidates, root);
-
-  try {
-    const activeProfile = fs
-      .readFileSync(path.join(root, 'active_profile'), 'utf8')
-      .trim();
-    if (activeProfile) {
-      addCandidate(candidates, path.join(root, 'profiles', activeProfile));
-    }
-  } catch {
-    // No active profile marker; root defaults are still usable.
-  }
-
-  addCandidate(candidates, nonEmpty(process.env['HERMES_HOME']));
+  addHomeWithActiveProfile(candidates, root);
+  addHomeWithActiveProfile(candidates, nonEmpty(process.env['HERMES_HOME']));
   return candidates;
 }
 

--- a/server/protocol-adapters/hermes-adapter.ts
+++ b/server/protocol-adapters/hermes-adapter.ts
@@ -75,26 +75,163 @@ function parseEnvFile(filePath: string): Record<string, string> {
   }
 }
 
+function stripYamlInlineComment(value: string): string {
+  let quote: 'single' | 'double' | null = null;
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+    if (char === "'" && quote !== 'double') {
+      quote = quote === 'single' ? null : 'single';
+    } else if (char === '"' && quote !== 'single') {
+      quote = quote === 'double' ? null : 'double';
+    } else if (char === '#' && quote === null) {
+      return value.slice(0, i).trim();
+    }
+  }
+  return value.trim();
+}
+
+function parseYamlScalar(value: string): string {
+  let parsed = stripYamlInlineComment(value).trim();
+  if (
+    (parsed.startsWith('"') && parsed.endsWith('"')) ||
+    (parsed.startsWith("'") && parsed.endsWith("'"))
+  ) {
+    parsed = parsed.slice(1, -1);
+  }
+  return parsed;
+}
+
+function readSimpleYamlScalars(filePath: string): Map<string, string> {
+  const values = new Map<string, string>();
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+    const stack: Array<{ indent: number; key: string }> = [];
+    for (const rawLine of content.split(/\r?\n/)) {
+      if (!rawLine.trim() || rawLine.trimStart().startsWith('#')) continue;
+      const match = /^(\s*)([A-Za-z0-9_-]+)\s*:\s*(.*)$/.exec(rawLine);
+      if (!match) continue;
+      const indent = match[1]?.length ?? 0;
+      const key = match[2];
+      const rawValue = match[3] ?? '';
+      if (!key) continue;
+      while (stack.length > 0 && indent <= stack[stack.length - 1]!.indent) {
+        stack.pop();
+      }
+      const pathParts = [...stack.map((entry) => entry.key), key];
+      const value = parseYamlScalar(rawValue);
+      if (value === '') {
+        stack.push({ indent, key });
+      } else {
+        values.set(pathParts.join('.'), value);
+      }
+    }
+  } catch {
+    // Missing or malformed config is fine; fall back to env/defaults.
+  }
+  return values;
+}
+
+function truthyConfig(value: string | null): boolean {
+  return value
+    ? ['true', '1', 'yes', 'on'].includes(value.toLowerCase())
+    : false;
+}
+
+function firstConfigValue(
+  values: Map<string, string>,
+  prefixes: string[],
+  keys: string[]
+): string | null {
+  for (const prefix of prefixes) {
+    for (const key of keys) {
+      const value = nonEmpty(values.get(`${prefix}.${key}`));
+      if (value) return value;
+    }
+  }
+  return null;
+}
+
+interface HermesConfigApiServerSettings {
+  endpoint: string | null;
+  apiKey: string | null;
+}
+
+function readHermesConfigApiServerFile(
+  filePath: string
+): HermesConfigApiServerSettings {
+  const values = readSimpleYamlScalars(filePath);
+  const prefixes = [
+    'api_server',
+    'platforms.api_server',
+    'gateway.platforms.api_server',
+    'gateway.api_server',
+  ];
+  const enabled = prefixes.some((prefix) =>
+    truthyConfig(
+      firstConfigValue(values, [prefix], ['enabled', 'extra.enabled'])
+    )
+  );
+  const host = firstConfigValue(values, prefixes, ['host', 'extra.host']);
+  const port = firstConfigValue(values, prefixes, ['port', 'extra.port']);
+  const apiKey = firstConfigValue(values, prefixes, [
+    'key',
+    'extra.key',
+    'api_key',
+    'apiKey',
+    'token',
+  ]);
+
+  const endpoint =
+    enabled || host || port
+      ? `http://${host ?? '127.0.0.1'}:${port ?? '8642'}`
+      : null;
+
+  return {
+    endpoint,
+    apiKey,
+  };
+}
+
+function readHermesConfigApiServer(): HermesConfigApiServerSettings {
+  const merged: HermesConfigApiServerSettings = {
+    endpoint: null,
+    apiKey: null,
+  };
+  for (const home of candidateHermesHomes()) {
+    const settings = readHermesConfigApiServerFile(
+      path.join(home, 'config.yaml')
+    );
+    if (settings.endpoint) merged.endpoint = settings.endpoint;
+    if (settings.apiKey) merged.apiKey = settings.apiKey;
+  }
+  return merged;
+}
+
+function addCandidate(candidates: string[], value: string | null): void {
+  if (value && !candidates.includes(value)) candidates.push(value);
+}
+
 function candidateHermesHomes(): string[] {
   const home = os.homedir();
   const root = path.join(home, '.hermes');
-  const candidates = new Set<string>();
-  const envHome = nonEmpty(process.env['HERMES_HOME']);
-  if (envHome) candidates.add(envHome);
+  const candidates: string[] = [];
+
+  // Merge from broadest to most specific so profile/env homes win.
+  addCandidate(candidates, root);
 
   try {
     const activeProfile = fs
       .readFileSync(path.join(root, 'active_profile'), 'utf8')
       .trim();
     if (activeProfile) {
-      candidates.add(path.join(root, 'profiles', activeProfile));
+      addCandidate(candidates, path.join(root, 'profiles', activeProfile));
     }
   } catch {
-    // No active profile marker; fall through to the root.
+    // No active profile marker; root defaults are still usable.
   }
 
-  candidates.add(root);
-  return [...candidates];
+  addCandidate(candidates, nonEmpty(process.env['HERMES_HOME']));
+  return candidates;
 }
 
 function readHermesEnv(): Record<string, string> {
@@ -134,19 +271,23 @@ export function resolveHermesGatewaySettings(
   extra: Record<string, unknown> | undefined
 ): HermesGatewaySettings {
   const fileEnv = readHermesEnv();
+  const configApiServer = readHermesConfigApiServer();
   const explicitEndpoint = nonEmpty(extra?.['endpoint']);
   const envEndpoint =
     firstEnvValue(ENDPOINT_ENV_KEYS, fileEnv) ??
     endpointFromApiServerEnv(fileEnv);
+  const configEndpoint = configApiServer.endpoint;
   const endpoint = (
     explicitEndpoint ??
     envEndpoint ??
+    configEndpoint ??
     DEFAULT_HERMES_ENDPOINT
   ).replace(/\/+$/, '');
   const apiKey =
     nonEmpty(extra?.['apiToken']) ??
     nonEmpty(extra?.['apiKey']) ??
-    firstEnvValue(TOKEN_ENV_KEYS, fileEnv);
+    firstEnvValue(TOKEN_ENV_KEYS, fileEnv) ??
+    configApiServer.apiKey;
 
   return {
     endpoint,
@@ -155,7 +296,9 @@ export function resolveHermesGatewaySettings(
       ? 'adapter config'
       : envEndpoint
         ? 'environment'
-        : 'default',
+        : configEndpoint
+          ? 'Hermes config'
+          : 'default',
   };
 }
 

--- a/test/degraded-ui/node-dashboard-degraded-interaction.test.ts
+++ b/test/degraded-ui/node-dashboard-degraded-interaction.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { HubNodeSummary } from '../../shared/relay-node-protocol.js';
+import { HubNodeDashboard } from '../../frontend/src/components/HubNodeDashboard.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const now = new Date('2026-01-02T03:05:00.000Z');
+
+function node(overrides: Partial<HubNodeSummary> = {}): HubNodeSummary {
+  return {
+    nodeId: 'node-1',
+    displayName: 'dev mac',
+    hostname: 'dev-mac.local',
+    platform: 'darwin',
+    arch: 'arm64',
+    relayVersion: '0.5.0',
+    protocolVersion: '1.0',
+    status: 'online',
+    connection: { route: 'reverse-link', status: 'connected' },
+    capabilities: {
+      totals: { available: 11, degraded: 1, unavailable: 0, unknown: 0 },
+      core: {
+        shell: 'available',
+        tmux: 'available',
+        git: 'available',
+        browserAutomation: 'degraded',
+        clipboardImage: 'available',
+        ssh: 'available',
+        tailscale: 'available',
+      },
+      agents: { hermes: 'degraded' },
+      serviceManager: 'launchd',
+      wsl: false,
+    },
+    createdAt: '2026-01-02T03:00:00.000Z',
+    pairedAt: '2026-01-02T03:00:00.000Z',
+    lastSeenAt: '2026-01-02T03:04:30.000Z',
+    credentialId: 'cred-1',
+    ...overrides,
+  };
+}
+
+describe('HubNodeDashboard degraded reasons interaction', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('exposes full degraded reason text after expanding', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(HubNodeDashboard, {
+          now,
+          nodes: [
+            node({
+              degradedReasons: [
+                {
+                  code: 'AGENT_DEGRADED_HERMES',
+                  description:
+                    'Hermes gateway API is not reachable at http://127.0.0.1:8642 (default). Last error: connect ECONNREFUSED 127.0.0.1:8642',
+                  severity: 'warn',
+                },
+              ],
+            }),
+          ],
+        })
+      );
+    });
+
+    const toggle = container.querySelector('.hub-node-degraded-toggle');
+    expect(toggle).toBeTruthy();
+
+    await act(async () => {
+      (toggle as HTMLButtonElement).click();
+    });
+
+    const reason = container.querySelector('.hub-node-degraded-reason');
+    expect(reason).toBeTruthy();
+    expect(reason?.textContent).toContain('connect ECONNREFUSED');
+    expect(reason?.getAttribute('title')).toBe(
+      'AGENT_DEGRADED_HERMES: Hermes gateway API is not reachable at http://127.0.0.1:8642 (default). Last error: connect ECONNREFUSED 127.0.0.1:8642 (warn)'
+    );
+  });
+});

--- a/test/server/protocol-adapters/hermes-adapter.test.ts
+++ b/test/server/protocol-adapters/hermes-adapter.test.ts
@@ -82,15 +82,40 @@ describe('Hermes gateway settings resolution', () => {
         '    extra:',
         '      host: 127.0.0.1',
         '      port: 9876',
-        '      key: cfg-secret',
+        '      key: cfg#secret # keep hash in scalar, drop comment',
         '',
       ].join('\n')
     );
 
     expect(resolveHermesGatewaySettings(undefined)).toEqual({
       endpoint: 'http://127.0.0.1:9876',
-      apiKey: 'cfg-secret',
+      apiKey: 'cfg#secret',
       source: 'Hermes config',
+    });
+  });
+
+  it('ignores disabled config.yaml API server endpoints', () => {
+    const home = makeTempHome();
+    const hermesHome = path.join(home, '.hermes');
+    fs.mkdirSync(hermesHome, { recursive: true });
+    fs.writeFileSync(
+      path.join(hermesHome, 'config.yaml'),
+      [
+        'platforms:',
+        '  api_server:',
+        '    enabled: false',
+        '    extra:',
+        '      host: 127.0.0.1',
+        '      port: 9876',
+        '      key: disabled-secret',
+        '',
+      ].join('\n')
+    );
+
+    expect(resolveHermesGatewaySettings(undefined)).toEqual({
+      endpoint: 'http://127.0.0.1:8642',
+      apiKey: null,
+      source: 'default',
     });
   });
 
@@ -109,6 +134,30 @@ describe('Hermes gateway settings resolution', () => {
     expect(resolveHermesGatewaySettings(undefined)).toEqual({
       endpoint: 'http://127.0.0.1:2222',
       apiKey: 'profile-secret',
+      source: 'environment',
+    });
+  });
+
+  it('uses the active profile under a custom HERMES_HOME root', () => {
+    makeTempHome();
+    const customRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'relay-hermes-custom-')
+    );
+    tempDirs.push(customRoot);
+    process.env.HERMES_HOME = customRoot;
+
+    const profileHome = path.join(customRoot, 'profiles', 'ebi');
+    fs.mkdirSync(profileHome, { recursive: true });
+    fs.writeFileSync(path.join(customRoot, '.env'), 'API_SERVER_PORT=1111\n');
+    fs.writeFileSync(path.join(customRoot, 'active_profile'), 'ebi\n');
+    fs.writeFileSync(
+      path.join(profileHome, '.env'),
+      'API_SERVER_PORT=2222\nAPI_SERVER_KEY=custom-profile-secret\n'
+    );
+
+    expect(resolveHermesGatewaySettings(undefined)).toEqual({
+      endpoint: 'http://127.0.0.1:2222',
+      apiKey: 'custom-profile-secret',
       source: 'environment',
     });
   });

--- a/test/server/protocol-adapters/hermes-adapter.test.ts
+++ b/test/server/protocol-adapters/hermes-adapter.test.ts
@@ -1,6 +1,56 @@
-import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 import { createAdapterV2 } from '../../../server/protocol-adapters/index.js';
 import { LegacyProtocolAdapterV2Bridge } from '../../../server/protocol-adapters/legacy-v2-bridge.js';
+import { resolveHermesGatewaySettings } from '../../../server/protocol-adapters/hermes-adapter.js';
+
+const ENV_KEYS = [
+  'HOME',
+  'HERMES_HOME',
+  'HERMES_API_ENDPOINT',
+  'HERMES_API_BASE_URL',
+  'HERMES_API_URL',
+  'HERMES_API_TOKEN',
+  'HERMES_API_KEY',
+  'HERMES_GATEWAY_API_KEY',
+  'API_SERVER_KEY',
+  'API_SERVER_HOST',
+  'API_SERVER_PORT',
+];
+
+const originalEnv = new Map<string, string | undefined>(
+  ENV_KEYS.map((key) => [key, process.env[key]])
+);
+const tempDirs: string[] = [];
+
+function resetHermesEnv(): void {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function makeTempHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-hermes-home-'));
+  tempDirs.push(dir);
+  process.env.HOME = dir;
+  delete process.env.HERMES_HOME;
+  for (const key of ENV_KEYS) {
+    if (key !== 'HOME' && key !== 'HERMES_HOME') delete process.env[key];
+  }
+  return dir;
+}
+
+afterEach(resetHermesEnv);
 
 describe('Hermes V2 web adapter registration', () => {
   it('registers hermes as a ProtocolAdapterV2 bridge while native gateway mapping is ported', () => {
@@ -14,6 +64,52 @@ describe('Hermes V2 web adapter registration', () => {
       fileChanges: true,
       approvals: true,
       interrupt: true,
+    });
+  });
+});
+
+describe('Hermes gateway settings resolution', () => {
+  it('reads the API server endpoint and key from Hermes config.yaml', () => {
+    const home = makeTempHome();
+    const hermesHome = path.join(home, '.hermes');
+    fs.mkdirSync(hermesHome, { recursive: true });
+    fs.writeFileSync(
+      path.join(hermesHome, 'config.yaml'),
+      [
+        'platforms:',
+        '  api_server:',
+        '    enabled: true',
+        '    extra:',
+        '      host: 127.0.0.1',
+        '      port: 9876',
+        '      key: cfg-secret',
+        '',
+      ].join('\n')
+    );
+
+    expect(resolveHermesGatewaySettings(undefined)).toEqual({
+      endpoint: 'http://127.0.0.1:9876',
+      apiKey: 'cfg-secret',
+      source: 'Hermes config',
+    });
+  });
+
+  it('lets active Hermes profile env override root env defaults', () => {
+    const home = makeTempHome();
+    const hermesHome = path.join(home, '.hermes');
+    const profileHome = path.join(hermesHome, 'profiles', 'ebi');
+    fs.mkdirSync(profileHome, { recursive: true });
+    fs.writeFileSync(path.join(hermesHome, '.env'), 'API_SERVER_PORT=1111\n');
+    fs.writeFileSync(path.join(hermesHome, 'active_profile'), 'ebi\n');
+    fs.writeFileSync(
+      path.join(profileHome, '.env'),
+      'API_SERVER_PORT=2222\nAPI_SERVER_KEY=profile-secret\n'
+    );
+
+    expect(resolveHermesGatewaySettings(undefined)).toEqual({
+      endpoint: 'http://127.0.0.1:2222',
+      apiKey: 'profile-secret',
+      source: 'environment',
     });
   });
 });


### PR DESCRIPTION
## Summary
- wrap degraded reason descriptions instead of truncating them in the node dashboard
- add full reason text as a hover title on each degraded row
- resolve Hermes gateway API settings from Hermes config.yaml and fix profile env precedence so Relay does not default to the wrong gateway endpoint/key

## Test Plan
- npm test -- test/server/protocol-adapters/hermes-adapter.test.ts test/degraded-ui/node-dashboard-degraded.test.ts test/degraded-ui/node-dashboard-degraded-interaction.test.ts
- npm run check
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips displaying full degraded reason details on hover.
  * Hermes gateway now reads configuration settings from Hermes config files in addition to environment variables.

* **Style**
  * Improved text wrapping for degraded reason descriptions instead of truncation.

* **Tests**
  * Added UI interaction tests for degraded reasons functionality.
  * Added configuration resolution tests for Hermes adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->