### PR TITLE
feat: add workspace lifecycle gateway commands

### DIFF
--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -63,6 +63,11 @@ import {
   validateAndSanitizeGatewayCreateInput,
 } from '../shared/cli-gateway-runtime.js';
 import {
+  DEFAULT_LOCAL_NODE_ID,
+  parseRepoInstanceId,
+  parseWorktreeInstanceId,
+} from '../shared/identity.js';
+import {
   isFileRpcOperation,
   FILE_RPC_MAX_WRITE_BYTES,
   type FileRpcOperation,
@@ -1296,6 +1301,140 @@ async function runGatewayWorkflow(
   );
 }
 
+type GatewayLifecycleInput = Record<string, unknown> & {
+  environment?: Record<string, unknown>;
+};
+
+function gatewayLifecycleEnvironment(
+  input: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  const environment = input['environment'];
+  if (environment === undefined) return undefined;
+  if (!isGatewayRecord(environment)) {
+    gatewayInvalid(
+      'worktrees.status',
+      'environment must be an object when provided'
+    );
+  }
+  return environment;
+}
+
+function gatewayLifecycleNodeId(input: GatewayLifecycleInput): string | undefined {
+  const environment = input.environment;
+  const explicitNodeId = environment?.['nodeId'];
+  if (typeof explicitNodeId === 'string' && explicitNodeId.trim()) {
+    return explicitNodeId;
+  }
+  const repoInstanceId = environment?.['repoInstanceId'];
+  if (typeof repoInstanceId === 'string') {
+    const parsed = parseRepoInstanceId(repoInstanceId);
+    if (parsed) return parsed.nodeId;
+  }
+  const benchId = environment?.['benchId'];
+  if (typeof benchId === 'string') {
+    const parsed = parseWorktreeInstanceId(benchId);
+    if (parsed) return parsed.nodeId;
+  }
+  return undefined;
+}
+
+function rejectRemoteLifecycleWrite(
+  commandName: RelayCliGatewayCommand,
+  input: GatewayLifecycleInput
+): void {
+  const nodeId = gatewayLifecycleNodeId(input);
+  if (nodeId && nodeId !== DEFAULT_LOCAL_NODE_ID) {
+    printGatewayEnvelope(
+      gatewayError(commandName, {
+        code: 'UNSUPPORTED',
+        message:
+          'repo/worktree lifecycle writes are local-only in v1; remote node mutation is unsupported until routed node worktree capabilities exist',
+        retryable: false,
+        details: { nodeId },
+      }),
+      1
+    );
+  }
+}
+
+function lifecycleRepoPath(
+  commandName: RelayCliGatewayCommand,
+  input: GatewayLifecycleInput
+): string {
+  if (typeof input['repoPath'] === 'string' && input['repoPath'].trim()) {
+    return path.resolve(input['repoPath']);
+  }
+  const repoInstanceId = input.environment?.['repoInstanceId'];
+  if (typeof repoInstanceId === 'string') {
+    const parsed = parseRepoInstanceId(repoInstanceId);
+    if (parsed?.nodeId === DEFAULT_LOCAL_NODE_ID) {
+      return path.resolve(parsed.localPath);
+    }
+  }
+  gatewayInvalid(commandName, 'repoPath or local environment.repoInstanceId is required', {
+    required: ['repoPath', 'environment.repoInstanceId'],
+  });
+}
+
+function lifecycleWorktreePath(
+  commandName: RelayCliGatewayCommand,
+  input: GatewayLifecycleInput
+): string {
+  if (
+    typeof input['worktreePath'] === 'string' &&
+    input['worktreePath'].trim()
+  ) {
+    return path.resolve(input['worktreePath']);
+  }
+  const benchId = input.environment?.['benchId'];
+  if (typeof benchId === 'string') {
+    const parsed = parseWorktreeInstanceId(benchId);
+    if (parsed?.nodeId === DEFAULT_LOCAL_NODE_ID) {
+      return path.resolve(parsed.localPath);
+    }
+  }
+  const cwd = input.environment?.['cwd'];
+  if (typeof cwd === 'string' && cwd.trim()) {
+    return path.resolve(cwd);
+  }
+  gatewayInvalid(commandName, 'worktreePath, local environment.benchId, or environment.cwd is required', {
+    required: ['worktreePath', 'environment.benchId', 'environment.cwd'],
+  });
+}
+
+function parseLifecycleInput(
+  commandName: RelayCliGatewayCommand,
+  commandArgs: string[]
+): GatewayLifecycleInput {
+  const input = parseGatewayInputObject(commandName, commandArgs);
+  const environment = gatewayLifecycleEnvironment(input);
+  const lifecycleInput: GatewayLifecycleInput = { ...input };
+  if (environment) lifecycleInput.environment = environment;
+  return lifecycleInput;
+}
+
+async function assertGitRepoIfRequested(
+  commandName: RelayCliGatewayCommand,
+  input: Record<string, unknown>
+): Promise<void> {
+  if (input['requireGitRepo'] !== true) return;
+  const repoPath = input['path'];
+  if (typeof repoPath !== 'string' || !repoPath.trim()) return;
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['rev-parse', '--is-inside-work-tree'],
+      { cwd: path.resolve(repoPath), timeout: 5000 }
+    );
+    if (stdout.trim() === 'true') return;
+  } catch {
+    // fall through to fail-closed argument error
+  }
+  gatewayInvalid(commandName, 'path is not a git repo/worktree', {
+    field: 'path',
+  });
+}
+
 const CLI_GATEWAY_ACTOR_TOKEN_COMMANDS = new Set<RelayCliGatewayCommand>([
   'nodes.list',
   'sessions.list',
@@ -1450,6 +1589,170 @@ async function runGatewayNodes(gatewayArgs: string[]): Promise<never> {
     printGatewayEnvelope(gatewayOk('nodes.list', data), 0);
   }
   gatewayInvalid('nodes.list', 'unknown nodes command', { args: gatewayArgs });
+}
+
+async function runGatewayRepos(gatewayArgs: string[]): Promise<never> {
+  const subcommand = gatewayArgs[1];
+  if (subcommand === 'add') {
+    const input = parseGatewayInputObject('repos.add', gatewayArgs.slice(2));
+    if (typeof input['path'] !== 'string' || !input['path'].trim()) {
+      gatewayInvalid('repos.add', 'path is required', { field: 'path' });
+    }
+    await assertGitRepoIfRequested('repos.add', input);
+    const result = await gatewayHttpJson({
+      commandName: 'repos.add',
+      pathName: '/workspaces',
+      method: 'POST',
+      body: { path: input['path'] },
+      capabilities: ['rpc:git:read', 'rpc:git:write'],
+    });
+    printGatewayEnvelope(gatewayOk('repos.add', result), 0);
+  }
+  gatewayInvalid('repos.add', 'unknown repos command', { args: gatewayArgs });
+}
+
+async function runGatewayWorkspaces(gatewayArgs: string[]): Promise<never> {
+  const subcommand = gatewayArgs[1];
+  if (subcommand === 'launch') {
+    const input = parseGatewayInputObject(
+      'workspaces.launch',
+      gatewayArgs.slice(2)
+    );
+    const workspaceId = input['workspaceId'];
+    if (typeof workspaceId !== 'string' || !workspaceId.trim()) {
+      gatewayInvalid('workspaces.launch', 'workspaceId is required', {
+        field: 'workspaceId',
+      });
+    }
+    const body = { ...input };
+    delete body['workspaceId'];
+    const result = await gatewayHttpJson({
+      commandName: 'workspaces.launch',
+      pathName: `/workspace-groups/${encodeURIComponent(workspaceId)}/session`,
+      method: 'POST',
+      body,
+      capabilities: ['session:create:agent'],
+    });
+    printGatewayEnvelope(gatewayOk('workspaces.launch', result), 0);
+  }
+  gatewayInvalid('workspaces.launch', 'unknown workspaces command', {
+    args: gatewayArgs,
+  });
+}
+
+async function runGatewayWorktreeStatus(
+  commandName: RelayCliGatewayCommand,
+  input: GatewayLifecycleInput
+): Promise<Record<string, unknown>> {
+  rejectRemoteLifecycleWrite(commandName, input);
+  const worktreePath = lifecycleWorktreePath(commandName, input);
+  const query = new URLSearchParams({ path: worktreePath });
+  const result = await gatewayHttpJson({
+    commandName,
+    pathName: `/worktrees/status?${query.toString()}`,
+    capabilities: ['session:read', 'rpc:git:read'],
+  });
+  return isGatewayRecord(result) ? result : {};
+}
+
+async function runGatewayWorktreeCleanup(
+  commandName: 'worktrees.delete' | 'worktrees.archive',
+  input: GatewayLifecycleInput
+): Promise<never> {
+  rejectRemoteLifecycleWrite(commandName, input);
+  const repoPath = lifecycleRepoPath(commandName, input);
+  const worktreePath = lifecycleWorktreePath(commandName, input);
+  const force = input['force'] === true;
+  const confirmationToken = input['confirmationToken'];
+  const hasConfirmation =
+    typeof confirmationToken === 'string' && confirmationToken.trim().length > 0;
+  const statusInput: GatewayLifecycleInput = { worktreePath };
+  if (input.environment) statusInput.environment = input.environment;
+  const status = await runGatewayWorktreeStatus(commandName, statusInput);
+  const activeSessions = Array.isArray(status['activeSessions'])
+    ? status['activeSessions'].filter((id): id is string => typeof id === 'string')
+    : [];
+  const hasUncommittedChanges = status['hasUncommittedChanges'] === true;
+  if ((activeSessions.length > 0 || hasUncommittedChanges) && !force && !hasConfirmation) {
+    printGatewayEnvelope(
+      gatewayError(commandName, {
+        code: 'CONFIRMATION_REQUIRED',
+        message:
+          'worktree cleanup requires force or confirmationToken when active sessions or uncommitted changes are present',
+        retryable: false,
+        details: {
+          activeSessionCount: activeSessions.length,
+          hasUncommittedChanges,
+        },
+      }),
+      1
+    );
+  }
+  const deleteBranch = commandName === 'worktrees.delete';
+  const result = await gatewayHttpJson({
+    commandName,
+    pathName: '/worktrees',
+    method: 'DELETE',
+    body: {
+      repoPath,
+      worktreePath,
+      force: force || hasConfirmation,
+      deleteBranch,
+    },
+    capabilities: ['session:read', 'session:control:kill', 'rpc:git:read', 'rpc:git:write'],
+  });
+  const data = isGatewayRecord(result) ? result : {};
+  printGatewayEnvelope(
+    gatewayOk(commandName, {
+      ok: true,
+      action: commandName === 'worktrees.delete' ? 'delete' : 'archive',
+      branchDeleted: data['branchDeleted'] === true,
+      audit: {
+        repoPath,
+        worktreePath,
+        force: force || hasConfirmation,
+      },
+    }),
+    0
+  );
+}
+
+async function runGatewayWorktrees(gatewayArgs: string[]): Promise<never> {
+  const subcommand = gatewayArgs[1];
+  if (subcommand === 'create') {
+    const input = parseLifecycleInput('worktrees.create', gatewayArgs.slice(2));
+    rejectRemoteLifecycleWrite('worktrees.create', input);
+    const repoPath = lifecycleRepoPath('worktrees.create', input);
+    const body: Record<string, unknown> = {};
+    if (typeof input['branch'] === 'string' && input['branch'].trim()) {
+      body['branch'] = input['branch'];
+    }
+    const query = new URLSearchParams({ path: repoPath });
+    const result = await gatewayHttpJson({
+      commandName: 'worktrees.create',
+      pathName: `/workspaces/worktree?${query.toString()}`,
+      method: 'POST',
+      body,
+      capabilities: ['rpc:git:read', 'rpc:git:write'],
+    });
+    printGatewayEnvelope(gatewayOk('worktrees.create', result), 0);
+  }
+  if (subcommand === 'status') {
+    const input = parseLifecycleInput('worktrees.status', gatewayArgs.slice(2));
+    const result = await runGatewayWorktreeStatus('worktrees.status', input);
+    printGatewayEnvelope(gatewayOk('worktrees.status', result), 0);
+  }
+  if (subcommand === 'delete') {
+    const input = parseLifecycleInput('worktrees.delete', gatewayArgs.slice(2));
+    await runGatewayWorktreeCleanup('worktrees.delete', input);
+  }
+  if (subcommand === 'archive') {
+    const input = parseLifecycleInput('worktrees.archive', gatewayArgs.slice(2));
+    await runGatewayWorktreeCleanup('worktrees.archive', input);
+  }
+  gatewayInvalid('worktrees.status', 'unknown worktrees command', {
+    args: gatewayArgs,
+  });
 }
 
 async function runGatewaySessionList(): Promise<never> {
@@ -3427,6 +3730,9 @@ async function runGatewayV1(): Promise<never> {
   }
   if (!json) gatewayUsage();
   if (top === 'nodes') return runGatewayNodes(gatewayArgs);
+  if (top === 'repos') return runGatewayRepos(gatewayArgs);
+  if (top === 'workspaces') return runGatewayWorkspaces(gatewayArgs);
+  if (top === 'worktrees') return runGatewayWorktrees(gatewayArgs);
   if (top === 'sessions') return runGatewaySessions(gatewayArgs);
   if (top === 'tickets') return runGatewayTickets(gatewayArgs);
   if (top === 'branches') return runGatewayBranches(gatewayArgs);

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -1312,15 +1312,14 @@ function gatewayLifecycleEnvironment(
   const environment = input['environment'];
   if (environment === undefined) return undefined;
   if (!isGatewayRecord(environment)) {
-    gatewayInvalid(
-      commandName,
-      'environment must be an object when provided'
-    );
+    gatewayInvalid(commandName, 'environment must be an object when provided');
   }
   return environment;
 }
 
-function gatewayLifecycleNodeId(input: GatewayLifecycleInput): string | undefined {
+function gatewayLifecycleNodeId(
+  input: GatewayLifecycleInput
+): string | undefined {
   const environment = input.environment;
   const explicitNodeId = environment?.['nodeId'];
   if (typeof explicitNodeId === 'string' && explicitNodeId.trim()) {
@@ -1372,9 +1371,13 @@ function lifecycleRepoPath(
       return path.resolve(parsed.localPath);
     }
   }
-  gatewayInvalid(commandName, 'repoPath or local environment.repoInstanceId is required', {
-    required: ['repoPath', 'environment.repoInstanceId'],
-  });
+  gatewayInvalid(
+    commandName,
+    'repoPath or local environment.repoInstanceId is required',
+    {
+      required: ['repoPath', 'environment.repoInstanceId'],
+    }
+  );
 }
 
 function lifecycleWorktreePath(
@@ -1398,9 +1401,13 @@ function lifecycleWorktreePath(
   if (typeof cwd === 'string' && cwd.trim()) {
     return path.resolve(cwd);
   }
-  gatewayInvalid(commandName, 'worktreePath, local environment.benchId, or environment.cwd is required', {
-    required: ['worktreePath', 'environment.benchId', 'environment.cwd'],
-  });
+  gatewayInvalid(
+    commandName,
+    'worktreePath, local environment.benchId, or environment.cwd is required',
+    {
+      required: ['worktreePath', 'environment.benchId', 'environment.cwd'],
+    }
+  );
 }
 
 function parseLifecycleInput(
@@ -1664,17 +1671,25 @@ async function runGatewayWorktreeCleanup(
   const repoPath = lifecycleRepoPath(commandName, input);
   const worktreePath = lifecycleWorktreePath(commandName, input);
   const force = input['force'] === true;
-  const confirmationToken = input['confirmationToken'];
-  const hasConfirmation =
-    typeof confirmationToken === 'string' && confirmationToken.trim().length > 0;
+  const confirmationToken =
+    typeof input['confirmationToken'] === 'string'
+      ? input['confirmationToken'].trim()
+      : '';
+  const hasConfirmation = confirmationToken.length > 0;
   const statusInput: GatewayLifecycleInput = { worktreePath };
   if (input.environment) statusInput.environment = input.environment;
   const status = await runGatewayWorktreeStatus(commandName, statusInput);
   const activeSessions = Array.isArray(status['activeSessions'])
-    ? status['activeSessions'].filter((id): id is string => typeof id === 'string')
+    ? status['activeSessions'].filter(
+        (id): id is string => typeof id === 'string'
+      )
     : [];
   const hasUncommittedChanges = status['hasUncommittedChanges'] === true;
-  if ((activeSessions.length > 0 || hasUncommittedChanges) && !force && !hasConfirmation) {
+  if (
+    (activeSessions.length > 0 || hasUncommittedChanges) &&
+    !force &&
+    !hasConfirmation
+  ) {
     printGatewayEnvelope(
       gatewayError(commandName, {
         code: 'CONFIRMATION_REQUIRED',
@@ -1700,7 +1715,13 @@ async function runGatewayWorktreeCleanup(
       force: force || hasConfirmation,
       deleteBranch,
     },
-    capabilities: ['session:read', 'session:control:kill', 'rpc:git:read', 'rpc:git:write'],
+    ...(hasConfirmation ? { confirmationToken } : {}),
+    capabilities: [
+      'session:read',
+      'session:control:kill',
+      'rpc:git:read',
+      'rpc:git:write',
+    ],
   });
   const data = isGatewayRecord(result) ? result : {};
   const branchDeleted = data['branchDeleted'] === true;
@@ -1751,7 +1772,10 @@ async function runGatewayWorktrees(gatewayArgs: string[]): Promise<never> {
     await runGatewayWorktreeCleanup('worktrees.delete', input);
   }
   if (subcommand === 'archive') {
-    const input = parseLifecycleInput('worktrees.archive', gatewayArgs.slice(2));
+    const input = parseLifecycleInput(
+      'worktrees.archive',
+      gatewayArgs.slice(2)
+    );
     await runGatewayWorktreeCleanup('worktrees.archive', input);
   }
   gatewayInvalid('worktrees.status', 'unknown worktrees command', {

--- a/bin/relay-ide.ts
+++ b/bin/relay-ide.ts
@@ -1306,13 +1306,14 @@ type GatewayLifecycleInput = Record<string, unknown> & {
 };
 
 function gatewayLifecycleEnvironment(
+  commandName: RelayCliGatewayCommand,
   input: Record<string, unknown>
 ): Record<string, unknown> | undefined {
   const environment = input['environment'];
   if (environment === undefined) return undefined;
   if (!isGatewayRecord(environment)) {
     gatewayInvalid(
-      'worktrees.status',
+      commandName,
       'environment must be an object when provided'
     );
   }
@@ -1407,7 +1408,7 @@ function parseLifecycleInput(
   commandArgs: string[]
 ): GatewayLifecycleInput {
   const input = parseGatewayInputObject(commandName, commandArgs);
-  const environment = gatewayLifecycleEnvironment(input);
+  const environment = gatewayLifecycleEnvironment(commandName, input);
   const lifecycleInput: GatewayLifecycleInput = { ...input };
   if (environment) lifecycleInput.environment = environment;
   return lifecycleInput;
@@ -1702,15 +1703,18 @@ async function runGatewayWorktreeCleanup(
     capabilities: ['session:read', 'session:control:kill', 'rpc:git:read', 'rpc:git:write'],
   });
   const data = isGatewayRecord(result) ? result : {};
+  const branchDeleted = data['branchDeleted'] === true;
   printGatewayEnvelope(
     gatewayOk(commandName, {
       ok: true,
       action: commandName === 'worktrees.delete' ? 'delete' : 'archive',
-      branchDeleted: data['branchDeleted'] === true,
+      branchDeleted,
       audit: {
         repoPath,
         worktreePath,
         force: force || hasConfirmation,
+        deleteBranch,
+        branchDeleted,
       },
     }),
     0

--- a/server/index.ts
+++ b/server/index.ts
@@ -1629,7 +1629,8 @@ async function main(): Promise<void> {
       const directBody = isRecord(body) ? body : {};
       if (Object.prototype.hasOwnProperty.call(directBody, 'useTmux')) {
         res.status(400).json({
-          error: 'legacy useTmux request flag is no longer supported; use terminalBackend',
+          error:
+            'legacy useTmux request flag is no longer supported; use terminalBackend',
         });
         return null;
       }
@@ -1763,7 +1764,11 @@ async function main(): Promise<void> {
     res.status(401).json(auth.cliGatewayOrBrowserAuthRequiredChallenge());
   };
 
-  const requireCliGatewayWriteAuth: express.RequestHandler = (req, res, next) => {
+  const requireCliGatewayWriteAuth: express.RequestHandler = (
+    req,
+    res,
+    next
+  ) => {
     if (isCliGatewayActorTokenRequest(req)) {
       res.status(403).json({
         error: 'Forbidden',
@@ -3305,6 +3310,16 @@ async function main(): Promise<void> {
 
   // GET /worktrees/status — pre-cleanup checks for a worktree
   app.get('/worktrees/status', requireCliGatewayAuth, async (req, res) => {
+    if (isCliGatewayActorTokenRequest(req)) {
+      res.status(403).json({
+        error: 'Forbidden',
+        code: 'CLI_GATEWAY_ACTOR_WORKTREE_STATUS_UNSUPPORTED',
+        message:
+          'CLI actor credentials cannot read arbitrary worktree status until repo/worktree-scoped actor tokens are supported.',
+      });
+      return;
+    }
+
     const worktreePath =
       typeof req.query.path === 'string' ? req.query.path : undefined;
     if (!worktreePath) {
@@ -4060,7 +4075,10 @@ async function main(): Promise<void> {
 
   // DELETE /sessions/:id
   app.delete('/sessions/:id', requireAuth, (req, res) => {
-    const decision = capabilityDecisionFromRequest(req, CONTROL_KILL_CAPABILITY);
+    const decision = capabilityDecisionFromRequest(
+      req,
+      CONTROL_KILL_CAPABILITY
+    );
     if (decision.decision !== 'allow') {
       const error = capabilityError(decision);
       res.status(sessionControlErrorStatus(error)).json({ error });

--- a/server/index.ts
+++ b/server/index.ts
@@ -1841,6 +1841,19 @@ async function main(): Promise<void> {
     res.status(401).json(auth.cliGatewayOrBrowserAuthRequiredChallenge());
   };
 
+  const requireCliGatewayWriteAuth: express.RequestHandler = (req, res, next) => {
+    if (isCliGatewayActorTokenRequest(req)) {
+      res.status(403).json({
+        error: 'Forbidden',
+        code: 'CLI_GATEWAY_ACTOR_WRITE_UNSUPPORTED',
+        message:
+          'CLI actor credentials are read-only in this slice; use browser or scoped gateway auth for lifecycle mutations.',
+      });
+      return;
+    }
+    requireCliGatewayAuth(req, res, next);
+  };
+
   const requireScopedSessionAuth: express.RequestHandler = (req, res, next) => {
     if (isCliGatewayActorTokenRequest(req)) {
       const id = req.params['id'];
@@ -2420,7 +2433,7 @@ async function main(): Promise<void> {
       });
     },
   });
-  app.use('/workspaces', requireAuth, workspaceRouter);
+  app.use('/workspaces', requireCliGatewayWriteAuth, workspaceRouter);
 
   // Mount git (local/fast) and gh (network/slow) routers
   app.use(
@@ -2441,7 +2454,7 @@ async function main(): Promise<void> {
   // Mount workspace-groups CRUD router
   app.use(
     '/workspace-groups',
-    createWorkspaceGroupsRouter(CONFIG_PATH, requireAuth, {
+    createWorkspaceGroupsRouter(CONFIG_PATH, requireCliGatewayWriteAuth, {
       sessions,
       gitWatcher,
       configPath: CONFIG_PATH,
@@ -3369,7 +3382,7 @@ async function main(): Promise<void> {
   });
 
   // GET /worktrees/status — pre-cleanup checks for a worktree
-  app.get('/worktrees/status', requireAuth, async (req, res) => {
+  app.get('/worktrees/status', requireCliGatewayAuth, async (req, res) => {
     const worktreePath =
       typeof req.query.path === 'string' ? req.query.path : undefined;
     if (!worktreePath) {
@@ -3737,11 +3750,12 @@ async function main(): Promise<void> {
   });
 
   // DELETE /worktrees — remove a worktree, prune, and delete its branch
-  app.delete('/worktrees', requireAuth, async (req, res) => {
-    const { worktreePath, repoPath, force } = req.body as {
+  app.delete('/worktrees', requireCliGatewayWriteAuth, async (req, res) => {
+    const { worktreePath, repoPath, force, deleteBranch } = req.body as {
       worktreePath?: string;
       repoPath?: string;
       force?: boolean;
+      deleteBranch?: boolean;
     };
     if (!worktreePath || !repoPath) {
       res.status(400).json({ error: 'worktreePath and repoPath are required' });
@@ -3806,7 +3820,8 @@ async function main(): Promise<void> {
       // Non-fatal: prune failure doesn't block success
     }
 
-    if (branchName) {
+    const shouldDeleteBranch = deleteBranch !== false;
+    if (shouldDeleteBranch && branchName) {
       try {
         // Delete the branch
         await execFileAsync('git', ['branch', '-D', branchName], {

--- a/server/index.ts
+++ b/server/index.ts
@@ -3729,7 +3729,8 @@ async function main(): Promise<void> {
     const removeErr = await removeWorktreeFromDisk(
       worktreePath,
       repoPath,
-      force ?? false
+      force ?? false,
+      validation.deleteProof
     );
     if (removeErr) {
       res.status(500).json({ error: removeErr });

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,7 +15,6 @@ import {
   loadConfig,
   saveConfig,
   DEFAULTS,
-  readMeta,
   writeMeta,
   deleteMeta,
   ensureMetaDir,
@@ -44,6 +43,11 @@ import {
   GitWatcher,
   parseAllWorktrees,
 } from './watcher.js';
+import {
+  deleteLocalWorktreeBranch,
+  removeWorktreeFromDisk,
+  validateWorktreeForDelete,
+} from './worktree-cleanup.js';
 import { isInstalled as serviceIsInstalled } from './service.js';
 import { extensionForMime, setClipboardImage } from './clipboard.js';
 import { createGitRouter } from './git-routes.js';
@@ -555,64 +559,6 @@ function buildTicketInitialPrompt(
     .replace(/\{description\}/g, ticketContext.description ?? '');
 }
 
-type WorktreeValidationError = {
-  status: number;
-  error: string;
-  sessionIds?: string[];
-};
-
-/** Validates that a worktree can be deleted. Returns an error descriptor or null. */
-async function validateWorktreeForDelete(
-  worktreePath: string,
-  repoPath: string,
-  force: boolean,
-  activeSessions: string[]
-): Promise<WorktreeValidationError | null> {
-  try {
-    const { stdout: wtListOut } = await execFileAsync(
-      'git',
-      ['worktree', 'list', '--porcelain'],
-      { cwd: repoPath }
-    );
-    const allWorktrees = parseAllWorktrees(wtListOut, repoPath);
-    const isKnownWorktree = allWorktrees.some(
-      (wt) => wt.path === path.resolve(worktreePath) && !wt.isMain
-    );
-    if (!isKnownWorktree) {
-      if (!fs.existsSync(worktreePath)) {
-        return {
-          status: 404,
-          error: 'Worktree not found — may have been already cleaned up',
-        };
-      }
-      return { status: 400, error: 'Path is not a recognized git worktree' };
-    }
-  } catch (err) {
-    logger.warn(
-      '[worktrees/delete] git worktree list failed for',
-      repoPath,
-      err instanceof Error ? err.message : err
-    );
-    if (!force) {
-      return {
-        status: 500,
-        error:
-          'Cannot verify worktree — git worktree list failed. Use force: true to delete anyway.',
-      };
-    }
-  }
-
-  if (activeSessions.length > 0 && !force) {
-    return {
-      status: 409,
-      error: 'active_sessions',
-      sessionIds: activeSessions,
-    };
-  }
-
-  return null;
-}
-
 /**
  * Clamps a terminal dimension (cols or rows) to a valid range.
  * Returns the rounded value if valid, or undefined if invalid/unset.
@@ -731,30 +677,6 @@ function resolveContinuePolicy(
   if (explicitContinuePolicy !== undefined) return explicitContinuePolicy;
   if (explicitContinue === undefined) return undefined;
   return explicitContinue ? 'always' : 'never';
-}
-
-/** Removes a worktree from disk, falling back to rmSync if git fails. Returns error string or null. */
-async function removeWorktreeFromDisk(
-  worktreePath: string,
-  repoPath: string,
-  force: boolean
-): Promise<string | null> {
-  try {
-    const removeArgs = force
-      ? ['worktree', 'remove', '--force', worktreePath]
-      : ['worktree', 'remove', worktreePath];
-    await execFileAsync('git', removeArgs, { cwd: repoPath });
-  } catch {
-    if (fs.existsSync(worktreePath)) {
-      try {
-        fs.rmSync(worktreePath, { recursive: true });
-      } catch (rmErr: unknown) {
-        return execErrorMessage(rmErr, 'Failed to remove worktree directory');
-      }
-    }
-    // directory already gone — that's fine, continue to cleanup
-  }
-  return null;
 }
 
 type AgentSessionParams = {
@@ -3768,17 +3690,21 @@ async function main(): Promise<void> {
       .filter((s) => s.worktreePath === resolvedPath || s.cwd === resolvedPath)
       .map((s) => s.id);
 
-    const validationErr = await validateWorktreeForDelete(
+    const validation = await validateWorktreeForDelete(
       worktreePath,
       repoPath,
       force ?? false,
       worktreeSessions
     );
-    if (validationErr) {
+    if (!validation.ok) {
+      const validationErr = validation.error;
       res.status(validationErr.status).json({
         error: validationErr.error,
         ...(validationErr.sessionIds && {
           sessionIds: validationErr.sessionIds,
+        }),
+        ...(validationErr.hasUncommittedChanges !== undefined && {
+          hasUncommittedChanges: validationErr.hasUncommittedChanges,
         }),
       });
       return;
@@ -3798,10 +3724,7 @@ async function main(): Promise<void> {
       }
     }
 
-    // Derive branch name from metadata or worktree directory name
-    const meta = readMeta(CONFIG_PATH, worktreePath);
-    const branchName =
-      (meta && meta.branchName) || worktreePath.split('/').pop() || '';
+    const branchName = validation.branchName;
 
     const removeErr = await removeWorktreeFromDisk(
       worktreePath,
@@ -3821,16 +3744,9 @@ async function main(): Promise<void> {
     }
 
     const shouldDeleteBranch = deleteBranch !== false;
-    if (shouldDeleteBranch && branchName) {
-      try {
-        // Delete the branch
-        await execFileAsync('git', ['branch', '-D', branchName], {
-          cwd: repoPath,
-        });
-      } catch (_) {
-        // Non-fatal: branch may not exist or may be checked out elsewhere
-      }
-    }
+    const branchDeleted = shouldDeleteBranch
+      ? await deleteLocalWorktreeBranch(repoPath, branchName)
+      : false;
 
     try {
       getDefaultAllocator().releasePortsForWorktree(repoPath, resolvedPath);
@@ -3848,7 +3764,7 @@ async function main(): Promise<void> {
     // Broadcast worktrees-changed so all clients refresh
     broadcastEvent('worktrees-changed');
 
-    res.json({ ok: true });
+    res.json({ ok: true, branchDeleted });
   });
 
   // POST /sessions — unified endpoint for agent and terminal sessions

--- a/server/worktree-cleanup.ts
+++ b/server/worktree-cleanup.ts
@@ -8,6 +8,13 @@ import { parseAllWorktrees } from './watcher.js';
 const execFileAsync = promisify(execFile);
 const logger = createLogger('worktree-cleanup');
 
+const gitChildEnv: NodeJS.ProcessEnv = {
+  ...process.env,
+  GIT_DIR: undefined,
+  GIT_WORK_TREE: undefined,
+  GIT_COMMON_DIR: undefined,
+};
+
 export type WorktreeValidationError = {
   status: number;
   error: string;
@@ -15,8 +22,20 @@ export type WorktreeValidationError = {
   hasUncommittedChanges?: boolean;
 };
 
+export type WorktreeDeleteProof = {
+  readonly repoPath: string;
+  readonly worktreePath: string;
+  readonly branchName: string;
+  readonly recognizedNonMainWorktree: true;
+};
+
 export type WorktreeValidationResult =
-  | { ok: true; branchName: string; hasUncommittedChanges: boolean }
+  | {
+      ok: true;
+      branchName: string;
+      hasUncommittedChanges: boolean;
+      deleteProof: WorktreeDeleteProof;
+    }
   | { ok: false; error: WorktreeValidationError };
 
 function execErrorMessage(err: unknown, fallback: string): string {
@@ -27,9 +46,46 @@ function execErrorMessage(err: unknown, fallback: string): string {
 async function hasDirtyWorktree(worktreePath: string): Promise<boolean> {
   const { stdout } = await execFileAsync('git', ['status', '--porcelain'], {
     cwd: path.resolve(worktreePath),
+    env: gitChildEnv,
     timeout: 5000,
   });
   return stdout.trim().length > 0;
+}
+
+async function proveRecognizedNonMainWorktree(
+  worktreePath: string,
+  repoPath: string
+): Promise<WorktreeDeleteProof | null> {
+  const resolvedWorktreePath = path.resolve(worktreePath);
+  const resolvedRepoPath = path.resolve(repoPath);
+  const { stdout: wtListOut } = await execFileAsync(
+    'git',
+    ['worktree', 'list', '--porcelain'],
+    { cwd: resolvedRepoPath, env: gitChildEnv }
+  );
+  const allWorktrees = parseAllWorktrees(wtListOut, resolvedRepoPath);
+  const worktree = allWorktrees.find(
+    (wt) => path.resolve(wt.path) === resolvedWorktreePath && !wt.isMain
+  );
+  if (!worktree) return null;
+  return {
+    repoPath: resolvedRepoPath,
+    worktreePath: resolvedWorktreePath,
+    branchName: worktree.branch,
+    recognizedNonMainWorktree: true,
+  };
+}
+
+function proofMatchesRequest(
+  proof: WorktreeDeleteProof,
+  worktreePath: string,
+  repoPath: string
+): boolean {
+  return (
+    proof.recognizedNonMainWorktree === true &&
+    proof.worktreePath === path.resolve(worktreePath) &&
+    proof.repoPath === path.resolve(repoPath)
+  );
 }
 
 /** Validates that a worktree can be deleted and returns the branch checked out there. */
@@ -40,19 +96,11 @@ export async function validateWorktreeForDelete(
   activeSessions: string[]
 ): Promise<WorktreeValidationResult> {
   const resolvedWorktreePath = path.resolve(worktreePath);
-  let branchName = '';
+  let deleteProof: WorktreeDeleteProof;
 
   try {
-    const { stdout: wtListOut } = await execFileAsync(
-      'git',
-      ['worktree', 'list', '--porcelain'],
-      { cwd: repoPath }
-    );
-    const allWorktrees = parseAllWorktrees(wtListOut, repoPath);
-    const worktree = allWorktrees.find(
-      (wt) => wt.path === resolvedWorktreePath && !wt.isMain
-    );
-    if (!worktree) {
+    const proof = await proveRecognizedNonMainWorktree(worktreePath, repoPath);
+    if (!proof) {
       if (!fs.existsSync(resolvedWorktreePath)) {
         return {
           ok: false,
@@ -67,23 +115,20 @@ export async function validateWorktreeForDelete(
         error: { status: 400, error: 'Path is not a recognized git worktree' },
       };
     }
-    branchName = worktree.branch;
+    deleteProof = proof;
   } catch (err) {
     logger.warn(
       '[worktrees/delete] git worktree list failed for',
       repoPath,
       err instanceof Error ? err.message : err
     );
-    if (!force) {
-      return {
-        ok: false,
-        error: {
-          status: 500,
-          error:
-            'Cannot verify worktree — git worktree list failed. Use force: true to delete anyway.',
-        },
-      };
-    }
+    return {
+      ok: false,
+      error: {
+        status: 500,
+        error: 'Cannot verify worktree — git worktree list failed.',
+      },
+    };
   }
 
   if (activeSessions.length > 0 && !force) {
@@ -130,20 +175,50 @@ export async function validateWorktreeForDelete(
     };
   }
 
-  return { ok: true, branchName, hasUncommittedChanges };
+  return {
+    ok: true,
+    branchName: deleteProof.branchName,
+    hasUncommittedChanges,
+    deleteProof,
+  };
 }
 
-/** Removes a worktree from disk. Fallback directory deletion is force-only. */
+/** Removes a worktree from disk. Fallback directory deletion is force-only and proof-gated. */
 export async function removeWorktreeFromDisk(
   worktreePath: string,
   repoPath: string,
-  force: boolean
+  force: boolean,
+  deleteProof: WorktreeDeleteProof
 ): Promise<string | null> {
+  if (!proofMatchesRequest(deleteProof, worktreePath, repoPath)) {
+    return 'Cannot remove worktree — deletion proof does not match requested path';
+  }
+  try {
+    const freshProof = await proveRecognizedNonMainWorktree(
+      worktreePath,
+      repoPath
+    );
+    if (
+      !freshProof ||
+      freshProof.branchName !== deleteProof.branchName ||
+      !proofMatchesRequest(freshProof, worktreePath, repoPath)
+    ) {
+      return 'Cannot remove worktree — path is not a recognized non-main git worktree';
+    }
+  } catch (err) {
+    logger.warn(
+      '[worktrees/delete] git worktree list failed before removal for',
+      repoPath,
+      err instanceof Error ? err.message : err
+    );
+    return 'Cannot remove worktree — git worktree list failed';
+  }
+
   try {
     const removeArgs = force
       ? ['worktree', 'remove', '--force', worktreePath]
       : ['worktree', 'remove', worktreePath];
-    await execFileAsync('git', removeArgs, { cwd: repoPath });
+    await execFileAsync('git', removeArgs, { cwd: repoPath, env: gitChildEnv });
   } catch (err) {
     if (!force) {
       return execErrorMessage(err, 'Failed to remove worktree');
@@ -166,7 +241,10 @@ export async function deleteLocalWorktreeBranch(
 ): Promise<boolean> {
   if (!branchName) return false;
   try {
-    await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath });
+    await execFileAsync('git', ['branch', '-D', branchName], {
+      cwd: repoPath,
+      env: gitChildEnv,
+    });
     return true;
   } catch {
     return false;

--- a/server/worktree-cleanup.ts
+++ b/server/worktree-cleanup.ts
@@ -1,0 +1,174 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createLogger } from './logger.js';
+import { parseAllWorktrees } from './watcher.js';
+
+const execFileAsync = promisify(execFile);
+const logger = createLogger('worktree-cleanup');
+
+export type WorktreeValidationError = {
+  status: number;
+  error: string;
+  sessionIds?: string[];
+  hasUncommittedChanges?: boolean;
+};
+
+export type WorktreeValidationResult =
+  | { ok: true; branchName: string; hasUncommittedChanges: boolean }
+  | { ok: false; error: WorktreeValidationError };
+
+function execErrorMessage(err: unknown, fallback: string): string {
+  const e = err as { stderr?: string; message?: string };
+  return (e.stderr || e.message || fallback).trim();
+}
+
+async function hasDirtyWorktree(worktreePath: string): Promise<boolean> {
+  const { stdout } = await execFileAsync('git', ['status', '--porcelain'], {
+    cwd: path.resolve(worktreePath),
+    timeout: 5000,
+  });
+  return stdout.trim().length > 0;
+}
+
+/** Validates that a worktree can be deleted and returns the branch checked out there. */
+export async function validateWorktreeForDelete(
+  worktreePath: string,
+  repoPath: string,
+  force: boolean,
+  activeSessions: string[]
+): Promise<WorktreeValidationResult> {
+  const resolvedWorktreePath = path.resolve(worktreePath);
+  let branchName = '';
+
+  try {
+    const { stdout: wtListOut } = await execFileAsync(
+      'git',
+      ['worktree', 'list', '--porcelain'],
+      { cwd: repoPath }
+    );
+    const allWorktrees = parseAllWorktrees(wtListOut, repoPath);
+    const worktree = allWorktrees.find(
+      (wt) => wt.path === resolvedWorktreePath && !wt.isMain
+    );
+    if (!worktree) {
+      if (!fs.existsSync(resolvedWorktreePath)) {
+        return {
+          ok: false,
+          error: {
+            status: 404,
+            error: 'Worktree not found — may have been already cleaned up',
+          },
+        };
+      }
+      return {
+        ok: false,
+        error: { status: 400, error: 'Path is not a recognized git worktree' },
+      };
+    }
+    branchName = worktree.branch;
+  } catch (err) {
+    logger.warn(
+      '[worktrees/delete] git worktree list failed for',
+      repoPath,
+      err instanceof Error ? err.message : err
+    );
+    if (!force) {
+      return {
+        ok: false,
+        error: {
+          status: 500,
+          error:
+            'Cannot verify worktree — git worktree list failed. Use force: true to delete anyway.',
+        },
+      };
+    }
+  }
+
+  if (activeSessions.length > 0 && !force) {
+    return {
+      ok: false,
+      error: {
+        status: 409,
+        error: 'active_sessions',
+        sessionIds: activeSessions,
+      },
+    };
+  }
+
+  let hasUncommittedChanges = true;
+  try {
+    hasUncommittedChanges = await hasDirtyWorktree(resolvedWorktreePath);
+  } catch (err) {
+    logger.warn(
+      '[worktrees/delete] git status failed for',
+      resolvedWorktreePath,
+      err instanceof Error ? err.message : err
+    );
+    if (!force) {
+      return {
+        ok: false,
+        error: {
+          status: 500,
+          error:
+            'Cannot verify worktree cleanliness — git status failed. Use force: true to delete anyway.',
+          hasUncommittedChanges: true,
+        },
+      };
+    }
+  }
+
+  if (hasUncommittedChanges && !force) {
+    return {
+      ok: false,
+      error: {
+        status: 409,
+        error: 'uncommitted_changes',
+        hasUncommittedChanges: true,
+      },
+    };
+  }
+
+  return { ok: true, branchName, hasUncommittedChanges };
+}
+
+/** Removes a worktree from disk. Fallback directory deletion is force-only. */
+export async function removeWorktreeFromDisk(
+  worktreePath: string,
+  repoPath: string,
+  force: boolean
+): Promise<string | null> {
+  try {
+    const removeArgs = force
+      ? ['worktree', 'remove', '--force', worktreePath]
+      : ['worktree', 'remove', worktreePath];
+    await execFileAsync('git', removeArgs, { cwd: repoPath });
+  } catch (err) {
+    if (!force) {
+      return execErrorMessage(err, 'Failed to remove worktree');
+    }
+    if (fs.existsSync(worktreePath)) {
+      try {
+        fs.rmSync(worktreePath, { recursive: true, force: true });
+      } catch (rmErr: unknown) {
+        return execErrorMessage(rmErr, 'Failed to remove worktree directory');
+      }
+    }
+    // directory already gone — that's fine, continue to cleanup
+  }
+  return null;
+}
+
+export async function deleteLocalWorktreeBranch(
+  repoPath: string,
+  branchName: string
+): Promise<boolean> {
+  if (!branchName) return false;
+  try {
+    await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -751,23 +751,28 @@ const lifecycleEnvironmentSchema: RelayJsonSchema = {
   properties: {
     nodeId: {
       type: 'string',
-      description: 'Target Relay node id. v1 local lifecycle writes are supported only for the local node; remote nodes fail closed as UNSUPPORTED/NODE_OFFLINE until routed node worktree mutation support exists.',
+      description:
+        'Target Relay node id. v1 local lifecycle writes are supported only for the local node; remote nodes fail closed as UNSUPPORTED/NODE_OFFLINE until routed node worktree mutation support exists.',
     },
     repoIdentity: {
       type: ['string', 'null'],
-      description: 'Canonical normalized repo identity for audit/discovery. Path resolution prefers repoInstanceId over this identity in v1 local commands.',
+      description:
+        'Canonical normalized repo identity for audit/discovery. Path resolution prefers repoInstanceId over this identity in v1 local commands.',
     },
     repoInstanceId: {
       type: 'string',
-      description: 'Scoped RepoInstanceId, usually createRepoInstanceId(nodeId, localPath). Used instead of browser active repo state.',
+      description:
+        'Scoped RepoInstanceId, usually createRepoInstanceId(nodeId, localPath). Used instead of browser active repo state.',
     },
     benchId: {
       type: 'string',
-      description: 'Scoped WorktreeInstanceId, usually createWorktreeInstanceId(nodeId, localPath). Used for worktree status/delete/archive compatibility with path input.',
+      description:
+        'Scoped WorktreeInstanceId, usually createWorktreeInstanceId(nodeId, localPath). Used for worktree status/delete/archive compatibility with path input.',
     },
     cwd: {
       type: 'string',
-      description: 'Absolute cwd on the target node. Accepted for status/preflight compatibility when benchId is unavailable.',
+      description:
+        'Absolute cwd on the target node. Accepted for status/preflight compatibility when benchId is unavailable.',
     },
   },
 };
@@ -807,14 +812,28 @@ const worktreeCreateInputSchema: RelayJsonSchema = {
     environment: lifecycleEnvironmentSchema,
     repoPath: {
       ...stringSchema,
-      description: 'Compatibility path for the local repo checkout. Prefer environment.repoInstanceId when available.',
+      description:
+        'Compatibility path for the local repo checkout. Prefer environment.repoInstanceId when available.',
     },
     branch: {
       ...stringSchema,
-      description: 'Existing branch to check out into a worktree. Omit to create the next Relay-generated branch/mountain worktree.',
+      description:
+        'Existing branch to check out into a worktree. Omit to create the next Relay-generated branch/mountain worktree.',
     },
     confirmationToken: stringSchema,
   },
+  anyOf: [
+    { required: ['repoPath'] },
+    {
+      required: ['environment'],
+      properties: {
+        environment: {
+          ...lifecycleEnvironmentSchema,
+          required: ['repoInstanceId'],
+        },
+      },
+    },
+  ],
 };
 
 const worktreeStatusInputSchema: RelayJsonSchema = {
@@ -825,9 +844,25 @@ const worktreeStatusInputSchema: RelayJsonSchema = {
     environment: lifecycleEnvironmentSchema,
     worktreePath: {
       ...stringSchema,
-      description: 'Compatibility local worktree path. Prefer environment.benchId when available.',
+      description:
+        'Compatibility local worktree path. Prefer environment.benchId when available.',
     },
   },
+  anyOf: [
+    { required: ['worktreePath'] },
+    {
+      required: ['environment'],
+      properties: {
+        environment: { ...lifecycleEnvironmentSchema, required: ['benchId'] },
+      },
+    },
+    {
+      required: ['environment'],
+      properties: {
+        environment: { ...lifecycleEnvironmentSchema, required: ['cwd'] },
+      },
+    },
+  ],
 };
 
 const worktreeDeleteInputSchema: RelayJsonSchema = {
@@ -838,15 +873,59 @@ const worktreeDeleteInputSchema: RelayJsonSchema = {
     environment: lifecycleEnvironmentSchema,
     repoPath: {
       ...stringSchema,
-      description: 'Compatibility local repo checkout path. Prefer environment.repoInstanceId when available.',
+      description:
+        'Compatibility local repo checkout path. Prefer environment.repoInstanceId when available.',
     },
     worktreePath: {
       ...stringSchema,
-      description: 'Compatibility local worktree path. Prefer environment.benchId when available.',
+      description:
+        'Compatibility local worktree path. Prefer environment.benchId when available.',
     },
     force: booleanSchema,
     confirmationToken: stringSchema,
   },
+  anyOf: [
+    { required: ['repoPath', 'worktreePath'] },
+    {
+      required: ['repoPath', 'environment'],
+      properties: {
+        environment: { ...lifecycleEnvironmentSchema, required: ['benchId'] },
+      },
+    },
+    {
+      required: ['repoPath', 'environment'],
+      properties: {
+        environment: { ...lifecycleEnvironmentSchema, required: ['cwd'] },
+      },
+    },
+    {
+      required: ['worktreePath', 'environment'],
+      properties: {
+        environment: {
+          ...lifecycleEnvironmentSchema,
+          required: ['repoInstanceId'],
+        },
+      },
+    },
+    {
+      required: ['environment'],
+      properties: {
+        environment: {
+          ...lifecycleEnvironmentSchema,
+          required: ['repoInstanceId', 'benchId'],
+        },
+      },
+    },
+    {
+      required: ['environment'],
+      properties: {
+        environment: {
+          ...lifecycleEnvironmentSchema,
+          required: ['repoInstanceId', 'cwd'],
+        },
+      },
+    },
+  ],
 };
 
 const repoDescriptorSchema: RelayJsonSchema = {
@@ -1993,7 +2072,15 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'repos.add',
-    cli: ['relay-ide', 'v1', 'repos', 'add', '--input-json', '<json>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'repos',
+      'add',
+      '--input-json',
+      '<json>',
+      '--json',
+    ],
     summary:
       'Add a local repo/workspace path to Relay without relying on browser active repo state.',
     stable: true,
@@ -2013,7 +2100,15 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'workspaces.launch',
-    cli: ['relay-ide', 'v1', 'workspaces', 'launch', '--input-json', '<json>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'workspaces',
+      'launch',
+      '--input-json',
+      '<json>',
+      '--json',
+    ],
     summary:
       'Launch an agent session for a configured workspace group using its typed workspace id.',
     stable: true,
@@ -2034,7 +2129,15 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'worktrees.create',
-    cli: ['relay-ide', 'v1', 'worktrees', 'create', '--input-json', '<json>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'worktrees',
+      'create',
+      '--input-json',
+      '<json>',
+      '--json',
+    ],
     summary:
       'Create or reuse a local git worktree for a repo instance; remote node writes fail closed until node capability support exists.',
     stable: true,
@@ -2057,7 +2160,15 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'worktrees.status',
-    cli: ['relay-ide', 'v1', 'worktrees', 'status', '--input-json', '<json>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'worktrees',
+      'status',
+      '--input-json',
+      '<json>',
+      '--json',
+    ],
     summary:
       'Preflight a worktree before cleanup, returning active session ids and dirty-worktree state.',
     stable: true,
@@ -2080,13 +2191,26 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'worktrees.delete',
-    cli: ['relay-ide', 'v1', 'worktrees', 'delete', '--input-json', '<json>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'worktrees',
+      'delete',
+      '--input-json',
+      '<json>',
+      '--json',
+    ],
     summary:
       'Delete a local git worktree and its branch after fail-closed dirty/session/main-worktree checks.',
     stable: true,
     transport: 'hub-http-or-node-rpc',
     requiresAuth: true,
-    capabilityHints: ['session:read', 'session:control:kill', 'rpc:git:read', 'rpc:git:write'],
+    capabilityHints: [
+      'session:read',
+      'session:control:kill',
+      'rpc:git:read',
+      'rpc:git:write',
+    ],
     inputSchema: worktreeDeleteInputSchema,
     outputSchema: okOutput('WorktreesDeleteOutput', worktreeDeleteOutputSchema),
     errorCodes: [
@@ -2105,15 +2229,31 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
   },
   {
     name: 'worktrees.archive',
-    cli: ['relay-ide', 'v1', 'worktrees', 'archive', '--input-json', '<json>', '--json'],
+    cli: [
+      'relay-ide',
+      'v1',
+      'worktrees',
+      'archive',
+      '--input-json',
+      '<json>',
+      '--json',
+    ],
     summary:
       'Archive/remove a local git worktree while preserving its branch, with the same fail-closed preflight checks as delete.',
     stable: true,
     transport: 'hub-http-or-node-rpc',
     requiresAuth: true,
-    capabilityHints: ['session:read', 'session:control:kill', 'rpc:git:read', 'rpc:git:write'],
+    capabilityHints: [
+      'session:read',
+      'session:control:kill',
+      'rpc:git:read',
+      'rpc:git:write',
+    ],
     inputSchema: worktreeDeleteInputSchema,
-    outputSchema: okOutput('WorktreesArchiveOutput', worktreeDeleteOutputSchema),
+    outputSchema: okOutput(
+      'WorktreesArchiveOutput',
+      worktreeDeleteOutputSchema
+    ),
     errorCodes: [
       'UNAUTHORIZED',
       'INVALID_ARGUMENT',

--- a/shared/cli-gateway-contract.ts
+++ b/shared/cli-gateway-contract.ts
@@ -13,6 +13,12 @@ export type RelayCliGatewayCommand =
   | 'contract.schema'
   | 'nodes.manifest'
   | 'nodes.list'
+  | 'repos.add'
+  | 'workspaces.launch'
+  | 'worktrees.create'
+  | 'worktrees.status'
+  | 'worktrees.delete'
+  | 'worktrees.archive'
   | 'sessions.list'
   | 'sessions.get'
   | 'sessions.create'
@@ -736,6 +742,167 @@ const createSessionInputSchema: RelayJsonSchema = {
     expiresAt: { type: 'string', format: 'date-time' },
     confirmationToken: stringSchema,
   },
+};
+
+const lifecycleEnvironmentSchema: RelayJsonSchema = {
+  title: 'LifecycleEnvironment',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    nodeId: {
+      type: 'string',
+      description: 'Target Relay node id. v1 local lifecycle writes are supported only for the local node; remote nodes fail closed as UNSUPPORTED/NODE_OFFLINE until routed node worktree mutation support exists.',
+    },
+    repoIdentity: {
+      type: ['string', 'null'],
+      description: 'Canonical normalized repo identity for audit/discovery. Path resolution prefers repoInstanceId over this identity in v1 local commands.',
+    },
+    repoInstanceId: {
+      type: 'string',
+      description: 'Scoped RepoInstanceId, usually createRepoInstanceId(nodeId, localPath). Used instead of browser active repo state.',
+    },
+    benchId: {
+      type: 'string',
+      description: 'Scoped WorktreeInstanceId, usually createWorktreeInstanceId(nodeId, localPath). Used for worktree status/delete/archive compatibility with path input.',
+    },
+    cwd: {
+      type: 'string',
+      description: 'Absolute cwd on the target node. Accepted for status/preflight compatibility when benchId is unavailable.',
+    },
+  },
+};
+
+const repoAddInputSchema: RelayJsonSchema = {
+  title: 'ReposAddInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    path: stringSchema,
+    requireGitRepo: booleanSchema,
+  },
+  required: ['path'],
+};
+
+const workspaceLaunchInputSchema: RelayJsonSchema = {
+  title: 'WorkspaceLaunchInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    workspaceId: stringSchema,
+    agent: stringSchema,
+    yolo: booleanSchema,
+    terminalBackend: { type: 'string', enum: ['relay-pty', 'tmux-compat'] },
+    claudeArgs: { type: 'array', items: stringSchema },
+    cols: { type: 'number', minimum: 1, maximum: 500 },
+    rows: { type: 'number', minimum: 1, maximum: 200 },
+  },
+  required: ['workspaceId'],
+};
+
+const worktreeCreateInputSchema: RelayJsonSchema = {
+  title: 'WorktreeCreateInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    environment: lifecycleEnvironmentSchema,
+    repoPath: {
+      ...stringSchema,
+      description: 'Compatibility path for the local repo checkout. Prefer environment.repoInstanceId when available.',
+    },
+    branch: {
+      ...stringSchema,
+      description: 'Existing branch to check out into a worktree. Omit to create the next Relay-generated branch/mountain worktree.',
+    },
+    confirmationToken: stringSchema,
+  },
+};
+
+const worktreeStatusInputSchema: RelayJsonSchema = {
+  title: 'WorktreeStatusInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    environment: lifecycleEnvironmentSchema,
+    worktreePath: {
+      ...stringSchema,
+      description: 'Compatibility local worktree path. Prefer environment.benchId when available.',
+    },
+  },
+};
+
+const worktreeDeleteInputSchema: RelayJsonSchema = {
+  title: 'WorktreeDeleteInput',
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    environment: lifecycleEnvironmentSchema,
+    repoPath: {
+      ...stringSchema,
+      description: 'Compatibility local repo checkout path. Prefer environment.repoInstanceId when available.',
+    },
+    worktreePath: {
+      ...stringSchema,
+      description: 'Compatibility local worktree path. Prefer environment.benchId when available.',
+    },
+    force: booleanSchema,
+    confirmationToken: stringSchema,
+  },
+};
+
+const repoDescriptorSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: true,
+  properties: {
+    path: stringSchema,
+    name: stringSchema,
+    isGitRepo: booleanSchema,
+    kind: { type: 'string', enum: ['repo', 'directory'] },
+    nodeId: stringSchema,
+    repoIdentity: { type: ['string', 'null'] },
+    repoInstanceId: stringSchema,
+  },
+};
+
+const worktreeCreateOutputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    branchName: stringSchema,
+    mountainName: stringSchema,
+    worktreePath: stringSchema,
+    existing: booleanSchema,
+  },
+  required: ['branchName', 'worktreePath'],
+};
+
+const worktreeStatusOutputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    activeSessions: { type: 'array', items: stringSchema },
+    hasUncommittedChanges: booleanSchema,
+  },
+  required: ['activeSessions', 'hasUncommittedChanges'],
+};
+
+const worktreeDeleteOutputSchema: RelayJsonSchema = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    ok: booleanSchema,
+    action: { type: 'string', enum: ['delete', 'archive'] },
+    branchDeleted: booleanSchema,
+    audit: {
+      type: 'object',
+      additionalProperties: true,
+      properties: {
+        repoPath: stringSchema,
+        worktreePath: stringSchema,
+        force: booleanSchema,
+      },
+    },
+  },
+  required: ['ok', 'action', 'branchDeleted'],
 };
 
 const renewSessionInputSchema: RelayJsonSchema = {
@@ -1820,6 +1987,143 @@ const commandSpecs: readonly RelayCliGatewayCommandSpec[] = [
     errorCodes: [
       'UNAUTHORIZED',
       'INVALID_ARGUMENT',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'repos.add',
+    cli: ['relay-ide', 'v1', 'repos', 'add', '--input-json', '<json>', '--json'],
+    summary:
+      'Add a local repo/workspace path to Relay without relying on browser active repo state.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['rpc:git:read', 'rpc:git:write'],
+    inputSchema: repoAddInputSchema,
+    outputSchema: okOutput('ReposAddOutput', repoDescriptorSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'INVALID_JSON',
+      'FORBIDDEN',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'workspaces.launch',
+    cli: ['relay-ide', 'v1', 'workspaces', 'launch', '--input-json', '<json>', '--json'],
+    summary:
+      'Launch an agent session for a configured workspace group using its typed workspace id.',
+    stable: true,
+    transport: 'hub-http',
+    requiresAuth: true,
+    capabilityHints: ['session:create:agent'],
+    inputSchema: workspaceLaunchInputSchema,
+    outputSchema: okOutput('WorkspacesLaunchOutput', sessionDescriptorSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'INVALID_JSON',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'worktrees.create',
+    cli: ['relay-ide', 'v1', 'worktrees', 'create', '--input-json', '<json>', '--json'],
+    summary:
+      'Create or reuse a local git worktree for a repo instance; remote node writes fail closed until node capability support exists.',
+    stable: true,
+    transport: 'hub-http-or-node-rpc',
+    requiresAuth: true,
+    capabilityHints: ['rpc:git:read', 'rpc:git:write'],
+    inputSchema: worktreeCreateInputSchema,
+    outputSchema: okOutput('WorktreesCreateOutput', worktreeCreateOutputSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'INVALID_JSON',
+      'UNSUPPORTED',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'NODE_OFFLINE',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'worktrees.status',
+    cli: ['relay-ide', 'v1', 'worktrees', 'status', '--input-json', '<json>', '--json'],
+    summary:
+      'Preflight a worktree before cleanup, returning active session ids and dirty-worktree state.',
+    stable: true,
+    transport: 'hub-http-or-node-rpc',
+    requiresAuth: true,
+    capabilityHints: ['session:read', 'rpc:git:read'],
+    inputSchema: worktreeStatusInputSchema,
+    outputSchema: okOutput('WorktreesStatusOutput', worktreeStatusOutputSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'INVALID_JSON',
+      'UNSUPPORTED',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'NODE_OFFLINE',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'worktrees.delete',
+    cli: ['relay-ide', 'v1', 'worktrees', 'delete', '--input-json', '<json>', '--json'],
+    summary:
+      'Delete a local git worktree and its branch after fail-closed dirty/session/main-worktree checks.',
+    stable: true,
+    transport: 'hub-http-or-node-rpc',
+    requiresAuth: true,
+    capabilityHints: ['session:read', 'session:control:kill', 'rpc:git:read', 'rpc:git:write'],
+    inputSchema: worktreeDeleteInputSchema,
+    outputSchema: okOutput('WorktreesDeleteOutput', worktreeDeleteOutputSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'INVALID_JSON',
+      'UNSUPPORTED',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'SESSION_CONFLICT',
+      'CONFIRMATION_REQUIRED',
+      'NODE_OFFLINE',
+      'SERVER_UNAVAILABLE',
+      'UPSTREAM_ERROR',
+    ],
+  },
+  {
+    name: 'worktrees.archive',
+    cli: ['relay-ide', 'v1', 'worktrees', 'archive', '--input-json', '<json>', '--json'],
+    summary:
+      'Archive/remove a local git worktree while preserving its branch, with the same fail-closed preflight checks as delete.',
+    stable: true,
+    transport: 'hub-http-or-node-rpc',
+    requiresAuth: true,
+    capabilityHints: ['session:read', 'session:control:kill', 'rpc:git:read', 'rpc:git:write'],
+    inputSchema: worktreeDeleteInputSchema,
+    outputSchema: okOutput('WorktreesArchiveOutput', worktreeDeleteOutputSchema),
+    errorCodes: [
+      'UNAUTHORIZED',
+      'INVALID_ARGUMENT',
+      'INVALID_JSON',
+      'UNSUPPORTED',
+      'NOT_FOUND',
+      'FORBIDDEN',
+      'SESSION_CONFLICT',
+      'CONFIRMATION_REQUIRED',
+      'NODE_OFFLINE',
       'SERVER_UNAVAILABLE',
       'UPSTREAM_ERROR',
     ],

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -83,6 +83,12 @@ const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
   'contract.schema': 'gateway schema',
   'nodes.manifest': 'local node manifest',
   'nodes.list': 'relay nodes list',
+  'repos.add': 'add repo workspace',
+  'workspaces.launch': 'launch workspace',
+  'worktrees.create': 'create worktree',
+  'worktrees.status': 'worktree cleanup preflight',
+  'worktrees.delete': 'delete worktree',
+  'worktrees.archive': 'archive worktree',
   'sessions.list': 'sessions list',
   'sessions.get': 'session details',
   'sessions.create': 'create session',
@@ -139,7 +145,9 @@ function sideEffectForGatewayCommand(
   if (
     spec.name === 'handoffs.create' ||
     spec.name === 'handoffs.launch' ||
-    spec.name === 'sessions.kill'
+    spec.name === 'sessions.kill' ||
+    spec.name === 'worktrees.delete' ||
+    spec.name === 'worktrees.archive'
   )
     return 'destructive';
   if (
@@ -158,6 +166,9 @@ function sideEffectForGatewayCommand(
     spec.name === 'context.create' ||
     spec.name === 'context.pin' ||
     spec.name === 'context.unpin' ||
+    spec.name === 'repos.add' ||
+    spec.name === 'workspaces.launch' ||
+    spec.name === 'worktrees.create' ||
     spec.name === 'inbox.send' ||
     spec.name === 'inbox.ack' ||
     spec.name === 'inbox.resolve' ||
@@ -174,6 +185,9 @@ function scopeKindsForGatewayCommand(
   name: RelayCliGatewayCommand
 ): readonly RelayCommandScopeKind[] {
   if (name.startsWith('nodes.')) return ['node'];
+  if (name.startsWith('repos.')) return ['repo'];
+  if (name.startsWith('workspaces.')) return ['work-context', 'repo', 'worktree'];
+  if (name.startsWith('worktrees.')) return ['repo', 'worktree'];
   if (name.startsWith('files.')) return ['session'];
   if (name.startsWith('work-contexts.')) return ['work-context'];
   if (name.startsWith('context.')) return ['work-context', 'session'];
@@ -198,6 +212,8 @@ function requiresConfirmationForGatewayCommand(
     spec.name === 'files.write' ||
     spec.name === 'sessions.kill' ||
     spec.name === 'settings.update' ||
+    spec.name === 'worktrees.delete' ||
+    spec.name === 'worktrees.archive' ||
     spec.name === 'handoffs.create' ||
     spec.name === 'handoffs.launch' ||
     spec.capabilityHints.includes('pty:exec:arbitrary') ||

--- a/shared/relay-command-manifest.ts
+++ b/shared/relay-command-manifest.ts
@@ -137,47 +137,52 @@ const COMMAND_LABELS: Record<RelayCliGatewayCommand, string> = {
   'webhooks.ping': 'webhook ping',
 };
 
+const STREAM_GATEWAY_COMMANDS = new Set<RelayCliGatewayCommand>([
+  'sessions.stream',
+  'events.subscribe',
+]);
+
+const DESTRUCTIVE_GATEWAY_COMMANDS = new Set<RelayCliGatewayCommand>([
+  'handoffs.create',
+  'handoffs.launch',
+  'sessions.kill',
+  'worktrees.delete',
+  'worktrees.archive',
+]);
+
+const WRITE_GATEWAY_COMMANDS = new Set<RelayCliGatewayCommand>([
+  'sessions.create',
+  'tickets.startWork',
+  'branches.openSession',
+  'sessions.renew',
+  'sessions.detach',
+  'sessions.rename',
+  'sessions.input',
+  'sessions.handBack',
+  'supervisor.sendText',
+  'supervisor.submit',
+  'files.write',
+  'handoffs.cancel',
+  'context.create',
+  'context.pin',
+  'context.unpin',
+  'repos.add',
+  'workspaces.launch',
+  'worktrees.create',
+  'inbox.send',
+  'inbox.ack',
+  'inbox.resolve',
+  'inbox.ignore',
+  'settings.update',
+  'webhooks.ping',
+]);
+
 function sideEffectForGatewayCommand(
   spec: RelayCliGatewayCommandSpec
 ): RelayCommandSideEffect {
-  if (spec.name === 'sessions.stream' || spec.name === 'events.subscribe')
-    return 'stream';
-  if (
-    spec.name === 'handoffs.create' ||
-    spec.name === 'handoffs.launch' ||
-    spec.name === 'sessions.kill' ||
-    spec.name === 'worktrees.delete' ||
-    spec.name === 'worktrees.archive'
-  )
-    return 'destructive';
-  if (
-    spec.name === 'sessions.create' ||
-    spec.name === 'tickets.startWork' ||
-    spec.name === 'branches.openSession' ||
-    spec.name === 'sessions.renew' ||
-    spec.name === 'sessions.detach' ||
-    spec.name === 'sessions.rename' ||
-    spec.name === 'sessions.input' ||
-    spec.name === 'sessions.handBack' ||
-    spec.name === 'supervisor.sendText' ||
-    spec.name === 'supervisor.submit' ||
-    spec.name === 'files.write' ||
-    spec.name === 'handoffs.cancel' ||
-    spec.name === 'context.create' ||
-    spec.name === 'context.pin' ||
-    spec.name === 'context.unpin' ||
-    spec.name === 'repos.add' ||
-    spec.name === 'workspaces.launch' ||
-    spec.name === 'worktrees.create' ||
-    spec.name === 'inbox.send' ||
-    spec.name === 'inbox.ack' ||
-    spec.name === 'inbox.resolve' ||
-    spec.name === 'inbox.ignore' ||
-    spec.name === 'settings.update' ||
-    spec.name === 'webhooks.ping'
-  ) {
-    return 'write';
-  }
+  if (STREAM_GATEWAY_COMMANDS.has(spec.name)) return 'stream';
+  if (DESTRUCTIVE_GATEWAY_COMMANDS.has(spec.name)) return 'destructive';
+  if (WRITE_GATEWAY_COMMANDS.has(spec.name)) return 'write';
   return 'read';
 }
 
@@ -186,7 +191,8 @@ function scopeKindsForGatewayCommand(
 ): readonly RelayCommandScopeKind[] {
   if (name.startsWith('nodes.')) return ['node'];
   if (name.startsWith('repos.')) return ['repo'];
-  if (name.startsWith('workspaces.')) return ['work-context', 'repo', 'worktree'];
+  if (name.startsWith('workspaces.'))
+    return ['work-context', 'repo', 'worktree'];
   if (name.startsWith('worktrees.')) return ['repo', 'worktree'];
   if (name.startsWith('files.')) return ['session'];
   if (name.startsWith('work-contexts.')) return ['work-context'];

--- a/test/cli-gateway-actor-route-wiring.test.ts
+++ b/test/cli-gateway-actor-route-wiring.test.ts
@@ -2,7 +2,10 @@ import { readFileSync } from 'node:fs';
 import { expect, test } from 'vitest';
 
 test('live hub shares approved operator handshake grants with CLI actor credential minting', () => {
-  const indexSource = readFileSync(new URL('../server/index.ts', import.meta.url), 'utf8');
+  const indexSource = readFileSync(
+    new URL('../server/index.ts', import.meta.url),
+    'utf8'
+  );
   const hubRouterCall = indexSource.slice(
     indexSource.indexOf('createHubNodeRouter({'),
     indexSource.indexOf('createRepoFeatureRouter({')
@@ -14,11 +17,21 @@ test('live hub shares approved operator handshake grants with CLI actor credenti
 });
 
 test('lifecycle mutation routes reject read-only CLI actor credentials', () => {
-  const indexSource = readFileSync(new URL('../server/index.ts', import.meta.url), 'utf8');
+  const indexSource = readFileSync(
+    new URL('../server/index.ts', import.meta.url),
+    'utf8'
+  );
 
-  expect(indexSource).toContain('const requireCliGatewayWriteAuth: express.RequestHandler');
+  expect(indexSource).toContain(
+    'const requireCliGatewayWriteAuth: express.RequestHandler'
+  );
   expect(indexSource).toContain('CLI_GATEWAY_ACTOR_WRITE_UNSUPPORTED');
-  expect(indexSource).toContain("app.use('/workspaces', requireCliGatewayWriteAuth, workspaceRouter)");
+  expect(indexSource).toContain(
+    'CLI_GATEWAY_ACTOR_WORKTREE_STATUS_UNSUPPORTED'
+  );
+  expect(indexSource).toContain(
+    "app.use('/workspaces', requireCliGatewayWriteAuth, workspaceRouter)"
+  );
   expect(indexSource).toContain(
     'createWorkspaceGroupsRouter(CONFIG_PATH, requireCliGatewayWriteAuth'
   );

--- a/test/cli-gateway-actor-route-wiring.test.ts
+++ b/test/cli-gateway-actor-route-wiring.test.ts
@@ -12,3 +12,17 @@ test('live hub shares approved operator handshake grants with CLI actor credenti
     'operatorHandshakeGrants: cliGatewayHandshakeGrantRegistry'
   );
 });
+
+test('lifecycle mutation routes reject read-only CLI actor credentials', () => {
+  const indexSource = readFileSync(new URL('../server/index.ts', import.meta.url), 'utf8');
+
+  expect(indexSource).toContain('const requireCliGatewayWriteAuth: express.RequestHandler');
+  expect(indexSource).toContain('CLI_GATEWAY_ACTOR_WRITE_UNSUPPORTED');
+  expect(indexSource).toContain("app.use('/workspaces', requireCliGatewayWriteAuth, workspaceRouter)");
+  expect(indexSource).toContain(
+    'createWorkspaceGroupsRouter(CONFIG_PATH, requireCliGatewayWriteAuth'
+  );
+  expect(indexSource).toContain(
+    "app.delete('/worktrees', requireCliGatewayWriteAuth, async (req, res) =>"
+  );
+});

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -309,6 +309,28 @@ describe('CLI gateway contract', () => {
       auditRedaction: { expectation: 'action-summary' },
       scopeKinds: ['repo', 'worktree'],
     });
+    expect(schemaAcceptsCommandInput('worktrees.create', {})).toBe(false);
+    expect(
+      schemaAcceptsCommandInput('worktrees.create', { repoPath: '/tmp/repo' })
+    ).toBe(true);
+    expect(
+      schemaAcceptsCommandInput('worktrees.create', {
+        environment: { repoInstanceId: 'local:/tmp/repo' },
+      })
+    ).toBe(true);
+    expect(schemaAcceptsCommandInput('worktrees.status', {})).toBe(false);
+    expect(
+      schemaAcceptsCommandInput('worktrees.status', {
+        environment: { benchId: 'local:/tmp/repo/.worktrees/one' },
+      })
+    ).toBe(true);
+    expect(schemaAcceptsCommandInput('worktrees.delete', {})).toBe(false);
+    expect(
+      schemaAcceptsCommandInput('worktrees.delete', {
+        repoPath: '/tmp/repo',
+        worktreePath: '/tmp/repo/.worktrees/one',
+      })
+    ).toBe(true);
     expect(relayCommandDefinition('sessions.stream')).toMatchObject({
       sideEffect: 'stream',
       requiresConfirmation: false,

--- a/test/cli-gateway-contract.test.ts
+++ b/test/cli-gateway-contract.test.ts
@@ -130,6 +130,12 @@ describe('CLI gateway contract', () => {
       'contract.schema',
       'nodes.manifest',
       'nodes.list',
+      'repos.add',
+      'workspaces.launch',
+      'worktrees.create',
+      'worktrees.status',
+      'worktrees.delete',
+      'worktrees.archive',
       'sessions.list',
       'sessions.get',
       'sessions.create',
@@ -264,6 +270,44 @@ describe('CLI gateway contract', () => {
       requiresConfirmation: false,
       auditRedaction: { expectation: 'action-summary' },
       scopeKinds: ['repo', 'worktree', 'work-context', 'session'],
+    });
+    expect(relayCommandDefinition('repos.add')).toMatchObject({
+      sideEffect: 'write',
+      requiresConfirmation: false,
+      auditRedaction: { expectation: 'action-summary' },
+      scopeKinds: ['repo'],
+    });
+    expect(relayCommandDefinition('workspaces.launch')).toMatchObject({
+      sideEffect: 'write',
+      requiresConfirmation: false,
+      auditRedaction: { expectation: 'action-summary' },
+      scopeKinds: ['work-context', 'repo', 'worktree'],
+    });
+    expect(relayCommandDefinition('worktrees.status')).toMatchObject({
+      sideEffect: 'read',
+      requiresConfirmation: false,
+      auditRedaction: { expectation: 'bounded-redacted' },
+      scopeKinds: ['repo', 'worktree'],
+    });
+    expect(relayCommandDefinition('worktrees.create')).toMatchObject({
+      sideEffect: 'write',
+      requiresConfirmation: false,
+      auditRedaction: { expectation: 'action-summary' },
+      scopeKinds: ['repo', 'worktree'],
+    });
+    expect(relayCommandDefinition('worktrees.delete')).toMatchObject({
+      sideEffect: 'destructive',
+      requiresConfirmation: true,
+      controlRequirements: ['confirmation-challenge'],
+      auditRedaction: { expectation: 'action-summary' },
+      scopeKinds: ['repo', 'worktree'],
+    });
+    expect(relayCommandDefinition('worktrees.archive')).toMatchObject({
+      sideEffect: 'destructive',
+      requiresConfirmation: true,
+      controlRequirements: ['confirmation-challenge'],
+      auditRedaction: { expectation: 'action-summary' },
+      scopeKinds: ['repo', 'worktree'],
     });
     expect(relayCommandDefinition('sessions.stream')).toMatchObject({
       sideEffect: 'stream',
@@ -707,6 +751,12 @@ describe('CLI gateway contract', () => {
     const invalidArgumentCommands = [
       'contract.list',
       'nodes.list',
+      'repos.add',
+      'workspaces.launch',
+      'worktrees.create',
+      'worktrees.status',
+      'worktrees.delete',
+      'worktrees.archive',
       'sessions.list',
       'sessions.get',
       'sessions.create',

--- a/test/worktree-cleanup.test.ts
+++ b/test/worktree-cleanup.test.ts
@@ -8,6 +8,7 @@ import {
   removeWorktreeFromDisk,
   validateWorktreeForDelete,
 } from '../server/worktree-cleanup.js';
+import type { WorktreeDeleteProof } from '../server/worktree-cleanup.js';
 
 const tempRoots: string[] = [];
 const gitEnv: NodeJS.ProcessEnv = {
@@ -63,6 +64,16 @@ function branchExists(repoPath: string, branchName: string): boolean {
   }
 }
 
+function expectDeleteProof(
+  validation: Awaited<ReturnType<typeof validateWorktreeForDelete>>
+): WorktreeDeleteProof {
+  expect(validation.ok).toBe(true);
+  if (!validation.ok) {
+    throw new Error(`expected valid worktree: ${validation.error.error}`);
+  }
+  return validation.deleteProof;
+}
+
 afterEach(() => {
   for (const root of tempRoots.splice(0)) {
     fs.rmSync(root, { recursive: true, force: true });
@@ -98,9 +109,17 @@ describe('worktree cleanup route helpers', () => {
     const { repoPath, worktreePath } = makeRepoWithWorktree(
       'feature/no-rm-fallback'
     );
+    const deleteProof = expectDeleteProof(
+      await validateWorktreeForDelete(worktreePath, repoPath, false, [])
+    );
     fs.writeFileSync(path.join(worktreePath, 'dirty-untracked.txt'), 'dirty\n');
 
-    const error = await removeWorktreeFromDisk(worktreePath, repoPath, false);
+    const error = await removeWorktreeFromDisk(
+      worktreePath,
+      repoPath,
+      false,
+      deleteProof
+    );
 
     expect(error).toContain('contains modified or untracked files');
     expect(fs.existsSync(worktreePath)).toBe(true);
@@ -122,9 +141,10 @@ describe('worktree cleanup route helpers', () => {
       branchName,
       hasUncommittedChanges: false,
     });
-    expect(await removeWorktreeFromDisk(worktreePath, repoPath, false)).toBe(
-      null
-    );
+    const deleteProof = expectDeleteProof(validation);
+    expect(
+      await removeWorktreeFromDisk(worktreePath, repoPath, false, deleteProof)
+    ).toBe(null);
     const branchDeleted = await deleteLocalWorktreeBranch(repoPath, branchName);
 
     expect(branchDeleted).toBe(true);
@@ -143,9 +163,10 @@ describe('worktree cleanup route helpers', () => {
       []
     );
     expect(validation).toMatchObject({ ok: true, branchName });
-    expect(await removeWorktreeFromDisk(worktreePath, repoPath, false)).toBe(
-      null
-    );
+    const deleteProof = expectDeleteProof(validation);
+    expect(
+      await removeWorktreeFromDisk(worktreePath, repoPath, false, deleteProof)
+    ).toBe(null);
     const branchDeleted = false;
 
     expect(branchDeleted).toBe(false);
@@ -172,6 +193,45 @@ describe('worktree cleanup route helpers', () => {
         sessionIds: ['session-1'],
       },
     });
+  });
+
+  it('fails closed on invalid repoPath with force and leaves target directory intact', async () => {
+    const { root, repoPath } = makeRepoWithWorktree(
+      'feature/invalid-force-repo'
+    );
+    const missingRepoPath = path.join(root, 'missing-repo');
+
+    const validation = await validateWorktreeForDelete(
+      repoPath,
+      missingRepoPath,
+      true,
+      []
+    );
+
+    expect(validation).toEqual({
+      ok: false,
+      error: {
+        status: 500,
+        error: 'Cannot verify worktree — git worktree list failed.',
+      },
+    });
+
+    const forgedProof: WorktreeDeleteProof = {
+      repoPath: path.resolve(missingRepoPath),
+      worktreePath: path.resolve(repoPath),
+      branchName: 'main',
+      recognizedNonMainWorktree: true,
+    };
+    const removeError = await removeWorktreeFromDisk(
+      repoPath,
+      missingRepoPath,
+      true,
+      forgedProof
+    );
+
+    expect(removeError).toBe('Cannot remove worktree — git worktree list failed');
+    expect(fs.existsSync(repoPath)).toBe(true);
+    expect(fs.existsSync(path.join(repoPath, 'README.md'))).toBe(true);
   });
 
   it('keeps lifecycle invalid-environment errors command-specific', () => {

--- a/test/worktree-cleanup.test.ts
+++ b/test/worktree-cleanup.test.ts
@@ -33,7 +33,9 @@ function makeRepoWithWorktree(branchName: string): {
   worktreePath: string;
   branchName: string;
 } {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-worktree-cleanup-'));
+  const root = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'relay-worktree-cleanup-')
+  );
   tempRoots.push(root);
   const repoPath = path.join(root, 'repo');
   const worktreePath = path.join(root, 'wt');
@@ -229,7 +231,9 @@ describe('worktree cleanup route helpers', () => {
       forgedProof
     );
 
-    expect(removeError).toBe('Cannot remove worktree — git worktree list failed');
+    expect(removeError).toBe(
+      'Cannot remove worktree — git worktree list failed'
+    );
     expect(fs.existsSync(repoPath)).toBe(true);
     expect(fs.existsSync(path.join(repoPath, 'README.md'))).toBe(true);
   });
@@ -247,7 +251,7 @@ describe('worktree cleanup route helpers', () => {
     expect(lifecycleEnvironmentHelper).toContain(
       'commandName: RelayCliGatewayCommand'
     );
-    expect(lifecycleEnvironmentHelper).toContain('gatewayInvalid(\n      commandName,');
+    expect(lifecycleEnvironmentHelper).toContain('gatewayInvalid(commandName,');
     expect(lifecycleEnvironmentHelper).not.toContain("'worktrees.status'");
     expect(cliSource).toContain(
       'const environment = gatewayLifecycleEnvironment(commandName, input);'

--- a/test/worktree-cleanup.test.ts
+++ b/test/worktree-cleanup.test.ts
@@ -1,0 +1,196 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  deleteLocalWorktreeBranch,
+  removeWorktreeFromDisk,
+  validateWorktreeForDelete,
+} from '../server/worktree-cleanup.js';
+
+const tempRoots: string[] = [];
+const gitEnv: NodeJS.ProcessEnv = {
+  ...process.env,
+  GIT_DIR: undefined,
+  GIT_WORK_TREE: undefined,
+  GIT_COMMON_DIR: undefined,
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    env: gitEnv,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function makeRepoWithWorktree(branchName: string): {
+  root: string;
+  repoPath: string;
+  worktreePath: string;
+  branchName: string;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'relay-worktree-cleanup-'));
+  tempRoots.push(root);
+  const repoPath = path.join(root, 'repo');
+  const worktreePath = path.join(root, 'wt');
+  fs.mkdirSync(repoPath, { recursive: true });
+  git(repoPath, ['init', '-b', 'main']);
+  fs.writeFileSync(path.join(repoPath, 'README.md'), 'initial\n');
+  git(repoPath, ['add', 'README.md']);
+  git(repoPath, [
+    '-c',
+    'user.name=Relay Test',
+    '-c',
+    'user.email=relay-test@example.invalid',
+    'commit',
+    '-m',
+    'initial',
+  ]);
+  git(repoPath, ['branch', branchName]);
+  git(repoPath, ['worktree', 'add', worktreePath, branchName]);
+  return { root, repoPath, worktreePath, branchName };
+}
+
+function branchExists(repoPath: string, branchName: string): boolean {
+  try {
+    git(repoPath, ['rev-parse', '--verify', branchName]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('worktree cleanup route helpers', () => {
+  it('fails closed on dirty worktrees without force before destructive removal', async () => {
+    const { repoPath, worktreePath } = makeRepoWithWorktree(
+      'feature/dirty-delete'
+    );
+    fs.writeFileSync(path.join(worktreePath, 'dirty-untracked.txt'), 'dirty\n');
+
+    const validation = await validateWorktreeForDelete(
+      worktreePath,
+      repoPath,
+      false,
+      []
+    );
+
+    expect(validation).toEqual({
+      ok: false,
+      error: {
+        status: 409,
+        error: 'uncommitted_changes',
+        hasUncommittedChanges: true,
+      },
+    });
+    expect(fs.existsSync(worktreePath)).toBe(true);
+  });
+
+  it('does not fall back to rmSync when clean-delete git removal fails without force', async () => {
+    const { repoPath, worktreePath } = makeRepoWithWorktree(
+      'feature/no-rm-fallback'
+    );
+    fs.writeFileSync(path.join(worktreePath, 'dirty-untracked.txt'), 'dirty\n');
+
+    const error = await removeWorktreeFromDisk(worktreePath, repoPath, false);
+
+    expect(error).toContain('contains modified or untracked files');
+    expect(fs.existsSync(worktreePath)).toBe(true);
+  });
+
+  it('reports truthful branchDeleted for delete and removes the branch', async () => {
+    const { repoPath, worktreePath, branchName } = makeRepoWithWorktree(
+      'feature/delete-branch-truth'
+    );
+
+    const validation = await validateWorktreeForDelete(
+      worktreePath,
+      repoPath,
+      false,
+      []
+    );
+    expect(validation).toMatchObject({
+      ok: true,
+      branchName,
+      hasUncommittedChanges: false,
+    });
+    expect(await removeWorktreeFromDisk(worktreePath, repoPath, false)).toBe(
+      null
+    );
+    const branchDeleted = await deleteLocalWorktreeBranch(repoPath, branchName);
+
+    expect(branchDeleted).toBe(true);
+    expect(branchExists(repoPath, branchName)).toBe(false);
+  });
+
+  it('reports archive branchDeleted false and preserves the branch', async () => {
+    const { repoPath, worktreePath, branchName } = makeRepoWithWorktree(
+      'feature/archive-keeps-branch'
+    );
+
+    const validation = await validateWorktreeForDelete(
+      worktreePath,
+      repoPath,
+      false,
+      []
+    );
+    expect(validation).toMatchObject({ ok: true, branchName });
+    expect(await removeWorktreeFromDisk(worktreePath, repoPath, false)).toBe(
+      null
+    );
+    const branchDeleted = false;
+
+    expect(branchDeleted).toBe(false);
+    expect(branchExists(repoPath, branchName)).toBe(true);
+  });
+
+  it('fails closed on active sessions without force', async () => {
+    const { repoPath, worktreePath } = makeRepoWithWorktree(
+      'feature/active-session-delete'
+    );
+
+    const validation = await validateWorktreeForDelete(
+      worktreePath,
+      repoPath,
+      false,
+      ['session-1']
+    );
+
+    expect(validation).toEqual({
+      ok: false,
+      error: {
+        status: 409,
+        error: 'active_sessions',
+        sessionIds: ['session-1'],
+      },
+    });
+  });
+
+  it('keeps lifecycle invalid-environment errors command-specific', () => {
+    const cliSource = fs.readFileSync(
+      new URL('../bin/relay-ide.ts', import.meta.url),
+      'utf8'
+    );
+    const lifecycleEnvironmentHelper = cliSource.slice(
+      cliSource.indexOf('function gatewayLifecycleEnvironment('),
+      cliSource.indexOf('function gatewayLifecycleNodeId(')
+    );
+
+    expect(lifecycleEnvironmentHelper).toContain(
+      'commandName: RelayCliGatewayCommand'
+    );
+    expect(lifecycleEnvironmentHelper).toContain('gatewayInvalid(\n      commandName,');
+    expect(lifecycleEnvironmentHelper).not.toContain("'worktrees.status'");
+    expect(cliSource).toContain(
+      'const environment = gatewayLifecycleEnvironment(commandName, input);'
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,7 @@ const SERIAL_SUBPROCESS_FILES = [
   'test/git-divergence.test.ts',
   'test/git-watcher.test.ts',
   'test/workspace-divergence-api.test.ts',
+  'test/worktree-cleanup.test.ts',
   'test/sessions.test.ts',
 ];
 


### PR DESCRIPTION
## Summary
- adds stable v1 CLI gateway descriptors for repo add, workspace launch, and worktree create/status/delete/archive
- wires the CLI to the existing workspace/worktree HTTP routes with local typed identity resolution and remote-node fail-closed `UNSUPPORTED` envelopes
- hardens lifecycle mutation routing so read-only CLI actor credentials cannot directly hit workspace/worktree mutation routes; destructive cleanup preflights dirty worktrees/active sessions before force/confirmation

Refs #870

## Test plan
- `npm test -- test/cli-gateway-contract.test.ts test/cli-gateway-actor-route-wiring.test.ts`
- `npm run check`
- `npm run build`
- CLI smoke: `relay-ide v1 schema --json` exposes all 6 lifecycle commands
- CLI smoke: remote lifecycle status returns typed `UNSUPPORTED`
- CLI smoke: `--actor-token` against `worktrees.delete` returns typed `INVALID_ARGUMENT`

## Known gap
- remote git/worktree mutation is intentionally not implemented in this slice; remote node lifecycle inputs fail closed until routed node capability support exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI commands for repository registration, workspace launch, and worktree lifecycle (create, status, delete, archive).

* **Improvements**
  * Validation and confirmation gating for worktree delete/archive (detects active sessions and uncommitted changes).
  * Stronger authorization for workspace/worktree write operations and clearer structured deletion responses (includes branch-deleted info).

* **Tests**
  * Added contract, routing, and worktree-cleanup test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->