### PR TITLE
test: make server-startup SIGTERM shutdown wait flake-resistant

### DIFF
--- a/test/server-startup.test.ts
+++ b/test/server-startup.test.ts
@@ -18,6 +18,10 @@ const SERVER_SCRIPT = path.resolve(
   'index.js'
 );
 
+if (!fs.existsSync(SERVER_SCRIPT)) {
+  throw new Error('dist/server/index.js missing — run npm run build first');
+}
+
 interface StartServerOpts {
   env: Record<string, string>;
 }
@@ -59,9 +63,13 @@ async function killAndWait(child: ChildProcess): Promise<void> {
   // Reject on timeout (not resolve) — a non-exiting server is a real bug and
   // should fail the test loudly instead of racing with the rmSync in finally.
   await new Promise<void>((resolve, reject) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve();
+      return;
+    }
     const timeout = setTimeout(() => {
-      reject(new Error('Server did not exit within 3s of SIGTERM'));
-    }, 3000);
+      reject(new Error('Server did not exit within 10s of SIGTERM'));
+    }, 10000);
     child.on('exit', () => {
       clearTimeout(timeout);
       resolve();


### PR DESCRIPTION
## Summary
- `killAndWait` resolves immediately when the spawned server already exited — previously a pre-exited child waited out the full timeout because the `exit` listener never fired.
- SIGTERM exit wait bumped 3s → 10s; the 3s budget flaked on loaded CI runners in 2 of the last 3 runs (one on a docs-only diff, run 27290857827 — definitive environmental evidence).
- Module-level fast-fail with a clear message when `dist/server/index.js` is missing, which previously masked locally as the same SIGTERM-timeout error.

Fixes #909

## Test plan
- `tsc --noEmit -p test/tsconfig.json` clean.
- The suite needs `npm run build` first (now stated explicitly by the fast-fail); CI runs it as part of the normal pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)