### PR TITLE
Spike RelayPtySession libghostty terminal model

### DIFF
--- a/docs/spikes/834-relay-pty-libghostty.md
+++ b/docs/spikes/834-relay-pty-libghostty.md
@@ -1,0 +1,178 @@
+# Spike: RelayPtySession + libghostty-vt non-tmux TUI parity
+
+> **Status:** Spike complete — prototype path, tests, and smoke evidence
+> **Scope:** Relay-owned PTY path without tmux, backed by a server-side terminal model
+> **Date:** 2026-05-31
+> **Issue:** [#834](https://github.com/donovan-yohan/relay-ide/issues/834)
+> **Epic:** [#832](https://github.com/donovan-yohan/relay-ide/issues/832)
+
+---
+
+## tl;dr
+
+**Recommendation: go, but keep tmux as compatibility until durability/control gaps close.**
+
+`RelayPtySession` can become the next candidate default behind a feature flag. The spike proves that Relay can spawn a command directly with `node-pty`, feed PTY bytes into `libghostty-vt`, read modeled screen text/JSON/cells/cursor/alt-screen state without `tmux capture-pane`, send typed input bytes without `tmux send-keys`, track idle/activity from PTY timing, and resize both the PTY and terminal model.
+
+Do **not** delete the tmux runtime yet. The prototype does not solve durable reattach after Relay process restart, tmux copy-mode/mobile selection parity, full DEC/private mode reporting, tmux session naming/operator recovery, or persistent process ownership. Those are the remaining tmux assumptions.
+
+---
+
+## Prototype files
+
+- `server/terminal-model-backend.ts`
+  - `TerminalModelBackend` interface.
+  - `LibghosttyTerminalModelBackend` implementation using `@coder/libghostty-vt-node`.
+  - screen text/json snapshots, cursor, title tracking from OSC `0/2`, alt-screen mode, cells, resize, and typed input encoding.
+- `server/relay-pty-session.ts`
+  - `RelayPtySession` owner that directly spawns `command + args` under `node-pty`, not tmux.
+  - feeds output into the terminal model.
+  - sends typed text/keys (`Enter`, `Escape`, `Tab`, arrows, `Ctrl-C`) as terminal bytes.
+  - exposes snapshot timing (`startedAt`, `lastActivityAt`, `lastOutputAt`, `lastInputAt`, `lastResizeAt`, `idleMs`).
+  - injects Relay identity env (`RELAY_IDE_SESSION_ID`, `RELAY_IDE_SESSION_RUNTIME`, `RELAY_IDE_CLI_PATH`, optional work context/task refs).
+- `test/relay-pty-session.test.ts`
+  - unit coverage for libghostty snapshots, title tracking, alt-screen, input encoding, direct non-tmux spawn, resize, timing, and env injection.
+
+The existing production `sessions.ts` / `pty-handler.ts` path is untouched. This is deliberate: #834 is a deletion-gate spike, not a runtime migration hidden in a research PR.
+
+---
+
+## libghostty-vt binding result
+
+Primary binding tested: `@coder/libghostty-vt-node@0.1.0-beta.1`.
+
+Local install/import smoke:
+
+```bash
+npm install @coder/libghostty-vt-node@0.1.0-beta.1
+node --input-type=module -e "import('@coder/libghostty-vt-node').then(m=>{ const t=m.createTerminal({cols:80,rows:24,scrollbackLimit:100}); t.feed('hello\\n'); console.log(t.getVisibleText()); })"
+```
+
+Result: import worked on devbox Linux x64 and rendered `hello`.
+
+Runtime metadata from the prototype smoke:
+
+```json
+{
+  "napiVersion": 10,
+  "ghosttyVersion": "0.1.0-dev",
+  "packageVersion": "0.1.0-beta.1",
+  "platform": "linux",
+  "arch": "x64"
+}
+```
+
+Binding/build notes:
+
+- The npm tarball includes prebuilds for Linux x64, Linux arm64, and macOS arm64.
+- Windows is unsupported by the package today.
+- The package install script does not build native code automatically; local native rebuild is explicit via `npm run build:libghostty` then `npm run build:native` inside the package.
+- Native build requires fetching a pinned Ghostty commit and building static `libghostty-vt`; that adds Zig/Ghostty C API/platform risk if a prebuild is missing.
+- The exposed beta API gives visible text, structured visible lines/cells, cursor, resize, and `isAltScreen`; it does not expose every private terminal mode Relay may eventually want. The prototype therefore reports unavailable mode booleans as `null` and lists them in `unsupported`.
+
+No fallback was needed for the implemented prototype because the libghostty binding worked locally. If future CI/platforms reject the native addon, `@xterm/headless` is the named fallback to validate the same interface before deciding whether to keep the abstraction.
+
+---
+
+## Smoke evidence
+
+### Provider-like CLI smoke: Codex auth TUI
+
+Command: `codex` under `RelayPtySession`, dimensions `100x30`, resized to `120x32`.
+
+Important caveat: standalone `codex` in this process opened its sign-in picker instead of an authenticated agent session. Hermes has OpenAI Codex auth in the profile, but the external Codex CLI did not see usable CLI auth here. So this is evidence for a real provider CLI interactive TUI, not evidence that a paid Codex coding session ran. annoying, but honest.
+
+Evidence artifact: `/tmp/relay-pty-codex-smoke.json`.
+
+Observed:
+
+- spawned command was `codex` directly, not tmux.
+- visible modeled screen text included `Welcome to Codex, OpenAI's command-line coding agent`.
+- text/key input was sent through `RelayPtySession`: text, `Tab`, arrows, `Escape`, `Ctrl-C`.
+- selection moved from option 1 to option 3 after typed key input.
+- resize was applied and timing updated.
+- modeled cell sample included styled `Codex` cells with `bold: true`.
+- `altScreen` was `false`; Codex used cursor-addressed full-screen rendering without DEC alt-screen in this auth picker.
+
+Sample modeled text after input:
+
+```text
+Welcome to Codex, OpenAI's command-line coding agent
+
+Sign in with ChatGPT to use Codex as part of your paid plan
+or connect an API key for usage-based billing
+
+1. Sign in with ChatGPT
+   Usage included with Plus, Pro, Business, and Enterprise plans
+
+2. Sign in with Device Code
+   Sign in from another device with a one-time code
+
+> 3. Provide your own API key
+   Pay for what you use
+
+Press enter to continue
+```
+
+### Alternate-screen smoke: Vim
+
+Command: `vim -Nu NONE -n /tmp/relay-pty-vim-smoke.txt` under `RelayPtySession`, dimensions `90x24`, resized to `100x28`.
+
+Evidence artifact: `/tmp/relay-pty-vim-smoke.json`.
+
+Observed:
+
+- `initial.terminal.modes.altScreen === true`.
+- after `:q!` + `Enter`, `after.terminal.modes.altScreen === false`.
+- visible modeled screen text included file contents and Vim status text.
+- typed input exercised text, `Escape`, arrows, resize, and `Enter` without tmux.
+
+Sample initial modeled text:
+
+```text
+relay pty vim smoke
+~
+~
+~
+"/tmp/relay-pty-vim-smoke.txt" 1L, 20B
+```
+
+---
+
+## Input mapping
+
+`TerminalInput` is intentionally small and typed:
+
+| Action | Bytes |
+| --- | --- |
+| text | UTF-8 text bytes |
+| Enter | `\r` |
+| Escape | `\x1b` |
+| Tab | `\t` |
+| ArrowUp | `\x1b[A` |
+| ArrowDown | `\x1b[B` |
+| ArrowRight | `\x1b[C` |
+| ArrowLeft | `\x1b[D` |
+| Ctrl-C | `\x03` |
+
+This is not a replacement for raw debug writes. It is the product/control vocabulary Relay can audit and route without exposing `tmux send-keys` or terminal-substrate-specific names.
+
+---
+
+## Remaining tmux assumptions
+
+Keep tmux compatibility until these are resolved:
+
+1. **Durability / reattach:** tmux currently keeps the process alive when browser/server attachments churn. `RelayPtySession` owns the child directly, so a Relay process restart kills or orphans it unless a runtime daemon/process-owner layer lands.
+2. **Operator recovery:** tmux session names are human-discoverable and killable with standard tools. The prototype needs equivalent process registry/diagnostics.
+3. **Mobile selection/copy-mode:** current mobile copy-mode depends on tmux behavior. A non-tmux path needs a xterm/model-backed selection/copy story.
+4. **Mode coverage:** libghostty beta exposes `isAltScreen`, cursor, cells, and text. Application cursor mode, mouse tracking, bracketed paste, and other private modes are not exposed through the Node binding yet.
+5. **Control/audit integration:** typed input exists in the prototype, but production supervisor/control-state/audit paths still need policy wiring.
+6. **Session persistence:** scrollback/model state is in memory only; it needs serialization if Relay wants hot restart or daemon migration parity.
+7. **Platform support:** Linux x64 is green here. macOS arm64 likely works via prebuild. Windows and missing-prebuild platforms need fallback or native build proof.
+
+---
+
+## Next slice
+
+Feature-flag the prototype as an internal/local-only runtime candidate, wire it behind a narrow create option, and add a real runtime-owner decision before replacing tmux defaults. The next PR should keep the invariant explicit: `tmux` remains the stable production substrate until non-tmux sessions can survive the same lifecycle surfaces.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.119",
+        "@coder/libghostty-vt-node": "^0.1.0-beta.1",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -580,6 +581,20 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@coder/libghostty-vt-node": {
+      "version": "0.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@coder/libghostty-vt-node/-/libghostty-vt-node-0.1.0-beta.1.tgz",
+      "integrity": "sha512-HUt/FN3XAu4p/xmrkPWcvXgbWOu5YX+8jCv3ZNJXHk6BvVNENdwBv1KmoB34ejuSVWQbiD2Vsiv27cnpphQv5g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.1",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=20.19"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -5447,6 +5462,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-pty": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "author": "Donovan Yohan",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.119",
+    "@coder/libghostty-vt-node": "^0.1.0-beta.1",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/server/relay-pty-session.ts
+++ b/server/relay-pty-session.ts
@@ -1,0 +1,259 @@
+import * as pty from 'node-pty';
+import type { IPty, IPtyForkOptions } from 'node-pty';
+import { fileURLToPath } from 'node:url';
+import { cleanEnv } from './utils.js';
+import {
+  createLibghosttyTerminalModelBackend,
+  encodeTerminalInput,
+  type EncodedTerminalInput,
+  type TerminalInput,
+  type TerminalInputKey,
+  type TerminalModelBackend,
+  type TerminalModelSnapshot,
+} from './terminal-model-backend.js';
+
+export type RelayPtySessionStatus = 'starting' | 'running' | 'exited' | 'closed';
+
+export interface RelayPtySessionOptions {
+  id: string;
+  command: string;
+  args?: string[];
+  cwd: string;
+  cols?: number;
+  rows?: number;
+  env?: NodeJS.ProcessEnv;
+  backend?: TerminalModelBackend;
+  spawn?: PtySpawn;
+  relayCliPath?: string;
+  workContextId?: string;
+  taskRef?: string;
+}
+
+export interface RelayPtySessionTimingSnapshot {
+  startedAt: string;
+  lastActivityAt: string;
+  lastOutputAt: string | null;
+  lastInputAt: string | null;
+  lastResizeAt: string | null;
+  idleMs: number;
+}
+
+export interface RelayPtySessionSnapshot {
+  id: string;
+  status: RelayPtySessionStatus;
+  command: string;
+  args: string[];
+  cwd: string;
+  cols: number;
+  rows: number;
+  timing: RelayPtySessionTimingSnapshot;
+  terminal: TerminalModelSnapshot;
+  exit: { exitCode: number; signal?: number } | null;
+}
+
+export interface RelayPtySessionDisposable {
+  dispose(): void;
+}
+
+type DataHandler = (bytes: Buffer) => void;
+type ExitHandler = (event: { exitCode: number; signal?: number }) => void;
+
+type PtySpawn = (
+  command: string,
+  args: string[],
+  options: IPtyForkOptions
+) => IPty;
+
+const DEFAULT_COLS = 80;
+const DEFAULT_ROWS = 24;
+const TERM_NAME = 'xterm-256color';
+
+function defaultRelayCliPath(): string {
+  return fileURLToPath(new URL('../dist/bin/relay-ide.js', import.meta.url));
+}
+
+export function buildRelayPtySessionEnv(
+  options: Pick<
+    RelayPtySessionOptions,
+    'id' | 'env' | 'relayCliPath' | 'workContextId' | 'taskRef'
+  >
+): Record<string, string> {
+  const base = {
+    ...cleanEnv(),
+    ...options.env,
+  } as Record<string, string>;
+  delete base.CLAUDECODE;
+
+  base.RELAY_IDE_SESSION_ID = options.id;
+  base.RELAY_IDE_SESSION_RUNTIME = 'relay-pty/libghostty-vt';
+  base.RELAY_IDE_CLI_PATH = options.relayCliPath ?? defaultRelayCliPath();
+  if (options.workContextId) base.RELAY_IDE_WORK_CONTEXT_ID = options.workContextId;
+  if (options.taskRef) base.RELAY_IDE_TASK_REF = options.taskRef;
+  return base;
+}
+
+export function createRelayPtySession(options: RelayPtySessionOptions): RelayPtySession {
+  return new RelayPtySession(options);
+}
+
+/**
+ * Prototype PTY owner that bypasses tmux. It is intentionally not wired into the
+ * production session registry yet: the point of #834 is to prove the terminal
+ * model and input contract while keeping the existing tmux runtime untouched.
+ */
+export class RelayPtySession {
+  readonly id: string;
+  readonly command: string;
+  readonly args: string[];
+  readonly cwd: string;
+  readonly backend: TerminalModelBackend;
+
+  private readonly proc: IPty;
+  private readonly dataHandlers = new Set<DataHandler>();
+  private readonly exitHandlers = new Set<ExitHandler>();
+  private statusValue: RelayPtySessionStatus = 'starting';
+  private colsValue: number;
+  private rowsValue: number;
+  private readonly startedAt = Date.now();
+  private lastActivityAt = this.startedAt;
+  private lastOutputAt: number | null = null;
+  private lastInputAt: number | null = null;
+  private lastResizeAt: number | null = null;
+  private exitValue: { exitCode: number; signal?: number } | null = null;
+
+  constructor(options: RelayPtySessionOptions) {
+    this.id = options.id;
+    this.command = options.command;
+    this.args = options.args ?? [];
+    this.cwd = options.cwd;
+    this.colsValue = options.cols ?? DEFAULT_COLS;
+    this.rowsValue = options.rows ?? DEFAULT_ROWS;
+    this.backend =
+      options.backend ??
+      createLibghosttyTerminalModelBackend({
+        cols: this.colsValue,
+        rows: this.rowsValue,
+        scrollbackLimit: 1000,
+      });
+
+    const spawn = options.spawn ?? (pty.spawn as unknown as PtySpawn);
+    this.proc = spawn(this.command, this.args, {
+      name: TERM_NAME,
+      cols: this.colsValue,
+      rows: this.rowsValue,
+      cwd: this.cwd,
+      env: buildRelayPtySessionEnv(options),
+    });
+
+    this.proc.onData((chunk) => {
+      const bytes = Buffer.from(chunk, 'utf8');
+      this.markOutput();
+      this.backend.feed(bytes);
+      for (const handler of Array.from(this.dataHandlers)) handler(bytes);
+    });
+    this.proc.onExit(({ exitCode, signal }) => {
+      this.statusValue = 'exited';
+      const event: { exitCode: number; signal?: number } = { exitCode: exitCode ?? 0 };
+      if (signal !== undefined && signal !== null) event.signal = signal;
+      this.exitValue = event;
+      for (const handler of Array.from(this.exitHandlers)) handler(event);
+    });
+    this.statusValue = 'running';
+  }
+
+  get status(): RelayPtySessionStatus {
+    return this.statusValue;
+  }
+
+  onData(handler: DataHandler): RelayPtySessionDisposable {
+    this.dataHandlers.add(handler);
+    return { dispose: () => this.dataHandlers.delete(handler) };
+  }
+
+  onExit(handler: ExitHandler): RelayPtySessionDisposable {
+    this.exitHandlers.add(handler);
+    return { dispose: () => this.exitHandlers.delete(handler) };
+  }
+
+  writeRaw(bytes: Buffer): void {
+    if (this.statusValue !== 'running') return;
+    this.markInput();
+    this.proc.write(bytes.toString('utf8'));
+  }
+
+  send(input: TerminalInput): EncodedTerminalInput {
+    const encoded = encodeTerminalInput(input);
+    this.writeRaw(encoded.bytes);
+    return encoded;
+  }
+
+  sendText(text: string): EncodedTerminalInput {
+    return this.send({ type: 'text', text });
+  }
+
+  sendKey(key: TerminalInputKey): EncodedTerminalInput {
+    return this.send({ type: 'key', key });
+  }
+
+  resize(cols: number, rows: number): void {
+    if (!Number.isInteger(cols) || cols <= 0) return;
+    if (!Number.isInteger(rows) || rows <= 0) return;
+    if (this.statusValue !== 'running') return;
+    this.colsValue = cols;
+    this.rowsValue = rows;
+    this.markResize();
+    this.proc.resize(cols, rows);
+    this.backend.resize(cols, rows);
+  }
+
+  snapshot(options: { includeCells?: boolean; includeScrollback?: boolean } = {}): RelayPtySessionSnapshot {
+    const at = Date.now();
+    return {
+      id: this.id,
+      status: this.statusValue,
+      command: this.command,
+      args: this.args,
+      cwd: this.cwd,
+      cols: this.colsValue,
+      rows: this.rowsValue,
+      timing: {
+        startedAt: new Date(this.startedAt).toISOString(),
+        lastActivityAt: new Date(this.lastActivityAt).toISOString(),
+        lastOutputAt: this.lastOutputAt === null ? null : new Date(this.lastOutputAt).toISOString(),
+        lastInputAt: this.lastInputAt === null ? null : new Date(this.lastInputAt).toISOString(),
+        lastResizeAt: this.lastResizeAt === null ? null : new Date(this.lastResizeAt).toISOString(),
+        idleMs: at - this.lastActivityAt,
+      },
+      terminal: this.backend.snapshot(options),
+      exit: this.exitValue,
+    };
+  }
+
+  close(): void {
+    if (this.statusValue === 'closed') return;
+    this.statusValue = 'closed';
+    try {
+      this.proc.kill();
+    } finally {
+      this.backend.dispose();
+    }
+  }
+
+  private markOutput(): void {
+    const at = Date.now();
+    this.lastOutputAt = at;
+    this.lastActivityAt = at;
+  }
+
+  private markInput(): void {
+    const at = Date.now();
+    this.lastInputAt = at;
+    this.lastActivityAt = at;
+  }
+
+  private markResize(): void {
+    const at = Date.now();
+    this.lastResizeAt = at;
+    this.lastActivityAt = at;
+  }
+}

--- a/server/terminal-model-backend.ts
+++ b/server/terminal-model-backend.ts
@@ -1,0 +1,205 @@
+import {
+  createTerminal,
+  getNativeInfo,
+  type NativeInfo,
+  type SnapshotCell,
+  type VisibleLine,
+  type GhosttyVtTerminal,
+} from '@coder/libghostty-vt-node';
+
+export type TerminalInputKey =
+  | 'Enter'
+  | 'Escape'
+  | 'Tab'
+  | 'ArrowUp'
+  | 'ArrowDown'
+  | 'ArrowLeft'
+  | 'ArrowRight'
+  | 'CtrlC';
+
+export type TerminalInput =
+  | { type: 'text'; text: string }
+  | { type: 'key'; key: TerminalInputKey };
+
+export interface EncodedTerminalInput {
+  input: TerminalInput;
+  sequence: string;
+  bytes: Buffer;
+}
+
+export interface TerminalCursorSnapshot {
+  row: number;
+  col: number;
+}
+
+export interface TerminalModeSnapshot {
+  altScreen: boolean;
+  applicationCursorKeys: boolean | null;
+  mouseTracking: boolean | null;
+  bracketedPaste: boolean | null;
+}
+
+export interface TerminalModelSnapshot {
+  backend: 'libghostty-vt';
+  backendInfo: NativeInfo;
+  cols: number;
+  rows: number;
+  cursor: TerminalCursorSnapshot;
+  title: string | null;
+  modes: TerminalModeSnapshot;
+  visibleText: string;
+  visibleLines: VisibleLine[];
+  scrollbackLines?: VisibleLine[];
+  cells?: SnapshotCell[];
+  generatedAt: string;
+  unsupported: string[];
+}
+
+export interface TerminalModelBackend {
+  readonly name: 'libghostty-vt';
+  readonly backendInfo: NativeInfo;
+  feed(data: Uint8Array | Buffer | string): void;
+  resize(cols: number, rows: number): void;
+  getVisibleText(): string;
+  snapshot(options?: { includeCells?: boolean; includeScrollback?: boolean }): TerminalModelSnapshot;
+  dispose(): void;
+}
+
+const KEY_SEQUENCES: Record<TerminalInputKey, string> = {
+  Enter: '\r',
+  Escape: '\x1b',
+  Tab: '\t',
+  ArrowUp: '\x1b[A',
+  ArrowDown: '\x1b[B',
+  ArrowRight: '\x1b[C',
+  ArrowLeft: '\x1b[D',
+  CtrlC: '\x03',
+};
+
+/**
+ * Encodes the small supervisor/mobile input vocabulary into real terminal bytes.
+ * This is intentionally smaller than raw PTY writes; callers that need arbitrary
+ * bytes can still use lower-level debug APIs, but product actions should stay
+ * typed and auditable.
+ */
+export function encodeTerminalInput(input: TerminalInput): EncodedTerminalInput {
+  const sequence = input.type === 'text' ? input.text : KEY_SEQUENCES[input.key];
+  return {
+    input,
+    sequence,
+    bytes: Buffer.from(sequence, 'utf8'),
+  };
+}
+
+export interface LibghosttyTerminalModelBackendOptions {
+  cols: number;
+  rows: number;
+  scrollbackLimit?: number;
+}
+
+export function createLibghosttyTerminalModelBackend(
+  options: LibghosttyTerminalModelBackendOptions
+): LibghosttyTerminalModelBackend {
+  return new LibghosttyTerminalModelBackend(options);
+}
+
+export class LibghosttyTerminalModelBackend implements TerminalModelBackend {
+  readonly name = 'libghostty-vt' as const;
+  readonly backendInfo: NativeInfo;
+  private readonly terminal: GhosttyVtTerminal;
+  private title: string | null = null;
+  private disposed = false;
+
+  constructor(options: LibghosttyTerminalModelBackendOptions) {
+    this.backendInfo = getNativeInfo();
+    this.terminal = createTerminal(options);
+  }
+
+  feed(data: Uint8Array | Buffer | string): void {
+    this.assertLive();
+    this.captureTitle(data);
+    this.terminal.feed(data);
+  }
+
+  resize(cols: number, rows: number): void {
+    this.assertLive();
+    this.terminal.resize(cols, rows);
+  }
+
+  getVisibleText(): string {
+    this.assertLive();
+    return this.terminal.getVisibleText();
+  }
+
+  snapshot(options: { includeCells?: boolean; includeScrollback?: boolean } = {}): TerminalModelSnapshot {
+    this.assertLive();
+    const snapshot = this.terminal.snapshot(options);
+    const modelSnapshot: TerminalModelSnapshot = {
+      backend: this.name,
+      backendInfo: this.backendInfo,
+      cols: snapshot.cols,
+      rows: snapshot.rows,
+      cursor: {
+        row: snapshot.cursorRow,
+        col: snapshot.cursorCol,
+      },
+      title: this.title,
+      modes: {
+        altScreen: snapshot.isAltScreen,
+        applicationCursorKeys: null,
+        mouseTracking: null,
+        bracketedPaste: null,
+      },
+      visibleText: this.terminal.getVisibleText(),
+      visibleLines: snapshot.visibleLines,
+      generatedAt: new Date().toISOString(),
+      unsupported: [
+        'libghostty-vt-node beta exposes alt-screen but not DEC mode booleans for application cursor keys, mouse tracking, or bracketed paste yet',
+      ],
+    };
+    if (snapshot.scrollbackLines !== undefined) {
+      modelSnapshot.scrollbackLines = snapshot.scrollbackLines;
+    }
+    if (snapshot.cells !== undefined) {
+      modelSnapshot.cells = snapshot.cells;
+    }
+    return modelSnapshot;
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.terminal.dispose();
+  }
+
+  private assertLive(): void {
+    if (this.disposed) throw new Error('terminal model backend is disposed');
+  }
+
+  private captureTitle(data: Uint8Array | Buffer | string): void {
+    const text = typeof data === 'string' ? data : Buffer.from(data).toString('utf8');
+    const oscPrefix = String.fromCharCode(27, 93);
+    const bel = String.fromCharCode(7);
+    const st = `${String.fromCharCode(27)}\\`;
+    let offset = 0;
+    while (offset < text.length) {
+      const start = text.indexOf(oscPrefix, offset);
+      if (start === -1) return;
+      const payloadStart = start + oscPrefix.length;
+      const belEnd = text.indexOf(bel, payloadStart);
+      const stEnd = text.indexOf(st, payloadStart);
+      const end =
+        belEnd === -1
+          ? stEnd
+          : stEnd === -1
+            ? belEnd
+            : Math.min(belEnd, stEnd);
+      if (end === -1) return;
+      const payload = text.slice(payloadStart, end);
+      if (payload.startsWith('0;') || payload.startsWith('2;')) {
+        this.title = payload.slice(2);
+      }
+      offset = end + 1;
+    }
+  }
+}

--- a/server/terminal-model-backend.ts
+++ b/server/terminal-model-backend.ts
@@ -103,11 +103,17 @@ export function createLibghosttyTerminalModelBackend(
   return new LibghosttyTerminalModelBackend(options);
 }
 
+const OSC_PREFIX = `${String.fromCharCode(27)}]`;
+const BEL_TERMINATOR = String.fromCharCode(7);
+const ST_TERMINATOR = `${String.fromCharCode(27)}\\`;
+const MAX_PENDING_OSC_TITLE_BYTES = 8192;
+
 export class LibghosttyTerminalModelBackend implements TerminalModelBackend {
   readonly name = 'libghostty-vt' as const;
   readonly backendInfo: NativeInfo;
   private readonly terminal: GhosttyVtTerminal;
   private title: string | null = null;
+  private pendingOscTitleText = '';
   private disposed = false;
 
   constructor(options: LibghosttyTerminalModelBackendOptions) {
@@ -177,29 +183,40 @@ export class LibghosttyTerminalModelBackend implements TerminalModelBackend {
   }
 
   private captureTitle(data: Uint8Array | Buffer | string): void {
-    const text = typeof data === 'string' ? data : Buffer.from(data).toString('utf8');
-    const oscPrefix = String.fromCharCode(27, 93);
-    const bel = String.fromCharCode(7);
-    const st = `${String.fromCharCode(27)}\\`;
+    const incoming = typeof data === 'string' ? data : Buffer.from(data).toString('utf8');
+    const text = this.pendingOscTitleText + incoming;
+    this.pendingOscTitleText = '';
+
     let offset = 0;
     while (offset < text.length) {
-      const start = text.indexOf(oscPrefix, offset);
-      if (start === -1) return;
-      const payloadStart = start + oscPrefix.length;
-      const belEnd = text.indexOf(bel, payloadStart);
-      const stEnd = text.indexOf(st, payloadStart);
-      const end =
-        belEnd === -1
-          ? stEnd
-          : stEnd === -1
-            ? belEnd
-            : Math.min(belEnd, stEnd);
-      if (end === -1) return;
+      const start = text.indexOf(OSC_PREFIX, offset);
+      if (start === -1) {
+        const possiblePrefixStart = OSC_PREFIX.charAt(0);
+        this.pendingOscTitleText = text.endsWith(possiblePrefixStart) ? possiblePrefixStart : '';
+        return;
+      }
+
+      const payloadStart = start + OSC_PREFIX.length;
+      const belEnd = text.indexOf(BEL_TERMINATOR, payloadStart);
+      const stEnd = text.indexOf(ST_TERMINATOR, payloadStart);
+      const [end, terminatorLength] = this.firstOscTerminator(belEnd, stEnd);
+      if (end === -1) {
+        this.pendingOscTitleText = text.slice(start, start + MAX_PENDING_OSC_TITLE_BYTES);
+        return;
+      }
+
       const payload = text.slice(payloadStart, end);
       if (payload.startsWith('0;') || payload.startsWith('2;')) {
         this.title = payload.slice(2);
       }
-      offset = end + 1;
+      offset = end + terminatorLength;
     }
+  }
+
+  private firstOscTerminator(belEnd: number, stEnd: number): [number, number] {
+    if (belEnd === -1 && stEnd === -1) return [-1, 0];
+    if (belEnd === -1) return [stEnd, ST_TERMINATOR.length];
+    if (stEnd === -1) return [belEnd, BEL_TERMINATOR.length];
+    return belEnd < stEnd ? [belEnd, BEL_TERMINATOR.length] : [stEnd, ST_TERMINATOR.length];
   }
 }

--- a/test/relay-pty-session.test.ts
+++ b/test/relay-pty-session.test.ts
@@ -79,6 +79,30 @@ describe('TerminalModelBackend — libghostty-vt', () => {
     backend.dispose();
   });
 
+  it('tracks OSC titles split across feed calls with BEL terminators', () => {
+    const backend = createLibghosttyTerminalModelBackend({ cols: 20, rows: 5, scrollbackLimit: 10 });
+
+    backend.feed('\x1b]2;spl');
+    backend.feed('it-title\x07hello');
+
+    const snapshot = backend.snapshot();
+    expect(snapshot.title).toBe('split-title');
+    expect(snapshot.visibleText).toContain('hello');
+    backend.dispose();
+  });
+
+  it('tracks OSC titles split across feed calls with ST terminators', () => {
+    const backend = createLibghosttyTerminalModelBackend({ cols: 20, rows: 5, scrollbackLimit: 10 });
+
+    backend.feed('\x1b]0;st-title\x1b');
+    backend.feed('\\hello');
+
+    const snapshot = backend.snapshot();
+    expect(snapshot.title).toBe('st-title');
+    expect(snapshot.visibleText).toContain('hello');
+    backend.dispose();
+  });
+
   it('encodes typed input keys without tmux send-keys names', () => {
     expect(encodeTerminalInput({ type: 'text', text: 'abc' }).sequence).toBe('abc');
     expect(encodeTerminalInput({ type: 'key', key: 'Enter' }).bytes).toEqual(Buffer.from('\r'));

--- a/test/relay-pty-session.test.ts
+++ b/test/relay-pty-session.test.ts
@@ -1,0 +1,180 @@
+import { Buffer } from 'node:buffer';
+import { describe, expect, it } from 'vitest';
+import type { IPty } from 'node-pty';
+import {
+  createLibghosttyTerminalModelBackend,
+  encodeTerminalInput,
+} from '../server/terminal-model-backend.js';
+import {
+  buildRelayPtySessionEnv,
+  createRelayPtySession,
+} from '../server/relay-pty-session.js';
+
+type DataHandler = (chunk: string) => void;
+type ExitHandler = (event: { exitCode: number; signal?: number }) => void;
+
+class FakePty {
+  cols: number;
+  rows: number;
+  written: string[] = [];
+  killed = false;
+  private dataHandlers: DataHandler[] = [];
+  private exitHandlers: ExitHandler[] = [];
+
+  constructor(cols: number, rows: number) {
+    this.cols = cols;
+    this.rows = rows;
+  }
+
+  onData(handler: DataHandler): { dispose: () => void } {
+    this.dataHandlers.push(handler);
+    return { dispose: () => undefined };
+  }
+
+  onExit(handler: ExitHandler): { dispose: () => void } {
+    this.exitHandlers.push(handler);
+    return { dispose: () => undefined };
+  }
+
+  write(data: string): void {
+    this.written.push(data);
+  }
+
+  resize(cols: number, rows: number): void {
+    this.cols = cols;
+    this.rows = rows;
+  }
+
+  kill(): void {
+    this.killed = true;
+    for (const handler of this.exitHandlers) handler({ exitCode: 0 });
+  }
+
+  emitData(chunk: string): void {
+    for (const handler of this.dataHandlers) handler(chunk);
+  }
+}
+
+describe('TerminalModelBackend — libghostty-vt', () => {
+  it('models visible text, cursor, title, resize, and alt screen from terminal bytes', () => {
+    const backend = createLibghosttyTerminalModelBackend({ cols: 20, rows: 5, scrollbackLimit: 10 });
+    backend.feed('\x1b]2;relay-title\x07hello\r\nworld');
+
+    const normal = backend.snapshot({ includeCells: true });
+    expect(normal.backend).toBe('libghostty-vt');
+    expect(normal.title).toBe('relay-title');
+    expect(normal.visibleText).toContain('hello');
+    expect(normal.visibleText).toContain('world');
+    expect(normal.cursor.row).toBeGreaterThanOrEqual(0);
+    expect(normal.modes.altScreen).toBe(false);
+    expect(normal.cells?.length).toBeGreaterThan(0);
+
+    backend.resize(40, 10);
+    backend.feed('\x1b[?1049h\x1b[Halt-screen');
+    const alt = backend.snapshot();
+    expect(alt.cols).toBe(40);
+    expect(alt.rows).toBe(10);
+    expect(alt.modes.altScreen).toBe(true);
+    expect(alt.visibleText).toContain('alt-screen');
+    backend.dispose();
+  });
+
+  it('encodes typed input keys without tmux send-keys names', () => {
+    expect(encodeTerminalInput({ type: 'text', text: 'abc' }).sequence).toBe('abc');
+    expect(encodeTerminalInput({ type: 'key', key: 'Enter' }).bytes).toEqual(Buffer.from('\r'));
+    expect(encodeTerminalInput({ type: 'key', key: 'Escape' }).sequence).toBe('\x1b');
+    expect(encodeTerminalInput({ type: 'key', key: 'Tab' }).sequence).toBe('\t');
+    expect(encodeTerminalInput({ type: 'key', key: 'ArrowUp' }).sequence).toBe('\x1b[A');
+    expect(encodeTerminalInput({ type: 'key', key: 'ArrowDown' }).sequence).toBe('\x1b[B');
+    expect(encodeTerminalInput({ type: 'key', key: 'ArrowLeft' }).sequence).toBe('\x1b[D');
+    expect(encodeTerminalInput({ type: 'key', key: 'ArrowRight' }).sequence).toBe('\x1b[C');
+    expect(encodeTerminalInput({ type: 'key', key: 'CtrlC' }).sequence).toBe('\x03');
+  });
+});
+
+describe('RelayPtySession prototype', () => {
+  it('spawns the requested command directly, not through tmux, and feeds a terminal model', () => {
+    let lastPty: FakePty | undefined;
+    let spawnedCommand: string | undefined;
+    let spawnedArgs: string[] | undefined;
+    let spawnedEnv: Record<string, string | undefined> | undefined;
+
+    const session = createRelayPtySession({
+      id: 'relay-pty-test',
+      command: 'fake-agent',
+      args: ['--tui'],
+      cwd: '/tmp',
+      cols: 80,
+      rows: 24,
+      env: { CUSTOM_ENV: 'ok' },
+      relayCliPath: '/tmp/relay-ide',
+      workContextId: 'wc-1',
+      taskRef: 'github:834',
+      spawn: (command, args, options) => {
+        spawnedCommand = command;
+        spawnedArgs = args;
+        spawnedEnv = options.env as Record<string, string>;
+        lastPty = new FakePty(options.cols ?? 0, options.rows ?? 0);
+        return lastPty as unknown as IPty;
+      },
+    });
+
+    expect(spawnedCommand).toBe('fake-agent');
+    expect(spawnedArgs).toEqual(['--tui']);
+    expect(spawnedCommand).not.toBe('tmux');
+    expect(spawnedEnv?.RELAY_IDE_SESSION_ID).toBe('relay-pty-test');
+    expect(spawnedEnv?.RELAY_IDE_SESSION_RUNTIME).toBe('relay-pty/libghostty-vt');
+    expect(spawnedEnv?.RELAY_IDE_CLI_PATH).toBe('/tmp/relay-ide');
+    expect(spawnedEnv?.RELAY_IDE_WORK_CONTEXT_ID).toBe('wc-1');
+    expect(spawnedEnv?.RELAY_IDE_TASK_REF).toBe('github:834');
+
+    lastPty?.emitData('\x1b]2;agent\x07ready\r\n> ');
+    session.sendText('hello');
+    session.sendKey('Enter');
+    session.sendKey('Escape');
+    session.sendKey('Tab');
+    session.sendKey('ArrowUp');
+    session.sendKey('ArrowDown');
+    session.sendKey('ArrowLeft');
+    session.sendKey('ArrowRight');
+    session.sendKey('CtrlC');
+    session.resize(100, 30);
+
+    expect(lastPty?.written).toEqual([
+      'hello',
+      '\r',
+      '\x1b',
+      '\t',
+      '\x1b[A',
+      '\x1b[B',
+      '\x1b[D',
+      '\x1b[C',
+      '\x03',
+    ]);
+    expect(lastPty?.cols).toBe(100);
+    expect(lastPty?.rows).toBe(30);
+
+    const snapshot = session.snapshot({ includeCells: true });
+    expect(snapshot.terminal.title).toBe('agent');
+    expect(snapshot.terminal.visibleText).toContain('ready');
+    expect(snapshot.timing.lastOutputAt).not.toBeNull();
+    expect(snapshot.timing.lastInputAt).not.toBeNull();
+    expect(snapshot.timing.lastResizeAt).not.toBeNull();
+
+    session.close();
+    expect(lastPty?.killed).toBe(true);
+  });
+
+  it('injects Relay identity env without preserving CLAUDECODE', () => {
+    const env = buildRelayPtySessionEnv({
+      id: 's1',
+      env: { CLAUDECODE: 'bad', RELAY_IDE_TOKEN: 'allowed' },
+      relayCliPath: '/bin/relay-ide',
+    });
+    expect(env.CLAUDECODE).toBeUndefined();
+    expect(env.RELAY_IDE_SESSION_ID).toBe('s1');
+    expect(env.RELAY_IDE_SESSION_RUNTIME).toBe('relay-pty/libghostty-vt');
+    expect(env.RELAY_IDE_CLI_PATH).toBe('/bin/relay-ide');
+    expect(env.RELAY_IDE_TOKEN).toBe('allowed');
+  });
+});


### PR DESCRIPTION
## Summary
- add a prototype `RelayPtySession` that spawns commands directly under Relay-owned `node-pty` without tmux
- add a `TerminalModelBackend` abstraction backed by `@coder/libghostty-vt-node`, including screen text/json/cells, cursor, OSC title tracking, alt-screen mode, resize, idle/activity timing, and typed input encoding
- document the libghostty binding/build result, Codex/Vim smoke evidence, remaining tmux assumptions, and the deletion-gate recommendation

Closes #834
Refs #832

## Verification
- `npm test -- test/relay-pty-session.test.ts` — 4/4 passed
- `npm run check` — passed with existing lint warnings only
- `npm run build` — passed
- `node /tmp/relay-pty-codex-smoke.mjs` — ran standalone Codex provider CLI auth TUI under non-tmux RelayPtySession, captured modeled screen/cells/input/resize evidence at `/tmp/relay-pty-codex-smoke.json`
- `node /tmp/relay-pty-vim-smoke.mjs` — ran Vim alternate-screen TUI under non-tmux RelayPtySession, captured alt-screen/input/resize evidence at `/tmp/relay-pty-vim-smoke.json`

## Notes
- Standalone `codex` opened its auth picker in this environment, so the spike records it as real provider CLI TUI evidence but not an authenticated coding session.
- Recommendation is `go` for a feature-flagged candidate runtime, while keeping tmux compatibility until durability/reattach/copy-mode/mode coverage/control/audit gaps are closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a prototype PTY-backed session system with direct command spawning and terminal state modeling.
  * Added support for tracking terminal output, cursor position, alt-screen modes, and activity metrics.

* **Documentation**
  * Added spike document outlining the prototype design and remaining work before replacing tmux as the default.

* **Tests**
  * Added comprehensive test coverage for the new PTY session and terminal model systems.

* **Chores**
  * Added `@coder/libghostty-vt-node` dependency for terminal modeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->