### PR TITLE
feat: add WorkContext artifact store index

### DIFF
--- a/server/work-context-artifacts.ts
+++ b/server/work-context-artifacts.ts
@@ -17,7 +17,6 @@ import {
   ARTIFACT_KINDS,
   type ArtifactKind,
   type TaskRef,
-  type TaskRefKind,
   type WorkContextId,
 } from '../shared/work-context.js';
 
@@ -26,14 +25,6 @@ const DEFAULT_PAYLOAD_MEDIA_TYPE = 'application/json';
 const DEFAULT_VISIBILITY: WorkContextArtifactVisibility = 'private';
 const VISIBILITIES = new Set<string>(['private', 'public']);
 const STAGES = new Set<string>(PIPELINE_HANDOFF_STAGES);
-const TASK_REF_KINDS = new Set<string>([
-  'github-issue',
-  'github-pr',
-  'kanban-task',
-  'jira-ticket',
-  'linear-issue',
-  'external',
-]);
 const SECRET_TEXT_RE =
   /(?:bearer\s+[a-z0-9._~+/-]+=*|sk-[a-z0-9_-]{8,}|relay-(?:sac|ohg|grant|auth|pair)-v1[a-z0-9._-]*|pair_[a-z0-9_-]{8,}|node_[a-z0-9._~+/=-]+\.secret_[a-z0-9._~+/=-]+|secret_[a-z0-9._~+/=-]+)/gi;
 const ABSOLUTE_LOCAL_PATH_RE =
