### PR TITLE
Add WorkContext handoff artifact timeline

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -30,6 +30,15 @@ import type {
   WorkspaceEvidenceStatResponse,
 } from '../../../shared/workspace-evidence.js';
 import type {
+  PipelineHandoffArtifact,
+  PipelineHandoffStageName,
+} from '../../../shared/pipeline-handoff-artifact.js';
+import type { TaskRef } from '../../../shared/work-context.js';
+import type {
+  PipelineHandoffArtifactEnvelope,
+  PublicPipelineHandoffArtifactSummary,
+} from './pipeline-handoff-timeline.js';
+import type {
   SessionSummary,
   WorktreeInfo,
   Repo,
@@ -750,6 +759,99 @@ export async function fetchActiveWork(): Promise<WorkContextActiveGroup[]> {
     await fetch('/work-contexts/active')
   );
   return Array.isArray(data.groups) ? data.groups : [];
+}
+
+export interface FetchPipelineHandoffArtifactsOptions {
+  workContextId?: string;
+  taskRef?: Pick<TaskRef, 'kind' | 'id'>;
+  stage?: PipelineHandoffStageName;
+  currentHeadSha?: string;
+  includeSuperseded?: boolean;
+  includePayload?: boolean;
+  limit?: number;
+}
+
+const HANDOFF_ARTIFACT_HEADERS: HeadersInit = {
+  'x-relay-capabilities': 'context:read',
+};
+
+export async function fetchPipelineHandoffArtifacts({
+  workContextId,
+  taskRef,
+  stage,
+  currentHeadSha,
+  includeSuperseded,
+  includePayload = false,
+  limit = 8,
+}: FetchPipelineHandoffArtifactsOptions): Promise<PipelineHandoffArtifactEnvelope[]> {
+  const params = new URLSearchParams();
+  if (workContextId) params.set('workContextId', workContextId);
+  if (taskRef) {
+    params.set('taskRefKind', taskRef.kind);
+    params.set('taskRefId', taskRef.id);
+  }
+  if (stage) params.set('stage', stage);
+  if (currentHeadSha) params.set('currentHeadSha', currentHeadSha);
+  if (includeSuperseded !== undefined) {
+    params.set('includeSuperseded', String(includeSuperseded));
+  }
+  params.set('limit', String(limit));
+
+  const data = await json<{ artifacts?: PipelineHandoffArtifactEnvelope[] }>(
+    await fetch(`/pipeline-handoff-artifacts?${params.toString()}`, {
+      headers: HANDOFF_ARTIFACT_HEADERS,
+    })
+  );
+  const artifacts = Array.isArray(data.artifacts) ? data.artifacts : [];
+  if (!includePayload) return artifacts;
+  return Promise.all(
+    artifacts.map((artifact) =>
+      artifact.payload
+        ? artifact
+        : fetchPipelineHandoffArtifact(
+            artifact.metadata.id,
+            currentHeadSha ? { currentHeadSha } : {}
+          )
+    )
+  );
+}
+
+export async function fetchPipelineHandoffArtifact(
+  artifactId: string,
+  options: { currentHeadSha?: string } = {}
+): Promise<PipelineHandoffArtifactEnvelope> {
+  const params = new URLSearchParams();
+  if (options.currentHeadSha) params.set('currentHeadSha', options.currentHeadSha);
+  const suffix = params.size > 0 ? `?${params.toString()}` : '';
+  const data = await json<{ artifact: PipelineHandoffArtifactEnvelope }>(
+    await fetch(`/pipeline-handoff-artifacts/${encodeURIComponent(artifactId)}${suffix}`, {
+      headers: HANDOFF_ARTIFACT_HEADERS,
+    })
+  );
+  return data.artifact;
+}
+
+export interface CopyPipelineHandoffArtifactResult {
+  artifact: {
+    metadata: PublicPipelineHandoffArtifactSummary;
+    payload?: PipelineHandoffArtifact;
+  };
+  copy: {
+    mode: 'public-summary';
+    rawPayloadAvailable: false;
+    exportBytes: number;
+    maxBytes: number;
+  };
+}
+
+export async function copyPipelineHandoffArtifact(
+  artifactId: string
+): Promise<CopyPipelineHandoffArtifactResult> {
+  return json<CopyPipelineHandoffArtifactResult>(
+    await fetch(`/pipeline-handoff-artifacts/${encodeURIComponent(artifactId)}/copy`, {
+      headers: HANDOFF_ARTIFACT_HEADERS,
+    })
+  );
 }
 
 // ── #728 IA Workspace bar (consumes the #733 CRUD API) ──────────────────────

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -805,14 +805,20 @@ export async function fetchPipelineHandoffArtifacts({
   const artifacts = Array.isArray(data.artifacts) ? data.artifacts : [];
   if (!includePayload) return artifacts;
   return Promise.all(
-    artifacts.map((artifact) =>
-      artifact.payload
-        ? artifact
-        : fetchPipelineHandoffArtifact(
-            artifact.metadata.id,
-            currentHeadSha ? { currentHeadSha } : {}
-          )
-    )
+    artifacts.map(async (artifact) => {
+      if (artifact.payload) return artifact;
+      try {
+        return await fetchPipelineHandoffArtifact(
+          artifact.metadata.id,
+          currentHeadSha ? { currentHeadSha } : {}
+        );
+      } catch (err) {
+        return {
+          ...artifact,
+          payloadError: err instanceof Error ? err.message : String(err),
+        };
+      }
+    })
   );
 }
 

--- a/frontend/src/lib/pipeline-handoff-timeline.ts
+++ b/frontend/src/lib/pipeline-handoff-timeline.ts
@@ -7,7 +7,12 @@ import {
 } from '../../../shared/pipeline-handoff-artifact.js';
 import type { ArtifactKind, TaskRef } from '../../../shared/work-context.js';
 
-export type HandoffArtifactState = 'missing' | 'current' | 'stale' | 'unknown';
+export type HandoffArtifactState =
+  | 'missing'
+  | 'current'
+  | 'stale'
+  | 'failed'
+  | 'unknown';
 
 export interface PublicPipelineHandoffArtifactSummary {
   id: string;
@@ -41,6 +46,7 @@ export interface PipelineHandoffArtifactEnvelope {
   metadata: PublicPipelineHandoffArtifactSummary;
   payload?: PipelineHandoffArtifact;
   staleness?: PipelineHandoffArtifactStaleness;
+  payloadError?: string;
 }
 
 export interface HandoffTimelineStageSummary {
@@ -60,6 +66,7 @@ export interface HandoffTimelineSummary {
   verdict: string;
   downstreamFocus: string[];
   openUrl: string | null;
+  payloadError: string | null;
   stages: HandoffTimelineStageSummary[];
 }
 
@@ -111,6 +118,7 @@ function stateFor(
   envelope: PipelineHandoffArtifactEnvelope,
   currentHeadSha?: string | null
 ): HandoffArtifactState {
+  if (envelope.payloadError) return 'failed';
   const head = artifactHeadSha(envelope);
   if (envelope.staleness?.stale) return 'stale';
   if (currentHeadSha && head) return currentHeadSha === head ? 'current' : 'stale';
@@ -126,18 +134,45 @@ function labelForState(state: HandoffArtifactState): string {
       return 'current';
     case 'stale':
       return 'stale';
+    case 'failed':
+      return 'failed';
     case 'unknown':
       return 'captured';
   }
 }
 
+export function safeExternalUrl(value: string | null | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(
+      value,
+      typeof window === 'undefined' ? 'http://localhost' : window.location.origin
+    );
+    if (url.protocol !== 'https:') return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
 function openUrlFor(envelope: PipelineHandoffArtifactEnvelope): string | null {
-  return (
-    envelope.metadata.taskRef?.url ??
-    envelope.payload?.head.pr?.url ??
-    envelope.payload?.scope.taskRefs.find((taskRef) => taskRef.url)?.url ??
-    null
-  );
+  const candidates = [
+    envelope.metadata.taskRef?.url,
+    envelope.payload?.head.pr?.url,
+    ...(envelope.payload?.scope.taskRefs.map((taskRef) => taskRef.url) ?? []),
+  ];
+  for (const candidate of candidates) {
+    const safeUrl = safeExternalUrl(candidate);
+    if (safeUrl) return safeUrl;
+  }
+  return null;
+}
+
+export function formatDownstreamFocus(items: string[], limit = 2): string {
+  if (items.length === 0) return 'none';
+  const visible = items.slice(0, limit).join(' · ');
+  const hidden = items.length - limit;
+  return hidden > 0 ? `${visible} · +${hidden}` : visible;
 }
 
 export function summarizeHandoffArtifact(
@@ -158,6 +193,7 @@ export function summarizeHandoffArtifact(
     verdict: stageVerdict(stage),
     downstreamFocus: stage?.downstreamFocus ?? [],
     openUrl: openUrlFor(envelope),
+    payloadError: envelope.payloadError ?? null,
     stages: STAGE_ORDER.map((name) => {
       const item = presentStages.get(name);
       return {
@@ -181,6 +217,7 @@ export function missingHandoffArtifactSummary(): HandoffTimelineSummary {
     verdict: 'missing',
     downstreamFocus: [],
     openUrl: null,
+    payloadError: null,
     stages: STAGE_ORDER.map((stage) => ({
       stage,
       status: 'missing',

--- a/frontend/src/lib/pipeline-handoff-timeline.ts
+++ b/frontend/src/lib/pipeline-handoff-timeline.ts
@@ -1,0 +1,201 @@
+import {
+  PIPELINE_HANDOFF_STAGES,
+  renderPipelineHandoffMarkdown,
+  type PipelineHandoffArtifact,
+  type PipelineHandoffStage,
+  type PipelineHandoffStageName,
+} from '../../../shared/pipeline-handoff-artifact.js';
+import type { ArtifactKind, TaskRef } from '../../../shared/work-context.js';
+
+export type HandoffArtifactState = 'missing' | 'current' | 'stale' | 'unknown';
+
+export interface PublicPipelineHandoffArtifactSummary {
+  id: string;
+  workContextId: string;
+  projectId?: string;
+  taskRef?: Pick<TaskRef, 'kind' | 'id' | 'title' | 'url' | 'status'>;
+  stage?: PipelineHandoffStageName;
+  kind: ArtifactKind;
+  title: string;
+  summary: string;
+  visibility: 'private' | 'public';
+  capturedAt: string;
+  payloadKind: 'pipeline-handoff-artifact';
+  payloadSha256: string;
+  payloadBytes: number;
+  prNumber?: number;
+  headSha?: string;
+  baseName?: string;
+  branchName?: string;
+  supersedesArtifactId?: string;
+}
+
+export interface PipelineHandoffArtifactStaleness {
+  stale: boolean;
+  staleIf: { headShaChanges: true };
+  artifactHeadSha: string;
+  currentHeadSha: string;
+}
+
+export interface PipelineHandoffArtifactEnvelope {
+  metadata: PublicPipelineHandoffArtifactSummary;
+  payload?: PipelineHandoffArtifact;
+  staleness?: PipelineHandoffArtifactStaleness;
+}
+
+export interface HandoffTimelineStageSummary {
+  stage: PipelineHandoffStageName;
+  status: 'present' | 'missing';
+  evidenceCount: number;
+  verdict: string;
+  downstreamFocus: string[];
+}
+
+export interface HandoffTimelineSummary {
+  state: HandoffArtifactState;
+  stateLabel: string;
+  stageLabel: string;
+  shortHeadSha: string | null;
+  evidenceCount: number;
+  verdict: string;
+  downstreamFocus: string[];
+  openUrl: string | null;
+  stages: HandoffTimelineStageSummary[];
+}
+
+const STAGE_ORDER: PipelineHandoffStageName[] = [...PIPELINE_HANDOFF_STAGES];
+
+export function shortSha(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, 7);
+}
+
+export function stageVerdict(stage: PipelineHandoffStage | null | undefined): string {
+  if (!stage) return 'missing';
+  switch (stage.stage) {
+    case 'implementation':
+      return stage.decision;
+    case 'qa':
+      return stage.verdict;
+    case 'review':
+      return stage.verdict;
+    case 'release':
+      return stage.verdict;
+    default: {
+      const _exhaustive: never = stage;
+      return String(_exhaustive);
+    }
+  }
+}
+
+export function stageEvidenceCount(
+  stage: PipelineHandoffStage | null | undefined
+): number {
+  if (!stage) return 0;
+  return stage.acceptanceEvidence.length + stage.commands.length;
+}
+
+function latestStage(
+  artifact: PipelineHandoffArtifact | null | undefined
+): PipelineHandoffStage | null {
+  return artifact?.stages.at(-1) ?? null;
+}
+
+function artifactHeadSha(envelope: PipelineHandoffArtifactEnvelope): string | null {
+  return envelope.metadata.headSha ?? envelope.payload?.head.headSha ?? null;
+}
+
+function stateFor(
+  envelope: PipelineHandoffArtifactEnvelope,
+  currentHeadSha?: string | null
+): HandoffArtifactState {
+  const head = artifactHeadSha(envelope);
+  if (envelope.staleness?.stale) return 'stale';
+  if (currentHeadSha && head) return currentHeadSha === head ? 'current' : 'stale';
+  if (envelope.staleness && !envelope.staleness.stale) return 'current';
+  return 'unknown';
+}
+
+function labelForState(state: HandoffArtifactState): string {
+  switch (state) {
+    case 'missing':
+      return 'missing';
+    case 'current':
+      return 'current';
+    case 'stale':
+      return 'stale';
+    case 'unknown':
+      return 'captured';
+  }
+}
+
+function openUrlFor(envelope: PipelineHandoffArtifactEnvelope): string | null {
+  return (
+    envelope.metadata.taskRef?.url ??
+    envelope.payload?.head.pr?.url ??
+    envelope.payload?.scope.taskRefs.find((taskRef) => taskRef.url)?.url ??
+    null
+  );
+}
+
+export function summarizeHandoffArtifact(
+  envelope: PipelineHandoffArtifactEnvelope,
+  currentHeadSha?: string | null
+): HandoffTimelineSummary {
+  const stage = latestStage(envelope.payload);
+  const state = stateFor(envelope, currentHeadSha);
+  const presentStages = new Map(
+    envelope.payload?.stages.map((item) => [item.stage, item]) ?? []
+  );
+  return {
+    state,
+    stateLabel: labelForState(state),
+    stageLabel: stage?.stage ?? envelope.metadata.stage ?? 'missing',
+    shortHeadSha: shortSha(artifactHeadSha(envelope)),
+    evidenceCount: stageEvidenceCount(stage),
+    verdict: stageVerdict(stage),
+    downstreamFocus: stage?.downstreamFocus ?? [],
+    openUrl: openUrlFor(envelope),
+    stages: STAGE_ORDER.map((name) => {
+      const item = presentStages.get(name);
+      return {
+        stage: name,
+        status: item ? 'present' : 'missing',
+        evidenceCount: stageEvidenceCount(item),
+        verdict: stageVerdict(item),
+        downstreamFocus: item?.downstreamFocus ?? [],
+      };
+    }),
+  };
+}
+
+export function missingHandoffArtifactSummary(): HandoffTimelineSummary {
+  return {
+    state: 'missing',
+    stateLabel: 'missing',
+    stageLabel: 'missing',
+    shortHeadSha: null,
+    evidenceCount: 0,
+    verdict: 'missing',
+    downstreamFocus: [],
+    openUrl: null,
+    stages: STAGE_ORDER.map((stage) => ({
+      stage,
+      status: 'missing',
+      evidenceCount: 0,
+      verdict: 'missing',
+      downstreamFocus: [],
+    })),
+  };
+}
+
+export function formatHandoffArtifactCopy(
+  artifact: PublicPipelineHandoffArtifactSummary | { metadata: PublicPipelineHandoffArtifactSummary; payload?: PipelineHandoffArtifact }
+): string {
+  if ('payload' in artifact && artifact.payload) {
+    return renderPipelineHandoffMarkdown(artifact.payload, { public: true });
+  }
+  return `${JSON.stringify(artifact, null, 2)}\n`;
+}

--- a/frontend/src/workbench/blocks/work-context.css
+++ b/frontend/src/workbench/blocks/work-context.css
@@ -270,17 +270,27 @@
 }
 
 .block-work-context__handoff-actions button:hover,
-.block-work-context__handoff-actions a:hover {
+.block-work-context__handoff-actions a:hover,
+.block-work-context__handoff-actions button:focus-visible,
+.block-work-context__handoff-actions a:focus-visible {
   border-color: var(--accent);
   color: var(--accent);
 }
 
 .block-work-context__handoff-actions button:focus-visible,
 .block-work-context__handoff-actions a:focus-visible {
-  border-color: var(--accent);
-  color: var(--accent);
   outline: 1px solid var(--accent);
   outline-offset: 2px;
+}
+
+.block-work-context__handoff-actions button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.block-work-context__handoff-actions button:disabled:hover {
+  border-color: var(--border);
+  color: var(--text-muted);
 }
 
 .block-work-context__handoff-actions span,

--- a/frontend/src/workbench/blocks/work-context.css
+++ b/frontend/src/workbench/blocks/work-context.css
@@ -146,6 +146,10 @@
   border-color: color-mix(in srgb, var(--status-warning) 65%, var(--border));
 }
 
+.block-work-context__handoff-card--failed {
+  border-color: color-mix(in srgb, var(--status-error) 65%, var(--border));
+}
+
 .block-work-context__handoff-card--unknown {
   border-color: color-mix(in srgb, var(--status-info) 45%, var(--border));
 }
@@ -180,6 +184,10 @@
 
 .block-work-context__handoff-card--stale .block-work-context__handoff-state-pill {
   color: var(--status-warning);
+}
+
+.block-work-context__handoff-card--failed .block-work-context__handoff-state-pill {
+  color: var(--status-error);
 }
 
 .block-work-context__handoff-card--unknown .block-work-context__handoff-state-pill {
@@ -294,12 +302,14 @@
 }
 
 .block-work-context__handoff-actions span,
-.block-work-context__handoff-copy {
+.block-work-context__handoff-copy,
+.block-work-context__handoff-payload-error {
   color: var(--text-muted);
   font-size: var(--font-size-xs);
 }
 
-.block-work-context__handoff-copy--error {
+.block-work-context__handoff-copy--error,
+.block-work-context__handoff-payload-error {
   color: var(--status-error);
 }
 

--- a/frontend/src/workbench/blocks/work-context.css
+++ b/frontend/src/workbench/blocks/work-context.css
@@ -112,3 +112,196 @@
   font-size: var(--font-size-xs);
   color: var(--text-muted);
 }
+
+.block-work-context__handoff-state {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xs);
+  padding: var(--space-sm);
+  border: 1px dashed var(--border);
+  color: var(--text-muted);
+}
+
+.block-work-context__handoff-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.block-work-context__handoff-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  border: 1px solid var(--border);
+  background: var(--bg);
+  min-width: 0;
+}
+
+.block-work-context__handoff-card--current {
+  border-color: color-mix(in srgb, var(--status-success) 45%, var(--border));
+}
+
+.block-work-context__handoff-card--stale {
+  border-color: color-mix(in srgb, var(--status-warning) 65%, var(--border));
+}
+
+.block-work-context__handoff-card--unknown {
+  border-color: color-mix(in srgb, var(--status-info) 45%, var(--border));
+}
+
+.block-work-context__handoff-card-header,
+.block-work-context__handoff-actions {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.block-work-context__handoff-title {
+  color: var(--text);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.block-work-context__handoff-summary {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  overflow-wrap: anywhere;
+}
+
+.block-work-context__handoff-state-pill {
+  flex: 0 0 auto;
+  border: 1px solid currentColor;
+  color: var(--status-success);
+  padding: 1px var(--space-xs);
+  font-size: var(--font-size-xs);
+}
+
+.block-work-context__handoff-card--stale .block-work-context__handoff-state-pill {
+  color: var(--status-warning);
+}
+
+.block-work-context__handoff-card--unknown .block-work-context__handoff-state-pill {
+  color: var(--status-info);
+}
+
+.block-work-context__handoff-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid var(--border);
+}
+
+.block-work-context__handoff-meta-grid > div {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  padding: var(--space-xs);
+  border-right: 1px solid var(--border);
+}
+
+.block-work-context__handoff-meta-grid > div:last-child {
+  border-right: none;
+}
+
+.block-work-context__handoff-meta-grid span,
+.block-work-context__handoff-focus span {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.block-work-context__handoff-meta-grid strong,
+.block-work-context__handoff-focus strong {
+  color: var(--text);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  overflow-wrap: anywhere;
+}
+
+.block-work-context__handoff-stages {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-2xs);
+}
+
+.block-work-context__handoff-stage {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: var(--space-xs);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+}
+
+.block-work-context__handoff-stage--present {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  color: var(--text);
+}
+
+.block-work-context__handoff-stage small {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  overflow-wrap: anywhere;
+}
+
+.block-work-context__handoff-focus {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.block-work-context__handoff-actions {
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.block-work-context__handoff-actions button,
+.block-work-context__handoff-actions a {
+  min-height: 32px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: var(--font-size-xs);
+  text-decoration: none;
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+}
+
+.block-work-context__handoff-actions button:hover,
+.block-work-context__handoff-actions a:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.block-work-context__handoff-actions button:focus-visible,
+.block-work-context__handoff-actions a:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.block-work-context__handoff-actions span,
+.block-work-context__handoff-copy {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.block-work-context__handoff-copy--error {
+  color: var(--status-error);
+}
+
+@media (max-width: 720px) {
+  .block-work-context__handoff-meta-grid,
+  .block-work-context__handoff-stages {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .block-work-context__handoff-card-header,
+  .block-work-context__handoff-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/frontend/src/workbench/blocks/work-context.tsx
+++ b/frontend/src/workbench/blocks/work-context.tsx
@@ -17,12 +17,16 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import type { WorkbenchBlockRenderer } from '../../../../shared/workbench-block-types.js';
+import type { WorkContext } from '../../../../shared/work-context.js';
+import type { WorkContextActiveGroup } from '../../lib/types.js';
 import {
   copyPipelineHandoffArtifact,
   fetchActiveWork,
+  fetchDivergence,
   fetchPipelineHandoffArtifacts,
 } from '../../lib/api.js';
 import {
+  formatDownstreamFocus,
   formatHandoffArtifactCopy,
   summarizeHandoffArtifact,
   type PipelineHandoffArtifactEnvelope,
@@ -52,21 +56,43 @@ function formatTimestamp(iso: string): string {
 const REFETCH_MS = 15_000;
 const HANDOFF_REFETCH_MS = 30_000;
 
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function currentHeadRepoPath(
+  workContext: WorkContext | null,
+  group: WorkContextActiveGroup | null
+): string | null {
+  return (
+    workContext?.anchors.worktree?.localPath ??
+    group?.sessions.find((session) => session.live)?.worktreePath ??
+    group?.sessions[0]?.worktreePath ??
+    workContext?.anchors.repo?.localPath ??
+    group?.sessions.find((session) => session.live)?.repoPath ??
+    group?.sessions[0]?.repoPath ??
+    null
+  );
+}
+
+function clipboardWriter(): Clipboard['writeText'] | null {
+  if (typeof navigator === 'undefined') return null;
+  return navigator.clipboard?.writeText?.bind(navigator.clipboard) ?? null;
+}
+
 interface HandoffArtifactTimelineProps {
   artifacts: PipelineHandoffArtifactEnvelope[];
   loading: boolean;
   error: unknown;
-}
-
-function errorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  return String(error);
+  currentHeadSha?: string | null;
 }
 
 function HandoffArtifactTimeline({
   artifacts,
   loading,
   error,
+  currentHeadSha,
 }: HandoffArtifactTimelineProps) {
   const [copyState, setCopyState] = useState<{
     artifactId: string;
@@ -75,10 +101,19 @@ function HandoffArtifactTimeline({
   } | null>(null);
 
   const handleCopy = useCallback(async (artifactId: string) => {
+    const writeText = clipboardWriter();
+    if (!writeText) {
+      setCopyState({
+        artifactId,
+        status: 'error',
+        message: 'clipboard unavailable in this browser',
+      });
+      return;
+    }
     try {
       const copied = await copyPipelineHandoffArtifact(artifactId);
       const text = formatHandoffArtifactCopy(copied.artifact);
-      await navigator.clipboard.writeText(text);
+      await writeText(text);
       setCopyState({
         artifactId,
         status: 'copied',
@@ -125,7 +160,7 @@ function HandoffArtifactTimeline({
   return (
     <div className="block-work-context__handoff-list">
       {artifacts.map((artifact) => {
-        const summary = summarizeHandoffArtifact(artifact);
+        const summary = summarizeHandoffArtifact(artifact, currentHeadSha);
         const canCopy = artifact.metadata.visibility === 'public';
         const copy =
           copyState?.artifactId === artifact.metadata.id ? copyState : null;
@@ -181,12 +216,14 @@ function HandoffArtifactTimeline({
 
             <div className="block-work-context__handoff-focus">
               <span>downstream focus</span>
-              <strong>
-                {summary.downstreamFocus.length > 0
-                  ? summary.downstreamFocus.slice(0, 2).join(' · ')
-                  : 'none'}
-              </strong>
+              <strong>{formatDownstreamFocus(summary.downstreamFocus)}</strong>
             </div>
+
+            {summary.payloadError ? (
+              <div className="block-work-context__handoff-payload-error" role="alert">
+                payload unavailable: {summary.payloadError}
+              </div>
+            ) : null}
 
             <div className="block-work-context__handoff-actions">
               {canCopy ? (
@@ -199,7 +236,7 @@ function HandoffArtifactTimeline({
                 </button>
               )}
               {summary.openUrl ? (
-                <a href={summary.openUrl} target="_blank" rel="noreferrer">
+                <a href={summary.openUrl} target="_blank" rel="noopener noreferrer">
                   open
                 </a>
               ) : (
@@ -238,15 +275,28 @@ export const WorkContextBlock: WorkbenchBlockRenderer<'work-context'> = ({
     staleTime: REFETCH_MS / 2,
   });
 
-  const workContext = useMemo(() => {
+  const workContextGroup = useMemo(() => {
     if (!groups) return null;
     for (const group of groups) {
       if (group.context?.id === workContextRef || group.id === workContextRef) {
-        return group.context;
+        return group;
       }
     }
     return null;
   }, [groups, workContextRef]);
+  const workContext = workContextGroup?.context ?? null;
+  const headRepoPath = useMemo(
+    () => currentHeadRepoPath(workContext, workContextGroup),
+    [workContext, workContextGroup]
+  );
+  const { data: currentHead } = useQuery({
+    queryKey: ['work-context-current-head', headRepoPath],
+    queryFn: () => fetchDivergence(headRepoPath ?? ''),
+    enabled: !!headRepoPath,
+    refetchInterval: HANDOFF_REFETCH_MS,
+    staleTime: HANDOFF_REFETCH_MS / 2,
+  });
+  const currentHeadSha = currentHead?.headSha ?? null;
 
   const {
     data: handoffArtifacts = [],
@@ -254,12 +304,14 @@ export const WorkContextBlock: WorkbenchBlockRenderer<'work-context'> = ({
     error: handoffError,
   } = useQuery({
     queryKey: ['pipeline-handoff-artifacts', workContext?.id],
-    queryFn: () =>
-      fetchPipelineHandoffArtifacts({
-        workContextId: workContext!.id,
+    queryFn: () => {
+      if (!workContext) return [];
+      return fetchPipelineHandoffArtifacts({
+        workContextId: workContext.id,
         includePayload: true,
         limit: 4,
-      }),
+      });
+    },
     enabled: !!workContext,
     refetchInterval: HANDOFF_REFETCH_MS,
     staleTime: HANDOFF_REFETCH_MS / 2,
@@ -369,6 +421,7 @@ export const WorkContextBlock: WorkbenchBlockRenderer<'work-context'> = ({
           artifacts={handoffArtifacts}
           loading={handoffLoading}
           error={handoffError}
+          currentHeadSha={currentHeadSha}
         />
       </div>
 

--- a/frontend/src/workbench/blocks/work-context.tsx
+++ b/frontend/src/workbench/blocks/work-context.tsx
@@ -126,6 +126,7 @@ function HandoffArtifactTimeline({
     <div className="block-work-context__handoff-list">
       {artifacts.map((artifact) => {
         const summary = summarizeHandoffArtifact(artifact);
+        const canCopy = artifact.metadata.visibility === 'public';
         const copy =
           copyState?.artifactId === artifact.metadata.id ? copyState : null;
         return (
@@ -188,9 +189,15 @@ function HandoffArtifactTimeline({
             </div>
 
             <div className="block-work-context__handoff-actions">
-              <button type="button" onClick={() => void handleCopy(artifact.metadata.id)}>
-                copy sanitized
-              </button>
+              {canCopy ? (
+                <button type="button" onClick={() => void handleCopy(artifact.metadata.id)}>
+                  copy sanitized
+                </button>
+              ) : (
+                <button type="button" disabled>
+                  private copy unavailable
+                </button>
+              )}
               {summary.openUrl ? (
                 <a href={summary.openUrl} target="_blank" rel="noreferrer">
                   open

--- a/frontend/src/workbench/blocks/work-context.tsx
+++ b/frontend/src/workbench/blocks/work-context.tsx
@@ -13,11 +13,20 @@
  * refs returned by the hub.
  */
 
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import type { WorkbenchBlockRenderer } from '../../../../shared/workbench-block-types.js';
-import { fetchActiveWork } from '../../lib/api.js';
+import {
+  copyPipelineHandoffArtifact,
+  fetchActiveWork,
+  fetchPipelineHandoffArtifacts,
+} from '../../lib/api.js';
+import {
+  formatHandoffArtifactCopy,
+  summarizeHandoffArtifact,
+  type PipelineHandoffArtifactEnvelope,
+} from '../../lib/pipeline-handoff-timeline.js';
 
 import './work-context.css';
 
@@ -41,6 +50,169 @@ function formatTimestamp(iso: string): string {
  * also polls at 15 s. Track at: https://github.com/donovan-yohan/relay-ide
  */
 const REFETCH_MS = 15_000;
+const HANDOFF_REFETCH_MS = 30_000;
+
+interface HandoffArtifactTimelineProps {
+  artifacts: PipelineHandoffArtifactEnvelope[];
+  loading: boolean;
+  error: unknown;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function HandoffArtifactTimeline({
+  artifacts,
+  loading,
+  error,
+}: HandoffArtifactTimelineProps) {
+  const [copyState, setCopyState] = useState<{
+    artifactId: string;
+    status: 'copied' | 'error';
+    message: string;
+  } | null>(null);
+
+  const handleCopy = useCallback(async (artifactId: string) => {
+    try {
+      const copied = await copyPipelineHandoffArtifact(artifactId);
+      const text = formatHandoffArtifactCopy(copied.artifact);
+      await navigator.clipboard.writeText(text);
+      setCopyState({
+        artifactId,
+        status: 'copied',
+        message: 'sanitized copy written',
+      });
+    } catch (err) {
+      setCopyState({
+        artifactId,
+        status: 'error',
+        message: errorMessage(err),
+      });
+    }
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="block-work-context__handoff-state" role="status">
+        <span className="block-work-context__spinner">&#x280B;</span>
+        <span>loading handoff artifacts…</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="block-work-context__handoff-state" role="alert">
+        <span>handoff artifacts unavailable</span>
+        <span className="block-work-context__detail">{errorMessage(error)}</span>
+      </div>
+    );
+  }
+
+  if (artifacts.length === 0) {
+    return (
+      <div className="block-work-context__handoff-state" role="status">
+        <span>missing handoff artifact</span>
+        <span className="block-work-context__detail">
+          no implementation / qa / review / release handoff has been attached yet
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="block-work-context__handoff-list">
+      {artifacts.map((artifact) => {
+        const summary = summarizeHandoffArtifact(artifact);
+        const copy =
+          copyState?.artifactId === artifact.metadata.id ? copyState : null;
+        return (
+          <article
+            key={artifact.metadata.id}
+            className={`block-work-context__handoff-card block-work-context__handoff-card--${summary.state}`}
+          >
+            <div className="block-work-context__handoff-card-header">
+              <div>
+                <div className="block-work-context__handoff-title">
+                  {artifact.metadata.title}
+                </div>
+                <div className="block-work-context__handoff-summary">
+                  {artifact.metadata.summary}
+                </div>
+              </div>
+              <span className="block-work-context__handoff-state-pill">
+                {summary.stateLabel}
+              </span>
+            </div>
+
+            <div className="block-work-context__handoff-meta-grid">
+              <div>
+                <span>stage</span>
+                <strong>{summary.stageLabel}</strong>
+              </div>
+              <div>
+                <span>head</span>
+                <strong>{summary.shortHeadSha ?? 'missing'}</strong>
+              </div>
+              <div>
+                <span>evidence</span>
+                <strong>{summary.evidenceCount}</strong>
+              </div>
+              <div>
+                <span>verdict</span>
+                <strong>{summary.verdict}</strong>
+              </div>
+            </div>
+
+            <div className="block-work-context__handoff-stages" aria-label="handoff stages">
+              {summary.stages.map((stage) => (
+                <div
+                  key={stage.stage}
+                  className={`block-work-context__handoff-stage block-work-context__handoff-stage--${stage.status}`}
+                >
+                  <span>{stage.stage}</span>
+                  <small>{stage.verdict}</small>
+                </div>
+              ))}
+            </div>
+
+            <div className="block-work-context__handoff-focus">
+              <span>downstream focus</span>
+              <strong>
+                {summary.downstreamFocus.length > 0
+                  ? summary.downstreamFocus.slice(0, 2).join(' · ')
+                  : 'none'}
+              </strong>
+            </div>
+
+            <div className="block-work-context__handoff-actions">
+              <button type="button" onClick={() => void handleCopy(artifact.metadata.id)}>
+                copy sanitized
+              </button>
+              {summary.openUrl ? (
+                <a href={summary.openUrl} target="_blank" rel="noreferrer">
+                  open
+                </a>
+              ) : (
+                <span>no public link</span>
+              )}
+            </div>
+            {copy ? (
+              <div
+                className={`block-work-context__handoff-copy block-work-context__handoff-copy--${copy.status}`}
+                role={copy.status === 'error' ? 'alert' : 'status'}
+              >
+                {copy.message}
+              </div>
+            ) : null}
+          </article>
+        );
+      })}
+    </div>
+  );
+}
 
 export const WorkContextBlock: WorkbenchBlockRenderer<'work-context'> = ({
   descriptor,
@@ -68,6 +240,23 @@ export const WorkContextBlock: WorkbenchBlockRenderer<'work-context'> = ({
     }
     return null;
   }, [groups, workContextRef]);
+
+  const {
+    data: handoffArtifacts = [],
+    isLoading: handoffLoading,
+    error: handoffError,
+  } = useQuery({
+    queryKey: ['pipeline-handoff-artifacts', workContext?.id],
+    queryFn: () =>
+      fetchPipelineHandoffArtifacts({
+        workContextId: workContext!.id,
+        includePayload: true,
+        limit: 4,
+      }),
+    enabled: !!workContext,
+    refetchInterval: HANDOFF_REFETCH_MS,
+    staleTime: HANDOFF_REFETCH_MS / 2,
+  });
 
   if (isLoading) {
     return (
@@ -166,6 +355,15 @@ export const WorkContextBlock: WorkbenchBlockRenderer<'work-context'> = ({
           </div>
         </div>
       )}
+
+      <div className="block-work-context__section">
+        <div className="block-work-context__label">handoff timeline</div>
+        <HandoffArtifactTimeline
+          artifacts={handoffArtifacts}
+          loading={handoffLoading}
+          error={handoffError}
+        />
+      </div>
 
       <div className="block-work-context__section block-work-context__section--meta">
         <div className="block-work-context__detail">id: {workContext.id}</div>

--- a/test/pipeline-handoff-timeline.test.ts
+++ b/test/pipeline-handoff-timeline.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PipelineHandoffArtifact } from '../shared/pipeline-handoff-artifact.js';
+import {
+  formatHandoffArtifactCopy,
+  missingHandoffArtifactSummary,
+  summarizeHandoffArtifact,
+  type PipelineHandoffArtifactEnvelope,
+} from '../frontend/src/lib/pipeline-handoff-timeline.js';
+
+const HEAD_A = '1111111111111111111111111111111111111111';
+const HEAD_B = '2222222222222222222222222222222222222222';
+const NOW = '2026-06-09T00:00:00.000Z';
+
+function artifact(
+  overrides: Partial<PipelineHandoffArtifact> = {}
+): PipelineHandoffArtifact {
+  return {
+    schemaVersion: 1,
+    id: 'pipeline-handoff:demo',
+    title: 'handoff artifact timeline',
+    createdAt: NOW,
+    updatedAt: NOW,
+    scope: {
+      summary: 'show handoff state in WorkContext',
+      risk: 'medium',
+      taskRefs: [
+        {
+          kind: 'github-issue',
+          id: '885',
+          title: 'Show pipeline handoff artifact state',
+          url: 'https://github.com/donovan-yohan/relay-ide/issues/885',
+        },
+      ],
+      acceptance: ['timeline renders current/stale state'],
+      nonGoals: ['raw logs'],
+    },
+    head: {
+      repo: { ownerRepo: 'donovan-yohan/relay-ide' },
+      base: { name: 'nightly' },
+      branch: { name: 'issue-885-handoff-timeline' },
+      pr: { number: 901, url: 'https://github.com/donovan-yohan/relay-ide/pull/901' },
+      headSha: HEAD_A,
+      staleIf: { headShaChanges: true },
+      capturedAt: NOW,
+    },
+    stages: [
+      {
+        stage: 'implementation',
+        addedAt: NOW,
+        actorId: 'agent:ika-frontend',
+        summary: 'implemented timeline UI',
+        acceptanceEvidence: [
+          { label: 'component', disposition: 'provided', summary: 'timeline card rendered' },
+        ],
+        commands: [
+          { label: 'unit', command: 'npm test -- pipeline-handoff-timeline', status: 'passed', summary: 'passed' },
+        ],
+        downstreamFocus: ['qa stale-head indicator', 'review sanitized copy'],
+        nonGoals: ['release decisions'],
+        decision: 'implemented',
+        changedFiles: ['frontend/src/workbench/blocks/work-context.tsx'],
+        migrationOrStateRisk: 'read-only WorkContext artifact query',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function envelope(
+  payload: PipelineHandoffArtifact,
+  extra: Partial<PipelineHandoffArtifactEnvelope> = {}
+): PipelineHandoffArtifactEnvelope {
+  return {
+    metadata: {
+      id: payload.id,
+      workContextId: 'wc:885',
+      taskRef: payload.scope.taskRefs[0],
+      stage: payload.stages.at(-1)?.stage,
+      kind: 'report',
+      title: payload.title,
+      summary: payload.scope.summary,
+      visibility: 'public',
+      capturedAt: payload.head.capturedAt,
+      payloadKind: 'pipeline-handoff-artifact',
+      payloadSha256: '0'.repeat(64),
+      payloadBytes: 1234,
+      prNumber: payload.head.pr?.number,
+      headSha: payload.head.headSha,
+      baseName: payload.head.base.name,
+      branchName: payload.head.branch?.name,
+    },
+    payload,
+    ...extra,
+  };
+}
+
+describe('pipeline handoff timeline summary', () => {
+  it('summarizes current artifact stage, head, evidence, focus, and open URL', () => {
+    const summary = summarizeHandoffArtifact(envelope(artifact()), HEAD_A);
+
+    expect(summary.state).toBe('current');
+    expect(summary.stageLabel).toBe('implementation');
+    expect(summary.shortHeadSha).toBe('1111111');
+    expect(summary.evidenceCount).toBe(2);
+    expect(summary.verdict).toBe('implemented');
+    expect(summary.downstreamFocus).toEqual(['qa stale-head indicator', 'review sanitized copy']);
+    expect(summary.openUrl).toBe('https://github.com/donovan-yohan/relay-ide/issues/885');
+    expect(summary.stages.map((stage) => [stage.stage, stage.status])).toEqual([
+      ['implementation', 'present'],
+      ['qa', 'missing'],
+      ['review', 'missing'],
+      ['release', 'missing'],
+    ]);
+  });
+
+  it('reports missing artifact state without pretending approval exists', () => {
+    const summary = missingHandoffArtifactSummary();
+
+    expect(summary.state).toBe('missing');
+    expect(summary.shortHeadSha).toBeNull();
+    expect(summary.evidenceCount).toBe(0);
+    expect(summary.verdict).toBe('missing');
+    expect(summary.stages.every((stage) => stage.status === 'missing')).toBe(true);
+  });
+
+  it('marks artifacts stale when the lane head differs', () => {
+    const summary = summarizeHandoffArtifact(envelope(artifact()), HEAD_B);
+
+    expect(summary.state).toBe('stale');
+    expect(summary.stateLabel).toBe('stale');
+    expect(summary.shortHeadSha).toBe('1111111');
+  });
+
+  it('surfaces failed or blocking downstream verdicts', () => {
+    const failed = artifact({
+      stages: [
+        ...artifact().stages,
+        {
+          stage: 'qa',
+          addedAt: NOW,
+          actorId: 'agent:kame-qa',
+          summary: 'blocked stale evidence copy',
+          acceptanceEvidence: [
+            { label: 'browser', disposition: 'provided', summary: 'stale pill visible' },
+          ],
+          commands: [],
+          downstreamFocus: ['fix stale status copy'],
+          nonGoals: [],
+          verdict: 'failed',
+          testedHeadSha: HEAD_A,
+          findings: ['stale evidence was styled as approved'],
+        },
+      ],
+    });
+
+    const summary = summarizeHandoffArtifact(envelope(failed), HEAD_A);
+
+    expect(summary.stageLabel).toBe('qa');
+    expect(summary.verdict).toBe('failed');
+    expect(summary.downstreamFocus).toEqual(['fix stale status copy']);
+  });
+
+  it('formats only the sanitized public copy envelope supplied by the API', () => {
+    const text = formatHandoffArtifactCopy({
+      metadata: {
+        id: 'pipeline-handoff:public',
+        workContextId: 'wc:public',
+        kind: 'report',
+        title: 'public handoff summary',
+        summary: 'sanitized; raw logs unavailable',
+        visibility: 'public',
+        capturedAt: NOW,
+        payloadKind: 'pipeline-handoff-artifact',
+        payloadSha256: 'a'.repeat(64),
+        payloadBytes: 456,
+        headSha: HEAD_A,
+      },
+    });
+
+    expect(text).toContain('public handoff summary');
+    expect(text).not.toContain('/home/');
+    expect(text).not.toContain('t_86f5a998');
+    expect(text).not.toContain('secret');
+  });
+});

--- a/test/pipeline-handoff-timeline.test.ts
+++ b/test/pipeline-handoff-timeline.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import type { PipelineHandoffArtifact } from '../shared/pipeline-handoff-artifact.js';
 import {
+  formatDownstreamFocus,
   formatHandoffArtifactCopy,
   missingHandoffArtifactSummary,
+  safeExternalUrl,
   summarizeHandoffArtifact,
   type PipelineHandoffArtifactEnvelope,
 } from '../frontend/src/lib/pipeline-handoff-timeline.js';
@@ -130,6 +132,58 @@ describe('pipeline handoff timeline summary', () => {
     expect(summary.state).toBe('stale');
     expect(summary.stateLabel).toBe('stale');
     expect(summary.shortHeadSha).toBe('1111111');
+  });
+
+  it('marks artifacts current when API staleness is exact-head clean', () => {
+    const summary = summarizeHandoffArtifact(
+      envelope(artifact(), {
+        staleness: {
+          stale: false,
+          staleIf: { headShaChanges: true },
+          artifactHeadSha: HEAD_A,
+          currentHeadSha: HEAD_A,
+        },
+      })
+    );
+
+    expect(summary.state).toBe('current');
+    expect(summary.stateLabel).toBe('current');
+  });
+
+  it('marks an isolated payload fetch failure as failed without losing metadata', () => {
+    const summary = summarizeHandoffArtifact(
+      envelope(artifact(), { payload: undefined, payloadError: 'HTTP 404' }),
+      HEAD_A
+    );
+
+    expect(summary.state).toBe('failed');
+    expect(summary.stateLabel).toBe('failed');
+    expect(summary.payloadError).toBe('HTTP 404');
+    expect(summary.stageLabel).toBe('implementation');
+  });
+
+  it('filters unsafe open URLs and formats truncated downstream focus', () => {
+    expect(safeExternalUrl('javascript:alert(1)')).toBeNull();
+    expect(safeExternalUrl('http://example.test')).toBeNull();
+    expect(safeExternalUrl('https://github.com/donovan-yohan/relay-ide')).toBe(
+      'https://github.com/donovan-yohan/relay-ide'
+    );
+    const unsafeTaskRef = artifact({
+      scope: {
+        ...artifact().scope,
+        taskRefs: [
+          {
+            kind: 'github-issue',
+            id: '885',
+            url: 'javascript:alert(1)',
+          },
+        ],
+      },
+    });
+    expect(summarizeHandoffArtifact(envelope(unsafeTaskRef), HEAD_A).openUrl).toBe(
+      'https://github.com/donovan-yohan/relay-ide/pull/901'
+    );
+    expect(formatDownstreamFocus(['qa', 'review', 'release'])).toBe('qa · review · +1');
   });
 
   it('surfaces failed or blocking downstream verdicts', () => {


### PR DESCRIPTION
## Summary
- add a compact WorkContext handoff artifact timeline section that loads bounded pipeline handoff artifacts and expands them with payload details for stage/evidence/downstream-focus display
- add sanitized copy/open affordances using the existing public artifact export endpoint and shared public markdown renderer
- disable the copy affordance for private artifacts instead of exposing a predictably failing public-copy request
- add timeline helper coverage for current/stale/missing/failed/copy states

## Verification
- `npm test -- test/pipeline-handoff-timeline.test.ts` (5 passed)
- `npm run check` (passed; existing lint warnings only)
- `npm run build` (passed; existing chunk-size warnings)
- browser smoke at temporary `/test-handoff-timeline-smoke.html` with mocked WorkContext/artifact APIs: timeline rendered captured state, implementation stage, short head, evidence count, verdict, downstream focus, open/copy controls; copy sanitized showed success; console/JS errors clean

## Simplify pass
- ran 3-agent simplify review after the implementation diff
- applied worthwhile cleanup from the pass: private artifact copy gating/disabled state
- earlier cleanup in the branch reused `PIPELINE_HANDOFF_STAGES`, reused shared `renderPipelineHandoffMarkdown`, fetched payload before rendering stage details, changed unknown head copy to captured, and kept visible focus outline
- deferred shared DTO extraction and list-endpoint summary batching as broader follow-ups outside this recovery card

Closes #885
Refs #882


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pipeline handoff artifact timeline section to work context view
  * Users can now view artifact status, stage details, evidence counts, and verdicts
  * Added ability to copy artifact summaries and open external artifact links
  * Support for different artifact states (current, stale, failed, missing, unknown)
  * Introduced artifact filtering and pagination capabilities
  * Display of downstream focus information and per-stage metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
