### PR TITLE
feat: add relay-pty terminal backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ Relay Agentic Development Environment — a hub/node web workspace for AI coding
 | Design             | `docs/DESIGN.md`                       | Backend patterns, auth flow, PTY management, session types                                     |
 | Frontend           | `docs/FRONTEND.md`                     | React 19 components, state management (Zustand + TanStack Query)                               |
 | Quality            | `docs/QUALITY.md`                      | Test runner, test files, isolation patterns                                                    |
+| Terminal backends  | `docs/TERMINAL_BACKENDS.md`            | `relay-pty` rollout, `tmux-compat` fallback, migration/import behavior                         |
 | Review             | `docs/REVIEW_GUIDANCE.md`              | Review agent config, question bank, escape log                                                 |
 | Deployment         | `docs/references/deployment.md`        | Publishing + branching (nightly/master + tags)                                                 |
 | Devbox deploy      | `docs/references/devbox-hub-deploy.md` | Shared devbox hub deploy, Mac node-link restart, verification evidence, process hygiene        |

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ This index separates current source-of-truth docs from historical plans and spik
 | Backend design notes  | `DESIGN.md`                       | Backend patterns, auth/session/PTY behavior                                                  |
 | Frontend              | `FRONTEND.md`                     | React components, frontend state, UI entrypoints                                             |
 | Quality               | `QUALITY.md`                      | Test strategy, isolation rules, known gate behavior                                          |
+| Terminal backends     | `TERMINAL_BACKENDS.md`            | `relay-pty` rollout, `tmux-compat` fallback, migration/import behavior                       |
 | Review                | `REVIEW_GUIDANCE.md`              | Reviewer prompts, risk areas, escape log                                                     |
 | Deployment            | `references/deployment.md`        | Branching, npm channels, publishing flow                                                     |
 | Devbox deploy         | `references/devbox-hub-deploy.md` | Shared devbox hub deploy, Mac node-link restart, verification evidence, process hygiene      |

--- a/docs/TERMINAL_BACKENDS.md
+++ b/docs/TERMINAL_BACKENDS.md
@@ -1,0 +1,55 @@
+# Terminal backends and relay-pty rollout
+
+Relay supports two PTY execution backends for local sessions:
+
+- `tmux-compat` (default): the existing stable path. Relay launches sessions through tmux and reattaches to tmux sessions across browser reconnects and server restarts.
+- `relay-pty`: the new direct `RelayPtySession` runtime using Relay's PTY/libghostty-vt pipeline. It is opt-in while it rolls out.
+
+The rollout is intentionally conservative. Existing installs and existing sessions stay on `tmux-compat` unless a new session is explicitly created with `terminalBackend: "relay-pty"` or an operator/repo/workspace default selects `relay-pty`.
+
+## Configuration and precedence
+
+`terminalBackend` can be set globally, per workspace, per repo, or per session request. Effective session settings use this order, most-specific first:
+
+1. Explicit session override: `POST /sessions` or `PATCH /config/terminalBackend` request fields such as `terminalBackend: "relay-pty"` or legacy `useTmux: false`.
+2. Repo settings: `repoSettings[repoPath].terminalBackend`.
+3. Workspace settings: `workspaces[].settings.terminalBackend`.
+4. Global default: `RELAY_IDE_TERMINAL_BACKEND`, then `config.terminalBackend`, then the hardcoded default `tmux-compat`.
+
+`RELAY_IDE_TERMINAL_BACKEND` is a global default, not an absolute operator lock. A repo or workspace configured for `tmux-compat` must continue to resolve to `tmux-compat` even when the process environment default is `relay-pty`. Explicit per-session overrides still win over all saved defaults.
+
+Legacy `useTmux` maps to the same backend contract for compatibility:
+
+- `useTmux: true` => `terminalBackend: "tmux-compat"`
+- `useTmux: false` => `terminalBackend: "relay-pty"`
+
+New code should prefer `terminalBackend`; `useTmux` exists so older callers and saved settings keep working during migration.
+
+## Which sessions migrate
+
+Backend selection happens when a session is created or restored from saved session metadata. Relay does not live-migrate a running PTY process from one backend to the other.
+
+- Running tmux-backed sessions continue as tmux-backed sessions. Browser reconnects and normal server restarts reattach to the existing tmux session.
+- Serialized sessions that already include `terminalBackend` restore with that stored backend.
+- Legacy serialized sessions without `terminalBackend` restore as `tmux-compat`. This keeps old session files safe even if the current global default has changed to `relay-pty`.
+- New sessions created after a default changes use the effective default from the precedence rules above.
+- To move a tab from tmux compatibility to relay-pty, start a new session with `terminalBackend: "relay-pty"`. To keep a repo/workspace on tmux while testing relay-pty globally, set its repo/workspace `terminalBackend` to `tmux-compat`.
+
+## Import and fallback behavior
+
+`tmux-compat` remains the fallback/import path for old Relay state:
+
+- Old session manifests that only have `useTmux` are normalized into a backend before launch/restore.
+- Missing or unknown `terminalBackend` values fall back to `tmux-compat` rather than silently selecting the experimental runtime.
+- Startup only requires tmux when the effective default backend is `tmux-compat`, but any session resolved to `tmux-compat` still needs tmux available.
+- Relay-pty sessions do not import existing tmux process state. They start new `RelayPtySession` processes and expose `RELAY_IDE_SESSION_RUNTIME=relay-pty/libghostty-vt` to the child environment.
+
+## Operator rollout pattern
+
+Recommended staged rollout:
+
+1. Leave the global default at `tmux-compat`.
+2. Opt one repo or workspace into `relay-pty` and start new sessions there.
+3. Keep critical or long-lived repos explicitly pinned to `tmux-compat` while testing.
+4. After relay-pty is proven for new sessions, change the global default if desired.
+5. Do not expect existing tmux sessions to convert in place; close/recreate them when they are ready to move.

--- a/server/config.ts
+++ b/server/config.ts
@@ -6,6 +6,7 @@ import type {
   Config,
   ContinuePolicy,
   FilterPreset,
+  TerminalBackend,
   WorkspaceSettings,
   WorktreeMetadata,
 } from './types.js';
@@ -46,6 +47,7 @@ export const DEFAULTS: Omit<
   defaultYolo: false,
   maxPtySessions: 64,
   launchInTmux: true,
+  terminalBackend: 'tmux-compat',
   defaultNotifications: true,
   claudeFullscreen: true,
   updateChannel: 'stable',
@@ -138,6 +140,7 @@ export function getRepoSettings(
     defaultContinue: config.defaultContinue,
     defaultYolo: config.defaultYolo,
     launchInTmux: true,
+    terminalBackend: defaultTerminalBackend(config),
     claudeArgs: config.claudeArgs,
   };
   const perWorkspace = config.repoSettings?.[repoPath] ?? {};
