### PR TITLE
feat: bridge session lifecycle actions to shared descriptor contract

### DIFF
--- a/docs/refactor/860-action-contract-follow-up-map.md
+++ b/docs/refactor/860-action-contract-follow-up-map.md
@@ -25,6 +25,27 @@ The first converted vertical is session launch through the stable command id `se
 
 This documents only the converted `sessions.create` launch family. Other action groups below remain follow-up work.
 
+## #869 converted lifecycle slice
+
+The second converted vertical is session close/kill/rename through the stable command ids `sessions.kill` and `sessions.rename`:
+
+- Stable CLI/API commands: `relay-ide v1 sessions kill --id <session-id> --json` and `relay-ide v1 sessions rename --id <session-id> --display-name <display-name> --json`
+- Shared descriptor source: `sessionKillActionDescriptor()` / `sessionRenameActionDescriptor()` in `frontend/src/lib/actions/session-lifecycle.ts`, generated from `relayCommandDefinition('sessions.kill')` and `relayCommandDefinition('sessions.rename')`
+- Browser action metadata using the descriptors: `session.close-active` and `session.kill` bridge to `sessions.kill`; `session.rename` and `sidebar.rename-session` bridge to `sessions.rename`
+- Typed input: `{ id, confirmationToken? }` for kill and `{ id, displayName }` for rename, matching the `sessions.kill` / `sessions.rename` input schemas
+- Typed success result: the normal v1 `RelayCliGatewayEnvelope` with `ok`, `contract`, `contractVersion`, `command`, and `data` carrying session identity. Kill data is `{ ok, killed, id, sessionId, requestedId, nodeId, globalSessionId }`; rename data is `{ renamed, id, sessionId, requestedId, nodeId, globalSessionId, displayName, session? }`
+- Typed failure result: the normal v1 gateway error envelope from `gatewayError('sessions.kill', ...)` / `gatewayError('sessions.rename', ...)`, including stable codes `NOT_FOUND`, `NODE_OFFLINE`, `FORBIDDEN`, `CONFIRMATION_REQUIRED`, and `UPSTREAM_ERROR`. Session-control `reasonCode`s (`SESSION_NOT_FOUND`, `SESSION_DISCONNECTED`, `CONTROL_STATE_STALE`, `CONTROL_STATE_UNKNOWN`, `CAPABILITY_REQUIRED`) ride on `error.details.reasonCode`; stale/unknown control state and disconnected/unsupported-mode sessions surface as gateway `FORBIDDEN`
+- Confirmation/side-effect: `sessions.kill` is a destructive command (`sideEffect: 'destructive'`, `confirmation.required: true`); execution delegates to api.ts `killSession`, whose `registerConfirmationRetry` loop remains the single confirmation-token path. `sessions.rename` is a non-destructive write (`sideEffect: 'write'`, `confirmation.required: false`)
+- Availability/capability behavior: `sessionKillActionAvailability()` / `sessionRenameActionAvailability()` report the shared availability shape with the `session:read` + `session:control:kill` / `session:control:rename` capability hints. Missing session, offline node, unsupported session mode, and stale/unknown control state map to `unavailable`
+
+### `session.close-active` → `sessions.kill` split rationale
+
+`close` is `kill` plus a tab-selection UI layered on top, not a distinct verb. Closing the active tab destroys the underlying session, which is exactly the `sessions.kill` destructive contract; the only extra behavior is selecting the next tab in the web UI, which stays browser-only. No new `sessions.close` command is introduced. `sessions.detach` already owns the non-destructive close path (handle-release only) and is untouched by this slice.
+
+### `sidebar.rename-session` → `sessions.rename` collapse
+
+`sidebar.rename-session` was a duplicate browser-only rename affordance. It collapses into the single `sessions.rename` descriptor and shares the same executor; there is no separate sidebar rename command. The sidebar entry point remains a UI affordance over the one stable rename contract.
+
 ## Follow-up issues
 
 | Issue                                                         | Group                                    | Owner area                          | Gap type                | Scope                                                                                                                                                                                     | Parent closeout impact                                                           |

--- a/frontend/src/hooks/useActionRegistry.ts
+++ b/frontend/src/hooks/useActionRegistry.ts
@@ -93,7 +93,8 @@ import { cliGatewayCommandActions } from '../lib/actions/definitions/cli-gateway
 import { useSessionsStore } from '../lib/stores/sessions.js';
 import { useUiStore } from '../lib/stores/ui.js';
 import { useConfigStore } from '../lib/stores/config.js';
-import { ConflictError, killSession, setDefaultYolo } from '../lib/api.js';
+import { ConflictError, setDefaultYolo } from '../lib/api.js';
+import { executeSessionKillAction } from '../lib/actions/session-lifecycle.js';
 import { createLogger } from '../lib/logger.js';
 import type { Action, ActionContext } from '../lib/actions/types.js';
 import type { Repo } from '../lib/types.js';
@@ -210,10 +211,15 @@ export function useActionRegistry(params: UseActionRegistryParams): void {
               useSessionsStore.getState().sessions,
               id
             );
-            try {
-              await killSession(sessionId, nodeId);
-            } catch (err) {
-              logger.error('Failed to kill session', err);
+            // Route through the shared sessions.kill executor. Resolving the
+            // owning node here and passing it in the input keeps the existing
+            // owning-node DELETE routing intact via the default api executor.
+            const result = await executeSessionKillAction({
+              id: sessionId,
+              nodeId,
+            });
+            if (!result.ok) {
+              logger.error('Failed to kill session', result.error);
             }
             await useSessionsStore.getState().refreshAll();
           }

--- a/frontend/src/hooks/useSessionHandlers.ts
+++ b/frontend/src/hooks/useSessionHandlers.ts
@@ -16,9 +16,12 @@ import {
   fetchWorktreeStatus,
   killSession,
   deleteWorktree,
-  renameSession as renameSessionApi,
   launchWorkspaceSession,
 } from '../lib/api.js';
+import {
+  executeSessionKillAction,
+  executeSessionRenameAction,
+} from '../lib/actions/session-lifecycle.js';
 import type { BenchCreatePayload } from '../lib/state/view-tree.js';
 import {
   derivePrAction,
@@ -90,7 +93,16 @@ export function useSessionHandlers({
     const id = state.activeSessionId;
     const session = id ? resolveSessionByKey(state.sessions, id) : undefined;
     if (name?.trim() && session) {
-      await renameSessionApi(session.id, name.trim());
+      // Route through the shared sessions.rename executor; passing the owning
+      // node lets the default api executor keep its node-aware PATCH routing.
+      const result = await executeSessionRenameAction({
+        id: session.id,
+        displayName: name.trim(),
+        ...(session.nodeId ? { nodeId: session.nodeId } : {}),
+      });
+      if (!result.ok) {
+        logger.error('Failed to rename session:', result.error);
+      }
     }
   }, []);
 
@@ -897,10 +909,15 @@ export function useSessionHandlers({
         sessionId: localSessionId,
         nodeId: targetNodeId,
       } = resolveSessionCloseTarget(state.sessions, sessionId, nodeId);
-      // Kill session via API, then refresh
-      void killSession(localSessionId, targetNodeId)
-        .catch((error) => {
-          logger.error('Failed to close session:', error);
+      // Close = kill + tab-selection UI. Route the kill through the shared
+      // sessions.kill executor with the resolved owning node, then refresh
+      // regardless of outcome. Tab selection below stays synchronous so the UI
+      // advances without waiting on the kill.
+      void executeSessionKillAction({ id: localSessionId, nodeId: targetNodeId })
+        .then((result) => {
+          if (!result.ok) {
+            logger.error('Failed to close session:', result.error);
+          }
         })
         .finally(() => useSessionsStore.getState().refreshAll());
       const currentActiveSessionId = state.activeSessionId;

--- a/frontend/src/lib/actions/definitions/session.ts
+++ b/frontend/src/lib/actions/definitions/session.ts
@@ -3,6 +3,12 @@ import {
   sessionCreateActionAvailability,
   sessionCreateActionDescriptor,
 } from '../session-create.js';
+import {
+  sessionKillActionAvailability,
+  sessionKillActionDescriptor,
+  sessionRenameActionAvailability,
+  sessionRenameActionDescriptor,
+} from '../session-lifecycle.js';
 
 const launchDescriptor = sessionCreateActionDescriptor();
 const launchRequiresContext = (ctx: ActionContext) =>
@@ -10,6 +16,17 @@ const launchRequiresContext = (ctx: ActionContext) =>
     ...(ctx.workspacePath ? { workspacePath: ctx.workspacePath } : {}),
     ...(ctx.cwd ? { cwd: ctx.cwd } : {}),
   }).reason;
+
+// #869: session.kill is the stable destructive lifecycle verb. session.close-active
+// bridges to the SAME descriptor — close is kill plus tab-selection UI, with no
+// separate sessions.close command in the manifest.
+const killDescriptor = sessionKillActionDescriptor();
+const killRequiresSession = (ctx: ActionContext) =>
+  sessionKillActionAvailability({ sessionMissing: !ctx.sessionId }).reason;
+
+const renameDescriptor = sessionRenameActionDescriptor();
+const renameRequiresSession = (ctx: ActionContext) =>
+  sessionRenameActionAvailability({ sessionMissing: !ctx.sessionId }).reason;
 
 export const sessionNewAgent: ActionMeta = {
   id: 'session.new-agent',
@@ -42,6 +59,8 @@ export const sessionCloseActive: ActionMeta = {
   icon: '×',
   shortcut: { key: 'mod+w' },
   when: (ctx) => !!ctx.sessionId,
+  disabledReason: killRequiresSession,
+  descriptor: killDescriptor,
 };
 
 export const sessionKill: ActionMeta = {
@@ -51,6 +70,8 @@ export const sessionKill: ActionMeta = {
   category: 'session',
   icon: '■',
   when: (ctx) => !!ctx.sessionId,
+  disabledReason: killRequiresSession,
+  descriptor: killDescriptor,
 };
 
 export const sessionStartOnRepo: ActionMeta = {
@@ -98,6 +119,8 @@ export const sessionRename: ActionMeta = {
   category: 'session',
   icon: '~',
   when: (ctx) => !!ctx.sessionId,
+  disabledReason: renameRequiresSession,
+  descriptor: renameDescriptor,
 };
 
 // #630: command-palette entry that opens the EnvironmentPicker (#627) and

--- a/frontend/src/lib/actions/definitions/sidebar.ts
+++ b/frontend/src/lib/actions/definitions/sidebar.ts
@@ -1,4 +1,14 @@
-import type { ActionMeta } from '../types.js';
+import type { ActionContext, ActionMeta } from '../types.js';
+import {
+  sessionRenameActionAvailability,
+  sessionRenameActionDescriptor,
+} from '../session-lifecycle.js';
+
+// #869: sidebar.rename-session collapses into the sessions.rename descriptor —
+// same stable command and executor as session.rename, just a different entry point.
+const renameDescriptor = sessionRenameActionDescriptor();
+const renameRequiresSession = (ctx: ActionContext) =>
+  sessionRenameActionAvailability({ sessionMissing: !ctx.sessionId }).reason;
 
 export const sidebarCollapse: ActionMeta = {
   id: 'sidebar.collapse',
@@ -33,6 +43,8 @@ export const sidebarRenameSession: ActionMeta = {
   category: 'sidebar',
   icon: '~',
   when: (ctx) => !!ctx.sessionId,
+  disabledReason: renameRequiresSession,
+  descriptor: renameDescriptor,
 };
 
 export const sidebarDeleteWorktree: ActionMeta = {

--- a/frontend/src/lib/actions/session-lifecycle.ts
+++ b/frontend/src/lib/actions/session-lifecycle.ts
@@ -1,0 +1,331 @@
+import {
+  relayActionDescriptorFromCommandDefinition,
+  type RelayActionAvailability,
+  type RelayActionDescriptor,
+} from '../../../../shared/action-descriptor.js';
+import {
+  gatewayError,
+  gatewayOk,
+  type RelayCliGatewayEnvelope,
+  type RelayCliGatewayError,
+  type RelayCliGatewayErrorCode,
+} from '../../../../shared/cli-gateway-contract.js';
+import { normalizeGatewayErrorCode } from '../../../../shared/cli-gateway-runtime.js';
+import {
+  DEFAULT_LOCAL_NODE_ID,
+  createGlobalSessionId,
+  type NodeId,
+} from '../../../../shared/identity.js';
+import {
+  relayCommandDefinition,
+  type RelayCommandDefinition,
+} from '../../../../shared/relay-command-manifest.js';
+import {
+  ConfirmationRequiredError,
+  HttpError,
+  killSession as killSessionApi,
+  renameSession as renameSessionApi,
+} from '../api.js';
+
+const SESSIONS_KILL_COMMAND = relayCommandDefinition('sessions.kill');
+const SESSIONS_RENAME_COMMAND = relayCommandDefinition('sessions.rename');
+
+// Optional fields permit explicit `undefined` to satisfy exactOptionalPropertyTypes
+// at the call sites that resolve node identity conditionally.
+export interface SessionKillActionInput {
+  id: string;
+  nodeId?: NodeId | string | undefined;
+  globalSessionId?: string | undefined;
+  confirmationToken?: string | undefined;
+}
+
+export interface SessionRenameActionInput {
+  id: string;
+  displayName: string;
+  nodeId?: NodeId | string | undefined;
+  globalSessionId?: string | undefined;
+}
+
+export interface SessionLifecycleActionTarget {
+  sessionId: string;
+  globalSessionId: string;
+  nodeId: string;
+}
+
+export interface SessionKillActionData {
+  ok: true;
+  killed: true;
+  id: string;
+  sessionId: string;
+  requestedId: string;
+  nodeId: string;
+  globalSessionId: string;
+}
+
+export interface SessionRenameActionData {
+  renamed: true;
+  id: string;
+  sessionId: string;
+  requestedId: string;
+  nodeId: string;
+  globalSessionId: string;
+  displayName: string;
+}
+
+export type SessionKillActionResult =
+  RelayCliGatewayEnvelope<SessionKillActionData>;
+export type SessionRenameActionResult =
+  RelayCliGatewayEnvelope<SessionRenameActionData>;
+
+// Executors take the action input object so call sites can resolve owning-node
+// routing once and pass it through (see useActionRegistry sessions.kill wiring).
+// Defaults delegate to api.ts so the DELETE/PATCH + confirmation-retry stay one path.
+export type SessionKillExecutor = (
+  input: SessionKillActionInput
+) => Promise<void>;
+export type SessionRenameExecutor = (
+  input: SessionRenameActionInput
+) => Promise<unknown>;
+
+// Session-control reasonCodes (server/session-control-api.ts:29-37) carry a
+// finer-grained meaning than the gateway code; surface them on the gateway code
+// the spec freezes (stale/unknown control and disconnected sessions are gateway
+// FORBIDDEN even though normalizeGatewayErrorCode keeps them as their own codes).
+const REASON_CODE_TO_GATEWAY_CODE: Record<string, RelayCliGatewayErrorCode> = {
+  SESSION_NOT_FOUND: 'NOT_FOUND',
+  CAPABILITY_REQUIRED: 'FORBIDDEN',
+  SESSION_DISCONNECTED: 'FORBIDDEN',
+  CONTROL_STATE_STALE: 'FORBIDDEN',
+  CONTROL_STATE_UNKNOWN: 'FORBIDDEN',
+};
+
+function killCapabilityAvailability(reason?: string): RelayActionAvailability {
+  return {
+    state: reason ? 'unavailable' : 'available',
+    ...(reason ? { reason } : {}),
+    capabilityHints: SESSIONS_KILL_COMMAND.capabilityHints,
+  };
+}
+
+function renameCapabilityAvailability(reason?: string): RelayActionAvailability {
+  return {
+    state: reason ? 'unavailable' : 'available',
+    ...(reason ? { reason } : {}),
+    capabilityHints: SESSIONS_RENAME_COMMAND.capabilityHints,
+  };
+}
+
+export function sessionKillActionDescriptor(
+  availability: RelayActionAvailability = killCapabilityAvailability()
+): RelayActionDescriptor {
+  return relayActionDescriptorFromCommandDefinition(SESSIONS_KILL_COMMAND, {
+    availability,
+    surfaces: ['cli', 'agent', 'web', 'command-center'],
+  });
+}
+
+export function sessionRenameActionDescriptor(
+  availability: RelayActionAvailability = renameCapabilityAvailability()
+): RelayActionDescriptor {
+  return relayActionDescriptorFromCommandDefinition(SESSIONS_RENAME_COMMAND, {
+    availability,
+    surfaces: ['cli', 'agent', 'web', 'command-center'],
+  });
+}
+
+interface SessionLifecycleAvailabilityInput {
+  sessionMissing?: boolean;
+  nodeUnavailableReason?: string | null;
+  unsupportedModeReason?: string | null;
+  controlState?: 'stale' | 'unknown' | null;
+}
+
+function lifecycleUnavailableReason(
+  input: SessionLifecycleAvailabilityInput,
+  verb: string
+): string | undefined {
+  if (input.sessionMissing) return `${verb} requires an existing session`;
+  if (input.nodeUnavailableReason) return input.nodeUnavailableReason;
+  if (input.unsupportedModeReason) return input.unsupportedModeReason;
+  if (input.controlState === 'stale')
+    return `${verb} requires fresh session control state`;
+  if (input.controlState === 'unknown')
+    return `${verb} requires known session control state`;
+  return undefined;
+}
+
+export function sessionKillActionAvailability(
+  input: SessionLifecycleAvailabilityInput
+): RelayActionAvailability {
+  return killCapabilityAvailability(
+    lifecycleUnavailableReason(input, 'closing a session')
+  );
+}
+
+export function sessionRenameActionAvailability(
+  input: SessionLifecycleAvailabilityInput
+): RelayActionAvailability {
+  return renameCapabilityAvailability(
+    lifecycleUnavailableReason(input, 'renaming a session')
+  );
+}
+
+export function sessionsKillCommandDefinition(): RelayCommandDefinition {
+  return SESSIONS_KILL_COMMAND;
+}
+
+export function sessionsRenameCommandDefinition(): RelayCommandDefinition {
+  return SESSIONS_RENAME_COMMAND;
+}
+
+function resolveIdentity(input: {
+  id: string;
+  nodeId?: NodeId | string | undefined;
+  globalSessionId?: string | undefined;
+}): SessionLifecycleActionTarget {
+  const parsedNodeId = input.globalSessionId?.includes(':')
+    ? input.globalSessionId.slice(0, input.globalSessionId.indexOf(':'))
+    : undefined;
+  const nodeId = input.nodeId ?? parsedNodeId ?? DEFAULT_LOCAL_NODE_ID;
+  return {
+    sessionId: input.id,
+    globalSessionId:
+      input.globalSessionId ?? createGlobalSessionId(nodeId, input.id),
+    nodeId,
+  };
+}
+
+export function sessionKillActionTarget(
+  input: SessionKillActionInput
+): SessionLifecycleActionTarget {
+  return resolveIdentity(input);
+}
+
+export function sessionRenameActionTarget(
+  input: SessionRenameActionInput
+): SessionLifecycleActionTarget {
+  return resolveIdentity(input);
+}
+
+function reasonCodeFromError(error: HttpError): string | undefined {
+  const reasonCode = error.details?.['reasonCode'];
+  return typeof reasonCode === 'string' ? reasonCode : undefined;
+}
+
+function gatewayCodeForHttpError(error: HttpError): RelayCliGatewayErrorCode {
+  const reasonCode = reasonCodeFromError(error);
+  const mapped = reasonCode ? REASON_CODE_TO_GATEWAY_CODE[reasonCode] : undefined;
+  if (mapped) return mapped;
+  return normalizeGatewayErrorCode(error.status, {
+    code: error.code,
+    message: error.message,
+    retryable: error.retryable,
+    details: error.details,
+  });
+}
+
+function errorFromUnknown(
+  error: unknown,
+  fallbackReasonCode: string,
+  fallbackMessage: string
+): RelayCliGatewayError {
+  if (error instanceof ConfirmationRequiredError) {
+    return {
+      code: 'CONFIRMATION_REQUIRED',
+      message: error.message,
+      retryable: true,
+      details: {
+        reasonCode: error.challenge.reasonCode,
+        challengeId: error.challenge.challengeId,
+        requiredBits: error.challenge.requiredBits,
+        expiresAt: error.challenge.expiresAt,
+      },
+    };
+  }
+
+  if (error instanceof HttpError) {
+    const reasonCode = reasonCodeFromError(error) ?? error.code ?? fallbackReasonCode;
+    return {
+      code: gatewayCodeForHttpError(error),
+      message: error.message,
+      retryable: error.retryable ?? error.status >= 500,
+      details: { reasonCode, ...(error.details ?? {}) },
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      code: 'UPSTREAM_ERROR',
+      message: error.message,
+      retryable: true,
+      details: { reasonCode: fallbackReasonCode },
+    };
+  }
+
+  return {
+    code: 'UPSTREAM_ERROR',
+    message: fallbackMessage,
+    retryable: true,
+    details: { reasonCode: fallbackReasonCode },
+  };
+}
+
+const defaultKillExecutor: SessionKillExecutor = (input) =>
+  killSessionApi(input.id, input.nodeId);
+const defaultRenameExecutor: SessionRenameExecutor = (input) =>
+  renameSessionApi(input.id, input.displayName, input.nodeId);
+
+export async function executeSessionKillAction(
+  input: SessionKillActionInput,
+  killSession: SessionKillExecutor = defaultKillExecutor
+): Promise<SessionKillActionResult> {
+  try {
+    // Delegate to api.ts killSession so its registerConfirmationRetry loop stays
+    // the single confirmation path; the DELETE returns no body, so the identity
+    // envelope is projected from the request target.
+    await killSession(input);
+    const target = sessionKillActionTarget(input);
+    return gatewayOk('sessions.kill', {
+      ok: true,
+      killed: true,
+      id: target.sessionId,
+      sessionId: target.sessionId,
+      requestedId: target.sessionId,
+      nodeId: target.nodeId,
+      globalSessionId: target.globalSessionId,
+    });
+  } catch (rawError) {
+    return gatewayError(
+      'sessions.kill',
+      errorFromUnknown(rawError, 'SESSION_KILL_FAILED', 'failed to close session')
+    );
+  }
+}
+
+export async function executeSessionRenameAction(
+  input: SessionRenameActionInput,
+  renameSession: SessionRenameExecutor = defaultRenameExecutor
+): Promise<SessionRenameActionResult> {
+  try {
+    await renameSession(input);
+    const target = sessionRenameActionTarget(input);
+    return gatewayOk('sessions.rename', {
+      renamed: true,
+      id: target.sessionId,
+      sessionId: target.sessionId,
+      requestedId: target.sessionId,
+      nodeId: target.nodeId,
+      globalSessionId: target.globalSessionId,
+      displayName: input.displayName,
+    });
+  } catch (rawError) {
+    return gatewayError(
+      'sessions.rename',
+      errorFromUnknown(
+        rawError,
+        'SESSION_RENAME_FAILED',
+        'failed to rename session'
+      )
+    );
+  }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1687,13 +1687,22 @@ export async function killSession(
 
 export async function renameSession(
   id: string,
-  displayName: string
-): Promise<void> {
-  await fetch('/sessions/' + id, {
+  displayName: string,
+  nodeId?: NodeId | string
+): Promise<SessionSummary> {
+  const sessionPath =
+    nodeId && nodeId !== DEFAULT_LOCAL_NODE_ID
+      ? `/hub/nodes/${encodeURIComponent(nodeId)}/sessions/${encodeURIComponent(id)}`
+      : `/sessions/${encodeURIComponent(id)}`;
+  const res = await fetch(sessionPath, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ displayName }),
   });
+  // The local PATCH 404 body is `{error:'Session not found'}` (non-envelope);
+  // httpErrorFromResponse normalizes both that and routed RelayError envelopes.
+  if (!res.ok) throw await httpErrorFromResponse(res, 'Failed to rename session');
+  return jsonEither<SessionSummary>(res);
 }
 
 export async function fetchWorktreeStatus(

--- a/test/action-coverage.test.ts
+++ b/test/action-coverage.test.ts
@@ -201,6 +201,42 @@ describe('Action Coverage', () => {
     });
   });
 
+  it('bridges sessions.kill as a destructive, confirmation-gated Relay action descriptor', () => {
+    const action = cliGatewayCommandActions.find(
+      (entry) => entry.relayCommand.name === 'sessions.kill'
+    );
+    expect(action).toBeTruthy();
+    const descriptor = action!.descriptor;
+
+    expect(descriptor.id).toBe('sessions.kill');
+    expect(descriptor.stable).toBe(true);
+    expect(descriptor.sideEffect).toBe('destructive');
+    expect(descriptor.confirmation.required).toBe(true);
+    expect(descriptor.contract).toMatchObject({
+      relayCommandName: 'sessions.kill',
+      stable: true,
+      source: 'shared/relay-command-manifest.ts',
+    });
+  });
+
+  it('bridges sessions.rename as a non-destructive write Relay action descriptor', () => {
+    const action = cliGatewayCommandActions.find(
+      (entry) => entry.relayCommand.name === 'sessions.rename'
+    );
+    expect(action).toBeTruthy();
+    const descriptor = action!.descriptor;
+
+    expect(descriptor.id).toBe('sessions.rename');
+    expect(descriptor.stable).toBe(true);
+    expect(descriptor.sideEffect).toBe('write');
+    expect(descriptor.confirmation.required).toBe(false);
+    expect(descriptor.contract).toMatchObject({
+      relayCommandName: 'sessions.rename',
+      stable: true,
+      source: 'shared/relay-command-manifest.ts',
+    });
+  });
+
   it('projects UI-only actions without promoting them to stable Relay commands', () => {
     const descriptor = actionDescriptorFromMeta(terminalScrollTop, {
       view: 'session',

--- a/test/session-lifecycle-action.test.ts
+++ b/test/session-lifecycle-action.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RelayJsonSchema } from '../shared/cli-gateway-contract.js';
+import {
+  executeSessionKillAction,
+  executeSessionRenameAction,
+  sessionKillActionAvailability,
+  sessionKillActionDescriptor,
+  sessionKillActionTarget,
+  sessionRenameActionAvailability,
+  sessionRenameActionDescriptor,
+  sessionRenameActionTarget,
+} from '../frontend/src/lib/actions/session-lifecycle.js';
+import {
+  ConfirmationRequiredError,
+  HttpError,
+  renameSession,
+  type ConfirmationChallenge,
+} from '../frontend/src/lib/api.js';
+
+function schemaTypeMatches(type: string, value: unknown): boolean {
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'null') return value === null;
+  if (type === 'object') {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+  return typeof value === type;
+}
+
+// The test intentionally implements the tiny JSON Schema subset used by the gateway
+// envelopes so this regression does not depend on an undeclared Ajv package.
+// eslint-disable-next-line sonarjs/cognitive-complexity
+function validateJsonSchema(
+  schema: RelayJsonSchema | undefined,
+  value: unknown,
+  path = '$'
+): string[] {
+  if (!schema) return [`${path} has no schema`];
+
+  const errors: string[] = [];
+  if ('const' in schema && value !== schema.const) {
+    errors.push(`${path} expected const ${String(schema.const)}`);
+  }
+  if (schema.enum && !schema.enum.includes(String(value))) {
+    errors.push(`${path} expected enum ${schema.enum.join('|')}`);
+  }
+  if (schema.oneOf) {
+    const matches = schema.oneOf.filter(
+      (candidate) => validateJsonSchema(candidate, value, path).length === 0
+    );
+    if (matches.length !== 1) errors.push(`${path} expected oneOf match`);
+    return errors;
+  }
+  if (schema.type) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (!types.some((type) => schemaTypeMatches(type, value))) {
+      errors.push(`${path} expected type ${types.join('|')}`);
+      return errors;
+    }
+  }
+  if (schema.type === 'object' && typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const objectValue = value as Record<string, unknown>;
+    const properties = schema.properties ?? {};
+    for (const required of schema.required ?? []) {
+      if (!(required in objectValue)) {
+        errors.push(`${path} missing required property ${required}`);
+      }
+    }
+    if (schema.additionalProperties === false) {
+      for (const key of Object.keys(objectValue)) {
+        if (!(key in properties)) errors.push(`${path} has additional property ${key}`);
+      }
+    }
+    for (const [key, childSchema] of Object.entries(properties)) {
+      if (key in objectValue) {
+        errors.push(...validateJsonSchema(childSchema, objectValue[key], `${path}.${key}`));
+      }
+    }
+  }
+  if (schema.type === 'array' && Array.isArray(value) && schema.items) {
+    for (let index = 0; index < value.length; index += 1) {
+      errors.push(...validateJsonSchema(schema.items, value[index], `${path}[${index}]`));
+    }
+  }
+  return errors;
+}
+
+function challenge(
+  overrides: Partial<ConfirmationChallenge> = {}
+): ConfirmationChallenge {
+  return {
+    challengeId: 'chal-1',
+    status: 'pending',
+    nodeId: 'remote-1',
+    intent: { action: 'sessions.kill', target: 'remote-1' },
+    requiredBits: ['session:control:kill'],
+    challengeBits: ['session:control:kill'],
+    canonicalParams: { action: 'sessions.kill' },
+    canonicalParamsHash: 'hash-1',
+    createdAt: '2026-06-03T00:00:00.000Z',
+    expiresAt: '2026-06-03T00:05:00.000Z',
+    failedRedemptions: 0,
+    maxFailedRedemptions: 3,
+    reasonCode: 'CONFIRMATION_REQUIRED',
+    message: 'confirmation required to kill session',
+    ...overrides,
+  };
+}
+
+describe('sessions.kill / sessions.rename frontend action contract', () => {
+  it('executes a kill as the stable CLI gateway success envelope with full identity', async () => {
+    const descriptor = sessionKillActionDescriptor();
+    const result = await executeSessionKillAction(
+      { id: 'sess-1', nodeId: 'remote-1' },
+      async () => undefined
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      contract: 'v1',
+      contractVersion: '1.0',
+      command: 'sessions.kill',
+      data: {
+        ok: true,
+        killed: true,
+        id: 'sess-1',
+        sessionId: 'sess-1',
+        requestedId: 'sess-1',
+        nodeId: 'remote-1',
+        globalSessionId: 'remote-1:sess-1',
+      },
+    });
+    expect(validateJsonSchema(descriptor.result.schema, result)).toEqual([]);
+  });
+
+  it('executes a rename as the stable CLI gateway success envelope', async () => {
+    const descriptor = sessionRenameActionDescriptor();
+    const result = await executeSessionRenameAction(
+      { id: 'sess-1', displayName: 'renamed tab', nodeId: 'remote-1' },
+      async () => ({ renamed: true })
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      command: 'sessions.rename',
+      data: {
+        renamed: true,
+        id: 'sess-1',
+        sessionId: 'sess-1',
+        requestedId: 'sess-1',
+        nodeId: 'remote-1',
+        globalSessionId: 'remote-1:sess-1',
+        displayName: 'renamed tab',
+      },
+    });
+    expect(validateJsonSchema(descriptor.result.schema, result)).toEqual([]);
+  });
+
+  it('normalizes a missing session into NOT_FOUND + SESSION_NOT_FOUND', async () => {
+    const descriptor = sessionKillActionDescriptor();
+    const result = await executeSessionKillAction(
+      { id: 'missing', nodeId: 'remote-1' },
+      async () => {
+        throw new HttpError(404, 'Session not found', 'NOT_FOUND', false, {
+          reasonCode: 'SESSION_NOT_FOUND',
+        });
+      }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      command: 'sessions.kill',
+      error: {
+        code: 'NOT_FOUND',
+        retryable: false,
+        details: { reasonCode: 'SESSION_NOT_FOUND' },
+      },
+    });
+    expect(validateJsonSchema(descriptor.error.schema, result)).toEqual([]);
+  });
+
+  it('normalizes an offline node into NODE_OFFLINE', async () => {
+    const result = await executeSessionKillAction(
+      { id: 'sess-1', nodeId: 'remote-1' },
+      async () => {
+        throw new HttpError(503, 'node is offline', 'NODE_OFFLINE', true, {
+          nodeId: 'remote-1',
+        });
+      }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: 'NODE_OFFLINE',
+        message: 'node is offline',
+        retryable: true,
+        details: { reasonCode: 'NODE_OFFLINE', nodeId: 'remote-1' },
+      },
+    });
+  });
+
+  it('maps an unsupported session mode (disconnected) to FORBIDDEN + SESSION_DISCONNECTED', async () => {
+    const result = await executeSessionRenameAction(
+      { id: 'sess-1', displayName: 'x', nodeId: 'remote-1' },
+      async () => {
+        throw new HttpError(403, 'session is disconnected', 'FORBIDDEN', false, {
+          reasonCode: 'SESSION_DISCONNECTED',
+        });
+      }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: 'FORBIDDEN',
+        retryable: false,
+        details: { reasonCode: 'SESSION_DISCONNECTED' },
+      },
+    });
+  });
+
+  it('maps stale control state to FORBIDDEN + CONTROL_STATE_STALE', async () => {
+    const result = await executeSessionKillAction(
+      { id: 'sess-1', nodeId: 'remote-1' },
+      async () => {
+        throw new HttpError(403, 'control state is stale', 'FORBIDDEN', false, {
+          reasonCode: 'CONTROL_STATE_STALE',
+        });
+      }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: 'FORBIDDEN',
+        details: { reasonCode: 'CONTROL_STATE_STALE' },
+      },
+    });
+  });
+
+  it('preserves ConfirmationRequiredError challenge fields and stays retryable', async () => {
+    const descriptor = sessionKillActionDescriptor();
+    const result = await executeSessionKillAction(
+      { id: 'sess-1', nodeId: 'remote-1' },
+      async () => {
+        const httpError = new HttpError(
+          409,
+          'confirmation required to kill session',
+          'CONFIRMATION_REQUIRED',
+          true
+        );
+        throw new ConfirmationRequiredError(httpError, challenge());
+      }
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      command: 'sessions.kill',
+      error: {
+        code: 'CONFIRMATION_REQUIRED',
+        retryable: true,
+        details: {
+          reasonCode: 'CONFIRMATION_REQUIRED',
+          challengeId: 'chal-1',
+          requiredBits: ['session:control:kill'],
+          expiresAt: '2026-06-03T00:05:00.000Z',
+        },
+      },
+    });
+    expect(validateJsonSchema(descriptor.error.schema, result)).toEqual([]);
+  });
+
+  it('reports the shared availability shape per failure mode incl. capability hints', () => {
+    expect(sessionKillActionAvailability({ sessionMissing: true })).toMatchObject({
+      state: 'unavailable',
+      reason: 'closing a session requires an existing session',
+      capabilityHints: expect.arrayContaining(['session:control:kill']),
+    });
+    expect(
+      sessionKillActionAvailability({ nodeUnavailableReason: 'node is offline' })
+    ).toMatchObject({ state: 'unavailable', reason: 'node is offline' });
+    expect(
+      sessionKillActionAvailability({ controlState: 'stale' })
+    ).toMatchObject({
+      state: 'unavailable',
+      reason: 'closing a session requires fresh session control state',
+    });
+    expect(
+      sessionRenameActionAvailability({ unsupportedModeReason: 'mode unsupported' })
+    ).toMatchObject({
+      state: 'unavailable',
+      reason: 'mode unsupported',
+      capabilityHints: expect.arrayContaining(['session:control:rename']),
+    });
+    expect(sessionRenameActionAvailability({})).toMatchObject({
+      state: 'available',
+      capabilityHints: expect.arrayContaining(['session:control:rename']),
+    });
+  });
+
+  it('builds identity targets from the request input', () => {
+    expect(sessionKillActionTarget({ id: 'sess-1', nodeId: 'remote-1' })).toEqual({
+      sessionId: 'sess-1',
+      globalSessionId: 'remote-1:sess-1',
+      nodeId: 'remote-1',
+    });
+    expect(
+      sessionRenameActionTarget({
+        id: 'sess-2',
+        displayName: 'x',
+        globalSessionId: 'remote-2:sess-2',
+      })
+    ).toEqual({
+      sessionId: 'sess-2',
+      globalSessionId: 'remote-2:sess-2',
+      nodeId: 'remote-2',
+    });
+  });
+
+  it('surfaces renameSession res.ok failures instead of silently swallowing them', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ error: 'Session not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      await expect(renameSession('missing', 'new name')).rejects.toMatchObject({
+        name: 'HttpError',
+        status: 404,
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/test/session-lifecycle-registry.test.ts
+++ b/test/session-lifecycle-registry.test.ts
@@ -1,0 +1,229 @@
+// @vitest-environment happy-dom
+
+import * as React from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { gatewayOk } from '../shared/cli-gateway-contract.js';
+
+// Mock the shared sessions.kill executor so the close-active path resolves with
+// a successful gateway envelope without touching the network. The mock records
+// the input so we can assert the registry/handler routed the right session id.
+const executeSessionKillAction = vi.fn(
+  async (input: { id: string; nodeId?: string }) =>
+    gatewayOk('sessions.kill', {
+      ok: true,
+      killed: true,
+      id: input.id,
+      sessionId: input.id,
+      requestedId: input.id,
+      nodeId: input.nodeId ?? 'local',
+      globalSessionId: `${input.nodeId ?? 'local'}:${input.id}`,
+    })
+);
+const executeSessionRenameAction = vi.fn(
+  async (input: { id: string; displayName: string; nodeId?: string }) =>
+    gatewayOk('sessions.rename', {
+      renamed: true,
+      id: input.id,
+      sessionId: input.id,
+      requestedId: input.id,
+      nodeId: input.nodeId ?? 'local',
+      globalSessionId: `${input.nodeId ?? 'local'}:${input.id}`,
+      displayName: input.displayName,
+    })
+);
+
+vi.mock('../frontend/src/lib/actions/session-lifecycle.js', async () => {
+  const actual = await vi.importActual<
+    typeof import('../frontend/src/lib/actions/session-lifecycle.js')
+  >('../frontend/src/lib/actions/session-lifecycle.js');
+  return {
+    ...actual,
+    executeSessionKillAction,
+    executeSessionRenameAction,
+  };
+});
+
+vi.mock('../frontend/src/components/dialogs/CustomizeSessionDialog.js', () => ({
+  isFrameworkAvailable: () => true,
+}));
+
+import type { SessionSummary } from '../frontend/src/lib/types.js';
+import { useSessionHandlers } from '../frontend/src/hooks/useSessionHandlers.js';
+import { useSessionsStore } from '../frontend/src/lib/stores/sessions.js';
+import { useUiStore } from '../frontend/src/lib/stores/ui.js';
+import {
+  sessionCloseActive,
+  sessionKill,
+  sessionRename,
+} from '../frontend/src/lib/actions/definitions/session.js';
+import { sidebarRenameSession } from '../frontend/src/lib/actions/definitions/sidebar.js';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const originalRefreshAll = useSessionsStore.getState().refreshAll;
+
+function makeSession(
+  overrides: Partial<SessionSummary> & { id: string }
+): SessionSummary {
+  return {
+    id: overrides.id,
+    type: 'agent',
+    agent: 'claude',
+    mode: 'pty',
+    repoName: 'relay-ide',
+    repoPath: '/repo/relay-ide',
+    worktreePath: null,
+    cwd: '/repo/relay-ide',
+    branchName: 'nightly',
+    displayName: overrides.id,
+    createdAt: '2026-06-10T00:00:00.000Z',
+    lastActivity: '2026-06-10T00:00:00.000Z',
+    idle: false,
+    ...overrides,
+  };
+}
+
+async function flushPromises(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+type SessionHandlers = ReturnType<typeof useSessionHandlers>;
+
+function SessionHandlersHarness({
+  onReady,
+}: {
+  onReady: (handlers: SessionHandlers) => void;
+}) {
+  const handlers = useSessionHandlers({
+    customizeDialogRef: React.createRef(),
+    deleteWorktreeDialogRef: React.createRef(),
+    workspaceSettingsDialogRef: React.createRef(),
+    setAnalyticsView: vi.fn(),
+  });
+  onReady(handlers);
+  return null;
+}
+
+describe('session lifecycle action registry wiring (#869)', () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+  let refreshAll: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    executeSessionKillAction.mockClear();
+    executeSessionRenameAction.mockClear();
+    refreshAll = vi.fn(async () => undefined);
+    useSessionsStore.setState({
+      sessions: [],
+      worktrees: [],
+      repos: [],
+      workspaceGroups: [],
+      activeSessionId: null,
+      sidebarItems: [],
+      enrichmentResults: {},
+      repoEnrichmentMeta: {},
+      reconnectingPtySessionIds: {},
+      backendConnectionStatus: 'connected',
+      refreshAll: refreshAll as unknown as typeof originalRefreshAll,
+    });
+    useUiStore.setState({ activeRepoPath: '/repo/relay-ide' });
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container?.remove();
+    root = null;
+    container = null;
+    useSessionsStore.setState({
+      sessions: [],
+      worktrees: [],
+      repos: [],
+      workspaceGroups: [],
+      activeSessionId: null,
+      sidebarItems: [],
+      enrichmentResults: {},
+      repoEnrichmentMeta: {},
+      reconnectingPtySessionIds: {},
+      backendConnectionStatus: 'connected',
+      refreshAll: originalRefreshAll,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('attaches stable lifecycle descriptor.contract metadata to kill/rename/close definitions', () => {
+    expect(sessionKill.descriptor?.id).toBe('sessions.kill');
+    expect(sessionKill.descriptor?.contract).toMatchObject({
+      relayCommandName: 'sessions.kill',
+      stable: true,
+      source: 'shared/relay-command-manifest.ts',
+    });
+    expect(sessionKill.descriptor?.confirmation.required).toBe(true);
+
+    // close-active bridges to the SAME sessions.kill descriptor (no sessions.close verb).
+    expect(sessionCloseActive.descriptor?.id).toBe('sessions.kill');
+    expect(sessionCloseActive.descriptor?.contract?.relayCommandName).toBe(
+      'sessions.kill'
+    );
+
+    expect(sessionRename.descriptor?.id).toBe('sessions.rename');
+    expect(sessionRename.descriptor?.contract).toMatchObject({
+      relayCommandName: 'sessions.rename',
+      stable: true,
+      source: 'shared/relay-command-manifest.ts',
+    });
+
+    // sidebar.rename-session collapses into the same sessions.rename descriptor.
+    expect(sidebarRenameSession.descriptor?.id).toBe('sessions.rename');
+    expect(sidebarRenameSession.descriptor?.contract?.relayCommandName).toBe(
+      'sessions.rename'
+    );
+  });
+
+  it('still performs next-tab selection after a successful kill envelope from close-active', async () => {
+    const active = makeSession({ id: 'active-session' });
+    const sibling = makeSession({ id: 'sibling-session' });
+    useSessionsStore.setState({
+      sessions: [active, sibling],
+      activeSessionId: active.id,
+    });
+
+    let handlers: SessionHandlers | undefined;
+    await act(async () => {
+      root!.render(
+        React.createElement(SessionHandlersHarness, {
+          onReady: (next) => {
+            handlers = next;
+          },
+        })
+      );
+    });
+
+    act(() => {
+      handlers!.handleCloseSession(active.id);
+    });
+
+    // Kill routed through the shared executor with the resolved local session id.
+    expect(executeSessionKillAction).toHaveBeenCalledTimes(1);
+    expect(executeSessionKillAction.mock.calls[0]?.[0]).toMatchObject({
+      id: 'active-session',
+    });
+
+    // Tab selection is synchronous and does not wait on the kill envelope: the
+    // sibling in the same workspace/cwd becomes active immediately.
+    expect(useSessionsStore.getState().activeSessionId).toBe('sibling-session');
+
+    // The kill envelope still resolves and refreshAll fires afterward.
+    await flushPromises();
+    expect(refreshAll).toHaveBeenCalled();
+  });
+});

--- a/test/session-lifecycle-registry.test.ts
+++ b/test/session-lifecycle-registry.test.ts
@@ -9,7 +9,14 @@ import { gatewayOk } from '../shared/cli-gateway-contract.js';
 // Mock the shared sessions.kill executor so the close-active path resolves with
 // a successful gateway envelope without touching the network. The mock records
 // the input so we can assert the registry/handler routed the right session id.
-const executeSessionKillAction = vi.fn(
+// vi.hoisted so the fns exist when the hoisted vi.mock factory below runs.
+const { executeSessionKillAction, executeSessionRenameAction } = vi.hoisted(
+  () => ({
+    executeSessionKillAction: vi.fn(),
+    executeSessionRenameAction: vi.fn(),
+  })
+);
+executeSessionKillAction.mockImplementation(
   async (input: { id: string; nodeId?: string }) =>
     gatewayOk('sessions.kill', {
       ok: true,
@@ -21,7 +28,7 @@ const executeSessionKillAction = vi.fn(
       globalSessionId: `${input.nodeId ?? 'local'}:${input.id}`,
     })
 );
-const executeSessionRenameAction = vi.fn(
+executeSessionRenameAction.mockImplementation(
   async (input: { id: string; displayName: string; nodeId?: string }) =>
     gatewayOk('sessions.rename', {
       renamed: true,


### PR DESCRIPTION
## Summary
- Bridges `session.close-active`, `session.kill`, `session.rename`, and `sidebar.rename-session` to the shared Relay action descriptor contract, mirroring the #867 `sessions.create` bridge. Backend gateway commands, manifest definitions, confirmation gating, and node-link routing were verified complete and are untouched.
- New `frontend/src/lib/actions/session-lifecycle.ts`: descriptor factories, availability helpers (missing session / offline node / unsupported mode / stale-or-unknown control state), gateway-envelope executors with typed error mapping, and session identity target builders. Executors delegate to the existing `killSession`/`renameSession` API so the `registerConfirmationRetry` confirmation loop stays the single mutation path.
- Registry/handler rewiring inspects returned envelopes instead of fire-and-forget private calls; close-active keeps its tab-selection semantics on top of the kill envelope.
- Split/collapse rationale recorded in `docs/refactor/860-action-contract-follow-up-map.md`: close-active → `sessions.kill` (no new `sessions.close` verb; `sessions.detach` owns non-destructive close), sidebar rename → `sessions.rename`.
- Bug fix: `api.ts renameSession` never checked `res.ok` (silent failures) and couldn't target routed sessions — now routes local vs hub-node paths and surfaces typed errors.

Fixes #869 (epic #849 parity burn-down)

## Review
Built via parallel implementation agents + two adversarial review lenses (correctness, contract-parity/acceptance). No CRITICAL/HIGH findings.

## Test plan
- New `test/session-lifecycle-action.test.ts` (envelope schema validation against the frozen contract, all six availability failure modes, confirmation-challenge preservation, renameSession res.ok fix).
- New `test/session-lifecycle-registry.test.ts` + handlers test (descriptor attachment on all four action ids, close-active tab-selection after successful kill envelope).
- `test/action-coverage.test.ts` extended (kill: destructive + confirmation required; rename: write + no confirmation).
- Locally: 69 tests across the action suites pass; `npm run check` 0 errors.
- The prod WorkContext for this slice (`wc:bd7c…`, planner artifact `pipeline-handoff:relay-869:planner01`) carries the plan + downstream focus per the #892 dogfood pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)