### PR TITLE
Tighten tmux cleanup and terminal attention detection

### DIFF
--- a/docs/TERMINAL_BACKENDS.md
+++ b/docs/TERMINAL_BACKENDS.md
@@ -11,19 +11,19 @@ Existing tmux sessions and legacy saved state stay on `tmux-compat`, but new ses
 
 `terminalBackend` can be set globally, per workspace, per repo, or per session request. Effective session settings use this order, most-specific first:
 
-1. Explicit session override: `POST /sessions` or `PATCH /config/terminalBackend` request fields such as `terminalBackend: "relay-pty"` or legacy `useTmux: false`.
+1. Explicit session override: `POST /sessions`, routed `sessions.create`, or `PATCH /config/terminalBackend` request fields such as `terminalBackend: "relay-pty"`.
 2. Repo settings: `repoSettings[repoPath].terminalBackend`.
 3. Workspace settings: `workspaces[].settings.terminalBackend`.
 4. Global default: `RELAY_IDE_TERMINAL_BACKEND`, then `config.terminalBackend`, then the hardcoded default `relay-pty`.
 
 `RELAY_IDE_TERMINAL_BACKEND` is a global default, not an absolute operator lock. A repo or workspace configured for `tmux-compat` must continue to resolve to `tmux-compat` even when the process environment default is `relay-pty`. Explicit per-session overrides still win over all saved defaults.
 
-Legacy `useTmux` maps to the same backend contract for compatibility:
+`terminalBackend` is the public create/config knob. Legacy serialized/runtime `useTmux` still maps to the same backend contract when restoring old state, but it is no longer part of the CLI gateway `sessions.create` surface:
 
-- `useTmux: true` => `terminalBackend: "tmux-compat"`
-- `useTmux: false` => `terminalBackend: "relay-pty"`
+- legacy `useTmux: true` => `terminalBackend: "tmux-compat"`
+- legacy `useTmux: false` => `terminalBackend: "relay-pty"`
 