@@ -227,6 +218,8 @@ interface WorkContextArtifactRow {
 interface PersistedMetadataJson {
   taskRef: TaskRef;
 }
+
+type IndexedTaskRef = Pick<TaskRef, 'id' | 'title' | 'url' | 'status'> & { kind: string };
 
 export class WorkContextArtifactStoreError extends Error {
   readonly status: number;
@@ -555,7 +548,6 @@ function backfillArtifactTaskRefs(
     for (const row of rows) {
       const taskRefs = dedupeTaskRefs([legacyTaskRef(row), ...payloadTaskRefs(row)]);
       for (const taskRef of taskRefs) {
-        if (!isValidTaskRef(taskRef)) continue;
         insertTaskRef.run({
           artifactId: row.id,
           taskRefKind: taskRef.kind,
@@ -569,17 +561,19 @@ function backfillArtifactTaskRefs(
   })();
 }
 
-function legacyTaskRef(row: WorkContextArtifactRow): TaskRef {
-  return { kind: row.task_ref_kind as TaskRefKind, id: row.task_ref_id };
+function legacyTaskRef(row: WorkContextArtifactRow): IndexedTaskRef {
+  return { kind: row.task_ref_kind, id: row.task_ref_id };
 }
 
-function payloadTaskRefs(row: WorkContextArtifactRow): TaskRef[] {
+function payloadTaskRefs(row: WorkContextArtifactRow): IndexedTaskRef[] {
   try {
     const raw = readFileSync(row.payload_path, 'utf8');
     assertPayloadSha256(raw, row);
     const parsed = JSON.parse(raw) as unknown;
-    if (!isPipelineHandoffArtifact(parsed)) return [];
-    return parsed.scope.taskRefs.filter(isValidTaskRef);
+    if (!isRecord(parsed)) return [];
+    const scope = parsed.scope;
+    if (!isRecord(scope) || !Array.isArray(scope.taskRefs)) return [];
+    return scope.taskRefs.filter(isIndexableTaskRef);
   } catch {
     return [];
   }
@@ -657,9 +651,9 @@ function firstTaskRef(artifact: PipelineHandoffArtifact): TaskRef | undefined {
   );
 }
 
-function dedupeTaskRefs(taskRefs: TaskRef[]): TaskRef[] {
+function dedupeTaskRefs<T extends { kind: string; id: string }>(taskRefs: T[]): T[] {
   const seen = new Set<string>();
-  const unique: TaskRef[] = [];
+  const unique: T[] = [];
   for (const taskRef of taskRefs) {
     const key = `${taskRef.kind}\u0000${taskRef.id}`;
     if (seen.has(key)) continue;
@@ -718,13 +712,21 @@ function assertValidTaskRef(value: TaskRef): void {
   assertNonEmptyString(value.id, 'taskRef.id');
 }
 
-function isValidTaskRef(value: TaskRef): value is TaskRef & { kind: TaskRefKind } {
+function isIndexableTaskRef(value: unknown): value is IndexedTaskRef {
+  if (!isRecord(value)) return false;
   return (
     typeof value.kind === 'string' &&
-    TASK_REF_KINDS.has(value.kind) &&
+    value.kind.trim().length > 0 &&
     typeof value.id === 'string' &&
-    value.id.trim().length > 0
+    value.id.trim().length > 0 &&
+    isOptionalString(value.title) &&
+    isOptionalString(value.url) &&
+    isOptionalString(value.status)
   );
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === 'string';
 }
 
 function sanitizePublicText(value: string): string {

--- a/server/work-context-artifacts.ts
+++ b/server/work-context-artifacts.ts
@@ -1,0 +1,620 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+import Database from 'better-sqlite3';
+
+import {
+  PIPELINE_HANDOFF_STAGES,
+  isPipelineHandoffArtifact,
+  sanitizePipelineHandoffArtifactForPublic,
+  validatePipelineHandoffArtifact,
+  validatePublicPipelineHandoffArtifact,
+  type PipelineHandoffArtifact,
+  type PipelineHandoffStageName,
+} from '../shared/pipeline-handoff-artifact.js';
+import {
+  ARTIFACT_KINDS,
+  type ArtifactKind,
+  type TaskRef,
+  type WorkContextId,
+} from '../shared/work-context.js';
+
+const SCHEMA_VERSION = 1;
+const DEFAULT_PAYLOAD_MEDIA_TYPE = 'application/json';
+const DEFAULT_VISIBILITY: WorkContextArtifactVisibility = 'private';
+const VISIBILITIES = new Set<string>(['private', 'public']);
+const STAGES = new Set<string>(PIPELINE_HANDOFF_STAGES);
+const SECRET_TEXT_RE =
+  /(?:bearer\s+[a-z0-9._~+/-]+=*|sk-[a-z0-9_-]{8,}|relay-(?:sac|ohg|grant|auth|pair)-v1[a-z0-9._-]*|pair_[a-z0-9_-]{8,}|node_[a-z0-9._~+/=-]+\.secret_[a-z0-9._~+/=-]+|secret_[a-z0-9._~+/=-]+)/gi;
+const ABSOLUTE_LOCAL_PATH_RE =
+  /(?:^|[\s:=('"])(?:\/home\/[^\s)'"]+|\/Users\/[^\s)'"]+|\/tmp\/[^\s)'"]+)/g;
+const WINDOWS_ABSOLUTE_PATH_RE = /(?:^|[\s:=('"])[a-z]:[\\/][^\s)'"]+/gi;
+const UNC_PATH_RE = /(?:^|[\s:=('"])\\\\[^\s\\/'"]+[\\/][^\s)'"]+/g;
+const KANBAN_TASK_ID_RE = /\bt_[a-f0-9]{8,}\b/gi;
+
+const SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS work_context_artifacts (
+  id                    TEXT PRIMARY KEY,
+  work_context_id       TEXT NOT NULL,
+  project_id            TEXT,
+  task_ref_kind         TEXT NOT NULL,
+  task_ref_id           TEXT NOT NULL,
+  stage                 TEXT,
+  provenance_actor_id   TEXT,
+  kind                  TEXT NOT NULL,
+  title                 TEXT NOT NULL,
+  summary               TEXT NOT NULL,
+  visibility            TEXT NOT NULL,
+  created_at            TEXT NOT NULL,
+  updated_at            TEXT NOT NULL,
+  captured_at           TEXT NOT NULL,
+  payload_kind          TEXT NOT NULL,
+  payload_media_type    TEXT NOT NULL,
+  payload_path          TEXT NOT NULL,
+  payload_sha256        TEXT NOT NULL,
+  payload_bytes         INTEGER NOT NULL,
+  pr_number             INTEGER,
+  head_sha              TEXT,
+  base_name             TEXT,
+  branch_name           TEXT,
+  supersedes_artifact_id TEXT,
+  metadata_json         TEXT NOT NULL,
+  CHECK (visibility IN ('private', 'public'))
+);
+CREATE INDEX IF NOT EXISTS idx_work_context_artifacts_context
+  ON work_context_artifacts(work_context_id, captured_at DESC);
+CREATE INDEX IF NOT EXISTS idx_work_context_artifacts_task_ref
+  ON work_context_artifacts(task_ref_kind, task_ref_id, captured_at DESC);
+CREATE INDEX IF NOT EXISTS idx_work_context_artifacts_project
+  ON work_context_artifacts(project_id, captured_at DESC);
+CREATE INDEX IF NOT EXISTS idx_work_context_artifacts_head
+  ON work_context_artifacts(head_sha);
+CREATE INDEX IF NOT EXISTS idx_work_context_artifacts_supersedes
+  ON work_context_artifacts(supersedes_artifact_id);
+`;
+
+export type WorkContextArtifactVisibility = 'private' | 'public';
+export type WorkContextArtifactPayloadKind = 'pipeline-handoff-artifact';
+
+export interface WorkContextArtifactIndexInput {
+  id?: string;
+  workContextId: WorkContextId;
+  projectId?: string;
+  taskRef?: TaskRef;
+  stage?: PipelineHandoffStageName;
+  provenanceActorId?: string;
+  visibility?: WorkContextArtifactVisibility;
+  kind?: ArtifactKind;
+  title?: string;
+  summary?: string;
+  capturedAt?: string;
+  supersedesArtifactId?: string;
+}
+
+export interface StorePipelineHandoffArtifactInput extends WorkContextArtifactIndexInput {
+  artifact: PipelineHandoffArtifact;
+}
+
+export interface WorkContextArtifactMetadata {
+  id: string;
+  workContextId: WorkContextId;
+  projectId?: string;
+  taskRef: TaskRef;
+  stage?: PipelineHandoffStageName;
+  provenanceActorId?: string;
+  kind: ArtifactKind;
+  title: string;
+  summary: string;
+  visibility: WorkContextArtifactVisibility;
+  createdAt: string;
+  updatedAt: string;
+  capturedAt: string;
+  payloadKind: WorkContextArtifactPayloadKind;
+  payloadMediaType: string;
+  payloadSha256: string;
+  payloadBytes: number;
+  prNumber?: number;
+  headSha?: string;
+  baseName?: string;
+  branchName?: string;
+  supersedesArtifactId?: string;
+}
+
+export interface WorkContextArtifactRecord {
+  metadata: WorkContextArtifactMetadata;
+  payloadPath: string;
+}
+
+export interface WorkContextArtifactReadResult extends WorkContextArtifactRecord {
+  payload?: PipelineHandoffArtifact;
+}
+
+export interface PublicWorkContextArtifactSummary {
+  id: string;
+  workContextId: WorkContextId;
+  projectId?: string;
+  taskRef?: Pick<TaskRef, 'kind' | 'id' | 'title' | 'url' | 'status'>;
+  stage?: PipelineHandoffStageName;
+  kind: ArtifactKind;
+  title: string;
+  summary: string;
+  visibility: WorkContextArtifactVisibility;
+  capturedAt: string;
+  payloadKind: WorkContextArtifactPayloadKind;
+  payloadSha256: string;
+  payloadBytes: number;
+  prNumber?: number;
+  headSha?: string;
+  baseName?: string;
+  branchName?: string;
+  supersedesArtifactId?: string;
+}
+
+export interface PublicWorkContextArtifactReadResult {
+  metadata: PublicWorkContextArtifactSummary;
+  payload?: PipelineHandoffArtifact;
+}
+
+export interface WorkContextArtifactListInput {
+  workContextId?: WorkContextId;
+  projectId?: string;
+  taskRef?: Pick<TaskRef, 'kind' | 'id'>;
+  stage?: PipelineHandoffStageName;
+  includeSuperseded?: boolean;
+  limit?: number;
+}
+
+export interface WorkContextArtifactStore {
+  close(): void;
+  storePipelineHandoffArtifact(input: StorePipelineHandoffArtifactInput): WorkContextArtifactRecord;
+  get(id: string): WorkContextArtifactRecord | null;
+  read(id: string): WorkContextArtifactReadResult | null;
+  list(input?: WorkContextArtifactListInput): WorkContextArtifactRecord[];
+  publicSummary(id: string): PublicWorkContextArtifactReadResult | null;
+}
+
+interface WorkContextArtifactRow {
+  id: string;
+  work_context_id: string;
+  project_id: string | null;
+  task_ref_kind: string;
+  task_ref_id: string;
+  stage: string | null;
+  provenance_actor_id: string | null;
+  kind: string;
+  title: string;
+  summary: string;
+  visibility: WorkContextArtifactVisibility;
+  created_at: string;
+  updated_at: string;
+  captured_at: string;
+  payload_kind: WorkContextArtifactPayloadKind;
+  payload_media_type: string;
+  payload_path: string;
+  payload_sha256: string;
+  payload_bytes: number;
+  pr_number: number | null;
+  head_sha: string | null;
+  base_name: string | null;
+  branch_name: string | null;
+  supersedes_artifact_id: string | null;
+  metadata_json: string;
+}
+
+interface PersistedMetadataJson {
+  taskRef: TaskRef;
+}
+
+export class WorkContextArtifactStoreError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, code: string, message = code) {
+    super(message);
+    this.name = 'WorkContextArtifactStoreError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export function initWorkContextArtifactStore(
+  configDir: string
+): WorkContextArtifactStore {
+  return createWorkContextArtifactStore({
+    dbPath: path.join(configDir, 'work-context-artifacts.db'),
+    payloadRoot: path.join(configDir, 'work-context-artifacts', 'payloads'),
+  });
+}
+
+export function createWorkContextArtifactStore(input: {
+  dbPath: string;
+  payloadRoot?: string;
+}): WorkContextArtifactStore {
+  mkdirSync(path.dirname(input.dbPath), { recursive: true });
+  const payloadRoot = input.payloadRoot ?? path.join(path.dirname(input.dbPath), 'work-context-artifacts', 'payloads');
+  mkdirSync(payloadRoot, { recursive: true });
+
+  const db = new Database(input.dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+  db.exec('CREATE TABLE IF NOT EXISTS work_context_artifact_schema_version (version INTEGER NOT NULL)');
+  const schemaRow = db.prepare('SELECT version FROM work_context_artifact_schema_version').get() as
+    | { version: number }
+    | undefined;
+  const hadSchemaRow = schemaRow !== undefined;
+  if ((schemaRow?.version ?? 0) < SCHEMA_VERSION) {
+    db.transaction(() => {
+      db.exec(SCHEMA_SQL);
+      if (hadSchemaRow) {
+        db.prepare('UPDATE work_context_artifact_schema_version SET version = ?').run(SCHEMA_VERSION);
+      } else {
+        db.prepare('INSERT INTO work_context_artifact_schema_version (version) VALUES (?)').run(SCHEMA_VERSION);
+      }
+    })();
+  }
+
+  const insertArtifact = db.prepare(`
+    INSERT INTO work_context_artifacts (
+      id, work_context_id, project_id, task_ref_kind, task_ref_id, stage,
+      provenance_actor_id, kind, title, summary, visibility, created_at,
+      updated_at, captured_at, payload_kind, payload_media_type, payload_path,
+      payload_sha256, payload_bytes, pr_number, head_sha, base_name,
+      branch_name, supersedes_artifact_id, metadata_json
+    ) VALUES (
+      @id, @workContextId, @projectId, @taskRefKind, @taskRefId, @stage,
+      @provenanceActorId, @kind, @title, @summary, @visibility, @createdAt,
+      @updatedAt, @capturedAt, @payloadKind, @payloadMediaType, @payloadPath,
+      @payloadSha256, @payloadBytes, @prNumber, @headSha, @baseName,
+      @branchName, @supersedesArtifactId, @metadataJson
+    )
+  `);
+  const selectById = db.prepare('SELECT * FROM work_context_artifacts WHERE id = ?');
+
+  function mustNotAlreadyExist(id: string): void {
+    if (selectById.get(id)) {
+      throw new WorkContextArtifactStoreError(409, 'artifact_already_exists');
+    }
+  }
+
+  function mustValidateSupersedes(id: string | undefined): void {
+    if (!id) return;
+    if (!selectById.get(id)) {
+      throw new WorkContextArtifactStoreError(400, 'superseded_artifact_not_found');
+    }
+  }
+
+  function writePayloadFile(payloadJson: string, sha256: string): string {
+    const dir = path.join(payloadRoot, sha256.slice(0, 2), sha256.slice(2, 4));
+    mkdirSync(dir, { recursive: true });
+    const payloadPath = path.join(dir, `${sha256}.json`);
+    if (!existsSync(payloadPath)) {
+      try {
+        writeFileSync(payloadPath, payloadJson, { flag: 'wx' });
+      } catch (err) {
+        if (!isFileExistsError(err)) throw err;
+      }
+    }
+    return payloadPath;
+  }
+
+  function rowToRecord(row: WorkContextArtifactRow): WorkContextArtifactRecord {
+    return {
+      metadata: rowToMetadata(row),
+      payloadPath: row.payload_path,
+    };
+  }
+
+  function getRow(id: string): WorkContextArtifactRow | null {
+    return (selectById.get(id) as WorkContextArtifactRow | undefined) ?? null;
+  }
+
+  return {
+    close() {
+      db.close();
+    },
+
+    storePipelineHandoffArtifact(storeInput: StorePipelineHandoffArtifactInput) {
+      assertNonEmptyString(storeInput.workContextId, 'workContextId');
+      if (storeInput.projectId !== undefined)
+        assertNonEmptyString(storeInput.projectId, 'projectId');
+      if (storeInput.stage !== undefined) assertValidStage(storeInput.stage);
+      if (storeInput.provenanceActorId !== undefined)
+        assertNonEmptyString(storeInput.provenanceActorId, 'provenanceActorId');
+      if (storeInput.visibility !== undefined)
+        assertValidVisibility(storeInput.visibility);
+      if (storeInput.kind !== undefined) assertValidArtifactKind(storeInput.kind);
+      if (storeInput.title !== undefined)
+        assertNonEmptyString(storeInput.title, 'title');
+      if (storeInput.summary !== undefined)
+        assertNonEmptyString(storeInput.summary, 'summary');
+      const validation = validatePipelineHandoffArtifact(storeInput.artifact);
+      if (!validation.valid) {
+        throw new WorkContextArtifactStoreError(
+          400,
+          'invalid_pipeline_handoff_artifact',
+          validation.errors.join('; ')
+        );
+      }
+      const artifactId = storeInput.id ?? storeInput.artifact.id ?? `artifact:${randomUUID()}`;
+      mustNotAlreadyExist(artifactId);
+      mustValidateSupersedes(storeInput.supersedesArtifactId);
+
+      const taskRef = storeInput.taskRef ?? firstTaskRef(storeInput.artifact);
+      if (!taskRef) {
+        throw new WorkContextArtifactStoreError(400, 'task_ref_required');
+      }
+      assertValidTaskRef(taskRef);
+      const now = new Date().toISOString();
+      const capturedAt = storeInput.capturedAt ?? storeInput.artifact.head.capturedAt;
+      assertIsoTimestamp(capturedAt, 'capturedAt');
+      const payloadJson = JSON.stringify(storeInput.artifact, null, 2);
+      const payloadSha256 = sha256Hex(payloadJson);
+      const payloadPath = writePayloadFile(payloadJson, payloadSha256);
+      const payloadBytes = Buffer.byteLength(payloadJson, 'utf8');
+      const metadata: WorkContextArtifactMetadata = {
+        id: artifactId,
+        workContextId: storeInput.workContextId,
+        ...(storeInput.projectId ? { projectId: storeInput.projectId } : {}),
+        taskRef,
+        ...(storeInput.stage ? { stage: storeInput.stage } : {}),
+        ...(storeInput.provenanceActorId ? { provenanceActorId: storeInput.provenanceActorId } : {}),
+        kind: storeInput.kind ?? 'report',
+        title: storeInput.title ?? storeInput.artifact.title,
+        summary: storeInput.summary ?? storeInput.artifact.scope.summary,
+        visibility: storeInput.visibility ?? DEFAULT_VISIBILITY,
+        createdAt: now,
+        updatedAt: now,
+        capturedAt,
+        payloadKind: 'pipeline-handoff-artifact',
+        payloadMediaType: DEFAULT_PAYLOAD_MEDIA_TYPE,
+        payloadSha256,
+        payloadBytes,
+        ...(storeInput.artifact.head.pr?.number ? { prNumber: storeInput.artifact.head.pr.number } : {}),
+        headSha: storeInput.artifact.head.headSha,
+        baseName: storeInput.artifact.head.base.name,
+        ...(storeInput.artifact.head.branch?.name ? { branchName: storeInput.artifact.head.branch.name } : {}),
+        ...(storeInput.supersedesArtifactId ? { supersedesArtifactId: storeInput.supersedesArtifactId } : {}),
+      };
+      db.transaction(() => {
+        insertArtifact.run({
+          id: metadata.id,
+          workContextId: metadata.workContextId,
+          projectId: metadata.projectId ?? null,
+          taskRefKind: metadata.taskRef.kind,
+          taskRefId: metadata.taskRef.id,
+          stage: metadata.stage ?? null,
+          provenanceActorId: metadata.provenanceActorId ?? null,
+          kind: metadata.kind,
+          title: metadata.title,
+          summary: metadata.summary,
+          visibility: metadata.visibility,
+          createdAt: metadata.createdAt,
+          updatedAt: metadata.updatedAt,
+          capturedAt: metadata.capturedAt,
+          payloadKind: metadata.payloadKind,
+          payloadMediaType: metadata.payloadMediaType,
+          payloadPath,
+          payloadSha256: metadata.payloadSha256,
+          payloadBytes: metadata.payloadBytes,
+          prNumber: metadata.prNumber ?? null,
+          headSha: metadata.headSha ?? null,
+          baseName: metadata.baseName ?? null,
+          branchName: metadata.branchName ?? null,
+          supersedesArtifactId: metadata.supersedesArtifactId ?? null,
+          metadataJson: JSON.stringify({ taskRef: metadata.taskRef } satisfies PersistedMetadataJson),
+        });
+      })();
+      return { metadata, payloadPath };
+    },
+
+    get(id: string) {
+      const row = getRow(id);
+      return row ? rowToRecord(row) : null;
+    },
+
+    read(id: string) {
+      const row = getRow(id);
+      if (!row) return null;
+      const record = rowToRecord(row);
+      const raw = readFileSync(row.payload_path, 'utf8');
+      const payload = JSON.parse(raw) as unknown;
+      if (!isPipelineHandoffArtifact(payload)) {
+        throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
+      }
+      return { ...record, payload };
+    },
+
+    list(input: WorkContextArtifactListInput = {}) {
+      const limit = Math.min(Math.max(input.limit ?? 50, 1), 200);
+      const clauses: string[] = [];
+      const params: Record<string, unknown> = { limit };
+      if (input.workContextId) {
+        clauses.push('work_context_id = @workContextId');
+        params.workContextId = input.workContextId;
+      }
+      if (input.projectId) {
+        clauses.push('project_id = @projectId');
+        params.projectId = input.projectId;
+      }
+      if (input.taskRef) {
+        clauses.push('task_ref_kind = @taskRefKind AND task_ref_id = @taskRefId');
+        params.taskRefKind = input.taskRef.kind;
+        params.taskRefId = input.taskRef.id;
+      }
+      if (input.stage) {
+        clauses.push('stage = @stage');
+        params.stage = input.stage;
+      }
+      if (!input.includeSuperseded) {
+        clauses.push('NOT EXISTS (SELECT 1 FROM work_context_artifacts newer WHERE newer.supersedes_artifact_id = work_context_artifacts.id)');
+      }
+      const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+      const rows = db.prepare(`SELECT * FROM work_context_artifacts ${where} ORDER BY captured_at DESC, created_at DESC LIMIT @limit`).all(params) as WorkContextArtifactRow[];
+      return rows.map(rowToRecord);
+    },
+
+    publicSummary(id: string) {
+      const row = getRow(id);
+      if (!row) return null;
+      const metadata = publicMetadata(rowToMetadata(row));
+      const raw = readFileSync(row.payload_path, 'utf8');
+      const parsed = JSON.parse(raw) as unknown;
+      if (!isPipelineHandoffArtifact(parsed)) {
+        throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
+      }
+      const payload = sanitizePipelineHandoffArtifactForPublic(parsed);
+      const publicValidation = validatePublicPipelineHandoffArtifact(payload);
+      if (!publicValidation.valid) {
+        throw new WorkContextArtifactStoreError(
+          500,
+          'public_artifact_sanitization_failed',
+          publicValidation.errors.join('; ')
+        );
+      }
+      return { metadata, payload };
+    },
+  };
+}
+
+function rowToMetadata(row: WorkContextArtifactRow): WorkContextArtifactMetadata {
+  const json = JSON.parse(row.metadata_json) as PersistedMetadataJson;
+  return {
+    id: row.id,
+    workContextId: row.work_context_id,
+    ...(row.project_id ? { projectId: row.project_id } : {}),
+    taskRef: json.taskRef,
+    ...(row.stage ? { stage: row.stage as PipelineHandoffStageName } : {}),
+    ...(row.provenance_actor_id ? { provenanceActorId: row.provenance_actor_id } : {}),
+    kind: row.kind as ArtifactKind,
+    title: row.title,
+    summary: row.summary,
+    visibility: row.visibility,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    capturedAt: row.captured_at,
+    payloadKind: row.payload_kind,
+    payloadMediaType: row.payload_media_type,
+    payloadSha256: row.payload_sha256,
+    payloadBytes: row.payload_bytes,
+    ...(row.pr_number !== null ? { prNumber: row.pr_number } : {}),
+    ...(row.head_sha ? { headSha: row.head_sha } : {}),
+    ...(row.base_name ? { baseName: row.base_name } : {}),
+    ...(row.branch_name ? { branchName: row.branch_name } : {}),
+    ...(row.supersedes_artifact_id ? { supersedesArtifactId: row.supersedes_artifact_id } : {}),
+  };
+}
+
+function publicMetadata(
+  metadata: WorkContextArtifactMetadata
+): PublicWorkContextArtifactSummary {
+  const taskRef = ['github-issue', 'github-pr'].includes(metadata.taskRef.kind)
+    ? {
+        kind: metadata.taskRef.kind,
+        id: sanitizePublicText(metadata.taskRef.id),
+        ...(metadata.taskRef.title ? { title: sanitizePublicText(metadata.taskRef.title) } : {}),
+        ...(metadata.taskRef.url ? { url: sanitizePublicText(metadata.taskRef.url) } : {}),
+        ...(metadata.taskRef.status ? { status: sanitizePublicText(metadata.taskRef.status) } : {}),
+      }
+    : undefined;
+  return {
+    id: sanitizePublicText(metadata.id),
+    workContextId: sanitizePublicText(metadata.workContextId),
+    ...(metadata.projectId ? { projectId: sanitizePublicText(metadata.projectId) } : {}),
+    ...(taskRef ? { taskRef } : {}),
+    ...(metadata.stage ? { stage: metadata.stage } : {}),
+    kind: metadata.kind,
+    title: sanitizePublicText(metadata.title),
+    summary: sanitizePublicText(metadata.summary),
+    visibility: metadata.visibility,
+    capturedAt: metadata.capturedAt,
+    payloadKind: metadata.payloadKind,
+    payloadSha256: metadata.payloadSha256,
+    payloadBytes: metadata.payloadBytes,
+    ...(metadata.prNumber ? { prNumber: metadata.prNumber } : {}),
+    ...(metadata.headSha ? { headSha: metadata.headSha } : {}),
+    ...(metadata.baseName ? { baseName: sanitizePublicText(metadata.baseName) } : {}),
+    ...(metadata.branchName ? { branchName: sanitizePublicText(metadata.branchName) } : {}),
+    ...(metadata.supersedesArtifactId
+      ? { supersedesArtifactId: sanitizePublicText(metadata.supersedesArtifactId) }
+      : {}),
+  };
+}
+
+function firstTaskRef(artifact: PipelineHandoffArtifact): TaskRef | undefined {
+  return (
+    artifact.scope.taskRefs.find((taskRef) => taskRef.kind === 'github-issue') ??
+    artifact.scope.taskRefs.find((taskRef) => taskRef.kind === 'github-pr') ??
+    artifact.scope.taskRefs[0]
+  );
+}
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function assertIsoTimestamp(value: string, label: string): void {
+  if (Number.isNaN(Date.parse(value))) {
+    throw new WorkContextArtifactStoreError(400, `${label}_invalid`);
+  }
+}
+
+function assertNonEmptyString(value: string, label: string): void {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new WorkContextArtifactStoreError(400, `${label}_required`);
+  }
+}
+
+function assertValidStage(value: string): void {
+  if (!STAGES.has(value)) {
+    throw new WorkContextArtifactStoreError(400, 'stage_invalid');
+  }
+}
+
+function assertValidVisibility(value: string): void {
+  if (!VISIBILITIES.has(value)) {
+    throw new WorkContextArtifactStoreError(400, 'visibility_invalid');
+  }
+}
+
+function assertValidArtifactKind(value: string): void {
+  if (!ARTIFACT_KINDS.has(value)) {
+    throw new WorkContextArtifactStoreError(400, 'artifact_kind_invalid');
+  }
+}
+
+function assertValidTaskRef(value: TaskRef): void {
+  assertNonEmptyString(value.kind, 'taskRef.kind');
+  assertNonEmptyString(value.id, 'taskRef.id');
+}
+
+function sanitizePublicText(value: string): string {
+  SECRET_TEXT_RE.lastIndex = 0;
+  ABSOLUTE_LOCAL_PATH_RE.lastIndex = 0;
+  WINDOWS_ABSOLUTE_PATH_RE.lastIndex = 0;
+  UNC_PATH_RE.lastIndex = 0;
+  KANBAN_TASK_ID_RE.lastIndex = 0;
+  return value
+    .replace(SECRET_TEXT_RE, '[redacted-secret]')
+    .replace(ABSOLUTE_LOCAL_PATH_RE, (match) => {
+      const prefix = " \t:=('\"".includes(match[0] ?? '') ? match[0] : '';
+      return `${prefix}[redacted-local-path]`;
+    })
+    .replace(WINDOWS_ABSOLUTE_PATH_RE, (match) => {
+      const prefix = " \t:=('\"".includes(match[0] ?? '') ? match[0] : '';
+      return `${prefix}[redacted-local-path]`;
+    })
+    .replace(UNC_PATH_RE, (match) => {
+      const prefix = " \t:=('\"".includes(match[0] ?? '') ? match[0] : '';
+      return `${prefix}[redacted-local-path]`;
+    })
+    .replace(KANBAN_TASK_ID_RE, '[redacted-kanban-task]');
+}
+
+function isFileExistsError(err: unknown): boolean {
+  return isRecord(err) && err.code === 'EEXIST';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/server/work-context-artifacts.ts
+++ b/server/work-context-artifacts.ts
@@ -17,6 +17,7 @@ import {
   ARTIFACT_KINDS,
   type ArtifactKind,
   type TaskRef,
+  type TaskRefKind,
   type WorkContextId,
 } from '../shared/work-context.js';
 
@@ -25,6 +26,14 @@ const DEFAULT_PAYLOAD_MEDIA_TYPE = 'application/json';
 const DEFAULT_VISIBILITY: WorkContextArtifactVisibility = 'private';
 const VISIBILITIES = new Set<string>(['private', 'public']);
 const STAGES = new Set<string>(PIPELINE_HANDOFF_STAGES);
+const TASK_REF_KINDS = new Set<string>([
+  'github-issue',
+  'github-pr',
+  'kanban-task',
+  'jira-ticket',
+  'linear-issue',
+  'external',
+]);
 const SECRET_TEXT_RE =
   /(?:bearer\s+[a-z0-9._~+/-]+=*|sk-[a-z0-9_-]{8,}|relay-(?:sac|ohg|grant|auth|pair)-v1[a-z0-9._-]*|pair_[a-z0-9_-]{8,}|node_[a-z0-9._~+/=-]+\.secret_[a-z0-9._~+/=-]+|secret_[a-z0-9._~+/=-]+)/gi;
 const ABSOLUTE_LOCAL_PATH_RE =
@@ -282,13 +291,6 @@ export function createWorkContextArtifactStore(input: {
       @branchName, @supersedesArtifactId, @metadataJson
     )
   `);
-  db.prepare(`
-    INSERT OR IGNORE INTO work_context_artifact_task_refs (
-      artifact_id, task_ref_kind, task_ref_id
-    )
-    SELECT id, task_ref_kind, task_ref_id
-    FROM work_context_artifacts
-  `).run();
   const insertTaskRef = db.prepare(`
     INSERT OR IGNORE INTO work_context_artifact_task_refs (
       artifact_id, task_ref_kind, task_ref_id, task_ref_title, task_ref_url, task_ref_status
@@ -296,6 +298,7 @@ export function createWorkContextArtifactStore(input: {
       @artifactId, @taskRefKind, @taskRefId, @taskRefTitle, @taskRefUrl, @taskRefStatus
     )
   `);
+  backfillArtifactTaskRefs(db, insertTaskRef);
   const selectById = db.prepare('SELECT * FROM work_context_artifacts WHERE id = ?');
 
   function mustNotAlreadyExist(id: string): void {
@@ -543,6 +546,45 @@ export function createWorkContextArtifactStore(input: {
   };
 }
 
+function backfillArtifactTaskRefs(
+  db: Database.Database,
+  insertTaskRef: Database.Statement
+): void {
+  const rows = db.prepare('SELECT * FROM work_context_artifacts').all() as WorkContextArtifactRow[];
+  db.transaction(() => {
+    for (const row of rows) {
+      const taskRefs = dedupeTaskRefs([legacyTaskRef(row), ...payloadTaskRefs(row)]);
+      for (const taskRef of taskRefs) {
+        if (!isValidTaskRef(taskRef)) continue;
+        insertTaskRef.run({
+          artifactId: row.id,
+          taskRefKind: taskRef.kind,
+          taskRefId: taskRef.id,
+          taskRefTitle: taskRef.title ?? null,
+          taskRefUrl: taskRef.url ?? null,
+          taskRefStatus: taskRef.status ?? null,
+        });
+      }
+    }
+  })();
+}
+
+function legacyTaskRef(row: WorkContextArtifactRow): TaskRef {
+  return { kind: row.task_ref_kind as TaskRefKind, id: row.task_ref_id };
+}
+
+function payloadTaskRefs(row: WorkContextArtifactRow): TaskRef[] {
+  try {
+    const raw = readFileSync(row.payload_path, 'utf8');
+    assertPayloadSha256(raw, row);
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isPipelineHandoffArtifact(parsed)) return [];
+    return parsed.scope.taskRefs.filter(isValidTaskRef);
+  } catch {
+    return [];
+  }
+}
+
 function rowToMetadata(row: WorkContextArtifactRow): WorkContextArtifactMetadata {
   const json = JSON.parse(row.metadata_json) as PersistedMetadataJson;
   return {
@@ -674,6 +716,15 @@ function assertValidArtifactKind(value: string): void {
 function assertValidTaskRef(value: TaskRef): void {
   assertNonEmptyString(value.kind, 'taskRef.kind');
   assertNonEmptyString(value.id, 'taskRef.id');
+}
+
+function isValidTaskRef(value: TaskRef): value is TaskRef & { kind: TaskRefKind } {
+  return (
+    typeof value.kind === 'string' &&
+    TASK_REF_KINDS.has(value.kind) &&
+    typeof value.id === 'string' &&
+    value.id.trim().length > 0
+  );
 }
 
 function sanitizePublicText(value: string): string {

--- a/server/work-context-artifacts.ts
+++ b/server/work-context-artifacts.ts
@@ -20,7 +20,7 @@ import {
   type WorkContextId,
 } from '../shared/work-context.js';
 
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 const DEFAULT_PAYLOAD_MEDIA_TYPE = 'application/json';
 const DEFAULT_VISIBILITY: WorkContextArtifactVisibility = 'private';
 const VISIBILITIES = new Set<string>(['private', 'public']);
@@ -32,6 +32,7 @@ const ABSOLUTE_LOCAL_PATH_RE =
 const WINDOWS_ABSOLUTE_PATH_RE = /(?:^|[\s:=('"])[a-z]:[\\/][^\s)'"]+/gi;
 const UNC_PATH_RE = /(?:^|[\s:=('"])\\\\[^\s\\/'"]+[\\/][^\s)'"]+/g;
 const KANBAN_TASK_ID_RE = /\bt_[a-f0-9]{8,}\b/gi;
+const STRICT_ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS work_context_artifacts (
@@ -72,6 +73,18 @@ CREATE INDEX IF NOT EXISTS idx_work_context_artifacts_head
   ON work_context_artifacts(head_sha);
 CREATE INDEX IF NOT EXISTS idx_work_context_artifacts_supersedes
   ON work_context_artifacts(supersedes_artifact_id);
+CREATE TABLE IF NOT EXISTS work_context_artifact_task_refs (
+  artifact_id          TEXT NOT NULL,
+  task_ref_kind        TEXT NOT NULL,
+  task_ref_id          TEXT NOT NULL,
+  task_ref_title       TEXT,
+  task_ref_url         TEXT,
+  task_ref_status      TEXT,
+  PRIMARY KEY (artifact_id, task_ref_kind, task_ref_id),
+  FOREIGN KEY (artifact_id) REFERENCES work_context_artifacts(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_work_context_artifact_task_refs_lookup
+  ON work_context_artifact_task_refs(task_ref_kind, task_ref_id, artifact_id);
 `;
 
 export type WorkContextArtifactVisibility = 'private' | 'public';
@@ -269,6 +282,20 @@ export function createWorkContextArtifactStore(input: {
       @branchName, @supersedesArtifactId, @metadataJson
     )
   `);
+  db.prepare(`
+    INSERT OR IGNORE INTO work_context_artifact_task_refs (
+      artifact_id, task_ref_kind, task_ref_id
+    )
+    SELECT id, task_ref_kind, task_ref_id
+    FROM work_context_artifacts
+  `).run();
+  const insertTaskRef = db.prepare(`
+    INSERT OR IGNORE INTO work_context_artifact_task_refs (
+      artifact_id, task_ref_kind, task_ref_id, task_ref_title, task_ref_url, task_ref_status
+    ) VALUES (
+      @artifactId, @taskRefKind, @taskRefId, @taskRefTitle, @taskRefUrl, @taskRefStatus
+    )
+  `);
   const selectById = db.prepare('SELECT * FROM work_context_artifacts WHERE id = ?');
 
   function mustNotAlreadyExist(id: string): void {
@@ -277,10 +304,17 @@ export function createWorkContextArtifactStore(input: {
     }
   }
 
-  function mustValidateSupersedes(id: string | undefined): void {
+  function mustValidateSupersedes(
+    id: string | undefined,
+    workContextId: WorkContextId
+  ): void {
     if (!id) return;
-    if (!selectById.get(id)) {
+    const row = selectById.get(id) as WorkContextArtifactRow | undefined;
+    if (!row) {
       throw new WorkContextArtifactStoreError(400, 'superseded_artifact_not_found');
+    }
+    if (row.work_context_id !== workContextId) {
+      throw new WorkContextArtifactStoreError(400, 'superseded_artifact_scope_mismatch');
     }
   }
 
@@ -336,15 +370,23 @@ export function createWorkContextArtifactStore(input: {
           validation.errors.join('; ')
         );
       }
+      if (storeInput.id !== undefined) {
+        assertNonEmptyString(storeInput.id, 'id');
+        if (storeInput.artifact.id !== undefined && storeInput.id !== storeInput.artifact.id) {
+          throw new WorkContextArtifactStoreError(400, 'artifact_id_mismatch');
+        }
+      }
       const artifactId = storeInput.id ?? storeInput.artifact.id ?? `artifact:${randomUUID()}`;
       mustNotAlreadyExist(artifactId);
-      mustValidateSupersedes(storeInput.supersedesArtifactId);
+      mustValidateSupersedes(storeInput.supersedesArtifactId, storeInput.workContextId);
 
       const taskRef = storeInput.taskRef ?? firstTaskRef(storeInput.artifact);
       if (!taskRef) {
         throw new WorkContextArtifactStoreError(400, 'task_ref_required');
       }
       assertValidTaskRef(taskRef);
+      const taskRefs = dedupeTaskRefs([taskRef, ...storeInput.artifact.scope.taskRefs]);
+      for (const indexedTaskRef of taskRefs) assertValidTaskRef(indexedTaskRef);
       const now = new Date().toISOString();
       const capturedAt = storeInput.capturedAt ?? storeInput.artifact.head.capturedAt;
       assertIsoTimestamp(capturedAt, 'capturedAt');
@@ -404,6 +446,16 @@ export function createWorkContextArtifactStore(input: {
           supersedesArtifactId: metadata.supersedesArtifactId ?? null,
           metadataJson: JSON.stringify({ taskRef: metadata.taskRef } satisfies PersistedMetadataJson),
         });
+        for (const indexedTaskRef of taskRefs) {
+          insertTaskRef.run({
+            artifactId: metadata.id,
+            taskRefKind: indexedTaskRef.kind,
+            taskRefId: indexedTaskRef.id,
+            taskRefTitle: indexedTaskRef.title ?? null,
+            taskRefUrl: indexedTaskRef.url ?? null,
+            taskRefStatus: indexedTaskRef.status ?? null,
+          });
+        }
       })();
       return { metadata, payloadPath };
     },
@@ -418,6 +470,7 @@ export function createWorkContextArtifactStore(input: {
       if (!row) return null;
       const record = rowToRecord(row);
       const raw = readFileSync(row.payload_path, 'utf8');
+      assertPayloadSha256(raw, row);
       const payload = JSON.parse(raw) as unknown;
       if (!isPipelineHandoffArtifact(payload)) {
         throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
@@ -438,7 +491,13 @@ export function createWorkContextArtifactStore(input: {
         params.projectId = input.projectId;
       }
       if (input.taskRef) {
-        clauses.push('task_ref_kind = @taskRefKind AND task_ref_id = @taskRefId');
+        clauses.push(`EXISTS (
+          SELECT 1
+          FROM work_context_artifact_task_refs task_refs
+          WHERE task_refs.artifact_id = work_context_artifacts.id
+            AND task_refs.task_ref_kind = @taskRefKind
+            AND task_refs.task_ref_id = @taskRefId
+        )`);
         params.taskRefKind = input.taskRef.kind;
         params.taskRefId = input.taskRef.id;
       }
@@ -447,7 +506,12 @@ export function createWorkContextArtifactStore(input: {
         params.stage = input.stage;
       }
       if (!input.includeSuperseded) {
-        clauses.push('NOT EXISTS (SELECT 1 FROM work_context_artifacts newer WHERE newer.supersedes_artifact_id = work_context_artifacts.id)');
+        clauses.push(`NOT EXISTS (
+          SELECT 1
+          FROM work_context_artifacts newer
+          WHERE newer.supersedes_artifact_id = work_context_artifacts.id
+            AND newer.work_context_id = work_context_artifacts.work_context_id
+        )`);
       }
       const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
       const rows = db.prepare(`SELECT * FROM work_context_artifacts ${where} ORDER BY captured_at DESC, created_at DESC LIMIT @limit`).all(params) as WorkContextArtifactRow[];
@@ -457,8 +521,10 @@ export function createWorkContextArtifactStore(input: {
     publicSummary(id: string) {
       const row = getRow(id);
       if (!row) return null;
+      if (row.visibility !== 'public') return null;
       const metadata = publicMetadata(rowToMetadata(row));
       const raw = readFileSync(row.payload_path, 'utf8');
+      assertPayloadSha256(raw, row);
       const parsed = JSON.parse(raw) as unknown;
       if (!isPipelineHandoffArtifact(parsed)) {
         throw new WorkContextArtifactStoreError(500, 'stored_payload_invalid');
@@ -549,12 +615,34 @@ function firstTaskRef(artifact: PipelineHandoffArtifact): TaskRef | undefined {
   );
 }
 
+function dedupeTaskRefs(taskRefs: TaskRef[]): TaskRef[] {
+  const seen = new Set<string>();
+  const unique: TaskRef[] = [];
+  for (const taskRef of taskRefs) {
+    const key = `${taskRef.kind}\u0000${taskRef.id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(taskRef);
+  }
+  return unique;
+}
+
 function sha256Hex(value: string): string {
   return createHash('sha256').update(value).digest('hex');
 }
 
+function assertPayloadSha256(raw: string, row: WorkContextArtifactRow): void {
+  if (sha256Hex(raw) !== row.payload_sha256) {
+    throw new WorkContextArtifactStoreError(500, 'stored_payload_sha256_mismatch');
+  }
+}
+
 function assertIsoTimestamp(value: string, label: string): void {
-  if (Number.isNaN(Date.parse(value))) {
+  if (!STRICT_ISO_TIMESTAMP_RE.test(value)) {
+    throw new WorkContextArtifactStoreError(400, `${label}_invalid`);
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== value) {
     throw new WorkContextArtifactStoreError(400, `${label}_invalid`);
   }
 }

--- a/test/work-context-artifacts.test.ts
+++ b/test/work-context-artifacts.test.ts
@@ -1,7 +1,9 @@
+import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
@@ -30,6 +32,12 @@ function tmpStore(): { root: string; store: WorkContextArtifactStore } {
   });
   cleanup.push(() => store.close());
   return { root, store };
+}
+
+function tmpRoot(prefix = 'work-context-artifacts-'): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  cleanup.push(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
 }
 
 afterEach(() => {
@@ -107,6 +115,106 @@ function artifact(input: Partial<PipelineHandoffArtifact> = {}): PipelineHandoff
     ],
     ...input,
   };
+}
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function createLegacyV1Store(input: {
+  root: string;
+  payload: PipelineHandoffArtifact;
+  primaryTaskRef: { kind: string; id: string };
+}): string {
+  const dbPath = path.join(input.root, 'index.db');
+  const payloadRoot = path.join(input.root, 'payloads');
+  fs.mkdirSync(payloadRoot, { recursive: true });
+  const payloadJson = JSON.stringify(input.payload, null, 2);
+  const payloadSha256 = sha256Hex(payloadJson);
+  const payloadPath = path.join(payloadRoot, `${payloadSha256}.json`);
+  fs.writeFileSync(payloadPath, payloadJson);
+
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE work_context_artifact_schema_version (version INTEGER NOT NULL);
+    INSERT INTO work_context_artifact_schema_version (version) VALUES (1);
+    CREATE TABLE work_context_artifacts (
+      id                    TEXT PRIMARY KEY,
+      work_context_id       TEXT NOT NULL,
+      project_id            TEXT,
+      task_ref_kind         TEXT NOT NULL,
+      task_ref_id           TEXT NOT NULL,
+      stage                 TEXT,
+      provenance_actor_id   TEXT,
+      kind                  TEXT NOT NULL,
+      title                 TEXT NOT NULL,
+      summary               TEXT NOT NULL,
+      visibility            TEXT NOT NULL,
+      created_at            TEXT NOT NULL,
+      updated_at            TEXT NOT NULL,
+      captured_at           TEXT NOT NULL,
+      payload_kind          TEXT NOT NULL,
+      payload_media_type    TEXT NOT NULL,
+      payload_path          TEXT NOT NULL,
+      payload_sha256        TEXT NOT NULL,
+      payload_bytes         INTEGER NOT NULL,
+      pr_number             INTEGER,
+      head_sha              TEXT,
+      base_name             TEXT,
+      branch_name           TEXT,
+      supersedes_artifact_id TEXT,
+      metadata_json         TEXT NOT NULL,
+      CHECK (visibility IN ('private', 'public'))
+    );
+  `);
+  db.prepare(`
+    INSERT INTO work_context_artifacts (
+      id, work_context_id, project_id, task_ref_kind, task_ref_id, stage,
+      provenance_actor_id, kind, title, summary, visibility, created_at,
+      updated_at, captured_at, payload_kind, payload_media_type, payload_path,
+      payload_sha256, payload_bytes, pr_number, head_sha, base_name,
+      branch_name, supersedes_artifact_id, metadata_json
+    ) VALUES (
+      @id, @workContextId, @projectId, @taskRefKind, @taskRefId, @stage,
+      @provenanceActorId, @kind, @title, @summary, @visibility, @createdAt,
+      @updatedAt, @capturedAt, @payloadKind, @payloadMediaType, @payloadPath,
+      @payloadSha256, @payloadBytes, @prNumber, @headSha, @baseName,
+      @branchName, @supersedesArtifactId, @metadataJson
+    )
+  `).run({
+    id: input.payload.id,
+    workContextId: 'wc:legacy-v1',
+    projectId: 'project:example-org/example-project',
+    taskRefKind: input.primaryTaskRef.kind,
+    taskRefId: input.primaryTaskRef.id,
+    stage: 'implementation',
+    provenanceActorId: 'agent:kani-backend',
+    kind: 'report',
+    title: input.payload.title,
+    summary: input.payload.scope.summary,
+    visibility: 'private',
+    createdAt: input.payload.createdAt,
+    updatedAt: input.payload.updatedAt,
+    capturedAt: input.payload.head.capturedAt,
+    payloadKind: 'pipeline-handoff-artifact',
+    payloadMediaType: 'application/json',
+    payloadPath,
+    payloadSha256,
+    payloadBytes: Buffer.byteLength(payloadJson, 'utf8'),
+    prNumber: input.payload.head.pr?.number ?? null,
+    headSha: input.payload.head.headSha,
+    baseName: input.payload.head.base.name,
+    branchName: input.payload.head.branch?.name ?? null,
+    supersedesArtifactId: null,
+    metadataJson: JSON.stringify({
+      taskRef: {
+        kind: input.primaryTaskRef.kind,
+        id: input.primaryTaskRef.id,
+      },
+    }),
+  });
+  db.close();
+  return dbPath;
 }
 
 describe('WorkContext artifact store/index', () => {
@@ -187,6 +295,51 @@ describe('WorkContext artifact store/index', () => {
     expect(store.list({ taskRef: { kind: 'github-pr', id: '893' } })).toHaveLength(1);
     expect(store.list({ taskRef: { kind: 'github-pr', id: '893' } })[0]?.metadata.id).toBe(
       stored.metadata.id
+    );
+  });
+
+  it('backfills v1 artifact rows from every valid payload task ref during migration', () => {
+    const root = tmpRoot('work-context-artifacts-v1-');
+    const legacyPayload = artifact({
+      id: 'pipeline-handoff:legacy-v1:aaaaaaaa',
+      scope: {
+        ...artifact().scope,
+        taskRefs: [
+          {
+            kind: 'github-issue',
+            id: '889',
+            url: 'https://github.com/example-org/example-project/issues/889',
+          },
+          {
+            kind: 'github-pr',
+            id: '893',
+            url: 'https://github.com/example-org/example-project/pull/893',
+          },
+        ],
+      },
+      head: {
+        ...artifact().head,
+        pr: {
+          number: 893,
+          url: 'https://github.com/example-org/example-project/pull/893',
+        },
+      },
+    });
+    const dbPath = createLegacyV1Store({
+      root,
+      payload: legacyPayload,
+      primaryTaskRef: { kind: 'github-issue', id: '889' },
+    });
+    const store = createWorkContextArtifactStore({
+      dbPath,
+      payloadRoot: path.join(root, 'payloads'),
+    });
+    cleanup.push(() => store.close());
+
+    expect(store.list({ taskRef: { kind: 'github-issue', id: '889' } })).toHaveLength(1);
+    expect(store.list({ taskRef: { kind: 'github-pr', id: '893' } })).toHaveLength(1);
+    expect(store.list({ taskRef: { kind: 'github-pr', id: '893' } })[0]?.metadata.id).toBe(
+      legacyPayload.id
     );
   });
 

--- a/test/work-context-artifacts.test.ts
+++ b/test/work-context-artifacts.test.ts
@@ -151,6 +151,45 @@ describe('WorkContext artifact store/index', () => {
     expect(read?.payload?.title).toBe('Example Project implementation handoff');
   });
 
+  it('indexes every task ref from a handoff artifact payload', () => {
+    const { store } = tmpStore();
+    const multiRefArtifact = artifact({
+      scope: {
+        ...artifact().scope,
+        taskRefs: [
+          {
+            kind: 'github-issue',
+            id: '889',
+            url: 'https://github.com/example-org/example-project/issues/889',
+          },
+          {
+            kind: 'github-pr',
+            id: '893',
+            url: 'https://github.com/example-org/example-project/pull/893',
+          },
+        ],
+      },
+      head: {
+        ...artifact().head,
+        pr: {
+          number: 893,
+          url: 'https://github.com/example-org/example-project/pull/893',
+        },
+      },
+    });
+
+    const stored = store.storePipelineHandoffArtifact({
+      workContextId: 'wc:multi-task-ref',
+      artifact: multiRefArtifact,
+    });
+
+    expect(store.list({ taskRef: { kind: 'github-issue', id: '889' } })).toHaveLength(1);
+    expect(store.list({ taskRef: { kind: 'github-pr', id: '893' } })).toHaveLength(1);
+    expect(store.list({ taskRef: { kind: 'github-pr', id: '893' } })[0]?.metadata.id).toBe(
+      stored.metadata.id
+    );
+  });
+
   it('lists from the SQLite index without reading payload files', () => {
     const { store } = tmpStore();
     const stored = store.storePipelineHandoffArtifact({
@@ -164,7 +203,7 @@ describe('WorkContext artifact store/index', () => {
     expect(listed[0]?.metadata.summary).toBe(
       'artifact store foundation for generic project work'
     );
-    expect(() => store.read(stored.metadata.id)).toThrow(SyntaxError);
+    expect(() => store.read(stored.metadata.id)).toThrow(WorkContextArtifactStoreError);
   });
 
   it('preserves append-only history and models superseded refs without rewriting prior rows', () => {
@@ -263,5 +302,81 @@ describe('WorkContext artifact store/index', () => {
       publicCopy?.payload?.scope.nonGoals.some((item) => /kanban|dispatcher|worktree/i.test(item))
     ).toBe(false);
     expect(validatePublicPipelineHandoffArtifact(publicCopy?.payload as PipelineHandoffArtifact).valid).toBe(true);
+  });
+
+  it('does not expose private artifacts through publicSummary', () => {
+    const { store } = tmpStore();
+    const stored = store.storePipelineHandoffArtifact({
+      workContextId: 'wc:private-copy',
+      visibility: 'private',
+      artifact: artifact(),
+    });
+
+    expect(store.publicSummary(stored.metadata.id)).toBeNull();
+  });
+
+  it('verifies sha-addressed payload integrity when reading stored artifacts', () => {
+    const { store } = tmpStore();
+    const stored = store.storePipelineHandoffArtifact({
+      workContextId: 'wc:tamper-proof',
+      visibility: 'public',
+      artifact: artifact(),
+    });
+    fs.writeFileSync(
+      stored.payloadPath,
+      JSON.stringify(
+        artifact({
+          id: 'pipeline-handoff:example:tampered',
+          head: { ...artifact().head, headSha: nextHeadSha },
+        }),
+        null,
+        2
+      )
+    );
+
+    expect(() => store.read(stored.metadata.id)).toThrow(WorkContextArtifactStoreError);
+    expect(() => store.publicSummary(stored.metadata.id)).toThrow(WorkContextArtifactStoreError);
+  });
+
+  it('rejects supersedes edges across WorkContexts', () => {
+    const { store } = tmpStore();
+    const first = store.storePipelineHandoffArtifact({
+      workContextId: 'wc:a',
+      artifact: artifact(),
+    });
+
+    expect(() =>
+      store.storePipelineHandoffArtifact({
+        workContextId: 'wc:b',
+        artifact: artifact({
+          id: 'pipeline-handoff:example:bbbbbbbb',
+          head: { ...artifact().head, headSha: nextHeadSha },
+        }),
+        supersedesArtifactId: first.metadata.id,
+      })
+    ).toThrow(WorkContextArtifactStoreError);
+    expect(store.list({ workContextId: 'wc:a' }).map((entry) => entry.metadata.id)).toEqual([
+      first.metadata.id,
+    ]);
+  });
+
+  it('rejects loose timestamps and mismatched store ids', () => {
+    const { store } = tmpStore();
+
+    expect(() =>
+      store.storePipelineHandoffArtifact({
+        workContextId: 'wc:validation',
+        capturedAt: '2026-06-08 12:00:00',
+        artifact: artifact(),
+      })
+    ).toThrow(WorkContextArtifactStoreError);
+
+    expect(() =>
+      store.storePipelineHandoffArtifact({
+        id: 'different-id',
+        workContextId: 'wc:validation',
+        artifact: artifact(),
+      })
+    ).toThrow(WorkContextArtifactStoreError);
   });
 });

--- a/test/work-context-artifacts.test.ts
+++ b/test/work-context-artifacts.test.ts
@@ -125,7 +125,7 @@ function createLegacyV1Store(input: {
   root: string;
   payload: PipelineHandoffArtifact;
   primaryTaskRef: { kind: string; id: string };
-}): string {
+}): { dbPath: string; payloadPath: string } {
   const dbPath = path.join(input.root, 'index.db');
   const payloadRoot = path.join(input.root, 'payloads');
   fs.mkdirSync(payloadRoot, { recursive: true });
@@ -214,7 +214,7 @@ function createLegacyV1Store(input: {
     }),
   });
   db.close();
-  return dbPath;
+  return { dbPath, payloadPath };
 }
 
 describe('WorkContext artifact store/index', () => {
@@ -325,7 +325,7 @@ describe('WorkContext artifact store/index', () => {
         },
       },
     });
-    const dbPath = createLegacyV1Store({
+    const { dbPath } = createLegacyV1Store({
       root,
       payload: legacyPayload,
       primaryTaskRef: { kind: 'github-issue', id: '889' },
@@ -341,6 +341,34 @@ describe('WorkContext artifact store/index', () => {
     expect(store.list({ taskRef: { kind: 'github-pr', id: '893' } })[0]?.metadata.id).toBe(
       legacyPayload.id
     );
+  });
+
+  it('falls back to the legacy primary task ref when a v1 payload is tampered', () => {
+    const root = tmpRoot('work-context-artifacts-v1-tampered-');
+    const legacyPayload = artifact({
+      id: 'pipeline-handoff:legacy-v1-tampered:aaaaaaaa',
+      scope: {
+        ...artifact().scope,
+        taskRefs: [
+          { kind: 'github-issue', id: '889' },
+          { kind: 'github-pr', id: '893' },
+        ],
+      },
+    });
+    const { dbPath, payloadPath } = createLegacyV1Store({
+      root,
+      payload: legacyPayload,
+      primaryTaskRef: { kind: 'github-issue', id: '889' },
+    });
+    fs.writeFileSync(payloadPath, '{"scope":{"taskRefs":[{"kind":"github-pr","id":"893"}]}}');
+    const store = createWorkContextArtifactStore({
+      dbPath,
+      payloadRoot: path.join(root, 'payloads'),
+    });
+    cleanup.push(() => store.close());
+
+    expect(store.list({ taskRef: { kind: 'github-issue', id: '889' } })).toHaveLength(1);
+    expect(store.list({ taskRef: { kind: 'github-pr', id: '893' } })).toHaveLength(0);
   });
 
   it('lists from the SQLite index without reading payload files', () => {

--- a/test/work-context-artifacts.test.ts
+++ b/test/work-context-artifacts.test.ts
@@ -1,0 +1,267 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createWorkContextArtifactStore,
+  WorkContextArtifactStoreError,
+  type WorkContextArtifactStore,
+} from '../server/work-context-artifacts.js';
+import {
+  PIPELINE_HANDOFF_ARTIFACT_SCHEMA_VERSION,
+  validatePublicPipelineHandoffArtifact,
+  type PipelineHandoffArtifact,
+} from '../shared/pipeline-handoff-artifact.js';
+
+const now = '2026-06-08T12:00:00.000Z';
+const headSha = 'a'.repeat(40);
+const nextHeadSha = 'b'.repeat(40);
+
+const cleanup: Array<() => void> = [];
+
+function tmpStore(): { root: string; store: WorkContextArtifactStore } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'work-context-artifacts-'));
+  cleanup.push(() => fs.rmSync(root, { recursive: true, force: true }));
+  const store = createWorkContextArtifactStore({
+    dbPath: path.join(root, 'index.db'),
+    payloadRoot: path.join(root, 'payloads'),
+  });
+  cleanup.push(() => store.close());
+  return { root, store };
+}
+
+afterEach(() => {
+  for (const dispose of cleanup.splice(0).reverse()) dispose();
+});
+
+function artifact(input: Partial<PipelineHandoffArtifact> = {}): PipelineHandoffArtifact {
+  return {
+    schemaVersion: PIPELINE_HANDOFF_ARTIFACT_SCHEMA_VERSION,
+    id: 'pipeline-handoff:example:aaaaaaaa',
+    title: 'Example Project implementation handoff',
+    createdAt: now,
+    updatedAt: now,
+    scope: {
+      summary: 'artifact store foundation for generic project work',
+      risk: 'medium',
+      taskRefs: [
+        {
+          kind: 'github-issue',
+          id: '42',
+          url: 'https://github.com/example-org/example-project/issues/42',
+        },
+        {
+          kind: 'kanban-task',
+          id: 't_12345678',
+          status: 'running',
+        },
+      ],
+      acceptance: [
+        'payload files are separate from indexed metadata',
+        'list queries are bounded by the metadata index',
+      ],
+      nonGoals: ['no raw transcript ingestion', 'no internal dispatcher or local worktree public copy'],
+    },
+    head: {
+      repo: { ownerRepo: 'example-org/example-project' },
+      base: { name: 'nightly' },
+      branch: { name: 'issue-42-artifact-store' },
+      pr: {
+        number: 123,
+        url: 'https://github.com/example-org/example-project/pull/123',
+      },
+      headSha,
+      staleIf: { headShaChanges: true },
+      capturedAt: now,
+    },
+    stages: [
+      {
+        stage: 'implementation',
+        addedAt: now,
+        actorId: 'agent:kani-backend',
+        summary: 'stored payload file from /home/operator/example while keeping index metadata bounded',
+        acceptanceEvidence: [
+          {
+            label: 'storage/index',
+            disposition: 'provided',
+            summary: 'metadata row and sha-addressed payload file recorded',
+          },
+        ],
+        commands: [
+          {
+            label: 'targeted tests',
+            command: 'npm test -- test/work-context-artifacts.test.ts',
+            status: 'passed',
+            summary: 'focused artifact store tests passed',
+            exitCode: 0,
+          },
+        ],
+        downstreamFocus: ['verify append-only metadata and public sanitizer boundaries'],
+        nonGoals: ['no UI or resume-packet integration in this slice'],
+        decision: 'implemented',
+        changedFiles: ['server/work-context-artifacts.ts'],
+        migrationOrStateRisk: 'new isolated SQLite index and payload directory only',
+      },
+    ],
+    ...input,
+  };
+}
+
+describe('WorkContext artifact store/index', () => {
+  it('persists validated handoff artifacts as payload files plus indexed metadata', () => {
+    const { root, store } = tmpStore();
+
+    const stored = store.storePipelineHandoffArtifact({
+      workContextId: 'wc:example',
+      projectId: 'project:example-org/example-project',
+      stage: 'implementation',
+      provenanceActorId: 'agent:kani-backend',
+      artifact: artifact(),
+    });
+
+    expect(stored.metadata).toMatchObject({
+      id: 'pipeline-handoff:example:aaaaaaaa',
+      workContextId: 'wc:example',
+      projectId: 'project:example-org/example-project',
+      taskRef: { kind: 'github-issue', id: '42' },
+      stage: 'implementation',
+      kind: 'report',
+      visibility: 'private',
+      payloadKind: 'pipeline-handoff-artifact',
+      prNumber: 123,
+      headSha,
+      baseName: 'nightly',
+      branchName: 'issue-42-artifact-store',
+    });
+    expect(stored.payloadPath.startsWith(path.join(root, 'payloads'))).toBe(true);
+    expect(fs.existsSync(stored.payloadPath)).toBe(true);
+
+    const byContext = store.list({ workContextId: 'wc:example' });
+    expect(byContext).toHaveLength(1);
+    expect(byContext[0]?.metadata.payloadSha256).toBe(stored.metadata.payloadSha256);
+
+    const byTask = store.list({ taskRef: { kind: 'github-issue', id: '42' } });
+    expect(byTask.map((entry) => entry.metadata.id)).toEqual([
+      'pipeline-handoff:example:aaaaaaaa',
+    ]);
+
+    const read = store.read(stored.metadata.id);
+    expect(read?.payload?.title).toBe('Example Project implementation handoff');
+  });
+
+  it('lists from the SQLite index without reading payload files', () => {
+    const { store } = tmpStore();
+    const stored = store.storePipelineHandoffArtifact({
+      workContextId: 'wc:bounded-list',
+      artifact: artifact(),
+    });
+    fs.writeFileSync(stored.payloadPath, '{ definitely not valid json');
+
+    const listed = store.list({ workContextId: 'wc:bounded-list' });
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.metadata.summary).toBe(
+      'artifact store foundation for generic project work'
+    );
+    expect(() => store.read(stored.metadata.id)).toThrow(SyntaxError);
+  });
+
+  it('preserves append-only history and models superseded refs without rewriting prior rows', () => {
+    const { store } = tmpStore();
+    const first = store.storePipelineHandoffArtifact({
+      workContextId: 'wc:append-only',
+      artifact: artifact(),
+    });
+
+    expect(() =>
+      store.storePipelineHandoffArtifact({
+        workContextId: 'wc:append-only',
+        artifact: artifact(),
+      })
+    ).toThrow(WorkContextArtifactStoreError);
+
+    const replacementArtifact = artifact({
+      id: 'pipeline-handoff:example:bbbbbbbb',
+      updatedAt: '2026-06-08T12:10:00.000Z',
+      head: {
+        ...artifact().head,
+        headSha: nextHeadSha,
+        capturedAt: '2026-06-08T12:10:00.000Z',
+      },
+    });
+    const replacement = store.storePipelineHandoffArtifact({
+      workContextId: 'wc:append-only',
+      artifact: replacementArtifact,
+      supersedesArtifactId: first.metadata.id,
+    });
+
+    expect(replacement.metadata.supersedesArtifactId).toBe(first.metadata.id);
+    expect(store.get(first.metadata.id)?.metadata.headSha).toBe(headSha);
+    expect(store.list({ workContextId: 'wc:append-only' }).map((entry) => entry.metadata.id)).toEqual([
+      replacement.metadata.id,
+    ]);
+    expect(
+      store
+        .list({ workContextId: 'wc:append-only', includeSuperseded: true })
+        .map((entry) => entry.metadata.id)
+        .sort()
+    ).toEqual([first.metadata.id, replacement.metadata.id].sort());
+  });
+
+  it('rejects invalid handoff payloads before indexing metadata', () => {
+    const { store } = tmpStore();
+    const unsafe = {
+      ...artifact(),
+      stages: [
+        {
+          ...artifact().stages[0],
+          rawTranscript: 'nope',
+        },
+      ],
+    };
+
+    try {
+      store.storePipelineHandoffArtifact({
+        workContextId: 'wc:rejects-raw',
+        artifact: unsafe as PipelineHandoffArtifact,
+      });
+      throw new Error('store unexpectedly accepted raw transcript payload');
+    } catch (err) {
+      expect(err).toBeInstanceOf(WorkContextArtifactStoreError);
+      expect((err as WorkContextArtifactStoreError).code).toBe(
+        'invalid_pipeline_handoff_artifact'
+      );
+    }
+    expect(store.list({ workContextId: 'wc:rejects-raw' })).toHaveLength(0);
+  });
+
+  it('returns public summaries without local paths, private task refs, or payload file paths', () => {
+    const { store } = tmpStore();
+    const stored = store.storePipelineHandoffArtifact({
+      workContextId: 'wc:public-copy',
+      visibility: 'public',
+      artifact: artifact(),
+    });
+
+    const publicCopy = store.publicSummary(stored.metadata.id);
+    expect(publicCopy?.metadata).not.toHaveProperty('payloadPath');
+    expect(publicCopy?.metadata.taskRef).toMatchObject({
+      kind: 'github-issue',
+      id: '42',
+    });
+    expect(publicCopy?.payload?.scope.taskRefs).toEqual([
+      {
+        kind: 'github-issue',
+        id: '42',
+        url: 'https://github.com/example-org/example-project/issues/42',
+      },
+    ]);
+    expect(publicCopy?.payload?.stages[0]?.actorId).toBe('agent');
+    expect(publicCopy?.payload?.stages[0]?.summary).toContain('[redacted-local-path]');
+    expect(
+      publicCopy?.payload?.scope.nonGoals.some((item) => /kanban|dispatcher|worktree/i.test(item))
+    ).toBe(false);
+    expect(validatePublicPipelineHandoffArtifact(publicCopy?.payload as PipelineHandoffArtifact).valid).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a WorkContext artifact store/index foundation with SQLite metadata rows and sha-addressed JSON payload files.
- Supports PipelineHandoffArtifact validation, WorkContext/Project/TaskRef/stage/provenance indexing, stale PR head metadata, superseded refs, and public summary sanitization.
- Keeps list/show-index queries bounded by SQLite metadata and reads payload files only for explicit payload reads/public rendering.

## Tests
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm test -- test/work-context-artifacts.test.ts`
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run check`
- `PATH=/home/donovanyohan/.local/opt/node-v24.16.0-linux-x64/bin:$PATH npm run build`

Closes #889
