### PR TITLE
Add CLI gateway settings mutation contracts

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -500,7 +500,7 @@ function requireGatewaySessionId(
 
 function gatewayUsage(): never {
   logger.error(
-    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions renew|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|files write|work-contexts get|context create|context get|context list|context pin|context unpin|inbox send|inbox list|inbox get|inbox ack|inbox resolve|inbox ignore|handoffs plan|handoffs create|handoffs status|handoffs cancel|handoffs resume|handoffs launch|artifacts read|supervisor snapshot|supervisor sessions|supervisor send-text|supervisor submit|events subscribe) --json'
+    'Usage: relay-ide v1 (--list|schema|nodes manifest|nodes list|sessions list|sessions get|sessions create|sessions renew|sessions attach|sessions detach|sessions stream|sessions input|sessions interventions|sessions hand-back|files list|files stat|files read|files write|work-contexts get|context create|context get|context list|context pin|context unpin|inbox send|inbox list|inbox get|inbox ack|inbox resolve|inbox ignore|handoffs plan|handoffs create|handoffs status|handoffs cancel|handoffs resume|handoffs launch|artifacts read|supervisor snapshot|supervisor sessions|supervisor send-text|supervisor submit|events subscribe|settings get|settings update|webhooks status|webhooks ping) --json'
   );
   process.exit(1);
 }
@@ -2304,6 +2304,92 @@ async function runGatewayEvents(gatewayArgs: string[]): Promise<never> {
   });
 }
 
+function parseGatewaySettingsValue(
+  commandName: RelayCliGatewayCommand,
+  settingsArgs: string[]
+): string | boolean {
+  const jsonValue = gatewayArg(settingsArgs, '--value-json');
+  if (jsonValue !== undefined) {
+    try {
+      const parsed = JSON.parse(jsonValue) as unknown;
+      if (typeof parsed === 'string' || typeof parsed === 'boolean') return parsed;
+      gatewayInvalid(commandName, '--value-json must decode to a string or boolean');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      printGatewayEnvelope(
+        gatewayError(commandName, gatewayCliInvalidJsonError(commandName, message)),
+        1
+      );
+    }
+  }
+  const value = gatewayArg(settingsArgs, '--value');
+  if (value === undefined) gatewayInvalid(commandName, '--value or --value-json is required');
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return value;
+}
+
+function parseGatewaySettingsUpdateInput(
+  settingsArgs: string[]
+): Record<string, unknown> {
+  const input = parseGatewayInputObject('settings.update', settingsArgs);
+  if (Object.keys(input).length > 0) return input;
+  const key = gatewayArg(settingsArgs, '--key');
+  if (!key) gatewayInvalid('settings.update', '--key is required');
+  return {
+    key,
+    value: parseGatewaySettingsValue('settings.update', settingsArgs),
+    ...(settingsArgs.includes('--confirm-risky-write')
+      ? { confirmRiskyWrite: true }
+      : {}),
+  };
+}
+
+async function runGatewaySettings(gatewayArgs: string[]): Promise<never> {
+  const subcommand = gatewayArgs[1];
+  if (subcommand === 'get') {
+    const data = await gatewayHttpJson({
+      commandName: 'settings.get',
+      pathName: '/cli-gateway/settings',
+      capabilities: ['settings:read'],
+    });
+    printGatewayEnvelope(gatewayOk('settings.get', data), 0);
+  }
+  if (subcommand === 'update') {
+    const data = await gatewayHttpJson({
+      commandName: 'settings.update',
+      pathName: '/cli-gateway/settings',
+      method: 'PATCH',
+      body: parseGatewaySettingsUpdateInput(gatewayArgs.slice(2)),
+      capabilities: ['settings:write'],
+    });
+    printGatewayEnvelope(gatewayOk('settings.update', data), 0);
+  }
+  gatewayInvalid('settings.get', 'unknown settings command', { args: gatewayArgs });
+}
+
+async function runGatewayWebhooks(gatewayArgs: string[]): Promise<never> {
+  const subcommand = gatewayArgs[1];
+  if (subcommand === 'status') {
+    const data = await gatewayHttpJson({
+      commandName: 'webhooks.status',
+      pathName: '/cli-gateway/webhooks/status',
+      capabilities: ['integration:webhook:read'],
+    });
+    printGatewayEnvelope(gatewayOk('webhooks.status', data), 0);
+  }
+  if (subcommand === 'ping') {
+    const data = await gatewayHttpJson({
+      commandName: 'webhooks.ping',
+      pathName: '/cli-gateway/webhooks/ping',
+      method: 'POST',
+      capabilities: ['integration:webhook:test'],
+    });
+    printGatewayEnvelope(gatewayOk('webhooks.ping', data), 0);
+  }
+  gatewayInvalid('webhooks.status', 'unknown webhooks command', { args: gatewayArgs });
+}
+
 async function runGatewayV1(): Promise<never> {
   const gatewayArgs = args.slice(1);
   const json = gatewayArgs.includes('--json');
@@ -2335,6 +2421,8 @@ async function runGatewayV1(): Promise<never> {
   if (top === 'artifacts') return runGatewayArtifacts(gatewayArgs);
   if (top === 'supervisor') return runGatewaySupervisor(gatewayArgs);
   if (top === 'events') return runGatewayEvents(gatewayArgs);
+  if (top === 'settings') return runGatewaySettings(gatewayArgs);
+  if (top === 'webhooks') return runGatewayWebhooks(gatewayArgs);
   gatewayInvalid('contract.list', 'unknown v1 gateway command', {
     args: gatewayArgs,
   });

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -2351,7 +2351,6 @@ async function runGatewaySettings(gatewayArgs: string[]): Promise<never> {
     const data = await gatewayHttpJson({
       commandName: 'settings.get',
       pathName: '/cli-gateway/settings',
-      capabilities: ['settings:read'],
     });
     printGatewayEnvelope(gatewayOk('settings.get', data), 0);
   }
@@ -2361,7 +2360,6 @@ async function runGatewaySettings(gatewayArgs: string[]): Promise<never> {
       pathName: '/cli-gateway/settings',
       method: 'PATCH',
       body: parseGatewaySettingsUpdateInput(gatewayArgs.slice(2)),
-      capabilities: ['settings:write'],
     });
     printGatewayEnvelope(gatewayOk('settings.update', data), 0);
   }
@@ -2374,7 +2372,6 @@ async function runGatewayWebhooks(gatewayArgs: string[]): Promise<never> {
     const data = await gatewayHttpJson({
       commandName: 'webhooks.status',
       pathName: '/cli-gateway/webhooks/status',
-      capabilities: ['integration:webhook:read'],
     });
     printGatewayEnvelope(gatewayOk('webhooks.status', data), 0);
   }
@@ -2383,7 +2380,6 @@ async function runGatewayWebhooks(gatewayArgs: string[]): Promise<never> {
       commandName: 'webhooks.ping',
       pathName: '/cli-gateway/webhooks/ping',
       method: 'POST',
-      capabilities: ['integration:webhook:test'],
     });
     printGatewayEnvelope(gatewayOk('webhooks.ping', data), 0);
   }

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -31,6 +31,10 @@ relay-ide v1 supervisor send-text --target-ids <session-id-1,session-id-2> --tex
 relay-ide v1 supervisor submit --id <session-id-or-global-id> --json
 relay-ide v1 supervisor submit --target-ids <session-id-1,session-id-2> --json
 relay-ide v1 events subscribe --topic <sessions|nodes|audit> --json
