### PR TITLE
Route session launches through shared action contract

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -966,13 +966,19 @@ export default function App() {
         sessionId: activeSessionId,
       };
       if (activeRepoPath) ctx.workspacePath = activeRepoPath;
+      if (activeWorkspaceCwd) ctx.cwd = activeWorkspaceCwd;
       return ctx;
     }
     if (activeRepoPath) {
-      return { view: 'workspace', workspacePath: activeRepoPath };
+      const ctx: ActionContext = {
+        view: 'workspace',
+        workspacePath: activeRepoPath,
+      };
+      if (activeWorkspaceCwd) ctx.cwd = activeWorkspaceCwd;
+      return ctx;
     }
     return { view: 'dashboard' };
-  }, [activeSessionId, activeRepoPath]);
+  }, [activeSessionId, activeRepoPath, activeWorkspaceCwd]);
 
   // Keep actionContext in a ref so registry callbacks (set up once on mount) always read current value
   const actionContextRef = useRef(actionContext);

--- a/frontend/src/lib/actions/definitions/session.ts
+++ b/frontend/src/lib/actions/definitions/session.ts
@@ -7,7 +7,8 @@ import {
 const launchDescriptor = sessionCreateActionDescriptor();
 const launchRequiresContext = (ctx: ActionContext) =>
   sessionCreateActionAvailability({
-    workspacePath: ctx.workspacePath ?? null,
+    ...(ctx.workspacePath ? { workspacePath: ctx.workspacePath } : {}),
+    ...(ctx.cwd ? { cwd: ctx.cwd } : {}),
   }).reason;
 
 export const sessionNewAgent: ActionMeta = {

--- a/frontend/src/lib/actions/definitions/session.ts
+++ b/frontend/src/lib/actions/definitions/session.ts
@@ -1,13 +1,14 @@
-import type { ActionMeta } from '../types.js';
+import type { ActionContext, ActionMeta } from '../types.js';
 import {
   sessionCreateActionAvailability,
   sessionCreateActionDescriptor,
 } from '../session-create.js';
 
 const launchDescriptor = sessionCreateActionDescriptor();
-const launchRequiresContext = () =>
-  sessionCreateActionAvailability({}).reason ??
-  'session launch requires a workspace, cwd, or selected environment';
+const launchRequiresContext = (ctx: ActionContext) =>
+  sessionCreateActionAvailability({
+    workspacePath: ctx.workspacePath ?? null,
+  }).reason;
 
 export const sessionNewAgent: ActionMeta = {
   id: 'session.new-agent',

--- a/frontend/src/lib/actions/definitions/session.ts
+++ b/frontend/src/lib/actions/definitions/session.ts
@@ -1,4 +1,13 @@
 import type { ActionMeta } from '../types.js';
+import {
+  sessionCreateActionAvailability,
+  sessionCreateActionDescriptor,
+} from '../session-create.js';
+
+const launchDescriptor = sessionCreateActionDescriptor();
+const launchRequiresContext = () =>
+  sessionCreateActionAvailability({}).reason ??
+  'session launch requires a workspace, cwd, or selected environment';
 
 export const sessionNewAgent: ActionMeta = {
   id: 'session.new-agent',
@@ -8,6 +17,8 @@ export const sessionNewAgent: ActionMeta = {
   icon: '+',
   shortcut: { key: 'mod+t', global: true },
   when: (ctx) => !!ctx.workspacePath,
+  disabledReason: launchRequiresContext,
+  descriptor: launchDescriptor,
 };
 
 export const sessionNewTerminal: ActionMeta = {
@@ -17,6 +28,8 @@ export const sessionNewTerminal: ActionMeta = {
   category: 'session',
   icon: '+',
   when: (ctx) => !!ctx.workspacePath,
+  disabledReason: launchRequiresContext,
+  descriptor: launchDescriptor,
 };
 
 export const sessionCloseActive: ActionMeta = {
@@ -45,6 +58,8 @@ export const sessionStartOnRepo: ActionMeta = {
   category: 'session',
   icon: '▸',
   when: (ctx) => !!ctx.workspacePath,
+  disabledReason: launchRequiresContext,
+  descriptor: launchDescriptor,
 };
 
 export const sessionStartOnTicket: ActionMeta = {
@@ -97,6 +112,7 @@ export const sessionStartWorkInEnv: ActionMeta = {
   aliases: ['start work', 'environment', 'env', 'node', 'where', 'pick env'],
   category: 'session',
   icon: '▸',
+  descriptor: launchDescriptor,
 };
 
 export const sessionActions: ActionMeta[] = [

--- a/frontend/src/lib/actions/session-create.ts
+++ b/frontend/src/lib/actions/session-create.ts
@@ -127,7 +127,10 @@ function targetFromInputAndSession(
   const repoPath = session.repoPath ?? input.repoPath;
   if (repoPath) target.repoPath = repoPath;
   if (session.worktreePath !== undefined || input.worktreePath !== undefined) {
-    target.worktreePath = session.worktreePath ?? input.worktreePath ?? null;
+    target.worktreePath =
+      session.worktreePath !== undefined
+        ? session.worktreePath
+        : (input.worktreePath ?? null);
   }
   const type = session.type ?? input.type;
   if (type) target.type = type;

--- a/frontend/src/lib/actions/session-create.ts
+++ b/frontend/src/lib/actions/session-create.ts
@@ -4,13 +4,20 @@ import {
   type RelayActionDescriptor,
 } from '../../../../shared/action-descriptor.js';
 import {
-  relayCommandDefinition,
-  type RelayCommandDefinition,
-} from '../../../../shared/relay-command-manifest.js';
+  gatewayError,
+  gatewayOk,
+  type RelayCliGatewayEnvelope,
+  type RelayCliGatewayError,
+} from '../../../../shared/cli-gateway-contract.js';
+import { normalizeGatewayErrorCode } from '../../../../shared/cli-gateway-runtime.js';
 import {
   DEFAULT_LOCAL_NODE_ID,
   createGlobalSessionId,
 } from '../../../../shared/identity.js';
+import {
+  relayCommandDefinition,
+  type RelayCommandDefinition,
+} from '../../../../shared/relay-command-manifest.js';
 import {
   ConfirmationRequiredError,
   ConflictError,
@@ -37,35 +44,15 @@ export interface SessionCreateActionTarget {
   terminalBackend?: 'relay-pty' | 'tmux-compat';
 }
 
-export interface SessionCreateActionError {
-  code: string;
-  reasonCode: string;
-  message: string;
-  retryable: boolean;
-  details?: Record<string, unknown>;
-}
-
-export interface SessionCreateActionSuccess {
-  ok: true;
-  command: 'sessions.create';
-  descriptor: RelayActionDescriptor;
-  input: SessionCreateActionInput;
-  session: SessionSummary;
-  target: SessionCreateActionTarget;
-}
-
-export interface SessionCreateActionFailure {
-  ok: false;
-  command: 'sessions.create';
-  descriptor: RelayActionDescriptor;
-  input: SessionCreateActionInput;
-  target: Partial<SessionCreateActionTarget>;
-  error: SessionCreateActionError;
+export type SessionCreateActionFailure = Extract<
+  RelayCliGatewayEnvelope<SessionSummary>,
+  { ok: false }
+> & {
+  /** Internal-only raw error for legacy frontend conflict/refresh handling. */
   rawError?: unknown;
-}
-
+};
 export type SessionCreateActionResult =
-  | SessionCreateActionSuccess
+  | Extract<RelayCliGatewayEnvelope<SessionSummary>, { ok: true }>
   | SessionCreateActionFailure;
 
 export type SessionCreateExecutor = (
@@ -110,7 +97,7 @@ export function sessionsCreateCommandDefinition(): RelayCommandDefinition {
   return SESSIONS_CREATE_COMMAND;
 }
 
-function targetFromInputAndSession(
+export function sessionCreateActionTarget(
   input: SessionCreateActionInput,
   session: SessionSummary
 ): SessionCreateActionTarget {
@@ -142,37 +129,25 @@ function targetFromInputAndSession(
   return target;
 }
 
-function targetFromInput(input: SessionCreateActionInput): Partial<SessionCreateActionTarget> {
-  return {
-    ...(input.nodeId ? { nodeId: input.nodeId } : {}),
-    ...(input.cwd ? { cwd: input.cwd } : {}),
-    ...(input.repoPath ? { repoPath: input.repoPath } : {}),
-    ...(input.worktreePath !== undefined ? { worktreePath: input.worktreePath } : {}),
-    ...(input.type ? { type: input.type } : {}),
-    ...(input.mode ? { mode: input.mode } : {}),
-    ...(input.agent ? { agent: input.agent } : {}),
-    ...(input.terminalBackend ? { terminalBackend: input.terminalBackend } : {}),
-  };
-}
-
-function errorFromUnknown(error: unknown): SessionCreateActionError {
+function errorFromUnknown(error: unknown): RelayCliGatewayError {
   if (error instanceof ConflictError) {
     return {
       code: 'SESSION_CONFLICT',
-      reasonCode: 'SESSION_ALREADY_EXISTS',
       message: 'session already exists for this launch target',
       retryable: false,
-      details: error.sessionId ? { sessionId: error.sessionId } : {},
+      details: error.sessionId
+        ? { sessionId: error.sessionId, reasonCode: 'SESSION_ALREADY_EXISTS' }
+        : { reasonCode: 'SESSION_ALREADY_EXISTS' },
     };
   }
 
   if (error instanceof ConfirmationRequiredError) {
     return {
       code: 'CONFIRMATION_REQUIRED',
-      reasonCode: error.challenge.reasonCode,
       message: error.message,
       retryable: true,
       details: {
+        reasonCode: error.challenge.reasonCode,
         challengeId: error.challenge.challengeId,
         requiredBits: error.challenge.requiredBits,
         expiresAt: error.challenge.expiresAt,
@@ -182,61 +157,60 @@ function errorFromUnknown(error: unknown): SessionCreateActionError {
 
   if (error instanceof HttpError) {
     return {
-      code: error.code ?? 'UPSTREAM_ERROR',
-      reasonCode: error.code ?? 'HTTP_ERROR',
+      code: normalizeGatewayErrorCode(error.status, {
+        code: error.code,
+        message: error.message,
+        retryable: error.retryable,
+        details: error.details,
+      }),
       message: error.message,
       retryable: error.retryable ?? error.status >= 500,
-      ...(error.details ? { details: error.details } : {}),
+      ...(error.details
+        ? { details: { reasonCode: error.code ?? 'HTTP_ERROR', ...error.details } }
+        : { details: { reasonCode: error.code ?? 'HTTP_ERROR' } }),
     };
   }
 
   if (error instanceof Error) {
     return {
       code: 'UPSTREAM_ERROR',
-      reasonCode: 'SESSION_CREATE_FAILED',
       message: error.message,
       retryable: true,
+      details: { reasonCode: 'SESSION_CREATE_FAILED' },
     };
   }
 
   return {
     code: 'UPSTREAM_ERROR',
-    reasonCode: 'SESSION_CREATE_FAILED',
     message: 'failed to create session',
     retryable: true,
+    details: { reasonCode: 'SESSION_CREATE_FAILED' },
   };
+}
+
+function withRawError(
+  envelope: Extract<RelayCliGatewayEnvelope<SessionSummary>, { ok: false }>,
+  rawError: unknown
+): SessionCreateActionFailure {
+  Object.defineProperty(envelope, 'rawError', {
+    value: rawError,
+    enumerable: false,
+    configurable: true,
+  });
+  return envelope as SessionCreateActionFailure;
 }
 
 export async function executeSessionCreateAction(
   input: SessionCreateActionInput,
   createSession: SessionCreateExecutor = createSessionApi
 ): Promise<SessionCreateActionResult> {
-  const descriptor = sessionCreateActionDescriptor(
-    sessionCreateActionAvailability({
-      workspacePath: input.repoPath ?? input.worktreePath ?? null,
-      cwd: input.cwd ?? null,
-    })
-  );
-
   try {
     const session = await createSession(input);
-    return {
-      ok: true,
-      command: 'sessions.create',
-      descriptor,
-      input,
-      session,
-      target: targetFromInputAndSession(input, session),
-    };
+    return gatewayOk('sessions.create', session);
   } catch (rawError) {
-    return {
-      ok: false,
-      command: 'sessions.create',
-      descriptor,
-      input,
-      target: targetFromInput(input),
-      error: errorFromUnknown(rawError),
-      rawError,
-    };
+    return withRawError(
+      gatewayError('sessions.create', errorFromUnknown(rawError)),
+      rawError
+    );
   }
 }

--- a/frontend/src/lib/actions/session-create.ts
+++ b/frontend/src/lib/actions/session-create.ts
@@ -44,16 +44,11 @@ export interface SessionCreateActionTarget {
   terminalBackend?: 'relay-pty' | 'tmux-compat';
 }
 
+export type SessionCreateActionResult = RelayCliGatewayEnvelope<SessionSummary>;
 export type SessionCreateActionFailure = Extract<
-  RelayCliGatewayEnvelope<SessionSummary>,
+  SessionCreateActionResult,
   { ok: false }
-> & {
-  /** Internal-only raw error for legacy frontend conflict/refresh handling. */
-  rawError?: unknown;
-};
-export type SessionCreateActionResult =
-  | Extract<RelayCliGatewayEnvelope<SessionSummary>, { ok: true }>
-  | SessionCreateActionFailure;
+>;
 
 export type SessionCreateExecutor = (
   input: CreateSessionBody
@@ -188,18 +183,6 @@ function errorFromUnknown(error: unknown): RelayCliGatewayError {
   };
 }
 
-function withRawError(
-  envelope: Extract<RelayCliGatewayEnvelope<SessionSummary>, { ok: false }>,
-  rawError: unknown
-): SessionCreateActionFailure {
-  Object.defineProperty(envelope, 'rawError', {
-    value: rawError,
-    enumerable: false,
-    configurable: true,
-  });
-  return envelope as SessionCreateActionFailure;
-}
-
 export async function executeSessionCreateAction(
   input: SessionCreateActionInput,
   createSession: SessionCreateExecutor = createSessionApi
@@ -208,9 +191,6 @@ export async function executeSessionCreateAction(
     const session = await createSession(input);
     return gatewayOk('sessions.create', session);
   } catch (rawError) {
-    return withRawError(
-      gatewayError('sessions.create', errorFromUnknown(rawError)),
-      rawError
-    );
+    return gatewayError('sessions.create', errorFromUnknown(rawError));
   }
 }

--- a/frontend/src/lib/actions/session-create.ts
+++ b/frontend/src/lib/actions/session-create.ts
@@ -1,0 +1,239 @@
+import {
+  relayActionDescriptorFromCommandDefinition,
+  type RelayActionAvailability,
+  type RelayActionDescriptor,
+} from '../../../../shared/action-descriptor.js';
+import {
+  relayCommandDefinition,
+  type RelayCommandDefinition,
+} from '../../../../shared/relay-command-manifest.js';
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  createGlobalSessionId,
+} from '../../../../shared/identity.js';
+import {
+  ConfirmationRequiredError,
+  ConflictError,
+  HttpError,
+  createSession as createSessionApi,
+  type CreateSessionBody,
+} from '../api.js';
+import type { SessionSummary } from '../types.js';
+
+const SESSIONS_CREATE_COMMAND = relayCommandDefinition('sessions.create');
+
+export type SessionCreateActionInput = CreateSessionBody;
+
+export interface SessionCreateActionTarget {
+  sessionId: string;
+  globalSessionId: string;
+  nodeId: string;
+  cwd?: string;
+  repoPath?: string;
+  worktreePath?: string | null;
+  type?: 'agent' | 'terminal';
+  mode?: 'pty' | 'web';
+  agent?: string;
+  terminalBackend?: 'relay-pty' | 'tmux-compat';
+}
+
+export interface SessionCreateActionError {
+  code: string;
+  reasonCode: string;
+  message: string;
+  retryable: boolean;
+  details?: Record<string, unknown>;
+}
+
+export interface SessionCreateActionSuccess {
+  ok: true;
+  command: 'sessions.create';
+  descriptor: RelayActionDescriptor;
+  input: SessionCreateActionInput;
+  session: SessionSummary;
+  target: SessionCreateActionTarget;
+}
+
+export interface SessionCreateActionFailure {
+  ok: false;
+  command: 'sessions.create';
+  descriptor: RelayActionDescriptor;
+  input: SessionCreateActionInput;
+  target: Partial<SessionCreateActionTarget>;
+  error: SessionCreateActionError;
+  rawError?: unknown;
+}
+
+export type SessionCreateActionResult =
+  | SessionCreateActionSuccess
+  | SessionCreateActionFailure;
+
+export type SessionCreateExecutor = (
+  input: CreateSessionBody
+) => Promise<SessionSummary>;
+
+function capabilityAvailability(
+  reason?: string
+): RelayActionAvailability {
+  return {
+    state: reason ? 'unavailable' : 'available',
+    ...(reason ? { reason } : {}),
+    capabilityHints: SESSIONS_CREATE_COMMAND.capabilityHints,
+  };
+}
+
+export function sessionCreateActionDescriptor(
+  availability: RelayActionAvailability = capabilityAvailability()
+): RelayActionDescriptor {
+  return relayActionDescriptorFromCommandDefinition(SESSIONS_CREATE_COMMAND, {
+    availability,
+    surfaces: ['cli', 'agent', 'web', 'command-center'],
+  });
+}
+
+export function sessionCreateActionAvailability(input: {
+  workspacePath?: string | null;
+  cwd?: string | null;
+  nodeUnavailableReason?: string | null;
+  unsupportedCapabilityReason?: string | null;
+}): RelayActionAvailability {
+  const reason =
+    input.nodeUnavailableReason ??
+    input.unsupportedCapabilityReason ??
+    (!input.workspacePath && !input.cwd
+      ? 'session launch requires a workspace, cwd, or selected environment'
+      : undefined);
+  return capabilityAvailability(reason ?? undefined);
+}
+
+export function sessionsCreateCommandDefinition(): RelayCommandDefinition {
+  return SESSIONS_CREATE_COMMAND;
+}
+
+function targetFromInputAndSession(
+  input: SessionCreateActionInput,
+  session: SessionSummary
+): SessionCreateActionTarget {
+  const nodeId = session.nodeId ?? input.nodeId ?? DEFAULT_LOCAL_NODE_ID;
+  const sessionId = session.id;
+  const target: SessionCreateActionTarget = {
+    sessionId,
+    globalSessionId:
+      session.globalSessionId ?? createGlobalSessionId(nodeId, sessionId),
+    nodeId,
+  };
+  const cwd = session.cwd ?? input.cwd;
+  if (cwd) target.cwd = cwd;
+  const repoPath = session.repoPath ?? input.repoPath;
+  if (repoPath) target.repoPath = repoPath;
+  if (session.worktreePath !== undefined || input.worktreePath !== undefined) {
+    target.worktreePath = session.worktreePath ?? input.worktreePath ?? null;
+  }
+  const type = session.type ?? input.type;
+  if (type) target.type = type;
+  const mode = session.mode ?? input.mode;
+  if (mode) target.mode = mode;
+  const agent = session.agent ?? input.agent;
+  if (agent) target.agent = agent;
+  if (input.terminalBackend) target.terminalBackend = input.terminalBackend;
+  return target;
+}
+
+function targetFromInput(input: SessionCreateActionInput): Partial<SessionCreateActionTarget> {
+  return {
+    ...(input.nodeId ? { nodeId: input.nodeId } : {}),
+    ...(input.cwd ? { cwd: input.cwd } : {}),
+    ...(input.repoPath ? { repoPath: input.repoPath } : {}),
+    ...(input.worktreePath !== undefined ? { worktreePath: input.worktreePath } : {}),
+    ...(input.type ? { type: input.type } : {}),
+    ...(input.mode ? { mode: input.mode } : {}),
+    ...(input.agent ? { agent: input.agent } : {}),
+    ...(input.terminalBackend ? { terminalBackend: input.terminalBackend } : {}),
+  };
+}
+
+function errorFromUnknown(error: unknown): SessionCreateActionError {
+  if (error instanceof ConflictError) {
+    return {
+      code: 'SESSION_CONFLICT',
+      reasonCode: 'SESSION_ALREADY_EXISTS',
+      message: 'session already exists for this launch target',
+      retryable: false,
+      details: error.sessionId ? { sessionId: error.sessionId } : {},
+    };
+  }
+
+  if (error instanceof ConfirmationRequiredError) {
+    return {
+      code: 'CONFIRMATION_REQUIRED',
+      reasonCode: error.challenge.reasonCode,
+      message: error.message,
+      retryable: true,
+      details: {
+        challengeId: error.challenge.challengeId,
+        requiredBits: error.challenge.requiredBits,
+        expiresAt: error.challenge.expiresAt,
+      },
+    };
+  }
+
+  if (error instanceof HttpError) {
+    return {
+      code: error.code ?? 'UPSTREAM_ERROR',
+      reasonCode: error.code ?? 'HTTP_ERROR',
+      message: error.message,
+      retryable: error.retryable ?? error.status >= 500,
+      ...(error.details ? { details: error.details } : {}),
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      code: 'UPSTREAM_ERROR',
+      reasonCode: 'SESSION_CREATE_FAILED',
+      message: error.message,
+      retryable: true,
+    };
+  }
+
+  return {
+    code: 'UPSTREAM_ERROR',
+    reasonCode: 'SESSION_CREATE_FAILED',
+    message: 'failed to create session',
+    retryable: true,
+  };
+}
+
+export async function executeSessionCreateAction(
+  input: SessionCreateActionInput,
+  createSession: SessionCreateExecutor = createSessionApi
+): Promise<SessionCreateActionResult> {
+  const descriptor = sessionCreateActionDescriptor(
+    sessionCreateActionAvailability({
+      workspacePath: input.repoPath ?? input.worktreePath ?? null,
+      cwd: input.cwd ?? null,
+    })
+  );
+
+  try {
+    const session = await createSession(input);
+    return {
+      ok: true,
+      command: 'sessions.create',
+      descriptor,
+      input,
+      session,
+      target: targetFromInputAndSession(input, session),
+    };
+  } catch (rawError) {
+    return {
+      ok: false,
+      command: 'sessions.create',
+      descriptor,
+      input,
+      target: targetFromInput(input),
+      error: errorFromUnknown(rawError),
+      rawError,
+    };
+  }
+}

--- a/frontend/src/lib/actions/types.ts
+++ b/frontend/src/lib/actions/types.ts
@@ -16,6 +16,7 @@ export type ActionCategory =
 export type ActionContext = {
   view: 'workspace' | 'session' | 'dashboard' | 'settings' | 'org';
   workspacePath?: string;
+  cwd?: string;
   sessionId?: string;
   agentRunning?: boolean;
   isMobile?: boolean;

--- a/frontend/src/lib/session-utils.ts
+++ b/frontend/src/lib/session-utils.ts
@@ -56,6 +56,22 @@ export interface CreateAgentSessionResult {
   error: unknown;
 }
 
+function conflictSessionIdFromFailure(
+  failure: SessionCreateActionFailure
+): string | undefined {
+  const stableSessionId = failure.error.details?.sessionId;
+  if (
+    failure.error.code === 'SESSION_CONFLICT' &&
+    typeof stableSessionId === 'string'
+  ) {
+    return stableSessionId;
+  }
+
+  return failure.rawError instanceof ConflictError
+    ? failure.rawError.sessionId
+    : undefined;
+}
+
 export function getCurrentSessionContext(): CurrentSessionContext {
   const sessionsStore = useSessionsStore.getState();
   const currentRepoPath = useUiStore.getState().activeRepoPath;
@@ -115,14 +131,14 @@ export async function createSessionWithoutActivation(
 
   const failure = action as SessionCreateActionFailure;
   const error = failure.rawError ?? failure.error;
-  if (error instanceof ConflictError) {
+  const conflictingSessionId = conflictSessionIdFromFailure(failure);
+  if (conflictingSessionId) {
     let refreshError: unknown = null;
     try {
       await useSessionsStore.getState().refreshAll();
     } catch (caughtRefreshError) {
       refreshError = caughtRefreshError;
     }
-    const conflictingSessionId = error.sessionId;
     const session = conflictingSessionId
       ? resolveSessionByKey(
           useSessionsStore.getState().sessions,
@@ -149,9 +165,9 @@ export async function createAgentSession(
 
   const failure = action as SessionCreateActionFailure;
   const error = failure.rawError ?? failure.error;
-  if (error instanceof ConflictError) {
+  const conflictingSessionId = conflictSessionIdFromFailure(failure);
+  if (conflictingSessionId) {
     await useSessionsStore.getState().refreshAll();
-    const conflictingSessionId = error.sessionId;
     const session = conflictingSessionId
       ? resolveSessionByKey(
           useSessionsStore.getState().sessions,

--- a/frontend/src/lib/session-utils.ts
+++ b/frontend/src/lib/session-utils.ts
@@ -1,10 +1,14 @@
-import { ConflictError, createSession as createSessionApi } from './api.js';
+import { ConflictError } from './api.js';
 import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
 import { resolveSessionByKey } from './session-keys.js';
 import type { Repo, SessionSummary } from './types.js';
 import type { NodeId } from '../../../shared/identity.js';
 import type { SessionLane } from '../../../shared/session-lane.js';
+import {
+  executeSessionCreateAction,
+  type SessionCreateActionFailure,
+} from './actions/session-create.js';
 
 export interface CreateAgentSessionOptions {
   nodeId?: NodeId | undefined;
@@ -96,8 +100,9 @@ export async function createSessionWithoutActivation(
   const before = useSessionsStore.getState();
   const activeSessionId = before.activeSessionId;
   const workspaceLastSession = { ...before.workspaceLastSession };
-  try {
-    const session = await createSessionApi(options);
+  const action = await executeSessionCreateAction(options);
+
+  if (action.ok) {
     let refreshError: unknown = null;
     try {
       await useSessionsStore.getState().refreshAll();
@@ -105,54 +110,59 @@ export async function createSessionWithoutActivation(
       refreshError = error;
     }
     restoreSessionPlacement(activeSessionId, workspaceLastSession);
-    return { session, error: refreshError };
-  } catch (error) {
-    if (error instanceof ConflictError) {
-      let refreshError: unknown = null;
-      try {
-        await useSessionsStore.getState().refreshAll();
-      } catch (caughtRefreshError) {
-        refreshError = caughtRefreshError;
-      }
-      const conflictingSessionId = error.sessionId;
-      const session = conflictingSessionId
-        ? resolveSessionByKey(
-            useSessionsStore.getState().sessions,
-            conflictingSessionId
-          )
-        : undefined;
-      restoreSessionPlacement(activeSessionId, workspaceLastSession);
-      return { session, error: refreshError ?? error };
-    }
-
-    return { session: undefined, error };
+    return { session: action.session, error: refreshError };
   }
+
+  const failure = action as SessionCreateActionFailure;
+  const error = failure.rawError ?? failure.error;
+  if (error instanceof ConflictError) {
+    let refreshError: unknown = null;
+    try {
+      await useSessionsStore.getState().refreshAll();
+    } catch (caughtRefreshError) {
+      refreshError = caughtRefreshError;
+    }
+    const conflictingSessionId = error.sessionId;
+    const session = conflictingSessionId
+      ? resolveSessionByKey(
+          useSessionsStore.getState().sessions,
+          conflictingSessionId
+        )
+      : undefined;
+    restoreSessionPlacement(activeSessionId, workspaceLastSession);
+    return { session, error: refreshError ?? error };
+  }
+
+  return { session: undefined, error };
 }
 
 export async function createAgentSession(
   options: CreateAgentSessionOptions
 ): Promise<CreateAgentSessionResult> {
-  try {
-    const session = await createSessionApi(options);
-    await useSessionsStore.getState().refreshAll();
-    useSessionsStore.getState().setActiveSessionId(session.id);
-    return { session, error: null };
-  } catch (error) {
-    if (error instanceof ConflictError) {
-      await useSessionsStore.getState().refreshAll();
-      const conflictingSessionId = error.sessionId;
-      const session = conflictingSessionId
-        ? resolveSessionByKey(
-            useSessionsStore.getState().sessions,
-            conflictingSessionId
-          )
-        : undefined;
-      if (conflictingSessionId) {
-        useSessionsStore.getState().setActiveSessionId(conflictingSessionId);
-      }
-      return { session, error };
-    }
+  const action = await executeSessionCreateAction(options);
 
-    return { session: undefined, error };
+  if (action.ok) {
+    await useSessionsStore.getState().refreshAll();
+    useSessionsStore.getState().setActiveSessionId(action.session.id);
+    return { session: action.session, error: null };
   }
+
+  const failure = action as SessionCreateActionFailure;
+  const error = failure.rawError ?? failure.error;
+  if (error instanceof ConflictError) {
+    await useSessionsStore.getState().refreshAll();
+    const conflictingSessionId = error.sessionId;
+    const session = conflictingSessionId
+      ? resolveSessionByKey(
+          useSessionsStore.getState().sessions,
+          conflictingSessionId
+        )
+      : undefined;
+    if (conflictingSessionId) {
+      useSessionsStore.getState().setActiveSessionId(conflictingSessionId);
+    }
+    return { session, error };
+  }
+
+  return { session: undefined, error };
 }

--- a/frontend/src/lib/session-utils.ts
+++ b/frontend/src/lib/session-utils.ts
@@ -1,4 +1,3 @@
-import { ConflictError } from './api.js';
 import { useSessionsStore } from './stores/sessions.js';
 import { useUiStore } from './stores/ui.js';
 import { resolveSessionByKey } from './session-keys.js';
@@ -67,9 +66,7 @@ function conflictSessionIdFromFailure(
     return stableSessionId;
   }
 
-  return failure.rawError instanceof ConflictError
-    ? failure.rawError.sessionId
-    : undefined;
+  return undefined;
 }
 
 export function getCurrentSessionContext(): CurrentSessionContext {
@@ -126,11 +123,11 @@ export async function createSessionWithoutActivation(
       refreshError = error;
     }
     restoreSessionPlacement(activeSessionId, workspaceLastSession);
-    return { session: action.session, error: refreshError };
+    return { session: action.data, error: refreshError };
   }
 
   const failure = action as SessionCreateActionFailure;
-  const error = failure.rawError ?? failure.error;
+  const error = failure.error;
   const conflictingSessionId = conflictSessionIdFromFailure(failure);
   if (conflictingSessionId) {
     let refreshError: unknown = null;
@@ -164,12 +161,12 @@ export async function createAgentSession(
     } catch (error) {
       refreshError = error;
     }
-    useSessionsStore.getState().setActiveSessionId(action.session.id);
-    return { session: action.session, error: refreshError };
+    useSessionsStore.getState().setActiveSessionId(action.data.id);
+    return { session: action.data, error: refreshError };
   }
 
   const failure = action as SessionCreateActionFailure;
-  const error = failure.rawError ?? failure.error;
+  const error = failure.error;
   const conflictingSessionId = conflictSessionIdFromFailure(failure);
   if (conflictingSessionId) {
     let refreshError: unknown = null;

--- a/frontend/src/lib/session-utils.ts
+++ b/frontend/src/lib/session-utils.ts
@@ -158,16 +158,26 @@ export async function createAgentSession(
   const action = await executeSessionCreateAction(options);
 
   if (action.ok) {
-    await useSessionsStore.getState().refreshAll();
+    let refreshError: unknown = null;
+    try {
+      await useSessionsStore.getState().refreshAll();
+    } catch (error) {
+      refreshError = error;
+    }
     useSessionsStore.getState().setActiveSessionId(action.session.id);
-    return { session: action.session, error: null };
+    return { session: action.session, error: refreshError };
   }
 
   const failure = action as SessionCreateActionFailure;
   const error = failure.rawError ?? failure.error;
   const conflictingSessionId = conflictSessionIdFromFailure(failure);
   if (conflictingSessionId) {
-    await useSessionsStore.getState().refreshAll();
+    let refreshError: unknown = null;
+    try {
+      await useSessionsStore.getState().refreshAll();
+    } catch (caughtRefreshError) {
+      refreshError = caughtRefreshError;
+    }
     const session = conflictingSessionId
       ? resolveSessionByKey(
           useSessionsStore.getState().sessions,
@@ -177,7 +187,7 @@ export async function createAgentSession(
     if (conflictingSessionId) {
       useSessionsStore.getState().setActiveSessionId(conflictingSessionId);
     }
-    return { session, error };
+    return { session, error: refreshError ?? error };
   }
 
   return { session: undefined, error };

--- a/shared/action-descriptor.ts
+++ b/shared/action-descriptor.ts
@@ -3,6 +3,7 @@ import type {
   RelayCliGatewayErrorCode,
   RelayJsonSchema,
 } from './cli-gateway-contract.js';
+import { gatewayErrorSchema } from './cli-gateway-contract.js';
 import type {
   RelayCommandControlRequirement,
   RelayCommandDefinition,
@@ -130,6 +131,7 @@ export function relayActionDescriptorFromCommandDefinition(
     error: {
       kind: 'typed-shape',
       type: 'RelayCliGatewayErrorEnvelope',
+      schema: gatewayErrorSchema,
     },
     stable: command.stable,
     source: 'cli-gateway-v1',

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -702,7 +702,7 @@ const renewSessionInputSchema: RelayJsonSchema = {
   required: ['id'],
 };
 
-const gatewayErrorSchema: RelayJsonSchema = {
+export const gatewayErrorSchema: RelayJsonSchema = {
   title: 'RelayCliGatewayErrorEnvelope',
   type: 'object',
   additionalProperties: false,

--- a/test/session-create-action.test.ts
+++ b/test/session-create-action.test.ts
@@ -70,6 +70,19 @@ describe('sessions.create frontend action contract', () => {
     }
   });
 
+  it('keeps launch actions enabled in a workspace command context', () => {
+    const ctx = { view: 'workspace' as const, workspacePath: '/home/me/repo' };
+
+    for (const action of [
+      sessionNewAgent,
+      sessionNewTerminal,
+      sessionStartOnRepo,
+    ]) {
+      expect(action.when?.(ctx)).toBe(true);
+      expect(action.disabledReason?.(ctx)).toBeUndefined();
+    }
+  });
+
   it('executes a web launch through the shared action path with typed success target', async () => {
     const result = await executeSessionCreateAction(
       {
@@ -98,6 +111,47 @@ describe('sessions.create frontend action contract', () => {
       },
     });
     expect(result.descriptor.contract?.relayCommandName).toBe('sessions.create');
+  });
+
+  it('preserves explicit null worktree responses instead of falling back to input', async () => {
+    const result = await executeSessionCreateAction(
+      {
+        nodeId: 'remote-1',
+        cwd: '/home/me/repo',
+        repoPath: '/home/me/repo',
+        worktreePath: '/home/me/repo/.worktrees/feature',
+        type: 'terminal',
+        mode: 'pty',
+      },
+      async () => session({ worktreePath: null })
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      target: { worktreePath: null },
+    });
+  });
+
+  it('falls back to input worktree only when the session omits the field', async () => {
+    const serverSession = session();
+    delete serverSession.worktreePath;
+
+    const result = await executeSessionCreateAction(
+      {
+        nodeId: 'remote-1',
+        cwd: '/home/me/repo',
+        repoPath: '/home/me/repo',
+        worktreePath: '/home/me/repo/.worktrees/feature',
+        type: 'terminal',
+        mode: 'pty',
+      },
+      async () => serverSession
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      target: { worktreePath: '/home/me/repo/.worktrees/feature' },
+    });
   });
 
   it('normalizes launch failures into a stable typed error envelope', async () => {

--- a/test/session-create-action.test.ts
+++ b/test/session-create-action.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import type { RelayJsonSchema } from '../shared/cli-gateway-contract.js';
 import {
   executeSessionCreateAction,
   sessionCreateActionAvailability,
   sessionCreateActionDescriptor,
+  sessionCreateActionTarget,
   sessionsCreateCommandDefinition,
 } from '../frontend/src/lib/actions/session-create.js';
 import {
@@ -14,16 +16,85 @@ import {
 import { HttpError } from '../frontend/src/lib/api.js';
 import type { SessionSummary } from '../frontend/src/lib/types.js';
 
+function schemaTypeMatches(type: string, value: unknown): boolean {
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'null') return value === null;
+  if (type === 'object') {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+  return typeof value === type;
+}
+
+// The test intentionally implements the tiny JSON Schema subset used by the gateway
+// envelopes so this regression does not depend on an undeclared Ajv package.
+// eslint-disable-next-line sonarjs/cognitive-complexity
+function validateJsonSchema(
+  schema: RelayJsonSchema | undefined,
+  value: unknown,
+  path = '$'
+): string[] {
+  if (!schema) return [`${path} has no schema`];
+
+  const errors: string[] = [];
+  if ('const' in schema && value !== schema.const) {
+    errors.push(`${path} expected const ${String(schema.const)}`);
+  }
+  if (schema.enum && !schema.enum.includes(String(value))) {
+    errors.push(`${path} expected enum ${schema.enum.join('|')}`);
+  }
+  if (schema.oneOf) {
+    const matches = schema.oneOf.filter(
+      (candidate) => validateJsonSchema(candidate, value, path).length === 0
+    );
+    if (matches.length !== 1) errors.push(`${path} expected oneOf match`);
+    return errors;
+  }
+  if (schema.type) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (!types.some((type) => schemaTypeMatches(type, value))) {
+      errors.push(`${path} expected type ${types.join('|')}`);
+      return errors;
+    }
+  }
+  if (schema.type === 'object' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const objectValue = value as Record<string, unknown>;
+    const properties = schema.properties ?? {};
+    for (const required of schema.required ?? []) {
+      if (!(required in objectValue)) {
+        errors.push(`${path} missing required property ${required}`);
+      }
+    }
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(objectValue)) {
+        if (!(key in properties)) errors.push(`${path} has additional property ${key}`);
+      }
+    }
+    for (const [key, childSchema] of Object.entries(properties)) {
+      if (key in objectValue) {
+        errors.push(...validateJsonSchema(childSchema, objectValue[key], `${path}.${key}`));
+      }
+    }
+  }
+  if (schema.type === 'array' && Array.isArray(value) && schema.items) {
+    for (let index = 0; index < value.length; index += 1) {
+      errors.push(...validateJsonSchema(schema.items, value[index], `${path}[${index}]`));
+    }
+  }
+  return errors;
+}
+
 function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
   return {
     id: 'sess-1',
     globalSessionId: 'remote-1:sess-1',
     nodeId: 'remote-1',
     type: 'terminal',
+    agent: 'claude',
     mode: 'pty',
     cwd: '/home/me/repo',
     repoPath: '/home/me/repo',
     worktreePath: null,
+    displayName: 'terminal',
     createdAt: '2026-06-03T00:00:00.000Z',
     lastActivity: '2026-06-03T00:00:00.000Z',
     idle: true,
@@ -51,7 +122,11 @@ describe('sessions.create frontend action contract', () => {
       kind: 'json-schema',
       schema: command.outputSchema,
     });
-    expect(descriptor.error.kind).toBe('typed-shape');
+    expect(descriptor.error).toMatchObject({
+      kind: 'typed-shape',
+      type: 'RelayCliGatewayErrorEnvelope',
+      schema: expect.objectContaining({ title: 'RelayCliGatewayErrorEnvelope' }),
+    });
     expect(descriptor.surfaces).toEqual(
       expect.arrayContaining(['cli', 'agent', 'web', 'command-center'])
     );
@@ -83,7 +158,8 @@ describe('sessions.create frontend action contract', () => {
     }
   });
 
-  it('executes a web launch through the shared action path with typed success target', async () => {
+  it('executes a web launch as the stable CLI gateway success envelope', async () => {
+    const descriptor = sessionCreateActionDescriptor();
     const result = await executeSessionCreateAction(
       {
         nodeId: 'remote-1',
@@ -98,9 +174,11 @@ describe('sessions.create frontend action contract', () => {
 
     expect(result).toMatchObject({
       ok: true,
+      contract: 'v1',
+      contractVersion: '1.0',
       command: 'sessions.create',
-      target: {
-        sessionId: 'sess-1',
+      data: {
+        id: 'sess-1',
         globalSessionId: 'remote-1:sess-1',
         nodeId: 'remote-1',
         cwd: '/home/me/repo',
@@ -110,7 +188,36 @@ describe('sessions.create frontend action contract', () => {
         mode: 'pty',
       },
     });
-    expect(result.descriptor.contract?.relayCommandName).toBe('sessions.create');
+    expect(validateJsonSchema(descriptor.result.schema, result)).toEqual([]);
+  });
+
+  it('rejects the legacy custom web envelope against the advertised result schema', () => {
+    const descriptor = sessionCreateActionDescriptor();
+    const legacyResult = {
+      ok: true,
+      command: 'sessions.create',
+      descriptor,
+      input: { cwd: '/home/me/repo', type: 'terminal' },
+      session: session(),
+      target: {
+        sessionId: 'sess-1',
+        globalSessionId: 'remote-1:sess-1',
+        nodeId: 'remote-1',
+      },
+    };
+
+    const errors = validateJsonSchema(descriptor.result.schema, legacyResult);
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        '$ missing required property contract',
+        '$ missing required property contractVersion',
+        '$ missing required property data',
+        '$ has additional property descriptor',
+        '$ has additional property input',
+        '$ has additional property session',
+        '$ has additional property target',
+      ])
+    );
   });
 
   it('preserves explicit null worktree responses instead of falling back to input', async () => {
@@ -128,33 +235,36 @@ describe('sessions.create frontend action contract', () => {
 
     expect(result).toMatchObject({
       ok: true,
-      target: { worktreePath: null },
+      data: { worktreePath: null },
     });
   });
 
-  it('falls back to input worktree only when the session omits the field', async () => {
+  it('keeps fallback targeting as an explicit internal projection helper', () => {
     const serverSession = session();
     delete serverSession.worktreePath;
 
-    const result = await executeSessionCreateAction(
-      {
-        nodeId: 'remote-1',
-        cwd: '/home/me/repo',
-        repoPath: '/home/me/repo',
-        worktreePath: '/home/me/repo/.worktrees/feature',
-        type: 'terminal',
-        mode: 'pty',
-      },
-      async () => serverSession
-    );
-
-    expect(result).toMatchObject({
-      ok: true,
-      target: { worktreePath: '/home/me/repo/.worktrees/feature' },
+    expect(
+      sessionCreateActionTarget(
+        {
+          nodeId: 'remote-1',
+          cwd: '/home/me/repo',
+          repoPath: '/home/me/repo',
+          worktreePath: '/home/me/repo/.worktrees/feature',
+          type: 'terminal',
+          mode: 'pty',
+        },
+        serverSession
+      )
+    ).toMatchObject({
+      sessionId: 'sess-1',
+      globalSessionId: 'remote-1:sess-1',
+      nodeId: 'remote-1',
+      worktreePath: '/home/me/repo/.worktrees/feature',
     });
   });
 
-  it('normalizes launch failures into a stable typed error envelope', async () => {
+  it('normalizes launch failures into the stable CLI gateway error envelope', async () => {
+    const descriptor = sessionCreateActionDescriptor();
     const result = await executeSessionCreateAction(
       { nodeId: 'remote-1', cwd: '/home/me/repo', type: 'terminal' },
       async () => {
@@ -166,20 +276,24 @@ describe('sessions.create frontend action contract', () => {
 
     expect(result).toMatchObject({
       ok: false,
+      contract: 'v1',
+      contractVersion: '1.0',
       command: 'sessions.create',
-      target: {
-        nodeId: 'remote-1',
-        cwd: '/home/me/repo',
-        type: 'terminal',
-      },
       error: {
         code: 'NODE_OFFLINE',
-        reasonCode: 'NODE_OFFLINE',
         message: 'node is offline',
         retryable: true,
-        details: { nodeId: 'remote-1' },
+        details: { reasonCode: 'NODE_OFFLINE', nodeId: 'remote-1' },
       },
     });
+    expect(Object.keys(result)).toEqual([
+      'ok',
+      'contract',
+      'contractVersion',
+      'command',
+      'error',
+    ]);
+    expect(validateJsonSchema(descriptor.error.schema, result)).toEqual([]);
   });
 
   it('uses the shared availability shape for missing context and node/capability blocks', () => {

--- a/test/session-create-action.test.ts
+++ b/test/session-create-action.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import {
+  executeSessionCreateAction,
+  sessionCreateActionAvailability,
+  sessionCreateActionDescriptor,
+  sessionsCreateCommandDefinition,
+} from '../frontend/src/lib/actions/session-create.js';
+import {
+  sessionNewAgent,
+  sessionNewTerminal,
+  sessionStartOnRepo,
+  sessionStartWorkInEnv,
+} from '../frontend/src/lib/actions/definitions/session.js';
+import { HttpError } from '../frontend/src/lib/api.js';
+import type { SessionSummary } from '../frontend/src/lib/types.js';
+
+function session(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 'sess-1',
+    globalSessionId: 'remote-1:sess-1',
+    nodeId: 'remote-1',
+    type: 'terminal',
+    mode: 'pty',
+    cwd: '/home/me/repo',
+    repoPath: '/home/me/repo',
+    worktreePath: null,
+    createdAt: '2026-06-03T00:00:00.000Z',
+    lastActivity: '2026-06-03T00:00:00.000Z',
+    idle: true,
+    status: 'active',
+    ...overrides,
+  } as SessionSummary;
+}
+
+describe('sessions.create frontend action contract', () => {
+  it('projects the same typed descriptor as the stable CLI gateway command', () => {
+    const command = sessionsCreateCommandDefinition();
+    const descriptor = sessionCreateActionDescriptor();
+
+    expect(descriptor.id).toBe('sessions.create');
+    expect(descriptor.contract).toMatchObject({
+      relayCommandName: 'sessions.create',
+      stable: true,
+      source: 'shared/relay-command-manifest.ts',
+    });
+    expect(descriptor.input).toEqual({
+      kind: 'json-schema',
+      schema: command.inputSchema,
+    });
+    expect(descriptor.result).toEqual({
+      kind: 'json-schema',
+      schema: command.outputSchema,
+    });
+    expect(descriptor.error.kind).toBe('typed-shape');
+    expect(descriptor.surfaces).toEqual(
+      expect.arrayContaining(['cli', 'agent', 'web', 'command-center'])
+    );
+  });
+
+  it('attaches sessions.create to launch action metadata without promoting dialog-only actions', () => {
+    for (const action of [
+      sessionNewAgent,
+      sessionNewTerminal,
+      sessionStartOnRepo,
+      sessionStartWorkInEnv,
+    ]) {
+      expect(action.descriptor?.id).toBe('sessions.create');
+      expect(action.descriptor?.stable).toBe(true);
+      expect(action.descriptor?.contract?.relayCommandName).toBe('sessions.create');
+    }
+  });
+
+  it('executes a web launch through the shared action path with typed success target', async () => {
+    const result = await executeSessionCreateAction(
+      {
+        nodeId: 'remote-1',
+        cwd: '/home/me/repo',
+        repoPath: '/home/me/repo',
+        worktreePath: null,
+        type: 'terminal',
+        mode: 'pty',
+      },
+      async () => session()
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      command: 'sessions.create',
+      target: {
+        sessionId: 'sess-1',
+        globalSessionId: 'remote-1:sess-1',
+        nodeId: 'remote-1',
+        cwd: '/home/me/repo',
+        repoPath: '/home/me/repo',
+        worktreePath: null,
+        type: 'terminal',
+        mode: 'pty',
+      },
+    });
+    expect(result.descriptor.contract?.relayCommandName).toBe('sessions.create');
+  });
+
+  it('normalizes launch failures into a stable typed error envelope', async () => {
+    const result = await executeSessionCreateAction(
+      { nodeId: 'remote-1', cwd: '/home/me/repo', type: 'terminal' },
+      async () => {
+        throw new HttpError(503, 'node is offline', 'NODE_OFFLINE', true, {
+          nodeId: 'remote-1',
+        });
+      }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      command: 'sessions.create',
+      target: {
+        nodeId: 'remote-1',
+        cwd: '/home/me/repo',
+        type: 'terminal',
+      },
+      error: {
+        code: 'NODE_OFFLINE',
+        reasonCode: 'NODE_OFFLINE',
+        message: 'node is offline',
+        retryable: true,
+        details: { nodeId: 'remote-1' },
+      },
+    });
+  });
+
+  it('uses the shared availability shape for missing context and node/capability blocks', () => {
+    expect(sessionCreateActionAvailability({}).reason).toBe(
+      'session launch requires a workspace, cwd, or selected environment'
+    );
+    expect(
+      sessionCreateActionAvailability({
+        cwd: '/home/me/repo',
+        nodeUnavailableReason: 'node is offline',
+      })
+    ).toMatchObject({
+      state: 'unavailable',
+      reason: 'node is offline',
+      capabilityHints: expect.arrayContaining(['session:create:terminal']),
+    });
+    expect(sessionCreateActionAvailability({ cwd: '/home/me/repo' })).toMatchObject({
+      state: 'available',
+    });
+  });
+});

--- a/test/session-utils.test.ts
+++ b/test/session-utils.test.ts
@@ -176,7 +176,7 @@ describe('createSessionWithoutActivation', () => {
     expect(useSessionsStore.getState().workspaceLastSession['/repo/a']).toBe('main');
   });
 
-  it('returns the conflicting session and ConflictError when refresh succeeds', async () => {
+  it('returns the conflicting session and stable ConflictError envelope when refresh succeeds', async () => {
     const conflict = new ConflictError('main');
     apiMocks.createSession.mockRejectedValue(conflict);
     apiMocks.fetchSessions.mockResolvedValue([session('main', 'agent')]);
@@ -187,7 +187,12 @@ describe('createSessionWithoutActivation', () => {
     });
 
     expect(result.session?.id).toBe('main');
-    expect(result.error).toBe(conflict);
+    expect(result.error).toMatchObject({
+      code: 'SESSION_CONFLICT',
+      message: 'session already exists for this launch target',
+      retryable: false,
+      details: { sessionId: 'main' },
+    });
     expect(useSessionsStore.getState().activeSessionId).toBe('main');
     expect(useSessionsStore.getState().workspaceLastSession['/repo/a']).toBe('main');
   });
@@ -247,7 +252,15 @@ describe('createSessionWithoutActivation', () => {
       type: 'terminal',
     });
 
-    expect(result).toEqual({ session: undefined, error: createError });
+    expect(result).toMatchObject({
+      session: undefined,
+      error: {
+        code: 'UPSTREAM_ERROR',
+        message: 'create failed',
+        retryable: true,
+        details: { reasonCode: 'SESSION_CREATE_FAILED' },
+      },
+    });
     expect(refreshAll).not.toHaveBeenCalled();
   });
 

--- a/test/session-utils.test.ts
+++ b/test/session-utils.test.ts
@@ -10,21 +10,65 @@ const apiMocks = vi.hoisted(() => ({
   enrichBranches: vi.fn(),
 }));
 
-vi.mock('../frontend/src/lib/api.js', () => ({
-  ConflictError: class ConflictError extends Error {
+vi.mock('../frontend/src/lib/api.js', () => {
+  class ConflictError extends Error {
     sessionId: string;
     constructor(sessionId: string) {
       super('conflict');
       this.sessionId = sessionId;
     }
-  },
-  createSession: apiMocks.createSession,
-  fetchSessions: apiMocks.fetchSessions,
-  fetchWorktrees: apiMocks.fetchWorktrees,
-  fetchWorkspaces: apiMocks.fetchWorkspaces,
-  fetchWorkspaceGroups: apiMocks.fetchWorkspaceGroups,
-  enrichBranches: apiMocks.enrichBranches,
-}));
+  }
+
+  class ConfirmationRequiredError extends Error {
+    challenge: {
+      reasonCode: string;
+      challengeId: string;
+      requiredBits: string[];
+      expiresAt: string;
+    };
+    constructor() {
+      super('confirmation required');
+      this.challenge = {
+        reasonCode: 'CONFIRMATION_REQUIRED',
+        challengeId: 'challenge-1',
+        requiredBits: [],
+        expiresAt: '2026-05-05T00:00:00.000Z',
+      };
+    }
+  }
+
+  class HttpError extends Error {
+    status: number;
+    code?: string;
+    retryable?: boolean;
+    details?: Record<string, unknown>;
+    constructor(
+      status: number,
+      message: string,
+      code?: string,
+      retryable?: boolean,
+      details?: Record<string, unknown>
+    ) {
+      super(message);
+      this.status = status;
+      if (code !== undefined) this.code = code;
+      if (retryable !== undefined) this.retryable = retryable;
+      if (details !== undefined) this.details = details;
+    }
+  }
+
+  return {
+    ConflictError,
+    ConfirmationRequiredError,
+    HttpError,
+    createSession: apiMocks.createSession,
+    fetchSessions: apiMocks.fetchSessions,
+    fetchWorktrees: apiMocks.fetchWorktrees,
+    fetchWorkspaces: apiMocks.fetchWorkspaces,
+    fetchWorkspaceGroups: apiMocks.fetchWorkspaceGroups,
+    enrichBranches: apiMocks.enrichBranches,
+  };
+});
 
 const storage: Record<string, string> = {};
 Object.defineProperty(globalThis, 'localStorage', {
@@ -40,7 +84,7 @@ Object.defineProperty(globalThis, 'localStorage', {
   configurable: true,
 });
 
-import { ConflictError } from '../frontend/src/lib/api.js';
+import { ConflictError, HttpError } from '../frontend/src/lib/api.js';
 import { createSessionWithoutActivation } from '../frontend/src/lib/session-utils.js';
 import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
 
@@ -141,6 +185,31 @@ describe('createSessionWithoutActivation', () => {
 
     expect(result.session?.id).toBe('main');
     expect(result.error).toBe(conflict);
+    expect(useSessionsStore.getState().activeSessionId).toBe('main');
+    expect(useSessionsStore.getState().workspaceLastSession['/repo/a']).toBe('main');
+  });
+
+  it('returns the conflicting session from stable error details', async () => {
+    const conflict = new HttpError(
+      409,
+      'session already exists',
+      'SESSION_CONFLICT',
+      false,
+      { sessionId: 'main' }
+    );
+    apiMocks.createSession.mockRejectedValue(conflict);
+    apiMocks.fetchSessions.mockResolvedValue([session('main', 'agent')]);
+
+    const result = await createSessionWithoutActivation({
+      repoPath: '/repo/a',
+      type: 'terminal',
+    });
+
+    expect(result.session?.id).toBe('main');
+    expect(result.error).toMatchObject({
+      code: 'SESSION_CONFLICT',
+      details: { sessionId: 'main' },
+    });
     expect(useSessionsStore.getState().activeSessionId).toBe('main');
     expect(useSessionsStore.getState().workspaceLastSession['/repo/a']).toBe('main');
   });

--- a/test/session-utils.test.ts
+++ b/test/session-utils.test.ts
@@ -85,7 +85,10 @@ Object.defineProperty(globalThis, 'localStorage', {
 });
 
 import { ConflictError, HttpError } from '../frontend/src/lib/api.js';
-import { createSessionWithoutActivation } from '../frontend/src/lib/session-utils.js';
+import {
+  createAgentSession,
+  createSessionWithoutActivation,
+} from '../frontend/src/lib/session-utils.js';
 import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
 
 const originalRefreshAll = useSessionsStore.getState().refreshAll;
@@ -246,6 +249,42 @@ describe('createSessionWithoutActivation', () => {
 
     expect(result).toEqual({ session: undefined, error: createError });
     expect(refreshAll).not.toHaveBeenCalled();
+  });
+
+  it('activates created agent sessions and returns refresh errors instead of throwing', async () => {
+    const created = session('new-agent', 'agent');
+    const refreshError = new Error('refresh failed');
+    apiMocks.createSession.mockResolvedValue(created);
+    useSessionsStore.setState({
+      refreshAll: vi.fn().mockRejectedValue(refreshError),
+    });
+
+    const result = await createAgentSession({
+      repoPath: '/repo/a',
+      type: 'agent',
+    });
+
+    expect(result.session).toBe(created);
+    expect(result.error).toBe(refreshError);
+    expect(useSessionsStore.getState().activeSessionId).toBe('new-agent');
+  });
+
+  it('activates conflicting agent sessions and returns conflict refresh errors instead of throwing', async () => {
+    const conflict = new ConflictError('main');
+    const refreshError = new Error('refresh failed');
+    apiMocks.createSession.mockRejectedValue(conflict);
+    useSessionsStore.setState({
+      refreshAll: vi.fn().mockRejectedValue(refreshError),
+    });
+
+    const result = await createAgentSession({
+      repoPath: '/repo/a',
+      type: 'agent',
+    });
+
+    expect(result.session?.id).toBe('main');
+    expect(result.error).toBe(refreshError);
+    expect(useSessionsStore.getState().activeSessionId).toBe('main');
   });
 
   it('does not throw when legacy workspace groups omit repos', () => {


### PR DESCRIPTION
Closes #859

## Summary
- add a frontend `sessions.create` action wrapper that projects the stable CLI gateway descriptor and returns typed success/failure envelopes
- route `createAgentSession` and `createSessionWithoutActivation` through the shared action path while preserving refresh, activation, and conflict handling
- attach the shared descriptor/availability metadata to the primary session launch command-center actions
- cover descriptor parity, availability, success target, and failure envelope behavior in tests

## Verification
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/session-create-action.test.ts test/action-coverage.test.ts` — 15/15 tests passed
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check` — passed, 116 warnings / 0 errors
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run build` — passed

## Browser QA
- Not run: this is a typed launch-contract/state-path change with no intentional visual layout change; downstream QA should verify quick agent, quick terminal, tab-plus node picker, and Customize/Start Work launches against the latest PR head.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified session creation behavior across agents, terminals, and environment launches for consistent experience and improved error handling.

* **Tests**
  * Added comprehensive test coverage for session creation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->