### PR TITLE
fix: degrade work context store boot failures

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -71,7 +71,7 @@ import {
 } from './relay-state-db.js';
 import {
   createWorkContextRouter,
-  initWorkContextStore,
+  initWorkContextStoreBestEffort,
   type WorkContextStore,
 } from './work-contexts.js';
 import { initIaStore, type IaStore } from './ia-store.js';
@@ -1557,7 +1557,7 @@ async function main(): Promise<void> {
     );
   }
 
-  const workContextStore = initWorkContextStore(configDir);
+  const workContextStore = initWorkContextStoreBestEffort(configDir);
 
   // IA persistence substrate (#737): Workspace grouping + Bench overlays. Own
   // SQLite file; new tables only, non-destructive. Routes that consume it

--- a/server/work-contexts.ts
+++ b/server/work-contexts.ts
@@ -304,6 +304,54 @@ export function initWorkContextStore(configDir: string): WorkContextStore {
   return createWorkContextStore(path.join(configDir, 'work-contexts.db'));
 }
 
+export type WorkContextStoreInitializer = (configDir: string) => WorkContextStore;
+
+export function initWorkContextStoreBestEffort(
+  configDir: string,
+  initializer: WorkContextStoreInitializer = initWorkContextStore
+): WorkContextStore {
+  try {
+    return initializer(configDir);
+  } catch (err) {
+    logger.warn(
+      'Work context store disabled: failed to initialize: %s',
+      errorMessage(err)
+    );
+    return createUnavailableWorkContextStore(err);
+  }
+}
+
+export function createUnavailableWorkContextStore(reason: unknown): WorkContextStore {
+  const unavailable = (): never => {
+    throw new WorkContextStoreError(
+      503,
+      'work_context_store_unavailable',
+      `work_context_store_unavailable: ${errorMessage(reason)}`
+    );
+  };
+  return {
+    close() {},
+    create: unavailable,
+    get() {
+      return null;
+    },
+    list() {
+      return [];
+    },
+    update: unavailable,
+    linkContexts: unavailable,
+    associateSession: unavailable,
+    recordLifecycleEvent: unavailable,
+    getResumeSnapshot: unavailable,
+    listActiveWork() {
+      return [];
+    },
+    findSessionWorkContextIds() {
+      return [];
+    },
+  };
+}
+
 export function createWorkContextStore(dbPath: string): WorkContextStore {
   const db = new Database(dbPath);
   db.pragma('journal_mode = WAL');
@@ -1548,6 +1596,10 @@ function nodeStateForNodeId(
 
 function sessionKey(nodeId: string, sessionId: string): string {
   return `${nodeId}\u0000${sessionId}`;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 function sendStoreError(

--- a/test/work-context-store.test.ts
+++ b/test/work-context-store.test.ts
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import {
   createWorkContextRouter,
   createWorkContextStore,
+  initWorkContextStoreBestEffort,
   type WorkContextStore,
 } from '../server/work-contexts.js';
 import type { SessionSummary } from '../server/types.js';
@@ -38,6 +39,23 @@ function makeStoreHandle(): { store: WorkContextStore; dbPath: string } {
 function makeStore(): WorkContextStore {
   return makeStoreHandle().store;
 }
+
+describe('work-context store boot fallback', () => {
+  it('degrades to an unavailable store when sqlite initialization fails', () => {
+    const store = initWorkContextStoreBestEffort('/tmp/relay-config', () => {
+      throw new Error('Module did not self-register');
+    });
+
+    expect(store.list()).toEqual([]);
+    expect(store.get('wc:missing')).toBeNull();
+    expect(
+      store.listActiveWork({ sessions: [], nodes: [] })
+    ).toEqual([]);
+    expect(() => store.create({ id: 'wc:fallback' })).toThrow(
+      'work_context_store_unavailable'
+    );
+  });
+});
 
 function replacePersistedContextJson(
   dbPath: string,


### PR DESCRIPTION
## Summary
- wrap WorkContext store initialization in a best-effort boot fallback
- degrade WorkContext reads to empty/null and writes to `work_context_store_unavailable` instead of crashing the hub
- add regression coverage for sqlite/native module initialization failure

## Test Plan
- `npx vitest run test/work-context-store.test.ts`
- `npm run check`
- `npm run build`
- `node dist/bin/relay-ide.js manifest`

Closes #742