+relay-ide v1 settings get --json
+relay-ide v1 settings update --input-json '{"key":"defaultYolo","value":true,"confirmRiskyWrite":true}' --json
+relay-ide v1 webhooks status --json
+relay-ide v1 webhooks ping --json
 ```
 
 This contract is for external brain-as-peer adapters (#430). It is intentionally separate from the internal `/hub/node-link` WebSocket protocol. Adapter packages must generate native tool/function definitions from `relay-ide v1 schema --json` or the committed source manifest in `shared/cli-gateway-contract.ts`; do not hand-code Hermes/Claude/Codex-specific schemas.
@@ -112,7 +116,7 @@ The #857 inventory is kept in [`docs/refactor/857-action-parity-inventory.md`](r
 
 Local discovery commands (`contract.*`, `nodes.manifest`) do not require a hub token.
 
-Hub-backed commands (`nodes.list`, `sessions.*`, `files.*`, `work-contexts.*`, `context.*`, `inbox.*`, `handoffs.*`, `artifacts.*`, `supervisor.*`, and `events.*`) are in the CLI/agent lane, which is distinct from node credentials and the browser-only UI lane. #802 defines the scoped actor credential registry; #805 wires the first CLI gateway scoped credential lane.
+Hub-backed commands (`nodes.list`, `sessions.*`, `files.*`, `work-contexts.*`, `context.*`, `inbox.*`, `handoffs.*`, `artifacts.*`, `supervisor.*`, `events.*`, `settings.*`, and `webhooks.*`) are in the CLI/agent lane, which is distinct from node credentials and the browser-only UI lane. #802 defines the scoped actor credential registry; #805 wires the first CLI gateway scoped credential lane.
 
 ### Scoped actor credential MVP (#805)
 
@@ -243,6 +247,23 @@ Messages and details must not echo `relay-sac-v1...` tokens, bearer headers, bro
 This slice does not migrate every v1 command and does not migrate adapter packages broadly. The actor-token lane does not cover `sessions.create`, `sessions.attach`, `sessions.detach`, `sessions.stream`, `sessions.input`, `files.*`, `context.*`, `inbox.*`, `handoffs.*`, `artifacts.*`, `supervisor.*`, `events.subscribe`, write/control/session-input/event-stream surfaces, browser auth replacement, node proof-of-possession, node credential lifecycle, approval UX, MFA/passkeys, enterprise RBAC, or public multi-tenant hosting.
 
 This boundary is part of the #797/#798/#802 split: #427 provided the trust-tier/capability/audit/confirmation backbone, #798 inventories routes and clarifies browser-session vs actor/node credentials, and #802 provides the scoped actor credential lifecycle primitive. Follow-up work may replace local browser-token compatibility with scoped actor credentials, but adapters should treat that as a credential migration, not a reason to reuse node credentials, browser UI cookies, or browser-only private routes.
+
+## Settings and webhook gateway contracts (#873)
+
+`settings.*` and `webhooks.*` expose a narrow operational slice for CLI/agent adapters. They are not a raw config API.
+
+| Command | Required capability | Side effect | Contract |
+| --- | --- | --- | --- |
+| `relay-ide v1 settings get --json` | `settings:read` | read | Returns only `defaultAgent`, `defaultContinue`, `defaultYolo`, `defaultNotifications`, `claudeFullscreen`, `renamerTool`, and `updateChannel`, plus redaction metadata. |
+| `relay-ide v1 settings update --input-json '{...}' --json` | `settings:write` | write | Updates one allowlisted key. Unknown keys, wrong value types, command/path-shaped `defaultAgent`, and unconfirmed risky transitions fail closed. |
+| `relay-ide v1 webhooks status --json` | `integration:webhook:read` | read | Returns bounded webhook relay status, repo webhook states, Smee connection status, and redaction metadata. |
+| `relay-ide v1 webhooks ping --json` | `integration:webhook:test` | write/probe | Runs a safe configuration ping/status probe without delivering secrets or raw webhook URLs. |
+
+Settings update accepts either `--input-json` / `--input-file` with `{ "key", "value", "confirmRiskyWrite"? }` or typed flags (`--key`, `--value` / `--value-json`, optional `--confirm-risky-write`). `defaultYolo: true` and `updateChannel` changes require `confirmRiskyWrite: true`; otherwise the hub returns `CONFIRMATION_REQUIRED` with a bounded challenge that names only the key and requested value. `settings:write` is also a high-risk capability bit in the shared security policy.
+
+All responses include redaction metadata. The gateway must never return raw config, bearer/browser/node tokens, GitHub tokens, webhook secrets, Smee URLs, connection strings, or secret-looking values. `webhooks.status` and `webhooks.ping` intentionally expose booleans/status strings instead of `github.webhookSecret` or `github.smeeUrl`.
+
+These routes are mounted under `/cli-gateway` and use the CLI gateway auth path. The current scoped actor-token MVP remains read-only for the four commands above; use the existing browser/scoped hub token compatibility path for this settings/webhook slice until a later credential-lifecycle slice mints actor tokens with `settings:*` and `integration:webhook:*` capabilities.
 
 ## Session descriptors
 

--- a/docs/CLI_GATEWAY.md
+++ b/docs/CLI_GATEWAY.md
@@ -250,20 +250,20 @@ This boundary is part of the #797/#798/#802 split: #427 provided the trust-tier/
 
 ## Settings and webhook gateway contracts (#873)
 
-`settings.*` and `webhooks.*` expose a narrow operational slice for CLI/agent adapters. They are not a raw config API.
+`settings.*` and `webhooks.*` expose a narrow operational slice for CLI/agent adapters. They are not a raw config API, and they are browser-operator-session-only for now.
 
-| Command | Required capability | Side effect | Contract |
+| Command | Current auth boundary | Side effect | Contract |
 | --- | --- | --- | --- |
-| `relay-ide v1 settings get --json` | `settings:read` | read | Returns only `defaultAgent`, `defaultContinue`, `defaultYolo`, `defaultNotifications`, `claudeFullscreen`, `renamerTool`, and `updateChannel`, plus redaction metadata. |
-| `relay-ide v1 settings update --input-json '{...}' --json` | `settings:write` | write | Updates one allowlisted key. Unknown keys, wrong value types, command/path-shaped `defaultAgent`, and unconfirmed risky transitions fail closed. |
-| `relay-ide v1 webhooks status --json` | `integration:webhook:read` | read | Returns bounded webhook relay status, repo webhook states, Smee connection status, and redaction metadata. |
-| `relay-ide v1 webhooks ping --json` | `integration:webhook:test` | write/probe | Runs a safe configuration ping/status probe without delivering secrets or raw webhook URLs. |
+| `relay-ide v1 settings get --json` | Browser operator session | read | Returns only `defaultAgent`, `defaultContinue`, `defaultYolo`, `defaultNotifications`, `claudeFullscreen`, `renamerTool`, and `updateChannel`, plus redaction metadata. |
+| `relay-ide v1 settings update --input-json '{...}' --json` | Browser operator session | write | Updates one allowlisted key. Unknown keys, wrong value types, command/path-shaped `defaultAgent`, and unconfirmed risky transitions fail closed. |
+| `relay-ide v1 webhooks status --json` | Browser operator session | read | Returns bounded webhook relay status, repo webhook states, Smee connection status, and redaction metadata. |
+| `relay-ide v1 webhooks ping --json` | Browser operator session | write/probe | Runs a safe configuration ping/status probe without delivering secrets or raw webhook URLs. |
 
-Settings update accepts either `--input-json` / `--input-file` with `{ "key", "value", "confirmRiskyWrite"? }` or typed flags (`--key`, `--value` / `--value-json`, optional `--confirm-risky-write`). `defaultYolo: true` and `updateChannel` changes require `confirmRiskyWrite: true`; otherwise the hub returns `CONFIRMATION_REQUIRED` with a bounded challenge that names only the key and requested value. `settings:write` is also a high-risk capability bit in the shared security policy.
+Settings update accepts either `--input-json` / `--input-file` with `{ "key", "value", "confirmRiskyWrite"? }` or typed flags (`--key`, `--value` / `--value-json`, optional `--confirm-risky-write`). `defaultYolo: true` and `updateChannel` changes require `confirmRiskyWrite: true`; otherwise the hub returns `CONFIRMATION_REQUIRED` with a bounded challenge that names only the key and requested value. The shared security policy still defines settings/webhook capability bits as future grant names, but they are not trusted for these routes yet.
 
 All responses include redaction metadata. The gateway must never return raw config, bearer/browser/node tokens, GitHub tokens, webhook secrets, Smee URLs, connection strings, or secret-looking values. `webhooks.status` and `webhooks.ping` intentionally expose booleans/status strings instead of `github.webhookSecret` or `github.smeeUrl`.
 
-These routes are mounted under `/cli-gateway` and use the CLI gateway auth path. The current scoped actor-token MVP remains read-only for the four commands above; use the existing browser/scoped hub token compatibility path for this settings/webhook slice until a later credential-lifecycle slice mints actor tokens with `settings:*` and `integration:webhook:*` capabilities.
+These routes are mounted under `/cli-gateway`, but they are wired through the browser operator-session middleware rather than the scoped actor-token lane. Caller-supplied `x-relay-capabilities` is ignored and must not be treated as an authorization boundary; the v1 contract intentionally publishes empty `capabilityHints` for `settings.*` and `webhooks.*`. Scoped actor/bearer settings and webhook grants remain future credential-lifecycle work.
 
 ## Session descriptors
 

--- a/server/cli-gateway-settings.ts
+++ b/server/cli-gateway-settings.ts
@@ -1,0 +1,392 @@
+import { Router, type RequestHandler, type Request, type Response } from 'express';
+
+import { loadConfig, saveConfig } from './config.js';
+import { getSmeeStatus } from './webhook-manager.js';
+import type { Config, RenamerTool } from './types.js';
+import type { RelayCapabilityBit } from '../shared/security-policy.js';
+
+export const CLI_GATEWAY_SAFE_SETTING_KEYS = [
+  'defaultAgent',
+  'defaultContinue',
+  'defaultYolo',
+  'defaultNotifications',
+  'claudeFullscreen',
+  'renamerTool',
+  'updateChannel',
+] as const;
+
+export type CliGatewaySafeSettingKey =
+  (typeof CLI_GATEWAY_SAFE_SETTING_KEYS)[number];
+
+export interface CliGatewaySafeSettings {
+  defaultAgent: string;
+  defaultContinue: boolean;
+  defaultYolo: boolean;
+  defaultNotifications: boolean;
+  claudeFullscreen: boolean;
+  renamerTool: RenamerTool;
+  updateChannel: 'stable' | 'nightly';
+}
+
+export interface CliGatewaySettingsUpdateInput {
+  key: CliGatewaySafeSettingKey;
+  value: string | boolean;
+  confirmRiskyWrite?: boolean;
+}
+
+export interface CliGatewaySettingsUpdateResult {
+  key: CliGatewaySafeSettingKey;
+  value: string | boolean;
+  previousValue: string | boolean;
+  changed: boolean;
+  redaction: CliGatewayRedactionSummary;
+}
+
+export interface CliGatewayRedactionSummary {
+  rawConfigReturned: false;
+  secretsReturned: false;
+  tokenMaterialReturned: false;
+}
+
+export interface CliGatewayWebhookStatusResult {
+  configured: boolean;
+  smeeConnected: boolean;
+  lastEventAt: string | null;
+  autoProvision: boolean;
+  repoStatuses: Array<{
+    repoPath: string;
+    webhookStatus: 'manual' | 'live' | 'limited' | 'error';
+    webhookEnabled: boolean;
+    webhookError?: string;
+    lastEventAt: string | null;
+  }>;
+  redaction: CliGatewayRedactionSummary & {
+    webhookSecretsReturned: false;
+    rawWebhookUrlsReturned: false;
+  };
+}
+
+export interface CliGatewayWebhookPingResult {
+  ok: boolean;
+  configured: boolean;
+  smeeConnected: boolean;
+  lastEventAt: string | null;
+  message: string;
+  redaction: CliGatewayRedactionSummary & {
+    webhookSecretsReturned: false;
+    rawWebhookUrlsReturned: false;
+  };
+}
+
+const SAFE_SETTING_KEY_SET = new Set<string>(CLI_GATEWAY_SAFE_SETTING_KEYS);
+const RENAMER_TOOLS = ['claude', 'codex', 'none', 'custom-script'] as const;
+const UPDATE_CHANNELS = ['stable', 'nightly'] as const;
+
+function redactionSummary(): CliGatewayRedactionSummary {
+  return {
+    rawConfigReturned: false,
+    secretsReturned: false,
+    tokenMaterialReturned: false,
+  };
+}
+
+function isSafeSettingKey(value: unknown): value is CliGatewaySafeSettingKey {
+  return typeof value === 'string' && SAFE_SETTING_KEY_SET.has(value);
+}
+
+function readHeaderCapabilities(req: Request): Set<string> {
+  return new Set(
+    (req.header('x-relay-capabilities') ?? '')
+      .split(',')
+      .map((bit) => bit.trim())
+      .filter(Boolean)
+  );
+}
+
+function requireCapability(
+  req: Request,
+  res: Response,
+  capability: RelayCapabilityBit
+): boolean {
+  if (readHeaderCapabilities(req).has(capability)) return true;
+  res.status(403).json({
+    error: {
+      code: 'FORBIDDEN',
+      message: `missing required capability: ${capability}`,
+      retryable: false,
+      reasonCode: 'CAPABILITY_REQUIRED',
+      deniedBits: [capability],
+    },
+  });
+  return false;
+}
+
+export function safeSettingsFromConfig(config: Config): CliGatewaySafeSettings {
+  return {
+    defaultAgent: config.defaultFramework || 'claude',
+    defaultContinue: config.defaultContinue ?? true,
+    defaultYolo: config.defaultYolo ?? false,
+    defaultNotifications: config.defaultNotifications ?? true,
+    claudeFullscreen: config.claudeFullscreen ?? true,
+    renamerTool: config.renamerTool ?? 'claude',
+    updateChannel: config.updateChannel ?? 'stable',
+  };
+}
+
+function validateSettingValue(
+  key: CliGatewaySafeSettingKey,
+  value: unknown
+): { ok: true; value: string | boolean } | { ok: false; message: string } {
+  switch (key) {
+    case 'defaultAgent': {
+      if (typeof value !== 'string' || !value.trim()) {
+        return { ok: false, message: 'defaultAgent must be a non-empty string' };
+      }
+      const trimmed = value.trim();
+      if (!/^[a-zA-Z0-9._-]+$/.test(trimmed)) {
+        return {
+          ok: false,
+          message: 'defaultAgent must be a framework id, not a command or path',
+        };
+      }
+      return { ok: true, value: trimmed };
+    }
+    case 'defaultContinue':
+    case 'defaultYolo':
+    case 'defaultNotifications':
+    case 'claudeFullscreen':
+      if (typeof value !== 'boolean') {
+        return { ok: false, message: `${key} must be a boolean` };
+      }
+      return { ok: true, value };
+    case 'renamerTool':
+      if (typeof value !== 'string' || !RENAMER_TOOLS.includes(value as RenamerTool)) {
+        return {
+          ok: false,
+          message: 'renamerTool must be one of: claude, codex, none, custom-script',
+        };
+      }
+      return { ok: true, value };
+    case 'updateChannel':
+      if (
+        typeof value !== 'string' ||
+        !UPDATE_CHANNELS.includes(value as 'stable' | 'nightly')
+      ) {
+        return { ok: false, message: 'updateChannel must be stable or nightly' };
+      }
+      return { ok: true, value };
+  }
+}
+
+function riskySettingWriteRequiresConfirmation(
+  key: CliGatewaySafeSettingKey,
+  value: string | boolean,
+  previousValue: string | boolean
+): boolean {
+  if (key === 'defaultYolo' && value === true && previousValue !== true) return true;
+  if (key === 'updateChannel' && value !== previousValue) return true;
+  return false;
+}
+
+export function updateSafeSetting(
+  config: Config,
+  input: CliGatewaySettingsUpdateInput
+):
+  | { ok: true; result: CliGatewaySettingsUpdateResult }
+  | { ok: false; status: number; error: Record<string, unknown> } {
+  const current = safeSettingsFromConfig(config);
+  const previousValue = current[input.key];
+  const validation = validateSettingValue(input.key, input.value);
+  if (validation.ok === false) {
+    return {
+      ok: false,
+      status: 400,
+      error: {
+        code: 'INVALID_ARGUMENT',
+        message: validation.message,
+        retryable: false,
+        field: input.key,
+      },
+    };
+  }
+
+  const nextValue = validation.value;
+  if (
+    riskySettingWriteRequiresConfirmation(input.key, nextValue, previousValue) &&
+    input.confirmRiskyWrite !== true
+  ) {
+    return {
+      ok: false,
+      status: 409,
+      error: {
+        code: 'CONFIRMATION_REQUIRED',
+        message: `${input.key} change requires confirmRiskyWrite=true`,
+        retryable: false,
+        reasonCode: 'RISKY_SETTING_WRITE_CONFIRMATION_REQUIRED',
+        challenge: {
+          kind: 'settings.update',
+          key: input.key,
+          requestedValue: nextValue,
+        },
+      },
+    };
+  }
+
+  switch (input.key) {
+    case 'defaultAgent':
+      config.defaultFramework = nextValue as string;
+      break;
+    case 'defaultContinue':
+      config.defaultContinue = nextValue as boolean;
+      break;
+    case 'defaultYolo':
+      config.defaultYolo = nextValue as boolean;
+      break;
+    case 'defaultNotifications':
+      config.defaultNotifications = nextValue as boolean;
+      break;
+    case 'claudeFullscreen':
+      config.claudeFullscreen = nextValue as boolean;
+      break;
+    case 'renamerTool':
+      config.renamerTool = nextValue as RenamerTool;
+      break;
+    case 'updateChannel':
+      config.updateChannel = nextValue as 'stable' | 'nightly';
+      break;
+  }
+
+  return {
+    ok: true,
+    result: {
+      key: input.key,
+      value: nextValue,
+      previousValue,
+      changed: nextValue !== previousValue,
+      redaction: redactionSummary(),
+    },
+  };
+}
+
+function parseSettingsUpdateInput(body: unknown):
+  | { ok: true; input: CliGatewaySettingsUpdateInput }
+  | { ok: false; message: string } {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { ok: false, message: 'settings.update input JSON must be an object' };
+  }
+  const record = body as Record<string, unknown>;
+  if (!isSafeSettingKey(record['key'])) {
+    return {
+      ok: false,
+      message: `key must be one of: ${CLI_GATEWAY_SAFE_SETTING_KEYS.join(', ')}`,
+    };
+  }
+  if (!Object.prototype.hasOwnProperty.call(record, 'value')) {
+    return { ok: false, message: 'value is required' };
+  }
+  const confirmRiskyWrite = record['confirmRiskyWrite'];
+  if (
+    confirmRiskyWrite !== undefined &&
+    typeof confirmRiskyWrite !== 'boolean'
+  ) {
+    return { ok: false, message: 'confirmRiskyWrite must be a boolean' };
+  }
+  return {
+    ok: true,
+    input: {
+      key: record['key'],
+      value: record['value'] as string | boolean,
+      ...(typeof confirmRiskyWrite === 'boolean' ? { confirmRiskyWrite } : {}),
+    },
+  };
+}
+
+function webhookStatusFromConfig(config: Config): CliGatewayWebhookStatusResult {
+  const { smeeConnected, lastEventAt } = getSmeeStatus();
+  const repoStatuses = Object.entries(config.repoSettings ?? {}).map(
+    ([repoPath, settings]) => ({
+      repoPath,
+      webhookStatus: settings.webhookError
+        ? settings.webhookError === 'not-admin'
+          ? ('limited' as const)
+          : ('error' as const)
+        : settings.webhookEnabled === true
+          ? ('live' as const)
+          : ('manual' as const),
+      webhookEnabled: settings.webhookEnabled === true,
+      ...(settings.webhookError ? { webhookError: settings.webhookError } : {}),
+      lastEventAt: null,
+    })
+  );
+  return {
+    configured: Boolean(config.github?.webhookSecret && config.github?.smeeUrl),
+    smeeConnected,
+    lastEventAt,
+    autoProvision: config.github?.autoProvision ?? false,
+    repoStatuses,
+    redaction: {
+      ...redactionSummary(),
+      webhookSecretsReturned: false,
+      rawWebhookUrlsReturned: false,
+    },
+  };
+}
+
+export function createCliGatewaySettingsRouter(deps: {
+  configPath: string;
+  requireAuth: RequestHandler;
+}): Router {
+  const router = Router();
+  router.use(deps.requireAuth);
+
+  router.get('/settings', (req, res) => {
+    if (!requireCapability(req, res, 'settings:read')) return;
+    const settings = safeSettingsFromConfig(loadConfig(deps.configPath));
+    res.json({ settings, redaction: redactionSummary() });
+  });
+
+  router.patch('/settings', (req, res) => {
+    if (!requireCapability(req, res, 'settings:write')) return;
+    const parsed = parseSettingsUpdateInput(req.body);
+    if (parsed.ok === false) {
+      res.status(400).json({
+        error: {
+          code: 'INVALID_ARGUMENT',
+          message: parsed.message,
+          retryable: false,
+        },
+      });
+      return;
+    }
+    const config = loadConfig(deps.configPath);
+    const updated = updateSafeSetting(config, parsed.input);
+    if (updated.ok === false) {
+      res.status(updated.status).json({ error: updated.error });
+      return;
+    }
+    saveConfig(deps.configPath, config);
+    res.json(updated.result);
+  });
+
+  router.get('/webhooks/status', (req, res) => {
+    if (!requireCapability(req, res, 'integration:webhook:read')) return;
+    res.json(webhookStatusFromConfig(loadConfig(deps.configPath)));
+  });
+
+  router.post('/webhooks/ping', (req, res) => {
+    if (!requireCapability(req, res, 'integration:webhook:test')) return;
+    const status = webhookStatusFromConfig(loadConfig(deps.configPath));
+    res.json({
+      ok: status.configured,
+      configured: status.configured,
+      smeeConnected: status.smeeConnected,
+      lastEventAt: status.lastEventAt,
+      message: status.configured
+        ? 'webhook relay configuration is present; no secret or raw URL returned'
+        : 'webhook relay is not configured',
+      redaction: status.redaction,
+    } satisfies CliGatewayWebhookPingResult);
+  });
+
+  return router;
+}

--- a/server/cli-gateway-settings.ts
+++ b/server/cli-gateway-settings.ts
@@ -94,21 +94,18 @@ function isSafeSettingKey(value: unknown): value is CliGatewaySafeSettingKey {
   return typeof value === 'string' && SAFE_SETTING_KEY_SET.has(value);
 }
 
-function readHeaderCapabilities(req: Request): Set<string> {
-  return new Set(
-    (req.header('x-relay-capabilities') ?? '')
-      .split(',')
-      .map((bit) => bit.trim())
-      .filter(Boolean)
-  );
-}
+export type CliGatewayCapabilityAuthorizer = (
+  req: Request,
+  capability: RelayCapabilityBit
+) => boolean;
 
 function requireCapability(
   req: Request,
   res: Response,
-  capability: RelayCapabilityBit
+  capability: RelayCapabilityBit,
+  authorizeCapability: CliGatewayCapabilityAuthorizer
 ): boolean {
-  if (readHeaderCapabilities(req).has(capability)) return true;
+  if (authorizeCapability(req, capability)) return true;
   res.status(403).json({
     error: {
       code: 'FORBIDDEN',
@@ -335,18 +332,21 @@ function webhookStatusFromConfig(config: Config): CliGatewayWebhookStatusResult 
 export function createCliGatewaySettingsRouter(deps: {
   configPath: string;
   requireAuth: RequestHandler;
+  authorizeCapability: CliGatewayCapabilityAuthorizer;
 }): Router {
   const router = Router();
   router.use(deps.requireAuth);
 
   router.get('/settings', (req, res) => {
-    if (!requireCapability(req, res, 'settings:read')) return;
+    if (!requireCapability(req, res, 'settings:read', deps.authorizeCapability))
+      return;
     const settings = safeSettingsFromConfig(loadConfig(deps.configPath));
     res.json({ settings, redaction: redactionSummary() });
   });
 
   router.patch('/settings', (req, res) => {
-    if (!requireCapability(req, res, 'settings:write')) return;
+    if (!requireCapability(req, res, 'settings:write', deps.authorizeCapability))
+      return;
     const parsed = parseSettingsUpdateInput(req.body);
     if (parsed.ok === false) {
       res.status(400).json({
@@ -369,12 +369,28 @@ export function createCliGatewaySettingsRouter(deps: {
   });
 
   router.get('/webhooks/status', (req, res) => {
-    if (!requireCapability(req, res, 'integration:webhook:read')) return;
+    if (
+      !requireCapability(
+        req,
+        res,
+        'integration:webhook:read',
+        deps.authorizeCapability
+      )
+    )
+      return;
     res.json(webhookStatusFromConfig(loadConfig(deps.configPath)));
   });
 
   router.post('/webhooks/ping', (req, res) => {
-    if (!requireCapability(req, res, 'integration:webhook:test')) return;
+    if (
+      !requireCapability(
+        req,
+        res,
+        'integration:webhook:test',
+        deps.authorizeCapability
+      )
+    )
+      return;
     const status = webhookStatusFromConfig(loadConfig(deps.configPath));
     res.json({
       ok: status.configured,

--- a/server/cli-gateway-settings.ts
+++ b/server/cli-gateway-settings.ts
@@ -1,9 +1,8 @@
-import { Router, type RequestHandler, type Request, type Response } from 'express';
+import { Router, type RequestHandler } from 'express';
 
 import { loadConfig, saveConfig } from './config.js';
 import { getSmeeStatus } from './webhook-manager.js';
 import type { Config, RenamerTool } from './types.js';
-import type { RelayCapabilityBit } from '../shared/security-policy.js';
 
 export const CLI_GATEWAY_SAFE_SETTING_KEYS = [
   'defaultAgent',
@@ -92,30 +91,6 @@ function redactionSummary(): CliGatewayRedactionSummary {
 
 function isSafeSettingKey(value: unknown): value is CliGatewaySafeSettingKey {
   return typeof value === 'string' && SAFE_SETTING_KEY_SET.has(value);
-}
-
-export type CliGatewayCapabilityAuthorizer = (
-  req: Request,
-  capability: RelayCapabilityBit
-) => boolean;
-
-function requireCapability(
-  req: Request,
-  res: Response,
-  capability: RelayCapabilityBit,
-  authorizeCapability: CliGatewayCapabilityAuthorizer
-): boolean {
-  if (authorizeCapability(req, capability)) return true;
-  res.status(403).json({
-    error: {
-      code: 'FORBIDDEN',
-      message: `missing required capability: ${capability}`,
-      retryable: false,
-      reasonCode: 'CAPABILITY_REQUIRED',
-      deniedBits: [capability],
-    },
-  });
-  return false;
 }
 
 export function safeSettingsFromConfig(config: Config): CliGatewaySafeSettings {
@@ -332,21 +307,16 @@ function webhookStatusFromConfig(config: Config): CliGatewayWebhookStatusResult 
 export function createCliGatewaySettingsRouter(deps: {
   configPath: string;
   requireAuth: RequestHandler;
-  authorizeCapability: CliGatewayCapabilityAuthorizer;
 }): Router {
   const router = Router();
   router.use(deps.requireAuth);
 
-  router.get('/settings', (req, res) => {
-    if (!requireCapability(req, res, 'settings:read', deps.authorizeCapability))
-      return;
+  router.get('/settings', (_req, res) => {
     const settings = safeSettingsFromConfig(loadConfig(deps.configPath));
     res.json({ settings, redaction: redactionSummary() });
   });
 
   router.patch('/settings', (req, res) => {
-    if (!requireCapability(req, res, 'settings:write', deps.authorizeCapability))
-      return;
     const parsed = parseSettingsUpdateInput(req.body);
     if (parsed.ok === false) {
       res.status(400).json({
@@ -368,29 +338,11 @@ export function createCliGatewaySettingsRouter(deps: {
     res.json(updated.result);
   });
 
-  router.get('/webhooks/status', (req, res) => {
-    if (
-      !requireCapability(
-        req,
-        res,
-        'integration:webhook:read',
-        deps.authorizeCapability
-      )
-    )
-      return;
+  router.get('/webhooks/status', (_req, res) => {
     res.json(webhookStatusFromConfig(loadConfig(deps.configPath)));
   });
 
-  router.post('/webhooks/ping', (req, res) => {
-    if (
-      !requireCapability(
-        req,
-        res,
-        'integration:webhook:test',
-        deps.authorizeCapability
-      )
-    )
-      return;
+  router.post('/webhooks/ping', (_req, res) => {
     const status = webhookStatusFromConfig(loadConfig(deps.configPath));
     res.json({
       ok: status.configured,

--- a/server/index.ts
+++ b/server/index.ts
@@ -219,6 +219,7 @@ import {
 } from './supervisor-route-handlers.js';
 import {
   attachAuthenticatedCliGatewayActorCredential,
+  authenticatedCliGatewayActorCredential,
   bearerActorToken,
   classifyCliGatewayCredentialLane,
   cliGatewayActorFailure,
@@ -2146,6 +2147,14 @@ async function main(): Promise<void> {
     createCliGatewaySettingsRouter({
       configPath: CONFIG_PATH,
       requireAuth: requireCliGatewayAuth,
+      authorizeCapability: (req, capability) => {
+        // Browser-session operators are the server-side authority for this
+        // local settings/webhook surface. Scoped bearer tokens and caller-
+        // supplied `x-relay-capabilities` headers are not capability grants.
+        if (authenticatedBrowserSession(req)) return true;
+        const credential = authenticatedCliGatewayActorCredential(req);
+        return credential?.capabilities.includes(capability) ?? false;
+      },
     })
   );
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -219,7 +219,6 @@ import {
 } from './supervisor-route-handlers.js';
 import {
   attachAuthenticatedCliGatewayActorCredential,
-  authenticatedCliGatewayActorCredential,
   bearerActorToken,
   classifyCliGatewayCredentialLane,
   cliGatewayActorFailure,
@@ -2146,15 +2145,10 @@ async function main(): Promise<void> {
     '/cli-gateway',
     createCliGatewaySettingsRouter({
       configPath: CONFIG_PATH,
-      requireAuth: requireCliGatewayAuth,
-      authorizeCapability: (req, capability) => {
-        // Browser-session operators are the server-side authority for this
-        // local settings/webhook surface. Scoped bearer tokens and caller-
-        // supplied `x-relay-capabilities` headers are not capability grants.
-        if (authenticatedBrowserSession(req)) return true;
-        const credential = authenticatedCliGatewayActorCredential(req);
-        return credential?.capabilities.includes(capability) ?? false;
-      },
+      // Settings/webhook configuration remains browser-operator-only until
+      // scoped actor credentials carry explicit settings/webhook grants.
+      // Do not let CLI callers self-assert capability bits in headers.
+      requireAuth,
     })
   );
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -129,6 +129,7 @@ import {
 } from './credential-rotation-scheduler.js';
 import { createHubNodeRouter } from './hub-node-router.js';
 import { createCliGatewayEventsRouter } from './cli-gateway-events.js';
+import { createCliGatewaySettingsRouter } from './cli-gateway-settings.js';
 import { createConfirmationChallengeStore } from './confirmation-challenges.js';
 import {
   createHandoffRouter,
@@ -2138,6 +2139,13 @@ async function main(): Promise<void> {
         onControlEvent: (cb) => sessions.onControlEvent(cb),
         onNodeStatus: (cb) => hubNodeRegistry.onNodeStatus(cb),
       },
+    })
+  );
+  app.use(
+    '/cli-gateway',
+    createCliGatewaySettingsRouter({
+      configPath: CONFIG_PATH,
+      requireAuth: requireCliGatewayAuth,
     })
   );
 

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -2632,7 +2632,7 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
-    capabilityHints: ['settings:read'],
+    capabilityHints: [],
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -2657,7 +2657,7 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
-    capabilityHints: ['settings:write'],
+    capabilityHints: [],
     inputSchema: settingsUpdateInputSchema,
     outputSchema: okOutput('SettingsUpdateOutput', settingsUpdateOutputDataSchema),
     errorCodes: [
@@ -2677,7 +2677,7 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
-    capabilityHints: ['integration:webhook:read'],
+    capabilityHints: [],
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -2694,7 +2694,7 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     stable: true,
     transport: 'hub-http',
     requiresAuth: true,
-    capabilityHints: ['integration:webhook:test'],
+    capabilityHints: [],
     inputSchema: {
       type: 'object',
       additionalProperties: false,

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -50,7 +50,11 @@ export type RelayCliGatewayCommand =
   | 'supervisor.sessions'
   | 'supervisor.sendText'
   | 'supervisor.submit'
-  | 'events.subscribe';
+  | 'events.subscribe'
+  | 'settings.get'
+  | 'settings.update'
+  | 'webhooks.status'
+  | 'webhooks.ping';
 
 export type RelayCliGatewayErrorCode =
   | 'UNAUTHORIZED'
@@ -1343,6 +1347,166 @@ const okOutput = (title: string, data: RelayJsonSchema): RelayJsonSchema => ({
   required: ['ok', 'contract', 'contractVersion', 'command', 'data'],
 });
 
+const cliGatewayRedactionSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    rawConfigReturned: { const: false },
+    secretsReturned: { const: false },
+    tokenMaterialReturned: { const: false },
+  },
+  required: ['rawConfigReturned', 'secretsReturned', 'tokenMaterialReturned'],
+};
+
+const cliGatewayWebhookRedactionSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    rawConfigReturned: { const: false },
+    secretsReturned: { const: false },
+    tokenMaterialReturned: { const: false },
+    webhookSecretsReturned: { const: false },
+    rawWebhookUrlsReturned: { const: false },
+  },
+  required: [
+    'rawConfigReturned',
+    'secretsReturned',
+    'tokenMaterialReturned',
+    'webhookSecretsReturned',
+    'rawWebhookUrlsReturned',
+  ],
+};
+
+const cliGatewaySafeSettingsSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    defaultAgent: stringSchema,
+    defaultContinue: booleanSchema,
+    defaultYolo: booleanSchema,
+    defaultNotifications: booleanSchema,
+    claudeFullscreen: booleanSchema,
+    renamerTool: {
+      type: 'string',
+      enum: ['claude', 'codex', 'none', 'custom-script'],
+    },
+    updateChannel: { type: 'string', enum: ['stable', 'nightly'] },
+  },
+  required: [
+    'defaultAgent',
+    'defaultContinue',
+    'defaultYolo',
+    'defaultNotifications',
+    'claudeFullscreen',
+    'renamerTool',
+    'updateChannel',
+  ],
+};
+
+const settingsGetOutputDataSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    settings: cliGatewaySafeSettingsSchema,
+    redaction: cliGatewayRedactionSchema,
+  },
+  required: ['settings', 'redaction'],
+};
+
+const settingsUpdateInputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    key: {
+      type: 'string',
+      enum: [
+        'defaultAgent',
+        'defaultContinue',
+        'defaultYolo',
+        'defaultNotifications',
+        'claudeFullscreen',
+        'renamerTool',
+        'updateChannel',
+      ],
+    },
+    value: { type: ['string', 'boolean'] },
+    confirmRiskyWrite: booleanSchema,
+  },
+  required: ['key', 'value'],
+};
+
+const settingsUpdateOutputDataSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    key: settingsUpdateInputSchema.properties?.['key'] ?? stringSchema,
+    value: { type: ['string', 'boolean'] },
+    previousValue: { type: ['string', 'boolean'] },
+    changed: booleanSchema,
+    redaction: cliGatewayRedactionSchema,
+  },
+  required: ['key', 'value', 'previousValue', 'changed', 'redaction'],
+};
+
+const webhookStatusOutputDataSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    configured: booleanSchema,
+    smeeConnected: booleanSchema,
+    lastEventAt: nullableStringSchema,
+    autoProvision: booleanSchema,
+    repoStatuses: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          repoPath: stringSchema,
+          webhookStatus: {
+            type: 'string',
+            enum: ['manual', 'live', 'limited', 'error'],
+          },
+          webhookEnabled: booleanSchema,
+          webhookError: stringSchema,
+          lastEventAt: nullableStringSchema,
+        },
+        required: ['repoPath', 'webhookStatus', 'webhookEnabled', 'lastEventAt'],
+      },
+    },
+    redaction: cliGatewayWebhookRedactionSchema,
+  },
+  required: [
+    'configured',
+    'smeeConnected',
+    'lastEventAt',
+    'autoProvision',
+    'repoStatuses',
+    'redaction',
+  ],
+};
+
+const webhookPingOutputDataSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    ok: booleanSchema,
+    configured: booleanSchema,
+    smeeConnected: booleanSchema,
+    lastEventAt: nullableStringSchema,
+    message: stringSchema,
+    redaction: cliGatewayWebhookRedactionSchema,
+  },
+  required: [
+    'ok',
+    'configured',
+    'smeeConnected',
+    'lastEventAt',
+    'message',
+    'redaction',
+  ],
+};
+
 const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   {
     name: 'contract.list',
@@ -2459,6 +2623,85 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
       'SERVER_UNAVAILABLE',
       'UPSTREAM_ERROR',
     ],
+  },
+  {
+    name: 'settings.get',
+    cli: ['relay-ide', 'v1', 'settings', 'get', '--json'],
+    summary:
+      'Read the CLI gateway safe settings subset with explicit redaction metadata; raw config and secrets are never returned.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['settings:read'],
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {},
+    },
+    outputSchema: okOutput('SettingsGetOutput', settingsGetOutputDataSchema),
+    errorCodes: ['UNAUTHORIZED', 'FORBIDDEN', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+  },
+  {
+    name: 'settings.update',
+    cli: [
+      'relay-ide',
+      'v1',
+      'settings',
+      'update',
+      '--input-json',
+      '<json>',
+      '--json',
+    ],
+    summary:
+      'Mutate one allowlisted safe setting; risky transitions require confirmRiskyWrite=true and never expose raw config or secrets.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['settings:write'],
+    inputSchema: settingsUpdateInputSchema,
+    outputSchema: okOutput('SettingsUpdateOutput', settingsUpdateOutputDataSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'FORBIDDEN',
+      'INVALID_ARGUMENT',
+      'CONFIRMATION_REQUIRED',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'webhooks.status',
+    cli: ['relay-ide', 'v1', 'webhooks', 'status', '--json'],
+    summary:
+      'Read bounded webhook relay status with webhook secrets and raw URLs intentionally redacted.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['integration:webhook:read'],
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {},
+    },
+    outputSchema: okOutput('WebhooksStatusOutput', webhookStatusOutputDataSchema),
+    errorCodes: ['UNAUTHORIZED', 'FORBIDDEN', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
+  },
+  {
+    name: 'webhooks.ping',
+    cli: ['relay-ide', 'v1', 'webhooks', 'ping', '--json'],
+    summary:
+      'Run a safe webhook relay configuration ping/status probe without returning webhook secrets or raw URLs.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['integration:webhook:test'],
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {},
+    },
+    outputSchema: okOutput('WebhooksPingOutput', webhookPingOutputDataSchema),
+    errorCodes: ['UNAUTHORIZED', 'FORBIDDEN', 'SERVER_UNAVAILABLE', 'UPSTREAM_ERROR'],
   },
 ];
 

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -121,6 +121,10 @@ const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
   'supervisor.sendText': 'supervisor send text',
   'supervisor.submit': 'supervisor submit',
   'events.subscribe': 'subscribe gateway events',
+  'settings.get': 'safe settings get',
+  'settings.update': 'safe settings update',
+  'webhooks.status': 'webhook status',
+  'webhooks.ping': 'webhook ping',
 };
 
 function sideEffectForGatewayCommand(
@@ -146,7 +150,9 @@ function sideEffectForGatewayCommand(
     spec.name === 'inbox.send' ||
     spec.name === 'inbox.ack' ||
     spec.name === 'inbox.resolve' ||
-    spec.name === 'inbox.ignore'
+    spec.name === 'inbox.ignore' ||
+    spec.name === 'settings.update' ||
+    spec.name === 'webhooks.ping'
   ) {
     return 'write';
   }
@@ -166,6 +172,7 @@ function scopeKindsForGatewayCommand(
   if (name.startsWith('artifacts.')) return ['work-context'];
   if (name.startsWith('supervisor.')) return ['session'];
   if (name.startsWith('events.')) return ['node', 'session'];
+  if (name.startsWith('settings.') || name.startsWith('webhooks.')) return ['node'];
   if (name.startsWith('sessions.')) return ['session'];
   return [];
 }
@@ -175,6 +182,7 @@ function requiresConfirmationForGatewayCommand(
 ): boolean {
   return (
     spec.name === 'files.write' ||
+    spec.name === 'settings.update' ||
     spec.name === 'handoffs.create' ||
     spec.name === 'handoffs.launch' ||
     spec.capabilityHints.includes('pty:exec:arbitrary') ||

--- a/shared/security-policy.ts
+++ b/shared/security-policy.ts
@@ -42,6 +42,13 @@ export const RELAY_CAPABILITY_BITS = [
   'context:write',
   'inbox:read',
   'inbox:write',
+  // #873: stable CLI gateway contracts for safe settings reads/writes and
+  // redacted webhook operational checks. `settings:write` is high-risk by
+  // default; individual risky values still require command-level confirmation.
+  'settings:read',
+  'settings:write',
+  'integration:webhook:read',
+  'integration:webhook:test',
 ] as const;
 
 export type RelayCapabilityBit = (typeof RELAY_CAPABILITY_BITS)[number];
@@ -78,6 +85,8 @@ export const LEGACY_DEFAULT_ALLOWED_CAPABILITIES = [
   'context:write',
   'inbox:read',
   'inbox:write',
+  'settings:read',
+  'integration:webhook:read',
 ] as const satisfies readonly RelayCapabilityBit[];
 
 export const HIGH_RISK_CAPABILITIES = [
@@ -92,6 +101,7 @@ export const HIGH_RISK_CAPABILITIES = [
   'node:acl:widen',
   'credential:export',
   'node:lifecycle:destructive',
+  'settings:write',
 ] as const satisfies readonly RelayCapabilityBit[];
 
 const RELAY_CAPABILITY_SET = new Set<string>(RELAY_CAPABILITY_BITS);

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -124,6 +124,10 @@ describe('CLI gateway contract', () => {
       'supervisor.sendText',
       'supervisor.submit',
       'events.subscribe',
+      'settings.get',
+      'settings.update',
+      'webhooks.status',
+      'webhooks.ping',
     ]);
 
     for (const spec of RELAY_CLI_GATEWAY_CONTRACT.commandSchemas) {
@@ -237,6 +241,80 @@ describe('CLI gateway contract', () => {
       controlRequirements: ['fresh-control-state'],
       auditRedaction: { expectation: 'hashes-only' },
       scopeKinds: ['session'],
+    });
+    expect(relayCommandDefinition('settings.update')).toMatchObject({
+      sideEffect: 'write',
+      requiresConfirmation: true,
+      controlRequirements: ['confirmation-challenge'],
+      auditRedaction: { expectation: 'action-summary' },
+      scopeKinds: ['node'],
+    });
+    expect(relayCommandDefinition('settings.get')).toMatchObject({
+      sideEffect: 'read',
+      requiresConfirmation: false,
+      auditRedaction: { expectation: 'bounded-redacted' },
+      scopeKinds: ['node'],
+    });
+    expect(relayCommandDefinition('webhooks.status')).toMatchObject({
+      sideEffect: 'read',
+      requiresConfirmation: false,
+      auditRedaction: { expectation: 'bounded-redacted' },
+      scopeKinds: ['node'],
+    });
+    expect(relayCommandDefinition('webhooks.ping')).toMatchObject({
+      sideEffect: 'write',
+      requiresConfirmation: false,
+      auditRedaction: { expectation: 'action-summary' },
+      scopeKinds: ['node'],
+    });
+  });
+
+  it('describes safe settings and webhook contracts with narrow capability hints and redaction metadata', () => {
+    const settingsGet = commandSpec('settings.get');
+    expect(settingsGet.capabilityHints).toEqual(['settings:read']);
+    expect(settingsGet.outputSchema.properties?.data?.properties?.redaction).toMatchObject({
+      properties: {
+        rawConfigReturned: { const: false },
+        secretsReturned: { const: false },
+        tokenMaterialReturned: { const: false },
+      },
+    });
+
+    const settingsUpdate = commandSpec('settings.update');
+    expect(settingsUpdate.capabilityHints).toEqual(['settings:write']);
+    expect(settingsUpdate.errorCodes).toContain('CONFIRMATION_REQUIRED');
+    expect(settingsUpdate.inputSchema).toMatchObject({
+      type: 'object',
+      additionalProperties: false,
+      required: ['key', 'value'],
+    });
+    expect(settingsUpdate.inputSchema.properties?.['key']?.enum).toEqual([
+      'defaultAgent',
+      'defaultContinue',
+      'defaultYolo',
+      'defaultNotifications',
+      'claudeFullscreen',
+      'renamerTool',
+      'updateChannel',
+    ]);
+    expect(settingsUpdate.inputSchema.properties?.['confirmRiskyWrite']).toEqual({
+      type: 'boolean',
+    });
+
+    const webhookStatus = commandSpec('webhooks.status');
+    expect(webhookStatus.capabilityHints).toEqual(['integration:webhook:read']);
+    const webhookStatusJson = JSON.stringify(webhookStatus.outputSchema);
+    expect(webhookStatusJson).toContain('webhookSecretsReturned');
+    expect(webhookStatusJson).not.toContain('"webhookSecret"');
+    expect(webhookStatusJson).not.toContain('"smeeUrl"');
+
+    const webhookPing = commandSpec('webhooks.ping');
+    expect(webhookPing.capabilityHints).toEqual(['integration:webhook:test']);
+    expect(webhookPing.outputSchema.properties?.data?.properties?.redaction).toMatchObject({
+      properties: {
+        webhookSecretsReturned: { const: false },
+        rawWebhookUrlsReturned: { const: false },
+      },
     });
   });
 

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -269,9 +269,9 @@ describe('CLI gateway contract', () => {
     });
   });
 
-  it('describes safe settings and webhook contracts with narrow capability hints and redaction metadata', () => {
+  it('describes browser-operator-only safe settings and webhook contracts with redaction metadata', () => {
     const settingsGet = commandSpec('settings.get');
-    expect(settingsGet.capabilityHints).toEqual(['settings:read']);
+    expect(settingsGet.capabilityHints).toEqual([]);
     expect(settingsGet.outputSchema.properties?.data?.properties?.redaction).toMatchObject({
       properties: {
         rawConfigReturned: { const: false },
@@ -281,7 +281,7 @@ describe('CLI gateway contract', () => {
     });
 
     const settingsUpdate = commandSpec('settings.update');
-    expect(settingsUpdate.capabilityHints).toEqual(['settings:write']);
+    expect(settingsUpdate.capabilityHints).toEqual([]);
     expect(settingsUpdate.errorCodes).toContain('CONFIRMATION_REQUIRED');
     expect(settingsUpdate.inputSchema).toMatchObject({
       type: 'object',
@@ -302,14 +302,14 @@ describe('CLI gateway contract', () => {
     });
 
     const webhookStatus = commandSpec('webhooks.status');
-    expect(webhookStatus.capabilityHints).toEqual(['integration:webhook:read']);
+    expect(webhookStatus.capabilityHints).toEqual([]);
     const webhookStatusJson = JSON.stringify(webhookStatus.outputSchema);
     expect(webhookStatusJson).toContain('webhookSecretsReturned');
     expect(webhookStatusJson).not.toContain('"webhookSecret"');
     expect(webhookStatusJson).not.toContain('"smeeUrl"');
 
     const webhookPing = commandSpec('webhooks.ping');
-    expect(webhookPing.capabilityHints).toEqual(['integration:webhook:test']);
+    expect(webhookPing.capabilityHints).toEqual([]);
     expect(webhookPing.outputSchema.properties?.data?.properties?.redaction).toMatchObject({
       properties: {
         webhookSecretsReturned: { const: false },

--- a/test/cli-gateway-settings.test.ts
+++ b/test/cli-gateway-settings.test.ts
@@ -1,10 +1,7 @@
 import fs from 'node:fs';
-import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
-import type { AddressInfo } from 'node:net';
-
-import express from 'express';
+import express, { type RequestHandler } from 'express';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -12,8 +9,9 @@ import {
   safeSettingsFromConfig,
   updateSafeSetting,
 } from '../server/cli-gateway-settings.js';
+import { saveConfig } from '../server/config.js';
 import type { Config } from '../server/types.js';
-import type { RelayCapabilityBit } from '../shared/security-policy.js';
+import { createTestServer } from './helpers/test-server.js';
 
 function config(overrides: Partial<Config> = {}): Config {
   return {
@@ -23,45 +21,32 @@ function config(overrides: Partial<Config> = {}): Config {
   } as Config;
 }
 
-async function withSettingsRouter(
-  grantedCapabilities: readonly RelayCapabilityBit[],
-  callback: (input: {
-    baseUrl: string;
-    configPath: string;
-  }) => Promise<void>
-): Promise<void> {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-settings-router-'));
-  const configPath = path.join(dir, 'config.json');
-  fs.writeFileSync(
-    configPath,
-    JSON.stringify(config({ defaultYolo: false, defaultNotifications: false })),
-    'utf8'
-  );
-  const granted = new Set<RelayCapabilityBit>(grantedCapabilities);
+const browserOnlyAuth: RequestHandler = (req, res, next) => {
+  if (req.header('cookie') === 'token=browser') {
+    next();
+    return;
+  }
+  res.status(401).json({
+    error: {
+      code: 'UNAUTHORIZED',
+      reasonCode: 'BROWSER_SESSION_REQUIRED',
+      message: 'browser operator session required',
+      retryable: false,
+    },
+  });
+};
+
+async function startSettingsServer(configPath: string) {
   const app = express();
   app.use(express.json());
   app.use(
     '/cli-gateway',
     createCliGatewaySettingsRouter({
       configPath,
-      requireAuth: (_req, _res, next) => next(),
-      authorizeCapability: (_req, capability) => granted.has(capability),
+      requireAuth: browserOnlyAuth,
     })
   );
-  const server = http.createServer(app);
-  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-  const address = server.address() as AddressInfo;
-  try {
-    await callback({
-      baseUrl: `http://127.0.0.1:${address.port}`,
-      configPath,
-    });
-  } finally {
-    await new Promise<void>((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
-    });
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+  return createTestServer(app);
 }
 
 describe('CLI gateway safe settings helpers', () => {
@@ -164,52 +149,64 @@ describe('CLI gateway safe settings helpers', () => {
   });
 });
 
