### PR TITLE
fix: reap session descendant language servers

### DIFF
--- a/server/diagnostics-bundle.ts
+++ b/server/diagnostics-bundle.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { loadConfig } from './config.js';
 import { isPinConfigured } from './auth.js';
 import { getNodeManifest } from './node-manifest.js';
+import { collectLanguageServerDiagnostics } from './process-tree.js';
 import {
   readLocalLogSnapshot,
   resolveLocalLogPlan,
@@ -244,12 +245,13 @@ export async function createDiagnosticsBundle(
     });
   }
 
-  writeJson(
-    'version.json',
-    'package and runtime version info',
-    options.versionInfo ?? collectVersionInfo(cwd)
-  );
+  writeJson('version.json', 'package and runtime version info', options.versionInfo ?? collectVersionInfo(cwd));
   writeJson('environment.json', 'selected environment hints', buildEnvironmentHints(env, cwd));
+  writeJson(
+    'processes/language-servers.json',
+    'local language-server process diagnostics',
+    collectLanguageServerDiagnostics()
+  );
 
   const manifest =
     options.manifest ??

--- a/server/process-tree.ts
+++ b/server/process-tree.ts
@@ -302,8 +302,52 @@ function parseProcStat(stat: string):
 function readCommandLine(processDir: string, fallbackCommand: string): string {
   const cmdline = readText(`${processDir}/cmdline`);
   if (!cmdline) return fallbackCommand;
-  const normalized = cmdline.replace(/\0+/g, ' ').trim();
-  return normalized || fallbackCommand;
+  const argv = cmdline.split('\0').filter((arg) => arg.length > 0);
+  if (argv.length === 0) return fallbackCommand;
+  return redactSensitiveArgvValues(argv).join(' ');
+}
+
+function redactSensitiveArgvValues(argv: string[]): string[] {
+  const redacted: string[] = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    const inline = redactInlineSensitiveArg(arg);
+    if (inline) {
+      redacted.push(inline);
+      continue;
+    }
+
+    if (isSensitiveStandaloneArg(arg) && argv[index + 1] !== undefined) {
+      redacted.push(arg, '[REDACTED]');
+      index += 1;
+      continue;
+    }
+
+    redacted.push(arg);
+  }
+  return redacted;
+}
+
+function redactInlineSensitiveArg(arg: string): string | undefined {
+  const optionMatch = arg.match(
+    /^(--?(?:api[-_]?key|token|access[-_]?token|auth(?:orization)?|password|secret|credential|client[-_]?secret)=)(.+)$/i
+  );
+  if (optionMatch) return `${optionMatch[1]}[REDACTED]`;
+
+  const envMatch = arg.match(
+    /^([A-Z0-9_]*(?:TOKEN|PASSWORD|SECRET|API_KEY|ACCESS_KEY)[A-Z0-9_]*=)(.+)$/
+  );
+  if (envMatch) return `${envMatch[1]}[REDACTED]`;
+
+  return undefined;
+}
+
+function isSensitiveStandaloneArg(arg: string): boolean {
+  return (
+    /^--?(?:api[-_]?key|token|access[-_]?token|auth(?:orization)?|password|secret|credential|client[-_]?secret)$/i.test(
+      arg
+    ) || /^(?:bearer|basic)$/i.test(arg)
+  );
 }
 
 type CommandToken = { start: number; end: number; text: string };

--- a/server/process-tree.ts
+++ b/server/process-tree.ts
@@ -306,21 +306,29 @@ function readCommandLine(processDir: string, fallbackCommand: string): string {
   return normalized || fallbackCommand;
 }
 