@@ -150,6 +153,7 @@ export interface ResolvedSessionSettings {
   yolo: boolean;
   continuePolicy: ContinuePolicy;
   useTmux: boolean;
+  terminalBackend: TerminalBackend;
   claudeArgs: string[];
   /** #614 slice 4: effective per-session scrollback cap, undefined = use pty-handler default. */
   scrollbackBytes?: number;
@@ -206,7 +210,22 @@ export interface SessionSettingsOverrides {
   yolo?: boolean | undefined;
   continuePolicy?: ContinuePolicy | undefined;
   useTmux?: boolean | undefined;
+  terminalBackend?: TerminalBackend | undefined;
   claudeArgs?: string[] | undefined;
+}
+
+export function normalizeTerminalBackend(
+  value: unknown
+): TerminalBackend | undefined {
+  return value === 'relay-pty' || value === 'tmux-compat' ? value : undefined;
+}
+
+export function defaultTerminalBackend(config: Config): TerminalBackend {
+  return (
+    normalizeTerminalBackend(process.env.RELAY_IDE_TERMINAL_BACKEND) ??
+    normalizeTerminalBackend(config.terminalBackend) ??
+    'tmux-compat'
+  );
 }
 
 export function resolveSessionSettings(
@@ -220,6 +239,7 @@ export function resolveSessionSettings(
     defaultContinue: config.defaultContinue,
     defaultYolo: config.defaultYolo,
     launchInTmux: true,
+    terminalBackend: defaultTerminalBackend(config),
     claudeArgs: config.claudeArgs,
   };
 
@@ -233,6 +253,16 @@ export function resolveSessionSettings(
 
   // Merge: repo overrides workspace overrides global
   const merged = { ...globalDefaults, ...wsDefaults, ...repoSpecific };
+  const terminalBackend =
+    overrides.terminalBackend ??
+    (overrides.useTmux === false
+      ? 'relay-pty'
+      : overrides.useTmux === true
+        ? 'tmux-compat'
+        : undefined) ??
+    normalizeTerminalBackend(process.env.RELAY_IDE_TERMINAL_BACKEND) ??
+    normalizeTerminalBackend(merged.terminalBackend) ??
+    'tmux-compat';
 
   // Map boolean defaultContinue → ContinuePolicy for backward compat
   const configPolicy: ContinuePolicy =
@@ -261,7 +291,8 @@ export function resolveSessionSettings(
     agent: overrides.agent ?? agentFromLayers,
     yolo: overrides.yolo ?? merged.defaultYolo ?? false,
     continuePolicy: overrides.continuePolicy ?? configPolicy,
-    useTmux: true,
+    terminalBackend,
+    useTmux: terminalBackend === 'tmux-compat',
     ...(scrollbackBytes !== undefined ? { scrollbackBytes } : {}),
     claudeArgs: overrides.claudeArgs ?? merged.claudeArgs ?? [],
   };

--- a/server/config.ts
+++ b/server/config.ts
@@ -260,7 +260,6 @@ export function resolveSessionSettings(
       : overrides.useTmux === true
         ? 'tmux-compat'
         : undefined) ??
-    normalizeTerminalBackend(process.env.RELAY_IDE_TERMINAL_BACKEND) ??
     normalizeTerminalBackend(merged.terminalBackend) ??
     'tmux-compat';
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,6 +20,8 @@ import {
   deleteMeta,
   ensureMetaDir,
   getConfigDir,
+  defaultTerminalBackend,
+  normalizeTerminalBackend,
   resolveSessionSettings,
 } from './config.js';
 import * as auth from './auth.js';
@@ -166,6 +168,7 @@ import type {
   Config,
   ContinuePolicy,
   SessionSummary,
+  TerminalBackend,
   TicketContext,
   WorkspaceSettings,
 } from './types.js';
@@ -239,7 +242,8 @@ const execFileAsync = promisify(execFile);
 const logger = createLogger('index');
 const localRelayNode = createLocalRelayNode();
 const cliGatewayActorRegistry = createCliGatewayActorRegistry();
-const cliGatewayHandshakeGrantRegistry = createCliGatewayHandshakeGrantRegistry();
+const cliGatewayHandshakeGrantRegistry =
+  createCliGatewayHandshakeGrantRegistry();
 
 // When run via CLI bin, config lives in ~/.config/relay-ide/
 // When run directly (development), fall back to local config.json
@@ -759,6 +763,7 @@ type AgentSessionParams = {
   tmuxDisplayName: string;
   args: string[];
   resolvedAgent: AgentType;
+  resolvedTerminalBackend: TerminalBackend;
   resolvedUseTmux: boolean;
   resolvedYolo: boolean;
   resolvedClaudeArgs: string[];
@@ -787,6 +792,8 @@ type TerminalSessionParams = {
   cwd: string;
   safeCols: number | undefined;
   safeRows: number | undefined;
+  resolvedTerminalBackend: TerminalBackend;
+  resolvedUseTmux: boolean;
   sessionLane: SessionLane | undefined;
   workContextId?: string | undefined;
   portVariables?: string[] | undefined;
@@ -810,6 +817,8 @@ function createTerminalSessionRecord(
     branchName: '',
     command: shell,
     args: [],
+    terminalBackend: params.resolvedTerminalBackend,
+    useTmux: params.resolvedUseTmux,
     ...(params.safeCols != null && { cols: params.safeCols }),
     ...(params.safeRows != null && { rows: params.safeRows }),
     ...(params.sessionLane ? { sessionLane: params.sessionLane } : {}),
@@ -835,6 +844,7 @@ function createAgentSessionRecord(params: AgentSessionParams): CreateResult {
     tmuxDisplayName: params.tmuxDisplayName,
     args: params.args,
     configPath: CONFIG_PATH,
+    terminalBackend: params.resolvedTerminalBackend,
     useTmux: params.resolvedUseTmux,
     yolo: params.resolvedYolo,
     claudeArgs: params.resolvedClaudeArgs,
@@ -1052,6 +1062,11 @@ function createHandoffDestinationLauncher(params: {
 
     try {
       if (input.request.desiredRuntime.kind === 'terminal') {
+        const resolvedTerminal = resolveSessionSettings(
+          freshConfig,
+          repoPath,
+          {}
+        );
         const session = createTerminalSessionRecord({
           repoName,
           repoPath,
@@ -1059,6 +1074,8 @@ function createHandoffDestinationLauncher(params: {
           cwd,
           safeCols: undefined,
           safeRows: undefined,
+          resolvedTerminalBackend: resolvedTerminal.terminalBackend,
+          resolvedUseTmux: resolvedTerminal.useTmux,
           sessionLane: undefined,
           workContextId: undefined,
           portVariables,
@@ -1111,6 +1128,7 @@ function createHandoffDestinationLauncher(params: {
         tmuxDisplayName: branchName ? `${repoName}-${branchName}` : repoName,
         args,
         resolvedAgent: resolved.agent,
+        resolvedTerminalBackend: resolved.terminalBackend,
         resolvedUseTmux: resolved.useTmux,
         resolvedYolo: resolved.yolo,
         resolvedClaudeArgs: resolved.claudeArgs,
@@ -1347,6 +1365,14 @@ function deriveContextInboxStore(
   return store ? createContextInboxStoreAdapter(store) : null;
 }
 
+async function ensureStartupTerminalBackendAvailable(
+  startupConfig: Config
+): Promise<void> {
+  if (defaultTerminalBackend(startupConfig) === 'tmux-compat') {
+    await ensureTmuxAvailable();
+  }
+}
+
 async function main(): Promise<void> {
   // Ignore SIGPIPE: node-pty can propagate pipe breaks causing unexpected session exits.
   // Ignore SIGHUP: keep server alive if controlling terminal disconnects.
@@ -1512,7 +1538,7 @@ async function main(): Promise<void> {
     }
   }
 
-  await ensureTmuxAvailable();
+  await ensureStartupTerminalBackendAvailable(startupConfig);
 
   await initializePortAllocatorAndReconcile(
     CONFIG_PATH,
@@ -1842,7 +1868,9 @@ async function main(): Promise<void> {
   const actorLifecycleError = (res: express.Response, error: unknown) => {
     const message = error instanceof Error ? error.message : String(error);
     const reason =
-      error instanceof Error && 'reason' in error && typeof error.reason === 'string'
+      error instanceof Error &&
+      'reason' in error &&
+      typeof error.reason === 'string'
         ? error.reason
         : 'issue_failed';
     res.status(reason === 'credential_not_found' ? 404 : 400).json({
@@ -1856,7 +1884,9 @@ async function main(): Promise<void> {
 
   app.post('/cli-gateway/actor-credentials', actorLifecycleAuth, (req, res) => {
     try {
-      const body = isRecord(req.body) ? (req.body as CliGatewayActorIssueInput) : {};
+      const body = isRecord(req.body)
+        ? (req.body as CliGatewayActorIssueInput)
+        : {};
       const issued =
         isRecord(req.body) && typeof req.body['grantHandle'] === 'string'
           ? issueCliGatewayActorCredentialWithGrant(
@@ -1906,7 +1936,10 @@ async function main(): Promise<void> {
     }
     const body = isRecord(req.body) ? req.body : {};
     const credential = cliGatewayActorRegistry.revoke(id, {
-      revokedBy: typeof body['revokedBy'] === 'string' ? body['revokedBy'] : 'browser-operator',
+      revokedBy:
+        typeof body['revokedBy'] === 'string'
+          ? body['revokedBy']
+          : 'browser-operator',
       ...(typeof body['reason'] === 'string' ? { reason: body['reason'] } : {}),
       ...(typeof body['correlationId'] === 'string'
         ? { correlationId: body['correlationId'] }
@@ -2163,6 +2196,40 @@ async function main(): Promise<void> {
     c.launchInTmux = true;
     saveConfig(CONFIG_PATH, c);
     res.json({ launchInTmux: true, required: true });
+  });
+
+  app.get('/config/terminalBackend', requireAuth, (_req, res) => {
+    const c = getConfig();
+    res.json({
+      terminalBackend: defaultTerminalBackend(c),
+      allowed: ['tmux-compat', 'relay-pty'],
+    });
+  });
+  app.patch('/config/terminalBackend', requireAuth, async (req, res) => {
+    const value = normalizeTerminalBackend(
+      (req.body as Record<string, unknown>).terminalBackend
+    );
+    if (!value) {
+      res.status(400).json({
+        error: 'terminalBackend must be tmux-compat or relay-pty',
+      });
+      return;
+    }
+    if (value === 'tmux-compat') {
+      try {
+        await ensureTmuxAvailable();
+      } catch (err) {
+        res.status(400).json({
+          error: err instanceof Error ? err.message : 'tmux is not available',
+        });
+        return;
+      }
+    }
+    const c = getConfig();
+    c.terminalBackend = value;
+    c.launchInTmux = value === 'tmux-compat';
+    saveConfig(CONFIG_PATH, c);
+    res.json({ terminalBackend: value, launchInTmux: c.launchInTmux });
   });
 
   const watcher = new WorktreeWatcher();
@@ -2919,119 +2986,129 @@ async function main(): Promise<void> {
   // GET /sessions — enrich with live branch from git (rate-limited to avoid spawning git on every poll)
   const branchRefreshCache = new Map<string, number>(); // sessionId -> last refresh timestamp
   const BRANCH_REFRESH_INTERVAL_MS = 10_000;
-  app.get('/sessions', requireCliGatewayAuthForActorCommand('sessions.list'), async (_req, res) => {
-    const [localSessions, remoteSessions] = await Promise.all([
-      Promise.resolve(
-        localRelayNode.sessions
+  app.get(
+    '/sessions',
+    requireCliGatewayAuthForActorCommand('sessions.list'),
+    async (_req, res) => {
+      const [localSessions, remoteSessions] = await Promise.all([
+        Promise.resolve(
+          localRelayNode.sessions
+            .list()
+            .map((session) =>
+              withWorkContextMetadata(workContextStore, session)
+            )
+        ),
+        aggregateRemoteSessions({
+          registry: hubNodeRegistry,
+          nodeLinks: hubNodeLinks,
+          logger,
+          sessionEnvelopes: sessionEnvelopeRegistry,
+          workContextStore,
+          readModelCache: remoteSessionReadModelCache,
+        }),
+      ]);
+      const allSessions = [...localSessions, ...remoteSessions];
+      const now = Date.now();
+
+      // Prune cache entries for sessions that no longer exist. Branch
+      // refresh only runs against local sessions (they have a real cwd
+      // on this host); the routed-session subset is skipped below via
+      // the `nodeId === undefined` guard.
+      const activeIds = new Set(allSessions.map((s) => s.id));
+      for (const sessionId of branchRefreshCache.keys()) {
+        if (!activeIds.has(sessionId)) branchRefreshCache.delete(sessionId);
+      }
+
+      await Promise.all(
+        allSessions.map(async (s) => {
+          if (s.type !== 'agent') return;
+          // Skip remote (routed) sessions: their cwd lives on the owning
+          // node and running `git` against it locally is meaningless.
+          if (!isLocallyOwnedSession(s)) return;
+          if (!s.cwd) return;
+          const lastRefresh = branchRefreshCache.get(s.id) ?? 0;
+          if (now - lastRefresh < BRANCH_REFRESH_INTERVAL_MS) return;
+          const cwd = s.cwd;
+          branchRefreshCache.set(s.id, now);
+          try {
+            const { stdout } = await execFileAsync(
+              'git',
+              ['rev-parse', '--abbrev-ref', 'HEAD'],
+              { cwd }
+            );
+            const liveBranch = stdout.trim();
+            if (liveBranch && liveBranch !== s.branchName) {
+              s.branchName = liveBranch;
+              const raw = localRelayNode.sessions.get(s.id);
+              if (raw) raw.branchName = liveBranch;
+            }
+          } catch {
+            /* non-fatal */
+          }
+        })
+      );
+      res.json(allSessions);
+    }
+  );
+
+  app.get(
+    '/sessions/:id',
+    requireScopedSessionAuthForActorCommand('sessions.get'),
+    async (req, res) => {
+      const decision = capabilityDecisionFromRequest(
+        req,
+        CONTROL_READ_CAPABILITY
+      );
+      if (decision.decision !== 'allow') {
+        const error = capabilityError(decision);
+        res.status(sessionControlErrorStatus(error)).json({ error });
+        return;
+      }
+      const id = req.params['id'] as string;
+      const local = localRelayNode.sessions.get(id);
+      if (local) {
+        const session = localRelayNode.sessions
           .list()
-          .map((session) => withWorkContextMetadata(workContextStore, session))
-      ),
-      aggregateRemoteSessions({
+          .find((candidate) => candidate.id === id);
+        if (!session) {
+          res.status(404).json({
+            error: {
+              code: 'NOT_FOUND',
+              reasonCode: 'SESSION_NOT_FOUND',
+              message: 'session summary was not found',
+              retryable: false,
+            },
+          });
+          return;
+        }
+        res.json(withWorkContextMetadata(workContextStore, session));
+        return;
+      }
+      const remoteSessions = await aggregateRemoteSessions({
         registry: hubNodeRegistry,
         nodeLinks: hubNodeLinks,
         logger,
         sessionEnvelopes: sessionEnvelopeRegistry,
         workContextStore,
         readModelCache: remoteSessionReadModelCache,
-      }),
-    ]);
-    const allSessions = [...localSessions, ...remoteSessions];
-    const now = Date.now();
-
-    // Prune cache entries for sessions that no longer exist. Branch
-    // refresh only runs against local sessions (they have a real cwd
-    // on this host); the routed-session subset is skipped below via
-    // the `nodeId === undefined` guard.
-    const activeIds = new Set(allSessions.map((s) => s.id));
-    for (const sessionId of branchRefreshCache.keys()) {
-      if (!activeIds.has(sessionId)) branchRefreshCache.delete(sessionId);
-    }
-
-    await Promise.all(
-      allSessions.map(async (s) => {
-        if (s.type !== 'agent') return;
-        // Skip remote (routed) sessions: their cwd lives on the owning
-        // node and running `git` against it locally is meaningless.
-        if (!isLocallyOwnedSession(s)) return;
-        if (!s.cwd) return;
-        const lastRefresh = branchRefreshCache.get(s.id) ?? 0;
-        if (now - lastRefresh < BRANCH_REFRESH_INTERVAL_MS) return;
-        const cwd = s.cwd;
-        branchRefreshCache.set(s.id, now);
-        try {
-          const { stdout } = await execFileAsync(
-            'git',
-            ['rev-parse', '--abbrev-ref', 'HEAD'],
-            { cwd }
-          );
-          const liveBranch = stdout.trim();
-          if (liveBranch && liveBranch !== s.branchName) {
-            s.branchName = liveBranch;
-            const raw = localRelayNode.sessions.get(s.id);
-            if (raw) raw.branchName = liveBranch;
-          }
-        } catch {
-          /* non-fatal */
-        }
-      })
-    );
-    res.json(allSessions);
-  });
-
-  app.get('/sessions/:id', requireScopedSessionAuthForActorCommand('sessions.get'), async (req, res) => {
-    const decision = capabilityDecisionFromRequest(
-      req,
-      CONTROL_READ_CAPABILITY
-    );
-    if (decision.decision !== 'allow') {
-      const error = capabilityError(decision);
-      res.status(sessionControlErrorStatus(error)).json({ error });
-      return;
-    }
-    const id = req.params['id'] as string;
-    const local = localRelayNode.sessions.get(id);
-    if (local) {
-      const session = localRelayNode.sessions
-        .list()
-        .find((candidate) => candidate.id === id);
-      if (!session) {
+      });
+      const remote = remoteSessions.find(
+        (candidate) => candidate.id === id || candidate.globalSessionId === id
+      );
+      if (!remote) {
         res.status(404).json({
           error: {
             code: 'NOT_FOUND',
             reasonCode: 'SESSION_NOT_FOUND',
-            message: 'session summary was not found',
+            message: 'session was not found',
             retryable: false,
           },
         });
         return;
       }
-      res.json(withWorkContextMetadata(workContextStore, session));
-      return;
+      res.json(remote);
     }
-    const remoteSessions = await aggregateRemoteSessions({
-      registry: hubNodeRegistry,
-      nodeLinks: hubNodeLinks,
-      logger,
-      sessionEnvelopes: sessionEnvelopeRegistry,
-      workContextStore,
-      readModelCache: remoteSessionReadModelCache,
-    });
-    const remote = remoteSessions.find(
-      (candidate) => candidate.id === id || candidate.globalSessionId === id
-    );
-    if (!remote) {
-      res.status(404).json({
-        error: {
-          code: 'NOT_FOUND',
-          reasonCode: 'SESSION_NOT_FOUND',
-          message: 'session was not found',
-          retryable: false,
-        },
-      });
-      return;
-    }
-    res.json(remote);
-  });
+  );
 
   app.get('/sessions/:id/replay', requireScopedSessionAuth, (req, res) => {
     const decision = capabilityDecisionFromRequest(
@@ -3766,6 +3843,7 @@ async function main(): Promise<void> {
       agent,
       yolo,
       useTmux,
+      terminalBackend,
       claudeArgs,
       cols,
       rows,
@@ -3788,6 +3866,7 @@ async function main(): Promise<void> {
       agent?: AgentType;
       yolo?: boolean;
       useTmux?: boolean;
+      terminalBackend?: TerminalBackend;
       claudeArgs?: string[];
       cols?: number;
       rows?: number;
@@ -3814,6 +3893,7 @@ async function main(): Promise<void> {
 
     // Read config once for the lifetime of this request
     const freshConfig = getConfig();
+    const requestedTerminalBackend = normalizeTerminalBackend(terminalBackend);
 
     // #740: Bench-inherited env overrides (sanitized to string->string). The
     // PTY layer applies these additively and refuses reserved keys.
@@ -3857,6 +3937,14 @@ async function main(): Promise<void> {
     if (sendPtyCapacityError(res, capacityResponse)) return;
 
     if (type === 'terminal') {
+      const terminalSettings = resolveSessionSettings(
+        freshConfig,
+        checkedRepoPath,
+        {
+          useTmux,
+          terminalBackend: requestedTerminalBackend,
+        }
+      );
       // Terminal session — bare shell
       let session: CreateResult;
       try {
@@ -3867,6 +3955,8 @@ async function main(): Promise<void> {
           cwd,
           safeCols,
           safeRows,
+          resolvedTerminalBackend: terminalSettings.terminalBackend,
+          resolvedUseTmux: terminalSettings.useTmux,
           sessionLane,
           workContextId,
           portVariables,
@@ -3898,6 +3988,7 @@ async function main(): Promise<void> {
       agent,
       yolo,
       useTmux,
+      terminalBackend: requestedTerminalBackend,
       claudeArgs,
       continuePolicy: effectivePolicy,
     });
@@ -3995,6 +4086,7 @@ async function main(): Promise<void> {
         tmuxDisplayName,
         args,
         resolvedAgent,
+        resolvedTerminalBackend: resolved.terminalBackend,
         resolvedUseTmux: resolved.useTmux,
         resolvedYolo: resolved.yolo,
         resolvedClaudeArgs: resolved.claudeArgs,

--- a/server/index.ts
+++ b/server/index.ts
@@ -2227,9 +2227,9 @@ async function main(): Promise<void> {
     }
     const c = getConfig();
     c.terminalBackend = value;
-    c.launchInTmux = value === 'tmux-compat';
+    c.launchInTmux = true;
     saveConfig(CONFIG_PATH, c);
-    res.json({ terminalBackend: value, launchInTmux: c.launchInTmux });
+    res.json({ terminalBackend: value, launchInTmux: true, required: true });
   });
 
   const watcher = new WorktreeWatcher();

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -1446,6 +1446,7 @@ export function createPtySession(
           cwd,
           env,
           tmuxEnv,
+          workContextId: params.workContextId,
           scrollback,
           scrollbackRef,
           timers: {
@@ -1542,6 +1543,7 @@ type RetryContext = {
   cwd: string;
   env: NodeJS.ProcessEnv;
   tmuxEnv: NodeJS.ProcessEnv;
+  workContextId: string | undefined;
   scrollback: string[];
   scrollbackRef: { bytes: number };
   timers: {
@@ -1593,7 +1595,11 @@ function tryRetrySpawn(
       cwd: ctx.cwd,
       env: ctx.useTmux
         ? ctx.tmuxEnv
-        : buildRelayPtySessionEnv({ id: ctx.id, env: ctx.env }),
+        : buildRelayPtySessionEnv({
+            id: ctx.id,
+            env: ctx.env,
+            ...(ctx.workContextId ? { workContextId: ctx.workContextId } : {}),
+          }),
     });
   } catch {
     try {

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -13,6 +13,7 @@ import type {
   Session,
   SessionStatus,
   SessionSummary,
+  TerminalBackend,
   SessionType,
 } from './types.js';
 import {
@@ -40,6 +41,11 @@ import {
   appendTerminalStreamData,
   createTerminalStreamState,
 } from '../shared/session-replay.js';
+import {
+  createLibghosttyTerminalModelBackend,
+  type TerminalModelBackend,
+} from './terminal-model-backend.js';
+import { buildRelayPtySessionEnv } from './relay-pty-session.js';
 
 const IDLE_TIMEOUT_MS = 5000;
 /** Default per-session scrollback cap. Overridable via createPtySession options. */
@@ -390,6 +396,7 @@ export type CreatePtyParams = {
   rows?: number | undefined;
   configPath?: string | undefined;
   configDir?: string | undefined;
+  terminalBackend?: TerminalBackend | undefined;
   useTmux?: boolean | undefined;
   tmuxSessionName?: string | undefined;
   tmuxDisplayName?: string | undefined;
@@ -913,13 +920,15 @@ function resolveSpawnTarget(
   command: string | undefined,
   resolvedCommand: string,
   args: string[],
-  _paramUseTmux: boolean | undefined,
+  paramUseTmux: boolean | undefined,
+  paramTerminalBackend: TerminalBackend | undefined,
   paramTmuxSessionName: string | undefined,
   tmuxAttach: boolean | undefined,
   tmuxDisplayName: string | undefined,
+  cwd: string,
+  workContextId: string | undefined,
   displayName: string | undefined,
   repoName: string | undefined,
-  cwd: string,
   id: string,
   env: NodeJS.ProcessEnv,
   tmuxEnv: NodeJS.ProcessEnv
@@ -927,28 +936,52 @@ function resolveSpawnTarget(
   spawnCommand: string;
   spawnArgs: string[];
   spawnEnv: NodeJS.ProcessEnv;
+  terminalBackend: TerminalBackend;
   useTmux: boolean;
   tmuxSessionName: string;
 } {
-  const useTmux = true;
+  const terminalBackend =
+    paramTerminalBackend ??
+    (paramUseTmux === false ? 'relay-pty' : 'tmux-compat');
+  const useTmux = terminalBackend === 'tmux-compat';
   const tmuxSessionName =
     paramTmuxSessionName ||
-    generateTmuxSessionName(
-      tmuxDisplayName ||
-        displayName ||
-        repoName ||
-        path.basename(cwd) ||
-        'session',
-      id
-    );
+    (useTmux
+      ? generateTmuxSessionName(
+          tmuxDisplayName ||
+            displayName ||
+            repoName ||
+            path.basename(cwd) ||
+            'session',
+          id
+        )
+      : '');
 
-  const spawnEnv = tmuxEnv;
+  const spawnEnv = useTmux
+    ? tmuxEnv
+    : buildRelayPtySessionEnv({
+        id,
+        env,
+        ...(workContextId ? { workContextId } : {}),
+      });
+
+  if (!useTmux) {
+    return {
+      spawnCommand: resolvedCommand,
+      spawnArgs: args,
+      spawnEnv,
+      terminalBackend,
+      useTmux,
+      tmuxSessionName,
+    };
+  }
 
   if (tmuxAttach) {
     return {
       spawnCommand: resolvedCommand,
       spawnArgs: args,
       spawnEnv,
+      terminalBackend,
       useTmux,
       tmuxSessionName,
     };
@@ -964,6 +997,7 @@ function resolveSpawnTarget(
       spawnCommand: tmux.command,
       spawnArgs: tmux.args,
       spawnEnv,
+      terminalBackend,
       useTmux,
       tmuxSessionName,
     };
@@ -978,6 +1012,8 @@ function buildSessionObject(
   hookToken: string,
   hooksActive: boolean,
   effectiveEventSource: EventSourceType,
+  terminalBackend: TerminalBackend,
+  terminalModel: TerminalModelBackend | undefined,
   useTmux: boolean,
   tmuxSessionName: string,
   createdAt: string,
@@ -1029,6 +1065,8 @@ function buildSessionObject(
       initialChunks: scrollback,
     }),
     terminalStreamSubscribers: [],
+    terminalBackend,
+    ...(terminalModel ? { terminalModel } : {}),
     idle: false,
     cwd,
     customCommand:
@@ -1217,22 +1255,30 @@ export function createPtySession(
   const { env, tmuxEnv, hookToken, hooksActive, settingsPath } = hookSetup;
   const args = hookSetup.args;
 
-  const { spawnCommand, spawnArgs, spawnEnv, useTmux, tmuxSessionName } =
-    resolveSpawnTarget(
-      command,
-      resolvedCommand,
-      args,
-      paramUseTmux,
-      paramTmuxSessionName,
-      tmuxAttach,
-      params.tmuxDisplayName,
-      displayName,
-      repoName,
-      cwd,
-      id,
-      env,
-      tmuxEnv
-    );
+  const {
+    spawnCommand,
+    spawnArgs,
+    spawnEnv,
+    terminalBackend,
+    useTmux,
+    tmuxSessionName,
+  } = resolveSpawnTarget(
+    command,
+    resolvedCommand,
+    args,
+    paramUseTmux,
+    params.terminalBackend,
+    paramTmuxSessionName,
+    tmuxAttach,
+    params.tmuxDisplayName,
+    cwd,
+    params.workContextId,
+    displayName,
+    repoName,
+    id,
+    env,
+    tmuxEnv
+  );
 
   let ptyProcess: pty.IPty;
   try {
@@ -1255,6 +1301,17 @@ export function createPtySession(
   }
 
   const scrollback: string[] = initialScrollback ? [...initialScrollback] : [];
+  const terminalModel =
+    terminalBackend === 'relay-pty'
+      ? createLibghosttyTerminalModelBackend({
+          cols,
+          rows,
+          scrollbackLimit: 1000,
+        })
+      : undefined;
+  if (terminalModel) {
+    for (const chunk of scrollback) terminalModel.feed(chunk);
+  }
   // Use a ref so tryRetrySpawn (called from onExit) can reset the byte counter
   const scrollbackRef = {
     bytes: initialScrollback
@@ -1274,6 +1331,8 @@ export function createPtySession(
     hookToken,
     hooksActive,
     effectiveEventSource,
+    terminalBackend,
+    terminalModel,
     useTmux,
     tmuxSessionName,
     createdAt,
@@ -1324,6 +1383,7 @@ export function createPtySession(
       session.lastActivity = new Date().toISOString();
       resetIdleTimer();
       scrollback.push(data);
+      session.terminalModel?.feed(data);
       scrollbackRef.bytes += data.length;
       const terminalStreamEnvelope = session.terminalStream
         ? appendTerminalStreamData(session.terminalStream, data)
@@ -1458,6 +1518,7 @@ export function createPtySession(
     idle: false,
     cwd,
     customCommand: session.customCommand,
+    terminalBackend,
     useTmux,
     tmuxSessionName,
     status: 'active' as SessionStatus,
@@ -1530,7 +1591,9 @@ function tryRetrySpawn(
       cols: ctx.cols,
       rows: ctx.rows,
       cwd: ctx.cwd,
-      env: ctx.tmuxEnv,
+      env: ctx.useTmux
+        ? ctx.tmuxEnv
+        : buildRelayPtySessionEnv({ id: ctx.id, env: ctx.env }),
     });
   } catch {
     try {
@@ -1576,6 +1639,7 @@ function runExitCleanup(
     }
   }
   sessionsMap.delete(id);
+  session.terminalModel?.dispose();
   if (!session.preserveRuntimeFilesOnExit) {
     const tmpDir = path.join(os.tmpdir(), 'relay-ide', id);
     fs.rm(tmpDir, { recursive: true, force: true }, () => {});

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -13,6 +13,7 @@ import type {
   Session,
   SessionSummary,
   SessionMeta,
+  TerminalBackend,
   SessionType,
   WebSession,
 } from './types.js';
@@ -105,6 +106,10 @@ import {
   securityAuditEntryForTabControlEvent,
   type SecurityAuditEntryInput,
 } from '../shared/security-audit.js';
+import {
+  encodeTerminalInput,
+  type TerminalInputKey,
+} from './terminal-model-backend.js';
 
 const execFileAsync = promisify(execFile);
 const logger = createLogger('sessions');
@@ -202,6 +207,7 @@ interface SerializedPtySession {
   displayName: string;
   createdAt: string;
   lastActivity: string;
+  terminalBackend?: TerminalBackend;
   useTmux: boolean;
   tmuxSessionName: string;
   customCommand: string | null;
@@ -836,7 +842,11 @@ function list(): SessionSummary[] {
         currentActivity: s.currentActivity,
         ...normalizeControlStateSummary(s.controlState),
         ...(s.mode === 'pty'
-          ? { useTmux: s.useTmux, tmuxSessionName: s.tmuxSessionName }
+          ? {
+              terminalBackend: s.terminalBackend,
+              useTmux: s.useTmux,
+              tmuxSessionName: s.tmuxSessionName,
+            }
           : {}),
         ...(s.workspaceId ? { workspaceId: s.workspaceId } : {}),
         ...(s.additionalDirs?.length
@@ -879,7 +889,7 @@ function kill(id: string): void {
     } catch {
       // PTY may already be dead (e.g. disconnected sessions) — still delete from registry
     }
-    if (session.tmuxSessionName) {
+    if (session.useTmux && session.tmuxSessionName) {
       execFile(
         TMUX_COMMAND,
         ['kill-session', '-t', session.tmuxSessionName],
@@ -936,7 +946,7 @@ function detachForRestart(id: string): void {
   }
   if (session.mode === 'pty') {
     session.preserveRuntimeFilesOnExit = true;
-    if (session.tmuxSessionName) {
+    if (session.useTmux && session.tmuxSessionName) {
       try {
         execFileSync(
           TMUX_COMMAND,
@@ -966,7 +976,7 @@ function detachForRestart(id: string): void {
 
 function killAllTmuxSessions(): void {
   for (const session of sessions.values()) {
-    if (session.mode === 'pty' && session.tmuxSessionName) {
+    if (session.mode === 'pty' && session.useTmux && session.tmuxSessionName) {
       execFile(
         TMUX_COMMAND,
         ['kill-session', '-t', session.tmuxSessionName],
@@ -983,6 +993,7 @@ function resize(id: string, cols: number, rows: number): void {
   }
   if (session.mode === 'pty') {
     session.pty.resize(cols, rows);
+    session.terminalModel?.resize(cols, rows);
   } else {
     logger.warn(`resize() called on web session ${id} — no-op`);
   }
@@ -1019,12 +1030,16 @@ function supervisorWrite(
   try {
     session.pty.write(input.payload);
   } catch (error) {
-    logger.warn(`supervisorWrite() failed to write to PTY session ${id}: ${String(error)}`);
+    logger.warn(
+      `supervisorWrite() failed to write to PTY session ${id}: ${String(error)}`
+    );
     throw error;
   }
   const event = recordSupervisorAction(session, input, controlEngineOptions());
   if (event.type !== 'tab.intervention') {
-    throw new Error(`Supervisor action did not produce an intervention event for ${id}`);
+    throw new Error(
+      `Supervisor action did not produce an intervention event for ${id}`
+    );
   }
   session.lastActivity = new Date().toISOString();
   return {
@@ -1086,6 +1101,7 @@ function routedPtyControlSession(nodeId: string, sessionId: string): Session {
     mode: 'pty',
     pty: { write: () => {}, resize: () => {}, kill: () => {} },
     scrollback: [],
+    terminalBackend: 'relay-pty',
     useTmux: false,
     tmuxSessionName: `routed-${globalSessionId}`,
     onPtyReplacedCallbacks: [],
@@ -1211,23 +1227,76 @@ function tmuxTargetForSession(id: string): string {
   if (!session) {
     throw new Error(`Session not found: ${id}`);
   }
-  if (session.mode !== 'pty' || !session.tmuxSessionName) {
-    throw new Error(`Session ${id} does not have a tmux target`);
+  if (session.mode !== 'pty' || !session.useTmux || !session.tmuxSessionName) {
+    throw new Error(`Session ${id} does not have a tmux compatibility target`);
   }
   return session.tmuxSessionName;
 }
 
+function ptySessionForTerminalControl(id: string): PtySession {
+  const session = sessions.get(id);
+  if (!session) {
+    throw new Error(`Session not found: ${id}`);
+  }
+  if (session.mode !== 'pty') {
+    throw new Error(`Session ${id} is not a PTY session`);
+  }
+  return session;
+}
+
+const SUPPORTED_TERMINAL_INPUT_KEYS = new Set<TerminalInputKey>([
+  'Enter',
+  'Escape',
+  'Tab',
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'CtrlC',
+]);
+
+function toTerminalInputKey(key: string): TerminalInputKey {
+  if (SUPPORTED_TERMINAL_INPUT_KEYS.has(key as TerminalInputKey)) {
+    return key as TerminalInputKey;
+  }
+  throw new Error(`Unsupported relay-pty input key: ${key}`);
+}
+
 async function sendTmuxKeys(id: string, keys: string[]): Promise<void> {
+  const session = ptySessionForTerminalControl(id);
+  if (session.terminalBackend === 'relay-pty') {
+    for (const key of keys) {
+      const encoded = encodeTerminalInput({
+        type: 'key',
+        key: toTerminalInputKey(key),
+      });
+      session.pty.write(encoded.sequence);
+    }
+    return;
+  }
   const target = tmuxTargetForSession(id);
   await execFileAsync(TMUX_COMMAND, ['send-keys', '-t', target, ...keys]);
 }
 
 async function sendTmuxText(id: string, text: string): Promise<void> {
+  const session = ptySessionForTerminalControl(id);
+  if (session.terminalBackend === 'relay-pty') {
+    const encoded = encodeTerminalInput({ type: 'text', text });
+    session.pty.write(encoded.sequence);
+    return;
+  }
   const target = tmuxTargetForSession(id);
   await execFileAsync(TMUX_COMMAND, ['send-keys', '-t', target, '-l', text]);
 }
 
 async function captureTmuxPane(id: string): Promise<string> {
+  const session = ptySessionForTerminalControl(id);
+  if (session.terminalBackend === 'relay-pty') {
+    if (!session.terminalModel) {
+      throw new Error(`Session ${id} does not have a terminal model`);
+    }
+    return session.terminalModel.getVisibleText();
+  }
   const target = tmuxTargetForSession(id);
   const { stdout } = await execFileAsync(TMUX_COMMAND, [
     'capture-pane',
@@ -1380,6 +1449,7 @@ function serializePtySession(
     displayName: session.displayName,
     createdAt: session.createdAt,
     lastActivity: session.lastActivity,
+    terminalBackend: session.terminalBackend,
     useTmux: session.useTmux,
     tmuxSessionName: session.tmuxSessionName || '',
     customCommand: session.customCommand,
@@ -1580,9 +1650,14 @@ function buildAgentArgs(
 type RestoredPtySpawnParams = {
   command: string | undefined;
   args: string[];
+  terminalBackend: TerminalBackend;
   tmuxSessionName: string;
   tmuxAttach: boolean;
 };
+
+function serializedTerminalBackend(s: SerializedPtySession): TerminalBackend {
+  return s.terminalBackend ?? 'tmux-compat';
+}
 
 function stableTmuxSessionName(s: SerializedPtySession): string {
   return (
@@ -1595,9 +1670,11 @@ async function resolveSessionSpawnParams(
   s: SerializedPtySession,
   frameworks?: Record<string, Partial<AgentFramework>>
 ): Promise<RestoredPtySpawnParams> {
-  const tmuxSessionName = stableTmuxSessionName(s);
+  const terminalBackend = serializedTerminalBackend(s);
+  const tmuxSessionName =
+    terminalBackend === 'tmux-compat' ? stableTmuxSessionName(s) : '';
 
-  if (tmuxSessionName) {
+  if (terminalBackend === 'tmux-compat' && tmuxSessionName) {
     let tmuxAlive = false;
     try {
       await execFileAsync(TMUX_COMMAND, ['has-session', '-t', tmuxSessionName]);
@@ -1619,6 +1696,7 @@ async function resolveSessionSpawnParams(
       return {
         command: TMUX_COMMAND,
         args: ['-u', 'attach-session', '-t', tmuxSessionName],
+        terminalBackend,
         tmuxSessionName,
         tmuxAttach: true,
       };
@@ -1629,6 +1707,7 @@ async function resolveSessionSpawnParams(
     return {
       command: s.customCommand,
       args: [],
+      terminalBackend,
       tmuxSessionName,
       tmuxAttach: false,
     };
@@ -1637,6 +1716,7 @@ async function resolveSessionSpawnParams(
   return {
     command: undefined,
     args: buildAgentArgs(s, frameworks),
+    terminalBackend,
     tmuxSessionName,
     tmuxAttach: false,
   };
@@ -1658,7 +1738,8 @@ function restoreSession(
     branchName: s.branchName,
     displayName: s.displayName,
     args: spawn.args,
-    useTmux: true,
+    terminalBackend: spawn.terminalBackend,
+    useTmux: spawn.terminalBackend === 'tmux-compat',
     tmuxSessionName: spawn.tmuxSessionName,
     tmuxAttach: spawn.tmuxAttach,
     sessionCustomCommand: s.customCommand,
@@ -2107,7 +2188,7 @@ async function restoreFromDisk(
 function activeTmuxSessionNames(): Set<string> {
   const names = new Set<string>();
   for (const session of sessions.values()) {
-    if (session.mode === 'pty' && session.tmuxSessionName)
+    if (session.mode === 'pty' && session.useTmux && session.tmuxSessionName)
       names.add(session.tmuxSessionName);
   }
   return names;

--- a/server/types.ts
+++ b/server/types.ts
@@ -31,6 +31,7 @@ import type {
 } from '../shared/control-state.js';
 import type { SessionEnvelope } from '../shared/session-envelope.js';
 import type { SessionDurabilityState } from '../shared/session-durability.js';
+import type { TerminalModelBackend } from './terminal-model-backend.js';
 
 export type AgentState =
   | 'initializing'
@@ -54,6 +55,7 @@ export type ContinuePolicy = 'always' | 'never';
 export type BranchLifecycleState = 'active' | 'stale' | 'merged';
 export type SessionStatus = 'active' | 'disconnected';
 export type SessionMode = 'pty' | 'web';
+export type TerminalBackend = 'tmux-compat' | 'relay-pty';
 
 // ── Agent Framework Registry ──
 
@@ -321,6 +323,9 @@ export interface PtySession extends BaseSession {
   terminalStream?: TerminalStreamState;
   /** Live subscribers for terminal stream v2 envelopes. */
   terminalStreamSubscribers?: Array<(envelope: TerminalStreamEnvelope) => void>;
+  terminalBackend: TerminalBackend;
+  /** Relay-owned terminal screen model used by the relay-pty backend. */
+  terminalModel?: TerminalModelBackend;
   useTmux: boolean;
   tmuxSessionName: string;
   onPtyReplacedCallbacks: Array<(newPty: IPty) => void>;
@@ -424,6 +429,8 @@ export interface SessionSummary {
   /** Node-scoped worktree/cwd instance id when this session runs in a worktree. */
   worktreeInstanceId?: WorktreeInstanceId;
   /** PTY sessions only */
+  terminalBackend?: TerminalBackend;
+  /** PTY sessions only */
   useTmux?: boolean;
   /** PTY sessions only */
   tmuxSessionName?: string;
@@ -509,6 +516,7 @@ export interface WorkspaceSettings {
   defaultContinuePolicy?: ContinuePolicy;
   defaultYolo?: boolean;
   launchInTmux?: boolean;
+  terminalBackend?: TerminalBackend;
   claudeArgs?: string[];
 
   // Git settings
@@ -606,6 +614,7 @@ export interface Config {
   defaultYolo: boolean;
   maxPtySessions: number;
   launchInTmux: boolean;
+  terminalBackend: TerminalBackend;
   defaultNotifications: boolean;
   claudeFullscreen: boolean;
   /**
@@ -906,6 +915,7 @@ export interface WorkspaceLevelSettings {
   defaultContinue?: boolean;
   defaultYolo?: boolean;
   launchInTmux?: boolean;
+  terminalBackend?: TerminalBackend;
   claudeArgs?: string[];
   promptCodeReview?: string;
   promptCreatePr?: string;

--- a/shared/cli-gateway-runtime.ts
+++ b/shared/cli-gateway-runtime.ts
@@ -90,6 +90,24 @@ const localUnsupportedFields = [
   'confirmationToken',
 ] as const;
 
+const localCreateSupportedFields = [
+  'repoPath',
+  'worktreePath',
+  'type',
+  'mode',
+  'agent',
+  'yolo',
+  'useTmux',
+  'terminalBackend',
+  'cols',
+  'rows',
+  'branchName',
+  'initialPrompt',
+  'continuePolicy',
+  'workContextId',
+  'controlMode',
+] as const;
+
 function createValidationError(
   code: RelayCliGatewayErrorCode,
   message: string,
@@ -507,13 +525,7 @@ function validateLocalCreateSupport(
         `local sessions.create does not support ${field}; use routed node creation or omit the field`,
         {
           field,
-          supportedLocalFields: [
-            'repoPath',
-            'worktreePath',
-            'type',
-            'mode',
-            'agent',
-          ],
+          supportedLocalFields: localCreateSupportedFields,
         }
       );
     }

--- a/shared/cli-gateway-runtime.ts
+++ b/shared/cli-gateway-runtime.ts
@@ -30,6 +30,8 @@ const createSessionAllowedFields = new Set([
   'mode',
   'agent',
   'yolo',
+  'useTmux',
+  'terminalBackend',
   'cols',
   'rows',
   'branchName',
@@ -61,13 +63,19 @@ const createSessionEnvironmentAllowedFields = new Set([
  * Legacy flat fields that cannot be combined with the typed `environment`
  * object. Callers pick one shape per request; mixing produces INVALID_ARGUMENT.
  */
-const legacyEnvironmentFlatFields = ['nodeId', 'repoPath', 'worktreePath', 'cwd'] as const;
+const legacyEnvironmentFlatFields = [
+  'nodeId',
+  'repoPath',
+  'worktreePath',
+  'cwd',
+] as const;
 
 const stringFields = [
   'nodeId',
   'repoPath',
   'cwd',
   'agent',
+  'terminalBackend',
   'branchName',
   'initialPrompt',
   'workContextId',
@@ -146,7 +154,9 @@ function validateStringField(
 ): GatewayCreateValidationFailure | null {
   if (input[field] === undefined) return null;
   if (typeof input[field] !== 'string') {
-    return invalidCreateInput(`sessions.create ${field} must be a string`, { field });
+    return invalidCreateInput(`sessions.create ${field} must be a string`, {
+      field,
+    });
   }
   return null;
 }
@@ -159,7 +169,10 @@ function validateNumberField(
 ): GatewayCreateValidationFailure | null {
   if (input[field] === undefined) return null;
   if (typeof input[field] !== 'number' || !Number.isFinite(input[field])) {
-    return invalidCreateInput(`sessions.create ${field} must be a finite number`, { field });
+    return invalidCreateInput(
+      `sessions.create ${field} must be a finite number`,
+      { field }
+    );
   }
   if (input[field] < min || (max !== undefined && input[field] > max)) {
     return invalidCreateInput(
@@ -206,13 +219,19 @@ function validateCreateEnvironment(
     }
   }
 
-  if (typeof environment['nodeId'] !== 'string' || environment['nodeId'].length === 0) {
+  if (
+    typeof environment['nodeId'] !== 'string' ||
+    environment['nodeId'].length === 0
+  ) {
     return invalidCreateInput(
       'sessions.create environment.nodeId is required and must be a non-empty string',
       { field: 'environment.nodeId' }
     );
   }
-  if (typeof environment['cwd'] !== 'string' || environment['cwd'].length === 0) {
+  if (
+    typeof environment['cwd'] !== 'string' ||
+    environment['cwd'].length === 0
+  ) {
     return invalidCreateInput(
       'sessions.create environment.cwd is required and must be a non-empty string',
       { field: 'environment.cwd' }
@@ -281,22 +300,35 @@ function validateSessionEnvelopeInput(
 ): GatewayCreateValidationFailure | null {
   if (envelope === undefined) return null;
   if (!isRecord(envelope)) {
-    return invalidCreateInput('sessions.create sessionEnvelope must be an object', {
-      field: 'sessionEnvelope',
-    });
+    return invalidCreateInput(
+      'sessions.create sessionEnvelope must be an object',
+      {
+        field: 'sessionEnvelope',
+      }
+    );
   }
   const envelopeNodeId = envelope['nodeId'];
   if (envelopeNodeId !== undefined && typeof envelopeNodeId !== 'string') {
-    return invalidCreateInput('sessions.create sessionEnvelope.nodeId must be a string', {
-      field: 'sessionEnvelope.nodeId',
-    });
+    return invalidCreateInput(
+      'sessions.create sessionEnvelope.nodeId must be a string',
+      {
+        field: 'sessionEnvelope.nodeId',
+      }
+    );
   }
-  if (nodeId && typeof envelopeNodeId === 'string' && envelopeNodeId !== nodeId) {
-    return invalidCreateInput('sessions.create sessionEnvelope.nodeId must match nodeId', {
-      field: 'sessionEnvelope.nodeId',
-      nodeId,
-      envelopeNodeId,
-    });
+  if (
+    nodeId &&
+    typeof envelopeNodeId === 'string' &&
+    envelopeNodeId !== nodeId
+  ) {
+    return invalidCreateInput(
+      'sessions.create sessionEnvelope.nodeId must match nodeId',
+      {
+        field: 'sessionEnvelope.nodeId',
+        nodeId,
+        envelopeNodeId,
+      }
+    );
   }
   const peerIdentity = envelope['peerIdentity'];
   if (peerIdentity !== undefined) {
@@ -336,13 +368,18 @@ function validateSessionEnvelopeInput(
 
 function sanitizedCreateInput(
   rawInput: Record<string, unknown>
-): GatewayCreateValidationFailure | { ok: true; input: Record<string, unknown> } {
+):
+  | GatewayCreateValidationFailure
+  | { ok: true; input: Record<string, unknown> } {
   const sanitized: Record<string, unknown> = {};
   for (const [field, value] of Object.entries(rawInput)) {
     if (!createSessionAllowedFields.has(field)) {
-      return invalidCreateInput(`sessions.create field is not in the v1 contract: ${field}`, {
-        field,
-      });
+      return invalidCreateInput(
+        `sessions.create field is not in the v1 contract: ${field}`,
+        {
+          field,
+        }
+      );
     }
     sanitized[field] = value;
   }
@@ -361,12 +398,22 @@ function validateCreateFieldTypes(
     input['worktreePath'] !== null &&
     typeof input['worktreePath'] !== 'string'
   ) {
-    return invalidCreateInput('sessions.create worktreePath must be a string or null', {
-      field: 'worktreePath',
-    });
+    return invalidCreateInput(
+      'sessions.create worktreePath must be a string or null',
+      {
+        field: 'worktreePath',
+      }
+    );
   }
   if (input['yolo'] !== undefined && typeof input['yolo'] !== 'boolean') {
-    return invalidCreateInput('sessions.create yolo must be a boolean', { field: 'yolo' });
+    return invalidCreateInput('sessions.create yolo must be a boolean', {
+      field: 'yolo',
+    });
+  }
+  if (input['useTmux'] !== undefined && typeof input['useTmux'] !== 'boolean') {
+    return invalidCreateInput('sessions.create useTmux must be a boolean', {
+      field: 'useTmux',
+    });
   }
   for (const [field, min, max] of [
     ['cols', 1, 500],
@@ -382,34 +429,71 @@ function validateCreateFieldTypes(
 function validateCreateEnums(
   input: Record<string, unknown>
 ): GatewayCreateValidationFailure | null {
-  if (input['type'] !== undefined && input['type'] !== 'agent' && input['type'] !== 'terminal') {
-    return invalidCreateInput('sessions.create type must be agent or terminal', { field: 'type' });
+  if (
+    input['type'] !== undefined &&
+    input['type'] !== 'agent' &&
+    input['type'] !== 'terminal'
+  ) {
+    return invalidCreateInput(
+      'sessions.create type must be agent or terminal',
+      { field: 'type' }
+    );
   }
-  if (input['mode'] !== undefined && input['mode'] !== 'pty' && input['mode'] !== 'web') {
-    return invalidCreateInput('sessions.create mode must be pty or web', { field: 'mode' });
+  if (
+    input['mode'] !== undefined &&
+    input['mode'] !== 'pty' &&
+    input['mode'] !== 'web'
+  ) {
+    return invalidCreateInput('sessions.create mode must be pty or web', {
+      field: 'mode',
+    });
+  }
+  if (
+    input['terminalBackend'] !== undefined &&
+    input['terminalBackend'] !== 'tmux-compat' &&
+    input['terminalBackend'] !== 'relay-pty'
+  ) {
+    return invalidCreateInput(
+      'sessions.create terminalBackend must be tmux-compat or relay-pty',
+      {
+        field: 'terminalBackend',
+      }
+    );
   }
   if (
     input['continuePolicy'] !== undefined &&
     input['continuePolicy'] !== 'always' &&
     input['continuePolicy'] !== 'never'
   ) {
-    return invalidCreateInput('sessions.create continuePolicy must be always or never', {
-      field: 'continuePolicy',
-    });
+    return invalidCreateInput(
+      'sessions.create continuePolicy must be always or never',
+      {
+        field: 'continuePolicy',
+      }
+    );
   }
   if (
     input['controlMode'] !== undefined &&
     input['controlMode'] !== 'agent-driven' &&
     input['controlMode'] !== 'human-driven'
   ) {
-    return invalidCreateInput('sessions.create controlMode must be agent-driven or human-driven', {
-      field: 'controlMode',
-    });
+    return invalidCreateInput(
+      'sessions.create controlMode must be agent-driven or human-driven',
+      {
+        field: 'controlMode',
+      }
+    );
   }
-  if (input['expiresAt'] !== undefined && Number.isNaN(Date.parse(input['expiresAt'] as string))) {
-    return invalidCreateInput('sessions.create expiresAt must be an ISO date-time string', {
-      field: 'expiresAt',
-    });
+  if (
+    input['expiresAt'] !== undefined &&
+    Number.isNaN(Date.parse(input['expiresAt'] as string))
+  ) {
+    return invalidCreateInput(
+      'sessions.create expiresAt must be an ISO date-time string',
+      {
+        field: 'expiresAt',
+      }
+    );
   }
   return null;
 }
@@ -421,7 +505,16 @@ function validateLocalCreateSupport(
     if (input[field] !== undefined) {
       return unsupportedCreateInput(
         `local sessions.create does not support ${field}; use routed node creation or omit the field`,
-        { field, supportedLocalFields: ['repoPath', 'worktreePath', 'type', 'mode', 'agent'] }
+        {
+          field,
+          supportedLocalFields: [
+            'repoPath',
+            'worktreePath',
+            'type',
+            'mode',
+            'agent',
+          ],
+        }
       );
     }
   }
@@ -438,7 +531,9 @@ function validateLocalCreateSupport(
     );
   }
   if (typeof input['repoPath'] !== 'string') {
-    return invalidCreateInput('local session creation requires repoPath', { field: 'repoPath' });
+    return invalidCreateInput('local session creation requires repoPath', {
+      field: 'repoPath',
+    });
   }
   return null;
 }
@@ -460,15 +555,21 @@ export function validateAndSanitizeGatewayCreateInput(
   // The typed environment supplies an effective nodeId for downstream routing
   // when present. When `environment` is set, `nodeId` (flat) is forbidden by
   // validateCreateEnvironment, so this is unambiguous.
-  const environment = isRecord(sanitized['environment']) ? sanitized['environment'] : undefined;
+  const environment = isRecord(sanitized['environment'])
+    ? sanitized['environment']
+    : undefined;
   const environmentNodeId =
     environment && typeof environment['nodeId'] === 'string'
       ? environment['nodeId']
       : undefined;
-  const flatNodeId = typeof sanitized['nodeId'] === 'string' ? sanitized['nodeId'] : undefined;
+  const flatNodeId =
+    typeof sanitized['nodeId'] === 'string' ? sanitized['nodeId'] : undefined;
   const nodeId = environmentNodeId ?? flatNodeId;
 
-  const envelopeError = validateSessionEnvelopeInput(sanitized['sessionEnvelope'], nodeId);
+  const envelopeError = validateSessionEnvelopeInput(
+    sanitized['sessionEnvelope'],
+    nodeId
+  );
   if (envelopeError) return envelopeError;
   if (!nodeId) {
     const localError = validateLocalCreateSupport(sanitized);
@@ -477,7 +578,12 @@ export function validateAndSanitizeGatewayCreateInput(
 
   const sessionType = sanitized['type'] === 'terminal' ? 'terminal' : 'agent';
   sanitized['type'] = sessionType;
-  return { ok: true, input: sanitized, ...(nodeId ? { nodeId } : {}), sessionType };
+  return {
+    ok: true,
+    input: sanitized,
+    ...(nodeId ? { nodeId } : {}),
+    sessionType,
+  };
 }
 
 export function validateAndSanitizeLocalGatewayCreateInput(
@@ -500,7 +606,9 @@ export function validateAndSanitizeLocalGatewayCreateInput(
   return validated;
 }
 
-function upstreamErrorRecord(upstream: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+function upstreamErrorRecord(
+  upstream: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
   const error = upstream?.['error'];
   return typeof error === 'object' && error !== null
     ? (error as Record<string, unknown>)
@@ -545,9 +653,11 @@ export function normalizeGatewayErrorCode(
   upstream: Record<string, unknown> | undefined
 ): RelayCliGatewayErrorCode {
   const body = upstreamErrorRecord(upstream);
-  const reason = typeof body?.['reasonCode'] === 'string' ? body['reasonCode'] : undefined;
+  const reason =
+    typeof body?.['reasonCode'] === 'string' ? body['reasonCode'] : undefined;
   const code = typeof body?.['code'] === 'string' ? body['code'] : undefined;
-  if (code === 'CONFIRMATION_REQUIRED' || reason === 'CONFIRMATION_REQUIRED') return 'CONFIRMATION_REQUIRED';
+  if (code === 'CONFIRMATION_REQUIRED' || reason === 'CONFIRMATION_REQUIRED')
+    return 'CONFIRMATION_REQUIRED';
   const handoffCode = normalizeHandoffGatewayErrorCode(code);
   if (handoffCode) return handoffCode;
   if (isGatewayPassthroughErrorCode(code)) return code;
@@ -559,7 +669,12 @@ export function normalizeGatewayErrorCode(
   if (code === 'NODE_UNSUPPORTED') return 'UNSUPPORTED';
   if (code === 'NOT_FOUND' || status === 404) return 'NOT_FOUND';
   if (code === 'FORBIDDEN' || status === 403) return 'FORBIDDEN';
-  if (status === 400 || code === 'INVALID_REQUEST' || code === 'INVALID_ARGUMENT') return 'INVALID_ARGUMENT';
+  if (
+    status === 400 ||
+    code === 'INVALID_REQUEST' ||
+    code === 'INVALID_ARGUMENT'
+  )
+    return 'INVALID_ARGUMENT';
   if (status === 409 || code === 'SESSION_CONFLICT') return 'SESSION_CONFLICT';
   if (status === 503) return 'SERVER_UNAVAILABLE';
   return 'UPSTREAM_ERROR';
@@ -584,10 +699,18 @@ export function gatewayErrorMessage(
     : `Relay hub returned HTTP ${status}`;
 }
 
-function redactedChallenge(value: unknown): Record<string, unknown> | undefined {
+function redactedChallenge(
+  value: unknown
+): Record<string, unknown> | undefined {
   if (!isRecord(value)) return undefined;
   const result: Record<string, unknown> = {};
-  for (const key of ['id', 'challengeId', 'expiresAt', 'requiredBits', 'requiredCapabilities']) {
+  for (const key of [
+    'id',
+    'challengeId',
+    'expiresAt',
+    'requiredBits',
+    'requiredCapabilities',
+  ]) {
     const entry = value[key];
     if (entry !== undefined) result[key] = entry;
   }
@@ -605,11 +728,17 @@ export function sanitizedGatewayErrorDetails(
   if (typeof code === 'string') details['upstreamCode'] = code;
   if (typeof reasonCode === 'string') details['reasonCode'] = reasonCode;
 
-  const upstreamDetails = isRecord(body?.['details']) ? body['details'] : undefined;
-  const field = isRecord(upstreamDetails) ? upstreamDetails['field'] : body?.['field'];
+  const upstreamDetails = isRecord(body?.['details'])
+    ? body['details']
+    : undefined;
+  const field = isRecord(upstreamDetails)
+    ? upstreamDetails['field']
+    : body?.['field'];
   if (typeof field === 'string') details['field'] = field;
   const challenge = redactedChallenge(
-    isRecord(upstreamDetails) ? upstreamDetails['challenge'] : body?.['challenge']
+    isRecord(upstreamDetails)
+      ? upstreamDetails['challenge']
+      : body?.['challenge']
   );
   if (challenge) details['challenge'] = challenge;
   return details;

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -382,6 +382,29 @@ describe('CLI gateway contract', () => {
       ok: false,
       error: { code: 'UNSUPPORTED', details: { field: 'ttlSeconds' } },
     });
+    expect(localLifecycle.ok).toBe(false);
+    if (localLifecycle.ok === false) {
+      expect(localLifecycle.error.details?.['supportedLocalFields']).toEqual(
+        expect.arrayContaining([
+          'repoPath',
+          'worktreePath',
+          'type',
+          'mode',
+          'agent',
+          'useTmux',
+          'terminalBackend',
+          'cols',
+          'rows',
+          'workContextId',
+        ])
+      );
+      expect(
+        localLifecycle.error.details?.['supportedLocalFields']
+      ).not.toContain('ttlSeconds');
+      expect(
+        localLifecycle.error.details?.['supportedLocalFields']
+      ).not.toContain('cwd');
+    }
 
     const localEnvelope = validateAndSanitizeGatewayCreateInput({
       repoPath: '/tmp/repo',
@@ -446,7 +469,10 @@ describe('CLI gateway contract', () => {
       repoPath: '/tmp/repo',
       worktreePath: null,
       type: 'terminal',
+      terminalBackend: 'relay-pty',
+      useTmux: false,
       cols: 120,
+      rows: 32,
       workContextId: 'wc:handoff',
     });
     expect(clean).toMatchObject({
@@ -455,7 +481,10 @@ describe('CLI gateway contract', () => {
         repoPath: '/tmp/repo',
         worktreePath: null,
         type: 'terminal',
+        terminalBackend: 'relay-pty',
+        useTmux: false,
         cols: 120,
+        rows: 32,
         workContextId: 'wc:handoff',
       },
       sessionType: 'terminal',

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -84,6 +84,7 @@ test('DEFAULTS has expected keys and values', () => {
   expect(DEFAULTS.defaultContinue).toBe(true);
   expect(DEFAULTS.defaultYolo).toBe(false);
   expect(DEFAULTS.launchInTmux).toBe(true);
+  expect(DEFAULTS.terminalBackend).toBe('tmux-compat');
 });
 
 test('loadConfig returns correct defaults for defaultContinue, defaultYolo, and launchInTmux', () => {
@@ -94,6 +95,7 @@ test('loadConfig returns correct defaults for defaultContinue, defaultYolo, and 
   expect(config.defaultContinue).toBe(true);
   expect(config.defaultYolo).toBe(false);
   expect(config.launchInTmux).toBe(true);
+  expect(config.terminalBackend).toBe('tmux-compat');
 });
 
 test('ensureMetaDir creates worktree-meta directory', () => {
@@ -173,6 +175,7 @@ test('resolveSessionSettings returns global defaults when no workspace or overri
   expect(result.agent).toBe('claude');
   expect(result.yolo).toBe(false);
   expect(result.continuePolicy).toBe('always');
+  expect(result.terminalBackend).toBe('tmux-compat');
   expect(result.useTmux).toBe(true);
   expect(result.claudeArgs).toEqual([]);
 });
@@ -200,7 +203,7 @@ test('resolveSessionSettings applies workspace overrides over globals', () => {
   expect(result.continuePolicy).toBe('always');
 });
 
-test('resolveSessionSettings treats tmux as mandatory even when explicitly disabled', () => {
+test('resolveSessionSettings can opt into relay-pty through legacy useTmux:false', () => {
   const configPath = path.join(tmpDir, 'config.json');
   const wsId = 'ws-tmux-required';
   fs.writeFileSync(
@@ -236,7 +239,27 @@ test('resolveSessionSettings treats tmux as mandatory even when explicitly disab
     wsId
   );
 
-  expect(result.useTmux).toBe(true);
+  expect(result.terminalBackend).toBe('relay-pty');
+  expect(result.useTmux).toBe(false);
+});
+
+test('resolveSessionSettings can opt into relay-pty through terminalBackend', () => {
+  const configPath = path.join(tmpDir, 'config.json');
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({
+      defaultFramework: 'claude',
+      defaultYolo: false,
+      defaultContinue: true,
+      terminalBackend: 'relay-pty',
+      claudeArgs: [],
+    }),
+    'utf8'
+  );
+  const config = loadConfig(configPath);
+  const result = resolveSessionSettings(config, '/some/repo', {});
+  expect(result.terminalBackend).toBe('relay-pty');
+  expect(result.useTmux).toBe(false);
 });
 
 test('resolveSessionSettings explicit overrides beat workspace settings', () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -262,6 +262,38 @@ test('resolveSessionSettings can opt into relay-pty through terminalBackend', ()
   expect(result.useTmux).toBe(false);
 });
 
+test('resolveSessionSettings lets repo terminalBackend override env global default', () => {
+  const configPath = path.join(tmpDir, 'config.json');
+  const previousBackend = process.env.RELAY_IDE_TERMINAL_BACKEND;
+  process.env.RELAY_IDE_TERMINAL_BACKEND = 'relay-pty';
+  try {
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        defaultFramework: 'claude',
+        defaultYolo: false,
+        defaultContinue: true,
+        terminalBackend: 'relay-pty',
+        claudeArgs: [],
+        repoSettings: {
+          '/my/repo': { terminalBackend: 'tmux-compat' },
+        },
+      }),
+      'utf8'
+    );
+    const config = loadConfig(configPath);
+    const result = resolveSessionSettings(config, '/my/repo', {});
+    expect(result.terminalBackend).toBe('tmux-compat');
+    expect(result.useTmux).toBe(true);
+  } finally {
+    if (previousBackend === undefined) {
+      delete process.env.RELAY_IDE_TERMINAL_BACKEND;
+    } else {
+      process.env.RELAY_IDE_TERMINAL_BACKEND = previousBackend;
+    }
+  }
+});
+
 test('resolveSessionSettings explicit overrides beat workspace settings', () => {
   const configPath = path.join(tmpDir, 'config.json');
   fs.writeFileSync(

--- a/test/pty-handler.test.ts
+++ b/test/pty-handler.test.ts
@@ -174,6 +174,36 @@ describe('framework-driven PTY handler', () => {
     expect(session.sessionArgs).toEqual([]);
   });
 
+  it('relay-pty backend bypasses tmux and maintains a relay terminal model', async () => {
+    const result = sessions.create({
+      repoName: 'test-repo',
+      repoPath: '/tmp',
+      worktreePath: null,
+      cwd: '/tmp',
+      agent: 'claude',
+      command: '/bin/cat',
+      args: [],
+      terminalBackend: 'relay-pty',
+      useTmux: false,
+      cols: 80,
+      rows: 24,
+    });
+    createdIds.push(result.id);
+    const session = sessions.get(result.id) as PtySession;
+    expect(session).toBeTruthy();
+    expect(session.terminalBackend).toBe('relay-pty');
+    expect(session.useTmux).toBe(false);
+    expect(session.tmuxSessionName).toBe('');
+    expect(session.terminalModel).toBeTruthy();
+
+    await sessions.sendTmuxText(result.id, 'relay-pty-ok\n');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await expect(sessions.captureTmuxPane(result.id)).resolves.toContain(
+      'relay-pty-ok'
+    );
+  });
+
   it('forceOutputParser sets dataQuality to parser regardless of framework', () => {
     const result = sessions.create({
       repoName: 'test-repo',

--- a/test/pty-handler.test.ts
+++ b/test/pty-handler.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, afterEach, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import * as sessions from '../server/sessions.js';
 import type { PtySession, EventSourceType } from '../server/types.js';
 
@@ -202,6 +205,48 @@ describe('framework-driven PTY handler', () => {
     await expect(sessions.captureTmuxPane(result.id)).resolves.toContain(
       'relay-pty-ok'
     );
+  });
+
+  it('preserves workContextId when relay-pty retries without --continue', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-pty-retry-'));
+    const envPath = path.join(tmp, 'retry-env.txt');
+    const scriptPath = path.join(tmp, 'retry-env.sh');
+    fs.writeFileSync(
+      scriptPath,
+      `#!/bin/sh
+set -eu
+if [ "\${1:-}" = "--continue" ]; then
+  exit 1
+fi
+env > ${JSON.stringify(envPath)}
+sleep 60
+`,
+      { mode: 0o700 }
+    );
+
+    try {
+      const result = sessions.create({
+        repoName: 'test-repo',
+        repoPath: '/tmp',
+        worktreePath: null,
+        cwd: '/tmp',
+        agent: 'claude',
+        command: scriptPath,
+        args: ['--continue'],
+        terminalBackend: 'relay-pty',
+        useTmux: false,
+        workContextId: 'wc:retry-preserve',
+      });
+      createdIds.push(result.id);
+
+      await expect
+        .poll(() =>
+          fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf8') : ''
+        )
+        .toContain('RELAY_WORK_CONTEXT_ID=wc:retry-preserve');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it('forceOutputParser sets dataQuality to parser regardless of framework', () => {

--- a/test/sessions.test.ts
+++ b/test/sessions.test.ts
@@ -880,7 +880,7 @@ describe('sessions', () => {
     expect(result.tmuxSessionName).toMatch(/^relay-(ide|dev)-test-repo-/);
   });
 
-  it('useTmux cannot be disabled by custom command sessions or useTmux:false', () => {
+  it('useTmux:false opts custom command sessions into relay-pty', () => {
     const result = sessions.create({
       repoName: 'test-repo',
       repoPath: '/tmp',
@@ -891,8 +891,9 @@ describe('sessions', () => {
       useTmux: false,
     });
     createdIds.push(result.id);
-    expect(result.useTmux).toBe(true);
-    expect(result.tmuxSessionName).toMatch(/^relay-(ide|dev)-test-repo-/);
+    expect(result.terminalBackend).toBe('relay-pty');
+    expect(result.useTmux).toBe(false);
+    expect(result.tmuxSessionName).toBe('');
   });
 
   it('list includes useTmux and tmuxSessionName fields', () => {


### PR DESCRIPTION
## Summary
- add feature-flagged `terminalBackend` support with `tmux-compat` default/fallback and `relay-pty` opt-in
- plumb backend choice through config, session creation, CLI gateway runtime, summaries, restore, resize, and startup tmux availability checks
- route relay-pty sessions through PTY stdin/TerminalModelBackend paths while preserving tmux helper behavior for tmux sessions

Closes #836

## Tests
- `npm run typecheck:test -- --pretty false && npx vitest run test/sessions.test.ts test/pty-handler.test.ts test/config.test.ts`
- `npm run check`
- `npm run build`
- pre-push changed-test suite: 72 files, 889 passed, 7 skipped
- smoke: built server with `RELAY_IDE_TERMINAL_BACKEND=relay-pty`, authenticated local PIN, `GET /config/terminalBackend` returned `relay-pty`, `POST /sessions` created terminal session with `terminalBackend:"relay-pty"`, `useTmux:false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable terminal backend selection between `tmux-compat` (default) and `relay-pty`, allowing users to choose their preferred PTY execution method.
  * Terminal backend can be configured globally via `RELAY_IDE_TERMINAL_BACKEND` environment variable, workspace settings, or per-session overrides.

* **Documentation**
  * Added comprehensive documentation covering terminal backend options, configuration precedence, rollout steps, and migration behavior for existing sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->