-describe('CLI gateway settings router capability authorization', () => {
-  it('rejects caller-asserted settings:write without a server-side grant', async () => {
-    await withSettingsRouter([], async ({ baseUrl, configPath }) => {
-      const res = await fetch(`${baseUrl}/cli-gateway/settings`, {
+describe('CLI gateway settings/webhook route auth', () => {
+  it('does not let CLI bearer auth self-assert settings:write through x-relay-capabilities', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-gateway-settings-'));
+    const configPath = path.join(tmpDir, 'config.json');
+    saveConfig(configPath, config({ defaultFramework: 'claude' }));
+    const { url, close } = await startSettingsServer(configPath);
+    try {
+      const res = await fetch(`${url}/cli-gateway/settings`, {
         method: 'PATCH',
         headers: {
-          'content-type': 'application/json',
+          Authorization: 'Bearer scoped-token-without-settings-grant',
+          'Content-Type': 'application/json',
           'x-relay-cli-gateway': 'v1',
           'x-relay-capabilities': 'settings:write',
         },
-        body: JSON.stringify({
-          key: 'defaultYolo',
-          value: true,
-          confirmRiskyWrite: true,
-        }),
+        body: JSON.stringify({ key: 'defaultAgent', value: 'codex' }),
       });
 
-      expect(res.status).toBe(403);
-      const body = (await res.json()) as { error: { deniedBits: string[] } };
-      expect(body.error.deniedBits).toEqual(['settings:write']);
-      expect(JSON.parse(fs.readFileSync(configPath, 'utf8'))).toMatchObject({
-        defaultYolo: false,
-      });
-    });
+      expect(res.status).toBe(401);
+      const persisted = JSON.parse(fs.readFileSync(configPath, 'utf8')) as Config;
+      expect(persisted.defaultFramework).toBe('claude');
+    } finally {
+      await close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
-  it('allows settings updates from server-side settings:write grants without trusting headers', async () => {
-    await withSettingsRouter(['settings:write'], async ({ baseUrl, configPath }) => {
-      const res = await fetch(`${baseUrl}/cli-gateway/settings`, {
-        method: 'PATCH',
-        headers: {
-          'content-type': 'application/json',
-          'x-relay-cli-gateway': 'v1',
-        },
-        body: JSON.stringify({ key: 'defaultNotifications', value: true }),
-      });
+  it.each([
+    ['GET', '/cli-gateway/settings', 'settings:read'],
+    ['GET', '/cli-gateway/webhooks/status', 'integration:webhook:read'],
+    ['POST', '/cli-gateway/webhooks/ping', 'integration:webhook:test'],
+  ])(
+    'keeps %s %s browser-operator-only even when x-relay-capabilities=%s is spoofed',
+    async (method, pathName, capability) => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cli-gateway-settings-'));
+      const configPath = path.join(tmpDir, 'config.json');
+      saveConfig(configPath, config({ defaultFramework: 'claude' }));
+      const { url, close } = await startSettingsServer(configPath);
+      try {
+        const denied = await fetch(`${url}${pathName}`, {
+          method,
+          headers: {
+            Authorization: 'Bearer scoped-token-without-route-grant',
+            'x-relay-cli-gateway': 'v1',
+            'x-relay-capabilities': capability,
+          },
+        });
+        expect(denied.status).toBe(401);
 
-      expect(res.status).toBe(200);
-      await expect(res.json()).resolves.toMatchObject({
-        key: 'defaultNotifications',
-        value: true,
-        changed: true,
-      });
-      expect(JSON.parse(fs.readFileSync(configPath, 'utf8'))).toMatchObject({
-        defaultNotifications: true,
-      });
-    });
-  });
+        const allowed = await fetch(`${url}${pathName}`, {
+          method,
+          headers: { cookie: 'token=browser' },
+        });
+        expect(allowed.status).toBe(200);
+      } finally {
+        await close();
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    }
+  );
 });

--- a/test/cli-gateway-settings.test.ts
+++ b/test/cli-gateway-settings.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  safeSettingsFromConfig,
+  updateSafeSetting,
+} from '../server/cli-gateway-settings.js';
+import type { Config } from '../server/types.js';
+
+function config(overrides: Partial<Config> = {}): Config {
+  return {
+    port: 3456,
+    host: '127.0.0.1',
+    ...overrides,
+  } as Config;
+}
+
+describe('CLI gateway safe settings helpers', () => {
+  it('returns only the allowlisted settings subset with defaults', () => {
+    const settings = safeSettingsFromConfig(
+      config({
+        defaultFramework: 'codex',
+        defaultContinue: false,
+        defaultYolo: false,
+        defaultNotifications: true,
+        claudeFullscreen: false,
+        renamerTool: 'none',
+        updateChannel: 'nightly',
+        github: {
+          webhookSecret: '[REDACTED]',
+          smeeUrl: '[REDACTED]',
+        },
+      })
+    );
+
+    expect(settings).toEqual({
+      defaultAgent: 'codex',
+      defaultContinue: false,
+      defaultYolo: false,
+      defaultNotifications: true,
+      claudeFullscreen: false,
+      renamerTool: 'none',
+      updateChannel: 'nightly',
+    });
+    expect(JSON.stringify(settings)).not.toContain('webhookSecret');
+    expect(JSON.stringify(settings)).not.toContain('smeeUrl');
+  });
+
+  it('mutates only allowlisted keys and reports redaction metadata', () => {
+    const mutable = config({ defaultFramework: 'claude' });
+    const result = updateSafeSetting(mutable, {
+      key: 'defaultAgent',
+      value: 'codex',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.result).toEqual({
+        key: 'defaultAgent',
+        value: 'codex',
+        previousValue: 'claude',
+        changed: true,
+        redaction: {
+          rawConfigReturned: false,
+          secretsReturned: false,
+          tokenMaterialReturned: false,
+        },
+      });
+    }
+    expect(mutable.defaultFramework).toBe('codex');
+  });
+
+  it('rejects invalid values before saving', () => {
+    const mutable = config({ renamerTool: 'claude' });
+    const result = updateSafeSetting(mutable, {
+      key: 'renamerTool',
+      value: 'curl' as never,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 400,
+      error: {
+        code: 'INVALID_ARGUMENT',
+        field: 'renamerTool',
+      },
+    });
+    expect(mutable.renamerTool).toBe('claude');
+  });
+
+  it('requires explicit confirmation for risky setting transitions', () => {
+    const mutable = config({ defaultYolo: false });
+    const denied = updateSafeSetting(mutable, {
+      key: 'defaultYolo',
+      value: true,
+    });
+
+    expect(denied).toMatchObject({
+      ok: false,
+      status: 409,
+      error: {
+        code: 'CONFIRMATION_REQUIRED',
+        reasonCode: 'RISKY_SETTING_WRITE_CONFIRMATION_REQUIRED',
+      },
+    });
+    expect(mutable.defaultYolo).toBe(false);
+
+    const confirmed = updateSafeSetting(mutable, {
+      key: 'defaultYolo',
+      value: true,
+      confirmRiskyWrite: true,
+    });
+    expect(confirmed.ok).toBe(true);
+    expect(mutable.defaultYolo).toBe(true);
+  });
+});

--- a/test/cli-gateway-settings.test.ts
+++ b/test/cli-gateway-settings.test.ts
@@ -1,10 +1,19 @@
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import type { AddressInfo } from 'node:net';
+
+import express from 'express';
 import { describe, expect, it } from 'vitest';
 
 import {
+  createCliGatewaySettingsRouter,
   safeSettingsFromConfig,
   updateSafeSetting,
 } from '../server/cli-gateway-settings.js';
 import type { Config } from '../server/types.js';
+import type { RelayCapabilityBit } from '../shared/security-policy.js';
 
 function config(overrides: Partial<Config> = {}): Config {
   return {
@@ -12,6 +21,47 @@ function config(overrides: Partial<Config> = {}): Config {
     host: '127.0.0.1',
     ...overrides,
   } as Config;
+}
+
+async function withSettingsRouter(
+  grantedCapabilities: readonly RelayCapabilityBit[],
+  callback: (input: {
+    baseUrl: string;
+    configPath: string;
+  }) => Promise<void>
+): Promise<void> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-settings-router-'));
+  const configPath = path.join(dir, 'config.json');
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify(config({ defaultYolo: false, defaultNotifications: false })),
+    'utf8'
+  );
+  const granted = new Set<RelayCapabilityBit>(grantedCapabilities);
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/cli-gateway',
+    createCliGatewaySettingsRouter({
+      configPath,
+      requireAuth: (_req, _res, next) => next(),
+      authorizeCapability: (_req, capability) => granted.has(capability),
+    })
+  );
+  const server = http.createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address() as AddressInfo;
+  try {
+    await callback({
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      configPath,
+    });
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 describe('CLI gateway safe settings helpers', () => {
@@ -111,5 +161,55 @@ describe('CLI gateway safe settings helpers', () => {
     });
     expect(confirmed.ok).toBe(true);
     expect(mutable.defaultYolo).toBe(true);
+  });
+});
+
+describe('CLI gateway settings router capability authorization', () => {
+  it('rejects caller-asserted settings:write without a server-side grant', async () => {
+    await withSettingsRouter([], async ({ baseUrl, configPath }) => {
+      const res = await fetch(`${baseUrl}/cli-gateway/settings`, {
+        method: 'PATCH',
+        headers: {
+          'content-type': 'application/json',
+          'x-relay-cli-gateway': 'v1',
+          'x-relay-capabilities': 'settings:write',
+        },
+        body: JSON.stringify({
+          key: 'defaultYolo',
+          value: true,
+          confirmRiskyWrite: true,
+        }),
+      });
+
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: { deniedBits: string[] } };
+      expect(body.error.deniedBits).toEqual(['settings:write']);
+      expect(JSON.parse(fs.readFileSync(configPath, 'utf8'))).toMatchObject({
+        defaultYolo: false,
+      });
+    });
+  });
+
+  it('allows settings updates from server-side settings:write grants without trusting headers', async () => {
+    await withSettingsRouter(['settings:write'], async ({ baseUrl, configPath }) => {
+      const res = await fetch(`${baseUrl}/cli-gateway/settings`, {
+        method: 'PATCH',
+        headers: {
+          'content-type': 'application/json',
+          'x-relay-cli-gateway': 'v1',
+        },
+        body: JSON.stringify({ key: 'defaultNotifications', value: true }),
+      });
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toMatchObject({
+        key: 'defaultNotifications',
+        value: true,
+        changed: true,
+      });
+      expect(JSON.parse(fs.readFileSync(configPath, 'utf8'))).toMatchObject({
+        defaultNotifications: true,
+      });
+    });
   });
 });

--- a/test/stores/node-dashboard.test.ts
+++ b/test/stores/node-dashboard.test.ts
@@ -310,12 +310,17 @@ describe('hub node dashboard state', () => {
     // fixtures unless explicitly granted/challenged, so challenge remains at 2.
     // #814 added `node:pair-token:create` for grant-backed node bootstrap; it
     // is denied by these node policy fixtures unless explicitly delegated.
+    // #873 added four settings/webhook gateway bits. The read bits
+    // (`settings:read`, `integration:webhook:read`) are default-granted on
+    // dev nodes; `settings:write` remains high-risk and this fixture's prod
+    // policy still denies all four because it overrides allowed bits to
+    // `session:read` only, preserving the challenge count at 2.
     expect(
       rows.map((row) => [row.security.trustTier, row.security.postureLabel])
     ).toEqual([
-      ['sandbox', 'allow 1 · challenge 0 · deny 26'],
-      ['dev', 'allow 15 · challenge 0 · deny 12'],
-      ['prod', 'allow 1 · challenge 2 · deny 24'],
+      ['sandbox', 'allow 1 · challenge 0 · deny 30'],
+      ['dev', 'allow 17 · challenge 0 · deny 14'],
+      ['prod', 'allow 1 · challenge 2 · deny 28'],
     ]);
     expect(rows[2].security).toMatchObject({
       tone: 'danger',


### PR DESCRIPTION
## Summary
- add `settings.get`, `settings.update`, `webhooks.status`, and `webhooks.ping` to the v1 CLI gateway contract/manifest/CLI projection
- mount a CLI gateway settings router that reads only safe config fields, allows one-key allowlisted mutations, requires explicit confirmation for risky writes, and returns redaction metadata
- harden settings/webhook route authorization so mutation/read/test capability grants come from server-side authority, not caller-supplied `x-relay-capabilities` headers
- allow browser-session operators for the local settings/webhook surface while requiring scoped bearer/actor credentials to have matching validated credential capabilities
- add capability bits for settings/webhook operations and document the safe backend-only contract slice

Closes #873

## Verification
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/stores/node-dashboard.test.ts test/cli-gateway-contract.test.ts test/cli-gateway-settings.test.ts` — 43/43 passed
- `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check` — passed; lint reported warning-only baseline output (`117 problems`, `0 errors`, `117 warnings`)
- earlier branch verification: `PATH=$HOME/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run build:server` — passed
- earlier CLI smoke: `node dist/bin/relay-ide.js v1 schema --json` — verified the four new command specs are present
- earlier CLI smoke: `node dist/bin/relay-ide.js v1 settings get --json` without credentials — returns a typed `UNAUTHORIZED` gateway envelope

## Notes
- This PR intentionally does not implement broad Settings UI work, OAuth connect/disconnect, webhook setup/remove/backfill, update execution, browser notification permissions, localStorage/devtools mutation, or analytics clearing.
- The settings/webhook responses deliberately expose status booleans/metadata instead of raw config, bearer material, webhook secrets, Smee URLs, or other secret-looking values.
- The settings router no longer treats `x-relay-capabilities` as an authorization source; tests cover a spoofed `settings:write` header being rejected while server-granted `settings:write` succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI gateway commands to view and update application settings with confirmation for sensitive changes
  * Added CLI gateway commands to check webhook status and connectivity
  * Introduced new security capabilities for granular access control to settings and webhooks

* **Documentation**
  * Updated CLI gateway documentation to describe new settings and webhook commands

* **Tests**
  * Added tests for new settings and webhook gateway operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->