+const REDACTABLE_VALUE = String.raw`(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S+)`;
+const SENSITIVE_FLAG_VALUE = new RegExp(
+  String.raw`(^|\s)(--?(?:api[-_]?key|token|access[-_]?token|auth(?:orization)?|password|secret|credential|client[-_]?secret)(?:=|\s+))${REDACTABLE_VALUE}`,
+  'gi'
+);
+const AUTH_SCHEME_VALUE = new RegExp(
+  String.raw`((?:bearer|basic)\s+)${REDACTABLE_VALUE}`,
+  'gi'
+);
+const SENSITIVE_ENV_VALUE = new RegExp(
+  String.raw`([A-Z0-9_]*(?:TOKEN|PASSWORD|SECRET|API_KEY|ACCESS_KEY)[A-Z0-9_]*=)${REDACTABLE_VALUE}`,
+  'g'
+);
+
 export function redactCommandLine(commandLine: string): string {
   return commandLine
-    .replace(
-      /(^|\s)(--?(?:api[-_]?key|token|access[-_]?token|auth(?:orization)?|password|secret|credential|client[-_]?secret)(?:=|\s+))\S+/gi,
-      '$1$2[REDACTED]'
-    )
-    .replace(/((?:bearer|basic)\s+)\S+/gi, '$1[REDACTED]')
+    .replace(SENSITIVE_FLAG_VALUE, '$1$2[REDACTED]')
+    .replace(AUTH_SCHEME_VALUE, '$1[REDACTED]')
     .replace(
       /([?&](?:token|access_token|api_key|key|secret|password)=)[^&\s]+/gi,
       '$1[REDACTED]'
     )
-    .replace(
-      /([A-Z0-9_]*(?:TOKEN|PASSWORD|SECRET|API_KEY|ACCESS_KEY)[A-Z0-9_]*=)\S+/g,
-      '$1[REDACTED]'
-    );
+    .replace(SENSITIVE_ENV_VALUE, '$1[REDACTED]');
 }
 
 function readRssBytes(processDir: string): number {

--- a/server/process-tree.ts
+++ b/server/process-tree.ts
@@ -1,0 +1,409 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+
+export type LanguageServerKind =
+  | 'tsserver'
+  | 'typescript-language-server'
+  | 'pyright';
+
+export interface ProcessInfo {
+  pid: number;
+  ppid: number;
+  pgid: number;
+  command: string;
+  commandLine: string;
+  rssBytes: number;
+  ageMs?: number;
+  languageServerKind?: LanguageServerKind;
+}
+
+export interface ProcessTableOptions {
+  procRoot?: string;
+  nowMs?: number;
+  uptimeSeconds?: number;
+  clockTickHz?: number;
+}
+
+export interface LanguageServerDiagnostics {
+  generatedAt: string;
+  platform: NodeJS.Platform;
+  processCount: number;
+  totalRssBytes: number;
+  processes: Array<{
+    pid: number;
+    ppid: number;
+    pgid: number;
+    kind: LanguageServerKind;
+    command: string;
+    commandLine: string;
+    rssBytes: number;
+    ageMs?: number;
+    relayOwnedLikely: boolean;
+    ancestors: Array<{
+      pid: number;
+      ppid: number;
+      pgid: number;
+      command: string;
+      commandLine: string;
+    }>;
+  }>;
+}
+
+export interface ProcessReapSummary {
+  rootPids: number[];
+  descendantPids: number[];
+  processGroupIds: number[];
+  languageServers: Array<{
+    pid: number;
+    kind: LanguageServerKind;
+    rssBytes: number;
+    commandLine: string;
+  }>;
+}
+
+export interface ProcessReapOptions {
+  rootPids: number[];
+  reason?: string;
+  procRoot?: string;
+  processTable?: ProcessInfo[];
+  killDelayMs?: number;
+  killProcess?: (pid: number, signal: NodeJS.Signals) => void;
+  setTimer?: (callback: () => void, delayMs: number) => { unref?: () => void };
+  logger?: {
+    debug?: (message: string, ...args: unknown[]) => void;
+    warn?: (message: string, ...args: unknown[]) => void;
+  };
+}
+
+const LANGUAGE_SERVER_MATCHERS: Array<{
+  kind: LanguageServerKind;
+  pattern: RegExp;
+}> = [
+  { kind: 'tsserver', pattern: /(^|[/\s])tsserver\.js(\s|$)/i },
+  {
+    kind: 'typescript-language-server',
+    pattern: /(^|[/\s])typescript-language-server(\s|$)/i,
+  },
+  { kind: 'pyright', pattern: /(^|[/\s])pyright-langserver(\s|$)/i },
+];
+
+const DEFAULT_CLOCK_TICK_HZ = 100;
+
+export function readProcessTable(options: ProcessTableOptions = {}): ProcessInfo[] {
+  if (process.platform !== 'linux' && options.procRoot === undefined) return [];
+
+  const procRoot = options.procRoot ?? '/proc';
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(procRoot);
+  } catch {
+    return [];
+  }
+
+  const uptimeSeconds = options.uptimeSeconds ?? safeUptimeSeconds(procRoot);
+  const clockTickHz = options.clockTickHz ?? DEFAULT_CLOCK_TICK_HZ;
+  const processes: ProcessInfo[] = [];
+
+  for (const entry of entries) {
+    if (!/^\d+$/.test(entry)) continue;
+    const pid = Number(entry);
+    if (!Number.isSafeInteger(pid) || pid <= 0) continue;
+    const processDir = `${procRoot}/${entry}`;
+    const stat = readText(`${processDir}/stat`);
+    if (!stat) continue;
+    const parsed = parseProcStat(stat);
+    if (!parsed) continue;
+
+    const commandLine = readCommandLine(processDir, parsed.command);
+    const languageServerKind = classifyLanguageServer(commandLine);
+    const startSeconds = parsed.startTicks / clockTickHz;
+    const ageMs =
+      uptimeSeconds > 0 && startSeconds >= 0 && startSeconds <= uptimeSeconds
+        ? Math.max(0, Math.round((uptimeSeconds - startSeconds) * 1000))
+        : undefined;
+
+    processes.push({
+      pid,
+      ppid: parsed.ppid,
+      pgid: parsed.pgid,
+      command: parsed.command,
+      commandLine,
+      rssBytes: readRssBytes(processDir),
+      ...(ageMs !== undefined ? { ageMs } : {}),
+      ...(languageServerKind ? { languageServerKind } : {}),
+    });
+  }
+
+  return processes.sort((a, b) => a.pid - b.pid);
+}
+
+export function descendantsOf(rootPid: number, table: ProcessInfo[]): ProcessInfo[] {
+  const children = new Map<number, ProcessInfo[]>();
+  for (const proc of table) {
+    const bucket = children.get(proc.ppid) ?? [];
+    bucket.push(proc);
+    children.set(proc.ppid, bucket);
+  }
+
+  const descendants: ProcessInfo[] = [];
+  const seen = new Set<number>([rootPid]);
+  const queue = [...(children.get(rootPid) ?? [])];
+  while (queue.length > 0) {
+    const proc = queue.shift()!;
+    if (seen.has(proc.pid)) continue;
+    seen.add(proc.pid);
+    descendants.push(proc);
+    queue.push(...(children.get(proc.pid) ?? []));
+  }
+  return descendants;
+}
+
+export function summarizeProcessReap(
+  rootPids: number[],
+  table: ProcessInfo[] = readProcessTable()
+): ProcessReapSummary {
+  const cleanRoots = uniqueSafePids(rootPids);
+  const byPid = new Map(table.map((proc) => [proc.pid, proc]));
+  const descendants = new Map<number, ProcessInfo>();
+  const processGroupIds = new Set<number>();
+
+  for (const rootPid of cleanRoots) {
+    const root = byPid.get(rootPid);
+    if (root && root.pgid === root.pid && root.pgid !== process.pid) {
+      processGroupIds.add(root.pgid);
+    }
+    for (const child of descendantsOf(rootPid, table)) {
+      descendants.set(child.pid, child);
+      if (child.pgid === child.pid && child.pgid !== process.pid) {
+        processGroupIds.add(child.pgid);
+      }
+    }
+  }
+
+  return {
+    rootPids: cleanRoots,
+    descendantPids: Array.from(descendants.keys()).sort((a, b) => a - b),
+    processGroupIds: Array.from(processGroupIds).sort((a, b) => a - b),
+    languageServers: Array.from(descendants.values())
+      .filter((proc) => proc.languageServerKind)
+      .map((proc) => ({
+        pid: proc.pid,
+        kind: proc.languageServerKind!,
+        rssBytes: proc.rssBytes,
+        commandLine: proc.commandLine,
+      }))
+      .sort((a, b) => a.pid - b.pid),
+  };
+}
+
+export function scheduleRelayProcessTreeReap(
+  options: ProcessReapOptions
+): ProcessReapSummary {
+  const procRoot = options.procRoot;
+  const processTableOptions = procRoot === undefined ? {} : { procRoot };
+  const table = options.processTable ?? readProcessTable(processTableOptions);
+  const summary = summarizeProcessReap(options.rootPids, table);
+  const knownPids = new Set([...summary.rootPids, ...summary.descendantPids]);
+  const processGroupIds = new Set(summary.processGroupIds);
+  const killProcess = options.killProcess ?? ((pid, signal) => process.kill(pid, signal));
+  const logger = options.logger;
+
+  if (knownPids.size === 0 && processGroupIds.size === 0) return summary;
+
+  if (summary.languageServers.length > 0) {
+    logger?.warn?.(
+      'session runtime reap found %d language-server descendants (%s)',
+      summary.languageServers.length,
+      options.reason ?? 'unspecified'
+    );
+  } else {
+    logger?.debug?.(
+      'session runtime reap found %d descendants (%s)',
+      summary.descendantPids.length,
+      options.reason ?? 'unspecified'
+    );
+  }
+
+  signalProcessGroups(processGroupIds, 'SIGTERM', killProcess);
+  signalPids(knownPids, 'SIGTERM', killProcess);
+
+  const timer = (options.setTimer ?? setTimeout)(() => {
+    signalProcessGroups(processGroupIds, 'SIGKILL', killProcess);
+    const refreshed = readProcessTable(processTableOptions);
+    const liveKnown = new Set<number>();
+    const livePids = new Set(refreshed.map((proc) => proc.pid));
+    for (const pid of Array.from(knownPids)) {
+      if (livePids.has(pid)) liveKnown.add(pid);
+    }
+    signalPids(liveKnown, 'SIGKILL', killProcess);
+  }, options.killDelayMs ?? 1_000) as { unref?: () => void };
+  timer.unref?.();
+
+  return summary;
+}
+
+export function collectLanguageServerDiagnostics(
+  options: ProcessTableOptions = {}
+): LanguageServerDiagnostics {
+  const table = readProcessTable(options);
+  const byPid = new Map(table.map((proc) => [proc.pid, proc]));
+  const processes = table
+    .filter((proc) => proc.languageServerKind)
+    .map((proc) => {
+      const ancestors = ancestorsOf(proc, byPid);
+      const relayOwnedLikely = [proc, ...ancestors].some((candidate) =>
+        /relay-ide|relayctl|claude|codex|opencode|hermes/i.test(candidate.commandLine)
+      );
+      return {
+        pid: proc.pid,
+        ppid: proc.ppid,
+        pgid: proc.pgid,
+        kind: proc.languageServerKind!,
+        command: proc.command,
+        commandLine: redactCommandLine(proc.commandLine),
+        rssBytes: proc.rssBytes,
+        ...(proc.ageMs !== undefined ? { ageMs: proc.ageMs } : {}),
+        relayOwnedLikely,
+        ancestors: ancestors.map((ancestor) => ({
+          pid: ancestor.pid,
+          ppid: ancestor.ppid,
+          pgid: ancestor.pgid,
+          command: ancestor.command,
+          commandLine: redactCommandLine(ancestor.commandLine),
+        })),
+      };
+    })
+    .sort((a, b) => b.rssBytes - a.rssBytes || a.pid - b.pid);
+
+  return {
+    generatedAt: new Date(options.nowMs ?? Date.now()).toISOString(),
+    platform: process.platform,
+    processCount: processes.length,
+    totalRssBytes: processes.reduce((sum, proc) => sum + proc.rssBytes, 0),
+    processes,
+  };
+}
+
+function parseProcStat(stat: string):
+  | { command: string; ppid: number; pgid: number; startTicks: number }
+  | undefined {
+  const open = stat.indexOf('(');
+  const close = stat.lastIndexOf(')');
+  if (open < 0 || close <= open) return undefined;
+  const command = stat.slice(open + 1, close);
+  const rest = stat.slice(close + 2).trim().split(/\s+/);
+  const ppid = Number(rest[1]);
+  const pgid = Number(rest[2]);
+  const startTicks = Number(rest[19]);
+  if (![ppid, pgid, startTicks].every(Number.isFinite)) return undefined;
+  return { command, ppid, pgid, startTicks };
+}
+
+function readCommandLine(processDir: string, fallbackCommand: string): string {
+  const cmdline = readText(`${processDir}/cmdline`);
+  if (!cmdline) return fallbackCommand;
+  const normalized = cmdline.replace(/\0+/g, ' ').trim();
+  return normalized || fallbackCommand;
+}
+
+export function redactCommandLine(commandLine: string): string {
+  return commandLine
+    .replace(
+      /(^|\s)(--?(?:api[-_]?key|token|access[-_]?token|auth(?:orization)?|password|secret|credential|client[-_]?secret)(?:=|\s+))\S+/gi,
+      '$1$2[REDACTED]'
+    )
+    .replace(/((?:bearer|basic)\s+)\S+/gi, '$1[REDACTED]')
+    .replace(
+      /([?&](?:token|access_token|api_key|key|secret|password)=)[^&\s]+/gi,
+      '$1[REDACTED]'
+    )
+    .replace(
+      /([A-Z0-9_]*(?:TOKEN|PASSWORD|SECRET|API_KEY|ACCESS_KEY)[A-Z0-9_]*=)\S+/g,
+      '$1[REDACTED]'
+    );
+}
+
+function readRssBytes(processDir: string): number {
+  const status = readText(`${processDir}/status`);
+  const match = status?.match(/^VmRSS:\s+(\d+)\s+kB/im);
+  return match ? Number(match[1]) * 1024 : 0;
+}
+
+function readText(filePath: string): string | undefined {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return undefined;
+  }
+}
+
+function safeUptimeSeconds(procRoot: string): number {
+  if (procRoot === '/proc') return os.uptime();
+  const uptime = readText(`${procRoot}/uptime`);
+  const first = uptime?.trim().split(/\s+/)[0];
+  const parsed = first ? Number(first) : NaN;
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function classifyLanguageServer(commandLine: string): LanguageServerKind | undefined {
+  for (const matcher of LANGUAGE_SERVER_MATCHERS) {
+    if (matcher.pattern.test(commandLine)) return matcher.kind;
+  }
+  return undefined;
+}
+
+function ancestorsOf(proc: ProcessInfo, byPid: Map<number, ProcessInfo>): ProcessInfo[] {
+  const ancestors: ProcessInfo[] = [];
+  const seen = new Set<number>([proc.pid]);
+  let current = proc;
+  while (current.ppid > 1 && !seen.has(current.ppid) && ancestors.length < 12) {
+    const parent = byPid.get(current.ppid);
+    if (!parent) break;
+    ancestors.push(parent);
+    seen.add(parent.pid);
+    current = parent;
+  }
+  return ancestors;
+}
+
+function uniqueSafePids(pids: number[]): number[] {
+  return Array.from(new Set(pids))
+    .filter(
+      (pid) =>
+        Number.isSafeInteger(pid) && pid > 1 && pid !== process.pid
+    )
+    .sort((a, b) => a - b);
+}
+
+function signalProcessGroups(
+  processGroupIds: Set<number>,
+  signal: NodeJS.Signals,
+  killProcess: (pid: number, signal: NodeJS.Signals) => void
+): void {
+  for (const pgid of Array.from(processGroupIds)) {
+    safeSignal(-pgid, signal, killProcess);
+  }
+}
+
+function signalPids(
+  pids: Set<number>,
+  signal: NodeJS.Signals,
+  killProcess: (pid: number, signal: NodeJS.Signals) => void
+): void {
+  const ordered = Array.from(pids)
+    .filter((pid) => pid > 1 && pid !== process.pid)
+    .sort((a, b) => b - a);
+  for (const pid of ordered) safeSignal(pid, signal, killProcess);
+}
+
+function safeSignal(
+  pid: number,
+  signal: NodeJS.Signals,
+  killProcess: (pid: number, signal: NodeJS.Signals) => void
+): void {
+  try {
+    killProcess(pid, signal);
+  } catch {
+    // Already exited, not owned by this user, or no process group. Reaping is best effort.
+  }
+}

--- a/server/process-tree.ts
+++ b/server/process-tree.ts
@@ -306,29 +306,147 @@ function readCommandLine(processDir: string, fallbackCommand: string): string {
   return normalized || fallbackCommand;
 }
 
-const REDACTABLE_VALUE = String.raw`(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S+)`;
-const SENSITIVE_FLAG_VALUE = new RegExp(
-  String.raw`(^|\s)(--?(?:api[-_]?key|token|access[-_]?token|auth(?:orization)?|password|secret|credential|client[-_]?secret)(?:=|\s+))${REDACTABLE_VALUE}`,
-  'gi'
-);
-const AUTH_SCHEME_VALUE = new RegExp(
-  String.raw`((?:bearer|basic)\s+)${REDACTABLE_VALUE}`,
-  'gi'
-);
-const SENSITIVE_ENV_VALUE = new RegExp(
-  String.raw`([A-Z0-9_]*(?:TOKEN|PASSWORD|SECRET|API_KEY|ACCESS_KEY)[A-Z0-9_]*=)${REDACTABLE_VALUE}`,
-  'g'
-);
+type CommandToken = { start: number; end: number; text: string };
+type RedactionRange = { start: number; end: number };
 
 export function redactCommandLine(commandLine: string): string {
-  return commandLine
-    .replace(SENSITIVE_FLAG_VALUE, '$1$2[REDACTED]')
-    .replace(AUTH_SCHEME_VALUE, '$1[REDACTED]')
-    .replace(
-      /([?&](?:token|access_token|api_key|key|secret|password)=)[^&\s]+/gi,
-      '$1[REDACTED]'
+  const tokens = tokenizeCommandLine(commandLine);
+  const redactions = collectCommandLineRedactions(tokens);
+
+  return applyRedactions(commandLine, redactions).replace(
+    /([?&](?:token|access_token|api_key|key|secret|password)=)[^&\s]+/gi,
+    '$1[REDACTED]'
+  );
+}
+
+function collectCommandLineRedactions(tokens: CommandToken[]): RedactionRange[] {
+  const redactions: RedactionRange[] = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index]!;
+    const range =
+      secretOptionRedaction(token, tokens[index + 1]) ??
+      envAssignmentRedaction(token, tokens, index) ??
+      credentialSchemeRedaction(token, tokens[index + 1]);
+    if (range) redactions.push(range);
+  }
+  return redactions;
+}
+
+function secretOptionRedaction(
+  token: CommandToken,
+  nextToken: CommandToken | undefined
+): RedactionRange | undefined {
+  if (
+    !/^(--?(?:api[-_]?key|token|access[-_]?token|auth(?:orization)?|password|secret|credential|client[-_]?secret))(?:=.*)?$/i.test(
+      token.text
     )
-    .replace(SENSITIVE_ENV_VALUE, '$1[REDACTED]');
+  ) {
+    return undefined;
+  }
+
+  if (!token.text.includes('=')) return nextToken;
+
+  const valueStart = token.start + token.text.indexOf('=') + 1;
+  return valueStart < token.end ? { start: valueStart, end: token.end } : undefined;
+}
+
+function envAssignmentRedaction(
+  token: CommandToken,
+  tokens: CommandToken[],
+  index: number
+): RedactionRange | undefined {
+  const envMatch = token.text.match(
+    /^([A-Z0-9_]*(?:TOKEN|PASSWORD|SECRET|API_KEY|ACCESS_KEY)[A-Z0-9_]*=)/
+  );
+  const envPrefix = envMatch?.[1];
+  if (!envPrefix) return undefined;
+
+  const valueStart = token.start + envPrefix.length;
+  const valueText = token.text.slice(envPrefix.length);
+  let valueEnd = token.end;
+  if (valueText.includes('"')) {
+    valueEnd = consumeUntilQuote(tokens, index, '"');
+  } else if (valueText.includes("'")) {
+    valueEnd = consumeUntilQuote(tokens, index, "'");
+  } else {
+    valueEnd = consumeFollowingQuotedFragments(tokens, index) ?? valueEnd;
+  }
+  return valueStart < valueEnd ? { start: valueStart, end: valueEnd } : undefined;
+}
+
+function credentialSchemeRedaction(
+  token: CommandToken,
+  nextToken: CommandToken | undefined
+): RedactionRange | undefined {
+  return /^(?:bearer|basic)$/i.test(token.text) ? nextToken : undefined;
+}
+
+function tokenizeCommandLine(commandLine: string): Array<{ start: number; end: number; text: string }> {
+  const tokens: Array<{ start: number; end: number; text: string }> = [];
+  let index = 0;
+
+  while (index < commandLine.length) {
+    while (index < commandLine.length && /\s/.test(commandLine[index]!)) index += 1;
+    if (index >= commandLine.length) break;
+
+    const start = index;
+    let quote: '"' | "'" | undefined;
+    while (index < commandLine.length) {
+      const char = commandLine[index]!;
+      if (quote) {
+        if (char === quote) quote = undefined;
+      } else if (char === '"' || char === "'") {
+        quote = char;
+      } else if (/\s/.test(char)) {
+        break;
+      }
+      index += 1;
+    }
+
+    tokens.push({ start, end: index, text: commandLine.slice(start, index) });
+  }
+
+  return tokens;
+}
+
+function consumeUntilQuote(
+  tokens: Array<{ start: number; end: number; text: string }>,
+  startIndex: number,
+  quote: '"' | "'"
+): number {
+  for (let index = startIndex; index < tokens.length; index += 1) {
+    const token = tokens[index]!;
+    if (token.text.endsWith(quote) && !token.text.endsWith(`\\${quote}`)) return token.end;
+  }
+  return tokens[startIndex]!.end;
+}
+
+function consumeFollowingQuotedFragments(
+  tokens: Array<{ start: number; end: number; text: string }>,
+  startIndex: number
+): number | undefined {
+  for (let index = startIndex + 1; index < tokens.length; index += 1) {
+    const token = tokens[index]!;
+    if (/^--?\w/.test(token.text) || /^[A-Z0-9_]+=/.test(token.text)) return undefined;
+    const quoteOffset = Math.max(token.text.indexOf('"'), token.text.indexOf("'"));
+    if (quoteOffset >= 0) return token.start + quoteOffset + 1;
+    if (token.text.endsWith('"') || token.text.endsWith("'")) return token.end;
+  }
+  return undefined;
+}
+
+function applyRedactions(
+  commandLine: string,
+  redactions: Array<{ start: number; end: number }>
+): string {
+  const ranges = redactions
+    .filter((range) => range.start < range.end)
+    .sort((a, b) => b.start - a.start);
+  let redacted = commandLine;
+  for (const range of ranges) {
+    redacted = `${redacted.slice(0, range.start)}[REDACTED]${redacted.slice(range.end)}`;
+  }
+  return redacted;
 }
 
 function readRssBytes(processDir: string): number {

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -883,33 +883,33 @@ function updateDisplayName(
   return { id, displayName };
 }
 
-function tmuxPanePid(tmuxSessionName: string): number | undefined {
+async function tmuxPanePid(tmuxSessionName: string): Promise<number | undefined> {
   try {
-    const output = execFileSync(
+    const { stdout } = await execFileAsync(
       TMUX_COMMAND,
       ['display-message', '-p', '-t', tmuxSessionName, '#{pane_pid}'],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 1_000 }
-    ).trim();
-    const pid = Number(output);
+      { encoding: 'utf8', timeout: 1_000 }
+    );
+    const pid = Number(stdout.trim());
     return Number.isSafeInteger(pid) && pid > 1 ? pid : undefined;
   } catch {
     return undefined;
   }
 }
 
-function sessionRuntimeRootPids(session: PtySession): number[] {
+async function sessionRuntimeRootPids(session: PtySession): Promise<number[]> {
   const pids = new Set<number>();
   const ptyPid = session.pty.pid;
   if (Number.isSafeInteger(ptyPid) && ptyPid > 1) pids.add(ptyPid);
   if (session.useTmux && session.tmuxSessionName) {
-    const panePid = tmuxPanePid(session.tmuxSessionName);
+    const panePid = await tmuxPanePid(session.tmuxSessionName);
     if (panePid !== undefined) pids.add(panePid);
   }
   return Array.from(pids);
 }
 
-function scheduleSessionRuntimeReap(session: PtySession, reason: string): void {
-  const rootPids = sessionRuntimeRootPids(session);
+async function scheduleSessionRuntimeReap(session: PtySession, reason: string): Promise<void> {
+  const rootPids = await sessionRuntimeRootPids(session);
   if (rootPids.length === 0) return;
 
   const preview = summarizeProcessReap(rootPids);
@@ -928,13 +928,10 @@ function scheduleSessionRuntimeReap(session: PtySession, reason: string): void {
   });
 }
 
-function kill(id: string): void {
-  const session = sessions.get(id);
-  if (!session) {
-    throw new Error(`Session not found: ${id}`);
-  }
-  if (session.mode === 'pty') {
-    scheduleSessionRuntimeReap(session, 'explicit-session-kill');
+async function terminatePtySession(session: PtySession, reason: string): Promise<void> {
+  try {
+    await scheduleSessionRuntimeReap(session, reason);
+  } finally {
     try {
       session.pty.kill('SIGTERM');
     } catch {
@@ -947,6 +944,16 @@ function kill(id: string): void {
         () => {}
       );
     }
+  }
+}
+
+function kill(id: string): void {
+  const session = sessions.get(id);
+  if (!session) {
+    throw new Error(`Session not found: ${id}`);
+  }
+  if (session.mode === 'pty') {
+    void terminatePtySession(session, 'explicit-session-kill');
   } else {
     // Web session: disconnect adapter (tears down network connections and event handlers)
     session.adapterV2?.disconnect().catch(() => {

--- a/server/sessions.ts
+++ b/server/sessions.ts
@@ -82,6 +82,10 @@ import {
   normalizeSessionEnvelope,
 } from '../shared/session-envelope.js';
 import {
+  scheduleRelayProcessTreeReap,
+  summarizeProcessReap,
+} from './process-tree.js';
+import {
   sessionEnvelopeRegistry,
   type SessionRenewResult,
 } from './session-envelope-registry.js';
@@ -879,12 +883,58 @@ function updateDisplayName(
   return { id, displayName };
 }
 
+function tmuxPanePid(tmuxSessionName: string): number | undefined {
+  try {
+    const output = execFileSync(
+      TMUX_COMMAND,
+      ['display-message', '-p', '-t', tmuxSessionName, '#{pane_pid}'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 1_000 }
+    ).trim();
+    const pid = Number(output);
+    return Number.isSafeInteger(pid) && pid > 1 ? pid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function sessionRuntimeRootPids(session: PtySession): number[] {
+  const pids = new Set<number>();
+  const ptyPid = session.pty.pid;
+  if (Number.isSafeInteger(ptyPid) && ptyPid > 1) pids.add(ptyPid);
+  if (session.useTmux && session.tmuxSessionName) {
+    const panePid = tmuxPanePid(session.tmuxSessionName);
+    if (panePid !== undefined) pids.add(panePid);
+  }
+  return Array.from(pids);
+}
+
+function scheduleSessionRuntimeReap(session: PtySession, reason: string): void {
+  const rootPids = sessionRuntimeRootPids(session);
+  if (rootPids.length === 0) return;
+
+  const preview = summarizeProcessReap(rootPids);
+  if (preview.languageServers.length > 0) {
+    logger.warn(
+      'reaping %d language-server descendants for session %s (%s)',
+      preview.languageServers.length,
+      session.id,
+      reason
+    );
+  }
+  scheduleRelayProcessTreeReap({
+    rootPids,
+    reason: `${reason}:${session.id}`,
+    logger,
+  });
+}
+
 function kill(id: string): void {
   const session = sessions.get(id);
   if (!session) {
     throw new Error(`Session not found: ${id}`);
   }
   if (session.mode === 'pty') {
+    scheduleSessionRuntimeReap(session, 'explicit-session-kill');
     try {
       session.pty.kill('SIGTERM');
     } catch {

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -184,6 +184,43 @@ describe('process-tree session runtime reaping', () => {
     }
   });
 
+  it('redacts shell-stripped secret argv values without hiding following safe args', () => {
+    const procRoot = mkdtempSync(`${tmpdir()}/relay-proc-`);
+    try {
+      writeFileSync(`${procRoot}/uptime`, '1000 0');
+      writeFakeProc(procRoot, {
+        pid: 400,
+        ppid: 1,
+        pgid: 400,
+        command: 'node',
+        cmdlineArgs: [
+          'node',
+          '/typescript/lib/tsserver.js',
+          '--token=my secret value',
+          '--safe',
+          'flag',
+          'GITHUB_TOKEN=*** secret value',
+          '--after-env',
+        ],
+        rssKb: 42,
+      });
+
+      const diagnostics = collectLanguageServerDiagnostics({
+        procRoot,
+        nowMs: 1_000_000,
+        uptimeSeconds: 1000,
+        clockTickHz: 100,
+      });
+
+      expect(diagnostics.processes).toHaveLength(1);
+      expect(diagnostics.processes[0]?.commandLine).toBe(
+        'node /typescript/lib/tsserver.js --token=[REDACTED] --safe flag GITHUB_TOKEN=[REDACTED] --after-env'
+      );
+    } finally {
+      rmSync(procRoot, { recursive: true, force: true });
+    }
+  });
+
   it('spawn/kill cycle returns language-server descendants to baseline on Linux', async () => {
     if (process.platform !== 'linux') return;
 

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -1,7 +1,10 @@
 import { spawn } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe, expect, it } from 'vitest';
 import {
+  collectLanguageServerDiagnostics,
   readProcessTable,
   redactCommandLine,
   scheduleRelayProcessTreeReap,
@@ -16,6 +19,27 @@ function proc(overrides: Partial<ProcessInfo> & Pick<ProcessInfo, 'pid' | 'ppid'
     rssBytes: 0,
     ...overrides,
   };
+}
+
+function writeFakeProc(
+  procRoot: string,
+  options: {
+    pid: number;
+    ppid: number;
+    pgid: number;
+    command: string;
+    cmdlineArgs: string[];
+    rssKb?: number;
+  }
+): void {
+  const procDir = `${procRoot}/${options.pid}`;
+  mkdirSync(procDir, { recursive: true });
+  writeFileSync(
+    `${procDir}/stat`,
+    `${options.pid} (${options.command}) S ${options.ppid} ${options.pgid} 1 0 0 0 0 0 0 0 0 0 0 0 20 0 1 0 100`
+  );
+  writeFileSync(`${procDir}/cmdline`, `${options.cmdlineArgs.join('\0')}\0`);
+  writeFileSync(`${procDir}/status`, `Name:\t${options.command}\nVmRSS:\t${options.rssKb ?? 0} kB\n`);
 }
 
 async function waitFor(predicate: () => boolean, timeoutMs = 4_000): Promise<void> {
@@ -94,6 +118,62 @@ describe('process-tree session runtime reaping', () => {
     expect(redactCommandLine('Authorization Bearer abc123')).toBe(
       'Authorization Bearer [REDACTED]'
     );
+    expect(
+      redactCommandLine(
+        'node relay-ide --token="my secret value" --client-secret \'client secret value\' Authorization Basic "basic secret value" GITHUB_TOKEN=\'env secret value\''
+      )
+    ).toBe(
+      'node relay-ide --token=[REDACTED] --client-secret [REDACTED] Authorization Basic [REDACTED] GITHUB_TOKEN=[REDACTED]'
+    );
+  });
+
+  it('redacts quoted secrets in collected language-server diagnostics', () => {
+    const procRoot = mkdtempSync(`${tmpdir()}/relay-proc-`);
+    try {
+      writeFileSync(`${procRoot}/uptime`, '1000 0');
+      writeFakeProc(procRoot, {
+        pid: 300,
+        ppid: 1,
+        pgid: 300,
+        command: 'relay-ide',
+        cmdlineArgs: ['node', 'relay-ide', '--token="parent secret value"'],
+      });
+      writeFakeProc(procRoot, {
+        pid: 301,
+        ppid: 300,
+        pgid: 300,
+        command: 'node',
+        cmdlineArgs: [
+          'node',
+          '/typescript/lib/tsserver.js',
+          '--api-key="child secret value"',
+          '--password',
+          "'spaced password value'",
+          'Authorization',
+          'Bearer',
+          '"bearer secret value"',
+          "GITHUB_TOKEN='env secret value'",
+        ],
+        rssKb: 42,
+      });
+
+      const diagnostics = collectLanguageServerDiagnostics({
+        procRoot,
+        nowMs: 1_000_000,
+        uptimeSeconds: 1000,
+        clockTickHz: 100,
+      });
+
+      expect(diagnostics.processes).toHaveLength(1);
+      expect(diagnostics.processes[0]?.commandLine).toBe(
+        'node /typescript/lib/tsserver.js --api-key=[REDACTED] --password [REDACTED] Authorization Bearer [REDACTED] GITHUB_TOKEN=[REDACTED]'
+      );
+      expect(diagnostics.processes[0]?.ancestors[0]?.commandLine).toBe(
+        'node relay-ide --token=[REDACTED]'
+      );
+    } finally {
+      rmSync(procRoot, { recursive: true, force: true });
+    }
   });
 
   it('spawn/kill cycle returns language-server descendants to baseline on Linux', async () => {

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -1,0 +1,146 @@
+import { spawn } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { describe, expect, it } from 'vitest';
+import {
+  readProcessTable,
+  redactCommandLine,
+  scheduleRelayProcessTreeReap,
+  summarizeProcessReap,
+  type ProcessInfo,
+} from '../server/process-tree.js';
+
+function proc(overrides: Partial<ProcessInfo> & Pick<ProcessInfo, 'pid' | 'ppid' | 'pgid'>): ProcessInfo {
+  return {
+    command: 'node',
+    commandLine: 'node',
+    rssBytes: 0,
+    ...overrides,
+  };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 4_000): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (predicate()) return;
+    await delay(25);
+  }
+  throw new Error('condition was not met before timeout');
+}
+
+describe('process-tree session runtime reaping', () => {
+  it('summarizes descendant language servers before session kill', () => {
+    const table: ProcessInfo[] = [
+      proc({ pid: 100, ppid: 1, pgid: 100, commandLine: 'node relay-ide workspace host' }),
+      proc({
+        pid: 101,
+        ppid: 100,
+        pgid: 100,
+        commandLine: 'node /typescript/lib/tsserver.js --stdio',
+        rssBytes: 42 * 1024 * 1024,
+        languageServerKind: 'tsserver',
+      }),
+      proc({ pid: 102, ppid: 101, pgid: 100, commandLine: 'helper' }),
+    ];
+
+    const summary = summarizeProcessReap([100], table);
+
+    expect(summary.rootPids).toEqual([100]);
+    expect(summary.descendantPids).toEqual([101, 102]);
+    expect(summary.processGroupIds).toEqual([100]);
+    expect(summary.languageServers).toEqual([
+      {
+        pid: 101,
+        kind: 'tsserver',
+        rssBytes: 42 * 1024 * 1024,
+        commandLine: 'node /typescript/lib/tsserver.js --stdio',
+      },
+    ]);
+  });
+
+  it('signals process group and descendants for explicit session teardown', () => {
+    const calls: Array<{ pid: number; signal: NodeJS.Signals }> = [];
+    const table: ProcessInfo[] = [
+      proc({ pid: 200, ppid: 1, pgid: 200, commandLine: 'node relay-ide workspace host' }),
+      proc({ pid: 201, ppid: 200, pgid: 200, commandLine: 'typescript-language-server --stdio' }),
+    ];
+
+    scheduleRelayProcessTreeReap({
+      rootPids: [200],
+      processTable: table,
+      killProcess: (pid, signal) => calls.push({ pid, signal }),
+      setTimer: () => ({ unref() {} }),
+      logger: {},
+      killDelayMs: 1,
+    });
+
+    expect(calls).toEqual([
+      { pid: -200, signal: 'SIGTERM' },
+      { pid: 201, signal: 'SIGTERM' },
+      { pid: 200, signal: 'SIGTERM' },
+    ]);
+  });
+
+  it('redacts likely secrets from language-server diagnostics', () => {
+    expect(
+      redactCommandLine(
+        'node /typescript/lib/tsserver.js --api-key=child-secret https://example.test/?access_token=url-secret GITHUB_TOKEN=env-secret'
+      )
+    ).toBe(
+      'node /typescript/lib/tsserver.js --api-key=[REDACTED] https://example.test/?access_token=[REDACTED] GITHUB_TOKEN=[REDACTED]'
+    );
+    expect(redactCommandLine('node relay-ide --token parent-secret')).toBe(
+      'node relay-ide --token [REDACTED]'
+    );
+    expect(redactCommandLine('Authorization Bearer abc123')).toBe(
+      'Authorization Bearer [REDACTED]'
+    );
+  });
+
+  it('spawn/kill cycle returns language-server descendants to baseline on Linux', async () => {
+    if (process.platform !== 'linux') return;
+
+    const parentCode = `
+      const { spawn } = require('node:child_process');
+      const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)', 'tsserver.js'], { stdio: 'ignore' });
+      console.log(child.pid);
+      setInterval(() => {}, 1000);
+    `;
+    const parent = spawn(process.execPath, ['-e', parentCode], {
+      detached: true,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const parentPid = parent.pid;
+    if (!parentPid) throw new Error('spawn did not return parent pid');
+
+    let childPid: number | undefined;
+    parent.stdout.setEncoding('utf8');
+    parent.stdout.on('data', (chunk: string) => {
+      const parsed = Number(chunk.trim());
+      if (Number.isSafeInteger(parsed)) childPid = parsed;
+    });
+
+    try {
+      await waitFor(() => childPid !== undefined);
+      const baseline = readProcessTable().filter((p) => p.languageServerKind).length;
+      await waitFor(() =>
+        readProcessTable().some((p) => p.pid === childPid && p.languageServerKind === 'tsserver')
+      );
+
+      scheduleRelayProcessTreeReap({ rootPids: [parentPid], killDelayMs: 50, logger: {} });
+
+      await waitFor(() => {
+        const table = readProcessTable();
+        return !table.some((p) => p.pid === parentPid || p.pid === childPid);
+      });
+      const after = readProcessTable().filter((p) => p.languageServerKind).length;
+      expect(after).toBeLessThanOrEqual(baseline);
+    } finally {
+      try {
+        process.kill(-parentPid, 'SIGKILL');
+      } catch {
+        // already gone
+      }
+      parent.stdout.destroy();
+    }
+  }, 10_000);
+});

--- a/test/process-tree.test.ts
+++ b/test/process-tree.test.ts
@@ -119,11 +119,19 @@ describe('process-tree session runtime reaping', () => {
       'Authorization Bearer [REDACTED]'
     );
     expect(
-      redactCommandLine(
-        'node relay-ide --token="my secret value" --client-secret \'client secret value\' Authorization Basic "basic secret value" GITHUB_TOKEN=\'env secret value\''
-      )
-    ).toBe(
-      'node relay-ide --token=[REDACTED] --client-secret [REDACTED] Authorization Basic [REDACTED] GITHUB_TOKEN=[REDACTED]'
+      redactCommandLine('node relay-ide --token="my secret value" --safe flag')
+    ).toBe('node relay-ide --token=[REDACTED] --safe flag');
+    expect(
+      redactCommandLine("node relay-ide GITHUB_TOKEN='ghp secret value' --safe flag")
+    ).toBe('node relay-ide GITHUB_TOKEN=[REDACTED] --safe flag');
+    expect(
+      redactCommandLine("node relay-ide GITHUB_TOKEN=*** secret value' --safe flag")
+    ).toBe('node relay-ide GITHUB_TOKEN=[REDACTED] --safe flag');
+    expect(redactCommandLine('Authorization Bearer "abc 123" next')).toBe(
+      'Authorization Bearer [REDACTED] next'
+    );
+    expect(redactCommandLine("Authorization Basic 'dXNlci pwYXNz' next")).toBe(
+      'Authorization Basic [REDACTED] next'
     );
   });
 
@@ -152,7 +160,7 @@ describe('process-tree session runtime reaping', () => {
           'Authorization',
           'Bearer',
           '"bearer secret value"',
-          "GITHUB_TOKEN='env secret value'",
+          "GITHUB_TOKEN=*** secret value'",
         ],
         rssKb: 42,
       });
@@ -222,5 +230,5 @@ describe('process-tree session runtime reaping', () => {
       }
       parent.stdout.destroy();
     }
-  }, 10_000);
+  }, 15_000);
 });


### PR DESCRIPTION
## Summary
- add Linux `/proc` process-tree utilities to find session descendants, process groups, and language-server children (`tsserver`, `typescript-language-server`, `pyright`)
- schedule descendant/process-group SIGTERM + delayed SIGKILL before explicit PTY session kill, including tmux pane PID discovery
- add diagnostics bundle output for local language-server processes with command-line redaction
- preserve `/proc/<pid>/cmdline` argv boundaries for sensitive option/env values by redacting whole argv values before collapsing to display text
- add regression coverage for process-tree summaries, signal ordering, redaction, and a real Linux spawn/kill cycle

Closes #844

## Test Plan
- `npm test -- test/process-tree.test.ts -- --testNamePattern 'redacts shell-stripped secret argv values'` — reproduced the review leak before the fix, now passes
- `npm test -- test/process-tree.test.ts` — 6/6 passing
- `npm test -- test/process-tree.test.ts test/diagnostics-bundle.test.ts test/source-diagnostics.test.ts` — 13/13 passing
- `npm run check` — pass, existing 116 lint warnings / 0 errors
- `npm run build` — pass, existing Vite chunk-size warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added language-server diagnostics to surface running language servers and resource usage.
  * Improved session shutdown to better detect and clean up related background processes (including terminal/tmux sessions).

* **Tests**
  * Added tests covering diagnostics, command-line redaction, and process cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
