### PR TITLE
Introduce shared Relay action descriptor bridge

### DIFF
--- a/frontend/src/lib/actions/definitions/cli-gateway.ts
+++ b/frontend/src/lib/actions/definitions/cli-gateway.ts
@@ -1,4 +1,8 @@
 import {
+  relayActionDescriptorFromCommandDefinition,
+  type RelayActionDescriptor,
+} from '../../../../../shared/action-descriptor.js';
+import {
   RELAY_COMMAND_MANIFEST,
   type RelayCommandDefinition,
 } from '../../../../../shared/relay-command-manifest.js';
@@ -6,6 +10,7 @@ import type { ActionMeta } from '../types.js';
 
 export type CliGatewayCommandActionMeta = ActionMeta & {
   relayCommand: RelayCommandDefinition;
+  descriptor: RelayActionDescriptor;
 };
 
 export function cliGatewayActionId(command: RelayCommandDefinition): `gateway.${string}` {
@@ -17,8 +22,11 @@ function gatewayDisabledReason(command: RelayCommandDefinition): string {
   return `stable cli gateway command; run via ${argv}. Command Center execution is not wired yet.`;
 }
 
-export const cliGatewayCommandActions: CliGatewayCommandActionMeta[] =
-  RELAY_COMMAND_MANIFEST.commands.map((command) => ({
+function cliGatewayCommandAction(
+  command: RelayCommandDefinition
+): CliGatewayCommandActionMeta {
+  const reason = gatewayDisabledReason(command);
+  return {
     id: cliGatewayActionId(command),
     label: command.label,
     description: command.description,
@@ -33,6 +41,18 @@ export const cliGatewayCommandActions: CliGatewayCommandActionMeta[] =
     category: 'gateway',
     icon: 'v1',
     when: () => false,
-    disabledReason: () => gatewayDisabledReason(command),
+    disabledReason: () => reason,
     relayCommand: command,
-  }));
+    descriptor: relayActionDescriptorFromCommandDefinition(command, {
+      availability: {
+        state: 'unavailable',
+        reason,
+        capabilityHints: command.capabilityHints,
+      },
+      surfaces: [...command.surfaces, 'command-center'],
+    }),
+  };
+}
+
+export const cliGatewayCommandActions: CliGatewayCommandActionMeta[] =
+  RELAY_COMMAND_MANIFEST.commands.map(cliGatewayCommandAction);

--- a/frontend/src/lib/actions/descriptors.ts
+++ b/frontend/src/lib/actions/descriptors.ts
@@ -1,0 +1,113 @@
+import {
+  relayEmptyObjectSchema,
+  relayUnknownErrorSchema,
+  relayVoidResultSchema,
+  type RelayActionAvailability,
+  type RelayActionDescriptor,
+} from '../../../../shared/action-descriptor.js';
+import type { ActionContext, ActionMeta } from './types.js';
+
+function capabilityAvailability(
+  state: RelayActionAvailability['state'],
+  reason: string | undefined,
+  fallback: RelayActionAvailability | undefined
+): RelayActionAvailability {
+  return {
+    state,
+    ...(reason ? { reason } : {}),
+    ...(fallback?.capabilityHints
+      ? { capabilityHints: fallback.capabilityHints }
+      : {}),
+  };
+}
+
+function uiMetadata(meta: ActionMeta): NonNullable<RelayActionDescriptor['ui']> {
+  return {
+    actionId: meta.id,
+    category: meta.category,
+    ...(meta.icon ? { icon: meta.icon } : {}),
+    ...(meta.aliases ? { aliases: meta.aliases } : {}),
+    ...(meta.shortcut ? { shortcut: meta.shortcut } : {}),
+    ...(meta.mobile ? { mobile: meta.mobile } : {}),
+  };
+}
+
+function availabilityFromActionMeta(
+  meta: ActionMeta,
+  ctx: ActionContext | undefined,
+  fallback: RelayActionAvailability | undefined
+): RelayActionAvailability {
+  if (!ctx) {
+    return fallback ?? { state: 'unknown', reason: 'action context not supplied' };
+  }
+
+  const enabled = meta.when?.(ctx) ?? true;
+  const disabledReason = meta.disabledReason?.(ctx);
+
+  if (disabledReason) {
+    return capabilityAvailability('unavailable', disabledReason, fallback);
+  }
+
+  if (!enabled) {
+    return capabilityAvailability(
+      'unavailable',
+      fallback?.reason ?? 'not available in the current context',
+      fallback
+    );
+  }
+
+  return capabilityAvailability('available', undefined, fallback);
+}
+
+/**
+ * Project frontend ActionMeta into the shared descriptor bridge.
+ *
+ * This is intentionally a projection, not a new execution registry: UI-only
+ * actions remain `source: ui-action-registry`, while stable Relay commands keep
+ * their `descriptor.contract` from `shared/relay-command-manifest.ts`.
+ */
+export function actionDescriptorFromMeta(
+  meta: ActionMeta,
+  ctx?: ActionContext
+): RelayActionDescriptor {
+  const availability = availabilityFromActionMeta(
+    meta,
+    ctx,
+    meta.descriptor?.availability
+  );
+
+  if (meta.descriptor) {
+    return {
+      ...meta.descriptor,
+      availability,
+      ui: {
+        ...uiMetadata(meta),
+        ...meta.descriptor.ui,
+      },
+    };
+  }
+
+  return {
+    id: meta.id,
+    title: meta.label,
+    label: meta.label,
+    ...(meta.description ? { description: meta.description } : {}),
+    input: {
+      kind: 'typed-shape',
+      type: 'ActionContext',
+      schema: relayEmptyObjectSchema,
+    },
+    availability,
+    sideEffect: 'ui',
+    confirmation: {
+      required: false,
+      controlRequirements: [],
+    },
+    surfaces: ['web', 'command-center'],
+    result: { kind: 'json-schema', schema: relayVoidResultSchema },
+    error: { kind: 'json-schema', schema: relayUnknownErrorSchema },
+    stable: false,
+    source: 'ui-action-registry',
+    ui: uiMetadata(meta),
+  };
+}

--- a/frontend/src/lib/actions/descriptors.ts
+++ b/frontend/src/lib/actions/descriptors.ts
@@ -42,16 +42,12 @@ function availabilityFromActionMeta(
   }
 
   const enabled = meta.when?.(ctx) ?? true;
-  const disabledReason = meta.disabledReason?.(ctx);
-
-  if (disabledReason) {
-    return capabilityAvailability('unavailable', disabledReason, fallback);
-  }
 
   if (!enabled) {
+    const disabledReason = meta.disabledReason?.(ctx);
     return capabilityAvailability(
       'unavailable',
-      fallback?.reason ?? 'not available in the current context',
+      disabledReason ?? fallback?.reason ?? 'not available in the current context',
       fallback
     );
   }

--- a/frontend/src/lib/actions/types.ts
+++ b/frontend/src/lib/actions/types.ts
@@ -1,3 +1,5 @@
+import type { RelayActionDescriptor } from '../../../../shared/action-descriptor.js';
+
 export type ActionCategory =
   | 'session'
   | 'workspace'
@@ -49,6 +51,12 @@ export type Action = {
   disabledReason?: (ctx: ActionContext) => string | undefined;
   handler: (ctx: ActionContext) => void | Promise<void>;
   mobile?: { showInSheet?: boolean; label?: string };
+  /**
+   * Optional shared descriptor bridge. Stable CLI/API/agent commands attach the
+   * Relay-owned contract descriptor; UI-only helpers may be projected with
+   * actionDescriptorFromMeta without becoming stable agent commands.
+   */
+  descriptor?: RelayActionDescriptor;
 };
 
 export type ActionMeta = Omit<Action, 'handler'>;

--- a/shared/action-descriptor.ts
+++ b/shared/action-descriptor.ts
@@ -1,0 +1,144 @@
+import type {
+  RelayCliGatewayCommand,
+  RelayCliGatewayErrorCode,
+  RelayJsonSchema,
+} from './cli-gateway-contract.js';
+import type {
+  RelayCommandControlRequirement,
+  RelayCommandDefinition,
+  RelayCommandSideEffect,
+  RelayCommandSurface,
+} from './relay-command-manifest.js';
+import type { RelayCapabilityBit } from './security-policy.js';
+
+export type RelayActionSurface = RelayCommandSurface | 'command-center';
+export type RelayActionSideEffectClass = RelayCommandSideEffect | 'ui';
+export type RelayActionAvailabilityState =
+  | 'available'
+  | 'unavailable'
+  | 'unknown';
+
+export interface RelayActionAvailability {
+  state: RelayActionAvailabilityState;
+  reason?: string;
+  capabilityHints?: readonly RelayCapabilityBit[];
+}
+
+export type RelayActionShapeDescriptor =
+  | {
+      kind: 'json-schema';
+      schema: RelayJsonSchema;
+    }
+  | {
+      kind: 'typed-shape';
+      type: string;
+      schema?: RelayJsonSchema;
+    };
+
+export interface RelayActionConfirmationDescriptor {
+  required: boolean;
+  controlRequirements: readonly RelayCommandControlRequirement[];
+  reason?: string;
+}
+
+/**
+ * Shared bridge descriptor for Relay actions.
+ *
+ * Field ownership is deliberately split:
+ * - Top-level `id`, `input`, `result`, `error`, `sideEffect`, `confirmation`,
+ *   `surfaces`, and `availability` are the stable cross-surface contract.
+ * - `contract` is populated only for commands sourced from
+ *   `shared/relay-command-manifest.ts` / `RELAY_CLI_GATEWAY_CONTRACT` and is
+ *   safe for CLI/API/agent tooling to treat as a stable Relay command.
+ * - `ui` is Command Center metadata only. UI-only helpers can be searchable and
+ *   typed without pretending they are part of the stable CLI/agent gateway.
+ */
+export interface RelayActionDescriptor {
+  id: string;
+  title: string;
+  label: string;
+  description?: string;
+  input: RelayActionShapeDescriptor;
+  availability: RelayActionAvailability;
+  sideEffect: RelayActionSideEffectClass;
+  confirmation: RelayActionConfirmationDescriptor;
+  surfaces: readonly RelayActionSurface[];
+  result: RelayActionShapeDescriptor;
+  error: RelayActionShapeDescriptor;
+  stable: boolean;
+  source: 'cli-gateway-v1' | 'ui-action-registry';
+  contract?: {
+    relayCommandName: RelayCliGatewayCommand;
+    stable: boolean;
+    source: 'shared/relay-command-manifest.ts';
+    cli?: readonly string[];
+    errorCodes?: readonly RelayCliGatewayErrorCode[];
+  };
+  ui?: {
+    actionId: string;
+    category: string;
+    icon?: string;
+    aliases?: readonly string[];
+    shortcut?: { key: string; global?: boolean };
+    mobile?: { showInSheet?: boolean; label?: string };
+  };
+}
+
+export const relayEmptyObjectSchema: RelayJsonSchema = {
+  title: 'EmptyObject',
+  type: 'object',
+  additionalProperties: false,
+};
+
+export const relayVoidResultSchema: RelayJsonSchema = {
+  title: 'VoidResult',
+  type: 'object',
+  additionalProperties: false,
+  properties: {},
+};
+
+export const relayUnknownErrorSchema: RelayJsonSchema = {
+  title: 'RelayActionError',
+  type: 'object',
+  additionalProperties: true,
+};
+
+export function relayActionDescriptorFromCommandDefinition(
+  command: RelayCommandDefinition,
+  options: {
+    availability?: RelayActionAvailability;
+    surfaces?: readonly RelayActionSurface[];
+  } = {}
+): RelayActionDescriptor {
+  return {
+    id: command.id,
+    title: command.label,
+    label: command.label,
+    description: command.description,
+    input: { kind: 'json-schema', schema: command.inputSchema },
+    availability: options.availability ?? {
+      state: 'available',
+      capabilityHints: command.capabilityHints,
+    },
+    sideEffect: command.sideEffect,
+    confirmation: {
+      required: command.requiresConfirmation,
+      controlRequirements: command.controlRequirements,
+    },
+    surfaces: options.surfaces ?? command.surfaces,
+    result: { kind: 'json-schema', schema: command.outputSchema },
+    error: {
+      kind: 'typed-shape',
+      type: 'RelayCliGatewayErrorEnvelope',
+    },
+    stable: command.stable,
+    source: 'cli-gateway-v1',
+    contract: {
+      relayCommandName: command.name,
+      stable: command.stable,
+      source: 'shared/relay-command-manifest.ts',
+      ...(command.handler.cli ? { cli: command.handler.cli } : {}),
+      errorCodes: command.errorCodes,
+    },
+  };
+}

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -2,6 +2,7 @@ import {
   RELAY_CLI_GATEWAY_CONTRACT,
   type RelayCliGatewayCommand,
   type RelayCliGatewayCommandSpec,
+  type RelayCliGatewayErrorCode,
   type RelayJsonSchema,
 } from './cli-gateway-contract.js';
 import type { RelayCapabilityBit } from './security-policy.js';
@@ -62,6 +63,7 @@ export interface RelayCommandDefinition {
   requiresConfirmation: boolean;
   controlRequirements: readonly RelayCommandControlRequirement[];
   auditRedaction: RelayCommandAuditRedaction;
+  errorCodes: readonly RelayCliGatewayErrorCode[];
   scopeKinds: readonly RelayCommandScopeKind[];
   handler: RelayCommandHandler;
   stable: boolean;
@@ -251,6 +253,7 @@ export function relayCommandDefinitionFromCliGatewaySpec(
     requiresConfirmation: requiresConfirmationForGatewayCommand(spec),
     controlRequirements: controlRequirementsForGatewayCommand(spec),
     auditRedaction: auditRedactionForGatewayCommand(spec),
+    errorCodes: spec.errorCodes,
     scopeKinds: scopeKindsForGatewayCommand(spec.name),
     handler: { cli: spec.cli },
     stable: spec.stable,

--- a/test/action-coverage.test.ts
+++ b/test/action-coverage.test.ts
@@ -11,9 +11,14 @@ import { prActions } from '../frontend/src/lib/actions/definitions/pr.js';
 import { settingsActions } from '../frontend/src/lib/actions/definitions/settings.js';
 import { sidebarActions } from '../frontend/src/lib/actions/definitions/sidebar.js';
 import { dashboardActions } from '../frontend/src/lib/actions/definitions/dashboard.js';
-import { terminalActions } from '../frontend/src/lib/actions/definitions/terminal.js';
+import {
+  terminalActions,
+  terminalScrollTop,
+} from '../frontend/src/lib/actions/definitions/terminal.js';
 import { navigationActions } from '../frontend/src/lib/actions/definitions/navigation.js';
 import { cliGatewayCommandActions } from '../frontend/src/lib/actions/definitions/cli-gateway.js';
+import { workspaceOpenFileBrowser } from '../frontend/src/lib/actions/definitions/workspace-file-rpc.js';
+import { actionDescriptorFromMeta } from '../frontend/src/lib/actions/descriptors.js';
 import { stableCommandNames } from '../shared/cli-gateway-contract.js';
 
 // Full allowlist: 60 palettable action IDs (15 Phase 2 + 44 Phase 3 + 1 from #630)
@@ -160,7 +165,72 @@ describe('Action Coverage', () => {
       );
       expect(action.when?.({ view: 'workspace' })).toBe(false);
       expect(action.disabledReason?.({ view: 'workspace' })).toContain('relay-ide v1');
+      expect(action.descriptor.contract?.source).toBe(
+        'shared/relay-command-manifest.ts'
+      );
     }
+  });
+
+  it('bridges sessions.create as a stable Relay action descriptor', () => {
+    const action = cliGatewayCommandActions.find(
+      (entry) => entry.relayCommand.name === 'sessions.create'
+    );
+    expect(action).toBeTruthy();
+    const descriptor = action!.descriptor;
+
+    expect(action!.id).toBe('gateway.sessions.create');
+    expect(descriptor.id).toBe('sessions.create');
+    expect(descriptor.stable).toBe(true);
+    expect(descriptor.source).toBe('cli-gateway-v1');
+    expect(descriptor.input.kind).toBe('json-schema');
+    expect(descriptor.result.kind).toBe('json-schema');
+    expect(descriptor.error.kind).toBe('typed-shape');
+    expect(descriptor.sideEffect).toBe('write');
+    expect(descriptor.confirmation.required).toBe(false);
+    expect(descriptor.surfaces).toEqual(
+      expect.arrayContaining(['cli', 'agent', 'web', 'command-center'])
+    );
+    expect(descriptor.availability).toMatchObject({
+      state: 'unavailable',
+      reason: expect.stringContaining('Command Center execution is not wired yet'),
+    });
+    expect(descriptor.contract).toMatchObject({
+      relayCommandName: 'sessions.create',
+      stable: true,
+      source: 'shared/relay-command-manifest.ts',
+    });
+  });
+
+  it('projects UI-only actions without promoting them to stable Relay commands', () => {
+    const descriptor = actionDescriptorFromMeta(terminalScrollTop, {
+      view: 'session',
+      sessionId: 'session-1',
+    });
+
+    expect(descriptor).toMatchObject({
+      id: 'terminal.scroll-top',
+      stable: false,
+      source: 'ui-action-registry',
+      sideEffect: 'ui',
+      availability: { state: 'available' },
+    });
+    expect(descriptor.contract).toBeUndefined();
+    expect(descriptor.surfaces).toEqual(
+      expect.arrayContaining(['web', 'command-center'])
+    );
+  });
+
+  it('projects action availability reasons from contextual UI gates', () => {
+    const descriptor = actionDescriptorFromMeta(workspaceOpenFileBrowser, {
+      view: 'workspace',
+      workspacePath: '/repo',
+      activeNodeFileRpcAvailable: false,
+    });
+
+    expect(descriptor.availability).toEqual({
+      state: 'unavailable',
+      reason: 'file rpc unavailable on this node — check the node helper status',
+    });
   });
 
   it('no conflicting keyboard shortcuts', () => {

--- a/test/action-coverage.test.ts
+++ b/test/action-coverage.test.ts
@@ -233,6 +233,26 @@ describe('Action Coverage', () => {
     });
   });
 
+  it('does not evaluate disabled reasons for actions that pass contextual gates', () => {
+    let disabledReasonCalls = 0;
+    const descriptor = actionDescriptorFromMeta(
+      {
+        id: 'workspace.enabled-test',
+        label: 'enabled test action',
+        category: 'workspace',
+        when: () => true,
+        disabledReason: () => {
+          disabledReasonCalls += 1;
+          return 'should not be projected while enabled';
+        },
+      },
+      { view: 'workspace', workspacePath: '/repo' }
+    );
+
+    expect(disabledReasonCalls).toBe(0);
+    expect(descriptor.availability).toEqual({ state: 'available' });
+  });
+
   it('no conflicting keyboard shortcuts', () => {
     const shortcuts = ALL_META.filter((a: ActionMeta) => a.shortcut).map(
       (a: ActionMeta) => ({ id: a.id, key: a.shortcut!.key })


### PR DESCRIPTION
Closes #858

## Summary
- add shared Relay action descriptor types for stable command contracts and UI-only Command Center actions
- attach descriptor projection to stable CLI gateway Command Center metadata while keeping execution disabled
- add frontend ActionMeta descriptor projection and tests for sessions.create, UI-only actions, and contextual availability reasons

## Verification
- PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- cli-gateway-contract action-coverage
- PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check
- PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI gateway commands now integrated with command center interface.

* **Improvements**
  * Commands display consistent availability states and reasons across surfaces.
  * Enhanced error tracking with per-command error codes.
  * Improved action descriptor consistency across CLI, UI, and command center.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->