### PR TITLE
fix: stop hub crash when terminal WS writes to a reaped session

### DIFF
--- a/server/ws.ts
+++ b/server/ws.ts
@@ -63,6 +63,73 @@ function sendTerminalStreamEnvelope(
   if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(envelope));
 }
 
+// Application close code (4000-4999 range) for a terminal WS that wrote/resized
+// against a session the hub no longer has (e.g. reaped while a stale browser tab
+// stayed open). The terminal client only renders TerminalStreamEnvelope JSON or
+// raw bytes, so a JSON error blob would paint as terminal garbage — closing with
+// a typed code lets the client treat it as a session end instead. The non-1000
+// code routes the frontend through its reconnect/`/sessions` recheck path, which
+// discovers the session is gone and renders `[session ended]`.
+export const TERMINAL_WS_SESSION_NOT_FOUND_CLOSE_CODE = 4404;
+const TERMINAL_WS_SESSION_NOT_FOUND_REASON = 'session-not-found';
+
+function isSessionNotFoundError(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message.startsWith('Session not found:')
+  );
+}
+
+/**
+ * Minimal session-side dependency surface exercised by a terminal PTY ws
+ * message. Injected so the guard logic can be unit-tested without booting the
+ * full WebSocket server.
+ */
+interface TerminalPtySessionSink {
+  resize(id: string, cols: number, rows: number): void;
+  write(id: string, data: string): void;
+}
+
+/**
+ * Apply a terminal ws message's session side effect (resize or raw write),
+ * surviving a session-not-found throw from a reaped session (#905). Returns
+ * `'session-not-found'` when the socket was closed because the session is gone,
+ * `'applied'` once the side effect ran, or `null` when nothing was applied
+ * (e.g. a resize that was not the active owner). Any non-not-found throw is
+ * re-thrown so genuine faults stay visible.
+ */
+export function applyTerminalPtyMessage(
+  ws: WebSocket,
+  sessionId: string,
+  sink: TerminalPtySessionSink,
+  input:
+    | { kind: 'resize'; cols: number; rows: number; apply: boolean }
+    | { kind: 'write'; data: string }
+): 'applied' | 'session-not-found' | null {
+  try {
+    if (input.kind === 'resize') {
+      if (!input.apply) return null;
+      sink.resize(sessionId, input.cols, input.rows);
+    } else {
+      sink.write(sessionId, input.data);
+    }
+    return 'applied';
+  } catch (error) {
+    if (isSessionNotFoundError(error)) {
+      logger.warn(
+        `terminal ws message for missing session ${sessionId}; closing socket`
+      );
+      if (ws.readyState === ws.OPEN) {
+        ws.close(
+          TERMINAL_WS_SESSION_NOT_FOUND_CLOSE_CODE,
+          TERMINAL_WS_SESSION_NOT_FOUND_REASON
+        );
+      }
+      return 'session-not-found';
+    }
+    throw error;
+  }
+}
+
 function ensureTerminalStreamState(session: Extract<Session, { mode: 'pty' }>) {
   if (!session.terminalStream) {
     session.terminalStream = createTerminalStreamState({
@@ -836,6 +903,16 @@ function setupWebSocket(
 
       ws.on('message', (msg) => {
         const str = msg.toString();
+        // Parse control frames (ping/resize) separately so a malformed JSON
+        // payload falls through to the raw-input write path. Side effects that
+        // reach into the session (resize/write) are deferred until after parsing
+        // so the parse-error catch never masks a session-not-found throw.
+        let pendingResize: {
+          cols: number;
+          rows: number;
+          owner: TerminalStreamResizeOwner;
+          clientId: string | null;
+        } | null = null;
         try {
           const parsed = JSON.parse(str);
           if (parsed && typeof parsed === 'object') {
@@ -848,35 +925,53 @@ function setupWebSocket(
               const cols = parseResizeDimension(payload['cols']);
               const rows = parseResizeDimension(payload['rows']);
               if (cols === null || rows === null) return;
-              const owner = parseResizeOwner(
-                payload['owner'] ?? attachContext.resizeOwner
-              );
-              const resizeEnvelope = recordTerminalStreamResize(
-                terminalStream,
-                {
-                  cols,
-                  rows,
-                  owner,
-                  sourceClientId:
-                    parseClientId(payload['clientId']) ??
-                    attachContext.clientId,
-                }
-              );
-              if (resizeEnvelope.payload.applied) {
-                sessions.resize(session.id, cols, rows);
-              }
-              for (const cb of session.terminalStreamSubscribers ?? []) {
-                cb(resizeEnvelope);
-              }
-              return;
+              pendingResize = {
+                cols,
+                rows,
+                owner: parseResizeOwner(
+                  payload['owner'] ?? attachContext.resizeOwner
+                ),
+                clientId: parseClientId(payload['clientId']),
+              };
             }
           }
         } catch (_) {
-          // ignore
+          // Non-JSON payload — treated as raw terminal input below.
+        }
+
+        // Writes/resizes against a reaped session throw synchronously from
+        // sessions.write/resize. An uncaught throw in this ws callback would
+        // take down the whole hub (#905); applyTerminalPtyMessage guards the
+        // session-touching path and closes the socket with a typed code instead.
+        if (pendingResize) {
+          const resizeEnvelope = recordTerminalStreamResize(terminalStream, {
+            cols: pendingResize.cols,
+            rows: pendingResize.rows,
+            owner: pendingResize.owner,
+            sourceClientId: pendingResize.clientId ?? attachContext.clientId,
+          });
+          const outcome = applyTerminalPtyMessage(ws, session.id, sessions, {
+            kind: 'resize',
+            cols: pendingResize.cols,
+            rows: pendingResize.rows,
+            apply: resizeEnvelope.payload.applied,
+          });
+          if (outcome === 'session-not-found') return;
+          for (const cb of session.terminalStreamSubscribers ?? []) {
+            cb(resizeEnvelope);
+          }
+          return;
         }
         // Route browser PTY input through the session write path so control
         // interventions are recorded before the active PTY receives input.
-        sessions.write(session.id, str);
+        if (
+          applyTerminalPtyMessage(ws, session.id, sessions, {
+            kind: 'write',
+            data: str,
+          }) === 'session-not-found'
+        ) {
+          return;
+        }
         // Update activity timestamp on user input (throttled broadcast to avoid storm)
         const now = Date.now();
         session.lastActivity = new Date(now).toISOString();

--- a/test/ws-session-write-crash.test.ts
+++ b/test/ws-session-write-crash.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import type { WebSocket } from 'ws';
+import {
+  applyTerminalPtyMessage,
+  TERMINAL_WS_SESSION_NOT_FOUND_CLOSE_CODE,
+} from '../server/ws.js';
+
+// #905: a stale browser tab writing/resizing to a reaped PTY session used to
+// throw `Session not found: <id>` synchronously out of the ws 'message'
+// callback, which is an uncaught exception that killed the whole hub process.
+// applyTerminalPtyMessage must absorb that specific throw, close the socket with
+// a typed code, and never let it propagate.
+//
+// Protocol note: the terminal client (frontend/src/lib/ws.ts) only renders
+// recognized TerminalStreamEnvelope JSON or raw bytes — a JSON error blob would
+// be painted as terminal garbage. So instead of an in-band error envelope we
+// close with application close code 4404 'session-not-found'. The frontend's
+// onclose treats any non-1000 code as a reconnect trigger, re-checks /sessions,
+// and renders `[session ended]` when the session is gone — the desired UX.
+
+interface FakeWs {
+  readyState: number;
+  readonly OPEN: number;
+  closes: Array<{ code?: number; reason?: string }>;
+  close(code?: number, reason?: string): void;
+}
+
+function createFakeWs(open = true): FakeWs {
+  const OPEN = 1;
+  return {
+    OPEN,
+    readyState: open ? OPEN : 3 /* CLOSED */,
+    closes: [],
+    close(code?: number, reason?: string) {
+      this.closes.push({ code, reason });
+      this.readyState = 3;
+    },
+  };
+}
+
+function notFoundSink(id: string) {
+  const throwNotFound = () => {
+    throw new Error(`Session not found: ${id}`);
+  };
+  return { resize: throwNotFound, write: throwNotFound };
+}
+
+describe('applyTerminalPtyMessage (#905 reaped-session write crash)', () => {
+  it('does not throw when a write targets a reaped session', () => {
+    const ws = createFakeWs();
+    const outcome = applyTerminalPtyMessage(
+      ws as unknown as WebSocket,
+      'gone-session',
+      notFoundSink('gone-session'),
+      { kind: 'write', data: 'ls\n' }
+    );
+    expect(outcome).toBe('session-not-found');
+  });
+
+  it('closes the socket with the typed session-not-found code on write', () => {
+    const ws = createFakeWs();
+    applyTerminalPtyMessage(
+      ws as unknown as WebSocket,
+      'gone-session',
+      notFoundSink('gone-session'),
+      { kind: 'write', data: 'ls\n' }
+    );
+    expect(ws.closes).toHaveLength(1);
+    expect(ws.closes[0]).toEqual({
+      code: TERMINAL_WS_SESSION_NOT_FOUND_CLOSE_CODE,
+      reason: 'session-not-found',
+    });
+    expect(TERMINAL_WS_SESSION_NOT_FOUND_CLOSE_CODE).toBe(4404);
+  });
+
+  it('does not throw when a resize targets a reaped session', () => {
+    const ws = createFakeWs();
+    const outcome = applyTerminalPtyMessage(
+      ws as unknown as WebSocket,
+      'gone-session',
+      notFoundSink('gone-session'),
+      { kind: 'resize', cols: 80, rows: 24, apply: true }
+    );
+    expect(outcome).toBe('session-not-found');
+    expect(ws.closes[0]?.code).toBe(TERMINAL_WS_SESSION_NOT_FOUND_CLOSE_CODE);
+  });
+
+  it('skips the resize side effect (and never throws) when not the active owner', () => {
+    const ws = createFakeWs();
+    let resized = false;
+    const outcome = applyTerminalPtyMessage(
+      ws as unknown as WebSocket,
+      'gone-session',
+      {
+        resize: () => {
+          resized = true;
+        },
+        write: () => {},
+      },
+      { kind: 'resize', cols: 80, rows: 24, apply: false }
+    );
+    expect(outcome).toBeNull();
+    expect(resized).toBe(false);
+    expect(ws.closes).toHaveLength(0);
+  });
+
+  it('does not attempt to close an already-closed socket', () => {
+    const ws = createFakeWs(false);
+    const outcome = applyTerminalPtyMessage(
+      ws as unknown as WebSocket,
+      'gone-session',
+      notFoundSink('gone-session'),
+      { kind: 'write', data: 'x' }
+    );
+    expect(outcome).toBe('session-not-found');
+    expect(ws.closes).toHaveLength(0);
+  });
+
+  it('re-throws non-session-not-found errors so genuine faults stay visible', () => {
+    const ws = createFakeWs();
+    const sink = {
+      resize: () => {},
+      write: () => {
+        throw new Error('disk on fire');
+      },
+    };
+    expect(() =>
+      applyTerminalPtyMessage(ws as unknown as WebSocket, 'live-session', sink, {
+        kind: 'write',
+        data: 'x',
+      })
+    ).toThrow('disk on fire');
+    expect(ws.closes).toHaveLength(0);
+  });
+
+  it('applies a normal write to a live session and reports applied', () => {
+    const ws = createFakeWs();
+    const writes: string[] = [];
+    const outcome = applyTerminalPtyMessage(
+      ws as unknown as WebSocket,
+      'live-session',
+      {
+        resize: () => {},
+        write: (_id, data) => {
+          writes.push(data);
+        },
+      },
+      { kind: 'write', data: 'echo hi\n' }
+    );
+    expect(outcome).toBe('applied');
+    expect(writes).toEqual(['echo hi\n']);
+    expect(ws.closes).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- A stale browser tab writing/resizing a reaped session threw `Session not found` out of the terminal `ws.on('message')` handler — an uncaught exception that killed the whole hub process (reproduced twice during #897 QA).
- New guarded `applyTerminalPtyMessage` helper in `server/ws.ts` wraps the PTY-branch `sessions.resize`/`sessions.write` side effects: on session-not-found it logs a warning, closes the socket with typed close code `4404` (`session-not-found`), and returns a sentinel. Other errors still re-throw so genuine faults stay visible.
- Protocol decision: WS close code instead of a JSON error envelope — the terminal client (`frontend/src/lib/ws.ts`) writes any frame that isn't a terminal-stream envelope raw into xterm, so an envelope would render as garbage. A non-1000 close triggers the existing reconnect path, which finds the session gone and renders `[session ended]`.
- Survey of other network-reachable `sessions.write/resize/kill` sites: HTTP write route and node-link RPC host already guarded; the ws.ts PTY handler was the only unguarded site.

Fixes #905

## Test plan
- New `test/ws-session-write-crash.test.ts` (7 cases): write/resize to reaped session does not throw, closes 4404, already-closed socket not re-closed, non-not-found errors re-throw, live-session write still applies.
- `test/ws-pty-routing.test.ts` 15/15 pass locally; `npm run check` clean (0 errors).
- `test/ws-pty-intervention.test.ts` fails locally only due to the known hoisted better-sqlite3 ABI mismatch — CI is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Enhanced error handling for terminal sessions that are no longer available, preventing application crashes when stale browser connections attempt to interact with terminated terminals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->