-New code should prefer `terminalBackend`; `useTmux` exists so older callers and saved settings keep working during migration.
+New code must send `terminalBackend`; `useTmux` is runtime/status compatibility only.
 
 ## Which sessions migrate
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1328,7 +1328,7 @@ export interface CreateSessionBody {
   claudeArgs?: string[] | undefined;
   yolo?: boolean | undefined;
   agent?: string | undefined;
-  useTmux?: boolean | undefined;
+  terminalBackend?: 'relay-pty' | 'tmux-compat' | undefined;
   cols?: number | undefined;
   rows?: number | undefined;
   needsBranchRename?: boolean | undefined;
@@ -2007,7 +2007,7 @@ export async function launchWorkspaceSession(
   opts?: {
     agent?: string;
     yolo?: boolean;
-    useTmux?: boolean;
+    terminalBackend?: 'relay-pty' | 'tmux-compat';
     claudeArgs?: string[];
     cols?: number;
     rows?: number;

--- a/frontend/src/lib/session-utils.ts
+++ b/frontend/src/lib/session-utils.ts
@@ -18,7 +18,7 @@ export interface CreateAgentSessionOptions {
   claudeArgs?: string[] | undefined;
   yolo?: boolean | undefined;
   agent?: string | undefined;
-  useTmux?: boolean | undefined;
+  terminalBackend?: 'relay-pty' | 'tmux-compat' | undefined;
   cols?: number | undefined;
   rows?: number | undefined;
   needsBranchRename?: boolean | undefined;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -278,7 +278,7 @@ export interface OpenSessionOptions {
   branchName?: string;
   agent?: AgentType;
   claudeArgs?: string;
-  useTmux?: boolean;
+  terminalBackend?: 'relay-pty' | 'tmux-compat';
 }
 
 export interface SessionMeta {

--- a/server/config.ts
+++ b/server/config.ts
@@ -54,9 +54,22 @@ export const DEFAULTS: Omit<
   maxScrollbackGlobalBytes: DEFAULT_MAX_SCROLLBACK_GLOBAL_BYTES,
 };
 
-const LEGACY_TMUX_LAUNCH_KEY = 'launch' + 'InTmux';
+// Legacy no-op only: kept as a plain searchable string so audits can find and
+// delete stale config writers. Do not reintroduce this as a supported setting.
+const LEGACY_TMUX_LAUNCH_KEY = 'launchInTmux';
+const CONFIG_LOG = createLogger('config');
+let warnedLegacyTmuxLaunchSetting = false;
 
 function omitLegacyTmuxLaunchSetting<T extends object>(settings: T): T {
+  if (
+    !warnedLegacyTmuxLaunchSetting &&
+    Object.prototype.hasOwnProperty.call(settings, LEGACY_TMUX_LAUNCH_KEY)
+  ) {
+    warnedLegacyTmuxLaunchSetting = true;
+    CONFIG_LOG.warn(
+      'ignoring legacy launchInTmux setting; use terminalBackend instead'
+    );
+  }
   const { [LEGACY_TMUX_LAUNCH_KEY]: _legacyTmuxLaunch, ...rest } =
     settings as T & Record<string, unknown>;
   return rest as T;

--- a/server/hooks.ts
+++ b/server/hooks.ts
@@ -109,6 +109,10 @@ function setAgentState(
   state: AgentState,
   deps: HookDeps
 ): void {
+  if (state !== AGENT_STATE_PERMISSION_PROMPT) {
+    delete session.permissionType;
+    delete session.permissionPromptSource;
+  }
   session.agentState = state;
   deps.fireBackendStateIfChanged(session);
   if (session.mode === 'pty') {
@@ -138,6 +142,8 @@ function handleAgentEvent(
   } else if (eventType === 'session.idle' || eventType === 'session.ended') {
     setAgentState(session, 'idle', deps);
   } else if (eventType === 'permission.requested') {
+    session.permissionType = 'approval';
+    session.permissionPromptSource = 'hooks';
     setAgentState(session, AGENT_STATE_PERMISSION_PROMPT, deps);
     session.lastAttentionNotifiedAt = Date.now();
     deps.notifySessionAttention(session.id, {
@@ -380,6 +386,8 @@ export function createHooksRouter(deps: HookDeps): Router {
     const type = req.query.type;
 
     if (type === 'permission_prompt') {
+      session.permissionType = 'approval';
+      session.permissionPromptSource = 'hooks';
       setAgentState(session, AGENT_STATE_PERMISSION_PROMPT, deps);
       session.lastAttentionNotifiedAt = Date.now();
       deps.notifySessionAttention(session.id, {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1700,7 +1700,25 @@ async function main(): Promise<void> {
     res: express.Response
   ): Record<string, unknown> | null {
     const body = req.body as unknown;
-    if (!isCliGatewayV1Request(req)) return isRecord(body) ? body : {};
+    if (!isCliGatewayV1Request(req)) {
+      const directBody = isRecord(body) ? body : {};
+      if (Object.prototype.hasOwnProperty.call(directBody, 'useTmux')) {
+        res.status(400).json({
+          error: 'legacy useTmux request flag is no longer supported; use terminalBackend',
+        });
+        return null;
+      }
+      if (
+        Object.prototype.hasOwnProperty.call(directBody, 'terminalBackend') &&
+        normalizeTerminalBackend(directBody['terminalBackend']) === undefined
+      ) {
+        res.status(400).json({
+          error: 'terminalBackend must be "relay-pty" or "tmux-compat"',
+        });
+        return null;
+      }
+      return directBody;
+    }
     if (!isRecord(body)) {
       sendGatewayCreateValidationError(res, {
         code: 'INVALID_ARGUMENT',
@@ -3816,7 +3834,6 @@ async function main(): Promise<void> {
       mode,
       agent,
       yolo,
-      useTmux,
       terminalBackend,
       claudeArgs,
       cols,
@@ -3839,7 +3856,6 @@ async function main(): Promise<void> {
       mode?: 'pty' | 'web';
       agent?: AgentType;
       yolo?: boolean;
-      useTmux?: boolean;
       terminalBackend?: TerminalBackend;
       claudeArgs?: string[];
       cols?: number;
@@ -3915,7 +3931,6 @@ async function main(): Promise<void> {
         freshConfig,
         checkedRepoPath,
         {
-          useTmux,
           terminalBackend: requestedTerminalBackend,
         }
       );
@@ -3961,7 +3976,6 @@ async function main(): Promise<void> {
     const resolved = resolveSessionSettings(freshConfig, checkedRepoPath, {
       agent,
       yolo,
-      useTmux,
       terminalBackend: requestedTerminalBackend,
       claudeArgs,
       continuePolicy: effectivePolicy,

--- a/server/node-link-rpc-host.ts
+++ b/server/node-link-rpc-host.ts
@@ -28,7 +28,7 @@ import type {
   RelayNodeError,
 } from '../shared/relay-node-protocol.js';
 import { isSessionLane, type SessionLane } from '../shared/session-lane.js';
-import type { SessionSummary } from './types.js';
+import type { SessionSummary, TerminalBackend } from './types.js';
 
 // Node-side RPC dispatcher. Hub initiates rpc/<type> requests over the
 // reverse WS; this module receives them, calls into the local
@@ -97,6 +97,31 @@ function asBoolean(value: unknown): boolean | undefined {
   return typeof value === 'boolean' ? value : undefined;
 }
 
+function parseTerminalBackend(value: unknown): TerminalBackend | undefined {
+  if (value === 'relay-pty' || value === 'tmux-compat') return value;
+  return undefined;
+}
+
+function parseTerminalBackendOverride(
+  record: Record<string, unknown>
+): Pick<SessionsCreateInput, 'terminalBackend'> | RelayNodeError {
+  if (Object.prototype.hasOwnProperty.call(record, 'useTmux')) {
+    return invalidRequest(
+      'sessions.create payload.useTmux is no longer supported; use terminalBackend'
+    );
+  }
+  if (Object.prototype.hasOwnProperty.call(record, 'terminalBackend')) {
+    const terminalBackend = parseTerminalBackend(record['terminalBackend']);
+    if (terminalBackend === undefined) {
+      return invalidRequest(
+        'sessions.create payload.terminalBackend must be "relay-pty" or "tmux-compat"'
+      );
+    }
+    return { terminalBackend };
+  }
+  return {};
+}
+
 function asNullableString(value: unknown): string | null | undefined {
   if (value === null) return null;
   if (typeof value === 'string') return value;
@@ -157,7 +182,7 @@ interface SessionsCreateInput {
   workspaceId?: string;
   additionalDirs?: string[];
   initialPrompt?: string;
-  useTmux?: boolean;
+  terminalBackend?: TerminalBackend;
   needsBranchRename?: boolean;
   branchRenamePrompt?: string;
   continue?: boolean;
@@ -218,8 +243,9 @@ function parseSessionsCreateInput(
   if (additionalDirs !== undefined) input.additionalDirs = additionalDirs;
   const initialPrompt = asString(record['initialPrompt']);
   if (initialPrompt !== undefined) input.initialPrompt = initialPrompt;
-  const useTmux = asBoolean(record['useTmux']);
-  if (useTmux !== undefined) input.useTmux = useTmux;
+  const terminalOverride = parseTerminalBackendOverride(record);
+  if ('code' in terminalOverride) return terminalOverride;
+  Object.assign(input, terminalOverride);
   const needsBranchRename = asBoolean(record['needsBranchRename']);
   if (needsBranchRename !== undefined)
     input.needsBranchRename = needsBranchRename;

--- a/server/pty-handler.ts
+++ b/server/pty-handler.ts
@@ -45,6 +45,7 @@ import {
   createLibghosttyTerminalModelBackend,
   type TerminalModelBackend,
 } from './terminal-model-backend.js';
+import { detectTerminalAttentionPrompt } from './terminal-attention.js';
 import { buildRelayPtySessionEnv } from './relay-pty-session.js';
 
 const IDLE_TIMEOUT_MS = 5000;
@@ -1135,8 +1136,44 @@ function handleParserStateUpdate(
       return;
     }
   }
+  if (newState !== 'permission-prompt') {
+    delete session.permissionType;
+    delete session.permissionPromptSource;
+  }
   session.agentState = newState;
   for (const cb of stateChangeCallbacks) cb(session.id, newState);
+  fireBackendStateIfChanged?.(session);
+}
+
+export function handleTerminalAttentionUpdate(
+  session: PtySession,
+  stateChangeCallbacks: Array<(sessionId: string, state: AgentState) => void>,
+  fireBackendStateIfChanged: ((session: PtySession) => void) | undefined
+): void {
+  const terminalModel = session.terminalModel;
+  if (!terminalModel) return;
+
+  const attention = detectTerminalAttentionPrompt(terminalModel.getVisibleText());
+  if (!attention) {
+    if (
+      session.agentState === 'permission-prompt' &&
+      session.permissionPromptSource === 'terminal-model'
+    ) {
+      delete session.permissionType;
+      delete session.permissionPromptSource;
+      session.agentState = 'idle';
+      for (const cb of stateChangeCallbacks) cb(session.id, 'idle');
+      fireBackendStateIfChanged?.(session);
+    }
+    return;
+  }
+
+  session.permissionType = attention.kind;
+  session.permissionPromptSource = attention.source;
+  if (session.agentState !== 'permission-prompt') {
+    session.agentState = 'permission-prompt';
+    for (const cb of stateChangeCallbacks) cb(session.id, 'permission-prompt');
+  }
   fireBackendStateIfChanged?.(session);
 }
 
@@ -1429,6 +1466,11 @@ export function createPtySession(
           fireBackendStateIfChanged
         );
       }
+      handleTerminalAttentionUpdate(
+        session,
+        stateChangeCallbacks,
+        fireBackendStateIfChanged
+      );
     });
 
     proc.onExit(() => {

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -599,9 +599,10 @@ export function fireBackendStateIfChanged(session: Session): void {
   let permissionType: 'approval' | 'question' | undefined;
   if (newState === 'permission') {
     permissionType =
-      session.currentActivity?.tool === 'AskUserQuestion'
+      session.permissionType ??
+      (session.currentActivity?.tool === 'AskUserQuestion'
         ? 'question'
-        : 'approval';
+        : 'approval');
   }
 
   if (

--- a/server/terminal-attention.ts
+++ b/server/terminal-attention.ts
@@ -1,0 +1,44 @@
+export type TerminalAttentionKind = 'approval' | 'question';
+
+export interface TerminalAttentionPrompt {
+  kind: TerminalAttentionKind;
+  source: 'terminal-model';
+}
+
+const APPROVAL_PROMPTS = [
+  /do\s+you\s+want\s+to\s+proceed\?/i,
+  /(?:allow|approve|authorize)\s+(?:this\s+)?(?:command|tool|action|operation)/i,
+  /(?:command|tool|action|operation)\s+(?:requires|needs)\s+(?:your\s+)?(?:approval|permission)/i,
+  /permission\s+(?:required|requested|prompt)/i,
+  /\b(?:yes|allow|approve)\b[\s\S]{0,160}\b(?:no|deny|reject)\b/i,
+];
+
+const QUESTION_PROMPTS = [
+  /(?:needs|requires|waiting\s+for)\s+(?:your\s+)?(?:answer|input|response)/i,
+  /ask\s+user\s+question/i,
+];
+
+function normalizeVisibleText(text: string): string {
+  const sanitized = Array.from(text, (char) => {
+    const code = char.charCodeAt(0);
+    return code < 32 || code === 127 ? ' ' : char;
+  }).join('');
+  return sanitized.replace(/\s+/g, ' ').trim();
+}
+
+export function detectTerminalAttentionPrompt(
+  visibleText: string
+): TerminalAttentionPrompt | null {
+  const normalized = normalizeVisibleText(visibleText);
+  if (!normalized) return null;
+
+  if (APPROVAL_PROMPTS.some((pattern) => pattern.test(normalized))) {
+    return { kind: 'approval', source: 'terminal-model' };
+  }
+
+  if (QUESTION_PROMPTS.some((pattern) => pattern.test(normalized))) {
+    return { kind: 'question', source: 'terminal-model' };
+  }
+
+  return null;
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -299,6 +299,10 @@ interface BaseSession {
   sessionEnvelope?: SessionEnvelope | undefined;
   _lastEmittedBackendState?: BackendDisplayState | undefined;
   _lastEmittedPermissionType?: 'approval' | 'question' | undefined;
+  /** Tracks whether permission-prompt is for approval or question. */
+  permissionType?: 'approval' | 'question';
+  /** Distinguishes hook-owned prompts from terminal-model fallback prompts. */
+  permissionPromptSource?: 'hooks' | 'terminal-model';
   _lastEmittedDurability?: SessionDurabilityState | undefined;
   lastAttentionNotifiedAt?: number | undefined;
 }

--- a/server/workspace-groups.ts
+++ b/server/workspace-groups.ts
@@ -10,6 +10,7 @@ import {
   loadConfig,
   saveConfig,
   resolveSessionSettings,
+  normalizeTerminalBackend,
   writeMeta,
 } from './config.js';
 import type {
@@ -18,6 +19,7 @@ import type {
   AgentType,
   WorkspaceLevelSettings,
   WorkspaceTemplate,
+  TerminalBackend,
 } from './types.js';
 import { AGENT_CONTINUE_ARGS, AGENT_YOLO_ARGS } from './types.js';
 import { findOrCreateWorktreeForBranch } from './watcher.js';
@@ -69,6 +71,10 @@ type RepoResult =
   | { repoPath: string; resolvedPath: string }
   | { repoPath: string; error: string };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 async function resolveRepoPath(
   repoPath: string,
   execFn: ExecFn
@@ -111,7 +117,7 @@ function buildFinalArgs(
   overrides: {
     agent: string | undefined;
     yolo: boolean | undefined;
-    useTmux: boolean | undefined;
+    terminalBackend: TerminalBackend | undefined;
     claudeArgs: string[] | undefined;
   },
   workspaceId: string
@@ -126,8 +132,8 @@ function buildFinalArgs(
   if (overrides.agent !== undefined)
     sessionOverrides.agent = overrides.agent as AgentType;
   if (overrides.yolo !== undefined) sessionOverrides.yolo = overrides.yolo;
-  if (overrides.useTmux !== undefined)
-    sessionOverrides.useTmux = overrides.useTmux;
+  if (overrides.terminalBackend !== undefined)
+    sessionOverrides.terminalBackend = overrides.terminalBackend;
   if (overrides.claudeArgs !== undefined)
     sessionOverrides.claudeArgs = overrides.claudeArgs;
 
@@ -401,14 +407,35 @@ export function createWorkspaceGroupsRouter(
       requireAuth,
       async (req: Request, res: Response) => {
         const { id } = req.params as { id: string };
-        const { agent, yolo, useTmux, claudeArgs, cols, rows } = req.body as {
+        const body = req.body as unknown;
+        if (!isRecord(body)) {
+          res.status(400).json({ error: 'request body must be an object' });
+          return;
+        }
+        if (Object.prototype.hasOwnProperty.call(body, 'useTmux')) {
+          res.status(400).json({
+            error: 'legacy useTmux request flag is no longer supported; use terminalBackend',
+          });
+          return;
+        }
+        if (Object.prototype.hasOwnProperty.call(body, 'terminalBackend')) {
+          const normalized = normalizeTerminalBackend(body['terminalBackend']);
+          if (normalized === undefined) {
+            res.status(400).json({
+              error: 'terminalBackend must be "relay-pty" or "tmux-compat"',
+            });
+            return;
+          }
+        }
+        const { agent, yolo, terminalBackend, claudeArgs, cols, rows } = body as {
           agent?: string;
           yolo?: boolean;
-          useTmux?: boolean;
+          terminalBackend?: TerminalBackend;
           claudeArgs?: string[];
           cols?: number;
           rows?: number;
         };
+        const requestedTerminalBackend = normalizeTerminalBackend(terminalBackend);
 
         let config: Config;
         try {
@@ -469,7 +496,7 @@ export function createWorkspaceGroupsRouter(
           config,
           primary,
           additionalDirs,
-          { agent, yolo, useTmux, claudeArgs },
+          { agent, yolo, terminalBackend: requestedTerminalBackend, claudeArgs },
           workspace.id
         );
 
@@ -496,6 +523,7 @@ export function createWorkspaceGroupsRouter(
             displayName,
             args: finalArgs,
             configPath: sessionDeps.configPath,
+            terminalBackend: resolved.terminalBackend,
             useTmux: resolved.useTmux,
             yolo: resolved.yolo,
             claudeArgs: combinedClaudeArgs,

--- a/server/workspaces.ts
+++ b/server/workspaces.ts
@@ -60,7 +60,7 @@ import {
 
 const execFileAsync = promisify(execFile);
 const logger = createLogger('workspaces');
-const LEGACY_TMUX_LAUNCH_KEY = 'launch' + 'InTmux';
+const LEGACY_TMUX_LAUNCH_KEY = 'launchInTmux';
 
 // ── Typed git infrastructure errors ──────────────────────────────────────────
 

--- a/shared/cli-gateway-runtime.ts
+++ b/shared/cli-gateway-runtime.ts
@@ -30,7 +30,6 @@ const createSessionAllowedFields = new Set([
   'mode',
   'agent',
   'yolo',
-  'useTmux',
   'terminalBackend',
   'cols',
   'rows',
@@ -97,7 +96,6 @@ const localCreateSupportedFields = [
   'mode',
   'agent',
   'yolo',
-  'useTmux',
   'terminalBackend',
   'cols',
   'rows',
@@ -426,11 +424,6 @@ function validateCreateFieldTypes(
   if (input['yolo'] !== undefined && typeof input['yolo'] !== 'boolean') {
     return invalidCreateInput('sessions.create yolo must be a boolean', {
       field: 'yolo',
-    });
-  }
-  if (input['useTmux'] !== undefined && typeof input['useTmux'] !== 'boolean') {
-    return invalidCreateInput('sessions.create useTmux must be a boolean', {
-      field: 'useTmux',
     });
   }
   for (const [field, min, max] of [

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -391,7 +391,6 @@ describe('CLI gateway contract', () => {
           'type',
           'mode',
           'agent',
-          'useTmux',
           'terminalBackend',
           'cols',
           'rows',
@@ -415,6 +414,16 @@ describe('CLI gateway contract', () => {
     expect(localEnvelope).toMatchObject({
       ok: false,
       error: { code: 'UNSUPPORTED', details: { field: 'sessionEnvelope' } },
+    });
+
+    const legacyTmuxFlag = validateAndSanitizeGatewayCreateInput({
+      nodeId: 'node-a',
+      repoPath: '/tmp/repo',
+      useTmux: false,
+    });
+    expect(legacyTmuxFlag).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_ARGUMENT', details: { field: 'useTmux' } },
     });
 
     const agentPeer = validateAndSanitizeGatewayCreateInput({
@@ -470,7 +479,6 @@ describe('CLI gateway contract', () => {
       worktreePath: null,
       type: 'terminal',
       terminalBackend: 'relay-pty',
-      useTmux: false,
       cols: 120,
       rows: 32,
       workContextId: 'wc:handoff',
@@ -482,7 +490,6 @@ describe('CLI gateway contract', () => {
         worktreePath: null,
         type: 'terminal',
         terminalBackend: 'relay-pty',
-        useTmux: false,
         cols: 120,
         rows: 32,
         workContextId: 'wc:handoff',

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -15,7 +15,7 @@ import {
 } from '../server/config.js';
 import type { Config } from '../server/types.js';
 
-const LEGACY_TMUX_LAUNCH_KEY = 'launch' + 'InTmux';
+const LEGACY_TMUX_LAUNCH_KEY = 'launchInTmux';
 
 let tmpDir!: string;
 

--- a/test/node-link-rpc-host.test.ts
+++ b/test/node-link-rpc-host.test.ts
@@ -134,6 +134,67 @@ describe('node-link-rpc-host', () => {
     expect(replyPayload.session).not.toHaveProperty('pid');
   });
 
+  it('passes routed terminalBackend and rejects legacy routed useTmux', () => {
+    const localRelayNode = fakeLocalNode();
+    const host = createNodeLinkRpcHost({ localRelayNode });
+    const ok = context();
+
+    host.handle(
+      envelope('sessions.create', {
+        type: 'terminal',
+        cwd: '/home/user',
+        terminalBackend: 'relay-pty',
+      }),
+      ok.ctx
+    );
+
+    expect(localRelayNode.sessions.create).toHaveBeenCalledTimes(1);
+    expect(
+      (localRelayNode.sessions.create as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[0]
+    ).toMatchObject({ terminalBackend: 'relay-pty' });
+
+    const legacy = context();
+    host.handle(
+      envelope('sessions.create', {
+        type: 'terminal',
+        cwd: '/home/user',
+        useTmux: false,
+      }),
+      legacy.ctx
+    );
+
+    expect(localRelayNode.sessions.create).toHaveBeenCalledTimes(1);
+    expect(legacy.sent[0]).toMatchObject({
+      type: 'sessions.create.error',
+      error: {
+        code: 'INVALID_REQUEST',
+        message:
+          'sessions.create payload.useTmux is no longer supported; use terminalBackend',
+      },
+    });
+
+    const invalid = context();
+    host.handle(
+      envelope('sessions.create', {
+        type: 'terminal',
+        cwd: '/home/user',
+        terminalBackend: 'tmuxx',
+      }),
+      invalid.ctx
+    );
+
+    expect(localRelayNode.sessions.create).toHaveBeenCalledTimes(1);
+    expect(invalid.sent[0]).toMatchObject({
+      type: 'sessions.create.error',
+      error: {
+        code: 'INVALID_REQUEST',
+        message:
+          'sessions.create payload.terminalBackend must be "relay-pty" or "tmux-compat"',
+      },
+    });
+  });
+
   it('defaults routed terminal creates to a shell command instead of the agent command', () => {
     const localRelayNode = fakeLocalNode();
     const host = createNodeLinkRpcHost({ localRelayNode });

--- a/test/pty-handler.test.ts
+++ b/test/pty-handler.test.ts
@@ -8,6 +8,7 @@ import type { PtySession, EventSourceType } from '../server/types.js';
 import {
   buildStatusLineRelayScript,
   getTmuxPrefix,
+  handleTerminalAttentionUpdate,
 } from '../server/pty-handler.js';
 
 const originalRelayTmuxPrefix = process.env.RELAY_IDE_TMUX_PREFIX;
@@ -70,6 +71,62 @@ describe('tmux prefix resolution', () => {
 
     delete process.env.NO_PIN;
     expect(getTmuxPrefix()).toBe('relay-ide-');
+  });
+});
+
+describe('terminal attention fallback', () => {
+  function sessionWithVisibleText(
+    visibleText: string,
+    overrides: Partial<PtySession> = {}
+  ): PtySession {
+    return {
+      id: 'session-attention',
+      agentState: 'idle',
+      terminalModel: { getVisibleText: () => visibleText },
+      ...overrides,
+    } as PtySession;
+  }
+
+  it('clears terminal-model-owned permission prompts when the prompt disappears', () => {
+    const session = sessionWithVisibleText('npm test passed', {
+      agentState: 'permission-prompt',
+      permissionType: 'approval',
+      permissionPromptSource: 'terminal-model',
+    });
+    const states: string[] = [];
+    const backendChanges: string[] = [];
+
+    handleTerminalAttentionUpdate(
+      session,
+      [(_id, state) => states.push(state)],
+      (changed) => backendChanges.push(changed.agentState)
+    );
+
+    expect(session.agentState).toBe('idle');
+    expect(session.permissionType).toBeUndefined();
+    expect(session.permissionPromptSource).toBeUndefined();
+    expect(states).toEqual(['idle']);
+    expect(backendChanges).toEqual(['idle']);
+  });
+
+  it('does not clear hook-owned permission prompts just because fallback text is absent', () => {
+    const session = sessionWithVisibleText('waiting on hook event', {
+      agentState: 'permission-prompt',
+      permissionType: 'approval',
+      permissionPromptSource: 'hooks',
+    });
+    const states: string[] = [];
+
+    handleTerminalAttentionUpdate(
+      session,
+      [(_id, state) => states.push(state)],
+      undefined
+    );
+
+    expect(session.agentState).toBe('permission-prompt');
+    expect(session.permissionType).toBe('approval');
+    expect(session.permissionPromptSource).toBe('hooks');
+    expect(states).toEqual([]);
   });
 });
 

--- a/test/terminal-attention.test.ts
+++ b/test/terminal-attention.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { detectTerminalAttentionPrompt } from '../server/terminal-attention.js';
+
+describe('detectTerminalAttentionPrompt', () => {
+  it('detects Claude-style approval prompts from terminal visible text', () => {
+    expect(
+      detectTerminalAttentionPrompt(`
+        Bash command
+        gh pr view 843 --json mergeCommit
+
+        Do you want to proceed?
+        ❯ 1. Yes
+          2. No
+      `)
+    ).toEqual({ kind: 'approval', source: 'terminal-model' });
+  });
+
+  it('detects generic terminal permission wording', () => {
+    expect(
+      detectTerminalAttentionPrompt('Command requires your approval before running')
+    ).toEqual({ kind: 'approval', source: 'terminal-model' });
+  });
+
+  it('detects question prompts separately from approvals', () => {
+    expect(
+      detectTerminalAttentionPrompt('Agent is waiting for your answer to continue')
+    ).toEqual({ kind: 'question', source: 'terminal-model' });
+  });
+
+  it('ignores normal terminal output', () => {
+    expect(detectTerminalAttentionPrompt('npm test\n PASS test/config.test.ts')).toBeNull();
+  });
+
+  it('does not match approval words embedded inside other words', () => {
+    expect(
+      detectTerminalAttentionPrompt('the eyes know the answer and cannot reject nothing')
+    ).toBeNull();
+  });
+});

--- a/test/workspace-groups.test.ts
+++ b/test/workspace-groups.test.ts
@@ -1,4 +1,4 @@
-import { test, beforeAll, afterEach, afterAll, expect } from 'vitest';
+import { test, beforeAll, afterEach, afterAll, expect, vi } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -19,11 +19,11 @@ function writeConfig(data: object): void {
   fs.writeFileSync(configPath, JSON.stringify(data), 'utf8');
 }
 
-function startServer(cp: string): Promise<void> {
+function startServer(cp: string, sessionDeps?: any): Promise<void> {
   return new Promise((resolve) => {
     const app = express();
     app.use(express.json());
-    app.use('/workspace-groups', createWorkspaceGroupsRouter(cp, noAuth));
+    app.use('/workspace-groups', createWorkspaceGroupsRouter(cp, noAuth, sessionDeps));
     server = app.listen(0, '127.0.0.1', () => {
       const addr = server.address() as { port: number };
       baseUrl = `http://127.0.0.1:${addr.port}`;
@@ -59,6 +59,31 @@ async function req(
     }
   }
   return { status: res.status, body: parsed };
+}
+
+async function rawReq(
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+  url: string,
+  rawBody: string
+): Promise<{ status: number; body: any }> {
+  const res = await fetch(`${baseUrl}${url}`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: rawBody,
+  });
+  return { status: res.status, body: await res.json() };
+}
+
+function fakeSessionDeps() {
+  return {
+    sessions: {
+      create: vi.fn().mockReturnValue({ id: 'sess-1', cwd: tmpDir }),
+      list: () => [],
+      nextAgentName: () => 'Agent 1',
+    },
+    gitWatcher: { watch: vi.fn() },
+    configPath,
+  };
 }
 
 beforeAll(() => {
@@ -438,4 +463,51 @@ test('same repo can appear in multiple workspaces', async () => {
   expect(saved.workspaces.every((w: any) => w.repos.includes('/shared'))).toBe(
     true
   );
+});
+
+test('workspace session rejects malformed body and invalid terminal backend', async () => {
+  const repoPath = path.join(tmpDir, 'repo');
+  fs.mkdirSync(repoPath, { recursive: true });
+  writeConfig({
+    configVersion: 4,
+    repos: [repoPath],
+    workspaces: [{ id: 'ws-1', name: 'Ws', repos: [repoPath], order: 0 }],
+  });
+  const sessionDeps = fakeSessionDeps();
+  await startServer(configPath, sessionDeps);
+
+  const nullBody = await rawReq('POST', '/workspace-groups/ws-1/session', '[]');
+  expect(nullBody.status).toBe(400);
+  expect(nullBody.body).toEqual({ error: 'request body must be an object' });
+
+  const invalidBackend = await req('POST', '/workspace-groups/ws-1/session', {
+    terminalBackend: 'tmuxx',
+  });
+  expect(invalidBackend.status).toBe(400);
+  expect(invalidBackend.body).toEqual({
+    error: 'terminalBackend must be "relay-pty" or "tmux-compat"',
+  });
+  expect(sessionDeps.sessions.create).not.toHaveBeenCalled();
+});
+
+test('workspace session passes valid terminalBackend to session create', async () => {
+  const repoPath = path.join(tmpDir, 'repo-valid');
+  fs.mkdirSync(repoPath, { recursive: true });
+  writeConfig({
+    configVersion: 4,
+    repos: [repoPath],
+    workspaces: [{ id: 'ws-1', name: 'Ws', repos: [repoPath], order: 0 }],
+  });
+  const sessionDeps = fakeSessionDeps();
+  await startServer(configPath, sessionDeps);
+
+  const result = await req('POST', '/workspace-groups/ws-1/session', {
+    terminalBackend: 'tmux-compat',
+  });
+  expect(result.status).toBe(201);
+  expect(sessionDeps.sessions.create).toHaveBeenCalledTimes(1);
+  expect(sessionDeps.sessions.create.mock.calls[0]?.[0]).toMatchObject({
+    terminalBackend: 'tmux-compat',
+    useTmux: true,
+  });
 });

--- a/test/workspace-settings.test.ts
+++ b/test/workspace-settings.test.ts
@@ -8,7 +8,7 @@ import type { Server } from 'node:http';
 import { createWorkspaceRouter } from '../server/workspaces.js';
 import { DEFAULTS, loadConfig, saveConfig } from '../server/config.js';
 
-const LEGACY_TMUX_LAUNCH_KEY = 'launch' + 'InTmux';
+const LEGACY_TMUX_LAUNCH_KEY = 'launchInTmux';
 
 let tmpDir: string;
 let configPath: string;

--- a/test/workspaces-routes.test.ts
+++ b/test/workspaces-routes.test.ts
@@ -9,7 +9,7 @@ import { createWorkspaceRouter, type WorkspaceDeps } from '../server/workspaces.
 import { DEFAULTS, loadConfig, saveConfig } from '../server/config.js';
 import { createTestServer } from './helpers/test-server.js';
 
-const LEGACY_TMUX_LAUNCH_KEY = 'launch' + 'InTmux';
+const LEGACY_TMUX_LAUNCH_KEY = 'launchInTmux';
 
 type ExecFn = NonNullable<WorkspaceDeps['execAsync']>;
 type ExecResult = { stdout: string; stderr: string };


### PR DESCRIPTION
## Summary
- add terminal-model fallback detection for approval/question prompts and carry `permissionType` through backend state
- remove remaining public create-time `useTmux` surfaces in CLI gateway, direct `/sessions`, routed node RPC, workspace-group launch, and frontend create types
- make `launchInTmux` searchable again, keep it as an explicit logged no-op, and update docs/tests around `terminalBackend`

Closes #832 follow-up scope; this does not close the #832 epic.

## Verification
- `./node_modules/.bin/vitest run test/terminal-attention.test.ts test/cli-gateway-contract.test.ts test/config.test.ts test/workspace-settings.test.ts test/workspaces-routes.test.ts test/node-link-rpc-host.test.ts --reporter=dot --maxWorkers=1 --pool=threads`
- `npm run check`
- `npm run build`
- `git diff --check`

## Notes
- A broader run including `test/hub-routed-create-readmodel.test.ts` is still blocked locally by the known `better-sqlite3` Node ABI mismatch (`NODE_MODULE_VERSION 127` vs Node 24 `137`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminal backend configuration and precedence guidance to clarify explicit per-session settings priority and legacy compatibility handling.

* **Refactor**
  * Replaced legacy boolean terminal mode flag with explicit `terminalBackend` option supporting `relay-pty` and `tmux-compat` modes across session creation APIs.
  * Enhanced terminal attention detection for permission requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->