### PR TITLE
Add side-by-side mailbox attention UI

### DIFF
--- a/frontend/src/components/ActiveWorkSurface.tsx
+++ b/frontend/src/components/ActiveWorkSurface.tsx
@@ -22,6 +22,9 @@ import {
   activeWorkSessionActivationKey,
   activeWorkStateLabel,
 } from '../lib/active-work-control.js';
+import SessionMailboxPanel, {
+  SessionMailboxBadge,
+} from './SessionMailboxPanel.js';
 import { TuiButton } from './TuiButton.js';
 import './ActiveWorkSurface.css';
 
@@ -379,6 +382,9 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
                     last known
                   </span>
                 )}
+                <SessionMailboxBadge
+                  targetSessionId={activeWorkSessionActivationKey(session)}
+                />
               </div>
               <div className="active-work-session__cwd">{session.cwd}</div>
               <div className="active-work-session__meta">
@@ -389,6 +395,14 @@ function ActiveWorkCard({ group }: { group: WorkContextActiveGroup }) {
             </div>
           ))}
         </div>
+
+        <SessionMailboxPanel
+          compact
+          targetSessionId={
+            primarySession ? activeWorkSessionActivationKey(primarySession) : null
+          }
+          title="primary session mailbox"
+        />
 
         {artifacts.length > 0 && (
           <div className="active-work-artifacts" aria-label="artifacts">

--- a/frontend/src/components/SessionMailboxPanel.css
+++ b/frontend/src/components/SessionMailboxPanel.css
@@ -1,0 +1,157 @@
+.session-mailbox-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 20px;
+  padding: 0 5px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+}
+
+.session-mailbox-badge--critical {
+  border-color: var(--status-error);
+  color: var(--status-error);
+}
+
+.session-mailbox-badge--attention {
+  border-color: var(--status-warning);
+  color: var(--status-warning);
+}
+
+.session-mailbox-badge--info {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.session-mailbox-badge__label {
+  color: var(--text-muted);
+}
+
+.session-mailbox-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--bg) 92%, var(--panel) 8%);
+}
+
+.session-mailbox-panel--compact {
+  padding: 6px;
+}
+
+.session-mailbox-panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.session-mailbox-panel__header span:last-child {
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+.session-mailbox-state {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}
+
+.session-mailbox-state--error {
+  color: var(--status-error);
+}
+
+.session-mailbox-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 360px;
+  overflow: auto;
+}
+
+.session-mailbox-card {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+  padding: 7px;
+  border: 1px solid var(--border);
+  background: transparent;
+}
+
+.session-mailbox-card--critical {
+  border-color: color-mix(in srgb, var(--status-error) 70%, var(--border));
+}
+
+.session-mailbox-card--attention {
+  border-color: color-mix(in srgb, var(--status-warning) 70%, var(--border));
+}
+
+.session-mailbox-card--info {
+  border-color: color-mix(in srgb, var(--accent) 60%, var(--border));
+}
+
+.session-mailbox-card__header,
+.session-mailbox-card__meta,
+.session-mailbox-card__artifacts,
+.session-mailbox-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.session-mailbox-card__header {
+  justify-content: space-between;
+}
+
+.session-mailbox-card__title {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+}
+
+.session-mailbox-card__state,
+.session-mailbox-card__meta,
+.session-mailbox-artifact {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+}
+
+.session-mailbox-card__body {
+  margin: 0;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.session-mailbox-artifact {
+  display: inline-flex;
+  min-height: 20px;
+  align-items: center;
+  padding: 0 5px;
+  border: 1px solid var(--border);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/frontend/src/components/SessionMailboxPanel.tsx
+++ b/frontend/src/components/SessionMailboxPanel.tsx
@@ -1,0 +1,195 @@
+import type { SessionInboxMessageId } from '../../../shared/context-packet.js';
+import type { SessionMailboxAction } from '../hooks/useSessionMailbox.js';
+import { useSessionMailbox } from '../hooks/useSessionMailbox.js';
+import type {
+  SessionMailboxMessage,
+  SessionMailboxSummary,
+} from '../lib/session-mailbox.js';
+import { TuiButton } from './TuiButton.js';
+import './SessionMailboxPanel.css';
+
+interface SessionMailboxBadgeProps {
+  targetSessionId: string;
+  label?: string;
+}
+
+function priorityLabel(summary: SessionMailboxSummary): string {
+  if (summary.decisionCount > 0) return `${summary.decisionCount} decision`;
+  if (summary.attentionCount > 0) return `${summary.attentionCount} attention`;
+  if (summary.unreadCount > 0) return `${summary.unreadCount} unread`;
+  if (summary.artifactCount > 0) return `${summary.artifactCount} artifact`;
+  return 'clear';
+}
+
+export function SessionMailboxBadge({
+  targetSessionId,
+  label,
+}: SessionMailboxBadgeProps) {
+  const mailbox = useSessionMailbox(targetSessionId, { mode: 'preview', limit: 6 });
+  const summary = mailbox.summary;
+  const visible =
+    mailbox.isLoading ||
+    mailbox.isError ||
+    summary.openCount > 0 ||
+    summary.artifactCount > 0;
+
+  if (!visible) return null;
+
+  return (
+    <span
+      className={`session-mailbox-badge session-mailbox-badge--${summary.priority}`}
+      title={
+        mailbox.isError
+          ? (mailbox.error?.message ?? 'mailbox failed')
+          : (summary.latestPreview ?? 'mailbox clear')
+      }
+    >
+      <span className="session-mailbox-badge__label">{label ?? 'mail'}</span>
+      <span>{mailbox.isLoading ? 'loading' : priorityLabel(summary)}</span>
+    </span>
+  );
+}
+
+interface SessionMailboxPanelProps {
+  targetSessionId: string | null | undefined;
+  title?: string;
+  compact?: boolean;
+}
+
+function actionForMessage(message: SessionMailboxMessage): SessionMailboxAction[] {
+  if (!message.open) return [];
+  const actions: SessionMailboxAction[] = [];
+  if (message.ackable) actions.push('ack');
+  actions.push(message.kind === 'decision' ? 'resolve' : 'resolve');
+  actions.push('ignore');
+  return actions;
+}
+
+function actionLabel(action: SessionMailboxAction): string {
+  switch (action) {
+    case 'ack':
+      return 'ack';
+    case 'resolve':
+      return 'resolve';
+    case 'ignore':
+      return 'ignore';
+  }
+}
+
+interface SessionMailboxCardProps {
+  message: SessionMailboxMessage;
+  isUpdating: boolean;
+  onAction: (id: SessionInboxMessageId, action: SessionMailboxAction) => void;
+}
+
+function SessionMailboxCard({
+  message,
+  isUpdating,
+  onAction,
+}: SessionMailboxCardProps) {
+  return (
+    <article
+      className={`session-mailbox-card session-mailbox-card--${message.priority}`}
+      data-state={message.state}
+    >
+      <div className="session-mailbox-card__header">
+        <span className="session-mailbox-card__title">{message.title}</span>
+        <span className="session-mailbox-card__state">{message.state}</span>
+      </div>
+      <p className="session-mailbox-card__body">{message.body}</p>
+      <div className="session-mailbox-card__meta">
+        <span>{message.kind}</span>
+        <span>{message.sender}</span>
+        {message.createdAt && <span>{message.createdAt}</span>}
+      </div>
+      {message.artifacts.length > 0 && (
+        <div className="session-mailbox-card__artifacts" aria-label="artifact refs">
+          {message.artifacts.map((artifact) => (
+            <span key={artifact.packetId} className="session-mailbox-artifact">
+              {artifact.kind} · {artifact.label}
+              {artifact.path ? ` · ${artifact.path}` : ''}
+            </span>
+          ))}
+        </div>
+      )}
+      {message.open && (
+        <div className="session-mailbox-card__actions">
+          {actionForMessage(message).map((action) => (
+            <TuiButton
+              key={action}
+              size="sm"
+              variant={action === 'ignore' ? 'ghost' : 'info'}
+              disabled={isUpdating}
+              onClick={() => onAction(message.id, action)}
+            >
+              {actionLabel(action)}
+            </TuiButton>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}
+
+export default function SessionMailboxPanel({
+  targetSessionId,
+  title = 'mailbox',
+  compact = false,
+}: SessionMailboxPanelProps) {
+  const mailbox = useSessionMailbox(targetSessionId, {
+    mode: 'detail',
+    limit: compact ? 5 : 12,
+    enabled: !!targetSessionId,
+  });
+
+  if (!targetSessionId) {
+    return (
+      <section className="session-mailbox-panel session-mailbox-panel--empty">
+        <div className="session-mailbox-panel__header">
+          <span>{title}</span>
+          <span>no session</span>
+        </div>
+        <p>select a live session to read its mailroom inbox.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className={`session-mailbox-panel${compact ? ' session-mailbox-panel--compact' : ''}`}
+      aria-label={`${title} for ${targetSessionId}`}
+    >
+      <div className="session-mailbox-panel__header">
+        <span>{title}</span>
+        <span>
+          {mailbox.isLoading
+            ? 'loading'
+            : `${mailbox.summary.unreadCount} unread / ${mailbox.summary.openCount} open`}
+        </span>
+      </div>
+      {mailbox.isError ? (
+        <div className="session-mailbox-state session-mailbox-state--error">
+          <span>mailbox failed: {mailbox.error?.message ?? 'unknown error'}</span>
+          <TuiButton size="sm" variant="ghost" onClick={() => void mailbox.refetch()}>
+            retry
+          </TuiButton>
+        </div>
+      ) : mailbox.isLoading ? (
+        <div className="session-mailbox-state">loading mailroom messages...</div>
+      ) : mailbox.summary.messages.length === 0 ? (
+        <div className="session-mailbox-state">mailbox clear · no session mail</div>
+      ) : (
+        <div className="session-mailbox-list">
+          {mailbox.summary.messages.map((message) => (
+            <SessionMailboxCard
+              key={message.id}
+              message={message}
+              isUpdating={mailbox.isUpdating}
+              onAction={(id, action) => void mailbox.updateMessage(id, action)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/SessionMailboxPanel.tsx
+++ b/frontend/src/components/SessionMailboxPanel.tsx
@@ -137,7 +137,7 @@ export default function SessionMailboxPanel({
   compact = false,
 }: SessionMailboxPanelProps) {
   const mailbox = useSessionMailbox(targetSessionId, {
-    mode: 'detail',
+    mode: 'preview',
     limit: compact ? 5 : 12,
     enabled: !!targetSessionId,
   });

--- a/frontend/src/components/WorkspaceTabBar.tsx
+++ b/frontend/src/components/WorkspaceTabBar.tsx
@@ -11,7 +11,9 @@ import {
   type SummaryContext,
   type WorkspaceTabSummary,
 } from '../lib/workspace-summary.js';
+import { scopedSessionKey } from '../lib/session-keys.js';
 import { TabControlBadge } from './TabControlBadge.js';
+import { SessionMailboxBadge } from './SessionMailboxPanel.js';
 import './WorkspaceTabBar.css';
 
 const ICON_GLYPH: Record<WorkspaceTabSummary['icon'], string> = {
@@ -104,6 +106,12 @@ function WorkspaceTabItem({
           session={session}
           nodeBadge={summary.nodeBadge}
           compact
+        />
+      )}
+      {tab.kind === 'session' && session && (
+        <SessionMailboxBadge
+          targetSessionId={scopedSessionKey(session)}
+          label="inbox"
         />
       )}
       {summary.nodeBadge && (

--- a/frontend/src/hooks/useSessionMailbox.ts
+++ b/frontend/src/hooks/useSessionMailbox.ts
@@ -1,0 +1,107 @@
+import { useCallback, useMemo } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { SessionInboxMessageId } from '../../../shared/context-packet.js';
+import {
+  fetchInboxMessages,
+  previewInboxMessages,
+  updateInboxMessageState,
+  type DecoratedInboxMessage,
+} from '../lib/api.js';
+import {
+  buildSessionMailboxSummary,
+  type SessionMailboxSummary,
+} from '../lib/session-mailbox.js';
+
+export const SESSION_MAILBOX_REFETCH_MS = 10_000;
+
+export type SessionMailboxMode = 'preview' | 'detail';
+export type SessionMailboxAction = 'ack' | 'resolve' | 'ignore';
+
+export interface UseSessionMailboxOptions {
+  limit?: number;
+  mode?: SessionMailboxMode;
+  enabled?: boolean;
+}
+
+export interface UseSessionMailboxResult {
+  messages: DecoratedInboxMessage[];
+  summary: SessionMailboxSummary;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  isUpdating: boolean;
+  refetch: () => Promise<unknown>;
+  updateMessage: (
+    id: SessionInboxMessageId,
+    action: SessionMailboxAction
+  ) => Promise<void>;
+}
+
+export function sessionMailboxQueryKey(
+  sessionId: string | null | undefined,
+  mode: SessionMailboxMode
+): readonly [string, string, SessionMailboxMode] {
+  return ['session-mailbox', sessionId ?? 'none', mode] as const;
+}
+
+export function useSessionMailbox(
+  sessionId: string | null | undefined,
+  options: UseSessionMailboxOptions = {}
+): UseSessionMailboxResult {
+  const { limit = 8, mode = 'preview', enabled = true } = options;
+  const queryClient = useQueryClient();
+  const query = useQuery({
+    queryKey: sessionMailboxQueryKey(sessionId, mode),
+    enabled: enabled && !!sessionId,
+    staleTime: 2_500,
+    refetchInterval: enabled && !!sessionId ? SESSION_MAILBOX_REFETCH_MS : false,
+    refetchOnWindowFocus: true,
+    queryFn: () => {
+      if (!sessionId) return Promise.resolve([]);
+      return mode === 'detail'
+        ? fetchInboxMessages(sessionId, limit)
+        : previewInboxMessages(sessionId, limit);
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: ({
+      id,
+      action,
+    }: {
+      id: SessionInboxMessageId;
+      action: SessionMailboxAction;
+    }) => updateInboxMessageState(id, action),
+    onSuccess: () => {
+      if (sessionId) {
+        void queryClient.invalidateQueries({
+          queryKey: ['session-mailbox', sessionId],
+        });
+      }
+      void queryClient.invalidateQueries({ queryKey: ['active-work'] });
+    },
+  });
+
+  const messages = useMemo(() => query.data ?? [], [query.data]);
+  const summary = useMemo(
+    () => buildSessionMailboxSummary(messages),
+    [messages]
+  );
+  const updateMessage = useCallback(
+    async (id: SessionInboxMessageId, action: SessionMailboxAction) => {
+      await mutation.mutateAsync({ id, action });
+    },
+    [mutation]
+  );
+
+  return {
+    messages,
+    summary,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error instanceof Error ? query.error : null,
+    isUpdating: mutation.isPending,
+    refetch: query.refetch,
+    updateMessage,
+  };
+}

--- a/frontend/src/lib/active-work-control.ts
+++ b/frontend/src/lib/active-work-control.ts
@@ -1,12 +1,12 @@
 import {
   DEFAULT_LOCAL_NODE_ID,
-  createGlobalSessionId,
 } from '../../../shared/identity.js';
 import type {
   WorkContextActiveGroup,
   WorkContextSessionSummary,
 } from './types.js';
 import { durabilityDisabledReason } from './session-durability.js';
+import { scopedSessionKey } from './session-keys.js';
 
 export interface ActiveWorkMobileControlState {
   attachDisabledReason: string | null;
@@ -20,9 +20,10 @@ export interface ActiveWorkMobileControlState {
 export function activeWorkSessionActivationKey(
   session: WorkContextSessionSummary
 ): string {
-  const nodeId = session.nodeId ?? DEFAULT_LOCAL_NODE_ID;
-  if (nodeId === DEFAULT_LOCAL_NODE_ID) return session.id;
-  return session.globalSessionId ?? createGlobalSessionId(nodeId, session.id);
+  return scopedSessionKey({
+    ...session,
+    nodeId: session.nodeId ?? DEFAULT_LOCAL_NODE_ID,
+  });
 }
 
 export function activeWorkAttentionPriority(

--- a/frontend/src/lib/session-mailbox.ts
+++ b/frontend/src/lib/session-mailbox.ts
@@ -1,0 +1,252 @@
+import type { ContextPacketId } from '../../../shared/context-packet.js';
+import type { DecoratedInboxMessage } from './api.js';
+
+export type SessionMailboxMessageKind =
+  | 'decision'
+  | 'attention'
+  | 'artifact'
+  | 'message';
+
+export type SessionMailboxPriority = 'critical' | 'attention' | 'info' | 'quiet';
+
+export interface SessionMailboxArtifactRef {
+  packetId: ContextPacketId;
+  kind: string;
+  path?: string;
+  label: string;
+}
+
+export interface SessionMailboxMessage {
+  id: string;
+  state: DecoratedInboxMessage['state'];
+  kind: SessionMailboxMessageKind;
+  priority: SessionMailboxPriority;
+  unread: boolean;
+  open: boolean;
+  ackable: boolean;
+  resolvable: boolean;
+  sender: string;
+  createdAt?: string;
+  title: string;
+  body: string;
+  attentionKind?: string;
+  artifacts: SessionMailboxArtifactRef[];
+  packetIds: ContextPacketId[];
+}
+
+export interface SessionMailboxSummary {
+  messages: SessionMailboxMessage[];
+  unreadCount: number;
+  openCount: number;
+  ackableCount: number;
+  decisionCount: number;
+  attentionCount: number;
+  artifactCount: number;
+  latestPreview: string | null;
+  priority: SessionMailboxPriority;
+}
+
+const ATTENTION_RE = /^\[attention:([^\]\s]+)\]\s*(.*)$/i;
+const DECISION_RE = /^\[decision:pending\]\s*(.*)$/i;
+
+function messageCreatedAt(message: DecoratedInboxMessage): string | undefined {
+  return (
+    message.createdAt ??
+    message.deliveredAt ??
+    message.acknowledgedAt ??
+    message.resolvedAt ??
+    message.ignoredAt
+  );
+}
+
+function stateIsOpen(state: DecoratedInboxMessage['state']): boolean {
+  return state !== 'resolved' && state !== 'ignored';
+}
+
+function stateIsUnread(state: DecoratedInboxMessage['state']): boolean {
+  return state === 'queued' || state === 'delivered';
+}
+
+function cleanBody(value: string | undefined): string {
+  return value?.replace(/\s+/g, ' ').trim() ?? '';
+}
+
+function packetNotes(message: DecoratedInboxMessage): string[] {
+  return (message.contextPackets ?? [])
+    .map((packet) => (packet.kind === 'note' ? cleanBody(packet.note) : ''))
+    .filter((note) => note.length > 0);
+}
+
+function artifactsForMessage(
+  message: DecoratedInboxMessage
+): SessionMailboxArtifactRef[] {
+  return (message.contextPackets ?? [])
+    .filter(
+      (packet) =>
+        packet.kind === 'log-ref' ||
+        packet.kind === 'diff-ref' ||
+        packet.kind === 'file-ref' ||
+        packet.kind === 'file-anchor' ||
+        !!packet.fileRef ||
+        !!packet.anchor
+    )
+    .map((packet) => {
+      const fileRefPath = packet.fileRef?.path;
+      const anchorPath = packet.anchor?.ref?.path;
+      const path = fileRefPath ?? anchorPath;
+      const label = packet.note
+        ? cleanBody(packet.note)
+        : path
+          ? path.split('/').filter(Boolean).pop() ?? path
+          : packet.id;
+      return {
+        packetId: packet.id,
+        kind: packet.kind,
+        ...(path ? { path } : {}),
+        label,
+      };
+    });
+}
+
+function classifyMessage(message: DecoratedInboxMessage): {
+  kind: SessionMailboxMessageKind;
+  title: string;
+  body: string;
+  attentionKind?: string;
+} {
+  const notes = packetNotes(message);
+  const bodyCandidates = [message.text, ...notes]
+    .map(cleanBody)
+    .filter((body) => body.length > 0);
+
+  for (const body of bodyCandidates) {
+    const decisionMatch = DECISION_RE.exec(body);
+    if (decisionMatch) {
+      return {
+        kind: 'decision',
+        title: 'decision requested',
+        body: cleanBody(decisionMatch[1]) || 'pending decision',
+      };
+    }
+  }
+
+  for (const body of bodyCandidates) {
+    const attentionMatch = ATTENTION_RE.exec(body);
+    if (attentionMatch) {
+      const attentionKind = attentionMatch[1]?.toLowerCase() ?? 'attention';
+      return {
+        kind: 'attention',
+        title: `${attentionKind} attention`,
+        body: cleanBody(attentionMatch[2]) || 'attention requested',
+        attentionKind,
+      };
+    }
+  }
+
+  const artifacts = artifactsForMessage(message);
+  if (artifacts.length > 0) {
+    const first = artifacts[0];
+    return {
+      kind: 'artifact',
+      title: artifacts.length === 1 ? 'artifact published' : 'artifacts published',
+      body: first?.label ?? message.id,
+    };
+  }
+
+  return {
+    kind: 'message',
+    title: 'message',
+    body: bodyCandidates[0] ?? 'context packet delivered',
+  };
+}
+
+function priorityFor(
+  kind: SessionMailboxMessageKind,
+  unread: boolean,
+  open: boolean
+): SessionMailboxPriority {
+  if (!open) return 'quiet';
+  if (kind === 'decision') return 'critical';
+  if (kind === 'attention') return 'attention';
+  if (unread) return 'info';
+  return 'quiet';
+}
+
+function compareMailboxMessages(
+  a: SessionMailboxMessage,
+  b: SessionMailboxMessage
+): number {
+  const priorityRank: Record<SessionMailboxPriority, number> = {
+    critical: 0,
+    attention: 1,
+    info: 2,
+    quiet: 3,
+  };
+  const byPriority = priorityRank[a.priority] - priorityRank[b.priority];
+  if (byPriority !== 0) return byPriority;
+  const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+  const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+  return bTime - aTime;
+}
+
+function summaryPriority(messages: SessionMailboxMessage[]): SessionMailboxPriority {
+  if (messages.some((message) => message.priority === 'critical')) return 'critical';
+  if (messages.some((message) => message.priority === 'attention')) return 'attention';
+  if (messages.some((message) => message.priority === 'info')) return 'info';
+  return 'quiet';
+}
+
+export function buildSessionMailboxMessage(
+  message: DecoratedInboxMessage
+): SessionMailboxMessage {
+  const classification = classifyMessage(message);
+  const unread = stateIsUnread(message.state);
+  const open = stateIsOpen(message.state);
+  const artifacts = artifactsForMessage(message);
+  const createdAt = messageCreatedAt(message);
+  return {
+    id: message.id,
+    state: message.state,
+    kind: classification.kind,
+    priority: priorityFor(classification.kind, unread, open),
+    unread,
+    open,
+    ackable: unread && open,
+    resolvable: open,
+    sender: message.createdBy,
+    ...(createdAt ? { createdAt } : {}),
+    title: classification.title,
+    body: classification.body,
+    ...(classification.attentionKind
+      ? { attentionKind: classification.attentionKind }
+      : {}),
+    artifacts,
+    packetIds: message.contextPacketIds,
+  };
+}
+
+export function buildSessionMailboxSummary(
+  messages: DecoratedInboxMessage[]
+): SessionMailboxSummary {
+  const projected = messages
+    .map(buildSessionMailboxMessage)
+    .sort(compareMailboxMessages);
+  return {
+    messages: projected,
+    unreadCount: projected.filter((message) => message.unread).length,
+    openCount: projected.filter((message) => message.open).length,
+    ackableCount: projected.filter((message) => message.ackable).length,
+    decisionCount: projected.filter(
+      (message) => message.open && message.kind === 'decision'
+    ).length,
+    attentionCount: projected.filter(
+      (message) => message.open && message.kind === 'attention'
+    ).length,
+    artifactCount: projected.reduce(
+      (total, message) => total + message.artifacts.length,
+      0
+    ),
+    latestPreview: projected[0]?.body ?? null,
+    priority: summaryPriority(projected),
+  };
+}

--- a/server/features/context-inbox-router.ts
+++ b/server/features/context-inbox-router.ts
@@ -804,25 +804,23 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
   }
 
   /**
-   * #760: collect the decorated `file-anchor` packets a message references, so
-   * `inbox.get`/`inbox.list` can surface each referenced packet's derived
-   * `AnchorState` without the agent issuing a follow-up `context.get`. Only
-   * `file-anchor` packets are decorated; missing/non-anchor packets are skipped.
-   * Returns `[]` when the message references no resolvable file-anchor packets.
+   * #760/#835: collect the referenced packets a message names, so
+   * `inbox.get`/`inbox.list` can surface artifact refs without the frontend
+   * issuing follow-up `context.get` calls. File anchors still receive derived
+   * `AnchorState`; non-anchor packets pass through unchanged. Missing packet
+   * ids are skipped.
    */
-  async function decoratedAnchorPacketsFor(
+  async function decoratedContextPacketsFor(
     s: ContextInboxStore,
     message: SessionInboxMessage
   ): Promise<DecoratedContextPacket[]> {
-    const anchorPackets: ContextPacket[] = [];
+    const packets: ContextPacket[] = [];
     for (const id of message.contextPacketIds) {
       const packet = s.getPacket(id);
-      if (packet && packet.kind === 'file-anchor' && packet.anchor) {
-        anchorPackets.push(packet);
-      }
+      if (packet) packets.push(packet);
     }
-    if (anchorPackets.length === 0) return [];
-    return decoratePacketsAnchorState(anchorPackets, resolveAnchorState);
+    if (packets.length === 0) return [];
+    return decoratePacketsAnchorState(packets, resolveAnchorState);
   }
 
   /** Attach decorated referenced packets to a message envelope (additive). */
@@ -832,7 +830,7 @@ export function createContextInboxRouter(deps: ContextInboxRouterDeps): Router {
   ): Promise<
     SessionInboxMessage & { contextPackets?: DecoratedContextPacket[] }
   > {
-    const contextPackets = await decoratedAnchorPacketsFor(s, message);
+    const contextPackets = await decoratedContextPacketsFor(s, message);
     return contextPackets.length > 0 ? { ...message, contextPackets } : message;
   }
 

--- a/test/active-work-control.test.ts
+++ b/test/active-work-control.test.ts
@@ -172,6 +172,9 @@ describe('active work mobile control helpers', () => {
       activeWorkSessionActivationKey(
         session({ id: 'local-session-1', nodeId: DEFAULT_LOCAL_NODE_ID })
       )
-    ).toBe('local-session-1');
+    ).toBe('local:local-session-1');
+    expect(
+      activeWorkSessionActivationKey(session({ id: 'local-session-2' }))
+    ).toBe('local:local-session-2');
   });
 });

--- a/test/components/SessionMailboxPanel.test.ts
+++ b/test/components/SessionMailboxPanel.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flush() {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+const fetchMock = vi.fn(async () =>
+  new Response(
+    JSON.stringify({
+      messages: [
+        {
+          id: 'im:web-1',
+          targetSessionId: 'local:session-1',
+          contextPacketIds: [],
+          state: 'queued',
+          text: 'passive preview only',
+          createdBy: 'relay-web',
+        },
+      ],
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  )
+);
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+const { default: SessionMailboxPanel } = await import(
+  '../../frontend/src/components/SessionMailboxPanel.js'
+);
+
+describe('SessionMailboxPanel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    fetchMock.mockClear();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    queryClient.clear();
+  });
+
+  it('uses the non-consuming inbox preview endpoint for passive detail reads', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(SessionMailboxPanel, {
+            targetSessionId: 'local:session-1',
+            title: 'primary session mailbox',
+          })
+        )
+      );
+    });
+
+    await act(async () => {
+      await flush();
+      await flush();
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+      '/inbox/preview?targetSessionId=local%3Asession-1&limit=12'
+    );
+    expect(container.textContent).toContain('passive preview only');
+  });
+});

--- a/test/context-inbox-router.test.ts
+++ b/test/context-inbox-router.test.ts
@@ -806,4 +806,75 @@ describe('context/inbox gateway router — #760 derived AnchorState decoration',
       'unchanged'
     );
   });
+
+  it('inbox.preview attaches referenced file-ref and log-ref packets for artifact rendering', async () => {
+    await mount(createFakeStore(), resolverReturning('unchanged'));
+    const filePacket = await req('POST', '/context', {
+      caps: 'context:write',
+      body: {
+        kind: 'file-ref',
+        fileRef: createFileResourceRef({
+          nodeId: 'node1',
+          path: '/repo/dist/report.html',
+          intent: 'read',
+          sha256: 'b'.repeat(64),
+          mtimeMs: 2_000,
+        }),
+        note: 'browser artifact',
+        createdBy: 'agent_1',
+      },
+    });
+    expect(filePacket.status).toBe(201);
+    const logPacket = await req('POST', '/context', {
+      caps: 'context:write',
+      body: {
+        kind: 'log-ref',
+        fileRef: createFileResourceRef({
+          nodeId: 'node1',
+          path: '/tmp/relay/session.log',
+          intent: 'read',
+          sha256: 'c'.repeat(64),
+          mtimeMs: 3_000,
+        }),
+        note: 'session log',
+        createdBy: 'agent_1',
+      },
+    });
+    expect(logPacket.status).toBe(201);
+    await req('POST', '/inbox', {
+      caps: 'inbox:write',
+      body: {
+        targetSessionId: 'node1:s12',
+        contextPacketIds: [
+          filePacket.body.contextPacket.id,
+          logPacket.body.contextPacket.id,
+        ],
+        text: 'published artifacts',
+        createdBy: 'agent_1',
+      },
+    });
+
+    const previewed = await req(
+      'GET',
+      '/inbox/preview?targetSessionId=node1:s12',
+      { caps: 'inbox:read' }
+    );
+
+    expect(previewed.status).toBe(200);
+    expect(previewed.body.messages[0].state).toBe('queued');
+    expect(previewed.body.messages[0].contextPackets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'file-ref',
+          note: 'browser artifact',
+          fileRef: expect.objectContaining({ path: '/repo/dist/report.html' }),
+        }),
+        expect.objectContaining({
+          kind: 'log-ref',
+          note: 'session log',
+          fileRef: expect.objectContaining({ path: '/tmp/relay/session.log' }),
+        }),
+      ])
+    );
+  });
 });

--- a/test/session-mailbox.test.ts
+++ b/test/session-mailbox.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'vitest';
+
+import type { DecoratedInboxMessage } from '../frontend/src/lib/api.js';
+import {
+  buildSessionMailboxMessage,
+  buildSessionMailboxSummary,
+} from '../frontend/src/lib/session-mailbox.js';
+
+function msg(
+  input: Partial<DecoratedInboxMessage> & Pick<DecoratedInboxMessage, 'id'>
+): DecoratedInboxMessage {
+  return {
+    targetSessionId: 'local:session-1',
+    contextPacketIds: [],
+    state: 'queued',
+    createdBy: 'relayctl',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    ...input,
+  } as DecoratedInboxMessage;
+}
+
+describe('session mailbox projection', () => {
+  test('classifies relay notify notes as unread session-bound attention', () => {
+    const projected = buildSessionMailboxMessage(
+      msg({
+        id: 'im:notify',
+        state: 'delivered',
+        contextPacketIds: ['cp:notify'],
+        contextPackets: [
+          {
+            id: 'cp:notify',
+            kind: 'note',
+            note: '[attention:review] check the failing pane',
+            createdBy: 'relayctl',
+            createdAt: '2026-06-01T00:00:00.000Z',
+          },
+        ],
+      })
+    );
+
+    expect(projected.kind).toBe('attention');
+    expect(projected.attentionKind).toBe('review');
+    expect(projected.priority).toBe('attention');
+    expect(projected.unread).toBe(true);
+    expect(projected.ackable).toBe(true);
+    expect(projected.body).toBe('check the failing pane');
+  });
+
+  test('classifies decision requests as critical until resolved', () => {
+    const open = buildSessionMailboxMessage(
+      msg({
+        id: 'im:decision',
+        state: 'queued',
+        text: '[decision:pending] pick claude or codex for pane 2',
+      })
+    );
+    const closed = buildSessionMailboxMessage(
+      msg({
+        id: 'im:decision',
+        state: 'resolved',
+        text: '[decision:pending] pick claude or codex for pane 2',
+      })
+    );
+
+    expect(open.kind).toBe('decision');
+    expect(open.priority).toBe('critical');
+    expect(open.resolvable).toBe(true);
+    expect(closed.priority).toBe('quiet');
+    expect(closed.open).toBe(false);
+  });
+
+  test('renders log/file refs as safe artifact summaries without file bytes', () => {
+    const projected = buildSessionMailboxMessage(
+      msg({
+        id: 'im:artifact',
+        state: 'acknowledged',
+        contextPacketIds: ['cp:log'],
+        contextPackets: [
+          {
+            id: 'cp:log',
+            kind: 'log-ref',
+            fileRef: {
+              nodeId: 'local',
+              path: '/tmp/relay/session.log',
+              capturedAt: '2026-06-01T00:00:00.000Z',
+              intent: 'read',
+            },
+            note: 'terminal transcript',
+            createdBy: 'relayctl',
+            createdAt: '2026-06-01T00:00:00.000Z',
+          },
+        ],
+      })
+    );
+
+    expect(projected.kind).toBe('artifact');
+    expect(projected.artifacts).toEqual([
+      {
+        packetId: 'cp:log',
+        kind: 'log-ref',
+        path: '/tmp/relay/session.log',
+        label: 'terminal transcript',
+      },
+    ]);
+    expect(projected.body).toBe('terminal transcript');
+  });
+
+  test('summarizes unread/open priority before older quiet messages', () => {
+    const summary = buildSessionMailboxSummary([
+      msg({
+        id: 'im:old',
+        state: 'acknowledged',
+        text: 'already read',
+        createdAt: '2026-06-01T00:05:00.000Z',
+      }),
+      msg({
+        id: 'im:decision',
+        state: 'queued',
+        text: '[decision:pending] choose runtime',
+        createdAt: '2026-06-01T00:01:00.000Z',
+      }),
+      msg({
+        id: 'im:attention',
+        state: 'delivered',
+        text: '[attention:notify] stdout changed',
+        createdAt: '2026-06-01T00:03:00.000Z',
+      }),
+    ]);
+
+    expect(summary.priority).toBe('critical');
+    expect(summary.unreadCount).toBe(2);
+    expect(summary.openCount).toBe(3);
+    expect(summary.decisionCount).toBe(1);
+    expect(summary.attentionCount).toBe(1);
+    expect(summary.latestPreview).toBe('choose runtime');
+    expect(summary.messages.map((message) => message.id)).toEqual([
+      'im:decision',
+      'im:attention',
+      'im:old',
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #835

## Summary
- adds a session mailbox projection for real /inbox + context packet data, including notify attention, pending decisions, and log/file artifacts
- renders mailbox badges in Active Work session rows and workspace tab chrome
- adds a primary-session mailbox panel with ack / resolve / ignore actions backed by inbox state transitions

## Verification
- PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/session-mailbox.test.ts
- PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/active-work-surface.test.ts test/active-work-control.test.ts test/context-feedback-api.test.ts test/session-mailbox.test.ts
- PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check
- PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run build

## Browser smoke
- built server loaded at http://127.0.0.1:3495/ with no console errors; full authenticated mailbox flow was blocked by browser PIN setup prompt in this worker environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced session inbox display showing unread and open messages for each session
  * Added notification badges to session tabs and session cards indicating inbox status
  * Enabled message actions (acknowledge, resolve, ignore) directly from the inbox interface
  * Supports both preview and detailed message views with error handling and retry functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->